### PR TITLE
ci(bench): tolerate protected-main push rejection

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -656,4 +656,12 @@ jobs:
           fi
           git commit -m "bench: update realistic benchmark site (${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT})"
           git pull --rebase origin main
-          git push origin HEAD:main
+          push_output="$(git push origin HEAD:main 2>&1)" && push_status=0 || push_status=$?
+          printf '%s\n' "$push_output"
+          if [ "$push_status" -ne 0 ]; then
+            if printf '%s' "$push_output" | grep -qE "protected branch|GH006"; then
+              echo "::warning::Cannot push benchmark history to protected main; the site artifact is uploaded for follow-up."
+              exit 0
+            fi
+            exit "$push_status"
+          fi


### PR DESCRIPTION
## Summary

- The Realistic Benchmarks workflow pushes the regenerated history snapshot, skip set, and built site back to `main` on schedule and after each merge.
- Branch protection now rejects bot pushes (`GH006: protected branch hook declined`), so the final *Commit updated history and site* step has been failing every run since 2026-04-23 even though the native + browser suites and the Vercel production deploy all succeed.
- Treat protected-branch rejection as a warning instead of a job failure: emit a workflow warning and exit 0. Any other push failure still surfaces as a real failure.

## Test plan

- [ ] After merge, the next scheduled / push-to-main run of *Realistic Benchmarks* finishes green; the *Commit updated history and site* step prints the warning and the job exits 0.
- [ ] The site artifact upload + Vercel production deploy continue to work as before.