### PR TITLE
Add sync protocol handshake version

### DIFF
--- a/.changeset/polite-protocol-handshake.md
+++ b/.changeset/polite-protocol-handshake.md
@@ -1,0 +1,9 @@
+---
+"jazz-tools": patch
+"jazz-wasm": patch
+"jazz-napi": patch
+"jazz-rn": patch
+"create-jazz": patch
+---
+
+Add sync protocol version checks to the WebSocket handshake so incompatible clients and servers fail with an explicit update prompt.

--- a/crates/jazz-tools/src/server/routes/mod.rs
+++ b/crates/jazz-tools/src/server/routes/mod.rs
@@ -339,6 +339,7 @@ mod tests {
 
         // An AuthHandshake with an empty AuthConfig (no secret, no JWT).
         let handshake = AuthHandshake {
+            sync_protocol_version: crate::transport_manager::SYNC_PROTOCOL_VERSION,
             client_id: client_id.to_string(),
             auth: crate::transport_manager::AuthConfig::default(),
             catalogue_state_hash: None,
@@ -375,6 +376,7 @@ mod tests {
             .expect("build sync test state")
             .state;
         let handshake = crate::transport_manager::AuthHandshake {
+            sync_protocol_version: crate::transport_manager::SYNC_PROTOCOL_VERSION,
             client_id: ClientId::new().to_string(),
             auth: crate::transport_manager::AuthConfig::default(),
             catalogue_state_hash: None,
@@ -417,6 +419,7 @@ mod tests {
             .expect("build sync test state")
             .state;
         let handshake = crate::transport_manager::AuthHandshake {
+            sync_protocol_version: crate::transport_manager::SYNC_PROTOCOL_VERSION,
             client_id: ClientId::new().to_string(),
             auth: crate::transport_manager::AuthConfig::default(),
             catalogue_state_hash: None,
@@ -459,6 +462,7 @@ mod tests {
             .expect("build sync test state")
             .state;
         let handshake = crate::transport_manager::AuthHandshake {
+            sync_protocol_version: crate::transport_manager::SYNC_PROTOCOL_VERSION,
             client_id: ClientId::new().to_string(),
             auth: crate::transport_manager::AuthConfig::default(),
             catalogue_state_hash: None,
@@ -501,6 +505,7 @@ mod tests {
             .expect("build sync test state")
             .state;
         let handshake = crate::transport_manager::AuthHandshake {
+            sync_protocol_version: crate::transport_manager::SYNC_PROTOCOL_VERSION,
             client_id: ClientId::new().to_string(),
             auth: crate::transport_manager::AuthConfig::default(),
             catalogue_state_hash: None,
@@ -1964,6 +1969,7 @@ mod tests {
         let state = make_state_with_schema(schema).await;
         let declared_hash = SchemaHash::from_bytes([9; 32]);
         let handshake = crate::transport_manager::AuthHandshake {
+            sync_protocol_version: crate::transport_manager::SYNC_PROTOCOL_VERSION,
             client_id: ClientId::new().to_string(),
             auth: crate::transport_manager::AuthConfig::default(),
             catalogue_state_hash: state.runtime.catalogue_state_hash().ok(),
@@ -2001,6 +2007,7 @@ mod tests {
         let (mut ws, _) = connect_async(&ws_url).await.expect("connect ws");
 
         let handshake = crate::transport_manager::AuthHandshake {
+            sync_protocol_version: crate::transport_manager::SYNC_PROTOCOL_VERSION,
             client_id: client_id.clone(),
             auth: crate::transport_manager::AuthConfig {
                 backend_secret: Some("test-backend-secret".to_string()),
@@ -2021,9 +2028,16 @@ mod tests {
             .expect("wait for ConnectedResponse")
             .expect("ws frame")
             .expect("ws result");
-        assert!(
-            matches!(connected, WsMessage::Binary(_)),
-            "expected binary ConnectedResponse frame"
+        let WsMessage::Binary(connected_frame) = connected else {
+            panic!("expected binary ConnectedResponse frame, got {connected:?}");
+        };
+        let connected_payload = crate::transport_manager::frame_decode(&connected_frame)
+            .expect("decode ConnectedResponse frame");
+        let connected_response: crate::transport_manager::ConnectedResponse =
+            serde_json::from_slice(connected_payload).expect("parse ConnectedResponse");
+        assert_eq!(
+            connected_response.sync_protocol_version,
+            crate::transport_manager::SYNC_PROTOCOL_VERSION
         );
 
         tokio::time::sleep(Duration::from_millis(50)).await;
@@ -2041,6 +2055,84 @@ mod tests {
         );
 
         let _ = ws.close(None).await;
+        server_task.abort();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn ws_handler_rejects_pre_versioned_handshake_loudly() {
+        let state = make_sync_test_state("test-backend-secret").await;
+        let app = create_router(state);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind ws listener");
+        let addr = listener.local_addr().expect("ws local addr");
+        let server_task = tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve ws app");
+        });
+
+        let ws_url = format!("ws://{addr}{}", test_app_route("/ws"));
+        let (mut ws, _) = connect_async(&ws_url).await.expect("connect ws");
+        let payload = serde_json::to_vec(&serde_json::json!({
+            "client_id": ClientId::new().to_string(),
+            "auth": {
+                "backend_secret": "test-backend-secret"
+            },
+            "catalogue_state_hash": null,
+            "declared_schema_hash": null
+        }))
+        .expect("serialize old handshake");
+        ws.send(WsMessage::Binary(
+            crate::transport_manager::frame_encode(&payload).into(),
+        ))
+        .await
+        .expect("send handshake");
+
+        let error_frame = tokio::time::timeout(Duration::from_secs(5), ws.next())
+            .await
+            .expect("wait for error frame")
+            .expect("ws frame")
+            .expect("ws result");
+        let WsMessage::Binary(error_frame) = error_frame else {
+            panic!("expected binary ServerEvent::Error frame, got {error_frame:?}");
+        };
+        let payload =
+            crate::transport_manager::frame_decode(&error_frame).expect("decode error frame");
+        let event: crate::jazz_transport::ServerEvent =
+            serde_json::from_slice(payload).expect("parse error event");
+        match event {
+            crate::jazz_transport::ServerEvent::Error { message, code } => {
+                assert_eq!(code, crate::jazz_transport::ErrorCode::BadRequest);
+                assert!(
+                    message.contains("Incompatible Jazz sync protocol"),
+                    "unexpected error message: {message}"
+                );
+                assert!(
+                    message.contains("client sent 0"),
+                    "unexpected error message: {message}"
+                );
+            }
+            other => panic!("expected Error event, got {:?}", other.variant_name()),
+        }
+
+        let close_frame = tokio::time::timeout(Duration::from_secs(5), ws.next())
+            .await
+            .expect("wait for close frame")
+            .expect("ws frame")
+            .expect("ws result");
+        let WsMessage::Close(Some(close)) = close_frame else {
+            panic!("expected native close frame, got {close_frame:?}");
+        };
+        assert_eq!(
+            close.code,
+            tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode::Protocol
+        );
+        assert!(
+            close.reason.contains("Incompatible Jazz sync protocol"),
+            "unexpected close reason: {}",
+            close.reason
+        );
+
         server_task.abort();
     }
 }

--- a/crates/jazz-tools/src/server/routes/websocket.rs
+++ b/crates/jazz-tools/src/server/routes/websocket.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use axum::{
     extract::State,
-    extract::ws::{Message, WebSocket, WebSocketUpgrade},
+    extract::ws::{CloseFrame, Message, WebSocket, WebSocketUpgrade, close_code},
     http::HeaderMap,
     response::Response,
 };
@@ -227,10 +227,23 @@ fn is_loopback_dev_host(host: &str) -> bool {
 
 /// Send a `ServerEvent::Error` frame on the socket, best-effort.
 async fn send_ws_error(socket: &mut WebSocket, message: &str) {
-    use crate::jazz_transport::ErrorCode;
+    send_ws_error_with_code(
+        socket,
+        crate::jazz_transport::ErrorCode::Unauthorized,
+        message,
+    )
+    .await;
+}
+
+/// Send a `ServerEvent::Error` frame on the socket, best-effort.
+async fn send_ws_error_with_code(
+    socket: &mut WebSocket,
+    code: crate::jazz_transport::ErrorCode,
+    message: &str,
+) {
     let event = crate::jazz_transport::ServerEvent::Error {
         message: message.to_string(),
-        code: ErrorCode::Unauthorized,
+        code,
     };
     if let Ok(bytes) = serde_json::to_vec(&event) {
         let _ = socket
@@ -239,6 +252,16 @@ async fn send_ws_error(socket: &mut WebSocket, message: &str) {
             )))
             .await;
     }
+}
+
+async fn close_ws_with_protocol_reason(socket: &mut WebSocket, reason: &str) {
+    let reason = reason.chars().take(123).collect::<String>();
+    let _ = socket
+        .send(Message::Close(Some(CloseFrame {
+            code: close_code::PROTOCOL,
+            reason: reason.into(),
+        })))
+        .await;
 }
 
 async fn handle_ws_connection(
@@ -269,6 +292,27 @@ async fn handle_ws_connection(
                 return;
             }
         };
+
+    // Older, pre-versioned clients deserialize as protocol version 0. Reject
+    // them explicitly so developers see an actionable update prompt instead
+    // of a dropped socket.
+    if handshake.sync_protocol_version != crate::transport_manager::SYNC_PROTOCOL_VERSION {
+        let message = format!(
+            "Incompatible Jazz sync protocol: client sent {}, server requires {}. Please update Jazz.",
+            handshake.sync_protocol_version,
+            crate::transport_manager::SYNC_PROTOCOL_VERSION,
+        );
+        // Use BadRequest here so older clients that do not know newer error
+        // codes can still deserialize and log the message.
+        send_ws_error_with_code(
+            &mut socket,
+            crate::jazz_transport::ErrorCode::BadRequest,
+            &message,
+        )
+        .await;
+        close_ws_with_protocol_reason(&mut socket, &message).await;
+        return;
+    }
 
     // 2. Parse client_id.
     let client_id = match crate::sync_manager::ClientId::parse(&handshake.client_id) {
@@ -337,6 +381,7 @@ async fn handle_ws_connection(
 
     // 6. Send the Connected response.
     let resp = crate::transport_manager::ConnectedResponse {
+        sync_protocol_version: crate::transport_manager::SYNC_PROTOCOL_VERSION,
         connection_id: connection_id.to_string(),
         client_id: client_id.to_string(),
         next_sync_seq: Some(next_sync_seq),

--- a/crates/jazz-tools/src/transport_manager.rs
+++ b/crates/jazz-tools/src/transport_manager.rs
@@ -7,6 +7,8 @@ use crate::query_manager::types::SchemaHash;
 use crate::sync_manager::types::{ClientId, InboxEntry, OutboxEntry, ServerId};
 use futures::channel::mpsc;
 
+pub const SYNC_PROTOCOL_VERSION: u32 = 1;
+
 pub trait TickNotifier: 'static {
     fn notify(&self);
 }
@@ -169,10 +171,16 @@ impl std::fmt::Debug for AuthConfig {
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct AuthHandshake {
+    #[serde(default = "default_sync_protocol_version")]
+    pub sync_protocol_version: u32,
     pub client_id: String,
     pub auth: AuthConfig,
     pub catalogue_state_hash: Option<String>,
     pub declared_schema_hash: Option<String>,
+}
+
+fn default_sync_protocol_version() -> u32 {
+    0
 }
 
 impl AuthHandshake {
@@ -193,6 +201,7 @@ mod handshake_tests {
         let declared_hash = SchemaHash::from_bytes([7; 32]);
         let catalogue_hash = "ab".repeat(32);
         let handshake = AuthHandshake {
+            sync_protocol_version: SYNC_PROTOCOL_VERSION,
             client_id: "client-1".to_string(),
             auth: AuthConfig::default(),
             catalogue_state_hash: Some(catalogue_hash.clone()),
@@ -202,6 +211,7 @@ mod handshake_tests {
         assert_eq!(handshake.declared_schema_hash(), Some(declared_hash));
 
         let handshake_without_declared_hash = AuthHandshake {
+            sync_protocol_version: SYNC_PROTOCOL_VERSION,
             client_id: "client-1".to_string(),
             auth: AuthConfig::default(),
             catalogue_state_hash: Some(catalogue_hash),
@@ -210,10 +220,38 @@ mod handshake_tests {
 
         assert_eq!(handshake_without_declared_hash.declared_schema_hash(), None);
     }
+
+    #[test]
+    fn auth_handshake_defaults_missing_sync_protocol_version_to_zero() {
+        let handshake: AuthHandshake = serde_json::from_value(serde_json::json!({
+            "client_id": "client-1",
+            "auth": {},
+            "catalogue_state_hash": null,
+            "declared_schema_hash": null
+        }))
+        .expect("pre-versioned handshake should deserialize");
+
+        assert_eq!(handshake.sync_protocol_version, 0);
+    }
+
+    #[test]
+    fn connected_response_defaults_missing_sync_protocol_version_to_zero() {
+        let response: ConnectedResponse = serde_json::from_value(serde_json::json!({
+            "connection_id": "conn-1",
+            "client_id": "client-1",
+            "next_sync_seq": null,
+            "catalogue_state_hash": null
+        }))
+        .expect("pre-versioned connected response should deserialize");
+
+        assert_eq!(response.sync_protocol_version, 0);
+    }
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct ConnectedResponse {
+    #[serde(default = "default_sync_protocol_version")]
+    pub sync_protocol_version: u32,
     pub connection_id: String,
     pub client_id: String,
     pub next_sync_seq: Option<u64>,
@@ -379,6 +417,7 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
             .ok()
             .and_then(|g| g.clone());
         let handshake = AuthHandshake {
+            sync_protocol_version: SYNC_PROTOCOL_VERSION,
             client_id: self.client_id.to_string(),
             auth: self.auth.clone(),
             catalogue_state_hash,
@@ -414,6 +453,12 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
 
         // First try to parse as the success path.
         if let Ok(resp) = serde_json::from_slice::<ConnectedResponse>(resp_payload) {
+            if resp.sync_protocol_version != SYNC_PROTOCOL_VERSION {
+                return HandshakeResult::NetworkError(format!(
+                    "incompatible Jazz sync protocol: server sent {}, client requires {}. Please update Jazz.",
+                    resp.sync_protocol_version, SYNC_PROTOCOL_VERSION
+                ));
+            }
             return HandshakeResult::Connected(resp);
         }
 
@@ -878,6 +923,7 @@ mod tests {
         async fn connect(_url: &str) -> Result<Self, Self::Error> {
             // Pre-load a valid ConnectedResponse frame so the handshake succeeds.
             let resp = ConnectedResponse {
+                sync_protocol_version: SYNC_PROTOCOL_VERSION,
                 connection_id: "conn-1".into(),
                 client_id: "client-1".into(),
                 next_sync_seq: Some(0),
@@ -982,6 +1028,7 @@ mod tests {
 
     fn make_handshake_response_frame() -> Vec<u8> {
         let resp = ConnectedResponse {
+            sync_protocol_version: SYNC_PROTOCOL_VERSION,
             connection_id: "conn-1".into(),
             client_id: "client-1".into(),
             next_sync_seq: Some(0),

--- a/crates/jazz-tools/src/transport_protocol.rs
+++ b/crates/jazz-tools/src/transport_protocol.rs
@@ -113,6 +113,8 @@ impl ServerEvent {
 pub enum ErrorCode {
     /// Invalid request format.
     BadRequest,
+    /// Client and server do not share a compatible sync protocol version.
+    IncompatibleProtocol,
     /// Authentication required or failed.
     Unauthorized,
     /// Permission denied by policy.

--- a/crates/jazz-tools/tests/auth_test.rs
+++ b/crates/jazz-tools/tests/auth_test.rs
@@ -19,7 +19,9 @@ use jazz_tools::metadata::{MetadataKey, ObjectType};
 use jazz_tools::query_manager::session::Session;
 use jazz_tools::schema_manager::encoding::encode_schema;
 use jazz_tools::sync_manager::{ClientId, SyncError, SyncPayload};
-use jazz_tools::transport_manager::{AuthConfig, AuthHandshake, ConnectedResponse};
+use jazz_tools::transport_manager::{
+    AuthConfig, AuthHandshake, ConnectedResponse, SYNC_PROTOCOL_VERSION,
+};
 use jsonwebtoken::{EncodingKey, Header, encode};
 use reqwest::{Client, StatusCode};
 use serde::{Deserialize, Serialize};
@@ -111,6 +113,7 @@ async fn ws_handshake_open(
         .map_err(|e| format!("ws connect failed: {e}"))?;
 
     let handshake = AuthHandshake {
+        sync_protocol_version: SYNC_PROTOCOL_VERSION,
         client_id: ClientId::new().to_string(),
         auth,
         catalogue_state_hash: None,

--- a/crates/jazz-tools/tests/integration.rs
+++ b/crates/jazz-tools/tests/integration.rs
@@ -12,7 +12,9 @@ use std::time::Duration;
 
 use futures::{SinkExt as _, StreamExt as _};
 use jazz_tools::sync_manager::ClientId;
-use jazz_tools::transport_manager::{AuthConfig, AuthHandshake, ConnectedResponse};
+use jazz_tools::transport_manager::{
+    AuthConfig, AuthHandshake, ConnectedResponse, SYNC_PROTOCOL_VERSION,
+};
 use reqwest::Client;
 use tempfile::TempDir;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
@@ -60,6 +62,7 @@ async fn ws_handshake(port: u16, jwt_token: &str) -> Result<ConnectedResponse, S
         .map_err(|e| format!("ws connect failed: {e}"))?;
 
     let handshake = AuthHandshake {
+        sync_protocol_version: SYNC_PROTOCOL_VERSION,
         client_id: ClientId::new().to_string(),
         auth: AuthConfig {
             jwt_token: Some(jwt_token.to_string()),
@@ -358,6 +361,7 @@ async fn test_ws_connection_stays_open_after_handshake() {
     let (mut ws, _) = connect_async(&ws_url).await.expect("ws connect");
 
     let handshake = AuthHandshake {
+        sync_protocol_version: SYNC_PROTOCOL_VERSION,
         client_id: ClientId::new().to_string(),
         auth: AuthConfig {
             jwt_token: Some(token),


### PR DESCRIPTION
## Summary

Adds an explicit sync protocol version to the WebSocket `AuthHandshake` and echoes it in `ConnectedResponse`.

Incompatible clients are rejected before auth with a parseable `ServerEvent::Error` using `BadRequest`, followed by a native WebSocket protocol close reason that asks developers to please update Jazz. Missing protocol versions deserialize as `0`, so pre-versioned clients and servers produce actionable errors instead of silent or vague disconnects.

Includes a patch changeset for the fixed Jazz package group.

## Validation

- `cargo test -p jazz-tools sync_protocol_version`
- `cargo test -p jazz-tools --features server,test-utils ws_handler_rejects_pre_versioned_handshake_loudly`
- `cargo test -p jazz-tools --features server,test-utils ws_handler_logs_when_connection_is_established`
- `pnpm lint`

Note: `pnpm lint` completed successfully; oxlint reported existing warnings but no errors, then Cargo clippy completed cleanly with `-D warnings`.