### PR TITLE
fix(jazz-tools): share OPFS namespace across anonymous sessions

### DIFF
--- a/packages/jazz-tools/src/runtime/db.browser-storage-scope.test.ts
+++ b/packages/jazz-tools/src/runtime/db.browser-storage-scope.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { resolveDefaultPersistentDbName, type DbConfig } from "./db.js";
+import { ANONYMOUS_JWT_ISSUER, LOCAL_FIRST_JWT_ISSUER } from "./client-session.js";
 
 function toBase64Url(value: unknown): string {
   return Buffer.from(JSON.stringify(value), "utf8")
@@ -51,5 +52,25 @@ describe("resolveDefaultPersistentDbName", () => {
     };
 
     expect(resolveDefaultPersistentDbName(config)).toBe("chat-app");
+  });
+
+  it("does not scope by user_id for anonymous sessions", () => {
+    const config: DbConfig = {
+      appId: "chat-app",
+      driver: { type: "persistent" },
+      jwtToken: makeJwt({ sub: "ephemeral-pubkey", iss: ANONYMOUS_JWT_ISSUER }),
+    };
+
+    expect(resolveDefaultPersistentDbName(config)).toBe("chat-app");
+  });
+
+  it("scopes by user_id for local-first sessions", () => {
+    const config: DbConfig = {
+      appId: "chat-app",
+      driver: { type: "persistent" },
+      jwtToken: makeJwt({ sub: "stable-pubkey", iss: LOCAL_FIRST_JWT_ISSUER }),
+    };
+
+    expect(resolveDefaultPersistentDbName(config)).toBe("chat-app::stable-pubkey");
   });
 });

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -160,16 +160,16 @@ export function resolveDefaultPersistentDbName(config: DbConfig): string {
     return explicitDbName;
   }
 
-  const sessionUserId = resolveClientSessionSync({
+  const session = resolveClientSessionSync({
     appId: config.appId,
     jwtToken: config.jwtToken,
-  })?.user_id;
+  });
 
-  if (!sessionUserId) {
+  if (!session?.user_id || session.authMode === "anonymous") {
     return config.appId;
   }
 
-  return `${config.appId}::${encodeURIComponent(sessionUserId)}`;
+  return `${config.appId}::${encodeURIComponent(session.user_id)}`;
 }
 
 /**
@@ -3179,6 +3179,8 @@ export async function createDb(config: DbConfig): Promise<Db> {
     throw new Error("driver.type='memory' requires serverUrl.");
   }
 
+  logAuthModeInDev(resolvedConfig);
+
   let db: Db;
   if (isBrowser() && driver.type === "persistent") {
     db = await Db.createWithWorker(resolvedConfig);
@@ -3191,6 +3193,23 @@ export async function createDb(config: DbConfig): Promise<Db> {
   }
 
   return db;
+}
+
+function logAuthModeInDev(config: DbConfig): void {
+  if (config.env === "prod") return;
+  const session = resolveClientSessionSync({
+    appId: config.appId,
+    jwtToken: config.jwtToken,
+    cookieSession: config.cookieSession,
+  });
+  const authMode = session?.authMode ?? "anonymous";
+  const description =
+    authMode === "anonymous"
+      ? "anonymous — ephemeral identity, no write permissions on synced data"
+      : authMode === "local-first"
+        ? "local-first — identity persisted locally via secret"
+        : "external — identity issued by an auth provider";
+  console.info(`[jazz] auth mode: ${authMode} (${description})`);
 }
 
 export function createDbFromClient(


### PR DESCRIPTION
## Summary

- When \`DbConfig\` has no \`secret\`/\`jwtToken\`/\`cookieSession\`, \`createDb\` mints an anonymous JWT with a fresh ephemeral seed on every call. \`resolveDefaultPersistentDbName\` then used that JWT's \`user_id\` as the OPFS namespace suffix, so every page refresh created a new namespace and orphaned the previous one — a local-only app configured with only \`{ appId }\` appeared to lose its data on reload.
- Fix: skip the \`user_id\` suffix when \`session.authMode === "anonymous"\`, so all anonymous sessions on an origin share a single OPFS namespace. Scoping by \`user_id\` still applies for \`local-first\` and \`external\` sessions, where the identity is stable and two logged-in accounts on the same device must not collide.
- Also log the resolved auth mode via \`console.info\` during startup (suppressed when \`config.env === "prod"\`) so developers can see the active identity model at a glance:
  - \`anonymous — ephemeral identity, no write permissions on synced data\`
  - \`local-first — identity persisted locally via secret\`
  - \`external — identity issued by an auth provider\`

## Reproduction

With this provider config:

\`\`\`tsx
<JazzProvider config={{ appId: "019daf1e-cc4d-7d62-b95a-51474859896d" }}>
\`\`\`

**Before:** adding a todo, then reloading, writes a new OPFS file \`<appId>::<new-ephemeral-uuid>.opfsbtree\` on every reload; the todo list is empty.

**After:** a single OPFS file \`<appId>.opfsbtree\` is reused; the todo survives reload.

## Test plan

- [x] \`pnpm exec vitest run src/runtime/db.browser-storage-scope.test.ts\` — 6/6 passing, including two new cases:
  - \`does not scope by user_id for anonymous sessions\` (locks in the fix)
  - \`scopes by user_id for local-first sessions\` (guards authenticated scoping)
- [x] Manual reproduction in the \`react-localfirst\` starter via Playwright: todo persists across reload; console shows \`[jazz] auth mode: anonymous (…)\`.

## Notes

- Pre-existing \`<appId>::<ephemeral-uuid>.opfsbtree\` files from earlier sessions remain on disk as orphans. Out of scope here; happy to follow up with one-time startup cleanup if useful.