### PR TITLE
fix: retain row metadata on overlapping writes until server confirmation

### DIFF
--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/rejection_recovery.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/rejection_recovery.rs
@@ -1,5 +1,22 @@
 use super::*;
 
+fn users_delete_denied_authorization_schema() -> Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("users")
+                .column("id", ColumnType::Uuid)
+                .column("name", ColumnType::Text)
+                .policies(
+                    TablePolicies::new()
+                        .with_select(PolicyExpr::True)
+                        .with_insert(PolicyExpr::True)
+                        .with_update(Some(PolicyExpr::True), PolicyExpr::True)
+                        .with_delete(PolicyExpr::False),
+                ),
+        )
+        .build()
+}
+
 #[test]
 fn rc_direct_insert_persisted_reconnect_reconciles_rejected_batch_from_server() {
     let mut core = create_runtime_with_boxed_storage(
@@ -592,6 +609,123 @@ fn rc_transactional_insert_is_rejected_by_authority_permission_check() {
     assert_eq!(
         alice_history_rows[0].state,
         crate::row_histories::RowState::Rejected
+    );
+}
+
+#[test]
+fn rc_worker_path_overlapping_insert_and_delete_rejects_delete() {
+    let mut s = create_3tier_rc();
+
+    s.c.schema_manager_mut()
+        .query_manager_mut()
+        .set_authorization_schema(users_delete_denied_authorization_schema());
+    s.c.schema_manager_mut()
+        .query_manager_mut()
+        .sync_manager_mut()
+        .set_client_session(s.b_client_of_c, Session::new("alice"));
+    s.c.schema_manager_mut()
+        .query_manager_mut()
+        .sync_manager_mut()
+        .set_client_role(s.b_client_of_c, ClientRole::User);
+
+    let ((row_id, _row_values), mut insert_receiver) =
+        s.a.insert_persisted(
+            "users",
+            user_insert_values(ObjectId::new(), "Alice"),
+            None,
+            DurabilityTier::EdgeServer,
+        )
+        .unwrap();
+    let insert_batch_id =
+        s.a.storage()
+            .scan_history_row_batches("users", row_id)
+            .unwrap()[0]
+            .batch_id;
+    let mut delete_receiver =
+        s.a.delete_persisted(row_id, None, DurabilityTier::EdgeServer)
+            .unwrap();
+    let delete_batch_id =
+        s.a.storage()
+            .scan_history_row_batches("users", row_id)
+            .unwrap()
+            .iter()
+            .find(|row| row.batch_id != insert_batch_id)
+            .expect("delete should append a second history row")
+            .batch_id;
+
+    pump_a_to_b(&mut s);
+
+    let b_out = s.b.sync_sender().take();
+    assert!(
+        b_out.iter().any(|entry| matches!(
+            entry,
+            OutboxEntry {
+                destination: Destination::Server(server_id),
+                payload: SyncPayload::RowBatchCreated { row, .. },
+            } if *server_id == s.c_server_for_b && row.batch_id == delete_batch_id && row.is_deleted
+        )),
+        "worker should forward the delete tombstone upstream when insert and delete overlap",
+    );
+    for entry in b_out {
+        match &entry.destination {
+            Destination::Client(cid) if *cid == s.a_client_of_b => {
+                s.a.park_sync_message(InboxEntry {
+                    source: Source::Server(s.b_server_for_a),
+                    payload: entry.payload,
+                });
+            }
+            Destination::Server(server_id) if *server_id == s.c_server_for_b => {
+                s.c.park_sync_message(InboxEntry {
+                    source: Source::Client(s.b_client_of_c),
+                    payload: entry.payload,
+                });
+            }
+            _ => {}
+        }
+    }
+    s.c.batched_tick();
+    s.c.immediate_tick();
+
+    let c_out = s.c.sync_sender().take();
+    assert!(
+        c_out.iter().any(|entry| matches!(
+            entry,
+            OutboxEntry {
+                destination: Destination::Client(client_id),
+                payload: SyncPayload::BatchSettlement {
+                    settlement: crate::batch_fate::BatchSettlement::Rejected { batch_id, .. },
+                },
+            } if *client_id == s.b_client_of_c && *batch_id == delete_batch_id
+        )),
+        "edge should reject the overlapping delete batch, got {c_out:?}",
+    );
+    for entry in c_out {
+        if entry.destination == Destination::Client(s.b_client_of_c) {
+            s.b.park_sync_message(InboxEntry {
+                source: Source::Server(s.c_server_for_b),
+                payload: entry.payload,
+            });
+        }
+    }
+    s.b.batched_tick();
+    s.b.immediate_tick();
+    pump_b_to_a(&mut s);
+
+    assert_eq!(
+        insert_receiver.try_recv(),
+        Ok(Some(Ok(()))),
+        "insert waiter should resolve once the edge accepts the base row"
+    );
+    let rejection = delete_receiver
+        .try_recv()
+        .expect("delete wait should settle after edge permission evaluation")
+        .expect("delete wait should produce a settlement result")
+        .expect_err("delete wait should reject under edge delete-denied policy");
+    assert_eq!(rejection.code, "permission_denied");
+    assert!(
+        rejection.reason.contains("Delete denied"),
+        "expected delete rejection reason, got {:?}",
+        rejection.reason
     );
 }
 

--- a/crates/jazz-tools/src/sync_manager/forwarding.rs
+++ b/crates/jazz-tools/src/sync_manager/forwarding.rs
@@ -7,6 +7,68 @@ use std::collections::HashSet;
 use uuid::Uuid;
 
 impl SyncManager {
+    fn object_has_upstream_confirmation<H: Storage>(
+        &self,
+        storage: &H,
+        table: &str,
+        branch_name: &BranchName,
+        object_id: ObjectId,
+    ) -> bool {
+        let Ok(Some(visible_entry)) =
+            storage.load_visible_region_entry(table, branch_name.as_str(), object_id)
+        else {
+            return false;
+        };
+        let local_tier = self.max_local_durability_tier();
+        match local_tier {
+            None => {
+                visible_entry.current_row.confirmed_tier.is_some()
+                    || visible_entry.worker_batch_id.is_some()
+                    || visible_entry.edge_batch_id.is_some()
+                    || visible_entry.global_batch_id.is_some()
+            }
+            Some(my_tier) => {
+                visible_entry
+                    .current_row
+                    .confirmed_tier
+                    .is_some_and(|row_tier| row_tier > my_tier)
+                    || matches!(my_tier, DurabilityTier::Local)
+                        && (visible_entry.edge_batch_id.is_some()
+                            || visible_entry.global_batch_id.is_some())
+                    || matches!(my_tier, DurabilityTier::EdgeServer)
+                        && visible_entry.global_batch_id.is_some()
+            }
+        }
+    }
+
+    fn queue_row_to_server_with_storage<H: Storage>(
+        &mut self,
+        storage: &H,
+        table: &str,
+        server_id: ServerId,
+        object_id: ObjectId,
+        metadata: HashMap<String, String>,
+        row: StoredRowBatch,
+    ) {
+        let branch_name = BranchName::new(&row.branch);
+        let include_metadata = {
+            let Some(server) = self.servers.get(&server_id) else {
+                return;
+            };
+            let metadata_already_sent = server.sent_metadata.contains(&object_id);
+            let object_confirmed_upstream =
+                self.object_has_upstream_confirmation(storage, table, &branch_name, object_id);
+            !metadata_already_sent || !object_confirmed_upstream
+        };
+        self.queue_row_to_server_with_metadata(
+            server_id,
+            object_id,
+            metadata,
+            row,
+            include_metadata,
+        );
+    }
+
     pub(super) fn load_current_row_from_storage<H: crate::storage::Storage + ?Sized>(
         &self,
         storage: &H,
@@ -218,15 +280,38 @@ impl SyncManager {
             visiting.remove(&parent_batch_id);
         }
 
-        self.queue_row_to_server(server_id, object_id, metadata, row);
+        self.queue_row_to_server_with_storage(storage, table, server_id, object_id, metadata, row);
     }
 
-    pub(crate) fn forward_row_batch_to_servers(
+    pub(crate) fn forward_row_batch_to_servers<H: Storage>(
         &mut self,
+        storage: &H,
         object_id: ObjectId,
         metadata: HashMap<String, String>,
         row: StoredRowBatch,
     ) {
+        let table = metadata
+            .get(crate::metadata::MetadataKey::Table.as_str())
+            .cloned()
+            .or_else(|| {
+                storage
+                    .load_row_locator(object_id)
+                    .ok()
+                    .flatten()
+                    .map(|locator| locator.table.to_string())
+            });
+
+        if let Some(table) = table {
+            self.forward_row_batch_to_servers_with_storage(
+                storage,
+                table.as_str(),
+                object_id,
+                metadata,
+                row,
+            );
+            return;
+        }
+
         let server_ids: Vec<ServerId> = self.servers.keys().copied().collect();
         if !server_ids.is_empty() {
             tracing::trace!(
@@ -238,7 +323,17 @@ impl SyncManager {
         }
 
         for server_id in server_ids {
-            self.queue_row_to_server(server_id, object_id, metadata.clone(), row.clone());
+            let include_metadata = self
+                .servers
+                .get(&server_id)
+                .is_some_and(|server| !server.sent_metadata.contains(&object_id));
+            self.queue_row_to_server_with_metadata(
+                server_id,
+                object_id,
+                metadata.clone(),
+                row.clone(),
+                include_metadata,
+            );
         }
     }
 
@@ -264,7 +359,13 @@ impl SyncManager {
                 }
             }
 
-            self.queue_row_to_server(server_id, object_id, metadata.clone(), row.clone());
+            self.queue_row_to_server_with_metadata(
+                server_id,
+                object_id,
+                metadata.clone(),
+                row.clone(),
+                true,
+            );
         }
     }
 

--- a/crates/jazz-tools/src/sync_manager/forwarding.rs
+++ b/crates/jazz-tools/src/sync_manager/forwarding.rs
@@ -56,9 +56,11 @@ impl SyncManager {
                 return;
             };
             let metadata_already_sent = server.sent_metadata.contains(&object_id);
-            let object_confirmed_upstream =
-                self.object_has_upstream_confirmation(storage, table, &branch_name, object_id);
-            !metadata_already_sent || !object_confirmed_upstream
+            if !metadata_already_sent {
+                true
+            } else {
+                !self.object_has_upstream_confirmation(storage, table, &branch_name, object_id)
+            }
         };
         self.queue_row_to_server_with_metadata(
             server_id,

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -1714,18 +1714,12 @@ impl SyncManager {
 
                 if let Some(applied) = self.apply_row_updated(storage, metadata, row.clone()) {
                     self.retain_client_local_batch_row(storage, &applied.metadata, &applied.row);
-                    if let Some(table) = applied.metadata.get(MetadataKey::Table.as_str()).cloned()
-                    {
-                        self.forward_row_batch_to_servers_with_storage(
-                            storage,
-                            table.as_str(),
-                            object_id,
-                            applied.metadata.clone(),
-                            row,
-                        );
-                    } else {
-                        self.forward_row_batch_to_servers(object_id, applied.metadata.clone(), row);
-                    }
+                    self.forward_row_batch_to_servers(
+                        storage,
+                        object_id,
+                        applied.metadata.clone(),
+                        row,
+                    );
                     if !matches!(
                         applied.row.state,
                         RowState::StagingPending | RowState::Superseded

--- a/crates/jazz-tools/src/sync_manager/sync_logic.rs
+++ b/crates/jazz-tools/src/sync_manager/sync_logic.rs
@@ -186,12 +186,13 @@ impl SyncManager {
         }
     }
 
-    pub(super) fn queue_row_to_server(
+    pub(super) fn queue_row_to_server_with_metadata(
         &mut self,
         server_id: ServerId,
         object_id: ObjectId,
         metadata: HashMap<String, String>,
         row: StoredRowBatch,
+        include_metadata: bool,
     ) {
         if metadata
             .get(crate::metadata::MetadataKey::NoSync.as_str())
@@ -203,18 +204,15 @@ impl SyncManager {
 
         let branch_name = BranchName::new(&row.branch);
         let batch_id = row.batch_id;
-
-        let (include_metadata, already_sent) = {
+        let already_sent = {
             let Some(server) = self.servers.get(&server_id) else {
                 return;
             };
-            let include_metadata = !server.sent_metadata.contains(&object_id);
-            let already_sent = server
+            server
                 .sent_batch_ids
                 .get(&(object_id, branch_name))
                 .cloned()
-                .unwrap_or_default();
-            (include_metadata, already_sent)
+                .unwrap_or_default()
         };
 
         if already_sent.contains(&batch_id) && !include_metadata {

--- a/crates/jazz-tools/src/sync_manager/tests/server_sync.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/server_sync.rs
@@ -97,7 +97,7 @@ fn add_server_with_storage_syncs_full_row_history_to_server() {
         OutboxEntry {
             destination: Destination::Server(id),
             payload: SyncPayload::RowBatchCreated { row, metadata, .. },
-        } if *id == server_id && row.batch_id() == newer.batch_id() && metadata.is_none()
+        } if *id == server_id && row.batch_id() == newer.batch_id() && metadata.is_some()
     ));
 }
 


### PR DESCRIPTION
## Description

When performing write operations, the row metadata is only sent to the server if it hasn't previously been sent. This caused a race condition when doing multiple write operations on the same object (e.g. an insert followed by an update) before the server had processed the first operation: the later write could arrive without the row locator metadata the server needs to identify the row’s table and schema context. Even though messages are delivered in order, the first write may still be waiting on permission evaluation and not yet applied to storage, so the server cannot reliably recover that locator from its local state. In that window, policy evaluation for the later write can run with incomplete context and produce the wrong result.

This PR fixes the issue by keeping row metadata attached to server-bound writes until the object has at least one upstream-confirmed row. In other words, we no longer treat “metadata was sent once” as equivalent to “the server has definitely persisted enough state to infer it.” That makes overlapping writes self-describing until the server has fully caught up, which removes the race.