### PR TITLE
Fix create-jazz alpha latest release

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -31,7 +31,7 @@
     "world-tour": "0.0.0",
     "cloudflare-worker-runtime-ts": "0.1.0",
     "moon-lander-react": "0.1.0",
-    "create-jazz": "2.0.0",
+    "create-jazz": "2.0.0-alpha.6",
     "next-betterauth": "0.1.0",
     "next-hybrid": "0.1.0",
     "next-localfirst": "0.1.0",

--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -961,6 +961,9 @@ jobs:
       - name: Build jazz-tools TypeScript package
         run: pnpm --filter jazz-tools build
 
+      - name: Build create-jazz TypeScript package
+        run: pnpm --filter create-jazz build
+
       - name: Verify jazz-tools publish artifacts
         run: |
           test -f packages/jazz-tools/dist/index.js
@@ -1010,12 +1013,14 @@ jobs:
               set_pkg_version_if_needed crates/jazz-wasm
               set_pkg_version_if_needed crates/jazz-napi
               set_pkg_version_if_needed crates/jazz-rn
+              set_pkg_version_if_needed packages/create-jazz
             else
               pnpm release:version
               VERSION=$(node -p 'JSON.parse(require("fs").readFileSync("packages/jazz-tools/package.json","utf8")).version')
               set_pkg_version_if_needed crates/jazz-wasm
               set_pkg_version_if_needed crates/jazz-napi
               set_pkg_version_if_needed crates/jazz-rn
+              set_pkg_version_if_needed packages/create-jazz
             fi
           else
             VERSION=$(node -p 'JSON.parse(require("fs").readFileSync("packages/jazz-tools/package.json","utf8")).version')
@@ -1031,7 +1036,7 @@ jobs:
 
       - name: Guard alpha-only lock-stepped publish versions
         run: |
