### PR TITLE
fix(jazz-tools): SvelteKit dev plugin restarts Vite after first appId allocation

### DIFF
--- a/.changeset/fix-sveltekit-cold-start-env.md
+++ b/.changeset/fix-sveltekit-cold-start-env.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix the SvelteKit dev plugin so the first-ever cold start no longer needs a manual restart. The plugin now triggers a Vite restart immediately after allocating a fresh app ID, so SvelteKit's `$env/*` capture re-reads the now-populated `.env` on the second pass. Plugin order in `vite.config.ts` is no longer load-bearing.

--- a/docs/content/docs/getting-started/client-setup.mdx
+++ b/docs/content/docs/getting-started/client-setup.mdx
@@ -172,7 +172,7 @@ Jazz ships bundler plugins that remove boilerplate in development. They start a 
     import { jazzSvelteKit } from "jazz-tools/dev/sveltekit";
 
     export default defineConfig({
-      plugins: [jazzSvelteKit(), svelte()],
+      plugins: [svelte(), jazzSvelteKit()],
     });
     ```
 
@@ -186,9 +186,7 @@ Jazz ships bundler plugins that remove boilerplate in development. They start a 
     import { defineConfig } from "vite";
 
     export default defineConfig({
-      // jazzSvelteKit must come before sveltekit so it populates
-      // process.env before SvelteKit captures $env/dynamic/public.
-      plugins: [jazzSvelteKit(), sveltekit()],
+      plugins: [sveltekit(), jazzSvelteKit()],
     });
     ```
 

--- a/docs/content/docs/getting-started/client-setup.mdx
+++ b/docs/content/docs/getting-started/client-setup.mdx
@@ -172,7 +172,7 @@ Jazz ships bundler plugins that remove boilerplate in development. They start a 
     import { jazzSvelteKit } from "jazz-tools/dev/sveltekit";
 
     export default defineConfig({
-      plugins: [svelte(), jazzSvelteKit()],
+      plugins: [jazzSvelteKit(), svelte()],
     });
     ```
 

--- a/examples/todo-client-localfirst-svelte/vite.config.ts
+++ b/examples/todo-client-localfirst-svelte/vite.config.ts
@@ -3,5 +3,5 @@ import { svelte } from "@sveltejs/vite-plugin-svelte";
 import { jazzSvelteKit } from "jazz-tools/dev/sveltekit";
 
 export default defineConfig({
-  plugins: [jazzSvelteKit(), svelte()],
+  plugins: [svelte(), jazzSvelteKit()],
 });

--- a/examples/todo-client-localfirst-svelte/vite.config.ts
+++ b/examples/todo-client-localfirst-svelte/vite.config.ts
@@ -3,5 +3,5 @@ import { svelte } from "@sveltejs/vite-plugin-svelte";
 import { jazzSvelteKit } from "jazz-tools/dev/sveltekit";
 
 export default defineConfig({
-  plugins: [svelte(), jazzSvelteKit()],
+  plugins: [jazzSvelteKit(), svelte()],
 });

--- a/packages/jazz-tools/src/dev/sveltekit.test.ts
+++ b/packages/jazz-tools/src/dev/sveltekit.test.ts
@@ -17,11 +17,12 @@ const originalBackendSecret = process.env.BACKEND_SECRET;
 function makeViteServer(
   command: "serve" | "build",
   root = "/tmp/jazz-sveltekit-test",
-): ViteDevServer {
+): ViteDevServer & { restart: ReturnType<typeof vi.fn> } {
   return {
     config: { root, command, env: {} },
     httpServer: { once() {} },
     ws: { send() {} },
+    restart: vi.fn(),
   };
 }
 
@@ -98,6 +99,45 @@ describe("jazzSvelteKit", () => {
     expect(process.env.PUBLIC_JAZZ_SERVER_URL).toBe(`http://127.0.0.1:${port}`);
   }, 30_000);
 
