### PR TITLE
Skip missing permissions in deploy

### DIFF
--- a/.changeset/fix-deploy-missing-permissions.md
+++ b/.changeset/fix-deploy-missing-permissions.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix `jazz-tools deploy` so apps without a `permissions.ts` file still publish their structural schema. The CLI now skips the permissions publish step instead of failing when no current permissions are defined.

--- a/packages/jazz-tools/src/cli.test.ts
+++ b/packages/jazz-tools/src/cli.test.ts
@@ -1948,11 +1948,38 @@ describe("cli permissions", () => {
 });
 
 describe("cli deploy", () => {
-  it("fails when there's no permissions.ts file", async () => {
+  it("publishes only the structural schema when there's no permissions.ts file", async () => {
     const { root } = await createWorkspace();
     await writeFile(join(root, "schema.ts"), rootSchemaWithoutInlinePermissions());
 
-    await expect(
+    const schemaHash = "1234123412341234123412341234123412341234123412341234123412341234";
+    let schemaPublishBody: any;
+
+    const fetchMock = vi.fn(async (input: string, init?: RequestInit) => {
+      if (input.endsWith(`/apps/${APP_ID}/schemas`)) {
+        return new Response(JSON.stringify({ hashes: [] }), { status: 200 });
+      }
+
+      if (input.endsWith(`/apps/${APP_ID}/admin/schemas`)) {
+        schemaPublishBody = JSON.parse(String(init?.body));
+        return new Response(
+          JSON.stringify({
+            objectId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            hash: schemaHash,
+          }),
+          { status: 201 },
+        );
+      }
+
+      if (input.includes(`/admin/permissions`)) {
+        throw new Error("deploy() should skip permissions when no permissions.ts is present.");
+      }
+
+      throw new Error(`Unexpected fetch: ${input}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { logs } = await captureConsoleLogs(() =>
       deploy({
         appId: APP_ID,
         serverUrl: "http://localhost:1625",
@@ -1960,7 +1987,12 @@ describe("cli deploy", () => {
         schemaDir: root,
         migrationsDir: join(root, "migrations"),
       }),
-    ).rejects.toThrow(/no permissions found for this app/i);
+    );
+
+    expect(schemaPublishBody.schema.projects.columns[0].name).toBe("name");
+    expect(logs).toContain(`Loaded current schema from ${join(root, "schema.ts")}.`);
+    expect(logs).toContain(`Published the current schema as ${schemaHash.slice(0, 12)}.`);
+    expect(logs).toContain("No permissions.ts found; skipping permissions publish.");
   });
 
   it("publishes the structural schema and permissions when the server has neither", async () => {

--- a/packages/jazz-tools/src/cli.ts
+++ b/packages/jazz-tools/src/cli.ts
@@ -1715,9 +1715,8 @@ export async function permissionsStatus(options: PermissionsCommandOptions): Pro
 }
 
 export async function deploy(options: DeployOptions): Promise<void> {
-  const compiled = ensurePermissionsProject(await loadCompiledSchema(options.schemaDir));
+  const compiled = await loadCompiledSchema(options.schemaDir);
   console.log(`Loaded current schema from ${compiled.schemaFile}.`);
-  console.log(`Loaded current permissions from ${compiled.permissionsFile}.`);
 
   let localSchemaHash = await resolveStoredStructuralSchemaHash(
     options.appId,
@@ -1739,6 +1738,13 @@ export async function deploy(options: DeployOptions): Promise<void> {
       `The current schema is already stored in the server as ${shortSchemaHash(localSchemaHash)}; skipping publish.`,
     );
   }
+
+  if (!compiled.permissions || !compiled.permissionsFile) {
+    console.log("No permissions.ts found; skipping permissions publish.");
+    return;
+  }
+
+  console.log(`Loaded current permissions from ${compiled.permissionsFile}.`);
 
   const { head: currentHead } = await fetchPermissionsHead(options.serverUrl, {
     appId: options.appId,


### PR DESCRIPTION
## Summary
- Make `jazz-tools deploy` publish the structural schema even when `permissions.ts` is absent
- Skip the permissions publish path with a clear log message instead of failing early
- Update the deploy test to cover schema-only deploys

## Testing
- Added/updated `cli.test.ts` coverage for deploy without `permissions.ts`
- Ran the `jazz-tools` Vitest suite successfully