### PR TITLE
fix(todo-react stress test): read VITE_-prefixed Jazz env vars

### DIFF
--- a/stress-tests/todo-react/src/App.tsx
+++ b/stress-tests/todo-react/src/App.tsx
@@ -58,8 +58,8 @@ function Router() {
   return <GenerateData />;
 }
 
-const appId = import.meta.env.JAZZ_APP_ID;
-const serverUrl = import.meta.env.JAZZ_SERVER_URL;
+const appId = import.meta.env.VITE_JAZZ_APP_ID;
+const serverUrl = import.meta.env.VITE_JAZZ_SERVER_URL;
 
 if (!appId) {
   throw new Error("JAZZ_APP_ID is required");


### PR DESCRIPTION
## Summary
- `stress-tests/todo-react` threw `JAZZ_APP_ID is required` on startup.
- Vite only exposes `VITE_`-prefixed vars on `import.meta.env`, and `jazzPlugin` injects `VITE_JAZZ_APP_ID` / `VITE_JAZZ_SERVER_URL` (matches `src/vite-env.d.ts`). `App.tsx` was reading the unprefixed names.

## Test plan
- [x] `pnpm dev` in `stress-tests/todo-react` loads without throwing.