### PR TITLE
Fix session-scoped synced query scopes

### DIFF
--- a/.changeset/green-oranges-wave.md
+++ b/.changeset/green-oranges-wave.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix backend `forSession(...)` synced queries so session-scoped reads keep locally visible rows instead of collapsing to empty results when the connected server has no published permissions head yet.

--- a/crates/jazz-tools/src/query_manager/manager_tests.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests.rs
@@ -11278,6 +11278,98 @@ fn synced_session_query_for_exists_rel_sends_policy_context_tables_upstream() {
 }
 
 #[test]
+fn backend_sync_subscription_without_handshake_session_keeps_local_rows_without_permissions_head() {
+    use crate::sync_manager::ClientRole;
+    use crate::sync_manager::{ClientId, ServerId};
+    use uuid::Uuid;
+
+    let mut schema = Schema::new();
+    schema.insert(
+        TableName::new("teams"),
+        TableSchema {
+            columns: RowDescriptor::new(vec![
+                ColumnDescriptor::new("name", ColumnType::Text),
+                ColumnDescriptor::new("identity_key", ColumnType::Text).nullable(),
+            ]),
+            policies: TablePolicies::new().with_select(PolicyExpr::eq_session(
+                "identity_key",
+                vec!["user_id".into()],
+            )),
+        },
+    );
+
+    let mut structural_server_schema = Schema::new();
+    structural_server_schema.insert(
+        TableName::new("teams"),
+        TableSchema::new(RowDescriptor::new(vec![
+            ColumnDescriptor::new("name", ColumnType::Text),
+            ColumnDescriptor::new("identity_key", ColumnType::Text).nullable(),
+        ])),
+    );
+
+    let server_sync = SyncManager::new();
+    let (mut server, mut server_io) = create_query_manager(server_sync, structural_server_schema);
+    server.require_authorization_schema();
+    let client_sync = SyncManager::new();
+    let (mut client, mut client_io) = create_query_manager(client_sync, schema);
+
+    let server_id = ServerId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+    let client_id = ClientId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+    connect_server(&mut client, &client_io, server_id);
+    connect_client(&mut server, &server_io, client_id);
+    server
+        .sync_manager_mut()
+        .set_client_role(client_id, ClientRole::Backend);
+    let _ = client.sync_manager_mut().take_outbox();
+
+    let team_row = client
+        .insert(
+            &mut client_io,
+            "teams",
+            &[Value::Text("Bob".into()), Value::Text("bob".into())],
+        )
+        .unwrap();
+    client.process(&mut client_io);
+    client.clear_local_pending_row_overlay("teams", team_row.row_id);
+    client.process(&mut client_io);
+
+    let sub_id = client
+        .subscribe_with_sync(
+            client.query("teams").build(),
+            Some(PolicySession::new("bob")),
+            Some(crate::sync_manager::DurabilityTier::EdgeServer),
+        )
+        .unwrap();
+
+    pump_messages(
+        &mut client,
+        &mut server,
+        &mut client_io,
+        &mut server_io,
+        client_id,
+        server_id,
+    );
+
+    assert!(
+        !client
+            .sync_manager()
+            .has_remote_query_scope_snapshot(crate::sync_manager::QueryId(sub_id.0)),
+        "backend-authenticated clients without a handshake session should still treat missing permissions head as non-authoritative"
+    );
+
+    let results = client.get_subscription_results(sub_id);
+    assert_eq!(
+        results.len(),
+        1,
+        "session payload queries should keep locally visible rows until an authoritative remote scope exists"
+    );
+    assert_eq!(
+        results[0].1,
+        vec![Value::Text("Bob".into()), Value::Text("bob".into())]
+    );
+}
+
+#[test]
 fn synced_subscription_filters_rows_removed_from_remote_scope() {
     use crate::query_manager::policy::Operation;
     use crate::sync_manager::{ClientId, ServerId};

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -625,18 +625,26 @@ impl QueryManager {
         })
     }
 
