### PR TITLE
Fix websocket row-batch broadcast leakage

### DIFF
--- a/.changeset/fix-websocket-rowbatch-ack-leak.md
+++ b/.changeset/fix-websocket-rowbatch-ack-leak.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fixed the flood of ws messages by stop forwarding client-origin `RowBatchStateChanged` acknowledgements to other subscribers. This keeps per-client row-batch durability bookkeeping local to the server/client pair and avoids leaking `BatchSettlement` echoes to unrelated WebSocket clients.

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -1357,44 +1357,6 @@ impl SyncManager {
                     *state,
                     *confirmed_tier,
                 );
-                let key = RowBatchKey::new(*row_id, *branch_name, *batch_id);
-                let mut interested = HashSet::new();
-                if let Some(clients) = self.row_batch_interest.get(&key) {
-                    interested.extend(clients);
-                }
-                interested.remove(&client_id);
-                let settlement = self.settlement_for_row_batch_state_change(
-                    storage,
-                    *row_id,
-                    *branch_name,
-                    *batch_id,
-                    *confirmed_tier,
-                );
-                let persisted_settlement = settlement.clone().filter(|settlement| {
-                    self.persist_authoritative_batch_settlement(storage, settlement)
-                        .is_ok()
-                });
-                if let Some(settlement) = persisted_settlement.clone() {
-                    self.pending_batch_settlements.push(settlement);
-                }
-                for cid in interested {
-                    self.outbox.push(OutboxEntry {
-                        destination: Destination::Client(cid),
-                        payload: SyncPayload::RowBatchStateChanged {
-                            row_id: *row_id,
-                            branch_name: *branch_name,
-                            batch_id: *batch_id,
-                            state: *state,
-                            confirmed_tier: *confirmed_tier,
-                        },
-                    });
-                    if let Some(settlement) = persisted_settlement.clone() {
-                        self.outbox.push(OutboxEntry {
-                            destination: Destination::Client(cid),
-                            payload: SyncPayload::BatchSettlement { settlement },
-                        });
-                    }
-                }
             }
             SyncPayload::BatchSettlement { settlement } => {
                 self.pending_batch_settlements.push(settlement.clone());

--- a/crates/jazz-tools/src/sync_manager/tests.rs
+++ b/crates/jazz-tools/src/sync_manager/tests.rs
@@ -950,6 +950,76 @@ fn row_batch_state_changed_relays_to_clients_that_received_row_batch_needed() {
 }
 
 #[test]
+fn client_row_batch_state_ack_does_not_leak_to_other_subscribers() {
+    let mut sm = SyncManager::new();
+    let mut io = MemoryStorage::new();
+    let alice = ClientId::new();
+    let bob = ClientId::new();
+    let row_id = ObjectId::new();
+    let mut row = visible_row(row_id, "main", Vec::new(), 1_000, b"alice-todo");
+    row.confirmed_tier = Some(DurabilityTier::GlobalServer);
+    let batch_id = row.batch_id;
+
+    add_client(&mut sm, &io, alice);
+    add_client(&mut sm, &io, bob);
+    sm.take_outbox();
+    seed_visible_row(&mut sm, &mut io, "users", row.clone());
+    persist_visible_row_settlement(&mut io, row_id, &row);
+
+    for (client_id, query_id) in [(alice, QueryId(1)), (bob, QueryId(2))] {
+        set_client_query_scope(
+            &mut sm,
+            &io,
+            client_id,
+            query_id,
+            HashSet::from([(row_id, BranchName::new("main"))]),
+            None,
+        );
+    }
+
+    let initial = sm.take_outbox();
+    assert!(initial.iter().any(|entry| matches!(
+        entry,
+        OutboxEntry {
+            destination: Destination::Client(id),
+            payload: SyncPayload::RowBatchNeeded { row: needed, .. },
+        } if *id == alice && needed.row_id == row_id
+    )));
+    assert!(initial.iter().any(|entry| matches!(
+        entry,
+        OutboxEntry {
+            destination: Destination::Client(id),
+            payload: SyncPayload::RowBatchNeeded { row: needed, .. },
+        } if *id == bob && needed.row_id == row_id
+    )));
+
+    sm.process_from_client(
+        &mut io,
+        bob,
+        SyncPayload::RowBatchStateChanged {
+            row_id,
+            branch_name: BranchName::new("main"),
+            batch_id,
+            state: None,
+            confirmed_tier: Some(DurabilityTier::Local),
+        },
+    );
+
+    let outbox = sm.take_outbox();
+    assert!(
+        outbox.iter().all(|entry| !matches!(
+            entry,
+            OutboxEntry {
+                destination: Destination::Client(id),
+                payload:
+                    SyncPayload::RowBatchStateChanged { .. } | SyncPayload::BatchSettlement { .. },
+            } if *id == alice
+        )),
+        "alice should not receive bob's per-client row-batch ack: {outbox:#?}"
+    );
+}
+
+#[test]
 fn initial_query_sync_replays_current_direct_batch_settlement() {
     let mut sm = SyncManager::new();
     let mut io = MemoryStorage::new();


### PR DESCRIPTION
## Bug, Cause, And Fix
- Bug: when client B received a row via `RowBatchNeeded` and answered the server with `RowBatchStateChanged`, client A could receive B's ack and the `BatchSettlement` response meant for B.
- Cause: the client-origin `RowBatchStateChanged` handler reused relay logic intended for server-origin durability updates, walking `row_batch_interest` and forwarding the ack plus settlement to other interested clients.
- Why this fix: client-origin row-batch acks are per-client/server bookkeeping, so the server should apply them locally only. Authoritative server-origin `RowBatchStateChanged` messages still use the existing interested-client relay path.

## Summary
- Stop relaying client-origin `RowBatchStateChanged` messages to other clients.
- Keep the server-side row-batch state handling local so Bob’s ack no longer fans out to Alice.
- Add a regression test covering two subscribers on the same row batch.

## Testing
- `cargo fmt --check`
- `cargo test -p jazz-tools client_row_batch_state_ack_does_not_leak_to_other_subscribers`
- `cargo test -p jazz-tools sync_manager::tests`
- `cargo test -p jazz-tools --features test --test sync_tracer_integration alice_write_bob_read`