### PR TITLE
Document local-first auth recovery options

### DIFF
--- a/docs/content/docs/auth/local-first-auth.mdx
+++ b/docs/content/docs/auth/local-first-auth.mdx
@@ -21,9 +21,95 @@ Use `useLocalFirstAuth()` to manage the user's secret. On first load it generate
 
 <Callout type="warn">
   The secret is the user's identity. If it's lost (e.g. `localStorage` cleared), the identity is
-  gone and any data owned by that user becomes inaccessible. For durable identity, upgrade to an
-  external provider.
+  gone and any data owned by that user becomes inaccessible unless you restore it from a recovery
+  passphrase, a passkey backup, or an external provider you linked earlier.
 </Callout>
+
+## Backing up and restoring the secret
+
+You can keep local-first auth fully serverless and still make it recoverable. Jazz ships two backup
+helpers for the same 32-byte secret:
+
+| Method                      | Platforms     | Best for                                       | Trade-offs                                           |
+| --------------------------- | ------------- | ---------------------------------------------- | ---------------------------------------------------- |
+| `jazz-tools/passphrase`     | Browser, Expo | Manual backup users can carry anywhere         | User must safely store a 24-word recovery passphrase |
+| `jazz-tools/passkey-backup` | Browser only  | Fast recovery on devices that support passkeys | Requires WebAuthn and a stable relying-party ID      |
+
+### Recovery passphrase
+
+`jazz-tools/passphrase` converts the local-first secret into a 24-word English recovery
+passphrase. Restoring that passphrase produces the exact same secret, so the user keeps the same
+Jazz identity.
+
+<Tabs groupId="local-first-recovery-platform" persist updateAnchor items={["React", "Expo"]}>
+  <Tab value="React">
+    <include cwd lang="tsx" meta='title="auth-snippets.tsx"'>
+      ../examples/docs/todo-client-localfirst-react/src/auth-snippets.tsx#auth-localfirst-react-backup
+    </include>
+  </Tab>
+  <Tab value="Expo">
+    <include cwd lang="tsx" meta='title="auth-snippets.tsx"'>
+      ../examples/docs/todo-client-localfirst-expo/src/auth-snippets.tsx#auth-localfirst-expo-backup
+    </include>
+  </Tab>
+</Tabs>
+
+To restore, decode the user-provided passphrase back into a secret and hand it back to your
+local-first auth flow:
+
+<Tabs
+  groupId="local-first-recovery-restore-platform"
+  persist
+  updateAnchor
+  items={["React", "Expo"]}
+>
+  <Tab value="React">
+    <include cwd lang="tsx" meta='title="auth-snippets.tsx"'>
+      ../examples/docs/todo-client-localfirst-react/src/auth-snippets.tsx#auth-localfirst-react-restore
+    </include>
+  </Tab>
+  <Tab value="Expo">
+    <include cwd lang="tsx" meta='title="auth-snippets.tsx"'>
+      ../examples/docs/todo-client-localfirst-expo/src/auth-snippets.tsx#auth-localfirst-expo-restore
+    </include>
+  </Tab>
+</Tabs>
+
+The parser accepts upper-case input and extra whitespace. Invalid input throws
+`RecoveryPhraseError` with codes like `invalid-length`, `invalid-word`, and
+`invalid-checksum`.
+
+<Callout type="info">
+  In React, prefer `useLocalFirstAuth()` for backup and restore so the mounted `JazzProvider`
+  updates immediately. The lower-level `BrowserAuthSecretStore` and `ExpoAuthSecretStore` APIs are
+  still useful outside React.
+</Callout>
+
+### Passkey backup
+
+For browser apps, `jazz-tools/passkey-backup` stores the same secret in a resident WebAuthn
+credential. That gives users passkey-style recovery without adding a server-side auth provider.
+
+Create the passkey from the current local-first secret:
+
+<include cwd lang="tsx" meta='title="auth-snippets.tsx"'>
+  ../examples/docs/todo-client-localfirst-react/src/auth-snippets.tsx#auth-localfirst-react-passkey-backup
+</include>
+
+Restore from the passkey by reading the secret back and passing it to `login(...)` from
+`useLocalFirstAuth()`:
+
+<include cwd lang="tsx" meta='title="auth-snippets.tsx"'>
+  ../examples/docs/todo-client-localfirst-react/src/auth-snippets.tsx#auth-localfirst-react-passkey-restore
+</include>
+
+Use a stable `appHostname` everywhere you want passkey recovery to work. It becomes the WebAuthn
+relying-party ID, so changing it creates a different passkey namespace. `backup(secret,
+displayName)` also needs a user-visible name for the platform passkey sheet.
+
+Handle `PasskeyBackupError` in your UI to surface cases like unsupported browsers, no saved
+credential, or missing user verification. Keep a recovery passphrase or external sign-in as a
+fallback if the user might lose access to their passkey provider.
 
 ## Server configuration
 

