### PR TITLE
Fix provenance magic timestamp conversion

### DIFF
--- a/.changeset/fix-provenance-magic-timestamps.md
+++ b/.changeset/fix-provenance-magic-timestamps.md
@@ -1,0 +1,7 @@
+---
+"jazz-tools": patch
+---
+
+Fix `$createdAt` and `$updatedAt` provenance magic columns in `jazz-tools` so they round-trip as real JavaScript dates instead of far-future timestamps.
+
+Queries now convert JS millisecond `Date` and numeric filter values to the internal provenance timestamp format consistently, so selecting and filtering on those magic columns uses the same time scale.

--- a/packages/jazz-tools/src/magic-columns.ts
+++ b/packages/jazz-tools/src/magic-columns.ts
@@ -9,9 +9,11 @@ export const PROVENANCE_MAGIC_COLUMNS = [
   "$updatedBy",
   "$updatedAt",
 ] as const;
+export const PROVENANCE_MAGIC_TIMESTAMP_COLUMNS = ["$createdAt", "$updatedAt"] as const;
 
 export type PermissionIntrospectionColumn = (typeof PERMISSION_INTROSPECTION_COLUMNS)[number];
 export type ProvenanceMagicColumn = (typeof PROVENANCE_MAGIC_COLUMNS)[number];
