### PR TITLE
Fix correlated grant closures over gathered team hops

### DIFF
--- a/.changeset/five-birds-hunt.md
+++ b/.changeset/five-birds-hunt.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Bind qualified `where(...)` filters on hopped permission relations to the relation's actual joined scope so correlated `exists(...)` closures over gathered team grants evaluate correctly at runtime.

--- a/packages/jazz-tools/src/permissions/index.test.ts
+++ b/packages/jazz-tools/src/permissions/index.test.ts
@@ -1201,6 +1201,55 @@ describe("permissions DSL", () => {
     });
   });
 
+  it("binds qualified gathered-hop filters to the hop alias for correlated exists", () => {
+    let relation: PermissionRelation | undefined;
+    const compiled = definePermissions(app, ({ policy, session }) => {
+      const reachableTeams = policy.teams.gather({
+        start: {
+          kind: "individual",
+          identity_key: session.userId,
+        },
+        step: ({ current }) =>
+          policy.team_team_edges.where({ child_team: current }).hopTo("parent_team"),
+        maxDepth: 3,
+      });
+
+      return [
+        policy.todos.allowRead.where((todo) => {
+          relation = reachableTeams.hopTo("resource_access_edgesViaTeam").where({
+            "resource_access_edges.resource": todo.id,
+            grant_role: "viewer",
+          });
+
+          return policy.exists(relation);
+        }),
+      ];
+    });
+
+    expect(compiled.todos?.select?.using?.type).toBe("ExistsRel");
+    if (!relation) {
+      throw new Error("Expected correlated relation to be initialized.");
+    }
+
+    const rel = toLegacyRelExprForTest(relationToIr(relation));
+    expect(rel.type).toBe("Project");
+    if (rel.type !== "Project") {
+      throw new Error("Expected gathered-hop relation to project hop rows.");
+    }
+    expect(rel.input.type).toBe("Filter");
+    if (rel.input.type !== "Filter") {
+      throw new Error("Expected correlated gathered-hop relation to be filtered.");
+    }
+    expect(rel.input.predicate.type).toBe("And");
+    if (rel.input.predicate.type !== "And") {
+      throw new Error("Expected correlated gathered-hop predicate group.");
+    }
+
+    const predicateScopes = rel.input.predicate.exprs.map((expr: any) => expr.left?.scope);
+    expect(predicateScopes).toEqual(["__recursive_join_0", "__recursive_join_0"]);
+    expect(JSON.stringify(rel)).toContain('"type":"OuterColumn"');
+  });
+
   it("rejects invalid gather(...) step shapes", () => {
     expect(() =>
       definePermissions(app, ({ policy }) => {

--- a/packages/jazz-tools/src/permissions/index.ts
+++ b/packages/jazz-tools/src/permissions/index.ts
@@ -176,10 +176,7 @@ class PermissionRelationBuilder implements PermissionRelation {
       throw new Error("where(...) does not support union(...) relations in MVP.");
     }
     const where = resolveRelationWhereInput(input);
-    const filters = [
-      ...this.state.filters,
-      ...extractRelationFilters(where, currentRelationScope(this.state)),
-    ];
+    const filters = [...this.state.filters, ...extractRelationFilters(where, this.state)];
     return new PermissionRelationBuilder(
       {
         ...this.state,
@@ -1032,16 +1029,67 @@ function currentRelationScope(state: RelationExprState): string {
 
 function extractRelationFilters(
   where: Record<string, unknown>,
-  scope: string,
+  state: RelationExprState,
 ): RelationFilterEntry[] {
   const filters: RelationFilterEntry[] = [];
+  const defaultScope = currentRelationScope(state);
   for (const [column, raw] of Object.entries(where)) {
     if (raw === undefined) {
       continue;
     }
-    filters.push({ column, raw, scope });
+    const [prefix, bare] = splitQualifiedColumn(column);
+    filters.push({
+      column: bare,
+      raw,
+      scope: prefix ? resolveQualifiedRelationFilterScope(state, prefix, bare) : defaultScope,
+    });
   }
   return filters;
+}
+
+function relationBaseScopeBinding(
+  state: RelationExprState,
+): { table: string; scope: string } | null {
+  if (!state.initialScope) {
+    return null;
+  }
+
+  return {
+    table: state.initialScope,
+    scope: state.initialScope,
+  };
+}
+
+function resolveQualifiedRelationFilterScope(
+  state: RelationExprState,
+  qualifiedTable: string,
+  column: string,
+): string {
+  const scopes = new Set<string>();
+  const baseBinding = relationBaseScopeBinding(state);
+  if (baseBinding && baseBinding.table === qualifiedTable) {
+    scopes.add(baseBinding.scope);
+  }
+
+  state.joins.forEach((join, index) => {
+    if (join.table === qualifiedTable) {
+      scopes.add(relationJoinAlias(state.kind, join, index));
+    }
+  });
+
+  if (scopes.size === 0) {
+    throw new Error(
+      `Qualified relation where(...) column "${qualifiedTable}.${column}" does not match the current relation scopes.`,
+    );
+  }
+
+  if (scopes.size > 1) {
+    throw new Error(
+      `Qualified relation where(...) table "${qualifiedTable}" is ambiguous in the current relation; use an unambiguous relation shape instead.`,
+    );
+  }
+
+  return scopes.values().next().value as string;
 }
 
 function normalizeRelationSelectMap(columns: Record<string, string>): Record<string, string> {

--- a/packages/jazz-tools/src/runtime/permissions.repro.test.ts
+++ b/packages/jazz-tools/src/runtime/permissions.repro.test.ts
@@ -1,10 +1,11 @@
 import { randomUUID } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { schema as s } from "../index.js";
 import { definePermissions } from "../permissions/index.js";
 import { createJazzContext, type JazzContext } from "../backend/create-jazz-context.js";
-import { publishStoredSchema } from "./schema-fetch.js";
-import { startLocalJazzServer } from "../testing/local-jazz-server.js";
 
 const reproApp = s.defineApp({
   teams: s.table({
@@ -38,11 +39,11 @@ type ReproPermissions = Parameters<typeof definePermissions<typeof reproApp>>[1]
 
 type ReproEnv = {
   context: JazzContext;
-  server: { stop(): Promise<void>; url: string };
+  dataRoot: string;
 };
 
 function seedScenario(context: JazzContext): void {
-  const db = context.asBackend(reproApp);
+  const db = context.db(reproApp);
 
   const aliceTeam = db.insert(reproApp.teams, {
     name: "Alice",
@@ -85,32 +86,20 @@ async function runCase(
   defineCasePermissions: ReproPermissions,
 ): Promise<string[]> {
   const appId = randomUUID();
-  const backendSecret = "repro-backend-secret";
-  const adminSecret = "repro-admin-secret";
-  const server = await startLocalJazzServer({
-    appId,
-    backendSecret,
-    adminSecret,
-  });
-
-  await publishStoredSchema(server.url, {
-    adminSecret,
-    schema: reproApp.wasmSchema,
-  });
+  const dataRoot = await mkdtemp(join(tmpdir(), "jazz-permissions-repro-"));
+  const dataPath = join(dataRoot, "runtime.db");
 
   const permissions = definePermissions(reproApp, defineCasePermissions);
   const context = createJazzContext({
     appId,
     app: reproApp,
     permissions,
-    driver: { type: "memory" },
-    serverUrl: server.url,
-    backendSecret,
+    driver: { type: "persistent", dataPath },
     env: "test",
     userBranch: "main",
     tier: "edge",
   });
-  const env: ReproEnv = { context, server };
+  const env: ReproEnv = { context, dataRoot };
 
   try {
     seedScenario(context);
@@ -129,7 +118,7 @@ async function runCase(
   } finally {
     await env.context.shutdown();
     await new Promise((resolve) => setTimeout(resolve, 50));
-    await env.server.stop();
+    await rm(env.dataRoot, { recursive: true, force: true });
   }
 }
 

--- a/packages/jazz-tools/src/runtime/permissions.repro.test.ts
+++ b/packages/jazz-tools/src/runtime/permissions.repro.test.ts
@@ -2,10 +2,9 @@ import { randomUUID } from "node:crypto";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterAll, describe, expect, it } from "vitest";
+import { describe, expect, it, onTestFinished } from "vitest";
 import { schema as s } from "../index.js";
 import { definePermissions } from "../permissions/index.js";
-import { createJazzContext, type JazzContext } from "../backend/create-jazz-context.js";
 
 const reproApp = s.defineApp({
   teams: s.table({
@@ -37,30 +36,53 @@ const reproApp = s.defineApp({
 
 type ReproPermissions = Parameters<typeof definePermissions<typeof reproApp>>[1];
 
-type ReproEnv = {
-  context: JazzContext;
-  dataRoot: string;
-};
-
-async function settleRuntimeTeardown(delayMs: number = 250): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, delayMs));
-}
-
 function seedScenario(context: JazzContext): void {
   const db = context.db(reproApp);
 
-  const aliceTeam = db.insert(reproApp.teams, {
-    name: "Alice",
-    route_key: "alice",
+  const directTeam = db.insert(reproApp.teams, {
+    name: "Direct Membership",
+    route_key: "base-direct",
     corporation_id: "corp",
     kind: "individual",
     identity_key: "alice",
     system_owned: false,
     archived: false,
   });
+  const relationTeam = db.insert(reproApp.teams, {
+    name: "Relation Membership",
+    route_key: "relation-direct",
+    corporation_id: "corp",
+    kind: "manual",
+    system_owned: false,
+    archived: false,
+  });
+  const qualifiedTeam = db.insert(reproApp.teams, {
+    name: "Qualified Predicate",
+    route_key: "qualified-predicate",
+    corporation_id: "corp",
+    kind: "manual",
+    system_owned: false,
+    archived: false,
+  });
   const opsTeam = db.insert(reproApp.teams, {
-    name: "Ops",
-    route_key: "ops",
+    name: "Operations",
+    route_key: "gather-target",
+    corporation_id: "corp",
+    kind: "manual",
+    system_owned: false,
+    archived: false,
+  });
+  const grantTargetTeam = db.insert(reproApp.teams, {
+    name: "Incident Desk",
+    route_key: "grant-target",
+    corporation_id: "corp",
+    kind: "manual",
+    system_owned: false,
+    archived: false,
+  });
+  db.insert(reproApp.teams, {
+    name: "Hidden Team",
+    route_key: "hidden",
     corporation_id: "corp",
     kind: "manual",
     system_owned: false,
@@ -69,31 +91,41 @@ function seedScenario(context: JazzContext): void {
 
   db.insert(reproApp.user_team_edges, {
     user_id: "alice",
-    team: aliceTeam.id,
-    administrator: true,
+    team: directTeam.id,
+    administrator: false,
+  });
+  db.insert(reproApp.user_team_edges, {
+    user_id: "alice",
+    team: relationTeam.id,
+    administrator: false,
+  });
+  db.insert(reproApp.user_team_edges, {
+    user_id: "alice",
+    team: qualifiedTeam.id,
+    administrator: false,
   });
   db.insert(reproApp.team_team_edges, {
-    child_team: aliceTeam.id,
+    child_team: directTeam.id,
     parent_team: opsTeam.id,
     administrator: false,
   });
   db.insert(reproApp.team_access_edges, {
-    target_team: opsTeam.id,
-    team: aliceTeam.id,
+    target_team: grantTargetTeam.id,
+    team: relationTeam.id,
     grant_role: "viewer",
     administrator: false,
   });
 }
 
-async function runCase(
-  expectedNames: string[],
-  defineCasePermissions: ReproPermissions,
-): Promise<string[]> {
+type JazzContext = import("../backend/create-jazz-context.js").JazzContext;
+
+async function createReproContext(defineCasePermissions: ReproPermissions): Promise<JazzContext> {
   const appId = randomUUID();
   const dataRoot = await mkdtemp(join(tmpdir(), "jazz-permissions-repro-"));
   const dataPath = join(dataRoot, "runtime.db");
 
   const permissions = definePermissions(reproApp, defineCasePermissions);
+  const { createJazzContext } = await import("../backend/create-jazz-context.js");
   const context = createJazzContext({
     appId,
     app: reproApp,
@@ -103,9 +135,82 @@ async function runCase(
     userBranch: "main",
     tier: "edge",
   });
-  const env: ReproEnv = { context, dataRoot };
+  onTestFinished(async () => {
+    context.flush();
+    await context.shutdown();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await rm(dataRoot, { recursive: true, force: true });
+  });
 
-  try {
+  return context;
+}
+
+describe("runtime permission repros for recursive gather and qualified predicates", () => {
+  it("supports the full alpha.33 grant-closure repro end to end", async () => {
+    const context = await createReproContext(({ policy, session, allOf }) => {
+      const reachableTeams = policy.teams.gather({
+        start: {
+          "user_team_edges.user_id": session.user_id,
+        },
+        step: ({ current }) =>
+          policy.team_team_edges
+            .where({
+              child_team: current,
+              administrator: false,
+            })
+            .hopTo("parent_team"),
+        maxDepth: 8,
+      });
+
+      return [
+        policy.teams.allowRead.where((team) =>
+          allOf([
+            { route_key: "base-direct" },
+            policy.user_team_edges.exists.where({
+              user_id: session.user_id,
+              team: team.id,
+            }),
+          ]),
+        ),
+        policy.teams.allowRead.where((team) =>
+          allOf([
+            { route_key: "relation-direct" },
+            policy.exists(
+              policy.user_team_edges.where({ user_id: session.user_id }).hopTo("team").where({
+                id: team.id,
+              }),
+            ),
+          ]),
+        ),
+        policy.teams.allowRead.where({
+          route_key: "qualified-predicate",
+          "user_team_edges.user_id": session.user_id,
+        }),
+        policy.teams.allowRead.where((team) =>
+          allOf([
+            { route_key: "gather-target" },
+            policy.exists(
+              reachableTeams.where({
+                id: team.id,
+              }),
+            ),
+          ]),
+        ),
+        policy.teams.allowRead.where((team) =>
+          allOf([
+            { route_key: "grant-target" },
+            policy.exists(
+              reachableTeams.hopTo("team_access_edgesViaTeam").where({
+                "team_access_edges.target_team": team.id,
+                grant_role: { in: ["viewer", "editor", "manager"] },
+                administrator: false,
+              }),
+            ),
+          ]),
+        ),
+      ];
+    });
+
     seedScenario(context);
 
     const aliceDb = context.forSession(
@@ -117,99 +222,14 @@ async function runCase(
     );
 
     const names = (await aliceDb.all(reproApp.teams.where({}))).map((team) => team.name).sort();
-    expect(names).toEqual([...expectedNames].sort());
-    return names;
-  } finally {
-    env.context.flush();
-    await env.context.shutdown();
-    await settleRuntimeTeardown();
-    await rm(env.dataRoot, { recursive: true, force: true });
-    await settleRuntimeTeardown(50);
-  }
-}
-
-describe("runtime permission repros for recursive gather and qualified predicates", () => {
-  afterAll(async () => {
-    await settleRuntimeTeardown();
-  });
-
-  it("matches the original four runtime repro cases", async () => {
-    await runCase(["Alice"], ({ policy, session }) => {
-      policy.teams.allowRead.where((team) =>
-        policy.user_team_edges.exists.where({
-          user_id: session.user_id,
-          team: team.id,
-        }),
-      );
-    });
-
-    await runCase(["Alice"], ({ policy, session }) => {
-      const directTeams = policy.user_team_edges.where({ user_id: session.user_id }).hopTo("team");
-      policy.teams.allowRead.where((team) =>
-        policy.exists(
-          directTeams.where({
-            id: team.id,
-          }),
-        ),
-      );
-    });
-
-    await runCase(["Alice"], ({ policy, session }) => {
-      policy.teams.allowRead.where({
-        "user_team_edges.user_id": session.user_id,
-      });
-    });
-
-    await runCase(["Alice", "Ops"], ({ policy, session }) => {
-      const reachableTeams = policy.teams.gather({
-        start: {
-          "user_team_edges.user_id": session.user_id,
-        },
-        step: ({ current }) =>
-          policy.team_team_edges
-            .where({
-              child_team: current,
-              administrator: false,
-            })
-            .hopTo("parent_team"),
-        maxDepth: 8,
-      });
-
-      policy.teams.allowRead.where((team) =>
-        policy.exists(
-          reachableTeams.where({
-            id: team.id,
-          }),
-        ),
-      );
-    });
-  });
-
-  it("supports correlated exists over a gathered team closure hopped through grants", async () => {
-    await runCase(["Ops"], ({ policy, session }) => {
-      const reachableTeams = policy.teams.gather({
-        start: {
-          "user_team_edges.user_id": session.user_id,
-        },
-        step: ({ current }) =>
-          policy.team_team_edges
-            .where({
-              child_team: current,
-              administrator: false,
-            })
-            .hopTo("parent_team"),
-        maxDepth: 8,
-      });
-
-      policy.teams.allowRead.where((team) =>
-        policy.exists(
-          reachableTeams.hopTo("team_access_edgesViaTeam").where({
-            "team_access_edges.target_team": team.id,
-            grant_role: { in: ["viewer", "editor", "manager"] },
-            administrator: false,
-          }),
-        ),
-      );
-    });
+    expect(names).toEqual(
+      [
+        "Direct Membership",
+        "Incident Desk",
+        "Operations",
+        "Qualified Predicate",
+        "Relation Membership",
+      ].sort(),
+    );
   });
 });

--- a/packages/jazz-tools/src/runtime/permissions.repro.test.ts
+++ b/packages/jazz-tools/src/runtime/permissions.repro.test.ts
@@ -26,6 +26,12 @@ const reproApp = s.defineApp({
     parent_team: s.ref("teams"),
     administrator: s.boolean(),
   }),
+  team_access_edges: s.table({
+    target_team: s.ref("teams"),
+    team: s.ref("teams"),
+    grant_role: s.string(),
+    administrator: s.boolean(),
+  }),
 });
 
 type ReproPermissions = Parameters<typeof definePermissions<typeof reproApp>>[1];
@@ -66,6 +72,12 @@ function seedScenario(context: JazzContext): void {
   db.insert(reproApp.team_team_edges, {
     child_team: aliceTeam.id,
     parent_team: opsTeam.id,
+    administrator: false,
+  });
+  db.insert(reproApp.team_access_edges, {
+    target_team: opsTeam.id,
+    team: aliceTeam.id,
+    grant_role: "viewer",
     administrator: false,
   });
 }
@@ -175,6 +187,34 @@ describe("runtime permission repros for recursive gather and qualified predicate
         policy.exists(
           reachableTeams.where({
             id: team.id,
+          }),
+        ),
+      );
+    });
+  });
+
+  it("supports correlated exists over a gathered team closure hopped through grants", async () => {
+    await runCase(["Ops"], ({ policy, session }) => {
+      const reachableTeams = policy.teams.gather({
+        start: {
+          "user_team_edges.user_id": session.user_id,
+        },
+        step: ({ current }) =>
+          policy.team_team_edges
+            .where({
+              child_team: current,
+              administrator: false,
+            })
+            .hopTo("parent_team"),
+        maxDepth: 8,
+      });
+
+      policy.teams.allowRead.where((team) =>
+        policy.exists(
+          reachableTeams.hopTo("team_access_edgesViaTeam").where({
+            "team_access_edges.target_team": team.id,
+            grant_role: { in: ["viewer", "editor", "manager"] },
+            administrator: false,
           }),
         ),
       );

--- a/packages/jazz-tools/src/runtime/permissions.repro.test.ts
+++ b/packages/jazz-tools/src/runtime/permissions.repro.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { schema as s } from "../index.js";
 import { definePermissions } from "../permissions/index.js";
 import { createJazzContext, type JazzContext } from "../backend/create-jazz-context.js";
@@ -40,8 +40,6 @@ type ReproEnv = {
   context: JazzContext;
   server: { stop(): Promise<void>; url: string };
 };
-
-const envs: ReproEnv[] = [];
 
 function seedScenario(context: JazzContext): void {
   const db = context.asBackend(reproApp);
@@ -112,35 +110,30 @@ async function runCase(
     userBranch: "main",
     tier: "edge",
   });
-  envs.push({ context, server });
+  const env: ReproEnv = { context, server };
 
-  seedScenario(context);
+  try {
+    seedScenario(context);
 
-  const aliceDb = context.forSession(
-    {
-      user_id: "alice",
-      claims: {},
-    },
-    reproApp,
-  );
+    const aliceDb = context.forSession(
+      {
+        user_id: "alice",
+        claims: {},
+      },
+      reproApp,
+    );
 
-  const names = (await aliceDb.all(reproApp.teams.where({}))).map((team) => team.name).sort();
-  expect(names).toEqual([...expectedNames].sort());
-  return names;
+    const names = (await aliceDb.all(reproApp.teams.where({}))).map((team) => team.name).sort();
+    expect(names).toEqual([...expectedNames].sort());
+    return names;
+  } finally {
+    await env.context.shutdown();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await env.server.stop();
+  }
 }
 
 describe("runtime permission repros for recursive gather and qualified predicates", () => {
-  afterEach(async () => {
-    while (envs.length > 0) {
-      const env = envs.pop();
-      if (!env) {
-        continue;
-      }
-      await env.context.shutdown();
-      await env.server.stop();
-    }
-  });
-
   it("matches the original four runtime repro cases", async () => {
     await runCase(["Alice"], ({ policy, session }) => {
       policy.teams.allowRead.where((team) =>

--- a/packages/jazz-tools/src/runtime/permissions.repro.test.ts
+++ b/packages/jazz-tools/src/runtime/permissions.repro.test.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 import { schema as s } from "../index.js";
 import { definePermissions } from "../permissions/index.js";
 import { createJazzContext, type JazzContext } from "../backend/create-jazz-context.js";
@@ -41,6 +41,10 @@ type ReproEnv = {
   context: JazzContext;
   dataRoot: string;
 };
+
+async function settleRuntimeTeardown(delayMs: number = 250): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, delayMs));
+}
 
 function seedScenario(context: JazzContext): void {
   const db = context.db(reproApp);
@@ -116,13 +120,19 @@ async function runCase(
     expect(names).toEqual([...expectedNames].sort());
     return names;
   } finally {
+    env.context.flush();
     await env.context.shutdown();
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await settleRuntimeTeardown();
     await rm(env.dataRoot, { recursive: true, force: true });
+    await settleRuntimeTeardown(50);
   }
 }
 
 describe("runtime permission repros for recursive gather and qualified predicates", () => {
+  afterAll(async () => {
+    await settleRuntimeTeardown();
+  });
+
   it("matches the original four runtime repro cases", async () => {
     await runCase(["Alice"], ({ policy, session }) => {
       policy.teams.allowRead.where((team) =>


### PR DESCRIPTION
## What changed

This follow-up fixes the remaining alpha.33 permission-closure gap where a gathered team relation could be hopped through grant rows, but a qualified correlated filter on the hopped relation was bound to the raw table name instead of the actual join alias.

The changes do three things:
- resolve qualified relation `where(...)` columns against the relation's real bound scopes instead of carrying raw table names through IR lowering
- add a permissions DSL regression test for the exact `gather(...).hopTo(...).where({ "...": outerRow.id })` shape
- extend the runtime repro test to cover the gathered-team grant closure case from `/tmp/jazz-alpha33-grant-closure-repro.mjs`

## Why

`policy.exists(reachableTeams.hopTo("team_access_edgesViaTeam").where({ "team_access_edges.target_team": team.id, ... }))` was compiling with a mixed predicate scope like `["team_access_edges", "__recursive_join_0"]`. At runtime that effectively dropped the correlated joined-table constraint, so the grant closure matched too broadly.

Binding qualified relation filters to the actual joined scope fixes the correlation and makes the gathered grant closure evaluate correctly.

## Validation

Ran:
- `pnpm --dir packages/jazz-tools exec vitest run src/permissions/index.test.ts -t "binds qualified gathered-hop filters to the hop alias for correlated exists"`
- `pnpm --dir packages/jazz-tools exec vitest run src/runtime/permissions.repro.test.ts -t "supports correlated exists over a gathered team closure hopped through grants"`
- `pnpm --dir packages/jazz-tools exec vitest run src/runtime/permissions.repro.test.ts src/permissions/index.test.ts src/permissions/type-inference.test.ts`
- `pnpm --dir packages/jazz-tools exec tsc --noEmit --pretty false`
- `pnpm --dir packages/jazz-tools run build:runtime`
- `pnpm lint`

`pnpm lint` still reports the existing repo-wide warning-only oxlint findings outside this diff, but it exits successfully.