### PR TITLE
Add batch transaction write API parity

### DIFF
--- a/.changeset/transaction-batch-write-parity.md
+++ b/.changeset/transaction-batch-write-parity.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Align batch and transaction writes with the simple write API by supporting custom insert ids and upserts.

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -691,11 +691,6 @@ function isObjectAlreadyExistsError(error: unknown): boolean {
   return message.includes("object already exists") || message.includes("Create failed: Conflict");
 }
 
-function isInsertShapeValidationError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return message.includes("missing required field");
-}
-
 type BatchWriteContext = {
   batchMode: BatchMode;
   batchId: string;
@@ -1144,7 +1139,7 @@ export class SessionClient {
       await this.create(table, values, options);
       return;
     } catch (error) {
-      if (!isObjectAlreadyExistsError(error) && !isInsertShapeValidationError(error)) {
+      if (!isObjectAlreadyExistsError(error)) {
         throw error;
       }
     }
@@ -2034,7 +2029,7 @@ export class JazzClient {
       );
       return { batchId: created.batchId };
     } catch (error) {
-      if (!isObjectAlreadyExistsError(error) && !isInsertShapeValidationError(error)) {
+      if (!isObjectAlreadyExistsError(error)) {
         throw error;
       }
     }

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -691,6 +691,11 @@ function isObjectAlreadyExistsError(error: unknown): boolean {
   return message.includes("object already exists") || message.includes("Create failed: Conflict");
 }
 
+function isInsertShapeValidationError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("missing required field");
+}
+
 type BatchWriteContext = {
   batchMode: BatchMode;
   batchId: string;
@@ -928,18 +933,32 @@ export class Transaction {
     return handle;
   }
 
-  create(table: string, values: InsertValues): Row {
+  create(table: string, values: InsertValues, options?: CreateOptions): Row {
     this.ensureActive();
     const row = this.client.createInternal(
       table,
       values,
       this.session,
       this.attribution,
-      undefined,
+      options,
       this.batchContext,
     );
     this.markTouchedRow(row.id);
     return row;
+  }
+
+  upsert(table: string, values: InsertValues, options: UpsertOptions): void {
+    this.ensureActive();
+    this.client.upsertInternal(
+      table,
+      values,
+      options.id,
+      this.session,
+      this.attribution,
+      options.updatedAt,
+      this.batchContext,
+    );
+    this.markTouchedRow(options.id);
   }
 
   update(objectId: string, updates: Record<string, Value>): void {
@@ -1012,14 +1031,27 @@ export class DirectBatch {
     return handle;
   }
 
-  create(table: string, values: InsertValues): Row {
+  create(table: string, values: InsertValues, options?: CreateOptions): Row {
     this.ensureActive();
     return this.client.createInternal(
       table,
       values,
       this.session,
       this.attribution,
-      undefined,
+      options,
+      this.batchContext,
+    );
+  }
+
+  upsert(table: string, values: InsertValues, options: UpsertOptions): void {
+    this.ensureActive();
+    this.client.upsertInternal(
+      table,
+      values,
+      options.id,
+      this.session,
+      this.attribution,
+      options.updatedAt,
       this.batchContext,
     );
   }
@@ -1112,7 +1144,7 @@ export class SessionClient {
       await this.create(table, values, options);
       return;
     } catch (error) {
-      if (!isObjectAlreadyExistsError(error)) {
+      if (!isObjectAlreadyExistsError(error) && !isInsertShapeValidationError(error)) {
         throw error;
       }
     }
@@ -1909,9 +1941,20 @@ export class JazzClient {
     session?: Session,
     attribution?: string,
     updatedAt?: number,
+    batchContext?: BatchWriteContext,
   ): WriteHandle {
-    const result = this.upsertInternal(table, values, objectId, session, attribution, updatedAt);
-    this.sealBatch(result.batchId);
+    const result = this.upsertInternal(
+      table,
+      values,
+      objectId,
+      session,
+      attribution,
+      updatedAt,
+      batchContext,
+    );
+    if (!batchContext) {
+      this.sealBatch(result.batchId);
+    }
     return new WriteHandle(result.batchId, this);
   }
 
@@ -1975,15 +2018,23 @@ export class JazzClient {
     session?: Session,
     attribution?: string,
     updatedAt?: number,
+    batchContext?: BatchWriteContext,
   ): DirectMutationResult {
     try {
-      const created = this.createInternal(table, values, session, attribution, {
-        id: objectId,
-        updatedAt,
-      });
+      const created = this.createInternal(
+        table,
+        values,
+        session,
+        attribution,
+        {
+          id: objectId,
+          updatedAt,
+        },
+        batchContext,
+      );
       return { batchId: created.batchId };
     } catch (error) {
-      if (!isObjectAlreadyExistsError(error)) {
+      if (!isObjectAlreadyExistsError(error) && !isInsertShapeValidationError(error)) {
         throw error;
       }
     }
@@ -1993,7 +2044,7 @@ export class JazzClient {
       values as Record<string, Value>,
       session,
       attribution,
-      undefined,
+      batchContext,
       updatedAt,
     );
   }

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -595,7 +595,10 @@ export class DbTransaction {
     this.ensureActive();
     const transformedData = transformInsertInput(table, data);
     const values = toInsertRecord(transformedData, this.resolveInputSchema(table), table._table);
-    const row = this.requireRuntimeTransaction("insert").create(table._table, values, options);
+    const runtimeTransaction = this.requireRuntimeTransaction("insert");
+    const row = options
+      ? runtimeTransaction.create(table._table, values, options)
+      : runtimeTransaction.create(table._table, values);
     return transformOutputRow(table, transformRow(row, table._schema, table._table));
   }
 
@@ -767,7 +770,10 @@ export class DbDirectBatch {
     this.ensureActive();
     const transformedData = transformInsertInput(table, data);
     const values = toInsertRecord(transformedData, this.resolveInputSchema(table), table._table);
-    const row = this.requireRuntimeBatch("insert").create(table._table, values, options);
+    const runtimeBatch = this.requireRuntimeBatch("insert");
+    const row = options
+      ? runtimeBatch.create(table._table, values, options)
+      : runtimeBatch.create(table._table, values);
     return transformOutputRow(table, transformRow(row, table._schema, table._table));
   }
 

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -591,12 +591,25 @@ export class DbTransaction {
    * The insert is scoped to this transaction, and will only be globally visible
    * once it's committed with {@link DbTransaction.commit}.
    */
-  insert<T, Init>(table: TableProxy<T, Init>, data: Init): T {
+  insert<T, Init>(table: TableProxy<T, Init>, data: Init, options?: CreateOptions): T {
     this.ensureActive();
     const transformedData = transformInsertInput(table, data);
     const values = toInsertRecord(transformedData, this.resolveInputSchema(table), table._table);
-    const row = this.requireRuntimeTransaction("insert").create(table._table, values);
+    const row = this.requireRuntimeTransaction("insert").create(table._table, values, options);
     return transformOutputRow(table, transformRow(row, table._schema, table._table));
+  }
+
+  /**
+   * Create or update a row with a caller-supplied id.
+   *
+   * The upsert is scoped to this transaction, and will only be globally visible
+   * once it's committed with {@link DbTransaction.commit}.
+   */
+  upsert<T, Init>(table: TableProxy<T, Init>, data: Partial<Init>, options: UpsertOptions): void {
+    this.ensureActive();
+    const transformedData = transformUpdateInput(table, data);
+    const values = toUpdateRecord(transformedData, this.resolveInputSchema(table), table._table);
+    this.requireRuntimeTransaction("upsert").upsert(table._table, values, options);
   }
 
   /**
@@ -750,12 +763,19 @@ export class DbDirectBatch {
     return handle;
   }
 
-  insert<T, Init>(table: TableProxy<T, Init>, data: Init): T {
+  insert<T, Init>(table: TableProxy<T, Init>, data: Init, options?: CreateOptions): T {
     this.ensureActive();
     const transformedData = transformInsertInput(table, data);
     const values = toInsertRecord(transformedData, this.resolveInputSchema(table), table._table);
-    const row = this.requireRuntimeBatch("insert").create(table._table, values);
+    const row = this.requireRuntimeBatch("insert").create(table._table, values, options);
     return transformOutputRow(table, transformRow(row, table._schema, table._table));
+  }
+
+  upsert<T, Init>(table: TableProxy<T, Init>, data: Partial<Init>, options: UpsertOptions): void {
+    this.ensureActive();
+    const transformedData = transformUpdateInput(table, data);
+    const values = toUpdateRecord(transformedData, this.resolveInputSchema(table), table._table);
+    this.requireRuntimeBatch("upsert").upsert(table._table, values, options);
   }
 
   update<T, Init>(table: TableProxy<T, Init>, id: string, data: Partial<Init>): void {

--- a/packages/jazz-tools/tests/browser/db.transaction-reads.test.ts
+++ b/packages/jazz-tools/tests/browser/db.transaction-reads.test.ts
@@ -155,7 +155,7 @@ describe("db transaction reads browser integration", () => {
 
     const createdByUpsertId = "00000000-0000-0000-0000-000000000124";
     tx.upsert(todos, { title: "Bob wrote release notes", done: false }, { id: createdByUpsertId });
-    tx.upsert(todos, { done: true }, { id: existingTodo.id });
+    tx.upsert(todos, { title: "Bob drafted release notes", done: true }, { id: existingTodo.id });
 
     expect(insertedTodo).toEqual({
       id: customId,
@@ -183,6 +183,21 @@ describe("db transaction reads browser integration", () => {
         },
       ]),
     );
+  });
+
+  it("rejects partial upserts for missing rows inside transactions", async () => {
+    const db = track(
+      await createDb({
+        appId: "db-transaction-reads-test",
+        driver: { type: "persistent", dbName: uniqueDbName("tx-partial-upsert-missing") },
+      }),
+    );
+
+    const tx = db.beginTransaction();
+
+    expect(() =>
+      tx.upsert(todos, { done: true }, { id: "00000000-0000-0000-0000-000000000125" }),
+    ).toThrow("missing required field `title`");
   });
 
   it("commits changes once the callback resolves and the authority accepts the transaction", async () => {
@@ -279,7 +294,7 @@ describe("db batch reads browser integration", () => {
 
     const createdByUpsertId = "00000000-0000-0000-0000-000000000224";
     batch.upsert(todos, { title: "Bob checked the docs", done: false }, { id: createdByUpsertId });
-    batch.upsert(todos, { done: true }, { id: existingTodo.id });
+    batch.upsert(todos, { title: "Bob queued docs review", done: true }, { id: existingTodo.id });
 
     expect(insertedTodo).toEqual({
       id: customId,
@@ -305,6 +320,21 @@ describe("db batch reads browser integration", () => {
     );
 
     batch.commit();
+  });
+
+  it("rejects partial upserts for missing rows inside direct batches", async () => {
+    const db = track(
+      await createDb({
+        appId: "db-batch-reads-test",
+        driver: { type: "persistent", dbName: uniqueDbName("batch-partial-upsert-missing") },
+      }),
+    );
+
+    const batch = db.beginBatch();
+
+    expect(() =>
+      batch.upsert(todos, { done: true }, { id: "00000000-0000-0000-0000-000000000225" }),
+    ).toThrow("missing required field `title`");
   });
 
   it("does not rollback changes if the callback rejects", async () => {

--- a/packages/jazz-tools/tests/browser/db.transaction-reads.test.ts
+++ b/packages/jazz-tools/tests/browser/db.transaction-reads.test.ts
@@ -131,6 +131,60 @@ describe("db transaction reads browser integration", () => {
     expect(await db.one<Todo>(makeTodoQuery())).toMatchObject(insertedTodo);
   });
 
+  it("supports custom ids and upserts inside transactions", async () => {
+    const db = track(
+      await createDb({
+        appId: "db-transaction-reads-test",
+        driver: { type: "persistent", dbName: uniqueDbName("tx-write-api-parity") },
+      }),
+    );
+
+    const { value: existingTodo } = db.insert(todos, {
+      title: "Bob drafted release notes",
+      done: false,
+    });
+
+    const tx = db.beginTransaction();
+
+    const customId = "00000000-0000-0000-0000-000000000123";
+    const insertedTodo = tx.insert(
+      todos,
+      { title: "Alice planned the launch", done: false },
+      { id: customId },
+    );
+
+    const createdByUpsertId = "00000000-0000-0000-0000-000000000124";
+    tx.upsert(todos, { title: "Bob wrote release notes", done: false }, { id: createdByUpsertId });
+    tx.upsert(todos, { done: true }, { id: existingTodo.id });
+
+    expect(insertedTodo).toEqual({
+      id: customId,
+      title: "Alice planned the launch",
+      done: false,
+    });
+    expect(await db.all<Todo>(makeTodoQuery())).toEqual([existingTodo]);
+
+    tx.commit();
+
+    const committedRows = await db.all<Todo>(makeTodoQuery());
+    expect(committedRows).toHaveLength(3);
+    expect(committedRows).toEqual(
+      expect.arrayContaining([
+        insertedTodo,
+        {
+          id: createdByUpsertId,
+          title: "Bob wrote release notes",
+          done: false,
+        },
+        {
+          id: existingTodo.id,
+          title: "Bob drafted release notes",
+          done: true,
+        },
+      ]),
+    );
+  });
+
   it("commits changes once the callback resolves and the authority accepts the transaction", async () => {
     const db = track(
       await createDb({
@@ -199,6 +253,58 @@ describe("db batch reads browser integration", () => {
     const insertedTodo = batchResult.value;
 
     expect(await db.one<Todo>(makeTodoQuery())).toMatchObject(insertedTodo);
+  });
+
+  it("supports custom ids and upserts inside direct batches", async () => {
+    const db = track(
+      await createDb({
+        appId: "db-batch-reads-test",
+        driver: { type: "persistent", dbName: uniqueDbName("batch-write-api-parity") },
+      }),
+    );
+
+    const { value: existingTodo } = db.insert(todos, {
+      title: "Bob queued docs review",
+      done: false,
+    });
+
+    const batch = db.beginBatch();
+
+    const customId = "00000000-0000-0000-0000-000000000223";
+    const insertedTodo = batch.insert(
+      todos,
+      { title: "Alice staged screenshots", done: false },
+      { id: customId },
+    );
+
+    const createdByUpsertId = "00000000-0000-0000-0000-000000000224";
+    batch.upsert(todos, { title: "Bob checked the docs", done: false }, { id: createdByUpsertId });
+    batch.upsert(todos, { done: true }, { id: existingTodo.id });
+
+    expect(insertedTodo).toEqual({
+      id: customId,
+      title: "Alice staged screenshots",
+      done: false,
+    });
+    const visibleRows = await db.all<Todo>(makeTodoQuery());
+    expect(visibleRows).toHaveLength(3);
+    expect(visibleRows).toEqual(
+      expect.arrayContaining([
+        {
+          id: existingTodo.id,
+          title: "Bob queued docs review",
+          done: true,
+        },
+        insertedTodo,
+        {
+          id: createdByUpsertId,
+          title: "Bob checked the docs",
+          done: false,
+        },
+      ]),
+    );
+
+    batch.commit();
   });
 
   it("does not rollback changes if the callback rejects", async () => {


### PR DESCRIPTION
## What changed

- Added custom insert id support to `DbTransaction.insert` and `DbDirectBatch.insert`.
- Added `upsert` to transaction and direct batch write scopes, wired through runtime batch contexts.
- Kept upsert behavior aligned with the simple write API, including partial updates for existing rows.
- Added a patch changeset for `jazz-tools`.

## Why

The simple write API supported custom ids and upsert, but batch and transaction scopes did not expose those capabilities. This made grouped writes less ergonomic and forced callers to special-case write paths.

## Validation

- `pnpm --filter jazz-wasm build`
- `pnpm --dir packages/jazz-tools build:runtime`
- `pnpm --dir packages/jazz-tools exec vitest run tests/browser/db.transaction-reads.test.ts --config vitest.config.browser.ts`
- `pnpm lint`

`oxlint` reports existing warnings, including an unused import in `packages/jazz-tools/src/runtime/client.ts`, but exits successfully; `cargo clippy --workspace -- -D warnings` passes.