### PR TITLE
fix(inspector): keep schema select inside card

### DIFF
--- a/packages/inspector/src/components/db-config-form/SchemaHashSelect.module.css
+++ b/packages/inspector/src/components/db-config-form/SchemaHashSelect.module.css
@@ -1,43 +1,49 @@
 .card,
 .form {
-  width: min(460px, 100%);
+  box-sizing: border-box;
+  width: min(640px, 100%);
   border: 1px solid #2a3341;
   border-radius: 8px;
   background: #151a24;
-  padding: 20px;
+  padding: 28px;
 }
 
 .form {
   display: grid;
-  gap: 12px;
+  gap: 16px;
 }
 
 .title {
   margin: 0;
   color: #e2e8f3;
-  font-size: 20px;
+  font-size: 24px;
 }
 
 .description {
-  margin: 10px 0 0;
+  margin: 12px 0 0;
   color: #9dacbf;
-  font-size: 13px;
+  font-size: 15px;
 }
 
 .field {
   display: grid;
-  gap: 6px;
+  gap: 8px;
+  min-width: 0;
   color: #bcc7da;
-  font-size: 13px;
+  font-size: 15px;
 }
 
 .select {
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
   border: 1px solid #324258;
   border-radius: 6px;
   background: #101723;
   color: #e2e8f4;
-  padding: 9px 10px;
+  padding: 11px 36px 11px 12px;
   font: inherit;
+  text-overflow: ellipsis;
 }
 
 .submitButton {
@@ -45,8 +51,8 @@
   background: #283a52;
   color: #ebf1fb;
   border-radius: 6px;
-  padding: 8px 12px;
-  font-size: 13px;
+  padding: 10px 14px;
+  font-size: 15px;
   font-weight: 600;
   cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- Long option strings (full schema hashes) pushed the `<select>` past its parent grid in the schema picker, leaving the dropdown and "Use schema" button visibly outside the card.
- Constrains the grid item with `min-width: 0` + `width: 100%` + `box-sizing: border-box` so the select stays inside the form.
- Reserves right padding on the select for the native chevron and adds `text-overflow: ellipsis` so long hashes truncate instead of colliding with the arrow.
- Widens the card (460 → 640px), bumps padding, and scales the typography up so the form feels proportional at the new size.

before: 
<img width="704" height="289" alt="image" src="https://github.com/user-attachments/assets/b9c5fef1-df84-4ff9-83fd-b2c0ed5137e9" />

After:
<img width="677" height="293" alt="image" src="https://github.com/user-attachments/assets/b6140c73-db11-4043-a1d2-3b3bdb782a52" />


## Test plan
- [ ] `pnpm --filter inspector dev` and open `#serverUrl=...&appId=...` with stored schemas — card contains select + button, no horizontal overflow.
- [ ] Open the dropdown, select a long hash — selected value does not overlap the chevron.
- [ ] Resize the viewport below 640px — card shrinks with the viewport, select still fits inside.