### PR TITLE
[codex] Add callback Db batch APIs

### DIFF
--- a/.changeset/codex-db-callback-batches.md
+++ b/.changeset/codex-db-callback-batches.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Replace the typed `Db` table-seeded transaction and batch APIs with callback-scoped helpers that automatically commit and return a waitable write handle.

--- a/packages/jazz-tools/src/runtime/db.transaction.test.ts
+++ b/packages/jazz-tools/src/runtime/db.transaction.test.ts
@@ -98,7 +98,7 @@ function makeWriteHandle(batchId: string, mode: LocalBatchRecord["mode"] = "tran
 }
 
 describe("Db transactions", () => {
-  it("creates a typed db transaction seeded by a table schema", async () => {
+  it("runs a typed transaction callback and returns a waitable committed handle", async () => {
     const table = todoTable();
     const runtimeRow: Row = {
       id: "todo-1",
@@ -128,18 +128,25 @@ describe("Db transactions", () => {
     } as unknown as JazzClient;
     const db = new TestDb(client);
 
-    const tx = db.beginTransaction(table);
-    const inserted = tx.insert(table, { title: "Transactional", done: false });
-    const updated = tx.update(table, "todo-1", { done: true });
-    const deleted = tx.delete(table, "todo-1");
+    const committed = db.transaction((tx) => {
+      const inserted = tx.insert(table, { title: "Transactional", done: false });
+      const updated = tx.update(table, "todo-1", { done: true });
+      const deleted = tx.delete(table, "todo-1");
+
+      expect(tx.batchId()).toBe("batch-tx");
+      expect(inserted).toEqual({
+        id: "todo-1",
+        title: "Transactional",
+        done: false,
+      });
+      expect(updated).toBeUndefined();
+      expect(deleted).toBeUndefined();
+      expect(tx.localBatchRecord()).toMatchObject({ batchId: "batch-tx" });
+      expect(tx.localBatchRecords()).toEqual([makeLocalBatchRecord("batch-tx")]);
+      expect(tx.acknowledgeRejectedBatch()).toBe(false);
+    });
 
     expect(beginTransactionInternal).toHaveBeenCalledWith();
-    expect(tx.batchId()).toBe("batch-tx");
-    expect(inserted).toEqual({
-      id: "todo-1",
-      title: "Transactional",
-      done: false,
-    });
     expect(runtimeTransaction.create).toHaveBeenCalledWith("todos", {
       title: { type: "Text", value: "Transactional" },
       done: { type: "Boolean", value: false },
@@ -148,9 +155,6 @@ describe("Db transactions", () => {
       done: { type: "Boolean", value: true },
     });
     expect(runtimeTransaction.delete).toHaveBeenCalledWith("todo-1");
-    expect(updated).toBeUndefined();
-    expect(deleted).toBeUndefined();
-    const committed = tx.commit();
     expect(committed).toBeInstanceOf(WriteHandle);
     expect(committed.batchId).toBe("batch-tx");
     await expect(committed.wait({ tier: "global" })).resolves.toBeUndefined();
@@ -159,12 +163,9 @@ describe("Db transactions", () => {
       "global",
     );
     expect(runtimeTransaction.commit).toHaveBeenCalledWith();
-    expect(tx.localBatchRecord()).toMatchObject({ batchId: "batch-tx" });
-    expect(tx.localBatchRecords()).toEqual([makeLocalBatchRecord("batch-tx")]);
-    expect(tx.acknowledgeRejectedBatch()).toBe(false);
   });
 
-  it("threads session-backed db transactions through beginTransactionInternal", async () => {
+  it("threads session-backed transaction callbacks through beginTransactionInternal", () => {
     const table = todoTable();
     const session: Session = {
       user_id: "alice",
@@ -202,62 +203,21 @@ describe("Db transactions", () => {
       "alice@writer",
     );
 
-    const tx = db.beginTransaction(table);
-    const inserted = tx.insert(table, { title: "Session transaction", done: true });
+    const committed = db.transaction((tx) => {
+      expect(tx.insert(table, { title: "Session transaction", done: true })).toEqual({
+        id: "todo-2",
+        title: "Session transaction",
+        done: true,
+      });
+    });
 
     expect(runtimeClient.beginTransactionInternal).toHaveBeenCalledWith(session, "alice@writer");
-    const committed = tx.commit();
     expect(committed).toBeInstanceOf(WriteHandle);
     expect(committed.batchId).toBe("batch-session-tx");
     expect(runtimeTransaction.commit).toHaveBeenCalledWith();
-    expect(inserted).toEqual({
-      id: "todo-2",
-      title: "Session transaction",
-      done: true,
-    });
   });
 
-  it("rejects db transaction writes after commit", () => {
-    const table = todoTable();
-    const runtimeRow = {
-      id: "todo-closed",
-      values: [
-        { type: "Text", value: "Closed" },
-        { type: "Boolean", value: false },
-      ],
-      batchId: "batch-closed",
-    } as Row;
-    const runtimeTransaction = {
-      batchId: vi.fn(() => "batch-closed"),
-      create: vi.fn(() => runtimeRow),
-      update: vi.fn(),
-      delete: vi.fn(),
-      commit: vi.fn(() => makeWriteHandle("batch-closed").handle),
-      localBatchRecord: vi.fn((batchId = "batch-closed") => makeLocalBatchRecord(batchId)),
-      localBatchRecords: vi.fn(() => [makeLocalBatchRecord("batch-closed")]),
-      acknowledgeRejectedBatch: vi.fn(() => false),
-    };
-    const runtimeClient = {
-      getSchema: () => new Map(Object.entries(todoSchema())),
-      beginTransactionInternal: vi.fn(() => runtimeTransaction),
-      localBatchRecord: vi.fn((batchId: string) => makeLocalBatchRecord(batchId)),
-      acknowledgeRejectedBatch: vi.fn(() => false),
-    };
-    const db = createDbFromClient(
-      { appId: "client-backed-transaction" },
-      runtimeClient as unknown as JazzClient,
-    );
-
-    const tx = db.beginTransaction(table);
-    const committed = tx.commit();
-    expect(committed).toBeInstanceOf(WriteHandle);
-    expect(committed.batchId).toBe("batch-closed");
-
-    expect(() => tx.insert(table, { title: "Nope", done: false })).toThrow(/committed/i);
-    expect(runtimeTransaction.create).not.toHaveBeenCalled();
-  });
-
-  it("supports typed reads scoped to the open transaction", async () => {
+  it("keeps typed reads scoped to an async transaction callback", async () => {
     const table = todoTable();
     const query = todoQuery();
     const runtimeRow: Row = {
@@ -286,68 +246,74 @@ describe("Db transactions", () => {
     } as unknown as JazzClient;
     const db = new TestDb(client);
 
-    const tx = db.beginTransaction(table);
-    tx.insert(table, { title: "Transactional read", done: false });
+    const committed = await db.transaction(async (tx) => {
+      tx.insert(table, { title: "Transactional read", done: false });
 
-    await expect(tx.all(query)).resolves.toEqual([
-      {
+      await expect(tx.all(query)).resolves.toEqual([
+        {
+          id: "todo-read-1",
+          title: "Transactional read",
+          done: false,
+        },
+      ]);
+      await expect(tx.one(query)).resolves.toEqual({
         id: "todo-read-1",
         title: "Transactional read",
         done: false,
-      },
-    ]);
-    await expect(tx.one(query)).resolves.toEqual({
-      id: "todo-read-1",
-      title: "Transactional read",
-      done: false,
+      });
     });
 
+    expect(committed.batchId).toBe("batch-read");
     expect(runtimeTransaction.query).toHaveBeenCalledTimes(2);
+    expect(runtimeTransaction.commit).toHaveBeenCalledWith();
   });
 
-  it("rejects db transaction reads after commit", async () => {
+  it("does not commit when a transaction callback fails", () => {
     const table = todoTable();
-    const query = todoQuery();
     const runtimeTransaction = {
-      batchId: vi.fn(() => "batch-read-closed"),
+      batchId: vi.fn(() => "batch-fail"),
       create: vi.fn(),
       update: vi.fn(),
       delete: vi.fn(),
-      query: vi.fn(),
-      commit: vi.fn(() => makeWriteHandle("batch-read-closed").handle),
-      localBatchRecord: vi.fn((batchId = "batch-read-closed") => makeLocalBatchRecord(batchId)),
-      localBatchRecords: vi.fn(() => [makeLocalBatchRecord("batch-read-closed")]),
+      commit: vi.fn(() => makeWriteHandle("batch-fail").handle),
+      localBatchRecord: vi.fn((batchId = "batch-fail") => makeLocalBatchRecord(batchId)),
+      localBatchRecords: vi.fn(() => [makeLocalBatchRecord("batch-fail")]),
       acknowledgeRejectedBatch: vi.fn(() => false),
     };
-    const runtimeClient = {
+    const client = {
       getSchema: () => new Map(Object.entries(todoSchema())),
       beginTransactionInternal: vi.fn(() => runtimeTransaction),
       localBatchRecord: vi.fn((batchId: string) => makeLocalBatchRecord(batchId)),
       acknowledgeRejectedBatch: vi.fn(() => false),
-    };
-    const db = createDbFromClient(
-      { appId: "client-backed-transaction" },
-      runtimeClient as unknown as JazzClient,
-    );
+    } as unknown as JazzClient;
+    const db = new TestDb(client);
 
-    const tx = db.beginTransaction(table);
-    const committed = tx.commit();
-    expect(committed).toBeInstanceOf(WriteHandle);
-    expect(committed.batchId).toBe("batch-read-closed");
-
-    await expect(tx.all(query)).rejects.toThrow(/committed/i);
-    expect(runtimeTransaction.query).not.toHaveBeenCalled();
+    expect(() =>
+      db.transaction((tx) => {
+        tx.update(table, "todo-1", { done: true });
+        throw new Error("policy preflight failed");
+      }),
+    ).toThrow("policy preflight failed");
+    expect(runtimeTransaction.commit).not.toHaveBeenCalled();
   });
 
-  it("rejects db transaction writes against a different client/schema", () => {
+  it("rejects transaction writes against a different client/schema", () => {
     const primaryTable = todoTable();
     const secondaryTable = {
       ...todoTable(),
       _schema: todoSchema(),
     };
+    const runtimeRow: Row = {
+      id: "todo-cross-client",
+      values: [
+        { type: "Text", value: "Right client" },
+        { type: "Boolean", value: false },
+      ],
+      batchId: "batch-cross-client",
+    } as Row;
     const runtimeTransaction = {
       batchId: vi.fn(() => "batch-cross-client"),
-      create: vi.fn(),
+      create: vi.fn(() => runtimeRow),
       update: vi.fn(),
       delete: vi.fn(),
       commit: vi.fn(() => makeWriteHandle("batch-cross-client").handle),
@@ -374,15 +340,17 @@ describe("Db transactions", () => {
       ]),
     );
 
-    const tx = db.beginTransaction(primaryTable);
-
-    expect(() => tx.insert(secondaryTable, { title: "Wrong client", done: false })).toThrow(
-      /cannot be used with table "todos" from a different schema\/client/,
-    );
-    expect(runtimeTransaction.create).not.toHaveBeenCalled();
+    expect(() =>
+      db.transaction((tx) => {
+        tx.insert(primaryTable, { title: "Right client", done: false });
+        tx.insert(secondaryTable, { title: "Wrong client", done: false });
+      }),
+    ).toThrow(/cannot be used with table "todos" from a different schema\/client/);
+    expect(runtimeTransaction.create).toHaveBeenCalledTimes(1);
+    expect(runtimeTransaction.commit).not.toHaveBeenCalled();
   });
 
-  it("creates a typed db direct batch seeded by a table schema", async () => {
+  it("runs a typed direct batch callback and returns a waitable committed handle", async () => {
     const table = todoTable();
     const runtimeRow: Row = {
       id: "todo-direct-1",
@@ -414,18 +382,28 @@ describe("Db transactions", () => {
     } as unknown as JazzClient;
     const db = new TestDb(client);
 
-    const batch = db.beginDirectBatch(table);
-    const inserted = batch.insert(table, { title: "Direct batch", done: false });
-    const updated = batch.update(table, "todo-direct-1", { done: true });
-    const deleted = batch.delete(table, "todo-direct-1");
+    const committed = db.batch((batch) => {
+      const inserted = batch.insert(table, { title: "Direct batch", done: false });
+      const updated = batch.update(table, "todo-direct-1", { done: true });
+      const deleted = batch.delete(table, "todo-direct-1");
+
+      expect(batch.batchId()).toBe("batch-direct");
+      expect(inserted).toEqual({
+        id: "todo-direct-1",
+        title: "Direct batch",
+        done: false,
+      });
+      expect(updated).toBeUndefined();
+      expect(deleted).toBeUndefined();
+      expect(batch.localBatchRecord()).toMatchObject({
+        batchId: "batch-direct",
+        mode: "direct",
+      });
+      expect(batch.localBatchRecords()).toEqual([makeLocalBatchRecord("batch-direct", "direct")]);
+      expect(batch.acknowledgeRejectedBatch()).toBe(false);
+    });
 
     expect(beginDirectBatchInternal).toHaveBeenCalledWith();
-    expect(batch.batchId()).toBe("batch-direct");
-    expect(inserted).toEqual({
-      id: "todo-direct-1",
-      title: "Direct batch",
-      done: false,
-    });
     expect(runtimeBatch.create).toHaveBeenCalledWith("todos", {
       title: { type: "Text", value: "Direct batch" },
       done: { type: "Boolean", value: false },
@@ -434,9 +412,6 @@ describe("Db transactions", () => {
       done: { type: "Boolean", value: true },
     });
     expect(runtimeBatch.delete).toHaveBeenCalledWith("todo-direct-1");
-    expect(updated).toBeUndefined();
-    expect(deleted).toBeUndefined();
-    const committed = batch.commit();
     expect(committed).toBeInstanceOf(WriteHandle);
     expect(committed.batchId).toBe("batch-direct");
     await expect(committed.wait({ tier: "global" })).resolves.toBeUndefined();
@@ -445,23 +420,25 @@ describe("Db transactions", () => {
       "global",
     );
     expect(runtimeBatch.commit).toHaveBeenCalledWith();
-    expect(batch.localBatchRecord()).toMatchObject({
-      batchId: "batch-direct",
-      mode: "direct",
-    });
-    expect(batch.localBatchRecords()).toEqual([makeLocalBatchRecord("batch-direct", "direct")]);
-    expect(batch.acknowledgeRejectedBatch()).toBe(false);
   });
 
-  it("rejects db direct batch writes against a different client/schema", () => {
+  it("rejects direct batch writes against a different client/schema", () => {
     const primaryTable = todoTable();
     const secondaryTable = {
       ...todoTable(),
       _schema: todoSchema(),
     };
+    const runtimeRow: Row = {
+      id: "todo-cross-client-direct",
+      values: [
+        { type: "Text", value: "Right client" },
+        { type: "Boolean", value: false },
+      ],
+      batchId: "batch-cross-client-direct",
+    } as Row;
     const runtimeBatch = {
       batchId: vi.fn(() => "batch-cross-client-direct"),
-      create: vi.fn(),
+      create: vi.fn(() => runtimeRow),
       update: vi.fn(),
       delete: vi.fn(),
       commit: vi.fn(() => makeWriteHandle("batch-cross-client-direct", "direct").handle),
@@ -490,11 +467,13 @@ describe("Db transactions", () => {
       ]),
     );
 
-    const batch = db.beginDirectBatch(primaryTable);
-
-    expect(() => batch.insert(secondaryTable, { title: "Wrong client", done: false })).toThrow(
-      /cannot be used with table "todos" from a different schema\/client/,
-    );
-    expect(runtimeBatch.create).not.toHaveBeenCalled();
+    expect(() =>
+      db.batch((batch) => {
+        batch.insert(primaryTable, { title: "Right client", done: false });
+        batch.insert(secondaryTable, { title: "Wrong client", done: false });
+      }),
+    ).toThrow(/cannot be used with table "todos" from a different schema\/client/);
+    expect(runtimeBatch.create).toHaveBeenCalledTimes(1);
+    expect(runtimeBatch.commit).not.toHaveBeenCalled();
   });
 });

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -248,6 +248,15 @@ function createDeferred<T>(): Deferred<T> {
   return { promise, resolve, reject };
 }
 
+function isPromiseLike<T>(value: MaybePromise<T>): value is Promise<T> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "then" in value &&
+    typeof (value as Promise<T>).then === "function"
+  );
+}
+
 function trimSubscriptionTraceStack(stack: string | undefined): string | undefined {
   if (!stack) {
     return stack;
@@ -482,19 +491,25 @@ function backendScopedAuthState(session?: Session | null): AuthState {
   };
 }
 
+type MaybePromise<T> = T | Promise<T>;
+
+type DbTransactionCallback<T> = (tx: DbTransaction) => MaybePromise<T>;
+type DbDirectBatchCallback<T> = (batch: DbDirectBatch) => MaybePromise<T>;
+
 /**
  * Transactions group a set of writes that should settle together after an authority validates them.
  *
  * Data read and written through this transaction is scoped to it, and will only be
- * globally visible once it's committed using {@link DbTransaction.commit} and
- * accepted by the authority.
+ * globally visible once the transaction callback completes and the authority accepts it.
  */
 export class DbTransaction {
-  private committed = false;
+  private runtimeTransaction: RuntimeTransaction | null = null;
+  private client: JazzClient | null = null;
+  private committedHandle: WriteHandle | null = null;
 
   constructor(
-    private readonly client: JazzClient,
-    private readonly runtimeTransaction: RuntimeTransaction,
+    private readonly resolveClient: (schema: WasmSchema) => JazzClient,
+    private readonly beginRuntimeTransaction: (client: JazzClient) => RuntimeTransaction,
     private readonly assertOwnsTable: <T, Init>(
       table: TableProxy<T, Init>,
       operation: string,
@@ -502,47 +517,69 @@ export class DbTransaction {
   ) {}
 
   private ensureActive(): void {
-    if (this.committed) {
-      throw new Error(`Transaction ${this.runtimeTransaction.batchId()} is already committed`);
+    if (this.committedHandle) {
+      throw new Error(`Transaction ${this.batchId()} is already committed`);
     }
   }
 
-  private resolveInputSchema<T, Init>(table: TableProxy<T, Init>): WasmSchema {
+  private bindToTable<T, Init>(table: TableProxy<T, Init>): RuntimeTransaction {
+    if (!this.runtimeTransaction) {
+      this.client = this.resolveClient(table._schema);
+      this.runtimeTransaction = this.beginRuntimeTransaction(this.client);
+    }
     this.assertOwnsTable(table, "DbTransaction");
+    return this.runtimeTransaction;
+  }
+
+  private requireRuntimeTransaction(): RuntimeTransaction {
+    if (!this.runtimeTransaction) {
+      throw new Error("Cannot commit an empty transaction before using a table or query");
+    }
+    return this.runtimeTransaction;
+  }
+
+  private resolveInputSchema<T, Init>(table: TableProxy<T, Init>): WasmSchema {
+    this.bindToTable(table);
+    const client = this.client;
+    if (!client) {
+      throw new Error("Transaction is not bound to a client");
+    }
     return resolveSchemaWithTable(
       table._schema,
-      normalizeRuntimeSchema(this.client.getSchema()),
+      normalizeRuntimeSchema(client.getSchema()),
       table._table,
     );
   }
 
   private assertOwnsQuery<T>(query: QueryBuilder<T>): void {
-    this.assertOwnsTable(query as unknown as TableProxy<T, never>, "DbTransaction");
+    this.bindToTable(query as unknown as TableProxy<T, never>);
   }
 
   batchId(): string {
-    return this.runtimeTransaction.batchId();
+    return this.requireRuntimeTransaction().batchId();
   }
 
-  /**
-   * Commit the transaction. Data will be globally visible once it's accepted by the authority.
-   */
-  commit(): WriteHandle {
-    this.committed = true;
-    return this.runtimeTransaction.commit();
+  /** @internal */
+  finalize(): WriteHandle {
+    if (this.committedHandle) {
+      return this.committedHandle;
+    }
+    const handle = this.requireRuntimeTransaction().commit();
+    this.committedHandle = handle;
+    return handle;
   }
 
   /**
    * Insert a new row into a table.
    *
    * The insert is scoped to this transaction, and will only be globally visible
-   * once it's committed with {@link DbTransaction.commit}.
+   * once the transaction callback completes.
    */
   insert<T, Init>(table: TableProxy<T, Init>, data: Init): T {
     this.ensureActive();
     const transformedData = transformInsertInput(table, data);
     const values = toInsertRecord(transformedData, this.resolveInputSchema(table), table._table);
-    const row = this.runtimeTransaction.create(table._table, values);
+    const row = this.requireRuntimeTransaction().create(table._table, values);
     return transformOutputRow(table, transformRow(row, table._schema, table._table));
   }
 
@@ -550,25 +587,25 @@ export class DbTransaction {
    * Update an existing row in a table.
    *
    * The update is scoped to this transaction, and will only be globally visible
-   * once it's committed with {@link DbTransaction.commit}.
+   * once the transaction callback completes.
    */
   update<T, Init>(table: TableProxy<T, Init>, id: string, data: Partial<Init>): void {
     this.ensureActive();
     const transformedData = transformUpdateInput(table, data);
     const updates = toUpdateRecord(transformedData, this.resolveInputSchema(table), table._table);
-    this.runtimeTransaction.update(id, updates);
+    this.requireRuntimeTransaction().update(id, updates);
   }
 
   /**
    * Delete an existing row from a table.
    *
    * The delete is scoped to this transaction, and will only be globally visible
-   * once it's committed with {@link DbTransaction.commit}.
+   * once the transaction callback completes.
    */
   delete<T, Init>(table: TableProxy<T, Init>, id: string): void {
     this.ensureActive();
-    this.assertOwnsTable(table, "DbTransaction");
-    this.runtimeTransaction.delete(id);
+    this.bindToTable(table);
+    this.requireRuntimeTransaction().delete(id);
   }
 
   /**
@@ -579,13 +616,17 @@ export class DbTransaction {
   async all<T>(query: QueryBuilder<T>, options?: QueryOptions): Promise<T[]> {
     this.ensureActive();
     this.assertOwnsQuery(query);
-    const runtimeSchema = normalizeRuntimeSchema(this.client.getSchema());
+    const client = this.client;
+    if (!client) {
+      throw new Error("Transaction is not bound to a client");
+    }
+    const runtimeSchema = normalizeRuntimeSchema(client.getSchema());
     const builderJson = query._build();
     const builtQuery = normalizeBuiltQuery(JSON.parse(builderJson), query._table);
     const planningSchema = resolveSchemaWithTable(query._schema, runtimeSchema, builtQuery.table);
     const outputTable = resolveBuiltQueryOutputTable(planningSchema, builtQuery);
     const outputSchema = resolveSchemaWithTable(query._schema, runtimeSchema, outputTable);
-    const rows = await this.runtimeTransaction.query(
+    const rows = await this.requireRuntimeTransaction().query(
       translateQuery(builderJson, planningSchema),
       options,
     );
@@ -613,15 +654,15 @@ export class DbTransaction {
   }
 
   localBatchRecord(batchId = this.batchId()): LocalBatchRecord | null {
-    return this.runtimeTransaction.localBatchRecord(batchId);
+    return this.requireRuntimeTransaction().localBatchRecord(batchId);
   }
 
   localBatchRecords(): LocalBatchRecord[] {
-    return this.runtimeTransaction.localBatchRecords();
+    return this.requireRuntimeTransaction().localBatchRecords();
   }
 
   acknowledgeRejectedBatch(batchId = this.batchId()): boolean {
-    return this.runtimeTransaction.acknowledgeRejectedBatch(batchId);
+    return this.requireRuntimeTransaction().acknowledgeRejectedBatch(batchId);
   }
 }
 
@@ -633,44 +674,63 @@ export class DbTransaction {
  */
 export class DbDirectBatch {
   private committedHandle: WriteHandle | null = null;
+  private runtimeBatch: RuntimeDirectBatch | null = null;
+  private client: JazzClient | null = null;
 
   constructor(
-    private readonly client: JazzClient,
-    private readonly runtimeBatch: RuntimeDirectBatch,
+    private readonly resolveClient: (schema: WasmSchema) => JazzClient,
+    private readonly beginRuntimeBatch: (client: JazzClient) => RuntimeDirectBatch,
     private readonly assertOwnsTable: <T, Init>(
       table: TableProxy<T, Init>,
       operation: string,
     ) => void,
   ) {}
 
-  private resolveInputSchema<T, Init>(table: TableProxy<T, Init>): WasmSchema {
+  private bindToTable<T, Init>(table: TableProxy<T, Init>): RuntimeDirectBatch {
+    if (!this.runtimeBatch) {
+      this.client = this.resolveClient(table._schema);
+      this.runtimeBatch = this.beginRuntimeBatch(this.client);
+    }
     this.assertOwnsTable(table, "DbDirectBatch");
+    return this.runtimeBatch;
+  }
+
+  private requireRuntimeBatch(): RuntimeDirectBatch {
+    if (!this.runtimeBatch) {
+      throw new Error("Cannot commit an empty batch before using a table");
+    }
+    return this.runtimeBatch;
+  }
+
+  private resolveInputSchema<T, Init>(table: TableProxy<T, Init>): WasmSchema {
+    this.bindToTable(table);
+    const client = this.client;
+    if (!client) {
+      throw new Error("Direct batch is not bound to a client");
+    }
     return resolveSchemaWithTable(
       table._schema,
-      normalizeRuntimeSchema(this.client.getSchema()),
+      normalizeRuntimeSchema(client.getSchema()),
       table._table,
     );
   }
 
   batchId(): string {
-    return this.runtimeBatch.batchId();
+    return this.requireRuntimeBatch().batchId();
   }
 
   private ensureActive(): void {
     if (this.committedHandle) {
-      throw new Error(`Direct batch ${this.runtimeBatch.batchId()} is already committed`);
+      throw new Error(`Direct batch ${this.batchId()} is already committed`);
     }
   }
 
-  /**
-   * Commit the direct batch. Data is visible optimistically immediately and can
-   * be waited on through the returned handle.
-   */
-  commit(): WriteHandle {
+  /** @internal */
+  finalize(): WriteHandle {
     if (this.committedHandle) {
       return this.committedHandle;
     }
-    const handle = this.runtimeBatch.commit();
+    const handle = this.requireRuntimeBatch().commit();
     this.committedHandle = handle;
     return handle;
   }
@@ -679,7 +739,7 @@ export class DbDirectBatch {
     this.ensureActive();
     const transformedData = transformInsertInput(table, data);
     const values = toInsertRecord(transformedData, this.resolveInputSchema(table), table._table);
-    const row = this.runtimeBatch.create(table._table, values);
+    const row = this.requireRuntimeBatch().create(table._table, values);
     return transformOutputRow(table, transformRow(row, table._schema, table._table));
   }
 
@@ -687,25 +747,25 @@ export class DbDirectBatch {
     this.ensureActive();
     const transformedData = transformUpdateInput(table, data);
     const updates = toUpdateRecord(transformedData, this.resolveInputSchema(table), table._table);
-    this.runtimeBatch.update(id, updates);
+    this.requireRuntimeBatch().update(id, updates);
   }
 
   delete<T, Init>(table: TableProxy<T, Init>, id: string): void {
     this.ensureActive();
-    this.assertOwnsTable(table, "DbDirectBatch");
-    this.runtimeBatch.delete(id);
+    this.bindToTable(table);
+    this.requireRuntimeBatch().delete(id);
   }
 
   localBatchRecord(batchId = this.batchId()): LocalBatchRecord | null {
-    return this.runtimeBatch.localBatchRecord(batchId);
+    return this.requireRuntimeBatch().localBatchRecord(batchId);
   }
 
   localBatchRecords(): LocalBatchRecord[] {
-    return this.runtimeBatch.localBatchRecords();
+    return this.requireRuntimeBatch().localBatchRecords();
   }
 
   acknowledgeRejectedBatch(batchId = this.batchId()): boolean {
-    return this.runtimeBatch.acknowledgeRejectedBatch(batchId);
+    return this.requireRuntimeBatch().acknowledgeRejectedBatch(batchId);
   }
 }
 
@@ -2305,51 +2365,67 @@ export class Db {
   }
 
   /**
-   * Begin a new transaction.
-   *
-   * Use transactions when several writes should settle together after an authority validates them.
-   *
-   * Use {@link DbTransaction.commit} to commit the transaction.
+   * Run a transaction callback and return a handle for waiting on the committed batch.
    */
-  beginTransaction<T, Init>(table: TableProxy<T, Init>): DbTransaction {
-    const client = this.getClient(table._schema);
-    return new DbTransaction(
-      client,
-      client.beginTransactionInternal(),
-      (candidateTable, operation) =>
+  transaction<T>(callback: (tx: DbTransaction) => Promise<T>): Promise<WriteHandle>;
+  transaction<T>(callback: (tx: DbTransaction) => T): WriteHandle;
+  transaction<T>(callback: DbTransactionCallback<T>): WriteHandle | Promise<WriteHandle> {
+    let boundClient: JazzClient | null = null;
+    const tx = new DbTransaction(
+      (schema) => {
+        boundClient = this.getClient(schema);
+        return boundClient;
+      },
+      (client) => client.beginTransactionInternal(),
+      (candidateTable, operation) => {
+        if (!boundClient) {
+          throw new Error("Transaction is not bound to a client");
+        }
         assertTableBelongsToClient(
           candidateTable,
-          client,
+          boundClient,
           (schema) => this.getClient(schema),
           operation,
-        ),
+        );
+      },
     );
+    const result = callback(tx);
+    if (isPromiseLike(result)) {
+      return result.then(() => tx.finalize());
+    }
+    return tx.finalize();
   }
 
   /**
-   * Begin a new direct batch.
-   *
-   * Use a direct batch when several visible writes should settle together.
-   * Call {@link DbDirectBatch.commit} to freeze the batch, then wait on the
-   * returned handle if you need durable confirmation.
+   * Run a direct batch callback and return a handle for waiting on the committed batch.
    */
-  beginDirectBatch<T, Init>(table: TableProxy<T, Init>): DbDirectBatch {
-    const client = this.getClient(table._schema);
-    return new DbDirectBatch(
-      client,
-      client.beginDirectBatchInternal(),
-      (candidateTable, operation) =>
+  batch<T>(callback: (batch: DbDirectBatch) => Promise<T>): Promise<WriteHandle>;
+  batch<T>(callback: (batch: DbDirectBatch) => T): WriteHandle;
+  batch<T>(callback: DbDirectBatchCallback<T>): WriteHandle | Promise<WriteHandle> {
+    let boundClient: JazzClient | null = null;
+    const batch = new DbDirectBatch(
+      (schema) => {
+        boundClient = this.getClient(schema);
+        return boundClient;
+      },
+      (client) => client.beginDirectBatchInternal(),
+      (candidateTable, operation) => {
+        if (!boundClient) {
+          throw new Error("Direct batch is not bound to a client");
+        }
         assertTableBelongsToClient(
           candidateTable,
-          client,
+          boundClient,
           (schema) => this.getClient(schema),
           operation,
-        ),
+        );
+      },
     );
-  }
-
-  beginBatch<T, Init>(table: TableProxy<T, Init>): DbDirectBatch {
-    return this.beginDirectBatch(table);
+    const result = callback(batch);
+    if (isPromiseLike(result)) {
+      return result.then(() => batch.finalize());
+    }
+    return batch.finalize();
   }
 
   /**
@@ -2830,28 +2906,38 @@ class ClientBackedDb extends Db {
     return this.runtimeClient.deleteHandleInternal(id, this.session, this.attribution);
   }
 
-  override beginTransaction<T, Init>(table: TableProxy<T, Init>): DbTransaction {
+  override transaction<T>(callback: (tx: DbTransaction) => Promise<T>): Promise<WriteHandle>;
+  override transaction<T>(callback: (tx: DbTransaction) => T): WriteHandle;
+  override transaction<T>(callback: DbTransactionCallback<T>): WriteHandle | Promise<WriteHandle> {
     const client = this.runtimeClient;
-    return new DbTransaction(
-      client,
-      client.beginTransactionInternal(this.session, this.attribution),
+    const tx = new DbTransaction(
+      () => client,
+      () => client.beginTransactionInternal(this.session, this.attribution),
       (candidateTable, operation) =>
         assertTableBelongsToClient(candidateTable, client, () => client, operation),
     );
+    const result = callback(tx);
+    if (isPromiseLike(result)) {
+      return result.then(() => tx.finalize());
+    }
+    return tx.finalize();
   }
 
-  override beginDirectBatch<T, Init>(table: TableProxy<T, Init>): DbDirectBatch {
+  override batch<T>(callback: (batch: DbDirectBatch) => Promise<T>): Promise<WriteHandle>;
+  override batch<T>(callback: (batch: DbDirectBatch) => T): WriteHandle;
+  override batch<T>(callback: DbDirectBatchCallback<T>): WriteHandle | Promise<WriteHandle> {
     const client = this.runtimeClient;
-    return new DbDirectBatch(
-      client,
-      client.beginDirectBatchInternal(this.session, this.attribution),
+    const batch = new DbDirectBatch(
+      () => client,
+      () => client.beginDirectBatchInternal(this.session, this.attribution),
       (candidateTable, operation) =>
         assertTableBelongsToClient(candidateTable, client, () => client, operation),
     );
-  }
-
-  override beginBatch<T, Init>(table: TableProxy<T, Init>): DbDirectBatch {
-    return this.beginDirectBatch(table);
+    const result = callback(batch);
+    if (isPromiseLike(result)) {
+      return result.then(() => batch.finalize());
+    }
+    return batch.finalize();
   }
 
   override async all<T>(query: QueryBuilder<T>, options?: QueryOptions): Promise<T[]> {

--- a/specs/status-quo/batches.md
+++ b/specs/status-quo/batches.md
@@ -508,13 +508,12 @@ Important APIs:
 - `client.acknowledgeRejectedBatch(batchId)`
 - `tx.commit()`
 - `batch.commit()`
-- `db.beginDirectBatch(table)`
-- `db.beginBatch(table)`
-- `db.beginTransaction(table)`
+- `db.batch((batch) => { ... })`
+- `db.transaction((tx) => { ... })`
 
-The `Db` batch handles are intentionally seeded by a table: that first table chooses the runtime
-client/schema, and later writes through the same handle must stay on that client-bound schema
-surface.
+The typed `Db` callback handles are not seeded by a table. The first table or query used inside the
+callback chooses the runtime client/schema, and later writes through the same handle must stay on
+that client-bound schema surface.
 
 Transactional handles also support transaction-scoped reads before commit:
 

--- a/specs/status-quo/browser_adapters.md
+++ b/specs/status-quo/browser_adapters.md
@@ -51,7 +51,7 @@ It is useful for tests, demos, and environments that do not want a dedicated wor
 - translating typed query builders into runtime queries
 - creating or reusing `JazzClient` instances
 - exposing `all`, `one`, `insert`, `update`, `delete`, and subscription APIs
-- exposing explicit `beginDirectBatch(...)` / `beginBatch(...)` and `beginTransaction(...)` APIs
+- exposing callback-scoped `batch(...)` and `transaction(...)` APIs
 - waiting for the worker bridge when a call needs worker-backed durability
 
 From the application's point of view, it is just "the database object". Internally, it is the coordinator for the main-thread runtime plus any worker bridge.
@@ -110,10 +110,9 @@ That is why the browser architecture can stay faithful to the rest of Jazz. The 
 5. Worker forwards upstream when configured.
 6. Durable APIs resolve when the requested tier is confirmed.
 
-The same path also handles explicit `db.beginDirectBatch(...)` / `db.beginBatch(...)` and
-`db.beginTransaction(...)` flows. The difference is whether the worker is persisting a visible
-direct batch that will settle as `DurableDirect` after `commit()`, or a transactional batch that
-still needs an authority decision.
+The same path also handles explicit `db.batch(...)` and `db.transaction(...)` flows. The difference
+is whether the worker is persisting a visible direct batch that will settle as `DurableDirect` after
+the callback commits, or a transactional batch that still needs an authority decision.
 
 ### Query
 

--- a/specs/status-quo/ts_client.md
+++ b/specs/status-quo/ts_client.md
@@ -96,17 +96,16 @@ The current `Db` API centers around a small set of predictable operations:
 - `update(...)`
 - `delete(...)`
 - `subscribeAll(...)`
-- `beginDirectBatch(...)`
-- `beginBatch(...)`
-- `beginTransaction(...)`
+- `batch(...)`
+- `transaction(...)`
 
 Simple write calls are one-member direct batches under the hood. They seal immediately and return
 handles that callers can wait on for a specific durability tier.
 
 ## Explicit Batch APIs
 
-For callers that want to group writes or opt into authority-decided transactions, the app surface
-now exposes explicit batch handles.
+For callers that want to group writes or opt into authority-decided transactions, the typed app
+surface exposes callback-scoped batch helpers.
 
 At the runtime-client layer:
 
@@ -119,26 +118,37 @@ At the runtime-client layer:
 
 At the typed `Db` layer:
 
-- `db.beginDirectBatch(table)`
-- `db.beginBatch(table)`
-- `db.beginTransaction(table)`
+- `db.batch((batch) => { ... })`
+- `db.transaction((tx) => { ... })`
 
-The returned handles (`DirectBatch`, `Transaction`, `DbDirectBatch`, `DbTransaction`) reuse the
-same CRUD surface as normal writes, but with one shared logical `BatchId`.
-For the typed `Db` wrappers, the begin-time table also fixes which underlying runtime
-client/schema owns that handle.
+The callback handles (`DbDirectBatch`, `DbTransaction`) reuse the same CRUD surface as normal
+writes, but with one shared logical `BatchId`. The first table or query used inside the callback
+chooses the underlying runtime client/schema for that handle; later writes through the same handle
+must stay on that client-bound schema surface.
 
 Open batch writes are intentionally not individually waitable:
 
 - `tx.insert(...)` and `batch.insert(...)` return the inserted row
 - `tx.update(...)`, `tx.delete(...)`, `batch.update(...)`, and `batch.delete(...)` return `void`
-- `tx.commit()` and `batch.commit()` return the batch-shaped write handle
+- the callback return value is ignored for commit purposes
+- `db.transaction(...)` and `db.batch(...)` return the committed batch-shaped write handle
 
 That makes the common durable path explicit in the type shape:
 
 ```ts
-await db.beginBatch(app.todos).commit().wait({ tier: "edge" });
-await db.beginTransaction(app.todos).commit().wait({ tier: "global" });
+await db
+  .batch((batch) => {
+    batch.insert(app.todos, { title: "Ship docs", done: false });
+    batch.update(app.projects, projectId, { name: "Launch" });
+  })
+  .wait({ tier: "edge" });
+
+await db
+  .transaction((tx) => {
+    tx.insert(app.todos, { title: "Ship docs", done: false });
+    tx.update(app.projects, projectId, { name: "Launch" });
+  })
+  .wait({ tier: "global" });
 ```
 
 Transactional handles also expose transaction-scoped reads over their own staged rows:
@@ -147,17 +157,15 @@ Transactional handles also expose transaction-scoped reads over their own staged
 - `DbTransaction.all(...)`
 - `DbTransaction.one(...)`
 
-Both explicit batch handles add the explicit completion step:
+The typed `Db` callback helpers commit automatically when the callback completes. Runtime-client
+handles still expose explicit `commit()` for lower-level callers.
 
-- `tx.commit()` in TypeScript
-- `batch.commit()` in TypeScript
+Persisted write handles are batch-shaped too:
 
-Persisted writes are batch-shaped too:
-
-- the handle exposes `batchId()`
+- the handle exposes `batchId`
 - `wait()` resolves when the requested replayable durability outcome is satisfied, or rejects if the batch is rejected
-- `localBatchRecord()` reloads retained local state
-- `acknowledgeRejectedBatch()` prunes retained rejected records once the app has handled them
+- `localBatchRecord(batchId)` and `acknowledgeRejectedBatch(batchId)` remain available on the
+  runtime client for retained batch state
 
 ## What App Code Does _Not_ Need to Care About
 


### PR DESCRIPTION
## What changed

- Replaced the typed `Db` table-seeded transaction and batch entry points with callback-scoped `db.transaction(...)` and `db.batch(...)` helpers.
- The callback handles lazily bind to the first table/query used, then automatically commit and return the committed `WriteHandle` so callers can use `.wait(...)` directly.
- Updated transaction/batch tests and status-quo docs to describe the new typed API.
- Added a patch changeset for `jazz-tools`.

## Why

`Db.beginTransaction(table)` and `Db.beginBatch(table)` implied transactions and batches were table-scoped, but both can cover multiple tables. The new callback API reflects the real scope: one database/runtime context, many table writes.

## Validation

- `pnpm exec vitest run src/runtime/db.transaction.test.ts --config vitest.config.ts`
- `pnpm exec vitest run src/runtime/client.test.ts --config vitest.config.ts`
- `pnpm exec tsc --noEmit` currently stops on existing unresolved local `jazz-wasm` module types in `src/runtime/client.ts` and `src/worker/jazz-worker.ts`.