### PR TITLE
feat(starters): add passphrase & passkey backup/restore UI

### DIFF
--- a/examples/chat-react/src/App.tsx
+++ b/examples/chat-react/src/App.tsx
@@ -22,7 +22,7 @@ function defaultConfig(secret: string, overrides: Partial<DbConfig> = {}): DbCon
     appId,
     env: "dev",
     userBranch: "main",
-    auth: { localFirstSecret: secret },
+    secret,
     ...(SERVER_URL ? { serverUrl: SERVER_URL } : {}),
     ...overrides,
   };

--- a/examples/chat-react/tests/browser/canvas.test.tsx
+++ b/examples/chat-react/tests/browser/canvas.test.tsx
@@ -57,7 +57,7 @@ describe("Canvas E2E", () => {
       appId?: string;
       dbName?: string;
       serverUrl?: string;
-      auth?: { localFirstSecret: string };
+      secret?: string;
     } = {},
   ): Promise<HTMLDivElement> {
     const el = document.createElement("div");
@@ -213,7 +213,7 @@ describe("Canvas E2E", () => {
       appId: APP_ID,
       dbName: uniqueDbName("collab-canvas-a"),
       serverUrl,
-      auth: { localFirstSecret: await testSecret(`canvas-user-a-${Date.now()}`) },
+      secret: await testSecret(`canvas-user-a-${Date.now()}`),
     });
 
     await waitFor(
@@ -270,7 +270,7 @@ describe("Canvas E2E", () => {
       appId: APP_ID,
       dbName: uniqueDbName("collab-canvas-b"),
       serverUrl,
-      auth: { localFirstSecret: await testSecret(`canvas-user-b-${Date.now()}`) },
+      secret: await testSecret(`canvas-user-b-${Date.now()}`),
     });
 
     // User B should see the canvas

--- a/examples/chat-react/tests/browser/chat-app.test.tsx
+++ b/examples/chat-react/tests/browser/chat-app.test.tsx
@@ -68,7 +68,7 @@ describe("Chat App E2E", () => {
       appId?: string;
       dbName?: string;
       serverUrl?: string;
-      auth?: { localFirstSecret: string };
+      secret?: string;
     } = {},
   ): Promise<HTMLDivElement> {
     const el = document.createElement("div");
@@ -405,7 +405,7 @@ describe("Chat App E2E", () => {
       appId: APP_ID,
       dbName: uniqueDbName("access-a"),
       serverUrl,
-      auth: { localFirstSecret: await testSecret(`chat-access-user-a-${Date.now()}`) },
+      secret: await testSecret(`chat-access-user-a-${Date.now()}`),
     });
 
     await waitFor(
@@ -505,7 +505,7 @@ describe("Chat App E2E", () => {
       appId: APP_ID,
       dbName: uniqueDbName("access-b"),
       serverUrl,
-      auth: { localFirstSecret: await testSecret(`chat-access-user-b-${Date.now()}`) },
+      secret: await testSecret(`chat-access-user-b-${Date.now()}`),
     });
 
     // Wait for sync to settle so Bob has whatever data the server delivers

--- a/examples/chat-react/tests/browser/chat-settings.test.tsx
+++ b/examples/chat-react/tests/browser/chat-settings.test.tsx
@@ -53,7 +53,7 @@ describe("ChatHeader + ChatSettings E2E", () => {
       appId?: string;
       dbName?: string;
       serverUrl?: string;
-      auth?: { localFirstSecret: string };
+      secret?: string;
     } = {},
   ): Promise<HTMLDivElement> {
     const el = document.createElement("div");
@@ -289,7 +289,7 @@ describe("ChatHeader + ChatSettings E2E", () => {
       appId: APP_ID,
       dbName: uniqueDbName("members-alice"),
       serverUrl,
-      auth: { localFirstSecret: await testSecret(`settings-alice-${Date.now()}`) },
+      secret: await testSecret(`settings-alice-${Date.now()}`),
     });
 
     await waitFor(
@@ -312,7 +312,7 @@ describe("ChatHeader + ChatSettings E2E", () => {
       appId: APP_ID,
       dbName: uniqueDbName("members-bob"),
       serverUrl,
-      auth: { localFirstSecret: await testSecret(`settings-bob-${Date.now()}`) },
+      secret: await testSecret(`settings-bob-${Date.now()}`),
     });
 
     // Wait for Bob to see the chat

--- a/examples/chat-react/tests/browser/invite.test.tsx
+++ b/examples/chat-react/tests/browser/invite.test.tsx
@@ -53,7 +53,7 @@ describe("Invite Flow E2E", () => {
       appId?: string;
       dbName?: string;
       serverUrl?: string;
-      auth?: { localFirstSecret: string };
+      secret?: string;
     } = {},
   ): Promise<HTMLDivElement> {
     const el = document.createElement("div");
@@ -121,7 +121,7 @@ describe("Invite Flow E2E", () => {
       appId: APP_ID,
       dbName: uniqueDbName("invite-a"),
       serverUrl,
-      auth: { localFirstSecret: await testSecret(`invite-user-a-${Date.now()}`) },
+      secret: await testSecret(`invite-user-a-${Date.now()}`),
     });
 
     await waitFor(
@@ -261,7 +261,7 @@ describe("Invite Flow E2E", () => {
       appId: APP_ID,
       dbName: uniqueDbName("invite-b"),
       serverUrl,
-      auth: { localFirstSecret: await testSecret(`invite-user-b-${Date.now()}`) },
+      secret: await testSecret(`invite-user-b-${Date.now()}`),
     });
 
     // User B should see the secret message after joining via invite

--- a/examples/chat-react/tests/browser/send-permission.test.tsx
+++ b/examples/chat-react/tests/browser/send-permission.test.tsx
@@ -76,7 +76,7 @@ describe("Send permission — private chat INSERT policy", () => {
     config: {
       dbName?: string;
       serverUrl?: string;
-      auth?: { localFirstSecret: string };
+      secret?: string;
     } = {},
   ): Promise<HTMLDivElement> {
     const el = document.createElement("div");
@@ -185,7 +185,7 @@ describe("Send permission — private chat INSERT policy", () => {
     const aliceContainer = await mountApp({
       dbName: uniqueDbName("alice-a"),
       serverUrl,
-      auth: { localFirstSecret: await testSecret(`send-perm-alice-a-${Date.now()}`) },
+      secret: await testSecret(`send-perm-alice-a-${Date.now()}`),
     });
 
     // Alice's app auto-creates a public chat first; navigate to a private one
@@ -235,7 +235,7 @@ describe("Send permission — private chat INSERT policy", () => {
     const aliceContainer = await mountApp({
       dbName: uniqueDbName("alice-b"),
       serverUrl,
-      auth: { localFirstSecret: await testSecret(`send-perm-alice-b-${Date.now()}`) },
+      secret: await testSecret(`send-perm-alice-b-${Date.now()}`),
     });
 
     await waitFor(
@@ -296,7 +296,7 @@ describe("Send permission — private chat INSERT policy", () => {
     const bobContainer = await mountApp({
       dbName: uniqueDbName("bob-b"),
       serverUrl,
-      auth: { localFirstSecret: await testSecret(`send-perm-bob-b-${Date.now()}`) },
+      secret: await testSecret(`send-perm-bob-b-${Date.now()}`),
     });
 
     // InviteHandler should redirect Bob to the chat after inserting chatMember

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -2975,22 +2975,12 @@ function isBrowser(): boolean {
 /**
  * Generate a 32-byte ephemeral seed for anonymous auth.
  *
- * INTENTIONALLY NOT CRYPTOGRAPHICALLY SECURE. We pick Math.random over
- * crypto.getRandomValues on purpose: we want one implementation that runs on
- * every target (browser, Node ESM, React Native, edge workers) without a
- * `crypto` import or WASM dependency, and we're willing to trade CSPRNG-grade
- * unpredictability for that portability.
- *
- * Safe because anonymous sessions cannot own or write anything — the server
- * denies writes at the middleware layer regardless of identity — so a
- * predictable seed has no confidentiality or integrity consequence. Do NOT
- * reuse this helper for anything that touches writable state.
+ * Uses `globalThis.crypto.getRandomValues`, which is available in all
+ * supported environments (browser, Node ≥15, React Native, edge workers).
  */
 function generateEphemeralSeedBase64Url(): string {
   const bytes = new Uint8Array(32);
-  for (let i = 0; i < bytes.length; i++) {
-    bytes[i] = Math.floor(Math.random() * 256);
-  }
+  globalThis.crypto.getRandomValues(bytes);
   let binary = "";
   for (const b of bytes) binary += String.fromCharCode(b);
   return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
@@ -3043,7 +3033,7 @@ export async function createDb(config: DbConfig): Promise<Db> {
       nowSeconds,
     );
     resolvedConfig = { ...resolvedConfig, jwtToken };
-  } else if (!config.jwtToken) {
+  } else if (!config.jwtToken && !config.cookieSession) {
     // Anonymous: mint an ephemeral keypair + anonymous JWT.
     const wasmModule = await loadWasmModule(config.runtimeSources);
     const ephemeralSeed = generateEphemeralSeedBase64Url();

--- a/starters/next-betterauth/components/jazz-provider.tsx
+++ b/starters/next-betterauth/components/jazz-provider.tsx
@@ -17,26 +17,21 @@ export function JazzProvider({ children }: { children: React.ReactNode }) {
       setConfig(null);
       return;
     }
+    if (!APP_ID || !SERVER_URL) {
+      const missing = [
+        !APP_ID && "NEXT_PUBLIC_JAZZ_APP_ID",
+        !SERVER_URL && "NEXT_PUBLIC_JAZZ_SERVER_URL",
+      ]
+        .filter((v) => !!v)
+        .join(" & ");
+      throw new Error(
+        `${missing} not set. The withJazz Next plugin injects these at dev time; in production, set them explicitly in your environment.`,
+      );
+    }
     let cancelled = false;
     authClient.token().then(({ data, error }) => {
       if (cancelled || error || !data?.token) return;
-      const { token: jwtToken } = data;
-      if (!APP_ID || !SERVER_URL) {
-        const missing = [
-          !APP_ID && "NEXT_PUBLIC_JAZZ_APP_ID",
-          !SERVER_URL && "NEXT_PUBLIC_JAZZ_SERVER_URL",
-        ]
-          .filter((v) => !!v)
-          .join(" & ");
-        throw new Error(
-          `${missing} not set. The withJazz Next plugin injects these at dev time; in production, set them explicitly in your environment.`,
-        );
-      }
-      setConfig({
-        appId: APP_ID,
-        serverUrl: SERVER_URL,
-        jwtToken,
-      });
+      setConfig({ appId: APP_ID, serverUrl: SERVER_URL, jwtToken: data.token });
     });
     return () => {
       cancelled = true;
@@ -61,7 +56,7 @@ function JwtRefresh() {
   useEffect(
     () =>
       db.onAuthChanged((state) => {
-        if (state.status !== "unauthenticated") return;
+        if (state.error !== "expired") return;
         authClient.token().then(({ data, error }) => {
           if (!error && data?.token) db.updateAuthToken(data.token);
         });

--- a/starters/next-hybrid/app/globals.css
+++ b/starters/next-hybrid/app/globals.css
@@ -223,3 +223,86 @@ button:disabled {
   background: none;
   color: var(--danger);
 }
+
+.auth-backup {
+  width: 100%;
+  max-width: 540px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.5rem;
+}
+.auth-backup > summary {
+  cursor: pointer;
+  font-weight: 500;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--muted);
+  font-size: 0.875rem;
+}
+.auth-backup > summary::before {
+  content: "▸";
+  font-size: 0.75rem;
+  transition: transform 0.15s;
+}
+.auth-backup[open] > summary::before {
+  transform: rotate(90deg);
+}
+.auth-backup-hint {
+  margin-top: 1rem;
+  font-size: 0.875rem;
+  color: var(--muted);
+}
+.auth-backup-section {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+.auth-backup-section h3 {
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin: 0;
+}
+.auth-backup-phrase {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  font: 0.875rem/1.5 monospace;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  resize: none;
+}
+.auth-backup-restore {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.auth-backup-restore textarea {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  font: inherit;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  resize: none;
+}
+.auth-backup-restore textarea:focus {
+  outline: none;
+  border-color: var(--brand);
+  box-shadow: 0 0 0 3px rgba(20, 106, 255, 0.15);
+}
+.auth-backup-row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+.auth-backup-success {
+  margin: 0;
+  font-size: 0.875rem;
+  color: #16a34a;
+}

--- a/starters/next-hybrid/app/page.tsx
+++ b/starters/next-hybrid/app/page.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { TodoWidget } from "@/components/todo-widget";
+import { AuthBackup } from "@/components/auth-backup";
 import { authClient } from "@/lib/auth-client";
 import { BrowserAuthSecretStore } from "jazz-tools";
 
@@ -44,6 +45,9 @@ function HeaderActions() {
 }
 
 export default function Page() {
+  const { data: authSession } = authClient.useSession();
+  const authenticated = Boolean(authSession?.session);
+
   return (
     <main className="dashboard">
       <header>
@@ -59,6 +63,7 @@ export default function Page() {
         <HeaderActions />
       </header>
       <TodoWidget />
+      {!authenticated && <AuthBackup />}
     </main>
   );
 }

--- a/starters/next-hybrid/components/auth-backup.tsx
+++ b/starters/next-hybrid/components/auth-backup.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useState } from "react";
+import { BrowserAuthSecretStore } from "jazz-tools";
+
+type Status =
+  | { kind: "idle" }
+  | { kind: "error"; message: string }
+  | { kind: "success"; message: string };
+
+// In production, pin this to your deployed hostname so passkeys remain usable
+// across preview deployments. Leaving it undefined falls back to location.hostname.
+const PASSKEY_APP_HOSTNAME: string | undefined = undefined;
+const PASSKEY_APP_NAME = "Jazz Starter";
+
+export function AuthBackup({
+  redirectAfterRestore,
+  mode = "full",
+}: {
+  redirectAfterRestore?: string;
+  mode?: "full" | "restore-only";
+} = {}) {
+  function navigate() {
+    if (redirectAfterRestore) {
+      location.assign(redirectAfterRestore);
+    } else {
+      location.reload();
+    }
+  }
+  const [phrase, setPhrase] = useState<string | null>(null);
+  const [restoreInput, setRestoreInput] = useState("");
+  const [status, setStatus] = useState<Status>({ kind: "idle" });
+  const [busy, setBusy] = useState(false);
+
+  async function handleReveal() {
+    setStatus({ kind: "idle" });
+    setBusy(true);
+    try {
+      const secret = await BrowserAuthSecretStore.loadSecret();
+      if (!secret) {
+        setStatus({ kind: "error", message: "No local secret to reveal yet." });
+        return;
+      }
+      const { RecoveryPhrase } = await import("jazz-tools/passphrase");
+      setPhrase(RecoveryPhrase.fromSecret(secret));
+    } catch (err) {
+      setStatus({ kind: "error", message: describeError(err) });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleCopy() {
+    if (!phrase) return;
+    try {
+      await navigator.clipboard.writeText(phrase);
+      setStatus({ kind: "success", message: "Phrase copied." });
+    } catch {
+      setStatus({
+        kind: "error",
+        message: "Copy failed — select the text and copy manually.",
+      });
+    }
+  }
+
+  async function handleRestorePhrase(e: React.FormEvent) {
+    e.preventDefault();
+    setStatus({ kind: "idle" });
+    setBusy(true);
+    try {
+      const { RecoveryPhrase } = await import("jazz-tools/passphrase");
+      const secret = RecoveryPhrase.toSecret(restoreInput.trim());
+      await BrowserAuthSecretStore.saveSecret(secret);
+      navigate();
+    } catch (err) {
+      setStatus({ kind: "error", message: describeError(err) });
+      setBusy(false);
+    }
+  }
+
+  async function handlePasskeyBackup() {
+    setStatus({ kind: "idle" });
+    setBusy(true);
+    try {
+      const secret = await BrowserAuthSecretStore.loadSecret();
+      if (!secret) {
+        setStatus({ kind: "error", message: "No local secret to back up yet." });
+        return;
+      }
+      const { BrowserPasskeyBackup } = await import("jazz-tools/passkey-backup");
+      const pb = new BrowserPasskeyBackup({
+        appName: PASSKEY_APP_NAME,
+        appHostname: PASSKEY_APP_HOSTNAME,
+      });
+      await pb.backup(secret, "My account");
+      setStatus({ kind: "success", message: "Passkey backup created." });
+    } catch (err) {
+      setStatus({ kind: "error", message: describeError(err) });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handlePasskeyRestore() {
+    setStatus({ kind: "idle" });
+    setBusy(true);
+    try {
+      const { BrowserPasskeyBackup } = await import("jazz-tools/passkey-backup");
+      const pb = new BrowserPasskeyBackup({
+        appName: PASSKEY_APP_NAME,
+        appHostname: PASSKEY_APP_HOSTNAME,
+      });
+      const secret = await pb.restore();
+      await BrowserAuthSecretStore.saveSecret(secret);
+      navigate();
+    } catch (err) {
+      setStatus({ kind: "error", message: describeError(err) });
+      setBusy(false);
+    }
+  }
+
+  return (
+    <details className="auth-backup">
+      <summary>Back up or restore your local-only account</summary>
+      <p className="auth-backup-hint">
+        Save your account's recovery phrase or a passkey so you can get back in on another device or
+        after clearing storage.
+      </p>
+
+      <div className="auth-backup-section">
+        <h3>Recovery phrase</h3>
+        {mode === "full" && (
+          <>
+            <button type="button" onClick={handleReveal} disabled={busy}>
+              Show recovery phrase
+            </button>
+            {phrase && (
+              <>
+                <textarea
+                  className="auth-backup-phrase"
+                  readOnly
+                  rows={3}
+                  value={phrase}
+                  aria-label="Recovery phrase"
+                />
+                <button type="button" onClick={handleCopy} disabled={busy}>
+                  Copy
+                </button>
+              </>
+            )}
+          </>
+        )}
+
+        <form onSubmit={handleRestorePhrase} className="auth-backup-restore">
+          <label htmlFor="auth-backup-restore-input">Restore from recovery phrase</label>
+          <textarea
+            id="auth-backup-restore-input"
+            rows={3}
+            value={restoreInput}
+            onChange={(e) => setRestoreInput(e.target.value)}
+            placeholder="Paste your 24-word phrase"
+            required
+          />
+          <button type="submit" disabled={busy || !restoreInput.trim()}>
+            Restore
+          </button>
+        </form>
+      </div>
+
+      <div className="auth-backup-section">
+        <h3>Passkey</h3>
+        <div className="auth-backup-row">
+          {mode === "full" && (
+            <button type="button" onClick={handlePasskeyBackup} disabled={busy}>
+              Back up with passkey
+            </button>
+          )}
+          <button type="button" onClick={handlePasskeyRestore} disabled={busy}>
+            Restore with passkey
+          </button>
+        </div>
+      </div>
+
+      {status.kind === "error" && (
+        <p className="alert-error" role="alert">
+          {status.message}
+        </p>
+      )}
+      {status.kind === "success" && (
+        <p className="auth-backup-success" role="status">
+          {status.message}
+        </p>
+      )}
+    </details>
+  );
+}
+
+function describeError(err: unknown): string {
+  if (err && typeof err === "object" && "code" in err && "message" in err) {
+    const code = String((err as { code: unknown }).code);
+    const message = String((err as { message: unknown }).message);
+    return `${code}: ${message}`;
+  }
+  if (err instanceof Error) return err.message;
+  return "Unknown error";
+}

--- a/starters/next-hybrid/components/jazz-provider.tsx
+++ b/starters/next-hybrid/components/jazz-provider.tsx
@@ -10,7 +10,7 @@ function JwtRefresh() {
   useEffect(
     () =>
       db.onAuthChanged((state) => {
-        if (state.status !== "unauthenticated") return;
+        if (state.error !== "expired") return;
         authClient.token().then(({ data, error }) => {
           if (!error && data?.token) db.updateAuthToken(data.token);
         });
@@ -59,7 +59,7 @@ export function JazzProvider({ children }: React.PropsWithChildren) {
   );
 }
 
-function baseConfig(): Omit<DbConfig, "jwtToken" | "auth"> {
+function baseConfig(): Omit<DbConfig, "jwtToken" | "secret"> {
   if (!APP_ID || !SERVER_URL) {
     const missing = [
       !APP_ID && "NEXT_PUBLIC_JAZZ_APP_ID",
@@ -79,7 +79,7 @@ function baseConfig(): Omit<DbConfig, "jwtToken" | "auth"> {
 
 async function buildLocalFirstConfig(): Promise<DbConfig> {
   const secret = await BrowserAuthSecretStore.getOrCreateSecret();
-  return { ...baseConfig(), auth: { localFirstSecret: secret } };
+  return { ...baseConfig(), secret };
 }
 
 async function buildJwtConfig(): Promise<DbConfig | null> {

--- a/starters/next-hybrid/e2e/auth-backup.spec.ts
+++ b/starters/next-hybrid/e2e/auth-backup.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const TODO_INPUT_LABEL = "New todo";
+const TIMEOUT = 20_000;
+
+async function waitForApp(page: Page) {
+  await expect(page.getByLabel(TODO_INPUT_LABEL)).toBeVisible({
+    timeout: TIMEOUT,
+  });
+}
+
+async function addTodo(page: Page, title: string) {
+  await page.getByLabel(TODO_INPUT_LABEL).fill(title);
+  await page.getByRole("button", { name: "Add" }).click();
+  await expect(page.getByText(title)).toBeVisible({ timeout: TIMEOUT });
+}
+
+test("recovery phrase round-trips the local-first identity", async ({ page }) => {
+  const runId = Date.now();
+  const todo = `Backup todo ${runId}`;
+
+  await page.goto("/");
+  await waitForApp(page);
+  await addTodo(page, todo);
+
+  // Reveal the phrase.
+  await page.getByText("Back up or restore your local-only account").click();
+  await page.getByRole("button", { name: "Show recovery phrase" }).click();
+  const phraseTextarea = page.getByLabel("Recovery phrase", { exact: true });
+  await expect(phraseTextarea).not.toHaveValue("", { timeout: TIMEOUT });
+  const phrase = await phraseTextarea.inputValue();
+  expect(phrase.trim().split(/\s+/).length).toBe(24);
+
+  // Clear local storage → a fresh anonymous identity is generated, todo vanishes.
+  await page.evaluate(() => localStorage.clear());
+  await page.reload();
+  await waitForApp(page);
+  await expect(page.getByText(todo)).toHaveCount(0, { timeout: TIMEOUT });
+
+  // Restore the phrase.
+  await page.getByText("Back up or restore your local-only account").click();
+  await page.getByLabel("Restore from recovery phrase").fill(phrase);
+  await page.getByRole("button", { name: "Restore", exact: true }).click();
+
+  // Page reloads; the original todo should reappear.
+  await waitForApp(page);
+  await expect(page.getByText(todo)).toBeVisible({ timeout: TIMEOUT });
+});

--- a/starters/next-localfirst/app/globals.css
+++ b/starters/next-localfirst/app/globals.css
@@ -223,3 +223,86 @@ button:disabled {
   background: none;
   color: var(--danger);
 }
+
+.auth-backup {
+  width: 100%;
+  max-width: 540px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.5rem;
+}
+.auth-backup > summary {
+  cursor: pointer;
+  font-weight: 500;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--muted);
+  font-size: 0.875rem;
+}
+.auth-backup > summary::before {
+  content: "▸";
+  font-size: 0.75rem;
+  transition: transform 0.15s;
+}
+.auth-backup[open] > summary::before {
+  transform: rotate(90deg);
+}
+.auth-backup-hint {
+  margin-top: 1rem;
+  font-size: 0.875rem;
+  color: var(--muted);
+}
+.auth-backup-section {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+.auth-backup-section h3 {
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin: 0;
+}
+.auth-backup-phrase {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  font: 0.875rem/1.5 monospace;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  resize: none;
+}
+.auth-backup-restore {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.auth-backup-restore textarea {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  font: inherit;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  resize: none;
+}
+.auth-backup-restore textarea:focus {
+  outline: none;
+  border-color: var(--brand);
+  box-shadow: 0 0 0 3px rgba(20, 106, 255, 0.15);
+}
+.auth-backup-row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+.auth-backup-success {
+  margin: 0;
+  font-size: 0.875rem;
+  color: #16a34a;
+}

--- a/starters/next-localfirst/app/page.tsx
+++ b/starters/next-localfirst/app/page.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { TodoWidget } from "@/components/todo-widget";
+import { AuthBackup } from "@/components/auth-backup";
 
 export default function Page() {
   return (
@@ -18,6 +19,7 @@ export default function Page() {
         />
       </header>
       <TodoWidget />
+      <AuthBackup />
     </main>
   );
 }

--- a/starters/next-localfirst/components/auth-backup.tsx
+++ b/starters/next-localfirst/components/auth-backup.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useState } from "react";
+import { BrowserAuthSecretStore } from "jazz-tools";
+
+type Status =
+  | { kind: "idle" }
+  | { kind: "error"; message: string }
+  | { kind: "success"; message: string };
+
+// In production, pin this to your deployed hostname so passkeys remain usable
+// across preview deployments. Leaving it undefined falls back to location.hostname.
+const PASSKEY_APP_HOSTNAME: string | undefined = undefined;
+const PASSKEY_APP_NAME = "Jazz Starter";
+
+export function AuthBackup({
+  redirectAfterRestore,
+  mode = "full",
+}: {
+  redirectAfterRestore?: string;
+  mode?: "full" | "restore-only";
+} = {}) {
+  function navigate() {
+    if (redirectAfterRestore) {
+      location.assign(redirectAfterRestore);
+    } else {
+      location.reload();
+    }
+  }
+  const [phrase, setPhrase] = useState<string | null>(null);
+  const [restoreInput, setRestoreInput] = useState("");
+  const [status, setStatus] = useState<Status>({ kind: "idle" });
+  const [busy, setBusy] = useState(false);
+
+  async function handleReveal() {
+    setStatus({ kind: "idle" });
+    setBusy(true);
+    try {
+      const secret = await BrowserAuthSecretStore.loadSecret();
+      if (!secret) {
+        setStatus({ kind: "error", message: "No local secret to reveal yet." });
+        return;
+      }
+      const { RecoveryPhrase } = await import("jazz-tools/passphrase");
+      setPhrase(RecoveryPhrase.fromSecret(secret));
+    } catch (err) {
+      setStatus({ kind: "error", message: describeError(err) });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleCopy() {
+    if (!phrase) return;
+    try {
+      await navigator.clipboard.writeText(phrase);
+      setStatus({ kind: "success", message: "Phrase copied." });
+    } catch {
+      setStatus({
+        kind: "error",
+        message: "Copy failed — select the text and copy manually.",
+      });
+    }
+  }
+
+  async function handleRestorePhrase(e: React.FormEvent) {
+    e.preventDefault();
+    setStatus({ kind: "idle" });
+    setBusy(true);
+    try {
+      const { RecoveryPhrase } = await import("jazz-tools/passphrase");
+      const secret = RecoveryPhrase.toSecret(restoreInput.trim());
+      await BrowserAuthSecretStore.saveSecret(secret);
+      navigate();
+    } catch (err) {
+      setStatus({ kind: "error", message: describeError(err) });
+      setBusy(false);
+    }
+  }
+
+  async function handlePasskeyBackup() {
+    setStatus({ kind: "idle" });
+    setBusy(true);
+    try {
+      const secret = await BrowserAuthSecretStore.loadSecret();
+      if (!secret) {
+        setStatus({ kind: "error", message: "No local secret to back up yet." });
+        return;
+      }
+      const { BrowserPasskeyBackup } = await import("jazz-tools/passkey-backup");
+      const pb = new BrowserPasskeyBackup({
+        appName: PASSKEY_APP_NAME,
+        appHostname: PASSKEY_APP_HOSTNAME,
+      });
+      await pb.backup(secret, "My account");
+      setStatus({ kind: "success", message: "Passkey backup created." });
+    } catch (err) {
+      setStatus({ kind: "error", message: describeError(err) });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handlePasskeyRestore() {
+    setStatus({ kind: "idle" });
+    setBusy(true);
+    try {
+      const { BrowserPasskeyBackup } = await import("jazz-tools/passkey-backup");
+      const pb = new BrowserPasskeyBackup({
+        appName: PASSKEY_APP_NAME,
+        appHostname: PASSKEY_APP_HOSTNAME,
+      });
+      const secret = await pb.restore();
+      await BrowserAuthSecretStore.saveSecret(secret);
+      navigate();
+    } catch (err) {
+      setStatus({ kind: "error", message: describeError(err) });
+      setBusy(false);
+    }
+  }
+
+  return (
+    <details className="auth-backup">
+      <summary>Back up or restore your local-only account</summary>
+      <p className="auth-backup-hint">
+        Save your account's recovery phrase or a passkey so you can get back in on another device or
+        after clearing storage.
+      </p>
+
+      <div className="auth-backup-section">
+        <h3>Recovery phrase</h3>
+        {mode === "full" && (
+          <>
+            <button type="button" onClick={handleReveal} disabled={busy}>
+              Show recovery phrase
+            </button>
+            {phrase && (
+              <>
+                <textarea
+                  className="auth-backup-phrase"
+                  readOnly
+                  rows={3}
+                  value={phrase}
+                  aria-label="Recovery phrase"
+                />
+                <button type="button" onClick={handleCopy} disabled={busy}>
+                  Copy
+                </button>
+              </>
+            )}
+          </>
+        )}
+
+        <form onSubmit={handleRestorePhrase} className="auth-backup-restore">
+          <label htmlFor="auth-backup-restore-input">Restore from recovery phrase</label>
+          <textarea
+            id="auth-backup-restore-input"
+            rows={3}
+            value={restoreInput}
+            onChange={(e) => setRestoreInput(e.target.value)}
+            placeholder="Paste your 24-word phrase"
+            required
+          />
+          <button type="submit" disabled={busy || !restoreInput.trim()}>
+            Restore
+          </button>
+        </form>
+      </div>
+
+      <div className="auth-backup-section">
+        <h3>Passkey</h3>
+        <div className="auth-backup-row">
+          {mode === "full" && (
+            <button type="button" onClick={handlePasskeyBackup} disabled={busy}>
+              Back up with passkey
+            </button>
+          )}
+          <button type="button" onClick={handlePasskeyRestore} disabled={busy}>
+            Restore with passkey
+          </button>
+        </div>
+      </div>
+
+      {status.kind === "error" && (
+        <p className="alert-error" role="alert">
+          {status.message}
+        </p>
+      )}
+      {status.kind === "success" && (
+        <p className="auth-backup-success" role="status">
+          {status.message}
+        </p>
+      )}
+    </details>
+  );
+}
+
+function describeError(err: unknown): string {
+  if (err && typeof err === "object" && "code" in err && "message" in err) {
+    const code = String((err as { code: unknown }).code);
+    const message = String((err as { message: unknown }).message);
+    return `${code}: ${message}`;
+  }
+  if (err instanceof Error) return err.message;
+  return "Unknown error";
+}

--- a/starters/next-localfirst/components/jazz-provider.tsx
+++ b/starters/next-localfirst/components/jazz-provider.tsx
@@ -25,7 +25,7 @@ export function JazzProvider({ children }: React.PropsWithChildren) {
   );
 }
 
-function buildConfig(localFirstSecret: string): DbConfig {
+function buildConfig(secret: string): DbConfig {
   if (!APP_ID || !SERVER_URL) {
     const missing = [
       !APP_ID && "NEXT_PUBLIC_JAZZ_APP_ID",
@@ -40,6 +40,6 @@ function buildConfig(localFirstSecret: string): DbConfig {
   return {
     appId: APP_ID,
     serverUrl: SERVER_URL,
-    auth: { localFirstSecret },
+    secret,
   };
 }

--- a/starters/next-localfirst/e2e/auth-backup.spec.ts
+++ b/starters/next-localfirst/e2e/auth-backup.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const TODO_INPUT_LABEL = "New todo";
+const TIMEOUT = 20_000;
+
+async function waitForApp(page: Page) {
+  await expect(page.getByLabel(TODO_INPUT_LABEL)).toBeVisible({
+    timeout: TIMEOUT,
+  });
+}
+
+async function addTodo(page: Page, title: string) {
+  await page.getByLabel(TODO_INPUT_LABEL).fill(title);
+  await page.getByRole("button", { name: "Add" }).click();
+  await expect(page.getByText(title)).toBeVisible({ timeout: TIMEOUT });
+}
+
+test("recovery phrase round-trips the local-first identity", async ({ page }) => {
+  const runId = Date.now();
+  const todo = `Backup todo ${runId}`;
+
+  await page.goto("/");
+  await waitForApp(page);
+  await addTodo(page, todo);
+
+  // Reveal the phrase.
+  await page.getByText("Back up or restore your local-only account").click();
+  await page.getByRole("button", { name: "Show recovery phrase" }).click();
+  const phraseTextarea = page.getByLabel("Recovery phrase", { exact: true });
+  await expect(phraseTextarea).not.toHaveValue("", { timeout: TIMEOUT });
+  const phrase = await phraseTextarea.inputValue();
+  expect(phrase.trim().split(/\s+/).length).toBe(24);
+
+  // Clear local storage → a fresh anonymous identity is generated, todo vanishes.
+  await page.evaluate(() => localStorage.clear());
+  await page.reload();
+  await waitForApp(page);
+  await expect(page.getByText(todo)).toHaveCount(0, { timeout: TIMEOUT });
+
+  // Restore the phrase.
+  await page.getByText("Back up or restore your local-only account").click();
+  await page.getByLabel("Restore from recovery phrase").fill(phrase);
+  await page.getByRole("button", { name: "Restore", exact: true }).click();
+
+  // Page reloads; the original todo should reappear.
+  await waitForApp(page);
+  await expect(page.getByText(todo)).toBeVisible({ timeout: TIMEOUT });
+});

--- a/starters/sveltekit-betterauth/src/routes/(authenticated)/+layout.svelte
+++ b/starters/sveltekit-betterauth/src/routes/(authenticated)/+layout.svelte
@@ -34,7 +34,7 @@
       // long-lived sessions don't silently drop to unauthenticated.
       const resolved = await client;
       unsubRefresh = resolved.db.onAuthChanged(async (state) => {
-        if (state.status !== "unauthenticated") return;
+        if (state.error !== "expired") return;
         const fresh = await getToken();
         if (fresh) resolved.db.updateAuthToken(fresh);
       });

--- a/starters/sveltekit-hybrid/e2e/auth-backup.spec.ts
+++ b/starters/sveltekit-hybrid/e2e/auth-backup.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const TODO_INPUT_LABEL = "New todo";
+const TIMEOUT = 20_000;
+
+async function waitForApp(page: Page) {
+  await expect(page.getByLabel(TODO_INPUT_LABEL)).toBeVisible({
+    timeout: TIMEOUT,
+  });
+}
+
+async function addTodo(page: Page, title: string) {
+  await page.getByLabel(TODO_INPUT_LABEL).fill(title);
+  await page.getByRole("button", { name: "Add" }).click();
+  await expect(page.getByText(title)).toBeVisible({ timeout: TIMEOUT });
+}
+
+test("recovery phrase round-trips the local-first identity", async ({ page }) => {
+  const runId = Date.now();
+  const todo = `Backup todo ${runId}`;
+
+  await page.goto("/");
+  await waitForApp(page);
+  await addTodo(page, todo);
+
+  // Reveal the phrase.
+  await page.getByText("Back up or restore your local-only account").click();
+  await page.getByRole("button", { name: "Show recovery phrase" }).click();
+  const phraseTextarea = page.getByLabel("Recovery phrase", { exact: true });
+  await expect(phraseTextarea).not.toHaveValue("", { timeout: TIMEOUT });
+  const phrase = await phraseTextarea.inputValue();
+  expect(phrase.trim().split(/\s+/).length).toBe(24);
+
+  // Clear local storage → a fresh anonymous identity is generated, todo vanishes.
+  await page.evaluate(() => localStorage.clear());
+  await page.reload();
+  await waitForApp(page);
+  await expect(page.getByText(todo)).toHaveCount(0, { timeout: TIMEOUT });
+
+  // Restore the phrase.
+  await page.getByText("Back up or restore your local-only account").click();
+  await page.getByLabel("Restore from recovery phrase").fill(phrase);
+  await page.getByRole("button", { name: "Restore", exact: true }).click();
+
+  // Page reloads; the original todo should reappear.
+  await waitForApp(page);
+  await expect(page.getByText(todo)).toBeVisible({ timeout: TIMEOUT });
+});

--- a/starters/sveltekit-hybrid/src/lib/AuthBackup.svelte
+++ b/starters/sveltekit-hybrid/src/lib/AuthBackup.svelte
@@ -1,0 +1,197 @@
+<script lang="ts">
+  import { BrowserAuthSecretStore } from "jazz-tools/svelte";
+  import { goto } from "$app/navigation";
+
+  // In production, pin this to your deployed hostname so passkeys remain
+  // usable across preview deployments. Leaving it undefined falls back to
+  // location.hostname.
+  const PASSKEY_APP_HOSTNAME: string | undefined = undefined;
+  const PASSKEY_APP_NAME = "Jazz Starter";
+
+  type Status =
+    | { kind: "idle" }
+    | { kind: "error"; message: string }
+    | { kind: "success"; message: string };
+
+  let {
+    redirectAfterRestore,
+    mode = "full",
+  }: {
+    redirectAfterRestore?: string;
+    mode?: "full" | "restore-only";
+  } = $props();
+
+  let phrase = $state<string | null>(null);
+  let restoreInput = $state("");
+  let status = $state<Status>({ kind: "idle" });
+  let busy = $state(false);
+
+  async function navigate() {
+    if (redirectAfterRestore) {
+      await goto(redirectAfterRestore);
+      location.reload();
+    } else {
+      location.reload();
+    }
+  }
+
+  function describeError(err: unknown): string {
+    if (err && typeof err === "object" && "code" in err && "message" in err) {
+      return `${String((err as { code: unknown }).code)}: ${String((err as { message: unknown }).message)}`;
+    }
+    if (err instanceof Error) return err.message;
+    return "Unknown error";
+  }
+
+  async function handleReveal() {
+    status = { kind: "idle" };
+    busy = true;
+    try {
+      const secret = await BrowserAuthSecretStore.loadSecret();
+      if (!secret) {
+        status = { kind: "error", message: "No local secret to reveal yet." };
+        return;
+      }
+      const { RecoveryPhrase } = await import("jazz-tools/passphrase");
+      phrase = RecoveryPhrase.fromSecret(secret);
+    } catch (err) {
+      status = { kind: "error", message: describeError(err) };
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function handleCopy() {
+    if (!phrase) return;
+    try {
+      await navigator.clipboard.writeText(phrase);
+      status = { kind: "success", message: "Phrase copied." };
+    } catch {
+      status = {
+        kind: "error",
+        message: "Copy failed — select the text and copy manually.",
+      };
+    }
+  }
+
+  async function handleRestorePhrase(e: SubmitEvent) {
+    e.preventDefault();
+    status = { kind: "idle" };
+    busy = true;
+    try {
+      const { RecoveryPhrase } = await import("jazz-tools/passphrase");
+      const secret = RecoveryPhrase.toSecret(restoreInput.trim());
+      await BrowserAuthSecretStore.saveSecret(secret);
+      await navigate();
+    } catch (err) {
+      status = { kind: "error", message: describeError(err) };
+      busy = false;
+    }
+  }
+
+  async function handlePasskeyBackup() {
+    status = { kind: "idle" };
+    busy = true;
+    try {
+      const secret = await BrowserAuthSecretStore.loadSecret();
+      if (!secret) {
+        status = { kind: "error", message: "No local secret to back up yet." };
+        return;
+      }
+      const { BrowserPasskeyBackup } = await import("jazz-tools/passkey-backup");
+      const pb = new BrowserPasskeyBackup({
+        appName: PASSKEY_APP_NAME,
+        appHostname: PASSKEY_APP_HOSTNAME,
+      });
+      await pb.backup(secret, "My account");
+      status = { kind: "success", message: "Passkey backup created." };
+    } catch (err) {
+      status = { kind: "error", message: describeError(err) };
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function handlePasskeyRestore() {
+    status = { kind: "idle" };
+    busy = true;
+    try {
+      const { BrowserPasskeyBackup } = await import("jazz-tools/passkey-backup");
+      const pb = new BrowserPasskeyBackup({
+        appName: PASSKEY_APP_NAME,
+        appHostname: PASSKEY_APP_HOSTNAME,
+      });
+      const secret = await pb.restore();
+      await BrowserAuthSecretStore.saveSecret(secret);
+      await navigate();
+    } catch (err) {
+      status = { kind: "error", message: describeError(err) };
+      busy = false;
+    }
+  }
+</script>
+
+<details class="auth-backup">
+  <summary>Back up or restore your local-only account</summary>
+  <p class="auth-backup-hint">
+    Save your account's recovery phrase or a passkey so you can get back in
+    on another device or after clearing storage.
+  </p>
+
+  <div class="auth-backup-section">
+    <h3>Recovery phrase</h3>
+    {#if mode === "full"}
+      <button type="button" onclick={handleReveal} disabled={busy}>
+        Show recovery phrase
+      </button>
+      {#if phrase}
+        <textarea
+          class="auth-backup-phrase"
+          readonly
+          rows={3}
+          value={phrase}
+          aria-label="Recovery phrase"
+        ></textarea>
+        <button type="button" onclick={handleCopy} disabled={busy}>
+          Copy
+        </button>
+      {/if}
+    {/if}
+
+    <form onsubmit={handleRestorePhrase} class="auth-backup-restore">
+      <label for="auth-backup-restore-input">
+        Restore from recovery phrase
+      </label>
+      <textarea
+        id="auth-backup-restore-input"
+        rows={3}
+        bind:value={restoreInput}
+        placeholder="Paste your 24-word phrase"
+        required
+      ></textarea>
+      <button type="submit" disabled={busy || !restoreInput.trim()}>
+        Restore
+      </button>
+    </form>
+  </div>
+
+  <div class="auth-backup-section">
+    <h3>Passkey</h3>
+    <div class="auth-backup-row">
+      {#if mode === "full"}
+        <button type="button" onclick={handlePasskeyBackup} disabled={busy}>
+          Back up with passkey
+        </button>
+      {/if}
+      <button type="button" onclick={handlePasskeyRestore} disabled={busy}>
+        Restore with passkey
+      </button>
+    </div>
+  </div>
+
+  {#if status.kind === "error"}
+    <p class="alert-error" role="alert">{status.message}</p>
+  {:else if status.kind === "success"}
+    <p class="auth-backup-success" role="status">{status.message}</p>
+  {/if}
+</details>

--- a/starters/sveltekit-hybrid/src/lib/JazzClientProvider.svelte
+++ b/starters/sveltekit-hybrid/src/lib/JazzClientProvider.svelte
@@ -29,7 +29,7 @@
       if (authenticated) {
         const resolved = await jazzClient;
         unsubRefresh = resolved.db.onAuthChanged(async (state) => {
-          if (state.status !== "unauthenticated") return;
+          if (state.error !== "expired") return;
           const fresh = await getToken();
           if (fresh) resolved.db.updateAuthToken(fresh);
         });
@@ -54,7 +54,7 @@
       );
       return Promise.resolve(null);
     }
-    const base: Omit<DbConfig, "jwtToken" | "auth"> = { appId, serverUrl };
+    const base: Omit<DbConfig, "jwtToken" | "secret"> = { appId, serverUrl };
 
     if (auth) {
       return getToken().then((token) =>
@@ -64,7 +64,7 @@
 
     return BrowserAuthSecretStore.getOrCreateSecret().then((secret) => ({
       ...base,
-      auth: { localFirstSecret: secret },
+      secret,
     }));
   }
 </script>

--- a/starters/sveltekit-hybrid/src/routes/+layout.svelte
+++ b/starters/sveltekit-hybrid/src/routes/+layout.svelte
@@ -6,9 +6,16 @@
   let { children: pageChildren } = $props();
 
   const session = authClient.useSession();
-  const authenticated = $derived(
-    $session.isPending ? null : Boolean($session.data?.session),
-  );
+
+  // Never revert to null once resolved — prevents JazzClientProvider from
+  // unmounting during BetterAuth background re-fetches (which set isPending:true
+  // briefly), which would reset any in-progress UI state (e.g. open <details>).
+  let authenticated = $state<boolean | null>(null);
+  $effect(() => {
+    if (!$session.isPending) {
+      authenticated = Boolean($session.data?.session);
+    }
+  });
 </script>
 
 {#if authenticated !== null}

--- a/starters/sveltekit-hybrid/src/routes/+page.svelte
+++ b/starters/sveltekit-hybrid/src/routes/+page.svelte
@@ -3,6 +3,7 @@
   import { authClient } from "$lib/auth-client";
   import { BrowserAuthSecretStore } from "jazz-tools/svelte";
   import TodoWidget from "$lib/TodoWidget.svelte";
+  import AuthBackup from "$lib/AuthBackup.svelte";
 
   const session = authClient.useSession();
 
@@ -28,4 +29,7 @@
     </div>
   </header>
   <TodoWidget />
+  {#if !$session.data?.session}
+    <AuthBackup />
+  {/if}
 </main>

--- a/starters/sveltekit-localfirst/e2e/auth-backup.spec.ts
+++ b/starters/sveltekit-localfirst/e2e/auth-backup.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const TODO_INPUT_LABEL = "New todo";
+const TIMEOUT = 20_000;
+
+async function waitForApp(page: Page) {
+  await expect(page.getByLabel(TODO_INPUT_LABEL)).toBeVisible({
+    timeout: TIMEOUT,
+  });
+}
+
+async function addTodo(page: Page, title: string) {
+  await page.getByLabel(TODO_INPUT_LABEL).fill(title);
+  await page.getByRole("button", { name: "Add" }).click();
+  await expect(page.getByText(title)).toBeVisible({ timeout: TIMEOUT });
+}
+
+test("recovery phrase round-trips the local-first identity", async ({ page }) => {
+  const runId = Date.now();
+  const todo = `Backup todo ${runId}`;
+
+  await page.goto("/");
+  await waitForApp(page);
+  await addTodo(page, todo);
+
+  // Reveal the phrase.
+  await page.getByText("Back up or restore your local-only account").click();
+  await page.getByRole("button", { name: "Show recovery phrase" }).click();
+  const phraseTextarea = page.getByLabel("Recovery phrase", { exact: true });
+  await expect(phraseTextarea).not.toHaveValue("", { timeout: TIMEOUT });
+  const phrase = await phraseTextarea.inputValue();
+  expect(phrase.trim().split(/\s+/).length).toBe(24);
+
+  // Clear local storage → a fresh anonymous identity is generated, todo vanishes.
+  await page.evaluate(() => localStorage.clear());
+  await page.reload();
+  await waitForApp(page);
+  await expect(page.getByText(todo)).toHaveCount(0, { timeout: TIMEOUT });
+
+  // Restore the phrase.
+  await page.getByText("Back up or restore your local-only account").click();
+  await page.getByLabel("Restore from recovery phrase").fill(phrase);
+  await page.getByRole("button", { name: "Restore", exact: true }).click();
+
+  // Page reloads; the original todo should reappear.
+  await waitForApp(page);
+  await expect(page.getByText(todo)).toBeVisible({ timeout: TIMEOUT });
+});

--- a/starters/sveltekit-localfirst/src/lib/AuthBackup.svelte
+++ b/starters/sveltekit-localfirst/src/lib/AuthBackup.svelte
@@ -1,0 +1,197 @@
+<script lang="ts">
+  import { BrowserAuthSecretStore } from "jazz-tools/svelte";
+  import { goto } from "$app/navigation";
+
+  // In production, pin this to your deployed hostname so passkeys remain
+  // usable across preview deployments. Leaving it undefined falls back to
+  // location.hostname.
+  const PASSKEY_APP_HOSTNAME: string | undefined = undefined;
+  const PASSKEY_APP_NAME = "Jazz Starter";
+
+  type Status =
+    | { kind: "idle" }
+    | { kind: "error"; message: string }
+    | { kind: "success"; message: string };
+
+  let {
+    redirectAfterRestore,
+    mode = "full",
+  }: {
+    redirectAfterRestore?: string;
+    mode?: "full" | "restore-only";
+  } = $props();
+
+  let phrase = $state<string | null>(null);
+  let restoreInput = $state("");
+  let status = $state<Status>({ kind: "idle" });
+  let busy = $state(false);
+
+  async function navigate() {
+    if (redirectAfterRestore) {
+      await goto(redirectAfterRestore);
+      location.reload();
+    } else {
+      location.reload();
+    }
+  }
+
+  function describeError(err: unknown): string {
+    if (err && typeof err === "object" && "code" in err && "message" in err) {
+      return `${String((err as { code: unknown }).code)}: ${String((err as { message: unknown }).message)}`;
+    }
+    if (err instanceof Error) return err.message;
+    return "Unknown error";
+  }
+
+  async function handleReveal() {
+    status = { kind: "idle" };
+    busy = true;
+    try {
+      const secret = await BrowserAuthSecretStore.loadSecret();
+      if (!secret) {
+        status = { kind: "error", message: "No local secret to reveal yet." };
+        return;
+      }
+      const { RecoveryPhrase } = await import("jazz-tools/passphrase");
+      phrase = RecoveryPhrase.fromSecret(secret);
+    } catch (err) {
+      status = { kind: "error", message: describeError(err) };
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function handleCopy() {
+    if (!phrase) return;
+    try {
+      await navigator.clipboard.writeText(phrase);
+      status = { kind: "success", message: "Phrase copied." };
+    } catch {
+      status = {
+        kind: "error",
+        message: "Copy failed — select the text and copy manually.",
+      };
+    }
+  }
+
+  async function handleRestorePhrase(e: SubmitEvent) {
+    e.preventDefault();
+    status = { kind: "idle" };
+    busy = true;
+    try {
+      const { RecoveryPhrase } = await import("jazz-tools/passphrase");
+      const secret = RecoveryPhrase.toSecret(restoreInput.trim());
+      await BrowserAuthSecretStore.saveSecret(secret);
+      await navigate();
+    } catch (err) {
+      status = { kind: "error", message: describeError(err) };
+      busy = false;
+    }
+  }
+
+  async function handlePasskeyBackup() {
+    status = { kind: "idle" };
+    busy = true;
+    try {
+      const secret = await BrowserAuthSecretStore.loadSecret();
+      if (!secret) {
+        status = { kind: "error", message: "No local secret to back up yet." };
+        return;
+      }
+      const { BrowserPasskeyBackup } = await import("jazz-tools/passkey-backup");
+      const pb = new BrowserPasskeyBackup({
+        appName: PASSKEY_APP_NAME,
+        appHostname: PASSKEY_APP_HOSTNAME,
+      });
+      await pb.backup(secret, "My account");
+      status = { kind: "success", message: "Passkey backup created." };
+    } catch (err) {
+      status = { kind: "error", message: describeError(err) };
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function handlePasskeyRestore() {
+    status = { kind: "idle" };
+    busy = true;
+    try {
+      const { BrowserPasskeyBackup } = await import("jazz-tools/passkey-backup");
+      const pb = new BrowserPasskeyBackup({
+        appName: PASSKEY_APP_NAME,
+        appHostname: PASSKEY_APP_HOSTNAME,
+      });
+      const secret = await pb.restore();
+      await BrowserAuthSecretStore.saveSecret(secret);
+      await navigate();
+    } catch (err) {
+      status = { kind: "error", message: describeError(err) };
+      busy = false;
+    }
+  }
+</script>
+
+<details class="auth-backup">
+  <summary>Back up or restore your local-only account</summary>
+  <p class="auth-backup-hint">
+    Save your account's recovery phrase or a passkey so you can get back in
+    on another device or after clearing storage.
+  </p>
+
+  <div class="auth-backup-section">
+    <h3>Recovery phrase</h3>
+    {#if mode === "full"}
+      <button type="button" onclick={handleReveal} disabled={busy}>
+        Show recovery phrase
+      </button>
+      {#if phrase}
+        <textarea
+          class="auth-backup-phrase"
+          readonly
+          rows={3}
+          value={phrase}
+          aria-label="Recovery phrase"
+        ></textarea>
+        <button type="button" onclick={handleCopy} disabled={busy}>
+          Copy
+        </button>
+      {/if}
+    {/if}
+
+    <form onsubmit={handleRestorePhrase} class="auth-backup-restore">
+      <label for="auth-backup-restore-input">
+        Restore from recovery phrase
+      </label>
+      <textarea
+        id="auth-backup-restore-input"
+        rows={3}
+        bind:value={restoreInput}
+        placeholder="Paste your 24-word phrase"
+        required
+      ></textarea>
+      <button type="submit" disabled={busy || !restoreInput.trim()}>
+        Restore
+      </button>
+    </form>
+  </div>
+
+  <div class="auth-backup-section">
+    <h3>Passkey</h3>
+    <div class="auth-backup-row">
+      {#if mode === "full"}
+        <button type="button" onclick={handlePasskeyBackup} disabled={busy}>
+          Back up with passkey
+        </button>
+      {/if}
+      <button type="button" onclick={handlePasskeyRestore} disabled={busy}>
+        Restore with passkey
+      </button>
+    </div>
+  </div>
+
+  {#if status.kind === "error"}
+    <p class="alert-error" role="alert">{status.message}</p>
+  {:else if status.kind === "success"}
+    <p class="auth-backup-success" role="status">{status.message}</p>
+  {/if}
+</details>

--- a/starters/sveltekit-localfirst/src/routes/+layout.svelte
+++ b/starters/sveltekit-localfirst/src/routes/+layout.svelte
@@ -29,7 +29,7 @@
       const config: DbConfig = {
         appId,
         serverUrl,
-        auth: { localFirstSecret: secret },
+        secret,
       };
       client = createJazzClient(config);
     })();

--- a/starters/sveltekit-localfirst/src/routes/+page.svelte
+++ b/starters/sveltekit-localfirst/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import TodoWidget from "$lib/TodoWidget.svelte";
+  import AuthBackup from "$lib/AuthBackup.svelte";
 </script>
 
 <main class="dashboard">
@@ -7,4 +8,5 @@
     <img src="/jazz.svg" alt="Jazz" class="wordmark" />
   </header>
   <TodoWidget />
+  <AuthBackup />
 </main>


### PR DESCRIPTION
## Summary

- Adds an `<AuthBackup>` component to all four local-first starters (next-localfirst, next-hybrid, sveltekit-localfirst, sveltekit-hybrid) with recovery phrase and passkey backup/restore
- Aligns all starter jazz-provider files with the new flat `DbConfig` API from #549 (`secret` replaces `auth.localFirstSecret`, `state.error !== "expired"` replaces `state.status !== "unauthenticated"`)
- Fixes two bugs in `packages/jazz-tools/src/runtime/db.ts`: anonymous JWT fallback condition and use of `Math.random` → `globalThis.crypto.getRandomValues`
- Fixes sveltekit-hybrid layout to avoid remounting `JazzClientProvider` during BetterAuth background re-fetches

## Depends on

**This PR should be reviewed and merged after #549 (`feat/auth-improvements`) lands on `main`.** The API alignment commits are layered directly on top of that work.

## Test plan

- [ ] All four starters' e2e suites pass (next-localfirst ✓, next-hybrid ✓, sveltekit-localfirst ✓, sveltekit-hybrid ✓)
- [ ] Recovery phrase round-trip: reveal phrase → clear localStorage → restore → data reappears
- [ ] Passkey backup/restore UI renders correctly in hybrid starters (only shown when unauthenticated)