### PR TITLE
docs: document permission testing

### DIFF
--- a/.changeset/silly-camels-rule.md
+++ b/.changeset/silly-camels-rule.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Modifies `createPolicyTestApp` to receive an app and permission objects instead of the schema's dir.

--- a/docs/content/docs/auth/permissions.mdx
+++ b/docs/content/docs/auth/permissions.mdx
@@ -202,3 +202,97 @@ When you want to reuse the same check inside a larger rule, compose `isCreator` 
 
 For more dynamic sharing or ownership models, prefer explicit tables and relations rather than
 encoding extra meaning into authorship alone.
+
+## Testing permissions
+
+Jazz provides utilities to test permissions in isolation without testing your whole app's logic.
+
+The `createPolicyTestApp` helper from `jazz-tools/testing` starts an isolated local Jazz server, publishes your app schema
+and compiled permissions, and gives you session-scoped database clients for assertions.
+
+```typescript title="permissions.test.ts"
+import { createPolicyTestApp, type PolicyTestApp } from "jazz-tools/testing";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { app } from "../schema.js";
+import permissions from "../permissions.js";
+
+let testApp: PolicyTestApp;
+
+beforeEach(async () => {
+  testApp = await createPolicyTestApp(app, permissions, expect);
+});
+
+afterEach(async () => {
+  await testApp.shutdown();
+});
+
+describe("todo permissions", () => {
+  it("allows owners to update their own todos", () => {
+    const todo = testApp.seed((db) => {
+      const { value } = db.insert(app.todos, {
+        title: "Buy milk",
+        ownerId: "alice",
+      });
+      return value;
+    });
+
+    const alice = testApp.as({
+      user_id: "alice",
+      claims: {},
+      authMode: "local-first",
+    });
+    const bob = testApp.as({
+      user_id: "bob",
+      claims: {},
+      authMode: "local-first",
+    });
+
+    testApp.expectAllowed(() =>
+      alice.update(app.todos, todo.id, {
+        title: "Buy oat milk",
+      }),
+    );
+
+    testApp.expectDenied(() =>
+      bob.update(app.todos, todo.id, {
+        title: "Buy orange juice",
+      }),
+    );
+  });
+});
+```
+
+`createPolicyTestApp` takes the app created with `defineApp(...)`, the
+permissions object created with `definePermissions(...)`, and your test runner's `expect` function.
+
+The returned `PolicyTestApp` provides:
+
+- `seed(fn)` — run setup writes as an admin, bypassing policy checks
+- `as(session)` — create a `Db` client scoped to a specific session
+- `expectAllowed(fn)` — assert that a write does not throw a policy error
+- `expectDenied(fn)` — assert that a write is rejected by a policy
+- `shutdown()` — stop the local client and server
+
+For read policies, assert on returned rows directly. Denied reads are filtered out rather than
+throwing.
+
+```typescript
+const bob = testApp.as({
+  user_id: "bob",
+  claims: {},
+  authMode: "local-first",
+});
+
+await expect(bob.all(app.todos.where({ id: privateTodo.id }))).resolves.toEqual([]);
+```
+
+If your policies depend on JWT claims, put those values in `session.claims` using the same claim
+names your policy reads.
+
+```typescript
+const invitedUser = testApp.as({
+  user_id: "bob",
+  claims: { join_code: "invite-123" },
+  authMode: "local-first",
+});
+```

--- a/examples/chat-react/package.json
+++ b/examples/chat-react/package.json
@@ -7,7 +7,10 @@
     "dev": "vite",
     "build": "node ../../packages/jazz-tools/dist/cli.js validate && vite build",
     "preview": "vite preview",
-    "test": "vitest run --config vitest.config.browser.ts",
+    "test": "pnpm run test:unit && pnpm run test:browser",
+    "test:unit": "vitest run --config vitest.config.ts",
+    "test:browser": "vitest run --config vitest.config.browser.ts",
+    "test:e2e": "playwright test",
     "walkthrough": "npx @marp-team/marp-cli --html --theme walkthrough/theme-jazz.css walkthrough/jazz-chat.md --preview",
     "walkthrough:shots": "playwright test --config playwright.screenshots.config.ts"
   },

