### PR TITLE
feat(worker): fall back to ephemeral storage when OPFS is blocked (Firefox private browsing)

### DIFF
--- a/.changeset/fix-opfs-firefox-private-browsing-fallback.md
+++ b/.changeset/fix-opfs-firefox-private-browsing-fallback.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fall back to ephemeral in-memory storage when OPFS is blocked by a SecurityError (Firefox private browsing, Safari private mode). Jazz now initialises successfully without persistence instead of failing to load entirely.

--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,7 @@
 ### High
 
 - [**change-user-id-on-live-client**](todo/issues/change-user-id-on-live-client.md) — Changing auth principal on a live Jazz client is currently unsupported. We need a focused follow-up
+- [**firefox-private-browsing-opfs-unavailable**](todo/issues/firefox-private-browsing-opfs-unavailable.md) — Firefox's private browsing mode blocks `navigator.storage.getDirectory()`, so Jazz 2 fails to initialise entirely — there is no fallback to ephemeral/in-memory storage.
 - [**forward-inherits-select-bug**](todo/issues/forward-inherits-select-bug.md) — Forward `INHERITS VIA <fk>` select policies fail to expose child rows to sessions that should inherit access from the parent row.
 - [**stale-client-cache-after-scope-removal**](todo/issues/stale-client-cache-after-scope-removal.md) — When a row is deleted (or otherwise exits a query's result set) while a client has no active server-side subscription for that query, the client's local object manager retains stale data indefinitely. Subsequent one-shot `query()` calls with `tier: "edge"` return the stale row because the server never sends the deletion to the client — it considers the object "out of scope" and skips it.
 - [**test_multi-server-sync**](todo/issues/test_multi-server-sync.md) — Missing integration tests simulating client -> edge -> server communication topology.

--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -16,7 +16,6 @@ export declare class NapiRuntime {
   constructor(schemaJson: string, appId: string, jazzEnv: string, userBranch: string, dataPath: string, tier?: string | undefined | null)
   /** Create a new NapiRuntime with in-memory storage (no local persistence). */
   static inMemory(schemaJson: string, appId: string, jazzEnv: string, userBranch: string, tier?: string | undefined | null): NapiRuntime
-  readonly returnsDeclaredSchemaRows: true
   insert(table: string, values: Record<string, unknown>, objectId?: string | undefined | null): any
   insertWithSession(table: string, values: Record<string, unknown>, writeContextJson?: string | undefined | null, objectId?: string | undefined | null): any
   update(objectId: string, values: any): any

--- a/crates/jazz-napi/index.js
+++ b/crates/jazz-napi/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@garden-co/jazz-napi-android-arm64')
         const bindingPackageVersion = require('@garden-co/jazz-napi-android-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.0-alpha.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@garden-co/jazz-napi-android-arm-eabi')
         const bindingPackageVersion = require('@garden-co/jazz-napi-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.0-alpha.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@garden-co/jazz-napi-win32-x64-gnu')
         const bindingPackageVersion = require('@garden-co/jazz-napi-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.0-alpha.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@garden-co/jazz-napi-win32-x64-msvc')
         const bindingPackageVersion = require('@garden-co/jazz-napi-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.0-alpha.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@garden-co/jazz-napi-win32-ia32-msvc')
         const bindingPackageVersion = require('@garden-co/jazz-napi-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.0-alpha.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@garden-co/jazz-napi-win32-arm64-msvc')
         const bindingPackageVersion = require('@garden-co/jazz-napi-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.0-alpha.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@garden-co/jazz-napi-darwin-universal')
       const bindingPackageVersion = require('@garden-co/jazz-napi-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '2.0.0-alpha.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@garden-co/jazz-napi-darwin-x64')
         const bindingPackageVersion = require('@garden-co/jazz-napi-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.0-alpha.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@garden-co/jazz-napi-darwin-arm64')
         const bindingPackageVersion = require('@garden-co/jazz-napi-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.0-alpha.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@garden-co/jazz-napi-freebsd-x64')
         const bindingPackageVersion = require('@garden-co/jazz-napi-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.0-alpha.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@garden-co/jazz-napi-freebsd-arm64')
         const bindingPackageVersion = require('@garden-co/jazz-napi-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.0-alpha.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@garden-co/jazz-napi-linux-x64-musl')
           const bindingPackageVersion = require('@garden-co/jazz-napi-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.0-alpha.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@garden-co/jazz-napi-linux-x64-gnu')
           const bindingPackageVersion = require('@garden-co/jazz-napi-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.0-alpha.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@garden-co/jazz-napi-linux-arm64-musl')
           const bindingPackageVersion = require('@garden-co/jazz-napi-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.0-alpha.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@garden-co/jazz-napi-linux-arm64-gnu')
           const bindingPackageVersion = require('@garden-co/jazz-napi-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.0-alpha.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@garden-co/jazz-napi-linux-arm-musleabihf')
           const bindingPackageVersion = require('@garden-co/jazz-napi-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.0-alpha.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@garden-co/jazz-napi-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@garden-co/jazz-napi-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.0-alpha.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@garden-co/jazz-napi-linux-loong64-musl')
           const bindingPackageVersion = require('@garden-co/jazz-napi-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.0-alpha.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@garden-co/jazz-napi-linux-loong64-gnu')
           const bindingPackageVersion = require('@garden-co/jazz-napi-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.0-alpha.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@garden-co/jazz-napi-linux-riscv64-musl')
           const bindingPackageVersion = require('@garden-co/jazz-napi-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.0-alpha.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@garden-co/jazz-napi-linux-riscv64-gnu')
           const bindingPackageVersion = require('@garden-co/jazz-napi-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.0-alpha.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@garden-co/jazz-napi-linux-ppc64-gnu')
         const bindingPackageVersion = require('@garden-co/jazz-napi-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.0-alpha.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@garden-co/jazz-napi-linux-s390x-gnu')
         const bindingPackageVersion = require('@garden-co/jazz-napi-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.0-alpha.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@garden-co/jazz-napi-openharmony-arm64')
         const bindingPackageVersion = require('@garden-co/jazz-napi-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.0-alpha.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@garden-co/jazz-napi-openharmony-x64')
         const bindingPackageVersion = require('@garden-co/jazz-napi-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.0-alpha.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@garden-co/jazz-napi-openharmony-arm')
         const bindingPackageVersion = require('@garden-co/jazz-napi-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '2.0.0-alpha.34' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.34 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.0-alpha.36' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.36 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -578,13 +578,6 @@ if (!nativeBinding) {
 module.exports = nativeBinding
 module.exports.DevServer = nativeBinding.DevServer
 module.exports.NapiRuntime = nativeBinding.NapiRuntime
-if (module.exports.NapiRuntime?.prototype) {
-  Object.defineProperty(module.exports.NapiRuntime.prototype, 'returnsDeclaredSchemaRows', {
-    value: true,
-    enumerable: false,
-    configurable: true,
-  })
-}
 module.exports.TestingServer = nativeBinding.TestingServer
 module.exports.currentTimestamp = nativeBinding.currentTimestamp
 module.exports.deriveUserId = nativeBinding.deriveUserId

--- a/crates/jazz-tools/src/storage/mod.rs
+++ b/crates/jazz-tools/src/storage/mod.rs
@@ -70,6 +70,7 @@ pub enum StorageError {
         key_bytes: usize,
         max_key_bytes: usize,
     },
+    SecurityError(String),
 }
 
 impl std::fmt::Display for StorageError {
@@ -87,6 +88,7 @@ impl std::fmt::Display for StorageError {
                 f,
                 "indexed value too large for {table}.{column} on branch {branch}: index key would be {key_bytes} bytes (max {max_key_bytes})"
             ),
+            StorageError::SecurityError(message) => write!(f, "security error: {message}"),
         }
     }
 }

--- a/crates/jazz-tools/src/storage/opfs_btree.rs
+++ b/crates/jazz-tools/src/storage/opfs_btree.rs
@@ -463,7 +463,10 @@ impl Storage for OpfsBTreeStorage {
 }
 
 fn map_storage_err(error: BTreeError) -> StorageError {
-    StorageError::IoError(format!("opfs-btree: {}", error))
+    match error {
+        BTreeError::SecurityError(msg) => StorageError::SecurityError(msg),
+        other => StorageError::IoError(format!("opfs-btree: {}", other)),
+    }
 }
 
 #[cfg(test)]

--- a/crates/jazz-wasm/Cargo.toml
+++ b/crates/jazz-wasm/Cargo.toml
@@ -35,9 +35,7 @@ base64 = "0.22"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.3", features = ["wasm_js"] }
-web-sys = { version = "0.3", features = [
-  "DomException",
-] }
+
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/crates/jazz-wasm/Cargo.toml
+++ b/crates/jazz-wasm/Cargo.toml
@@ -35,6 +35,9 @@ base64 = "0.22"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.3", features = ["wasm_js"] }
+web-sys = { version = "0.3", features = [
+  "DomException",
+] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/crates/jazz-wasm/src/runtime.rs
+++ b/crates/jazz-wasm/src/runtime.rs
@@ -1766,7 +1766,7 @@ impl WasmRuntime {
         db_name: &str,
         tier: Option<String>,
         use_binary_encoding: bool,
-    ) -> Result<WasmRuntime, JsError> {
+    ) -> Result<WasmRuntime, JsValue> {
         #[cfg(feature = "console_error_panic_hook")]
         console_error_panic_hook::set_once();
         init_tracing();
@@ -1784,11 +1784,12 @@ impl WasmRuntime {
         info!("opening persistent OPFS runtime");
 
         // Parse schema
-        let runtime_schema = jazz_tools::binding_support::parse_runtime_schema_input(schema_json)
-            .map_err(|e| JsError::new(&format!("Invalid schema JSON: {}", e)))?;
+        let runtime_schema =
+            jazz_tools::binding_support::parse_runtime_schema_input(schema_json)
+                .map_err(|e| JsValue::from(JsError::new(&format!("Invalid schema JSON: {}", e))))?;
         let schema = runtime_schema.schema;
         // Parse optional node durability tiers
-        let node_tiers = parse_node_durability_tiers(tier.as_deref())?;
+        let node_tiers = parse_node_durability_tiers(tier.as_deref()).map_err(JsValue::from)?;
 
         // Create sync manager
         let mut sync_manager = SyncManager::new();
@@ -1811,13 +1812,28 @@ impl WasmRuntime {
                 jazz_tools::query_manager::types::RowPolicyMode::PermissiveLocal
             },
         )
-        .map_err(|e| JsError::new(&format!("Failed to create SchemaManager: {:?}", e)))?;
+        .map_err(|e| {
+            JsValue::from(JsError::new(&format!(
+                "Failed to create SchemaManager: {:?}",
+                e
+            )))
+        })?;
 
         const DEFAULT_CACHE_SIZE: usize = 32 * 1024 * 1024;
         let storage: Box<dyn Storage> = Box::new(
             OpfsBTreeStorage::open_opfs(db_name, DEFAULT_CACHE_SIZE)
                 .await
-                .map_err(|e| JsError::new(&format!("Storage: {:?}", e)))?,
+                .map_err(|e| {
+                    if let jazz_tools::storage::StorageError::SecurityError(ref msg) = e {
+                        web_sys::DomException::new_with_message_and_name(msg, "SecurityError")
+                            .map(JsValue::from)
+                            .unwrap_or_else(|_| {
+                                JsValue::from(JsError::new(&format!("Storage: {:?}", e)))
+                            })
+                    } else {
+                        JsValue::from(JsError::new(&format!("Storage: {:?}", e)))
+                    }
+                })?,
         );
         if let Err(error) =
             rehydrate_schema_manager_from_catalogue(&mut schema_manager, storage.as_ref(), app_id)

--- a/crates/jazz-wasm/src/runtime.rs
+++ b/crates/jazz-wasm/src/runtime.rs
@@ -1860,6 +1860,94 @@ impl WasmRuntime {
             tier_label,
         })
     }
+
+    /// Create an ephemeral WasmRuntime backed by in-memory storage.
+    ///
+    /// Data is not persisted across page loads. Used as a fallback when OPFS
+    /// is unavailable (e.g. Firefox private browsing mode).
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen(js_name = openEphemeral)]
+    pub fn open_ephemeral(
+        schema_json: &str,
+        app_id: &str,
+        env: &str,
+        user_branch: &str,
+        db_name: &str,
+        tier: Option<String>,
+        use_binary_encoding: bool,
+    ) -> Result<WasmRuntime, JsError> {
+        #[cfg(feature = "console_error_panic_hook")]
+        console_error_panic_hook::set_once();
+        init_tracing();
+
+        let tier_label = tier_label_for_node_tier(tier.as_deref());
+        let _span = info_span!(
+            "WasmRuntime::openEphemeral",
+            tier = tier_label,
+            app_id,
+            env,
+            user_branch,
+            db_name
+        )
+        .entered();
+        info!("opening ephemeral in-memory runtime (OPFS unavailable)");
+
+        let runtime_schema = jazz_tools::binding_support::parse_runtime_schema_input(schema_json)
+            .map_err(|e| JsError::new(&format!("Invalid schema JSON: {}", e)))?;
+        let schema = runtime_schema.schema;
+        let node_tiers = parse_node_durability_tiers(tier.as_deref())?;
+
+        let mut sync_manager = SyncManager::new();
+        if !node_tiers.is_empty() {
+            sync_manager = sync_manager.with_durability_tiers(node_tiers);
+        }
+
+        let app_id = AppId::from_string(app_id).unwrap_or_else(|_| AppId::from_name(app_id));
+
+        let schema_manager = SchemaManager::new_with_policy_mode(
+            sync_manager,
+            schema,
+            app_id,
+            env,
+            user_branch,
+            if runtime_schema.loaded_policy_bundle {
+                jazz_tools::query_manager::types::RowPolicyMode::Enforcing
+            } else {
+                jazz_tools::query_manager::types::RowPolicyMode::PermissiveLocal
+            },
+        )
+        .map_err(|e| JsError::new(&format!("Failed to create SchemaManager: {:?}", e)))?;
+
+        const DEFAULT_CACHE_SIZE: usize = 32 * 1024 * 1024;
+        let storage: Box<dyn Storage> = Box::new(
+            OpfsBTreeStorage::memory(DEFAULT_CACHE_SIZE)
+                .map_err(|e| JsError::new(&format!("Storage: {:?}", e)))?,
+        );
+
+        let scheduler = WasmScheduler::new();
+        let sync_sender = JsSyncSender::new(use_binary_encoding);
+
+        let mut core = RuntimeCore::new(schema_manager, storage, scheduler);
+        core.set_tier_label(tier_label);
+        core.set_sync_sender(Box::new(sync_sender.clone()));
+
+        let core_rc = Rc::new(RefCell::new(core));
+        {
+            let mut core_guard = core_rc.borrow_mut();
+            core_guard
+                .scheduler_mut()
+                .set_core_ref(Rc::downgrade(&core_rc));
+        }
+
+        core_rc.borrow_mut().persist_schema();
+
+        Ok(WasmRuntime {
+            core: core_rc,
+            sync_sender,
+            upstream_server_id: RefCell::new(None),
+            tier_label,
+        })
+    }
 }
 
 fn decode_seed(seed_b64: &str) -> Result<[u8; 32], JsError> {

--- a/crates/jazz-wasm/src/runtime.rs
+++ b/crates/jazz-wasm/src/runtime.rs
@@ -376,6 +376,71 @@ fn tier_label_for_node_tier(tier: Option<&str>) -> &'static str {
         _ => "client",
     }
 }
