### PR TITLE
[codex] Mark sliceable app changeset as patch

### DIFF
--- a/.changeset/define-sliceable-app.md
+++ b/.changeset/define-sliceable-app.md
@@ -1,5 +1,5 @@
 ---
-"jazz-tools": minor
+"jazz-tools": patch
 ---
 
 Add `schema.defineSliceableApp(schema).slice(...)` for deriving smaller typed app surfaces backed by one complete runtime schema.


### PR DESCRIPTION
## What changed

Updates the `defineSliceableApp` changeset from a minor bump to a patch bump.

## Validation

- `pnpm exec oxfmt --check --ignore-path .oxfmtignore .changeset/define-sliceable-app.md`