### PR TITLE
Preserve schema loader defaults

### DIFF
--- a/.changeset/lossless-schema-loader-roundtrip.md
+++ b/.changeset/lossless-schema-loader-roundtrip.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Preserve column defaults and counter merge strategies when loading typed-app schemas through the CLI schema loader, keeping the AST and wasm schema round-trip lossless for fields both representations support.

--- a/packages/jazz-tools/src/schema-loader.test.ts
+++ b/packages/jazz-tools/src/schema-loader.test.ts
@@ -1,0 +1,46 @@
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { schemaToWasm } from "./codegen/schema-reader.js";
+import { loadCompiledSchema } from "./schema-loader.js";
+
+const WITH_DEFAULTS_DIR = fileURLToPath(
+  new URL("./testing/fixtures/with-defaults", import.meta.url),
+);
+
+describe("loadCompiledSchema", () => {
+  it("keeps typed-app schema and wasm schema losslessly aligned", async () => {
+    const { app } = (await import("./testing/fixtures/with-defaults/schema.js")) as {
+      app: { wasmSchema: unknown };
+    };
+    const loaded = await loadCompiledSchema(WITH_DEFAULTS_DIR);
+
+    expect(schemaToWasm(loaded.schema)).toEqual(loaded.wasmSchema);
+    expect(loaded.wasmSchema).toEqual(app.wasmSchema);
+
+    const todos = loaded.schema.tables.find((table) => table.name === "todos");
+    const doneColumn = todos?.columns.find((column) => column.name === "done");
+    const tagsColumn = todos?.columns.find((column) => column.name === "tags");
+    const metadataColumn = todos?.columns.find((column) => column.name === "metadata");
+    const avatarColumn = todos?.columns.find((column) => column.name === "avatar");
+    const counter = loaded.schema.tables.find((table) => table.name === "counters");
+    const countColumn = counter?.columns.find((column) => column.name === "count");
+
+    expect(doneColumn?.default).toBe(false);
+    expect(tagsColumn?.default).toEqual(["work", "home"]);
+    expect(metadataColumn?.default).toEqual({ createdBy: "alice" });
+    expect(avatarColumn?.default).toEqual(new Uint8Array([0, 1, 255]));
+    expect(countColumn?.mergeStrategy).toBe("counter");
+    expect(loaded.wasmSchema).toEqual(
+      expect.objectContaining({
+        todos: expect.objectContaining({
+          columns: expect.arrayContaining([
+            expect.objectContaining({
+              name: "done",
+              default: { type: "Boolean", value: false },
+            }),
+          ]),
+        }),
+      }),
+    );
+  });
+});

--- a/packages/jazz-tools/src/schema-loader.ts
+++ b/packages/jazz-tools/src/schema-loader.ts
@@ -6,7 +6,13 @@ import { build } from "esbuild";
 import { schemaToWasm } from "./codegen/schema-reader.js";
 import { getCollectedSchema, resetCollectedState } from "./dsl.js";
 import type { Column, OperationPolicy, Schema, SqlType, TablePolicies } from "./schema.js";
-import type { ColumnDescriptor, ColumnType, TableSchema, WasmSchema } from "./drivers/types.js";
+import type {
+  ColumnDescriptor,
+  ColumnType,
+  TableSchema,
+  Value,
+  WasmSchema,
+} from "./drivers/types.js";
 import { schemaDefinitionToAst } from "./migrations.js";
 import type { CompiledPermissionsMap } from "./schema-permissions.js";
 import { validatePermissionsAgainstSchema } from "./schema-permissions.js";
@@ -86,12 +92,56 @@ function columnTypeToSqlType(columnType: ColumnType): SqlType {
   }
 }
 
+function wasmValueToDefault(value: Value, columnType: ColumnType): unknown {
+  switch (value.type) {
+    case "Null":
+      return null;
+    case "Integer":
+    case "BigInt":
+    case "Double":
+    case "Boolean":
+    case "Text":
+    case "Timestamp":
+    case "Uuid":
+      if (columnType.type === "Json") {
+        return JSON.parse(String(value.value));
+      }
+      return value.value;
+    case "Bytea":
+      return new Uint8Array(value.value);
+    case "Array": {
+      if (columnType.type !== "Array") {
+        throw new Error("Array default does not match column type.");
+      }
+      return value.value.map((inner) => wasmValueToDefault(inner, columnType.element));
+    }
+    case "Row":
+      throw new Error("Root schema loading does not yet support row-valued defaults.");
+  }
+}
+
+function columnMergeStrategyToAst(
+  strategy: ColumnDescriptor["merge_strategy"],
+): Column["mergeStrategy"] {
+  switch (strategy) {
+    case undefined:
+      return undefined;
+    case "Counter":
+      return "counter";
+  }
+}
+
 function wasmColumnToAst(column: ColumnDescriptor): Column {
   return {
     name: column.name,
     sqlType: columnTypeToSqlType(column.column_type),
     nullable: column.nullable,
+    default:
+      column.default === undefined
+        ? undefined
+        : wasmValueToDefault(column.default, column.column_type),
     references: column.references,
+    mergeStrategy: columnMergeStrategyToAst(column.merge_strategy),
   };
 }
 

--- a/packages/jazz-tools/src/testing/fixtures/with-defaults/schema.ts
+++ b/packages/jazz-tools/src/testing/fixtures/with-defaults/schema.ts
@@ -1,0 +1,15 @@
+import { col } from "../../../dsl.js";
+import { defineApp } from "../../../typed-app.js";
+
+export const app = defineApp({
+  todos: {
+    title: col.string(),
+    done: col.boolean().default(false),
+    tags: col.array(col.string()).default(["work", "home"]),
+    metadata: col.json().default({ createdBy: "alice" }),
+    avatar: col.bytes().default(new Uint8Array([0, 1, 255])),
+  },
+  counters: {
+    count: col.int().merge("counter") as ReturnType<typeof col.int>,
+  },
+});


### PR DESCRIPTION
## Summary

Make the CLI schema loader's wasm-to-AST conversion preserve column fields that the AST already supports:

- column defaults, including arrays, JSON, byte arrays, and null
- counter merge strategies

This keeps `LoadedSchemaProject.schema`, `schemaToWasm(loaded.schema)`, and the typed app's original `wasmSchema` aligned instead of bypassing the lossy AST round-trip.

## Root Cause

`wasmColumnToAst()` only projected `name`, `sqlType`, `nullable`, and `references` from `ColumnDescriptor`. When loading a typed app export, `.default(...)` and `merge("counter")` survived in the app's runtime `wasmSchema`, but were dropped from the AST before the CLI recomputed the schema hash.

## Validation

- `corepack pnpm install`
- `corepack pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/schema-loader.test.ts` (red before the fix, green after)
- `corepack pnpm --filter jazz-tools build`
- `corepack pnpm --filter jazz-tools test`

Note: the first full test run failed before build artifacts existed (`jazz-wasm` / `jazz-napi` resolution failures). After running the package build, the full `jazz-tools` test script passed.