### PR TITLE
fix: reliable wasm load in Next.js Turbopack workers

### DIFF
--- a/examples/auth-betterauth-chat/.gitignore
+++ b/examples/auth-betterauth-chat/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 dist
 next-env.d.ts
+public/_jazz

--- a/examples/auth-betterauth-chat/next.config.ts
+++ b/examples/auth-betterauth-chat/next.config.ts
@@ -5,6 +5,10 @@ export const baseNextConfig = {
   serverExternalPackages: ["jazz-napi", "jazz-tools/backend"],
 };
 
-export const jazzOptions = {};
+export const jazzOptions = {
+  server: {
+    backendSecret: "auth-betterauth-chat-dev-backend-secret",
+  },
+};
 
 export default withJazz(baseNextConfig, jazzOptions);

--- a/examples/nextjs-csr-ssr/.gitignore
+++ b/examples/nextjs-csr-ssr/.gitignore
@@ -40,3 +40,5 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+public/_jazz/

--- a/packages/jazz-tools/src/dev/next.test.ts
+++ b/packages/jazz-tools/src/dev/next.test.ts
@@ -105,6 +105,21 @@ describe("withJazz", () => {
     expect(process.env.NEXT_PUBLIC_JAZZ_SERVER_URL).toBeUndefined();
   });
 
