### PR TITLE
Add column merge strategies

### DIFF
--- a/.changeset/column-merge-strategies.md
+++ b/.changeset/column-merge-strategies.md
@@ -1,0 +1,7 @@
+---
+"jazz-tools": patch
+---
+
+Add schema-level per-column merge strategies to `jazz-tools`.
+
+Columns now default to MRCA-relative per-column LWW, and non-nullable integer columns can opt into `merge("counter")` to merge concurrent snapshots by summing their MRCA-relative deltas. Merge strategy is schema metadata, so different schema versions can resolve the same conflicting history differently without rewriting stored rows.

--- a/crates/jazz-tools/src/query_manager/graph_nodes/array_subquery.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/array_subquery.rs
@@ -125,6 +125,7 @@ impl ArraySubqueryNode {
             nullable: false,
             references: None,
             default: None,
+            merge_strategy: None,
         });
 
         let output_descriptor = RowDescriptor::new(output_columns);

--- a/crates/jazz-tools/src/query_manager/graph_nodes/magic_columns.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/magic_columns.rs
@@ -127,6 +127,7 @@ impl MagicColumnsNode {
                         ),
                         references: None,
                         default: None,
+                        merge_strategy: None,
                     });
                 }
 

--- a/crates/jazz-tools/src/query_manager/graph_nodes/policy_filter.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/policy_filter.rs
@@ -794,6 +794,7 @@ mod tests {
                 nullable: false,
                 references: Some(TableName::new("folders")),
                 default: None,
+                merge_strategy: None,
             },
             ColumnDescriptor::new("title", ColumnType::Text),
         ]);

--- a/crates/jazz-tools/src/query_manager/graph_nodes/project.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/project.rs
@@ -114,6 +114,7 @@ impl ProjectNode {
                         nullable: source_column.nullable,
                         references: source_column.references,
                         default: source_column.default.clone(),
+                        merge_strategy: source_column.merge_strategy,
                     }
                 }
                 ProjectionSource::RowId { .. } => ColumnDescriptor {
@@ -122,6 +123,7 @@ impl ProjectNode {
                     nullable: false,
                     references: None,
                     default: None,
+                    merge_strategy: None,
                 },
             };
 

--- a/crates/jazz-tools/src/query_manager/types/branch.rs
+++ b/crates/jazz-tools/src/query_manager/types/branch.rs
@@ -132,6 +132,17 @@ fn hash_column_descriptor(hasher: &mut blake3::Hasher, col: &ColumnDescriptor) {
     } else {
         hasher.update(&[0]);
     }
+
+    if let Some(strategy) = col.merge_strategy {
+        hasher.update(&[1]);
+        match strategy {
+            ColumnMergeStrategy::Counter => {
+                hasher.update(&[1]);
+            }
+        }
+    } else {
+        hasher.update(&[0]);
+    }
     hasher.update(&[0]); // delimiter
 }
 

--- a/crates/jazz-tools/src/query_manager/types/schema.rs
+++ b/crates/jazz-tools/src/query_manager/types/schema.rs
@@ -149,6 +149,11 @@ impl ColumnType {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ColumnMergeStrategy {
+    Counter,
+}
+
 /// Interned column name type.
 /// Pointer-sized (8 bytes), Copy, fast equality.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -226,6 +231,9 @@ pub struct ColumnDescriptor {
     /// Optional schema-level default used for omitted values on insert.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default: Option<Value>,
+    /// Optional per-column merge strategy. Absence means MRCA-relative LWW.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub merge_strategy: Option<ColumnMergeStrategy>,
 }
 
 impl ColumnDescriptor {
@@ -236,6 +244,7 @@ impl ColumnDescriptor {
             nullable: false,
             references: None,
             default: None,
+            merge_strategy: None,
         }
     }
 
@@ -257,6 +266,29 @@ impl ColumnDescriptor {
     pub fn default(mut self, value: Value) -> Self {
         self.default = Some(value);
         self
+    }
+
+    pub fn merge_strategy(mut self, strategy: ColumnMergeStrategy) -> Self {
+        self.merge_strategy = Some(strategy);
+        self
+    }
+
+    pub fn validate_merge_strategy(&self) -> Result<(), String> {
+        match self.merge_strategy {
+            None => Ok(()),
+            Some(ColumnMergeStrategy::Counter) => {
+                if self.nullable || self.column_type != ColumnType::Integer {
+                    Err(format!(
+                        "counter merge strategy is only supported on non-nullable INTEGER columns, got {} ({:?}, nullable={})",
+                        self.name_str(),
+                        self.column_type,
+                        self.nullable
+                    ))
+                } else {
+                    Ok(())
+                }
+            }
+        }
     }
 }
 

--- a/crates/jazz-tools/src/query_manager/types/tests.rs
+++ b/crates/jazz-tools/src/query_manager/types/tests.rs
@@ -79,6 +79,24 @@ fn column_descriptor_deserializes_payload_with_default() {
 }
 
 #[test]
+fn column_descriptor_deserializes_payload_with_merge_strategy() {
+    let col: ColumnDescriptor = serde_json::from_str(
+        r#"{
+            "name":"count",
+            "column_type":{"type":"Integer"},
+            "nullable":false,
+            "merge_strategy":"Counter"
+        }"#,
+    )
+    .expect("deserialize column descriptor with merge strategy");
+
+    assert_eq!(col.name, "count");
+    assert_eq!(col.column_type, ColumnType::Integer);
+    assert!(!col.nullable);
+    assert_eq!(col.merge_strategy, Some(ColumnMergeStrategy::Counter));
+}
+
+#[test]
 fn row_descriptor_column_lookup() {
     let descriptor = RowDescriptor::new(vec![
         ColumnDescriptor::new("id", ColumnType::Uuid),
@@ -175,6 +193,21 @@ fn tuple_element_id() {
     assert!(!elem.is_materialized());
     assert!(elem.content().is_none());
     assert!(elem.batch_id().is_none());
+}
+
+#[test]
+fn row_descriptor_hash_changes_when_merge_strategy_changes() {
+    let lww = RowDescriptor::new(vec![ColumnDescriptor::new("count", ColumnType::Integer)]);
+    let counter = RowDescriptor::new(vec![
+        ColumnDescriptor::new("count", ColumnType::Integer)
+            .merge_strategy(ColumnMergeStrategy::Counter),
+    ]);
+
+    assert_ne!(
+        lww.content_hash(),
+        counter.content_hash(),
+        "changing only the merge strategy should change the schema hash"
+    );
 }
 
 #[test]

--- a/crates/jazz-tools/src/row_histories/mod.rs
+++ b/crates/jazz-tools/src/row_histories/mod.rs
@@ -304,6 +304,7 @@ fn visible_row_system_columns() -> Vec<ColumnDescriptor> {
         ColumnDescriptor::new("_jazz_worker_winner_ordinals", ColumnType::Bytea).nullable(),
         ColumnDescriptor::new("_jazz_edge_winner_ordinals", ColumnType::Bytea).nullable(),
         ColumnDescriptor::new("_jazz_global_winner_ordinals", ColumnType::Bytea).nullable(),
+        ColumnDescriptor::new("_jazz_merge_artifacts", ColumnType::Bytea).nullable(),
     ]);
     columns
 }
@@ -337,6 +338,11 @@ fn visible_row_system_values(entry: &VisibleRowEntry) -> Vec<Value> {
         optional_winner_ordinals_to_value(entry.worker_winner_ordinals.as_deref()),
         optional_winner_ordinals_to_value(entry.edge_winner_ordinals.as_deref()),
         optional_winner_ordinals_to_value(entry.global_winner_ordinals.as_deref()),
+        entry
+            .merge_artifacts
+            .as_ref()
+            .map(|bytes| Value::Bytea(bytes.clone()))
+            .unwrap_or(Value::Null),
     ]);
     values
 }
