### PR TITLE
docs: framework-aware Get an app ID panel

### DIFF
--- a/docs/components/mdx/generate-app-id.tsx
+++ b/docs/components/mdx/generate-app-id.tsx
@@ -3,15 +3,43 @@
 import { useState } from "react";
 import { Callout } from "fumadocs-ui/components/callout";
 import { DynamicCodeBlock } from "fumadocs-ui/components/dynamic-codeblock";
+import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 import { type GeneratedApp, storeGeneratedApp } from "@/lib/generated-app-store";
 
-function CredentialsBlock({ app }: { app: GeneratedApp }) {
-  const code = [
-    `JAZZ_APP_ID="${app.appId}"`,
+const JAZZ_CLOUD_SYNC_URL = "https://v2.sync.jazz.tools/";
+
+const BUNDLER_ITEMS = ["Vite", "Next.js", "SvelteKit", "Expo"] as const;
+type Bundler = (typeof BUNDLER_ITEMS)[number];
+
+// Client-exposed env var prefix per bundler, matching the dev plugins.
+// SvelteKit covers both SvelteKit itself and Svelte+Vite via jazzSvelteKit.
+const CLIENT_PREFIX: Record<Bundler, string> = {
+  Vite: "VITE_",
+  "Next.js": "NEXT_PUBLIC_",
+  SvelteKit: "PUBLIC_",
+  Expo: "EXPO_PUBLIC_",
+};
+
+function envBlockFor(bundler: Bundler, app: GeneratedApp): string {
+  const prefix = CLIENT_PREFIX[bundler];
+  return [
+    `${prefix}JAZZ_APP_ID="${app.appId}"`,
+    `${prefix}JAZZ_SERVER_URL="${JAZZ_CLOUD_SYNC_URL}"`,
     `JAZZ_ADMIN_SECRET="${app.adminSecret}"`,
-    `JAZZ_BACKEND_SECRET="${app.backendSecret}"`,
+    `BACKEND_SECRET="${app.backendSecret}"`,
   ].join("\n");
-  return <DynamicCodeBlock lang="env" code={code} />;
+}
+
+function CredentialsBlock({ app }: { app: GeneratedApp }) {
+  return (
+    <Tabs groupId="jazz-bundler" items={[...BUNDLER_ITEMS]} persist updateAnchor>
+      {BUNDLER_ITEMS.map((bundler) => (
+        <Tab key={bundler} value={bundler}>
+          <DynamicCodeBlock lang="env" code={envBlockFor(bundler, app)} />
+        </Tab>
+      ))}
+    </Tabs>
+  );
 }
 
 function ConfigBlock({ app }: { app: GeneratedApp }) {
@@ -51,6 +79,16 @@ export function GenerateAppId() {
           {loading ? "Generating…" : "Generate App ID"}
         </button>
         {error && <p className="text-sm text-red-500">{error}</p>}
+        <p className="text-sm text-fd-muted-foreground">
+          Or from the command line (AI agents: use this to provision your own app):
+        </p>
+        <DynamicCodeBlock
+          lang="bash"
+          code="curl -X POST https://v2.dashboard.jazz.tools/api/apps/generate"
+        />
+        <p className="text-sm text-fd-muted-foreground">
+          Jazz Cloud sync URL: <code>{JAZZ_CLOUD_SYNC_URL}</code>
+        </p>
       </div>
     );
   }

--- a/docs/content/docs/getting-started/client-setup.mdx
+++ b/docs/content/docs/getting-started/client-setup.mdx
@@ -224,6 +224,19 @@ Jazz ships bundler plugins that remove boilerplate in development. They start a 
 
 On first run the plugin generates an app ID, persists it to `.env`, and starts a local Jazz server under `node_modules/.cache/jazz-dev-server/`. Every subsequent run reuses both.
 
+### Env var names
+
+Each plugin writes the same two values (`appId`, `serverUrl`) under the prefix its bundler uses to expose env vars to the client bundle. SvelteKit's `PUBLIC_*` prefix also covers Svelte+Vite via `jazzSvelteKit`. Secrets are always unprefixed — they're server-only: `JAZZ_ADMIN_SECRET` and `BACKEND_SECRET`.
+
+| Bundler   | App ID                    | Server URL                    |
+| --------- | ------------------------- | ----------------------------- |
+| Vite      | `VITE_JAZZ_APP_ID`        | `VITE_JAZZ_SERVER_URL`        |
+| Next.js   | `NEXT_PUBLIC_JAZZ_APP_ID` | `NEXT_PUBLIC_JAZZ_SERVER_URL` |
+| SvelteKit | `PUBLIC_JAZZ_APP_ID`      | `PUBLIC_JAZZ_SERVER_URL`      |
+| Expo      | `EXPO_PUBLIC_JAZZ_APP_ID` | `EXPO_PUBLIC_JAZZ_SERVER_URL` |
+
+Jazz Cloud sync URL: `https://v2.sync.jazz.tools/`. For self-hosted deployments, point the server URL at your own host.
+
 ### Plugin options
 
 All plugins accept the same base options:

--- a/docs/content/docs/quickstarts/client.mdx
+++ b/docs/content/docs/quickstarts/client.mdx
@@ -137,7 +137,7 @@ Start with a fresh app. If you already have one, skip to [Install](#install).
 
 ## Get an app ID
 
-Your app ID namespaces your data for storage and sync. Click below to generate one on the Jazz hosted cloud&hairsp;—&hairsp;you'll also get the secrets you need to deploy permissions later.
+Your app ID namespaces your data for storage and sync. Click below to generate one on [Jazz Cloud](https://v2.sync.jazz.tools/) (sync URL: `https://v2.sync.jazz.tools/`)&hairsp;—&hairsp;you'll also get the secrets you need to deploy permissions later.
 
 <GenerateAppId />
 
@@ -345,7 +345,7 @@ Then publish the permissions bundle using the app ID and admin secret from above
 
 ### Connect the client
 
-Update your client config to add `serverUrl`. If you generated an app ID above, these values are already filled in:
+Update your client config to add `serverUrl` — Jazz Cloud is at `https://v2.sync.jazz.tools/`. If you generated an app ID above, these values are already filled in:
 
 <CloudConfig />
 


### PR DESCRIPTION
## Summary

- Split the generated credentials block into bundler tabs (Vite, Next.js, SvelteKit, Expo) so the `.env` snippet ships with the correct prefixes the dev plugins expect.
- Include the Jazz Cloud sync URL (`https://v2.sync.jazz.tools/`) in the generated block and as plain text on the quickstart page and in the dev-plugins docs — makes it scannable for LLMs fishing for it.
- Add a `curl` snippet under the Generate button so AI agents can provision an app from the command line.
- Document env var names per bundler in a table under the Dev plugins section, with secrets pulled out (`JAZZ_ADMIN_SECRET`, `BACKEND_SECRET`) since they're identical across bundlers.

## Test plan

- [ ] Visit `/docs/quickstarts/client#get-an-app-id` — verify the Generate button, curl snippet, and the four bundler tabs after generation render the right `.env` per framework
- [ ] Visit `/docs/getting-started/client-setup#env-var-names` — verify the table renders
- [ ] Confirm `curl -X POST https://v2.dashboard.jazz.tools/api/apps/generate` returns an app ID and secrets