### PR TITLE
refactor(jazz-tools): Phase 4 — fold runtime_core.rs and extract DurabilityTracker

### DIFF
--- a/crates/jazz-tools/src/runtime_core/durability.rs
+++ b/crates/jazz-tools/src/runtime_core/durability.rs
@@ -1,0 +1,110 @@
+//! [`DurabilityTracker`] — owns the per-batch ack-watcher map and the set of
+//! rejected replayable batch ids that bindings still need to surface.
+//!
+//! Extracted from `RuntimeCore` so the orchestrator no longer carries the
+//! bookkeeping for who-is-waiting-on-which-tier; it only delegates the
+//! six primitive operations (`register_watcher`, `record_ack`,
+//! `record_rejection`, `drain_rejected`, `forget_batch`) defined here.
+
+use std::collections::{BTreeSet, HashMap};
+
+use futures::channel::oneshot;
+
+use crate::row_histories::BatchId;
+use crate::sync_manager::{DurabilityTier, RowBatchKey};
+
+use super::{PersistedWriteAck, PersistedWriteRejection};
+
+#[derive(Default)]
+pub(crate) struct DurabilityTracker {
+    /// Watchers waiting for a row+batch to be confirmed at a requested tier.
+    ack_watchers: HashMap<RowBatchKey, Vec<(DurabilityTier, oneshot::Sender<PersistedWriteAck>)>>,
+    /// Rejected replayable batch ids surfaced once to bindings on next drain.
+    rejected_batch_ids: BTreeSet<BatchId>,
+}
+
+impl DurabilityTracker {
+    /// Construct a tracker preloaded with rejection ids recovered from
+    /// persisted local batch records on startup.
+    pub(crate) fn with_initial_rejections(rejected: BTreeSet<BatchId>) -> Self {
+        Self {
+            ack_watchers: HashMap::new(),
+            rejected_batch_ids: rejected,
+        }
+    }
+
+    /// Register a watcher that resolves when `key` reaches `tier` (or higher).
+    pub(crate) fn register_watcher(
+        &mut self,
+        key: RowBatchKey,
+        tier: DurabilityTier,
+        sender: oneshot::Sender<PersistedWriteAck>,
+    ) {
+        self.ack_watchers
+            .entry(key)
+            .or_default()
+            .push((tier, sender));
+    }
+
+    /// Resolve every watcher on `key` whose requested tier is satisfied by
+    /// `acked_tier`; keep the rest registered.
+    pub(crate) fn record_ack(&mut self, key: RowBatchKey, acked_tier: DurabilityTier) {
+        let Some(watchers) = self.ack_watchers.remove(&key) else {
+            return;
+        };
+        let mut remaining = Vec::new();
+        for (requested_tier, sender) in watchers {
+            if acked_tier >= requested_tier {
+                tracing::debug!(?key, ?acked_tier, ?requested_tier, "ack watcher resolved");
+                let _ = sender.send(Ok(()));
+            } else {
+                remaining.push((requested_tier, sender));
+            }
+        }
+        if !remaining.is_empty() {
+            self.ack_watchers.insert(key, remaining);
+        }
+    }
+
+    /// Mark `batch_id` rejected and notify every watcher whose key references
+    /// that batch with the rejection details.
+    pub(crate) fn record_rejection(&mut self, batch_id: BatchId, code: &str, reason: &str) {
+        self.rejected_batch_ids.insert(batch_id);
+
+        let rejection = PersistedWriteRejection {
+            batch_id,
+            code: code.to_string(),
+            reason: reason.to_string(),
+        };
+
+        let affected_keys: Vec<_> = self
+            .ack_watchers
+            .keys()
+            .copied()
+            .filter(|key| key.batch_id == batch_id)
+            .collect();
+        for key in affected_keys {
+            if let Some(watchers) = self.ack_watchers.remove(&key) {
+                for (_requested_tier, sender) in watchers {
+                    let _ = sender.send(Err(rejection.clone()));
+                }
+            }
+        }
+    }
+
+    /// Drain every rejection id pending surface; subsequent calls return an
+    /// empty vec until a new rejection is recorded.
+    pub(crate) fn drain_rejected(&mut self) -> Vec<BatchId> {
+        std::mem::take(&mut self.rejected_batch_ids)
+            .into_iter()
+            .collect()
+    }
+
+    /// Forget a batch entirely — drops any remaining watchers for it and
+    /// removes it from the rejected set. Used when an explicit ack flushes
+    /// the local batch record.
+    pub(crate) fn forget_batch(&mut self, batch_id: BatchId) {
+        self.ack_watchers.retain(|key, _| key.batch_id != batch_id);
+        self.rejected_batch_ids.remove(&batch_id);
+    }
+}