@@ -1003,6 +1009,8 @@ pub(crate) fn decode_flat_visible_row_entry_with_codecs(
             "global_winner_ordinals",
             codecs.user_descriptor.columns.len(),
         )?,
+        merge_artifacts: column_bytes_with_layout(descriptor, layout, data, 17)?
+            .map(|bytes| bytes.to_vec()),
     })
 }
 
@@ -1241,6 +1249,7 @@ pub struct VisibleRowEntry {
     pub worker_winner_ordinals: Option<Vec<u16>>,
     pub edge_winner_ordinals: Option<Vec<u16>>,
     pub global_winner_ordinals: Option<Vec<u16>>,
+    pub merge_artifacts: Option<Vec<u8>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1262,6 +1271,7 @@ impl VisibleRowEntry {
             worker_winner_ordinals: None,
             edge_winner_ordinals: None,
             global_winner_ordinals: None,
+            merge_artifacts: None,
         }
     }
 
@@ -1288,6 +1298,7 @@ impl VisibleRowEntry {
             worker_winner_ordinals: None,
             edge_winner_ordinals: None,
             global_winner_ordinals: None,
+            merge_artifacts: None,
         }
     }
 
@@ -1355,6 +1366,7 @@ impl VisibleRowEntry {
             worker_winner_ordinals,
             edge_winner_ordinals,
             global_winner_ordinals,
+            merge_artifacts: None,
         }))
     }
 
@@ -2348,6 +2360,7 @@ mod tests {
             worker_winner_ordinals: None,
             edge_winner_ordinals: None,
             global_winner_ordinals: None,
+            merge_artifacts: Some(vec![1, 2, 3, 4]),
         };
 
         let encoded =
@@ -2383,6 +2396,7 @@ mod tests {
         assert_eq!(decoded.worker_batch_id, entry.worker_batch_id);
         assert_eq!(decoded.edge_batch_id, entry.edge_batch_id);
         assert_eq!(decoded.global_batch_id, entry.global_batch_id);
+        assert_eq!(decoded.merge_artifacts, entry.merge_artifacts);
     }
 
     #[test]
@@ -2394,6 +2408,7 @@ mod tests {
         assert_eq!(entry.worker_batch_id, None);
         assert_eq!(entry.edge_batch_id, None);
         assert_eq!(entry.global_batch_id, None);
+        assert_eq!(entry.merge_artifacts, None);
     }
 
     #[test]