+  it("restarts the dev server on first-ever cold start so SvelteKit's $env capture sees the freshly allocated appId", async () => {
+    const port = await getAvailablePort();
+    const root = await tempRoots.create("jazz-sveltekit-cold-start-");
+    await mkdir(join(root, "src", "lib"), { recursive: true });
+    await writeFile(join(root, "src", "lib", "schema.ts"), todoSchema());
+
+    const plugin = jazzSvelteKit({
+      server: { port, adminSecret: "cold-start-admin" },
+    });
+    const viteServer = makeViteServer("serve", root);
+    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(viteServer);
+
+    expect(viteServer.restart).toHaveBeenCalledTimes(1);
+  }, 30_000);
+
+  it("does not restart when appId is already persisted in .env (warm start)", async () => {
+    const persistedAppId = "00000000-0000-0000-0000-000000000099";
+    vi.spyOn(devServer, "startLocalJazzServer").mockResolvedValue({
+      appId: persistedAppId,
+      port: 19990,
+      url: "http://127.0.0.1:19990",
+      dataDir: undefined as unknown as string,
+      stop: vi.fn().mockResolvedValue(undefined),
+    });
+    vi.spyOn(devServer, "pushSchemaCatalogue").mockResolvedValue({ hash: "abc" });
+    vi.spyOn(schemaWatcher, "watchSchema").mockReturnValue({ close: vi.fn() });
+
+    const root = await tempRoots.create("jazz-sveltekit-warm-start-");
+    await writeFile(join(root, ".env"), `PUBLIC_JAZZ_APP_ID=${persistedAppId}\n`);
+
+    const plugin = jazzSvelteKit({
+      server: { port: 19990, adminSecret: "warm-start-admin" },
+    });
+    const viteServer = makeViteServer("serve", root);
+    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(viteServer);
+
+    expect(viteServer.restart).not.toHaveBeenCalled();
+  });
+
   it("does not start a server during build", async () => {
     const spy = vi.spyOn(devServer, "startLocalJazzServer");
 
@@ -163,6 +203,7 @@ describe("jazzSvelteKit", () => {
       config: { root, command: "serve", env: {}, server: { port: 3000 } },
       httpServer: { once() {} },
       ws: { send() {} },
+      restart: vi.fn(),
     };
     await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(viteServer);
 
@@ -198,6 +239,7 @@ describe("jazzSvelteKit", () => {
         config: { root, command: "serve", env: {}, server: { port: 3000 } },
         httpServer: { once() {} },
         ws: { send() {} },
+        restart: vi.fn(),
       };
       await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(viteServer);
 
@@ -280,47 +322,6 @@ describe("jazzSvelteKit", () => {
     await expect(
       (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(makeViteServer("serve")),
     ).rejects.toThrow("appId is required when connecting to an existing server");
-  });
-
-  it("stops the server and closes the watcher when the close hook fires", async () => {
-    const stop = vi.fn().mockResolvedValue(undefined);
-    const close = vi.fn();
-
-    vi.spyOn(devServer, "startLocalJazzServer").mockResolvedValue({
-      appId: "00000000-0000-0000-0000-000000000002",
-      port: 19997,
-      url: "http://127.0.0.1:19997",
-      dataDir: undefined as unknown as string,
-      stop,
-    });
-    vi.spyOn(devServer, "pushSchemaCatalogue").mockResolvedValue({
-      hash: "abc",
-    });
-    vi.spyOn(schemaWatcher, "watchSchema").mockReturnValue({ close });
-
-    const root = await tempRoots.create("jazz-sveltekit-close-test-");
-    let capturedCloseCallback: (() => void) | undefined;
-    const viteServer: ViteDevServer = {
-      config: { root, command: "serve", env: {} },
-      httpServer: {
-        once(event, cb) {
-          if (event === "close") capturedCloseCallback = cb;
-        },
-      },
-      ws: { send() {} },
-    };
-
-    const plugin = jazzSvelteKit({
-      server: { port: 19997, adminSecret: "close-hook-admin" },
-    });
-    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(viteServer);
-
-    expect(capturedCloseCallback).toBeDefined();
-    capturedCloseCallback!();
-    await new Promise((r) => setTimeout(r, 50));
-
-    expect(stop).toHaveBeenCalledOnce();
-    expect(close).toHaveBeenCalledOnce();
   });
 
   it("surfaces schema push failures as HMR errors", async () => {

--- a/packages/jazz-tools/src/dev/sveltekit.test.ts
+++ b/packages/jazz-tools/src/dev/sveltekit.test.ts
@@ -22,7 +22,7 @@ function makeViteServer(
     config: { root, command, env: {} },
     httpServer: { once() {} },
     ws: { send() {} },
-    restart: vi.fn(),
+    restart: vi.fn(() => Promise.resolve()),
   };
 }
 

--- a/packages/jazz-tools/src/dev/sveltekit.ts
+++ b/packages/jazz-tools/src/dev/sveltekit.ts
@@ -129,7 +129,7 @@ export function jazzSvelteKit(options: JazzPluginOptions = {}) {
         console.log(
           `${LOG_PREFIX} initial appId allocated, restarting dev server so SvelteKit's $env captures it`,
         );
-        void viteServer.restart();
+        void viteServer.restart?.();
       }
     },
   };

--- a/packages/jazz-tools/src/dev/sveltekit.ts
+++ b/packages/jazz-tools/src/dev/sveltekit.ts
@@ -68,6 +68,13 @@ export function jazzSvelteKit(options: JazzPluginOptions = {}) {
       // would otherwise never fire. Backfill before reading.
       loadEnvFileIntoProcessEnv(viteServer.config.root);
 
+      // SvelteKit's vite-plugin captures env in its `config: { order: 'pre' }`
+      // hook, before configureServer ever runs. If this is the first-ever start
+      // (no persisted appId yet), SvelteKit's captured env is empty when we
+      // allocate one below. Trigger a restart so its config hook re-runs and
+      // re-reads the now-populated .env. No-ops on warm starts.
+      const wasColdStart = !process.env.PUBLIC_JAZZ_APP_ID;
+
       const schemaDir = options.schemaDir ?? join(viteServer.config.root, "src", "lib");
       const serverOpt = options.server ?? true;
 
@@ -118,11 +125,12 @@ export function jazzSvelteKit(options: JazzPluginOptions = {}) {
       viteServer.config.env.PUBLIC_JAZZ_APP_ID = managed.appId;
       viteServer.config.env.PUBLIC_JAZZ_SERVER_URL = managed.serverUrl;
 
-      viteServer.httpServer?.once("close", () => {
-        runtime.dispose().catch((error) => {
-          console.error(`${LOG_PREFIX} dispose failed:`, error);
-        });
-      });
+      if (wasColdStart && managed.appId) {
+        console.log(
+          `${LOG_PREFIX} initial appId allocated, restarting dev server so SvelteKit's $env captures it`,
+        );
+        void viteServer.restart();
+      }
     },
   };
 }

--- a/packages/jazz-tools/src/dev/vite.ts
+++ b/packages/jazz-tools/src/dev/vite.ts
@@ -59,6 +59,7 @@ export interface ViteDevServer {
   ws: {
     send(payload: { type: string; err?: { message: string; stack?: string } }): void;
   };
+  restart?(forceOptimize?: boolean): Promise<void>;
 }
 
 export function jazzPlugin(options: JazzPluginOptions = {}) {

--- a/starters/sveltekit-betterauth/vite.config.ts
+++ b/starters/sveltekit-betterauth/vite.config.ts
@@ -3,10 +3,7 @@ import { jazzSvelteKit } from "jazz-tools/dev/sveltekit";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-  // jazzSvelteKit must come before sveltekit so that it populates
-  // process.env.PUBLIC_JAZZ_* before SvelteKit's plugin captures the
-  // public env for $env/dynamic/public.
-  plugins: [jazzSvelteKit(), sveltekit()],
+  plugins: [sveltekit(), jazzSvelteKit()],
   server: {
     fs: {
       allow: ["../.."],

--- a/starters/sveltekit-hybrid/vite.config.ts
+++ b/starters/sveltekit-hybrid/vite.config.ts
@@ -3,10 +3,7 @@ import { jazzSvelteKit } from "jazz-tools/dev/sveltekit";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-  // jazzSvelteKit must come before sveltekit so that it populates
-  // process.env.PUBLIC_JAZZ_* before SvelteKit's plugin captures the
-  // public env for $env/dynamic/public.
-  plugins: [jazzSvelteKit(), sveltekit()],
+  plugins: [sveltekit(), jazzSvelteKit()],
   server: {
     fs: {
       allow: ["../.."],

--- a/starters/sveltekit-localfirst/vite.config.ts
+++ b/starters/sveltekit-localfirst/vite.config.ts
@@ -3,10 +3,7 @@ import { jazzSvelteKit } from "jazz-tools/dev/sveltekit";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-  // jazzSvelteKit must come before sveltekit so that it populates
-  // process.env.PUBLIC_JAZZ_* before SvelteKit's plugin captures the
-  // public env for $env/dynamic/public.
-  plugins: [jazzSvelteKit(), sveltekit()],
+  plugins: [sveltekit(), jazzSvelteKit()],
   server: {
     fs: {
       allow: ["../.."],


### PR DESCRIPTION
## Summary
- Fixes the SvelteKit dev plugin so the first-ever cold start no longer needs a manual restart. After `runtime.initialize` allocates an appId, `configureServer` calls `viteServer.restart()` so SvelteKit's `config: { order: 'pre' }` hook re-runs and re-reads the now-populated `.env`. Warm starts (where `.env` already has the appId) skip the restart.
- Removes the `httpServer.once("close", dispose)` handler — it would dispose the cached runtime on Vite restart, defeating the cache. Real shutdown is still covered by SIGINT/SIGTERM/exit handlers in `installShutdownHooks`.
- Plugin order in `vite.config.ts` is no longer load-bearing. Removes the "must come before sveltekit" guidance from docs and SvelteKit starter `vite.config.ts` files. Configs return to natural framework-first order (the swap from the first commit is reverted).

## Test plan
- [x] `pnpm exec vitest run src/dev/sveltekit.test.ts` — added `restarts the dev server on first-ever cold start...` and `does not restart when appId is already persisted...`. Both green. Existing tests still pass; the close-hook test was deleted (its asserted behaviour is intentionally removed).
- [ ] Smoke: scaffold a fresh SvelteKit app, run `pnpm dev`, confirm: first run logs the restart message and the page loads without manual intervention; subsequent runs do not restart.
- [ ] Smoke: reverse plugin order in `vite.config.ts` (`[jazzSvelteKit(), sveltekit()]`) — first run still self-heals via restart.