### PR TITLE
perf: switch native targets to mimalloc

### DIFF
--- a/.changeset/mimalloc-native-allocator.md
+++ b/.changeset/mimalloc-native-allocator.md
@@ -1,0 +1,6 @@
+---
+"jazz-tools": patch
+"jazz-napi": patch
+---
+
+Switch native targets to `mimalloc` as the global allocator. The `jazz-tools` CLI server binary and the `jazz-napi` Node native module now run on `mimalloc` (via `mimalloc-safe` for napi, the napi-rs–maintained fork). Yields ~12–26% throughput on alloc-heavy database paths (insert/update/observer) on Linux and macOS without API changes. Bundle-size impact is negligible (~+43 KB gzipped on the napi `.node`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,6 +556,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1728,6 +1737,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "jazz-tools",
+ "mimalloc-safe",
  "napi",
  "napi-build",
  "napi-derive",
@@ -1959,6 +1969,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "libmimalloc-sys2"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cac9b2d60928163027249a1ebd0ec8e6c58b66dca93cccf58ee618e66fc062"
+dependencies = [
+ "cc",
+ "cmake",
+ "libc",
+]
+
+[[package]]
 name = "librocksdb-sys"
 version = "0.18.0+10.7.5"
 dependencies = [
@@ -2059,6 +2089,24 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
+dependencies = [
+ "libmimalloc-sys",
+]
+
+[[package]]
+name = "mimalloc-safe"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8bf95a709c09e85ae74e77b2413cbb11a1b8f2f3d11e23b3751382467c9c15c"
+dependencies = [
+ "libmimalloc-sys2",
+]
 
 [[package]]
 name = "mime"
@@ -3744,6 +3792,7 @@ dependencies = [
  "http-body-util",
  "jazz-tools",
  "jsonwebtoken",
+ "mimalloc",
  "reqwest",
  "reqwest-eventsource",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1790,6 +1790,7 @@ dependencies = [
  "internment",
  "jsonschema",
  "jsonwebtoken",
+ "mimalloc",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-stdout",

--- a/crates/jazz-napi/Cargo.toml
+++ b/crates/jazz-napi/Cargo.toml
@@ -23,6 +23,7 @@ serde_bytes = "0.11"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v7"] }
+mimalloc-safe = "0.1"
 
 [build-dependencies]
 napi-build = "2"

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -10,6 +10,22 @@
 //!   `batched_tick()` on the Node.js event loop (debounced)
 //! - `NapiRuntime` wraps `Arc<Mutex<RuntimeCore<...>>>`
 //! - Server sync uses the Rust-owned WebSocket transport via `connect()`
+//!
+//! # Allocator
+//!
+//! This crate uses `mimalloc-safe` (napi-rs–maintained mimalloc fork) as Rust's
+//! `#[global_allocator]`. It does NOT override the host process's `malloc`/`free` —
+//! Node.js / V8 keep their own allocator. The two coexist safely as long as
+//! memory crosses the FFI boundary **by copy**, which is what napi-rs does today
+//! for Vec/String/Buffer returns.
+//!
+//! Footgun: never `Vec::leak` / `Box::into_raw` an allocation across FFI and let
+//! the host call `free()` on it — that mixes allocators and corrupts the heap.
+//! If a future zero-copy shim is added, hand the host a Rust-defined finalizer
+//! callback that frees through mimalloc instead.
+
+#[global_allocator]
+static GLOBAL: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;
 
 use napi::bindgen_prelude::*;
 use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};

--- a/crates/jazz-tools/Cargo.toml
+++ b/crates/jazz-tools/Cargo.toml
@@ -41,7 +41,7 @@ server = [
   "dep:bytes",
   "dep:reqwest",
 ]
-cli = ["server", "rocksdb", "dep:clap"]
+cli = ["server", "rocksdb", "dep:clap", "dep:mimalloc"]
 test-utils = ["server", "client", "sqlite"]
 test = ["test-utils", "cli"]
 otel-core = [
@@ -101,6 +101,7 @@ async-stream = { version = "0.3", optional = true }
 jsonwebtoken = { version = "9", optional = true }
 base64 = "0.22"
 ed25519-dalek = { version = "2", features = ["rand_core"] }
+mimalloc = { version = "0.1", default-features = false, optional = true }
 
 reqwest = { version = "0.12", default-features = false, features = [
   "json",

--- a/crates/jazz-tools/src/main.rs
+++ b/crates/jazz-tools/src/main.rs
@@ -7,6 +7,13 @@
 //! jazz-tools server <APP_ID> [--port 1625] [--data-dir ./data] [--in-memory]
 //! ```
 
+// mimalloc replaces the system allocator for ~12-26% throughput on the server's
+// allocation-heavy paths (query/insert/observer). The global allocator is a
+// per-binary choice; library code in `jazz-tools` does not declare one so that
+// consumers (jazz-napi, todo-server, third-party embedders) keep theirs.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 mod commands;
 
 use clap::{Parser, Subcommand};

--- a/examples/todo-server-rs/Cargo.toml
+++ b/examples/todo-server-rs/Cargo.toml
@@ -22,6 +22,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tower-http = { version = "0.5", features = ["cors", "trace"] }
 uuid = { version = "1", features = ["v4"] }
 futures-util = "0.3"
+mimalloc = { version = "0.1", default-features = false }
 
 [dev-dependencies]
 jazz_tools = { package = "jazz-tools", path = "../../crates/jazz-tools", features = ["sqlite"] }

--- a/examples/todo-server-rs/src/main.rs
+++ b/examples/todo-server-rs/src/main.rs
@@ -24,6 +24,12 @@
 //! | `/todos/:id` | DELETE | Delete item |
 //! | `/updates` | GET | SSE stream of add/remove events |
 
+// mimalloc replaces the system allocator for ~25% throughput on Rust-side
+// allocation-heavy paths (query/insert/observer). Single-process, single-language —
+// no FFI ownership concerns here.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 mod routes;
 
 use std::net::SocketAddr;


### PR DESCRIPTION
## Summary

Use `mimalloc` as the global allocator for the three native targets where Rust-side allocations dominate the hot path. Both targets are allocation-heavy on the database paths (`HashMap`, `BTreeMap`, `Vec`, `Arc`, query/insert/observer churn) and the system allocators we currently rely on are not the strongest.

- `crates/jazz-tools` **CLI binary** (the production server entrypoint, `jazz-tools server <APP_ID>`): upstream `mimalloc`, pulled in via the `cli` feature. Allocator declared in `src/main.rs` so library consumers of `jazz-tools` are unaffected and keep their own allocator choice.
- `examples/todo-server-rs` (example axum/tokio service): upstream `mimalloc`. Single-process, single-language — no FFI ownership concerns.
- `crates/jazz-napi` (Node native bindings): `mimalloc-safe` (the napi-rs maintained fork). Builds with explicit no-override of the host's `malloc`/`free`, plus shutdown-safe defaults for the dlopen-into-Node scenario. Module-level doc note added documenting the cross-allocator FFI rule.

`#[global_allocator]` is a per-binary, link-time choice — it cannot be flipped at runtime. Keeping it out of the library and inside each binary's `main.rs` lets every target pick its own allocator without conflicts.

`wasm32` is intentionally **not** included — mimalloc's C source needs libc headers that `wasm32-unknown-unknown` does not provide. RN/iOS+Android are deferred to a follow-up.

## Benchmarks

### Rust core (criterion, `observer_write_path`, macOS arm64)

| Benchmark | system | mimalloc | Δ |
|---|---|---|---|
| `no_observer/1000` (single update) | 37.21 µs | 28.02 µs | **−25.5%** |
| `observe_all/1000` (update + subscription propagation) | 653.82 µs | 468.70 µs | **−27.7%** |

Both `p < 0.05`, change reported by criterion's built-in baseline comparison.

### napi end-to-end through FFI (Node 22, single-thread, N=1000 ops, 5 rounds, median)

**macOS arm64:**

| Operation | system | mimalloc-safe | Δ |
|---|---|---|---|
| insert (per row) | 27.15 µs | 21.13 µs | **−22.2%** |
| update (per row) | 24.71 µs | 18.57 µs | **−24.8%** |
| update warm (per row) | 24.66 µs | 18.44 µs | **−25.2%** |

**Linux arm64 (Docker, glibc malloc baseline):**

| Operation | glibc | mimalloc-safe | Δ |
|---|---|---|---|
| insert (per row) | 27.99 µs | 20.71 µs | **−26.0%** |
| update (per row) | 21.52 µs | 18.92 µs | **−12.1%** |
| update warm (per row) | 21.79 µs | 18.83 µs | **−13.6%** |

The FFI overhead does not noticeably dilute the allocator gain — the Rust-only criterion result and the napi end-to-end result match closely on macOS, confirming the `#[global_allocator]` change is doing its job through the napi-rs binding.

The Linux update path benefits less than macOS (~13% vs ~25%) because glibc's per-thread arenas are more competitive than macOS's single-zone allocator. The insert path delta is similar across both platforms (~26% vs ~22%) — that workload's allocation pattern hits a sweet spot for mimalloc regardless of baseline. Single-threaded numbers are the conservative case; multi-threaded server load will likely show bigger Linux wins because of arena contention in glibc malloc.

## Bundle size impact

Measured on the napi `.node` binary (macOS arm64, release profile):

| Build | Raw | Gzipped |
|---|---|---|
| baseline (system malloc) | 24,752,096 B (23.61 MB) | 9,605,999 B (9.16 MB) |
| mimalloc-safe (this PR) | 24,815,584 B (23.67 MB) | 9,650,366 B (9.20 MB) |
| **Δ** | **+62 KB (+0.26%)** | **+43 KB (+0.46%)** |

Negligible on a 24 MB native module; npm install will not feel it. Server binaries (jazz-tools CLI, todo-server) see a similar absolute add (~50–100 KB) and aren't shipped over npm anyway.

## Where the allocator lives

| Crate | Binary | Allocator |
|---|---|---|
| `jazz-tools` (lib) | — | none — consumers choose |
| `jazz-tools` (CLI bin, gated by `cli` feature) | `jazz-tools` | `mimalloc` |
| `jazz-napi` | `*.node` | `mimalloc-safe` |
| `todo-server-rs` | `todo-server` | `mimalloc` |
| `jazz-wasm` | wasm | system (mimalloc won't compile on `wasm32-unknown-unknown`) |

A `cargo tree -p jazz-tools --no-default-features --features client` confirms `mimalloc` is absent from the lib-only dependency closure — non-CLI consumers don't pull it in.

## FFI safety (jazz-napi specifically)

`#[global_allocator]` only replaces Rust's `Global` allocator (used by `Box`/`Vec`/`String`/`HashMap`/etc. inside the .node module). It does **not** override the host process's `malloc`/`free`. Two allocators coexist in the Node process: V8 + system allocator on the JS side, mimalloc on the Rust side.

This is safe **as long as memory crosses the FFI boundary by copy**, which is what napi-rs does today for `Vec<T>` / `String` / `Buffer` returns. The footgun: if a future zero-copy shim leaks a `Box::into_raw` / `Vec::leak` pointer for V8 to free, you'd get heap corruption (mimalloc-allocated memory freed by system free).

A documentation block at the top of `crates/jazz-napi/src/lib.rs` records this constraint so the next person adding a zero-copy path knows to use a Rust-defined finalizer callback instead of a raw pointer leak.

## Drawbacks considered

- **Memory footprint**: mimalloc reserves arenas in 32MB chunks and holds freed pages for ~10s before returning to the OS. Translates to +5–15% RSS on idle, comparable or lower under sustained load. Not material for a server / Node addon. Tunable via `MIMALLOC_PURGE_DELAY=0` if it ever bites.
- **Sanitizers / heap profilers** lose some fidelity vs system malloc (AddressSanitizer in particular can interact badly). If this becomes a problem for debug workflows, gating mimalloc behind a feature flag is a one-line change.
- **Build complexity**: adds a C compile step (cmake + clang). First build ~20s slower, incremental builds unchanged. Linux CI image needs `cmake` and `build-essential` — both should already be present on standard images.

## Test plan

- [x] `cargo build -p jazz-tools --features cli --bin jazz-tools --release` succeeds locally.
- [x] `cargo tree -p jazz-tools --no-default-features --features client` shows mimalloc is NOT in the lib closure.
- [x] `cargo build -p todo-server --release` succeeds locally.
- [x] `cargo build -p jazz-napi --release` succeeds locally.
- [x] Rust criterion bench `observer_write_path` reports allocator delta as expected.
- [x] napi end-to-end bench (macOS arm64) confirms gain carries through FFI.
- [x] napi end-to-end bench (Linux arm64 in Docker) confirms gain on Linux.
- [x] Bundle-size delta on the napi `.node` binary measured (+62 KB raw / +43 KB gzipped).
- [ ] CI builds pass (clippy, rustfmt, test).
- [ ] Multi-threaded server load test on Linux (follow-up if interest).