### PR TITLE
Fix wasm-pack profiling profile losing -O

### DIFF
--- a/crates/jazz-wasm/Cargo.toml
+++ b/crates/jazz-wasm/Cargo.toml
@@ -59,9 +59,4 @@ default = ["console_error_panic_hook"]
 wasm-opt = ["-O", "-g"]
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = [
-  "--enable-nontrapping-float-to-int",
-  "--enable-bulk-memory",
-  "-O4",
-  "-g",
-]
+wasm-opt = ["-O4", "-g"]

--- a/crates/jazz-wasm/Cargo.toml
+++ b/crates/jazz-wasm/Cargo.toml
@@ -58,5 +58,10 @@ default = ["console_error_panic_hook"]
 [package.metadata.wasm-pack.profile.profiling]
 wasm-opt = ["-O", "-g"]
 
+# `-O` (level 2) matched higher levels in our runtime benchmarks, so we stop there.
+# `-g` is kept because it had no measurable impact on runtime or output size,
+# and it preserves the wasm `name` section so function names appear in profilers.
+# wasm-pack only recognizes the profile names `dev`/`profiling`/`release`; any other
+# name is silently ignored and wasm-pack falls back to its built-in defaults.
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ["-O4", "-g"]
+wasm-opt = ["-O", "-g"]

--- a/crates/jazz-wasm/Cargo.toml
+++ b/crates/jazz-wasm/Cargo.toml
@@ -59,4 +59,9 @@ default = ["console_error_panic_hook"]
 wasm-opt = ["-O", "-g"]
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ["-O"]
+wasm-opt = [
+  "--enable-nontrapping-float-to-int",
+  "--enable-bulk-memory",
+  "-O4",
+  "-g",
+]

--- a/crates/jazz-wasm/Cargo.toml
+++ b/crates/jazz-wasm/Cargo.toml
@@ -52,7 +52,11 @@ web-sys = { version = "0.3", features = [
 [features]
 default = ["console_error_panic_hook"]
 
-# Even if the profiling profile is set, wasm-opt will strip off debug info unless the `-g` param is provided. 
+# `wasm-opt` here REPLACES wasm-pack's defaults, so we must include `-O` ourselves
+# or optimization is silently disabled. `-g` preserves debug info for profiling builds.
 # See https://github.com/DataDog/js-instrumentation-wasm/pull/12
 [package.metadata.wasm-pack.profile.profiling]
-wasm-opt = ["-g"]
+wasm-opt = ["-O", "-g"]
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-O"]

--- a/crates/jazz-wasm/package.json
+++ b/crates/jazz-wasm/package.json
@@ -26,6 +26,7 @@
     "tag": "alpha"
   },
   "scripts": {
-    "build": "wasm-pack build --target web --profiling"
+    "build": "wasm-pack build --target web --release",
+    "build:profiling": "wasm-pack build --target web --profiling"
   }
 }


### PR DESCRIPTION
## Summary

- The `jazz-wasm` crate's `[package.metadata.wasm-pack.profile.profiling]` block set `wasm-opt = ["-g"]`, which **replaces** wasm-pack's defaults wholesale rather than extending them. That silently dropped `-O`, so every `--profiling` build shipped unoptimized WASM.
- Switch the default `pnpm build` script for `jazz-wasm` to `--release` so the published artifact runs through wasm-opt instead of relying on the broken profiling profile, and add an explicit `pnpm build:profiling` for local profiling iteration.
- Make both wasm-pack profiles explicit in `Cargo.toml` so the same silent-defaults trap can't bite again, and tune the release profile for runtime perf while keeping debug names for symbolicatable stack traces:
  - `profiling`: `["-O", "-g"]`
  - `release`: `["-O", "-g"]`
- Note: the metadata key **must** be one of `dev`/`profiling`/`release`. Any other name (e.g. `wasm-release`) is silently ignored and wasm-pack falls back to its built-in defaults, which strip the `name` section and break profiler symbol names.

## Optimization tuning

We benchmarked the wasm-opt level for the release profile and `-O` (level 2) was the sweet spot:

- `-O4` showed no measurable runtime gain over `-O` on our benchmarks, and `-O` actually produces a slightly smaller binary.
- `-Oz` (size-aggressive) measurably **reduced** runtime performance, so it was rejected.
- Setting Rust's cargo `[profile.release] opt-level = "z"` shrinks the binary down to ~5 MB raw, but **drastically** regresses runtime performance — also rejected. Runtime perf is the priority for this artifact; size optimization should happen at the wasm-opt layer, not by asking rustc to pessimize codegen.
- `-g` adds ~170 KB gzipped (cheap) and preserves the wasm `name` section so profilers and stack traces stay symbolicatable in production.
- Explicit `--enable-bulk-memory` / `--enable-nontrapping-float-to-int` flags were dropped: redundant on Rust ≥1.82 + wasm-opt ≥0.116, which auto-detect features from the rustc-emitted `target_features` section.
- Unbounded inlining (`--flexible-inline-max-function-size`) was rejected — it adds ~320 KB gzipped without a perf benchmark to justify it.

## Size impact (release WASM)

Measured by building each variant and comparing `pkg/jazz_wasm_bg.wasm`:

| Config | Raw | Gzip |
|---|---|---|
| `["-O"]` (broken-profile baseline) | 8.56 MB | 2.74 MB |
| `["-O4", "-g"]` | 9.31 MB | 2.93 MB |
| **`["-O", "-g"]` (this PR)** | **8.83 MB** | **2.76 MB** |
| `["-O4", "-g", --flexible-inline]` | 12.67 MB | 3.25 MB |
| Rust `opt-level = "z"` + `["-O", "-g"]` (rejected, perf regression) | ~5 MB | — |

## Test plan

- [ ] `pnpm build` in `crates/jazz-wasm` produces a working release WASM with function names visible in the browser profiler.
- [ ] `pnpm build:profiling` produces a profiling WASM with both `-O` applied and `-g` symbols preserved.
- [ ] `pnpm test` passes at the workspace root.
- [ ] Spot-check the bundled WASM loads in a browser.