### PR TITLE
Speed up server subscription authorization settlement

### DIFF
--- a/crates/jazz-tools/benches/server_authorization_scope_benchmark.rs
+++ b/crates/jazz-tools/benches/server_authorization_scope_benchmark.rs
@@ -5,14 +5,17 @@
 //! used to re-run visibility checks for output tuples and sync-scope tuples
 //! separately, which shows up as main-thread WASM work in browser profiles.
 
+use std::collections::HashMap;
+use std::sync::Arc;
+
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use jazz_tools::query_manager::manager::QueryManager;
 use jazz_tools::query_manager::policy::PolicyExpr;
 use jazz_tools::query_manager::query::QueryBuilder;
 use jazz_tools::query_manager::session::Session;
 use jazz_tools::query_manager::types::{
-    ColumnDescriptor, ColumnType, RowDescriptor, Schema, TableName, TablePolicies, TableSchema,
-    Value,
+    ColumnDescriptor, ColumnType, RowDescriptor, Schema, SchemaHash, TableName, TablePolicies,
+    TableSchema, Value,
 };
 use jazz_tools::schema_manager::AppId;
 use jazz_tools::storage::MemoryStorage;
@@ -29,6 +32,31 @@ fn schema() -> Schema {
         ColumnDescriptor::new("name", ColumnType::Text),
         ColumnDescriptor::new("score", ColumnType::Integer),
     ]);
