### PR TITLE
[codex] require transactions for selected tables

### DIFF
--- a/.changeset/transaction-required-tables.md
+++ b/.changeset/transaction-required-tables.md
@@ -1,0 +1,7 @@
+---
+"jazz-tools": patch
+---
+
+Add schema support for transaction-required tables in `jazz-tools`.
+
+You can now mark a table as requiring transactional writes with either `defineTable(...).requireTransaction()` or `table(..., columns, { requiresTransaction: true })`. When a table is marked this way, direct writes like `db.insert(...)`, `db.update(...)`, `db.delete(...)`, and direct batches now fail immediately with a clear error, while transactional writes continue to work normally. Non-transactional tables are still allowed inside transactions.

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -61,6 +61,10 @@ pub enum QueryError {
         table: TableName,
         operation: Operation,
     },
+    /// Table requires transactional write mode.
+    TransactionRequired {
+        table: TableName,
+    },
     /// Unknown schema hash - client should sync schema first.
     UnknownSchema(SchemaHash),
 }
@@ -94,6 +98,9 @@ impl std::fmt::Display for QueryError {
             QueryError::RowHardDeleted(id) => write!(f, "row hard deleted: {:?}", id),
             QueryError::PolicyDenied { table, operation } => {
                 write!(f, "policy denied {} on table {}", operation, table)
+            }
+            QueryError::TransactionRequired { table } => {
+                write!(f, "table {} requires transactional writes", table)
             }
             QueryError::UnknownSchema(hash) => {
                 write!(
@@ -260,6 +267,7 @@ pub(super) struct WriteTableCacheEntry {
     pub(super) update_check_policy: Option<Arc<PolicyExpr>>,
     pub(super) delete_using_policy: Option<Arc<PolicyExpr>>,
     pub(super) select_policy: Option<Arc<PolicyExpr>>,
+    pub(super) requires_transaction: bool,
 }
 
 /// Server-side query subscription state.

--- a/crates/jazz-tools/src/query_manager/manager_tests.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests.rs
@@ -10433,6 +10433,7 @@ fn e2e_permissions_prevent_sync() {
             ]),
             policies: TablePolicies::new()
                 .with_select(PolicyExpr::eq_session("owner_id", vec!["user_id".into()])),
+            requires_transaction: false,
         },
     );
 
@@ -10521,6 +10522,7 @@ fn e2e_permissions_prevent_new_row_sync() {
             ]),
             policies: TablePolicies::new()
                 .with_select(PolicyExpr::eq_session("owner_id", vec!["user_id".into()])),
+            requires_transaction: false,
         },
     );
 
@@ -10685,6 +10687,7 @@ fn sync_backed_session_subscription_keeps_local_rows_when_server_scope_is_empty(
             ]),
             policies: TablePolicies::new()
                 .with_select(PolicyExpr::eq_session("owner_id", vec!["user_id".into()])),
+            requires_transaction: false,
         },
     );
 
@@ -10775,6 +10778,7 @@ fn sync_backed_exists_rel_session_subscription_keeps_local_rows_when_server_scop
                     ]),
                 },
             }),
+            requires_transaction: false,
         },
     );
     schema.insert(
@@ -10873,6 +10877,7 @@ fn sync_backed_exists_session_subscription_keeps_local_rows_when_server_scope_is
                     PolicyExpr::eq_session("user_id", vec!["user_id".into()]),
                 ])),
             }),
+            requires_transaction: false,
         },
     );
     schema.insert(
@@ -10990,6 +10995,7 @@ fn sync_backed_joined_exists_rel_session_subscription_keeps_local_rows_when_serv
                     ]),
                 },
             }),
+            requires_transaction: false,
         },
     );
     schema.insert(
@@ -11106,6 +11112,7 @@ fn fail_closed_server_does_not_emit_scope_snapshot_before_permissions_head() {
                     ]),
                 },
             }),
+            requires_transaction: false,
         },
     );
     schema.insert(
@@ -11236,6 +11243,7 @@ fn synced_session_query_for_exists_rel_sends_policy_context_tables_upstream() {
                     ]),
                 },
             }),
+            requires_transaction: false,
         },
     );
     schema.insert(

--- a/crates/jazz-tools/src/query_manager/types/schema.rs
+++ b/crates/jazz-tools/src/query_manager/types/schema.rs
@@ -323,10 +323,21 @@ pub struct TableSchema {
     /// Access control policies.
     #[serde(default, skip_serializing_if = "table_policies_are_default")]
     pub policies: TablePolicies,
+    /// Whether writes must use transactional batch mode.
+    #[serde(
+        default,
+        rename = "requiresTransaction",
+        skip_serializing_if = "table_requires_transaction_is_false"
+    )]
+    pub requires_transaction: bool,
 }
 
 fn table_policies_are_default(policies: &TablePolicies) -> bool {
     *policies == TablePolicies::default()
+}
+
+fn table_requires_transaction_is_false(requires_transaction: &bool) -> bool {
+    !*requires_transaction
 }
 
 impl TableSchema {
@@ -337,12 +348,17 @@ impl TableSchema {
         Self {
             columns,
             policies: TablePolicies::default(),
+            requires_transaction: false,
         }
     }
 
     /// Create a table schema with policies.
     pub fn with_policies(columns: RowDescriptor, policies: TablePolicies) -> Self {
-        Self { columns, policies }
+        Self {
+            columns,
+            policies,
+            requires_transaction: false,
+        }
     }
 
     /// Start building a new table schema.
@@ -363,6 +379,7 @@ pub struct TableSchemaBuilder {
     name: String,
     columns: Vec<ColumnDescriptor>,
     policies: TablePolicies,
+    requires_transaction: bool,
 }
 
 impl TableSchemaBuilder {
@@ -372,6 +389,7 @@ impl TableSchemaBuilder {
             name: name.to_string(),
             columns: Vec::new(),
             policies: TablePolicies::default(),
+            requires_transaction: false,
         }
     }
 
@@ -423,6 +441,12 @@ impl TableSchemaBuilder {
         self
     }
 
+    /// Require transactional batch mode for writes against this table.
+    pub fn require_transaction(mut self) -> Self {
+        self.requires_transaction = true;
+        self
+    }
+
     /// Get the table name.
     pub fn name(&self) -> &str {
         &self.name
@@ -433,6 +457,7 @@ impl TableSchemaBuilder {
         TableSchema {
             columns: RowDescriptor::new(self.columns),
             policies: self.policies,
+            requires_transaction: self.requires_transaction,
         }
     }
 
@@ -442,6 +467,7 @@ impl TableSchemaBuilder {
         let schema = TableSchema {
             columns: RowDescriptor::new(self.columns),
             policies: self.policies,
+            requires_transaction: self.requires_transaction,
         };
         (name, schema)
     }

--- a/crates/jazz-tools/src/query_manager/writes.rs
+++ b/crates/jazz-tools/src/query_manager/writes.rs
@@ -109,6 +109,7 @@ impl QueryManager {
                 .cloned()
                 .map(Arc::new),
             select_policy: table_schema.policies.select_policy().cloned().map(Arc::new),
+            requires_transaction: table_schema.requires_transaction,
         });
         self.write_table_cache.insert(cache_key, entry.clone());
         Ok(entry)
@@ -193,6 +194,22 @@ impl QueryManager {
             Some(BatchMode::Transactional) => RowState::StagingPending,
             Some(BatchMode::Direct) | None => RowState::VisibleDirect,
         }
+    }
+
+    fn ensure_write_mode_allowed(
+        table_name: &TableName,
+        requires_transaction: bool,
+        write_context: Option<&WriteContext>,
+    ) -> Result<(), QueryError> {
+        if requires_transaction
+            && write_context
+                .map(WriteContext::batch_mode)
+                .unwrap_or(BatchMode::Direct)
+                != BatchMode::Transactional
+        {
+            return Err(QueryError::TransactionRequired { table: *table_name });
+        }
+        Ok(())
     }
 
     fn row_batch_authoring<'a>(
