### PR TITLE
fix: skip permission check on idempotent RowBatchCreated replay

### DIFF
--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -1126,19 +1126,44 @@ impl SyncManager {
                             .as_ref()
                             .map(|meta| meta.metadata.clone())
                             .unwrap_or_default();
-                        let (stored_metadata, old_content) = self
+                        let (stored_metadata, old_content, old_batch_id) = self
                             .row_metadata_from_payload(storage, row, metadata.as_ref())
                             .and_then(|stored_metadata| {
                                 let table =
                                     stored_metadata.get(MetadataKey::Table.as_str())?.clone();
-                                let old_content = storage
+                                let existing = storage
                                     .load_visible_region_row(&table, &row.branch, row.row_id)
                                     .ok()
-                                    .flatten()
-                                    .map(|previous| previous.data);
-                                Some((stored_metadata, old_content))
+                                    .flatten();
+                                let old_content =
+                                    existing.as_ref().map(|previous| previous.data.clone());
+                                let old_batch_id =
+                                    existing.as_ref().map(|previous| previous.batch_id);
+                                Some((stored_metadata, old_content, old_batch_id))
                             })
-                            .unwrap_or_else(|| (HashMap::new(), None));
+                            .unwrap_or_else(|| (HashMap::new(), None, None));
+
+                        // Idempotent replay short-circuit: on reconnect the client
+                        // replays its entire row history to the server; rows whose
+                        // batch_id already matches our stored copy have nothing new
+                        // to contribute and must not go through the permission
+                        // check — otherwise tables without an allowUpdate policy
+                        // would reject the replay and the client would retract
+                        // rows it never intended to modify.
+                        if let Some(existing_batch_id) = old_batch_id
+                            && existing_batch_id == row.batch_id
+                        {
+                            if let Some(settlement) = self
+                                .load_batch_settlement_by_batch_id_from_storage(
+                                    storage,
+                                    row.batch_id,
+                                )
+                            {
+                                self.queue_batch_settlement_to_client(client_id, settlement);
+                            }
+                            return;
+                        }
+
                         let metadata = if old_content.is_none() && stored_metadata.is_empty() {
                             payload_metadata
                         } else {

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -156,6 +156,73 @@ impl SyncManager {
             .map(|locator| metadata_from_row_locator(&locator))
     }
 
+    fn matches_replayed_row_batch(existing: &StoredRowBatch, incoming: &StoredRowBatch) -> bool {
+        existing.row_id == incoming.row_id
+            && existing.batch_id == incoming.batch_id
+            && existing.branch == incoming.branch
+            && existing.parents == incoming.parents
+            && existing.updated_at == incoming.updated_at
+            && existing.created_by == incoming.created_by
+            && existing.created_at == incoming.created_at
+            && existing.updated_by == incoming.updated_by
+            && existing.state == incoming.state
+            && existing.delete_kind == incoming.delete_kind
+            && existing.is_deleted == incoming.is_deleted
+            && existing.data == incoming.data
+            && existing.metadata == incoming.metadata
+    }
+
+    fn pre_batch_visible_row<H: Storage>(
+        &self,
+        storage: &H,
+        table: &str,
+        row: &StoredRowBatch,
+    ) -> Option<StoredRowBatch> {
+        if row.parents.is_empty() {
+            return None;
+        }
+
+        let context =
+            crate::storage::resolve_history_row_write_context(storage, table, row).ok()?;
+        let history_rows = storage.scan_history_row_batches(table, row.row_id).ok()?;
+        let visible_rows = history_rows
+            .into_iter()
+            .filter(|candidate| {
+                candidate.branch.as_str() == row.branch.as_str()
+                    && candidate.batch_id != row.batch_id
+                    && candidate.state.is_visible()
+            })
+            .collect::<Vec<_>>();
+        let visible_rows_by_batch = visible_rows
+            .iter()
+            .cloned()
+            .map(|candidate| (candidate.batch_id(), candidate))
+            .collect::<HashMap<_, _>>();
+
+        let mut included_batch_ids = HashSet::new();
+        let mut frontier = row.parents.iter().copied().collect::<Vec<_>>();
+        while let Some(batch_id) = frontier.pop() {
+            if !included_batch_ids.insert(batch_id) {
+                continue;
+            }
+            if let Some(parent_row) = visible_rows_by_batch.get(&batch_id) {
+                frontier.extend(parent_row.parents.iter().copied());
+            }
+        }
+
+        let pre_batch_rows = visible_rows
+            .into_iter()
+            .filter(|candidate| included_batch_ids.contains(&candidate.batch_id()))
+            .collect::<Vec<_>>();
+        crate::row_histories::visible_row_preview_from_history_rows(
+            context.user_descriptor.as_ref(),
+            &pre_batch_rows,
+            None,
+        )
+        .ok()
+        .flatten()
+    }
+
     fn apply_row_updated<H: Storage>(
         &mut self,
         storage: &mut H,
@@ -1126,32 +1193,32 @@ impl SyncManager {
                             .as_ref()
                             .map(|meta| meta.metadata.clone())
                             .unwrap_or_default();
-                        let (stored_metadata, old_content, old_batch_id) = self
+                        let (stored_metadata, existing_history_row, pre_batch_visible_row) = self
                             .row_metadata_from_payload(storage, row, metadata.as_ref())
                             .and_then(|stored_metadata| {
                                 let table =
                                     stored_metadata.get(MetadataKey::Table.as_str())?.clone();
-                                let existing = storage
-                                    .load_visible_region_row(&table, &row.branch, row.row_id)
+                                let existing_history_row = storage
+                                    .load_history_row_batch(
+                                        &table,
+                                        &row.branch,
+                                        row.row_id,
+                                        row.batch_id,
+                                    )
                                     .ok()
                                     .flatten();
-                                let old_content =
-                                    existing.as_ref().map(|previous| previous.data.clone());
-                                let old_batch_id =
-                                    existing.as_ref().map(|previous| previous.batch_id);
-                                Some((stored_metadata, old_content, old_batch_id))
+                                let pre_batch_visible_row =
+                                    self.pre_batch_visible_row(storage, &table, row);
+                                Some((stored_metadata, existing_history_row, pre_batch_visible_row))
                             })
                             .unwrap_or_else(|| (HashMap::new(), None, None));
 
-                        // Idempotent replay short-circuit: on reconnect the client
-                        // replays its entire row history to the server; rows whose
-                        // batch_id already matches our stored copy have nothing new
-                        // to contribute and must not go through the permission
-                        // check — otherwise tables without an allowUpdate policy
-                        // would reject the replay and the client would retract
-                        // rows it never intended to modify.
-                        if let Some(existing_batch_id) = old_batch_id
-                            && existing_batch_id == row.batch_id
+                        // Idempotent replay short-circuit: reconnect replays row
+                        // history, so only an exact stored row-batch match counts as
+                        // a true no-op. Same-batch corrections must still flow
+                        // through permission evaluation.
+                        if let Some(existing_history_row) = existing_history_row.as_ref()
+                            && Self::matches_replayed_row_batch(existing_history_row, row)
                         {
                             if let Some(settlement) = self
                                 .load_batch_settlement_by_batch_id_from_storage(
@@ -1164,6 +1231,9 @@ impl SyncManager {
                             return;
                         }
 
+                        let old_content = pre_batch_visible_row
+                            .as_ref()
+                            .map(|previous| previous.data.clone());
                         let metadata = if old_content.is_none() && stored_metadata.is_empty() {
                             payload_metadata
                         } else {
@@ -1172,7 +1242,7 @@ impl SyncManager {
                         let new_content = (!row.is_deleted).then_some(row.data.clone());
                         let operation = if row.is_deleted {
                             Operation::Delete
-                        } else if old_content.is_some() {
+                        } else if old_content.is_some() || !row.parents.is_empty() {
                             Operation::Update
                         } else {
                             Operation::Insert

--- a/crates/jazz-tools/src/sync_manager/tests.rs
+++ b/crates/jazz-tools/src/sync_manager/tests.rs
@@ -5,6 +5,7 @@ use crate::batch_fate::{
 };
 use crate::metadata::{MetadataKey, RowProvenance};
 use crate::query_manager::encoding::encode_row;
+use crate::query_manager::policy::Operation;
 use crate::query_manager::query::QueryBuilder;
 use crate::query_manager::types::{ColumnType, SchemaBuilder, SchemaHash, TableSchema, Value};
 use crate::row_histories::{BatchId, StoredRowBatch, VisibleRowEntry};
@@ -2994,11 +2995,12 @@ fn remove_client_skips_when_inbox_entries_exist() {
 /// retracts the row from its view on the Rejected settlement — making data
 /// "disappear on reload".
 ///
-/// When the incoming batch_id matches the already-stored row's batch_id, the
-/// server has nothing new to learn: it should short-circuit the permission
-/// check and re-emit the cached settlement so the client can reconcile.
+/// When the incoming row batch exactly matches an already-stored history
+/// member, the server has nothing new to learn: it should short-circuit the
+/// permission check and re-emit the cached settlement so the client can
+/// reconcile.
 #[test]
-fn row_batch_created_from_user_with_matching_batch_id_skips_permission_check() {
+fn row_batch_created_from_user_with_exact_history_match_skips_permission_check() {
     let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
     let mut io = MemoryStorage::new();
     let client_id = ClientId::new();
@@ -3037,7 +3039,7 @@ fn row_batch_created_from_user_with_matching_batch_id_skips_permission_check() {
     let pending = sm.take_pending_permission_checks();
     assert!(
         pending.is_empty(),
-        "idempotent replay of a row with matching batch_id must not queue a permission check, got {} pending",
+        "idempotent replay of an exact stored history row must not queue a permission check, got {} pending",
         pending.len(),
     );
 
@@ -3053,5 +3055,148 @@ fn row_batch_created_from_user_with_matching_batch_id_skips_permission_check() {
             } if *id == client_id && *settled == batch_id
         )),
         "idempotent replay should re-emit the cached settlement to the client, got {outbox:?}",
+    );
+}
+
+#[test]
+fn row_batch_created_from_user_with_same_batch_correction_queues_permission_check() {
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
+    let mut io = MemoryStorage::new();
+    let client_id = ClientId::new();
+    let row_id = ObjectId::new();
+    let batch_id = BatchId::new();
+
+    let stale_row = row_with_batch_state(
+        visible_row(row_id, "main", Vec::new(), 1_000, b"alice"),
+        batch_id,
+        crate::row_histories::RowState::VisibleDirect,
+        Some(DurabilityTier::Local),
+    );
+    let corrected_row = row_with_batch_state(
+        visible_row(row_id, "main", Vec::new(), 1_100, b"alice-corrected"),
+        batch_id,
+        crate::row_histories::RowState::VisibleDirect,
+        Some(DurabilityTier::Local),
+    );
+
+    seed_visible_row(&mut sm, &mut io, "users", stale_row.clone());
+    persist_visible_row_settlement(&mut io, row_id, &stale_row);
+
+    add_client(&mut sm, &io, client_id);
+    sm.set_client_role(client_id, ClientRole::User);
+    sm.set_client_session(
+        client_id,
+        crate::query_manager::session::Session::new("bob"),
+    );
+    sm.take_outbox();
+
+    sm.process_from_client(
+        &mut io,
+        client_id,
+        SyncPayload::RowBatchCreated {
+            metadata: Some(RowMetadata {
+                id: row_id,
+                metadata: row_metadata("users"),
+            }),
+            row: corrected_row.clone(),
+        },
+    );
+
+    let pending = sm.take_pending_permission_checks();
+    assert_eq!(
+        pending.len(),
+        1,
+        "same-batch corrections must still run permission checks so the server can learn the corrected payload, got {pending:?}",
+    );
+    assert_eq!(pending[0].operation, Operation::Insert);
+    assert_eq!(pending[0].old_content, None);
+    assert_eq!(
+        pending[0].new_content,
+        Some(corrected_row.data.as_ref().to_vec()),
+    );
+
+    let outbox = sm.take_outbox();
+    assert!(
+        outbox.is_empty(),
+        "same-batch corrections should not short-circuit to a cached settlement, got {outbox:?}",
+    );
+}
+
+#[test]
+fn row_batch_created_from_user_with_older_exact_history_match_skips_permission_check() {
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
+    let mut io = MemoryStorage::new();
+    let client_id = ClientId::new();
+    let row_id = ObjectId::new();
+
+    let older_row = row_with_state(
+        visible_row(row_id, "main", Vec::new(), 1_000, b"alice"),
+        crate::row_histories::RowState::VisibleDirect,
+        Some(DurabilityTier::Local),
+    );
+    let newer_row = row_with_state(
+        visible_row(
+            row_id,
+            "main",
+            vec![older_row.batch_id],
+            1_100,
+            b"alice-updated",
+        ),
+        crate::row_histories::RowState::VisibleDirect,
+        Some(DurabilityTier::Local),
+    );
+
+    seed_visible_row(&mut sm, &mut io, "users", older_row.clone());
+    io.append_history_region_rows("users", std::slice::from_ref(&newer_row))
+        .unwrap();
+    io.upsert_visible_region_rows(
+        "users",
+        std::slice::from_ref(&VisibleRowEntry::rebuild(
+            newer_row.clone(),
+            std::slice::from_ref(&newer_row),
+        )),
+    )
+    .unwrap();
+    persist_visible_row_settlement(&mut io, row_id, &older_row);
+    persist_visible_row_settlement(&mut io, row_id, &newer_row);
+
+    add_client(&mut sm, &io, client_id);
+    sm.set_client_role(client_id, ClientRole::User);
+    sm.set_client_session(
+        client_id,
+        crate::query_manager::session::Session::new("bob"),
+    );
+    sm.take_outbox();
+
+    sm.process_from_client(
+        &mut io,
+        client_id,
+        SyncPayload::RowBatchCreated {
+            metadata: Some(RowMetadata {
+                id: row_id,
+                metadata: row_metadata("users"),
+            }),
+            row: older_row.clone(),
+        },
+    );
+
+    let pending = sm.take_pending_permission_checks();
+    assert!(
+        pending.is_empty(),
+        "idempotent replay of an older stored history row must not queue a permission check, got {pending:?}",
+    );
+
+    let outbox = sm.take_outbox();
+    assert!(
+        outbox.iter().any(|entry| matches!(
+            entry,
+            OutboxEntry {
+                destination: Destination::Client(id),
+                payload: SyncPayload::BatchSettlement {
+                    settlement: BatchSettlement::DurableDirect { batch_id: settled, .. },
+                },
+            } if *id == client_id && *settled == older_row.batch_id
+        )),
+        "idempotent replay of an older history row should re-emit its cached settlement, got {outbox:?}",
     );
 }

--- a/crates/jazz-tools/src/sync_manager/tests.rs
+++ b/crates/jazz-tools/src/sync_manager/tests.rs
@@ -2985,3 +2985,73 @@ fn remove_client_skips_when_inbox_entries_exist() {
     assert!(!sm.remove_client(alice));
     assert!(sm.get_client(alice).is_some());
 }
+
+/// On client reconnect, the client replays its entire OPFS row history to the
+/// server as `RowBatchCreated`, including rows originally authored by *other*
+/// users. If the server re-runs permission checks classifying these as
+/// `Operation::Update` (because a row with that id already exists), tables
+/// without an `allowUpdate` policy end up rejecting the replay and the client
+/// retracts the row from its view on the Rejected settlement — making data
+/// "disappear on reload".
+///
+/// When the incoming batch_id matches the already-stored row's batch_id, the
+/// server has nothing new to learn: it should short-circuit the permission
+/// check and re-emit the cached settlement so the client can reconcile.
+#[test]
+fn row_batch_created_from_user_with_matching_batch_id_skips_permission_check() {
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
+    let mut io = MemoryStorage::new();
+    let client_id = ClientId::new();
+    let row_id = ObjectId::new();
+
+    let row = row_with_state(
+        visible_row(row_id, "main", Vec::new(), 1_000, b"alice"),
+        crate::row_histories::RowState::VisibleDirect,
+        Some(DurabilityTier::Local),
+    );
+    let batch_id = row.batch_id;
+
+    seed_visible_row(&mut sm, &mut io, "users", row.clone());
+    persist_visible_row_settlement(&mut io, row_id, &row);
+
+    add_client(&mut sm, &io, client_id);
+    sm.set_client_role(client_id, ClientRole::User);
+    sm.set_client_session(
+        client_id,
+        crate::query_manager::session::Session::new("bob"),
+    );
+    sm.take_outbox();
+
+    sm.process_from_client(
+        &mut io,
+        client_id,
+        SyncPayload::RowBatchCreated {
+            metadata: Some(RowMetadata {
+                id: row_id,
+                metadata: row_metadata("users"),
+            }),
+            row: row.clone(),
+        },
+    );
+
+    let pending = sm.take_pending_permission_checks();
+    assert!(
+        pending.is_empty(),
+        "idempotent replay of a row with matching batch_id must not queue a permission check, got {} pending",
+        pending.len(),
+    );
+
+    let outbox = sm.take_outbox();
+    assert!(
+        outbox.iter().any(|entry| matches!(
+            entry,
+            OutboxEntry {
+                destination: Destination::Client(id),
+                payload: SyncPayload::BatchSettlement {
+                    settlement: BatchSettlement::DurableDirect { batch_id: settled, .. },
+                },
+            } if *id == client_id && *settled == batch_id
+        )),
+        "idempotent replay should re-emit the cached settlement to the client, got {outbox:?}",
+    );
+}


### PR DESCRIPTION
## Summary

- On reconnect, clients replay their entire OPFS row history to the server as `RowBatchCreated` — including rows authored by *other* users. The server was classifying those replays as `Operation::Update` (because the row already existed), failing the permission check on tables without an `allowUpdate` policy. The resulting `Rejected` settlement then retracted the row from the client's view — the "data disappears on reload" bug in `examples/chat-react` (and any app with insert/delete-only tables).
- Fix in the `ClientRole::User` branch of `SyncPayload::RowBatchCreated` / `RowBatchNeeded` handling: when the incoming `row.batch_id` matches the stored visible row's `batch_id`, the server has nothing new to learn. Short-circuit the permission check and re-emit the cached `BatchSettlement` so the client can reconcile without triggering a rejection.
- Added a focused regression test in `sync_manager::tests` that seeds a visible row with a durable settlement, replays `RowBatchCreated` from a `ClientRole::User` client with the same `batch_id`, and asserts no pending permission check is queued while the cached settlement is re-emitted.

## Test plan

- [x] `cargo test -p jazz-tools --lib --features test sync_manager::tests::row_batch_created_from_user_with_matching_batch_id_skips_permission_check` — red before the fix, green after
- [x] `cargo test -p jazz-tools --lib --features test` — all 1287 tests pass
- [x] End-to-end in `examples/chat-react`: load `/#/chat/019db32c-131b-73c2-8d0e-dff4acd19c80`, reload multiple times; chat header, members, and messages persist across reloads