### PR TITLE
docs: fix Jazz Cloud link in client quickstart

### DIFF
--- a/docs/content/docs/quickstarts/client.mdx
+++ b/docs/content/docs/quickstarts/client.mdx
@@ -137,7 +137,7 @@ Start with a fresh app. If you already have one, skip to [Install](#install).
 
 ## Get an app ID
 
-Your app ID namespaces your data for storage and sync. Click below to generate one on [Jazz Cloud](https://v2.sync.jazz.tools/) (sync URL: `https://v2.sync.jazz.tools/`)&hairsp;—&hairsp;you'll also get the secrets you need to deploy permissions later.
+Your app ID namespaces your data for storage and sync. Click below to generate one on [Jazz Cloud](https://v2.dashboard.jazz.tools) (sync URL: `https://v2.sync.jazz.tools/`)&hairsp;—&hairsp;you'll also get the secrets you need to deploy permissions later.
 
 <GenerateAppId />
 


### PR DESCRIPTION
## Summary
- Point the "Jazz Cloud" link in the client quickstart to `https://v2.dashboard.jazz.tools` (the dashboard) instead of the sync endpoint.

## Test plan
- [ ] Verify the link in the rendered docs resolves to the dashboard.