### PR TITLE
refactor(jazz-tools): trim db.ts and extract cross-tab modules

### DIFF
--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -58,32 +58,25 @@ import {
   resolveRuntimeConfigWorkerUrl,
 } from "./runtime-config.js";
 import { installWasmTelemetry, resolveTelemetryCollectorUrlFromEnv } from "./sync-telemetry.js";
+import {
+  isTabSyncMessage,
+  resolveBroadcastChannelCtor,
+  type BroadcastChannelLike,
+  type FollowerCloseMessage,
+  type FollowerSyncMessage,
+  type LeaderSyncMessage,
+  type TabSyncMessage,
+} from "./tab-sync-protocol.js";
+import { StorageResetCoordinator, type StorageResetHost } from "./storage-reset-coordinator.js";
 
 type WasmLogLevel = "error" | "warn" | "info" | "debug" | "trace";
 const DEFAULT_WASM_LOG_LEVEL: WasmLogLevel = "warn";
-const STORAGE_RESET_REQUEST_RETRY_MS = 200;
-const STORAGE_RESET_REQUEST_TIMEOUT_MS = 5_000;
-const STORAGE_RESET_DISCOVERY_WINDOW_MS = 600;
-const STORAGE_RESET_ACK_QUIET_MS = 150;
-
 function setGlobalWasmLogLevel(level?: WasmLogLevel): void {
   (globalThis as any).__JAZZ_WASM_LOG_LEVEL = level ?? DEFAULT_WASM_LOG_LEVEL;
 }
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function createOperationId(prefix: string): string {
-  const cryptoObj = (globalThis as { crypto?: Crypto }).crypto;
-  if (cryptoObj && typeof cryptoObj.randomUUID === "function") {
-    return `${prefix}-${cryptoObj.randomUUID()}`;
-  }
-  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
-}
-
-function toError(error: unknown, fallbackMessage: string): Error {
-  return error instanceof Error ? error : new Error(error ? String(error) : fallbackMessage);
 }
 
 /**
@@ -234,40 +227,6 @@ type RuntimeQueryTracePayload = {
   table: string;
   branches: string[];
 };
-
-type Deferred<T> = {
-  promise: Promise<T>;
-  resolve: (value: T | PromiseLike<T>) => void;
-  reject: (reason?: unknown) => void;
-};
-
-type StorageResetContext = {
-  requestId: string;
-  initiatedBySelf: boolean;
-  coordinatorTabId: string | null;
-  begun: boolean;
-  completed: boolean;
-  preparePromise: Promise<string> | null;
-  completion: Deferred<void>;
-};
-
-type StorageResetCoordinatorState = {
-  requestId: string;
-  startedAtMs: number;
-  lastAckAtMs: number;
-  ackedNamespacesByTabId: Map<string, string>;
-  runPromise: Promise<void> | null;
-};
-
-function createDeferred<T>(): Deferred<T> {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-  return { promise, resolve, reject };
-}
 
 function trimSubscriptionTraceStack(stack: string | undefined): string | undefined {
   if (!stack) {
@@ -497,42 +456,22 @@ function transformOutputColumns(
   return transformed;
 }
 
-function transformInsertInput(
-  table: TableProxy<unknown, unknown>,
-  data: unknown,
-): Record<string, unknown> {
-  return transformInputColumns(table, data as Record<string, unknown>);
-}
-
-function transformUpdateInput(
-  table: TableProxy<unknown, unknown>,
-  data: unknown,
-): Record<string, unknown> {
-  return transformInputColumns(table, data as Record<string, unknown>);
-}
-
 function transformInputColumns(
   table: TableProxy<unknown, unknown>,
-  data: Record<string, unknown>,
+  data: unknown,
 ): Record<string, unknown> {
+  const record = data as Record<string, unknown>;
   if (!table._columnTransforms) {
-    return data;
+    return record;
   }
 
-  const transformed = { ...data };
+  const transformed = { ...record };
   for (const [column, transform] of Object.entries(table._columnTransforms)) {
     if (column in transformed) {
       transformed[column] = transform.to(transformed[column]);
     }
   }
   return transformed;
-}
-
-function backendScopedAuthState(session?: Session | null): AuthState {
-  return {
-    authMode: session?.authMode ?? "external",
-    session: session ?? null,
-  };
 }
 
 /**
@@ -601,7 +540,7 @@ export class DbTransaction {
   insert<T, Init>(table: TableProxy<T, Init>, data: Init, options?: CreateOptions): T {
     this.ensureActive();
     this.bindTable(table, "DbTransaction");
-    const transformedData = transformInsertInput(table, data);
+    const transformedData = transformInputColumns(table, data);
     const values = toInsertRecord(transformedData, table._schema, table._table);
     const runtimeTransaction = this.requireRuntimeTransaction("insert");
     const row = options
@@ -619,7 +558,7 @@ export class DbTransaction {
   upsert<T, Init>(table: TableProxy<T, Init>, data: Partial<Init>, options: UpsertOptions): void {
     this.ensureActive();
     this.bindTable(table, "DbTransaction");
-    const transformedData = transformUpdateInput(table, data);
+    const transformedData = transformInputColumns(table, data);
     const values = toUpdateRecord(transformedData, table._schema, table._table);
     this.requireRuntimeTransaction("upsert").upsert(table._table, values, options);
   }
@@ -633,7 +572,7 @@ export class DbTransaction {
   update<T, Init>(table: TableProxy<T, Init>, id: string, data: Partial<Init>): void {
     this.ensureActive();
     this.bindTable(table, "DbTransaction");
-    const transformedData = transformUpdateInput(table, data);
+    const transformedData = transformInputColumns(table, data);
     const updates = toUpdateRecord(transformedData, table._schema, table._table);
     this.requireRuntimeTransaction("update").update(id, updates);
   }
@@ -770,7 +709,7 @@ export class DbDirectBatch {
   insert<T, Init>(table: TableProxy<T, Init>, data: Init, options?: CreateOptions): T {
     this.ensureActive();
     this.bindTable(table, "DbDirectBatch");
-    const transformedData = transformInsertInput(table, data);
+    const transformedData = transformInputColumns(table, data);
     const values = toInsertRecord(transformedData, table._schema, table._table);
     const runtimeBatch = this.requireRuntimeBatch("insert");
     const row = options
@@ -782,7 +721,7 @@ export class DbDirectBatch {
   upsert<T, Init>(table: TableProxy<T, Init>, data: Partial<Init>, options: UpsertOptions): void {
     this.ensureActive();
     this.bindTable(table, "DbDirectBatch");
-    const transformedData = transformUpdateInput(table, data);
+    const transformedData = transformInputColumns(table, data);
     const values = toUpdateRecord(transformedData, table._schema, table._table);
     this.requireRuntimeBatch("upsert").upsert(table._table, values, options);
   }
@@ -790,7 +729,7 @@ export class DbDirectBatch {
   update<T, Init>(table: TableProxy<T, Init>, id: string, data: Partial<Init>): void {
     this.ensureActive();
     this.bindTable(table, "DbDirectBatch");
-    const transformedData = transformUpdateInput(table, data);
+    const transformedData = transformInputColumns(table, data);
     const updates = toUpdateRecord(transformedData, table._schema, table._table);
     this.requireRuntimeBatch("update").update(id, updates);
   }
@@ -818,165 +757,6 @@ export class DbDirectBatch {
  * Batch object available inside {@link Db.batch}'s callback.
  */
 export type DbBatchScope = Omit<DbDirectBatch, "commit">;
