### PR TITLE
fix: auto-generated server URL in starter apps

### DIFF
--- a/packages/create-jazz/src/cloud-init.test.ts
+++ b/packages/create-jazz/src/cloud-init.test.ts
@@ -20,7 +20,7 @@ const SVELTE_KEYS = {
   backendSecret: "BACKEND_SECRET",
 };
 
-const CLOUD_SYNC_URL = "https://prod.v2.aws.cloud.jazz.tools/";
+const CLOUD_SYNC_URL = "https://v2.sync.jazz.tools/";
 const API_URL = "https://example.com/api/apps/generate";
 
 let dir: string;

--- a/packages/create-jazz/src/cloud-init.test.ts
+++ b/packages/create-jazz/src/cloud-init.test.ts
@@ -74,7 +74,7 @@ describe("runHostedInit", () => {
       const content = readEnv(dir);
       const values = parseEnv(content);
       expect(values["NEXT_PUBLIC_JAZZ_APP_ID"]).toBe("app-alice");
-      expect(values["NEXT_PUBLIC_JAZZ_SERVER_URL"]).toBe(`${CLOUD_SYNC_URL}apps/app-alice/`);
+      expect(values["NEXT_PUBLIC_JAZZ_SERVER_URL"]).toBe(CLOUD_SYNC_URL);
       expect(values["JAZZ_ADMIN_SECRET"]).toBe("admin-secret-alice");
       expect(values["BACKEND_SECRET"]).toBe("backend-secret-alice");
       expect(content).not.toContain("TODO");
@@ -111,7 +111,7 @@ describe("runHostedInit", () => {
 
       const values = parseEnv(readEnv(dir));
       expect(values["PUBLIC_JAZZ_APP_ID"]).toBe("app-bob");
-      expect(values["PUBLIC_JAZZ_SERVER_URL"]).toBe(`${CLOUD_SYNC_URL}apps/app-bob/`);
+      expect(values["PUBLIC_JAZZ_SERVER_URL"]).toBe(CLOUD_SYNC_URL);
       expect(values["JAZZ_ADMIN_SECRET"]).toBe("admin-bob");
       expect(values["BACKEND_SECRET"]).toBe("backend-bob");
     });

--- a/packages/create-jazz/src/cloud-init.ts
+++ b/packages/create-jazz/src/cloud-init.ts
@@ -33,18 +33,6 @@ function readEnvValues(envPath: string): Record<string, string> {
   return values;
 }
 
-/**
- * Compose the per-app server URL. The Jazz Cloud proxy routes requests
- * under `/apps/<appId>/…`, so the value we write to .env must already carry
- * the app-specific prefix — otherwise the plugin's schema-push would hit
- * the cloud root and 404.
- */
-function composeAppServerUrl(cloudSyncUrl: string, appId: string): string {
-  const base = cloudSyncUrl.replace(/\/+$/, "");
-  const suffix = `/apps/${appId}`;
-  return base.endsWith(suffix) ? `${base}/` : `${base}${suffix}/`;
-}
-
 export async function runHostedInit(options: RunHostedInitOptions): Promise<void> {
   const { dir, cloudSyncUrl, envKeys, apiUrl } = options;
   const keys = [envKeys.appId, envKeys.serverUrl, envKeys.adminSecret, envKeys.backendSecret];
@@ -70,13 +58,12 @@ export async function runHostedInit(options: RunHostedInitOptions): Promise<void
     }
 
     const { appId, adminSecret, backendSecret } = provisioned;
-    const appServerUrl = composeAppServerUrl(cloudSyncUrl, appId);
 
     writeHostedEnv({
       dir,
       values: {
         [envKeys.appId]: appId,
-        [envKeys.serverUrl]: appServerUrl,
+        [envKeys.serverUrl]: cloudSyncUrl,
         [envKeys.adminSecret]: adminSecret,
         [envKeys.backendSecret]: backendSecret,
       },

--- a/packages/create-jazz/src/cloud-init.ts
+++ b/packages/create-jazz/src/cloud-init.ts
@@ -72,7 +72,7 @@ export async function runHostedInit(options: RunHostedInitOptions): Promise<void
 
     console.log("Jazz app provisioned successfully and written to .env:");
     console.log(`  ${envKeys.appId}=${appId}`);
-    console.log(`  ${envKeys.serverUrl}=${appServerUrl}`);
+    console.log(`  ${envKeys.serverUrl}=${cloudSyncUrl}`);
     console.log(`  ${envKeys.adminSecret}=${adminSecret}`);
     console.log(`  ${envKeys.backendSecret}=${backendSecret}`);
     console.log("");

--- a/packages/create-jazz/src/index.ts
+++ b/packages/create-jazz/src/index.ts
@@ -26,7 +26,7 @@ const STARTERS: Record<Framework, Record<Auth, StarterName | null>> = {
 };
 
 const VALID_HOSTING_VALUES: Hosting[] = ["hosted", "selfhosted"];
-const CLOUD_SYNC_URL = "https://prod.v2.aws.cloud.jazz.tools/";
+const CLOUD_SYNC_URL = "https://v2.sync.jazz.tools/";
 
 interface HostedEnvKeys {
   appId: string;

--- a/starters/next-betterauth/README.md
+++ b/starters/next-betterauth/README.md
@@ -89,7 +89,7 @@ write the values below by hand.
 | ----------------------------- | ---------- | ------------------------------------------------------------------- |
 | `BETTER_AUTH_SECRET`          | always     | BetterAuth session signing. `lib/auth.ts` throws loudly if missing. |
 | `NEXT_PUBLIC_JAZZ_APP_ID`     | cloud only | Provisioned app ID. Unset in self-hosted dev — plugin injects it.   |
-| `NEXT_PUBLIC_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://prod.v2.aws.cloud.jazz.tools`).       |
+| `NEXT_PUBLIC_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://v2.sync.jazz.tools`).                 |
 | `JAZZ_ADMIN_SECRET`           | cloud only | Admin credential for schema pushes to the cloud.                    |
 | `BACKEND_SECRET`              | cloud only | Backend signing credential.                                         |
 

--- a/starters/next-betterauth/README.md
+++ b/starters/next-betterauth/README.md
@@ -85,13 +85,13 @@ session on every row and the permission policy scopes reads/writes to it.
 Scaffold via `create-jazz` to have `.env` populated automatically; otherwise
 write the values below by hand.
 
-| Variable                      | When       | Purpose                                                              |
-| ----------------------------- | ---------- | -------------------------------------------------------------------- |
-| `BETTER_AUTH_SECRET`          | always     | BetterAuth session signing. `lib/auth.ts` throws loudly if missing.  |
-| `NEXT_PUBLIC_JAZZ_APP_ID`     | cloud only | Provisioned app ID. Unset in self-hosted dev — plugin injects it.    |
-| `NEXT_PUBLIC_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://prod.v2.aws.cloud.jazz.tools/apps/…`). |
-| `JAZZ_ADMIN_SECRET`           | cloud only | Admin credential for schema pushes to the cloud.                     |
-| `BACKEND_SECRET`              | cloud only | Backend signing credential.                                          |
+| Variable                      | When       | Purpose                                                             |
+| ----------------------------- | ---------- | ------------------------------------------------------------------- |
+| `BETTER_AUTH_SECRET`          | always     | BetterAuth session signing. `lib/auth.ts` throws loudly if missing. |
+| `NEXT_PUBLIC_JAZZ_APP_ID`     | cloud only | Provisioned app ID. Unset in self-hosted dev — plugin injects it.   |
+| `NEXT_PUBLIC_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://prod.v2.aws.cloud.jazz.tools`).       |
+| `JAZZ_ADMIN_SECRET`           | cloud only | Admin credential for schema pushes to the cloud.                    |
+| `BACKEND_SECRET`              | cloud only | Backend signing credential.                                         |
 
 Generate a dev `BETTER_AUTH_SECRET` with `openssl rand -base64 32`. In
 self-hosted mode (no cloud env vars), the `withJazz` plugin spawns a local

--- a/starters/next-hybrid/README.md
+++ b/starters/next-hybrid/README.md
@@ -99,13 +99,13 @@ session on every row and the permission policy scopes reads/writes to it.
 Scaffold via `create-jazz` to have `.env` populated automatically; otherwise
 write the values below by hand.
 
-| Variable                      | When       | Purpose                                                              |
-| ----------------------------- | ---------- | -------------------------------------------------------------------- |
-| `BETTER_AUTH_SECRET`          | always     | BetterAuth session signing. `lib/auth.ts` throws if missing.         |
-| `NEXT_PUBLIC_JAZZ_APP_ID`     | cloud only | Provisioned app ID. Unset in self-hosted dev — plugin injects it.    |
-| `NEXT_PUBLIC_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://prod.v2.aws.cloud.jazz.tools/apps/…`). |
-| `JAZZ_ADMIN_SECRET`           | cloud only | Admin credential for schema pushes to the cloud.                     |
-| `BACKEND_SECRET`              | cloud only | Backend signing credential.                                          |
+| Variable                      | When       | Purpose                                                           |
+| ----------------------------- | ---------- | ----------------------------------------------------------------- |
+| `BETTER_AUTH_SECRET`          | always     | BetterAuth session signing. `lib/auth.ts` throws if missing.      |
+| `NEXT_PUBLIC_JAZZ_APP_ID`     | cloud only | Provisioned app ID. Unset in self-hosted dev — plugin injects it. |
+| `NEXT_PUBLIC_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://prod.v2.aws.cloud.jazz.tools`).     |
+| `JAZZ_ADMIN_SECRET`           | cloud only | Admin credential for schema pushes to the cloud.                  |
+| `BACKEND_SECRET`              | cloud only | Backend signing credential.                                       |
 
 Generate a dev `BETTER_AUTH_SECRET` with `openssl rand -base64 32`. In
 self-hosted mode (no cloud env vars), the `withJazz` plugin spawns a local