+
+#[cfg(target_arch = "wasm32")]
+const DEFAULT_OPFS_CACHE_SIZE: usize = 32 * 1024 * 1024;
+
+/// Build a `SchemaManager` from raw inputs. Shared by `open_persistent` and `open_ephemeral`.
+#[cfg(target_arch = "wasm32")]
+fn build_schema_manager(
+    schema_json: &str,
+    app_id: AppId,
+    env: &str,
+    user_branch: &str,
+    tier: Option<&str>,
+) -> Result<SchemaManager, JsError> {
+    let runtime_schema = jazz_tools::binding_support::parse_runtime_schema_input(schema_json)
+        .map_err(|e| JsError::new(&format!("Invalid schema JSON: {}", e)))?;
+    let node_tiers = parse_node_durability_tiers(tier)?;
+    let mut sync_manager = SyncManager::new();
+    if !node_tiers.is_empty() {
+        sync_manager = sync_manager.with_durability_tiers(node_tiers);
+    }
+    SchemaManager::new_with_policy_mode(
+        sync_manager,
+        runtime_schema.schema,
+        app_id,
+        env,
+        user_branch,
+        if runtime_schema.loaded_policy_bundle {
+            jazz_tools::query_manager::types::RowPolicyMode::Enforcing
+        } else {
+            jazz_tools::query_manager::types::RowPolicyMode::PermissiveLocal
+        },
+    )
+    .map_err(|e| JsError::new(&format!("Failed to create SchemaManager: {:?}", e)))
+}
+
+/// Wire up scheduler, sync sender, and `RuntimeCore` into a `WasmRuntime`.
+/// Shared by `open_persistent` and `open_ephemeral`.
+#[cfg(target_arch = "wasm32")]
+fn assemble_wasm_runtime(
+    schema_manager: SchemaManager,
+    storage: Box<dyn Storage>,
+    tier_label: &'static str,
+    use_binary_encoding: bool,
+) -> WasmRuntime {
+    let scheduler = WasmScheduler::new();
+    let sync_sender = JsSyncSender::new(use_binary_encoding);
+    let mut core = RuntimeCore::new(schema_manager, storage, scheduler);
+    core.set_tier_label(tier_label);
+    core.set_sync_sender(Box::new(sync_sender.clone()));
+    let core_rc = Rc::new(RefCell::new(core));
+    {
+        let mut core_guard = core_rc.borrow_mut();
+        core_guard
+            .scheduler_mut()
+            .set_core_ref(Rc::downgrade(&core_rc));
+    }
+    core_rc.borrow_mut().persist_schema();
+    WasmRuntime {
+        core: core_rc,
+        sync_sender,
+        upstream_server_id: RefCell::new(None),
+        tier_label,
+    }
+}
+
 // ============================================================================
 // Type alias
 // ============================================================================
