### PR TITLE
refactor(jazz-tools): Phase 3 (opfs_btree) — split cfg-gated constructors into native/wasm submodules

### DIFF
--- a/crates/jazz-tools/src/storage/opfs_btree/mod.rs
+++ b/crates/jazz-tools/src/storage/opfs_btree/mod.rs
@@ -12,14 +12,17 @@
 //! ```
 
 use std::cell::RefCell;
-#[cfg(not(target_arch = "wasm32"))]
-use std::path::Path;
 
 #[cfg(target_arch = "wasm32")]
 use opfs_btree::OpfsFile;
 #[cfg(not(target_arch = "wasm32"))]
 use opfs_btree::StdFile;
 use opfs_btree::{BTreeError, BTreeOptions, MemoryFile, OpfsBTree, SyncFile};
+
+#[cfg(not(target_arch = "wasm32"))]
+mod native;
+#[cfg(target_arch = "wasm32")]
+mod wasm;
 
 use crate::object::ObjectId;
 use crate::row_histories::{HistoryScan, RowState, StoredRowBatch};
@@ -39,7 +42,7 @@ use super::{
 const MIN_CACHE_SIZE_BYTES: usize = 4 * 1024 * 1024;
 
 #[derive(Clone, Debug)]
-enum AnyFile {
+pub(super) enum AnyFile {
     Memory(MemoryFile),
     #[cfg(not(target_arch = "wasm32"))]
     Std(StdFile),
@@ -136,33 +139,14 @@ impl OpfsBTreeStorage {
         }
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn open(path: impl AsRef<Path>, cache_size_bytes: usize) -> Result<Self, StorageError> {
-        let file = StdFile::open(path).map_err(map_storage_err)?;
-        Self::open_with_file(AnyFile::Std(file), cache_size_bytes)
-    }
-
     pub fn memory(cache_size_bytes: usize) -> Result<Self, StorageError> {
         Self::open_with_file(AnyFile::Memory(MemoryFile::new()), cache_size_bytes)
     }
 
-    #[cfg(target_arch = "wasm32")]
-    pub fn with_opfs(file: OpfsFile, cache_size_bytes: usize) -> Result<Self, StorageError> {
-        Self::open_with_file(AnyFile::Opfs(file), cache_size_bytes)
-    }
-
-    #[cfg(target_arch = "wasm32")]
-    pub async fn open_opfs(namespace: &str, cache_size_bytes: usize) -> Result<Self, StorageError> {
-        let file = OpfsFile::open(namespace).await.map_err(map_storage_err)?;
-        Self::with_opfs(file, cache_size_bytes)
-    }
-
-    #[cfg(target_arch = "wasm32")]
-    pub async fn destroy_opfs(namespace: &str) -> Result<(), StorageError> {
-        OpfsFile::destroy(namespace).await.map_err(map_storage_err)
-    }
-
-    fn open_with_file(file: AnyFile, cache_size_bytes: usize) -> Result<Self, StorageError> {
+    pub(super) fn open_with_file(
+        file: AnyFile,
+        cache_size_bytes: usize,
+    ) -> Result<Self, StorageError> {
         let options = Self::options(cache_size_bytes);
         let mut tree = OpfsBTree::open(file, options).map_err(map_storage_err)?;
         Self::ensure_store_manifest(&mut tree)?;
@@ -462,7 +446,7 @@ impl Storage for OpfsBTreeStorage {
     }
 }
 
-fn map_storage_err(error: BTreeError) -> StorageError {
+pub(super) fn map_storage_err(error: BTreeError) -> StorageError {
     match error {
         BTreeError::SecurityError(msg) => StorageError::SecurityError(msg),
         other => StorageError::IoError(format!("opfs-btree: {}", other)),

--- a/crates/jazz-tools/src/storage/opfs_btree/native.rs
+++ b/crates/jazz-tools/src/storage/opfs_btree/native.rs
@@ -1,0 +1,18 @@
+//! Native-only entry points (anything that touches `std::fs::Path` or
+//! `opfs_btree::StdFile`). The whole module is cfg-gated to non-wasm32 in
+//! `mod.rs`, so the body is unconditional here.
+
+use std::path::Path;
+
+use opfs_btree::StdFile;
+
+use crate::storage::StorageError;
+
+use super::{AnyFile, OpfsBTreeStorage, map_storage_err};
+
+impl OpfsBTreeStorage {
+    pub fn open(path: impl AsRef<Path>, cache_size_bytes: usize) -> Result<Self, StorageError> {
+        let file = StdFile::open(path).map_err(map_storage_err)?;
+        Self::open_with_file(AnyFile::Std(file), cache_size_bytes)
+    }
+}

--- a/crates/jazz-tools/src/storage/opfs_btree/wasm.rs
+++ b/crates/jazz-tools/src/storage/opfs_btree/wasm.rs
@@ -1,0 +1,23 @@
+//! WASM-only entry points (`OpfsFile`-based constructors). The whole module
+//! is cfg-gated to wasm32 in `mod.rs`, so the body is unconditional here.
+
+use opfs_btree::OpfsFile;
+
+use crate::storage::StorageError;
+
+use super::{AnyFile, OpfsBTreeStorage, map_storage_err};
+
+impl OpfsBTreeStorage {
+    pub fn with_opfs(file: OpfsFile, cache_size_bytes: usize) -> Result<Self, StorageError> {
+        Self::open_with_file(AnyFile::Opfs(file), cache_size_bytes)
+    }
+
+    pub async fn open_opfs(namespace: &str, cache_size_bytes: usize) -> Result<Self, StorageError> {
+        let file = OpfsFile::open(namespace).await.map_err(map_storage_err)?;
+        Self::with_opfs(file, cache_size_bytes)
+    }
+
+    pub async fn destroy_opfs(namespace: &str) -> Result<(), StorageError> {
+        OpfsFile::destroy(namespace).await.map_err(map_storage_err)
+    }
+}


### PR DESCRIPTION
## Summary

Phase 3 (opfs_btree half) of [crate structure cleanup](specs/todo/c_later/crate_structure_cleanup.md). `storage/opfs_btree.rs` is renamed to `storage/opfs_btree/mod.rs` and the cfg-gated entry points move to dedicated, module-level cfg-gated submodules.

| File | cfg | Contents |
| --- | --- | --- |
| `storage/opfs_btree/mod.rs` | none | shared body: `AnyFile` dispatch enum, `SyncFile` impl on `AnyFile`, `OpfsBTreeStorage` struct, the `Storage` trait impl, helpers, tests |
| `storage/opfs_btree/native.rs` | `#[cfg(not(target_arch = "wasm32"))]` | `OpfsBTreeStorage::open` (taking `impl AsRef<Path>`) backed by `opfs_btree::StdFile` |
| `storage/opfs_btree/wasm.rs` | `#[cfg(target_arch = "wasm32")]` | `OpfsBTreeStorage::{with_opfs, open_opfs, destroy_opfs}` backed by `opfs_btree::OpfsFile` |

The shared `AnyFile` enum still has cfg-gated `Std` / `Opfs` variants and the `SyncFile` dispatch arms still match on those — that's the natural shape of a typed dispatch enum and would only churn if every native- or wasm-specific code path were duplicated. The substantive win is **removing the cfg-gated function bodies threaded through the shared file**: everything in `native.rs` is unconditionally native, everything in `wasm.rs` is unconditionally wasm.

Visibility surgery: `AnyFile` becomes `pub(super)` and `open_with_file` + `map_storage_err` become `pub(super) fn` so the submodules can delegate to the shared core.

Independent of every other in-flight PR. Builds on the storage trait/impl split that landed earlier in [#711](https://github.com/garden-co/jazz2/pull/711).

## Test plan

- [x] `cargo build --all-features -p jazz-tools`
- [x] `cargo build -p jazz-napi -p jazz-rn`
- [x] `cargo check --target wasm32-unknown-unknown -p jazz-wasm` — exercises the `wasm.rs` branch
- [x] `cargo fmt -- --check`
- [x] `cargo test --all-features -p jazz-tools` — 1302 lib tests + integration tests all green