@@ -585,6 +602,11 @@ impl QueryManager {
         let table_name = TableName::new(table);
         let table_write =
             self.write_table_cache_entry_for_schema(branch, table_name, write_schema)?;
+        Self::ensure_write_mode_allowed(
+            &table_name,
+            table_write.requires_transaction,
+            write_context,
+        )?;
         let descriptor = table_write.descriptor.as_ref();
         let using_policy = table_write.update_using_policy.as_deref();
         let check_policy = table_write.update_check_policy.as_deref();
@@ -882,6 +904,11 @@ impl QueryManager {
             table_name,
             write_schema.as_ref(),
         )?;
+        Self::ensure_write_mode_allowed(
+            &table_name,
+            table_write.requires_transaction,
+            write_context,
+        )?;
         let descriptor = table_write.descriptor.as_ref();
         let insert_policy = table_write.insert_policy.as_deref();
 
@@ -1077,6 +1104,11 @@ impl QueryManager {
         let write_schema = self.schema.clone();
         let table_write =
             self.write_table_cache_entry_for_schema(branch, table_name, write_schema.as_ref())?;
+        Self::ensure_write_mode_allowed(
+            &table_name,
+            table_write.requires_transaction,
+            write_context,
+        )?;
         let descriptor = table_write.descriptor.as_ref();
         let insert_policy = table_write.insert_policy.as_deref();
 
@@ -1238,6 +1270,11 @@ impl QueryManager {
         let table_name = TableName::new(table);
         let table_write =
             self.write_table_cache_entry_for_schema(branch, table_name, write_schema)?;
+        Self::ensure_write_mode_allowed(
+            &table_name,
+            table_write.requires_transaction,
+            write_context,
+        )?;
         let descriptor = table_write.descriptor.as_ref();
         let insert_policy = table_write.insert_policy.as_deref();
 
@@ -1905,6 +1942,19 @@ impl QueryManager {
         let table = self
             .load_row_table_name(storage, id)
             .ok_or(QueryError::ObjectNotFound(id))?;
+        let table_name = TableName::new(&table);
+        let current_branch = self.current_branch().as_str().to_string();
+        let write_schema = self.schema.clone();
+        let table_write = self.write_table_cache_entry_for_schema(
+            &current_branch,
+            table_name,
+            write_schema.as_ref(),
+        )?;
+        Self::ensure_write_mode_allowed(
+            &table_name,
+            table_write.requires_transaction,
+            write_context,
+        )?;
         let current_row = self
             .transactional_staged_row_for_write(
                 storage,
@@ -2006,6 +2056,14 @@ impl QueryManager {
             old_data_for_policy: _old_data_for_policy,
             old_provenance_for_policy,
         } = write;
+        let table_name = TableName::new(table);
+        let table_write =
+            self.write_table_cache_entry_for_schema(branch, table_name, write_schema)?;
+        Self::ensure_write_mode_allowed(
+            &table_name,
+            table_write.requires_transaction,
+            write_context,
+        )?;
         let timestamp = self.resolve_update_timestamp(write_context);
         let new_provenance =
             self.row_provenance_for_update(old_provenance_for_policy, write_context, timestamp);
@@ -2120,8 +2178,19 @@ impl QueryManager {
         let table = self
             .load_row_table_name(storage, id)
             .ok_or(QueryError::ObjectNotFound(id))?;
-
         let table_name = TableName::new(&table);
+        let current_branch = self.current_branch().as_str().to_string();
+        let write_schema = self.schema.clone();
+        let table_write = self.write_table_cache_entry_for_schema(
+            &current_branch,
+            table_name,
+            write_schema.as_ref(),
+        )?;
+        Self::ensure_write_mode_allowed(
+            &table_name,
+            table_write.requires_transaction,
+            write_context,
+        )?;
 
         // Check if already soft-deleted
         let current_branch = self.current_branch().to_string();
@@ -2328,6 +2397,13 @@ impl QueryManager {
         let staged_branch_row =
             self.transactional_staged_row_for_write(storage, id, branch, write_context);
         let table_name = TableName::new(table);
+        let table_write =
+            self.write_table_cache_entry_for_schema(branch, table_name, write_schema)?;
+        Self::ensure_write_mode_allowed(
+            &table_name,
+            table_write.requires_transaction,
+            write_context,
+        )?;
         // Check if already soft-deleted on this branch
         if staged_branch_row
             .as_ref()
@@ -2336,8 +2412,6 @@ impl QueryManager {
         {
             return Err(QueryError::RowAlreadyDeleted(id));
         }
-        let table_write =
-            self.write_table_cache_entry_for_schema(branch, table_name, write_schema)?;
         let descriptor = table_write.descriptor.as_ref();
         let using_policy = table_write.delete_using_policy.as_deref();
 

--- a/crates/jazz-tools/src/runtime_core/tests.rs
+++ b/crates/jazz-tools/src/runtime_core/tests.rs
@@ -1333,6 +1333,17 @@ fn test_schema() -> Schema {
         .build()
 }
 
+fn transaction_required_users_schema() -> Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("users")
+                .require_transaction()
+                .column("id", ColumnType::Uuid)
+                .column("name", ColumnType::Text),
+        )
+        .build()
+}
+
 fn schema_evolution_v1() -> Schema {
     test_schema()
 }
@@ -4071,6 +4082,63 @@ fn rc_transactional_update_can_modify_row_inserted_earlier_in_same_batch() {
     )
     .expect("latest staged row should decode");
     assert_eq!(values, user_row_values(inserted_user_id, "Bob"));
+}
+
+#[test]
+fn rc_transaction_required_tables_reject_direct_writes_but_allow_transactions() {
+    let mut core =
+        create_runtime_with_schema(transaction_required_users_schema(), "tx-required-users");
+    let batch_id = BatchId::new();
+    let transactional_write_context = WriteContext::default()
+        .with_batch_mode(crate::batch_fate::BatchMode::Transactional)
+        .with_batch_id(batch_id);
+
+    let (row_id, _) = core
+        .insert(
+            "users",
+            user_insert_values(ObjectId::new(), "Alice"),
+            Some(&transactional_write_context),
+        )
+        .expect("transactional insert should be allowed");
+
+    let direct_insert_err = core
+        .insert("users", user_insert_values(ObjectId::new(), "Bob"), None)
+        .unwrap_err();
+    assert!(matches!(
+        direct_insert_err,
+        RuntimeError::WriteError(message)
+            if message.contains("users") && message.contains("requires transactional writes")
+    ));
+
+    let direct_update_err = core
+        .update(
+            row_id,
+            vec![("name".to_string(), Value::Text("Alicia".to_string()))],
+            None,
+        )
+        .unwrap_err();
+    assert!(matches!(
+        direct_update_err,
+        RuntimeError::WriteError(message)
+            if message.contains("users") && message.contains("requires transactional writes")
+    ));
+
+    core.update(
+        row_id,
+        vec![("name".to_string(), Value::Text("Alicia".to_string()))],
+        Some(&transactional_write_context),
+    )
+    .expect("transactional update should be allowed");
+
+    let direct_delete_err = core.delete(row_id, None).unwrap_err();
+    assert!(matches!(
+        direct_delete_err,
+        RuntimeError::WriteError(message)
+            if message.contains("users") && message.contains("requires transactional writes")
+    ));
+
+    core.delete(row_id, Some(&transactional_write_context))
+        .expect("transactional delete should be allowed");
 }
 
 #[test]

--- a/crates/jazz-tools/src/schema_manager/encoding.rs
+++ b/crates/jazz-tools/src/schema_manager/encoding.rs
@@ -17,8 +17,8 @@ use crate::query_manager::types::{
 use super::lens::{LensOp, LensTransform};
 
 /// Current encoding version.
-const SCHEMA_VERSION: u8 = SchemaEncodingVersion::V4 as u8;
-const LENS_VERSION: u8 = 2;
+const SCHEMA_VERSION: u8 = SchemaEncodingVersion::V5 as u8;
+const LENS_VERSION: u8 = 3;
 const PERMISSIONS_VERSION: u8 = 1;
 const PERMISSIONS_BUNDLE_VERSION: u8 = 2;
 const PERMISSIONS_HEAD_VERSION: u8 = 2;
@@ -34,6 +34,8 @@ enum SchemaEncodingVersion {
     V3 = 3,
     // v4 schemas include column defaults.
     V4 = 4,
+    // v5 schemas include table-level transaction requirements.
+    V5 = 5,
 }
 
 impl SchemaEncodingVersion {
@@ -43,6 +45,7 @@ impl SchemaEncodingVersion {
             2 => Some(Self::V2),
             3 => Some(Self::V3),
             4 => Some(Self::V4),
+            5 => Some(Self::V5),
             _ => None,
         }
     }
@@ -56,7 +59,11 @@ impl SchemaEncodingVersion {
     }
 
     fn has_column_defaults(self) -> bool {
-        matches!(self, Self::V4)
+        matches!(self, Self::V4 | Self::V5)
+    }
+
+    fn has_requires_transaction(self) -> bool {
+        matches!(self, Self::V5)
     }
 }
 
@@ -114,7 +121,7 @@ impl std::error::Error for CatalogueEncodingError {}
 /// table is preserved exactly as declared.
 pub fn encode_schema(schema: &Schema) -> Vec<u8> {
     let mut buf = Vec::new();
-    let version = SchemaEncodingVersion::V4;
+    let version = SchemaEncodingVersion::V5;
     buf.push(version as u8);
 
     // Sort tables by name for deterministic ordering
@@ -160,6 +167,9 @@ fn encode_table_entry_with_version(
     if version.has_table_policies() {
         encode_table_policies(buf, &schema.policies);
     }
+    if version.has_requires_transaction() {
+        buf.push(if schema.requires_transaction { 1 } else { 0 });
+    }
 }
 
 fn decode_table_entry_with_version(
@@ -175,12 +185,18 @@ fn decode_table_entry_with_version(
         // separately.
         decode_table_policies(data, offset)?;
     }
+    let requires_transaction = if version.has_requires_transaction() {
+        read_u8(data, offset)? != 0
+    } else {
+        false
+    };
 
     Ok((
         TableName::new(name),
         TableSchema {
             columns: descriptor,
             policies: TablePolicies::default(),
+            requires_transaction,
         },
     ))
 }
@@ -506,7 +522,8 @@ pub fn decode_lens_transform(data: &[u8]) -> Result<LensTransform, CatalogueEnco
     let version = data[0];
     match version {
         1 => decode_lens_transform_v1(data),
-        LENS_VERSION => decode_lens_transform_v2(data),
+        2 => decode_lens_transform_v2(data),
+        LENS_VERSION => decode_lens_transform_v3(data),
         _ => Err(CatalogueEncodingError::UnsupportedVersion {
             found: version,
             expected: LENS_VERSION,
@@ -659,6 +676,24 @@ fn decode_lens_transform_v2(data: &[u8]) -> Result<LensTransform, CatalogueEncod
     let op_count = read_u32(data, &mut offset)?;
     let mut ops = Vec::with_capacity(op_count as usize);
     for _ in 0..op_count {
+        ops.push(decode_lens_op_v2(data, &mut offset)?);
+    }
+
+    let draft_count = read_u32(data, &mut offset)?;
+    let mut draft_ops = Vec::with_capacity(draft_count as usize);
+    for _ in 0..draft_count {
+        draft_ops.push(read_u32(data, &mut offset)? as usize);
+    }
+
+    Ok(LensTransform { ops, draft_ops })
+}
+
+fn decode_lens_transform_v3(data: &[u8]) -> Result<LensTransform, CatalogueEncodingError> {
+    let mut offset = 1;
+
+    let op_count = read_u32(data, &mut offset)?;
+    let mut ops = Vec::with_capacity(op_count as usize);
+    for _ in 0..op_count {
         ops.push(decode_lens_op(data, &mut offset)?);
     }
 
@@ -669,6 +704,65 @@ fn decode_lens_transform_v2(data: &[u8]) -> Result<LensTransform, CatalogueEncod
     }
 
     Ok(LensTransform { ops, draft_ops })
+}
+
+fn decode_lens_op_v2(data: &[u8], offset: &mut usize) -> Result<LensOp, CatalogueEncodingError> {
+    let tag = read_u8(data, offset)?;
+    match tag {
+        OP_RENAME_TABLE => {
+            let old_name = read_string(data, offset, "old_name")?;
+            let new_name = read_string(data, offset, "new_name")?;
+            Ok(LensOp::RenameTable { old_name, new_name })
+        }
+        OP_ADD_COLUMN => {
+            let table = read_string(data, offset, "table")?;
+            let column = read_string(data, offset, "column")?;
+            let column_type = decode_column_type(data, offset)?;
+            let default = decode_value(data, offset)?;
+            Ok(LensOp::AddColumn {
+                table,
+                column,
+                column_type,
+                default,
+            })
+        }
+        OP_REMOVE_COLUMN => {
+            let table = read_string(data, offset, "table")?;
+            let column = read_string(data, offset, "column")?;
+            let column_type = decode_column_type(data, offset)?;
+            let default = decode_value(data, offset)?;
+            Ok(LensOp::RemoveColumn {
+                table,
+                column,
+                column_type,
+                default,
+            })
+        }
+        OP_RENAME_COLUMN => {
+            let table = read_string(data, offset, "table")?;
+            let old_name = read_string(data, offset, "old_name")?;
+            let new_name = read_string(data, offset, "new_name")?;
+            Ok(LensOp::RenameColumn {
+                table,
+                old_name,
+                new_name,
+            })
+        }
+        OP_ADD_TABLE => {
+            let table = read_string(data, offset, "table")?;
+            let schema = decode_table_schema_v2(data, offset)?;
+            Ok(LensOp::AddTable { table, schema })
+        }
+        OP_REMOVE_TABLE => {
+            let table = read_string(data, offset, "table")?;
+            let schema = decode_table_schema_v2(data, offset)?;
+            Ok(LensOp::RemoveTable { table, schema })
+        }
+        _ => Err(CatalogueEncodingError::InvalidTypeTag {
+            tag,
+            context: "lens_op",
+        }),
+    }
 }
 
 fn decode_lens_op_v1(data: &[u8], offset: &mut usize) -> Result<LensOp, CatalogueEncodingError> {
@@ -727,6 +821,7 @@ fn decode_lens_op_v1(data: &[u8], offset: &mut usize) -> Result<LensOp, Catalogu
 
 fn encode_table_schema(buf: &mut Vec<u8>, schema: &TableSchema) {
     encode_row_descriptor(buf, &schema.columns);
+    buf.push(if schema.requires_transaction { 1 } else { 0 });
 }
 
 fn decode_table_schema(
@@ -737,6 +832,19 @@ fn decode_table_schema(
     Ok(TableSchema {
         columns: descriptor,
         policies: TablePolicies::default(),
+        requires_transaction: read_u8(data, offset)? != 0,
+    })
+}
+
+fn decode_table_schema_v2(
+    data: &[u8],
+    offset: &mut usize,
+) -> Result<TableSchema, CatalogueEncodingError> {
+    let descriptor = decode_row_descriptor(data, offset)?;
+    Ok(TableSchema {
+        columns: descriptor,
+        policies: TablePolicies::default(),
+        requires_transaction: false,
     })
 }
 
@@ -749,6 +857,7 @@ fn decode_table_schema_v1(
     Ok(TableSchema {
         columns: descriptor,
         policies: TablePolicies::default(),
+        requires_transaction: false,
     })
 }
 

--- a/crates/jazz-tools/src/schema_manager/manager.rs
+++ b/crates/jazz-tools/src/schema_manager/manager.rs
@@ -14,6 +14,7 @@ use std::{
 
 use blake3::Hasher;
 
+use crate::batch_fate::BatchMode;
 use crate::catalogue::CatalogueEntry;
 use crate::object::{BranchName, ObjectId};
 use crate::query_manager::manager::{DeleteHandle, InsertResult, QueryError, QueryManager};
@@ -38,6 +39,7 @@ use super::encoding::{
     encode_permissions_head, encode_schema,
 };
 use super::lens::Lens;
+use super::resolve_current_table_name;
 use super::types::AppId;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -399,6 +401,52 @@ impl SchemaManager {
 
         temp_context.try_activate_pending();
         Ok(temp_context)
+    }
+
+    fn row_table_name_for_target_schema(
+        storage: &dyn Storage,
+        object_id: ObjectId,
+        target_context: &SchemaContext,
+    ) -> Option<String> {
+        let locator = storage.load_row_locator(object_id).ok().flatten()?;
+        resolve_current_table_name(
+            target_context,
+            locator.table.as_str(),
+            locator.origin_schema_hash.as_ref(),
+        )
+        .or_else(|| Some(locator.table.to_string()))
+    }
+
+    fn ensure_row_write_mode_allowed(
+        storage: &dyn Storage,
+        object_id: ObjectId,
+        target_schema: &Schema,
+        target_context: &SchemaContext,
+        write_context: Option<&WriteContext>,
+    ) -> Result<(), QueryError> {
+        if write_context
+            .map(WriteContext::batch_mode)
+            .unwrap_or(BatchMode::Direct)
+            == BatchMode::Transactional
+        {
+            return Ok(());
+        }
+
+        let Some(table) =
+            Self::row_table_name_for_target_schema(storage, object_id, target_context)
+        else {
+            return Ok(());
+        };
+
+        let table_name = TableName::new(&table);
+        if target_schema
+            .get(&table_name)
+            .is_some_and(|table_schema| table_schema.requires_transaction)
+        {
+            return Err(QueryError::TransactionRequired { table: table_name });
+        }
+
+        Ok(())
     }
 
     fn get_insert_values_with_defaults_for_schema(
@@ -1657,7 +1705,17 @@ impl SchemaManager {
         Self::validate_external_upsert_object_id(object_id)?;
         let _ = self.ensure_current_schema_persisted(storage);
         let (target_branch, target_hash) = self.resolve_target_branch(write_context)?;
+        let target_schema = self
+            .schema_for_hash(target_hash)
+            .ok_or(QueryError::UnknownSchema(target_hash))?;
         let target_context = self.schema_context_for_hash(target_hash)?;
+        Self::ensure_row_write_mode_allowed(
+            storage,
+            object_id,
+            target_schema,
+            &target_context,
+            write_context,
+        )?;
         let branches = target_context
             .all_branch_names()
             .into_iter()
@@ -1724,6 +1782,13 @@ impl SchemaManager {
             .ok_or(QueryError::UnknownSchema(target_hash))?
             .clone();
         let target_context = self.schema_context_for_hash(target_hash)?;
+        Self::ensure_row_write_mode_allowed(
+            storage,
+            object_id,
+            &target_schema,
+            &target_context,
+            write_context,
+        )?;
         let branches = target_context
             .all_branch_names()
             .into_iter()
@@ -1826,6 +1891,13 @@ impl SchemaManager {
             .ok_or(QueryError::UnknownSchema(target_hash))?
             .clone();
         let target_context = self.schema_context_for_hash(target_hash)?;
+        Self::ensure_row_write_mode_allowed(
+            storage,
+            object_id,
+            &target_schema,
+            &target_context,
+            write_context,
+        )?;
         let branches = target_context
             .all_branch_names()
             .into_iter()

--- a/packages/jazz-tools/src/cli.ts
+++ b/packages/jazz-tools/src/cli.ts
@@ -833,7 +833,12 @@ function renderSchemaWitness(schema: WasmSchema): string {
       const columnLines = tableSchema.columns.map(
         (column) => `${JSON.stringify(column.name)}: ${builderExpressionForColumn(column)},`,
       );
-      return `${JSON.stringify(tableName)}: s.table({\n${indentBlock(columnLines.join("\n"), 2)}\n})`;
+      const tableExpression = `s.table({\n${indentBlock(columnLines.join("\n"), 2)}\n})`;
+      return `${JSON.stringify(tableName)}: ${
+        tableSchema.requiresTransaction
+          ? `${tableExpression}.requireTransaction()`
+          : tableExpression
+      }`;
     });
 
   if (tableEntries.length === 0) {

--- a/packages/jazz-tools/src/codegen/schema-reader.ts
+++ b/packages/jazz-tools/src/codegen/schema-reader.ts
@@ -241,6 +241,7 @@ export function schemaToWasm(schema: Schema): WasmSchema {
     tables[table.name] = {
       columns,
       policies: table.policies ? clonePolicies(table.policies) : undefined,
+      requiresTransaction: table.requiresTransaction,
     };
   }
 

--- a/packages/jazz-tools/src/drivers/types.ts
+++ b/packages/jazz-tools/src/drivers/types.ts
@@ -134,6 +134,7 @@ export interface TablePolicies {
 export interface TableSchema {
   columns: ColumnDescriptor[];
   policies?: TablePolicies;
+  requiresTransaction?: boolean;
 }
 
 export type Schema = Record<string, TableSchema>;

--- a/packages/jazz-tools/src/dsl.test.ts
+++ b/packages/jazz-tools/src/dsl.test.ts
@@ -122,6 +122,24 @@ describe("schema default DSL", () => {
   });
 });
 
+describe("table transactionality DSL", () => {
+  it("marks side-effect tables as transaction-required", () => {
+    resetCollectedState();
+    table(
+      "audit_logs",
+      {
+        message: col.string(),
+      },
+      { requiresTransaction: true },
+    );
+
+    expect(getCollectedSchema().tables[0]).toMatchObject({
+      name: "audit_logs",
+      requiresTransaction: true,
+    });
+  });
+});
+
 describe("ref DSL", () => {
   it("stores references on ref columns", () => {
     resetCollectedState();

--- a/packages/jazz-tools/src/dsl.ts
+++ b/packages/jazz-tools/src/dsl.ts
@@ -703,12 +703,26 @@ type EnforceReferenceColumnNames<T extends Record<string, ColumnBuilder>> = {
 export function table<const T extends Record<string, ColumnBuilder>>(
   name: string,
   columns: EnforceReferenceColumnNames<T>,
+  options?: { requiresTransaction?: boolean },
 ): void {
   if (arguments.length > 2) {
-    throw new Error(
-      "Inline table permissions are no longer supported in schema.ts. " +
-        "Define policies in permissions.ts with definePermissions(...).",
-    );
+    const invalidOptions =
+      options === null ||
+      typeof options !== "object" ||
+      Array.isArray(options) ||
+      Object.keys(options).some((key) => key !== "requiresTransaction");
+    if (invalidOptions) {
+      throw new Error(
+        "Inline table permissions are no longer supported in schema.ts. " +
+          "Define policies in permissions.ts with definePermissions(...).",
+      );
+    }
+    if (
+      options.requiresTransaction !== undefined &&
+      typeof options.requiresTransaction !== "boolean"
+    ) {
+      throw new Error("table(..., options) requires requiresTransaction to be a boolean.");
+    }
   }
 
   const cols: Column[] = [];
@@ -720,6 +734,7 @@ export function table<const T extends Record<string, ColumnBuilder>>(
   collectedTables.push({
     name,
     columns: cols,
+    requiresTransaction: options?.requiresTransaction,
   });
 }
 

--- a/packages/jazz-tools/src/migrations.ts
+++ b/packages/jazz-tools/src/migrations.ts
@@ -24,7 +24,7 @@ import type {
   Simplify,
   TableDefinition,
 } from "./typed-app.js";
-import { unwrapTableDefinition } from "./typed-app.js";
+import { resolveTableOptions, unwrapTableDefinition } from "./typed-app.js";
 
 type SchemaLike = SchemaDefinition | AppSchema<any>;
 
@@ -533,6 +533,7 @@ function tableDefinitionToAst(
       assertUserColumnNameAllowed(columnName);
       return builder._build(columnName);
     }),
+    requiresTransaction: resolveTableOptions(definition).requiresTransaction,
   };
 }
 
@@ -548,9 +549,8 @@ function normalizeSchemaDefinition(
 }
 
 function definitionToSchema(definition: SchemaDefinition): SchemaAst {
-  const normalizedDefinition = normalizeSchemaDefinition(definition);
   return {
-    tables: Object.entries(normalizedDefinition).map(([tableName, tableDefinition]) =>
+    tables: Object.entries(definition).map(([tableName, tableDefinition]) =>
       tableDefinitionToAst(tableName, tableDefinition),
     ),
   };

--- a/packages/jazz-tools/src/runtime/db.transaction.test.ts
+++ b/packages/jazz-tools/src/runtime/db.transaction.test.ts
@@ -39,8 +39,33 @@ function todoSchema(): WasmSchema {
   };
 }
 
+function transactionRequiredTodoSchema(): WasmSchema {
+  return {
+    todos: {
+      columns: [
+        { name: "title", column_type: { type: "Text" }, nullable: false },
+        { name: "done", column_type: { type: "Boolean" }, nullable: false },
+      ],
+      requiresTransaction: true,
+    },
+  };
+}
+
 function todoTable() {
   const schema = todoSchema();
+  return {
+    _table: "todos",
+    _schema: schema,
+    _rowType: {} as { id: string; title: string; done: boolean },
+    _initType: {} as { title: string; done: boolean },
+  } satisfies TableProxy<
+    { id: string; title: string; done: boolean },
+    { title: string; done: boolean }
+  >;
+}
+
+function transactionRequiredTodoTable() {
+  const schema = transactionRequiredTodoSchema();
   return {
     _table: "todos",
     _schema: schema,
@@ -452,5 +477,67 @@ describe("Db transactions", () => {
       /cannot be used with table "todos" from a different schema\/client/,
     );
     expect(runtimeBatch.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects direct db writes for tables that require transactions", () => {
+    const table = transactionRequiredTodoTable();
+    const runtimeTransaction = {
+      batchId: vi.fn(() => "batch-required-transaction"),
+      create: vi.fn(() => ({
+        id: "todo-required-1",
+        values: [
+          { type: "Text", value: "Transactional only" },
+          { type: "Boolean", value: false },
+        ],
+      })),
+      createPersisted: vi.fn(),
+      update: vi.fn(),
+      updatePersisted: vi.fn(),
+      delete: vi.fn(),
+      deletePersisted: vi.fn(),
+      commit: vi.fn(() => "batch-required-transaction"),
+      localBatchRecord: vi.fn((batchId = "batch-required-transaction") =>
+        makeLocalBatchRecord(batchId),
+      ),
+      localBatchRecords: vi.fn(() => [makeLocalBatchRecord("batch-required-transaction")]),
+      acknowledgeRejectedBatch: vi.fn(() => false),
+    };
+    const create = vi.fn();
+    const createPersisted = vi.fn();
+    const beginDirectBatchInternal = vi.fn();
+    const beginTransactionInternal = vi.fn(() => runtimeTransaction);
+    const client = {
+      getSchema: () => new Map(Object.entries(transactionRequiredTodoSchema())),
+      create,
+      createPersisted,
+      beginDirectBatchInternal,
+      beginTransactionInternal,
+      localBatchRecord: vi.fn((batchId: string) => makeLocalBatchRecord(batchId)),
+      acknowledgeRejectedBatch: vi.fn(() => false),
+    } as unknown as JazzClient;
+    const db = new TestDb(client);
+
+    expect(() => db.insert(table, { title: "Transactional only", done: false })).toThrow(
+      /requires transactional writes/i,
+    );
+    expect(() => db.insertPersisted(table, { title: "Transactional only", done: false })).toThrow(
+      /requires transactional writes/i,
+    );
+    expect(() => db.beginDirectBatch(table)).toThrow(/requires transactional writes/i);
+    expect(create).not.toHaveBeenCalled();
+    expect(createPersisted).not.toHaveBeenCalled();
+    expect(beginDirectBatchInternal).not.toHaveBeenCalled();
+
+    const tx = db.beginTransaction(table);
+    expect(tx.insert(table, { title: "Transactional only", done: false })).toEqual({
+      id: "todo-required-1",
+      title: "Transactional only",
+      done: false,
+    });
+    expect(beginTransactionInternal).toHaveBeenCalledWith();
+    expect(runtimeTransaction.create).toHaveBeenCalledWith("todos", {
+      title: { type: "Text", value: "Transactional only" },
+      done: { type: "Boolean", value: false },
+    });
   });
 });

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -347,6 +347,19 @@ function resolveSchemaWithTable(
   return preferredSchema[tableName] ? preferredSchema : fallbackSchema;
 }
 
+function assertDirectWritesAllowed<T, Init>(
+  table: TableProxy<T, Init>,
+  runtimeSchema: WasmSchema,
+  operation: string,
+): void {
+  const resolvedSchema = resolveSchemaWithTable(table._schema, runtimeSchema, table._table);
+  if (resolvedSchema[table._table]?.requiresTransaction) {
+    throw new Error(
+      `${operation} cannot target table "${table._table}" because the schema requires transactional writes.`,
+    );
+  }
+}
+
 function assertTableBelongsToClient<T, Init>(
   table: TableProxy<T, Init>,
   expectedClient: JazzClient,
@@ -594,6 +607,11 @@ export class DbDirectBatch {
   }
 
   insert<T, Init>(table: TableProxy<T, Init>, data: Init): T {
+    assertDirectWritesAllowed(
+      table,
+      normalizeRuntimeSchema(this.client.getSchema()),
+      "DbDirectBatch",
+    );
     const values = toInsertRecord(
       data as Record<string, unknown>,
       this.resolveInputSchema(table),
@@ -608,6 +626,11 @@ export class DbDirectBatch {
     data: Init,
     options?: { tier?: DurabilityTier },
   ): DbPersistedWrite<T> {
+    assertDirectWritesAllowed(
+      table,
+      normalizeRuntimeSchema(this.client.getSchema()),
+      "DbDirectBatch",
+    );
     const values = toInsertRecord(
       data as Record<string, unknown>,
       this.resolveInputSchema(table),
@@ -620,6 +643,11 @@ export class DbDirectBatch {
   }
 
   update<T, Init>(table: TableProxy<T, Init>, id: string, data: Partial<Init>): void {
+    assertDirectWritesAllowed(
+      table,
+      normalizeRuntimeSchema(this.client.getSchema()),
+      "DbDirectBatch",
+    );
     const updates = toUpdateRecord(
       data as Record<string, unknown>,
       this.resolveInputSchema(table),
@@ -634,6 +662,11 @@ export class DbDirectBatch {
     data: Partial<Init>,
     options?: { tier?: DurabilityTier },
   ): DbPersistedWrite<void> {
+    assertDirectWritesAllowed(
+      table,
+      normalizeRuntimeSchema(this.client.getSchema()),
+      "DbDirectBatch",
+    );
     const updates = toUpdateRecord(
       data as Record<string, unknown>,
       this.resolveInputSchema(table),
@@ -648,6 +681,11 @@ export class DbDirectBatch {
 
   delete<T, Init>(table: TableProxy<T, Init>, id: string): void {
     this.assertOwnsTable(table, "DbDirectBatch");
+    assertDirectWritesAllowed(
+      table,
+      normalizeRuntimeSchema(this.client.getSchema()),
+      "DbDirectBatch",
+    );
     this.runtimeBatch.delete(id);
   }
 
@@ -657,6 +695,11 @@ export class DbDirectBatch {
     options?: { tier?: DurabilityTier },
   ): DbPersistedWrite<void> {
     this.assertOwnsTable(table, "DbDirectBatch");
+    assertDirectWritesAllowed(
+      table,
+      normalizeRuntimeSchema(this.client.getSchema()),
+      "DbDirectBatch",
+    );
     const pendingWrite = this.runtimeBatch.deletePersisted(id, options);
     return this.wrapPersistedWrite(
       pendingWrite as RuntimePersistedWrite<Row | void>,
@@ -2114,6 +2157,7 @@ export class Db {
    */
   insert<T, Init>(table: TableProxy<T, Init>, data: Init, options?: CreateOptions): T {
     const client = this.getClient(table._schema);
+    assertDirectWritesAllowed(table, normalizeRuntimeSchema(client.getSchema()), "Db.insert");
     // Don't wait for bridge to be ready in worker mode. Inserts will be propagated once the bridge is ready.
     // If the bridge fails to initialize, the insert will be lost on restart.
     const values = toInsertRecord(data as Record<string, unknown>, table._schema, table._table);
@@ -2137,6 +2181,11 @@ export class Db {
     options: CreateDurabilityOptions,
   ): Promise<T> {
     const client = this.getClient(table._schema);
+    assertDirectWritesAllowed(
+      table,
+      normalizeRuntimeSchema(client.getSchema()),
+      "Db.insertDurable",
+    );
     const inputSchema = resolveSchemaWithTable(
       table._schema,
       normalizeRuntimeSchema(client.getSchema()),
@@ -2154,6 +2203,11 @@ export class Db {
     options?: { tier?: DurabilityTier },
   ): DbPersistedWrite<T> {
     const client = this.getClient(table._schema);
+    assertDirectWritesAllowed(
+      table,
+      normalizeRuntimeSchema(client.getSchema()),
+      "Db.insertPersisted",
+    );
     const values = toInsertRecord(data as Record<string, unknown>, table._schema, table._table);
     const pendingWrite = client.createPersisted(table._table, values, options);
     return this.wrapPersistedWrite(
@@ -2168,6 +2222,7 @@ export class Db {
    */
   upsert<T, Init>(table: TableProxy<T, Init>, data: Partial<Init>, options: UpsertOptions): void {
     const client = this.getClient(table._schema);
+    assertDirectWritesAllowed(table, normalizeRuntimeSchema(client.getSchema()), "Db.upsert");
     const values = toUpdateRecord(data as Record<string, unknown>, table._schema, table._table);
     client.upsert(table._table, values, options);
   }
@@ -2181,6 +2236,11 @@ export class Db {
     options: UpsertDurabilityOptions,
   ): Promise<void> {
     const client = this.getClient(table._schema);
+    assertDirectWritesAllowed(
+      table,
+      normalizeRuntimeSchema(client.getSchema()),
+      "Db.upsertDurable",
+    );
     const inputSchema = resolveSchemaWithTable(
       table._schema,
       normalizeRuntimeSchema(client.getSchema()),
@@ -2201,6 +2261,7 @@ export class Db {
     options?: UpdateOptions,
   ): void {
     const client = this.getClient(table._schema);
+    assertDirectWritesAllowed(table, normalizeRuntimeSchema(client.getSchema()), "Db.update");
     const updates = toUpdateRecord(data as Record<string, unknown>, table._schema, table._table);
     client.update(id, updates, options);
   }
@@ -2215,6 +2276,11 @@ export class Db {
     options?: UpdateDurabilityOptions,
   ): Promise<void> {
     const client = this.getClient(table._schema);
+    assertDirectWritesAllowed(
+      table,
+      normalizeRuntimeSchema(client.getSchema()),
+      "Db.updateDurable",
+    );
     const inputSchema = resolveSchemaWithTable(
       table._schema,
       normalizeRuntimeSchema(client.getSchema()),
@@ -2232,6 +2298,11 @@ export class Db {
     options?: UpdateDurabilityOptions,
   ): DbPersistedWrite<void> {
     const client = this.getClient(table._schema);
+    assertDirectWritesAllowed(
+      table,
+      normalizeRuntimeSchema(client.getSchema()),
+      "Db.updatePersisted",
+    );
     const updates = toUpdateRecord(data as Record<string, unknown>, table._schema, table._table);
     const pendingWrite = client.updatePersisted(id, updates, options);
     return this.wrapPersistedWrite(
@@ -2246,6 +2317,7 @@ export class Db {
    */
   delete<T, Init>(table: TableProxy<T, Init>, id: string): void {
     const client = this.getClient(table._schema);
+    assertDirectWritesAllowed(table, normalizeRuntimeSchema(client.getSchema()), "Db.delete");
     client.delete(id);
   }
 
@@ -2258,6 +2330,11 @@ export class Db {
     options?: { tier?: DurabilityTier },
   ): Promise<void> {
     const client = this.getClient(table._schema);
+    assertDirectWritesAllowed(
+      table,
+      normalizeRuntimeSchema(client.getSchema()),
+      "Db.deleteDurable",
+    );
     await this.ensureBridgeReady();
     await client.deleteDurable(id, options);
   }
@@ -2268,6 +2345,11 @@ export class Db {
     options?: { tier?: DurabilityTier },
   ): DbPersistedWrite<void> {
     const client = this.getClient(table._schema);
+    assertDirectWritesAllowed(
+      table,
+      normalizeRuntimeSchema(client.getSchema()),
+      "Db.deletePersisted",
+    );
     const pendingWrite = client.deletePersisted(id, options);
     return this.wrapPersistedWrite(
       client,
@@ -2293,6 +2375,11 @@ export class Db {
 
   beginDirectBatch<T, Init>(table: TableProxy<T, Init>): DbDirectBatch {
     const client = this.getClient(table._schema);
+    assertDirectWritesAllowed(
+      table,
+      normalizeRuntimeSchema(client.getSchema()),
+      "Db.beginDirectBatch",
+    );
     return new DbDirectBatch(
       client,
       client.beginDirectBatchInternal(),
@@ -2700,6 +2787,7 @@ class ClientBackedDb extends Db {
 
   override insert<T, Init>(table: TableProxy<T, Init>, data: Init, options?: CreateOptions): T {
     const runtimeSchema = normalizeRuntimeSchema(this.runtimeClient.getSchema());
+    assertDirectWritesAllowed(table, runtimeSchema, "Db.insert");
     const inputSchema = resolveSchemaWithTable(table._schema, runtimeSchema, table._table);
     const values = toInsertRecord(data as Record<string, unknown>, inputSchema, table._table);
     const row = this.runtimeClient.createInternal(
@@ -2718,6 +2806,7 @@ class ClientBackedDb extends Db {
     options: CreateDurabilityOptions,
   ): Promise<T> {
     const runtimeSchema = normalizeRuntimeSchema(this.runtimeClient.getSchema());
+    assertDirectWritesAllowed(table, runtimeSchema, "Db.insertDurable");
     const inputSchema = resolveSchemaWithTable(table._schema, runtimeSchema, table._table);
     const values = toInsertRecord(data as Record<string, unknown>, inputSchema, table._table);
     const row = await this.runtimeClient.createDurableInternal(
@@ -2736,6 +2825,7 @@ class ClientBackedDb extends Db {
     options: UpsertOptions,
   ): void {
     const runtimeSchema = normalizeRuntimeSchema(this.runtimeClient.getSchema());
+    assertDirectWritesAllowed(table, runtimeSchema, "Db.upsert");
     const inputSchema = resolveSchemaWithTable(table._schema, runtimeSchema, table._table);
     const values = toUpdateRecord(data as Record<string, unknown>, inputSchema, table._table);
     this.runtimeClient.upsertInternal(
@@ -2754,6 +2844,7 @@ class ClientBackedDb extends Db {
     options: UpsertDurabilityOptions,
   ): Promise<void> {
     const runtimeSchema = normalizeRuntimeSchema(this.runtimeClient.getSchema());
+    assertDirectWritesAllowed(table, runtimeSchema, "Db.upsertDurable");
     const inputSchema = resolveSchemaWithTable(table._schema, runtimeSchema, table._table);
     const values = toUpdateRecord(data as Record<string, unknown>, inputSchema, table._table);
     await this.runtimeClient.upsertDurableInternal(
@@ -2772,6 +2863,7 @@ class ClientBackedDb extends Db {
     options?: { tier?: DurabilityTier },
   ): DbPersistedWrite<T> {
     const runtimeSchema = normalizeRuntimeSchema(this.runtimeClient.getSchema());
+    assertDirectWritesAllowed(table, runtimeSchema, "Db.insertPersisted");
     const inputSchema = resolveSchemaWithTable(table._schema, runtimeSchema, table._table);
     const values = toInsertRecord(data as Record<string, unknown>, inputSchema, table._table);
     const pendingWrite = this.runtimeClient.createPersistedInternal(
@@ -2795,6 +2887,7 @@ class ClientBackedDb extends Db {
     options?: UpdateOptions,
   ): void {
     const runtimeSchema = normalizeRuntimeSchema(this.runtimeClient.getSchema());
+    assertDirectWritesAllowed(table, runtimeSchema, "Db.update");
     const inputSchema = resolveSchemaWithTable(table._schema, runtimeSchema, table._table);
     const updates = toUpdateRecord(data as Record<string, unknown>, inputSchema, table._table);
     this.runtimeClient.updateInternal(
@@ -2814,6 +2907,7 @@ class ClientBackedDb extends Db {
     options?: UpdateDurabilityOptions,
   ): Promise<void> {
     const runtimeSchema = normalizeRuntimeSchema(this.runtimeClient.getSchema());
+    assertDirectWritesAllowed(table, runtimeSchema, "Db.updateDurable");
     const inputSchema = resolveSchemaWithTable(table._schema, runtimeSchema, table._table);
     const updates = toUpdateRecord(data as Record<string, unknown>, inputSchema, table._table);
     await this.runtimeClient.updateDurableInternal(
@@ -2833,6 +2927,7 @@ class ClientBackedDb extends Db {
     options?: UpdateDurabilityOptions,
   ): DbPersistedWrite<void> {
     const runtimeSchema = normalizeRuntimeSchema(this.runtimeClient.getSchema());
+    assertDirectWritesAllowed(table, runtimeSchema, "Db.updatePersisted");
     const inputSchema = resolveSchemaWithTable(table._schema, runtimeSchema, table._table);
     const updates = toUpdateRecord(data as Record<string, unknown>, inputSchema, table._table);
     const pendingWrite = this.runtimeClient.updatePersistedInternal(
@@ -2851,23 +2946,38 @@ class ClientBackedDb extends Db {
     );
   }
 
-  override delete<T, Init>(_table: TableProxy<T, Init>, id: string): void {
+  override delete<T, Init>(table: TableProxy<T, Init>, id: string): void {
+    assertDirectWritesAllowed(
+      table,
+      normalizeRuntimeSchema(this.runtimeClient.getSchema()),
+      "Db.delete",
+    );
     this.runtimeClient.deleteInternal(id, this.session, this.attribution);
   }
 
   override async deleteDurable<T, Init>(
-    _table: TableProxy<T, Init>,
+    table: TableProxy<T, Init>,
     id: string,
     options?: { tier?: DurabilityTier },
   ): Promise<void> {
+    assertDirectWritesAllowed(
+      table,
+      normalizeRuntimeSchema(this.runtimeClient.getSchema()),
+      "Db.deleteDurable",
+    );
     await this.runtimeClient.deleteDurableInternal(id, this.session, this.attribution, options);
   }
 
   override deletePersisted<T, Init>(
-    _table: TableProxy<T, Init>,
+    table: TableProxy<T, Init>,
     id: string,
     options?: { tier?: DurabilityTier },
   ): DbPersistedWrite<void> {
+    assertDirectWritesAllowed(
+      table,
+      normalizeRuntimeSchema(this.runtimeClient.getSchema()),
+      "Db.deletePersisted",
+    );
     const pendingWrite = this.runtimeClient.deletePersistedInternal(
       id,
       this.session,
@@ -2894,6 +3004,11 @@ class ClientBackedDb extends Db {
 
   override beginDirectBatch<T, Init>(table: TableProxy<T, Init>): DbDirectBatch {
     const client = this.runtimeClient;
+    assertDirectWritesAllowed(
+      table,
+      normalizeRuntimeSchema(client.getSchema()),
+      "Db.beginDirectBatch",
+    );
     return new DbDirectBatch(
       client,
       client.beginDirectBatchInternal(this.session, this.attribution),

--- a/packages/jazz-tools/src/schema-loader.ts
+++ b/packages/jazz-tools/src/schema-loader.ts
@@ -100,6 +100,7 @@ function wasmTableToAst(name: string, table: TableSchema): Schema["tables"][numb
     name,
     columns: table.columns.map(wasmColumnToAst),
     policies: table.policies as TablePolicies | undefined,
+    requiresTransaction: table.requiresTransaction,
   };
 }
 

--- a/packages/jazz-tools/src/schema.ts
+++ b/packages/jazz-tools/src/schema.ts
@@ -212,6 +212,7 @@ export interface Table {
   name: string;
   columns: Column[];
   policies?: TablePolicies;
+  requiresTransaction?: boolean;
 }
 
 export interface Schema {

--- a/packages/jazz-tools/src/typed-app.test.ts
+++ b/packages/jazz-tools/src/typed-app.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { col } from "./dsl.js";
+import { defineApp, defineTable } from "./typed-app.js";
+
+describe("typed app table transactionality", () => {
+  it("emits transaction-required metadata into the wasm schema", () => {
+    const app = defineApp({
+      audit_logs: defineTable({
+        message: col.string(),
+      }).requireTransaction(),
+      comments: defineTable({
+        body: col.string(),
+      }),
+    });
+
+    expect(app.wasmSchema.audit_logs?.requiresTransaction).toBe(true);
+    expect(app.wasmSchema.comments?.requiresTransaction).toBeUndefined();
+  });
+});

--- a/packages/jazz-tools/src/typed-app.ts
+++ b/packages/jazz-tools/src/typed-app.ts
@@ -24,6 +24,10 @@ export interface TableIndex<TColumns extends TableDefinition = TableDefinition> 
   readonly columns: readonly Extract<keyof TColumns, string>[];
 }
 
+export interface TableOptions {
+  readonly requiresTransaction?: boolean;
+}
+
 // Wrap table columns so we can hang chained modifiers like .index(...) off tables
 // without changing the column-level schema representation the runtime uses today.
 export class DefinedTable<TColumns extends TableDefinition = TableDefinition> {
@@ -32,6 +36,7 @@ export class DefinedTable<TColumns extends TableDefinition = TableDefinition> {
   constructor(
     public readonly columns: TColumns,
     public readonly indexes: readonly TableIndex[] = [],
+    public readonly options: TableOptions = {},
   ) {}
 
   index<
@@ -53,13 +58,24 @@ export class DefinedTable<TColumns extends TableDefinition = TableDefinition> {
       }
     }
 
-    return new DefinedTable(this.columns, [
-      ...this.indexes,
-      {
-        name: normalizedName,
-        columns: normalizedColumns,
-      },
-    ]);
+    return new DefinedTable(
+      this.columns,
+      [
+        ...this.indexes,
+        {
+          name: normalizedName,
+          columns: normalizedColumns,
+        },
+      ],
+      this.options,
+    );
+  }
+
+  requireTransaction(): DefinedTable<TColumns> {
+    return new DefinedTable(this.columns, this.indexes, {
+      ...this.options,
+      requiresTransaction: true,
+    });
   }
 }
 
@@ -1188,6 +1204,26 @@ export function unwrapTableDefinition<const TColumns extends TableDefinition>(
   return definition;
 }
 
+export function resolveTableOptions<const TColumns extends TableDefinition>(
+  definition: TColumns | DefinedTable<TColumns>,
+): TableOptions {
+  if (definition instanceof DefinedTable) {
+    return definition.options;
+  }
+
+  if (typeof definition === "object" && definition !== null) {
+    const maybeDefinedTable = definition as {
+      __jazzTableDefinition?: unknown;
+      options?: TableOptions;
+    };
+    if (maybeDefinedTable.__jazzTableDefinition === true) {
+      return maybeDefinedTable.options ?? {};
+    }
+  }
+
+  return {};
+}
+
 function definitionToColumns(
   definition: TableDefinition | DefinedTable<TableDefinition>,
 ): Column[] {
@@ -1205,6 +1241,7 @@ function definitionToSchema<TSchema extends SchemaDefinition>(definition: TSchem
     tables: Object.entries(definition).map(([tableName, tableDefinition]) => ({
       name: tableName,
       columns: definitionToColumns(tableDefinition),
+      requiresTransaction: resolveTableOptions(tableDefinition).requiresTransaction,
     })),
   };
 }


### PR DESCRIPTION
## What changed
This adds a schema-level transaction-required flag for specific tables and enforces it across the TypeScript schema APIs, runtime direct-write APIs, and Rust core write paths.

- add `requiresTransaction` schema metadata and schema encoding support
- add `defineTable(...).requireTransaction()` and `table(..., columns, { requiresTransaction: true })`
- reject direct writes and direct batches for flagged tables with a clear error
- keep transactional writes working normally for those same tables
- add TS and Rust regression coverage plus a `jazz-tools` changeset

## Why
Some tables represent side-effectful or invariant-sensitive data that should only be mutated transactionally. Before this change, the schema could not express that requirement, and direct update/delete paths could fall through to row lookup behavior instead of rejecting immediately.

## API
Two schema entry points now mark a table as transaction-required:

```ts
const auditLogs = defineTable({
  actor: text(),
  action: text(),
}).requireTransaction();
```

```ts
table(
  "audit_logs",
  {
    actor: text(),
    action: text(),
  },
  { requiresTransaction: true },
);
```

Behavior:

- direct writes now throw immediately for marked tables
- this includes `db.insert(...)`, `db.update(...)`, `db.delete(...)`, and direct batch entry points like `db.beginDirectBatch(...)`
- transactional writes still work for those tables
- tables that do not opt in keep existing behavior and can still participate in transactions

## Validation
- `cargo clippy --workspace -- -D warnings`
- `pnpm --filter jazz-tools exec vitest run src/dsl.test.ts src/typed-app.test.ts src/runtime/db.transaction.test.ts`
- `cargo test -p jazz-tools rc_transaction_required_tables_reject_direct_writes_but_allow_transactions -- --nocapture`
