### PR TITLE
fix: generated schema snapshots' timestamps

### DIFF
--- a/packages/jazz-tools/src/cli.test.ts
+++ b/packages/jazz-tools/src/cli.test.ts
@@ -2636,6 +2636,26 @@ describe("bin integration", () => {
     expect(JSON.parse(String(result.stdout))).toEqual(schema);
   });
 
+  it("loads schema export --schema-hash from a legacy malformed local snapshot filename", async () => {
+    const { root } = await createWorkspace();
+    const schema = storedRootSchema();
+    const schemaHash = await computeTestSchemaHash(schema);
+    const snapshotsDir = join(root, "migrations", "snapshots");
+    await mkdir(snapshotsDir, { recursive: true });
+    await writeFile(
+      join(snapshotsDir, `582761109T032422-${schemaHash.slice(0, 12)}.json`),
+      JSON.stringify(schema, null, 2),
+      "utf8",
+    );
+
+    const result = runBin(["schema", "export", APP_ID, "--schema-hash", schemaHash], {
+      cwd: root,
+    });
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(String(result.stdout))).toEqual(schema);
+  });
+
   it("loads schema export --schema-hash from a custom migrations dir", async () => {
     const { root } = await createWorkspace();
     const schema = storedRootSchema();
@@ -2702,6 +2722,44 @@ describe("bin integration", () => {
     expect(
       JSON.parse(await readFile(join(root, "migrations", "snapshots", snapshotFiles[0]!), "utf8")),
     ).toEqual(schema);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("normalizes microsecond publishedAt values when persisting fetched snapshots", async () => {
+    const { root } = await createWorkspace();
+    const schema = storedRootSchema();
+    const schemaHash = await computeTestSchemaHash(schema);
+    const publishedAtMicros = Date.UTC(2026, 3, 6, 12, 0, 0) * 1_000;
+    const writes: string[] = [];
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(((
+      chunk: string | Uint8Array,
+    ) => {
+      writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+      return true;
+    }) as typeof process.stdout.write);
+
+    const fetchMock = vi.fn(async () => storedSchemaResponse(schema, publishedAtMicros));
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      await exportSchema({
+        schemaHash,
+        schemaDir: root,
+        serverUrl: "http://localhost:1625",
+        adminSecret: "admin-secret",
+      });
+    } finally {
+      writeSpy.mockRestore();
+      process.stdout.write = originalWrite;
+    }
+
+    expect(JSON.parse(writes.join(""))).toEqual(schema);
+    const shortSchemaHash = schemaHash.slice(0, 12);
+    const snapshotFiles = (await readdir(join(root, "migrations", "snapshots"))).filter((name) =>
+      name.endsWith(`-${shortSchemaHash}.json`),
+    );
+    expect(snapshotFiles).toEqual([`20260406T120000-${shortSchemaHash}.json`]);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/jazz-tools/src/cli.ts
+++ b/packages/jazz-tools/src/cli.ts
@@ -315,8 +315,9 @@ interface SnapshotEntry {
   schema: WasmSchema;
 }
 
+// Supports both millisecond and microsecond-precision timestamps
 function looksLikeSnapshotFileName(fileName: string): boolean {
-  return /^(?:\d{8,}T\d{6}-)?[0-9a-f]{12}\.json$/i.test(fileName);
+  return /^(?:\d{8,17}T\d{6}-)?[0-9a-f]{12}\.json$/i.test(fileName);
 }
 
 async function readSnapshotEntry(dir: string, fileName: string): Promise<SnapshotEntry | null> {

--- a/packages/jazz-tools/src/cli.ts
+++ b/packages/jazz-tools/src/cli.ts
@@ -316,7 +316,7 @@ interface SnapshotEntry {
 }
 
 function looksLikeSnapshotFileName(fileName: string): boolean {
-  return /^(?:\d{8}T\d{6}-)?[0-9a-f]{12}\.json$/i.test(fileName);
+  return /^(?:\d{8,}T\d{6}-)?[0-9a-f]{12}\.json$/i.test(fileName);
 }
 
 async function readSnapshotEntry(dir: string, fileName: string): Promise<SnapshotEntry | null> {

--- a/packages/jazz-tools/src/runtime/schema-fetch.test.ts
+++ b/packages/jazz-tools/src/runtime/schema-fetch.test.ts
@@ -47,6 +47,28 @@ describe("schema-fetch", () => {
     });
   });
 
+  it("normalizes microsecond publishedAt values to epoch milliseconds", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({
+        schema: { users: { columns: [] } },
+        publishedAt: 1_744_011_200_000_000,
+      }),
+    });
+    (globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
+
+    const hash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const result = await fetchStoredWasmSchema("http://localhost:1625/", {
+      appId: "app-123",
+      adminSecret: "admin-secret",
+      schemaHash: hash,
+    });
+
+    expect(result.publishedAt).toBe(1_744_011_200_000);
+  });
+
   it("throws a descriptive error on non-2xx responses", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: false,

--- a/packages/jazz-tools/src/runtime/schema-fetch.ts
+++ b/packages/jazz-tools/src/runtime/schema-fetch.ts
@@ -14,6 +14,23 @@ export interface FetchStoredWasmSchemaOptions {
   schemaHash: string;
 }
 
+const MICROSECONDS_PER_MILLISECOND = 1_000;
+const EPOCH_MICROSECONDS_THRESHOLD = 100_000_000_000_000;
+
+function normalizePublishedAtEpochMilliseconds(
+  publishedAt: number | null | undefined,
+): number | null {
+  if (typeof publishedAt !== "number" || !Number.isFinite(publishedAt)) {
+    return null;
+  }
+
+  if (publishedAt >= EPOCH_MICROSECONDS_THRESHOLD) {
+    return Math.trunc(publishedAt / MICROSECONDS_PER_MILLISECOND);
+  }
+
+  return publishedAt;
+}
+
 export async function fetchStoredWasmSchema(
   serverUrl: string,
   options: FetchStoredWasmSchemaOptions,
@@ -44,7 +61,7 @@ export async function fetchStoredWasmSchema(
 
   return {
     schema: body.schema,
-    publishedAt: body.publishedAt ?? null,
+    publishedAt: normalizePublishedAtEpochMilliseconds(body.publishedAt),
   };
 }
 


### PR DESCRIPTION
## Description

When generating migrations for a new app, I noticed snapshots had weird names (e.g. `582761109T032422-268a4ad77008.json`) instead of the expected timestamp (`20260422T160045-8bde091420f7.json`).

Turns out the server returns the schema timestamp with microsecond precision, and the CLI expects in in millisecond precision. This PR adjusts the timestamp to generate correct snapshot filenames.