--- a/starters/next-hybrid/README.md
+++ b/starters/next-hybrid/README.md
@@ -103,7 +103,7 @@ write the values below by hand.
 | ----------------------------- | ---------- | ----------------------------------------------------------------- |
 | `BETTER_AUTH_SECRET`          | always     | BetterAuth session signing. `lib/auth.ts` throws if missing.      |
 | `NEXT_PUBLIC_JAZZ_APP_ID`     | cloud only | Provisioned app ID. Unset in self-hosted dev — plugin injects it. |
-| `NEXT_PUBLIC_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://prod.v2.aws.cloud.jazz.tools`).     |
+| `NEXT_PUBLIC_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://v2.sync.jazz.tools`).               |
 | `JAZZ_ADMIN_SECRET`           | cloud only | Admin credential for schema pushes to the cloud.                  |
 | `BACKEND_SECRET`              | cloud only | Backend signing credential.                                       |
 

--- a/starters/react-betterauth/README.md
+++ b/starters/react-betterauth/README.md
@@ -105,7 +105,7 @@ write the values below by hand.
 | `BETTER_AUTH_SECRET`   | always     | BetterAuth session signing. `server/auth.ts` throws if missing.   |
 | `PORT`                 | optional   | Hono server port (default `3001`).                                |
 | `VITE_JAZZ_APP_ID`     | cloud only | Provisioned app ID. Unset in self-hosted dev — plugin injects it. |
