### PR TITLE
Avoid schema resolution in prepared write paths

### DIFF
--- a/.changeset/prepared-write-context-perf.md
+++ b/.changeset/prepared-write-context-perf.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Improve local insert performance by reusing prepared write context through row-history application and caching catalogue row descriptors for repeated same-schema writes.

--- a/crates/jazz-tools/src/query_manager/manager_tests.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests.rs
@@ -129,6 +129,7 @@ fn get_branch(qm: &QueryManager) -> String {
 struct CountingCatalogueUpsertsStorage {
     inner: MemoryStorage,
     catalogue_upserts: Cell<usize>,
+    catalogue_loads: Cell<usize>,
     visible_query_loads: Cell<usize>,
 }
 
@@ -141,12 +142,21 @@ impl CountingCatalogueUpsertsStorage {
         Self {
             inner,
             catalogue_upserts: Cell::new(0),
+            catalogue_loads: Cell::new(0),
             visible_query_loads: Cell::new(0),
         }
     }
 
     fn catalogue_upserts(&self) -> usize {
         self.catalogue_upserts.get()
+    }
+
+    fn catalogue_loads(&self) -> usize {
+        self.catalogue_loads.get()
+    }
+
+    fn reset_catalogue_loads(&self) {
+        self.catalogue_loads.set(0);
     }
 
     fn visible_query_loads(&self) -> usize {
@@ -253,6 +263,7 @@ impl Storage for CountingCatalogueUpsertsStorage {
         &self,
         object_id: crate::object::ObjectId,
     ) -> Result<Option<crate::catalogue::CatalogueEntry>, StorageError> {
+        self.catalogue_loads.set(self.catalogue_loads.get() + 1);
         self.inner.load_catalogue_entry(object_id)
     }
 

--- a/crates/jazz-tools/src/query_manager/manager_tests/bootstrap.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests/bootstrap.rs
@@ -84,3 +84,26 @@ fn direct_query_manager_catalogues_known_schemas_only_once_per_storage() {
         "ordinary writes should not recatalogue unchanged schemas on the same storage",
     );
 }
+
+#[test]
+fn direct_query_manager_insert_uses_prepared_write_context_without_catalogue_loads() {
+    let mut qm = QueryManager::new(SyncManager::new());
+    qm.set_current_schema(test_schema(), "dev", "main");
+    let mut storage = CountingCatalogueUpsertsStorage::new();
+    qm.ensure_known_schemas_catalogued(&mut storage)
+        .expect("schema bootstrap should succeed");
+    storage.reset_catalogue_loads();
+
+    qm.insert(
+        &mut storage,
+        "users",
+        &[Value::Text("Alice".into()), Value::Integer(1)],
+    )
+    .expect("insert should succeed");
+
+    assert_eq!(
+        storage.catalogue_loads(),
+        0,
+        "prepared local inserts already have the table descriptor and should not reload catalogue descriptors during history apply",
+    );
+}

--- a/crates/jazz-tools/src/query_manager/writes.rs
+++ b/crates/jazz-tools/src/query_manager/writes.rs
@@ -5,11 +5,14 @@ use crate::batch_fate::BatchMode;
 use crate::metadata::{DeleteKind, RowProvenance, SYSTEM_PRINCIPAL_ID, row_provenance_metadata};
 use crate::object::{BranchName, ObjectId};
 use crate::row_histories::{
-    BatchId, QueryRowBatch, RowHistoryError, RowState, RowVisibilityChange, StoredRowBatch,
-    apply_row_batch,
+    ApplyRowBatchWithContext, BatchId, QueryRowBatch, RowHistoryError, RowState,
+    RowVisibilityChange, StoredRowBatch, apply_row_batch, apply_row_batch_with_context,
 };
 use crate::schema_manager::{SchemaContext, resolve_current_table_name};
-use crate::storage::{RowLocator, Storage, metadata_from_row_locator};
+use crate::storage::{
+    RowLocator, Storage, metadata_from_row_locator,
+    prepared_row_write_context_for_known_exact_locator,
+};
 use crate::sync_manager::RowBatchKey;
 
 use super::encoding::{decode_column, decode_row, encode_row};
@@ -50,6 +53,16 @@ struct RowBatchAuthoring<'a> {
     delete_kind: Option<DeleteKind>,
     row_state: RowState,
     batch_id: Option<BatchId>,
+}
+
+struct PreparedLocalRowHistoryWrite<'a> {
+    table: &'a str,
+    branch_name: &'a BranchName,
+    row_id: ObjectId,
+    row: StoredRowBatch,
+    index_mutations: &'a [crate::storage::IndexMutation<'a>],
+    row_locator: &'a RowLocator,
+    descriptor: Arc<RowDescriptor>,
 }
 
 pub struct RowBranchDelete<'a> {
