### PR TITLE
fix(jazz-tools): use bundled webpki roots for native WS TLS

### DIFF
--- a/.changeset/native-ws-tls-mobile-roots.md
+++ b/.changeset/native-ws-tls-mobile-roots.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix native WebSocket TLS handshakes failing on mobile (Expo/React Native) when the OS root certificate store is empty or unavailable, by falling back to bundled `webpki` roots only when no native roots are loaded.

--- a/.github/workflows/expo-android-maestro-e2e.yml
+++ b/.github/workflows/expo-android-maestro-e2e.yml
@@ -254,6 +254,19 @@ jobs:
           echo "$HEALTH_BODY"
           echo "$HEALTH_BODY" | grep -F '"status":"healthy"'
 
+      - name: Push schema and permissions to sandbox server
+        # In dev, the Expo Metro plugin (`withJazz` in metro.config.mjs) publishes
+        # schema.ts and permissions.ts on every Metro start. The release APK never
+        # runs Metro, so we have to publish them out-of-band before the app can
+        # connect — otherwise the server has no schema and every client request
+        # fails.
+        working-directory: examples/todo-client-localfirst-expo
+        env:
+          JAZZ_APP_ID: ${{ env.JAZZ_E2E_APP_ID }}
+          JAZZ_SERVER_URL: ${{ env.SERVER_PUBLIC_URL }}
+          JAZZ_ADMIN_SECRET: ${{ env.JAZZ_E2E_ADMIN_SECRET }}
+        run: pnpm exec jazz-tools deploy "$JAZZ_APP_ID"
+
       - name: Build release APK
         working-directory: examples/todo-client-localfirst-expo/android
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1772,6 +1772,7 @@ dependencies = [
  "opfs-btree",
  "postcard",
  "rand 0.8.5",
+ "rcgen",
  "reqwest",
  "rocksdb",
  "rusqlite",
@@ -2818,6 +2819,18 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -4950,6 +4963,15 @@ name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,7 +1444,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1775,6 +1775,8 @@ dependencies = [
  "reqwest",
  "rocksdb",
  "rusqlite",
+ "rustls",
+ "rustls-native-certs",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -1793,6 +1795,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "web-time",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2935,7 +2938,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -3025,6 +3028,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3791,6 +3795,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -4565,6 +4570,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/crates/jazz-tools/Cargo.toml
+++ b/crates/jazz-tools/Cargo.toml
@@ -134,6 +134,7 @@ serde = { version = "1", features = ["derive"] }
 futures = "0.3"
 tokio = { version = "1", features = ["test-util", "full"] }
 tower = { version = "0.5", features = ["util"] }
+rcgen = { version = "0.13", default-features = false, features = ["ring"] }
 
 [[bench]]
 name = "realistic_phase1"

--- a/crates/jazz-tools/Cargo.toml
+++ b/crates/jazz-tools/Cargo.toml
@@ -21,7 +21,14 @@ rocksdb = ["dep:rocksdb"]
 sqlite = ["dep:rusqlite"]
 runtime-tokio = ["dep:tokio"]
 transport = []
-transport-websocket = ["transport", "runtime-tokio", "dep:tokio-tungstenite"]
+transport-websocket = [
+  "transport",
+  "runtime-tokio",
+  "dep:tokio-tungstenite",
+  "dep:rustls",
+  "dep:rustls-native-certs",
+  "dep:webpki-roots",
+]
 client = ["runtime-tokio", "transport-websocket", "dep:thiserror", "dep:tokio"]
 server = [
   "transport-websocket",
@@ -73,7 +80,18 @@ rocksdb = { version = "0.24", default-features = false, features = ["lz4", "zstd
 rusqlite = { version = "0.34", features = ["bundled"], optional = true }
 
 axum = { version = "0.7", features = ["ws"], optional = true }
-tokio-tungstenite = { version = "0.24", features = ["rustls-tls-native-roots"], optional = true }
+tokio-tungstenite = { version = "0.24", features = [
+  "rustls-tls-native-roots",
+  "rustls-tls-webpki-roots",
+], optional = true }
+rustls = { version = "0.23", default-features = false, features = [
+  "std",
+  "tls12",
+  "ring",
+  "logging",
+], optional = true }
+rustls-native-certs = { version = "0.8", optional = true }
+webpki-roots = { version = "0.26", optional = true }
 bytes = { version = "1", optional = true }
 clap = { version = "4", features = ["derive", "env"], optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }

--- a/crates/jazz-tools/src/ws_stream/native.rs
+++ b/crates/jazz-tools/src/ws_stream/native.rs
@@ -11,17 +11,44 @@ pub struct NativeWsStream {
     inner: WebSocketStream<MaybeTlsStream<TcpStream>>,
 }
 
-// Build a rustls root store that combines the OS trust store (when reachable)
-// with Mozilla's bundled webpki-roots. On Android/iOS the native store is
-// frequently empty or unreadable from a Rust binary, so the bundled roots are
-// what actually let mobile clients reach the cloud/edge over wss://.
+// Build a rustls root store from the OS trust store, falling back to Mozilla's
+// bundled webpki-roots only when the native store yields zero usable anchors.
+//
+// We do NOT union webpki-roots with a populated native store: doing so would
+// silently re-introduce CAs that an administrator or enterprise policy has
+// distrusted, undermining OS-level trust restrictions on desktop.
+//
+// The fallback exists for platforms where `rustls-native-certs` cannot reach
+// the OS trust store at all — most notably Android (anchors live in
+// `AndroidCAStore`, accessible only via JNI), and frequently iOS depending on
+// linkage. Without the fallback, every `wss://` handshake on those platforms
+// fails with `UnknownIssuer`.
 fn root_store() -> rustls::RootCertStore {
-    let mut roots = rustls::RootCertStore::empty();
     let native = rustls_native_certs::load_native_certs();
-    for cert in native.certs {
-        let _ = roots.add(cert);
+    let native_error_count = native.errors.len();
+    build_root_store_from_native(native.certs, native_error_count)
+}
+
+fn build_root_store_from_native(
+    native_certs: Vec<rustls::pki_types::CertificateDer<'static>>,
+    native_error_count: usize,
+) -> rustls::RootCertStore {
+    let mut roots = rustls::RootCertStore::empty();
+    let mut native_added = 0usize;
+    for cert in native_certs {
+        if roots.add(cert).is_ok() {
+            native_added += 1;
+        }
     }
-    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+
+    if native_added == 0 {
+        tracing::debug!(
+            errors = native_error_count,
+            "native cert store returned no usable anchors; falling back to bundled webpki-roots"
+        );
+        roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    }
+
     roots
 }
 
@@ -81,13 +108,18 @@ mod tests {
     use tokio_tungstenite::accept_async;
 
     #[test]
-    fn root_store_includes_bundled_webpki_roots_for_mobile_tls() {
-        let roots = root_store();
-        // The OS trust store is empty/unavailable on Android and iOS from Rust;
-        // we rely on webpki-roots to give us a working set of CAs there. Assert
-        // we have at least every bundled anchor so mobile can validate wss://.
-        assert!(roots.len() >= webpki_roots::TLS_SERVER_ROOTS.len());
+    fn empty_native_store_falls_back_to_bundled_webpki_roots() {
+        // Mobile case: OS trust store unreachable / empty. The fallback must
+        // populate the store with the bundled Mozilla anchors so wss:// works.
+        let roots = build_root_store_from_native(vec![], 3);
+        assert_eq!(roots.len(), webpki_roots::TLS_SERVER_ROOTS.len());
     }
+
+    // The "populated native store does not pull in webpki-roots" branch is
+    // trivially correct from inspection (the fallback is gated on
+    // `native_added == 0`) and exercising it would require synthesising a
+    // valid X.509 DER cert as a fixture, which adds binary blobs or a
+    // cert-generation dev-dep just to assert a one-line conditional.
 
     #[tokio::test]
     async fn native_ws_stream_send_recv_roundtrip() {

--- a/crates/jazz-tools/src/ws_stream/native.rs
+++ b/crates/jazz-tools/src/ws_stream/native.rs
@@ -1,18 +1,49 @@
 use crate::transport_manager::StreamAdapter;
 use futures::{SinkExt, StreamExt};
+use std::sync::{Arc, OnceLock};
 use tokio::net::TcpStream;
 use tokio_tungstenite::tungstenite::Message;
-use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async};
+use tokio_tungstenite::{
+    Connector, MaybeTlsStream, WebSocketStream, connect_async_tls_with_config,
+};
 
 pub struct NativeWsStream {
     inner: WebSocketStream<MaybeTlsStream<TcpStream>>,
+}
+
+// Build a rustls root store that combines the OS trust store (when reachable)
+// with Mozilla's bundled webpki-roots. On Android/iOS the native store is
+// frequently empty or unreadable from a Rust binary, so the bundled roots are
+// what actually let mobile clients reach the cloud/edge over wss://.
+fn root_store() -> rustls::RootCertStore {
+    let mut roots = rustls::RootCertStore::empty();
+    let native = rustls_native_certs::load_native_certs();
+    for cert in native.certs {
+        let _ = roots.add(cert);
+    }
+    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    roots
+}
+
+fn rustls_connector() -> Connector {
+    static CONFIG: OnceLock<Arc<rustls::ClientConfig>> = OnceLock::new();
+    let config = CONFIG
+        .get_or_init(|| {
+            let cfg = rustls::ClientConfig::builder()
+                .with_root_certificates(root_store())
+                .with_no_client_auth();
+            Arc::new(cfg)
+        })
+        .clone();
+    Connector::Rustls(config)
 }
 
 impl StreamAdapter for NativeWsStream {
     type Error = tokio_tungstenite::tungstenite::Error;
 
     async fn connect(url: &str) -> Result<Self, Self::Error> {
-        let (ws, _) = connect_async(url).await?;
+        let (ws, _) =
+            connect_async_tls_with_config(url, None, false, Some(rustls_connector())).await?;
         Ok(Self { inner: ws })
     }
 
@@ -48,6 +79,15 @@ mod tests {
     use super::*;
     use tokio::net::TcpListener;
     use tokio_tungstenite::accept_async;
+
+    #[test]
+    fn root_store_includes_bundled_webpki_roots_for_mobile_tls() {
+        let roots = root_store();
+        // The OS trust store is empty/unavailable on Android and iOS from Rust;
+        // we rely on webpki-roots to give us a working set of CAs there. Assert
+        // we have at least every bundled anchor so mobile can validate wss://.
+        assert!(roots.len() >= webpki_roots::TLS_SERVER_ROOTS.len());
+    }
 
     #[tokio::test]
     async fn native_ws_stream_send_recv_roundtrip() {

--- a/crates/jazz-tools/src/ws_stream/native.rs
+++ b/crates/jazz-tools/src/ws_stream/native.rs
@@ -115,11 +115,23 @@ mod tests {
         assert_eq!(roots.len(), webpki_roots::TLS_SERVER_ROOTS.len());
     }
 
-    // The "populated native store does not pull in webpki-roots" branch is
-    // trivially correct from inspection (the fallback is gated on
-    // `native_added == 0`) and exercising it would require synthesising a
-    // valid X.509 DER cert as a fixture, which adds binary blobs or a
-    // cert-generation dev-dep just to assert a one-line conditional.
+    #[test]
+    fn populated_native_store_does_not_extend_with_bundled_webpki_roots() {
+        // Desktop case: OS trust store has anchors. Unioning bundled
+        // webpki-roots on top would silently re-introduce CAs that an admin
+        // or enterprise policy has distrusted, so the resulting store must
+        // contain only the native anchor we provided.
+        let cert = rcgen::generate_simple_self_signed(vec!["jazz-tls-fixture.local".into()])
+            .expect("rcgen self-signed");
+        let native = vec![cert.cert.der().clone()];
+
+        let roots = build_root_store_from_native(native, 0);
+        assert_eq!(
+            roots.len(),
+            1,
+            "populated native store must not pull in bundled webpki-roots"
+        );
+    }
 
     #[tokio::test]
     async fn native_ws_stream_send_recv_roundtrip() {


### PR DESCRIPTION
## Summary

- `NativeWsStream` was using `tokio-tungstenite`'s default `Connector`, which builds rustls from `rustls-native-certs`. On Android (and frequently iOS) the OS trust store is unreachable from a Rust binary, so the `RootCertStore` came back empty and every `wss://` handshake failed with `UnknownIssuer` — breaking RN clients connecting to cloud and edge tier.
- Construct an explicit `Connector::Rustls`. The trust store is built **strictly from the OS native store**, with `webpki-roots` used **only as a fallback when the native store yields zero usable anchors**. The `ClientConfig` is built once via `OnceLock` to avoid re-parsing certs per connection.
- `rustls` / `rustls-native-certs` / `webpki-roots` are pinned to the same versions `tokio-tungstenite 0.24` already pulls in, so there is no duplicate `rustls` in the binary and `Connector::Rustls(Arc<ClientConfig>)` types match.

## Why fallback, not union

An earlier draft unconditionally appended `webpki-roots` on top of the native store. That subtly broke security guarantees on desktop: environments that rely on OS trust restrictions (enterprise-managed trust stores, administrator-distrusted roots) would silently re-accept CAs because the bundled Mozilla set re-introduced them.

The fallback shape preserves OS trust policy wherever the OS is reachable, and only kicks in when the native store is genuinely unusable (mobile, or stripped-down environments).

## Why not just enable `rustls-tls-webpki-roots` on tokio-tungstenite?

That feature only compiles the Mozilla CA bundle into the binary; it doesn't change which root source the default connector picks. The default still chose native roots first, returned an empty store on RN, and never consulted webpki. Crates don't chain root sources automatically — you have to build a `ClientConfig` whose store is constructed by your own logic.

## Test plan

- [x] `cargo test -p jazz-tools --features transport-websocket --no-default-features --lib ws_stream::native` — 3/3 pass (incl. new `empty_native_store_falls_back_to_bundled_webpki_roots`).
- [x] `cargo build -p jazz-tools --features client` and `--features server` — clean.
- [x] Verify on a real Android RN build that `wss://` to cloud/edge succeeds.
- [x] Verify on a real iOS RN build that `wss://` to cloud/edge succeeds.
- [ ] Verify on desktop with an admin-distrusted CA that the previously-rejected cert is **still rejected** (confirms no webpki re-introduction).