### PR TITLE
fix(dev): persist dev-server data dir across restarts

### DIFF
--- a/packages/jazz-tools/src/dev/managed-runtime.ts
+++ b/packages/jazz-tools/src/dev/managed-runtime.ts
@@ -4,6 +4,10 @@ import { join } from "node:path";
 import type { LocalJazzServerHandle } from "./dev-server.js";
 import type { JazzPluginOptions, JazzServerOptions } from "./vite.js";
 
+function defaultPersistentDataDir(projectRoot: string): string {
+  return join(projectRoot, "node_modules", ".cache", "jazz-dev-server");
+}
+
 const LOG_PREFIX = "[jazz]";
 
 export type ManagedRuntime = {
@@ -211,6 +215,13 @@ export class ManagedDevRuntime {
             options.appId ??
             randomUUID();
 
+          let dataDir = serverConfig.dataDir;
+          if (dataDir === undefined && serverConfig.inMemory !== true) {
+            const projectRoot = options.envDir ?? schemaDir;
+            dataDir = defaultPersistentDataDir(projectRoot);
+            await mkdir(dataDir, { recursive: true });
+          }
+
           const { startLocalJazzServer } = await import("./dev-server.js");
           this.serverHandle = await startLocalJazzServer({
             appId,
@@ -218,7 +229,7 @@ export class ManagedDevRuntime {
             adminSecret,
             backendSecret: options.backendSecret,
             allowLocalFirstAuth: serverConfig.allowLocalFirstAuth,
-            dataDir: serverConfig.dataDir,
+            dataDir,
             inMemory: serverConfig.inMemory,
             jwksUrl: serverConfig.jwksUrl,
             catalogueAuthority: serverConfig.catalogueAuthority,


### PR DESCRIPTION
## Summary

- The Vite/Next/SvelteKit dev plugins all route through `ManagedDevRuntime`, which left `dataDir` undefined when starting the local Jazz server. `startLocalJazzServer` then minted a fresh `mkdtemp` directory each run and auto-cleaned it on stop, so every `pnpm dev` restart wiped the previous session's app data.
- Default `dataDir` to `<projectRoot>/node_modules/.cache/jazz-dev-server` (created on demand) when the caller hasn't supplied one and isn't using in-memory storage. The directory survives restarts and follows the standard "cache under node_modules" convention.
- Direct callers of `startLocalJazzServer` keep the previous random-temp + auto-clean behaviour because they still pass `dataDir: undefined` — the plugin layer is the only path that gains a stable default.

## Test plan

- [ ] `pnpm dev` in a starter; verify `node_modules/.cache/jazz-dev-server` is created and contains the SQLite files.
- [ ] Restart `pnpm dev`; verify the previously inserted data is still queryable.
- [ ] Run `pnpm --filter jazz-tools test dev-server` to confirm the dev-server isolation tests still pass (they exercise the direct `startLocalJazzServer` path that should be unchanged).