### PR TITLE
feat(jazz-plugin): add config hook for worker format, and optimizeDeps

### DIFF
--- a/.changeset/vite-plugin-config-hook.md
+++ b/.changeset/vite-plugin-config-hook.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+`jazzPlugin` and `jazzSvelteKit` now inject `build.target: "es2020"`, `worker.format: "es"`, and `optimizeDeps.exclude: ["jazz-wasm"]` via a Vite `config` hook. Consumers no longer need to set these manually in their `vite.config.ts`. The `es2020` target is required because `jazz-wasm` exports a `u64` function via wasm-bindgen, which generates BigInt code — bundlers targeting older environments will attempt to downcompile it and break the WASM bindings.

--- a/.changeset/vite-plugin-config-hook.md
+++ b/.changeset/vite-plugin-config-hook.md
@@ -2,4 +2,4 @@
 "jazz-tools": patch
 ---
 
-`jazzPlugin` and `jazzSvelteKit` now inject `build.target: "es2020"`, `worker.format: "es"`, and `optimizeDeps.exclude: ["jazz-wasm"]` via a Vite `config` hook. Consumers no longer need to set these manually in their `vite.config.ts`. The `es2020` target is required because `jazz-wasm` exports a `u64` function via wasm-bindgen, which generates BigInt code — bundlers targeting older environments will attempt to downcompile it and break the WASM bindings.
+`jazzPlugin` and `jazzSvelteKit` now inject `worker.format: "es"` and `optimizeDeps.exclude: ["jazz-wasm"]` via a Vite `config` hook. Consumers no longer need to set these manually in their `vite.config.ts`.

--- a/examples/auth-simple-chat/vite.config.ts
+++ b/examples/auth-simple-chat/vite.config.ts
@@ -15,11 +15,6 @@ export default defineConfig({
       },
     }),
   ],
