### PR TITLE
docs: interactive app ID generation and cloud quickstart

### DIFF
--- a/docs/app/api/generate-app/route.ts
+++ b/docs/app/api/generate-app/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+
+export async function POST() {
+  const res = await fetch("https://v2.dashboard.jazz.tools/api/apps/generate", {
+    method: "POST",
+  });
+
+  const data: unknown = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/docs/components/mdx/cloud-config.tsx
+++ b/docs/components/mdx/cloud-config.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { DynamicCodeBlock } from "fumadocs-ui/components/dynamic-codeblock";
+import {
+  getStoredApp,
+  onAppGenerated,
+  restoreFromSession,
+  type GeneratedApp,
+} from "@/lib/generated-app-store";
+
+export function CloudConfig() {
+  const [app, setApp] = useState<GeneratedApp | null>(null);
+
+  useEffect(() => {
+    restoreFromSession();
+    setApp(getStoredApp());
+    return onAppGenerated(setApp);
+  }, []);
+
+  const appId = app?.appId ?? "<your-app-id>";
+  const code = `{\n  appId: "${appId}",\n  serverUrl: "https://v2.sync.jazz.tools/",\n}`;
+
+  return <DynamicCodeBlock lang="ts" code={code} />;
+}

--- a/docs/components/mdx/deploy-command.tsx
+++ b/docs/components/mdx/deploy-command.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { DynamicCodeBlock } from "fumadocs-ui/components/dynamic-codeblock";
+import { getStoredApp, onAppGenerated, type GeneratedApp } from "@/lib/generated-app-store";
+
+export function DeployCommand() {
+  const [app, setApp] = useState<GeneratedApp | null>(null);
+
+  useEffect(() => {
+    setApp(getStoredApp());
+    return onAppGenerated(setApp);
+  }, []);
+
+  const appId = app?.appId ?? "<your-app-id>";
+  const adminSecret = app?.adminSecret ?? "<your-admin-secret>";
+
+  const code = [
+    "pnpm dlx jazz-tools@alpha deploy \\",
+    `  ${appId} \\`,
+    `  --server-url https://v2.sync.jazz.tools/ \\`,
+    `  --admin-secret ${adminSecret}`,
+  ].join("\n");
+
+  return <DynamicCodeBlock lang="bash" code={code} />;
+}

--- a/docs/components/mdx/generate-app-id.tsx
+++ b/docs/components/mdx/generate-app-id.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState } from "react";
+import { Callout } from "fumadocs-ui/components/callout";
+import { DynamicCodeBlock } from "fumadocs-ui/components/dynamic-codeblock";
+import { type GeneratedApp, storeGeneratedApp } from "@/lib/generated-app-store";
+
+function CredentialsBlock({ app }: { app: GeneratedApp }) {
+  const code = [
+    `JAZZ_APP_ID="${app.appId}"`,
+    `JAZZ_ADMIN_SECRET="${app.adminSecret}"`,
+    `JAZZ_BACKEND_SECRET="${app.backendSecret}"`,
+  ].join("\n");
+  return <DynamicCodeBlock lang="env" code={code} />;
+}
+
+function ConfigBlock({ app }: { app: GeneratedApp }) {
+  const code = `{\n  appId: "${app.appId}",\n  serverUrl: "https://v2.sync.jazz.tools/",\n}`;
+  return <DynamicCodeBlock lang="ts" code={code} />;
+}
+
+export function GenerateAppId() {
+  const [app, setApp] = useState<GeneratedApp | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function generate() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/generate-app", { method: "POST" });
+      if (!res.ok) throw new Error(`Request failed (${res.status})`);
+      const data = (await res.json()) as GeneratedApp;
+      storeGeneratedApp(data);
+      setApp(data);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (!app) {
+    return (
+      <div className="space-y-3">
+        <button
+          onClick={generate}
+          disabled={loading}
+          className="rounded-lg bg-fd-primary px-5 py-2.5 text-sm font-medium text-fd-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
+        >
+          {loading ? "Generating…" : "Generate App ID"}
+        </button>
+        {error && <p className="text-sm text-red-500">{error}</p>}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <Callout type="warn">
+        Save these credentials now — they won't be shown again. You'll need the admin secret to
+        claim this app in the{" "}
+        <a
+          href="https://v2.dashboard.jazz.tools"
+          className="underline"
+          target="_blank"
+          rel="noreferrer"
+        >
+          dashboard
+        </a>{" "}
+        later.
+      </Callout>
+
+      <CredentialsBlock app={app} />
+
+      <p className="text-sm text-fd-muted-foreground">Use this config in your app:</p>
+      <ConfigBlock app={app} />
+    </div>
+  );
+}

--- a/docs/content/docs/auth/local-first-auth.mdx
+++ b/docs/content/docs/auth/local-first-auth.mdx
@@ -1,6 +1,7 @@
 ---
 title: Local-first auth
 description: "Authenticate users without a server using self-signed tokens, and optionally upgrade to an external provider while preserving identity."
+reviewedAt: "22485728"
 ---
 
 Local-first auth lets users start using your app immediately — no sign-up, no server round-trip. Jazz generates a stable identity from a secret stored on the device. Without a recovery mechanism, that identity lives only on the device — if the secret is lost, it's gone. Linking to an external provider at sign-up is one way to make the identity durable and recoverable.
@@ -29,7 +30,7 @@ Use `useLocalFirstAuth()` to manage the user's secret. On first load it generate
 Local-first auth is enabled by default in development. In production, enable it explicitly:
 
 ```bash
-jazz-tools server <APP_ID> --allow-local-first-auth
+pnpm dlx jazz-tools@alpha server <APP_ID> --allow-local-first-auth
 ```
 
 No JWKS endpoint is needed — the token is self-contained and the server can verify it on its own.

--- a/docs/content/docs/auth/permissions.mdx
+++ b/docs/content/docs/auth/permissions.mdx
@@ -32,7 +32,7 @@ We can define permissions in `permissions.ts`:
 <Callout type="info">
   Write your permissions policies in `permissions.ts` next to `schema.ts`. By default Jazz looks for both files at your project root — except in SvelteKit projects, where they should live in `src/lib/` (the standard location for shared app code).
 
-Run `npx jazz-tools@alpha validate` before publishing to identify any issues. You do not need to write a schema migration to update permissions policies. Push the updated policies by running `npx jazz-tools@alpha deploy <appId>`.
+Run `pnpm dlx jazz-tools@alpha validate` before publishing to surface warnings about tables with no explicit permission policy&hairsp;—&hairsp;`deploy` does not run these checks. You do not need to write a schema migration to update permissions policies. Push the updated policies by running `pnpm dlx jazz-tools@alpha deploy <appId>`.
 
 </Callout>
 

--- a/docs/content/docs/auth/permissions.mdx
+++ b/docs/content/docs/auth/permissions.mdx
@@ -32,7 +32,7 @@ We can define permissions in `permissions.ts`:
 <Callout type="info">
   Write your permissions policies in `permissions.ts` next to `schema.ts`. By default Jazz looks for both files at your project root — except in SvelteKit projects, where they should live in `src/lib/` (the standard location for shared app code).
 
-Run `pnpm dlx jazz-tools@alpha validate` before publishing to surface warnings about tables with no explicit permission policy&hairsp;—&hairsp;`deploy` does not run these checks. You do not need to write a schema migration to update permissions policies. Push the updated policies by running `pnpm dlx jazz-tools@alpha deploy <appId>`.
+Run `pnpm dlx jazz-tools@alpha validate` before publishing to surface warnings about tables with no explicit permission policy. You do not need to write a schema migration to update permissions policies. Push the updated policies by running `pnpm dlx jazz-tools@alpha deploy <appId>`.
 
 </Callout>
 

--- a/docs/content/docs/getting-started/server-setup.mdx
+++ b/docs/content/docs/getting-started/server-setup.mdx
@@ -1,7 +1,7 @@
 ---
 title: Server Setup
 description: Hosted and self-hosted database server configuration, app provisioning, and backend context setup.
-reviewedAt: "cd2e1bc21"
+reviewedAt: "22485728"
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
@@ -21,7 +21,7 @@ App IDs are provisioned on request. Ask in the `jazz2-adopters` Discord channel 
   ../examples/docs/todo-server-rs/docs/self-host-cli.sh#setup-self-host-cli
 </include>
 
-`jazz-tools server <APP_ID>` currently supports:
+`jazz-tools@alpha server <APP_ID>` currently supports:
 
 | Option                              | Purpose                                                                                                                                  | Environment variable          | Default                   |
 | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- | ------------------------- |

--- a/docs/content/docs/guides/better-auth-adapter.mdx
+++ b/docs/content/docs/guides/better-auth-adapter.mdx
@@ -1,6 +1,7 @@
 ---
 title: Better Auth Adapter
 description: Use Better Auth with Jazz as the database adapter.
+reviewedAt: "22485728"
 ---
 
 The Jazz Better Auth adapter lets Better Auth store its tables in Jazz. For general Better Auth setup (route handlers, client, plugins), see the [Better Auth documentation](https://www.better-auth.com/docs).
@@ -57,7 +58,7 @@ npx @better-auth/cli@latest generate \
   --output ./schema-better-auth/schema.ts
 
 # Validate the generated schema source
-npx jazz-tools@alpha validate --schema-dir ./schema-better-auth
+pnpm dlx jazz-tools@alpha validate --schema-dir ./schema-better-auth
 ```
 
 The generated `schema.ts` includes a `permissions` export that denies all operations on the better-auth tables by default. This prevents any regular Jazz client session from reading or writing better-auth data. The adapter uses `context.asBackend()`, which authenticates with `backendSecret` and bypasses permission checks entirely, so better-auth itself is unaffected.
@@ -72,7 +73,7 @@ schema publication flow you already use for your app schema. Once that schema is
 server, publish the deny-all permissions:
 
 ```bash
-npx jazz-tools@alpha permissions push \
+pnpm dlx jazz-tools@alpha permissions push \
   --schema-dir ./schema-better-auth \
   --server-url $JAZZ_SERVER_URL \
   --admin-secret $JAZZ_ADMIN_SECRET
@@ -81,7 +82,7 @@ npx jazz-tools@alpha permissions push \
 You can check the currently deployed permissions head at any time:
 
 ```bash
-npx jazz-tools@alpha permissions status \
+pnpm dlx jazz-tools@alpha permissions status \
   --schema-dir ./schema-better-auth \
   --server-url $JAZZ_SERVER_URL \
   --admin-secret $JAZZ_ADMIN_SECRET
@@ -90,9 +91,9 @@ npx jazz-tools@alpha permissions status \
 After the initial push, schema changes require a migration edge:
 
 ```bash
-npx jazz-tools@alpha migrations create --fromHash <fromHash>
-npx jazz-tools@alpha migrations create --fromHash <fromHash> --toHash <toHash>
-npx jazz-tools@alpha migrations push <fromHash> <toHash>
+pnpm dlx jazz-tools@alpha migrations create --fromHash <fromHash>
+pnpm dlx jazz-tools@alpha migrations create --fromHash <fromHash> --toHash <toHash>
+pnpm dlx jazz-tools@alpha migrations push <fromHash> <toHash>
 ```
 
 <Callout title="No push needed for local-only setups">

--- a/docs/content/docs/quickstarts/client.mdx
+++ b/docs/content/docs/quickstarts/client.mdx
@@ -1,7 +1,7 @@
 ---
 title: Client
 description: Build a local-first to-do app with Jazz, step by step.
-reviewedAt: "4059cdef"
+reviewedAt: "22485728"
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
@@ -59,22 +59,22 @@ Start with a fresh app. If you already have one, skip to [Install](#install).
 <Tabs groupId="jazz-framework" items={["React", "Vue", "Svelte", "Expo", "TypeScript"]} persist updateAnchor>
   <Tab value="React">
     ```bash title="Terminal"
-    pnpm add jazz-tools
+    pnpm add jazz-tools@alpha
     ```
   </Tab>
   <Tab value="Vue">
     ```bash title="Terminal"
-    pnpm add jazz-tools
+    pnpm add jazz-tools@alpha
     ```
   </Tab>
   <Tab value="Svelte">
     ```bash title="Terminal"
-    pnpm add jazz-tools
+    pnpm add jazz-tools@alpha
     ```
   </Tab>
   <Tab value="Expo">
     ```bash title="Terminal"
-    pnpm add jazz-tools jazz-rn expo
+    pnpm add jazz-tools@alpha jazz-rn expo
     pnpm add -D @babel/plugin-transform-flow-strip-types
     ```
 
@@ -130,10 +130,16 @@ Start with a fresh app. If you already have one, skip to [Install](#install).
   </Tab>
   <Tab value="TypeScript">
     ```bash title="Terminal"
-    pnpm add jazz-tools
+    pnpm add jazz-tools@alpha
     ```
   </Tab>
 </Tabs>
+
+## Get an app ID
+
+Your app ID namespaces your data for storage and sync. Click below to generate one on the Jazz hosted cloud&hairsp;—&hairsp;you'll also get the secrets you need to deploy permissions later.
+
+<GenerateAppId />
 
 ## Define your schema
 
@@ -188,8 +194,10 @@ Create the basic structure for your app with Jazz and a to-do list.
 
 <Accordions type="single">
   <Accordion title="Client Config">
-    `appId` identifies your app for storage and sync. For all client config options and runtime
-    source overrides, see [Client Setup](/docs/getting-started/client-setup#client-config-options).
+    `appId` identifies your app for storage and sync. Use the UUID you generated
+    above&hairsp;—&hairsp;not a human-readable name&hairsp;—&hairsp;so your local data is already
+    correctly namespaced when you add a server. For all client config options and runtime source
+    overrides, see [Client Setup](/docs/getting-started/client-setup#client-config-options).
   </Accordion>
 </Accordions>
 
@@ -315,22 +323,13 @@ Framework hooks return `undefined` while loading, then an array of matching rows
 
 ## Enable sync
 
-So far, your to-do list only works locally. To sync across devices, you need a server, permissions, and an app ID.
+So far, your to-do list only works locally. To sync across devices, you need permissions published to the server.
 
-### Start a server
-
-Generate an app ID:
-
-```bash title="Terminal"
-npx jazz-tools@alpha create app
-# outputs a UUID like: 019d0ba1-519a-7e01-b0eb-0059ee898e4d
-```
-
-Start the server with that ID. In development mode, clients auto-publish the schema when they connect, so you don't need an admin secret just to sync schema changes. The default port is 1625.
-
-```bash title="Terminal"
-npx jazz-tools@alpha server <your-app-id> --admin-secret secret
-```
+<Accordions type="single">
+  <Accordion title="Didn't generate your app ID above? Generate it now!">
+    <GenerateAppId />
+  </Accordion>
+</Accordions>
 
 ### Add permissions
 
@@ -340,33 +339,21 @@ The server rejects all reads and writes unless you define [permissions](/docs/au
   ../examples/docs/todo-client-localfirst-ts/permissions.ts#quickstart-permissions-ts
 </include>
 
-Then publish the permissions bundle:
+Then publish the permissions bundle using the app ID and admin secret from above:
 
-```bash title="Terminal"
-npx jazz-tools@alpha deploy \
-  <your-app-id> \
-  --server-url http://127.0.0.1:1625 \
-  --admin-secret secret
-```
+<DeployCommand />
 
 ### Connect the client
 
-Update your client config to use the same app ID, and add `serverUrl`:
+Update your client config to add `serverUrl`. If you generated an app ID above, these values are already filled in:
 
-```ts title="Client config"
-{
-  appId: "<your-app-id>",
-  // Use your machine's LAN IP for mobile devices.
-  serverUrl: "http://127.0.0.1:1625",
-}
-```
+<CloudConfig />
 
 Clients pick up the schema from the server when they connect. If you update `schema.ts` you need to [create and push a migration to the new schema](/docs/schemas/migrations) so that clients can understand existing data with the new schema.
 
-Permissions can be updated without adding a new schema by using
-`npx jazz-tools@alpha deploy <your-app-id>`.
+Permissions can be updated without a schema migration by re-running `pnpm dlx jazz-tools@alpha deploy`.
 
-For production deployment and hosting options, see [Server Setup](/docs/getting-started/server-setup).
+For self-hosted deployments, see [Server Setup](/docs/getting-started/server-setup).
 
 ## Next steps
 

--- a/docs/content/docs/quickstarts/typescript-server.mdx
+++ b/docs/content/docs/quickstarts/typescript-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: TypeScript Server
 description: Build a server-side to-do API with Jazz and Hono, step by step.
-reviewedAt: "4059cdef"
+reviewedAt: "22485728"
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
@@ -24,7 +24,7 @@ pnpm init
 `jazz-napi` is the native runtime for Jazz on Node.js. It bundles the query engine, storage, and sync layer as a Rust binary via NAPI. `jazz-tools` detects it automatically at runtime, but it must be listed as an explicit dependency.
 
 ```bash title="Terminal"
-pnpm add jazz-tools jazz-napi hono @hono/node-server
+pnpm add jazz-tools@alpha jazz-napi@alpha hono @hono/node-server
 pnpm add -D typescript tsx
 ```
 
@@ -65,7 +65,7 @@ export default s.definePermissions(app, ({ policy }) => {
 Generate an app ID:
 
 ```bash title="Terminal"
-npx jazz-tools@alpha create app
+pnpm dlx jazz-tools@alpha create app
 # outputs a UUID like: 019d0ba1-519a-7e01-b0eb-0059ee898e4d
 ```
 

--- a/docs/content/docs/recipes/auth-provider-integration.mdx
+++ b/docs/content/docs/recipes/auth-provider-integration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Auth provider integration"
 description: Connect an external auth provider to Jazz with JWT validation, with examples for Better Auth and WorkOS.
-reviewedAt: "f7048c19"
+reviewedAt: "22485728"
 ---
 
 Jazz supports external JWT-based authentication for production use. This recipe walks through connecting a provider to Jazz, with examples for [Better Auth](https://www.better-auth.com/) (self-hosted) and [WorkOS](https://workos.com/) (managed service).
@@ -72,7 +72,7 @@ If you're unfamiliar with JWTs and JWKS, see the [explainer on the Authenticatio
     Point the Jazz server at your Better Auth JWKS endpoint:
 
     ```bash
-    jazz-tools server <APP_ID> --jwks-url https://your-app.example.com/api/auth/jwks
+    pnpm dlx jazz-tools@alpha server <APP_ID> --jwks-url https://your-app.example.com/api/auth/jwks
     ```
 
     For a full working example, see the [Better Auth chat example](https://github.com/garden-co/jazz/tree/main/examples/auth-betterauth-chat).
@@ -94,7 +94,7 @@ If you're unfamiliar with JWTs and JWKS, see the [explainer on the Authenticatio
     Point the Jazz server at the WorkOS JWKS endpoint:
 
     ```bash
-    jazz-tools server <APP_ID> --jwks-url https://api.workos.com/sso/jwks/client_01ABC...
+    pnpm dlx jazz-tools@alpha server <APP_ID> --jwks-url https://api.workos.com/sso/jwks/client_01ABC...
     ```
 
     For a full working example, see the [WorkOS chat example](https://github.com/garden-co/jazz/tree/main/examples/auth-workos-chat).

--- a/docs/content/docs/reference/mcp.mdx
+++ b/docs/content/docs/reference/mcp.mdx
@@ -1,7 +1,7 @@
 ---
 title: MCP Server
 description: Give your AI assistant direct access to Jazz documentation via the Model Context Protocol.
-reviewedAt: "4059cdef"
+reviewedAt: "22485728"
 ---
 
 The `jazz-tools` package ships with a built-in [MCP](https://modelcontextprotocol.io) server that
@@ -9,7 +9,7 @@ exposes the Jazz docs as tools any MCP-compatible AI assistant can call during a
 
 The docs served are always matched to the version of `jazz-tools` you install, so your
 assistant is reading documentation for the exact API you have available. To use a different
-version's docs, specify a version in the npx command (e.g. `npx jazz-tools@2.0.0 mcp`).
+version's docs, specify a version tag instead (e.g. `pnpm dlx jazz-tools@2.0.0 mcp`).
 
 <Callout type="info">
   Node 22.13 or later is recommended for the best search results. Earlier versions fall back to

--- a/docs/content/docs/schemas/migrations.mdx
+++ b/docs/content/docs/schemas/migrations.mdx
@@ -17,18 +17,18 @@ Traditional migration systems run a linear sequence and require peers to converg
 1. If this is the first migration you are creating, run:
 
    ```bash
-   npx jazz-tools@alpha migrations create
+   pnpm dlx jazz-tools@alpha migrations create
    ```
 
    This creates an initial snapshot of your schema in `migrations/snapshots/`. No migration file is created yet because there is no previous schema to diff against.
 
 2. **Edit `schema.ts`**&hairsp;—&hairsp;change the data shape as needed.
-3. **Validate locally**&hairsp;—&hairsp;optionally run `npx jazz-tools@alpha validate` to catch authoring errors
-   before connecting.
+3. **Validate locally**&hairsp;—&hairsp;optionally run `pnpm dlx jazz-tools@alpha validate` to surface warnings
+   about tables with no explicit permission policy, without needing server credentials.
 4. **Create a migration stub for the updated schema**&hairsp;—&hairsp;run:
 
    ```bash
-   npx jazz-tools@alpha migrations create --name <your-migration-name>
+   pnpm dlx jazz-tools@alpha migrations create --name <your-migration-name>
    ```
 
    By default, Jazz diffs the latest committed snapshot in `migrations/snapshots/` against the
@@ -38,13 +38,13 @@ Traditional migration systems run a linear sequence and require peers to converg
 6. **Publish**&hairsp;—&hairsp;push the migration to the server:
 
    ```bash
-   npx jazz-tools@alpha migrations push <appId> <fromHash> <toHash>
+   pnpm dlx jazz-tools@alpha migrations push <appId> <fromHash> <toHash>
    ```
 
    If you also want to publish the current schema, the migration and permissions in one step, you can run:
 
    ```bash
-   npx jazz-tools@alpha deploy <appId>
+   pnpm dlx jazz-tools@alpha deploy <appId>
    ```
 
    `deploy` publishes the current schema if the server does not already know it, checks whether the
@@ -52,7 +52,7 @@ Traditional migration systems run a linear sequence and require peers to converg
    if needed, and then publishes the current permissions.
 
 Permission-only changes in `permissions.ts` do not need migrations, but they do still require
-`npx jazz-tools@alpha deploy <appId>`. See [Permissions](/docs/auth/permissions) for details.
+`pnpm dlx jazz-tools@alpha deploy <appId>`. See [Permissions](/docs/auth/permissions) for details.
 
 ## Generated stub
 
@@ -110,8 +110,8 @@ The Jazz server will detect when there are rows that are not reachable from the 
 In order to do so, you'll need to **create the migration using explicit to/from schema hashes**:
 
 ```bash
-npx jazz-tools@alpha migrations create <appId> --fromHash <fromHash>
-npx jazz-tools@alpha migrations create <appId> --fromHash <fromHash> --toHash <toHash>
+pnpm dlx jazz-tools@alpha migrations create <appId> --fromHash <fromHash>
+pnpm dlx jazz-tools@alpha migrations create <appId> --fromHash <fromHash> --toHash <toHash>
 ```
 
 `--toHash` defaults to the current local schema. When a requested hash is not already saved locally, Jazz resolves it from the
@@ -119,13 +119,13 @@ server and saves a snapshot in `migrations/snapshots/`.
 
 ## Exporting the compiled schema
 
-`npx jazz-tools@alpha schema export` prints the compiled structural schema as JSON to stdout. It
+`pnpm dlx jazz-tools@alpha schema export` prints the compiled structural schema as JSON to stdout. It
 also saves a snapshot of the schema in the local snapshot directory.
 
 ```bash
-npx jazz-tools@alpha schema export
-npx jazz-tools@alpha schema export --schema-dir ./packages/app
-npx jazz-tools@alpha schema export <appId> --schema-hash <hash> --server-url http://localhost:4200 --admin-secret <secret>
+pnpm dlx jazz-tools@alpha schema export
+pnpm dlx jazz-tools@alpha schema export --schema-dir ./packages/app
+pnpm dlx jazz-tools@alpha schema export <appId> --schema-hash <hash> --server-url http://localhost:4200 --admin-secret <secret>
 ```
 
 Without `--schema-hash`, Jazz exports the current local `schema.ts`. With `--schema-hash`, it

--- a/docs/content/docs/schemas/migrations.mdx
+++ b/docs/content/docs/schemas/migrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrations
 description: Structural schema evolution workflow and reviewed migration edges.
-reviewedAt: "f6535a533"
+reviewedAt: "22485728"
 ---
 
 <Callout type="info" title="You can skip this first">
@@ -23,8 +23,8 @@ Traditional migration systems run a linear sequence and require peers to converg
    This creates an initial snapshot of your schema in `migrations/snapshots/`. No migration file is created yet because there is no previous schema to diff against.
 
 2. **Edit `schema.ts`**&hairsp;—&hairsp;change the data shape as needed.
-3. **Validate locally**&hairsp;—&hairsp;optionally run `pnpm dlx jazz-tools@alpha validate` to surface warnings
-   about tables with no explicit permission policy, without needing server credentials.
+3. **Validate locally**&hairsp;—&hairsp;optionally run `pnpm dlx jazz-tools@alpha validate` to ensure policies
+   are valid before they are deployed. `deploy` does not run these checks.
 4. **Create a migration stub for the updated schema**&hairsp;—&hairsp;run:
 
    ```bash
@@ -34,7 +34,7 @@ Traditional migration systems run a linear sequence and require peers to converg
    By default, Jazz diffs the latest committed snapshot in `migrations/snapshots/` against the
    current schema and writes a stub migration file into `migrations/`. It also saves a snapshot of the generated schema.
 
-5. **Review and customise**&hairsp;—&hairsp; the migration, if needed (see below).
+5. **Review and customise**&hairsp;—&hairsp;the migration, if needed (see below).
 6. **Publish**&hairsp;—&hairsp;push the migration to the server:
 
    ```bash

--- a/docs/content/partials/schema-setup.mdx
+++ b/docs/content/partials/schema-setup.mdx
@@ -2,7 +2,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 Validate your schema and permissions locally:
 
-`npx jazz-tools@alpha validate`
+`pnpm dlx jazz-tools@alpha validate`
 
 This validates `schema.ts` and the optional `permissions.ts`, then compiles them into Jazz's
 internal schema representation.
@@ -10,6 +10,6 @@ internal schema representation.
 When Jazz reports a difference between the old and new schema hashes after changing `schema.ts`, and your app already has data, you should create and push a migration edge as described in [Migrations](/docs/schemas/migrations):
 
 ```bash
-npx jazz-tools@alpha migrations create <appId> --fromHash <fromHash> --toHash <toHash>
-npx jazz-tools@alpha migrations push <appId> <fromHash> <toHash>
+pnpm dlx jazz-tools@alpha migrations create <appId> --fromHash <fromHash> --toHash <toHash>
+pnpm dlx jazz-tools@alpha migrations push <appId> <fromHash> <toHash>
 ```

--- a/docs/lib/generated-app-store.ts
+++ b/docs/lib/generated-app-store.ts
@@ -1,0 +1,54 @@
+export interface GeneratedApp {
+  appId: string;
+  adminSecret: string;
+  backendSecret: string;
+}
+
+const STORAGE_KEY = "jazz-quickstart-generated-app";
+const EVENT_NAME = "jazz-app-generated";
+
+export function storeGeneratedApp(app: GeneratedApp): void {
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(app));
+  } catch {
+    // sessionStorage may be unavailable in some environments
+  }
+  substituteInPage(app);
+  window.dispatchEvent(new CustomEvent(EVENT_NAME, { detail: app }));
+}
+
+function substituteInPage(app: GeneratedApp): void {
+  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+  let node: Text | null;
+  while ((node = walker.nextNode() as Text | null)) {
+    if (!node.nodeValue) continue;
+    if (
+      node.nodeValue.includes("<your-app-id>") ||
+      node.nodeValue.includes("<your-admin-secret>")
+    ) {
+      node.nodeValue = node.nodeValue
+        .replaceAll("<your-app-id>", app.appId)
+        .replaceAll("<your-admin-secret>", app.adminSecret);
+    }
+  }
+}
+
+export function restoreFromSession(): void {
+  const app = getStoredApp();
+  if (app) substituteInPage(app);
+}
+
+export function getStoredApp(): GeneratedApp | null {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as GeneratedApp) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function onAppGenerated(cb: (app: GeneratedApp) => void): () => void {
+  const handler = (e: Event) => cb((e as CustomEvent<GeneratedApp>).detail);
+  window.addEventListener(EVENT_NAME, handler);
+  return () => window.removeEventListener(EVENT_NAME, handler);
+}

--- a/docs/mdx-components.tsx
+++ b/docs/mdx-components.tsx
@@ -2,12 +2,18 @@ import defaultMdxComponents from "fumadocs-ui/mdx";
 import * as TabsComponents from "fumadocs-ui/components/tabs";
 import type { MDXComponents } from "mdx/types";
 import { Mermaid } from "./components/mdx/mermaid";
+import { GenerateAppId } from "./components/mdx/generate-app-id";
+import { CloudConfig } from "./components/mdx/cloud-config";
+import { DeployCommand } from "./components/mdx/deploy-command";
 
 export function getMDXComponents(components?: MDXComponents): MDXComponents {
   return {
     ...defaultMdxComponents,
     ...TabsComponents,
     Mermaid,
+    GenerateAppId,
+    CloudConfig,
+    DeployCommand,
     ...components,
   };
 }

--- a/examples/docs/todo-client-localfirst-expo/src/setup-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-expo/src/setup-snippets.tsx
@@ -7,7 +7,7 @@ export function App() {
   return (
     <JazzProvider
       config={{
-        appId: "my-todo-app",
+        appId: "<your-app-id>",
       }}
     >
       <SafeAreaView style={{ flex: 1 }}>

--- a/examples/docs/todo-client-localfirst-react/src/setup-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/setup-snippets.tsx
@@ -1,12 +1,12 @@
+// #region context-setup-react-minimal
 import { JazzProvider } from "jazz-tools/react";
 import { TodoList } from "./TodoList.js";
 
-// #region context-setup-react-minimal
 export default function App() {
   return (
     <JazzProvider
       config={{
-        appId: "my-todo-app",
+        appId: "<your-app-id>",
       }}
     >
       <h1>Todos</h1>

--- a/examples/docs/todo-client-localfirst-svelte/src/App.svelte
+++ b/examples/docs/todo-client-localfirst-svelte/src/App.svelte
@@ -4,7 +4,7 @@
   import TodoList from './TodoList.svelte';
 
   const client = createJazzClient({
-    appId: 'my-todo-app',
+    appId: '<your-app-id>',
   });
 </script>
 

--- a/examples/docs/todo-client-localfirst-ts/permissions.ts
+++ b/examples/docs/todo-client-localfirst-ts/permissions.ts
@@ -1,7 +1,7 @@
+// #region quickstart-permissions-ts
 import { schema as s } from "jazz-tools";
 import { app } from "./schema.js";
 
-// #region quickstart-permissions-ts
 export default s.definePermissions(app, ({ policy }) => {
   policy.todos.allowRead.always();
   policy.todos.allowInsert.always();

--- a/examples/docs/todo-client-localfirst-ts/src/quickstart-list.html
+++ b/examples/docs/todo-client-localfirst-ts/src/quickstart-list.html
@@ -11,7 +11,7 @@
       import { app } from "./schema.js";
 
       const db = await createDb({
-        appId: "my-todo-app",
+        appId: "<your-app-id>",
         env: "dev",
         userBranch: "main",
       });

--- a/examples/docs/todo-client-localfirst-ts/src/quickstart.ts
+++ b/examples/docs/todo-client-localfirst-ts/src/quickstart.ts
@@ -4,7 +4,7 @@ import { app } from "../schema.js";
 import { renderTodoItem } from "./TodoItem.js";
 
 const db = await createDb({
-  appId: "my-todo-app",
+  appId: "<your-app-id>",
 });
 // use db.shutdown() to clean up when finished
 // #endregion setup-ts

--- a/examples/docs/todo-client-localfirst-vue/src/App.vue
+++ b/examples/docs/todo-client-localfirst-vue/src/App.vue
@@ -3,7 +3,7 @@ import { createJazzClient, JazzProvider } from "jazz-tools/vue";
 import TodoList from "./TodoList.vue";
 
 const client = createJazzClient({
-  appId: "my-todo-app",
+  appId: "<your-app-id>",
 });
 </script>
 


### PR DESCRIPTION
## Summary

- Replaces the CLI `jazz-tools create app` step in the client quickstart with an interactive widget that generates an app ID, admin secret, and backend secret from the hosted Jazz cloud
- Generated credentials are displayed in a single env-var code block with a warning to save them
- After generation, `<your-app-id>` and `<your-admin-secret>` placeholders are substituted live across the page (DOM walker + reactive `DeployCommand`/`CloudConfig` components)
- Session storage preserves generated values across page reloads; a restore-on-load pass runs via `CloudConfig`'s mount effect
- Quickstart "Enable sync" section is now cloud-first; self-hosted instructions remain linked via Server Setup
- Snippet placeholder app IDs updated from `"my-todo-app"` to `"<your-app-id>"` across all framework examples
- Clarifies why `jazz-tools validate` is worth running before `deploy`
- Various `reviewedAt` stamps and `pnpm dlx` command consistency fixes across other doc pages

## New files

- `docs/app/api/generate-app/route.ts` — Next.js proxy route (avoids CORS on the dashboard API)
- `docs/lib/generated-app-store.ts` — session storage + CustomEvent store shared between components
- `docs/components/mdx/generate-app-id.tsx` — generate button, credentials block, config block
- `docs/components/mdx/cloud-config.tsx` — reactive client config code block
- `docs/components/mdx/deploy-command.tsx` — reactive deploy command code block

## Test plan

- [ ] Click "Generate App ID" on the client quickstart — credentials appear, all `<your-app-id>` and `<your-admin-secret>` occurrences on the page update
- [ ] Reload the page — values are restored from session storage and substituted on mount
- [ ] Open the "Didn't generate your app ID above?" accordion in the Enable sync section — widget works there too
- [ ] Open a new tab / new session — placeholders show correctly (session storage not shared)