### PR TITLE
Add changeset for replay idempotency fix

### DIFF
--- a/.changeset/replay-idempotent-reconnect.md
+++ b/.changeset/replay-idempotent-reconnect.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Treat reconnect row-history replay as idempotent only when the incoming row exactly matches the stored history member. This avoids spuriously reclassifying replayed inserts as updates on insert-only tables while still allowing same-batch corrections to propagate their final payload.


### PR DESCRIPTION
## What changed
- adds a Changesets entry for the replay idempotency fix already merged in #624
- marks `jazz-tools` for a patch release so the fix is picked up by the release workflow

## Why
- the code fix is already on `main`, but it landed without release intent
- this follow-up lets the Changesets release PR include the reconnect replay permission fix in the next published version

## User impact
- the next published patch release will include the reconnect replay settlement fix
- no runtime code changes are included in this PR; it is release metadata only

## Root cause
- the original fix PR merged without a `.changeset` entry

## Checks
- pre-commit formatting (`oxfmt`) on the new changeset file
