### PR TITLE
Fix OPFS splits for large index keys

### DIFF
--- a/.changeset/codex-opfs-size-aware-splits.md
+++ b/.changeset/codex-opfs-size-aware-splits.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix OPFS B-tree page splitting for large index keys by choosing split points based on encoded page size instead of entry count. This prevents synced inserts with many near-threshold JSON index values from failing with leaf or internal split fit errors.

--- a/crates/jazz-tools/src/query_manager/manager_tests.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests.rs
@@ -24,8 +24,8 @@ use crate::query_manager::types::{
 use crate::row_histories::{BatchId, HistoryScan, RowState, StoredRowBatch, VisibleRowEntry};
 use crate::schema_manager::encoding::encode_schema;
 use crate::storage::{
-    HistoryRowBytes, IndexMutation, MemoryStorage, OwnedHistoryRowBytes, OwnedVisibleRowBytes,
-    RawTableMutation, RawTableRows, Storage, StorageError, VisibleRowBytes,
+    HistoryRowBytes, IndexMutation, MemoryStorage, OpfsBTreeStorage, OwnedHistoryRowBytes,
+    OwnedVisibleRowBytes, RawTableMutation, RawTableRows, Storage, StorageError, VisibleRowBytes,
 };
 use crate::sync_manager::{InboxEntry, ServerId, Source, SyncManager, SyncPayload};
 use crate::test_row_history::{
@@ -678,6 +678,18 @@ fn json_documents_schema(schema: Option<serde_json::Value>) -> Schema {
     out
 }
 
+fn visual_description_schema() -> Schema {
+    let mut out = Schema::new();
+    out.insert(
+        TableName::new("visual_description"),
+        RowDescriptor::new(vec![
+            ColumnDescriptor::new("config", ColumnType::Json { schema: None }).nullable(),
+        ])
+        .into(),
+    );
+    out
+}
+
 /// Helper to execute a query synchronously via subscribe/process/unsubscribe.
 /// Returns Vec<(ObjectId, Vec<Value>)> matching old execute() return type.
 fn execute_query<H: Storage>(
@@ -856,6 +868,75 @@ fn synced_insert_log_includes_failing_index_column() {
         event.fields.get("table").map(String::as_str),
         Some("documents")
     );
+}
+
+#[test]
+fn synced_insert_many_large_json_configs_survive_opfs_splits() {
+    let collector = EventCollector::default();
+    let subscriber = Registry::default().with(collector.clone());
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let sync_manager = SyncManager::new();
+    let schema = visual_description_schema();
+    let descriptor = schema[&TableName::new("visual_description")]
+        .columns
+        .clone();
+
+    let mut qm = QueryManager::new(sync_manager);
+    qm.set_current_schema(schema.clone(), "dev", "main");
+
+    let mut storage = OpfsBTreeStorage::memory(4 * 1024 * 1024).expect("open opfs storage");
+    persist_test_schema(&mut storage, &schema);
+
+    let branch = get_branch(&qm);
+    let table = "visual_description";
+    let max_index_value_segment_len =
+        5 * 1024 - (4 + table.len() + 1 + "config".len() + 1 + branch.len() + 1 + 32);
+    let max_inline_text_bytes = (max_index_value_segment_len / 2).saturating_sub(1);
+    let json_overhead = "{\"config\":\"\"}".len();
+    let shared_prefix = "a".repeat(max_inline_text_bytes - json_overhead - 8);
+
+    for i in 0..128 {
+        let row_id = ObjectId::new();
+        let mut metadata = HashMap::new();
+        metadata.insert(MetadataKey::Table.to_string(), table.to_string());
+        put_test_row_metadata(&mut storage, row_id, metadata);
+
+        let payload = if i % 8 == 7 {
+            format!("{{\"config\":\"b{i:08x}\"}}")
+        } else {
+            format!("{{\"config\":\"{shared_prefix}{i:08x}\"}}")
+        };
+        let row_data = encode_row(&descriptor, &[Value::Text(payload)]).unwrap();
+
+        qm.sync_manager_mut().push_inbox(InboxEntry {
+            source: Source::Server(ServerId::new()),
+            payload: SyncPayload::RowBatchCreated {
+                metadata: None,
+                row: stored_row_commit(smallvec![], row_data, 1_000 + i as u64, row_id.to_string())
+                    .to_row(row_id, &branch, RowState::VisibleDirect),
+            },
+        });
+    }
+
+    qm.process(&mut storage);
+
+    let failures = collector
+        .snapshot()
+        .into_iter()
+        .filter(|event| {
+            event.level == tracing::Level::ERROR
+                && event.message.as_deref() == Some("failed to update indices for synced insert")
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        failures.is_empty(),
+        "synced inserts should not hit opfs split failures: {failures:?}"
+    );
+
+    let query = qm.query(table).build();
+    let rows = execute_query(&mut qm, &mut storage, query).expect("query synced rows");
+    assert_eq!(rows.len(), 128, "all synced rows should remain queryable");
 }
 
 #[test]

--- a/crates/opfs-btree/src/db.rs
+++ b/crates/opfs-btree/src/db.rs
@@ -483,25 +483,12 @@ impl<F: SyncFile> OpfsBTree<F> {
                     ));
                 }
 
-                let split_at = entries.len() / 2;
-                let right_entries = entries.split_off(split_at);
-                let split_key = right_entries
-                    .first()
-                    .map(|(k, _)| k.clone())
-                    .ok_or_else(|| BTreeError::Corrupt("right leaf split empty".to_string()))?;
-
+                let (split_key, mut left_page, right_page) =
+                    choose_leaf_split(entries, next, self.options.page_size)?;
                 let right_page_id = self.alloc_page_near(page_id);
-                let left_page = Page::Leaf {
-                    entries,
-                    next: Some(right_page_id),
-                };
-                let right_page = Page::Leaf {
-                    entries: right_entries,
-                    next,
-                };
-
-                ensure_page_fits(&left_page, self.options.page_size, "left leaf split")?;
-                ensure_page_fits(&right_page, self.options.page_size, "right leaf split")?;
+                if let Page::Leaf { next, .. } = &mut left_page {
+                    *next = Some(right_page_id);
+                }
 
                 self.set_dirty_page(page_id, left_page)?;
                 self.set_dirty_page(right_page_id, right_page)?;
@@ -556,21 +543,8 @@ impl<F: SyncFile> OpfsBTree<F> {
                     ));
                 }
 
