### PR TITLE
Fix create-jazz alpha release baseline

### DIFF
--- a/packages/create-jazz/package.json
+++ b/packages/create-jazz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-jazz",
-  "version": "2.0.0",
+  "version": "2.0.0-alpha.39",
   "description": "Scaffold a new Jazz app from a starter template.",
   "license": "MIT",
   "bin": {

--- a/packages/create-jazz/src/release-config.test.ts
+++ b/packages/create-jazz/src/release-config.test.ts
@@ -12,10 +12,14 @@ describe("release config", () => {
     const preState = JSON.parse(
       fs.readFileSync(path.join(repoRoot, ".changeset", "pre.json"), "utf8"),
     ) as { initialVersions?: Record<string, string> };
+    const createJazzPackage = JSON.parse(
+      fs.readFileSync(path.join(repoRoot, "packages", "create-jazz", "package.json"), "utf8"),
+    ) as { version?: string };
 
     const jazzFixedGroup = ["jazz-tools", "jazz-wasm", "jazz-napi", "jazz-rn", "create-jazz"];
 
     expect(config.fixed).toContainEqual(jazzFixedGroup);
+    expect(createJazzPackage.version).toMatch(/^2\.0\.0-alpha\./);
 
     for (const packageName of jazzFixedGroup) {
       expect(preState.initialVersions?.[packageName]).toBe("2.0.0-alpha.6");


### PR DESCRIPTION
## What

- Move the checked-in `create-jazz` package version from stable `2.0.0` back onto the current alpha train at `2.0.0-alpha.39`.
- Extend the release-config guard to assert that `create-jazz` remains a `2.0.0-alpha.*` package while it is part of the lockstep prerelease group.

## Why

PR #685 fixed the Changesets fixed-group config and prerelease seed, but `packages/create-jazz/package.json` on `main` was still `2.0.0`. Because `create-jazz` is now in the fixed group, Changesets uses that stable package version when generating PR #652 and lifts the whole group to `2.0.1-alpha.40`.

With this branch applied, a local `pnpm release:version` simulation computes all five lockstep packages as `2.0.0-alpha.40`.

## Validation

- `pnpm --filter create-jazz test -- src/release-config.test.ts`
- temporary-worktree `pnpm release:version` simulation produced:
  - `jazz-tools: 2.0.0-alpha.40`
  - `jazz-wasm: 2.0.0-alpha.40`
  - `jazz-napi: 2.0.0-alpha.40`
  - `jazz-rn: 2.0.0-alpha.40`
  - `create-jazz: 2.0.0-alpha.40`