### PR TITLE
Add crate structure cleanup spec

### DIFF
--- a/specs/todo/c_later/crate_structure_cleanup.md
+++ b/specs/todo/c_later/crate_structure_cleanup.md
@@ -36,10 +36,10 @@ resolving from the new module locations.
 Two phases are **deliberate API breaks** coordinated with binding updates in
 the same PR:
 
-- **Phase 3 (builder collapse)** — replaces four public `ServerBuilder::with_*_storage`
+- **Phase 2 (builder collapse)** — replaces four public `ServerBuilder::with_*_storage`
   methods. Call sites in `crates/jazz-napi/src/lib.rs:1585, 1754, 1756` must
   be updated in the same PR.
-- **Phase 6 (typed subscribe)** — replaces public
+- **Phase 5 (typed subscribe)** — replaces public
   `RuntimeCore::{create_subscription, execute_subscription}`. Call sites in
   `crates/jazz-napi/src/lib.rs:941, 983`, `crates/jazz-wasm/src/runtime.rs:1588, 1612`,
   and `crates/jazz-rn/rust/src/lib.rs:713, 755` (plus the regenerated UniFFI
@@ -82,63 +82,7 @@ Acceptance:
   unchanged. No `pub use` from `lib.rs` is renamed; only the right-hand
   side of each re-export shifts.
 
-## Phase 2 — Entry-point dedup
-
-Small, independent fixes that remove parallel construction logic between
-`client.rs` and `server/builder.rs`.
-
-1. Share the `NODE_ENV` → "are we in prod?" classification between
-   `main.rs::resolve_node_env_mode()` (`main.rs:24-29`) and
-   `builder.rs::should_allow_unprivileged_schema_catalogue_writes()`
-   (`builder.rs:305-310`). The two functions do not do the same thing — one
-   gates auth defaults, the other gates unprivileged catalogue writes — but
-   they share the same env-var match (`eq_ignore_ascii_case("production")`,
-   anything else treated as dev). Extract just the classifier (e.g. a
-   pub `node_env_mode() -> NodeEnvMode` in `server/env.rs`) and have both
-   policy functions call it. The policy decisions on top stay separate.
-   Scope is ~3 lines of true dedup; "leave it alone" is also defensible.
-2. Thin `main.rs`: push CLI-helper functions
-   (`resolve_jwt_public_key_input` at `main.rs:38-59`, plus
-   `resolve_node_env_mode` and `resolve_dev_default_flag` from item 1 if
-   pursued) into `commands/server.rs`, where they're actually consumed.
-   `main.rs` keeps the clap struct definitions and dispatch only. Note:
-   both files are binary-only (`commands/` is `mod` in `main.rs`, not
-   re-exported from `lib.rs`), so this is purely a binary-internal
-   organization choice — nothing leaves or enters the public library.
-   `main.rs` is 358 lines today; "leave it alone" is defensible.
-3. (Optional, naming-only.) Give the two `reqwest::Client` constructions in
-   `builder.rs` named helpers so their intent is explicit at the call site:
-   `build_authority_forwarding_client()` for `builder.rs:155` and
-   `build_jwks_client()` for `builder.rs:338-342`. **Do not collapse them
-   into one shared client** — they encode two different policies. The main
-   client is used at `routes.rs:219` to proxy catalogue admin requests
-   (potentially carrying large schema bundles) and uses default timeouts.
-   The JWKS client uses `connect_timeout(5s)` + `timeout(10s)` so a hung
-   IDP cannot block the auth path. Sharing one client requires picking
-   either policy for both, which is a behavior change in either direction.
-4. Delete `#[allow(dead_code)] pub app_id` on `ServerState` (`server/mod.rs:165`)
-   — either use it in a routed handler or remove the field.
-
-(An earlier draft proposed extracting a shared `build_schema_manager` from
-`client.rs:64-82` and `server/builder.rs:217-238`. On closer reading those
-two functions are not duplicates: the client uses an empty `SyncManager`,
-always constructs `SchemaManager::new(...)` with the declared schema, uses
-the `"client"` tier label, and always rehydrates from the catalogue. The
-server uses `server_sync_manager()` (Edge+Global tiers, plus optional
-unprivileged catalogue writes when `NODE_ENV != production`), splits on
-Dynamic vs Fixed schema mode, uses `"prod"`, only rehydrates in Dynamic
-mode, calls `require_authorization_schema()` afterwards to fail closed,
-and returns `String` errors. Sharing them would require a function with
-five orthogonal parameters that obscures rather than clarifies. Left as
-two separate construction policies.)
-
-(Promoting `allow_local_first_auth: true` into `AuthConfig::default()` was
-considered but moved to _Out of scope_ below: `AuthConfig` derives `Default`
-today, so the bool defaults to `false`, and `crates/jazz-tools/src/middleware/auth.rs:1134, 1617`
-plus `crates/jazz-tools/tests/auth_test.rs:228` rely on that. Flipping it is
-a behavior change, not cleanup.)
-
-## Phase 3 — Builder collapse
+## Phase 2 — Builder collapse
 
 Replace the four storage builder variants (`with_persistent_storage`,
 `with_in_memory_storage`, `with_sqlite_storage`, `with_rocksdb_storage` —
@@ -172,7 +116,7 @@ Acceptance:
   the same PR; `pnpm build` and `pnpm test` for the napi package pass.
 - Tests unchanged in spirit (only the call shape rewritten).
 
-## Phase 4 — Storage trait split
+## Phase 3 — Storage trait split
 
 `storage/mod.rs` is ~8K LOC: the `Storage` trait definition (~2K) plus the
 in-memory implementation (~6K). Split into:
@@ -197,7 +141,7 @@ Acceptance: every existing import keeps resolving via `storage::*`. The
 `opfs_btree` cfg-fork now lives at module boundary, not as `#[cfg]` blocks
 threaded through one file.
 
-## Phase 5 — `RuntimeCore` decomposition
+## Phase 4 — `RuntimeCore` decomposition
 
 `RuntimeCore` (`runtime_core.rs:282-332`) holds 15+ fields blending
 unrelated concerns. Extract three focused owners:
@@ -247,7 +191,7 @@ Acceptance: existing `runtime_core/tests.rs` passes unchanged. Behavior of
 `immediate_tick` and `batched_tick` is identical (verified by integration
 tests, not internal mocks — see CLAUDE.md TDD note).
 
-## Phase 6 — Subscribe as typed builder
+## Phase 5 — Subscribe as typed builder
 
 The two-phase subscribe path (`runtime_core/subscriptions.rs:179-266`)
 requires the caller to call `create_subscription` followed by
@@ -291,7 +235,7 @@ Acceptance: every Rust call site updated in the same PR; no
 `RuntimeCore`. If the FFI-internal-forwarding shape is chosen, document
 that explicitly in each binding's wrapper.
 
-## Phase 7 — Centralize storage-flush flag
+## Phase 6 — Centralize storage-flush flag
 
 `mark_storage_write_pending_flush()` is currently called from four files:
 
@@ -315,7 +259,7 @@ Acceptance:
   `writes.rs`, `ticks.rs`, or `sync.rs`.
 - `batched_tick` flushes whenever the guard registry shows unflushed work.
 
-## Phase 8 — `query_manager/graph.rs` split
+## Phase 7 — `query_manager/graph.rs` split
 
 `graph.rs` is 4.6K LOC and conflates two phases:
 
@@ -352,25 +296,25 @@ These came up in the audit but should be separate specs if pursued:
 
 ## Invariants
 
-- Phases 1, 2, 4, 5, 7, 8 preserve the public API of `jazz-tools`. Phases
-  3 and 6 are deliberate API breaks; they coordinate the corresponding
+- Phases 1, 3, 4, 6, 7 preserve the public API of `jazz-tools`. Phases 2
+  and 5 are deliberate API breaks; they coordinate the corresponding
   binding updates in the same PR (see _Public API impact_ above).
 - All phases preserve wire format, storage format, sync semantics.
 - Tests are not rewritten; they move with their code. Per CLAUDE.md, an
   unexpectedly failing test is treated as a signal, not as something to
   edit out.
-- Each phase is its own PR. Phases 1–4 are independent of one another;
-  phases 5–8 build on the cleaner module layout from 1–4.
+- Each phase is its own PR. Phases 1–3 are independent of one another;
+  phases 4–7 build on the cleaner module layout from 1–3.
 
 ## Testing Strategy
 
 - Each phase relies on the existing `cargo test --all-features` and
   `pnpm test` suites. No new test files are required for the moves
   themselves.
-- For Phase 5 (RuntimeCore decomposition), the existing
+- For Phase 4 (RuntimeCore decomposition), the existing
   `runtime_core/tests.rs` exercises `immediate_tick`/`batched_tick`
   end-to-end and is the load-bearing safety net.
-- For Phase 6 (typed subscribe), removing the old API at compile time
+- For Phase 5 (typed subscribe), removing the old API at compile time
   is the test — no path can call `create_subscription` without the
   compiler complaining.
 - Per CLAUDE.md, prefer e2e checks over unit tests added during the
@@ -383,22 +327,20 @@ These came up in the audit but should be separate specs if pursued:
 ```
 1 Junk drawer ────┐
                   ├── independent, mergeable in any order
-2 Entry-point   ──┤
+2 Builder enum ───┤
                   │
-3 Builder enum ───┤
-                  │
-4 Storage split ──┘
+3 Storage split ──┘
                   │
                   v
-5 RuntimeCore decomposition  (depends on 1: sync_tracer + clock have moved)
+4 RuntimeCore decomposition  (depends on 1: sync_tracer + clock have moved)
                   │
                   v
-6 Typed subscribe            (depends on 5: SubscriptionRegistry exists)
+5 Typed subscribe            (depends on 4: SubscriptionRegistry exists)
                   │
                   v
-7 WriteGuard                 (depends on 5: DurabilityTracker exists)
+6 WriteGuard                 (depends on 4: DurabilityTracker exists)
                   │
                   v
-8 graph.rs split             (independent; sequenced last to avoid
+7 graph.rs split             (independent; sequenced last to avoid
                               merge conflicts with hot-path PRs)
 ```

--- a/specs/todo/c_later/crate_structure_cleanup.md
+++ b/specs/todo/c_later/crate_structure_cleanup.md
@@ -37,8 +37,10 @@ Two phases are **deliberate API breaks** coordinated with binding updates in
 the same PR:
 
 - **Phase 2 (builder collapse)** — replaces four public `ServerBuilder::with_*_storage`
-  methods. Call sites in `crates/jazz-napi/src/lib.rs:1585, 1754, 1756` must
-  be updated in the same PR.
+  methods. Call sites in `crates/jazz-napi/src/lib.rs:1754, 1756` must be
+  updated in the same PR. (Note: `jazz-napi/src/lib.rs:1585` looks similar
+  but is a call on `TestingServerBuilder`, a separate builder — out of
+  scope for this phase. See Phase 2 below.)
 - **Phase 5 (typed subscribe)** — replaces public
   `RuntimeCore::{create_subscription, execute_subscription}`. Call sites in
   `crates/jazz-napi/src/lib.rs:941, 983`, `crates/jazz-wasm/src/runtime.rs:1588, 1612`,
@@ -49,30 +51,46 @@ the same PR:
 
 Pure mechanical moves. Each one is a single PR.
 
-| Move                | From                  | To                                                                                 |
-| ------------------- | --------------------- | ---------------------------------------------------------------------------------- |
-| Sync clock          | `monotonic_clock.rs`  | `sync_manager/clock.rs`                                                            |
-| Batch lifecycle     | `batch_fate.rs`       | `sync_manager/batch_fate.rs`                                                       |
-| Sync test recorder  | `sync_tracer.rs`      | `sync_manager/test_support.rs` (gated `#[cfg(any(test, feature = "test-utils"))]`) |
-| HTTP route surface  | `routes.rs`           | `server/routes.rs`                                                                 |
-| Native binding glue | `binding_support.rs`  | `query_manager/bindings.rs`                                                        |
-| Test row history    | `test_row_history.rs` | `row_histories/tests.rs` (gated `#[cfg(test)]`)                                    |
+| Move                | From                  | To                                                                    |
+| ------------------- | --------------------- | --------------------------------------------------------------------- |
+| Sync clock          | `monotonic_clock.rs`  | `sync_manager/clock.rs`                                               |
+| Sync tracer         | `sync_tracer.rs`      | `sync_manager/sync_tracer.rs`                                         |
+| HTTP route surface  | `routes.rs`           | `server/routes.rs`                                                    |
+| Native binding glue | `binding_support.rs`  | `query_manager/bindings.rs`                                           |
+| Test row history    | `test_row_history.rs` | `test_support.rs` (gated `#[cfg(any(test, feature = "test-utils"))]`) |
 
 Notes:
 
-- The sync-test-recorder gate uses the existing `test-utils` feature defined
-  in `crates/jazz-tools/Cargo.toml` (alongside `test`). No new feature is
-  introduced.
+- `sync_tracer` is **not** moved behind a feature gate. The type is referenced
+  unconditionally by production code: `RuntimeCore::sync_tracer`
+  (`runtime_core.rs:327`), `RuntimeCore::set_sync_tracer`
+  (`runtime_core.rs:403`), and `ServerBuilder::with_sync_tracer`
+  (`server/builder.rs:86`). It's named "tracer" because tests use it as a
+  recorder, but the surface is part of the production API. The move is a
+  pure relocation.
+- `batch_fate` **stays at the top level**. It's used by ~15 files spanning
+  `runtime_core.rs`, `storage/mod.rs`, `binding_support.rs`,
+  `schema_manager/manager.rs`, `sync_manager/*` — by the ≥3-subsystem rule
+  below it qualifies as a primitive.
+- `test_row_history` is consumed by tests in `storage/`, `sync_manager/`,
+  `schema_manager/`, and `query_manager/`. A top-level `crate::test_support`
+  is the most honest home; tucking it inside any one subsystem creates
+  awkward cross-subsystem `crate::<subsystem>::tests::*` imports.
 - `binding_support` is currently `pub mod binding_support;` in `lib.rs:2` and
   imported as `jazz_tools::binding_support::*` from all three FFI crates
   (e.g. `jazz-napi/src/lib.rs:25`, `jazz-wasm/src/runtime.rs:21, 62`,
   `jazz-rn/rust/src/lib.rs:14`). The move keeps that import path stable via
   a `pub use crate::query_manager::bindings as binding_support;` re-export in
   `lib.rs` — so binding crates see no source change.
+- Every other moved module (`monotonic_clock`, `sync_tracer`, `routes`) is
+  also `pub mod` in `lib.rs` today. Each one needs a matching `pub use`
+  re-export in `lib.rs` so callers using `jazz_tools::sync_tracer::SyncTracer`
+  (e.g. `crates/jazz-tools/tests/sync_tracer_integration.rs`) continue to
+  resolve.
 
 Top-level files that **stay** (true primitives, used by ≥3 subsystems):
-`commit.rs`, `digest.rs`, `identity.rs`, `metadata.rs`, `object.rs`,
-`row_format.rs`, `wire_types.rs`, `catalogue.rs`, `otel.rs`.
+`batch_fate.rs`, `commit.rs`, `digest.rs`, `identity.rs`, `metadata.rs`,
+`object.rs`, `row_format.rs`, `wire_types.rs`, `catalogue.rs`, `otel.rs`.
 
 Acceptance:
 
@@ -84,10 +102,10 @@ Acceptance:
 
 ## Phase 2 — Builder collapse
 
-Replace the four storage builder variants (`with_persistent_storage`,
-`with_in_memory_storage`, `with_sqlite_storage`, `with_rocksdb_storage` —
-`server/builder.rs:86-146`) with a single `.with_storage(StorageBackend)`
-where `StorageBackend` is an enum:
+Replace the four storage builder variants on `ServerBuilder`
+(`with_persistent_storage`, `with_in_memory_storage`, `with_sqlite_storage`,
+`with_rocksdb_storage` — `server/builder.rs:106, 118, 130, 137`) with a
+single `.with_storage(StorageBackend)` where `StorageBackend` is an enum:
 
 ```rust
 pub enum StorageBackend {
@@ -98,33 +116,62 @@ pub enum StorageBackend {
 }
 ```
 
-The four call sites in tests, `commands/server.rs`, and `server/testing.rs`
-are mechanical replacements. Old methods are removed (no deprecation shim —
-this is prototype-stage code, per CLAUDE.md).
+Internal call sites are mechanical replacements:
+
+- `commands/server.rs:37, 39`
+- `server/mod.rs:359`
+- `server/testing.rs:476, 480, 483, 485` (the test-builder façade — see
+  below for why this stays)
+- 6 calls in tests inside `routes.rs` (lines 1719, 1731, 1746, 1947, 1989,
+  2053).
+
+Old methods are removed (no deprecation shim — this is prototype-stage code,
+per CLAUDE.md).
+
+**Scope clarification.** `TestingServerBuilder` (`server/testing.rs:27`) has
+its own parallel `with_persistent_storage` / `with_sqlite_storage` /
+`with_rocksdb_storage` (testing.rs:79, 87, 96). It's a different type —
+`napi/src/lib.rs:1585`, for example, is a call on `TestingServerBuilder`,
+not `ServerBuilder`. Phase 2 leaves the testing builder untouched; its
+public surface is consumed by the napi `TestingServer` wrapper and changing
+it would expand the FFI break unnecessarily. If a follow-up wants to apply
+the same enum collapse there, that's a separate phase.
 
 **This is a public API break.** `with_persistent_storage`,
 `with_in_memory_storage`, `with_sqlite_storage`, and `with_rocksdb_storage`
-are public on `ServerBuilder` (`crates/jazz-tools/src/server/builder.rs:106-137`)
-and called directly by `crates/jazz-napi/src/lib.rs:1585, 1754, 1756`. The
-napi crate must be updated in the same PR. WASM and RN do not currently call
+are public on `ServerBuilder` (`crates/jazz-tools/src/server/builder.rs:106-140`)
+and called directly by `crates/jazz-napi/src/lib.rs:1754, 1756`. The napi
+crate must be updated in the same PR. WASM and RN do not currently call
 these.
 
 Acceptance:
 
 - `cargo build --all-features` clean.
-- `crates/jazz-napi/src/lib.rs` updated to the new `with_storage(...)` API in
-  the same PR; `pnpm build` and `pnpm test` for the napi package pass.
+- `crates/jazz-napi/src/lib.rs:1754, 1756` updated to the new
+  `with_storage(...)` API in the same PR; `pnpm build` and `pnpm test` for
+  the napi package pass.
 - Tests unchanged in spirit (only the call shape rewritten).
 
 ## Phase 3 — Storage trait split
 
-`storage/mod.rs` is ~8K LOC: the `Storage` trait definition (~2K) plus the
-in-memory implementation (~6K). Split into:
+`storage/mod.rs` is ~8K LOC, structured as three buckets:
+
+- Lines 1–2621 (~2.6K): trait-adjacent types and codecs — `StorageError`,
+  `RawTableHeader`, `RowLocator`, `IndexMutation`, `RawTableMutation`, the
+  `cached_*` static helpers, key encoders/decoders, etc.
+- Lines 2622–4751 (~2.1K): the `Storage` trait definition with default
+  methods.
+- Lines 4752–8040 (~3.3K): `MemoryStorage` struct + impls + tests.
+
+Split into:
 
 ```
 storage/
-  mod.rs           re-exports + module docs
-  trait.rs         the Storage trait + associated types
+  mod.rs           re-exports + module docs + the ~2.6K of trait-adjacent
+                   types and codecs (StorageError, RowLocator, key encoders,
+                   cache statics, etc.) — these are not specific to any one
+                   backend
+  storage_trait.rs the Storage trait + associated types
   memory.rs        MemoryStorage impl
   sqlite.rs        (existing)
   rocksdb.rs       (existing)
@@ -136,6 +183,12 @@ storage/
     native.rs      #[cfg(not(target_arch = "wasm32"))] body
     wasm.rs        #[cfg(target_arch = "wasm32")] body
 ```
+
+Naming `storage_trait.rs` rather than `trait.rs` avoids the reserved-keyword
+filename. The trait-adjacent types stay in `mod.rs` because they're shared
+across all backends — moving them into `storage_trait.rs` would create a
+weird "trait module owns the storage error type" coupling, and moving them
+into `memory.rs` is wrong since sqlite/rocksdb need them too.
 
 Acceptance: every existing import keeps resolving via `storage::*`. The
 `opfs_btree` cfg-fork now lives at module boundary, not as `#[cfg]` blocks
@@ -156,7 +209,7 @@ unrelated concerns. Extract three focused owners:
   (`Option<seq>`). Exact API to be settled during implementation, but it
   must support: parking new entries, draining ready entries with their
   metadata (notably whether each entry writes storage — see
-  `runtime_core/sync.rs:47` and `runtime_core/ticks.rs:632`), and reporting
+  `runtime_core/sync.rs:49` and `runtime_core/ticks.rs:634`), and reporting
   whether further work is pending. Orchestration concerns (marking
   storage-flush state, scheduling the next tick) stay in `RuntimeCore` —
   the inbox returns enough information for the orchestrator to do them.
@@ -291,8 +344,9 @@ These came up in the audit but should be separate specs if pursued:
 - Rejected-batch notification channel — currently polled via
   `drain_rejected_batch_ids`; piggybacking on the subscription delta
   stream is appealing but is a behavioral change, not cleanup.
-- `query_manager/graph_nodes/magic_columns.rs` (47 LOC) — possibly inline
-  into `graph_nodes/mod.rs`, but trivially low value on its own.
+- `query_manager/magic_columns.rs` (47 LOC, the top-level helper, not the
+  444-LOC operator file at `query_manager/graph_nodes/magic_columns.rs`) —
+  possibly inline into its single caller, but trivially low value on its own.
 
 ## Invariants
 

--- a/specs/todo/c_later/crate_structure_cleanup.md
+++ b/specs/todo/c_later/crate_structure_cleanup.md
@@ -87,16 +87,27 @@ Acceptance:
 Small, independent fixes that remove parallel construction logic between
 `client.rs` and `server/builder.rs`.
 
-1. Extract `build_schema_manager(storage, context, role)` from the duplicated
-   blocks at `client.rs:64-82` and `server/builder.rs:217-238`.
-2. Extract `resolve_node_env()` from `main.rs:24-36` and `builder.rs:305-309`
+1. Extract `resolve_node_env()` from `main.rs:24-36` and `builder.rs:305-309`
    into a single helper (likely `server/env.rs`).
-3. Move JWT key resolution from `main.rs:38-59` into `commands/server.rs` so
+2. Move JWT key resolution from `main.rs:38-59` into `commands/server.rs` so
    the library no longer carries CLI-shaped logic.
-4. Reuse one `reqwest::Client` between the main server (`builder.rs:155`) and
+3. Reuse one `reqwest::Client` between the main server (`builder.rs:155`) and
    the JWKS loader (`builder.rs:338-342`).
-5. Delete `#[allow(dead_code)] pub app_id` on `ServerState` (`server/mod.rs:165`)
+4. Delete `#[allow(dead_code)] pub app_id` on `ServerState` (`server/mod.rs:165`)
    — either use it in a routed handler or remove the field.
+
+(An earlier draft proposed extracting a shared `build_schema_manager` from
+`client.rs:64-82` and `server/builder.rs:217-238`. On closer reading those
+two functions are not duplicates: the client uses an empty `SyncManager`,
+always constructs `SchemaManager::new(...)` with the declared schema, uses
+the `"client"` tier label, and always rehydrates from the catalogue. The
+server uses `server_sync_manager()` (Edge+Global tiers, plus optional
+unprivileged catalogue writes when `NODE_ENV != production`), splits on
+Dynamic vs Fixed schema mode, uses `"prod"`, only rehydrates in Dynamic
+mode, calls `require_authorization_schema()` afterwards to fail closed,
+and returns `String` errors. Sharing them would require a function with
+five orthogonal parameters that obscures rather than clarifies. Left as
+two separate construction policies.)
 
 (Promoting `allow_local_first_auth: true` into `AuthConfig::default()` was
 considered but moved to _Out of scope_ below: `AuthConfig` derives `Default`

--- a/specs/todo/c_later/crate_structure_cleanup.md
+++ b/specs/todo/c_later/crate_structure_cleanup.md
@@ -1,0 +1,277 @@
+# Crate Structure Cleanup — TODO (Later)
+
+Non-blocking refactor of `crates/jazz-tools/` aimed at making the crate easier to
+read end-to-end. No functional change. Each phase is independently mergeable and
+ordered so later work depends on earlier moves.
+
+The motivation is captured in a runtime-first walkthrough done against `main`
+at `fa52406b6`: the runtime layer itself is in good shape (a sync state machine
+plus a thin tokio wrapper), but the top-level `src/` directory has become a
+junk drawer, a few files have outgrown their seams, and a handful of types live
+inside `RuntimeCore` that conceptually belong elsewhere.
+
+## Goals
+
+- Top-level `src/` only contains entry points and true cross-subsystem
+  primitives.
+- Each subsystem owns its own helpers, test support, and platform splits.
+- `RuntimeCore` shrinks to orchestration; bookkeeping moves to dedicated types.
+- No file over ~3K LOC except as a deliberate, documented exception.
+
+## Non-goals
+
+- No change to public API of `jazz-tools` consumed by `jazz-napi`, `jazz-wasm`,
+  `jazz-rn`, or the TS client. Re-exports in `lib.rs` continue to expose the
+  same names from their new paths.
+- No change to wire format, storage format, sync semantics, or query
+  evaluation.
+- No new features. Hypothetical future requirements do not justify abstractions
+  introduced here.
+- No tests rewritten. Tests move with their code; their assertions stay.
+
+## Phase 1 — Junk-drawer relocation
+
+Pure mechanical moves. Each one is a single PR.
+
+| Move                | From                  | To                                                                                   |
+| ------------------- | --------------------- | ------------------------------------------------------------------------------------ |
+| Sync clock          | `monotonic_clock.rs`  | `sync_manager/clock.rs`                                                              |
+| Batch lifecycle     | `batch_fate.rs`       | `sync_manager/batch_fate.rs`                                                         |
+| Sync test recorder  | `sync_tracer.rs`      | `sync_manager/test_support.rs` (gated `#[cfg(any(test, feature = "test-support"))]`) |
+| HTTP route surface  | `routes.rs`           | `server/routes.rs`                                                                   |
+| Native binding glue | `binding_support.rs`  | `query_manager/bindings.rs`                                                          |
+| Test row history    | `test_row_history.rs` | `row_histories/tests.rs` (gated `#[cfg(test)]`)                                      |
+
+Top-level files that **stay** (true primitives, used by ≥3 subsystems):
+`commit.rs`, `digest.rs`, `identity.rs`, `metadata.rs`, `object.rs`,
+`row_format.rs`, `wire_types.rs`, `catalogue.rs`, `otel.rs`.
+
+Acceptance:
+
+- `cargo build --all-features` and `cargo test --all-features` pass.
+- `pnpm build` and `pnpm test` pass (covers napi/wasm/rn re-export paths).
+- No `pub use` from `lib.rs` changes name; only the path on the right-hand
+  side of each re-export shifts.
+
+## Phase 2 — Entry-point dedup
+
+Small, independent fixes that remove parallel construction logic between
+`client.rs` and `server/builder.rs`.
+
+1. Extract `build_schema_manager(storage, context, role)` from the duplicated
+   blocks at `client.rs:64-82` and `server/builder.rs:217-238`.
+2. Extract `resolve_node_env()` from `main.rs:24-36` and `builder.rs:305-309`
+   into a single helper (likely `server/env.rs`).
+3. Move JWT key resolution from `main.rs:38-59` into `commands/server.rs` so
+   the library no longer carries CLI-shaped logic.
+4. Reuse one `reqwest::Client` between the main server (`builder.rs:155`) and
+   the JWKS loader (`builder.rs:338-342`).
+5. Promote `allow_local_first_auth: true` to `AuthConfig::default()` and drop
+   the hardcoded copies in `builder.rs:73-76` and `server/testing.rs:105`.
+6. Delete `#[allow(dead_code)] pub app_id` on `ServerState` (`server/mod.rs:165`)
+   — either use it in a routed handler or remove the field.
+
+## Phase 3 — Builder collapse
+
+Replace the four storage builder variants (`with_persistent_storage`,
+`with_in_memory_storage`, `with_sqlite_storage`, `with_rocksdb_storage` —
+`server/builder.rs:86-146`) with a single `.with_storage(StorageBackend)`
+where `StorageBackend` is an enum:
+
+```rust
+pub enum StorageBackend {
+    InMemory,
+    Sqlite { path: PathBuf },
+    RocksDb { path: PathBuf },
+    Persistent { path: PathBuf }, // current default-shape
+}
+```
+
+The four call sites in tests, `commands/server.rs`, and `server/testing.rs`
+are mechanical replacements. Old methods are removed (no deprecation shim —
+this is prototype-stage code, per CLAUDE.md).
+
+Acceptance: `cargo build --all-features` clean; tests unchanged in spirit.
+
+## Phase 4 — Storage trait split
+
+`storage/mod.rs` is ~8K LOC: the `Storage` trait definition (~2K) plus the
+in-memory implementation (~6K). Split into:
+
+```
+storage/
+  mod.rs           re-exports + module docs
+  trait.rs         the Storage trait + associated types
+  memory.rs        MemoryStorage impl
+  sqlite.rs        (existing)
+  rocksdb.rs       (existing)
+  storage_core.rs  (existing)
+  key_codec.rs     (existing)
+  conformance.rs   (existing)
+  opfs_btree/
+    mod.rs
+    native.rs      #[cfg(not(target_arch = "wasm32"))] body
+    wasm.rs        #[cfg(target_arch = "wasm32")] body
+```
+
+Acceptance: every existing import keeps resolving via `storage::*`. The
+`opfs_btree` cfg-fork now lives at module boundary, not as `#[cfg]` blocks
+threaded through one file.
+
+## Phase 5 — `RuntimeCore` decomposition
+
+`RuntimeCore` (`runtime_core.rs:282-332`) holds 15+ fields blending
+unrelated concerns. Extract three focused owners:
+
+- **`DurabilityTracker`** — owns `ack_watchers` and `rejected_batch_ids`.
+  Provides `register_watcher`, `record_ack`, `record_rejection`,
+  `drain_rejected`. Used by `runtime_core/writes.rs`.
+- **`SyncInbox`** — owns `parked_sync_messages`,
+  `parked_sync_messages_by_server_seq`, `next_expected_server_seq`,
+  `last_applied_server_seq`. Replaces dual-buffer code at
+  `runtime_core/ticks.rs:622-684` with one keyed buffer
+  (`Option<seq>`). Provides `push`, `apply_ready(&mut SyncManager)`.
+- **`SubscriptionRegistry`** — owns `subscriptions`, `subscription_reverse`,
+  `pending_subscriptions`, `pending_one_shot_queries`. Encloses the
+  one-shot leak window in `runtime_core/ticks.rs:390-475` by carrying the
+  `sub_id` on `PendingOneShotQuery` so failure paths clean up
+  consistently.
+
+Done correctly, `RuntimeCore` becomes:
+
+```rust
+pub struct RuntimeCore<S, Sch> {
+    schema_manager: SchemaManager,
+    storage: S,
+    scheduler: Sch,
+    transport: Option<TransportHandle>,
+    sync_sender: Option<Box<dyn SyncSender>>,
+    inbox: SyncInbox,
+    durability: DurabilityTracker,
+    subscriptions: SubscriptionRegistry,
+    tier_label: &'static str,
+    sync_tracer: Option<SyncTracer>,
+    auth_failure_callback: Option<AuthFailureCallback>,
+}
+```
+
+The Scheduler / SyncSender trait boundaries do not move. The FFI scheduler
+glue in `jazz-napi` and `jazz-wasm` continues to talk to the same traits.
+
+Acceptance: existing `runtime_core/tests.rs` passes unchanged. Behavior of
+`immediate_tick` and `batched_tick` is identical (verified by integration
+tests, not internal mocks — see CLAUDE.md TDD note).
+
+## Phase 6 — Subscribe as typed builder
+
+The two-phase subscribe path (`runtime_core/subscriptions.rs:179-266`)
+requires the caller to call `create_subscription` followed by
+`execute_subscription`. The pair is enforced by convention only.
+
+Replace with a state-machine type:
+
+```rust
+let pending = runtime.subscribe(query); // -> PendingSubscription
+let handle  = pending.execute(callback); // consumes pending
+```
+
+`PendingSubscription` is `#[must_use]` and only exposes `execute(...)`.
+Forgetting to call `execute` becomes a compiler warning; calling it twice
+is impossible.
+
+Acceptance: every existing call site updated in the same PR; no
+`pub fn create_subscription` / `pub fn execute_subscription` remain on
+`RuntimeCore`.
+
+## Phase 7 — Centralize storage-flush flag
+
+`mark_storage_write_pending_flush()` is called 21× in
+`runtime_core/writes.rs` and 3× in `runtime_core/ticks.rs`. The flag is
+set defensively after any mutation that touches the storage layer.
+
+Replace with a `WriteGuard` returned by mutation entry points; the guard
+sets the flag on construction and releases it normally. Mutation
+functions stop knowing about the flag at all.
+
+Acceptance: zero direct calls to `mark_storage_write_pending_flush` from
+`writes.rs`; `batched_tick` flushes whenever the guard registry shows
+unflushed work.
+
+## Phase 8 — `query_manager/graph.rs` split
+
+`graph.rs` is 4.6K LOC and conflates two phases:
+
+- **compile** — turn relation IR into `QueryGraph` nodes; pure transform
+- **execute** — `QueryGraph::settle()` and friends; row I/O via closure
+
+Split into `graph_compile.rs` and `graph_execute.rs` with `graph/mod.rs`
+re-exporting. `policy_eval` logic that today lives in `policy.rs` (3.1K)
+folds into the existing `graph_nodes/` per-operator files where possible;
+shared evaluation primitives stay in `policy.rs` but shrink.
+
+Acceptance: no public type renamed; `cargo bench` (if present for query
+hot paths) is within ±2% of pre-split numbers.
+
+## Out of scope (capture only)
+
+These came up in the audit but should be separate specs if pursued:
+
+- WASM/native callback duplication in `subscriptions.rs:79-148` — needs
+  thinking about whether the `Send` bound should be at the trait or the
+  call site.
+- Rejected-batch notification channel — currently polled via
+  `drain_rejected_batch_ids`; piggybacking on the subscription delta
+  stream is appealing but is a behavioral change, not cleanup.
+- `query_manager/graph_nodes/magic_columns.rs` (47 LOC) — possibly inline
+  into `graph_nodes/mod.rs`, but trivially low value on its own.
+
+## Invariants
+
+- All phases preserve the public API of `jazz-tools`.
+- All phases preserve wire format, storage format, sync semantics.
+- Tests are not rewritten; they move with their code. Per CLAUDE.md, an
+  unexpectedly failing test is treated as a signal, not as something to
+  edit out.
+- Each phase is its own PR. Phases 1–4 are independent of one another;
+  phases 5–8 build on the cleaner module layout from 1–4.
+
+## Testing Strategy
+
+- Each phase relies on the existing `cargo test --all-features` and
+  `pnpm test` suites. No new test files are required for the moves
+  themselves.
+- For Phase 5 (RuntimeCore decomposition), the existing
+  `runtime_core/tests.rs` exercises `immediate_tick`/`batched_tick`
+  end-to-end and is the load-bearing safety net.
+- For Phase 6 (typed subscribe), removing the old API at compile time
+  is the test — no path can call `create_subscription` without the
+  compiler complaining.
+- Per CLAUDE.md, prefer e2e checks over unit tests added during the
+  refactor; do not introduce internal-helper tests for the new types
+  (`DurabilityTracker`, `SyncInbox`, `SubscriptionRegistry`) unless they
+  contain non-trivial pure logic worth pinning.
+
+## Phase ordering rationale
+
+```
+1 Junk drawer ────┐
+                  ├── independent, mergeable in any order
+2 Entry-point   ──┤
+                  │
+3 Builder enum ───┤
+                  │
+4 Storage split ──┘
+                  │
+                  v
+5 RuntimeCore decomposition  (depends on 1: sync_tracer + clock have moved)
+                  │
+                  v
+6 Typed subscribe            (depends on 5: SubscriptionRegistry exists)
+                  │
+                  v
+7 WriteGuard                 (depends on 5: DurabilityTracker exists)
+                  │
+                  v
+8 graph.rs split             (independent; sequenced last to avoid
+                              merge conflicts with hot-path PRs)
+```

--- a/specs/todo/c_later/crate_structure_cleanup.md
+++ b/specs/todo/c_later/crate_structure_cleanup.md
@@ -103,8 +103,8 @@ Acceptance:
 ## Phase 2 — Builder collapse
 
 Replace the four storage builder variants on `ServerBuilder`
-(`with_persistent_storage`, `with_in_memory_storage`, `with_sqlite_storage`,
-`with_rocksdb_storage` — `server/builder.rs:106, 118, 130, 137`) with a
+(`with_persistent_storage`, `with_sqlite_storage`, `with_rocksdb_storage`,
+`with_in_memory_storage` — `server/builder.rs:106, 118, 130, 137`) with a
 single `.with_storage(StorageBackend)` where `StorageBackend` is an enum:
 
 ```rust
@@ -122,8 +122,12 @@ Internal call sites are mechanical replacements:
 - `server/mod.rs:359`
 - `server/testing.rs:476, 480, 483, 485` (the test-builder façade — see
   below for why this stays)
-- 6 calls in tests inside `routes.rs` (lines 1719, 1731, 1746, 1947, 1989,
-  2053).
+- 8 calls in tests inside `routes.rs` (lines 1752, 1764, 1779, 1980, 2022,
+  2064, 2106, 2170 — all `with_in_memory_storage`).
+- Integration tests under `crates/jazz-tools/tests/` —
+  `sqlite_storage_integration.rs` (7×), `rocksdb_storage_integration.rs`
+  (7×), `history_conflict.rs` (1×), `support/mod.rs` (1×). 16 calls
+  total; mechanical rewrite in the same PR.
 
 Old methods are removed (no deprecation shim — this is prototype-stage code,
 per CLAUDE.md).
@@ -214,8 +218,9 @@ unrelated concerns. Extract three focused owners:
   storage-flush state, scheduling the next tick) stay in `RuntimeCore` —
   the inbox returns enough information for the orchestrator to do them.
 - **`SubscriptionRegistry`** — owns `subscriptions`, `subscription_reverse`,
-  `pending_subscriptions`, `pending_one_shot_queries`. Pure extraction;
-  the one-shot leak claim from earlier audit notes is stale —
+  `pending_subscriptions`, `pending_one_shot_queries`, and the
+  `next_subscription_handle` counter that allocates fresh handles. Pure
+  extraction; the one-shot leak claim from earlier audit notes is stale —
   `PendingOneShotQuery` already stores `subscription_id`
   (`runtime_core.rs:273-274`, populated at `subscriptions.rs:396`).
 
@@ -231,22 +236,39 @@ pub struct RuntimeCore<S, Sch> {
     inbox: SyncInbox,
     durability: DurabilityTracker,
     subscriptions: SubscriptionRegistry,
+    storage_write_pending_flush: bool,
     tier_label: &'static str,
     sync_tracer: Option<SyncTracer>,
     auth_failure_callback: Option<AuthFailureCallback>,
 }
 ```
 
+`storage_write_pending_flush` (the flag set by
+`mark_storage_write_pending_flush`) stays on `RuntimeCore` rather than
+moving into `DurabilityTracker`. Phase 6 reworks how it's set (via a
+`WriteGuard` constructed at mutation entry points), but the orchestrator
+is still the one that flushes, so the field belongs at the orchestrator
+level.
+
 The Scheduler / SyncSender trait boundaries do not move. The FFI scheduler
 glue in `jazz-napi` and `jazz-wasm` continues to talk to the same traits.
 
-Acceptance: existing `runtime_core/tests.rs` passes unchanged. Behavior of
-`immediate_tick` and `batched_tick` is identical (verified by integration
-tests, not internal mocks — see CLAUDE.md TDD note).
+Acceptance:
+
+- Existing `runtime_core/tests.rs` passes unchanged. Behavior of
+  `immediate_tick` and `batched_tick` is identical (verified by integration
+  tests, not internal mocks — see CLAUDE.md TDD note).
+- `runtime_core.rs` (the parent file alongside the `runtime_core/`
+  directory) is folded into `runtime_core/mod.rs`. Every other subsystem
+  (`query_manager`, `schema_manager`, `storage`, `sync_manager`, `server`,
+  `middleware`, `row_histories`, `ws_stream`, `commands`) uses `mod.rs`;
+  `runtime_core` is the lone holdout. The decomposition is the natural
+  moment to align — once orchestration shrinks, folding the parent file is
+  cheap.
 
 ## Phase 5 — Subscribe as typed builder
 
-The two-phase subscribe path (`runtime_core/subscriptions.rs:179-266`)
+The two-phase subscribe path (`runtime_core/subscriptions.rs:173-269`)
 requires the caller to call `create_subscription` followed by
 `execute_subscription`. The pair is enforced by convention only.
 
@@ -324,8 +346,42 @@ re-exporting. `policy_eval` logic that today lives in `policy.rs` (3.1K)
 folds into the existing `graph_nodes/` per-operator files where possible;
 shared evaluation primitives stay in `policy.rs` but shrink.
 
-Acceptance: no public type renamed; `cargo bench` (if present for query
-hot paths) is within ±2% of pre-split numbers.
+Acceptance: no public type renamed. The existing `realistic_phase1` and
+`observer_write_path` benches (`crates/jazz-tools/benches/`) show no
+regression — >5% slowdown is a blocker, <2% is noise. No graph-execution
+micro-bench exists today; the realistic-phase bench is the closest
+stand-in.
+
+## Phase 8 — Remaining 3K-LOC violators
+
+Phase 1 relocates `routes.rs` to `server/routes.rs` but does not split it.
+Two top-level files still exceed the 3K-LOC goal after Phase 1; Phase 8
+addresses both.
+
+- `server/routes.rs` (3654 LOC) — splits along three seams: HTTP endpoint
+  handlers + the `create_router` builder, the WebSocket lifecycle
+  (`ws_handler`, `authenticate_ws_handshake`, `handle_ws_connection`,
+  `ws_cleanup`, etc. — `routes.rs:1178-1675`), and parser/validator
+  helpers. Target: `server/routes/{http,websocket,utils,mod}.rs`. The
+  `mod.rs` re-exports `create_router` so `server::routes::create_router`
+  resolves unchanged for `server/mod.rs` and `commands/server.rs`.
+- `row_histories/mod.rs` (3441 LOC) — three buckets: data types
+  (`BatchId` at line 25, `RowState` at line 102, `QueryRowBatch`,
+  `StoredRowBatch`, `VisibleRowEntry`, error types), descriptor/codec
+  builders + flat encode/decode, and the application algorithms
+  (`apply_row_batch` at line 2068, `patch_row_batch_state` at line 2196).
+  Target: `row_histories/{types,codecs,apply,mod}.rs`.
+
+Watch list (no action this phase): `query_manager/policy.rs` (3181 LOC,
+already shrinks under Phase 7), `schema_manager/manager.rs` (3105 LOC,
+cohesive façade), `query_manager/writes.rs` (2814 LOC but most active
+borderline file, ~100 commits — flag for split if it crosses ~3.5K).
+
+Each split is mechanical and independent of the others. Acceptance: no
+public type renamed; existing imports continue to resolve via
+re-exports from each module's `mod.rs`. `cargo build --all-features`
+and `cargo test --all-features` pass; `pnpm build` and `pnpm test`
+pass.
 
 ## Out of scope (capture only)
 
@@ -350,15 +406,18 @@ These came up in the audit but should be separate specs if pursued:
 
 ## Invariants
 
-- Phases 1, 3, 4, 6, 7 preserve the public API of `jazz-tools`. Phases 2
-  and 5 are deliberate API breaks; they coordinate the corresponding
-  binding updates in the same PR (see _Public API impact_ above).
+- Phases 1, 3, 4, 6, 7, 8 preserve the public API of `jazz-tools`.
+  Phases 2 and 5 are deliberate API breaks; they coordinate the
+  corresponding binding updates in the same PR (see _Public API impact_
+  above).
 - All phases preserve wire format, storage format, sync semantics.
 - Tests are not rewritten; they move with their code. Per CLAUDE.md, an
   unexpectedly failing test is treated as a signal, not as something to
   edit out.
 - Each phase is its own PR. Phases 1–3 are independent of one another;
-  phases 4–7 build on the cleaner module layout from 1–3.
+  phases 4–7 build on the cleaner module layout from 1–3. Phase 8
+  depends on Phase 1 for the `routes.rs` move only; the
+  `row_histories/mod.rs` split is independent of every other phase.
 
 ## Testing Strategy
 
@@ -397,4 +456,9 @@ These came up in the audit but should be separate specs if pursued:
                   v
 7 graph.rs split             (independent; sequenced last to avoid
                               merge conflicts with hot-path PRs)
+                  │
+                  v
+8 3K-LOC violators           (routes.rs split depends on Phase 1's move;
+                              row_histories split is independent of all
+                              other phases)
 ```

--- a/specs/todo/c_later/crate_structure_cleanup.md
+++ b/specs/todo/c_later/crate_structure_cleanup.md
@@ -97,8 +97,15 @@ Small, independent fixes that remove parallel construction logic between
    pub `node_env_mode() -> NodeEnvMode` in `server/env.rs`) and have both
    policy functions call it. The policy decisions on top stay separate.
    Scope is ~3 lines of true dedup; "leave it alone" is also defensible.
-2. Move JWT key resolution from `main.rs:38-59` into `commands/server.rs` so
-   the library no longer carries CLI-shaped logic.
+2. Thin `main.rs`: push CLI-helper functions
+   (`resolve_jwt_public_key_input` at `main.rs:38-59`, plus
+   `resolve_node_env_mode` and `resolve_dev_default_flag` from item 1 if
+   pursued) into `commands/server.rs`, where they're actually consumed.
+   `main.rs` keeps the clap struct definitions and dispatch only. Note:
+   both files are binary-only (`commands/` is `mod` in `main.rs`, not
+   re-exported from `lib.rs`), so this is purely a binary-internal
+   organization choice — nothing leaves or enters the public library.
+   `main.rs` is 358 lines today; "leave it alone" is defensible.
 3. Reuse one `reqwest::Client` between the main server (`builder.rs:155`) and
    the JWKS loader (`builder.rs:338-342`).
 4. Delete `#[allow(dead_code)] pub app_id` on `ServerState` (`server/mod.rs:165`)

--- a/specs/todo/c_later/crate_structure_cleanup.md
+++ b/specs/todo/c_later/crate_structure_cleanup.md
@@ -87,8 +87,16 @@ Acceptance:
 Small, independent fixes that remove parallel construction logic between
 `client.rs` and `server/builder.rs`.
 
-1. Extract `resolve_node_env()` from `main.rs:24-36` and `builder.rs:305-309`
-   into a single helper (likely `server/env.rs`).
+1. Share the `NODE_ENV` → "are we in prod?" classification between
+   `main.rs::resolve_node_env_mode()` (`main.rs:24-29`) and
+   `builder.rs::should_allow_unprivileged_schema_catalogue_writes()`
+   (`builder.rs:305-310`). The two functions do not do the same thing — one
+   gates auth defaults, the other gates unprivileged catalogue writes — but
+   they share the same env-var match (`eq_ignore_ascii_case("production")`,
+   anything else treated as dev). Extract just the classifier (e.g. a
+   pub `node_env_mode() -> NodeEnvMode` in `server/env.rs`) and have both
+   policy functions call it. The policy decisions on top stay separate.
+   Scope is ~3 lines of true dedup; "leave it alone" is also defensible.
 2. Move JWT key resolution from `main.rs:38-59` into `commands/server.rs` so
    the library no longer carries CLI-shaped logic.
 3. Reuse one `reqwest::Client` between the main server (`builder.rs:155`) and

--- a/specs/todo/c_later/crate_structure_cleanup.md
+++ b/specs/todo/c_later/crate_structure_cleanup.md
@@ -20,27 +20,55 @@ inside `RuntimeCore` that conceptually belong elsewhere.
 
 ## Non-goals
 
-- No change to public API of `jazz-tools` consumed by `jazz-napi`, `jazz-wasm`,
-  `jazz-rn`, or the TS client. Re-exports in `lib.rs` continue to expose the
-  same names from their new paths.
 - No change to wire format, storage format, sync semantics, or query
   evaluation.
 - No new features. Hypothetical future requirements do not justify abstractions
   introduced here.
 - No tests rewritten. Tests move with their code; their assertions stay.
 
+## Public API impact
+
+Most phases preserve the public API of `jazz-tools` consumed by `jazz-napi`,
+`jazz-wasm`, `jazz-rn`, and the TS client — either because they touch internal
+code only, or because re-exports in `lib.rs` keep the existing import paths
+resolving from the new module locations.
+
+Two phases are **deliberate API breaks** coordinated with binding updates in
+the same PR:
+
+- **Phase 3 (builder collapse)** — replaces four public `ServerBuilder::with_*_storage`
+  methods. Call sites in `crates/jazz-napi/src/lib.rs:1585, 1754, 1756` must
+  be updated in the same PR.
+- **Phase 6 (typed subscribe)** — replaces public
+  `RuntimeCore::{create_subscription, execute_subscription}`. Call sites in
+  `crates/jazz-napi/src/lib.rs:941, 983`, `crates/jazz-wasm/src/runtime.rs:1588, 1612`,
+  and `crates/jazz-rn/rust/src/lib.rs:713, 755` (plus the regenerated UniFFI
+  C++ shim under `crates/jazz-rn/cpp/`) must be updated in the same PR.
+
 ## Phase 1 — Junk-drawer relocation
 
 Pure mechanical moves. Each one is a single PR.
 
-| Move                | From                  | To                                                                                   |
-| ------------------- | --------------------- | ------------------------------------------------------------------------------------ |
-| Sync clock          | `monotonic_clock.rs`  | `sync_manager/clock.rs`                                                              |
-| Batch lifecycle     | `batch_fate.rs`       | `sync_manager/batch_fate.rs`                                                         |
-| Sync test recorder  | `sync_tracer.rs`      | `sync_manager/test_support.rs` (gated `#[cfg(any(test, feature = "test-support"))]`) |
-| HTTP route surface  | `routes.rs`           | `server/routes.rs`                                                                   |
-| Native binding glue | `binding_support.rs`  | `query_manager/bindings.rs`                                                          |
-| Test row history    | `test_row_history.rs` | `row_histories/tests.rs` (gated `#[cfg(test)]`)                                      |
+| Move                | From                  | To                                                                                 |
+| ------------------- | --------------------- | ---------------------------------------------------------------------------------- |
+| Sync clock          | `monotonic_clock.rs`  | `sync_manager/clock.rs`                                                            |
+| Batch lifecycle     | `batch_fate.rs`       | `sync_manager/batch_fate.rs`                                                       |
+| Sync test recorder  | `sync_tracer.rs`      | `sync_manager/test_support.rs` (gated `#[cfg(any(test, feature = "test-utils"))]`) |
+| HTTP route surface  | `routes.rs`           | `server/routes.rs`                                                                 |
+| Native binding glue | `binding_support.rs`  | `query_manager/bindings.rs`                                                        |
+| Test row history    | `test_row_history.rs` | `row_histories/tests.rs` (gated `#[cfg(test)]`)                                    |
+
+Notes:
+
+- The sync-test-recorder gate uses the existing `test-utils` feature defined
+  in `crates/jazz-tools/Cargo.toml` (alongside `test`). No new feature is
+  introduced.
+- `binding_support` is currently `pub mod binding_support;` in `lib.rs:2` and
+  imported as `jazz_tools::binding_support::*` from all three FFI crates
+  (e.g. `jazz-napi/src/lib.rs:25`, `jazz-wasm/src/runtime.rs:21, 62`,
+  `jazz-rn/rust/src/lib.rs:14`). The move keeps that import path stable via
+  a `pub use crate::query_manager::bindings as binding_support;` re-export in
+  `lib.rs` — so binding crates see no source change.
 
 Top-level files that **stay** (true primitives, used by ≥3 subsystems):
 `commit.rs`, `digest.rs`, `identity.rs`, `metadata.rs`, `object.rs`,
@@ -50,7 +78,8 @@ Acceptance:
 
 - `cargo build --all-features` and `cargo test --all-features` pass.
 - `pnpm build` and `pnpm test` pass (covers napi/wasm/rn re-export paths).
-- No `pub use` from `lib.rs` changes name; only the path on the right-hand
+- All `jazz_tools::binding_support::*` imports in the three FFI crates resolve
+  unchanged. No `pub use` from `lib.rs` is renamed; only the right-hand
   side of each re-export shifts.
 
 ## Phase 2 — Entry-point dedup
@@ -66,10 +95,14 @@ Small, independent fixes that remove parallel construction logic between
    the library no longer carries CLI-shaped logic.
 4. Reuse one `reqwest::Client` between the main server (`builder.rs:155`) and
    the JWKS loader (`builder.rs:338-342`).
-5. Promote `allow_local_first_auth: true` to `AuthConfig::default()` and drop
-   the hardcoded copies in `builder.rs:73-76` and `server/testing.rs:105`.
-6. Delete `#[allow(dead_code)] pub app_id` on `ServerState` (`server/mod.rs:165`)
+5. Delete `#[allow(dead_code)] pub app_id` on `ServerState` (`server/mod.rs:165`)
    — either use it in a routed handler or remove the field.
+
+(Promoting `allow_local_first_auth: true` into `AuthConfig::default()` was
+considered but moved to _Out of scope_ below: `AuthConfig` derives `Default`
+today, so the bool defaults to `false`, and `crates/jazz-tools/src/middleware/auth.rs:1134, 1617`
+plus `crates/jazz-tools/tests/auth_test.rs:228` rely on that. Flipping it is
+a behavior change, not cleanup.)
 
 ## Phase 3 — Builder collapse
 
@@ -91,7 +124,19 @@ The four call sites in tests, `commands/server.rs`, and `server/testing.rs`
 are mechanical replacements. Old methods are removed (no deprecation shim —
 this is prototype-stage code, per CLAUDE.md).
 
-Acceptance: `cargo build --all-features` clean; tests unchanged in spirit.
+**This is a public API break.** `with_persistent_storage`,
+`with_in_memory_storage`, `with_sqlite_storage`, and `with_rocksdb_storage`
+are public on `ServerBuilder` (`crates/jazz-tools/src/server/builder.rs:106-137`)
+and called directly by `crates/jazz-napi/src/lib.rs:1585, 1754, 1756`. The
+napi crate must be updated in the same PR. WASM and RN do not currently call
+these.
+
+Acceptance:
+
+- `cargo build --all-features` clean.
+- `crates/jazz-napi/src/lib.rs` updated to the new `with_storage(...)` API in
+  the same PR; `pnpm build` and `pnpm test` for the napi package pass.
+- Tests unchanged in spirit (only the call shape rewritten).
 
 ## Phase 4 — Storage trait split
 
@@ -130,12 +175,18 @@ unrelated concerns. Extract three focused owners:
   `parked_sync_messages_by_server_seq`, `next_expected_server_seq`,
   `last_applied_server_seq`. Replaces dual-buffer code at
   `runtime_core/ticks.rs:622-684` with one keyed buffer
-  (`Option<seq>`). Provides `push`, `apply_ready(&mut SyncManager)`.
+  (`Option<seq>`). Exact API to be settled during implementation, but it
+  must support: parking new entries, draining ready entries with their
+  metadata (notably whether each entry writes storage — see
+  `runtime_core/sync.rs:47` and `runtime_core/ticks.rs:632`), and reporting
+  whether further work is pending. Orchestration concerns (marking
+  storage-flush state, scheduling the next tick) stay in `RuntimeCore` —
+  the inbox returns enough information for the orchestrator to do them.
 - **`SubscriptionRegistry`** — owns `subscriptions`, `subscription_reverse`,
-  `pending_subscriptions`, `pending_one_shot_queries`. Encloses the
-  one-shot leak window in `runtime_core/ticks.rs:390-475` by carrying the
-  `sub_id` on `PendingOneShotQuery` so failure paths clean up
-  consistently.
+  `pending_subscriptions`, `pending_one_shot_queries`. Pure extraction;
+  the one-shot leak claim from earlier audit notes is stale —
+  `PendingOneShotQuery` already stores `subscription_id`
+  (`runtime_core.rs:273-274`, populated at `subscriptions.rs:396`).
 
 Done correctly, `RuntimeCore` becomes:
 
@@ -179,23 +230,56 @@ let handle  = pending.execute(callback); // consumes pending
 Forgetting to call `execute` becomes a compiler warning; calling it twice
 is impossible.
 
-Acceptance: every existing call site updated in the same PR; no
+**This is a public API break.** `create_subscription` and
+`execute_subscription` are public on `RuntimeCore`
+(`crates/jazz-tools/src/runtime_core/subscriptions.rs:179-231`) and called
+from all three FFI crates: `crates/jazz-napi/src/lib.rs:941, 983`,
+`crates/jazz-wasm/src/runtime.rs:1588, 1612`,
+`crates/jazz-rn/rust/src/lib.rs:713, 755` (with regenerated UniFFI bindings
+under `crates/jazz-rn/cpp/`).
+
+Two viable shapes:
+
+- **Coordinated rewrite** — change all three FFI crates in the same PR to
+  use the new state-machine API. Largest blast radius but cleanest end state.
+- **FFI-internal forwarding** — keep the new `subscribe(...).execute(cb)` API
+  at the `RuntimeCore` level but have each FFI wrapper expose a flat
+  `create_subscription` / `execute_subscription` pair internally to preserve
+  its own JS/UniFFI signatures. The "no-pair-misuse" guarantee then applies
+  inside `jazz-tools`; the FFI surface keeps its current shape until each
+  binding's API is updated independently.
+
+The coordinated rewrite is preferred unless the FFI breakage is judged too
+costly at the time of implementation.
+
+Acceptance: every Rust call site updated in the same PR; no
 `pub fn create_subscription` / `pub fn execute_subscription` remain on
-`RuntimeCore`.
+`RuntimeCore`. If the FFI-internal-forwarding shape is chosen, document
+that explicitly in each binding's wrapper.
 
 ## Phase 7 — Centralize storage-flush flag
 
-`mark_storage_write_pending_flush()` is called 21× in
-`runtime_core/writes.rs` and 3× in `runtime_core/ticks.rs`. The flag is
-set defensively after any mutation that touches the storage layer.
+`mark_storage_write_pending_flush()` is currently called from four files:
 
-Replace with a `WriteGuard` returned by mutation entry points; the guard
-sets the flag on construction and releases it normally. Mutation
+| File                     | Calls                            |
+| ------------------------ | -------------------------------- |
+| `runtime_core/writes.rs` | 12                               |
+| `runtime_core.rs`        | 5 (incl. the setter at line 427) |
+| `runtime_core/ticks.rs`  | 3                                |
+| `runtime_core/sync.rs`   | 1                                |
+
+The flag is set defensively after any mutation that touches the storage
+layer. Replace with a `WriteGuard` returned by mutation entry points; the
+guard sets the flag on construction and releases it normally. Mutation
 functions stop knowing about the flag at all.
 
-Acceptance: zero direct calls to `mark_storage_write_pending_flush` from
-`writes.rs`; `batched_tick` flushes whenever the guard registry shows
-unflushed work.
+Acceptance:
+
+- The only direct callers of the flag setter are the helper that constructs
+  a `WriteGuard` and (if still useful) `runtime_core.rs` itself for cases
+  that genuinely have no guard to attach to. No direct calls remain in
+  `writes.rs`, `ticks.rs`, or `sync.rs`.
+- `batched_tick` flushes whenever the guard registry shows unflushed work.
 
 ## Phase 8 — `query_manager/graph.rs` split
 
@@ -216,6 +300,13 @@ hot paths) is within ±2% of pre-split numbers.
 
 These came up in the audit but should be separate specs if pursued:
 
