### PR TITLE
Add sliceable app schemas

### DIFF
--- a/.changeset/define-sliceable-app.md
+++ b/.changeset/define-sliceable-app.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": minor
+---
+
+Add `schema.defineSliceableApp(schema).slice(...)` for deriving smaller typed app surfaces backed by one complete runtime schema.

--- a/docs/content/docs/schemas/defining-tables.mdx
+++ b/docs/content/docs/schemas/defining-tables.mdx
@@ -64,3 +64,93 @@ Extract precise TypeScript types from any table handle:
 | `s.RowOf<typeof app.todos>`    | The row type (all columns, `id` included)                   |
 | `s.InsertOf<typeof app.todos>` | The insert shape (no `id`, respects optionals and defaults) |
 | `s.WhereOf<typeof app.todos>`  | The `where(...)` input shape for that table                 |
+
+## Very Large Schemas
+
+For most apps, `s.defineApp(schema)` is the right export: it gives you one typed table handle for
+each table in the schema, and Jazz uses the same schema for runtime validation, migrations, query
+planning, and TypeScript inference.
+
+Very large apps can hit a different tradeoff. The runtime schema may need to contain hundreds of
+tables, while a given feature area only works with a much smaller subset. Because typed relations
+and reverse relations are derived from the app schema, asking TypeScript to understand the whole
+graph can make editor and build performance worse than the code you are writing actually needs.
+
+Use `s.defineSliceableApp(schema)` when you want one complete runtime schema but smaller typed app
+surfaces:
+
+```ts title="schema.ts"
+import { schema as s } from "jazz-tools";
+
+const schema = {
+  accounts: s.table({
+    name: s.string(),
+  }),
+  workspaces: s.table({
+    name: s.string(),
+    accountId: s.ref("accounts"),
+  }),
+  catalog_items: s.table({
+    title: s.string(),
+    workspaceId: s.ref("workspaces"),
+  }),
+  orders: s.table({
+    number: s.string(),
+    catalogItemId: s.ref("catalog_items"),
+    buyerId: s.ref("users"),
+  }),
+  shipments: s.table({
+    trackingCode: s.string(),
+    orderId: s.ref("orders"),
+  }),
+  users: s.table({
+    name: s.string(),
+  }),
+  support_tickets: s.table({
+    workspaceId: s.ref("workspaces"),
+    requesterId: s.ref("users"),
+  }),
+};
+
+const sliceableApp = s.defineSliceableApp(schema);
+
+export const commerceApp = sliceableApp.slice(
+  "accounts",
+  "workspaces",
+  "catalog_items",
+  "orders",
+  "shipments",
+);
+export const supportApp = sliceableApp.slice("accounts", "workspaces", "support_tickets");
+```
+
+Each slice returns a normal typed `App` surface for only the selected tables:
+
+```ts
+await db.all(commerceApp.orders.include({ catalogItem: true }));
+await db.all(commerceApp.catalog_items.include({ ordersViaCatalogItem: true }));
+```
+
+Refs to tables inside the slice become typed relations and includes. Refs to tables outside the slice
+remain valid scalar ID columns:
+
+```ts
+type Order = s.RowOf<typeof commerceApp.orders>;
+// Order["catalogItemId"] is string, and commerceApp.orders.include({ catalogItem: true }) is typed.
+// Order["buyerId"] is string, but there is no typed `buyer` include unless `users` is in the slice.
+```
+
+Reverse relations are also derived only from the current slice. In the example above,
+`commerceApp.catalog_items` has `ordersViaCatalogItem`, while `supportApp.workspaces` has
+`support_ticketsViaWorkspace`.
+
+All slices share the complete runtime schema:
+
+```ts
+commerceApp.wasmSchema === sliceableApp.wasmSchema;
+supportApp.wasmSchema === sliceableApp.wasmSchema;
+```
+
+That means schema hashing, migrations, permissions, runtime validation, query planning, inserts,
+updates, and row transforms still see the full schema. The slice only limits the TypeScript app
+graph you ask the compiler to expand.