--- a/crates/jazz-tools/src/runtime_core/mod.rs
+++ b/crates/jazz-tools/src/runtime_core/mod.rs
@@ -48,9 +48,7 @@ use crate::row_format::decode_row;
 use crate::row_histories::BatchId;
 use crate::schema_manager::{Lens, SchemaManager};
 use crate::storage::Storage;
-use crate::sync_manager::{
-    ClientId, DurabilityTier, InboxEntry, OutboxEntry, RowBatchKey, ServerId,
-};
+use crate::sync_manager::{ClientId, DurabilityTier, InboxEntry, OutboxEntry, ServerId};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QueryLocalOverlay {
@@ -312,12 +310,8 @@ pub struct RuntimeCore<S: Storage, Sch: Scheduler> {
     /// Pending one-shot queries (query() calls waiting for first callback).
     pending_one_shot_queries: HashMap<SubscriptionHandle, PendingOneShotQuery>,
 
-    /// Watchers for persistence acks: (row, branch, logical write batch, requested_tier) → senders.
-    /// A tier >= requested tier satisfies the watcher (e.g., EdgeServer ack satisfies Local).
-    ack_watchers: HashMap<RowBatchKey, Vec<(DurabilityTier, oneshot::Sender<PersistedWriteAck>)>>,
-
-    /// Rejected replayable batch ids that should be surfaced once to bindings.
-    rejected_batch_ids: BTreeSet<crate::row_histories::BatchId>,
+    /// Per-batch durability bookkeeping: ack watchers + rejection set.
+    pub(crate) durability: DurabilityTracker,
 
     /// Label for tracing (e.g. "local", "edge", "client").
     tier_label: &'static str,
@@ -367,8 +361,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             next_subscription_handle: 0,
             pending_subscriptions: HashMap::new(),
             pending_one_shot_queries: HashMap::new(),
-            ack_watchers: HashMap::new(),
-            rejected_batch_ids: rejected_batch_ids.clone(),
+            durability: DurabilityTracker::with_initial_rejections(rejected_batch_ids.clone()),
             tier_label: "unknown",
             sync_tracer: None,
             auth_failure_callback: None,
@@ -609,10 +602,13 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
     }
 }
 
+mod durability;
 mod subscriptions;
 mod sync;
 mod ticks;
 mod writes;
+
+use durability::DurabilityTracker;
 
 #[cfg(test)]
 mod tests;

--- a/crates/jazz-tools/src/runtime_core/ticks.rs
+++ b/crates/jazz-tools/src/runtime_core/ticks.rs
@@ -65,59 +65,6 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         rows
     }
 
