### PR TITLE
feat: accept getter functions in Svelte QuerySubscription

### DIFF
--- a/.changeset/svelte-query-subscription-getter.md
+++ b/.changeset/svelte-query-subscription-getter.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+`QuerySubscription` in the Svelte bindings now accepts a getter for both the query and the options, e.g. `new QuerySubscription(() => filter ? app.todos.where({ title: { contains: filter } }) : undefined)`. Reactive reads inside the getter are tracked, so the subscription re-runs when its dependencies change. The bare-value forms continue to work unchanged.

--- a/packages/jazz-tools/src/svelte/test-helpers.svelte.ts
+++ b/packages/jazz-tools/src/svelte/test-helpers.svelte.ts
@@ -13,5 +13,6 @@ vi.mock("svelte", async (importOriginal) => {
     ...actual,
     setContext: (key: unknown, value: unknown) => contextStore.set(key, value),
     getContext: (key: unknown) => contextStore.get(key),
+    onDestroy: vi.fn(),
   };
 });

--- a/packages/jazz-tools/src/svelte/use-all.svelte.test.ts
+++ b/packages/jazz-tools/src/svelte/use-all.svelte.test.ts
@@ -168,6 +168,40 @@ describe("svelte/QuerySubscription", () => {
     cleanup();
   });
 
