### PR TITLE
Add transformed row table handles

### DIFF
--- a/.changeset/transformed-row-table-handles.md
+++ b/.changeset/transformed-row-table-handles.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Add TypeScript-only transformed row table handles with bidirectional read/write shape mapping.

--- a/docs/content/docs/schemas/defining-tables.mdx
+++ b/docs/content/docs/schemas/defining-tables.mdx
@@ -64,3 +64,42 @@ Extract precise TypeScript types from any table handle:
 | `s.RowOf<typeof app.todos>`    | The row type (all columns, `id` included)                   |
 | `s.InsertOf<typeof app.todos>` | The insert shape (no `id`, respects optionals and defaults) |
 | `s.WhereOf<typeof app.todos>`  | The `where(...)` input shape for that table                 |
+
+## Transformed Rows
+
+Use `.transformed(...)` when app code should read and write a TypeScript shape that differs from
+the stored table columns. The transform runs only in TypeScript at the `Db` boundary; the runtime
+schema, storage format, permissions, and query planner still use the table's real column names.
+
+```ts
+const todoCards = app.todos.transformed({
+  row: (todo) => ({
+    id: todo.id,
+    label: todo.title,
+    project: todo.projectId,
+    completed: todo.done,
+  }),
+
+  insert: (card: { label: string; project: string; completed?: boolean }) => ({
+    title: card.label,
+    projectId: card.project,
+    done: card.completed,
+  }),
+
+  update: (card: Partial<{ label: string; project: string; completed: boolean }>) => ({
+    title: card.label,
+    projectId: card.project,
+    done: card.completed,
+  }),
+});
+```
+
+Queries still filter, sort, and select using the stored row representation:
+
+```ts
+const openCards = await db.all(todoCards.where({ done: false }));
+```
+
+Reads and subscriptions return the transformed `row(...)` shape. Inserts and updates accept the
+transformed shapes and convert them through `insert(...)` and `update(...)` before writing stored
+columns.

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -176,6 +176,8 @@ export interface QueryBuilder<T> {
   readonly _table: string;
   /** Schema reference for translation and transformation */
   readonly _schema: WasmSchema;
+  /** Optional TypeScript-only row transform carried by transformed table handles. */
+  readonly _rowTransform?: RowTransform;
   /** Build and return the query as JSON */
   _build(): string;
   /** @internal Phantom brand — enables TypeScript to infer T from usage */
@@ -403,10 +405,36 @@ export interface TableProxy<T, Init> {
   readonly _table: string;
   /** Schema reference */
   readonly _schema: WasmSchema;
+  /** Optional TypeScript-only row transform carried by transformed table handles. */
+  readonly _rowTransform?: RowTransform;
   /** @internal Phantom brand — enables TypeScript to infer T from usage */
   readonly _rowType: T;
   /** @internal Phantom brand — enables TypeScript to infer Init from usage */
   readonly _initType: Init;
+}
+
+export interface RowTransform {
+  row(row: unknown): unknown;
+  insert(row: unknown): Record<string, unknown>;
+  update(row: unknown): Record<string, unknown>;
+}
+
+function transformOutputRow<T>(source: { readonly _rowTransform?: RowTransform }, row: unknown): T {
+  return (source._rowTransform ? source._rowTransform.row(row) : row) as T;
+}
+
+function transformInsertInput(
+  table: TableProxy<unknown, unknown>,
+  data: unknown,
+): Record<string, unknown> {
+  return table._rowTransform ? table._rowTransform.insert(data) : (data as Record<string, unknown>);
+}
+
+function transformUpdateInput(
+  table: TableProxy<unknown, unknown>,
+  data: unknown,
+): Record<string, unknown> {
+  return table._rowTransform ? table._rowTransform.update(data) : (data as Record<string, unknown>);
 }
 
 function backendScopedAuthState(session?: Session | null): AuthState {
@@ -474,13 +502,11 @@ export class DbTransaction {
    */
   insert<T, Init>(table: TableProxy<T, Init>, data: Init): T {
     this.ensureActive();
-    const values = toInsertRecord(
-      data as Record<string, unknown>,
-      this.resolveInputSchema(table),
-      table._table,
-    );
+    const transformedData = transformInsertInput(table, data);
+    const values = toInsertRecord(transformedData, this.resolveInputSchema(table), table._table);
     const row = this.runtimeTransaction.create(table._table, values);
-    return transformRow(row, table._schema, table._table);
+    const typedRow = transformRow(row, table._schema, table._table);
+    return transformOutputRow(table, typedRow);
   }
 
   /**
@@ -491,11 +517,8 @@ export class DbTransaction {
    */
   update<T, Init>(table: TableProxy<T, Init>, id: string, data: Partial<Init>): void {
     this.ensureActive();
-    const updates = toUpdateRecord(
-      data as Record<string, unknown>,
-      this.resolveInputSchema(table),
-      table._table,
-    );
+    const transformedData = transformUpdateInput(table, data);
+    const updates = toUpdateRecord(transformedData, this.resolveInputSchema(table), table._table);
     this.runtimeTransaction.update(id, updates);
   }
 
@@ -530,7 +553,9 @@ export class DbTransaction {
       options,
     );
     const outputIncludes = outputTable !== builtQuery.table ? {} : builtQuery.includes;
-    return transformRows<T>(rows, outputSchema, outputTable, outputIncludes, builtQuery.select);
+    return transformRows(rows, outputSchema, outputTable, outputIncludes, builtQuery.select).map(
+      (row) => transformOutputRow(query, row),
+    );
   }
 
   /**
@@ -608,22 +633,17 @@ export class DbDirectBatch {
 
   insert<T, Init>(table: TableProxy<T, Init>, data: Init): T {
     this.ensureActive();
-    const values = toInsertRecord(
-      data as Record<string, unknown>,
-      this.resolveInputSchema(table),
-      table._table,
-    );
+    const transformedData = transformInsertInput(table, data);
+    const values = toInsertRecord(transformedData, this.resolveInputSchema(table), table._table);
     const row = this.runtimeBatch.create(table._table, values);
-    return transformRow(row, table._schema, table._table);
+    const typedRow = transformRow(row, table._schema, table._table);
+    return transformOutputRow(table, typedRow);
   }
 
   update<T, Init>(table: TableProxy<T, Init>, id: string, data: Partial<Init>): void {
     this.ensureActive();
-    const updates = toUpdateRecord(
-      data as Record<string, unknown>,
-      this.resolveInputSchema(table),
-      table._table,
-    );
+    const transformedData = transformUpdateInput(table, data);
+    const updates = toUpdateRecord(transformedData, this.resolveInputSchema(table), table._table);
     this.runtimeBatch.update(id, updates);
   }
 
@@ -2190,9 +2210,13 @@ export class Db {
     const client = this.getClient(table._schema);
     // Don't wait for bridge to be ready in worker mode. Inserts will be propagated once the bridge is ready.
     // If the bridge fails to initialize, the insert will be lost on restart.
-    const values = toInsertRecord(data as Record<string, unknown>, table._schema, table._table);
+    const transformedData = transformInsertInput(table, data);
+    const values = toInsertRecord(transformedData, table._schema, table._table);
     const inserted = client.create(table._table, values, options);
-    return inserted.mapValue((row) => transformRow(row, table._schema, table._table));
+    return inserted.mapValue((row) => {
+      const typedRow = transformRow(row, table._schema, table._table);
+      return transformOutputRow(table, typedRow);
+    });
   }
 
   /**
@@ -2206,7 +2230,8 @@ export class Db {
     options: UpsertOptions,
   ): WriteHandle {
     const client = this.getClient(table._schema);
-    const values = toUpdateRecord(data as Record<string, unknown>, table._schema, table._table);
+    const transformedData = transformUpdateInput(table, data);
+    const values = toUpdateRecord(transformedData, table._schema, table._table);
     return client.upsert(table._table, values, options);
   }
 
@@ -2222,7 +2247,8 @@ export class Db {
     options?: UpdateOptions,
   ): WriteHandle {
     const client = this.getClient(table._schema);
-    const updates = toUpdateRecord(data as Record<string, unknown>, table._schema, table._table);
+    const transformedData = transformUpdateInput(table, data);
+    const updates = toUpdateRecord(transformedData, table._schema, table._table);
     return client.update(id, updates, options);
   }
 
@@ -2361,7 +2387,9 @@ export class Db {
     const wasmQuery = translateQuery(builderJson, planningSchema);
     const rows = await client.query(wasmQuery, options);
     const outputIncludes = outputTable !== builtQuery.table ? {} : builtQuery.includes;
-    return transformRows<T>(rows, outputSchema, outputTable, outputIncludes, builtQuery.select);
+    return transformRows(rows, outputSchema, outputTable, outputIncludes, builtQuery.select).map(
+      (row) => transformOutputRow(query, row),
+    );
   }
 
   /**
@@ -2475,7 +2503,14 @@ export class Db {
     const wasmQuery = translateQuery(builderJson, planningSchema);
 
     const transform = (row: WasmRow): T => {
-      return transformRow<T>(row, outputSchema, outputTable, outputIncludes, builtQuery.select);
+      const typedRow = transformRow(
+        row,
+        outputSchema,
+        outputTable,
+        outputIncludes,
+        builtQuery.select,
+      );
+      return transformOutputRow(query, typedRow);
     };
 
     const handleDelta = (delta: Parameters<SubscriptionManager<T>["handleDelta"]>[0]) => {
@@ -2697,10 +2732,14 @@ class ClientBackedDb extends Db {
       normalizeRuntimeSchema(this.runtimeClient.getSchema()),
     );
     const inputSchema = resolveSchemaWithTable(table._schema, runtimeSchema.get, table._table);
-    const values = toInsertRecord(data as Record<string, unknown>, inputSchema, table._table);
+    const transformedData = transformInsertInput(table, data);
+    const values = toInsertRecord(transformedData, inputSchema, table._table);
     return this.runtimeClient
       .createHandleInternal(table._table, values, this.session, this.attribution, options)
-      .mapValue((row) => transformRow(row, table._schema, table._table));
+      .mapValue((row) => {
+        const typedRow = transformRow(row, table._schema, table._table);
+        return transformOutputRow(table, typedRow);
+      });
   }
 
   override upsert<T, Init>(
@@ -2712,7 +2751,8 @@ class ClientBackedDb extends Db {
       normalizeRuntimeSchema(this.runtimeClient.getSchema()),
     );
     const inputSchema = resolveSchemaWithTable(table._schema, runtimeSchema.get, table._table);
-    const values = toUpdateRecord(data as Record<string, unknown>, inputSchema, table._table);
+    const transformedData = transformUpdateInput(table, data);
+    const values = toUpdateRecord(transformedData, inputSchema, table._table);
     return this.runtimeClient.upsertHandleInternal(
       table._table,
       values,
@@ -2733,7 +2773,8 @@ class ClientBackedDb extends Db {
       normalizeRuntimeSchema(this.runtimeClient.getSchema()),
     );
     const inputSchema = resolveSchemaWithTable(table._schema, runtimeSchema.get, table._table);
-    const updates = toUpdateRecord(data as Record<string, unknown>, inputSchema, table._table);
+    const transformedData = transformUpdateInput(table, data);
+    const updates = toUpdateRecord(transformedData, inputSchema, table._table);
     return this.runtimeClient.updateHandleInternal(
       id,
       updates,
@@ -2793,7 +2834,9 @@ class ClientBackedDb extends Db {
       runtimeSchema.peek(),
     );
     const outputIncludes = outputTable !== builtQuery.table ? {} : builtQuery.includes;
-    return transformRows<T>(rows, outputSchema, outputTable, outputIncludes, builtQuery.select);
+    return transformRows(rows, outputSchema, outputTable, outputIncludes, builtQuery.select).map(
+      (row) => transformOutputRow(query, row),
+    );
   }
 
   override async one<T>(query: QueryBuilder<T>, options?: QueryOptions): Promise<T | null> {
@@ -2823,8 +2866,16 @@ class ClientBackedDb extends Db {
     const outputIncludes = outputTable !== builtQuery.table ? {} : builtQuery.includes;
     const wasmQuery = translateQuery(builderJson, planningSchema);
 
-    const transform = (row: WasmRow): T =>
-      transformRow<T>(row, outputSchema, outputTable, outputIncludes, builtQuery.select);
+    const transform = (row: WasmRow): T => {
+      const typedRow = transformRow(
+        row,
+        outputSchema,
+        outputTable,
+        outputIncludes,
+        builtQuery.select,
+      );
+      return transformOutputRow(query, typedRow);
+    };
 
     const subId = this.runtimeClient.subscribeInternal(
       wasmQuery,

--- a/packages/jazz-tools/src/typed-app.ts
+++ b/packages/jazz-tools/src/typed-app.ts
@@ -14,7 +14,7 @@ import {
   type ProvenanceMagicColumn,
   assertUserColumnNameAllowed,
 } from "./magic-columns.js";
-import type { QueryBuilder } from "./runtime/db.js";
+import type { QueryBuilder, RowTransform } from "./runtime/db.js";
 import type { Column, Schema as SchemaAst, SqlType, TSTypeFromSqlType } from "./schema.js";
 
 export type TableDefinition = Record<string, AnyTypedColumnBuilder>;
@@ -690,6 +690,21 @@ type MetaQueryBuilderShape<TMeta extends AnyTableMeta, TRow = unknown> = QueryBu
   readonly _initType: TableInitFromMeta<TMeta>;
 };
 
+export type RowTransformSpec<StoredRow, StoredInit, ViewRow, ViewInit> = {
+  row(row: StoredRow): ViewRow;
+  insert(row: ViewInit): StoredInit;
+  update(row: Partial<ViewInit>): Partial<StoredInit>;
+};
+
+type TransformedQueryHandle<
+  TMeta extends AnyTableMeta,
+  TInclude extends BuilderInclude<TMeta>,
+  TSelection extends TableSelectableFromMeta<TMeta>,
+  TRequired extends boolean,
+  ViewRow,
+  ViewInit,
+> = TypedTableQueryBuilder<TMeta, TInclude, TSelection, TRequired, ViewRow, ViewInit>;
+
 type BuilderInclude<TMeta extends AnyTableMeta> = {
   [TRelation in RelationNameFromMeta<TMeta>]?:
     | true
@@ -822,11 +837,13 @@ export class TypedTableQueryBuilder<
   TInclude extends BuilderInclude<TMeta> = {},
   TSelection extends TableSelectableFromMeta<TMeta> = DefaultTableSelection<TMeta>,
   TRequired extends boolean = false,
-> implements QueryBuilder<SelectedWithIncludesFromMeta<TMeta, TInclude, TSelection, TRequired>> {
+  TRow = SelectedWithIncludesFromMeta<TMeta, TInclude, TSelection, TRequired>,
+  TInit = TableInitFromMeta<TMeta>,
+> implements QueryBuilder<TRow> {
   readonly _table: TableNameFromMeta<TMeta>;
   readonly _schema: WasmSchema;
-  declare readonly _rowType: SelectedWithIncludesFromMeta<TMeta, TInclude, TSelection, TRequired>;
-  declare readonly _initType: TableInitFromMeta<TMeta>;
+  declare readonly _rowType: TRow;
+  declare readonly _initType: TInit;
   private _conditions: BuiltCondition[] = [];
   private _includes: Partial<BuilderInclude<TMeta>> = {};
   private _requireIncludes = false;
@@ -837,26 +854,35 @@ export class TypedTableQueryBuilder<
   private _hops: string[] = [];
   private _gatherVal?: BuiltGather;
   private _unionVal?: BuiltRelation;
+  _rowTransform?: RowTransform;
 
-  constructor(table: TableNameFromMeta<TMeta>, schema: WasmSchema) {
+  constructor(table: TableNameFromMeta<TMeta>, schema: WasmSchema, rowTransform?: RowTransform) {
     this._table = table;
     this._schema = schema;
+    this._rowTransform = rowTransform;
   }
 
   where(
     conditions: TableWhereFromMeta<TMeta>,
-  ): MetaQueryHandle<TMeta, TInclude, TSelection, TRequired> {
+  ): MetaQueryHandle<TMeta, TInclude, TSelection, TRequired, TRow, TInit> {
     if (this._unionVal) {
       throw new Error("union(...) currently only supports gather(...) in MVP.");
     }
-    const clone = this._clone<TInclude, TSelection, TRequired>();
+    const clone = this._clone<TInclude, TSelection, TRequired, TRow, TInit>();
     clone._conditions.push(...this._whereConditions(conditions as Record<string, unknown>));
     return clone;
   }
 
   select<NewSelection extends TableSelectableFromMeta<TMeta>>(
     ...columns: [NewSelection, ...NewSelection[]]
-  ): MetaQueryHandle<TMeta, TInclude, NewSelection, TRequired> {
+  ): MetaQueryHandle<
+    TMeta,
+    TInclude,
+    NewSelection,
+    TRequired,
+    SelectedWithIncludesFromMeta<TMeta, TInclude, NewSelection, TRequired>,
+    TInit
+  > {
     const clone = this._clone<TInclude, NewSelection, TRequired>();
     clone._selectColumns = [...columns] as string[];
     return clone;
@@ -864,13 +890,27 @@ export class TypedTableQueryBuilder<
 
   include<NewInclude extends BuilderInclude<TMeta>>(
     relations: NewInclude,
-  ): MetaQueryHandle<TMeta, TInclude & NewInclude, TSelection, TRequired> {
+  ): MetaQueryHandle<
+    TMeta,
+    TInclude & NewInclude,
+    TSelection,
+    TRequired,
+    SelectedWithIncludesFromMeta<TMeta, TInclude & NewInclude, TSelection, TRequired>,
+    TInit
+  > {
     const clone = this._clone<TInclude & NewInclude, TSelection, TRequired>();
     clone._includes = { ...this._includes, ...relations };
     return clone;
   }
 
-  requireIncludes(): MetaQueryHandle<TMeta, TInclude, TSelection, true> {
+  requireIncludes(): MetaQueryHandle<
+    TMeta,
+    TInclude,
+    TSelection,
+    true,
+    SelectedWithIncludesFromMeta<TMeta, TInclude, TSelection, true>,
+    TInit
+  > {
     const clone = this._clone<TInclude, TSelection, true>();
     clone._requireIncludes = true;
     return clone;
@@ -879,31 +919,31 @@ export class TypedTableQueryBuilder<
   orderBy(
     column: TableOrderableFromMeta<TMeta>,
     direction: "asc" | "desc" = "asc",
-  ): MetaQueryHandle<TMeta, TInclude, TSelection, TRequired> {
-    const clone = this._clone<TInclude, TSelection, TRequired>();
+  ): MetaQueryHandle<TMeta, TInclude, TSelection, TRequired, TRow, TInit> {
+    const clone = this._clone<TInclude, TSelection, TRequired, TRow, TInit>();
     clone._orderBys.push([column as string, direction]);
     return clone;
   }
 
-  limit(n: number): MetaQueryHandle<TMeta, TInclude, TSelection, TRequired> {
-    const clone = this._clone<TInclude, TSelection, TRequired>();
+  limit(n: number): MetaQueryHandle<TMeta, TInclude, TSelection, TRequired, TRow, TInit> {
+    const clone = this._clone<TInclude, TSelection, TRequired, TRow, TInit>();
     clone._limitVal = n;
     return clone;
   }
 
-  offset(n: number): MetaQueryHandle<TMeta, TInclude, TSelection, TRequired> {
-    const clone = this._clone<TInclude, TSelection, TRequired>();
+  offset(n: number): MetaQueryHandle<TMeta, TInclude, TSelection, TRequired, TRow, TInit> {
+    const clone = this._clone<TInclude, TSelection, TRequired, TRow, TInit>();
     clone._offsetVal = n;
     return clone;
   }
 
   hopTo(
     relation: RelationNameFromMeta<TMeta>,
-  ): MetaQueryHandle<TMeta, TInclude, TSelection, TRequired> {
+  ): MetaQueryHandle<TMeta, TInclude, TSelection, TRequired, TRow, TInit> {
     if (this._unionVal) {
       throw new Error("union(...) currently only supports gather(...) in MVP.");
     }
-    const clone = this._clone<TInclude, TSelection, TRequired>();
+    const clone = this._clone<TInclude, TSelection, TRequired, TRow, TInit>();
     clone._hops.push(relation as string);
     return clone;
   }
@@ -912,7 +952,7 @@ export class TypedTableQueryBuilder<
     start?: TableWhereFromMeta<TMeta>;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
-  }): MetaQueryHandle<TMeta, TInclude, TSelection, TRequired> {
+  }): MetaQueryHandle<TMeta, TInclude, TSelection, TRequired, TRow, TInit> {
     if (typeof options.step !== "function") {
       throw new Error("gather(...) requires step callback.");
     }
@@ -976,8 +1016,8 @@ export class TypedTableQueryBuilder<
       this._unionVal !== undefined || this._hops.length > 0 || this._gatherVal !== undefined;
     const seedSource = options.start === undefined ? this : this.where(options.start);
     const clone = needsExplicitSeed
-      ? this._clone<TInclude, TSelection, TRequired>()
-      : seedSource._clone<TInclude, TSelection, TRequired>();
+      ? this._clone<TInclude, TSelection, TRequired, TRow, TInit>()
+      : seedSource._clone<TInclude, TSelection, TRequired, TRow, TInit>();
     clone._conditions = [];
     clone._hops = [];
     clone._gatherVal = {
@@ -991,6 +1031,26 @@ export class TypedTableQueryBuilder<
     clone._unionVal = undefined;
 
     return clone;
+  }
+
+  transformed<ViewRow, ViewInit>(
+    transform: RowTransformSpec<
+      SelectedWithIncludesFromMeta<TMeta, TInclude, TSelection, TRequired>,
+      TableInitFromMeta<TMeta>,
+      ViewRow,
+      ViewInit
+    >,
+  ): TransformedQueryHandle<TMeta, TInclude, TSelection, TRequired, ViewRow, ViewInit> {
+    const clone = this._clone<TInclude, TSelection, TRequired>();
+    (clone as { _rowTransform?: RowTransform })._rowTransform = transform as RowTransform;
+    return clone as unknown as TransformedQueryHandle<
+      TMeta,
+      TInclude,
+      TSelection,
+      TRequired,
+      ViewRow,
+      ViewInit
+    >;
   }
 
   _build(): string {
@@ -1017,11 +1077,17 @@ export class TypedTableQueryBuilder<
     TNewInclude extends BuilderInclude<TMeta>,
     TNewSelection extends TableSelectableFromMeta<TMeta>,
     TNewRequired extends boolean,
-  >(): TypedTableQueryBuilder<TMeta, TNewInclude, TNewSelection, TNewRequired> {
-    const clone = new TypedTableQueryBuilder<TMeta, TNewInclude, TNewSelection, TNewRequired>(
-      this._table,
-      this._schema,
-    );
+    TNewRow = SelectedWithIncludesFromMeta<TMeta, TNewInclude, TNewSelection, TNewRequired>,
+    TNewInit = TInit,
+  >(): TypedTableQueryBuilder<TMeta, TNewInclude, TNewSelection, TNewRequired, TNewRow, TNewInit> {
+    const clone = new TypedTableQueryBuilder<
+      TMeta,
+      TNewInclude,
+      TNewSelection,
+      TNewRequired,
+      TNewRow,
+      TNewInit
+    >(this._table, this._schema, this._rowTransform);
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes } as Partial<BuilderInclude<TMeta>>;
     clone._requireIncludes = this._requireIncludes;
@@ -1070,7 +1136,9 @@ interface MetaQueryHandle<
   TInclude extends BuilderInclude<TMeta> = {},
   TSelection extends TableSelectableFromMeta<TMeta> = DefaultTableSelection<TMeta>,
   TRequired extends boolean = false,
-> extends TypedTableQueryBuilder<TMeta, TInclude, TSelection, TRequired> {}
+  TRow = SelectedWithIncludesFromMeta<TMeta, TInclude, TSelection, TRequired>,
+  TInit = TableInitFromMeta<TMeta>,
+> extends TypedTableQueryBuilder<TMeta, TInclude, TSelection, TRequired, TRow, TInit> {}
 
 export interface Query<
   TTable extends string,
@@ -1278,7 +1346,7 @@ export function defineApp(
       return builder;
     },
     wasmSchema,
-  } as App<Schema<SchemaDefinition>>;
+  } as unknown as App<Schema<SchemaDefinition>>;
 }
 
 export const permissionIntrospectionColumns = [...PERMISSION_INTROSPECTION_COLUMNS];

--- a/packages/jazz-tools/tests/ts-dsl/transformed-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/transformed-api.test.ts
@@ -1,0 +1,152 @@
+import { createDb, type Db } from "../../src/runtime/db.js";
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it } from "vitest";
+import { app } from "./fixtures/basic/schema";
+import { insertProject, insertUser, uniqueDbName } from "./factories";
+import { schema as s } from "../../src/index.js";
+
+type TodoCard = {
+  id: string;
+  label: string;
+  project: string;
+  owner: string | null;
+  completed: boolean;
+};
+
+type TodoCardInput = {
+  label: string;
+  project: string;
+  owner?: string | null;
+  completed?: boolean;
+};
+
+const todoCards = app.todos.transformed<TodoCard, TodoCardInput>({
+  row: (todo) => ({
+    id: todo.id,
+    label: todo.title,
+    project: todo.projectId,
+    owner: todo.ownerId,
+    completed: todo.done,
+  }),
+  insert: (card) => ({
+    title: card.label,
+    projectId: card.project,
+    ownerId: card.owner,
+    done: card.completed,
+  }),
+  update: (card) => ({
+    title: card.label,
+    projectId: card.project,
+    ownerId: card.owner,
+    done: card.completed,
+  }),
+});
+
+describe("TS transformed row API", () => {
+  let db: Db;
+
+  beforeEach(async () => {
+    db = await createDb({
+      appId: "test-app",
+      driver: { type: "persistent", dbName: uniqueDbName("transformed-api") },
+    });
+  });
+
+  afterEach(async () => {
+    await db.shutdown();
+  });
+
+  it("returns transformed rows from raw-column queries", async () => {
+    const project = insertProject(db, "Launch");
+    const owner = insertUser(db, "Alice");
+    const { value: inserted } = db.insert(app.todos, {
+      title: "Write announcement",
+      projectId: project.id,
+      ownerId: owner.id,
+    });
+
+    const cards = await db.all(todoCards.where({ done: false }));
+
+    expectTypeOf(cards).toEqualTypeOf<TodoCard[]>();
+    expect(cards).toEqual([
+      {
+        id: inserted.id,
+        label: "Write announcement",
+        project: project.id,
+        owner: owner.id,
+        completed: false,
+      },
+    ]);
+  });
+
+  it("accepts transformed insert and update payloads", async () => {
+    const project = insertProject(db, "Roadmap");
+    const owner = insertUser(db, "Bob");
+
+    const { value: card } = db.insert(todoCards, {
+      label: "Draft milestone",
+      project: project.id,
+      owner: owner.id,
+    });
+
+    expectTypeOf(card).toEqualTypeOf<TodoCard>();
+    expect(card).toMatchObject({
+      label: "Draft milestone",
+      project: project.id,
+      owner: owner.id,
+      completed: false,
+    });
+
+    db.update(todoCards, card.id, { completed: true, label: "Publish milestone" });
+
+    const raw = await db.one(app.todos.where({ id: card.id }));
+    expect(raw).toMatchObject({
+      title: "Publish milestone",
+      done: true,
+      projectId: project.id,
+      ownerId: owner.id,
+    });
+
+    const transformed = await db.one(todoCards.where({ id: card.id }));
+    expect(transformed).toMatchObject({
+      id: card.id,
+      label: "Publish milestone",
+      completed: true,
+    });
+  });
+
+  it("emits transformed rows from subscriptions", async () => {
+    const project = insertProject(db, "Realtime");
+    let resolveUpdate: (all: TodoCard[]) => void = () => {};
+    const nextUpdate = new Promise<TodoCard[]>((resolve) => {
+      resolveUpdate = resolve;
+    });
+
+    const unsubscribe = db.subscribeAll(todoCards.where({ projectId: project.id }), ({ all }) => {
+      if (all.length > 0) {
+        resolveUpdate(all);
+      }
+    });
+
+    db.insert(todoCards, {
+      label: "Notify listeners",
+      project: project.id,
+      completed: false,
+    });
+
+    await expect(nextUpdate).resolves.toEqual([
+      expect.objectContaining({
+        label: "Notify listeners",
+        project: project.id,
+        completed: false,
+      }),
+    ]);
+
+    unsubscribe();
+  });
+
+  it("exposes transformed helper types while keeping where input raw", () => {
+    expectTypeOf<s.RowOf<typeof todoCards>>().toEqualTypeOf<TodoCard>();
+    expectTypeOf<s.InsertOf<typeof todoCards>>().toEqualTypeOf<TodoCardInput>();
+    expectTypeOf<s.WhereOf<typeof todoCards>>().toEqualTypeOf<s.WhereOf<typeof app.todos>>();
+  });
+});


### PR DESCRIPTION
## What changed

- Added `app.<table>.transformed({ row, insert, update })` for TypeScript-only row shape transforms.
- Applied transforms across read results, subscriptions, inserts, updates, upserts, transactions, direct batches, and scoped backend DBs.
- Added TS DSL tests for raw-column filters, transformed read/write payloads, subscriptions, and helper types.
- Documented the feature in `Schemas / Defining Tables` under `Transformed Rows`.

## Compatibility

This PR is stacked on #688 (`codex/define-sliceable-app`) so the shared `typed-app.ts` and `Schemas / Defining Tables` changes are resolved together. `transformed(...)` works on the same table handles returned from sliced apps.

## Validation

- `pnpm --filter jazz-wasm build`
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts tests/ts-dsl/transformed-api.test.ts`
- `pnpm --filter jazz-tools exec tsc --project tsconfig.tests.json --noEmit`
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts tests/ts-dsl/transformed-api.test.ts tests/ts-dsl/typed-app.test.ts`