@@ -1783,58 +1848,25 @@ impl WasmRuntime {
         .entered();
         info!("opening persistent OPFS runtime");
 
-        // Parse schema
-        let runtime_schema =
-            jazz_tools::binding_support::parse_runtime_schema_input(schema_json)
-                .map_err(|e| JsValue::from(JsError::new(&format!("Invalid schema JSON: {}", e))))?;
-        let schema = runtime_schema.schema;
-        // Parse optional node durability tiers
-        let node_tiers = parse_node_durability_tiers(tier.as_deref()).map_err(JsValue::from)?;
-
-        // Create sync manager
-        let mut sync_manager = SyncManager::new();
-        if !node_tiers.is_empty() {
-            sync_manager = sync_manager.with_durability_tiers(node_tiers);
-        }
-
         let app_id = AppId::from_string(app_id).unwrap_or_else(|_| AppId::from_name(app_id));
+        let mut schema_manager =
+            build_schema_manager(schema_json, app_id, env, user_branch, tier.as_deref())
+                .map_err(JsValue::from)?;
 
-        // Create schema manager
-        let mut schema_manager = SchemaManager::new_with_policy_mode(
-            sync_manager,
-            schema,
-            app_id,
-            env,
-            user_branch,
-            if runtime_schema.loaded_policy_bundle {
-                jazz_tools::query_manager::types::RowPolicyMode::Enforcing
-            } else {
-                jazz_tools::query_manager::types::RowPolicyMode::PermissiveLocal
-            },
-        )
-        .map_err(|e| {
-            JsValue::from(JsError::new(&format!(
-                "Failed to create SchemaManager: {:?}",
-                e
-            )))
-        })?;
-
-        const DEFAULT_CACHE_SIZE: usize = 32 * 1024 * 1024;
         let storage: Box<dyn Storage> = Box::new(
-            OpfsBTreeStorage::open_opfs(db_name, DEFAULT_CACHE_SIZE)
+            OpfsBTreeStorage::open_opfs(db_name, DEFAULT_OPFS_CACHE_SIZE)
                 .await
                 .map_err(|e| {
                     if let jazz_tools::storage::StorageError::SecurityError(ref msg) = e {
-                        web_sys::DomException::new_with_message_and_name(msg, "SecurityError")
-                            .map(JsValue::from)
-                            .unwrap_or_else(|_| {
-                                JsValue::from(JsError::new(&format!("Storage: {:?}", e)))
-                            })
+                        let err = js_sys::Error::new(msg);
+                        err.set_name("SecurityError");
+                        JsValue::from(err)
                     } else {
                         JsValue::from(JsError::new(&format!("Storage: {:?}", e)))
                     }
                 })?,
         );
+
         if let Err(error) =
             rehydrate_schema_manager_from_catalogue(&mut schema_manager, storage.as_ref(), app_id)
         {
@@ -1845,36 +1877,12 @@ impl WasmRuntime {
             );
         }
 
-        let scheduler = WasmScheduler::new();
-        let sync_sender = JsSyncSender::new(use_binary_encoding);
-
-        // Create RuntimeCore
-        let mut core = RuntimeCore::new(schema_manager, storage, scheduler);
-        core.set_tier_label(tier_label);
-        // Install the JS-callback sender so `batched_tick` drains outbox
-        // entries to the worker bridge (no transport handle here).
-        core.set_sync_sender(Box::new(sync_sender.clone()));
-
-        // Wrap in Rc<RefCell>
-        let core_rc = Rc::new(RefCell::new(core));
-
-        // Set the core_ref on the Scheduler
-        {
-            let mut core_guard = core_rc.borrow_mut();
-            core_guard
-                .scheduler_mut()
-                .set_core_ref(Rc::downgrade(&core_rc));
-        }
-
-        // Persist schema to catalogue for server sync
-        core_rc.borrow_mut().persist_schema();
-
-        Ok(WasmRuntime {
-            core: core_rc,
-            sync_sender,
-            upstream_server_id: RefCell::new(None),
+        Ok(assemble_wasm_runtime(
+            schema_manager,
+            storage,
             tier_label,
-        })
+            use_binary_encoding,
+        ))
     }
 
     /// Create an ephemeral WasmRuntime backed by in-memory storage.