-          EXPECTED_VERSION="${{ github.event.inputs.version || '' }}" node -e 'const fs=require("fs");const path=require("path");const expected=process.env.EXPECTED_VERSION;const alphaVersion=/^2\.0\.0-alpha\.[0-9A-Za-z.-]+$/;const tools=JSON.parse(fs.readFileSync("packages/jazz-tools/package.json","utf8"));const wasm=JSON.parse(fs.readFileSync("crates/jazz-wasm/package.json","utf8"));const napi=JSON.parse(fs.readFileSync("crates/jazz-napi/package.json","utf8"));const rn=JSON.parse(fs.readFileSync("crates/jazz-rn/package.json","utf8"));if(expected){if(!alphaVersion.test(expected)){throw new Error(`Version override must match 2.0.0-alpha.*, got ${expected}`);}if(tools.version!==expected){throw new Error(`Version override mismatch: expected ${expected}, got ${tools.version}`);}}for(const pkg of [tools,wasm,napi,rn]){if(!alphaVersion.test(pkg.version)){throw new Error(`${pkg.name} version must match 2.0.0-alpha.*, got ${pkg.version}`);}const tag=pkg.publishConfig&&pkg.publishConfig.tag;if(tag&&tag!=="alpha"){throw new Error(`${pkg.name} publishConfig.tag must be alpha, got ${tag}`);}}if(!(tools.version===wasm.version&&tools.version===napi.version&&napi.version===rn.version)){throw new Error(`Versions diverged: tools=${tools.version} wasm=${wasm.version} napi=${napi.version} rn=${rn.version}`);}for(const [name,version] of Object.entries(napi.optionalDependencies||{})){if(version!==napi.version){throw new Error(`napi optional dep ${name} is ${version}, expected ${napi.version}`);}}for(const entry of fs.readdirSync("crates/jazz-napi/npm",{withFileTypes:true})){if(!entry.isDirectory())continue;const pkgPath=path.join("crates/jazz-napi/npm",entry.name,"package.json");const pkg=JSON.parse(fs.readFileSync(pkgPath,"utf8"));if(!alphaVersion.test(pkg.version)){throw new Error(`${pkg.name} version must match 2.0.0-alpha.*, got ${pkg.version}`);}if(pkg.version!==napi.version){throw new Error(`${pkg.name} version ${pkg.version} must match jazz-napi ${napi.version}`);}}console.log(`Alpha-only publish guard passed at ${tools.version}`);'
+          EXPECTED_VERSION="${{ github.event.inputs.version || '' }}" node -e 'const fs=require("fs");const path=require("path");const expected=process.env.EXPECTED_VERSION;const alphaVersion=/^2\.0\.0-alpha\.[0-9A-Za-z.-]+$/;const tools=JSON.parse(fs.readFileSync("packages/jazz-tools/package.json","utf8"));const wasm=JSON.parse(fs.readFileSync("crates/jazz-wasm/package.json","utf8"));const napi=JSON.parse(fs.readFileSync("crates/jazz-napi/package.json","utf8"));const rn=JSON.parse(fs.readFileSync("crates/jazz-rn/package.json","utf8"));const createJazz=JSON.parse(fs.readFileSync("packages/create-jazz/package.json","utf8"));if(expected){if(!alphaVersion.test(expected)){throw new Error(`Version override must match 2.0.0-alpha.*, got ${expected}`);}if(tools.version!==expected){throw new Error(`Version override mismatch: expected ${expected}, got ${tools.version}`);}}for(const pkg of [tools,wasm,napi,rn,createJazz]){if(!alphaVersion.test(pkg.version)){throw new Error(`${pkg.name} version must match 2.0.0-alpha.*, got ${pkg.version}`);}const tag=pkg.publishConfig&&pkg.publishConfig.tag;if(tag&&tag!=="alpha"&&pkg.name!=="create-jazz"){throw new Error(`${pkg.name} publishConfig.tag must be alpha, got ${tag}`);}}if(!(tools.version===wasm.version&&tools.version===napi.version&&napi.version===rn.version&&rn.version===createJazz.version)){throw new Error(`Versions diverged: tools=${tools.version} wasm=${wasm.version} napi=${napi.version} rn=${rn.version} create-jazz=${createJazz.version}`);}for(const [name,version] of Object.entries(napi.optionalDependencies||{})){if(version!==napi.version){throw new Error(`napi optional dep ${name} is ${version}, expected ${napi.version}`);}}for(const entry of fs.readdirSync("crates/jazz-napi/npm",{withFileTypes:true})){if(!entry.isDirectory())continue;const pkgPath=path.join("crates/jazz-napi/npm",entry.name,"package.json");const pkg=JSON.parse(fs.readFileSync(pkgPath,"utf8"));if(!alphaVersion.test(pkg.version)){throw new Error(`${pkg.name} version must match 2.0.0-alpha.*, got ${pkg.version}`);}if(pkg.version!==napi.version){throw new Error(`${pkg.name} version ${pkg.version} must match jazz-napi ${napi.version}`);}}console.log(`Alpha-only publish guard passed at ${tools.version}`);'
 
       - name: Verify packed jazz-wasm payload
         run: |
@@ -1058,6 +1063,15 @@ jobs:
           pnpm --filter jazz-tools pack --pack-destination "${TMP_DIR}"
           TARBALL=$(ls "${TMP_DIR}"/jazz-tools-*.tgz | head -n 1)
           tar -xOf "${TARBALL}" package/package.json | node -e 'let s="";process.stdin.on("data",(d)=>s+=d);process.stdin.on("end",()=>{const p=JSON.parse(s);for(const field of ["dependencies","optionalDependencies","peerDependencies"]){for(const [name,version] of Object.entries(p[field]||{})){if(typeof version==="string"&&version.startsWith("workspace:")){throw new Error(`${field}.${name} uses workspace protocol (${version}) in packed manifest`);}}}console.log(`Packed manifest OK for ${p.name}@${p.version}`);});'
