### PR TITLE
[codex] Defer parented update permission checks

### DIFF
--- a/.changeset/defer-parented-update-permissions.md
+++ b/.changeset/defer-parented-update-permissions.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Defer synced parented row updates until their old content is visible before evaluating update `USING` policies.

--- a/crates/jazz-tools/src/query_manager/rebac_tests.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests.rs
@@ -372,6 +372,18 @@ fn authorship_permissions_schema() -> Schema {
     schema
 }
 
+fn permissive_cursors_schema() -> Schema {
+    let mut schema = Schema::new();
+    let policies = TablePolicies::new()
+        .with_insert(PolicyExpr::True)
+        .with_update(Some(PolicyExpr::True), PolicyExpr::True);
+    schema.insert(
+        TableName::new("cursors"),
+        TableSchema::with_policies(provenance_notes_descriptor(), policies),
+    );
+    schema
+}
+
 fn query_rows(
     qm: &mut QueryManager,
     storage: &mut MemoryStorage,
@@ -430,6 +442,226 @@ fn recursive_folders_schema(max_depth: Option<usize>) -> Schema {
     );
 
     schema
+}
+
+#[test]
+fn parented_update_waits_for_old_content_before_using_policy_evaluation() {
+    let schema = permissive_cursors_schema();
+    let branch = ComposedBranchName::new("dev", SchemaHash::compute(&schema), "main")
+        .to_branch_name()
+        .as_str()
+        .to_string();
+    let mut qm = create_query_manager(SyncManager::new(), schema);
+    let mut storage = MemoryStorage::new();
+    let alice = ClientId::new();
+    connect_client(&mut qm, &storage, alice);
+    qm.sync_manager_mut()
+        .set_client_session(alice, Session::new("alice"));
+
+    let cursor_id = ObjectId::new();
+    let metadata = HashMap::from([(MetadataKey::Table.to_string(), "cursors".to_string())]);
+    let parent = stored_row_commit(
+        smallvec![],
+        encode_row(
+            &provenance_notes_descriptor(),
+            &[Value::Text("first cursor position".into())],
+        )
+        .expect("parent cursor row should encode"),
+        1_000,
+        "alice",
+        None,
+    );
+    let child = stored_row_commit(
+        smallvec![parent.batch_id],
+        encode_row(
+            &provenance_notes_descriptor(),
+            &[Value::Text("second cursor position".into())],
+        )
+        .expect("child cursor row should encode"),
+        1_100,
+        "alice",
+        None,
+    );
+
+    qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(alice),
+        payload: row_batch_created_payload(
+            cursor_id,
+            &branch,
+            Some(RowMetadata {
+                id: cursor_id,
+                metadata: metadata.clone(),
+            }),
+            &child,
+        ),
+    });
+    qm.process(&mut storage);
+
+    let outbox = qm.sync_manager_mut().take_outbox();
+    assert!(
+        !client_write_was_rejected(&outbox, alice, cursor_id, &branch, child.batch_id),
+        "permissive update policy should not reject before the parent row has arrived: {outbox:?}"
+    );
+    let pending = qm.sync_manager_mut().take_pending_permission_checks();
+    assert_eq!(
+        pending.len(),
+        1,
+        "parented update should stay pending until old content is visible"
+    );
+    qm.sync_manager_mut()
+        .requeue_pending_permission_checks(pending);
+
+    qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(alice),
+        payload: row_batch_created_payload(
+            cursor_id,
+            &branch,
+            Some(RowMetadata {
+                id: cursor_id,
+                metadata,
+            }),
+            &parent,
+        ),
+    });
+    qm.process(&mut storage);
+    qm.process(&mut storage);
+
+    let outbox = qm.sync_manager_mut().take_outbox();
+    assert!(
+        !client_write_was_rejected(&outbox, alice, cursor_id, &branch, child.batch_id),
+        "parented update should be approved after the parent supplies old content: {outbox:?}"
+    );
+    let visible = storage
+        .load_visible_region_row("cursors", &branch, cursor_id)
+        .expect("visible row lookup should succeed")
+        .expect("cursor row should be visible");
+    assert_eq!(visible.batch_id(), child.batch_id);
+}
+
+#[test]
+fn parented_update_waits_for_declared_parent_not_unrelated_visible_content() {
+    let schema = permissive_cursors_schema();
+    let branch = ComposedBranchName::new("dev", SchemaHash::compute(&schema), "main")
+        .to_branch_name()
+        .as_str()
+        .to_string();
+    let mut qm = create_query_manager(SyncManager::new(), schema);
+    let mut storage = MemoryStorage::new();
+    let alice = ClientId::new();
+    connect_client(&mut qm, &storage, alice);
+    qm.sync_manager_mut()
+        .set_client_session(alice, Session::new("alice"));
+
+    let cursor_id = ObjectId::new();
+    let metadata = HashMap::from([(MetadataKey::Table.to_string(), "cursors".to_string())]);
+    let unrelated_visible = stored_row_commit(
+        smallvec![],
+        encode_row(
+            &provenance_notes_descriptor(),
+            &[Value::Text("unrelated visible cursor position".into())],
+        )
+        .expect("unrelated cursor row should encode"),
+        1_000,
+        "alice",
+        None,
+    );
+    qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(alice),
+        payload: row_batch_created_payload(
+            cursor_id,
+            &branch,
+            Some(RowMetadata {
+                id: cursor_id,
+                metadata: metadata.clone(),
+            }),
+            &unrelated_visible,
+        ),
+    });
+    qm.process(&mut storage);
+    qm.sync_manager_mut().take_outbox();
+
+    let declared_parent_batch_id = BatchId::new();
+    let child = stored_row_commit(
+        smallvec![declared_parent_batch_id],
+        encode_row(
+            &provenance_notes_descriptor(),
+            &[Value::Text("child cursor position".into())],
+        )
+        .expect("child cursor row should encode"),
+        1_200,
+        "alice",
+        None,
+    );
+    qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(alice),
+        payload: row_batch_created_payload(
+            cursor_id,
+            &branch,
+            Some(RowMetadata {
+                id: cursor_id,
+                metadata: metadata.clone(),
+            }),
+            &child,
+        ),
+    });
+    qm.process(&mut storage);
+
+    let outbox = qm.sync_manager_mut().take_outbox();
+    assert!(
+        !client_write_was_rejected(&outbox, alice, cursor_id, &branch, child.batch_id),
+        "parented update should wait for its declared parent, not reject: {outbox:?}"
+    );
+    let pending = qm.sync_manager_mut().take_pending_permission_checks();
+    assert_eq!(
+        pending.len(),
+        1,
+        "unrelated visible content must not satisfy the child update's old-content requirement"
+    );
+    let visible = storage
+        .load_visible_region_row("cursors", &branch, cursor_id)
+        .expect("visible row lookup should succeed")
+        .expect("unrelated cursor row should still be visible");
+    assert_eq!(visible.batch_id(), unrelated_visible.batch_id);
+    qm.sync_manager_mut()
+        .requeue_pending_permission_checks(pending);
+
+    let declared_parent = IncomingRowBatch {
+        batch_id: declared_parent_batch_id,
+        parents: smallvec![],
+        content: encode_row(
+            &provenance_notes_descriptor(),
+            &[Value::Text("declared parent cursor position".into())],
+        )
+        .expect("declared parent cursor row should encode"),
+        timestamp: 1_100,
+        author: "alice".into(),
+        delete_kind: None,
+    };
+    qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(alice),
+        payload: row_batch_created_payload(
+            cursor_id,
+            &branch,
+            Some(RowMetadata {
+                id: cursor_id,
+                metadata,
+            }),
+            &declared_parent,
+        ),
+    });
+    qm.process(&mut storage);
+    qm.process(&mut storage);
+
+    let outbox = qm.sync_manager_mut().take_outbox();
+    assert!(
+        !client_write_was_rejected(&outbox, alice, cursor_id, &branch, child.batch_id),
+        "parented update should be approved after its declared parent is visible: {outbox:?}"
+    );
+    let visible = storage
+        .load_visible_region_row("cursors", &branch, cursor_id)
+        .expect("visible row lookup should succeed")
+        .expect("child cursor row should be visible");
+    assert_eq!(visible.batch_id(), child.batch_id);
 }
 
 /// Helper to encode a document row

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant};
 use crate::metadata::{MetadataKey, RowProvenance};
 use crate::object::{BranchName, ObjectId};
 use crate::query_manager::graph_nodes::policy_eval::PolicyContextEvaluator;
