### PR TITLE
fix: drop config reference from JazzProvider useEffect deps

### DIFF
--- a/.changeset/fix-provider-config-dep-stability.md
+++ b/.changeset/fix-provider-config-dep-stability.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix JazzProvider re-initialising when an inline config object is passed on every render. The useEffect dep array previously included `config` (the object reference); it now uses `configKey` (the JSON-stringified value) so that structurally identical config objects no longer trigger a cleanup→reacquire cycle.

--- a/packages/jazz-tools/src/react-core/provider.stable-deps.test.tsx
+++ b/packages/jazz-tools/src/react-core/provider.stable-deps.test.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, act } from "@testing-library/react";
+import { JazzProvider } from "./provider.js";
+import { makeFakeClient } from "./test-utils.js";
+import type { DbConfig } from "../runtime/db.js";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  // Flush any pending release timers so the module-level cache is clean.
+  vi.runAllTimers();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("JazzProvider — stable config deps", () => {
+  /**
+   * Regression: passing a fresh config object with the same JSON shape must not
+   * trigger a cleanup→reacquire cycle. The useEffect must only re-fire when the
+   * configKey (JSON.stringify of config) or createJazzClient changes.
+   *
+   * Before the fix, `config` was in the dep array. A new reference caused:
+   *   cleanup → releaseClient (schedules setTimeout(0) to shut down the client)
+   *   re-run  → acquireClient (clears the timer — but only if it runs in time)
+   * Under production timing the timer could fire before the re-run, tearing the
+   * client down and surfacing as 'Worker load error: undefined'.
+   *
+   * We detect the cleanup firing by spying on setTimeout: releaseClient calls
+   * setTimeout(0) to schedule the deferred shutdown. If the effect re-runs
+   * unnecessarily, at least one setTimeout call will occur.
+   */
+  it("does not trigger a release timer when config object is replaced by a structurally identical one", async () => {
+    const alice = makeFakeClient({ authMode: "local-first", userId: "alice", claims: {} });
+    const createJazzClient = vi.fn().mockResolvedValue(alice);
+
+    // Track setTimeout calls made after initial mount so we can detect spurious
+    // release timers scheduled by an unnecessary cleanup.
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    function Wrapper({ config }: { config: DbConfig }) {
+      return (
+        <JazzProvider config={config} createJazzClient={createJazzClient} fallback={null}>
+          <div data-testid="child" />
+        </JazzProvider>
+      );
+    }
+
+    const initialConfig: DbConfig = { appId: "app-1", serverUrl: "https://jazz.example.com" };
+
+    let rerender!: (ui: React.ReactElement) => void;
+
+    await act(async () => {
+      const result = render(<Wrapper config={initialConfig} />);
+      rerender = result.rerender;
+      await Promise.resolve();
+    });
+
+    expect(createJazzClient).toHaveBeenCalledTimes(1);
+
+    // Reset the spy so we only observe calls that happen during the re-render.
+    setTimeoutSpy.mockClear();
+
+    // Re-render with a freshly constructed config object: same shape, new reference.
+    const freshConfig: DbConfig = { appId: "app-1", serverUrl: "https://jazz.example.com" };
+    expect(freshConfig).not.toBe(initialConfig); // guard: references differ
+
+    await act(async () => {
+      rerender(<Wrapper config={freshConfig} />);
+      await Promise.resolve();
+    });
+
+    // If config was in the dep array, releaseClient would have called setTimeout(0).
+    // After the fix (config removed from deps), no setTimeout call should occur.
+    expect(setTimeoutSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/jazz-tools/src/react-core/provider.tsx
+++ b/packages/jazz-tools/src/react-core/provider.tsx
@@ -215,13 +215,13 @@ export function JazzProvider({
   // initializer and useEffect don't double-count the same provider.
   const holder = useRef({}).current;
 
+  const configKey = JSON.stringify(config);
+
   const [clientPromise, setClientPromise] = useState(() => {
-    const configKey = JSON.stringify(config);
     return acquireClient<CoreJazzClient>(configKey, config, createJazzClient, holder);
   });
 
   useEffect(() => {
-    const configKey = JSON.stringify(config);
     const clientPromise = acquireClient<CoreJazzClient>(
       configKey,
       config,
@@ -234,7 +234,7 @@ export function JazzProvider({
     return () => {
       releaseClient(configKey, holder);
     };
-  }, [config, createJazzClient, holder]);
+  }, [configKey, createJazzClient, holder]);
 
   return (
     <React.Suspense fallback={fallback}>


### PR DESCRIPTION
## Summary

- `JazzProvider`'s `useEffect` dep array previously included `config` (the object reference), causing a cleanup→reacquire cycle whenever a consumer passed a freshly constructed config object on each render.
- `acquireClient` already caches by `configKey` (`JSON.stringify(config)`), so the object reference was a redundant — and harmful — dependency.
- Fix: hoist `configKey` to the component body and use `[configKey, createJazzClient, holder]` as the dep array instead of `[config, createJazzClient, holder]`.
- Under unlucky timing the deferred release `setTimeout(0)` could fire before the reacquire effect ran, tearing down the cached client and surfacing as "Worker load error: undefined".
- Consumers can now pass inline config objects without memoising them.

The `useState` workaround in `starters/next-betterauth/components/jazz-provider.tsx` (holding config in state so the reference stays stable) was reviewed. It is not a pure reference-stability workaround — it also handles async token fetching and conditional rendering based on session state — so it has been left in place.

## Test plan

- [ ] New regression test in `packages/jazz-tools/src/react-core/provider.stable-deps.test.tsx`: mounts `JazzProvider`, re-renders with a structurally identical config object with a new reference, asserts that no `setTimeout` call (release timer) is scheduled.
- [ ] Test was confirmed red before the fix, green after.
- [ ] Full `vitest.config.react.ts` suite (4 files, 11 tests) passes with no regressions.