### PR TITLE
Filter scoped batch settlements

### DIFF
--- a/.changeset/filter-scoped-batch-settlements.md
+++ b/.changeset/filter-scoped-batch-settlements.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Filter replayed batch settlement members to each receiving client's scope.

--- a/crates/jazz-tools/src/runtime_core/ticks.rs
+++ b/crates/jazz-tools/src/runtime_core/ticks.rs
@@ -119,14 +119,15 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                                 .enqueue_row_visibility_change(update),
                             Ok(None) => {}
                             Err(error) => {
-                                tracing::warn!(
+                                tracing::debug!(
                                     object_id = %member.object_id,
                                     branch_name = %member.branch_name,
                                     batch_id = ?member.batch_id,
                                     ?acked_tier,
                                     ?error,
-                                    "failed to apply batch settlement tier to local row"
+                                    "ignoring batch settlement tier for local row batch that is not present"
                                 );
+                                continue;
                             }
                         }
                         self.durability.record_ack(

--- a/crates/jazz-tools/src/sync_manager/forwarding.rs
+++ b/crates/jazz-tools/src/sync_manager/forwarding.rs
@@ -84,6 +84,9 @@ impl SyncManager {
         client_id: ClientId,
         settlement: BatchSettlement,
     ) {
+        let Some(settlement) = self.batch_settlement_for_client(client_id, &settlement) else {
+            return;
+        };
         self.outbox.push(OutboxEntry {
             destination: Destination::Client(client_id),
             payload: SyncPayload::BatchSettlement { settlement },

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -461,10 +461,79 @@ impl SyncManager {
             let settlement = self
                 .load_batch_settlement_by_batch_id_from_storage(storage, batch_id)
                 .unwrap_or(BatchSettlement::Missing { batch_id });
+            let settlement = match destination {
+                Destination::Client(client_id) => {
+                    let Some(settlement) = self.batch_settlement_for_client(client_id, &settlement)
+                    else {
+                        continue;
+                    };
+                    settlement
+                }
+                Destination::Server(_) => settlement,
+            };
             self.outbox.push(OutboxEntry {
                 destination: destination.clone(),
                 payload: SyncPayload::BatchSettlement { settlement },
             });
+        }
+    }
+
+    pub(super) fn batch_settlement_for_client(
+        &self,
+        client_id: ClientId,
+        settlement: &BatchSettlement,
+    ) -> Option<BatchSettlement> {
+        let client = self.clients.get(&client_id)?;
+        match settlement {
+            BatchSettlement::DurableDirect {
+                batch_id,
+                confirmed_tier,
+                visible_members,
+            } => {
+                let visible_members = visible_members
+                    .iter()
+                    .filter(|member| {
+                        let key =
+                            RowBatchKey::new(member.object_id, member.branch_name, member.batch_id);
+                        self.row_batch_interest
+                            .get(&key)
+                            .is_some_and(|clients| clients.contains(&client_id))
+                            || client.is_in_scope(member.object_id, &member.branch_name)
+                    })
+                    .cloned()
+                    .collect::<Vec<_>>();
+                (!visible_members.is_empty()).then_some(BatchSettlement::DurableDirect {
+                    batch_id: *batch_id,
+                    confirmed_tier: *confirmed_tier,
+                    visible_members,
+                })
+            }
+            BatchSettlement::AcceptedTransaction {
+                batch_id,
+                confirmed_tier,
+                visible_members,
+            } => {
+                let visible_members = visible_members
+                    .iter()
+                    .filter(|member| {
+                        let key =
+                            RowBatchKey::new(member.object_id, member.branch_name, member.batch_id);
+                        self.row_batch_interest
+                            .get(&key)
+                            .is_some_and(|clients| clients.contains(&client_id))
+                            || client.is_in_scope(member.object_id, &member.branch_name)
+                    })
+                    .cloned()
+                    .collect::<Vec<_>>();
+                (!visible_members.is_empty()).then_some(BatchSettlement::AcceptedTransaction {
+                    batch_id: *batch_id,
+                    confirmed_tier: *confirmed_tier,
+                    visible_members,
+                })
+            }
+            BatchSettlement::Missing { .. } | BatchSettlement::Rejected { .. } => {
+                Some(settlement.clone())
+            }
         }
     }
 
@@ -762,10 +831,7 @@ impl SyncManager {
         }
         if matches!(settlement, BatchSettlement::DurableDirect { .. }) {
             if let Some(client_id) = origin_client_id {
-                self.outbox.push(OutboxEntry {
-                    destination: Destination::Client(client_id),
-                    payload: SyncPayload::BatchSettlement { settlement },
-                });
+                self.queue_batch_settlement_to_client(client_id, settlement);
             }
             return;
         }
@@ -1102,12 +1168,12 @@ impl SyncManager {
                     }
                 };
                 for cid in interested {
-                    self.outbox.push(OutboxEntry {
-                        destination: Destination::Client(cid),
-                        payload: SyncPayload::BatchSettlement {
-                            settlement: settlement.clone(),
-                        },
-                    });
+                    if let Some(settlement) = self.batch_settlement_for_client(cid, &settlement) {
+                        self.outbox.push(OutboxEntry {
+                            destination: Destination::Client(cid),
+                            payload: SyncPayload::BatchSettlement { settlement },
+                        });
+                    }
                 }
             }
             SyncPayload::BatchSettlementNeeded { batch_ids } => {

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -483,7 +483,7 @@ impl SyncManager {
         client_id: ClientId,
         settlement: &BatchSettlement,
     ) -> Option<BatchSettlement> {
-        let client = self.clients.get(&client_id)?;
+        self.clients.get(&client_id)?;
         match settlement {
             BatchSettlement::DurableDirect {
                 batch_id,
@@ -498,7 +498,6 @@ impl SyncManager {
                         self.row_batch_interest
                             .get(&key)
                             .is_some_and(|clients| clients.contains(&client_id))
-                            || client.is_in_scope(member.object_id, &member.branch_name)
                     })
                     .cloned()
                     .collect::<Vec<_>>();
@@ -521,7 +520,6 @@ impl SyncManager {
                         self.row_batch_interest
                             .get(&key)
                             .is_some_and(|clients| clients.contains(&client_id))
-                            || client.is_in_scope(member.object_id, &member.branch_name)
                     })
                     .cloned()
                     .collect::<Vec<_>>();
@@ -1121,10 +1119,7 @@ impl SyncManager {
                         },
                     });
                     if let Some(settlement) = persisted_settlement.clone() {
-                        self.outbox.push(OutboxEntry {
-                            destination: Destination::Client(cid),
-                            payload: SyncPayload::BatchSettlement { settlement },
-                        });
+                        self.queue_batch_settlement_to_client(cid, settlement);
                     }
                 }
             }