@@ -1908,61 +1916,21 @@ impl WasmRuntime {
         .entered();
         info!("opening ephemeral in-memory runtime (OPFS unavailable)");
 
-        let runtime_schema = jazz_tools::binding_support::parse_runtime_schema_input(schema_json)
-            .map_err(|e| JsError::new(&format!("Invalid schema JSON: {}", e)))?;
-        let schema = runtime_schema.schema;
-        let node_tiers = parse_node_durability_tiers(tier.as_deref())?;
-
-        let mut sync_manager = SyncManager::new();
-        if !node_tiers.is_empty() {
-            sync_manager = sync_manager.with_durability_tiers(node_tiers);
-        }
-
         let app_id = AppId::from_string(app_id).unwrap_or_else(|_| AppId::from_name(app_id));
+        let schema_manager =
+            build_schema_manager(schema_json, app_id, env, user_branch, tier.as_deref())?;
 
-        let schema_manager = SchemaManager::new_with_policy_mode(
-            sync_manager,
-            schema,
-            app_id,
-            env,
-            user_branch,
-            if runtime_schema.loaded_policy_bundle {
-                jazz_tools::query_manager::types::RowPolicyMode::Enforcing
-            } else {
-                jazz_tools::query_manager::types::RowPolicyMode::PermissiveLocal
-            },
-        )
-        .map_err(|e| JsError::new(&format!("Failed to create SchemaManager: {:?}", e)))?;
-
-        const DEFAULT_CACHE_SIZE: usize = 32 * 1024 * 1024;
         let storage: Box<dyn Storage> = Box::new(
-            OpfsBTreeStorage::memory(DEFAULT_CACHE_SIZE)
+            OpfsBTreeStorage::memory(DEFAULT_OPFS_CACHE_SIZE)
                 .map_err(|e| JsError::new(&format!("Storage: {:?}", e)))?,
         );
 
-        let scheduler = WasmScheduler::new();
-        let sync_sender = JsSyncSender::new(use_binary_encoding);
-
-        let mut core = RuntimeCore::new(schema_manager, storage, scheduler);
-        core.set_tier_label(tier_label);
-        core.set_sync_sender(Box::new(sync_sender.clone()));
-
-        let core_rc = Rc::new(RefCell::new(core));
-        {
-            let mut core_guard = core_rc.borrow_mut();
-            core_guard
-                .scheduler_mut()
-                .set_core_ref(Rc::downgrade(&core_rc));
-        }
-
-        core_rc.borrow_mut().persist_schema();
-
-        Ok(WasmRuntime {
-            core: core_rc,
-            sync_sender,
-            upstream_server_id: RefCell::new(None),
+        Ok(assemble_wasm_runtime(
+            schema_manager,
+            storage,
             tier_label,
-        })
+            use_binary_encoding,
+        ))
     }
 }
 