--- a/docs/content/docs/auth/local-first-auth.mdx
+++ b/docs/content/docs/auth/local-first-auth.mdx
@@ -80,9 +80,9 @@ The parser accepts upper-case input and extra whitespace. Invalid input throws
 `invalid-checksum`.
 
 <Callout type="info">
-  In React, prefer `useLocalFirstAuth()` for backup and restore so the mounted `JazzProvider`
-  updates immediately. The lower-level `BrowserAuthSecretStore` and `ExpoAuthSecretStore` APIs are
-  still useful outside React.
+  In React and Expo, prefer `useLocalFirstAuth()` for backup and restore so the mounted
+  `JazzProvider` updates immediately. The lower-level `BrowserAuthSecretStore` and
+  `ExpoAuthSecretStore` APIs are still useful outside React-based UIs.
 </Callout>
 
 ### Passkey backup

--- a/docs/content/docs/getting-started/client-setup.mdx
+++ b/docs/content/docs/getting-started/client-setup.mdx
@@ -10,7 +10,7 @@ import CreateJazzClientReference from "../../partials/create-jazz-client-referen
 
 ## Zero-config client setup
 
-Every client needs an `appId`. Add a `serverUrl` to enable sync. For login and authentication options, see [Authentication](/docs/auth/authentication).
+Every client needs an `appId` and a `secret` for [local-first auth](/docs/auth/local-first-auth). Without `secret`, the client runs in anonymous mode and every write is rejected with `AnonymousWriteDeniedError`. Add a `serverUrl` to enable sync. For the full auth matrix (anonymous, local-first, external JWT), see [Authentication](/docs/auth/authentication).
 
 <Tabs
   groupId="jazz-framework"
@@ -20,32 +20,94 @@ Every client needs an `appId`. Add a `serverUrl` to enable sync. For login and a
 >
   <Tab value="React">
     <include cwd lang="tsx" meta='title="App.tsx"'>
-      ../examples/docs/todo-client-localfirst-react/src/setup-snippets.tsx#context-setup-react-minimal
+      ../examples/docs/todo-client-localfirst-react/src/auth-snippets.tsx#auth-localfirst-react
     </include>
+
+    `useLocalFirstAuth()` from `jazz-tools/react` loads the device secret (or generates one on first run) and exposes `login` / `signOut` for switching identity.
+
   </Tab>
   <Tab value="Vue">
-    <include cwd lang="vue" meta='title="App.vue"'>
-      ../examples/docs/todo-client-localfirst-vue/src/App.vue
-    </include>
+    ```vue title="App.vue"
+    <script setup lang="ts">
+    import { createJazzClient, JazzProvider } from "jazz-tools/vue";
+    import { BrowserAuthSecretStore } from "jazz-tools";
+    import TodoList from "./TodoList.vue";
+
+    const secret = await BrowserAuthSecretStore.getOrCreateSecret();
+
+    const client = createJazzClient({
+      appId: "<your-app-id>",
+      secret,
+    });
+    </script>
+
+    <template>
+      <JazzProvider :client="client">
+        <h1>Todos</h1>
+        <TodoList />
+      </JazzProvider>
+    </template>
+    ```
+
   </Tab>
   <Tab value="Svelte">
