### PR TITLE
feat(cli): warn on missing explicit permission policies during deploy

### DIFF
--- a/.changeset/deploy-missing-policy-warnings.md
+++ b/.changeset/deploy-missing-policy-warnings.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+`jazz-tools deploy` now warns about tables that have no explicit permission policy, matching the behaviour of `jazz-tools validate`.

--- a/examples/docs/todo-server-ts/tests/integration.test.ts
+++ b/examples/docs/todo-server-ts/tests/integration.test.ts
@@ -194,6 +194,15 @@ describe("Todo Server Integration", () => {
 
   describe("Persistence / Cold Start", () => {
     it("survives a server restart", async () => {
+      // Use an isolated upstream so CRUD test data doesn't leak into the count assertion.
+      const coldStartUpstream = await TestingServer.start();
+      await pushSchemaCatalogue({
+        serverUrl: coldStartUpstream.url,
+        appId: coldStartUpstream.appId,
+        adminSecret: coldStartUpstream.adminSecret,
+        schemaDir: join(import.meta.dirname ?? __dirname, ".."),
+      });
+
       // Use a shared data path so both server instances see the same Fjall file
       const dataDir = mkdtempSync(join(tmpdir(), "jazz-cold-start-"));
       const dbPath = join(dataDir, "jazz.db");
@@ -202,10 +211,10 @@ describe("Todo Server Integration", () => {
       const server1 = await startServer(
         await createServer({
           dataPath: dbPath,
-          appId: upstream!.appId,
-          serverUrl: upstream!.url,
-          backendSecret: upstream!.backendSecret,
-          adminSecret: upstream!.adminSecret,
+          appId: coldStartUpstream.appId,
+          serverUrl: coldStartUpstream.url,
+          backendSecret: coldStartUpstream.backendSecret,
+          adminSecret: coldStartUpstream.adminSecret,
         }),
         0,
       );
@@ -234,10 +243,10 @@ describe("Todo Server Integration", () => {
       const server2 = await startServer(
         await createServer({
           dataPath: dbPath,
-          appId: upstream!.appId,
-          serverUrl: upstream!.url,
-          backendSecret: upstream!.backendSecret,
-          adminSecret: upstream!.adminSecret,
+          appId: coldStartUpstream.appId,
+          serverUrl: coldStartUpstream.url,
+          backendSecret: coldStartUpstream.backendSecret,
+          adminSecret: coldStartUpstream.adminSecret,
         }),
         0,
       );
@@ -259,6 +268,7 @@ describe("Todo Server Integration", () => {
       expect(found2!.title).toBe("Also persist");
 
       await stopServer(server2);
+      await coldStartUpstream.stop();
     });
   });
 

--- a/packages/jazz-tools/src/cli.test.ts
+++ b/packages/jazz-tools/src/cli.test.ts
@@ -2358,6 +2358,56 @@ export default s.defineMigration({
     expect(logs.some((line) => line.includes("Warning: The new permissions schema"))).toBe(true);
     expect(logs.some((line) => line.includes("Published permissions"))).toBe(true);
   });
+
+  it("warns about tables with no explicit permission policy", async () => {
+    const { root } = await createWorkspace();
+    await writeFile(join(root, "schema.ts"), rootSchemaWithoutInlinePermissions());
+    await writeFile(join(root, "permissions.ts"), rootPermissionsSchema());
+
+    const schemaHash = "1234123412341234123412341234123412341234123412341234123412341234";
+    const fetchMock = vi.fn(async (input: string, init?: RequestInit) => {
+      if (input.endsWith(`/apps/${APP_ID}/admin/schemas`)) {
+        return new Response(
+          JSON.stringify({ objectId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", hash: schemaHash }),
+          { status: 201 },
+        );
+      }
+      if (input.endsWith(`/apps/${APP_ID}/schemas`)) {
+        return new Response(JSON.stringify({ hashes: [] }), { status: 200 });
+      }
+      if (input.endsWith(`/apps/${APP_ID}/admin/permissions/head`)) {
+        return new Response(JSON.stringify({ head: null }), { status: 200 });
+      }
+      if (input.endsWith(`/apps/${APP_ID}/admin/permissions`)) {
+        return new Response(
+          JSON.stringify({
+            head: {
+              schemaHash,
+              version: 1,
+              parentBundleObjectId: null,
+              bundleObjectId: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            },
+          }),
+          { status: 201 },
+        );
+      }
+      throw new Error(`Unexpected fetch: ${input}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { logs } = await captureConsoleLogs(() =>
+      deploy({
+        appId: APP_ID,
+        serverUrl: "http://localhost:1625",
+        adminSecret: "admin-secret",
+        schemaDir: root,
+        migrationsDir: join(root, "migrations"),
+      }),
+    );
+
+    const warnings = logs.filter((line) => line.includes("has no explicit"));
+    expect(warnings.length).toBeGreaterThan(0);
+  });
 });
 
 function runBin(

--- a/packages/jazz-tools/src/cli.ts
+++ b/packages/jazz-tools/src/cli.ts
@@ -1719,6 +1719,13 @@ export async function deploy(options: DeployOptions): Promise<void> {
   console.log(`Loaded current schema from ${compiled.schemaFile}.`);
   console.log(`Loaded current permissions from ${compiled.permissionsFile}.`);
 
+  for (const diagnostic of collectMissingExplicitPolicyDiagnostics(
+    compiled.schema.tables.map((table) => table.name),
+    compiled.permissions,
+  )) {
+    console.warn(`\x1b[33m${diagnostic.message}\x1b[0m`);
+  }
+
   let localSchemaHash = await resolveStoredStructuralSchemaHash(
     options.appId,
     options.serverUrl,


### PR DESCRIPTION
## Summary

- `jazz-tools deploy` now calls `collectMissingExplicitPolicyDiagnostics` after loading the schema, emitting the same yellow warnings as `jazz-tools validate` for tables with no explicit permission policy
- `deploy` does not block on these warnings — they are informational only
- Previously the only way to surface these warnings was to run `validate` separately before deploying

## Test plan

- [ ] Red test added first, confirmed failing before implementation
- [ ] Green implementation added, test confirmed passing
- [ ] Changeset included (`patch` on `jazz-tools`)