### PR TITLE
Optimize paginated query settle

### DIFF
--- a/.changeset/faster-paginated-query-settle.md
+++ b/.changeset/faster-paginated-query-settle.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Optimize paginated query settling while preserving authorized sync scope for offset/limit queries.

--- a/crates/jazz-tools/src/query_manager/graph/execute.rs
+++ b/crates/jazz-tools/src/query_manager/graph/execute.rs
@@ -290,6 +290,41 @@ impl QueryGraph {
         result
     }
 
+    fn process_limit_offset_with_ordered_sort_input(
+        &mut self,
+        node_id: NodeId,
+        input_node: NodeId,
+    ) -> Option<TupleDelta> {
+        let node_idx = node_id.0 as usize;
+        let input_idx = input_node.0 as usize;
+
+        if node_idx == input_idx || node_idx >= self.nodes.len() || input_idx >= self.nodes.len() {
+            return None;
+        }
+
+        if input_idx < node_idx {
+            let (before_node, from_node) = self.nodes.split_at_mut(node_idx);
+            let input = &before_node[input_idx].node;
+            let node = &mut from_node[0].node;
+            return match (input, node) {
+                (GraphNode::Sort(sort_node), GraphNode::LimitOffset(limit_offset_node)) => {
+                    Some(limit_offset_node.process_with_ordered_input(sort_node.sorted_tuples()))
+                }
+                _ => None,
+            };
+        }
+
+        let (before_input, from_input) = self.nodes.split_at_mut(input_idx);
+        let node = &mut before_input[node_idx].node;
+        let input = &from_input[0].node;
+        match (input, node) {
+            (GraphNode::Sort(sort_node), GraphNode::LimitOffset(limit_offset_node)) => {
+                Some(limit_offset_node.process_with_ordered_input(sort_node.sorted_tuples()))
+            }
+            _ => None,
+        }
+    }
+
     /// Settle the graph - process all dirty nodes in topological order.
     /// Uses tuple-based processing internally, converts to RowDelta for output.
     pub fn settle<F>(&mut self, storage: &dyn Storage, mut row_loader: F) -> RowDelta