-    <include cwd lang="svelte" meta='title="App.svelte"'>
-      ../examples/docs/todo-client-localfirst-svelte/src/App.svelte#provider-svelte
-    </include>
+    ```svelte title="App.svelte"
+    <script lang="ts">
+      import {
+        createJazzClient,
+        JazzSvelteProvider,
+        BrowserAuthSecretStore,
+      } from 'jazz-tools/svelte';
+      import TodoList from './TodoList.svelte';
+
+      let client = $state<ReturnType<typeof createJazzClient> | null>(null);
+
+      BrowserAuthSecretStore.getOrCreateSecret().then((secret) => {
+        client = createJazzClient({ appId: '<your-app-id>', secret });
+      });
+    </script>
+
+    {#if client}
+      <JazzSvelteProvider {client}>
+        {#snippet children()}
+          <h1>Todos</h1>
+          <TodoList />
+        {/snippet}
+        {#snippet fallback()}
+          <p>Loading...</p>
+        {/snippet}
+      </JazzSvelteProvider>
+    {/if}
+    ```
+
   </Tab>
   <Tab value="Expo">
     <include cwd lang="tsx" meta='title="App.tsx"'>
-      ../examples/docs/todo-client-localfirst-expo/src/setup-snippets.tsx#context-setup-expo-minimal
+      ../examples/docs/todo-client-localfirst-expo/src/auth-snippets.tsx#auth-localfirst-expo
     </include>
+
+    `ExpoAuthSecretStore` persists the secret in the device's secure storage. Or use `useLocalFirstAuth()` from `jazz-tools/expo` for a hook-based API.
+
   </Tab>
   <Tab value="TypeScript">
     <include cwd lang="ts" meta='title="app.ts"'>
-      ../examples/docs/todo-client-localfirst-ts/src/main.ts#context-setup-ts-client
+      ../examples/docs/todo-client-localfirst-ts/src/auth-snippets.ts#auth-localfirst-ts
     </include>
   </Tab>
 </Tabs>
 
