### PR TITLE
fix(jazz-tools): prevent tokio scheduler task pileup under contention

### DIFF
--- a/.changeset/steady-tides-tick.md
+++ b/.changeset/steady-tides-tick.md
@@ -1,0 +1,7 @@
+---
+"jazz-tools": patch
+---
+
+Prevent TokioScheduler task pileup under contention.
+
+`schedule_batched_tick` used to clear the debounce flag at the start of the spawned task, before acquiring the core lock. When the lock was held, every caller arriving during that window saw `scheduled=false` and spawned another task, piling up behind the same mutex. The flag is now cleared after the lock is acquired, immediately before `batched_tick` runs, capping the pending queue at one tick while preserving the lost-wakeup fix.

--- a/crates/jazz-tools/src/runtime_tokio.rs
+++ b/crates/jazz-tools/src/runtime_tokio.rs
@@ -87,19 +87,28 @@ impl<S: Storage + Send + 'static> Scheduler for TokioScheduler<S> {
             let flag = self.scheduled.clone();
 
             tokio::spawn(async move {
-                // Clear the debounce flag BEFORE running batched_tick so that
-                // messages arriving while the tick executes can successfully
-                // schedule a follow-up tick.  Without this, a message parked
-                // between the drain inside batched_tick and the flag.store(false)
-                // below would be silently dropped — no tick would ever wake up
-                // to process it.
+                // Acquire the core lock FIRST, then clear the debounce flag
+                // immediately before running batched_tick.
+                //
+                // Clearing the flag before running the tick preserves the
+                // lost-wakeup fix: a message arriving while batched_tick
+                // executes finds scheduled=false and can schedule a follow-up.
+                //
+                // Clearing it only after acquiring the lock prevents task
+                // pileup: if we cleared earlier, every caller that arrived
+                // while this task was blocked on the mutex would see
+                // scheduled=false and spawn another task, all piling up
+                // behind the same lock. Holding the flag high until we
+                // actually own the core caps the queue at one pending tick.
+                let Some(core_arc) = core_ref.upgrade() else {
+                    return;
+                };
+                let Ok(mut core) = core_arc.lock() else {
+                    flag.store(false, Ordering::SeqCst);
+                    return;
+                };
                 flag.store(false, Ordering::SeqCst);
-
-                if let Some(core_arc) = core_ref.upgrade()
-                    && let Ok(mut core) = core_arc.lock()
-                {
-                    core.batched_tick();
-                }
+                core.batched_tick();
             });
         }
     }

--- a/crates/jazz-tools/src/runtime_tokio.rs
+++ b/crates/jazz-tools/src/runtime_tokio.rs
@@ -101,9 +101,16 @@ impl<S: Storage + Send + 'static> Scheduler for TokioScheduler<S> {
                 // behind the same lock. Holding the flag high until we
                 // actually own the core caps the queue at one pending tick.
                 let Some(core_arc) = core_ref.upgrade() else {
+                    // Core is permanently gone. Leave the flag high so any
+                    // stray scheduler clones (e.g. NativeTickNotifier) short-
+                    // circuit instead of spawning more doomed tasks.
                     return;
                 };
                 let Ok(mut core) = core_arc.lock() else {
+                    // Mutex is poisoned but the core Arc still exists. Clear
+                    // the flag so we don't leave a stale "tick queued" signal
+                    // behind — callers are free to retry (and fail) on their
+                    // own terms.
                     flag.store(false, Ordering::SeqCst);
                     return;
                 };

--- a/crates/jazz-tools/src/runtime_tokio.rs
+++ b/crates/jazz-tools/src/runtime_tokio.rs
@@ -104,6 +104,7 @@ impl<S: Storage + Send + 'static> Scheduler for TokioScheduler<S> {
                     // Core is permanently gone. Leave the flag high so any
                     // stray scheduler clones (e.g. NativeTickNotifier) short-
                     // circuit instead of spawning more doomed tasks.
+                    tracing::debug!("TokioScheduler: core dropped before tick could run; skipping");
                     return;
                 };
                 let Ok(mut core) = core_arc.lock() else {
@@ -111,6 +112,7 @@ impl<S: Storage + Send + 'static> Scheduler for TokioScheduler<S> {
                     // the flag so we don't leave a stale "tick queued" signal
                     // behind — callers are free to retry (and fail) on their
                     // own terms.
+                    tracing::error!("TokioScheduler: core mutex poisoned; scheduler is unusable");
                     flag.store(false, Ordering::SeqCst);
                     return;
                 };


### PR DESCRIPTION
## Summary

- `TokioScheduler::schedule_batched_tick` cleared the debounce flag at the start of the spawned task, before acquiring the core lock. Under contention every caller that arrived while the task was blocked on the mutex observed `scheduled=false` and spawned another task, piling up behind the same lock.
- Acquire the core lock first, then clear the flag immediately before running `batched_tick`. The lost-wakeup fix is preserved — messages arriving during the tick still find `scheduled=false` and can schedule a follow-up — while the pending queue is capped at one tick.

## Test plan

- [ ] `cargo check -p jazz-tools`
- [ ] `cargo test -p jazz-tools`