### PR TITLE
fix(chat-react): await membership confirmation before enabling composer

### DIFF
--- a/.changeset/chat-react-auto-join-race.md
+++ b/.changeset/chat-react-auto-join-race.md
@@ -1,0 +1,8 @@
+---
+"chat-react": patch
+---
+
+Fix race condition where the message composer could enable before the auto-join
+chatMembers insert was acknowledged by the server, allowing a message send to
+fail with a permissions error. The composer now stays disabled until the
+membership insert has been confirmed at edge durability.

--- a/examples/chat-react/e2e/global-setup.ts
+++ b/examples/chat-react/e2e/global-setup.ts
@@ -1,0 +1,30 @@
+import { join } from "node:path";
+import type { FullConfig } from "@playwright/test";
+import { startLocalJazzServer, pushSchemaCatalogue } from "jazz-tools/testing";
+
+const APP_ID = "00000000-0000-0000-0000-000000000101";
+const ADMIN_SECRET = "chat-react-e2e-admin-secret";
+const SERVER_PORT = 5184;
+
+async function globalSetup(_config: FullConfig): Promise<() => Promise<void>> {
+  const server = await startLocalJazzServer({
+    appId: APP_ID,
+    port: SERVER_PORT,
+    adminSecret: ADMIN_SECRET,
+    allowLocalFirstAuth: true,
+    inMemory: true,
+  });
+
+  await pushSchemaCatalogue({
+    serverUrl: server.url,
+    appId: APP_ID,
+    adminSecret: ADMIN_SECRET,
+    schemaDir: join(import.meta.dirname ?? __dirname, ".."),
+  });
+
+  return async () => {
+    await server.stop();
+  };
+}
+
+export default globalSetup;