-| `VITE_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://prod.v2.aws.cloud.jazz.tools`).     |
+| `VITE_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://v2.sync.jazz.tools`).               |
 | `JAZZ_ADMIN_SECRET`    | cloud only | Admin credential for schema pushes to the cloud.                  |
 | `BACKEND_SECRET`       | cloud only | Backend signing credential.                                       |
 

--- a/starters/react-betterauth/README.md
+++ b/starters/react-betterauth/README.md
@@ -100,14 +100,14 @@ random port and writes `VITE_JAZZ_APP_ID` / `VITE_JAZZ_SERVER_URL` to
 Scaffold via `create-jazz` to have `.env` populated automatically; otherwise
 write the values below by hand.
 
-| Variable               | When       | Purpose                                                              |
-| ---------------------- | ---------- | -------------------------------------------------------------------- |
-| `BETTER_AUTH_SECRET`   | always     | BetterAuth session signing. `server/auth.ts` throws if missing.      |
-| `PORT`                 | optional   | Hono server port (default `3001`).                                   |
-| `VITE_JAZZ_APP_ID`     | cloud only | Provisioned app ID. Unset in self-hosted dev — plugin injects it.    |
-| `VITE_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://prod.v2.aws.cloud.jazz.tools/apps/…`). |
-| `JAZZ_ADMIN_SECRET`    | cloud only | Admin credential for schema pushes to the cloud.                     |
-| `BACKEND_SECRET`       | cloud only | Backend signing credential.                                          |
+| Variable               | When       | Purpose                                                           |
+| ---------------------- | ---------- | ----------------------------------------------------------------- |
+| `BETTER_AUTH_SECRET`   | always     | BetterAuth session signing. `server/auth.ts` throws if missing.   |
+| `PORT`                 | optional   | Hono server port (default `3001`).                                |
+| `VITE_JAZZ_APP_ID`     | cloud only | Provisioned app ID. Unset in self-hosted dev — plugin injects it. |
+| `VITE_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://prod.v2.aws.cloud.jazz.tools`).     |
+| `JAZZ_ADMIN_SECRET`    | cloud only | Admin credential for schema pushes to the cloud.                  |
+| `BACKEND_SECRET`       | cloud only | Backend signing credential.                                       |
 
 Generate a dev `BETTER_AUTH_SECRET` with `openssl rand -base64 32`. In
 self-hosted mode (no cloud env vars), the `jazzPlugin` plugin spawns a local

