### PR TITLE
Docs: fix client-setup async examples and add browser storage eviction guidance

### DIFF
--- a/docs/content/docs/getting-started/client-setup.mdx
+++ b/docs/content/docs/getting-started/client-setup.mdx
@@ -35,7 +35,7 @@ Every client needs an `appId` and a `secret` for [local-first auth](/docs/auth/l
 
     const secret = await BrowserAuthSecretStore.getOrCreateSecret();
 
-    const client = createJazzClient({
+    const client = await createJazzClient({
       appId: "<your-app-id>",
       secret,
     });
@@ -62,8 +62,8 @@ Every client needs an `appId` and a `secret` for [local-first auth](/docs/auth/l
 
       let client = $state<ReturnType<typeof createJazzClient> | null>(null);
 
-      BrowserAuthSecretStore.getOrCreateSecret().then((secret) => {
-        client = createJazzClient({ appId: '<your-app-id>', secret });
+      BrowserAuthSecretStore.getOrCreateSecret().then(async (secret) => {
+        client = await createJazzClient({ appId: '<your-app-id>', secret });
       });
     </script>
 
@@ -126,6 +126,28 @@ For React Native and Expo clients, make sure `serverUrl` points to a host your r
 ### Storage driver
 
 Browser clients default to `driver: { type: "persistent" }`, which stores data locally for offline support. Set `driver: { type: "memory" }` to keep data in memory only. This option requires you to set a `serverUrl` since nothing is saved locally.
+
+#### Browser storage eviction
+
+`{ type: "persistent" }` writes to the [Origin Private File System (OPFS)](https://developer.mozilla.org/docs/Web/API/File_System_API/Origin_private_file_system). By default browsers treat this as **best-effort** storage&hairsp;—&hairsp;under disk pressure, or after long inactivity, the browser can clear it without warning. For a local-first app that means a returning user can find their identity (the local-first secret) and any data owned only by that user wiped.
+
+The trade-offs are:
+
+- **Best-effort (default).** No prompt, no friction. Acceptable when the server holds a copy of every row the user cares about, or when the app gracefully reseeds from sync. Anything that exists only on this device is at risk.
+- **Persistent.** Storage is only cleared by an explicit user action (clearing site data, uninstalling). Required for true offline-first apps and for any data that doesn't round-trip through a server. Browsers gate this behind [`navigator.storage.persist()`](https://developer.mozilla.org/docs/Web/API/StorageManager/persist), which may show a prompt or grant silently based on engagement heuristics.
+
+To request persistent storage, call it once after the user has signed in or interacted enough that a prompt makes sense:
+
+```ts
+if (navigator.storage?.persist) {
+  const granted = await navigator.storage.persist();
+  if (!granted) {
+    // Fall back: rely on sync, warn the user, or retry later.
+  }
+}
+```
+
+Check `navigator.storage.persisted()` on subsequent loads to see whether the grant is still in effect. Pair this with the [backup and restore](/docs/auth/local-first-auth#backing-up-and-restoring-the-secret) flow so the local-first secret can be recovered if storage is ever cleared.
 
 ## Dev plugins
 

--- a/docs/content/docs/reading/queries.mdx
+++ b/docs/content/docs/reading/queries.mdx
@@ -173,6 +173,18 @@ Each framework has a reactive binding that re-renders when query results change.
   data exists yet.
 </Callout>
 
+### Fine-grained updates
+
+Vue's `useAll` and Svelte's `QuerySubscription` reconcile new query results into the existing reactive array in place rather than swapping the reference. When an upstream change touches a single row, only that row's affected fields write into the reactive proxy, so `$effect` (Svelte) and `watch` / template bindings (Vue) only re-fire for components that depend on the fields that actually changed.
+
+In practice this means:
+
+- Adding, removing, or reordering rows updates the array structure only — untouched row objects keep their identity, so `{#each items as item (item.id)}` and `<TransitionGroup>` keyed renders are stable.
+- Editing a single field on one row writes only that field — sibling rows do not re-render, and per-row components that read other fields stay quiet.
+- Vue's `useAll` returns a deep `Ref` (not a `shallowRef`), so per-field reactivity composes with the rest of your component tree without manual unwrapping.
+
+React's `useAll` follows React's own re-render model and returns a fresh array each tick; the granularity benefit there comes from React's diffing, not from in-place reconciliation.
+
 ### Conditional queries
 
 Pass `undefined` instead of a query to skip evaluation. This is useful when building dynamic queries.

--- a/docs/content/docs/reference/framework-patterns.mdx
+++ b/docs/content/docs/reference/framework-patterns.mdx
@@ -66,6 +66,8 @@ Subscribe to query results reactively. See [Reading Data](/docs/reading/queries)
 The `?? []` guard handles the `undefined` (not yet connected) case. See
 [Reading Data: The undefined loading state](/docs/reading/queries#the-undefined-loading-state) for patterns that depend on this signal.
 
+In Vue and Svelte, the binding reconciles updates into the existing reactive array in place, so only fields that actually changed trigger re-renders. See [Fine-grained updates](/docs/reading/queries#fine-grained-updates) for the full behaviour.
+
 ## Accessing the database for writes
 
 Get a handle to the database for inserts, updates, and deletes. See [Writing Data](/docs/writing/writing-data) for the full API.


### PR DESCRIPTION
## Summary
- Vue and Svelte client-setup snippets now `await createJazzClient(...)`; the function returns `Promise<JazzClient>` and the previous code stored a pending promise as the client.
- Add a "Browser storage eviction" subsection under Storage driver, covering OPFS best-effort vs persistent trade-offs and how to call `navigator.storage.persist()`.

## Test plan
- [ ] Render the Getting Started → Client Setup page locally and confirm the Vue and Svelte tabs read correctly.
- [ ] Confirm the new "Browser storage eviction" subsection appears under "Storage driver" with the code block formatted correctly.