### PR TITLE
fix(auth-betterauth-chat): keep isLoading true while JWT is fetched

### DIFF
--- a/examples/auth-betterauth-chat/app/page.tsx
+++ b/examples/auth-betterauth-chat/app/page.tsx
@@ -124,7 +124,7 @@ function useBetterAuthJWT() {
   }
 
   return {
-    isLoading: isPending || isLoadingJWT,
+    isLoading: isPending || isLoadingJWT || (!!sessionId && !jwt),
     jwt,
     getRefreshedJWT,
   };


### PR DESCRIPTION
## Summary
- Close a 1-frame race in `useBetterAuthJWT` where `isPending` flipped false before the `useEffect` set `isLoadingJWT` to true. During that frame, `Page` fell through to the local-first `secret` branch and mounted `JazzProvider` with a local-first config, only to tear it down and remount once the JWT arrived.
- On reload this manifested as a ~10s delay before the authenticated user's data appeared.
- Treating "session exists but JWT not yet resolved" as a loading state makes the provider mount exactly once with the JWT config.

## Test plan
- [x] Reload the page with an authenticated session: `ChatShell` mounts once with `authMode=external`, first rows land in <1s (was 5–10s).
- [ ] Sign out → sign in: no regression, provider still transitions cleanly.
- [ ] Anonymous (no session) path unaffected: local-first secret is still used when no session exists.