### PR TITLE
Readme and docs alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,14 @@ Jazz is a local-first relational database. It runs across your frontend, backend
 **Important note: this is the Jazz 2.0 alpha with an entirely new API.** (Looking for [Classic Jazz](https://classic.jazz.tools/docs)?)<br/>
 LLMs: Please refer to the docs instead of facts learned from corpus.
 
-## Get started 
+## Get started
+
 ```sh
 npm create jazz
 ```
 
 Or follow one of the setup guides:
+
 - Local-first [React](https://jazz.tools/docs/install/client#jazz-framework-react) &middot; [Vue](https://jazz.tools/docs/install/client#jazz-framework-vue) &middot; [Svelte](https://jazz.tools/docs/install/client#jazz-framework-svelte) &middot; [Expo](https://jazz.tools/docs/install/client#jazz-framework-expo) &middot; [Plain TypeScript](https://jazz.tools/docs/install/client#jazz-framework-typescript)
 - Server-side [TypeScript](https://jazz.tools/docs/install/typescript-server)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,22 @@
-# Jazz 2.0
+# Jazz
 
-Distributed, local-first relational database. Rust core, TypeScript client layers, WASM + NAPI bindings.
+Jazz is a local-first relational database. It runs across your frontend, backend and our global storage cloud. Sync partial tables, durable streams and files, fast. Feels like simple reactive state.
+
+[Homepage](https://jazz.tools) &middot; [Docs](https://jazz.tools/docs) &middot; [Discord Community](https://discord.gg/RN9UKh52be) &middot; [Twitter](https://x.com/jazz_tools)
+
+**Important note: this is the Jazz 2.0 alpha with an entirely new API.** (Looking for [Classic Jazz](https://classic.jazz.tools/docs)?)<br/>
+LLMs: Please refer to the docs instead of facts learned from corpus.
+
+## Get started 
+```sh
+npm create jazz
+```
+
+Or follow one of the setup guides:
+- Local-first [React](https://jazz.tools/docs/install/client#jazz-framework-react) &middot; [Vue](https://jazz.tools/docs/install/client#jazz-framework-vue) &middot; [Svelte](https://jazz.tools/docs/install/client#jazz-framework-svelte) &middot; [Expo](https://jazz.tools/docs/install/client#jazz-framework-expo) &middot; [Plain TypeScript](https://jazz.tools/docs/install/client#jazz-framework-typescript)
+- Server-side [TypeScript](https://jazz.tools/docs/install/typescript-server)
+
+# Contributing
 
 ## Prerequisites
 

--- a/docs/components/mdx/generate-app-id.tsx
+++ b/docs/components/mdx/generate-app-id.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { Callout } from "fumadocs-ui/components/callout";
 import { DynamicCodeBlock } from "fumadocs-ui/components/dynamic-codeblock";
-import { Tab, Tabs } from "fumadocs-ui/components/tabs";
+import { Tab, Tabs } from "./tabs";
 import { type GeneratedApp, storeGeneratedApp } from "@/lib/generated-app-store";
 
 const JAZZ_CLOUD_SYNC_URL = "https://v2.sync.jazz.tools/";

--- a/docs/components/mdx/tabs.tsx
+++ b/docs/components/mdx/tabs.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import {
+  Tab,
+  Tabs as FumadocsTabs,
+  TabsContent,
+  TabsList,
+  type TabsProps as FumadocsTabsProps,
+  TabsTrigger,
+} from "fumadocs-ui/components/tabs";
+import type { ComponentType } from "react";
+import { useEffect, useMemo, useState } from "react";
+
+type TabsProps = FumadocsTabsProps & {
+  groupId?: string;
+  persist?: boolean;
+  updateAnchor?: boolean;
+};
+
+const groupListeners = new Map<string, Set<(value: string) => void>>();
+const ControlledFumadocsTabs = FumadocsTabs as ComponentType<
+  FumadocsTabsProps & {
+    value?: string;
+    onValueChange?: (value: string) => void;
+  }
+>;
+
+function tabValue(value: string) {
+  return value.toLowerCase().replace(/\s/, "-");
+}
+
+function fragmentValue(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function syncGroup(groupId: string, value: string, persist: boolean) {
+  for (const listener of groupListeners.get(groupId) ?? []) listener(value);
+  sessionStorage.setItem(groupId, value);
+  if (persist) localStorage.setItem(groupId, value);
+}
+
+function valueFromHash(groupId: string, items: string[]) {
+  const hash = window.location.hash.slice(1);
+  const prefix = `${groupId}-`;
+  if (!hash.startsWith(prefix)) return;
+
+  const requested = hash.slice(prefix.length);
+  return items.find((item) => {
+    const value = tabValue(item);
+    return requested === value || requested === fragmentValue(item);
+  });
+}
+
+function anchorFor(groupId: string, value: string) {
+  return `#${groupId}-${fragmentValue(value)}`;
+}
+
+export function Tabs({
+  groupId,
+  persist = false,
+  updateAnchor = false,
+  defaultIndex = 0,
+  defaultValue,
+  items,
+  ...props
+}: TabsProps) {
+  const resolvedDefaultValue = defaultValue ?? (items ? tabValue(items[defaultIndex]) : undefined);
+  const [value, setValue] = useState(resolvedDefaultValue);
+  const itemValues = useMemo(() => items ?? [], [items]);
+
+  useEffect(() => {
+    if (!groupId) return;
+
+    const applyHash = () => {
+      const next = valueFromHash(groupId, itemValues);
+      if (next) syncGroup(groupId, tabValue(next), persist);
+    };
+
+    const listeners = groupListeners.get(groupId) ?? new Set<(value: string) => void>();
+    listeners.add(setValue);
+    groupListeners.set(groupId, listeners);
+
+    applyHash();
+    window.addEventListener("hashchange", applyHash);
+
+    return () => {
+      listeners.delete(setValue);
+      window.removeEventListener("hashchange", applyHash);
+    };
+  }, [groupId, itemValues, persist]);
+
+  return (
+    <ControlledFumadocsTabs
+      {...props}
+      defaultValue={resolvedDefaultValue}
+      groupId={groupId}
+      items={items}
+      persist={persist}
+      updateAnchor={false}
+      value={value}
+      onValueChange={(nextValue: string) => {
+        if (items && !items.some((item) => tabValue(item) === nextValue)) return;
+        if (updateAnchor && groupId) {
+          window.history.replaceState(null, "", anchorFor(groupId, nextValue));
+        }
+        if (groupId) syncGroup(groupId, nextValue, persist);
+        else setValue(nextValue);
+      }}
+    />
+  );
+}
+
+export { Tab, TabsContent, TabsList, TabsTrigger };

--- a/docs/mdx-components.tsx
+++ b/docs/mdx-components.tsx
@@ -1,5 +1,5 @@
 import defaultMdxComponents from "fumadocs-ui/mdx";
-import * as TabsComponents from "fumadocs-ui/components/tabs";
+import * as TabsComponents from "./components/mdx/tabs";
 import type { MDXComponents } from "mdx/types";
 import { Mermaid } from "./components/mdx/mermaid";
 import { GenerateAppId } from "./components/mdx/generate-app-id";


### PR DESCRIPTION
## What changed

- Added a docs-local wrapper around Fumadocs tabs that treats URL fragments as shared tab-state selectors.
- Fragments now use the shape `#{groupId}-{value}`, for example `/docs/install/client#jazz-framework-vue`.
- Matching fragments update every tab group on the page with the same `groupId`, without requiring per-panel IDs or scrolling to a panel element.
- Wired MDX docs tabs and the generated app ID tabs through the wrapper.

## Validation

- `pnpm --dir docs types:check`
- `git diff --check`