### PR TITLE
Fix .default schema hash

### DIFF
--- a/.changeset/cli-preserve-column-defaults.md
+++ b/.changeset/cli-preserve-column-defaults.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix CLI `loadCompiledSchema` dropping column `.default(...)` values, which caused `deploy` to publish a different schema hash than the runtime computed and broke permission checks with `Your declared schema <A> is disconnected from the schema used to enforce permissions: <B>`. The original `wasmSchema` from `defineApp` is now preserved instead of being round-tripped through a lossy AST.

--- a/TODO.md
+++ b/TODO.md
@@ -38,6 +38,7 @@
 
 - [**postmessage-stream-adapter-for-worker-bridge**](todo/issues/postmessage-stream-adapter-for-worker-bridge.md) — The browser main-thread ↔ worker bridge currently uses a bespoke `postMessage` path and the `JsSyncSender` Rust-side shim. A `PostMessageStream` adapter implementing `StreamAdapter` would let the worker bridge reuse the same `TransportManager` + run-loop code path as the network transport, eliminating the `sync_sender` field and `JsSyncSender` entirely.
 - [**text-encoded-storage-enums**](todo/issues/text-encoded-storage-enums.md) — Flat row storage currently encodes enum-like fields as text, which is larger than necessary and adds avoidable decode overhead on hot storage paths.
+- [**wasm-column-to-ast-lossy**](todo/issues/wasm-column-to-ast-lossy.md) — `wasmColumnToAst` in `packages/jazz-tools/src/schema-loader.ts` projects a `ColumnDescriptor` to an AST `Column` but only carries `name`, `sqlType`, `nullable`, and `references`. `default` and `mergeStrategy` are dropped on the floor.
 - [**ws-route-clones-every-inbound-frame**](todo/issues/ws-route-clones-every-inbound-frame.md) — `crates/jazz-tools/src/routes.rs:1345` does `let inner = inner.to_vec();` before handing the payload to `process_ws_client_frame(&inner)`. The borrow from `frame_decode(&data)` would survive the `.await` because `data` owns the bytes, so the clone is avoidable — pass `&[u8]` through directly.
 
 ## Ideas

--- a/packages/jazz-tools/src/schema-loader.test.ts
+++ b/packages/jazz-tools/src/schema-loader.test.ts
@@ -1,0 +1,21 @@
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { loadCompiledSchema } from "./schema-loader.js";
+
+const WITH_DEFAULTS_DIR = fileURLToPath(
+  new URL("./testing/fixtures/with-defaults", import.meta.url),
+);
+
+describe("loadCompiledSchema", () => {
+  it("preserves column defaults from defineApp (no lossy AST round-trip)", async () => {
+    const { app } = (await import("./testing/fixtures/with-defaults/schema.js")) as {
+      app: { wasmSchema: unknown };
+    };
+    const loaded = await loadCompiledSchema(WITH_DEFAULTS_DIR);
+
+    expect(JSON.stringify(loaded.wasmSchema)).toBe(JSON.stringify(app.wasmSchema));
+
+    const doneColumn = loaded.wasmSchema.todos?.columns.find((c) => c.name === "done");
+    expect(doneColumn?.default).toEqual({ type: "Boolean", value: false });
+  });
+});

--- a/packages/jazz-tools/src/schema-loader.ts
+++ b/packages/jazz-tools/src/schema-loader.ts
@@ -120,10 +120,15 @@ function isTypedAppLike(value: Record<string, unknown>): value is { wasmSchema: 
   return typeof schema === "object" && schema !== null && !Array.isArray(schema);
 }
 
