### PR TITLE
Auto-reload Next.js apps when the schema is pushed

### DIFF
--- a/.changeset/next-schema-reload.md
+++ b/.changeset/next-schema-reload.md
@@ -1,0 +1,8 @@
+---
+"jazz-tools": patch
+---
+
+Auto-reload the browser when the schema changes in a Next.js app.
+`withJazz` writes the live schema hash into a generated module that the
+React provider depends on, so Turbopack and Webpack reload the page
+whenever the schema is pushed — no consumer-side wiring required.

--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -52,6 +52,10 @@
       "types": "./dist/dev/index.d.ts",
       "default": "./dist/dev/index.js"
     },
+    "./_dev/schema-hash": {
+      "types": "./dist/_dev/schema-hash.d.ts",
+      "default": "./dist/_dev/schema-hash.js"
+    },
     "./dev/next": {
       "types": "./dist/dev/next.d.ts",
       "default": "./dist/dev/next.js"

--- a/packages/jazz-tools/src/_dev/schema-hash.ts
+++ b/packages/jazz-tools/src/_dev/schema-hash.ts
@@ -1,0 +1,1 @@
+export const HASH = "";

--- a/packages/jazz-tools/src/dev/managed-runtime.ts
+++ b/packages/jazz-tools/src/dev/managed-runtime.ts
@@ -143,8 +143,8 @@ export interface InitializeOptions extends JazzPluginOptions {
   envDir?: string;
   /** Called when a schema watch push fails after initialisation. Use this to forward errors to e.g. Vite's HMR overlay. */
   onSchemaError?: (error: Error) => void;
-  /** Called when the schema watcher successfully pushes an updated schema. Use this to e.g. trigger a Vite full-reload. */
-  onSchemaPush?: (hash: string) => void;
+  /** Called when the schema watcher successfully pushes an updated schema. Use this to e.g. trigger a Vite full-reload. The initial dev-server push awaits this callback so plugins can write generated artefacts before the host bundler starts compiling. */
+  onSchemaPush?: (hash: string) => void | Promise<void>;
 }
 
 export class ManagedDevRuntime {
@@ -329,8 +329,14 @@ export class ManagedDevRuntime {
 
         const { pushSchemaCatalogue } = await import("./dev-server.js");
         try {
-          await pushSchemaCatalogue({ serverUrl, appId, adminSecret, schemaDir });
+          const initialPush = await pushSchemaCatalogue({
+            serverUrl,
+            appId,
+            adminSecret,
+            schemaDir,
+          });
           console.log(`${LOG_PREFIX} schema published`);
+          await options.onSchemaPush?.(initialPush.hash);
         } catch (error) {
           if (usesExistingServer && isSchemaPushNetworkError(error)) {
             warnInitialSchemaPushSkipped({
@@ -349,9 +355,9 @@ export class ManagedDevRuntime {
           serverUrl,
           appId,
           adminSecret,
-          onPush: (hash) => {
+          onPush: async (hash) => {
             console.log(`${LOG_PREFIX} schema updated (${hash.slice(0, 12)})`);
-            options.onSchemaPush?.(hash);
+            await options.onSchemaPush?.(hash);
           },
           onError: (error) => {
             console.error(`${LOG_PREFIX} schema push failed:`, error.message);

--- a/packages/jazz-tools/src/dev/next.test.ts
+++ b/packages/jazz-tools/src/dev/next.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { access, writeFile } from "node:fs/promises";
+import { access, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createTempRootTracker, getAvailablePort, todoSchema } from "./test-helpers.js";
 import * as devServer from "./dev-server.js";
+import * as schemaWatcher from "./schema-watcher.js";
 import { __resetJazzNextPluginForTests, withJazz, type NextConfigLike } from "./next.js";
 
 const dev = await import("./index.js");
@@ -281,6 +282,94 @@ describe("withJazz", () => {
       "conflicting Jazz dev runtime configuration",
     );
   }, 30_000);
+
+  it("writes a dev schema-hash stub on startup and rewrites it on each schema push", async () => {
+    vi.spyOn(devServer, "startLocalJazzServer").mockResolvedValue({
+      appId: "00000000-0000-0000-0000-000000000070",
+      port: 19870,
+      url: "http://127.0.0.1:19870",
+      dataDir: undefined as unknown as string,
+      stop: vi.fn().mockResolvedValue(undefined),
+    });
+    const pushSchemaCatalogue = vi
+      .spyOn(devServer, "pushSchemaCatalogue")
+      .mockResolvedValue({ hash: "1111111111111111aaaaaaaaaaaaaaaaaaaaaaaa" });
+    let capturedOnPush: ((hash: string) => void) | undefined;
+    vi.spyOn(schemaWatcher, "watchSchema").mockImplementation((opts) => {
+      capturedOnPush = opts.onPush;
+      return { close: vi.fn() };
+    });
+
+    const appRoot = await tempRoots.create("jazz-next-schema-hash-");
+    const schemaDir = appRoot;
+    await writeFile(join(schemaDir, "schema.ts"), todoSchema());
+
+    const wrapped = withJazz(
+      {},
+      {
+        appRoot,
+        schemaDir,
+        server: { port: 19870, adminSecret: "next-schema-hash-admin" },
+      },
+    );
+
+    await resolveWrappedConfig(wrapped, DEVELOPMENT_PHASE);
+
+    const stubPath = join(appRoot, "node_modules", ".cache", "jazz", "schema-hash.js");
+    const initial = await readFile(stubPath, "utf8");
+    expect(initial).toContain("1111111111111111aaaaaaaaaaaaaaaaaaaaaaaa");
+
+    expect(capturedOnPush).toBeDefined();
+    await capturedOnPush!("2222222222222222bbbbbbbbbbbbbbbbbbbbbbbb");
+
+    const updated = await readFile(stubPath, "utf8");
+    expect(updated).toContain("2222222222222222bbbbbbbbbbbbbbbbbbbbbbbb");
+    expect(updated).not.toContain("1111111111111111aaaaaaaaaaaaaaaaaaaaaaaa");
+
+    expect(pushSchemaCatalogue).toHaveBeenCalled();
+  });
+
+  it("aliases jazz-tools/_dev/schema-hash to the generated stub for both webpack and turbopack", async () => {
+    vi.spyOn(devServer, "startLocalJazzServer").mockResolvedValue({
+      appId: "00000000-0000-0000-0000-000000000080",
+      port: 19880,
+      url: "http://127.0.0.1:19880",
+      dataDir: undefined as unknown as string,
+      stop: vi.fn().mockResolvedValue(undefined),
+    });
+    vi.spyOn(devServer, "pushSchemaCatalogue").mockResolvedValue({ hash: "abc" });
+    vi.spyOn(schemaWatcher, "watchSchema").mockImplementation(() => ({ close: vi.fn() }));
+
+    const appRoot = await tempRoots.create("jazz-next-alias-");
+    const schemaDir = appRoot;
+    await writeFile(join(schemaDir, "schema.ts"), todoSchema());
+
+    const wrapped = withJazz(
+      {},
+      {
+        appRoot,
+        schemaDir,
+        server: { port: 19880, adminSecret: "next-alias-admin" },
+      },
+    );
+
+    const resolved = (await resolveWrappedConfig(wrapped, DEVELOPMENT_PHASE)) as NextConfigLike & {
+      turbopack?: { resolveAlias?: Record<string, string> };
+      webpack?: (config: { resolve?: { alias?: Record<string, string> } }) => unknown;
+    };
+
+    const expectedStub = join(appRoot, "node_modules", ".cache", "jazz", "schema-hash.js");
+
+    expect(resolved.turbopack?.resolveAlias?.["jazz-tools/_dev/schema-hash"]).toBe(
+      "./node_modules/.cache/jazz/schema-hash.js",
+    );
+
+    const baseConfig: { resolve?: { alias?: Record<string, string> } } = { resolve: { alias: {} } };
+    const finalConfig = resolved.webpack!(baseConfig) as {
+      resolve: { alias: Record<string, string> };
+    };
+    expect(finalConfig.resolve.alias["jazz-tools/_dev/schema-hash"]).toBe(expectedStub);
+  });
 
   it("throws when env-driven existing-server config changes in one process", async () => {
     const schemaDir = await tempRoots.create("jazz-next-env-conflict-");

--- a/packages/jazz-tools/src/dev/next.ts
+++ b/packages/jazz-tools/src/dev/next.ts
@@ -1,5 +1,5 @@
 import { createRequire } from "node:module";
-import { copyFile, mkdir } from "node:fs/promises";
+import { copyFile, mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { buildInspectorLink } from "./inspector-link.js";
 import { ManagedDevRuntime } from "./managed-runtime.js";
@@ -37,6 +37,14 @@ const PUBLIC_APP_ID_ENV = "NEXT_PUBLIC_JAZZ_APP_ID";
 const PUBLIC_SERVER_URL_ENV = "NEXT_PUBLIC_JAZZ_SERVER_URL";
 const PUBLIC_WASM_URL_ENV = "NEXT_PUBLIC_JAZZ_WASM_URL";
 const PUBLIC_WASM_SUBPATH = "_jazz/jazz_wasm_bg.wasm";
+const SCHEMA_HASH_STUB_SUBPATH = join("node_modules", ".cache", "jazz", "schema-hash.js");
+const SCHEMA_HASH_ALIAS = "jazz-tools/_dev/schema-hash";
+
+async function writeSchemaHashStub(appRoot: string, hash: string): Promise<void> {
+  const stubPath = join(appRoot, SCHEMA_HASH_STUB_SUBPATH);
+  await mkdir(dirname(stubPath), { recursive: true });
+  await writeFile(stubPath, `export const HASH = ${JSON.stringify(hash)};\n`);
+}
 
 function buildPublicWasmUrl(basePath: unknown): string {
   if (typeof basePath !== "string" || basePath.length === 0) {
@@ -122,7 +130,12 @@ export function withJazz(
         : undefined;
     const backendSecret = explicitBackendSecret ?? process.env.BACKEND_SECRET;
 
-    const managed = await runtime.initialize({ ...options, backendSecret });
+    const resolvedAppRoot = options.appRoot ?? process.cwd();
+    const managed = await runtime.initialize({
+      ...options,
+      backendSecret,
+      onSchemaPush: (hash) => writeSchemaHashStub(resolvedAppRoot, hash),
+    });
     if (!hasLoggedInspectorLink) {
       console.log(
         `[jazz] Open the inspector: ${buildInspectorLink(
@@ -134,6 +147,16 @@ export function withJazz(
       hasLoggedInspectorLink = true;
     }
 
+    const stubPath = join(resolvedAppRoot, SCHEMA_HASH_STUB_SUBPATH);
+    // Turbopack interprets absolute alias targets as server-relative paths and
+    // refuses to resolve them. Use the project-root-relative form there. Webpack
+    // is happy with either, so feed it the absolute path for clarity.
+    const turbopackStubPath = `./${SCHEMA_HASH_STUB_SUBPATH}`;
+    const previousWebpack = mergedWithWasmEnv.webpack as
+      | ((config: WebpackConfig, ctx: unknown) => WebpackConfig)
+      | undefined;
+    const previousTurbopack = (mergedWithWasmEnv.turbopack as TurbopackConfig | undefined) ?? {};
+
     return {
       ...mergedWithWasmEnv,
       env: {
@@ -142,8 +165,34 @@ export function withJazz(
         [PUBLIC_SERVER_URL_ENV]: managed.serverUrl,
         ...(managed.backendSecret ? { BACKEND_SECRET: managed.backendSecret } : {}),
       },
+      turbopack: {
+        ...previousTurbopack,
+        resolveAlias: {
+          ...previousTurbopack.resolveAlias,
+          [SCHEMA_HASH_ALIAS]: turbopackStubPath,
+        },
+      },
+      webpack: (config: WebpackConfig, ctx: unknown) => {
+        const next = previousWebpack ? previousWebpack(config, ctx) : config;
+        next.resolve = next.resolve ?? {};
+        next.resolve.alias = {
+          ...next.resolve.alias,
+          [SCHEMA_HASH_ALIAS]: stubPath,
+        };
+        return next;
+      },
     };
   };
+}
+
+interface WebpackConfig {
+  resolve?: { alias?: Record<string, string> };
+  [key: string]: unknown;
+}
+
+interface TurbopackConfig {
+  resolveAlias?: Record<string, string>;
+  [key: string]: unknown;
 }
 
 export async function __resetJazzNextPluginForTests(): Promise<void> {

--- a/packages/jazz-tools/src/react/provider.tsx
+++ b/packages/jazz-tools/src/react/provider.tsx
@@ -9,6 +9,14 @@ import {
 } from "../react-core/provider.js";
 import { createJazzClient, type JazzClient as CreatedJazzClient } from "./create-jazz-client.js";
 
+// In dev builds, pull in a generated module that withJazz (next.ts/vite.ts/...)
+// rewrites on every schema push. The bundler tracks this as a dependency of the
+// React provider, so any push to the file forces a full reload of the host app
+// without each framework plugin needing its own dev-server WebSocket wiring.
+if (process.env.NODE_ENV === "development" && typeof window !== "undefined") {
+  import("jazz-tools/_dev/schema-hash").catch(() => {});
+}
+
 export { JazzClientProvider, type JazzClientProviderProps } from "../react-core/provider.js";
 
 interface JazzClientContextValue {


### PR DESCRIPTION
## Summary
- `withJazz` writes a `schema-hash` stub into `.cache/jazz/` and rewrites it on every schema push, then aliases `jazz-tools/_dev/schema-hash` to that stub for both Turbopack and Webpack.
- The React provider imports the alias in dev only, so the bundler tracks it as a dependency and triggers a full page reload whenever the hash changes — no per-framework WebSocket wiring needed.
- `ManagedDevRuntime.onSchemaPush` is now awaited (and called for the initial push too) so plugins can finish writing artefacts before the host bundler starts compiling.

## Test plan
- [ ] `pnpm --filter jazz-tools test src/dev/next.test.ts`
- [ ] Scaffold a Next.js app with `withJazz`, run `next dev`, edit `schema.ts`, and confirm the browser reloads on save under both Turbopack and Webpack.