### PR TITLE
Make batch durability start at seal

### DIFF
--- a/crates/jazz-tools/src/runtime_core/mod.rs
+++ b/crates/jazz-tools/src/runtime_core/mod.rs
@@ -313,6 +313,11 @@ pub struct RuntimeCore<S: Storage, Sch: Scheduler> {
     /// Per-batch durability bookkeeping: ack watchers + rejection set.
     pub(crate) durability: DurabilityTracker,
 
+    /// Recently mutated local batch records. Large direct batches append one
+    /// member per write, so reloading the record from storage on every insert
+    /// means repeatedly decoding the full accumulated member array.
+    local_batch_record_cache: HashMap<BatchId, crate::batch_fate::LocalBatchRecord>,
+
     /// Label for tracing (e.g. "local", "edge", "client").
     tier_label: &'static str,
 
@@ -362,6 +367,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             pending_subscriptions: HashMap::new(),
             pending_one_shot_queries: HashMap::new(),
             durability: DurabilityTracker::with_initial_rejections(rejected_batch_ids.clone()),
+            local_batch_record_cache: HashMap::new(),
             tier_label: "unknown",
             sync_tracer: None,
             auth_failure_callback: None,

--- a/crates/jazz-tools/src/runtime_core/tests.rs
+++ b/crates/jazz-tools/src/runtime_core/tests.rs
@@ -51,6 +51,7 @@ struct RowMutationCallCounts {
     row_mutation_calls: usize,
     separate_index_mutation_calls: usize,
     flush_wal_calls: usize,
+    local_batch_record_get_calls: usize,
 }
 
 struct RowMutationObservingStorage {
@@ -968,6 +969,9 @@ impl Storage for RowMutationObservingStorage {
     }
 
     fn raw_table_get(&self, table: &str, key: &str) -> Result<Option<Vec<u8>>, StorageError> {
+        if table == "__local_batch_record" && key.starts_with("batch:") {
+            self.calls.lock().unwrap().local_batch_record_get_calls += 1;
+        }
         self.inner.raw_table_get(table, key)
     }
 

--- a/crates/jazz-tools/src/runtime_core/tests/query_subscription.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/query_subscription.rs
@@ -1467,6 +1467,8 @@ fn rc_transaction_visible_subscription_removes_local_pending_overlay_when_reject
         assert_eq!(decode_added_rows(&calls[1])[0].0, row_id);
     }
 
+    s.a.seal_batch(batch_id).unwrap();
+
     s.a.park_sync_message(InboxEntry {
         source: Source::Server(s.b_server_for_a),
         payload: SyncPayload::BatchSettlement {

--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/direct.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/direct.rs
@@ -144,6 +144,45 @@ fn rc_same_row_direct_batch_overwrites_in_place() {
 }
 
 #[test]
+fn rc_direct_batch_reuses_loaded_local_batch_record_while_building() {
+    let calls = Arc::new(Mutex::new(RowMutationCallCounts::default()));
+    let mut core = create_runtime_with_boxed_storage(
+        test_schema(),
+        "direct-batch-local-record-cache-test",
+        Box::new(RowMutationObservingStorage::new(calls.clone())),
+    );
+    let batch_id = BatchId::new();
+    let write_context = WriteContext::default()
+        .with_batch_mode(crate::batch_fate::BatchMode::Direct)
+        .with_batch_id(batch_id);
+
+    core.insert(
+        "users",
+        user_insert_values(ObjectId::new(), "Alice"),
+        Some(&write_context),
+    )
+    .unwrap();
+    core.insert(
+        "users",
+        user_insert_values(ObjectId::new(), "Bob"),
+        Some(&write_context),
+    )
+    .unwrap();
+    core.insert(
+        "users",
+        user_insert_values(ObjectId::new(), "Cleo"),
+        Some(&write_context),
+    )
+    .unwrap();
+
+    assert_eq!(
+        calls.lock().unwrap().local_batch_record_get_calls,
+        1,
+        "building a direct batch should not repeatedly load and decode the growing local batch record"
+    );
+}
+
+#[test]
 fn rc_worker_direct_batch_retains_all_visible_members() {
     let mut s = create_3tier_rc();
     let batch_id = BatchId::new();

--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/direct.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/direct.rs
@@ -183,7 +183,7 @@ fn rc_direct_batch_reuses_loaded_local_batch_record_while_building() {
 }
 
 #[test]
-fn rc_worker_direct_batch_retains_all_visible_members() {
+fn rc_worker_direct_batch_persists_visible_members_on_seal() {
     let mut s = create_3tier_rc();
     let batch_id = BatchId::new();
     let write_context = WriteContext::default()
@@ -207,12 +207,21 @@ fn rc_worker_direct_batch_retains_all_visible_members() {
     assert_eq!(first_batch_id, batch_id);
     assert_eq!(second_batch_id, batch_id);
 
+    assert_eq!(
+        s.b.storage().load_local_batch_record(batch_id).unwrap(),
+        None,
+        "open direct batches should not persist replayable durability records before seal"
+    );
+
+    s.b.seal_batch(batch_id).unwrap();
+
     let branch_name = s.b.schema_manager().branch_name();
     let local_record =
         s.b.storage()
             .load_local_batch_record(batch_id)
             .unwrap()
-            .expect("worker should retain one direct batch record for shared writes");
+            .expect("sealed direct batch should persist one record for shared writes");
+    assert!(local_record.sealed);
 
     match local_record.latest_settlement {
         Some(crate::batch_fate::BatchSettlement::DurableDirect {
@@ -292,7 +301,7 @@ fn rc_sealed_direct_batch_rejects_further_writes() {
 }
 
 #[test]
-fn rc_local_batch_record_does_not_seal_current_open_direct_batch() {
+fn rc_open_direct_batch_has_no_persisted_local_batch_record() {
     let mut core = create_test_runtime();
     let batch_id = BatchId::new();
     let write_context = WriteContext::default()
@@ -306,12 +315,11 @@ fn rc_local_batch_record_does_not_seal_current_open_direct_batch() {
     )
     .unwrap();
 
-    let record = core
-        .local_batch_record(batch_id)
-        .unwrap()
-        .expect("open direct batch should have a local record");
-    assert!(!record.sealed);
-    assert!(record.sealed_submission.is_none());
+    assert_eq!(
+        core.local_batch_record(batch_id).unwrap(),
+        None,
+        "open direct batches are in-memory builders until sealed"
+    );
 }
 
 #[test]

--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/persisted.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/persisted.rs
@@ -33,6 +33,7 @@ fn rc_update_direct_batch_remains_pending_until_terminal_settlement() {
     let update_batch_id =
         s.a.update(id, vec![("name".into(), Value::Text("Bob".into()))], None)
             .unwrap();
+    s.a.seal_batch(update_batch_id).unwrap();
 
     let update_record =
         s.a.storage()
@@ -98,6 +99,7 @@ fn rc_delete_direct_batch_remains_pending_until_terminal_settlement() {
     s.a.immediate_tick();
 
     let delete_batch_id = s.a.delete(id, None).unwrap();
+    s.a.seal_batch(delete_batch_id).unwrap();
 
     let delete_record =
         s.a.storage()
@@ -335,8 +337,17 @@ fn rc_insert_persisted_tracks_local_batch_record_and_settlement() {
     assert_eq!(initial_record.batch_id, batch_id);
     assert_eq!(initial_record.mode, crate::batch_fate::BatchMode::Direct);
     assert_eq!(
-        initial_record.latest_settlement, None,
-        "client-side persisted direct writes should start pending until an upstream durability settlement arrives"
+        initial_record.latest_settlement,
+        Some(crate::batch_fate::BatchSettlement::DurableDirect {
+            batch_id,
+            confirmed_tier: DurabilityTier::Local,
+            visible_members: vec![crate::batch_fate::VisibleBatchMember {
+                object_id: row_id,
+                branch_name,
+                batch_id,
+            }],
+        }),
+        "standalone persisted direct writes auto-seal and start locally durable"
     );
 
     s.a.push_sync_inbox(InboxEntry {

--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/rejection_recovery.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/rejection_recovery.rs
@@ -452,6 +452,7 @@ fn rc_transactional_insert_is_rejected_by_authority_permission_check() {
     assert_eq!(history_rows.len(), 1);
     let batch_id = history_rows[0].batch_id;
 
+    alice.seal_batch(batch_id).unwrap();
     pump_client_messages_to_server(&mut alice, &mut worker, server_id, client_id);
 
     let worker_outbox = worker.sync_sender().take();
@@ -566,6 +567,7 @@ fn rc_acknowledge_rejected_batch_prunes_local_batch_record() {
     assert_eq!(history_rows.len(), 1);
     let batch_id = history_rows[0].batch_id;
 
+    alice.seal_batch(batch_id).unwrap();
     pump_client_messages_to_server(&mut alice, &mut worker, server_id, client_id);
 
     for entry in worker.sync_sender().take() {
@@ -664,6 +666,7 @@ fn rc_rejected_batch_survives_restart_until_acknowledged() {
     assert_eq!(history_rows.len(), 1);
     let batch_id = history_rows[0].batch_id;
 
+    alice.seal_batch(batch_id).unwrap();
     pump_client_messages_to_server(&mut alice, &mut worker, server_id, client_id);
 
     for entry in worker.sync_sender().take() {

--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/storage_flush.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/storage_flush.rs
@@ -54,6 +54,7 @@ fn rc_local_row_writes_batch_row_and_index_mutations() {
             row_mutation_calls: 3,
             separate_index_mutation_calls: 0,
             flush_wal_calls: 0,
+            local_batch_record_get_calls: 3,
         },
         "local row writes should persist row history, visible heads, and index changes in one storage mutation"
     );

--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/transactional.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/transactional.rs
@@ -530,18 +530,11 @@ fn rc_transactional_insert_persisted_tracks_local_batch_record_and_settlement() 
     let batch_id = history_rows[0].batch_id;
     let branch_name = s.a.schema_manager().branch_name();
 
-    let initial_record =
-        s.a.storage()
-            .load_local_batch_record(batch_id)
-            .unwrap()
-            .expect("transactional persisted write should create a local batch record");
-    assert_eq!(initial_record.batch_id, batch_id);
     assert_eq!(
-        initial_record.mode,
-        crate::batch_fate::BatchMode::Transactional
+        s.a.storage().load_local_batch_record(batch_id).unwrap(),
+        None,
+        "open transactional batches should not persist replayable durability records before seal"
     );
-    assert!(!initial_record.sealed);
-    assert_eq!(initial_record.latest_settlement, None);
 
     s.a.seal_batch(batch_id).unwrap();
     pump_a_to_b(&mut s);
@@ -691,14 +684,10 @@ fn rc_transactional_persisted_writes_with_shared_batch_id_reconcile_as_one_batch
     assert_eq!(first_history_rows[0].batch_id, batch_id);
     assert_eq!(second_history_rows[0].batch_id, batch_id);
 
-    let initial_records = s.a.storage().scan_local_batch_records().unwrap();
-    assert_eq!(
-        initial_records.len(),
-        1,
-        "shared batch should persist one local batch record"
+    assert!(
+        s.a.storage().scan_local_batch_records().unwrap().is_empty(),
+        "open shared transactional batches should not persist replayable durability records before seal"
     );
-    assert_eq!(initial_records[0].batch_id, batch_id);
-    assert!(!initial_records[0].sealed);
 
     s.a.seal_batch(batch_id).unwrap();
     pump_a_to_b(&mut s);

--- a/crates/jazz-tools/src/runtime_core/writes.rs
+++ b/crates/jazz-tools/src/runtime_core/writes.rs
@@ -30,6 +30,13 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             .unwrap_or(DurabilityTier::Local)
     }
 
+    fn should_auto_seal_direct_write(
+        batch_mode: BatchMode,
+        write_context: Option<&WriteContext>,
+    ) -> bool {
+        batch_mode == BatchMode::Direct && write_context.and_then(WriteContext::batch_id).is_none()
+    }
+
     fn ensure_batch_is_writable(
         &mut self,
         write_context: Option<&WriteContext>,
@@ -86,23 +93,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         row_id: ObjectId,
         batch_id: BatchId,
         mode: BatchMode,
-        seed_local_settlement: bool,
     ) -> Result<(), RuntimeError> {
-        let branch_name = self.schema_manager.branch_name();
-        let visible_members = vec![VisibleBatchMember {
-            object_id: row_id,
-            branch_name,
-            batch_id,
-        }];
-        let latest_settlement = match (mode, seed_local_settlement) {
-            (BatchMode::Direct, true) => Some(BatchSettlement::DurableDirect {
-                batch_id,
-                confirmed_tier: self.local_write_confirmed_tier(),
-                visible_members: visible_members.clone(),
-            }),
-            (BatchMode::Direct, false) | (BatchMode::Transactional, _) => None,
-        };
-
         let mut record = self
             .local_batch_record_cache
             .remove(&batch_id)
@@ -125,15 +116,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         for member in self.local_batch_members_for_row(row_id, batch_id)? {
             record.upsert_member(member);
         }
-        if let Some(settlement) = latest_settlement {
-            record.apply_settlement(settlement);
-        }
 
-        self.storage
-            .upsert_local_batch_record(&record)
-            .map_err(|err| {
-                RuntimeError::WriteError(format!("persist local batch record: {err}"))
-            })?;
         self.local_batch_record_cache.insert(batch_id, record);
         Ok(())
     }
@@ -226,22 +209,13 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         )))
     }
 
-    pub(crate) fn sealed_batch_members(
-        &self,
-        batch_id: BatchId,
+    pub(crate) fn sealed_batch_members_from_record(
+        record: &LocalBatchRecord,
     ) -> Result<(crate::object::BranchName, Vec<SealedBatchMember>), RuntimeError> {
-        let Some(record) = self
-            .storage
-            .load_local_batch_record(batch_id)
-            .map_err(|err| RuntimeError::WriteError(format!("load local batch record: {err}")))?
-        else {
-            return Err(RuntimeError::WriteError(format!(
-                "missing local batch record for {batch_id:?}"
-            )));
-        };
         let Some(first_member) = record.members.first() else {
             return Err(RuntimeError::WriteError(format!(
-                "cannot seal empty batch {batch_id:?}"
+                "cannot seal empty batch {:?}",
+                record.batch_id
             )));
         };
         let target_branch_name = first_member.branch_name;
@@ -251,13 +225,14 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             .any(|member| member.branch_name != target_branch_name)
         {
             return Err(RuntimeError::WriteError(format!(
-                "batch {batch_id:?} spans multiple target branches"
+                "batch {:?} spans multiple target branches",
+                record.batch_id
             )));
         }
 
         let mut members: Vec<_> = record
             .members
-            .into_iter()
+            .iter()
             .map(|member| SealedBatchMember {
                 object_id: member.object_id,
                 row_digest: member.row_digest,
@@ -275,30 +250,20 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
 
     pub(crate) fn sealed_batch_submission(
         &self,
-        batch_id: BatchId,
+        record: &LocalBatchRecord,
     ) -> Result<SealedBatchSubmission, RuntimeError> {
-        let (target_branch_name, members) = self.sealed_batch_members(batch_id)?;
-        let captured_frontier = match self.storage.load_local_batch_record(batch_id) {
-            Ok(Some(record)) if record.mode == BatchMode::Transactional => self
-                .storage
+        let (target_branch_name, members) = Self::sealed_batch_members_from_record(record)?;
+        let captured_frontier = if record.mode == BatchMode::Transactional {
+            self.storage
                 .capture_family_visible_frontier(target_branch_name)
                 .map_err(|err| {
                     RuntimeError::WriteError(format!("capture family visible frontier: {err}"))
-                })?,
-            Ok(Some(_)) => Vec::new(),
-            Ok(None) => {
-                return Err(RuntimeError::WriteError(format!(
-                    "missing local batch record for {batch_id:?}"
-                )));
-            }
-            Err(err) => {
-                return Err(RuntimeError::WriteError(format!(
-                    "load local batch record: {err}"
-                )));
-            }
+                })?
+        } else {
+            Vec::new()
         };
         Ok(SealedBatchSubmission::new(
-            batch_id,
+            record.batch_id,
             target_branch_name,
             members,
             captured_frontier,
@@ -328,7 +293,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         let batch_mode = write_context
             .map(WriteContext::batch_mode)
             .unwrap_or(BatchMode::Direct);
-        self.track_local_batch(row_id, batch_id, batch_mode, true)?;
+        self.track_local_batch(row_id, batch_id, batch_mode)?;
         debug!(object_id = %row_id, "inserted");
         self.mark_storage_write_pending_flush();
         self.immediate_tick();
@@ -360,7 +325,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         let batch_mode = write_context
             .map(WriteContext::batch_mode)
             .unwrap_or(BatchMode::Direct);
-        self.track_local_batch(row_id, batch_id, batch_mode, true)?;
+        self.track_local_batch(row_id, batch_id, batch_mode)?;
         debug!(object_id = %row_id, "inserted");
         self.mark_storage_write_pending_flush();
         self.immediate_tick();
@@ -383,7 +348,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         let batch_mode = write_context
             .map(WriteContext::batch_mode)
             .unwrap_or(BatchMode::Direct);
-        self.track_local_batch(object_id, batch_id, batch_mode, true)?;
+        self.track_local_batch(object_id, batch_id, batch_mode)?;
 
         self.mark_storage_write_pending_flush();
         self.immediate_tick();
@@ -415,7 +380,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             .unwrap_or(BatchMode::Direct)
             == BatchMode::Transactional
         {
-            self.track_local_batch(object_id, batch_id, BatchMode::Transactional, false)?;
+            self.track_local_batch(object_id, batch_id, BatchMode::Transactional)?;
         }
 
         self.mark_storage_write_pending_flush();
@@ -439,7 +404,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         let batch_mode = write_context
             .map(WriteContext::batch_mode)
             .unwrap_or(BatchMode::Direct);
-        self.track_local_batch(object_id, batch_id, batch_mode, true)?;
+        self.track_local_batch(object_id, batch_id, batch_mode)?;
         debug!("deleted");
         self.mark_storage_write_pending_flush();
         self.immediate_tick();
@@ -492,10 +457,13 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             .unwrap_or(BatchMode::Direct)
             == BatchMode::Transactional
         {
-            self.track_local_batch(row_id, batch_id, BatchMode::Transactional, false)?;
+            self.track_local_batch(row_id, batch_id, BatchMode::Transactional)?;
         } else {
-            self.track_local_batch(row_id, batch_id, BatchMode::Direct, false)?;
+            self.track_local_batch(row_id, batch_id, BatchMode::Direct)?;
         }
+        let batch_mode = write_context
+            .map(WriteContext::batch_mode)
+            .unwrap_or(BatchMode::Direct);
         let (sender, receiver) = oneshot::channel();
         if self
             .schema_manager
@@ -508,6 +476,9 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             let row_batch_key = self.ack_watcher_key(row_id, batch_id, write_context);
             self.durability
                 .register_watcher(row_batch_key, tier, sender);
+        }
+        if Self::should_auto_seal_direct_write(batch_mode, write_context) {
+            self.seal_batch(batch_id)?;
         }
         self.mark_storage_write_pending_flush();
         self.immediate_tick();
@@ -534,7 +505,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             .unwrap_or(BatchMode::Direct);
         let batch_id = result.batch_id;
         let row_values = result.row_values;
-        self.track_local_batch(row_id, batch_id, batch_mode, false)?;
+        self.track_local_batch(row_id, batch_id, batch_mode)?;
 
         let (sender, receiver) = oneshot::channel();
         if self
@@ -548,6 +519,9 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             let row_batch_key = self.ack_watcher_key(row_id, batch_id, write_context);
             self.durability
                 .register_watcher(row_batch_key, tier, sender);
+        }
+        if Self::should_auto_seal_direct_write(batch_mode, write_context) {
+            self.seal_batch(batch_id)?;
         }
 
         self.mark_storage_write_pending_flush();
@@ -586,7 +560,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         let batch_mode = write_context
             .map(WriteContext::batch_mode)
             .unwrap_or(BatchMode::Direct);
-        self.track_local_batch(object_id, batch_id, batch_mode, false)?;
+        self.track_local_batch(object_id, batch_id, batch_mode)?;
 
         let (sender, receiver) = oneshot::channel();
         if self
@@ -600,6 +574,9 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             let row_batch_key = self.ack_watcher_key(object_id, batch_id, write_context);
             self.durability
                 .register_watcher(row_batch_key, tier, sender);
+        }
+        if Self::should_auto_seal_direct_write(batch_mode, write_context) {
+            self.seal_batch(batch_id)?;
         }
 
         self.mark_storage_write_pending_flush();
@@ -643,7 +620,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         let batch_mode = write_context
             .map(WriteContext::batch_mode)
             .unwrap_or(BatchMode::Direct);
-        self.track_local_batch(object_id, batch_id, batch_mode, false)?;
+        self.track_local_batch(object_id, batch_id, batch_mode)?;
 
         let (sender, receiver) = oneshot::channel();
         if self
@@ -657,6 +634,9 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             let row_batch_key = self.ack_watcher_key(object_id, batch_id, write_context);
             self.durability
                 .register_watcher(row_batch_key, tier, sender);
+        }
+        if Self::should_auto_seal_direct_write(batch_mode, write_context) {
+            self.seal_batch(batch_id)?;
         }
 
         self.mark_storage_write_pending_flush();
@@ -681,7 +661,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             .map(WriteContext::batch_mode)
             .unwrap_or(BatchMode::Direct);
         let batch_id = handle.batch_id;
-        self.track_local_batch(object_id, batch_id, batch_mode, false)?;
+        self.track_local_batch(object_id, batch_id, batch_mode)?;
 
         let (sender, receiver) = oneshot::channel();
         if self
@@ -695,6 +675,9 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             let row_batch_key = self.ack_watcher_key(object_id, batch_id, write_context);
             self.durability
                 .register_watcher(row_batch_key, tier, sender);
+        }
+        if Self::should_auto_seal_direct_write(batch_mode, write_context) {
+            self.seal_batch(batch_id)?;
         }
 
         self.mark_storage_write_pending_flush();
@@ -775,9 +758,25 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             return Ok(());
         }
 
-        let submission = self.sealed_batch_submission(batch_id)?;
+        let submission = self.sealed_batch_submission(&record)?;
 
         record.mark_sealed(submission.clone());
+        if record.mode == BatchMode::Direct {
+            let visible_members = record
+                .members
+                .iter()
+                .map(|member| VisibleBatchMember {
+                    object_id: member.object_id,
+                    branch_name: member.branch_name,
+                    batch_id,
+                })
+                .collect();
+            record.apply_settlement(BatchSettlement::DurableDirect {
+                batch_id,
+                confirmed_tier: self.local_write_confirmed_tier(),
+                visible_members,
+            });
+        }
         self.storage
             .upsert_local_batch_record(&record)
             .map_err(|err| {

--- a/crates/jazz-tools/src/runtime_core/writes.rs
+++ b/crates/jazz-tools/src/runtime_core/writes.rs
@@ -31,7 +31,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
     }
 
     fn ensure_batch_is_writable(
-        &self,
+        &mut self,
         write_context: Option<&WriteContext>,
     ) -> Result<(), RuntimeError> {
         let Some(write_context) = write_context else {
@@ -42,11 +42,27 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             return Ok(());
         };
 
+        if let Some(record) = self.local_batch_record_cache.get(&batch_id) {
+            if record.mode != mode {
+                return Err(RuntimeError::WriteError(format!(
+                    "batch {batch_id:?} reused with conflicting modes"
+                )));
+            }
+            if record.sealed {
+                return Err(RuntimeError::WriteError(format!(
+                    "batch {batch_id:?} is already sealed"
+                )));
+            }
+            return Ok(());
+        }
+
         let Some(record) = self
             .storage
             .load_local_batch_record(batch_id)
             .map_err(|err| RuntimeError::WriteError(format!("load local batch record: {err}")))?
         else {
+            self.local_batch_record_cache
+                .insert(batch_id, LocalBatchRecord::new(batch_id, mode, false, None));
             return Ok(());
         };
 
@@ -61,6 +77,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             )));
         }
 
+        self.local_batch_record_cache.insert(batch_id, record);
         Ok(())
     }
 
@@ -87,10 +104,19 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         };
 
         let mut record = self
-            .storage
-            .load_local_batch_record(batch_id)
-            .map_err(|err| RuntimeError::WriteError(format!("load local batch record: {err}")))?
-            .unwrap_or_else(|| LocalBatchRecord::new(batch_id, mode, false, None));
+            .local_batch_record_cache
+            .remove(&batch_id)
+            .map(Ok)
+            .unwrap_or_else(|| {
+                self.storage
+                    .load_local_batch_record(batch_id)
+                    .map_err(|err| {
+                        RuntimeError::WriteError(format!("load local batch record: {err}"))
+                    })
+                    .map(|record| {
+                        record.unwrap_or_else(|| LocalBatchRecord::new(batch_id, mode, false, None))
+                    })
+            })?;
         if record.mode != mode {
             return Err(RuntimeError::WriteError(format!(
                 "batch {batch_id:?} reused with conflicting modes"
@@ -105,7 +131,11 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
 
         self.storage
             .upsert_local_batch_record(&record)
-            .map_err(|err| RuntimeError::WriteError(format!("persist local batch record: {err}")))
+            .map_err(|err| {
+                RuntimeError::WriteError(format!("persist local batch record: {err}"))
+            })?;
+        self.local_batch_record_cache.insert(batch_id, record);
+        Ok(())
     }
 
     fn local_batch_members_for_row(
@@ -698,6 +728,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
     /// Acknowledge a replayable rejected batch outcome and prune the local
     /// batch record that kept it alive across reconnect and restart.
     pub fn acknowledge_rejected_batch(&mut self, batch_id: BatchId) -> Result<bool, RuntimeError> {
+        self.local_batch_record_cache.remove(&batch_id);
         let Some(record) = self
             .storage
             .load_local_batch_record(batch_id)
@@ -722,17 +753,25 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
     }
 
     pub fn seal_batch(&mut self, batch_id: BatchId) -> Result<(), RuntimeError> {
-        let Some(mut record) = self
-            .storage
-            .load_local_batch_record(batch_id)
-            .map_err(|err| RuntimeError::WriteError(format!("load local batch record: {err}")))?
-        else {
-            return Err(RuntimeError::WriteError(format!(
-                "missing local batch record for {batch_id:?}"
-            )));
+        let mut record = if let Some(record) = self.local_batch_record_cache.remove(&batch_id) {
+            record
+        } else {
+            let Some(record) = self
+                .storage
+                .load_local_batch_record(batch_id)
+                .map_err(|err| {
+                    RuntimeError::WriteError(format!("load local batch record: {err}"))
+                })?
+            else {
+                return Err(RuntimeError::WriteError(format!(
+                    "missing local batch record for {batch_id:?}"
+                )));
+            };
+            record
         };
 
         if record.sealed {
+            self.local_batch_record_cache.insert(batch_id, record);
             return Ok(());
         }
 
@@ -744,6 +783,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             .map_err(|err| {
                 RuntimeError::WriteError(format!("persist local batch record: {err}"))
             })?;
+        self.local_batch_record_cache.insert(batch_id, record);
         self.schema_manager
             .query_manager_mut()
             .sync_manager_mut()

--- a/packages/jazz-tools/src/runtime/db.transaction.test.ts
+++ b/packages/jazz-tools/src/runtime/db.transaction.test.ts
@@ -170,6 +170,59 @@ describe("Db transactions", () => {
     expect(tx.acknowledgeRejectedBatch()).toBe(false);
   });
 
+  it("uses declared schemas for transaction writes without fetching runtime schema", () => {
+    const table = todoTable();
+    const runtimeRow: Row = {
+      id: "todo-tx-fast-path",
+      values: [
+        { type: "Text", value: "Fast transaction" },
+        { type: "Boolean", value: false },
+      ],
+      batchId: "batch-tx-fast-path",
+    } as Row;
+    const runtimeTransaction = {
+      batchId: vi.fn(() => "batch-tx-fast-path"),
+      create: vi.fn(() => runtimeRow),
+      update: vi.fn(() => undefined),
+      upsert: vi.fn(() => undefined),
+      delete: vi.fn(() => undefined),
+      commit: vi.fn(() => makeWriteHandle("batch-tx-fast-path").handle),
+      localBatchRecord: vi.fn((batchId = "batch-tx-fast-path") => makeLocalBatchRecord(batchId)),
+      localBatchRecords: vi.fn(() => [makeLocalBatchRecord("batch-tx-fast-path")]),
+      acknowledgeRejectedBatch: vi.fn(() => false),
+    };
+    const getSchema = vi.fn(() => new Map(Object.entries(todoSchema())));
+    const getSchemaHash = vi.fn(() => "schema-hash");
+    const client = {
+      getSchema,
+      getSchemaHash,
+      beginTransactionInternal: vi.fn(() => runtimeTransaction),
+      localBatchRecord: vi.fn((batchId: string) => makeLocalBatchRecord(batchId)),
+      acknowledgeRejectedBatch: vi.fn(() => false),
+    } as unknown as JazzClient;
+    const db = new TestDb(client);
+    const tx = db.beginTransaction();
+
+    tx.insert(table, { title: "Fast transaction", done: false });
+    tx.upsert(table, { title: "Fast transaction upsert" }, { id: "todo-tx-fast-path" });
+    tx.update(table, "todo-tx-fast-path", { done: true });
+
+    expect(getSchema).not.toHaveBeenCalled();
+    expect(getSchemaHash).not.toHaveBeenCalled();
+    expect(runtimeTransaction.create).toHaveBeenCalledWith("todos", {
+      title: { type: "Text", value: "Fast transaction" },
+      done: { type: "Boolean", value: false },
+    });
+    expect(runtimeTransaction.upsert).toHaveBeenCalledWith(
+      "todos",
+      { title: { type: "Text", value: "Fast transaction upsert" } },
+      { id: "todo-tx-fast-path" },
+    );
+    expect(runtimeTransaction.update).toHaveBeenCalledWith("todo-tx-fast-path", {
+      done: { type: "Boolean", value: true },
+    });
+  });
+
   it("threads session-backed db transactions through beginTransactionInternal", async () => {
     const table = todoTable();
     const session: Session = {
@@ -644,6 +697,61 @@ describe("Db transactions", () => {
     });
     expect(batch.localBatchRecords()).toEqual([makeLocalBatchRecord("batch-direct", "direct")]);
     expect(batch.acknowledgeRejectedBatch()).toBe(false);
+  });
+
+  it("uses declared schemas for direct batch writes without fetching runtime schema", () => {
+    const table = todoTable();
+    const runtimeRow: Row = {
+      id: "todo-batch-fast-path",
+      values: [
+        { type: "Text", value: "Fast batch" },
+        { type: "Boolean", value: false },
+      ],
+      batchId: "batch-direct-fast-path",
+    } as Row;
+    const runtimeBatch = {
+      batchId: vi.fn(() => "batch-direct-fast-path"),
+      create: vi.fn(() => runtimeRow),
+      update: vi.fn(() => undefined),
+      upsert: vi.fn(() => undefined),
+      delete: vi.fn(() => undefined),
+      commit: vi.fn(() => makeWriteHandle("batch-direct-fast-path", "direct").handle),
+      localBatchRecord: vi.fn((batchId = "batch-direct-fast-path") =>
+        makeLocalBatchRecord(batchId, "direct"),
+      ),
+      localBatchRecords: vi.fn(() => [makeLocalBatchRecord("batch-direct-fast-path", "direct")]),
+      acknowledgeRejectedBatch: vi.fn(() => false),
+    };
+    const getSchema = vi.fn(() => new Map(Object.entries(todoSchema())));
+    const getSchemaHash = vi.fn(() => "schema-hash");
+    const client = {
+      getSchema,
+      getSchemaHash,
+      beginBatchInternal: vi.fn(() => runtimeBatch),
+      localBatchRecord: vi.fn((batchId: string) => makeLocalBatchRecord(batchId, "direct")),
+      acknowledgeRejectedBatch: vi.fn(() => false),
+    } as unknown as JazzClient;
+    const db = new TestDb(client);
+    const batch = db.beginBatch();
+
+    batch.insert(table, { title: "Fast batch", done: false });
+    batch.upsert(table, { title: "Fast batch upsert" }, { id: "todo-batch-fast-path" });
+    batch.update(table, "todo-batch-fast-path", { done: true });
+
+    expect(getSchema).not.toHaveBeenCalled();
+    expect(getSchemaHash).not.toHaveBeenCalled();
+    expect(runtimeBatch.create).toHaveBeenCalledWith("todos", {
+      title: { type: "Text", value: "Fast batch" },
+      done: { type: "Boolean", value: false },
+    });
+    expect(runtimeBatch.upsert).toHaveBeenCalledWith(
+      "todos",
+      { title: { type: "Text", value: "Fast batch upsert" } },
+      { id: "todo-batch-fast-path" },
+    );
+    expect(runtimeBatch.update).toHaveBeenCalledWith("todo-batch-fast-path", {
+      done: { type: "Boolean", value: true },
+    });
   });
 
   it("commits a callback batch and returns the callback result handle", async () => {

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -554,15 +554,6 @@ export class DbTransaction {
     }
   }
 
-  private resolveInputSchema<T, Init>(table: TableProxy<T, Init>): WasmSchema {
-    const { client } = this.bindTable(table, "DbTransaction");
-    return resolveSchemaWithTable(
-      table._schema,
-      normalizeRuntimeSchema(client.getSchema()),
-      table._table,
-    );
-  }
-
   private bindTable<T, Init>(table: TableProxy<T, Init>, operation: string): DbTransactionBinding {
     const existingBinding = dbTransactionBindings.get(this);
     if (existingBinding) {
@@ -606,8 +597,9 @@ export class DbTransaction {
    */
   insert<T, Init>(table: TableProxy<T, Init>, data: Init, options?: CreateOptions): T {
     this.ensureActive();
+    this.bindTable(table, "DbTransaction");
     const transformedData = transformInsertInput(table, data);
-    const values = toInsertRecord(transformedData, this.resolveInputSchema(table), table._table);
+    const values = toInsertRecord(transformedData, table._schema, table._table);
     const runtimeTransaction = this.requireRuntimeTransaction("insert");
     const row = options
       ? runtimeTransaction.create(table._table, values, options)
@@ -623,8 +615,9 @@ export class DbTransaction {
    */
   upsert<T, Init>(table: TableProxy<T, Init>, data: Partial<Init>, options: UpsertOptions): void {
     this.ensureActive();
+    this.bindTable(table, "DbTransaction");
     const transformedData = transformUpdateInput(table, data);
-    const values = toUpdateRecord(transformedData, this.resolveInputSchema(table), table._table);
+    const values = toUpdateRecord(transformedData, table._schema, table._table);
     this.requireRuntimeTransaction("upsert").upsert(table._table, values, options);
   }
 
@@ -636,8 +629,9 @@ export class DbTransaction {
    */
   update<T, Init>(table: TableProxy<T, Init>, id: string, data: Partial<Init>): void {
     this.ensureActive();
+    this.bindTable(table, "DbTransaction");
     const transformedData = transformUpdateInput(table, data);
-    const updates = toUpdateRecord(transformedData, this.resolveInputSchema(table), table._table);
+    const updates = toUpdateRecord(transformedData, table._schema, table._table);
     this.requireRuntimeTransaction("update").update(id, updates);
   }
 
@@ -728,15 +722,6 @@ export class DbDirectBatch {
     private readonly beginRuntimeBatch: (client: JazzClient) => RuntimeDirectBatch,
   ) {}
 
-  private resolveInputSchema<T, Init>(table: TableProxy<T, Init>): WasmSchema {
-    const { client } = this.bindTable(table, "DbDirectBatch");
-    return resolveSchemaWithTable(
-      table._schema,
-      normalizeRuntimeSchema(client.getSchema()),
-      table._table,
-    );
-  }
-
   private bindTable<T, Init>(table: TableProxy<T, Init>, operation: string): DbDirectBatchBinding {
     const existingBinding = dbDirectBatchBindings.get(this);
     if (existingBinding) {
@@ -781,8 +766,9 @@ export class DbDirectBatch {
 
   insert<T, Init>(table: TableProxy<T, Init>, data: Init, options?: CreateOptions): T {
     this.ensureActive();
+    this.bindTable(table, "DbDirectBatch");
     const transformedData = transformInsertInput(table, data);
-    const values = toInsertRecord(transformedData, this.resolveInputSchema(table), table._table);
+    const values = toInsertRecord(transformedData, table._schema, table._table);
     const runtimeBatch = this.requireRuntimeBatch("insert");
     const row = options
       ? runtimeBatch.create(table._table, values, options)
@@ -792,15 +778,17 @@ export class DbDirectBatch {
 
   upsert<T, Init>(table: TableProxy<T, Init>, data: Partial<Init>, options: UpsertOptions): void {
     this.ensureActive();
+    this.bindTable(table, "DbDirectBatch");
     const transformedData = transformUpdateInput(table, data);
-    const values = toUpdateRecord(transformedData, this.resolveInputSchema(table), table._table);
+    const values = toUpdateRecord(transformedData, table._schema, table._table);
     this.requireRuntimeBatch("upsert").upsert(table._table, values, options);
   }
 
   update<T, Init>(table: TableProxy<T, Init>, id: string, data: Partial<Init>): void {
     this.ensureActive();
+    this.bindTable(table, "DbDirectBatch");
     const transformedData = transformUpdateInput(table, data);
-    const updates = toUpdateRecord(transformedData, this.resolveInputSchema(table), table._table);
+    const updates = toUpdateRecord(transformedData, table._schema, table._table);
     this.requireRuntimeBatch("update").update(id, updates);
   }
 
@@ -2933,12 +2921,8 @@ class ClientBackedDb extends Db {
     data: Init,
     options?: CreateOptions,
   ): WriteResult<T> {
-    const runtimeSchema = createRuntimeSchemaResolver(() =>
-      normalizeRuntimeSchema(this.runtimeClient.getSchema()),
-    );
-    const inputSchema = resolveSchemaWithTable(table._schema, runtimeSchema.get, table._table);
     const transformedData = transformInsertInput(table, data);
-    const values = toInsertRecord(transformedData, inputSchema, table._table);
+    const values = toInsertRecord(transformedData, table._schema, table._table);
     return this.runtimeClient
       .createHandleInternal(table._table, values, this.session, this.attribution, options)
       .mapValue((row) => transformOutputRow(table, transformRow(row, table._schema, table._table)));
@@ -2949,12 +2933,8 @@ class ClientBackedDb extends Db {
     data: Partial<Init>,
     options: UpsertOptions,
   ): WriteHandle {
-    const runtimeSchema = createRuntimeSchemaResolver(() =>
-      normalizeRuntimeSchema(this.runtimeClient.getSchema()),
-    );
-    const inputSchema = resolveSchemaWithTable(table._schema, runtimeSchema.get, table._table);
     const transformedData = transformUpdateInput(table, data);
-    const values = toUpdateRecord(transformedData, inputSchema, table._table);
+    const values = toUpdateRecord(transformedData, table._schema, table._table);
     return this.runtimeClient.upsertHandleInternal(
       table._table,
       values,
@@ -2971,12 +2951,8 @@ class ClientBackedDb extends Db {
     data: Partial<Init>,
     options?: UpdateOptions,
   ): WriteHandle {
-    const runtimeSchema = createRuntimeSchemaResolver(() =>
-      normalizeRuntimeSchema(this.runtimeClient.getSchema()),
-    );
-    const inputSchema = resolveSchemaWithTable(table._schema, runtimeSchema.get, table._table);
     const transformedData = transformUpdateInput(table, data);
-    const updates = toUpdateRecord(transformedData, inputSchema, table._table);
+    const updates = toUpdateRecord(transformedData, table._schema, table._table);
     return this.runtimeClient.updateHandleInternal(
       id,
       updates,


### PR DESCRIPTION
## Summary

This branch frames the remaining write-path performance work as a batch semantics change:

- explicit direct and transactional batches now become local/remote durability units at `seal_batch`, rather than rewriting the persisted local batch record on every member write
- open batches still apply writes to the local visible state immediately, but batch records/submissions are persisted only when sealed
- standalone persisted direct writes auto-seal so normal one-off write durability behavior is preserved
- TS transaction, direct batch, and client-backed write paths now use declared table schema context directly instead of resolving runtime schema for each write

This follows the latest BoreDM profile: the old decode path is gone, and the next ceiling was per-insert local batch record encode/upsert plus remaining schema hashing.

## Tests

- `pnpm lint` (passes; oxlint reports existing warnings, clippy clean with `-D warnings`)
- `cargo test -p jazz-tools runtime_core::tests::write_batch -- --nocapture`
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/runtime/db.transaction.test.ts src/runtime/db.schema-order.test.ts`
- `pnpm --filter jazz-tools build:test`