### PR TITLE
starters: add AGENTS.md with Jazz docs lookup guidance

### DIFF
--- a/scripts/check-starters-parity.mjs
+++ b/scripts/check-starters-parity.mjs
@@ -35,6 +35,10 @@ const HORIZONTAL_FILES = {
   react: ["schema.ts", "permissions.ts", "src/todo-widget.tsx"],
 };
 
+// Files that must be byte-identical across all nine starters regardless of
+// framework or auth variant.
+const ALL_STARTERS_FILES = ["AGENTS.md"];
+
 // Files that should be byte-identical across both frameworks (a "vertical"
 // parity rule on top of the horizontal one). We resolve them per framework
 // via HORIZONTAL_FILES — the logical name is the dict key.
@@ -186,8 +190,32 @@ function checkSharedReadmeBlocks() {
   }
 }
 
+function checkAllStartersParity() {
+  const allDirs = Object.values(STARTERS).flat();
+  for (const rel of ALL_STARTERS_FILES) {
+    const hashes = new Map();
+    for (const dir of allDirs) {
+      const content = read(`${dir}/${rel}`);
+      if (content === null) {
+        errors.push(`Missing file: ${dir}/${rel}`);
+        continue;
+      }
+      const h = hash(content);
+      if (!hashes.has(h)) hashes.set(h, []);
+      hashes.get(h).push(`${dir}/${rel}`);
+    }
+    if (hashes.size > 1) {
+      const groups = [...hashes.entries()]
+        .map(([h, files]) => `  ${h.slice(0, 12)}  ${files.join(", ")}`)
+        .join("\n");
+      errors.push(`All-starters drift: ${rel} disagrees across starters\n${groups}`);
+    }
+  }
+}
+
 checkHorizontalParity();
 checkCrossFrameworkParity();
+checkAllStartersParity();
 checkReadmeStructure();
 checkSharedReadmeBlocks();
 

