### PR TITLE
Replace JazzClient::connect polling with a watch channel

### DIFF
--- a/crates/jazz-tools/src/client.rs
+++ b/crates/jazz-tools/src/client.rs
@@ -177,7 +177,7 @@ impl JazzClient {
             // `batched_tick` handles `TransportInbound::Connected` automatically —
             // it calls `add_server_with_catalogue_state_hash` — so we only need
             // to gate here until that first tick fires.
-            tokio::time::timeout(
+            let connected = tokio::time::timeout(
                 Duration::from_secs(10),
                 runtime.transport_wait_until_connected(),
             )
@@ -187,6 +187,11 @@ impl JazzClient {
                     "timed out waiting for WebSocket handshake to complete".to_string(),
                 )
             })?;
+            if !connected {
+                return Err(JazzError::Connection(
+                    "transport closed before WebSocket handshake completed".to_string(),
+                ));
+            }
         }
 
         Ok(Self {

--- a/crates/jazz-tools/src/client.rs
+++ b/crates/jazz-tools/src/client.rs
@@ -111,6 +111,25 @@ fn default_session_from_context(context: &AppContext) -> Option<Session> {
         .and_then(session_from_unverified_jwt)
 }
 
+async fn wait_for_initial_transport_handshake(
+    runtime: &ClientRuntime,
+    timeout_after: Duration,
+) -> Result<()> {
+    let connected = tokio::time::timeout(timeout_after, runtime.transport_wait_until_connected())
+        .await
+        .map_err(|_| {
+            JazzError::Connection(
+                "timed out waiting for WebSocket handshake to complete".to_string(),
+            )
+        })?;
+    if !connected {
+        return Err(JazzError::Connection(
+            "transport closed before WebSocket handshake completed".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 impl JazzClient {
     /// Connect to Jazz with the given configuration.
     ///
@@ -177,21 +196,7 @@ impl JazzClient {
             // `batched_tick` handles `TransportInbound::Connected` automatically —
             // it calls `add_server_with_catalogue_state_hash` — so we only need
             // to gate here until that first tick fires.
-            let connected = tokio::time::timeout(
-                Duration::from_secs(10),
-                runtime.transport_wait_until_connected(),
-            )
-            .await
-            .map_err(|_| {
-                JazzError::Connection(
-                    "timed out waiting for WebSocket handshake to complete".to_string(),
-                )
-            })?;
-            if !connected {
-                return Err(JazzError::Connection(
-                    "transport closed before WebSocket handshake completed".to_string(),
-                ));
-            }
+            wait_for_initial_transport_handshake(&runtime, Duration::from_secs(10)).await?;
         }
 
         Ok(Self {
@@ -1040,6 +1045,30 @@ mod tests {
             default_session_from_context(&context).is_none(),
             "backend/admin clients should keep using explicit SessionClient scopes"
         );
+    }
+
+    #[tokio::test]
+    async fn initial_transport_handshake_wait_errors_when_transport_is_absent() {
+        let app_id = AppId::from_name("client-missing-transport");
+        let context = make_offline_context(
+            app_id,
+            TempDir::new().expect("tempdir").keep(),
+            declared_todo_schema(),
+        );
+        let storage: DynStorage = Box::new(MemoryStorage::new());
+        let schema_manager =
+            build_client_schema_manager(storage.as_ref(), &context).expect("schema manager");
+        let runtime = TokioRuntime::new(schema_manager, storage, |_entry: OutboxEntry| {});
+
+        let result = wait_for_initial_transport_handshake(&runtime, Duration::from_secs(1)).await;
+
+        match result {
+            Err(JazzError::Connection(message)) => assert_eq!(
+                message,
+                "transport closed before WebSocket handshake completed"
+            ),
+            other => panic!("expected connection error for missing transport, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/jazz-tools/src/client.rs
+++ b/crates/jazz-tools/src/client.rs
@@ -177,14 +177,10 @@ impl JazzClient {
             // `batched_tick` handles `TransportInbound::Connected` automatically —
             // it calls `add_server_with_catalogue_state_hash` — so we only need
             // to gate here until that first tick fires.
-            tokio::time::timeout(Duration::from_secs(10), async {
-                loop {
-                    if runtime.transport_ever_connected() {
-                        break;
-                    }
-                    tokio::time::sleep(Duration::from_millis(10)).await;
-                }
-            })
+            tokio::time::timeout(
+                Duration::from_secs(10),
+                runtime.transport_wait_until_connected(),
+            )
             .await
             .map_err(|_| {
                 JazzError::Connection(

--- a/crates/jazz-tools/src/runtime_tokio.rs
+++ b/crates/jazz-tools/src/runtime_tokio.rs
@@ -844,6 +844,26 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
             .unwrap_or(false)
     }
 
+    /// Async wait that resolves once the WebSocket transport has completed
+    /// its first successful handshake (or returns immediately if it already
+    /// has). Returns `false` when no transport is installed — callers should
+    /// either check `is_connected()`/`has_server` first or wrap this in a
+    /// timeout.
+    pub async fn transport_wait_until_connected(&self) -> bool {
+        let Some(mut rx) = self
+            .core
+            .lock()
+            .ok()
+            .and_then(|c| c.transport.as_ref().map(|h| h.connected_rx.clone()))
+        else {
+            return false;
+        };
+        if *rx.borrow() {
+            return true;
+        }
+        rx.wait_for(|connected| *connected).await.is_ok()
+    }
+
     /// Returns the wire `ClientId` used by the active transport, if any.
     ///
     /// Tests use this to register the transport's client identity with a

--- a/crates/jazz-tools/src/transport_manager.rs
+++ b/crates/jazz-tools/src/transport_manager.rs
@@ -64,8 +64,9 @@ pub struct TransportHandle {
     /// Async signal that flips to `true` on the first successful handshake.
     /// Callers can `clone()` the receiver and `await` `wait_for(|v| *v)` to
     /// be notified without polling. Kept alongside `ever_connected` so the
-    /// non-tokio (wasm) build can still read the latched state synchronously.
-    #[cfg(feature = "runtime-tokio")]
+    /// wasm transport and other non-native wait paths can still read the
+    /// latched state synchronously.
+    #[cfg(feature = "transport-websocket")]
     pub(crate) connected_rx: tokio::sync::watch::Receiver<bool>,
     pub control_tx: mpsc::UnboundedSender<TransportControl>,
     /// Client's current catalogue-state digest. The TransportManager reads
@@ -267,9 +268,9 @@ pub struct TransportManager<W: StreamAdapter, T: TickNotifier> {
     ever_connected: std::sync::Arc<std::sync::atomic::AtomicBool>,
     /// Sender side of the handshake-completion watch. Held by the manager
     /// task so it can broadcast `true` once on the first handshake. Only
-    /// present under `runtime-tokio`; the wasm path relies solely on the
-    /// `AtomicBool` above (no current wasm caller awaits this signal).
-    #[cfg(feature = "runtime-tokio")]
+    /// present for the native Tokio WebSocket wait path; the wasm transport
+    /// relies solely on the `AtomicBool` above.
+    #[cfg(feature = "transport-websocket")]
     connected_tx: tokio::sync::watch::Sender<bool>,
     control_rx: mpsc::UnboundedReceiver<TransportControl>,
     /// Shared with `TransportHandle::catalogue_state_hash`. Read at each
@@ -292,7 +293,7 @@ pub fn create<W: StreamAdapter, T: TickNotifier>(
     let (inbound_tx, inbound_rx) = mpsc::unbounded();
     let (control_tx, control_rx) = mpsc::unbounded();
     let ever_connected = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-    #[cfg(feature = "runtime-tokio")]
+    #[cfg(feature = "transport-websocket")]
     let (connected_tx, connected_rx) = tokio::sync::watch::channel(false);
     let catalogue_state_hash = std::sync::Arc::new(std::sync::Mutex::new(None::<String>));
     let declared_schema_hash = std::sync::Arc::new(std::sync::Mutex::new(None::<String>));
@@ -302,7 +303,7 @@ pub fn create<W: StreamAdapter, T: TickNotifier>(
         outbox_tx,
         inbound_rx,
         ever_connected: ever_connected.clone(),
-        #[cfg(feature = "runtime-tokio")]
+        #[cfg(feature = "transport-websocket")]
         connected_rx,
         control_tx,
         catalogue_state_hash: catalogue_state_hash.clone(),
@@ -318,7 +319,7 @@ pub fn create<W: StreamAdapter, T: TickNotifier>(
         reconnect: ReconnectState::new(),
         client_id,
         ever_connected,
-        #[cfg(feature = "runtime-tokio")]
+        #[cfg(feature = "transport-websocket")]
         connected_tx,
         control_rx,
         catalogue_state_hash,
@@ -519,6 +520,7 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
                 ControlOrPhase::Phase(HandshakeResult::Connected(resp)) => {
                     self.ever_connected
                         .store(true, std::sync::atomic::Ordering::Release);
+                    #[cfg(feature = "transport-websocket")]
                     let _ = self.connected_tx.send(true);
                     let _ = self.inbound_tx.unbounded_send(TransportInbound::Connected {
                         catalogue_state_hash: resp.catalogue_state_hash,

--- a/crates/jazz-tools/src/transport_manager.rs
+++ b/crates/jazz-tools/src/transport_manager.rs
@@ -61,6 +61,12 @@ pub struct TransportHandle {
     pub outbox_tx: mpsc::UnboundedSender<OutboxEntry>,
     pub inbound_rx: mpsc::UnboundedReceiver<TransportInbound>,
     pub ever_connected: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    /// Async signal that flips to `true` on the first successful handshake.
+    /// Callers can `clone()` the receiver and `await` `wait_for(|v| *v)` to
+    /// be notified without polling. Kept alongside `ever_connected` so the
+    /// non-tokio (wasm) build can still read the latched state synchronously.
+    #[cfg(feature = "runtime-tokio")]
+    pub(crate) connected_rx: tokio::sync::watch::Receiver<bool>,
     pub control_tx: mpsc::UnboundedSender<TransportControl>,
     /// Client's current catalogue-state digest. The TransportManager reads
     /// this at each handshake attempt so reconnects can tell the server
@@ -259,6 +265,12 @@ pub struct TransportManager<W: StreamAdapter, T: TickNotifier> {
     reconnect: ReconnectState,
     pub client_id: ClientId,
     ever_connected: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    /// Sender side of the handshake-completion watch. Held by the manager
+    /// task so it can broadcast `true` once on the first handshake. Only
+    /// present under `runtime-tokio`; the wasm path relies solely on the
+    /// `AtomicBool` above (no current wasm caller awaits this signal).
+    #[cfg(feature = "runtime-tokio")]
+    connected_tx: tokio::sync::watch::Sender<bool>,
     control_rx: mpsc::UnboundedReceiver<TransportControl>,
     /// Shared with `TransportHandle::catalogue_state_hash`. Read at each
     /// handshake attempt so reconnects can reflect catalogue changes.
@@ -280,6 +292,8 @@ pub fn create<W: StreamAdapter, T: TickNotifier>(
     let (inbound_tx, inbound_rx) = mpsc::unbounded();
     let (control_tx, control_rx) = mpsc::unbounded();
     let ever_connected = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    #[cfg(feature = "runtime-tokio")]
+    let (connected_tx, connected_rx) = tokio::sync::watch::channel(false);
     let catalogue_state_hash = std::sync::Arc::new(std::sync::Mutex::new(None::<String>));
     let declared_schema_hash = std::sync::Arc::new(std::sync::Mutex::new(None::<String>));
     let handle = TransportHandle {
@@ -288,6 +302,8 @@ pub fn create<W: StreamAdapter, T: TickNotifier>(
         outbox_tx,
         inbound_rx,
         ever_connected: ever_connected.clone(),
+        #[cfg(feature = "runtime-tokio")]
+        connected_rx,
         control_tx,
         catalogue_state_hash: catalogue_state_hash.clone(),
         declared_schema_hash: declared_schema_hash.clone(),
@@ -302,6 +318,8 @@ pub fn create<W: StreamAdapter, T: TickNotifier>(
         reconnect: ReconnectState::new(),
         client_id,
         ever_connected,
+        #[cfg(feature = "runtime-tokio")]
+        connected_tx,
         control_rx,
         catalogue_state_hash,
         declared_schema_hash,
@@ -501,6 +519,7 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
                 ControlOrPhase::Phase(HandshakeResult::Connected(resp)) => {
                     self.ever_connected
                         .store(true, std::sync::atomic::Ordering::Release);
+                    let _ = self.connected_tx.send(true);
                     let _ = self.inbound_tx.unbounded_send(TransportInbound::Connected {
                         catalogue_state_hash: resp.catalogue_state_hash,
                         next_sync_seq: resp.next_sync_seq,


### PR DESCRIPTION
## Summary

- `JazzClient::connect` previously gated on `transport_ever_connected()` inside a `loop { tokio::time::sleep(10ms) }` under a 10s timeout. The transport already knows exactly when the WS handshake fires, so the polling added up to 10ms of avoidable connect latency and burned a tokio task per attempt.
- Adds a `tokio::sync::watch::<bool>` alongside the existing `AtomicBool` on `TransportHandle`/`TransportManager` (under `runtime-tokio`). The manager task broadcasts `true` on first handshake.
- Exposes `TokioRuntime::transport_wait_until_connected()` which clones the watch receiver and awaits `wait_for(|v| *v)` — returns immediately if the handshake has already fired.
- `JazzClient::connect` now wraps that future in the existing 10s timeout, so the loop and the `tokio::time::sleep` are gone.
- The `Arc<AtomicBool> ever_connected` field stays untouched. It still backs the synchronous `has_ever_connected()` API and remains the only signal used by the wasm path (`#[cfg(not(feature = "runtime-tokio"))]`), where `tokio::sync::watch` isn't available.

## Test plan

- [x] `cargo check -p jazz-tools` (default features)
- [x] `cargo check -p jazz-tools --no-default-features` (wasm-shaped build)
- [x] `cargo check -p jazz-wasm --target wasm32-unknown-unknown`
- [x] `cargo clippy -p jazz-tools --features test --lib` — no new warnings
- [x] `cargo test -p jazz-tools --features test --lib` — full suite green (1296 tests, including all 9 `transport_manager` and 12 `client::tests`)