### PR TITLE
fix(dev): honor root adminSecret in managed dev server

### DIFF
--- a/.changeset/expo-managed-admin-secret-root.md
+++ b/.changeset/expo-managed-admin-secret-root.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Honor the root `adminSecret` option in `ManagedDevRuntime` (used by the `vite`, `next`, `sveltekit`, and `expo` dev plugins). The managed local-server branch previously read only `server.adminSecret` and silently fell back to a random `jazz-dev-XXXXXXXX` when the root option was set; it now falls through to root `adminSecret`, mirroring the precedence already used for `appId`. The startup banner also surfaces the resolved admin secret, and the Expo plugin now logs the inspector link the same way `vite` and `next` do.

--- a/packages/jazz-tools/src/dev/expo.test.ts
+++ b/packages/jazz-tools/src/dev/expo.test.ts
@@ -89,6 +89,29 @@ describe("withJazz", () => {
     expect(resolved.extra?.jazzServerUrl).toBe(`http://127.0.0.1:${port}`);
   }, 30_000);
 
+  it("seeds the managed server's adminSecret from the root option when no server.adminSecret is given", async () => {
+    const port = await getAvailablePort();
+    const schemaDir = await tempRoots.create("jazz-expo-root-secret-");
+    await writeFile(join(schemaDir, "schema.ts"), todoSchema());
+
+    const resolved = await withJazz(
+      { name: "my-app" },
+      {
+        server: { port },
+        adminSecret: "expo-root-admin",
+        schemaDir,
+      },
+    );
+
+    const schemasResponse = await fetch(
+      `http://127.0.0.1:${port}/apps/${resolved.extra?.jazzAppId}/schemas`,
+      {
+        headers: { "X-Jazz-Admin-Secret": "expo-root-admin" },
+      },
+    );
+    expect(schemasResponse.ok).toBe(true);
+  }, 30_000);
+
   it("releases a failed startup before retrying the same port after the schema is fixed", async () => {
     const port = await getAvailablePort();
     const schemaDir = await tempRoots.create("jazz-expo-retry-");

--- a/packages/jazz-tools/src/dev/expo.ts
+++ b/packages/jazz-tools/src/dev/expo.ts
@@ -1,3 +1,4 @@
+import { buildInspectorLink } from "./inspector-link.js";
 import { ManagedDevRuntime } from "./managed-runtime.js";
 import type { JazzPluginOptions, JazzServerOptions } from "./vite.js";
 
@@ -13,6 +14,8 @@ const runtime = new ManagedDevRuntime({
   serverUrl: "EXPO_PUBLIC_JAZZ_SERVER_URL",
 });
 
+let hasLoggedInspectorLink = false;
+
 export async function withJazz(
   expoConfig: ExpoConfigLike,
   options: JazzPluginOptions = {},
@@ -22,6 +25,17 @@ export async function withJazz(
   }
 
   const managed = await runtime.initialize(options);
+
+  if (!hasLoggedInspectorLink) {
+    console.log(
+      `[jazz] Open the inspector: ${buildInspectorLink(
+        managed.serverUrl,
+        managed.appId,
+        managed.adminSecret,
+      )}`,
+    );
+    hasLoggedInspectorLink = true;
+  }
 
   return {
     ...expoConfig,
@@ -34,5 +48,6 @@ export async function withJazz(
 }
 
 export async function __resetJazzPluginForTests(): Promise<void> {
+  hasLoggedInspectorLink = false;
   await runtime.resetForTests();
 }

--- a/packages/jazz-tools/src/dev/managed-runtime.ts
+++ b/packages/jazz-tools/src/dev/managed-runtime.ts
@@ -22,6 +22,7 @@ function printServerStartedBanner(opts: {
   serverUrl: string;
   appId: string;
   dataDir?: string;
+  adminSecret?: string;
 }): void {
   const useColor = Boolean(process.stdout.isTTY) && process.env.NO_COLOR === undefined;
   const bold = useColor ? "\x1b[1m" : "";
@@ -47,7 +48,9 @@ function printServerStartedBanner(opts: {
     console.log(`${bold}Data dir:${reset} ${bold}${brand}${toRelativePath(opts.dataDir)}${reset}`);
   }
   console.log(`${bold}App id:${reset}   ${bold}${brand}${opts.appId}${reset}`);
-  console.log("");
+  if (opts.adminSecret) {
+    console.log(`${bold}Admin secret:${reset} ${bold}${brand}${opts.adminSecret}${reset}`);
+  }
 }
 
 export type ManagedRuntime = {
@@ -248,7 +251,10 @@ export class ManagedDevRuntime {
           console.log(`${LOG_PREFIX} app id: ${appId}`);
         } else {
           const serverConfig = typeof serverOpt === "object" ? serverOpt : {};
-          adminSecret = serverConfig.adminSecret ?? `jazz-dev-${randomUUID().slice(0, 8)}`;
+          adminSecret =
+            serverConfig.adminSecret ??
+            options.adminSecret ??
+            `jazz-dev-${randomUUID().slice(0, 8)}`;
           const envAppId = await readEnvAppId(envPath, this.envKeys.appId);
           appId =
             process.env[this.envKeys.appId] ??
@@ -284,6 +290,7 @@ export class ManagedDevRuntime {
             serverUrl,
             appId,
             dataDir: this.serverHandle.dataDir,
+            adminSecret,
           });
         }
 


### PR DESCRIPTION
## Summary

- The dev plugins (`vite`, `next`, `sveltekit`, `expo`) accept `adminSecret` both at the root of `JazzPluginOptions` and nested under `server`. Only the external-server branches in `ManagedDevRuntime.initialize` consulted the root field; the managed local-server branch read `server.adminSecret` exclusively, silently falling back to a random `jazz-dev-XXXXXXXX` when callers set the root option. This made root `adminSecret` look like a no-op.
- Mirrors the precedence already used a few lines below for `appId`: nested wins, root falls through, random as last resort.
- Surfaces the resolved admin secret in the managed-server startup banner and prints the inspector link from `expo.ts` so the value is visible the same way it is for `vite` / `next`.

## Test plan

- [x] New regression test in `packages/jazz-tools/src/dev/expo.test.ts` spawns a managed server with only the root `adminSecret`, hits `/apps/:id/schemas` with that secret, and asserts the server accepts it. Red before the fix, green after.
- [x] Full `pnpm vitest run src/dev/` suite (60 tests) still passes.
- [x] `tsc --noEmit` clean.