### PR TITLE
Align SessionClient upsert fallback

### DIFF
--- a/packages/jazz-tools/src/runtime/client.mutations.test.ts
+++ b/packages/jazz-tools/src/runtime/client.mutations.test.ts
@@ -2,6 +2,14 @@ import { describe, expect, it, vi } from "vitest";
 import { JazzClient, type Runtime } from "./client.js";
 import type { AppContext, Session } from "./context.js";
 
+function response(ok: boolean, statusText: string, body: unknown = {}): Response {
+  return {
+    ok,
+    statusText,
+    json: async () => body,
+  } as Response;
+}
+
 function makeClient(runtimeOverrides: Partial<Runtime> = {}) {
   const insertCalls: Array<[string, Record<string, unknown>]> = [];
   const insertWithSessionCalls: Array<[string, Record<string, unknown>, string | undefined]> = [];
@@ -243,6 +251,25 @@ describe("JazzClient mutation durability split", () => {
     });
   });
 
+  it("does not fall back to update when upsert insert shape validation fails", () => {
+    const validationError = new Error("encoding error: missing required column title");
+    const insert = vi.fn(() => {
+      throw validationError;
+    });
+    const update = vi.fn(() => ({ batchId: "should-not-update" }));
+    const { client } = makeClient({ insert, update });
+
+    expect(() =>
+      client.upsert(
+        "todos",
+        { done: { type: "Boolean" as const, value: true } },
+        { id: "todo-missing-title" },
+      ),
+    ).toThrow(validationError);
+
+    expect(update).not.toHaveBeenCalled();
+  });
+
   it("encodes session and attribution together when both are provided", () => {
     const { client, insertWithSessionCalls } = makeClient();
     const session: Session = {
@@ -317,5 +344,117 @@ describe("JazzClient mutation durability split", () => {
 
     expect(insertWithSession).toHaveBeenCalledWith("todos", values, updatedAtContext, externalId);
     expect(updateWithSession).toHaveBeenCalledWith(externalId, values, updatedAtContext);
+  });
+
+  it("uses the same conflict-only upsert fallback in transactions and direct batches", () => {
+    const externalId = "01963f3e-5cbe-7a62-8d7c-123456789abc";
+    const values = { title: { type: "Text" as const, value: "Updated title" } };
+    const insertError = new Error(`encoding error: object already exists: ${externalId}`);
+    const insertWithSession = vi.fn(() => {
+      throw insertError;
+    });
+    const updateWithSession = vi.fn(
+      (
+        _objectId: string,
+        _updates: Record<string, unknown>,
+        _writeContextJson?: string | null,
+      ) => ({
+        batchId: "fallback-update-batch",
+      }),
+    );
+    const { client } = makeClient({ insertWithSession, updateWithSession });
+
+    client.beginTransactionInternal().upsert("todos", values, { id: externalId });
+    client.beginBatchInternal().upsert("todos", values, { id: externalId });
+
+    expect(updateWithSession).toHaveBeenCalledTimes(2);
+    expect(updateWithSession.mock.calls[0]?.[0]).toBe(externalId);
+    expect(updateWithSession.mock.calls[0]?.[1]).toBe(values);
+    expect(JSON.parse(updateWithSession.mock.calls[0]?.[2] ?? "{}")).toMatchObject({
+      batch_mode: "transactional",
+    });
+    expect(updateWithSession.mock.calls[1]?.[0]).toBe(externalId);
+    expect(updateWithSession.mock.calls[1]?.[1]).toBe(values);
+    expect(JSON.parse(updateWithSession.mock.calls[1]?.[2] ?? "{}")).toMatchObject({
+      batch_mode: "direct",
+    });
+  });
+
+  it("does not fall back to update in transactions or direct batches when insert validation fails", () => {
+    const validationError = new Error("encoding error: missing required column title");
+    const insertWithSession = vi.fn(() => {
+      throw validationError;
+    });
+    const updateWithSession = vi.fn(() => ({ batchId: "should-not-update" }));
+    const { client } = makeClient({ insertWithSession, updateWithSession });
+    const values = { done: { type: "Boolean" as const, value: true } };
+
+    expect(() =>
+      client.beginTransactionInternal().upsert("todos", values, { id: "todo-missing-title" }),
+    ).toThrow(validationError);
+    expect(() =>
+      client.beginBatchInternal().upsert("todos", values, { id: "todo-missing-title" }),
+    ).toThrow(validationError);
+
+    expect(updateWithSession).not.toHaveBeenCalled();
+  });
+
+  it("uses create then update-on-conflict for SessionClient upsert", async () => {
+    const { client } = makeClient();
+    const session: Session = {
+      user_id: "backend-user",
+      claims: { role: "admin" },
+      authMode: "external",
+    };
+    const values = { title: { type: "Text" as const, value: "Backend todo" } };
+    const sendRequest = vi
+      .spyOn(client, "sendRequest")
+      .mockResolvedValueOnce(response(true, "Created", { object_id: "todo-session" }))
+      .mockResolvedValueOnce(response(false, "Conflict"))
+      .mockResolvedValueOnce(response(true, "OK"));
+    const scoped = client.forSession(session);
+
+    await expect(scoped.upsert("todos", values, { id: "todo-session-create" })).resolves.toBe(
+      undefined,
+    );
+    await expect(scoped.upsert("todos", values, { id: "todo-session-existing" })).resolves.toBe(
+      undefined,
+    );
+
+    expect(sendRequest.mock.calls.map((call) => call[1])).toEqual(["POST", "POST", "PUT"]);
+    expect(sendRequest.mock.calls[0]?.[2]).toMatchObject({
+      table: "todos",
+      values,
+      object_id: "todo-session-create",
+    });
+    expect(sendRequest.mock.calls[2]?.[2]).toMatchObject({
+      object_id: "todo-session-existing",
+      updates: Object.entries(values),
+    });
+  });
+
+  it("does not fall back to SessionClient update when insert shape validation fails", async () => {
+    const { client } = makeClient();
+    const session: Session = {
+      user_id: "backend-user",
+      claims: { role: "admin" },
+      authMode: "external",
+    };
+    const sendRequest = vi
+      .spyOn(client, "sendRequest")
+      .mockResolvedValueOnce(response(false, "Bad Request"));
+
+    await expect(
+      client
+        .forSession(session)
+        .upsert(
+          "todos",
+          { done: { type: "Boolean" as const, value: true } },
+          { id: "todo-missing-title" },
+        ),
+    ).rejects.toThrow("Create failed: Bad Request");
+
+    expect(sendRequest).toHaveBeenCalledTimes(1);
+    expect(sendRequest.mock.calls[0]?.[1]).toBe("POST");
   });
 });

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -686,7 +686,7 @@ export function sessionFromRequest(request: RequestLike): Session {
   return { user_id: typedPayload.sub, claims, authMode };
 }
 
-function isObjectAlreadyExistsError(error: unknown): boolean {
+function shouldFallbackToUpsertUpdate(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return message.includes("object already exists") || message.includes("Create failed: Conflict");
 }
@@ -1139,7 +1139,7 @@ export class SessionClient {
       await this.create(table, values, options);
       return;
     } catch (error) {
-      if (!isObjectAlreadyExistsError(error)) {
+      if (!shouldFallbackToUpsertUpdate(error)) {
         throw error;
       }
     }
@@ -2029,7 +2029,7 @@ export class JazzClient {
       );
       return { batchId: created.batchId };
     } catch (error) {
-      if (!isObjectAlreadyExistsError(error)) {
+      if (!shouldFallbackToUpsertUpdate(error)) {
         throw error;
       }
     }

--- a/packages/jazz-tools/src/runtime/db.transaction.test.ts
+++ b/packages/jazz-tools/src/runtime/db.transaction.test.ts
@@ -303,6 +303,38 @@ describe("Db transactions", () => {
     expect(runtimeTransaction.commit).not.toHaveBeenCalled();
   });
 
+  it("routes typed transaction upserts through the runtime transaction", () => {
+    const table = todoTable();
+    const runtimeTransaction = {
+      batchId: vi.fn(() => "batch-upsert-tx"),
+      create: vi.fn(),
+      update: vi.fn(),
+      upsert: vi.fn(),
+      delete: vi.fn(),
+      commit: vi.fn(() => makeWriteHandle("batch-upsert-tx").handle),
+      localBatchRecord: vi.fn((batchId = "batch-upsert-tx") => makeLocalBatchRecord(batchId)),
+      localBatchRecords: vi.fn(() => [makeLocalBatchRecord("batch-upsert-tx")]),
+      acknowledgeRejectedBatch: vi.fn(() => false),
+    };
+    const client = {
+      getSchema: () => new Map(Object.entries(todoSchema())),
+      beginTransactionInternal: vi.fn(() => runtimeTransaction),
+      localBatchRecord: vi.fn((batchId: string) => makeLocalBatchRecord(batchId)),
+      acknowledgeRejectedBatch: vi.fn(() => false),
+    } as unknown as JazzClient;
+    const db = new TestDb(client);
+
+    db.transaction((tx) => {
+      tx.upsert(table, { title: "Updated in transaction" }, { id: "todo-upsert-tx" });
+    });
+
+    expect(runtimeTransaction.upsert).toHaveBeenCalledWith(
+      "todos",
+      { title: { type: "Text", value: "Updated in transaction" } },
+      { id: "todo-upsert-tx" },
+    );
+  });
+
   it("commits a typed async callback transaction after the callback resolves", async () => {
     const table = todoTable();
     const runtimeRow: Row = {
@@ -695,6 +727,40 @@ describe("Db transactions", () => {
     await expect(db.batch(async () => Promise.reject(error))).rejects.toBe(error);
 
     expect(runtimeBatch.commit).not.toHaveBeenCalled();
+  });
+
+  it("routes typed direct batch upserts through the runtime batch", () => {
+    const table = todoTable();
+    const runtimeBatch = {
+      batchId: vi.fn(() => "batch-upsert-direct"),
+      create: vi.fn(),
+      update: vi.fn(),
+      upsert: vi.fn(),
+      delete: vi.fn(),
+      commit: vi.fn(() => makeWriteHandle("batch-upsert-direct", "direct").handle),
+      localBatchRecord: vi.fn((batchId = "batch-upsert-direct") =>
+        makeLocalBatchRecord(batchId, "direct"),
+      ),
+      localBatchRecords: vi.fn(() => [makeLocalBatchRecord("batch-upsert-direct", "direct")]),
+      acknowledgeRejectedBatch: vi.fn(() => false),
+    };
+    const client = {
+      getSchema: () => new Map(Object.entries(todoSchema())),
+      beginBatchInternal: vi.fn(() => runtimeBatch),
+      localBatchRecord: vi.fn((batchId: string) => makeLocalBatchRecord(batchId, "direct")),
+      acknowledgeRejectedBatch: vi.fn(() => false),
+    } as unknown as JazzClient;
+    const db = new TestDb(client);
+
+    db.batch((batch) => {
+      batch.upsert(table, { title: "Updated in direct batch" }, { id: "todo-upsert-direct" });
+    });
+
+    expect(runtimeBatch.upsert).toHaveBeenCalledWith(
+      "todos",
+      { title: { type: "Text", value: "Updated in direct batch" } },
+      { id: "todo-upsert-direct" },
+    );
   });
 
   it("commits a typed async callback batch after the callback resolves", async () => {


### PR DESCRIPTION
## What

- Renames the shared upsert conflict predicate so normal and SessionClient upserts both use the same conflict-only fallback rule.
- Adds focused mutation tests for create, update-on-conflict, validation errors not falling through, transaction/direct batch consistency, and SessionClient upsert behavior.
- Adds thin typed Db transaction/direct-batch upsert routing coverage on top of PR #747.

## Why

PR #747 aligned transaction and direct-batch upserts with the normal `JazzClient.upsertInternal(..., batchContext)` path. `SessionClient.upsert` still had its own create-then-update-on-conflict flow, so the important fallback condition could drift. This keeps the semantics pinned in one predicate and adds tests around the HTTP/backend path.

## Validation

- `pnpm --dir packages/jazz-tools exec vitest run --config vitest.config.ts src/runtime/client.mutations.test.ts src/runtime/db.transaction.test.ts`
- `pnpm --dir packages/jazz-tools exec tsc --noEmit` is currently blocked locally by missing `jazz-wasm` module/type artifacts.