### PR TITLE
Reduce per-insert write bookkeeping

### DIFF
--- a/.changeset/faster-write-batches.md
+++ b/.changeset/faster-write-batches.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Improve local write performance by skipping idle subscription recompilation, reducing local batch member sorting, and reusing prepared schema insert alignment.

--- a/crates/jazz-tools/src/batch_fate.rs
+++ b/crates/jazz-tools/src/batch_fate.rs
@@ -1,6 +1,7 @@
 use crate::digest::Digest32;
 use blake3::Hasher;
 use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
 
 use crate::object::{BranchName, ObjectId};
 use crate::query_manager::types::SchemaHash;
@@ -269,29 +270,45 @@ impl LocalBatchRecord {
     }
 
     pub fn upsert_member(&mut self, member: LocalBatchMember) {
-        if let Some(existing) = self.members.iter_mut().find(|existing| {
-            existing.object_id == member.object_id
-                && existing.table_name == member.table_name
-                && existing.branch_name == member.branch_name
+        match self.members.binary_search_by(|existing| {
+            Self::compare_member_identity(existing, &member)
+                .then_with(|| Self::compare_member_version(existing, &member))
         }) {
-            *existing = member;
-        } else {
-            self.members.push(member);
+            Ok(index) => {
+                self.members[index] = member;
+            }
+            Err(index) => {
+                if index > 0
+                    && Self::compare_member_identity(&self.members[index - 1], &member)
+                        == Ordering::Equal
+                {
+                    self.members[index - 1] = member;
+                } else if index < self.members.len()
+                    && Self::compare_member_identity(&self.members[index], &member)
+                        == Ordering::Equal
+                {
+                    self.members[index] = member;
+                } else {
+                    self.members.insert(index, member);
+                }
+            }
         }
-        self.members.sort_by(|left, right| {
-            left.object_id
-                .uuid()
-                .as_bytes()
-                .cmp(right.object_id.uuid().as_bytes())
-                .then_with(|| left.table_name.cmp(&right.table_name))
-                .then_with(|| left.branch_name.as_str().cmp(right.branch_name.as_str()))
-                .then_with(|| {
-                    left.schema_hash
-                        .as_bytes()
-                        .cmp(right.schema_hash.as_bytes())
-                })
-                .then_with(|| left.row_digest.0.cmp(&right.row_digest.0))
-        });
+    }
+
+    fn compare_member_identity(left: &LocalBatchMember, right: &LocalBatchMember) -> Ordering {
+        left.object_id
+            .uuid()
+            .as_bytes()
+            .cmp(right.object_id.uuid().as_bytes())
+            .then_with(|| left.table_name.cmp(&right.table_name))
+            .then_with(|| left.branch_name.as_str().cmp(right.branch_name.as_str()))
+    }
+
+    fn compare_member_version(left: &LocalBatchMember, right: &LocalBatchMember) -> Ordering {
+        left.schema_hash
+            .as_bytes()
+            .cmp(right.schema_hash.as_bytes())
+            .then_with(|| left.row_digest.0.cmp(&right.row_digest.0))
     }
 
     pub fn mark_sealed(&mut self, submission: SealedBatchSubmission) {
@@ -1021,6 +1038,45 @@ mod tests {
         let decoded = LocalBatchRecord::decode_storage_row(&bytes).expect("decode record");
 
         assert_eq!(decoded, record);
+    }
+
+    #[test]
+    fn local_batch_record_upsert_member_keeps_members_sorted_and_replaces_row() {
+        let batch_id = BatchId::new();
+        let mut record = LocalBatchRecord::new(batch_id, BatchMode::Direct, false, None);
+        let alice_id = ObjectId::from_uuid(uuid::Uuid::from_u128(1));
+        let bob_id = ObjectId::from_uuid(uuid::Uuid::from_u128(2));
+
+        record.upsert_member(LocalBatchMember {
+            object_id: bob_id,
+            table_name: "tasks".to_string(),
+            branch_name: BranchName::new("main"),
+            schema_hash: SchemaHash::from_bytes([2; 32]),
+            row_digest: Digest32([2; 32]),
+        });
+        record.upsert_member(LocalBatchMember {
+            object_id: alice_id,
+            table_name: "tasks".to_string(),
+            branch_name: BranchName::new("main"),
+            schema_hash: SchemaHash::from_bytes([1; 32]),
+            row_digest: Digest32([1; 32]),
+        });
+        record.upsert_member(LocalBatchMember {
+            object_id: bob_id,
+            table_name: "tasks".to_string(),
+            branch_name: BranchName::new("main"),
+            schema_hash: SchemaHash::from_bytes([3; 32]),
+            row_digest: Digest32([3; 32]),
+        });
+
+        assert_eq!(
+            record
+                .members
+                .iter()
+                .map(|member| (member.object_id, member.row_digest))
+                .collect::<Vec<_>>(),
+            vec![(alice_id, Digest32([1; 32])), (bob_id, Digest32([3; 32]))]
+        );
     }
 
     #[test]

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -731,6 +731,14 @@ impl QueryManager {
         }
     }
 
+    pub(super) fn has_stale_subscriptions(&self) -> bool {
+        self.subscriptions.values().any(|sub| sub.needs_recompile)
+            || self
+                .server_subscriptions
+                .values()
+                .any(|sub| sub.needs_recompile)
+    }
+
     pub(crate) fn ensure_known_schemas_catalogued<H: Storage>(
         &mut self,
         storage: &mut H,
@@ -791,6 +799,10 @@ impl QueryManager {
     ///
     /// Called during process() to rebuild QueryGraphs when schemas change.
     fn recompile_stale_subscriptions(&mut self) {
+        if !self.has_stale_subscriptions() {
+            return;
+        }
+
         let mut failed_local: Vec<(QuerySubscriptionId, String)> = Vec::new();
         let current_schema = self.schema.clone();
         let current_schema_context = self.schema_context.clone();

--- a/crates/jazz-tools/src/query_manager/manager_tests/bootstrap.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests/bootstrap.rs
@@ -107,3 +107,14 @@ fn direct_query_manager_insert_uses_prepared_write_context_without_catalogue_loa
         "prepared local inserts already have the table descriptor and should not reload catalogue descriptors during history apply",
     );
 }
+
+#[test]
+fn direct_query_manager_process_has_no_stale_subscription_work_without_subscriptions() {
+    let mut qm = QueryManager::new(SyncManager::new());
+    qm.set_current_schema(test_schema(), "dev", "main");
+    let mut storage = MemoryStorage::new();
+
+    assert!(!qm.has_stale_subscriptions());
+    qm.process(&mut storage);
+    assert!(!qm.has_stale_subscriptions());
+}

--- a/crates/jazz-tools/src/runtime_core/writes.rs
+++ b/crates/jazz-tools/src/runtime_core/writes.rs
@@ -156,21 +156,23 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                 })
             })
             .collect::<Result<Vec<_>, RuntimeError>>()?;