--- a/starters/react-hybrid/README.md
+++ b/starters/react-hybrid/README.md
@@ -96,14 +96,14 @@ session on every row and the permission policy scopes reads/writes to it.
 Scaffold via `create-jazz` to have `.env` populated automatically; otherwise
 write the values below by hand.
 
-| Variable               | When       | Purpose                                                              |
-| ---------------------- | ---------- | -------------------------------------------------------------------- |
-| `BETTER_AUTH_SECRET`   | always     | BetterAuth session signing. `server/auth.ts` throws if missing.      |
-| `PORT`                 | optional   | Hono server port (default `3001`).                                   |
-| `VITE_JAZZ_APP_ID`     | cloud only | Provisioned app ID. Unset in self-hosted dev — plugin injects it.    |
-| `VITE_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://prod.v2.aws.cloud.jazz.tools/apps/…`). |
-| `JAZZ_ADMIN_SECRET`    | cloud only | Admin credential for schema pushes to the cloud.                     |
-| `BACKEND_SECRET`       | cloud only | Backend signing credential.                                          |
+| Variable               | When       | Purpose                                                           |
+| ---------------------- | ---------- | ----------------------------------------------------------------- |
+| `BETTER_AUTH_SECRET`   | always     | BetterAuth session signing. `server/auth.ts` throws if missing.   |
+| `PORT`                 | optional   | Hono server port (default `3001`).                                |
+| `VITE_JAZZ_APP_ID`     | cloud only | Provisioned app ID. Unset in self-hosted dev — plugin injects it. |
+| `VITE_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://prod.v2.aws.cloud.jazz.tools`).     |
+| `JAZZ_ADMIN_SECRET`    | cloud only | Admin credential for schema pushes to the cloud.                  |
+| `BACKEND_SECRET`       | cloud only | Backend signing credential.                                       |
 
 Generate a dev `BETTER_AUTH_SECRET` with `openssl rand -base64 32`. In
 self-hosted mode (no cloud env vars), the `jazzPlugin` plugin spawns a local

--- a/starters/react-hybrid/README.md
+++ b/starters/react-hybrid/README.md
@@ -101,7 +101,7 @@ write the values below by hand.
 | `BETTER_AUTH_SECRET`   | always     | BetterAuth session signing. `server/auth.ts` throws if missing.   |
 | `PORT`                 | optional   | Hono server port (default `3001`).                                |
 | `VITE_JAZZ_APP_ID`     | cloud only | Provisioned app ID. Unset in self-hosted dev — plugin injects it. |
-| `VITE_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://prod.v2.aws.cloud.jazz.tools`).     |
+| `VITE_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://v2.sync.jazz.tools`).               |
 | `JAZZ_ADMIN_SECRET`    | cloud only | Admin credential for schema pushes to the cloud.                  |
 | `BACKEND_SECRET`       | cloud only | Backend signing credential.                                       |
 

--- a/starters/sveltekit-betterauth/README.md
+++ b/starters/sveltekit-betterauth/README.md
@@ -96,7 +96,7 @@ write the values below by hand.
 | ------------------------ | ---------- | ----------------------------------------------------------------- |
 | `BETTER_AUTH_SECRET`     | always     | BetterAuth session signing. `src/lib/auth.ts` throws if missing.  |
 | `PUBLIC_JAZZ_APP_ID`     | cloud only | Provisioned app ID. Unset in self-hosted dev — plugin injects it. |
-| `PUBLIC_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://prod.v2.aws.cloud.jazz.tools`).     |
+| `PUBLIC_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://v2.sync.jazz.tools`).               |
 | `JAZZ_ADMIN_SECRET`      | cloud only | Admin credential for schema pushes to the cloud.                  |
 | `BACKEND_SECRET`         | cloud only | Backend signing credential.                                       |
 

--- a/starters/sveltekit-betterauth/README.md
+++ b/starters/sveltekit-betterauth/README.md
@@ -92,13 +92,13 @@ session on every row and the permission policy scopes reads/writes to it.
 Scaffold via `create-jazz` to have `.env` populated automatically; otherwise
 write the values below by hand.
 
