### PR TITLE
fix BatchId write-context wire format

### DIFF
--- a/.changeset/batch-id-json-wire.md
+++ b/.changeset/batch-id-json-wire.md
@@ -1,0 +1,10 @@
+---
+"jazz-tools": patch
+"jazz-wasm": patch
+"jazz-napi": patch
+"jazz-rn": patch
+---
+
+Standardize BatchId JSON values on hex strings across Jazz write-context bindings.
+
+Batch write contexts now accept the TypeScript wire shape used by current clients, including lowercase `batch_mode` values and string `batch_id` values, and reject the old array-style BatchId JSON representation.

--- a/crates/jazz-tools/src/batch_fate.rs
+++ b/crates/jazz-tools/src/batch_fate.rs
@@ -12,6 +12,7 @@ use crate::sync_manager::DurabilityTier;
 pub const BATCH_FATE_STORAGE_FORMAT_V2: i32 = 2;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum BatchMode {
     Direct,
     Transactional,

--- a/crates/jazz-tools/src/binding_support.rs
+++ b/crates/jazz-tools/src/binding_support.rs
@@ -433,7 +433,7 @@ pub fn current_timestamp_ms() -> i64 {
 mod tests {
     use super::{
         align_query_rows_to_declared_schema, align_values_to_declared_schema,
-        parse_read_durability_options, parse_runtime_schema_input,
+        parse_read_durability_options, parse_runtime_schema_input, parse_write_context_input,
         query_rows_can_be_schema_aligned,
     };
     use crate::object::ObjectId;
@@ -594,5 +594,53 @@ mod tests {
 
         assert!(!input.loaded_policy_bundle);
         assert!(input.schema.contains_key(&TableName::new("todos")));
+    }
+
+    #[test]
+    fn parse_write_context_accepts_ts_batch_id_strings() {
+        let batch_id = "0123456789abcdef0123456789abcdef";
+        let input = format!(
+            r#"{{
+                "session": {{
+                    "user_id": "alice",
+                    "claims": {{}},
+                    "authMode": "external"
+                }},
+                "batch_mode": "transactional",
+                "batch_id": "{batch_id}",
+                "target_branch_name": "dev-123456789abc-main"
+            }}"#
+        );
+
+        let context = parse_write_context_input(Some(&input))
+            .expect("parse write context")
+            .expect("write context");
+
+        assert_eq!(
+            context
+                .batch_id()
+                .map(|parsed| parsed.to_string())
+                .as_deref(),
+            Some(batch_id)
+        );
+        assert_eq!(context.target_branch_name(), Some("dev-123456789abc-main"));
+    }
+
+    #[test]
+    fn parse_write_context_rejects_legacy_batch_id_arrays() {
+        let input = r#"{
+            "session": {
+                "user_id": "alice",
+                "claims": {},
+                "authMode": "external"
+            },
+            "batch_mode": "transactional",
+            "batch_id": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+            "target_branch_name": "dev-123456789abc-main"
+        }"#;
+
+        let error =
+            parse_write_context_input(Some(input)).expect_err("legacy batch_id should fail");
+        assert!(error.contains("WriteContextWire"));
     }
 }

--- a/crates/jazz-tools/src/row_histories/mod.rs
+++ b/crates/jazz-tools/src/row_histories/mod.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use blake3::Hasher;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use smallvec::SmallVec;
 use uuid::Uuid;
 
@@ -21,7 +21,7 @@ use crate::row_format::{
 use crate::storage::{IndexMutation, RowLocator, Storage, StorageError};
 use crate::sync_manager::DurabilityTier;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct BatchId(pub [u8; 16]);
 
 impl BatchId {
@@ -76,6 +76,25 @@ impl From<Digest32> for BatchId {
         let mut bytes = [0u8; 16];
         bytes.copy_from_slice(&value.0[..16]);
         Self(bytes)
+    }
+}
+
+impl Serialize for BatchId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for BatchId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        raw.parse().map_err(serde::de::Error::custom)
     }
 }
 


### PR DESCRIPTION
## What changed

- standardized `BatchId` JSON serialization/deserialization on hex strings
- updated `BatchMode` serde to accept the lowercase wire values emitted by TypeScript write contexts
- added binding-support tests that prove TS-style batch write contexts parse successfully and legacy array-style `batch_id` payloads are rejected
- added a changeset for `jazz-tools`, `jazz-wasm`, `jazz-napi`, and `jazz-rn`

## Why

Batch write contexts coming from current TypeScript clients encode `batch_id` as a hex string and `batch_mode` as lowercase text. Rust was still accepting a legacy `BatchId` JSON shape and default enum casing, which caused write-context parsing to fail with:

`data did not match any variant of untagged enum WriteContextWire`

This PR makes the wire format explicit and consistent across bindings.

## Impact

Current TS-driven batch writes now parse cleanly across the Rust-backed bindings, and the old array-style `BatchId` JSON shape is no longer accepted.

## Validation

- `cargo test -p jazz-tools binding_support::tests -- --nocapture`
- `cargo test -p jazz-tools test_write_context_batch_mode_override -- --nocapture`
- `pnpm lint`
