### PR TITLE
feat: allow waiting for transaction acknowledgement/rejection

### DIFF
--- a/.changeset/vast-geese-dress.md
+++ b/.changeset/vast-geese-dress.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+`Transaction.commit()` now returns a write handle, which allows waiting for ack from a given durability tier

--- a/docs/content/docs/writing/writing-data.mdx
+++ b/docs/content/docs/writing/writing-data.mdx
@@ -156,8 +156,9 @@ tx.insert(app.todos, { title: "Draft copy", done: false });
 const stagedDrafts = await tx.all(app.todos.where({ done: false }));
 tx.update(app.todos, todoId, { done: true });
 
-const batchId = tx.commit();
-console.log(batchId);
+const committed = tx.commit();
+await committed.wait({ tier: "edge" });
+console.log(committed.batchId);
 ```
 
 The changes made as part of the transaction are scoped to it, and will only be

--- a/packages/jazz-tools/bin/docs-index.txt
+++ b/packages/jazz-tools/bin/docs-index.txt
@@ -5487,8 +5487,9 @@ tx.insert(app.todos, { title: "Draft copy", done: false });
 const stagedDrafts = await tx.all(app.todos.where({ done: false }));
 tx.update(app.todos, todoId, { done: true });
 
-const batchId = tx.commit();
-console.log(batchId);
+const committed = tx.commit();
+await committed.wait({ tier: "edge" });
+console.log(committed.batchId);
 ```
 
 The changes made as part of the transaction are scoped to it, and will only be

--- a/packages/jazz-tools/src/runtime/client.test.ts
+++ b/packages/jazz-tools/src/runtime/client.test.ts
@@ -4,6 +4,7 @@ import {
   resolveDefaultDurabilityTier,
   type MutationErrorEvent,
   type Runtime,
+  WriteHandle,
 } from "./client.js";
 import type { AppContext } from "./context.js";
 import type { WasmSchema } from "../drivers/types.js";
@@ -57,6 +58,7 @@ function makeFakeRuntime() {
     ),
     drainRejectedBatchIds: vi.fn<() => string[]>(() => []),
     acknowledgeRejectedBatch: vi.fn<(batch_id: string) => boolean>(() => false),
+    sealBatch: vi.fn<(batch_id: string) => void>(),
     onSyncMessageReceived: vi.fn(),
     addServer: vi.fn(),
     removeServer: vi.fn(),
