### PR TITLE
Add explicit rollback cancelation for transactional batches

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -40,6 +40,10 @@
 - [**text-encoded-storage-enums**](todo/issues/text-encoded-storage-enums.md) — Flat row storage currently encodes enum-like fields as text, which is larger than necessary and adds avoidable decode overhead on hot storage paths.
 - [**ws-route-clones-every-inbound-frame**](todo/issues/ws-route-clones-every-inbound-frame.md) — `crates/jazz-tools/src/routes.rs:1345` does `let inner = inner.to_vec();` before handing the payload to `process_ws_client_frame(&inner)`. The borrow from `frame_decode(&data)` would survive the `.await` because `data` owns the bytes, so the clone is avoidable — pass `&[u8]` through directly.
 
+### Unknown
+
+- [**stagingpending-retention-crashed-disconnected-clients**](todo/issues/stagingpending-retention-crashed-disconnected-clients.md) — Server-side `StagingPending` transactional rows may need an explicit retention and cleanup policy when the originating client crashes or stays disconnected before commit or rollback.
+
 ## Ideas
 
 ### Mvp

--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -27,6 +27,7 @@ export declare class NapiRuntime {
   drainRejectedBatchIds(): string[]
   acknowledgeRejectedBatch(batchId: string): boolean
   sealBatch(batchId: string): void
+  rollbackBatch(batchId: string): void
   query(queryJson: string, sessionJson?: string | undefined | null, tier?: string | undefined | null, optionsJson?: string | undefined | null): Promise<any>
   subscribe(queryJson: string, onUpdate: (...args: any[]) => any, sessionJson?: string | undefined | null, tier?: string | undefined | null, optionsJson?: string | undefined | null): number
   unsubscribe(handle: number): void

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -802,6 +802,17 @@ impl NapiRuntime {
             .map_err(|e| napi::Error::from_reason(format!("Seal batch failed: {e}")))
     }
 
+    #[napi(js_name = "rollbackBatch")]
+    pub fn rollback_batch(&self, batch_id: String) -> napi::Result<()> {
+        let batch_id = parse_batch_id_input(&batch_id).map_err(napi::Error::from_reason)?;
+        let mut core = self
+            .core
+            .lock()
+            .map_err(|_| napi::Error::from_reason("lock"))?;
+        core.rollback_batch(batch_id)
+            .map_err(|e| napi::Error::from_reason(format!("Rollback batch failed: {e}")))
+    }
+
     // =========================================================================
     // Queries
     // =========================================================================

--- a/crates/jazz-rn/cpp/jazz_rn.cpp
+++ b/crates/jazz-rn/cpp/jazz_rn.cpp
@@ -189,6 +189,9 @@ RustBuffer uniffi_jazz_rn_fn_method_rnruntime_query(
     RustBuffer tier, RustCallStatus *uniffi_out_err);
 void uniffi_jazz_rn_fn_method_rnruntime_remove_server(
     /*handle*/ uint64_t ptr, RustCallStatus *uniffi_out_err);
+void uniffi_jazz_rn_fn_method_rnruntime_rollback_batch(
+    /*handle*/ uint64_t ptr, RustBuffer batch_id,
+    RustCallStatus *uniffi_out_err);
 void uniffi_jazz_rn_fn_method_rnruntime_seal_batch(
     /*handle*/ uint64_t ptr, RustBuffer batch_id,
     RustCallStatus *uniffi_out_err);
@@ -365,6 +368,7 @@ uint16_t
 uniffi_jazz_rn_checksum_method_rnruntime_on_sync_message_received_from_client();
 uint16_t uniffi_jazz_rn_checksum_method_rnruntime_query();
 uint16_t uniffi_jazz_rn_checksum_method_rnruntime_remove_server();
+uint16_t uniffi_jazz_rn_checksum_method_rnruntime_rollback_batch();
 uint16_t uniffi_jazz_rn_checksum_method_rnruntime_seal_batch();
 uint16_t uniffi_jazz_rn_checksum_method_rnruntime_set_client_role();
 uint16_t uniffi_jazz_rn_checksum_method_rnruntime_subscribe();
@@ -3228,6 +3232,17 @@ NativeJazzRn::NativeJazzRn(
             return this->cpp_uniffi_jazz_rn_fn_method_rnruntime_remove_server(
                 rt, thisVal, args, count);
           });
+  props["ubrn_uniffi_jazz_rn_fn_method_rnruntime_rollback_batch"] =
+      jsi::Function::createFromHostFunction(
+          rt,
+          jsi::PropNameID::forAscii(
+              rt, "ubrn_uniffi_jazz_rn_fn_method_rnruntime_rollback_batch"),
+          2,
+          [this](jsi::Runtime &rt, const jsi::Value &thisVal,
+                 const jsi::Value *args, size_t count) -> jsi::Value {
+            return this->cpp_uniffi_jazz_rn_fn_method_rnruntime_rollback_batch(
+                rt, thisVal, args, count);
+          });
   props["ubrn_uniffi_jazz_rn_fn_method_rnruntime_seal_batch"] =
       jsi::Function::createFromHostFunction(
           rt,
@@ -3694,6 +3709,19 @@ NativeJazzRn::NativeJazzRn(
                  const jsi::Value *args, size_t count) -> jsi::Value {
             return this
                 ->cpp_uniffi_jazz_rn_checksum_method_rnruntime_remove_server(
+                    rt, thisVal, args, count);
+          });
+  props["ubrn_uniffi_jazz_rn_checksum_method_rnruntime_rollback_batch"] =
+      jsi::Function::createFromHostFunction(
+          rt,
+          jsi::PropNameID::forAscii(
+              rt,
+              "ubrn_uniffi_jazz_rn_checksum_method_rnruntime_rollback_batch"),
+          0,
+          [this](jsi::Runtime &rt, const jsi::Value &thisVal,
+                 const jsi::Value *args, size_t count) -> jsi::Value {
+            return this
+                ->cpp_uniffi_jazz_rn_checksum_method_rnruntime_rollback_batch(
                     rt, thisVal, args, count);
           });
   props["ubrn_uniffi_jazz_rn_checksum_method_rnruntime_seal_batch"] =
@@ -4369,6 +4397,21 @@ jsi::Value NativeJazzRn::cpp_uniffi_jazz_rn_fn_method_rnruntime_remove_server(
 
   return jsi::Value::undefined();
 }
+jsi::Value NativeJazzRn::cpp_uniffi_jazz_rn_fn_method_rnruntime_rollback_batch(
+    jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
+    size_t count) {
+  RustCallStatus status =
+      uniffi::jazz_rn::Bridging<RustCallStatus>::rustSuccess(rt);
+  uniffi_jazz_rn_fn_method_rnruntime_rollback_batch(
+      uniffi_jsi::Bridging</*handle*/ uint64_t>::fromJs(rt, callInvoker,
+                                                        args[0]),
+      uniffi::jazz_rn::Bridging<RustBuffer>::fromJs(rt, callInvoker, args[1]),
+      &status);
+  uniffi::jazz_rn::Bridging<RustCallStatus>::copyIntoJs(rt, callInvoker, status,
+                                                        args[count - 1]);
+
+  return jsi::Value::undefined();
+}
 jsi::Value NativeJazzRn::cpp_uniffi_jazz_rn_fn_method_rnruntime_seal_batch(
     jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
     size_t count) {
@@ -4773,6 +4816,14 @@ NativeJazzRn::cpp_uniffi_jazz_rn_checksum_method_rnruntime_remove_server(
     jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
     size_t count) {
   auto value = uniffi_jazz_rn_checksum_method_rnruntime_remove_server();
+
+  return uniffi_jsi::Bridging<uint16_t>::toJs(rt, callInvoker, value);
+}
+jsi::Value
+NativeJazzRn::cpp_uniffi_jazz_rn_checksum_method_rnruntime_rollback_batch(
+    jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
+    size_t count) {
+  auto value = uniffi_jazz_rn_checksum_method_rnruntime_rollback_batch();
 
   return uniffi_jsi::Bridging<uint16_t>::toJs(rt, callInvoker, value);
 }

--- a/crates/jazz-rn/cpp/jazz_rn.hpp
+++ b/crates/jazz-rn/cpp/jazz_rn.hpp
@@ -112,6 +112,9 @@ protected:
   jsi::Value cpp_uniffi_jazz_rn_fn_method_rnruntime_remove_server(
       jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
       size_t count);
+  jsi::Value cpp_uniffi_jazz_rn_fn_method_rnruntime_rollback_batch(
+      jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
+      size_t count);
   jsi::Value cpp_uniffi_jazz_rn_fn_method_rnruntime_seal_batch(
       jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
       size_t count);
@@ -238,6 +241,9 @@ protected:
       jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
       size_t count);
   jsi::Value cpp_uniffi_jazz_rn_checksum_method_rnruntime_remove_server(
+      jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
+      size_t count);
+  jsi::Value cpp_uniffi_jazz_rn_checksum_method_rnruntime_rollback_batch(
       jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
       size_t count);
   jsi::Value cpp_uniffi_jazz_rn_checksum_method_rnruntime_seal_batch(

--- a/crates/jazz-rn/rust/src/lib.rs
+++ b/crates/jazz-rn/rust/src/lib.rs
@@ -989,6 +989,17 @@ impl RnRuntime {
         })
     }
 
