### PR TITLE
refactor(jazz-tools): Phase 6 — replace mark_storage_write_pending_flush calls with WriteGuard

### DIFF
--- a/crates/jazz-tools/src/runtime_core/mod.rs
+++ b/crates/jazz-tools/src/runtime_core/mod.rs
@@ -424,6 +424,27 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
     pub(crate) fn clear_storage_write_pending_flush(&mut self) {
         self.storage_write_pending_flush = false;
     }
+}
+
+/// Marker constructed by mutation entry points in `writes.rs`, `ticks.rs`, and
+/// `sync.rs` to record that storage was touched and a WAL flush is pending.
+///
+/// The act of constructing the guard *is* the side effect — there is no
+/// release-on-drop. The flag is consumed by `batched_tick` when it issues
+/// the next flush. Mutation functions hold no `&mut RuntimeCore` borrow
+/// while the guard is bound, since `WriteGuard` carries no runtime state.
+#[must_use = "WriteGuard exists for its side effect; binding to `_` is fine but discarding without binding misses the flag"]
+pub(crate) struct WriteGuard;
+
+impl WriteGuard {
+    pub(crate) fn new<S: Storage, Sch: Scheduler>(core: &mut RuntimeCore<S, Sch>) -> Self {
+        core.mark_storage_write_pending_flush();
+        Self
+    }
+}
+
+impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
+    // (continued below — split for the WriteGuard definition above)
 
     /// Consume RuntimeCore and return the Storage.
     /// Used for cold-start testing to transfer driver state.

--- a/crates/jazz-tools/src/runtime_core/sync.rs
+++ b/crates/jazz-tools/src/runtime_core/sync.rs
@@ -46,7 +46,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
     /// Push a sync message to the inbox (from network).
     pub fn push_sync_inbox(&mut self, entry: InboxEntry) {
         if entry.payload.writes_storage() {
-            self.mark_storage_write_pending_flush();
+            let _guard = crate::runtime_core::WriteGuard::new(self);
         }
         self.schema_manager
             .query_manager_mut()

--- a/crates/jazz-tools/src/runtime_core/ticks.rs
+++ b/crates/jazz-tools/src/runtime_core/ticks.rs
@@ -248,7 +248,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             .sync_manager_mut()
             .recover_completed_sealed_batches_with_storage(&mut self.storage);
         if recovered_sealed_batches {
-            self.mark_storage_write_pending_flush();
+            let _guard = crate::runtime_core::WriteGuard::new(self);
         }
 
         // 1. Process logical updates (sync, subscriptions)
@@ -572,7 +572,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         }
         for msg in messages {
             if msg.payload.writes_storage() {
-                self.mark_storage_write_pending_flush();
+                let _guard = crate::runtime_core::WriteGuard::new(self);
             }
             self.push_sync_inbox(msg);
             applied_messages += 1;
@@ -604,7 +604,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                 .unwrap_or(next_expected.saturating_sub(1));
             for (sequence, msg) in ready_messages {
                 if msg.payload.writes_storage() {
-                    self.mark_storage_write_pending_flush();
+                    let _guard = crate::runtime_core::WriteGuard::new(self);
                 }
                 self.push_sync_inbox(msg);
                 applied_messages += 1;

--- a/crates/jazz-tools/src/runtime_core/writes.rs
+++ b/crates/jazz-tools/src/runtime_core/writes.rs
@@ -300,7 +300,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             .unwrap_or(BatchMode::Direct);
         self.track_local_batch(row_id, batch_id, batch_mode, true)?;
         debug!(object_id = %row_id, "inserted");
-        self.mark_storage_write_pending_flush();
+        let _guard = crate::runtime_core::WriteGuard::new(self);
         self.immediate_tick();
         Ok(((row_id, row_values), batch_id))
     }
@@ -332,7 +332,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             .unwrap_or(BatchMode::Direct);
         self.track_local_batch(row_id, batch_id, batch_mode, true)?;
         debug!(object_id = %row_id, "inserted");
-        self.mark_storage_write_pending_flush();
+        let _guard = crate::runtime_core::WriteGuard::new(self);
         self.immediate_tick();
         Ok(((row_id, row_values), batch_id))
     }
@@ -355,7 +355,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             .unwrap_or(BatchMode::Direct);
         self.track_local_batch(object_id, batch_id, batch_mode, true)?;
 
-        self.mark_storage_write_pending_flush();
+        let _guard = crate::runtime_core::WriteGuard::new(self);
         self.immediate_tick();
         Ok(batch_id)
     }
@@ -388,7 +388,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             self.track_local_batch(object_id, batch_id, BatchMode::Transactional, false)?;
         }
 
