### PR TITLE
create-jazz spinner UX + jazz-tools CLI dotenv support

### DIFF
--- a/.changeset/fix-create-jazz-provisioning-spinner.md
+++ b/.changeset/fix-create-jazz-provisioning-spinner.md
@@ -1,0 +1,5 @@
+---
+"create-jazz": patch
+---
+
+Advance the `create-jazz` spinner to "Provisioning Jazz Cloud app" during the dashboard call, and stop credential/banner output from concatenating onto the active spinner line.

--- a/.changeset/jazz-tools-cli-loads-dotenv.md
+++ b/.changeset/jazz-tools-cli-loads-dotenv.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+The `jazz-tools` CLI now loads `.env` from the working directory at startup, so `deploy` and other commands pick up `JAZZ_ADMIN_SECRET`, `JAZZ_SERVER_URL` (and framework-prefixed equivalents) from the same dotenv file your app uses. Real environment variables still take precedence.

--- a/.changeset/jazz-tools-cli-loads-dotenv.md
+++ b/.changeset/jazz-tools-cli-loads-dotenv.md
@@ -2,4 +2,4 @@
 "jazz-tools": patch
 ---
 
-The `jazz-tools` CLI now loads `.env` from the working directory at startup, so `deploy` and other commands pick up `JAZZ_ADMIN_SECRET`, `JAZZ_SERVER_URL` (and framework-prefixed equivalents) from the same dotenv file your app uses. Real environment variables still take precedence.
+The `jazz-tools` CLI now loads `.env` from the working directory at startup, so `deploy` and other commands pick up `JAZZ_ADMIN_SECRET`, `JAZZ_SERVER_URL` (and framework-prefixed equivalents) from the same dotenv file your app uses. Pass `--env-file <path>` (repeatable) to load from a specific file — useful for staging/production splits like `--env-file .env.staging`. Real environment variables still take precedence.

--- a/packages/create-jazz/package.json
+++ b/packages/create-jazz/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build": "tsup src/index.ts --format esm --out-dir dist",
     "prepublishOnly": "pnpm build",
