### PR TITLE
fix: skip upstream-confirmed rows when replaying to server

### DIFF
--- a/.changeset/skip-upstream-confirmed-rows-on-reconnect.md
+++ b/.changeset/skip-upstream-confirmed-rows-on-reconnect.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Stop replaying upstream-confirmed rows to the server on reconnect. The client's full-storage sync now skips rows whose `confirmed_tier` is already above the node's own tier, so a user-role client no longer re-pushes subscription-delivered rows it never authored. Previously these replays were rejected by row-level update policies (e.g. "Update denied by USING policy — cannot see old row") on every reconnect.

--- a/crates/jazz-tools/src/sync_manager/sync_logic.rs
+++ b/crates/jazz-tools/src/sync_manager/sync_logic.rs
@@ -66,8 +66,22 @@ impl SyncManager {
         else {
             return;
         };
+        let my_max_tier = self.max_local_durability_tier();
 
         for row in rows.into_iter() {
+            // Skip rows already confirmed above our own tier — an upstream
+            // server has them. Without this, a user-role client replays every
+            // stored row (including ones authored by other users that it only
+            // observed via subscription) on every reconnect, which the server
+            // rejects under row-level update policies.
+            let already_upstream = match (row.confirmed_tier, my_max_tier) {
+                (None, _) => false,
+                (Some(_), None) => true,
+                (Some(row_tier), Some(local_tier)) => row_tier > local_tier,
+            };
+            if already_upstream {
+                continue;
+            }
             row_sync.push((object_id, metadata.clone(), row));
         }
     }

--- a/crates/jazz-tools/src/sync_manager/tests.rs
+++ b/crates/jazz-tools/src/sync_manager/tests.rs
@@ -2849,6 +2849,65 @@ fn add_server_with_storage_syncs_full_row_history_to_server() {
     ));
 }
 
+#[test]
+fn add_server_with_storage_skips_rows_already_confirmed_upstream() {
+    let mut io = MemoryStorage::new();
+    let row_id = ObjectId::new();
+    let local_pending = visible_row(row_id, "main", Vec::new(), 1_000, b"local-pending");
+    let upstream_confirmed = row_with_state(
+        visible_row(
+            row_id,
+            "main",
+            vec![local_pending.batch_id()],
+            2_000,
+            b"upstream",
+        ),
+        crate::row_histories::RowState::VisibleDirect,
+        Some(DurabilityTier::EdgeServer),
+    );
+
+    seed_users_schema(&mut io);
+    io.put_row_locator(
+        row_id,
+        Some(
+            &crate::storage::row_locator_from_metadata(&row_metadata("users"))
+                .expect("row metadata should produce a row locator"),
+        ),
+    )
+    .unwrap();
+    io.append_history_region_rows(
+        "users",
+        &[local_pending.clone(), upstream_confirmed.clone()],
+    )
+    .unwrap();
+    io.upsert_visible_region_rows(
+        "users",
+        std::slice::from_ref(&VisibleRowEntry::rebuild(
+            upstream_confirmed.clone(),
+            &[local_pending.clone(), upstream_confirmed.clone()],
+        )),
+    )
+    .unwrap();
+
+    let mut sm = SyncManager::new();
+    let server_id = ServerId::new();
+    sm.add_server_with_storage(server_id, false, &io);
+
+    let outbox = sm.take_outbox();
+    let pushed_batch_ids: Vec<_> = outbox
+        .iter()
+        .filter_map(|entry| match entry {
+            OutboxEntry {
+                destination: Destination::Server(id),
+                payload: SyncPayload::RowBatchCreated { row, .. },
+            } if *id == server_id => Some(row.batch_id()),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(pushed_batch_ids, vec![local_pending.batch_id()]);
+}
+
 fn push_query_subscription(
     sm: &mut SyncManager,
     client_id: ClientId,


### PR DESCRIPTION
## Summary

- User-role clients (like the shareable-diagrams browser app) were spamming `PermissionDenied { reason: "Update denied by USING policy on table documents - cannot see old row" }` on every reconnect.
- Root cause: `queue_full_sync_to_server_from_storage` replays **every** stored history row back to the server, including rows the client only observed via subscription. The server's row-level update policies reject those replays because the client isn't authorized to update them.
- Fix: in `collect_row_sync_versions`, skip rows whose `confirmed_tier` is already above the local node's own tier. For a pure user-role client (no local tier), any row with a `confirmed_tier` means an upstream server already has it. Locally-pending writes (`confirmed_tier = None`) still replay, so ack-chasing still works. For tiered nodes (edge/global), the comparison handles them correctly: an edge server still pushes its edge-confirmed rows up, but skips rows already global-confirmed.

## Test plan

- [x] New unit test `add_server_with_storage_skips_rows_already_confirmed_upstream` in `sync_manager/tests.rs`. Red-then-green verified: fails without the fix, passes with.
- [x] Existing `add_server_with_storage_syncs_full_row_history_to_server` still passes (locally-pending rows replay unchanged).
- [x] Full `cargo test -p jazz-tools --features test --lib` passes (1291 tests).
- [x] Browser repro: loaded shareable-diagrams against the live v2 server with a document the user can read but not edit. Before: `PermissionDenied` at 129s, 140s, 158s, 278s, 313s. After the WASM rebuild: zero `PermissionDenied` entries over 2.5 minutes, only the expected startup `CatalogueWriteDenied` noise.