### PR TITLE
[codex] Budget remote sync ticks

### DIFF
--- a/crates/jazz-tools/Cargo.toml
+++ b/crates/jazz-tools/Cargo.toml
@@ -148,6 +148,10 @@ harness = false
 name = "limit_offset_benchmark"
 harness = false
 
+[[bench]]
+name = "batched_tick_budget_benchmark"
+harness = false
+
 [[example]]
 name = "realistic_bench"
 required-features = ["client"]

--- a/crates/jazz-tools/benches/batched_tick_budget_benchmark.rs
+++ b/crates/jazz-tools/benches/batched_tick_budget_benchmark.rs
@@ -1,0 +1,70 @@
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use jazz_tools::query_manager::types::{ColumnType, Schema, SchemaBuilder, TableSchema};
+use jazz_tools::runtime_core::{NoopScheduler, RuntimeCore};
+use jazz_tools::schema_manager::{AppId, SchemaManager};
+use jazz_tools::storage::MemoryStorage;
+use jazz_tools::sync_manager::{
+    DurabilityTier, InboxEntry, QueryId, ServerId, Source, SyncManager, SyncPayload,
+};
+use std::time::Duration;
+
+fn bench_schema() -> Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("items")
+                .column("id", ColumnType::Uuid)
+                .column("title", ColumnType::Text),
+        )
+        .build()
+}
+
+fn runtime_with_parked_query_settled(count: u64) -> RuntimeCore<MemoryStorage, NoopScheduler> {
+    let schema_manager = SchemaManager::new(
+        SyncManager::new(),
+        bench_schema(),
+        AppId::from_name("batched-tick-budget-bench"),
+        "dev",
+        "main",
+    )
+    .expect("bench schema should initialize");
+    let mut core = RuntimeCore::new(schema_manager, MemoryStorage::new(), NoopScheduler);
+    let server_id = ServerId::new();
+
+    for through_seq in 1..=count {
+        core.park_sync_message(InboxEntry {
+            source: Source::Server(server_id),
+            payload: SyncPayload::QuerySettled {
+                query_id: QueryId(1),
+                tier: DurabilityTier::EdgeServer,
+                through_seq,
+            },
+        });
+    }
+
+    core
+}
+
+fn parked_sync_backlog_single_tick(c: &mut Criterion) {
+    let mut group = c.benchmark_group("batched_tick/parked_sync_backlog_single_tick");
+
+    for count in [1_000_u64, 10_000, 100_000] {
+        group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, &count| {
+            b.iter_custom(|iters| {
+                let mut total = Duration::ZERO;
+                for _ in 0..iters {
+                    let mut core = runtime_with_parked_query_settled(count);
+                    let start = std::time::Instant::now();
+                    core.batched_tick();
+                    total += start.elapsed();
+                    black_box(core);
+                }
+                total
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, parked_sync_backlog_single_tick);
+criterion_main!(benches);

--- a/crates/jazz-tools/src/runtime_core/mod.rs
+++ b/crates/jazz-tools/src/runtime_core/mod.rs
@@ -28,7 +28,7 @@
 //! ```
 
 use std::any::Any;
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -291,7 +291,7 @@ pub struct RuntimeCore<S: Storage, Sch: Scheduler> {
     pub(crate) sync_sender: Option<Box<dyn SyncSender + Send>>,
 
     /// Parked sync messages (from network).
-    parked_sync_messages: Vec<InboxEntry>,
+    parked_sync_messages: VecDeque<InboxEntry>,
     /// Sequenced server messages buffered for in-order application.
     parked_sync_messages_by_server_seq: HashMap<ServerId, BTreeMap<u64, InboxEntry>>,
     /// Next expected per-server stream sequence.
@@ -352,7 +352,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             storage_write_pending_flush: false,
             transport: None,
             sync_sender: None,
-            parked_sync_messages: Vec::new(),
+            parked_sync_messages: VecDeque::new(),
             parked_sync_messages_by_server_seq: HashMap::new(),
             next_expected_server_seq: HashMap::new(),
             last_applied_server_seq: HashMap::new(),

--- a/crates/jazz-tools/src/runtime_core/tests/basic.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/basic.rs
@@ -62,6 +62,67 @@ fn add_server_rehydrates_visible_rows_from_storage_after_restart() {
 }
 
 #[test]
+fn batched_tick_applies_parked_sync_messages_in_bounded_slices() {
+    use crate::runtime_core::ticks::MAX_SYNC_MESSAGES_PER_BATCHED_TICK;
+    use crate::sync_manager::QueryId;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct CountingScheduler {
+        scheduled: Arc<AtomicUsize>,
+    }
+
+    impl Scheduler for CountingScheduler {
+        fn schedule_batched_tick(&self) {
+            self.scheduled.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    let scheduled = Arc::new(AtomicUsize::new(0));
+    let app_id = AppId::from_name("bounded-sync-tick-test");
+    let schema_manager =
+        SchemaManager::new(SyncManager::new(), test_schema(), app_id, "dev", "main").unwrap();
+    let mut core = new_test_core(
+        schema_manager,
+        MemoryStorage::new(),
+        CountingScheduler {
+            scheduled: scheduled.clone(),
+        },
+    );
+
+    let server_id = ServerId::new();
+    for sequence in 1..=(MAX_SYNC_MESSAGES_PER_BATCHED_TICK as u64 + 1) {
+        core.park_sync_message_with_sequence(
+            InboxEntry {
+                source: Source::Server(server_id),
+                payload: SyncPayload::QuerySettled {
+                    query_id: QueryId(1),
+                    tier: DurabilityTier::EdgeServer,
+                    through_seq: sequence,
+                },
+            },
+            sequence,
+        );
+    }
+    scheduled.store(0, Ordering::SeqCst);
+
+    core.batched_tick();
+    assert_eq!(
+        core.last_applied_server_seq.get(&server_id).copied(),
+        Some(MAX_SYNC_MESSAGES_PER_BATCHED_TICK as u64)
+    );
+    assert!(
+        scheduled.load(Ordering::SeqCst) > 0,
+        "remaining ready messages should schedule another batched tick"
+    );
+
+    core.batched_tick();
+    assert_eq!(
+        core.last_applied_server_seq.get(&server_id).copied(),
+        Some(MAX_SYNC_MESSAGES_PER_BATCHED_TICK as u64 + 1)
+    );
+}
+
+#[test]
 fn test_runtime_core_insert_materializes_schema_defaults() {
     let mut core = create_runtime_with_schema(defaulted_todos_schema(), "todos-with-defaults");
 

--- a/crates/jazz-tools/src/runtime_core/ticks.rs
+++ b/crates/jazz-tools/src/runtime_core/ticks.rs
@@ -3,6 +3,9 @@ use crate::batch_fate::LocalBatchMember;
 use crate::row_histories::RowState;
 use crate::storage::metadata_from_row_locator;
 
+pub(crate) const MAX_TRANSPORT_MESSAGES_PER_BATCHED_TICK: usize = 16;
+pub(crate) const MAX_SYNC_MESSAGES_PER_BATCHED_TICK: usize = 16;
+
 impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
     fn local_batch_rows(
         &self,
@@ -512,10 +515,13 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
 
         let mut inbound = Vec::new();
         if let Some(handle) = self.transport.as_mut() {
-            while let Some(message) = handle.try_recv_inbound() {
+            while inbound.len() < MAX_TRANSPORT_MESSAGES_PER_BATCHED_TICK
+                && let Some(message) = handle.try_recv_inbound()
+            {
                 inbound.push(message);
             }
         }
+        let hit_batch_limit = inbound.len() == MAX_TRANSPORT_MESSAGES_PER_BATCHED_TICK;
 
         for message in inbound {
             match message {
@@ -557,20 +563,31 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                 }
             }
         }
+
+        if hit_batch_limit {
+            self.scheduler.schedule_batched_tick();
+        }
     }
 
     /// Apply parked sync messages and tick.
     fn handle_sync_messages(&mut self) {
-        let messages = std::mem::take(&mut self.parked_sync_messages);
         let mut applied_messages = 0usize;
+        let unsequenced_count = self
+            .parked_sync_messages
+            .len()
+            .min(MAX_SYNC_MESSAGES_PER_BATCHED_TICK);
 
-        if !messages.is_empty() {
+        if unsequenced_count > 0 {
             debug!(
-                count = messages.len(),
+                count = unsequenced_count,
                 "processing parked unsequenced sync messages"
             );
         }
-        for msg in messages {
+        for _ in 0..unsequenced_count {
+            let msg = self
+                .parked_sync_messages
+                .pop_front()
+                .expect("unsequenced_count is bounded by parked_sync_messages length");
             if msg.payload.writes_storage() {
                 self.mark_storage_write_pending_flush();
             }
@@ -578,17 +595,38 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             applied_messages += 1;
         }
 
+        if applied_messages < MAX_SYNC_MESSAGES_PER_BATCHED_TICK {
+            self.apply_ready_sequenced_sync_messages(&mut applied_messages);
+        }
+
+        if applied_messages > 0 {
+            debug!(count = applied_messages, "applied parked sync messages");
+            self.immediate_tick();
+        }
+
+        if self.has_ready_parked_sync_messages() {
+            self.scheduler.schedule_batched_tick();
+        }
+    }
+
+    fn apply_ready_sequenced_sync_messages(&mut self, applied_messages: &mut usize) {
         let server_ids: Vec<ServerId> = self
             .parked_sync_messages_by_server_seq
             .keys()
             .copied()
             .collect();
         for server_id in server_ids {
+            if *applied_messages >= MAX_SYNC_MESSAGES_PER_BATCHED_TICK {
+                break;
+            }
+
             let mut next_expected = *self.next_expected_server_seq.get(&server_id).unwrap_or(&1);
             let mut ready_messages = Vec::new();
             let mut remove_buffer = false;
             if let Some(buffered) = self.parked_sync_messages_by_server_seq.get_mut(&server_id) {
-                while let Some(msg) = buffered.remove(&next_expected) {
+                while *applied_messages + ready_messages.len() < MAX_SYNC_MESSAGES_PER_BATCHED_TICK
+                    && let Some(msg) = buffered.remove(&next_expected)
+                {
                     ready_messages.push((next_expected, msg));
                     next_expected += 1;
                 }
@@ -607,7 +645,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                     self.mark_storage_write_pending_flush();
                 }
                 self.push_sync_inbox(msg);
-                applied_messages += 1;
+                *applied_messages += 1;
                 last_applied = sequence;
             }
             self.next_expected_server_seq
@@ -617,11 +655,17 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                 self.parked_sync_messages_by_server_seq.remove(&server_id);
             }
         }
+    }
 
-        if applied_messages > 0 {
-            debug!(count = applied_messages, "applied parked sync messages");
-            self.immediate_tick();
-        }
+    fn has_ready_parked_sync_messages(&self) -> bool {
+        !self.parked_sync_messages.is_empty()
+            || self
+                .parked_sync_messages_by_server_seq
+                .iter()
+                .any(|(server_id, buffered)| {
+                    let next_expected = *self.next_expected_server_seq.get(server_id).unwrap_or(&1);
+                    buffered.contains_key(&next_expected)
+                })
     }
 
     /// Check if there are outbound messages requiring a batched_tick.
@@ -640,7 +684,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         if let Some((ref tracer, ref name)) = self.sync_tracer {
             tracer.record_incoming(&message.source, name, &message.payload);
         }
-        self.parked_sync_messages.push(message);
+        self.parked_sync_messages.push_back(message);
         self.scheduler.schedule_batched_tick();
     }
 


### PR DESCRIPTION
## What

Caps how much remote sync work a single `RuntimeCore::batched_tick()` applies before yielding back to the scheduler.

- Limit transport inbox draining to `MAX_TRANSPORT_MESSAGES_PER_BATCHED_TICK`.
- Limit parked sync message application to `MAX_SYNC_MESSAGES_PER_BATCHED_TICK`.
- Preserve sequenced-message ordering and reschedule another batched tick when ready work remains.
- Store unsequenced parked messages in a `VecDeque` so bounded draining does not shift the whole buffer.
- Add a regression test and a Criterion benchmark for parked sync backlog cost per event-loop turn.

## Why

The browser traces showed long message handlers / runtime ticks after bulk `useAll` loads. The previous subscription fix removed the idle clean-subscription recompute freeze, but a large remote backlog can still be applied in one browser turn. This PR does not reduce total sync work; it budgets it across multiple scheduled ticks so the UI thread gets chances to breathe.

## Benchmarks

Benchmark: `cargo bench -p jazz-tools --bench batched_tick_budget_benchmark -- --quick`

Measures one `batched_tick()` call with a parked `QuerySettled` backlog. `origin/main` had the benchmark file temporarily added for comparison only.

| Backlog | main | this PR | per-tick improvement |
| ---: | ---: | ---: | ---: |
| 1,000 | 70.399 us | 10.844 us | 6.5x |
| 10,000 | 1.1503 ms | 15.298 us | 75.2x |
| 100,000 | 20.316 ms | 58.604 us | 346.7x |

## Validation

- `cargo test -p jazz-tools batched_tick_applies_parked_sync_messages_in_bounded_slices --lib`
- `cargo test -p jazz-tools runtime_core::tests --lib`
- `cargo fmt --check`
- `git diff --check`
- pre-commit hook: clippy + rustfmt