--- a/crates/jazz-wasm/src/runtime.rs
+++ b/crates/jazz-wasm/src/runtime.rs
@@ -1920,10 +1920,7 @@ impl WasmRuntime {
         let schema_manager =
             build_schema_manager(schema_json, app_id, env, user_branch, tier.as_deref())?;
 
-        let storage: Box<dyn Storage> = Box::new(
-            OpfsBTreeStorage::memory(DEFAULT_OPFS_CACHE_SIZE)
-                .map_err(|e| JsError::new(&format!("Storage: {:?}", e)))?,
-        );
+        let storage: Box<dyn Storage> = Box::new(MemoryStorage::new());
 
         Ok(assemble_wasm_runtime(
             schema_manager,

--- a/crates/opfs-btree/src/error.rs
+++ b/crates/opfs-btree/src/error.rs
@@ -8,4 +8,6 @@ pub enum BTreeError {
     Corrupt(String),
     #[error("io error: {0}")]
     Io(String),
+    #[error("security error: {0}")]
+    SecurityError(String),
 }

--- a/crates/opfs-btree/src/file.rs
+++ b/crates/opfs-btree/src/file.rs
@@ -474,6 +474,13 @@ fn is_retryable_handle_conflict(value: &wasm_bindgen::JsValue) -> bool {
 
 #[cfg(target_arch = "wasm32")]
 fn map_js_error(value: wasm_bindgen::JsValue) -> BTreeError {
+    if value.is_instance_of::<web_sys::DomException>() {
+        let ex: web_sys::DomException = value.unchecked_into();
+        if ex.name() == "SecurityError" {
+            return BTreeError::SecurityError(ex.message().into());
+        }
+        return BTreeError::Io(format!("DOMException({}): {}", ex.name(), ex.message()));
+    }
     if let Some(s) = value.as_string() {
         BTreeError::Io(s)
     } else {

--- a/crates/opfs-btree/src/file.rs
+++ b/crates/opfs-btree/src/file.rs
@@ -465,11 +465,15 @@ async fn sleep_ms(ms: u32) {
     let _ = JsFuture::from(promise).await;
 }
 
-/// Returns true if the JS error is a `DOMException`, which indicates a
-/// retryable handle conflict. Plain `Error`/`TypeError`/etc. fail immediately.
+/// Returns true if the JS error is a retryable handle conflict DOMException.
+/// `SecurityError` is excluded — it signals a blocked API, not a transient conflict.
 #[cfg(target_arch = "wasm32")]
 fn is_retryable_handle_conflict(value: &wasm_bindgen::JsValue) -> bool {
-    value.is_instance_of::<web_sys::DomException>()
+    if value.is_instance_of::<web_sys::DomException>() {
+        let ex: &web_sys::DomException = value.unchecked_ref();
+        return ex.name() != "SecurityError";
+    }
+    false
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/examples/auth-betterauth-chat/.gitignore
+++ b/examples/auth-betterauth-chat/.gitignore
@@ -1,3 +1,4 @@
 .next
 node_modules
 dist
+next-env.d.ts

--- a/examples/auth-betterauth-chat/next-env.d.ts
+++ b/examples/auth-betterauth-chat/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/todo-client-localfirst-react/src/App.tsx
+++ b/examples/todo-client-localfirst-react/src/App.tsx
@@ -6,8 +6,8 @@ import { app } from "../schema.js";
 
 const devToolsAttachedClients = new WeakSet<object>();
 
-const appId = import.meta.env.JAZZ_APP_ID;
-const serverUrl = import.meta.env.JAZZ_SERVER_URL;
+const appId = import.meta.env.VITE_JAZZ_APP_ID;
+const serverUrl = import.meta.env.VITE_JAZZ_SERVER_URL;
 
 // #region context-setup-react
 function defaultConfig(secret: string, overrides: Partial<DbConfig> = {}): DbConfig {

--- a/packages/jazz-tools/src/worker/jazz-worker.test.ts
+++ b/packages/jazz-tools/src/worker/jazz-worker.test.ts
@@ -156,38 +156,67 @@ describe("handleInit — OPFS unavailable (Firefox private browsing)", () => {
     fakeSelf().postMessage.mockClear();
   });
 
-  it("falls back to openEphemeral and posts init-ok when openPersistent throws SecurityError", async () => {
-    openPersistentMock.mockRejectedValue(
-      new DOMException("The operation is insecure.", "SecurityError"),
-    );
-    openEphemeralMock.mockResolvedValue(fakeRuntime());
-
+  function sendInit(appId = "opfs-blocked-test") {
     fakeSelf().onmessage(
       new MessageEvent("message", {
         data: {
           type: "init",
           schemaJson: "{}",
-          appId: "opfs-blocked-test",
+          appId,
           env: "development",
           userBranch: "main",
-          dbName: "opfs-blocked-db",
+          dbName: "test-db",
           clientId: "",
         },
       }),
     );
+  }
 
+  async function waitForMessage(type: string) {
     await vi.waitUntil(
-      () =>
-        (fakeSelf().postMessage.mock.calls as [any][]).some(
-          ([msg]) => msg.type === "init-ok" || msg.type === "error",
-        ),
+      () => (fakeSelf().postMessage.mock.calls as [any][]).some(([msg]) => msg.type === type),
       { timeout: 2000 },
     );
-
-    const result: any = (fakeSelf().postMessage.mock.calls as [any][])
+    return (fakeSelf().postMessage.mock.calls as [any][])
       .map(([msg]) => msg)
-      .find((msg: any) => msg.type === "init-ok" || msg.type === "error");
+      .find((msg: any) => msg.type === type);
+  }
 
-    expect(result.type).toBe("init-ok");
+  it("falls back to openEphemeral and posts init-ok when openPersistent throws SecurityError", async () => {
+    openPersistentMock.mockRejectedValue(
+      new DOMException("The operation is insecure.", "SecurityError"),
+    );
+    openEphemeralMock.mockReturnValue(fakeRuntime());
+
+    sendInit();
+
+    const result = await waitForMessage("init-ok");
+    expect(result).toBeDefined();
+    expect(openEphemeralMock).toHaveBeenCalledOnce();
+  });
+
+  it("re-throws and posts error when openPersistent throws a non-SecurityError", async () => {
+    openPersistentMock.mockRejectedValue(new Error("disk full"));
+
+    sendInit("non-security-test");
+
+    const result = await waitForMessage("error");
+    expect(result).toBeDefined();
+    expect(openEphemeralMock).not.toHaveBeenCalled();
+  });
+
+  it("posts error when openEphemeral itself throws after SecurityError fallback", async () => {
+    openPersistentMock.mockRejectedValue(
+      new DOMException("The operation is insecure.", "SecurityError"),
+    );
+    openEphemeralMock.mockImplementation(() => {
+      throw new Error("out of memory");
+    });
+
+    sendInit("ephemeral-fail-test");
+
+    const result = await waitForMessage("error");
+    expect(result).toBeDefined();
+    expect(openEphemeralMock).toHaveBeenCalledOnce();
   });
 });

--- a/packages/jazz-tools/src/worker/jazz-worker.test.ts
+++ b/packages/jazz-tools/src/worker/jazz-worker.test.ts
@@ -1,18 +1,14 @@
 /**
- * Unit tests for jazz-worker URL normalization and auth-merge helpers.
+ * Unit tests for jazz-worker URL normalization, auth-merge helpers, and
+ * handleInit fallback behaviour.
  *
- * These tests target the exported pure helpers `composeConnectUrl` and
- * `mergeAuth`, which encapsulate the two behaviours that T22 validates:
- *
- *   1. serverUrl + appId → correct WebSocket URL via httpUrlToWs
- *   2. update-auth merges / clears jwt_token while preserving other fields
- *
- * The helpers are pure functions — no WASM, no worker globals needed.
- * We must still stub `self` and `jazz-wasm` because jazz-worker.ts installs
- * `self.onmessage` and calls `startup()` at module top level.
+ * Pure helper tests (composeConnectUrl, mergeAuth, etc.) need no WASM.
+ * The handleInit test drives the full init flow via self.onmessage and a
+ * mocked WasmRuntime so we can exercise the SecurityError fallback path
+ * without a real browser or OPFS.
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ── Stub the worker global `self` before the module is loaded ────────────────
 // jazz-worker.ts does `self.onmessage = ...` at module scope.
@@ -27,10 +23,25 @@ vi.hoisted(() => {
   (globalThis as Record<string, unknown>).self = fakeSelf;
 });
 
+// ── WasmRuntime mocks (hoisted so vi.mock factory can close over them) ────────
+const { openPersistentMock, openEphemeralMock } = vi.hoisted(() => ({
+  openPersistentMock: vi.fn(),
+  openEphemeralMock: vi.fn(),
+}));
+
 // ── Stub jazz-wasm so startup() doesn't reject ───────────────────────────────
 vi.mock("jazz-wasm", () => ({
   default: vi.fn().mockResolvedValue(undefined),
   initSync: vi.fn(),
+  WasmRuntime: {
+    openPersistent: openPersistentMock,
+    openEphemeral: openEphemeralMock,
+  },
+}));
+
+// ── Stub schema-wire so handleInit doesn't fail on schema validation ──────────
+vi.mock("../drivers/schema-wire.js", () => ({
+  normalizeRuntimeSchemaJson: vi.fn((s: string) => s),
 }));
 
 import {
@@ -115,5 +126,68 @@ describe("performUpstreamConnect", () => {
 
     expect(posted).toEqual([{ type: "upstream-disconnected" }]);
     errorSpy.mockRestore();
+  });
+});
+
+// ── Firefox private browsing: OPFS unavailable ────────────────────────────────
+//
+// navigator.storage.getDirectory() is blocked in Firefox private browsing,
+// causing WasmRuntime.openPersistent to throw a SecurityError. The worker
+// should detect this and fall back to WasmRuntime.openEphemeral so that Jazz
+// still initialises (with ephemeral, non-persisted storage) instead of failing.
+//
+// This test will fail until the fallback is implemented in handleInit.
+
+describe("handleInit — OPFS unavailable (Firefox private browsing)", () => {
+  const fakeSelf = () => (globalThis as any).self;
+
+  const fakeRuntime = () => ({
+    addClient: vi.fn().mockReturnValue("client-ephemeral"),
+    setClientRole: vi.fn(),
+    onAuthFailure: null,
+    onSyncMessageToSend: vi.fn(),
+    addServer: vi.fn(),
+    removeServer: vi.fn(),
+  });
+
+  beforeEach(() => {
+    openPersistentMock.mockReset();
+    openEphemeralMock.mockReset();
+    fakeSelf().postMessage.mockClear();
+  });
+
+  it("falls back to openEphemeral and posts init-ok when openPersistent throws SecurityError", async () => {
+    openPersistentMock.mockRejectedValue(
+      new DOMException("The operation is insecure.", "SecurityError"),
+    );
+    openEphemeralMock.mockResolvedValue(fakeRuntime());
+
+    fakeSelf().onmessage(
+      new MessageEvent("message", {
+        data: {
+          type: "init",
+          schemaJson: "{}",
+          appId: "opfs-blocked-test",
+          env: "development",
+          userBranch: "main",
+          dbName: "opfs-blocked-db",
+          clientId: "",
+        },
+      }),
+    );
+
+    await vi.waitUntil(
+      () =>
+        (fakeSelf().postMessage.mock.calls as [any][]).some(
+          ([msg]) => msg.type === "init-ok" || msg.type === "error",
+        ),
+      { timeout: 2000 },
+    );
+
+    const result: any = (fakeSelf().postMessage.mock.calls as [any][])
+      .map(([msg]) => msg)
+      .find((msg: any) => msg.type === "init-ok" || msg.type === "error");
+
+    expect(result.type).toBe("init-ok");
   });
 });

--- a/packages/jazz-tools/src/worker/jazz-worker.ts
+++ b/packages/jazz-tools/src/worker/jazz-worker.ts
@@ -306,7 +306,7 @@ async function handleInit(msg: InitMessage): Promise<void> {
         false,
       );
     } catch (e: any) {
-      if (e instanceof DOMException && e.name === "SecurityError") {
+      if (e?.name === "SecurityError") {
         console.warn("[jazz] OPFS unavailable (SecurityError) — falling back to ephemeral storage");
         runtime = await wasmModule.WasmRuntime.openEphemeral(
           schemaJson,

--- a/packages/jazz-tools/src/worker/jazz-worker.ts
+++ b/packages/jazz-tools/src/worker/jazz-worker.ts
@@ -307,6 +307,7 @@ async function handleInit(msg: InitMessage): Promise<void> {
       );
     } catch (e: any) {
       if (e instanceof DOMException && e.name === "SecurityError") {
+        console.warn("[jazz] OPFS unavailable (SecurityError) — falling back to ephemeral storage");
         runtime = await wasmModule.WasmRuntime.openEphemeral(
           schemaJson,
           msg.appId,

--- a/packages/jazz-tools/src/worker/jazz-worker.ts
+++ b/packages/jazz-tools/src/worker/jazz-worker.ts
@@ -293,16 +293,33 @@ async function handleInit(msg: InitMessage): Promise<void> {
     peerIdByRuntimeClient.clear();
     peerTermByPeerId.clear();
 
-    // Open persistent OPFS-backed runtime with local durability tier
-    runtime = await wasmModule.WasmRuntime.openPersistent(
-      schemaJson,
-      msg.appId,
-      msg.env,
-      msg.userBranch,
-      msg.dbName,
-      "local",
-      false,
-    );
+    // Open persistent OPFS-backed runtime, falling back to ephemeral in-memory
+    // storage if OPFS is blocked (e.g. Firefox private browsing raises SecurityError).
+    try {
+      runtime = await wasmModule.WasmRuntime.openPersistent(
+        schemaJson,
+        msg.appId,
+        msg.env,
+        msg.userBranch,
+        msg.dbName,
+        "local",
+        false,
+      );
+    } catch (e: any) {
+      if (e instanceof DOMException && e.name === "SecurityError") {
+        runtime = await wasmModule.WasmRuntime.openEphemeral(
+          schemaJson,
+          msg.appId,
+          msg.env,
+          msg.userBranch,
+          msg.dbName,
+          "local",
+          false,
+        );
+      } else {
+        throw e;
+      }
+    }
 
     // Register main thread as a Peer client
     mainClientId = runtime.addClient();

--- a/starters/next-betterauth/package.json
+++ b/starters/next-betterauth/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
+    "prebuild": "node scripts/ensure-env.js",
     "build": "next build",
     "start": "next start",
     "test:e2e": "playwright test"

--- a/starters/next-betterauth/scripts/ensure-env.js
+++ b/starters/next-betterauth/scripts/ensure-env.js
@@ -1,0 +1,13 @@
+import { existsSync, writeFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const envPath = join(__dirname, "..", ".env");
+
+if (!existsSync(envPath)) {
+  const secret = randomBytes(32).toString("hex");
+  writeFileSync(envPath, `BETTER_AUTH_SECRET=${secret}\nAPP_ORIGIN=http://localhost:3000\n`);
+  console.log("No .env detected. Generated .env with a random BETTER_AUTH_SECRET");
+}

--- a/starters/next-hybrid/package.json
+++ b/starters/next-hybrid/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
+    "prebuild": "node scripts/ensure-env.js",
     "build": "next build",
     "start": "next start",
     "test:e2e": "playwright test"

--- a/starters/next-hybrid/scripts/ensure-env.js
+++ b/starters/next-hybrid/scripts/ensure-env.js
@@ -1,0 +1,13 @@
+import { existsSync, writeFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const envPath = join(__dirname, "..", ".env");
+
+if (!existsSync(envPath)) {
+  const secret = randomBytes(32).toString("hex");
+  writeFileSync(envPath, `BETTER_AUTH_SECRET=${secret}\nAPP_ORIGIN=http://localhost:3000\n`);
+  console.log("No .env detected. Generated .env with a random BETTER_AUTH_SECRET");
+}

--- a/starters/react-betterauth/package.json
+++ b/starters/react-betterauth/package.json
@@ -7,6 +7,7 @@
     "dev": "concurrently --kill-others-on-fail --names server,vite \"pnpm dev:server\" \"pnpm dev:vite\"",
     "dev:vite": "wait-on --timeout 20000 http-get://127.0.0.1:3001/health && vite",
     "dev:server": "tsx watch --env-file=.env server/index.ts",
+    "prebuild": "node scripts/ensure-env.js",
     "build": "vite build && tsc -p tsconfig.server.json",
     "start": "node server-dist/index.js",
     "test:e2e": "playwright test"

--- a/starters/react-betterauth/scripts/ensure-env.js
+++ b/starters/react-betterauth/scripts/ensure-env.js
@@ -1,0 +1,13 @@
+import { existsSync, writeFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const envPath = join(__dirname, "..", ".env");
+
+if (!existsSync(envPath)) {
+  const secret = randomBytes(32).toString("hex");
+  writeFileSync(envPath, `BETTER_AUTH_SECRET=${secret}\nAPP_ORIGIN=http://localhost:3001\n`);
+  console.log("No .env detected. Generated .env with a random BETTER_AUTH_SECRET");
+}

--- a/starters/react-hybrid/package.json
+++ b/starters/react-hybrid/package.json
@@ -7,6 +7,7 @@
     "dev": "concurrently --kill-others-on-fail --names server,vite \"pnpm dev:server\" \"pnpm dev:vite\"",
     "dev:vite": "wait-on --timeout 20000 http-get://127.0.0.1:3001/health && vite",
     "dev:server": "tsx watch --env-file=.env server/index.ts",
+    "prebuild": "node scripts/ensure-env.js",
     "build": "vite build && tsc -p tsconfig.server.json",
     "start": "node server-dist/index.js",
     "test:e2e": "playwright test"

--- a/starters/react-hybrid/scripts/ensure-env.js
+++ b/starters/react-hybrid/scripts/ensure-env.js
@@ -1,0 +1,13 @@
+import { existsSync, writeFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const envPath = join(__dirname, "..", ".env");
+
+if (!existsSync(envPath)) {
+  const secret = randomBytes(32).toString("hex");
+  writeFileSync(envPath, `BETTER_AUTH_SECRET=${secret}\nAPP_ORIGIN=http://localhost:3001\n`);
+  console.log("No .env detected. Generated .env with a random BETTER_AUTH_SECRET");
+}

--- a/starters/sveltekit-betterauth/package.json
+++ b/starters/sveltekit-betterauth/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
+    "prebuild": "node scripts/ensure-env.js",
     "build": "vite build",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",

--- a/starters/sveltekit-betterauth/scripts/ensure-env.js
+++ b/starters/sveltekit-betterauth/scripts/ensure-env.js
@@ -1,0 +1,13 @@
+import { existsSync, writeFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const envPath = join(__dirname, "..", ".env");
+
+if (!existsSync(envPath)) {
+  const secret = randomBytes(32).toString("hex");
+  writeFileSync(envPath, `BETTER_AUTH_SECRET=${secret}\nAPP_ORIGIN=http://localhost:5173\n`);
+  console.log("No .env detected. Generated .env with a random BETTER_AUTH_SECRET");
+}

--- a/starters/sveltekit-hybrid/package.json
+++ b/starters/sveltekit-hybrid/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
+    "prebuild": "node scripts/ensure-env.js",
     "build": "vite build",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",

--- a/starters/sveltekit-hybrid/scripts/ensure-env.js
+++ b/starters/sveltekit-hybrid/scripts/ensure-env.js
@@ -1,0 +1,13 @@
+import { existsSync, writeFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const envPath = join(__dirname, "..", ".env");
+
+if (!existsSync(envPath)) {
+  const secret = randomBytes(32).toString("hex");
+  writeFileSync(envPath, `BETTER_AUTH_SECRET=${secret}\nAPP_ORIGIN=http://localhost:5173\n`);
+  console.log("No .env detected. Generated .env with a random BETTER_AUTH_SECRET");
+}

--- a/todo/issues/firefox-private-browsing-opfs-unavailable.md
+++ b/todo/issues/firefox-private-browsing-opfs-unavailable.md
@@ -1,0 +1,24 @@
+# Firefox Private Browsing: OPFS Unavailable
+
+## What
+
+Firefox's private browsing mode blocks `navigator.storage.getDirectory()`, so Jazz 2 fails to initialise entirely — there is no fallback to ephemeral/in-memory storage.
+
+Error chain:
+
+1. `OpfsFile::open()` (`crates/opfs-btree/src/file.rs`) calls `storage.get_directory()` — throws in private mode
+2. Error bubbles through `WasmRuntime::openPersistent()` → `handleInit()` in the worker
+3. Worker posts `{ type: "error", message: "Init failed: ..." }` and the app never starts
+
+There is no feature-detection for OPFS availability, no `openEphemeral()` path, and no graceful degradation.
+
+## Priority
+
+high
+
+## Notes
+
+- `localStorage` (used by `BrowserAuthSecretStore`) does work in private mode, so auth secret storage is fine — the block is purely the OPFS-backed data persistence layer
+- An `openEphemeral()` / in-memory fallback already exists in Rust (`OpfsBTreeStorage::memory()`); it just isn't wired up on the browser path
+- Same issue will affect Chrome/Edge incognito if they ever restrict OPFS; Safari already blocks it in some private-mode configurations
+- Relevant files: `crates/opfs-btree/src/file.rs`, `crates/jazz-wasm/src/runtime.rs`, `packages/jazz-tools/src/worker/jazz-worker.ts`, `packages/jazz-tools/src/runtime/db.ts`


### PR DESCRIPTION
## Summary

- Firefox private browsing (and Safari in some private-mode configs) blocks `navigator.storage.getDirectory()` with a `SecurityError`, causing Jazz to fail to initialise entirely
- Adds a `SecurityError` detection path through the full Rust stack (`opfs-btree` → `jazz-tools` storage layer → `jazz-wasm` WASM boundary)
- Adds `WasmRuntime.openEphemeral` (in-memory storage, no persistence) as a fallback when `openPersistent` is blocked
- Worker catches the `SecurityError` and transparently falls back to ephemeral storage so the app still loads

## Changes

- **`crates/opfs-btree`** — new `BTreeError::SecurityError` variant; `map_js_error` detects `DOMException(SecurityError)`; `is_retryable_handle_conflict` excludes `SecurityError` from retries
- **`crates/jazz-tools/storage`** — new `StorageError::SecurityError` variant propagated from `BTreeError`
- **`crates/jazz-wasm`** — `open_persistent` maps `SecurityError` to a `js_sys::Error` with `name = "SecurityError"` at the WASM boundary; new `open_ephemeral` entry point using `OpfsBTreeStorage::memory`; shared `build_schema_manager` and `assemble_wasm_runtime` helpers eliminate duplication between both constructors
- **`packages/jazz-tools/worker`** — `handleInit` catches `e?.name === "SecurityError"` from `openPersistent` and falls back to `openEphemeral`
- **`crates/jazz-napi`** — regenerated bindings (alpha.36), removed `returnsDeclaredSchemaRows`
- **`starters/*`** — `prebuild` script auto-generates `.env` with a random `BETTER_AUTH_SECRET` when absent
- **`examples/todo-react`** — corrected env var prefix to `VITE_JAZZ_*`

## Test plan

- [ ] New worker unit tests cover: SecurityError fallback (happy path), non-SecurityError re-throw, `openEphemeral` itself failing
- [ ] Run `pnpm test` — all passing
- [ ] Manual test in Firefox private browsing: app should load with ephemeral storage rather than showing an error