### PR TITLE
Preserve row parent ordering when syncing to servers

### DIFF
--- a/.changeset/row-parent-sync-ordering.md
+++ b/.changeset/row-parent-sync-ordering.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Queue unsent parent row batches before child row batches when syncing to servers. This keeps server-side permission checks from evaluating updates before their prior row content has arrived.

--- a/crates/jazz-tools/src/query_manager/writes.rs
+++ b/crates/jazz-tools/src/query_manager/writes.rs
@@ -373,7 +373,9 @@ impl QueryManager {
                 }
             })?;
 
-        self.sync_manager.forward_row_batch_to_servers(
+        self.sync_manager.forward_row_batch_to_servers_with_storage(
+            storage,
+            table,
             row_id,
             metadata_from_row_locator(&applied.row_locator),
             forwarded_row,

--- a/crates/jazz-tools/src/sync_manager/forwarding.rs
+++ b/crates/jazz-tools/src/sync_manager/forwarding.rs
@@ -2,7 +2,8 @@ use super::*;
 use crate::batch_fate::BatchSettlement;
 use crate::object::{BranchName, ObjectId};
 use crate::row_histories::{BatchId, HistoryScan, StoredRowBatch};
-use crate::storage::{RowLocator, metadata_from_row_locator};
+use crate::storage::{RowLocator, Storage, metadata_from_row_locator};
+use std::collections::HashSet;
 use uuid::Uuid;
 
 impl SyncManager {
@@ -108,11 +109,113 @@ impl SyncManager {
             self.load_current_row_from_storage(storage, object_id, &branch_name, &row_locator)
         {
             let metadata = metadata_from_row_locator(&row_locator);
-            for server_id in server_ids {
-                self.queue_row_to_server(server_id, object_id, metadata.clone(), row.clone());
-            }
+            self.forward_row_batch_to_servers_with_storage(
+                storage,
+                row_locator.table.as_str(),
+                object_id,
+                metadata,
+                row,
+            );
             return;
         }
+    }
+
+    pub(crate) fn forward_row_batch_to_servers_with_storage<H: Storage>(
+        &mut self,
+        storage: &H,
+        table: &str,
+        object_id: ObjectId,
+        metadata: HashMap<String, String>,
+        row: StoredRowBatch,
+    ) {
+        let server_ids: Vec<ServerId> = self.servers.keys().copied().collect();
+        if !server_ids.is_empty() {
+            tracing::trace!(
+                %object_id,
+                branch = row.branch.as_str(),
+                servers = server_ids.len(),
+                "forwarding row batch entry with parent closure to servers"
+            );
+        }
+
+        for server_id in server_ids {
+            let mut visiting = HashSet::new();
+            self.queue_row_to_server_with_missing_parents(
+                storage,
+                table,
+                server_id,
+                metadata.clone(),
+                row.clone(),
+                &mut visiting,
+            );
+        }
+    }
+
+    pub(super) fn queue_row_to_server_with_missing_parents<H: Storage>(
+        &mut self,
+        storage: &H,
+        table: &str,
+        server_id: ServerId,
+        metadata: HashMap<String, String>,
+        row: StoredRowBatch,
+        visiting: &mut HashSet<BatchId>,
+    ) {
+        let object_id = row.row_id;
+        let branch_name = BranchName::new(&row.branch);
+        let already_sent = self
+            .servers
+            .get(&server_id)
+            .and_then(|server| {
+                server
+                    .sent_batch_ids
+                    .get(&(object_id, branch_name))
+                    .cloned()
+            })
+            .unwrap_or_default();
+
+        for parent_batch_id in row.parents.iter().copied() {
+            if already_sent.contains(&parent_batch_id) {
+                continue;
+            }
+            if !visiting.insert(parent_batch_id) {
+                continue;
+            }
+
+            match storage.load_history_row_batch(
+                table,
+                row.branch.as_str(),
+                object_id,
+                parent_batch_id,
+            ) {
+                Ok(Some(parent_row)) => self.queue_row_to_server_with_missing_parents(
+                    storage,
+                    table,
+                    server_id,
+                    metadata.clone(),
+                    parent_row,
+                    visiting,
+                ),
+                Ok(None) => tracing::warn!(
+                    %server_id,
+                    %object_id,
+                    %branch_name,
+                    ?parent_batch_id,
+                    "missing parent row batch in local storage while queueing row batch to server"
+                ),
+                Err(error) => tracing::warn!(
+                    %server_id,
+                    %object_id,
+                    %branch_name,
+                    ?parent_batch_id,
+                    %error,
+                    "failed to load parent row batch while queueing row batch to server"
+                ),
+            }
+
+            visiting.remove(&parent_batch_id);
+        }
+
+        self.queue_row_to_server(server_id, object_id, metadata, row);
     }
 
     pub(crate) fn forward_row_batch_to_servers(

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -1538,7 +1538,18 @@ impl SyncManager {
                     .insert(client_id);
 
                 if let Some(applied) = self.apply_row_updated(storage, metadata, row.clone()) {
-                    self.forward_row_batch_to_servers(object_id, applied.metadata.clone(), row);
+                    if let Some(table) = applied.metadata.get(MetadataKey::Table.as_str()).cloned()
+                    {
+                        self.forward_row_batch_to_servers_with_storage(
+                            storage,
+                            table.as_str(),
+                            object_id,
+                            applied.metadata.clone(),
+                            row,
+                        );
+                    } else {
+                        self.forward_row_batch_to_servers(object_id, applied.metadata.clone(), row);
+                    }
                     if !matches!(
                         applied.row.state,
                         RowState::StagingPending | RowState::Superseded

--- a/crates/jazz-tools/src/sync_manager/sync_logic.rs
+++ b/crates/jazz-tools/src/sync_manager/sync_logic.rs
@@ -50,7 +50,23 @@ impl SyncManager {
         }
 
         for (object_id, metadata, row) in row_sync {
-            self.queue_row_to_server(server_id, object_id, metadata, row);
+            let Some(table) = metadata
+                .get(crate::metadata::MetadataKey::Table.as_str())
+                .cloned()
+            else {
+                self.queue_row_to_server(server_id, object_id, metadata, row);
+                continue;
+            };
+
+            let mut visiting = std::collections::HashSet::new();
+            self.queue_row_to_server_with_missing_parents(
+                storage,
+                table.as_str(),
+                server_id,
+                metadata,
+                row,
+                &mut visiting,
+            );
         }
     }
 

--- a/crates/jazz-tools/src/sync_manager/sync_logic.rs
+++ b/crates/jazz-tools/src/sync_manager/sync_logic.rs
@@ -1,11 +1,12 @@
 use super::*;
 use crate::catalogue::CatalogueEntry;
 use crate::object::{BranchName, ObjectId};
+use crate::query_manager::types::SharedString;
 use crate::row_histories::StoredRowBatch;
 use crate::storage::{RowLocator, metadata_from_row_locator};
 use std::collections::HashMap;
 
-type RowSyncData = (ObjectId, HashMap<String, String>, StoredRowBatch);
+type RowSyncData = (SharedString, HashMap<String, String>, StoredRowBatch);
 
 impl SyncManager {
     fn scope_delivery_row(mut row: StoredRowBatch) -> StoredRowBatch {
@@ -49,15 +50,7 @@ impl SyncManager {
             self.collect_row_sync_versions(storage, object_id, &row_locator, &mut row_sync);
         }
 
-        for (object_id, metadata, row) in row_sync {
-            let Some(table) = metadata
-                .get(crate::metadata::MetadataKey::Table.as_str())
-                .cloned()
-            else {
-                self.queue_row_to_server(server_id, object_id, metadata, row);
-                continue;
-            };
-
+        for (table, metadata, row) in row_sync {
             let mut visiting = std::collections::HashSet::new();
             self.queue_row_to_server_with_missing_parents(
                 storage,
@@ -98,7 +91,7 @@ impl SyncManager {
             if already_upstream {
                 continue;
             }
-            row_sync.push((object_id, metadata.clone(), row));
+            row_sync.push((row_locator.table.clone(), metadata.clone(), row));
         }
     }
 

--- a/crates/jazz-tools/src/sync_manager/tests/server_sync.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/server_sync.rs
@@ -159,3 +159,65 @@ fn add_server_with_storage_skips_rows_already_confirmed_upstream() {
 
     assert_eq!(pushed_batch_ids, vec![local_pending.batch_id()]);
 }
+
+#[test]
+fn add_server_with_storage_sends_skipped_parent_before_child() {
+    let mut io = MemoryStorage::new();
+    let row_id = ObjectId::new();
+    let upstream_confirmed_parent = row_with_state(
+        visible_row(row_id, "main", Vec::new(), 1_000, b"upstream-parent"),
+        crate::row_histories::RowState::VisibleDirect,
+        Some(DurabilityTier::EdgeServer),
+    );
+    let local_child = visible_row(
+        row_id,
+        "main",
+        vec![upstream_confirmed_parent.batch_id()],
+        2_000,
+        b"local-child",
+    );
+
+    seed_users_schema(&mut io);
+    io.put_row_locator(
+        row_id,
+        Some(
+            &crate::storage::row_locator_from_metadata(&row_metadata("users"))
+                .expect("row metadata should produce a row locator"),
+        ),
+    )
+    .unwrap();
+    io.append_history_region_rows(
+        "users",
+        &[upstream_confirmed_parent.clone(), local_child.clone()],
+    )
+    .unwrap();
+    io.upsert_visible_region_rows(
+        "users",
+        std::slice::from_ref(&VisibleRowEntry::rebuild(
+            local_child.clone(),
+            &[upstream_confirmed_parent.clone(), local_child.clone()],
+        )),
+    )
+    .unwrap();
+
+    let mut sm = SyncManager::new();
+    let server_id = ServerId::new();
+    sm.add_server_with_storage(server_id, false, &io);
+
+    let outbox = sm.take_outbox();
+    let pushed_batch_ids: Vec<_> = outbox
+        .iter()
+        .filter_map(|entry| match entry {
+            OutboxEntry {
+                destination: Destination::Server(id),
+                payload: SyncPayload::RowBatchCreated { row, .. },
+            } if *id == server_id => Some(row.batch_id()),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(
+        pushed_batch_ids,
+        vec![upstream_confirmed_parent.batch_id(), local_child.batch_id()]
+    );
+}


### PR DESCRIPTION
## Summary
- queue unsent parent row batches before child batches when forwarding rows to servers
- use the parent-closure path for full sync, local writes, and server-relayed row batches
- add a regression test for a skipped upstream-confirmed parent followed by a local child
- add a patch changeset for jazz-tools

## Test
- cargo test -p jazz-tools server_sync

Note: the changeset amend bypassed lefthook because the fresh isolated worktree had no node_modules/oxfmt installed; the Rust test suite above passed.