### PR TITLE
starters: add Jazz skill install guidance to AGENTS.md

### DIFF
--- a/starters/next-betterauth/AGENTS.md
+++ b/starters/next-betterauth/AGENTS.md
@@ -31,3 +31,18 @@ Only fetch the pages you actually need.
 - **Concepts** — local-first data model, how sync works, branches
 - **Recipes** — user-owned data, shared access, real-time collaboration, nested data
 - **Reference** — column types, operators, framework patterns, FAQ
+
+## Agent skill
+
+Install the Jazz skill for richer, automatic doc lookup:
+
+```bash
+# Claude Code
+npx @anthropic-ai/claude-code skills install garden-co/jazz-skill
+
+# Gemini CLI
+gemini skills install garden-co/jazz-skill
+
+# Any agent (via skills.sh)
+npx skills add garden-co/jazz-skill
+```

--- a/starters/next-hybrid/AGENTS.md
+++ b/starters/next-hybrid/AGENTS.md
@@ -31,3 +31,18 @@ Only fetch the pages you actually need.
 - **Concepts** — local-first data model, how sync works, branches
 - **Recipes** — user-owned data, shared access, real-time collaboration, nested data
 - **Reference** — column types, operators, framework patterns, FAQ
+
+## Agent skill
+
+Install the Jazz skill for richer, automatic doc lookup:
+
+```bash
+# Claude Code
+npx @anthropic-ai/claude-code skills install garden-co/jazz-skill
+
+# Gemini CLI
+gemini skills install garden-co/jazz-skill
+
+# Any agent (via skills.sh)
+npx skills add garden-co/jazz-skill
+```

--- a/starters/next-localfirst/AGENTS.md
+++ b/starters/next-localfirst/AGENTS.md
@@ -31,3 +31,18 @@ Only fetch the pages you actually need.
 - **Concepts** — local-first data model, how sync works, branches
 - **Recipes** — user-owned data, shared access, real-time collaboration, nested data
 - **Reference** — column types, operators, framework patterns, FAQ
+
+## Agent skill
+
+Install the Jazz skill for richer, automatic doc lookup:
+
+```bash
+# Claude Code
+npx @anthropic-ai/claude-code skills install garden-co/jazz-skill
+
+# Gemini CLI
+gemini skills install garden-co/jazz-skill
+
+# Any agent (via skills.sh)
+npx skills add garden-co/jazz-skill
+```

--- a/starters/react-betterauth/AGENTS.md
+++ b/starters/react-betterauth/AGENTS.md
@@ -31,3 +31,18 @@ Only fetch the pages you actually need.
 - **Concepts** — local-first data model, how sync works, branches
 - **Recipes** — user-owned data, shared access, real-time collaboration, nested data
 - **Reference** — column types, operators, framework patterns, FAQ
+
+## Agent skill
+
+Install the Jazz skill for richer, automatic doc lookup:
+
+```bash
+# Claude Code
+npx @anthropic-ai/claude-code skills install garden-co/jazz-skill
+
+# Gemini CLI
+gemini skills install garden-co/jazz-skill
+
+# Any agent (via skills.sh)
+npx skills add garden-co/jazz-skill
+```

--- a/starters/react-hybrid/AGENTS.md
+++ b/starters/react-hybrid/AGENTS.md
@@ -31,3 +31,18 @@ Only fetch the pages you actually need.
 - **Concepts** — local-first data model, how sync works, branches
 - **Recipes** — user-owned data, shared access, real-time collaboration, nested data
 - **Reference** — column types, operators, framework patterns, FAQ
+
+## Agent skill
+
+Install the Jazz skill for richer, automatic doc lookup:
+
+```bash
+# Claude Code
+npx @anthropic-ai/claude-code skills install garden-co/jazz-skill
+
+# Gemini CLI
+gemini skills install garden-co/jazz-skill
+
+# Any agent (via skills.sh)
+npx skills add garden-co/jazz-skill
+```

--- a/starters/react-localfirst/AGENTS.md
+++ b/starters/react-localfirst/AGENTS.md
@@ -31,3 +31,18 @@ Only fetch the pages you actually need.
 - **Concepts** — local-first data model, how sync works, branches
 - **Recipes** — user-owned data, shared access, real-time collaboration, nested data
 - **Reference** — column types, operators, framework patterns, FAQ
+
+## Agent skill
+
+Install the Jazz skill for richer, automatic doc lookup:
+
+```bash
+# Claude Code
+npx @anthropic-ai/claude-code skills install garden-co/jazz-skill
+
+# Gemini CLI
+gemini skills install garden-co/jazz-skill
+
+# Any agent (via skills.sh)
+npx skills add garden-co/jazz-skill
+```

--- a/starters/sveltekit-betterauth/AGENTS.md
+++ b/starters/sveltekit-betterauth/AGENTS.md
@@ -31,3 +31,18 @@ Only fetch the pages you actually need.
 - **Concepts** — local-first data model, how sync works, branches
 - **Recipes** — user-owned data, shared access, real-time collaboration, nested data
 - **Reference** — column types, operators, framework patterns, FAQ
+
+## Agent skill
+
+Install the Jazz skill for richer, automatic doc lookup:
+
+```bash
+# Claude Code
+npx @anthropic-ai/claude-code skills install garden-co/jazz-skill
+
+# Gemini CLI
+gemini skills install garden-co/jazz-skill
+
+# Any agent (via skills.sh)
+npx skills add garden-co/jazz-skill
+```

--- a/starters/sveltekit-hybrid/AGENTS.md
+++ b/starters/sveltekit-hybrid/AGENTS.md
@@ -31,3 +31,18 @@ Only fetch the pages you actually need.
 - **Concepts** — local-first data model, how sync works, branches
 - **Recipes** — user-owned data, shared access, real-time collaboration, nested data
 - **Reference** — column types, operators, framework patterns, FAQ
+
+## Agent skill
+
+Install the Jazz skill for richer, automatic doc lookup:
+
+```bash
+# Claude Code
+npx @anthropic-ai/claude-code skills install garden-co/jazz-skill
+
+# Gemini CLI
+gemini skills install garden-co/jazz-skill
+
+# Any agent (via skills.sh)
+npx skills add garden-co/jazz-skill
+```

--- a/starters/sveltekit-localfirst/AGENTS.md
+++ b/starters/sveltekit-localfirst/AGENTS.md
@@ -31,3 +31,18 @@ Only fetch the pages you actually need.
 - **Concepts** — local-first data model, how sync works, branches
 - **Recipes** — user-owned data, shared access, real-time collaboration, nested data
 - **Reference** — column types, operators, framework patterns, FAQ
+
+## Agent skill
+
+Install the Jazz skill for richer, automatic doc lookup:
+
+```bash
+# Claude Code
+npx @anthropic-ai/claude-code skills install garden-co/jazz-skill
+
+# Gemini CLI
+gemini skills install garden-co/jazz-skill
+
+# Any agent (via skills.sh)
+npx skills add garden-co/jazz-skill
+```


### PR DESCRIPTION
## Summary

Adds a skill install section to the `AGENTS.md` in all nine starters, covering Claude Code, Gemini CLI, and the generic `skills.sh` installer.

Stacked on top of #630.

## ⚠️ Do not merge until `garden-co/jazz-skill` is public

This PR references `garden-co/jazz-skill` directly in install commands. Merging before the repo is public will surface broken instructions to users.

## Test plan

- [ ] `node scripts/check-starters-parity.mjs` passes
- [ ] All nine `AGENTS.md` files are byte-identical