-| Variable                 | When       | Purpose                                                              |
-| ------------------------ | ---------- | -------------------------------------------------------------------- |
-| `BETTER_AUTH_SECRET`     | always     | BetterAuth session signing. `src/lib/auth.ts` throws if missing.     |
-| `PUBLIC_JAZZ_APP_ID`     | cloud only | Provisioned app ID. Unset in self-hosted dev — plugin injects it.    |
-| `PUBLIC_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://prod.v2.aws.cloud.jazz.tools/apps/…`). |
-| `JAZZ_ADMIN_SECRET`      | cloud only | Admin credential for schema pushes to the cloud.                     |
-| `BACKEND_SECRET`         | cloud only | Backend signing credential.                                          |
+| Variable                 | When       | Purpose                                                           |
+| ------------------------ | ---------- | ----------------------------------------------------------------- |
+| `BETTER_AUTH_SECRET`     | always     | BetterAuth session signing. `src/lib/auth.ts` throws if missing.  |
+| `PUBLIC_JAZZ_APP_ID`     | cloud only | Provisioned app ID. Unset in self-hosted dev — plugin injects it. |
+| `PUBLIC_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://prod.v2.aws.cloud.jazz.tools`).     |
+| `JAZZ_ADMIN_SECRET`      | cloud only | Admin credential for schema pushes to the cloud.                  |
+| `BACKEND_SECRET`         | cloud only | Backend signing credential.                                       |
 
 Generate a dev `BETTER_AUTH_SECRET` with `openssl rand -base64 32`. In
 self-hosted mode (no cloud env vars), the `jazzSvelteKit` plugin spawns a

--- a/starters/sveltekit-hybrid/README.md
+++ b/starters/sveltekit-hybrid/README.md
@@ -117,7 +117,7 @@ write the values below by hand.
 | ------------------------ | ---------- | ----------------------------------------------------------------- |
 | `BETTER_AUTH_SECRET`     | always     | BetterAuth session signing. `src/lib/auth.ts` throws if missing.  |
 | `PUBLIC_JAZZ_APP_ID`     | cloud only | Provisioned app ID. Unset in self-hosted dev — plugin injects it. |
-| `PUBLIC_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://prod.v2.aws.cloud.jazz.tools`).     |
+| `PUBLIC_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://v2.sync.jazz.tools`).               |
 | `JAZZ_ADMIN_SECRET`      | cloud only | Admin credential for schema pushes to the cloud.                  |
 | `BACKEND_SECRET`         | cloud only | Backend signing credential.                                       |
 

--- a/starters/sveltekit-hybrid/README.md
+++ b/starters/sveltekit-hybrid/README.md
@@ -113,13 +113,13 @@ session on every row and the permission policy scopes reads/writes to it.
 Scaffold via `create-jazz` to have `.env` populated automatically; otherwise
 write the values below by hand.
 
-| Variable                 | When       | Purpose                                                              |
-| ------------------------ | ---------- | -------------------------------------------------------------------- |
-| `BETTER_AUTH_SECRET`     | always     | BetterAuth session signing. `src/lib/auth.ts` throws if missing.     |
-| `PUBLIC_JAZZ_APP_ID`     | cloud only | Provisioned app ID. Unset in self-hosted dev — plugin injects it.    |
-| `PUBLIC_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://prod.v2.aws.cloud.jazz.tools/apps/…`). |
-| `JAZZ_ADMIN_SECRET`      | cloud only | Admin credential for schema pushes to the cloud.                     |
-| `BACKEND_SECRET`         | cloud only | Backend signing credential.                                          |
+| Variable                 | When       | Purpose                                                           |
+| ------------------------ | ---------- | ----------------------------------------------------------------- |
+| `BETTER_AUTH_SECRET`     | always     | BetterAuth session signing. `src/lib/auth.ts` throws if missing.  |
+| `PUBLIC_JAZZ_APP_ID`     | cloud only | Provisioned app ID. Unset in self-hosted dev — plugin injects it. |
+| `PUBLIC_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://prod.v2.aws.cloud.jazz.tools`).     |
+| `JAZZ_ADMIN_SECRET`      | cloud only | Admin credential for schema pushes to the cloud.                  |
+| `BACKEND_SECRET`         | cloud only | Backend signing credential.                                       |
 
 Generate a dev `BETTER_AUTH_SECRET` with `openssl rand -base64 32`. In
 self-hosted mode (no cloud env vars), the `jazzSvelteKit` plugin spawns a


### PR DESCRIPTION
## Description

Adjusts the auto-generated server URL in starter apps created with `pnpm create jazz`. We no longer need to set the appId as part of the URL.