### PR TITLE
Use durable inserts in docs todo server

### DIFF
--- a/examples/docs/todo-server-ts/src/main.ts
+++ b/examples/docs/todo-server-ts/src/main.ts
@@ -150,11 +150,15 @@ export async function createServer(config: TodoServerConfig = {}): Promise<TodoS
         return;
       }
 
-      const { value: todo } = db.insert(schemaApp.todos, {
-        title: body.title,
-        done: false,
-        owner_id: body.owner_id ?? "anonymous",
-      });
+      const todo = await db.insertDurable(
+        schemaApp.todos,
+        {
+          title: body.title,
+          done: false,
+          owner_id: body.owner_id ?? "anonymous",
+        },
+        { tier: "edge" },
+      );
 
       res.status(201).json(todo);
 


### PR DESCRIPTION
## Summary
- switch `examples/docs/todo-server-ts` POST `/todos` to `insertDurable(..., { tier: "edge" })`
- align the docs example with the maintained `examples/todo-server-ts` server behavior
- harden the restart/persistence path that failed in the release-preview CI run

## Why
Release preview PR #578 failed in `todo-server-ts-docs` on the restart test with `expected 4 to be 2` after rebooting the server. I couldn't reproduce that failure locally after a clean build, but the docs example was still using non-durable `db.insert(...)` while the maintained sibling example already uses durable inserts. That mismatch leaves a likely timing hole around restart and upstream sync, so this change removes the most obvious source of CI-only duplication.

## Verification
- `pnpm --filter todo-server-ts-docs exec vitest run tests/integration.test.ts -t "survives a server restart"`
- `pnpm --filter todo-server-ts-docs test`
- `pnpm test --filter=!moon-lander-react --filter=!@jazz/rust --filter=!jazz-rn --concurrency=2`