--- a/examples/chat-react/e2e/helpers.ts
+++ b/examples/chat-react/e2e/helpers.ts
@@ -1,0 +1,73 @@
+import { expect, type Browser, type BrowserContext, type Page } from "@playwright/test";
+
+const APP_URL = "http://127.0.0.1:5183";
+
+export interface UserContext {
+  page: Page;
+  context: BrowserContext;
+}
+
+/**
+ * Spin up a fresh browser context (isolated localStorage) for a named user and
+ * navigate to the app.  The app auto-generates a local-first secret on first
+ * load, so each context gets a distinct identity.
+ */
+export async function newUserContext(browser: Browser, _name: string): Promise<UserContext> {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await page.goto(APP_URL);
+  return { page, context };
+}
+
+/**
+ * Wait until the app has finished creating the initial chat and has navigated
+ * to it, then return the chat ID from the URL hash.
+ */
+export async function createChatAndGetId(page: Page): Promise<string> {
+  // The app redirects from / to /#/chat/:id after creating the initial chat.
+  await page.waitForURL(/\/#\/chat\//, { timeout: 30_000 });
+  await waitForComposer(page);
+  const hash = new URL(page.url()).hash; // e.g. "#/chat/abc123"
+  const match = hash.match(/\/chat\/([^/]+)/);
+  if (!match) throw new Error(`Could not extract chatId from URL: ${page.url()}`);
+  return match[1];
+}
+
+/**
+ * Wait for the message composer to be ready (not disabled).
+ */
+export async function waitForComposer(page: Page, timeout = 20_000): Promise<void> {
+  // The send button is disabled when composerReady is false.
+  const sendBtn = page
+    .locator("button[data-slot='button']")
+    .filter({ has: page.locator("svg") })
+    .last();
+  // More reliable: wait for the ProseMirror editor to be editable.
+  const editor = page.locator("#messageEditor .ProseMirror");
+  await expect(editor).not.toHaveAttribute("contenteditable", "false", { timeout });
+}
+
+/**
+ * Send a message via the composer.  Waits for the composer to be ready first.
+ */
+export async function sendMessage(page: Page, text: string): Promise<void> {
+  await waitForComposer(page);
+
+  // Use the __editorHandle exposed on the editor container to insert text
+  // without relying on keyboard events (avoids contenteditable quirks).
+  await page.evaluate((msg) => {
+    const el = document.getElementById("messageEditor") as
+      | (HTMLElement & { __editorHandle?: { insertText: (t: string) => void; send: () => void } })
+      | null;
+    if (!el?.__editorHandle) throw new Error("Editor handle not found");
+    el.__editorHandle.insertText(msg);
+    el.__editorHandle.send();
+  }, text);
+}
+
+/**
+ * Wait for a message with the given text to appear in the chat view.
+ */
+export async function waitForMessage(page: Page, text: string, timeout = 20_000): Promise<void> {
+  await expect(page.locator("article").filter({ hasText: text })).toBeVisible({ timeout });
+}

--- a/examples/chat-react/e2e/invite-auto-join.spec.ts
+++ b/examples/chat-react/e2e/invite-auto-join.spec.ts
@@ -11,9 +11,11 @@
  * Fix: gate the composer on membershipReady (true only after chatMembers insert
  * is acknowledged at edge-tier), not just userId + myProfile.
  *
- * Test contract: when Bob lands on a chat he is not yet a member of, the
- * composer MUST be disabled until auto-join completes server-side.  Sending
- * immediately after the composer first enables must always deliver the message.
+ * Test contract:
+ *   A. The composer MUST transition through a disabled state before enabling
+ *      (i.e. it must not start enabled immediately).
+ *   B. Sending a message the moment the composer first enables must always
+ *      deliver the message to other participants (no permission error).
  */
 import { expect, test, type Page } from "@playwright/test";
 import { newUserContext, createChatAndGetId, waitForComposer, waitForMessage } from "./helpers";
@@ -29,46 +31,80 @@ test.describe("auto-join race on first message send", () => {
     const { page: alice } = await newUserContext(browser, "alice");
     const chatId = await createChatAndGetId(alice);
 
-    // ── Bob: open the chat directly (he is not yet a member) ─────────────────
-    const { page: bob } = await newUserContext(browser, "bob");
+    // ── Bob: open the chat directly via a fresh browser context ─────────────
+    // We do NOT use newUserContext here (which navigates to the root first),
+    // because navigating to the chat hash URL from the root is a client-side
+    // hash change that won't trigger a page reload — meaning addInitScript
+    // wouldn't re-run.  Instead we navigate directly to the final URL so that
+    // the very first page load includes the observer script.
+    const bobContext = await browser.newContext();
+    const bob = await bobContext.newPage();
 
     const consoleErrors: string[] = [];
     bob.on("console", (msg) => {
       if (msg.type() === "error") consoleErrors.push(msg.text());
     });
 
+    // Install the observer before the first (and only) navigation.
+    await bob.addInitScript(() => {
+      (window as typeof window & { __editorHistory: string[] }).__editorHistory = [];
+
+      // Poll until the ProseMirror editor appears, then record its state.
+      const poll = setInterval(() => {
+        const pm = document.querySelector("#messageEditor .ProseMirror");
+        if (!pm) return;
+        clearInterval(poll);
+
+        const initial = pm.getAttribute("contenteditable") ?? "missing";
+        (window as typeof window & { __editorHistory: string[] }).__editorHistory.push(
+          `initial:${initial}`,
+        );
+
+        new MutationObserver((mutations) => {
+          for (const m of mutations) {
+            if (m.attributeName === "contenteditable") {
+              const val = (m.target as Element).getAttribute("contenteditable") ?? "missing";
+              (window as typeof window & { __editorHistory: string[] }).__editorHistory.push(
+                `change:${val}`,
+              );
+            }
+          }
+        }).observe(pm, { attributes: true });
+      }, 5);
+    });
+
     await bob.goto(`http://127.0.0.1:5183/#/chat/${chatId}`);
 
-    // ── Assert 1: composer must be initially disabled ─────────────────────────
+    // ── Assert A: composer must transition through disabled before enabling ───
     //
-    // With the buggy code composerReady = !!userId && !!myProfile — both are
-    // available almost immediately from local state — so the composer is enabled
-    // before the chatMembers insert reaches the server.  The fix adds a
-    // membershipReady gate, so the composer starts disabled.
+    // With the fix, the editor starts as contenteditable="false" and transitions
+    // to "true" after the chatMembers insert is server-acknowledged.
     //
-    // We check within a short window (500 ms) immediately after navigation.
-    // If the composer is already enabled at this point, the test fails: the UI
-    // is allowing sends before membership is confirmed.
-    const composerEnabledImmediately = await isComposerEnabled(bob);
-    expect(
-      composerEnabledImmediately,
-      "composer must not be enabled immediately on landing — it should wait for membership confirmation",
-    ).toBe(false);
-
-    // ── Assert 2: composer eventually becomes enabled ─────────────────────────
+    // With the buggy code, composerReady = !!userId && !!myProfile skips the
+    // membership gate, so the editor starts as contenteditable="true" directly.
     //
-    // After the chatMembers insert is acknowledged at the server, membership is
-    // confirmed and the composer should unlock.
+    // We wait until the editor is enabled, then inspect the recorded history.
     await waitForComposer(bob, 20_000);
 
-    // ── Assert 3: sending the first message succeeds ──────────────────────────
-    //
-    // Now that the composer is enabled (membership confirmed), a send must
-    // succeed.  Bob's message must appear in Alice's tab.
+    const editorHistory = await bob.evaluate(
+      () => (window as typeof window & { __editorHistory: string[] }).__editorHistory ?? [],
+    );
+
+    // The history must include an initial or change event showing "false",
+    // meaning the editor was disabled before it became enabled.
+    const wasEverDisabled = editorHistory.some(
+      (entry) => entry === "initial:false" || entry === "change:false",
+    );
+    expect(
+      wasEverDisabled,
+      `composer must have been disabled before enabling — history: ${JSON.stringify(editorHistory)}`,
+    ).toBe(true);
+
+    // ── Assert B: message sent the moment composer enables is delivered ───────
     await sendImmediately(bob, bobMessage);
     await waitForMessage(alice, bobMessage, 20_000);
 
-    // ── Assert 4: no permission errors ───────────────────────────────────────
+    // ── Assert C: no permission errors ───────────────────────────────────────
     await bob.waitForTimeout(1_000);
     const permissionErrors = consoleErrors.filter(
       (e) =>
@@ -79,23 +115,6 @@ test.describe("auto-join race on first message send", () => {
     expect(permissionErrors, "expected no permission errors on Bob's page").toHaveLength(0);
   });
 });
-
-/**
- * Returns true if the ProseMirror editor is currently editable (not disabled).
- *
- * Waits for the editor element to mount first, then reads its initial
- * contenteditable state.  This avoids a false-negative when the editor hasn't
- * rendered yet.
- */
-async function isComposerEnabled(page: Page): Promise<boolean> {
-  const editorLocator = page.locator("#messageEditor .ProseMirror");
-  // Wait for the element to be in the DOM before reading its attribute.
-  await editorLocator.waitFor({ state: "attached", timeout: 10_000 }).catch(() => {});
-  const attr = await editorLocator
-    .getAttribute("contenteditable", { timeout: 1_000 })
-    .catch(() => null);
-  return attr === "true";
-}
 
 /**
  * Send a message without waiting for any network idle — as fast as possible.

--- a/examples/chat-react/e2e/invite-auto-join.spec.ts
+++ b/examples/chat-react/e2e/invite-auto-join.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * Regression test for the auto-join race condition.
+ *
+ * ChatView performs a fire-and-forget db.insert(chatMembers) when a user lands
+ * on a chat they can see but are not yet a member of.  The MessageComposer
+ * enables as soon as userId + myProfile are available — independently of
+ * membership — so the user can send a message before the server has
+ * acknowledged the chatMembers insert.  The server then rejects the message
+ * insert with a permissions error because the sender is not yet a member.
+ *
+ * Fix: gate the composer on membershipReady (true only after chatMembers insert
+ * is acknowledged at edge-tier), not just userId + myProfile.
+ *
+ * Test contract: when Bob lands on a chat he is not yet a member of, the
+ * composer MUST be disabled until auto-join completes server-side.  Sending
+ * immediately after the composer first enables must always deliver the message.
+ */
+import { expect, test, type Page } from "@playwright/test";
+import { newUserContext, createChatAndGetId, waitForComposer, waitForMessage } from "./helpers";
+
+test.describe("auto-join race on first message send", () => {
+  test("composer is disabled until membership is confirmed, then message delivers", async ({
+    browser,
+  }) => {
+    const runId = Date.now();
+    const bobMessage = `first-send-${runId}`;
+
+    // ── Alice: create a public chat ───────────────────────────────────────────
+    const { page: alice } = await newUserContext(browser, "alice");
+    const chatId = await createChatAndGetId(alice);
+
+    // ── Bob: open the chat directly (he is not yet a member) ─────────────────
+    const { page: bob } = await newUserContext(browser, "bob");
+
+    const consoleErrors: string[] = [];
+    bob.on("console", (msg) => {
+      if (msg.type() === "error") consoleErrors.push(msg.text());
+    });
+
+    await bob.goto(`http://127.0.0.1:5183/#/chat/${chatId}`);
+
+    // ── Assert 1: composer must be initially disabled ─────────────────────────
+    //
+    // With the buggy code composerReady = !!userId && !!myProfile — both are
+    // available almost immediately from local state — so the composer is enabled
+    // before the chatMembers insert reaches the server.  The fix adds a
+    // membershipReady gate, so the composer starts disabled.
+    //
+    // We check within a short window (500 ms) immediately after navigation.
+    // If the composer is already enabled at this point, the test fails: the UI
+    // is allowing sends before membership is confirmed.
+    const composerEnabledImmediately = await isComposerEnabled(bob);
+    expect(
+      composerEnabledImmediately,
+      "composer must not be enabled immediately on landing — it should wait for membership confirmation",
+    ).toBe(false);
+
+    // ── Assert 2: composer eventually becomes enabled ─────────────────────────
+    //
+    // After the chatMembers insert is acknowledged at the server, membership is
+    // confirmed and the composer should unlock.
+    await waitForComposer(bob, 20_000);
+
+    // ── Assert 3: sending the first message succeeds ──────────────────────────
+    //
+    // Now that the composer is enabled (membership confirmed), a send must
+    // succeed.  Bob's message must appear in Alice's tab.
+    await sendImmediately(bob, bobMessage);
+    await waitForMessage(alice, bobMessage, 20_000);
+
+    // ── Assert 4: no permission errors ───────────────────────────────────────
+    await bob.waitForTimeout(1_000);
+    const permissionErrors = consoleErrors.filter(
+      (e) =>
+        e.toLowerCase().includes("policy denied") ||
+        e.toLowerCase().includes("writeerror") ||
+        e.toLowerCase().includes("permission"),
+    );
+    expect(permissionErrors, "expected no permission errors on Bob's page").toHaveLength(0);
+  });
+});
+
+/**
+ * Returns true if the ProseMirror editor is currently editable (not disabled).
+ *
+ * Waits for the editor element to mount first, then reads its initial
+ * contenteditable state.  This avoids a false-negative when the editor hasn't
+ * rendered yet.
+ */
+async function isComposerEnabled(page: Page): Promise<boolean> {
+  const editorLocator = page.locator("#messageEditor .ProseMirror");
+  // Wait for the element to be in the DOM before reading its attribute.
+  await editorLocator.waitFor({ state: "attached", timeout: 10_000 }).catch(() => {});
+  const attr = await editorLocator
+    .getAttribute("contenteditable", { timeout: 1_000 })
+    .catch(() => null);
+  return attr === "true";
+}
+
+/**
+ * Send a message without waiting for any network idle — as fast as possible.
+ * Uses the __editorHandle exposed on the editor container.
+ */
+async function sendImmediately(page: Page, text: string): Promise<void> {
+  await page.evaluate((msg) => {
+    const el = document.getElementById("messageEditor") as
+      | (HTMLElement & {
+          __editorHandle?: { insertText: (t: string) => void; send: () => void };
+        })
+      | null;
+    if (!el?.__editorHandle) throw new Error("Editor handle not found on #messageEditor");
+    el.__editorHandle.insertText(msg);
+    el.__editorHandle.send();
+  }, text);
+}

--- a/examples/chat-react/package.json
+++ b/examples/chat-react/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "test": "vitest run --config vitest.config.browser.ts",
     "walkthrough": "npx @marp-team/marp-cli --html --theme walkthrough/theme-jazz.css walkthrough/jazz-chat.md --preview",
-    "walkthrough:shots": "playwright test --config playwright.screenshots.config.ts"
+    "walkthrough:shots": "playwright test --config playwright.screenshots.config.ts",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@multiavatar/multiavatar": "^1.0.7",
@@ -45,6 +46,7 @@
   "devDependencies": {
     "@playwright/test": "^1.58.2",
     "@types/dompurify": "^3.2.0",
+    "@types/node": "^20.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "catalog:default",

--- a/examples/chat-react/playwright.config.ts
+++ b/examples/chat-react/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = 5183;
+
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: "**/*.spec.ts",
+  timeout: 90_000,
+  fullyParallel: false,
+  workers: 1,
+  retries: process.env.CI ? 2 : 0,
+  globalSetup: "./e2e/global-setup.ts",
+  use: {
+    baseURL: `http://127.0.0.1:${PORT}`,
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: `pnpm dev --host 127.0.0.1 --port ${PORT}`,
+    url: `http://127.0.0.1:${PORT}`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+    env: {
+      VITE_JAZZ_APP_ID: "00000000-0000-0000-0000-000000000101",
+      VITE_JAZZ_SERVER_URL: "http://127.0.0.1:5184",
+    },
+  },
+});

--- a/examples/chat-react/src/components/chat-view/ChatView.tsx
+++ b/examples/chat-react/src/components/chat-view/ChatView.tsx
@@ -7,6 +7,7 @@ import { MessageComposer } from "@/components/composer/MessageComposer";
 import { Button } from "@/components/ui/button";
 import { useMyProfile } from "@/hooks/useMyProfile";
 import { app } from "../../../schema.js";
+import { type DurabilityTier } from "jazz-tools";
 
 const INITIAL_MESSAGES_TO_SHOW = 20;
 const LOAD_MORE_STEP = 20;
@@ -20,6 +21,9 @@ export const ChatView = ({ chatId }: ChatViewProps) => {
   const session = useSession();
   const userId = session?.user_id ?? null;
   const myProfile = useMyProfile();
+  const sharedWriteOptions: { tier: DurabilityTier } = {
+    tier: db.getConfig().serverUrl ? "edge" : "local",
+  };
 
   const [showNLastMessages, setShowNLastMessages] = useState(INITIAL_MESSAGES_TO_SHOW);
 
@@ -34,18 +38,51 @@ export const ChatView = ({ chatId }: ChatViewProps) => {
   const myMemberships =
     useAll(app.chatMembers.where({ chatId, userId: userId ?? "__none__" })) ?? [];
   const isMember = myMemberships.length > 0;
+  // autoJoinPending: true while we've started the insert but haven't yet
+  // received server acknowledgement.  Used to suppress the isMember shortcut
+  // so a local-only membership row can't unlock the composer prematurely.
+  const autoJoinPending = useRef(false);
   const autoJoined = useRef(false);
 
+  // membershipReady gates the composer: true when we know the server has
+  // acknowledged this user's membership.  Starts true if the user was already
+  // a member before this component mounted (e.g. returning to a chat they
+  // joined in a previous session); otherwise becomes true only after the
+  // auto-join insert is durably persisted at edge tier.
+  const [membershipReady, setMembershipReady] = useState(false);
+
   useEffect(() => {
+    // If the local store already shows membership AND we haven't just inserted
+    // it ourselves (i.e. this is a pre-existing membership), unlock the
+    // composer immediately — no insert needed.
+    if (isMember && !autoJoinPending.current) {
+      setMembershipReady(true);
+      return;
+    }
+
     if (!userId || !chatKnown || isMember || autoJoined.current) return;
     autoJoined.current = true;
-    db.insert(app.chatMembers, { chatId, userId });
-  }, [userId, chatKnown, isMember, chatId, db]);
+    autoJoinPending.current = true;
+
+    db.insert(app.chatMembers, { chatId, userId })
+      .wait(sharedWriteOptions)
+      .then(() => {
+        autoJoinPending.current = false;
+        setMembershipReady(true);
+      })
+      .catch((error) => {
+        console.error("auto-join failed", error);
+        autoJoined.current = false;
+        autoJoinPending.current = false;
+      });
+  }, [userId, chatKnown, isMember, chatId, db, sharedWriteOptions]);
 
   const [accessChecked, setAccessChecked] = useState(false);
   useEffect(() => {
     setAccessChecked(false);
     autoJoined.current = false;
+    autoJoinPending.current = false;
+    setMembershipReady(false);
     const timer = setTimeout(() => setAccessChecked(true), 1500);
     return () => clearTimeout(timer);
   }, [chatId]);
@@ -125,7 +162,7 @@ export const ChatView = ({ chatId }: ChatViewProps) => {
         )}
       </div>
 