-                let mid = keys.len() / 2;
-                let promoted = keys[mid].clone();
-
-                let right_keys = keys.split_off(mid + 1);
-                let _ = keys.pop();
-                let right_children = children.split_off(mid + 1);
-
-                let left_page = Page::Internal { keys, children };
-                let right_page = Page::Internal {
-                    keys: right_keys,
-                    children: right_children,
-                };
-
-                ensure_page_fits(&left_page, self.options.page_size, "left internal split")?;
-                ensure_page_fits(&right_page, self.options.page_size, "right internal split")?;
+                let (promoted, left_page, right_page) =
+                    choose_internal_split(keys, children, self.options.page_size)?;
 
                 let right_page_id = self.alloc_page_near(page_id);
                 self.set_dirty_page(page_id, left_page)?;
@@ -1585,6 +1559,92 @@ fn ensure_page_fits(page: &Page, page_size: usize, context: &str) -> Result<(), 
             context
         )))
     }
+}
+
+fn centered_split_candidates(preferred: usize, min: usize, max: usize) -> Vec<usize> {
+    debug_assert!(min <= max);
+
+    let preferred = preferred.clamp(min, max);
+    let mut out = Vec::with_capacity(max - min + 1);
+    out.push(preferred);
+
+    for offset in 1..=max - min {
+        if let Some(left) = preferred.checked_sub(offset)
+            && left >= min
+        {
+            out.push(left);
+        }
+
+        let right = preferred + offset;
+        if right <= max {
+            out.push(right);
+        }
+    }
+
+    out
+}
+
+fn choose_leaf_split(
+    entries: Vec<(Vec<u8>, ValueCell)>,
+    next: Option<PageId>,
+    page_size: usize,
+) -> Result<(Vec<u8>, Page, Page), BTreeError> {
+    debug_assert!(entries.len() >= 2);
+
+    for split_at in centered_split_candidates(entries.len() / 2, 1, entries.len() - 1) {
+        let left_page = Page::Leaf {
+            entries: entries[..split_at].to_vec(),
+            next: Some(1),
+        };
+        let right_page = Page::Leaf {
+            entries: entries[split_at..].to_vec(),
+            next,
+        };
+
+        if page_fits(&left_page, page_size)? && page_fits(&right_page, page_size)? {
+            let split_key = match &right_page {
+                Page::Leaf { entries, .. } => entries
+                    .first()
+                    .map(|(key, _)| key.clone())
+                    .ok_or_else(|| BTreeError::Corrupt("right leaf split empty".to_string()))?,
+                _ => unreachable!("constructed leaf page must remain a leaf"),
+            };
+            return Ok((split_key, left_page, right_page));
+        }
+    }
+
+    Err(BTreeError::InvalidOptions(
+        "no valid leaf split fits in page".to_string(),
+    ))
+}
+
+fn choose_internal_split(
+    keys: Vec<Vec<u8>>,
+    children: Vec<PageId>,
+    page_size: usize,
+) -> Result<(Vec<u8>, Page, Page), BTreeError> {
+    debug_assert!(keys.len() >= 2);
+    debug_assert_eq!(children.len(), keys.len() + 1);
+
+    for mid in centered_split_candidates(keys.len() / 2, 1, keys.len() - 1) {
+        let promoted = keys[mid].clone();
+        let left_page = Page::Internal {
+            keys: keys[..mid].to_vec(),
+            children: children[..mid + 1].to_vec(),
+        };
+        let right_page = Page::Internal {
+            keys: keys[mid + 1..].to_vec(),
+            children: children[mid + 1..].to_vec(),
+        };
+
+        if page_fits(&left_page, page_size)? && page_fits(&right_page, page_size)? {
+            return Ok((promoted, left_page, right_page));
+        }
+    }
+
+    Err(BTreeError::InvalidOptions(
+        "no valid internal split fits in page".to_string(),
+    ))
 }
 
 fn choose_active(


### PR DESCRIPTION
## What changed

- make OPFS B-tree leaf and internal splits choose a pivot based on encoded page fit instead of entry count
- add a synced-insert regression that reproduces many large JSON `config` index inserts through the real `QueryManager` + OPFS path
- add a `jazz-tools` patch changeset for the fix

## Why

We reproduced the user failure locally: many near-threshold JSON index entries could drive the OPFS B-tree into `left/right leaf split does not fit in page` and then `internal split does not fit in page` errors during synced inserts. The old midpoint-by-count split heuristic was not safe for large uneven keys.

## Impact

This keeps valid large index keys queryable instead of failing synced insert index updates when OPFS pages need to split.

## Validation

- `cargo test -p jazz-tools --lib synced_insert_many_large_json_configs_survive_opfs_splits`
- `cargo test -p opfs-btree`
- pre-commit hooks: `clippy`, `oxfmt`, `rustfmt`