--- a/examples/chat-react/tests/permissions/permissions.test.ts
+++ b/examples/chat-react/tests/permissions/permissions.test.ts
@@ -1,0 +1,155 @@
+import { fileURLToPath } from "node:url";
+import { createPolicyTestApp, type PolicyTestApp } from "jazz-tools/testing";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { app } from "../../schema.js";
+
+const SCHEMA_DIR = fileURLToPath(new URL("../..", import.meta.url));
+
+let testApp: PolicyTestApp;
+
+beforeEach(async () => {
+  testApp = await createPolicyTestApp(SCHEMA_DIR, expect);
+});
+
+afterEach(async () => {
+  await testApp?.shutdown();
+});
+
+describe("chat permissions", () => {
+  it("allows pre-authorized private chat reads via join_code claim", async () => {
+    const privateChat = testApp.seed((db) => {
+      const { value: privateChat } = db.insert(app.chats, {
+        name: "Private room",
+        isPublic: false,
+        createdBy: "alice",
+        joinCode: "invite-123",
+      });
+      db.insert(app.chatMembers, {
+        chatId: privateChat.id,
+        userId: "alice",
+        joinCode: "invite-123",
+      });
+      return privateChat;
+    });
+
+    const bobWithoutClaim = testApp.as({ user_id: "bob", claims: {}, authMode: "local-first" });
+    const bobWithClaim = testApp.as({
+      user_id: "bob",
+      claims: { join_code: "invite-123" },
+      authMode: "local-first",
+    });
+
+    await expect(bobWithoutClaim.all(app.chats.where({ id: privateChat.id }))).resolves.toEqual([]);
+    await expect(bobWithClaim.all(app.chats.where({ id: privateChat.id }))).resolves.toEqual([
+      expect.objectContaining({ id: privateChat.id, name: "Private room" }),
+    ]);
+  });
+
+  it("allows message inserts only for chat members", async () => {
+    const { aliceProfile, bobProfile, privateChat } = testApp.seed((db) => {
+      const { value: aliceProfile } = db.insert(app.profiles, {
+        userId: "alice",
+        name: "Alice",
+      });
+      const { value: bobProfile } = db.insert(app.profiles, {
+        userId: "bob",
+        name: "Bob",
+      });
+      const { value: privateChat } = db.insert(app.chats, {
+        name: "Members only",
+        isPublic: false,
+        createdBy: "alice",
+        joinCode: "invite-456",
+      });
+      db.insert(app.chatMembers, {
+        chatId: privateChat.id,
+        userId: "alice",
+        joinCode: "invite-456",
+      });
+      return { aliceProfile, bobProfile, privateChat };
+    });
+
+    const aliceDb = testApp.as({ user_id: "alice", claims: {}, authMode: "local-first" });
+    const bobDb = testApp.as({ user_id: "bob", claims: {}, authMode: "local-first" });
+
+    testApp.expectAllowed(() =>
+      aliceDb.insert(app.messages, {
+        chatId: privateChat.id,
+        text: "hello from alice",
+        senderId: aliceProfile.id,
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      }),
+    );
+
+    testApp.expectDenied(() =>
+      bobDb.insert(app.messages, {
+        chatId: privateChat.id,
+        text: "hello from bob",
+        senderId: bobProfile.id,
+        createdAt: new Date("2026-01-01T00:00:01.000Z"),
+      }),
+    );
+
+    testApp.seed((db) => {
+      db.insert(app.chatMembers, {
+        chatId: privateChat.id,
+        userId: "bob",
+        joinCode: "invite-456",
+      });
+    });
+
+    testApp.expectAllowed(() =>
+      bobDb.insert(app.messages, {
+        chatId: privateChat.id,
+        text: "hello from bob after joining",
+        senderId: bobProfile.id,
+        createdAt: new Date("2026-01-01T00:00:02.000Z"),
+      }),
+    );
+  });
+
+  it("inherits reaction reads from the parent message/chat chain", async () => {
+    const reaction = testApp.seed((db) => {
+      const { value: aliceProfile } = db.insert(app.profiles, {
+        userId: "alice",
+        name: "Alice",
+      });
+      const { value: privateChat } = db.insert(app.chats, {
+        name: "Uploads",
+        isPublic: false,
+        createdBy: "alice",
+        joinCode: "invite-789",
+      });
+      db.insert(app.chatMembers, {
+        chatId: privateChat.id,
+        userId: "alice",
+        joinCode: "invite-789",
+      });
+      db.insert(app.chatMembers, {
+        chatId: privateChat.id,
+        userId: "bob",
+        joinCode: "invite-789",
+      });
+      const { value: message } = db.insert(app.messages, {
+        chatId: privateChat.id,
+        text: "see attachment",
+        senderId: aliceProfile.id,
+        createdAt: new Date("2026-01-01T00:00:03.000Z"),
+      });
+      const { value: reaction } = db.insert(app.reactions, {
+        messageId: message.id,
+        userId: "alice",
+        emoji: "fire",
+      });
+      return reaction;
+    });
+
+    const bobDb = testApp.as({ user_id: "bob", claims: {}, authMode: "local-first" });
+    const carolDb = testApp.as({ user_id: "carol", claims: {}, authMode: "local-first" });
+
+    await expect(bobDb.all(app.reactions.where({ id: reaction.id }))).resolves.toEqual([
+      expect.objectContaining({ id: reaction.id, emoji: "fire" }),
+    ]);
+    await expect(carolDb.all(app.reactions.where({ id: reaction.id }))).resolves.toEqual([]);
+  });
+});