-    "test": "vitest run"
+    "typecheck": "tsc --noEmit",
+    "test": "pnpm typecheck && vitest run"
   },
   "dependencies": {
     "@clack/prompts": "^0.10.0",

--- a/packages/create-jazz/package.json
+++ b/packages/create-jazz/package.json
@@ -22,8 +22,8 @@
   "scripts": {
     "build": "tsup src/index.ts --format esm --out-dir dist",
     "prepublishOnly": "pnpm build",
-    "typecheck": "tsc --noEmit",
-    "test": "pnpm typecheck && vitest run"
+    "check": "tsc --noEmit",
+    "test": "pnpm check && vitest run"
   },
   "dependencies": {
     "@clack/prompts": "^0.10.0",

--- a/packages/create-jazz/src/cli.integration.test.ts
+++ b/packages/create-jazz/src/cli.integration.test.ts
@@ -25,7 +25,7 @@ describe("create-jazz CLI end-to-end", () => {
       tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "create-jazz-cli-e2e-"));
 
       const starterPath = path.join(repoRoot, "starters/next-betterauth");
-      const env = {
+      const env: NodeJS.ProcessEnv = {
         ...process.env,
         JAZZ_STARTER_PATH: starterPath,
         // CI runners have no global git identity; inject fallbacks so the

--- a/packages/create-jazz/src/cloud-init.test.ts
+++ b/packages/create-jazz/src/cloud-init.test.ts
@@ -248,6 +248,81 @@ describe("runHostedInit", () => {
     });
   });
 
+  describe("spinner-safe progress and logging", () => {
+    it("calls onStep with a provisioning label before the HTTP request fires", async () => {
+      const events: string[] = [];
+
+      vi.spyOn(cloudProvision, "provisionHostedApp").mockImplementation(async () => {
+        events.push("fetch");
+        return { appId: "app-eve", adminSecret: "admin-eve", backendSecret: "backend-eve" };
+      });
+
+      await runHostedInit({
+        dir,
+        cloudSyncUrl: CLOUD_SYNC_URL,
+        envKeys: NEXT_KEYS,
+        apiUrl: API_URL,
+        onStep: (label) => events.push(`step:${label}`),
+      });
+
+      const firstStepIdx = events.findIndex((e) => e.startsWith("step:"));
+      const fetchIdx = events.indexOf("fetch");
+      expect(firstStepIdx).toBeGreaterThanOrEqual(0);
+      expect(fetchIdx).toBeGreaterThan(firstStepIdx);
+      expect(events[firstStepIdx]).toMatch(/provision/i);
+    });
+
+    it("routes success output through onLog and does not call console.log", async () => {
+      vi.spyOn(cloudProvision, "provisionHostedApp").mockResolvedValue({
+        appId: "app-frank",
+        adminSecret: "admin-frank",
+        backendSecret: "backend-frank",
+      });
+
+      const logs: { kind: string; message: string }[] = [];
+
+      await runHostedInit({
+        dir,
+        cloudSyncUrl: CLOUD_SYNC_URL,
+        envKeys: NEXT_KEYS,
+        apiUrl: API_URL,
+        onLog: (kind, message) => logs.push({ kind, message }),
+      });
+
+      expect(logSpy).not.toHaveBeenCalled();
+
+      const allInfo = logs
+        .filter((l) => l.kind === "info")
+        .map((l) => l.message)
+        .join("\n");
+      expect(allInfo).toContain("app-frank");
+      expect(allInfo).toContain("NEXT_PUBLIC_JAZZ_APP_ID=app-frank");
+      expect(allInfo).toContain("BACKEND_SECRET=backend-frank");
+      expect(allInfo).toContain("https://v2.dashboard.jazz.tools");
+    });
+
+    it("routes failure warnings through onLog and does not call console.warn", async () => {
+      vi.spyOn(cloudProvision, "provisionHostedApp").mockRejectedValue(
+        new cloudProvision.ProvisionHttpError(API_URL, 503),
+      );
+
+      const logs: { kind: string; message: string }[] = [];
+
+      await runHostedInit({
+        dir,
+        cloudSyncUrl: CLOUD_SYNC_URL,
+        envKeys: NEXT_KEYS,
+        apiUrl: API_URL,
+        onLog: (kind, message) => logs.push({ kind, message }),
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      const warnMessages = logs.filter((l) => l.kind === "warn").map((l) => l.message);
+      expect(warnMessages.some((m) => m.includes("ProvisionHttpError"))).toBe(true);
+    });
+  });
+
   describe("writeHostedEnv throws (outer catch)", () => {
     it("best-effort writes empty placeholder and returns successfully without throwing", async () => {
       vi.spyOn(cloudProvision, "provisionHostedApp").mockResolvedValue({

--- a/packages/create-jazz/src/cloud-init.ts
+++ b/packages/create-jazz/src/cloud-init.ts
@@ -17,6 +17,19 @@ export interface RunHostedInitOptions {
   };
   /** Override the provisioning endpoint (defaults to the production cloud dashboard). */
   apiUrl?: string;
+  /**
+   * Progress hook — called with a short step label before long-running work
+   * (e.g. the provisioning HTTP request). Lets the caller keep an outer
+   * spinner message in sync with what's actually happening.
+   */
+  onStep?: (label: string) => void;
+  /**
+   * Output hook — when provided, credential banners and warnings are routed
+   * here instead of `console.log` / `console.warn`. Required when the caller
+   * has an active clack spinner, since raw `console.*` calls would bleed
+   * onto the spinner's active line.
+   */
+  onLog?: (kind: "info" | "warn", message: string) => void;
 }
 
 function readEnvValues(envPath: string): Record<string, string> {
@@ -34,8 +47,17 @@ function readEnvValues(envPath: string): Record<string, string> {
 }
 
 export async function runHostedInit(options: RunHostedInitOptions): Promise<void> {
-  const { dir, cloudSyncUrl, envKeys, apiUrl } = options;
+  const { dir, cloudSyncUrl, envKeys, apiUrl, onStep, onLog } = options;
   const keys = [envKeys.appId, envKeys.serverUrl, envKeys.adminSecret, envKeys.backendSecret];
+
+  const emitInfo = (message: string) => {
+    if (onLog) onLog("info", message);
+    else console.log(message);
+  };
+  const emitWarn = (message: string) => {
+    if (onLog) onLog("warn", message);
+    else console.warn(message);
+  };
 
   const existing = readEnvValues(join(dir, ".env"));
   if (keys.some((k) => existing[k] && existing[k].length > 0)) {
@@ -46,10 +68,11 @@ export async function runHostedInit(options: RunHostedInitOptions): Promise<void
     let provisioned: { appId: string; adminSecret: string; backendSecret: string } | null = null;
 
     try {
+      onStep?.("Provisioning Jazz Cloud app");
       provisioned = await provisionHostedApp({ apiUrl });
     } catch (err) {
       const name = err instanceof Error ? err.name : "Error";
-      console.warn(
+      emitWarn(
         `[jazz] Provisioning failed (${name}: ${err instanceof Error ? err.message : String(err)}). ` +
           `Writing placeholder .env — visit https://v2.dashboard.jazz.tools to provision manually.`,
       );
@@ -70,15 +93,21 @@ export async function runHostedInit(options: RunHostedInitOptions): Promise<void
       keys,
     });
 
-    console.log("Jazz app provisioned successfully and written to .env:");
-    console.log(`  ${envKeys.appId}=${appId}`);
-    console.log(`  ${envKeys.serverUrl}=${cloudSyncUrl}`);
-    console.log(`  ${envKeys.adminSecret}=${adminSecret}`);
-    console.log(`  ${envKeys.backendSecret}=${backendSecret}`);
-    console.log("");
-    console.log("Visit https://v2.dashboard.jazz.tools to sign up and claim your app!");
+    emitInfo(
+      [
+        "Jazz app provisioned successfully and written to .env:",
+        `  ${envKeys.appId}=${appId}`,
+        `  ${envKeys.serverUrl}=${cloudSyncUrl}`,
+        `  ${envKeys.adminSecret}=${adminSecret}`,
+        `  ${envKeys.backendSecret}=${backendSecret}`,
+        "",
+        "Visit https://v2.dashboard.jazz.tools to sign up and claim your app!",
+      ].join("\n"),
+    );
   } catch (err) {
-    console.warn("[jazz] init-env failed unexpectedly:", err instanceof Error ? err.message : err);
+    emitWarn(
+      `[jazz] init-env failed unexpectedly: ${err instanceof Error ? err.message : String(err)}`,
+    );
     try {
       writeHostedEnv({ dir, values: {}, keys });
     } catch {

--- a/packages/create-jazz/src/index.ts
+++ b/packages/create-jazz/src/index.ts
@@ -1,7 +1,7 @@
 import { intro, outro, text, select, spinner, log, isCancel } from "@clack/prompts";
 import pc from "picocolors";
 import * as path from "node:path";
-import { scaffold, validateAppName, type StarterName } from "./scaffold.js";
+import { scaffold, validateAppName, type StarterName, type ScaffoldOptions } from "./scaffold.js";
 import { detectPackageManager } from "./detect-pm.js";
 import { runHostedInit } from "./cloud-init.js";
 import { writeBetterAuthSecret } from "./init-secret.js";
@@ -186,23 +186,31 @@ async function main() {
 
   const needsBetterAuthSecret = starter.endsWith("-betterauth") || starter.endsWith("-hybrid");
 
-  const preInstall: ((dir: string) => Promise<void>) | undefined =
+  // Buffer log output emitted during scaffolding so it can be printed after
+  // the spinner stops — otherwise clack's active-line redraw concatenates
+  // it onto the current spinner message.
+  const deferredLogs: { kind: "info" | "warn"; message: string }[] = [];
+
+  const preInstall: ScaffoldOptions["preInstall"] =
     hosting === "hosted" || needsBetterAuthSecret
-      ? async (dir: string) => {
+      ? async ({ dir, onStep }) => {
           if (needsBetterAuthSecret) {
             writeBetterAuthSecret(dir);
           }
           if (hosting === "hosted") {
             const envKeys = envKeysForStarter(starter);
             if (!envKeys) {
-              log.warn(
-                `Skipping hosted provisioning: no env key map registered for starter "${starter}".`,
-              );
+              deferredLogs.push({
+                kind: "warn",
+                message: `Skipping hosted provisioning: no env key map registered for starter "${starter}".`,
+              });
             } else {
               await runHostedInit({
                 dir,
                 cloudSyncUrl: CLOUD_SYNC_URL,
                 envKeys,
+                onStep,
+                onLog: (kind, message) => deferredLogs.push({ kind, message }),
               });
             }
           }
@@ -229,6 +237,11 @@ async function main() {
     s.stop(pc.red("Failed."));
     log.error(err instanceof Error ? err.message : String(err));
     process.exit(1);
+  }
+
+  for (const entry of deferredLogs) {
+    if (entry.kind === "warn") log.warn(entry.message);
+    else log.info(entry.message);
   }
 
   if (pm) {

--- a/packages/create-jazz/src/scaffold.test.ts
+++ b/packages/create-jazz/src/scaffold.test.ts
@@ -131,6 +131,32 @@ describe("scaffold() — next-betterauth e2e via JAZZ_STARTER_PATH", () => {
     expect(fs.existsSync(path.join(tmpDir, ".git"))).toBe(false);
   });
 
+  it(
+    "passes onStep to preInstall so the spinner advances past git init",
+    { timeout: 30_000 },
+    async () => {
+      tmpDir = path.join(os.tmpdir(), `scaffold-preinstall-${Date.now()}`);
+      const steps: string[] = [];
+
+      await scaffold({
+        appName: "dave-preinstall",
+        targetDir: tmpDir,
+        pm: null,
+        starter: "next-betterauth",
+        git: false,
+        onStep: (label) => steps.push(label),
+        preInstall: async (ctx) => {
+          expect(typeof ctx).toBe("object");
+          expect(typeof ctx.dir).toBe("string");
+          expect(typeof ctx.onStep).toBe("function");
+          ctx.onStep("Provisioning Jazz Cloud app");
+        },
+      });
+
+      expect(steps).toContain("Provisioning Jazz Cloud app");
+    },
+  );
+
   it("reports per-package progress during dep resolution", { timeout: 30_000 }, async () => {
     tmpDir = path.join(os.tmpdir(), `scaffold-progress-${Date.now()}`);
     const steps: string[] = [];

--- a/packages/create-jazz/src/scaffold.ts
+++ b/packages/create-jazz/src/scaffold.ts
@@ -52,9 +52,11 @@ export interface ScaffoldOptions {
   /**
    * Runs after git init and before `pnpm install`. Use for anything that must
    * land in the scaffolded project before the install runs — e.g. cloud
-   * provisioning that writes `.env`.
+   * provisioning that writes `.env`. Receives `onStep` so long-running work
+   * (e.g. a provisioning HTTP request) can advance the caller's spinner
+   * rather than leaving it stuck on the previous step.
    */
-  preInstall?: (targetDir: string) => Promise<void>;
+  preInstall?: (ctx: { dir: string; onStep: (label: string) => void }) => Promise<void>;
 }
 
 const SCAFFOLD_COPY_SKIP = new Set(["node_modules", ".next", ".jazz", ".turbo", ".env", ".git"]);
@@ -131,7 +133,10 @@ export async function scaffold(options: ScaffoldOptions): Promise<void> {
   // Pre-install hook runs after the transactional steps; failures from here
   // on leave the project intact so the user can inspect / retry manually.
   if (options.preInstall) {
-    await options.preInstall(options.targetDir);
+    await options.preInstall({
+      dir: options.targetDir,
+      onStep: (label) => options.onStep?.(label),
+    });
   }
 
   // Install is not transactional for the same reason — failure leaves the

--- a/packages/create-jazz/src/tiged.d.ts
+++ b/packages/create-jazz/src/tiged.d.ts
@@ -1,0 +1,17 @@
+// Minimal ambient type for `tiged` — it ships no types. Only the subset
+// we actually use (default export: factory returning an object with .clone).
+declare module "tiged" {
+  interface TigedEmitter {
+    clone(dest: string): Promise<void>;
+  }
+
+  interface TigedOptions {
+    disableCache?: boolean;
+    force?: boolean;
+    verbose?: boolean;
+  }
+
+  function tiged(src: string, options?: TigedOptions): TigedEmitter;
+
+  export default tiged;
+}

--- a/packages/jazz-tools/src/cli.test.ts
+++ b/packages/jazz-tools/src/cli.test.ts
@@ -21,6 +21,7 @@ import {
   createMigration as rawCreateMigration,
   deploy as rawDeploy,
   exportSchema as rawExportSchema,
+  loadDotEnv,
   permissionsStatus as rawPermissionsStatus,
   pushMigration as rawPushMigration,
   resolveEnvVar,
@@ -400,6 +401,74 @@ function storedSchemaResponse(
     { status },
   );
 }
+
+describe("loadDotEnv", () => {
+  it("merges values from .env into the supplied env object", async () => {
+    await mkdir(tmpBase, { recursive: true });
+    const dir = await mkdtemp(join(tmpBase, "jazz-tools-dotenv-"));
+    await writeFile(
+      join(dir, ".env"),
+      ["JAZZ_SERVER_URL=http://from-dotenv", "JAZZ_ADMIN_SECRET=secret-123", ""].join("\n"),
+    );
+    const env: Record<string, string | undefined> = {};
+    loadDotEnv(dir, env);
+    expect(env.JAZZ_SERVER_URL).toBe("http://from-dotenv");
+    expect(env.JAZZ_ADMIN_SECRET).toBe("secret-123");
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("does not override values already set in the environment", async () => {
+    await mkdir(tmpBase, { recursive: true });
+    const dir = await mkdtemp(join(tmpBase, "jazz-tools-dotenv-"));
+    await writeFile(join(dir, ".env"), "JAZZ_SERVER_URL=http://from-dotenv\n");
+    const env: Record<string, string | undefined> = {
+      JAZZ_SERVER_URL: "http://from-real-env",
+    };
+    loadDotEnv(dir, env);
+    expect(env.JAZZ_SERVER_URL).toBe("http://from-real-env");
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("is a no-op when no .env file exists", async () => {
+    await mkdir(tmpBase, { recursive: true });
+    const dir = await mkdtemp(join(tmpBase, "jazz-tools-dotenv-"));
+    const env: Record<string, string | undefined> = { PRE_EXISTING: "kept" };
+    loadDotEnv(dir, env);
+    expect(env).toEqual({ PRE_EXISTING: "kept" });
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("ignores comments and blank lines and strips surrounding quotes", async () => {
+    await mkdir(tmpBase, { recursive: true });
+    const dir = await mkdtemp(join(tmpBase, "jazz-tools-dotenv-"));
+    await writeFile(
+      join(dir, ".env"),
+      [
+        "# leading comment",
+        "",
+        'JAZZ_SERVER_URL="http://quoted"',
+        "JAZZ_ADMIN_SECRET='single-quoted'",
+        "JAZZ_APP_ID=plain",
+      ].join("\n"),
+    );
+    const env: Record<string, string | undefined> = {};
+    loadDotEnv(dir, env);
+    expect(env.JAZZ_SERVER_URL).toBe("http://quoted");
+    expect(env.JAZZ_ADMIN_SECRET).toBe("single-quoted");
+    expect(env.JAZZ_APP_ID).toBe("plain");
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("flows through resolveEnvVar so deploy-style lookups pick up the .env value", async () => {
+    await mkdir(tmpBase, { recursive: true });
+    const dir = await mkdtemp(join(tmpBase, "jazz-tools-dotenv-"));
+    await writeFile(join(dir, ".env"), "VITE_JAZZ_SERVER_URL=http://vite-from-dotenv\n");
+    const env: Record<string, string | undefined> = {};
+    loadDotEnv(dir, env);
+    expect(resolveEnvVar(SERVER_URL_ENV_VARS, env)).toBe("http://vite-from-dotenv");
+    await rm(dir, { recursive: true, force: true });
+  });
+});
 
 describe("resolveEnvVar", () => {
   it("returns the first name that has a defined value", () => {

--- a/packages/jazz-tools/src/cli.test.ts
+++ b/packages/jazz-tools/src/cli.test.ts
@@ -22,6 +22,8 @@ import {
   deploy as rawDeploy,
   exportSchema as rawExportSchema,
   loadDotEnv,
+  loadEnvFile,
+  readEnvFiles,
   permissionsStatus as rawPermissionsStatus,
   pushMigration as rawPushMigration,
   resolveEnvVar,
@@ -457,6 +459,54 @@ describe("loadDotEnv", () => {
     expect(env.JAZZ_ADMIN_SECRET).toBe("single-quoted");
     expect(env.JAZZ_APP_ID).toBe("plain");
     await rm(dir, { recursive: true, force: true });
+  });
+
+  it("loadEnvFile loads from an explicit absolute path", async () => {
+    await mkdir(tmpBase, { recursive: true });
+    const dir = await mkdtemp(join(tmpBase, "jazz-tools-dotenv-"));
+    const filePath = join(dir, ".env.staging");
+    await writeFile(filePath, "JAZZ_SERVER_URL=http://staging\n");
+    const env: Record<string, string | undefined> = {};
+    loadEnvFile(filePath, env);
+    expect(env.JAZZ_SERVER_URL).toBe("http://staging");
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("loadEnvFile keeps real env precedence when called repeatedly — first file wins per key", async () => {
+    await mkdir(tmpBase, { recursive: true });
+    const dir = await mkdtemp(join(tmpBase, "jazz-tools-dotenv-"));
+    await writeFile(join(dir, "a.env"), "JAZZ_SERVER_URL=from-a\nA_ONLY=a\n");
+    await writeFile(join(dir, "b.env"), "JAZZ_SERVER_URL=from-b\nB_ONLY=b\n");
+    const env: Record<string, string | undefined> = {};
+    loadEnvFile(join(dir, "a.env"), env);
+    loadEnvFile(join(dir, "b.env"), env);
+    expect(env.JAZZ_SERVER_URL).toBe("from-a");
+    expect(env.A_ONLY).toBe("a");
+    expect(env.B_ONLY).toBe("b");
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("readEnvFiles collects --env-file=PATH and --env-file PATH in order", () => {
+    expect(
+      readEnvFiles([
+        "--env-file=.env.staging",
+        "deploy",
+        "myAppId",
+        "--env-file",
+        ".env",
+        "--admin-secret=xyz",
+      ]),
+    ).toEqual([".env.staging", ".env"]);
+  });
+
+  it("readEnvFiles returns an empty array when no flag is present", () => {
+    expect(readEnvFiles(["deploy", "myAppId", "--admin-secret=xyz"])).toEqual([]);
+  });
+
+  it("loadEnvFile is a no-op for a missing path", async () => {
+    const env: Record<string, string | undefined> = { KEPT: "yes" };
+    loadEnvFile(join(tmpBase, "no-such-file.env"), env);
+    expect(env).toEqual({ KEPT: "yes" });
   });
 
   it("flows through resolveEnvVar so deploy-style lookups pick up the .env value", async () => {

--- a/packages/jazz-tools/src/cli.ts
+++ b/packages/jazz-tools/src/cli.ts
@@ -2,6 +2,7 @@
 
 // CLI for jazz-tools schema tooling
 
+import { existsSync, readFileSync } from "fs";
 import { access, mkdir, readFile, readdir, rm, writeFile } from "fs/promises";
 import { basename, dirname, join, resolve } from "path";
 import { pathToFileURL } from "url";
@@ -200,6 +201,33 @@ export const APP_ID_ENV_VARS = [
   "NEXT_PUBLIC_JAZZ_APP_ID",
   "EXPO_PUBLIC_JAZZ_APP_ID",
 ] as const;
+
+// Load values from `.env` in the given directory into `env` without
+// overriding entries that are already set. Real environment variables
+// always win — `.env` is a fallback only. No-op when the file is absent.
+export function loadDotEnv(
+  cwd: string = process.cwd(),
+  env: Record<string, string | undefined> = process.env,
+): void {
+  const envPath = join(cwd, ".env");
+  if (!existsSync(envPath)) return;
+  const content = readFileSync(envPath, "utf8");
+  for (let line of content.split("\n")) {
+    if (line.endsWith("\r")) line = line.slice(0, -1);
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (env[key] === undefined) env[key] = value;
+  }
+}
 
 export function resolveEnvVar(
   names: readonly string[],
@@ -1870,6 +1898,7 @@ function isMainModule(): boolean {
 }
 
 if (isMainModule()) {
+  loadDotEnv();
   const command = process.argv[2] ?? "";
 
   if (command === "validate") {

--- a/packages/jazz-tools/src/cli.ts
+++ b/packages/jazz-tools/src/cli.ts
@@ -202,19 +202,13 @@ export const APP_ID_ENV_VARS = [
   "EXPO_PUBLIC_JAZZ_APP_ID",
 ] as const;
 
-// Load values from `.env` in the given directory into `env` without
-// overriding entries that are already set. Real environment variables
-// always win — `.env` is a fallback only. No-op when the file is absent.
-//
-// In production (`env === process.env`) we delegate to Node's built-in
-// `process.loadEnvFile` when available (Node 20.12+/21.7+), which gets us
-// quoting/escape edge cases for free. Older Node and tests passing a
-// custom env object fall through to the in-house parser.
-export function loadDotEnv(
-  cwd: string = process.cwd(),
+// Real environment variables always win — `.env` is a fallback only.
+// Uses Node's built-in `process.loadEnvFile` when operating on the real
+// process.env; falls back to a small parser for tests and older Node.
+export function loadEnvFile(
+  envPath: string,
   env: Record<string, string | undefined> = process.env,
 ): void {
-  const envPath = join(cwd, ".env");
   if (!existsSync(envPath)) return;
   if (env === process.env && typeof process.loadEnvFile === "function") {
     process.loadEnvFile(envPath);
@@ -236,6 +230,31 @@ export function loadDotEnv(
     }
     if (env[key] === undefined) env[key] = value;
   }
+}
+
+export function loadDotEnv(
+  cwd: string = process.cwd(),
+  env: Record<string, string | undefined> = process.env,
+): void {
+  loadEnvFile(join(cwd, ".env"), env);
+}
+
+// Collect every `--env-file=PATH` and `--env-file PATH` from argv, in
+// the order they appear. Earlier files take precedence over later ones
+// because loadEnvFile only fills in keys that are still undefined.
+export function readEnvFiles(args: string[]): string[] {
+  const files: string[] = [];
+  const prefix = "--env-file=";
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--env-file") {
+      const value = args[i + 1];
+      if (value) files.push(value);
+    } else if (arg.startsWith(prefix)) {
+      files.push(arg.slice(prefix.length));
+    }
+  }
+  return files;
 }
 
 export function resolveEnvVar(
@@ -1907,7 +1926,14 @@ function isMainModule(): boolean {
 }
 
 if (isMainModule()) {
-  loadDotEnv();
+  const envFiles = readEnvFiles(process.argv.slice(2));
+  if (envFiles.length > 0) {
+    for (const file of envFiles) {
+      loadEnvFile(resolve(process.cwd(), file));
+    }
+  } else {
+    loadDotEnv();
+  }
   const command = process.argv[2] ?? "";
 
   if (command === "validate") {
@@ -2073,6 +2099,10 @@ if (isMainModule()) {
     );
     console.log("  --toHash <hash>       Optional target schema hash (defaults to current schema)");
     console.log("  --name <name>         Optional migration filename label (default: unnamed)");
+    console.log("\nGlobal options:");
+    console.log(
+      "  --env-file <path>     Load env vars from this file (repeatable; first file wins per key). Defaults to .env in cwd.",
+    );
     process.exit(command ? 1 : 0);
   }
 }

--- a/packages/jazz-tools/src/cli.ts
+++ b/packages/jazz-tools/src/cli.ts
@@ -205,12 +205,21 @@ export const APP_ID_ENV_VARS = [
 // Load values from `.env` in the given directory into `env` without
 // overriding entries that are already set. Real environment variables
 // always win — `.env` is a fallback only. No-op when the file is absent.
+//
+// In production (`env === process.env`) we delegate to Node's built-in
+// `process.loadEnvFile` when available (Node 20.12+/21.7+), which gets us
+// quoting/escape edge cases for free. Older Node and tests passing a
+// custom env object fall through to the in-house parser.
 export function loadDotEnv(
   cwd: string = process.cwd(),
   env: Record<string, string | undefined> = process.env,
 ): void {
   const envPath = join(cwd, ".env");
   if (!existsSync(envPath)) return;
+  if (env === process.env && typeof process.loadEnvFile === "function") {
+    process.loadEnvFile(envPath);
+    return;
+  }
   const content = readFileSync(envPath, "utf8");
   for (let line of content.split("\n")) {
     if (line.endsWith("\r")) line = line.slice(0, -1);


### PR DESCRIPTION
## Summary

Enhancements to CLI experience.

### `create-jazz` provisioning UX
- Advance the spinner to "Provisioning Jazz Cloud app" before the dashboard HTTP round-trip, so it no longer appears stuck on "Initialising git" during the network wait.
- Route credential/warning output through an injected `onLog` hook that the CLI replays via clack's `log.info` / `log.warn` after the spinner stops — the success banner now lands on its own line.
- Gate `pnpm test` on `tsc --noEmit` so type errors fail CI (tsup and vitest were both transpile-only).

### `jazz-tools` CLI dotenv support
- The CLI now loads `.env` from the working directory at startup, so `deploy` (and any other command that reads `JAZZ_ADMIN_SECRET` / `JAZZ_SERVER_URL` / framework-prefixed equivalents) picks up values from the same dotenv file your app uses.
- Real environment variables still take precedence; a missing `.env` is a no-op.

## Test plan
- [ ] `pnpm --filter create-jazz test` passes (typecheck + 64 tests).
- [ ] `pnpm --filter jazz-tools vitest run --config vitest.config.ts src/cli.test.ts -t loadDotEnv` passes (5 tests).
- [ ] In a project containing a `.env` with `JAZZ_ADMIN_SECRET=…`, run `npx jazz-tools deploy` without exporting the var — confirm the deploy succeeds.
- [ ] Run `pnpm create jazz` end-to-end and confirm the spinner advances during provisioning and the success banner prints on its own line.