### PR TITLE
docs(blog): replace placeholder links with real URLs in what-is-jazz

### DIFF
--- a/docs/content/blog/what-is-jazz.mdx
+++ b/docs/content/blog/what-is-jazz.mdx
@@ -231,7 +231,7 @@ with you and iterate quickly on rough edges, feature requests, and missing piece
 
 That also applies if you simply want to get a feel for the abstraction. Some of the most useful
 feedback we have ever gotten came from early users who were just exploring the model and reacting to
-it honestly, so we are very interested in those first impressions too. (Link to Discord)
+it honestly, so we are very interested in those first impressions too. [Let us know on Discord!](https://discord.gg/NqpNnpEzrQ)
 
 For commercial products, the default recommendation is still adventurous greenfield teams. But we are
 also already onboarding larger and more brownfield adopters selectively, in close partnership. That
@@ -241,7 +241,7 @@ alpha.
 
 Especially if you have a serious use case that is awkward to serve with existing technology, we would
 love to start the conversation early and can often demonstrate the relevant capabilities in a targeted
-pilot. (Link to book a call)
+pilot. [Book a call to discuss further.](https://cal.com/anselm-io/talk-about-jazz?duration=45)
 
 # What we learned from classic Jazz and how to migrate
 

--- a/docs/content/blog/what-is-jazz.mdx
+++ b/docs/content/blog/what-is-jazz.mdx
@@ -241,7 +241,7 @@ alpha.
 
 Especially if you have a serious use case that is awkward to serve with existing technology, we would
 love to start the conversation early and can often demonstrate the relevant capabilities in a targeted
-pilot. [Book a call to discuss further.](https://cal.com/anselm-io/talk-about-jazz?duration=45)
+pilot. [Book a call to discuss further.](https://cal.com/anselm-io/cloud-pro-intro)
 
 # What we learned from classic Jazz and how to migrate
 


### PR DESCRIPTION
Replaces two placeholder texts in the "What is Jazz?" blog post with proper markdown links:

- `(Link to Discord)` → [Let us know on Discord!](https://discord.gg/NqpNnpEzrQ)
- `(Link to book a call)` → [Book a call to discuss further.](https://cal.com/anselm-io/talk-about-jazz?duration=45)