--- a/examples/chat-react/tests/permissions/permissions.test.ts
+++ b/examples/chat-react/tests/permissions/permissions.test.ts
@@ -1,14 +1,12 @@
-import { fileURLToPath } from "node:url";
 import { createPolicyTestApp, type PolicyTestApp } from "jazz-tools/testing";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { app } from "../../schema.js";
-
-const SCHEMA_DIR = fileURLToPath(new URL("../..", import.meta.url));
+import permissions from "../../permissions.js";
 
 let testApp: PolicyTestApp;
 
 beforeEach(async () => {
-  testApp = await createPolicyTestApp(SCHEMA_DIR, expect);
+  testApp = await createPolicyTestApp(app, permissions, expect);
 });
 
 afterEach(async () => {

--- a/examples/chat-react/tsconfig.json
+++ b/examples/chat-react/tsconfig.json
@@ -13,5 +13,5 @@
     },
     "types": ["node"]
   },
-  "include": ["src", "schema", "e2e", "playwright.config.ts"]
+  "include": ["src", "schema.ts", "tests", "e2e", "playwright.config.ts"]
 }

--- a/examples/chat-react/vitest.config.ts
+++ b/examples/chat-react/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/permissions/**/*.test.ts"],
+    testTimeout: 30000,
+  },
+});

--- a/packages/jazz-tools/src/testing/index.test.ts
+++ b/packages/jazz-tools/src/testing/index.test.ts
@@ -1,20 +1,33 @@
-import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import type { WasmSchema } from "../drivers/types.js";
-import { TestingServer, pushSchemaCatalogue, startLocalJazzServer } from "./index.js";
+import { anyOf, definePermissions } from "../permissions/index.js";
+import { schema as s } from "../index.js";
+import {
+  createPolicyTestApp,
+  TestingServer,
+  pushSchemaCatalogue,
+  startLocalJazzServer,
+} from "./index.js";
 
 const tempRoots: string[] = [];
