### PR TITLE
fix: missing `.wait()` & `onMutationError` rejections in worker mode

### DIFF
--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/rejection_recovery.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/rejection_recovery.rs
@@ -83,6 +83,87 @@ fn rc_direct_insert_persisted_reconnect_reconciles_rejected_batch_from_server() 
 }
 
 #[test]
+fn rc_worker_peer_relays_rejected_batch_settlement_to_downstream_peer() {
+    let mut s = create_3tier_rc();
+
+    let ((row_id, _row_values), mut receiver) =
+        s.a.insert_persisted(
+            "users",
+            user_insert_values(ObjectId::new(), "Alice"),
+            None,
+            DurabilityTier::EdgeServer,
+        )
+        .unwrap();
+
+    let batch_id =
+        s.a.storage()
+            .scan_history_row_batches("users", row_id)
+            .unwrap()[0]
+            .batch_id;
+    let branch_name = s.a.schema_manager().branch_name();
+
+    pump_a_to_b(&mut s);
+
+    s.b.push_sync_inbox(InboxEntry {
+        source: Source::Server(s.c_server_for_b),
+        payload: SyncPayload::BatchSettlement {
+            settlement: crate::batch_fate::BatchSettlement::Rejected {
+                batch_id,
+                code: "permission_denied".to_string(),
+                reason: "writer lacks publish rights".to_string(),
+            },
+        },
+    });
+    s.b.immediate_tick();
+    pump_b_to_a(&mut s);
+
+    assert_eq!(
+        receiver.try_recv(),
+        Ok(Some(Err(crate::runtime_core::PersistedWriteRejection {
+            batch_id,
+            code: "permission_denied".to_string(),
+            reason: "writer lacks publish rights".to_string(),
+        }))),
+        "worker peers should relay rejected settlements back to downstream persisted waits"
+    );
+    assert_eq!(
+        s.a.storage()
+            .load_visible_region_row("users", branch_name.as_str(), row_id)
+            .unwrap(),
+        None,
+        "downstream peer should retract the optimistic visible row after rejection"
+    );
+}
+
+#[test]
+fn rc_worker_peer_retains_replayable_batch_record_for_downstream_direct_write() {
+    let mut s = create_3tier_rc();
+
+    let ((row_id, _row_values), _receiver) =
+        s.a.insert_persisted(
+            "users",
+            user_insert_values(ObjectId::new(), "Alice"),
+            None,
+            DurabilityTier::EdgeServer,
+        )
+        .unwrap();
+
+    let batch_id =
+        s.a.storage()
+            .scan_history_row_batches("users", row_id)
+            .unwrap()[0]
+            .batch_id;
+
+    pump_a_to_b(&mut s);
+
+    let record = s.b.storage().load_local_batch_record(batch_id).unwrap();
+    assert!(
+        record.is_some(),
+        "worker peers should retain a replayable local batch record for downstream direct writes"
+    );
+}
+
+#[test]
 fn rc_transactional_insert_persisted_reconnect_reconciles_rejected_batch_from_server() {
     // alice -> worker
     //   alice stages one transactional batch locally

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -1,5 +1,8 @@
 use super::*;
-use crate::batch_fate::{BatchSettlement, SealedBatchSubmission, VisibleBatchMember};
+use crate::batch_fate::{
+    BatchMode, BatchSettlement, LocalBatchMember, LocalBatchRecord, SealedBatchSubmission,
+    VisibleBatchMember,
+};
 use crate::metadata::MetadataKey;
 use crate::object::{BranchName, ObjectId};
 use crate::query_manager::policy::Operation;
@@ -22,6 +25,93 @@ enum SealedBatchMode {
 }
 
 impl SyncManager {
+    fn client_batch_mode(row: &StoredRowBatch) -> BatchMode {
+        match row.state {
+            RowState::StagingPending | RowState::VisibleTransactional => BatchMode::Transactional,
+            RowState::Superseded | RowState::Rejected | RowState::VisibleDirect => {
+                BatchMode::Direct
+            }
+        }
+    }
+
+    fn retain_client_local_batch_row<H: Storage>(
+        &self,
+        storage: &mut H,
+        metadata: &HashMap<String, String>,
+        row: &StoredRowBatch,
+    ) {
+        let Some(table_name) = metadata
+            .get(MetadataKey::Table.as_str())
+            .cloned()
+            .or_else(|| {
+                storage
+                    .load_row_locator(row.row_id)
+                    .ok()
+                    .flatten()
+                    .map(|locator| locator.table.to_string())
+            })
+        else {
+            return;
+        };
+
+        let Some(schema_hash) = storage
+            .load_history_row_batch_table_locator(row.branch.as_str(), row.row_id, row.batch_id)
+            .ok()
+            .flatten()
+            .map(|locator| locator.schema_hash)
+            .or_else(|| {
+                storage
+                    .load_row_locator(row.row_id)
+                    .ok()
+                    .flatten()
+                    .and_then(|locator| locator.origin_schema_hash)
+            })
+        else {
+            return;
+        };
+
+        let mut record = match storage.load_local_batch_record(row.batch_id) {
+            Ok(Some(record)) => record,
+            Ok(None) => {
+                LocalBatchRecord::new(row.batch_id, Self::client_batch_mode(row), false, None)
+            }
+            Err(_) => return,
+        };
+        record.upsert_member(LocalBatchMember {
+            object_id: row.row_id,
+            table_name,
+            branch_name: BranchName::new(&row.branch),
+            schema_hash,
+            row_digest: row.content_digest(),
+        });
+        let _ = storage.upsert_local_batch_record(&record);
+    }
+
+    fn retain_client_batch_settlement<H: Storage>(
+        &self,
+        storage: &mut H,
+        settlement: &BatchSettlement,
+    ) {
+        let batch_id = settlement.batch_id();
+        let Ok(Some(mut record)) = storage.load_local_batch_record(batch_id) else {
+            return;
+        };
+        record.apply_settlement(settlement.clone());
+        let _ = storage.upsert_local_batch_record(&record);
+    }
+
+    fn retain_client_sealed_batch_submission<H: Storage>(
+        &self,
+        storage: &mut H,
+        submission: &SealedBatchSubmission,
+    ) {
+        let Ok(Some(mut record)) = storage.load_local_batch_record(submission.batch_id) else {
+            return;
+        };
+        record.mark_sealed(submission.clone());
+        let _ = storage.upsert_local_batch_record(&record);
+    }
+
     fn validate_sealed_batch_submission(
         &self,
         submission: &SealedBatchSubmission,
@@ -532,6 +622,41 @@ impl SyncManager {
             BatchSettlement::Missing { .. } | BatchSettlement::Rejected { .. } => {
                 Some(settlement.clone())
             }
+        }
+    }
+
+    fn interested_clients_for_batch_settlement<H: Storage>(
+        &self,
+        _storage: &H,
+        settlement: &BatchSettlement,
+    ) -> HashSet<ClientId> {
+        match settlement {
+            BatchSettlement::DurableDirect {
+                visible_members, ..
+            }
+            | BatchSettlement::AcceptedTransaction {
+                visible_members, ..
+            } => {
+                let mut interested = HashSet::new();
+                for member in visible_members {
+                    let key =
+                        RowBatchKey::new(member.object_id, member.branch_name, member.batch_id);
+                    if let Some(clients) = self.row_batch_interest.get(&key) {
+                        interested.extend(clients.iter().copied());
+                    }
+                }
+                interested
+            }
+            BatchSettlement::Rejected { batch_id, .. } => {
+                let mut interested = HashSet::new();
+                for (key, clients) in &self.row_batch_interest {
+                    if key.batch_id == *batch_id {
+                        interested.extend(clients.iter().copied());
+                    }
+                }
+                interested
+            }
+            BatchSettlement::Missing { .. } => HashSet::new(),
         }
     }
 
@@ -1131,30 +1256,7 @@ impl SyncManager {
                     return;
                 }
                 self.pending_batch_settlements.push(settlement.clone());
-                let interested: HashSet<ClientId> = match &settlement {
-                    BatchSettlement::DurableDirect {
-                        visible_members, ..
-                    }
-                    | BatchSettlement::AcceptedTransaction {
-                        visible_members, ..
-                    } => {
-                        let mut interested = HashSet::new();
-                        for member in visible_members {
-                            let key = RowBatchKey::new(
-                                member.object_id,
-                                member.branch_name,
-                                member.batch_id,
-                            );
-                            if let Some(clients) = self.row_batch_interest.get(&key) {
-                                interested.extend(clients.iter().copied());
-                            }
-                        }
-                        interested
-                    }
-                    BatchSettlement::Missing { .. } | BatchSettlement::Rejected { .. } => {
-                        HashSet::new()
-                    }
-                };
+                let interested = self.interested_clients_for_batch_settlement(storage, &settlement);
                 for cid in interested {
                     if let Some(settlement) = self.batch_settlement_for_client(cid, &settlement) {
                         self.outbox.push(OutboxEntry {
@@ -1611,6 +1713,7 @@ impl SyncManager {
                     .insert(client_id);
 
                 if let Some(applied) = self.apply_row_updated(storage, metadata, row.clone()) {
+                    self.retain_client_local_batch_row(storage, &applied.metadata, &applied.row);
                     if let Some(table) = applied.metadata.get(MetadataKey::Table.as_str()).cloned()
                     {
                         self.forward_row_batch_to_servers_with_storage(
@@ -1683,6 +1786,7 @@ impl SyncManager {
                 {
                     return;
                 }
+                self.retain_client_sealed_batch_submission(storage, &submission);
                 self.seal_batch_to_servers(submission.clone());
                 self.try_accept_completed_sealed_batch_from_client(
                     storage,
@@ -1691,6 +1795,7 @@ impl SyncManager {
                 );
             }
             SyncPayload::BatchSettlement { settlement } => {
+                self.retain_client_batch_settlement(storage, &settlement);
                 self.pending_batch_settlements.push(settlement);
             }
             SyncPayload::BatchSettlementNeeded { batch_ids } => {

--- a/crates/jazz-tools/src/sync_manager/tests/row_batch_state.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/row_batch_state.rs
@@ -365,6 +365,57 @@ fn batch_settlement_from_server_relays_to_row_batch_interested_writer() {
 }
 
 #[test]
+fn rejected_batch_settlement_from_server_relays_to_row_batch_interested_writer() {
+    let mut sm = SyncManager::new();
+    let mut io = MemoryStorage::new();
+    let client_id = ClientId::new();
+    let server_id = ServerId::new();
+    let row_id = ObjectId::new();
+    let row = visible_row(row_id, "main", Vec::new(), 1_000, b"alice");
+    let batch_id = row.batch_id;
+    seed_users_schema(&mut io);
+
+    add_client(&mut sm, &io, client_id);
+    add_server(&mut sm, &io, server_id);
+    sm.set_client_role(client_id, ClientRole::Peer);
+    sm.take_outbox();
+
+    sm.process_from_client(
+        &mut io,
+        client_id,
+        SyncPayload::RowBatchCreated {
+            metadata: Some(RowMetadata {
+                id: row_id,
+                metadata: row_metadata("users"),
+            }),
+            row,
+        },
+    );
+    sm.take_outbox();
+
+    let settlement = BatchSettlement::Rejected {
+        batch_id,
+        code: "permission_denied".to_string(),
+        reason: "write rejected by policy".to_string(),
+    };
+    sm.process_from_server(
+        &mut io,
+        server_id,
+        SyncPayload::BatchSettlement {
+            settlement: settlement.clone(),
+        },
+    );
+
+    assert!(sm.take_outbox().into_iter().any(|entry| matches!(
+        entry,
+        OutboxEntry {
+            destination: Destination::Client(id),
+            payload: SyncPayload::BatchSettlement { settlement: relayed },
+        } if id == client_id && relayed == settlement
+    )));
+}
+
+#[test]
 fn row_batch_state_changed_relays_accepted_transaction_settlement_to_interested_clients() {
     let mut sm = SyncManager::new();
     let mut io = MemoryStorage::new();

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -314,6 +314,7 @@ export type SubscriptionCallback = (delta: RowDelta) => void;
 export interface ConnectSyncRuntimeOptions {
   useBinaryEncoding?: boolean;
   onAuthFailure?: (reason: AuthFailureReason) => void;
+  onRejectedBatchAcknowledged?: (batchId: string) => void;
 }
 
 /**
@@ -1266,7 +1267,12 @@ export class JazzClient {
    */
   private readonly mutationErrorListeners = new Set<(event: MutationErrorEvent) => void>();
   private readonly acknowledgedRejectedBatchErrors = new Map<string, PersistedWriteRejectedError>();
+  private readonly replayedRejectedBatchRecords = new Map<string, LocalBatchRecord>();
+  private readonly hydratedWorkerBatchIds = new Set<string>();
+  private readonly pendingReplayedRejectedBatchIds = new Set<string>();
+  private readonly onRejectedBatchAcknowledged?: (batchId: string) => void;
   private pendingBatchWaitPollTimer: ReturnType<typeof setTimeout> | null = null;
+  private settlementPollTimer: ReturnType<typeof setTimeout> | null = null;
   private shutdownPromise: Promise<void> | null = null;
   private cachedRuntimeSchemaHash: string | null = null;
   private cachedRuntimeSchema: WasmSchema | null = null;
@@ -1313,6 +1319,7 @@ export class JazzClient {
     this.context = context;
     this.defaultDurabilityTier = defaultDurabilityTier;
     this.resolvedSession = this.resolveSessionFromContext();
+    this.onRejectedBatchAcknowledged = runtimeOptions?.onRejectedBatchAcknowledged;
 
     if (runtimeOptions?.onAuthFailure) {
       const handler = runtimeOptions.onAuthFailure;
@@ -1526,29 +1533,119 @@ export class JazzClient {
   }
 
   localBatchRecord(batchId: string): LocalBatchRecord | null {
-    return this.requireBatchRecordMethod("loadLocalBatchRecord")(batchId);
+    const runtimeRecord = this.requireBatchRecordMethod("loadLocalBatchRecord")(batchId);
+    const replayedRecord = this.replayedRejectedBatchRecords.get(batchId) ?? null;
+    if (
+      replayedRecord?.latestSettlement?.kind === "rejected" &&
+      runtimeRecord?.latestSettlement?.kind !== "rejected"
+    ) {
+      return replayedRecord;
+    }
+    return runtimeRecord ?? replayedRecord ?? null;
   }
 
   localBatchRecords(): LocalBatchRecord[] {
-    const records = this.requireBatchRecordMethod("loadLocalBatchRecords")();
-    return [...records].sort((left, right) => left.batchId.localeCompare(right.batchId));
+    const records = new Map(
+      this.requireBatchRecordMethod("loadLocalBatchRecords")().map((record) => [
+        record.batchId,
+        record,
+      ]),
+    );
+    for (const [batchId, record] of this.replayedRejectedBatchRecords) {
+      const runtimeRecord = records.get(batchId);
+      if (
+        !runtimeRecord ||
+        (record.latestSettlement?.kind === "rejected" &&
+          runtimeRecord.latestSettlement?.kind !== "rejected")
+      ) {
+        records.set(batchId, record);
+      }
+    }
+    return [...records.values()].sort((left, right) => left.batchId.localeCompare(right.batchId));
+  }
+
+  hasPendingHydratedBatchReconciliation(tier: DurabilityTier): boolean {
+    for (const batchId of this.hydratedWorkerBatchIds) {
+      const record = this.localBatchRecord(batchId);
+      if (!record) {
+        continue;
+      }
+      const settlement = record.latestSettlement;
+      if (rejectionFromSettlement(settlement)) {
+        continue;
+      }
+      if (!settlementSatisfiesTier(settlement, tier)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  hasHydratedWorkerBatch(batchId: string): boolean {
+    return this.hydratedWorkerBatchIds.has(batchId);
   }
 
   onMutationError(listener: (event: MutationErrorEvent) => void): () => void {
     this.mutationErrorListeners.add(listener);
     this.flushUnhandledMutationErrors();
+    this.ensureSettlementPolling();
     return () => {
       this.mutationErrorListeners.delete(listener);
+      if (!this.shouldPollSettlements()) {
+        this.cancelSettlementPolling();
+      }
     };
   }
 
   private acknowledgeRejectedBatchInternal(batchId: string): boolean {
     const rejection = rejectionFromSettlement(this.localBatchRecord(batchId)?.latestSettlement);
-    const acknowledged = this.requireBatchRecordMethod("acknowledgeRejectedBatch")(batchId);
+    const acknowledgedInRuntime = this.requireBatchRecordMethod("acknowledgeRejectedBatch")(
+      batchId,
+    );
+    const acknowledgedReplayed = this.replayedRejectedBatchRecords.delete(batchId);
+    this.pendingReplayedRejectedBatchIds.delete(batchId);
+    const acknowledged = acknowledgedInRuntime || acknowledgedReplayed;
     if (acknowledged && rejection) {
       this.acknowledgedRejectedBatchErrors.set(batchId, rejection);
     }
+    if (acknowledged) {
+      this.onRejectedBatchAcknowledged?.(batchId);
+    }
     return acknowledged;
+  }
+
+  hydrateLocalBatchRecords(records: LocalBatchRecord[]): void {
+    const loadLocalBatchRecord = this.requireBatchRecordMethod("loadLocalBatchRecord");
+    for (const record of records) {
+      this.hydratedWorkerBatchIds.add(record.batchId);
+      const runtimeRecord = loadLocalBatchRecord(record.batchId);
+      if (
+        runtimeRecord &&
+        !(
+          record.latestSettlement?.kind === "rejected" &&
+          runtimeRecord.latestSettlement?.kind !== "rejected"
+        )
+      ) {
+        continue;
+      }
+      this.replayedRejectedBatchRecords.set(record.batchId, record);
+      if (record.latestSettlement?.kind === "rejected") {
+        this.pendingReplayedRejectedBatchIds.add(record.batchId);
+      }
+    }
+  }
+
+  replayRejectedBatchRecord(record: LocalBatchRecord): void {
+    this.hydratedWorkerBatchIds.add(record.batchId);
+    if (record.latestSettlement?.kind !== "rejected") {
+      return;
+    }
+    this.replayedRejectedBatchRecords.set(record.batchId, record);
+    this.pendingReplayedRejectedBatchIds.add(record.batchId);
+  }
+
+  markReplayedRejectedBatchDelivered(batchId: string): void {
+    this.pendingReplayedRejectedBatchIds.delete(batchId);
   }
 
   acknowledgeRejectedBatch(batchId: string): boolean {
@@ -2441,6 +2538,41 @@ export class JazzClient {
     this.pendingBatchWaitPollTimer = null;
   }
 
+  private shouldPollSettlements(): boolean {
+    return this.pendingBatchWaiters.size > 0 || this.mutationErrorListeners.size > 0;
+  }
+
+  private ensureSettlementPolling(): void {
+    this.ensurePendingBatchWaitPolling();
+    if (this.settlementPollTimer !== null) {
+      return;
+    }
+    if (!this.shouldPollSettlements()) {
+      return;
+    }
+
+    // Rust-owned transports can settle batch records without routing through
+    // JS `onSyncMessageReceived`, so poll retained batch metadata while waits
+    // or mutation error listeners are outstanding.
+    this.settlementPollTimer = setTimeout(() => {
+      this.settlementPollTimer = null;
+      const batchesWithPendingWaiters = new Set(this.pendingBatchWaiters.keys());
+      this.flushPendingBatchWaiters();
+      this.flushUnhandledMutationErrors(this.drainRejectedBatchIds(), batchesWithPendingWaiters);
+
+      this.ensureSettlementPolling();
+    }, 20);
+  }
+
+  private cancelSettlementPolling(): void {
+    if (this.settlementPollTimer === null) {
+      return;
+    }
+
+    clearTimeout(this.settlementPollTimer);
+    this.settlementPollTimer = null;
+  }
+
   private flushUnhandledMutationErrors(
     rejectedBatchIds: readonly string[] = this.drainRejectedBatchIds(),
     batchesHandledByLiveWaiters: ReadonlySet<string> = new Set<string>(),
@@ -2482,10 +2614,10 @@ export class JazzClient {
 
   private drainRejectedBatchIds(): string[] {
     const drainRejectedBatchIds = this.runtime.drainRejectedBatchIds;
-    if (!drainRejectedBatchIds) {
-      return [];
-    }
-    return [...new Set(drainRejectedBatchIds.call(this.runtime))].sort();
+    const runtimeBatchIds = drainRejectedBatchIds ? drainRejectedBatchIds.call(this.runtime) : [];
+    const replayedBatchIds = [...this.pendingReplayedRejectedBatchIds];
+    this.pendingReplayedRejectedBatchIds.clear();
+    return [...new Set([...runtimeBatchIds, ...replayedBatchIds])].sort();
   }
 
   waitForPersistedBatch(batchId: string, tier: DurabilityTier): Promise<void> {
@@ -2499,7 +2631,7 @@ export class JazzClient {
       waiters.push({ tier, resolve, reject });
       this.pendingBatchWaiters.set(batchId, waiters);
       this.flushPendingBatchWaiters();
-      this.ensurePendingBatchWaitPolling();
+      this.ensureSettlementPolling();
     });
   }
 
@@ -2512,6 +2644,7 @@ export class JazzClient {
     }
 
     this.shutdownPromise = (async () => {
+      this.cancelSettlementPolling();
       this.cancelPendingBatchWaitPolling();
 
       // Disconnect Rust-owned transport if present.

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -1041,6 +1041,7 @@ export class Db {
    * Unsubscribers for {@link Db.clients}'s {@link JazzClient.onMutationError} listeners
    */
   private readonly clientMutationErrorUnsubscribers = new Map<JazzClient, () => void>();
+  private readonly pendingWorkerMutationErrorEvents: MutationErrorEvent[] = [];
   private nextActiveQuerySubscriptionTraceId = 1;
   private readonly onSyncChannelMessage = (event: MessageEvent): void => {
     this.handleSyncChannelMessage(event.data);
@@ -1289,15 +1290,17 @@ export class Db {
           onAuthFailure: (reason) => {
             this.markUnauthenticated(reason);
           },
+          onRejectedBatchAcknowledged: (batchId) => {
+            this.workerBridge?.acknowledgeRejectedBatch(batchId);
+          },
         },
       );
 
+      this.attachMutationErrorHandler(client);
       // In worker mode, set up the bridge for this client
       if (this.worker && !this.workerBridge) {
         this.attachWorkerBridge(key, client);
       }
-
-      this.attachMutationErrorHandler(client);
       // Direct (non-worker) clients with a serverUrl must open their own
       // Rust transport — the worker bridge is not doing it for them.
       if (!this.worker && this.config.serverUrl) {
@@ -1306,8 +1309,6 @@ export class Db {
           admin_secret: this.config.adminSecret,
         });
       }
-
-      this.attachMutationErrorHandler(client);
       this.clients.set(key, client);
     }
 
@@ -1331,6 +1332,7 @@ export class Db {
         for (const listener of this.mutationErrorListeners) {
           listener(event);
         }
+        this.workerBridge?.acknowledgeRejectedBatch(event.batch.batchId);
       }),
     );
   }
@@ -1345,15 +1347,32 @@ export class Db {
     }
   }
 
-  protected async ensureQueryReady(options?: QueryOptions): Promise<void> {
+  protected async ensureQueryReady(options?: QueryOptions, client?: JazzClient): Promise<void> {
     await this.ensureBridgeReady();
     if (!this.workerBridge || !this.config.serverUrl) {
       return;
     }
     if (!options?.tier || options.tier === "local") {
+      if (client?.hasPendingHydratedBatchReconciliation("edge")) {
+        await this.workerBridge.waitForUpstreamServerConnection();
+        await this.waitForHydratedWorkerBatchReconciliation(client, "edge");
+      }
       return;
     }
     await this.workerBridge.waitForUpstreamServerConnection();
+  }
+
+  private async waitForHydratedWorkerBatchReconciliation(
+    client: JazzClient,
+    tier: DurabilityTier,
+  ): Promise<void> {
+    const deadline = Date.now() + 5_000;
+    while (client.hasPendingHydratedBatchReconciliation(tier)) {
+      if (Date.now() >= deadline) {
+        return;
+      }
+      await sleep(20);
+    }
   }
 
   private attachWorkerBridge(schemaJson: string, client: JazzClient): void {
@@ -1369,6 +1388,35 @@ export class Db {
     this.applyBridgeRoutingForCurrentLeader(bridge, false);
     bridge.onAuthFailure((reason) => {
       this.markUnauthenticated(reason);
+    });
+    bridge.onLocalBatchRecordsSync((batches) => {
+      client.hydrateLocalBatchRecords(batches);
+    });
+    bridge.onMutationErrorReplay((batch) => {
+      const existingRecord = client.localBatchRecord(batch.batchId);
+      const replayableFromWorker = client.hasHydratedWorkerBatch(batch.batchId);
+      client.replayRejectedBatchRecord(batch);
+      if (existingRecord && !replayableFromWorker) {
+        return;
+      }
+      client.markReplayedRejectedBatchDelivered(batch.batchId);
+      const settlement = batch.latestSettlement;
+      if (!settlement || settlement.kind !== "rejected") {
+        return;
+      }
+      const event: MutationErrorEvent = {
+        code: settlement.code,
+        reason: settlement.reason,
+        batch,
+      };
+      if (this.mutationErrorListeners.size === 0) {
+        this.pendingWorkerMutationErrorEvents.push(event);
+        return;
+      }
+      for (const listener of this.mutationErrorListeners) {
+        listener(event);
+      }
+      this.workerBridge?.acknowledgeRejectedBatch(batch.batchId);
     });
     this.workerBridge = bridge;
     const bridgeReady = bridge
@@ -2304,6 +2352,14 @@ export class Db {
     for (const client of this.clients.values()) {
       this.attachMutationErrorHandler(client);
     }
+    while (this.pendingWorkerMutationErrorEvents.length > 0) {
+      const event = this.pendingWorkerMutationErrorEvents.shift()!;
+      listener(event);
+      for (const client of this.clients.values()) {
+        client.markReplayedRejectedBatchDelivered(event.batch.batchId);
+      }
+      this.workerBridge?.acknowledgeRejectedBatch(event.batch.batchId);
+    }
     return () => {
       this.mutationErrorListeners.delete(listener);
       if (this.mutationErrorListeners.size > 0) {
@@ -2555,7 +2611,7 @@ export class Db {
     const outputTable = resolveBuiltQueryOutputTable(planningSchema, builtQuery);
     const outputSchema = resolveSchemaWithTable(query._schema, runtimeSchema.get, outputTable);
     const queryOptions = ordinaryDbQueryOptions(options);
-    await this.ensureQueryReady(queryOptions);
+    await this.ensureQueryReady(queryOptions, client);
     const wasmQuery = translateQuery(builderJson, planningSchema);
     const rows = await client.query(wasmQuery, queryOptions);
     const outputIncludes = outputTable !== builtQuery.table ? {} : builtQuery.includes;
@@ -3025,7 +3081,7 @@ class ClientBackedDb extends Db {
     const outputTable = resolveBuiltQueryOutputTable(planningSchema, builtQuery);
     const outputSchema = resolveSchemaWithTable(query._schema, runtimeSchema.get, outputTable);
     const queryOptions = ordinaryDbQueryOptions(options);
-    await this.ensureQueryReady(queryOptions);
+    await this.ensureQueryReady(queryOptions, this.runtimeClient);
     const rows = await this.runtimeClient.queryInternal(
       translateQuery(builderJson, planningSchema),
       this.session,

--- a/packages/jazz-tools/src/runtime/worker-bridge.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.ts
@@ -11,7 +11,9 @@ import type { RuntimeSourcesConfig } from "./context.js";
 import type { AuthFailureReason } from "./sync-transport.js";
 import type {
   InitMessage,
+  LocalBatchRecordsSyncMessage,
   SequencedSyncPayload,
+  MutationErrorReplayMessage,
   WorkerLifecycleEvent,
   WorkerToMainMessage,
 } from "../worker/worker-protocol.js";
@@ -60,6 +62,10 @@ interface WorkerBridgeState {
   syncBatchFlushQueued: boolean;
   peerSyncListener: ((batch: PeerSyncBatch) => void) | null;
   authFailureListener: ((reason: AuthFailureReason) => void) | null;
+  localBatchRecordsSyncListener:
+    | ((batches: LocalBatchRecordsSyncMessage["batches"]) => void)
+    | null;
+  mutationErrorReplayListener: ((batch: MutationErrorReplayMessage["batch"]) => void) | null;
   serverPayloadForwarder: ((payload: Uint8Array) => void) | null;
 }
 
@@ -103,6 +109,8 @@ export class WorkerBridge {
       syncBatchFlushQueued: false,
       peerSyncListener: null,
       authFailureListener: null,
+      localBatchRecordsSyncListener: null,
+      mutationErrorReplayListener: null,
       serverPayloadForwarder: null,
     };
 
@@ -121,6 +129,10 @@ export class WorkerBridge {
         this.markUpstreamServerDisconnected();
       } else if (msg.type === "auth-failed") {
         this.state.authFailureListener?.(msg.reason);
+      } else if (msg.type === "local-batch-records-sync") {
+        this.state.localBatchRecordsSyncListener?.(msg.batches);
+      } else if (msg.type === "mutation-error-replay") {
+        this.state.mutationErrorReplayListener?.(msg.batch);
       } else if (msg.type === "peer-sync") {
         this.state.peerSyncListener?.({
           peerId: msg.peerId,
@@ -316,12 +328,27 @@ export class WorkerBridge {
     this.worker.postMessage({ type: "reconnect-upstream" });
   }
 
+  acknowledgeRejectedBatch(batchId: string): void {
+    if (this.isDisposedLike()) return;
+    this.worker.postMessage({ type: "acknowledge-rejected-batch", batchId });
+  }
+
   onPeerSync(listener: (batch: PeerSyncBatch) => void): void {
     this.state.peerSyncListener = listener;
   }
 
   onAuthFailure(listener: (reason: AuthFailureReason) => void): void {
     this.state.authFailureListener = listener;
+  }
+
+  onLocalBatchRecordsSync(
+    listener: (batches: LocalBatchRecordsSyncMessage["batches"]) => void,
+  ): void {
+    this.state.localBatchRecordsSyncListener = listener;
+  }
+
+  onMutationErrorReplay(listener: (batch: MutationErrorReplayMessage["batch"]) => void): void {
+    this.state.mutationErrorReplayListener = listener;
   }
 
   openPeer(peerId: string): void {
@@ -441,6 +468,8 @@ export class WorkerBridge {
     this.state.pendingSyncPayloadsForWorker = [];
     this.state.serverPayloadForwarder = null;
     this.state.peerSyncListener = null;
+    this.state.localBatchRecordsSyncListener = null;
+    this.state.mutationErrorReplayListener = null;
     this.state.syncBatchFlushQueued = false;
     this.runtime.onSyncMessageToSend?.(() => undefined);
   }

--- a/packages/jazz-tools/src/worker/jazz-worker.ts
+++ b/packages/jazz-tools/src/worker/jazz-worker.ts
@@ -65,6 +65,7 @@ let pendingSyncMessages: Uint8Array[] = []; // Buffer sync messages until init c
 let pendingPeerSyncMessages: Array<{ peerId: string; term: number; payload: Uint8Array[] }> = [];
 let pendingSyncPayloadsForMain: (Uint8Array | string | SequencedSyncPayload)[] = [];
 let syncBatchFlushQueued = false;
+let rejectedBatchReplayQueued = false;
 let bootstrapCatalogueForwarding = false;
 const DEFAULT_WASM_LOG_LEVEL = "warn";
 let peerRuntimeClientByPeerId = new Map<string, string>();
@@ -73,6 +74,47 @@ let peerTermByPeerId = new Map<string, number>();
 let currentAuth: Record<string, string> = {};
 // Stored after init so reconnect-upstream can re-establish the WS.
 let currentWsUrl: string | null = null;
+
+function syncRetainedLocalBatchRecordsToMain(): void {
+  if (!runtime) {
+    return;
+  }
+  try {
+    const batches = runtime.loadLocalBatchRecords?.() ?? [];
+    post({ type: "local-batch-records-sync", batches });
+  } catch (error) {
+    console.warn("[worker] loadLocalBatchRecords failed:", error);
+  }
+}
+
+function replayNewlyRejectedBatchesToMain(): void {
+  if (!runtime) {
+    return;
+  }
+  try {
+    const batchIds = runtime.drainRejectedBatchIds?.() ?? [];
+    for (const batchId of batchIds) {
+      const batch = runtime.loadLocalBatchRecord?.(batchId);
+      if (batch?.latestSettlement?.kind !== "rejected") {
+        continue;
+      }
+      post({ type: "mutation-error-replay", batch });
+    }
+  } catch (error) {
+    console.warn("[worker] drainRejectedBatchIds failed:", error);
+  }
+}
+
+function queueRejectedBatchReplayToMain(): void {
+  if (rejectedBatchReplayQueued) {
+    return;
+  }
+  rejectedBatchReplayQueued = true;
+  queueMicrotask(() => {
+    rejectedBatchReplayQueued = false;
+    replayNewlyRejectedBatchesToMain();
+  });
+}
 
 function resolveAbsoluteWasmUrlFromInitError(error: unknown): string | null {
   const origin = self.location?.origin;
@@ -366,6 +408,7 @@ async function handleInit(msg: InitMessage): Promise<void> {
           if (destinationClientId === mainClientId) {
             // Local main-thread client-bound payload.
             enqueueSyncMessageForMain(payload, sequence);
+            queueRejectedBatchReplayToMain();
             return;
           }
 
@@ -423,6 +466,9 @@ async function handleInit(msg: InitMessage): Promise<void> {
     } finally {
       bootstrapCatalogueForwarding = false;
     }
+
+    syncRetainedLocalBatchRecordsToMain();
+    queueRejectedBatchReplayToMain();
 
     post({ type: "init-ok", clientId: mainClientId! });
 
@@ -575,6 +621,14 @@ self.onmessage = async (event: MessageEvent<MainToWorkerMessage>) => {
       pendingPeerSyncMessages = [];
       post({ type: "shutdown-ok" });
       self.close();
+      break;
+
+    case "acknowledge-rejected-batch":
+      try {
+        runtime?.acknowledgeRejectedBatch?.(msg.batchId);
+      } catch (error) {
+        console.warn("[worker] acknowledgeRejectedBatch failed:", error);
+      }
       break;
 
     case "simulate-crash":

--- a/packages/jazz-tools/src/worker/worker-protocol.ts
+++ b/packages/jazz-tools/src/worker/worker-protocol.ts
@@ -5,6 +5,7 @@
  */
 
 import type { RuntimeSourcesConfig } from "../runtime/context.js";
+import type { LocalBatchRecord } from "../runtime/client.js";
 import type { AuthFailureReason } from "../runtime/sync-transport.js";
 
 // ============================================================================
@@ -101,6 +102,12 @@ export interface ShutdownMessage {
   type: "shutdown";
 }
 
+/** Acknowledge that the main thread already handled a replayable rejection. */
+export interface AcknowledgeRejectedBatchMessage {
+  type: "acknowledge-rejected-batch";
+  batchId: string;
+}
+
 /**
  * Simulate a crash: release OPFS handles without flushing snapshot.
  * Used for testing WAL recovery. Worker closes OPFS locks and confirms
@@ -132,6 +139,7 @@ export type MainToWorkerMessage =
   | DisconnectUpstreamMessage
   | ReconnectUpstreamMessage
   | ShutdownMessage
+  | AcknowledgeRejectedBatchMessage
   | SimulateCrashMessage
   | DebugSchemaStateMessage
   | DebugSeedLiveSchemaMessage;
@@ -173,6 +181,18 @@ export interface PeerSyncToMainMessage {
   peerId: string;
   term: number;
   payload: Uint8Array[];
+}
+
+/** Replay a persisted rejected batch that was not acknowledged before restart. */
+export interface MutationErrorReplayMessage {
+  type: "mutation-error-replay";
+  batch: LocalBatchRecord;
+}
+
+/** Sync retained local batch records from the worker into the main runtime overlay. */
+export interface LocalBatchRecordsSyncMessage {
+  type: "local-batch-records-sync";
+  batches: LocalBatchRecord[];
 }
 
 /** Worker encountered an error. */
@@ -223,6 +243,8 @@ export type WorkerToMainMessage =
   | UpstreamDisconnectedMessage
   | SyncToMainMessage
   | PeerSyncToMainMessage
+  | MutationErrorReplayMessage
+  | LocalBatchRecordsSyncMessage
   | ErrorMessage
   | WorkerAuthFailedMessage
   | ShutdownOkMessage

--- a/packages/jazz-tools/tests/browser/realistic-bench.test.ts
+++ b/packages/jazz-tools/tests/browser/realistic-bench.test.ts
@@ -519,7 +519,7 @@ async function createServerDb(
     config.jwtToken = await getTestingServerJwtForUser(sub, claims);
   }
   if (options.localFirstSecret) {
-    config.auth = { localFirstSecret: options.localFirstSecret };
+    config.secret = options.localFirstSecret;
   }
   return createDb(config);
 }

--- a/packages/jazz-tools/tests/browser/remote-db-harness.ts
+++ b/packages/jazz-tools/tests/browser/remote-db-harness.ts
@@ -93,7 +93,7 @@ export async function createRemoteBrowserDb(input: RemoteBrowserDbCreateInput): 
     appId: input.appId,
     driver: { type: "persistent", dbName: input.dbName },
     serverUrl: input.serverUrl,
-    ...(input.localFirstSecret ? { auth: { localFirstSecret: input.localFirstSecret } } : {}),
+    ...(input.localFirstSecret ? { secret: input.localFirstSecret } : {}),
     adminSecret: input.adminSecret,
     logLevel: input.logLevel,
   });

--- a/packages/jazz-tools/tests/browser/support.ts
+++ b/packages/jazz-tools/tests/browser/support.ts
@@ -273,7 +273,7 @@ export async function createSyncedDb(
       appId,
       driver: { type: "persistent", dbName: uniqueDbName(label) },
       serverUrl,
-      auth: { localFirstSecret },
+      secret: localFirstSecret,
     }),
   );
 }

--- a/packages/jazz-tools/tests/browser/testing-server-node.ts
+++ b/packages/jazz-tools/tests/browser/testing-server-node.ts
@@ -10,7 +10,6 @@ interface StartedTestingServer {
 
 const DEFAULT_TESTING_SERVER_KEY = "__default__";
 const testingServerPromises = new Map<string, Promise<StartedTestingServer>>();
-const isolatedTestingServers = new Set<Promise<StartedTestingServer>>();
 const blockedServerRoutes = new WeakMap<BrowserContext, Map<string, (route: Route) => void>>();
 const browserContextIds = new WeakMap<BrowserContext, number>();
 let nextBrowserContextId = 1;
@@ -77,33 +76,11 @@ export async function testingServerJwtForUser(
   return server.jwtForUser(userId, claims);
 }
 
-/**
- * Starts a new isolated testing server and returns its info.
- */
-export async function isolatedTestingServerInfo(): Promise<{
-  appId: string;
-  serverUrl: string;
-  adminSecret: string;
-}> {
-  const startedServerPromise = startTestingServer();
-  isolatedTestingServers.add(startedServerPromise);
-
-  try {
-    const { appId, serverUrl, adminSecret } = await startedServerPromise;
-    return { appId, serverUrl, adminSecret };
-  } catch (error) {
-    isolatedTestingServers.delete(startedServerPromise);
-    throw error;
-  }
-}
-
 export async function stopTestingServer(): Promise<void> {
   const runningServers = [...testingServerPromises.values()];
   testingServerPromises.clear();
-  const isolatedServerPromises = [...isolatedTestingServers];
-  isolatedTestingServers.clear();
 
-  if (runningServers.length === 0 && isolatedServerPromises.length === 0) {
+  if (runningServers.length === 0) {
     return;
   }
 
@@ -116,17 +93,6 @@ export async function stopTestingServer(): Promise<void> {
       // or stop() itself failed (nothing recoverable during teardown).
     }
   }
-
-  await Promise.all(
-    isolatedServerPromises.map(async (serverPromise) => {
-      try {
-        const { server } = await serverPromise;
-        await server.stop();
-      } catch {
-        // Same best-effort cleanup as the shared testing server.
-      }
-    }),
-  );
 }
 
 function testingServerUrlPattern(serverUrl: string): string {

--- a/packages/jazz-tools/tests/browser/testing-server.ts
+++ b/packages/jazz-tools/tests/browser/testing-server.ts
@@ -16,7 +16,6 @@ export interface TestingServerNetworkDebugState {
 declare module "vitest/internal/browser" {
   interface BrowserCommands {
     testingServerInfo: (appId?: string) => Promise<TestingServerInfo>;
-    isolatedTestingServerInfo: () => Promise<TestingServerInfo>;
     testingServerBlockNetwork: (serverUrl: string) => Promise<void>;
     testingServerUnblockNetwork: (serverUrl: string) => Promise<void>;
     testingServerNetworkDebug: (serverUrl: string) => Promise<TestingServerNetworkDebugState>;
@@ -30,10 +29,6 @@ declare module "vitest/internal/browser" {
 
 export function getTestingServerInfo(appId?: string): Promise<TestingServerInfo> {
   return commands.testingServerInfo(appId);
-}
-
-export function getIsolatedTestingServerInfo(): Promise<TestingServerInfo> {
-  return commands.isolatedTestingServerInfo();
 }
 
 export function blockTestingServerNetwork(serverUrl: string): Promise<void> {

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -7,7 +7,7 @@
  * Server sync tests use a real jazz-tools server spawned by global-setup.
  */
 
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { createDb, Db, type QueryBuilder } from "../../src/runtime/db.js";
 import type { WasmSchema } from "../../src/drivers/types.js";
 import { generateAuthSecret } from "../../src/runtime/auth-secret-store.js";
@@ -23,7 +23,6 @@ import {
 } from "./support.js";
 import {
   blockTestingServerNetwork,
-  getIsolatedTestingServerInfo,
   getTestingServerInfo,
   getTestingServerJwtForUser,
   getTestingServerNetworkDebug,
@@ -76,14 +75,36 @@ const app: s.App<AppSchema> = s.defineApp(schema);
 const { projects, todos } = app;
 type Todo = s.RowOf<typeof todos>;
 
-const rejectAllPermissions = s.definePermissions(app, ({ policy }) => [
-  policy.projects.allowRead.never(),
+const readOnlyPermissions = s.definePermissions(app, ({ policy }) => [
+  policy.projects.allowRead.always(),
   policy.projects.allowInsert.never(),
   policy.projects.allowUpdate.never(),
   policy.projects.allowDelete.never(),
-  policy.todos.allowRead.never(),
+  policy.todos.allowRead.always(),
   policy.todos.allowInsert.never(),
   policy.todos.allowUpdate.never(),
+  policy.todos.allowDelete.never(),
+]);
+
+const noUpdatePermissions = s.definePermissions(app, ({ policy }) => [
+  policy.projects.allowRead.always(),
+  policy.projects.allowInsert.always(),
+  policy.projects.allowUpdate.never(),
+  policy.projects.allowDelete.always(),
+  policy.todos.allowRead.always(),
+  policy.todos.allowInsert.always(),
+  policy.todos.allowUpdate.never(),
+  policy.todos.allowDelete.always(),
+]);
+
+const noDeletePermissions = s.definePermissions(app, ({ policy }) => [
+  policy.projects.allowRead.always(),
+  policy.projects.allowInsert.always(),
+  policy.projects.allowUpdate.always(),
+  policy.projects.allowDelete.never(),
+  policy.todos.allowRead.always(),
+  policy.todos.allowInsert.always(),
+  policy.todos.allowUpdate.always(),
   policy.todos.allowDelete.never(),
 ]);
 
@@ -272,49 +293,6 @@ const allCatalogueTodos: QueryBuilder<CatalogueTodo> = {
     });
   },
 };
-
-/**
- * Sets up a server with the given app schema and permissions.
- */
-async function getServerWithPermissions(
-  app: { wasmSchema: WasmSchema },
-  permissions: CompiledPermissions,
-): Promise<{ appId: string; serverUrl: string; adminSecret: string }> {
-  const { appId, serverUrl, adminSecret } = await getIsolatedTestingServerInfo();
-  const { hash: schemaHash } = await publishStoredSchema(serverUrl, {
-    adminSecret,
-    schema: app.wasmSchema,
-  });
-  const { head } = await fetchPermissionsHead(serverUrl, { adminSecret });
-  await publishStoredPermissions(serverUrl, {
-    adminSecret,
-    schemaHash,
-    permissions,
-    expectedParentBundleObjectId: head?.bundleObjectId ?? null,
-  });
-  return { appId, serverUrl, adminSecret };
-}
-
-/**
- * Creates a non-admin Db with the given appId and serverUrl.
- */
-async function getNonAdminClientDb(
-  appId: string,
-  serverUrl: string,
-  ctx: TestCleanup,
-): Promise<Db> {
-  const jwtToken = await getTestingServerJwtForUser("browser-offline-rejected-wait", {
-    role: "user",
-  });
-  return ctx.track(
-    await createDb({
-      appId,
-      driver: { type: "persistent", dbName: uniqueDbName("sync-wait-edge-rejected-offline") },
-      serverUrl,
-      jwtToken,
-    }),
-  );
-}
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -1281,9 +1259,10 @@ describe("Worker Bridge with OPFS", () => {
     expect(rowsOnA.some((row) => row.title === title)).toBe(true);
   }, 60000);
 
-  it.skip("resolves insert wait at edge tier through the worker bridge", async () => {
+  it("resolves insert wait at edge tier through the worker bridge", async () => {
+    const syncServer = await publishSyncServerSchemaAndPermissions("sync-wait-edge");
     const sharedLocalAuthToken = generateAuthSecret();
-    const db = await createSyncedDb(ctx, "sync-wait-edge", sharedLocalAuthToken);
+    const db = await createSyncedDb(ctx, "sync-wait-edge", sharedLocalAuthToken, syncServer);
 
     const title = `wait-edge-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const inserted = db.insert(todos, { title, done: false });
@@ -1304,60 +1283,232 @@ describe("Worker Bridge with OPFS", () => {
     expect(rowsAtEdge.some((row) => row.id === insertedTodo.id)).toBe(true);
   }, 60000);
 
-  it.skip("rejects insert immediately when published server permissions deny writes", async () => {
-    const { appId, serverUrl } = await getServerWithPermissions(app, rejectAllPermissions);
-
-    // Wait for client to fetch permissions from the server
-    const db = await getNonAdminClientDb(appId, serverUrl, ctx);
-    await waitForCondition(
-      async () => Boolean(db.getAuthState().session) && !db.getAuthState().error,
-      10_000,
-      "client db should authenticate before rejected insert",
-    );
-    await withTimeout(
-      db.all(allTodos, { tier: "edge" }),
-      10_000,
-      "client db should complete an initial edge read before rejected insert",
+  it("server permissions check rejects client optimistic insert - wait notification", async () => {
+    const syncServer = await publishSyncServerSchemaAndPermissions(
+      "sync-wait-edge",
+      readOnlyPermissions,
     );
 
-    expect(() => db.insert(todos, { title: "Rejected", done: false })).toThrow(
-      'WriteError("policy denied INSERT on table todos")',
-    );
-  });
+    const sharedLocalAuthToken = generateAuthSecret();
+    const db = await createSyncedDb(ctx, "sync-wait-edge", sharedLocalAuthToken, syncServer);
 
-  it.skip("server permissions check rejects offline insert", async () => {
-    const { appId, serverUrl } = await getServerWithPermissions(app, rejectAllPermissions);
-
-    // Block network to prevent server permissions from being fetched by the client
-    await blockTestingServerNetwork(serverUrl);
-
-    const db = await getNonAdminClientDb(appId, serverUrl, ctx);
-
-    const inserted = db.insert(todos, { title: "Rejected later", done: false });
-    const waitPromise = inserted.wait({ tier: "edge" });
-
-    const todosAfterInsert = await db.all(allTodos, { tier: "local" });
-    expect(todosAfterInsert.length).toBe(1);
-
-    await unblockTestingServerNetwork(serverUrl);
-    // Insert is reverted in the client
-    await waitForTodos(
-      db,
-      (rows) => rows.length === 0,
-      "offline insert should be reverted once rejected by the server",
-      10_000,
-      "local",
-    );
-
-    // `WriteResult.wait` rejects
-    await expect(
-      withTimeout(waitPromise, 20_000, "offline rejected insert wait(edge) timed out"),
-    ).rejects.toMatchObject({
+    const insertResult = db.insert(todos, { title: "Rejected", done: false });
+    await expect(insertResult.wait({ tier: "edge" })).rejects.toMatchObject({
       name: "PersistedWriteRejectedError",
-      batchId: inserted.batchId,
+      batchId: insertResult.batchId,
       code: "permission_denied",
     });
-  }, 60000);
+
+    const todosAfterRevert = await db.all(allTodos, { tier: "local" });
+    expect(todosAfterRevert.length).toBe(0);
+  });
+
+  it("server permissions check rejects client optimistic insert - onMutationError notification", async () => {
+    const syncServer = await publishSyncServerSchemaAndPermissions(
+      "sync-wait-edge",
+      readOnlyPermissions,
+    );
+
+    const sharedLocalAuthToken = generateAuthSecret();
+    const db = await createSyncedDb(ctx, "sync-wait-edge", sharedLocalAuthToken, syncServer);
+
+    const mutationErrorSpy = vi.fn();
+    db.onMutationError(mutationErrorSpy);
+
+    const insertResult = db.insert(todos, { title: "Rejected", done: false });
+    await waitForCondition(
+      async () => mutationErrorSpy.mock.calls.length > 0,
+      1000,
+      "onMutationError handler should be called",
+    );
+    expect(mutationErrorSpy).toHaveBeenCalledWith({
+      code: "permission_denied",
+      reason: "Insert denied by policy on table todos",
+      batch: {
+        batchId: insertResult.batchId,
+        mode: "direct",
+        sealed: true,
+        latestSettlement: {
+          kind: "rejected",
+          batchId: insertResult.batchId,
+          code: "permission_denied",
+          reason: "Insert denied by policy on table todos",
+        },
+      },
+    });
+
+    const todosAfterRevert = await db.all(allTodos, { tier: "local" });
+    expect(todosAfterRevert.length).toBe(0);
+  });
+
+  it("wait() prevents onMutationError handler from firing", async () => {
+    const syncServer = await publishSyncServerSchemaAndPermissions(
+      "sync-wait-edge",
+      readOnlyPermissions,
+    );
+
+    const sharedLocalAuthToken = generateAuthSecret();
+    const db = await createSyncedDb(ctx, "sync-wait-edge", sharedLocalAuthToken, syncServer);
+
+    const mutationErrorSpy = vi.fn();
+    db.onMutationError(mutationErrorSpy);
+
+    const insertResult = db.insert(todos, { title: "Rejected", done: false });
+    await expect(insertResult.wait({ tier: "edge" })).rejects.toMatchObject({
+      name: "PersistedWriteRejectedError",
+      batchId: insertResult.batchId,
+      code: "permission_denied",
+    });
+    expect(mutationErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it("replays onMutationError after restart when the rejection was not previously delivered", async () => {
+    const syncServer = await publishSyncServerSchemaAndPermissions(
+      "sync-on-mutation-error-restart",
+      readOnlyPermissions,
+    );
+
+    const sharedLocalAuthToken = generateAuthSecret();
+    const dbName = uniqueDbName("sync-on-mutation-error-restart");
+    const dbBeforeRestart = track(
+      await createDb({
+        appId: syncServer.appId,
+        driver: { type: "persistent", dbName },
+        serverUrl: syncServer.serverUrl,
+        secret: sharedLocalAuthToken,
+      }),
+    );
+
+    const insertResult = dbBeforeRestart.insert(todos, {
+      title: "Rejected on restart",
+      done: false,
+    });
+    // Wait for the insert to be persisted locally before restarting
+    await insertResult.wait({ tier: "local" });
+
+    // Ensure the insert is not rejected before restarting
+    const clientBeforeRestart = (dbBeforeRestart as any).getClient(app.wasmSchema);
+    expect(
+      clientBeforeRestart.localBatchRecord(insertResult.batchId)?.latestSettlement,
+    ).not.toMatchObject({
+      kind: "rejected",
+    });
+
+    await dbBeforeRestart.shutdown();
+    untrack(dbBeforeRestart);
+
+    const dbAfterRestart = track(
+      await createDb({
+        appId: syncServer.appId,
+        driver: { type: "persistent", dbName },
+        serverUrl: syncServer.serverUrl,
+        secret: sharedLocalAuthToken,
+      }),
+    );
+
+    const mutationErrorSpy = vi.fn();
+    dbAfterRestart.onMutationError(mutationErrorSpy);
+
+    // Run a query to ensure both the in-memory and worker clients are initialized
+    // Also checks the insert was reverted
+    const todosAfterRestart = await dbAfterRestart.all(allTodos, { tier: "local" });
+    expect(todosAfterRestart.length).toBe(0);
+
+    await waitForCondition(
+      async () => mutationErrorSpy.mock.calls.length > 0,
+      5000,
+      "onMutationError handler should receive rejection after restart",
+    );
+    expect(mutationErrorSpy).toHaveBeenCalledWith({
+      code: "permission_denied",
+      reason: "Insert denied by policy on table todos",
+      batch: {
+        batchId: insertResult.batchId,
+        mode: "direct",
+        sealed: true,
+        latestSettlement: {
+          kind: "rejected",
+          batchId: insertResult.batchId,
+          code: "permission_denied",
+          reason: "Insert denied by policy on table todos",
+        },
+      },
+    });
+  });
+
+  describe("optimistic writes are reverted on server rejection", () => {
+    it("insert", async () => {
+      const syncServer = await publishSyncServerSchemaAndPermissions(
+        "sync-wait-edge",
+        readOnlyPermissions,
+      );
+
+      const sharedLocalAuthToken = generateAuthSecret();
+      const db = await createSyncedDb(ctx, "sync-wait-edge", sharedLocalAuthToken, syncServer);
+
+      const insertResult = db.insert(todos, { title: "Rejected", done: false });
+      await expect(insertResult.wait({ tier: "edge" })).rejects.toMatchObject({
+        name: "PersistedWriteRejectedError",
+        batchId: insertResult.batchId,
+        code: "permission_denied",
+      });
+
+      const todosAfterRevert = await db.all(allTodos, { tier: "local" });
+      expect(todosAfterRevert.length).toBe(0);
+    });
+
+    it("update", async () => {
+      const syncServer = await publishSyncServerSchemaAndPermissions(
+        "sync-wait-edge",
+        noUpdatePermissions,
+      );
+
+      const sharedLocalAuthToken = generateAuthSecret();
+      const db = await createSyncedDb(ctx, "sync-wait-edge", sharedLocalAuthToken, syncServer);
+
+      const insertResult = await db.insert(todos, { title: "Initial task", done: false });
+      const todo = insertResult.value;
+
+      const updateResult = db.update(todos, todo.id, { title: "Updated task" });
+      await insertResult.wait({ tier: "edge" });
+      await expect(updateResult.wait({ tier: "edge" })).rejects.toMatchObject({
+        name: "PersistedWriteRejectedError",
+        batchId: updateResult.batchId,
+        code: "permission_denied",
+      });
+
+      const todosAfterRevert = await db.all(allTodos, { tier: "local" });
+      expect(todosAfterRevert).toEqual([todo]);
+    });
+
+    it("delete", async () => {
+      const syncServer = await publishSyncServerSchemaAndPermissions(
+        "sync-wait-edge",
+        noDeletePermissions,
+      );
+
+      const sharedLocalAuthToken = generateAuthSecret();
+      const db = await createSyncedDb(ctx, "sync-wait-edge", sharedLocalAuthToken, syncServer);
+
+      const insertResult = await db.insert(todos, { title: "Initial task", done: false });
+      const todo = insertResult.value;
+
+      const deleteResult = db.delete(todos, todo.id);
+
+      const todosBeforeRevert = await db.all(allTodos, { tier: "local" });
+      expect(todosBeforeRevert).toEqual([]);
+
+      await insertResult.wait({ tier: "edge" });
+      await expect(deleteResult.wait({ tier: "edge" })).rejects.toMatchObject({
+        name: "PersistedWriteRejectedError",
+        batchId: deleteResult.batchId,
+        code: "permission_denied",
+      });
+
+      const todosAfterRevert = await db.all(allTodos, { tier: "local" });
+      expect(todosAfterRevert).toEqual([todo]);
+    });
+  });
 
   it("recovers sync after browser-side network loss with B in a separate context", async () => {
     const syncServer = await publishSyncServerSchemaAndPermissions("sync-recover");
@@ -1887,7 +2038,10 @@ async function waitForTodos(
   return waitForQuery(db, allTodos, predicate, label, timeoutMs, tier);
 }
 
-async function publishSyncServerSchemaAndPermissions(scope: string): Promise<TestingServerInfo> {
+async function publishSyncServerSchemaAndPermissions(
+  scope: string,
+  permissions?: CompiledPermissions,
+): Promise<TestingServerInfo> {
   const testingServer = await getTestingServerInfo(uniqueDbName(`worker-bridge-${scope}`));
   const { appId, serverUrl, adminSecret } = testingServer;
   const { hash: schemaHash } = await publishStoredSchema(serverUrl, {
@@ -1896,30 +2050,31 @@ async function publishSyncServerSchemaAndPermissions(scope: string): Promise<Tes
     schema: app.wasmSchema,
   });
   const { head } = await fetchPermissionsHead(serverUrl, { appId, adminSecret });
+  const permissionsToPublish = permissions ?? {
+    todos: {
+      select: { using: { type: "True" } },
+      insert: { with_check: { type: "True" } },
+      update: {
+        using: { type: "True" },
+        with_check: { type: "True" },
+      },
+      delete: { using: { type: "True" } },
+    },
+    projects: {
+      select: { using: { type: "True" } },
+      insert: { with_check: { type: "True" } },
+      update: {
+        using: { type: "True" },
+        with_check: { type: "True" },
+      },
+      delete: { using: { type: "True" } },
+    },
+  };
   await publishStoredPermissions(serverUrl, {
     appId,
     adminSecret,
     schemaHash,
-    permissions: {
-      todos: {
-        select: { using: { type: "True" } },
-        insert: { with_check: { type: "True" } },
-        update: {
-          using: { type: "True" },
-          with_check: { type: "True" },
-        },
-        delete: { using: { type: "True" } },
-      },
-      projects: {
-        select: { using: { type: "True" } },
-        insert: { with_check: { type: "True" } },
-        update: {
-          using: { type: "True" },
-          with_check: { type: "True" },
-        },
-        delete: { using: { type: "True" } },
-      },
-    },
+    permissions: permissionsToPublish,
     expectedParentBundleObjectId: head?.bundleObjectId ?? null,
   });
 

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -1466,12 +1466,18 @@ describe("Worker Bridge with OPFS", () => {
       const sharedLocalAuthToken = generateAuthSecret();
       const db = await createSyncedDb(ctx, "sync-wait-edge", sharedLocalAuthToken, syncServer);
 
-      const insertResult = await db.insert(todos, { title: "Initial task", done: false });
+      const insertResult = db.insert(todos, { title: "Initial task", done: false });
       const todo = insertResult.value;
+      const insertConfirmed = insertResult.wait({ tier: "edge" });
 
       const updateResult = db.update(todos, todo.id, { title: "Updated task" });
-      await insertResult.wait({ tier: "edge" });
-      await expect(updateResult.wait({ tier: "edge" })).rejects.toMatchObject({
+      const updateConfirmed = updateResult.wait({ tier: "edge" });
+
+      const todosBeforeRevert = await db.all(allTodos, { tier: "local" });
+      expect(todosBeforeRevert).toEqual([{ ...todo, title: "Updated task" }]);
+
+      await insertConfirmed;
+      await expect(updateConfirmed).rejects.toMatchObject({
         name: "PersistedWriteRejectedError",
         batchId: updateResult.batchId,
         code: "permission_denied",
@@ -1490,16 +1496,18 @@ describe("Worker Bridge with OPFS", () => {
       const sharedLocalAuthToken = generateAuthSecret();
       const db = await createSyncedDb(ctx, "sync-wait-edge", sharedLocalAuthToken, syncServer);
 
-      const insertResult = await db.insert(todos, { title: "Initial task", done: false });
+      const insertResult = db.insert(todos, { title: "Initial task", done: false });
       const todo = insertResult.value;
+      const insertConfirmed = insertResult.wait({ tier: "edge" });
 
       const deleteResult = db.delete(todos, todo.id);
+      const deleteConfirmed = deleteResult.wait({ tier: "edge" });
 
       const todosBeforeRevert = await db.all(allTodos, { tier: "local" });
       expect(todosBeforeRevert).toEqual([]);
 
-      await insertResult.wait({ tier: "edge" });
-      await expect(deleteResult.wait({ tier: "edge" })).rejects.toMatchObject({
+      await insertConfirmed;
+      await expect(deleteConfirmed).rejects.toMatchObject({
         name: "PersistedWriteRejectedError",
         batchId: deleteResult.batchId,
         code: "permission_denied",

--- a/packages/jazz-tools/vitest.config.browser.ts
+++ b/packages/jazz-tools/vitest.config.browser.ts
@@ -7,7 +7,6 @@ import { playwright } from "@vitest/browser-playwright";
 import {
   blockTestingServerNetwork,
   debugTestingServerNetwork,
-  isolatedTestingServerInfo,
   testingServerInfo,
   testingServerJwtForUser,
   unblockTestingServerNetwork,
@@ -67,7 +66,6 @@ export default defineConfig({
       instances: [{ browser: "chromium", headless: true }],
       commands: {
         testingServerInfo: async (_context, appId) => testingServerInfo(appId),
-        isolatedTestingServerInfo: async () => isolatedTestingServerInfo(),
         testingServerBlockNetwork: async ({ context }, serverUrl) =>
           blockTestingServerNetwork(context, serverUrl),
         testingServerUnblockNetwork: async ({ context }, serverUrl) =>


### PR DESCRIPTION
## Description

Improves test coverage over `.wait({tier})` and `onMutationError`, and fixes several issues that prevented rejections from reaching the in-memory client when in worker mode.

The biggest gap was that the worker previously retained enough row state to resend data after reopen, but not enough batch metadata to replay a missed rejection, so `onMutationError` was lost across restarts. The Rust side now retains replayable client batch records (only when in worker mode).