### PR TITLE
Fix flaky TypeScript example tests

### DIFF
--- a/examples/chat-react/src/components/chat-view/ChatSettings.tsx
+++ b/examples/chat-react/src/components/chat-view/ChatSettings.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { useDb, useAll, useSession } from "jazz-tools/react";
 import { LogOutIcon, Share2Icon } from "lucide-react";
 import { Avatar } from "@/components/Avatar";
@@ -64,6 +64,11 @@ function ChatSettingsContent({
 
   const chatRows = useAll(app.chats.where({ id: chatId })) ?? [];
   const chat = chatRows[0];
+  const [draftName, setDraftName] = useState("");
+
+  useEffect(() => {
+    setDraftName(chat?.name ?? "");
+  }, [chatId, chat?.name]);
 
   const members = useAll(app.chatMembers.where({ chatId })) ?? [];
   const allProfiles = useAll(app.profiles) ?? [];
@@ -74,7 +79,7 @@ function ChatSettingsContent({
   const myMembership = members.find((m) => m.userId === userId);
 
   const handleNameChange = (newName: string) => {
-    if (!chat) return;
+    setDraftName(newName);
     db.update(app.chats, chatId, {
       name: newName || (null as unknown as string),
     });
@@ -86,6 +91,22 @@ function ChatSettingsContent({
     onOpenChange(false);
     navigate("/#/chats");
   };
+
+  if (!chat) {
+    return (
+      <>
+        <SheetHeader>
+          <SheetTitle>Chat settings</SheetTitle>
+        </SheetHeader>
+
+        <SheetDescription className="sr-only">
+          Manage chat name, view members, and leave the chat.
+        </SheetDescription>
+
+        <div className="px-4 py-6 text-sm text-muted-foreground italic">Loading chat...</div>
+      </>
+    );
+  }
 
   return (
     <>
@@ -105,7 +126,7 @@ function ChatSettingsContent({
           </p>
           <Input
             id="chat-name"
-            value={chat?.name ?? ""}
+            value={draftName}
             onChange={(evt) => handleNameChange(evt.currentTarget.value)}
           />
         </div>

--- a/examples/chat-react/src/components/editor/Editor.tsx
+++ b/examples/chat-react/src/components/editor/Editor.tsx
@@ -53,11 +53,16 @@ export const Editor = forwardRef<EditorHandle, EditorProps>(function Editor(
   const editorRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
+  const onSendRef = useRef(onSend);
   const [toolbarState, setToolbarState] = useState<FloatingToolbarState>({
     visible: false,
     top: 0,
     left: 0,
   });
+
+  useEffect(() => {
+    onSendRef.current = onSend;
+  }, [onSend]);
 
   const handleSend = useCallback(() => {
     const view = viewRef.current;
@@ -65,11 +70,11 @@ export const Editor = forwardRef<EditorHandle, EditorProps>(function Editor(
     if (isDocEmpty(view.state)) return;
 
     const html = serialiseToHtml(view.state);
-    onSend(html);
+    onSendRef.current(html);
 
     const newState = EditorState.create({ schema, plugins: view.state.plugins });
     view.updateState(newState);
-  }, [onSend]);
+  }, []);
 
   const handleInsertText = useCallback((text: string) => {
     const view = viewRef.current;
@@ -137,7 +142,13 @@ export const Editor = forwardRef<EditorHandle, EditorProps>(function Editor(
       view.destroy();
       viewRef.current = null;
     };
-  }, [disabled, handleSend]);
+  }, [handleSend, placeholder]);
+
+  useEffect(() => {
+    viewRef.current?.setProps({
+      editable: () => !disabled,
+    });
+  }, [disabled]);
 
   return (
     <div ref={containerRef} id="messageEditor" className="relative flex-1">

--- a/examples/chat-react/tests/browser/chat-app.test.tsx
+++ b/examples/chat-react/tests/browser/chat-app.test.tsx
@@ -42,6 +42,75 @@ function findSendButton(container: ParentNode): HTMLButtonElement | undefined {
     | undefined;
 }
 
+async function waitForSendButton(
+  container: ParentNode,
+  timeoutMs: number,
+  message: string,
+): Promise<HTMLButtonElement> {
+  await waitFor(
+    () => {
+      const button = findSendButton(container);
+      return !!button && !button.disabled;
+    },
+    timeoutMs,
+    message,
+  );
+
+  return findSendButton(container)!;
+}
+
+async function waitForEditorReady(
+  editorEl: HTMLElement,
+  timeoutMs: number,
+  message: string,
+): Promise<HTMLElement> {
+  await waitFor(
+    () => {
+      const handle = (editorEl as any).__editorHandle;
+      const proseMirror = editorEl.querySelector<HTMLElement>('[contenteditable="true"]');
+      return !!handle && typeof handle.insertText === "function" && proseMirror !== null;
+    },
+    timeoutMs,
+    message,
+  );
+
+  return editorEl.querySelector<HTMLElement>('[contenteditable="true"]')!;
+}
+
+async function sendMessage(
+  container: ParentNode,
+  editorEl: HTMLElement,
+  text: string,
+  timeoutMs: number,
+): Promise<void> {
+  await waitForSendButton(
+    container,
+    timeoutMs,
+    "Send button should be enabled after the composer finishes loading",
+  );
+
+  const proseMirror = await waitForEditorReady(
+    editorEl,
+    timeoutMs,
+    "Editor should be ready for typing before sending",
+  );
+
+  await act(async () => typeIntoEditor(editorEl, text));
+
+  await waitFor(
+    () => proseMirror.textContent?.includes(text) ?? false,
+    timeoutMs,
+    `Editor should contain "${text}" before sending`,
+  );
+
+  const sendButton = await waitForSendButton(
+    container,
+    timeoutMs,
+    `Send button should stay enabled while sending "${text}"`,
+  );
+  await act(async () => simulateClick(sendButton));
+}
+
 function hasRenderedMessage(container: ParentNode, text: string): boolean {
   return [...container.querySelectorAll("article")].some((article) =>
     article.textContent?.includes(text),
@@ -154,15 +223,7 @@ describe("Chat App E2E", () => {
     );
 
     const editor = el.querySelector<HTMLElement>("#messageEditor")!;
-    const sendButton = findSendButton(el);
-
-    await act(async () => {
-      typeIntoEditor(editor, "Hello Public 2");
-    });
-
-    if (sendButton) {
-      await act(async () => simulateClick(sendButton));
-    }
+    await sendMessage(el, editor, "Hello Public 2", 10000);
 
     await waitFor(
       () => el.textContent?.includes("Hello Public 2") ?? false,
@@ -258,14 +319,7 @@ describe("Chat App E2E", () => {
 
     // Send a message to delete
     const editor = el.querySelector<HTMLElement>("#messageEditor")!;
-    const sendButton = [...el.querySelectorAll("button")].find((b) =>
-      b.querySelector(".lucide-send"),
-    );
-
-    await act(async () => typeIntoEditor(editor, "Message to delete"));
-    if (sendButton) {
-      await act(async () => simulateClick(sendButton));
-    }
+    await sendMessage(el, editor, "Message to delete", 10000);
 
     await waitFor(
       () => el.textContent?.includes("Message to delete") ?? false,
@@ -467,21 +521,7 @@ describe("Chat App E2E", () => {
 
     // Send the secret message
     const aliceEditor = aliceContainer.querySelector<HTMLElement>("#messageEditor")!;
-    await waitFor(
-      () => {
-        const button = findSendButton(aliceContainer);
-        return !!button && !button.disabled;
-      },
-      10000,
-      "Private chat send button should be enabled for user A",
-    );
-
-    const aliceSendButton = findSendButton(aliceContainer);
-
-    await act(async () => typeIntoEditor(aliceEditor, "Secret Data"));
-    if (aliceSendButton) {
-      await act(async () => simulateClick(aliceSendButton));
-    }
+    await sendMessage(aliceContainer, aliceEditor, "Secret Data", 10000);
 
     await waitFor(
       () => hasRenderedMessage(aliceContainer, "Secret Data"),
@@ -535,11 +575,9 @@ describe("Chat App E2E", () => {
     );
 
     const editor = el.querySelector<HTMLElement>("#messageEditor")!;
-    const sendButton = findSendButton(el);
 
     for (const text of ["msg1", "msg2"]) {
-      await act(async () => typeIntoEditor(editor, text));
-      if (sendButton) await act(async () => simulateClick(sendButton));
+      await sendMessage(el, editor, text, 10000);
       await waitFor(() => hasRenderedMessage(el, text), 5000, `Message "${text}" should appear`);
       // Ensure the next message gets a strictly greater createdAt second.
       await new Promise((r) => setTimeout(r, 1100));
@@ -573,9 +611,7 @@ describe("Chat App E2E", () => {
 
     // Send a plain-text message first
     const editor = el.querySelector<HTMLElement>("#messageEditor")!;
-    const sendButton = findSendButton(el);
-    await act(async () => typeIntoEditor(editor, "msg1"));
-    if (sendButton) await act(async () => simulateClick(sendButton));
+    await sendMessage(el, editor, "msg1", 10000);
 
     await waitFor(() => hasRenderedMessage(el, "msg1"), 5000, "msg1 should appear before canvas");
 

--- a/examples/chat-react/tests/browser/chat-settings.test.tsx
+++ b/examples/chat-react/tests/browser/chat-settings.test.tsx
@@ -147,18 +147,15 @@ describe("ChatHeader + ChatSettings E2E", () => {
 
     await openSettings(el);
 
-    // Find the chat name input
-    const nameInput = document.querySelector<HTMLInputElement>("#chat-name");
-    expect(nameInput).toBeTruthy();
-
-    await act(async () => typeInto(nameInput!, "Weekend plans"));
-
-    // Wait for the DB update to round-trip back into the controlled input
     await waitFor(
-      () => nameInput!.value === "Weekend plans",
+      () => document.querySelector<HTMLInputElement>("#chat-name") !== null,
       5000,
-      "Chat name input should reflect the persisted value",
+      "Chat name input should appear",
     );
+
+    await act(async () => {
+      typeInto(document.querySelector<HTMLInputElement>("#chat-name")!, "Weekend plans");
+    });
 
     // Close the sheet
     const closeButton = document
@@ -188,14 +185,22 @@ describe("ChatHeader + ChatSettings E2E", () => {
 
     // Set a name first
     await openSettings(el);
-    const nameInput = document.querySelector<HTMLInputElement>("#chat-name")!;
-    await act(async () => typeInto(nameInput, "Temporary name"));
+    await waitFor(
+      () => document.querySelector<HTMLInputElement>("#chat-name") !== null,
+      5000,
+      "Chat name input should appear",
+    );
+    await act(async () => {
+      typeInto(document.querySelector<HTMLInputElement>("#chat-name")!, "Temporary name");
+    });
 
     // Wait for the name to take effect
     await new Promise((r) => setTimeout(r, 500));
 
     // Clear it
-    await act(async () => typeInto(nameInput, ""));
+    await act(async () => {
+      typeInto(document.querySelector<HTMLInputElement>("#chat-name")!, "");
+    });
 
     // Close the sheet
     const closeButton = document

--- a/examples/chat-react/tests/browser/chat-settings.test.tsx
+++ b/examples/chat-react/tests/browser/chat-settings.test.tsx
@@ -255,10 +255,19 @@ describe("ChatHeader + ChatSettings E2E", () => {
 
     await openSettings(el);
 
+    await waitFor(
+      () =>
+        [...document.querySelectorAll<HTMLElement>('[data-slot="sheet-content"] button')].some(
+          (b) => b.textContent?.toLowerCase().includes("leave chat"),
+        ),
+      5000,
+      "Leave chat button should appear",
+    );
+
     // Click the "Leave chat" button
-    const leaveButton = [...document.querySelectorAll("button")].find((b) =>
-      b.textContent?.toLowerCase().includes("leave"),
-    ) as HTMLElement | undefined;
+    const leaveButton = [
+      ...document.querySelectorAll<HTMLElement>('[data-slot="sheet-content"] button'),
+    ].find((b) => b.textContent?.toLowerCase().includes("leave chat"));
     expect(leaveButton).toBeTruthy();
     await act(async () => simulateClick(leaveButton!));
 

--- a/examples/docs/todo-server-ts/src/main.ts
+++ b/examples/docs/todo-server-ts/src/main.ts
@@ -79,6 +79,7 @@ export async function createServer(config: TodoServerConfig = {}): Promise<TodoS
   const jwtPublicKey = config.jwtPublicKey ?? process.env.JAZZ_JWT_PUBLIC_KEY?.trim();
   const allowLocalFirstAuth =
     config.allowLocalFirstAuth ?? process.env.JAZZ_ALLOW_LOCAL_FIRST_AUTH !== "false";
+  const writeTier = serverUrl ? "edge" : "local";
 
   if (!serverUrl || !backendSecret) {
     throw new Error(
@@ -156,7 +157,7 @@ export async function createServer(config: TodoServerConfig = {}): Promise<TodoS
           done: false,
           owner_id: body.owner_id ?? "anonymous",
         })
-        .wait({ tier: "local" });
+        .wait({ tier: writeTier });
 
       res.status(201).json(todo);
 
@@ -242,7 +243,7 @@ export async function createServer(config: TodoServerConfig = {}): Promise<TodoS
         return;
       }
 
-      await db.update(schemaApp.todos, id, updates).wait({ tier: "local" });
+      await db.update(schemaApp.todos, id, updates).wait({ tier: writeTier });
 
       // Fetch updated todo
       const todo = await db.one(schemaApp.todos.where({ id }));
@@ -264,7 +265,7 @@ export async function createServer(config: TodoServerConfig = {}): Promise<TodoS
     try {
       const { id } = req.params;
 
-      await db.delete(schemaApp.todos, id).wait({ tier: "local" });
+      await db.delete(schemaApp.todos, id).wait({ tier: writeTier });
       res.status(204).send();
 
       // Notify SSE connections

--- a/examples/todo-client-localfirst-ts/src/main.ts
+++ b/examples/todo-client-localfirst-ts/src/main.ts
@@ -66,9 +66,8 @@ export async function startApp(
 
   // #region context-setup-ts-client
   const db = await createDb(resolvedConfig);
-  const session = db.getAuthState().session;
   // #endregion context-setup-ts-client
-  const sessionUserId = session?.user_id ?? null;
+  let sessionUserId = db.getAuthState().session?.user_id ?? null;
 
   // Build DOM
   const h1 = document.createElement("h1");
@@ -85,7 +84,11 @@ export async function startApp(
   const btn = document.createElement("button");
   btn.type = "submit";
   btn.textContent = "Add";
-  btn.disabled = !sessionUserId;
+  const syncAuthState = (userId: string | null) => {
+    sessionUserId = userId;
+    btn.disabled = !sessionUserId;
+  };
+  syncAuthState(sessionUserId);
   const parentSelect = document.createElement("select");
   parentSelect.id = "parent-select";
   const noParentOption = document.createElement("option");
@@ -143,6 +146,9 @@ export async function startApp(
       )
       .join("");
   });
+  const stopAuthSync = db.onAuthChanged(({ session }) => {
+    syncAuthState(session?.user_id ?? null);
+  });
 
   // Add todo form
   form.addEventListener("submit", (e) => {
@@ -189,6 +195,7 @@ export async function startApp(
     db,
     destroy: async () => {
       unsubscribe();
+      stopAuthSync();
       await db.shutdown();
       container.innerHTML = "";
     },

--- a/examples/todo-client-localfirst-ts/tests/browser/todo-app.test.ts
+++ b/examples/todo-client-localfirst-ts/tests/browser/todo-app.test.ts
@@ -63,6 +63,14 @@ describe("Vanilla TS Todo App E2E", () => {
 
     // Wait for the app to render
     await waitFor(() => el.querySelector("#todo-list") !== null, 5000, "App should render");
+    await waitFor(
+      () => {
+        const submitButton = el.querySelector<HTMLButtonElement>('#add-form button[type="submit"]');
+        return submitButton !== null && !submitButton.disabled;
+      },
+      5000,
+      "Todo form should be ready",
+    );
 
     return el;
   }


### PR DESCRIPTION
## What changed

This broadens the original browser-flake PR into a set of fixes for the TypeScript example test failures we were seeing across recent `test-ts` runs.

- keep the `chat-react` settings sheet from exposing a rename input before the chat row exists, and keep a local draft value so rename edits do not depend on an async DB echo to stay editable
- harden the `chat-react` browser settings tests so they re-query the live sheet input instead of holding stale portal DOM references across rerenders, and wait for the leave-chat action after the sheet content finishes loading
- update `todo-client-localfirst-ts` to react to auth state changes after startup instead of snapshotting the session once and leaving the add form permanently disabled if auth arrives late
- make the `todo-client-localfirst-ts` browser tests wait for the add form to be genuinely ready before submitting todos
- make the `todo-server-ts` example wait for `edge` durability on writes when configured against an upstream server so restart tests do not observe partially-settled state

## Why

Three separate PRs had recent `test-ts` failures in example apps:

- `#601`: `chat-react` browser timeouts centered around the settings flow and editor visibility
- `#608`: `todo-client-localfirst-ts` browser timeouts where todos never appeared after form submit
- `#581`: `todo-server-ts` cold-start persistence failures where the restart test observed duplicate rows

## Root cause

These were three related race classes rather than one shared bug:

- `chat-react`: the settings UI could render before the backing chat row had loaded, so rename events could be dropped under suite load, and the test was also keeping stale references to portal-rendered inputs or assuming settings actions existed before the loading gate had resolved
- `todo-client-localfirst-ts`: the app captured `db.getAuthState().session` only once during startup, so if auth resolved a moment later the submit button stayed disabled for the lifetime of the app instance
- `todo-server-ts`: the server returned write success after only local durability even when backed by an upstream server, which left the restart test exposed to unsettled state

## Impact

The TypeScript example suites are more robust under CI timing, especially in browser runs where load order and auth readiness can drift slightly from one run to the next.

## Validation

- `pnpm exec vitest run --config vitest.config.browser.ts` in `examples/chat-react`
- `pnpm exec vitest run --config vitest.config.browser.ts` in `examples/todo-client-localfirst-ts`
- `pnpm exec vitest run tests/integration.test.ts -t 'survives a server restart'` in `examples/docs/todo-server-ts`
- repeated local passes:
  - `chat-react` browser suite: 3 back-to-back passes
  - `todo-client-localfirst-ts` browser suite: 5 back-to-back passes
  - `todo-server-ts` restart test: 10 back-to-back passes
  - `chat-settings` leave-chat test: 5 back-to-back passes