@@ -372,6 +385,70 @@ impl QueryManager {
                     QueryError::EncodingError(format!("apply row batch: {error}"))
                 }
             })?;
+
+        self.sync_manager.forward_row_batch_to_servers_with_storage(
+            storage,
+            table,
+            row_id,
+            metadata_from_row_locator(&applied.row_locator),
+            forwarded_row,
+        );
+
+        let batch_id = applied.batch_id;
+        Ok((batch_id, applied.visibility_change))
+    }
+
+    fn apply_local_row_history_write_with_prepared_context<H: Storage>(
+        &mut self,
+        storage: &mut H,
+        write: PreparedLocalRowHistoryWrite<'_>,
+    ) -> Result<(BatchId, Option<RowVisibilityChange>), QueryError> {
+        let PreparedLocalRowHistoryWrite {
+            table,
+            branch_name,
+            row_id,
+            row,
+            index_mutations,
+            row_locator,
+            descriptor,
+        } = write;
+        self.ensure_known_schemas_catalogued(storage)
+            .map_err(|err| QueryError::EncodingError(format!("persist known schemas: {err}")))?;
+
+        let schema_hash = row_locator.origin_schema_hash.ok_or_else(|| {
+            QueryError::EncodingError(format!(
+                "missing origin schema hash for prepared local write to {table}"
+            ))
+        })?;
+        let context =
+            prepared_row_write_context_for_known_exact_locator(table, schema_hash, descriptor)
+                .map_err(|err| {
+                    QueryError::EncodingError(format!("prepare row write context: {err}"))
+                })?;
+        let forwarded_row = row.clone();
+        let applied = apply_row_batch_with_context(
+            storage,
+            ApplyRowBatchWithContext {
+                object_id: row_id,
+                branch_name,
+                row,
+                index_mutations,
+                row_locator: row_locator.clone(),
+                table: table.to_string(),
+                branch: branch_name.as_str().to_string().into(),
+                context,
+                is_known_new_object: true,
+            },
+        )
+        .map_err(|error| match error {
+            RowHistoryError::ObjectNotFound(id) => QueryError::ObjectNotFound(id),
+            RowHistoryError::ParentNotFound(parent) => QueryError::EncodingError(format!(
+                "missing row-history parent {parent:?} while applying local write for {row_id:?}"
+            )),
+            RowHistoryError::StorageError(error) => {
+                QueryError::EncodingError(format!("apply row batch: {error}"))
+            }
+        })?;
 
         self.sync_manager.forward_row_batch_to_servers_with_storage(
             storage,
@@ -996,14 +1073,19 @@ impl QueryManager {
             self.row_batch_authoring(&provenance, None, write_context),
         );
         let branch_name = BranchName::new(&current_branch);
-        let (row_batch_id, visibility_change) = self.apply_local_row_history_write(
-            storage,
-            table,
-            &branch_name,
-            object_id,
-            row,
-            &index_mutations,
-        )?;
+        let (row_batch_id, visibility_change) = self
+            .apply_local_row_history_write_with_prepared_context(
+                storage,
+                PreparedLocalRowHistoryWrite {
+                    table,
+                    branch_name: &branch_name,
+                    row_id: object_id,
+                    row,
+                    index_mutations: &index_mutations,
+                    row_locator: &table_write.row_locator,
+                    descriptor: table_write.descriptor.clone(),
+                },
+            )?;
         self.maybe_track_local_pending_transaction_overlay(
             table,
             RowBatchKey::new(object_id, branch_name, row_batch_id),

--- a/crates/jazz-tools/src/row_histories/mod.rs
+++ b/crates/jazz-tools/src/row_histories/mod.rs
@@ -28,6 +28,7 @@ pub use codecs::{
     encode_flat_history_row, encode_flat_visible_row_entry, history_row_physical_descriptor,
     visible_row_physical_descriptor,
 };
+pub(crate) use mutations::{ApplyRowBatchWithContext, apply_row_batch_with_context};
 pub use mutations::{apply_row_batch, patch_row_batch_state};
 pub(crate) use resolution::visible_row_preview_from_history_rows;
 pub use types::{

--- a/crates/jazz-tools/src/row_histories/mutations.rs
+++ b/crates/jazz-tools/src/row_histories/mutations.rs
@@ -16,7 +16,7 @@
 
 use crate::object::{BranchName, ObjectId};
 use crate::query_manager::types::{RowDescriptor, SharedString};
-use crate::storage::{IndexMutation, RowLocator, Storage, StorageError};
+use crate::storage::{IndexMutation, PreparedRowWriteContext, RowLocator, Storage, StorageError};
 use crate::sync_manager::DurabilityTier;
 
 use super::resolution::visible_entry_from_history_rows;
@@ -32,6 +32,18 @@ pub(super) struct AppliedRowBatch {
     current_visible: Option<StoredRowBatch>,
     is_new_object: bool,
     visible_changed: bool,
+}
+
+pub(crate) struct ApplyRowBatchWithContext<'a> {
+    pub(crate) object_id: ObjectId,
+    pub(crate) branch_name: &'a BranchName,
+    pub(crate) row: StoredRowBatch,
+    pub(crate) index_mutations: &'a [IndexMutation<'a>],
+    pub(crate) row_locator: RowLocator,
+    pub(crate) table: String,
+    pub(crate) branch: SharedString,
+    pub(crate) context: PreparedRowWriteContext,
+    pub(crate) is_known_new_object: bool,
 }
 
 pub(super) fn row_locator_from_storage<H: Storage>(
@@ -152,36 +164,82 @@ pub fn apply_row_batch<H: Storage>(
 ) -> Result<ApplyRowBatchResult, RowHistoryError> {
     let row_locator = row_locator_from_storage(io, object_id)?;
     let table = row_locator.table.to_string();
-    let batch_id = row.batch_id();
     let branch = SharedString::from(branch_name.as_str().to_string());
     let context = crate::storage::resolve_history_row_write_context(io, &table, &row)
         .map_err(RowHistoryError::StorageError)?;
-    let previous_entry = load_previous_visible_entry(
+    apply_row_batch_with_context(
         io,
-        &table,
+        ApplyRowBatchWithContext {
+            object_id,
+            branch_name,
+            row,
+            index_mutations,
+            row_locator,
+            table,
+            branch,
+            context,
+            is_known_new_object: false,
+        },
+    )
+}
+
+pub(crate) fn apply_row_batch_with_context<H: Storage>(
+    io: &mut H,
+    request: ApplyRowBatchWithContext<'_>,
+) -> Result<ApplyRowBatchResult, RowHistoryError> {
+    let ApplyRowBatchWithContext {
         object_id,
-        &branch,
-        context.user_descriptor.as_ref(),
-    )?;
+        branch_name,
+        row,
+        index_mutations,
+        row_locator,
+        table,
+        branch,
+        context,
+        is_known_new_object,
+    } = request;
+    let batch_id = row.batch_id();
+    debug_assert!(
+        !is_known_new_object || row.parents.is_empty(),
+        "known-new row apply skips parent lookups"
+    );
+    let previous_entry = if is_known_new_object {
+        None
+    } else {
+        load_previous_visible_entry(
+            io,
+            &table,
+            object_id,
+            &branch,
+            context.user_descriptor.as_ref(),
+        )?
+    };
     let previous_visible = previous_entry
         .as_ref()
         .map(|entry| entry.current_row.clone());
 
-    for parent in &row.parents {
-        if io
-            .load_history_row_batch(&table, branch_name.as_str(), object_id, *parent)
-            .map_err(RowHistoryError::StorageError)?
-            .is_none()
-        {
-            return Err(RowHistoryError::ParentNotFound(*parent));
+    if !is_known_new_object {
+        for parent in &row.parents {
+            if io
+                .load_history_row_batch(&table, branch_name.as_str(), object_id, *parent)
+                .map_err(RowHistoryError::StorageError)?
+                .is_none()
+            {
+                return Err(RowHistoryError::ParentNotFound(*parent));
+            }
         }
     }
 
-    let mut patched_history = load_branch_history(io, &table, object_id, &branch)?;
+    let mut patched_history = if is_known_new_object {
+        Vec::new()
+    } else {
+        load_branch_history(io, &table, object_id, &branch)?
+    };
 
-    if let Some(existing_row) = io
-        .load_history_row_batch(&table, branch_name.as_str(), object_id, batch_id)
-        .map_err(RowHistoryError::StorageError)?
+    if !is_known_new_object
+        && let Some(existing_row) = io
+            .load_history_row_batch(&table, branch_name.as_str(), object_id, batch_id)
+            .map_err(RowHistoryError::StorageError)?
         && existing_row == row
     {
         return Ok(ApplyRowBatchResult {

--- a/crates/jazz-tools/src/storage/memory.rs
+++ b/crates/jazz-tools/src/storage/memory.rs
@@ -2366,6 +2366,90 @@ mod tests {
     }
 
     #[test]
+    fn typed_history_appends_reuse_catalogue_descriptor_for_same_schema() {
+        use crate::catalogue::CatalogueEntry;
+        use crate::metadata::{MetadataKey, ObjectType};
+        use crate::query_manager::types::{SchemaBuilder, SchemaHash, TableSchema, Value};
+        use crate::schema_manager::encoding::encode_schema;
+
+        let mut storage = CountingCatalogueLoadsStorage::new();
+        let schema = SchemaBuilder::new()
+            .table(
+                TableSchema::builder("tasks")
+                    .column("title", ColumnType::Text)
+                    .nullable_column("done", ColumnType::Boolean),
+            )
+            .build();
+        let schema_hash = SchemaHash::compute(&schema);
+        let user_descriptor = schema[&"tasks".into()].columns.clone();
+
+        storage
+            .upsert_catalogue_entry(&CatalogueEntry {
+                object_id: schema_hash.to_object_id(),
+                metadata: HashMap::from([(
+                    MetadataKey::Type.to_string(),
+                    ObjectType::CatalogueSchema.to_string(),
+                )]),
+                content: encode_schema(&schema),
+            })
+            .unwrap();
+
+        let alice_task_id = ObjectId::new();
+        let bob_task_id = ObjectId::new();
+        let row_locator = RowLocator {
+            table: "tasks".into(),
+            origin_schema_hash: Some(schema_hash),
+        };
+        storage
+            .put_row_locator(alice_task_id, Some(&row_locator))
+            .unwrap();
+        storage
+            .put_row_locator(bob_task_id, Some(&row_locator))
+            .unwrap();
+
+        let alice_task = crate::row_histories::StoredRowBatch::new(
+            alice_task_id,
+            "main",
+            Vec::new(),
+            encode_row(
+                &user_descriptor,
+                &[
+                    Value::Text("Prepare dropdown seeds".into()),
+                    Value::Boolean(false),
+                ],
+            )
+            .unwrap(),
+            RowProvenance::for_insert("alice".to_string(), 100),
+            HashMap::new(),
+            crate::row_histories::RowState::VisibleDirect,
+            None,
+        );
+        let bob_task = crate::row_histories::StoredRowBatch::new(
+            bob_task_id,
+            "main",
+            Vec::new(),
+            encode_row(
+                &user_descriptor,
+                &[
+                    Value::Text("Verify seeded rows".into()),
+                    Value::Boolean(true),
+                ],
+            )
+            .unwrap(),
+            RowProvenance::for_insert("bob".to_string(), 101),
+            HashMap::new(),
+            crate::row_histories::RowState::VisibleDirect,
+            None,
+        );
+
+        storage
+            .append_history_region_rows("tasks", &[alice_task, bob_task])
+            .unwrap();
+
+        assert_eq!(storage.catalogue_loads(), 1);
+    }
+
+    #[test]
     fn typed_history_appends_use_row_locator_schema_before_catalogue_scans() {
         use crate::catalogue::CatalogueEntry;
         use crate::metadata::{MetadataKey, ObjectType};

--- a/crates/jazz-tools/src/storage/mod.rs
+++ b/crates/jazz-tools/src/storage/mod.rs
@@ -463,6 +463,7 @@ pub(crate) struct PreparedRowWriteContext {
 }
 
 type RowRawTableIdCache = HashMap<(RowRawTableKind, String, SchemaHash), RowRawTableId>;
+type CatalogueUserDescriptorCache = HashMap<(usize, String, SchemaHash), Arc<RowDescriptor>>;
 
 fn row_raw_table_id_cache() -> &'static Mutex<RowRawTableIdCache> {
     static CACHE: OnceLock<Mutex<RowRawTableIdCache>> = OnceLock::new();
@@ -571,6 +572,46 @@ fn cache_row_descriptor(raw_table: &str, descriptor: Arc<RowDescriptor>) {
         .lock()
         .expect("row raw table descriptor cache poisoned")
         .insert(raw_table.to_string(), descriptor);
+}
+
+fn catalogue_user_descriptor_cache() -> &'static Mutex<CatalogueUserDescriptorCache> {
+    static CACHE: OnceLock<Mutex<CatalogueUserDescriptorCache>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn cached_catalogue_user_descriptor_with_storage<H: Storage + ?Sized>(
+    storage: &H,
+    table_name: &str,
+    schema_hash: SchemaHash,
+) -> Option<Arc<RowDescriptor>> {
+    catalogue_user_descriptor_cache()
+        .lock()
+        .expect("catalogue user descriptor cache poisoned")
+        .get(&(
+            storage.storage_cache_namespace(),
+            table_name.to_string(),
+            schema_hash,
+        ))
+        .cloned()
+}
+
+fn cache_catalogue_user_descriptor_with_storage<H: Storage + ?Sized>(
+    storage: &H,
+    table_name: &str,
+    schema_hash: SchemaHash,
+    descriptor: Arc<RowDescriptor>,
+) {
+    catalogue_user_descriptor_cache()
+        .lock()
+        .expect("catalogue user descriptor cache poisoned")
+        .insert(
+            (
+                storage.storage_cache_namespace(),
+                table_name.to_string(),
+                schema_hash,
+            ),
+            descriptor,
+        );
 }
 
 fn metadata_raw_key(id: ObjectId) -> String {
@@ -1075,7 +1116,7 @@ fn load_user_descriptor_for_schema_hash<H: Storage + ?Sized>(
     storage: &H,
     table_name: &str,
     schema_hash: SchemaHash,
-) -> Result<RowDescriptor, StorageError> {
+) -> Result<Arc<RowDescriptor>, StorageError> {
     load_history_user_descriptor_for_schema_hash(storage, table_name, schema_hash)?.ok_or_else(
         || {
             StorageError::IoError(format!(
@@ -1085,26 +1126,61 @@ fn load_user_descriptor_for_schema_hash<H: Storage + ?Sized>(
     )
 }
 
+fn prepared_row_write_context_for_descriptor(
+    table_name: &str,
+    schema_hash: SchemaHash,
+    user_descriptor: Arc<RowDescriptor>,
+    needs_exact_locator: bool,
+) -> Result<PreparedRowWriteContext, StorageError> {
+    Ok(PreparedRowWriteContext {
+        history_row_raw_table_id: history_row_raw_table_id(table_name, schema_hash),
+        visible_row_raw_table_id: visible_row_raw_table_id(table_name, schema_hash),
+        user_descriptor,
+        needs_exact_locator,
+    })
+}
+
+pub(crate) fn prepared_row_write_context_for_known_exact_locator(
+    table_name: &str,
+    schema_hash: SchemaHash,
+    user_descriptor: Arc<RowDescriptor>,
+) -> Result<PreparedRowWriteContext, StorageError> {
+    prepared_row_write_context_for_descriptor(table_name, schema_hash, user_descriptor, false)
+}
+
+pub(crate) fn prepared_row_write_context_for_schema_hash_and_descriptor<H: Storage + ?Sized>(
+    storage: &H,
+    table_name: &str,
+    schema_hash: SchemaHash,
+    row_id: ObjectId,
+    user_descriptor: Arc<RowDescriptor>,
+) -> Result<PreparedRowWriteContext, StorageError> {
+    let needs_exact_locator = storage
+        .load_row_locator(row_id)?
+        .and_then(|locator| locator.origin_schema_hash)
+        != Some(schema_hash);
+    prepared_row_write_context_for_descriptor(
+        table_name,
+        schema_hash,
+        user_descriptor,
+        needs_exact_locator,
+    )
+}
+
 fn prepared_row_write_context_for_schema_hash<H: Storage + ?Sized>(
     storage: &H,
     table_name: &str,
     schema_hash: SchemaHash,
     row_id: ObjectId,
 ) -> Result<PreparedRowWriteContext, StorageError> {
-    let needs_exact_locator = storage
-        .load_row_locator(row_id)?
-        .and_then(|locator| locator.origin_schema_hash)
-        != Some(schema_hash);
-    Ok(PreparedRowWriteContext {
-        history_row_raw_table_id: history_row_raw_table_id(table_name, schema_hash),
-        visible_row_raw_table_id: visible_row_raw_table_id(table_name, schema_hash),
-        user_descriptor: Arc::new(load_user_descriptor_for_schema_hash(
-            storage,
-            table_name,
-            schema_hash,
-        )?),
-        needs_exact_locator,
-    })
+    let user_descriptor = load_user_descriptor_for_schema_hash(storage, table_name, schema_hash)?;
+    prepared_row_write_context_for_schema_hash_and_descriptor(
+        storage,
+        table_name,
+        schema_hash,
+        row_id,
+        user_descriptor,
+    )
 }
 
 fn load_user_descriptor_from_raw_table_header(
@@ -1133,10 +1209,10 @@ fn resolved_user_descriptor_for_raw_table<H: Storage + ?Sized>(
         return Ok(descriptor);
     }
 
-    let descriptor = load_user_descriptor_from_raw_table_header(header)?.unwrap_or(
-        load_user_descriptor_for_schema_hash(storage, table_name, schema_hash)?,
-    );
-    let descriptor = Arc::new(descriptor);
+    let descriptor = match load_user_descriptor_from_raw_table_header(header)? {
+        Some(descriptor) => Arc::new(descriptor),
+        None => load_user_descriptor_for_schema_hash(storage, table_name, schema_hash)?,
+    };
     cache_row_descriptor(raw_table_name, descriptor.clone());
     Ok(descriptor)
 }
@@ -1322,11 +1398,11 @@ fn resolved_row_table_from_locator<H: Storage + ?Sized>(
         if let Some(descriptor) = cached_row_descriptor(locator.row_raw_table.as_str()) {
             descriptor
         } else {
-            let descriptor = Arc::new(load_user_descriptor_for_schema_hash(
+            let descriptor = load_user_descriptor_for_schema_hash(
                 storage,
                 locator.table_name.as_str(),
                 locator.schema_hash,
-            )?);
+            )?;
             cache_row_descriptor(locator.row_raw_table.as_str(), descriptor.clone());
             descriptor
         };
@@ -1517,7 +1593,13 @@ fn load_history_user_descriptor_for_schema_hash<H: Storage + ?Sized>(
     storage: &H,
     table_hint: &str,
     schema_hash: SchemaHash,
-) -> Result<Option<crate::query_manager::types::RowDescriptor>, StorageError> {
+) -> Result<Option<Arc<RowDescriptor>>, StorageError> {
+    if let Some(descriptor) =
+        cached_catalogue_user_descriptor_with_storage(storage, table_hint, schema_hash)
+    {
+        return Ok(Some(descriptor));
+    }
+
     let Some(entry) = storage.load_catalogue_entry(schema_hash.to_object_id())? else {
         return Ok(None);
     };
@@ -1525,9 +1607,17 @@ fn load_history_user_descriptor_for_schema_hash<H: Storage + ?Sized>(
         .map_err(|err| StorageError::IoError(format!("decode schema for row history: {err}")))?;
 
     let hinted_table_name = crate::query_manager::types::TableName::new(table_hint);
-    Ok(schema
-        .get(&hinted_table_name)
-        .map(|table_schema| table_schema.columns.clone()))
+    let Some(table_schema) = schema.get(&hinted_table_name) else {
+        return Ok(None);
+    };
+    let descriptor = Arc::new(table_schema.columns.clone());
+    cache_catalogue_user_descriptor_with_storage(
+        storage,
+        table_hint,
+        schema_hash,
+        descriptor.clone(),
+    );
+    Ok(Some(descriptor))
 }
 
 fn catalogue_schema_hash(entry: &CatalogueEntry) -> Result<SchemaHash, StorageError> {
@@ -1590,23 +1680,22 @@ fn required_history_user_descriptor_and_schema_hash_for_row<H: Storage + ?Sized>
     storage: &H,
     table_hint: &str,
     row: &StoredRowBatch,
-) -> Result<(SchemaHash, crate::query_manager::types::RowDescriptor), StorageError> {
+) -> Result<(SchemaHash, Arc<RowDescriptor>), StorageError> {
     let row_data_matches = |descriptor: &crate::query_manager::types::RowDescriptor| {
         row.data.is_empty() || crate::row_format::decode_row(descriptor, &row.data).is_ok()
     };
-    let try_schema_hash =
-        |candidates: &mut Vec<(SchemaHash, crate::query_manager::types::RowDescriptor)>,
-         table_name: &str,
-         schema_hash: SchemaHash|
-         -> Result<(), StorageError> {
-            if let Some(descriptor) =
-                load_history_user_descriptor_for_schema_hash(storage, table_name, schema_hash)?
-                && row_data_matches(&descriptor)
-            {
-                candidates.push((schema_hash, descriptor));
-            }
-            Ok(())
-        };
+    let try_schema_hash = |candidates: &mut Vec<(SchemaHash, Arc<RowDescriptor>)>,
+                           table_name: &str,
+                           schema_hash: SchemaHash|
+     -> Result<(), StorageError> {
+        if let Some(descriptor) =
+            load_history_user_descriptor_for_schema_hash(storage, table_name, schema_hash)?
+            && row_data_matches(descriptor.as_ref())
+        {
+            candidates.push((schema_hash, descriptor));
+        }
+        Ok(())
+    };
 
     let row_locator = storage.load_row_locator(row.row_id)?;
     let mut locator_candidates = Vec::new();
@@ -1641,6 +1730,7 @@ fn required_history_user_descriptor_and_schema_hash_for_row<H: Storage + ?Sized>
     let mut table_candidates = catalogue_row_descriptors_for_table(storage, table_hint)?
         .into_iter()
         .filter(|(_, descriptor)| row_data_matches(descriptor))
+        .map(|(schema_hash, descriptor)| (schema_hash, Arc::new(descriptor)))
         .collect::<Vec<_>>();
     table_candidates.sort_by_key(|(schema_hash, _)| schema_hash.to_string());
     table_candidates.dedup_by(|(left_hash, _), (right_hash, _)| left_hash == right_hash);
@@ -1676,10 +1766,13 @@ pub(crate) fn resolve_history_row_write_context<H: Storage + ?Sized>(
 ) -> Result<PreparedRowWriteContext, StorageError> {
     let (schema_hash, user_descriptor) =
         required_history_user_descriptor_and_schema_hash_for_row(storage, table, row)?;
-    let mut context =
-        prepared_row_write_context_for_schema_hash(storage, table, schema_hash, row.row_id)?;
-    context.user_descriptor = Arc::new(user_descriptor);
-    Ok(context)
+    prepared_row_write_context_for_schema_hash_and_descriptor(
+        storage,
+        table,
+        schema_hash,
+        row.row_id,
+        user_descriptor,
+    )
 }
 
 pub(crate) fn encode_history_row_bytes_with_context(

--- a/packages/jazz-tools/src/runtime/client-tests/schema-order.test.ts
+++ b/packages/jazz-tools/src/runtime/client-tests/schema-order.test.ts
@@ -82,6 +82,76 @@ describe("JazzClient schema order", () => {
     });
   });
 
+  it("aligns create result rows from declared schema context without runtime schema hashing", async () => {
+    const getSchema = vi.fn(() => {
+      throw new Error("create result alignment should not fetch runtime schema");
+    });
+    const getSchemaHash = vi.fn(() => {
+      throw new Error("create result alignment should not hash runtime schema");
+    });
+    const runtime: Runtime = {
+      ...runtimeBatchRecordStubs,
+      insert: () => ({
+        id: "todo-1",
+        values: [
+          { type: "Text", value: "Buy milk" },
+          { type: "Boolean", value: false },
+        ],
+        batchId: "batch-id",
+      }),
+      update: () => ({
+        batchId: "batch-id",
+      }),
+      delete: () => ({
+        batchId: "batch-id",
+      }),
+      query: async () => [],
+      subscribe: () => 0,
+      createSubscription: () => 0,
+      executeSubscription: () => {},
+      unsubscribe: () => {},
+      onSyncMessageReceived: () => {},
+      onSyncMessageToSend: () => {},
+      addServer: () => {},
+      removeServer: () => {},
+      addClient: () => "client-1",
+      getSchema,
+      getSchemaHash,
+    };
+    const schema = {
+      todos: {
+        columns: [
+          {
+            name: "title",
+            column_type: { type: "Text" as const },
+            nullable: false,
+          },
+          {
+            name: "done",
+            column_type: { type: "Boolean" as const },
+            nullable: false,
+          },
+        ],
+      },
+    };
+    const client = JazzClient.connectWithRuntime(runtime, {
+      appId: "test-app",
+      schema,
+    });
+
+    const result = client.create("todos", {
+      title: { type: "Text", value: "Buy milk" },
+      done: { type: "Boolean", value: false },
+    });
+
+    expect(result.value.values).toEqual([
+      { type: "Text", value: "Buy milk" },
+      { type: "Boolean", value: false },
+    ]);
+    expect(getSchema).not.toHaveBeenCalled();
+    expect(getSchemaHash).not.toHaveBeenCalled();
+  });
+
   it("reorders query rows back to the declared schema order", async () => {
     const runtime: Runtime = {
       ...runtimeBatchRecordStubs,

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -1972,7 +1972,11 @@ export class JazzClient {
           : this.runtime.insert(table, values);
     return {
       ...row,
-      values: this.alignRowValuesToDeclaredSchema(table, row.values as Value[]),
+      values: this.alignRowValuesToDeclaredSchema(
+        table,
+        row.values as Value[],
+        this.context.schema,
+      ),
     };
   }
 


### PR DESCRIPTION
## Summary

This PR follows the BoreDM dropdown write-path profile after the batch-record durability cleanup. Once local batch encode/decode stopped dominating, the remaining hot spots were repeated schema work around write result alignment and native history write-context resolution.

Changes:

- Align freshly returned TypeScript write rows against the declared client schema context instead of fetching/hashing the runtime schema.
- Add a regression test that fails if create-result alignment calls runtime `getSchema()` or `getSchemaHash()`.
- Cache catalogue-backed user row descriptors by storage namespace/table/schema hash, so repeated same-schema history writes do not repeatedly load and decode the same schema descriptor.
- Avoid the duplicate descriptor load in `resolve_history_row_write_context` by threading the already-resolved descriptor into prepared row write context construction.
- Route ordinary prepared local inserts through `apply_row_batch_with_context`, using the `WriteTableCacheEntry` descriptor and row locator instead of resolving history write context again during apply.
- For known-new prepared inserts, skip unnecessary previous-visible/history/idempotence reads and avoid reloading the exact row locator after it was just persisted.
- Add a patch changeset for `jazz-tools`.

This keeps query/subscription alignment and generic row-history apply paths intact. The faster path is limited to writes that already have declared schema/write context available, while fallback paths still resolve context from storage when needed.

## Tests

- `pnpm lint` (passes; oxlint reports existing repo warnings, clippy clean with `-D warnings`)
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/runtime/client-tests/schema-order.test.ts src/runtime/client.mutations.test.ts src/runtime/client.test.ts`
- `pnpm --filter jazz-tools build:test`
- `cargo test -p jazz-tools direct_query_manager_insert_uses_prepared_write_context_without_catalogue_loads -- --nocapture`
- `cargo test -p jazz-tools typed_history_appends_reuse_catalogue_descriptor_for_same_schema -- --nocapture`
- `cargo test -p jazz-tools storage::memory::tests -- --nocapture`
- `cargo test -p jazz-tools query_manager::manager_tests::bootstrap -- --nocapture`
- `cargo test -p jazz-tools row_histories -- --nocapture`

Pre-commit also ran `clippy` and `rustfmt` successfully for the Rust changes.