### PR TITLE
Allow any uuid row ids

### DIFF
--- a/.changeset/codex-any-uuid-row-id.md
+++ b/.changeset/codex-any-uuid-row-id.md
@@ -1,0 +1,8 @@
+---
+"jazz-tools": patch
+"jazz-wasm": patch
+"jazz-napi": patch
+"jazz-rn": patch
+---
+
+Allow caller-supplied row ids to use any valid UUID and rely on explicit row metadata for created-at semantics.

--- a/crates/jazz-tools/src/binding_support.rs
+++ b/crates/jazz-tools/src/binding_support.rs
@@ -456,13 +456,6 @@ pub fn parse_external_object_id(object_id: Option<&str>) -> Result<Option<Object
     };
 
     let uuid = Uuid::parse_str(object_id).map_err(|err| format!("Invalid ObjectId: {err}"))?;
-    if uuid.get_version_num() != 7 {
-        return Err(format!(
-            "Invalid ObjectId: expected UUIDv7, got version {}",
-            uuid.get_version_num()
-        ));
-    }
-
     Ok(Some(ObjectId::from_uuid(uuid)))
 }
 
@@ -538,6 +531,17 @@ mod tests {
                 Value::Boolean(false),
                 Value::Text("note".to_string()),
             ]
+        );
+    }
+
+    #[test]
+    fn parse_external_object_id_accepts_any_valid_uuid() {
+        let parsed = super::parse_external_object_id(Some("550e8400-e29b-41d4-a716-446655440000"))
+            .expect("parse valid uuid");
+
+        assert_eq!(
+            parsed.expect("object id").uuid().to_string(),
+            "550e8400-e29b-41d4-a716-446655440000"
         );
     }
 

--- a/crates/jazz-tools/src/client.rs
+++ b/crates/jazz-tools/src/client.rs
@@ -289,7 +289,7 @@ impl JazzClient {
             .await
     }
 
