### PR TITLE
fix: better schema-loader error messages

### DIFF
--- a/packages/jazz-tools/src/schema-loader.ts
+++ b/packages/jazz-tools/src/schema-loader.ts
@@ -154,8 +154,11 @@ async function loadSchemaAst(filePath: string): Promise<Schema> {
   }
 
   throw new Error(
-    `Could not find a schema export in ${basename(filePath)}. ` +
-      "Use side-effect table(...) declarations, or export schema/app/default from schema.ts.",
+    `Could not find a schema in ${filePath}. ` +
+      `Define tables with side-effect table(...) calls at module scope, ` +
+      `or export const schema / app / default. ` +
+      `By convention, schema.ts (and permissions.ts) live at the project root ` +
+      `(or src/lib/ for SvelteKit). See https://jazz.tools/docs/schemas/defining-tables.`,
   );
 }
 
@@ -279,7 +282,12 @@ export async function hasRootSchema(schemaDir: string): Promise<boolean> {
 export async function loadCompiledSchema(schemaDir: string): Promise<LoadedSchemaProject> {
   const resolved = resolveRootSchemaFiles(schemaDir);
   if (!resolved) {
-    throw new Error(`Schema file not found. Expected ${describeExpectedSchemaFiles(schemaDir)}.`);
+    throw new Error(
+      `Schema file not found. Jazz looks for schema.ts (and, optionally, permissions.ts alongside it) ` +
+        `at the project root, ./src/, or ./src/lib/ (SvelteKit). ` +
+        `Searched: ${describeExpectedSchemaFiles(schemaDir)}. ` +
+        `Pass --schema-dir <path> to point at a different root.`,
+    );
   }
 
   let schema = await loadSchemaAst(resolved.schemaFile);


### PR DESCRIPTION
## Summary

Triggered by a deploy run that failed with a bare \`Could not find a schema export in schema.ts\` — the message told the user *what* was missing but nothing about *where* the file should live or how to fix it.

- \"Schema file not found\" now spells out the search locations (project root, \`./src/\`, \`./src/lib/\` for SvelteKit), mentions that \`permissions.ts\` lives alongside \`schema.ts\`, and points at \`--schema-dir\`.
- \"Could not find a schema\" now shows the full file path (so deploy logs pinpoint which file was loaded), restates the table authoring options, reminds of the file convention, and links to [defining-tables](https://jazz.tools/docs/schemas/defining-tables).

## Test plan

- [x] \`pnpm exec vitest run src/cli.test.ts\` — 61 tests pass; existing assertions (\`stderr toContain \"Schema file not found\"\`) still hold.
- [ ] Trigger the bad path locally: \`jazz-tools deploy <appId> --schema-dir path/to/empty/dir\` and confirm the new message.