-      <MessageComposer chatId={chatId} />
+      <MessageComposer chatId={chatId} disabled={!membershipReady} />
     </>
   );
 };

--- a/examples/chat-react/src/components/composer/MessageComposer.tsx
+++ b/examples/chat-react/src/components/composer/MessageComposer.tsx
@@ -11,9 +11,11 @@ import { DurabilityTier } from "jazz-tools";
 
 interface MessageComposerProps {
   chatId: string;
+  /** When true, the composer is locked regardless of internal readiness. */
+  disabled?: boolean;
 }
 
-export function MessageComposer({ chatId }: MessageComposerProps) {
+export function MessageComposer({ chatId, disabled = false }: MessageComposerProps) {
   const editorRef = useRef<EditorHandle>(null);
   const db = useDb();
   const session = useSession();
@@ -23,7 +25,7 @@ export function MessageComposer({ chatId }: MessageComposerProps) {
   };
 
   const myProfile = useMyProfile();
-  const composerReady = !!userId && !!myProfile;
+  const composerReady = !!userId && !!myProfile && !disabled;
 
   const handleSend = useCallback(
     (html: string) => {

--- a/examples/chat-react/tsconfig.json
+++ b/examples/chat-react/tsconfig.json
@@ -10,7 +10,8 @@
     "jsx": "react-jsx",
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "types": ["node"]
   },
-  "include": ["src", "schema"]
+  "include": ["src", "schema", "e2e", "playwright.config.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -401,7 +401,7 @@ importers:
         version: 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tailwindcss/vite':
         specifier: ^4.1.18
-        version: 4.2.2(vite@8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.2.2(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -466,6 +466,9 @@ importers:
       '@types/dompurify':
         specifier: ^3.2.0
         version: 3.2.0
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.35
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -474,13 +477,13 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: catalog:default
-        version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/browser':
         specifier: catalog:default
-        version: 4.1.0(vite@8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)
+        version: 4.1.0(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)
       '@vitest/browser-playwright':
         specifier: catalog:default
-        version: 4.1.0(playwright@1.58.2)(vite@8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)
+        version: 4.1.0(playwright@1.58.2)(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
@@ -492,16 +495,16 @@ importers:
         version: 6.0.2
       vite:
         specifier: catalog:default
-        version: 8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vite-plugin-top-level-await:
         specifier: catalog:default
-        version: 1.6.0(rollup@4.59.0)(vite@8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 1.6.0(rollup@4.59.0)(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vite-plugin-wasm:
         specifier: catalog:default
-        version: 3.6.0(vite@8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 3.6.0(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: catalog:default
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   examples/cloudflare-worker-runtime-ts:
     dependencies:
@@ -17325,12 +17328,12 @@ snapshots:
       postcss: 8.5.6
       tailwindcss: 4.2.1
 
-  '@tailwindcss/vite@4.2.2(vite@8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@tailwindcss/vite@4.2.2(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: 8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@tanstack/react-table@8.21.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -17861,6 +17864,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitejs/plugin-react@6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.7
+      vite: 8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+    optionalDependencies:
+      babel-plugin-react-compiler: 1.0.0
+
   '@vitejs/plugin-react@6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
@@ -17906,7 +17916,6 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
-    optional: true
 
   '@vitest/browser-playwright@4.1.0(playwright@1.58.2)(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)':
     dependencies:
@@ -17981,7 +17990,6 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
-    optional: true
 
   '@vitest/browser@4.1.0(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)':
     dependencies:
@@ -20787,7 +20795,7 @@ snapshots:
 
   happy-dom@20.8.4:
     dependencies:
-      '@types/node': 20.19.35
+      '@types/node': 25.6.0
       '@types/whatwg-mimetype': 3.0.2
       '@types/ws': 8.18.1
       entities: 7.0.1
@@ -25304,6 +25312,17 @@ snapshots:
       - '@swc/helpers'
       - rollup
 
+  vite-plugin-top-level-await@1.6.0(rollup@4.59.0)(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+    dependencies:
+      '@rollup/plugin-virtual': 3.0.2(rollup@4.59.0)
+      '@swc/core': 1.15.18
+      '@swc/wasm': 1.15.18
+      uuid: 10.0.0
+      vite: 8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@swc/helpers'
+      - rollup
+
   vite-plugin-top-level-await@1.6.0(rollup@4.59.0)(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@rollup/plugin-virtual': 3.0.2(rollup@4.59.0)
@@ -25340,6 +25359,10 @@ snapshots:
   vite-plugin-wasm@3.6.0(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       vite: 6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
+  vite-plugin-wasm@3.6.0(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+    dependencies:
+      vite: 8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   vite-plugin-wasm@3.6.0(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:


### PR DESCRIPTION
## Summary

- **Root cause:** `ChatView` auto-joined users with a fire-and-forget `db.insert(chatMembers, ...)` (no `.wait()`). The `MessageComposer` was gated only on `userId && myProfile`, so it enabled immediately — before the server confirmed membership. A fast send would fail with a policy-denied error because the server hadn't registered the membership yet.
- **Fix:** Added a `membershipReady` state that starts `false` and becomes `true` only after the `chatMembers` insert is acknowledged at edge-tier durability. The `disabled` prop is passed through to `MessageComposer`, which merges it into `composerReady`. Returning members (membership already in local store from a previous session) unlock immediately without a new insert.
- **Test:** New playwright e2e harness for chat-react. The regression test uses a `MutationObserver` injected via `addInitScript` to verify the editor transitions through `contenteditable="false"` before enabling, then asserts the first message is delivered without permission errors.

## Test plan

- [x] `pnpm exec playwright test` in `examples/chat-react` — 1 test, green
- [x] TypeScript: `pnpm exec tsc --noEmit` — clean
- [x] `pnpm format && pnpm oxlint --fix` — no errors
- [ ] Verify that reverting the `ChatView` auto-join change makes the test red (manual sanity check)