### PR TITLE
refactor(jazz-tools): Phase 2 — collapse storage builder methods into StorageBackend enum

### DIFF
--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -42,7 +42,7 @@ use jazz_tools::runtime_core::{
 };
 use jazz_tools::schema_manager::{AppId, SchemaManager};
 use jazz_tools::server::{
-    CatalogueAuthorityMode, HostedServer as JazzHostedServer, ServerBuilder,
+    CatalogueAuthorityMode, HostedServer as JazzHostedServer, ServerBuilder, StorageBackend,
     TestingServer as JazzTestingServer,
 };
 use jazz_tools::storage::{MemoryStorage, SqliteStorage, Storage};
@@ -1751,9 +1751,11 @@ impl DevServer {
             .with_catalogue_authority(catalogue_authority);
 
         if in_memory {
-            server_builder = server_builder.with_in_memory_storage();
+            server_builder = server_builder.with_storage(StorageBackend::InMemory);
         } else {
-            server_builder = server_builder.with_sqlite_storage(&data_dir);
+            server_builder = server_builder.with_storage(StorageBackend::Sqlite {
+                path: data_dir.clone().into(),
+            });
         }
 
         let built = server_builder

--- a/crates/jazz-tools/src/commands/server.rs
+++ b/crates/jazz-tools/src/commands/server.rs
@@ -4,7 +4,7 @@ use std::net::SocketAddr;
 
 use jazz_tools::middleware::AuthConfig;
 use jazz_tools::schema_manager::AppId;
-use jazz_tools::server::{CatalogueAuthorityMode, ServerBuilder};
+use jazz_tools::server::{CatalogueAuthorityMode, ServerBuilder, StorageBackend};
 use tracing::info;
 
 const STANDALONE_INSPECTOR_URL: &str = "https://jazz2-inspector.vercel.app/";
@@ -34,9 +34,14 @@ pub async fn run(
         .with_auth_config(auth_config)
         .with_catalogue_authority(catalogue_authority);
     let built = if in_memory {
-        builder.with_in_memory_storage().build().await
+        builder.with_storage(StorageBackend::InMemory).build().await
     } else {
-        builder.with_persistent_storage(data_dir).build().await
+        builder
+            .with_storage(StorageBackend::Persistent {
+                path: data_dir.into(),
+            })
+            .build()
+            .await
     }
     .map_err(|e| format!("failed to build server: {e}"))?;
 

--- a/crates/jazz-tools/src/server/builder.rs
+++ b/crates/jazz-tools/src/server/builder.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -38,23 +38,25 @@ enum ServerSchemaMode {
     Fixed(Schema),
 }
 
-enum ServerStorageMode {
-    Persistent {
-        data_dir: String,
-    },
-    /// Explicitly selects SQLite regardless of which other storage features are
-    /// enabled.  Created via [`ServerBuilder::with_sqlite_storage`].
-    #[cfg(feature = "sqlite")]
-    PersistentSqlite {
-        data_dir: String,
-    },
-    /// Explicitly selects RocksDB regardless of which other storage features
-    /// are enabled.  Created via [`ServerBuilder::with_rocksdb_storage`].
-    #[cfg(feature = "rocksdb")]
-    PersistentRocksDb {
-        data_dir: String,
-    },
+/// Storage backend selection for [`ServerBuilder::with_storage`].
+///
+/// `Persistent` picks the best available backend at compile time
+/// (RocksDB > SQLite > in-memory). `Sqlite` and `RocksDb` pin the backend
+/// regardless of which other storage features are enabled.
+#[derive(Debug, Clone)]
+pub enum StorageBackend {
     InMemory,
+    Persistent {
+        path: PathBuf,
+    },
+    #[cfg(feature = "sqlite")]
+    Sqlite {
+        path: PathBuf,
+    },
+    #[cfg(feature = "rocksdb")]
+    RocksDb {
+        path: PathBuf,
+    },
 }
 
 pub struct ServerBuilder {
@@ -62,7 +64,7 @@ pub struct ServerBuilder {
     auth_config: AuthConfig,
     catalogue_authority: CatalogueAuthorityMode,
     schema_mode: ServerSchemaMode,
-    storage_mode: ServerStorageMode,
+    storage_backend: StorageBackend,
     sync_tracer: Option<crate::sync_tracer::SyncTracer>,
 }
 
@@ -76,8 +78,8 @@ impl ServerBuilder {
             },
             catalogue_authority: CatalogueAuthorityMode::Local,
             schema_mode: ServerSchemaMode::Dynamic,
-            storage_mode: ServerStorageMode::Persistent {
-                data_dir: "./data".to_string(),
+            storage_backend: StorageBackend::Persistent {
+                path: PathBuf::from("./data"),
             },
             sync_tracer: None,
         }
@@ -103,39 +105,8 @@ impl ServerBuilder {
         self
     }
 
-    pub fn with_persistent_storage(mut self, data_dir: impl Into<String>) -> Self {
-        self.storage_mode = ServerStorageMode::Persistent {
-            data_dir: data_dir.into(),
-        };
-        self
-    }
-
-    /// Use SQLite as the persistent storage backend, regardless of which other
-    /// storage features (e.g. `rocksdb`) are enabled.  Prefer this over
-    /// [`with_persistent_storage`] whenever you need to pin the backend to
-    /// SQLite (e.g. in tests or on mobile).
-    #[cfg(feature = "sqlite")]
-    pub fn with_sqlite_storage(mut self, data_dir: impl Into<String>) -> Self {
-        self.storage_mode = ServerStorageMode::PersistentSqlite {
-            data_dir: data_dir.into(),
-        };
-        self
-    }
-
-    /// Use RocksDB as the persistent storage backend, regardless of which
-    /// other storage features are enabled.  Prefer this over
-    /// [`with_persistent_storage`] whenever you need to pin the backend to
-    /// RocksDB (e.g. in tests or on desktop/server deployments).
-    #[cfg(feature = "rocksdb")]
-    pub fn with_rocksdb_storage(mut self, data_dir: impl Into<String>) -> Self {
-        self.storage_mode = ServerStorageMode::PersistentRocksDb {
-            data_dir: data_dir.into(),
-        };
-        self
-    }
-
-    pub fn with_in_memory_storage(mut self) -> Self {
-        self.storage_mode = ServerStorageMode::InMemory;
+    pub fn with_storage(mut self, backend: StorageBackend) -> Self {
+        self.storage_backend = backend;
         self
     }
 
@@ -238,14 +209,14 @@ impl ServerBuilder {
     }
 
     fn build_main_storage(&self) -> Result<DynStorage, String> {
-        match &self.storage_mode {
-            ServerStorageMode::Persistent { data_dir } => {
-                std::fs::create_dir_all(data_dir)
-                    .map_err(|e| format!("failed to create data dir '{}': {e}", data_dir))?;
+        match &self.storage_backend {
+            StorageBackend::Persistent { path } => {
+                std::fs::create_dir_all(path)
+                    .map_err(|e| format!("failed to create data dir '{}': {e}", path.display()))?;
 
                 #[cfg(feature = "rocksdb")]
                 {
-                    let db_path = Path::new(data_dir).join("jazz.rocksdb");
+                    let db_path = path.join("jazz.rocksdb");
                     let storage = RocksDBStorage::open(&db_path, STORAGE_CACHE_SIZE_BYTES)
                         .map_err(|e| {
                             format!("failed to open storage '{}': {e:?}", db_path.display())
@@ -254,7 +225,7 @@ impl ServerBuilder {
                 }
                 #[cfg(all(feature = "sqlite", not(feature = "rocksdb")))]
                 {
-                    let db_path = Path::new(data_dir).join("jazz.sqlite");
+                    let db_path = path.join("jazz.sqlite");
                     let storage = SqliteStorage::open(&db_path).map_err(|e| {
                         format!("failed to open storage '{}': {e:?}", db_path.display())
                     })?;
@@ -266,27 +237,27 @@ impl ServerBuilder {
                 }
             }
             #[cfg(feature = "sqlite")]
-            ServerStorageMode::PersistentSqlite { data_dir } => {
-                std::fs::create_dir_all(data_dir)
-                    .map_err(|e| format!("failed to create data dir '{}': {e}", data_dir))?;
-                let db_path = Path::new(data_dir).join("jazz.sqlite");
+            StorageBackend::Sqlite { path } => {
+                std::fs::create_dir_all(path)
+                    .map_err(|e| format!("failed to create data dir '{}': {e}", path.display()))?;
+                let db_path = path.join("jazz.sqlite");
                 let storage = SqliteStorage::open(&db_path).map_err(|e| {
                     format!("failed to open storage '{}': {e:?}", db_path.display())
                 })?;
                 Ok(Box::new(storage))
             }
             #[cfg(feature = "rocksdb")]
-            ServerStorageMode::PersistentRocksDb { data_dir } => {
-                std::fs::create_dir_all(data_dir)
-                    .map_err(|e| format!("failed to create data dir '{}': {e}", data_dir))?;
-                let db_path = Path::new(data_dir).join("jazz.rocksdb");
+            StorageBackend::RocksDb { path } => {
+                std::fs::create_dir_all(path)
+                    .map_err(|e| format!("failed to create data dir '{}': {e}", path.display()))?;
+                let db_path = path.join("jazz.rocksdb");
                 let storage =
                     RocksDBStorage::open(&db_path, STORAGE_CACHE_SIZE_BYTES).map_err(|e| {
                         format!("failed to open storage '{}': {e:?}", db_path.display())
                     })?;
                 Ok(Box::new(storage))
             }
-            ServerStorageMode::InMemory => Ok(Box::new(MemoryStorage::new())),
+            StorageBackend::InMemory => Ok(Box::new(MemoryStorage::new())),
         }
     }
 }

--- a/crates/jazz-tools/src/server/mod.rs
+++ b/crates/jazz-tools/src/server/mod.rs
@@ -18,7 +18,7 @@ pub mod routes;
 #[cfg(feature = "test-utils")]
 mod testing;
 
-pub use builder::{BuiltServer, ServerBuilder};
+pub use builder::{BuiltServer, ServerBuilder, StorageBackend};
 pub use hosted::HostedServer;
 #[cfg(feature = "test-utils")]
 pub use testing::{TestingJwksServer, TestingServer, TestingServerBuilder};
@@ -352,12 +352,12 @@ mod tests {
 
     use super::*;
     use crate::schema_manager::AppId;
-    use crate::server::builder::ServerBuilder;
+    use crate::server::builder::{ServerBuilder, StorageBackend};
 
     async fn build_test_state() -> Arc<ServerState> {
         let app_id = AppId::from_name("lifecycle-test");
         let built = ServerBuilder::new(app_id)
-            .with_in_memory_storage()
+            .with_storage(StorageBackend::InMemory)
             .build()
             .await
             .expect("build test server");

--- a/crates/jazz-tools/src/server/routes.rs
+++ b/crates/jazz-tools/src/server/routes.rs
@@ -1712,7 +1712,7 @@ mod tests {
     use tracing_subscriber::{Layer, Registry};
 
     use crate::middleware::AuthConfig;
-    use crate::server::{CatalogueAuthorityMode, ServerBuilder, ServerState};
+    use crate::server::{CatalogueAuthorityMode, ServerBuilder, ServerState, StorageBackend};
 
     fn test_auth_config() -> AuthConfig {
         AuthConfig {
@@ -1749,7 +1749,7 @@ mod tests {
 
         ServerBuilder::new(AppId::from_name("test-app"))
             .with_auth_config(auth_config)
-            .with_in_memory_storage()
+            .with_storage(StorageBackend::InMemory)
             .build()
             .await
             .expect("build sync test state")
@@ -1761,7 +1761,7 @@ mod tests {
     ) -> Arc<ServerState> {
         ServerBuilder::new(AppId::from_name("test-app"))
             .with_auth_config(test_auth_config())
-            .with_in_memory_storage()
+            .with_storage(StorageBackend::InMemory)
             .with_schema(schema)
             .build()
             .await
@@ -1776,7 +1776,7 @@ mod tests {
         ServerBuilder::new(AppId::from_name("test-app"))
             .with_auth_config(test_auth_config())
             .with_catalogue_authority(catalogue_authority)
-            .with_in_memory_storage()
+            .with_storage(StorageBackend::InMemory)
             .with_schema(schema)
             .build()
             .await
@@ -1977,7 +1977,7 @@ mod tests {
         };
         let state = ServerBuilder::new(AppId::from_name("test-app"))
             .with_auth_config(auth_config)
-            .with_in_memory_storage()
+            .with_storage(StorageBackend::InMemory)
             .build()
             .await
             .expect("build sync test state")
@@ -2019,7 +2019,7 @@ mod tests {
         };
         let state = ServerBuilder::new(AppId::from_name("test-app"))
             .with_auth_config(auth_config)
-            .with_in_memory_storage()
+            .with_storage(StorageBackend::InMemory)
             .build()
             .await
             .expect("build sync test state")
@@ -2061,7 +2061,7 @@ mod tests {
         };
         let state = ServerBuilder::new(AppId::from_name("test-app"))
             .with_auth_config(auth_config)
-            .with_in_memory_storage()
+            .with_storage(StorageBackend::InMemory)
             .build()
             .await
             .expect("build sync test state")
@@ -2103,7 +2103,7 @@ mod tests {
         };
         let state = ServerBuilder::new(AppId::from_name("test-app"))
             .with_auth_config(auth_config)
-            .with_in_memory_storage()
+            .with_storage(StorageBackend::InMemory)
             .build()
             .await
             .expect("build sync test state")
@@ -2167,7 +2167,7 @@ mod tests {
                 jwks_url: None,
                 ..Default::default()
             })
-            .with_in_memory_storage()
+            .with_storage(StorageBackend::InMemory)
             .build()
             .await
             .expect("build server state")

--- a/crates/jazz-tools/src/server/testing.rs
+++ b/crates/jazz-tools/src/server/testing.rs
@@ -14,8 +14,8 @@ use crate::middleware::AuthConfig;
 use crate::query_manager::types::Schema;
 use crate::schema_manager::AppId;
 
-use super::ServerBuilder;
 use super::hosted::HostedServer;
+use super::{ServerBuilder, StorageBackend};
 use crate::sync_manager::ClientId;
 
 const DEFAULT_APP_ID_STR: &str = "00000000-0000-0000-0000-000000000001";
@@ -239,10 +239,9 @@ impl TestingServer {
         };
 
         let server_builder = ServerBuilder::new(app_id).with_auth_config(auth_config);
-        let data_dir_str = data_dir.to_string_lossy().into_owned();
         let mut server_builder = apply_storage_mode(
             server_builder,
-            data_dir_str,
+            data_dir.clone(),
             persistent_storage,
             sqlite_storage,
             rocksdb_storage,
@@ -466,23 +465,23 @@ fn prepare_data_dir(data_dir: Option<PathBuf>) -> (PathBuf, Option<OwnedTempDir>
 /// blocks inside `start_from_builder`.
 fn apply_storage_mode(
     builder: ServerBuilder,
-    data_dir: String,
+    data_dir: PathBuf,
     persistent: bool,
     #[allow(unused_variables)] sqlite: bool,
     #[allow(unused_variables)] rocksdb: bool,
 ) -> ServerBuilder {
     #[cfg(feature = "sqlite")]
     if sqlite {
-        return builder.with_sqlite_storage(data_dir);
+        return builder.with_storage(StorageBackend::Sqlite { path: data_dir });
     }
     #[cfg(feature = "rocksdb")]
     if rocksdb {
-        return builder.with_rocksdb_storage(data_dir);
+        return builder.with_storage(StorageBackend::RocksDb { path: data_dir });
     }
     if persistent {
-        builder.with_persistent_storage(data_dir)
+        builder.with_storage(StorageBackend::Persistent { path: data_dir })
     } else {
-        builder.with_in_memory_storage()
+        builder.with_storage(StorageBackend::InMemory)
     }
 }
 


### PR DESCRIPTION
## Summary

Phase 2 of [crate structure cleanup](specs/todo/c_later/crate_structure_cleanup.md). Replaces four `ServerBuilder::with_*_storage` methods with a single `.with_storage(StorageBackend)`.

```rust
pub enum StorageBackend {
    InMemory,
    Persistent { path: PathBuf },
    #[cfg(feature = "sqlite")] Sqlite { path: PathBuf },
    #[cfg(feature = "rocksdb")] RocksDb { path: PathBuf },
}
```

**Public API break.** All `ServerBuilder` call sites are updated in this PR — `jazz-tools` (`commands/server.rs`, `server/{mod,testing}.rs`, `routes.rs`) and `jazz-napi` (the dynamic-server entry point).

`TestingServerBuilder` keeps its parallel `with_*_storage` methods — it's a different builder consumed by the napi `TestingServer` wrapper, and folding it in would expand the FFI break unnecessarily. A follow-up phase can apply the same treatment if desired.

The internal `ServerStorageMode` private enum is gone; the public `StorageBackend` now drives `build_main_storage` directly. On-disk file paths (`jazz.rocksdb` / `jazz.sqlite` under the configured directory) are unchanged.

## Test plan

- [x] `cargo build --all-features -p jazz-tools`
- [x] `cargo build -p jazz-napi -p jazz-wasm -p jazz-rn`
- [x] `cargo test --all-features -p jazz-tools` — all 1300+ lib tests + integration tests pass