-  build: { target: "es2020" },
-  worker: { format: "es" },
-  optimizeDeps: {
-    exclude: ["jazz-wasm"],
-  },
   server: {
     proxy: {
       "/auth": {

--- a/examples/auth-workos-chat/vite.config.ts
+++ b/examples/auth-workos-chat/vite.config.ts
@@ -4,11 +4,6 @@ import { jazzPlugin } from "jazz-tools/dev/vite";
 
 export default defineConfig({
   plugins: [react(), jazzPlugin()],
-  build: { target: "es2020" },
-  worker: { format: "es" },
-  optimizeDeps: {
-    exclude: ["jazz-wasm"],
-  },
   server: {
     proxy: {
       "/sync": {

--- a/examples/docs/todo-client-localfirst-react/vite.config.ts
+++ b/examples/docs/todo-client-localfirst-react/vite.config.ts
@@ -1,11 +1,7 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { jazzPlugin } from "jazz-tools/dev/vite";
 
 export default defineConfig({
-  plugins: [react()],
-  build: { target: "es2020" },
-  worker: { format: "es" },
-  optimizeDeps: {
-    exclude: ["jazz-wasm"],
-  },
+  plugins: [react(), jazzPlugin()],
 });

--- a/examples/docs/todo-client-localfirst-svelte/vite.config.ts
+++ b/examples/docs/todo-client-localfirst-svelte/vite.config.ts
@@ -1,11 +1,7 @@
 import { defineConfig } from "vite";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
+import { jazzPlugin } from "jazz-tools/dev/vite";
 
 export default defineConfig({
-  plugins: [svelte()],
-  build: { target: "es2020" },
-  worker: { format: "es" },
-  optimizeDeps: {
-    exclude: ["jazz-wasm"],
-  },
+  plugins: [svelte(), jazzPlugin()],
 });

--- a/examples/docs/todo-client-localfirst-ts/vite.config.ts
+++ b/examples/docs/todo-client-localfirst-ts/vite.config.ts
@@ -1,9 +1,6 @@
 import { defineConfig } from "vite";
+import { jazzPlugin } from "jazz-tools/dev/vite";
 
 export default defineConfig({
-  build: { target: "es2020" },
-  worker: { format: "es" },
-  optimizeDeps: {
-    exclude: ["jazz-wasm"],
-  },
+  plugins: [jazzPlugin()],
 });

--- a/examples/docs/todo-client-localfirst-vue/vite.config.ts
+++ b/examples/docs/todo-client-localfirst-vue/vite.config.ts
@@ -1,11 +1,7 @@
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
+import { jazzPlugin } from "jazz-tools/dev/vite";
 
 export default defineConfig({
-  plugins: [vue()],
-  build: { target: "es2020" },
-  worker: { format: "es" },
-  optimizeDeps: {
-    exclude: ["jazz-wasm"],
-  },
+  plugins: [vue(), jazzPlugin()],
 });

--- a/examples/todo-client-localfirst-react/vite.config.ts
+++ b/examples/todo-client-localfirst-react/vite.config.ts
@@ -4,9 +4,4 @@ import { jazzPlugin } from "jazz-tools/dev/vite";
 
 export default defineConfig({
   plugins: [react(), jazzPlugin()],
-  build: { target: "es2020" },
-  worker: { format: "es" },
-  optimizeDeps: {
-    exclude: ["jazz-wasm"],
-  },
 });

--- a/examples/todo-client-localfirst-svelte/vite.config.ts
+++ b/examples/todo-client-localfirst-svelte/vite.config.ts
@@ -4,9 +4,4 @@ import { jazzSvelteKit } from "jazz-tools/dev/sveltekit";
 
 export default defineConfig({
   plugins: [svelte(), jazzSvelteKit()],
-  build: { target: "es2020" },
-  worker: { format: "es" },
-  optimizeDeps: {
-    exclude: ["jazz-wasm"],
-  },
 });

--- a/examples/todo-client-localfirst-ts/vite.config.ts
+++ b/examples/todo-client-localfirst-ts/vite.config.ts
@@ -2,10 +2,5 @@ import { defineConfig } from "vite";
 import { jazzPlugin } from "jazz-tools/dev/vite";
 
 export default defineConfig({
-  build: { target: "es2020" },
-  worker: { format: "es" },
-  optimizeDeps: {
-    exclude: ["jazz-wasm"],
-  },
   plugins: [jazzPlugin()],
 });

--- a/packages/jazz-tools/src/dev/sveltekit.test.ts
+++ b/packages/jazz-tools/src/dev/sveltekit.test.ts
@@ -347,6 +347,29 @@ it("config hook preserves existing ssr.external entries", () => {
   expect(result.ssr?.external).toContain("some-other-pkg");
 });
 
+it("config hook injects build target, worker format, and optimizeDeps exclude", () => {
+  const plugin = jazzSvelteKit();
+  const config = (plugin as { config?: (c: Record<string, unknown>) => unknown }).config;
+  const result = config!({}) as {
+    build?: { target?: string };
+    worker?: { format?: string };
+    optimizeDeps?: { exclude?: string[] };
+  };
+  expect(result.build?.target).toBe("es2020");
+  expect(result.worker?.format).toBe("es");
+  expect(result.optimizeDeps?.exclude).toContain("jazz-wasm");
+});
+
+it("config hook preserves existing optimizeDeps excludes", () => {
+  const plugin = jazzSvelteKit();
+  const config = (plugin as { config?: (c: Record<string, unknown>) => unknown }).config;
+  const result = config!({ optimizeDeps: { exclude: ["some-dep"] } }) as {
+    optimizeDeps?: { exclude?: string[] };
+  };
+  expect(result.optimizeDeps?.exclude).toContain("jazz-wasm");
+  expect(result.optimizeDeps?.exclude).toContain("some-dep");
+});
+
 describe("dev barrel", () => {
   it("exposes jazzSvelteKit", () => {
     expect((dev as Record<string, unknown>).jazzSvelteKit).toBeDefined();

--- a/packages/jazz-tools/src/dev/sveltekit.test.ts
+++ b/packages/jazz-tools/src/dev/sveltekit.test.ts
@@ -1,17 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import {
-  createTempRootTracker,
-  getAvailablePort,
-  todoSchema,
-} from "./test-helpers.js";
+import { createTempRootTracker, getAvailablePort, todoSchema } from "./test-helpers.js";
 import * as devServer from "./dev-server.js";
 import * as schemaWatcher from "./schema-watcher.js";
-import {
-  jazzSvelteKit,
-  __resetJazzSvelteKitPluginForTests,
-} from "./sveltekit.js";
+import { jazzSvelteKit, __resetJazzSvelteKitPluginForTests } from "./sveltekit.js";
 import type { ViteDevServer } from "./vite.js";
 
 const dev = await import("./index.js");
@@ -83,9 +76,7 @@ describe("jazzSvelteKit", () => {
       server: { port, adminSecret: "sveltekit-test-admin" },
     });
     const viteServer = makeViteServer("serve", root);
-    const configureServer = plugin.configureServer as (
-      server: typeof viteServer,
-    ) => Promise<void>;
+    const configureServer = plugin.configureServer as (server: typeof viteServer) => Promise<void>;
     await configureServer(viteServer);
 
     const healthResponse = await fetch(`http://127.0.0.1:${port}/health`);
@@ -102,12 +93,8 @@ describe("jazzSvelteKit", () => {
     expect(body.hashes?.length).toBeGreaterThan(0);
 
     expect(viteServer.config.env!.PUBLIC_JAZZ_APP_ID).toBeTruthy();
-    expect(viteServer.config.env!.PUBLIC_JAZZ_SERVER_URL).toBe(
-      `http://127.0.0.1:${port}`,
-    );
-    expect(process.env.PUBLIC_JAZZ_APP_ID).toBe(
-      viteServer.config.env!.PUBLIC_JAZZ_APP_ID,
-    );
+    expect(viteServer.config.env!.PUBLIC_JAZZ_SERVER_URL).toBe(`http://127.0.0.1:${port}`);
+    expect(process.env.PUBLIC_JAZZ_APP_ID).toBe(viteServer.config.env!.PUBLIC_JAZZ_APP_ID);
     expect(process.env.PUBLIC_JAZZ_SERVER_URL).toBe(`http://127.0.0.1:${port}`);
   }, 30_000);
 
@@ -117,9 +104,7 @@ describe("jazzSvelteKit", () => {
     const plugin = jazzSvelteKit({
       server: { port: 19999, adminSecret: "build-admin" },
     });
-    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(
-      makeViteServer("build"),
-    );
+    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(makeViteServer("build"));
 
     expect(spy).not.toHaveBeenCalled();
     expect(process.env.PUBLIC_JAZZ_APP_ID).toBeUndefined();
@@ -129,9 +114,7 @@ describe("jazzSvelteKit", () => {
     const spy = vi.spyOn(devServer, "startLocalJazzServer");
 
     const plugin = jazzSvelteKit({ server: false });
-    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(
-      makeViteServer("serve"),
-    );
+    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(makeViteServer("serve"));
 
     expect(spy).not.toHaveBeenCalled();
     expect(process.env.PUBLIC_JAZZ_APP_ID).toBeUndefined();
@@ -154,23 +137,19 @@ describe("jazzSvelteKit", () => {
     const plugin = jazzSvelteKit({
       server: { port: 19998, adminSecret: "backend-secret-admin" },
     });
-    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(
-      makeViteServer("serve"),
-    );
+    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(makeViteServer("serve"));
 
     expect(process.env.BACKEND_SECRET).toBe("test-backend-secret");
   });
 
   it("builds jwksUrl from Vite's configured host and port", async () => {
-    const startSpy = vi
-      .spyOn(devServer, "startLocalJazzServer")
-      .mockResolvedValue({
-        appId: "00000000-0000-0000-0000-000000000004",
-        port: 19995,
-        url: "http://127.0.0.1:19995",
-        dataDir: undefined as unknown as string,
-        stop: vi.fn().mockResolvedValue(undefined),
-      });
+    const startSpy = vi.spyOn(devServer, "startLocalJazzServer").mockResolvedValue({
+      appId: "00000000-0000-0000-0000-000000000004",
+      port: 19995,
+      url: "http://127.0.0.1:19995",
+      dataDir: undefined as unknown as string,
+      stop: vi.fn().mockResolvedValue(undefined),
+    });
     vi.spyOn(devServer, "pushSchemaCatalogue").mockResolvedValue({
       hash: "abc",
     });
@@ -185,9 +164,7 @@ describe("jazzSvelteKit", () => {
       httpServer: { once() {} },
       ws: { send() {} },
     };
-    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(
-      viteServer,
-    );
+    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(viteServer);
 
     expect(startSpy).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -200,15 +177,13 @@ describe("jazzSvelteKit", () => {
     const originalAppOrigin = process.env.APP_ORIGIN;
     process.env.APP_ORIGIN = "https://app.example.com";
 
-    const startSpy = vi
-      .spyOn(devServer, "startLocalJazzServer")
-      .mockResolvedValue({
-        appId: "00000000-0000-0000-0000-000000000005",
-        port: 19994,
-        url: "http://127.0.0.1:19994",
-        dataDir: undefined as unknown as string,
-        stop: vi.fn().mockResolvedValue(undefined),
-      });
+    const startSpy = vi.spyOn(devServer, "startLocalJazzServer").mockResolvedValue({
+      appId: "00000000-0000-0000-0000-000000000005",
+      port: 19994,
+      url: "http://127.0.0.1:19994",
+      dataDir: undefined as unknown as string,
+      stop: vi.fn().mockResolvedValue(undefined),
+    });
     vi.spyOn(devServer, "pushSchemaCatalogue").mockResolvedValue({
       hash: "abc",
     });
@@ -224,9 +199,7 @@ describe("jazzSvelteKit", () => {
         httpServer: { once() {} },
         ws: { send() {} },
       };
-      await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(
-        viteServer,
-      );
+      await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(viteServer);
 
       expect(startSpy).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -254,9 +227,7 @@ describe("jazzSvelteKit", () => {
 
     const plugin = jazzSvelteKit({ adminSecret: "env-test-admin" });
     const viteServer = makeViteServer("serve");
-    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(
-      viteServer,
-    );
+    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(viteServer);
 
     expect(devServer.startLocalJazzServer).not.toHaveBeenCalled();
     expect(devServer.pushSchemaCatalogue).toHaveBeenCalledWith(
@@ -265,9 +236,7 @@ describe("jazzSvelteKit", () => {
         appId: "00000000-0000-0000-0000-000000000010",
       }),
     );
-    expect(viteServer.config.env!.PUBLIC_JAZZ_SERVER_URL).toBe(
-      "http://jazz-test-server:4000",
-    );
+    expect(viteServer.config.env!.PUBLIC_JAZZ_SERVER_URL).toBe("http://jazz-test-server:4000");
   });
 
   it("connects to an existing server via options.server string URL", async () => {
@@ -282,9 +251,7 @@ describe("jazzSvelteKit", () => {
       adminSecret: "str-admin",
       appId: "00000000-0000-0000-0000-000000000020",
     });
-    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(
-      makeViteServer("serve"),
-    );
+    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(makeViteServer("serve"));
 
     expect(devServer.startLocalJazzServer).not.toHaveBeenCalled();
     expect(devServer.pushSchemaCatalogue).toHaveBeenCalledWith(
@@ -301,12 +268,8 @@ describe("jazzSvelteKit", () => {
 
     const plugin = jazzSvelteKit({});
     await expect(
-      (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(
-        makeViteServer("serve"),
-      ),
-    ).rejects.toThrow(
-      "adminSecret is required when connecting to an existing server",
-    );
+      (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(makeViteServer("serve")),
+    ).rejects.toThrow("adminSecret is required when connecting to an existing server");
   });
 
   it("throws when connecting to an existing server without appId", async () => {
@@ -315,12 +278,8 @@ describe("jazzSvelteKit", () => {
 
     const plugin = jazzSvelteKit({ adminSecret: "admin" });
     await expect(
-      (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(
-        makeViteServer("serve"),
-      ),
-    ).rejects.toThrow(
-      "appId is required when connecting to an existing server",
-    );
+      (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(makeViteServer("serve")),
+    ).rejects.toThrow("appId is required when connecting to an existing server");
   });
 
   it("stops the server and closes the watcher when the close hook fires", async () => {
@@ -354,9 +313,7 @@ describe("jazzSvelteKit", () => {
     const plugin = jazzSvelteKit({
       server: { port: 19997, adminSecret: "close-hook-admin" },
     });
-    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(
-      viteServer,
-    );
+    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(viteServer);
 
     expect(capturedCloseCallback).toBeDefined();
     capturedCloseCallback!();
@@ -374,9 +331,7 @@ describe("jazzSvelteKit", () => {
       dataDir: undefined as unknown as string,
       stop: vi.fn().mockResolvedValue(undefined),
     });
-    vi.spyOn(devServer, "pushSchemaCatalogue").mockRejectedValue(
-      new Error("schema push failed"),
-    );
+    vi.spyOn(devServer, "pushSchemaCatalogue").mockRejectedValue(new Error("schema push failed"));
     vi.spyOn(schemaWatcher, "watchSchema").mockReturnValue({ close: vi.fn() });
 
     const root = await tempRoots.create("jazz-sveltekit-hmr-test-");
@@ -390,13 +345,9 @@ describe("jazzSvelteKit", () => {
     const plugin = jazzSvelteKit({
       server: { port: 19996, adminSecret: "hmr-error-admin" },
     });
-    const configureServer = plugin.configureServer as (
-      s: ViteDevServer,
-    ) => Promise<void>;
+    const configureServer = plugin.configureServer as (s: ViteDevServer) => Promise<void>;
 
-    await expect(configureServer(viteServer)).rejects.toThrow(
-      "schema push failed",
-    );
+    await expect(configureServer(viteServer)).rejects.toThrow("schema push failed");
     expect(wsSend).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "error",
@@ -410,9 +361,7 @@ describe("jazzSvelteKit", () => {
 
 it("config hook adds jazz-napi to ssr.external", () => {
   const plugin = jazzSvelteKit();
-  const config = (
-    plugin as { config?: (c: Record<string, unknown>) => unknown }
-  ).config;
+  const config = (plugin as { config?: (c: Record<string, unknown>) => unknown }).config;
   expect(config).toBeDefined();
   const result = config!({}) as { ssr?: { external?: string[] } };
   expect(result.ssr?.external).toContain("jazz-napi");
@@ -420,9 +369,7 @@ it("config hook adds jazz-napi to ssr.external", () => {
 
 it("config hook preserves existing ssr.external entries", () => {
   const plugin = jazzSvelteKit();
-  const config = (
-    plugin as { config?: (c: Record<string, unknown>) => unknown }
-  ).config;
+  const config = (plugin as { config?: (c: Record<string, unknown>) => unknown }).config;
   const result = config!({ ssr: { external: ["some-other-pkg"] } }) as {
     ssr?: { external?: string[] };
   };
@@ -432,9 +379,7 @@ it("config hook preserves existing ssr.external entries", () => {
 
 it("config hook injects worker format and optimizeDeps exclude", () => {
   const plugin = jazzSvelteKit();
-  const config = (
-    plugin as { config?: (c: Record<string, unknown>) => unknown }
-  ).config;
+  const config = (plugin as { config?: (c: Record<string, unknown>) => unknown }).config;
   const result = config!({}) as {
     worker?: { format?: string };
     optimizeDeps?: { exclude?: string[] };
@@ -445,9 +390,7 @@ it("config hook injects worker format and optimizeDeps exclude", () => {
 
 it("config hook preserves existing optimizeDeps excludes", () => {
   const plugin = jazzSvelteKit();
-  const config = (
-    plugin as { config?: (c: Record<string, unknown>) => unknown }
-  ).config;
+  const config = (plugin as { config?: (c: Record<string, unknown>) => unknown }).config;
   const result = config!({ optimizeDeps: { exclude: ["some-dep"] } }) as {
     optimizeDeps?: { exclude?: string[] };
   };

--- a/packages/jazz-tools/src/dev/sveltekit.test.ts
+++ b/packages/jazz-tools/src/dev/sveltekit.test.ts
@@ -430,30 +430,17 @@ it("config hook preserves existing ssr.external entries", () => {
   expect(result.ssr?.external).toContain("some-other-pkg");
 });
 
-it("config hook injects build target, worker format, and optimizeDeps exclude", () => {
+it("config hook injects worker format and optimizeDeps exclude", () => {
   const plugin = jazzSvelteKit();
   const config = (
     plugin as { config?: (c: Record<string, unknown>) => unknown }
   ).config;
   const result = config!({}) as {
-    build?: { target?: string };
     worker?: { format?: string };
     optimizeDeps?: { exclude?: string[] };
   };
-  expect(result.build?.target).toBe("es2020");
   expect(result.worker?.format).toBe("es");
   expect(result.optimizeDeps?.exclude).toContain("jazz-wasm");
-});
-
-it("config hook respects a higher build target set by the user", () => {
-  const plugin = jazzSvelteKit();
-  const config = (
-    plugin as { config?: (c: Record<string, unknown>) => unknown }
-  ).config;
-  const result = config!({ build: { target: "esnext" } }) as {
-    build?: { target?: string };
-  };
-  expect(result.build?.target).toBe("esnext");
 });
 
 it("config hook preserves existing optimizeDeps excludes", () => {

--- a/packages/jazz-tools/src/dev/sveltekit.test.ts
+++ b/packages/jazz-tools/src/dev/sveltekit.test.ts
@@ -1,10 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { createTempRootTracker, getAvailablePort, todoSchema } from "./test-helpers.js";
+import {
+  createTempRootTracker,
+  getAvailablePort,
+  todoSchema,
+} from "./test-helpers.js";
 import * as devServer from "./dev-server.js";
 import * as schemaWatcher from "./schema-watcher.js";
-import { jazzSvelteKit, __resetJazzSvelteKitPluginForTests } from "./sveltekit.js";
+import {
+  jazzSvelteKit,
+  __resetJazzSvelteKitPluginForTests,
+} from "./sveltekit.js";
 import type { ViteDevServer } from "./vite.js";
 
 const dev = await import("./index.js");
@@ -72,9 +79,13 @@ describe("jazzSvelteKit", () => {
     await mkdir(join(root, "src", "lib"), { recursive: true });
     await writeFile(join(root, "src", "lib", "schema.ts"), todoSchema());
 
-    const plugin = jazzSvelteKit({ server: { port, adminSecret: "sveltekit-test-admin" } });
+    const plugin = jazzSvelteKit({
+      server: { port, adminSecret: "sveltekit-test-admin" },
+    });
     const viteServer = makeViteServer("serve", root);
-    const configureServer = plugin.configureServer as (server: typeof viteServer) => Promise<void>;
+    const configureServer = plugin.configureServer as (
+      server: typeof viteServer,
+    ) => Promise<void>;
     await configureServer(viteServer);
 
     const healthResponse = await fetch(`http://127.0.0.1:${port}/health`);
@@ -91,16 +102,24 @@ describe("jazzSvelteKit", () => {
     expect(body.hashes?.length).toBeGreaterThan(0);
 
     expect(viteServer.config.env!.PUBLIC_JAZZ_APP_ID).toBeTruthy();
-    expect(viteServer.config.env!.PUBLIC_JAZZ_SERVER_URL).toBe(`http://127.0.0.1:${port}`);
-    expect(process.env.PUBLIC_JAZZ_APP_ID).toBe(viteServer.config.env!.PUBLIC_JAZZ_APP_ID);
+    expect(viteServer.config.env!.PUBLIC_JAZZ_SERVER_URL).toBe(
+      `http://127.0.0.1:${port}`,
+    );
+    expect(process.env.PUBLIC_JAZZ_APP_ID).toBe(
+      viteServer.config.env!.PUBLIC_JAZZ_APP_ID,
+    );
     expect(process.env.PUBLIC_JAZZ_SERVER_URL).toBe(`http://127.0.0.1:${port}`);
   }, 30_000);
 
   it("does not start a server during build", async () => {
     const spy = vi.spyOn(devServer, "startLocalJazzServer");
 
-    const plugin = jazzSvelteKit({ server: { port: 19999, adminSecret: "build-admin" } });
-    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(makeViteServer("build"));
+    const plugin = jazzSvelteKit({
+      server: { port: 19999, adminSecret: "build-admin" },
+    });
+    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(
+      makeViteServer("build"),
+    );
 
     expect(spy).not.toHaveBeenCalled();
     expect(process.env.PUBLIC_JAZZ_APP_ID).toBeUndefined();
@@ -110,7 +129,9 @@ describe("jazzSvelteKit", () => {
     const spy = vi.spyOn(devServer, "startLocalJazzServer");
 
     const plugin = jazzSvelteKit({ server: false });
-    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(makeViteServer("serve"));
+    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(
+      makeViteServer("serve"),
+    );
 
     expect(spy).not.toHaveBeenCalled();
     expect(process.env.PUBLIC_JAZZ_APP_ID).toBeUndefined();
@@ -125,37 +146,53 @@ describe("jazzSvelteKit", () => {
       backendSecret: "test-backend-secret",
       stop: vi.fn().mockResolvedValue(undefined),
     });
-    vi.spyOn(devServer, "pushSchemaCatalogue").mockResolvedValue({ hash: "abc" });
+    vi.spyOn(devServer, "pushSchemaCatalogue").mockResolvedValue({
+      hash: "abc",
+    });
     vi.spyOn(schemaWatcher, "watchSchema").mockReturnValue({ close: vi.fn() });
 
-    const plugin = jazzSvelteKit({ server: { port: 19998, adminSecret: "backend-secret-admin" } });
-    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(makeViteServer("serve"));
+    const plugin = jazzSvelteKit({
+      server: { port: 19998, adminSecret: "backend-secret-admin" },
+    });
+    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(
+      makeViteServer("serve"),
+    );
 
     expect(process.env.BACKEND_SECRET).toBe("test-backend-secret");
   });
 
   it("builds jwksUrl from Vite's configured host and port", async () => {
-    const startSpy = vi.spyOn(devServer, "startLocalJazzServer").mockResolvedValue({
-      appId: "00000000-0000-0000-0000-000000000004",
-      port: 19995,
-      url: "http://127.0.0.1:19995",
-      dataDir: undefined as unknown as string,
-      stop: vi.fn().mockResolvedValue(undefined),
+    const startSpy = vi
+      .spyOn(devServer, "startLocalJazzServer")
+      .mockResolvedValue({
+        appId: "00000000-0000-0000-0000-000000000004",
+        port: 19995,
+        url: "http://127.0.0.1:19995",
+        dataDir: undefined as unknown as string,
+        stop: vi.fn().mockResolvedValue(undefined),
+      });
+    vi.spyOn(devServer, "pushSchemaCatalogue").mockResolvedValue({
+      hash: "abc",
     });
-    vi.spyOn(devServer, "pushSchemaCatalogue").mockResolvedValue({ hash: "abc" });
     vi.spyOn(schemaWatcher, "watchSchema").mockReturnValue({ close: vi.fn() });
 
     const root = await tempRoots.create("jazz-sveltekit-jwks-test-");
-    const plugin = jazzSvelteKit({ server: { port: 19995, adminSecret: "jwks-admin" } });
+    const plugin = jazzSvelteKit({
+      server: { port: 19995, adminSecret: "jwks-admin" },
+    });
     const viteServer: ViteDevServer = {
       config: { root, command: "serve", env: {}, server: { port: 3000 } },
       httpServer: { once() {} },
       ws: { send() {} },
     };
-    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(viteServer);
+    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(
+      viteServer,
+    );
 
     expect(startSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ jwksUrl: "http://localhost:3000/api/auth/jwks" }),
+      expect.objectContaining({
+        jwksUrl: "http://localhost:3000/api/auth/jwks",
+      }),
     );
   });
 
@@ -163,28 +200,38 @@ describe("jazzSvelteKit", () => {
     const originalAppOrigin = process.env.APP_ORIGIN;
     process.env.APP_ORIGIN = "https://app.example.com";
 
-    const startSpy = vi.spyOn(devServer, "startLocalJazzServer").mockResolvedValue({
-      appId: "00000000-0000-0000-0000-000000000005",
-      port: 19994,
-      url: "http://127.0.0.1:19994",
-      dataDir: undefined as unknown as string,
-      stop: vi.fn().mockResolvedValue(undefined),
+    const startSpy = vi
+      .spyOn(devServer, "startLocalJazzServer")
+      .mockResolvedValue({
+        appId: "00000000-0000-0000-0000-000000000005",
+        port: 19994,
+        url: "http://127.0.0.1:19994",
+        dataDir: undefined as unknown as string,
+        stop: vi.fn().mockResolvedValue(undefined),
+      });
+    vi.spyOn(devServer, "pushSchemaCatalogue").mockResolvedValue({
+      hash: "abc",
     });
-    vi.spyOn(devServer, "pushSchemaCatalogue").mockResolvedValue({ hash: "abc" });
     vi.spyOn(schemaWatcher, "watchSchema").mockReturnValue({ close: vi.fn() });
 
     try {
       const root = await tempRoots.create("jazz-sveltekit-apporigin-test-");
-      const plugin = jazzSvelteKit({ server: { port: 19994, adminSecret: "app-origin-admin" } });
+      const plugin = jazzSvelteKit({
+        server: { port: 19994, adminSecret: "app-origin-admin" },
+      });
       const viteServer: ViteDevServer = {
         config: { root, command: "serve", env: {}, server: { port: 3000 } },
         httpServer: { once() {} },
         ws: { send() {} },
       };
-      await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(viteServer);
+      await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(
+        viteServer,
+      );
 
       expect(startSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ jwksUrl: "https://app.example.com/api/auth/jwks" }),
+        expect.objectContaining({
+          jwksUrl: "https://app.example.com/api/auth/jwks",
+        }),
       );
     } finally {
       if (originalAppOrigin === undefined) {
@@ -200,12 +247,16 @@ describe("jazzSvelteKit", () => {
     process.env.PUBLIC_JAZZ_APP_ID = "00000000-0000-0000-0000-000000000010";
 
     vi.spyOn(devServer, "startLocalJazzServer");
-    vi.spyOn(devServer, "pushSchemaCatalogue").mockResolvedValue({ hash: "abc" });
+    vi.spyOn(devServer, "pushSchemaCatalogue").mockResolvedValue({
+      hash: "abc",
+    });
     vi.spyOn(schemaWatcher, "watchSchema").mockReturnValue({ close: vi.fn() });
 
     const plugin = jazzSvelteKit({ adminSecret: "env-test-admin" });
     const viteServer = makeViteServer("serve");
-    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(viteServer);
+    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(
+      viteServer,
+    );
 
     expect(devServer.startLocalJazzServer).not.toHaveBeenCalled();
     expect(devServer.pushSchemaCatalogue).toHaveBeenCalledWith(
@@ -214,12 +265,16 @@ describe("jazzSvelteKit", () => {
         appId: "00000000-0000-0000-0000-000000000010",
       }),
     );
-    expect(viteServer.config.env!.PUBLIC_JAZZ_SERVER_URL).toBe("http://jazz-test-server:4000");
+    expect(viteServer.config.env!.PUBLIC_JAZZ_SERVER_URL).toBe(
+      "http://jazz-test-server:4000",
+    );
   });
 
   it("connects to an existing server via options.server string URL", async () => {
     vi.spyOn(devServer, "startLocalJazzServer");
-    vi.spyOn(devServer, "pushSchemaCatalogue").mockResolvedValue({ hash: "abc" });
+    vi.spyOn(devServer, "pushSchemaCatalogue").mockResolvedValue({
+      hash: "abc",
+    });
     vi.spyOn(schemaWatcher, "watchSchema").mockReturnValue({ close: vi.fn() });
 
     const plugin = jazzSvelteKit({
@@ -227,7 +282,9 @@ describe("jazzSvelteKit", () => {
       adminSecret: "str-admin",
       appId: "00000000-0000-0000-0000-000000000020",
     });
-    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(makeViteServer("serve"));
+    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(
+      makeViteServer("serve"),
+    );
 
     expect(devServer.startLocalJazzServer).not.toHaveBeenCalled();
     expect(devServer.pushSchemaCatalogue).toHaveBeenCalledWith(
@@ -244,8 +301,12 @@ describe("jazzSvelteKit", () => {
 
     const plugin = jazzSvelteKit({});
     await expect(
-      (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(makeViteServer("serve")),
-    ).rejects.toThrow("adminSecret is required when connecting to an existing server");
+      (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(
+        makeViteServer("serve"),
+      ),
+    ).rejects.toThrow(
+      "adminSecret is required when connecting to an existing server",
+    );
   });
 
   it("throws when connecting to an existing server without appId", async () => {
@@ -254,8 +315,12 @@ describe("jazzSvelteKit", () => {
 
     const plugin = jazzSvelteKit({ adminSecret: "admin" });
     await expect(
-      (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(makeViteServer("serve")),
-    ).rejects.toThrow("appId is required when connecting to an existing server");
+      (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(
+        makeViteServer("serve"),
+      ),
+    ).rejects.toThrow(
+      "appId is required when connecting to an existing server",
+    );
   });
 
   it("stops the server and closes the watcher when the close hook fires", async () => {
@@ -269,7 +334,9 @@ describe("jazzSvelteKit", () => {
       dataDir: undefined as unknown as string,
       stop,
     });
-    vi.spyOn(devServer, "pushSchemaCatalogue").mockResolvedValue({ hash: "abc" });
+    vi.spyOn(devServer, "pushSchemaCatalogue").mockResolvedValue({
+      hash: "abc",
+    });
     vi.spyOn(schemaWatcher, "watchSchema").mockReturnValue({ close });
 
     const root = await tempRoots.create("jazz-sveltekit-close-test-");
@@ -284,8 +351,12 @@ describe("jazzSvelteKit", () => {
       ws: { send() {} },
     };
 
-    const plugin = jazzSvelteKit({ server: { port: 19997, adminSecret: "close-hook-admin" } });
-    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(viteServer);
+    const plugin = jazzSvelteKit({
+      server: { port: 19997, adminSecret: "close-hook-admin" },
+    });
+    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(
+      viteServer,
+    );
 
     expect(capturedCloseCallback).toBeDefined();
     capturedCloseCallback!();
@@ -303,7 +374,9 @@ describe("jazzSvelteKit", () => {
       dataDir: undefined as unknown as string,
       stop: vi.fn().mockResolvedValue(undefined),
     });
-    vi.spyOn(devServer, "pushSchemaCatalogue").mockRejectedValue(new Error("schema push failed"));
+    vi.spyOn(devServer, "pushSchemaCatalogue").mockRejectedValue(
+      new Error("schema push failed"),
+    );
     vi.spyOn(schemaWatcher, "watchSchema").mockReturnValue({ close: vi.fn() });
 
     const root = await tempRoots.create("jazz-sveltekit-hmr-test-");
@@ -314,10 +387,16 @@ describe("jazzSvelteKit", () => {
       ws: { send: wsSend },
     };
 
-    const plugin = jazzSvelteKit({ server: { port: 19996, adminSecret: "hmr-error-admin" } });
-    const configureServer = plugin.configureServer as (s: ViteDevServer) => Promise<void>;
+    const plugin = jazzSvelteKit({
+      server: { port: 19996, adminSecret: "hmr-error-admin" },
+    });
+    const configureServer = plugin.configureServer as (
+      s: ViteDevServer,
+    ) => Promise<void>;
 
-    await expect(configureServer(viteServer)).rejects.toThrow("schema push failed");
+    await expect(configureServer(viteServer)).rejects.toThrow(
+      "schema push failed",
+    );
     expect(wsSend).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "error",
@@ -331,7 +410,9 @@ describe("jazzSvelteKit", () => {
 
 it("config hook adds jazz-napi to ssr.external", () => {
   const plugin = jazzSvelteKit();
-  const config = (plugin as { config?: (c: Record<string, unknown>) => unknown }).config;
+  const config = (
+    plugin as { config?: (c: Record<string, unknown>) => unknown }
+  ).config;
   expect(config).toBeDefined();
   const result = config!({}) as { ssr?: { external?: string[] } };
   expect(result.ssr?.external).toContain("jazz-napi");
@@ -339,7 +420,9 @@ it("config hook adds jazz-napi to ssr.external", () => {
 
 it("config hook preserves existing ssr.external entries", () => {
   const plugin = jazzSvelteKit();
-  const config = (plugin as { config?: (c: Record<string, unknown>) => unknown }).config;
+  const config = (
+    plugin as { config?: (c: Record<string, unknown>) => unknown }
+  ).config;
   const result = config!({ ssr: { external: ["some-other-pkg"] } }) as {
     ssr?: { external?: string[] };
   };
@@ -349,7 +432,9 @@ it("config hook preserves existing ssr.external entries", () => {
 
 it("config hook injects build target, worker format, and optimizeDeps exclude", () => {
   const plugin = jazzSvelteKit();
-  const config = (plugin as { config?: (c: Record<string, unknown>) => unknown }).config;
+  const config = (
+    plugin as { config?: (c: Record<string, unknown>) => unknown }
+  ).config;
   const result = config!({}) as {
     build?: { target?: string };
     worker?: { format?: string };
@@ -360,9 +445,22 @@ it("config hook injects build target, worker format, and optimizeDeps exclude", 
   expect(result.optimizeDeps?.exclude).toContain("jazz-wasm");
 });
 
+it("config hook respects a higher build target set by the user", () => {
+  const plugin = jazzSvelteKit();
+  const config = (
+    plugin as { config?: (c: Record<string, unknown>) => unknown }
+  ).config;
+  const result = config!({ build: { target: "esnext" } }) as {
+    build?: { target?: string };
+  };
+  expect(result.build?.target).toBe("esnext");
+});
+
 it("config hook preserves existing optimizeDeps excludes", () => {
   const plugin = jazzSvelteKit();
-  const config = (plugin as { config?: (c: Record<string, unknown>) => unknown }).config;
+  const config = (
+    plugin as { config?: (c: Record<string, unknown>) => unknown }
+  ).config;
   const result = config!({ optimizeDeps: { exclude: ["some-dep"] } }) as {
     optimizeDeps?: { exclude?: string[] };
   };

--- a/packages/jazz-tools/src/dev/sveltekit.ts
+++ b/packages/jazz-tools/src/dev/sveltekit.ts
@@ -47,14 +47,12 @@ export function jazzSvelteKit(options: JazzPluginOptions = {}) {
     name: "jazz-sveltekit",
 
     config(config: {
-      build?: { target?: string | string[] };
       ssr?: { external?: string[] };
       optimizeDeps?: { exclude?: string[] };
     }) {
       const existingSsr = config.ssr?.external ?? [];
       const existingExclude = config.optimizeDeps?.exclude ?? [];
       return {
-        build: { target: config.build?.target ?? "es2020" },
         worker: { format: "es" as const },
         optimizeDeps: {
           exclude: Array.from(new Set([...existingExclude, "jazz-wasm"])),

--- a/packages/jazz-tools/src/dev/sveltekit.ts
+++ b/packages/jazz-tools/src/dev/sveltekit.ts
@@ -18,10 +18,7 @@ export interface JazzServerOptions extends BaseJazzServerOptions {
   backendSecret?: string;
 }
 
-export interface JazzPluginOptions extends Omit<
-  BaseJazzPluginOptions,
-  "server"
-> {
+export interface JazzPluginOptions extends Omit<BaseJazzPluginOptions, "server"> {
   server?: boolean | string | JazzServerOptions;
 }
 
@@ -46,10 +43,7 @@ export function jazzSvelteKit(options: JazzPluginOptions = {}) {
   return {
     name: "jazz-sveltekit",
 
-    config(config: {
-      ssr?: { external?: string[] };
-      optimizeDeps?: { exclude?: string[] };
-    }) {
+    config(config: { ssr?: { external?: string[] }; optimizeDeps?: { exclude?: string[] } }) {
       const existingSsr = config.ssr?.external ?? [];
       const existingExclude = config.optimizeDeps?.exclude ?? [];
       return {
@@ -62,23 +56,20 @@ export function jazzSvelteKit(options: JazzPluginOptions = {}) {
     },
 
     async configureServer(viteServer: ViteDevServer): Promise<void> {
-      if (viteServer.config.command !== "serve" || options.server === false)
-        return;
+      if (viteServer.config.command !== "serve" || options.server === false) return;
 
       // Vite (and SvelteKit-via-Vite) doesn't populate process.env from .env
       // for unprefixed keys, so the managed runtime's env-driven cloud-mode check
       // would otherwise never fire. Backfill before reading.
       loadEnvFileIntoProcessEnv(viteServer.config.root);
 
-      const schemaDir =
-        options.schemaDir ?? join(viteServer.config.root, "src", "lib");
+      const schemaDir = options.schemaDir ?? join(viteServer.config.root, "src", "lib");
       const serverOpt = options.server ?? true;
 
       // Extract backendSecret from the server config object (SvelteKit-only option).
       const serverConfig: JazzServerOptions =
         typeof serverOpt === "object" && serverOpt !== null ? serverOpt : {};
-      const backendSecret =
-        serverConfig.backendSecret ?? process.env.BACKEND_SECRET;
+      const backendSecret = serverConfig.backendSecret ?? process.env.BACKEND_SECRET;
 
       // Pre-resolve jwksUrl from Vite's configured host/port when starting a
       // local server. Precedence: explicit option → APP_ORIGIN env → Vite config
@@ -144,8 +135,7 @@ function resolveServerWithJwks(
   const serverConfig: JazzServerOptions =
     typeof serverOpt === "object" && serverOpt !== null ? serverOpt : {};
 
-  if (serverConfig.jwksUrl !== undefined)
-    return serverConfig as BaseJazzServerOptions;
+  if (serverConfig.jwksUrl !== undefined) return serverConfig as BaseJazzServerOptions;
 
   const appOrigin = process.env.APP_ORIGIN ?? resolveViteOrigin(viteServer);
   return {

--- a/packages/jazz-tools/src/dev/sveltekit.ts
+++ b/packages/jazz-tools/src/dev/sveltekit.ts
@@ -18,7 +18,10 @@ export interface JazzServerOptions extends BaseJazzServerOptions {
   backendSecret?: string;
 }
 
-export interface JazzPluginOptions extends Omit<BaseJazzPluginOptions, "server"> {
+export interface JazzPluginOptions extends Omit<
+  BaseJazzPluginOptions,
+  "server"
+> {
   server?: boolean | string | JazzServerOptions;
 }
 
@@ -43,32 +46,41 @@ export function jazzSvelteKit(options: JazzPluginOptions = {}) {
   return {
     name: "jazz-sveltekit",
 
-    config(config: { ssr?: { external?: string[] }; optimizeDeps?: { exclude?: string[] } }) {
+    config(config: {
+      build?: { target?: string | string[] };
+      ssr?: { external?: string[] };
+      optimizeDeps?: { exclude?: string[] };
+    }) {
       const existingSsr = config.ssr?.external ?? [];
       const existingExclude = config.optimizeDeps?.exclude ?? [];
       return {
-        build: { target: "es2020" },
+        build: { target: config.build?.target ?? "es2020" },
         worker: { format: "es" as const },
-        optimizeDeps: { exclude: Array.from(new Set([...existingExclude, "jazz-wasm"])) },
+        optimizeDeps: {
+          exclude: Array.from(new Set([...existingExclude, "jazz-wasm"])),
+        },
         ssr: { external: Array.from(new Set([...existingSsr, "jazz-napi"])) },
       };
     },
 
     async configureServer(viteServer: ViteDevServer): Promise<void> {
-      if (viteServer.config.command !== "serve" || options.server === false) return;
+      if (viteServer.config.command !== "serve" || options.server === false)
+        return;
 
       // Vite (and SvelteKit-via-Vite) doesn't populate process.env from .env
       // for unprefixed keys, so the managed runtime's env-driven cloud-mode check
       // would otherwise never fire. Backfill before reading.
       loadEnvFileIntoProcessEnv(viteServer.config.root);
 
-      const schemaDir = options.schemaDir ?? join(viteServer.config.root, "src", "lib");
+      const schemaDir =
+        options.schemaDir ?? join(viteServer.config.root, "src", "lib");
       const serverOpt = options.server ?? true;
 
       // Extract backendSecret from the server config object (SvelteKit-only option).
       const serverConfig: JazzServerOptions =
         typeof serverOpt === "object" && serverOpt !== null ? serverOpt : {};
-      const backendSecret = serverConfig.backendSecret ?? process.env.BACKEND_SECRET;
+      const backendSecret =
+        serverConfig.backendSecret ?? process.env.BACKEND_SECRET;
 
       // Pre-resolve jwksUrl from Vite's configured host/port when starting a
       // local server. Precedence: explicit option → APP_ORIGIN env → Vite config
@@ -134,8 +146,12 @@ function resolveServerWithJwks(
   const serverConfig: JazzServerOptions =
     typeof serverOpt === "object" && serverOpt !== null ? serverOpt : {};
 
-  if (serverConfig.jwksUrl !== undefined) return serverConfig as BaseJazzServerOptions;
+  if (serverConfig.jwksUrl !== undefined)
+    return serverConfig as BaseJazzServerOptions;
 
   const appOrigin = process.env.APP_ORIGIN ?? resolveViteOrigin(viteServer);
-  return { ...serverConfig, jwksUrl: `${appOrigin}/api/auth/jwks` } as BaseJazzServerOptions;
+  return {
+    ...serverConfig,
+    jwksUrl: `${appOrigin}/api/auth/jwks`,
+  } as BaseJazzServerOptions;
 }

--- a/packages/jazz-tools/src/dev/sveltekit.ts
+++ b/packages/jazz-tools/src/dev/sveltekit.ts
@@ -43,10 +43,14 @@ export function jazzSvelteKit(options: JazzPluginOptions = {}) {
   return {
     name: "jazz-sveltekit",
 
-    config(config: { ssr?: { external?: string[] } }) {
-      const existing = config.ssr?.external ?? [];
+    config(config: { ssr?: { external?: string[] }; optimizeDeps?: { exclude?: string[] } }) {
+      const existingSsr = config.ssr?.external ?? [];
+      const existingExclude = config.optimizeDeps?.exclude ?? [];
       return {
-        ssr: { external: Array.from(new Set([...existing, "jazz-napi"])) },
+        build: { target: "es2020" },
+        worker: { format: "es" as const },
+        optimizeDeps: { exclude: Array.from(new Set([...existingExclude, "jazz-wasm"])) },
+        ssr: { external: Array.from(new Set([...existingSsr, "jazz-napi"])) },
       };
     },
 

--- a/packages/jazz-tools/src/dev/vite.test.ts
+++ b/packages/jazz-tools/src/dev/vite.test.ts
@@ -2,7 +2,11 @@ import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { jazzPlugin } from "./vite.js";
-import { createTempRootTracker, getAvailablePort, todoSchema } from "./test-helpers.js";
+import {
+  createTempRootTracker,
+  getAvailablePort,
+  todoSchema,
+} from "./test-helpers.js";
 
 const tempRoots = createTempRootTracker();
 const originalJazzServerUrl = process.env.VITE_JAZZ_SERVER_URL;
@@ -49,7 +53,9 @@ describe("jazzPlugin", () => {
 
   it("config hook injects build target, worker format, and optimizeDeps exclude", () => {
     const plugin = jazzPlugin();
-    const config = (plugin as { config?: (c: Record<string, unknown>) => unknown }).config;
+    const config = (
+      plugin as { config?: (c: Record<string, unknown>) => unknown }
+    ).config;
     const result = config!({}) as {
       build?: { target?: string };
       worker?: { format?: string };
@@ -60,9 +66,22 @@ describe("jazzPlugin", () => {
     expect(result.optimizeDeps?.exclude).toContain("jazz-wasm");
   });
 
+  it("config hook respects a higher build target set by the user", () => {
+    const plugin = jazzPlugin();
+    const config = (
+      plugin as { config?: (c: Record<string, unknown>) => unknown }
+    ).config;
+    const result = config!({ build: { target: "esnext" } }) as {
+      build?: { target?: string };
+    };
+    expect(result.build?.target).toBe("esnext");
+  });
+
   it("config hook preserves existing optimizeDeps excludes", () => {
     const plugin = jazzPlugin();
-    const config = (plugin as { config?: (c: Record<string, unknown>) => unknown }).config;
+    const config = (
+      plugin as { config?: (c: Record<string, unknown>) => unknown }
+    ).config;
     const result = config!({ optimizeDeps: { exclude: ["some-dep"] } }) as {
       optimizeDeps?: { exclude?: string[] };
     };
@@ -83,7 +102,11 @@ describe("jazzPlugin", () => {
 
     const closeHandlers: (() => Promise<void> | void)[] = [];
     const fakeViteServer = {
-      config: { root: schemaDir, command: "serve" as const, env: {} as Record<string, string> },
+      config: {
+        root: schemaDir,
+        command: "serve" as const,
+        env: {} as Record<string, string>,
+      },
       httpServer: {
         once(_event: string, cb: () => void) {
           closeHandlers.push(cb);
@@ -110,12 +133,19 @@ describe("jazzPlugin", () => {
       },
     );
     const schemasRaw = await schemasResponse.text();
-    expect(schemasResponse.ok, `schemas ${schemasResponse.status}: ${schemasRaw}`).toBe(true);
+    expect(
+      schemasResponse.ok,
+      `schemas ${schemasResponse.status}: ${schemasRaw}`,
+    ).toBe(true);
     const body = JSON.parse(schemasRaw) as { hashes?: string[] };
     expect(body.hashes?.length).toBeGreaterThan(0);
     expect(fakeViteServer.config.env.VITE_JAZZ_APP_ID).toBeTruthy();
-    expect(fakeViteServer.config.env.VITE_JAZZ_SERVER_URL).toBe(`http://127.0.0.1:${port}`);
-    expect(process.env.VITE_JAZZ_APP_ID).toBe(fakeViteServer.config.env.VITE_JAZZ_APP_ID);
+    expect(fakeViteServer.config.env.VITE_JAZZ_SERVER_URL).toBe(
+      `http://127.0.0.1:${port}`,
+    );
+    expect(process.env.VITE_JAZZ_APP_ID).toBe(
+      fakeViteServer.config.env.VITE_JAZZ_APP_ID,
+    );
     expect(process.env.VITE_JAZZ_SERVER_URL).toBe(`http://127.0.0.1:${port}`);
     expect(logSpy).toHaveBeenCalledWith(
       expect.stringContaining(
@@ -129,7 +159,9 @@ describe("jazzPlugin", () => {
       await handler();
     }
 
-    await expect(fetch(`http://127.0.0.1:${port}/health`).then((r) => r.ok)).rejects.toThrow();
+    await expect(
+      fetch(`http://127.0.0.1:${port}/health`).then((r) => r.ok),
+    ).rejects.toThrow();
   }, 30_000);
 
   it("does not inject a dev server url during build", async () => {
@@ -167,7 +199,11 @@ describe("jazzPlugin", () => {
 
     const closeHandlers: (() => Promise<void> | void)[] = [];
     const fakeViteServer = {
-      config: { root: schemaDir, command: "serve" as const, env: {} as Record<string, string> },
+      config: {
+        root: schemaDir,
+        command: "serve" as const,
+        env: {} as Record<string, string>,
+      },
       httpServer: {
         once(_event: string, cb: () => void) {
           closeHandlers.push(cb);
@@ -198,7 +234,10 @@ describe("jazzPlugin", () => {
     await writeFile(join(schemaDir, "schema.ts"), todoSchema());
 
     const existingAppId = "00000000-0000-0000-0000-000000000001";
-    await writeFile(join(schemaDir, ".env"), `VITE_JAZZ_APP_ID=${existingAppId}\n`);
+    await writeFile(
+      join(schemaDir, ".env"),
+      `VITE_JAZZ_APP_ID=${existingAppId}\n`,
+    );
 
     const plugin = jazzPlugin({
       server: { port, adminSecret: "vite-existing-env-test-admin" },

--- a/packages/jazz-tools/src/dev/vite.test.ts
+++ b/packages/jazz-tools/src/dev/vite.test.ts
@@ -51,30 +51,17 @@ describe("jazzPlugin", () => {
     expect(plugin.name).toBe("jazz");
   });
 
-  it("config hook injects build target, worker format, and optimizeDeps exclude", () => {
+  it("config hook injects worker format and optimizeDeps exclude", () => {
     const plugin = jazzPlugin();
     const config = (
       plugin as { config?: (c: Record<string, unknown>) => unknown }
     ).config;
     const result = config!({}) as {
-      build?: { target?: string };
       worker?: { format?: string };
       optimizeDeps?: { exclude?: string[] };
     };
-    expect(result.build?.target).toBe("es2020");
     expect(result.worker?.format).toBe("es");
     expect(result.optimizeDeps?.exclude).toContain("jazz-wasm");
-  });
-
-  it("config hook respects a higher build target set by the user", () => {
-    const plugin = jazzPlugin();
-    const config = (
-      plugin as { config?: (c: Record<string, unknown>) => unknown }
-    ).config;
-    const result = config!({ build: { target: "esnext" } }) as {
-      build?: { target?: string };
-    };
-    expect(result.build?.target).toBe("esnext");
   });
 
   it("config hook preserves existing optimizeDeps excludes", () => {

--- a/packages/jazz-tools/src/dev/vite.test.ts
+++ b/packages/jazz-tools/src/dev/vite.test.ts
@@ -47,6 +47,29 @@ describe("jazzPlugin", () => {
     expect(plugin.name).toBe("jazz");
   });
 
+  it("config hook injects build target, worker format, and optimizeDeps exclude", () => {
+    const plugin = jazzPlugin();
+    const config = (plugin as { config?: (c: Record<string, unknown>) => unknown }).config;
+    const result = config!({}) as {
+      build?: { target?: string };
+      worker?: { format?: string };
+      optimizeDeps?: { exclude?: string[] };
+    };
+    expect(result.build?.target).toBe("es2020");
+    expect(result.worker?.format).toBe("es");
+    expect(result.optimizeDeps?.exclude).toContain("jazz-wasm");
+  });
+
+  it("config hook preserves existing optimizeDeps excludes", () => {
+    const plugin = jazzPlugin();
+    const config = (plugin as { config?: (c: Record<string, unknown>) => unknown }).config;
+    const result = config!({ optimizeDeps: { exclude: ["some-dep"] } }) as {
+      optimizeDeps?: { exclude?: string[] };
+    };
+    expect(result.optimizeDeps?.exclude).toContain("jazz-wasm");
+    expect(result.optimizeDeps?.exclude).toContain("some-dep");
+  });
+
   it("starts a server and pushes schema via configureServer hook", async () => {
     const port = await getAvailablePort();
     const schemaDir = await tempRoots.create("jazz-vite-test-");

--- a/packages/jazz-tools/src/dev/vite.test.ts
+++ b/packages/jazz-tools/src/dev/vite.test.ts
@@ -2,11 +2,7 @@ import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { jazzPlugin } from "./vite.js";
-import {
-  createTempRootTracker,
-  getAvailablePort,
-  todoSchema,
-} from "./test-helpers.js";
+import { createTempRootTracker, getAvailablePort, todoSchema } from "./test-helpers.js";
 
 const tempRoots = createTempRootTracker();
 const originalJazzServerUrl = process.env.VITE_JAZZ_SERVER_URL;
@@ -53,9 +49,7 @@ describe("jazzPlugin", () => {
 
   it("config hook injects worker format and optimizeDeps exclude", () => {
     const plugin = jazzPlugin();
-    const config = (
-      plugin as { config?: (c: Record<string, unknown>) => unknown }
-    ).config;
+    const config = (plugin as { config?: (c: Record<string, unknown>) => unknown }).config;
     const result = config!({}) as {
       worker?: { format?: string };
       optimizeDeps?: { exclude?: string[] };
@@ -66,9 +60,7 @@ describe("jazzPlugin", () => {
 
   it("config hook preserves existing optimizeDeps excludes", () => {
     const plugin = jazzPlugin();
-    const config = (
-      plugin as { config?: (c: Record<string, unknown>) => unknown }
-    ).config;
+    const config = (plugin as { config?: (c: Record<string, unknown>) => unknown }).config;
     const result = config!({ optimizeDeps: { exclude: ["some-dep"] } }) as {
       optimizeDeps?: { exclude?: string[] };
     };
@@ -120,19 +112,12 @@ describe("jazzPlugin", () => {
       },
     );
     const schemasRaw = await schemasResponse.text();
-    expect(
-      schemasResponse.ok,
-      `schemas ${schemasResponse.status}: ${schemasRaw}`,
-    ).toBe(true);
+    expect(schemasResponse.ok, `schemas ${schemasResponse.status}: ${schemasRaw}`).toBe(true);
     const body = JSON.parse(schemasRaw) as { hashes?: string[] };
     expect(body.hashes?.length).toBeGreaterThan(0);
     expect(fakeViteServer.config.env.VITE_JAZZ_APP_ID).toBeTruthy();
-    expect(fakeViteServer.config.env.VITE_JAZZ_SERVER_URL).toBe(
-      `http://127.0.0.1:${port}`,
-    );
-    expect(process.env.VITE_JAZZ_APP_ID).toBe(
-      fakeViteServer.config.env.VITE_JAZZ_APP_ID,
-    );
+    expect(fakeViteServer.config.env.VITE_JAZZ_SERVER_URL).toBe(`http://127.0.0.1:${port}`);
+    expect(process.env.VITE_JAZZ_APP_ID).toBe(fakeViteServer.config.env.VITE_JAZZ_APP_ID);
     expect(process.env.VITE_JAZZ_SERVER_URL).toBe(`http://127.0.0.1:${port}`);
     expect(logSpy).toHaveBeenCalledWith(
       expect.stringContaining(
@@ -146,9 +131,7 @@ describe("jazzPlugin", () => {
       await handler();
     }
 
-    await expect(
-      fetch(`http://127.0.0.1:${port}/health`).then((r) => r.ok),
-    ).rejects.toThrow();
+    await expect(fetch(`http://127.0.0.1:${port}/health`).then((r) => r.ok)).rejects.toThrow();
   }, 30_000);
 
   it("does not inject a dev server url during build", async () => {
@@ -221,10 +204,7 @@ describe("jazzPlugin", () => {
     await writeFile(join(schemaDir, "schema.ts"), todoSchema());
 
     const existingAppId = "00000000-0000-0000-0000-000000000001";
-    await writeFile(
-      join(schemaDir, ".env"),
-      `VITE_JAZZ_APP_ID=${existingAppId}\n`,
-    );
+    await writeFile(join(schemaDir, ".env"), `VITE_JAZZ_APP_ID=${existingAppId}\n`);
 
     const plugin = jazzPlugin({
       server: { port, adminSecret: "vite-existing-env-test-admin" },

--- a/packages/jazz-tools/src/dev/vite.ts
+++ b/packages/jazz-tools/src/dev/vite.ts
@@ -40,7 +40,10 @@ export interface ViteDevServer {
   };
   httpServer: { once(event: string, cb: () => void): void } | null;
   ws: {
-    send(payload: { type: string; err?: { message: string; stack?: string } }): void;
+    send(payload: {
+      type: string;
+      err?: { message: string; stack?: string };
+    }): void;
   };
 }
 
@@ -56,12 +59,17 @@ export function jazzPlugin(options: JazzPluginOptions = {}) {
   return {
     name: "jazz",
 
-    config(config: { optimizeDeps?: { exclude?: string[] } }) {
+    config(config: {
+      build?: { target?: string | string[] };
+      optimizeDeps?: { exclude?: string[] };
+    }) {
       const existing = config.optimizeDeps?.exclude ?? [];
       return {
-        build: { target: "es2020" },
+        build: { target: config.build?.target ?? "es2020" },
         worker: { format: "es" as const },
-        optimizeDeps: { exclude: Array.from(new Set([...existing, "jazz-wasm"])) },
+        optimizeDeps: {
+          exclude: Array.from(new Set([...existing, "jazz-wasm"])),
+        },
       };
     },
 

--- a/packages/jazz-tools/src/dev/vite.ts
+++ b/packages/jazz-tools/src/dev/vite.ts
@@ -40,10 +40,7 @@ export interface ViteDevServer {
   };
   httpServer: { once(event: string, cb: () => void): void } | null;
   ws: {
-    send(payload: {
-      type: string;
-      err?: { message: string; stack?: string };
-    }): void;
+    send(payload: { type: string; err?: { message: string; stack?: string } }): void;
   };
 }
 

--- a/packages/jazz-tools/src/dev/vite.ts
+++ b/packages/jazz-tools/src/dev/vite.ts
@@ -59,13 +59,9 @@ export function jazzPlugin(options: JazzPluginOptions = {}) {
   return {
     name: "jazz",
 
-    config(config: {
-      build?: { target?: string | string[] };
-      optimizeDeps?: { exclude?: string[] };
-    }) {
+    config(config: { optimizeDeps?: { exclude?: string[] } }) {
       const existing = config.optimizeDeps?.exclude ?? [];
       return {
-        build: { target: config.build?.target ?? "es2020" },
         worker: { format: "es" as const },
         optimizeDeps: {
           exclude: Array.from(new Set([...existing, "jazz-wasm"])),

--- a/packages/jazz-tools/src/dev/vite.ts
+++ b/packages/jazz-tools/src/dev/vite.ts
@@ -56,6 +56,15 @@ export function jazzPlugin(options: JazzPluginOptions = {}) {
   return {
     name: "jazz",
 
+    config(config: { optimizeDeps?: { exclude?: string[] } }) {
+      const existing = config.optimizeDeps?.exclude ?? [];
+      return {
+        build: { target: "es2020" },
+        worker: { format: "es" as const },
+        optimizeDeps: { exclude: Array.from(new Set([...existing, "jazz-wasm"])) },
+      };
+    },
+
     async configureServer(viteServer: ViteDevServer) {
       if (viteServer.config.command !== "serve") return;
 


### PR DESCRIPTION
## Summary

- `jazzPlugin` and `jazzSvelteKit` now inject `worker.format: "es"`, and `optimizeDeps.exclude: ["jazz-wasm"]` via a Vite `config` hook, so consumers no longer need to set these manually
- Removes the now-redundant explicit settings from all example `vite.config.ts` files
- Adds tests for the new `config` hook behaviour in both plugins

## Test plan

- [ ] `pnpm --filter jazz-tools test` passes (vite and sveltekit plugin tests)
- [ ] Example apps build without errors