### PR TITLE
Fix paginated query provenance scope

### DIFF
--- a/crates/jazz-tools/Cargo.toml
+++ b/crates/jazz-tools/Cargo.toml
@@ -144,6 +144,10 @@ harness = false
 name = "observer_write_path"
 harness = false
 
+[[bench]]
+name = "limit_offset_benchmark"
+harness = false
+
 [[example]]
 name = "realistic_bench"
 required-features = ["client"]

--- a/crates/jazz-tools/benches/limit_offset_benchmark.rs
+++ b/crates/jazz-tools/benches/limit_offset_benchmark.rs
@@ -1,0 +1,89 @@
+//! Benchmarks for paginated live-query settling.
+//!
+//! The growing-prefix case mirrors a query subscription receiving many existing
+//! rows incrementally: each settle sees a longer ordered input and recomputes the
+//! current page. This used to amplify provenance into every window tuple, making
+//! repeated settles get progressively more expensive.
+
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use jazz_tools::metadata::RowProvenance;
+use jazz_tools::object::{BranchName, ObjectId};
+use jazz_tools::query_manager::encoding::encode_row;
+use jazz_tools::query_manager::graph_nodes::LimitOffsetNode;
+use jazz_tools::query_manager::types::{
+    ColumnDescriptor, ColumnType, RowDescriptor, Tuple, TupleDescriptor, TupleElement, Value,
+};
+use jazz_tools::row_histories::BatchId;
+
+fn descriptor() -> RowDescriptor {
+    RowDescriptor::new(vec![
+        ColumnDescriptor::new("id", ColumnType::Integer),
+        ColumnDescriptor::new("name", ColumnType::Text),
+    ])
+}
+
+fn make_tuple(id: ObjectId, index: usize, descriptor: &RowDescriptor) -> Tuple {
+    let content = encode_row(
+        descriptor,
+        &[
+            Value::Integer(index as i32),
+            Value::Text(format!("Organization {}", index)),
+        ],
+    )
+    .expect("row should encode");
+
+    Tuple::new(vec![TupleElement::Row {
+        id,
+        content: content.into(),
+        batch_id: BatchId([index as u8; 16]),
+        row_provenance: RowProvenance::for_insert("jazz:bench", index as u64),
+    }])
+    .with_provenance([(id, BranchName::new("main"))].into_iter().collect())
+}
+
+fn make_tuples(count: usize) -> Vec<Tuple> {
+    let descriptor = descriptor();
+    (0..count)
+        .map(|index| make_tuple(ObjectId::new(), index, &descriptor))
+        .collect()
+}
+
+fn settle_growing_prefix(c: &mut Criterion) {
+    let mut group = c.benchmark_group("limit_offset/growing_prefix");
+
+    for row_count in [1_800usize] {
+        group.throughput(Throughput::Elements(row_count as u64));
+        group.bench_with_input(
+            BenchmarkId::new("limit_50_offset_0", row_count),
+            &row_count,
+            |b, &row_count| {
+                let tuples = make_tuples(row_count);
+                let tuple_descriptor =
+                    TupleDescriptor::single_with_materialization("", descriptor(), true);
+
+                b.iter(|| {
+                    let mut node = LimitOffsetNode::with_tuple_descriptor(
+                        tuple_descriptor.clone(),
+                        Some(50),
+                        0,
+                    );
+
+                    for len in 1..=row_count {
+                        black_box(node.process_with_ordered_input(black_box(&tuples[..len])));
+                    }
+
+                    black_box(node.windowed_tuples().len());
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = settle_growing_prefix
+}
+criterion_main!(benches);

--- a/crates/jazz-tools/src/query_manager/graph/mod.rs
+++ b/crates/jazz-tools/src/query_manager/graph/mod.rs
@@ -501,13 +501,19 @@ impl QueryGraph {
     /// Returns ObjectIds that must be synced for the client to reproduce the
     /// current query result locally.
     pub fn sync_scope_object_ids(&self) -> HashSet<(ObjectId, BranchName)> {
+        self.scope_from_tuples(&self.sync_scope_tuples())
+    }
+
+    /// Returns tuples that must be synced for the client to reproduce the current
+    /// query result locally.
+    pub fn sync_scope_tuples(&self) -> Vec<Tuple> {
         if let Some(node_id) = self.pagination_node
             && let Some(GraphNode::LimitOffset(limit_offset)) = self.get_node(node_id)
         {
-            return self.scope_from_tuples(limit_offset.sync_input_tuples());
+            return limit_offset.sync_input_tuples().to_vec();
         }
 
-        self.contributing_object_ids()
+        self.current_output_tuples()
     }
 
     fn scope_from_tuples(&self, tuples: &[Tuple]) -> HashSet<(ObjectId, BranchName)> {

--- a/crates/jazz-tools/src/query_manager/graph/mod.rs
+++ b/crates/jazz-tools/src/query_manager/graph/mod.rs
@@ -516,6 +516,33 @@ impl QueryGraph {
         self.current_output_tuples()
     }
 
+    /// Returns sync-scope tuples after applying a caller-provided visibility
+    /// filter. For paginated queries, filtering must happen before selecting the
+    /// ordered prefix so denied rows do not count toward offset/limit replay.
+    pub fn filtered_sync_scope_tuples(
+        &self,
+        mut tuple_is_visible: impl FnMut(&Tuple) -> bool,
+    ) -> Vec<Tuple> {
+        if let Some(node_id) = self.pagination_node
+            && let Some(GraphNode::LimitOffset(limit_offset)) = self.get_node(node_id)
+        {
+            let visible_ordered_tuples: Vec<_> = limit_offset
+                .ordered_input_tuples()
+                .iter()
+                .filter(|tuple| tuple_is_visible(tuple))
+                .cloned()
+                .collect();
+            return limit_offset
+                .filtered_sync_input_tuples(&visible_ordered_tuples)
+                .to_vec();
+        }
+
+        self.current_output_tuples()
+            .into_iter()
+            .filter(|tuple| tuple_is_visible(tuple))
+            .collect()
+    }
+
     fn scope_from_tuples(&self, tuples: &[Tuple]) -> HashSet<(ObjectId, BranchName)> {
         tuples
             .iter()

--- a/crates/jazz-tools/src/query_manager/graph_nodes/limit_offset.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/limit_offset.rs
@@ -56,18 +56,9 @@ impl LimitOffsetNode {
             Some(limit) => (start + limit).min(self.all_tuples.len()),
             None => self.all_tuples.len(),
         };
-        let sync_scope = self.sync_scope_provenance();
         self.windowed_tuples.clear();
         self.windowed_tuples
-            .extend(
-                self.all_tuples[start..end]
-                    .iter()
-                    .cloned()
-                    .map(|mut tuple| {
-                        tuple.merge_provenance(&sync_scope);
-                        tuple
-                    }),
-            );
+            .extend(self.all_tuples[start..end].iter().cloned());
         self.current_tuples = self.windowed_tuples.iter().cloned().collect();
     }
 
@@ -97,13 +88,6 @@ impl LimitOffsetNode {
             None => self.all_tuples.len(),
         };
         &self.all_tuples[..end]
-    }
-
-    fn sync_scope_provenance(&self) -> crate::query_manager::types::TupleProvenance {
-        self.sync_input_tuples()
-            .iter()
-            .flat_map(|tuple| tuple.provenance().iter().copied())
-            .collect()
     }
 }
 
@@ -184,6 +168,14 @@ mod tests {
             batch_id: crate::row_histories::BatchId([0; 16]),
             row_provenance: crate::metadata::RowProvenance::for_insert("jazz:test", 0),
         }])
+    }
+
+    fn make_scoped_tuple(id: ObjectId, n: i32, name: &str) -> Tuple {
+        make_tuple(id, n, name).with_provenance(
+            [(id, crate::object::BranchName::new("main"))]
+                .into_iter()
+                .collect(),
+        )
     }
 
     fn contains_id(tuples: &[Tuple], id: ObjectId) -> bool {
@@ -280,6 +272,37 @@ mod tests {
         assert_eq!(windowed_ids.len(), 2);
         assert_eq!(windowed_ids[0], ids[1]);
         assert_eq!(windowed_ids[1], ids[2]);
+    }
+
+    #[test]
+    fn windowed_tuples_keep_row_provenance_separate_from_sync_prefix() {
+        let mut node = make_limit_offset_node(Some(2), 1);
+
+        let ids: Vec<_> = (0..4).map(|_| ObjectId::new()).collect();
+        let tuples: Vec<_> = ids
+            .iter()
+            .enumerate()
+            .map(|(i, id)| make_scoped_tuple(*id, i as i32, &format!("Row{}", i)))
+            .collect();
+
+        node.process_with_ordered_input(&tuples);
+
+        assert_eq!(node.sync_input_tuples().len(), 3);
+        assert_eq!(node.windowed_tuples().len(), 2);
+        assert_eq!(node.windowed_tuples()[0].first_id(), Some(ids[1]));
+        assert_eq!(node.windowed_tuples()[1].first_id(), Some(ids[2]));
+        assert_eq!(node.windowed_tuples()[0].provenance().len(), 1);
+        assert_eq!(node.windowed_tuples()[1].provenance().len(), 1);
+        assert!(
+            node.windowed_tuples()[0]
+                .provenance()
+                .contains(&(ids[1], crate::object::BranchName::new("main")))
+        );
+        assert!(
+            node.windowed_tuples()[1]
+                .provenance()
+                .contains(&(ids[2], crate::object::BranchName::new("main")))
+        );
     }
 
     #[test]

--- a/crates/jazz-tools/src/query_manager/graph_nodes/limit_offset.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/limit_offset.rs
@@ -77,17 +77,36 @@ impl LimitOffsetNode {
         &self.windowed_tuples
     }
 
+    /// Full ordered input before offset/limit are applied.
+    pub fn ordered_input_tuples(&self) -> &[Tuple] {
+        &self.all_tuples
+    }
+
     /// Tuples that must be present locally to reproduce this paginated window.
     ///
     /// For offset-based pagination, the client must have the ordered prefix up to
     /// `offset + limit` so it can reapply the same windowing logic locally.
     /// When no limit is present, that means the full ordered input.
     pub fn sync_input_tuples(&self) -> &[Tuple] {
-        let end = match self.limit {
-            Some(limit) => self.offset.saturating_add(limit).min(self.all_tuples.len()),
-            None => self.all_tuples.len(),
+        Self::sync_input_tuples_from_ordered(self.limit, self.offset, &self.all_tuples)
+    }
+
+    /// Tuples from an already-filtered ordered input that must be present locally
+    /// to reproduce this paginated window.
+    pub fn filtered_sync_input_tuples<'a>(&self, ordered_tuples: &'a [Tuple]) -> &'a [Tuple] {
+        Self::sync_input_tuples_from_ordered(self.limit, self.offset, ordered_tuples)
+    }
+
+    fn sync_input_tuples_from_ordered(
+        limit: Option<usize>,
+        offset: usize,
+        ordered_tuples: &[Tuple],
+    ) -> &[Tuple] {
+        let end = match limit {
+            Some(limit) => offset.saturating_add(limit).min(ordered_tuples.len()),
+            None => ordered_tuples.len(),
         };
-        &self.all_tuples[..end]
+        &ordered_tuples[..end]
     }
 }
 

--- a/crates/jazz-tools/src/query_manager/manager_tests/e2e_sync.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests/e2e_sync.rs
@@ -149,6 +149,98 @@ fn e2e_client_receives_paginated_server_data_on_cold_offset_subscription() {
 }
 
 #[test]
+fn e2e_authorized_paginated_server_scope_counts_only_visible_prefix() {
+    use crate::sync_manager::{ClientId, ServerId};
+    use uuid::Uuid;
+
+    let mut structural_schema = Schema::new();
+    structural_schema.insert(
+        TableName::new("documents"),
+        TableSchema::new(RowDescriptor::new(vec![
+            ColumnDescriptor::new("title", ColumnType::Text),
+            ColumnDescriptor::new("score", ColumnType::Integer),
+            ColumnDescriptor::new("owner_id", ColumnType::Text),
+        ])),
+    );
+
+    let mut authorization_schema = Schema::new();
+    authorization_schema.insert(
+        TableName::new("documents"),
+        TableSchema::with_policies(
+            RowDescriptor::new(vec![
+                ColumnDescriptor::new("title", ColumnType::Text),
+                ColumnDescriptor::new("score", ColumnType::Integer),
+                ColumnDescriptor::new("owner_id", ColumnType::Text),
+            ]),
+            TablePolicies::new()
+                .with_select(PolicyExpr::eq_session("owner_id", vec!["user_id".into()])),
+        ),
+    );
+
+    let server_sync = SyncManager::new();
+    let (mut server, mut server_io) = create_query_manager(server_sync, structural_schema.clone());
+    server.set_authorization_schema(authorization_schema.clone());
+
+    for (title, score, owner_id) in [
+        ("Bob private", 1, "bob"),
+        ("Alice first", 2, "alice"),
+        ("Alice second", 3, "alice"),
+    ] {
+        server
+            .insert(
+                &mut server_io,
+                "documents",
+                &[
+                    Value::Text(title.into()),
+                    Value::Integer(score),
+                    Value::Text(owner_id.into()),
+                ],
+            )
+            .unwrap();
+    }
+    server.process(&mut server_io);
+
+    let client_sync = SyncManager::new();
+    let (mut client, mut client_io) = create_query_manager(client_sync, authorization_schema);
+
+    let server_id = ServerId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+    let client_id = ClientId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+
+    connect_server(&mut client, &client_io, server_id);
+    connect_client(&mut server, &server_io, client_id);
+    let _ = client.sync_manager_mut().take_outbox();
+
+    let query = client
+        .query("documents")
+        .order_by("score")
+        .offset(1)
+        .limit(1)
+        .build();
+
+    let sub_id = client
+        .subscribe_with_sync(query, Some(PolicySession::new("alice")), None)
+        .unwrap();
+
+    pump_messages(
+        &mut client,
+        &mut server,
+        &mut client_io,
+        &mut server_io,
+        client_id,
+        server_id,
+    );
+
+    let results = client.get_subscription_results(sub_id);
+    assert_eq!(
+        results.len(),
+        1,
+        "authorized pagination should replay offset over visible rows"
+    );
+    assert_eq!(results[0].1[0], Value::Text("Alice second".into()));
+    assert_eq!(results[0].1[1], Value::Integer(3));
+}
+
+#[test]
 fn e2e_client_receives_paginated_server_data_on_cold_offset_only_subscription() {
     use crate::sync_manager::{ClientId, ServerId};
     use uuid::Uuid;

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -539,14 +539,58 @@ impl QueryManager {
             source_branch_schema_map,
             session,
         ) {
-            AuthorizedTuplesResult::Ready(tuples) => Some(
-                tuples
-                    .into_iter()
-                    .flat_map(|tuple| tuple.provenance().clone().into_iter())
-                    .collect(),
-            ),
-            AuthorizedTuplesResult::PermissionsUnavailable => None,
+            AuthorizedTuplesResult::Ready(_) => {}
+            AuthorizedTuplesResult::PermissionsUnavailable => return None,
         }
+
+        let Some((auth_schema, auth_context)) =
+            self.authorization_schema_for_context(&schema_context.env, &schema_context.user_branch)
+        else {
+            if !self.authorization_schema_required {
+                return Some(graph.sync_scope_object_ids());
+            }
+            return None;
+        };
+
+        if !self.row_policy_mode.denies_missing_explicit_policy()
+            && auth_schema
+                .values()
+                .all(|table_schema| table_schema.policies.select.using.is_none())
+        {
+            return Some(graph.sync_scope_object_ids());
+        }
+
+        let mut authorization_cache: HashMap<(ObjectId, BranchName), bool> = HashMap::new();
+
+        Some(
+            graph
+                .sync_scope_tuples()
+                .into_iter()
+                .filter_map(|tuple| {
+                    tuple
+                        .provenance()
+                        .iter()
+                        .copied()
+                        .all(|(object_id, branch_name)| {
+                            *authorization_cache
+                                .entry((object_id, branch_name))
+                                .or_insert_with(|| {
+                                    self.provenance_row_matches_current_select_policy(
+                                        storage,
+                                        object_id,
+                                        branch_name,
+                                        session,
+                                        &auth_schema,
+                                        &auth_context,
+                                        source_branch_schema_map,
+                                    )
+                                })
+                        })
+                        .then_some(tuple)
+                })
+                .flat_map(|tuple| tuple.provenance().clone().into_iter())
+                .collect(),
+        )
     }
 
     pub(super) fn resolved_server_query_branches(

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -562,32 +562,31 @@ impl QueryManager {
 
         let mut authorization_cache: HashMap<(ObjectId, BranchName), bool> = HashMap::new();
 
-        Some(
-            graph
-                .sync_scope_tuples()
-                .into_iter()
-                .filter_map(|tuple| {
-                    tuple
-                        .provenance()
-                        .iter()
-                        .copied()
-                        .all(|(object_id, branch_name)| {
-                            *authorization_cache
-                                .entry((object_id, branch_name))
-                                .or_insert_with(|| {
-                                    self.provenance_row_matches_current_select_policy(
-                                        storage,
-                                        object_id,
-                                        branch_name,
-                                        session,
-                                        &auth_schema,
-                                        &auth_context,
-                                        source_branch_schema_map,
-                                    )
-                                })
+        let authorized_scope_tuples = graph.filtered_sync_scope_tuples(|tuple| {
+            tuple
+                .provenance()
+                .iter()
+                .copied()
+                .all(|(object_id, branch_name)| {
+                    *authorization_cache
+                        .entry((object_id, branch_name))
+                        .or_insert_with(|| {
+                            self.provenance_row_matches_current_select_policy(
+                                storage,
+                                object_id,
+                                branch_name,
+                                session,
+                                &auth_schema,
+                                &auth_context,
+                                source_branch_schema_map,
+                            )
                         })
-                        .then_some(tuple)
                 })
+        });
+
+        Some(
+            authorized_scope_tuples
+                .into_iter()
                 .flat_map(|tuple| tuple.provenance().clone().into_iter())
                 .collect(),
         )

--- a/crates/jazz-tools/src/query_manager/subscriptions.rs
+++ b/crates/jazz-tools/src/query_manager/subscriptions.rs
@@ -659,7 +659,7 @@ impl QueryManager {
     ) -> std::collections::HashSet<(crate::object::ObjectId, crate::object::BranchName)> {
         self.subscriptions
             .get(&sub_id)
-            .map(|sub| sub.graph.contributing_object_ids())
+            .map(|sub| sub.graph.sync_scope_object_ids())
             .unwrap_or_default()
     }
 }


### PR DESCRIPTION
## What

- Stop merging the paginated sync prefix into every visible `LimitOffsetNode` output tuple.
- Add explicit graph sync-scope tuple access so paginated sync can still include the ordered prefix without inflating delivered row provenance.
- Route subscription and server authorized sync-scope calculations through the explicit sync-scope path.
- Add a focused Criterion benchmark for growing-prefix paginated live-query settling.

## Why

A `useAll` query over a table with ~1.8k backend rows was resolving extremely slowly in the browser. The trace showed long WASM tasks dominated by hashing, cloning, allocation, `LimitOffsetNode`, `OutputNode`, and tuple diffing.

The root cause was provenance amplification: for `offset/limit`, the limit node copied the entire sync prefix provenance into each visible page row. As rows arrived incrementally, already-visible rows appeared to change because their provenance kept growing, which caused repeated update churn and expensive hash/diff work.

## Validation

- `cargo test -p jazz-tools query_manager::graph_nodes::limit_offset`
- `cargo test -p jazz-tools contributing_ids_for_`
- `cargo test -p jazz-tools e2e_client_receives_paginated_server_data`
- `cargo test -p jazz-tools query_manager::manager_tests::subscriptions`
- `cargo bench -p jazz-tools --bench limit_offset_benchmark -- --quick`

Quick benchmark before/after while preparing the PR:

- old provenance merge: ~692 ms for 1,800 growing-prefix settles
- fixed path: ~329 ms for the same benchmark

## Notes

During prep, the first cut exposed a real regression: paginated sync scope became too small when output provenance stopped carrying the prefix. This PR fixes that by separating output provenance from sync-scope tuples explicitly.