+- **`AuthConfig::default()` flipping `allow_local_first_auth` to `true`** —
+  this is a behavior change, not cleanup. Today the field defaults to `false`
+  via the derived `Default`, and tests and runtime paths in
+  `crates/jazz-tools/src/middleware/auth.rs:1134, 1617` plus
+  `crates/jazz-tools/tests/auth_test.rs:228` rely on that. If the new-app
+  default should be `true`, that needs its own spec and a sweep of all
+  callers that construct `AuthConfig::default()` for "no creds" scenarios.
 - WASM/native callback duplication in `subscriptions.rs:79-148` — needs
   thinking about whether the `Send` bound should be at the trait or the
   call site.
@@ -227,7 +318,9 @@ These came up in the audit but should be separate specs if pursued:
 
 ## Invariants
 
-- All phases preserve the public API of `jazz-tools`.
+- Phases 1, 2, 4, 5, 7, 8 preserve the public API of `jazz-tools`. Phases
+  3 and 6 are deliberate API breaks; they coordinate the corresponding
+  binding updates in the same PR (see _Public API impact_ above).
 - All phases preserve wire format, storage format, sync semantics.
 - Tests are not rewritten; they move with their code. Per CLAUDE.md, an
   unexpectedly failing test is treated as a signal, not as something to

