### PR TITLE
Bypass local policies for admin-secret clients

### DIFF
--- a/.changeset/silent-seals-prove.md
+++ b/.changeset/silent-seals-prove.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Admin-secret clients now bypass local row-policy enforcement so writes still reach the sync server, where permissions are actually checked.

--- a/examples/todo-client-localfirst-svelte/tests/browser/todo-app.test.ts
+++ b/examples/todo-client-localfirst-svelte/tests/browser/todo-app.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, afterEach } from "vitest";
 import { mount, unmount, type Component } from "svelte";
-import { TEST_PORT, ADMIN_SECRET, APP_ID } from "./test-constants.js";
+import { TEST_PORT, APP_ID } from "./test-constants.js";
 import type { DbConfig } from "jazz-tools";
 
 // ---------------------------------------------------------------------------
@@ -263,15 +263,11 @@ describe("Svelte Todo App E2E", () => {
       appId: APP_ID,
       driver: { type: "persistent", dbName: uniqueDbName("sync-a") },
       serverUrl,
-      auth: { localFirstSecret: "7qSvV33vJ5RRj0PvggMwRHZM_DvrO4aC-FrRPHl9Oc4" },
-      adminSecret: ADMIN_SECRET,
     });
     const el2 = await mountApp({
       appId: APP_ID,
       driver: { type: "persistent", dbName: uniqueDbName("sync-b") },
       serverUrl,
-      auth: { localFirstSecret: "JpMaXfvIgbjIQ7Uo-QMb6HmE144K08GB-c5qbZQp36A" },
-      adminSecret: ADMIN_SECRET,
     });
 
     // Let both app instances finish server/event-stream setup before mutating.

--- a/examples/todo-client-localfirst-ts/tests/browser/todo-app.test.ts
+++ b/examples/todo-client-localfirst-ts/tests/browser/todo-app.test.ts
@@ -7,9 +7,8 @@
 
 import { describe, it, expect, afterEach } from "vitest";
 import { startApp } from "../../src/main.js";
-import { TEST_PORT, ADMIN_SECRET, APP_ID } from "./test-constants.js";
-import { app } from "../../schema.js";
-import { createDb, DbConfig } from "jazz-tools";
+import { TEST_PORT, APP_ID } from "./test-constants.js";
+import { DbConfig } from "jazz-tools";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -268,15 +267,11 @@ describe("Vanilla TS Todo App E2E", () => {
       appId: APP_ID,
       driver: { type: "persistent", dbName: uniqueDbName("sync-a") },
       serverUrl,
-      auth: { localFirstSecret: "IsHiz7lWH1KJEuM5J8Hn_oleBb6SBcuGSE9Ro3H0G68" },
-      adminSecret: ADMIN_SECRET,
     });
     const el2 = await mount({
       appId: APP_ID,
       driver: { type: "persistent", dbName: uniqueDbName("sync-b") },
       serverUrl,
-      auth: { localFirstSecret: "C5-etNr9-YLchXK15XLhDVIn-An8mgb35sc5lfJpAQE" },
-      adminSecret: ADMIN_SECRET,
     });
 
     // Let both app instances finish server/event-stream setup before mutating.

--- a/packages/inspector/scripts/dev-sync-server.ts
+++ b/packages/inspector/scripts/dev-sync-server.ts
@@ -8,7 +8,7 @@ import {
   TEST_ENV,
   TEST_PORT,
 } from "../tests/browser/test-constants.js";
-import { app } from "../tests/browser/schema.ts";
+import { app, permissions } from "../tests/browser/schema.ts";
 import { createJazzContext } from "jazz-tools/backend";
 
 const SEED_BATCH_SIZE = 50;
