### PR TITLE
fix(create-jazz): show per-package progress on resolving dependencies spinner

### DIFF
--- a/.changeset/create-jazz-spinner-progress.md
+++ b/.changeset/create-jazz-spinner-progress.md
@@ -1,0 +1,5 @@
+---
+"create-jazz": patch
+---
+
+The "Resolving dependencies" spinner now updates as each package resolves (e.g. `Resolving dependencies (2/5)`), so `npm create jazz` no longer appears frozen during that step.

--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -1172,3 +1172,16 @@ jobs:
           else
             pnpm --filter jazz-tools publish --tag alpha --access public --no-git-checks
           fi
+
+      - name: Build create-jazz
+        run: pnpm --filter create-jazz build
+
+      - name: Publish create-jazz (alpha tag)
+        if: env.RELEASE_MODE == 'publish'
+        run: |
+          CREATE_JAZZ_VERSION=$(node -p 'JSON.parse(require("fs").readFileSync("packages/create-jazz/package.json","utf8")).version')
+          if npm view "create-jazz@${CREATE_JAZZ_VERSION}" version >/dev/null 2>&1; then
+            echo "create-jazz@${CREATE_JAZZ_VERSION} already exists on npm; skipping publish."
+          else
+            pnpm --filter create-jazz publish --tag alpha --access public --no-git-checks
+          fi

--- a/packages/create-jazz/src/deps.ts
+++ b/packages/create-jazz/src/deps.ts
@@ -9,6 +9,8 @@ export type PackageManifest = {
   [key: string]: unknown;
 };
 
+export type ResolveProgressCallback = (resolved: number, total: number) => void;
+
 type WorkspaceConfig = {
   catalogs?: Record<string, Record<string, string>>;
 };
@@ -61,6 +63,7 @@ async function applyResolvedManifest(
   manifest: PackageManifest,
   workspaceConfig: WorkspaceConfig,
   fetchPackageVersion: FetchPackageVersion,
+  onProgress?: ResolveProgressCallback,
 ): Promise<PackageManifest> {
   const deps = manifest.dependencies ?? {};
   const devDeps = manifest.devDependencies ?? {};
@@ -77,10 +80,14 @@ async function applyResolvedManifest(
     }
   }
 
+  const total = toFetch.size;
+  let resolvedCount = 0;
   const fetchedVersions = new Map<string, string>();
   await Promise.all(
     [...toFetch].map(async (name) => {
-      fetchedVersions.set(name, await fetchPackageVersion(name));
+      const version = await fetchPackageVersion(name);
+      fetchedVersions.set(name, version);
+      onProgress?.(++resolvedCount, total);
     }),
   );
 