+  it("prefixes NEXT_PUBLIC_JAZZ_WASM_URL with basePath", async () => {
+    const resolved = await resolveWrappedConfig(
+      withJazz({ basePath: "/myapp" }),
+      PRODUCTION_BUILD_PHASE,
+    );
+
+    expect(resolved.env?.NEXT_PUBLIC_JAZZ_WASM_URL).toBe("/myapp/_jazz/jazz_wasm_bg.wasm");
+  });
+
+  it("omits basePath when not configured", async () => {
+    const resolved = await resolveWrappedConfig(withJazz({}), PRODUCTION_BUILD_PHASE);
+
+    expect(resolved.env?.NEXT_PUBLIC_JAZZ_WASM_URL).toBe("/_jazz/jazz_wasm_bg.wasm");
+  });
+
   it("starts a local server in development and injects NEXT_PUBLIC_JAZZ_* env vars", async () => {
     const port = await getAvailablePort();
     const schemaDir = await tempRoots.create("jazz-next-test-");

--- a/packages/jazz-tools/src/dev/next.test.ts
+++ b/packages/jazz-tools/src/dev/next.test.ts
@@ -25,11 +25,18 @@ async function resolveWrappedConfig(
 // to process.env on successful init; that state leaks across vitest workers in
 // the same thread pool and flips later tests onto the env-driven cloud branch.
 // Scrub before each test so every case starts from the same baseline.
-beforeEach(() => {
+beforeEach(async () => {
   delete process.env.NEXT_PUBLIC_JAZZ_APP_ID;
   delete process.env.NEXT_PUBLIC_JAZZ_SERVER_URL;
   delete process.env.JAZZ_ADMIN_SECRET;
   delete process.env.BACKEND_SECRET;
+
+  // withJazz copies jazz_wasm_bg.wasm into the host's public/ dir (derived
+  // from process.cwd() when no schemaDir is provided). Redirect cwd to a
+  // per-test temp dir so tests that don't pass schemaDir don't pollute the
+  // package directory.
+  const fakeCwd = await tempRoots.create("jazz-next-test-cwd-");
+  vi.spyOn(process, "cwd").mockReturnValue(fakeCwd);
 });
 
 afterEach(async () => {
@@ -62,7 +69,10 @@ describe("withJazz", () => {
     );
 
     expect(resolved.reactStrictMode).toBe(true);
-    expect(resolved.env).toEqual({ EXISTING_ENV: "1" });
+    expect(resolved.env).toEqual({
+      EXISTING_ENV: "1",
+      NEXT_PUBLIC_JAZZ_WASM_URL: "/_jazz/jazz_wasm_bg.wasm",
+    });
     expect(resolved.serverExternalPackages).toEqual(
       expect.arrayContaining(["sharp", "jazz-tools", "jazz-napi"]),
     );

--- a/packages/jazz-tools/src/dev/next.test.ts
+++ b/packages/jazz-tools/src/dev/next.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { writeFile } from "node:fs/promises";
+import { access, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createTempRootTracker, getAvailablePort, todoSchema } from "./test-helpers.js";
 import * as devServer from "./dev-server.js";
@@ -31,9 +31,9 @@ beforeEach(async () => {
   delete process.env.JAZZ_ADMIN_SECRET;
   delete process.env.BACKEND_SECRET;
 
-  // withJazz copies jazz_wasm_bg.wasm into the host's public/ dir (derived
-  // from process.cwd() when no schemaDir is provided). Redirect cwd to a
-  // per-test temp dir so tests that don't pass schemaDir don't pollute the
+  // withJazz copies jazz_wasm_bg.wasm into the host app's public/ dir
+  // (derived from process.cwd() when no appRoot is provided). Redirect cwd to a
+  // per-test temp dir so tests that don't pass appRoot don't pollute the
   // package directory.
   const fakeCwd = await tempRoots.create("jazz-next-test-cwd-");
   vi.spyOn(process, "cwd").mockReturnValue(fakeCwd);
@@ -118,6 +118,28 @@ describe("withJazz", () => {
     const resolved = await resolveWrappedConfig(withJazz({}), PRODUCTION_BUILD_PHASE);
 
     expect(resolved.env?.NEXT_PUBLIC_JAZZ_WASM_URL).toBe("/_jazz/jazz_wasm_bg.wasm");
+  });
+
+  it("copies wasm into appRoot instead of schemaDir when both differ", async () => {
+    const appRoot = await tempRoots.create("jazz-next-app-root-");
+    const schemaDir = await tempRoots.create("jazz-next-schema-dir-");
+    await writeFile(join(schemaDir, "schema.ts"), todoSchema());
+
+    await resolveWrappedConfig(
+      withJazz(
+        {},
+        {
+          appRoot,
+          schemaDir,
+        },
+      ),
+      PRODUCTION_BUILD_PHASE,
+    );
+
+    await expect(
+      access(join(appRoot, "public", "_jazz", "jazz_wasm_bg.wasm")),
+    ).resolves.toBeUndefined();
+    await expect(access(join(schemaDir, "public", "_jazz", "jazz_wasm_bg.wasm"))).rejects.toThrow();
   });
 
   it("starts a local server in development and injects NEXT_PUBLIC_JAZZ_* env vars", async () => {

--- a/packages/jazz-tools/src/dev/next.ts
+++ b/packages/jazz-tools/src/dev/next.ts
@@ -1,3 +1,6 @@
+import { createRequire } from "node:module";
+import { copyFile, mkdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import { buildInspectorLink } from "./inspector-link.js";
 import { ManagedDevRuntime } from "./managed-runtime.js";
 import type { JazzPluginOptions, JazzServerOptions } from "./vite.js";
@@ -28,13 +31,24 @@ export interface NextJazzPluginOptions extends JazzPluginOptions {
 }
 
 const DEVELOPMENT_PHASE = "phase-development-server";
+const PRODUCTION_BUILD_PHASE = "phase-production-build";
 const PUBLIC_APP_ID_ENV = "NEXT_PUBLIC_JAZZ_APP_ID";
 const PUBLIC_SERVER_URL_ENV = "NEXT_PUBLIC_JAZZ_SERVER_URL";
+const PUBLIC_WASM_SUBPATH = "_jazz/jazz_wasm_bg.wasm";
 
 const runtime = new ManagedDevRuntime({
   appId: PUBLIC_APP_ID_ENV,
   serverUrl: PUBLIC_SERVER_URL_ENV,
 });
+
+async function copyWasmToPublic(projectRoot: string): Promise<void> {
+  const require = createRequire(import.meta.url);
+  const pkgJsonPath = require.resolve("jazz-wasm/package.json");
+  const wasmSource = join(dirname(pkgJsonPath), "pkg", "jazz_wasm_bg.wasm");
+  const wasmDest = join(projectRoot, "public", PUBLIC_WASM_SUBPATH);
+  await mkdir(dirname(wasmDest), { recursive: true });
+  await copyFile(wasmSource, wasmDest);
+}
 
 function mergeServerExternalPackages(existing: string[] | undefined): string[] {
   return Array.from(new Set([...(existing ?? []), "jazz-tools", "jazz-napi"]));
@@ -65,6 +79,17 @@ export function withJazz(
       serverExternalPackages: mergeServerExternalPackages(resolved.serverExternalPackages),
     };
 
+    // Copy jazz-wasm bytes into the host app's public/ dir so they're served
+    // at a stable origin-root URL. Works around bundlers (Turbopack) that
+    // don't transform wasm-bindgen's `new URL('*.wasm', import.meta.url)`
+    // pattern inside worker chunks. Runs in dev and production-build so the
+    // asset is present in the built output.
+    if (phase === DEVELOPMENT_PHASE || phase === PRODUCTION_BUILD_PHASE) {
+      await copyWasmToPublic(options.schemaDir ?? process.cwd());
+    }
+
+    // Everything below is dev-only: managed server, APP_ID/SERVER_URL
+    // injection. In production the host app supplies those via its own env.
     if (phase !== DEVELOPMENT_PHASE || options.server === false) {
       return merged;
     }

--- a/packages/jazz-tools/src/dev/next.ts
+++ b/packages/jazz-tools/src/dev/next.ts
@@ -28,6 +28,7 @@ type NextConfigInput = NextConfigLike | NextConfigFactory;
 
 export interface NextJazzPluginOptions extends JazzPluginOptions {
   server?: boolean | string | NextJazzServerOptions;
+  appRoot?: string;
 }
 
 const DEVELOPMENT_PHASE = "phase-development-server";
@@ -51,11 +52,11 @@ const runtime = new ManagedDevRuntime({
   serverUrl: PUBLIC_SERVER_URL_ENV,
 });
 
-async function copyWasmToPublic(projectRoot: string): Promise<void> {
+async function copyWasmToPublic(appRoot: string): Promise<void> {
   const require = createRequire(import.meta.url);
   const pkgJsonPath = require.resolve("jazz-wasm/package.json");
   const wasmSource = join(dirname(pkgJsonPath), "pkg", "jazz_wasm_bg.wasm");
-  const wasmDest = join(projectRoot, "public", PUBLIC_WASM_SUBPATH);
+  const wasmDest = join(appRoot, "public", PUBLIC_WASM_SUBPATH);
   await mkdir(dirname(wasmDest), { recursive: true });
   await copyFile(wasmSource, wasmDest);
 }
@@ -96,7 +97,7 @@ export function withJazz(
     // asset is present in the built output.
     const copyAndAdvertiseWasm = phase === DEVELOPMENT_PHASE || phase === PRODUCTION_BUILD_PHASE;
     if (copyAndAdvertiseWasm) {
-      await copyWasmToPublic(options.schemaDir ?? process.cwd());
+      await copyWasmToPublic(options.appRoot ?? process.cwd());
     }
     const mergedWithWasmEnv: NextConfigLike = copyAndAdvertiseWasm
       ? {

--- a/packages/jazz-tools/src/dev/next.ts
+++ b/packages/jazz-tools/src/dev/next.ts
@@ -34,7 +34,9 @@ const DEVELOPMENT_PHASE = "phase-development-server";
 const PRODUCTION_BUILD_PHASE = "phase-production-build";
 const PUBLIC_APP_ID_ENV = "NEXT_PUBLIC_JAZZ_APP_ID";
 const PUBLIC_SERVER_URL_ENV = "NEXT_PUBLIC_JAZZ_SERVER_URL";
+const PUBLIC_WASM_URL_ENV = "NEXT_PUBLIC_JAZZ_WASM_URL";
 const PUBLIC_WASM_SUBPATH = "_jazz/jazz_wasm_bg.wasm";
+const PUBLIC_WASM_URL = `/${PUBLIC_WASM_SUBPATH}`;
 
 const runtime = new ManagedDevRuntime({
   appId: PUBLIC_APP_ID_ENV,
@@ -84,14 +86,21 @@ export function withJazz(
     // don't transform wasm-bindgen's `new URL('*.wasm', import.meta.url)`
     // pattern inside worker chunks. Runs in dev and production-build so the
     // asset is present in the built output.
-    if (phase === DEVELOPMENT_PHASE || phase === PRODUCTION_BUILD_PHASE) {
+    const copyAndAdvertiseWasm = phase === DEVELOPMENT_PHASE || phase === PRODUCTION_BUILD_PHASE;
+    if (copyAndAdvertiseWasm) {
       await copyWasmToPublic(options.schemaDir ?? process.cwd());
     }
+    const mergedWithWasmEnv: NextConfigLike = copyAndAdvertiseWasm
+      ? {
+          ...merged,
+          env: { ...merged.env, [PUBLIC_WASM_URL_ENV]: PUBLIC_WASM_URL },
+        }
+      : merged;
 
     // Everything below is dev-only: managed server, APP_ID/SERVER_URL
     // injection. In production the host app supplies those via its own env.
     if (phase !== DEVELOPMENT_PHASE || options.server === false) {
-      return merged;
+      return mergedWithWasmEnv;
     }
 
     const serverOpt = options.server;
@@ -114,9 +123,9 @@ export function withJazz(
     }
 
     return {
-      ...merged,
+      ...mergedWithWasmEnv,
       env: {
-        ...merged.env,
+        ...mergedWithWasmEnv.env,
         [PUBLIC_APP_ID_ENV]: managed.appId,
         [PUBLIC_SERVER_URL_ENV]: managed.serverUrl,
         ...(managed.backendSecret ? { BACKEND_SECRET: managed.backendSecret } : {}),

--- a/packages/jazz-tools/src/dev/next.ts
+++ b/packages/jazz-tools/src/dev/next.ts
@@ -36,7 +36,15 @@ const PUBLIC_APP_ID_ENV = "NEXT_PUBLIC_JAZZ_APP_ID";
 const PUBLIC_SERVER_URL_ENV = "NEXT_PUBLIC_JAZZ_SERVER_URL";
 const PUBLIC_WASM_URL_ENV = "NEXT_PUBLIC_JAZZ_WASM_URL";
 const PUBLIC_WASM_SUBPATH = "_jazz/jazz_wasm_bg.wasm";
-const PUBLIC_WASM_URL = `/${PUBLIC_WASM_SUBPATH}`;
+
+function buildPublicWasmUrl(basePath: unknown): string {
+  if (typeof basePath !== "string" || basePath.length === 0) {
+    return `/${PUBLIC_WASM_SUBPATH}`;
+  }
+  const trimmed = basePath.replace(/\/+$/, "");
+  const prefix = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  return `${prefix}/${PUBLIC_WASM_SUBPATH}`;
+}
 
 const runtime = new ManagedDevRuntime({
   appId: PUBLIC_APP_ID_ENV,
@@ -93,7 +101,10 @@ export function withJazz(
     const mergedWithWasmEnv: NextConfigLike = copyAndAdvertiseWasm
       ? {
           ...merged,
-          env: { ...merged.env, [PUBLIC_WASM_URL_ENV]: PUBLIC_WASM_URL },
+          env: {
+            ...merged.env,
+            [PUBLIC_WASM_URL_ENV]: buildPublicWasmUrl(merged.basePath),
+          },
         }
       : merged;
 

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -1309,17 +1309,28 @@ export class Db {
 
     const locationHref = typeof location !== "undefined" ? location.href : undefined;
 
-    // If the host app didn't pass `runtimeSources.wasmUrl`, default to the file
-    // `withJazz` copies into the app's public/ dir. Computed against the
-    // main-thread origin so the worker receives an absolute URL and doesn't
-    // need to resolve against its own (Turbopack-unreliable) self.location.
+    // Opt-in default: when a bundler plugin (e.g. `withJazz` for Next) copies
+    // the wasm into the host app and advertises the URL via
+    // NEXT_PUBLIC_JAZZ_WASM_URL, pick it up so the worker receives an
+    // absolute URL and skips the (Turbopack-unreliable) bundler default.
+    //
+    // Precedence follows RuntimeSourcesConfig: any of wasmModule / wasmSource /
+    // wasmUrl / baseUrl already supplied by the caller wins — we only fill in
+    // when none of those is set, preserving the documented resolution order
+    // for Vite/webpack/Svelte/etc. callers.
     const configRuntimeSources = this.config.runtimeSources;
+    const envWasmUrl =
+      typeof process !== "undefined" ? process.env?.NEXT_PUBLIC_JAZZ_WASM_URL : undefined;
+    const hasConfiguredSource =
+      !!configRuntimeSources?.wasmUrl ||
+      !!configRuntimeSources?.baseUrl ||
+      !!resolveRuntimeConfigSyncInitInput(configRuntimeSources);
     const runtimeSources =
-      configRuntimeSources?.wasmUrl || typeof location === "undefined"
+      hasConfiguredSource || !envWasmUrl || typeof location === "undefined"
         ? configRuntimeSources
         : {
             ...configRuntimeSources,
-            wasmUrl: `${location.origin}/_jazz/jazz_wasm_bg.wasm`,
+            wasmUrl: new URL(envWasmUrl, location.href).href,
           };
 
     // For the static-URL spawn path (no explicit workerUrl/baseUrl), compute a

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -1319,8 +1319,14 @@ export class Db {
     // when none of those is set, preserving the documented resolution order
     // for Vite/webpack/Svelte/etc. callers.
     const configRuntimeSources = this.config.runtimeSources;
+    // Use the literal `process.env.NEXT_PUBLIC_JAZZ_WASM_URL` form: Next's
+    // build-time replacement only rewrites that exact property access. Optional
+    // chaining on `process.env` can bypass the replacement in Turbopack and
+    // leave this as `undefined` in client bundles, defeating the fallback.
     const envWasmUrl =
-      typeof process !== "undefined" ? process.env?.NEXT_PUBLIC_JAZZ_WASM_URL : undefined;
+      typeof process !== "undefined" && process.env
+        ? process.env.NEXT_PUBLIC_JAZZ_WASM_URL
+        : undefined;
     // Any explicit override means the caller is taking control of wasm/worker
     // resolution — don't second-guess them by injecting a Next-plugin URL.
     // `workerUrl` counts too: the spawn path at `Db.spawnWorker` already

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -1321,9 +1321,15 @@ export class Db {
     const configRuntimeSources = this.config.runtimeSources;
     const envWasmUrl =
       typeof process !== "undefined" ? process.env?.NEXT_PUBLIC_JAZZ_WASM_URL : undefined;
+    // Any explicit override means the caller is taking control of wasm/worker
+    // resolution — don't second-guess them by injecting a Next-plugin URL.
+    // `workerUrl` counts too: the spawn path at `Db.spawnWorker` already
+    // resolves a wasm URL colocated with the custom worker script via
+    // `appendWorkerRuntimeWasmUrl` + `readWorkerRuntimeWasmUrl`.
     const hasConfiguredSource =
       !!configRuntimeSources?.wasmUrl ||
       !!configRuntimeSources?.baseUrl ||
+      !!configRuntimeSources?.workerUrl ||
       !!resolveRuntimeConfigSyncInitInput(configRuntimeSources);
     const runtimeSources =
       hasConfiguredSource || !envWasmUrl || typeof location === "undefined"

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -1307,12 +1307,25 @@ export class Db {
       throw new Error("Worker bridge is only available for driver.type='persistent'");
     }
 
+    const locationHref = typeof location !== "undefined" ? location.href : undefined;
+
+    // If the host app didn't pass `runtimeSources.wasmUrl`, default to the file
+    // `withJazz` copies into the app's public/ dir. Computed against the
+    // main-thread origin so the worker receives an absolute URL and doesn't
+    // need to resolve against its own (Turbopack-unreliable) self.location.
+    const configRuntimeSources = this.config.runtimeSources;
+    const runtimeSources =
+      configRuntimeSources?.wasmUrl || typeof location === "undefined"
+        ? configRuntimeSources
+        : {
+            ...configRuntimeSources,
+            wasmUrl: `${location.origin}/_jazz/jazz_wasm_bg.wasm`,
+          };
+
     // For the static-URL spawn path (no explicit workerUrl/baseUrl), compute a
     // fallback WASM URL for non-bundled contexts where wasmModule.default() may fail.
-    const runtimeSources = this.config.runtimeSources;
     let fallbackWasmUrl: string | undefined;
     if (!runtimeSources?.workerUrl && !runtimeSources?.baseUrl && !runtimeSources?.wasmUrl) {
-      const locationHref = typeof location !== "undefined" ? location.href : undefined;
       if (!resolveRuntimeConfigSyncInitInput(runtimeSources)) {
         fallbackWasmUrl =
           resolveWorkerBootstrapWasmUrl(import.meta.url, locationHref, runtimeSources) ?? undefined;
@@ -1328,7 +1341,7 @@ export class Db {
       serverUrl: this.config.serverUrl,
       jwtToken: this.config.jwtToken,
       adminSecret: this.config.adminSecret,
-      runtimeSources: this.config.runtimeSources,
+      runtimeSources,
       fallbackWasmUrl,
       logLevel: this.config.logLevel,
     };

--- a/packages/jazz-tools/src/runtime/runtime-config.ts
+++ b/packages/jazz-tools/src/runtime/runtime-config.ts
@@ -18,11 +18,22 @@ function resolveBrowserAssetBase(locationHref: string): string {
 }
 
 function resolveConfiguredUrl(url: string, locationHref: string | undefined): string {
-  if (locationHref) {
-    return new URL(url, locationHref).href;
+  // If `url` is already absolute, ignore the base. Workers under some bundlers
+  // (Turbopack) expose a non-URL `self.location.href`, and `new URL(absolute,
+  // badBase)` still throws because the base is validated.
+  try {
+    return new URL(url).href;
+  } catch {
+    // url is relative — fall through.
   }
-
-  return new URL(url).href;
+  if (locationHref) {
+    try {
+      return new URL(url, locationHref).href;
+    } catch {
+      // base unparseable — fall through.
+    }
+  }
+  return url;
 }
 
 function resolveConfiguredBaseUrl(

--- a/starters/next-betterauth/.gitignore
+++ b/starters/next-betterauth/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .env
 .jazz/
 next-env.d.ts
+public/_jazz/

--- a/starters/next-hybrid/.gitignore
+++ b/starters/next-hybrid/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .env
 .jazz/
 next-env.d.ts
+public/_jazz/

--- a/starters/next-localfirst/.gitignore
+++ b/starters/next-localfirst/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .env
 .jazz/
 next-env.d.ts
+public/_jazz/


### PR DESCRIPTION
## Summary

- Jazz apps running on Next.js 16 (Turbopack) crash in the worker with `TypeError: Failed to construct 'URL': Invalid URL` because Turbopack doesn't transform wasm-bindgen's `new URL('jazz_wasm_bg.wasm', import.meta.url)` pattern inside nested `node_modules` worker chunks, and the main-thread fallback was gated behind an `isHttpUrl(runtimeModuleUrl)` check that is always true in a real app.
- `withJazz` now copies `jazz_wasm_bg.wasm` into the host app's `public/_jazz/` (dev + production-build phases) and `buildWorkerBridgeOptions` defaults `runtimeSources.wasmUrl` to an absolute URL against `location.origin`, so the worker receives a fully-qualified URL and skips the broken bundler-default path.
- `resolveConfiguredUrl` tries absolute-first so a bogus `self.location.href` (as emitted by Turbopack in some worker contexts) can't poison an already-absolute URL.

## Test plan

- [ ] `pnpm --filter auth-betterauth-chat dev` — app loads without `Invalid URL` in the browser console.
- [ ] `pnpm --filter auth-betterauth-chat build && pnpm --filter auth-betterauth-chat start` — wasm served from `/_jazz/jazz_wasm_bg.wasm`, app loads.
- [ ] Other examples that use `withJazz` still work (no regressions in `nextjs-csr-ssr`, starters).
- [ ] Consumers who pass `runtimeSources.wasmUrl` themselves still have their value respected.