-use crate::row_histories::BatchId;
+use crate::row_histories::{BatchId, StoredRowBatch};
 use crate::schema_manager::LensTransformer;
 use crate::storage::Storage;
 use crate::sync_manager::{
@@ -102,6 +102,71 @@ impl QueryManager {
             }
             _ => None,
         }
+    }
+
+    fn payload_has_parents(payload: &SyncPayload) -> bool {
+        match payload {
+            SyncPayload::RowBatchCreated { row, .. } | SyncPayload::RowBatchNeeded { row, .. } => {
+                !row.parents.is_empty()
+            }
+            _ => false,
+        }
+    }
+
+    fn payload_pre_batch_visible_row(
+        storage: &dyn Storage,
+        table: &str,
+        payload: &SyncPayload,
+    ) -> Option<StoredRowBatch> {
+        let row = match payload {
+            SyncPayload::RowBatchCreated { row, .. } | SyncPayload::RowBatchNeeded { row, .. } => {
+                row
+            }
+            _ => return None,
+        };
+        if row.parents.is_empty() {
+            return None;
+        }
+
+        let context =
+            crate::storage::resolve_history_row_write_context(storage, table, row).ok()?;
+        let history_rows = storage.scan_history_row_batches(table, row.row_id).ok()?;
+        let visible_rows = history_rows
+            .into_iter()
+            .filter(|candidate| {
+                candidate.branch.as_str() == row.branch.as_str()
+                    && candidate.batch_id != row.batch_id
+                    && candidate.state.is_visible()
+            })
+            .collect::<Vec<_>>();
+        let visible_rows_by_batch = visible_rows
+            .iter()
+            .cloned()
+            .map(|candidate| (candidate.batch_id(), candidate))
+            .collect::<HashMap<_, _>>();
+
+        let mut included_batch_ids = HashSet::new();
+        let mut frontier = row.parents.iter().copied().collect::<Vec<_>>();
+        while let Some(batch_id) = frontier.pop() {
+            if !included_batch_ids.insert(batch_id) {
+                continue;
+            }
+            if let Some(parent_row) = visible_rows_by_batch.get(&batch_id) {
+                frontier.extend(parent_row.parents.iter().copied());
+            }
+        }
+
+        let pre_batch_rows = visible_rows
+            .into_iter()
+            .filter(|candidate| included_batch_ids.contains(&candidate.batch_id()))
+            .collect::<Vec<_>>();
+        crate::row_histories::visible_row_preview_from_history_rows(
+            context.user_descriptor.as_ref(),
+            &pre_batch_rows,
+            None,
+        )
+        .ok()
+        .flatten()
     }
 
     pub(super) fn build_server_subscription_context(
@@ -1432,7 +1497,7 @@ impl QueryManager {
     fn evaluate_update_permission<H: Storage>(
         &mut self,
         storage: &mut H,
-        check: PendingPermissionCheck,
+        mut check: PendingPermissionCheck,
         request: UpdatePermissionRequest<'_>,
     ) {
         let UpdatePermissionRequest {
@@ -1467,7 +1532,17 @@ impl QueryManager {
         let using_policy = table_schema.policies.update_using_policy();
         let check_policy = table_schema.policies.update_check_policy();
         let source_branch_schema_map = self.branch_schema_map.clone();
-        let old_provenance = self.current_row_provenance(storage, object_id, branch_name);
+        let pre_batch_old_row =
+            Self::payload_pre_batch_visible_row(storage, table_name.as_str(), &check.payload);
+        if check.old_content.is_none()
+            && let Some(row) = pre_batch_old_row.as_ref()
+        {
+            check.old_content = Some(row.data.as_ref().to_vec());
+        }
+        let old_provenance = pre_batch_old_row
+            .as_ref()
+            .map(|row| row.row_provenance())
+            .or_else(|| self.current_row_provenance(storage, object_id, branch_name));
         let new_provenance = Self::payload_row_provenance(&check.payload);
 
         if using_policy.is_none() && check_policy.is_none() {
@@ -1490,6 +1565,25 @@ impl QueryManager {
             let old_content = match check.old_content.as_ref() {
                 Some(c) if !c.is_empty() => c,
                 _ => {
+                    if Self::payload_has_parents(&check.payload) {
+                        let wait_started_at = check
+                            .schema_wait_started_at
+                            .get_or_insert_with(Instant::now);
+                        let wait_elapsed = wait_started_at.elapsed();
+
+                        if wait_elapsed < SCHEMA_RESOLUTION_TIMEOUT {
+                            tracing::debug!(
+                                table = %table_name,
+                                branch = %branch_name,
+                                object_id = %object_id,
+                                waited_ms = wait_elapsed.as_millis() as u64,
+                                "deferring update permission check until old content becomes visible"
+                            );
+                            self.sync_manager
+                                .requeue_pending_permission_checks(vec![check]);
+                            return;
+                        }
+                    }
                     let reason = format!(
                         "Update denied by USING policy on table {} - no old content",
                         table_name.0

--- a/crates/jazz-tools/src/runtime_core/tests/basic.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/basic.rs
@@ -62,6 +62,133 @@ fn add_server_rehydrates_visible_rows_from_storage_after_restart() {
 }
 
 #[test]
+fn rapid_updates_sync_every_parent_batch_to_server_outbox() {
+    let mut core = create_test_runtime();
+    let server_id = ServerId::new();
+    core.add_server(server_id);
+    core.sync_sender().take();
+
+    let user_id = ObjectId::new();
+    let ((row_object_id, _), insert_batch_id) = core
+        .insert("users", user_insert_values(user_id, "cursor-0"), None)
+        .expect("initial cursor insert should succeed");
+
+    let update_count = 1_000;
+    let mut expected_batch_ids = vec![insert_batch_id];
+    for idx in 1..=update_count {
+        let batch_id = core
+            .update(
+                row_object_id,
+                vec![("name".to_string(), Value::Text(format!("cursor-{idx}")))],
+                None,
+            )
+            .expect("rapid cursor update should succeed");
+        expected_batch_ids.push(batch_id);
+    }
+
+    core.batched_tick();
+    let outbox = core.sync_sender().take();
+    let cursor_rows = outbox
+        .iter()
+        .filter_map(|entry| match &entry.payload {
+            SyncPayload::RowBatchCreated { row, .. } if row.row_id == row_object_id => Some(row),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        cursor_rows.len(),
+        expected_batch_ids.len(),
+        "client-to-server sync should send every rapid cursor row version, not only the newest"
+    );
+
+    let mut seen = std::collections::HashSet::new();
+    for row in cursor_rows {
+        for parent in row.parents.iter().copied() {
+            assert!(
+                seen.contains(&parent),
+                "outgoing row batch {:?} referenced parent {:?} before that parent was sent; outbox contained {} row batches",
+                row.batch_id,
+                parent,
+                expected_batch_ids.len()
+            );
+        }
+        assert!(
+            seen.insert(row.batch_id),
+            "same row batch {:?} should not be sent twice in one rapid update burst",
+            row.batch_id
+        );
+    }
+
+    for batch_id in expected_batch_ids {
+        assert!(
+            seen.contains(&batch_id),
+            "locally authored batch {batch_id:?} was not sent to the server"
+        );
+    }
+}
+
+#[test]
+fn rapid_offline_updates_full_sync_every_parent_batch_on_reconnect() {
+    let mut core = create_test_runtime();
+
+    let user_id = ObjectId::new();
+    let ((row_object_id, _), insert_batch_id) = core
+        .insert("users", user_insert_values(user_id, "cursor-0"), None)
+        .expect("initial offline cursor insert should succeed");
+
+    let update_count = 1_000;
+    let mut expected_batch_ids = vec![insert_batch_id];
+    for idx in 1..=update_count {
+        let batch_id = core
+            .update(
+                row_object_id,
+                vec![("name".to_string(), Value::Text(format!("cursor-{idx}")))],
+                None,
+            )
+            .expect("rapid offline cursor update should succeed");
+        expected_batch_ids.push(batch_id);
+    }
+
+    let server_id = ServerId::new();
+    core.add_server(server_id);
+    core.batched_tick();
+
+    let outbox = core.sync_sender().take();
+    let cursor_rows = outbox
+        .iter()
+        .filter_map(|entry| match &entry.payload {
+            SyncPayload::RowBatchCreated { row, .. } if row.row_id == row_object_id => Some(row),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        cursor_rows.len(),
+        expected_batch_ids.len(),
+        "full sync should replay every rapid offline cursor row version, not only the newest"
+    );
+
+    let mut seen = std::collections::HashSet::new();
+    for row in cursor_rows {
+        for parent in row.parents.iter().copied() {
+            assert!(
+                seen.contains(&parent),
+                "full sync emitted row batch {:?} before its parent {:?}",
+                row.batch_id,
+                parent
+            );
+        }
+        seen.insert(row.batch_id);
+    }
+
+    for batch_id in expected_batch_ids {
+        assert!(
+            seen.contains(&batch_id),
+            "locally authored offline batch {batch_id:?} was not replayed on reconnect"
+        );
+    }
+}
+
+#[test]
 fn test_runtime_core_insert_materializes_schema_defaults() {
     let mut core = create_runtime_with_schema(defaulted_todos_schema(), "todos-with-defaults");
 


### PR DESCRIPTION
## What changed

- Added regression tests for synced parented row updates that arrive before their parent row is visible on the server.
- Added coverage that an unrelated visible row does not satisfy an update's old-content requirement; the evaluator waits for the update's declared parent frontier.
- Added high-write-load RuntimeCore tests for realtime-cursor-style bursts, covering both connected client-to-server sync and offline full-sync replay on reconnect.
- Rehydrate missing update `old_content` from the payload's pre-batch parent frontier when possible before evaluating `USING` policies.
- Requeue parented update permission checks while declared parent content is still unavailable, instead of rejecting immediately.
- Added a patch changeset for `jazz-tools`.

## Why

Parented row batches are classified as updates, but a server may be missing the exact parent/old row needed for an update `USING` policy. The update permission evaluator previously rejected any explicit `USING` policy before evaluating it when `old_content` was missing, even for permissive `USING true` policies.

The fix now waits for the exact old row implied by the incoming batch's parent frontier, rather than accepting any currently visible row for the same object/branch.

The high-load cursor-style repro did not confirm that clients only send the newest row version: in the tested Rust runtime paths, rapid connected updates and offline replay both emitted all 1,001 row batches with parents appearing before children.

## Validation

- `cargo test -p jazz-tools parented_update -- --nocapture`
- `cargo test -p jazz-tools rapid_ -- --nocapture`
- `cargo test -p jazz-tools query_manager::rebac_tests -- --nocapture`
- `pnpm lint`
- pre-commit hook: clippy, rustfmt