### PR TITLE
chore: update docs URLs in starter AGENTS.md files

### DIFF
--- a/starters/next-betterauth/AGENTS.md
+++ b/starters/next-betterauth/AGENTS.md
@@ -9,13 +9,13 @@ Jazz is actively developed. Always fetch the live docs before answering Jazz-rel
 **Step 1:** Fetch the page index to identify relevant pages:
 
 ```
-https://jazz2-docs.vercel.app/llms.txt
+https://jazz.tools/llms.txt
 ```
 
 **Step 2:** Fetch the relevant page by appending `.mdx` to its path, e.g.:
 
 ```
-https://jazz2-docs.vercel.app/docs/schemas/defining-tables.mdx
+https://jazz.tools/docs/schemas/defining-tables.mdx
 ```
 
 Only fetch the pages you actually need.

--- a/starters/next-hybrid/AGENTS.md
+++ b/starters/next-hybrid/AGENTS.md
@@ -9,13 +9,13 @@ Jazz is actively developed. Always fetch the live docs before answering Jazz-rel
 **Step 1:** Fetch the page index to identify relevant pages:
 
 ```
-https://jazz2-docs.vercel.app/llms.txt
+https://jazz.tools/llms.txt
 ```
 
 **Step 2:** Fetch the relevant page by appending `.mdx` to its path, e.g.:
 
 ```
-https://jazz2-docs.vercel.app/docs/schemas/defining-tables.mdx
+https://jazz.tools/docs/schemas/defining-tables.mdx
 ```
 
 Only fetch the pages you actually need.

--- a/starters/next-localfirst/AGENTS.md
+++ b/starters/next-localfirst/AGENTS.md
@@ -9,13 +9,13 @@ Jazz is actively developed. Always fetch the live docs before answering Jazz-rel
 **Step 1:** Fetch the page index to identify relevant pages:
 
 ```
-https://jazz2-docs.vercel.app/llms.txt
+https://jazz.tools/llms.txt
 ```
 
 **Step 2:** Fetch the relevant page by appending `.mdx` to its path, e.g.:
 
 ```
-https://jazz2-docs.vercel.app/docs/schemas/defining-tables.mdx
+https://jazz.tools/docs/schemas/defining-tables.mdx
 ```
 
 Only fetch the pages you actually need.

--- a/starters/react-betterauth/AGENTS.md
+++ b/starters/react-betterauth/AGENTS.md
@@ -9,13 +9,13 @@ Jazz is actively developed. Always fetch the live docs before answering Jazz-rel
 **Step 1:** Fetch the page index to identify relevant pages:
 
 ```
-https://jazz2-docs.vercel.app/llms.txt
+https://jazz.tools/llms.txt
 ```
 
 **Step 2:** Fetch the relevant page by appending `.mdx` to its path, e.g.:
 
 ```
-https://jazz2-docs.vercel.app/docs/schemas/defining-tables.mdx
+https://jazz.tools/docs/schemas/defining-tables.mdx
 ```
 
 Only fetch the pages you actually need.

--- a/starters/react-hybrid/AGENTS.md
+++ b/starters/react-hybrid/AGENTS.md
@@ -9,13 +9,13 @@ Jazz is actively developed. Always fetch the live docs before answering Jazz-rel
 **Step 1:** Fetch the page index to identify relevant pages:
 
 ```
-https://jazz2-docs.vercel.app/llms.txt
+https://jazz.tools/llms.txt
 ```
 
 **Step 2:** Fetch the relevant page by appending `.mdx` to its path, e.g.:
 
 ```
-https://jazz2-docs.vercel.app/docs/schemas/defining-tables.mdx
+https://jazz.tools/docs/schemas/defining-tables.mdx
 ```
 
 Only fetch the pages you actually need.

--- a/starters/react-localfirst/AGENTS.md
+++ b/starters/react-localfirst/AGENTS.md
@@ -9,13 +9,13 @@ Jazz is actively developed. Always fetch the live docs before answering Jazz-rel
 **Step 1:** Fetch the page index to identify relevant pages:
 
 ```
-https://jazz2-docs.vercel.app/llms.txt
+https://jazz.tools/llms.txt
 ```
 
 **Step 2:** Fetch the relevant page by appending `.mdx` to its path, e.g.:
 
 ```
-https://jazz2-docs.vercel.app/docs/schemas/defining-tables.mdx
+https://jazz.tools/docs/schemas/defining-tables.mdx
 ```
 
 Only fetch the pages you actually need.

--- a/starters/sveltekit-betterauth/AGENTS.md
+++ b/starters/sveltekit-betterauth/AGENTS.md
@@ -9,13 +9,13 @@ Jazz is actively developed. Always fetch the live docs before answering Jazz-rel
 **Step 1:** Fetch the page index to identify relevant pages:
 
 ```
-https://jazz2-docs.vercel.app/llms.txt
+https://jazz.tools/llms.txt
 ```
 
 **Step 2:** Fetch the relevant page by appending `.mdx` to its path, e.g.:
 
 ```
-https://jazz2-docs.vercel.app/docs/schemas/defining-tables.mdx
+https://jazz.tools/docs/schemas/defining-tables.mdx
 ```
 
 Only fetch the pages you actually need.

--- a/starters/sveltekit-hybrid/AGENTS.md
+++ b/starters/sveltekit-hybrid/AGENTS.md
@@ -9,13 +9,13 @@ Jazz is actively developed. Always fetch the live docs before answering Jazz-rel
 **Step 1:** Fetch the page index to identify relevant pages:
 
 ```
-https://jazz2-docs.vercel.app/llms.txt
+https://jazz.tools/llms.txt
 ```
 
 **Step 2:** Fetch the relevant page by appending `.mdx` to its path, e.g.:
 
 ```
-https://jazz2-docs.vercel.app/docs/schemas/defining-tables.mdx
+https://jazz.tools/docs/schemas/defining-tables.mdx
 ```
 
 Only fetch the pages you actually need.

--- a/starters/sveltekit-localfirst/AGENTS.md
+++ b/starters/sveltekit-localfirst/AGENTS.md
@@ -9,13 +9,13 @@ Jazz is actively developed. Always fetch the live docs before answering Jazz-rel
 **Step 1:** Fetch the page index to identify relevant pages:
 
 ```
-https://jazz2-docs.vercel.app/llms.txt
+https://jazz.tools/llms.txt
 ```
 
 **Step 2:** Fetch the relevant page by appending `.mdx` to its path, e.g.:
 
 ```
-https://jazz2-docs.vercel.app/docs/schemas/defining-tables.mdx
+https://jazz.tools/docs/schemas/defining-tables.mdx
 ```
 
 Only fetch the pages you actually need.


### PR DESCRIPTION
Replaces `jazz2-docs.vercel.app` with `jazz.tools` across all starter `AGENTS.md` files.