### PR TITLE
Fix O(n^2) bulk insert in MemoryStorage

### DIFF
--- a/.changeset/memorystorage-row-history-lookup.md
+++ b/.changeset/memorystorage-row-history-lookup.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Speed up per-row history lookups in `MemoryStorage` by nesting the history map by `row_id`, so reads scale with the row's own history rather than the table size.

--- a/crates/jazz-tools/src/storage/memory.rs
+++ b/crates/jazz-tools/src/storage/memory.rs
@@ -15,17 +15,17 @@ type RawTableEntries = BTreeMap<String, Vec<u8>>;
 #[derive(Debug, Clone, Default)]
 struct TableRowHistories {
     visible: BTreeMap<SharedString, BTreeMap<ObjectId, VisibleRowEntry>>,
-    history: BTreeMap<(ObjectId, SharedString, BatchId), StoredRowBatch>,
+    history: BTreeMap<ObjectId, BTreeMap<(SharedString, BatchId), StoredRowBatch>>,
 }
 
 impl TableRowHistories {
     fn history_rows_for(&self, branch: &str, row_id: ObjectId) -> Vec<StoredRowBatch> {
         let mut rows: Vec<_> = self
             .history
-            .iter()
-            .filter(|((history_row_id, history_branch, _), _)| {
-                *history_row_id == row_id && history_branch.as_str() == branch
-            })
+            .get(&row_id)
+            .into_iter()
+            .flat_map(|inner| inner.iter())
+            .filter(|((history_branch, _), _)| history_branch.as_str() == branch)
             .map(|(_, row)| row.clone())
             .collect();
         rows.sort_by_key(|row| (row.updated_at, row.batch_id()));
@@ -139,19 +139,16 @@ impl Storage for MemoryStorage {
                 .entry(table.clone())
                 .or_default()
                 .history
-                .insert(
-                    (row.row_id, row.branch.clone(), row.batch_id()),
-                    row.clone(),
-                );
+                .entry(row.row_id)
+                .or_default()
+                .insert((row.branch.clone(), row.batch_id()), row.clone());
             self.row_history_bytes
                 .entry(table.clone())
                 .or_default()
+                .entry(encoded.row_id)
+                .or_default()
                 .insert(
-                    (
-                        encoded.row_id,
-                        encoded.branch.clone().into(),
-                        encoded.batch_id,
-                    ),
+                    (encoded.branch.clone().into(), encoded.batch_id),
                     encoded.bytes.clone(),
                 );
         }
@@ -228,17 +225,15 @@ impl Storage for MemoryStorage {
                 .entry(table.clone())
                 .or_default()
                 .history
-                .insert(
-                    (row.row_id, row.branch.clone().into(), row.batch_id),
-                    decoded,
-                );
+                .entry(row.row_id)
+                .or_default()
+                .insert((row.branch.clone().into(), row.batch_id), decoded);
             self.row_history_bytes
                 .entry(table.clone())
                 .or_default()
-                .insert(
-                    (row.row_id, row.branch.clone().into(), row.batch_id),
-                    row.bytes.clone(),
-                );
+                .entry(row.row_id)
+                .or_default()
+                .insert((row.branch.clone().into(), row.batch_id), row.bytes.clone());
         }
 
         for row in visible_rows {
@@ -474,10 +469,11 @@ impl Storage for MemoryStorage {
         {
             let regions = self.row_histories.entry(table.to_string()).or_default();
             for row in rows {
-                regions.history.insert(
-                    (row.row_id, row.branch.clone(), row.batch_id()),
-                    row.clone(),
-                );
+                regions
+                    .history
+                    .entry(row.row_id)
+                    .or_default()
+                    .insert((row.branch.clone(), row.batch_id()), row.clone());
             }
         }
         for row in &encoded_rows {
@@ -500,10 +496,10 @@ impl Storage for MemoryStorage {
         }
         let raw_regions = self.row_history_bytes.entry(table.to_string()).or_default();
         for row in encoded_rows {
-            raw_regions.insert(
-                (row.row_id, row.branch.clone().into(), row.batch_id),
-                row.bytes,
-            );
+            raw_regions
+                .entry(row.row_id)
+                .or_default()
+                .insert((row.branch.clone().into(), row.batch_id), row.bytes);
         }
         Ok(())
     }
@@ -515,8 +511,8 @@ impl Storage for MemoryStorage {
     ) -> Result<(), StorageError> {
         let regions = self.row_history_bytes.entry(table.to_string()).or_default();
         for row in rows {
-            regions.insert(
-                (row.row_id, row.branch.to_string().into(), row.batch_id),
+            regions.entry(row.row_id).or_default().insert(
+                (row.branch.to_string().into(), row.batch_id),
                 row.bytes.to_vec(),
             );
         }
@@ -593,7 +589,11 @@ impl Storage for MemoryStorage {
             };
 
             let mut affected_visible_rows = HashSet::new();
-            for row in regions.history.values_mut() {
+            for row in regions
+                .history
+                .values_mut()
+                .flat_map(|inner| inner.values_mut())
+            {
                 if row.batch_id == batch_id {
                     if let Some(state) = state {
                         row.state = state;
@@ -861,9 +861,10 @@ impl Storage for MemoryStorage {
 
         let mut rows: Vec<_> = regions
             .history
-            .iter()
-            .filter(|((history_row_id, _, _), _)| *history_row_id == row_id)
-            .map(|(_, row)| row.clone())
+            .get(&row_id)
+            .into_iter()
+            .flat_map(|inner| inner.values())
+            .cloned()
             .collect();
         rows.sort_by_key(|row| (row.branch.clone(), row.updated_at, row.batch_id()));
         Ok(rows)
@@ -878,7 +879,8 @@ impl Storage for MemoryStorage {
     ) -> Result<Option<Vec<u8>>, StorageError> {
         Ok(self.row_history_bytes.get(table).and_then(|regions| {
             regions
-                .get(&(row_id, branch.to_string().into(), batch_id))
+                .get(&row_id)
+                .and_then(|inner| inner.get(&(branch.to_string().into(), batch_id)))
                 .cloned()
         }))
     }
@@ -893,14 +895,15 @@ impl Storage for MemoryStorage {
         };
 
         Ok(match scan {
-            HistoryScan::Branch | HistoryScan::AsOf { .. } => {
-                regions.values().cloned().collect::<Vec<_>>()
-            }
-            HistoryScan::Row { row_id } => regions
-                .iter()
-                .filter(|((history_row_id, _, _), _)| *history_row_id == row_id)
-                .map(|(_, bytes)| bytes.clone())
+            HistoryScan::Branch | HistoryScan::AsOf { .. } => regions
+                .values()
+                .flat_map(|inner| inner.values())
+                .cloned()
                 .collect::<Vec<_>>(),
+            HistoryScan::Row { row_id } => regions
+                .get(&row_id)
+                .map(|inner| inner.values().cloned().collect::<Vec<_>>())
+                .unwrap_or_default(),
         })
     }
 
@@ -955,7 +958,8 @@ impl Storage for MemoryStorage {
         Ok(self.row_histories.get(table).and_then(|regions| {
             regions
                 .history
-                .get(&(row_id, branch.to_string().into(), batch_id))
+                .get(&row_id)
+                .and_then(|inner| inner.get(&(branch.to_string().into(), batch_id)))
                 .cloned()
         }))
     }
@@ -984,7 +988,8 @@ impl Storage for MemoryStorage {
             .and_then(|regions| {
                 regions
                     .history
-                    .get(&(row_id, branch.to_string().into(), batch_id))
+                    .get(&row_id)
+                    .and_then(|inner| inner.get(&(branch.to_string().into(), batch_id)))
             })
             .map(QueryRowBatch::from))
     }
@@ -1002,30 +1007,36 @@ impl Storage for MemoryStorage {
         let mut rows: Vec<StoredRowBatch> = match scan {
             HistoryScan::Branch => regions
                 .history
-                .iter()
-                .filter(|(_, row)| row.branch == branch)
-                .map(|(_, row)| row.clone())
+                .values()
+                .flat_map(|inner| inner.values())
+                .filter(|row| row.branch == branch)
+                .cloned()
                 .collect(),
             HistoryScan::Row { row_id } => regions
                 .history
-                .iter()
-                .filter(|((history_row_id, _, _), row)| {
-                    row.branch == branch && *history_row_id == row_id
+                .get(&row_id)
+                .map(|inner| {
+                    inner
+                        .values()
+                        .filter(|row| row.branch == branch)
+                        .cloned()
+                        .collect()
                 })
-                .map(|(_, row)| row.clone())
-                .collect(),
+                .unwrap_or_default(),
             HistoryScan::AsOf { ts } => {
                 let mut latest_per_row: BTreeMap<ObjectId, StoredRowBatch> = BTreeMap::new();
-                for ((row_id, _, _), row) in &regions.history {
-                    if row.branch != branch || row.updated_at > ts || !row.state.is_visible() {
-                        continue;
-                    }
-                    match latest_per_row.get(row_id) {
-                        Some(existing)
-                            if (existing.updated_at, existing.batch_id())
-                                >= (row.updated_at, row.batch_id()) => {}
-                        _ => {
-                            latest_per_row.insert(*row_id, row.clone());
+                for (row_id, inner) in &regions.history {
+                    for row in inner.values() {
+                        if row.branch != branch || row.updated_at > ts || !row.state.is_visible() {
+                            continue;
+                        }
+                        match latest_per_row.get(row_id) {
+                            Some(existing)
+                                if (existing.updated_at, existing.batch_id())
+                                    >= (row.updated_at, row.batch_id()) => {}
+                            _ => {
+                                latest_per_row.insert(*row_id, row.clone());
+                            }
                         }
                     }
                 }

--- a/crates/jazz-tools/src/storage/mod.rs
+++ b/crates/jazz-tools/src/storage/mod.rs
@@ -58,8 +58,7 @@ use crate::sync_manager::DurabilityTier;
 // Storage Types
 // ============================================================================
 
-type EncodedHistoryRowKey = (ObjectId, SharedString, BatchId);
-type EncodedTableRowHistories = BTreeMap<EncodedHistoryRowKey, Vec<u8>>;
+type EncodedTableRowHistories = BTreeMap<ObjectId, BTreeMap<(SharedString, BatchId), Vec<u8>>>;
 
 /// Errors from storage operations.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
## Before / after

10k projects + 50k todos via `stress-tests/todo-react`:

| total rows | before | after | speedup |
|---|---:|---:|---:|
| 500 | 78 ms | 64.5 ms | ~1× |
| 10,000 | 162 ms | 35 ms | 4.6× |
| 25,000 | 467 ms | 47.2 ms | 9.9× |
| 39,500 | 1,629 ms | ~46 ms | 35× |
| 46,000 | 2,685 ms | 47.5 ms | 57× |

End-to-end wall-clock for the full 60k-insert run: **100s+ and still growing → 15s flat**.

`ms/row` was climbing from 0.13 → 5.37 (and rising). Now it stays at ~0.09 across the whole run.

## What was wrong

`MemoryStorage` keeps row history in a `BTreeMap` keyed by `(row_id, branch, batch_id)`.

To find every history entry for a single row, the code did this:

```rust
self.history
    .iter()
    .filter(|((id, _, _), _)| *id == row_id)
```

That walks **every single entry** in the map, even though we only care about one `row_id`. With 100 rows in the table that's fine. With 50,000 rows it's painfully slow.

And this lookup runs on every server-confirmed insert: when you insert a row, the runtime sends a `RowBatchCreated` to the server, the server replies with `RowBatchStateChanged`, and processing that reply does the lookup above. So:

- 1 insert → 1 lookup that touches every row already in the table
- n inserts → n × (touch every row) = O(n²)

That's why generation got slower the more rows you'd already added — each new insert had to walk past everything that came before it.

## The fix

Nest the BTreeMap by `row_id`:

```rust
// before
history: BTreeMap<(ObjectId, SharedString, BatchId), StoredRowBatch>

// after
history: BTreeMap<ObjectId, BTreeMap<(SharedString, BatchId), StoredRowBatch>>
```

Now "give me everything for row X" is a single `history.get(&row_id)` — a direct hash-style lookup into the outer map. The cost no longer depends on how many *other* rows are in the table.

This mirrors how `visible:` is already organized in the same struct (outer key = the indexable thing, inner map = the rest), so the file ends up more consistent with itself, not less.

The same restructuring applies to `row_history_bytes` (the encoded-bytes mirror of `history`), since it has the same key shape and the same bug.

All 67 `storage::memory::` unit tests still pass.