@@ -199,10 +206,7 @@ async function fetchWithTimeout(url: string): Promise<Response> {
 async function fetchOnce(url: string): Promise<Response> {
   try {
     return await fetchWithTimeout(url);
-  } catch (firstErr) {
-    console.warn(
-      `Retrying ${url} after transient failure: ${firstErr instanceof Error ? firstErr.message : String(firstErr)}`,
-    );
+  } catch {
     return await fetchWithTimeout(url);
   }
 }
@@ -210,6 +214,7 @@ async function fetchOnce(url: string): Promise<Response> {
 export async function resolveRemoteDeps(
   manifest: PackageManifest,
   repoConfig: { repo: string; branch: string },
+  onProgress?: ResolveProgressCallback,
 ): Promise<PackageManifest> {
   const rawBase = `https://raw.githubusercontent.com/${repoConfig.repo}/refs/heads/${repoConfig.branch}`;
   const workspaceUrl = `${rawBase}/pnpm-workspace.yaml`;
@@ -242,7 +247,7 @@ export async function resolveRemoteDeps(
     throw new Error(`Package "${name}" not found in upstream repo`);
   };
 
-  return applyResolvedManifest(manifest, workspaceConfig, fetchPackageVersion);
+  return applyResolvedManifest(manifest, workspaceConfig, fetchPackageVersion, onProgress);
 }
 
 // --------------------------------------------------------------------------
@@ -252,6 +257,7 @@ export async function resolveRemoteDeps(
 export async function resolveLocalDeps(
   manifest: PackageManifest,
   repoRoot: string,
+  onProgress?: ResolveProgressCallback,
 ): Promise<PackageManifest> {
   const wsPath = path.join(repoRoot, "pnpm-workspace.yaml");
   const wsYaml = fs.readFileSync(wsPath, "utf-8");
@@ -269,5 +275,5 @@ export async function resolveLocalDeps(
     throw new Error(`Package "${name}" not found in any workspace subdir`);
   };
 
-  return applyResolvedManifest(manifest, workspaceConfig, fetchPackageVersion);
+  return applyResolvedManifest(manifest, workspaceConfig, fetchPackageVersion, onProgress);
 }

--- a/packages/create-jazz/src/scaffold.test.ts
+++ b/packages/create-jazz/src/scaffold.test.ts
@@ -127,6 +127,29 @@ describe("scaffold() — next-betterauth e2e via JAZZ_STARTER_PATH", () => {
     expect(fs.existsSync(path.join(tmpDir, "package.json"))).toBe(true);
     expect(fs.existsSync(path.join(tmpDir, ".git"))).toBe(false);
   });
+
+  it("reports per-package progress during dep resolution", { timeout: 30_000 }, async () => {
+    tmpDir = path.join(os.tmpdir(), `scaffold-progress-${Date.now()}`);
+    const steps: string[] = [];
+
+    await scaffold({
+      appName: "carol-progress",
+      targetDir: tmpDir,
+      pm: null,
+      starter: "next-betterauth",
+      git: false,
+      onStep: (label) => steps.push(label),
+    });
+
+    const progressSteps = steps.filter((s) => s.startsWith("Resolving dependencies ("));
+    expect(progressSteps.length).toBeGreaterThan(0);
+    for (const step of progressSteps) {
+      expect(step).toMatch(/^Resolving dependencies \(\d+\/\d+\)$/);
+    }
+    const last = progressSteps.at(-1)!;
+    const [, resolved, total] = last.match(/\((\d+)\/(\d+)\)/)!;
+    expect(Number(resolved)).toBe(Number(total));
+  });
 });
 
 describe("scaffold() — next-localfirst e2e via JAZZ_STARTER_PATH", () => {

--- a/packages/create-jazz/src/scaffold.ts
+++ b/packages/create-jazz/src/scaffold.ts
@@ -1,7 +1,12 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { execFileSync } from "node:child_process";
-import { resolveLocalDeps, resolveRemoteDeps, type PackageManifest } from "./deps.js";
+import {
+  resolveLocalDeps,
+  resolveRemoteDeps,
+  type PackageManifest,
+  type ResolveProgressCallback,
+} from "./deps.js";
 
 const REPO = "garden-co/jazz2";
 const BRANCH = "main";
@@ -68,12 +73,15 @@ async function fetchStarter(starter: StarterName, dir: string): Promise<void> {
   await emitter.clone(dir);
 }
 
-async function resolveManifest(manifest: PackageManifest): Promise<PackageManifest> {
+async function resolveManifest(
+  manifest: PackageManifest,
+  onProgress?: ResolveProgressCallback,
+): Promise<PackageManifest> {
   const localPath = process.env.JAZZ_STARTER_PATH;
   if (localPath) {
-    return resolveLocalDeps(manifest, path.resolve(localPath, "../.."));
+    return resolveLocalDeps(manifest, path.resolve(localPath, "../.."), onProgress);
   }
-  return resolveRemoteDeps(manifest, { repo: REPO, branch: BRANCH });
+  return resolveRemoteDeps(manifest, { repo: REPO, branch: BRANCH }, onProgress);
 }
 
 export async function scaffold(options: ScaffoldOptions): Promise<void> {
@@ -104,7 +112,9 @@ export async function scaffold(options: ScaffoldOptions): Promise<void> {
     options.onStep?.("Resolving dependencies");
     const pkgJsonPath = path.join(options.targetDir, "package.json");
     const rawManifest = JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8")) as PackageManifest;
-    const resolved = await resolveManifest(rawManifest);
+    const resolved = await resolveManifest(rawManifest, (done, total) => {
+      options.onStep?.(`Resolving dependencies (${done}/${total})`);
+    });
     const finalManifest = { ...resolved, name: options.appName };
     fs.writeFileSync(pkgJsonPath, JSON.stringify(finalManifest, null, 2) + "\n", "utf-8");
 


### PR DESCRIPTION
## Summary
- The "Resolving dependencies" spinner step showed no progress during GitHub
  fetches, making `npm create jazz` appear frozen
- Spinner message now updates as each workspace dep resolves:
  e.g. `Resolving dependencies (2/5)`
- Removed a `console.warn` in the retry path that was writing raw text to the
  terminal while the spinner was active, corrupting its output
- Wired `create-jazz` into the alpha publish workflow so new versions deploy
  to npm automatically

## Test plan
- [ ] Run `pnpm test` in `packages/create-jazz` — all 56 tests should pass
- [ ] Build and run: `cd packages/create-jazz && pnpm build && node dist/index.js my-test-app --no-git`, then `rm -rf my-test-app` — observe spinner updating with `(N/M)` counts during dep resolution