### PR TITLE
Inline TS sources in jazz-tools published sourcemaps

### DIFF
--- a/.changeset/inline-jazz-tools-sources.md
+++ b/.changeset/inline-jazz-tools-sources.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Embed TypeScript sources into published `.js.map` files via `inlineSources`. Resolves "Sourcemap points to missing source files" warnings in consuming projects, since the `src/` tree is not shipped in the npm tarball.

--- a/packages/jazz-tools/tsconfig.json
+++ b/packages/jazz-tools/tsconfig.json
@@ -6,6 +6,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
+    "inlineSources": true,
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,

--- a/packages/jazz-tools/tsconfig.tests.json
+++ b/packages/jazz-tools/tsconfig.tests.json
@@ -8,6 +8,7 @@
     "noEmit": true,
     "rootDir": ".",
     "sourceMap": false,
+    "inlineSources": false,
     "paths": {
       "jazz-tools": ["./src/index.ts"],
       "jazz-tools/*": ["./src/*"]


### PR DESCRIPTION
## Summary

- `packages/jazz-tools/tsconfig.json` had `sourceMap: true` but no `inlineSources`, so emitted `.js.map` files referenced `../../src/...` paths that aren't shipped in the npm tarball (`files` only includes `bin/`, `dist/`, `README.md`).
- Consumers (e.g. Vite users) saw `Sourcemap for ".../jazz-tools/dist/runtime/*.js" points to missing source files` warnings for every runtime module.
- Enabling `inlineSources` embeds the TS source content directly into the emitted maps, so source-level debugging works without us needing to ship the `src/` tree.

## Test plan

- [ ] Verified `pnpm build:runtime` succeeds locally
- [ ] Verified emitted `dist/runtime/*.js.map` files now contain a populated `sourcesContent` array
- [ ] Install the alpha into a downstream app (e.g. `personal/tasks`) and confirm the sourcemap warnings no longer appear