### PR TITLE
fix: wrap React.use to make JazzClientProvider compatible with React18

### DIFF
--- a/.changeset/fix-react18-use-wrapper.md
+++ b/.changeset/fix-react18-use-wrapper.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Wrap React `use` inside `JazzClientProvider` so it remains compatible with React 18 while preserving behavior on newer React versions.

--- a/packages/jazz-tools/src/react-core/provider.tsx
+++ b/packages/jazz-tools/src/react-core/provider.tsx
@@ -9,7 +9,7 @@ import React, {
 import type { AuthState } from "../runtime/auth-state.js";
 import type { Session } from "../runtime/context.js";
 import type { DbConfig } from "../runtime/db.js";
-import { SubscriptionsOrchestrator } from "../subscriptions-orchestrator.js";
+import { SubscriptionsOrchestrator, trackPromise } from "../subscriptions-orchestrator.js";
 
 type CoreJazzDb = {
   getAuthState(): AuthState;
@@ -157,6 +157,29 @@ function useAuthSubscription(
   return authRev;
 }
 
+// Wrap React.use to make it compatible with React 18 and 19
+function usePromise<T extends object>(promise: Promise<T> | T): T {
+  if (!("then" in promise)) {
+    return promise;
+  }
+
+  if (React.use !== undefined) {
+    return React.use(promise);
+  }
+
+  const tracked = trackPromise(promise);
+
+  if (tracked.status === "pending") {
+    throw tracked;
+  }
+
+  if (tracked.status === "rejected") {
+    throw tracked.reason;
+  }
+
+  return tracked.value as T;
+}
+
 /**
  * Makes a Jazz client available to children components through a React context.
  * Useful if you need to create a Jazz client outside of the React component lifecycle.
@@ -166,7 +189,7 @@ export function JazzClientProvider({
   onJWTExpired,
   children,
 }: JazzClientProviderProps) {
-  const client = "then" in clientPromise ? React.use(clientPromise) : clientPromise;
+  const client = usePromise(clientPromise);
 
   const authRev = useAuthSubscription(client, onJWTExpired);
 


### PR DESCRIPTION
In #549 we started using [React.use directly](https://github.com/garden-co/jazz2/pull/549/changes#diff-7018ca6340ec6bbd7436633200f40ab5470f6ad2835b528fa993104e03756701R169). Although our peer dependency on React is `>=19`, this usage of React.use prevents usage in React 18.

This PR wraps React.use to make it best-effort compatible with React 18.