### PR TITLE
Expand local-first auth docs and add internals reference

### DIFF
--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import { RootProvider } from "fumadocs-ui/provider/next";
 import { Analytics } from "@vercel/analytics/next";
@@ -8,6 +9,15 @@ const inter = Inter({
   display: "swap",
   variable: "--font-inter",
 });
+
+export const metadata: Metadata = {
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_SITE_URL ??
+      (process.env.VERCEL_PROJECT_PRODUCTION_URL
+        ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
+        : "http://localhost:3000"),
+  ),
+};
 
 export default function Layout({ children }: LayoutProps<"/">) {
   return (

--- a/docs/content/docs/auth/local-first-auth.mdx
+++ b/docs/content/docs/auth/local-first-auth.mdx
@@ -15,7 +15,7 @@ This secret (and therefore the account) lives wherever the user uses the app. To
 
 ## When to use local-first auth
 
-If you want users to be able start immediately, local-first ([client setup](#client-setup)) is a great option, but any user who clears site data (intentionally or otherwise) loses their account.
+If you want users to be able to start immediately, local-first ([client setup](#client-setup)) is a great option, but any user who clears site data (intentionally or otherwise) loses their account.
 
 You can add a [recovery passphrase](#recovery-passphrase) or [passkey backup](#passkey-backup) which allows users to more easily log in on multiple devices or recover their accounts if they delete them. However, these are often less familiar and can add UX friction.
 
@@ -27,7 +27,7 @@ You can also combine modes: let local-first users read and experiment, but requi
 
 ## Client setup
 
-Fetch or create a persistent secret and pass it to your Jazz client. Jazz stores the secret in the browser (or equivalent on native) so subsequent loads reuse the same account.
+Fetch or create a secret and pass it to your Jazz client. Jazz stores the secret in the browser (or equivalent on native) so subsequent loads reuse the same account.
 
 <Tabs
   groupId="jazz-framework"
@@ -153,7 +153,7 @@ The parser is case-insensitive and tolerant of extra whitespace between words. I
 <Callout type="info">
   In React and Expo, `useLocalFirstAuth().login()` updates the mounted `JazzProvider` immediately.
   Other frameworks use `BrowserAuthSecretStore.saveSecret()` directly, which doesn't notify the live
-  client. The snippets above reload the page so the new secret is picked up on next boot.
+  client — the snippets above reload the page so the new secret is picked up on the next load.
 </Callout>
 
 ### Passkey backup
@@ -275,7 +275,7 @@ Before calling your sign-up endpoint, the client generates a short-lived proof t
   ../examples/auth-betterauth-chat/src/docs/local-first-proof-snippet.tsx#local-first-proof-signup
 </include>
 
-The `audience` can be anything, but match what the server expects when verifying. The `ttlSeconds` keeps the window short. 60 seconds should be enough for a sign-up round-trip.
+`audience` is application-defined; the string only needs to match what the server passes when verifying. `ttlSeconds` keeps the window short — 60 seconds is usually enough for a sign-up round-trip.
 
 ### Verifying on sign-up
 
@@ -312,7 +312,9 @@ The BetterAuth example above uses a framework-specific middleware hook. With any
 3. Stores the proven Jazz user ID linked to the new user account
 4. Issues JWTs with `sub: jazzId`
 
-```ts title="server.ts"
+Sketched in pseudo-Express (`db.users.create` and `issueJwt` stand in for whatever your stack provides):
+
+```ts title="Illustrative — not a runnable example"
 import { verifyLocalFirstIdentityProof } from "jazz-napi";
 
 // POST /signup
@@ -339,12 +341,6 @@ app.post("/signup", async (req, res) => {
 The `audience` string on the client and server must match. `jazz-napi` normalizes it internally, so any consistent string works.
 
 Jazz reads the JWT `sub` claim verbatim as `session.user_id` — no custom-claim fallback — so your provider needs to emit the Jazz ID as `sub`. If it doesn't let you override `sub` (e.g. it pins it to its own user ID), you'll need to mint the JWT yourself rather than using the provider's issuer.
-
-## How it works
-
-Local-first auth derives an Ed25519 keypair from a 32-byte seed, then takes the user ID to be a deterministic function of the public key (UUIDv5, namespace `jazz-auth-key-v1`). The client authenticates by minting a self-signed JWT that embeds its public key; the server verifies the signature and checks that the embedded key hashes to the claimed user ID. No external key store is involved — the token is fully self-contained.
-
-For the byte-level token format, proof-token structure, and further information, see [Local-first auth internals](/docs/reference/local-first-auth-internals).
 
 ## Next steps
 

--- a/docs/content/docs/auth/local-first-auth.mdx
+++ b/docs/content/docs/auth/local-first-auth.mdx
@@ -1,55 +1,116 @@
 ---
 title: Local-first auth
 description: "Authenticate users without a server using self-signed tokens, and optionally upgrade to an external provider while preserving identity."
-reviewedAt: "22485728"
+reviewedAt: "c5f0807b6"
 ---
 
-Local-first auth lets users start using your app immediately — no sign-up, no server round-trip. Jazz generates a stable identity from a secret stored on the device. Without a recovery mechanism, that identity lives only on the device — if the secret is lost, it's gone. Linking to an external provider at sign-up is one way to make the identity durable and recoverable.
+Local-first auth lets users start using your app immediately without signing up. Jazz generates a secret on the client, derives a stable account ID from it, and uses self-signed tokens to prove the user owns that account. The secret itself effectively _is_ the account.
 
-| Mode          | Identity source         | Server needed? | Best for                                               |
-| ------------- | ----------------------- | -------------- | ------------------------------------------------------ |
-| `local-first` | Secret stored on device | No             | Production offline-first apps, try-before-signup flows |
-| `external`    | JWT from auth provider  | Yes            | Production apps with real user accounts                |
+This secret (and therefore the account) lives wherever the user uses the app. To log in from other devices, the user needs to use the same secret.
+
+| Mode          | Identity source        | Server needed? | Best for                                               |
+| ------------- | ---------------------- | -------------- | ------------------------------------------------------ |
+| `local-first` | Keypair held by client | No             | Production offline-first apps, try-before-signup flows |
+| `external`    | JWT from auth provider | Yes            | Production apps with real user accounts                |
+
+## When to use local-first auth
+
+If you want users to be able start immediately, local-first ([client setup](#client-setup)) is a great option, but any user who clears site data (intentionally or otherwise) loses their account.
+
+You can add a [recovery passphrase](#recovery-passphrase) or [passkey backup](#passkey-backup) which allows users to more easily log in on multiple devices or recover their accounts if they delete them. However, these are often less familiar and can add UX friction.
+
+A good middle ground is starting users on local-first so they can play around immediately, but let them upgrade to a managed account when they want to, for example using Better Auth (see [signing up with BetterAuth](#signing-up-with-betterauth)).
+
+If you don't want a try-before-signup flow at all, skip local-first entirely and use [external auth](/docs/auth/authentication) from day one.
+
+You can also combine modes: let local-first users read and experiment, but require an upgrade before any sensitive action — see [Permissions by auth mode](#permissions-by-auth-mode).
 
 ## Client setup
 
-Use `useLocalFirstAuth()` to manage the user's secret. On first load it generates a new identity; on subsequent loads it reuses the stored one. It also exposes `login` and `signOut` for switching or clearing the local identity.
+Fetch or create a persistent secret and pass it to your Jazz client. Jazz stores the secret in the browser (or equivalent on native) so subsequent loads reuse the same account.
 
-<include cwd lang="tsx" meta='title="App.tsx"'>
-  ../examples/auth-betterauth-chat/src/docs/local-first-client-snippet.tsx#local-first-client-setup
-</include>
+<Tabs
+  groupId="jazz-framework"
+  persist
+  updateAnchor
+  items={["React", "Vue", "Svelte", "TypeScript"]}
+>
+  <Tab value="React">
+    <include cwd lang="tsx" meta='title="App.tsx"'>
+      ../examples/docs/todo-client-localfirst-react/src/auth-snippets.tsx#auth-localfirst-react
+    </include>
+    `useLocalFirstAuth()` also exposes `login` and `signOut` for switching or clearing accounts.
+  </Tab>
+  <Tab value="Vue">
+    <include cwd lang="vue" meta='title="App.vue"'>
+      ../examples/docs/todo-client-localfirst-vue/src/AuthLocalfirst.vue
+    </include>
+  </Tab>
+  <Tab value="Svelte">
+    <include cwd lang="svelte" meta='title="App.svelte"'>
+      ../examples/docs/todo-client-localfirst-svelte/src/AuthLocalfirst.svelte#auth-localfirst-svelte
+    </include>
+  </Tab>
+  <Tab value="TypeScript">
+    <include cwd lang="ts" meta='title="jazz-client.ts"'>
+      ../examples/docs/todo-client-localfirst-ts/src/auth-snippets.ts#auth-localfirst-ts
+    </include>
+  </Tab>
+</Tabs>
 
 <Callout type="warn">
-  The secret is the user's identity. If it's lost (e.g. `localStorage` cleared), the identity is
-  gone and any data owned by that user becomes inaccessible unless you restore it from a recovery
-  passphrase, a passkey backup, or an external provider you linked earlier.
+  Lose the secret and you lose the account. If it's cleared (e.g. `localStorage` wiped), the account
+  and any data owned by it become inaccessible unless the user restores from a recovery passphrase,
+  a passkey backup, or an external provider they linked earlier.
 </Callout>
 
 ## Backing up and restoring the secret
 
 You can keep local-first auth fully serverless and still make it recoverable. Jazz ships two backup
-helpers for the same 32-byte secret:
+helpers:
 
-| Method                      | Platforms     | Best for                                       | Trade-offs                                           |
-| --------------------------- | ------------- | ---------------------------------------------- | ---------------------------------------------------- |
-| `jazz-tools/passphrase`     | Browser, Expo | Manual backup users can carry anywhere         | User must safely store a 24-word recovery passphrase |
-| `jazz-tools/passkey-backup` | Browser only  | Fast recovery on devices that support passkeys | Requires WebAuthn and a stable relying-party ID      |
+| Method                      | Platforms     | Best for                                       | Trade-offs                                                                                      |
+| --------------------------- | ------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `jazz-tools/passphrase`     | Browser, Expo | Manual backup users can carry anywhere         | User must securely store a 24-word recovery passphrase, and UI has to convey the weight of this |
+| `jazz-tools/passkey-backup` | Browser only  | Fast recovery on devices that support passkeys | Passkey sync is platform-bounded                                                                |
 
 ### Recovery passphrase
 
-`jazz-tools/passphrase` converts the local-first secret into a 24-word English recovery
-passphrase. Restoring that passphrase produces the exact same secret, so the user keeps the same
-Jazz identity.
+`jazz-tools/passphrase` encodes the secret as a 24-word English passphrase, similar to
+a crypto-wallet seed phrase. Decoding the passphrase produces the exact same secret, so the user
+keeps the same Jazz account.
 
-<Tabs groupId="local-first-recovery-platform" persist updateAnchor items={["React", "Expo"]}>
+<Callout type="warn">
+  The 24 words are just the secret encoded differently, not a password layered over it. There's no
+  hashing, no key-wrapping, no challenge-response: whoever sees the passphrase can sign in as the
+  user. This poses a difficult UX challenge: the phrase is too long for most people to remember, and
+  the risk of insecure storage is high.
+</Callout>
+
+<Tabs
+  groupId="jazz-framework"
+  persist
+  updateAnchor
+  items={["React", "Vue", "Svelte", "TypeScript"]}
+>
   <Tab value="React">
-    <include cwd lang="tsx" meta='title="auth-snippets.tsx"'>
+    <include cwd lang="tsx">
       ../examples/docs/todo-client-localfirst-react/src/auth-snippets.tsx#auth-localfirst-react-backup
     </include>
   </Tab>
-  <Tab value="Expo">
-    <include cwd lang="tsx" meta='title="auth-snippets.tsx"'>
-      ../examples/docs/todo-client-localfirst-expo/src/auth-snippets.tsx#auth-localfirst-expo-backup
+  <Tab value="Vue">
+    <include cwd lang="ts">
+      ../examples/docs/todo-client-localfirst-vue/src/auth-snippets.ts#auth-localfirst-vue-backup
+    </include>
+  </Tab>
+  <Tab value="Svelte">
+    <include cwd lang="ts">
+      ../examples/docs/todo-client-localfirst-svelte/src/auth-snippets.svelte.ts#auth-localfirst-svelte-backup
+    </include>
+  </Tab>
+  <Tab value="TypeScript">
+    <include cwd lang="ts">
+      ../examples/docs/todo-client-localfirst-ts/src/auth-snippets.ts#auth-localfirst-ts-backup
     </include>
   </Tab>
 </Tabs>
@@ -58,54 +119,133 @@ To restore, decode the user-provided passphrase back into a secret and hand it b
 local-first auth flow:
 
 <Tabs
-  groupId="local-first-recovery-restore-platform"
+  groupId="jazz-framework"
   persist
   updateAnchor
-  items={["React", "Expo"]}
+  items={["React", "Vue", "Svelte", "TypeScript"]}
 >
   <Tab value="React">
-    <include cwd lang="tsx" meta='title="auth-snippets.tsx"'>
+    <include cwd lang="tsx">
       ../examples/docs/todo-client-localfirst-react/src/auth-snippets.tsx#auth-localfirst-react-restore
     </include>
   </Tab>
-  <Tab value="Expo">
-    <include cwd lang="tsx" meta='title="auth-snippets.tsx"'>
-      ../examples/docs/todo-client-localfirst-expo/src/auth-snippets.tsx#auth-localfirst-expo-restore
+  <Tab value="Vue">
+    <include cwd lang="ts">
+      ../examples/docs/todo-client-localfirst-vue/src/auth-snippets.ts#auth-localfirst-vue-restore
+    </include>
+  </Tab>
+  <Tab value="Svelte">
+    <include cwd lang="ts">
+      ../examples/docs/todo-client-localfirst-svelte/src/auth-snippets.svelte.ts#auth-localfirst-svelte-restore
+    </include>
+  </Tab>
+  <Tab value="TypeScript">
+    <include cwd lang="ts">
+      ../examples/docs/todo-client-localfirst-ts/src/auth-snippets.ts#auth-localfirst-ts-restore
     </include>
   </Tab>
 </Tabs>
 
-The parser accepts upper-case input and extra whitespace. Invalid input throws
+The parser is case-insensitive and tolerant of extra whitespace between words. Invalid input throws
 `RecoveryPhraseError` with codes like `invalid-length`, `invalid-word`, and
 `invalid-checksum`.
 
 <Callout type="info">
-  In React and Expo, prefer `useLocalFirstAuth()` for backup and restore so the mounted
-  `JazzProvider` updates immediately. The lower-level `BrowserAuthSecretStore` and
-  `ExpoAuthSecretStore` APIs are still useful outside React-based UIs.
+  In React and Expo, `useLocalFirstAuth().login()` updates the mounted `JazzProvider` immediately.
+  Other frameworks use `BrowserAuthSecretStore.saveSecret()` directly, which doesn't notify the live
+  client. The snippets above reload the page so the new secret is picked up on next boot.
 </Callout>
 
 ### Passkey backup
 
-For browser apps, `jazz-tools/passkey-backup` stores the same secret in a resident WebAuthn
-credential. That gives users passkey-style recovery without adding a server-side auth provider.
+A passkey is a credential stored and synced by the user's browser or platform (via the WebAuthn
+browser API), typically unlocked with biometrics. `jazz-tools/passkey-backup` uses this as an
+encrypted at-rest store for the secret: the secret is held inside a resident WebAuthn
+credential and released after a user verification prompt. This is not a full WebAuthn
+authentication flow&hairsp;—&hairsp;Jazz is not challenging the key, just using the passkey as a vault for the
+seed.
+
+Passkey availability depends on where the user's passkey provider works. OS-native stores
+(iCloud Keychain, Google Password Manager) have platform boundaries that are not always visible
+to users. For example, a passkey created on Safari/macOS may not be available on Chrome/Windows unless the
+user is using a third-party passkey manager (1Password, Bitwarden, Dashlane etc.) that spans
+both. WebAuthn's cross-device flow (QR from laptop to phone) can bridge a session but requires
+the original device, so it doesn't help after a loss.
+
+<Callout type="warn">
+  Treat passkey backup as one option among several. Pair it with a recovery passphrase or a linked
+  provider account so the user doesn't get locked out.
+</Callout>
 
 Create the passkey from the current local-first secret:
 
-<include cwd lang="tsx" meta='title="auth-snippets.tsx"'>
-  ../examples/docs/todo-client-localfirst-react/src/auth-snippets.tsx#auth-localfirst-react-passkey-backup
-</include>
+<Tabs
+  groupId="jazz-framework"
+  persist
+  updateAnchor
+  items={["React", "Vue", "Svelte", "TypeScript"]}
+>
+  <Tab value="React">
+    <include cwd lang="tsx">
+      ../examples/docs/todo-client-localfirst-react/src/auth-snippets.tsx#auth-localfirst-react-passkey-backup
+    </include>
+  </Tab>
+  <Tab value="Vue">
+    <include cwd lang="ts">
+      ../examples/docs/todo-client-localfirst-vue/src/auth-snippets.ts#auth-localfirst-vue-passkey-backup
+    </include>
+  </Tab>
+  <Tab value="Svelte">
+    <include cwd lang="ts">
+      ../examples/docs/todo-client-localfirst-svelte/src/auth-snippets.svelte.ts#auth-localfirst-svelte-passkey-backup
+    </include>
+  </Tab>
+  <Tab value="TypeScript">
+    <include cwd lang="ts">
+      ../examples/docs/todo-client-localfirst-ts/src/auth-snippets.ts#auth-localfirst-ts-passkey-backup
+    </include>
+  </Tab>
+</Tabs>
 
-Restore from the passkey by reading the secret back and passing it to `login(...)` from
-`useLocalFirstAuth()`:
+Restore by reading the secret back from the passkey:
 
-<include cwd lang="tsx" meta='title="auth-snippets.tsx"'>
-  ../examples/docs/todo-client-localfirst-react/src/auth-snippets.tsx#auth-localfirst-react-passkey-restore
-</include>
+<Tabs
+  groupId="jazz-framework"
+  persist
+  updateAnchor
+  items={["React", "Vue", "Svelte", "TypeScript"]}
+>
+  <Tab value="React">
+    <include cwd lang="tsx">
+      ../examples/docs/todo-client-localfirst-react/src/auth-snippets.tsx#auth-localfirst-react-passkey-restore
+    </include>
+  </Tab>
+  <Tab value="Vue">
+    <include cwd lang="ts">
+      ../examples/docs/todo-client-localfirst-vue/src/auth-snippets.ts#auth-localfirst-vue-passkey-restore
+    </include>
+  </Tab>
+  <Tab value="Svelte">
+    <include cwd lang="ts">
+      ../examples/docs/todo-client-localfirst-svelte/src/auth-snippets.svelte.ts#auth-localfirst-svelte-passkey-restore
+    </include>
+  </Tab>
+  <Tab value="TypeScript">
+    <include cwd lang="ts">
+      ../examples/docs/todo-client-localfirst-ts/src/auth-snippets.ts#auth-localfirst-ts-passkey-restore
+    </include>
+  </Tab>
+</Tabs>
 
-Use a stable `appHostname` everywhere you want passkey recovery to work. It becomes the WebAuthn
-relying-party ID, so changing it creates a different passkey namespace. `backup(secret,
-displayName)` also needs a user-visible name for the platform passkey sheet.
+<Callout type="info">
+  Passkey backup is currently browser-only. Mobile platform support is planned.
+</Callout>
+
+- `appHostname` becomes the WebAuthn relying-party ID which is the namespace passkeys are scoped to.
+  If you change it, all existing passkeys will stop working.
+
+- The `displayName` argument to `backup(secret,
+displayName)` is the user-visible name shown in the platform passkey sheet.
 
 Handle `PasskeyBackupError` in your UI to surface cases like unsupported browsers, no saved
 credential, or missing user verification. Keep a recovery passphrase or external sign-in as a
@@ -113,47 +253,35 @@ fallback if the user might lose access to their passkey provider.
 
 ## Server configuration
 
-Local-first auth is enabled by default in development. In production, enable it explicitly:
+Local-first auth is enabled by default in the cloud, and in local dev mode. For self-hosted production setups, enable it explicitly:
 
 ```bash
 pnpm dlx jazz-tools@alpha server <APP_ID> --allow-local-first-auth
 ```
 
-No JWKS endpoint is needed — the token is self-contained and the server can verify it on its own.
+No JWKS endpoint is needed: the token is self-contained and the server can verify it on its own.
 
 ## Signing up with BetterAuth
 
-Users can try your app before creating an account. When they sign up later through BetterAuth, all the data they created carries over — same account, nothing lost.
+Users can try your app before creating an account. When they sign up later through BetterAuth, all the data they created carries over: same Jazz account, now with an email (or OAuth identity) attached.
 
-<Mermaid chart={`
-sequenceDiagram
-    participant Client
-    participant BetterAuth as BetterAuth server
-
-    Note over Client: User starts with local-first auth
-    Client->>Client: db.getLocalFirstIdentityProof()
-    Client->>BetterAuth: Sign up (email + proofToken)
-    BetterAuth->>BetterAuth: Verify proof, create user with same ID
-    BetterAuth-->>Client: Session + JWT
-    Note over Client: Same user ID, now with an account
-
-`} />
+The client generates a short-lived proof that it owns the current Jazz account and hands it to BetterAuth alongside the sign-up credentials. BetterAuth verifies the proof, records the Jazz account ID against the new user, and issues JWTs that keep pointing to the same ID. For the reasoning and sequence diagram, see [Upgrading to a provider account](/docs/reference/local-first-auth-internals#upgrading-to-a-provider-account).
 
 ### Generating the proof token
 
-Before calling your sign-up endpoint, the client generates a short-lived proof that it owns the current Jazz identity:
+Before calling your sign-up endpoint, the client generates a short-lived proof that it owns the current Jazz account:
 
-<include cwd lang="tsx" meta='title="SignUp.tsx"'>
+<include cwd lang="tsx">
   ../examples/auth-betterauth-chat/src/docs/local-first-proof-snippet.tsx#local-first-proof-signup
 </include>
 
-The `audience` should match what the server expects when verifying. The `ttlSeconds` keeps the window short — 60 seconds is enough for a sign-up round-trip.
+The `audience` can be anything, but match what the server expects when verifying. The `ttlSeconds` keeps the window short. 60 seconds should be enough for a sign-up round-trip.
 
 ### Verifying on sign-up
 
 On the server, a BetterAuth middleware hook intercepts sign-up requests, verifies the proof token, and assigns the proven Jazz user ID to the new BetterAuth user:
 
-<include cwd lang="ts" meta='title="src/lib/auth.ts"'>
+<include cwd lang="ts">
   ../examples/auth-betterauth-chat/src/docs/local-first-server-snippet.ts#local-first-verify-hook
 </include>
 
@@ -163,7 +291,7 @@ On the server, a BetterAuth middleware hook intercepts sign-up requests, verifie
 
 The app switches between local-first auth and external JWT based on whether the user has a BetterAuth session:
 
-<include cwd lang="tsx" meta='title="App.tsx"'>
+<include cwd lang="tsx">
   ../examples/auth-betterauth-chat/src/docs/local-first-proof-snippet.tsx#local-first-config-resolution
 </include>
 
@@ -171,7 +299,7 @@ The app switches between local-first auth and external JWT based on whether the 
 
 You can restrict what local-first users can do until they sign up. Define an `isLocalFirstAuthMode` check in your permissions and use it to gate writes:
 
-<include cwd lang="ts" meta='title="permissions.ts"'>
+<include cwd lang="ts">
   ../examples/auth-betterauth-chat/src/docs/local-first-permissions-snippet.ts#local-first-permissions
 </include>
 
@@ -210,28 +338,17 @@ app.post("/signup", async (req, res) => {
 
 The `audience` string on the client and server must match. `jazz-napi` normalizes it internally, so any consistent string works.
 
-Jazz uses the JWT `sub` claim as `session.user_id`. If your provider keeps `sub` fixed to its own user ID, add a `/link-jazz-identity` endpoint that stores the Jazz ID and mint the JWT with `sub: <jazzId>` yourself — either via a custom `getSubject` hook on your provider or by issuing the JWT directly.
+Jazz reads the JWT `sub` claim verbatim as `session.user_id` — no custom-claim fallback — so your provider needs to emit the Jazz ID as `sub`. If it doesn't let you override `sub` (e.g. it pins it to its own user ID), you'll need to mint the JWT yourself rather than using the provider's issuer.
 
-## Under the hood
+## How it works
 
-Local-first auth uses Ed25519 cryptography to derive a stable identity from a secret:
+Local-first auth derives an Ed25519 keypair from a 32-byte seed, then takes the user ID to be a deterministic function of the public key (UUIDv5, namespace `jazz-auth-key-v1`). The client authenticates by minting a self-signed JWT that embeds its public key; the server verifies the signature and checks that the embedded key hashes to the claimed user ID. No external key store is involved — the token is fully self-contained.
 
-1. A 32-byte **seed** is hashed with SHA-512 to produce an Ed25519 **signing key**.
-2. The corresponding **public key** (32 bytes) is extracted.
-3. A deterministic **user ID** is derived from the public key using UUIDv5 (namespace `jazz-auth-key-v1`).
-4. The client mints a **self-signed JWT** with:
-   - `alg: "EdDSA"` — Ed25519 signature
-   - `iss: "urn:jazz:local-first"` — identifies the token as local-first
-   - `sub: <user_id>` — the derived user ID
-   - `jazz_pub_key: <base64url>` — the embedded public key
-   - `aud: <app_id>` — scoped to the app
-
-The server verifies the signature using the embedded public key, re-derives the user ID, and confirms it matches `sub`. No external key store is involved — the token is fully self-contained.
-
-Same seed always produces the same user ID, across devices and time.
+For the byte-level token format, proof-token structure, and further information, see [Local-first auth internals](/docs/reference/local-first-auth-internals).
 
 ## Next steps
 
 - [Sessions](/docs/auth/sessions) — read the current user and scope queries to their identity
 - [Permissions](/docs/auth/permissions) — define row-level access policies
 - [Auth provider integration](/docs/recipes/auth-provider-integration) — set up BetterAuth or WorkOS as your JWT provider
+- [Local-first auth internals](/docs/reference/local-first-auth-internals) — token format, verification, and design rationale

--- a/docs/content/docs/reference/local-first-auth-internals.mdx
+++ b/docs/content/docs/reference/local-first-auth-internals.mdx
@@ -18,10 +18,7 @@ public key, so holding the secret is the same thing as being the account: it let
 the keypair on demand and self-certify as that identity. Signing in is reconstructing the keypair
 from the stored secret; signing up is generating a new one.
 
-This is why the design doesn't need a server-side user registry. The public key embedded in a
-token, paired with its signature, is everything the server needs to confirm the claimed account. Verification reuses the JWT-checking path the server already runs for
-external-auth tokens; only the source of the signing key differs (embedded in the token for
-local-first, fetched from a JWKS endpoint for external auth).
+This is why the design doesn't need a server-side user registry: the public key embedded in a token, paired with its signature, is everything the server needs to confirm the claimed account. Verification reuses the JWT-checking path the server already runs for external-auth tokens — only the source of the signing key differs (embedded in the token for local-first, fetched from a JWKS endpoint for external auth).
 
 ## Identity derivation
 
@@ -48,7 +45,7 @@ The key claims are:
 | `jazz_pub_key` | Public key (base64url)   | Embedded so the server can verify without a lookup   |
 | `aud`          | App ID                   | Scopes the token to a specific app                   |
 
-Because the public key is embedded in the JWT itself, and signed using the private key, there is no need for a separate key-distribution step or a shared secret between the server and the client.
+The public key travels inside the JWT and the whole JWT is signed with the matching private key, so the server doesn't need a separate key-distribution step or a shared secret with the client.
 
 ## Server verification
 

--- a/docs/content/docs/reference/local-first-auth-internals.mdx
+++ b/docs/content/docs/reference/local-first-auth-internals.mdx
@@ -1,0 +1,101 @@
+---
+title: Local-first auth internals
+description: "How local-first auth derives a stable account from a secret, how the self-signed JWT is structured, and how the server verifies it without an external key store."
+reviewedAt: "c5f0807b6"
+---
+
+This page explains how [local-first auth](/docs/auth/local-first-auth) works under the hood. You do
+not need any of this to use it. Read this if you are debugging, building a custom client, or
+reasoning about what the design actually guarantees.
+
+## The core idea
+
+An account, in local-first auth, is a secret: a single 32-byte seed.
+
+There is no registry mapping "user X → public key Y" sitting on a server somewhere. The seed
+deterministically produces a keypair, and the user ID is a deterministic function of the resulting
+public key, so holding the secret is the same thing as being the account: it lets you regenerate
+the keypair on demand and self-certify as that identity. Signing in is reconstructing the keypair
+from the stored secret; signing up is generating a new one.
+
+This is why the design doesn't need a server-side user registry. The public key embedded in a
+token, paired with its signature, is everything the server needs to confirm the claimed account. Verification reuses the JWT-checking path the server already runs for
+external-auth tokens; only the source of the signing key differs (embedded in the token for
+local-first, fetched from a JWKS endpoint for external auth).
+
+## Identity derivation
+
+The account is built from a single 32-byte secret the client stores locally.
+
+1. The 32-byte **seed** is hashed with SHA-512 to produce an Ed25519 **signing key**.
+2. The corresponding **public key** (32 bytes) is extracted from the signing key.
+3. A deterministic **user ID** is derived from the public key using UUIDv5 with the namespace
+   `jazz-auth-key-v1`.
+
+Every step is deterministic, so the same seed always produces the same user ID, on any device, at
+any time. Backing up the seed is backing up the identity.
+
+## The self-signed JWT
+
+When the client talks to a server, it mints a JWT and signs it with the Ed25519 key derived above.
+The key claims are:
+
+| Claim          | Value                    | Purpose                                              |
+| -------------- | ------------------------ | ---------------------------------------------------- |
+| `alg`          | `"EdDSA"`                | Ed25519 signature algorithm                          |
+| `iss`          | `"urn:jazz:local-first"` | Marks the token as local-first (not provider-issued) |
+| `sub`          | User ID (UUIDv5)         | The claimed account ID                               |
+| `jazz_pub_key` | Public key (base64url)   | Embedded so the server can verify without a lookup   |
+| `aud`          | App ID                   | Scopes the token to a specific app                   |
+
+Because the public key is embedded in the JWT itself, and signed using the private key, there is no need for a separate key-distribution step or a shared secret between the server and the client.
+
+## Server verification
+
+When the server receives a local-first JWT (as identified by the `iss` field), it:
+
+1. Reads `jazz_pub_key` from the token
+2. Uses it to verify the signature
+3. Recomputes the UUIDv5 from that public key (same namespace, same algorithm)
+4. Confirms the recomputed ID matches `sub`
+
+A token where `sub` and `jazz_pub_key` disagree is rejected outright, because either would require
+forging the other. A token where the signature does not verify is rejected because the holder did
+not prove possession of the private key.
+
+## Upgrading to a provider account
+
+When a local-first account upgrades to a real account via an external provider (BetterAuth,
+WorkOS, etc.), the user should keep the same Jazz account ID so their existing data carries over
+unchanged. This works because the account ID is a deterministic function of the keypair: if the
+client can prove (to the provider) that it holds the key behind account ID X, the provider can
+safely record X as the Jazz ID of the new user. Any JWT the provider issues afterwards uses X as
+its subject, and the user's existing data is already owned by X.
+
+The proof takes the form of a **proof token** — a short-lived JWT signed by the same key the
+client uses for self-signed auth. Structurally it is the same as a local-first JWT, but scoped to
+a specific sign-up flow:
+
+- `aud` is an application-defined string like `"my-app-signup"` (the client and server must agree).
+- `exp` is short — 60 seconds is usually enough for a sign-up round-trip.
+- `sub` and `jazz_pub_key` still pin the token to a specific account.
+
+The provider's endpoint verifies the proof token the same way any Jazz server verifies a
+local-first JWT, then records the proven Jazz user ID against the newly created provider account.
+
+<Mermaid chart={`
+sequenceDiagram
+    participant Client
+    participant Provider as Provider server
+
+    Note over Client: User starts with local-first auth
+    Client->>Client: db.getLocalFirstIdentityProof()
+    Client->>Provider: Sign up (email + proofToken)
+    Provider->>Provider: Verify proof, create user with same Jazz ID
+    Provider-->>Client: Session + JWT
+    Note over Client: Same Jazz ID, now with a provider account
+
+`} />
+
+See [Signing up with BetterAuth](/docs/auth/local-first-auth#signing-up-with-betterauth) for the
+practical, BetterAuth-specific flow.

--- a/docs/content/docs/reference/meta.json
+++ b/docs/content/docs/reference/meta.json
@@ -7,6 +7,7 @@
     "framework-patterns",
     "inspector",
     "mcp",
-    "internals"
+    "internals",
+    "local-first-auth-internals"
   ]
 }

--- a/examples/docs/todo-client-localfirst-react/src/auth-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/auth-snippets.tsx
@@ -6,11 +6,6 @@ function TodoApp() {
   return null;
 }
 
-const passkeyBackup = new BrowserPasskeyBackup({
-  appName: "My App",
-  appHostname: "myapp.com",
-});
-
 // #region auth-localfirst-react
 export function LocalFirstAuthApp() {
   const { secret, isLoading } = useLocalFirstAuth();
@@ -72,6 +67,13 @@ export function useRecoveryPhraseRestore(): (userInput: string) => Promise<void>
 // #endregion auth-localfirst-react-restore
 
 // #region auth-localfirst-react-passkey-backup
+const passkeyBackup = new BrowserPasskeyBackup({
+  appName: "My App",
+  // Pin to your canonical production hostname. If omitted, defaults to `location.hostname`,
+  // which scopes passkeys per preview-deploy URL.
+  appHostname: "myapp.com",
+});
+
 export function usePasskeyBackup(): {
   isLoading: boolean;
   backupWithPasskey: (displayName: string) => Promise<void>;

--- a/examples/docs/todo-client-localfirst-svelte/src/AuthLocalfirst.svelte
+++ b/examples/docs/todo-client-localfirst-svelte/src/AuthLocalfirst.svelte
@@ -1,0 +1,24 @@
+<!-- #region auth-localfirst-svelte -->
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { BrowserAuthSecretStore, createJazzClient, JazzSvelteProvider } from 'jazz-tools/svelte';
+
+  let client = $state<ReturnType<typeof createJazzClient> | null>(null);
+
+  onMount(async () => {
+    const secret = await BrowserAuthSecretStore.getOrCreateSecret();
+    client = createJazzClient({
+      appId: 'my-app',
+      secret,
+    });
+  });
+</script>
+
+{#if client}
+  <JazzSvelteProvider {client}>
+    {#snippet children({ db })}
+      <slot />
+    {/snippet}
+  </JazzSvelteProvider>
+{/if}
+<!-- #endregion auth-localfirst-svelte -->

--- a/examples/docs/todo-client-localfirst-svelte/src/auth-snippets.svelte.ts
+++ b/examples/docs/todo-client-localfirst-svelte/src/auth-snippets.svelte.ts
@@ -1,0 +1,58 @@
+import { onMount } from "svelte";
+import { BrowserAuthSecretStore } from "jazz-tools/svelte";
+import { RecoveryPhrase } from "jazz-tools/passphrase";
+import { BrowserPasskeyBackup } from "jazz-tools/passkey-backup";
+
+// #region auth-localfirst-svelte-backup
+export function createRecoveryPhraseBackup() {
+  let isLoading = $state(true);
+  let recoveryPhrase = $state<string | null>(null);
+
+  onMount(async () => {
+    const secret = await BrowserAuthSecretStore.loadSecret();
+    recoveryPhrase = secret ? RecoveryPhrase.fromSecret(secret) : null;
+    isLoading = false;
+  });
+
+  return {
+    get isLoading() {
+      return isLoading;
+    },
+    get recoveryPhrase() {
+      return recoveryPhrase;
+    },
+  };
+}
+// #endregion auth-localfirst-svelte-backup
+
+// #region auth-localfirst-svelte-restore
+export async function restoreFromRecoveryPhrase(userInput: string) {
+  const restoredSecret = RecoveryPhrase.toSecret(userInput);
+  await BrowserAuthSecretStore.saveSecret(restoredSecret);
+  // Reload so the mounted JazzSvelteProvider picks up the restored secret.
+  location.reload();
+}
+// #endregion auth-localfirst-svelte-restore
+
+// #region auth-localfirst-svelte-passkey-backup
+const passkeyBackup = new BrowserPasskeyBackup({
+  appName: "My App",
+  // Pin to your canonical production hostname. If omitted, defaults to `location.hostname`,
+  // which scopes passkeys per preview-deploy URL.
+  appHostname: "myapp.com",
+});
+
+export async function backupToPasskey(displayName: string) {
+  const secret = await BrowserAuthSecretStore.loadSecret();
+  if (!secret) throw new Error("No local secret to back up yet");
+  await passkeyBackup.backup(secret, displayName);
+}
+// #endregion auth-localfirst-svelte-passkey-backup
+
+// #region auth-localfirst-svelte-passkey-restore
+export async function restoreFromPasskey() {
+  const restoredSecret = await passkeyBackup.restore();
+  await BrowserAuthSecretStore.saveSecret(restoredSecret);
+  location.reload();
+}
+// #endregion auth-localfirst-svelte-passkey-restore

--- a/examples/docs/todo-client-localfirst-ts/src/auth-snippets.ts
+++ b/examples/docs/todo-client-localfirst-ts/src/auth-snippets.ts
@@ -1,4 +1,6 @@
 import { createDb, BrowserAuthSecretStore } from "jazz-tools";
+import { RecoveryPhrase } from "jazz-tools/passphrase";
+import { BrowserPasskeyBackup } from "jazz-tools/passkey-backup";
 
 // #region auth-localfirst-ts
 export async function createLocalFirstDb() {
@@ -6,8 +8,6 @@ export async function createLocalFirstDb() {
 
   return createDb({
     appId: "my-app",
-    env: "dev",
-    userBranch: "main",
     secret,
   });
 }
@@ -22,3 +22,42 @@ export async function createJwtDb() {
   });
 }
 // #endregion auth-jwt-ts
+
+// #region auth-localfirst-ts-backup
+export async function getRecoveryPhrase(): Promise<string | null> {
+  const secret = await BrowserAuthSecretStore.loadSecret();
+  return secret ? RecoveryPhrase.fromSecret(secret) : null;
+}
+// #endregion auth-localfirst-ts-backup
+
+// #region auth-localfirst-ts-restore
+export async function restoreFromRecoveryPhrase(userInput: string): Promise<void> {
+  const restoredSecret = RecoveryPhrase.toSecret(userInput);
+  await BrowserAuthSecretStore.saveSecret(restoredSecret);
+  // Reload so the live Jazz client picks up the restored secret.
+  location.reload();
+}
+// #endregion auth-localfirst-ts-restore
+
+// #region auth-localfirst-ts-passkey-backup
+const passkeyBackup = new BrowserPasskeyBackup({
+  appName: "My App",
+  // Pin to your canonical production hostname. If omitted, defaults to `location.hostname`,
+  // which scopes passkeys per preview-deploy URL.
+  appHostname: "myapp.com",
+});
+
+export async function backupToPasskey(displayName: string): Promise<void> {
+  const secret = await BrowserAuthSecretStore.loadSecret();
+  if (!secret) throw new Error("No local secret to back up yet");
+  await passkeyBackup.backup(secret, displayName);
+}
+// #endregion auth-localfirst-ts-passkey-backup
+
+// #region auth-localfirst-ts-passkey-restore
+export async function restoreFromPasskey(): Promise<void> {
+  const restoredSecret = await passkeyBackup.restore();
+  await BrowserAuthSecretStore.saveSecret(restoredSecret);
+  location.reload();
+}
+// #endregion auth-localfirst-ts-passkey-restore

--- a/examples/docs/todo-client-localfirst-vue/src/AuthLocalfirst.vue
+++ b/examples/docs/todo-client-localfirst-vue/src/AuthLocalfirst.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+import { createJazzClient, JazzProvider } from "jazz-tools/vue";
+import { BrowserAuthSecretStore } from "jazz-tools";
+
+const client = ref<ReturnType<typeof createJazzClient> | null>(null);
+
+onMounted(async () => {
+  const secret = await BrowserAuthSecretStore.getOrCreateSecret();
+  client.value = createJazzClient({
+    appId: "my-app",
+    secret,
+  });
+});
+</script>
+
+<template>
+  <JazzProvider v-if="client" :client="client">
+    <slot />
+  </JazzProvider>
+</template>

--- a/examples/docs/todo-client-localfirst-vue/src/auth-snippets.ts
+++ b/examples/docs/todo-client-localfirst-vue/src/auth-snippets.ts
@@ -1,0 +1,57 @@
+import { ref, onMounted } from "vue";
+import { BrowserAuthSecretStore } from "jazz-tools";
+import { RecoveryPhrase } from "jazz-tools/passphrase";
+import { BrowserPasskeyBackup } from "jazz-tools/passkey-backup";
+
+// #region auth-localfirst-vue-backup
+export function useRecoveryPhraseBackup() {
+  const isLoading = ref(true);
+  const recoveryPhrase = ref<string | null>(null);
+
+  onMounted(async () => {
+    const secret = await BrowserAuthSecretStore.loadSecret();
+    recoveryPhrase.value = secret ? RecoveryPhrase.fromSecret(secret) : null;
+    isLoading.value = false;
+  });
+
+  return { isLoading, recoveryPhrase };
+}
+// #endregion auth-localfirst-vue-backup
+
+// #region auth-localfirst-vue-restore
+export function useRecoveryPhraseRestore() {
+  return async (userInput: string) => {
+    const restoredSecret = RecoveryPhrase.toSecret(userInput);
+    await BrowserAuthSecretStore.saveSecret(restoredSecret);
+    // Reload so the mounted JazzProvider picks up the restored secret.
+    location.reload();
+  };
+}
+// #endregion auth-localfirst-vue-restore
+
+// #region auth-localfirst-vue-passkey-backup
+const passkeyBackup = new BrowserPasskeyBackup({
+  appName: "My App",
+  // Pin to your canonical production hostname. If omitted, defaults to `location.hostname`,
+  // which scopes passkeys per preview-deploy URL.
+  appHostname: "myapp.com",
+});
+
+export function usePasskeyBackup() {
+  return async (displayName: string) => {
+    const secret = await BrowserAuthSecretStore.loadSecret();
+    if (!secret) throw new Error("No local secret to back up yet");
+    await passkeyBackup.backup(secret, displayName);
+  };
+}
+// #endregion auth-localfirst-vue-passkey-backup
+
+// #region auth-localfirst-vue-passkey-restore
+export function usePasskeyRestore() {
+  return async () => {
+    const restoredSecret = await passkeyBackup.restore();
+    await BrowserAuthSecretStore.saveSecret(restoredSecret);
+    location.reload();
+  };
+}
+// #endregion auth-localfirst-vue-passkey-restore


### PR DESCRIPTION
## Summary
- Restructure the local-first auth page around mental model (the secret is the account) and decision points, with framework tabs (React/Vue/Svelte/TypeScript) replacing the React/Expo-only snippets for client setup, passphrase backup/restore, and passkey backup/restore
- Move the theory (Ed25519 derivation, JWT structure, server verification, provider-upgrade proof flow) to a new `reference/local-first-auth-internals.mdx`
- Add parallel Vue/Svelte/TypeScript example snippets covering the full backup/restore surface, including the `BrowserPasskeyBackup` constructor so the `appHostname` gotcha is self-explanatory
- Set `metadataBase` on the docs root layout from env (`NEXT_PUBLIC_SITE_URL` → `VERCEL_PROJECT_PRODUCTION_URL` → localhost) so OG URLs resolve on previews without hardcoding the production hostname

## Test plan
- [ ] `cd docs && pnpm dev` and verify the Client setup, Passphrase, and Passkey tabs switch cleanly between React/Vue/Svelte/TypeScript with all four include blocks rendering
- [ ] Open `/docs/reference/local-first-auth-internals` and confirm it renders (a dev-server restart may be needed to regenerate `.source`)
- [ ] Click the `#upgrading-to-a-provider-account` cross-link from the main page and confirm it lands on the right section
- [ ] `pnpm build --filter=todo-client-localfirst-{react,vue,svelte,ts}-docs` — all four succeed