-    fn resolve_ack_watchers_for_key(
-        &mut self,
-        row_batch_key: crate::sync_manager::RowBatchKey,
-        acked_tier: DurabilityTier,
-    ) {
-        if let Some(watchers) = self.ack_watchers.remove(&row_batch_key) {
-            let mut remaining = Vec::new();
-            for (requested_tier, sender) in watchers {
-                if acked_tier >= requested_tier {
-                    tracing::debug!(
-                        ?row_batch_key,
-                        ?acked_tier,
-                        ?requested_tier,
-                        "ack watcher resolved"
-                    );
-                    let _ = sender.send(Ok(()));
-                } else {
-                    remaining.push((requested_tier, sender));
-                }
-            }
-            if !remaining.is_empty() {
-                self.ack_watchers.insert(row_batch_key, remaining);
-            }
-        }
-    }
-
-    fn reject_ack_watchers_for_batch(
-        &mut self,
-        batch_id: crate::row_histories::BatchId,
-        code: &str,
-        reason: &str,
-    ) {
-        let rejection = crate::runtime_core::PersistedWriteRejection {
-            batch_id,
-            code: code.to_string(),
-            reason: reason.to_string(),
-        };
-
-        let affected_keys: Vec<_> = self
-            .ack_watchers
-            .keys()
-            .copied()
-            .filter(|key| key.batch_id == batch_id)
-            .collect();
-        for key in affected_keys {
-            if let Some(watchers) = self.ack_watchers.remove(&key) {
-                for (_requested_tier, sender) in watchers {
-                    let _ = sender.send(Err(rejection.clone()));
-                }
-            }
-        }
-    }
-
     fn apply_received_batch_settlement(&mut self, settlement: crate::batch_fate::BatchSettlement) {
         let batch_id = settlement.batch_id();
         if let Ok(Some(mut record)) = self.storage.load_local_batch_record(batch_id) {
@@ -131,15 +78,9 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             }
         }
 
-        if matches!(
-            settlement,
-            crate::batch_fate::BatchSettlement::Rejected { .. }
-        ) {
-            self.rejected_batch_ids.insert(batch_id);
+        if let crate::batch_fate::BatchSettlement::Rejected { code, reason, .. } = &settlement {
             self.mark_local_batch_rows_rejected(batch_id);
-            if let crate::batch_fate::BatchSettlement::Rejected { code, reason, .. } = &settlement {
-                self.reject_ack_watchers_for_batch(batch_id, code, reason);
-            }
+            self.durability.record_rejection(batch_id, code, reason);
         } else if matches!(
             settlement,
             crate::batch_fate::BatchSettlement::Missing { .. }
@@ -156,7 +97,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                     visible_members, ..
                 } => {
                     for member in visible_members {
-                        self.resolve_ack_watchers_for_key(
+                        self.durability.record_ack(
                             crate::sync_manager::RowBatchKey::new(
                                 member.object_id,
                                 member.branch_name,
@@ -481,7 +422,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             .sync_manager_mut()
             .take_received_row_batch_acks();
         for (row_batch_key, acked_tier) in received_acks {
-            self.resolve_ack_watchers_for_key(row_batch_key, acked_tier);
+            self.durability.record_ack(row_batch_key, acked_tier);
         }
 
         // 4. Schedule batched_tick if outbound messages exist or a WAL flush

--- a/crates/jazz-tools/src/runtime_core/writes.rs
+++ b/crates/jazz-tools/src/runtime_core/writes.rs
@@ -476,10 +476,8 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             let _ = sender.send(Ok(()));
         } else {
             let row_batch_key = self.ack_watcher_key(row_id, batch_id, write_context);
-            self.ack_watchers
-                .entry(row_batch_key)
-                .or_default()
-                .push((tier, sender));
+            self.durability
+                .register_watcher(row_batch_key, tier, sender);
         }
         self.mark_storage_write_pending_flush();
         self.immediate_tick();
@@ -518,10 +516,8 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             let _ = sender.send(Ok(()));
         } else {
             let row_batch_key = self.ack_watcher_key(row_id, batch_id, write_context);
-            self.ack_watchers
-                .entry(row_batch_key)
-                .or_default()
-                .push((tier, sender));
+            self.durability
+                .register_watcher(row_batch_key, tier, sender);
         }
 
         self.mark_storage_write_pending_flush();
@@ -572,10 +568,8 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             let _ = sender.send(Ok(()));
         } else {
             let row_batch_key = self.ack_watcher_key(object_id, batch_id, write_context);
-            self.ack_watchers
-                .entry(row_batch_key)
-                .or_default()
-                .push((tier, sender));
+            self.durability
+                .register_watcher(row_batch_key, tier, sender);
         }
 
         self.mark_storage_write_pending_flush();
@@ -631,10 +625,8 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             let _ = sender.send(Ok(()));
         } else {
             let row_batch_key = self.ack_watcher_key(object_id, batch_id, write_context);
-            self.ack_watchers
-                .entry(row_batch_key)
-                .or_default()
-                .push((tier, sender));
+            self.durability
+                .register_watcher(row_batch_key, tier, sender);
         }
 
         self.mark_storage_write_pending_flush();
@@ -671,10 +663,8 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             let _ = sender.send(Ok(()));
         } else {
             let row_batch_key = self.ack_watcher_key(object_id, batch_id, write_context);
-            self.ack_watchers
-                .entry(row_batch_key)
-                .or_default()
-                .push((tier, sender));
+            self.durability
+                .register_watcher(row_batch_key, tier, sender);
         }
 
         self.mark_storage_write_pending_flush();
@@ -702,9 +692,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
 
     /// Drain replayable rejected batch ids that should be surfaced by bindings.
     pub fn drain_rejected_batch_ids(&mut self) -> Vec<BatchId> {
-        std::mem::take(&mut self.rejected_batch_ids)
-            .into_iter()
-            .collect()
+        self.durability.drain_rejected()
     }
 
     /// Acknowledge a replayable rejected batch outcome and prune the local
@@ -728,8 +716,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         self.storage
             .delete_local_batch_record(batch_id)
             .map_err(|err| RuntimeError::WriteError(format!("delete local batch record: {err}")))?;
-        self.ack_watchers.retain(|key, _| key.batch_id != batch_id);
-        self.rejected_batch_ids.remove(&batch_id);
+        self.durability.forget_batch(batch_id);
         self.mark_storage_write_pending_flush();
         Ok(true)
     }


