### PR TITLE
fix: apply stored Rejected batch settlements on runtime startup

### DIFF
--- a/.changeset/apply-stored-rejected-on-startup.md
+++ b/.changeset/apply-stored-rejected-on-startup.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Re-apply stored Rejected batch settlements on runtime startup so that a crash between persisting a rejection and deleting its visible row no longer causes the lingering row to flash into queries on reload before being retracted.

--- a/crates/jazz-tools/src/runtime_core.rs
+++ b/crates/jazz-tools/src/runtime_core.rs
@@ -335,7 +335,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
     /// Create a new RuntimeCore.
     pub fn new(mut schema_manager: SchemaManager, mut storage: S, scheduler: Sch) -> Self {
         let _ = schema_manager.ensure_current_schema_persisted(&mut storage);
-        let rejected_batch_ids = storage
+        let rejected_batch_ids: BTreeSet<BatchId> = storage
             .scan_local_batch_records()
             .map(|records| {
                 records
@@ -351,7 +351,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             })
             .unwrap_or_default();
 
-        Self {
+        let mut core = Self {
             schema_manager,
             storage,
             scheduler,
@@ -368,11 +368,22 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             pending_subscriptions: HashMap::new(),
             pending_one_shot_queries: HashMap::new(),
             ack_watchers: HashMap::new(),
-            rejected_batch_ids,
+            rejected_batch_ids: rejected_batch_ids.clone(),
             tier_label: "unknown",
             sync_tracer: None,
             auth_failure_callback: None,
+        };
+
+        // If a crash landed between "persist rejection settlement" and
+        // "delete visible row + retract subscriptions", lingering visible
+        // rows would render on reload and then get retracted by the next
+        // network-delivered settlement — a visible flash. Re-apply stored
+        // rejections before any query can observe the visible region.
+        for batch_id in rejected_batch_ids {
+            core.mark_local_batch_rows_rejected(batch_id);
         }
+
+        core
     }
 
     /// Set the tier label used in tracing spans.

--- a/crates/jazz-tools/src/runtime_core/tests.rs
+++ b/crates/jazz-tools/src/runtime_core/tests.rs
@@ -5585,6 +5585,76 @@ fn rc_rejected_batch_survives_restart_until_acknowledged() {
 }
 
 #[test]
+fn rc_restart_retracts_visible_rows_with_stored_rejected_settlement() {
+    // Simulates a crash between "rejection settlement persisted" and
+    // "visible row deleted + query retracted": the local batch record has a
+    // Rejected settlement but its visible row is still in the visible
+    // region. On restart the runtime must retract the lingering visible row
+    // so queries never emit it — otherwise the row would render on reload
+    // and then be retracted by the next network-delivered re-rejection,
+    // causing a visible flash.
+    let schema = test_schema();
+    let mut alice =
+        create_runtime_with_schema(schema.clone(), "rc-restart-apply-stored-rejected-test");
+
+    let ((row_id, _row_values), _receiver) = alice
+        .insert_persisted(
+            "users",
+            user_insert_values(ObjectId::new(), "Alice"),
+            None,
+            DurabilityTier::Local,
+        )
+        .unwrap();
+
+    let branch_name = alice.schema_manager().branch_name();
+    let visible_row_before = alice
+        .storage()
+        .load_visible_region_row("users", branch_name.as_str(), row_id)
+        .unwrap()
+        .expect("insert_persisted should create one visible row");
+    let batch_id = visible_row_before.batch_id;
+
+    let mut record = alice
+        .storage()
+        .load_local_batch_record(batch_id)
+        .unwrap()
+        .expect("insert_persisted should create a local batch record");
+    record.latest_settlement = Some(crate::batch_fate::BatchSettlement::Rejected {
+        batch_id,
+        code: "permission_denied".to_string(),
+        reason: "simulated post-insert rejection".to_string(),
+    });
+    alice
+        .storage_mut()
+        .upsert_local_batch_record(&record)
+        .unwrap();
+
+    let storage = alice.into_storage();
+    let restarted =
+        create_runtime_with_storage(schema, "rc-restart-apply-stored-rejected-test", storage);
+
+    assert_eq!(
+        restarted
+            .storage()
+            .load_visible_region_row("users", branch_name.as_str(), row_id)
+            .unwrap(),
+        None,
+        "restart must apply stored Rejected settlement and retract the lingering visible row"
+    );
+
+    let history_rows = restarted
+        .storage()
+        .scan_history_row_batches("users", row_id)
+        .unwrap();
+    assert_eq!(history_rows.len(), 1);
+    assert_eq!(
+        history_rows[0].state,
+        crate::row_histories::RowState::Rejected,
+        "row history should reflect the stored rejection"
+    );
+}
+
+#[test]
 fn rc_restart_recovers_completed_sealed_batch_from_storage() {
     let schema = test_schema();
     let schema_hash = SchemaHash::compute(&schema);

--- a/crates/jazz-tools/src/runtime_core/ticks.rs
+++ b/crates/jazz-tools/src/runtime_core/ticks.rs
@@ -172,7 +172,10 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         }
     }
 
-    fn mark_local_batch_rows_rejected(&mut self, batch_id: crate::row_histories::BatchId) {
+    pub(super) fn mark_local_batch_rows_rejected(
+        &mut self,
+        batch_id: crate::row_histories::BatchId,
+    ) {
         let mut cleared_rows = Vec::new();
         let mut batch_patch_succeeded_by_table = std::collections::HashMap::new();
 


### PR DESCRIPTION
## Summary

- If a crash landed between persisting a Rejected `BatchSettlement` and deleting the corresponding visible row (+ retracting it from subscriptions), the next reload would render the lingering visible row and then retract it once the server's re-rejection arrived — a visible flash.
- `RuntimeCore::new` now re-applies stored Rejected settlements via `mark_local_batch_rows_rejected` before any query can observe the visible region, making the invariant "rejected batch ⇒ no visible rows" hold across restarts.

## Test plan

- [x] New regression test `rc_restart_retracts_visible_rows_with_stored_rejected_settlement` — inserts a VisibleDirect row, injects a Rejected settlement into the local batch record (bypassing the in-memory retraction path to simulate a partial crash), restarts, and asserts the visible row is gone and row history state is `Rejected`.
- [x] Full `cargo test -p jazz-tools --features test --lib`: 1287/1287 pass.