### PR TITLE
fix: add jazz-wasm as direct dep to Vite-based starters

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -554,7 +554,7 @@ importers:
         version: 19.2.14
       babel-preset-expo:
         specifier: ~54.0.10
-        version: 54.0.10(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-refresh@0.17.0)
+        version: 54.0.10(@babel/core@7.29.0)(@babel/runtime@7.28.6)(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-refresh@0.14.2)
       typescript:
         specifier: catalog:default
         version: 6.0.2
@@ -1380,6 +1380,9 @@ importers:
       jazz-tools:
         specifier: workspace:*
         version: link:../../packages/jazz-tools
+      jazz-wasm:
+        specifier: workspace:*
+        version: link:../../crates/jazz-wasm
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -1435,6 +1438,9 @@ importers:
       jazz-tools:
         specifier: workspace:*
         version: link:../../packages/jazz-tools
+      jazz-wasm:
+        specifier: workspace:*
+        version: link:../../crates/jazz-wasm
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -1478,6 +1484,9 @@ importers:
       jazz-tools:
         specifier: workspace:*
         version: link:../../packages/jazz-tools
+      jazz-wasm:
+        specifier: workspace:*
+        version: link:../../crates/jazz-wasm
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -1512,6 +1521,9 @@ importers:
       jazz-tools:
         specifier: workspace:*
         version: link:../../packages/jazz-tools
+      jazz-wasm:
+        specifier: workspace:*
+        version: link:../../crates/jazz-wasm
       svelte:
         specifier: ^5.0.0
         version: 5.53.6
@@ -1549,6 +1561,9 @@ importers:
       jazz-tools:
         specifier: workspace:*
         version: link:../../packages/jazz-tools
+      jazz-wasm:
+        specifier: workspace:*
+        version: link:../../crates/jazz-wasm
       svelte:
         specifier: ^5.0.0
         version: 5.53.6
@@ -1580,6 +1595,9 @@ importers:
       jazz-tools:
         specifier: workspace:*
         version: link:../../packages/jazz-tools
+      jazz-wasm:
+        specifier: workspace:*
+        version: link:../../crates/jazz-wasm
       svelte:
         specifier: ^5.0.0
         version: 5.53.6
@@ -18111,7 +18129,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   '@vitest/utils@4.1.0':
     dependencies:

--- a/starters/react-betterauth/package.json
+++ b/starters/react-betterauth/package.json
@@ -17,6 +17,7 @@
     "better-auth": "^1.5.5",
     "hono": "^4.7.11",
     "jazz-tools": "workspace:*",
+    "jazz-wasm": "workspace:*",
     "react": "19.2.4",
     "react-dom": "19.2.4"
   },

--- a/starters/react-hybrid/package.json
+++ b/starters/react-hybrid/package.json
@@ -18,6 +18,7 @@
     "hono": "^4.7.11",
     "jazz-napi": "workspace:*",
     "jazz-tools": "workspace:*",
+    "jazz-wasm": "workspace:*",
     "react": "19.2.4",
     "react-dom": "19.2.4"
   },

--- a/starters/react-localfirst/package.json
+++ b/starters/react-localfirst/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "jazz-tools": "workspace:*",
+    "jazz-wasm": "workspace:*",
     "react": "19.2.4",
     "react-dom": "19.2.4"
   },

--- a/starters/sveltekit-betterauth/package.json
+++ b/starters/sveltekit-betterauth/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "better-auth": "^1.5.5",
     "jazz-tools": "workspace:*",
+    "jazz-wasm": "workspace:*",
     "svelte": "^5.0.0"
   },
   "devDependencies": {

--- a/starters/sveltekit-hybrid/package.json
+++ b/starters/sveltekit-hybrid/package.json
@@ -15,6 +15,7 @@
     "better-auth": "^1.5.5",
     "jazz-napi": "workspace:*",
     "jazz-tools": "workspace:*",
+    "jazz-wasm": "workspace:*",
     "svelte": "^5.0.0"
   },
   "devDependencies": {

--- a/starters/sveltekit-localfirst/package.json
+++ b/starters/sveltekit-localfirst/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "jazz-tools": "workspace:*",
+    "jazz-wasm": "workspace:*",
     "svelte": "^5.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Adds `jazz-wasm` as a direct dependency to the six Vite-based starters (three React, three SvelteKit)
- Next.js starters are unaffected — `withJazz` copies the `.wasm` file to `public/` instead of relying on Vite's module resolution

## Why

The Jazz Vite plugin excludes `jazz-wasm` from `optimizeDeps`, so Vite leaves the bare `import("jazz-wasm")` to resolve at runtime from within a pre-bundled chunk. In pnpm, that resolution only works if the package is hoisted to the top level — which requires it to be a direct dependency. Without this, users scaffolded with `npm create jazz` hit `Failed to resolve import "jazz-wasm"` at runtime.

## Test plan

- [ ] Scaffold a new SvelteKit or React starter with `npm create jazz` and verify `dev` starts without a `Failed to resolve import "jazz-wasm"` error