### PR TITLE
chore: add missing changeset for starters' server URL fix

### DIFF
--- a/.changeset/odd-snails-look.md
+++ b/.changeset/odd-snails-look.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Update Jazz server URL in generated starter apps to https://v2.sync.jazz.tools/.


### PR DESCRIPTION
Forgot to add a changeset on https://github.com/garden-co/jazz2/pull/641