### PR TITLE
docs: update better-auth adapter guide for merged schema pattern

### DIFF
--- a/docs/content/docs/guides/better-auth-adapter.mdx
+++ b/docs/content/docs/guides/better-auth-adapter.mdx
@@ -6,15 +6,52 @@ reviewedAt: "22485728"
 
 The Jazz Better Auth adapter lets Better Auth store its tables in Jazz. For general Better Auth setup (route handlers, client, plugins), see the [Better Auth documentation](https://www.better-auth.com/docs).
 
+## Schema Workflow
+
+Better Auth tables live in a generated `schema-better-auth/` module that your app schema spreads into its own table map. This keeps Better Auth's tables in the same Jazz app as your own data, so a single backend context handles both.
+
+```bash
+# Generate the Better Auth schema module into schema-better-auth/
+npx @better-auth/cli@latest generate \
+  --config ./src/lib/auth.ts \
+  --output ./schema-better-auth/schema.ts
+
+# Validate the generated schema source alongside your own
+pnpm dlx jazz-tools@alpha validate
+```
+
+Import the generated tables in your app's `schema.ts` and merge them into the app definition:
+
+```ts title="schema.ts"
+import { schema as s } from "jazz-tools";
+import { schema as betterauthSchema } from "./schema-better-auth/schema";
+
+const schema = {
+  ...betterauthSchema,
+  messages: s.table({
+    author_name: s.string(),
+    chat_id: s.string(),
+    text: s.string(),
+    sent_at: s.timestamp(),
+  }),
+  // ...your own tables
+};
+
+type AppSchema = s.Schema<typeof schema>;
+export const app: s.App<AppSchema> = s.defineApp(schema);
+```
+
+The generated `schema-better-auth/schema.ts` also ships a `permissions` export that denies all operations on the Better Auth tables. Merge it with your own permissions so regular client sessions can't read or write Better Auth rows — the adapter itself uses `context.asBackend()`, which authenticates with `backendSecret` and bypasses permission checks entirely.
+
 ## Database Adapter
 
-Create a server-side [Jazz context](/docs/getting-started/server-setup#backend-context-setup), then pass it to `jazzAdapter(...)` as the `database` in your Better Auth config:
+Create a server-side [Jazz context](/docs/getting-started/server-setup#backend-context-setup), then pass it to `jazzAdapter(...)` as the `database` in your Better Auth config. Point both `db` and `schema` at the merged `app` — not at the generated module directly — so Better Auth and your own tables share a single Jazz app.
 
 ```ts title="src/lib/auth.ts"
 import { betterAuth } from "better-auth";
 import { createJazzContext } from "jazz-tools/backend";
 import { jazzAdapter } from "jazz-tools/better-auth-adapter";
-import { app as authSchema } from "../../schema-better-auth/schema";
+import { app } from "../../schema";
 
 const jazzContext = createJazzContext({
   appId: process.env.APP_ID!,
@@ -27,81 +64,35 @@ const jazzContext = createJazzContext({
 
 export const auth = betterAuth({
   database: jazzAdapter({
-    db: () => jazzContext.asBackend(authSchema),
-    schema: authSchema,
+    db: () => jazzContext.asBackend(app),
+    schema: app.wasmSchema,
   }),
   // ...your Better Auth config
 });
 ```
 
-| Option      | Description                                                                          |
-| ----------- | ------------------------------------------------------------------------------------ |
-| `db`        | A function returning a `Db` handle via `context.asBackend()`.                        |
-| `schema`    | A Jazz schema source such as the exported `app` from `schema-better-auth/schema.ts`. |
-| `debugLogs` | Better Auth adapter debug logging controls.                                          |
-| `usePlural` | Whether Better Auth model names should use plural table names.                       |
-| `prefix`    | Table name prefix (defaults to `"better_auth_"`).                                    |
+| Option      | Description                                                                                            |
+| ----------- | ------------------------------------------------------------------------------------------------------ |
+| `db`        | A function returning a `Db` handle via `context.asBackend(app)`. Use the merged app, not `authSchema`. |
+| `schema`    | Typically `app.wasmSchema` from your merged schema. A raw `s.App` is also accepted.                    |
+| `debugLogs` | Better Auth adapter debug logging controls.                                                            |
+| `usePlural` | Whether Better Auth model names should use plural table names.                                         |
+| `prefix`    | Table name prefix (defaults to `"better_auth_"`).                                                      |
 
 <Callout title="Leave Better Auth joins disabled">
   The Jazz adapter does not support Better Auth experimental joins yet, so do not enable
   `experimental.joins`.
 </Callout>
 
-## Schema Workflow
-
-Better Auth tables live in a separate `schema-better-auth/` directory from your app schema.
-
-```bash
-# Generate the Better Auth root schema module into schema-better-auth/
-npx @better-auth/cli@latest generate \
-  --config ./src/lib/auth.ts \
-  --output ./schema-better-auth/schema.ts
-
-# Validate the generated schema source
-pnpm dlx jazz-tools@alpha validate --schema-dir ./schema-better-auth
-```
-
-The generated `schema.ts` includes a `permissions` export that denies all operations on the better-auth tables by default. This prevents any regular Jazz client session from reading or writing better-auth data. The adapter uses `context.asBackend()`, which authenticates with `backendSecret` and bypasses permission checks entirely, so better-auth itself is unaffected.
-
 ### Publishing to a sync server
 
-If you connect your auth context to a sync server (`serverUrl`), publish the structural schema
-before the app starts, then publish the generated permissions bundle.
-
-Jazz currently exposes `schema export` in the CLI, not `schema push`, so use the same structural
-schema publication flow you already use for your app schema. Once that schema is available on the
-server, publish the deny-all permissions:
+Because Better Auth tables are merged into your app schema, they ride on the same deploy as everything else — no separate push for `schema-better-auth/`. Publish schema, permissions, and migrations through the normal workflow:
 
 ```bash
-pnpm dlx jazz-tools@alpha permissions push \
-  --schema-dir ./schema-better-auth \
-  --server-url $JAZZ_SERVER_URL \
-  --admin-secret $JAZZ_ADMIN_SECRET
+pnpm dlx jazz-tools@alpha deploy <appId>
 ```
 
-You can check the currently deployed permissions head at any time:
-
-```bash
-pnpm dlx jazz-tools@alpha permissions status \
-  --schema-dir ./schema-better-auth \
-  --server-url $JAZZ_SERVER_URL \
-  --admin-secret $JAZZ_ADMIN_SECRET
-```
-
-After the initial push, schema changes require a migration edge:
-
-```bash
-pnpm dlx jazz-tools@alpha migrations create --fromHash <fromHash>
-pnpm dlx jazz-tools@alpha migrations create --fromHash <fromHash> --toHash <toHash>
-pnpm dlx jazz-tools@alpha migrations push <fromHash> <toHash>
-```
-
-<Callout title="No push needed for local-only setups">
-  If your auth context uses a local persistence driver with no `serverUrl`, no CLI push commands are
-  required. The generated `permissions` export is still tooling-facing, though:
-  `context.asBackend(authSchema)` reads the schema source, not the `permissions` export. If you need
-  those policies in an in-process context, pass them separately when creating the Jazz context.
-</Callout>
+See [Migrations](/docs/schemas/migrations) for the full deploy flow and how schema changes produce migration edges.
 
 ## Compatibility
 

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -18,6 +18,7 @@
     "recipes/real-time-collaborative-list",
     "recipes/nested-data",
     "recipes/auth-provider-integration",
+    "guides/better-auth-adapter",
     "faq",
     "---Reference---",
     "reference"


### PR DESCRIPTION
## Summary
- Reorder the better-auth adapter guide so the schema workflow comes before the adapter config.
- Document the merged-schema pattern: import the generated `schema-better-auth/schema.ts` and spread it into your app's `schema.ts`, then pass `app.wasmSchema` (and `context.asBackend(app)`) to `jazzAdapter`.
- Simplify the deploy step — auth tables now ride on the main app's normal `jazz-tools deploy`, so the separate `--schema-dir` push is gone.
- Link `guides/better-auth-adapter` from the top-level docs nav so it's discoverable.

## Preview
- https://jazz2-docs-git-docs-better-auth-adapter-merged-schema-garden-co.vercel.app/docs/guides/better-auth-adapter

## Test plan
- [ ] Build docs locally and confirm the page renders with updated ordering, code samples, and nav link.