-Without auth configuration, Jazz creates a local-first identity automatically. To use Jazz completely offline, don't set a `serverUrl`.
+The secret is generated on first load, persisted locally (`localStorage` in the browser, secure storage on Expo), and reused on every subsequent run — the same device keeps the same Jazz identity.
+
+<Callout type="info">
+  Using Jazz completely offline? Leave out `serverUrl` and everything above still works — writes
+  stay on the device until a server is reachable.
+</Callout>
+
+<Callout type="warn">
+  The local-first secret **is** the user's identity. If it's lost (e.g. cleared `localStorage`), the
+  identity is gone and any data owned by that user becomes inaccessible. Plan for recovery with
+  [backup and restore](/docs/auth/local-first-auth#backing-up-and-restoring-the-secret).
+</Callout>
 
 <Accordions type="single">
 <Accordion title="Zero config not working?">
@@ -64,6 +126,136 @@ For React Native and Expo clients, make sure `serverUrl` points to a host your r
 ### Storage driver
 
 Browser clients default to `driver: { type: "persistent" }`, which stores data locally for offline support. Set `driver: { type: "memory" }` to keep data in memory only. This option requires you to set a `serverUrl` since nothing is saved locally.
+
+## Dev plugins
+
+Jazz ships bundler plugins that remove boilerplate in development. They start a local Jazz dev server, watch `schema.ts` and `permissions.ts`, auto-push both on change, and inject the app ID and server URL as framework-appropriate env vars so `createJazzClient({ appId, serverUrl })` picks them up without any manual wiring.
+
+<Tabs
+  groupId="jazz-framework"
+  items={["React (Vite)", "Vue (Vite)", "Svelte (Vite)", "SvelteKit", "Next.js", "Expo"]}
+  persist
+  updateAnchor
+>
+  <Tab value="React (Vite)">
+    ```ts title="vite.config.ts"
+    import { defineConfig } from "vite";
+    import react from "@vitejs/plugin-react";
+    import { jazzPlugin } from "jazz-tools/dev/vite";
+
+    export default defineConfig({
+      plugins: [react(), jazzPlugin()],
+    });
+    ```
+
+    Injects `VITE_JAZZ_APP_ID` and `VITE_JAZZ_SERVER_URL` into `import.meta.env`.
+
+  </Tab>
+  <Tab value="Vue (Vite)">
+    ```ts title="vite.config.ts"
+    import { defineConfig } from "vite";
+    import vue from "@vitejs/plugin-vue";
+    import { jazzPlugin } from "jazz-tools/dev/vite";
+
+    export default defineConfig({
+      plugins: [vue(), jazzPlugin()],
+    });
+    ```
+
+    Injects `VITE_JAZZ_APP_ID` and `VITE_JAZZ_SERVER_URL` into `import.meta.env`.
+
+  </Tab>
+  <Tab value="Svelte (Vite)">
+    ```ts title="vite.config.ts"
+    import { defineConfig } from "vite";
+    import { svelte } from "@sveltejs/vite-plugin-svelte";
+    import { jazzSvelteKit } from "jazz-tools/dev/sveltekit";
+
+    export default defineConfig({
+      plugins: [svelte(), jazzSvelteKit()],
+    });
+    ```
+
+    Injects `PUBLIC_JAZZ_APP_ID` and `PUBLIC_JAZZ_SERVER_URL`. Use `jazzSvelteKit` for both Vite+Svelte and SvelteKit projects.
+
+  </Tab>
+  <Tab value="SvelteKit">
+    ```ts title="vite.config.ts"
+    import { sveltekit } from "@sveltejs/kit/vite";
+    import { jazzSvelteKit } from "jazz-tools/dev/sveltekit";
+    import { defineConfig } from "vite";
+
+    export default defineConfig({
+      // jazzSvelteKit must come before sveltekit so it populates
+      // process.env before SvelteKit captures $env/dynamic/public.
+      plugins: [jazzSvelteKit(), sveltekit()],
+    });
+    ```
+
+    Defaults `schemaDir` to `src/lib/`. Injects `PUBLIC_JAZZ_APP_ID` and `PUBLIC_JAZZ_SERVER_URL`.
+
+  </Tab>
+  <Tab value="Next.js">
+    ```ts title="next.config.ts"
+    import { withJazz } from "jazz-tools/dev/next";
+
+    export default withJazz({});
+    ```
+
+    Injects `NEXT_PUBLIC_JAZZ_APP_ID` and `NEXT_PUBLIC_JAZZ_SERVER_URL`. Only runs in the Next.js dev phase; production builds are untouched.
+
+  </Tab>
+  <Tab value="Expo">
+    ```js title="metro.config.js"
+    import { getDefaultConfig } from "expo/metro-config";
+    import { withJazz } from "jazz-tools/dev/expo";
+
+    const config = getDefaultConfig(__dirname);
+
+    await withJazz(config, { schemaDir: __dirname });
+
+    export default config;
+    ```
+
+    Injects `EXPO_PUBLIC_JAZZ_APP_ID` and `EXPO_PUBLIC_JAZZ_SERVER_URL` via `expoConfig.extra`. Skipped automatically when `NODE_ENV=production`.
+
+  </Tab>
+</Tabs>
+
+On first run the plugin generates an app ID, persists it to `.env`, and starts a local Jazz server under `node_modules/.cache/jazz-dev-server/`. Every subsequent run reuses both.
+
+### Plugin options
+
+All plugins accept the same base options:
+
+| Option        | Description                                                                                                                                                                       |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `server`      | `true` (default) starts an embedded local server. `false` disables the plugin. A URL string connects to an existing server. An object configures the embedded server (see below). |
+| `schemaDir`   | Directory containing `schema.ts` and `permissions.ts`. Defaults to the project root, or `src/lib/` for SvelteKit.                                                                 |
+| `appId`       | Override the app ID. Defaults to the value in `.env`, otherwise a generated UUID persisted on first run.                                                                          |
+| `adminSecret` | Required when `server` is a URL. Ignored for the embedded server (a random secret is generated).                                                                                  |
+
+When `server` is an object, the embedded server accepts: `port` (default: random), `dataDir` (default: `node_modules/.cache/jazz-dev-server`), `inMemory`, `allowLocalFirstAuth`, `jwksUrl`, and the catalogue authority forwarding fields. See [Server Setup](/docs/getting-started/server-setup) for the full semantics.
+
+### Connecting to an existing server
+
+Pass a URL to point the plugin at a server you already run — hosted cloud, staging, or a shared self-hosted instance. You must also provide `adminSecret` (or set `JAZZ_ADMIN_SECRET`) so the plugin can push schema and permissions.
+
+```ts title="vite.config.ts"
+jazzPlugin({
+  server: "https://my-jazz-server.example.com",
+  adminSecret: process.env.JAZZ_ADMIN_SECRET,
+  appId: process.env.VITE_JAZZ_APP_ID,
+});
+```
+
+### What auto-pushes
+
+On startup and on every change to `schema.ts` or `permissions.ts`, the plugin publishes the current structural schema and permissions bundle to the server. Structural schema push works without an admin secret in development, so a bare `schema.ts` edit is enough to see clients pick up the new shape. Permission pushes use the server's admin secret (generated for the embedded server, supplied by you for a remote server).
+
+<Callout type="warn">
+  Auto-push covers the development loop. For production — or any change that needs a schema migration — run `pnpm dlx jazz-tools@alpha deploy <appId>` to publish the migration, the new schema, and the current permissions in one step. See [Migrations](/docs/schemas/migrations).
+</Callout>
 
 ## Runtime source overrides
 

--- a/docs/lib/presentation-deck.test.ts
+++ b/docs/lib/presentation-deck.test.ts
@@ -4,7 +4,7 @@ import {
   estimatePresentationSpeakingDurationSeconds,
   parsePresentationSlidesFromMdx,
   resolvePresentationSlideIdentity,
-} from "./presentation-deck.ts";
+} from "./presentation-deck.js";
 
 test("parses slide order from the MDX file in source order", () => {
   const slides = parsePresentationSlidesFromMdx(

--- a/examples/docs/todo-client-localfirst-expo/src/auth-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-expo/src/auth-snippets.tsx
@@ -2,6 +2,7 @@ import { Text, View } from "react-native";
 import { JazzProvider } from "jazz-tools/react-native";
 import { use } from "react";
 import { ExpoAuthSecretStore } from "jazz-tools/expo";
+import { RecoveryPhrase } from "jazz-tools/passphrase";
 
 function TodoApp() {
   return null;
@@ -31,14 +32,12 @@ export function LocalFirstAuthExpoApp() {
 export async function getRecoveryPhraseForBackup(): Promise<string | null> {
   const secret = await ExpoAuthSecretStore.loadSecret();
   if (!secret) return null;
-  const { RecoveryPhrase } = await import("jazz-tools/passphrase");
   return RecoveryPhrase.fromSecret(secret);
 }
 // #endregion auth-localfirst-expo-backup
 
 // #region auth-localfirst-expo-restore
 export async function restoreFromRecoveryPhrase(userInput: string): Promise<void> {
-  const { RecoveryPhrase } = await import("jazz-tools/passphrase");
   const secret = RecoveryPhrase.toSecret(userInput);
   await ExpoAuthSecretStore.saveSecret(secret);
 }

--- a/examples/docs/todo-client-localfirst-expo/src/auth-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-expo/src/auth-snippets.tsx
@@ -1,7 +1,6 @@
 import { Text, View } from "react-native";
 import { JazzProvider } from "jazz-tools/react-native";
-import { use } from "react";
-import { ExpoAuthSecretStore } from "jazz-tools/expo";
+import { useLocalFirstAuth } from "jazz-tools/expo";
 import { RecoveryPhrase } from "jazz-tools/passphrase";
 
 function TodoApp() {
@@ -10,7 +9,9 @@ function TodoApp() {
 
 // #region auth-localfirst-expo
 export function LocalFirstAuthExpoApp() {
-  const secret = use(ExpoAuthSecretStore.getOrCreateSecret());
+  const { secret, isLoading } = useLocalFirstAuth();
+
+  if (isLoading || !secret) return null;
 
   return (
     <JazzProvider
@@ -29,16 +30,26 @@ export function LocalFirstAuthExpoApp() {
 // #endregion auth-localfirst-expo
 
 // #region auth-localfirst-expo-backup
-export async function getRecoveryPhraseForBackup(): Promise<string | null> {
-  const secret = await ExpoAuthSecretStore.loadSecret();
-  if (!secret) return null;
-  return RecoveryPhrase.fromSecret(secret);
+export function useRecoveryPhraseBackup(): {
+  isLoading: boolean;
+  recoveryPhrase: string | null;
+} {
+  const { secret, isLoading } = useLocalFirstAuth();
+
+  return {
+    isLoading,
+    recoveryPhrase: secret ? RecoveryPhrase.fromSecret(secret) : null,
+  };
 }
 // #endregion auth-localfirst-expo-backup
 
 // #region auth-localfirst-expo-restore
-export async function restoreFromRecoveryPhrase(userInput: string): Promise<void> {
-  const secret = RecoveryPhrase.toSecret(userInput);
-  await ExpoAuthSecretStore.saveSecret(secret);
+export function useRecoveryPhraseRestore(): (userInput: string) => Promise<void> {
+  const { login } = useLocalFirstAuth();
+
+  return async (userInput: string) => {
+    const restoredSecret = RecoveryPhrase.toSecret(userInput);
+    await login(restoredSecret);
+  };
 }
 // #endregion auth-localfirst-expo-restore

--- a/examples/docs/todo-client-localfirst-react/src/auth-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/auth-snippets.tsx
@@ -1,9 +1,15 @@
-import { BrowserAuthSecretStore } from "jazz-tools";
+import { BrowserPasskeyBackup } from "jazz-tools/passkey-backup";
+import { RecoveryPhrase } from "jazz-tools/passphrase";
 import { JazzProvider, useLocalFirstAuth } from "jazz-tools/react";
 
 function TodoApp() {
   return null;
 }
+
+const passkeyBackup = new BrowserPasskeyBackup({
+  appName: "My App",
+  appHostname: "myapp.com",
+});
 
 // #region auth-localfirst-react
 export function LocalFirstAuthApp() {
@@ -41,35 +47,57 @@ export function JwtAuthApp() {
 // #endregion auth-jwt-react
 
 // #region auth-localfirst-react-backup
-export async function getRecoveryPhraseForBackup(): Promise<string | null> {
-  const secret = await BrowserAuthSecretStore.loadSecret({ appId: "my-app" });
-  if (!secret) return null;
-  const { RecoveryPhrase } = await import("jazz-tools/passphrase");
-  return RecoveryPhrase.fromSecret(secret);
+export function useRecoveryPhraseBackup(): {
+  isLoading: boolean;
+  recoveryPhrase: string | null;
+} {
+  const { secret, isLoading } = useLocalFirstAuth();
+
+  return {
+    isLoading,
+    recoveryPhrase: secret ? RecoveryPhrase.fromSecret(secret) : null,
+  };
 }
 // #endregion auth-localfirst-react-backup
 
 // #region auth-localfirst-react-restore
-export async function restoreFromRecoveryPhrase(userInput: string): Promise<void> {
-  const { RecoveryPhrase } = await import("jazz-tools/passphrase");
-  const secret = RecoveryPhrase.toSecret(userInput);
-  await BrowserAuthSecretStore.saveSecret(secret, { appId: "my-app" });
+export function useRecoveryPhraseRestore(): (userInput: string) => Promise<void> {
+  const { login } = useLocalFirstAuth();
+
+  return async (userInput: string) => {
+    const restoredSecret = RecoveryPhrase.toSecret(userInput);
+    await login(restoredSecret);
+  };
 }
 // #endregion auth-localfirst-react-restore
 
 // #region auth-localfirst-react-passkey-backup
-export async function backupWithPasskey(secret: string): Promise<void> {
-  const { BrowserPasskeyBackup } = await import("jazz-tools/passkey-backup");
-  const pb = new BrowserPasskeyBackup({ appName: "My App", appHostname: "myapp.com" });
-  await pb.backup(secret);
+export function usePasskeyBackup(): {
+  isLoading: boolean;
+  backupWithPasskey: (displayName: string) => Promise<void>;
+} {
+  const { secret, isLoading } = useLocalFirstAuth();
+
+  return {
+    isLoading,
+    backupWithPasskey: async (displayName: string) => {
+      if (!secret) {
+        throw new Error("Local-first secret is not ready yet");
+      }
+
+      await passkeyBackup.backup(secret, displayName);
+    },
+  };
 }
 // #endregion auth-localfirst-react-passkey-backup
 
 // #region auth-localfirst-react-passkey-restore
-export async function restoreWithPasskey(): Promise<void> {
-  const { BrowserPasskeyBackup } = await import("jazz-tools/passkey-backup");
-  const pb = new BrowserPasskeyBackup({ appName: "My App", appHostname: "myapp.com" });
-  const secret = await pb.restore();
-  await BrowserAuthSecretStore.saveSecret(secret, { appId: "my-app" });
+export function usePasskeyRestore(): () => Promise<void> {
+  const { login } = useLocalFirstAuth();
+
+  return async () => {
+    const restoredSecret = await passkeyBackup.restore();
+    await login(restoredSecret);
+  };
 }
 // #endregion auth-localfirst-react-passkey-restore

--- a/examples/docs/todo-client-localfirst-react/tests/browser/auth-snippets.test.tsx
+++ b/examples/docs/todo-client-localfirst-react/tests/browser/auth-snippets.test.tsx
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { usePasskeyBackup } from "../../src/auth-snippets.js";
+
+function PasskeyBackupProbe(props: {
+  onRender: (value: ReturnType<typeof usePasskeyBackup>) => void;
+}) {
+  props.onRender(usePasskeyBackup());
+  return null;
+}
+
+describe("usePasskeyBackup", () => {
+  let root: Root | null = null;
+  let container: HTMLDivElement | null = null;
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root!.unmount();
+      });
+    }
+
+    container?.remove();
+    root = null;
+    container = null;
+  });
+
+  it("always returns a callable backup function", async () => {
+    let latest: ReturnType<typeof usePasskeyBackup> | null = null;
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(
+        <PasskeyBackupProbe
+          onRender={(value) => {
+            latest = value;
+          }}
+        />,
+      );
+    });
+
+    expect(latest).not.toBeNull();
+    expect(typeof latest!.backupWithPasskey).toBe("function");
+  });
+});


### PR DESCRIPTION
## Summary
- document passphrase and passkey recovery for local-first auth, including when to use each and how restore works
- switch the React recovery examples to static imports and `useLocalFirstAuth()`-driven backup and restore flows
- make `usePasskeyBackup().backupWithPasskey` non-nullable, add a focused browser test for that contract, and fix a docs test import so `docs` typecheck passes again
- rework the Client Setup zero-config section to wire local-first auth into every framework tab, so starter snippets can actually write (no more silent `AnonymousWriteDeniedError`)
- add a Dev plugins section to Client Setup covering `jazz-tools/dev/{vite,sveltekit,next,expo}`: per-framework config, shared options, remote-server wiring, and what the plugin auto-pushes on `schema.ts` / `permissions.ts` changes

Docs:
- https://jazz2-docs-git-codex-local-first-auth-recovery-docs-garden-co.vercel.app/docs/auth/local-first-auth#backing-up-and-restoring-the-secret
- https://jazz2-docs-git-codex-local-first-auth-recovery-docs-garden-co.vercel.app/docs/getting-started/client-setup