### PR TITLE
Avoid duplicate server scope authorization

### DIFF
--- a/.changeset/quick-tobi-scope.md
+++ b/.changeset/quick-tobi-scope.md
@@ -1,0 +1,7 @@
+---
+"jazz-tools": patch
+---
+
+Avoid duplicate server subscription authorization checks when computing authorized sync scope.
+
+Thanks, Tobi!

--- a/crates/jazz-tools/Cargo.toml
+++ b/crates/jazz-tools/Cargo.toml
@@ -148,6 +148,10 @@ harness = false
 name = "limit_offset_benchmark"
 harness = false
 
+[[bench]]
+name = "server_authorization_scope_benchmark"
+harness = false
+
 [[example]]
 name = "realistic_bench"
 required-features = ["client"]

--- a/crates/jazz-tools/benches/server_authorization_scope_benchmark.rs
+++ b/crates/jazz-tools/benches/server_authorization_scope_benchmark.rs
@@ -1,0 +1,117 @@
+//! Server subscription authorization-scope benchmarks.
+//!
+//! Models a downstream client subscribing to a large `useAll(...).limit(n)`
+//! query with row-level select policies. The initial server scope computation
+//! used to re-run visibility checks for output tuples and sync-scope tuples
+//! separately, which shows up as main-thread WASM work in browser profiles.
+
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use jazz_tools::query_manager::manager::QueryManager;
+use jazz_tools::query_manager::policy::PolicyExpr;
+use jazz_tools::query_manager::query::QueryBuilder;
+use jazz_tools::query_manager::session::Session;
+use jazz_tools::query_manager::types::{
+    ColumnDescriptor, ColumnType, RowDescriptor, Schema, TableName, TablePolicies, TableSchema,
+    Value,
+};
+use jazz_tools::schema_manager::AppId;
+use jazz_tools::storage::MemoryStorage;
+use jazz_tools::sync_manager::{
+    ClientId, InboxEntry, QueryId, QueryPropagation, Source, SyncManager, SyncPayload,
+};
+
+const USER_ID: &str = "benchmark_user";
+
+fn schema() -> Schema {
+    let mut schema = Schema::new();
+    let descriptor = RowDescriptor::new(vec![
+        ColumnDescriptor::new("owner_id", ColumnType::Text),
+        ColumnDescriptor::new("name", ColumnType::Text),
+        ColumnDescriptor::new("score", ColumnType::Integer),
+    ]);
+    let policies = TablePolicies::new()
+        .with_select(PolicyExpr::eq_session("owner_id", vec!["user_id".into()]));
+    schema.insert(
+        TableName::new("items"),
+        TableSchema::with_policies(descriptor, policies),
+    );
+    schema
+}
+
+fn setup(row_count: usize) -> (QueryManager, MemoryStorage) {
+    let mut manager = QueryManager::new(SyncManager::new());
+    manager.set_catalogue_app_id(AppId::from_name("authorization-scope-bench").to_string());
+    manager.set_current_schema(schema(), "dev", "main");
+    let mut storage = MemoryStorage::new();
+
+    for index in 0..row_count {
+        manager
+            .insert(
+                &mut storage,
+                "items",
+                &[
+                    Value::Text(USER_ID.to_string()),
+                    Value::Text(format!("Item {index}")),
+                    Value::Integer(index as i32),
+                ],
+            )
+            .expect("insert benchmark item");
+    }
+    manager.process(&mut storage);
+    let _ = manager.sync_manager_mut().take_outbox();
+
+    (manager, storage)
+}
+
+fn subscribe_limit(manager: &mut QueryManager, storage: &mut MemoryStorage, limit: usize) {
+    let client_id = ClientId::new();
+    manager
+        .sync_manager_mut()
+        .add_client_with_storage(storage, client_id);
+    let _ = manager.sync_manager_mut().take_outbox();
+
+    let query = QueryBuilder::new("items").limit(limit).build();
+    manager.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::QuerySubscription {
+            query_id: QueryId(1),
+            query: Box::new(query),
+            session: Some(Session::new(USER_ID)),
+            propagation: QueryPropagation::Full,
+            policy_context_tables: vec![],
+        },
+    });
+
+    manager.process(storage);
+    black_box(manager.sync_manager_mut().take_outbox());
+}
+
+fn initial_authorized_scope(c: &mut Criterion) {
+    let mut group = c.benchmark_group("server_authorization_scope/initial_limit");
+
+    for row_count in [1_000usize, 2_000, 10_000] {
+        group.throughput(Throughput::Elements(row_count as u64));
+        group.bench_with_input(
+            BenchmarkId::new("select_policy", row_count),
+            &row_count,
+            |b, &row_count| {
+                b.iter_batched(
+                    || setup(row_count),
+                    |(mut manager, mut storage)| {
+                        subscribe_limit(&mut manager, &mut storage, row_count);
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = initial_authorized_scope
+}
+criterion_main!(benches);

--- a/crates/jazz-tools/src/query_manager/manager_tests.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests.rs
@@ -129,18 +129,32 @@ fn get_branch(qm: &QueryManager) -> String {
 struct CountingCatalogueUpsertsStorage {
     inner: MemoryStorage,
     catalogue_upserts: Cell<usize>,
+    visible_query_loads: Cell<usize>,
 }
 
 impl CountingCatalogueUpsertsStorage {
     fn new() -> Self {
+        Self::with_inner(MemoryStorage::new())
+    }
+
+    fn with_inner(inner: MemoryStorage) -> Self {
         Self {
-            inner: MemoryStorage::new(),
+            inner,
             catalogue_upserts: Cell::new(0),
+            visible_query_loads: Cell::new(0),
         }
     }
 
     fn catalogue_upserts(&self) -> usize {
         self.catalogue_upserts.get()
+    }
+
+    fn visible_query_loads(&self) -> usize {
+        self.visible_query_loads.get()
+    }
+
+    fn reset_visible_query_loads(&self) {
+        self.visible_query_loads.set(0);
     }
 }
 
@@ -240,6 +254,17 @@ impl Storage for CountingCatalogueUpsertsStorage {
         object_id: crate::object::ObjectId,
     ) -> Result<Option<crate::catalogue::CatalogueEntry>, StorageError> {
         self.inner.load_catalogue_entry(object_id)
+    }
+
+    fn load_visible_query_row(
+        &self,
+        table: &str,
+        branch: &str,
+        row_id: ObjectId,
+    ) -> Result<Option<crate::row_histories::QueryRowBatch>, StorageError> {
+        self.visible_query_loads
+            .set(self.visible_query_loads.get() + 1);
+        self.inner.load_visible_query_row(table, branch, row_id)
     }
 }
 
@@ -468,9 +493,9 @@ fn connect_server(
         .add_server_with_storage(server_id, false, storage);
 }
 
-fn connect_client(
+fn connect_client<H: Storage>(
     qm: &mut QueryManager,
-    storage: &MemoryStorage,
+    storage: &H,
     client_id: crate::sync_manager::ClientId,
 ) {
     qm.sync_manager_mut()

--- a/crates/jazz-tools/src/query_manager/manager_tests/server_subscriptions.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests/server_subscriptions.rs
@@ -1,5 +1,20 @@
 use super::*;
 
+fn owned_items_schema() -> Schema {
+    let mut schema = Schema::new();
+    let descriptor = RowDescriptor::new(vec![
+        ColumnDescriptor::new("owner_id", ColumnType::Text),
+        ColumnDescriptor::new("name", ColumnType::Text),
+    ]);
+    let policies = TablePolicies::new()
+        .with_select(PolicyExpr::eq_session("owner_id", vec!["user_id".into()]));
+    schema.insert(
+        TableName::new("items"),
+        TableSchema::with_policies(descriptor, policies),
+    );
+    schema
+}
+
 #[test]
 fn server_builds_query_graph_on_subscription() {
     use crate::sync_manager::{ClientId, Destination, InboxEntry, QueryId, Source, SyncPayload};
@@ -136,6 +151,58 @@ fn server_subscription_reads_visible_region_after_legacy_commit_history_is_remov
         "server subscription should settle from visible rows without legacy object-backed storage"
     );
     assert_eq!(row_updates[0], handle.row_id);
+}
+
+#[test]
+fn server_authorizes_subscription_sync_scope_without_rechecking_output_scope() {
+    use crate::query_manager::session::Session;
+    use crate::sync_manager::{
+        ClientId, InboxEntry, QueryId, QueryPropagation, Source, SyncPayload,
+    };
+
+    let mut server_qm = QueryManager::new(SyncManager::new());
+    server_qm.set_current_schema(owned_items_schema(), "dev", "main");
+    let inner = seeded_memory_storage(&server_qm.schema_context().current_schema);
+    let mut storage = CountingCatalogueUpsertsStorage::with_inner(inner);
+
+    for index in 0..4 {
+        server_qm
+            .insert(
+                &mut storage,
+                "items",
+                &[
+                    Value::Text("alice".to_string()),
+                    Value::Text(format!("Item {index}")),
+                ],
+            )
+            .expect("insert item");
+    }
+    server_qm.process(&mut storage);
+
+    let client_id = ClientId::new();
+    connect_client(&mut server_qm, &storage, client_id);
+    let _ = server_qm.sync_manager_mut().take_outbox();
+    storage.reset_visible_query_loads();
+
+    let query = server_qm.query("items").limit(4).build();
+    server_qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::QuerySubscription {
+            query_id: QueryId(1),
+            query: Box::new(query),
+            session: Some(Session::new("alice")),
+            propagation: QueryPropagation::Full,
+            policy_context_tables: vec![],
+        },
+    });
+
+    server_qm.process(&mut storage);
+
+    assert!(
+        storage.visible_query_loads() <= 12,
+        "server subscription should not re-run an extra output-scope authorization pass, got {} visible row loads",
+        storage.visible_query_loads()
+    );
 }
 
 #[test]

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -532,17 +532,6 @@ impl QueryManager {
         source_branch_schema_map: &std::collections::HashMap<String, SchemaHash>,
         session: Option<&Session>,
     ) -> Option<HashSet<(ObjectId, BranchName)>> {
-        match self.authorized_tuples_from_graph_result(
-            storage,
-            graph,
-            schema_context,
-            source_branch_schema_map,
-            session,
-        ) {
-            AuthorizedTuplesResult::Ready(_) => {}
-            AuthorizedTuplesResult::PermissionsUnavailable => return None,
-        }
-
         let Some((auth_schema, auth_context)) =
             self.authorization_schema_for_context(&schema_context.env, &schema_context.user_branch)
         else {


### PR DESCRIPTION
## What

Avoid re-running server-side authorization over query output tuples before computing the authorized sync scope. `authorized_scope_from_graph_if_available` now authorizes the sync-scope tuples directly, using the existing per-call cache.

## Why

Large `useAll(...).limit(n)` subscriptions can materialize rows and then spend additional main-thread WASM time computing the server query scope. The previous path first called `authorized_tuples_from_graph_result(...)` only to check permission availability, discarded the authorized tuples, then authorized the sync scope again.

## Benchmarks

Command:

```sh
cargo bench -p jazz-tools --bench server_authorization_scope_benchmark -- --quiet
```

Fresh authorized `limit(n)` subscription setup:

| rows | before | after | change |
|---:|---:|---:|---:|
| 1k | 33.987 ms | 28.089 ms | ~17% faster |
| 2k | 74.204 ms | 61.355 ms | ~17% faster |
| 10k | 376.34 ms | 312.46 ms | ~17% faster |

Regression test load counts went from 20 visible row loads before the fix to 12 after the fix.

## Validation

- `cargo test -p jazz-tools query_manager::manager_tests::server_subscriptions --lib`
- `cargo test -p jazz-tools query_manager::manager_tests::policies --lib`
- pre-commit `clippy`
- pre-commit `rustfmt`
