### PR TITLE
Reload browser on successful schema watch push

### DIFF
--- a/.changeset/reload-on-schema-push.md
+++ b/.changeset/reload-on-schema-push.md
@@ -1,0 +1,7 @@
+---
+"jazz-tools": patch
+---
+
+Trigger a Vite full-reload from the Jazz Vite and SvelteKit dev plugins
+whenever the schema watcher successfully pushes an updated schema, so the
+browser picks up the new schema without a manual refresh.

--- a/packages/jazz-tools/src/dev/managed-runtime.ts
+++ b/packages/jazz-tools/src/dev/managed-runtime.ts
@@ -119,6 +119,8 @@ export interface InitializeOptions extends JazzPluginOptions {
   envDir?: string;
   /** Called when a schema watch push fails after initialisation. Use this to forward errors to e.g. Vite's HMR overlay. */
   onSchemaError?: (error: Error) => void;
+  /** Called when the schema watcher successfully pushes an updated schema. Use this to e.g. trigger a Vite full-reload. */
+  onSchemaPush?: (hash: string) => void;
 }
 
 export class ManagedDevRuntime {
@@ -308,6 +310,7 @@ export class ManagedDevRuntime {
           adminSecret,
           onPush: (hash) => {
             console.log(`${LOG_PREFIX} schema updated (${hash.slice(0, 12)})`);
+            options.onSchemaPush?.(hash);
           },
           onError: (error) => {
             console.error(`${LOG_PREFIX} schema push failed:`, error.message);

--- a/packages/jazz-tools/src/dev/sveltekit.test.ts
+++ b/packages/jazz-tools/src/dev/sveltekit.test.ts
@@ -324,6 +324,41 @@ describe("jazzSvelteKit", () => {
     ).rejects.toThrow("appId is required when connecting to an existing server");
   });
 
+  it("sends a full-reload to the browser on a successful schema watch push", async () => {
+    vi.spyOn(devServer, "startLocalJazzServer").mockResolvedValue({
+      appId: "00000000-0000-0000-0000-000000000050",
+      port: 19890,
+      url: "http://127.0.0.1:19890",
+      dataDir: undefined as unknown as string,
+      stop: vi.fn().mockResolvedValue(undefined),
+    });
+    vi.spyOn(devServer, "pushSchemaCatalogue").mockResolvedValue({ hash: "abc123def4567890" });
+    let capturedOnPush: ((hash: string) => void) | undefined;
+    vi.spyOn(schemaWatcher, "watchSchema").mockImplementation((opts) => {
+      capturedOnPush = opts.onPush;
+      return { close: vi.fn() };
+    });
+
+    const root = await tempRoots.create("jazz-sveltekit-reload-test-");
+    const wsSend = vi.fn();
+    const viteServer: ViteDevServer & { restart: ReturnType<typeof vi.fn> } = {
+      config: { root, command: "serve", env: {} },
+      httpServer: { once() {} },
+      ws: { send: wsSend },
+      restart: vi.fn(() => Promise.resolve()),
+    };
+
+    const plugin = jazzSvelteKit({
+      server: { port: 19890, adminSecret: "reload-admin" },
+    });
+    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(viteServer);
+
+    expect(capturedOnPush).toBeDefined();
+    capturedOnPush!("abc123def4567890");
+
+    expect(wsSend).toHaveBeenCalledWith({ type: "full-reload" });
+  });
+
   it("surfaces schema push failures as HMR errors", async () => {
     vi.spyOn(devServer, "startLocalJazzServer").mockResolvedValue({
       appId: "00000000-0000-0000-0000-000000000003",

--- a/packages/jazz-tools/src/dev/sveltekit.ts
+++ b/packages/jazz-tools/src/dev/sveltekit.ts
@@ -108,6 +108,9 @@ export function jazzSvelteKit(options: JazzPluginOptions = {}) {
               },
             });
           },
+          onSchemaPush: () => {
+            viteServer.ws.send({ type: "full-reload" });
+          },
         });
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/packages/jazz-tools/src/dev/vite.test.ts
+++ b/packages/jazz-tools/src/dev/vite.test.ts
@@ -2,6 +2,8 @@ import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { jazzPlugin } from "./vite.js";
+import * as devServer from "./dev-server.js";
+import * as schemaWatcher from "./schema-watcher.js";
 import { createTempRootTracker, getAvailablePort, todoSchema } from "./test-helpers.js";
 
 const tempRoots = createTempRootTracker();
@@ -20,6 +22,7 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   await tempRoots.cleanup();
 
   if (originalJazzServerUrl === undefined) {
@@ -212,6 +215,52 @@ describe("jazzPlugin", () => {
       await handler();
     }
   }, 30_000);
+
+  it("sends a full-reload to the browser on a successful schema watch push", async () => {
+    vi.spyOn(devServer, "startLocalJazzServer").mockResolvedValue({
+      appId: "00000000-0000-0000-0000-000000000060",
+      port: 19880,
+      url: "http://127.0.0.1:19880",
+      dataDir: undefined as unknown as string,
+      stop: vi.fn().mockResolvedValue(undefined),
+    });
+    vi.spyOn(devServer, "pushSchemaCatalogue").mockResolvedValue({ hash: "abc123def4567890" });
+    let capturedOnPush: ((hash: string) => void) | undefined;
+    vi.spyOn(schemaWatcher, "watchSchema").mockImplementation((opts) => {
+      capturedOnPush = opts.onPush;
+      return { close: vi.fn() };
+    });
+
+    const schemaDir = await tempRoots.create("jazz-vite-reload-test-");
+    await writeFile(join(schemaDir, "schema.ts"), todoSchema());
+
+    const wsSend = vi.fn();
+    const fakeViteServer = {
+      config: {
+        root: schemaDir,
+        command: "serve" as const,
+        env: {} as Record<string, string>,
+      },
+      httpServer: {
+        once(_event: string, _cb: () => void) {},
+      },
+      ws: { send: wsSend },
+    };
+
+    const plugin = jazzPlugin({
+      server: { port: 19880, adminSecret: "vite-reload-admin" },
+      schemaDir,
+    });
+    const configureServer = plugin.configureServer as (
+      server: typeof fakeViteServer,
+    ) => Promise<void>;
+    await configureServer(fakeViteServer);
+
+    expect(capturedOnPush).toBeDefined();
+    capturedOnPush!("abc123def4567890");
+
+    expect(wsSend).toHaveBeenCalledWith({ type: "full-reload" });
+  });
 
   it("does not overwrite an existing JAZZ_APP_ID in .env when one is already set", async () => {
     const port = await getAvailablePort();

--- a/packages/jazz-tools/src/dev/vite.ts
+++ b/packages/jazz-tools/src/dev/vite.ts
@@ -104,7 +104,13 @@ export function jazzPlugin(options: JazzPluginOptions = {}) {
 
       let managed;
       try {
-        managed = await runtime.initialize({ ...options, schemaDir });
+        managed = await runtime.initialize({
+          ...options,
+          schemaDir,
+          onSchemaPush: () => {
+            viteServer.ws.send({ type: "full-reload" });
+          },
+        });
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         viteServer.ws.send({


### PR DESCRIPTION
## Summary
- Add an `onSchemaPush` callback to `ManagedDevRuntime.initialize`, fired after a schema watch push succeeds
- Wire the Vite and SvelteKit dev plugins to send a `full-reload` over the dev server's WebSocket from that callback, so the browser picks up the new schema without a manual refresh

## Test plan
- [ ] `pnpm --filter jazz-tools exec vitest run src/dev/sveltekit.test.ts src/dev/vite.test.ts` — new "sends a full-reload to the browser on a successful schema watch push" tests pass for both plugins
- [ ] In a Vite or SvelteKit example app, edit `schema.ts` while `pnpm dev` is running and confirm the browser reloads on its own