-function schemaFromLoadedModule(loaded: Record<string, unknown>): Schema | null {
+interface LoadedSchemaResult {
+  schema: Schema;
+  wasmSchema?: WasmSchema;
+}
+
+function schemaFromLoadedModule(loaded: Record<string, unknown>): LoadedSchemaResult | null {
   const collected = getCollectedSchema();
   if (collected.tables.length > 0) {
-    return collected;
+    return { schema: collected };
   }
 
   const candidates = [loaded.schema, loaded.schemaDef, loaded.default, loaded.app].filter(
@@ -133,11 +138,14 @@ function schemaFromLoadedModule(loaded: Record<string, unknown>): Schema | null 
 
   for (const candidate of candidates) {
     if (isTypedAppLike(candidate)) {
-      return wasmSchemaToAst(candidate.wasmSchema);
+      return {
+        schema: wasmSchemaToAst(candidate.wasmSchema),
+        wasmSchema: candidate.wasmSchema,
+      };
     }
 
     try {
-      return schemaDefinitionToAst(candidate as any);
+      return { schema: schemaDefinitionToAst(candidate as any) };
     } catch {
       // Try the next supported export shape.
     }
@@ -146,7 +154,7 @@ function schemaFromLoadedModule(loaded: Record<string, unknown>): Schema | null 
   return null;
 }
 
-async function loadSchemaAst(filePath: string): Promise<Schema> {
+async function loadSchemaAst(filePath: string): Promise<LoadedSchemaResult> {
   const loaded = await loadTsModule(filePath);
   const directSchema = schemaFromLoadedModule(loaded);
   if (directSchema) {
@@ -290,7 +298,8 @@ export async function loadCompiledSchema(schemaDir: string): Promise<LoadedSchem
     );
   }
 
-  let schema = await loadSchemaAst(resolved.schemaFile);
+  const loadedSchema = await loadSchemaAst(resolved.schemaFile);
+  const schema = loadedSchema.schema;
   const tablesWithInlinePolicies = findInlinePolicyTables(schema);
   if (tablesWithInlinePolicies.length > 0) {
     throw new Error(
@@ -328,6 +337,6 @@ export async function loadCompiledSchema(schemaDir: string): Promise<LoadedSchem
     permissionsFile: resolvedPermissionsFile,
     permissions,
     schema,
-    wasmSchema: schemaToWasm(schema),
+    wasmSchema: loadedSchema.wasmSchema ?? schemaToWasm(schema),
   };
 }

--- a/packages/jazz-tools/src/testing/fixtures/with-defaults/schema.ts
+++ b/packages/jazz-tools/src/testing/fixtures/with-defaults/schema.ts
@@ -1,0 +1,12 @@
+import { col } from "../../../dsl.js";
+import { defineApp, type Schema, type App } from "../../../typed-app.js";
+
+const schema = {
+  todos: {
+    title: col.string(),
+    done: col.boolean().default(false),
+  },
+};
+
+type AppSchema = Schema<typeof schema>;
+export const app: App<AppSchema> = defineApp(schema);

--- a/todo/issues/wasm-column-to-ast-lossy.md
+++ b/todo/issues/wasm-column-to-ast-lossy.md
@@ -1,0 +1,17 @@
+# `wasmColumnToAst` silently drops `default` and `mergeStrategy`
+
+## What
+
+`wasmColumnToAst` in `packages/jazz-tools/src/schema-loader.ts` projects a `ColumnDescriptor` to an AST `Column` but only carries `name`, `sqlType`, `nullable`, and `references`. `default` and `mergeStrategy` are dropped on the floor.
+
+PR #665 sidesteps this for the wasm hash by preserving the original `wasmSchema` from `defineApp` instead of regenerating one from the lossy AST. But any consumer that reads `LoadedSchemaProject.schema` (the AST) for those fields will silently see the wrong value. Today nothing in `cli.ts` / `dev-server.ts` reads them — only table names — so this is latent, not active.
+
+## Priority
+
+low
+
+## Notes
+
+- File: `packages/jazz-tools/src/schema-loader.ts:89-96`
+- Either fix the round-trip in `wasmColumnToAst` (carry `default` and `mergeStrategy` through) or remove the AST round-trip entirely and have `wasmSchemaToAst` return a tagged structure that callers can't accidentally trust for these fields.
+- Surfaced during review of PR #665.


### PR DESCRIPTION


### Summary
The CLI's AST-based `loadCompiledSchema` strips `.default(...)` from column definitions, but the runtime `defineApp` preserves them. Because the published schema hash is computed from the CLI's wasmSchema while the client hash is computed from `defineApp`'s wasmSchema, they diverge — so every client hits:

```
Your declared schema <A> is disconnected from the schema used to enforce permissions: <B>
```

### Repro
`schema.ts`:

```ts
import { schema as s } from "jazz-tools";

const schema = {
  messages: s.table({
    content: s.string(),
    done: s.boolean().default(false), // <-- the trigger
  }),
};

export const app = s.defineApp(schema);
```

Compare the two wasmSchemas:

```ts
import { loadCompiledSchema } from "jazz-tools/dist/schema-loader.js";
import { app } from "./schema.ts";

const cli = await loadCompiledSchema(".");
console.log(JSON.stringify(cli.wasmSchema) === JSON.stringify(app.wasmSchema));
// false — 596 vs 639 bytes
```

The 43-byte delta is:

```json
"default":{"type":"Boolean","value":false}
```

present only in `defineApp`'s output.

### Impact
`jazz-tools deploy` publishes hash `A`; browser/server both compute `B`; permissions can never match. The error is opaque — nothing points at `.default()` as the cause.

### Workaround
Remove `.default(...)` from all column definitions and supply defaults in application code.

### Fix
Either have `loadCompiledSchema` preserve `.default(...)` chains, or have `defineApp` drop them, so the two paths produce byte-identical wasmSchema for identical source.

### Environment
- `jazz-tools@2.0.0-alpha.39`
- Node 22.13.1, macOS


fixes #664