-        members.sort_by(|left, right| {
-            left.object_id
-                .uuid()
-                .as_bytes()
-                .cmp(right.object_id.uuid().as_bytes())
-                .then_with(|| left.table_name.cmp(&right.table_name))
-                .then_with(|| left.branch_name.as_str().cmp(right.branch_name.as_str()))
-                .then_with(|| {
-                    left.schema_hash
-                        .as_bytes()
-                        .cmp(right.schema_hash.as_bytes())
-                })
-                .then_with(|| left.row_digest.0.cmp(&right.row_digest.0))
-        });
-        members.dedup();
+        if members.len() > 1 {
+            members.sort_by(|left, right| {
+                left.object_id
+                    .uuid()
+                    .as_bytes()
+                    .cmp(right.object_id.uuid().as_bytes())
+                    .then_with(|| left.table_name.cmp(&right.table_name))
+                    .then_with(|| left.branch_name.as_str().cmp(right.branch_name.as_str()))
+                    .then_with(|| {
+                        left.schema_hash
+                            .as_bytes()
+                            .cmp(right.schema_hash.as_bytes())
+                    })
+                    .then_with(|| left.row_digest.0.cmp(&right.row_digest.0))
+            });
+            members.dedup();
+        }
         if members.is_empty() {
             return Err(RuntimeError::WriteError(format!(
                 "missing local batch member rows for {batch_id:?} / {row_id:?}"

--- a/crates/jazz-tools/src/schema_manager/manager.rs
+++ b/crates/jazz-tools/src/schema_manager/manager.rs
@@ -70,6 +70,19 @@ pub struct CurrentPermissionsSummary {
     pub permissions: HashMap<TableName, TablePolicies>,
 }
 
+#[derive(Clone, Debug)]
+struct InsertAlignmentColumn {
+    name: String,
+    nullable: bool,
+    default: Option<Value>,
+}
+
+#[derive(Clone, Debug)]
+struct InsertAlignmentPlan {
+    columns: Vec<InsertAlignmentColumn>,
+    positions_by_name: HashMap<String, usize>,
+}
+
 /// SchemaManager coordinates schema evolution with query execution.
 ///
 /// It manages:
@@ -128,6 +141,7 @@ pub struct SchemaManager {
     known_schemas: Arc<HashMap<SchemaHash, Schema>>,
     known_schemas_dirty: bool,
     persisted_current_schema_in_storage: HashSet<(usize, SchemaHash)>,
+    insert_alignment_cache: HashMap<(SchemaHash, TableName), Arc<InsertAlignmentPlan>>,
 }
 
 impl SchemaManager {
@@ -200,6 +214,7 @@ impl SchemaManager {
             known_schemas: Arc::new(known_schemas),
             known_schemas_dirty: true,
             persisted_current_schema_in_storage: HashSet::new(),
+            insert_alignment_cache: HashMap::new(),
         })
     }
 
@@ -235,6 +250,7 @@ impl SchemaManager {
             known_schemas: Arc::new(HashMap::new()),
             known_schemas_dirty: false,
             persisted_current_schema_in_storage: HashSet::new(),
+            insert_alignment_cache: HashMap::new(),
         }
     }
 
@@ -318,10 +334,17 @@ impl SchemaManager {
     }
 
     fn schema_for_hash(&self, schema_hash: SchemaHash) -> Option<&Schema> {
-        if schema_hash == self.context.current_hash {
-            return Some(&self.context.current_schema);
+        Self::schema_for_hash_in_context(&self.context, schema_hash)
+    }
+
+    fn schema_for_hash_in_context(
+        context: &SchemaContext,
+        schema_hash: SchemaHash,
+    ) -> Option<&Schema> {
+        if schema_hash == context.current_hash {
+            return Some(&context.current_schema);
         }
-        self.context.live_schemas.get(&schema_hash)
+        context.live_schemas.get(&schema_hash)
     }
 
     fn resolve_target_branch(
@@ -401,26 +424,59 @@ impl SchemaManager {
         Ok(temp_context)
     }
 
-    fn get_insert_values_with_defaults_for_schema(
-        table: &str,
+    fn insert_alignment_plan_for_schema(
+        cache: &mut HashMap<(SchemaHash, TableName), Arc<InsertAlignmentPlan>>,
+        schema_hash: SchemaHash,
+        table_name: TableName,
         schema: &Schema,
-        mut values_by_column: HashMap<String, Value>,
-    ) -> Result<Vec<Value>, QueryError> {
-        let table_name = TableName::new(table);
+    ) -> Result<Arc<InsertAlignmentPlan>, QueryError> {
+        let cache_key = (schema_hash, table_name);
+        if let Some(plan) = cache.get(&cache_key) {
+            return Ok(plan.clone());
+        }
+
         let table_schema = schema
             .get(&table_name)
             .ok_or(QueryError::TableNotFound(table_name))?;
+        let mut positions_by_name = HashMap::with_capacity(table_schema.columns.columns.len());
+        let columns = table_schema
+            .columns
+            .columns
+            .iter()
+            .enumerate()
+            .map(|(index, column)| {
+                let name = column.name.as_str().to_string();
+                positions_by_name.insert(name.clone(), index);
+                InsertAlignmentColumn {
+                    name,
+                    nullable: column.nullable,
+                    default: column.default.clone(),
+                }
+            })
+            .collect();
+        let plan = Arc::new(InsertAlignmentPlan {
+            columns,
+            positions_by_name,
+        });
+        cache.insert(cache_key, plan.clone());
+        Ok(plan)
+    }
 
+    fn align_insert_values_with_plan(
+        table: &str,
+        plan: &InsertAlignmentPlan,
+        mut values_by_column: HashMap<String, Value>,
+    ) -> Result<Vec<Value>, QueryError> {
         for column in values_by_column.keys() {
-            if table_schema.columns.column(column.as_str()).is_none() {
+            if !plan.positions_by_name.contains_key(column.as_str()) {
                 return Err(QueryError::EncodingError(format!(
                     "unknown column `{column}` on table `{table}`"
                 )));
             }
         }
 
-        let mut aligned_values = Vec::with_capacity(table_schema.columns.columns.len());
-        for column in &table_schema.columns.columns {
+        let mut aligned_values = Vec::with_capacity(plan.columns.len());
+        for column in &plan.columns {
             if let Some(value) = values_by_column.remove(column.name.as_str()) {
                 if value == Value::Null && !column.nullable {
                     return Err(QueryError::EncodingError(format!(
@@ -1620,22 +1676,29 @@ impl SchemaManager {
     ) -> Result<InsertResult, QueryError> {
         let _ = self.ensure_current_schema_persisted(storage);
         let (target_branch, target_hash) = self.resolve_target_branch(write_context)?;
-        let target_schema = self
-            .schema_for_hash(target_hash)
-            .ok_or(QueryError::UnknownSchema(target_hash))?
-            .clone();
-        let aligned_values =
-            Self::get_insert_values_with_defaults_for_schema(table, &target_schema, values)?;
-        self.query_manager
-            .insert_on_branch_with_schema_and_write_context_and_id(
-                storage,
-                table,
-                &target_branch,
-                &aligned_values,
-                object_id,
-                &target_schema,
-                write_context,
-            )
+        let table_name = TableName::new(table);
+
+        let context = &self.context;
+        let insert_alignment_cache = &mut self.insert_alignment_cache;
+        let query_manager = &mut self.query_manager;
+        let target_schema = Self::schema_for_hash_in_context(context, target_hash)
+            .ok_or(QueryError::UnknownSchema(target_hash))?;
+        let plan = Self::insert_alignment_plan_for_schema(
+            insert_alignment_cache,
+            target_hash,
+            table_name,
+            target_schema,
+        )?;
+        let aligned_values = Self::align_insert_values_with_plan(table, &plan, values)?;
+        query_manager.insert_on_branch_with_schema_and_write_context_and_id(
+            storage,
+            table,
+            &target_branch,
+            &aligned_values,
+            object_id,
+            target_schema,
+            write_context,
+        )
     }
 
     pub fn insert_with_session<H: Storage>(
@@ -3008,6 +3071,33 @@ mod tests {
         assert_eq!(stored[title_idx], Value::Text("ship default".into()));
         assert_eq!(stored[done_idx], Value::Boolean(false));
         assert_eq!(stored[note_idx], Value::Text("from default".into()));
+    }
+
+    #[test]
+    fn schema_manager_insert_reuses_prepared_alignment_for_same_table() {
+        use crate::storage::MemoryStorage;
+
+        let schema = make_schema_with_insert_defaults();
+        let mut storage = MemoryStorage::new();
+        let mut manager =
+            SchemaManager::new(SyncManager::new(), schema, test_app_id(), "dev", "main").unwrap();
+
+        manager
+            .insert(
+                &mut storage,
+                "todos",
+                HashMap::from([("title".to_string(), Value::Text("first".into()))]),
+            )
+            .unwrap();
+        manager
+            .insert(
+                &mut storage,
+                "todos",
+                HashMap::from([("title".to_string(), Value::Text("second".into()))]),
+            )
+            .unwrap();
+
+        assert_eq!(manager.insert_alignment_cache.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## What changed

This PR removes the next round of per-row write-path overhead exposed by the BoreDM dropdown seed profile:

- Skip stale subscription recompilation before cloning schema state when there are no stale local or server subscriptions.
- Keep local batch members ordered with binary-search replacement/insertion instead of sorting the whole member list for every insert.
- Avoid sorting/deduping local batch members when tracking finds only one member for the row.
- Avoid cloning the full target schema in `SchemaManager::insert_with_write_context_and_id`.
- Cache insert alignment metadata per `(schema hash, table)` so repeated inserts reuse prepared column/default/nullability information.

## Why

After the prepared history-context work, the profile shifted to two avoidable costs: idle `immediate_tick()` processing that cloned schema data while checking for stale subscriptions, and local batch member sorting during giant batch construction. A later profile then showed schema/table descriptor clone work inside the schema-manager insert boundary.

## Validation

- `pnpm lint`
- `cargo test -p jazz-tools schema_manager::manager::tests -- --nocapture`
- `cargo test -p jazz-tools query_manager::manager_tests::bootstrap -- --nocapture`
- `cargo test -p jazz-tools runtime_core::tests::write_batch -- --nocapture`
- `cargo test -p jazz-tools batch_fate -- --nocapture`
- `cargo test -p jazz-tools runtime_core:: -- --nocapture`
