### PR TITLE
Rename `worker` durability tier to `local`

### DIFF
--- a/benchmarks/realistic/profile_browser.mjs
+++ b/benchmarks/realistic/profile_browser.mjs
@@ -540,13 +540,13 @@ function buildInitScript(schemaTables) {
           owner_id: owners.allowedOwnerId,
           title: "allowed-root",
           updated_at: ts,
-        }, { tier: "worker" });
+        }, { tier: "local" });
         const deniedRoot = await db.insertDurable(folderTable, {
           parent_id: null,
           owner_id: owners.deniedOwnerId,
           title: "denied-root",
           updated_at: ts + 1,
-        }, { tier: "worker" });
+        }, { tier: "local" });
         allowedFolders.push(allowedRoot.id);
         deniedFolders.push(deniedRoot.id);
         for (let i = 2; i < totalFolders; i += 1) {
@@ -559,7 +559,7 @@ function buildInitScript(schemaTables) {
             owner_id: allowedChain ? owners.allowedOwnerId : owners.deniedOwnerId,
             title: "folder-" + i,
             updated_at: ts + i,
-          }, { tier: "worker" });
+          }, { tier: "local" });
           if (allowedChain) allowedFolders.push(row.id);
           else deniedFolders.push(row.id);
         }
@@ -578,7 +578,7 @@ function buildInitScript(schemaTables) {
             body: "doc-" + i,
             revision: 0,
             updated_at: ts + 10000 + i,
-          }, { tier: "worker" });
+          }, { tier: "local" });
         }
       }
       async function seedDataset(db, config) {
@@ -702,7 +702,7 @@ function buildW4Setup(config, dbName) {
       const state = await h.seedDataset(db, cfg);
       await db.all(
         h.query("tasks", [{ column: "project_id", op: "eq", value: state.projects[0] }], [["updated_at", "desc"]], 200),
-        { tier: "worker" }
+        { tier: "local" }
       );
       await db.shutdown();
       globalThis.__w4Profile = { dbName, hotProjectId: state.projects[0] };
@@ -720,7 +720,7 @@ function buildW4Run() {
       const db = await h.createDb({ appId: "profile-w4-app", dbName, logLevel: "warn" });
       const rows = await db.all(
         h.query("tasks", [{ column: "project_id", op: "eq", value: hotProjectId }], [["updated_at", "desc"]], 200),
-        { tier: "worker" }
+        { tier: "local" }
       );
       globalThis.__w4Profile.db = db;
       return { rows: rows.length, elapsedMs: performance.now() - t0 };

--- a/crates/jazz-tools/src/batch_fate.rs
+++ b/crates/jazz-tools/src/batch_fate.rs
@@ -776,7 +776,7 @@ impl SealedBatchSubmission {
 
 fn durability_tier_to_str(tier: DurabilityTier) -> &'static str {
     match tier {
-        DurabilityTier::Worker => "worker",
+        DurabilityTier::Local => "local",
         DurabilityTier::EdgeServer => "edge",
         DurabilityTier::GlobalServer => "global",
     }
@@ -784,7 +784,7 @@ fn durability_tier_to_str(tier: DurabilityTier) -> &'static str {
 
 fn durability_tier_from_str(raw: &str) -> Result<DurabilityTier, String> {
     match raw {
-        "worker" => Ok(DurabilityTier::Worker),
+        "local" => Ok(DurabilityTier::Local),
         "edge" => Ok(DurabilityTier::EdgeServer),
         "global" => Ok(DurabilityTier::GlobalServer),
         other => Err(format!("unknown durability tier '{other}'")),
@@ -909,7 +909,7 @@ fn storage_descriptor() -> RowDescriptor {
             "requested_tier",
             ColumnType::Enum {
                 variants: vec![
-                    "worker".to_string(),
+                    "local".to_string(),
                     "edge".to_string(),
                     "global".to_string(),
                 ],
@@ -986,7 +986,7 @@ fn batch_settlement_storage_descriptor() -> RowDescriptor {
             "confirmed_tier",
             ColumnType::Enum {
                 variants: vec![
-                    "worker".to_string(),
+                    "local".to_string(),
                     "edge".to_string(),
                     "global".to_string(),
                 ],
@@ -1021,7 +1021,7 @@ mod tests {
             true,
             Some(BatchSettlement::DurableDirect {
                 batch_id,
-                confirmed_tier: DurabilityTier::Worker,
+                confirmed_tier: DurabilityTier::Local,
                 visible_members: vec![VisibleBatchMember {
                     object_id: ObjectId::from_uuid(uuid::Uuid::from_u128(7)),
                     branch_name: BranchName::new("main"),
@@ -1060,7 +1060,7 @@ mod tests {
 
         record.apply_settlement(BatchSettlement::DurableDirect {
             batch_id,
-            confirmed_tier: DurabilityTier::Worker,
+            confirmed_tier: DurabilityTier::Local,
             visible_members: Vec::new(),
         });
 
@@ -1082,11 +1082,11 @@ mod tests {
         let mut record = LocalBatchRecord::new(
             batch_id,
             BatchMode::Direct,
-            DurabilityTier::Worker,
+            DurabilityTier::Local,
             true,
             Some(BatchSettlement::DurableDirect {
                 batch_id,
-                confirmed_tier: DurabilityTier::Worker,
+                confirmed_tier: DurabilityTier::Local,
                 visible_members: vec![VisibleBatchMember {
                     object_id: first_row_id,
                     branch_name: BranchName::new("main"),
@@ -1097,7 +1097,7 @@ mod tests {
 
         record.apply_settlement(BatchSettlement::DurableDirect {
             batch_id,
-            confirmed_tier: DurabilityTier::Worker,
+            confirmed_tier: DurabilityTier::Local,
             visible_members: vec![VisibleBatchMember {
                 object_id: second_row_id,
                 branch_name: BranchName::new("main"),
@@ -1109,7 +1109,7 @@ mod tests {
             record.latest_settlement,
             Some(BatchSettlement::DurableDirect {
                 batch_id,
-                confirmed_tier: DurabilityTier::Worker,
+                confirmed_tier: DurabilityTier::Local,
                 visible_members: vec![
                     VisibleBatchMember {
                         object_id: first_row_id,

--- a/crates/jazz-tools/src/binding_support.rs
+++ b/crates/jazz-tools/src/binding_support.rs
@@ -195,11 +195,11 @@ pub fn parse_write_context_input(
 
 pub fn parse_durability_tier(tier: &str) -> Result<DurabilityTier, String> {
     match tier {
-        "worker" => Ok(DurabilityTier::Worker),
+        "local" => Ok(DurabilityTier::Local),
         "edge" => Ok(DurabilityTier::EdgeServer),
         "global" => Ok(DurabilityTier::GlobalServer),
         _ => Err(format!(
-            "Invalid tier '{}'. Must be 'worker', 'edge', or 'global'.",
+            "Invalid tier '{}'. Must be 'local', 'edge', or 'global'.",
             tier
         )),
     }
@@ -213,7 +213,7 @@ pub fn parse_batch_id_input(batch_id: &str) -> Result<BatchId, String> {
 
 pub fn serialize_durability_tier(tier: DurabilityTier) -> &'static str {
     match tier {
-        DurabilityTier::Worker => "worker",
+        DurabilityTier::Local => "local",
         DurabilityTier::EdgeServer => "edge",
         DurabilityTier::GlobalServer => "global",
     }
@@ -531,11 +531,11 @@ mod tests {
     #[test]
     fn read_durability_options_default_to_full_and_immediate() {
         let (durability, propagation) =
-            parse_read_durability_options(Some("worker"), None).expect("parse options");
+            parse_read_durability_options(Some("local"), None).expect("parse options");
 
         assert_eq!(
             durability.tier,
-            Some(crate::sync_manager::DurabilityTier::Worker)
+            Some(crate::sync_manager::DurabilityTier::Local)
         );
         assert_eq!(
             durability.local_updates,

--- a/crates/jazz-tools/src/commands/server.rs
+++ b/crates/jazz-tools/src/commands/server.rs
@@ -17,11 +17,11 @@ pub async fn run(
     in_memory: bool,
     auth_config: AuthConfig,
     catalogue_authority: CatalogueAuthorityMode,
+    bound_port_file: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let app_id = AppId::from_string(app_id_str)?;
     let app_id_string = app_id.to_string();
-    let inspector_link =
-        build_inspector_link(port, &app_id_string, auth_config.admin_secret.as_deref());
+    let admin_secret = auth_config.admin_secret.clone();
 
     info!("Starting Jazz server for app: {}", app_id);
     if in_memory {
@@ -41,10 +41,18 @@ pub async fn run(
     .map_err(|e| format!("failed to build server: {e}"))?;
 
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
-    info!("Listening on http://{}", addr);
-    info!("Open the inspector: {}", inspector_link);
-
     let listener = tokio::net::TcpListener::bind(addr).await?;
+    let bound_addr = listener.local_addr()?;
+    let inspector_link =
+        build_inspector_link(bound_addr.port(), &app_id_string, admin_secret.as_deref());
+
+    if let Some(path) = bound_port_file {
+        std::fs::write(&path, bound_addr.port().to_string())
+            .map_err(|e| format!("failed to write bound port file {path}: {e}"))?;
+    }
+
+    info!("Listening on http://{}", bound_addr);
+    info!("Open the inspector: {}", inspector_link);
     axum::serve(listener, built.app).await?;
 
     Ok(())

--- a/crates/jazz-tools/src/main.rs
+++ b/crates/jazz-tools/src/main.rs
@@ -107,6 +107,10 @@ enum Commands {
         /// Admin secret used by this server when forwarding catalogue requests upstream.
         #[arg(long, env = "JAZZ_CATALOGUE_AUTHORITY_ADMIN_SECRET")]
         catalogue_authority_admin_secret: Option<String>,
+
+        /// Internal testing hook: write the resolved listen port after binding.
+        #[arg(long, env = "JAZZ_BOUND_PORT_FILE", hide = true)]
+        bound_port_file: Option<String>,
     },
 }
 
@@ -146,6 +150,7 @@ async fn main() {
             catalogue_authority,
             catalogue_authority_url,
             catalogue_authority_admin_secret,
+            bound_port_file,
         } => {
             let node_env_mode = resolve_node_env_mode();
             let allow_local_first_auth =
@@ -195,6 +200,7 @@ async fn main() {
                 in_memory,
                 auth_config,
                 catalogue_authority,
+                bound_port_file,
             )
             .await
             {

--- a/crates/jazz-tools/src/query_manager/manager_tests.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests.rs
@@ -8931,7 +8931,7 @@ fn subscribe_with_sync_local_only_on_persistence_tier_does_not_send_upstream() {
     use crate::sync_manager::{Destination, DurabilityTier, ServerId, SyncPayload};
     use uuid::Uuid;
 
-    let sync_manager = SyncManager::new().with_durability_tier(DurabilityTier::Worker);
+    let sync_manager = SyncManager::new().with_durability_tier(DurabilityTier::Local);
     let schema = test_schema();
     let (mut worker_qm, _storage) = create_query_manager(sync_manager, schema);
 
@@ -8958,7 +8958,7 @@ fn subscribe_with_sync_local_only_on_persistence_tier_does_not_send_upstream() {
     assert_eq!(
         query_subs.len(),
         0,
-        "worker-tier local-only subscription should not be sent to upstream sync server"
+        "local-tier local-only subscription should not be sent to upstream sync server"
     );
 }
 

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -799,7 +799,7 @@ impl QueryManager {
             let settled_tier = self
                 .sync_manager
                 .max_local_durability_tier()
-                .unwrap_or(DurabilityTier::Worker);
+                .unwrap_or(DurabilityTier::Local);
             settled_notifications.push((sub.client_id, sub.query_id, settled_tier));
 
             // Forward QuerySubscription to upstream servers (multi-tier forwarding)
@@ -938,7 +938,7 @@ impl QueryManager {
                     let settled_tier = self
                         .sync_manager
                         .max_local_durability_tier()
-                        .unwrap_or(DurabilityTier::Worker);
+                        .unwrap_or(DurabilityTier::Local);
                     settled_notifications.push((client_id, query_id, settled_tier));
                 }
 

--- a/crates/jazz-tools/src/row_histories/mod.rs
+++ b/crates/jazz-tools/src/row_histories/mod.rs
@@ -206,7 +206,7 @@ fn row_state_column_type() -> ColumnType {
 fn confirmed_tier_column_type() -> ColumnType {
     ColumnType::Enum {
         variants: vec![
-            "worker".to_string(),
+            "local".to_string(),
             "edge".to_string(),
             "global".to_string(),
         ],
@@ -488,7 +488,7 @@ fn row_state_to_value(state: RowState) -> Value {
 fn durability_tier_to_value(tier: DurabilityTier) -> Value {
     Value::Text(
         match tier {
-            DurabilityTier::Worker => "worker",
+            DurabilityTier::Local => "local",
             DurabilityTier::EdgeServer => "edge",
             DurabilityTier::GlobalServer => "global",
         }
@@ -612,10 +612,10 @@ fn decode_optional_durability_tier_bytes(
 ) -> Result<Option<DurabilityTier>, EncodingError> {
     match bytes {
         None => Ok(None),
-        Some([0]) => Ok(Some(DurabilityTier::Worker)),
+        Some([0]) => Ok(Some(DurabilityTier::Local)),
         Some([1]) => Ok(Some(DurabilityTier::EdgeServer)),
         Some([2]) => Ok(Some(DurabilityTier::GlobalServer)),
-        Some(b"worker") => Ok(Some(DurabilityTier::Worker)),
+        Some(b"local") => Ok(Some(DurabilityTier::Local)),
         Some(b"edge") => Ok(Some(DurabilityTier::EdgeServer)),
         Some(b"global") => Ok(Some(DurabilityTier::GlobalServer)),
         Some(bytes) => Err(malformed(format!(
@@ -1168,7 +1168,7 @@ impl VisibleRowEntry {
     pub fn rebuild(current_row: StoredRowBatch, history_rows: &[StoredRowBatch]) -> Self {
         let current_batch_id = current_row.batch_id();
         let branch_frontier = branch_frontier(history_rows);
-        let worker = latest_visible_version_for_tier(history_rows, DurabilityTier::Worker);
+        let worker = latest_visible_version_for_tier(history_rows, DurabilityTier::Local);
         let worker_batch_id = worker.filter(|batch_id| *batch_id != current_batch_id);
 
         let edge = latest_visible_version_for_tier(history_rows, DurabilityTier::EdgeServer);
@@ -1197,7 +1197,7 @@ impl VisibleRowEntry {
         }
 
         match tier {
-            DurabilityTier::Worker => self.worker_batch_id,
+            DurabilityTier::Local => self.worker_batch_id,
             DurabilityTier::EdgeServer => self.edge_batch_id,
             DurabilityTier::GlobalServer => self.global_batch_id,
         }
@@ -1367,7 +1367,7 @@ fn visible_entry_after_append<H: Storage>(
         io,
         table,
         appended_row,
-        previous_entry.batch_id_for_tier(DurabilityTier::Worker),
+        previous_entry.batch_id_for_tier(DurabilityTier::Local),
     )?
     .filter(|batch_id| *batch_id != current_batch_id);
     let edge_batch_id = latest_visible_version_after_append(
@@ -1470,7 +1470,7 @@ fn visible_entry_after_tier_upgrade<H: Storage>(
         &entry,
         &current_row,
         patched_row,
-        DurabilityTier::Worker,
+        DurabilityTier::Local,
     )?
     .filter(|batch_id| *batch_id != current_batch_id);
     let edge_batch_id = winner_after_tier_upgrade(
@@ -1827,9 +1827,9 @@ mod tests {
             )
             .expect("encode current row"),
             RowProvenance::for_update(&global.row_provenance(), "bob".to_string(), 30),
-            HashMap::from([("source".to_string(), "worker".to_string())]),
+            HashMap::from([("source".to_string(), "local".to_string())]),
             RowState::VisibleDirect,
-            Some(DurabilityTier::Worker),
+            Some(DurabilityTier::Local),
         );
         let entry = VisibleRowEntry {
             current_row: current,
@@ -1906,7 +1906,7 @@ mod tests {
             RowProvenance::for_update(&edge.row_provenance(), "alice".to_string(), 30),
             HashMap::new(),
             RowState::VisibleDirect,
-            Some(DurabilityTier::Worker),
+            Some(DurabilityTier::Local),
         );
         let history = vec![global.clone(), edge.clone(), current.clone()];
 
@@ -1917,7 +1917,7 @@ mod tests {
         assert_eq!(entry.edge_batch_id, Some(edge.batch_id()));
         assert_eq!(entry.global_batch_id, Some(global.batch_id()));
         assert_eq!(
-            entry.batch_id_for_tier(DurabilityTier::Worker),
+            entry.batch_id_for_tier(DurabilityTier::Local),
             Some(current.batch_id())
         );
         assert_eq!(
@@ -1932,7 +1932,7 @@ mod tests {
 
     #[test]
     fn visible_row_entry_returns_none_when_no_version_meets_required_tier() {
-        let current = visible_row(30, Some(DurabilityTier::Worker));
+        let current = visible_row(30, Some(DurabilityTier::Local));
         let entry = VisibleRowEntry::rebuild(current.clone(), std::slice::from_ref(&current));
 
         assert_eq!(entry.branch_frontier, vec![current.batch_id()]);
@@ -1942,7 +1942,7 @@ mod tests {
 
     #[test]
     fn visible_row_entry_preserves_multiple_branch_tips() {
-        let base = visible_row(10, Some(DurabilityTier::Worker));
+        let base = visible_row(10, Some(DurabilityTier::Local));
         let left = StoredRowBatch::new(
             base.row_id,
             "main",
@@ -1951,7 +1951,7 @@ mod tests {
             RowProvenance::for_update(&base.row_provenance(), "alice".to_string(), 20),
             HashMap::new(),
             RowState::VisibleDirect,
-            Some(DurabilityTier::Worker),
+            Some(DurabilityTier::Local),
         );
         let right = StoredRowBatch::new(
             base.row_id,
@@ -1961,7 +1961,7 @@ mod tests {
             RowProvenance::for_update(&base.row_provenance(), "bob".to_string(), 21),
             HashMap::new(),
             RowState::VisibleDirect,
-            Some(DurabilityTier::Worker),
+            Some(DurabilityTier::Local),
         );
 
         let entry = VisibleRowEntry::rebuild(right.clone(), &[base, left.clone(), right.clone()]);
@@ -2063,7 +2063,7 @@ mod tests {
     #[test]
     fn flat_visible_row_common_case_omits_empty_arrays_and_metadata() {
         let descriptor = user_descriptor();
-        let current = visible_row(10, Some(DurabilityTier::Worker));
+        let current = visible_row(10, Some(DurabilityTier::Local));
         let entry = VisibleRowEntry::rebuild(current.clone(), std::slice::from_ref(&current));
 
         let encoded =
@@ -2138,11 +2138,11 @@ mod tests {
             .expect("encode user row"),
             RowProvenance::for_insert("alice".to_string(), 100),
             HashMap::from([
-                ("source".to_string(), "worker".to_string()),
+                ("source".to_string(), "local".to_string()),
                 ("kind".to_string(), "task".to_string()),
             ]),
             RowState::VisibleDirect,
-            Some(DurabilityTier::Worker),
+            Some(DurabilityTier::Local),
         );
 
         let encoded =
@@ -2267,7 +2267,7 @@ mod tests {
             provenance.clone(),
             HashMap::new(),
             RowState::VisibleDirect,
-            Some(DurabilityTier::Worker),
+            Some(DurabilityTier::Local),
         );
 
         assert_eq!(

--- a/crates/jazz-tools/src/runtime_core.rs
+++ b/crates/jazz-tools/src/runtime_core.rs
@@ -277,10 +277,10 @@ pub struct RuntimeCore<S: Storage, Sch: Scheduler> {
     pending_one_shot_queries: HashMap<SubscriptionHandle, PendingOneShotQuery>,
 
     /// Watchers for persistence acks: (row, branch, logical write batch, requested_tier) → senders.
-    /// A tier >= requested tier satisfies the watcher (e.g., EdgeServer ack satisfies Worker).
+    /// A tier >= requested tier satisfies the watcher (e.g., EdgeServer ack satisfies Local).
     ack_watchers: HashMap<RowBatchKey, Vec<(DurabilityTier, oneshot::Sender<PersistedWriteAck>)>>,
 
-    /// Label for tracing (e.g. "worker", "edge", "client").
+    /// Label for tracing (e.g. "local", "edge", "client").
     tier_label: &'static str,
 
     /// Optional sync-message tracer used by tests to record outgoing/incoming

--- a/crates/jazz-tools/src/runtime_core/tests.rs
+++ b/crates/jazz-tools/src/runtime_core/tests.rs
@@ -2241,7 +2241,7 @@ fn rc_user_subscription_does_not_forward_rows_to_other_sessions() {
     let mut server = create_runtime_with_schema_and_sync_manager(
         schema,
         "scope-bypass-subscription-test",
-        SyncManager::new().with_durability_tier(DurabilityTier::Worker),
+        SyncManager::new().with_durability_tier(DurabilityTier::Local),
     );
 
     let alice_session = Session::new("alice");
@@ -2459,7 +2459,7 @@ fn rc_user_subscription_does_not_forward_rows_to_other_sessions() {
         documents_query_by_title(title),
         Some(bob_session.clone()),
         ReadDurabilityOptions {
-            tier: Some(DurabilityTier::Worker),
+            tier: Some(DurabilityTier::Local),
             local_updates: crate::query_manager::manager::LocalUpdates::Deferred,
             strict_transactions: false,
         },
@@ -2469,7 +2469,7 @@ fn rc_user_subscription_does_not_forward_rows_to_other_sessions() {
     let mut cx = std::task::Context::from_waker(&waker);
     assert!(
         Pin::new(&mut fresh_bob_query).poll(&mut cx).is_pending(),
-        "fresh bob full query should wait for Worker settlement instead of resolving from local empty state"
+        "fresh bob full query should wait for Local settlement instead of resolving from local empty state"
     );
 
     let server_outputs_after_fresh_bob_query = pump_server_with_three_clients(
@@ -2501,7 +2501,7 @@ fn rc_user_subscription_does_not_forward_rows_to_other_sessions() {
             );
         }
         Poll::Ready(Err(err)) => panic!("fresh bob full query should succeed: {err:?}"),
-        Poll::Pending => panic!("fresh bob full query should resolve after Worker settlement"),
+        Poll::Pending => panic!("fresh bob full query should resolve after Local settlement"),
     }
 }
 
@@ -2558,7 +2558,7 @@ fn create_3tier_rc() -> ThreeTierRC {
     let mut a = new_test_core(mgr_a, MemoryStorage::new(), NoopScheduler);
 
     // B = Worker server
-    let sm_b = SyncManager::new().with_durability_tier(DurabilityTier::Worker);
+    let sm_b = SyncManager::new().with_durability_tier(DurabilityTier::Local);
     let mgr_b = SchemaManager::new(sm_b, schema.clone(), app_id, "dev", "main").unwrap();
     let mut b = new_test_core(mgr_b, MemoryStorage::new(), NoopScheduler);
 
@@ -2778,7 +2778,7 @@ fn rc_replays_downstream_query_when_upstream_added_late() {
     let mut a = new_test_core(mgr_a, MemoryStorage::new(), NoopScheduler);
 
     let mgr_b = SchemaManager::new(
-        SyncManager::new().with_durability_tier(DurabilityTier::Worker),
+        SyncManager::new().with_durability_tier(DurabilityTier::Local),
         schema.clone(),
         app_id,
         "dev",
@@ -3123,7 +3123,7 @@ fn rc_batched_tick_skips_flush_wal_for_query_settled_only_message() {
         source: Source::Server(ServerId::new()),
         payload: SyncPayload::QuerySettled {
             query_id: crate::sync_manager::QueryId(1),
-            tier: DurabilityTier::Worker,
+            tier: DurabilityTier::Local,
             through_seq: 1,
         },
     });
@@ -3180,7 +3180,7 @@ fn rc_insert_persisted_resolves_on_worker_ack() {
             "users",
             user_insert_values(user_id, "Alice"),
             None,
-            DurabilityTier::Worker,
+            DurabilityTier::Local,
         )
         .unwrap();
     assert!(!id.0.is_nil());
@@ -3197,7 +3197,7 @@ fn rc_insert_persisted_resolves_on_worker_ack() {
     match receiver.try_recv() {
         Ok(Some(Ok(()))) => {}
         Ok(Some(Err(rejection))) => panic!("Receiver should not reject: {rejection:?}"),
-        Ok(None) => panic!("Receiver should be resolved after Worker ack"),
+        Ok(None) => panic!("Receiver should be resolved after Local ack"),
         Err(_) => panic!("Receiver was cancelled"),
     }
 }
@@ -3216,7 +3216,7 @@ fn rc_insert_persisted_does_not_touch_legacy_ack_storage() {
             "users",
             user_insert_values(ObjectId::new(), "Alice"),
             None,
-            DurabilityTier::Worker,
+            DurabilityTier::Local,
         )
         .unwrap();
 
@@ -3235,7 +3235,7 @@ fn rc_insert_persisted_does_not_touch_legacy_ack_storage() {
             branch_name,
             batch_id,
             state: None,
-            confirmed_tier: Some(DurabilityTier::Worker),
+            confirmed_tier: Some(DurabilityTier::Local),
         },
     });
     core.immediate_tick();
@@ -3260,7 +3260,7 @@ fn rc_insert_persisted_ignores_row_state_changed_for_different_row_same_batch_id
             "users",
             user_insert_values(ObjectId::new(), "Alice"),
             None,
-            DurabilityTier::Worker,
+            DurabilityTier::Local,
         )
         .unwrap();
 
@@ -3279,7 +3279,7 @@ fn rc_insert_persisted_ignores_row_state_changed_for_different_row_same_batch_id
             branch_name,
             batch_id: row_batch_id,
             state: None,
-            confirmed_tier: Some(DurabilityTier::Worker),
+            confirmed_tier: Some(DurabilityTier::Local),
         },
     });
     s.a.immediate_tick();
@@ -3309,7 +3309,7 @@ fn rc_insert_persisted_holds_until_correct_tier() {
     assert_eq!(
         receiver.try_recv(),
         Ok(None),
-        "Worker ack should not satisfy EdgeServer request"
+        "Local ack should not satisfy EdgeServer request"
     );
 
     pump_b_to_c(&mut s);
@@ -3331,7 +3331,7 @@ fn rc_insert_persisted_higher_tier_satisfies_lower() {
             "users",
             user_insert_values(ObjectId::new(), "Alice"),
             None,
-            DurabilityTier::Worker,
+            DurabilityTier::Local,
         )
         .unwrap();
 
@@ -3339,8 +3339,8 @@ fn rc_insert_persisted_higher_tier_satisfies_lower() {
 
     match receiver.try_recv() {
         Ok(Some(Ok(()))) => {}
-        Ok(Some(Err(rejection))) => panic!("Worker request should not reject: {rejection:?}"),
-        Ok(None) => panic!("EdgeServer ack should satisfy Worker request"),
+        Ok(Some(Err(rejection))) => panic!("Local request should not reject: {rejection:?}"),
+        Ok(None) => panic!("EdgeServer ack should satisfy Local request"),
         Err(_) => panic!("Receiver was cancelled"),
     }
 }
@@ -3353,7 +3353,7 @@ fn rc_insert_persisted_tracks_local_batch_record_and_settlement() {
             "users",
             user_insert_values(ObjectId::new(), "Alice"),
             None,
-            DurabilityTier::Worker,
+            DurabilityTier::Local,
         )
         .unwrap();
 
@@ -3372,7 +3372,7 @@ fn rc_insert_persisted_tracks_local_batch_record_and_settlement() {
             .expect("persisted write should create a local batch record");
     assert_eq!(initial_record.batch_id, batch_id);
     assert_eq!(initial_record.mode, crate::batch_fate::BatchMode::Direct);
-    assert_eq!(initial_record.requested_tier, DurabilityTier::Worker);
+    assert_eq!(initial_record.requested_tier, DurabilityTier::Local);
     assert_eq!(
         initial_record.latest_settlement, None,
         "client-side persisted direct writes should start pending until an upstream durability settlement arrives"
@@ -3385,7 +3385,7 @@ fn rc_insert_persisted_tracks_local_batch_record_and_settlement() {
             branch_name,
             batch_id,
             state: None,
-            confirmed_tier: Some(DurabilityTier::Worker),
+            confirmed_tier: Some(DurabilityTier::Local),
         },
     });
     s.a.immediate_tick();
@@ -3401,7 +3401,7 @@ fn rc_insert_persisted_tracks_local_batch_record_and_settlement() {
         settled_record.latest_settlement,
         Some(crate::batch_fate::BatchSettlement::DurableDirect {
             batch_id,
-            confirmed_tier: DurabilityTier::Worker,
+            confirmed_tier: DurabilityTier::Local,
             visible_members: vec![crate::batch_fate::VisibleBatchMember {
                 object_id: row_id,
                 branch_name,
@@ -3419,7 +3419,7 @@ fn rc_insert_persisted_resolves_from_batch_settlement_without_row_state_changed(
             "users",
             user_insert_values(ObjectId::new(), "Alice"),
             None,
-            DurabilityTier::Worker,
+            DurabilityTier::Local,
         )
         .unwrap();
 
@@ -3436,7 +3436,7 @@ fn rc_insert_persisted_resolves_from_batch_settlement_without_row_state_changed(
         payload: SyncPayload::BatchSettlement {
             settlement: crate::batch_fate::BatchSettlement::DurableDirect {
                 batch_id,
-                confirmed_tier: DurabilityTier::Worker,
+                confirmed_tier: DurabilityTier::Local,
                 visible_members: vec![crate::batch_fate::VisibleBatchMember {
                     object_id: row_id,
                     branch_name,
@@ -3467,7 +3467,7 @@ fn rc_direct_insert_persisted_reconnect_reconciles_rejected_batch_from_server() 
             "users",
             user_insert_values(ObjectId::new(), "Alice"),
             None,
-            DurabilityTier::Worker,
+            DurabilityTier::Local,
         )
         .unwrap();
 
@@ -3583,7 +3583,7 @@ fn rc_worker_direct_batch_retains_all_visible_members() {
             "users",
             user_insert_values(ObjectId::new(), "Alice"),
             Some(&write_context),
-            DurabilityTier::Worker,
+            DurabilityTier::Local,
         )
         .unwrap();
     let ((second_row_id, _), mut second_receiver) =
@@ -3591,7 +3591,7 @@ fn rc_worker_direct_batch_retains_all_visible_members() {
             "users",
             user_insert_values(ObjectId::new(), "Bob"),
             Some(&write_context),
-            DurabilityTier::Worker,
+            DurabilityTier::Local,
         )
         .unwrap();
 
@@ -3612,7 +3612,7 @@ fn rc_worker_direct_batch_retains_all_visible_members() {
             visible_members,
         }) => {
             assert_eq!(settled_batch_id, batch_id);
-            assert_eq!(confirmed_tier, DurabilityTier::Worker);
+            assert_eq!(confirmed_tier, DurabilityTier::Local);
             assert_eq!(
                 visible_members.len(),
                 2,
@@ -3644,7 +3644,7 @@ fn rc_insert_persisted_reconnect_reconciles_pending_batch_from_server() {
             "users",
             user_insert_values(ObjectId::new(), "Alice"),
             None,
-            DurabilityTier::Worker,
+            DurabilityTier::Local,
         )
         .unwrap();
 
@@ -3685,7 +3685,7 @@ fn rc_insert_persisted_reconnect_reconciles_pending_batch_from_server() {
         settled_record.latest_settlement,
         Some(crate::batch_fate::BatchSettlement::DurableDirect {
             batch_id,
-            confirmed_tier: DurabilityTier::Worker,
+            confirmed_tier: DurabilityTier::Local,
             visible_members: vec![crate::batch_fate::VisibleBatchMember {
                 object_id: row_id,
                 branch_name,
@@ -3796,7 +3796,7 @@ fn rc_transactional_insert_is_accepted_when_replayed_to_reconnected_upstream() {
         history_rows[0].state,
         crate::row_histories::RowState::VisibleTransactional
     );
-    assert_eq!(history_rows[0].confirmed_tier, Some(DurabilityTier::Worker));
+    assert_eq!(history_rows[0].confirmed_tier, Some(DurabilityTier::Local));
     assert_eq!(history_rows[0].batch_id(), batch_id);
 
     let worker_row =
@@ -3853,7 +3853,7 @@ fn rc_transactional_insert_is_accepted_by_first_durable_upstream() {
         worker_row.state,
         crate::row_histories::RowState::VisibleTransactional
     );
-    assert_eq!(worker_row.confirmed_tier, Some(DurabilityTier::Worker));
+    assert_eq!(worker_row.confirmed_tier, Some(DurabilityTier::Local));
     assert_eq!(worker_row.batch_id(), batch_id);
 
     assert_eq!(
@@ -3875,7 +3875,7 @@ fn rc_transactional_insert_is_accepted_by_first_durable_upstream() {
         client_row.state,
         crate::row_histories::RowState::VisibleTransactional
     );
-    assert_eq!(client_row.confirmed_tier, Some(DurabilityTier::Worker));
+    assert_eq!(client_row.confirmed_tier, Some(DurabilityTier::Local));
     assert_eq!(client_row.batch_id(), batch_id);
 }
 
@@ -3900,7 +3900,7 @@ fn rc_transactional_insert_is_accepted_only_after_batch_is_sealed() {
             "users",
             user_insert_values(ObjectId::new(), "Alice"),
             Some(&write_context),
-            DurabilityTier::Worker,
+            DurabilityTier::Local,
         )
         .unwrap();
 
@@ -3938,7 +3938,7 @@ fn rc_transactional_insert_is_accepted_only_after_batch_is_sealed() {
         worker_row.state,
         crate::row_histories::RowState::VisibleTransactional
     );
-    assert_eq!(worker_row.confirmed_tier, Some(DurabilityTier::Worker));
+    assert_eq!(worker_row.confirmed_tier, Some(DurabilityTier::Local));
 
     assert_eq!(
         receiver.try_recv(),
@@ -4111,7 +4111,7 @@ fn rc_transactional_batch_rejects_writes_after_local_seal() {
             "users",
             user_insert_values(ObjectId::new(), "Alice"),
             Some(&open_write_context),
-            DurabilityTier::Worker,
+            DurabilityTier::Local,
         )
         .unwrap();
 
@@ -4151,7 +4151,7 @@ fn rc_transactional_batch_rejects_writes_after_local_seal() {
             "users",
             user_insert_values(ObjectId::new(), "Carol"),
             Some(&sealed_write_context),
-            DurabilityTier::Worker,
+            DurabilityTier::Local,
         )
         .unwrap_err();
     assert!(matches!(
@@ -4213,7 +4213,7 @@ fn rc_transactional_insert_persisted_tracks_local_batch_record_and_settlement() 
             "users",
             user_insert_values(ObjectId::new(), "Alice"),
             Some(&write_context),
-            DurabilityTier::Worker,
+            DurabilityTier::Local,
         )
         .unwrap();
 
@@ -4235,7 +4235,7 @@ fn rc_transactional_insert_persisted_tracks_local_batch_record_and_settlement() 
         initial_record.mode,
         crate::batch_fate::BatchMode::Transactional
     );
-    assert_eq!(initial_record.requested_tier, DurabilityTier::Worker);
+    assert_eq!(initial_record.requested_tier, DurabilityTier::Local);
     assert!(!initial_record.sealed);
     assert_eq!(initial_record.latest_settlement, None);
 
@@ -4260,7 +4260,7 @@ fn rc_transactional_insert_persisted_tracks_local_batch_record_and_settlement() 
         settled_record.latest_settlement,
         Some(crate::batch_fate::BatchSettlement::AcceptedTransaction {
             batch_id,
-            confirmed_tier: DurabilityTier::Worker,
+            confirmed_tier: DurabilityTier::Local,
             visible_members: vec![crate::batch_fate::VisibleBatchMember {
                 object_id: row_id,
                 branch_name,
@@ -4292,7 +4292,7 @@ fn rc_transactional_insert_persisted_reconnect_reconciles_pending_batch_from_ser
             "users",
             user_insert_values(ObjectId::new(), "Alice"),
             Some(&write_context),
-            DurabilityTier::Worker,
+            DurabilityTier::Local,
         )
         .unwrap();
 
@@ -4334,7 +4334,7 @@ fn rc_transactional_insert_persisted_reconnect_reconciles_pending_batch_from_ser
         settled_record.latest_settlement,
         Some(crate::batch_fate::BatchSettlement::AcceptedTransaction {
             batch_id,
-            confirmed_tier: DurabilityTier::Worker,
+            confirmed_tier: DurabilityTier::Local,
             visible_members: vec![crate::batch_fate::VisibleBatchMember {
                 object_id: row_id,
                 branch_name,
@@ -4362,7 +4362,7 @@ fn rc_transactional_persisted_writes_with_shared_batch_id_reconcile_as_one_batch
             "users",
             user_insert_values(ObjectId::new(), "Alice"),
             Some(&write_context),
-            DurabilityTier::Worker,
+            DurabilityTier::Local,
         )
         .unwrap();
     let ((second_row_id, _second_row_values), mut second_receiver) =
@@ -4370,7 +4370,7 @@ fn rc_transactional_persisted_writes_with_shared_batch_id_reconcile_as_one_batch
             "users",
             user_insert_values(ObjectId::new(), "Bob"),
             Some(&write_context),
-            DurabilityTier::Worker,
+            DurabilityTier::Local,
         )
         .unwrap();
 
@@ -4419,7 +4419,7 @@ fn rc_transactional_persisted_writes_with_shared_batch_id_reconcile_as_one_batch
             visible_members,
         } => {
             assert_eq!(settled_batch_id, batch_id);
-            assert_eq!(confirmed_tier, DurabilityTier::Worker);
+            assert_eq!(confirmed_tier, DurabilityTier::Local);
             assert_eq!(visible_members.len(), 2);
             assert!(visible_members.iter().any(|member| {
                 member.object_id == first_row_id
@@ -4447,7 +4447,7 @@ fn rc_transactional_persisted_writes_with_shared_batch_id_reconcile_as_one_batch
             visible_members,
         }) => {
             assert_eq!(settled_batch_id, batch_id);
-            assert_eq!(confirmed_tier, DurabilityTier::Worker);
+            assert_eq!(confirmed_tier, DurabilityTier::Local);
             assert_eq!(visible_members.len(), 2);
             assert!(visible_members.iter().any(|member| {
                 member.object_id == first_row_id
@@ -4483,7 +4483,7 @@ fn rc_add_server_requests_pending_batch_settlement_reconciliation() {
             "users",
             user_insert_values(ObjectId::new(), "Alice"),
             Some(&write_context),
-            DurabilityTier::Worker,
+            DurabilityTier::Local,
         )
         .unwrap();
 
@@ -4531,7 +4531,7 @@ fn rc_transactional_insert_persisted_reconnect_reconciles_rejected_batch_from_se
             "users",
             user_insert_values(ObjectId::new(), "Alice"),
             Some(&write_context),
-            DurabilityTier::Worker,
+            DurabilityTier::Local,
         )
         .unwrap();
 
@@ -4587,7 +4587,7 @@ fn rc_direct_insert_persisted_is_rejected_by_authority_permission_check() {
     let mut worker = create_runtime_with_schema_and_sync_manager(
         schema,
         "direct-reject-test",
-        SyncManager::new().with_durability_tier(DurabilityTier::Worker),
+        SyncManager::new().with_durability_tier(DurabilityTier::Local),
     );
     worker
         .schema_manager_mut()
@@ -4616,7 +4616,7 @@ fn rc_direct_insert_persisted_is_rejected_by_authority_permission_check() {
             "users",
             user_insert_values(ObjectId::new(), "Alice"),
             Some(&write_context),
-            DurabilityTier::Worker,
+            DurabilityTier::Local,
         )
         .unwrap();
 
@@ -4720,7 +4720,7 @@ fn rc_transactional_insert_is_rejected_by_authority_permission_check() {
     let mut worker = create_runtime_with_schema_and_sync_manager(
         schema,
         "transactional-reject-test",
-        SyncManager::new().with_durability_tier(DurabilityTier::Worker),
+        SyncManager::new().with_durability_tier(DurabilityTier::Local),
     );
     worker
         .schema_manager_mut()
@@ -4756,7 +4756,7 @@ fn rc_transactional_insert_is_rejected_by_authority_permission_check() {
             "users",
             user_insert_values(ObjectId::new(), "Alice"),
             Some(&write_context),
-            DurabilityTier::Worker,
+            DurabilityTier::Local,
         )
         .unwrap();
 
@@ -4840,7 +4840,7 @@ fn rc_acknowledge_rejected_batch_prunes_local_batch_record() {
     let mut worker = create_runtime_with_schema_and_sync_manager(
         schema,
         "transactional-ack-reject-test",
-        SyncManager::new().with_durability_tier(DurabilityTier::Worker),
+        SyncManager::new().with_durability_tier(DurabilityTier::Local),
     );
     worker
         .schema_manager_mut()
@@ -4870,7 +4870,7 @@ fn rc_acknowledge_rejected_batch_prunes_local_batch_record() {
             "users",
             user_insert_values(ObjectId::new(), "Alice"),
             Some(&write_context),
-            DurabilityTier::Worker,
+            DurabilityTier::Local,
         )
         .unwrap();
 
@@ -4938,7 +4938,7 @@ fn rc_rejected_batch_survives_restart_until_acknowledged() {
     let mut worker = create_runtime_with_schema_and_sync_manager(
         schema.clone(),
         "transactional-restart-reject-test",
-        SyncManager::new().with_durability_tier(DurabilityTier::Worker),
+        SyncManager::new().with_durability_tier(DurabilityTier::Local),
     );
     worker
         .schema_manager_mut()
@@ -4968,7 +4968,7 @@ fn rc_rejected_batch_survives_restart_until_acknowledged() {
             "users",
             user_insert_values(ObjectId::new(), "Alice"),
             Some(&write_context),
-            DurabilityTier::Worker,
+            DurabilityTier::Local,
         )
         .unwrap();
 
@@ -5039,7 +5039,7 @@ fn rc_restart_recovers_completed_sealed_batch_from_storage() {
     let mut old_runtime = create_runtime_with_schema_and_sync_manager(
         schema.clone(),
         "transactional-restart-seal-recovery-test",
-        SyncManager::new().with_durability_tier(DurabilityTier::Worker),
+        SyncManager::new().with_durability_tier(DurabilityTier::Local),
     );
     old_runtime
         .storage_mut()
@@ -5073,7 +5073,7 @@ fn rc_restart_recovers_completed_sealed_batch_from_storage() {
         schema,
         "transactional-restart-seal-recovery-test",
         storage,
-        SyncManager::new().with_durability_tier(DurabilityTier::Worker),
+        SyncManager::new().with_durability_tier(DurabilityTier::Local),
     );
 
     let settlement = restarted
@@ -5085,7 +5085,7 @@ fn rc_restart_recovers_completed_sealed_batch_from_storage() {
         settlement,
         crate::batch_fate::BatchSettlement::AcceptedTransaction {
             batch_id: settled_batch_id,
-            confirmed_tier: DurabilityTier::Worker,
+            confirmed_tier: DurabilityTier::Local,
             ref visible_members,
         } if settled_batch_id == batch_id
             && *visible_members == vec![crate::batch_fate::VisibleBatchMember {
@@ -5142,7 +5142,7 @@ fn rc_persisting_invalid_multibranch_sealed_batch_submission_fails() {
     let mut old_runtime = create_runtime_with_schema_and_sync_manager(
         schema.clone(),
         "transactional-restart-invalid-seal-recovery-test",
-        SyncManager::new().with_durability_tier(DurabilityTier::Worker),
+        SyncManager::new().with_durability_tier(DurabilityTier::Local),
     );
     for row_id in [main_row_id, draft_row_id] {
         old_runtime
@@ -5184,7 +5184,7 @@ fn rc_persisting_invalid_multibranch_sealed_batch_submission_fails() {
         schema,
         "transactional-restart-invalid-seal-recovery-test",
         storage,
-        SyncManager::new().with_durability_tier(DurabilityTier::Worker),
+        SyncManager::new().with_durability_tier(DurabilityTier::Local),
     );
 
     assert_eq!(
@@ -5265,7 +5265,7 @@ fn rc_restart_rejects_stale_family_frontier_sealed_batch_from_storage() {
     let mut old_runtime = create_runtime_with_schema_and_sync_manager(
         schema.clone(),
         "transactional-restart-frontier-conflict-test",
-        SyncManager::new().with_durability_tier(DurabilityTier::Worker),
+        SyncManager::new().with_durability_tier(DurabilityTier::Local),
     );
     for row_id in [existing_row_id, conflicting_row_id, staged_row_id] {
         old_runtime
@@ -5328,7 +5328,7 @@ fn rc_restart_rejects_stale_family_frontier_sealed_batch_from_storage() {
         schema,
         "transactional-restart-frontier-conflict-test",
         storage,
-        SyncManager::new().with_durability_tier(DurabilityTier::Worker),
+        SyncManager::new().with_durability_tier(DurabilityTier::Local),
     );
 
     assert_eq!(
@@ -5389,7 +5389,7 @@ fn rc_missing_batch_settlement_retransmits_local_transactional_rows() {
             "users",
             user_insert_values(ObjectId::new(), "Alice"),
             Some(&write_context),
-            DurabilityTier::Worker,
+            DurabilityTier::Local,
         )
         .unwrap();
 
@@ -5506,7 +5506,7 @@ fn rc_missing_batch_settlement_retransmits_local_transactional_rows_without_row_
             "users",
             user_insert_values(ObjectId::new(), "Alice"),
             Some(&write_context),
-            DurabilityTier::Worker,
+            DurabilityTier::Local,
         )
         .unwrap();
 
@@ -5586,7 +5586,7 @@ fn rc_missing_batch_settlement_retransmits_original_captured_frontier() {
             "users",
             user_insert_values(ObjectId::new(), "Alice"),
             Some(&write_context),
-            DurabilityTier::Worker,
+            DurabilityTier::Local,
         )
         .unwrap();
 
@@ -5676,7 +5676,7 @@ fn rc_update_persisted_resolves_on_ack() {
             id,
             vec![("name".into(), Value::Text("Bob".into()))],
             None,
-            DurabilityTier::Worker,
+            DurabilityTier::Local,
         )
         .unwrap();
 
@@ -5686,7 +5686,7 @@ fn rc_update_persisted_resolves_on_ack() {
     match receiver.try_recv() {
         Ok(Some(Ok(()))) => {}
         Ok(Some(Err(rejection))) => panic!("Update receiver should not reject: {rejection:?}"),
-        Ok(None) => panic!("Update receiver should be resolved after Worker ack"),
+        Ok(None) => panic!("Update receiver should be resolved after Local ack"),
         Err(_) => panic!("Receiver was cancelled"),
     }
 
@@ -5704,7 +5704,7 @@ fn rc_delete_persisted_resolves_on_ack() {
     pump_a_to_b(&mut s);
 
     let mut receiver =
-        s.a.delete_persisted(id, None, DurabilityTier::Worker)
+        s.a.delete_persisted(id, None, DurabilityTier::Local)
             .unwrap();
 
     pump_a_to_b(&mut s);
@@ -5713,7 +5713,7 @@ fn rc_delete_persisted_resolves_on_ack() {
     match receiver.try_recv() {
         Ok(Some(Ok(()))) => {}
         Ok(Some(Err(rejection))) => panic!("Delete receiver should not reject: {rejection:?}"),
-        Ok(None) => panic!("Delete receiver should be resolved after Worker ack"),
+        Ok(None) => panic!("Delete receiver should be resolved after Local ack"),
         Err(_) => panic!("Receiver was cancelled"),
     }
 
@@ -5731,7 +5731,7 @@ fn rc_multiple_persisted_inserts_independent() {
             "users",
             user_insert_values(ObjectId::new(), "Alice"),
             None,
-            DurabilityTier::Worker,
+            DurabilityTier::Local,
         )
         .unwrap();
 
@@ -5740,7 +5740,7 @@ fn rc_multiple_persisted_inserts_independent() {
             "users",
             user_insert_values(ObjectId::new(), "Bob"),
             None,
-            DurabilityTier::Worker,
+            DurabilityTier::Local,
         )
         .unwrap();
 
@@ -5794,7 +5794,7 @@ fn rc_query_settled_tier_holds() {
         Query::new("users"),
         None,
         ReadDurabilityOptions {
-            tier: Some(DurabilityTier::Worker),
+            tier: Some(DurabilityTier::Local),
             local_updates: crate::query_manager::manager::LocalUpdates::Immediate,
             strict_transactions: false,
         },
@@ -5805,7 +5805,7 @@ fn rc_query_settled_tier_holds() {
     let mut cx = std::task::Context::from_waker(&waker);
     assert!(
         Pin::new(&mut future).poll(&mut cx).is_pending(),
-        "Query should be pending before Worker settlement"
+        "Query should be pending before Local settlement"
     );
 
     pump_a_to_b(&mut s);
@@ -5847,7 +5847,7 @@ fn rc_query_remote_tier_immediate_local_updates_falls_back_to_local_pending_row(
         "Query should wait for the initial remote frontier"
     );
 
-    // Worker frontier completion is enough to unblock the first snapshot. With
+    // Local frontier completion is enough to unblock the first snapshot. With
     // immediate local updates, the locally-authored row should still be visible
     // even though it has not reached EdgeServer durability yet.
     pump_a_to_b(&mut s);
@@ -5871,7 +5871,7 @@ fn rc_query_settled_tier_empty_resolves() {
         Query::new("users"),
         None,
         ReadDurabilityOptions {
-            tier: Some(DurabilityTier::Worker),
+            tier: Some(DurabilityTier::Local),
             local_updates: crate::query_manager::manager::LocalUpdates::Immediate,
             strict_transactions: false,
         },
@@ -5882,7 +5882,7 @@ fn rc_query_settled_tier_empty_resolves() {
     let mut cx = std::task::Context::from_waker(&waker);
     assert!(
         Pin::new(&mut future).poll(&mut cx).is_pending(),
-        "Query should be pending before Worker settlement"
+        "Query should be pending before Local settlement"
     );
 
     // No rows inserted anywhere; query should still resolve once settled tier is reached.
@@ -5953,7 +5953,7 @@ fn query_reads_pick_row_batches_by_required_durability_tier() {
             "users",
             second_visible.batch_id,
             None,
-            Some(DurabilityTier::Worker),
+            Some(DurabilityTier::Local),
         )
         .unwrap();
 
@@ -5962,7 +5962,7 @@ fn query_reads_pick_row_batches_by_required_durability_tier() {
         Query::new("users"),
         None,
         ReadDurabilityOptions {
-            tier: Some(DurabilityTier::Worker),
+            tier: Some(DurabilityTier::Local),
             local_updates: crate::query_manager::manager::LocalUpdates::Deferred,
             strict_transactions: false,
         },
@@ -6006,12 +6006,12 @@ fn rc_query_settled_before_data_should_not_drop_upstream_rows() {
     s.b.batched_tick();
     s.b.sync_sender().take();
 
-    // One-shot settled query on A should wait for Worker settlement.
+    // One-shot settled query on A should wait for Local settlement.
     let mut future = s.a.query_with_propagation(
         Query::new("users"),
         None,
         ReadDurabilityOptions {
-            tier: Some(DurabilityTier::Worker),
+            tier: Some(DurabilityTier::Local),
             local_updates: crate::query_manager::manager::LocalUpdates::Immediate,
             strict_transactions: false,
         },
@@ -6022,7 +6022,7 @@ fn rc_query_settled_before_data_should_not_drop_upstream_rows() {
     let mut cx = std::task::Context::from_waker(&waker);
     assert!(
         Pin::new(&mut future).poll(&mut cx).is_pending(),
-        "Query should be pending before Worker settlement"
+        "Query should be pending before Local settlement"
     );
 
     // Deliver A -> B query subscription and let B compute response traffic.
@@ -6127,7 +6127,7 @@ fn rc_subscribe_settled_tier() {
             },
             None,
             ReadDurabilityOptions {
-                tier: Some(DurabilityTier::Worker),
+                tier: Some(DurabilityTier::Local),
                 local_updates: crate::query_manager::manager::LocalUpdates::Deferred,
                 strict_transactions: false,
             },
@@ -6142,7 +6142,7 @@ fn rc_subscribe_settled_tier() {
 
     assert!(
         received.lock().unwrap().is_empty(),
-        "Callback should not fire before Worker settlement"
+        "Callback should not fire before Local settlement"
     );
 
     pump_a_to_b(&mut s);
@@ -6199,7 +6199,7 @@ fn rc_subscribe_remote_tier_immediate_local_updates() {
     );
     drop(calls);
 
-    // Worker frontier completion is enough to unblock the first snapshot. With
+    // Local frontier completion is enough to unblock the first snapshot. With
     // immediate local updates, the locally-authored row is shown immediately
     // while its EdgeServer durability is still pending.
     pump_a_to_b(&mut s);
@@ -6261,7 +6261,7 @@ fn rc_subscribe_remote_tier_immediate_local_updates() {
 fn rc_strict_transaction_subscription_can_overlay_local_pending_batch() {
     // alice strict-subscribes at EdgeServer durability
     //   alice stages one transactional row locally
-    //   worker frontier completion unblocks the first snapshot
+    //   local frontier completion unblocks the first snapshot
     //   the row should appear via alice's local pending overlay even before EdgeServer settlement
     //   later EdgeServer settlement should not emit the same row again
     let mut s = create_3tier_rc();
@@ -6316,7 +6316,7 @@ fn rc_strict_transaction_subscription_can_overlay_local_pending_batch() {
     assert_eq!(
         calls.len(),
         1,
-        "worker frontier completion should unblock the first snapshot"
+        "local frontier completion should unblock the first snapshot"
     );
     assert_eq!(
         calls[0].len(),
@@ -6340,7 +6340,7 @@ fn rc_strict_transaction_subscription_can_overlay_local_pending_batch() {
 #[test]
 fn rc_strict_transaction_subscription_removes_local_pending_overlay_when_rejected() {
     // alice strict-subscribes at EdgeServer durability
-    //   worker frontier first opens the subscription with an empty snapshot
+    //   local frontier first opens the subscription with an empty snapshot
     //   alice then stages one transactional row locally
     //   the row appears only through the local pending overlay
     //   a replayable rejected batch settlement should remove that overlay immediately
@@ -6505,7 +6505,7 @@ fn rc_strict_transaction_subscription_hides_partial_accepted_batch_until_scope_c
             },
             None,
             ReadDurabilityOptions {
-                tier: Some(DurabilityTier::Worker),
+                tier: Some(DurabilityTier::Local),
                 local_updates: crate::query_manager::manager::LocalUpdates::Deferred,
                 strict_transactions: true,
             },

--- a/crates/jazz-tools/src/runtime_core/writes.rs
+++ b/crates/jazz-tools/src/runtime_core/writes.rs
@@ -27,7 +27,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             .query_manager()
             .sync_manager()
             .max_local_durability_tier()
-            .unwrap_or(DurabilityTier::Worker)
+            .unwrap_or(DurabilityTier::Local)
     }
 
     fn ensure_transactional_batch_is_writable(

--- a/crates/jazz-tools/src/schema_manager/integration_tests.rs
+++ b/crates/jazz-tools/src/schema_manager/integration_tests.rs
@@ -4663,8 +4663,8 @@ mod tests {
         assert_eq!(matching[0].delta.added.len(), 1);
     }
 
-    /// Test 2: Client A subscribes on server B with settled_tier=Worker.
-    /// B settles → emits QuerySettled(Worker). After A receives it, A delivers.
+    /// Test 2: Client A subscribes on server B with settled_tier=Local.
+    /// B settles → emits QuerySettled(Local). After A receives it, A delivers.
     #[test]
     fn query_settled_direct() {
         let schema = SchemaBuilder::new()
@@ -4686,9 +4686,9 @@ mod tests {
         .unwrap();
         let mut io_a = MemoryStorage::new();
 
-        // === Setup Server B (Worker tier) ===
+        // === Setup Server B (Local tier) ===
         let mut server_b = SchemaManager::new(
-            SyncManager::new().with_durability_tier(DurabilityTier::Worker),
+            SyncManager::new().with_durability_tier(DurabilityTier::Local),
             schema.clone(),
             test_app_id(),
             "dev",
@@ -4719,13 +4719,13 @@ mod tests {
         server_b.insert(&mut io_b, "items", values).unwrap();
         server_b.process(&mut io_b);
 
-        // === Client A subscribes with settled_tier=Worker ===
+        // === Client A subscribes with settled_tier=Local ===
         let query = QueryBuilder::new("items")
             .branch(client_a.branch_name().to_string())
             .build();
         let sub_id = client_a
             .query_manager_mut()
-            .subscribe_with_sync(query, None, Some(DurabilityTier::Worker))
+            .subscribe_with_sync(query, None, Some(DurabilityTier::Local))
             .unwrap();
         client_a.process(&mut io_a);
 
@@ -4766,13 +4766,13 @@ mod tests {
             .sync_manager_mut()
             .take_outbox();
 
-        // Expect QuerySettled(Worker) in outbox
+        // Expect QuerySettled(Local) in outbox
         let settled_msg = outbox_b
             .iter()
             .find(|e| matches!(e.payload, SyncPayload::QuerySettled { .. }));
         assert!(
             settled_msg.is_some(),
-            "Server B should emit QuerySettled(Worker)"
+            "Server B should emit QuerySettled(Local)"
         );
 
         // Forward all from B to A (including data + QuerySettled)
@@ -4800,7 +4800,7 @@ mod tests {
             .collect();
         assert!(
             !matching.is_empty(),
-            "Should deliver after QuerySettled(Worker) received"
+            "Should deliver after QuerySettled(Local) received"
         );
         let total_added: usize = matching.iter().map(|u| u.delta.added.len()).sum();
         assert!(total_added >= 1, "Should have at least 1 row delivered");
@@ -4872,7 +4872,7 @@ mod tests {
             .expect("one visible row");
         let server_b_id = ServerId::new();
 
-        // Simulate per-row Worker settlement — still insufficient for EdgeServer reads.
+        // Simulate per-row Local settlement — still insufficient for EdgeServer reads.
         client_a
             .query_manager_mut()
             .sync_manager_mut()
@@ -4883,7 +4883,7 @@ mod tests {
                     branch_name: BranchName::new(&visible_row.branch),
                     batch_id: visible_row.batch_id,
                     state: None,
-                    confirmed_tier: Some(DurabilityTier::Worker),
+                    confirmed_tier: Some(DurabilityTier::Local),
                 },
             });
         client_a.process(&mut io_a);
@@ -4895,7 +4895,7 @@ mod tests {
             .collect();
         assert!(
             matching.is_empty() || matching.iter().all(|u| u.delta.is_empty()),
-            "Worker < EdgeServer — should still not deliver"
+            "Local < EdgeServer — should still not deliver"
         );
 
         // Simulate per-row EdgeServer settlement — now the row may become visible.
@@ -4944,7 +4944,7 @@ mod tests {
             )
             .build();
 
-        // A = end client, B = worker tier mid-tier, C = edge tier upstream.
+        // A = end client, B = local tier mid-tier, C = edge tier upstream.
         let mut client_a = SchemaManager::new(
             SyncManager::new(),
             schema.clone(),
@@ -4956,7 +4956,7 @@ mod tests {
         let mut io_a = MemoryStorage::new();
 
         let mut worker_b = SchemaManager::new(
-            SyncManager::new().with_durability_tier(DurabilityTier::Worker),
+            SyncManager::new().with_durability_tier(DurabilityTier::Local),
             schema.clone(),
             test_app_id(),
             "dev",
@@ -5119,7 +5119,7 @@ mod tests {
         });
         assert!(
             edge_settled.is_some(),
-            "Worker tier should relay QuerySettled(EdgeServer) from upstream to client"
+            "Local tier should relay QuerySettled(EdgeServer) from upstream to client"
         );
 
         for entry in &relayed_from_b {
@@ -5173,7 +5173,7 @@ mod tests {
         .unwrap();
         let mut storage = MemoryStorage::new();
 
-        // Subscribe with settled_tier=Worker
+        // Subscribe with settled_tier=Local
         let query = QueryBuilder::new("items")
             .branch(client.branch_name().to_string())
             .build();
@@ -5182,7 +5182,7 @@ mod tests {
             .subscribe_with_sync_with_local_updates(
                 query,
                 None,
-                Some(DurabilityTier::Worker),
+                Some(DurabilityTier::Local),
                 LocalUpdates::Deferred,
             )
             .unwrap();
@@ -5225,7 +5225,7 @@ mod tests {
                         branch_name: BranchName::new(&row.branch),
                         batch_id: row.batch_id,
                         state: None,
-                        confirmed_tier: Some(DurabilityTier::Worker),
+                        confirmed_tier: Some(DurabilityTier::Local),
                     },
                 });
         }
@@ -5280,13 +5280,13 @@ mod tests {
         client.insert(&mut storage, "items", values).unwrap();
         client.process(&mut storage);
 
-        // Subscribe with settled_tier=Worker (simulating one-shot behavior)
+        // Subscribe with settled_tier=Local (simulating one-shot behavior)
         let query = QueryBuilder::new("items")
             .branch(client.branch_name().to_string())
             .build();
         let sub_id = client
             .query_manager_mut()
-            .subscribe_with_sync(query, None, Some(DurabilityTier::Worker))
+            .subscribe_with_sync(query, None, Some(DurabilityTier::Local))
             .unwrap();
         client.process(&mut storage);
 
@@ -5321,12 +5321,12 @@ mod tests {
                     branch_name: BranchName::new(&visible_row.branch),
                     batch_id: visible_row.batch_id,
                     state: None,
-                    confirmed_tier: Some(DurabilityTier::Worker),
+                    confirmed_tier: Some(DurabilityTier::Local),
                 },
             });
         client.process(&mut storage);
 
-        // Worker durability arriving later should not emit another visible
+        // Local durability arriving later should not emit another visible
         // delta because the row is already present.
         let updates = client.query_manager_mut().take_updates();
         let matching: Vec<_> = updates
@@ -5335,7 +5335,7 @@ mod tests {
             .collect();
         assert!(
             matching.is_empty() || matching.iter().all(|u| u.delta.is_empty()),
-            "Worker promotion should not emit a second visible delta"
+            "Local promotion should not emit a second visible delta"
         );
     }
 
@@ -5360,13 +5360,13 @@ mod tests {
         .unwrap();
         let mut storage = MemoryStorage::new();
 
-        // No rows inserted. Subscribe with settled_tier=Worker.
+        // No rows inserted. Subscribe with settled_tier=Local.
         let query = QueryBuilder::new("items")
             .branch(client.branch_name().to_string())
             .build();
         let sub_id = client
             .query_manager_mut()
-            .subscribe_with_sync(query, None, Some(DurabilityTier::Worker))
+            .subscribe_with_sync(query, None, Some(DurabilityTier::Local))
             .unwrap();
         client.process(&mut storage);
 

--- a/crates/jazz-tools/src/storage/conformance.rs
+++ b/crates/jazz-tools/src/storage/conformance.rs
@@ -565,7 +565,7 @@ pub fn test_visible_region_uses_flat_bytes_when_schema_known(
         RowProvenance::for_insert("alice".to_string(), 100),
         HashMap::new(),
         RowState::VisibleDirect,
-        Some(DurabilityTier::Worker),
+        Some(DurabilityTier::Local),
     );
     let entry = VisibleRowEntry::rebuild(row.clone(), std::slice::from_ref(&row));
 
@@ -621,7 +621,7 @@ pub fn test_visible_region_does_not_write_separate_batch_side_index(
         RowProvenance::for_insert("alice".to_string(), 100),
         HashMap::new(),
         RowState::VisibleDirect,
-        Some(DurabilityTier::Worker),
+        Some(DurabilityTier::Local),
     );
     let entry = VisibleRowEntry::rebuild(row.clone(), std::slice::from_ref(&row));
 
@@ -690,7 +690,7 @@ pub fn test_row_region_patch_state_monotonic(factory: &dyn Fn() -> Box<dyn Stora
             "users",
             version.batch_id,
             None,
-            Some(DurabilityTier::Worker),
+            Some(DurabilityTier::Local),
         )
         .unwrap();
 
@@ -924,7 +924,7 @@ pub fn test_local_batch_record_round_trip(factory: &dyn Fn() -> Box<dyn Storage>
         true,
         Some(BatchSettlement::DurableDirect {
             batch_id,
-            confirmed_tier: DurabilityTier::Worker,
+            confirmed_tier: DurabilityTier::Local,
             visible_members: vec![VisibleBatchMember {
                 object_id: ObjectId::from_uuid(uuid::Uuid::from_u128(91)),
                 branch_name: crate::object::BranchName::new("main"),
@@ -989,7 +989,7 @@ pub fn test_local_batch_record_scan_returns_sorted_entries(factory: &dyn Fn() ->
         .upsert_local_batch_record(&LocalBatchRecord::new(
             high,
             BatchMode::Direct,
-            DurabilityTier::Worker,
+            DurabilityTier::Local,
             true,
             None,
         ))
@@ -1016,7 +1016,7 @@ pub fn test_local_batch_record_delete_removes_record(factory: &dyn Fn() -> Box<d
     let record = LocalBatchRecord::new(
         batch_id,
         BatchMode::Transactional,
-        DurabilityTier::Worker,
+        DurabilityTier::Local,
         false,
         Some(BatchSettlement::Rejected {
             batch_id,
@@ -1230,7 +1230,7 @@ pub fn test_local_batch_record_survives_close_reopen(factory: &PersistentStorage
         true,
         Some(BatchSettlement::DurableDirect {
             batch_id,
-            confirmed_tier: DurabilityTier::Worker,
+            confirmed_tier: DurabilityTier::Local,
             visible_members: vec![VisibleBatchMember {
                 object_id: ObjectId::from_uuid(uuid::Uuid::from_u128(111)),
                 branch_name: crate::object::BranchName::new("main"),

--- a/crates/jazz-tools/src/storage/mod.rs
+++ b/crates/jazz-tools/src/storage/mod.rs
@@ -1512,7 +1512,7 @@ fn decode_batch_mode(raw: &str) -> Result<crate::batch_fate::BatchMode, StorageE
 
 fn encode_durability_tier(tier: DurabilityTier) -> &'static str {
     match tier {
-        DurabilityTier::Worker => "worker",
+        DurabilityTier::Local => "local",
         DurabilityTier::EdgeServer => "edge",
         DurabilityTier::GlobalServer => "global",
     }
@@ -1520,7 +1520,7 @@ fn encode_durability_tier(tier: DurabilityTier) -> &'static str {
 
 fn decode_durability_tier(raw: &str) -> Result<DurabilityTier, StorageError> {
     match raw {
-        "worker" => Ok(DurabilityTier::Worker),
+        "local" => Ok(DurabilityTier::Local),
         "edge" => Ok(DurabilityTier::EdgeServer),
         "global" => Ok(DurabilityTier::GlobalServer),
         other => Err(StorageError::IoError(format!(
@@ -6569,7 +6569,7 @@ mod tests {
             "alice",
             crate::metadata::RowProvenance::for_insert("alice".to_string(), 10),
             RowState::VisibleDirect,
-            Some(DurabilityTier::Worker),
+            Some(DurabilityTier::Local),
             Vec::new(),
         );
 
@@ -6613,7 +6613,7 @@ mod tests {
             "alice",
             crate::metadata::RowProvenance::for_insert("alice".to_string(), 10),
             crate::row_histories::RowState::VisibleDirect,
-            Some(DurabilityTier::Worker),
+            Some(DurabilityTier::Local),
             Vec::new(),
         );
 
@@ -6646,7 +6646,7 @@ mod tests {
             "alice",
             crate::metadata::RowProvenance::for_insert("alice".to_string(), 10),
             crate::row_histories::RowState::VisibleDirect,
-            Some(DurabilityTier::Worker),
+            Some(DurabilityTier::Local),
             Vec::new(),
         );
 
@@ -6695,7 +6695,7 @@ mod tests {
             "alpha",
             RowProvenance::for_insert("alice".to_string(), 10),
             crate::row_histories::RowState::VisibleDirect,
-            Some(DurabilityTier::Worker),
+            Some(DurabilityTier::Local),
             Vec::new(),
         );
 
@@ -6742,7 +6742,7 @@ mod tests {
             "alpha",
             RowProvenance::for_insert("alice".to_string(), 10),
             crate::row_histories::RowState::VisibleDirect,
-            Some(DurabilityTier::Worker),
+            Some(DurabilityTier::Local),
             Vec::new(),
         );
 
@@ -6787,7 +6787,7 @@ mod tests {
             "alpha",
             RowProvenance::for_insert("alice".to_string(), 10),
             crate::row_histories::RowState::VisibleDirect,
-            Some(DurabilityTier::Worker),
+            Some(DurabilityTier::Local),
             Vec::new(),
         );
         let sibling_row = make_users_row_batch(
@@ -6796,7 +6796,7 @@ mod tests {
             "beta",
             RowProvenance::for_insert("bob".to_string(), 20),
             crate::row_histories::RowState::VisibleDirect,
-            Some(DurabilityTier::Worker),
+            Some(DurabilityTier::Local),
             Vec::new(),
         );
 
@@ -6876,7 +6876,7 @@ mod tests {
             "alpha",
             RowProvenance::for_insert("alice".to_string(), 10),
             crate::row_histories::RowState::VisibleDirect,
-            Some(DurabilityTier::Worker),
+            Some(DurabilityTier::Local),
             Vec::new(),
         );
         let second_row = make_users_row_batch(
@@ -6885,7 +6885,7 @@ mod tests {
             "beta",
             RowProvenance::for_insert("alice".to_string(), 20),
             crate::row_histories::RowState::VisibleDirect,
-            Some(DurabilityTier::Worker),
+            Some(DurabilityTier::Local),
             Vec::new(),
         );
 
@@ -6936,7 +6936,7 @@ mod tests {
             "alpha",
             RowProvenance::for_insert("alice".to_string(), 10),
             crate::row_histories::RowState::VisibleDirect,
-            Some(DurabilityTier::Worker),
+            Some(DurabilityTier::Local),
             Vec::new(),
         );
         let second_row = make_users_row_batch(
@@ -6945,7 +6945,7 @@ mod tests {
             "beta",
             RowProvenance::for_insert("alice".to_string(), 20),
             crate::row_histories::RowState::VisibleDirect,
-            Some(DurabilityTier::Worker),
+            Some(DurabilityTier::Local),
             Vec::new(),
         );
 
@@ -6993,7 +6993,7 @@ mod tests {
                 updated_at: 20,
             },
             RowState::VisibleDirect,
-            Some(DurabilityTier::Worker),
+            Some(DurabilityTier::Local),
             vec![globally_confirmed.batch_id()],
         );
 
@@ -7344,7 +7344,7 @@ mod tests {
             RowProvenance::for_insert("alice".to_string(), 100),
             HashMap::new(),
             crate::row_histories::RowState::VisibleDirect,
-            Some(DurabilityTier::Worker),
+            Some(DurabilityTier::Local),
         );
 
         storage
@@ -7472,7 +7472,7 @@ mod tests {
             RowProvenance::for_insert("alice".to_string(), 100),
             HashMap::new(),
             crate::row_histories::RowState::VisibleDirect,
-            Some(DurabilityTier::Worker),
+            Some(DurabilityTier::Local),
         );
         let entry = VisibleRowEntry::new(row.clone());
 

--- a/crates/jazz-tools/src/sync_manager/tests.rs
+++ b/crates/jazz-tools/src/sync_manager/tests.rs
@@ -367,7 +367,7 @@ fn memory_size_separates_sync_state_buckets() {
     sm.row_batch_interest
         .insert(row_key, HashSet::from([client_id]));
     sm.received_row_batch_acks
-        .push((row_key, DurabilityTier::Worker));
+        .push((row_key, DurabilityTier::Local));
     sm.query_origin
         .insert(QueryId(7), HashSet::from([client_id]));
     sm.clients
@@ -388,7 +388,7 @@ fn memory_size_separates_sync_state_buckets() {
         destination: Destination::Client(client_id),
         payload: SyncPayload::QuerySettled {
             query_id: QueryId(7),
-            tier: DurabilityTier::Worker,
+            tier: DurabilityTier::Local,
             through_seq: 1,
         },
     });
@@ -418,7 +418,7 @@ fn memory_size_separates_sync_state_buckets() {
     sm.pending_query_settled.push(PendingQuerySettled {
         server_id: Some(server_id),
         query_id: QueryId(7),
-        tier: DurabilityTier::Worker,
+        tier: DurabilityTier::Local,
         through_seq: 2,
     });
     sm.pending_permission_checks.push(PendingPermissionCheck {
@@ -693,7 +693,7 @@ fn schema_warning_from_server_relays_to_interested_clients() {
 
 #[test]
 fn row_batch_created_emits_row_batch_state_changed_to_source() {
-    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Worker);
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
     let mut io = MemoryStorage::new();
     let server_id = ServerId::new();
     let row_id = ObjectId::new();
@@ -731,7 +731,7 @@ fn row_batch_created_emits_row_batch_state_changed_to_source() {
             assert_eq!(*branch_name, BranchName::new("main"));
             assert_eq!(*batch_id, row.batch_id);
             assert_eq!(*state, None);
-            assert_eq!(*confirmed_tier, Some(DurabilityTier::Worker));
+            assert_eq!(*confirmed_tier, Some(DurabilityTier::Local));
         }
         other => panic!("expected RowBatchStateChanged to server, got {other:?}"),
     }
@@ -807,7 +807,7 @@ fn row_batch_state_changed_updates_row_region_confirmed_tier_monotonically() {
             branch_name: BranchName::new("main"),
             batch_id,
             state: None,
-            confirmed_tier: Some(DurabilityTier::Worker),
+            confirmed_tier: Some(DurabilityTier::Local),
         },
     );
 
@@ -926,7 +926,7 @@ fn row_batch_state_changed_relays_to_clients_that_received_row_batch_needed() {
             branch_name: BranchName::new("main"),
             batch_id,
             state: None,
-            confirmed_tier: Some(DurabilityTier::Worker),
+            confirmed_tier: Some(DurabilityTier::Local),
         },
     );
 
@@ -938,7 +938,7 @@ fn row_batch_state_changed_relays_to_clients_that_received_row_batch_needed() {
                 SyncPayload::RowBatchStateChanged {
                     row_id: changed_row_id,
                     batch_id: changed_batch_id,
-                    confirmed_tier: Some(DurabilityTier::Worker),
+                    confirmed_tier: Some(DurabilityTier::Local),
                     ..
                 },
         } if id == client_id && changed_row_id == row_id && changed_batch_id == batch_id
@@ -952,7 +952,7 @@ fn initial_query_sync_replays_current_direct_batch_settlement() {
     let client_id = ClientId::new();
     let row_id = ObjectId::new();
     let mut row = visible_row(row_id, "main", Vec::new(), 1_000, b"alice");
-    row.confirmed_tier = Some(DurabilityTier::Worker);
+    row.confirmed_tier = Some(DurabilityTier::Local);
 
     add_client(&mut sm, &io, client_id);
     sm.take_outbox();
@@ -976,7 +976,7 @@ fn initial_query_sync_replays_current_direct_batch_settlement() {
             payload: SyncPayload::BatchSettlement { settlement },
         } if *id == client_id && *settlement == BatchSettlement::DurableDirect {
             batch_id: row.batch_id,
-            confirmed_tier: DurabilityTier::Worker,
+            confirmed_tier: DurabilityTier::Local,
             visible_members: vec![VisibleBatchMember {
                 object_id: row_id,
                 branch_name: BranchName::new("main"),
@@ -1053,7 +1053,7 @@ fn initial_query_sync_replays_current_accepted_transaction_settlement() {
     let row = row_with_state(
         visible_row(row_id, "main", Vec::new(), 1_000, b"alice"),
         crate::row_histories::RowState::VisibleTransactional,
-        Some(DurabilityTier::Worker),
+        Some(DurabilityTier::Local),
     );
 
     add_client(&mut sm, &io, client_id);
@@ -1078,7 +1078,7 @@ fn initial_query_sync_replays_current_accepted_transaction_settlement() {
             payload: SyncPayload::BatchSettlement { settlement },
         } if *id == client_id && *settlement == BatchSettlement::AcceptedTransaction {
             batch_id: row.batch_id,
-            confirmed_tier: DurabilityTier::Worker,
+            confirmed_tier: DurabilityTier::Local,
             visible_members: vec![VisibleBatchMember {
                 object_id: row_id,
                 branch_name: BranchName::new("main"),
@@ -1097,7 +1097,7 @@ fn batch_settlement_needed_returns_current_accepted_transaction() {
     let row = row_with_state(
         visible_row(row_id, "main", Vec::new(), 1_000, b"alice"),
         crate::row_histories::RowState::VisibleTransactional,
-        Some(DurabilityTier::Worker),
+        Some(DurabilityTier::Local),
     );
 
     add_client(&mut sm, &io, client_id);
@@ -1120,7 +1120,7 @@ fn batch_settlement_needed_returns_current_accepted_transaction() {
             payload: SyncPayload::BatchSettlement { settlement },
         } if id == client_id && settlement == BatchSettlement::AcceptedTransaction {
             batch_id: row.batch_id,
-            confirmed_tier: DurabilityTier::Worker,
+            confirmed_tier: DurabilityTier::Local,
             visible_members: vec![VisibleBatchMember {
                 object_id: row_id,
                 branch_name: BranchName::new("main"),
@@ -1137,7 +1137,7 @@ fn batch_settlement_needed_returns_missing_without_persisted_visible_settlement(
     let client_id = ClientId::new();
     let row_id = ObjectId::new();
     let mut row = visible_row(row_id, "main", Vec::new(), 1_000, b"alice");
-    row.confirmed_tier = Some(DurabilityTier::Worker);
+    row.confirmed_tier = Some(DurabilityTier::Local);
 
     add_client(&mut sm, &io, client_id);
     sm.take_outbox();
@@ -1228,7 +1228,7 @@ fn row_batch_state_changed_relays_direct_batch_settlement_to_interested_clients(
     let client_id = ClientId::new();
     let row_id = ObjectId::new();
     let mut row = visible_row(row_id, "main", Vec::new(), 1_000, b"alice");
-    row.confirmed_tier = Some(DurabilityTier::Worker);
+    row.confirmed_tier = Some(DurabilityTier::Local);
     let batch_id = row.batch_id;
 
     add_client(&mut sm, &io, client_id);
@@ -1254,7 +1254,7 @@ fn row_batch_state_changed_relays_direct_batch_settlement_to_interested_clients(
             branch_name: BranchName::new("main"),
             batch_id,
             state: None,
-            confirmed_tier: Some(DurabilityTier::Worker),
+            confirmed_tier: Some(DurabilityTier::Local),
         },
     );
 
@@ -1265,7 +1265,7 @@ fn row_batch_state_changed_relays_direct_batch_settlement_to_interested_clients(
             payload: SyncPayload::BatchSettlement { settlement },
         } if id == client_id && settlement == BatchSettlement::DurableDirect {
             batch_id: row.batch_id,
-            confirmed_tier: DurabilityTier::Worker,
+            confirmed_tier: DurabilityTier::Local,
             visible_members: vec![VisibleBatchMember {
                 object_id: row_id,
                 branch_name: BranchName::new("main"),
@@ -1284,7 +1284,7 @@ fn row_batch_state_changed_relays_accepted_transaction_settlement_to_interested_
     let row = row_with_state(
         visible_row(row_id, "main", Vec::new(), 1_000, b"alice"),
         crate::row_histories::RowState::VisibleTransactional,
-        Some(DurabilityTier::Worker),
+        Some(DurabilityTier::Local),
     );
     let batch_id = row.batch_id;
 
@@ -1311,7 +1311,7 @@ fn row_batch_state_changed_relays_accepted_transaction_settlement_to_interested_
             branch_name: BranchName::new("main"),
             batch_id,
             state: None,
-            confirmed_tier: Some(DurabilityTier::Worker),
+            confirmed_tier: Some(DurabilityTier::Local),
         },
     );
 
@@ -1322,7 +1322,7 @@ fn row_batch_state_changed_relays_accepted_transaction_settlement_to_interested_
             payload: SyncPayload::BatchSettlement { settlement },
         } if id == client_id && settlement == BatchSettlement::AcceptedTransaction {
             batch_id: row.batch_id,
-            confirmed_tier: DurabilityTier::Worker,
+            confirmed_tier: DurabilityTier::Local,
             visible_members: vec![VisibleBatchMember {
                 object_id: row_id,
                 branch_name: BranchName::new("main"),
@@ -1340,14 +1340,14 @@ fn row_batch_state_changed_persists_accepted_transaction_tier_upgrade_authoritat
     let row = row_with_state(
         visible_row(row_id, "main", Vec::new(), 1_000, b"alice"),
         crate::row_histories::RowState::VisibleTransactional,
-        Some(DurabilityTier::Worker),
+        Some(DurabilityTier::Local),
     );
     let batch_id = row.batch_id;
 
     seed_visible_row(&mut sm, &mut io, "users", row.clone());
     io.upsert_authoritative_batch_settlement(&BatchSettlement::AcceptedTransaction {
         batch_id: row.batch_id,
-        confirmed_tier: DurabilityTier::Worker,
+        confirmed_tier: DurabilityTier::Local,
         visible_members: vec![VisibleBatchMember {
             object_id: row_id,
             branch_name: BranchName::new("main"),
@@ -1414,7 +1414,7 @@ fn row_batch_state_changed_stops_relaying_after_scope_removal() {
             branch_name: BranchName::new("main"),
             batch_id: row.batch_id,
             state: None,
-            confirmed_tier: Some(DurabilityTier::Worker),
+            confirmed_tier: Some(DurabilityTier::Local),
         },
     );
 
@@ -1617,7 +1617,7 @@ fn stale_divergent_row_batch_from_client_does_not_regress_newer_visible_row() {
 
 #[test]
 fn transactional_row_from_client_stays_staged_until_batch_is_sealed() {
-    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Worker);
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
     let mut io = MemoryStorage::new();
     let client_id = ClientId::new();
     let row_id = ObjectId::new();
@@ -1675,7 +1675,7 @@ fn transactional_row_from_client_stays_staged_until_batch_is_sealed() {
 
 #[test]
 fn seal_batch_accepts_all_staged_transactional_rows_as_one_settlement() {
-    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Worker);
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
     let mut io = MemoryStorage::new();
     let client_id = ClientId::new();
     let batch_id = crate::row_histories::BatchId::new();
@@ -1750,7 +1750,7 @@ fn seal_batch_accepts_all_staged_transactional_rows_as_one_settlement() {
         panic!("expected accepted transactional settlement, got {settlement:?}");
     };
     assert_eq!(settled_batch_id, batch_id);
-    assert_eq!(confirmed_tier, DurabilityTier::Worker);
+    assert_eq!(confirmed_tier, DurabilityTier::Local);
     assert_eq!(visible_members.len(), 2);
     assert!(visible_members.contains(&VisibleBatchMember {
         object_id: first_row_id,
@@ -1788,7 +1788,7 @@ fn seal_batch_accepts_all_staged_transactional_rows_as_one_settlement() {
             payload: SyncPayload::BatchSettlement { settlement: returned },
         } if *id == client_id && *returned == BatchSettlement::AcceptedTransaction {
             batch_id,
-            confirmed_tier: DurabilityTier::Worker,
+            confirmed_tier: DurabilityTier::Local,
             visible_members: visible_members.clone(),
         }
     )));
@@ -1796,7 +1796,7 @@ fn seal_batch_accepts_all_staged_transactional_rows_as_one_settlement() {
 
 #[test]
 fn seal_batch_collapses_same_row_to_latest_visible_member() {
-    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Worker);
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
     let mut io = MemoryStorage::new();
     let client_id = ClientId::new();
     let batch_id = crate::row_histories::BatchId::new();
@@ -1911,7 +1911,7 @@ fn seal_batch_collapses_same_row_to_latest_visible_member() {
                 branch_name,
                 batch_id: changed_batch_id,
                 state: Some(crate::row_histories::RowState::VisibleTransactional),
-                confirmed_tier: Some(DurabilityTier::Worker),
+                confirmed_tier: Some(DurabilityTier::Local),
             },
         } if *id == client_id
             && *changed_row_id == row_id
@@ -1929,7 +1929,7 @@ fn seal_batch_collapses_same_row_to_latest_visible_member() {
 
 #[test]
 fn seal_batch_same_row_preserves_pre_transaction_parent_frontier() {
-    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Worker);
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
     let mut io = MemoryStorage::new();
     let client_id = ClientId::new();
     let batch_id = crate::row_histories::BatchId::new();
@@ -2007,7 +2007,7 @@ fn seal_batch_same_row_preserves_pre_transaction_parent_frontier() {
 
 #[test]
 fn seal_batch_waits_for_all_declared_rows_before_accepting() {
-    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Worker);
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
     let mut io = MemoryStorage::new();
     let client_id = ClientId::new();
     let batch_id = crate::row_histories::BatchId::new();
@@ -2108,7 +2108,7 @@ fn seal_batch_waits_for_all_declared_rows_before_accepting() {
 
 #[test]
 fn seal_batch_waits_for_declared_latest_row_batch_before_accepting() {
-    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Worker);
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
     let mut io = MemoryStorage::new();
     let client_id = ClientId::new();
     let batch_id = crate::row_histories::BatchId::new();
@@ -2213,7 +2213,7 @@ fn seal_batch_waits_for_declared_latest_row_batch_before_accepting() {
 
 #[test]
 fn same_row_staging_in_one_batch_keeps_only_latest_live_pending_member_before_seal() {
-    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Worker);
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
     let mut io = MemoryStorage::new();
     let client_id = ClientId::new();
     let batch_id = crate::row_histories::BatchId::new();
@@ -2283,7 +2283,7 @@ fn same_row_staging_in_one_batch_keeps_only_latest_live_pending_member_before_se
 
 #[test]
 fn seal_batch_rejects_members_spanning_multiple_target_branches() {
-    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Worker);
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
     let mut io = MemoryStorage::new();
     let client_id = ClientId::new();
     let batch_id = crate::row_histories::BatchId::new();
@@ -2391,7 +2391,7 @@ fn seal_batch_rejects_members_spanning_multiple_target_branches() {
 
 #[test]
 fn seal_batch_rejects_when_batch_digest_does_not_match_members() {
-    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Worker);
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
     let mut io = MemoryStorage::new();
     let client_id = ClientId::new();
     let batch_id = crate::row_histories::BatchId::new();
@@ -2452,7 +2452,7 @@ fn seal_batch_rejects_when_batch_digest_does_not_match_members() {
 
 #[test]
 fn seal_batch_rejection_stops_when_settlement_persistence_fails() {
-    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Worker);
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
     let mut io = FailingHistoryPatchStorage::new();
     io.fail_authoritative_settlement_upsert = true;
     let client_id = ClientId::new();
@@ -2511,7 +2511,7 @@ fn seal_batch_rejection_stops_when_settlement_persistence_fails() {
 
 #[test]
 fn seal_batch_acceptance_stops_when_submission_persistence_fails() {
-    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Worker);
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
     let mut io = FailingHistoryPatchStorage::new();
     io.fail_sealed_submission_upsert = true;
     let client_id = ClientId::new();
@@ -2570,7 +2570,7 @@ fn seal_batch_acceptance_stops_when_submission_persistence_fails() {
 
 #[test]
 fn seal_batch_rejects_when_family_visible_frontier_changed() {
-    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Worker);
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
     let mut io = MemoryStorage::new();
     let client_id = ClientId::new();
     let batch_id = crate::row_histories::BatchId::new();
@@ -2673,7 +2673,7 @@ fn seal_batch_rejects_when_family_visible_frontier_changed() {
 
 #[test]
 fn seal_batch_accepts_when_family_visible_frontier_matches() {
-    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Worker);
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
     let mut io = MemoryStorage::new();
     let client_id = ClientId::new();
     let batch_id = crate::row_histories::BatchId::new();
@@ -2733,7 +2733,7 @@ fn seal_batch_accepts_when_family_visible_frontier_matches() {
         io.load_authoritative_batch_settlement(batch_id).unwrap(),
         Some(BatchSettlement::AcceptedTransaction {
             batch_id: settled_batch_id,
-            confirmed_tier: DurabilityTier::Worker,
+            confirmed_tier: DurabilityTier::Local,
             ref visible_members,
         }) if settled_batch_id == batch_id
             && *visible_members == vec![VisibleBatchMember {

--- a/crates/jazz-tools/src/sync_manager/types.rs
+++ b/crates/jazz-tools/src/sync_manager/types.rs
@@ -23,10 +23,10 @@ pub struct PolicyError {
 // ID Types
 // ============================================================================
 
-/// Persistence tier — declaration order defines Ord (Worker < EdgeServer < GlobalServer).
+/// Persistence tier — declaration order defines Ord (Local < EdgeServer < GlobalServer).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
 pub enum DurabilityTier {
-    Worker,
+    Local,
     EdgeServer,
     GlobalServer,
 }

--- a/crates/jazz-tools/tests/auth_test.rs
+++ b/crates/jazz-tools/tests/auth_test.rs
@@ -381,6 +381,19 @@ mod integration_tests {
         );
     }
 
+    /// Test harness should resolve the actual bound port when the CLI listens on port 0.
+    #[tokio::test]
+    async fn test_server_start_on_port_zero_reports_actual_bound_port() {
+        let server = TestServer::start_on_port(0).await;
+
+        assert_ne!(server.port, 0, "test server should expose the bound port");
+
+        let health = reqwest::get(format!("{}/health", server.base_url()))
+            .await
+            .expect("health check request");
+        assert!(health.status().is_success());
+    }
+
     /// Admin-secret-authenticated handshakes should connect successfully.
     #[tokio::test]
     async fn test_admin_secret_ws_handshake() {

--- a/crates/jazz-tools/tests/client_restart_integration.rs
+++ b/crates/jazz-tools/tests/client_restart_integration.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "test")]
 
 use std::collections::HashMap;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -78,11 +79,13 @@ async fn jwks_handler() -> Json<JsonValue> {
 struct ServerProcess {
     process: Child,
     port: u16,
+    bound_port_file: PathBuf,
     client: reqwest::Client,
 }
 
 impl ServerProcess {
     async fn start(port: u16, data_dir: &Path, jwks_endpoint: &str) -> Self {
+        let bound_port_file = data_dir.join("bound-port");
         let mut cmd = Command::new(env!("CARGO_BIN_EXE_jazz-tools"));
         cmd.args([
             "server",
@@ -95,18 +98,20 @@ impl ServerProcess {
         .env("JAZZ_JWKS_URL", jwks_endpoint)
         .env("JAZZ_BACKEND_SECRET", BACKEND_SECRET)
         .env("JAZZ_ADMIN_SECRET", ADMIN_SECRET)
-        .stdout(Stdio::null());
+        .env("JAZZ_BOUND_PORT_FILE", &bound_port_file)
+        .stdout(Stdio::piped());
 
         if std::env::var("JAZZ_TEST_SERVER_LOGS").is_ok() {
             cmd.stderr(Stdio::inherit());
         } else {
-            cmd.stderr(Stdio::null());
+            cmd.stderr(Stdio::piped());
         }
 
         let process = cmd.spawn().expect("spawn jazz-tools server");
         let mut server = Self {
             process,
             port,
+            bound_port_file,
             client: reqwest::Client::new(),
         };
         server.wait_ready().await;
@@ -118,19 +123,60 @@ impl ServerProcess {
     }
 
     async fn wait_ready(&mut self) {
-        let health_url = format!("{}/health", self.base_url());
         for _ in 0..200 {
+            self.maybe_update_bound_port();
             if let Some(status) = self.process.try_wait().expect("poll jazz-tools server") {
-                panic!("jazz-tools server exited before becoming ready: {status}");
+                panic!(
+                    "jazz-tools server exited before becoming ready: {status}{}",
+                    self.process_output_summary()
+                );
             }
-            if let Ok(response) = self.client.get(&health_url).send().await
-                && response.status().is_success()
-            {
-                return;
+            if self.port != 0 {
+                let health_url = format!("{}/health", self.base_url());
+                if let Ok(response) = self.client.get(&health_url).send().await
+                    && response.status().is_success()
+                {
+                    return;
+                }
             }
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
-        panic!("jazz-tools server did not become ready within 20 seconds");
+        panic!(
+            "jazz-tools server did not become ready within 20 seconds{}",
+            self.process_output_summary()
+        );
+    }
+
+    fn maybe_update_bound_port(&mut self) {
+        let Ok(contents) = std::fs::read_to_string(&self.bound_port_file) else {
+            return;
+        };
+        let Ok(port) = contents.trim().parse::<u16>() else {
+            return;
+        };
+        self.port = port;
+    }
+
+    fn process_output_summary(&mut self) -> String {
+        let stdout = take_pipe_text(&mut self.process.stdout);
+        let stderr = take_pipe_text(&mut self.process.stderr);
+        if stdout.is_empty() && stderr.is_empty() {
+            return String::new();
+        }
+
+        format!(
+            "\nstdout:\n{}\nstderr:\n{}",
+            if stdout.is_empty() {
+                "<empty>"
+            } else {
+                stdout.trim()
+            },
+            if stderr.is_empty() {
+                "<empty>"
+            } else {
+                stderr.trim()
+            }
+        )
     }
 }
 
@@ -159,9 +205,14 @@ impl Drop for ServerProcess {
     }
 }
 
-fn get_free_port() -> u16 {
-    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind port 0");
-    listener.local_addr().expect("local addr").port()
+fn take_pipe_text<T: Read>(pipe: &mut Option<T>) -> String {
+    let Some(mut pipe) = pipe.take() else {
+        return String::new();
+    };
+
+    let mut bytes = Vec::new();
+    let _ = pipe.read_to_end(&mut bytes);
+    String::from_utf8_lossy(&bytes).into_owned()
 }
 
 fn make_jwt(sub: &str) -> String {
@@ -317,9 +368,8 @@ async fn jazz_tools_cli_existing_client_keeps_working_after_server_restart_witho
     let jwks_server = JwksServer::start().await;
     let server_data = TempDir::new().expect("temp server dir");
     let app_id = AppId::from_string(APP_ID_STR).expect("parse app id");
-    let port = get_free_port();
 
-    let server = ServerProcess::start(port, server_data.path(), &jwks_server.endpoint()).await;
+    let server = ServerProcess::start(0, server_data.path(), &jwks_server.endpoint()).await;
 
     let client_dir = TempDir::new().expect("client dir");
     let client = JazzClient::connect(make_context(
@@ -355,6 +405,7 @@ async fn jazz_tools_cli_existing_client_keeps_working_after_server_restart_witho
     )
     .await;
 
+    let restart_port = server.port;
     drop(server);
     wait_for_catalogue_schema_entry_count_on_disk(
         app_id,
@@ -364,7 +415,8 @@ async fn jazz_tools_cli_existing_client_keeps_working_after_server_restart_witho
     )
     .await;
 
-    let restarted = ServerProcess::start(port, server_data.path(), &jwks_server.endpoint()).await;
+    let restarted =
+        ServerProcess::start(restart_port, server_data.path(), &jwks_server.endpoint()).await;
 
     let rows_after_restart = wait_for_todos_count(
         &client,

--- a/crates/jazz-tools/tests/integration.rs
+++ b/crates/jazz-tools/tests/integration.rs
@@ -5,6 +5,7 @@
 //! These tests spawn the actual `jazz-tools` binary and interact via HTTP
 //! and WebSocket with binary length-prefixed frames.
 
+use std::io::Read;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::time::Duration;
@@ -90,6 +91,7 @@ async fn ws_handshake(port: u16, jwt_token: &str) -> Result<ConnectedResponse, S
 struct TestServer {
     process: Child,
     port: u16,
+    bound_port_file: PathBuf,
     #[allow(dead_code)]
     data_dir: TempDir,
     configured_data_dir: PathBuf,
@@ -100,6 +102,7 @@ impl TestServer {
     async fn start(port: u16) -> Self {
         let data_dir = TempDir::new().expect("create temp dir");
         let configured_data_dir = data_dir.path().to_path_buf();
+        let bound_port_file = data_dir.path().join("bound-port");
 
         // Use a deterministic UUID app ID for testing
         let app_id = "00000000-0000-0000-0000-000000000001";
@@ -115,6 +118,7 @@ impl TestServer {
                 "--data-dir",
                 configured_data_dir.to_str().unwrap(),
             ])
+            .env("JAZZ_BOUND_PORT_FILE", &bound_port_file)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
@@ -128,6 +132,7 @@ impl TestServer {
         let mut server = Self {
             process,
             port,
+            bound_port_file,
             data_dir,
             configured_data_dir,
         };
@@ -142,6 +147,7 @@ impl TestServer {
     async fn start_in_memory(port: u16) -> Self {
         let data_dir = TempDir::new().expect("create temp dir");
         let configured_data_dir = data_dir.path().join("should-not-exist");
+        let bound_port_file = data_dir.path().join("bound-port");
 
         let app_id = "00000000-0000-0000-0000-000000000001";
         let jazz_binary = Self::find_jazz_binary();
@@ -156,6 +162,7 @@ impl TestServer {
                 configured_data_dir.to_str().unwrap(),
                 "--in-memory",
             ])
+            .env("JAZZ_BOUND_PORT_FILE", &bound_port_file)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
@@ -169,6 +176,7 @@ impl TestServer {
         let mut server = Self {
             process,
             port,
+            bound_port_file,
             data_dir,
             configured_data_dir,
         };
@@ -202,23 +210,64 @@ impl TestServer {
 
     async fn wait_ready(&mut self) {
         let client = Client::new();
-        let url = format!("{}/health", self.base_url());
 
         for i in 0..200 {
+            self.maybe_update_bound_port();
             if let Some(status) = self.process.try_wait().expect("poll jazz-tools server") {
-                panic!("jazz-tools server exited before becoming ready: {status}");
+                panic!(
+                    "jazz-tools server exited before becoming ready: {status}{}",
+                    self.process_output_summary()
+                );
             }
-            match client.get(&url).send().await {
-                Ok(_) => return,
-                Err(e) => {
-                    if i == 199 {
-                        eprintln!("Last error: {:?}", e);
+            if self.port != 0 {
+                let url = format!("{}/health", self.base_url());
+                match client.get(&url).send().await {
+                    Ok(_) => return,
+                    Err(e) => {
+                        if i == 199 {
+                            eprintln!("Last error: {:?}", e);
+                        }
                     }
                 }
             }
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
-        panic!("Server failed to become ready within 20 seconds");
+        panic!(
+            "Server failed to become ready within 20 seconds{}",
+            self.process_output_summary()
+        );
+    }
+
+    fn maybe_update_bound_port(&mut self) {
+        let Ok(contents) = std::fs::read_to_string(&self.bound_port_file) else {
+            return;
+        };
+        let Ok(port) = contents.trim().parse::<u16>() else {
+            return;
+        };
+        self.port = port;
+    }
+
+    fn process_output_summary(&mut self) -> String {
+        let stdout = take_pipe_text(&mut self.process.stdout);
+        let stderr = take_pipe_text(&mut self.process.stderr);
+        if stdout.is_empty() && stderr.is_empty() {
+            return String::new();
+        }
+
+        format!(
+            "\nstdout:\n{}\nstderr:\n{}",
+            if stdout.is_empty() {
+                "<empty>"
+            } else {
+                stdout.trim()
+            },
+            if stderr.is_empty() {
+                "<empty>"
+            } else {
+                stderr.trim()
+            }
+        )
     }
 }
 
@@ -229,16 +278,19 @@ impl Drop for TestServer {
     }
 }
 
-/// Find an available port by binding to port 0.
-fn get_free_port() -> u16 {
-    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind to port 0");
-    listener.local_addr().unwrap().port()
+fn take_pipe_text<T: Read>(pipe: &mut Option<T>) -> String {
+    let Some(mut pipe) = pipe.take() else {
+        return String::new();
+    };
+
+    let mut bytes = Vec::new();
+    let _ = pipe.read_to_end(&mut bytes);
+    String::from_utf8_lossy(&bytes).into_owned()
 }
 
 #[tokio::test]
 async fn test_server_health_check() {
-    let port = get_free_port();
-    let server = TestServer::start(port).await;
+    let server = TestServer::start(0).await;
 
     let client = Client::new();
     let resp = client
@@ -255,8 +307,7 @@ async fn test_server_health_check() {
 
 #[tokio::test]
 async fn test_server_health_check_in_memory_does_not_create_data_dir() {
-    let port = get_free_port();
-    let server = TestServer::start_in_memory(port).await;
+    let server = TestServer::start_in_memory(0).await;
 
     let client = Client::new();
     let resp = client
@@ -274,8 +325,7 @@ async fn test_server_health_check_in_memory_does_not_create_data_dir() {
 
 #[tokio::test]
 async fn test_ws_connection_receives_connected_response() {
-    let port = get_free_port();
-    let server = TestServer::start(port).await;
+    let server = TestServer::start(0).await;
 
     let token = mint_test_token("00000000-0000-0000-0000-000000000001");
     let resp = tokio::time::timeout(Duration::from_secs(5), ws_handshake(server.port, &token))
@@ -296,8 +346,7 @@ async fn test_ws_connection_receives_connected_response() {
 
 #[tokio::test]
 async fn test_ws_connection_stays_open_after_handshake() {
-    let port = get_free_port();
-    let server = TestServer::start(port).await;
+    let server = TestServer::start(0).await;
 
     let token = mint_test_token("00000000-0000-0000-0000-000000000001");
     let ws_url = format!("ws://127.0.0.1:{}/ws", server.port);
@@ -352,8 +401,7 @@ async fn test_ws_connection_stays_open_after_handshake() {
 
 #[tokio::test]
 async fn test_ws_handshake_returns_valid_connection_id() {
-    let port = get_free_port();
-    let server = TestServer::start(port).await;
+    let server = TestServer::start(0).await;
 
     let token = mint_test_token("00000000-0000-0000-0000-000000000001");
     let resp = tokio::time::timeout(Duration::from_secs(5), ws_handshake(server.port, &token))

--- a/crates/jazz-tools/tests/test_server.rs
+++ b/crates/jazz-tools/tests/test_server.rs
@@ -4,6 +4,7 @@
 //!
 //! Spawns the jazz-tools binary as a subprocess and waits for it to become ready.
 
+use std::io::Read;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
@@ -86,6 +87,7 @@ impl Drop for JwksServer {
 pub struct TestServer {
     process: Child,
     pub port: u16,
+    bound_port_file: PathBuf,
     #[allow(dead_code)]
     data_dir: TempDir,
     #[allow(dead_code)]
@@ -95,16 +97,14 @@ pub struct TestServer {
 impl TestServer {
     /// Start a test server on a free port.
     pub async fn start() -> Self {
-        let port = get_free_port();
-        Self::start_on_port(port).await
+        Self::start_on_port(0).await
     }
 
     /// Start a test server without JWT validation configured.
     pub async fn start_without_jwks() -> Self {
-        let port = get_free_port();
         let data_dir = TempDir::new().expect("create temp dir");
         let jwks_server = JwksServer::start(JWT_KID, JWT_SECRET).await;
-        Self::start_inner(port, data_dir, jwks_server, false, vec![]).await
+        Self::start_inner(0, data_dir, jwks_server, false, vec![]).await
     }
 
     /// Start a test server with programmable JWKS responses.
@@ -112,10 +112,9 @@ impl TestServer {
     /// The JWKS server returns `responses[N]` for the Nth request,
     /// falling back to the last response for subsequent requests.
     pub async fn start_with_jwks_responses(responses: Vec<Value>) -> Self {
-        let port = get_free_port();
         let data_dir = TempDir::new().expect("create temp dir");
         let jwks_server = JwksServer::start_with_responses(responses).await;
-        Self::start_inner(port, data_dir, jwks_server, true, vec![]).await
+        Self::start_inner(0, data_dir, jwks_server, true, vec![]).await
     }
 
     /// Start a test server with programmable JWKS responses and custom cache timing.
@@ -129,11 +128,10 @@ impl TestServer {
         ttl_secs: u64,
         max_stale_secs: u64,
     ) -> Self {
-        let port = get_free_port();
         let data_dir = TempDir::new().expect("create temp dir");
         let jwks_server = JwksServer::start_with_responses(responses).await;
         Self::start_inner(
-            port,
+            0,
             data_dir,
             jwks_server,
             true,
@@ -168,6 +166,7 @@ impl TestServer {
         let app_id = "00000000-0000-0000-0000-000000000001";
 
         let jazz_binary = Self::find_jazz_binary();
+        let bound_port_file = data_dir.path().join("bound-port");
 
         let mut command = Command::new(&jazz_binary);
         command
@@ -184,6 +183,7 @@ impl TestServer {
                 "backend-secret-for-integration-tests",
             )
             .env("JAZZ_ADMIN_SECRET", "admin-secret-for-integration-tests")
+            .env("JAZZ_BOUND_PORT_FILE", &bound_port_file)
             .envs(extra_env)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
@@ -199,6 +199,7 @@ impl TestServer {
         let mut server = Self {
             process,
             port,
+            bound_port_file,
             data_dir,
             jwks_server,
         };
@@ -238,23 +239,64 @@ impl TestServer {
     /// Wait for the server to become ready by polling /health.
     async fn wait_ready(&mut self) {
         let client = reqwest::Client::new();
-        let url = format!("{}/health", self.base_url());
 
         for i in 0..200 {
+            self.maybe_update_bound_port();
             if let Some(status) = self.process.try_wait().expect("poll jazz-tools server") {
-                panic!("jazz-tools server exited before becoming ready: {status}");
+                panic!(
+                    "jazz-tools server exited before becoming ready: {status}{}",
+                    self.process_output_summary()
+                );
             }
-            match client.get(&url).send().await {
-                Ok(_) => return,
-                Err(e) => {
-                    if i == 199 {
-                        eprintln!("Last error: {:?}", e);
+            if self.port != 0 {
+                let url = format!("{}/health", self.base_url());
+                match client.get(&url).send().await {
+                    Ok(_) => return,
+                    Err(e) => {
+                        if i == 199 {
+                            eprintln!("Last error: {:?}", e);
+                        }
                     }
                 }
             }
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
-        panic!("Server failed to become ready within 20 seconds");
+        panic!(
+            "Server failed to become ready within 20 seconds{}",
+            self.process_output_summary()
+        );
+    }
+
+    fn maybe_update_bound_port(&mut self) {
+        let Ok(contents) = std::fs::read_to_string(&self.bound_port_file) else {
+            return;
+        };
+        let Ok(port) = contents.trim().parse::<u16>() else {
+            return;
+        };
+        self.port = port;
+    }
+
+    fn process_output_summary(&mut self) -> String {
+        let stdout = take_pipe_text(&mut self.process.stdout);
+        let stderr = take_pipe_text(&mut self.process.stderr);
+        if stdout.is_empty() && stderr.is_empty() {
+            return String::new();
+        }
+
+        format!(
+            "\nstdout:\n{}\nstderr:\n{}",
+            if stdout.is_empty() {
+                "<empty>"
+            } else {
+                stdout.trim()
+            },
+            if stderr.is_empty() {
+                "<empty>"
+            } else {
+                stderr.trim()
+            }
+        )
     }
 }
 
@@ -265,10 +307,14 @@ impl Drop for TestServer {
     }
 }
 
-/// Find an available port by binding to port 0.
-fn get_free_port() -> u16 {
-    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind to port 0");
-    listener.local_addr().unwrap().port()
+fn take_pipe_text<T: Read>(pipe: &mut Option<T>) -> String {
+    let Some(mut pipe) = pipe.take() else {
+        return String::new();
+    };
+
+    let mut bytes = Vec::new();
+    let _ = pipe.read_to_end(&mut bytes);
+    String::from_utf8_lossy(&bytes).into_owned()
 }
 
 async fn jwks_handler(State(state): State<JwksState>) -> Json<Value> {

--- a/crates/jazz-wasm/src/runtime.rs
+++ b/crates/jazz-wasm/src/runtime.rs
@@ -116,11 +116,11 @@ struct WasmLensEdgeDebug {
 /// Parse a persistence tier string from JS.
 fn parse_tier(tier: &str) -> Result<DurabilityTier, JsError> {
     match tier {
-        "worker" => Ok(DurabilityTier::Worker),
+        "local" => Ok(DurabilityTier::Local),
         "edge" => Ok(DurabilityTier::EdgeServer),
         "global" => Ok(DurabilityTier::GlobalServer),
         _ => Err(JsError::new(&format!(
-            "Invalid tier '{}'. Must be 'worker', 'edge', or 'global'.",
+            "Invalid tier '{}'. Must be 'local', 'edge', or 'global'.",
             tier
         ))),
     }
@@ -288,7 +288,7 @@ fn parse_node_durability_tiers(tier: Option<&str>) -> Result<Vec<DurabilityTier>
 
 fn tier_label_for_node_tier(tier: Option<&str>) -> &'static str {
     match tier {
-        Some("worker") => "worker",
+        Some("local") => "local",
         Some("edge") => "edge",
         Some("global") => "global",
         _ => "client",
@@ -468,7 +468,7 @@ pub struct WasmRuntime {
     /// the main thread via postMessage. Server sync goes through `connect()`.
     sync_sender: JsSyncSender,
     upstream_server_id: RefCell<Option<ServerId>>,
-    /// Label for tracing (e.g. "worker", "edge", or "client").
+    /// Label for tracing (e.g. "local", "edge", or "client").
     tier_label: &'static str,
 }
 
@@ -483,7 +483,7 @@ impl WasmRuntime {
     /// * `app_id` - Application identifier
     /// * `env` - Environment (e.g., "dev", "prod")
     /// * `user_branch` - User's branch name (e.g., "main")
-    /// * `tier` - Optional node durability tier ("worker", "edge", "global").
+    /// * `tier` - Optional node durability tier ("local", "edge", "global").
     ///            Set for server nodes to enable ack emission.
     /// * `use_binary_encoding` - Optional outgoing sync payload encoding mode.
     ///   `Some(true)` emits postcard bytes (`Uint8Array`), otherwise JSON strings.
@@ -891,7 +891,7 @@ impl WasmRuntime {
 
     /// Insert a row and return a Promise that resolves when the tier acks.
     ///
-    /// `tier` must be one of: "worker", "edge", "global".
+    /// `tier` must be one of: "local", "edge", "global".
     #[wasm_bindgen(js_name = insertDurable)]
     pub fn insert_durable(
         &self,

--- a/docs/content/docs/concepts/how-sync-works.mdx
+++ b/docs/content/docs/concepts/how-sync-works.mdx
@@ -65,13 +65,13 @@ Jazz sync runs across three tiers:
 ```mermaid
 graph TD
     G["Global\n(global core)"] --- E1["Edge\n(sync server)"] & E2["Edge\n(sync server)"]
-    E1 --- W1["Worker"] & W2["Worker"]
-    E2 --- W3["Worker"]
+    E1 --- W1["Local"] & W2["Local"]
+    E2 --- W3["Local"]
 ```
 
-**Worker** runs on the client itself, making it the first tier to respond to queries. The worker
-keeps the locally durable copy of subscribed data so it can respond immediately while updates from
-higher tiers stream in.
+**Local** is the first tier on the client itself. In browser persistent mode, a dedicated worker
+hosts that local durable copy in OPFS so it can respond immediately while updates from higher tiers
+stream in.
 
 **Edge** is the first server hop after the client. In cloud configurations it is usually a nearby
 node. Edge servers hold the data needed to serve the queries currently flowing through them.
@@ -84,7 +84,7 @@ updates eventually spread to every subscribed client.
 Writes flow **upward**:
 
 ```text
-app -> worker -> edge -> global
+app -> local -> edge -> global
 ```
 
 As a write flows through the network, each tier can confirm that it has durably received it. That
@@ -99,11 +99,11 @@ them. As a rough guide:
 
 - waiting for the global core is only necessary if you want the strongest cross-region visibility
 - waiting for edge is useful when you want to know data has left the user's device
-- the default worker tier is right for most local-first interactions
+- the default local tier is right for most local-first interactions
 
 <Callout type="info" title="Sync is automatic">
   Sync happens whenever a node is online. Writes keep propagating upward even if your promise
-  resolves at the worker tier. Reads similarly propagate downward as each tier registers the query
+  resolves at the local tier. Reads similarly propagate downward as each tier registers the query
   with the next one up. If higher tiers have newer rows, they stream down automatically.
 </Callout>
 
@@ -114,7 +114,7 @@ replicated upward, and contributes to the current visible state for that row.
 
 Because sync is local-first, different tiers can temporarily disagree:
 
-- your worker may already have a newer row version than edge
+- your local tier may already have a newer row version than edge
 - one edge may have data another edge has not fetched yet
 - another client may have its own concurrent local write
 

--- a/docs/content/docs/reading/queries.mdx
+++ b/docs/content/docs/reading/queries.mdx
@@ -71,7 +71,7 @@ For background on how data flows between tiers, see [How Sync Works](/docs/conce
 
 Pass a tier when you need the first result to be authoritative at a specific level&hairsp;—&hairsp;for example, when a user has just navigated to a page and a stale local snapshot would mislead them.
 
-- `"worker"`&hairsp;—&hairsp;Local storage only. The default on browsers and clients. Fastest, but reflects only what this device has already synced.
+- `"local"`&hairsp;—&hairsp;Local storage only. The default on browsers and clients. Fastest, but reflects only what this device has already synced.
 - `"edge"`&hairsp;—&hairsp;Wait for the nearest sync server to respond. The default on backends and servers. A good middle ground when you want confirmation that the query has fetched data from the network.
 - `"global"`&hairsp;—&hairsp;Wait for the central server. Use when you need a globally-consistent snapshot, accepting the extra round-trip latency.
 

--- a/docs/content/docs/reference/durability-tiers.mdx
+++ b/docs/content/docs/reference/durability-tiers.mdx
@@ -16,8 +16,8 @@ For background on how data flows between tiers, see [How Sync Works](/docs/conce
 
 Options:
 
-- `options.tier`: `"worker"` \| `"edge"` \| `"global"`
-- Browser/client default: `"worker"`
+- `options.tier`: `"local"` \| `"edge"` \| `"global"`
+- Browser/client default: `"local"`
 - Backend/server default: `"edge"`
 
 See [Writing Data](/docs/writing/writing-data#write-durability-tiers) for detailed guidance on which tier to use and code examples.
@@ -26,11 +26,11 @@ See [Writing Data](/docs/writing/writing-data#write-durability-tiers) for detail
 
 Read durability controls when the **first result** of a query or subscription is delivered.
 
-| Option         | Values                               | Default        | What it does                                                                                                                                                                                                                                                                     |
-| -------------- | ------------------------------------ | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `tier`         | `"worker"` \| `"edge"` \| `"global"` | Same as writes | How far the first result must come from before the query delivers.                                                                                                                                                                                                               |
-| `localUpdates` | `"immediate"` \| `"deferred"`        | `"immediate"`  | With `"immediate"`, your own local writes appear in the subscription while still waiting for the tier to confirm the initial snapshot. This only takes effect after the subscription has settled at least once. With `"deferred"`, all delivery is held until the tier confirms. |
-| `propagation`  | `"full"` \| `"local-only"`           | `"full"`       | With `"full"`, the subscription is sent to upstream servers, which push matching data back. With `"local-only"`, only local storage is queried&hairsp;—&hairsp;no server communication.                                                                                          |
+| Option         | Values                              | Default        | What it does                                                                                                                                                                                                                                                                     |
+| -------------- | ----------------------------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tier`         | `"local"` \| `"edge"` \| `"global"` | Same as writes | How far the first result must come from before the query delivers.                                                                                                                                                                                                               |
+| `localUpdates` | `"immediate"` \| `"deferred"`       | `"immediate"`  | With `"immediate"`, your own local writes appear in the subscription while still waiting for the tier to confirm the initial snapshot. This only takes effect after the subscription has settled at least once. With `"deferred"`, all delivery is held until the tier confirms. |
+| `propagation`  | `"full"` \| `"local-only"`          | `"full"`       | With `"full"`, the subscription is sent to upstream servers, which push matching data back. With `"local-only"`, only local storage is queried&hairsp;—&hairsp;no server communication.                                                                                          |
 
 These options apply to:
 

--- a/docs/content/docs/reference/internals.mdx
+++ b/docs/content/docs/reference/internals.mdx
@@ -259,7 +259,7 @@ Jazz separates two durability questions:
 | `QuerySettled`          | First read delivery      | "Has the query result settled at tier T?"  |
 | Write tier confirmation | Durable write completion | "Has this write been confirmed at tier T?" |
 
-Both use the same tier lattice (`worker` < `edge` < `global`), but they answer different
+Both use the same tier lattice (`local` < `edge` < `global`), but they answer different
 questions. A query's first callback is held until `QuerySettled` reaches the requested tier. A
 durable write promise resolves when the requested tier confirms the write.
 

--- a/docs/content/docs/writing/writing-data.mdx
+++ b/docs/content/docs/writing/writing-data.mdx
@@ -93,11 +93,11 @@ Required fields cannot be set to `null`.
 
 ## Write durability tiers
 
-When using `insertDurable`, `updateDurable`, or `deleteDurable`, you can pass a tier option to control how far the mutation must propagate before the promise resolves: locally on the client (`worker`), the nearest edge server (`edge`), or the global core (`global`). If omitted, the tier defaults based on environment (see table).
+When using `insertDurable`, `updateDurable`, or `deleteDurable`, you can pass a tier option to control how far the mutation must propagate before the promise resolves: locally on the client (`local`), the nearest edge server (`edge`), or the global core (`global`). If omitted, the tier defaults based on environment (see table).
 
 | Tier     | Resolves when                       | Default for    |
 | -------- | ----------------------------------- | -------------- |
-| `worker` | Persisted to local OPFS             | Browser/client |
+| `local`  | Persisted to local OPFS             | Browser/client |
 | `edge`   | Acknowledged by nearest sync server | Backend/server |
 | `global` | Propagated to global core           | —              |
 

--- a/docs/content/partials/durability-tiers-table.mdx
+++ b/docs/content/partials/durability-tiers-table.mdx
@@ -2,6 +2,6 @@ Jazz data propagates through tiers, from fast local confirmation to broader reac
 
 | Tier       | Where               | When to use                                                  |
 | ---------- | ------------------- | ------------------------------------------------------------ |
-| `"worker"` | On the device       | Default. Instant writes, no network needed.                  |
+| `"local"`  | On the device       | Default. Instant writes, no network needed.                  |
 | `"edge"`   | Nearest sync server | Confirm data has left the device before continuing.          |
 | `"global"` | Central server      | Ensure all clients can see the data, regardless of location. |

--- a/examples/docs/todo-client-localfirst-expo/src/docs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-expo/src/docs-snippets.ts
@@ -107,10 +107,10 @@ export async function writeWithDurabilityTier(db: Db, todoTitle: string) {
       owner_id: EXAMPLE_OWNER_ID,
       projectId: EXAMPLE_PROJECT_ID,
     },
-    { tier: "worker" },
+    { tier: "local" },
   );
 
-  await db.updateDurable(app.todos, id, { done: true }, { tier: "worker" });
-  await db.deleteDurable(app.todos, id, { tier: "worker" });
+  await db.updateDurable(app.todos, id, { done: true }, { tier: "local" });
+  await db.deleteDurable(app.todos, id, { tier: "local" });
 }
 // #endregion writing-durability-expo

--- a/examples/moon-lander-react/src/jazz/SyncManager.ts
+++ b/examples/moon-lander-react/src/jazz/SyncManager.ts
@@ -8,7 +8,7 @@
  *
  * The "edge" tier broadcasts the write to all connected clients' live
  * subscriptions, triggering WHERE ENTRY / WHERE EXIT events remotely.
- * The default "worker" tier only updates the local OPFS database.
+ * The default "local" tier only updates the local OPFS database.
  *
  * Writes are fired immediately when game callbacks are invoked — no batching
  * interval. releasingIds guards against double-releasing the same deposit

--- a/examples/moon-lander-react/walkthrough/jazz-moon-lander.md
+++ b/examples/moon-lander-react/walkthrough/jazz-moon-lander.md
@@ -224,12 +224,12 @@ The tier on a write controls where the promise resolves. All writes eventually p
   <line x1="390" y1="48" x2="390" y2="233" stroke="#e0e0f0" stroke-width="1" stroke-dasharray="4,3"/>
   <line x1="555" y1="48" x2="555" y2="233" stroke="#e0e0f0" stroke-width="1" stroke-dasharray="4,3"/>
 
-  <!-- write "worker": Client -> OPFS Worker -->
+  <!-- write "local": Client -> OPFS Worker -->
   <line x1="79" y1="90" x2="226" y2="90" stroke="rgba(20,106,255,0.45)" stroke-width="1.5" marker-end="url(#aw)"/>
   <circle cx="230" cy="90" r="5" fill="rgba(20,106,255,0.45)" stroke="#fff" stroke-width="1.5"/>
   <line x1="235" y1="90" x2="386" y2="90" stroke="#e0e0f0" stroke-width="1" stroke-dasharray="4,3"/>
   <line x1="394" y1="90" x2="551" y2="90" stroke="#e0e0f0" stroke-width="1" stroke-dasharray="4,3"/>
-  <text x="152" y="82" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="10.5" fill="rgba(20,106,255,0.6)">db.insert({tier:"worker"})</text>
+  <text x="152" y="82" text-anchor="middle" font-family="JetBrains Mono,monospace" font-size="10.5" fill="rgba(20,106,255,0.6)">db.insert({tier:"local"})</text>
 
   <!-- write "edge": Client -> Edge Node -->
   <line x1="79" y1="135" x2="386" y2="135" stroke="rgba(20,106,255,0.7)" stroke-width="1.5" marker-end="url(#ae)"/>

--- a/examples/wequencer/src/Nav.svelte
+++ b/examples/wequencer/src/Nav.svelte
@@ -66,7 +66,7 @@
 		const epochMs = Math.floor(date.getTime() / 60_000) * 60_000;
 		const floored = new Date(epochMs);
 
-		const results = await db.all(app.jams.where({ created_at: floored }).limit(1), 'worker');
+		const results = await db.all(app.jams.where({ created_at: floored }).limit(1), 'local');
 		if (results.length > 0) {
 			setHashJamId(results[0].id);
 			historyOpen = false;

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
@@ -271,7 +271,7 @@ describe("TableDataGrid", () => {
         done: true,
         owner_id: "owner-c",
       }),
-      { tier: "worker" },
+      { tier: "local" },
     );
   });
 
@@ -319,7 +319,7 @@ describe("TableDataGrid", () => {
           meta: { done: true },
           owner_id: "owner-a",
         }),
-        { tier: "worker" },
+        { tier: "local" },
       );
     });
   });
@@ -364,7 +364,7 @@ describe("TableDataGrid", () => {
         expect.objectContaining({
           title: "zeta queued",
         }),
-        { tier: "worker" },
+        { tier: "local" },
       );
     });
 
@@ -392,7 +392,7 @@ describe("TableDataGrid", () => {
         expect.objectContaining({
           done: true,
         }),
-        { tier: "worker" },
+        { tier: "local" },
       );
     });
   });
@@ -554,7 +554,7 @@ describe("TableDataGrid", () => {
         done: true,
         meta: null,
       }),
-      { tier: "worker" },
+      { tier: "local" },
     );
   });
 
@@ -586,7 +586,7 @@ describe("TableDataGrid", () => {
       expect(mockDeleteDurable).toHaveBeenCalledWith(
         expect.objectContaining({ _table: "todos" }),
         "row-2",
-        { tier: "worker" },
+        { tier: "local" },
       );
     });
   });

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
@@ -596,7 +596,7 @@ export function TableDataGrid() {
     return builder.orderBy(sortColumn, sortDirection).limit(queryLimit).offset(queryOffset);
   }, [table, schema, filters, sortColumn, sortDirection, queryLimit, queryOffset]);
   const builtQuery = useMemo(() => queryBuilder._build(), [queryBuilder]);
-  const mutationDurabilityTier = runtime === "standalone" ? "edge" : "worker";
+  const mutationDurabilityTier = runtime === "standalone" ? "edge" : "local";
   const queryOptions = useMemo(
     () =>
       ({

--- a/packages/inspector/src/pages/live-query/LiveQueryFilters.test.tsx
+++ b/packages/inspector/src/pages/live-query/LiveQueryFilters.test.tsx
@@ -22,7 +22,7 @@ describe("LiveQueryFilters", () => {
     expect(screen.getByRole("option", { name: "projects" })).not.toBeNull();
     expect(screen.getByRole("option", { name: "todos" })).not.toBeNull();
     expect(screen.getByRole("option", { name: "All tiers" })).not.toBeNull();
-    expect(screen.getByRole("option", { name: "worker" })).not.toBeNull();
+    expect(screen.getByRole("option", { name: "local" })).not.toBeNull();
     expect(screen.getByRole("option", { name: "edge" })).not.toBeNull();
     expect(screen.getByRole("option", { name: "global" })).not.toBeNull();
   });

--- a/packages/inspector/src/pages/live-query/LiveQueryFilters.tsx
+++ b/packages/inspector/src/pages/live-query/LiveQueryFilters.tsx
@@ -11,7 +11,7 @@ interface LiveQueryFiltersProps {
 
 const TIER_OPTIONS = [
   { value: "", label: "All tiers" },
-  { value: "worker", label: "worker" },
+  { value: "local", label: "local" },
   { value: "edge", label: "edge" },
   { value: "global", label: "global" },
 ] as const;

--- a/packages/inspector/src/pages/live-query/index.test.tsx
+++ b/packages/inspector/src/pages/live-query/index.test.tsx
@@ -73,7 +73,7 @@ describe("LiveQuery", () => {
       {
         id: "sub-1",
         table: "todos",
-        tier: "worker",
+        tier: "local",
         propagation: "full",
         branches: ["main"],
         createdAt: "2026-03-10T10:00:00.000Z",
@@ -105,7 +105,7 @@ describe("LiveQuery", () => {
       {
         id: "sub-1",
         table: "todos",
-        tier: "worker",
+        tier: "local",
         propagation: "full",
         branches: ["main"],
         createdAt: "2026-03-10T10:00:00.000Z",
@@ -138,7 +138,7 @@ describe("LiveQuery", () => {
     expect(screen.getByRole("cell", { name: "projects" })).not.toBeNull();
 
     fireEvent.change(screen.getByLabelText("Filter by tier"), {
-      target: { value: "worker" },
+      target: { value: "local" },
     });
 
     expect(screen.getByText("No active subscriptions")).not.toBeNull();
@@ -169,7 +169,7 @@ describe("LiveQuery", () => {
       {
         id: "sub-3",
         table: "users",
-        tier: "worker",
+        tier: "local",
         propagation: "full",
         branches: ["main"],
         createdAt: "2026-03-10T11:00:00.000Z",

--- a/packages/inspector/src/pages/live-query/index.tsx
+++ b/packages/inspector/src/pages/live-query/index.tsx
@@ -103,7 +103,7 @@ function formatTime(value: string | number): string {
 
 function tierRank(tier: DurabilityTier): number {
   switch (tier) {
-    case "worker":
+    case "local":
       return 0;
     case "edge":
       return 1;

--- a/packages/jazz-tools/CHANGELOG.md
+++ b/packages/jazz-tools/CHANGELOG.md
@@ -120,7 +120,7 @@
 
 ### Patch Changes
 
-- 30df2b4: Fix browser worker reconnect after network loss when offline `worker`-tier writes were queued locally.
+- 30df2b4: Fix browser worker reconnect after network loss when offline `local`-tier writes were queued locally.
 
   The worker now aborts its stale upstream events stream before scheduling reconnect after sync POST failures, which lets later writes promote normally once network access returns. This also adds browser regression coverage for the split-context reconnect case where one client stays online while another writes offline and reconnects.
   - jazz-wasm@2.0.0-alpha.25

--- a/packages/jazz-tools/bin/docs-index.txt
+++ b/packages/jazz-tools/bin/docs-index.txt
@@ -1082,13 +1082,13 @@ Jazz sync runs across three tiers:
 ```mermaid
 graph TD
     G["Global\n(global core)"] --- E1["Edge\n(sync server)"] & E2["Edge\n(sync server)"]
-    E1 --- W1["Worker"] & W2["Worker"]
-    E2 --- W3["Worker"]
+    E1 --- W1["Local"] & W2["Local"]
+    E2 --- W3["Local"]
 ```
 
-**Worker** runs on the client itself, making it the first tier to respond to queries. The worker
-keeps the locally durable copy of subscribed data so it can respond immediately while updates from
-higher tiers stream in.
+**Local** is the first tier on the client itself. In browser persistent mode, a dedicated worker
+hosts that local durable copy in OPFS so it can respond immediately while updates from higher tiers
+stream in.
 
 **Edge** is the first server hop after the client. In cloud configurations it is usually a nearby
 node. Edge servers hold the data needed to serve the queries currently flowing through them.
@@ -1101,7 +1101,7 @@ updates eventually spread to every subscribed client.
 Writes flow **upward**:
 
 ```text
-app -> worker -> edge -> global
+app -> local -> edge -> global
 ```
 
 As a write flows through the network, each tier can confirm that it has durably received it. That
@@ -1116,10 +1116,10 @@ them. As a rough guide:
 
 - waiting for the global core is only necessary if you want the strongest cross-region visibility
 - waiting for edge is useful when you want to know data has left the user's device
-- the default worker tier is right for most local-first interactions
+- the default local tier is right for most local-first interactions
 
   Sync happens whenever a node is online. Writes keep propagating upward even if your promise
-  resolves at the worker tier. Reads similarly propagate downward as each tier registers the query
+  resolves at the local tier. Reads similarly propagate downward as each tier registers the query
   with the next one up. If higher tiers have newer rows, they stream down automatically.
 
 ## Consistency model
@@ -1129,7 +1129,7 @@ replicated upward, and contributes to the current visible state for that row.
 
 Because sync is local-first, different tiers can temporarily disagree:
 
-- your worker may already have a newer row version than edge
+- your local tier may already have a newer row version than edge
 - one edge may have data another edge has not fetched yet
 - another client may have its own concurrent local write
 
@@ -2797,7 +2797,7 @@ For background on how data flows between tiers, see [How Sync Works](/docs/conce
 
 Pass a tier when you need the first result to be authoritative at a specific level&hairsp;—&hairsp;for example, when a user has just navigated to a page and a stale local snapshot would mislead them.
 
-- `"worker"`&hairsp;—&hairsp;Local storage only. The default on browsers and clients. Fastest, but reflects only what this device has already synced.
+- `"local"`&hairsp;—&hairsp;Local storage only. The default on browsers and clients. Fastest, but reflects only what this device has already synced.
 - `"edge"`&hairsp;—&hairsp;Wait for the nearest sync server to respond. The default on backends and servers. A good middle ground when you want confirmation that the query has fetched data from the network.
 - `"global"`&hairsp;—&hairsp;Wait for the central server. Use when you need a globally-consistent snapshot, accepting the extra round-trip latency.
 
@@ -3722,8 +3722,8 @@ For background on how data flows between tiers, see [How Sync Works](/docs/conce
 
 Options:
 
-- `options.tier`: `"worker"` \| `"edge"` \| `"global"`
-- Browser/client default: `"worker"`
+- `options.tier`: `"local"` \| `"edge"` \| `"global"`
+- Browser/client default: `"local"`
 - Backend/server default: `"edge"`
 
 See [Writing Data](/docs/writing/writing-data#write-durability-tiers) for detailed guidance on which tier to use and code examples.
@@ -3734,7 +3734,7 @@ Read durability controls when the **first result** of a query or subscription is
 
 | Option         | Values                               | Default        | What it does                                                                                                                                                                                                                                                                     |
 | -------------- | ------------------------------------ | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `tier`         | `"worker"` \| `"edge"` \| `"global"` | Same as writes | How far the first result must come from before the query delivers.                                                                                                                                                                                                               |
+| `tier`         | `"local"` \| `"edge"` \| `"global"` | Same as writes | How far the first result must come from before the query delivers.                                                                                                                                                                                                               |
 | `localUpdates` | `"immediate"` \| `"deferred"`        | `"immediate"`  | With `"immediate"`, your own local writes appear in the subscription while still waiting for the tier to confirm the initial snapshot. This only takes effect after the subscription has settled at least once. With `"deferred"`, all delivery is held until the tier confirms. |
 | `propagation`  | `"full"` \| `"local-only"`           | `"full"`       | With `"full"`, the subscription is sent to upstream servers, which push matching data back. With `"local-only"`, only local storage is queried&hairsp;—&hairsp;no server communication.                                                                                          |
 
@@ -4285,7 +4285,7 @@ Jazz separates two durability questions:
 | `QuerySettled`          | First read delivery      | "Has the query result settled at tier T?"  |
 | Write tier confirmation | Durable write completion | "Has this write been confirmed at tier T?" |
 
-Both use the same tier lattice (`worker` < `edge` < `global`), but they answer different
+Both use the same tier lattice (`local` < `edge` < `global`), but they answer different
 questions. A query's first callback is held until `QuerySettled` reaches the requested tier. A
 durable write promise resolves when the requested tier confirms the write.
 
@@ -5347,11 +5347,11 @@ pub async fn clear_nullable_fields(
 
 ## Write durability tiers
 
-When using `insertDurable`, `updateDurable`, or `deleteDurable`, you can pass a tier option to control how far the mutation must propagate before the promise resolves: locally on the client (`worker`), the nearest edge server (`edge`), or the global core (`global`). If omitted, the tier defaults based on environment (see table).
+When using `insertDurable`, `updateDurable`, or `deleteDurable`, you can pass a tier option to control how far the mutation must propagate before the promise resolves: locally on the client (`local`), the nearest edge server (`edge`), or the global core (`global`). If omitted, the tier defaults based on environment (see table).
 
 | Tier     | Resolves when                       | Default for    |
 | -------- | ----------------------------------- | -------------- |
-| `worker` | Persisted to local OPFS             | Browser/client |
+| `local` | Persisted to local OPFS             | Browser/client |
 | `edge`   | Acknowledged by nearest sync server | Backend/server |
 | `global` | Propagated to global core           | —              |
 

--- a/packages/jazz-tools/src/backend/create-jazz-context.ts
+++ b/packages/jazz-tools/src/backend/create-jazz-context.ts
@@ -44,7 +44,7 @@ export type BackendContextConfig = Omit<AppContext, "schema" | "driver" | "clien
   /** Server runtime driver mode and storage location. */
   driver: BackendDriver;
   /** Optional node durability tier identity. */
-  tier?: "worker" | "edge" | "global";
+  tier?: "local" | "edge" | "global";
   /** JWKS endpoint used to verify external bearer JWTs in `forRequest()`. */
   jwksUrl?: string;
   /** Whether local-first bearer JWTs are accepted in `forRequest()`. Defaults to `true`. */

--- a/packages/jazz-tools/src/dev-tools/dev-tools.test.ts
+++ b/packages/jazz-tools/src/dev-tools/dev-tools.test.ts
@@ -124,7 +124,7 @@ describe("attachDevTools active query subscription bridge", () => {
         query: '{"table":"todos"}',
         table: "todos",
         branches: ["main"],
-        tier: "worker",
+        tier: "local",
         propagation: "full",
         createdAt: "2026-03-10T10:00:00.000Z",
         stack: "Error\n  at demo",
@@ -237,7 +237,7 @@ describe("attachDevTools mutation bridge", () => {
       payload: {
         table: "todos",
         values: { title: { type: "Text", value: "hello" } },
-        tier: "worker",
+        tier: "local",
       },
     });
 
@@ -247,7 +247,7 @@ describe("attachDevTools mutation bridge", () => {
     expect(createDurable).toHaveBeenCalledWith(
       "todos",
       { title: { type: "Text", value: "hello" } },
-      { tier: "worker" },
+      { tier: "local" },
     );
   });
 

--- a/packages/jazz-tools/src/react-native/db.test.ts
+++ b/packages/jazz-tools/src/react-native/db.test.ts
@@ -98,7 +98,7 @@ describe("react-native Db", () => {
       userBranch: "user-branch",
       jwtToken: "jwt-token",
       adminSecret: "admin-secret",
-      tier: "worker",
+      tier: "local",
       dataPath: "/tmp/rn-data",
     };
 

--- a/packages/jazz-tools/src/react-native/db.ts
+++ b/packages/jazz-tools/src/react-native/db.ts
@@ -21,7 +21,7 @@ export class Db extends RuntimeDb {
     const key = JSON.stringify(schema);
 
     if (!this.nativeClients.has(key)) {
-      const tier = this.nativeConfig.tier ?? "worker";
+      const tier = this.nativeConfig.tier ?? "local";
       const runtime = createJazzRnRuntime({
         schema,
         appId: this.nativeConfig.appId,
@@ -43,7 +43,7 @@ export class Db extends RuntimeDb {
           jwtToken: this.nativeConfig.jwtToken,
           adminSecret: this.nativeConfig.adminSecret,
           tier,
-          defaultDurabilityTier: "worker",
+          defaultDurabilityTier: "local",
         },
         {
           onAuthFailure: (reason) => {

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.test.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.test.ts
@@ -184,16 +184,16 @@ describe("JazzRnRuntimeAdapter", () => {
     expect(binding.deleteWithSession).toHaveBeenCalledWith("row-1", writeContextJson);
 
     await expect(
-      adapter.insertDurableWithSession("todos", {}, writeContextJson, "worker"),
+      adapter.insertDurableWithSession("todos", {}, writeContextJson, "local"),
     ).resolves.toEqual({
       id: "row-1",
       values: [],
     });
     await expect(
-      adapter.updateDurableWithSession("row-1", {}, writeContextJson, "worker"),
+      adapter.updateDurableWithSession("row-1", {}, writeContextJson, "local"),
     ).resolves.toBeUndefined();
     await expect(
-      adapter.deleteDurableWithSession("row-1", writeContextJson, "worker"),
+      adapter.deleteDurableWithSession("row-1", writeContextJson, "local"),
     ).resolves.toBeUndefined();
     expect(binding.flush).toHaveBeenCalledTimes(3);
   });
@@ -297,21 +297,21 @@ describe("JazzRnRuntimeAdapter", () => {
     });
   });
 
-  it("supports worker-tier persisted mutations and rejects global tiers", async () => {
+  it("supports local-tier persisted mutations and rejects global tiers", async () => {
     const binding = createBinding();
     const adapter = new JazzRnRuntimeAdapter(binding, {});
 
-    await expect(adapter.insertDurable("todos", {}, "worker")).resolves.toEqual({
+    await expect(adapter.insertDurable("todos", {}, "local")).resolves.toEqual({
       id: "row-1",
       values: [],
     });
     expect(binding.flush).toHaveBeenCalledTimes(1);
 
-    await expect(adapter.updateDurable("row-1", {}, "worker")).resolves.toBeUndefined();
-    await expect(adapter.deleteDurable("row-1", "worker")).resolves.toBeUndefined();
+    await expect(adapter.updateDurable("row-1", {}, "local")).resolves.toBeUndefined();
+    await expect(adapter.deleteDurable("row-1", "local")).resolves.toBeUndefined();
     expect(binding.flush).toHaveBeenCalledTimes(3);
 
-    expect(() => adapter.insertDurable("todos", {}, "edge")).toThrow("supports only 'worker' tier");
+    expect(() => adapter.insertDurable("todos", {}, "edge")).toThrow("supports only 'local' tier");
   });
 
   it("swallows ObjectNotFound runtime errors for update/delete", () => {

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
@@ -70,9 +70,9 @@ export interface JazzRnRuntimeBinding {
 }
 
 function assertWorkerTier(tier: string): void {
-  if (tier !== "worker") {
+  if (tier !== "local") {
     throw new Error(
-      `jazz-rn runtime adapter currently supports only 'worker' tier for persisted mutations (received '${tier}')`,
+      `jazz-rn runtime adapter currently supports only 'local' tier for persisted mutations (received '${tier}')`,
     );
   }
 }

--- a/packages/jazz-tools/src/runtime/client.for-request.test.ts
+++ b/packages/jazz-tools/src/runtime/client.for-request.test.ts
@@ -107,7 +107,7 @@ function makeClient() {
     new (
       runtime: Runtime,
       context: AppContext,
-      defaultDurabilityTier: "worker" | "edge" | "global",
+      defaultDurabilityTier: "local" | "edge" | "global",
     ): JazzClient;
   };
   return {
@@ -149,7 +149,7 @@ function makeClientWithContext(context: AppContext): JazzClient {
     new (
       runtime: Runtime,
       context: AppContext,
-      defaultDurabilityTier: "worker" | "edge" | "global",
+      defaultDurabilityTier: "local" | "edge" | "global",
     ): JazzClient;
   };
   return new JazzClientCtor(runtime, context, "edge");

--- a/packages/jazz-tools/src/runtime/client.mutations.test.ts
+++ b/packages/jazz-tools/src/runtime/client.mutations.test.ts
@@ -105,7 +105,7 @@ function makeClient(runtimeOverrides: Partial<Runtime> = {}) {
     new (
       runtime: Runtime,
       context: AppContext,
-      defaultDurabilityTier: "worker" | "edge" | "global",
+      defaultDurabilityTier: "local" | "edge" | "global",
     ): JazzClient;
   };
 

--- a/packages/jazz-tools/src/runtime/client.test.ts
+++ b/packages/jazz-tools/src/runtime/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { JazzClient } from "./client.js";
+import { JazzClient, resolveDefaultDurabilityTier } from "./client.js";
 import type { AppContext } from "./context.js";
 
 function makeFakeRuntime() {
@@ -146,5 +146,15 @@ describe("JazzClient.updateCookieSession", () => {
     expect(runtime.updateAuth).toHaveBeenCalledTimes(1);
     const arg = runtime.updateAuth.mock.calls[0][0] as string;
     expect(JSON.parse(arg)).toMatchObject({ jwt_token: null });
+  });
+});
+
+describe("resolveDefaultDurabilityTier", () => {
+  it("uses local as the default offline durability tier", () => {
+    expect(resolveDefaultDurabilityTier({})).toBe("local");
+  });
+
+  it("still prefers edge when a server is configured outside the browser runtime", () => {
+    expect(resolveDefaultDurabilityTier({ serverUrl: "https://example.test" })).toBe("edge");
   });
 });

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -169,11 +169,11 @@ export interface AuthConfig {
 /**
  * Persistence tier for durability guarantees.
  *
- * - `worker`: Persisted in web worker / local storage
+ * - `local`: Persisted in local durable storage
  * - `edge`: Persisted at edge server
  * - `global`: Persisted at global server
  */
-export type DurabilityTier = "worker" | "edge" | "global";
+export type DurabilityTier = "local" | "edge" | "global";
 export type LocalUpdatesMode = "immediate" | "deferred";
 export type QueryPropagation = "full" | "local-only";
 export type QueryVisibility = "public" | "hidden_from_live_query_list";
@@ -319,12 +319,12 @@ export function resolveDefaultDurabilityTier(
   }
 
   if (isBrowserRuntime()) {
-    return "worker";
+    return "local";
   }
 
   // In non-browser environments, default to edge when connected to a server.
-  // For local/in-memory runtimes without a server, keep worker semantics.
-  return context.serverUrl ? "edge" : "worker";
+  // For local/in-memory runtimes without a server, keep local semantics.
+  return context.serverUrl ? "edge" : "local";
 }
 
 export function resolveEffectiveQueryExecutionOptions(
@@ -679,7 +679,7 @@ function normalizeUpdatedAt(updatedAt?: number): number | undefined {
 
 function durabilityTierRank(tier: DurabilityTier): number {
   switch (tier) {
-    case "worker":
+    case "local":
       return 0;
     case "edge":
       return 1;

--- a/packages/jazz-tools/src/runtime/context.ts
+++ b/packages/jazz-tools/src/runtime/context.ts
@@ -103,10 +103,10 @@ export interface AppContext {
    * Set for server nodes to enable durability notifications.
    * Clients typically leave this undefined.
    */
-  tier?: "worker" | "edge" | "global" | Array<"worker" | "edge" | "global">;
+  tier?: "local" | "edge" | "global" | Array<"local" | "edge" | "global">;
 
   /**
    * Default durability tier for reads and writes when no explicit tier is provided.
    */
-  defaultDurabilityTier?: "worker" | "edge" | "global";
+  defaultDurabilityTier?: "local" | "edge" | "global";
 }

--- a/packages/jazz-tools/src/runtime/db.dev-mode.test.ts
+++ b/packages/jazz-tools/src/runtime/db.dev-mode.test.ts
@@ -67,7 +67,7 @@ describe("Db devMode active query tracing", () => {
 
     expect(trace?.table).toBe("todos");
     expect(trace?.branches).toEqual(["feature-branch"]);
-    expect(trace?.tier).toBe("worker");
+    expect(trace?.tier).toBe("local");
     expect(trace?.propagation).toBe("full");
     expect(trace?.query).toContain('"table":"todos"');
     expect(trace?.stack).toContain("Error");

--- a/packages/jazz-tools/src/runtime/db.persisted.test.ts
+++ b/packages/jazz-tools/src/runtime/db.persisted.test.ts
@@ -183,7 +183,7 @@ describe("Db persisted writes", () => {
       { tier: "global" },
     );
     const updated = db.updatePersisted(table, "todo-2", { done: false }, { tier: "edge" });
-    const deleted = db.deletePersisted(table, "todo-2", { tier: "worker" });
+    const deleted = db.deletePersisted(table, "todo-2", { tier: "local" });
 
     expect(createPersistedInternal).toHaveBeenCalledWith(
       "todos",
@@ -210,7 +210,7 @@ describe("Db persisted writes", () => {
       "todo-2",
       session,
       "alice@writer",
-      { tier: "worker" },
+      { tier: "local" },
       undefined,
     );
     expect(inserted.value()).toEqual({

--- a/packages/jazz-tools/src/runtime/db.transaction.test.ts
+++ b/packages/jazz-tools/src/runtime/db.transaction.test.ts
@@ -118,7 +118,7 @@ describe("Db transactions", () => {
       { tier: "global" },
     );
     const updated = tx.updatePersisted(table, "todo-1", { done: true }, { tier: "edge" });
-    const deleted = tx.deletePersisted(table, "todo-1", { tier: "worker" });
+    const deleted = tx.deletePersisted(table, "todo-1", { tier: "local" });
 
     expect(beginTransactionInternal).toHaveBeenCalledWith();
     expect(tx.batchId()).toBe("batch-tx");
@@ -150,7 +150,7 @@ describe("Db transactions", () => {
       },
       { tier: "edge" },
     );
-    expect(runtimeTransaction.deletePersisted).toHaveBeenCalledWith("todo-1", { tier: "worker" });
+    expect(runtimeTransaction.deletePersisted).toHaveBeenCalledWith("todo-1", { tier: "local" });
     expect(persisted.value()).toEqual({
       id: "todo-1",
       title: "Transactional",
@@ -359,7 +359,7 @@ describe("Db transactions", () => {
       { tier: "global" },
     );
     const updated = batch.updatePersisted(table, "todo-direct-1", { done: true }, { tier: "edge" });
-    const deleted = batch.deletePersisted(table, "todo-direct-1", { tier: "worker" });
+    const deleted = batch.deletePersisted(table, "todo-direct-1", { tier: "local" });
 
     expect(beginDirectBatchInternal).toHaveBeenCalledWith();
     expect(batch.batchId()).toBe("batch-direct");
@@ -391,7 +391,7 @@ describe("Db transactions", () => {
       },
       { tier: "edge" },
     );
-    expect(runtimeBatch.deletePersisted).toHaveBeenCalledWith("todo-direct-1", { tier: "worker" });
+    expect(runtimeBatch.deletePersisted).toHaveBeenCalledWith("todo-direct-1", { tier: "local" });
     expect(persisted.value()).toEqual({
       id: "todo-direct-1",
       title: "Direct batch",

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -1076,8 +1076,8 @@ export class Db {
           jwtToken: this.config.jwtToken,
           cookieSession: this.config.cookieSession,
           adminSecret: this.config.adminSecret,
-          tier: this.worker ? undefined : "worker",
-          // Keep worker-bridged browser clients on worker durability by default.
+          tier: this.worker ? undefined : "local",
+          // Keep worker-bridged browser clients on local durability by default.
           // For direct (non-worker) clients connected to a server, default to edge.
           defaultDurabilityTier: this.worker
             ? undefined
@@ -1135,7 +1135,7 @@ export class Db {
     if (!this.workerBridge || !this.config.serverUrl) {
       return;
     }
-    if (!options?.tier || options.tier === "worker") {
+    if (!options?.tier || options.tier === "local") {
       return;
     }
     await this.workerBridge.waitForUpstreamServerConnection();

--- a/packages/jazz-tools/src/runtime/file-storage.test.ts
+++ b/packages/jazz-tools/src/runtime/file-storage.test.ts
@@ -84,7 +84,7 @@ class FakeDb implements FileStorageDb {
   async insertDurable<T, Init>(
     table: TableProxy<T, Init>,
     data: Init,
-    options: { tier: "worker" | "edge" | "global" },
+    options: { tier: "local" | "edge" | "global" },
   ): Promise<T> {
     return this.store(table, data, true, options.tier) as T;
   }
@@ -289,7 +289,7 @@ describe("createFileStorage", () => {
     const storage = createConventionalFileStorage(db, app);
     await expect(
       storage.toBlob("file-1", {
-        tier: "worker",
+        tier: "local",
         propagation: "local-only",
       }),
     ).rejects.toMatchObject({

--- a/packages/jazz-tools/src/runtime/napi.for-request.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.for-request.test.ts
@@ -97,7 +97,7 @@ async function createTestContext(
     adminSecret,
     env: "test",
     userBranch: "main",
-    tier: "worker",
+    tier: "local",
   });
 
   onTestFinished(async () => {

--- a/packages/jazz-tools/src/runtime/napi.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.integration.test.ts
@@ -268,7 +268,7 @@ async function waitForQueryRows<T>(
   query: QueryBuilder<T>,
   predicate: (rows: T[]) => boolean,
   timeoutMs = 20_000,
-  queryOptions: { tier?: "worker" | "edge" | "global" } = { tier: "edge" },
+  queryOptions: { tier?: "local" | "edge" | "global" } = { tier: "edge" },
 ): Promise<T[]> {
   const deadline = Date.now() + timeoutMs;
   let lastRows: T[] = [];
@@ -711,7 +711,7 @@ describe("NAPI integration", () => {
           title: "persisted-local-item",
           done: false,
         },
-        { tier: "worker" },
+        { tier: "local" },
       );
       const rowId = createdRow.id;
 
@@ -720,7 +720,7 @@ describe("NAPI integration", () => {
         allTodosQuery,
         (rows) => rows.some((row) => row.id === rowId),
         10_000,
-        { tier: "worker" },
+        { tier: "local" },
       );
 
       await writerContext.shutdown();
@@ -740,7 +740,7 @@ describe("NAPI integration", () => {
         allTodosQuery,
         (rows) => rows.some((row) => row.id === rowId),
         10_000,
-        { tier: "worker" },
+        { tier: "local" },
       );
 
       const reopenedRow = reopenedRows.find((row) => row.id === rowId);
@@ -787,7 +787,7 @@ describe("NAPI integration", () => {
             created_at: new Date(timestamp),
             updated_at: new Date(timestamp),
           },
-          { tier: "worker" },
+          { tier: "local" },
         ),
       ).resolves.toEqual({
         id: expect.any(String),
@@ -829,7 +829,7 @@ describe("NAPI integration", () => {
       expect(Array.from(created.data)).toEqual([1, 2, 3]);
 
       const reloaded = await context.db().one(byteChunksTable.where({ id: created.id }), {
-        tier: "worker",
+        tier: "local",
       });
 
       expect(reloaded).not.toBeNull();
@@ -891,7 +891,7 @@ describe("NAPI integration", () => {
       });
 
       const reloaded = await context.db().one(byteChunksTable.where({ id: created.id }), {
-        tier: "worker",
+        tier: "local",
       });
 
       expect(reloaded).not.toBeNull();
@@ -933,7 +933,7 @@ describe("NAPI integration", () => {
       );
 
       const part = await context.db().one(filePartsTable.where({ id: file.partIds[0] }), {
-        tier: "worker",
+        tier: "local",
       });
 
       expect(part).not.toBeNull();

--- a/packages/jazz-tools/src/vue/use-all.test.ts
+++ b/packages/jazz-tools/src/vue/use-all.test.ts
@@ -64,7 +64,7 @@ describe("vue/useAll", () => {
   it("VU-ALL-03: forwards full QueryOptions to makeQueryKey", () => {
     const query = makeQuery();
     const options = {
-      tier: "worker" as const,
+      tier: "local" as const,
       localUpdates: "deferred" as const,
       propagation: "local-only" as const,
     };
@@ -76,7 +76,7 @@ describe("vue/useAll", () => {
 
   it("VU-ALL-04: reactive options trigger re-subscription on change", async () => {
     const query = makeQuery();
-    const options = ref<any>({ tier: "worker" });
+    const options = ref<any>({ tier: "local" });
 
     mocks.makeQueryKey.mockReturnValueOnce("key-worker").mockReturnValueOnce("key-edge");
     mocks.getCacheEntry.mockReturnValue({
@@ -87,7 +87,7 @@ describe("vue/useAll", () => {
     const scope = effectScope();
     scope.run(() => useAll(query, options));
 
-    expect(mocks.makeQueryKey).toHaveBeenCalledWith(query, { tier: "worker" });
+    expect(mocks.makeQueryKey).toHaveBeenCalledWith(query, { tier: "local" });
     expect(mocks.subscribe).toHaveBeenCalledTimes(1);
 
     options.value = { tier: "edge" };

--- a/packages/jazz-tools/src/worker/jazz-worker.ts
+++ b/packages/jazz-tools/src/worker/jazz-worker.ts
@@ -294,14 +294,14 @@ async function handleInit(msg: InitMessage): Promise<void> {
     peerIdByRuntimeClient.clear();
     peerTermByPeerId.clear();
 
-    // Open persistent OPFS-backed runtime with Worker tier
+    // Open persistent OPFS-backed runtime with local durability tier
     runtime = await wasmModule.WasmRuntime.openPersistent(
       schemaJson,
       msg.appId,
       msg.env,
       msg.userBranch,
       msg.dbName,
-      "worker",
+      "local",
       false,
     );
 

--- a/packages/jazz-tools/tests/browser/db.auth-refresh.test.ts
+++ b/packages/jazz-tools/tests/browser/db.auth-refresh.test.ts
@@ -161,7 +161,7 @@ describe("Db auth refresh browser integration", () => {
       (rows) => rows.some((row) => row.title === marker),
       "queued write should flush after auth refresh",
       20_000,
-      "worker",
+      "local",
     );
   });
 });

--- a/packages/jazz-tools/tests/browser/db.auth-refresh.worker.test.ts
+++ b/packages/jazz-tools/tests/browser/db.auth-refresh.worker.test.ts
@@ -17,7 +17,7 @@
  * 2. Post-refresh usability (real server via getTestingServerJwtForUser):
  *    creates a Db with an initial valid JWT, writes a row, refreshes the
  *    JWT with a fresh token for the same user, and confirms the Db still
- *    serves worker-tier queries.  Uses global-setup server but does not
+ *    serves local-tier queries.  Uses global-setup server but does not
  *    rely on the auth-rejection → unauthenticated path.
  *
  * Coverage of the full update-auth chain is split across:
@@ -154,7 +154,7 @@ describe("Db worker-path auth refresh — update-auth dispatch chain", () => {
 
   it("posts update-auth to the worker when updateAuthToken is called after bridge init", async () => {
     // No serverUrl: pure OPFS Db.  The worker bridge is fully set up but
-    // not waiting on any WS connection, so worker-tier queries resolve as
+    // not waiting on any WS connection, so local-tier queries resolve as
     // soon as the worker processes pending inserts.
     //
     // Both tokens have sub="alice" so applyJwtToken doesn't throw on
@@ -177,12 +177,12 @@ describe("Db worker-path auth refresh — update-auth dispatch chain", () => {
     // Trigger lazy bridge init: WorkerBridge is created on first getClient() call.
     db.insert(todos, { title: "bridge-init-trigger", done: false });
 
-    // Wait for the bridge handshake to complete: a worker-tier query resolves
+    // Wait for the bridge handshake to complete: a local-tier query resolves
     // only after the worker has sent "init-ok" and applied the pending insert.
     await withTimeout(
-      db.all(allTodos, { tier: "worker" }),
+      db.all(allTodos, { tier: "local" }),
       15_000,
-      "bridge init: worker-tier query did not resolve",
+      "bridge init: local-tier query did not resolve",
     );
 
     // Bridge is ready.  Start capturing outbound messages to the worker.
@@ -209,8 +209,8 @@ describe("Db worker-path auth refresh — update-auth dispatch chain", () => {
     });
   });
 
-  it("Db remains usable for worker-tier queries after updateAuthToken", async () => {
-    // No serverUrl: pure OPFS Db so worker-tier queries resolve locally
+  it("Db remains usable for local-tier queries after updateAuthToken", async () => {
+    // No serverUrl: pure OPFS Db so local-tier queries resolve locally
     // without waiting for a WS connection.  Both tokens carry sub="bob"
     // so the principal-change guard in applyJwtToken does not trigger.
     const initialJwt = makeFakeJwt("bob", { role: "member" });
@@ -229,9 +229,9 @@ describe("Db worker-path auth refresh — update-auth dispatch chain", () => {
     db.insert(todos, { title: preMarker, done: false });
 
     const rowsBefore = await withTimeout(
-      db.all(allTodos, { tier: "worker" }),
+      db.all(allTodos, { tier: "local" }),
       15_000,
-      "pre-refresh worker-tier query did not resolve",
+      "pre-refresh local-tier query did not resolve",
     );
     expect(rowsBefore.some((r) => r.title === preMarker)).toBe(true);
 
@@ -242,12 +242,12 @@ describe("Db worker-path auth refresh — update-auth dispatch chain", () => {
     const postMarker = `post-refresh-${Date.now()}`;
     db.insert(todos, { title: postMarker, done: true });
 
-    // Both rows must be visible at worker tier — the Db must stay
+    // Both rows must be visible at local tier — the Db must stay
     // operational after auth refresh.
     const rowsAfter = await withTimeout(
-      db.all(allTodos, { tier: "worker" }),
+      db.all(allTodos, { tier: "local" }),
       10_000,
-      "post-refresh worker-tier query did not resolve",
+      "post-refresh local-tier query did not resolve",
     );
     expect(rowsAfter.some((r) => r.title === preMarker)).toBe(true);
     expect(rowsAfter.some((r) => r.title === postMarker)).toBe(true);

--- a/packages/jazz-tools/tests/browser/history-conflict.test.ts
+++ b/packages/jazz-tools/tests/browser/history-conflict.test.ts
@@ -122,7 +122,7 @@ describe("History & Conflict Management", () => {
     // Alice inserts a todo
     const uniqueTitle = `original-${Date.now()}`;
     const { id } = await withTimeout(
-      dbAlice.insertDurable(todos, { title: uniqueTitle, done: false }, { tier: "worker" }),
+      dbAlice.insertDurable(todos, { title: uniqueTitle, done: false }, { tier: "local" }),
       10000,
       "Alice insert(worker) did not resolve",
     );
@@ -139,8 +139,8 @@ describe("History & Conflict Management", () => {
     // Both update concurrently — creates diverged tips (true conflict).
     // Promise.all ensures neither awaits the other's round-trip first.
     await Promise.all([
-      dbAlice.updateDurable(todos, id, { title: "alice-edit" }, { tier: "worker" }),
-      dbBob.updateDurable(todos, id, { title: "bob-edit" }, { tier: "worker" }),
+      dbAlice.updateDurable(todos, id, { title: "alice-edit" }, { tier: "local" }),
+      dbBob.updateDurable(todos, id, { title: "bob-edit" }, { tier: "local" }),
     ]);
 
     // Both must converge to the same final title.
@@ -170,7 +170,7 @@ describe("History & Conflict Management", () => {
 
     // Alice inserts
     const { id } = await withTimeout(
-      dbAlice.insertDurable(todos, { title: "original", done: false }, { tier: "worker" }),
+      dbAlice.insertDurable(todos, { title: "original", done: false }, { tier: "local" }),
       10000,
       "Alice insert did not resolve",
     );
@@ -185,7 +185,7 @@ describe("History & Conflict Management", () => {
     );
 
     // Alice updates
-    await dbAlice.updateDurable(todos, id, { title: "updated-by-alice" }, { tier: "worker" });
+    await dbAlice.updateDurable(todos, id, { title: "updated-by-alice" }, { tier: "local" });
 
     // Alice sees her own update locally
     await waitForQuery(
@@ -225,12 +225,12 @@ describe("History & Conflict Management", () => {
 
     // Both create concurrently
     await withTimeout(
-      dbAlice.insertDurable(todos, { title: milkTitle, done: false }, { tier: "worker" }),
+      dbAlice.insertDurable(todos, { title: milkTitle, done: false }, { tier: "local" }),
       10000,
       "Alice insert did not resolve",
     );
     await withTimeout(
-      dbBob.insertDurable(todos, { title: eggsTitle, done: false }, { tier: "worker" }),
+      dbBob.insertDurable(todos, { title: eggsTitle, done: false }, { tier: "local" }),
       10000,
       "Bob insert did not resolve",
     );
@@ -278,7 +278,7 @@ describe("History & Conflict Management", () => {
     // Alice inserts a todo
     const originalTitle = `sub-test-${Date.now()}`;
     const { id } = await withTimeout(
-      dbAlice.insertDurable(todos, { title: originalTitle, done: false }, { tier: "worker" }),
+      dbAlice.insertDurable(todos, { title: originalTitle, done: false }, { tier: "local" }),
       10000,
       "Alice insert did not resolve",
     );
@@ -309,7 +309,7 @@ describe("History & Conflict Management", () => {
 
     // Bob updates (durable so it propagates)
     const bobTitle = `bob-updated-${Date.now()}`;
-    await dbBob.updateDurable(todos, id, { title: bobTitle }, { tier: "worker" });
+    await dbBob.updateDurable(todos, id, { title: bobTitle }, { tier: "local" });
 
     // Alice's subscription should fire with the update
     await waitForCondition(
@@ -346,7 +346,7 @@ describe("History & Conflict Management", () => {
     // Alice inserts a todo
     const originalTitle = `fresh-test-${Date.now()}`;
     const { id } = await withTimeout(
-      dbAlice.insertDurable(todos, { title: originalTitle, done: false }, { tier: "worker" }),
+      dbAlice.insertDurable(todos, { title: originalTitle, done: false }, { tier: "local" }),
       10000,
       "Alice insert did not resolve",
     );
@@ -362,8 +362,8 @@ describe("History & Conflict Management", () => {
 
     // Both update concurrently — creates diverged tips (true conflict).
     await Promise.all([
-      dbAlice.updateDurable(todos, id, { title: "alice-edit" }, { tier: "worker" }),
-      dbBob.updateDurable(todos, id, { title: "bob-edit" }, { tier: "worker" }),
+      dbAlice.updateDurable(todos, id, { title: "alice-edit" }, { tier: "local" }),
+      dbBob.updateDurable(todos, id, { title: "bob-edit" }, { tier: "local" }),
     ]);
 
     // Wait for convergence between Alice and Bob
@@ -418,7 +418,7 @@ describe("History & Conflict Management", () => {
     const dbBob = await createReadySyncedDb(ctx, "hc-bob-fields", token, testingServer);
 
     const { id } = await withTimeout(
-      dbAlice.insertDurable(todos, { title: "task", done: false }, { tier: "worker" }),
+      dbAlice.insertDurable(todos, { title: "task", done: false }, { tier: "local" }),
       10000,
       "Alice insert did not resolve",
     );
@@ -433,8 +433,8 @@ describe("History & Conflict Management", () => {
 
     // Alice updates title, Bob updates done — concurrently
     await Promise.all([
-      dbAlice.updateDurable(todos, id, { title: "alice-title" }, { tier: "worker" }),
-      dbBob.updateDurable(todos, id, { done: true }, { tier: "worker" }),
+      dbAlice.updateDurable(todos, id, { title: "alice-title" }, { tier: "local" }),
+      dbBob.updateDurable(todos, id, { done: true }, { tier: "local" }),
     ]);
 
     // Both must converge to the same state
@@ -466,7 +466,7 @@ async function createReadySyncedDb(
     async () => {
       try {
         await withTimeout(
-          db.insertDurable(todos, { title: warmupTitle, done: false }, { tier: "worker" }),
+          db.insertDurable(todos, { title: warmupTitle, done: false }, { tier: "local" }),
           2_000,
           `${label} warmup insert did not resolve`,
         );
@@ -487,7 +487,7 @@ async function waitForPeerSync(dbAlice: Db, dbBob: Db, label: string): Promise<v
     dbAlice.insertDurable(
       todos,
       { title: `peer-sync-a2b-${label}-${Date.now()}`, done: false },
-      { tier: "worker" },
+      { tier: "local" },
     ),
     10_000,
     `${label} Alice->Bob peer sync insert did not resolve`,
@@ -505,7 +505,7 @@ async function waitForPeerSync(dbAlice: Db, dbBob: Db, label: string): Promise<v
     dbBob.insertDurable(
       todos,
       { title: `peer-sync-b2a-${label}-${Date.now()}`, done: false },
-      { tier: "worker" },
+      { tier: "local" },
     ),
     10_000,
     `${label} Bob->Alice peer sync insert did not resolve`,

--- a/packages/jazz-tools/tests/browser/realistic-bench.test.ts
+++ b/packages/jazz-tools/tests/browser/realistic-bench.test.ts
@@ -22,9 +22,9 @@ declare const __JAZZ_REALISTIC_BROWSER_SCENARIOS__: string;
 declare const __JAZZ_REALISTIC_BROWSER_RUN_ID__: string;
 declare const __JAZZ_REALISTIC_BROWSER_LIMIT_OVERRIDES_JSON__: string;
 
-type PersistenceTier = "worker" | "edge" | "core";
+type PersistenceTier = "local" | "edge" | "core";
 
-function durabilityOptions(tier: PersistenceTier): { tier: "worker" | "edge" | "global" } {
+function durabilityOptions(tier: PersistenceTier): { tier: "local" | "edge" | "global" } {
   return { tier: tier === "core" ? "global" : tier };
 }
 
@@ -682,7 +682,7 @@ async function runW1(db: Db, config: ProfileConfig, state: SeedState): Promise<S
               [["updated_at", "desc"]],
               200,
             ),
-            "worker",
+            "local",
           );
           break;
         }
@@ -698,7 +698,7 @@ async function runW1(db: Db, config: ProfileConfig, state: SeedState): Promise<S
               [["updated_at", "desc"]],
               200,
             ),
-            "worker",
+            "local",
           );
           break;
         }
@@ -711,7 +711,7 @@ async function runW1(db: Db, config: ProfileConfig, state: SeedState): Promise<S
               [["created_at", "desc"]],
               200,
             ),
-            "worker",
+            "local",
           );
           await db.all(
             query<ActivityRow>(
@@ -720,7 +720,7 @@ async function runW1(db: Db, config: ProfileConfig, state: SeedState): Promise<S
               [["created_at", "desc"]],
               200,
             ),
-            "worker",
+            "local",
           );
           break;
         }
@@ -818,7 +818,7 @@ async function runW3(config: ProfileConfig): Promise<ScenarioResult> {
           body: `offline_reconnect_marker_${i}`,
           created_at: nowMicros(),
         },
-        "worker",
+        "local",
       );
     }
     const offlineWriteMs = performance.now() - offlineWriteStart;
@@ -917,7 +917,7 @@ async function runW4(config: ProfileConfig): Promise<ScenarioResult> {
         [["updated_at", "desc"]],
         200,
       ),
-      "worker",
+      "local",
     );
     await db.shutdown();
     db = null;
@@ -934,7 +934,7 @@ async function runW4(config: ProfileConfig): Promise<ScenarioResult> {
           [["updated_at", "desc"]],
           200,
         ),
-        "worker",
+        "local",
       );
       await db.shutdown();
       db = null;
@@ -1586,7 +1586,7 @@ async function seedPermissionDataset(
     deniedOwnerId: string;
     intermediateOwnerId: string;
   },
-  tier: PersistenceTier = "worker",
+  tier: PersistenceTier = "local",
 ): Promise<PermissionSeedState> {
   const folderTable = tableProxy<PermissionFolderRow, Omit<PermissionFolderRow, "id">>(
     "folders",

--- a/packages/jazz-tools/tests/browser/remote-db-harness.ts
+++ b/packages/jazz-tools/tests/browser/remote-db-harness.ts
@@ -18,7 +18,7 @@ export interface RemoteBrowserDbWaitForTitleInput {
   id: string;
   title: string;
   timeoutMs: number;
-  tier?: "worker" | "edge";
+  tier?: "local" | "edge";
 }
 
 interface RemoteBrowserDbState {

--- a/packages/jazz-tools/tests/browser/support.ts
+++ b/packages/jazz-tools/tests/browser/support.ts
@@ -67,7 +67,7 @@ export async function waitForQuery<T>(
   predicate: (rows: T[]) => boolean,
   label: string,
   timeoutMs = 15000,
-  tier?: "worker" | "edge",
+  tier?: "local" | "edge",
 ): Promise<T[]> {
   const deadline = Date.now() + timeoutMs;
   let lastRows: T[] = [];

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -341,7 +341,7 @@ describe("Worker Bridge with OPFS", () => {
     title: string,
     label: string,
     timeoutMs: number,
-    tier?: "worker" | "edge",
+    tier?: "local" | "edge",
   ): Promise<Record<string, unknown>[]> {
     try {
       return await waitForRemoteBrowserDbTitle({ id, title, timeoutMs, tier });
@@ -514,7 +514,7 @@ describe("Worker Bridge with OPFS", () => {
 
     await waitForCondition(
       async () => {
-        const row = await db1.one(allTodos, { tier: "worker" });
+        const row = await db1.one(allTodos, { tier: "local" });
         return row?.id === id;
       },
       8_000,
@@ -531,7 +531,7 @@ describe("Worker Bridge with OPFS", () => {
       }),
     );
 
-    const persistedRow = await db2.one(allTodos, { tier: "worker" });
+    const persistedRow = await db2.one(allTodos, { tier: "local" });
     expect(persistedRow?.id).toBe(id);
   });
 
@@ -580,7 +580,7 @@ describe("Worker Bridge with OPFS", () => {
       }),
     );
 
-    const persistedRows = await db2.all(allTodos, { tier: "worker" });
+    const persistedRows = await db2.all(allTodos, { tier: "local" });
     expect(persistedRows.length).toEqual(0);
   });
 
@@ -610,7 +610,7 @@ describe("Worker Bridge with OPFS", () => {
       return originalPostMessage(message, { transfer });
     }) as Worker["postMessage"];
 
-    await expect(db.all(allTodos, { tier: "worker" })).rejects.toThrow(
+    await expect(db.all(allTodos, { tier: "local" })).rejects.toThrow(
       "Worker init failed: forced bridge init failure for query test",
     );
 
@@ -650,13 +650,13 @@ describe("Worker Bridge with OPFS", () => {
     const { id } = await db.insertDurable(
       todos,
       { title: "Original", done: false },
-      { tier: "worker" },
+      { tier: "local" },
     );
-    const pending = db.updateDurable(todos, id, { done: true }, { tier: "worker" });
+    const pending = db.updateDurable(todos, id, { done: true }, { tier: "local" });
     expect(pending).toBeInstanceOf(Promise);
     await pending;
 
-    const results = await db.all(allTodos, { tier: "worker" });
+    const results = await db.all(allTodos, { tier: "local" });
     expect(results.length).toBe(1);
     expect(results[0].done).toBe(true);
   });
@@ -689,15 +689,15 @@ describe("Worker Bridge with OPFS", () => {
     const { id } = await db.insertDurable(
       todos,
       { title: "Ephemeral", done: false },
-      { tier: "worker" },
+      { tier: "local" },
     );
-    expect((await db.all(allTodos, { tier: "worker" })).length).toBe(1);
+    expect((await db.all(allTodos, { tier: "local" })).length).toBe(1);
 
-    const pending = db.deleteDurable(todos, id, { tier: "worker" });
+    const pending = db.deleteDurable(todos, id, { tier: "local" });
     expect(pending).toBeInstanceOf(Promise);
     await pending;
 
-    const results = await db.all(allTodos, { tier: "worker" });
+    const results = await db.all(allTodos, { tier: "local" });
     expect(results.length).toBe(0);
   });
 
@@ -715,12 +715,12 @@ describe("Worker Bridge with OPFS", () => {
     await db1.shutdown();
 
     // New Db with same dbName — worker reopens OPFS, main thread starts empty.
-    // Using "worker" settled tier makes the query wait for the worker's
+    // Using "local" settled tier makes the query wait for the worker's
     // QuerySettled response, ensuring OPFS data arrives before resolving.
     const db2 = track(
       await createDb({ appId: "test-app", driver: { type: "persistent", dbName } }),
     );
-    const after = await db2.all(allTodos, { tier: "worker" });
+    const after = await db2.all(allTodos, { tier: "local" });
     expect(after.length).toBe(1);
     expect(after[0].title).toBe("Survive reload");
     expect(after[0].done).toBe(true);
@@ -733,9 +733,9 @@ describe("Worker Bridge with OPFS", () => {
       await createDb({ appId: "test-app", driver: { type: "persistent", dbName } }),
     );
 
-    // insert({ tier: "worker" }) ensures data is in OPFS WAL before we crash
-    await db1.insertDurable(todos, { title: "Crash-proof", done: false }, { tier: "worker" });
-    await db1.insertDurable(todos, { title: "Also survives", done: true }, { tier: "worker" });
+    // insert({ tier: "local" }) ensures data is in OPFS WAL before we crash
+    await db1.insertDurable(todos, { title: "Crash-proof", done: false }, { tier: "local" });
+    await db1.insertDurable(todos, { title: "Also survives", done: true }, { tier: "local" });
 
     // Simulate crash: release OPFS handles WITHOUT flushing snapshot.
     // WAL has the data, but snapshot is stale. Recovery must replay WAL.
@@ -755,7 +755,7 @@ describe("Worker Bridge with OPFS", () => {
     const db2 = track(
       await createDb({ appId: "test-app", driver: { type: "persistent", dbName } }),
     );
-    const after = await db2.all(allTodos, { tier: "worker" });
+    const after = await db2.all(allTodos, { tier: "local" });
     expect(after.length).toBe(2);
 
     const titles = after.map((r) => r.title).sort();
@@ -786,7 +786,7 @@ describe("Worker Bridge with OPFS", () => {
     setTimeout(() => writable.close(), 100);
 
     const db = track(await dbPromise);
-    const rows = await db.all(allTodos, { tier: "worker" });
+    const rows = await db.all(allTodos, { tier: "local" });
     expect(rows).toEqual([]);
   });
 
@@ -798,18 +798,18 @@ describe("Worker Bridge with OPFS", () => {
       }),
     );
 
-    await db.insertDurable(todos, { title: "Should be deleted", done: false }, { tier: "worker" });
-    const before = await db.all(allTodos, { tier: "worker" });
+    await db.insertDurable(todos, { title: "Should be deleted", done: false }, { tier: "local" });
+    const before = await db.all(allTodos, { tier: "local" });
     expect(before.length).toBe(1);
     expect(before[0].title).toBe("Should be deleted");
 
     await db.deleteClientStorage();
 
-    const afterDelete = await db.all(allTodos, { tier: "worker" });
+    const afterDelete = await db.all(allTodos, { tier: "local" });
     expect(afterDelete).toEqual([]);
 
     const { id } = await db.insert(todos, { title: "Fresh after delete", done: true });
-    const afterReinsert = await db.all(allTodos, { tier: "worker" });
+    const afterReinsert = await db.all(allTodos, { tier: "local" });
     expect(afterReinsert).toHaveLength(1);
     expect(afterReinsert[0].id).toBe(id);
     expect(afterReinsert[0].title).toBe("Fresh after delete");
@@ -829,18 +829,18 @@ describe("Worker Bridge with OPFS", () => {
     await leader.insertDurable(
       todos,
       { title: "Leader data before follower wipe", done: false },
-      { tier: "worker" },
+      { tier: "local" },
     );
     await follower.insertDurable(
       todos,
       { title: "Follower data before follower wipe", done: true },
-      { tier: "worker" },
+      { tier: "local" },
     );
 
     await waitForCondition(
       async () => {
-        const leaderRows = await leader.all(allTodos, { tier: "worker" });
-        const followerRows = await follower.all(allTodos, { tier: "worker" });
+        const leaderRows = await leader.all(allTodos, { tier: "local" });
+        const followerRows = await follower.all(allTodos, { tier: "local" });
         return leaderRows.length === 2 && followerRows.length === 2;
       },
       8000,
@@ -851,8 +851,8 @@ describe("Worker Bridge with OPFS", () => {
 
     await waitForCondition(
       async () => {
-        const leaderRows = await leader.all(allTodos, { tier: "worker" });
-        const followerRows = await follower.all(allTodos, { tier: "worker" });
+        const leaderRows = await leader.all(allTodos, { tier: "local" });
+        const followerRows = await follower.all(allTodos, { tier: "local" });
         return leaderRows.length === 0 && followerRows.length === 0;
       },
       12000,
@@ -860,12 +860,12 @@ describe("Worker Bridge with OPFS", () => {
     );
 
     const marker = `fresh-after-follower-wipe-${Date.now()}`;
-    await leader.insertDurable(todos, { title: marker, done: false }, { tier: "worker" });
+    await leader.insertDurable(todos, { title: marker, done: false }, { tier: "local" });
 
     await waitForCondition(
       async () => {
-        const leaderRows = await leader.all(allTodos, { tier: "worker" });
-        const followerRows = await follower.all(allTodos, { tier: "worker" });
+        const leaderRows = await leader.all(allTodos, { tier: "local" });
+        const followerRows = await follower.all(allTodos, { tier: "local" });
         const leaderHas = leaderRows.some((row) => row.title === marker);
         const followerHas = followerRows.some((row) => row.title === marker);
         return leaderHas && followerHas;
@@ -888,10 +888,10 @@ describe("Worker Bridge with OPFS", () => {
       todos,
       { title: "Should be wiped on logout", done: false },
       {
-        tier: "worker",
+        tier: "local",
       },
     );
-    expect((await db.all(allTodos, { tier: "worker" })).length).toBe(1);
+    expect((await db.all(allTodos, { tier: "local" })).length).toBe(1);
 
     await db.logout({ wipeData: true });
     untrack(db);
@@ -902,7 +902,7 @@ describe("Worker Bridge with OPFS", () => {
         driver: { type: "persistent", dbName },
       }),
     );
-    const rows = await reopened.all(allTodos, { tier: "worker" });
+    const rows = await reopened.all(allTodos, { tier: "local" });
     expect(rows).toEqual([]);
   });
 
@@ -913,7 +913,7 @@ describe("Worker Bridge with OPFS", () => {
     );
 
     // Initialize worker/main runtimes with schema v2 from client context.
-    await seeded.all(allCatalogueTodos, { tier: "worker" });
+    await seeded.all(allCatalogueTodos, { tier: "local" });
 
     // Seed historical v1 schema + auto lens v1->v2 directly into worker OPFS.
     await seedWorkerLiveSchema(seeded, catalogueSchemaV1);
@@ -933,7 +933,7 @@ describe("Worker Bridge with OPFS", () => {
     const offline = track(
       await createDb({ appId: "test-app", driver: { type: "persistent", dbName } }),
     );
-    await offline.all(allCatalogueTodos, { tier: "worker" });
+    await offline.all(allCatalogueTodos, { tier: "local" });
 
     await waitForCondition(
       async () => {
@@ -946,7 +946,7 @@ describe("Worker Bridge with OPFS", () => {
 
     await waitForCondition(
       async () => {
-        await offline.all(allCatalogueTodos, { tier: "worker" });
+        await offline.all(allCatalogueTodos, { tier: "local" });
         const mainState = getMainDebugSchemaState(offline, catalogueSchemaV2);
         return hasRestoredCatalogueState(mainState);
       },
@@ -956,10 +956,10 @@ describe("Worker Bridge with OPFS", () => {
   }, 90_000);
 
   // -------------------------------------------------------------------------
-  // 5. Durable insert resolves at worker tier
+  // 5. Durable insert resolves at local tier
   // -------------------------------------------------------------------------
 
-  it("insert resolves when worker acks", async () => {
+  it("insert resolves when local acks", async () => {
     const db = track(
       await createDb({
         appId: "test-app",
@@ -967,11 +967,11 @@ describe("Worker Bridge with OPFS", () => {
       }),
     );
 
-    // insert("worker") should resolve once the worker's OPFS has it
+    // insert("local") should resolve once the worker's OPFS has it
     const { id } = await db.insertDurable(
       todos,
       { title: "Durable", done: false },
-      { tier: "worker" },
+      { tier: "local" },
     );
     expect(id).toBeTruthy();
     expect(typeof id).toBe("string");
@@ -1068,7 +1068,7 @@ describe("Worker Bridge with OPFS", () => {
       const { id } = await db.insertDurable(
         todos,
         { title: `seeded-${i}`, done: i % 2 === 0 },
-        { tier: "worker" },
+        { tier: "local" },
       );
       insertedIds.push(id);
     }
@@ -1129,7 +1129,7 @@ describe("Worker Bridge with OPFS", () => {
       const { id } = await db.insertDurable(
         todos,
         { title: `seeded-jwt-${i}`, done: i % 2 === 0 },
-        { tier: "worker" },
+        { tier: "local" },
       );
       insertedIds.push(id);
     }
@@ -1212,7 +1212,7 @@ describe("Worker Bridge with OPFS", () => {
 
     const title = `sync-a-to-b-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     await withTimeout(
-      dbA.insertDurable(todos, { title, done: false }, { tier: "worker" }),
+      dbA.insertDurable(todos, { title, done: false }, { tier: "local" }),
       10000,
       "A insert(worker) did not resolve",
     );
@@ -1234,7 +1234,7 @@ describe("Worker Bridge with OPFS", () => {
 
     const title = `sync-b-to-a-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     await withTimeout(
-      dbB.insertDurable(todos, { title, done: true }, { tier: "worker" }),
+      dbB.insertDurable(todos, { title, done: true }, { tier: "local" }),
       10000,
       "B insert(worker) did not resolve",
     );
@@ -1267,7 +1267,7 @@ describe("Worker Bridge with OPFS", () => {
 
     const baselineTitle = `baseline-network-recover-${Date.now()}`;
     await withTimeout(
-      dbA.insertDurable(todos, { title: baselineTitle, done: false }, { tier: "worker" }),
+      dbA.insertDurable(todos, { title: baselineTitle, done: false }, { tier: "local" }),
       10000,
       "Baseline insert(worker) did not resolve",
     );
@@ -1291,7 +1291,7 @@ describe("Worker Bridge with OPFS", () => {
 
     const recoveredTitle = `network-recovered-${Date.now()}`;
     await withTimeout(
-      dbA.insertDurable(todos, { title: recoveredTitle, done: false }, { tier: "worker" }),
+      dbA.insertDurable(todos, { title: recoveredTitle, done: false }, { tier: "local" }),
       10000,
       "Recovered insert(worker) did not resolve",
     );
@@ -1328,7 +1328,7 @@ describe("Worker Bridge with OPFS", () => {
     try {
       const baselineTitle = `edge-late-baseline-${Date.now()}`;
       await withTimeout(
-        dbWriter.insertDurable(todos, { title: baselineTitle, done: false }, { tier: "worker" }),
+        dbWriter.insertDurable(todos, { title: baselineTitle, done: false }, { tier: "local" }),
         10000,
         "Baseline insert(worker) did not resolve",
       );
@@ -1416,7 +1416,7 @@ describe("Worker Bridge with OPFS", () => {
 
     const baselineTitle = `baseline-before-offline-${Date.now()}`;
     await withTimeout(
-      dbA.insertDurable(todos, { title: baselineTitle, done: false }, { tier: "worker" }),
+      dbA.insertDurable(todos, { title: baselineTitle, done: false }, { tier: "local" }),
       10000,
       "Baseline insert(worker) did not resolve",
     );
@@ -1437,7 +1437,7 @@ describe("Worker Bridge with OPFS", () => {
 
     const offlineTitle = `offline-worker-row-${Date.now()}`;
     await withTimeout(
-      dbA.insertDurable(todos, { title: offlineTitle, done: true }, { tier: "worker" }),
+      dbA.insertDurable(todos, { title: offlineTitle, done: true }, { tier: "local" }),
       10000,
       "Offline insert(worker) did not resolve",
     );
@@ -1447,7 +1447,7 @@ describe("Worker Bridge with OPFS", () => {
       (rows) => rows.some((row) => row.title === offlineTitle),
       "A sees offline worker row locally",
       10000,
-      "worker",
+      "local",
     );
 
     await expect(
@@ -1471,7 +1471,7 @@ describe("Worker Bridge with OPFS", () => {
 
     const postReconnectTitle = `post-reconnect-control-${Date.now()}`;
     await withTimeout(
-      dbA.insertDurable(todos, { title: postReconnectTitle, done: false }, { tier: "worker" }),
+      dbA.insertDurable(todos, { title: postReconnectTitle, done: false }, { tier: "local" }),
       10000,
       "Post-reconnect control insert(worker) did not resolve",
     );
@@ -1481,7 +1481,7 @@ describe("Worker Bridge with OPFS", () => {
       (rows) => rows.some((row) => row.title === postReconnectTitle),
       "A sees control row locally after reconnect",
       10000,
-      "worker",
+      "local",
     );
     await waitForRemoteTodoTitle(
       remoteDbId,
@@ -1548,7 +1548,7 @@ describe("Worker Bridge with OPFS", () => {
       ),
     );
 
-    await dbA.insertDurable(todos, { title: "local-only-local-1", done: true }, { tier: "worker" });
+    await dbA.insertDurable(todos, { title: "local-only-local-1", done: true }, { tier: "local" });
 
     // Wait for initial local-only snapshot.
     await waitForCondition(
@@ -1607,7 +1607,7 @@ describe("Worker Bridge with OPFS", () => {
 
     const remoteTitle = `remote-for-local-only-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     await withTimeout(
-      dbA.insertDurable(todos, { title: remoteTitle, done: false }, { tier: "worker" }),
+      dbA.insertDurable(todos, { title: remoteTitle, done: false }, { tier: "local" }),
       10000,
       "A insert(worker) did not resolve",
     );
@@ -1670,8 +1670,8 @@ describe("Worker Bridge with OPFS", () => {
 
     await waitForCondition(
       async () => {
-        const leaderRows = await leader.all(allTodos, { tier: "worker" });
-        const followerRows = await follower.all(allTodos, { tier: "worker" });
+        const leaderRows = await leader.all(allTodos, { tier: "local" });
+        const followerRows = await follower.all(allTodos, { tier: "local" });
         const leaderHas = leaderRows.some((row) => row.title === "Routed via leader");
         const followerHas = followerRows.some((row) => row.title === "Routed via leader");
         return leaderHas && followerHas;
@@ -1705,7 +1705,7 @@ describe("Worker Bridge with OPFS", () => {
     const { id } = await follower.insert(todos, { title: "Post-failover", done: true });
     await waitForCondition(
       async () => {
-        const rows = await follower.all(allTodos, { tier: "worker" });
+        const rows = await follower.all(allTodos, { tier: "local" });
         return rows.some((row) => row.id === id && row.title === "Post-failover");
       },
       8000,
@@ -1737,19 +1737,19 @@ describe("Worker Bridge with OPFS", () => {
     );
     const currentLeader = await waitForSingleLeader([survivor, reopened]);
     const currentFollower = currentLeader === survivor ? reopened : survivor;
-    await currentLeader.all(allTodos, { tier: "worker" });
+    await currentLeader.all(allTodos, { tier: "local" });
 
     const marker = `reopen-${Date.now()}`;
     await withTimeout(
-      currentFollower.insertDurable(todos, { title: marker, done: false }, { tier: "worker" }),
+      currentFollower.insertDurable(todos, { title: marker, done: false }, { tier: "local" }),
       10000,
       "Follower insert during reopen re-election did not resolve",
     );
 
     await waitForCondition(
       async () => {
-        const leaderRows = await currentLeader.all(allTodos, { tier: "worker" });
-        const followerRows = await currentFollower.all(allTodos, { tier: "worker" });
+        const leaderRows = await currentLeader.all(allTodos, { tier: "local" });
+        const followerRows = await currentFollower.all(allTodos, { tier: "local" });
         const leaderHas = leaderRows.some((row) => row.title === marker);
         const followerHas = followerRows.some((row) => row.title === marker);
         return leaderHas && followerHas;
@@ -1769,7 +1769,7 @@ async function waitForTodos(
   predicate: (rows: Todo[]) => boolean,
   label: string,
   timeoutMs = 15000,
-  tier?: "worker" | "edge",
+  tier?: "local" | "edge",
 ): Promise<Todo[]> {
   return waitForQuery(db, allTodos, predicate, label, timeoutMs, tier);
 }

--- a/packages/jazz-tools/tests/ts-dsl/delete-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/delete-api.test.ts
@@ -40,7 +40,7 @@ describe("TS Delete API", () => {
     const project = await db.insertDurable(
       app.projects,
       { name: "Test Project" },
-      { tier: "worker" },
+      { tier: "local" },
     );
     const owner = insertUser(db);
     const todo = await db.insertDurable(
@@ -53,15 +53,15 @@ describe("TS Delete API", () => {
         ownerId: owner.id,
         assigneesIds: [],
       },
-      { tier: "worker" },
+      { tier: "local" },
     );
 
-    const pending = db.deleteDurable(app.todos, todo.id, { tier: "worker" });
+    const pending = db.deleteDurable(app.todos, todo.id, { tier: "local" });
     expect(pending).toBeInstanceOf(Promise);
 
     await pending;
 
-    const rows = await db.all(app.todos.where({ id: { eq: todo.id } }), { tier: "worker" });
+    const rows = await db.all(app.todos.where({ id: { eq: todo.id } }), { tier: "local" });
     expect(rows).toEqual([]);
   });
 });

--- a/packages/jazz-tools/tests/ts-dsl/insert-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/insert-api.test.ts
@@ -50,7 +50,7 @@ describe("TS Insert API", () => {
     const project = await db.insertDurable(
       app.projects,
       { name: "Test Project" },
-      { tier: "worker" },
+      { tier: "local" },
     );
 
     expect(project).toEqual({
@@ -69,7 +69,7 @@ describe("TS Insert API", () => {
         ownerId: owner.id,
         assigneesIds: [],
       },
-      { tier: "worker" },
+      { tier: "local" },
     );
 
     expect(todo).toEqual({

--- a/packages/jazz-tools/tests/ts-dsl/update-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/update-api.test.ts
@@ -107,12 +107,12 @@ describe("TS Update API", () => {
       assigneesIds: [],
     });
 
-    const pending = db.updateDurable(app.todos, todo.id, { done: true }, { tier: "worker" });
+    const pending = db.updateDurable(app.todos, todo.id, { done: true }, { tier: "local" });
     expect(pending).toBeInstanceOf(Promise);
 
     await pending;
 
-    const [updated] = await db.all(app.todos.where({ id: { eq: todo.id } }), { tier: "worker" });
+    const [updated] = await db.all(app.todos.where({ id: { eq: todo.id } }), { tier: "local" });
     expect(updated!.done).toBe(true);
   });
 });

--- a/specs/status-quo/batches.md
+++ b/specs/status-quo/batches.md
@@ -229,7 +229,7 @@ The important design point is that this same struct is used for:
 
 - `current_row: StoredRowBatch`
 - `branch_frontier`
-- optional older visible winners for `worker`, `edge`, and `global`
+- optional older visible winners for `local`, `edge`, and `global`
 
 This is the main hot-path query shape. In durable storage, the common visible-row case now keeps
 some fields implicit to save bytes:

--- a/specs/status-quo/query_sync_integration.md
+++ b/specs/status-quo/query_sync_integration.md
@@ -77,7 +77,7 @@ In the browser stack, for example:
 main thread subscribes
   -> worker settles locally
   -> worker may also forward upstream
-  -> worker sends row batch entries + QuerySettled(worker)
+  -> worker sends row batch entries + QuerySettled(local)
   -> main thread publishes once requested tier is satisfied
 ```
 

--- a/specs/status-quo/row_histories.md
+++ b/specs/status-quo/row_histories.md
@@ -64,7 +64,7 @@ A `VisibleRowEntry` is the compact current answer for one `(branch, row_id)` pai
 
 - the current winning batch id
 - the current visible row values for that branch view
-- optional tier-specific winner ids for `worker`, `edge`, and `global`
+- optional tier-specific winner ids for `local`, `edge`, and `global`
 
 Physically, the visible region is also stored as flat `row_format` rows with the same user columns
 and a slightly larger `_jazz_*` prefix. That lets ordinary reads stay fast while still allowing

--- a/specs/status-quo/sync_manager.md
+++ b/specs/status-quo/sync_manager.md
@@ -145,7 +145,7 @@ Typical browser example:
 main thread subscribes
   -> worker settles query locally
   -> worker relays upstream if propagation is full
-  -> worker emits QuerySettled(worker)
+  -> worker emits QuerySettled(local)
   -> main thread can deliver once requested tier is satisfied
 ```
 


### PR DESCRIPTION
## What changed

Renames the public durability tier from `worker` to `local` across the stack.

This updates:
- TypeScript public types and defaults
- Rust durability tier enums, parsing, and serialization
- WASM/NAPI/RN bindings
- inspector tier UI
- docs, examples, specs, and tests

The browser worker runtime remains a worker implementation detail. The public tier name now describes the semantic tier rather than the browser host.

## Why

`worker` was leaking a browser implementation detail into the durability model. The lowest tier exists outside web-worker-backed browser runtimes too, so `local` better matches the actual tier lattice:

`local < edge < global`

## Impact

This is intentionally breaking in greenfield code:
- callers must use `tier: "local"` instead of `tier: "worker"`
- docs/examples now describe the lowest durability tier as `local`
- worker-hosted browser runtimes still use a dedicated worker under the hood

## Validation

- `cargo test -p jazz-tools binding_support::tests::read_durability_options_default_to_full_and_immediate`
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/runtime/client.test.ts src/runtime/client.for-request.test.ts src/runtime/client.mutations.test.ts src/react-native/jazz-rn-runtime-adapter.test.ts`
- `pnpm build`