--- a/specs/todo/c_later/crate_structure_cleanup.md
+++ b/specs/todo/c_later/crate_structure_cleanup.md
@@ -106,8 +106,16 @@ Small, independent fixes that remove parallel construction logic between
    re-exported from `lib.rs`), so this is purely a binary-internal
    organization choice — nothing leaves or enters the public library.
    `main.rs` is 358 lines today; "leave it alone" is defensible.
-3. Reuse one `reqwest::Client` between the main server (`builder.rs:155`) and
-   the JWKS loader (`builder.rs:338-342`).
+3. (Optional, naming-only.) Give the two `reqwest::Client` constructions in
+   `builder.rs` named helpers so their intent is explicit at the call site:
+   `build_authority_forwarding_client()` for `builder.rs:155` and
+   `build_jwks_client()` for `builder.rs:338-342`. **Do not collapse them
+   into one shared client** — they encode two different policies. The main
+   client is used at `routes.rs:219` to proxy catalogue admin requests
+   (potentially carrying large schema bundles) and uses default timeouts.
+   The JWKS client uses `connect_timeout(5s)` + `timeout(10s)` so a hung
+   IDP cannot block the auth path. Sharing one client requires picking
+   either policy for both, which is a behavior change in either direction.
 4. Delete `#[allow(dead_code)] pub app_id` on `ServerState` (`server/mod.rs:165`)
    — either use it in a routed handler or remove the field.
 


