### PR TITLE
fix: delete `*Durable` & `*Persisted` write APIs

### DIFF
--- a/docs/content/docs/reference/durability-tiers.mdx
+++ b/docs/content/docs/reference/durability-tiers.mdx
@@ -12,13 +12,7 @@ For background on how data flows between tiers, see [How Sync Works](/docs/conce
 
 ## Write tiers
 
-`insert`, `update`, and `delete` apply locally with no durability guarantee. Their `Durable` counterparts return promises that resolve when the requested tier acknowledges.
-
-Options:
-
-- `options.tier`: `"local"` \| `"edge"` \| `"global"`
-- Browser/client default: `"local"`
-- Backend/server default: `"edge"`
+`insert`, `update`, and `delete` apply locally with no durability guarantee, and return a write handle. Call `.wait({ tier: ... })` on those handles when you need confirmation that the write reached a specific durability tier.
 
 See [Writing Data](/docs/writing/writing-data#write-durability-tiers) for detailed guidance on which tier to use and code examples.
 
@@ -26,11 +20,11 @@ See [Writing Data](/docs/writing/writing-data#write-durability-tiers) for detail
 
 Read durability controls when the **first result** of a query or subscription is delivered.
 
-| Option         | Values                              | Default        | What it does                                                                                                                                                                                                                                                                     |
-| -------------- | ----------------------------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `tier`         | `"local"` \| `"edge"` \| `"global"` | Same as writes | How far the first result must come from before the query delivers.                                                                                                                                                                                                               |
-| `localUpdates` | `"immediate"` \| `"deferred"`       | `"immediate"`  | With `"immediate"`, your own local writes appear in the subscription while still waiting for the tier to confirm the initial snapshot. This only takes effect after the subscription has settled at least once. With `"deferred"`, all delivery is held until the tier confirms. |
-| `propagation`  | `"full"` \| `"local-only"`          | `"full"`       | With `"full"`, the subscription is sent to upstream servers, which push matching data back. With `"local-only"`, only local storage is queried&hairsp;—&hairsp;no server communication.                                                                                          |
+| Option         | Values                              | Default                                                | What it does                                                                                                                                                                                                                                                                     |
+| -------------- | ----------------------------------- | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tier`         | `"local"` \| `"edge"` \| `"global"` | `"local"` (browser/client) / `"edge"` (backend/server) | How far the first result must come from before the query delivers.                                                                                                                                                                                                               |
+| `localUpdates` | `"immediate"` \| `"deferred"`       | `"immediate"`                                          | With `"immediate"`, your own local writes appear in the subscription while still waiting for the tier to confirm the initial snapshot. This only takes effect after the subscription has settled at least once. With `"deferred"`, all delivery is held until the tier confirms. |
+| `propagation`  | `"full"` \| `"local-only"`          | `"full"`                                               | With `"full"`, the subscription is sent to upstream servers, which push matching data back. With `"local-only"`, only local storage is queried&hairsp;—&hairsp;no server communication.                                                                                          |
 
 These options apply to:
 

--- a/docs/content/docs/reference/internals.mdx
+++ b/docs/content/docs/reference/internals.mdx
@@ -251,14 +251,14 @@ uses that catalogue state to resolve schema context on demand.
 
 Jazz separates two durability questions:
 
-| Signal                  | Gates                    | Question it answers                        |
-| ----------------------- | ------------------------ | ------------------------------------------ |
-| `QuerySettled`          | First read delivery      | "Has the query result settled at tier T?"  |
-| Write tier confirmation | Durable write completion | "Has this write been confirmed at tier T?" |
+| Signal                  | Gates                                | Question it answers                        |
+| ----------------------- | ------------------------------------ | ------------------------------------------ |
+| `QuerySettled`          | First read delivery                  | "Has the query result settled at tier T?"  |
+| Write tier confirmation | `.wait({ tier })` promise completion | "Has this write been confirmed at tier T?" |
 
 Both use the same tier lattice (`local` < `edge` < `global`), but they answer different
 questions. A query's first callback is held until `QuerySettled` reaches the requested tier. A
-durable write promise resolves when the requested tier confirms the write.
+`.wait({ tier })` promise resolves when the requested tier confirms the write.
 
 <Callout type="warn">
   The read durability tier only gates the **first** delivery of a subscription. After the initial

--- a/examples/auth-betterauth-chat/src/ChatPanel.tsx
+++ b/examples/auth-betterauth-chat/src/ChatPanel.tsx
@@ -53,16 +53,14 @@ export function ChatPanel({
     setDeleteError(null);
 
     try {
-      await db.insertDurable(
-        app.messages,
-        {
+      await db
+        .insert(app.messages, {
           author_name: authorName,
           chat_id: chatId,
           text: messageText.trim(),
           sent_at: new Date(),
-        },
-        { tier: "edge" },
-      );
+        })
+        .wait({ tier: "edge" });
       setMessageText("");
     } catch (error) {
       setMessageError(error instanceof Error ? error.message : String(error));
@@ -76,7 +74,7 @@ export function ChatPanel({
     setDeleteError(null);
 
     try {
-      await db.deleteDurable(app.messages, messageId, { tier: "edge" });
+      await db.delete(app.messages, messageId).wait({ tier: "edge" });
     } catch (error) {
       setDeleteError(error instanceof Error ? error.message : String(error));
     } finally {

--- a/examples/moon-lander-react/tests/browser/multiplayer.test.tsx
+++ b/examples/moon-lander-react/tests/browser/multiplayer.test.tsx
@@ -319,7 +319,7 @@ describe("Moon Lander — Cross-Client Sync", () => {
       // collectDeposit now uses DELETE+INSERT so the deposit gets a new ID.
       // The game engine's collectedIds tracks the OLD ID, so deposit-count
       // doesn't reflect the collection. Use sync-uncollected (raw edge count)
-      // which correctly drops when deleteDurable fires WHERE EXIT.
+      // which correctly drops when delete fires WHERE EXIT.
       const syncEl = el.querySelector('[data-testid="sync-debug"]')!;
       const countAfterCollect = parseInt(syncEl.getAttribute("data-sync-uncollected") ?? "0", 10);
       const collected = countBefore - countAfterCollect;

--- a/packages/jazz-tools/bin/docs-index.txt
+++ b/packages/jazz-tools/bin/docs-index.txt
@@ -3785,7 +3785,7 @@ See [Queries](/docs/reading/queries) for subscriptions, one-shot queries, and du
 }
 ```
 
-Use `insertDurable` if you need confirmation that the write reached a specific [durability tier](/docs/reference/durability-tiers).
+Use `db.insert(...).wait({ tier: "..." })` if you need confirmation that the write reached a specific [durability tier](/docs/reference/durability-tiers).
 
 If ownership can be transferred after creation, use an explicit `owner_id` column instead of `$createdBy`.
 
@@ -3825,13 +3825,7 @@ For background on how data flows between tiers, see [How Sync Works](/docs/conce
 
 ## Write tiers
 
-`insert`, `update`, and `delete` apply locally with no durability guarantee. Their `Durable` counterparts return promises that resolve when the requested tier acknowledges.
-
-Options:
-
-- `options.tier`: `"local"` \| `"edge"` \| `"global"`
-- Browser/client default: `"local"`
-- Backend/server default: `"edge"`
+`insert`, `update`, and `delete` apply locally with no durability guarantee, and return a write handle. Call `.wait({ tier: ... })` on those handles when you need confirmation that the write reached a specific durability tier.
 
 See [Writing Data](/docs/writing/writing-data#write-durability-tiers) for detailed guidance on which tier to use and code examples.
 
@@ -4164,7 +4158,7 @@ fall back to surprise table scans.
 
 ### Deletion
 
-The user-facing `delete` and `deleteDurable` APIs perform a **soft delete**. The row is preserved in
+The user-facing `delete` API performs a **soft delete**. The row is preserved in
 history, but it disappears from ordinary live queries.
 
 Internally, the current visible state leaves the live `_id` index and can still be addressed
@@ -5412,7 +5406,7 @@ pub async fn clear_nullable_fields(
 
 ## Write durability tiers
 
-When using `insertDurable`, `updateDurable`, or `deleteDurable`, you can pass a tier option to control how far the mutation must propagate before the promise resolves: locally on the client (`local`), the nearest edge server (`edge`), or the global core (`global`).
+When using `insert(...).wait({ tier })`, `update(...).wait({ tier })`, or `delete(...).wait({ tier })`, the tier controls how far the mutation must propagate before the promise resolves: locally on the client (`local`), the nearest edge server (`edge`), or the global core (`global`).
 
 | Tier     | Resolves when                       | 
 | -------- | ----------------------------------- | 

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -924,24 +924,6 @@ export class Transaction {
     return handle;
   }
 
-  createPersisted(
-    table: string,
-    values: InsertValues,
-    options?: WriteDurabilityOptions,
-  ): PersistedWrite<Row> {
-    this.ensureActive();
-    const pendingWrite = this.client.createPersistedInternal(
-      table,
-      values,
-      this.session,
-      this.attribution,
-      options,
-      this.batchContext,
-    );
-    this.markTouchedRow(pendingWrite.value().id);
-    return pendingWrite;
-  }
-
   update(objectId: string, updates: Record<string, Value>): WriteHandle {
     this.ensureActive();
     const result = this.client.updateHandleInternal(
@@ -955,24 +937,6 @@ export class Transaction {
     return result;
   }
 
-  updatePersisted(
-    objectId: string,
-    updates: Record<string, Value>,
-    options?: WriteDurabilityOptions,
-  ): PersistedWrite<void> {
-    this.ensureActive();
-    const pendingWrite = this.client.updatePersistedInternal(
-      objectId,
-      updates,
-      this.session,
-      this.attribution,
-      options,
-      this.batchContext,
-    );
-    this.markTouchedRow(objectId);
-    return pendingWrite;
-  }
-
   delete(objectId: string): WriteHandle {
     this.ensureActive();
     const result = this.client.deleteHandleInternal(
@@ -983,19 +947,6 @@ export class Transaction {
     );
     this.markTouchedRow(objectId);
     return result;
-  }
-
-  deletePersisted(objectId: string, options?: WriteDurabilityOptions): PersistedWrite<void> {
-    this.ensureActive();
-    const pendingWrite = this.client.deletePersistedInternal(
-      objectId,
-      this.session,
-      this.attribution,
-      options,
-      this.batchContext,
-    );
-    this.markTouchedRow(objectId);
-    return pendingWrite;
   }
 
   async query(query: string | QueryInput, options?: QueryExecutionOptions): Promise<Row[]> {
@@ -1039,21 +990,6 @@ export class DirectBatch {
     );
   }
 
-  createPersisted(
-    table: string,
-    values: InsertValues,
-    options?: WriteDurabilityOptions,
-  ): PersistedWrite<Row> {
-    return this.client.createPersistedInternal(
-      table,
-      values,
-      this.session,
-      this.attribution,
-      options,
-      this.batchContext,
-    );
-  }
-
   update(objectId: string, updates: Record<string, Value>): WriteHandle {
     return this.client.updateHandleInternal(
       objectId,
@@ -1064,36 +1000,11 @@ export class DirectBatch {
     );
   }
 
-  updatePersisted(
-    objectId: string,
-    updates: Record<string, Value>,
-    options?: WriteDurabilityOptions,
-  ): PersistedWrite<void> {
-    return this.client.updatePersistedInternal(
-      objectId,
-      updates,
-      this.session,
-      this.attribution,
-      options,
-      this.batchContext,
-    );
-  }
-
   delete(objectId: string): WriteHandle {
     return this.client.deleteHandleInternal(
       objectId,
       this.session,
       this.attribution,
-      this.batchContext,
-    );
-  }
-
-  deletePersisted(objectId: string, options?: WriteDurabilityOptions): PersistedWrite<void> {
-    return this.client.deletePersistedInternal(
-      objectId,
-      this.session,
-      this.attribution,
-      options,
       this.batchContext,
     );
   }
@@ -1666,33 +1577,7 @@ export class JazzClient {
   }
 
   private requireSessionWriteMethod<
-    T extends keyof Pick<
-      Runtime,
-      | "insertWithSession"
-      | "insertDurableWithSession"
-      | "updateWithSession"
-      | "updateDurableWithSession"
-      | "deleteWithSession"
-      | "deleteDurableWithSession"
-    >,
-  >(method: T): NonNullable<Runtime[T]> {
-    const runtimeMethod = this.runtime[method];
-    if (!runtimeMethod) {
-      throw new Error(`${String(method)} is not supported by this runtime`);
-    }
-    return runtimeMethod.bind(this.runtime) as NonNullable<Runtime[T]>;
-  }
-
-  private requirePersistedWriteMethod<
-    T extends keyof Pick<
-      Runtime,
-      | "insertPersisted"
-      | "insertPersistedWithSession"
-      | "updatePersisted"
-      | "updatePersistedWithSession"
-      | "deletePersisted"
-      | "deletePersistedWithSession"
-    >,
+    T extends keyof Pick<Runtime, "insertWithSession" | "updateWithSession" | "deleteWithSession">,
   >(method: T): NonNullable<Runtime[T]> {
     const runtimeMethod = this.runtime[method];
     if (!runtimeMethod) {
@@ -2034,149 +1919,6 @@ export class JazzClient {
   }
 
   /**
-   * Insert a new row into a table and wait for durability at the requested tier.
-   */
-  async createDurable(
-    table: string,
-    values: InsertValues,
-    options?: CreateDurabilityOptions,
-  ): Promise<Row> {
-    return this.createDurableInternal(table, values, undefined, undefined, options);
-  }
-
-  /**
-   * Create or update a row with a caller-supplied id and wait for durability.
-   */
-  async upsertDurable(
-    table: string,
-    values: InsertValues,
-    options: UpsertDurabilityOptions,
-  ): Promise<void> {
-    await this.upsertDurableInternal(table, values, options.id, undefined, undefined, options);
-  }
-
-  /**
-   * Insert a new row into a table and wait for durability, optionally scoped to a session.
-   * @internal
-   */
-  async createDurableInternal(
-    table: string,
-    values: InsertValues,
-    session?: Session,
-    attribution?: string,
-    options?: CreateDurabilityOptions,
-  ): Promise<Row> {
-    const tier = this.resolveWriteTier(options);
-    const effectiveSession = this.resolveWriteSession(session, attribution);
-    let row;
-    try {
-      row =
-        effectiveSession || attribution !== undefined || options?.updatedAt !== undefined
-          ? options?.id
-            ? await this.requireSessionWriteMethod("insertDurableWithSession")(
-                table,
-                values,
-                this.encodeWriteContext(
-                  effectiveSession,
-                  attribution,
-                  undefined,
-                  options.updatedAt,
-                ),
-                tier,
-                options.id,
-              )
-            : await this.requireSessionWriteMethod("insertDurableWithSession")(
-                table,
-                values,
-                this.encodeWriteContext(
-                  effectiveSession,
-                  attribution,
-                  undefined,
-                  options?.updatedAt,
-                ),
-                tier,
-              )
-          : options?.id
-            ? await this.runtime.insertDurable(table, values, tier, options.id)
-            : await this.runtime.insertDurable(table, values, tier);
-    } catch (error) {
-      throw normalizeRuntimeWriteError(error);
-    }
-    return {
-      ...row,
-      values: this.alignRowValuesToDeclaredSchema(table, row.values as Value[]),
-    };
-  }
-
-  createPersisted(
-    table: string,
-    values: InsertValues,
-    options?: WriteDurabilityOptions,
-  ): PersistedWrite<Row> {
-    return this.createPersistedInternal(table, values, undefined, undefined, options);
-  }
-
-  createPersistedInternal(
-    table: string,
-    values: InsertValues,
-    session?: Session,
-    attribution?: string,
-    options?: WriteDurabilityOptions,
-    batchContext?: BatchWriteContext,
-  ): PersistedWrite<Row> {
-    const tier = this.resolveWriteTier(options);
-    const effectiveSession = this.resolveWriteSession(session, attribution);
-    const result =
-      effectiveSession || attribution !== undefined || batchContext
-        ? this.requirePersistedWriteMethod("insertPersistedWithSession")(
-            table,
-            values,
-            this.encodeWriteContext(effectiveSession, attribution, batchContext),
-            tier,
-          )
-        : this.requirePersistedWriteMethod("insertPersisted")(table, values, tier);
-    return new PersistedWrite(this, tier, result.batchId, {
-      ...result.row,
-      values: this.alignRowValuesToDeclaredSchema(table, result.row.values as Value[]),
-    });
-  }
-
-  /**
-   * Create or update a row with a caller-supplied id and wait for durability,
-   * optionally scoped to a session.
-   * @internal
-   */
-  async upsertDurableInternal(
-    table: string,
-    values: InsertValues,
-    objectId: string,
-    session?: Session,
-    attribution?: string,
-    options?: UpsertDurabilityOptions,
-  ): Promise<void> {
-    try {
-      await this.createDurableInternal(table, values, session, attribution, {
-        ...options,
-        id: objectId,
-      });
-      return;
-    } catch (error) {
-      if (!isObjectAlreadyExistsError(error)) {
-        throw error;
-      }
-    }
-
-    await this.updateDurableInternal(
-      objectId,
-      values as Record<string, Value>,
-      session,
-      attribution,
-      options,
-      options?.updatedAt,
-    );
-  }
-
-  /**
    * Execute a query and return all matching rows.
    *
    * @param query Query builder or JSON-encoded query specification
@@ -2210,78 +1952,6 @@ export class JazzClient {
       optionsJson,
     );
     return this.alignQueryRowsToDeclaredSchema(queryJson, results as Row[], effectiveRuntimeSchema);
-  }
-
-  async updateDurable(
-    objectId: string,
-    updates: Record<string, Value>,
-    options?: UpdateDurabilityOptions,
-  ): Promise<void> {
-    await this.updateDurableInternal(
-      objectId,
-      updates,
-      undefined,
-      undefined,
-      options,
-      options?.updatedAt,
-    );
-  }
-
-  async updateDurableInternal(
-    objectId: string,
-    updates: Record<string, Value>,
-    session?: Session,
-    attribution?: string,
-    options?: UpdateDurabilityOptions,
-    updatedAt?: number,
-  ): Promise<void> {
-    const tier = this.resolveWriteTier(options);
-    const effectiveSession = this.resolveWriteSession(session, attribution);
-    try {
-      if (effectiveSession || attribution !== undefined || updatedAt !== undefined) {
-        await this.requireSessionWriteMethod("updateDurableWithSession")(
-          objectId,
-          updates,
-          this.encodeWriteContext(effectiveSession, attribution, undefined, updatedAt),
-          tier,
-        );
-        return;
-      }
-      await this.runtime.updateDurable(objectId, updates, tier);
-    } catch (error) {
-      throw normalizeRuntimeWriteError(error);
-    }
-  }
-
-  updatePersisted(
-    objectId: string,
-    updates: Record<string, Value>,
-    options?: WriteDurabilityOptions,
-  ): PersistedWrite<void> {
-    return this.updatePersistedInternal(objectId, updates, undefined, undefined, options);
-  }
-
-  updatePersistedInternal(
-    objectId: string,
-    updates: Record<string, Value>,
-    session?: Session,
-    attribution?: string,
-    options?: WriteDurabilityOptions,
-    batchContext?: BatchWriteContext,
-    updatedAt?: number,
-  ): PersistedWrite<void> {
-    const tier = this.resolveWriteTier(options);
-    const effectiveSession = this.resolveWriteSession(session, attribution);
-    const result =
-      effectiveSession || attribution !== undefined || batchContext || updatedAt !== undefined
-        ? this.requirePersistedWriteMethod("updatePersistedWithSession")(
-            objectId,
-            updates,
-            this.encodeWriteContext(effectiveSession, attribution, batchContext, updatedAt),
-            tier,
-          )
-        : this.requirePersistedWriteMethod("updatePersisted")(objectId, updates, tier);
-    return new PersistedWrite(this, tier, result.batchId, undefined);
   }
 
   /**
@@ -2377,59 +2047,6 @@ export class JazzClient {
       );
     }
     return this.runtime.delete(objectId);
-  }
-
-  async deleteDurable(objectId: string, options?: WriteDurabilityOptions): Promise<void> {
-    await this.deleteDurableInternal(objectId, undefined, undefined, options);
-  }
-
-  async deleteDurableInternal(
-    objectId: string,
-    session?: Session,
-    attribution?: string,
-    options?: WriteDurabilityOptions,
-    updatedAt?: number,
-  ): Promise<void> {
-    const tier = this.resolveWriteTier(options);
-    const effectiveSession = this.resolveWriteSession(session, attribution);
-    try {
-      if (effectiveSession || attribution !== undefined || updatedAt !== undefined) {
-        await this.requireSessionWriteMethod("deleteDurableWithSession")(
-          objectId,
-          this.encodeWriteContext(effectiveSession, attribution, undefined, updatedAt),
-          tier,
-        );
-        return;
-      }
-      await this.runtime.deleteDurable(objectId, tier);
-    } catch (error) {
-      throw normalizeRuntimeWriteError(error);
-    }
-  }
-
-  deletePersisted(objectId: string, options?: WriteDurabilityOptions): PersistedWrite<void> {
-    return this.deletePersistedInternal(objectId, undefined, undefined, options);
-  }
-
-  deletePersistedInternal(
-    objectId: string,
-    session?: Session,
-    attribution?: string,
-    options?: WriteDurabilityOptions,
-    batchContext?: BatchWriteContext,
-    updatedAt?: number,
-  ): PersistedWrite<void> {
-    const tier = this.resolveWriteTier(options);
-    const effectiveSession = this.resolveWriteSession(session, attribution);
-    const result =
-      effectiveSession || attribution !== undefined || batchContext || updatedAt !== undefined
-        ? this.requirePersistedWriteMethod("deletePersistedWithSession")(
-            objectId,
-            this.encodeWriteContext(effectiveSession, attribution, batchContext, updatedAt),
-            tier,
-          )
-        : this.requirePersistedWriteMethod("deletePersisted")(objectId, tier);
-    return new PersistedWrite(this, tier, result.batchId, undefined);
   }
 
   /**

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -483,18 +483,6 @@ export class DbTransaction {
     this.assertOwnsTable(query as unknown as TableProxy<T, never>, "DbTransaction");
   }
 
-  private wrapPersistedWrite<T>(
-    pendingWrite: RuntimePersistedWrite<Row | void>,
-    transformValue: (value: Row | void) => T,
-  ): DbPersistedWrite<T> {
-    return new DbPersistedWrite(
-      pendingWrite,
-      transformValue,
-      () => this.client.localBatchRecord(pendingWrite.batchId()),
-      () => this.client.acknowledgeRejectedBatch(pendingWrite.batchId()),
-    );
-  }
-
   batchId(): string {
     return this.runtimeTransaction.batchId();
   }
@@ -520,23 +508,6 @@ export class DbTransaction {
       .mapValue((row) => transformRow(row, table._schema, table._table));
   }
 
-  insertPersisted<T, Init>(
-    table: TableProxy<T, Init>,
-    data: Init,
-    options?: { tier?: DurabilityTier },
-  ): DbPersistedWrite<T> {
-    this.ensureActive();
-    const values = toInsertRecord(
-      data as Record<string, unknown>,
-      this.resolveInputSchema(table),
-      table._table,
-    );
-    const pendingWrite = this.runtimeTransaction.createPersisted(table._table, values, options);
-    return this.wrapPersistedWrite(pendingWrite as RuntimePersistedWrite<Row | void>, (row) =>
-      transformRow(row as Row, table._schema, table._table),
-    );
-  }
-
   update<T, Init>(table: TableProxy<T, Init>, id: string, data: Partial<Init>): WriteHandle {
     this.ensureActive();
     const updates = toUpdateRecord(
@@ -547,43 +518,10 @@ export class DbTransaction {
     return this.runtimeTransaction.update(id, updates);
   }
 
-  updatePersisted<T, Init>(
-    table: TableProxy<T, Init>,
-    id: string,
-    data: Partial<Init>,
-    options?: { tier?: DurabilityTier },
-  ): DbPersistedWrite<void> {
-    this.ensureActive();
-    const updates = toUpdateRecord(
-      data as Record<string, unknown>,
-      this.resolveInputSchema(table),
-      table._table,
-    );
-    const pendingWrite = this.runtimeTransaction.updatePersisted(id, updates, options);
-    return this.wrapPersistedWrite(
-      pendingWrite as RuntimePersistedWrite<Row | void>,
-      () => undefined,
-    );
-  }
-
   delete<T, Init>(table: TableProxy<T, Init>, id: string): WriteHandle {
     this.ensureActive();
     this.assertOwnsTable(table, "DbTransaction");
     return this.runtimeTransaction.delete(id);
-  }
-
-  deletePersisted<T, Init>(
-    table: TableProxy<T, Init>,
-    id: string,
-    options?: { tier?: DurabilityTier },
-  ): DbPersistedWrite<void> {
-    this.ensureActive();
-    this.assertOwnsTable(table, "DbTransaction");
-    const pendingWrite = this.runtimeTransaction.deletePersisted(id, options);
-    return this.wrapPersistedWrite(
-      pendingWrite as RuntimePersistedWrite<Row | void>,
-      () => undefined,
-    );
   }
 
   async all<T>(query: QueryBuilder<T>, options?: QueryOptions): Promise<T[]> {
@@ -640,18 +578,6 @@ export class DbDirectBatch {
     );
   }
 
-  private wrapPersistedWrite<T>(
-    pendingWrite: RuntimePersistedWrite<Row | void>,
-    transformValue: (value: Row | void) => T,
-  ): DbPersistedWrite<T> {
-    return new DbPersistedWrite(
-      pendingWrite,
-      transformValue,
-      () => this.client.localBatchRecord(pendingWrite.batchId()),
-      () => this.client.acknowledgeRejectedBatch(pendingWrite.batchId()),
-    );
-  }
-
   batchId(): string {
     return this.runtimeBatch.batchId();
   }
@@ -667,22 +593,6 @@ export class DbDirectBatch {
       .mapValue((row) => transformRow(row, table._schema, table._table));
   }
 
-  insertPersisted<T, Init>(
-    table: TableProxy<T, Init>,
-    data: Init,
-    options?: { tier?: DurabilityTier },
-  ): DbPersistedWrite<T> {
-    const values = toInsertRecord(
-      data as Record<string, unknown>,
-      this.resolveInputSchema(table),
-      table._table,
-    );
-    const pendingWrite = this.runtimeBatch.createPersisted(table._table, values, options);
-    return this.wrapPersistedWrite(pendingWrite as RuntimePersistedWrite<Row | void>, (row) =>
-      transformRow(row as Row, table._schema, table._table),
-    );
-  }
-
   update<T, Init>(table: TableProxy<T, Init>, id: string, data: Partial<Init>): WriteHandle {
     const updates = toUpdateRecord(
       data as Record<string, unknown>,
@@ -692,40 +602,9 @@ export class DbDirectBatch {
     return this.runtimeBatch.update(id, updates);
   }
 
-  updatePersisted<T, Init>(
-    table: TableProxy<T, Init>,
-    id: string,
-    data: Partial<Init>,
-    options?: { tier?: DurabilityTier },
-  ): DbPersistedWrite<void> {
-    const updates = toUpdateRecord(
-      data as Record<string, unknown>,
-      this.resolveInputSchema(table),
-      table._table,
-    );
-    const pendingWrite = this.runtimeBatch.updatePersisted(id, updates, options);
-    return this.wrapPersistedWrite(
-      pendingWrite as RuntimePersistedWrite<Row | void>,
-      () => undefined,
-    );
-  }
-
   delete<T, Init>(table: TableProxy<T, Init>, id: string): WriteHandle {
     this.assertOwnsTable(table, "DbDirectBatch");
     return this.runtimeBatch.delete(id);
-  }
-
-  deletePersisted<T, Init>(
-    table: TableProxy<T, Init>,
-    id: string,
-    options?: { tier?: DurabilityTier },
-  ): DbPersistedWrite<void> {
-    this.assertOwnsTable(table, "DbDirectBatch");
-    const pendingWrite = this.runtimeBatch.deletePersisted(id, options);
-    return this.wrapPersistedWrite(
-      pendingWrite as RuntimePersistedWrite<Row | void>,
-      () => undefined,
-    );
   }
 
   localBatchRecord(batchId = this.batchId()): LocalBatchRecord | null {
@@ -2247,45 +2126,6 @@ export class Db {
   }
 
   /**
-   * Insert a new row into a table and wait for durability at the requested tier.
-   *
-   * @param table Table proxy from generated app module
-   * @param data Init object with column values
-   * @param options Durability tier
-   * @returns Promise resolving to the inserted row
-   */
-  async insertDurable<T, Init>(
-    table: TableProxy<T, Init>,
-    data: Init,
-    options: CreateDurabilityOptions,
-  ): Promise<T> {
-    const client = this.getClient(table._schema);
-    const runtimeSchema = createRuntimeSchemaResolver(() =>
-      normalizeRuntimeSchema(client.getSchema()),
-    );
-    const inputSchema = resolveSchemaWithTable(table._schema, runtimeSchema.get, table._table);
-    await this.ensureBridgeReady();
-    const values = toInsertRecord(data as Record<string, unknown>, inputSchema, table._table);
-    const row = await client.createDurable(table._table, values, options);
-    return transformRow(row, table._schema, table._table);
-  }
-
-  insertPersisted<T, Init>(
-    table: TableProxy<T, Init>,
-    data: Init,
-    options?: { tier?: DurabilityTier },
-  ): DbPersistedWrite<T> {
-    const client = this.getClient(table._schema);
-    const values = toInsertRecord(data as Record<string, unknown>, table._schema, table._table);
-    const pendingWrite = client.createPersisted(table._table, values, options);
-    return this.wrapPersistedWrite(
-      client,
-      pendingWrite as RuntimePersistedWrite<Row | void>,
-      (row) => transformRow(row as Row, table._schema, table._table),
-    );
-  }
-
-  /**
    * Create or update a row with a caller-supplied id without waiting for durability.
    */
   upsert<T, Init>(
@@ -2296,24 +2136,6 @@ export class Db {
     const client = this.getClient(table._schema);
     const values = toUpdateRecord(data as Record<string, unknown>, table._schema, table._table);
     return client.upsert(table._table, values, options);
-  }
-
-  /**
-   * Create or update a row with a caller-supplied id and wait for durability.
-   */
-  async upsertDurable<T, Init>(
-    table: TableProxy<T, Init>,
-    data: Partial<Init>,
-    options: UpsertDurabilityOptions,
-  ): Promise<void> {
-    const client = this.getClient(table._schema);
-    const runtimeSchema = createRuntimeSchemaResolver(() =>
-      normalizeRuntimeSchema(client.getSchema()),
-    );
-    const inputSchema = resolveSchemaWithTable(table._schema, runtimeSchema.get, table._table);
-    await this.ensureBridgeReady();
-    const values = toUpdateRecord(data as Record<string, unknown>, inputSchema, table._table);
-    await client.upsertDurable(table._table, values, options);
   }
 
   /**
@@ -2328,41 +2150,6 @@ export class Db {
     const client = this.getClient(table._schema);
     const updates = toUpdateRecord(data as Record<string, unknown>, table._schema, table._table);
     return client.update(id, updates, options);
-  }
-
-  /**
-   * Update an existing row and wait for durability at the requested tier.
-   */
-  async updateDurable<T, Init>(
-    table: TableProxy<T, Init>,
-    id: string,
-    data: Partial<Init>,
-    options?: UpdateDurabilityOptions,
-  ): Promise<void> {
-    const client = this.getClient(table._schema);
-    const runtimeSchema = createRuntimeSchemaResolver(() =>
-      normalizeRuntimeSchema(client.getSchema()),
-    );
-    const inputSchema = resolveSchemaWithTable(table._schema, runtimeSchema.get, table._table);
-    await this.ensureBridgeReady();
-    const updates = toUpdateRecord(data as Record<string, unknown>, inputSchema, table._table);
-    await client.updateDurable(id, updates, options);
-  }
-
-  updatePersisted<T, Init>(
-    table: TableProxy<T, Init>,
-    id: string,
-    data: Partial<Init>,
-    options?: UpdateDurabilityOptions,
-  ): DbPersistedWrite<void> {
-    const client = this.getClient(table._schema);
-    const updates = toUpdateRecord(data as Record<string, unknown>, table._schema, table._table);
-    const pendingWrite = client.updatePersisted(id, updates, options);
-    return this.wrapPersistedWrite(
-      client,
-      pendingWrite as RuntimePersistedWrite<Row | void>,
-      () => undefined,
-    );
   }
 
   /**
@@ -2835,26 +2622,6 @@ class ClientBackedDb extends Db {
       .mapValue((row) => transformRow(row, table._schema, table._table));
   }
 
-  override async insertDurable<T, Init>(
-    table: TableProxy<T, Init>,
-    data: Init,
-    options: CreateDurabilityOptions,
-  ): Promise<T> {
-    const runtimeSchema = createRuntimeSchemaResolver(() =>
-      normalizeRuntimeSchema(this.runtimeClient.getSchema()),
-    );
-    const inputSchema = resolveSchemaWithTable(table._schema, runtimeSchema.get, table._table);
-    const values = toInsertRecord(data as Record<string, unknown>, inputSchema, table._table);
-    const row = await this.runtimeClient.createDurableInternal(
-      table._table,
-      values,
-      this.session,
-      this.attribution,
-      options,
-    );
-    return transformRow(row, table._schema, table._table);
-  }
-
   override upsert<T, Init>(
     table: TableProxy<T, Init>,
     data: Partial<Init>,
@@ -2872,50 +2639,6 @@ class ClientBackedDb extends Db {
       this.session,
       this.attribution,
       options.updatedAt,
-    );
-  }
-
-  override async upsertDurable<T, Init>(
-    table: TableProxy<T, Init>,
-    data: Partial<Init>,
-    options: UpsertDurabilityOptions,
-  ): Promise<void> {
-    const runtimeSchema = createRuntimeSchemaResolver(() =>
-      normalizeRuntimeSchema(this.runtimeClient.getSchema()),
-    );
-    const inputSchema = resolveSchemaWithTable(table._schema, runtimeSchema.get, table._table);
-    const values = toUpdateRecord(data as Record<string, unknown>, inputSchema, table._table);
-    await this.runtimeClient.upsertDurableInternal(
-      table._table,
-      values,
-      options.id,
-      this.session,
-      this.attribution,
-      options,
-    );
-  }
-
-  override insertPersisted<T, Init>(
-    table: TableProxy<T, Init>,
-    data: Init,
-    options?: { tier?: DurabilityTier },
-  ): DbPersistedWrite<T> {
-    const runtimeSchema = createRuntimeSchemaResolver(() =>
-      normalizeRuntimeSchema(this.runtimeClient.getSchema()),
-    );
-    const inputSchema = resolveSchemaWithTable(table._schema, runtimeSchema.get, table._table);
-    const values = toInsertRecord(data as Record<string, unknown>, inputSchema, table._table);
-    const pendingWrite = this.runtimeClient.createPersistedInternal(
-      table._table,
-      values,
-      this.session,
-      this.attribution,
-      options,
-    );
-    return this.wrapPersistedWrite(
-      this.runtimeClient,
-      pendingWrite as RuntimePersistedWrite<Row | void>,
-      (row) => transformRow(row as Row, table._schema, table._table),
     );
   }
 
@@ -2937,54 +2660,6 @@ class ClientBackedDb extends Db {
       this.attribution,
       undefined,
       options?.updatedAt,
-    );
-  }
-
-  override async updateDurable<T, Init>(
-    table: TableProxy<T, Init>,
-    id: string,
-    data: Partial<Init>,
-    options?: UpdateDurabilityOptions,
-  ): Promise<void> {
-    const runtimeSchema = createRuntimeSchemaResolver(() =>
-      normalizeRuntimeSchema(this.runtimeClient.getSchema()),
-    );
-    const inputSchema = resolveSchemaWithTable(table._schema, runtimeSchema.get, table._table);
-    const updates = toUpdateRecord(data as Record<string, unknown>, inputSchema, table._table);
-    await this.runtimeClient.updateDurableInternal(
-      id,
-      updates,
-      this.session,
-      this.attribution,
-      options,
-      options?.updatedAt,
-    );
-  }
-
-  override updatePersisted<T, Init>(
-    table: TableProxy<T, Init>,
-    id: string,
-    data: Partial<Init>,
-    options?: UpdateDurabilityOptions,
-  ): DbPersistedWrite<void> {
-    const runtimeSchema = createRuntimeSchemaResolver(() =>
-      normalizeRuntimeSchema(this.runtimeClient.getSchema()),
-    );
-    const inputSchema = resolveSchemaWithTable(table._schema, runtimeSchema.get, table._table);
-    const updates = toUpdateRecord(data as Record<string, unknown>, inputSchema, table._table);
-    const pendingWrite = this.runtimeClient.updatePersistedInternal(
-      id,
-      updates,
-      this.session,
-      this.attribution,
-      options,
-      undefined,
-      options?.updatedAt,
-    );
-    return this.wrapPersistedWrite(
-      this.runtimeClient,
-      pendingWrite as RuntimePersistedWrite<Row | void>,
-      () => undefined,
     );
   }
 


### PR DESCRIPTION
## Description

The changes from https://github.com/garden-co/jazz2/pull/594/ were partially reverted by a botched merge/rebase. Unifying the write API again.