### PR TITLE
Cache runtime schema keys

### DIFF
--- a/.changeset/cache-runtime-schema-key.md
+++ b/.changeset/cache-runtime-schema-key.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Memoize runtime schema cache keys by schema object identity so repeated writes do not reserialize the full schema on every `Db.getClient` lookup.

--- a/packages/jazz-tools/src/drivers/schema-wire.test.ts
+++ b/packages/jazz-tools/src/drivers/schema-wire.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { WasmSchema } from "./types.js";
-import { serializeRuntimeSchema } from "./schema-wire.js";
+import { getRuntimeSchemaCacheKey, serializeRuntimeSchema } from "./schema-wire.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("serializeRuntimeSchema", () => {
   it("wraps runtime schema payloads and serializes Bytea defaults as JSON arrays", () => {
@@ -43,5 +47,33 @@ describe("serializeRuntimeSchema", () => {
       schema: {},
       loadedPolicyBundle: true,
     });
+  });
+
+  it("memoizes cache keys by runtime schema identity", () => {
+    const schema: WasmSchema = {
+      todos: {
+        columns: [{ name: "title", column_type: { type: "Text" }, nullable: false }],
+      },
+    };
+    const stringify = vi.spyOn(JSON, "stringify");
+
+    const first = getRuntimeSchemaCacheKey(schema);
+    const second = getRuntimeSchemaCacheKey(schema);
+
+    expect(second).toBe(first);
+    expect(stringify).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps loaded policy bundle cache keys distinct for the same schema", () => {
+    const schema: WasmSchema = {};
+    const stringify = vi.spyOn(JSON, "stringify");
+
+    const unloaded = getRuntimeSchemaCacheKey(schema);
+    const loaded = getRuntimeSchemaCacheKey(schema, { loadedPolicyBundle: true });
+
+    expect(loaded).not.toBe(unloaded);
+    expect(JSON.parse(unloaded)).toMatchObject({ loadedPolicyBundle: false });
+    expect(JSON.parse(loaded)).toMatchObject({ loadedPolicyBundle: true });
+    expect(stringify).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/jazz-tools/src/drivers/schema-wire.ts
+++ b/packages/jazz-tools/src/drivers/schema-wire.ts
@@ -18,6 +18,8 @@ interface SerializeRuntimeSchemaOptions {
   loadedPolicyBundle?: boolean;
 }
 
+const runtimeSchemaCacheKeys = new WeakMap<WasmSchema, Map<boolean, string>>();
+
 function isRuntimeSchemaEnvelope(value: unknown): value is RuntimeSchemaEnvelope {
   return (
     isRecord(value) &&
@@ -59,6 +61,28 @@ export function serializeRuntimeSchema(
     loadedPolicyBundle: options?.loadedPolicyBundle ?? false,
   };
   return JSON.stringify(envelope, runtimeSchemaJsonReplacer);
+}
+
+export function getRuntimeSchemaCacheKey(
+  schema: WasmSchema,
+  options?: SerializeRuntimeSchemaOptions,
+): string {
+  const loadedPolicyBundle = options?.loadedPolicyBundle ?? false;
+  let keysByPolicyBundle = runtimeSchemaCacheKeys.get(schema);
+
+  if (!keysByPolicyBundle) {
+    keysByPolicyBundle = new Map();
+    runtimeSchemaCacheKeys.set(schema, keysByPolicyBundle);
+  }
+
+  const cached = keysByPolicyBundle.get(loadedPolicyBundle);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const key = serializeRuntimeSchema(schema, options);
+  keysByPolicyBundle.set(loadedPolicyBundle, key);
+  return key;
 }
 
 export function normalizeRuntimeSchemaJson(schemaJson: string): string {

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -11,7 +11,7 @@
  */
 
 import type { WasmSchema, WasmRow, StorageDriver } from "../drivers/types.js";
-import { normalizeRuntimeSchema, serializeRuntimeSchema } from "../drivers/schema-wire.js";
+import { getRuntimeSchemaCacheKey, normalizeRuntimeSchema } from "../drivers/schema-wire.js";
 import type { RuntimeSourcesConfig, Session } from "./context.js";
 import {
   DirectBatch as RuntimeDirectBatch,
@@ -135,6 +135,19 @@ function stripSchemaPolicies(schema: WasmSchema): WasmSchema {
       },
     ]),
   ) as WasmSchema;
+}
+
+const policyStrippedSchemaCache = new WeakMap<WasmSchema, WasmSchema>();
+
+function getPolicyStrippedSchema(schema: WasmSchema): WasmSchema {
+  const cached = policyStrippedSchemaCache.get(schema);
+  if (cached) {
+    return cached;
+  }
+
+  const strippedSchema = stripSchemaPolicies(schema);
+  policyStrippedSchemaCache.set(schema, strippedSchema);
+  return strippedSchema;
 }
 
 function trimOptionalString(value?: string | null): string | null {
@@ -1247,11 +1260,12 @@ export class Db {
     }
 
     const runtimeSchema = shouldBypassLocalPolicies(this.config)
-      ? stripSchemaPolicies(schema)
+      ? getPolicyStrippedSchema(schema)
       : schema;
 
-    // Use stringified schema as cache key
-    const key = serializeRuntimeSchema(runtimeSchema);
+    // Use the canonical schema JSON as the client cache key, but memoize it by
+    // schema identity so write-heavy paths don't stringify the same schema per row.
+    const key = getRuntimeSchemaCacheKey(runtimeSchema);
 
     if (!this.clients.has(key)) {
       setGlobalWasmLogLevel(this.config.logLevel);


### PR DESCRIPTION
## What

- Memoize runtime schema cache keys by schema object identity.
- Reuse policy-stripped schema objects in admin-secret mode so repeated writes do not rebuild and reserialize the schema.
- Add regression coverage for cache-key memoization and loaded policy bundle key separation.
- Add a patch changeset for `jazz-tools`.

## Why

Write-heavy paths call `Db.getClient(table._schema)` for every insert. Before this change, each lookup serialized the full runtime schema JSON just to compute the client cache key, so seed/import workloads spent significant JS CPU time in repeated `JSON.stringify` calls.

## Validation

- `pnpm lint` passed. It printed existing repo warnings, but no errors.
- `pnpm exec oxlint packages/jazz-tools/src/drivers/schema-wire.ts packages/jazz-tools/src/drivers/schema-wire.test.ts packages/jazz-tools/src/runtime/db.ts .changeset/cache-runtime-schema-key.md` passed with 0 warnings.
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/drivers/schema-wire.test.ts src/runtime/db.schema-order.test.ts` passed.

## Local benchmark note

A temporary local insert benchmark with 10,000 inserts against a 24-table x 24-column schema improved from 6223.7ms before the patch to 4575.4ms after the patch, while schema-envelope `JSON.stringify` calls dropped from 10001 to 2.