-
-interface BroadcastChannelLike {
-  postMessage(data: unknown): void;
-  addEventListener(type: "message", listener: (event: MessageEvent) => void): void;
-  removeEventListener(type: "message", listener: (event: MessageEvent) => void): void;
-  close(): void;
-}
-
-interface FollowerSyncMessage {
-  type: "follower-sync";
-  fromTabId: string;
-  toLeaderTabId: string;
-  term: number;
-  payload: Uint8Array[];
-}
-
-interface LeaderSyncMessage {
-  type: "leader-sync";
-  fromLeaderTabId: string;
-  toTabId: string;
-  term: number;
-  payload: Uint8Array[];
-}
-
-interface FollowerCloseMessage {
-  type: "follower-close";
-  fromTabId: string;
-  toLeaderTabId: string;
-  term: number;
-}
-
-interface StorageResetRequestMessage {
-  type: "storage-reset-request";
-  requestId: string;
-  fromTabId: string;
-  toLeaderTabId: string | null;
-  term: number;
-}
-
-interface StorageResetBeginMessage {
-  type: "storage-reset-begin";
-  requestId: string;
-  coordinatorTabId: string;
-  term: number;
-}
-
-interface StorageResetAckMessage {
-  type: "storage-reset-ack";
-  requestId: string;
-  fromTabId: string;
-  namespace: string;
-}
-
-interface StorageResetFinishedMessage {
-  type: "storage-reset-finished";
-  requestId: string;
-  success: boolean;
-  errorMessage?: string;
-}
-
-type TabSyncMessage =
-  | FollowerSyncMessage
-  | LeaderSyncMessage
-  | FollowerCloseMessage
-  | StorageResetRequestMessage
-  | StorageResetBeginMessage
-  | StorageResetAckMessage
-  | StorageResetFinishedMessage;
-
-function resolveBroadcastChannelCtor(): (new (name: string) => BroadcastChannelLike) | null {
-  const ctor = (globalThis as { BroadcastChannel?: unknown }).BroadcastChannel;
-  if (typeof ctor !== "function") return null;
-  return ctor as new (name: string) => BroadcastChannelLike;
-}
-
-function isBinaryPayloadArray(value: unknown): value is Uint8Array[] {
-  return Array.isArray(value) && value.every((entry) => entry instanceof Uint8Array);
-}
-
-function isTabSyncMessage(value: unknown): value is TabSyncMessage {
-  if (typeof value !== "object" || value === null) return false;
-  const message = value as Record<string, unknown>;
-
-  if (message.type === "follower-sync") {
-    return (
-      typeof message.fromTabId === "string" &&
-      typeof message.toLeaderTabId === "string" &&
-      typeof message.term === "number" &&
-      isBinaryPayloadArray(message.payload)
-    );
-  }
-
-  if (message.type === "leader-sync") {
-    return (
-      typeof message.fromLeaderTabId === "string" &&
-      typeof message.toTabId === "string" &&
-      typeof message.term === "number" &&
-      isBinaryPayloadArray(message.payload)
-    );
-  }
-
-  if (message.type === "follower-close") {
-    return (
-      typeof message.fromTabId === "string" &&
-      typeof message.toLeaderTabId === "string" &&
-      typeof message.term === "number"
-    );
-  }
-
-  if (message.type === "storage-reset-request") {
-    return (
-      typeof message.requestId === "string" &&
-      typeof message.fromTabId === "string" &&
-      (typeof message.toLeaderTabId === "string" || message.toLeaderTabId === null) &&
-      typeof message.term === "number"
-    );
-  }
-
-  if (message.type === "storage-reset-begin") {
-    return (
-      typeof message.requestId === "string" &&
-      typeof message.coordinatorTabId === "string" &&
-      typeof message.term === "number"
-    );
-  }
-
-  if (message.type === "storage-reset-ack") {
-    return (
-      typeof message.requestId === "string" &&
-      typeof message.fromTabId === "string" &&
-      typeof message.namespace === "string"
-    );
-  }
-
-  if (message.type === "storage-reset-finished") {
-    return (
-      typeof message.requestId === "string" &&
-      typeof message.success === "boolean" &&
-      (typeof message.errorMessage === "string" || message.errorMessage === undefined)
-    );
-  }
-
-  return false;
-}
-
-function isLeaderDebugEnabled(): boolean {
-  const globalFlag = (globalThis as { __JAZZ_LEADER_DEBUG__?: unknown }).__JAZZ_LEADER_DEBUG__;
-  if (globalFlag === true) return true;
-
-  try {
-    if (typeof localStorage !== "undefined") {
-      return localStorage.getItem("jazz:leader-debug") === "1";
-    }
-  } catch {
-    // Ignore storage access errors (e.g. privacy mode / unavailable storage).
-  }
-
-  return false;
-}
 
 /**
  * High-level database interface for typed queries and mutations.
@@ -1022,8 +802,7 @@ export class Db {
   private readonly leaderPeerIds = new Set<string>();
   private activeRemoteLeaderTabId: string | null = null;
   private workerReconfigure: Promise<void> = Promise.resolve();
-  private activeStorageReset: StorageResetContext | null = null;
-  private storageResetCoordinator: StorageResetCoordinatorState | null = null;
+  private storageReset: StorageResetCoordinator | null = null;
   private _localFirstSecret: string | null = null;
   private localFirstRefreshTimer: ReturnType<typeof setTimeout> | null = null;
   private isShuttingDown = false;
@@ -1216,8 +995,8 @@ export class Db {
       }
       db.adoptLeaderSnapshot(initialLeader);
       db.workerDbName = Db.resolveWorkerDbNameForSnapshot(db.primaryDbName, initialLeader);
-      db.logLeaderDebug("initial-election");
       db.openSyncChannel();
+      db.storageReset = new StorageResetCoordinator(db.createStorageResetHost());
       db.attachLifecycleHooks();
       db.leaderElectionUnsubscribe = election.onChange((snapshot) => {
         db.onLeaderElectionChange(snapshot);
@@ -1530,16 +1309,12 @@ export class Db {
     if (this.syncChannel || !this.primaryDbName) return;
     const ChannelCtor = resolveBroadcastChannelCtor();
     if (!ChannelCtor) {
-      this.logLeaderDebug("sync-channel-unavailable");
       return;
     }
 
     const channelName = `jazz-tab-sync:${this.config.appId}:${this.primaryDbName}`;
     this.syncChannel = new ChannelCtor(channelName);
     this.syncChannel.addEventListener("message", this.onSyncChannelMessage);
-    this.logLeaderDebug("sync-channel-open", {
-      channelName,
-    });
   }
 
   private closeSyncChannel(): void {
@@ -1547,331 +1322,17 @@ export class Db {
     this.syncChannel.removeEventListener("message", this.onSyncChannelMessage);
     this.syncChannel.close();
     this.syncChannel = null;
-    this.logLeaderDebug("sync-channel-close");
   }
 
   private postSyncChannelMessage(message: TabSyncMessage): void {
     this.syncChannel?.postMessage(message);
   }
 
-  private getOrCreateStorageResetContext(
-    requestId: string,
-    initiatedBySelf: boolean,
-  ): StorageResetContext {
-    if (this.activeStorageReset?.requestId === requestId) {
-      if (initiatedBySelf) {
-        this.activeStorageReset.initiatedBySelf = true;
-      }
-      return this.activeStorageReset;
-    }
-
-    const completion = createDeferred<void>();
-    // Suppress unhandled rejection warnings for remote-initiated resets that
-    // have no local caller awaiting the completion promise.
-    void completion.promise.catch(() => undefined);
-
-    const context: StorageResetContext = {
-      requestId,
-      initiatedBySelf,
-      coordinatorTabId: null,
-      begun: false,
-      completed: false,
-      preparePromise: null,
-      completion,
-    };
-    this.activeStorageReset = context;
-    return context;
-  }
-
-  private clearStorageResetContext(requestId: string): void {
-    if (this.activeStorageReset?.requestId === requestId) {
-      this.activeStorageReset = null;
-    }
-    if (this.storageResetCoordinator?.requestId === requestId) {
-      this.storageResetCoordinator = null;
-    }
-  }
-
-  private resolveStorageResetContext(context: StorageResetContext): void {
-    if (context.completed) {
-      return;
-    }
-    context.completed = true;
-    context.completion.resolve();
-    this.clearStorageResetContext(context.requestId);
-  }
-
-  private rejectStorageResetContext(context: StorageResetContext, error: unknown): void {
-    if (context.completed) {
-      return;
-    }
-    context.completed = true;
-    context.completion.reject(toError(error, "Browser storage reset failed"));
-    this.clearStorageResetContext(context.requestId);
-  }
-
-  private async prepareForStorageReset(
-    context: StorageResetContext,
-    coordinatorTabId: string,
-  ): Promise<string> {
-    if (context.preparePromise) {
-      return await context.preparePromise;
-    }
-
-    context.begun = true;
-    context.coordinatorTabId = coordinatorTabId;
-    context.preparePromise = (async () => {
-      if (this.bridgeReady) {
-        await this.bridgeReady;
-      }
-
-      const namespace = this.currentWorkerNamespace();
-      await this.shutdownWorkerAndClientsForStorageReset();
-
-      if (this.tabId && coordinatorTabId !== this.tabId) {
-        this.postSyncChannelMessage({
-          type: "storage-reset-ack",
-          requestId: context.requestId,
-          fromTabId: this.tabId,
-          namespace,
-        });
-      }
-
-      return namespace;
-    })();
-
-    return await context.preparePromise;
-  }
-
-  private async waitForStorageResetQuiescence(
-    coordinator: StorageResetCoordinatorState,
-  ): Promise<void> {
-    while (true) {
-      const now = Date.now();
-      const elapsed = now - coordinator.startedAtMs;
-      const idleMs = now - coordinator.lastAckAtMs;
-      if (elapsed >= STORAGE_RESET_DISCOVERY_WINDOW_MS && idleMs >= STORAGE_RESET_ACK_QUIET_MS) {
-        return;
-      }
-      await sleep(25);
-    }
-  }
-
-  private async collectStorageResetNamespaces(
-    extraNamespaces: Iterable<string>,
-  ): Promise<string[]> {
-    const namespaces = new Set<string>();
-    const primaryDbName = this.primaryDbName;
-    if (primaryDbName) {
-      namespaces.add(primaryDbName);
-    }
-    for (const namespace of extraNamespaces) {
-      namespaces.add(namespace);
-    }
-
-    if (!primaryDbName) {
-      return [...namespaces];
-    }
-
-    const rootDirectory = await navigator.storage.getDirectory();
-    const rootWithEntries = rootDirectory as FileSystemDirectoryHandle & {
-      entries?: () => AsyncIterable<[string, FileSystemHandle]>;
-    };
-    if (typeof rootWithEntries.entries !== "function") {
-      return [...namespaces];
-    }
-
-    const suffix = ".opfsbtree";
-    const fallbackPrefix = `${primaryDbName}__fallback__`;
-
-    for await (const [name] of rootWithEntries.entries()) {
-      if (!name.endsWith(suffix)) continue;
-      const namespace = name.slice(0, -suffix.length);
-      if (namespace === primaryDbName || namespace.startsWith(fallbackPrefix)) {
-        namespaces.add(namespace);
-      }
-    }
-
-    return [...namespaces];
-  }
-
-  private async resumeAfterStorageReset(): Promise<void> {
+  private async resumeWorker(): Promise<void> {
     if (this.worker || this.isShuttingDown) {
       return;
     }
     this.worker = await Db.spawnWorker(this.config.runtimeSources);
-  }
-
-  private async runSingleTabStorageReset(context: StorageResetContext): Promise<void> {
-    const coordinatorTabId = this.tabId ?? "single-tab-reset";
-    let resultError: Error | null = null;
-
-    try {
-      const namespace = await this.prepareForStorageReset(context, coordinatorTabId);
-      const namespaces = await this.collectStorageResetNamespaces([namespace]);
-      for (const candidate of namespaces) {
-        await this.removeOpfsNamespaceFile(candidate);
-      }
-    } catch (error) {
-      resultError = toError(error, "Browser storage reset failed");
-    }
-
-    try {
-      await this.resumeAfterStorageReset();
-    } catch (error) {
-      if (!resultError) {
-        resultError = toError(error, "Failed to restart browser worker after storage reset");
-      }
-    }
-
-    if (resultError) {
-      throw resultError;
-    }
-  }
-
-  private async startStorageResetAsCoordinator(context: StorageResetContext): Promise<void> {
-    if (this.storageResetCoordinator?.requestId === context.requestId) {
-      return await (this.storageResetCoordinator.runPromise ?? context.completion.promise);
-    }
-
-    if (!this.tabId || this.tabRole !== "leader") {
-      throw new Error("Storage reset coordination requires the current tab to be the leader.");
-    }
-
-    const coordinator: StorageResetCoordinatorState = {
-      requestId: context.requestId,
-      startedAtMs: Date.now(),
-      lastAckAtMs: Date.now(),
-      ackedNamespacesByTabId: new Map(),
-      runPromise: null,
-    };
-    this.storageResetCoordinator = coordinator;
-
-    coordinator.runPromise = (async () => {
-      let resultError: Error | null = null;
-
-      try {
-        this.postSyncChannelMessage({
-          type: "storage-reset-begin",
-          requestId: context.requestId,
-          coordinatorTabId: this.tabId!,
-          term: this.currentLeaderTerm,
-        });
-
-        const localNamespace = await this.prepareForStorageReset(context, this.tabId!);
-        coordinator.ackedNamespacesByTabId.set(this.tabId!, localNamespace);
-        coordinator.lastAckAtMs = Date.now();
-
-        await this.waitForStorageResetQuiescence(coordinator);
-
-        const namespaces = await this.collectStorageResetNamespaces(
-          coordinator.ackedNamespacesByTabId.values(),
-        );
-        for (const namespace of namespaces) {
-          await this.removeOpfsNamespaceFile(namespace);
-        }
-      } catch (error) {
-        resultError = toError(error, "Browser storage reset failed");
-      }
-
-      try {
-        await this.resumeAfterStorageReset();
-      } catch (error) {
-        if (!resultError) {
-          resultError = toError(error, "Failed to restart browser worker after storage reset");
-        }
-      }
-
-      this.postSyncChannelMessage({
-        type: "storage-reset-finished",
-        requestId: context.requestId,
-        success: resultError === null,
-        ...(resultError ? { errorMessage: resultError.message } : {}),
-      });
-
-      if (resultError) {
-        throw resultError;
-      }
-    })()
-      .then(() => {
-        this.resolveStorageResetContext(context);
-      })
-      .catch((error) => {
-        this.rejectStorageResetContext(context, error);
-      })
-      .finally(() => {
-        if (this.storageResetCoordinator?.requestId === context.requestId) {
-          this.storageResetCoordinator = null;
-        }
-      });
-
-    await coordinator.runPromise;
-  }
-
-  private async requestCoordinatedStorageReset(): Promise<void> {
-    if (!this.syncChannel || !this.tabId) {
-      const requestId = createOperationId("storage-reset");
-      const context = this.getOrCreateStorageResetContext(requestId, true);
-      try {
-        await this.runSingleTabStorageReset(context);
-        this.resolveStorageResetContext(context);
-      } catch (error) {
-        this.rejectStorageResetContext(context, error);
-      }
-      await context.completion.promise;
-      return;
-    }
-
-    if (this.activeStorageReset) {
-      await this.activeStorageReset.completion.promise;
-      return;
-    }
-
-    const requestId = createOperationId("storage-reset");
-    const context = this.getOrCreateStorageResetContext(requestId, true);
-
-    if (this.tabRole === "leader") {
-      await this.startStorageResetAsCoordinator(context);
-      return;
-    }
-
-    const deadline = Date.now() + STORAGE_RESET_REQUEST_TIMEOUT_MS;
-    while (!context.begun) {
-      if ((this.tabRole as LeaderRole) === "leader") {
-        await this.startStorageResetAsCoordinator(context);
-        return;
-      }
-
-      this.postSyncChannelMessage({
-        type: "storage-reset-request",
-        requestId,
-        fromTabId: this.tabId,
-        toLeaderTabId: this.currentLeaderTabId,
-        term: this.currentLeaderTerm,
-      });
-
-      const settled = await Promise.race([
-        context.completion.promise.then(
-          () => true,
-          () => true,
-        ),
-        sleep(STORAGE_RESET_REQUEST_RETRY_MS).then(() => false),
-      ]);
-      if (settled) {
-        await context.completion.promise;
-        return;
-      }
-
-      if (Date.now() >= deadline) {
-        const error = new Error(
-          "Timed out waiting for the leader tab to begin browser storage reset.",
-        );
-        this.rejectStorageResetContext(context, error);
-        throw error;
-      }
-    }
-
-    await context.completion.promise;
   }
 
   private attachLifecycleHooks(): void {
@@ -1899,7 +1360,6 @@ export class Db {
 
   private sendLifecycleHint(event: WorkerLifecycleEvent): void {
     if (this.isShuttingDown || !this.worker) return;
-    this.logLeaderDebug("lifecycle-hint", { event });
 
     if (this.workerBridge) {
       this.workerBridge.sendLifecycleHint(event);
@@ -1913,35 +1373,15 @@ export class Db {
     });
   }
 
-  private logLeaderDebug(event: string, extra?: Record<string, unknown>): void {
-    if (!isLeaderDebugEnabled()) return;
-    console.info("[db:leader]", event, {
-      tabId: this.tabId,
-      role: this.tabRole,
-      term: this.currentLeaderTerm,
-      leaderTabId: this.currentLeaderTabId,
-      workerDbName: this.workerDbName,
-      ...extra,
-    });
-  }
-
   private handleSyncChannelMessage(raw: unknown): void {
     if (this.isShuttingDown || !this.tabId) return;
     if (!isTabSyncMessage(raw)) return;
 
+    if (this.storageReset?.handleSyncChannelMessage(raw)) {
+      return;
+    }
+
     switch (raw.type) {
-      case "storage-reset-request":
-        this.handleStorageResetRequest(raw);
-        return;
-      case "storage-reset-begin":
-        this.handleStorageResetBegin(raw);
-        return;
-      case "storage-reset-ack":
-        this.handleStorageResetAck(raw);
-        return;
-      case "storage-reset-finished":
-        this.handleStorageResetFinished(raw);
-        return;
       case "follower-sync":
         this.handleFollowerSync(raw);
         return;
@@ -1954,67 +1394,6 @@ export class Db {
     }
   }
 
-  private handleStorageResetRequest(message: StorageResetRequestMessage): void {
-    if (this.tabRole !== "leader") return;
-    if (!this.tabId) return;
-    if (message.fromTabId === this.tabId) return;
-    if (message.toLeaderTabId && message.toLeaderTabId !== this.tabId) return;
-    if (message.term !== this.currentLeaderTerm) return;
-    if (this.activeStorageReset && this.activeStorageReset.requestId !== message.requestId) return;
-
-    const context = this.getOrCreateStorageResetContext(message.requestId, false);
-    void this.startStorageResetAsCoordinator(context).catch(() => undefined);
-  }
-
-  private handleStorageResetBegin(message: StorageResetBeginMessage): void {
-    if (!this.currentLeaderTabId) return;
-    if (message.coordinatorTabId !== this.currentLeaderTabId) return;
-    if (message.term !== this.currentLeaderTerm) return;
-    if (message.coordinatorTabId === this.tabId) return;
-    if (this.activeStorageReset && this.activeStorageReset.requestId !== message.requestId) return;
-
-    const context = this.getOrCreateStorageResetContext(message.requestId, false);
-    context.begun = true;
-    context.coordinatorTabId = message.coordinatorTabId;
-
-    void this.prepareForStorageReset(context, message.coordinatorTabId).catch((error) => {
-      this.rejectStorageResetContext(context, error);
-    });
-  }
-
-  private handleStorageResetAck(message: StorageResetAckMessage): void {
-    const coordinator = this.storageResetCoordinator;
-    if (!coordinator || coordinator.requestId !== message.requestId) return;
-
-    coordinator.ackedNamespacesByTabId.set(message.fromTabId, message.namespace);
-    coordinator.lastAckAtMs = Date.now();
-  }
-
-  private handleStorageResetFinished(message: StorageResetFinishedMessage): void {
-    const context = this.activeStorageReset;
-    if (!context || context.requestId !== message.requestId || context.completed) return;
-
-    void (async () => {
-      let resultError: Error | null = message.success
-        ? null
-        : new Error(message.errorMessage ?? "Browser storage reset failed");
-
-      try {
-        await this.resumeAfterStorageReset();
-      } catch (error) {
-        if (!resultError) {
-          resultError = toError(error, "Failed to restart browser worker after storage reset");
-        }
-      }
-
-      if (resultError) {
-        this.rejectStorageResetContext(context, resultError);
-      } else {
-        this.resolveStorageResetContext(context);
-      }
-    })();
-  }
-
   private handleFollowerSync(message: FollowerSyncMessage): void {
     if (this.tabRole !== "leader") return;
     if (!this.workerBridge) return;
@@ -2024,9 +1403,6 @@ export class Db {
     if (!this.leaderPeerIds.has(message.fromTabId)) {
       this.leaderPeerIds.add(message.fromTabId);
       this.workerBridge.openPeer(message.fromTabId);
-      this.logLeaderDebug("peer-open", {
-        peerId: message.fromTabId,
-      });
     }
     this.workerBridge.sendPeerSync(message.fromTabId, message.term, message.payload);
   }
@@ -2052,9 +1428,6 @@ export class Db {
 
     this.leaderPeerIds.delete(message.fromTabId);
     this.workerBridge.closePeer(message.fromTabId);
-    this.logLeaderDebug("peer-close", {
-      peerId: message.fromTabId,
-    });
   }
 
   private handleWorkerPeerSync(batch: PeerSyncBatch): void {
@@ -2076,11 +1449,6 @@ export class Db {
     if (!leaderTabId || !this.tabId) return;
     if (leaderTabId === this.tabId) return;
 
-    this.logLeaderDebug("follower-close", {
-      toLeaderTabId: leaderTabId,
-      closeTerm: term,
-    });
-
     this.postSyncChannelMessage({
       type: "follower-close",
       fromTabId: this.tabId,
@@ -2096,9 +1464,6 @@ export class Db {
     if (this.tabRole === "leader") {
       bridge.setServerPayloadForwarder(null);
       this.activeRemoteLeaderTabId = null;
-      this.logLeaderDebug("upstream-mode", {
-        mode: "leader-direct",
-      });
     } else {
       bridge.setServerPayloadForwarder((payload) => {
         if (!this.tabId || !this.currentLeaderTabId) return;
@@ -2113,15 +1478,10 @@ export class Db {
         });
       });
       this.activeRemoteLeaderTabId = this.currentLeaderTabId;
-      this.logLeaderDebug("upstream-mode", {
-        mode: "follower-via-leader",
-        upstreamLeaderTabId: this.currentLeaderTabId,
-      });
     }
 
     if (replayConnection) {
       bridge.replayServerConnection();
-      this.logLeaderDebug("upstream-replay");
     }
   }
 
@@ -2132,11 +1492,6 @@ export class Db {
     const previousLeaderTabId = this.currentLeaderTabId;
     const previousTerm = this.currentLeaderTerm;
     this.adoptLeaderSnapshot(snapshot);
-    this.logLeaderDebug("leader-change", {
-      previousRole,
-      previousLeaderTabId,
-      previousTerm,
-    });
 
     if (previousRole === "follower" && previousLeaderTabId !== this.currentLeaderTabId) {
       this.sendFollowerClose(previousLeaderTabId, previousTerm);
@@ -2152,9 +1507,6 @@ export class Db {
     this.enqueueWorkerReconfigure(async () => {
       if (this.isShuttingDown) return;
       if (dbNameChanged) {
-        this.logLeaderDebug("worker-restart", {
-          reason: "db-name-change",
-        });
         await this.restartWorkerWithCurrentDbName();
         return;
       }
@@ -2238,27 +1590,23 @@ export class Db {
     this.worker = null;
   }
 
-  private async removeOpfsNamespaceFile(namespace: string): Promise<void> {
-    const rootDirectory = await navigator.storage.getDirectory();
-    const fileName = `${namespace}.opfsbtree`;
-    try {
-      await rootDirectory.removeEntry(fileName, { recursive: false });
-    } catch (error) {
-      const name = (error as { name?: string } | undefined)?.name;
-      if (name === "NotFoundError") {
-        return;
-      }
-      if (name === "NoModificationAllowedError" || name === "InvalidStateError") {
-        throw new Error(
-          `Failed to delete browser storage for "${namespace}" because OPFS is locked by another tab. Close other tabs and retry.`,
-        );
-      }
-      throw new Error(
-        `Failed to delete browser storage for "${namespace}": ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
-    }
+  private createStorageResetHost(): StorageResetHost {
+    return {
+      isShuttingDown: () => this.isShuttingDown,
+      getTabId: () => this.tabId,
+      getTabRole: () => this.tabRole,
+      getCurrentLeaderTabId: () => this.currentLeaderTabId,
+      getCurrentLeaderTerm: () => this.currentLeaderTerm,
+      hasSyncChannel: () => this.syncChannel !== null,
+      getPrimaryDbName: () => this.primaryDbName,
+      getCurrentWorkerNamespace: () => this.currentWorkerNamespace(),
+      postSyncChannelMessage: (message) => this.postSyncChannelMessage(message),
+      ensureBridgeReady: async () => {
+        if (this.bridgeReady) await this.bridgeReady;
+      },
+      shutdownWorkerAndClients: () => this.shutdownWorkerAndClientsForStorageReset(),
+      resumeWorker: () => this.resumeWorker(),
+    };
   }
 
   private static resolveWorkerDbNameForSnapshot(
@@ -2438,7 +1786,7 @@ export class Db {
     const client = this.getClient(table._schema);
     // Don't wait for bridge to be ready in worker mode. Inserts will be propagated once the bridge is ready.
     // If the bridge fails to initialize, the insert will be lost on restart.
-    const transformedData = transformInsertInput(table, data);
+    const transformedData = transformInputColumns(table, data);
     const values = toInsertRecord(transformedData, table._schema, table._table);
     const inserted = client.create(table._table, values, options);
     return inserted.mapValue((row) =>
@@ -2457,7 +1805,7 @@ export class Db {
     options: UpsertOptions,
   ): WriteHandle {
     const client = this.getClient(table._schema);
-    const transformedData = transformUpdateInput(table, data);
+    const transformedData = transformInputColumns(table, data);
     const values = toUpdateRecord(transformedData, table._schema, table._table);
     return client.upsert(table._table, values, options);
   }
@@ -2474,7 +1822,7 @@ export class Db {
     options?: UpdateOptions,
   ): WriteHandle {
     const client = this.getClient(table._schema);
-    const transformedData = transformUpdateInput(table, data);
+    const transformedData = transformInputColumns(table, data);
     const updates = toUpdateRecord(transformedData, table._schema, table._table);
     return client.update(id, updates, options);
   }
@@ -2587,8 +1935,12 @@ export class Db {
       return;
     }
 
+    const coordinator = this.storageReset;
+    if (!coordinator) {
+      throw new Error("deleteClientStorage() requires an initialized storage-reset coordinator.");
+    }
     const operation = this.workerReconfigure.then(async () => {
-      await this.requestCoordinatedStorageReset();
+      await coordinator.requestReset();
     });
 
     this.workerReconfigure = operation.then(
@@ -2816,7 +2168,6 @@ export class Db {
       this.localFirstRefreshTimer = null;
     }
     this.clearActiveQuerySubscriptionTraces();
-    this.logLeaderDebug("shutdown");
     this.sendFollowerClose(this.activeRemoteLeaderTabId, this.currentLeaderTerm);
     this.activeRemoteLeaderTabId = null;
     this.leaderPeerIds.clear();
@@ -3003,7 +2354,7 @@ class ClientBackedDb extends Db {
     data: Init,
     options?: CreateOptions,
   ): WriteResult<T> {
-    const transformedData = transformInsertInput(table, data);
+    const transformedData = transformInputColumns(table, data);
     const values = toInsertRecord(transformedData, table._schema, table._table);
     return this.runtimeClient
       .createHandleInternal(table._table, values, this.session, this.attribution, options)
@@ -3015,7 +2366,7 @@ class ClientBackedDb extends Db {
     data: Partial<Init>,
     options: UpsertOptions,
   ): WriteHandle {
-    const transformedData = transformUpdateInput(table, data);
+    const transformedData = transformInputColumns(table, data);
     const values = toUpdateRecord(transformedData, table._schema, table._table);
     return this.runtimeClient.upsertHandleInternal(
       table._table,
@@ -3033,7 +2384,7 @@ class ClientBackedDb extends Db {
     data: Partial<Init>,
     options?: UpdateOptions,
   ): WriteHandle {
-    const transformedData = transformUpdateInput(table, data);
+    const transformedData = transformInputColumns(table, data);
     const updates = toUpdateRecord(transformedData, table._schema, table._table);
     return this.runtimeClient.updateHandleInternal(
       id,
@@ -3274,8 +2625,6 @@ export async function createDb(config: DbConfig): Promise<Db> {
     throw new Error("driver.type='memory' requires serverUrl.");
   }
 
-  logAuthModeInDev(resolvedConfig);
-
   let db: Db;
   if (isBrowser() && driver.type === "persistent") {
     db = await Db.createWithWorker(resolvedConfig);
@@ -3290,23 +2639,6 @@ export async function createDb(config: DbConfig): Promise<Db> {
   return db;
 }
 
-function logAuthModeInDev(config: DbConfig): void {
-  if (config.env === "prod") return;
-  const session = resolveClientSessionSync({
-    appId: config.appId,
-    jwtToken: config.jwtToken,
-    cookieSession: config.cookieSession,
-  });
-  const authMode = session?.authMode ?? "anonymous";
-  const description =
-    authMode === "anonymous"
-      ? "anonymous — ephemeral identity, no write permissions on synced data"
-      : authMode === "local-first"
-        ? "local-first — identity persisted locally via secret"
-        : "external — identity issued by an auth provider";
-  console.info(`[jazz] auth mode: ${authMode} (${description})`);
-}
-
 export function createDbFromClient(
   config: DbConfig,
   client: JazzClient,
@@ -3319,6 +2651,9 @@ export function createDbFromClient(
     client,
     session,
     attribution,
-    scopedAuthState ?? (session || attribution ? backendScopedAuthState(session) : undefined),
+    scopedAuthState ??
+      (session || attribution
+        ? { authMode: session?.authMode ?? "external", session: session ?? null }
+        : undefined),
   );
 }

--- a/packages/jazz-tools/src/runtime/storage-reset-coordinator.ts
+++ b/packages/jazz-tools/src/runtime/storage-reset-coordinator.ts
@@ -1,0 +1,487 @@
+import type { LeaderRole } from "./tab-leader-election.js";
+import type {
+  StorageResetAckMessage,
+  StorageResetBeginMessage,
+  StorageResetFinishedMessage,
+  StorageResetRequestMessage,
+  TabSyncMessage,
+} from "./tab-sync-protocol.js";
+
+const STORAGE_RESET_REQUEST_RETRY_MS = 200;
+const STORAGE_RESET_REQUEST_TIMEOUT_MS = 5_000;
+const STORAGE_RESET_DISCOVERY_WINDOW_MS = 600;
+const STORAGE_RESET_ACK_QUIET_MS = 150;
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+};
+
+type StorageResetContext = {
+  requestId: string;
+  initiatedBySelf: boolean;
+  coordinatorTabId: string | null;
+  begun: boolean;
+  completed: boolean;
+  preparePromise: Promise<string> | null;
+  completion: Deferred<void>;
+};
+
+type CoordinatorState = {
+  requestId: string;
+  startedAtMs: number;
+  lastAckAtMs: number;
+  ackedNamespacesByTabId: Map<string, string>;
+  runPromise: Promise<void> | null;
+};
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function createOperationId(prefix: string): string {
+  const cryptoObj = (globalThis as { crypto?: Crypto }).crypto;
+  if (cryptoObj && typeof cryptoObj.randomUUID === "function") {
+    return `${prefix}-${cryptoObj.randomUUID()}`;
+  }
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function toError(error: unknown, fallbackMessage: string): Error {
+  return error instanceof Error ? error : new Error(error ? String(error) : fallbackMessage);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export interface StorageResetHost {
+  isShuttingDown(): boolean;
+  getTabId(): string | null;
+  getTabRole(): LeaderRole;
+  getCurrentLeaderTabId(): string | null;
+  getCurrentLeaderTerm(): number;
+  hasSyncChannel(): boolean;
+  getPrimaryDbName(): string | null;
+  getCurrentWorkerNamespace(): string;
+  postSyncChannelMessage(message: TabSyncMessage): void;
+  ensureBridgeReady(): Promise<void>;
+  shutdownWorkerAndClients(): Promise<void>;
+  resumeWorker(): Promise<void>;
+}
+
+export class StorageResetCoordinator {
+  private active: StorageResetContext | null = null;
+  private coordinator: CoordinatorState | null = null;
+
+  constructor(private readonly host: StorageResetHost) {}
+
+  async requestReset(): Promise<void> {
+    if (!this.host.hasSyncChannel() || !this.host.getTabId()) {
+      const requestId = createOperationId("storage-reset");
+      const context = this.getOrCreateContext(requestId, true);
+      try {
+        await this.runSingleTab(context);
+        this.resolveContext(context);
+      } catch (error) {
+        this.rejectContext(context, error);
+      }
+      await context.completion.promise;
+      return;
+    }
+
+    if (this.active) {
+      await this.active.completion.promise;
+      return;
+    }
+
+    const requestId = createOperationId("storage-reset");
+    const context = this.getOrCreateContext(requestId, true);
+
+    if (this.host.getTabRole() === "leader") {
+      await this.startAsCoordinator(context);
+      return;
+    }
+
+    const deadline = Date.now() + STORAGE_RESET_REQUEST_TIMEOUT_MS;
+    while (!context.begun) {
+      if (this.host.getTabRole() === "leader") {
+        await this.startAsCoordinator(context);
+        return;
+      }
+
+      this.host.postSyncChannelMessage({
+        type: "storage-reset-request",
+        requestId,
+        fromTabId: this.host.getTabId()!,
+        toLeaderTabId: this.host.getCurrentLeaderTabId(),
+        term: this.host.getCurrentLeaderTerm(),
+      });
+
+      const settled = await Promise.race([
+        context.completion.promise.then(
+          () => true,
+          () => true,
+        ),
+        sleep(STORAGE_RESET_REQUEST_RETRY_MS).then(() => false),
+      ]);
+      if (settled) {
+        await context.completion.promise;
+        return;
+      }
+
+      if (Date.now() >= deadline) {
+        const error = new Error(
+          "Timed out waiting for the leader tab to begin browser storage reset.",
+        );
+        this.rejectContext(context, error);
+        throw error;
+      }
+    }
+
+    await context.completion.promise;
+  }
+
+  handleSyncChannelMessage(message: TabSyncMessage): boolean {
+    switch (message.type) {
+      case "storage-reset-request":
+        this.handleRequest(message);
+        return true;
+      case "storage-reset-begin":
+        this.handleBegin(message);
+        return true;
+      case "storage-reset-ack":
+        this.handleAck(message);
+        return true;
+      case "storage-reset-finished":
+        this.handleFinished(message);
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  private getOrCreateContext(requestId: string, initiatedBySelf: boolean): StorageResetContext {
+    if (this.active?.requestId === requestId) {
+      if (initiatedBySelf) {
+        this.active.initiatedBySelf = true;
+      }
+      return this.active;
+    }
+
+    const completion = createDeferred<void>();
+    void completion.promise.catch(() => undefined);
+
+    const context: StorageResetContext = {
+      requestId,
+      initiatedBySelf,
+      coordinatorTabId: null,
+      begun: false,
+      completed: false,
+      preparePromise: null,
+      completion,
+    };
+    this.active = context;
+    return context;
+  }
+
+  private clearContext(requestId: string): void {
+    if (this.active?.requestId === requestId) {
+      this.active = null;
+    }
+    if (this.coordinator?.requestId === requestId) {
+      this.coordinator = null;
+    }
+  }
+
+  private resolveContext(context: StorageResetContext): void {
+    if (context.completed) return;
+    context.completed = true;
+    context.completion.resolve();
+    this.clearContext(context.requestId);
+  }
+
+  private rejectContext(context: StorageResetContext, error: unknown): void {
+    if (context.completed) return;
+    context.completed = true;
+    context.completion.reject(toError(error, "Browser storage reset failed"));
+    this.clearContext(context.requestId);
+  }
+
+  private async prepare(context: StorageResetContext, coordinatorTabId: string): Promise<string> {
+    if (context.preparePromise) {
+      return await context.preparePromise;
+    }
+
+    context.begun = true;
+    context.coordinatorTabId = coordinatorTabId;
+    context.preparePromise = (async () => {
+      await this.host.ensureBridgeReady();
+
+      const namespace = this.host.getCurrentWorkerNamespace();
+      await this.host.shutdownWorkerAndClients();
+
+      const tabId = this.host.getTabId();
+      if (tabId && coordinatorTabId !== tabId) {
+        this.host.postSyncChannelMessage({
+          type: "storage-reset-ack",
+          requestId: context.requestId,
+          fromTabId: tabId,
+          namespace,
+        });
+      }
+
+      return namespace;
+    })();
+
+    return await context.preparePromise;
+  }
+
+  private async waitForQuiescence(coordinator: CoordinatorState): Promise<void> {
+    while (true) {
+      const now = Date.now();
+      const elapsed = now - coordinator.startedAtMs;
+      const idleMs = now - coordinator.lastAckAtMs;
+      if (elapsed >= STORAGE_RESET_DISCOVERY_WINDOW_MS && idleMs >= STORAGE_RESET_ACK_QUIET_MS) {
+        return;
+      }
+      await sleep(25);
+    }
+  }
+
+  private async collectNamespaces(extraNamespaces: Iterable<string>): Promise<string[]> {
+    const namespaces = new Set<string>();
+    const primaryDbName = this.host.getPrimaryDbName();
+    if (primaryDbName) {
+      namespaces.add(primaryDbName);
+    }
+    for (const namespace of extraNamespaces) {
+      namespaces.add(namespace);
+    }
+
+    if (!primaryDbName) {
+      return [...namespaces];
+    }
+
+    const rootDirectory = await navigator.storage.getDirectory();
+    const rootWithEntries = rootDirectory as FileSystemDirectoryHandle & {
+      entries?: () => AsyncIterable<[string, FileSystemHandle]>;
+    };
+    if (typeof rootWithEntries.entries !== "function") {
+      return [...namespaces];
+    }
+
+    const suffix = ".opfsbtree";
+    const fallbackPrefix = `${primaryDbName}__fallback__`;
+
+    for await (const [name] of rootWithEntries.entries()) {
+      if (!name.endsWith(suffix)) continue;
+      const namespace = name.slice(0, -suffix.length);
+      if (namespace === primaryDbName || namespace.startsWith(fallbackPrefix)) {
+        namespaces.add(namespace);
+      }
+    }
+
+    return [...namespaces];
+  }
+
+  private async removeNamespaceFile(namespace: string): Promise<void> {
+    const rootDirectory = await navigator.storage.getDirectory();
+    const fileName = `${namespace}.opfsbtree`;
+    try {
+      await rootDirectory.removeEntry(fileName, { recursive: false });
+    } catch (error) {
+      const name = (error as { name?: string } | undefined)?.name;
+      if (name === "NotFoundError") {
+        return;
+      }
+      if (name === "NoModificationAllowedError" || name === "InvalidStateError") {
+        throw new Error(
+          `Failed to delete browser storage for "${namespace}" because OPFS is locked by another tab. Close other tabs and retry.`,
+        );
+      }
+      throw new Error(
+        `Failed to delete browser storage for "${namespace}": ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+
+  private async runSingleTab(context: StorageResetContext): Promise<void> {
+    const coordinatorTabId = this.host.getTabId() ?? "single-tab-reset";
+    let resultError: Error | null = null;
+
+    try {
+      const namespace = await this.prepare(context, coordinatorTabId);
+      const namespaces = await this.collectNamespaces([namespace]);
+      for (const candidate of namespaces) {
+        await this.removeNamespaceFile(candidate);
+      }
+    } catch (error) {
+      resultError = toError(error, "Browser storage reset failed");
+    }
+
+    try {
+      await this.host.resumeWorker();
+    } catch (error) {
+      if (!resultError) {
+        resultError = toError(error, "Failed to restart browser worker after storage reset");
+      }
+    }
+
+    if (resultError) {
+      throw resultError;
+    }
+  }
+
+  private async startAsCoordinator(context: StorageResetContext): Promise<void> {
+    if (this.coordinator?.requestId === context.requestId) {
+      return await (this.coordinator.runPromise ?? context.completion.promise);
+    }
+
+    const tabId = this.host.getTabId();
+    if (!tabId || this.host.getTabRole() !== "leader") {
+      throw new Error("Storage reset coordination requires the current tab to be the leader.");
+    }
+
+    const coordinator: CoordinatorState = {
+      requestId: context.requestId,
+      startedAtMs: Date.now(),
+      lastAckAtMs: Date.now(),
+      ackedNamespacesByTabId: new Map(),
+      runPromise: null,
+    };
+    this.coordinator = coordinator;
+
+    coordinator.runPromise = (async () => {
+      let resultError: Error | null = null;
+
+      try {
+        this.host.postSyncChannelMessage({
+          type: "storage-reset-begin",
+          requestId: context.requestId,
+          coordinatorTabId: tabId,
+          term: this.host.getCurrentLeaderTerm(),
+        });
+
+        const localNamespace = await this.prepare(context, tabId);
+        coordinator.ackedNamespacesByTabId.set(tabId, localNamespace);
+        coordinator.lastAckAtMs = Date.now();
+
+        await this.waitForQuiescence(coordinator);
+
+        const namespaces = await this.collectNamespaces(
+          coordinator.ackedNamespacesByTabId.values(),
+        );
+        for (const namespace of namespaces) {
+          await this.removeNamespaceFile(namespace);
+        }
+      } catch (error) {
+        resultError = toError(error, "Browser storage reset failed");
+      }
+
+      try {
+        await this.host.resumeWorker();
+      } catch (error) {
+        if (!resultError) {
+          resultError = toError(error, "Failed to restart browser worker after storage reset");
+        }
+      }
+
+      this.host.postSyncChannelMessage({
+        type: "storage-reset-finished",
+        requestId: context.requestId,
+        success: resultError === null,
+        ...(resultError ? { errorMessage: resultError.message } : {}),
+      });
+
+      if (resultError) {
+        throw resultError;
+      }
+    })()
+      .then(() => {
+        this.resolveContext(context);
+      })
+      .catch((error) => {
+        this.rejectContext(context, error);
+      })
+      .finally(() => {
+        if (this.coordinator?.requestId === context.requestId) {
+          this.coordinator = null;
+        }
+      });
+
+    await coordinator.runPromise;
+  }
+
+  private handleRequest(message: StorageResetRequestMessage): void {
+    if (this.host.getTabRole() !== "leader") return;
+    const tabId = this.host.getTabId();
+    if (!tabId) return;
+    if (message.fromTabId === tabId) return;
+    if (message.toLeaderTabId && message.toLeaderTabId !== tabId) return;
+    if (message.term !== this.host.getCurrentLeaderTerm()) return;
+    if (this.active && this.active.requestId !== message.requestId) return;
+
+    const context = this.getOrCreateContext(message.requestId, false);
+    void this.startAsCoordinator(context).catch(() => undefined);
+  }
+
+  private handleBegin(message: StorageResetBeginMessage): void {
+    const leaderTabId = this.host.getCurrentLeaderTabId();
+    if (!leaderTabId) return;
+    if (message.coordinatorTabId !== leaderTabId) return;
+    if (message.term !== this.host.getCurrentLeaderTerm()) return;
+    if (message.coordinatorTabId === this.host.getTabId()) return;
+    if (this.active && this.active.requestId !== message.requestId) return;
+
+    const context = this.getOrCreateContext(message.requestId, false);
+    context.begun = true;
+    context.coordinatorTabId = message.coordinatorTabId;
+
+    void this.prepare(context, message.coordinatorTabId).catch((error) => {
+      this.rejectContext(context, error);
+    });
+  }
+
+  private handleAck(message: StorageResetAckMessage): void {
+    const coordinator = this.coordinator;
+    if (!coordinator || coordinator.requestId !== message.requestId) return;
+
+    coordinator.ackedNamespacesByTabId.set(message.fromTabId, message.namespace);
+    coordinator.lastAckAtMs = Date.now();
+  }
+
+  private handleFinished(message: StorageResetFinishedMessage): void {
+    const context = this.active;
+    if (!context || context.requestId !== message.requestId || context.completed) return;
+
+    void (async () => {
+      let resultError: Error | null = message.success
+        ? null
+        : new Error(message.errorMessage ?? "Browser storage reset failed");
+
+      try {
+        await this.host.resumeWorker();
+      } catch (error) {
+        if (!resultError) {
+          resultError = toError(error, "Failed to restart browser worker after storage reset");
+        }
+      }
+
+      if (resultError) {
+        this.rejectContext(context, resultError);
+      } else {
+        this.resolveContext(context);
+      }
+    })();
+  }
+}

--- a/packages/jazz-tools/src/runtime/storage-reset-coordinator.ts
+++ b/packages/jazz-tools/src/runtime/storage-reset-coordinator.ts
@@ -62,6 +62,12 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * The capabilities the {@link StorageResetCoordinator} needs from its embedding
+ * runtime (the `Db`) to drive a cross-tab OPFS reset: tab/leader state, the
+ * sync channel for tab-to-tab messages, and lifecycle hooks to shut down and
+ * resume the worker around the destructive delete.
+ */
 export interface StorageResetHost {
   isShuttingDown(): boolean;
   getTabId(): string | null;
@@ -77,6 +83,19 @@ export interface StorageResetHost {
   resumeWorker(): Promise<void>;
 }
 
+/**
+ * Coordinates a browser storage (OPFS) reset across all open tabs of the same
+ * origin so the destructive delete only happens while every tab has released
+ * its worker.
+ *
+ * The leader tab runs the protocol: it broadcasts `storage-reset-begin`, waits
+ * for each follower's `storage-reset-ack` with its current namespace, deletes
+ * the matching OPFS files once the channel goes quiet, and broadcasts
+ * `storage-reset-finished` so all tabs resume their workers in lockstep.
+ * Non-leader tabs send `storage-reset-request` to the leader and otherwise
+ * follow the leader's messages. With no sync channel (single-tab fallback)
+ * the local tab plays both roles.
+ */
 export class StorageResetCoordinator {
   private active: StorageResetContext | null = null;
   private coordinator: CoordinatorState | null = null;

--- a/packages/jazz-tools/src/runtime/tab-sync-protocol.ts
+++ b/packages/jazz-tools/src/runtime/tab-sync-protocol.ts
@@ -1,0 +1,143 @@
+export interface BroadcastChannelLike {
+  postMessage(data: unknown): void;
+  addEventListener(type: "message", listener: (event: MessageEvent) => void): void;
+  removeEventListener(type: "message", listener: (event: MessageEvent) => void): void;
+  close(): void;
+}
+
+export interface FollowerSyncMessage {
+  type: "follower-sync";
+  fromTabId: string;
+  toLeaderTabId: string;
+  term: number;
+  payload: Uint8Array[];
+}
+
+export interface LeaderSyncMessage {
+  type: "leader-sync";
+  fromLeaderTabId: string;
+  toTabId: string;
+  term: number;
+  payload: Uint8Array[];
+}
+
+export interface FollowerCloseMessage {
+  type: "follower-close";
+  fromTabId: string;
+  toLeaderTabId: string;
+  term: number;
+}
+
+export interface StorageResetRequestMessage {
+  type: "storage-reset-request";
+  requestId: string;
+  fromTabId: string;
+  toLeaderTabId: string | null;
+  term: number;
+}
+
+export interface StorageResetBeginMessage {
+  type: "storage-reset-begin";
+  requestId: string;
+  coordinatorTabId: string;
+  term: number;
+}
+
+export interface StorageResetAckMessage {
+  type: "storage-reset-ack";
+  requestId: string;
+  fromTabId: string;
+  namespace: string;
+}
+
+export interface StorageResetFinishedMessage {
+  type: "storage-reset-finished";
+  requestId: string;
+  success: boolean;
+  errorMessage?: string;
+}
+
+export type TabSyncMessage =
+  | FollowerSyncMessage
+  | LeaderSyncMessage
+  | FollowerCloseMessage
+  | StorageResetRequestMessage
+  | StorageResetBeginMessage
+  | StorageResetAckMessage
+  | StorageResetFinishedMessage;
+
+export function resolveBroadcastChannelCtor(): (new (name: string) => BroadcastChannelLike) | null {
+  const ctor = (globalThis as { BroadcastChannel?: unknown }).BroadcastChannel;
+  if (typeof ctor !== "function") return null;
+  return ctor as new (name: string) => BroadcastChannelLike;
+}
+
+function isBinaryPayloadArray(value: unknown): value is Uint8Array[] {
+  return Array.isArray(value) && value.every((entry) => entry instanceof Uint8Array);
+}
+
+export function isTabSyncMessage(value: unknown): value is TabSyncMessage {
+  if (typeof value !== "object" || value === null) return false;
+  const message = value as Record<string, unknown>;
+
+  if (message.type === "follower-sync") {
+    return (
+      typeof message.fromTabId === "string" &&
+      typeof message.toLeaderTabId === "string" &&
+      typeof message.term === "number" &&
+      isBinaryPayloadArray(message.payload)
+    );
+  }
+
+  if (message.type === "leader-sync") {
+    return (
+      typeof message.fromLeaderTabId === "string" &&
+      typeof message.toTabId === "string" &&
+      typeof message.term === "number" &&
+      isBinaryPayloadArray(message.payload)
+    );
+  }
+
+  if (message.type === "follower-close") {
+    return (
+      typeof message.fromTabId === "string" &&
+      typeof message.toLeaderTabId === "string" &&
+      typeof message.term === "number"
+    );
+  }
+
+  if (message.type === "storage-reset-request") {
+    return (
+      typeof message.requestId === "string" &&
+      typeof message.fromTabId === "string" &&
+      (typeof message.toLeaderTabId === "string" || message.toLeaderTabId === null) &&
+      typeof message.term === "number"
+    );
+  }
+
+  if (message.type === "storage-reset-begin") {
+    return (
+      typeof message.requestId === "string" &&
+      typeof message.coordinatorTabId === "string" &&
+      typeof message.term === "number"
+    );
+  }
+
+  if (message.type === "storage-reset-ack") {
+    return (
+      typeof message.requestId === "string" &&
+      typeof message.fromTabId === "string" &&
+      typeof message.namespace === "string"
+    );
+  }
+
+  if (message.type === "storage-reset-finished") {
+    return (
+      typeof message.requestId === "string" &&
+      typeof message.success === "boolean" &&
+      (typeof message.errorMessage === "string" || message.errorMessage === undefined)
+    );
+  }
+
+  return false;
+}


### PR DESCRIPTION
A little semplification on db.ts done by:
- removing some dead code
- remove leader debug code
- moving some types/guards related to the tab sync in a dedicated module
- extracted the storage reset coordinator in their own module