### PR TITLE
fix(jazz-tools): widen jazzPlugin config hook to accept ssr.external: true

### DIFF
--- a/.changeset/jazz-vite-plugin-ssr-external-bool.md
+++ b/.changeset/jazz-vite-plugin-ssr-external-bool.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix `jazzPlugin()` (`jazz-tools/dev/vite`) so its return type matches Vite's `Plugin`. The `config` hook's parameter previously typed `ssr.external` as `string[] | undefined`, but Vite's `UserConfig` allows `true | string[] | undefined` (`true` = externalize everything), causing `TS2769` in consumer `vite.config.ts` files. Widen the param and preserve `external: true` when the user already opts into it.

--- a/packages/jazz-tools/src/dev/vite.ts
+++ b/packages/jazz-tools/src/dev/vite.ts
@@ -74,14 +74,21 @@ export function jazzPlugin(options: JazzPluginOptions = {}) {
   return {
     name: "jazz",
 
-    config(config: { ssr?: { external?: string[] }; optimizeDeps?: { exclude?: string[] } }) {
-      const existingSsr = config.ssr?.external ?? [];
+    config(config: {
+      ssr?: { external?: true | string[] };
+      optimizeDeps?: { exclude?: string[] };
+    }) {
+      const existingSsr = config.ssr?.external;
       const existingExclude = config.optimizeDeps?.exclude ?? [];
       const jazzWasmEntry = resolveJazzWasmEntry();
+      // `ssr.external: true` means "externalize everything", so jazz-napi is
+      // already covered — preserve the bool rather than coercing to an array.
+      const ssrExternal: true | string[] =
+        existingSsr === true ? true : Array.from(new Set([...(existingSsr ?? []), "jazz-napi"]));
       return {
         worker: { format: "es" as const },
         optimizeDeps: { exclude: Array.from(new Set([...existingExclude, "jazz-wasm"])) },
-        ssr: { external: Array.from(new Set([...existingSsr, "jazz-napi"])) },
+        ssr: { external: ssrExternal },
         ...(jazzWasmEntry
           ? { resolve: { alias: [{ find: /^jazz-wasm$/, replacement: jazzWasmEntry }] } }
           : {}),


### PR DESCRIPTION
## Summary

Widen the `config` hook parameter type in `jazzPlugin()` (`jazz-tools/dev/vite`) so consumer `vite.config.ts` files type-check.

Vite's `UserConfig` allows `ssr.external` to be `true | string[] | undefined` — `true` means "externalize everything." The plugin previously typed it as `string[] | undefined`, which made `jazzPlugin()` not assignable to Vite's `Plugin` type, surfacing as `TS2769: No overload matches this call` in starters such as `react-localfirst`.

The fix:
- Widens the param to accept `true | string[]`.
- Preserves `external: true` when the consumer already opts into it (since `true` already covers jazz-napi externalization), otherwise merges `"jazz-napi"` into the existing array.

## Test plan

- [x] `pnpm --filter jazz-tools build` — clean
- [x] `pnpm --filter react-localfirst build` — `tsc -p tsconfig.json && vite build` clean
- [ ] CI green