### PR TITLE
fix(jazz-tools): resolve jazz-wasm via Vite alias

### DIFF
--- a/.changeset/vite-plugin-jazz-wasm-alias.md
+++ b/.changeset/vite-plugin-jazz-wasm-alias.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+`jazzPlugin` and `jazzSvelteKit` now alias `jazz-wasm` to an absolute path resolved from `jazz-tools`'s own install location. This removes the need for Vite/SvelteKit consumers on pnpm to add `jazz-wasm` as a direct dependency just to work around pnpm's strict-isolation layout.

--- a/packages/jazz-tools/src/dev/sveltekit.test.ts
+++ b/packages/jazz-tools/src/dev/sveltekit.test.ts
@@ -398,6 +398,21 @@ it("config hook preserves existing optimizeDeps excludes", () => {
   expect(result.optimizeDeps?.exclude).toContain("some-dep");
 });
 
+// Without this alias, a pnpm-installed SvelteKit app hits
+// "Failed to resolve import 'jazz-wasm'" at runtime — the bare specifier
+// in jazz-tools' chunk can't be found unless jazz-wasm is hoisted or a
+// direct dep. The alias resolves it from the plugin's own location.
+it("config hook aliases jazz-wasm to an absolute path", () => {
+  const plugin = jazzSvelteKit();
+  const config = (plugin as { config?: (c: Record<string, unknown>) => unknown }).config;
+  const result = config!({}) as {
+    resolve?: { alias?: { find: RegExp | string; replacement: string }[] };
+  };
+  const alias = result.resolve?.alias?.find((a) => String(a.find) === "/^jazz-wasm$/");
+  expect(alias).toBeDefined();
+  expect(alias!.replacement).toMatch(/jazz_wasm\.js$/);
+});
+
 describe("dev barrel", () => {
   it("exposes jazzSvelteKit", () => {
     expect((dev as Record<string, unknown>).jazzSvelteKit).toBeDefined();

--- a/packages/jazz-tools/src/dev/sveltekit.ts
+++ b/packages/jazz-tools/src/dev/sveltekit.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path";
 import { loadEnvFileIntoProcessEnv } from "./env-file.js";
 import { ManagedDevRuntime } from "./managed-runtime.js";
+import { resolveJazzWasmEntry } from "./vite.js";
 import type {
   JazzServerOptions as BaseJazzServerOptions,
   JazzPluginOptions as BaseJazzPluginOptions,
@@ -46,12 +47,16 @@ export function jazzSvelteKit(options: JazzPluginOptions = {}) {
     config(config: { ssr?: { external?: string[] }; optimizeDeps?: { exclude?: string[] } }) {
       const existingSsr = config.ssr?.external ?? [];
       const existingExclude = config.optimizeDeps?.exclude ?? [];
+      const jazzWasmEntry = resolveJazzWasmEntry();
       return {
         worker: { format: "es" as const },
         optimizeDeps: {
           exclude: Array.from(new Set([...existingExclude, "jazz-wasm"])),
         },
         ssr: { external: Array.from(new Set([...existingSsr, "jazz-napi"])) },
+        ...(jazzWasmEntry
+          ? { resolve: { alias: [{ find: /^jazz-wasm$/, replacement: jazzWasmEntry }] } }
+          : {}),
       };
     },
 

--- a/packages/jazz-tools/src/dev/vite.test.ts
+++ b/packages/jazz-tools/src/dev/vite.test.ts
@@ -68,6 +68,21 @@ describe("jazzPlugin", () => {
     expect(result.optimizeDeps?.exclude).toContain("some-dep");
   });
 
+  // Without this alias, a Vite consumer installed via pnpm hits
+  // "Failed to resolve import 'jazz-wasm'" at runtime — the bare specifier
+  // in jazz-tools' chunk can't be found unless jazz-wasm is hoisted or a
+  // direct dep. The alias resolves it from the plugin's own location.
+  it("config hook aliases jazz-wasm to an absolute path", () => {
+    const plugin = jazzPlugin();
+    const config = (plugin as { config?: (c: Record<string, unknown>) => unknown }).config;
+    const result = config!({}) as {
+      resolve?: { alias?: { find: RegExp | string; replacement: string }[] };
+    };
+    const alias = result.resolve?.alias?.find((a) => String(a.find) === "/^jazz-wasm$/");
+    expect(alias).toBeDefined();
+    expect(alias!.replacement).toMatch(/jazz_wasm\.js$/);
+  });
+
   it("starts a server and pushes schema via configureServer hook", async () => {
     const port = await getAvailablePort();
     const schemaDir = await tempRoots.create("jazz-vite-test-");

--- a/packages/jazz-tools/src/dev/vite.ts
+++ b/packages/jazz-tools/src/dev/vite.ts
@@ -1,6 +1,23 @@
+import { createRequire } from "node:module";
 import { loadEnvFileIntoProcessEnv } from "./env-file.js";
 import { buildInspectorLink } from "./inspector-link.js";
 import { ManagedDevRuntime } from "./managed-runtime.js";
+
+// jazz-tools contains a dynamic `import("jazz-wasm")` that we intentionally
+// keep out of Vite's dep optimizer (wasm-bindgen output breaks esbuild's
+// pre-bundling). With pnpm's strict install layout, a bare `jazz-wasm`
+// specifier left in a consumer bundle won't resolve at runtime because the
+// package isn't hoisted to the project root. We resolve jazz-wasm from this
+// module's location — where it IS a direct dependency of jazz-tools — and
+// return it as an absolute path, so the plugin can alias the bare specifier
+// without forcing the consumer to add jazz-wasm to their own package.json.
+export function resolveJazzWasmEntry(): string | null {
+  try {
+    return createRequire(import.meta.url).resolve("jazz-wasm");
+  } catch {
+    return null;
+  }
+}
 
 export interface JazzServerOptions {
   port?: number;
@@ -58,11 +75,15 @@ export function jazzPlugin(options: JazzPluginOptions = {}) {
 
     config(config: { optimizeDeps?: { exclude?: string[] } }) {
       const existing = config.optimizeDeps?.exclude ?? [];
+      const jazzWasmEntry = resolveJazzWasmEntry();
       return {
         worker: { format: "es" as const },
         optimizeDeps: {
           exclude: Array.from(new Set([...existing, "jazz-wasm"])),
         },
+        ...(jazzWasmEntry
+          ? { resolve: { alias: [{ find: /^jazz-wasm$/, replacement: jazzWasmEntry }] } }
+          : {}),
       };
     },
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1380,9 +1380,6 @@ importers:
       jazz-tools:
         specifier: workspace:*
         version: link:../../packages/jazz-tools
-      jazz-wasm:
-        specifier: workspace:*
-        version: link:../../crates/jazz-wasm
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -1438,9 +1435,6 @@ importers:
       jazz-tools:
         specifier: workspace:*
         version: link:../../packages/jazz-tools
-      jazz-wasm:
-        specifier: workspace:*
-        version: link:../../crates/jazz-wasm
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -1484,9 +1478,6 @@ importers:
       jazz-tools:
         specifier: workspace:*
         version: link:../../packages/jazz-tools
-      jazz-wasm:
-        specifier: workspace:*
-        version: link:../../crates/jazz-wasm
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -1521,9 +1512,6 @@ importers:
       jazz-tools:
         specifier: workspace:*
         version: link:../../packages/jazz-tools
-      jazz-wasm:
-        specifier: workspace:*
-        version: link:../../crates/jazz-wasm
       svelte:
         specifier: ^5.0.0
         version: 5.53.6
@@ -1561,9 +1549,6 @@ importers:
       jazz-tools:
         specifier: workspace:*
         version: link:../../packages/jazz-tools
-      jazz-wasm:
-        specifier: workspace:*
-        version: link:../../crates/jazz-wasm
       svelte:
         specifier: ^5.0.0
         version: 5.53.6
@@ -1595,9 +1580,6 @@ importers:
       jazz-tools:
         specifier: workspace:*
         version: link:../../packages/jazz-tools
-      jazz-wasm:
-        specifier: workspace:*
-        version: link:../../crates/jazz-wasm
       svelte:
         specifier: ^5.0.0
         version: 5.53.6

--- a/starters/react-betterauth/package.json
+++ b/starters/react-betterauth/package.json
@@ -17,7 +17,6 @@
     "better-auth": "^1.5.5",
     "hono": "^4.7.11",
     "jazz-tools": "workspace:*",
-    "jazz-wasm": "workspace:*",
     "react": "19.2.4",
     "react-dom": "19.2.4"
   },

--- a/starters/react-hybrid/package.json
+++ b/starters/react-hybrid/package.json
@@ -18,7 +18,6 @@
     "hono": "^4.7.11",
     "jazz-napi": "workspace:*",
     "jazz-tools": "workspace:*",
-    "jazz-wasm": "workspace:*",
     "react": "19.2.4",
     "react-dom": "19.2.4"
   },

--- a/starters/react-localfirst/package.json
+++ b/starters/react-localfirst/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "jazz-tools": "workspace:*",
-    "jazz-wasm": "workspace:*",
     "react": "19.2.4",
     "react-dom": "19.2.4"
   },

--- a/starters/sveltekit-betterauth/package.json
+++ b/starters/sveltekit-betterauth/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "better-auth": "^1.5.5",
     "jazz-tools": "workspace:*",
-    "jazz-wasm": "workspace:*",
     "svelte": "^5.0.0"
   },
   "devDependencies": {

--- a/starters/sveltekit-hybrid/package.json
+++ b/starters/sveltekit-hybrid/package.json
@@ -15,7 +15,6 @@
     "better-auth": "^1.5.5",
     "jazz-napi": "workspace:*",
     "jazz-tools": "workspace:*",
-    "jazz-wasm": "workspace:*",
     "svelte": "^5.0.0"
   },
   "devDependencies": {

--- a/starters/sveltekit-localfirst/package.json
+++ b/starters/sveltekit-localfirst/package.json
@@ -12,7 +12,6 @@
   },
   "dependencies": {
     "jazz-tools": "workspace:*",
-    "jazz-wasm": "workspace:*",
     "svelte": "^5.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- `jazzPlugin` and `jazzSvelteKit` now inject a `resolve.alias` mapping `jazz-wasm` to the absolute path resolved from jazz-tools' own install location, so Vite rewrites the bare specifier without relying on pnpm hoisting.
- Reverts #654 (c09796165) — Vite/SvelteKit starters no longer need `jazz-wasm` as a direct dependency.
- Added tests asserting the alias is emitted from both plugins' `config` hooks.

## Why

jazz-tools contains a dynamic `import(\"jazz-wasm\")` that has to stay in `optimizeDeps.exclude` (wasm-bindgen output breaks esbuild pre-bundling). Under pnpm, the bare `jazz-wasm` specifier left in the consumer bundle couldn't be resolved at runtime because pnpm doesn't hoist it to the project root. The previous fix papered over this by forcing every Vite/SvelteKit starter to declare `jazz-wasm` directly. That made the plugin leak an internal dependency into every consumer's `package.json`.

With the alias, consumers just add `jazz-tools` and the plugin handles it — matches what the install docs already say.

## Test plan

- [x] `pnpm --filter jazz-tools exec vitest run src/dev/vite.test.ts src/dev/sveltekit.test.ts` (26 passed)
- [x] `pnpm --filter jazz-tools build`
- [x] `pnpm --filter sveltekit-localfirst build` succeeds with no direct `jazz-wasm` dep
- [ ] CI green across the rest of the matrix
- [ ] Manual: scaffold a fresh app via `create-jazz`, `pnpm install`, `pnpm dev` — no "Failed to resolve import 'jazz-wasm'" at runtime