+    let policies = TablePolicies::new()
+        .with_select(PolicyExpr::eq_session("owner_id", vec!["user_id".into()]));
+    schema.insert(
+        TableName::new("items"),
+        TableSchema::with_policies(descriptor, policies),
+    );
+    schema
+}
+
+fn wide_schema(schema_index: usize, extra_columns: usize) -> Schema {
+    let mut schema = Schema::new();
+    let mut columns = vec![
+        ColumnDescriptor::new("owner_id", ColumnType::Text),
+        ColumnDescriptor::new("name", ColumnType::Text),
+        ColumnDescriptor::new("score", ColumnType::Integer),
+    ];
+
+    for column_index in 0..extra_columns {
+        columns.push(ColumnDescriptor::new(
+            format!("metadata_{schema_index}_{column_index}"),
+            ColumnType::Text,
+        ));
+    }
+
+    let descriptor = RowDescriptor::new(columns);
     let policies = TablePolicies::new()
         .with_select(PolicyExpr::eq_session("owner_id", vec!["user_id".into()]));
     schema.insert(
@@ -63,6 +91,46 @@ fn setup(row_count: usize) -> (QueryManager, MemoryStorage) {
     (manager, storage)
 }
 
+fn setup_with_wide_schema_catalogue(
+    row_count: usize,
+    known_schema_count: usize,
+    extra_columns: usize,
+) -> (QueryManager, MemoryStorage) {
+    let current_schema = wide_schema(0, extra_columns);
+    let mut manager = QueryManager::new(SyncManager::new());
+    manager
+        .set_catalogue_app_id(AppId::from_name("authorization-scope-wide-catalogue").to_string());
+    manager.set_current_schema(current_schema.clone(), "dev", "main");
+
+    let mut known_schemas = HashMap::new();
+    known_schemas.insert(SchemaHash::compute(&current_schema), current_schema);
+    for schema_index in 1..known_schema_count {
+        let schema = wide_schema(schema_index, extra_columns);
+        known_schemas.insert(SchemaHash::compute(&schema), schema);
+    }
+    manager.set_known_schemas(Arc::new(known_schemas));
+
+    let mut storage = MemoryStorage::new();
+    for index in 0..row_count {
+        let mut values = vec![
+            Value::Text(USER_ID.to_string()),
+            Value::Text(format!("Item {index}")),
+            Value::Integer(index as i32),
+        ];
+        values.extend(
+            (0..extra_columns)
+                .map(|column_index| Value::Text(format!("item-{index}-metadata-{column_index}"))),
+        );
+        manager
+            .insert(&mut storage, "items", &values)
+            .expect("insert benchmark item");
+    }
+    manager.process(&mut storage);
+    let _ = manager.sync_manager_mut().take_outbox();
+
+    (manager, storage)
+}
+
 fn subscribe_limit(manager: &mut QueryManager, storage: &mut MemoryStorage, limit: usize) {
     let client_id = ClientId::new();
     manager
@@ -81,6 +149,36 @@ fn subscribe_limit(manager: &mut QueryManager, storage: &mut MemoryStorage, limi
             policy_context_tables: vec![],
         },
     });
+
+    manager.process(storage);
+    black_box(manager.sync_manager_mut().take_outbox());
+}
+
+fn subscribe_many(
+    manager: &mut QueryManager,
+    storage: &mut MemoryStorage,
+    subscription_count: usize,
+    limit: usize,
+) {
+    for subscription_index in 0..subscription_count {
+        let client_id = ClientId::new();
+        manager
+            .sync_manager_mut()
+            .add_client_with_storage(storage, client_id);
+        let _ = manager.sync_manager_mut().take_outbox();
+
+        let query = QueryBuilder::new("items").limit(limit).build();
+        manager.sync_manager_mut().push_inbox(InboxEntry {
+            source: Source::Client(client_id),
+            payload: SyncPayload::QuerySubscription {
+                query_id: QueryId(subscription_index as u64 + 1),
+                query: Box::new(query),
+                session: Some(Session::new(USER_ID)),
+                propagation: QueryPropagation::Full,
+                policy_context_tables: vec![],
+            },
+        });
+    }
 
     manager.process(storage);
     black_box(manager.sync_manager_mut().take_outbox());
@@ -109,9 +207,79 @@ fn initial_authorized_scope(c: &mut Criterion) {
     group.finish();
 }
 
+fn initial_authorized_scope_with_wide_schema_catalogue(c: &mut Criterion) {
+    let mut group = c.benchmark_group("server_authorization_scope/wide_schema_catalogue");
+
+    for (row_count, known_schema_count, extra_columns) in [(2_000usize, 500usize, 256usize)] {
+        group.throughput(Throughput::Elements(row_count as u64));
+        group.bench_with_input(
+            BenchmarkId::new(
+                format!("{known_schema_count}_schemas_{extra_columns}_extra_columns"),
+                row_count,
+            ),
+            &(row_count, known_schema_count, extra_columns),
+            |b, &(row_count, known_schema_count, extra_columns)| {
+                b.iter_batched(
+                    || {
+                        setup_with_wide_schema_catalogue(
+                            row_count,
+                            known_schema_count,
+                            extra_columns,
+                        )
+                    },
+                    |(mut manager, mut storage)| {
+                        subscribe_limit(&mut manager, &mut storage, row_count);
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn many_initial_authorized_scopes_share_schema_context(c: &mut Criterion) {
+    let mut group = c.benchmark_group("server_authorization_scope/many_subscriptions");
+
+    for (row_count, known_schema_count, extra_columns, subscription_count) in
+        [(1_000usize, 500usize, 256usize, 25usize)]
+    {
+        group.throughput(Throughput::Elements(
+            (row_count * subscription_count) as u64,
+        ));
+        group.bench_with_input(
+            BenchmarkId::new(
+                format!(
+                    "{subscription_count}_subscriptions_{known_schema_count}_schemas_{extra_columns}_extra_columns"
+                ),
+                row_count,
+            ),
+            &(row_count, known_schema_count, extra_columns, subscription_count),
+            |b, &(row_count, known_schema_count, extra_columns, subscription_count)| {
+                b.iter_batched(
+                    || {
+                        setup_with_wide_schema_catalogue(
+                            row_count,
+                            known_schema_count,
+                            extra_columns,
+                        )
+                    },
+                    |(mut manager, mut storage)| {
+                        subscribe_many(&mut manager, &mut storage, subscription_count, row_count);
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
 criterion_group! {
     name = benches;
     config = Criterion::default().sample_size(10);
-    targets = initial_authorized_scope
+    targets = initial_authorized_scope, initial_authorized_scope_with_wide_schema_catalogue, many_initial_authorized_scopes_share_schema_context
 }
 criterion_main!(benches);

--- a/crates/jazz-tools/src/query_manager/indices.rs
+++ b/crates/jazz-tools/src/query_manager/indices.rs
@@ -1,6 +1,8 @@
 use crate::object::ObjectId;
 use crate::storage::{IndexMutation, Storage, StorageError, validate_index_value_size};
 
+use crate::row_format::CompiledRowLayout;
+
 use super::encoding::decode_column;
 use super::manager::{QueryError, QueryManager};
 use super::types::{ColumnDescriptor, ColumnType, RowDescriptor, TableName, Value};
@@ -138,6 +140,20 @@ impl QueryManager {
         data: &[u8],
         descriptor: &'a RowDescriptor,
     ) -> Vec<IndexMutation<'a>> {
+        let layout = crate::row_format::compiled_row_layout(descriptor);
+        Self::index_mutations_for_insert_on_branch_with_layout(
+            table, branch, object_id, data, descriptor, &layout,
+        )
+    }
+
+    pub(super) fn index_mutations_for_insert_on_branch_with_layout<'a>(
+        table: &'a str,
+        branch: &'a str,
+        object_id: ObjectId,
+        data: &[u8],
+        descriptor: &'a RowDescriptor,
+        layout: &CompiledRowLayout,
+    ) -> Vec<IndexMutation<'a>> {
         let mut mutations = vec![IndexMutation::Insert {
             table,
             column: "_id",
@@ -147,7 +163,8 @@ impl QueryManager {
         }];
 
         for (col_idx, col) in descriptor.columns.iter().enumerate() {
-            if let Ok(value) = decode_column(descriptor, data, col_idx)
+            if let Ok(value) =
+                crate::row_format::decode_column_with_layout(descriptor, layout, data, col_idx)
                 && value != Value::Null
             {
                 Self::push_insert_column_index_values(

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -271,6 +271,7 @@ pub(super) struct PolicyCheckState {
 #[derive(Debug)]
 pub(super) struct WriteTableCacheEntry {
     pub(super) descriptor: Arc<RowDescriptor>,
+    pub(super) row_layout: Arc<crate::row_format::CompiledRowLayout>,
     pub(super) row_locator: RowLocator,
     pub(super) insert_policy: Option<Arc<PolicyExpr>>,
     pub(super) update_using_policy: Option<Arc<PolicyExpr>>,
@@ -389,6 +390,7 @@ pub struct QueryManager {
     pub(super) row_policy_mode: RowPolicyMode,
     pub(super) authorization_schema: Option<Arc<Schema>>,
     pub(super) authorization_schema_required: bool,
+    pub(super) authorization_context_cache: HashMap<(String, String), Arc<SchemaContext>>,
 
     /// Pending catalogue updates (schemas/lenses received via sync).
     /// SchemaManager should call take_pending_catalogue_updates() to process these.
@@ -521,6 +523,7 @@ impl QueryManager {
             row_policy_mode: RowPolicyMode::PermissiveLocal,
             authorization_schema: None,
             authorization_schema_required: false,
+            authorization_context_cache: HashMap::new(),
             pending_catalogue_updates: Vec::new(),
             subscriptions: HashMap::new(),
             next_subscription_id: 0,
@@ -574,6 +577,7 @@ impl QueryManager {
         } else {
             None
         };
+        self.authorization_context_cache.clear();
         self.authorization_schema_required = false;
         self.write_table_cache.clear();
 
@@ -589,6 +593,7 @@ impl QueryManager {
 
     pub fn set_authorization_schema(&mut self, schema: Schema) {
         self.authorization_schema = Some(Arc::new(schema));
+        self.authorization_context_cache.clear();
         self.row_policy_mode = RowPolicyMode::Enforcing;
         self.authorization_schema_required = true;
         self.mark_subscriptions_for_recompile();
@@ -597,6 +602,7 @@ impl QueryManager {
     pub fn require_authorization_schema(&mut self) {
         self.row_policy_mode = RowPolicyMode::Enforcing;
         self.authorization_schema_required = true;
+        self.authorization_context_cache.clear();
     }
 
     #[cfg(test)]
@@ -647,6 +653,7 @@ impl QueryManager {
     /// Also attempts to activate any pending schemas that may now be reachable.
     pub fn register_lens(&mut self, lens: super::super::schema_manager::lens::Lens) {
         self.schema_context.register_lens(lens);
+        self.authorization_context_cache.clear();
 
         // Try to activate pending schemas
         let activated = self.schema_context.try_activate_pending();

--- a/crates/jazz-tools/src/query_manager/manager_tests/server_subscriptions.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests/server_subscriptions.rs
@@ -206,6 +206,35 @@ fn server_authorizes_subscription_sync_scope_without_rechecking_output_scope() {
 }
 
 #[test]
+fn authorization_schema_context_is_reused_for_matching_env_and_user_branch() {
+    let schema = owned_items_schema();
+    let schema_hash = crate::query_manager::types::SchemaHash::compute(&schema);
+    let mut server_qm = QueryManager::new(SyncManager::new());
+    server_qm.set_current_schema(schema.clone(), "dev", "main");
+    server_qm.set_authorization_schema(schema.clone());
+    server_qm.set_known_schemas(std::sync::Arc::new(HashMap::from([(schema_hash, schema)])));
+
+    let (_, first_context) = server_qm
+        .authorization_schema_for_context("dev", "main")
+        .expect("authorization context should be available");
+    let (_, second_context) = server_qm
+        .authorization_schema_for_context("dev", "main")
+        .expect("authorization context should be cached");
+
+    assert!(
+        std::sync::Arc::ptr_eq(&first_context, &second_context),
+        "authorization schema context should be reused for repeated subscription settlement"
+    );
+    assert_eq!(server_qm.authorization_context_cache.len(), 1);
+
+    server_qm.set_known_schemas(std::sync::Arc::new(HashMap::new()));
+    assert!(
+        server_qm.authorization_context_cache.is_empty(),
+        "known schema changes must invalidate cached authorization contexts"
+    );
+}
+
+#[test]
 fn local_stale_recompile_failure_drops_subscription_and_reports_failure() {
     let sync_manager = SyncManager::new();
     let schema = test_schema();

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -131,7 +131,7 @@ impl QueryManager {
 
         for (hash, schema) in self.known_schemas.iter() {
             if *hash != full_hash {
-                schema_context.add_pending_schema(schema.clone());
+                schema_context.add_pending_schema_with_hash(*hash, schema.clone());
             }
         }
 
@@ -160,10 +160,10 @@ impl QueryManager {
     }
 
     pub(super) fn authorization_schema_for_context(
-        &self,
+        &mut self,
         env: &str,
         user_branch: &str,
-    ) -> Option<(Arc<Schema>, crate::schema_manager::SchemaContext)> {
+    ) -> Option<(Arc<Schema>, Arc<crate::schema_manager::SchemaContext>)> {
         if self.authorization_schema_required && self.authorization_schema.is_none() {
             return None;
         }
@@ -172,6 +172,11 @@ impl QueryManager {
             .authorization_schema
             .clone()
             .or_else(|| (!self.schema.is_empty()).then(|| self.schema.clone()))?;
+
+        let cache_key = (env.to_string(), user_branch.to_string());
+        if let Some(context) = self.authorization_context_cache.get(&cache_key) {
+            return Some((schema, context.clone()));
+        }
 
         let mut schema_context =
             crate::schema_manager::SchemaContext::new((*schema).clone(), env, user_branch);
@@ -182,19 +187,23 @@ impl QueryManager {
 
         for (hash, known_schema) in self.known_schemas.iter() {
             if *hash != schema_context.current_hash {
-                schema_context.add_pending_schema(known_schema.clone());
+                schema_context.add_pending_schema_with_hash(*hash, known_schema.clone());
             }
         }
 
         schema_context.try_activate_pending();
 
+        let schema_context = Arc::new(schema_context);
+        self.authorization_context_cache
+            .insert(cache_key, schema_context.clone());
+
         Some((schema, schema_context))
     }
 
     pub(super) fn authorization_schema_for_branch(
-        &self,
+        &mut self,
         branch_name: &BranchName,
-    ) -> Option<(Arc<Schema>, crate::schema_manager::SchemaContext)> {
+    ) -> Option<(Arc<Schema>, Arc<crate::schema_manager::SchemaContext>)> {
         if let Some(composed) = ComposedBranchName::parse(branch_name) {
             if let Some(parts) =
                 self.authorization_schema_for_context(&composed.env, &composed.user_branch)
@@ -220,22 +229,21 @@ impl QueryManager {
 
             for (hash, known_schema) in self.known_schemas.iter() {
                 if *hash != full_hash {
-                    schema_context.add_pending_schema(known_schema.clone());
+                    schema_context.add_pending_schema_with_hash(*hash, known_schema.clone());
                 }
             }
 
             schema_context.try_activate_pending();
 
-            return Some((Arc::new(target_schema), schema_context));
+            return Some((Arc::new(target_schema), Arc::new(schema_context)));
         }
 
         if self.schema_context.is_initialized() {
+            let env = self.schema_context.env.clone();
+            let user_branch = self.schema_context.user_branch.clone();
             return self
-                .authorization_schema_for_context(
-                    &self.schema_context.env,
-                    &self.schema_context.user_branch,
-                )
-                .or_else(|| Some((self.schema.clone(), self.schema_context.clone())));
+                .authorization_schema_for_context(&env, &user_branch)
+                .or_else(|| Some((self.schema.clone(), Arc::new(self.schema_context.clone()))));
         }
 
         None

--- a/crates/jazz-tools/src/query_manager/subscriptions.rs
+++ b/crates/jazz-tools/src/query_manager/subscriptions.rs
@@ -557,6 +557,7 @@ impl QueryManager {
     /// This enables lazy branch activation when rows arrive with unknown branches.
     pub fn set_known_schemas(&mut self, schemas: Arc<HashMap<SchemaHash, Schema>>) {
         self.known_schemas = schemas;
+        self.authorization_context_cache.clear();
     }
 
     /// Add a branch → schema hash mapping (for server-mode schema activation).

--- a/crates/jazz-tools/src/query_manager/types/descriptor.rs
+++ b/crates/jazz-tools/src/query_manager/types/descriptor.rs
@@ -241,7 +241,7 @@ impl TupleDescriptor {
             .iter()
             .flat_map(|e| e.descriptor.columns.clone())
             .collect();
-        RowDescriptor { columns }
+        RowDescriptor::new(columns)
     }
 
     /// Get iterator over elements.

--- a/crates/jazz-tools/src/query_manager/types/schema.rs
+++ b/crates/jazz-tools/src/query_manager/types/schema.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::sync::OnceLock;
 
 use internment::Intern;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -293,15 +294,34 @@ impl ColumnDescriptor {
 }
 
 /// Descriptor for a row's schema, defining column order and types.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct RowDescriptor {
     pub columns: Vec<ColumnDescriptor>,
+    #[serde(skip)]
+    content_hash_cache: OnceLock<[u8; 32]>,
+}
+
+impl PartialEq for RowDescriptor {
+    fn eq(&self, other: &Self) -> bool {
+        self.columns == other.columns
+    }
+}
+
+impl Eq for RowDescriptor {}
+
+impl From<Vec<ColumnDescriptor>> for RowDescriptor {
+    fn from(columns: Vec<ColumnDescriptor>) -> Self {
+        Self::new(columns)
+    }
 }
 
 impl RowDescriptor {
     pub fn new(columns: Vec<ColumnDescriptor>) -> Self {
-        Self { columns }
+        Self {
+            columns,
+            content_hash_cache: OnceLock::new(),
+        }
     }
 
     /// Find column index by name.
@@ -336,14 +356,16 @@ impl RowDescriptor {
     pub fn combine(descriptors: &[RowDescriptor]) -> Self {
         let columns: Vec<ColumnDescriptor> =
             descriptors.iter().flat_map(|d| d.columns.clone()).collect();
-        Self { columns }
+        Self::new(columns)
     }
 
     /// Compute a content hash of this descriptor, preserving declared column order.
     pub fn content_hash(&self) -> [u8; 32] {
-        let mut hasher = blake3::Hasher::new();
-        super::branch::hash_row_descriptor(&mut hasher, self);
-        *hasher.finalize().as_bytes()
+        *self.content_hash_cache.get_or_init(|| {
+            let mut hasher = blake3::Hasher::new();
+            super::branch::hash_row_descriptor(&mut hasher, self);
+            *hasher.finalize().as_bytes()
+        })
     }
 }
 

--- a/crates/jazz-tools/src/query_manager/types/schema.rs
+++ b/crates/jazz-tools/src/query_manager/types/schema.rs
@@ -294,12 +294,18 @@ impl ColumnDescriptor {
 }
 
 /// Descriptor for a row's schema, defining column order and types.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct RowDescriptor {
     pub columns: Vec<ColumnDescriptor>,
     #[serde(skip)]
     content_hash_cache: OnceLock<[u8; 32]>,
+}
+
+impl Clone for RowDescriptor {
+    fn clone(&self) -> Self {
+        Self::new(self.columns.clone())
+    }
 }
 
 impl PartialEq for RowDescriptor {

--- a/crates/jazz-tools/src/query_manager/types/tests.rs
+++ b/crates/jazz-tools/src/query_manager/types/tests.rs
@@ -784,6 +784,26 @@ fn row_descriptor_content_hash() {
     );
 }
 
+#[test]
+fn cloned_row_descriptor_recomputes_content_hash_after_mutation() {
+    let desc = RowDescriptor::new(vec![
+        ColumnDescriptor::new("id", ColumnType::Uuid),
+        ColumnDescriptor::new("name", ColumnType::Text),
+    ]);
+    let original_hash = desc.content_hash();
+
+    let mut cloned = desc.clone();
+    cloned
+        .columns
+        .push(ColumnDescriptor::new("$canEdit", ColumnType::Boolean));
+
+    assert_ne!(
+        original_hash,
+        cloned.content_hash(),
+        "A cloned descriptor must not reuse a stale cached hash after its columns change"
+    );
+}
+
 // ========================================================================
 // ComposedBranchName Tests
 // ========================================================================

--- a/crates/jazz-tools/src/query_manager/writes.rs
+++ b/crates/jazz-tools/src/query_manager/writes.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use crate::batch_fate::BatchMode;
 use crate::metadata::{DeleteKind, RowProvenance, SYSTEM_PRINCIPAL_ID, row_provenance_metadata};
 use crate::object::{BranchName, ObjectId};
+use crate::row_format::compiled_row_layout;
 use crate::row_histories::{
     ApplyRowBatchWithContext, BatchId, QueryRowBatch, RowHistoryError, RowState,
     RowVisibilityChange, StoredRowBatch, apply_row_batch, apply_row_batch_with_context,
@@ -39,6 +40,7 @@ pub struct RowBranchWrite<'a> {
 struct PreparedUpdateWrite {
     new_data: Vec<u8>,
     descriptor: Arc<RowDescriptor>,
+    row_layout: Arc<crate::row_format::CompiledRowLayout>,
 }
 
 struct PreparedUpdateCommit<'a> {
@@ -101,6 +103,7 @@ impl QueryManager {
             .ok_or(QueryError::TableNotFound(table_name))?;
         let entry = Arc::new(WriteTableCacheEntry {
             descriptor: Arc::new(table_schema.columns.clone()),
+            row_layout: compiled_row_layout(&table_schema.columns),
             row_locator: RowLocator {
                 table: table_name.as_str().to_string().into(),
                 origin_schema_hash: Some(schema_hash),
@@ -798,6 +801,7 @@ impl QueryManager {
         Ok(PreparedUpdateWrite {
             new_data,
             descriptor: table_write.descriptor.clone(),
+            row_layout: table_write.row_layout.clone(),
         })
     }
 
@@ -1058,12 +1062,13 @@ impl QueryManager {
         self.persist_row_locator(storage, object_id, &table_write.row_locator);
 
         // Add commit with row data
-        let index_mutations = Self::index_mutations_for_insert_on_branch(
+        let index_mutations = Self::index_mutations_for_insert_on_branch_with_layout(
             table,
             &current_branch,
             object_id,
             &data,
             descriptor,
+            &table_write.row_layout,
         );
         let row = self.authored_row_batch(
             object_id,
@@ -1253,8 +1258,14 @@ impl QueryManager {
         self.persist_row_locator(storage, object_id, &table_write.row_locator);
 
         // Add commit with row data to specified branch
-        let index_mutations =
-            Self::index_mutations_for_insert_on_branch(table, branch, object_id, &data, descriptor);
+        let index_mutations = Self::index_mutations_for_insert_on_branch_with_layout(
+            table,
+            branch,
+            object_id,
+            &data,
+            descriptor,
+            &table_write.row_layout,
+        );
         let row = self.authored_row_batch(
             object_id,
             branch,
@@ -1394,8 +1405,14 @@ impl QueryManager {
 
         self.persist_row_locator(storage, object_id, &table_write.row_locator);
 
-        let index_mutations =
-            Self::index_mutations_for_insert_on_branch(table, branch, object_id, &data, descriptor);
+        let index_mutations = Self::index_mutations_for_insert_on_branch_with_layout(
+            table,
+            branch,
+            object_id,
+            &data,
+            descriptor,
+            &table_write.row_layout,
+        );
         let row = self.authored_row_batch(
             object_id,
             branch,
@@ -1536,10 +1553,13 @@ impl QueryManager {
     }
 
     fn local_write_authorization_context(
-        &self,
+        &mut self,
         branch: &str,
         session: Option<&Session>,
-    ) -> Option<(std::sync::Arc<Schema>, crate::schema_manager::SchemaContext)> {
+    ) -> Option<(
+        std::sync::Arc<Schema>,
+        std::sync::Arc<crate::schema_manager::SchemaContext>,
+    )> {
         self.local_subscription_uses_explicit_authorization(session)
             .then(|| self.authorization_schema_for_branch(&BranchName::new(branch)))
             .flatten()
@@ -2147,12 +2167,13 @@ impl QueryManager {
                 prepared.descriptor.as_ref(),
             )
         } else {
-            Self::index_mutations_for_insert_on_branch(
+            Self::index_mutations_for_insert_on_branch_with_layout(
                 table,
                 branch,
                 id,
                 &prepared.new_data,
                 prepared.descriptor.as_ref(),
+                &prepared.row_layout,
             )
         };
         let batch_id = self.commit_prepared_update_write(

--- a/crates/jazz-tools/src/row_format.rs
+++ b/crates/jazz-tools/src/row_format.rs
@@ -619,7 +619,7 @@ pub fn decode_column(
     decode_column_with_layout(descriptor, layout.as_ref(), data, col_index)
 }
 
-fn decode_column_with_layout(
+pub(crate) fn decode_column_with_layout(
     descriptor: &RowDescriptor,
     layout: &CompiledRowLayout,
     data: &[u8],

--- a/crates/jazz-tools/src/schema_manager/context.rs
+++ b/crates/jazz-tools/src/schema_manager/context.rs
@@ -373,6 +373,11 @@ impl SchemaContext {
     /// The schema will become live once a lens path to current_schema is available.
     pub fn add_pending_schema(&mut self, schema: Schema) {
         let hash = SchemaHash::compute(&schema);
+        self.add_pending_schema_with_hash(hash, schema);
+    }
+
+    /// Add a schema to the pending set when the caller already knows its hash.
+    pub fn add_pending_schema_with_hash(&mut self, hash: SchemaHash, schema: Schema) {
         // Don't add if already live or current
         if !self.is_live(&hash) {
             self.pending_schemas.insert(hash, schema);


### PR DESCRIPTION
## What

Speeds up server subscription settlement when many same-context subscriptions evaluate row-level select policies over large schemas.

Changes:
- cache authorization `SchemaContext`s per `(env, user_branch)` in `QueryManager`
- avoid recomputing known schema hashes when adding pending schemas to an authorization context
- cache `RowDescriptor::content_hash()` internally so repeated row layout lookups do not re-hash wide descriptors
- thread cached compiled row layouts through hot write/index insert paths
- expand `server_authorization_scope_benchmark` with large-schema and many-subscription repros
- add a regression test proving authorization context reuse and invalidation

## Why

The reload/holder wait profile showed server CPU dominated by subscription settlement, especially repeated schema hashing and authorization schema reconstruction. The remaining hot path after authorization context caching was policy-side `decode_column -> compiled_row_layout -> hash_row_descriptor -> blake3`; caching the descriptor content hash removes that repeated BLAKE3 work.

## Benchmarks

Large repro: `server_authorization_scope/many_subscriptions/25_subscriptions_500_schemas_256_extra_columns/1000`

- before this branch: ~3.6757s
- after authorization context reuse: ~2.3005s
- after descriptor hash caching: ~0.3000s

## Validation

- `cargo check -p jazz-tools --lib`
- `cargo test -p jazz-tools query_manager::manager_tests::server_subscriptions`
- `cargo test -p jazz-tools row_descriptor_content_hash`
- `cargo bench -p jazz-tools --bench server_authorization_scope_benchmark -- --warm-up-time 1 --measurement-time 2 server_authorization_scope/many_subscriptions`
- pre-commit hook: clippy + rustfmt

## Compatibility

Checked against https://github.com/garden-co/jazz/pull/767: this patch applies cleanly on PR 767 head (`0aaefd173`) and `cargo check -p jazz-tools --lib` passes in that scratch worktree. The only shared file is `crates/jazz-tools/src/query_manager/manager.rs`, with non-overlapping hunks.
