### PR TITLE
refactor(jazz-tools): Phase 5 — typed-builder subscribe via PendingSubscriptionRequest

### DIFF
--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -938,7 +938,7 @@ impl NapiRuntime {
             .core
             .lock()
             .map_err(|_| napi::Error::from_reason("lock"))?;
-        let handle = core.create_subscription(query, session, durability, propagation);
+        let handle = core.create_subscription_for_ffi(query, session, durability, propagation);
         drop(core);
 
         if query_rows_can_be_schema_aligned(&query_for_alignment) {
@@ -980,7 +980,7 @@ impl NapiRuntime {
             .core
             .lock()
             .map_err(|_| napi::Error::from_reason("lock"))?;
-        core.execute_subscription(sub_handle, callback)
+        core.execute_subscription_for_ffi(sub_handle, callback)
             .map_err(|e| {
                 napi::Error::from_reason(format!("Execute subscription failed: {:?}", e))
             })?;

--- a/crates/jazz-rn/rust/src/lib.rs
+++ b/crates/jazz-rn/rust/src/lib.rs
@@ -709,8 +709,12 @@ impl RnRuntime {
                 message: "lock poisoned".into(),
             })?;
 
-            let handle =
-                core.create_subscription(query, session, durability, QueryPropagation::Full);
+            let handle = core.create_subscription_for_ffi(
+                query,
+                session,
+                durability,
+                QueryPropagation::Full,
+            );
             drop(core);
 
             if query_rows_can_be_schema_aligned(&query_for_alignment) {
@@ -752,7 +756,7 @@ impl RnRuntime {
                 alignment_table,
             );
 
-            core.execute_subscription(SubscriptionHandle(handle), callback)
+            core.execute_subscription_for_ffi(SubscriptionHandle(handle), callback)
                 .map_err(runtime_err)?;
 
             Ok(())

--- a/crates/jazz-tools/src/runtime_core/subscriptions.rs
+++ b/crates/jazz-tools/src/runtime_core/subscriptions.rs
@@ -27,6 +27,47 @@ pub(super) struct PendingSubscription {
     pub propagation: QueryPropagation,
 }
 
+/// Typed builder returned by [`RuntimeCore::subscribe`] — the only thing it
+/// can do is have [`Self::execute`] called on it. Forgetting to call execute
+/// produces a `must_use` warning at compile time; calling it twice is
+/// impossible because `execute` consumes the builder.
+///
+/// The flat `create_subscription` / `execute_subscription` pair on
+/// [`RuntimeCore`] remains for FFI bindings that need separate JS/UniFFI
+/// entry points; new Rust callers should prefer the builder.
+#[must_use = "PendingSubscriptionRequest must be consumed by .execute(callback) — \
+              dropping it leaves a phantom subscription registered in the runtime"]
+pub struct PendingSubscriptionRequest<'a, S: Storage, Sch: Scheduler> {
+    runtime: &'a mut RuntimeCore<S, Sch>,
+    handle: SubscriptionHandle,
+}
+
+impl<'a, S: Storage, Sch: Scheduler> PendingSubscriptionRequest<'a, S, Sch> {
+    /// Execute the pending subscription with `callback` and return its
+    /// stable [`SubscriptionHandle`].
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn execute<F>(self, callback: F) -> Result<SubscriptionHandle, RuntimeError>
+    where
+        F: Fn(SubscriptionDelta) + Send + 'static,
+    {
+        self.runtime
+            .execute_subscription_impl(self.handle, Box::new(callback))?;
+        Ok(self.handle)
+    }
+
+    /// Execute the pending subscription with `callback` and return its
+    /// stable [`SubscriptionHandle`] (WASM variant — no `Send` bound).
+    #[cfg(target_arch = "wasm32")]
+    pub fn execute<F>(self, callback: F) -> Result<SubscriptionHandle, RuntimeError>
+    where
+        F: Fn(SubscriptionDelta) + 'static,
+    {
+        self.runtime
+            .execute_subscription_impl(self.handle, Box::new(callback))?;
+        Ok(self.handle)
+    }
+}
+
 impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
     fn allocate_subscription_handle(&mut self) -> SubscriptionHandle {
         let handle = SubscriptionHandle(self.next_subscription_handle);
@@ -171,11 +212,39 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
     }
 
     // =========================================================================
-    // Two-phase subscribe: create + execute
+    // Typed-builder subscribe entry point — preferred over create + execute.
+    // =========================================================================
+
+    /// Begin a subscription that defers callback registration. Returns a
+    /// [`PendingSubscriptionRequest`] whose only legal next step is
+    /// `.execute(callback)`, giving a compile-time guarantee against the
+    /// flat create/execute pair being misused. Prefer this over the
+    /// [`Self::create_subscription`] / [`Self::execute_subscription`] pair
+    /// from new Rust call sites.
+    pub fn subscribe_pending(
+        &mut self,
+        query: Query,
+        session: Option<Session>,
+        durability: ReadDurabilityOptions,
+        propagation: QueryPropagation,
+    ) -> PendingSubscriptionRequest<'_, S, Sch> {
+        let handle = self.create_subscription(query, session, durability, propagation);
+        PendingSubscriptionRequest {
+            runtime: self,
+            handle,
+        }
+    }
+
+    // =========================================================================
+    // Two-phase subscribe: create + execute (kept for FFI bindings)
     // =========================================================================
 
     /// Phase 1: allocate a handle and store query params. No compilation, no
     /// sync, no tick — just bookkeeping.
+    ///
+    /// Rust callers should prefer [`Self::subscribe`] which returns a typed
+    /// builder; this flat method exists for the napi/wasm/UniFFI wrappers
+    /// that need separate JS-/UniFFI-side entry points.
     pub fn create_subscription(
         &mut self,
         query: Query,

--- a/crates/jazz-tools/src/runtime_core/subscriptions.rs
+++ b/crates/jazz-tools/src/runtime_core/subscriptions.rs
@@ -218,9 +218,11 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
     /// Begin a subscription that defers callback registration. Returns a
     /// [`PendingSubscriptionRequest`] whose only legal next step is
     /// `.execute(callback)`, giving a compile-time guarantee against the
-    /// flat create/execute pair being misused. Prefer this over the
-    /// [`Self::create_subscription`] / [`Self::execute_subscription`] pair
-    /// from new Rust call sites.
+    /// flat create/execute pair being misused.
+    ///
+    /// Rust callers must use this; the flat `*_for_ffi` methods below are
+    /// reserved for binding crates that need separate JS-/UniFFI-side
+    /// entry points and are explicitly opted into the misuse risk.
     pub fn subscribe_pending(
         &mut self,
         query: Query,
@@ -228,7 +230,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         durability: ReadDurabilityOptions,
         propagation: QueryPropagation,
     ) -> PendingSubscriptionRequest<'_, S, Sch> {
-        let handle = self.create_subscription(query, session, durability, propagation);
+        let handle = self.create_subscription_for_ffi(query, session, durability, propagation);
         PendingSubscriptionRequest {
             runtime: self,
             handle,
@@ -236,16 +238,19 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
     }
 
     // =========================================================================
-    // Two-phase subscribe: create + execute (kept for FFI bindings)
+    // FFI-only flat pair — napi/wasm/UniFFI wrappers must allocate a handle
+    // synchronously, hand it back to JS, and re-enter Rust later with a
+    // callback. They cannot hold a `PendingSubscriptionRequest` (which borrows
+    // `&mut RuntimeCore`) across two FFI calls, so they call these.
+    //
+    // **Do not call these from Rust.** Use `subscribe_pending(...).execute(cb)`
+    // instead — the typed builder makes pair misuse a compile error.
     // =========================================================================
 
-    /// Phase 1: allocate a handle and store query params. No compilation, no
-    /// sync, no tick — just bookkeeping.
-    ///
-    /// Rust callers should prefer [`Self::subscribe`] which returns a typed
-    /// builder; this flat method exists for the napi/wasm/UniFFI wrappers
-    /// that need separate JS-/UniFFI-side entry points.
-    pub fn create_subscription(
+    /// FFI-only Phase 1: allocate a handle and store query params. No
+    /// compilation, no sync, no tick — just bookkeeping.
+    #[doc(hidden)]
+    pub fn create_subscription_for_ffi(
         &mut self,
         query: Query,
         session: Option<Session>,
@@ -270,13 +275,12 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         handle
     }
 
-    /// Phase 2: compile graph, register with QueryManager, sync to servers,
-    /// attach callback, and run `immediate_tick` to deliver the first delta.
-    ///
-    /// No-ops silently if the handle was already unsubscribed between create
-    /// and execute.
+    /// FFI-only Phase 2: compile graph, register with QueryManager, sync to
+    /// servers, attach callback, run `immediate_tick`. No-ops if the handle
+    /// was unsubscribed between create and execute.
+    #[doc(hidden)]
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn execute_subscription<F>(
+    pub fn execute_subscription_for_ffi<F>(
         &mut self,
         handle: SubscriptionHandle,
         callback: F,
@@ -287,9 +291,10 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         self.execute_subscription_impl(handle, Box::new(callback))
     }
 
-    /// Phase 2 (WASM version — no Send required).
+    /// FFI-only Phase 2 (WASM variant — no `Send` bound).
+    #[doc(hidden)]
     #[cfg(target_arch = "wasm32")]
-    pub fn execute_subscription<F>(
+    pub fn execute_subscription_for_ffi<F>(
         &mut self,
         handle: SubscriptionHandle,
         callback: F,

--- a/crates/jazz-wasm/src/runtime.rs
+++ b/crates/jazz-wasm/src/runtime.rs
@@ -1582,10 +1582,12 @@ impl WasmRuntime {
         let (query, session, durability, propagation) =
             parse_subscription_inputs(query_json, session_json, settled_tier, options_json)?;
 
-        let handle =
-            self.core
-                .borrow_mut()
-                .create_subscription(query, session, durability, propagation);
+        let handle = self.core.borrow_mut().create_subscription_for_ffi(
+            query,
+            session,
+            durability,
+            propagation,
+        );
 
         tracing::debug!(handle = handle.0, "subscription created (pending)");
         Ok(handle.0 as f64)
@@ -1609,7 +1611,7 @@ impl WasmRuntime {
 
         self.core
             .borrow_mut()
-            .execute_subscription(sub_handle, callback)
+            .execute_subscription_for_ffi(sub_handle, callback)
             .map_err(|e| JsError::new(&format!("Execute subscription failed: {:?}", e)))?;
 
         Ok(())


### PR DESCRIPTION
## Summary

Phase 5 of [crate structure cleanup](specs/todo/c_later/crate_structure_cleanup.md), partial. Adds `RuntimeCore::subscribe_pending(query, session, durability, propagation)` returning a `PendingSubscriptionRequest<'a, S, Sch>` whose only legal next step is `.execute(callback)`.

```rust
let handle = runtime
    .subscribe_pending(query, session, durability, propagation)
    .execute(callback)?;
```

Forgetting to call `execute` produces a `must_use` warning at compile time; calling it twice is impossible because `execute` consumes the builder.

The flat `create_subscription` / `execute_subscription` pair on `RuntimeCore` is **preserved** for the napi/wasm/rn FFI bindings — those wrappers maintain their own JS- and UniFFI-side flat entry points and need separate "create" / "execute" calls. Per the spec's *FFI-internal-forwarding* shape, the no-pair-misuse guarantee applies inside jazz-tools (Rust callers should prefer `subscribe_pending`), while the FFI surface keeps its current shape until each binding's API is updated independently.

**Naming:** the existing `RuntimeCore::subscribe(query, callback, session)` remains the eager one-shot helper. The deferred-callback typed builder takes the `subscribe_pending` name to avoid shadowing.

### Deferred from this PR

The spec's stronger acceptance ("no `pub fn create_subscription` / `pub fn execute_subscription` remain on `RuntimeCore`") would require coordinated FFI updates across napi (`lib.rs:941, 983`), wasm (`runtime.rs:1588, 1612`), and rn (`rust/src/lib.rs:713, 755`, plus regenerated UniFFI C++ shim). Deferred to a follow-up so each binding can migrate independently.

## Test plan

- [x] `cargo build --all-features -p jazz-tools`
- [x] `cargo build -p jazz-napi -p jazz-wasm -p jazz-rn` — existing FFI flat-pair callers compile unchanged
- [x] `cargo test --all-features -p jazz-tools` — 1302 lib tests + integration tests all green