@@ -1153,13 +1148,6 @@ impl SyncManager {
                             if let Some(clients) = self.row_batch_interest.get(&key) {
                                 interested.extend(clients.iter().copied());
                             }
-                            interested.extend(self.clients.iter().filter_map(
-                                |(client_id, client)| {
-                                    client
-                                        .is_in_scope(member.object_id, &member.branch_name)
-                                        .then_some(*client_id)
-                                },
-                            ));
                         }
                         interested
                     }
@@ -1407,6 +1395,10 @@ impl SyncManager {
                         if let Some(existing_history_row) = existing_history_row.as_ref()
                             && Self::matches_replayed_row_batch(existing_history_row, row)
                         {
+                            self.row_batch_interest
+                                .entry(RowBatchKey::from_row(row))
+                                .or_default()
+                                .insert(client_id);
                             self.try_accept_completed_sealed_batch_from_client(
                                 storage,
                                 client_id,

--- a/crates/jazz-tools/src/sync_manager/tests/settlements.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/settlements.rs
@@ -195,12 +195,12 @@ fn batch_settlement_needed_returns_current_accepted_transaction() {
 }
 
 #[test]
-fn batch_settlement_needed_filters_visible_members_to_client_scope() {
+fn batch_settlement_needed_filters_visible_members_to_sent_row_batches() {
     let mut sm = SyncManager::new();
     let mut io = MemoryStorage::new();
     let client_id = ClientId::new();
-    let visible_row_id = ObjectId::new();
-    let out_of_scope_row_id = ObjectId::new();
+    let sent_row_id = ObjectId::new();
+    let scoped_but_unsent_row_id = ObjectId::new();
     let batch_id = BatchId::new();
     let branch_name = BranchName::new("main");
     let settlement = BatchSettlement::DurableDirect {
@@ -208,12 +208,12 @@ fn batch_settlement_needed_filters_visible_members_to_client_scope() {
         confirmed_tier: DurabilityTier::GlobalServer,
         visible_members: vec![
             VisibleBatchMember {
-                object_id: visible_row_id,
+                object_id: sent_row_id,
                 branch_name,
                 batch_id,
             },
             VisibleBatchMember {
-                object_id: out_of_scope_row_id,
+                object_id: scoped_but_unsent_row_id,
                 branch_name,
                 batch_id,
             },
@@ -229,10 +229,17 @@ fn batch_settlement_needed_filters_visible_members_to_client_scope() {
         &io,
         client_id,
         QueryId(1),
-        HashSet::from([(visible_row_id, branch_name)]),
+        HashSet::from([
+            (sent_row_id, branch_name),
+            (scoped_but_unsent_row_id, branch_name),
+        ]),
         None,
     );
     sm.take_outbox();
+    sm.row_batch_interest
+        .entry(RowBatchKey::new(sent_row_id, branch_name, batch_id))
+        .or_default()
+        .insert(client_id);
 
     sm.process_from_client(
         &mut io,
@@ -251,7 +258,7 @@ fn batch_settlement_needed_filters_visible_members_to_client_scope() {
             batch_id,
             confirmed_tier: DurabilityTier::GlobalServer,
             visible_members: vec![VisibleBatchMember {
-                object_id: visible_row_id,
+                object_id: sent_row_id,
                 branch_name,
                 batch_id,
             }],
@@ -399,13 +406,13 @@ fn batch_settlement_needed_returns_persisted_rejected_without_visible_rows() {
 }
 
 #[test]
-fn batch_settlement_from_server_filters_visible_members_to_client_scope() {
+fn batch_settlement_from_server_filters_visible_members_to_sent_row_batches() {
     let mut sm = SyncManager::new();
     let mut io = MemoryStorage::new();
     let client_id = ClientId::new();
     let server_id = ServerId::new();
-    let visible_row_id = ObjectId::new();
-    let out_of_scope_row_id = ObjectId::new();
+    let sent_row_id = ObjectId::new();
+    let scoped_but_unsent_row_id = ObjectId::new();
     let batch_id = BatchId::new();
     let branch_name = BranchName::new("main");
 
@@ -418,10 +425,17 @@ fn batch_settlement_from_server_filters_visible_members_to_client_scope() {
         &io,
         client_id,
         QueryId(1),
-        HashSet::from([(visible_row_id, branch_name)]),
+        HashSet::from([
+            (sent_row_id, branch_name),
+            (scoped_but_unsent_row_id, branch_name),
+        ]),
         None,
     );
     sm.take_outbox();
+    sm.row_batch_interest
+        .entry(RowBatchKey::new(sent_row_id, branch_name, batch_id))
+        .or_default()
+        .insert(client_id);
 
     sm.process_from_server(
         &mut io,
@@ -432,12 +446,12 @@ fn batch_settlement_from_server_filters_visible_members_to_client_scope() {
                 confirmed_tier: DurabilityTier::GlobalServer,
                 visible_members: vec![
                     VisibleBatchMember {
-                        object_id: visible_row_id,
+                        object_id: sent_row_id,
                         branch_name,
                         batch_id,
                     },
                     VisibleBatchMember {
-                        object_id: out_of_scope_row_id,
+                        object_id: scoped_but_unsent_row_id,
                         branch_name,
                         batch_id,
                     },
@@ -464,7 +478,7 @@ fn batch_settlement_from_server_filters_visible_members_to_client_scope() {
             batch_id,
             confirmed_tier: DurabilityTier::GlobalServer,
             visible_members: vec![VisibleBatchMember {
-                object_id: visible_row_id,
+                object_id: sent_row_id,
                 branch_name,
                 batch_id,
             }],

--- a/crates/jazz-tools/src/sync_manager/tests/settlements.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/settlements.rs
@@ -159,6 +159,15 @@ fn batch_settlement_needed_returns_current_accepted_transaction() {
     sm.take_outbox();
     seed_visible_row(&mut sm, &mut io, "users", row.clone());
     persist_visible_row_settlement(&mut io, row_id, &row);
+    set_client_query_scope(
+        &mut sm,
+        &io,
+        client_id,
+        QueryId(1),
+        HashSet::from([(row_id, BranchName::new("main"))]),
+        None,
+    );
+    sm.take_outbox();
 
     sm.process_from_client(
         &mut io,
@@ -182,6 +191,119 @@ fn batch_settlement_needed_returns_current_accepted_transaction() {
                 batch_id: row.batch_id,
             }],
         }
+    )));
+}
+
+#[test]
+fn batch_settlement_needed_filters_visible_members_to_client_scope() {
+    let mut sm = SyncManager::new();
+    let mut io = MemoryStorage::new();
+    let client_id = ClientId::new();
+    let visible_row_id = ObjectId::new();
+    let out_of_scope_row_id = ObjectId::new();
+    let batch_id = BatchId::new();
+    let branch_name = BranchName::new("main");
+    let settlement = BatchSettlement::DurableDirect {
+        batch_id,
+        confirmed_tier: DurabilityTier::GlobalServer,
+        visible_members: vec![
+            VisibleBatchMember {
+                object_id: visible_row_id,
+                branch_name,
+                batch_id,
+            },
+            VisibleBatchMember {
+                object_id: out_of_scope_row_id,
+                branch_name,
+                batch_id,
+            },
+        ],
+    };
+
+    add_client(&mut sm, &io, client_id);
+    sm.take_outbox();
+    io.upsert_authoritative_batch_settlement(&settlement)
+        .unwrap();
+    set_client_query_scope(
+        &mut sm,
+        &io,
+        client_id,
+        QueryId(1),
+        HashSet::from([(visible_row_id, branch_name)]),
+        None,
+    );
+    sm.take_outbox();
+
+    sm.process_from_client(
+        &mut io,
+        client_id,
+        SyncPayload::BatchSettlementNeeded {
+            batch_ids: vec![batch_id],
+        },
+    );
+
+    assert!(sm.take_outbox().into_iter().any(|entry| matches!(
+        entry,
+        OutboxEntry {
+            destination: Destination::Client(id),
+            payload: SyncPayload::BatchSettlement { settlement },
+        } if id == client_id && settlement == BatchSettlement::DurableDirect {
+            batch_id,
+            confirmed_tier: DurabilityTier::GlobalServer,
+            visible_members: vec![VisibleBatchMember {
+                object_id: visible_row_id,
+                branch_name,
+                batch_id,
+            }],
+        }
+    )));
+}
+
+#[test]
+fn batch_settlement_needed_returns_full_visible_members_to_server() {
+    let mut sm = SyncManager::new();
+    let mut io = MemoryStorage::new();
+    let server_id = ServerId::new();
+    let first_row_id = ObjectId::new();
+    let second_row_id = ObjectId::new();
+    let batch_id = BatchId::new();
+    let branch_name = BranchName::new("main");
+    let settlement = BatchSettlement::DurableDirect {
+        batch_id,
+        confirmed_tier: DurabilityTier::GlobalServer,
+        visible_members: vec![
+            VisibleBatchMember {
+                object_id: first_row_id,
+                branch_name,
+                batch_id,
+            },
+            VisibleBatchMember {
+                object_id: second_row_id,
+                branch_name,
+                batch_id,
+            },
+        ],
+    };
+
+    add_server(&mut sm, &io, server_id);
+    sm.take_outbox();
+    io.upsert_authoritative_batch_settlement(&settlement)
+        .unwrap();
+
+    sm.process_from_server(
+        &mut io,
+        server_id,
+        SyncPayload::BatchSettlementNeeded {
+            batch_ids: vec![batch_id],
+        },
+    );
+
+    assert!(sm.take_outbox().into_iter().any(|entry| matches!(
+        entry,
+        OutboxEntry {
+            destination: Destination::Server(id),
+            payload: SyncPayload::BatchSettlement { settlement: returned },
+        } if id == server_id && returned == settlement
     )));
 }
 
@@ -274,6 +396,80 @@ fn batch_settlement_needed_returns_persisted_rejected_without_visible_rows() {
             payload: SyncPayload::BatchSettlement { settlement: returned },
         } if id == client_id && returned == settlement
     )));
+}
+
+#[test]
+fn batch_settlement_from_server_filters_visible_members_to_client_scope() {
+    let mut sm = SyncManager::new();
+    let mut io = MemoryStorage::new();
+    let client_id = ClientId::new();
+    let server_id = ServerId::new();
+    let visible_row_id = ObjectId::new();
+    let out_of_scope_row_id = ObjectId::new();
+    let batch_id = BatchId::new();
+    let branch_name = BranchName::new("main");
+
+    add_client(&mut sm, &io, client_id);
+    add_server(&mut sm, &io, server_id);
+    sm.take_outbox();
+
+    set_client_query_scope(
+        &mut sm,
+        &io,
+        client_id,
+        QueryId(1),
+        HashSet::from([(visible_row_id, branch_name)]),
+        None,
+    );
+    sm.take_outbox();
+
+    sm.process_from_server(
+        &mut io,
+        server_id,
+        SyncPayload::BatchSettlement {
+            settlement: BatchSettlement::DurableDirect {
+                batch_id,
+                confirmed_tier: DurabilityTier::GlobalServer,
+                visible_members: vec![
+                    VisibleBatchMember {
+                        object_id: visible_row_id,
+                        branch_name,
+                        batch_id,
+                    },
+                    VisibleBatchMember {
+                        object_id: out_of_scope_row_id,
+                        branch_name,
+                        batch_id,
+                    },
+                ],
+            },
+        },
+    );
+
+    let settlements = sm
+        .take_outbox()
+        .into_iter()
+        .filter_map(|entry| match entry {
+            OutboxEntry {
+                destination: Destination::Client(id),
+                payload: SyncPayload::BatchSettlement { settlement },
+            } if id == client_id => Some(settlement),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        settlements,
+        vec![BatchSettlement::DurableDirect {
+            batch_id,
+            confirmed_tier: DurabilityTier::GlobalServer,
+            visible_members: vec![VisibleBatchMember {
+                object_id: visible_row_id,
+                branch_name,
+                batch_id,
+            }],
+        }]
+    );
 }
 
 #[test]

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
@@ -792,13 +792,13 @@ export function TableDataGrid() {
       if (event.key !== "Escape") return;
       if (mutationState) {
         setMutationState(null);
-      } else if (selectedRowId) {
+      } else {
         setSelectedRowId(null);
       }
     }
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [mutationState, selectedRowId]);
+  }, [mutationState]);
 
   return (
     <section className={styles.container}>


### PR DESCRIPTION
## What changed

- Filter durable direct and accepted transaction batch settlements per receiving client.
- Tighten client delivery to row batches the client was explicitly sent or marked interested in, rather than broad query scope.
- Route the shared client settlement queue and reconciliation replies through the same client filter while keeping server-to-server settlement replies complete.
- Downgrade missing local row-batch handling during runtime settlement apply to a debug log.
- Add regression coverage for normal fanout, reconciliation replies, and exact-history replay.
- Add a patch changeset for `jazz-tools`.

## Why

Large batch settlements were replayed wholesale to clients that were only scoped to a subset of the visible members. Those clients could then try to patch durability onto row histories they never received, producing `ObjectNotFound` warning spam in browser WASM clients.

Settlements should upgrade durability for row batches the client actually has, not act as a visibility announcement for every object in query scope.

## Follow-up needed

The runtime-side missing-row case is currently tolerated by logging at debug level and skipping that member. That prevents warning floods for partially scoped clients, but it should be investigated further: ideally clients should not receive settlement members for row histories they never received, and any remaining missing-row cases should be understood rather than hidden as the final design.

## Validation

- `cargo test -p jazz-tools sync_manager::tests::settlements -- --nocapture`
- `cargo test -p jazz-tools --lib`
- `pnpm --dir packages/inspector test`
- `pnpm lint`
