### PR TITLE
Prefix local server URLs with /apps/<appId>

### DIFF
--- a/.changeset/tasty-toys-glow.md
+++ b/.changeset/tasty-toys-glow.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+`jazz-tools` now routes its sync, schema, permissions, migration, and introspection requests under app-scoped server paths like `/apps/<appId>/...` instead of relying on a configurable `serverPathPrefix`. Server-backed CLI commands now take `<appId>` when resolving those endpoints.

--- a/crates/jazz-tools/src/client.rs
+++ b/crates/jazz-tools/src/client.rs
@@ -24,7 +24,8 @@ use tokio::sync::{RwLock, mpsc};
 use uuid::Uuid;
 
 use crate::{
-    AppContext, ClientStorage, JazzError, ObjectId, Result, SubscriptionHandle, SubscriptionStream,
+    AppContext, AppId, ClientStorage, JazzError, ObjectId, Result, SubscriptionHandle,
+    SubscriptionStream,
 };
 
 type DynStorage = Box<dyn Storage + Send>;
@@ -154,7 +155,7 @@ impl JazzClient {
         let has_server = !context.server_url.is_empty();
 
         if has_server {
-            let ws_url = http_url_to_ws(&context.server_url)?;
+            let ws_url = http_url_to_ws(&context.server_url, context.app_id)?;
             let auth = WsAuthConfig {
                 jwt_token: context.jwt_token.clone(),
                 backend_secret: context.backend_secret.clone(),
@@ -1225,29 +1226,27 @@ fn load_or_create_persistent_client_id(context: &AppContext) -> Result<ClientId>
     Ok(client_id)
 }
 
-/// Convert an HTTP(S) server URL to the WebSocket `/ws` endpoint URL.
+/// Convert an HTTP(S) server URL to the app-scoped WebSocket endpoint URL.
 ///
-/// `http://host/prefix` → `ws://host/prefix/ws`
-/// `https://host` → `wss://host/ws`
-fn http_url_to_ws(server_url: &str) -> Result<String> {
+/// `http://host`, `my-app` → `ws://host/apps/my-app/ws`
+/// `https://host` → `wss://host/apps/my-app/ws`
+fn http_url_to_ws(server_url: &str, app_id: AppId) -> Result<String> {
     let trimmed = server_url.trim().trim_end_matches('/');
+    let ws_suffix = format!("/apps/{}/ws", app_id);
     let (ws_scheme, rest) = if let Some(r) = trimmed.strip_prefix("https://") {
         ("wss", r)
     } else if let Some(r) = trimmed.strip_prefix("http://") {
         ("ws", r)
     } else if trimmed.starts_with("ws://") || trimmed.starts_with("wss://") {
-        // Already a WS URL — just append /ws if not already present
-        return Ok(if trimmed.ends_with("/ws") {
-            trimmed.to_string()
-        } else {
-            format!("{trimmed}/ws")
-        });
+        // Already a WS URL — replace any bare trailing /ws with the app-scoped path.
+        let without_ws_suffix = trimmed.strip_suffix("/ws").unwrap_or(trimmed);
+        return Ok(format!("{without_ws_suffix}{ws_suffix}"));
     } else {
         return Err(JazzError::Connection(format!(
             "invalid server URL '{server_url}': expected http:// or https://"
         )));
     };
-    Ok(format!("{ws_scheme}://{rest}/ws"))
+    Ok(format!("{ws_scheme}://{rest}{ws_suffix}"))
 }
 
 async fn open_persistent_storage(data_dir: &std::path::Path) -> Result<DynStorage> {

--- a/crates/jazz-tools/src/routes.rs
+++ b/crates/jazz-tools/src/routes.rs
@@ -28,6 +28,8 @@ use crate::sync_manager::ClientId;
 
 /// Create the router with all routes.
 pub fn create_router(state: Arc<ServerState>) -> Router {
+    // TODO: Accept app-name aliases in app-scoped route matching
+    // Nesting all non-health routes under a fixed "/apps/{state.app_id}" path makes the server only match the canonical UUID string, but JavaScript callers frequently propagate human-readable app IDs (e.g. "test-app") that are valid elsewhere via AppId::from_name(...). In that non-UUID case, the client now builds /apps/test-app/... URLs while the server only serves /apps/<derived-uuid>/..., so websocket and admin/schema requests return 404 for otherwise valid app IDs.
     let app_route_prefix = format!("/apps/{}", state.app_id);
     let traced_routes = Router::new()
         .route("/ws", axum::routing::any(ws_handler))

--- a/crates/jazz-tools/src/routes.rs
+++ b/crates/jazz-tools/src/routes.rs
@@ -28,7 +28,9 @@ use crate::sync_manager::ClientId;
 
 /// Create the router with all routes.
 pub fn create_router(state: Arc<ServerState>) -> Router {
+    let app_route_prefix = format!("/apps/{}", state.app_id);
     let traced_routes = Router::new()
+        .route("/ws", axum::routing::any(ws_handler))
         .route("/schema/:hash", get(schema_handler))
         .route("/schemas", get(schema_hashes_handler))
         .route("/admin/schemas", post(publish_schema_handler))
@@ -46,13 +48,11 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
             "/admin/introspection/subscriptions",
             get(admin_subscription_introspection_handler),
         )
-        // Health check
-        .route("/health", get(health_handler))
         .layer(TraceLayer::new_for_http());
 
     Router::new()
-        .route("/ws", axum::routing::any(ws_handler))
-        .merge(traced_routes)
+        .route("/health", get(health_handler))
+        .nest(&app_route_prefix, traced_routes)
         .layer(CorsLayer::permissive())
         .with_state(state)
 }
@@ -206,7 +206,8 @@ async fn forward_catalogue_request(
         } => (base_url.as_str(), admin_secret.as_str()),
     };
 
-    let authority_url = authority_endpoint_url(base_url, path).map_err(|message| {
+    let app_scoped_path = format!("/apps/{}/{}", state.app_id, path.trim_start_matches('/'));
+    let authority_url = authority_endpoint_url(base_url, &app_scoped_path).map_err(|message| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse::internal(message)),
@@ -1752,6 +1753,18 @@ mod tests {
         create_router(state)
     }
 
+    fn test_app_id_text() -> String {
+        AppId::from_name("test-app").to_string()
+    }
+
+    fn test_app_route(path: &str) -> String {
+        format!(
+            "/apps/{}/{}",
+            test_app_id_text(),
+            path.trim_start_matches('/')
+        )
+    }
+
     /// A minimal valid `SyncPayload::RowBatchCreated` suitable for embedding
     /// in batch request bodies.
     fn row_version_created_payload(object_id: &str) -> crate::sync_manager::SyncPayload {
@@ -2041,17 +2054,14 @@ mod tests {
             .expect("build server state")
             .state;
 
-        let app = axum::Router::new()
-            .route("/schema/:hash", get(schema_handler))
-            .route("/schemas", get(schema_hashes_handler))
-            .with_state(state);
+        let app = create_router(state);
 
         let placeholder_hash = "0000000000000000000000000000000000000000000000000000000000000000";
         let response = app
             .clone()
             .oneshot(
                 axum::http::Request::builder()
-                    .uri(format!("/schema/{placeholder_hash}"))
+                    .uri(test_app_route(&format!("/schema/{placeholder_hash}")))
                     .body(axum::body::Body::empty())
                     .unwrap(),
             )
@@ -2064,7 +2074,7 @@ mod tests {
             .clone()
             .oneshot(
                 axum::http::Request::builder()
-                    .uri(format!("/schema/{placeholder_hash}"))
+                    .uri(test_app_route(&format!("/schema/{placeholder_hash}")))
                     .header("X-Jazz-Admin-Secret", "admin-secret")
                     .body(axum::body::Body::empty())
                     .unwrap(),
@@ -2075,15 +2085,27 @@ mod tests {
         assert_eq!(response_with_admin.status(), StatusCode::NOT_FOUND);
 
         let hashes_without_admin = app
+            .clone()
             .oneshot(
                 axum::http::Request::builder()
-                    .uri("/schemas")
+                    .uri(test_app_route("/schemas"))
                     .body(axum::body::Body::empty())
                     .unwrap(),
             )
             .await
             .unwrap();
         assert_eq!(hashes_without_admin.status(), StatusCode::UNAUTHORIZED);
+
+        let root_schema = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri(format!("/schema/{placeholder_hash}"))
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(root_schema.status(), StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]
@@ -2104,7 +2126,7 @@ mod tests {
             .clone()
             .oneshot(
                 axum::http::Request::builder()
-                    .uri("/schemas")
+                    .uri(test_app_route("/schemas"))
                     .header("X-Jazz-Admin-Secret", "admin-secret")
                     .body(axum::body::Body::empty())
                     .unwrap(),
@@ -2126,7 +2148,7 @@ mod tests {
             .clone()
             .oneshot(
                 axum::http::Request::builder()
-                    .uri(format!("/schema/{}", schema_hash))
+                    .uri(test_app_route(&format!("/schema/{}", schema_hash)))
                     .header("X-Jazz-Admin-Secret", "admin-secret")
                     .body(axum::body::Body::empty())
                     .unwrap(),
@@ -2145,7 +2167,7 @@ mod tests {
         let bad_hash_response = app
             .oneshot(
                 axum::http::Request::builder()
-                    .uri("/schema/invalid")
+                    .uri(test_app_route("/schema/invalid"))
                     .header("X-Jazz-Admin-Secret", "admin-secret")
                     .body(axum::body::Body::empty())
                     .unwrap(),
@@ -2165,7 +2187,7 @@ mod tests {
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string();
         let authority_routes = axum::Router::new()
             .route(
-                "/schemas",
+                &test_app_route("/schemas"),
                 get({
                     let forwarded = forwarded_for_router.clone();
                     let expected_hash = expected_hash.clone();
@@ -2175,7 +2197,7 @@ mod tests {
                         async move {
                             forwarded.lock().unwrap().push(ForwardedAdminRequest {
                                 method: "GET".to_string(),
-                                path: "/schemas".to_string(),
+                                path: test_app_route("/schemas"),
                                 admin_secret: headers
                                     .get("X-Jazz-Admin-Secret")
                                     .and_then(|value| value.to_str().ok())
@@ -2188,7 +2210,7 @@ mod tests {
                 }),
             )
             .route(
-                "/schema/:hash",
+                &test_app_route("/schema/:hash"),
                 get({
                     let forwarded = forwarded_for_router.clone();
                     move |Path(hash): Path<String>, headers: HeaderMap| {
@@ -2196,7 +2218,7 @@ mod tests {
                         async move {
                             forwarded.lock().unwrap().push(ForwardedAdminRequest {
                                 method: "GET".to_string(),
-                                path: format!("/schema/{hash}"),
+                                path: test_app_route(&format!("/schema/{hash}")),
                                 admin_secret: headers
                                     .get("X-Jazz-Admin-Secret")
                                     .and_then(|value| value.to_str().ok())
@@ -2216,7 +2238,7 @@ mod tests {
                 }),
             )
             .route(
-                "/admin/schemas",
+                &test_app_route("/admin/schemas"),
                 post({
                     let forwarded = forwarded_for_router.clone();
                     let expected_hash = expected_hash.clone();
@@ -2226,7 +2248,7 @@ mod tests {
                         async move {
                             forwarded.lock().unwrap().push(ForwardedAdminRequest {
                                 method: "POST".to_string(),
-                                path: "/admin/schemas".to_string(),
+                                path: test_app_route("/admin/schemas"),
                                 admin_secret: headers
                                     .get("X-Jazz-Admin-Secret")
                                     .and_then(|value| value.to_str().ok())
@@ -2245,7 +2267,7 @@ mod tests {
                 }),
             )
             .route(
-                "/admin/migrations",
+                &test_app_route("/admin/migrations"),
                 post({
                     let forwarded = forwarded_for_router.clone();
                     move |headers: HeaderMap, body: Json<Value>| {
@@ -2253,7 +2275,7 @@ mod tests {
                         async move {
                             forwarded.lock().unwrap().push(ForwardedAdminRequest {
                                 method: "POST".to_string(),
-                                path: "/admin/migrations".to_string(),
+                                path: test_app_route("/admin/migrations"),
                                 admin_secret: headers
                                     .get("X-Jazz-Admin-Secret")
                                     .and_then(|value| value.to_str().ok())
@@ -2273,7 +2295,7 @@ mod tests {
                 }),
             )
             .route(
-                "/admin/schema-connectivity",
+                &test_app_route("/admin/schema-connectivity"),
                 get({
                     let forwarded = forwarded_for_router.clone();
                     move |Query(params): Query<SchemaConnectivityParams>, headers: HeaderMap| {
@@ -2282,7 +2304,8 @@ mod tests {
                             forwarded.lock().unwrap().push(ForwardedAdminRequest {
                                 method: "GET".to_string(),
                                 path: format!(
-                                    "/admin/schema-connectivity?fromHash={}&toHash={}",
+                                    "{}?fromHash={}&toHash={}",
+                                    test_app_route("/admin/schema-connectivity"),
                                     params.from_hash, params.to_hash
                                 ),
                                 admin_secret: headers
@@ -2299,7 +2322,7 @@ mod tests {
                 }),
             )
             .route(
-                "/admin/permissions/head",
+                &test_app_route("/admin/permissions/head"),
                 get({
                     let forwarded = forwarded_for_router.clone();
                     move |headers: HeaderMap| {
@@ -2307,7 +2330,7 @@ mod tests {
                         async move {
                             forwarded.lock().unwrap().push(ForwardedAdminRequest {
                                 method: "GET".to_string(),
-                                path: "/admin/permissions/head".to_string(),
+                                path: test_app_route("/admin/permissions/head"),
                                 admin_secret: headers
                                     .get("X-Jazz-Admin-Secret")
                                     .and_then(|value| value.to_str().ok())
@@ -2327,7 +2350,7 @@ mod tests {
                 }),
             )
             .route(
-                "/admin/permissions",
+                &test_app_route("/admin/permissions"),
                 get({
                     let forwarded = forwarded_for_router.clone();
                     move |headers: HeaderMap| {
@@ -2335,7 +2358,7 @@ mod tests {
                         async move {
                             forwarded.lock().unwrap().push(ForwardedAdminRequest {
                                 method: "GET".to_string(),
-                                path: "/admin/permissions".to_string(),
+                                path: test_app_route("/admin/permissions"),
                                 admin_secret: headers
                                     .get("X-Jazz-Admin-Secret")
                                     .and_then(|value| value.to_str().ok())
@@ -2360,7 +2383,7 @@ mod tests {
                 }),
             )
             .route(
-                "/admin/permissions",
+                &test_app_route("/admin/permissions"),
                 post({
                     let forwarded = forwarded_for_router.clone();
                     move |headers: HeaderMap, body: Json<Value>| {
@@ -2368,7 +2391,7 @@ mod tests {
                         async move {
                             forwarded.lock().unwrap().push(ForwardedAdminRequest {
                                 method: "POST".to_string(),
-                                path: "/admin/permissions".to_string(),
+                                path: test_app_route("/admin/permissions"),
                                 admin_secret: headers
                                     .get("X-Jazz-Admin-Secret")
                                     .and_then(|value| value.to_str().ok())
@@ -2421,7 +2444,7 @@ mod tests {
             .clone()
             .oneshot(
                 axum::http::Request::builder()
-                    .uri("/schemas")
+                    .uri(test_app_route("/schemas"))
                     .header("X-Jazz-Admin-Secret", "admin-secret")
                     .body(axum::body::Body::empty())
                     .unwrap(),
@@ -2434,7 +2457,7 @@ mod tests {
             .clone()
             .oneshot(
                 axum::http::Request::builder()
-                    .uri(format!("/schema/{expected_hash}"))
+                    .uri(test_app_route(&format!("/schema/{expected_hash}")))
                     .header("X-Jazz-Admin-Secret", "admin-secret")
                     .body(axum::body::Body::empty())
                     .unwrap(),
@@ -2448,7 +2471,7 @@ mod tests {
             .oneshot(
                 axum::http::Request::builder()
                     .method("POST")
-                    .uri("/admin/schemas")
+                    .uri(test_app_route("/admin/schemas"))
                     .header("Content-Type", "application/json")
                     .header("X-Jazz-Admin-Secret", "admin-secret")
                     .body(axum::body::Body::from(
@@ -2465,7 +2488,7 @@ mod tests {
             .oneshot(
                 axum::http::Request::builder()
                     .method("POST")
-                    .uri("/admin/migrations")
+                    .uri(test_app_route("/admin/migrations"))
                     .header("Content-Type", "application/json")
                     .header("X-Jazz-Admin-Secret", "admin-secret")
                     .body(axum::body::Body::from(
@@ -2493,7 +2516,7 @@ mod tests {
             .clone()
             .oneshot(
                 axum::http::Request::builder()
-                    .uri("/admin/permissions/head")
+                    .uri(test_app_route("/admin/permissions/head"))
                     .header("X-Jazz-Admin-Secret", "admin-secret")
                     .body(axum::body::Body::empty())
                     .unwrap(),
@@ -2506,7 +2529,10 @@ mod tests {
             .clone()
             .oneshot(
                 axum::http::Request::builder()
-                    .uri("/admin/schema-connectivity?fromHash=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&toHash=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+                    .uri(format!(
+                        "{}?fromHash=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&toHash=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                        test_app_route("/admin/schema-connectivity")
+                    ))
                     .header("X-Jazz-Admin-Secret", "admin-secret")
                     .body(axum::body::Body::empty())
                     .unwrap(),
@@ -2519,7 +2545,7 @@ mod tests {
             .clone()
             .oneshot(
                 axum::http::Request::builder()
-                    .uri("/admin/permissions")
+                    .uri(test_app_route("/admin/permissions"))
                     .header("X-Jazz-Admin-Secret", "admin-secret")
                     .body(axum::body::Body::empty())
                     .unwrap(),
@@ -2532,7 +2558,7 @@ mod tests {
             .oneshot(
                 axum::http::Request::builder()
                     .method("POST")
-                    .uri("/admin/permissions")
+                    .uri(test_app_route("/admin/permissions"))
                     .header("Content-Type", "application/json")
                     .header("X-Jazz-Admin-Secret", "admin-secret")
                     .body(axum::body::Body::from(
@@ -2560,17 +2586,23 @@ mod tests {
                 .iter()
                 .all(|request| request.admin_secret.as_deref() == Some("authority-secret"))
         );
-        assert_eq!(forwarded[0].path, "/schemas");
-        assert_eq!(forwarded[1].path, format!("/schema/{expected_hash}"));
-        assert_eq!(forwarded[2].path, "/admin/schemas");
-        assert_eq!(forwarded[3].path, "/admin/migrations");
-        assert_eq!(forwarded[4].path, "/admin/permissions/head");
+        assert_eq!(forwarded[0].path, test_app_route("/schemas"));
+        assert_eq!(
+            forwarded[1].path,
+            test_app_route(&format!("/schema/{expected_hash}"))
+        );
+        assert_eq!(forwarded[2].path, test_app_route("/admin/schemas"));
+        assert_eq!(forwarded[3].path, test_app_route("/admin/migrations"));
+        assert_eq!(forwarded[4].path, test_app_route("/admin/permissions/head"));
         assert_eq!(
             forwarded[5].path,
-            "/admin/schema-connectivity?fromHash=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&toHash=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            format!(
+                "{}?fromHash=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&toHash=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                test_app_route("/admin/schema-connectivity")
+            )
         );
-        assert_eq!(forwarded[6].path, "/admin/permissions");
-        assert_eq!(forwarded[7].path, "/admin/permissions");
+        assert_eq!(forwarded[6].path, test_app_route("/admin/permissions"));
+        assert_eq!(forwarded[7].path, test_app_route("/admin/permissions"));
         assert_eq!(
             forwarded[7]
                 .body
@@ -2600,7 +2632,7 @@ mod tests {
             .clone()
             .oneshot(
                 axum::http::Request::builder()
-                    .uri("/admin/permissions/head")
+                    .uri(test_app_route("/admin/permissions/head"))
                     .header("X-Jazz-Admin-Secret", "admin-secret")
                     .body(axum::body::Body::empty())
                     .unwrap(),
@@ -2628,7 +2660,7 @@ mod tests {
             .oneshot(
                 axum::http::Request::builder()
                     .method("POST")
-                    .uri("/admin/permissions")
+                    .uri(test_app_route("/admin/permissions"))
                     .header("Content-Type", "application/json")
                     .header("X-Jazz-Admin-Secret", "admin-secret")
                     .body(axum::body::Body::from(first_request_body.to_string()))
@@ -2662,7 +2694,7 @@ mod tests {
             .oneshot(
                 axum::http::Request::builder()
                     .method("POST")
-                    .uri("/admin/permissions")
+                    .uri(test_app_route("/admin/permissions"))
                     .header("Content-Type", "application/json")
                     .header("X-Jazz-Admin-Secret", "admin-secret")
                     .body(axum::body::Body::from(second_request_body.to_string()))
@@ -2699,7 +2731,7 @@ mod tests {
             .oneshot(
                 axum::http::Request::builder()
                     .method("POST")
-                    .uri("/admin/permissions")
+                    .uri(test_app_route("/admin/permissions"))
                     .header("Content-Type", "application/json")
                     .header("X-Jazz-Admin-Secret", "admin-secret")
                     .body(axum::body::Body::from(stale_request_body.to_string()))
@@ -2713,7 +2745,7 @@ mod tests {
             .clone()
             .oneshot(
                 axum::http::Request::builder()
-                    .uri("/admin/permissions/head")
+                    .uri(test_app_route("/admin/permissions/head"))
                     .header("X-Jazz-Admin-Secret", "admin-secret")
                     .body(axum::body::Body::empty())
                     .unwrap(),
@@ -2736,7 +2768,7 @@ mod tests {
             .clone()
             .oneshot(
                 axum::http::Request::builder()
-                    .uri("/admin/permissions")
+                    .uri(test_app_route("/admin/permissions"))
                     .header("X-Jazz-Admin-Secret", "admin-secret")
                     .body(axum::body::Body::empty())
                     .unwrap(),
@@ -2771,7 +2803,7 @@ mod tests {
         let response = app
             .oneshot(
                 axum::http::Request::builder()
-                    .uri("/admin/permissions")
+                    .uri(test_app_route("/admin/permissions"))
                     .header("X-Jazz-Admin-Secret", "admin-secret")
                     .body(axum::body::Body::empty())
                     .unwrap(),
@@ -2819,8 +2851,10 @@ mod tests {
             .oneshot(
                 axum::http::Request::builder()
                     .uri(format!(
-                        "/admin/schema-connectivity?fromHash={}&toHash={}",
-                        v1_hash, v2_hash
+                        "{}?fromHash={}&toHash={}",
+                        test_app_route("/admin/schema-connectivity"),
+                        v1_hash,
+                        v2_hash
                     ))
                     .header("X-Jazz-Admin-Secret", "admin-secret")
                     .body(axum::body::Body::empty())
@@ -2841,7 +2875,7 @@ mod tests {
             .oneshot(
                 axum::http::Request::builder()
                     .method("POST")
-                    .uri("/admin/migrations")
+                    .uri(test_app_route("/admin/migrations"))
                     .header("Content-Type", "application/json")
                     .header("X-Jazz-Admin-Secret", "admin-secret")
                     .body(axum::body::Body::from(
@@ -2869,8 +2903,10 @@ mod tests {
             .oneshot(
                 axum::http::Request::builder()
                     .uri(format!(
-                        "/admin/schema-connectivity?fromHash={}&toHash={}",
-                        v1_hash, v2_hash
+                        "{}?fromHash={}&toHash={}",
+                        test_app_route("/admin/schema-connectivity"),
+                        v1_hash,
+                        v2_hash
                     ))
                     .header("X-Jazz-Admin-Secret", "admin-secret")
                     .body(axum::body::Body::empty())
@@ -2912,7 +2948,7 @@ mod tests {
             .oneshot(
                 axum::http::Request::builder()
                     .method("POST")
-                    .uri("/admin/schemas")
+                    .uri(test_app_route("/admin/schemas"))
                     .header("Content-Type", "application/json")
                     .header("X-Jazz-Admin-Secret", "admin-secret")
                     .body(axum::body::Body::from(request_body.to_string()))
@@ -2968,7 +3004,7 @@ mod tests {
             .oneshot(
                 axum::http::Request::builder()
                     .method("POST")
-                    .uri("/admin/migrations")
+                    .uri(test_app_route("/admin/migrations"))
                     .header("Content-Type", "application/json")
                     .body(axum::body::Body::from(request_body.to_string()))
                     .unwrap(),
@@ -2981,7 +3017,7 @@ mod tests {
             .oneshot(
                 axum::http::Request::builder()
                     .method("POST")
-                    .uri("/admin/migrations")
+                    .uri(test_app_route("/admin/migrations"))
                     .header("Content-Type", "application/json")
                     .header("X-Jazz-Admin-Secret", "admin-secret")
                     .body(axum::body::Body::from(request_body.to_string()))
@@ -3048,7 +3084,7 @@ mod tests {
             .oneshot(
                 axum::http::Request::builder()
                     .method("POST")
-                    .uri("/admin/migrations")
+                    .uri(test_app_route("/admin/migrations"))
                     .header("Content-Type", "application/json")
                     .header("X-Jazz-Admin-Secret", "admin-secret")
                     .body(axum::body::Body::from(request_body.to_string()))
@@ -3142,7 +3178,7 @@ mod tests {
             .oneshot(
                 axum::http::Request::builder()
                     .method("POST")
-                    .uri("/admin/migrations")
+                    .uri(test_app_route("/admin/migrations"))
                     .header("Content-Type", "application/json")
                     .header("X-Jazz-Admin-Secret", "admin-secret")
                     .body(axum::body::Body::from(request_body.to_string()))
@@ -3205,7 +3241,9 @@ mod tests {
             .clone()
             .oneshot(
                 axum::http::Request::builder()
-                    .uri("/admin/introspection/subscriptions?appId=test-app")
+                    .uri(test_app_route(
+                        "/admin/introspection/subscriptions?appId=test-app",
+                    ))
                     .body(axum::body::Body::empty())
                     .unwrap(),
             )
@@ -3217,7 +3255,9 @@ mod tests {
             .clone()
             .oneshot(
                 axum::http::Request::builder()
-                    .uri("/admin/introspection/subscriptions?appId=test-app")
+                    .uri(test_app_route(
+                        "/admin/introspection/subscriptions?appId=test-app",
+                    ))
                     .header("X-Jazz-Admin-Secret", "wrong-secret")
                     .body(axum::body::Body::empty())
                     .unwrap(),
@@ -3230,7 +3270,7 @@ mod tests {
             .clone()
             .oneshot(
                 axum::http::Request::builder()
-                    .uri("/admin/introspection/subscriptions")
+                    .uri(test_app_route("/admin/introspection/subscriptions"))
                     .header("X-Jazz-Admin-Secret", "admin-secret")
                     .body(axum::body::Body::empty())
                     .unwrap(),
@@ -3242,7 +3282,9 @@ mod tests {
         let invalid_app_id = app
             .oneshot(
                 axum::http::Request::builder()
-                    .uri("/admin/introspection/subscriptions?appId=bad/id")
+                    .uri(test_app_route(
+                        "/admin/introspection/subscriptions?appId=bad/id",
+                    ))
                     .header("X-Jazz-Admin-Secret", "admin-secret")
                     .body(axum::body::Body::empty())
                     .unwrap(),
@@ -3254,7 +3296,9 @@ mod tests {
         let mismatched_app_id = make_test_router(state)
             .oneshot(
                 axum::http::Request::builder()
-                    .uri("/admin/introspection/subscriptions?appId=other-app")
+                    .uri(test_app_route(
+                        "/admin/introspection/subscriptions?appId=other-app",
+                    ))
                     .header("X-Jazz-Admin-Secret", "admin-secret")
                     .body(axum::body::Body::empty())
                     .unwrap(),
@@ -3307,7 +3351,9 @@ mod tests {
         let response = make_test_router(state.clone())
             .oneshot(
                 axum::http::Request::builder()
-                    .uri("/admin/introspection/subscriptions?appId=test-app")
+                    .uri(test_app_route(
+                        "/admin/introspection/subscriptions?appId=test-app",
+                    ))
                     .header("X-Jazz-Admin-Secret", "admin-secret")
                     .body(axum::body::Body::empty())
                     .unwrap(),
@@ -3440,7 +3486,7 @@ mod tests {
         });
 
         let client_id = ClientId::new().to_string();
-        let ws_url = format!("ws://{addr}/ws");
+        let ws_url = format!("ws://{addr}{}", test_app_route("/ws"));
         let (mut ws, _) = connect_async(&ws_url).await.expect("connect ws");
 
         let handshake = crate::transport_manager::AuthHandshake {

--- a/crates/jazz-tools/tests/auth_test.rs
+++ b/crates/jazz-tools/tests/auth_test.rs
@@ -105,7 +105,7 @@ async fn ws_handshake_open(
     server: &TestServer,
     auth: AuthConfig,
 ) -> Result<(WsStream, ConnectedResponse), String> {
-    let ws_url = format!("ws://127.0.0.1:{}/ws", server.port);
+    let ws_url = format!("ws://127.0.0.1:{}/apps/{}/ws", server.port, server.app_id());
     let (mut ws, _) = connect_async(&ws_url)
         .await
         .map_err(|e| format!("ws connect failed: {e}"))?;
@@ -747,7 +747,11 @@ mod integration_tests {
 
         // Push schema via the typed admin endpoint.
         let publish_resp = http_client()
-            .post(format!("{}/admin/schemas", server.base_url()))
+            .post(format!(
+                "{}/apps/{}/admin/schemas",
+                server.base_url(),
+                server.app_id()
+            ))
             .header("X-Jazz-Admin-Secret", ADMIN_SECRET)
             .json(&json!({ "schema": schema, "permissions": null }))
             .send()
@@ -756,7 +760,11 @@ mod integration_tests {
         assert_eq!(publish_resp.status(), StatusCode::CREATED);
 
         let hashes_response = http_client()
-            .get(format!("{}/schemas", server.base_url()))
+            .get(format!(
+                "{}/apps/{}/schemas",
+                server.base_url(),
+                server.app_id()
+            ))
             .header("X-Jazz-Admin-Secret", ADMIN_SECRET)
             .send()
             .await
@@ -770,7 +778,11 @@ mod integration_tests {
         }));
 
         let schema_response = http_client()
-            .get(format!("{}/schema/{expected_hash}", server.base_url()))
+            .get(format!(
+                "{}/apps/{}/schema/{expected_hash}",
+                server.base_url(),
+                server.app_id()
+            ))
             .header("X-Jazz-Admin-Secret", ADMIN_SECRET)
             .send()
             .await

--- a/crates/jazz-tools/tests/catalogue_sync_integration.rs
+++ b/crates/jazz-tools/tests/catalogue_sync_integration.rs
@@ -90,7 +90,13 @@ async fn dynamic_server_denies_reads_until_permissions_head_is_published() {
         "dynamic server should deny reads before any permissions head is published"
     );
 
-    publish_allow_all_permissions(&server.base_url(), server.admin_secret(), &schema).await;
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &schema,
+    )
+    .await;
 
     let admin =
         JazzClient::connect(server.make_client_context_for_user(schema.clone(), "admin-dynamic"))
@@ -174,7 +180,13 @@ async fn dynamic_server_keeps_pre_permissions_user_write_hidden_after_publish() 
         "server should keep queued user writes invisible before permissions arrive"
     );
 
-    publish_allow_all_permissions(&server.base_url(), server.admin_secret(), &schema).await;
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &schema,
+    )
+    .await;
 
     let rows_after_publish = wait_for_query(
         &observer,
@@ -318,7 +330,13 @@ async fn dynamic_server_rejects_user_write_after_permissions_timeout() {
         rows_after_timeout.is_empty(),
         "timed-out write should still be absent before permissions are published"
     );
-    publish_allow_all_permissions(&server.base_url(), server.admin_secret(), &schema).await;
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &schema,
+    )
+    .await;
 
     let allowed_user_id = jazz_tools::ObjectId::new();
     let (allowed_row_id, _) = writer
@@ -391,8 +409,13 @@ async fn dynamic_server_live_subscription_replays_on_first_permissions_head_and_
         "first subscription snapshot should fail closed as an empty delta"
     );
 
-    let allow_head =
-        publish_allow_all_permissions(&server.base_url(), server.admin_secret(), &schema).await;
+    let allow_head = publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &schema,
+    )
+    .await;
 
     let admin =
         JazzClient::connect(server.make_client_context_for_user(schema.clone(), "admin-subscribe"))
@@ -421,6 +444,7 @@ async fn dynamic_server_live_subscription_replays_on_first_permissions_head_and_
 
     publish_permissions(
         &server.base_url(),
+        server.app_id(),
         server.admin_secret(),
         &schema,
         deny_all_select_permissions(&schema),
@@ -484,7 +508,13 @@ async fn catalogue_sync_e2e_schema_evolution_through_sync_manager() {
     )
     .await
     .expect("push catalogue");
-    publish_allow_all_permissions(&server.base_url(), server.admin_secret(), &target_schema).await;
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &target_schema,
+    )
+    .await;
 
     // === Alice connects with v1, creates a user after permissions publish ===
     let alice =
@@ -576,7 +606,13 @@ async fn catalogue_sync_e2e_backward_data_migration_through_sync_manager() {
     )
     .await
     .expect("push catalogue");
-    publish_allow_all_permissions(&server.base_url(), server.admin_secret(), &target_schema).await;
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &target_schema,
+    )
+    .await;
 
     // === Bob connects with v2, creates a user with the new email column ===
     let bob = JazzClient::connect(server.make_client_context_for_user(schema_v2(), "bob-backward"))
@@ -682,6 +718,24 @@ async fn catalogue_sync_e2e_schema_evolution_keeps_authorization_through_v1_head
         .await
         .expect("alice creates user after v1 permissions publish");
 
+    wait_for_query(
+        &alice,
+        query.clone(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "alice row settled before v1 permissions publish",
+        |rows| (rows.len() == 1 && rows[0].0 == user_obj_id).then_some(rows),
+    )
+    .await;
+
+    let v1_schema = schema_v1();
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &v1_schema,
+    )
+    .await;
     push_catalogue_in_memory(
         server.server_state(),
         server.app_id(),

--- a/crates/jazz-tools/tests/catalogue_sync_integration.rs
+++ b/crates/jazz-tools/tests/catalogue_sync_integration.rs
@@ -699,7 +699,13 @@ async fn catalogue_sync_e2e_schema_evolution_keeps_authorization_through_v1_head
     )
     .await
     .expect("push v1 catalogue before publishing v1 permissions");
-    publish_allow_all_permissions(&server.base_url(), server.admin_secret(), &v1_schema).await;
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &v1_schema,
+    )
+    .await;
 
     let alice =
         JazzClient::connect(server.make_client_context_for_user(schema_v1(), "alice-v1-head"))

--- a/crates/jazz-tools/tests/client_restart_integration.rs
+++ b/crates/jazz-tools/tests/client_restart_integration.rs
@@ -386,7 +386,7 @@ async fn jazz_tools_cli_existing_client_keeps_working_after_server_restart_witho
         publish_schema_response.status(),
         reqwest::StatusCode::CREATED
     );
-    publish_allow_all_permissions(&server.base_url(), ADMIN_SECRET, &test_schema()).await;
+    publish_allow_all_permissions(&server.base_url(), app_id, ADMIN_SECRET, &test_schema()).await;
 
     let client_dir = TempDir::new().expect("client dir");
     let client = JazzClient::connect(make_context(

--- a/crates/jazz-tools/tests/client_restart_integration.rs
+++ b/crates/jazz-tools/tests/client_restart_integration.rs
@@ -376,7 +376,11 @@ async fn jazz_tools_cli_existing_client_keeps_working_after_server_restart_witho
 
     let server = ServerProcess::start(0, server_data.path(), &jwks_server.endpoint()).await;
     let publish_schema_response = Client::new()
-        .post(format!("{}/admin/schemas", server.base_url()))
+        .post(format!(
+            "{}/apps/{}/admin/schemas",
+            server.base_url(),
+            APP_ID_STR
+        ))
         .header("X-Jazz-Admin-Secret", ADMIN_SECRET)
         .json(&json!({ "schema": test_schema(), "permissions": null }))
         .send()

--- a/crates/jazz-tools/tests/integration.rs
+++ b/crates/jazz-tools/tests/integration.rs
@@ -17,6 +17,8 @@ use reqwest::Client;
 use tempfile::TempDir;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 
+const TEST_APP_ID: &str = "00000000-0000-0000-0000-000000000001";
+
 fn mint_test_token(audience: &str) -> String {
     let seed = [42u8; 32];
     jazz_tools::identity::mint_jazz_self_signed_token(
@@ -48,11 +50,11 @@ fn frame_decode(data: &[u8]) -> Option<&[u8]> {
     Some(&data[4..4 + len])
 }
 
-/// Perform a WS handshake against `ws://host/ws` using a local-first JWT token.
+/// Perform a WS handshake against `ws://host/apps/<appId>/ws` using a local-first JWT token.
 ///
 /// Returns `Ok(ConnectedResponse)` on success, or `Err(message)` on failure.
 async fn ws_handshake(port: u16, jwt_token: &str) -> Result<ConnectedResponse, String> {
-    let ws_url = format!("ws://127.0.0.1:{port}/ws");
+    let ws_url = format!("ws://127.0.0.1:{port}/apps/{TEST_APP_ID}/ws");
     let (mut ws, _) = connect_async(&ws_url)
         .await
         .map_err(|e| format!("ws connect failed: {e}"))?;
@@ -111,14 +113,12 @@ impl TestServer {
         let bound_port_file = data_dir.path().join("bound-port");
 
         // Use a deterministic UUID app ID for testing
-        let app_id = "00000000-0000-0000-0000-000000000001";
-
         let jazz_binary = Self::find_jazz_binary();
 
         let process = Command::new(&jazz_binary)
             .args([
                 "server",
-                app_id,
+                TEST_APP_ID,
                 "--port",
                 &port.to_string(),
                 "--data-dir",
@@ -155,13 +155,12 @@ impl TestServer {
         let configured_data_dir = data_dir.path().join("should-not-exist");
         let bound_port_file = data_dir.path().join("bound-port");
 
-        let app_id = "00000000-0000-0000-0000-000000000001";
         let jazz_binary = Self::find_jazz_binary();
 
         let process = Command::new(&jazz_binary)
             .args([
                 "server",
-                app_id,
+                TEST_APP_ID,
                 "--port",
                 &port.to_string(),
                 "--data-dir",
@@ -355,7 +354,7 @@ async fn test_ws_connection_stays_open_after_handshake() {
     let server = TestServer::start(0).await;
 
     let token = mint_test_token("00000000-0000-0000-0000-000000000001");
-    let ws_url = format!("ws://127.0.0.1:{}/ws", server.port);
+    let ws_url = format!("ws://127.0.0.1:{}/apps/{TEST_APP_ID}/ws", server.port);
     let (mut ws, _) = connect_async(&ws_url).await.expect("ws connect");
 
     let handshake = AuthHandshake {

--- a/crates/jazz-tools/tests/rocksdb_storage_integration.rs
+++ b/crates/jazz-tools/tests/rocksdb_storage_integration.rs
@@ -243,7 +243,13 @@ async fn make_client(
         .connect()
         .await;
 
-    publish_allow_all_permissions(&server.base_url(), server.admin_secret(), &schema).await;
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &schema,
+    )
+    .await;
 
     client
 }
@@ -280,7 +286,13 @@ async fn make_client_external_jwks(
         |_| Some(()),
     )
     .await;
-    publish_allow_all_permissions(&server.base_url(), server.admin_secret(), &schema).await;
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &schema,
+    )
+    .await;
 
     client
 }

--- a/crates/jazz-tools/tests/sqlite_storage_integration.rs
+++ b/crates/jazz-tools/tests/sqlite_storage_integration.rs
@@ -243,7 +243,13 @@ async fn make_client(
         .connect()
         .await;
 
-    publish_allow_all_permissions(&server.base_url(), server.admin_secret(), &schema).await;
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &schema,
+    )
+    .await;
 
     client
 }
@@ -280,7 +286,13 @@ async fn make_client_external_jwks(
         |_| Some(()),
     )
     .await;
-    publish_allow_all_permissions(&server.base_url(), server.admin_secret(), &schema).await;
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &schema,
+    )
+    .await;
 
     client
 }

--- a/crates/jazz-tools/tests/support/permissions.rs
+++ b/crates/jazz-tools/tests/support/permissions.rs
@@ -63,11 +63,13 @@ pub fn deny_all_select_permissions(schema: &Schema) -> Map<String, JsonValue> {
 
 pub async fn publish_allow_all_permissions(
     base_url: &str,
+    app_id: impl std::fmt::Display,
     admin_secret: &str,
     schema: &Schema,
 ) -> PublishedPermissionsHead {
     publish_permissions(
         base_url,
+        app_id,
         admin_secret,
         schema,
         allow_all_permissions(schema),
@@ -78,6 +80,7 @@ pub async fn publish_allow_all_permissions(
 
 pub async fn publish_permissions(
     base_url: &str,
+    app_id: impl std::fmt::Display,
     admin_secret: &str,
     schema: &Schema,
     permissions: Map<String, JsonValue>,
@@ -90,7 +93,7 @@ pub async fn publish_permissions(
 
     loop {
         let response = client
-            .post(format!("{base_url}/admin/permissions"))
+            .post(format!("{base_url}/apps/{app_id}/admin/permissions"))
             .header("X-Jazz-Admin-Secret", admin_secret)
             .json(&json!({
                 "schemaHash": schema_hash.to_string(),
@@ -117,7 +120,8 @@ pub async fn publish_permissions(
             }
             StatusCode::CONFLICT if !fetched_parent_after_conflict => {
                 expected_parent_bundle_object_id =
-                    fetch_current_parent_bundle_object_id(&client, base_url, admin_secret).await;
+                    fetch_current_parent_bundle_object_id(&client, base_url, &app_id, admin_secret)
+                        .await;
                 fetched_parent_after_conflict = true;
             }
             _ => {
@@ -134,10 +138,11 @@ pub async fn publish_permissions(
 async fn fetch_current_parent_bundle_object_id(
     client: &Client,
     base_url: &str,
+    app_id: &impl std::fmt::Display,
     admin_secret: &str,
 ) -> Option<String> {
     let response = client
-        .get(format!("{base_url}/admin/permissions/head"))
+        .get(format!("{base_url}/apps/{app_id}/admin/permissions/head"))
         .header("X-Jazz-Admin-Secret", admin_secret)
         .send()
         .await

--- a/crates/jazz-tools/tests/test_server.rs
+++ b/crates/jazz-tools/tests/test_server.rs
@@ -18,6 +18,8 @@ use tempfile::TempDir;
 
 const JWT_SECRET: &str = "test-jwt-secret-for-integration";
 const JWT_KID: &str = "test-jwks-kid";
+// Use a deterministic UUID app ID for testing
+const TEST_APP_ID: &str = "00000000-0000-0000-0000-000000000001";
 
 #[derive(Clone)]
 struct JwksState {
@@ -162,9 +164,6 @@ impl TestServer {
         enable_jwks: bool,
         extra_env: Vec<(&str, String)>,
     ) -> Self {
-        // Use a deterministic UUID app ID for testing
-        let app_id = "00000000-0000-0000-0000-000000000001";
-
         let jazz_binary = Self::find_jazz_binary();
         let bound_port_file = data_dir.path().join("bound-port");
 
@@ -172,7 +171,7 @@ impl TestServer {
         command
             .args([
                 "server",
-                app_id,
+                TEST_APP_ID,
                 "--port",
                 &port.to_string(),
                 "--data-dir",
@@ -234,6 +233,10 @@ impl TestServer {
     /// Get the base URL for this server.
     pub fn base_url(&self) -> String {
         format!("http://127.0.0.1:{}", self.port)
+    }
+
+    pub fn app_id(&self) -> &'static str {
+        TEST_APP_ID
     }
 
     /// Wait for the server to become ready by polling /health.

--- a/docs/content/docs/auth/permissions.mdx
+++ b/docs/content/docs/auth/permissions.mdx
@@ -32,7 +32,7 @@ We can define permissions in `permissions.ts`:
 <Callout type="info">
   Write your permissions policies in `permissions.ts` next to `schema.ts`. By default Jazz looks for both files at your project root — except in SvelteKit projects, where they should live in `src/lib/` (the standard location for shared app code).
 
-Run `npx jazz-tools@alpha validate` before publishing to identify any issues. You do not need to write a schema migration to update permissions policies. Push the updated policies by running `npx jazz-tools@alpha deploy`.
+Run `npx jazz-tools@alpha validate` before publishing to identify any issues. You do not need to write a schema migration to update permissions policies. Push the updated policies by running `npx jazz-tools@alpha deploy <appId>`.
 
 </Callout>
 

--- a/docs/content/docs/quickstarts/client.mdx
+++ b/docs/content/docs/quickstarts/client.mdx
@@ -344,6 +344,7 @@ Then publish the permissions bundle:
 
 ```bash title="Terminal"
 npx jazz-tools@alpha deploy \
+  <your-app-id> \
   --server-url http://127.0.0.1:1625 \
   --admin-secret secret
 ```
@@ -362,7 +363,8 @@ Update your client config to use the same app ID, and add `serverUrl`:
 
 Clients pick up the schema from the server when they connect. If you update `schema.ts` you need to [create and push a migration to the new schema](/docs/schemas/migrations) so that clients can understand existing data with the new schema.
 
-Permissions can be updated without adding a new schema by using `npx jazz-tools@alpha deploy`.
+Permissions can be updated without adding a new schema by using
+`npx jazz-tools@alpha deploy <your-app-id>`.
 
 For production deployment and hosting options, see [Server Setup](/docs/getting-started/server-setup).
 

--- a/docs/content/docs/reference/internals.mdx
+++ b/docs/content/docs/reference/internals.mdx
@@ -192,14 +192,11 @@ correct and simple, but worth remembering when including across very large resul
 
 ### Transport
 
-Jazz uses HTTP with binary framing rather than WebSockets or raw SSE text.
+Jazz uses a single WebSocket sync transport plus a small HTTP surface for health and admin reads.
 
-- **Server -> client**: `GET /events?client_id=<uuid>` — a persistent binary stream of
-  length-prefixed JSON frames (`[4-byte u32 BE length][JSON payload]`). Event types include
-  `Connected`, `SyncUpdate`, and `Heartbeat`.
-- **Client -> server**: `POST /sync` — sends row-version updates, query subscription changes, and
-  related sync payloads.
-- **Admin**: `GET /schemas`, `GET /schema/:hash` — schema catalogue reads (requires admin access).
+- **Sync**: `GET /apps/<appId>/ws` upgrades to a WebSocket carrying the typed sync protocol.
+- **Admin**: `GET /apps/<appId>/schemas`, `GET /apps/<appId>/schema/:hash`, and
+  `POST /apps/<appId>/admin/...` handle schema and permissions publication/read flows.
 - **Health**: `GET /health`.
 
 ### Client identity

--- a/docs/content/docs/schemas/migrations.mdx
+++ b/docs/content/docs/schemas/migrations.mdx
@@ -38,13 +38,13 @@ Traditional migration systems run a linear sequence and require peers to converg
 6. **Publish**&hairsp;—&hairsp;push the migration to the server:
 
    ```bash
-   npx jazz-tools@alpha migrations push <fromHash> <toHash>
+   npx jazz-tools@alpha migrations push <appId> <fromHash> <toHash>
    ```
 
    If you also want to publish the current schema, the migration and permissions in one step, you can run:
 
    ```bash
-   npx jazz-tools@alpha deploy
+   npx jazz-tools@alpha deploy <appId>
    ```
 
    `deploy` publishes the current schema if the server does not already know it, checks whether the
@@ -52,7 +52,7 @@ Traditional migration systems run a linear sequence and require peers to converg
    if needed, and then publishes the current permissions.
 
 Permission-only changes in `permissions.ts` do not need migrations, but they do still require
-`npx jazz-tools@alpha deploy`. See [Permissions](/docs/auth/permissions) for details.
+`npx jazz-tools@alpha deploy <appId>`. See [Permissions](/docs/auth/permissions) for details.
 
 ## Generated stub
 
@@ -110,8 +110,8 @@ The Jazz server will detect when there are rows that are not reachable from the 
 In order to do so, you'll need to **create the migration using explicit to/from schema hashes**:
 
 ```bash
-npx jazz-tools@alpha migrations create --fromHash <fromHash>
-npx jazz-tools@alpha migrations create --fromHash <fromHash> --toHash <toHash>
+npx jazz-tools@alpha migrations create <appId> --fromHash <fromHash>
+npx jazz-tools@alpha migrations create <appId> --fromHash <fromHash> --toHash <toHash>
 ```
 
 `--toHash` defaults to the current local schema. When a requested hash is not already saved locally, Jazz resolves it from the
@@ -125,12 +125,15 @@ also saves a snapshot of the schema in the local snapshot directory.
 ```bash
 npx jazz-tools@alpha schema export
 npx jazz-tools@alpha schema export --schema-dir ./packages/app
-npx jazz-tools@alpha schema export --schema-hash <hash> --server-url http://localhost:4200 --admin-secret <secret>
+npx jazz-tools@alpha schema export <appId> --schema-hash <hash> --server-url http://localhost:4200 --admin-secret <secret>
 ```
 
 Without `--schema-hash`, Jazz exports the current local `schema.ts`. With `--schema-hash`, it
 loads the schema from the local snapshot folder or, if missing, from the server.
 `--schema-dir` and `--schema-hash` are mutually exclusive.
+
+Server-backed commands require the app id so Jazz can resolve app-scoped routes like
+`/apps/<appId>/schema/:hash`.
 
 | Flag                   | Default             | Description                                                     |
 | ---------------------- | ------------------- | --------------------------------------------------------------- |
@@ -142,7 +145,8 @@ loads the schema from the local snapshot folder or, if missing, from the server.
 
 ## Migration flags
 
-`migrations create` uses flags rather than positional hashes.
+`migrations create` uses flags rather than positional hashes. When it needs to resolve missing
+schema hashes from a server, pass `<appId>` as the leading positional argument.
 
 | Flag                   | Default             | Description                                      |
 | ---------------------- | ------------------- | ------------------------------------------------ |

--- a/docs/content/partials/schema-setup.mdx
+++ b/docs/content/partials/schema-setup.mdx
@@ -10,6 +10,6 @@ internal schema representation.
 When Jazz reports a difference between the old and new schema hashes after changing `schema.ts`, and your app already has data, you should create and push a migration edge as described in [Migrations](/docs/schemas/migrations):
 
 ```bash
-npx jazz-tools@alpha migrations create --fromHash <fromHash> --toHash <toHash>
-npx jazz-tools@alpha migrations push <fromHash> <toHash>
+npx jazz-tools@alpha migrations create <appId> --fromHash <fromHash> --toHash <toHash>
+npx jazz-tools@alpha migrations push <appId> <fromHash> <toHash>
 ```

--- a/examples/docs/todo-server-rs/docs/migrations-workflow.sh
+++ b/examples/docs/todo-server-rs/docs/migrations-workflow.sh
@@ -4,8 +4,8 @@
 # 1) Edit schema.ts during development and watch for Jazz migration warnings.
 
 # 2) Generate a typed migration stub after Jazz reports the old/new hashes.
-npx jazz-tools@alpha migrations create --fromHash <fromHash> --toHash <toHash>
+npx jazz-tools@alpha migrations create <appId> --fromHash <fromHash> --toHash <toHash>
 
 # 3) Fill in migrate, rename the file, then publish the reviewed edge.
-npx jazz-tools@alpha migrations push <fromHash> <toHash>
+npx jazz-tools@alpha migrations push <appId> <fromHash> <toHash>
 # #endregion migrations-workflow-rust

--- a/examples/docs/todo-server-rs/tests/integration.rs
+++ b/examples/docs/todo-server-rs/tests/integration.rs
@@ -758,6 +758,7 @@ async fn test_server_resync() {
         let permissions_schema = test_schema();
         permissions_support::publish_allow_all_permissions(
             &server.base_url(),
+            test_app_id,
             TEST_ADMIN_SECRET,
             &permissions_schema,
         )

--- a/examples/docs/todo-server-ts/docs/migrations-workflow.sh
+++ b/examples/docs/todo-server-ts/docs/migrations-workflow.sh
@@ -4,8 +4,8 @@
 # 1) Edit schema.ts during development and watch for Jazz migration warnings.
 
 # 2) Generate a typed migration stub after Jazz reports the old/new hashes.
-npx jazz-tools@alpha migrations create --fromHash <fromHash> --toHash <toHash>
+npx jazz-tools@alpha migrations create <appId> --fromHash <fromHash> --toHash <toHash>
 
 # 3) Fill in migrate, rename the file, then publish the reviewed edge.
-npx jazz-tools@alpha migrations push <fromHash> <toHash>
+npx jazz-tools@alpha migrations push <appId> <fromHash> <toHash>
 # #endregion migrations-workflow-ts

--- a/examples/todo-server-rs/docs/migrations-workflow.sh
+++ b/examples/todo-server-rs/docs/migrations-workflow.sh
@@ -3,7 +3,7 @@
 # 1) Edit schema.ts during development and watch for Jazz migration warnings.
 
 # 2) Generate a typed migration stub after Jazz reports the old/new hashes.
-npx jazz-tools@alpha migrations create --fromHash <fromHash> --toHash <toHash>
+npx jazz-tools@alpha migrations create <appId> --fromHash <fromHash> --toHash <toHash>
 
 # 3) Fill in migrate, rename the file, then publish the reviewed edge.
-npx jazz-tools@alpha migrations push <fromHash> <toHash>
+npx jazz-tools@alpha migrations push <appId> <fromHash> <toHash>

--- a/examples/todo-server-rs/tests/integration.rs
+++ b/examples/todo-server-rs/tests/integration.rs
@@ -758,6 +758,7 @@ async fn test_server_resync() {
         let permissions_schema = test_schema();
         permissions_support::publish_allow_all_permissions(
             &server.base_url(),
+            test_app_id,
             TEST_ADMIN_SECRET,
             &permissions_schema,
         )

--- a/examples/wequencer/README.md
+++ b/examples/wequencer/README.md
@@ -48,4 +48,4 @@ Defined in `schema.ts` using the Jazz typed schema DSL. Running `pnpm build` run
 
 ## HTTPS in development
 
-The dev server uses a self-signed TLS certificate (`@vitejs/plugin-basic-ssl`), required because `crypto.subtle` (used by Jazz) is only available in secure contexts. Vite proxies Jazz server requests (`/sync`, `/events`, `/health`, `/auth`) through the same HTTPS origin to avoid mixed content issues. When accessing from another device on the same network, accept the self-signed certificate warning in the browser.
+The dev server uses a self-signed TLS certificate (`@vitejs/plugin-basic-ssl`), required because `crypto.subtle` (used by Jazz) is only available in secure contexts. Vite proxies Jazz server requests (including `/apps/<appId>/ws`, `/apps/<appId>/...`, `/health`, and `/auth`) through the same HTTPS origin to avoid mixed content issues. When accessing from another device on the same network, accept the self-signed certificate warning in the browser.

--- a/examples/wequencer/walkthrough/jazz-wequencer.md
+++ b/examples/wequencer/walkthrough/jazz-wequencer.md
@@ -115,7 +115,7 @@ One call to `createJazzClient` initialises the WASM worker, opens the OPFS datab
   const client = createJazzClient({
     appId: import.meta.env.VITE_JAZZ_APP_ID ?? "wequencer",
     serverUrl: import.meta.env.DEV
-      ? window.location.origin // Vite proxies /sync and /events in dev
+      ? window.location.origin // Vite proxies app-scoped Jazz routes in dev
       : import.meta.env.VITE_JAZZ_SERVER_URL,
   });
 </script>

--- a/packages/inspector/README.md
+++ b/packages/inspector/README.md
@@ -19,7 +19,9 @@ Then open `http://localhost:5173` in your browser (Vite’s default dev server p
   - **adminSecret**: admin secret for that app.
   - **env**: environment name (for example `dev`, `staging`, `prod`). Defaults to `dev` if left empty.
   - **branch**: logical branch name (defaults to `main`).
-  - **serverPathPrefix** (optional): path prefix if your server is not mounted at `/`.
+
+The inspector derives app-scoped endpoints automatically from `serverUrl` and `appId`, so there is
+no separate path-prefix setting.
 
 ## Building the DevTools extension
 

--- a/packages/inspector/src/App.test.tsx
+++ b/packages/inspector/src/App.test.tsx
@@ -169,7 +169,7 @@ describe("App", () => {
       }),
     );
     window.location.hash =
-      "#serverUrl=https%3A%2F%2Fstaging.v2.aws.cloud.jazz.tools&appId=019d9bc9-646b-7560-b26d-b775a7d061d3&serverPathPrefix=%2Fapps%2F019d9bc9-646b-7560-b26d-b775a7d061d3";
+      "#serverUrl=https%3A%2F%2Fstaging.v2.aws.cloud.jazz.tools&appId=019d9bc9-646b-7560-b26d-b775a7d061d3";
 
     render(<App />);
 
@@ -183,9 +183,5 @@ describe("App", () => {
       "019d9bc9-646b-7560-b26d-b775a7d061d3",
     );
     expect(screen.getByLabelText("Admin secret")).toHaveProperty("value", "");
-    expect(screen.getByLabelText(/Path prefix/i)).toHaveProperty(
-      "value",
-      "/apps/019d9bc9-646b-7560-b26d-b775a7d061d3",
-    );
   });
 });

--- a/packages/inspector/src/App.test.tsx
+++ b/packages/inspector/src/App.test.tsx
@@ -133,7 +133,6 @@ describe("App", () => {
         env: "dev",
         branch: "main",
         schemaHash: "hash-b",
-        serverPathPrefix: "/apps/test-app-id",
       }),
     );
 
@@ -149,7 +148,6 @@ describe("App", () => {
     expect(screen.getByLabelText("Server URL")).toHaveProperty("value", "http://localhost:19879");
     expect(screen.getByLabelText("App ID")).toHaveProperty("value", "test-app-id");
     expect(screen.getByLabelText("Admin secret")).toHaveProperty("value", "admin-secret");
-    expect(screen.getByLabelText(/Path prefix/i)).toHaveProperty("value", "/apps/test-app-id");
 
     fireEvent.click(screen.getByRole("button", { name: "Reset connection" }));
 

--- a/packages/inspector/src/App.tsx
+++ b/packages/inspector/src/App.tsx
@@ -16,7 +16,6 @@ interface StoredConfig {
   env: string;
   branch: string;
   schemaHash: string;
-  serverPathPrefix?: string;
 }
 
 const STORAGE_KEY = "jazz-inspector-standalone-config";
@@ -58,7 +57,6 @@ export default function App() {
       env: formValues.env || "dev",
       branch: formValues.branch || "main",
       schemaHash,
-      serverPathPrefix: formValues.serverPathPrefix,
     };
     writeStoredConfig(config);
     setStoredConfig(config);
@@ -132,24 +130,23 @@ export default function App() {
           createJazzClient({
             appId: storedConfig.appId,
             serverUrl: storedConfig.serverUrl,
-            serverPathPrefix: storedConfig.serverPathPrefix,
             env: storedConfig.env,
             userBranch: storedConfig.branch,
             adminSecret: storedConfig.adminSecret,
             driver: { type: "memory" },
           }),
           fetchStoredWasmSchema(storedConfig.serverUrl, {
+            appId: storedConfig.appId,
             adminSecret: storedConfig.adminSecret,
             schemaHash: storedConfig.schemaHash,
-            pathPrefix: storedConfig.serverPathPrefix,
           }),
           fetchSchemaHashes(storedConfig.serverUrl, {
+            appId: storedConfig.appId,
             adminSecret: storedConfig.adminSecret,
-            pathPrefix: storedConfig.serverPathPrefix,
           }),
           fetchStoredPermissions(storedConfig.serverUrl, {
+            appId: storedConfig.appId,
             adminSecret: storedConfig.adminSecret,
-            pathPrefix: storedConfig.serverPathPrefix,
           }).catch(() => null),
         ]);
 
@@ -259,7 +256,6 @@ export default function App() {
             serverUrl: storedConfig.serverUrl,
             appId: storedConfig.appId,
             adminSecret: storedConfig.adminSecret,
-            serverPathPrefix: storedConfig.serverPathPrefix,
           }}
         >
           <BrowserRouter>
@@ -278,7 +274,6 @@ function storedConfigToFormValues(config: StoredConfig): DbConfigFormValues {
     adminSecret: config.adminSecret,
     env: config.env,
     branch: config.branch,
-    serverPathPrefix: config.serverPathPrefix,
   };
 }
 
@@ -324,7 +319,6 @@ function readFragmentConfig(): DbConfigFormValues | null {
     "adminSecret",
     "env",
     "branch",
-    "serverPathPrefix",
   ].some((key) => params.has(key));
 
   if (!hasKnownPrefillParam) {
@@ -337,6 +331,5 @@ function readFragmentConfig(): DbConfigFormValues | null {
     adminSecret: (params.get("adminSecret") ?? "").trim(),
     env: (params.get("env") ?? "dev").trim() || "dev",
     branch: (params.get("branch") ?? "main").trim() || "main",
-    serverPathPrefix: (params.get("serverPathPrefix") ?? "").trim() || undefined,
   };
 }

--- a/packages/inspector/src/App.tsx
+++ b/packages/inspector/src/App.tsx
@@ -313,13 +313,9 @@ function readFragmentConfig(): DbConfigFormValues | null {
   if (!raw) return null;
 
   const params = new URLSearchParams(raw);
-  const hasKnownPrefillParam = [
-    "serverUrl",
-    "appId",
-    "adminSecret",
-    "env",
-    "branch",
-  ].some((key) => params.has(key));
+  const hasKnownPrefillParam = ["serverUrl", "appId", "adminSecret", "env", "branch"].some((key) =>
+    params.has(key),
+  );
 
   if (!hasKnownPrefillParam) {
     return null;

--- a/packages/inspector/src/components/db-config-form/DbConfigForm.tsx
+++ b/packages/inspector/src/components/db-config-form/DbConfigForm.tsx
@@ -8,7 +8,6 @@ export interface DbConfigFormValues {
   adminSecret: string;
   env: string;
   branch: string;
-  serverPathPrefix?: string;
 }
 
 interface DbConfigFormProps {
@@ -29,7 +28,6 @@ export function DbConfigForm({
   const [adminSecret, setAdminSecret] = useState(initialValues?.adminSecret ?? "");
   const [env, setEnv] = useState(initialValues?.env ?? "dev");
   const [branch, setBranch] = useState(initialValues?.branch ?? "main");
-  const [serverPathPrefix, setServerPathPrefix] = useState(initialValues?.serverPathPrefix ?? "");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
@@ -39,7 +37,6 @@ export function DbConfigForm({
     setAdminSecret(initialValues?.adminSecret ?? "");
     setEnv(initialValues?.env ?? "dev");
     setBranch(initialValues?.branch ?? "main");
-    setServerPathPrefix(initialValues?.serverPathPrefix ?? "");
     setIsSubmitting(false);
     setErrorMessage(null);
   }, [initialValues]);
@@ -55,13 +52,12 @@ export function DbConfigForm({
       adminSecret: adminSecret.trim(),
       env: env.trim() || "dev",
       branch: branch.trim() || "main",
-      serverPathPrefix: serverPathPrefix.trim() || undefined,
     };
 
     try {
       const { hashes } = await fetchSchemaHashes(values.serverUrl, {
+        appId: values.appId,
         adminSecret: values.adminSecret,
-        pathPrefix: values.serverPathPrefix,
       });
       onSubmit(values, hashes);
     } catch (error) {
@@ -125,16 +121,6 @@ export function DbConfigForm({
           value={branch}
           onChange={(e) => setBranch(e.target.value)}
           placeholder="main"
-          className={styles.input}
-        />
-      </label>
-      <label className={styles.field}>
-        Path prefix <span className={styles.optionalText}>(optional)</span>
-        <input
-          type="text"
-          value={serverPathPrefix}
-          onChange={(e) => setServerPathPrefix(e.target.value)}
-          placeholder="/apps/&lt;appId&gt;"
           className={styles.input}
         />
       </label>

--- a/packages/inspector/src/contexts/standalone-context.tsx
+++ b/packages/inspector/src/contexts/standalone-context.tsx
@@ -4,7 +4,6 @@ export interface StandaloneConnectionConfig {
   serverUrl: string;
   appId: string;
   adminSecret: string;
-  serverPathPrefix?: string;
 }
 
 interface StandaloneContextValue {

--- a/packages/inspector/src/pages/live-query/index.test.tsx
+++ b/packages/inspector/src/pages/live-query/index.test.tsx
@@ -236,7 +236,6 @@ describe("LiveQuery", () => {
     expect(mockFetchServerSubscriptions).toHaveBeenCalledWith("http://localhost:1625", {
       adminSecret: "admin-secret",
       appId: "test-app",
-      pathPrefix: undefined,
     });
     expect(screen.getByRole("cell", { name: "2" })).not.toBeNull();
     expect(screen.queryByLabelText("Filter by tier")).toBeNull();

--- a/packages/inspector/src/pages/live-query/index.tsx
+++ b/packages/inspector/src/pages/live-query/index.tsx
@@ -157,7 +157,6 @@ function useServerSubscriptionTelemetry(runtime: "standalone" | "extension") {
         const response = await fetchServerSubscriptions(standaloneContext.connection.serverUrl, {
           adminSecret: standaloneContext.connection.adminSecret,
           appId: standaloneContext.connection.appId,
-          pathPrefix: standaloneContext.connection.serverPathPrefix,
         });
         if (cancelled) {
           return;
@@ -190,7 +189,6 @@ function useServerSubscriptionTelemetry(runtime: "standalone" | "extension") {
     runtime,
     standaloneContext?.connection.adminSecret,
     standaloneContext?.connection.appId,
-    standaloneContext?.connection.serverPathPrefix,
     standaloneContext?.connection.serverUrl,
   ]);
 

--- a/packages/jazz-tools/src/backend/create-jazz-context.ts
+++ b/packages/jazz-tools/src/backend/create-jazz-context.ts
@@ -161,7 +161,6 @@ export class JazzContext {
       appId: this.config.appId,
       schema,
       serverUrl: this.config.serverUrl,
-      serverPathPrefix: this.config.serverPathPrefix,
       env: this.config.env,
       userBranch: this.config.userBranch,
       jwtToken: this.config.jwtToken,
@@ -175,15 +174,11 @@ export class JazzContext {
 
     // Wire Rust-owned WebSocket transport when a server URL is configured.
     if (this.config.serverUrl) {
-      this.clientInstance.connectTransport(
-        this.config.serverUrl,
-        {
-          backend_secret: this.config.backendSecret,
-          admin_secret: this.config.adminSecret,
-          jwt_token: this.config.jwtToken,
-        },
-        this.config.serverPathPrefix,
-      );
+      this.clientInstance.connectTransport(this.config.serverUrl, {
+        backend_secret: this.config.backendSecret,
+        admin_secret: this.config.adminSecret,
+        jwt_token: this.config.jwtToken,
+      });
     }
 
     return this.clientInstance;
@@ -194,7 +189,6 @@ export class JazzContext {
       appId: this.config.appId,
       driver: this.config.driver.type === "memory" ? { type: "memory" } : { type: "persistent" },
       serverUrl: this.config.serverUrl,
-      serverPathPrefix: this.config.serverPathPrefix,
       env: this.config.env,
       userBranch: this.config.userBranch,
       jwtToken: this.config.jwtToken,

--- a/packages/jazz-tools/src/cli.test.ts
+++ b/packages/jazz-tools/src/cli.test.ts
@@ -16,11 +16,11 @@ import { fileURLToPath } from "node:url";
 import { afterEach, assert, describe, expect, it, vi } from "vitest";
 import { loadWasmModule } from "./runtime/client.js";
 import {
-  createMigration,
-  deploy,
-  exportSchema,
-  permissionsStatus,
-  pushMigration,
+  createMigration as rawCreateMigration,
+  deploy as rawDeploy,
+  exportSchema as rawExportSchema,
+  permissionsStatus as rawPermissionsStatus,
+  pushMigration as rawPushMigration,
   validate,
 } from "./cli.js";
 
@@ -35,6 +35,24 @@ const bootstrapVerifierPath = fileURLToPath(
 const packageRoot = dirname(fileURLToPath(import.meta.url));
 const tmpBase = join(packageRoot, ".test-tmp");
 const tempRoots: string[] = [];
+const APP_ID = "test-app";
+
+function withAppId<T extends { appId?: string }>(options: T): T & { appId: string } {
+  return { appId: APP_ID, ...options };
+}
+
+const exportSchema = (options: Parameters<typeof rawExportSchema>[0]) =>
+  rawExportSchema(withAppId(options));
+const createMigration = (options: Parameters<typeof rawCreateMigration>[0]) =>
+  rawCreateMigration(withAppId(options));
+const pushMigration = (
+  options: Omit<Parameters<typeof rawPushMigration>[0], "appId"> & { appId?: string },
+) => rawPushMigration(withAppId(options));
+const permissionsStatus = (
+  options: Omit<Parameters<typeof rawPermissionsStatus>[0], "appId"> & { appId?: string },
+) => rawPermissionsStatus(withAppId(options));
+const deploy = (options: Omit<Parameters<typeof rawDeploy>[0], "appId"> & { appId?: string }) =>
+  rawDeploy(withAppId(options));
 
 afterEach(async () => {
   vi.unstubAllGlobals();
@@ -700,11 +718,11 @@ describe("cli migrations", () => {
     const toHash = "7171717171717171717171717171717171717171717171717171717171717171";
 
     const fetchMock = vi.fn(async (input: string) => {
-      if (input.endsWith("/schemas")) {
+      if (input.endsWith(`/apps/${APP_ID}/schemas`)) {
         return new Response(JSON.stringify({ hashes: [fromHash, toHash] }), { status: 200 });
       }
 
-      if (input.endsWith(`/schema/${fromHash}`)) {
+      if (input.endsWith(`/apps/${APP_ID}/schema/${fromHash}`)) {
         return storedSchemaResponse({
           todos: {
             columns: [
@@ -715,7 +733,7 @@ describe("cli migrations", () => {
         });
       }
 
-      if (input.endsWith(`/schema/${toHash}`)) {
+      if (input.endsWith(`/apps/${APP_ID}/schema/${toHash}`)) {
         return storedSchemaResponse(storedBooleanTodoSchemaWithDefaultFalse());
       }
 
@@ -749,15 +767,15 @@ describe("cli migrations", () => {
     const fromHash = "1010101010101010101010101010101010101010101010101010101010101010";
     const toHash = "2020202020202020202020202020202020202020202020202020202020202020";
     const fetchMock = vi.fn(async (input: string) => {
-      if (input.endsWith("/schemas")) {
+      if (input.endsWith(`/apps/${APP_ID}/schemas`)) {
         return new Response(JSON.stringify({ hashes: [fromHash, toHash] }), { status: 200 });
       }
 
-      if (input.endsWith(`/schema/${fromHash}`)) {
+      if (input.endsWith(`/apps/${APP_ID}/schema/${fromHash}`)) {
         return storedSchemaResponse(storedRootSchema());
       }
 
-      if (input.endsWith(`/schema/${toHash}`)) {
+      if (input.endsWith(`/apps/${APP_ID}/schema/${toHash}`)) {
         return storedSchemaResponse(storedRootSchemaWithReorderedColumns());
       }
 
@@ -902,11 +920,11 @@ describe("cli migrations", () => {
     const toHash = "4040404040404040404040404040404040404040404040404040404040404040";
 
     const fetchMock = vi.fn(async (input: string) => {
-      if (input.endsWith("/schemas")) {
+      if (input.endsWith(`/apps/${APP_ID}/schemas`)) {
         return new Response(JSON.stringify({ hashes: [fromHash, toHash] }), { status: 200 });
       }
 
-      if (input.endsWith(`/schema/${fromHash}`)) {
+      if (input.endsWith(`/apps/${APP_ID}/schema/${fromHash}`)) {
         return storedSchemaResponse({
           todos: {
             columns: [{ name: "done", column_type: { type: "Boolean" }, nullable: false }],
@@ -914,7 +932,7 @@ describe("cli migrations", () => {
         });
       }
 
-      if (input.endsWith(`/schema/${toHash}`)) {
+      if (input.endsWith(`/apps/${APP_ID}/schema/${toHash}`)) {
         return storedSchemaResponse({
           todos: {
             columns: [{ name: "done", column_type: { type: "Boolean" }, nullable: true }],
@@ -983,11 +1001,11 @@ describe("cli migrations", () => {
     const fromShortHash = fromHash.slice(0, 12);
 
     const fetchMock = vi.fn(async (input: string) => {
-      if (input.endsWith("/schemas")) {
+      if (input.endsWith(`/apps/${APP_ID}/schemas`)) {
         return new Response(JSON.stringify({ hashes: [fromHash] }), { status: 200 });
       }
 
-      if (input.endsWith(`/schema/${fromHash}`)) {
+      if (input.endsWith(`/apps/${APP_ID}/schema/${fromHash}`)) {
         return storedSchemaResponse({
           todos: {
             columns: [{ name: "title", column_type: { type: "Text" }, nullable: false }],
@@ -1040,11 +1058,11 @@ describe("cli migrations", () => {
     const toShortHash = toHash.slice(0, 12);
 
     const fetchMock = vi.fn(async (input: string) => {
-      if (input.endsWith("/schemas")) {
+      if (input.endsWith(`/apps/${APP_ID}/schemas`)) {
         return new Response(JSON.stringify({ hashes: [fromHash, toHash] }), { status: 200 });
       }
 
-      if (input.endsWith(`/schema/${fromHash}`)) {
+      if (input.endsWith(`/apps/${APP_ID}/schema/${fromHash}`)) {
         return storedSchemaResponse({
           todos: {
             columns: [{ name: "title", column_type: { type: "Text" }, nullable: false }],
@@ -1055,7 +1073,7 @@ describe("cli migrations", () => {
         });
       }
 
-      if (input.endsWith(`/schema/${toHash}`)) {
+      if (input.endsWith(`/apps/${APP_ID}/schema/${toHash}`)) {
         return storedSchemaResponse({
           todos: {
             columns: [
@@ -1103,11 +1121,11 @@ describe("cli migrations", () => {
     const toShortHash = toHash.slice(0, 12);
 
     const fetchMock = vi.fn(async (input: string) => {
-      if (input.endsWith("/schemas")) {
+      if (input.endsWith(`/apps/${APP_ID}/schemas`)) {
         return new Response(JSON.stringify({ hashes: [fromHash, toHash] }), { status: 200 });
       }
 
-      if (input.endsWith(`/schema/${fromHash}`)) {
+      if (input.endsWith(`/apps/${APP_ID}/schema/${fromHash}`)) {
         return storedSchemaResponse({
           users: {
             columns: [{ name: "email", column_type: { type: "Text" }, nullable: false }],
@@ -1115,7 +1133,7 @@ describe("cli migrations", () => {
         });
       }
 
-      if (input.endsWith(`/schema/${toHash}`)) {
+      if (input.endsWith(`/apps/${APP_ID}/schema/${toHash}`)) {
         return storedSchemaResponse({
           people: {
             columns: [{ name: "email", column_type: { type: "Text" }, nullable: false }],
@@ -1156,11 +1174,11 @@ describe("cli migrations", () => {
     const toShortHash = toHash.slice(0, 12);
 
     const fetchMock = vi.fn(async (input: string) => {
-      if (input.endsWith("/schemas")) {
+      if (input.endsWith(`/apps/${APP_ID}/schemas`)) {
         return new Response(JSON.stringify({ hashes: [fromHash, toHash] }), { status: 200 });
       }
 
-      if (input.endsWith(`/schema/${fromHash}`)) {
+      if (input.endsWith(`/apps/${APP_ID}/schema/${fromHash}`)) {
         return storedSchemaResponse({
           users: {
             columns: [{ name: "email", column_type: { type: "Text" }, nullable: false }],
@@ -1171,7 +1189,7 @@ describe("cli migrations", () => {
         });
       }
 
-      if (input.endsWith(`/schema/${toHash}`)) {
+      if (input.endsWith(`/apps/${APP_ID}/schema/${toHash}`)) {
         return storedSchemaResponse({
           companies: {
             columns: [{ name: "slug", column_type: { type: "Text" }, nullable: false }],
@@ -1218,11 +1236,11 @@ describe("cli migrations", () => {
     const toShortHash = toHash.slice(0, 12);
 
     const fetchMock = vi.fn(async (input: string) => {
-      if (input.endsWith("/schemas")) {
+      if (input.endsWith(`/apps/${APP_ID}/schemas`)) {
         return new Response(JSON.stringify({ hashes: [fromHash, toHash] }), { status: 200 });
       }
 
-      if (input.endsWith(`/schema/${fromHash}`)) {
+      if (input.endsWith(`/apps/${APP_ID}/schema/${fromHash}`)) {
         return storedSchemaResponse({
           archived_users: {
             columns: [{ name: "email", column_type: { type: "Text" }, nullable: false }],
@@ -1233,7 +1251,7 @@ describe("cli migrations", () => {
         });
       }
 
-      if (input.endsWith(`/schema/${toHash}`)) {
+      if (input.endsWith(`/apps/${APP_ID}/schema/${toHash}`)) {
         return storedSchemaResponse({
           people: {
             columns: [{ name: "email", column_type: { type: "Text" }, nullable: false }],
@@ -1303,7 +1321,7 @@ export default s.defineMigration({
     );
 
     const fetchMock = vi.fn(async (_input: string, init?: RequestInit) => {
-      if (_input.endsWith("/schemas")) {
+      if (_input.endsWith(`/apps/${APP_ID}/schemas`)) {
         return new Response(JSON.stringify({ hashes: [fromHash, toHash] }), { status: 200 });
       }
 
@@ -1390,7 +1408,7 @@ export default s.defineMigration({
     );
 
     const fetchMock = vi.fn(async (_input: string, init?: RequestInit) => {
-      if (_input.endsWith("/schemas")) {
+      if (_input.endsWith(`/apps/${APP_ID}/schemas`)) {
         return new Response(JSON.stringify({ hashes: [fromHash, toHash] }), { status: 200 });
       }
 
@@ -1485,11 +1503,11 @@ export default s.defineMigration({
     );
 
     const fetchMock = vi.fn(async (_input: string, init?: RequestInit) => {
-      if (_input.endsWith("/schemas")) {
+      if (_input.endsWith(`/apps/${APP_ID}/schemas`)) {
         return new Response(JSON.stringify({ hashes: [fromHash, toHash] }), { status: 200 });
       }
 
-      if (_input.endsWith(`/schema/${fromHash}`)) {
+      if (_input.endsWith(`/apps/${APP_ID}/schema/${fromHash}`)) {
         return storedSchemaResponse({
           todos: {
             columns: [
@@ -1500,7 +1518,7 @@ export default s.defineMigration({
         });
       }
 
-      if (_input.endsWith(`/schema/${toHash}`)) {
+      if (_input.endsWith(`/apps/${APP_ID}/schema/${toHash}`)) {
         return storedSchemaResponse(storedBooleanTodoSchemaWithDefaultFalse());
       }
 
@@ -1544,15 +1562,15 @@ export default s.defineMigration({
     );
 
     const fetchMock = vi.fn(async (_input: string, init?: RequestInit) => {
-      if (_input.endsWith("/schemas")) {
+      if (_input.endsWith(`/apps/${APP_ID}/schemas`)) {
         return new Response(JSON.stringify({ hashes: [fromHash, toHash] }), { status: 200 });
       }
 
-      if (_input.endsWith(`/schema/${fromHash}`)) {
+      if (_input.endsWith(`/apps/${APP_ID}/schema/${fromHash}`)) {
         return storedSchemaResponse(storedRootSchema());
       }
 
-      if (_input.endsWith(`/schema/${toHash}`)) {
+      if (_input.endsWith(`/apps/${APP_ID}/schema/${toHash}`)) {
         return storedSchemaResponse(storedRootSchemaWithReorderedColumns());
       }
 
@@ -1586,11 +1604,11 @@ export default s.defineMigration({
     const toShortHash = toHash.slice(0, 12);
 
     const fetchMock = vi.fn(async (input: string) => {
-      if (input.endsWith("/schemas")) {
+      if (input.endsWith(`/apps/${APP_ID}/schemas`)) {
         return new Response(JSON.stringify({ hashes: [fromHash, toHash] }), { status: 200 });
       }
 
-      if (input.endsWith(`/schema/${fromHash}`)) {
+      if (input.endsWith(`/apps/${APP_ID}/schema/${fromHash}`)) {
         return storedSchemaResponse({
           memberships: {
             columns: [
@@ -1605,7 +1623,7 @@ export default s.defineMigration({
         });
       }
 
-      if (input.endsWith(`/schema/${toHash}`)) {
+      if (input.endsWith(`/apps/${APP_ID}/schema/${toHash}`)) {
         return storedSchemaResponse({
           memberships: {
             columns: [
@@ -1680,7 +1698,7 @@ export default s.defineMigration({
     );
 
     const fetchMock = vi.fn(async (_input: string, init?: RequestInit) => {
-      if (_input.endsWith("/schemas")) {
+      if (_input.endsWith(`/apps/${APP_ID}/schemas`)) {
         return new Response(JSON.stringify({ hashes: [fromHash, toHash] }), { status: 200 });
       }
 
@@ -1764,7 +1782,7 @@ export default s.defineMigration({
     );
 
     const fetchMock = vi.fn(async (_input: string, init?: RequestInit) => {
-      if (_input.endsWith("/schemas")) {
+      if (_input.endsWith(`/apps/${APP_ID}/schemas`)) {
         return new Response(JSON.stringify({ hashes: [fromHash, toHash] }), { status: 200 });
       }
 
@@ -1807,15 +1825,15 @@ describe("cli permissions", () => {
 
     const schemaHash = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
     const fetchMock = vi.fn(async (input: string) => {
-      if (input.endsWith("/schemas")) {
+      if (input.endsWith(`/apps/${APP_ID}/schemas`)) {
         return new Response(JSON.stringify({ hashes: [schemaHash] }), { status: 200 });
       }
 
-      if (input.endsWith(`/schema/${schemaHash}`)) {
+      if (input.endsWith(`/apps/${APP_ID}/schema/${schemaHash}`)) {
         return storedSchemaResponse(storedRootSchema());
       }
 
-      if (input.endsWith("/admin/permissions/head")) {
+      if (input.endsWith(`/apps/${APP_ID}/admin/permissions/head`)) {
         return new Response(
           JSON.stringify({
             head: {
@@ -1835,6 +1853,7 @@ describe("cli permissions", () => {
 
     const { logs } = await captureConsoleLogs(() =>
       permissionsStatus({
+        appId: APP_ID,
         serverUrl: "http://localhost:1625",
         adminSecret: "admin-secret",
         schemaDir: root,
@@ -1861,15 +1880,15 @@ describe("cli permissions", () => {
 
     const schemaHash = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
     const fetchMock = vi.fn(async (input: string) => {
-      if (input.endsWith("/schemas")) {
+      if (input.endsWith(`/apps/${APP_ID}/schemas`)) {
         return new Response(JSON.stringify({ hashes: [schemaHash] }), { status: 200 });
       }
 
-      if (input.endsWith(`/schema/${schemaHash}`)) {
+      if (input.endsWith(`/apps/${APP_ID}/schema/${schemaHash}`)) {
         return storedSchemaResponse(storedRootSchema());
       }
 
-      if (input.endsWith("/admin/permissions/head")) {
+      if (input.endsWith(`/apps/${APP_ID}/admin/permissions/head`)) {
         return new Response(JSON.stringify({ head: null }), { status: 200 });
       }
 
@@ -1879,6 +1898,7 @@ describe("cli permissions", () => {
 
     const { logs } = await captureConsoleLogs(() =>
       permissionsStatus({
+        appId: APP_ID,
         serverUrl: "http://localhost:1625",
         adminSecret: "admin-secret",
         schemaDir: root,
@@ -1896,15 +1916,15 @@ describe("cli permissions", () => {
 
     const schemaHash = "ababeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
     const fetchMock = vi.fn(async (input: string) => {
-      if (input.endsWith("/schemas")) {
+      if (input.endsWith(`/apps/${APP_ID}/schemas`)) {
         return new Response(JSON.stringify({ hashes: [schemaHash] }), { status: 200 });
       }
 
-      if (input.endsWith(`/schema/${schemaHash}`)) {
+      if (input.endsWith(`/apps/${APP_ID}/schema/${schemaHash}`)) {
         return storedSchemaResponse(storedRootSchemaWithReorderedColumns());
       }
 
-      if (input.endsWith("/admin/permissions/head")) {
+      if (input.endsWith(`/apps/${APP_ID}/admin/permissions/head`)) {
         return new Response(JSON.stringify({ head: null }), { status: 200 });
       }
 
@@ -1914,6 +1934,7 @@ describe("cli permissions", () => {
 
     const { logs } = await captureConsoleLogs(() =>
       permissionsStatus({
+        appId: APP_ID,
         serverUrl: "http://localhost:1625",
         adminSecret: "admin-secret",
         schemaDir: root,
@@ -1933,6 +1954,7 @@ describe("cli deploy", () => {
 
     await expect(
       deploy({
+        appId: APP_ID,
         serverUrl: "http://localhost:1625",
         adminSecret: "admin-secret",
         schemaDir: root,
@@ -1951,7 +1973,7 @@ describe("cli deploy", () => {
     let permissionsPublishBody: any;
 
     const fetchMock = vi.fn(async (input: string, init?: RequestInit) => {
-      if (input.endsWith("/admin/schemas")) {
+      if (input.endsWith(`/apps/${APP_ID}/admin/schemas`)) {
         schemaPublishBody = JSON.parse(String(init?.body));
         return new Response(
           JSON.stringify({
@@ -1962,15 +1984,15 @@ describe("cli deploy", () => {
         );
       }
 
-      if (input.endsWith("/schemas")) {
+      if (input.endsWith(`/apps/${APP_ID}/schemas`)) {
         return new Response(JSON.stringify({ hashes: [] }), { status: 200 });
       }
 
-      if (input.endsWith("/admin/permissions/head")) {
+      if (input.endsWith(`/apps/${APP_ID}/admin/permissions/head`)) {
         return new Response(JSON.stringify({ head: null }), { status: 200 });
       }
 
-      if (input.endsWith("/admin/permissions")) {
+      if (input.endsWith(`/apps/${APP_ID}/admin/permissions`)) {
         permissionsPublishBody = JSON.parse(String(init?.body));
         return new Response(
           JSON.stringify({
@@ -1990,6 +2012,7 @@ describe("cli deploy", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await deploy({
+      appId: APP_ID,
       serverUrl: "http://localhost:1625",
       adminSecret: "admin-secret",
       schemaDir: root,
@@ -2018,19 +2041,19 @@ describe("cli deploy", () => {
     let permissionsPublishBody: any;
 
     const fetchMock = vi.fn(async (input: string, init?: RequestInit) => {
-      if (input.endsWith("/schemas")) {
+      if (input.endsWith(`/apps/${APP_ID}/schemas`)) {
         return new Response(JSON.stringify({ hashes: [schemaHash] }), { status: 200 });
       }
 
-      if (input.endsWith(`/schema/${schemaHash}`)) {
+      if (input.endsWith(`/apps/${APP_ID}/schema/${schemaHash}`)) {
         return storedSchemaResponse(storedRootSchema());
       }
 
-      if (input.endsWith("/admin/permissions/head")) {
+      if (input.endsWith(`/apps/${APP_ID}/admin/permissions/head`)) {
         return new Response(JSON.stringify({ head: currentHead }), { status: 200 });
       }
 
-      if (input.endsWith("/admin/permissions")) {
+      if (input.endsWith(`/apps/${APP_ID}/admin/permissions`)) {
         permissionsPublishBody = JSON.parse(String(init?.body));
         return new Response(
           JSON.stringify({
@@ -2045,7 +2068,7 @@ describe("cli deploy", () => {
         );
       }
 
-      if (input.endsWith("/admin/schemas")) {
+      if (input.endsWith(`/apps/${APP_ID}/admin/schemas`)) {
         throw new Error("deploy() should not publish an unchanged structural schema.");
       }
 
@@ -2054,6 +2077,7 @@ describe("cli deploy", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await deploy({
+      appId: APP_ID,
       serverUrl: "http://localhost:1625",
       adminSecret: "admin-secret",
       schemaDir: root,
@@ -2079,13 +2103,13 @@ describe("cli deploy", () => {
     };
 
     const fetchMock = vi.fn(async (input: string, _init?: RequestInit) => {
-      if (input.endsWith("/schemas")) {
+      if (input.endsWith(`/apps/${APP_ID}/schemas`)) {
         return new Response(JSON.stringify({ hashes: [previousSchemaHash, nextSchemaHash] }), {
           status: 200,
         });
       }
 
-      if (input.endsWith(`/schema/${previousSchemaHash}`)) {
+      if (input.endsWith(`/apps/${APP_ID}/schema/${previousSchemaHash}`)) {
         return storedSchemaResponse({
           todos: {
             columns: [
@@ -2096,18 +2120,18 @@ describe("cli deploy", () => {
         });
       }
 
-      if (input.endsWith(`/schema/${nextSchemaHash}`)) {
+      if (input.endsWith(`/apps/${APP_ID}/schema/${nextSchemaHash}`)) {
         return storedSchemaResponse(storedRootSchema());
       }
 
-      if (input.includes("/admin/schema-connectivity?")) {
+      if (input.includes(`/apps/${APP_ID}/admin/schema-connectivity?`)) {
         const url = new URL(input);
         expect(url.searchParams.get("fromHash")).toBe(previousSchemaHash);
         expect(url.searchParams.get("toHash")).toBe(nextSchemaHash);
         return new Response(JSON.stringify({ connected: false }), { status: 200 });
       }
 
-      if (input.endsWith("/admin/permissions/head")) {
+      if (input.endsWith(`/apps/${APP_ID}/admin/permissions/head`)) {
         return new Response(JSON.stringify({ head: currentHead }), { status: 200 });
       }
 
@@ -2117,13 +2141,14 @@ describe("cli deploy", () => {
 
     await expect(
       deploy({
+        appId: APP_ID,
         serverUrl: "http://localhost:1625",
         adminSecret: "admin-secret",
         schemaDir: root,
         migrationsDir: join(root, "migrations"),
       }),
     ).rejects.toThrow(
-      "The new permissions schema bbbbbbbbbbbb is not connected to the previous permissions schema aaaaaaaaaaaa on the server. Reads and writes may fail until you push a migration. Run `jazz-tools migrations create --fromHash aaaaaaaaaaaa --toHash bbbbbbbbbbbb` to create a migration and then re-run this command.",
+      "The new permissions schema bbbbbbbbbbbb is not connected to the previous permissions schema aaaaaaaaaaaa on the server. Reads and writes may fail until you push a migration. Run `jazz-tools migrations create test-app --fromHash aaaaaaaaaaaa --toHash bbbbbbbbbbbb` to create a migration and then re-run this command.",
     );
   });
 
@@ -2173,13 +2198,13 @@ export default s.defineMigration({
     );
 
     const fetchMock = vi.fn(async (input: string, init?: RequestInit) => {
-      if (input.endsWith("/schemas")) {
+      if (input.endsWith(`/apps/${APP_ID}/schemas`)) {
         return new Response(JSON.stringify({ hashes: [previousSchemaHash, nextSchemaHash] }), {
           status: 200,
         });
       }
 
-      if (input.endsWith(`/schema/${previousSchemaHash}`)) {
+      if (input.endsWith(`/apps/${APP_ID}/schema/${previousSchemaHash}`)) {
         return storedSchemaResponse({
           users: {
             columns: [{ name: "email", column_type: { type: "Text" }, nullable: false }],
@@ -2187,19 +2212,19 @@ export default s.defineMigration({
         });
       }
 
-      if (input.endsWith(`/schema/${nextSchemaHash}`)) {
+      if (input.endsWith(`/apps/${APP_ID}/schema/${nextSchemaHash}`)) {
         return storedSchemaResponse(storedRootSchema());
       }
 
-      if (input.includes("/admin/schema-connectivity?")) {
+      if (input.includes(`/apps/${APP_ID}/admin/schema-connectivity?`)) {
         return new Response(JSON.stringify({ connected: false }), { status: 200 });
       }
 
-      if (input.endsWith("/admin/permissions/head")) {
+      if (input.endsWith(`/apps/${APP_ID}/admin/permissions/head`)) {
         return new Response(JSON.stringify({ head: currentHead }), { status: 200 });
       }
 
-      if (input.endsWith("/admin/migrations")) {
+      if (input.endsWith(`/apps/${APP_ID}/admin/migrations`)) {
         const body = JSON.parse(String(init?.body));
         expect(body.fromHash).toBe(previousSchemaHash);
         expect(body.toHash).toBe(nextSchemaHash);
@@ -2225,7 +2250,7 @@ export default s.defineMigration({
         );
       }
 
-      if (input.endsWith("/admin/permissions")) {
+      if (input.endsWith(`/apps/${APP_ID}/admin/permissions`)) {
         return new Response(
           JSON.stringify({
             head: {
@@ -2245,6 +2270,7 @@ export default s.defineMigration({
 
     const { logs } = await captureConsoleLogs(() =>
       deploy({
+        appId: APP_ID,
         serverUrl: "http://localhost:1625",
         adminSecret: "admin-secret",
         schemaDir: root,
@@ -2271,13 +2297,13 @@ export default s.defineMigration({
     };
 
     const fetchMock = vi.fn(async (input: string, _init?: RequestInit) => {
-      if (input.endsWith("/schemas")) {
+      if (input.endsWith(`/apps/${APP_ID}/schemas`)) {
         return new Response(JSON.stringify({ hashes: [previousSchemaHash, nextSchemaHash] }), {
           status: 200,
         });
       }
 
-      if (input.endsWith(`/schema/${previousSchemaHash}`)) {
+      if (input.endsWith(`/apps/${APP_ID}/schema/${previousSchemaHash}`)) {
         return storedSchemaResponse({
           todos: {
             columns: [
@@ -2288,19 +2314,19 @@ export default s.defineMigration({
         });
       }
 
-      if (input.endsWith(`/schema/${nextSchemaHash}`)) {
+      if (input.endsWith(`/apps/${APP_ID}/schema/${nextSchemaHash}`)) {
         return storedSchemaResponse(storedRootSchema());
       }
 
-      if (input.includes("/admin/schema-connectivity?")) {
+      if (input.includes(`/apps/${APP_ID}/admin/schema-connectivity?`)) {
         return new Response(JSON.stringify({ connected: false }), { status: 200 });
       }
 
-      if (input.endsWith("/admin/permissions/head")) {
+      if (input.endsWith(`/apps/${APP_ID}/admin/permissions/head`)) {
         return new Response(JSON.stringify({ head: currentHead }), { status: 200 });
       }
 
-      if (input.endsWith("/admin/permissions")) {
+      if (input.endsWith(`/apps/${APP_ID}/admin/permissions`)) {
         return new Response(
           JSON.stringify({
             head: {
@@ -2320,6 +2346,7 @@ export default s.defineMigration({
 
     const { logs } = await captureConsoleLogs(() =>
       deploy({
+        appId: APP_ID,
         serverUrl: "http://localhost:1625",
         adminSecret: "admin-secret",
         schemaDir: root,
@@ -2494,7 +2521,7 @@ describe("bin integration", () => {
       "utf8",
     );
 
-    const result = runBin(["schema", "export", "--schema-hash", schemaHash], {
+    const result = runBin(["schema", "export", APP_ID, "--schema-hash", schemaHash], {
       cwd: root,
     });
 
@@ -2539,7 +2566,7 @@ describe("bin integration", () => {
     }) as typeof process.stdout.write);
 
     const fetchMock = vi.fn(async (input: string, init?: RequestInit) => {
-      expect(input).toContain(`/schema/${schemaHash}`);
+      expect(input).toContain(`/apps/${APP_ID}/schema/${schemaHash}`);
       expect(init?.method).toBe("GET");
       expect(init?.headers).toMatchObject({ "X-Jazz-Admin-Secret": "admin-secret" });
       return storedSchemaResponse(schema, publishedAt);
@@ -2589,7 +2616,7 @@ describe("bin integration", () => {
     }) as typeof process.stdout.write);
 
     const exportFetchMock = vi.fn(async (input: string, init?: RequestInit) => {
-      expect(input).toContain(`/schema/${schemaHash}`);
+      expect(input).toContain(`/apps/${APP_ID}/schema/${schemaHash}`);
       expect(init?.method).toBe("GET");
       expect(init?.headers).toMatchObject({ "X-Jazz-Admin-Secret": "admin-secret" });
       return storedSchemaResponse(schema, publishedAt);

--- a/packages/jazz-tools/src/cli.ts
+++ b/packages/jazz-tools/src/cli.ts
@@ -39,6 +39,7 @@ export interface SchemaExportOptions {
   schemaDir: string;
   migrationsDir?: string;
   schemaHash?: string;
+  appId?: string;
   serverUrl?: string;
   adminSecret?: string;
 }
@@ -101,7 +102,9 @@ export async function validate(options: BuildOptions): Promise<void> {
   if (compiled.permissionsFile) {
     console.log(`Loaded current permissions from ${compiled.permissionsFile}.`);
     console.log(PERMISSIONS_LIFECYCLE_NOTE);
-    console.log("Use `jazz-tools permissions status` or `jazz-tools deploy` for auth publication.");
+    console.log(
+      "Use `jazz-tools permissions status <appId>` or `jazz-tools deploy <appId>` for auth publication.",
+    );
   }
   for (const diagnostic of collectMissingExplicitPolicyDiagnostics(
     compiled.schema.tables.map((table) => table.name),
@@ -125,6 +128,7 @@ export async function exportSchema(options: SchemaExportOptions): Promise<void> 
 }
 
 export interface MigrationCommandOptions {
+  appId?: string;
   serverUrl?: string;
   adminSecret?: string;
   migrationsDir: string;
@@ -132,6 +136,7 @@ export interface MigrationCommandOptions {
 }
 
 export interface PermissionsCommandOptions {
+  appId: string;
   serverUrl: string;
   adminSecret: string;
   schemaDir: string;
@@ -152,6 +157,7 @@ export interface PushMigrationOptions extends MigrationCommandOptions {
 }
 
 export interface DeployOptions {
+  appId: string;
   serverUrl: string;
   adminSecret: string;
   schemaDir: string;
@@ -182,6 +188,18 @@ function hasFlag(args: string[], flag: string): boolean {
   return args.includes(flag);
 }
 
+function splitLeadingAppId(args: string[]): { appId?: string; args: string[] } {
+  const first = args[0];
+  if (!first || first.startsWith("-")) {
+    return { args };
+  }
+
+  return {
+    appId: first,
+    args: args.slice(1),
+  };
+}
+
 function resolveMigrationOptions(args: string[]): MigrationCommandOptions {
   const serverUrl = getFlagValue(args, "--server-url") ?? process.env.JAZZ_SERVER_URL;
   const adminSecret = getFlagValue(args, "--admin-secret") ?? process.env.JAZZ_ADMIN_SECRET;
@@ -199,7 +217,7 @@ function resolveMigrationOptions(args: string[]): MigrationCommandOptions {
   };
 }
 
-function resolvePermissionsOptions(args: string[]): PermissionsCommandOptions {
+function resolvePermissionsOptions(args: string[]): Omit<PermissionsCommandOptions, "appId"> {
   const serverUrl = getFlagValue(args, "--server-url") ?? process.env.JAZZ_SERVER_URL;
   const adminSecret = getFlagValue(args, "--admin-secret") ?? process.env.JAZZ_ADMIN_SECRET;
   const schemaDir = resolve(process.cwd(), getFlagValue(args, "--schema-dir") ?? process.cwd());
@@ -428,11 +446,23 @@ function requireSchemaExportServerValue(
   throw new Error("Missing admin secret. Pass --admin-secret <secret> or set JAZZ_ADMIN_SECRET.");
 }
 
+function requireAppId(appId: string | undefined): string {
+  if (appId) {
+    return appId;
+  }
+
+  throw new Error(
+    "Missing app ID. Pass an <appId> positional argument for server-backed requests.",
+  );
+}
+
 function requireMigrationServerOptions(options: MigrationCommandOptions): {
+  appId: string;
   serverUrl: string;
   adminSecret: string;
 } {
   return {
+    appId: requireAppId(options.appId),
     serverUrl: requireSchemaExportServerValue(options.serverUrl, "serverUrl"),
     adminSecret: requireSchemaExportServerValue(options.adminSecret, "adminSecret"),
   };
@@ -458,6 +488,7 @@ async function resolveExportedSchemaByHash(options: SchemaExportOptions): Promis
     options.adminSecret ?? process.env.JAZZ_ADMIN_SECRET,
     "adminSecret",
   );
+  const appId = requireAppId(options.appId);
 
   const resolvedHash =
     schemaHash.length === 64
@@ -465,9 +496,10 @@ async function resolveExportedSchemaByHash(options: SchemaExportOptions): Promis
       : resolveKnownSchemaHash(
           schemaHash,
           "schema hash",
-          (await fetchSchemaHashes(serverUrl, { adminSecret })).hashes,
+          (await fetchSchemaHashes(serverUrl, { appId, adminSecret })).hashes,
         );
   const storedSchema = await fetchStoredWasmSchema(serverUrl, {
+    appId,
     adminSecret,
     schemaHash: resolvedHash,
   });
@@ -678,11 +710,12 @@ function ensurePermissionsProject(compiled: LoadedSchemaProject): LoadedSchemaPr
  * If the provided schema exists in the server, returns its hash. Otherwise, throws an error.
  */
 async function resolveStoredStructuralSchemaHashOrThrow(
+  appId: string,
   serverUrl: string,
   adminSecret: string,
   wasmSchema: WasmSchema,
 ): Promise<string> {
-  const hash = await resolveStoredStructuralSchemaHash(serverUrl, adminSecret, wasmSchema);
+  const hash = await resolveStoredStructuralSchemaHash(appId, serverUrl, adminSecret, wasmSchema);
   if (!hash) {
     throw new Error(
       "No stored structural schema matches the local schema.ts. Publish the structural schema before pushing permissions.",
@@ -693,15 +726,17 @@ async function resolveStoredStructuralSchemaHashOrThrow(
 }
 
 async function resolveStoredStructuralSchemaHash(
+  appId: string,
   serverUrl: string,
   adminSecret: string,
   wasmSchema: WasmSchema,
 ): Promise<string | null> {
-  const { hashes } = await fetchSchemaHashes(serverUrl, { adminSecret });
+  const { hashes } = await fetchSchemaHashes(serverUrl, { appId, adminSecret });
   const storedSchemas = await Promise.all(
     hashes.map(async (hash) => ({
       hash,
-      schema: (await fetchStoredWasmSchema(serverUrl, { adminSecret, schemaHash: hash })).schema,
+      schema: (await fetchStoredWasmSchema(serverUrl, { appId, adminSecret, schemaHash: hash }))
+        .schema,
     })),
   );
 
@@ -1331,6 +1366,7 @@ async function resolveHistoricalSchema(
   migrationsDir: string,
   hash: string,
   label: string,
+  appId: string | undefined,
   serverUrl: string | undefined,
   adminSecret: string | undefined,
 ): Promise<ResolvedSchemaInput> {
@@ -1369,16 +1405,19 @@ async function resolveHistoricalSchema(
           label,
           (
             await fetchSchemaHashes(requireSchemaExportServerValue(serverUrl, "serverUrl"), {
+              appId: requireAppId(appId),
               adminSecret: requireSchemaExportServerValue(adminSecret, "adminSecret"),
             })
           ).hashes,
         );
 
+  const resolvedAppId = requireAppId(appId);
   const resolvedServerUrl = requireSchemaExportServerValue(serverUrl, "serverUrl");
   const resolvedAdminSecret = requireSchemaExportServerValue(adminSecret, "adminSecret");
 
   try {
     const storedSchema = await fetchStoredWasmSchema(resolvedServerUrl, {
+      appId: resolvedAppId,
       adminSecret: resolvedAdminSecret,
       schemaHash: resolvedHash,
     });
@@ -1417,6 +1456,7 @@ export async function createMigration(options: CreateMigrationOptions): Promise<
         options.migrationsDir,
         options.fromHash,
         "fromHash",
+        options.appId,
         options.serverUrl,
         options.adminSecret,
       );
@@ -1435,6 +1475,7 @@ export async function createMigration(options: CreateMigrationOptions): Promise<
           options.migrationsDir,
           options.toHash,
           "toHash",
+          options.appId,
           options.serverUrl,
           options.adminSecret,
         )
@@ -1478,7 +1519,7 @@ export async function createMigration(options: CreateMigrationOptions): Promise<
       "No reviewed migration file needed because this schema change does not require row transformations.",
     );
     console.log(
-      `Next step: Run npx jazz-tools@${version} migrations push ${shortSchemaHash(fromSchema.hash)} ${shortSchemaHash(toSchema.hash)}`,
+      `Next step: Run npx jazz-tools@${version} migrations push ${options.appId ?? "<appId>"} ${shortSchemaHash(fromSchema.hash)} ${shortSchemaHash(toSchema.hash)}`,
     );
     return null;
   }
@@ -1518,15 +1559,16 @@ export async function createMigration(options: CreateMigrationOptions): Promise<
     console.log("2. Rename the file by replacing 'unnamed'.");
   }
   console.log(
-    `${options.name ? "2" : "3"}. Run npx jazz-tools@${version} migrations push ${shortSchemaHash(fromSchema.hash)} ${shortSchemaHash(toSchema.hash)}`,
+    `${options.name ? "2" : "3"}. Run npx jazz-tools@${version} migrations push ${options.appId ?? "<appId>"} ${shortSchemaHash(fromSchema.hash)} ${shortSchemaHash(toSchema.hash)}`,
   );
 
   return filePath;
 }
 
 export async function pushMigration(options: PushMigrationOptions): Promise<void> {
-  const { serverUrl, adminSecret } = requireMigrationServerOptions(options);
+  const { appId, serverUrl, adminSecret } = requireMigrationServerOptions(options);
   const { hashes } = await fetchSchemaHashes(serverUrl, {
+    appId,
     adminSecret,
   });
   const fromHash = resolveKnownSchemaHash(options.fromHash, "fromHash", hashes);
@@ -1549,6 +1591,7 @@ export async function pushMigration(options: PushMigrationOptions): Promise<void
       options.migrationsDir,
       fromHash,
       "fromHash",
+      appId,
       serverUrl,
       adminSecret,
     );
@@ -1556,17 +1599,19 @@ export async function pushMigration(options: PushMigrationOptions): Promise<void
       options.migrationsDir,
       toHash,
       "toHash",
+      appId,
       serverUrl,
       adminSecret,
     );
 
     if (schemaTransitionRequiresRowTransform(fromSchema.schema, toSchema.schema)) {
       throw new Error(
-        `No migration file found in ${options.migrationsDir} for ${fromHash} -> ${toHash}. Run \`jazz-tools migrations create --fromHash ${shortSchemaHash(fromHash)} --toHash ${shortSchemaHash(toHash)}\` first.`,
+        `No migration file found in ${options.migrationsDir} for ${fromHash} -> ${toHash}. Run \`jazz-tools migrations create ${appId} --fromHash ${shortSchemaHash(fromHash)} --toHash ${shortSchemaHash(toHash)}\` first.`,
       );
     }
 
     await publishStoredMigration(serverUrl, {
+      appId,
       adminSecret,
       fromHash,
       toHash,
@@ -1598,6 +1643,7 @@ export async function pushMigration(options: PushMigrationOptions): Promise<void
       options.migrationsDir,
       fromHash,
       "fromHash",
+      appId,
       serverUrl,
       adminSecret,
     );
@@ -1605,6 +1651,7 @@ export async function pushMigration(options: PushMigrationOptions): Promise<void
       options.migrationsDir,
       toHash,
       "toHash",
+      appId,
       serverUrl,
       adminSecret,
     );
@@ -1616,6 +1663,7 @@ export async function pushMigration(options: PushMigrationOptions): Promise<void
 
   const forward = migration.forward.length === 0 ? [] : serializeForwardLenses(migration.forward);
   await publishStoredMigration(serverUrl, {
+    appId,
     adminSecret,
     fromHash,
     toHash,
@@ -1634,11 +1682,13 @@ function describePermissionsHead(head: StoredPermissionsHead): string {
 export async function permissionsStatus(options: PermissionsCommandOptions): Promise<void> {
   const compiled = ensurePermissionsProject(await loadCompiledSchema(options.schemaDir));
   const localSchemaHash = await resolveStoredStructuralSchemaHashOrThrow(
+    options.appId,
     options.serverUrl,
     options.adminSecret,
     compiled.wasmSchema,
   );
   const { head } = await fetchPermissionsHead(options.serverUrl, {
+    appId: options.appId,
     adminSecret: options.adminSecret,
   });
 
@@ -1670,6 +1720,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
   console.log(`Loaded current permissions from ${compiled.permissionsFile}.`);
 
   let localSchemaHash = await resolveStoredStructuralSchemaHash(
+    options.appId,
     options.serverUrl,
     options.adminSecret,
     compiled.wasmSchema,
@@ -1677,6 +1728,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
 
   if (!localSchemaHash) {
     const publishedSchema = await publishStoredSchema(options.serverUrl, {
+      appId: options.appId,
       adminSecret: options.adminSecret,
       schema: compiled.wasmSchema,
     });
@@ -1689,6 +1741,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
   }
 
   const { head: currentHead } = await fetchPermissionsHead(options.serverUrl, {
+    appId: options.appId,
     adminSecret: options.adminSecret,
   });
   if (currentHead && currentHead.schemaHash !== localSchemaHash) {
@@ -1697,6 +1750,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
 
     try {
       const { connected } = await fetchSchemaConnectivity(options.serverUrl, {
+        appId: options.appId,
         adminSecret: options.adminSecret,
         fromHash: currentHead.schemaHash,
         toHash: localSchemaHash,
@@ -1704,6 +1758,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
 
       if (!connected) {
         await pushMigration({
+          appId: options.appId,
           serverUrl: options.serverUrl,
           adminSecret: options.adminSecret,
           migrationsDir: options.migrationsDir,
@@ -1717,7 +1772,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
         throw error;
       }
 
-      const message = `The new permissions schema ${toShortHash} is not connected to the previous permissions schema ${fromShortHash} on the server. Reads and writes may fail until you push a migration. Run \`jazz-tools migrations create --fromHash ${fromShortHash} --toHash ${toShortHash}\` to create a migration and then re-run this command.`;
+      const message = `The new permissions schema ${toShortHash} is not connected to the previous permissions schema ${fromShortHash} on the server. Reads and writes may fail until you push a migration. Run \`jazz-tools migrations create ${options.appId} --fromHash ${fromShortHash} --toHash ${toShortHash}\` to create a migration and then re-run this command.`;
       if (options.noVerify) {
         console.warn(`Warning: ${message}`);
       } else {
@@ -1727,6 +1782,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
   }
 
   const { head: publishedHead } = await publishStoredPermissions(options.serverUrl, {
+    appId: options.appId,
     adminSecret: options.adminSecret,
     schemaHash: localSchemaHash,
     permissions: compiled.permissions,
@@ -1763,12 +1819,12 @@ if (isMainModule()) {
     const subcommand = process.argv[3] ?? "";
     if (subcommand !== "export") {
       console.error(
-        "Usage: node dist/cli.js schema export [--schema-dir <path> | --schema-hash <hash>] [--migrations-dir <path>] [--server-url <url>] [--admin-secret <secret>]",
+        "Usage: node dist/cli.js schema export [<appId>] [--schema-dir <path> | --schema-hash <hash>] [--migrations-dir <path>] [--server-url <url>] [--admin-secret <secret>]",
       );
       process.exit(1);
     }
 
-    const args = process.argv.slice(4);
+    const { appId, args } = splitLeadingAppId(process.argv.slice(4));
     const schemaDirFlag = getFlagValue(args, "--schema-dir");
     const schemaHash = getFlagValue(args, "--schema-hash");
     if (schemaDirFlag && schemaHash) {
@@ -1783,6 +1839,7 @@ if (isMainModule()) {
         ? resolve(process.cwd(), getFlagValue(args, "--migrations-dir")!)
         : undefined,
       schemaHash,
+      appId,
       serverUrl: getFlagValue(args, "--server-url") ?? process.env.JAZZ_SERVER_URL,
       adminSecret: getFlagValue(args, "--admin-secret") ?? process.env.JAZZ_ADMIN_SECRET,
     }).catch((err) => {
@@ -1794,30 +1851,34 @@ if (isMainModule()) {
     let task: Promise<unknown>;
 
     if (subcommand === "create") {
-      const args = process.argv.slice(4);
+      const { appId, args } = splitLeadingAppId(process.argv.slice(4));
       const options = resolveMigrationOptions(args);
       task = createMigration({
         ...options,
+        appId,
         schemaDir: options.schemaDir ?? process.cwd(),
         fromHash: getFlagValue(args, "--fromHash"),
         toHash: getFlagValue(args, "--toHash"),
         name: getFlagValue(args, "--name"),
       });
     } else if (subcommand === "push") {
-      const fromHash = process.argv[4];
-      const toHash = process.argv[5];
-      const sharedArgs = process.argv.slice(6);
+      const appId = process.argv[4];
+      const fromHash = process.argv[5];
+      const toHash = process.argv[6];
+      const sharedArgs = process.argv.slice(7);
 
-      if (!fromHash || !toHash) {
-        console.error("Usage: node dist/cli.js migrations push <fromHash> <toHash> [options]");
+      if (!appId || !fromHash || !toHash) {
+        console.error(
+          "Usage: node dist/cli.js migrations push <appId> <fromHash> <toHash> [options]",
+        );
         process.exit(1);
       }
 
       const options = resolveMigrationOptions(sharedArgs);
-      task = pushMigration({ ...options, fromHash, toHash });
+      task = pushMigration({ ...options, appId, fromHash, toHash });
     } else {
       task = Promise.reject(
-        new Error("Usage: node dist/cli.js migrations <create|push> [options]"),
+        new Error("Usage: node dist/cli.js migrations <create|push> [<appId>] [options]"),
       );
     }
 
@@ -1827,19 +1888,20 @@ if (isMainModule()) {
     });
   } else if (command === "permissions") {
     const subcommand = process.argv[3] ?? "";
-    const options = resolvePermissionsOptions(process.argv.slice(4));
+    const { appId, args } = splitLeadingAppId(process.argv.slice(4));
+    const options = { ...resolvePermissionsOptions(args), appId: requireAppId(appId) };
     const task =
       subcommand === "status"
         ? permissionsStatus(options)
-        : Promise.reject(new Error("Usage: node dist/cli.js permissions status [options]"));
+        : Promise.reject(new Error("Usage: node dist/cli.js permissions status <appId> [options]"));
 
     task.catch((err) => {
       console.error(err.message);
       process.exit(1);
     });
   } else if (command === "deploy") {
-    const args = process.argv.slice(3);
-    const options = resolveMigrationOptions(args);
+    const { appId, args } = splitLeadingAppId(process.argv.slice(3));
+    const options = { ...resolveMigrationOptions(args), appId };
     deploy({
       ...requireMigrationServerOptions(options),
       schemaDir: options.schemaDir ?? process.cwd(),
@@ -1854,25 +1916,32 @@ if (isMainModule()) {
     console.log("\nCommands:");
     console.log("  validate              Validate root schema.ts and optional permissions.ts");
     console.log("  schema export         Print the compiled structural schema as JSON");
-    console.log("  deploy                Publish the current schema.ts and permissions.ts");
-    console.log("  permissions status    Show the current server permissions head for this app");
+    console.log("  deploy <appId>        Publish the current schema.ts and permissions.ts");
+    console.log(
+      "  permissions status <appId> Show the current server permissions head for this app",
+    );
     console.log(
       "  migrations create     Generate a typed structural migration stub between two schema versions",
     );
-    console.log("  migrations push       Push a reviewed migration edge to the server");
+    console.log(
+      "  migrations push <appId> <fromHash> <toHash> Push a reviewed migration edge to the server",
+    );
     console.log("\nValidation options:");
     console.log("  --schema-dir <path>   Path to app root containing schema.ts (default: .)");
     console.log("\nSchema export options:");
+    console.log("  <appId>               Required for server-backed schema export by hash");
     console.log("  --schema-dir <path>   Path to app root containing schema.ts (default: .)");
     console.log("  --schema-hash <hash>  Export a stored structural schema by hash");
     console.log("  --migrations-dir <p>  Path to migrations directory (default: ./migrations)");
     console.log("  --server-url <url>    Jazz server URL (or set JAZZ_SERVER_URL)");
     console.log("  --admin-secret <sec>  Admin secret (or set JAZZ_ADMIN_SECRET)");
     console.log("\nPermissions options:");
+    console.log("  <appId>               Required");
     console.log("  --schema-dir <path>   Path to app root containing schema.ts (default: .)");
     console.log("  --server-url <url>    Jazz server URL (or set JAZZ_SERVER_URL)");
     console.log("  --admin-secret <sec>  Admin secret (or set JAZZ_ADMIN_SECRET)");
     console.log("\nMigration options:");
+    console.log("  <appId>               Required for remote create/push commands");
     console.log("  --schema-dir <path>   Path to app root containing schema.ts (default: .)");
     console.log("  --server-url <url>    Jazz server URL (or set JAZZ_SERVER_URL)");
     console.log("  --admin-secret <sec>  Admin secret (or set JAZZ_ADMIN_SECRET)");

--- a/packages/jazz-tools/src/dev-tools/protocol.ts
+++ b/packages/jazz-tools/src/dev-tools/protocol.ts
@@ -235,7 +235,6 @@ export function sanitizeDbConfigForBridge(dbConfig: DbConfig | null): DbConfig |
   return {
     appId: dbConfig.appId,
     serverUrl: dbConfig.serverUrl,
-    serverPathPrefix: dbConfig.serverPathPrefix,
     env: dbConfig.env,
     userBranch: dbConfig.userBranch,
     devMode: dbConfig.devMode,

--- a/packages/jazz-tools/src/dev/dev-server.ts
+++ b/packages/jazz-tools/src/dev/dev-server.ts
@@ -165,15 +165,18 @@ export async function pushSchemaCatalogue(
 ): Promise<{ hash: string }> {
   const compiled = await loadCompiledSchema(options.schemaDir);
   const result = await publishStoredSchema(options.serverUrl, {
+    appId: options.appId,
     adminSecret: options.adminSecret,
     schema: compiled.wasmSchema,
   });
 
   if (compiled.permissions) {
     const { head } = await fetchPermissionsHead(options.serverUrl, {
+      appId: options.appId,
       adminSecret: options.adminSecret,
     });
     await publishStoredPermissions(options.serverUrl, {
+      appId: options.appId,
       adminSecret: options.adminSecret,
       schemaHash: result.hash,
       permissions: compiled.permissions,

--- a/packages/jazz-tools/src/dev/expo.test.ts
+++ b/packages/jazz-tools/src/dev/expo.test.ts
@@ -72,9 +72,12 @@ describe("withJazz", () => {
     const healthResponse = await fetch(`http://127.0.0.1:${port}/health`);
     expect(healthResponse.ok).toBe(true);
 
-    const schemasResponse = await fetch(`http://127.0.0.1:${port}/schemas`, {
-      headers: { "X-Jazz-Admin-Secret": "expo-test-admin" },
-    });
+    const schemasResponse = await fetch(
+      `http://127.0.0.1:${port}/apps/${resolved.extra?.jazzAppId}/schemas`,
+      {
+        headers: { "X-Jazz-Admin-Secret": "expo-test-admin" },
+      },
+    );
     expect(schemasResponse.ok).toBe(true);
 
     const body = (await schemasResponse.json()) as { hashes?: string[] };

--- a/packages/jazz-tools/src/dev/next.test.ts
+++ b/packages/jazz-tools/src/dev/next.test.ts
@@ -103,9 +103,12 @@ describe("withJazz", () => {
     const healthResponse = await fetch(`http://127.0.0.1:${port}/health`);
     expect(healthResponse.ok).toBe(true);
 
-    const schemasResponse = await fetch(`http://127.0.0.1:${port}/schemas`, {
-      headers: { "X-Jazz-Admin-Secret": "next-test-admin" },
-    });
+    const schemasResponse = await fetch(
+      `http://127.0.0.1:${port}/apps/${resolved.env?.NEXT_PUBLIC_JAZZ_APP_ID}/schemas`,
+      {
+        headers: { "X-Jazz-Admin-Secret": "next-test-admin" },
+      },
+    );
     expect(schemasResponse.ok).toBe(true);
 
     const body = (await schemasResponse.json()) as { hashes?: string[] };

--- a/packages/jazz-tools/src/dev/sveltekit.test.ts
+++ b/packages/jazz-tools/src/dev/sveltekit.test.ts
@@ -64,9 +64,12 @@ describe("jazzSvelteKit", () => {
     const healthResponse = await fetch(`http://127.0.0.1:${port}/health`);
     expect(healthResponse.ok).toBe(true);
 
-    const schemasResponse = await fetch(`http://127.0.0.1:${port}/schemas`, {
-      headers: { "X-Jazz-Admin-Secret": "sveltekit-test-admin" },
-    });
+    const schemasResponse = await fetch(
+      `http://127.0.0.1:${port}/apps/${viteServer.config.env!.PUBLIC_JAZZ_APP_ID}/schemas`,
+      {
+        headers: { "X-Jazz-Admin-Secret": "sveltekit-test-admin" },
+      },
+    );
     expect(schemasResponse.ok).toBe(true);
     const body = (await schemasResponse.json()) as { hashes?: string[] };
     expect(body.hashes?.length).toBeGreaterThan(0);

--- a/packages/jazz-tools/src/dev/vite.test.ts
+++ b/packages/jazz-tools/src/dev/vite.test.ts
@@ -61,9 +61,12 @@ describe("jazzPlugin", () => {
     const healthResponse = await fetch(`http://127.0.0.1:${port}/health`);
     expect(healthResponse.ok).toBe(true);
 
-    const schemasResponse = await fetch(`http://127.0.0.1:${port}/schemas`, {
-      headers: { "X-Jazz-Admin-Secret": "vite-test-admin" },
-    });
+    const schemasResponse = await fetch(
+      `http://127.0.0.1:${port}/apps/${fakeViteServer.config.env.JAZZ_APP_ID}/schemas`,
+      {
+        headers: { "X-Jazz-Admin-Secret": "vite-test-admin" },
+      },
+    );
     expect(schemasResponse.ok).toBe(true);
     const body = (await schemasResponse.json()) as { hashes?: string[] };
     expect(body.hashes?.length).toBeGreaterThan(0);

--- a/packages/jazz-tools/src/react-native/db.test.ts
+++ b/packages/jazz-tools/src/react-native/db.test.ts
@@ -93,7 +93,6 @@ describe("react-native Db", () => {
     const config: DbConfig = {
       appId: "rn-app",
       serverUrl: "https://example.test",
-      serverPathPrefix: "/apps/rn-app",
       env: "prod",
       userBranch: "user-branch",
       jwtToken: "jwt-token",
@@ -123,7 +122,6 @@ describe("react-native Db", () => {
         appId: config.appId,
         schema,
         serverUrl: config.serverUrl,
-        serverPathPrefix: config.serverPathPrefix,
         env: config.env,
         userBranch: config.userBranch,
         jwtToken: config.jwtToken,
@@ -253,20 +251,15 @@ describe("react-native Db", () => {
     const db = new TestDb({
       appId: "rn-app",
       serverUrl: "https://example.test",
-      serverPathPrefix: "/apps/rn-app",
       jwtToken: "jwt-x",
       adminSecret: "admin-y",
     });
     db.exposeGetClient(makeSchema("todos"));
 
-    expect(stub.connectTransport).toHaveBeenCalledWith(
-      "https://example.test",
-      {
-        jwt_token: "jwt-x",
-        admin_secret: "admin-y",
-      },
-      "/apps/rn-app",
-    );
+    expect(stub.connectTransport).toHaveBeenCalledWith("https://example.test", {
+      jwt_token: "jwt-x",
+      admin_secret: "admin-y",
+    });
   });
 
   it("RNDB-U09 does not call connectTransport when serverUrl is absent", () => {

--- a/packages/jazz-tools/src/react-native/db.ts
+++ b/packages/jazz-tools/src/react-native/db.ts
@@ -37,7 +37,6 @@ export class Db extends RuntimeDb {
           appId: this.nativeConfig.appId,
           schema,
           serverUrl: this.nativeConfig.serverUrl,
-          serverPathPrefix: this.nativeConfig.serverPathPrefix,
           env: this.nativeConfig.env,
           userBranch: this.nativeConfig.userBranch,
           jwtToken: this.nativeConfig.jwtToken,
@@ -53,14 +52,10 @@ export class Db extends RuntimeDb {
       );
 
       if (this.nativeConfig.serverUrl) {
-        client.connectTransport(
-          this.nativeConfig.serverUrl,
-          {
-            jwt_token: this.nativeConfig.jwtToken,
-            admin_secret: this.nativeConfig.adminSecret,
-          },
-          this.nativeConfig.serverPathPrefix,
-        );
+        client.connectTransport(this.nativeConfig.serverUrl, {
+          jwt_token: this.nativeConfig.jwtToken,
+          admin_secret: this.nativeConfig.adminSecret,
+        });
       }
 
       this.nativeClients.set(key, client);

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -25,8 +25,8 @@ import {
   resolveRuntimeConfigSyncInitInput,
   resolveRuntimeConfigWasmUrl,
 } from "./runtime-config.js";
-import { httpUrlToWs } from "./url.js";
 import { normalizeRuntimeWriteError } from "./anonymous-write-denied-error.js";
+import { appScopedUrl, httpUrlToWs } from "./url.js";
 
 /**
  * Minimal request shape supported by `JazzClient.forRequest()`.
@@ -2450,8 +2450,7 @@ export class JazzClient {
     if (!this.context.serverUrl) {
       throw new Error("No server connection");
     }
-    const normalizedPath = path.startsWith("/") ? path : `/${path}`;
-    return `${this.context.serverUrl.replace(/\/+$/, "")}/apps/${encodeURIComponent(this.context.appId)}${normalizedPath}`;
+    return appScopedUrl(this.context.serverUrl, this.context.appId, path);
   }
 
   /**

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -9,7 +9,6 @@ import type { AppContext, RuntimeSourcesConfig, Session } from "./context.js";
 import type { InsertValues, Value, RowDelta, WasmSchema } from "../drivers/types.js";
 import { normalizeRuntimeSchema, serializeRuntimeSchema } from "../drivers/schema-wire.js";
 import {
-  buildEndpointUrl,
   applyUserAuthHeaders,
   type AuthFailureReason,
   type RuntimeSyncOutboxCallback,
@@ -2401,15 +2400,14 @@ export class JazzClient {
    * passing it to the underlying Rust runtime's `connect()`.  Already-WS URLs
    * are passed through unchanged.
    *
-   * @param url        Server URL — http(s):// or ws(s)://. `/ws` is appended automatically.
-   * @param auth       Authentication credentials for the connection.
-   * @param pathPrefix Optional path prefix inserted before `/ws` (e.g. `/apps/<id>`).
+   * @param url  Server URL — http(s):// or ws(s)://. `/apps/<appId>/ws` is appended automatically.
+   * @param auth Authentication credentials for the connection.
    */
-  connectTransport(url: string, auth: AuthConfig, pathPrefix?: string): void {
+  connectTransport(url: string, auth: AuthConfig): void {
     if (!this.runtime.connect) {
       throw new Error("Underlying runtime does not support connect()");
     }
-    this.runtime.connect(httpUrlToWs(url, pathPrefix), JSON.stringify(auth));
+    this.runtime.connect(httpUrlToWs(url, this.context.appId), JSON.stringify(auth));
   }
 
   /**
@@ -2452,7 +2450,8 @@ export class JazzClient {
     if (!this.context.serverUrl) {
       throw new Error("No server connection");
     }
-    return buildEndpointUrl(this.context.serverUrl, path, this.context.serverPathPrefix);
+    const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+    return `${this.context.serverUrl.replace(/\/+$/, "")}/apps/${encodeURIComponent(this.context.appId)}${normalizedPath}`;
   }
 
   /**

--- a/packages/jazz-tools/src/runtime/context.ts
+++ b/packages/jazz-tools/src/runtime/context.ts
@@ -64,8 +64,6 @@ export interface AppContext {
 
   /** Optional server URL for sync */
   serverUrl?: string;
-  /** Optional route prefix for multi-tenant servers (e.g. `/apps/<appId>`). */
-  serverPathPrefix?: string;
 
   /** Optional runtime source overrides for WASM and worker loading. */
   runtimeSources?: RuntimeSourcesConfig;

--- a/packages/jazz-tools/src/runtime/db.transport.test.ts
+++ b/packages/jazz-tools/src/runtime/db.transport.test.ts
@@ -37,31 +37,26 @@ describe("runtime/Db direct path upstream wiring", () => {
     vi.restoreAllMocks();
   });
 
-  it("DBRT-U01 calls connectTransport with serverUrl and serverPathPrefix when configured and no worker", () => {
+  it("DBRT-U01 calls connectTransport with serverUrl and derived app scope when configured and no worker", () => {
     const client = makeClientStub();
     const connectSyncSpy = vi.spyOn(JazzClient, "connectSync").mockReturnValue(client);
 
     const db = new TestDb({
       appId: "app",
       serverUrl: "https://example.test",
-      serverPathPrefix: "/apps/app",
       jwtToken: "jwt-x",
       adminSecret: "admin-y",
     });
     db.exposeGetClient(makeSchema());
 
     expect(connectSyncSpy).toHaveBeenCalledTimes(1);
-    expect((client as any).connectTransport).toHaveBeenCalledWith(
-      "https://example.test",
-      {
-        jwt_token: "jwt-x",
-        admin_secret: "admin-y",
-      },
-      "/apps/app",
-    );
+    expect((client as any).connectTransport).toHaveBeenCalledWith("https://example.test", {
+      jwt_token: "jwt-x",
+      admin_secret: "admin-y",
+    });
   });
 
-  it("DBRT-U01b calls connectTransport without prefix when serverPathPrefix is absent", () => {
+  it("DBRT-U01b calls connectTransport without a separate prefix argument", () => {
     const client = makeClientStub();
     vi.spyOn(JazzClient, "connectSync").mockReturnValue(client);
 
@@ -73,14 +68,10 @@ describe("runtime/Db direct path upstream wiring", () => {
     });
     db.exposeGetClient(makeSchema());
 
-    expect((client as any).connectTransport).toHaveBeenCalledWith(
-      "https://example.test",
-      {
-        jwt_token: "jwt-x",
-        admin_secret: "admin-y",
-      },
-      undefined,
-    );
+    expect((client as any).connectTransport).toHaveBeenCalledWith("https://example.test", {
+      jwt_token: "jwt-x",
+      admin_secret: "admin-y",
+    });
   });
 
   it("DBRT-U02 does not call connectTransport when serverUrl is absent", () => {

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -98,8 +98,6 @@ export interface DbConfig {
   driver?: StorageDriver;
   /** Optional server URL for sync */
   serverUrl?: string;
-  /** Optional route prefix for multi-tenant servers (e.g. `/apps/<appId>`). */
-  serverPathPrefix?: string;
   /** Optional runtime source overrides for WASM and worker loading. */
   runtimeSources?: RuntimeSourcesConfig;
   /** Environment (e.g., "dev", "prod") */
@@ -1194,7 +1192,6 @@ export class Db {
           driver: this.config.driver,
           // In worker mode, don't connect to server directly — worker handles it
           serverUrl: this.worker ? undefined : this.config.serverUrl,
-          serverPathPrefix: this.worker ? undefined : this.config.serverPathPrefix,
           env: this.config.env,
           userBranch: this.config.userBranch,
           jwtToken: this.config.jwtToken,
@@ -1228,14 +1225,10 @@ export class Db {
       // Direct (non-worker) clients with a serverUrl must open their own
       // Rust transport — the worker bridge is not doing it for them.
       if (!this.worker && this.config.serverUrl) {
-        client.connectTransport(
-          this.config.serverUrl,
-          {
-            jwt_token: this.config.jwtToken,
-            admin_secret: this.config.adminSecret,
-          },
-          this.config.serverPathPrefix,
-        );
+        client.connectTransport(this.config.serverUrl, {
+          jwt_token: this.config.jwtToken,
+          admin_secret: this.config.adminSecret,
+        });
       }
 
       this.attachMutationErrorHandler(client);
@@ -1334,7 +1327,6 @@ export class Db {
       userBranch: this.config.userBranch ?? "main",
       dbName: this.workerDbName ?? driver.dbName ?? this.config.appId,
       serverUrl: this.config.serverUrl,
-      serverPathPrefix: this.config.serverPathPrefix,
       jwtToken: this.config.jwtToken,
       adminSecret: this.config.adminSecret,
       runtimeSources: this.config.runtimeSources,

--- a/packages/jazz-tools/src/runtime/introspection-fetch.ts
+++ b/packages/jazz-tools/src/runtime/introspection-fetch.ts
@@ -1,4 +1,5 @@
 import type { QueryPropagation } from "./client.js";
+import { appScopedUrl } from "./url.js";
 
 export interface IntrospectionSubscriptionGroup {
   groupKey: string;
@@ -25,7 +26,7 @@ export async function fetchServerSubscriptions(
   options: FetchServerSubscriptionsOptions,
 ): Promise<IntrospectionSubscriptionResponse> {
   const subscriptionsUrl = new URL(
-    `${serverUrl.replace(/\/+$/, "")}/apps/${encodeURIComponent(options.appId)}/admin/introspection/subscriptions`,
+    appScopedUrl(serverUrl, options.appId, "admin/introspection/subscriptions"),
   );
   subscriptionsUrl.searchParams.set("appId", options.appId);
 

--- a/packages/jazz-tools/src/runtime/introspection-fetch.ts
+++ b/packages/jazz-tools/src/runtime/introspection-fetch.ts
@@ -1,5 +1,4 @@
 import type { QueryPropagation } from "./client.js";
-import { buildEndpointUrl } from "./sync-transport.js";
 
 export interface IntrospectionSubscriptionGroup {
   groupKey: string;
@@ -19,7 +18,6 @@ export interface IntrospectionSubscriptionResponse {
 export interface FetchServerSubscriptionsOptions {
   adminSecret: string;
   appId: string;
-  pathPrefix?: string;
 }
 
 export async function fetchServerSubscriptions(
@@ -27,7 +25,7 @@ export async function fetchServerSubscriptions(
   options: FetchServerSubscriptionsOptions,
 ): Promise<IntrospectionSubscriptionResponse> {
   const subscriptionsUrl = new URL(
-    buildEndpointUrl(serverUrl, "/admin/introspection/subscriptions", options.pathPrefix),
+    `${serverUrl.replace(/\/+$/, "")}/apps/${encodeURIComponent(options.appId)}/admin/introspection/subscriptions`,
   );
   subscriptionsUrl.searchParams.set("appId", options.appId);
 

--- a/packages/jazz-tools/src/runtime/napi.auth-failure.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.auth-failure.test.ts
@@ -56,7 +56,7 @@ describe("NAPI on_auth_failure", () => {
       // Connect with an intentionally invalid JWT. The server requires
       // backendSecret auth; supplying a bad JWT triggers Unauthorized.
       runtime.connect(
-        httpUrlToWs(server.url),
+        httpUrlToWs(server.url, appId),
         JSON.stringify({ jwt_token: "definitely.invalid.jwt" }),
       );
 

--- a/packages/jazz-tools/src/runtime/napi.for-request.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.for-request.test.ts
@@ -73,11 +73,13 @@ async function createTestContext(
   adminSecret: string,
 ) {
   const { hash: schemaHash } = await publishStoredSchema(server.url, {
+    appId,
     adminSecret,
     schema: todoApp.wasmSchema,
   });
-  const { head } = await fetchPermissionsHead(server.url, { adminSecret });
+  const { head } = await fetchPermissionsHead(server.url, { appId, adminSecret });
   await publishStoredPermissions(server.url, {
+    appId,
     adminSecret,
     schemaHash,
     permissions: todoAppPermissions,

--- a/packages/jazz-tools/src/runtime/permissions.repro.test.ts
+++ b/packages/jazz-tools/src/runtime/permissions.repro.test.ts
@@ -168,6 +168,7 @@ async function createServerBackedReproContext(
     adminSecret,
   });
   await publishStoredSchema(server.url, {
+    appId,
     adminSecret,
     schema: reproApp.wasmSchema,
   });

--- a/packages/jazz-tools/src/runtime/schema-fetch.test.ts
+++ b/packages/jazz-tools/src/runtime/schema-fetch.test.ts
@@ -30,8 +30,8 @@ describe("schema-fetch", () => {
 
     const hash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     const result = await fetchStoredWasmSchema("http://localhost:1625/", {
+      appId: "app-123",
       adminSecret: "admin-secret",
-      pathPrefix: "/apps/app-123",
       schemaHash: hash,
     });
 
@@ -58,6 +58,7 @@ describe("schema-fetch", () => {
 
     await expect(
       fetchStoredWasmSchema("http://localhost:1625", {
+        appId: "test-app",
         adminSecret: "admin-secret",
         schemaHash:
           "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
@@ -77,8 +78,8 @@ describe("schema-fetch", () => {
     (globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
 
     const result = await fetchSchemaHashes("http://localhost:1625/", {
+      appId: "app-123",
       adminSecret: "admin-secret",
-      pathPrefix: "/apps/app-123",
     });
 
     expect(result.hashes).toEqual([
@@ -107,12 +108,13 @@ describe("schema-fetch", () => {
     (globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
 
     await fetchStoredWasmSchema("http://localhost:1625/", {
+      appId: "test-app",
       adminSecret: "admin-secret",
       schemaHash: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
     });
 
     expect(fetchMock.mock.calls[0]![0]).toBe(
-      "http://localhost:1625/schema/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "http://localhost:1625/apps/test-app/schema/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
     );
   });
 
@@ -133,6 +135,7 @@ describe("schema-fetch", () => {
     (globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
 
     await publishStoredPermissions("http://localhost:1625/", {
+      appId: "test-app",
       adminSecret: "admin-secret",
       schemaHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       permissions: {
@@ -186,7 +189,9 @@ describe("schema-fetch", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock.mock.calls[0]![0]).toBe("http://localhost:1625/admin/permissions");
+    expect(fetchMock.mock.calls[0]![0]).toBe(
+      "http://localhost:1625/apps/test-app/admin/permissions",
+    );
     expect(fetchMock.mock.calls[0]![1]).toMatchObject({
       method: "POST",
       headers: {
@@ -277,8 +282,8 @@ describe("schema-fetch", () => {
     (globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
 
     const result = await fetchStoredPermissions("http://localhost:1625/", {
+      appId: "app-123",
       adminSecret: "admin-secret",
-      pathPrefix: "/apps/app-123",
     });
 
     expect(result).toEqual({
@@ -321,6 +326,7 @@ describe("schema-fetch", () => {
 
     await expect(
       fetchStoredPermissions("http://localhost:1625", {
+        appId: "test-app",
         adminSecret: "admin-secret",
       }),
     ).rejects.toThrow('Permissions fetch failed: 401 Unauthorized - {"error":"bad secret"}');
@@ -338,8 +344,8 @@ describe("schema-fetch", () => {
     (globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
 
     const result = await fetchSchemaConnectivity("http://localhost:1625/", {
+      appId: "app-123",
       adminSecret: "admin-secret",
-      pathPrefix: "/apps/app-123",
       fromHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       toHash: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
     });
@@ -382,14 +388,13 @@ describe("schema-fetch", () => {
     const result = await fetchServerSubscriptions("http://localhost:1625/", {
       adminSecret: "admin-secret",
       appId: "test-app",
-      pathPrefix: "/apps/app-123",
     });
 
     expect(result.appId).toBe("app-123");
     expect(result.queries).toHaveLength(1);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0]![0]).toBe(
-      "http://localhost:1625/apps/app-123/admin/introspection/subscriptions?appId=test-app",
+      "http://localhost:1625/apps/test-app/admin/introspection/subscriptions?appId=test-app",
     );
     expect(fetchMock.mock.calls[0]![1]).toMatchObject({
       method: "GET",

--- a/packages/jazz-tools/src/runtime/schema-fetch.ts
+++ b/packages/jazz-tools/src/runtime/schema-fetch.ts
@@ -6,6 +6,7 @@ import type {
 } from "../drivers/types.js";
 import type { CompiledPermissionsMap } from "../schema-permissions.js";
 import { normalizePermissionsForWasm } from "../schema-permissions.js";
+import { appScopedUrl } from "./url.js";
 
 export interface FetchStoredWasmSchemaOptions {
   appId: string;
@@ -17,7 +18,11 @@ export async function fetchStoredWasmSchema(
   serverUrl: string,
   options: FetchStoredWasmSchemaOptions,
 ): Promise<{ schema: WasmSchema; publishedAt: number | null }> {
-  const schemaUrl = `${serverUrl.replace(/\/+$/, "")}/apps/${encodeURIComponent(options.appId)}/schema/${encodeURIComponent(options.schemaHash)}`;
+  const schemaUrl = appScopedUrl(
+    serverUrl,
+    options.appId,
+    `schema/${encodeURIComponent(options.schemaHash)}`,
+  );
 
   const response = await fetch(schemaUrl, {
     method: "GET",
@@ -52,15 +57,12 @@ export async function fetchSchemaHashes(
   serverUrl: string,
   options: FetchStoredSchemasOptions,
 ): Promise<{ hashes: string[] }> {
-  const response = await fetch(
-    `${serverUrl.replace(/\/+$/, "")}/apps/${encodeURIComponent(options.appId)}/schemas`,
-    {
-      method: "GET",
-      headers: {
-        "X-Jazz-Admin-Secret": options.adminSecret,
-      },
+  const response = await fetch(appScopedUrl(serverUrl, options.appId, "schemas"), {
+    method: "GET",
+    headers: {
+      "X-Jazz-Admin-Secret": options.adminSecret,
     },
-  );
+  });
 
   if (!response.ok) {
     const bodyText = await response.text().catch(() => "");
@@ -86,22 +88,19 @@ export async function publishStoredSchema(
   serverUrl: string,
   options: PublishStoredSchemaOptions,
 ): Promise<{ objectId: string; hash: string }> {
-  const response = await fetch(
-    `${serverUrl.replace(/\/+$/, "")}/apps/${encodeURIComponent(options.appId)}/admin/schemas`,
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Jazz-Admin-Secret": options.adminSecret,
-      },
-      body: JSON.stringify({
-        schema: options.schema,
-        permissions: options.permissions
-          ? normalizePermissionsForWasm(options.permissions)
-          : undefined,
-      }),
+  const response = await fetch(appScopedUrl(serverUrl, options.appId, "admin/schemas"), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Jazz-Admin-Secret": options.adminSecret,
     },
-  );
+    body: JSON.stringify({
+      schema: options.schema,
+      permissions: options.permissions
+        ? normalizePermissionsForWasm(options.permissions)
+        : undefined,
+    }),
+  });
 
   if (!response.ok) {
     const bodyText = await response.text().catch(() => "");
@@ -128,15 +127,12 @@ export async function fetchPermissionsHead(
   serverUrl: string,
   options: FetchPermissionsHeadOptions,
 ): Promise<{ head: StoredPermissionsHead | null }> {
-  const response = await fetch(
-    `${serverUrl.replace(/\/+$/, "")}/apps/${encodeURIComponent(options.appId)}/admin/permissions/head`,
-    {
-      method: "GET",
-      headers: {
-        "X-Jazz-Admin-Secret": options.adminSecret,
-      },
+  const response = await fetch(appScopedUrl(serverUrl, options.appId, "admin/permissions/head"), {
+    method: "GET",
+    headers: {
+      "X-Jazz-Admin-Secret": options.adminSecret,
     },
-  );
+  });
 
   if (!response.ok) {
     const bodyText = await response.text().catch(() => "");
@@ -166,15 +162,12 @@ export async function fetchStoredPermissions(
   serverUrl: string,
   options: FetchStoredPermissionsOptions,
 ): Promise<StoredPermissionsResponse> {
-  const response = await fetch(
-    `${serverUrl.replace(/\/+$/, "")}/apps/${encodeURIComponent(options.appId)}/admin/permissions`,
-    {
-      method: "GET",
-      headers: {
-        "X-Jazz-Admin-Secret": options.adminSecret,
-      },
+  const response = await fetch(appScopedUrl(serverUrl, options.appId, "admin/permissions"), {
+    method: "GET",
+    headers: {
+      "X-Jazz-Admin-Secret": options.adminSecret,
     },
-  );
+  });
 
   if (!response.ok) {
     const bodyText = await response.text().catch(() => "");
@@ -204,21 +197,18 @@ export async function publishStoredPermissions(
   serverUrl: string,
   options: PublishStoredPermissionsOptions,
 ): Promise<{ head: StoredPermissionsHead | null }> {
-  const response = await fetch(
-    `${serverUrl.replace(/\/+$/, "")}/apps/${encodeURIComponent(options.appId)}/admin/permissions`,
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Jazz-Admin-Secret": options.adminSecret,
-      },
-      body: JSON.stringify({
-        schemaHash: options.schemaHash,
-        permissions: normalizePermissionsForWasm(options.permissions),
-        expectedParentBundleObjectId: options.expectedParentBundleObjectId ?? null,
-      }),
+  const response = await fetch(appScopedUrl(serverUrl, options.appId, "admin/permissions"), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Jazz-Admin-Secret": options.adminSecret,
     },
-  );
+    body: JSON.stringify({
+      schemaHash: options.schemaHash,
+      permissions: normalizePermissionsForWasm(options.permissions),
+      expectedParentBundleObjectId: options.expectedParentBundleObjectId ?? null,
+    }),
+  });
 
   if (!response.ok) {
     const bodyText = await response.text().catch(() => "");
@@ -245,8 +235,7 @@ export async function fetchSchemaConnectivity(
   serverUrl: string,
   options: FetchSchemaConnectivityOptions,
 ): Promise<{ connected: boolean }> {
-  const endpoint = `${serverUrl.replace(/\/+$/, "")}/apps/${encodeURIComponent(options.appId)}/admin/schema-connectivity`;
-  const url = new URL(endpoint);
+  const url = new URL(appScopedUrl(serverUrl, options.appId, "admin/schema-connectivity"));
   url.searchParams.set("fromHash", options.fromHash);
   url.searchParams.set("toHash", options.toHash);
 
@@ -348,21 +337,18 @@ export async function publishStoredMigration(
   serverUrl: string,
   options: PublishStoredMigrationOptions,
 ): Promise<{ objectId: string; fromHash: string; toHash: string }> {
-  const response = await fetch(
-    `${serverUrl.replace(/\/+$/, "")}/apps/${encodeURIComponent(options.appId)}/admin/migrations`,
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Jazz-Admin-Secret": options.adminSecret,
-      },
-      body: JSON.stringify({
-        fromHash: options.fromHash,
-        toHash: options.toHash,
-        forward: options.forward,
-      }),
+  const response = await fetch(appScopedUrl(serverUrl, options.appId, "admin/migrations"), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Jazz-Admin-Secret": options.adminSecret,
     },
-  );
+    body: JSON.stringify({
+      fromHash: options.fromHash,
+      toHash: options.toHash,
+      forward: options.forward,
+    }),
+  });
 
   if (!response.ok) {
     const bodyText = await response.text().catch(() => "");

--- a/packages/jazz-tools/src/runtime/schema-fetch.ts
+++ b/packages/jazz-tools/src/runtime/schema-fetch.ts
@@ -6,11 +6,10 @@ import type {
 } from "../drivers/types.js";
 import type { CompiledPermissionsMap } from "../schema-permissions.js";
 import { normalizePermissionsForWasm } from "../schema-permissions.js";
-import { buildEndpointUrl } from "./sync-transport.js";
 
 export interface FetchStoredWasmSchemaOptions {
+  appId: string;
   adminSecret: string;
-  pathPrefix?: string;
   schemaHash: string;
 }
 
@@ -18,11 +17,7 @@ export async function fetchStoredWasmSchema(
   serverUrl: string,
   options: FetchStoredWasmSchemaOptions,
 ): Promise<{ schema: WasmSchema; publishedAt: number | null }> {
-  const schemaUrl = buildEndpointUrl(
-    serverUrl,
-    `/schema/${encodeURIComponent(options.schemaHash)}`,
-    options.pathPrefix,
-  );
+  const schemaUrl = `${serverUrl.replace(/\/+$/, "")}/apps/${encodeURIComponent(options.appId)}/schema/${encodeURIComponent(options.schemaHash)}`;
 
   const response = await fetch(schemaUrl, {
     method: "GET",
@@ -49,20 +44,23 @@ export async function fetchStoredWasmSchema(
 }
 
 export interface FetchStoredSchemasOptions {
+  appId: string;
   adminSecret: string;
-  pathPrefix?: string;
 }
 
 export async function fetchSchemaHashes(
   serverUrl: string,
   options: FetchStoredSchemasOptions,
 ): Promise<{ hashes: string[] }> {
-  const response = await fetch(buildEndpointUrl(serverUrl, "/schemas", options.pathPrefix), {
-    method: "GET",
-    headers: {
-      "X-Jazz-Admin-Secret": options.adminSecret,
+  const response = await fetch(
+    `${serverUrl.replace(/\/+$/, "")}/apps/${encodeURIComponent(options.appId)}/schemas`,
+    {
+      method: "GET",
+      headers: {
+        "X-Jazz-Admin-Secret": options.adminSecret,
+      },
     },
-  });
+  );
 
   if (!response.ok) {
     const bodyText = await response.text().catch(() => "");
@@ -77,8 +75,8 @@ export async function fetchSchemaHashes(
 }
 
 export interface PublishStoredSchemaOptions {
+  appId: string;
   adminSecret: string;
-  pathPrefix?: string;
   schema: WasmSchema;
   /** @deprecated Use `publishStoredPermissions` instead. */
   permissions?: CompiledPermissionsMap;
@@ -88,19 +86,22 @@ export async function publishStoredSchema(
   serverUrl: string,
   options: PublishStoredSchemaOptions,
 ): Promise<{ objectId: string; hash: string }> {
-  const response = await fetch(buildEndpointUrl(serverUrl, "/admin/schemas", options.pathPrefix), {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "X-Jazz-Admin-Secret": options.adminSecret,
+  const response = await fetch(
+    `${serverUrl.replace(/\/+$/, "")}/apps/${encodeURIComponent(options.appId)}/admin/schemas`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Jazz-Admin-Secret": options.adminSecret,
+      },
+      body: JSON.stringify({
+        schema: options.schema,
+        permissions: options.permissions
+          ? normalizePermissionsForWasm(options.permissions)
+          : undefined,
+      }),
     },
-    body: JSON.stringify({
-      schema: options.schema,
-      permissions: options.permissions
-        ? normalizePermissionsForWasm(options.permissions)
-        : undefined,
-    }),
-  });
+  );
 
   if (!response.ok) {
     const bodyText = await response.text().catch(() => "");
@@ -119,8 +120,8 @@ export interface StoredPermissionsHead {
 }
 
 export interface FetchPermissionsHeadOptions {
+  appId: string;
   adminSecret: string;
-  pathPrefix?: string;
 }
 
 export async function fetchPermissionsHead(
@@ -128,7 +129,7 @@ export async function fetchPermissionsHead(
   options: FetchPermissionsHeadOptions,
 ): Promise<{ head: StoredPermissionsHead | null }> {
   const response = await fetch(
-    buildEndpointUrl(serverUrl, "/admin/permissions/head", options.pathPrefix),
+    `${serverUrl.replace(/\/+$/, "")}/apps/${encodeURIComponent(options.appId)}/admin/permissions/head`,
     {
       method: "GET",
       headers: {
@@ -157,8 +158,8 @@ export interface StoredPermissionsResponse {
 }
 
 export interface FetchStoredPermissionsOptions {
+  appId: string;
   adminSecret: string;
-  pathPrefix?: string;
 }
 
 export async function fetchStoredPermissions(
@@ -166,7 +167,7 @@ export async function fetchStoredPermissions(
   options: FetchStoredPermissionsOptions,
 ): Promise<StoredPermissionsResponse> {
   const response = await fetch(
-    buildEndpointUrl(serverUrl, "/admin/permissions", options.pathPrefix),
+    `${serverUrl.replace(/\/+$/, "")}/apps/${encodeURIComponent(options.appId)}/admin/permissions`,
     {
       method: "GET",
       headers: {
@@ -192,8 +193,8 @@ export async function fetchStoredPermissions(
 }
 
 export interface PublishStoredPermissionsOptions {
+  appId: string;
   adminSecret: string;
-  pathPrefix?: string;
   schemaHash: string;
   permissions: CompiledPermissionsMap;
   expectedParentBundleObjectId?: string | null;
@@ -204,7 +205,7 @@ export async function publishStoredPermissions(
   options: PublishStoredPermissionsOptions,
 ): Promise<{ head: StoredPermissionsHead | null }> {
   const response = await fetch(
-    buildEndpointUrl(serverUrl, "/admin/permissions", options.pathPrefix),
+    `${serverUrl.replace(/\/+$/, "")}/apps/${encodeURIComponent(options.appId)}/admin/permissions`,
     {
       method: "POST",
       headers: {
@@ -234,8 +235,8 @@ export async function publishStoredPermissions(
 }
 
 export interface FetchSchemaConnectivityOptions {
+  appId: string;
   adminSecret: string;
-  pathPrefix?: string;
   fromHash: string;
   toHash: string;
 }
@@ -244,7 +245,7 @@ export async function fetchSchemaConnectivity(
   serverUrl: string,
   options: FetchSchemaConnectivityOptions,
 ): Promise<{ connected: boolean }> {
-  const endpoint = buildEndpointUrl(serverUrl, "/admin/schema-connectivity", options.pathPrefix);
+  const endpoint = `${serverUrl.replace(/\/+$/, "")}/apps/${encodeURIComponent(options.appId)}/admin/schema-connectivity`;
   const url = new URL(endpoint);
   url.searchParams.set("fromHash", options.fromHash);
   url.searchParams.set("toHash", options.toHash);
@@ -311,8 +312,8 @@ export interface PublishedTableLens {
 }
 
 export interface PublishStoredMigrationOptions {
+  appId: string;
   adminSecret: string;
-  pathPrefix?: string;
   fromHash: string;
   toHash: string;
   forward: PublishedTableLens[];
@@ -348,7 +349,7 @@ export async function publishStoredMigration(
   options: PublishStoredMigrationOptions,
 ): Promise<{ objectId: string; fromHash: string; toHash: string }> {
   const response = await fetch(
-    buildEndpointUrl(serverUrl, "/admin/migrations", options.pathPrefix),
+    `${serverUrl.replace(/\/+$/, "")}/apps/${encodeURIComponent(options.appId)}/admin/migrations`,
     {
       method: "POST",
       headers: {

--- a/packages/jazz-tools/src/runtime/sync-transport.ts
+++ b/packages/jazz-tools/src/runtime/sync-transport.ts
@@ -128,25 +128,6 @@ function trimTrailingSlash(url: string): string {
 }
 
 /**
- * Normalize an optional route prefix into a leading-slash path with no trailing slash.
- */
-export function normalizePathPrefix(pathPrefix?: string): string {
-  if (!pathPrefix) return "";
-  const trimmed = pathPrefix.trim();
-  if (!trimmed) return "";
-  const withoutTrailing = trimmed.replace(/\/+$/, "");
-  return withoutTrailing.startsWith("/") ? withoutTrailing : `/${withoutTrailing}`;
-}
-
-/**
- * Build a server endpoint URL with optional route prefix.
- */
-export function buildEndpointUrl(serverUrl: string, endpoint: string, pathPrefix?: string): string {
-  const normalizedEndpoint = endpoint.startsWith("/") ? endpoint : `/${endpoint}`;
-  return `${trimTrailingSlash(serverUrl)}${normalizePathPrefix(pathPrefix)}${normalizedEndpoint}`;
-}
-
-/**
  * Apply end-user auth headers. Sets `Authorization: Bearer <token>` when a JWT is available.
  */
 export function applyUserAuthHeaders(

--- a/packages/jazz-tools/src/runtime/url.test.ts
+++ b/packages/jazz-tools/src/runtime/url.test.ts
@@ -1,5 +1,19 @@
 import { describe, it, expect } from "vitest";
-import { httpUrlToWs } from "./url.js";
+import { appScopedUrl, httpUrlToWs } from "./url.js";
+
+describe("appScopedUrl", () => {
+  it("trims the server url, preserves any base path, and normalizes the app-scoped path", () => {
+    expect(appScopedUrl(" https://api.example.com/base/ ", "my app", "/admin/schemas")).toBe(
+      "https://api.example.com/base/apps/my%20app/admin/schemas",
+    );
+  });
+
+  it("throws when the server url includes query params or a hash fragment", () => {
+    expect(() => appScopedUrl("http://localhost:4000?debug=1", "xyz", "schemas")).toThrow(
+      /must not include query parameters or a hash fragment/i,
+    );
+  });
+});
 
 describe("httpUrlToWs", () => {
   it("http → ws and appends app-scoped /ws", () => {
@@ -13,6 +27,11 @@ describe("httpUrlToWs", () => {
   it("ws/wss passthrough and replaces a bare or trailing /ws with the app-scoped path", () => {
     expect(httpUrlToWs("ws://host", "xyz")).toBe("ws://host/apps/xyz/ws");
     expect(httpUrlToWs("wss://host/ws", "xyz")).toBe("wss://host/apps/xyz/ws");
+  });
+  it("trims surrounding whitespace before normalizing the app-scoped ws endpoint", () => {
+    expect(httpUrlToWs(" https://api.example.com/ ", "xyz")).toBe(
+      "wss://api.example.com/apps/xyz/ws",
+    );
   });
   it("accepts UUID app ids verbatim", () => {
     expect(httpUrlToWs("http://localhost:4000", "00000000-0000-0000-0000-000000000001")).toBe(

--- a/packages/jazz-tools/src/runtime/url.test.ts
+++ b/packages/jazz-tools/src/runtime/url.test.ts
@@ -2,31 +2,24 @@ import { describe, it, expect } from "vitest";
 import { httpUrlToWs } from "./url.js";
 
 describe("httpUrlToWs", () => {
-  it("http → ws and appends /ws", () => {
-    expect(httpUrlToWs("http://localhost:4000")).toBe("ws://localhost:4000/ws");
+  it("http → ws and appends app-scoped /ws", () => {
+    expect(httpUrlToWs("http://localhost:4000", "xyz")).toBe("ws://localhost:4000/apps/xyz/ws");
   });
   it("https → wss and trims trailing slash", () => {
-    expect(httpUrlToWs("https://api.example.com/")).toBe("wss://api.example.com/ws");
-  });
-  it("ws/wss passthrough and idempotent /ws suffix", () => {
-    expect(httpUrlToWs("ws://host")).toBe("ws://host/ws");
-    expect(httpUrlToWs("wss://host/ws")).toBe("wss://host/ws");
-  });
-  it("applies pathPrefix with leading slash handling", () => {
-    expect(httpUrlToWs("http://localhost:4000", "/apps/xyz")).toBe(
-      "ws://localhost:4000/apps/xyz/ws",
+    expect(httpUrlToWs("https://api.example.com/", "xyz")).toBe(
+      "wss://api.example.com/apps/xyz/ws",
     );
   });
-  it("applies pathPrefix tolerating extra slashes", () => {
-    expect(httpUrlToWs("http://localhost:4000", "apps/xyz/")).toBe(
-      "ws://localhost:4000/apps/xyz/ws",
-    );
+  it("ws/wss passthrough and replaces a bare or trailing /ws with the app-scoped path", () => {
+    expect(httpUrlToWs("ws://host", "xyz")).toBe("ws://host/apps/xyz/ws");
+    expect(httpUrlToWs("wss://host/ws", "xyz")).toBe("wss://host/apps/xyz/ws");
   });
-  it("empty or undefined pathPrefix behaves like no prefix", () => {
-    expect(httpUrlToWs("http://localhost:4000", "")).toBe("ws://localhost:4000/ws");
-    expect(httpUrlToWs("http://localhost:4000", undefined)).toBe("ws://localhost:4000/ws");
+  it("accepts UUID app ids verbatim", () => {
+    expect(httpUrlToWs("http://localhost:4000", "00000000-0000-0000-0000-000000000001")).toBe(
+      "ws://localhost:4000/apps/00000000-0000-0000-0000-000000000001/ws",
+    );
   });
   it("throws on invalid scheme", () => {
-    expect(() => httpUrlToWs("ftp://host")).toThrow(/Invalid server URL/);
+    expect(() => httpUrlToWs("ftp://host", "xyz")).toThrow(/Invalid server URL/);
   });
 });

--- a/packages/jazz-tools/src/runtime/url.ts
+++ b/packages/jazz-tools/src/runtime/url.ts
@@ -1,4 +1,19 @@
 /**
+ * Build an app-scoped URL under `/apps/<appId>`.
+ *
+ * Preserves any base path already present in `serverUrl`, trims surrounding
+ * whitespace, rejects query/hash fragments, and accepts path inputs with or
+ * without a leading slash.
+ */
+export function appScopedUrl(serverUrl: string, appId: string, path: string): string {
+  const base = normalizeServerUrlBase(serverUrl);
+  const normalizedPath = path.trim().replace(/^\/+/, "");
+  const appBase = `${base}/apps/${encodeURIComponent(appId)}`;
+
+  return normalizedPath ? `${appBase}/${normalizedPath}` : appBase;
+}
+
+/**
  * Convert an HTTP(S) server URL to the WebSocket `/ws` endpoint URL.
  *
  * Mirrors the Rust `http_url_to_ws` helper in `crates/jazz-tools/src/client.rs`.
@@ -9,20 +24,54 @@
  * - `ws://host/ws`, `xyz` → `ws://host/apps/xyz/ws`
  */
 export function httpUrlToWs(serverUrl: string, appId: string): string {
-  const base = serverUrl.replace(/\/+$/, "");
-  const tail = `/apps/${encodeURIComponent(appId)}/ws`;
+  const parsed = parseServerUrl(serverUrl);
 
-  if (base.startsWith("http://")) {
-    return `ws://${base.slice("http://".length)}${tail}`;
+  if (parsed.protocol === "http:") {
+    parsed.protocol = "ws:";
+    return appScopedUrl(parsed.toString(), appId, "ws");
   }
-  if (base.startsWith("https://")) {
-    return `wss://${base.slice("https://".length)}${tail}`;
+
+  if (parsed.protocol === "https:") {
+    parsed.protocol = "wss:";
+    return appScopedUrl(parsed.toString(), appId, "ws");
   }
-  if (base.startsWith("ws://") || base.startsWith("wss://")) {
-    const noWsSuffix = base.endsWith("/ws") ? base.slice(0, -"/ws".length) : base;
-    return `${noWsSuffix}${tail}`;
+
+  parsed.pathname = parsed.pathname.replace(/\/ws\/?$/, "");
+  return appScopedUrl(parsed.toString(), appId, "ws");
+}
+
+const ALLOWED_SERVER_URL_PROTOCOLS = new Set(["http:", "https:", "ws:", "wss:"]);
+
+function normalizeServerUrlBase(serverUrl: string): string {
+  const parsed = parseServerUrl(serverUrl);
+  parsed.pathname = parsed.pathname.replace(/\/+$/, "");
+  return parsed.toString().replace(/\/+$/, "");
+}
+
+function parseServerUrl(serverUrl: string): URL {
+  let parsed: URL;
+
+  try {
+    parsed = new URL(serverUrl.trim());
+  } catch {
+    throw invalidServerUrl(serverUrl);
   }
-  throw new Error(
+
+  if (!ALLOWED_SERVER_URL_PROTOCOLS.has(parsed.protocol)) {
+    throw invalidServerUrl(serverUrl);
+  }
+
+  if (parsed.search || parsed.hash) {
+    throw new Error(
+      `Invalid server URL "${serverUrl}": must not include query parameters or a hash fragment`,
+    );
+  }
+
+  return parsed;
+}
+
+function invalidServerUrl(serverUrl: string): Error {
+  return new Error(
     `Invalid server URL "${serverUrl}": expected http://, https://, ws://, or wss://`,
   );
 }

--- a/packages/jazz-tools/src/runtime/url.ts
+++ b/packages/jazz-tools/src/runtime/url.ts
@@ -3,16 +3,14 @@
  *
  * Mirrors the Rust `http_url_to_ws` helper in `crates/jazz-tools/src/client.rs`.
  *
- * - `http://host`              → `ws://host/ws`
- * - `https://host`             → `wss://host/ws`
- * - `http://host`, `/apps/xyz` → `ws://host/apps/xyz/ws`
- * - `ws://host`                → `ws://host/ws`
- * - `ws://host/ws`             → unchanged
+ * - `http://host`, `xyz` → `ws://host/apps/xyz/ws`
+ * - `https://host`, `xyz` → `wss://host/apps/xyz/ws`
+ * - `ws://host`, `xyz` → `ws://host/apps/xyz/ws`
+ * - `ws://host/ws`, `xyz` → `ws://host/apps/xyz/ws`
  */
-export function httpUrlToWs(serverUrl: string, pathPrefix?: string): string {
+export function httpUrlToWs(serverUrl: string, appId: string): string {
   const base = serverUrl.replace(/\/+$/, "");
-  const prefix = (pathPrefix ?? "").replace(/^\/+|\/+$/g, "");
-  const tail = prefix.length > 0 ? `/${prefix}/ws` : "/ws";
+  const tail = `/apps/${encodeURIComponent(appId)}/ws`;
 
   if (base.startsWith("http://")) {
     return `ws://${base.slice("http://".length)}${tail}`;
@@ -21,13 +19,8 @@ export function httpUrlToWs(serverUrl: string, pathPrefix?: string): string {
     return `wss://${base.slice("https://".length)}${tail}`;
   }
   if (base.startsWith("ws://") || base.startsWith("wss://")) {
-    // If prefix is given, append it; otherwise preserve the existing behavior:
-    // idempotent /ws suffix.
-    if (prefix.length > 0) {
-      const noWsSuffix = base.endsWith("/ws") ? base.slice(0, -"/ws".length) : base;
-      return `${noWsSuffix}${tail}`;
-    }
-    return base.endsWith("/ws") ? base : `${base}/ws`;
+    const noWsSuffix = base.endsWith("/ws") ? base.slice(0, -"/ws".length) : base;
+    return `${noWsSuffix}${tail}`;
   }
   throw new Error(
     `Invalid server URL "${serverUrl}": expected http://, https://, ws://, or wss://`,

--- a/packages/jazz-tools/src/runtime/worker-bridge.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.ts
@@ -26,7 +26,6 @@ export interface WorkerBridgeOptions {
   userBranch: string;
   dbName: string;
   serverUrl?: string;
-  serverPathPrefix?: string;
   jwtToken?: string;
   adminSecret?: string;
   runtimeSources?: RuntimeSourcesConfig;
@@ -173,7 +172,6 @@ export class WorkerBridge {
       userBranch: options.userBranch,
       dbName: options.dbName,
       serverUrl: options.serverUrl,
-      serverPathPrefix: options.serverPathPrefix,
       jwtToken: options.jwtToken,
       adminSecret: options.adminSecret,
       runtimeSources: options.runtimeSources,

--- a/packages/jazz-tools/src/testing/index.test.ts
+++ b/packages/jazz-tools/src/testing/index.test.ts
@@ -116,14 +116,14 @@ describe("TestingServer", () => {
       expect(server.adminSecret).toBe(adminSecret);
       expect(server.backendSecret).toBe(backendSecret);
 
-      const allowed = await fetch(`${server.url}/admin/schemas`, {
+      const allowed = await fetch(`${server.url}/apps/${server.appId}/admin/schemas`, {
         method: "POST",
         headers: { "content-type": "application/json", "X-Jazz-Admin-Secret": adminSecret },
         body: JSON.stringify({ schema: TEST_SCHEMA }),
       });
       expect(allowed.status).toBe(201);
 
-      const denied = await fetch(`${server.url}/admin/schemas`, {
+      const denied = await fetch(`${server.url}/apps/${server.appId}/admin/schemas`, {
         method: "POST",
         headers: { "content-type": "application/json", "X-Jazz-Admin-Secret": "wrong-secret" },
         body: JSON.stringify({ schema: TEST_SCHEMA }),
@@ -239,7 +239,7 @@ describe("startLocalJazzServer", () => {
     });
 
     try {
-      const response = await fetch(`${server.url}/admin/schemas`, {
+      const response = await fetch(`${server.url}/apps/${server.appId}/admin/schemas`, {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -265,7 +265,7 @@ describe("startLocalJazzServer", () => {
     });
 
     try {
-      const response = await fetch(`${server.url}/admin/schemas`, {
+      const response = await fetch(`${server.url}/apps/${server.appId}/admin/schemas`, {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -315,7 +315,7 @@ describe("pushSchemaCatalogue", () => {
 
       expect(hash).toBeTruthy();
 
-      const response = await fetch(`${server.url}/schemas`, {
+      const response = await fetch(`${server.url}/apps/${server.appId}/schemas`, {
         headers: {
           "X-Jazz-Admin-Secret": adminSecret,
         },

--- a/packages/jazz-tools/src/worker/jazz-worker.test.ts
+++ b/packages/jazz-tools/src/worker/jazz-worker.test.ts
@@ -4,7 +4,7 @@
  * These tests target the exported pure helpers `composeConnectUrl` and
  * `mergeAuth`, which encapsulate the two behaviours that T22 validates:
  *
- *   1. serverUrl + serverPathPrefix → correct WebSocket URL via httpUrlToWs
+ *   1. serverUrl + appId → correct WebSocket URL via httpUrlToWs
  *   2. update-auth merges / clears jwt_token while preserving other fields
  *
  * The helpers are pure functions — no WASM, no worker globals needed.
@@ -42,8 +42,8 @@ import {
 import type { WorkerToMainMessage } from "./worker-protocol.js";
 
 describe("worker URL + auth wiring", () => {
-  it("normalizes serverUrl with serverPathPrefix via httpUrlToWs", () => {
-    const wsUrl = composeConnectUrl("http://localhost:4000", "/apps/xyz");
+  it("normalizes serverUrl with appId via httpUrlToWs", () => {
+    const wsUrl = composeConnectUrl("http://localhost:4000", "xyz");
     expect(wsUrl).toBe("ws://localhost:4000/apps/xyz/ws");
   });
 

--- a/packages/jazz-tools/src/worker/jazz-worker.ts
+++ b/packages/jazz-tools/src/worker/jazz-worker.ts
@@ -213,10 +213,9 @@ export { mapAuthReason } from "../runtime/auth-state.js";
 
 /**
  * Build the WebSocket URL for runtime.connect() from the init message fields.
- * Delegates scheme conversion and path prefix appending to `httpUrlToWs`.
  */
-export function composeConnectUrl(serverUrl: string, serverPathPrefix?: string): string {
-  return httpUrlToWs(serverUrl, serverPathPrefix);
+export function composeConnectUrl(serverUrl: string, appId: string): string {
+  return httpUrlToWs(serverUrl, appId);
 }
 
 /**
@@ -396,7 +395,7 @@ async function handleInit(msg: InitMessage): Promise<void> {
         currentAuth.admin_secret = msg.adminSecret;
       }
       currentAuth = mergeAuth(currentAuth, msg.jwtToken);
-      const wsUrl = composeConnectUrl(msg.serverUrl, msg.serverPathPrefix);
+      const wsUrl = composeConnectUrl(msg.serverUrl, msg.appId);
       currentWsUrl = wsUrl;
       performUpstreamConnect(runtime, post, wsUrl, JSON.stringify(currentAuth));
     }

--- a/packages/jazz-tools/src/worker/worker-protocol.ts
+++ b/packages/jazz-tools/src/worker/worker-protocol.ts
@@ -21,7 +21,6 @@ export interface InitMessage {
   dbName: string;
   clientId: string;
   serverUrl?: string;
-  serverPathPrefix?: string;
   jwtToken?: string;
   adminSecret?: string;
   runtimeSources?: RuntimeSourcesConfig;

--- a/packages/jazz-tools/tests/browser/db.auth-refresh.test.ts
+++ b/packages/jazz-tools/tests/browser/db.auth-refresh.test.ts
@@ -90,6 +90,7 @@ describe("Db auth refresh browser integration", () => {
     );
 
     const { hash: publishedSchemaHash } = await publishStoredSchema(serverUrl, {
+      appId,
       adminSecret,
       schema,
     });
@@ -97,7 +98,7 @@ describe("Db auth refresh browser integration", () => {
     let latestSchemaHash: string | null = publishedSchemaHash;
     await waitForCondition(
       async () => {
-        const { hashes } = await fetchSchemaHashes(serverUrl, { adminSecret });
+        const { hashes } = await fetchSchemaHashes(serverUrl, { appId, adminSecret });
         latestSchemaHash = hashes.at(-1) ?? publishedSchemaHash;
         return latestSchemaHash !== null;
       },
@@ -105,9 +106,10 @@ describe("Db auth refresh browser integration", () => {
       "expected at least one published schema hash before publishing test permissions",
     );
 
-    const { head } = await fetchPermissionsHead(serverUrl, { adminSecret });
+    const { head } = await fetchPermissionsHead(serverUrl, { appId, adminSecret });
 
     await publishStoredPermissions(serverUrl, {
+      appId,
       adminSecret,
       schemaHash: latestSchemaHash!,
       permissions: {

--- a/packages/jazz-tools/tests/browser/history-conflict.test.ts
+++ b/packages/jazz-tools/tests/browser/history-conflict.test.ts
@@ -76,14 +76,16 @@ describe("History & Conflict Management", () => {
   afterEach(() => ctx.cleanup());
   beforeEach(async () => {
     testingServer = await getTestingServerInfo(uniqueDbName("history-conflict-app"));
-    const { serverUrl, adminSecret } = testingServer;
+    const { appId, serverUrl, adminSecret } = testingServer;
     await unblockTestingServerNetwork(serverUrl);
     const { hash: schemaHash } = await publishStoredSchema(serverUrl, {
+      appId,
       adminSecret,
       schema,
     });
-    const { head } = await fetchPermissionsHead(serverUrl, { adminSecret });
+    const { head } = await fetchPermissionsHead(serverUrl, { appId, adminSecret });
     await publishStoredPermissions(serverUrl, {
+      appId,
       adminSecret,
       schemaHash,
       permissions: {

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -1837,13 +1837,15 @@ async function waitForTodos(
 
 async function publishSyncServerSchemaAndPermissions(scope: string): Promise<TestingServerInfo> {
   const testingServer = await getTestingServerInfo(uniqueDbName(`worker-bridge-${scope}`));
-  const { serverUrl, adminSecret } = testingServer;
+  const { appId, serverUrl, adminSecret } = testingServer;
   const { hash: schemaHash } = await publishStoredSchema(serverUrl, {
+    appId,
     adminSecret,
     schema: app.wasmSchema,
   });
-  const { head } = await fetchPermissionsHead(serverUrl, { adminSecret });
+  const { head } = await fetchPermissionsHead(serverUrl, { appId, adminSecret });
   await publishStoredPermissions(serverUrl, {
+    appId,
     adminSecret,
     schemaHash,
     permissions: {

--- a/specs/README.md
+++ b/specs/README.md
@@ -44,7 +44,7 @@ These docs describe the system as it works today.
 
 ### 5. Transport and Adapters
 
-**[HTTP Transport](status-quo/http_transport.md)** — The concrete `/sync` + `/events` protocol used by clients and servers.
+**[HTTP Transport](status-quo/http_transport.md)** — The concrete app-scoped WebSocket + HTTP route surface used by clients and servers.
 
 **[Browser Adapters](status-quo/browser_adapters.md)** — How browser apps are split between an in-memory main-thread runtime and a persistent worker runtime backed by OPFS.
 

--- a/specs/status-quo/browser_adapters.md
+++ b/specs/status-quo/browser_adapters.md
@@ -21,7 +21,7 @@ React/Vue/Svelte app
            -> dedicated worker
               -> persistent WasmRuntime.openPersistent(...)
               -> OPFS-backed storage
-              -> upstream /sync + /events
+              -> upstream /apps/<appId>/ws
 ```
 
 ## Two Browser Modes
@@ -86,8 +86,7 @@ The worker is the durable browser runtime host. It owns:
 
 - `WasmRuntime.openPersistent(...)`
 - OPFS-backed storage
-- upstream `/events` connection
-- upstream `/sync` POSTs
+- upstream app-scoped WebSocket connection
 - replay of sync messages to the main thread runtime
 - durable local batch records, authoritative settlements, and sealed transactional submissions
 

--- a/specs/status-quo/http_transport.md
+++ b/specs/status-quo/http_transport.md
@@ -1,33 +1,27 @@
-# HTTP/SSE Transport Protocol — Status Quo
+# HTTP/WebSocket Transport Protocol — Status Quo
 
-Jazz uses a deliberately small HTTP transport surface:
+Jazz uses a deliberately small transport surface:
 
-- `POST /sync` for client-to-server batches
-- `GET /events` for server-to-client streaming updates
+- `GET /apps/:app_id/ws` for bidirectional sync over WebSocket
+- `GET /apps/:app_id/schemas` and `GET /apps/:app_id/schema/:hash` for schema catalogue reads
+- `POST /apps/:app_id/admin/...` for admin publication flows
+- `GET /health` at the server root
 
 That is enough because the interesting structure lives inside the typed sync payloads, not in a sprawling list of special-purpose endpoints.
 
-## The Two Channels
+## The Main Channel
 
-### `/sync`
+### `/apps/:app_id/ws`
 
-Clients POST a `SyncBatchRequest`:
-
-- one `client_id`
-- an ordered list of `SyncPayload`s
-
-The server applies them in order and returns a `SyncBatchResponse` with one success/error result per payload.
-
-### `/events`
-
-Clients open a long-lived stream and receive `ServerEvent`s such as:
+Clients open one WebSocket and exchange framed sync messages carrying payloads such as:
 
 - `Connected`
 - `SyncUpdate`
 - `Error`
 - `Heartbeat`
 
-The stream uses length-prefixed binary frames containing JSON payloads. That keeps parsing simple without turning the SSE body into newline-escaped JSON soup.
+The connection is app-scoped, so every non-health server interaction uses the same `/apps/<app_id>/...`
+prefix as the cloud server.
 
 ## What Actually Travels
 
@@ -79,13 +73,11 @@ can all use the same transport vocabulary instead of inventing a query-only side
 
 The in-repo server keeps a small route set:
 
-- `/events`
-- `/sync`
-- `/schemas`
-- `/schema/:hash`
+- `/apps/:app_id/ws`
+- `/apps/:app_id/schemas`
+- `/apps/:app_id/schema/:hash`
+- `/apps/:app_id/admin/...`
 - `/health`
-
-The cloud server exposes equivalent app-scoped routes under `/apps/:app_id/...` while preserving the same transport semantics.
 
 ## Key Files
 

--- a/specs/status-quo/life_of_a_subscription.md
+++ b/specs/status-quo/life_of_a_subscription.md
@@ -75,7 +75,7 @@ The worker runtime owns:
 
 - OPFS-backed storage
 - durable row histories and visible entries
-- upstream `/sync` and `/events`
+- upstream app-scoped `/apps/<appId>/ws`
 - query replay beyond the main-thread cache
 
 So if the main thread subscribes to a query whose answer depends on worker or server state, the worker is the place that settles and relays that answer back.

--- a/specs/status-quo/schema_files.md
+++ b/specs/status-quo/schema_files.md
@@ -66,9 +66,9 @@ Migrations are a separate workflow from validation.
 The current mental model is:
 
 - schemas are stored on the server and identified by hash
-- `jazz-tools migrations create --fromHash <fromHash> --toHash <toHash>` pulls two stored structural schemas and writes a typed migration stub into `migrations/`
+- `jazz-tools migrations create <appId> --fromHash <fromHash> --toHash <toHash>` pulls two stored structural schemas and writes a typed migration stub into `migrations/`
 - the developer reviews and edits that file
-- `jazz-tools migrations push <fromHash> <toHash>` publishes the reviewed migration edge back to the server
+- `jazz-tools migrations push <appId> <fromHash> <toHash>` publishes the reviewed migration edge back to the server
 
 Merge-strategy-only schema changes count as structural schema changes for hashing and migration
 generation, but they do not require row transforms because they reinterpret future conflict

--- a/specs/status-quo/storage.md
+++ b/specs/status-quo/storage.md
@@ -206,7 +206,7 @@ Main thread runtime
 
 Dedicated worker runtime
   -> OpfsBTreeStorage
-  -> upstream /sync and /events ownership
+  -> upstream /apps/<appId>/ws ownership
   -> durable local row histories, visible entries, and batch records
 ```
 


### PR DESCRIPTION
## Summary
- Nest single-app local server routes under `/apps/:app_id` and keep bare `/health` for readiness
- Make local server URLs canonical at `/apps/<appId>` across Rust, TS, NAPI, dev helpers, and the inspector
- Remove `serverPathPrefix` plumbing and update transport/url builders to derive endpoints from `serverUrl` only

## Testing
- `pnpm --filter jazz-tools exec vitest run src/runtime/url.test.ts src/runtime/schema-fetch.test.ts src/runtime/db.transport.test.ts src/dev/dev-server.test.ts src/worker/jazz-worker.test.ts src/react-native/db.test.ts`
- `pnpm --filter jazz-tools exec vitest run src/dev/next.test.ts src/dev/expo.test.ts src/dev/vite.test.ts src/dev/sveltekit.test.ts src/testing/index.test.ts`
- `pnpm --filter inspector exec vitest run`
- `cargo test -p jazz-tools --test integration --features test -- --nocapture`
- `cargo test -p jazz-tools --test auth_test --features test -- --nocapture`
- `cargo test -p jazz-tools --test client_restart_integration --features test -- --nocapture`