### PR TITLE
[codex] Fix EXISTS policy sync context

### DIFF
--- a/crates/jazz-tools/src/query_manager/graph_nodes/policy_eval.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/policy_eval.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use crate::object::ObjectId;
+use crate::object::{BranchName, ObjectId};
 use crate::query_manager::policy::{
     Operation, PolicyExpr, bind_outer_row_refs, bind_relation_refs,
     evaluate_expr_recursive_with_row_id, normalize_recursive_max_depth,
@@ -14,6 +14,14 @@ use crate::query_manager::types::{
 use crate::storage::Storage;
 
 use super::super::encoding::{column_is_null, decode_column};
+
+type WitnessScope = HashSet<(ObjectId, BranchName)>;
+
+#[derive(Default)]
+pub(crate) struct ScopedPolicyResult {
+    pub(crate) allowed: bool,
+    pub(crate) scope: WitnessScope,
+}
 
 pub(crate) struct PolicyContextEvaluator<'a> {
     schema: &'a Schema,
@@ -50,21 +58,48 @@ impl<'a> PolicyContextEvaluator<'a> {
         depth: usize,
         visited_referencing: &mut HashSet<(TableName, ObjectId, Operation)>,
     ) -> bool {
+        self.evaluate_row_access_with_witness_scope(
+            operation,
+            row,
+            descriptor,
+            table_name,
+            local_policy_override,
+            io,
+            row_loader,
+            depth,
+            visited_referencing,
+        )
+        .allowed
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn evaluate_row_access_with_witness_scope(
+        &self,
+        operation: Operation,
+        row: &Row,
+        descriptor: &RowDescriptor,
+        table_name: &str,
+        local_policy_override: Option<&PolicyExpr>,
+        io: &dyn Storage,
+        row_loader: &mut dyn FnMut(ObjectId, Option<TableName>) -> Option<LoadedRow>,
+        depth: usize,
+        visited_referencing: &mut HashSet<(TableName, ObjectId, Operation)>,
+    ) -> ScopedPolicyResult {
         if depth > crate::query_manager::policy::RECURSIVE_POLICY_MAX_DEPTH_HARD_CAP {
-            return false;
+            return ScopedPolicyResult::default();
         }
 
         let table = TableName::new(table_name);
         let key = (table, row.id, operation);
         if !visited_referencing.insert(key) {
-            return false;
+            return ScopedPolicyResult::default();
         }
 
-        let local_allow = local_policy_override
+        let result = local_policy_override
             .or_else(|| self.policy_for_operation(table, operation))
             .map(|policy| {
                 let mut visited_inherits = HashSet::new();
-                self.evaluate_expr_with_context(
+                self.evaluate_expr_with_witness_scope(
                     policy,
                     operation,
                     row,
@@ -77,10 +112,13 @@ impl<'a> PolicyContextEvaluator<'a> {
                     visited_referencing,
                 )
             })
-            .unwrap_or(!self.row_policy_mode.denies_missing_explicit_policy());
+            .unwrap_or(ScopedPolicyResult {
+                allowed: !self.row_policy_mode.denies_missing_explicit_policy(),
+                scope: WitnessScope::new(),
+            });
 
         visited_referencing.remove(&(table, row.id, operation));
-        local_allow
+        result
     }
 
     fn policy_for_operation(
@@ -98,7 +136,7 @@ impl<'a> PolicyContextEvaluator<'a> {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn evaluate_inherits_referencing_with_context(
+    fn evaluate_inherits_referencing_with_witness_scope(
         &self,
         operation: Operation,
         source_table: &str,
@@ -110,26 +148,26 @@ impl<'a> PolicyContextEvaluator<'a> {
         row_loader: &mut dyn FnMut(ObjectId, Option<TableName>) -> Option<LoadedRow>,
         depth: usize,
         visited_referencing: &mut HashSet<(TableName, ObjectId, Operation)>,
-    ) -> bool {
+    ) -> ScopedPolicyResult {
         let Some(effective_max_depth) = normalize_recursive_max_depth(max_depth) else {
-            return false;
+            return ScopedPolicyResult::default();
         };
         if depth >= effective_max_depth {
-            return false;
+            return ScopedPolicyResult::default();
         }
 
         let source_table_name = TableName::new(source_table);
         let Some(source_schema) = self.schema.get(&source_table_name) else {
-            return false;
+            return ScopedPolicyResult::default();
         };
         let source_descriptor = &source_schema.columns;
 
         let Some(col_idx) = source_descriptor.column_index(via_column) else {
-            return false;
+            return ScopedPolicyResult::default();
         };
         let col = &source_descriptor.columns[col_idx];
         if col.references != Some(TableName::new(target_table_name)) {
-            return false;
+            return ScopedPolicyResult::default();
         }
 
         let candidate_ids = match &col.column_type {
@@ -142,13 +180,14 @@ impl<'a> PolicyContextEvaluator<'a> {
             ColumnType::Array { element } if **element == ColumnType::Uuid => {
                 io.index_scan_all(source_table_name.as_str(), col.name.as_str(), self.branch)
             }
-            _ => return false,
+            _ => return ScopedPolicyResult::default(),
         };
 
         for source_row_id in candidate_ids {
             let Some(source_row) = row_loader(source_row_id, Some(source_table_name)) else {
                 continue;
             };
+            let source_scope = source_row.provenance.clone();
 
             if !referencing_edge_matches_target(
                 source_descriptor,
@@ -165,7 +204,7 @@ impl<'a> PolicyContextEvaluator<'a> {
                 source_row.batch_id,
                 source_row.row_provenance,
             );
-            if self.evaluate_row_access(
+            let mut result = self.evaluate_row_access_with_witness_scope(
                 operation,
                 &source_row,
                 source_descriptor,
@@ -175,16 +214,18 @@ impl<'a> PolicyContextEvaluator<'a> {
                 row_loader,
                 depth + 1,
                 visited_referencing,
-            ) {
-                return true;
+            );
+            if result.allowed {
+                result.scope.extend(source_scope);
+                return result;
             }
         }
 
-        false
+        ScopedPolicyResult::default()
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn evaluate_expr_with_context(
+    fn evaluate_expr_with_witness_scope(
         &self,
         expr: &PolicyExpr,
         operation: Operation,
@@ -196,9 +237,9 @@ impl<'a> PolicyContextEvaluator<'a> {
         depth: usize,
         visited: &mut HashSet<ObjectId>,
         visited_referencing: &mut HashSet<(TableName, ObjectId, Operation)>,
-    ) -> bool {
+    ) -> ScopedPolicyResult {
         if depth > crate::query_manager::policy::RECURSIVE_POLICY_MAX_DEPTH_HARD_CAP {
-            return false;
+            return ScopedPolicyResult::default();
         }
 
         match expr {
@@ -206,7 +247,7 @@ impl<'a> PolicyContextEvaluator<'a> {
                 operation,
                 via_column,
                 max_depth,
-            } => self.evaluate_inherits_with_context(
+            } => self.evaluate_inherits_with_witness_scope(
                 *operation,
                 via_column,
                 *max_depth,
@@ -224,7 +265,7 @@ impl<'a> PolicyContextEvaluator<'a> {
                 source_table,
                 via_column,
                 max_depth,
-            } => self.evaluate_inherits_referencing_with_context(
+            } => self.evaluate_inherits_referencing_with_witness_scope(
                 *operation,
                 source_table,
                 via_column,
@@ -236,10 +277,10 @@ impl<'a> PolicyContextEvaluator<'a> {
                 depth,
                 visited_referencing,
             ),
-            PolicyExpr::Exists { table, condition } => self.evaluate_exists_with_context(
+            PolicyExpr::Exists { table, condition } => self.evaluate_exists_with_witness_scope(
                 table, condition, operation, row, descriptor, io, row_loader, depth,
             ),
-            PolicyExpr::ExistsRel { rel } => self.evaluate_exists_rel_with_context(
+            PolicyExpr::ExistsRel { rel } => self.evaluate_exists_rel_with_witness_scope(
                 rel,
                 operation == Operation::Select,
                 row,
@@ -249,9 +290,54 @@ impl<'a> PolicyContextEvaluator<'a> {
                 row_loader,
                 depth,
             ),
-            PolicyExpr::And(exprs) => exprs.iter().all(|e| {
-                self.evaluate_expr_with_context(
-                    e,
+            PolicyExpr::And(exprs) => {
+                let mut scope = WitnessScope::new();
+                for expr in exprs {
+                    let result = self.evaluate_expr_with_witness_scope(
+                        expr,
+                        operation,
+                        row,
+                        descriptor,
+                        table_name,
+                        io,
+                        row_loader,
+                        depth,
+                        visited,
+                        visited_referencing,
+                    );
+                    if !result.allowed {
+                        return ScopedPolicyResult::default();
+                    }
+                    scope.extend(result.scope);
+                }
+                ScopedPolicyResult {
+                    allowed: true,
+                    scope,
+                }
+            }
+            PolicyExpr::Or(exprs) => {
+                for expr in exprs {
+                    let result = self.evaluate_expr_with_witness_scope(
+                        expr,
+                        operation,
+                        row,
+                        descriptor,
+                        table_name,
+                        io,
+                        row_loader,
+                        depth,
+                        visited,
+                        visited_referencing,
+                    );
+                    if result.allowed {
+                        return result;
+                    }
+                }
+                ScopedPolicyResult::default()
+            }
+            PolicyExpr::Not(inner) => {
+                let result = self.evaluate_expr_with_witness_scope(
+                    inner,
                     operation,
                     row,
                     descriptor,
@@ -261,48 +347,29 @@ impl<'a> PolicyContextEvaluator<'a> {
                     depth,
                     visited,
                     visited_referencing,
-                )
-            }),
-            PolicyExpr::Or(exprs) => exprs.iter().any(|e| {
-                self.evaluate_expr_with_context(
-                    e,
-                    operation,
-                    row,
+                );
+                ScopedPolicyResult {
+                    allowed: !result.allowed,
+                    scope: WitnessScope::new(),
+                }
+            }
+            _ => ScopedPolicyResult {
+                allowed: evaluate_expr_recursive_with_row_id(
+                    expr,
+                    &row.data,
+                    &row.provenance,
                     descriptor,
-                    table_name,
-                    io,
-                    row_loader,
+                    self.session,
+                    Some(row.id),
                     depth,
-                    visited,
-                    visited_referencing,
-                )
-            }),
-            PolicyExpr::Not(inner) => !self.evaluate_expr_with_context(
-                inner,
-                operation,
-                row,
-                descriptor,
-                table_name,
-                io,
-                row_loader,
-                depth,
-                visited,
-                visited_referencing,
-            ),
-            _ => evaluate_expr_recursive_with_row_id(
-                expr,
-                &row.data,
-                &row.provenance,
-                descriptor,
-                self.session,
-                Some(row.id),
-                depth,
-            ),
+                ),
+                scope: WitnessScope::new(),
+            },
         }
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn evaluate_inherits_with_context(
+    fn evaluate_inherits_with_witness_scope(
         &self,
         operation: Operation,
         via_column: &str,
@@ -315,48 +382,52 @@ impl<'a> PolicyContextEvaluator<'a> {
         depth: usize,
         visited: &mut HashSet<ObjectId>,
         visited_referencing: &mut HashSet<(TableName, ObjectId, Operation)>,
-    ) -> bool {
+    ) -> ScopedPolicyResult {
         let Some(effective_max_depth) = normalize_recursive_max_depth(max_depth) else {
-            return false;
+            return ScopedPolicyResult::default();
         };
         if depth >= effective_max_depth {
-            return false;
+            return ScopedPolicyResult::default();
         }
 
         let col_index = match descriptor.column_index(via_column) {
             Some(idx) => idx,
-            None => return false,
+            None => return ScopedPolicyResult::default(),
         };
 
         if column_is_null(descriptor, &row.data, col_index).unwrap_or(false) {
-            return true;
+            return ScopedPolicyResult {
+                allowed: true,
+                scope: WitnessScope::new(),
+            };
         }
 
         let col_desc = &descriptor.columns[col_index];
         let parent_table = match &col_desc.references {
             Some(table) => table,
-            None => return false,
+            None => return ScopedPolicyResult::default(),
         };
 
         let parent_id = match decode_column(descriptor, &row.data, col_index) {
             Ok(Value::Uuid(id)) => id,
-            _ => return false,
+            _ => return ScopedPolicyResult::default(),
         };
 
         if visited.contains(&parent_id) {
-            return false;
+            return ScopedPolicyResult::default();
         }
         visited.insert(parent_id);
 
         let parent_table_name = *parent_table;
         let parent_row = match row_loader(parent_id, Some(parent_table_name)) {
             Some(content) => content,
-            None => return false,
+            None => return ScopedPolicyResult::default(),
         };
+        let parent_scope = parent_row.provenance.clone();
 
         let parent_schema = match self.schema.get(&parent_table_name) {
             Some(schema) => schema,
-            None => return false,
+            None => return ScopedPolicyResult::default(),
         };
 
         let parent_policy = match operation {
@@ -368,7 +439,7 @@ impl<'a> PolicyContextEvaluator<'a> {
 
         let parent_policy = match parent_policy {
             Some(p) => p,
-            None => return false,
+            None => return ScopedPolicyResult::default(),
         };
 
         let parent_row = Row::new(
@@ -377,7 +448,7 @@ impl<'a> PolicyContextEvaluator<'a> {
             parent_row.batch_id,
             parent_row.row_provenance,
         );
-        self.evaluate_expr_with_context(
+        let mut result = self.evaluate_expr_with_witness_scope(
             parent_policy,
             operation,
             &parent_row,
@@ -388,11 +459,15 @@ impl<'a> PolicyContextEvaluator<'a> {
             depth + 1,
             visited,
             visited_referencing,
-        )
+        );
+        if result.allowed {
+            result.scope.extend(parent_scope);
+        }
+        result
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn evaluate_exists_with_context(
+    fn evaluate_exists_with_witness_scope(
         &self,
         table: &str,
         condition: &PolicyExpr,
@@ -402,15 +477,15 @@ impl<'a> PolicyContextEvaluator<'a> {
         io: &dyn Storage,
         row_loader: &mut dyn FnMut(ObjectId, Option<TableName>) -> Option<LoadedRow>,
         depth: usize,
-    ) -> bool {
+    ) -> ScopedPolicyResult {
         if depth >= crate::query_manager::policy::RECURSIVE_POLICY_MAX_DEPTH_HARD_CAP {
-            return false;
+            return ScopedPolicyResult::default();
         }
 
         let bound_condition =
             match bind_outer_row_refs(condition, &row.data, descriptor, Some(row.id)) {
                 Some(expr) => expr,
-                None => return false,
+                None => return ScopedPolicyResult::default(),
             };
 
         let table_name = TableName::new(table);
@@ -424,7 +499,7 @@ impl<'a> PolicyContextEvaluator<'a> {
             self.row_policy_mode,
         ) {
             Some(g) => g,
-            None => return false,
+            None => return ScopedPolicyResult::default(),
         };
 
         for _ in 0..100 {
@@ -433,11 +508,14 @@ impl<'a> PolicyContextEvaluator<'a> {
             }
         }
 
-        graph.result()
+        ScopedPolicyResult {
+            allowed: graph.result(),
+            scope: graph.matching_scope_object_ids(),
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn evaluate_exists_rel_with_context(
+    fn evaluate_exists_rel_with_witness_scope(
         &self,
         rel: &RelExpr,
         structural_scans: bool,
@@ -447,15 +525,15 @@ impl<'a> PolicyContextEvaluator<'a> {
         io: &dyn Storage,
         row_loader: &mut dyn FnMut(ObjectId, Option<TableName>) -> Option<LoadedRow>,
         depth: usize,
-    ) -> bool {
+    ) -> ScopedPolicyResult {
         if depth >= crate::query_manager::policy::RECURSIVE_POLICY_MAX_DEPTH_HARD_CAP {
-            return false;
+            return ScopedPolicyResult::default();
         }
 
         let bound_rel =
             match bind_relation_refs(rel, &row.data, descriptor, self.session, Some(row.id)) {
                 Some(expr) => expr,
-                None => return false,
+                None => return ScopedPolicyResult::default(),
             };
 
         let current_table = TableName::new(table_name);
@@ -469,7 +547,7 @@ impl<'a> PolicyContextEvaluator<'a> {
             structural_scans,
         ) {
             Some(g) => g,
-            None => return false,
+            None => return ScopedPolicyResult::default(),
         };
 
         for _ in 0..100 {
@@ -478,7 +556,10 @@ impl<'a> PolicyContextEvaluator<'a> {
             }
         }
 
-        graph.result()
+        ScopedPolicyResult {
+            allowed: graph.result(),
+            scope: graph.matching_scope_object_ids(),
+        }
     }
 }
 

--- a/crates/jazz-tools/src/query_manager/graph_nodes/policy_filter.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/policy_filter.rs
@@ -275,11 +275,8 @@ impl PolicyFilterNode {
         // Process added tuples
         for tuple in input.added {
             self.input_tuples.insert(tuple.clone());
-            let Some(row) = tuple_to_row(&tuple) else {
-                continue;
-            };
 
-            if self.evaluate_with_context(&row, io, &mut row_loader) {
+            if self.evaluate_tuple_with_context(&tuple, io, &mut row_loader) {
                 self.current_tuples.insert(tuple.clone());
                 result.added.push(tuple);
             }
@@ -298,15 +295,8 @@ impl PolicyFilterNode {
             self.input_tuples.remove(&old_tuple);
             self.input_tuples.insert(new_tuple.clone());
 
-            let old_row = tuple_to_row(&old_tuple);
-            let new_row = tuple_to_row(&new_tuple);
-
-            let old_passes = old_row
-                .map(|r| self.evaluate_with_context(&r, io, &mut row_loader))
-                .unwrap_or(false);
-            let new_passes = new_row
-                .map(|r| self.evaluate_with_context(&r, io, &mut row_loader))
-                .unwrap_or(false);
+            let old_passes = self.evaluate_tuple_with_context(&old_tuple, io, &mut row_loader);
+            let new_passes = self.evaluate_tuple_with_context(&new_tuple, io, &mut row_loader);
 
             match (old_passes, new_passes) {
                 (true, true) => {
@@ -339,9 +329,7 @@ impl PolicyFilterNode {
         let all_tuples: Vec<_> = self.input_tuples.iter().cloned().collect();
 
         for tuple in all_tuples {
-            let passes = tuple_to_row(&tuple)
-                .map(|row| self.evaluate_with_context(&row, io, row_loader))
-                .unwrap_or(false);
+            let passes = self.evaluate_tuple_with_context(&tuple, io, row_loader);
             let currently_visible = self.current_tuples.contains(&tuple);
 
             match (currently_visible, passes) {
@@ -362,18 +350,34 @@ impl PolicyFilterNode {
     }
 
     /// Evaluate with context - supports recursive INHERITS and EXISTS evaluation.
-    fn evaluate_with_context(
+    fn evaluate_tuple_with_context(
         &self,
-        row: &Row,
+        tuple: &Tuple,
         io: &dyn Storage,
         row_loader: &mut dyn FnMut(ObjectId, Option<TableName>) -> Option<LoadedRow>,
     ) -> bool {
-        let evaluator = PolicyContextEvaluator::new(
-            &self.schema,
-            &self.session,
-            &self.branch,
-            self.row_policy_mode,
-        );
+        let Some(row) = tuple_to_row(tuple) else {
+            return false;
+        };
+        let branch = tuple
+            .provenance()
+            .iter()
+            .find(|(id, _)| *id == row.id)
+            .map(|(_, branch)| branch.as_str())
+            .unwrap_or(&self.branch);
+        self.evaluate_with_context(&row, branch, io, row_loader)
+    }
+
+    /// Evaluate with context - supports recursive INHERITS and EXISTS evaluation.
+    fn evaluate_with_context(
+        &self,
+        row: &Row,
+        branch: &str,
+        io: &dyn Storage,
+        row_loader: &mut dyn FnMut(ObjectId, Option<TableName>) -> Option<LoadedRow>,
+    ) -> bool {
+        let evaluator =
+            PolicyContextEvaluator::new(&self.schema, &self.session, branch, self.row_policy_mode);
         let mut visited_referencing = HashSet::new();
         evaluator.evaluate_row_access(
             self.policy_operation,
@@ -832,7 +836,7 @@ mod tests {
         let storage = crate::storage::MemoryStorage::new();
         let mut seen = Vec::new();
 
-        let allowed = node.evaluate_with_context(&row, &storage, &mut |id, hint| {
+        let allowed = node.evaluate_with_context(&row, "main", &storage, &mut |id, hint| {
             seen.push((id, hint));
             None
         });

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -1019,8 +1019,25 @@ impl QueryManager {
 
     pub(crate) fn apply_query_settled(&mut self, query_id: QueryId, _tier: DurabilityTier) {
         let sub_id = QuerySubscriptionId(query_id.0);
+        let remote_scope = self.sync_manager.remote_query_scope(query_id);
         if let Some(sub) = self.subscriptions.get_mut(&sub_id) {
             sub.query_frontier_complete = true;
+            if remote_scope
+                .iter()
+                .any(|(_, branch)| !sub.branches.iter().any(|known| known == branch.as_str()))
+            {
+                sub.needs_recompile = true;
+            }
+            let root_table = sub.graph.table.as_str().to_string();
+            sub.graph.mark_dirty_for_table(&root_table);
+
+            let mut policy_context_tables = sub.policy_context_tables.clone();
+            policy_context_tables.extend(Self::policy_context_tables_for_graph(&sub.graph));
+            policy_context_tables.sort();
+            policy_context_tables.dedup();
+            for table in policy_context_tables {
+                sub.graph.mark_dirty_for_table(&table);
+            }
         }
     }
 

--- a/crates/jazz-tools/src/query_manager/manager_tests/policies.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests/policies.rs
@@ -870,6 +870,215 @@ fn sync_backed_exists_session_subscription_keeps_local_rows_when_server_scope_is
 }
 
 #[test]
+fn sync_backed_exists_policy_syncs_readable_predicate_table_rows() {
+    use crate::query_manager::policy::{CmpOp, PolicyValue};
+    use crate::sync_manager::{ClientId, ServerId};
+    use uuid::Uuid;
+
+    let mut schema = Schema::new();
+    schema.insert(
+        TableName::new("access_grants"),
+        TableSchema::with_policies(
+            RowDescriptor::new(vec![
+                ColumnDescriptor::new("user_id", ColumnType::Text),
+                ColumnDescriptor::new("active", ColumnType::Text),
+            ]),
+            TablePolicies::new().with_select(PolicyExpr::And(vec![
+                PolicyExpr::eq_session("user_id", vec!["user_id".into()]),
+                PolicyExpr::Cmp {
+                    column: "active".into(),
+                    op: CmpOp::Eq,
+                    value: PolicyValue::Literal(Value::Text("yes".into())),
+                },
+            ])),
+        ),
+    );
+    schema.insert(
+        TableName::new("protected_records"),
+        TableSchema::with_policies(
+            RowDescriptor::new(vec![ColumnDescriptor::new("name", ColumnType::Text)]),
+            TablePolicies::new().with_select(PolicyExpr::Exists {
+                table: "access_grants".into(),
+                condition: Box::new(PolicyExpr::And(vec![
+                    PolicyExpr::eq_session("user_id", vec!["user_id".into()]),
+                    PolicyExpr::Cmp {
+                        column: "active".into(),
+                        op: CmpOp::Eq,
+                        value: PolicyValue::Literal(Value::Text("yes".into())),
+                    },
+                ])),
+            }),
+        ),
+    );
+
+    let (mut server, mut server_io) = create_query_manager(SyncManager::new(), schema.clone());
+    server
+        .insert(
+            &mut server_io,
+            "access_grants",
+            &[Value::Text("alice".into()), Value::Text("yes".into())],
+        )
+        .unwrap();
+    server
+        .insert(
+            &mut server_io,
+            "access_grants",
+            &[Value::Text("bob".into()), Value::Text("yes".into())],
+        )
+        .unwrap();
+    server
+        .insert(
+            &mut server_io,
+            "access_grants",
+            &[Value::Text("alice".into()), Value::Text("no".into())],
+        )
+        .unwrap();
+    server
+        .insert(
+            &mut server_io,
+            "protected_records",
+            &[Value::Text("Visible record".into())],
+        )
+        .unwrap();
+    server.process(&mut server_io);
+
+    let (mut client, mut client_io) = create_query_manager(SyncManager::new(), schema);
+    let server_id = ServerId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+    let client_id = ClientId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+    connect_server(&mut client, &client_io, server_id);
+    connect_client(&mut server, &server_io, client_id);
+    let _ = client.sync_manager_mut().take_outbox();
+
+    let sub_id = client
+        .subscribe_with_sync(
+            client.query("protected_records").build(),
+            Some(PolicySession::new("alice")),
+            None,
+        )
+        .unwrap();
+
+    pump_messages(
+        &mut client,
+        &mut server,
+        &mut client_io,
+        &mut server_io,
+        client_id,
+        server_id,
+    );
+
+    client.process(&mut client_io);
+    let results = client.get_subscription_results(sub_id);
+    assert_eq!(
+        results.len(),
+        1,
+        "client should not need to subscribe to the EXISTS predicate table explicitly"
+    );
+    assert_eq!(results[0].1, vec![Value::Text("Visible record".into())]);
+
+    let synced_access_grants = client_io
+        .scan_row_locators()
+        .unwrap()
+        .into_iter()
+        .filter(|(_, locator)| locator.table.as_str() == "access_grants")
+        .count();
+    assert_eq!(
+        synced_access_grants, 1,
+        "server should sync only the predicate row that proves this read"
+    );
+}
+
+#[test]
+fn sync_backed_exists_policy_withholds_rows_when_predicate_rows_are_unreadable() {
+    use crate::query_manager::policy::{CmpOp, PolicyValue};
+    use crate::sync_manager::{ClientId, ServerId};
+    use uuid::Uuid;
+
+    let mut schema = Schema::new();
+    schema.insert(
+        TableName::new("access_grants"),
+        TableSchema::with_policies(
+            RowDescriptor::new(vec![
+                ColumnDescriptor::new("user_id", ColumnType::Text),
+                ColumnDescriptor::new("active", ColumnType::Text),
+            ]),
+            TablePolicies::new().with_select(PolicyExpr::False),
+        ),
+    );
+    schema.insert(
+        TableName::new("protected_records"),
+        TableSchema::with_policies(
+            RowDescriptor::new(vec![ColumnDescriptor::new("name", ColumnType::Text)]),
+            TablePolicies::new().with_select(PolicyExpr::Exists {
+                table: "access_grants".into(),
+                condition: Box::new(PolicyExpr::And(vec![
+                    PolicyExpr::eq_session("user_id", vec!["user_id".into()]),
+                    PolicyExpr::Cmp {
+                        column: "active".into(),
+                        op: CmpOp::Eq,
+                        value: PolicyValue::Literal(Value::Text("yes".into())),
+                    },
+                ])),
+            }),
+        ),
+    );
+
+    let (mut server, mut server_io) = create_query_manager(SyncManager::new(), schema.clone());
+    server
+        .insert(
+            &mut server_io,
+            "access_grants",
+            &[Value::Text("alice".into()), Value::Text("yes".into())],
+        )
+        .unwrap();
+    server
+        .insert(
+            &mut server_io,
+            "protected_records",
+            &[Value::Text("Hidden record".into())],
+        )
+        .unwrap();
+    server.process(&mut server_io);
+
+    let (mut client, mut client_io) = create_query_manager(SyncManager::new(), schema);
+    let server_id = ServerId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+    let client_id = ClientId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+    connect_server(&mut client, &client_io, server_id);
+    connect_client(&mut server, &server_io, client_id);
+    let _ = client.sync_manager_mut().take_outbox();
+
+    let sub_id = client
+        .subscribe_with_sync(
+            client.query("protected_records").build(),
+            Some(PolicySession::new("alice")),
+            None,
+        )
+        .unwrap();
+
+    pump_messages(
+        &mut client,
+        &mut server,
+        &mut client_io,
+        &mut server_io,
+        client_id,
+        server_id,
+    );
+
+    client.process(&mut client_io);
+    assert!(
+        client.get_subscription_results(sub_id).is_empty(),
+        "unreadable predicate rows should not authorize protected rows"
+    );
+
+    let synced_rows = client_io.scan_row_locators().unwrap();
+    assert!(
+        synced_rows
+            .iter()
+            .all(|(_, locator)| locator.table.as_str() != "protected_records"),
+        "server should not sync protected row bytes without a readable proof chain"
+    );
+}
+
+#[test]
 fn fail_closed_server_withholds_session_scope_before_permissions_head() {
     use crate::query_manager::relation_ir::{
         ColumnRef, JoinCondition, JoinKind, PredicateCmpOp, PredicateExpr, RelExpr, RowIdRef,

--- a/crates/jazz-tools/src/query_manager/policy_graph.rs
+++ b/crates/jazz-tools/src/query_manager/policy_graph.rs
@@ -11,6 +11,7 @@ use crate::schema_manager::SchemaContext;
 
 use super::graph::{GraphNode, QueryGraph, RelationCompileFeatures};
 use super::graph_nodes::NodeId;
+use super::graph_nodes::RowNode;
 use super::graph_nodes::exists_output::ExistsOutputNode;
 use super::graph_nodes::index_scan::IndexScanNode;
 use super::graph_nodes::materialize::MaterializeNode;
@@ -343,6 +344,24 @@ impl PolicyGraph {
         {
             Some(GraphNode::ExistsOutput(node)) => node.exists(),
             _ => false,
+        }
+    }
+
+    pub(crate) fn matching_scope_object_ids(
+        &self,
+    ) -> std::collections::HashSet<(ObjectId, crate::object::BranchName)> {
+        match self
+            .graph
+            .nodes
+            .get(self.exists_node.0 as usize)
+            .map(|c| &c.node)
+        {
+            Some(GraphNode::ExistsOutput(node)) => node
+                .current_tuples()
+                .iter()
+                .flat_map(|tuple| tuple.provenance().iter().copied())
+                .collect(),
+            _ => std::collections::HashSet::new(),
         }
     }
 

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -32,6 +32,10 @@ enum AuthorizedTuplesResult {
     PermissionsUnavailable,
 }
 
+type PolicyAuthKey = (ObjectId, BranchName);
+type PolicyAuthScope = HashSet<PolicyAuthKey>;
+type PolicyAuthScopeCache = HashMap<PolicyAuthKey, Option<PolicyAuthScope>>;
+
 pub(super) struct ResolvedSchemaRow {
     pub branch_name: BranchName,
     pub batch_id: BatchId,
@@ -384,6 +388,68 @@ impl QueryManager {
         )
     }
 
+    pub(super) fn evaluate_authorization_policy_with_witness_scope(
+        &mut self,
+        storage: &dyn Storage,
+        request: AuthorizationPolicyRequest<'_>,
+    ) -> Option<HashSet<(ObjectId, BranchName)>> {
+        let AuthorizationPolicyRequest {
+            object_id,
+            branch_name,
+            table_name,
+            policy,
+            content,
+            provenance,
+            session,
+            auth_schema,
+            auth_context,
+            source_branch_schema_map,
+            operation,
+        } = request;
+
+        let table_schema = auth_schema.get(&table_name)?;
+        let transformed = self.transform_content_to_authorization_schema(
+            table_name.as_str(),
+            content,
+            BatchId([0; 16]),
+            branch_name,
+            source_branch_schema_map,
+            auth_context,
+        )?;
+
+        let evaluator = PolicyContextEvaluator::new(
+            auth_schema,
+            session,
+            branch_name.as_str(),
+            self.row_policy_mode,
+        );
+        let row = Row::new(object_id, transformed, BatchId([0; 16]), provenance.clone());
+        let mut visited = HashSet::new();
+        let mut row_loader = |related_id: ObjectId, _table_hint: Option<TableName>| {
+            self.load_row_for_authorization_context(
+                storage,
+                related_id,
+                branch_name,
+                source_branch_schema_map,
+                auth_context,
+            )
+        };
+
+        let result = evaluator.evaluate_row_access_with_witness_scope(
+            operation,
+            &row,
+            &table_schema.columns,
+            table_name.as_str(),
+            Some(policy),
+            storage,
+            &mut row_loader,
+            0,
+            &mut visited,
+        );
+
+        result.allowed.then_some(result.scope)
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub(super) fn provenance_row_matches_current_select_policy(
         &mut self,
@@ -395,19 +461,40 @@ impl QueryManager {
         auth_context: &crate::schema_manager::SchemaContext,
         source_branch_schema_map: &std::collections::HashMap<String, SchemaHash>,
     ) -> bool {
+        self.provenance_row_select_policy_witness_scope(
+            storage,
+            object_id,
+            branch_name,
+            session,
+            auth_schema,
+            auth_context,
+            source_branch_schema_map,
+        )
+        .is_some()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn provenance_row_select_policy_witness_scope(
+        &mut self,
+        storage: &dyn Storage,
+        object_id: ObjectId,
+        branch_name: BranchName,
+        session: Option<&Session>,
+        auth_schema: &Schema,
+        auth_context: &crate::schema_manager::SchemaContext,
+        source_branch_schema_map: &std::collections::HashMap<String, SchemaHash>,
+    ) -> Option<PolicyAuthScope> {
         let branches = vec![branch_name.as_str().to_string()];
-        let Some((table, row)) = self.load_best_visible_row_batch(
+        let (table, row) = self.load_best_visible_row_batch(
             storage,
             object_id,
             &branches,
             None,
             auth_context,
             source_branch_schema_map,
-        ) else {
-            return false;
-        };
+        )?;
         if row.is_hard_deleted() {
-            return false;
+            return None;
         }
 
         let tip_content = row.data.clone();
@@ -418,14 +505,13 @@ impl QueryManager {
             .get(&table_name)
             .and_then(|table_schema| table_schema.policies.select_policy())
         else {
-            return !self.row_policy_mode.denies_missing_explicit_policy()
-                && auth_schema.contains_key(&table_name);
+            return (!self.row_policy_mode.denies_missing_explicit_policy()
+                && auth_schema.contains_key(&table_name))
+            .then(HashSet::new);
         };
-        let Some(session) = session else {
-            return false;
-        };
+        let session = session?;
 
-        self.evaluate_authorization_policy(
+        self.evaluate_authorization_policy_with_witness_scope(
             storage,
             AuthorizationPolicyRequest {
                 object_id,
@@ -524,23 +610,20 @@ impl QueryManager {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn authorized_scope_from_graph_if_available(
         &mut self,
         storage: &dyn Storage,
         graph: &super::graph::QueryGraph,
         schema_context: &crate::schema_manager::SchemaContext,
         source_branch_schema_map: &std::collections::HashMap<String, SchemaHash>,
+        branches: &[String],
         session: Option<&Session>,
+        explicit_policy_context_tables: &[String],
+        include_policy_witness_rows: bool,
     ) -> Option<HashSet<(ObjectId, BranchName)>> {
-        match self.authorized_tuples_from_graph_result(
-            storage,
-            graph,
-            schema_context,
-            source_branch_schema_map,
-            session,
-        ) {
-            AuthorizedTuplesResult::Ready(_) => {}
-            AuthorizedTuplesResult::PermissionsUnavailable => return None,
+        if self.authorization_schema_required && self.authorization_schema.is_none() {
+            return None;
         }
 
         let Some((auth_schema, auth_context)) =
@@ -560,7 +643,8 @@ impl QueryManager {
             return Some(graph.sync_scope_object_ids());
         }
 
-        let mut authorization_cache: HashMap<(ObjectId, BranchName), bool> = HashMap::new();
+        let mut authorization_cache: PolicyAuthScopeCache = HashMap::new();
+        let mut authorization_closure_cache: PolicyAuthScopeCache = HashMap::new();
 
         let authorized_scope_tuples = graph.filtered_sync_scope_tuples(|tuple| {
             tuple
@@ -568,28 +652,129 @@ impl QueryManager {
                 .iter()
                 .copied()
                 .all(|(object_id, branch_name)| {
-                    *authorization_cache
-                        .entry((object_id, branch_name))
-                        .or_insert_with(|| {
-                            self.provenance_row_matches_current_select_policy(
-                                storage,
-                                object_id,
-                                branch_name,
-                                session,
-                                &auth_schema,
-                                &auth_context,
-                                source_branch_schema_map,
-                            )
-                        })
+                    let mut visiting = HashSet::new();
+                    self.provenance_row_select_policy_readable_scope(
+                        storage,
+                        object_id,
+                        branch_name,
+                        session,
+                        &auth_schema,
+                        &auth_context,
+                        source_branch_schema_map,
+                        &mut authorization_cache,
+                        &mut authorization_closure_cache,
+                        &mut visiting,
+                    )
+                    .is_some()
                 })
         });
 
-        Some(
-            authorized_scope_tuples
-                .into_iter()
-                .flat_map(|tuple| tuple.provenance().clone().into_iter())
-                .collect(),
-        )
+        let mut authorized_scope: HashSet<(ObjectId, BranchName)> = authorized_scope_tuples
+            .iter()
+            .flat_map(|tuple| tuple.provenance().iter().copied())
+            .collect();
+        if include_policy_witness_rows {
+            authorized_scope.extend(
+                authorized_scope_tuples
+                    .iter()
+                    .flat_map(|tuple| tuple.provenance().iter().copied())
+                    .filter_map(|key| {
+                        authorization_closure_cache
+                            .get(&key)
+                            .and_then(Option::as_ref)
+                    })
+                    .flat_map(|scope| scope.iter().copied()),
+            );
+        }
+
+        let graph_policy_context_tables: HashSet<TableName> = graph
+            .policy_filter_tables
+            .iter()
+            .map(|(_, table)| *table)
+            .collect();
+        let explicit_only_policy_context_tables: HashSet<TableName> =
+            explicit_policy_context_tables
+                .iter()
+                .map(TableName::new)
+                .filter(|table| !graph_policy_context_tables.contains(table))
+                .collect();
+
+        Some(self.scope_with_authorized_policy_context_rows_for_tables(
+            authorized_scope,
+            &explicit_only_policy_context_tables,
+            branches,
+            storage,
+            session,
+            &auth_schema,
+            &auth_context,
+            source_branch_schema_map,
+        ))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn provenance_row_select_policy_readable_scope(
+        &mut self,
+        storage: &dyn Storage,
+        object_id: ObjectId,
+        branch_name: BranchName,
+        session: Option<&Session>,
+        auth_schema: &Schema,
+        auth_context: &crate::schema_manager::SchemaContext,
+        source_branch_schema_map: &std::collections::HashMap<String, SchemaHash>,
+        authorization_cache: &mut PolicyAuthScopeCache,
+        authorization_closure_cache: &mut PolicyAuthScopeCache,
+        visiting: &mut HashSet<PolicyAuthKey>,
+    ) -> Option<PolicyAuthScope> {
+        let key = (object_id, branch_name);
+        if let Some(cached) = authorization_closure_cache.get(&key) {
+            return cached.clone();
+        }
+        if !visiting.insert(key) {
+            return Some(HashSet::new());
+        }
+
+        let witness_scope = authorization_cache
+            .entry(key)
+            .or_insert_with(|| {
+                self.provenance_row_select_policy_witness_scope(
+                    storage,
+                    object_id,
+                    branch_name,
+                    session,
+                    auth_schema,
+                    auth_context,
+                    source_branch_schema_map,
+                )
+            })
+            .clone();
+
+        let Some(witness_scope) = witness_scope else {
+            visiting.remove(&key);
+            authorization_closure_cache.insert(key, None);
+            return None;
+        };
+
+        let mut readable_scope = HashSet::from([key]);
+        for (witness_id, witness_branch) in witness_scope {
+            let witness_readable_scope = self.provenance_row_select_policy_readable_scope(
+                storage,
+                witness_id,
+                witness_branch,
+                session,
+                auth_schema,
+                auth_context,
+                source_branch_schema_map,
+                authorization_cache,
+                authorization_closure_cache,
+                visiting,
+            )?;
+            readable_scope.insert((witness_id, witness_branch));
+            readable_scope.extend(witness_readable_scope);
+        }
+
+        visiting.remove(&key);
+        authorization_closure_cache.insert(key, Some(readable_scope.clone()));
+        Some(readable_scope)
     }
 
     pub(super) fn resolved_server_query_branches(
@@ -733,6 +918,64 @@ impl QueryManager {
                     continue;
                 };
                 if !row.is_hard_deleted() {
+                    scope.insert((object_id, *branch_name));
+                }
+            }
+        }
+
+        scope
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn scope_with_authorized_policy_context_rows_for_tables(
+        &mut self,
+        mut scope: HashSet<(ObjectId, BranchName)>,
+        policy_tables: &HashSet<TableName>,
+        branches: &[String],
+        storage: &dyn Storage,
+        session: Option<&Session>,
+        auth_schema: &Schema,
+        auth_context: &crate::schema_manager::SchemaContext,
+        source_branch_schema_map: &std::collections::HashMap<String, SchemaHash>,
+    ) -> HashSet<(ObjectId, BranchName)> {
+        if policy_tables.is_empty() {
+            return scope;
+        }
+
+        let branch_names: Vec<BranchName> = branches.iter().map(BranchName::new).collect();
+        let Ok(objects) = storage.scan_row_locators() else {
+            return scope;
+        };
+
+        for (object_id, row_locator) in objects {
+            let table_name = row_locator.table.as_str();
+            if !policy_tables
+                .iter()
+                .any(|table| table.as_str() == table_name)
+            {
+                continue;
+            }
+
+            for branch_name in &branch_names {
+                let Some(row) = storage
+                    .load_visible_region_row(table_name, branch_name.as_str(), object_id)
+                    .ok()
+                    .flatten()
+                else {
+                    continue;
+                };
+                if row.is_hard_deleted() {
+                    continue;
+                }
+                if self.provenance_row_matches_current_select_policy(
+                    storage,
+                    object_id,
+                    *branch_name,
+                    session,
+                    auth_schema,
+                    auth_context,
+                    source_branch_schema_map,
+                ) {
                     scope.insert((object_id, *branch_name));
                 }
             }
@@ -900,7 +1143,10 @@ impl QueryManager {
                     &graph,
                     &subscription_context,
                     &branch_schema_map,
+                    &branches,
                     session_for_policy.as_ref(),
+                    &sub.policy_context_tables,
+                    !self.sync_manager.has_servers(),
                 )
             };
             if let Some(scope) = scope.as_ref() {
@@ -1089,7 +1335,10 @@ impl QueryManager {
                         &sub.graph,
                         &sub.schema_context,
                         &branch_schema_map,
+                        branches,
                         sub.session.as_ref(),
+                        &sub.policy_context_tables,
+                        !self.sync_manager.has_servers(),
                     )
                 }
             };

--- a/crates/jazz-tools/tests/policies_integration/inherited_policies.rs
+++ b/crates/jazz-tools/tests/policies_integration/inherited_policies.rs
@@ -394,7 +394,6 @@ async fn update_row(client: &JazzClient, row_id: ObjectId, changes: Vec<(String,
 /// dave query ───► hidden
 /// ```
 #[tokio::test]
-#[should_panic] // "known failing: forward INHERITS SELECT fails to expose child rows to parent-authorized sessions"
 async fn inherited_folder_documents_are_visible_to_all_folder_owners() {
     let schema = SchemaBuilder::new()
         .table(make_folders_schema(
@@ -534,7 +533,6 @@ async fn inherited_folder_documents_are_visible_to_all_folder_owners() {
 /// bob(fresh) ─────query docs─────────────────────────────────► sees nothing
 /// ```
 #[tokio::test]
-#[should_panic] // "known failing: inherited select still resolves through deleted parent rows"
 async fn inherited_folder_documents_fail_closed_for_missing_and_deleted_folder_targets() {
     let schema = SchemaBuilder::new()
         .table(make_folders_schema(
@@ -681,7 +679,6 @@ async fn inherited_folder_documents_fail_closed_for_missing_and_deleted_folder_t
 /// dave query ────► nothing
 /// ```
 #[tokio::test]
-#[should_panic] // "known failing: forward INHERITS SELECT fails to expose child rows to parent-authorized sessions"
 async fn inherited_folder_access_extends_document_visibility_beyond_direct_owner() {
     let owner_policy = PolicyExpr::eq_session("owner_id", vec!["user_id".into()]);
     let schema = SchemaBuilder::new()
@@ -855,7 +852,6 @@ async fn inherited_folder_access_extends_document_visibility_beyond_direct_owner
 /// alice ──insert owner=alice, folder=shared─────────► server ──► accepted
 /// ```
 #[tokio::test]
-#[should_panic] // "known failing: inherited write policies resolves on wrong branch"
 async fn inherited_folder_insert_requires_folder_owner_when_fk_present() {
     let owner_policy = PolicyExpr::eq_session("owner_id", vec!["user_id".into()]);
     let schema = SchemaBuilder::new()
@@ -1084,7 +1080,6 @@ async fn inherited_folder_insert_requires_folder_owner_when_fk_present() {
 /// alice ──delete folder────────────────────────────► server ──► persisted
 /// ```
 #[tokio::test]
-#[should_panic] // "known failing: forward INHERITS SELECT fails to expose child rows to parent-authorized sessions"
 async fn inherited_folder_delete_allows_folder_owner_to_delete_folder_and_documents() {
     let owner_policy = PolicyExpr::eq_session("owner_id", vec!["user_id".into()]);
     let schema = SchemaBuilder::new()
@@ -1229,7 +1224,6 @@ async fn inherited_folder_delete_allows_folder_owner_to_delete_folder_and_docume
 /// bob ──delete charlie doc──────────────────────────► server ──✗ rejected
 /// ```
 #[tokio::test]
-#[should_panic] // "known failing: forward INHERITS SELECT fails to expose child rows to parent-authorized sessions"
 async fn inherited_folder_delete_allows_document_owner_but_blocks_other_non_owners() {
     let owner_policy = PolicyExpr::eq_session("owner_id", vec!["user_id".into()]);
     let schema = SchemaBuilder::new()
@@ -1388,7 +1382,6 @@ async fn inherited_folder_delete_allows_document_owner_but_blocks_other_non_owne
 /// Verifies that multiple forward inherited paths compose with OR: visibility
 /// through either FK should be enough to expose the child row.
 #[tokio::test]
-#[should_panic] // "known failing: forward INHERITS SELECT fails to expose child rows to parent-authorized sessions"
 async fn inherited_multiple_folder_paths_compose_with_or() {
     let schema = SchemaBuilder::new()
         .table(make_folders_schema(
@@ -1968,9 +1961,6 @@ async fn inherited_referencing_array_membership_preserves_set_semantics() {
 /// Verifies that non-recursive forward inheritance can compose across multiple
 /// tables, such as `folders -> files -> file_parts`.
 #[tokio::test]
-#[should_panic(
-    expected = "forward INHERITS SELECT fails to expose child rows to parent-authorized sessions"
-)]
 async fn inherited_multi_hop_forward_chain_grants_access_to_leaf_rows() {
     let schema = multi_hop_inherited_parts_schema();
     let server = TestingServer::builder()
@@ -2046,7 +2036,6 @@ async fn inherited_multi_hop_forward_chain_grants_access_to_leaf_rows() {
 /// Verifies that changing the parent row's policy-relevant contents revokes
 /// child visibility for active subscriptions.
 #[tokio::test]
-#[should_panic] // "known failing: forward INHERITS SELECT fails to expose child rows to parent-authorized sessions"
 async fn inherited_parent_policy_change_propagates_to_child_on_active_subscriptions() {
     let schema = SchemaBuilder::new()
         .table(make_folders_schema(
@@ -2139,7 +2128,6 @@ async fn inherited_parent_policy_change_propagates_to_child_on_active_subscripti
 /// Verifies that retargeting a child from a visible parent to a hidden parent
 /// removes it from active subscriptions.
 #[tokio::test]
-#[should_panic] // "known failing: forward INHERITS SELECT fails to expose child rows to parent-authorized sessions"
 async fn inherited_child_fk_retarget_visible_to_hidden_parent_removes_child_from_subscriptions() {
     let schema = SchemaBuilder::new()
         .table(make_folders_schema(
@@ -2234,7 +2222,6 @@ async fn inherited_child_fk_retarget_visible_to_hidden_parent_removes_child_from
 /// Verifies that retargeting a child from a hidden parent to a visible parent
 /// adds it to active subscriptions.
 #[tokio::test]
-#[should_panic] // "known failing: forward INHERITS SELECT fails to expose child rows to parent-authorized sessions"
 async fn inherited_child_fk_retarget_hidden_to_visible_parent_adds_child_to_subscriptions() {
     let schema = SchemaBuilder::new()
         .table(make_folders_schema(


### PR DESCRIPTION
## What

Fixes sync-backed client queries whose read policy depends on an `EXISTS` predicate over another table.

The server now includes the readable witness rows needed for the client to locally reproduce the policy decision, without requiring the client to explicitly query the predicate table first.

## Why

A client could receive no rows for a protected table when the policy depended on rows from a separate access/membership table, because those predicate rows were not part of the server query scope. The local client policy filter then failed closed.

## Details

- Collects successful policy witness scope from `EXISTS`, `EXISTS_REL`, and inherited policy evaluation.
- Merges only readable proof-chain rows into the sync scope.
- Withholds protected row bytes when the matching predicate rows are not readable.
- Recompiles/reevaluates subscriptions when upstream settled scope introduces branches needed for local evaluation.
- Adds sync-backed regression tests with generic `access_grants` / `protected_records` fixtures.

Resolves #742

## Checks

- `cargo test -p jazz-tools sync_backed_exists_policy -- --nocapture`
- `cargo test -p jazz-tools policy_filter -- --nocapture`
- `cargo test -p jazz-tools exists_policy -- --nocapture`
- `cargo test -p jazz-tools policy_context_tables -- --nocapture`
- pre-commit `clippy`
- pre-commit `rustfmt`
- `git diff --check`