### PR TITLE
Gate tiered subscription first snapshots

### DIFF
--- a/.changeset/fix-tiered-subscription-first-snapshot.md
+++ b/.changeset/fix-tiered-subscription-first-snapshot.md
@@ -1,0 +1,6 @@
+---
+"jazz-tools": patch
+"jazz-wasm": patch
+---
+
+Gate tiered browser subscriptions so the first callback is held until the worker bridge has replayed the settled server snapshot instead of exposing an empty transient snapshot.

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -914,16 +914,19 @@ impl QueryManager {
                 );
             }
 
-            let settled_tier = self
-                .sync_manager
-                .max_local_durability_tier()
-                .unwrap_or(DurabilityTier::Local);
-            settled_notifications.push((
-                sub.client_id,
-                sub.query_id,
-                settled_tier,
-                scope.clone().unwrap_or_default(),
-            ));
+            let settled_once = scope.is_some();
+            if let Some(scope) = scope.as_ref() {
+                let settled_tier = self
+                    .sync_manager
+                    .max_local_durability_tier()
+                    .unwrap_or(DurabilityTier::Local);
+                settled_notifications.push((
+                    sub.client_id,
+                    sub.query_id,
+                    settled_tier,
+                    scope.clone(),
+                ));
+            }
 
             // Forward QuerySubscription to upstream servers (multi-tier forwarding)
             // This allows hub servers to know about the query and push matching data
@@ -949,7 +952,7 @@ impl QueryManager {
                     policy_context_tables: sub.policy_context_tables,
                     last_scope: scope.unwrap_or_default(),
                     needs_recompile: false,
-                    settled_once: true,
+                    settled_once,
                     propagation: sub.propagation,
                     reported_schema_warnings,
                 },
@@ -1093,31 +1096,31 @@ impl QueryManager {
                     )
                 }
             };
