### PR TITLE
Fix Expo fetch polyfill rejecting URL and Request inputs

### DIFF
--- a/.changeset/expo-fetch-polyfill-url-input.md
+++ b/.changeset/expo-fetch-polyfill-url-input.md
@@ -1,0 +1,7 @@
+---
+"jazz-tools": patch
+---
+
+Fix `jazz-tools/expo` fetch polyfill rejecting URL and Request inputs.
+
+`expo/fetch`'s native bridge only accepts a string for the first argument, so calling `fetch(new URL(...))` or `fetch(new Request(...))` — both valid per the WHATWG spec, and the form better-auth's client uses — failed with "The 2nd argument cannot be cast to type URL". The polyfill now normalises URL and Request inputs to a string URL plus a merged init (including the request body) before delegating to `expo/fetch`.

--- a/packages/jazz-tools/src/expo/polyfills.ts
+++ b/packages/jazz-tools/src/expo/polyfills.ts
@@ -12,7 +12,27 @@ import { ReadableStream as PonyfillReadableStream } from "web-streams-polyfill";
 
 const readableStreamCtor = globalThis.ReadableStream ?? PonyfillReadableStream;
 
-polyfillGlobal("fetch", () => expoFetch);
+// expo/fetch's native bridge only accepts a string for `input`, but the
+// WHATWG fetch spec also accepts URL and Request. Normalise here so callers
+// that pass a URL object (e.g. better-auth's client) don't blow up with
+// "The 2nd argument cannot be cast to type URL" inside the native bridge.
+const fetchSpecCompliant: typeof globalThis.fetch = async (input, init) => {
+  if (typeof input === "string") return expoFetch(input, init);
+  if (input instanceof URL) return expoFetch(input.toString(), init);
+  const req = input as Request;
+  const body = req.body ? await req.arrayBuffer() : undefined;
+  return expoFetch(req.url, {
+    method: req.method,
+    headers: req.headers,
+    credentials: req.credentials,
+    redirect: req.redirect,
+    signal: req.signal,
+    body,
+    ...init,
+  });
+};
+
+polyfillGlobal("fetch", () => fetchSpecCompliant);
 polyfillGlobal("Headers", () => ReactNativeHeaders ?? globalThis.Headers);
 polyfillGlobal("Request", () => ReactNativeRequest ?? globalThis.Request);
 polyfillGlobal("Response", () => ReactNativeResponse ?? globalThis.Response);


### PR DESCRIPTION
## Summary
- `polyfillGlobal("fetch", () => expoFetch)` exposed `expo/fetch` directly, but its native bridge only accepts a string URL — passing a `URL` or `Request` (both valid per the WHATWG spec) crashed with `"The 2nd argument cannot be cast to type URL"`.
- Wrap `expoFetch` so it normalises `URL` and `Request` inputs to a string URL plus a merged init (method/headers/credentials/redirect/signal/body) before delegating to the native bridge.
- Triggered by better-auth's client, which passes a `URL` object on every request; should also unblock any other spec-compliant consumer.

## Test plan
- [ ] In an Expo app using `jazz-tools/expo` polyfills, call `fetch(new URL("https://example.com"))` and verify it resolves rather than throwing.
- [ ] Call `fetch(new Request("https://example.com", { method: "POST", body: "hi" }))` and confirm the body reaches the server.
- [ ] Run the better-auth flow that previously crashed and confirm the request completes.