### PR TITLE
Fix offline Cloud dev startup

### DIFF
--- a/.changeset/offline-cloud-dev-startup.md
+++ b/.changeset/offline-cloud-dev-startup.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Keep dev plugins running when the initial schema auto-push cannot reach a configured remote Jazz server. The plugins now warn and continue with the configured app and server URL, while still failing on schema, auth, or server rejections.

--- a/packages/jazz-tools/src/dev/managed-runtime.test.ts
+++ b/packages/jazz-tools/src/dev/managed-runtime.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { join } from "node:path";
+import { createTempRootTracker, todoSchema } from "./test-helpers.js";
+import * as devServer from "./dev-server.js";
+import * as schemaWatcher from "./schema-watcher.js";
+import { ManagedDevRuntime } from "./managed-runtime.js";
+import { writeFile } from "node:fs/promises";
+
+const tempRoots = createTempRootTracker();
+
+const originalJazzAppId = process.env.VITE_JAZZ_APP_ID;
+const originalJazzServerUrl = process.env.VITE_JAZZ_SERVER_URL;
+const originalAdminSecret = process.env.JAZZ_ADMIN_SECRET;
+
+function makeRuntime(): ManagedDevRuntime {
+  return new ManagedDevRuntime({
+    appId: "VITE_JAZZ_APP_ID",
+    serverUrl: "VITE_JAZZ_SERVER_URL",
+  });
+}
+
+function makeFetchFailedError(code: string): TypeError & { cause?: unknown } {
+  const error = new TypeError("fetch failed") as TypeError & { cause?: unknown };
+  error.cause = Object.assign(new Error(`getaddrinfo ${code} v2.sync.jazz.tools`), {
+    code,
+    hostname: "v2.sync.jazz.tools",
+  });
+  return error;
+}
+
+beforeEach(() => {
+  delete process.env.VITE_JAZZ_APP_ID;
+  delete process.env.VITE_JAZZ_SERVER_URL;
+  delete process.env.JAZZ_ADMIN_SECRET;
+});
+
+afterEach(async () => {
+  await tempRoots.cleanup();
+  vi.restoreAllMocks();
+
+  if (originalJazzAppId === undefined) {
+    delete process.env.VITE_JAZZ_APP_ID;
+  } else {
+    process.env.VITE_JAZZ_APP_ID = originalJazzAppId;
+  }
+
+  if (originalJazzServerUrl === undefined) {
+    delete process.env.VITE_JAZZ_SERVER_URL;
+  } else {
+    process.env.VITE_JAZZ_SERVER_URL = originalJazzServerUrl;
+  }
+
+  if (originalAdminSecret === undefined) {
+    delete process.env.JAZZ_ADMIN_SECRET;
+  } else {
+    process.env.JAZZ_ADMIN_SECRET = originalAdminSecret;
+  }
+});
+
+describe("ManagedDevRuntime", () => {
+  it("keeps env-driven Cloud startup alive when the initial schema push cannot reach the server", async () => {
+    const schemaDir = await tempRoots.create("jazz-managed-offline-cloud-");
+    await writeFile(join(schemaDir, "schema.ts"), todoSchema());
+
+    process.env.VITE_JAZZ_APP_ID = "00000000-0000-0000-0000-000000000777";
+    process.env.VITE_JAZZ_SERVER_URL = "https://v2.sync.jazz.tools/";
+    process.env.JAZZ_ADMIN_SECRET = "cloud-admin-secret";
+
+    const startLocalJazzServer = vi.spyOn(devServer, "startLocalJazzServer");
+    vi.spyOn(devServer, "pushSchemaCatalogue").mockRejectedValue(makeFetchFailedError("ENOTFOUND"));
+    const watchSchema = vi.spyOn(schemaWatcher, "watchSchema").mockReturnValue({
+      close: vi.fn(),
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const runtime = makeRuntime();
+    const managed = await runtime.initialize({ schemaDir });
+
+    expect(managed).toMatchObject({
+      appId: "00000000-0000-0000-0000-000000000777",
+      serverUrl: "https://v2.sync.jazz.tools/",
+      adminSecret: "cloud-admin-secret",
+    });
+    expect(startLocalJazzServer).not.toHaveBeenCalled();
+    expect(watchSchema).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appId: "00000000-0000-0000-0000-000000000777",
+        serverUrl: "https://v2.sync.jazz.tools/",
+        adminSecret: "cloud-admin-secret",
+        schemaDir,
+      }),
+    );
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "schema auto-push skipped because https://v2.sync.jazz.tools/ is unreachable",
+      ),
+    );
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("comment out VITE_JAZZ_SERVER_URL"));
+
+    await runtime.dispose();
+  });
+
+  it("still fails env-driven startup when the initial schema push reaches the server and is rejected", async () => {
+    const schemaDir = await tempRoots.create("jazz-managed-cloud-rejected-");
+    await writeFile(join(schemaDir, "schema.ts"), todoSchema());
+
+    process.env.VITE_JAZZ_APP_ID = "00000000-0000-0000-0000-000000000888";
+    process.env.VITE_JAZZ_SERVER_URL = "https://v2.sync.jazz.tools/";
+    process.env.JAZZ_ADMIN_SECRET = "cloud-admin-secret";
+
+    vi.spyOn(devServer, "pushSchemaCatalogue").mockRejectedValue(
+      new Error("Schema publish failed: 401 Unauthorized"),
+    );
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(makeRuntime().initialize({ schemaDir })).rejects.toThrow(
+      "Schema publish failed: 401 Unauthorized",
+    );
+  });
+
+  it("does not skip non-fetch errors just because their message contains a network error code", async () => {
+    const schemaDir = await tempRoots.create("jazz-managed-cloud-non-fetch-error-");
+    await writeFile(join(schemaDir, "schema.ts"), todoSchema());
+
+    process.env.VITE_JAZZ_APP_ID = "00000000-0000-0000-0000-000000000999";
+    process.env.VITE_JAZZ_SERVER_URL = "https://v2.sync.jazz.tools/";
+    process.env.JAZZ_ADMIN_SECRET = "cloud-admin-secret";
+
+    vi.spyOn(devServer, "pushSchemaCatalogue").mockRejectedValue(
+      new Error("getaddrinfo ENOTFOUND v2.sync.jazz.tools"),
+    );
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(makeRuntime().initialize({ schemaDir })).rejects.toThrow(
+      "getaddrinfo ENOTFOUND v2.sync.jazz.tools",
+    );
+  });
+});