-            if let Some(new_scope) = new_scope
-                && new_scope != sub.last_scope
-            {
-                scope_updates.push((client_id, query_id, new_scope.clone(), sub.session.clone()));
-                sub.last_scope = new_scope;
-                let settled_tier = self
-                    .sync_manager
-                    .max_local_durability_tier()
-                    .unwrap_or(DurabilityTier::Local);
-                settled_notifications.push((
-                    client_id,
-                    query_id,
-                    settled_tier,
-                    sub.last_scope.clone(),
-                ));
-            }
+            let scope_unavailable = new_scope.is_none();
+            if let Some(new_scope) = new_scope {
+                let scope_changed = new_scope != sub.last_scope;
+                if scope_changed {
+                    scope_updates.push((
+                        client_id,
+                        query_id,
+                        new_scope.clone(),
+                        sub.session.clone(),
+                    ));
+                    sub.last_scope = new_scope.clone();
+                }
 
-            // Emit QuerySettled on first settlement after the authoritative
-            // scope for that settled frame has been computed.
-            if !sub.settled_once {
-                sub.settled_once = true;
-                if !settled_notifications
-                    .iter()
-                    .any(|(cid, qid, _, _)| *cid == client_id && *qid == query_id)
-                {
+                // Emit an authoritative QuerySettled once the scope for this
+                // settled frame has been computed. A computed empty scope is
+                // authoritative; missing permissions/schema context returns None
+                // and must keep the subscription unsettled.
+                if !sub.settled_once {
+                    sub.settled_once = true;
+                    let settled_tier = self
+                        .sync_manager
+                        .max_local_durability_tier()
+                        .unwrap_or(DurabilityTier::Local);
+                    settled_notifications.push((client_id, query_id, settled_tier, new_scope));
+                } else if scope_changed {
                     let settled_tier = self
                         .sync_manager
                         .max_local_durability_tier()
@@ -1129,6 +1132,14 @@ impl QueryManager {
                         sub.last_scope.clone(),
                     ));
                 }
+            }
+
+            if scope_unavailable {
+                tracing::trace!(
+                    ?query_id,
+                    %client_id,
+                    "server subscription scope unavailable; holding QuerySettled"
+                );
             }
 
             self.server_subscriptions.insert((client_id, query_id), sub);

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -918,7 +918,12 @@ impl QueryManager {
                 .sync_manager
                 .max_local_durability_tier()
                 .unwrap_or(DurabilityTier::Local);
-            settled_notifications.push((sub.client_id, sub.query_id, settled_tier));
+            settled_notifications.push((
+                sub.client_id,
+                sub.query_id,
+                settled_tier,
+                scope.clone().unwrap_or_default(),
+            ));
 
             // Forward QuerySubscription to upstream servers (multi-tier forwarding)
             // This allows hub servers to know about the query and push matching data
@@ -955,9 +960,9 @@ impl QueryManager {
             self.sync_manager.emit_schema_warning(client_id, warning);
         }
 
-        for (client_id, query_id, tier) in settled_notifications {
+        for (client_id, query_id, tier, scope) in settled_notifications {
             self.sync_manager
-                .emit_query_settled(client_id, query_id, tier);
+                .emit_query_settled(client_id, query_id, tier, &scope);
         }
 
         // Re-queue subscriptions whose schema wasn't available yet
@@ -1003,7 +1008,12 @@ impl QueryManager {
             HashSet<(ObjectId, BranchName)>,
             Option<Session>,
         )> = Vec::new();
-        let mut settled_notifications: Vec<(ClientId, QueryId, DurabilityTier)> = Vec::new();
+        let mut settled_notifications: Vec<(
+            ClientId,
+            QueryId,
+            DurabilityTier,
+            HashSet<(ObjectId, BranchName)>,
+        )> = Vec::new();
         let mut schema_warning_notifications: Vec<(ClientId, crate::sync_manager::SchemaWarning)> =
             Vec::new();
 
@@ -1054,16 +1064,6 @@ impl QueryManager {
                         .map(|warning| (client_id, warning)),
                 );
 
-                // Emit QuerySettled on first settlement
-                if !sub.settled_once {
-                    sub.settled_once = true;
-                    let settled_tier = self
-                        .sync_manager
-                        .max_local_durability_tier()
-                        .unwrap_or(DurabilityTier::Local);
-                    settled_notifications.push((client_id, query_id, settled_tier));
-                }
-
                 // Check if scope changed
                 let policy_context_tables =
                     Self::merged_policy_context_tables(&sub.graph, &sub.policy_context_tables);
@@ -1098,6 +1098,37 @@ impl QueryManager {
             {
                 scope_updates.push((client_id, query_id, new_scope.clone(), sub.session.clone()));
                 sub.last_scope = new_scope;
+                let settled_tier = self
+                    .sync_manager
+                    .max_local_durability_tier()
+                    .unwrap_or(DurabilityTier::Local);
+                settled_notifications.push((
+                    client_id,
+                    query_id,
+                    settled_tier,
+                    sub.last_scope.clone(),
+                ));
+            }
+
+            // Emit QuerySettled on first settlement after the authoritative
+            // scope for that settled frame has been computed.
+            if !sub.settled_once {
+                sub.settled_once = true;
+                if !settled_notifications
+                    .iter()
+                    .any(|(cid, qid, _, _)| *cid == client_id && *qid == query_id)
+                {
+                    let settled_tier = self
+                        .sync_manager
+                        .max_local_durability_tier()
+                        .unwrap_or(DurabilityTier::Local);
+                    settled_notifications.push((
+                        client_id,
+                        query_id,
+                        settled_tier,
+                        sub.last_scope.clone(),
+                    ));
+                }
             }
 
             self.server_subscriptions.insert((client_id, query_id), sub);
@@ -1115,9 +1146,9 @@ impl QueryManager {
         }
 
         // Emit QuerySettled notifications
-        for (client_id, query_id, tier) in settled_notifications {
+        for (client_id, query_id, tier, scope) in settled_notifications {
             self.sync_manager
-                .emit_query_settled(client_id, query_id, tier);
+                .emit_query_settled(client_id, query_id, tier, &scope);
         }
     }
 

--- a/crates/jazz-tools/src/query_manager/subscriptions.rs
+++ b/crates/jazz-tools/src/query_manager/subscriptions.rs
@@ -159,7 +159,6 @@ impl QueryManager {
         let query_frontier_complete = durability_tier.is_none()
             || !self.should_send_local_subscription_upstream(propagation)
             || !self.sync_manager.has_servers_or_pending_servers();
-
         tracing::debug!(
             sub_id = id.0,
             ?branches,

--- a/crates/jazz-tools/src/runtime_core/tests/query_subscription.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/query_subscription.rs
@@ -321,7 +321,7 @@ fn rc_query_local_transaction_overlay_keeps_same_row_updates_isolated_by_batch()
 }
 
 #[test]
-fn rc_query_remote_tier_session_exists_rel_keeps_local_rows_without_permissions_head() {
+fn rc_query_remote_tier_session_exists_rel_waits_without_permissions_head() {
     let schema = session_exists_rel_teams_schema();
     let mut client = create_runtime_with_schema(schema, "session-exists-rel-query");
     let mut server = create_runtime_with_schema_and_sync_manager(
@@ -406,8 +406,8 @@ fn rc_query_remote_tier_session_exists_rel_keeps_local_rows_without_permissions_
     assert!(
         !server_outbox
             .iter()
-            .any(|entry| matches!(entry.payload, SyncPayload::QuerySettled { ref scope, .. } if !scope.is_empty())),
-        "server without a published permissions head should not advertise a non-empty authoritative scope"
+            .any(|entry| matches!(entry.payload, SyncPayload::QuerySettled { .. })),
+        "server without a published permissions head should not settle an authoritative session query"
     );
     for entry in server_outbox {
         if entry.destination == Destination::Client(client_id) {
@@ -422,22 +422,16 @@ fn rc_query_remote_tier_session_exists_rel_keeps_local_rows_without_permissions_
     client.immediate_tick();
 
     match Pin::new(&mut future).poll(&mut cx) {
-        Poll::Ready(Ok(results)) => {
-            assert_eq!(
-                results.len(),
-                1,
-                "Immediate local updates should keep the session-visible team"
-            );
-            assert_eq!(results[0].0, team_id);
-        }
+        Poll::Ready(Ok(results)) => panic!(
+            "Query should remain pending until the server can authorize scope, got {results:?}"
+        ),
         Poll::Ready(Err(e)) => panic!("Query failed: {:?}", e),
-        Poll::Pending => panic!("Query should resolve after frontier completion"),
+        Poll::Pending => {}
     }
 }
 
 #[test]
-fn rc_query_remote_tier_backend_client_session_exists_rel_keeps_local_rows_without_permissions_head()
- {
+fn rc_query_remote_tier_backend_client_session_exists_rel_waits_without_permissions_head() {
     let schema = session_exists_rel_teams_schema();
     let mut client = create_runtime_with_schema(schema, "backend-session-exists-rel-query");
     let mut server = create_runtime_with_schema_and_sync_manager(
@@ -522,6 +516,12 @@ fn rc_query_remote_tier_backend_client_session_exists_rel_keeps_local_rows_witho
     server.immediate_tick();
 
     let server_outbox = server.sync_sender().take();
+    assert!(
+        !server_outbox
+            .iter()
+            .any(|entry| matches!(entry.payload, SyncPayload::QuerySettled { .. })),
+        "server without a published permissions head should not settle an authoritative backend session query"
+    );
     for entry in server_outbox {
         if entry.destination == Destination::Client(client_id) {
             client.park_sync_message(InboxEntry {
@@ -535,21 +535,16 @@ fn rc_query_remote_tier_backend_client_session_exists_rel_keeps_local_rows_witho
     client.immediate_tick();
 
     match Pin::new(&mut future).poll(&mut cx) {
-        Poll::Ready(Ok(results)) => {
-            assert_eq!(
-                results.len(),
-                1,
-                "Immediate local updates should keep the session-visible team for backend-authenticated clients"
-            );
-            assert_eq!(results[0].0, team_id);
-        }
+        Poll::Ready(Ok(results)) => panic!(
+            "Query should remain pending until the server can authorize backend scope, got {results:?}"
+        ),
         Poll::Ready(Err(e)) => panic!("Query failed: {:?}", e),
-        Poll::Pending => panic!("Query should resolve after frontier completion"),
+        Poll::Pending => {}
     }
 }
 
 #[test]
-fn rc_query_remote_tier_backend_client_session_exists_rel_keeps_synced_policy_rows_without_permissions_head()
+fn rc_query_remote_tier_backend_client_session_exists_rel_waits_for_synced_policy_rows_without_permissions_head()
  {
     let schema = session_exists_rel_teams_schema();
     let mut client = create_runtime_with_schema(schema, "backend-session-exists-rel-synced");
@@ -599,7 +594,14 @@ fn rc_query_remote_tier_backend_client_session_exists_rel_keeps_synced_policy_ro
         .unwrap();
 
     pump_client_messages_to_server(&mut client, &mut server, server_id, client_id);
-    for entry in server.sync_sender().take() {
+    let server_outbox = server.sync_sender().take();
+    assert!(
+        !server_outbox
+            .iter()
+            .any(|entry| matches!(entry.payload, SyncPayload::QuerySettled { .. })),
+        "server without a published permissions head should not settle an authoritative backend session query even when policy rows synced"
+    );
+    for entry in server_outbox {
         if entry.destination == Destination::Client(client_id) {
             client.park_sync_message(InboxEntry {
                 source: Source::Server(server_id),
@@ -656,16 +658,11 @@ fn rc_query_remote_tier_backend_client_session_exists_rel_keeps_synced_policy_ro
     client.immediate_tick();
 
     match Pin::new(&mut future).poll(&mut cx) {
-        Poll::Ready(Ok(results)) => {
-            assert_eq!(
-                results.len(),
-                1,
-                "Synced policy context rows should keep the session-visible team"
-            );
-            assert_eq!(results[0].0, team_id);
-        }
+        Poll::Ready(Ok(results)) => panic!(
+            "Query should remain pending until the server can authorize synced policy scope, got {results:?}"
+        ),
         Poll::Ready(Err(e)) => panic!("Query failed: {:?}", e),
-        Poll::Pending => panic!("Query should resolve after frontier completion"),
+        Poll::Pending => {}
     }
 }
 

--- a/crates/jazz-tools/src/runtime_core/tests/query_subscription.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/query_subscription.rs
@@ -1491,7 +1491,7 @@ fn rc_transaction_visible_subscription_removes_local_pending_overlay_when_reject
 #[test]
 fn rc_transaction_visible_subscription_hides_partial_accepted_batch_until_scope_complete() {
     // alice authors one transactional batch with two rows
-    //   worker accepts it and reports both rows in the query scope snapshot
+    //   worker accepts it and reports both rows in the QuerySettled scope
     //   downstream strict visibility must hide the first delivered row until the second arrives
     let mut s = create_3tier_rc();
 

--- a/crates/jazz-tools/src/runtime_core/tests/query_subscription.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/query_subscription.rs
@@ -149,9 +149,9 @@ fn rc_query_remote_tier_immediate_local_updates_survives_empty_remote_scope_snap
     assert!(
         b_out.iter().any(|entry| matches!(
             entry.payload,
-            SyncPayload::QueryScopeSnapshot { ref scope, .. } if scope.is_empty()
+            SyncPayload::QuerySettled { ref scope, .. } if scope.is_empty()
         )),
-        "Expected an empty remote scope snapshot from B"
+        "Expected an empty settled remote scope from B"
     );
     for entry in b_out {
         if entry.destination == Destination::Client(s.a_client_of_b) {
@@ -406,8 +406,8 @@ fn rc_query_remote_tier_session_exists_rel_keeps_local_rows_without_permissions_
     assert!(
         !server_outbox
             .iter()
-            .any(|entry| matches!(entry.payload, SyncPayload::QueryScopeSnapshot { .. })),
-        "server without a published permissions head should not advertise an authoritative scope snapshot"
+            .any(|entry| matches!(entry.payload, SyncPayload::QuerySettled { ref scope, .. } if !scope.is_empty())),
+        "server without a published permissions head should not advertise a non-empty authoritative scope"
     );
     for entry in server_outbox {
         if entry.destination == Destination::Client(client_id) {
@@ -1290,9 +1290,9 @@ fn rc_subscribe_remote_tier_immediate_local_updates_survives_empty_remote_scope_
     assert!(
         b_out.iter().any(|entry| matches!(
             entry.payload,
-            SyncPayload::QueryScopeSnapshot { ref scope, .. } if scope.is_empty()
+            SyncPayload::QuerySettled { ref scope, .. } if scope.is_empty()
         )),
-        "Expected an empty remote scope snapshot from B"
+        "Expected an empty settled remote scope from B"
     );
     for entry in b_out {
         if entry.destination == Destination::Client(s.a_client_of_b) {
@@ -1603,8 +1603,7 @@ fn rc_transaction_visible_subscription_hides_partial_accepted_batch_until_scope_
                     remaining_row_payloads.push(payload);
                 }
             }
-            payload @ SyncPayload::QueryScopeSnapshot { .. }
-            | payload @ SyncPayload::BatchSettlement { .. }
+            payload @ SyncPayload::BatchSettlement { .. }
             | payload @ SyncPayload::QuerySettled { .. }
             | payload @ SyncPayload::RowBatchStateChanged { .. } => {
                 control_payloads.push(payload);
@@ -1617,11 +1616,11 @@ fn rc_transaction_visible_subscription_hides_partial_accepted_batch_until_scope_
     assert!(
         control_payloads
             .iter()
-            .any(|payload| matches!(payload, SyncPayload::QueryScopeSnapshot { query_id, scope }
+            .any(|payload| matches!(payload, SyncPayload::QuerySettled { query_id, scope, .. }
                 if *query_id == crate::sync_manager::QueryId(0)
                     && scope.iter().map(|(object_id, _)| *object_id).collect::<std::collections::HashSet<_>>()
                         == std::collections::HashSet::from([first_id, second_id]))),
-        "expected scope snapshot covering both accepted transaction members, got {control_payloads:#?}"
+        "expected settled scope covering both accepted transaction members, got {control_payloads:#?}"
     );
     assert!(
         control_payloads.iter().any(|payload| matches!(

--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/storage_flush.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/storage_flush.rs
@@ -130,6 +130,7 @@ fn rc_batched_tick_skips_flush_wal_for_query_settled_only_message() {
         payload: SyncPayload::QuerySettled {
             query_id: crate::sync_manager::QueryId(1),
             tier: DurabilityTier::Local,
+            scope: vec![],
             through_seq: 1,
         },
     });

--- a/crates/jazz-tools/src/server/mod.rs
+++ b/crates/jazz-tools/src/server/mod.rs
@@ -87,9 +87,15 @@ impl ConnectionEventHub {
             let seq = state.next_sync_seq;
             let through_seq = seq.saturating_sub(1);
             let payload = match &payload {
-                SyncPayload::QuerySettled { query_id, tier, .. } => SyncPayload::QuerySettled {
+                SyncPayload::QuerySettled {
+                    query_id,
+                    tier,
+                    scope,
+                    ..
+                } => SyncPayload::QuerySettled {
                     query_id: *query_id,
                     tier: *tier,
+                    scope: scope.clone(),
                     through_seq,
                 },
                 _ => payload.clone(),

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -1097,7 +1097,12 @@ impl SyncManager {
                     batch_ids,
                 );
             }
-            SyncPayload::QueryScopeSnapshot { query_id, scope } => {
+            SyncPayload::QuerySettled {
+                query_id,
+                tier,
+                scope,
+                through_seq,
+            } => {
                 let scope_set: HashSet<(ObjectId, BranchName)> = scope.iter().copied().collect();
                 let scope_changed = self
                     .remote_query_scopes
@@ -1109,23 +1114,6 @@ impl SyncManager {
                     self.remote_query_scope_dirty.insert(query_id);
                 }
 
-                if let Some(clients) = self.query_origin.get(&query_id) {
-                    for &cid in clients {
-                        self.outbox.push(OutboxEntry {
-                            destination: Destination::Client(cid),
-                            payload: SyncPayload::QueryScopeSnapshot {
-                                query_id,
-                                scope: scope.clone(),
-                            },
-                        });
-                    }
-                }
-            }
-            SyncPayload::QuerySettled {
-                query_id,
-                tier,
-                through_seq,
-            } => {
                 tracing::debug!(?query_id, "server→QuerySettled");
                 // Queue for local QueryManager to process
                 self.pending_query_settled.push(PendingQuerySettled {
@@ -1143,6 +1131,7 @@ impl SyncManager {
                             payload: SyncPayload::QuerySettled {
                                 query_id,
                                 tier,
+                                scope: scope.clone(),
                                 through_seq,
                             },
                         });
@@ -1483,6 +1472,7 @@ impl SyncManager {
             SyncPayload::QuerySettled {
                 query_id,
                 tier,
+                scope: _,
                 through_seq,
             } => {
                 // Client relaying a QuerySettled from downstream
@@ -1498,13 +1488,6 @@ impl SyncManager {
                     %client_id,
                     query_id = warning.query_id.0,
                     "client attempted to send SchemaWarning payload; ignoring"
-                );
-            }
-            SyncPayload::QueryScopeSnapshot { query_id, .. } => {
-                tracing::warn!(
-                    %client_id,
-                    query_id = query_id.0,
-                    "client attempted to send QueryScopeSnapshot payload; ignoring"
                 );
             }
             SyncPayload::ConnectionSchemaDiagnostics(_) => {

--- a/crates/jazz-tools/src/sync_manager/mod.rs
+++ b/crates/jazz-tools/src/sync_manager/mod.rs
@@ -646,14 +646,6 @@ impl SyncManager {
                 true,
             );
         }
-
-        self.outbox.push(OutboxEntry {
-            destination: Destination::Client(client_id),
-            payload: SyncPayload::QueryScopeSnapshot {
-                query_id,
-                scope: sorted_query_scope_snapshot(&scope),
-            },
-        });
     }
 
     /// Drop a client's query subscription state.
@@ -856,12 +848,14 @@ impl SyncManager {
         client_id: ClientId,
         query_id: QueryId,
         tier: DurabilityTier,
+        scope: &HashSet<(ObjectId, BranchName)>,
     ) {
         self.outbox.push(OutboxEntry {
             destination: Destination::Client(client_id),
             payload: SyncPayload::QuerySettled {
                 query_id,
                 tier,
+                scope: sorted_query_scope_snapshot(scope),
                 through_seq: 0,
             },
         });

--- a/crates/jazz-tools/src/sync_manager/sync_tracer.rs
+++ b/crates/jazz-tools/src/sync_manager/sync_tracer.rs
@@ -921,15 +921,18 @@ impl<'a> Normalizer<'a> {
             SyncPayload::QueryUnsubscription { query_id } => {
                 format!("query:{}", query_id.0)
             }
-            SyncPayload::QueryScopeSnapshot { query_id, scope } => {
-                format!("query:{} scope:{}", query_id.0, scope.len())
-            }
             SyncPayload::QuerySettled {
                 query_id,
+                scope,
                 through_seq,
                 ..
             } => {
-                format!("query:{} through_seq:{}", query_id.0, through_seq)
+                format!(
+                    "query:{} scope:{} through_seq:{}",
+                    query_id.0,
+                    scope.len(),
+                    through_seq
+                )
             }
             SyncPayload::SchemaWarning(w) => {
                 format!("query:{} table:{}", w.query_id.0, w.table_name)
@@ -1104,15 +1107,18 @@ fn format_payload_details(payload: &SyncPayload, names: &Names<'_>) -> String {
         SyncPayload::QueryUnsubscription { query_id } => {
             format!("query:{}", query_id.0)
         }
-        SyncPayload::QueryScopeSnapshot { query_id, scope } => {
-            format!("query:{} scope:{}", query_id.0, scope.len())
-        }
         SyncPayload::QuerySettled {
             query_id,
+            scope,
             through_seq,
             ..
         } => {
-            format!("query:{} through_seq:{}", query_id.0, through_seq)
+            format!(
+                "query:{} scope:{} through_seq:{}",
+                query_id.0,
+                scope.len(),
+                through_seq
+            )
         }
         SyncPayload::SchemaWarning(w) => {
             format!("query:{} table:{}", w.query_id.0, w.table_name)

--- a/crates/jazz-tools/src/sync_manager/tests/basic.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/basic.rs
@@ -58,6 +58,7 @@ fn memory_size_separates_sync_state_buckets() {
         payload: SyncPayload::QuerySettled {
             query_id: QueryId(7),
             tier: DurabilityTier::Local,
+            scope: vec![],
             through_seq: 1,
         },
     });

--- a/crates/jazz-tools/src/sync_manager/tests/query_scope.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/query_scope.rs
@@ -34,38 +34,7 @@ fn set_query_scope_stores_session() {
 }
 
 #[test]
-fn set_query_scope_emits_query_scope_snapshot_to_client() {
-    let mut sm = SyncManager::new();
-    let io = MemoryStorage::new();
-    let client_id = ClientId::new();
-    let row_id = ObjectId::new();
-    let query_id = QueryId(7);
-
-    add_client(&mut sm, &io, client_id);
-    sm.take_outbox();
-
-    set_client_query_scope(
-        &mut sm,
-        &io,
-        client_id,
-        query_id,
-        HashSet::from([(row_id, BranchName::new("main"))]),
-        None,
-    );
-
-    assert!(sm.take_outbox().into_iter().any(|entry| matches!(
-        entry,
-        OutboxEntry {
-            destination: Destination::Client(id),
-            payload: SyncPayload::QueryScopeSnapshot { query_id: snapshot_query_id, scope },
-        } if id == client_id
-            && snapshot_query_id == query_id
-            && scope == vec![(row_id, BranchName::new("main"))]
-    )));
-}
-
-#[test]
-fn query_scope_snapshot_from_server_is_stored_for_query() {
+fn query_settled_from_server_stores_scope_for_query() {
     let mut sm = SyncManager::new();
     let mut io = MemoryStorage::new();
     let server_id = ServerId::new();
@@ -76,12 +45,14 @@ fn query_scope_snapshot_from_server_is_stored_for_query() {
     sm.process_from_server(
         &mut io,
         server_id,
-        SyncPayload::QueryScopeSnapshot {
+        SyncPayload::QuerySettled {
             query_id,
+            tier: DurabilityTier::Local,
             scope: vec![
                 (second_row_id, BranchName::new("main")),
                 (first_row_id, BranchName::new("main")),
             ],
+            through_seq: 0,
         },
     );
 
@@ -95,7 +66,7 @@ fn query_scope_snapshot_from_server_is_stored_for_query() {
 }
 
 #[test]
-fn query_scope_snapshot_from_server_relays_to_interested_clients() {
+fn query_settled_from_server_relays_scope_to_interested_clients() {
     let mut sm = SyncManager::new();
     let mut io = MemoryStorage::new();
     let client_id = ClientId::new();
@@ -113,9 +84,11 @@ fn query_scope_snapshot_from_server_relays_to_interested_clients() {
     sm.process_from_server(
         &mut io,
         server_id,
-        SyncPayload::QueryScopeSnapshot {
+        SyncPayload::QuerySettled {
             query_id,
+            tier: DurabilityTier::Local,
             scope: vec![(row_id, BranchName::new("main"))],
+            through_seq: 0,
         },
     );
 
@@ -123,7 +96,7 @@ fn query_scope_snapshot_from_server_relays_to_interested_clients() {
         entry,
         OutboxEntry {
             destination: Destination::Client(id),
-            payload: SyncPayload::QueryScopeSnapshot { query_id: relayed_query_id, scope },
+            payload: SyncPayload::QuerySettled { query_id: relayed_query_id, scope, .. },
         } if id == client_id
             && relayed_query_id == query_id
             && scope == vec![(row_id, BranchName::new("main"))]
@@ -141,9 +114,11 @@ fn remove_server_clears_remote_query_scope() {
     sm.process_from_server(
         &mut io,
         server_id,
-        SyncPayload::QueryScopeSnapshot {
+        SyncPayload::QuerySettled {
             query_id,
+            tier: DurabilityTier::Local,
             scope: vec![(row_id, BranchName::new("main"))],
+            through_seq: 0,
         },
     );
     assert_eq!(

--- a/crates/jazz-tools/src/sync_manager/types.rs
+++ b/crates/jazz-tools/src/sync_manager/types.rs
@@ -308,13 +308,8 @@ pub enum SyncPayload {
     /// Unsubscribe from a query (client to server).
     QueryUnsubscription { query_id: QueryId },
 
-    /// Replayable scope snapshot for one query subscription.
-    QueryScopeSnapshot {
-        query_id: QueryId,
-        scope: Vec<(ObjectId, BranchName)>,
-    },
-
-    /// Query frontier settlement notification.
+    /// Query frontier settlement notification with the authoritative query scope
+    /// for the settled server result.
     ///
     /// This means the upstream server has reached a complete first frontier for the
     /// subscription. Per-row durability remains encoded and replayed on the rows
@@ -322,6 +317,7 @@ pub enum SyncPayload {
     QuerySettled {
         query_id: QueryId,
         tier: DurabilityTier,
+        scope: Vec<(ObjectId, BranchName)>,
         /// Highest stream sequence known to be emitted before this notification.
         through_seq: u64,
     },
@@ -444,7 +440,7 @@ impl SyncPayload {
             SyncPayload::SealBatch { submission } => {
                 submission.members.first().map(|member| member.object_id)
             }
-            SyncPayload::QueryScopeSnapshot { scope, .. } => {
+            SyncPayload::QuerySettled { scope, .. } => {
                 scope.first().map(|(object_id, _)| *object_id)
             }
             _ => None,
@@ -469,7 +465,7 @@ impl SyncPayload {
             },
             SyncPayload::BatchSettlementNeeded { .. } => None,
             SyncPayload::SealBatch { .. } => None,
-            SyncPayload::QueryScopeSnapshot { scope, .. } => {
+            SyncPayload::QuerySettled { scope, .. } => {
                 scope.first().map(|(_, branch_name)| *branch_name)
             }
             _ => None,
@@ -529,7 +525,6 @@ impl SyncPayload {
             SyncPayload::SealBatch { .. } => "SealBatch",
             SyncPayload::QuerySubscription { .. } => "QuerySubscription",
             SyncPayload::QueryUnsubscription { .. } => "QueryUnsubscription",
-            SyncPayload::QueryScopeSnapshot { .. } => "QueryScopeSnapshot",
             SyncPayload::QuerySettled { .. } => "QuerySettled",
             SyncPayload::SchemaWarning(_) => "SchemaWarning",
             SyncPayload::ConnectionSchemaDiagnostics(_) => "ConnectionSchemaDiagnostics",

--- a/crates/jazz-tools/tests/catalogue_sync_integration.rs
+++ b/crates/jazz-tools/tests/catalogue_sync_integration.rs
@@ -74,20 +74,18 @@ async fn dynamic_server_denies_reads_until_permissions_head_is_published() {
     let reader = JazzClient::connect(reader_context)
         .await
         .expect("connect reader");
-    wait_for_edge_query_ready(&reader, "users", Duration::from_secs(30)).await;
 
-    let rows_before_permissions = wait_for_query(
-        &reader,
-        QueryBuilder::new("users").build(),
-        Some(DurabilityTier::EdgeServer),
-        Duration::from_secs(10),
-        "reader query before permissions head",
-        Some,
-    )
-    .await;
     assert!(
-        rows_before_permissions.is_empty(),
-        "dynamic server should deny reads before any permissions head is published"
+        tokio::time::timeout(
+            Duration::from_secs(3),
+            reader.query(
+                QueryBuilder::new("users").build(),
+                Some(DurabilityTier::EdgeServer),
+            ),
+        )
+        .await
+        .is_err(),
+        "dynamic server should not settle reads before any permissions head is published"
     );
 
     publish_allow_all_permissions(
@@ -97,6 +95,8 @@ async fn dynamic_server_denies_reads_until_permissions_head_is_published() {
         &schema,
     )
     .await;
+
+    wait_for_edge_query_ready(&reader, "users", Duration::from_secs(30)).await;
 
     let admin =
         JazzClient::connect(server.make_client_context_for_user(schema.clone(), "admin-dynamic"))
@@ -145,7 +145,6 @@ async fn dynamic_server_keeps_pre_permissions_user_write_hidden_after_publish() 
         .with_server(&server)
         .with_schema(schema.clone())
         .with_user_id("observer-queued-write")
-        .ready_on("users", Duration::from_secs(30))
         .connect()
         .await;
     let writer = TestingClient::builder()
@@ -153,7 +152,6 @@ async fn dynamic_server_keeps_pre_permissions_user_write_hidden_after_publish() 
         .with_schema(schema.clone())
         .with_user_id("writer-queued-write")
         .as_user()
-        .ready_on("users", Duration::from_secs(30))
         .connect()
         .await;
 
@@ -178,18 +176,14 @@ async fn dynamic_server_keeps_pre_permissions_user_write_hidden_after_publish() 
         "expected missing permissions-head reason, got: {queued_write_error}"
     );
 
-    let rows_before_permissions = wait_for_query(
-        &observer,
-        query.clone(),
-        Some(DurabilityTier::EdgeServer),
-        Duration::from_secs(5),
-        "observer query before permissions for queued write",
-        Some,
-    )
-    .await;
     assert!(
-        rows_before_permissions.is_empty(),
-        "server should keep queued user writes invisible before permissions arrive"
+        tokio::time::timeout(
+            Duration::from_secs(3),
+            observer.query(query.clone(), Some(DurabilityTier::EdgeServer)),
+        )
+        .await
+        .is_err(),
+        "server should not settle observer queries before permissions arrive"
     );
 
     publish_allow_all_permissions(
@@ -199,6 +193,8 @@ async fn dynamic_server_keeps_pre_permissions_user_write_hidden_after_publish() 
         &schema,
     )
     .await;
+    wait_for_edge_query_ready(&observer, "users", Duration::from_secs(30)).await;
+    wait_for_edge_query_ready(&writer, "users", Duration::from_secs(30)).await;
 
     let rows_after_publish = wait_for_query(
         &observer,
@@ -307,7 +303,6 @@ async fn dynamic_server_rejects_user_write_after_permissions_timeout() {
         .with_server(&server)
         .with_schema(schema.clone())
         .with_user_id("observer-timeout-write")
-        .ready_on("users", Duration::from_secs(30))
         .connect()
         .await;
     let writer = TestingClient::builder()
@@ -315,7 +310,6 @@ async fn dynamic_server_rejects_user_write_after_permissions_timeout() {
         .with_schema(schema.clone())
         .with_user_id("writer-timeout-write")
         .as_user()
-        .ready_on("users", Duration::from_secs(30))
         .connect()
         .await;
 
@@ -329,18 +323,14 @@ async fn dynamic_server_rejects_user_write_after_permissions_timeout() {
         .expect("optimistic local create before timeout");
 
     tokio::time::sleep(Duration::from_secs(12)).await;
-    let rows_after_timeout = wait_for_query(
-        &observer,
-        query.clone(),
-        Some(DurabilityTier::EdgeServer),
-        Duration::from_secs(5),
-        "observer query after timeout before permissions publish",
-        Some,
-    )
-    .await;
     assert!(
-        rows_after_timeout.is_empty(),
-        "timed-out write should still be absent before permissions are published"
+        tokio::time::timeout(
+            Duration::from_secs(3),
+            observer.query(query.clone(), Some(DurabilityTier::EdgeServer)),
+        )
+        .await
+        .is_err(),
+        "observer query should remain unsettled before permissions are published"
     );
     publish_allow_all_permissions(
         &server.base_url(),
@@ -349,6 +339,8 @@ async fn dynamic_server_rejects_user_write_after_permissions_timeout() {
         &schema,
     )
     .await;
+    wait_for_edge_query_ready(&observer, "users", Duration::from_secs(30)).await;
+    wait_for_edge_query_ready(&writer, "users", Duration::from_secs(30)).await;
 
     let allowed_user_id = jazz_tools::ObjectId::new();
     let (allowed_row_id, _) = writer
@@ -399,7 +391,6 @@ async fn dynamic_server_live_subscription_replays_on_first_permissions_head_and_
         .with_schema(schema.clone())
         .with_user_id("reader-subscribe")
         .as_user()
-        .ready_on("users", Duration::from_secs(30))
         .connect()
         .await;
     let mut stream = reader
@@ -412,13 +403,13 @@ async fn dynamic_server_live_subscription_replays_on_first_permissions_head_and_
         &mut stream,
         &mut log,
         Duration::from_secs(10),
-        "initial empty subscription snapshot before permissions",
+        "initial empty local subscription snapshot before permissions",
         |updates| !updates.is_empty(),
     )
     .await;
     assert!(
         log[0].is_empty(),
-        "first subscription snapshot should fail closed as an empty delta"
+        "plain local subscription should fail closed as an empty local delta before permissions"
     );
 
     let allow_head = publish_allow_all_permissions(

--- a/crates/jazz-tools/tests/clients_sync.rs
+++ b/crates/jazz-tools/tests/clients_sync.rs
@@ -10,7 +10,7 @@ use jazz_tools::server::TestingServer;
 use jazz_tools::{
     ColumnType, DurabilityTier, JazzClient, QueryBuilder, SchemaBuilder, TableSchema, Value,
 };
-use support::wait_for_query;
+use support::{publish_allow_all_permissions, wait_for_query};
 use uuid::Uuid;
 
 fn test_schema() -> jazz_tools::Schema {
@@ -217,8 +217,15 @@ async fn jazz_tools_cli_two_clients_sync_values() {
 
 #[tokio::test]
 async fn caller_supplied_uuid_is_used_for_created_row() {
-    let server = TestingServer::start().await;
     let schema = test_schema();
+    let server = TestingServer::start_with_schema(schema.clone()).await;
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &schema,
+    )
+    .await;
     let client = JazzClient::connect(server.make_client_context(schema.clone()))
         .await
         .expect("connect writer");
@@ -266,8 +273,15 @@ async fn caller_supplied_uuid_is_used_for_created_row() {
 
 #[tokio::test]
 async fn caller_supplied_uuid_keeps_created_at_as_explicit_metadata() {
-    let server = TestingServer::start().await;
     let schema = test_schema();
+    let server = TestingServer::start_with_schema(schema.clone()).await;
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &schema,
+    )
+    .await;
     let client = JazzClient::connect(server.make_client_context(schema.clone()))
         .await
         .expect("connect writer");
@@ -334,8 +348,15 @@ async fn caller_supplied_uuid_keeps_created_at_as_explicit_metadata() {
 
 #[tokio::test]
 async fn upsert_uses_external_uuid_for_insert_and_updates_existing_row() {
-    let server = TestingServer::start().await;
     let schema = test_schema();
+    let server = TestingServer::start_with_schema(schema.clone()).await;
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &schema,
+    )
+    .await;
     let client = JazzClient::connect(server.make_client_context(schema.clone()))
         .await
         .expect("connect writer");

--- a/crates/jazz-tools/tests/rocksdb_storage_integration.rs
+++ b/crates/jazz-tools/tests/rocksdb_storage_integration.rs
@@ -239,7 +239,6 @@ async fn make_client(
         .with_server(server)
         .with_schema(schema.clone())
         .with_user_id(user_id)
-        .ready_on(ready_table, READY_TIMEOUT)
         .connect()
         .await;
 
@@ -248,6 +247,15 @@ async fn make_client(
         server.app_id(),
         server.admin_secret(),
         &schema,
+    )
+    .await;
+    wait_for_query(
+        &client,
+        QueryBuilder::new(ready_table).build(),
+        Some(DurabilityTier::EdgeServer),
+        READY_TIMEOUT,
+        format!("EdgeServer query readiness for {ready_table}"),
+        |_| Some(()),
     )
     .await;
 
@@ -277,6 +285,13 @@ async fn make_client_external_jwks(
 
     let client = JazzClient::connect(context).await.expect("connect client");
 
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &schema,
+    )
+    .await;
     wait_for_query(
         &client,
         QueryBuilder::new(ready_table).build(),
@@ -284,13 +299,6 @@ async fn make_client_external_jwks(
         READY_TIMEOUT,
         format!("EdgeServer query readiness for {ready_table}"),
         |_| Some(()),
-    )
-    .await;
-    publish_allow_all_permissions(
-        &server.base_url(),
-        server.app_id(),
-        server.admin_secret(),
-        &schema,
     )
     .await;
 

--- a/crates/jazz-tools/tests/sqlite_storage_integration.rs
+++ b/crates/jazz-tools/tests/sqlite_storage_integration.rs
@@ -239,7 +239,6 @@ async fn make_client(
         .with_server(server)
         .with_schema(schema.clone())
         .with_user_id(user_id)
-        .ready_on(ready_table, READY_TIMEOUT)
         .connect()
         .await;
 
@@ -248,6 +247,15 @@ async fn make_client(
         server.app_id(),
         server.admin_secret(),
         &schema,
+    )
+    .await;
+    wait_for_query(
+        &client,
+        QueryBuilder::new(ready_table).build(),
+        Some(DurabilityTier::EdgeServer),
+        READY_TIMEOUT,
+        format!("EdgeServer query readiness for {ready_table}"),
+        |_| Some(()),
     )
     .await;
 
@@ -277,6 +285,13 @@ async fn make_client_external_jwks(
 
     let client = JazzClient::connect(context).await.expect("connect client");
 
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &schema,
+    )
+    .await;
     wait_for_query(
         &client,
         QueryBuilder::new(ready_table).build(),
@@ -284,13 +299,6 @@ async fn make_client_external_jwks(
         READY_TIMEOUT,
         format!("EdgeServer query readiness for {ready_table}"),
         |_| Some(()),
-    )
-    .await;
-    publish_allow_all_permissions(
-        &server.base_url(),
-        server.app_id(),
-        server.admin_secret(),
-        &schema,
     )
     .await;
 

--- a/crates/jazz-tools/tests/sync_tracer_integration.rs
+++ b/crates/jazz-tools/tests/sync_tracer_integration.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use jazz_tools::server::TestingServer;
+use jazz_tools::sync_manager::SyncPayload;
 use jazz_tools::sync_tracer::SyncTracer;
 use jazz_tools::{ColumnType, DurabilityTier, QueryBuilder, SchemaBuilder, TableSchema, Value};
 use support::{TestingClient, wait_for_query};
@@ -134,16 +135,11 @@ async fn alice_write_bob_read() {
             "bob should see a batch settlement from the server"
         );
         assert!(
-            messages
-                .iter()
-                .any(|message| message.payload.variant_name() == "QueryScopeSnapshot"),
-            "bob should see at least one query scope snapshot from the server"
-        );
-        assert!(
-            messages
-                .iter()
-                .any(|message| message.payload.variant_name() == "QuerySettled"),
-            "bob should see query settlement from the server"
+            messages.iter().any(|message| matches!(
+                &message.payload,
+                SyncPayload::QuerySettled { scope, .. } if !scope.is_empty()
+            )),
+            "bob should see query settlement carrying the server scope"
         );
         assert!(
             messages.iter().any(|message| message.is_object_updated()),

--- a/crates/jazz-wasm/src/runtime.rs
+++ b/crates/jazz-wasm/src/runtime.rs
@@ -499,6 +499,7 @@ impl Scheduler for WasmScheduler {
 struct JsSyncSenderInner {
     callback: RefCell<Option<Function>>,
     use_binary_encoding: bool,
+    next_client_sequences: RefCell<HashMap<String, u64>>,
 }
 
 #[derive(Clone)]
@@ -517,6 +518,7 @@ impl JsSyncSender {
             inner: Rc::new(JsSyncSenderInner {
                 callback: RefCell::new(None),
                 use_binary_encoding,
+                next_client_sequences: RefCell::new(HashMap::new()),
             }),
         }
     }
@@ -534,25 +536,60 @@ impl SyncSender for JsSyncSender {
                 Destination::Server(server_id) => ("server", server_id.0.to_string()),
                 Destination::Client(client_id) => ("client", client_id.0.to_string()),
             };
+            let sequence = if destination_kind == "client" {
+                let mut next_sequences = self.inner.next_client_sequences.borrow_mut();
+                let sequence = next_sequences
+                    .entry(destination_id.clone())
+                    .and_modify(|next| *next += 1)
+                    .or_insert(1);
+                Some(*sequence)
+            } else {
+                None
+            };
+            let payload = match (&message.payload, sequence) {
+                (
+                    SyncPayload::QuerySettled {
+                        query_id,
+                        tier,
+                        scope,
+                        ..
+                    },
+                    Some(sequence),
+                ) => SyncPayload::QuerySettled {
+                    query_id: *query_id,
+                    tier: *tier,
+                    scope: scope.clone(),
+                    through_seq: sequence.saturating_sub(1),
+                },
+                _ => message.payload,
+            };
             if self.inner.use_binary_encoding || destination_kind == "client" {
-                if let Ok(payload_bytes) = message.payload.to_bytes() {
+                if let Ok(payload_bytes) = payload.to_bytes() {
                     let payload_js = Uint8Array::from(payload_bytes.as_slice());
-                    let _ = callback.call4(
+                    let sequence_js = sequence
+                        .map(|sequence| JsValue::from_f64(sequence as f64))
+                        .unwrap_or(JsValue::NULL);
+                    let _ = callback.call5(
                         &JsValue::NULL,
                         &JsValue::from_str(destination_kind),
                         &JsValue::from_str(&destination_id),
                         &payload_js.into(),
                         &JsValue::from_bool(is_catalogue),
+                        &sequence_js,
                     );
                 }
             } else {
-                let payload_json = message.payload.to_json().unwrap();
-                let _ = callback.call4(
+                let payload_json = payload.to_json().unwrap();
+                let sequence_js = sequence
+                    .map(|sequence| JsValue::from_f64(sequence as f64))
+                    .unwrap_or(JsValue::NULL);
+                let _ = callback.call5(
                     &JsValue::NULL,
                     &JsValue::from_str(destination_kind),
                     &JsValue::from_str(&destination_id),
                     &JsValue::from_str(&payload_json),
                     &JsValue::from_bool(is_catalogue),
+                    &sequence_js,
                 );
             }
         }

--- a/examples/chat-react/src/components/InviteHandler.tsx
+++ b/examples/chat-react/src/components/InviteHandler.tsx
@@ -3,7 +3,7 @@ import { useDb, useSession } from "jazz-tools/react";
 import { navigate } from "@/hooks/useRouter";
 import { useMyProfile } from "@/hooks/useMyProfile";
 import { app } from "../../schema.js";
-import { type Db, DurabilityTier } from "jazz-tools";
+import { DurabilityTier } from "jazz-tools";
 
 interface InviteHandlerProps {
   chatId: string;
@@ -46,7 +46,12 @@ export function InviteHandler({ chatId, code }: InviteHandlerProps) {
         joinCode: code,
       })
       .wait(sharedWriteOptions)
-      .then(() => waitForInvitedMessages(db, chatId, code, userId, sharedWriteOptions.tier))
+      .then(() =>
+        db.all(app.messages.where({ chatId }), {
+          tier: sharedWriteOptions.tier,
+          visibility: "hidden_from_live_query_list",
+        }),
+      )
       .then(() => {
         navigate(`/#/chat/${chatId}`);
       })
@@ -61,34 +66,4 @@ export function InviteHandler({ chatId, code }: InviteHandlerProps) {
       Joining chat...
     </div>
   );
-}
-
-function waitForInvitedMessages(
-  db: Db,
-  chatId: string,
-  code: string,
-  userId: string,
-  tier: DurabilityTier,
-): Promise<void> {
-  return new Promise((resolve) => {
-    let unsubscribe: (() => void) | undefined;
-    let settled = false;
-    const finish = () => {
-      if (settled) return;
-      settled = true;
-      window.clearTimeout(timeout);
-      queueMicrotask(() => unsubscribe?.());
-      resolve();
-    };
-    const timeout = window.setTimeout(finish, 3000);
-
-    unsubscribe = db.subscribeAll(
-      app.messages.where({ chatId }),
-      (delta) => {
-        if (delta.all.length > 0) finish();
-      },
-      { tier, visibility: "hidden_from_live_query_list" },
-      { user_id: userId, claims: { join_code: code }, authMode: "external" },
-    );
-  });
 }

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -2167,8 +2167,16 @@ export class JazzClient {
     query: string | QueryInput,
     callback: SubscriptionCallback,
     options?: QueryExecutionOptions,
+    beforeExecute?: () => Promise<void>,
   ): number {
-    return this.subscribeInternal(query, callback, this.resolvedSession ?? undefined, options);
+    return this.subscribeInternal(
+      query,
+      callback,
+      this.resolvedSession ?? undefined,
+      options,
+      undefined,
+      beforeExecute,
+    );
   }
 
   /**
@@ -2187,6 +2195,7 @@ export class JazzClient {
     session?: Session,
     options?: QueryExecutionOptions,
     runtimeSchema?: WasmSchema,
+    beforeExecute?: () => Promise<void>,
   ): number {
     const normalizedOptions = this.normalizeQueryExecutionOptions(options);
     const sessionJson = session ? JSON.stringify(session) : undefined;
@@ -2202,7 +2211,8 @@ export class JazzClient {
       optionsJson,
     );
 
-    this.scheduler(() => {
+    this.scheduler(async () => {
+      await beforeExecute?.();
       this.runtime.executeSubscription(handle, (...args: unknown[]) => {
         const deltaJsonOrObject = normalizeSubscriptionCallbackArgs(args);
         if (deltaJsonOrObject === undefined) {

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -2701,10 +2701,35 @@ export class Db {
 
     const handleDelta = (delta: Parameters<SubscriptionManager<T>["handleDelta"]>[0]) => {
       const typedDelta = manager.handleDelta(delta, transform);
+      if (beforeExecute && !deliveredFirstTieredDelta) {
+        pendingFirstTieredDelta = typedDelta;
+        if (firstTieredDeltaTimer) {
+          clearTimeout(firstTieredDeltaTimer);
+        }
+        firstTieredDeltaTimer = setTimeout(deliverFirstTieredDelta, 50);
+        return;
+      }
       callback(typedDelta);
     };
 
     const queryOptions = ordinaryDbQueryOptions(options);
+    const beforeExecute =
+      queryOptions.tier && queryOptions.tier !== "local"
+        ? () => this.ensureQueryReady(queryOptions)
+        : undefined;
+    let deliveredFirstTieredDelta = false;
+    let pendingFirstTieredDelta: SubscriptionDelta<T> | undefined;
+    let firstTieredDeltaTimer: ReturnType<typeof setTimeout> | undefined;
+    const deliverFirstTieredDelta = () => {
+      firstTieredDeltaTimer = undefined;
+      if (!pendingFirstTieredDelta) {
+        return;
+      }
+      const pendingDelta = pendingFirstTieredDelta;
+      pendingFirstTieredDelta = undefined;
+      deliveredFirstTieredDelta = true;
+      callback(pendingDelta);
+    };
     const subId =
       session !== undefined
         ? client.subscribeInternal(
@@ -2713,8 +2738,9 @@ export class Db {
             session,
             queryOptions,
             runtimeSchema.peek(),
+            beforeExecute,
           )
-        : client.subscribe(wasmQuery, handleDelta, queryOptions);
+        : client.subscribe(wasmQuery, handleDelta, queryOptions, beforeExecute);
     const traceId = this.registerActiveQuerySubscriptionTrace(
       wasmQuery,
       builtQuery.table,
@@ -2723,6 +2749,9 @@ export class Db {
 
     // Return unsubscribe function
     return () => {
+      if (firstTieredDeltaTimer) {
+        clearTimeout(firstTieredDeltaTimer);
+      }
       this.unregisterActiveQuerySubscriptionTrace(traceId);
       client.unsubscribe(subId);
       manager.clear();
@@ -3101,19 +3130,49 @@ class ClientBackedDb extends Db {
         outputTable === builtQuery.table ? query : {},
         transformRow(row, outputSchema, outputTable, outputIncludes, builtQuery.select),
       );
+    const queryOptions = ordinaryDbQueryOptions(options);
+    const beforeExecute =
+      queryOptions.tier && queryOptions.tier !== "local"
+        ? () => this.ensureQueryReady(queryOptions)
+        : undefined;
+    let deliveredFirstTieredDelta = false;
+    let pendingFirstTieredDelta: SubscriptionDelta<T> | undefined;
+    let firstTieredDeltaTimer: ReturnType<typeof setTimeout> | undefined;
+    const deliverFirstTieredDelta = () => {
+      firstTieredDeltaTimer = undefined;
+      if (!pendingFirstTieredDelta) {
+        return;
+      }
+      const pendingDelta = pendingFirstTieredDelta;
+      pendingFirstTieredDelta = undefined;
+      deliveredFirstTieredDelta = true;
+      callback(pendingDelta);
+    };
 
     const subId = this.runtimeClient.subscribeInternal(
       wasmQuery,
       (delta) => {
         const typedDelta = manager.handleDelta(delta, transform);
+        if (beforeExecute && !deliveredFirstTieredDelta) {
+          pendingFirstTieredDelta = typedDelta;
+          if (firstTieredDeltaTimer) {
+            clearTimeout(firstTieredDeltaTimer);
+          }
+          firstTieredDeltaTimer = setTimeout(deliverFirstTieredDelta, 50);
+          return;
+        }
         callback(typedDelta);
       },
       this.session,
-      ordinaryDbQueryOptions(options),
+      queryOptions,
       runtimeSchema.peek(),
+      beforeExecute,
     );
 
     return () => {
+      if (firstTieredDeltaTimer) {
+        clearTimeout(firstTieredDeltaTimer);
+      }
       this.runtimeClient.unsubscribe(subId);
       manager.clear();
     };

--- a/packages/jazz-tools/src/runtime/permissions.repro.test.ts
+++ b/packages/jazz-tools/src/runtime/permissions.repro.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { describe, expect, it, onTestFinished } from "vitest";
 import { schema as s } from "../index.js";
 import { definePermissions } from "../permissions/index.js";
-import { publishStoredSchema } from "./schema-fetch.js";
+import { publishStoredPermissions, publishStoredSchema } from "./schema-fetch.js";
 import { startLocalJazzServer } from "../testing/local-jazz-server.js";
 
 const reproApp = s.defineApp({
@@ -167,13 +167,19 @@ async function createServerBackedReproContext(
     backendSecret,
     adminSecret,
   });
-  await publishStoredSchema(server.url, {
+  const permissions = definePermissions(reproApp, defineCasePermissions);
+  const publishedSchema = await publishStoredSchema(server.url, {
     appId,
     adminSecret,
     schema: reproApp.wasmSchema,
   });
+  await publishStoredPermissions(server.url, {
+    appId,
+    adminSecret,
+    schemaHash: publishedSchema.hash,
+    permissions,
+  });
 
-  const permissions = definePermissions(reproApp, defineCasePermissions);
   const { createJazzContext } = await import("../backend/create-jazz-context.js");
   const context = createJazzContext({
     appId: server.appId,

--- a/packages/jazz-tools/src/runtime/sync-transport.ts
+++ b/packages/jazz-tools/src/runtime/sync-transport.ts
@@ -11,8 +11,12 @@ export type AuthFailureReason = "expired" | "missing" | "invalid" | "disabled";
 
 export interface SyncOutboxRouterOptions {
   logPrefix?: string;
-  onServerPayload(payload: Uint8Array | string, isCatalogue: boolean): void | Promise<void>;
-  onClientPayload?(payload: Uint8Array): void;
+  onServerPayload(
+    payload: Uint8Array | string,
+    isCatalogue: boolean,
+    sequence: number | null,
+  ): void | Promise<void>;
+  onClientPayload?(payload: Uint8Array, sequence: number | null): void;
   onServerPayloadError?(error: unknown): void;
   retryServerPayloads?: boolean;
 }
@@ -24,6 +28,7 @@ export type RuntimeSyncOutboxCallbackArgs =
       destinationId: string,
       payload: Uint8Array | string,
       isCatalogue: boolean,
+      sequence?: number | null,
     ]
   | [
       err: unknown,
@@ -31,6 +36,7 @@ export type RuntimeSyncOutboxCallbackArgs =
       destinationId: string,
       payload: Uint8Array | string,
       isCatalogue: boolean,
+      sequence?: number | null,
     ]
   | [
       err: unknown,
@@ -39,6 +45,7 @@ export type RuntimeSyncOutboxCallbackArgs =
         destinationId: string,
         payload: Uint8Array | string,
         isCatalogue: boolean,
+        sequence?: number | null,
       ],
     ];
 export type RuntimeSyncOutboxCallback = (...args: RuntimeSyncOutboxCallbackArgs) => void;
@@ -55,8 +62,9 @@ function normalizeOutboxCallbackArgs(args: unknown[]): {
   destinationKind: OutboxDestinationKind;
   payload: Uint8Array | string;
   isCatalogue: boolean;
+  sequence: number | null;
 } | null {
-  // WASM/RN-style callback: (destinationKind, destinationId, payloadJson, isCatalogue)
+  // WASM/RN-style callback: (destinationKind, destinationId, payloadJson, isCatalogue, sequence)
   if (isOutboxDestinationKind(args[0])) {
     const payload = args[2];
     if (!isOutboxPayload(payload)) return null;
@@ -64,10 +72,11 @@ function normalizeOutboxCallbackArgs(args: unknown[]): {
       destinationKind: args[0],
       payload: payload,
       isCatalogue: Boolean(args[3]),
+      sequence: typeof args[4] === "number" ? args[4] : null,
     };
   }
 
-  // NAPI callee-handled callback: (err, destinationKind, destinationId, payloadJson, isCatalogue)
+  // NAPI callee-handled callback: (err, destinationKind, destinationId, payloadJson, isCatalogue, sequence)
   if (isOutboxDestinationKind(args[1])) {
     const payload = args[3];
     if (!isOutboxPayload(payload)) return null;
@@ -75,10 +84,11 @@ function normalizeOutboxCallbackArgs(args: unknown[]): {
       destinationKind: args[1],
       payload: payload,
       isCatalogue: Boolean(args[4]),
+      sequence: typeof args[5] === "number" ? args[5] : null,
     };
   }
 
-  // Real NAPI callback: (err, [destinationKind, destinationId, payloadJson, isCatalogue])
+  // Real NAPI callback: (err, [destinationKind, destinationId, payloadJson, isCatalogue, sequence])
   if (Array.isArray(args[1]) && isOutboxDestinationKind(args[1][0])) {
     const payload = args[1][2];
     if (!isOutboxPayload(payload)) return null;
@@ -86,6 +96,7 @@ function normalizeOutboxCallbackArgs(args: unknown[]): {
       destinationKind: args[1][0],
       payload,
       isCatalogue: Boolean(args[1][3]),
+      sequence: typeof args[1][4] === "number" ? args[1][4] : null,
     };
   }
 
@@ -107,13 +118,13 @@ export function createSyncOutboxRouter(
       return;
     }
 
-    const { destinationKind, payload, isCatalogue } = normalized;
+    const { destinationKind, payload, isCatalogue, sequence } = normalized;
     if (destinationKind === "client") {
-      options.onClientPayload?.(payload as Uint8Array);
+      options.onClientPayload?.(payload as Uint8Array, sequence);
       return;
     }
 
-    Promise.resolve(options.onServerPayload(payload, isCatalogue)).catch((error) => {
+    Promise.resolve(options.onServerPayload(payload, isCatalogue, sequence)).catch((error) => {
       if (options.onServerPayloadError) {
         options.onServerPayloadError(error);
         return;

--- a/packages/jazz-tools/src/runtime/worker-bridge.test.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.test.ts
@@ -43,17 +43,20 @@ type SendSyncPayloadCallback = (
   destinationId: string,
   payload: Uint8Array,
   isCatalogue: boolean,
+  sequence?: number | null,
 ) => void;
 
 function createRuntimeMock(): {
   runtime: Runtime;
   emitSyncPayload: SendSyncPayloadCallback;
   receivedFromWorker: Uint8Array[];
+  receivedSequences: Array<number | null | undefined>;
   addServerCalls: { count: number };
   removeServerCalls: { count: number };
 } {
   let onSyncToSend: SendSyncPayloadCallback | null = null;
   const receivedFromWorker: Uint8Array[] = [];
+  const receivedSequences: Array<number | null | undefined> = [];
   const addServerCalls = { count: 0 };
   const removeServerCalls = { count: 0 };
 
@@ -72,10 +75,11 @@ function createRuntimeMock(): {
     unsubscribe: () => undefined,
     createSubscription: () => 1,
     executeSubscription: () => undefined,
-    onSyncMessageReceived: (payload: Uint8Array | string) => {
+    onSyncMessageReceived: (payload: Uint8Array | string, seq?: number | null) => {
       receivedFromWorker.push(
         typeof payload === "string" ? new TextEncoder().encode(payload) : payload,
       );
+      receivedSequences.push(seq);
     },
     onSyncMessageToSend: (callback: SendSyncPayloadCallback) => {
       onSyncToSend = callback;
@@ -98,13 +102,15 @@ function createRuntimeMock(): {
       destinationId: string,
       payload: Uint8Array,
       isCatalogue = false,
+      sequence?: number | null,
     ) => {
       if (!onSyncToSend) {
         throw new Error("onSyncMessageToSend callback not registered");
       }
-      onSyncToSend(destinationKind, destinationId, payload, isCatalogue);
+      onSyncToSend(destinationKind, destinationId, payload, isCatalogue, sequence);
     },
     receivedFromWorker,
+    receivedSequences,
     addServerCalls,
     removeServerCalls,
   };
@@ -127,6 +133,24 @@ describe("WorkerBridge", () => {
     });
 
     expect(runtimeMock.receivedFromWorker).toEqual([enc({ id: 1 }), enc({ id: 2 })]);
+  });
+
+  it("forwards worker sync stream sequences to the runtime", () => {
+    const worker = new MockWorker();
+    const runtimeMock = createRuntimeMock();
+
+    new WorkerBridge(worker as unknown as Worker, runtimeMock.runtime);
+
+    worker.emitFromWorker({
+      type: "sync",
+      payload: [
+        { payload: enc({ id: 1 }), sequence: 7 },
+        { payload: enc({ id: 2 }), sequence: 8 },
+      ],
+    });
+
+    expect(runtimeMock.receivedFromWorker).toEqual([enc({ id: 1 }), enc({ id: 2 })]);
+    expect(runtimeMock.receivedSequences).toEqual([7, 8]);
   });
 
   it("batches server-bound runtime payloads into one worker sync message", async () => {

--- a/packages/jazz-tools/src/runtime/worker-bridge.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.ts
@@ -11,6 +11,7 @@ import type { RuntimeSourcesConfig } from "./context.js";
 import type { AuthFailureReason } from "./sync-transport.js";
 import type {
   InitMessage,
+  SequencedSyncPayload,
   WorkerLifecycleEvent,
   WorkerToMainMessage,
 } from "../worker/worker-protocol.js";
@@ -109,8 +110,10 @@ export class WorkerBridge {
     this.worker.onmessage = (event: MessageEvent<WorkerToMainMessage>) => {
       const msg = event.data;
       if (msg.type === "sync") {
-        for (const payload of msg.payload) {
-          this.runtime.onSyncMessageReceived(payload);
+        for (const entry of msg.payload) {
+          const payload = isSequencedSyncPayload(entry) ? entry.payload : entry;
+          const sequence = isSequencedSyncPayload(entry) ? entry.sequence : undefined;
+          this.runtime.onSyncMessageReceived(payload, sequence);
         }
       } else if (msg.type === "upstream-connected") {
         this.markUpstreamServerConnected();
@@ -143,7 +146,7 @@ export class WorkerBridge {
     );
 
     // Register a server so the runtime sends sync messages to it
-    this.runtime.addServer();
+    this.runtime.addServer(null, 1);
   }
 
   /**
@@ -445,6 +448,16 @@ export class WorkerBridge {
 
 function collectPayloadTransferables(payloads: Uint8Array[]): Transferable[] {
   return payloads.map((payload) => payload.buffer);
+}
+
+function isSequencedSyncPayload(value: unknown): value is SequencedSyncPayload {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "payload" in value &&
+    "sequence" in value &&
+    typeof (value as { sequence?: unknown }).sequence === "number"
+  );
 }
 
 /**

--- a/packages/jazz-tools/src/types/jazz-wasm.d.ts
+++ b/packages/jazz-tools/src/types/jazz-wasm.d.ts
@@ -7,6 +7,7 @@ declare module "jazz-wasm" {
         destinationId: string,
         payload: string | Uint8Array,
         isCatalogue: boolean,
+        sequence?: number | null,
       ]
     | [
         err: unknown,
@@ -14,6 +15,7 @@ declare module "jazz-wasm" {
         destinationId: string,
         payload: string | Uint8Array,
         isCatalogue: boolean,
+        sequence?: number | null,
       ];
   type SyncOutboxCallback = (...args: SyncOutboxCallbackArgs) => void;
   type InsertValues = Record<string, unknown>;

--- a/packages/jazz-tools/src/worker/jazz-worker.ts
+++ b/packages/jazz-tools/src/worker/jazz-worker.ts
@@ -7,7 +7,12 @@
  * `runtime.connect()` — no HTTP/SSE code lives here.
  */
 
-import type { InitMessage, MainToWorkerMessage, WorkerToMainMessage } from "./worker-protocol.js";
+import type {
+  InitMessage,
+  MainToWorkerMessage,
+  SequencedSyncPayload,
+  WorkerToMainMessage,
+} from "./worker-protocol.js";
 import { OutboxDestinationKind } from "../runtime/sync-transport.js";
 import { mapAuthReason } from "../runtime/auth-state.js";
 import { normalizeRuntimeSchemaJson } from "../drivers/schema-wire.js";
@@ -58,7 +63,7 @@ let initComplete = false;
 let wasmInitialized = false;
 let pendingSyncMessages: Uint8Array[] = []; // Buffer sync messages until init completes
 let pendingPeerSyncMessages: Array<{ peerId: string; term: number; payload: Uint8Array[] }> = [];
-let pendingSyncPayloadsForMain: (Uint8Array | string)[] = [];
+let pendingSyncPayloadsForMain: (Uint8Array | string | SequencedSyncPayload)[] = [];
 let syncBatchFlushQueued = false;
 let bootstrapCatalogueForwarding = false;
 const DEFAULT_WASM_LOG_LEVEL = "warn";
@@ -153,8 +158,8 @@ async function ensureWorkerWasmInitialized(
   wasmInitialized = true;
 }
 
-function enqueueSyncMessageForMain(payload: Uint8Array | string): void {
-  pendingSyncPayloadsForMain.push(payload);
+function enqueueSyncMessageForMain(payload: Uint8Array | string, sequence?: number | null): void {
+  pendingSyncPayloadsForMain.push(typeof sequence === "number" ? { payload, sequence } : payload);
   if (syncBatchFlushQueued) return;
 
   syncBatchFlushQueued = true;
@@ -175,14 +180,27 @@ function post(msg: WorkerToMainMessage): void {
   self.postMessage(msg, transfer);
 }
 
-function collectPayloadTransferables(payloads: (Uint8Array | string)[]): Transferable[] {
+function collectPayloadTransferables(
+  payloads: (Uint8Array | string | SequencedSyncPayload)[],
+): Transferable[] {
   const transferables = [];
-  for (const payload of payloads) {
+  for (const entry of payloads) {
+    const payload = isSequencedSyncPayload(entry) ? entry.payload : entry;
     if (payload instanceof Uint8Array) {
       transferables.push(payload.buffer);
     }
   }
   return transferables;
+}
+
+function isSequencedSyncPayload(value: unknown): value is SequencedSyncPayload {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "payload" in value &&
+    "sequence" in value &&
+    typeof (value as { sequence?: unknown }).sequence === "number"
+  );
 }
 
 // ============================================================================
@@ -341,12 +359,13 @@ async function handleInit(msg: InitMessage): Promise<void> {
         destinationId: string,
         payload: Uint8Array | string,
         isCatalogue: boolean,
+        sequence?: number | null,
       ) => {
         if (destinationKind === "client") {
           const destinationClientId = destinationId;
           if (destinationClientId === mainClientId) {
             // Local main-thread client-bound payload.
-            enqueueSyncMessageForMain(payload);
+            enqueueSyncMessageForMain(payload, sequence);
             return;
           }
 
@@ -365,7 +384,7 @@ async function handleInit(msg: InitMessage): Promise<void> {
         } else if (destinationKind === "server") {
           if (bootstrapCatalogueForwarding) {
             if (isCatalogue) {
-              enqueueSyncMessageForMain(payload);
+              enqueueSyncMessageForMain(payload, sequence);
             }
           }
           // Server-bound payloads are delivered by the Rust transport; no TS action needed.

--- a/packages/jazz-tools/src/worker/worker-protocol.ts
+++ b/packages/jazz-tools/src/worker/worker-protocol.ts
@@ -36,6 +36,11 @@ export interface SyncToWorkerMessage {
   payload: Uint8Array[];
 }
 
+export interface SequencedSyncPayload {
+  payload: Uint8Array | string;
+  sequence: number;
+}
+
 export type WorkerLifecycleEvent =
   | "visibility-hidden"
   | "visibility-visible"
@@ -159,7 +164,7 @@ export interface UpstreamDisconnectedMessage {
 /** Forward a sync payload from worker to main thread. */
 export interface SyncToMainMessage {
   type: "sync";
-  payload: (Uint8Array | string)[];
+  payload: (Uint8Array | string | SequencedSyncPayload)[];
 }
 
 /** Forward sync payload(s) to a specific follower peer through leader main thread. */

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -1041,6 +1041,85 @@ describe("Worker Bridge with OPFS", () => {
     unsub();
   });
 
+  it("tiered subscriptions gate the first callback until the worker's settled snapshot content is local", async () => {
+    const syncServer = await publishSyncServerSchemaAndPermissions("subscribe-global-gated");
+    const sharedLocalAuthToken = generateAuthSecret();
+    const seeder = track(
+      await createDb({
+        appId: syncServer.appId,
+        driver: {
+          type: "persistent",
+          dbName: uniqueDbName("subscribe-global-gated-seeder"),
+        },
+        serverUrl: syncServer.serverUrl,
+        secret: sharedLocalAuthToken,
+      }),
+    );
+
+    const {
+      value: { id: projectId },
+    } = seeder.insert(projects, { name: `server-project-${Date.now()}` });
+    await seeder.all(app.projects.where({ id: projectId }), { tier: "global" });
+
+    const expectedTitles: string[] = [];
+    for (let i = 0; i < 12; i += 1) {
+      const title = `server-seeded-${i}`;
+      expectedTitles.push(title);
+      await seeder.insert(todos, { title, done: i % 2 === 0, projectId }).wait({ tier: "global" });
+    }
+    await seeder.shutdown();
+    ctx.untrack(seeder);
+
+    const fresh = track(
+      await createDb({
+        appId: syncServer.appId,
+        driver: {
+          type: "persistent",
+          dbName: uniqueDbName("subscribe-global-gated-fresh"),
+        },
+        serverUrl: syncServer.serverUrl,
+        secret: sharedLocalAuthToken,
+      }),
+    );
+    (fresh as unknown as { getClient(schema: WasmSchema): unknown }).getClient(app.wasmSchema);
+    await waitForCondition(
+      async () => Boolean((fresh as unknown as { worker?: Worker | null }).worker?.onmessage),
+      5000,
+      `fresh worker bridge should install its onmessage handler; diagnostics=${JSON.stringify({
+        tabRole: (fresh as unknown as { tabRole?: unknown }).tabRole,
+        workerExists: Boolean((fresh as unknown as { worker?: Worker | null }).worker),
+        workerOnMessage: Boolean(
+          (fresh as unknown as { worker?: Worker | null }).worker?.onmessage,
+        ),
+        bridge: Boolean((fresh as unknown as { workerBridge?: unknown }).workerBridge),
+        clientsType: typeof (fresh as unknown as { clients?: unknown }).clients,
+        clientKeys: Object.keys((fresh as unknown as { clients?: object }).clients ?? {}),
+      })}`,
+    );
+    const snapshots: Todo[][] = [];
+    const unsubscribe = trackSubscription(
+      fresh.subscribeAll(
+        todosByProject(projectId),
+        (delta) => {
+          snapshots.push([...delta.all]);
+        },
+        { tier: "global" },
+      ),
+    );
+
+    await waitForCondition(
+      async () => snapshots.some((snapshot) => snapshot.length === expectedTitles.length),
+      15000,
+      "global tier subscription should deliver the settled snapshot",
+    );
+
+    const firstSnapshot = snapshots[0];
+    expect(firstSnapshot).toHaveLength(expectedTitles.length);
+    expect(firstSnapshot.map((row) => row.title).sort()).toEqual([...expectedTitles].sort());
+
+    unsubscribe();
+  }, 90000);
+
   it("delivers an initial scoped subscription snapshot after seeding many synced rows", async () => {
     const sharedLocalAuthToken = generateAuthSecret();
     const syncServer = await publishSyncServerSchemaAndPermissions("subscribe-initial-snapshot");


### PR DESCRIPTION
## What

Fix tiered query subscriptions so `subscribeAll(..., { tier: "global" })` does not expose an empty/partial first callback while the requested tier's settled server result is still arriving locally.

The protocol now uses a single authoritative `QuerySettled` payload that always includes the query scope for the settled server result. The old separate `QueryScopeSnapshot` payload is gone. That makes the release signal self-contained: the same message carries the settled tier, the stream watermark, and the server scope/result dependency set.

Importantly, `QuerySettled` now has one meaning: the server has evaluated the query for that session/tier and the included scope is authoritative. If the server cannot determine that authoritative scope, for example because the permissions head/schema context is unavailable, it does not emit `QuerySettled` and tiered reads/subscriptions remain held.

The worker/main bridge preserves stream sequence metadata, initializes the main runtime's worker stream at sequence 1, and keeps `QuerySettled.through_seq` meaningful across the hop. Browser tiered subscriptions also wait for the worker bridge/upstream connection before execution and coalesce the first tiered delta burst so app callbacks do not see the worker's transient empty frame.

## Why

BoreDM observed an initial fulfillment with `0` rows followed by incremental deltas for the same global result set. That meant `QuerySettled` could unlock first delivery before the row payloads/scope defining the settled server result had been applied locally.

A previous attempt used a local storage/materialization probe against exact visible-row locators. CI showed that was too strict: exact locators are not the universal proof that a scoped row is locally queryable. The protocol-level fix is to keep the dependency in the sync stream instead of peeking into storage internals.

The final follow-up here tightens the invariant further: a server frontier that cannot be authorized is not a settled server result. Tests that previously expected remote-tier session queries to resolve without a permissions head now assert that no `QuerySettled` is emitted and the query remains pending.

## Tests

Red before the fix:

- `packages/jazz-tools/tests/browser/worker-bridge.test.ts` new E2E failed because the first snapshot was `[]` instead of the 12 server-seeded rows.

Green after the fix:

- `cargo test -p jazz-tools --lib --features test query_subscription -- --nocapture`
- `cargo test -p jazz-tools --lib --features test query_manager::manager_tests::policies -- --nocapture`
- `cargo test -p jazz-tools --lib --features test sync_manager::tests::query_scope -- --nocapture`
- `cargo test -p jazz-tools --lib sync_manager::tests::query_scope -- --nocapture`
- `cargo test -p jazz-tools --test catalogue_sync_integration --features test -- --nocapture`
- `pnpm --dir packages/jazz-tools exec vitest run --config vitest.config.ts src/runtime/worker-bridge.test.ts`
- `pnpm --dir packages/jazz-tools exec vitest run --config vitest.config.ts src/runtime/permissions.repro.test.ts --testTimeout 10000`
- `pnpm --dir packages/jazz-tools exec vitest run --config vitest.config.ts src/runtime/permissions.repro.test.ts`
- `cargo test -p jazz-tools --test subscribe_all_integration --features test subscribe_all_supports_order_by_limit_and_offset -- --nocapture`
- `pnpm --dir packages/jazz-tools exec tsc --noEmit --project tsconfig.tests.json --pretty false`
- `cargo fmt --check`
- `pnpm --filter jazz-wasm build`
- `pnpm --filter jazz-napi build`
- `pnpm --dir packages/jazz-tools exec vitest run --config vitest.config.browser.ts tests/browser/worker-bridge.test.ts -t "tiered subscriptions gate"`

I attempted the docs todo browser test locally, but that example package could not resolve `jazz-tools/testing` in this worktree invocation. CI should exercise it with the repo workflow wiring.

## Changeset

Patch changeset added for `jazz-tools` and `jazz-wasm`.