+
+      - name: Verify packed create-jazz manifest
+        run: |
+          TMP_DIR=$(mktemp -d)
+          pnpm --filter create-jazz pack --pack-destination "${TMP_DIR}"
+          TARBALL=$(ls "${TMP_DIR}"/create-jazz-*.tgz | head -n 1)
+          tar -xOf "${TARBALL}" package/package.json | node -e 'let s="";process.stdin.on("data",(d)=>s+=d);process.stdin.on("end",()=>{const p=JSON.parse(s);for(const field of ["dependencies","optionalDependencies","peerDependencies"]){for(const [name,version] of Object.entries(p[field]||{})){if(typeof version==="string"&&version.startsWith("workspace:")){throw new Error(`${field}.${name} uses workspace protocol (${version}) in packed manifest`);}}}console.log(`Packed manifest OK for ${p.name}@${p.version}`);});'
+          tar -tf "${TARBALL}" | grep -q "package/bin/create-jazz.js"
+          tar -tf "${TARBALL}" | grep -q "package/dist/index.js"
 
       - name: Verify packed jazz-tools native binaries and runtime bootstrap
         run: |
@@ -1173,10 +1187,7 @@ jobs:
             pnpm --filter jazz-tools publish --tag alpha --access public --no-git-checks
           fi
 
-      - name: Build create-jazz
-        run: pnpm --filter create-jazz build
-
-      - name: Publish create-jazz (alpha tag)
+      - name: Publish create-jazz (alpha tag, promote latest)
         if: env.RELEASE_MODE == 'publish'
         run: |
           CREATE_JAZZ_VERSION=$(node -p 'JSON.parse(require("fs").readFileSync("packages/create-jazz/package.json","utf8")).version')
@@ -1185,3 +1196,5 @@ jobs:
           else
             pnpm --filter create-jazz publish --tag alpha --access public --no-git-checks
           fi
+
+          npm dist-tag add "create-jazz@${CREATE_JAZZ_VERSION}" latest

--- a/packages/create-jazz/src/release-config.test.ts
+++ b/packages/create-jazz/src/release-config.test.ts
@@ -1,0 +1,24 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(import.meta.dirname, "..", "..", "..");
+
+describe("release config", () => {
+  it("keeps create-jazz on the lockstep Jazz alpha release train", () => {
+    const config = JSON.parse(
+      fs.readFileSync(path.join(repoRoot, ".changeset", "config.json"), "utf8"),
+    ) as { fixed?: string[][] };
+    const preState = JSON.parse(
+      fs.readFileSync(path.join(repoRoot, ".changeset", "pre.json"), "utf8"),
+    ) as { initialVersions?: Record<string, string> };
+
+    const jazzFixedGroup = ["jazz-tools", "jazz-wasm", "jazz-napi", "jazz-rn", "create-jazz"];
+
+    expect(config.fixed).toContainEqual(jazzFixedGroup);
+
+    for (const packageName of jazzFixedGroup) {
+      expect(preState.initialVersions?.[packageName]).toBe("2.0.0-alpha.6");
+    }
+  });
+});


### PR DESCRIPTION
## What

- Keep `create-jazz` in the lockstep Jazz alpha fixed group.
- Seed `create-jazz` from the same `2.0.0-alpha.6` prerelease baseline as the other lockstep packages.
- Include `create-jazz` in the alpha publish workflow: build, version sync, guard, pack verification, publish under `alpha`, then promote that version to the `latest` dist-tag.
- Add a regression test for the lockstep prerelease config.

## Why

A manual `create-jazz@2.0.0` release already exists on npm. When `create-jazz` was added to the fixed group with a stable `2.0.0` prerelease seed, Changesets selected `2.0.1-alpha.*` for the whole fixed group. Seeding it on the alpha train keeps the release at `2.0.0-alpha.*`, while the explicit dist-tag move makes `npm create jazz` resolve to the current alpha.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish-jazz-tools-alpha.yml"); puts "workflow yaml ok"'`
- `pnpm --filter create-jazz test -- src/release-config.test.ts`