--- a/starters/next-betterauth/AGENTS.md
+++ b/starters/next-betterauth/AGENTS.md
@@ -1,0 +1,33 @@
+# Jazz Application
+
+This project uses [Jazz](https://jazz.tools) — a local-first database with real-time sync.
+
+## Looking up Jazz APIs
+
+Jazz is actively developed. Always fetch the live docs before answering Jazz-related questions — do not rely on training data alone.
+
+**Step 1:** Fetch the page index to identify relevant pages:
+
+```
+https://jazz2-docs.vercel.app/llms.txt
+```
+
+**Step 2:** Fetch the relevant page by appending `.mdx` to its path, e.g.:
+
+```
+https://jazz2-docs.vercel.app/docs/schemas/defining-tables.mdx
+```
+
+Only fetch the pages you actually need.
+
+### Topic areas in the docs
+
+- **Getting started** — client and server setup
+- **Quickstarts** — client quickstart, TypeScript server quickstart
+- **Schemas** — defining tables, column types, relations, migrations
+- **Reading** — queries, subscriptions, filters, sorting, pagination
+- **Writing** — insert, update, delete, durability tiers, files and blobs
+- **Auth** — authentication modes, sessions, row-level permissions
+- **Concepts** — local-first data model, how sync works, branches
+- **Recipes** — user-owned data, shared access, real-time collaboration, nested data
+- **Reference** — column types, operators, framework patterns, FAQ

--- a/starters/next-hybrid/AGENTS.md
+++ b/starters/next-hybrid/AGENTS.md
@@ -1,0 +1,33 @@
+# Jazz Application
+
+This project uses [Jazz](https://jazz.tools) — a local-first database with real-time sync.
+
+## Looking up Jazz APIs
+
+Jazz is actively developed. Always fetch the live docs before answering Jazz-related questions — do not rely on training data alone.
+
+**Step 1:** Fetch the page index to identify relevant pages:
+
+```
+https://jazz2-docs.vercel.app/llms.txt
+```
+
+**Step 2:** Fetch the relevant page by appending `.mdx` to its path, e.g.:
+
+```
+https://jazz2-docs.vercel.app/docs/schemas/defining-tables.mdx
+```
+
+Only fetch the pages you actually need.
+
+### Topic areas in the docs
+
+- **Getting started** — client and server setup
+- **Quickstarts** — client quickstart, TypeScript server quickstart
+- **Schemas** — defining tables, column types, relations, migrations
+- **Reading** — queries, subscriptions, filters, sorting, pagination
+- **Writing** — insert, update, delete, durability tiers, files and blobs
+- **Auth** — authentication modes, sessions, row-level permissions
+- **Concepts** — local-first data model, how sync works, branches
+- **Recipes** — user-owned data, shared access, real-time collaboration, nested data
+- **Reference** — column types, operators, framework patterns, FAQ

--- a/starters/next-localfirst/AGENTS.md
+++ b/starters/next-localfirst/AGENTS.md
@@ -1,0 +1,33 @@
+# Jazz Application
+
+This project uses [Jazz](https://jazz.tools) — a local-first database with real-time sync.
+
+## Looking up Jazz APIs
+
+Jazz is actively developed. Always fetch the live docs before answering Jazz-related questions — do not rely on training data alone.
+
+**Step 1:** Fetch the page index to identify relevant pages:
+
+```
+https://jazz2-docs.vercel.app/llms.txt
+```
+
+**Step 2:** Fetch the relevant page by appending `.mdx` to its path, e.g.:
+
+```
+https://jazz2-docs.vercel.app/docs/schemas/defining-tables.mdx
+```
+
+Only fetch the pages you actually need.
+
+### Topic areas in the docs
+
+- **Getting started** — client and server setup
+- **Quickstarts** — client quickstart, TypeScript server quickstart
+- **Schemas** — defining tables, column types, relations, migrations
+- **Reading** — queries, subscriptions, filters, sorting, pagination
+- **Writing** — insert, update, delete, durability tiers, files and blobs
+- **Auth** — authentication modes, sessions, row-level permissions
+- **Concepts** — local-first data model, how sync works, branches
+- **Recipes** — user-owned data, shared access, real-time collaboration, nested data
+- **Reference** — column types, operators, framework patterns, FAQ

--- a/starters/react-betterauth/AGENTS.md
+++ b/starters/react-betterauth/AGENTS.md
@@ -1,0 +1,33 @@
+# Jazz Application
+
+This project uses [Jazz](https://jazz.tools) — a local-first database with real-time sync.
+
+## Looking up Jazz APIs
+
+Jazz is actively developed. Always fetch the live docs before answering Jazz-related questions — do not rely on training data alone.
+
+**Step 1:** Fetch the page index to identify relevant pages:
+
+```
+https://jazz2-docs.vercel.app/llms.txt
+```
+
+**Step 2:** Fetch the relevant page by appending `.mdx` to its path, e.g.:
+
+```
+https://jazz2-docs.vercel.app/docs/schemas/defining-tables.mdx
+```
+
+Only fetch the pages you actually need.
+
+### Topic areas in the docs
+
+- **Getting started** — client and server setup
+- **Quickstarts** — client quickstart, TypeScript server quickstart
+- **Schemas** — defining tables, column types, relations, migrations
+- **Reading** — queries, subscriptions, filters, sorting, pagination
+- **Writing** — insert, update, delete, durability tiers, files and blobs
+- **Auth** — authentication modes, sessions, row-level permissions
+- **Concepts** — local-first data model, how sync works, branches
+- **Recipes** — user-owned data, shared access, real-time collaboration, nested data
+- **Reference** — column types, operators, framework patterns, FAQ

--- a/starters/react-hybrid/AGENTS.md
+++ b/starters/react-hybrid/AGENTS.md
@@ -1,0 +1,33 @@
+# Jazz Application
+
+This project uses [Jazz](https://jazz.tools) — a local-first database with real-time sync.
+
+## Looking up Jazz APIs
+
+Jazz is actively developed. Always fetch the live docs before answering Jazz-related questions — do not rely on training data alone.
+
+**Step 1:** Fetch the page index to identify relevant pages:
+
+```
+https://jazz2-docs.vercel.app/llms.txt
+```
+
+**Step 2:** Fetch the relevant page by appending `.mdx` to its path, e.g.:
+
+```
+https://jazz2-docs.vercel.app/docs/schemas/defining-tables.mdx
+```
+
+Only fetch the pages you actually need.
+
+### Topic areas in the docs
+
+- **Getting started** — client and server setup
+- **Quickstarts** — client quickstart, TypeScript server quickstart
+- **Schemas** — defining tables, column types, relations, migrations
+- **Reading** — queries, subscriptions, filters, sorting, pagination
+- **Writing** — insert, update, delete, durability tiers, files and blobs
+- **Auth** — authentication modes, sessions, row-level permissions
+- **Concepts** — local-first data model, how sync works, branches
+- **Recipes** — user-owned data, shared access, real-time collaboration, nested data
+- **Reference** — column types, operators, framework patterns, FAQ

--- a/starters/react-localfirst/AGENTS.md
+++ b/starters/react-localfirst/AGENTS.md
@@ -1,0 +1,33 @@
+# Jazz Application
+
+This project uses [Jazz](https://jazz.tools) — a local-first database with real-time sync.
+
+## Looking up Jazz APIs
+
+Jazz is actively developed. Always fetch the live docs before answering Jazz-related questions — do not rely on training data alone.
+
+**Step 1:** Fetch the page index to identify relevant pages:
+
+```
+https://jazz2-docs.vercel.app/llms.txt
+```
+
+**Step 2:** Fetch the relevant page by appending `.mdx` to its path, e.g.:
+
+```
+https://jazz2-docs.vercel.app/docs/schemas/defining-tables.mdx
+```
+
+Only fetch the pages you actually need.
+
+### Topic areas in the docs
+
+- **Getting started** — client and server setup
+- **Quickstarts** — client quickstart, TypeScript server quickstart
+- **Schemas** — defining tables, column types, relations, migrations
+- **Reading** — queries, subscriptions, filters, sorting, pagination
+- **Writing** — insert, update, delete, durability tiers, files and blobs
+- **Auth** — authentication modes, sessions, row-level permissions
+- **Concepts** — local-first data model, how sync works, branches
+- **Recipes** — user-owned data, shared access, real-time collaboration, nested data
+- **Reference** — column types, operators, framework patterns, FAQ

--- a/starters/sveltekit-betterauth/AGENTS.md
+++ b/starters/sveltekit-betterauth/AGENTS.md
@@ -1,0 +1,33 @@
+# Jazz Application
+
+This project uses [Jazz](https://jazz.tools) — a local-first database with real-time sync.
+
+## Looking up Jazz APIs
+
+Jazz is actively developed. Always fetch the live docs before answering Jazz-related questions — do not rely on training data alone.
+
+**Step 1:** Fetch the page index to identify relevant pages:
+
+```
+https://jazz2-docs.vercel.app/llms.txt
+```
+
+**Step 2:** Fetch the relevant page by appending `.mdx` to its path, e.g.:
+
+```
+https://jazz2-docs.vercel.app/docs/schemas/defining-tables.mdx
+```
+
+Only fetch the pages you actually need.
+
+### Topic areas in the docs
+
+- **Getting started** — client and server setup
+- **Quickstarts** — client quickstart, TypeScript server quickstart
+- **Schemas** — defining tables, column types, relations, migrations
+- **Reading** — queries, subscriptions, filters, sorting, pagination
+- **Writing** — insert, update, delete, durability tiers, files and blobs
+- **Auth** — authentication modes, sessions, row-level permissions
+- **Concepts** — local-first data model, how sync works, branches
+- **Recipes** — user-owned data, shared access, real-time collaboration, nested data
+- **Reference** — column types, operators, framework patterns, FAQ

--- a/starters/sveltekit-hybrid/AGENTS.md
+++ b/starters/sveltekit-hybrid/AGENTS.md
@@ -1,0 +1,33 @@
+# Jazz Application
+
+This project uses [Jazz](https://jazz.tools) — a local-first database with real-time sync.
+
+## Looking up Jazz APIs
+
+Jazz is actively developed. Always fetch the live docs before answering Jazz-related questions — do not rely on training data alone.
+
+**Step 1:** Fetch the page index to identify relevant pages:
+
+```
+https://jazz2-docs.vercel.app/llms.txt
+```
+
+**Step 2:** Fetch the relevant page by appending `.mdx` to its path, e.g.:
+
+```
+https://jazz2-docs.vercel.app/docs/schemas/defining-tables.mdx
+```
+
+Only fetch the pages you actually need.
+
+### Topic areas in the docs
+
+- **Getting started** — client and server setup
+- **Quickstarts** — client quickstart, TypeScript server quickstart
+- **Schemas** — defining tables, column types, relations, migrations
+- **Reading** — queries, subscriptions, filters, sorting, pagination
+- **Writing** — insert, update, delete, durability tiers, files and blobs
+- **Auth** — authentication modes, sessions, row-level permissions
+- **Concepts** — local-first data model, how sync works, branches
+- **Recipes** — user-owned data, shared access, real-time collaboration, nested data
+- **Reference** — column types, operators, framework patterns, FAQ

--- a/starters/sveltekit-localfirst/AGENTS.md
+++ b/starters/sveltekit-localfirst/AGENTS.md
@@ -1,0 +1,33 @@
+# Jazz Application
+
+This project uses [Jazz](https://jazz.tools) — a local-first database with real-time sync.
+
+## Looking up Jazz APIs
+
+Jazz is actively developed. Always fetch the live docs before answering Jazz-related questions — do not rely on training data alone.
+
+**Step 1:** Fetch the page index to identify relevant pages:
+
+```
+https://jazz2-docs.vercel.app/llms.txt
+```
+
+**Step 2:** Fetch the relevant page by appending `.mdx` to its path, e.g.:
+
+```
+https://jazz2-docs.vercel.app/docs/schemas/defining-tables.mdx
+```
+
+Only fetch the pages you actually need.
+
+### Topic areas in the docs
+
+- **Getting started** — client and server setup
+- **Quickstarts** — client quickstart, TypeScript server quickstart
+- **Schemas** — defining tables, column types, relations, migrations
+- **Reading** — queries, subscriptions, filters, sorting, pagination
+- **Writing** — insert, update, delete, durability tiers, files and blobs
+- **Auth** — authentication modes, sessions, row-level permissions
+- **Concepts** — local-first data model, how sync works, branches
+- **Recipes** — user-owned data, shared access, real-time collaboration, nested data
+- **Reference** — column types, operators, framework patterns, FAQ


### PR DESCRIPTION
## Summary

- Adds a byte-identical `AGENTS.md` to all nine starters, directing coding agents to fetch live Jazz docs rather than rely on training data
- Covers the two-step docs lookup pattern (`llms.txt` index → `.mdx` page fetch) and the full topic area map
- Extends `check-starters-parity.mjs` with an all-starters identity check for `AGENTS.md`, so any drift across the nine copies fails CI

## Test plan

- [ ] `node scripts/check-starters-parity.mjs` passes
- [ ] All nine `AGENTS.md` files are byte-identical