--- a/packages/jazz-tools/src/dev/managed-runtime.ts
+++ b/packages/jazz-tools/src/dev/managed-runtime.ts
@@ -10,6 +10,30 @@ function defaultPersistentDataDir(projectRoot: string): string {
 
 const LOG_PREFIX = "[jazz]";
 
+function isSchemaPushNetworkError(error: unknown): boolean {
+  return error instanceof TypeError && error.message === "fetch failed";
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function warnInitialSchemaPushSkipped(opts: {
+  serverUrl: string;
+  envServerUrlKey: string | null;
+  error: unknown;
+}): void {
+  const fallback =
+    opts.envServerUrlKey === null
+      ? "remove the remote server URL option"
+      : `comment out ${opts.envServerUrlKey}`;
+  console.warn(
+    `${LOG_PREFIX} schema auto-push skipped because ${opts.serverUrl} is unreachable (${errorMessage(
+      opts.error,
+    )}). The dev server will keep using this app and server URL. To use a local Jazz dev server while offline, ${fallback}. Save schema.ts/permissions.ts or restart after reconnecting to publish again.`,
+  );
+}
+
 function toRelativePath(absPath: string): string {
   const rel = relative(process.cwd(), absPath);
   if (!rel) return ".";
@@ -214,6 +238,8 @@ export class ManagedDevRuntime {
       let serverUrl: string;
       let adminSecret: string;
       let appId: string;
+      let usesExistingServer = false;
+      let existingServerEnvKey: string | null = null;
 
       try {
         if (serverOpt === false) {
@@ -221,6 +247,8 @@ export class ManagedDevRuntime {
         }
 
         if (process.env[this.envKeys.serverUrl]) {
+          usesExistingServer = true;
+          existingServerEnvKey = this.envKeys.serverUrl;
           serverUrl = process.env[this.envKeys.serverUrl]!;
           adminSecret = options.adminSecret ?? process.env.JAZZ_ADMIN_SECRET ?? "";
           appId = process.env[this.envKeys.appId] ?? options.appId ?? "";
@@ -237,6 +265,7 @@ export class ManagedDevRuntime {
           console.log(`${LOG_PREFIX} using server from env: ${serverUrl}`);
           console.log(`${LOG_PREFIX} app id: ${appId}`);
         } else if (typeof serverOpt === "string") {
+          usesExistingServer = true;
           serverUrl = serverOpt;
           adminSecret = options.adminSecret ?? "";
           appId = options.appId ?? "";
@@ -299,8 +328,20 @@ export class ManagedDevRuntime {
         await persistAppIdToEnv(envPath, this.envKeys.appId, appId);
 
         const { pushSchemaCatalogue } = await import("./dev-server.js");
-        await pushSchemaCatalogue({ serverUrl, appId, adminSecret, schemaDir });
-        console.log(`${LOG_PREFIX} schema published`);
+        try {
+          await pushSchemaCatalogue({ serverUrl, appId, adminSecret, schemaDir });
+          console.log(`${LOG_PREFIX} schema published`);
+        } catch (error) {
+          if (usesExistingServer && isSchemaPushNetworkError(error)) {
+            warnInitialSchemaPushSkipped({
+              serverUrl,
+              envServerUrlKey: existingServerEnvKey,
+              error,
+            });
+          } else {
+            throw error;
+          }
+        }
 
         const { watchSchema } = await import("./schema-watcher.js");
         this.watcher = watchSchema({


### PR DESCRIPTION
## Summary

- Keep dev plugins running when the initial schema auto-push cannot reach a configured remote Jazz server.
- Warn and continue with the configured app/server URL for network-level failures, while still failing on schema, auth, or server rejections.
- Add runtime coverage for env-driven Cloud startup and a patch changeset for `jazz-tools`.

## Root Cause

When a Cloud server URL was present in dev env, startup treated Jazz Cloud as an existing remote server and tried to publish the schema before the framework dev server finished booting. A DNS or connection failure from `fetch()` was handled like any other initialization error, so dev startup crashed while offline.

## Test Plan

- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/dev/managed-runtime.test.ts src/dev/sveltekit.test.ts`
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/dev/vite.test.ts src/dev/sveltekit.test.ts src/dev/next.test.ts src/dev/expo.test.ts`
- `pnpm --filter jazz-tools test`
- pre-commit `oxfmt` and `oxlint`