-        self.mark_storage_write_pending_flush();
+        let _guard = crate::runtime_core::WriteGuard::new(self);
         self.immediate_tick();
         Ok(())
     }
@@ -411,7 +411,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             .unwrap_or(BatchMode::Direct);
         self.track_local_batch(object_id, batch_id, batch_mode, true)?;
         debug!("deleted");
-        self.mark_storage_write_pending_flush();
+        let _guard = crate::runtime_core::WriteGuard::new(self);
         self.immediate_tick();
         Ok(batch_id)
     }
@@ -479,7 +479,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             self.durability
                 .register_watcher(row_batch_key, tier, sender);
         }
-        self.mark_storage_write_pending_flush();
+        let _guard = crate::runtime_core::WriteGuard::new(self);
         self.immediate_tick();
         Ok(((row_id, row_values), receiver))
     }
@@ -520,7 +520,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                 .register_watcher(row_batch_key, tier, sender);
         }
 
-        self.mark_storage_write_pending_flush();
+        let _guard = crate::runtime_core::WriteGuard::new(self);
         self.immediate_tick();
         Ok(((row_id, row_values), batch_id, receiver))
     }
@@ -572,7 +572,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                 .register_watcher(row_batch_key, tier, sender);
         }
 
-        self.mark_storage_write_pending_flush();
+        let _guard = crate::runtime_core::WriteGuard::new(self);
         self.immediate_tick();
         Ok((batch_id, receiver))
     }
@@ -629,7 +629,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                 .register_watcher(row_batch_key, tier, sender);
         }
 
-        self.mark_storage_write_pending_flush();
+        let _guard = crate::runtime_core::WriteGuard::new(self);
         self.immediate_tick();
         Ok(receiver)
     }
@@ -667,7 +667,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                 .register_watcher(row_batch_key, tier, sender);
         }
 
-        self.mark_storage_write_pending_flush();
+        let _guard = crate::runtime_core::WriteGuard::new(self);
         self.immediate_tick();
         Ok((batch_id, receiver))
     }
@@ -717,7 +717,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             .delete_local_batch_record(batch_id)
             .map_err(|err| RuntimeError::WriteError(format!("delete local batch record: {err}")))?;
         self.durability.forget_batch(batch_id);
-        self.mark_storage_write_pending_flush();
+        let _guard = crate::runtime_core::WriteGuard::new(self);
         Ok(true)
     }
 
@@ -748,7 +748,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             .query_manager_mut()
             .sync_manager_mut()
             .seal_batch_to_servers(submission);
-        self.mark_storage_write_pending_flush();
+        let _guard = crate::runtime_core::WriteGuard::new(self);
         self.immediate_tick();
         Ok(())
     }


### PR DESCRIPTION
> **Stacked on #717 (Phase 4).** This PR's base is \`refactor/phase-4-runtime-core-decomp\`, not \`main\`. It uses the runtime_core/mod.rs layout from Phase 4.

## Summary

Phase 6 of [crate structure cleanup](specs/todo/c_later/crate_structure_cleanup.md). Introduces a \`WriteGuard\` marker type whose constructor sets the \`storage_write_pending_flush\` flag.

Mutation entry points in \`runtime_core/{writes,ticks,sync}.rs\` now bind a guard at entry:

\`\`\`rust
let _guard = crate::runtime_core::WriteGuard::new(self);
\`\`\`

instead of poking the flag directly via \`self.mark_storage_write_pending_flush()\`. All 16 direct call sites — 12 in \`writes.rs\`, 3 in \`ticks.rs\`, 1 in \`sync.rs\` — are replaced.

The flag setter itself stays on \`RuntimeCore\` (now called only from \`WriteGuard::new\` and the four pre-existing internal callers in \`mod.rs\` that have no clear mutation entry to attach a guard to — \`apply_received_batch_settlement\`, etc.). This matches the spec's acceptance: "no direct calls remain in writes.rs, ticks.rs, or sync.rs."

\`WriteGuard\` intentionally holds no \`&mut RuntimeCore\` reference — the construction is the entire side effect, so the borrow ends as soon as the constructor returns and subsequent self-using code in the mutation function compiles unchanged. \`#[must_use]\` is set on the type so a stray construction without a binding produces a warning.

\`batched_tick\` continues to consume the flag at flush time; the flag-clearing API (\`clear_storage_write_pending_flush\`) is unchanged.

## Test plan

- [x] \`cargo build --all-features -p jazz-tools\`
- [x] \`cargo build -p jazz-napi -p jazz-wasm -p jazz-rn\`
- [x] \`cargo test --all-features -p jazz-tools\` — 1302 lib tests + integration tests all green