+    pub fn rollback_batch(&self, batch_id: String) -> Result<(), JazzRnError> {
+        with_panic_boundary("rollback_batch", || {
+            let batch_id = parse_batch_id_input(&batch_id)
+                .map_err(|message| JazzRnError::InvalidUuid { message })?;
+            let mut core = self.core.lock().map_err(|_| JazzRnError::Internal {
+                message: "lock poisoned".into(),
+            })?;
+            core.rollback_batch(batch_id).map_err(runtime_err)
+        })
+    }
+
     /// Flush and close the underlying storage, releasing filesystem locks.
     pub fn close(&self) -> Result<(), JazzRnError> {
         with_panic_boundary("close", || {

--- a/crates/jazz-rn/src/generated/jazz_rn-ffi.ts
+++ b/crates/jazz-rn/src/generated/jazz_rn-ffi.ts
@@ -167,6 +167,11 @@ interface NativeModuleInterface {
     ptr: bigint,
     uniffi_out_err: UniffiRustCallStatus
   ): void;
+  ubrn_uniffi_jazz_rn_fn_method_rnruntime_rollback_batch(
+    ptr: bigint,
+    batchId: Uint8Array,
+    uniffi_out_err: UniffiRustCallStatus
+  ): void;
   ubrn_uniffi_jazz_rn_fn_method_rnruntime_seal_batch(
     ptr: bigint,
     batchId: Uint8Array,
@@ -257,6 +262,7 @@ interface NativeModuleInterface {
   ubrn_uniffi_jazz_rn_checksum_method_rnruntime_on_sync_message_received_from_client(): number;
   ubrn_uniffi_jazz_rn_checksum_method_rnruntime_query(): number;
   ubrn_uniffi_jazz_rn_checksum_method_rnruntime_remove_server(): number;
+  ubrn_uniffi_jazz_rn_checksum_method_rnruntime_rollback_batch(): number;
   ubrn_uniffi_jazz_rn_checksum_method_rnruntime_seal_batch(): number;
   ubrn_uniffi_jazz_rn_checksum_method_rnruntime_set_client_role(): number;
   ubrn_uniffi_jazz_rn_checksum_method_rnruntime_subscribe(): number;

--- a/crates/jazz-rn/src/generated/jazz_rn.ts
+++ b/crates/jazz-rn/src/generated/jazz_rn.ts
@@ -767,6 +767,7 @@ export interface RnRuntimeInterface {
     tier: string | undefined
   ) /*throws*/ : string;
   removeServer() /*throws*/ : void;
+  rollbackBatch(batchId: string) /*throws*/ : void;
   sealBatch(batchId: string) /*throws*/ : void;
   setClientRole(clientId: string, role: string) /*throws*/ : void;
   subscribe(
@@ -1294,6 +1295,22 @@ export class RnRuntime
     );
   }
 
+  rollbackBatch(batchId: string): void /*throws*/ {
+    uniffiCaller.rustCallWithError(
+      /*liftError:*/ FfiConverterTypeJazzRnError.lift.bind(
+        FfiConverterTypeJazzRnError
+      ),
+      /*caller:*/ (callStatus) => {
+        nativeModule().ubrn_uniffi_jazz_rn_fn_method_rnruntime_rollback_batch(
+          uniffiTypeRnRuntimeObjectFactory.clonePointer(this),
+          FfiConverterString.lower(batchId),
+          callStatus
+        );
+      },
+      /*liftString:*/ FfiConverterString.lift
+    );
+  }
+
   sealBatch(batchId: string): void /*throws*/ {
     uniffiCaller.rustCallWithError(
       /*liftError:*/ FfiConverterTypeJazzRnError.lift.bind(
@@ -1764,6 +1781,14 @@ function uniffiEnsureInitialized() {
   ) {
     throw new UniffiInternalError.ApiChecksumMismatch(
       'uniffi_jazz_rn_checksum_method_rnruntime_remove_server'
+    );
+  }
+  if (
+    nativeModule().ubrn_uniffi_jazz_rn_checksum_method_rnruntime_rollback_batch() !==
+    56959
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      'uniffi_jazz_rn_checksum_method_rnruntime_rollback_batch'
     );
   }
   if (

--- a/crates/jazz-tools/src/query_manager/indices.rs
+++ b/crates/jazz-tools/src/query_manager/indices.rs
@@ -487,6 +487,24 @@ impl QueryManager {
             self.mark_subscriptions_dirty_local(table);
             self.mark_local_row_deleted_in_subscriptions(table, row_id);
         } else {
+            if let Ok(Some(visible_row)) = storage.load_visible_region_row(table, branch, row_id)
+                && let Err(error) = Self::update_indices_for_insert_on_branch(
+                    storage,
+                    table,
+                    branch,
+                    row_id,
+                    &visible_row.data,
+                    &table_schema.columns,
+                )
+            {
+                tracing::warn!(
+                    table,
+                    branch,
+                    object_id = %row_id,
+                    %error,
+                    "failed to restore visible row indices after retracting local pending transaction row"
+                );
+            }
             self.clear_local_pending_row_overlay(table, row_id);
         }
     }

--- a/crates/jazz-tools/src/runtime_core/tests.rs
+++ b/crates/jazz-tools/src/runtime_core/tests.rs
@@ -51,6 +51,8 @@ struct RowMutationCallCounts {
     row_mutation_calls: usize,
     separate_index_mutation_calls: usize,
     flush_wal_calls: usize,
+    batch_patch_calls: usize,
+    exact_schema_hash_patch_calls: usize,
 }
 
 struct RowMutationObservingStorage {
@@ -1057,6 +1059,7 @@ impl Storage for RowMutationObservingStorage {
         state: Option<crate::row_histories::RowState>,
         confirmed_tier: Option<DurabilityTier>,
     ) -> Result<(), StorageError> {
+        self.calls.lock().unwrap().batch_patch_calls += 1;
         self.inner
             .patch_row_region_rows_by_batch(table, batch_id, state, confirmed_tier)
     }
@@ -1084,6 +1087,7 @@ impl Storage for RowMutationObservingStorage {
         state: Option<crate::row_histories::RowState>,
         confirmed_tier: Option<DurabilityTier>,
     ) -> Result<bool, StorageError> {
+        self.calls.lock().unwrap().exact_schema_hash_patch_calls += 1;
         self.inner.patch_exact_row_batch_for_schema_hash(
             table,
             schema_hash,

--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/storage_flush.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/storage_flush.rs
@@ -54,6 +54,8 @@ fn rc_local_row_writes_batch_row_and_index_mutations() {
             row_mutation_calls: 3,
             separate_index_mutation_calls: 0,
             flush_wal_calls: 0,
+            batch_patch_calls: 0,
+            exact_schema_hash_patch_calls: 0,
         },
         "local row writes should persist row history, visible heads, and index changes in one storage mutation"
     );

--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/transactional.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/transactional.rs
@@ -552,6 +552,120 @@ fn rc_transactional_rollback_does_not_write_staged_insert_upstream() {
 }
 
 #[test]
+fn rc_transactional_rollback_cancels_staged_rows_already_sent_upstream() {
+    let mut s = create_3tier_rc();
+    let write_context = WriteContext {
+        session: None,
+        attribution: None,
+        updated_at: None,
+        batch_mode: Some(crate::batch_fate::BatchMode::Transactional),
+        batch_id: None,
+        target_branch_name: None,
+    };
+
+    let ((row_id, _), _) =
+        s.a.insert(
+            "users",
+            user_insert_values(ObjectId::new(), "Alice draft"),
+            Some(&write_context),
+        )
+        .expect("transactional insert should stage locally");
+    let history_rows =
+        s.a.storage()
+            .scan_history_row_batches("users", row_id)
+            .unwrap();
+    assert_eq!(history_rows.len(), 1);
+    let batch_id = history_rows[0].batch_id;
+
+    pump_a_to_b(&mut s);
+    let worker_rows =
+        s.b.storage()
+            .scan_history_row_batches("users", row_id)
+            .unwrap();
+    assert_eq!(worker_rows.len(), 1);
+    assert_eq!(
+        worker_rows[0].state,
+        crate::row_histories::RowState::StagingPending,
+        "worker should hold the transactional row as still-pending before rollback"
+    );
+
+    pump_b_to_c(&mut s);
+    let edge_rows =
+        s.c.storage()
+            .scan_history_row_batches("users", row_id)
+            .unwrap();
+    assert_eq!(edge_rows.len(), 1);
+    assert_eq!(
+        edge_rows[0].state,
+        crate::row_histories::RowState::StagingPending,
+        "edge should hold the transactional row as still-pending before rollback"
+    );
+
+    s.a.rollback_batch(batch_id)
+        .expect("rollback should discard the staged transaction locally");
+    s.a.batched_tick();
+    let rollback_outbox = s.a.sync_sender().take();
+    assert!(
+        rollback_outbox.iter().any(|entry| {
+            matches!(
+                entry,
+                OutboxEntry {
+                    destination: Destination::Server(server_id),
+                    payload: SyncPayload::CancelBatch { batch_id: cancelled },
+                } if *server_id == s.b_server_for_a && *cancelled == batch_id
+            )
+        }),
+        "rollback should explicitly cancel the pending batch upstream, got {rollback_outbox:?}"
+    );
+    for entry in rollback_outbox {
+        if entry.destination == Destination::Server(s.b_server_for_a) {
+            s.b.park_sync_message(InboxEntry {
+                source: Source::Client(s.a_client_of_b),
+                payload: entry.payload,
+            });
+        }
+    }
+    s.b.batched_tick();
+    s.b.immediate_tick();
+    pump_b_to_c(&mut s);
+
+    for (node_name, core) in [("worker", &s.b), ("edge", &s.c)] {
+        let rows = core
+            .storage()
+            .scan_history_row_batches("users", row_id)
+            .unwrap();
+        assert_eq!(
+            rows.len(),
+            1,
+            "{node_name} should retain only audit history"
+        );
+        assert_eq!(
+            rows[0].state,
+            crate::row_histories::RowState::Rejected,
+            "{node_name} should reject the still-pending row after CancelBatch"
+        );
+        assert_eq!(
+            core.storage()
+                .load_visible_region_row(
+                    "users",
+                    core.schema_manager().branch_name().as_str(),
+                    row_id
+                )
+                .unwrap(),
+            None,
+            "{node_name} should never publish the cancelled staged row"
+        );
+        assert_eq!(
+            core.storage()
+                .load_authoritative_batch_settlement(batch_id)
+                .unwrap(),
+            None,
+            "{node_name} should not create a rejected settlement for a client cancel"
+        );
+    }
+}
+
+#[test]
 fn rc_transactional_rollback_restores_visible_state_after_staged_update() {
     let mut core = create_runtime_with_schema(defaulted_todos_schema(), "tx-rollback-update");
     let ((row_id, _), _) = core

--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/transactional.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/transactional.rs
@@ -666,6 +666,89 @@ fn rc_transactional_rollback_cancels_staged_rows_already_sent_upstream() {
 }
 
 #[test]
+fn rc_cancel_batch_from_unrelated_client_does_not_cancel_or_relay_pending_batch() {
+    let mut s = create_3tier_rc();
+    let bob_client_of_b = ClientId::new();
+    s.b.add_client(bob_client_of_b, None);
+    s.b.schema_manager_mut()
+        .query_manager_mut()
+        .sync_manager_mut()
+        .set_client_role(bob_client_of_b, ClientRole::Peer);
+    s.b.batched_tick();
+    s.b.sync_sender().take();
+
+    let write_context = WriteContext {
+        session: None,
+        attribution: None,
+        updated_at: None,
+        batch_mode: Some(crate::batch_fate::BatchMode::Transactional),
+        batch_id: None,
+        target_branch_name: None,
+    };
+
+    let ((row_id, _), _) =
+        s.a.insert(
+            "users",
+            user_insert_values(ObjectId::new(), "Alice draft"),
+            Some(&write_context),
+        )
+        .expect("transactional insert should stage locally");
+    let history_rows =
+        s.a.storage()
+            .scan_history_row_batches("users", row_id)
+            .unwrap();
+    assert_eq!(history_rows.len(), 1);
+    let batch_id = history_rows[0].batch_id;
+
+    pump_a_to_b(&mut s);
+    pump_b_to_c(&mut s);
+
+    s.b.park_sync_message(InboxEntry {
+        source: Source::Client(bob_client_of_b),
+        payload: SyncPayload::CancelBatch { batch_id },
+    });
+    s.b.batched_tick();
+    s.b.immediate_tick();
+    s.b.batched_tick();
+    let bob_cancel_outbox = s.b.sync_sender().take();
+
+    assert!(
+        bob_cancel_outbox.iter().all(|entry| {
+            !matches!(
+                entry,
+                OutboxEntry {
+                    destination: Destination::Server(server_id),
+                    payload: SyncPayload::CancelBatch {
+                        batch_id: cancelled
+                    },
+                } if *server_id == s.c_server_for_b && *cancelled == batch_id
+            )
+        }),
+        "worker should not relay Bob's spoofed cancel upstream, got {bob_cancel_outbox:?}"
+    );
+
+    for (node_name, core) in [("worker", &s.b), ("edge", &s.c)] {
+        let rows = core
+            .storage()
+            .scan_history_row_batches("users", row_id)
+            .unwrap();
+        assert_eq!(rows.len(), 1, "{node_name} should retain Alice's row");
+        assert_eq!(
+            rows[0].state,
+            crate::row_histories::RowState::StagingPending,
+            "{node_name} should keep Alice's row pending after Bob's spoofed cancel"
+        );
+        assert_eq!(
+            core.storage()
+                .load_authoritative_batch_settlement(batch_id)
+                .unwrap(),
+            None,
+            "{node_name} should not create a settlement for Bob's spoofed cancel"
+        );
+    }
+}
+
+#[test]
 fn rc_transactional_rollback_restores_visible_state_after_staged_update() {
     let mut core = create_runtime_with_schema(defaulted_todos_schema(), "tx-rollback-update");
     let ((row_id, _), _) = core

--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/transactional.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/transactional.rs
@@ -463,6 +463,58 @@ fn rc_transactional_rollback_discards_staged_insert_without_rejected_settlement(
 }
 
 #[test]
+fn rc_transactional_rollback_patches_exact_staged_members() {
+    let calls = Arc::new(Mutex::new(RowMutationCallCounts::default()));
+    let storage = RowMutationObservingStorage::new(calls.clone());
+    let app_id = AppId::from_name("tx-rollback-exact-members");
+    let schema_manager =
+        SchemaManager::new(SyncManager::new(), test_schema(), app_id, "dev", "main").unwrap();
+    let mut core = new_test_core(schema_manager, storage, NoopScheduler);
+    core.immediate_tick();
+
+    let batch_id = BatchId::new();
+    let write_context = WriteContext {
+        session: None,
+        attribution: None,
+        updated_at: None,
+        batch_mode: Some(crate::batch_fate::BatchMode::Transactional),
+        batch_id: Some(batch_id),
+        target_branch_name: None,
+    };
+
+    let ((row_id, _row_values), _) = core
+        .insert(
+            "users",
+            user_insert_values(ObjectId::new(), "Alice draft"),
+            Some(&write_context),
+        )
+        .expect("transactional insert should stage locally");
+
+    core.rollback_batch(batch_id)
+        .expect("rollback should discard the staged transaction");
+
+    let history_rows = core
+        .storage()
+        .scan_history_row_batches("users", row_id)
+        .unwrap();
+    assert_eq!(
+        history_rows[0].state,
+        crate::row_histories::RowState::Rejected,
+        "rollback should reject the staged row"
+    );
+
+    let calls = *calls.lock().unwrap();
+    assert_eq!(
+        calls.batch_patch_calls, 0,
+        "rollback should use exact local batch members instead of table-wide batch patching"
+    );
+    assert_eq!(
+        calls.exact_schema_hash_patch_calls, 1,
+        "rollback should patch the exact staged member"
+    );
+}
+
+#[test]
 fn rc_transactional_rollback_does_not_write_staged_insert_upstream() {
     let mut s = create_3tier_rc();
     let write_context = WriteContext {

--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/transactional.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/transactional.rs
@@ -400,6 +400,244 @@ fn rc_transactional_same_row_same_batch_collapses_to_one_live_staged_member() {
 }
 
 #[test]
+fn rc_transactional_rollback_discards_staged_insert_without_rejected_settlement() {
+    let mut core = create_test_runtime();
+    let batch_id = BatchId::new();
+    let write_context = WriteContext {
+        session: None,
+        attribution: None,
+        updated_at: None,
+        batch_mode: Some(crate::batch_fate::BatchMode::Transactional),
+        batch_id: Some(batch_id),
+        target_branch_name: None,
+    };
+
+    let ((row_id, _), _) = core
+        .insert(
+            "users",
+            user_insert_values(ObjectId::new(), "Alice draft"),
+            Some(&write_context),
+        )
+        .expect("transactional insert should stage locally");
+
+    core.rollback_batch(batch_id)
+        .expect("rollback should discard an open transaction");
+
+    assert_eq!(
+        core.storage().load_local_batch_record(batch_id).unwrap(),
+        None,
+        "rollback should remove the local batch record"
+    );
+    assert_eq!(
+        core.storage()
+            .load_visible_region_row(
+                "users",
+                core.schema_manager().branch_name().as_str(),
+                row_id
+            )
+            .unwrap(),
+        None,
+        "rolled-back staged inserts should never become visible"
+    );
+
+    let history_rows = core
+        .storage()
+        .scan_history_row_batches("users", row_id)
+        .unwrap();
+    assert_eq!(history_rows.len(), 1);
+    assert_eq!(
+        history_rows[0].state,
+        crate::row_histories::RowState::Rejected
+    );
+    assert!(
+        core.drain_rejected_batch_ids().is_empty(),
+        "client rollback should not surface as an authority rejection"
+    );
+    assert!(
+        core.sync_sender()
+            .take()
+            .into_iter()
+            .all(|entry| !matches!(entry.payload, SyncPayload::SealBatch { .. })),
+        "rollback should not seal or send the discarded transaction upstream"
+    );
+}
+
+#[test]
+fn rc_transactional_rollback_does_not_write_staged_insert_upstream() {
+    let mut s = create_3tier_rc();
+    let write_context = WriteContext {
+        session: None,
+        attribution: None,
+        updated_at: None,
+        batch_mode: Some(crate::batch_fate::BatchMode::Transactional),
+        batch_id: None,
+        target_branch_name: None,
+    };
+
+    let ((row_id, _), _) =
+        s.a.insert(
+            "users",
+            user_insert_values(ObjectId::new(), "Alice draft"),
+            Some(&write_context),
+        )
+        .expect("transactional insert should stage locally");
+    let history_rows =
+        s.a.storage()
+            .scan_history_row_batches("users", row_id)
+            .unwrap();
+    assert_eq!(history_rows.len(), 1);
+    let batch_id = history_rows[0].batch_id;
+
+    s.a.rollback_batch(batch_id)
+        .expect("rollback should discard the staged transaction");
+
+    s.a.batched_tick();
+    let rollback_outbox = s.a.sync_sender().take();
+    assert!(
+        rollback_outbox.iter().all(|entry| {
+            !matches!(
+                entry,
+                OutboxEntry {
+                    destination: Destination::Server(server_id),
+                    payload: SyncPayload::RowBatchCreated { row, .. }
+                        | SyncPayload::RowBatchNeeded { row, .. },
+                } if *server_id == s.b_server_for_a
+                    && row.row_id == row_id
+                    && row.batch_id == batch_id
+            )
+        }),
+        "rollback should not send the discarded row upstream, got {rollback_outbox:?}"
+    );
+    assert!(
+        rollback_outbox.iter().all(|entry| {
+            !matches!(
+                entry,
+                OutboxEntry {
+                    destination: Destination::Server(server_id),
+                    payload: SyncPayload::SealBatch { submission },
+                } if *server_id == s.b_server_for_a && submission.batch_id == batch_id
+            )
+        }),
+        "rollback should not seal the discarded transaction upstream, got {rollback_outbox:?}"
+    );
+
+    pump_a_to_b(&mut s);
+
+    assert!(
+        s.b.storage()
+            .scan_history_row_batches("users", row_id)
+            .unwrap()
+            .is_empty(),
+        "rolled-back transactional history should never be written to the worker"
+    );
+    assert_eq!(
+        s.b.storage()
+            .load_visible_region_row("users", s.b.schema_manager().branch_name().as_str(), row_id)
+            .unwrap(),
+        None,
+        "rolled-back staged inserts should not be visible to the worker"
+    );
+
+    s.a.remove_server(s.b_server_for_a);
+    s.a.add_server(s.b_server_for_a);
+    pump_a_to_b(&mut s);
+
+    assert!(
+        s.b.storage()
+            .scan_history_row_batches("users", row_id)
+            .unwrap()
+            .is_empty(),
+        "full sync after rollback should not replay rejected local history"
+    );
+}
+
+#[test]
+fn rc_transactional_rollback_restores_visible_state_after_staged_update() {
+    let mut core = create_runtime_with_schema(defaulted_todos_schema(), "tx-rollback-update");
+    let ((row_id, _), _) = core
+        .insert(
+            "todos",
+            HashMap::from([("title".to_string(), Value::Text("Keep me".to_string()))]),
+            None,
+        )
+        .expect("seed visible todo");
+    let batch_id = BatchId::new();
+    let write_context = WriteContext {
+        session: None,
+        attribution: None,
+        updated_at: None,
+        batch_mode: Some(crate::batch_fate::BatchMode::Transactional),
+        batch_id: Some(batch_id),
+        target_branch_name: None,
+    };
+
+    core.update(
+        row_id,
+        vec![("title".to_string(), Value::Text("Discard me".to_string()))],
+        Some(&write_context),
+    )
+    .expect("transactional update should stage locally");
+
+    core.rollback_batch(batch_id)
+        .expect("rollback should discard the staged update");
+
+    assert_eq!(
+        execute_query(&mut core, Query::new("todos")),
+        vec![(
+            row_id,
+            vec![Value::Text("Keep me".to_string()), Value::Boolean(false),],
+        )]
+    );
+    assert!(
+        core.storage()
+            .scan_history_row_batches("todos", row_id)
+            .unwrap()
+            .into_iter()
+            .any(|row| row.batch_id == batch_id
+                && matches!(row.state, crate::row_histories::RowState::Rejected)),
+        "rolled-back staged updates should be retained only as rejected history"
+    );
+}
+
+#[test]
+fn rc_transactional_rollback_rejects_sealed_batch_and_preserves_record() {
+    let mut core = create_test_runtime();
+    let batch_id = BatchId::new();
+    let write_context = WriteContext {
+        session: None,
+        attribution: None,
+        updated_at: None,
+        batch_mode: Some(crate::batch_fate::BatchMode::Transactional),
+        batch_id: Some(batch_id),
+        target_branch_name: None,
+    };
+
+    core.insert(
+        "users",
+        user_insert_values(ObjectId::new(), "Alice"),
+        Some(&write_context),
+    )
+    .expect("transactional insert should stage locally");
+    core.seal_batch(batch_id)
+        .expect("commit should seal the transaction");
+    let record_before = core
+        .storage()
+        .load_local_batch_record(batch_id)
+        .unwrap()
+        .expect("sealed batch record should be retained");
+
+    let error = core
+        .rollback_batch(batch_id)
+        .expect_err("sealed transactions should not be rolled back");
+
+    assert!(format!("{error:?}").contains("sealed"));
+    assert_eq!(
+        core.storage().load_local_batch_record(batch_id).unwrap(),
+        Some(record_before)
+    );
+}
+
+#[test]
 fn rc_transactional_batch_rejects_writes_after_local_seal() {
     let mut s = create_3tier_rc();
     let open_write_context = WriteContext {

--- a/crates/jazz-tools/src/runtime_core/ticks.rs
+++ b/crates/jazz-tools/src/runtime_core/ticks.rs
@@ -146,6 +146,10 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             .query_manager_mut()
             .sync_manager_mut()
             .discard_pending_batch_outbox(batch_id);
+        self.schema_manager
+            .query_manager_mut()
+            .sync_manager_mut()
+            .cancel_batch_to_servers(batch_id);
         self.storage
             .delete_local_batch_record(batch_id)
             .map_err(|err| RuntimeError::WriteError(format!("delete local batch record: {err}")))?;

--- a/crates/jazz-tools/src/runtime_core/ticks.rs
+++ b/crates/jazz-tools/src/runtime_core/ticks.rs
@@ -118,6 +118,48 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         }
     }
 
+    pub fn rollback_batch(
+        &mut self,
+        batch_id: crate::row_histories::BatchId,
+    ) -> Result<(), RuntimeError> {
+        let Some(record) = self
+            .storage
+            .load_local_batch_record(batch_id)
+            .map_err(|err| RuntimeError::WriteError(format!("load local batch record: {err}")))?
+        else {
+            return Ok(());
+        };
+
+        if record.mode != crate::batch_fate::BatchMode::Transactional {
+            return Err(RuntimeError::WriteError(format!(
+                "cannot roll back non-transactional batch {batch_id:?}"
+            )));
+        }
+        if record.sealed {
+            return Err(RuntimeError::WriteError(format!(
+                "cannot roll back sealed transaction {batch_id:?}"
+            )));
+        }
+
+        self.mark_local_batch_rows_rejected(batch_id);
+        self.schema_manager
+            .query_manager_mut()
+            .sync_manager_mut()
+            .discard_pending_batch_outbox(batch_id);
+        self.storage
+            .delete_local_batch_record(batch_id)
+            .map_err(|err| RuntimeError::WriteError(format!("delete local batch record: {err}")))?;
+        self.reject_ack_watchers_for_batch(
+            batch_id,
+            "rolled_back",
+            "transaction rolled back locally",
+        );
+        self.rejected_batch_ids.remove(&batch_id);
+        self.mark_storage_write_pending_flush();
+        self.immediate_tick();
+        Ok(())
+    }
+
     fn apply_received_batch_settlement(&mut self, settlement: crate::batch_fate::BatchSettlement) {
         let batch_id = settlement.batch_id();
         if let Ok(Some(mut record)) = self.storage.load_local_batch_record(batch_id) {

--- a/crates/jazz-tools/src/runtime_core/ticks.rs
+++ b/crates/jazz-tools/src/runtime_core/ticks.rs
@@ -223,7 +223,6 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         batch_id: crate::row_histories::BatchId,
     ) {
         let mut cleared_rows = Vec::new();
-        let mut batch_patch_succeeded_by_table = std::collections::HashMap::new();
 
         for (member, row_locator, row) in self.local_batch_rows(batch_id) {
             if !matches!(
@@ -244,40 +243,19 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             ));
         }
 
-        for (table, _, _, _, _, _, _) in &cleared_rows {
-            batch_patch_succeeded_by_table
-                .entry(table.clone())
-                .or_insert_with(|| {
-                    self.storage
-                        .patch_row_region_rows_by_batch(
-                            table,
-                            batch_id,
-                            Some(RowState::Rejected),
-                            None,
-                        )
-                        .is_ok()
-                });
-        }
-
         let query_manager = self.schema_manager.query_manager_mut();
         for (table, schema_hash, branch, row_id, member_batch_id, row_data, was_visible) in
             cleared_rows
         {
-            if !batch_patch_succeeded_by_table
-                .get(&table)
-                .copied()
-                .unwrap_or(false)
-            {
-                let _ = self.storage.patch_exact_row_batch_for_schema_hash(
-                    &table,
-                    schema_hash,
-                    &branch,
-                    row_id,
-                    member_batch_id,
-                    Some(RowState::Rejected),
-                    None,
-                );
-            }
+            let _ = self.storage.patch_exact_row_batch_for_schema_hash(
+                &table,
+                schema_hash,
+                &branch,
+                row_id,
+                member_batch_id,
+                Some(RowState::Rejected),
+                None,
+            );
             if was_visible {
                 let _ = self
                     .storage

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -468,6 +468,113 @@ impl SyncManager {
         }
     }
 
+    fn pending_row_payload_for_batch(
+        payload: &SyncPayload,
+        batch_id: crate::row_histories::BatchId,
+    ) -> bool {
+        matches!(
+            payload,
+            SyncPayload::RowBatchCreated { row, .. }
+                | SyncPayload::RowBatchNeeded { row, .. }
+                if row.batch_id == batch_id
+                    && matches!(row.state, RowState::StagingPending | RowState::Superseded)
+        )
+    }
+
+    fn discard_pending_permission_checks_for_batch(
+        &mut self,
+        batch_id: crate::row_histories::BatchId,
+    ) -> bool {
+        let before = self.pending_permission_checks.len();
+        self.pending_permission_checks
+            .retain(|check| !Self::pending_row_payload_for_batch(&check.payload, batch_id));
+        before != self.pending_permission_checks.len()
+    }
+
+    fn cancellable_pending_batch_rows<H: Storage>(
+        &self,
+        storage: &H,
+        batch_id: crate::row_histories::BatchId,
+    ) -> Vec<(String, StoredRowBatch)> {
+        let Ok(row_locators) = storage.scan_row_locators() else {
+            return Vec::new();
+        };
+
+        let mut rows = Vec::new();
+        for (row_id, row_locator) in row_locators {
+            let Ok(history_rows) =
+                storage.scan_history_row_batches(row_locator.table.as_str(), row_id)
+            else {
+                continue;
+            };
+
+            rows.extend(history_rows.into_iter().filter_map(|row| {
+                (row.batch_id == batch_id
+                    && matches!(row.state, RowState::StagingPending | RowState::Superseded))
+                .then(|| (row_locator.table.to_string(), row))
+            }));
+        }
+
+        rows.sort_by(|(left_table, left), (right_table, right)| {
+            left_table.cmp(right_table).then_with(|| {
+                left.row_id
+                    .uuid()
+                    .as_bytes()
+                    .cmp(right.row_id.uuid().as_bytes())
+                    .then_with(|| left.branch.as_str().cmp(right.branch.as_str()))
+                    .then_with(|| left.batch_id.0.cmp(&right.batch_id.0))
+            })
+        });
+        rows
+    }
+
+    fn cancel_pending_batch<H: Storage>(
+        &mut self,
+        storage: &mut H,
+        batch_id: crate::row_histories::BatchId,
+    ) {
+        let pending_rows = self.cancellable_pending_batch_rows(storage, batch_id);
+        let removed_pending_checks = self.discard_pending_permission_checks_for_batch(batch_id);
+        if pending_rows.is_empty() && !removed_pending_checks {
+            return;
+        }
+
+        self.discard_pending_batch_outbox(batch_id);
+        self.row_batch_interest
+            .retain(|key, _clients| key.batch_id != batch_id);
+
+        for (table, row) in pending_rows {
+            let row_id = row.row_id;
+            let branch_name = BranchName::new(&row.branch);
+            let visibility_change = patch_row_batch_state(
+                storage,
+                row_id,
+                &branch_name,
+                row.batch_id(),
+                Some(RowState::Rejected),
+                None,
+            )
+            .ok()
+            .flatten();
+
+            if let Some(update) = visibility_change {
+                self.pending_row_visibility_changes.push(update);
+                self.forward_update_to_clients_with_storage(storage, row_id, branch_name);
+            }
+
+            tracing::debug!(
+                ?batch_id,
+                table,
+                %row_id,
+                "cancelled pending transactional row"
+            );
+        }
+
+        if let Err(error) = storage.delete_sealed_batch_submission(batch_id) {
+            tracing::warn!(?batch_id, %error, "failed to delete cancelled sealed batch submission");
+        }
+    }
+
     fn transactional_batch_rows<H: Storage>(
         &self,
         storage: &H,
@@ -1097,6 +1204,9 @@ impl SyncManager {
                     batch_ids,
                 );
             }
+            SyncPayload::CancelBatch { batch_id } => {
+                self.cancel_pending_batch(storage, batch_id);
+            }
             SyncPayload::QueryScopeSnapshot { query_id, scope } => {
                 let scope_set: HashSet<(ObjectId, BranchName)> = scope.iter().copied().collect();
                 self.remote_query_scopes
@@ -1367,6 +1477,9 @@ impl SyncManager {
             SyncPayload::SealBatch { .. } => {
                 self.apply_payload_from_client(storage, client_id, payload, false);
             }
+            SyncPayload::CancelBatch { .. } => {
+                self.apply_payload_from_client(storage, client_id, payload, false);
+            }
             // Handle query subscription with full Query struct
             // Queue for QueryManager to process (SyncManager doesn't know about QueryGraph)
             SyncPayload::QuerySubscription {
@@ -1635,6 +1748,10 @@ impl SyncManager {
                     client_id,
                     submission.batch_id,
                 );
+            }
+            SyncPayload::CancelBatch { batch_id } => {
+                self.cancel_pending_batch(storage, batch_id);
+                self.cancel_batch_to_servers_except(batch_id, None);
             }
             SyncPayload::BatchSettlement { settlement } => {
                 self.pending_batch_settlements.push(settlement);

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -1854,7 +1854,7 @@ impl SyncManager {
                     return;
                 }
                 if self.cancel_pending_batch(storage, batch_id) {
-                    self.cancel_batch_to_servers_except(batch_id, None);
+                    self.cancel_batch_to_servers(batch_id);
                 }
             }
             SyncPayload::BatchSettlement { settlement } => {

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -491,6 +491,34 @@ impl SyncManager {
         before != self.pending_permission_checks.len()
     }
 
+    pub(super) fn remember_pending_batch_owner_for_payload(
+        &mut self,
+        client_id: ClientId,
+        payload: &SyncPayload,
+    ) {
+        let (SyncPayload::RowBatchCreated { row, .. } | SyncPayload::RowBatchNeeded { row, .. }) =
+            payload
+        else {
+            return;
+        };
+
+        if matches!(row.state, RowState::StagingPending | RowState::Superseded) {
+            self.pending_batch_owners
+                .entry(row.batch_id)
+                .or_insert(client_id);
+        }
+    }
+
+    fn client_owns_pending_batch(
+        &self,
+        client_id: ClientId,
+        batch_id: crate::row_histories::BatchId,
+    ) -> bool {
+        self.pending_batch_owners
+            .get(&batch_id)
+            .is_some_and(|owner| *owner == client_id)
+    }
+
     fn cancellable_pending_batch_rows<H: Storage>(
         &self,
         storage: &H,
@@ -532,14 +560,15 @@ impl SyncManager {
         &mut self,
         storage: &mut H,
         batch_id: crate::row_histories::BatchId,
-    ) {
+    ) -> bool {
         let pending_rows = self.cancellable_pending_batch_rows(storage, batch_id);
         let removed_pending_checks = self.discard_pending_permission_checks_for_batch(batch_id);
         if pending_rows.is_empty() && !removed_pending_checks {
-            return;
+            return false;
         }
 
         self.discard_pending_batch_outbox(batch_id);
+        self.pending_batch_owners.remove(&batch_id);
         self.row_batch_interest
             .retain(|key, _clients| key.batch_id != batch_id);
 
@@ -573,6 +602,8 @@ impl SyncManager {
         if let Err(error) = storage.delete_sealed_batch_submission(batch_id) {
             tracing::warn!(?batch_id, %error, "failed to delete cancelled sealed batch submission");
         }
+
+        true
     }
 
     fn transactional_batch_rows<H: Storage>(
@@ -777,6 +808,7 @@ impl SyncManager {
                 "failed to delete rejected sealed batch submission"
             );
         }
+        self.pending_batch_owners.remove(&settlement.batch_id());
         self.apply_transactional_batch_settlement_to_rows(
             storage,
             origin_client_id,
@@ -866,6 +898,7 @@ impl SyncManager {
             if let Err(error) = storage.delete_sealed_batch_submission(batch_id) {
                 tracing::warn!(?batch_id, %error, "failed to delete sealed batch submission");
             }
+            self.pending_batch_owners.remove(&batch_id);
         }
         let rows_to_patch: &[(String, StoredRowBatch)] = match settlement {
             BatchSettlement::AcceptedTransaction { .. } => &declared_rows,
@@ -1645,6 +1678,11 @@ impl SyncManager {
                 let object_id = row.row_id;
                 let branch_name = BranchName::new(&row.branch);
                 let batch_id = row.batch_id;
+                if matches!(row.state, RowState::StagingPending | RowState::Superseded) {
+                    self.pending_batch_owners
+                        .entry(batch_id)
+                        .or_insert(client_id);
+                }
                 self.row_batch_interest
                     .entry(RowBatchKey::new(object_id, branch_name, batch_id))
                     .or_default()
@@ -1750,8 +1788,17 @@ impl SyncManager {
                 );
             }
             SyncPayload::CancelBatch { batch_id } => {
-                self.cancel_pending_batch(storage, batch_id);
-                self.cancel_batch_to_servers_except(batch_id, None);
+                if !self.client_owns_pending_batch(client_id, batch_id) {
+                    tracing::warn!(
+                        %client_id,
+                        ?batch_id,
+                        "client attempted to cancel a pending batch it does not own"
+                    );
+                    return;
+                }
+                if self.cancel_pending_batch(storage, batch_id) {
+                    self.cancel_batch_to_servers_except(batch_id, None);
+                }
             }
             SyncPayload::BatchSettlement { settlement } => {
                 self.pending_batch_settlements.push(settlement);

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -509,6 +509,33 @@ impl SyncManager {
         }
     }
 
+    fn remember_pending_batch_member(
+        &mut self,
+        metadata: &HashMap<String, String>,
+        row: &StoredRowBatch,
+    ) {
+        let Some(table) = metadata.get(MetadataKey::Table.as_str()) else {
+            return;
+        };
+
+        self.pending_batch_members
+            .entry(row.batch_id)
+            .or_default()
+            .insert(PendingBatchMember {
+                table: table.clone(),
+                row_batch_key: RowBatchKey::new(
+                    row.row_id,
+                    BranchName::new(&row.branch),
+                    row.batch_id,
+                ),
+            });
+    }
+
+    fn forget_pending_batch(&mut self, batch_id: crate::row_histories::BatchId) {
+        self.pending_batch_owners.remove(&batch_id);
+        self.pending_batch_members.remove(&batch_id);
+    }
+
     fn client_owns_pending_batch(
         &self,
         client_id: ClientId,
@@ -523,28 +550,32 @@ impl SyncManager {
         &self,
         storage: &H,
         batch_id: crate::row_histories::BatchId,
-    ) -> Vec<(String, StoredRowBatch)> {
-        let Ok(row_locators) = storage.scan_row_locators() else {
-            return Vec::new();
+    ) -> Vec<(PendingBatchMember, StoredRowBatch)> {
+        let mut rows = Vec::new();
+        let Some(members) = self.pending_batch_members.get(&batch_id) else {
+            return rows;
         };
 
-        let mut rows = Vec::new();
-        for (row_id, row_locator) in row_locators {
-            let Ok(history_rows) =
-                storage.scan_history_row_batches(row_locator.table.as_str(), row_id)
-            else {
+        for member in members {
+            let row_batch_key = member.row_batch_key;
+            let Ok(Some(row)) = storage.load_history_row_batch(
+                member.table.as_str(),
+                row_batch_key.branch_name.as_str(),
+                row_batch_key.row_id,
+                row_batch_key.batch_id,
+            ) else {
                 continue;
             };
 
-            rows.extend(history_rows.into_iter().filter_map(|row| {
-                (row.batch_id == batch_id
-                    && matches!(row.state, RowState::StagingPending | RowState::Superseded))
-                .then(|| (row_locator.table.to_string(), row))
-            }));
+            if row.batch_id == batch_id
+                && matches!(row.state, RowState::StagingPending | RowState::Superseded)
+            {
+                rows.push((member.clone(), row));
+            }
         }
 
-        rows.sort_by(|(left_table, left), (right_table, right)| {
-            left_table.cmp(right_table).then_with(|| {
+        rows.sort_by(|(left_member, left), (right_member, right)| {
+            left_member.table.cmp(&right_member.table).then_with(|| {
                 left.row_id
                     .uuid()
                     .as_bytes()
@@ -568,23 +599,37 @@ impl SyncManager {
         }
 
         self.discard_pending_batch_outbox(batch_id);
-        self.pending_batch_owners.remove(&batch_id);
+        self.forget_pending_batch(batch_id);
         self.row_batch_interest
             .retain(|key, _clients| key.batch_id != batch_id);
 
-        for (table, row) in pending_rows {
+        for (member, row) in pending_rows {
             let row_id = row.row_id;
             let branch_name = BranchName::new(&row.branch);
-            let visibility_change = patch_row_batch_state(
+            let patched_exact = crate::storage::patch_exact_row_batch_with_storage(
                 storage,
+                &member.table,
+                &row.branch,
                 row_id,
-                &branch_name,
                 row.batch_id(),
                 Some(RowState::Rejected),
                 None,
             )
-            .ok()
-            .flatten();
+            .unwrap_or(false);
+            let visibility_change = if patched_exact {
+                None
+            } else {
+                patch_row_batch_state(
+                    storage,
+                    row_id,
+                    &branch_name,
+                    row.batch_id(),
+                    Some(RowState::Rejected),
+                    None,
+                )
+                .ok()
+                .flatten()
+            };
 
             if let Some(update) = visibility_change {
                 self.pending_row_visibility_changes.push(update);
@@ -593,7 +638,7 @@ impl SyncManager {
 
             tracing::debug!(
                 ?batch_id,
-                table,
+                table = member.table,
                 %row_id,
                 "cancelled pending transactional row"
             );
@@ -808,7 +853,7 @@ impl SyncManager {
                 "failed to delete rejected sealed batch submission"
             );
         }
-        self.pending_batch_owners.remove(&settlement.batch_id());
+        self.forget_pending_batch(settlement.batch_id());
         self.apply_transactional_batch_settlement_to_rows(
             storage,
             origin_client_id,
@@ -898,7 +943,7 @@ impl SyncManager {
             if let Err(error) = storage.delete_sealed_batch_submission(batch_id) {
                 tracing::warn!(?batch_id, %error, "failed to delete sealed batch submission");
             }
-            self.pending_batch_owners.remove(&batch_id);
+            self.forget_pending_batch(batch_id);
         }
         let rows_to_patch: &[(String, StoredRowBatch)] = match settlement {
             BatchSettlement::AcceptedTransaction { .. } => &declared_rows,
@@ -1107,6 +1152,12 @@ impl SyncManager {
                 );
                 if let Some(applied) = self.apply_row_updated(storage, metadata, row.clone()) {
                     let batch_id = applied.row.batch_id;
+                    if matches!(
+                        applied.row.state,
+                        RowState::StagingPending | RowState::Superseded
+                    ) {
+                        self.remember_pending_batch_member(&applied.metadata, &applied.row);
+                    }
 
                     for tier in self.my_tiers.iter().copied() {
                         self.outbox.push(OutboxEntry {
@@ -1689,6 +1740,12 @@ impl SyncManager {
                     .insert(client_id);
 
                 if let Some(applied) = self.apply_row_updated(storage, metadata, row.clone()) {
+                    if matches!(
+                        applied.row.state,
+                        RowState::StagingPending | RowState::Superseded
+                    ) {
+                        self.remember_pending_batch_member(&applied.metadata, &applied.row);
+                    }
                     self.forward_row_batch_to_servers(object_id, applied.metadata.clone(), row);
                     if !matches!(
                         applied.row.state,

--- a/crates/jazz-tools/src/sync_manager/mod.rs
+++ b/crates/jazz-tools/src/sync_manager/mod.rs
@@ -36,6 +36,12 @@ pub const PENDING_SERVER_TIMEOUT: Duration = Duration::from_secs(2);
 // SyncManager
 // ============================================================================
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(super) struct PendingBatchMember {
+    pub table: String,
+    pub row_batch_key: RowBatchKey,
+}
+
 /// Manages synchronization state atop storage-backed row and catalogue state.
 ///
 /// Coordinates:
@@ -72,6 +78,8 @@ pub struct SyncManager {
     pub(super) row_batch_interest: HashMap<RowBatchKey, HashSet<ClientId>>,
     /// Tracks the client that introduced each still-pending transactional batch.
     pub(super) pending_batch_owners: HashMap<BatchId, ClientId>,
+    /// Tracks exact row members for each still-pending transactional batch.
+    pub(super) pending_batch_members: HashMap<BatchId, HashSet<PendingBatchMember>>,
 
     /// Tracks which clients originated each query (for relaying QuerySettled).
     pub(super) query_origin: HashMap<QueryId, HashSet<ClientId>>,
@@ -120,6 +128,7 @@ impl std::fmt::Debug for SyncManager {
             .field("my_tiers", &self.my_tiers)
             .field("row_batch_interest", &self.row_batch_interest)
             .field("pending_batch_owners", &self.pending_batch_owners)
+            .field("pending_batch_members", &self.pending_batch_members)
             .field("query_origin", &self.query_origin)
             .field("remote_query_scopes", &self.remote_query_scopes)
             .field("pending_query_settled", &self.pending_query_settled)
@@ -219,6 +228,7 @@ impl SyncManager {
             my_tiers: HashSet::new(),
             row_batch_interest: HashMap::new(),
             pending_batch_owners: HashMap::new(),
+            pending_batch_members: HashMap::new(),
             query_origin: HashMap::new(),
             remote_query_scopes: HashMap::new(),
             pending_query_settled: Vec::new(),
@@ -343,6 +353,15 @@ impl SyncManager {
         }
         subscriptions += self.pending_batch_owners.len()
             * (std::mem::size_of::<BatchId>() + std::mem::size_of::<ClientId>() + 48);
+        for (batch_id, members) in &self.pending_batch_members {
+            subscriptions += std::mem::size_of_val(batch_id);
+            subscriptions += members.len() * std::mem::size_of::<PendingBatchMember>();
+            subscriptions += members
+                .iter()
+                .map(|member| member.table.len())
+                .sum::<usize>();
+            subscriptions += 48;
+        }
         for (query_id, clients) in &self.query_origin {
             subscriptions += std::mem::size_of_val(query_id);
             subscriptions += clients.len() * std::mem::size_of::<ClientId>();
@@ -505,6 +524,8 @@ impl SyncManager {
         // Clean up pending batch ownership
         self.pending_batch_owners
             .retain(|_, owner| *owner != client_id);
+        self.pending_batch_members
+            .retain(|batch_id, _| self.pending_batch_owners.contains_key(batch_id));
         // Clean up query origin map
         self.query_origin.retain(|_, clients| {
             clients.remove(&client_id);

--- a/crates/jazz-tools/src/sync_manager/mod.rs
+++ b/crates/jazz-tools/src/sync_manager/mod.rs
@@ -70,6 +70,8 @@ pub struct SyncManager {
     pub(super) my_tiers: HashSet<DurabilityTier>,
     /// Tracks which clients are interested in row batch-member state updates.
     pub(super) row_batch_interest: HashMap<RowBatchKey, HashSet<ClientId>>,
+    /// Tracks the client that introduced each still-pending transactional batch.
+    pub(super) pending_batch_owners: HashMap<BatchId, ClientId>,
 
     /// Tracks which clients originated each query (for relaying QuerySettled).
     pub(super) query_origin: HashMap<QueryId, HashSet<ClientId>>,
@@ -117,6 +119,7 @@ impl std::fmt::Debug for SyncManager {
             .field("next_pending_id", &self.next_pending_id)
             .field("my_tiers", &self.my_tiers)
             .field("row_batch_interest", &self.row_batch_interest)
+            .field("pending_batch_owners", &self.pending_batch_owners)
             .field("query_origin", &self.query_origin)
             .field("remote_query_scopes", &self.remote_query_scopes)
             .field("pending_query_settled", &self.pending_query_settled)
@@ -215,6 +218,7 @@ impl SyncManager {
             next_pending_id: 0,
             my_tiers: HashSet::new(),
             row_batch_interest: HashMap::new(),
+            pending_batch_owners: HashMap::new(),
             query_origin: HashMap::new(),
             remote_query_scopes: HashMap::new(),
             pending_query_settled: Vec::new(),
@@ -337,6 +341,8 @@ impl SyncManager {
             subscriptions += clients.len() * std::mem::size_of::<ClientId>();
             subscriptions += 48;
         }
+        subscriptions += self.pending_batch_owners.len()
+            * (std::mem::size_of::<BatchId>() + std::mem::size_of::<ClientId>() + 48);
         for (query_id, clients) in &self.query_origin {
             subscriptions += std::mem::size_of_val(query_id);
             subscriptions += clients.len() * std::mem::size_of::<ClientId>();
@@ -496,6 +502,9 @@ impl SyncManager {
             clients.remove(&client_id);
             !clients.is_empty()
         });
+        // Clean up pending batch ownership
+        self.pending_batch_owners
+            .retain(|_, owner| *owner != client_id);
         // Clean up query origin map
         self.query_origin.retain(|_, clients| {
             clients.remove(&client_id);

--- a/crates/jazz-tools/src/sync_manager/mod.rs
+++ b/crates/jazz-tools/src/sync_manager/mod.rs
@@ -8,7 +8,7 @@ use crate::catalogue::CatalogueEntry;
 use crate::object::{BranchName, ObjectId};
 use crate::query_manager::query::Query;
 use crate::query_manager::session::Session;
-use crate::row_histories::{BatchId, RowVisibilityChange};
+use crate::row_histories::{BatchId, RowState, RowVisibilityChange};
 use crate::storage::Storage;
 
 // Module declarations
@@ -434,6 +434,29 @@ impl SyncManager {
         }
     }
 
+    pub fn cancel_batch_to_servers(&mut self, batch_id: BatchId) {
+        self.cancel_batch_to_servers_except(batch_id, None);
+    }
+
+    pub(super) fn cancel_batch_to_servers_except(
+        &mut self,
+        batch_id: BatchId,
+        except: Option<ServerId>,
+    ) {
+        let server_ids: Vec<_> = self
+            .servers
+            .keys()
+            .copied()
+            .filter(|server_id| Some(*server_id) != except)
+            .collect();
+        for server_id in server_ids {
+            self.outbox.push(OutboxEntry {
+                destination: Destination::Server(server_id),
+                payload: SyncPayload::CancelBatch { batch_id },
+            });
+        }
+    }
+
     /// Remove a server connection.
     pub fn remove_server(&mut self, server_id: ServerId) {
         self.servers.remove(&server_id);
@@ -545,7 +568,8 @@ impl SyncManager {
         self.outbox.retain(|entry| match &entry.payload {
             SyncPayload::RowBatchCreated { metadata, row }
             | SyncPayload::RowBatchNeeded { metadata, row }
-                if row.batch_id == batch_id =>
+                if row.batch_id == batch_id
+                    && matches!(row.state, RowState::StagingPending | RowState::Superseded) =>
             {
                 let key = RowBatchKey::from_row(row);
                 match entry.destination {

--- a/crates/jazz-tools/src/sync_manager/mod.rs
+++ b/crates/jazz-tools/src/sync_manager/mod.rs
@@ -537,6 +537,73 @@ impl SyncManager {
         self.outbox = entries;
     }
 
+    /// Drop queued, not-yet-transported row/seal messages for a locally discarded batch.
+    pub(crate) fn discard_pending_batch_outbox(&mut self, batch_id: BatchId) {
+        let mut server_rows = Vec::new();
+        let mut client_rows = Vec::new();
+
+        self.outbox.retain(|entry| match &entry.payload {
+            SyncPayload::RowBatchCreated { metadata, row }
+            | SyncPayload::RowBatchNeeded { metadata, row }
+                if row.batch_id == batch_id =>
+            {
+                let key = RowBatchKey::from_row(row);
+                match entry.destination {
+                    Destination::Server(server_id) => {
+                        server_rows.push((server_id, key, metadata.is_some()));
+                    }
+                    Destination::Client(client_id) => {
+                        client_rows.push((client_id, key, metadata.is_some()));
+                    }
+                }
+                false
+            }
+            SyncPayload::SealBatch { submission } if submission.batch_id == batch_id => false,
+            _ => true,
+        });
+
+        for (server_id, key, included_metadata) in server_rows {
+            if let Some(server) = self.servers.get_mut(&server_id) {
+                Self::forget_sent_batch(&mut server.sent_batch_ids, key);
+                if included_metadata {
+                    server.sent_metadata.remove(&key.row_id);
+                }
+            }
+        }
+
+        for (client_id, key, included_metadata) in client_rows {
+            if let Some(client) = self.clients.get_mut(&client_id) {
+                Self::forget_sent_batch(&mut client.sent_batch_ids, key);
+                if included_metadata {
+                    client.sent_metadata.remove(&key.row_id);
+                }
+            }
+
+            let should_remove_interest =
+                if let Some(clients) = self.row_batch_interest.get_mut(&key) {
+                    clients.remove(&client_id);
+                    clients.is_empty()
+                } else {
+                    false
+                };
+            if should_remove_interest {
+                self.row_batch_interest.remove(&key);
+            }
+        }
+    }
+
+    fn forget_sent_batch(
+        sent_batch_ids: &mut HashMap<(ObjectId, BranchName), HashSet<BatchId>>,
+        key: RowBatchKey,
+    ) {
+        if let Some(sent_batches) = sent_batch_ids.get_mut(&(key.row_id, key.branch_name)) {
+            sent_batches.remove(&key.batch_id);
+            if sent_batches.is_empty() {
+                sent_batch_ids.remove(&(key.row_id, key.branch_name));
+            }
+        }
+    }
+
     /// Get a reference to the outbox (for checking if empty).
     pub fn outbox(&self) -> &[OutboxEntry] {
         &self.outbox

--- a/crates/jazz-tools/src/sync_manager/mod.rs
+++ b/crates/jazz-tools/src/sync_manager/mod.rs
@@ -460,20 +460,7 @@ impl SyncManager {
     }
 
     pub fn cancel_batch_to_servers(&mut self, batch_id: BatchId) {
-        self.cancel_batch_to_servers_except(batch_id, None);
-    }
-
-    pub(super) fn cancel_batch_to_servers_except(
-        &mut self,
-        batch_id: BatchId,
-        except: Option<ServerId>,
-    ) {
-        let server_ids: Vec<_> = self
-            .servers
-            .keys()
-            .copied()
-            .filter(|server_id| Some(*server_id) != except)
-            .collect();
+        let server_ids: Vec<_> = self.servers.keys().copied().collect();
         for server_id in server_ids {
             self.outbox.push(OutboxEntry {
                 destination: Destination::Server(server_id),

--- a/crates/jazz-tools/src/sync_manager/permissions.rs
+++ b/crates/jazz-tools/src/sync_manager/permissions.rs
@@ -127,6 +127,7 @@ impl SyncManager {
     ) -> PendingUpdateId {
         let id = PendingUpdateId(self.next_pending_id);
         self.next_pending_id += 1;
+        self.remember_pending_batch_owner_for_payload(client_id, &payload);
         self.pending_permission_checks.push(PendingPermissionCheck {
             id,
             client_id,

--- a/crates/jazz-tools/src/sync_manager/sync_logic.rs
+++ b/crates/jazz-tools/src/sync_manager/sync_logic.rs
@@ -69,6 +69,10 @@ impl SyncManager {
         let my_max_tier = self.max_local_durability_tier();
 
         for row in rows.into_iter() {
+            if matches!(row.state, crate::row_histories::RowState::Rejected) {
+                continue;
+            }
+
             // Skip rows already confirmed above our own tier — an upstream
             // server has them. Without this, a user-role client replays every
             // stored row (including ones authored by other users that it only

--- a/crates/jazz-tools/src/sync_manager/sync_tracer.rs
+++ b/crates/jazz-tools/src/sync_manager/sync_tracer.rs
@@ -160,6 +160,7 @@ impl SyncMessage {
                 vec![row.batch_id()]
             }
             SyncPayload::RowBatchStateChanged { batch_id, .. } => vec![*batch_id],
+            SyncPayload::CancelBatch { batch_id } => vec![*batch_id],
             _ => vec![],
         }
     }
@@ -908,6 +909,9 @@ impl<'a> Normalizer<'a> {
                     submission.captured_frontier
                 )
             }
+            SyncPayload::CancelBatch { batch_id } => {
+                format!("cancel batch:{}", self.batch(batch_id))
+            }
             SyncPayload::CatalogueEntryUpdated { entry } => {
                 format!(
                     "catalogue obj:{} type:{}",
@@ -1097,6 +1101,9 @@ fn format_payload_details(payload: &SyncPayload, names: &Names<'_>) -> String {
                 submission.members,
                 submission.captured_frontier
             )
+        }
+        SyncPayload::CancelBatch { batch_id } => {
+            format!("cancel batch:{}", names.batch(batch_id))
         }
         SyncPayload::QuerySubscription { query_id, .. } => {
             format!("query:{}", query_id.0)

--- a/crates/jazz-tools/src/sync_manager/tests.rs
+++ b/crates/jazz-tools/src/sync_manager/tests.rs
@@ -9,9 +9,174 @@ use crate::query_manager::policy::Operation;
 use crate::query_manager::query::QueryBuilder;
 use crate::query_manager::types::{ColumnType, SchemaBuilder, SchemaHash, TableSchema, Value};
 use crate::row_histories::{BatchId, StoredRowBatch, VisibleRowEntry};
-use crate::storage::{MemoryStorage, Storage};
+use crate::storage::{MemoryStorage, RawTableKeys, RawTableRows, Storage, StorageError};
 use crate::test_support::{create_test_row_with_id, persist_test_schema};
 use std::collections::{HashMap, HashSet};
+
+struct RowLocatorScanDisabledStorage {
+    inner: MemoryStorage,
+}
+
+impl RowLocatorScanDisabledStorage {
+    fn new(inner: MemoryStorage) -> Self {
+        Self { inner }
+    }
+}
+
+impl Storage for RowLocatorScanDisabledStorage {
+    fn scan_row_locators(&self) -> Result<crate::storage::RowLocatorRows, StorageError> {
+        Err(StorageError::IoError(
+            "row locator scans are disabled in this test".to_string(),
+        ))
+    }
+
+    fn load_row_locator(
+        &self,
+        id: ObjectId,
+    ) -> Result<Option<crate::storage::RowLocator>, StorageError> {
+        self.inner.load_row_locator(id)
+    }
+
+    fn put_row_locator(
+        &mut self,
+        id: ObjectId,
+        locator: Option<&crate::storage::RowLocator>,
+    ) -> Result<(), StorageError> {
+        self.inner.put_row_locator(id, locator)
+    }
+
+    fn raw_table_put(&mut self, table: &str, key: &str, value: &[u8]) -> Result<(), StorageError> {
+        self.inner.raw_table_put(table, key, value)
+    }
+
+    fn raw_table_delete(&mut self, table: &str, key: &str) -> Result<(), StorageError> {
+        self.inner.raw_table_delete(table, key)
+    }
+
+    fn raw_table_get(&self, table: &str, key: &str) -> Result<Option<Vec<u8>>, StorageError> {
+        self.inner.raw_table_get(table, key)
+    }
+
+    fn raw_table_scan_prefix(
+        &self,
+        table: &str,
+        prefix: &str,
+    ) -> Result<RawTableRows, StorageError> {
+        self.inner.raw_table_scan_prefix(table, prefix)
+    }
+
+    fn raw_table_scan_range(
+        &self,
+        table: &str,
+        start: Option<&str>,
+        end: Option<&str>,
+    ) -> Result<RawTableRows, StorageError> {
+        self.inner.raw_table_scan_range(table, start, end)
+    }
+
+    fn raw_table_scan_prefix_keys(
+        &self,
+        table: &str,
+        prefix: &str,
+    ) -> Result<RawTableKeys, StorageError> {
+        self.inner.raw_table_scan_prefix_keys(table, prefix)
+    }
+
+    fn raw_table_scan_range_keys(
+        &self,
+        table: &str,
+        start: Option<&str>,
+        end: Option<&str>,
+    ) -> Result<RawTableKeys, StorageError> {
+        self.inner.raw_table_scan_range_keys(table, start, end)
+    }
+
+    fn append_history_region_rows(
+        &mut self,
+        table: &str,
+        rows: &[crate::row_histories::StoredRowBatch],
+    ) -> Result<(), StorageError> {
+        self.inner.append_history_region_rows(table, rows)
+    }
+
+    fn apply_encoded_row_mutation(
+        &mut self,
+        table: &str,
+        history_rows: &[crate::storage::OwnedHistoryRowBytes],
+        visible_rows: &[crate::storage::OwnedVisibleRowBytes],
+        index_mutations: &[crate::storage::IndexMutation<'_>],
+    ) -> Result<(), StorageError> {
+        self.inner
+            .apply_encoded_row_mutation(table, history_rows, visible_rows, index_mutations)
+    }
+
+    fn apply_prepared_row_mutation(
+        &mut self,
+        table: &str,
+        history_rows: &[crate::row_histories::StoredRowBatch],
+        visible_entries: &[crate::row_histories::VisibleRowEntry],
+        encoded_history_rows: &[crate::storage::OwnedHistoryRowBytes],
+        encoded_visible_rows: &[crate::storage::OwnedVisibleRowBytes],
+        index_mutations: &[crate::storage::IndexMutation<'_>],
+    ) -> Result<(), StorageError> {
+        self.inner.apply_prepared_row_mutation(
+            table,
+            history_rows,
+            visible_entries,
+            encoded_history_rows,
+            encoded_visible_rows,
+            index_mutations,
+        )
+    }
+
+    fn apply_row_mutation(
+        &mut self,
+        table: &str,
+        history_rows: &[crate::row_histories::StoredRowBatch],
+        visible_entries: &[crate::row_histories::VisibleRowEntry],
+        index_mutations: &[crate::storage::IndexMutation<'_>],
+    ) -> Result<(), StorageError> {
+        self.inner
+            .apply_row_mutation(table, history_rows, visible_entries, index_mutations)
+    }
+
+    fn delete_visible_region_row(
+        &mut self,
+        table: &str,
+        branch: &str,
+        row_id: ObjectId,
+    ) -> Result<(), StorageError> {
+        self.inner.delete_visible_region_row(table, branch, row_id)
+    }
+
+    fn load_history_row_batch(
+        &self,
+        table: &str,
+        branch: &str,
+        row_id: ObjectId,
+        batch_id: BatchId,
+    ) -> Result<Option<crate::row_histories::StoredRowBatch>, StorageError> {
+        self.inner
+            .load_history_row_batch(table, branch, row_id, batch_id)
+    }
+
+    fn scan_history_row_batches(
+        &self,
+        table: &str,
+        row_id: ObjectId,
+    ) -> Result<Vec<crate::row_histories::StoredRowBatch>, StorageError> {
+        self.inner.scan_history_row_batches(table, row_id)
+    }
+
+    fn load_visible_region_row(
+        &self,
+        table: &str,
+        branch: &str,
+        row_id: ObjectId,
+    ) -> Result<Option<crate::row_histories::StoredRowBatch>, StorageError> {
+        self.inner.load_visible_region_row(table, branch, row_id)
+    }
+}
 
 fn users_test_schema() -> crate::query_manager::types::Schema {
     SchemaBuilder::new()

--- a/crates/jazz-tools/src/sync_manager/tests/permissions.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/permissions.rs
@@ -197,6 +197,53 @@ fn cancel_batch_from_unrelated_client_keeps_pending_permission_check() {
 }
 
 #[test]
+fn cancel_batch_from_owner_uses_exact_pending_members_without_locator_scan() {
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
+    let mut seeded = MemoryStorage::new();
+    let alice = ClientId::new();
+    let row_id = ObjectId::new();
+    let row = row_with_state(
+        visible_row(row_id, "main", Vec::new(), 1_000, b"Alice draft"),
+        crate::row_histories::RowState::StagingPending,
+        None,
+    );
+    seed_users_schema(&mut seeded);
+    add_client(&mut sm, &seeded, alice);
+    sm.set_client_role(alice, ClientRole::Peer);
+
+    let mut io = RowLocatorScanDisabledStorage::new(seeded);
+    sm.process_from_client(
+        &mut io,
+        alice,
+        SyncPayload::RowBatchCreated {
+            metadata: Some(RowMetadata {
+                id: row_id,
+                metadata: row_metadata("users"),
+            }),
+            row: row.clone(),
+        },
+    );
+    sm.take_outbox();
+    sm.process_from_client(
+        &mut io,
+        alice,
+        SyncPayload::CancelBatch {
+            batch_id: row.batch_id,
+        },
+    );
+
+    let rows = io
+        .scan_history_row_batches("users", row_id)
+        .expect("cancel should leave readable row history");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0].state,
+        crate::row_histories::RowState::Rejected,
+        "owner cancel should reject the exact pending row without discovering it through a locator scan"
+    );
+}
+
+#[test]
 fn row_batch_created_from_user_with_older_exact_history_match_skips_permission_check() {
     let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
     let mut io = MemoryStorage::new();

--- a/crates/jazz-tools/src/sync_manager/tests/permissions.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/permissions.rs
@@ -124,6 +124,79 @@ fn row_batch_created_from_user_with_same_batch_correction_queues_permission_chec
 }
 
 #[test]
+fn cancel_batch_from_unrelated_client_keeps_pending_permission_check() {
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
+    let mut io = MemoryStorage::new();
+    let alice = ClientId::new();
+    let bob = ClientId::new();
+    let upstream = ServerId::new();
+    let row_id = ObjectId::new();
+    let row = row_with_state(
+        visible_row(row_id, "main", Vec::new(), 1_000, b"Alice draft"),
+        crate::row_histories::RowState::StagingPending,
+        None,
+    );
+    seed_users_schema(&mut io);
+
+    add_client(&mut sm, &io, alice);
+    sm.set_client_role(alice, ClientRole::User);
+    sm.set_client_session(alice, crate::query_manager::session::Session::new("alice"));
+    add_client(&mut sm, &io, bob);
+    sm.set_client_role(bob, ClientRole::Peer);
+    add_server(&mut sm, &io, upstream);
+    sm.take_outbox();
+
+    sm.process_from_client(
+        &mut io,
+        alice,
+        SyncPayload::RowBatchCreated {
+            metadata: Some(RowMetadata {
+                id: row_id,
+                metadata: row_metadata("users"),
+            }),
+            row: row.clone(),
+        },
+    );
+    assert_eq!(
+        sm.pending_permission_checks.len(),
+        1,
+        "Alice's staged row should be waiting on permission evaluation"
+    );
+    sm.take_outbox();
+
+    sm.process_from_client(
+        &mut io,
+        bob,
+        SyncPayload::CancelBatch {
+            batch_id: row.batch_id,
+        },
+    );
+
+    assert_eq!(
+        sm.pending_permission_checks.len(),
+        1,
+        "Bob's spoofed cancel should not remove Alice's pending permission check"
+    );
+    assert_eq!(sm.pending_permission_checks[0].client_id, alice);
+
+    let outbox = sm.take_outbox();
+    assert!(
+        outbox.iter().all(|entry| {
+            !matches!(
+                entry,
+                OutboxEntry {
+                    destination: Destination::Server(server_id),
+                    payload: SyncPayload::CancelBatch {
+                        batch_id: cancelled
+                    },
+                } if *server_id == upstream && *cancelled == row.batch_id
+            )
+        }),
+        "Bob's spoofed cancel should not be forwarded upstream, got {outbox:?}"
+    );
+}
+
+#[test]
 fn row_batch_created_from_user_with_older_exact_history_match_skips_permission_check() {
     let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
     let mut io = MemoryStorage::new();

--- a/crates/jazz-tools/src/sync_manager/tests/permissions.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/permissions.rs
@@ -197,6 +197,70 @@ fn cancel_batch_from_unrelated_client_keeps_pending_permission_check() {
 }
 
 #[test]
+fn cancel_batch_from_owner_without_local_pending_work_does_not_forward_upstream() {
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
+    let mut io = MemoryStorage::new();
+    let alice = ClientId::new();
+    let upstream = ServerId::new();
+    let row_id = ObjectId::new();
+    let row = row_with_state(
+        visible_row(row_id, "main", Vec::new(), 1_000, b"Alice draft"),
+        crate::row_histories::RowState::StagingPending,
+        None,
+    );
+    seed_users_schema(&mut io);
+
+    add_client(&mut sm, &io, alice);
+    sm.set_client_role(alice, ClientRole::User);
+    sm.set_client_session(alice, crate::query_manager::session::Session::new("alice"));
+    add_server(&mut sm, &io, upstream);
+    sm.take_outbox();
+
+    sm.process_from_client(
+        &mut io,
+        alice,
+        SyncPayload::RowBatchCreated {
+            metadata: Some(RowMetadata {
+                id: row_id,
+                metadata: row_metadata("users"),
+            }),
+            row: row.clone(),
+        },
+    );
+    let pending = sm.take_pending_permission_checks();
+    assert_eq!(
+        pending.len(),
+        1,
+        "Alice's staged row should be waiting on permission evaluation"
+    );
+    sm.take_outbox();
+
+    sm.process_from_client(
+        &mut io,
+        alice,
+        SyncPayload::CancelBatch {
+            batch_id: row.batch_id,
+        },
+    );
+
+    let outbox = sm.take_outbox();
+    assert!(
+        outbox.iter().all(|entry| {
+            !matches!(
+                entry,
+                OutboxEntry {
+                    destination: Destination::Server(server_id),
+                    payload: SyncPayload::CancelBatch {
+                        batch_id: cancelled
+                    },
+                } if *server_id == upstream && *cancelled == row.batch_id
+            )
+        }),
+        "owner cancel with no matching local pending rows or checks should not fan out upstream, got {outbox:?}"
+    );
+}
+
+#[test]
 fn cancel_batch_from_owner_uses_exact_pending_members_without_locator_scan() {
     let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
     let mut seeded = MemoryStorage::new();

--- a/crates/jazz-tools/src/sync_manager/types.rs
+++ b/crates/jazz-tools/src/sync_manager/types.rs
@@ -292,6 +292,9 @@ pub enum SyncPayload {
     /// Explicitly seal a transactional batch so the authority can validate it.
     SealBatch { submission: SealedBatchSubmission },
 
+    /// Explicitly cancel an unsealed transactional batch and discard staged rows.
+    CancelBatch { batch_id: BatchId },
+
     /// Subscribe to a query (client to server).
     /// Server will build QueryGraph and send matching objects.
     QuerySubscription {
@@ -444,6 +447,7 @@ impl SyncPayload {
             SyncPayload::SealBatch { submission } => {
                 submission.members.first().map(|member| member.object_id)
             }
+            SyncPayload::CancelBatch { .. } => None,
             SyncPayload::QueryScopeSnapshot { scope, .. } => {
                 scope.first().map(|(object_id, _)| *object_id)
             }
@@ -469,6 +473,7 @@ impl SyncPayload {
             },
             SyncPayload::BatchSettlementNeeded { .. } => None,
             SyncPayload::SealBatch { .. } => None,
+            SyncPayload::CancelBatch { .. } => None,
             SyncPayload::QueryScopeSnapshot { scope, .. } => {
                 scope.first().map(|(_, branch_name)| *branch_name)
             }
@@ -486,6 +491,7 @@ impl SyncPayload {
                 | SyncPayload::RowBatchStateChanged { .. }
                 | SyncPayload::BatchSettlement { .. }
                 | SyncPayload::SealBatch { .. }
+                | SyncPayload::CancelBatch { .. }
         )
     }
 
@@ -527,6 +533,7 @@ impl SyncPayload {
             SyncPayload::BatchSettlement { .. } => "BatchSettlement",
             SyncPayload::BatchSettlementNeeded { .. } => "BatchSettlementNeeded",
             SyncPayload::SealBatch { .. } => "SealBatch",
+            SyncPayload::CancelBatch { .. } => "CancelBatch",
             SyncPayload::QuerySubscription { .. } => "QuerySubscription",
             SyncPayload::QueryUnsubscription { .. } => "QueryUnsubscription",
             SyncPayload::QueryScopeSnapshot { .. } => "QueryScopeSnapshot",

--- a/crates/jazz-wasm/src/runtime.rs
+++ b/crates/jazz-wasm/src/runtime.rs
@@ -1510,6 +1510,14 @@ impl WasmRuntime {
             .map_err(|e| JsError::new(&format!("Seal batch failed: {e}")))
     }
 
+    #[wasm_bindgen(js_name = rollbackBatch)]
+    pub fn rollback_batch(&self, batch_id: &str) -> Result<(), JsError> {
+        let batch_id = parse_batch_id_input(batch_id).map_err(|err| JsError::new(&err))?;
+        let mut core = self.core.borrow_mut();
+        core.rollback_batch(batch_id)
+            .map_err(|e| JsError::new(&format!("Rollback batch failed: {e}")))
+    }
+
     // =========================================================================
     // Subscriptions
     // =========================================================================

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.test.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.test.ts
@@ -483,6 +483,7 @@ describe("JazzRnRuntimeAdapter", () => {
       drainRejectedBatchIds: vi.fn(() => ["batch-1"]),
       acknowledgeRejectedBatch: vi.fn(() => true),
       sealBatch: vi.fn(),
+      rollbackBatch: vi.fn(),
     });
     const adapter = new JazzRnRuntimeAdapter(binding, {});
 
@@ -507,11 +508,13 @@ describe("JazzRnRuntimeAdapter", () => {
     expect(adapter.drainRejectedBatchIds()).toEqual(["batch-1"]);
     expect(adapter.acknowledgeRejectedBatch("batch-1")).toBe(true);
     adapter.sealBatch("batch-1");
+    adapter.rollbackBatch("batch-1");
 
     expect(binding.loadLocalBatchRecord).toHaveBeenCalledWith("batch-1");
     expect(binding.loadLocalBatchRecords).toHaveBeenCalledTimes(1);
     expect(binding.drainRejectedBatchIds).toHaveBeenCalledTimes(1);
     expect(binding.acknowledgeRejectedBatch).toHaveBeenCalledWith("batch-1");
     expect(binding.sealBatch).toHaveBeenCalledWith("batch-1");
+    expect(binding.rollbackBatch).toHaveBeenCalledWith("batch-1");
   });
 });

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
@@ -77,6 +77,7 @@ export interface JazzRnRuntimeBinding {
   ): string;
   acknowledgeRejectedBatch?(batchId: string): boolean;
   sealBatch?(batchId: string): void;
+  rollbackBatch?(batchId: string): void;
   uniffiDestroy?(): void;
 }
 
@@ -185,7 +186,8 @@ export class JazzRnRuntimeAdapter implements Runtime {
       | "loadLocalBatchRecords"
       | "drainRejectedBatchIds"
       | "acknowledgeRejectedBatch"
-      | "sealBatch",
+      | "sealBatch"
+      | "rollbackBatch",
   >(method: T): NonNullable<JazzRnRuntimeBinding[T]> {
     const runtimeMethod = this.binding[method];
     if (!runtimeMethod) {
@@ -486,6 +488,14 @@ export class JazzRnRuntimeAdapter implements Runtime {
   sealBatch(batch_id: string): void {
     try {
       this.requireBatchRecordMethod("sealBatch")(batch_id);
+    } catch (error) {
+      throw normalizeJazzRnError(error);
+    }
+  }
+
+  rollbackBatch(batch_id: string): void {
+    try {
+      this.requireBatchRecordMethod("rollbackBatch")(batch_id);
     } catch (error) {
       throw normalizeJazzRnError(error);
     }

--- a/packages/jazz-tools/src/runtime/client.test.ts
+++ b/packages/jazz-tools/src/runtime/client.test.ts
@@ -312,6 +312,21 @@ describe("JazzClient transactions", () => {
     expect(waitForPersistedBatch).toHaveBeenCalledWith(committed.batchId, "edge");
   });
 
+  it("rolls back an open transaction by discarding its runtime batch", () => {
+    const runtime = makeFakeRuntime();
+    const rollbackBatch = vi.fn<(batchId: string) => void>();
+    (runtime as any).rollbackBatch = rollbackBatch;
+    const client = JazzClient.connectWithRuntime(runtime as any, makeContext());
+
+    const tx = client.beginTransaction();
+    const batchId = tx.batchId();
+
+    tx.rollback();
+
+    expect(rollbackBatch).toHaveBeenCalledWith(batchId);
+    expect(() => tx.commit()).toThrow(/rolled back/i);
+  });
+
   it("returns a write handle from direct batch commit so callers can wait on the batch", async () => {
     const runtime = makeFakeRuntime();
     const client = JazzClient.connectWithRuntime(runtime as any, makeContext());

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -112,6 +112,7 @@ export interface Runtime {
   drainRejectedBatchIds?(): string[];
   acknowledgeRejectedBatch?(batch_id: string): boolean;
   sealBatch?(batch_id: string): void;
+  rollbackBatch?(batch_id: string): void;
   query(
     query_json: string,
     session_json?: string | null,
@@ -862,6 +863,7 @@ export class InsertHandle<T> extends WriteHandle<T> {
 export class Transaction {
   private committedHandle: WriteHandle | null = null;
   private readonly touchedRowIds = new Set<string>();
+  private state: "open" | "committed" | "rolled_back" = "open";
 
   constructor(
     private readonly client: JazzClient,
@@ -871,12 +873,15 @@ export class Transaction {
   ) {}
 
   private get committed(): boolean {
-    return this.committedHandle !== null;
+    return this.state === "committed";
   }
 
   private ensureActive(): void {
     if (this.committed) {
       throw new Error(`Transaction ${this.batchContext.batchId} is already committed`);
+    }
+    if (this.state === "rolled_back") {
+      throw new Error(`Transaction ${this.batchContext.batchId} is already rolled back`);
     }
   }
 
@@ -901,12 +906,23 @@ export class Transaction {
   }
 
   commit(): WriteHandle {
+    if (this.state === "rolled_back") {
+      throw new Error(`Transaction ${this.batchContext.batchId} is already rolled back`);
+    }
     if (this.committedHandle) {
       return this.committedHandle;
     }
     const handle = this.client.sealBatch(this.batchId());
     this.committedHandle = handle;
+    this.state = "committed";
     return handle;
+  }
+
+  rollback(): void {
+    this.ensureActive();
+    this.client.rollbackBatch(this.batchId());
+    this.touchedRowIds.clear();
+    this.state = "rolled_back";
   }
 
   create(table: string, values: InsertValues): Row {
@@ -1496,6 +1512,11 @@ export class JazzClient {
     return new WriteHandle(batchId, this);
   }
 
+  rollbackBatch(batchId: string): void {
+    this.requireBatchRecordMethod("rollbackBatch")(batchId);
+    this.flushPendingBatchWaiters();
+  }
+
   /**
    * Enable backend-scoped sync auth for this client.
    *
@@ -1600,7 +1621,11 @@ export class JazzClient {
   private requireBatchRecordMethod<
     T extends keyof Pick<
       Runtime,
-      "loadLocalBatchRecord" | "loadLocalBatchRecords" | "acknowledgeRejectedBatch" | "sealBatch"
+      | "loadLocalBatchRecord"
+      | "loadLocalBatchRecords"
+      | "acknowledgeRejectedBatch"
+      | "sealBatch"
+      | "rollbackBatch"
     >,
   >(method: T): NonNullable<Runtime[T]> {
     const runtimeMethod = this.runtime[method];

--- a/packages/jazz-tools/src/runtime/db.transaction.test.ts
+++ b/packages/jazz-tools/src/runtime/db.transaction.test.ts
@@ -339,6 +339,46 @@ describe("Db transactions", () => {
     expect(runtimeTransaction.query).not.toHaveBeenCalled();
   });
 
+  it("rolls back a db transaction and rejects later work", async () => {
+    const table = todoTable();
+    const query = todoQuery();
+    const runtimeTransaction = {
+      batchId: vi.fn(() => "batch-rolled-back"),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      query: vi.fn(),
+      commit: vi.fn(() => makeWriteHandle("batch-rolled-back").handle),
+      rollback: vi.fn(() => undefined),
+      localBatchRecord: vi.fn((batchId = "batch-rolled-back") => makeLocalBatchRecord(batchId)),
+      localBatchRecords: vi.fn(() => [makeLocalBatchRecord("batch-rolled-back")]),
+      acknowledgeRejectedBatch: vi.fn(() => false),
+    };
+    const runtimeClient = {
+      getSchema: () => new Map(Object.entries(todoSchema())),
+      beginTransactionInternal: vi.fn(() => runtimeTransaction),
+      localBatchRecord: vi.fn((batchId: string) => makeLocalBatchRecord(batchId)),
+      acknowledgeRejectedBatch: vi.fn(() => false),
+    };
+    const db = createDbFromClient(
+      { appId: "client-backed-transaction" },
+      runtimeClient as unknown as JazzClient,
+    );
+
+    const tx = db.beginTransaction(table);
+    tx.rollback();
+
+    expect(runtimeTransaction.rollback).toHaveBeenCalledWith();
+    expect(() => tx.insert(table, { title: "Nope", done: false })).toThrow(/rolled back/i);
+    expect(() => tx.update(table, "todo-1", { done: true })).toThrow(/rolled back/i);
+    expect(() => tx.delete(table, "todo-1")).toThrow(/rolled back/i);
+    expect(() => tx.commit()).toThrow(/rolled back/i);
+    expect(() => tx.rollback()).toThrow(/rolled back/i);
+    await expect(tx.all(query)).rejects.toThrow(/rolled back/i);
+    expect(runtimeTransaction.create).not.toHaveBeenCalled();
+    expect(runtimeTransaction.query).not.toHaveBeenCalled();
+  });
+
   it("rejects db transaction writes against a different client/schema", () => {
     const primaryTable = todoTable();
     const secondaryTable = {

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -490,7 +490,8 @@ function backendScopedAuthState(session?: Session | null): AuthState {
  * accepted by the authority.
  */
 export class DbTransaction {
-  private committed = false;
+  private state: "open" | "committed" | "rolled_back" = "open";
+  private committedHandle: WriteHandle | null = null;
 
   constructor(
     private readonly client: JazzClient,
@@ -502,8 +503,11 @@ export class DbTransaction {
   ) {}
 
   private ensureActive(): void {
-    if (this.committed) {
+    if (this.state === "committed") {
       throw new Error(`Transaction ${this.runtimeTransaction.batchId()} is already committed`);
+    }
+    if (this.state === "rolled_back") {
+      throw new Error(`Transaction ${this.runtimeTransaction.batchId()} is already rolled back`);
     }
   }
 
@@ -528,8 +532,26 @@ export class DbTransaction {
    * Commit the transaction. Data will be globally visible once it's accepted by the authority.
    */
   commit(): WriteHandle {
-    this.committed = true;
-    return this.runtimeTransaction.commit();
+    if (this.state === "rolled_back") {
+      throw new Error(`Transaction ${this.runtimeTransaction.batchId()} is already rolled back`);
+    }
+    if (this.committedHandle) {
+      return this.committedHandle;
+    }
+    const handle = this.runtimeTransaction.commit();
+    this.committedHandle = handle;
+    this.state = "committed";
+    return handle;
+  }
+
+  /**
+   * Roll back the transaction, discarding staged local changes.
+   */
+  rollback(): void {
+    this.ensureActive();
+    this.runtimeTransaction.rollback();
+    this.committedHandle = null;
+    this.state = "rolled_back";
   }
 
   /**

--- a/packages/jazz-tools/tests/browser/db.transaction-reads.test.ts
+++ b/packages/jazz-tools/tests/browser/db.transaction-reads.test.ts
@@ -1,7 +1,15 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { createDb, type Db, type QueryBuilder, type TableProxy } from "../../src/runtime/db.js";
 import type { WasmSchema } from "../../src/drivers/types.js";
-import { uniqueDbName } from "./support.js";
+import type { CompiledPermissions } from "../../src/permissions/index.js";
+import { generateAuthSecret } from "../../src/runtime/auth-secret-store.js";
+import {
+  fetchPermissionsHead,
+  publishStoredPermissions,
+  publishStoredSchema,
+} from "../../src/runtime/schema-fetch.js";
+import { uniqueDbName, waitForQuery, withTimeout } from "./support.js";
+import { getTestingServerInfo, type TestingServerInfo } from "./testing-server.js";
 
 const schema: WasmSchema = {
   todos: {
@@ -25,6 +33,18 @@ const todos: TableProxy<Todo, Omit<Todo, "id">> = {
   _initType: {} as Omit<Todo, "id">,
 };
 
+const allowAllPermissions: CompiledPermissions = {
+  todos: {
+    select: { using: { type: "True" } },
+    insert: { with_check: { type: "True" } },
+    update: {
+      using: { type: "True" },
+      with_check: { type: "True" },
+    },
+    delete: { using: { type: "True" } },
+  },
+};
+
 function makeTodoQuery(
   conditions: Array<{ column: string; op: string; value?: unknown }> = [],
 ): QueryBuilder<Todo> {
@@ -41,6 +61,25 @@ function makeTodoQuery(
       });
     },
   };
+}
+
+async function publishTransactionReadServer(scope: string): Promise<TestingServerInfo> {
+  const testingServer = await getTestingServerInfo(uniqueDbName(`tx-reads-${scope}`));
+  const { appId, serverUrl, adminSecret } = testingServer;
+  const { hash: schemaHash } = await publishStoredSchema(serverUrl, {
+    appId,
+    adminSecret,
+    schema,
+  });
+  const { head } = await fetchPermissionsHead(serverUrl, { appId, adminSecret });
+  await publishStoredPermissions(serverUrl, {
+    appId,
+    adminSecret,
+    schemaHash,
+    permissions: allowAllPermissions,
+    expectedParentBundleObjectId: head?.bundleObjectId ?? null,
+  });
+  return testingServer;
 }
 
 describe("db transaction reads browser integration", () => {
@@ -107,4 +146,118 @@ describe("db transaction reads browser integration", () => {
       done: false,
     });
   });
+
+  it("cleans up staged rows when a transaction is rolled back", async () => {
+    const db = track(
+      await createDb({
+        appId: "db-transaction-reads-test",
+        driver: { type: "persistent", dbName: uniqueDbName("tx-rollback-reads") },
+      }),
+    );
+
+    const tx = db.beginTransaction(todos);
+    const draft = tx.insert(todos, { title: "Discard me", done: false });
+
+    await expect(tx.all<Todo>(makeTodoQuery())).resolves.toEqual([draft]);
+
+    tx.rollback();
+
+    await expect(tx.all<Todo>(makeTodoQuery())).rejects.toThrow(/rolled back/i);
+    await expect(db.all<Todo>(makeTodoQuery())).resolves.toEqual([]);
+  });
+
+  it("keeps other open transaction overlays after rolling one transaction back", async () => {
+    const db = track(
+      await createDb({
+        appId: "db-transaction-reads-test",
+        driver: { type: "persistent", dbName: uniqueDbName("tx-rollback-isolated") },
+      }),
+    );
+
+    const aliceTx = db.beginTransaction(todos);
+    const bobTx = db.beginTransaction(todos);
+
+    aliceTx.insert(todos, { title: "Alice draft", done: false });
+    const bobDraft = bobTx.insert(todos, { title: "Bob draft", done: false });
+
+    aliceTx.rollback();
+
+    await expect(db.all<Todo>(makeTodoQuery())).resolves.toEqual([bobDraft]);
+    await expect(bobTx.all<Todo>(makeTodoQuery())).resolves.toEqual([bobDraft]);
+  });
+
+  it("does not write rolled-back transaction data for other clients", async () => {
+    const syncServer = await publishTransactionReadServer("rollback-other-clients");
+    const sharedSecret = generateAuthSecret();
+    const writer = track(
+      await createDb({
+        appId: syncServer.appId,
+        driver: { type: "persistent", dbName: uniqueDbName("tx-rollback-writer") },
+        serverUrl: syncServer.serverUrl,
+        secret: sharedSecret,
+      }),
+    );
+    const reader = track(
+      await createDb({
+        appId: syncServer.appId,
+        driver: { type: "persistent", dbName: uniqueDbName("tx-rollback-reader") },
+        serverUrl: syncServer.serverUrl,
+        secret: sharedSecret,
+      }),
+    );
+
+    const baseTitle = `rollback-base-${Date.now()}`;
+    const baseWrite = writer.insert(todos, { title: baseTitle, done: false });
+    const base = baseWrite.value;
+    await withTimeout(baseWrite.wait({ tier: "local" }), 10000, "base insert did not persist");
+    await waitForQuery(
+      reader,
+      makeTodoQuery(),
+      (rows) => rows.some((row) => row.id === base.id && row.title === baseTitle),
+      "reader should see the baseline row before rollback",
+      20000,
+      "edge",
+    );
+
+    const draftInsertTitle = `rolled-back-insert-${Date.now()}`;
+    const insertTx = writer.beginTransaction(todos);
+    const draft = insertTx.insert(todos, { title: draftInsertTitle, done: true });
+    insertTx.rollback();
+
+    const draftUpdateTitle = `rolled-back-update-${Date.now()}`;
+    const updateTx = writer.beginTransaction(todos);
+    updateTx.update(todos, base.id, { title: draftUpdateTitle });
+    updateTx.rollback();
+
+    const controlTitle = `rollback-control-${Date.now()}`;
+    const controlWrite = writer.insert(todos, { title: controlTitle, done: false });
+    const control = controlWrite.value;
+    await withTimeout(
+      controlWrite.wait({ tier: "local" }),
+      10000,
+      "control insert did not persist",
+    );
+
+    const probe = track(
+      await createDb({
+        appId: syncServer.appId,
+        driver: { type: "persistent", dbName: uniqueDbName("tx-rollback-probe") },
+        serverUrl: syncServer.serverUrl,
+        secret: sharedSecret,
+      }),
+    );
+    const probeRows = await waitForQuery(
+      probe,
+      makeTodoQuery(),
+      (rows) => rows.some((row) => row.id === control.id && row.title === controlTitle),
+      "fresh client should see the post-rollback control row",
+      20000,
+      "edge",
+    );
+
+    expect(probeRows.some((row) => row.id === draft.id)).toBe(false);
+    expect(probeRows.some((row) => row.title === draftInsertTitle)).toBe(false);
+    expect(probeRows.find((row) => row.id === base.id)?.title).toBe(baseTitle);
+    expect(probeRows.some((row) => row.title === draftUpdateTitle)).toBe(false);
+  }, 60000);
 });

--- a/todo/issues/stagingpending-retention-crashed-disconnected-clients.md
+++ b/todo/issues/stagingpending-retention-crashed-disconnected-clients.md
@@ -1,0 +1,13 @@
+# StagingPending Retention With Crashed Or Disconnected Clients
+
+## What
+
+Server-side `StagingPending` transactional rows may need an explicit retention and cleanup policy when the originating client crashes or stays disconnected before commit or rollback.
+
+## Priority
+
+unknown
+
+## Notes
+
+This came up while adding rollback `CancelBatch`: explicit rollback can discard pending rows, but crashes or long disconnections can leave pending transactional rows without a cancel or seal.


### PR DESCRIPTION
## Summary
- Add `rollback()` support on explicit transactions and wire it through client/db runtime APIs.
- Send an explicit `CancelBatch` sync message on rollback so servers discard still-pending transactional rows without creating a rejected settlement.
- Update sync handling, tracing, and transactional tests to cover rollback cleanup, upstream cancellation, and multi-client visibility.

## Testing
- Unit and integration coverage added for rollback behavior in Rust and TypeScript.
- Browser transaction-read integration validates that rolled-back staged rows disappear from ordinary reads and do not leak to other clients.
- Local verification passed for the targeted Rust, TS, browser, formatting, and type-check suites.