-const TEST_SCHEMA: WasmSchema = {
-  todos: {
-    columns: [
-      { name: "title", column_type: { type: "Text" }, nullable: false },
-      { name: "done", column_type: { type: "Boolean" }, nullable: false },
-    ],
-  },
+const testSchema = {
+  todos: s.table({
+    title: s.string(),
+    done: s.boolean(),
+    ownerId: s.string().optional(),
+  }),
 };
+type TestSchema = s.Schema<typeof testSchema>;
+const testApp: s.App<TestSchema> = s.defineApp(testSchema);
+const testPermissions = definePermissions(testApp, ({ policy, session }) => {
+  policy.todos.allowRead.where(
+    anyOf([{ ownerId: session.user_id }, { ownerId: { isNull: true } }]),
+  );
+  policy.todos.allowInsert.where({ ownerId: session.user_id });
+});
 
 afterEach(async () => {
   await Promise.all(
@@ -72,18 +85,6 @@ async function getAvailablePort(): Promise<number> {
   });
 }
 
-async function createFailingFakeJazzBinary(stderrText: string): Promise<string> {
-  const rootPath = await createTempRoot("jazz-tools-testing-fake-fail-");
-  const binaryPath = join(rootPath, "fake-jazz-fail");
-  const script = `#!/bin/sh
-echo "${stderrText}" 1>&2
-exit 13
-`;
-  await writeFile(binaryPath, script, "utf8");
-  await chmod(binaryPath, 0o755);
-  return binaryPath;
-}
-
 describe("TestingServer", () => {
   it("starts and is reachable at /health", async () => {
     const server = await TestingServer.start();
@@ -119,14 +120,14 @@ describe("TestingServer", () => {
       const allowed = await fetch(`${server.url}/apps/${server.appId}/admin/schemas`, {
         method: "POST",
         headers: { "content-type": "application/json", "X-Jazz-Admin-Secret": adminSecret },
-        body: JSON.stringify({ schema: TEST_SCHEMA }),
+        body: JSON.stringify({ schema: testApp.wasmSchema }),
       });
       expect(allowed.status).toBe(201);
 
       const denied = await fetch(`${server.url}/apps/${server.appId}/admin/schemas`, {
         method: "POST",
         headers: { "content-type": "application/json", "X-Jazz-Admin-Secret": "wrong-secret" },
-        body: JSON.stringify({ schema: TEST_SCHEMA }),
+        body: JSON.stringify({ schema: testApp.wasmSchema }),
       });
       expect(denied.status).toBe(401);
     } finally {
@@ -245,7 +246,7 @@ describe("startLocalJazzServer", () => {
           "content-type": "application/json",
           "X-Jazz-Admin-Secret": adminSecret,
         },
-        body: JSON.stringify({ schema: TEST_SCHEMA }),
+        body: JSON.stringify({ schema: testApp.wasmSchema }),
       });
 
       expect(response.status).toBe(201);
@@ -271,7 +272,7 @@ describe("startLocalJazzServer", () => {
           "content-type": "application/json",
           "X-Jazz-Admin-Secret": "wrong-admin-secret",
         },
-        body: JSON.stringify({ schema: TEST_SCHEMA }),
+        body: JSON.stringify({ schema: testApp.wasmSchema }),
       });
 
       expect(response.status).toBe(401);
@@ -339,4 +340,31 @@ describe("pushSchemaCatalogue", () => {
       }),
     ).rejects.toThrow();
   }, 10_000);
+});
+
+describe("createPolicyTestApp", () => {
+  it("creates a test app from an app definition and compiled permissions", async () => {
+    const policyTestApp = await createPolicyTestApp(testApp, testPermissions, expect);
+
+    try {
+      const seeded = policyTestApp.seed((db) => {
+        const { value } = db.insert(testApp.todos, {
+          title: "Ship the direct app API",
+          done: false,
+          ownerId: "alice",
+        });
+        return value;
+      });
+
+      const alice = policyTestApp.as({ user_id: "alice", claims: {}, authMode: "local-first" });
+      const bob = policyTestApp.as({ user_id: "bob", claims: {}, authMode: "local-first" });
+
+      await expect(alice.all(testApp.todos.where({ id: seeded.id }))).resolves.toEqual([
+        expect.objectContaining({ id: seeded.id }),
+      ]);
+      await expect(bob.all(testApp.todos.where({ id: seeded.id }))).resolves.toEqual([]);
+    } finally {
+      await policyTestApp.shutdown();
+    }
+  }, 30_000);
 });

--- a/packages/jazz-tools/src/testing/policy-test-app.ts
+++ b/packages/jazz-tools/src/testing/policy-test-app.ts
@@ -1,13 +1,14 @@
-import { access } from "node:fs/promises";
-import { basename, dirname, join } from "node:path";
-import { pathToFileURL } from "node:url";
 import { createJazzContext, Db, Session, type JazzContext } from "../backend/index.js";
+import type { WasmSchema } from "../drivers/types.js";
 import type { CompiledPermissions } from "../permissions/index.js";
 import {
-  pushSchemaCatalogue,
-  startLocalJazzServer,
-  type LocalJazzServerHandle,
-} from "./local-jazz-server.js";
+  fetchPermissionsHead,
+  publishStoredPermissions,
+  publishStoredSchema,
+} from "../runtime/schema-fetch.js";
+import { startLocalJazzServer, type LocalJazzServerHandle } from "./local-jazz-server.js";
+
+type PolicyTestAppSchema = { wasmSchema: WasmSchema };
 
 /**
  * A test app for permissions tests. Simplifies setting up a test app and provides methods
@@ -62,116 +63,43 @@ export class PolicyTestApp {
   }
 }
 
-async function pathExists(path: string): Promise<boolean> {
-  try {
-    await access(path);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function resolvePolicyTestSchemaPaths(schemaDir: string): Promise<{
-  catalogueDir: string;
-  appModulePath: string;
-  permissionsModulePath?: string;
-}> {
-  const directAppModule = join(schemaDir, "app.js");
-  if (await pathExists(directAppModule)) {
-    return {
-      catalogueDir: schemaDir,
-      appModulePath: directAppModule,
-      permissionsModulePath: (await pathExists(join(schemaDir, "permissions.js")))
-        ? join(schemaDir, "permissions.js")
-        : undefined,
-    };
-  }
-
-  for (const extension of ["ts", "js"]) {
-    const directRootSchema = join(schemaDir, `schema.${extension}`);
-    if (await pathExists(directRootSchema)) {
-      const permissionsModulePath = await findPermissionsModulePath(schemaDir);
-      return {
-        catalogueDir: schemaDir,
-        appModulePath: directRootSchema,
-        permissionsModulePath,
-      };
-    }
-  }
-
-  if (basename(schemaDir) === "schema") {
-    const appRoot = dirname(schemaDir);
-    for (const extension of ["ts", "js"]) {
-      const parentRootSchema = join(appRoot, `schema.${extension}`);
-      if (await pathExists(parentRootSchema)) {
-        const permissionsModulePath = await findPermissionsModulePath(appRoot);
-        return {
-          catalogueDir: appRoot,
-          appModulePath: parentRootSchema,
-          permissionsModulePath,
-        };
-      }
-    }
-  }
-
-  throw new Error(
-    `Could not find a schema app near ${schemaDir}. Expected app.js, schema.ts, or schema.js.`,
-  );
-}
-
-async function findPermissionsModulePath(rootDir: string): Promise<string | undefined> {
-  for (const extension of ["ts", "js"]) {
-    const candidate = join(rootDir, `permissions.${extension}`);
-    if (await pathExists(candidate)) {
-      return candidate;
-    }
-  }
-
-  return undefined;
-}
-
 /**
  * Create a new policy test app.
  * This will start a local Jazz server and push the schema catalogue to it.
- * Returns a PolicyTestApp instance that can be used to seed the database and validate policy checks.
- * @param schemaDir - The directory containing the Jazz schema and permissions
- * @param expectFn - The expect function to use for assertions
+ * @returns a {@link PolicyTestApp} instance that can be used to seed the database and validate policy checks.
+ * @param app - The Jazz app created with `defineApp(...)`
+ * @param permissions - The permissions created with `definePermissions(...)`
+ * @param expectFn - The `expect` function to use for assertions (e.g. `expect` from `vitest`)
  */
 export async function createPolicyTestApp(
-  schemaDir: string,
+  app: PolicyTestAppSchema,
+  permissions: CompiledPermissions,
   expectFn: Function,
 ): Promise<PolicyTestApp> {
   const backendSecret = `backend-secret`;
   const adminSecret = `admin-secret`;
-  const resolvedPaths = await resolvePolicyTestSchemaPaths(schemaDir);
   const server = await startLocalJazzServer({
     backendSecret,
     adminSecret,
   });
 
-  await pushSchemaCatalogue({
-    serverUrl: server.url,
+  const { hash: schemaHash } = await publishStoredSchema(server.url, {
     appId: server.appId,
     adminSecret,
-    schemaDir: resolvedPaths.catalogueDir,
-    env: "test",
-    userBranch: "main",
+    schema: app.wasmSchema,
+  });
+  const { head } = await fetchPermissionsHead(server.url, {
+    appId: server.appId,
+    adminSecret,
+  });
+  await publishStoredPermissions(server.url, {
+    appId: server.appId,
+    adminSecret,
+    schemaHash,
+    permissions,
+    expectedParentBundleObjectId: head?.bundleObjectId ?? null,
   });
 
-  const appModule = await import(pathToFileURL(resolvedPaths.appModulePath).href);
-  const app = appModule.default ?? appModule.app ?? appModule;
-  if (!app) {
-    throw new Error(`No schema app module found near ${schemaDir}`);
-  }
-  const permissionsModule = resolvedPaths.permissionsModulePath
-    ? await import(pathToFileURL(resolvedPaths.permissionsModulePath).href)
-    : null;
-  const permissions = (permissionsModule?.default ?? permissionsModule?.permissions) as
-    | CompiledPermissions
-    | undefined;
-  if (!permissions) {
-    throw new Error(`No permissions module found near ${resolvedPaths.appModulePath}`);
-  }
   const jazzContext = createJazzContext({
     appId: server.appId,
     app,

--- a/packages/jazz-tools/src/testing/policy-test-app.ts
+++ b/packages/jazz-tools/src/testing/policy-test-app.ts
@@ -158,7 +158,8 @@ export async function createPolicyTestApp(
     userBranch: "main",
   });
 
-  const app = await import(pathToFileURL(resolvedPaths.appModulePath).href);
+  const appModule = await import(pathToFileURL(resolvedPaths.appModulePath).href);
+  const app = appModule.default ?? appModule.app ?? appModule;
   if (!app) {
     throw new Error(`No schema app module found near ${schemaDir}`);
   }


### PR DESCRIPTION
## Description

Adds a section to the docs about testing permissions (see https://github.com/garden-co/jazz2/pull/360 for additional context), as well as a concrete test suite in the chat-react example.

Also modifies the `createPolicyTestApp` function to receive an app and permission objects instead of the schema's dir.