-    fn should_sync_policy_context_rows(&self, client_id: ClientId) -> bool {
-        self.client_bypasses_authorization_filtering(client_id)
+    fn should_sync_policy_context_rows(
+        &self,
+        client_id: ClientId,
+        session: Option<&Session>,
+    ) -> bool {
+        self.client_bypasses_authorization_filtering(client_id, session)
     }
 
-    fn client_bypasses_authorization_filtering(&self, client_id: ClientId) -> bool {
+    fn client_bypasses_authorization_filtering(
+        &self,
+        client_id: ClientId,
+        session: Option<&Session>,
+    ) -> bool {
         self.sync_manager
             .get_client(client_id)
             .map(|client| {
-                matches!(
-                    client.role,
-                    ClientRole::Peer | ClientRole::Admin | ClientRole::Backend
-                )
+                matches!(client.role, ClientRole::Peer | ClientRole::Admin)
+                    || matches!(client.role, ClientRole::Backend)
+                        && client.session.is_none()
+                        && session.is_none()
             })
             .unwrap_or(false)
     }
@@ -768,7 +776,8 @@ impl QueryManager {
                 continue;
             };
 
-            let sync_policy_context_rows = self.should_sync_policy_context_rows(sub.client_id);
+            let sync_policy_context_rows =
+                self.should_sync_policy_context_rows(sub.client_id, session_for_policy.as_ref());
             let branch_schema_map = Self::branch_schema_map_for_context(&subscription_context);
 
             // Initial settle to populate the graph
@@ -815,7 +824,9 @@ impl QueryManager {
             // locally, including any ordered prefix required by pagination.
             let policy_context_tables =
                 Self::merged_policy_context_tables(&graph, &sub.policy_context_tables);
-            let scope = if self.client_bypasses_authorization_filtering(sub.client_id) {
+            let scope = if self
+                .client_bypasses_authorization_filtering(sub.client_id, session_for_policy.as_ref())
+            {
                 let result_scope = graph.sync_scope_object_ids();
                 Some(
                     if sync_policy_context_rows || !policy_context_tables.is_empty() {
@@ -1000,10 +1011,10 @@ impl QueryManager {
                 // Check if scope changed
                 let policy_context_tables =
                     Self::merged_policy_context_tables(&sub.graph, &sub.policy_context_tables);
-                if self.client_bypasses_authorization_filtering(client_id) {
+                if self.client_bypasses_authorization_filtering(client_id, sub.session.as_ref()) {
                     let result_scope = sub.graph.sync_scope_object_ids();
                     Some(
-                        if self.should_sync_policy_context_rows(client_id)
+                        if self.should_sync_policy_context_rows(client_id, sub.session.as_ref())
                             || !policy_context_tables.is_empty()
                         {
                             Self::scope_with_policy_context_rows_for_tables(

--- a/packages/jazz-tools/src/runtime/permissions.repro.test.ts
+++ b/packages/jazz-tools/src/runtime/permissions.repro.test.ts
@@ -5,6 +5,8 @@ import { join } from "node:path";
 import { describe, expect, it, onTestFinished } from "vitest";
 import { schema as s } from "../index.js";
 import { definePermissions } from "../permissions/index.js";
+import { publishStoredSchema } from "./schema-fetch.js";
+import { startLocalJazzServer } from "../testing/local-jazz-server.js";
 
 const reproApp = s.defineApp({
   teams: s.table({
@@ -117,6 +119,14 @@ function seedScenario(context: JazzContext): void {
   });
 }
 
+function sortNames(rows: Array<{ name: string }>): string[] {
+  return rows.map((row) => row.name).sort();
+}
+
+function sortGrantRoles(rows: Array<{ grant_role: string }>): string[] {
+  return rows.map((row) => row.grant_role).sort();
+}
+
 type JazzContext = import("../backend/create-jazz-context.js").JazzContext;
 
 async function createReproContext(defineCasePermissions: ReproPermissions): Promise<JazzContext> {
@@ -145,7 +155,137 @@ async function createReproContext(defineCasePermissions: ReproPermissions): Prom
   return context;
 }
 
+async function createServerBackedReproContext(
+  defineCasePermissions: ReproPermissions,
+  tier: "local" | "edge" | "global" = "edge",
+): Promise<JazzContext> {
+  const appId = randomUUID();
+  const backendSecret = `permissions-repro-backend-${appId}`;
+  const adminSecret = `permissions-repro-admin-${appId}`;
+  const server = await startLocalJazzServer({
+    appId,
+    backendSecret,
+    adminSecret,
+  });
+  await publishStoredSchema(server.url, {
+    adminSecret,
+    schema: reproApp.wasmSchema,
+  });
+
+  const permissions = definePermissions(reproApp, defineCasePermissions);
+  const { createJazzContext } = await import("../backend/create-jazz-context.js");
+  const context = createJazzContext({
+    appId: server.appId,
+    app: reproApp,
+    permissions,
+    driver: { type: "memory" },
+    serverUrl: server.url,
+    backendSecret,
+    env: "test",
+    userBranch: "main",
+    tier,
+  });
+
+  onTestFinished(async () => {
+    await context.shutdown();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await server.stop();
+  });
+
+  return context;
+}
+
 describe("runtime permission repros for recursive gather and qualified predicates", () => {
+  it('keeps `allowedTo.read("target_team")` readable for team access rows', async () => {
+    const context = await createServerBackedReproContext(
+      ({ policy, allowedTo, anyOf, session }) => {
+        const anyGrantRoleValues = ["viewer", "editor", "manager"];
+        const teamIds = session["claims.team_ids"];
+        const adminTeamIds = session["claims.admin_team_ids"];
+        const readableNonAdminTeamGrant = {
+          team: { in: teamIds },
+          grant_role: { in: anyGrantRoleValues },
+          administrator: false,
+        };
+        const readableAdminTeamGrant = {
+          team: { in: adminTeamIds },
+          grant_role: { in: anyGrantRoleValues },
+          administrator: true,
+        };
+
+        return [
+          policy.teams.allowRead.where((team) =>
+            anyOf([
+              { identity_key: session.user_id },
+              policy.team_access_edges.exists.where({
+                target_team: team.id,
+                ...readableNonAdminTeamGrant,
+              }),
+              policy.team_access_edges.exists.where({
+                target_team: team.id,
+                ...readableAdminTeamGrant,
+              }),
+            ]),
+          ),
+          policy.team_access_edges.allowRead.where(allowedTo.read("target_team", { maxDepth: 32 })),
+        ];
+      },
+      "edge",
+    );
+
+    const db = context.asBackend(reproApp);
+    const bobTeam = await db.insertDurable(
+      reproApp.teams,
+      {
+        name: "Bob",
+        route_key: "bob",
+        corporation_id: "corp",
+        kind: "individual",
+        identity_key: "bob",
+        system_owned: false,
+        archived: false,
+      },
+      { tier: "edge" },
+    );
+    await db.insertDurable(
+      reproApp.team_access_edges,
+      {
+        target_team: bobTeam.id,
+        team: bobTeam.id,
+        grant_role: "viewer",
+        administrator: false,
+      },
+      { tier: "edge" },
+    );
+    await db.insertDurable(
+      reproApp.team_access_edges,
+      {
+        target_team: bobTeam.id,
+        team: bobTeam.id,
+        grant_role: "manager",
+        administrator: true,
+      },
+      { tier: "edge" },
+    );
+
+    const bobDb = context.forSession(
+      {
+        user_id: "bob",
+        claims: {
+          team_ids: [bobTeam.id],
+          admin_team_ids: [],
+        },
+      },
+      reproApp,
+    );
+
+    const teams = await bobDb.all(reproApp.teams.where({}));
+    const grants = await bobDb.all(reproApp.team_access_edges.where({}));
+
+    expect(sortNames(teams)).toEqual(["Bob"]);
+    expect(sortGrantRoles(grants)).toEqual(["manager", "viewer"]);
+  });
+
   it("supports the full alpha.33 grant-closure repro end to end", async () => {
     const context = await createReproContext(({ policy, session, allOf }) => {
       const reachableTeams = policy.teams.gather({
@@ -231,5 +371,169 @@ describe("runtime permission repros for recursive gather and qualified predicate
         "Relation Membership",
       ].sort(),
     );
+  });
+
+  it("keeps shared-context session reads stable across session order", async () => {
+    const context = await createServerBackedReproContext(
+      ({ policy, allowedTo, anyOf, session }) => {
+        const anyGrantRoleValues = ["viewer", "editor", "manager"];
+        const teamIds = session["claims.team_ids"];
+        const adminTeamIds = session["claims.admin_team_ids"];
+        const readableNonAdminTeamGrant = {
+          team: { in: teamIds },
+          grant_role: { in: anyGrantRoleValues },
+          administrator: false,
+        };
+        const readableAdminTeamGrant = {
+          team: { in: adminTeamIds },
+          grant_role: { in: anyGrantRoleValues },
+          administrator: true,
+        };
+
+        return [
+          policy.teams.allowRead.where((team) =>
+            anyOf([
+              { identity_key: session.user_id },
+              policy.team_access_edges.exists.where({
+                target_team: team.id,
+                ...readableNonAdminTeamGrant,
+              }),
+              policy.team_access_edges.exists.where({
+                target_team: team.id,
+                ...readableAdminTeamGrant,
+              }),
+            ]),
+          ),
+          policy.team_access_edges.allowRead.where(allowedTo.read("target_team", { maxDepth: 32 })),
+        ];
+      },
+      "local",
+    );
+
+    const db = context.asBackend(reproApp);
+    const aliceTeam = db.insert(reproApp.teams, {
+      name: "Alice",
+      route_key: "alice",
+      corporation_id: "corp",
+      kind: "individual",
+      identity_key: "alice",
+      system_owned: false,
+      archived: false,
+    });
+    const bobTeam = db.insert(reproApp.teams, {
+      name: "Bob",
+      route_key: "bob",
+      corporation_id: "corp",
+      kind: "individual",
+      identity_key: "bob",
+      system_owned: false,
+      archived: false,
+    });
+    const internTeam = db.insert(reproApp.teams, {
+      name: "Intern",
+      route_key: "intern",
+      corporation_id: "corp",
+      kind: "individual",
+      identity_key: "intern",
+      system_owned: false,
+      archived: false,
+    });
+    const opsTeam = db.insert(reproApp.teams, {
+      name: "Ops",
+      route_key: "ops",
+      corporation_id: "corp",
+      kind: "manual",
+      system_owned: false,
+      archived: false,
+    });
+    const regionalTeam = db.insert(reproApp.teams, {
+      name: "Regional",
+      route_key: "regional",
+      corporation_id: "corp",
+      kind: "manual",
+      system_owned: false,
+      archived: false,
+    });
+
+    for (const teamId of [aliceTeam.id, bobTeam.id, internTeam.id, opsTeam.id, regionalTeam.id]) {
+      db.insert(reproApp.team_access_edges, {
+        target_team: teamId,
+        team: teamId,
+        grant_role: "viewer",
+        administrator: false,
+      });
+      db.insert(reproApp.team_access_edges, {
+        target_team: teamId,
+        team: teamId,
+        grant_role: "manager",
+        administrator: true,
+      });
+    }
+
+    db.insert(reproApp.team_access_edges, {
+      target_team: opsTeam.id,
+      team: aliceTeam.id,
+      grant_role: "manager",
+      administrator: false,
+    });
+    db.insert(reproApp.team_access_edges, {
+      target_team: regionalTeam.id,
+      team: opsTeam.id,
+      grant_role: "editor",
+      administrator: false,
+    });
+    db.insert(reproApp.team_access_edges, {
+      target_team: internTeam.id,
+      team: regionalTeam.id,
+      grant_role: "viewer",
+      administrator: false,
+    });
+
+    const sessions = {
+      alice: {
+        user_id: "alice",
+        claims: {
+          team_ids: [aliceTeam.id, opsTeam.id, regionalTeam.id, internTeam.id],
+          admin_team_ids: [],
+        },
+      },
+      bob: {
+        user_id: "bob",
+        claims: {
+          team_ids: [bobTeam.id],
+          admin_team_ids: [],
+        },
+      },
+      intern: {
+        user_id: "intern",
+        claims: {
+          team_ids: [internTeam.id, regionalTeam.id, aliceTeam.id, opsTeam.id],
+          admin_team_ids: [],
+        },
+      },
+    } as const;
+
+    const expectedNames = {
+      alice: ["Alice", "Intern", "Ops", "Regional"],
+      bob: ["Bob"],
+      intern: ["Alice", "Intern", "Ops", "Regional"],
+    } as const;
+
+    const orders = [
+      ["bob"],
+      ["bob", "alice"],
+      ["alice", "bob"],
+      ["intern", "bob"],
+      ["alice", "intern", "bob"],
+    ] as const;
+
+    for (const order of orders) {
+      for (const actor of order) {
+        const actorDb = context.forSession(sessions[actor], reproApp);
+        expect(sortNames(await actorDb.all(reproApp.teams.where({})))).toEqual(
+          expectedNames[actor],
+        );
+      }
+    }
   });
 });


### PR DESCRIPTION
## What changed

This fixes server-side synced query scope handling for backend-authenticated websocket clients when the real user session is only present on the forwarded query payload, such as `createJazzContext(...).forSession(...)`.

The patch updates synced query scope evaluation so backend clients only bypass authorization filtering when the query is truly sessionless. If a subscription or query carries a session, it is treated as user-scoped and keeps local authorization semantics instead of publishing an authoritative remote scope snapshot too early.

## Why

This was collapsing otherwise-valid local reads to empty results in BoreDM-style session-scoped runtime flows when the connected server had no published permissions head yet.

## Root cause

`server_queries.rs` treated backend-authenticated clients as authorization-bypassing unconditionally. In the `forSession(...)` case, that meant the server could advertise remote policy context as authoritative even though the effective query was session-scoped and the server did not yet have permissions state to back that scope.

## Impact

This restores session-scoped synced reads for the reported repro family, including:

- shared-context multi-session query order stability
- team access edge reads gated by `allowedTo.read("target_team")`
- backend transport flows that forward a user session only in the query payload

## Validation

- `cargo test backend_sync_subscription_without_handshake_session_keeps_local_rows_without_permissions_head --package jazz-tools --features test`
- `cargo test sync_backed_subscription_without_remote_scope_snapshot_keeps_local_rows --package jazz-tools --features test`
- `pnpm --dir packages/jazz-tools exec vitest run src/runtime/permissions.repro.test.ts src/permissions/index.test.ts src/permissions/type-inference.test.ts --pool=forks`
- `pnpm --dir packages/jazz-tools exec tsc --noEmit --pretty false`
- `pnpm lint`

## Changeset

- `.changeset/green-oranges-wave.md`