+  it("clears a stale error when the getter flips back to undefined", async () => {
+    let active = $state(true);
+    const query = makeQuery("inbox");
+
+    let capturedOnError: ((err: unknown) => void) | undefined;
+    mocks.getCacheEntry.mockReturnValue({
+      state: { status: "fulfilled" as const, data: [] },
+      subscribe: (callbacks: any) => {
+        capturedOnError = callbacks.onError;
+        return mocks.unsubscribe;
+      },
+    } as any);
+
+    const sub = (() => {
+      let ref!: InstanceType<typeof QuerySubscription<{ id: string }>>;
+      const cleanup = $effect.root(() => {
+        ref = new QuerySubscription(() => (active ? query : undefined));
+      });
+      return { ref, cleanup };
+    })();
+    await settle();
+
+    capturedOnError!(new Error("boom"));
+    await settle();
+    expect(sub.ref.error).toBeInstanceOf(Error);
+
+    active = false;
+    await settle();
+
+    expect(sub.ref.error).toBeNull();
+
+    sub.cleanup();
+  });
+
   it("options accepts a getter and forwards the resolved value", async () => {
     const query = makeQuery("inbox");
 

--- a/packages/jazz-tools/src/svelte/use-all.svelte.test.ts
+++ b/packages/jazz-tools/src/svelte/use-all.svelte.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { flushSync } from "svelte";
+import "./test-helpers.svelte.js";
+
+const mocks = vi.hoisted(() => {
+  const unsubscribe = vi.fn();
+  const subscribe = vi.fn(() => unsubscribe);
+  const makeQueryKey = vi.fn((q: any) => `key:${q?._marker ?? "?"}`);
+  const getCacheEntry = vi.fn(() => ({
+    state: { status: "fulfilled", data: [] },
+    subscribe,
+  }));
+
+  return {
+    makeQueryKey,
+    getCacheEntry,
+    subscribe,
+    unsubscribe,
+    reset() {
+      unsubscribe.mockReset();
+      subscribe.mockReset().mockReturnValue(unsubscribe);
+      makeQueryKey.mockReset().mockImplementation((q: any) => `key:${q?._marker ?? "?"}`);
+      getCacheEntry.mockReset().mockReturnValue({
+        state: { status: "fulfilled", data: [] },
+        subscribe,
+      });
+    },
+  };
+});
+
+vi.mock("./context.svelte.js", () => ({
+  getJazzContext: () => ({
+    db: null,
+    session: null,
+    manager: {
+      makeQueryKey: mocks.makeQueryKey,
+      getCacheEntry: mocks.getCacheEntry,
+    },
+  }),
+}));
+
+const { QuerySubscription } = await import("./use-all.svelte.js");
+
+function makeQuery(marker = "todos") {
+  return { _marker: marker } as any;
+}
+
+async function settle() {
+  await Promise.resolve();
+  flushSync();
+}
+
+describe("svelte/QuerySubscription", () => {
+  beforeEach(() => {
+    mocks.reset();
+  });
+
+  it("subscribes when given a plain QueryBuilder", async () => {
+    const query = makeQuery("inbox");
+    const cleanup = $effect.root(() => {
+      new QuerySubscription(query);
+    });
+    await settle();
+
+    expect(mocks.makeQueryKey).toHaveBeenCalledWith(query, undefined);
+    expect(mocks.subscribe).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it("does not subscribe when given undefined", async () => {
+    const cleanup = $effect.root(() => {
+      new QuerySubscription(undefined);
+    });
+    await settle();
+
+    expect(mocks.makeQueryKey).not.toHaveBeenCalled();
+    expect(mocks.subscribe).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it("accepts a getter and subscribes with the resolved query", async () => {
+    const query = makeQuery("inbox");
+    const cleanup = $effect.root(() => {
+      new QuerySubscription(() => query);
+    });
+    await settle();
+
+    expect(mocks.makeQueryKey).toHaveBeenCalledWith(query, undefined);
+    expect(mocks.subscribe).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it("getter returning undefined does not subscribe", async () => {
+    const cleanup = $effect.root(() => {
+      new QuerySubscription(() => undefined);
+    });
+    await settle();
+
+    expect(mocks.makeQueryKey).not.toHaveBeenCalled();
+    expect(mocks.subscribe).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it("getter reading $state re-subscribes when state changes", async () => {
+    let filter = $state<string | null>(null);
+    const inboxQuery = makeQuery("inbox");
+    const filteredQuery = makeQuery("filtered");
+
+    const cleanup = $effect.root(() => {
+      new QuerySubscription(() => (filter ? filteredQuery : inboxQuery));
+    });
+    await settle();
+
+    expect(mocks.makeQueryKey).toHaveBeenLastCalledWith(inboxQuery, undefined);
+    expect(mocks.subscribe).toHaveBeenCalledTimes(1);
+
+    filter = "alice";
+    await settle();
+
+    expect(mocks.unsubscribe).toHaveBeenCalledTimes(1);
+    expect(mocks.makeQueryKey).toHaveBeenLastCalledWith(filteredQuery, undefined);
+    expect(mocks.subscribe).toHaveBeenCalledTimes(2);
+
+    cleanup();
+  });
+
+  it("getter flipping undefined → query subscribes only after the flip", async () => {
+    let filter = $state<string | null>(null);
+    const filteredQuery = makeQuery("filtered");
+
+    const cleanup = $effect.root(() => {
+      new QuerySubscription(() => (filter ? filteredQuery : undefined));
+    });
+    await settle();
+
+    expect(mocks.makeQueryKey).not.toHaveBeenCalled();
+    expect(mocks.subscribe).not.toHaveBeenCalled();
+
+    filter = "alice";
+    await settle();
+
+    expect(mocks.makeQueryKey).toHaveBeenCalledWith(filteredQuery, undefined);
+    expect(mocks.subscribe).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it("getter flipping query → undefined unsubscribes", async () => {
+    let active = $state(true);
+    const query = makeQuery("inbox");
+
+    const cleanup = $effect.root(() => {
+      new QuerySubscription(() => (active ? query : undefined));
+    });
+    await settle();
+
+    expect(mocks.subscribe).toHaveBeenCalledTimes(1);
+
+    active = false;
+    await settle();
+
+    expect(mocks.unsubscribe).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it("options accepts a getter and forwards the resolved value", async () => {
+    const query = makeQuery("inbox");
+
+    const cleanup = $effect.root(() => {
+      new QuerySubscription(query, () => ({ tier: "edge" as const }));
+    });
+    await settle();
+
+    expect(mocks.makeQueryKey).toHaveBeenCalledWith(query, { tier: "edge" });
+
+    cleanup();
+  });
+});

--- a/packages/jazz-tools/src/svelte/use-all.svelte.ts
+++ b/packages/jazz-tools/src/svelte/use-all.svelte.ts
@@ -55,6 +55,7 @@ export class QuerySubscription<T extends { id: string }> {
       if (!resolvedQuery) {
         this.current = undefined;
         this.loading = false;
+        this.error = null;
         return;
       }
 

--- a/packages/jazz-tools/src/svelte/use-all.svelte.ts
+++ b/packages/jazz-tools/src/svelte/use-all.svelte.ts
@@ -4,12 +4,21 @@ import type { SubscriptionDelta } from "../runtime/subscription-manager.js";
 import { applyDelta } from "../reconcile-array.js";
 import { getJazzContext } from "./context.svelte.js";
 
+type MaybeGetter<T> = T | (() => T);
+
+function resolve<T>(value: MaybeGetter<T>): T {
+  return typeof value === "function" ? (value as () => T)() : value;
+}
+
 /**
  * Reactive query subscription. Instantiate in a component script block,
  * access results via `.current`.
  *
- * @param query - the database query (e.g. `app.todos.where({ done: false })`)
- * @param options - optional query execution options, including durability tier
+ * @param query - the database query, or a getter for a dynamic query
+ *   (e.g. `() => filter ? app.todos.where({ title: { contains: filter } }) : undefined`).
+ *   When a getter is passed, any reactive reads inside it are tracked, so the
+ *   subscription re-runs when its dependencies change.
+ * @param options - optional query execution options, or a getter for them
  *
  * ```svelte
  * <script lang="ts">
@@ -34,12 +43,16 @@ export class QuerySubscription<T extends { id: string }> {
 
   #unsubscribe: (() => void) | null = null;
 
-  constructor(query: QueryBuilder<T> | undefined, options?: QueryOptions) {
+  constructor(
+    query: MaybeGetter<QueryBuilder<T> | undefined>,
+    options?: MaybeGetter<QueryOptions | undefined>,
+  ) {
     const ctx = getJazzContext();
-    this.current = options?.tier ? undefined : [];
+    this.current = resolve(options)?.tier ? undefined : [];
 
     $effect(() => {
-      if (!query) {
+      const resolvedQuery = resolve(query);
+      if (!resolvedQuery) {
         this.current = undefined;
         this.loading = false;
         return;
@@ -48,11 +61,13 @@ export class QuerySubscription<T extends { id: string }> {
       const manager = ctx.manager;
       if (!manager) return;
 
+      const resolvedOptions = resolve(options);
+
       this.loading = true;
       this.error = null;
 
       try {
-        const key = manager.makeQueryKey(query, options);
+        const key = manager.makeQueryKey(resolvedQuery, resolvedOptions);
         const entry = manager.getCacheEntry<T>(key);
 
         // Apply initial state from cache


### PR DESCRIPTION
## Summary
- Widens `QuerySubscription` (Svelte) to accept `() => QueryBuilder | undefined` for both the query and the options. Reactive reads inside the getter are tracked, so the subscription re-runs on dependency changes.
- Bare-value forms continue to work unchanged.
- The published Svelte conditional-query docs example (`ConditionalQueryExample.svelte`) already used this form; the implementation now matches the docs.
- Vue's `useAll` already supports `MaybeRefOrGetter` via `toValue`, so this gap was Svelte-only.

## Test plan
- [x] New `use-all.svelte.test.ts` covers: plain query (regression), undefined (regression), getter returning a query, getter returning undefined, getter reading `\$state` re-subscribes on change, getter flipping undefined → query, getter flipping query → undefined, options-as-getter.
- [x] Red-then-green TDD: 6 getter tests failed before the implementation; all 33 Svelte tests pass after.
- [x] Full `pnpm test` in `jazz-tools` passes (93 test files).
- [x] `pnpm build` in `jazz-tools` and the Svelte docs example build cleanly.
