### PR TITLE
fix: use output schema from JSON standard schema

### DIFF
--- a/.changeset/better-walls-call.md
+++ b/.changeset/better-walls-call.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Use output schema from JSON standard schema for the stored schema of `json` columns

--- a/packages/jazz-tools/src/dsl.test.ts
+++ b/packages/jazz-tools/src/dsl.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { StandardJSONSchemaV1 } from "@standard-schema/spec";
 import {
   col,
   getCollectedMigration,
@@ -66,6 +67,32 @@ describe("bytes DSL API", () => {
     expect(col.bytes()._sqlType).toBe("BYTEA");
     expect(col.add.bytes({ default: new Uint8Array([0]) }).sqlType).toBe("BYTEA");
     expect(col.drop.bytes({ backwardsDefault: new Uint8Array([0]) }).sqlType).toBe("BYTEA");
+  });
+});
+
+describe("json DSL API", () => {
+  it("stores the Standard Schema output JSON schema", () => {
+    resetCollectedState();
+    const taskEstimateSchema = {
+      "~standard": {
+        version: 1,
+        vendor: "jazz-test",
+        jsonSchema: {
+          input: () => ({ type: "string" }),
+          output: () => ({ type: "number" }),
+        },
+      },
+    } satisfies StandardJSONSchemaV1<string, number>;
+
+    table("tasks", {
+      estimate: col.json(taskEstimateSchema),
+    });
+
+    expect(getCollectedSchema().tables[0]?.columns[0]).toEqual({
+      name: "estimate",
+      sqlType: { kind: "JSON", schema: { type: "number" } },
+      nullable: false,
+    });
   });
 });
 

--- a/packages/jazz-tools/src/dsl.ts
+++ b/packages/jazz-tools/src/dsl.ts
@@ -47,21 +47,12 @@ function isJsonObject(value: unknown): value is JsonSchema {
 }
 
 function normalizeJsonSchema<Output>(schema: JsonSchemaSource<Output>): JsonSchema {
-  const maybeStandard = (
-    schema as {
-      "~standard"?: {
-        jsonSchema?: {
-          input?: (options: { target: string }) => unknown;
-        };
-      };
-    }
-  )["~standard"];
-  const converter = maybeStandard?.jsonSchema?.input;
-  if (typeof converter === "function") {
-    const converted = converter({ target: "draft-07" });
+  const maybeStandard = "~standard" in schema ? schema["~standard"] : undefined;
+  if (maybeStandard) {
+    const converted = maybeStandard.jsonSchema.output({ target: "draft-07" });
     if (!isJsonObject(converted)) {
       throw new Error(
-        "JSON schema conversion failed: expected an object from ~standard.jsonSchema.input(...).",
+        "JSON schema conversion failed: expected an object from ~standard.jsonSchema.output(...).",
       );
     }
     return converted;


### PR DESCRIPTION
## Summary

Trusted re-host of external PR #666 so secret-backed CI can run from a branch in `garden-co/jazz2`.

This cherry-picks Gabrola's original commits with attribution preserved:

- `d3aac0f8b43a02b5f4afbeb9194f0100ce098b12` — fix: use output schema from JSON standard schema
- `76bf750c904e58b8ea1550e3340799d744ef8ffc` — chore: add changeset

Original PR: https://github.com/garden-co/jazz2/pull/666

## What changed

`col.json(schema)` now stores the JSON Schema from Standard Schema's output shape instead of the input shape, matching the TypeScript type inferred via `StandardJSONSchemaV1.InferOutput<Schema>`.

A regression test covers a Standard JSON Schema source whose input and output schemas differ, ensuring the collected Jazz schema stores the output schema.

A patch changeset for `jazz-tools` is included.

## Review notes

CI-safety review: the copied changes touch only `.changeset/better-walls-call.md`, `packages/jazz-tools/src/dsl.ts`, and `packages/jazz-tools/src/dsl.test.ts`; no workflow files, package scripts, lockfiles, or CI-sensitive hooks are changed.

Implementation review: the intent and implementation look sound.

## Validation

- `pnpm --filter jazz-wasm build`
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/dsl.test.ts`
- `pnpm --filter jazz-tools build:runtime`

Fork PR #666 also passed `lint`, `test-ts`, `test-rust`, Android artifact build, and both sandbox binary builds after merging current `main`; its remaining failures were secret/auth related for forked PR infrastructure.