--- a/crates/jazz-tools/src/row_histories/mod.rs
+++ b/crates/jazz-tools/src/row_histories/mod.rs
@@ -12,7 +12,7 @@ use crate::digest::Digest32;
 use crate::metadata::{DeleteKind, MetadataKey, RowProvenance};
 use crate::object::{BranchName, ObjectId};
 use crate::query_manager::types::{
-    ColumnDescriptor, ColumnType, RowBytes, RowDescriptor, SharedString, Value,
+    ColumnDescriptor, ColumnMergeStrategy, ColumnType, RowBytes, RowDescriptor, SharedString, Value,
 };
 use crate::row_format::{
     CompiledRowLayout, EncodingError, column_bytes_with_layout, column_is_null_with_layout,
@@ -1607,6 +1607,99 @@ fn current_winner_batch_id(
         .unwrap_or_else(|| fallback.batch_id())
 }
 
+#[derive(Clone, Copy)]
+struct ColumnContender<'a> {
+    row: &'a StoredRowBatch,
+    value: &'a Value,
+}
+
+fn merge_column_with_strategy<'a>(
+    column: &ColumnDescriptor,
+    ancestor_value: &Value,
+    contenders: &[ColumnContender<'a>],
+) -> Result<(Value, Option<&'a StoredRowBatch>), EncodingError> {
+    match column.merge_strategy {
+        Some(ColumnMergeStrategy::Counter) => {
+            let ancestor = match ancestor_value {
+                Value::Integer(value) => *value,
+                Value::Null => 0,
+                other => {
+                    return Err(malformed(format!(
+                        "counter merge expected INTEGER ancestor for column '{}', got {:?}",
+                        column.name_str(),
+                        other
+                    )));
+                }
+            };
+
+            let mut delta_sum = 0i32;
+            let mut latest_contributor: Option<&StoredRowBatch> = None;
+            for contender in contenders {
+                let contender_value = match contender.value {
+                    Value::Integer(value) => *value,
+                    other => {
+                        return Err(malformed(format!(
+                            "counter merge expected INTEGER contender for column '{}', got {:?}",
+                            column.name_str(),
+                            other
+                        )));
+                    }
+                };
+                let delta = contender_value.checked_sub(ancestor).ok_or_else(|| {
+                    malformed(format!(
+                        "counter merge delta overflow for column '{}'",
+                        column.name_str()
+                    ))
+                })?;
+                delta_sum = delta_sum.checked_add(delta).ok_or_else(|| {
+                    malformed(format!(
+                        "counter merge overflow for column '{}'",
+                        column.name_str()
+                    ))
+                })?;
+                if delta != 0
+                    && latest_contributor
+                        .map(|current| {
+                            (contender.row.updated_at, contender.row.batch_id())
+                                > (current.updated_at, current.batch_id())
+                        })
+                        .unwrap_or(true)
+                {
+                    latest_contributor = Some(contender.row);
+                }
+            }
+
+            let merged = ancestor.checked_add(delta_sum).ok_or_else(|| {
+                malformed(format!(
+                    "counter merge overflow for column '{}'",
+                    column.name_str()
+                ))
+            })?;
+
+            Ok((Value::Integer(merged), latest_contributor))
+        }
+        None => {
+            let mut latest_changed: Option<&StoredRowBatch> = None;
+            let mut merged_value = ancestor_value.clone();
+
+            for contender in contenders {
+                if latest_changed
+                    .map(|current| {
+                        (contender.row.updated_at, contender.row.batch_id())
+                            > (current.updated_at, current.batch_id())
+                    })
+                    .unwrap_or(true)
+                {
+                    latest_changed = Some(contender.row);
+                    merged_value = contender.value.clone();
+                }
+            }
+
+            Ok((merged_value, latest_changed))
+        }
+    }
+}
+
 fn assign_winner_ordinals(
     winner_batch_ids: Option<&[BatchId]>,
     winner_batch_pool: &mut Vec<BatchId>,
@@ -1715,24 +1808,22 @@ fn build_computed_visible_preview(
 
     for column_index in 0..user_descriptor.columns.len() {
         let ancestor_value = ancestor_values[column_index].clone();
-        let mut best_changed: Option<&StoredRowBatch> = None;
-        let mut best_value = ancestor_value.clone();
-
-        for (row, row_values) in frontier.iter().zip(frontier_values.iter()) {
-            let candidate_value = row_values[column_index].clone();
-            if candidate_value == ancestor_value {
-                continue;
-            }
-            if best_changed
-                .map(|current| {
-                    (row.updated_at, row.batch_id()) > (current.updated_at, current.batch_id())
+        let changed_contenders = frontier
+            .iter()
+            .zip(frontier_values.iter())
+            .filter_map(|(row, row_values)| {
+                let candidate_value = &row_values[column_index];
+                (candidate_value != &ancestor_value).then_some(ColumnContender {
+                    row,
+                    value: candidate_value,
                 })
-                .unwrap_or(true)
-            {
-                best_changed = Some(*row);
-                best_value = candidate_value;
-            }
-        }
+            })
+            .collect::<Vec<_>>();
+        let (best_value, best_changed) = merge_column_with_strategy(
+            &user_descriptor.columns[column_index],
+            &ancestor_value,
+            &changed_contenders,
+        )?;
 
         merged_values.push(best_value);
         let winner_row = best_changed.or(ancestor).unwrap_or(latest_tip);
@@ -2458,6 +2549,184 @@ mod tests {
     }
 
     #[test]
+    fn visible_row_entry_applies_counter_merge_strategy_per_column() {
+        let descriptor = counter_descriptor();
+        let base = StoredRowBatch::new(
+            ObjectId::new(),
+            "main",
+            Vec::new(),
+            encode_row(
+                &descriptor,
+                &[Value::Text("task".into()), Value::Integer(5)],
+            )
+            .unwrap(),
+            RowProvenance::for_insert("alice".to_string(), 10),
+            HashMap::new(),
+            RowState::VisibleDirect,
+            Some(DurabilityTier::Local),
+        );
+        let left = StoredRowBatch::new(
+            base.row_id,
+            "main",
+            vec![base.batch_id()],
+            encode_row(
+                &descriptor,
+                &[Value::Text("alice-title".into()), Value::Integer(7)],
+            )
+            .unwrap(),
+            RowProvenance::for_update(&base.row_provenance(), "alice".to_string(), 20),
+            HashMap::new(),
+            RowState::VisibleDirect,
+            Some(DurabilityTier::Local),
+        );
+        let right = StoredRowBatch::new(
+            base.row_id,
+            "main",
+            vec![base.batch_id()],
+            encode_row(
+                &descriptor,
+                &[Value::Text("task".into()), Value::Integer(4)],
+            )
+            .unwrap(),
+            RowProvenance::for_update(&base.row_provenance(), "bob".to_string(), 21),
+            HashMap::new(),
+            RowState::VisibleDirect,
+            Some(DurabilityTier::Local),
+        );
+
+        let entry = VisibleRowEntry::rebuild_with_descriptor(
+            &descriptor,
+            &[base, left.clone(), right.clone()],
+        )
+        .unwrap()
+        .expect("merged visible entry");
+
+        assert_eq!(
+            decode_row(&descriptor, &entry.current_row.data).unwrap(),
+            vec![Value::Text("alice-title".into()), Value::Integer(6)]
+        );
+        assert_eq!(entry.current_row.batch_id(), right.batch_id());
+        assert_eq!(entry.current_row.updated_by.as_str(), "bob");
+        assert_eq!(
+            entry.branch_frontier,
+            vec![left.batch_id(), right.batch_id()]
+        );
+        assert_eq!(
+            entry.winner_batch_pool,
+            vec![left.batch_id(), right.batch_id()]
+        );
+        assert_eq!(entry.current_winner_ordinals, Some(vec![0, 1]));
+    }
+
+    #[test]
+    fn visible_row_entry_uses_consumer_schema_merge_strategy() {
+        let counter_descriptor = counter_descriptor();
+        let lww_descriptor = lww_integer_descriptor();
+        let base = StoredRowBatch::new(
+            ObjectId::new(),
+            "main",
+            Vec::new(),
+            encode_row(
+                &counter_descriptor,
+                &[Value::Text("task".into()), Value::Integer(5)],
+            )
+            .unwrap(),
+            RowProvenance::for_insert("alice".to_string(), 10),
+            HashMap::new(),
+            RowState::VisibleDirect,
+            Some(DurabilityTier::Local),
+        );
+        let left = StoredRowBatch::new(
+            base.row_id,
+            "main",
+            vec![base.batch_id()],
+            encode_row(
+                &counter_descriptor,
+                &[Value::Text("alice-title".into()), Value::Integer(7)],
+            )
+            .unwrap(),
+            RowProvenance::for_update(&base.row_provenance(), "alice".to_string(), 20),
+            HashMap::new(),
+            RowState::VisibleDirect,
+            Some(DurabilityTier::Local),
+        );
+        let right = StoredRowBatch::new(
+            base.row_id,
+            "main",
+            vec![base.batch_id()],
+            encode_row(
+                &counter_descriptor,
+                &[Value::Text("task".into()), Value::Integer(4)],
+            )
+            .unwrap(),
+            RowProvenance::for_update(&base.row_provenance(), "bob".to_string(), 21),
+            HashMap::new(),
+            RowState::VisibleDirect,
+            Some(DurabilityTier::Local),
+        );
+        let history = vec![base, left, right];
+
+        let counter_entry = VisibleRowEntry::rebuild_with_descriptor(&counter_descriptor, &history)
+            .unwrap()
+            .expect("counter merged visible entry");
+        let lww_entry = VisibleRowEntry::rebuild_with_descriptor(&lww_descriptor, &history)
+            .unwrap()
+            .expect("lww merged visible entry");
+
+        assert_eq!(
+            decode_row(&counter_descriptor, &counter_entry.current_row.data).unwrap(),
+            vec![Value::Text("alice-title".into()), Value::Integer(6)]
+        );
+        assert_eq!(
+            decode_row(&lww_descriptor, &lww_entry.current_row.data).unwrap(),
+            vec![Value::Text("alice-title".into()), Value::Integer(4)]
+        );
+    }
+
+    #[test]
+    fn visible_row_entry_errors_when_counter_merge_overflows() {
+        let descriptor = counter_only_descriptor();
+        let base = StoredRowBatch::new(
+            ObjectId::new(),
+            "main",
+            Vec::new(),
+            encode_row(&descriptor, &[Value::Integer(i32::MAX - 1)]).unwrap(),
+            RowProvenance::for_insert("alice".to_string(), 10),
+            HashMap::new(),
+            RowState::VisibleDirect,
+            Some(DurabilityTier::Local),
+        );
+        let left = StoredRowBatch::new(
+            base.row_id,
+            "main",
+            vec![base.batch_id()],
+            encode_row(&descriptor, &[Value::Integer(i32::MAX)]).unwrap(),
+            RowProvenance::for_update(&base.row_provenance(), "alice".to_string(), 20),
+            HashMap::new(),
+            RowState::VisibleDirect,
+            Some(DurabilityTier::Local),
+        );
+        let right = StoredRowBatch::new(
+            base.row_id,
+            "main",
+            vec![base.batch_id()],
+            encode_row(&descriptor, &[Value::Integer(i32::MAX)]).unwrap(),
+            RowProvenance::for_update(&base.row_provenance(), "bob".to_string(), 21),
+            HashMap::new(),
+            RowState::VisibleDirect,
+            Some(DurabilityTier::Local),
+        );
+
+        let error = VisibleRowEntry::rebuild_with_descriptor(&descriptor, &[base, left, right])
+            .expect_err("counter overflow should fail");
+
+        assert!(
+            error.to_string().contains("overflow"),
+            "expected overflow error, got {error}"
+        );
+    }
+
+    #[test]
     fn visible_row_entry_merges_accepted_transactional_rows_but_ignores_staging_and_rejected_rows()
     {
         let descriptor = user_descriptor();
@@ -2813,6 +3082,28 @@ mod tests {
         RowDescriptor::new(vec![
             ColumnDescriptor::new("title", ColumnType::Text),
             ColumnDescriptor::new("done", ColumnType::Boolean),
+        ])
+    }
+
+    fn lww_integer_descriptor() -> RowDescriptor {
+        RowDescriptor::new(vec![
+            ColumnDescriptor::new("title", ColumnType::Text),
+            ColumnDescriptor::new("count", ColumnType::Integer),
+        ])
+    }
+
+    fn counter_descriptor() -> RowDescriptor {
+        RowDescriptor::new(vec![
+            ColumnDescriptor::new("title", ColumnType::Text),
+            ColumnDescriptor::new("count", ColumnType::Integer)
+                .merge_strategy(ColumnMergeStrategy::Counter),
+        ])
+    }
+
+    fn counter_only_descriptor() -> RowDescriptor {
+        RowDescriptor::new(vec![
+            ColumnDescriptor::new("count", ColumnType::Integer)
+                .merge_strategy(ColumnMergeStrategy::Counter),
         ])
     }
 

--- a/crates/jazz-tools/src/schema_manager/encoding.rs
+++ b/crates/jazz-tools/src/schema_manager/encoding.rs
@@ -10,14 +10,14 @@ use std::collections::HashMap;
 use crate::object::ObjectId;
 use crate::query_manager::policy::{CmpOp, Operation, PolicyExpr, PolicyValue};
 use crate::query_manager::types::{
-    ColumnDescriptor, ColumnName, ColumnType, RowDescriptor, Schema, SchemaHash, TableName,
-    TablePolicies, TableSchema, Value,
+    ColumnDescriptor, ColumnMergeStrategy, ColumnName, ColumnType, RowDescriptor, Schema,
+    SchemaHash, TableName, TablePolicies, TableSchema, Value,
 };
 
 use super::lens::{LensOp, LensTransform};
 
 /// Current encoding version.
-const SCHEMA_VERSION: u8 = SchemaEncodingVersion::V4 as u8;
+const SCHEMA_VERSION: u8 = SchemaEncodingVersion::V5 as u8;
 const LENS_VERSION: u8 = 2;
 const PERMISSIONS_VERSION: u8 = 1;
 const PERMISSIONS_BUNDLE_VERSION: u8 = 2;
@@ -34,6 +34,8 @@ enum SchemaEncodingVersion {
     V3 = 3,
     // v4 schemas include column defaults.
     V4 = 4,
+    // v5 schemas include column merge strategies.
+    V5 = 5,
 }
 
 impl SchemaEncodingVersion {
@@ -43,6 +45,7 @@ impl SchemaEncodingVersion {
             2 => Some(Self::V2),
             3 => Some(Self::V3),
             4 => Some(Self::V4),
+            5 => Some(Self::V5),
             _ => None,
         }
     }
@@ -56,7 +59,11 @@ impl SchemaEncodingVersion {
     }
 
     fn has_column_defaults(self) -> bool {
-        matches!(self, Self::V4)
+        matches!(self, Self::V4 | Self::V5)
+    }
+
+    fn has_column_merge_strategies(self) -> bool {
+        matches!(self, Self::V5)
     }
 }
 
@@ -114,7 +121,7 @@ impl std::error::Error for CatalogueEncodingError {}
 /// table is preserved exactly as declared.
 pub fn encode_schema(schema: &Schema) -> Vec<u8> {
     let mut buf = Vec::new();
-    let version = SchemaEncodingVersion::V4;
+    let version = SchemaEncodingVersion::V5;
     buf.push(version as u8);
 
     // Sort tables by name for deterministic ordering
@@ -261,6 +268,15 @@ fn encode_column_descriptor_with_version(
             None => buf.push(0),
         }
     }
+    if version.has_column_merge_strategies() {
+        match col.merge_strategy {
+            Some(ColumnMergeStrategy::Counter) => {
+                buf.push(1);
+                buf.push(1);
+            }
+            None => buf.push(0),
+        }
+    }
 }
 
 fn decode_column_descriptor_with_version(
@@ -290,6 +306,24 @@ fn decode_column_descriptor_with_version(
     } else {
         None
     };
+    let merge_strategy = if version.has_column_merge_strategies() {
+        let has_merge_strategy = read_u8(data, offset)? != 0;
+        if has_merge_strategy {
+            match read_u8(data, offset)? {
+                1 => Some(ColumnMergeStrategy::Counter),
+                tag => {
+                    return Err(CatalogueEncodingError::InvalidTypeTag {
+                        tag,
+                        context: "column_merge_strategy",
+                    });
+                }
+            }
+        } else {
+            None
+        }
+    } else {
+        None
+    };
 
     Ok(ColumnDescriptor {
         name: ColumnName::new(name),
@@ -297,6 +331,7 @@ fn decode_column_descriptor_with_version(
         nullable,
         references,
         default,
+        merge_strategy,
     })
 }
 
@@ -1881,6 +1916,27 @@ mod tests {
             docs.columns.column("raw_payload").unwrap().column_type,
             ColumnType::Json { schema: None }
         );
+    }
+
+    #[test]
+    fn schema_roundtrip_preserves_column_merge_strategy() {
+        let mut schema = Schema::new();
+        schema.insert(
+            TableName::new("counters"),
+            TableSchema::new(RowDescriptor::new(vec![
+                ColumnDescriptor::new("value", ColumnType::Integer)
+                    .merge_strategy(ColumnMergeStrategy::Counter),
+            ])),
+        );
+
+        let encoded = encode_schema(&schema);
+        let decoded = decode_schema(&encoded).unwrap();
+        let table = decoded
+            .get(&TableName::new("counters"))
+            .expect("decoded counters table");
+        let column = table.columns.column("value").expect("counter column");
+
+        assert_eq!(column.merge_strategy, Some(ColumnMergeStrategy::Counter));
     }
 
     #[test]

--- a/crates/jazz-tools/src/storage/mod.rs
+++ b/crates/jazz-tools/src/storage/mod.rs
@@ -120,7 +120,7 @@ const BRANCH_ORD_NEXT_ORD_KEY: &str = "next_ord";
 pub(crate) const STORE_MANIFEST_KEY: &str = "__jazz_store_manifest";
 const STORE_MANIFEST_MAGIC: &[u8; 10] = b"JAZZSTORE1";
 const STORE_FORMAT_V3: i32 = 3;
-const ROW_STORAGE_FORMAT_V2: i32 = 2;
+const ROW_STORAGE_FORMAT_V3: i32 = 3;
 const ROW_LOCATOR_STORAGE_FORMAT_V1: i32 = 1;
 const EXACT_ROW_TABLE_LOCATOR_STORAGE_FORMAT_V1: i32 = 1;
 const CATALOGUE_STORAGE_FORMAT_V1: i32 = 1;
@@ -260,7 +260,7 @@ impl RawTableHeader {
         let table_name: SharedString = table_name.into().into();
         Self {
             storage_kind: kind.storage_kind().into(),
-            storage_format_version: ROW_STORAGE_FORMAT_V2,
+            storage_format_version: ROW_STORAGE_FORMAT_V3,
             logical_table_name: Some(table_name),
             schema_hash: Some(schema_hash),
             row_descriptor_bytes: Some(
@@ -959,7 +959,7 @@ fn supported_storage_format_version(storage_kind: &str) -> Result<i32, StorageEr
         STORAGE_KIND_SEALED_BATCH_SUBMISSION => Ok(SEALED_BATCH_SUBMISSION_FORMAT_V2),
         STORAGE_KIND_AUTHORITATIVE_BATCH_SETTLEMENT => Ok(AUTHORITATIVE_BATCH_SETTLEMENT_FORMAT_V2),
         STORAGE_KIND_CATALOGUE => Ok(CATALOGUE_STORAGE_FORMAT_V1),
-        "visible_rows" | "row_history" => Ok(ROW_STORAGE_FORMAT_V2),
+        "visible_rows" | "row_history" => Ok(ROW_STORAGE_FORMAT_V3),
         other => Err(StorageError::IoError(format!(
             "unknown raw table header storage_kind '{other}'"
         ))),

--- a/packages/jazz-tools/src/cli.test.ts
+++ b/packages/jazz-tools/src/cli.test.ts
@@ -349,6 +349,21 @@ function storedRootSchemaWithReorderedColumns() {
   };
 }
 
+function storedCounterSchema() {
+  return {
+    counters: {
+      columns: [
+        {
+          name: "value",
+          column_type: { type: "Integer" },
+          nullable: false,
+          merge_strategy: "Counter",
+        },
+      ],
+    },
+  };
+}
+
 function storedSchemaResponse(
   schema: object,
   publishedAt: number | null = null,
@@ -766,6 +781,118 @@ describe("cli migrations", () => {
     expect(logs).toContain(
       "No reviewed migration file needed because this schema change does not require row transformations.",
     );
+  });
+
+  it("skips creating a migration file for merge-strategy-only schema changes", async () => {
+    const { root } = await createWorkspace();
+    const migrationsDir = join(root, "migrations");
+    const fromHash = "2121212121212121212121212121212121212121212121212121212121212121";
+    const toHash = "3131313131313131313131313131313131313131313131313131313131313131";
+
+    const fetchMock = vi.fn(async (input: string) => {
+      if (input.endsWith("/schemas")) {
+        return new Response(JSON.stringify({ hashes: [fromHash, toHash] }), { status: 200 });
+      }
+
+      if (input.endsWith(`/schema/${fromHash}`)) {
+        return storedSchemaResponse({
+          counters: {
+            columns: [{ name: "value", column_type: { type: "Integer" }, nullable: false }],
+          },
+        });
+      }
+
+      if (input.endsWith(`/schema/${toHash}`)) {
+        return storedSchemaResponse(storedCounterSchema());
+      }
+
+      throw new Error(`Unexpected fetch: ${input}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, logs } = await captureConsoleLogs(() =>
+      createMigration({
+        schemaDir: root,
+        serverUrl: "http://localhost:1625",
+        adminSecret: "admin-secret",
+        migrationsDir,
+        fromHash: fromHash.slice(0, 12),
+        toHash: toHash.slice(0, 12),
+      }),
+    );
+
+    expect(result).toBeNull();
+    expect((await readdir(migrationsDir)).filter((name) => name.endsWith(".ts"))).toHaveLength(0);
+    expect(logs).toContain(
+      "No reviewed migration file needed because this schema change does not require row transformations.",
+    );
+  });
+
+  it("preserves merge strategy markers in generated migration schema witnesses", async () => {
+    const { root } = await createWorkspace();
+    const migrationsDir = join(root, "migrations");
+    const fromHash = "4141414141414141414141414141414141414141414141414141414141414141";
+    const toHash = "5151515151515151515151515151515151515151515151515151515151515151";
+
+    const fetchMock = vi.fn(async (input: string) => {
+      if (input.endsWith("/schemas")) {
+        return new Response(JSON.stringify({ hashes: [fromHash, toHash] }), { status: 200 });
+      }
+
+      if (input.endsWith(`/schema/${fromHash}`)) {
+        return storedSchemaResponse({
+          counters: {
+            columns: [
+              {
+                name: "value",
+                column_type: { type: "Integer" },
+                nullable: false,
+                merge_strategy: "Counter",
+              },
+              { name: "label", column_type: { type: "Text" }, nullable: false },
+            ],
+          },
+        });
+      }
+
+      if (input.endsWith(`/schema/${toHash}`)) {
+        return storedSchemaResponse({
+          counters: {
+            columns: [
+              {
+                name: "value",
+                column_type: { type: "Integer" },
+                nullable: false,
+                merge_strategy: "Counter",
+              },
+              { name: "label", column_type: { type: "Text" }, nullable: true },
+            ],
+          },
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${input}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result: filePath } = await captureConsoleLogs(() =>
+      createMigration({
+        schemaDir: root,
+        serverUrl: "http://localhost:1625",
+        adminSecret: "admin-secret",
+        migrationsDir,
+        fromHash: fromHash.slice(0, 12),
+        toHash: toHash.slice(0, 12),
+      }),
+    );
+
+    expect(filePath).not.toBeNull();
+    if (!filePath) {
+      throw new Error("Expected createMigration() to return a migration file path.");
+    }
+
+    const generated = await readFile(filePath, "utf8");
+    expect(generated).toContain('"value": s.int().merge("counter"),');
   });
 
   it("still creates a migration file for nullability-only schema changes", async () => {

--- a/packages/jazz-tools/src/cli.ts
+++ b/packages/jazz-tools/src/cli.ts
@@ -521,6 +521,7 @@ function columnsEqual(left: ColumnDescriptor, right: ColumnDescriptor): boolean 
     left.name === right.name &&
     left.nullable === right.nullable &&
     left.references === right.references &&
+    left.merge_strategy === right.merge_strategy &&
     columnTypeSignature(left.column_type) === columnTypeSignature(right.column_type)
   );
 }
@@ -759,7 +760,11 @@ function baseBuilderExpression(columnType: WasmColumnType, references?: string):
 
 function builderExpressionForColumn(column: ColumnDescriptor): string {
   const base = baseBuilderExpression(column.column_type, column.references);
-  return column.nullable ? `${base}.optional()` : base;
+  const withOptional = column.nullable ? `${base}.optional()` : base;
+  if (column.merge_strategy === "Counter") {
+    return `${withOptional}.merge("counter")`;
+  }
+  return withOptional;
 }
 
 function sqlTypeToWasmColumnType(sqlType: SqlType): WasmColumnType {

--- a/packages/jazz-tools/src/codegen/schema-reader.ts
+++ b/packages/jazz-tools/src/codegen/schema-reader.ts
@@ -85,6 +85,17 @@ function literalToWasmValue(value: unknown): Value {
   throw new Error(`Unsupported policy literal type: ${typeof value}`);
 }
 
+function columnMergeStrategyToWasm(
+  strategy: Schema["tables"][number]["columns"][number]["mergeStrategy"],
+): ColumnDescriptor["merge_strategy"] {
+  switch (strategy) {
+    case undefined:
+      return undefined;
+    case "counter":
+      return "Counter";
+  }
+}
+
 function clonePolicyValue(value: DslPolicyValue): PolicyValue {
   if (value.type === "SessionRef") {
     return { type: "SessionRef", path: [...value.path] };
@@ -224,6 +235,11 @@ export function schemaToWasm(schema: Schema): WasmSchema {
   for (const table of schema.tables) {
     const columns: ColumnDescriptor[] = table.columns.map((col) => {
       const columnType = sqlTypeToWasm(col.sqlType);
+      if (col.mergeStrategy === "counter" && (col.sqlType !== "INTEGER" || col.nullable)) {
+        throw new Error(
+          "Counter merge strategy is only supported on non-nullable INTEGER columns.",
+        );
+      }
       const descriptor: ColumnDescriptor = {
         name: col.name,
         column_type: columnType,
@@ -234,6 +250,9 @@ export function schemaToWasm(schema: Schema): WasmSchema {
       }
       if (col.references) {
         descriptor.references = col.references;
+      }
+      if (col.mergeStrategy) {
+        descriptor.merge_strategy = columnMergeStrategyToWasm(col.mergeStrategy);
       }
       return descriptor;
     });

--- a/packages/jazz-tools/src/drivers/types.ts
+++ b/packages/jazz-tools/src/drivers/types.ts
@@ -74,12 +74,15 @@ export type ColumnType =
   | { type: "Array"; element: ColumnType }
   | { type: "Row"; columns: ColumnDescriptor[] };
 
+export type ColumnMergeStrategy = "Counter";
+
 export interface ColumnDescriptor {
   name: string;
   column_type: ColumnType;
   nullable: boolean;
   default?: Value;
   references?: string;
+  merge_strategy?: ColumnMergeStrategy;
 }
 
 export type PolicyOperation = "Select" | "Insert" | "Update" | "Delete";

--- a/packages/jazz-tools/src/dsl.test.ts
+++ b/packages/jazz-tools/src/dsl.test.ts
@@ -7,6 +7,7 @@ import {
   resetCollectedState,
   table,
 } from "./dsl.js";
+import { schemaToWasm } from "./codegen/schema-reader.js";
 
 describe("enum DSL invariants", () => {
   it("rejects empty variant list", () => {
@@ -119,6 +120,91 @@ describe("schema default DSL", () => {
     col.ref("users").default(123);
     // @ts-expect-error array defaults must match the element type
     col.array(col.int()).default(["1"]);
+  });
+});
+
+describe("column merge strategy DSL", () => {
+  it("stores counter merge strategy on integer columns and exports it to wasm schema", () => {
+    resetCollectedState();
+    table("counters", {
+      value: col.int().merge("counter"),
+      label: col.string(),
+    });
+
+    const schema = getCollectedSchema();
+    expect(schema.tables[0]?.columns).toEqual([
+      {
+        name: "value",
+        sqlType: "INTEGER",
+        nullable: false,
+        mergeStrategy: "counter",
+      },
+      {
+        name: "label",
+        sqlType: "TEXT",
+        nullable: false,
+      },
+    ]);
+
+    expect(schemaToWasm(schema)).toEqual({
+      counters: {
+        columns: [
+          {
+            name: "value",
+            column_type: { type: "Integer" },
+            nullable: false,
+            merge_strategy: "Counter",
+          },
+          {
+            name: "label",
+            column_type: { type: "Text" },
+            nullable: false,
+          },
+        ],
+      },
+    });
+  });
+
+  it("normalizes explicit lww away", () => {
+    resetCollectedState();
+    table("todos", {
+      title: col.string().merge("lww"),
+    });
+
+    const schema = getCollectedSchema();
+    expect(schema.tables[0]?.columns).toEqual([
+      {
+        name: "title",
+        sqlType: "TEXT",
+        nullable: false,
+      },
+    ]);
+    expect(schemaToWasm(schema)).toEqual({
+      todos: {
+        columns: [
+          {
+            name: "title",
+            column_type: { type: "Text" },
+            nullable: false,
+          },
+        ],
+      },
+    });
+  });
+
+  it("rejects counter merge strategy on non-integer columns", () => {
+    expect(() => col.string().merge("counter")).toThrow(
+      "Counter merge strategy is only supported on non-nullable INTEGER columns.",
+    );
+  });
+
+  it("rejects counter merge strategy on nullable integer columns in either chaining order", () => {
+    expect(() => col.int().optional().merge("counter")).toThrow(
+      "Counter merge strategy is only supported on non-nullable INTEGER columns.",
+    );
+    expect(() => col.int().merge("counter").optional()).toThrow(
+      "Counter merge strategy is only supported on non-nullable INTEGER columns.",
+    );
   });
 });
 

--- a/packages/jazz-tools/src/dsl.ts
+++ b/packages/jazz-tools/src/dsl.ts
@@ -3,6 +3,8 @@
 import type { StandardJSONSchemaV1 } from "@standard-schema/spec";
 import type {
   Column,
+  ColumnMergeStrategy,
+  ColumnMergeStrategyName,
   Schema,
   Table,
   SqlType,
@@ -87,10 +89,16 @@ function jsonColumn(schema?: JsonSchemaSource): JsonBuilder {
 interface ColumnBuilder {
   optional(): this;
   default(value: unknown): this;
+  merge(strategy: ColumnMergeStrategyName): this;
   _build(name: string): Column;
   _sqlType: SqlType;
   _references: string | undefined;
 }
+
+type AllowedColumnMergeStrategy<
+  Sql extends SqlType,
+  Optional extends boolean,
+> = Optional extends true ? "lww" : Sql extends "INTEGER" ? ColumnMergeStrategyName : "lww";
 
 export type TypedColumnBuilder<
   Sql extends SqlType = SqlType,
@@ -105,6 +113,9 @@ export type TypedColumnBuilder<
   default(
     value: MaybeOptional<TSTypeFromSqlType<Sql>, Optional>,
   ): ColumnAlias<Sql, Optional, Ref, true>;
+  merge(
+    strategy: AllowedColumnMergeStrategy<Sql, Optional>,
+  ): ColumnAlias<Sql, Optional, Ref, HasDefault>;
   optional(): ColumnAlias<Sql, true, Ref, HasDefault>;
 };
 
@@ -247,13 +258,31 @@ function validateReferenceColumnName(name: string, builder: ColumnBuilder): void
   }
 }
 
+function normalizeColumnMergeStrategy(
+  strategy: ColumnMergeStrategyName,
+  sqlType: SqlType,
+  nullable: boolean,
+): ColumnMergeStrategy | undefined {
+  if (strategy === "lww") {
+    return undefined;
+  }
+  if (sqlType !== "INTEGER" || nullable) {
+    throw new Error("Counter merge strategy is only supported on non-nullable INTEGER columns.");
+  }
+  return "counter";
+}
+
 class ScalarBuilder implements ColumnBuilder {
   private _nullable = false;
   private _default: unknown = undefined;
+  private _mergeStrategy: ColumnMergeStrategy | undefined;
 
   constructor(public _sqlType: ScalarSqlType) {}
 
   optional(): this {
+    if (this._mergeStrategy === "counter") {
+      throw new Error("Counter merge strategy is only supported on non-nullable INTEGER columns.");
+    }
     this._nullable = true;
     return this;
   }
@@ -263,12 +292,18 @@ class ScalarBuilder implements ColumnBuilder {
     return this;
   }
 
+  merge(strategy: ColumnMergeStrategyName): this {
+    this._mergeStrategy = normalizeColumnMergeStrategy(strategy, this._sqlType, this._nullable);
+    return this;
+  }
+
   _build(name: string): Column {
     return {
       name,
       sqlType: this._sqlType,
       nullable: this._nullable,
       ...(this._default === undefined ? {} : { default: this._default }),
+      ...(this._mergeStrategy === undefined ? {} : { mergeStrategy: this._mergeStrategy }),
     };
   }
 
@@ -280,6 +315,7 @@ class ScalarBuilder implements ColumnBuilder {
 class EnumBuilder implements ColumnBuilder {
   private _nullable = false;
   private _default: unknown = undefined;
+  private _mergeStrategy: ColumnMergeStrategy | undefined;
   public _sqlType: EnumSqlType;
 
   constructor(...variants: string[]) {
@@ -287,6 +323,9 @@ class EnumBuilder implements ColumnBuilder {
   }
 
   optional(): this {
+    if (this._mergeStrategy === "counter") {
+      throw new Error("Counter merge strategy is only supported on non-nullable INTEGER columns.");
+    }
     this._nullable = true;
     return this;
   }
@@ -296,12 +335,18 @@ class EnumBuilder implements ColumnBuilder {
     return this;
   }
 
+  merge(strategy: ColumnMergeStrategyName): this {
+    this._mergeStrategy = normalizeColumnMergeStrategy(strategy, this._sqlType, this._nullable);
+    return this;
+  }
+
   _build(name: string): Column {
     return {
       name,
       sqlType: this._sqlType,
       nullable: this._nullable,
       ...(this._default === undefined ? {} : { default: this._default }),
+      ...(this._mergeStrategy === undefined ? {} : { mergeStrategy: this._mergeStrategy }),
     };
   }
 
@@ -313,6 +358,7 @@ class EnumBuilder implements ColumnBuilder {
 class JsonBuilder<Output = JsonValue> implements ColumnBuilder {
   private _nullable = false;
   private _default: unknown = undefined;
+  private _mergeStrategy: ColumnMergeStrategy | undefined;
   public _sqlType: JsonSqlType<Output>;
 
   constructor(schema?: JsonSchemaSource<Output>) {
@@ -322,6 +368,9 @@ class JsonBuilder<Output = JsonValue> implements ColumnBuilder {
   }
 
   optional(): this {
+    if (this._mergeStrategy === "counter") {
+      throw new Error("Counter merge strategy is only supported on non-nullable INTEGER columns.");
+    }
     this._nullable = true;
     return this;
   }
@@ -331,12 +380,18 @@ class JsonBuilder<Output = JsonValue> implements ColumnBuilder {
     return this;
   }
 
+  merge(strategy: ColumnMergeStrategyName): this {
+    this._mergeStrategy = normalizeColumnMergeStrategy(strategy, this._sqlType, this._nullable);
+    return this;
+  }
+
   _build(name: string): Column {
     return {
       name,
       sqlType: this._sqlType,
       nullable: this._nullable,
       ...(this._default === undefined ? {} : { default: this._default }),
+      ...(this._mergeStrategy === undefined ? {} : { mergeStrategy: this._mergeStrategy }),
     };
   }
 
@@ -352,10 +407,14 @@ class JsonBuilder<Output = JsonValue> implements ColumnBuilder {
 class RefBuilder implements ColumnBuilder {
   private _nullable = false;
   private _default: unknown = undefined;
+  private _mergeStrategy: ColumnMergeStrategy | undefined;
 
   constructor(private _targetTable: string) {}
 
   optional(): this {
+    if (this._mergeStrategy === "counter") {
+      throw new Error("Counter merge strategy is only supported on non-nullable INTEGER columns.");
+    }
     this._nullable = true;
     return this;
   }
@@ -365,12 +424,18 @@ class RefBuilder implements ColumnBuilder {
     return this;
   }
 
+  merge(strategy: ColumnMergeStrategyName): this {
+    this._mergeStrategy = normalizeColumnMergeStrategy(strategy, this._sqlType, this._nullable);
+    return this;
+  }
+
   _build(name: string): Column {
     return {
       name,
       sqlType: this._sqlType,
       nullable: this._nullable,
       ...(this._default === undefined ? {} : { default: this._default }),
+      ...(this._mergeStrategy === undefined ? {} : { mergeStrategy: this._mergeStrategy }),
       references: this._references,
     };
   }
@@ -387,10 +452,14 @@ class RefBuilder implements ColumnBuilder {
 class ArrayBuilder<T extends ColumnBuilder> implements ColumnBuilder {
   private _nullable = false;
   private _default: unknown = undefined;
+  private _mergeStrategy: ColumnMergeStrategy | undefined;
 
   constructor(public _element: T) {}
 
   optional(): this {
+    if (this._mergeStrategy === "counter") {
+      throw new Error("Counter merge strategy is only supported on non-nullable INTEGER columns.");
+    }
     this._nullable = true;
     return this;
   }
@@ -400,12 +469,18 @@ class ArrayBuilder<T extends ColumnBuilder> implements ColumnBuilder {
     return this;
   }
 
+  merge(strategy: ColumnMergeStrategyName): this {
+    this._mergeStrategy = normalizeColumnMergeStrategy(strategy, this._sqlType, this._nullable);
+    return this;
+  }
+
   _build(name: string): Column {
     return {
       name,
       sqlType: this._sqlType,
       nullable: this._nullable,
       ...(this._default === undefined ? {} : { default: this._default }),
+      ...(this._mergeStrategy === undefined ? {} : { mergeStrategy: this._mergeStrategy }),
       references: this._references,
     };
   }

--- a/packages/jazz-tools/src/index.ts
+++ b/packages/jazz-tools/src/index.ts
@@ -42,6 +42,8 @@ export type {
   Schema as SchemaAst,
   Table as SchemaAstTable,
   Column,
+  ColumnMergeStrategy,
+  ColumnMergeStrategyName,
   JsonSqlType,
   PolicyExpr,
   PolicyOperation,

--- a/packages/jazz-tools/src/schema.ts
+++ b/packages/jazz-tools/src/schema.ts
@@ -34,6 +34,8 @@ export interface JsonSqlType<Output = JsonValue> {
   __output?: Output;
 }
 export type SqlType = ScalarSqlType | ArraySqlType | EnumSqlType | JsonSqlType<unknown>;
+export type ColumnMergeStrategy = "counter";
+export type ColumnMergeStrategyName = ColumnMergeStrategy | "lww";
 
 export function sqlTypeToString(sqlType: SqlType): string {
   if (typeof sqlType === "string") {
@@ -84,6 +86,7 @@ export interface Column {
   nullable: boolean;
   default?: unknown;
   references?: string; // Target table name for foreign key
+  mergeStrategy?: ColumnMergeStrategy;
 }
 
 export type PolicyOperation = "Select" | "Insert" | "Update" | "Delete";

--- a/specs/status-quo/batches.md
+++ b/specs/status-quo/batches.md
@@ -42,6 +42,8 @@ The two modes are:
 - Transactional batches use the same `BatchId` for staging members, accepted visible members, replayable settlements, and public handles.
 - Visible resolution only merges visible rows. Staged or rejected transactional batches never
   participate in visible merges.
+- Merge strategy is schema metadata, not batch metadata. The same stored conflicting history can
+  therefore resolve differently under different schema versions.
 
 ## Durable Storage Format
 
@@ -169,6 +171,11 @@ default head and persists compact provenance alongside it:
 
 Lower-tier reads can reconstruct merged previews from that visible-row sidecar without walking the
 entire row history.
+
+The sidecar keeps only one provenance pointer per user column:
+
+- it names the latest timestamp-ordered batch that contributed to that column's resolved value
+- it does not try to encode every contributing batch for additive strategies such as counters
 
 ### Batch bookkeeping tables
 

--- a/specs/status-quo/batches.md
+++ b/specs/status-quo/batches.md
@@ -168,6 +168,7 @@ default head and persists compact provenance alongside it:
 - a batch-id pool containing only the rows that actually won at least one visible column
 - one packed ordinal vector for the default merged preview when it is synthetic
 - packed tier override ordinal vectors only for tiers whose preview differs from the default one
+- one reserved opaque merge-artifacts slot for future conflict diagnostics
 
 Lower-tier reads can reconstruct merged previews from that visible-row sidecar without walking the
 entire row history.
@@ -176,6 +177,11 @@ The sidecar keeps only one provenance pointer per user column:
 
 - it names the latest timestamp-ordered batch that contributed to that column's resolved value
 - it does not try to encode every contributing batch for additive strategies such as counters
+
+That reserved merge-artifacts slot is intentionally looser:
+
+- it is engine-owned and versioned as an opaque blob
+- it is currently left empty in the released per-column `lww` and `counter` implementation
 
 ### Batch bookkeeping tables
 

--- a/specs/status-quo/row_histories.md
+++ b/specs/status-quo/row_histories.md
@@ -82,6 +82,7 @@ visible body for the default head, plus:
 - a compact pool of contributing winner batch ids
 - one packed ordinal vector for the default merged preview when it is synthetic
 - extra packed ordinal vectors only for tiers whose preview differs from the default head
+- a reserved opaque merge-artifacts blob for future merge diagnostics and related sidecar metadata
 
 The visible-row format now also keeps the common case compact by treating some fields as implicit:
 
@@ -119,6 +120,14 @@ metadata stays coarse on purpose:
 
 Exact per-column provenance is carried in that visible-entry sidecar rather than expanded into the
 public row shape.
+
+The visible entry also reserves one engine-owned `_jazz_merge_artifacts` slot:
+
+- it lives only on visible rows, never on history rows
+- `null` means "no merge artifacts"
+- non-`null` bytes are a versioned opaque envelope owned by the engine
+- the current release keeps this slot empty while stabilizing the storage format for future
+  conflict diagnostics
 
 For history rows, the identity now lives in the raw-table-local storage key rather than the payload
 columns. For visible rows, `(branch_name, row_id)` comes from the raw-table-local key and the

--- a/specs/status-quo/row_histories.md
+++ b/specs/status-quo/row_histories.md
@@ -144,9 +144,30 @@ For concurrent frontiers, step 2 now does an explicit MRCA-relative merge:
 
 - pick the latest common ancestor of the current frontier
 - compare each frontier tip against that ancestor
-- for each user column, choose the latest tip whose value differs from the ancestor value
+- for each user column, apply that column's schema-declared merge strategy to the set of
+  frontier tips whose value differs from the ancestor value
 - if no frontier tip changed that column, attribute the winner to the ancestor itself
 - deletes win over updates; two soft deletes keep a soft-deleted merged body
+
+The current column merge strategies are:
+
+- implicit `lww` for all columns
+- explicit `counter` for non-nullable integer columns
+
+`lww` keeps the existing MRCA-relative "latest changed tip wins" behavior.
+
+`counter` treats each conflicting snapshot as a delta from the MRCA value:
+
+- compute `tip_value - ancestor_value` for each changed frontier tip
+- sum those deltas
+- apply the sum to the ancestor value
+- raise an error if checked integer arithmetic overflows
+
+The visible-entry sidecar intentionally stays coarse even for non-`lww` strategies:
+
+- each visible column still records only the latest timestamp-ordered batch that contributed to
+  that column's resolved value
+- readers that want deeper provenance must walk row history directly
 
 That work produces an `ApplyRowBatchResult`, including any `RowVisibilityChange` that downstream
 systems care about.
@@ -168,6 +189,13 @@ Two exclusion rules matter for merge behavior:
 - accepted transactional rows can participate in visible-row merges just like direct rows
 - conflicted transactional batches never participate in merging anywhere; rejected or still-staged
   rows do not affect merge previews, merge-on-write bases, or tier-specific visible resolution
+
+Merge strategy selection is schema-relative rather than history-relative:
+
+- row history stores the original snapshots only
+- the consumer's current schema decides which merge strategy applies to each visible column
+- after a schema change, old-schema consumers may resolve the same conflicting history differently
+  from new-schema consumers, and that is expected
 
 ## Why Visible Entries Exist
 

--- a/specs/status-quo/schema_files.md
+++ b/specs/status-quo/schema_files.md
@@ -20,6 +20,28 @@ app-root/
   explicit row-policy grants only.
 - `migrations/*.ts` contains reviewed migration modules.
 
+Column definitions may also carry schema-level merge metadata. The current DSL shape is:
+
+```typescript
+import { schema as s } from "jazz-tools";
+
+export const schema = s.schema({
+  counters: s.table({
+    name: s.string(),
+    value: s.int().merge("counter"),
+  }),
+});
+```
+
+Current merge-strategy rules:
+
+- merge strategy is declared per column in `schema.ts`
+- omitted means implicit `lww`
+- `counter` is currently valid only on non-nullable integer columns
+- changing a column's merge strategy is allowed across schema versions
+- the new strategy applies only to consumers of the new schema; older schema consumers keep using
+  their own version's rule when resolving conflicting history
+
 ## `jazz-tools validate`
 
 `jazz-tools validate` compiles the schema into the runtime `wasmSchema` form to
@@ -47,6 +69,10 @@ The current mental model is:
 - `jazz-tools migrations create --fromHash <fromHash> --toHash <toHash>` pulls two stored structural schemas and writes a typed migration stub into `migrations/`
 - the developer reviews and edits that file
 - `jazz-tools migrations push <fromHash> <toHash>` publishes the reviewed migration edge back to the server
+
+Merge-strategy-only schema changes count as structural schema changes for hashing and migration
+generation, but they do not require row transforms because they reinterpret future conflict
+resolution rather than rewriting stored row payloads.
 
 Generated migrations use `defineMigration(...)` and carry:
 


### PR DESCRIPTION
## Summary

This adds schema-level per-column merge strategies to `jazz-tools`, along with a changeset for the SDK surface and a reserved visible-row storage slot for future merge diagnostics.

## What changed

- adds DSL/schema support for per-column merge metadata via `s.int().merge("counter")`
- keeps MRCA-relative per-column LWW as the implicit default when no strategy is declared
- adds a first custom strategy, `counter`, for non-nullable integer columns
- wires merge strategy through TS schema export, Rust schema descriptors, schema hashing, schema catalogue encoding, and migration witness generation
- updates visible-row conflict resolution to dispatch per-column merge behavior from the consumer schema
- reserves `_jazz_merge_artifacts` on visible rows as an opaque future-facing slot for merge diagnostics and related sidecar metadata
- bumps the visible/history row raw-table storage format version to account for that stabilized physical layout
- adds red-then-green coverage for DSL validation, schema hashing/roundtrip, CLI migration behavior, MRCA merge semantics, and visible-row sidecar roundtrips

## Design

The new design treats merge strategy as schema metadata rather than row-history metadata.

That means we still store ordinary full-row snapshots in history, but when we resolve a conflicting frontier we first view those snapshots through the consumer's schema and then apply that schema's merge strategy per column. Different schema versions can therefore resolve the same conflicting history differently without rewriting stored rows.

For now there are two behaviors:

- implicit `lww`: pick the latest frontier value that differs from the MRCA for that column
- explicit `counter`: reinterpret each conflicting integer snapshot as an MRCA-relative delta and sum those deltas with checked overflow

The visible-row provenance sidecar stays intentionally coarse: it still records only the latest timestamp-ordered batch that contributed to each visible column.

To keep the storage format stable for the next step, visible rows now also reserve `_jazz_merge_artifacts` as a nullable opaque blob. This release intentionally leaves it empty; it is just the slot we can later use for schema-relative merge diagnostics without changing history rows again.

## Validation

- `pnpm --filter jazz-tools exec vitest run src/dsl.test.ts src/cli.test.ts`
- `pnpm --filter jazz-tools build`
- `cargo fmt --all --check`
- `cargo test -p jazz-tools --lib`