### PR TITLE
chore(jazz-tools): drop stale `/sync` and `/events` references

### DIFF
--- a/crates/jazz-tools/src/middleware/auth.rs
+++ b/crates/jazz-tools/src/middleware/auth.rs
@@ -1098,8 +1098,8 @@ pub fn validate_backend_secret(
 /// Check if admin secret is valid.
 ///
 /// Admin publication endpoints require admin authentication. Development-mode
-/// schema auto-push from ordinary clients flows through `/sync` and does not
-/// use this helper.
+/// schema auto-push from ordinary clients flows through the WebSocket transport
+/// and does not use this helper.
 pub fn validate_admin_secret(
     provided: Option<&str>,
     config: &AuthConfig,

--- a/crates/jazz-tools/src/runtime_core/tests/fk_remove_error.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/fk_remove_error.rs
@@ -136,7 +136,7 @@ fn rc_partial_update_changing_fk_to_missing_target_succeeds() {
 #[test]
 fn remove_client_blocked_by_parked_sync_messages() {
     //
-    // alice ──/sync──▶ server (message parked in RuntimeCore, not yet in SyncManager inbox)
+    // alice ──WS──▶ server (message parked in RuntimeCore, not yet in SyncManager inbox)
     //
     // Sweep tries to reap alice → remove_client returns false because
     // parked_sync_messages contains an entry from alice.
@@ -182,7 +182,7 @@ fn remove_client_blocked_by_parked_sync_messages() {
 #[test]
 fn remove_client_succeeds_after_parked_messages_drained() {
     //
-    // alice ──/sync──▶ server (message parked) ──batched_tick──▶ inbox drained
+    // alice ──WS──▶ server (message parked) ──batched_tick──▶ inbox drained
     //
     // After batched_tick processes the parked message, remove_client succeeds.
     //
@@ -228,7 +228,7 @@ fn remove_client_succeeds_after_parked_messages_drained() {
 #[test]
 fn remove_client_ignores_parked_messages_from_other_clients() {
     //
-    // bob ──/sync──▶ server (message parked)
+    // bob ──WS──▶ server (message parked)
     //
     // alice disconnects → remove_client(alice) succeeds because
     // the parked message is from bob, not alice.

--- a/crates/jazz-tools/src/server/routes/websocket.rs
+++ b/crates/jazz-tools/src/server/routes/websocket.rs
@@ -25,8 +25,7 @@ pub(super) async fn ws_handler(
     ws.on_upgrade(move |socket| handle_ws_connection(socket, state, headers))
 }
 
-/// Outcome of authenticating a WS handshake — mirrors `ClientSetup` in
-/// the old `/sync` + `/events` handlers.
+/// Outcome of authenticating a WS handshake.
 #[derive(Debug)]
 pub(super) enum WsClientSetup {
     Backend,

--- a/crates/jazz-tools/src/transport_protocol.rs
+++ b/crates/jazz-tools/src/transport_protocol.rs
@@ -1,24 +1,19 @@
-//! Binary HTTP streaming transport protocol types for Jazz.
+//! Binary WebSocket transport protocol types for Jazz.
 //!
-//! This crate defines the wire format for communication between Jazz clients
-//! and servers over HTTP with length-prefixed binary streaming.
+//! This module defines the wire format for communication between Jazz clients
+//! and servers over a single bidirectional WebSocket with length-prefixed
+//! binary frames.
 //!
 //! # Protocol Overview
 //!
-//! - Clients connect to `/events` for a long-lived binary stream (length-prefixed frames)
-//! - All client→server communication flows through a single `/sync` endpoint
-//! - Session is bound at connection time via HTTP headers
+//! - Clients connect to `/ws` and authenticate via an initial `AuthHandshake` frame
+//! - Both directions use the same length-prefixed binary framing
+//! - Server → client frames carry [`ServerEvent`] values
+//! - Client → server frames carry [`SyncBatchRequest`] payloads
 //!
 //! # Wire Format
 //!
-//! Each frame: `[4 bytes: u32 big-endian length][N bytes: JSON-encoded ServerEvent]`
-//!
-//! # Endpoints
-//!
-//! | Route | Method | Description |
-//! |-------|--------|-------------|
-//! | `/events` | GET | Binary streaming for all subscription updates |
-//! | `/sync` | POST | Unified sync endpoint for all SyncPayload variants |
+//! Each frame: `[4 bytes: u32 big-endian length][N bytes: JSON]`
 
 use serde::{Deserialize, Serialize};
 
@@ -200,7 +195,7 @@ pub enum UnauthenticatedCode {
     Disabled,
 }
 
-/// Structured unauthenticated response for `/sync` and `/events`.
+/// Structured unauthenticated response for the WebSocket transport.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct UnauthenticatedResponse {
     pub error: &'static str,

--- a/crates/jazz-tools/tests/catalogue_sync_integration.rs
+++ b/crates/jazz-tools/tests/catalogue_sync_integration.rs
@@ -498,7 +498,7 @@ async fn dynamic_server_live_subscription_replays_on_first_permissions_head_and_
 /// ```text
 /// alice (v1) ──create user──► server
 ///                                │
-///              push v2 schema + lens via HTTP /sync
+///              push v2 schema + lens via WS sync
 ///                                │
 ///                  bob (v2) connects and queries
 ///                                │

--- a/crates/jazz-tools/tests/policies_integration/session_cases.rs
+++ b/crates/jazz-tools/tests/policies_integration/session_cases.rs
@@ -1307,7 +1307,7 @@ async fn insert_policy_violation_does_not_leak_to_pristine_subscriber() {
         .expect("optimistic local create")
         .0;
 
-    // Alice's legitimate insert is the causal barrier: her /sync request is
+    // Alice's legitimate insert is the causal barrier: her sync push is
     // sent after mallory's, so once the server has committed alice's row the
     // inbox has already processed (and rejected) mallory's earlier request.
     let legit_id = create_document(&alice, "alice", "legitimate").await;

--- a/crates/jazz-tools/tests/support/mod.rs
+++ b/crates/jazz-tools/tests/support/mod.rs
@@ -9,14 +9,11 @@ use jazz_tools::schema_manager::{AppId, Lens, SchemaManager};
 use jazz_tools::server::{ServerState, TestingServer};
 use jazz_tools::storage::MemoryStorage;
 use jazz_tools::sync_manager::{ClientId, Destination, OutboxEntry, ServerId, SyncManager};
-use jazz_tools::transport_protocol::SyncBatchRequest;
 use jazz_tools::{
     AppContext, ClientStorage, DurabilityTier, JazzClient, ObjectId, OrderedRowDelta, Query,
     QueryBuilder, Schema, SubscriptionStream, Value,
 };
 use jsonwebtoken::{EncodingKey, Header, encode};
-use reqwest::Client;
-use reqwest::header::CONTENT_TYPE;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
@@ -39,58 +36,6 @@ pub use permissions::{
     PublishedPermissionsHead, allow_all_permissions, deny_all_select_permissions,
     publish_allow_all_permissions, publish_permissions,
 };
-
-struct SyncServerClient {
-    http_client: Client,
-    base_url: String,
-    route_prefix: String,
-    admin_secret: String,
-}
-
-impl SyncServerClient {
-    async fn connect(
-        server_url: &str,
-        admin_secret: &str,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
-        let http_client = Client::new();
-        let (base_url, route_prefix) = split_base_url(server_url)?;
-
-        let health_url = format!("{base_url}/health");
-        http_client
-            .get(health_url)
-            .send()
-            .await?
-            .error_for_status()?;
-
-        Ok(Self {
-            http_client,
-            base_url,
-            route_prefix,
-            admin_secret: admin_secret.to_string(),
-        })
-    }
-
-    async fn push_sync(
-        &self,
-        payload: jazz_tools::sync_manager::SyncPayload,
-        client_id: ClientId,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let request = SyncBatchRequest {
-            payloads: vec![payload],
-            client_id,
-        };
-        let sync_url = format!("{}{}/sync", self.base_url, self.route_prefix);
-        self.http_client
-            .post(sync_url)
-            .header(CONTENT_TYPE, "application/json")
-            .header("X-Jazz-Admin-Secret", &self.admin_secret)
-            .json(&request)
-            .send()
-            .await?
-            .error_for_status()?;
-        Ok(())
-    }
-}
 
 fn split_base_url(server_url: &str) -> Result<(String, String), Box<dyn std::error::Error>> {
     let mut url = reqwest::Url::parse(server_url)?;


### PR DESCRIPTION
## Summary

The HTTP `/sync` and `/events` endpoints were replaced by the unified `/ws` WebSocket transport, but several docstrings, comments, and one unused test helper still pointed at the old routes. This is a docs/comments sweep with one small dead-code removal — no behavior changes.

- Rewrote `transport_protocol` module docs to describe the WebSocket binary framing (length-prefixed frames over `/ws`); fixed the `UnauthenticatedResponse` doc-comment.
- Updated stale `/sync` references in `middleware/auth.rs` and `server/routes/websocket.rs`.
- Updated test ASCII diagrams in `fk_remove_error.rs`, `catalogue_sync_integration.rs`, and `session_cases.rs` from `/sync` to `WS` so they reflect the actual transport.
- Removed the unused `SyncServerClient` test helper in `tests/support/mod.rs` that POSTed to a `/sync` URL the server no longer exposes, plus its now-orphan imports (`reqwest::Client`, `CONTENT_TYPE`, `SyncBatchRequest`).

Out of scope (already tracked in `todo/ideas/1_mvp/stale-sessionclient-http-writes.md`): the dead `/sync/object` HTTP write paths in `packages/jazz-tools/src/runtime/client.ts`.

## Test plan

- [x] `cargo check -p jazz-tools --tests` passes with no new warnings
- [x] `grep -rn "/events\|/sync\b"` in `crates/jazz-tools/{src,tests}` returns no remaining hits (excluding `sync/object` and `sync-transport` filename matches)
- [ ] CI green