### PR DESCRIPTION
## Summary

Adds `specs/todo/c_later/crate_structure_cleanup.md` — a phased plan for non-blocking structural cleanup of `crates/jazz-tools/`.

The spec is grounded in a runtime-first walkthrough of the crate against `main` at `fa52406b6`. The runtime layer itself (sync `RuntimeCore` + thin tokio adapter) is in good shape; the debt is in:

- top-level `src/` having become a junk drawer (clock, batch_fate, sync_tracer, routes, binding_support all belong inside subsystems)
- duplicated construction logic between `client.rs` and `server/builder.rs`
- a few oversized files (`storage/mod.rs` ~8K LOC, `query_manager/graph.rs` ~4.6K LOC)
- bookkeeping inside `RuntimeCore` (ack watchers, parked sync messages, subscription registries) that conceptually belongs in dedicated owners

Eight phases, ordered so 1–4 are independent quick wins and 5–8 build on the cleaner module layout. Each phase has its own acceptance criteria. No public API change, no wire/storage format change, no test rewrites.

Bucketed under `c_later` to match the precedent set by `schema_manager_code_quality.md`. Easy to move to `a_mvp/` if treated as MVP polish instead.

## Test plan

- [ ] Spec only; no code changes. CI should be green by virtue of touching only `specs/`.
- [ ] If any phase is later picked up, it ships its own PR with its own acceptance criteria as listed in the spec.