@@ -290,6 +292,24 @@ describe("JazzClient runtime schema caching", () => {
 
     expect(runtime.getSchemaHash).not.toHaveBeenCalled();
     expect(runtime.getSchema).not.toHaveBeenCalled();
+  });
+});
+
+describe("JazzClient transactions", () => {
+  it("returns a write handle from commit so callers can wait on the batch", async () => {
+    const runtime = makeFakeRuntime();
+    const client = JazzClient.connectWithRuntime(runtime as any, makeContext());
+    const waitForPersistedBatch = vi
+      .spyOn(client, "waitForPersistedBatch")
+      .mockResolvedValue(undefined);
+
+    const committed = client.beginTransaction().commit();
+
+    expect(runtime.sealBatch).toHaveBeenCalledTimes(1);
+    expect(committed).toBeInstanceOf(WriteHandle);
+    expect(committed.batchId).toBeDefined();
+    await expect(committed.wait({ tier: "edge" })).resolves.toBeUndefined();
+    expect(waitForPersistedBatch).toHaveBeenCalledWith(committed.batchId, "edge");
   });
 });
 

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -860,7 +860,7 @@ export class InsertHandle<T> extends WriteHandle<T> {
 }
 
 export class Transaction {
-  private committed = false;
+  private committedHandle: WriteHandle | null = null;
   private readonly touchedRowIds = new Set<string>();
 
   constructor(
@@ -869,6 +869,10 @@ export class Transaction {
     private readonly session?: Session,
     private readonly attribution?: string,
   ) {}
+
+  private get committed(): boolean {
+    return this.committedHandle !== null;
+  }
 
   private ensureActive(): void {
     if (this.committed) {
@@ -896,13 +900,13 @@ export class Transaction {
     return this.batchContext.batchId;
   }
 
-  commit(): string {
-    if (this.committed) {
-      return this.batchId();
+  commit(): WriteHandle {
+    if (this.committedHandle) {
+      return this.committedHandle;
     }
-    const batchId = this.client.sealBatch(this.batchId());
-    this.committed = true;
-    return batchId;
+    const handle = this.client.sealBatch(this.batchId());
+    this.committedHandle = handle;
+    return handle;
   }
 
   create(table: string, values: InsertValues): InsertHandle<Row> {
@@ -1471,9 +1475,9 @@ export class JazzClient {
     return acknowledged;
   }
 
-  sealBatch(batchId: string): string {
+  sealBatch(batchId: string): WriteHandle {
     this.requireBatchRecordMethod("sealBatch")(batchId);
-    return batchId;
+    return new WriteHandle(batchId, this);
   }
 
   /**

--- a/packages/jazz-tools/src/runtime/db.transaction.test.ts
+++ b/packages/jazz-tools/src/runtime/db.transaction.test.ts
@@ -129,12 +129,13 @@ describe("Db transactions", () => {
     const insertedRuntime = makeInsertHandle(runtimeRow, "batch-tx");
     const updatedRuntime = makeWriteHandle("batch-tx");
     const deletedRuntime = makeWriteHandle("batch-tx");
+    const committedRuntime = makeWriteHandle("batch-tx");
     const runtimeTransaction = {
       batchId: vi.fn(() => "batch-tx"),
       create: vi.fn(() => insertedRuntime.handle),
       update: vi.fn(() => updatedRuntime.handle),
       delete: vi.fn(() => deletedRuntime.handle),
-      commit: vi.fn(() => "batch-tx"),
+      commit: vi.fn(() => committedRuntime.handle),
       localBatchRecord: vi.fn((batchId = "batch-tx") => makeLocalBatchRecord(batchId)),
       localBatchRecords: vi.fn(() => [makeLocalBatchRecord("batch-tx")]),
       acknowledgeRejectedBatch: vi.fn(() => false),
@@ -178,7 +179,14 @@ describe("Db transactions", () => {
     expect(insertedRuntime.client.waitForPersistedBatch).toHaveBeenCalledWith("batch-tx", "global");
     expect(updatedRuntime.client.waitForPersistedBatch).toHaveBeenCalledWith("batch-tx", "edge");
     expect(deletedRuntime.client.waitForPersistedBatch).toHaveBeenCalledWith("batch-tx", "local");
-    expect(tx.commit()).toBe("batch-tx");
+    const committed = tx.commit();
+    expect(committed).toBeInstanceOf(WriteHandle);
+    expect(committed.batchId).toBe("batch-tx");
+    await expect(committed.wait({ tier: "global" })).resolves.toBeUndefined();
+    expect(committedRuntime.client.waitForPersistedBatch).toHaveBeenCalledWith(
+      "batch-tx",
+      "global",
+    );
     expect(runtimeTransaction.commit).toHaveBeenCalledWith();
     expect(tx.localBatchRecord()).toMatchObject({ batchId: "batch-tx" });
     expect(tx.localBatchRecords()).toEqual([makeLocalBatchRecord("batch-tx")]);
@@ -208,7 +216,7 @@ describe("Db transactions", () => {
       create: vi.fn(() => insertedRuntime.handle),
       update: vi.fn(() => makeWriteHandle("batch-session-tx").handle),
       delete: vi.fn(() => makeWriteHandle("batch-session-tx").handle),
-      commit: vi.fn(() => "batch-session-tx"),
+      commit: vi.fn(() => makeWriteHandle("batch-session-tx").handle),
       localBatchRecord: vi.fn((batchId = "batch-session-tx") => makeLocalBatchRecord(batchId)),
       localBatchRecords: vi.fn(() => [makeLocalBatchRecord("batch-session-tx")]),
       acknowledgeRejectedBatch: vi.fn(() => true),
@@ -230,7 +238,9 @@ describe("Db transactions", () => {
     const inserted = tx.insert(table, { title: "Session transaction", done: true });
 
     expect(runtimeClient.beginTransactionInternal).toHaveBeenCalledWith(session, "alice@writer");
-    expect(tx.commit()).toBe("batch-session-tx");
+    const committed = tx.commit();
+    expect(committed).toBeInstanceOf(WriteHandle);
+    expect(committed.batchId).toBe("batch-session-tx");
     expect(runtimeTransaction.commit).toHaveBeenCalledWith();
     expect(inserted.value).toEqual({
       id: "todo-2",
@@ -263,7 +273,7 @@ describe("Db transactions", () => {
       create: vi.fn(() => insertedRuntime.handle),
       update: vi.fn(),
       delete: vi.fn(),
-      commit: vi.fn(() => "batch-closed"),
+      commit: vi.fn(() => makeWriteHandle("batch-closed").handle),
       localBatchRecord: vi.fn((batchId = "batch-closed") => makeLocalBatchRecord(batchId)),
       localBatchRecords: vi.fn(() => [makeLocalBatchRecord("batch-closed")]),
       acknowledgeRejectedBatch: vi.fn(() => false),
@@ -280,7 +290,9 @@ describe("Db transactions", () => {
     );
 
     const tx = db.beginTransaction(table);
-    expect(tx.commit()).toBe("batch-closed");
+    const committed = tx.commit();
+    expect(committed).toBeInstanceOf(WriteHandle);
+    expect(committed.batchId).toBe("batch-closed");
 
     expect(() => tx.insert(table, { title: "Nope", done: false })).toThrow(/committed/i);
     expect(runtimeTransaction.create).not.toHaveBeenCalled();
@@ -302,7 +314,7 @@ describe("Db transactions", () => {
       update: vi.fn(),
       delete: vi.fn(),
       query: vi.fn(async () => [runtimeRow]),
-      commit: vi.fn(() => "batch-read"),
+      commit: vi.fn(() => makeWriteHandle("batch-read").handle),
       localBatchRecord: vi.fn((batchId = "batch-read") => makeLocalBatchRecord(batchId)),
       localBatchRecords: vi.fn(() => [makeLocalBatchRecord("batch-read")]),
       acknowledgeRejectedBatch: vi.fn(() => false),
@@ -343,7 +355,7 @@ describe("Db transactions", () => {
       update: vi.fn(),
       delete: vi.fn(),
       query: vi.fn(),
-      commit: vi.fn(() => "batch-read-closed"),
+      commit: vi.fn(() => makeWriteHandle("batch-read-closed").handle),
       localBatchRecord: vi.fn((batchId = "batch-read-closed") => makeLocalBatchRecord(batchId)),
       localBatchRecords: vi.fn(() => [makeLocalBatchRecord("batch-read-closed")]),
       acknowledgeRejectedBatch: vi.fn(() => false),
@@ -360,7 +372,9 @@ describe("Db transactions", () => {
     );
 
     const tx = db.beginTransaction(table);
-    expect(tx.commit()).toBe("batch-read-closed");
+    const committed = tx.commit();
+    expect(committed).toBeInstanceOf(WriteHandle);
+    expect(committed.batchId).toBe("batch-read-closed");
 
     await expect(tx.all(query)).rejects.toThrow(/committed/i);
     expect(runtimeTransaction.query).not.toHaveBeenCalled();
@@ -377,7 +391,7 @@ describe("Db transactions", () => {
       create: vi.fn(),
       update: vi.fn(),
       delete: vi.fn(),
-      commit: vi.fn(() => "batch-cross-client"),
+      commit: vi.fn(() => makeWriteHandle("batch-cross-client").handle),
       localBatchRecord: vi.fn((batchId = "batch-cross-client") => makeLocalBatchRecord(batchId)),
       localBatchRecords: vi.fn(() => [makeLocalBatchRecord("batch-cross-client")]),
       acknowledgeRejectedBatch: vi.fn(() => false),

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -460,16 +460,10 @@ export class DbTransaction {
 
   /**
    * Commit the transaction. Data will be globally visible once it's accepted by the authority.
-   *
-   * @returns the batch id of the committed transaction.
    */
-  commit(): string {
-    if (this.committed) {
-      return this.batchId();
-    }
-    const batchId = this.runtimeTransaction.commit();
+  commit(): WriteHandle {
     this.committed = true;
-    return batchId;
+    return this.runtimeTransaction.commit();
   }
 
   /**


### PR DESCRIPTION
## Description

There's currently no way to know whether a committed transaction was actually accepted by a server other than by querying the result.

This PR modifies `Transaction.commit()` to return a write handle, which allows waiting for ack from a given durability tier.