### PR TITLE
docs: fix broken GitHub example links in docs

### DIFF
--- a/docs/content/docs/quickstarts/client.mdx
+++ b/docs/content/docs/quickstarts/client.mdx
@@ -364,6 +364,6 @@ For self-hosted deployments, see [Server Setup](/docs/getting-started/server-set
 
 ## Example apps
 
-- [Todo app (React)](https://github.com/garden-co/jazz2/tree/main/docs/examples/todo-client-localfirst-react)&hairsp;—&hairsp;the app you just built, as a complete project
-- [File upload (React)](https://github.com/garden-co/jazz2/tree/main/docs/examples/file-upload-react)&hairsp;—&hairsp;image upload and rendering with Jazz
-- [Wequencer (Svelte)](https://github.com/garden-co/jazz2/tree/main/docs/examples/wequencer)&hairsp;—&hairsp;collaborative real-time music sequencer
+- [Todo app (React)](https://github.com/garden-co/jazz2/tree/main/examples/docs/todo-client-localfirst-react)&hairsp;—&hairsp;the app you just built, as a complete project
+- [File upload (React)](https://github.com/garden-co/jazz2/tree/main/examples/file-upload-react)&hairsp;—&hairsp;image upload and rendering with Jazz
+- [Wequencer (Svelte)](https://github.com/garden-co/jazz2/tree/main/examples/wequencer)&hairsp;—&hairsp;collaborative real-time music sequencer

--- a/docs/content/docs/recipes/auth-provider-integration.mdx
+++ b/docs/content/docs/recipes/auth-provider-integration.mdx
@@ -75,7 +75,7 @@ If you're unfamiliar with JWTs and JWKS, see the [explainer on the Authenticatio
     pnpm dlx jazz-tools@alpha server <APP_ID> --jwks-url https://your-app.example.com/api/auth/jwks
     ```
 
-    For a full working example, see the [Better Auth chat example](https://github.com/garden-co/jazz/tree/main/examples/auth-betterauth-chat).
+    For a full working example, see the [Better Auth chat example](https://github.com/garden-co/jazz2/tree/main/examples/auth-betterauth-chat).
 
     <Callout type="info">
       If your users start unauthenticated and sign up later, see [Local-first auth](/docs/auth/local-first-auth#signing-up-with-betterauth) for how to preserve their identity across the transition.
@@ -97,7 +97,7 @@ If you're unfamiliar with JWTs and JWKS, see the [explainer on the Authenticatio
     pnpm dlx jazz-tools@alpha server <APP_ID> --jwks-url https://api.workos.com/sso/jwks/client_01ABC...
     ```
 
-    For a full working example, see the [WorkOS chat example](https://github.com/garden-co/jazz/tree/main/examples/auth-workos-chat).
+    For a full working example, see the [WorkOS chat example](https://github.com/garden-co/jazz2/tree/main/examples/auth-workos-chat).
 
   </Tab>
 </Tabs>
@@ -128,4 +128,4 @@ Any provider that issues JWTs and exposes a JWKS endpoint will work. The key pat
 
 Jazz uses the JWT `sub` claim as `session.user_id`. If your provider keeps `sub` fixed to its own user ID, mint the JWT with `sub` set to the Jazz user ID yourself — either via a custom `getSubject` hook on the provider or by issuing the JWT directly from your server.
 
-Full working examples: [Better Auth chat](https://github.com/garden-co/jazz/tree/main/examples/auth-betterauth-chat), [WorkOS chat](https://github.com/garden-co/jazz/tree/main/examples/auth-workos-chat).
+Full working examples: [Better Auth chat](https://github.com/garden-co/jazz2/tree/main/examples/auth-betterauth-chat), [WorkOS chat](https://github.com/garden-co/jazz2/tree/main/examples/auth-workos-chat).


### PR DESCRIPTION
- quickstarts/client.mdx: correct reversed path `docs/examples/` to `examples/docs/` (todo app) or `examples/` (file-upload, wequencer)
- recipes/auth-provider-integration.mdx: update auth-betterauth-chat and auth-workos-chat links from `garden-co/jazz` to `garden-co/jazz2`