### PR TITLE
[Inspector] Prefill partial fields from hash

### DIFF
--- a/crates/jazz-napi/index.js
+++ b/crates/jazz-napi/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@garden-co/jazz-napi-android-arm64')
         const bindingPackageVersion = require('@garden-co/jazz-napi-android-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.0-alpha.32' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@garden-co/jazz-napi-android-arm-eabi')
         const bindingPackageVersion = require('@garden-co/jazz-napi-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '2.0.0-alpha.32' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@garden-co/jazz-napi-win32-x64-gnu')
         const bindingPackageVersion = require('@garden-co/jazz-napi-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '2.0.0-alpha.32' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@garden-co/jazz-napi-win32-x64-msvc')
         const bindingPackageVersion = require('@garden-co/jazz-napi-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '2.0.0-alpha.32' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@garden-co/jazz-napi-win32-ia32-msvc')
         const bindingPackageVersion = require('@garden-co/jazz-napi-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '2.0.0-alpha.32' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@garden-co/jazz-napi-win32-arm64-msvc')
         const bindingPackageVersion = require('@garden-co/jazz-napi-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '2.0.0-alpha.32' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@garden-co/jazz-napi-darwin-universal')
       const bindingPackageVersion = require('@garden-co/jazz-napi-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '2.0.0-alpha.32' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@garden-co/jazz-napi-darwin-x64')
         const bindingPackageVersion = require('@garden-co/jazz-napi-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '2.0.0-alpha.32' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@garden-co/jazz-napi-darwin-arm64')
         const bindingPackageVersion = require('@garden-co/jazz-napi-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.0-alpha.32' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@garden-co/jazz-napi-freebsd-x64')
         const bindingPackageVersion = require('@garden-co/jazz-napi-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '2.0.0-alpha.32' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@garden-co/jazz-napi-freebsd-arm64')
         const bindingPackageVersion = require('@garden-co/jazz-napi-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.0-alpha.32' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@garden-co/jazz-napi-linux-x64-musl')
           const bindingPackageVersion = require('@garden-co/jazz-napi-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.0-alpha.32' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@garden-co/jazz-napi-linux-x64-gnu')
           const bindingPackageVersion = require('@garden-co/jazz-napi-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.0-alpha.32' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@garden-co/jazz-napi-linux-arm64-musl')
           const bindingPackageVersion = require('@garden-co/jazz-napi-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.0-alpha.32' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@garden-co/jazz-napi-linux-arm64-gnu')
           const bindingPackageVersion = require('@garden-co/jazz-napi-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.0-alpha.32' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@garden-co/jazz-napi-linux-arm-musleabihf')
           const bindingPackageVersion = require('@garden-co/jazz-napi-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '2.0.0-alpha.32' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@garden-co/jazz-napi-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@garden-co/jazz-napi-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '2.0.0-alpha.32' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@garden-co/jazz-napi-linux-loong64-musl')
           const bindingPackageVersion = require('@garden-co/jazz-napi-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.0-alpha.32' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@garden-co/jazz-napi-linux-loong64-gnu')
           const bindingPackageVersion = require('@garden-co/jazz-napi-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.0-alpha.32' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@garden-co/jazz-napi-linux-riscv64-musl')
           const bindingPackageVersion = require('@garden-co/jazz-napi-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.0-alpha.32' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@garden-co/jazz-napi-linux-riscv64-gnu')
           const bindingPackageVersion = require('@garden-co/jazz-napi-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.0-alpha.32' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@garden-co/jazz-napi-linux-ppc64-gnu')
         const bindingPackageVersion = require('@garden-co/jazz-napi-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '2.0.0-alpha.32' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@garden-co/jazz-napi-linux-s390x-gnu')
         const bindingPackageVersion = require('@garden-co/jazz-napi-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '2.0.0-alpha.32' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@garden-co/jazz-napi-openharmony-arm64')
         const bindingPackageVersion = require('@garden-co/jazz-napi-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.0-alpha.32' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@garden-co/jazz-napi-openharmony-x64')
         const bindingPackageVersion = require('@garden-co/jazz-napi-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '2.0.0-alpha.32' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@garden-co/jazz-napi-openharmony-arm')
         const bindingPackageVersion = require('@garden-co/jazz-napi-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '2.0.0-alpha.32' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.32 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/crates/jazz-tools/src/commands/server.rs
+++ b/crates/jazz-tools/src/commands/server.rs
@@ -62,7 +62,7 @@ fn build_inspector_link(port: u16, app_id: &str, admin_secret: Option<&str>) -> 
     let server_url = format!("http://localhost:{port}");
     let admin_secret_value = admin_secret.unwrap_or("");
     format!(
-        "{STANDALONE_INSPECTOR_URL}#url={}&appId={}&adminSecret={}",
+        "{STANDALONE_INSPECTOR_URL}#serverUrl={}&appId={}&adminSecret={}",
         percent_encode_fragment_value(&server_url),
         percent_encode_fragment_value(app_id),
         percent_encode_fragment_value(admin_secret_value),
@@ -94,7 +94,7 @@ mod tests {
 
         assert_eq!(
             link,
-            "https://jazz2-inspector.vercel.app/#url=http%3A%2F%2Flocalhost%3A4200&appId=app%3Aone%2Ftwo&adminSecret=secret%20with%20spaces"
+            "https://jazz2-inspector.vercel.app/#serverUrl=http%3A%2F%2Flocalhost%3A4200&appId=app%3Aone%2Ftwo&adminSecret=secret%20with%20spaces"
         );
     }
 }

--- a/packages/inspector/scripts/dev-sync-server.ts
+++ b/packages/inspector/scripts/dev-sync-server.ts
@@ -81,12 +81,12 @@ if (import.meta.url === new URL(process.argv[1], "file://").href) {
   console.log("Server running at", result.serverHandle.url);
   console.log("Press Ctrl-C to stop");
   console.log(
-    "Open dev inspector at http://localhost:5173/#url=" +
+    "Open dev inspector at http://localhost:5173/#serverUrl=" +
       result.serverHandle.url +
-      "&adminSecret=" +
-      result.serverHandle.adminSecret +
       "&appId=" +
-      result.serverHandle.appId,
+      result.serverHandle.appId +
+      "&adminSecret=" +
+      result.serverHandle.adminSecret,
   );
   setInterval(() => {}, 10_000_000);
 }

--- a/packages/inspector/src/App.test.tsx
+++ b/packages/inspector/src/App.test.tsx
@@ -157,4 +157,37 @@ describe("App", () => {
     expect(screen.getByLabelText("Server URL")).toHaveProperty("value", "");
     expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
   });
+
+  it("prefills the connection form from partial hash params", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        serverUrl: "http://localhost:19879",
+        appId: "stored-app-id",
+        adminSecret: "stored-admin-secret",
+        env: "dev",
+        branch: "main",
+        schemaHash: "hash-b",
+      }),
+    );
+    window.location.hash =
+      "#serverUrl=https%3A%2F%2Fstaging.v2.aws.cloud.jazz.tools&appId=019d9bc9-646b-7560-b26d-b775a7d061d3&serverPathPrefix=%2Fapps%2F019d9bc9-646b-7560-b26d-b775a7d061d3";
+
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "Connect to Jazz server" })).not.toBeNull();
+    expect(screen.getByLabelText("Server URL")).toHaveProperty(
+      "value",
+      "https://staging.v2.aws.cloud.jazz.tools",
+    );
+    expect(screen.getByLabelText("App ID")).toHaveProperty(
+      "value",
+      "019d9bc9-646b-7560-b26d-b775a7d061d3",
+    );
+    expect(screen.getByLabelText("Admin secret")).toHaveProperty("value", "");
+    expect(screen.getByLabelText(/Path prefix/i)).toHaveProperty(
+      "value",
+      "/apps/019d9bc9-646b-7560-b26d-b775a7d061d3",
+    );
+  });
 });

--- a/packages/inspector/src/App.tsx
+++ b/packages/inspector/src/App.tsx
@@ -318,33 +318,25 @@ function readFragmentConfig(): DbConfigFormValues | null {
   if (!raw) return null;
 
   const params = new URLSearchParams(raw);
-  const serverUrl = (params.get("url") ?? params.get("serverUrl") ?? "").trim();
-  const appId = (params.get("appid") ?? params.get("appId") ?? "").trim();
-  const adminSecret = (params.get("adminsecret") ?? params.get("adminSecret") ?? "").trim();
-  const env = (params.get("env") ?? "dev").trim() || "dev";
-  const branch = (params.get("branch") ?? "main").trim() || "main";
-  const serverPathPrefix = (
-    params.get("serverPathPrefix") ??
-    params.get("pathPrefix") ??
-    ""
-  ).trim();
+  const hasKnownPrefillParam = [
+    "serverUrl",
+    "appId",
+    "adminSecret",
+    "env",
+    "branch",
+    "serverPathPrefix",
+  ].some((key) => params.has(key));
 
-  if (!serverUrl || !appId || !adminSecret) {
-    return null;
-  }
-
-  try {
-    new URL(serverUrl);
-  } catch {
+  if (!hasKnownPrefillParam) {
     return null;
   }
 
   return {
-    serverUrl,
-    appId,
-    adminSecret,
-    env,
-    branch,
-    serverPathPrefix: serverPathPrefix || undefined,
+    serverUrl: (params.get("serverUrl") ?? "").trim(),
+    appId: (params.get("appId") ?? "").trim(),
+    adminSecret: (params.get("adminSecret") ?? "").trim(),
+    env: (params.get("env") ?? "dev").trim() || "dev",
+    branch: (params.get("branch") ?? "main").trim() || "main",
+    serverPathPrefix: (params.get("serverPathPrefix") ?? "").trim() || undefined,
   };
 }

--- a/packages/inspector/tests/browser/standalone-inspector.spec.ts
+++ b/packages/inspector/tests/browser/standalone-inspector.spec.ts
@@ -56,7 +56,7 @@ function rowByTitle(page: Page, title: string) {
 test.describe("connection page", () => {
   test("prefills connection form from hash fragment", async ({ page }) => {
     const fragment = new URLSearchParams({
-      url: SERVER_URL,
+      serverUrl: SERVER_URL,
       appId: APP_ID,
       adminSecret: ADMIN_SECRET,
     }).toString();

--- a/packages/jazz-tools/src/dev/inspector-link.ts
+++ b/packages/jazz-tools/src/dev/inspector-link.ts
@@ -1,0 +1,13 @@
+const STANDALONE_INSPECTOR_URL = "https://jazz2-inspector.vercel.app/";
+
+function encodeFragmentValue(value: string): string {
+  return encodeURIComponent(value);
+}
+
+export function buildInspectorLink(serverUrl: string, appId: string, adminSecret: string): string {
+  return (
+    `${STANDALONE_INSPECTOR_URL}#serverUrl=${encodeFragmentValue(serverUrl)}` +
+    `&appId=${encodeFragmentValue(appId)}` +
+    `&adminSecret=${encodeFragmentValue(adminSecret)}`
+  );
+}

--- a/packages/jazz-tools/src/dev/next.test.ts
+++ b/packages/jazz-tools/src/dev/next.test.ts
@@ -88,6 +88,7 @@ describe("withJazz", () => {
     const port = await getAvailablePort();
     const schemaDir = await tempRoots.create("jazz-next-test-");
     await writeFile(join(schemaDir, "schema.ts"), todoSchema());
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
     const wrapped = withJazz(
       { reactStrictMode: true },
@@ -113,6 +114,13 @@ describe("withJazz", () => {
     expect(resolved.env?.NEXT_PUBLIC_JAZZ_SERVER_URL).toBe(`http://127.0.0.1:${port}`);
     expect(process.env.NEXT_PUBLIC_JAZZ_APP_ID).toBe(resolved.env?.NEXT_PUBLIC_JAZZ_APP_ID);
     expect(process.env.NEXT_PUBLIC_JAZZ_SERVER_URL).toBe(`http://127.0.0.1:${port}`);
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `Open the inspector: https://jazz2-inspector.vercel.app/#serverUrl=${encodeURIComponent(
+          `http://127.0.0.1:${port}`,
+        )}&appId=${encodeURIComponent(resolved.env?.NEXT_PUBLIC_JAZZ_APP_ID!)}&adminSecret=next-test-admin`,
+      ),
+    );
   }, 30_000);
 
   it("releases a failed startup before retrying the same port after the schema is fixed", async () => {

--- a/packages/jazz-tools/src/dev/next.ts
+++ b/packages/jazz-tools/src/dev/next.ts
@@ -1,3 +1,4 @@
+import { buildInspectorLink } from "./inspector-link.js";
 import { ManagedDevRuntime } from "./managed-runtime.js";
 import type { JazzPluginOptions, JazzServerOptions } from "./vite.js";
 
@@ -55,6 +56,8 @@ export function withJazz(
   nextConfig?: NextConfigInput,
   options: NextJazzPluginOptions = {},
 ): NextConfigFactory {
+  let hasLoggedInspectorLink = false;
+
   return async (phase, context) => {
     const resolved = await resolveConfig(nextConfig, phase, context);
     const merged: NextConfigLike = {
@@ -73,6 +76,16 @@ export function withJazz(
         : undefined;
 
     const managed = await runtime.initialize({ ...options, backendSecret });
+    if (!hasLoggedInspectorLink) {
+      console.log(
+        `[jazz] Open the inspector: ${buildInspectorLink(
+          managed.serverUrl,
+          managed.appId,
+          managed.adminSecret,
+        )}`,
+      );
+      hasLoggedInspectorLink = true;
+    }
 
     return {
       ...merged,

--- a/packages/jazz-tools/src/dev/vite.test.ts
+++ b/packages/jazz-tools/src/dev/vite.test.ts
@@ -1,6 +1,6 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { jazzPlugin } from "./vite.js";
 import { createTempRootTracker, getAvailablePort, todoSchema } from "./test-helpers.js";
 
@@ -35,6 +35,7 @@ describe("jazzPlugin", () => {
     const port = await getAvailablePort();
     const schemaDir = await tempRoots.create("jazz-vite-test-");
     await writeFile(join(schemaDir, "schema.ts"), todoSchema());
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
     const plugin = jazzPlugin({
       server: { port, adminSecret: "vite-test-admin" },
@@ -70,6 +71,13 @@ describe("jazzPlugin", () => {
     expect(fakeViteServer.config.env.JAZZ_SERVER_URL).toBe(`http://127.0.0.1:${port}`);
     expect(process.env.JAZZ_APP_ID).toBe(fakeViteServer.config.env.JAZZ_APP_ID);
     expect(process.env.JAZZ_SERVER_URL).toBe(`http://127.0.0.1:${port}`);
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `Open the inspector: https://jazz2-inspector.vercel.app/#serverUrl=${encodeURIComponent(
+          `http://127.0.0.1:${port}`,
+        )}&appId=${encodeURIComponent(fakeViteServer.config.env.JAZZ_APP_ID!)}&adminSecret=vite-test-admin`,
+      ),
+    );
 
     for (const handler of closeHandlers) {
       await handler();

--- a/packages/jazz-tools/src/dev/vite.ts
+++ b/packages/jazz-tools/src/dev/vite.ts
@@ -1,3 +1,4 @@
+import { buildInspectorLink } from "./inspector-link.js";
 import { ManagedDevRuntime } from "./managed-runtime.js";
 
 export interface JazzServerOptions {
@@ -78,6 +79,13 @@ export function jazzPlugin(options: JazzPluginOptions = {}) {
       viteServer.config.env ??= {};
       viteServer.config.env.JAZZ_APP_ID = managed.appId;
       viteServer.config.env.JAZZ_SERVER_URL = managed.serverUrl;
+      console.log(
+        `${LOG_PREFIX} Open the inspector: ${buildInspectorLink(
+          managed.serverUrl,
+          managed.appId,
+          managed.adminSecret,
+        )}`,
+      );
 
       viteServer.httpServer?.once("close", async () => {
         await runtime.dispose();


### PR DESCRIPTION
## Summary
- Update the inspector hash-prefill flow to accept partial camelCase params only
- Switch the dev sync server and crate-side inspector link to `#serverUrl=...`
- Add tests covering partial form prefill and the startup link format

## Testing
- `pnpm --filter inspector test -- --run src/App.test.tsx`
- `pnpm --filter inspector exec playwright test --config playwright.config.ts --grep "prefills connection form from hash fragment"`
- `cargo test -p jazz-tools --bin jazz-tools --features cli inspector_link_percent_encodes_fragment_values`