+export type ProvenanceMagicTimestampColumn = (typeof PROVENANCE_MAGIC_TIMESTAMP_COLUMNS)[number];
 
 export function isPermissionIntrospectionColumn(
   column: string,
@@ -21,6 +23,12 @@ export function isPermissionIntrospectionColumn(
 
 export function isProvenanceMagicColumn(column: string): column is ProvenanceMagicColumn {
   return PROVENANCE_MAGIC_COLUMNS.includes(column as ProvenanceMagicColumn);
+}
+
+export function isProvenanceMagicTimestampColumn(
+  column: string,
+): column is ProvenanceMagicTimestampColumn {
+  return PROVENANCE_MAGIC_TIMESTAMP_COLUMNS.includes(column as ProvenanceMagicTimestampColumn);
 }
 
 export function isReservedMagicColumnName(column: string): boolean {

--- a/packages/jazz-tools/src/runtime/query-adapter-tests/condition-translation.test.ts
+++ b/packages/jazz-tools/src/runtime/query-adapter-tests/condition-translation.test.ts
@@ -374,7 +374,7 @@ describe("condition translation", () => {
       type: "Cmp",
       left: { scope: "todos", column: "$updatedAt" },
       op: "Ge",
-      right: { type: "Literal", value: { Timestamp: Date.parse(iso) } },
+      right: { type: "Literal", value: { Timestamp: Date.parse(iso) * 1_000 } },
     });
   });
 

--- a/packages/jazz-tools/src/runtime/query-adapter.ts
+++ b/packages/jazz-tools/src/runtime/query-adapter.ts
@@ -11,7 +11,7 @@
 import type { ColumnType, WasmSchema } from "../drivers/types.js";
 import { toJsonText } from "./json-text.js";
 import { analyzeRelations, type Relation } from "../codegen/relation-analyzer.js";
-import { magicColumnType } from "../magic-columns.js";
+import { isProvenanceMagicTimestampColumn, magicColumnType } from "../magic-columns.js";
 import {
   normalizeBuiltQuery,
   type BuiltCondition,
@@ -100,10 +100,17 @@ function toTimestampMs(value: unknown): number {
   throw new Error("Invalid timestamp condition. Expected Date, ISO string, or finite number.");
 }
 
+function toRuntimeTimestampValue(value: unknown, columnName?: string): number {
+  const timestampMs = toTimestampMs(value);
+  return columnName && isProvenanceMagicTimestampColumn(columnName)
+    ? timestampMs * 1_000
+    : timestampMs;
+}
+
 /**
  * Translate a JavaScript value to WasmValue format.
  */
-function toWasmValue(value: unknown, columnType: ColumnType): object {
+function toWasmValue(value: unknown, columnType: ColumnType, columnName?: string): object {
   if (value === null || value === undefined) {
     return { type: "Null" };
   }
@@ -111,7 +118,7 @@ function toWasmValue(value: unknown, columnType: ColumnType): object {
     return { type: "Text", value: toJsonText(value) };
   }
   if (columnType.type === "Timestamp" && value instanceof Date) {
-    return { type: "Timestamp", value: toTimestampMs(value) };
+    return { type: "Timestamp", value: toRuntimeTimestampValue(value, columnName) };
   }
   if (columnType.type === "Bytea") {
     if (value instanceof Uint8Array) {
@@ -143,14 +150,14 @@ function toWasmValue(value: unknown, columnType: ColumnType): object {
   }
   if (typeof value === "number") {
     if (columnType?.type === "Timestamp") {
-      return { type: "Timestamp", value: toTimestampMs(value) };
+      return { type: "Timestamp", value: toRuntimeTimestampValue(value, columnName) };
     }
     // Use Integer for all numbers - WASM will handle type coercion
     return { type: "Integer", value };
   }
   if (typeof value === "string") {
     if (columnType?.type === "Timestamp") {
-      return { type: "Timestamp", value: toTimestampMs(value) };
+      return { type: "Timestamp", value: toRuntimeTimestampValue(value, columnName) };
     }
     if (columnType?.type === "Uuid") {
       return { type: "Uuid", value };
@@ -228,7 +235,7 @@ function conditionToArraySubqueryFilter(
 
   const valueTypeForCondition =
     cond.op === "contains" && columnType.type === "Array" ? columnType.element : columnType;
-  const literalValue = toWasmValue(cond.value, valueTypeForCondition);
+  const literalValue = toWasmValue(cond.value, valueTypeForCondition, column);
   const isNullValue = cond.value === undefined ? true : cond.value;
 
   switch (cond.op) {
@@ -360,7 +367,7 @@ function conditionToRelPredicate(
     isFrontierRowIdToken(cond.value) && cond.op === "eq"
       ? { RowId: "Frontier" as const }
       : {
-          Literal: toWasmValue(cond.value, valueTypeForCondition),
+          Literal: toWasmValue(cond.value, valueTypeForCondition, column),
         };
   const isNullValue = cond.value === undefined ? true : cond.value;
   if (columnType.type === "Bytea" && ["gt", "gte", "lt", "lte"].includes(cond.op)) {
@@ -436,7 +443,7 @@ function conditionToRelPredicate(
         In: {
           left: columnRef,
           values: cond.value.map((value) => ({
-            Literal: toWasmValue(value, columnType),
+            Literal: toWasmValue(value, columnType, column),
           })),
         },
       };

--- a/packages/jazz-tools/src/runtime/row-transformer.test.ts
+++ b/packages/jazz-tools/src/runtime/row-transformer.test.ts
@@ -257,6 +257,35 @@ describe("transformRows", () => {
     expect(result[0]?.created_at.getTime()).toBe(ts);
   });
 
+  it("scales provenance magic timestamp columns down to JS milliseconds", () => {
+    const timestampSchema: WasmSchema = {
+      events: {
+        columns: [{ name: "title", column_type: { type: "Text" }, nullable: false }],
+      },
+    };
+    const tsMicros = 1_704_067_200_123_000;
+    const rows: WasmRow[] = [
+      {
+        id: "event-1",
+        values: [
+          { type: "Text", value: "Launch" },
+          { type: "Timestamp", value: tsMicros },
+        ],
+      },
+    ];
+
+    const result = transformRows<{ id: string; title: string; $updatedAt: Date }>(
+      rows,
+      timestampSchema,
+      "events",
+      {},
+      ["title", "$updatedAt"],
+    );
+
+    expect(result[0]?.$updatedAt).toBeInstanceOf(Date);
+    expect(result[0]?.$updatedAt.getTime()).toBe(1_704_067_200_123);
+  });
+
   it("transforms Json columns to parsed values", () => {
     const jsonSchema: WasmSchema = {
       documents: {

--- a/packages/jazz-tools/src/runtime/row-transformer.ts
+++ b/packages/jazz-tools/src/runtime/row-transformer.ts
@@ -5,7 +5,7 @@
 import type { Value as WasmValue, WasmRow, WasmSchema } from "../drivers/types.js";
 import type { ColumnType } from "../drivers/types.js";
 import { analyzeRelations, type Relation } from "../codegen/relation-analyzer.js";
-import { magicColumnType } from "../magic-columns.js";
+import { isProvenanceMagicTimestampColumn, magicColumnType } from "../magic-columns.js";
 import { normalizeIncludeEntries, type NormalizedIncludeSpec } from "./query-builder-shape.js";
 import { resolveSelectedColumns } from "./select-projection.js";
 
@@ -141,7 +141,7 @@ function transformRowValues(
     if (!col) continue;
     const value = values[i];
     if (value !== undefined) {
-      obj[col.name] = unwrapValue(value, col.columnType);
+      obj[col.name] = unwrapValue(value, col.columnType, col.name);
     }
   }
 
@@ -156,7 +156,14 @@ function transformRowValues(
   return obj;
 }
 
-export function unwrapValue(v: WasmValue, columnType?: ColumnType): unknown {
+function timestampToDate(value: number, columnName?: string): Date {
+  if (columnName && isProvenanceMagicTimestampColumn(columnName)) {
+    return new Date(Math.trunc(value / 1_000));
+  }
+  return new Date(value);
+}
+
+export function unwrapValue(v: WasmValue, columnType?: ColumnType, columnName?: string): unknown {
   switch (v.type) {
     case "Text":
       if (columnType?.type === "Json") {
@@ -178,7 +185,7 @@ export function unwrapValue(v: WasmValue, columnType?: ColumnType): unknown {
     case "Double":
       return v.value;
     case "Timestamp":
-      return new Date(v.value);
+      return timestampToDate(v.value, columnName);
     case "Bytea":
       return toByteArray((v as { value: unknown }).value);
     case "Null":

--- a/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
@@ -594,6 +594,49 @@ describe("TS Query API", () => {
       await db.shutdown();
     });
 
+    it("selects and filters provenance magic timestamp columns as JS dates", async () => {
+      const startedAt = Date.now();
+      const { id: projectId } = insertProject(db, "Announcements");
+      const { id: todoId } = insertTodo(db, {
+        title: "Draft docs",
+        done: false,
+        tags: ["dev"],
+        projectId,
+        assigneesIds: [],
+      });
+
+      const projected = await db.one(
+        app.todos.select("title", "$createdAt", "$updatedAt").where({ id: { eq: todoId } }),
+      );
+
+      assert(projected, "Result is not defined");
+      expectTypeOf(projected.$createdAt).toEqualTypeOf<Date>();
+      expectTypeOf(projected.$updatedAt).toEqualTypeOf<Date>();
+      expect(projected.title).toBe("Draft docs");
+      expect(projected.$createdAt).toBeInstanceOf(Date);
+      expect(projected.$updatedAt).toBeInstanceOf(Date);
+      expect(projected.$createdAt.getTime()).toBeGreaterThanOrEqual(startedAt - 60_000);
+      expect(projected.$createdAt.getTime()).toBeLessThanOrEqual(Date.now() + 60_000);
+      expect(projected.$updatedAt.getTime()).toBeGreaterThanOrEqual(startedAt - 60_000);
+      expect(projected.$updatedAt.getTime()).toBeLessThanOrEqual(Date.now() + 60_000);
+
+      const upperBound = new Date(Date.now() + 60_000);
+      const withinUpperBound = await db.all(
+        app.todos
+          .where({ $updatedAt: { lte: upperBound } })
+          .select("title", "$updatedAt")
+          .orderBy("title", "asc"),
+      );
+
+      expect(withinUpperBound).toContainEqual(
+        expect.objectContaining({
+          id: todoId,
+          title: "Draft docs",
+          $updatedAt: projected.$updatedAt,
+        }),
+      );
+    });
+
     it("include builders can project nested relation columns", async () => {
       const { id: projectId } = insertProject(db, "Announcements");
       const { id: ownerId } = insertUser(db);


### PR DESCRIPTION
## What changed
- fix `jazz-tools` provenance magic timestamp decoding so `$createdAt` and `$updatedAt` come back as real JS dates instead of far-future values
- convert query filter inputs for those magic columns onto the same internal timestamp scale used by the runtime
- add targeted coverage for row transformation, query translation, end-to-end query behavior, and a patch changeset

## Why
Selecting provenance magic timestamps was returning internal microsecond values as if they were JavaScript milliseconds. That produced far-future `Date` objects and made `where({ $updatedAt: ... })` filters inconsistent with selected results.

## Impact
Callers using `jazz-tools` can now safely select and filter on `$createdAt` and `$updatedAt` with normal JavaScript `Date` and millisecond values.

## Root cause
The Rust/runtime boundary stores provenance timestamps in microseconds, but the TypeScript magic-column path was treating all `Timestamp` payloads as ordinary millisecond timestamps.

## Validation
- `pnpm lint`
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/runtime/row-transformer.test.ts src/runtime/query-adapter.test.ts tests/ts-dsl/query-api.test.ts`
- `pnpm --filter jazz-tools build:runtime`