@@ -33,7 +33,7 @@ export default async function runServer() {
   const context = createJazzContext({
     appId: serverHandle.appId,
     app: app,
-    permissions: {},
+    permissions,
     driver: { type: "memory" },
     serverUrl: serverHandle.url,
     backendSecret: serverHandle.backendSecret,

--- a/packages/inspector/tests/browser/global-setup.ts
+++ b/packages/inspector/tests/browser/global-setup.ts
@@ -5,6 +5,7 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
   const { serverHandle } = await runServer();
 
   const { hashes } = await fetchSchemaHashes(serverHandle.url, {
+    appId: serverHandle.appId,
     adminSecret: serverHandle.adminSecret,
   });
 

--- a/packages/inspector/tests/browser/schema.ts
+++ b/packages/inspector/tests/browser/schema.ts
@@ -1,4 +1,4 @@
-import { col, defineApp, type Schema, type App } from "jazz-tools";
+import { col, defineApp, definePermissions, type Schema, type App } from "jazz-tools";
 
 const schema = {
   todos: {
@@ -10,3 +10,10 @@ const schema = {
 type AppSchema = Schema<typeof schema>;
 
 export const app: App<AppSchema> = defineApp(schema);
+
+export const permissions = definePermissions(app, ({ policy }) => {
+  policy.todos.allowRead.where({});
+  policy.todos.allowInsert.never();
+  policy.todos.allowUpdate.never();
+  policy.todos.allowDelete.never();
+});

--- a/packages/inspector/tests/browser/standalone-inspector.spec.ts
+++ b/packages/inspector/tests/browser/standalone-inspector.spec.ts
@@ -28,6 +28,9 @@ async function storeStandaloneConfig(page: Page) {
 async function expectTodosTableLoaded(page: Page) {
   await expect(page.getByRole("heading", { name: "Tables" })).toBeVisible({ timeout: 15_000 });
   await expect(page.getByRole("link", { name: "Schema" })).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByRole("checkbox", { name: /Toggle done for/ }).first()).toBeVisible({
+    timeout: 15_000,
+  });
 }
 
 async function openTodosTable(page: Page) {
@@ -136,9 +139,9 @@ test.describe("data explorer page", () => {
     await expect(page.getByText('"name": "done"')).toBeVisible();
     await expect(page.getByText('"type": "Boolean"')).toBeVisible();
     await expect(page.getByRole("heading", { name: "todos permissions" })).toBeVisible();
-    await expect(
-      page.getByText("No published sync-server permissions found for this app."),
-    ).toBeVisible();
+    await expect(page.getByText('"insert"')).toBeVisible();
+    await expect(page.getByText('"update"')).toBeVisible();
+    await expect(page.getByText('"delete"')).toBeVisible();
   });
 
   test("discards queued inline text edits without persisting them", async ({ page }) => {
@@ -219,6 +222,9 @@ test.describe("data explorer page", () => {
 
   test("filters rows to done=true and shows only checked boolean cells", async ({ page }) => {
     const visibleCheckboxesBeforeFilter = page.getByRole("checkbox", { name: /Toggle done for/ });
+    await expect
+      .poll(async () => await visibleCheckboxesBeforeFilter.count(), { timeout: 15_000 })
+      .toBeGreaterThan(0);
     const visibleCheckboxCountBeforeFilter = await visibleCheckboxesBeforeFilter.count();
     expect(visibleCheckboxCountBeforeFilter).toBeGreaterThan(0);
 
@@ -245,6 +251,7 @@ test.describe("data explorer page", () => {
     await expect(filterButton).toBeVisible();
 
     const checkboxes = page.getByRole("checkbox", { name: /Toggle done for/ });
+    await expect.poll(async () => await checkboxes.count(), { timeout: 15_000 }).toBeGreaterThan(0);
     const checkboxCount = await checkboxes.count();
     expect(checkboxCount).toBeGreaterThan(0);
 

--- a/packages/jazz-tools/src/runtime/db.anonymous.test.ts
+++ b/packages/jazz-tools/src/runtime/db.anonymous.test.ts
@@ -26,4 +26,16 @@ describe("createDb — anonymous mode", () => {
     expect(first).toBeTruthy();
     await db.shutdown();
   });
+
+  it("does not mint an anonymous identity when adminSecret is provided", async () => {
+    const { createDb } = await import("./db.js");
+    const db = await createDb({
+      appId: "test-app",
+      driver: { type: "memory" },
+      serverUrl: "ws://example.invalid",
+      adminSecret: "admin-secret",
+    });
+    expect(db.getAuthState().session).toBeNull();
+    await db.shutdown();
+  });
 });

--- a/packages/jazz-tools/src/runtime/db.transport.test.ts
+++ b/packages/jazz-tools/src/runtime/db.transport.test.ts
@@ -83,4 +83,37 @@ describe("runtime/Db direct path upstream wiring", () => {
 
     expect((client as any).connectTransport).not.toHaveBeenCalled();
   });
+
+  it("DBRT-U03 strips local policies for memory-driver admin-secret clients", () => {
+    const client = makeClientStub();
+    const connectSyncSpy = vi.spyOn(JazzClient, "connectSync").mockReturnValue(client);
+
+    const db = new TestDb({
+      appId: "app",
+      serverUrl: "https://example.test",
+      adminSecret: "admin-y",
+      driver: { type: "memory" },
+    });
+    db.exposeGetClient({
+      todos: {
+        columns: [{ name: "title", column_type: { type: "Text" }, nullable: false }],
+        policies: {
+          update: {
+            using: {
+              type: "False",
+            },
+          },
+        },
+      },
+    });
+
+    expect(connectSyncSpy).toHaveBeenCalledTimes(1);
+    expect(connectSyncSpy.mock.calls[0]?.[1]).toMatchObject({
+      schema: {
+        todos: {
+          columns: [{ name: "title", column_type: { type: "Text" }, nullable: false }],
+        },
+      },
+    });
+  });
 });

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -125,6 +125,22 @@ function resolveStorageDriver(driver?: StorageDriver): StorageDriver {
   return driver ?? { type: "persistent" };
 }
 
+function shouldBypassLocalPolicies(config: DbConfig): boolean {
+  return resolveStorageDriver(config.driver).type === "memory" && !!config.adminSecret;
+}
+
+function stripSchemaPolicies(schema: WasmSchema): WasmSchema {
+  return Object.fromEntries(
+    Object.entries(schema).map(([tableName, tableSchema]) => [
+      tableName,
+      {
+        ...tableSchema,
+        policies: undefined,
+      },
+    ]),
+  ) as WasmSchema;
+}
+
 function trimOptionalString(value?: string | null): string | null {
   if (typeof value !== "string") {
     return null;
@@ -1156,8 +1172,12 @@ export class Db {
       throw new Error("Db runtime module is not initialized for this Db implementation");
     }
 
+    const runtimeSchema = shouldBypassLocalPolicies(this.config)
+      ? stripSchemaPolicies(schema)
+      : schema;
+
     // Use stringified schema as cache key
-    const key = serializeRuntimeSchema(schema);
+    const key = serializeRuntimeSchema(runtimeSchema);
 
     if (!this.clients.has(key)) {
       setGlobalWasmLogLevel(this.config.logLevel);
@@ -1167,7 +1187,7 @@ export class Db {
         this.wasmModule,
         {
           appId: this.config.appId,
-          schema,
+          schema: runtimeSchema,
           driver: this.config.driver,
           // In worker mode, don't connect to server directly — worker handles it
           serverUrl: this.worker ? undefined : this.config.serverUrl,
@@ -3136,8 +3156,10 @@ export async function createDb(config: DbConfig): Promise<Db> {
       nowSeconds,
     );
     resolvedConfig = { ...resolvedConfig, jwtToken };
-  } else if (!config.jwtToken && !config.cookieSession) {
+  } else if (!config.jwtToken && !config.cookieSession && !config.adminSecret) {
     // Anonymous: mint an ephemeral keypair + anonymous JWT.
+    // Admin-secret clients intentionally stay sessionless so local policy
+    // evaluation does not preempt backend-authorized transport writes.
     const wasmModule = await loadWasmModule(config.runtimeSources);
     const ephemeralSeed = generateEphemeralSeedBase64Url();
     const nowSeconds = BigInt(Math.floor(Date.now() / 1000));

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -126,7 +126,7 @@ function resolveStorageDriver(driver?: StorageDriver): StorageDriver {
 }
 
 function shouldBypassLocalPolicies(config: DbConfig): boolean {
-  return resolveStorageDriver(config.driver).type === "memory" && !!config.adminSecret;
+  return !!config.adminSecret;
 }
 
 function stripSchemaPolicies(schema: WasmSchema): WasmSchema {


### PR DESCRIPTION
## Summary
- pass app-level permissions into the inspector dev sync server and include appId when fetching schema hashes
- define browser test permissions so the standalone inspector exercises real policy metadata
- skip anonymous session minting and strip local schema policies for clients that use an admin secret
- tighten inspector tests to wait for loaded table rows and assert permissions are rendered

## Testing
- Added runtime tests for anonymous session handling and schema policy stripping
- Updated browser coverage for the standalone inspector data explorer
- Not run (not requested)