### PR TITLE
Mark transformed columns experimental

### DIFF
--- a/.changeset/transformed-columns.md
+++ b/.changeset/transformed-columns.md
@@ -1,5 +1,5 @@
 ---
-"jazz-tools": minor
+"jazz-tools": patch
 ---
 
 Add transformed columns to the TypeScript schema DSL.

--- a/docs/content/docs/reference/column-types.mdx
+++ b/docs/content/docs/reference/column-types.mdx
@@ -12,6 +12,8 @@ Any column can be made nullable by chaining `.optional()`. For binary data like 
 
 ## Transformed Columns
 
+> **Experimental:** Transformed columns are an early TypeScript API and may change before the stable release.
+
 Any normal column definer can be transformed with `.transform({ from, to })`. The database still stores the column using the underlying SQL type, while the TypeScript API exposes the transformed type on rows, inserts, and updates.
 
 Use `from` to convert stored values into the value your app reads. Use `to` to convert app values back into the stored column value before inserts and updates.

--- a/packages/jazz-tools/src/dsl.ts
+++ b/packages/jazz-tools/src/dsl.ts
@@ -119,6 +119,8 @@ export type TypedColumnBuilder<
   ): ColumnAlias<Sql, Optional, Ref, HasDefault, Value>;
   /**
    * Transform stored column values at the TypeScript boundary.
+   *
+   * @experimental This API may change before the stable release.
    */
   transform<TransformedValue>(transform: {
     from(value: MaybeOptional<TSTypeFromSqlType<Sql>, Optional>): TransformedValue;


### PR DESCRIPTION
## What changed

Follow-up to the transformed columns PR:

- Changes the transformed columns changeset from `minor` to `patch`.
- Adds an experimental warning to the Column Types reference docs.
- Adds `@experimental` typedoc to the `.transform({ from, to })` column builder API.

## Validation

- `pnpm --dir packages/jazz-tools run build:runtime`
- Pre-commit hook passed: `oxfmt`, `oxlint`