--- a/packages/jazz-tools/src/index.ts
+++ b/packages/jazz-tools/src/index.ts
@@ -13,6 +13,7 @@ import { definePermissions } from "./permissions/index.js";
 import {
   defineApp,
   defineSchema,
+  defineSliceableApp,
   defineTable,
   TypedTableQueryBuilder,
   permissionIntrospectionColumns,
@@ -23,6 +24,7 @@ import type {
   RowOf as TypedRowOf,
   Schema as TypedSchema,
   SchemaDefinition as TypedSchemaDefinition,
+  SliceableApp as TypedSliceableApp,
   TableDefinition as TypedTableDefinition,
   TableIndex as TypedTableIndex,
   TableMetaOf as TypedTableMetaOf,
@@ -106,6 +108,7 @@ export { schemaToWasm } from "./codegen/schema-reader.js";
 export {
   defineSchema,
   defineApp,
+  defineSliceableApp,
   TypedTableQueryBuilder,
   permissionIntrospectionColumns,
 } from "./typed-app.js";
@@ -138,6 +141,7 @@ export type {
   TableHandle,
   QueryHandle,
   App,
+  SliceableApp,
   TypedApp,
   RowOf,
   InsertOf,
@@ -157,6 +161,7 @@ type RuntimeSchemaNamespace = typeof col & {
   table: typeof defineTable;
   defineSchema: typeof defineSchema;
   defineApp: typeof defineApp;
+  defineSliceableApp: typeof defineSliceableApp;
   defineMigration: typeof defineMigration;
   renameTableFrom: typeof renameTableFrom;
   definePermissions: typeof definePermissions;
@@ -167,6 +172,7 @@ export const schema: RuntimeSchemaNamespace = Object.assign({}, col, {
   table: defineTable,
   defineSchema,
   defineApp,
+  defineSliceableApp,
   defineMigration,
   renameTableFrom,
   definePermissions,
@@ -187,6 +193,11 @@ export namespace schema {
    * App for a given schema.
    */
   export type App<TSchema extends TypedSchema<any> | TypedSchemaDefinition> = TypedApp<TSchema>;
+  /**
+   * App factory for deriving typed slices over one full runtime schema.
+   */
+  export type SliceableApp<TSchema extends TypedSchema<any> | TypedSchemaDefinition> =
+    TypedSliceableApp<TSchema>;
   /**
    * Row type for a given table (all columns, `id` included)
    */

--- a/packages/jazz-tools/src/typed-app.ts
+++ b/packages/jazz-tools/src/typed-app.ts
@@ -1167,6 +1167,18 @@ export type App<TSchema extends SchemaLike> = Simplify<
 
 export type TypedApp<TSchema extends SchemaLike> = App<TSchema>;
 
+type SchemaSlice<
+  TSchema extends SchemaLike,
+  TTables extends readonly TableName<TSchema>[],
+> = Schema<Pick<NormalizedSchema<TSchema>, TTables[number]>>;
+
+export interface SliceableApp<TSchema extends SchemaLike> {
+  readonly wasmSchema: WasmSchema;
+  slice<const TTables extends readonly [TableName<TSchema>, ...TableName<TSchema>[]]>(
+    ...tables: TTables
+  ): App<SchemaSlice<TSchema, TTables>>;
+}
+
 export type RowOf<TTable> = TTable extends { readonly _rowType: infer TRow } ? TRow : never;
 export type InsertOf<TTable> = TTable extends { readonly _initType: infer TInit } ? TInit : never;
 export type TableMetaOf<TTable> =
@@ -1255,9 +1267,60 @@ export function defineApp(
   const normalizedDefinition = definition as unknown as SchemaDefinition;
   const schema = definitionToSchema(normalizedDefinition);
   const wasmSchema = schemaToWasm(schema);
+  return createAppForTables(Object.keys(normalizedDefinition), wasmSchema);
+}
+
+/**
+ * Create a sliceable app from a full schema definition.
+ *
+ * The full schema is compiled for runtime hashing, migrations, validation, and query planning,
+ * while each `.slice(...)` call exposes a smaller typed app surface backed by that same runtime
+ * schema.
+ *
+ * @example
+ * ```typescript
+ * const app = s.defineSliceableApp(schema);
+ * export const orgApp = app.slice("teams", "projects", "members");
+ * ```
+ */
+export function defineSliceableApp<const TSchema extends Schema<any>>(
+  definition: TSchema,
+): SliceableApp<TSchema>;
+export function defineSliceableApp<const TSchema extends SchemaDefinition>(
+  definition: TSchema,
+): SliceableApp<Schema<TSchema>>;
+export function defineSliceableApp(
+  definition: SchemaDefinition | Schema<any>,
+): SliceableApp<Schema<SchemaDefinition>> {
+  const normalizedDefinition = definition as unknown as SchemaDefinition;
+  const schema = definitionToSchema(normalizedDefinition);
+  const wasmSchema = schemaToWasm(schema);
+
+  return {
+    wasmSchema,
+    slice(...tableNames: string[]) {
+      if (tableNames.length === 0) {
+        throw new Error("slice(...) requires at least one table name.");
+      }
+
+      for (const tableName of tableNames) {
+        if (!(tableName in normalizedDefinition)) {
+          throw new Error(`slice(...) references unknown table "${tableName}".`);
+        }
+      }
+
+      return createAppForTables(tableNames, wasmSchema);
+    },
+  } as SliceableApp<Schema<SchemaDefinition>>;
+}
+
+function createAppForTables(
+  tableNames: readonly string[],
+  wasmSchema: WasmSchema,
+): App<Schema<SchemaDefinition>> {
   const tables = {} as Record<string, TypedTableQueryBuilder<any>>;
 
-  for (const tableName of Object.keys(normalizedDefinition)) {
+  for (const tableName of tableNames) {
     tables[tableName] = new TypedTableQueryBuilder(tableName, wasmSchema);
   }
 

--- a/packages/jazz-tools/tests/ts-dsl/typed-app.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/typed-app.test.ts
@@ -64,6 +64,36 @@ const graphSchema = {
 type GraphAppSchema = s.Schema<typeof graphSchema>;
 const graphApp: s.App<GraphAppSchema> = s.defineApp(graphSchema);
 
+const largeSchema = {
+  accounts: s.table({
+    name: s.string(),
+  }),
+  workspaces: s.table({
+    name: s.string(),
+    accountId: s.ref("accounts"),
+  }),
+  catalog_items: s.table({
+    title: s.string(),
+    workspaceId: s.ref("workspaces"),
+  }),
+  orders: s.table({
+    number: s.string(),
+    catalogItemId: s.ref("catalog_items"),
+    buyerId: s.ref("users"),
+  }),
+  shipments: s.table({
+    trackingCode: s.string(),
+    orderId: s.ref("orders"),
+  }),
+  users: s.table({
+    name: s.string(),
+  }),
+  support_tickets: s.table({
+    workspaceId: s.ref("workspaces"),
+    requesterId: s.ref("users"),
+  }),
+};
+
 describe("typed app prototype", () => {
   it("serializes select/include metadata without codegen", () => {
     expect(JSON.parse(app.todos.select("title").include({ project: true })._build())).toEqual({
@@ -326,6 +356,95 @@ describe("typed app prototype", () => {
         done: null,
       };
       void invalidDefaultedNull;
+    }
+  });
+
+  it("creates typed app slices over one full runtime schema", () => {
+    const sliceableApp = s.defineSliceableApp(largeSchema);
+    const commerceApp = sliceableApp.slice(
+      "accounts",
+      "workspaces",
+      "catalog_items",
+      "orders",
+      "shipments",
+    );
+    const supportApp = sliceableApp.slice("accounts", "workspaces", "support_tickets");
+
+    expect(commerceApp.wasmSchema).toBe(sliceableApp.wasmSchema);
+    expect(supportApp.wasmSchema).toBe(sliceableApp.wasmSchema);
+    expect(() => (sliceableApp.slice as (...tables: string[]) => unknown)()).toThrow(
+      "slice(...) requires at least one table name.",
+    );
+    expect(() => (sliceableApp.slice as (...tables: string[]) => unknown)("missing")).toThrow(
+      'slice(...) references unknown table "missing".',
+    );
+    expect(Object.keys(commerceApp.wasmSchema).sort()).toEqual([
+      "accounts",
+      "catalog_items",
+      "orders",
+      "shipments",
+      "support_tickets",
+      "users",
+      "workspaces",
+    ]);
+    expect(JSON.parse(commerceApp.orders.include({ catalogItem: true })._build())).toEqual({
+      table: "orders",
+      conditions: [],
+      includes: { catalogItem: true },
+      orderBy: [],
+      hops: [],
+    });
+
+    type OrderRow = s.RowOf<typeof commerceApp.orders>;
+    type OrderWithCatalogItem = s.RowOf<
+      ReturnType<typeof commerceApp.orders.include<{ catalogItem: true }>>
+    >;
+    type CatalogItemWithOrders = s.RowOf<
+      ReturnType<
+        typeof commerceApp.catalog_items.include<{
+          ordersViaCatalogItem: typeof commerceApp.orders;
+        }>
+      >
+    >;
+    type WorkspaceWithSupportTickets = s.RowOf<
+      ReturnType<typeof supportApp.workspaces.include<{ support_ticketsViaWorkspace: true }>>
+    >;
+
+    const orderRow = {} as OrderRow;
+    const orderWithCatalogItem = {} as OrderWithCatalogItem;
+    const catalogItemWithOrders = {} as CatalogItemWithOrders;
+    const workspaceWithSupportTickets = {} as WorkspaceWithSupportTickets;
+
+    expectTypeOf(orderRow.buyerId).toEqualTypeOf<string>();
+    expectTypeOf(orderWithCatalogItem.catalogItem).toEqualTypeOf<{
+      id: string;
+      title: string;
+      workspaceId: string;
+    } | null>();
+    expectTypeOf(catalogItemWithOrders.ordersViaCatalogItem).toEqualTypeOf<OrderRow[]>();
+    expectTypeOf(workspaceWithSupportTickets.support_ticketsViaWorkspace).toEqualTypeOf<
+      Array<{
+        id: string;
+        workspaceId: string;
+        requesterId: string;
+      }>
+    >();
+
+    if ((globalThis as { __typecheck_only__?: boolean }).__typecheck_only__) {
+      // @ts-expect-error the full app does not expose a typed global table graph
+      void sliceableApp.orders;
+
+      // @ts-expect-error only selected tables are exposed on this slice
+      void commerceApp.support_tickets;
+
+      // @ts-expect-error refs outside the slice stay scalar ids, not relations
+      commerceApp.orders.include({ buyer: true });
+
+      // @ts-expect-error reverse relations are derived only from the selected slice tables
+      commerceApp.workspaces.include({ support_ticketsViaWorkspace: true });
+
+      // @ts-expect-error unknown slice table
+      sliceableApp.slice("accounts", "missing");
     }
   });
 });


### PR DESCRIPTION
## What changed

Adds `schema.defineSliceableApp(schema).slice(...)` for large schemas that need one complete runtime schema but smaller typed app surfaces.

- Introduces `defineSliceableApp` and `SliceableApp` exports.
- Builds each slice from selected table names while sharing the full compiled `wasmSchema`.
- Keeps refs to omitted tables as scalar ID columns and derives reverse relations only from selected slice tables.
- Documents the API in a new "Very Large Schemas" section under Schemas / Defining Tables.
- Adds TS DSL coverage for runtime schema sharing, selected table exposure, external refs, slice-local reverse relations, and runtime errors for invalid slice calls.

## Validation

- `pnpm --filter jazz-wasm build`
- `pnpm --filter jazz-tools build`
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts tests/ts-dsl/typed-app.test.ts`
- `pnpm --filter jazz-tools exec tsc --project tsconfig.tests.json`
- `pnpm --filter jazz-tools build:test`
- `pnpm exec oxfmt --check --ignore-path .oxfmtignore .changeset/define-sliceable-app.md packages/jazz-tools/src/typed-app.ts packages/jazz-tools/src/index.ts packages/jazz-tools/tests/ts-dsl/typed-app.test.ts docs/content/docs/schemas/defining-tables.mdx`