### PR DESCRIPTION
## Summary

Phase 4 of [crate structure cleanup](specs/todo/c_later/crate_structure_cleanup.md), partial. Two of the four RuntimeCore decomposition steps from the spec — depends on Phase 1 (#709, merged).

1. **Mechanical fold.** `runtime_core.rs` (the parent file alongside the `runtime_core/` directory) becomes `runtime_core/mod.rs`, aligning with every other subsystem (query_manager, schema_manager, storage, sync_manager, server, middleware, row_histories, ws_stream, commands).

2. **`DurabilityTracker` extraction** (`runtime_core/durability.rs`). Owns `ack_watchers` + `rejected_batch_ids` and exposes:
   - `register_watcher(key, tier, sender)`
   - `record_ack(key, acked_tier)`
   - `record_rejection(batch_id, code, reason)`
   - `drain_rejected()`
   - `forget_batch(batch_id)`
   - `with_initial_rejections(...)` (startup recovery)

   `RuntimeCore` now holds a single `durability: DurabilityTracker` field in place of two per-batch maps. Call sites in `writes.rs` (5× `register_watcher`, `drain_rejected`, `forget_batch`) and `ticks.rs` (`record_ack` in two settle paths, `record_rejection` in the `BatchSettlement::Rejected` path) go through the tracker. The two private helpers on `RuntimeCore` — `resolve_ack_watchers_for_key` and `reject_ack_watchers_for_batch` — are removed.

A small simplification at `runtime_core/ticks.rs` collapses an `if matches!(..) { … if let Rejected{..} = settlement { … } }` shape into a single `if let Rejected { code, reason, .. } = &settlement { … }` since the outer `matches!` guard made the inner if-let unconditional.

Public API of `RuntimeCore` is unchanged (`drain_rejected_batch_ids`, `acknowledge_rejected_batch` still exist; they delegate now).

### Deferred from this PR

- **`SyncInbox` extraction** (4 fields + dual-buffer rewrite at `runtime_core/ticks.rs:622-684`). Larger surgery.
- **`SubscriptionRegistry` extraction** (5 items). Independent of SyncInbox.

Each warrants its own PR. Phase 6 (WriteGuard) was sequenced after Phase 4 in the spec — also deferred.

## Test plan

- [x] `cargo build --all-features -p jazz-tools`
- [x] `cargo build -p jazz-napi -p jazz-wasm -p jazz-rn`
- [x] `cargo test --all-features -p jazz-tools` — 1302 lib tests + integration tests all green; rejection-recovery tests in `runtime_core/tests/write_batch/` exercise `drain_rejected_batch_ids` and pass unchanged