### PR TITLE
fix(jazz-tools/react-native): override getLocalFirstIdentityProof to use jazz-rn

### DIFF
--- a/.changeset/rn-local-first-identity-proof.md
+++ b/.changeset/rn-local-first-identity-proof.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix `getLocalFirstIdentityProof` on React Native by minting the proof token through `jazz-rn` instead of the (unavailable) WASM module, restoring the local-first → upgrade-to-account sign-up flow on RN.

--- a/packages/jazz-tools/src/react-native/db.ts
+++ b/packages/jazz-tools/src/react-native/db.ts
@@ -80,6 +80,19 @@ export class Db extends RuntimeDb {
     }
     this.nativeClients.clear();
   }
+
+  // The base implementation needs a WASM module to mint the proof. RN has no
+  // WASM module, so route through jazz-rn's native binding instead.
+  override async getLocalFirstIdentityProof(options?: {
+    ttlSeconds?: number;
+    audience?: string;
+  }): Promise<string | null> {
+    const secret = this.nativeConfig.secret;
+    if (!secret) return null;
+    const ttl = BigInt(options?.ttlSeconds ?? 60);
+    const audience = options?.audience ?? this.nativeConfig.appId;
+    return jazzRn.jazz_rn.mintLocalFirstToken(secret, audience, ttl);
+  }
 }
 
 export async function createDb(config: DbConfig): Promise<Db> {


### PR DESCRIPTION
## Summary

`Db.getLocalFirstIdentityProof` (in `packages/jazz-tools/src/runtime/db.ts:2068`) mints the proof token via `wasmModule.WasmRuntime.mintJazzSelfSignedToken`. On React Native there is no WASM module — the runtime is `jazz-rn` — so `wasmModule` is null and the base method returns null. That makes the hybrid local-first → upgrade-to-account flow unreachable on RN: the sign-up form sees `null` and rejects with **"Sign up requires an active Jazz session"**.

This PR overrides the method on the RN `Db` subclass to route through `jazzRn.jazz_rn.mintLocalFirstToken`, which calls the same `mint_jazz_self_signed_token` underneath but is exposed via the UniFFI binding. Same audience-normalisation rules (`Uuid::new_v5(NAMESPACE_DNS, audience)`), same issuer (`urn:jazz:local-first`), so server-side `verifyLocalFirstIdentityProof` accepts it identically to the WASM-minted version.

## How this surfaced

While bringing up the new `expo-hybrid` starter on iOS sim. Sign-up form (`src/sign-up-form.tsx`) calls `db.getLocalFirstIdentityProof({ ttlSeconds, audience })` to mint a proof, hands it to `authClient.signUp.email({ ..., proofToken })`, and the server middleware verifies it against an expected audience. With the base method returning `null`, the form short-circuits before any network call. Override fixes this; sign-up succeeds and the resulting BetterAuth account is bound to the existing local-first identity.

## Test plan

- [ ] `pnpm --filter jazz-tools build` — type-check passes
- [ ] `pnpm --filter expo-hybrid ios` — local-first dashboard renders
- [ ] Tap **Sign up**, fill in name/email/password, submit — sign-up succeeds, dashboard switches to the authenticated state
- [ ] No regression on `pnpm --filter expo-localfirst ios` (does not exercise this code path)

## Notes

The RN binding's `mintLocalFirstToken` and the base WASM `mintJazzSelfSignedToken` produce byte-compatible tokens (same Rust function under the hood). The override accepts the same `{ ttlSeconds, audience }` options shape; `audience` defaults to `appId` matching base behaviour. Returns `null` only if no local-first secret is configured, also matching base.