@@ -593,22 +628,22 @@ impl QueryGraph {
                 }
                 Some(GraphNode::LimitOffset(_)) => {
                     let input_node = self.get_inputs(node_id).first().copied();
-                    let ordered_input = input_node.and_then(|dep| match self.get_node(dep) {
-                        Some(GraphNode::Sort(sort_node)) => {
-                            Some(sort_node.sorted_tuples().to_vec())
-                        }
-                        _ => None,
-                    });
-
-                    if let Some(GraphNode::LimitOffset(lo_node)) = self.get_node_mut(node_id) {
-                        let delta = if let Some(ordered) = ordered_input {
-                            lo_node.process_with_ordered_input(&ordered)
-                        } else {
+                    let delta = input_node
+                        .and_then(|dep| {
+                            self.process_limit_offset_with_ordered_sort_input(node_id, dep)
+                        })
+                        .or_else(|| {
+                            let Some(GraphNode::LimitOffset(lo_node)) = self.get_node_mut(node_id)
+                            else {
+                                return None;
+                            };
                             let input_delta = input_node
                                 .and_then(|dep| tuple_deltas.get(&dep).cloned())
                                 .unwrap_or_default();
-                            RowNode::process(lo_node, input_delta)
-                        };
+                            Some(RowNode::process(lo_node, input_delta))
+                        });
+
+                    if let Some(delta) = delta {
                         tracing::debug!(
                             node_id = node_id.0,
                             node_type,

--- a/crates/jazz-tools/src/query_manager/graph/mod.rs
+++ b/crates/jazz-tools/src/query_manager/graph/mod.rs
@@ -230,8 +230,15 @@ impl QueryGraph {
         if let Some(node_id) = self.pagination_node
             && let Some(GraphNode::LimitOffset(limit_offset)) = self.get_node(node_id)
         {
-            let visible_ordered_tuples: Vec<_> = limit_offset
-                .ordered_input_tuples()
+            let ordered_input = self
+                .get_inputs(node_id)
+                .first()
+                .and_then(|dep| match self.get_node(*dep) {
+                    Some(GraphNode::Sort(sort_node)) => Some(sort_node.sorted_tuples()),
+                    _ => None,
+                })
+                .unwrap_or_else(|| limit_offset.sync_input_tuples());
+            let visible_ordered_tuples: Vec<_> = ordered_input
                 .iter()
                 .filter(|tuple| tuple_is_visible(tuple))
                 .cloned()

--- a/crates/jazz-tools/src/query_manager/graph_nodes/limit_offset.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/limit_offset.rs
@@ -15,7 +15,12 @@ pub struct LimitOffsetNode {
     output_tuple_descriptor: TupleDescriptor,
     limit: Option<usize>,
     offset: usize,
-    /// All tuples from input (before limit/offset applied).
+    /// Ordered tuples used to compute the current window.
+    ///
+    /// Ordered full-input rebuilds retain only the prefix through
+    /// `offset + limit` for limited queries. Incremental unordered updates may
+    /// retain more, so `sync_input_tuples()` still slices this to the replay
+    /// prefix.
     all_tuples: Vec<Tuple>,
     /// Current tuples after limit/offset.
     windowed_tuples: Vec<Tuple>,
@@ -66,7 +71,8 @@ impl LimitOffsetNode {
     pub fn process_with_ordered_input(&mut self, ordered_tuples: &[Tuple]) -> TupleDelta {
         let old_tuples = std::mem::take(&mut self.windowed_tuples);
         self.all_tuples.clear();
-        self.all_tuples.extend_from_slice(ordered_tuples);
+        self.all_tuples
+            .extend_from_slice(&ordered_tuples[..self.sync_input_len(ordered_tuples.len())]);
         self.recompute_tuple_window();
         self.dirty = false;
         compute_tuple_delta(&old_tuples, &self.windowed_tuples)
@@ -77,36 +83,26 @@ impl LimitOffsetNode {
         &self.windowed_tuples
     }
 
-    /// Full ordered input before offset/limit are applied.
-    pub fn ordered_input_tuples(&self) -> &[Tuple] {
-        &self.all_tuples
-    }
-
     /// Tuples that must be present locally to reproduce this paginated window.
     ///
     /// For offset-based pagination, the client must have the ordered prefix up to
     /// `offset + limit` so it can reapply the same windowing logic locally.
     /// When no limit is present, that means the full ordered input.
     pub fn sync_input_tuples(&self) -> &[Tuple] {
-        Self::sync_input_tuples_from_ordered(self.limit, self.offset, &self.all_tuples)
+        &self.all_tuples[..self.sync_input_len(self.all_tuples.len())]
     }
 
     /// Tuples from an already-filtered ordered input that must be present locally
     /// to reproduce this paginated window.
     pub fn filtered_sync_input_tuples<'a>(&self, ordered_tuples: &'a [Tuple]) -> &'a [Tuple] {
-        Self::sync_input_tuples_from_ordered(self.limit, self.offset, ordered_tuples)
+        &ordered_tuples[..self.sync_input_len(ordered_tuples.len())]
     }
 
-    fn sync_input_tuples_from_ordered(
-        limit: Option<usize>,
-        offset: usize,
-        ordered_tuples: &[Tuple],
-    ) -> &[Tuple] {
-        let end = match limit {
-            Some(limit) => offset.saturating_add(limit).min(ordered_tuples.len()),
-            None => ordered_tuples.len(),
-        };
-        &ordered_tuples[..end]
+    fn sync_input_len(&self, input_len: usize) -> usize {
+        match self.limit {
+            Some(limit) => self.offset.saturating_add(limit).min(input_len),
+            None => input_len,
+        }
     }
 }
 
@@ -322,6 +318,27 @@ mod tests {
                 .provenance()
                 .contains(&(ids[2], crate::object::BranchName::new("main")))
         );
+    }
+
+    #[test]
+    fn ordered_limited_input_keeps_only_replay_prefix() {
+        let mut node = make_limit_offset_node(Some(2), 1);
+
+        let ids: Vec<_> = (0..5).map(|_| ObjectId::new()).collect();
+        let tuples: Vec<_> = ids
+            .iter()
+            .enumerate()
+            .map(|(i, id)| make_scoped_tuple(*id, i as i32, &format!("Row{}", i)))
+            .collect();
+
+        node.process_with_ordered_input(&tuples[..4]);
+        assert_eq!(node.sync_input_tuples().len(), 3);
+        assert_eq!(get_windowed_ids(&node), vec![ids[1], ids[2]]);
+
+        let delta = node.process_with_ordered_input(&tuples);
+        assert!(delta.is_empty());
+        assert_eq!(node.sync_input_tuples().len(), 3);
+        assert_eq!(get_windowed_ids(&node), vec![ids[1], ids[2]]);
     }
 
     #[test]


### PR DESCRIPTION
## What

This is stacked on #743.

- Retain only the paginated replay prefix in `LimitOffsetNode::process_with_ordered_input` for limited ordered rebuilds.
- Avoid cloning the full `SortNode::sorted_tuples()` list before handing ordered input to `LimitOffsetNode` during graph settle.
- Keep `sync_input_tuples()` slicing to the replay prefix so incremental paths remain conservative.

## Why

The first PR stops visible rows from inheriting full sync-prefix provenance. This follow-up removes more per-settle work in the same `useAll`/paginated-table path: we no longer copy all sorted rows into an intermediate vec, and limited queries only keep the rows needed to replay the visible window.

## Benchmark Results

Measured #744 against its base branch #743 with a one-shot release harness. Timings exclude fixture creation.

Growing-prefix settles, which model rows arriving incrementally and `LimitOffset` reprocessing a longer ordered input:

| rows | #743 base | #744 | improvement |
| ---: | ---: | ---: | ---: |
| 1k | 109 ms | 34.6 ms | 3.2x |
| 10k | 9.60 s | 365 ms | 26.3x |
| 100k | not run | 3.69 s | base extrapolates to ~16 min |
| 1m | not run | 35.4 s | base extrapolates to ~26.7 h |

Single full ordered settle, isolating the full-list clone vs replay-prefix retention:

| rows | #743 base | #744 | improvement |
| ---: | ---: | ---: | ---: |
| 1k | 0.143 ms | 0.031 ms | 4.6x |
| 10k | 0.996 ms | 0.028 ms | 35.6x |
| 100k | 10.1 ms | 0.035 ms | 288x |
| 1m | 106 ms | 0.046 ms | 2311x |

## Validation

- `cargo test -p jazz-tools query_manager::graph_nodes::limit_offset`
- `cargo test -p jazz-tools contributing_ids_for_`
- `cargo test -p jazz-tools e2e_client_receives_paginated_server_data`
- `cargo test -p jazz-tools query_manager::manager_tests::subscriptions`
- `cargo bench -p jazz-tools --bench limit_offset_benchmark -- --quick`
- pre-commit `clippy`
- pre-commit `rustfmt`