-    /// Create a new row in a table using a caller-supplied UUIDv7.
+    /// Create a new row in a table using a caller-supplied UUID.
     pub async fn create_with_id(
         &self,
         table: &str,
@@ -328,7 +328,7 @@ impl JazzClient {
             .await
     }
 
-    /// Create a new row with a caller-supplied UUIDv7 and wait for durability.
+    /// Create a new row with a caller-supplied UUID and wait for durability.
     pub async fn create_persisted_with_id(
         &self,
         table: &str,
@@ -359,7 +359,7 @@ impl JazzClient {
         Ok((object_id, row_values))
     }
 
-    /// Create or update a row using a caller-supplied UUIDv7.
+    /// Create or update a row using a caller-supplied UUID.
     pub async fn upsert(
         &self,
         table: &str,

--- a/crates/jazz-tools/src/object.rs
+++ b/crates/jazz-tools/src/object.rs
@@ -2,7 +2,7 @@ use internment::Intern;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use uuid::Uuid;
 
-/// Interned UUIDv7 identifying an object.
+/// Interned UUID identifying an object.
 /// Pointer-sized (8 bytes), Copy, fast equality via pointer comparison.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ObjectId(pub Intern<Uuid>);
@@ -33,6 +33,7 @@ impl std::fmt::Display for ObjectId {
 }
 
 impl ObjectId {
+    /// Generate a new time-ordered UUIDv7 object id.
     pub fn new() -> Self {
         Self(Intern::new(Uuid::now_v7()))
     }

--- a/crates/jazz-tools/src/query_manager/writes.rs
+++ b/crates/jazz-tools/src/query_manager/writes.rs
@@ -120,14 +120,6 @@ impl QueryManager {
         external_object_id: Option<ObjectId>,
     ) -> Result<ObjectId, QueryError> {
         if let Some(object_id) = external_object_id {
-            if object_id.uuid().get_version_num() != 7 {
-                return Err(QueryError::EncodingError(format!(
-                    "external create id must be UUIDv7, got version {} for {}",
-                    object_id.uuid().get_version_num(),
-                    object_id
-                )));
-            }
-
             if storage
                 .load_row_locator(object_id)
                 .map_err(|err| QueryError::EncodingError(format!("load row locator: {err}")))?

--- a/crates/jazz-tools/src/schema_manager/manager.rs
+++ b/crates/jazz-tools/src/schema_manager/manager.rs
@@ -1641,19 +1641,7 @@ impl SchemaManager {
         self.insert_with_write_context(storage, table, values, owned.as_ref())
     }
 
-    fn validate_external_upsert_object_id(object_id: ObjectId) -> Result<(), QueryError> {
-        if object_id.uuid().get_version_num() != 7 {
-            return Err(QueryError::EncodingError(format!(
-                "external upsert id must be UUIDv7, got version {} for {}",
-                object_id.uuid().get_version_num(),
-                object_id
-            )));
-        }
-
-        Ok(())
-    }
-
-    /// Create or update a row with a caller-supplied UUIDv7.
+    /// Create or update a row with a caller-supplied UUID.
     ///
     /// If a visible row already exists for `object_id`, only the supplied
     /// columns are updated. Otherwise a new row is inserted with that id.
@@ -1665,7 +1653,6 @@ impl SchemaManager {
         values: HashMap<String, Value>,
         write_context: Option<&WriteContext>,
     ) -> Result<crate::row_histories::BatchId, QueryError> {
-        Self::validate_external_upsert_object_id(object_id)?;
         let _ = self.ensure_current_schema_persisted(storage);
         let (target_branch, target_hash) = self.resolve_target_branch(write_context)?;
         let target_context = self.schema_context_for_hash(target_hash)?;

--- a/crates/jazz-tools/src/storage/mod.rs
+++ b/crates/jazz-tools/src/storage/mod.rs
@@ -4862,7 +4862,7 @@ pub(crate) fn encode_value(value: &Value) -> Vec<u8> {
         }
 
         Value::Uuid(id) => {
-            // UUID bytes (UUIDv7 is time-ordered)
+            // UUID bytes compare lexicographically by raw value.
             let mut bytes = vec![0x06];
             bytes.extend_from_slice(id.uuid().as_bytes());
             bytes

--- a/crates/jazz-tools/tests/clients_sync.rs
+++ b/crates/jazz-tools/tests/clients_sync.rs
@@ -216,7 +216,7 @@ async fn jazz_tools_cli_two_clients_sync_values() {
 }
 
 #[tokio::test]
-async fn caller_supplied_uuidv7_is_used_for_created_row() {
+async fn caller_supplied_uuid_is_used_for_created_row() {
     let server = TestingServer::start().await;
     let schema = test_schema();
     let client = JazzClient::connect(server.make_client_context(schema.clone()))
@@ -226,7 +226,7 @@ async fn caller_supplied_uuidv7_is_used_for_created_row() {
     wait_for_edge_query_ready(&client, Duration::from_secs(30)).await;
 
     let external_id =
-        Uuid::parse_str("01963f3e-5cbe-7a62-8d7c-123456789abc").expect("parse external uuidv7");
+        Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").expect("parse external uuid");
 
     let (todo_id, expected_values) = client
         .create_with_id(
@@ -265,7 +265,7 @@ async fn caller_supplied_uuidv7_is_used_for_created_row() {
 }
 
 #[tokio::test]
-async fn upsert_uses_external_uuidv7_for_insert_and_updates_existing_row() {
+async fn caller_supplied_uuid_keeps_created_at_as_explicit_metadata() {
     let server = TestingServer::start().await;
     let schema = test_schema();
     let client = JazzClient::connect(server.make_client_context(schema.clone()))
@@ -275,7 +275,75 @@ async fn upsert_uses_external_uuidv7_for_insert_and_updates_existing_row() {
     wait_for_edge_query_ready(&client, Duration::from_secs(30)).await;
 
     let external_id =
-        Uuid::parse_str("01963f3e-5cbf-73d1-9f8a-123456789abc").expect("parse external uuidv7");
+        Uuid::parse_str("550e8400-e29b-41d4-a716-446655440002").expect("parse external uuid");
+
+    client
+        .upsert(
+            "todos",
+            external_id,
+            HashMap::from([
+                ("title".to_string(), Value::Text("first-title".to_string())),
+                ("completed".to_string(), Value::Boolean(false)),
+            ]),
+        )
+        .await
+        .expect("insert row through upsert");
+
+    let provenance_query = QueryBuilder::new("todos")
+        .select(&["$createdAt", "$updatedAt"])
+        .build();
+
+    client
+        .upsert(
+            "todos",
+            external_id,
+            HashMap::from([(
+                "title".to_string(),
+                Value::Text("updated-title".to_string()),
+            )]),
+        )
+        .await
+        .expect("upsert row with external id");
+
+    let updated_rows = wait_for_query(
+        &client,
+        provenance_query,
+        Some(DurabilityTier::Local),
+        Duration::from_secs(25),
+        "updated provenance query returns row",
+        |rows| (rows.len() == 1 && rows[0].0.uuid() == &external_id).then_some(rows),
+    )
+    .await;
+
+    let Value::Timestamp(updated_created_at) = updated_rows[0].1[0] else {
+        panic!("updated $createdAt should decode as timestamp")
+    };
+    let Value::Timestamp(updated_updated_at) = updated_rows[0].1[1] else {
+        panic!("updated $updatedAt should decode as timestamp")
+    };
+
+    assert_eq!(updated_rows[0].0.uuid(), &external_id);
+    assert!(
+        updated_created_at < updated_updated_at,
+        "created_at should remain the original timestamp after an update"
+    );
+
+    client.shutdown().await.expect("shutdown writer");
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn upsert_uses_external_uuid_for_insert_and_updates_existing_row() {
+    let server = TestingServer::start().await;
+    let schema = test_schema();
+    let client = JazzClient::connect(server.make_client_context(schema.clone()))
+        .await
+        .expect("connect writer");
+
+    wait_for_edge_query_ready(&client, Duration::from_secs(30)).await;
+
+    let external_id =
+        Uuid::parse_str("550e8400-e29b-41d4-a716-446655440001").expect("parse external uuid");
 
     client
         .upsert(

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -83,7 +83,7 @@ pub fn parse_schema(json: &str) -> Result<JsValue, JsError> {
 
 /// Generate a new UUID v7 (time-ordered).
 ///
-/// Useful for generating row IDs on the client side.
+/// Useful when a caller wants the default generated row-id shape.
 #[wasm_bindgen(js_name = generateId)]
 pub fn generate_id() -> String {
     uuid::Uuid::now_v7().to_string()

--- a/packages/jazz-tools/src/react/create-jazz-client.integration.test.ts
+++ b/packages/jazz-tools/src/react/create-jazz-client.integration.test.ts
@@ -74,9 +74,9 @@ describe("react/create-jazz-client integration", () => {
     }
   }, 15000);
 
-  it("RC-I02: uses a caller-supplied uuidv7 for inserts", async () => {
+  it("RC-I02: uses a caller-supplied uuid for inserts", async () => {
     let client: JazzClient | null = null;
-    const externalId = "01963f3e-5cbe-7a62-8d7c-123456789abc";
+    const externalId = "550e8400-e29b-41d4-a716-446655440000";
 
     try {
       client = await createJazzClient({ appId: makeAppId("external-id") });


### PR DESCRIPTION
## What changed

- allow caller-supplied row ids to use any valid UUID instead of rejecting non-v7 UUIDs
- keep generated ids as UUIDv7 by default, but document that `created_at` semantics come from explicit row metadata rather than the row id format
- add regression coverage for non-v7 create/upsert flows and `$createdAt` / `$updatedAt` behavior
- add a changeset for the affected published surfaces

## Why

The write path still treated UUIDv7 as a hard requirement for external row ids even though row provenance already stores `_jazz_created_at` explicitly. That made row-id validity stricter than the actual storage semantics required.

## Impact

- callers can now provide any valid UUID as a row id
- `created_at` remains explicit metadata and is preserved across updates
- generated ids are still time-ordered UUIDv7s unless the caller provides their own id

## Validation

- `pnpm lint`
- `cargo test -p jazz-tools --features test parse_external_object_id_accepts_any_valid_uuid --lib`
- `cargo test -p jazz-tools --features test --test clients_sync caller_supplied_uuid`
- `cargo test -p jazz-tools --features test --test clients_sync upsert_uses_external_uuid_for_insert_and_updates_existing_row -- --exact`

## Notes

- the full-repo `oxlint` step reports existing workspace warnings outside this diff, but the lint command completed successfully and `cargo clippy --workspace -- -D warnings` passed
- I also updated the React integration test to the new UUID contract; I did not run that test locally because the package test environment in this worktree fails before execution when resolving the local `jazz-wasm` entry
