### PR TITLE
chore: refactor db to inject the native runtime module

### DIFF
--- a/.changeset/rn-anonymous-auth.md
+++ b/.changeset/rn-anonymous-auth.md
@@ -1,0 +1,6 @@
+---
+"jazz-tools": patch
+"jazz-rn": patch
+---
+
+Add React Native anonymous auth support. `jazz-tools` now mints anonymous JWTs through the React Native runtime module when no auth credentials are provided, and `jazz-rn` exposes the matching native `mintAnonymousToken` binding.

--- a/crates/jazz-rn/cpp/jazz_rn.cpp
+++ b/crates/jazz-rn/cpp/jazz_rn.cpp
@@ -218,6 +218,9 @@ void uniffi_jazz_rn_fn_init_callback_vtable_subscriptioncallback(
 int64_t
 uniffi_jazz_rn_fn_func_current_timestamp_ms(RustCallStatus *uniffi_out_err);
 RustBuffer uniffi_jazz_rn_fn_func_generate_id(RustCallStatus *uniffi_out_err);
+RustBuffer uniffi_jazz_rn_fn_func_mint_anonymous_token(
+    RustBuffer seed_b64, RustBuffer audience, int64_t ttl_seconds,
+    RustCallStatus *uniffi_out_err);
 RustBuffer uniffi_jazz_rn_fn_func_mint_local_first_token(
     RustBuffer seed_b64, RustBuffer audience, int64_t ttl_seconds,
     RustCallStatus *uniffi_out_err);
@@ -339,6 +342,7 @@ void ffi_jazz_rn_rust_future_complete_void(
     /*handle*/ uint64_t handle, RustCallStatus *uniffi_out_err);
 uint16_t uniffi_jazz_rn_checksum_func_current_timestamp_ms();
 uint16_t uniffi_jazz_rn_checksum_func_generate_id();
+uint16_t uniffi_jazz_rn_checksum_func_mint_anonymous_token();
 uint16_t uniffi_jazz_rn_checksum_func_mint_local_first_token();
 uint16_t uniffi_jazz_rn_checksum_method_rnruntime_acknowledge_rejected_batch();
 uint16_t uniffi_jazz_rn_checksum_method_rnruntime_add_client();
@@ -3365,6 +3369,17 @@ NativeJazzRn::NativeJazzRn(
             return this->cpp_uniffi_jazz_rn_fn_func_generate_id(rt, thisVal,
                                                                 args, count);
           });
+  props["ubrn_uniffi_jazz_rn_fn_func_mint_anonymous_token"] =
+      jsi::Function::createFromHostFunction(
+          rt,
+          jsi::PropNameID::forAscii(
+              rt, "ubrn_uniffi_jazz_rn_fn_func_mint_anonymous_token"),
+          3,
+          [this](jsi::Runtime &rt, const jsi::Value &thisVal,
+                 const jsi::Value *args, size_t count) -> jsi::Value {
+            return this->cpp_uniffi_jazz_rn_fn_func_mint_anonymous_token(
+                rt, thisVal, args, count);
+          });
   props["ubrn_uniffi_jazz_rn_fn_func_mint_local_first_token"] =
       jsi::Function::createFromHostFunction(
           rt,
@@ -3396,6 +3411,17 @@ NativeJazzRn::NativeJazzRn(
           [this](jsi::Runtime &rt, const jsi::Value &thisVal,
                  const jsi::Value *args, size_t count) -> jsi::Value {
             return this->cpp_uniffi_jazz_rn_checksum_func_generate_id(
+                rt, thisVal, args, count);
+          });
+  props["ubrn_uniffi_jazz_rn_checksum_func_mint_anonymous_token"] =
+      jsi::Function::createFromHostFunction(
+          rt,
+          jsi::PropNameID::forAscii(
+              rt, "ubrn_uniffi_jazz_rn_checksum_func_mint_anonymous_token"),
+          0,
+          [this](jsi::Runtime &rt, const jsi::Value &thisVal,
+                 const jsi::Value *args, size_t count) -> jsi::Value {
+            return this->cpp_uniffi_jazz_rn_checksum_func_mint_anonymous_token(
                 rt, thisVal, args, count);
           });
   props["ubrn_uniffi_jazz_rn_checksum_func_mint_local_first_token"] =
@@ -4547,6 +4573,20 @@ jsi::Value NativeJazzRn::cpp_uniffi_jazz_rn_fn_func_generate_id(
 
   return uniffi::jazz_rn::Bridging<RustBuffer>::toJs(rt, callInvoker, value);
 }
+jsi::Value NativeJazzRn::cpp_uniffi_jazz_rn_fn_func_mint_anonymous_token(
+    jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
+    size_t count) {
+  RustCallStatus status =
+      uniffi::jazz_rn::Bridging<RustCallStatus>::rustSuccess(rt);
+  auto value = uniffi_jazz_rn_fn_func_mint_anonymous_token(
+      uniffi::jazz_rn::Bridging<RustBuffer>::fromJs(rt, callInvoker, args[0]),
+      uniffi::jazz_rn::Bridging<RustBuffer>::fromJs(rt, callInvoker, args[1]),
+      uniffi_jsi::Bridging<int64_t>::fromJs(rt, callInvoker, args[2]), &status);
+  uniffi::jazz_rn::Bridging<RustCallStatus>::copyIntoJs(rt, callInvoker, status,
+                                                        args[count - 1]);
+
+  return uniffi::jazz_rn::Bridging<RustBuffer>::toJs(rt, callInvoker, value);
+}
 jsi::Value NativeJazzRn::cpp_uniffi_jazz_rn_fn_func_mint_local_first_token(
     jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
     size_t count) {
@@ -4572,6 +4612,13 @@ jsi::Value NativeJazzRn::cpp_uniffi_jazz_rn_checksum_func_generate_id(
     jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
     size_t count) {
   auto value = uniffi_jazz_rn_checksum_func_generate_id();
+
+  return uniffi_jsi::Bridging<uint16_t>::toJs(rt, callInvoker, value);
+}
+jsi::Value NativeJazzRn::cpp_uniffi_jazz_rn_checksum_func_mint_anonymous_token(
+    jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
+    size_t count) {
+  auto value = uniffi_jazz_rn_checksum_func_mint_anonymous_token();
 
   return uniffi_jsi::Bridging<uint16_t>::toJs(rt, callInvoker, value);
 }

--- a/crates/jazz-rn/cpp/jazz_rn.hpp
+++ b/crates/jazz-rn/cpp/jazz_rn.hpp
@@ -149,6 +149,9 @@ protected:
                                                     const jsi::Value &thisVal,
                                                     const jsi::Value *args,
                                                     size_t count);
+  jsi::Value cpp_uniffi_jazz_rn_fn_func_mint_anonymous_token(
+      jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
+      size_t count);
   jsi::Value cpp_uniffi_jazz_rn_fn_func_mint_local_first_token(
       jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
       size_t count);
@@ -156,6 +159,9 @@ protected:
       jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
       size_t count);
   jsi::Value cpp_uniffi_jazz_rn_checksum_func_generate_id(
+      jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
+      size_t count);
+  jsi::Value cpp_uniffi_jazz_rn_checksum_func_mint_anonymous_token(
       jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args,
       size_t count);
   jsi::Value cpp_uniffi_jazz_rn_checksum_func_mint_local_first_token(

--- a/crates/jazz-rn/rust/src/lib.rs
+++ b/crates/jazz-rn/rust/src/lib.rs
@@ -1224,6 +1224,39 @@ pub fn mint_local_first_token(
     audience: String,
     ttl_seconds: i64,
 ) -> Result<String, JazzRnError> {
+    mint_token(
+        seed_b64,
+        audience,
+        ttl_seconds,
+        jazz_tools::identity::LOCAL_FIRST_ISSUER,
+    )
+}
+
+/// Mint an anonymous JWT from a base64url-encoded 32-byte seed.
+///
+/// Returns a signed JWT that can be used as a bearer token for anonymous auth.
+/// `audience` should be the app ID (UUID) or a human-readable app name.
+/// `ttl_seconds` controls token lifetime (e.g. 3600 for one hour).
+#[uniffi::export]
+pub fn mint_anonymous_token(
+    seed_b64: String,
+    audience: String,
+    ttl_seconds: i64,
+) -> Result<String, JazzRnError> {
+    mint_token(
+        seed_b64,
+        audience,
+        ttl_seconds,
+        jazz_tools::identity::ANONYMOUS_ISSUER,
+    )
+}
+
+fn mint_token(
+    seed_b64: String,
+    audience: String,
+    ttl_seconds: i64,
+    issuer: &'static str,
+) -> Result<String, JazzRnError> {
     use base64::Engine;
     let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
         .decode(&seed_b64)
@@ -1233,11 +1266,6 @@ pub fn mint_local_first_token(
     let seed: [u8; 32] = bytes.try_into().map_err(|_| JazzRnError::Internal {
         message: "seed must be exactly 32 bytes".to_string(),
     })?;
-    jazz_tools::identity::mint_jazz_self_signed_token(
-        &seed,
-        jazz_tools::identity::LOCAL_FIRST_ISSUER,
-        &audience,
-        ttl_seconds as u64,
-    )
-    .map_err(|e| JazzRnError::Internal { message: e })
+    jazz_tools::identity::mint_jazz_self_signed_token(&seed, issuer, &audience, ttl_seconds as u64)
+        .map_err(|e| JazzRnError::Internal { message: e })
 }

--- a/crates/jazz-rn/src/generated/jazz_rn-ffi.ts
+++ b/crates/jazz-rn/src/generated/jazz_rn-ffi.ts
@@ -224,6 +224,12 @@ interface NativeModuleInterface {
   ubrn_uniffi_jazz_rn_fn_func_generate_id(
     uniffi_out_err: UniffiRustCallStatus
   ): Uint8Array;
+  ubrn_uniffi_jazz_rn_fn_func_mint_anonymous_token(
+    seedB64: Uint8Array,
+    audience: Uint8Array,
+    ttlSeconds: bigint,
+    uniffi_out_err: UniffiRustCallStatus
+  ): Uint8Array;
   ubrn_uniffi_jazz_rn_fn_func_mint_local_first_token(
     seedB64: Uint8Array,
     audience: Uint8Array,
@@ -232,6 +238,7 @@ interface NativeModuleInterface {
   ): Uint8Array;
   ubrn_uniffi_jazz_rn_checksum_func_current_timestamp_ms(): number;
   ubrn_uniffi_jazz_rn_checksum_func_generate_id(): number;
+  ubrn_uniffi_jazz_rn_checksum_func_mint_anonymous_token(): number;
   ubrn_uniffi_jazz_rn_checksum_func_mint_local_first_token(): number;
   ubrn_uniffi_jazz_rn_checksum_method_rnruntime_acknowledge_rejected_batch(): number;
   ubrn_uniffi_jazz_rn_checksum_method_rnruntime_add_client(): number;

--- a/crates/jazz-rn/src/generated/jazz_rn.ts
+++ b/crates/jazz-rn/src/generated/jazz_rn.ts
@@ -103,6 +103,35 @@ export function generateId(): string {
   );
 }
 /**
+ * Mint an anonymous JWT from a base64url-encoded 32-byte seed.
+ *
+ * Returns a signed JWT that can be used as a bearer token for anonymous auth.
+ * `audience` should be the app ID (UUID) or a human-readable app name.
+ * `ttl_seconds` controls token lifetime (e.g. 3600 for one hour).
+ */
+export function mintAnonymousToken(
+  seedB64: string,
+  audience: string,
+  ttlSeconds: /*i64*/ bigint
+): string /*throws*/ {
+  return FfiConverterString.lift(
+    uniffiCaller.rustCallWithError(
+      /*liftError:*/ FfiConverterTypeJazzRnError.lift.bind(
+        FfiConverterTypeJazzRnError
+      ),
+      /*caller:*/ (callStatus) => {
+        return nativeModule().ubrn_uniffi_jazz_rn_fn_func_mint_anonymous_token(
+          FfiConverterString.lower(seedB64),
+          FfiConverterString.lower(audience),
+          FfiConverterInt64.lower(ttlSeconds),
+          callStatus
+        );
+      },
+      /*liftString:*/ FfiConverterString.lift
+    )
+  );
+}
+/**
  * Mint a local-first JWT from a base64url-encoded 32-byte seed.
  *
  * Returns a signed JWT that can be used as a bearer token for local-first auth.
@@ -1564,6 +1593,14 @@ function uniffiEnsureInitialized() {
   ) {
     throw new UniffiInternalError.ApiChecksumMismatch(
       'uniffi_jazz_rn_checksum_func_generate_id'
+    );
+  }
+  if (
+    nativeModule().ubrn_uniffi_jazz_rn_checksum_func_mint_anonymous_token() !==
+    11470
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      'uniffi_jazz_rn_checksum_func_mint_anonymous_token'
     );
   }
   if (

--- a/packages/jazz-tools/src/dev-tools/extension-panel.ts
+++ b/packages/jazz-tools/src/dev-tools/extension-panel.ts
@@ -13,7 +13,6 @@ import {
   SubscriptionCallback,
   UpdateOptions,
   Value,
-  WasmModule,
   WasmSchema,
 } from "../index.js";
 import { DirectInsertResult, DirectMutationResult } from "../runtime/client.js";
@@ -425,7 +424,7 @@ async function ensureDevtoolsAnnounced(): Promise<DevToolsBootstrap> {
 
 export async function createDbFromInspectedPage(): Promise<DevToolsDb> {
   const bootstrap = await waitForDevToolsBootstrap();
-  return new DevToolsDb(bootstrap.dbConfig, null);
+  return new DevToolsDb(bootstrap.dbConfig);
 }
 
 export function getRegisteredWasmSchema(): WasmSchema | null {
@@ -469,8 +468,8 @@ export function onActiveQuerySubscriptionsChange(
 }
 
 class DevToolsDb extends Db {
-  constructor(config: DbConfig, wasmModule: WasmModule | null) {
-    super(config, wasmModule);
+  constructor(config: DbConfig) {
+    super(config, null);
   }
 
   async connectProxyRuntime(): Promise<DevToolsBootstrap> {

--- a/packages/jazz-tools/src/react-native/db.test.ts
+++ b/packages/jazz-tools/src/react-native/db.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { WasmSchema } from "../drivers/types.js";
-import { JazzClient } from "../runtime/client.js";
+import { schema as s } from "../index.js";
+import { JazzClient, WriteResult, type DirectInsertResult } from "../runtime/client.js";
 import { Db, type DbConfig, createDb } from "./db.js";
 import { createJazzRnRuntime } from "./create-jazz-rn-runtime.js";
 
@@ -12,32 +12,61 @@ vi.mock("jazz-rn", () => ({
   default: {
     jazz_rn: {
       mintLocalFirstToken: vi.fn(),
+      mintAnonymousToken: vi.fn(),
     },
   },
 }));
 
-class TestDb extends Db {
-  public exposeGetClient(schema: WasmSchema): JazzClient {
-    return this.getClient(schema);
-  }
+function makeTodosApp() {
+  return s.defineApp({
+    todos: s.table({
+      title: s.string(),
+    }),
+  });
 }
 
-function makeSchema(tableName: string): WasmSchema {
-  return {
-    [tableName]: {
-      columns: [{ name: "title", column_type: { type: "Text" }, nullable: false }],
-    },
-  };
+function makeProjectsApp() {
+  return s.defineApp({
+    projects: s.table({
+      title: s.string(),
+    }),
+  });
 }
 
 function makeClientStub() {
   const shutdown = vi.fn(async () => undefined);
   const updateAuthToken = vi.fn();
+  const updateCookieSession = vi.fn();
   const connectTransport = vi.fn();
-  return {
-    client: { shutdown, updateAuthToken, connectTransport } as unknown as JazzClient,
+  let client: JazzClient & {
+    create: ReturnType<typeof vi.fn>;
+    shutdown: ReturnType<typeof vi.fn>;
+    updateAuthToken: ReturnType<typeof vi.fn>;
+    updateCookieSession: ReturnType<typeof vi.fn>;
+    connectTransport: ReturnType<typeof vi.fn>;
+  };
+  const create = vi.fn(() => {
+    const row: DirectInsertResult = {
+      id: "todo-1",
+      values: [{ type: "Text", value: "Buy milk" }],
+      batchId: "batch-1",
+    };
+    return new WriteResult(row, row.batchId, client);
+  });
+  client = {
+    create,
     shutdown,
     updateAuthToken,
+    updateCookieSession,
+    connectTransport,
+    getRuntime: vi.fn(() => ({}) as never),
+  } as unknown as typeof client;
+  return {
+    client,
+    create,
+    shutdown,
+    updateAuthToken,
+    updateCookieSession,
     connectTransport,
   };
 }
@@ -60,17 +89,22 @@ describe("createDb", () => {
 
     expect(mintMock).toHaveBeenCalledWith("base64url-seed-32bytes", "test-app", BigInt(3600));
     expect(db).toBeInstanceOf(Db);
+    await db.shutdown();
   });
 
-  it("RNDB-U07 skips JWT minting and returns a plain Db when auth is absent", async () => {
+  it("RNDB-U07 mints an anonymous JWT when auth is absent", async () => {
     const jazzRn = (await import("jazz-rn")).default;
-    const mintMock = vi.mocked(jazzRn.jazz_rn.mintLocalFirstToken);
+    const localFirstMintMock = vi.mocked(jazzRn.jazz_rn.mintLocalFirstToken);
+    const anonymousMintMock = vi.mocked(jazzRn.jazz_rn.mintAnonymousToken);
+    anonymousMintMock.mockReturnValue("anonymous-jwt");
 
     const config: DbConfig = { appId: "test-app" };
     const db = await createDb(config);
 
-    expect(mintMock).not.toHaveBeenCalled();
+    expect(localFirstMintMock).not.toHaveBeenCalled();
+    expect(anonymousMintMock).toHaveBeenCalledWith(expect.any(String), "test-app", BigInt(3600));
     expect(db).toBeInstanceOf(Db);
+    await db.shutdown();
   });
 });
 
@@ -85,11 +119,12 @@ describe("react-native Db", () => {
     vi.restoreAllMocks();
   });
 
-  it("RNDB-U01 forwards config to runtime and client wiring on first schema access", () => {
+  it("RNDB-U01 forwards config to runtime and client wiring on first write", async () => {
     const connectWithRuntimeSpy = vi.spyOn(JazzClient, "connectWithRuntime");
     const { client } = makeClientStub();
     const runtime = { id: "runtime-a" };
-    const schema = makeSchema("todos");
+    const app = makeTodosApp();
+    const schema = app.todos._schema;
     const config: DbConfig = {
       appId: "rn-app",
       serverUrl: "https://example.test",
@@ -97,17 +132,17 @@ describe("react-native Db", () => {
       userBranch: "user-branch",
       jwtToken: "jwt-token",
       adminSecret: "admin-secret",
-      tier: "local",
+      tier: "edge",
       dataPath: "/tmp/rn-data",
     };
 
     createJazzRnRuntimeMock.mockReturnValue(runtime as never);
     connectWithRuntimeSpy.mockReturnValue(client);
 
-    const db = new TestDb(config);
-    const resolved = db.exposeGetClient(schema);
+    const db = await createDb(config);
+    const inserted = db.insert(app.todos, { title: "Buy milk" });
 
-    expect(resolved).toBe(client);
+    expect(inserted.value).toEqual({ id: "todo-1", title: "Buy milk" });
     expect(createJazzRnRuntimeMock).toHaveBeenCalledWith({
       schema,
       appId: config.appId,
@@ -127,7 +162,7 @@ describe("react-native Db", () => {
         jwtToken: config.jwtToken,
         adminSecret: config.adminSecret,
         tier: config.tier,
-        defaultDurabilityTier: config.tier,
+        defaultDurabilityTier: "local",
       },
       {
         onAuthFailure: expect.any(Function),
@@ -135,11 +170,11 @@ describe("react-native Db", () => {
     );
   });
 
-  it("RNDB-U02 reuses cached clients for same schema key and creates new clients for distinct schemas", () => {
+  it("RNDB-U02 reuses cached clients for same schema key and creates new clients for distinct schemas", async () => {
     const connectWithRuntimeSpy = vi.spyOn(JazzClient, "connectWithRuntime");
-    const schemaA = makeSchema("todos");
-    const schemaAClone = JSON.parse(JSON.stringify(schemaA)) as WasmSchema;
-    const schemaB = makeSchema("projects");
+    const todosApp = makeTodosApp();
+    const todosAppClone = makeTodosApp();
+    const projectsApp = makeProjectsApp();
 
     const { client: clientA } = makeClientStub();
     const { client: clientB } = makeClientStub();
@@ -149,23 +184,21 @@ describe("react-native Db", () => {
       .mockReturnValueOnce({ id: "runtime-b" } as never);
     connectWithRuntimeSpy.mockReturnValueOnce(clientA).mockReturnValueOnce(clientB);
 
-    const db = new TestDb({ appId: "rn-app" });
-    const first = db.exposeGetClient(schemaA);
-    const second = db.exposeGetClient(schemaAClone);
-    const third = db.exposeGetClient(schemaB);
+    const db = await createDb({ appId: "rn-app" });
+    db.insert(todosApp.todos, { title: "Buy milk" });
+    db.insert(todosAppClone.todos, { title: "Buy milk" });
+    db.insert(projectsApp.projects, { title: "Buy milk" });
 
-    expect(first).toBe(clientA);
-    expect(second).toBe(clientA);
-    expect(third).toBe(clientB);
-    expect(first).not.toBe(third);
+    expect(clientA.create).toHaveBeenCalledTimes(2);
+    expect(clientB.create).toHaveBeenCalledTimes(1);
     expect(createJazzRnRuntimeMock).toHaveBeenCalledTimes(2);
     expect(connectWithRuntimeSpy).toHaveBeenCalledTimes(2);
   });
 
   it("RNDB-U03 shutdown closes all memoized clients and clears cache", async () => {
     const connectWithRuntimeSpy = vi.spyOn(JazzClient, "connectWithRuntime");
-    const schemaA = makeSchema("todos");
-    const schemaB = makeSchema("projects");
+    const todosApp = makeTodosApp();
+    const projectsApp = makeProjectsApp();
 
     const clientA = makeClientStub();
     const clientB = makeClientStub();
@@ -180,35 +213,34 @@ describe("react-native Db", () => {
       .mockReturnValueOnce(clientB.client)
       .mockReturnValueOnce(clientAfterShutdown.client);
 
-    const db = new TestDb({ appId: "rn-app" });
-    const firstA = db.exposeGetClient(schemaA);
-    const firstB = db.exposeGetClient(schemaB);
+    const db = await createDb({ appId: "rn-app" });
+    const firstA = db.insert(todosApp.todos, { title: "Buy milk" });
+    const firstB = db.insert(projectsApp.projects, { title: "Buy milk" });
 
-    expect(firstA).toBe(clientA.client);
-    expect(firstB).toBe(clientB.client);
+    expect(firstA.value.id).toBe("todo-1");
+    expect(firstB.value.id).toBe("todo-1");
 
     await db.shutdown();
 
     expect(clientA.shutdown).toHaveBeenCalledTimes(1);
     expect(clientB.shutdown).toHaveBeenCalledTimes(1);
 
-    const secondA = db.exposeGetClient(schemaA);
-    expect(secondA).toBe(clientAfterShutdown.client);
-    expect(secondA).not.toBe(firstA);
+    db.insert(todosApp.todos, { title: "Buy milk" });
+    expect(clientAfterShutdown.create).toHaveBeenCalledTimes(1);
     expect(connectWithRuntimeSpy).toHaveBeenCalledTimes(3);
   });
 
-  it("RNDB-U04 surfaces runtime and client wiring failures", () => {
+  it("RNDB-U04 surfaces runtime and client wiring failures", async () => {
     const connectWithRuntimeSpy = vi.spyOn(JazzClient, "connectWithRuntime");
-    const schema = makeSchema("todos");
-    const db = new TestDb({ appId: "rn-app" });
+    const app = makeTodosApp();
+    const db = await createDb({ appId: "rn-app" });
 
     const runtimeError = new Error("runtime wiring failed");
     createJazzRnRuntimeMock.mockImplementationOnce(() => {
       throw runtimeError;
     });
 
-    expect(() => db.exposeGetClient(schema)).toThrow(runtimeError);
+    expect(() => db.insert(app.todos, { title: "Buy milk" })).toThrow(runtimeError);
     expect(connectWithRuntimeSpy).not.toHaveBeenCalled();
 
     const clientError = new Error("client wiring failed");
@@ -217,13 +249,13 @@ describe("react-native Db", () => {
       throw clientError;
     });
 
-    expect(() => db.exposeGetClient(schema)).toThrow(clientError);
+    expect(() => db.insert(app.todos, { title: "Buy milk" })).toThrow(clientError);
   });
 
-  it("RNDB-U05 forwards updateAuthToken to cached native clients", () => {
+  it("RNDB-U05 forwards updateAuthToken to cached native clients", async () => {
     const connectWithRuntimeSpy = vi.spyOn(JazzClient, "connectWithRuntime");
-    const schemaA = makeSchema("todos");
-    const schemaB = makeSchema("projects");
+    const todosApp = makeTodosApp();
+    const projectsApp = makeProjectsApp();
     const clientA = makeClientStub();
     const clientB = makeClientStub();
 
@@ -232,9 +264,9 @@ describe("react-native Db", () => {
       .mockReturnValueOnce({ id: "runtime-b" } as never);
     connectWithRuntimeSpy.mockReturnValueOnce(clientA.client).mockReturnValueOnce(clientB.client);
 
-    const db = new TestDb({ appId: "rn-app", jwtToken: "stale-jwt" });
-    db.exposeGetClient(schemaA);
-    db.exposeGetClient(schemaB);
+    const db = await createDb({ appId: "rn-app", jwtToken: "stale-jwt" });
+    db.insert(todosApp.todos, { title: "Buy milk" });
+    db.insert(projectsApp.projects, { title: "Buy milk" });
 
     db.updateAuthToken("fresh-jwt");
 
@@ -242,19 +274,47 @@ describe("react-native Db", () => {
     expect(clientB.updateAuthToken).toHaveBeenCalledWith("fresh-jwt");
   });
 
-  it("RNDB-U08 calls connectTransport when serverUrl is configured", () => {
+  it("RNDB-U10 forwards updateCookieSession to cached native clients", async () => {
+    const connectWithRuntimeSpy = vi.spyOn(JazzClient, "connectWithRuntime");
+    const app = makeTodosApp();
+    const stub = makeClientStub();
+
+    createJazzRnRuntimeMock.mockReturnValue({ id: "runtime" } as never);
+    connectWithRuntimeSpy.mockReturnValue(stub.client);
+
+    const db = await createDb({
+      appId: "rn-app",
+      cookieSession: {
+        user_id: "alice",
+        claims: { role: "reader" },
+        authMode: "external",
+      },
+    });
+    db.insert(app.todos, { title: "Buy milk" });
+
+    const cookieSession = {
+      user_id: "alice",
+      claims: { role: "editor" },
+      authMode: "external" as const,
+    };
+    db.updateCookieSession(cookieSession);
+
+    expect(stub.updateCookieSession).toHaveBeenCalledWith(cookieSession);
+  });
+
+  it("RNDB-U08 calls connectTransport when serverUrl is configured", async () => {
     const connectWithRuntimeSpy = vi.spyOn(JazzClient, "connectWithRuntime");
     const stub = makeClientStub();
     createJazzRnRuntimeMock.mockReturnValue({ id: "runtime" } as never);
     connectWithRuntimeSpy.mockReturnValue(stub.client);
 
-    const db = new TestDb({
+    const db = await createDb({
       appId: "rn-app",
       serverUrl: "https://example.test",
       jwtToken: "jwt-x",
       adminSecret: "admin-y",
     });
-    db.exposeGetClient(makeSchema("todos"));
+    db.insert(makeTodosApp().todos, { title: "Buy milk" });
 
     expect(stub.connectTransport).toHaveBeenCalledWith("https://example.test", {
       jwt_token: "jwt-x",
@@ -262,14 +322,14 @@ describe("react-native Db", () => {
     });
   });
 
-  it("RNDB-U09 does not call connectTransport when serverUrl is absent", () => {
+  it("RNDB-U09 does not call connectTransport when serverUrl is absent", async () => {
     const connectWithRuntimeSpy = vi.spyOn(JazzClient, "connectWithRuntime");
     const stub = makeClientStub();
     createJazzRnRuntimeMock.mockReturnValue({ id: "runtime" } as never);
     connectWithRuntimeSpy.mockReturnValue(stub.client);
 
-    const db = new TestDb({ appId: "rn-app" });
-    db.exposeGetClient(makeSchema("todos"));
+    const db = await createDb({ appId: "rn-app" });
+    db.insert(makeTodosApp().todos, { title: "Buy milk" });
 
     expect(stub.connectTransport).not.toHaveBeenCalled();
   });

--- a/packages/jazz-tools/src/react-native/db.ts
+++ b/packages/jazz-tools/src/react-native/db.ts
@@ -1,104 +1,10 @@
-import jazzRn from "jazz-rn";
-import type { WasmSchema } from "../drivers/types.js";
-import { JazzClient, type DurabilityTier } from "../runtime/client.js";
-import { Db as RuntimeDb, type DbConfig as RuntimeDbConfig } from "../runtime/db.js";
-import { createJazzRnRuntime } from "./create-jazz-rn-runtime.js";
+import { createDbWithRuntimeModule, Db } from "../runtime/db.js";
+import { ReactNativeRuntimeModule, type ReactNativeRuntimeDbConfig } from "./runtime-module.js";
 
-export interface DbConfig extends RuntimeDbConfig {
-  dataPath?: string;
-  tier?: DurabilityTier;
-}
+export { Db };
 
-export class Db extends RuntimeDb {
-  private readonly nativeClients = new Map<string, JazzClient>();
-
-  constructor(private readonly nativeConfig: DbConfig) {
-    // RN uses a native runtime instead of the browser WASM module path.
-    super(nativeConfig, null);
-  }
-
-  protected override getClient(schema: WasmSchema): JazzClient {
-    const key = JSON.stringify(schema);
-
-    if (!this.nativeClients.has(key)) {
-      const tier = this.nativeConfig.tier ?? "local";
-      const runtime = createJazzRnRuntime({
-        schema,
-        appId: this.nativeConfig.appId,
-        env: this.nativeConfig.env,
-        userBranch: this.nativeConfig.userBranch,
-        tier,
-        dataPath: this.nativeConfig.dataPath,
-      });
-
-      const client = JazzClient.connectWithRuntime(
-        runtime,
-        {
-          appId: this.nativeConfig.appId,
-          schema,
-          serverUrl: this.nativeConfig.serverUrl,
-          env: this.nativeConfig.env,
-          userBranch: this.nativeConfig.userBranch,
-          jwtToken: this.nativeConfig.jwtToken,
-          adminSecret: this.nativeConfig.adminSecret,
-          tier,
-          defaultDurabilityTier: "local",
-        },
-        {
-          onAuthFailure: (reason) => {
-            this.markUnauthenticated(reason);
-          },
-        },
-      );
-
-      if (this.nativeConfig.serverUrl) {
-        client.connectTransport(this.nativeConfig.serverUrl, {
-          jwt_token: this.nativeConfig.jwtToken,
-          admin_secret: this.nativeConfig.adminSecret,
-        });
-      }
-
-      this.nativeClients.set(key, client);
-    }
-
-    return this.nativeClients.get(key)!;
-  }
-
-  override updateAuthToken(jwtToken: string | null): void {
-    if (!this.applyAuthUpdate(jwtToken)) {
-      return;
-    }
-
-    for (const client of this.nativeClients.values()) {
-      client.updateAuthToken(jwtToken ?? undefined);
-    }
-  }
-
-  override async shutdown(): Promise<void> {
-    for (const client of this.nativeClients.values()) {
-      await client.shutdown();
-    }
-    this.nativeClients.clear();
-  }
-
-  // The base implementation needs a WASM module to mint the proof. RN has no
-  // WASM module, so route through jazz-rn's native binding instead.
-  override async getLocalFirstIdentityProof(options?: {
-    ttlSeconds?: number;
-    audience?: string;
-  }): Promise<string | null> {
-    const secret = this.nativeConfig.secret;
-    if (!secret) return null;
-    const ttl = BigInt(options?.ttlSeconds ?? 60);
-    const audience = options?.audience ?? this.nativeConfig.appId;
-    return jazzRn.jazz_rn.mintLocalFirstToken(secret, audience, ttl);
-  }
-}
+export interface DbConfig extends ReactNativeRuntimeDbConfig {}
 
 export async function createDb(config: DbConfig): Promise<Db> {
-  if (config.secret) {
-    const jwtToken = jazzRn.jazz_rn.mintLocalFirstToken(config.secret, config.appId, BigInt(3600));
-    return new Db({ ...config, jwtToken });
-  }
-  return new Db(config);
+  return await createDbWithRuntimeModule(config, new ReactNativeRuntimeModule());
 }

--- a/packages/jazz-tools/src/react-native/runtime-module.ts
+++ b/packages/jazz-tools/src/react-native/runtime-module.ts
@@ -1,0 +1,82 @@
+import jazzRn from "jazz-rn";
+import { JazzClient, type DurabilityTier } from "../runtime/client.js";
+import type { DbConfig as RuntimeDbConfig } from "../runtime/db.js";
+import {
+  DbRuntimeModule,
+  type DbRuntimeClientContext,
+  type RuntimeTokenOptions,
+} from "../runtime/db-runtime-module.js";
+import { createJazzRnRuntime } from "./create-jazz-rn-runtime.js";
+
+export interface ReactNativeRuntimeDbConfig extends RuntimeDbConfig {
+  dataPath?: string;
+  tier?: DurabilityTier;
+}
+
+type ReactNativeIdentityBinding = {
+  mintLocalFirstToken(seedB64: string, audience: string, ttlSeconds: bigint): string;
+  mintAnonymousToken(seedB64: string, audience: string, ttlSeconds: bigint): string;
+};
+
+function identityBinding(): ReactNativeIdentityBinding {
+  return jazzRn.jazz_rn as ReactNativeIdentityBinding;
+}
+
+export class ReactNativeRuntimeModule extends DbRuntimeModule<ReactNativeRuntimeDbConfig> {
+  override readonly supportsBrowserWorker = false;
+  override readonly supportsPolicyBypass = false;
+
+  protected override async loadRuntime(): Promise<void> {
+    return;
+  }
+
+  override createClient({
+    config,
+    schema,
+    onAuthFailure,
+  }: DbRuntimeClientContext<ReactNativeRuntimeDbConfig>): JazzClient {
+    const tier = config.tier ?? "local";
+    const runtime = createJazzRnRuntime({
+      schema,
+      appId: config.appId,
+      env: config.env,
+      userBranch: config.userBranch,
+      tier,
+      dataPath: config.dataPath,
+    });
+
+    return JazzClient.connectWithRuntime(
+      runtime,
+      {
+        appId: config.appId,
+        schema,
+        serverUrl: config.serverUrl,
+        env: config.env,
+        userBranch: config.userBranch,
+        jwtToken: config.jwtToken,
+        adminSecret: config.adminSecret,
+        tier,
+        defaultDurabilityTier: "local",
+      },
+      {
+        onAuthFailure,
+      },
+    );
+  }
+
+  override mintLocalFirstToken(options: RuntimeTokenOptions): string {
+    return identityBinding().mintLocalFirstToken(
+      options.secret,
+      options.audience,
+      BigInt(options.ttlSeconds),
+    );
+  }
+
+  override mintAnonymousToken(options: RuntimeTokenOptions): string {
+    return identityBinding().mintAnonymousToken(
+      options.secret,
+      options.audience,
+      BigInt(options.ttlSeconds),
+    );
+  }
+}

--- a/packages/jazz-tools/src/react-native/runtime-module.ts
+++ b/packages/jazz-tools/src/react-native/runtime-module.ts
@@ -13,15 +13,6 @@ export interface ReactNativeRuntimeDbConfig extends RuntimeDbConfig {
   tier?: DurabilityTier;
 }
 
-type ReactNativeIdentityBinding = {
-  mintLocalFirstToken(seedB64: string, audience: string, ttlSeconds: bigint): string;
-  mintAnonymousToken(seedB64: string, audience: string, ttlSeconds: bigint): string;
-};
-
-function identityBinding(): ReactNativeIdentityBinding {
-  return jazzRn.jazz_rn as ReactNativeIdentityBinding;
-}
-
 export class ReactNativeRuntimeModule extends DbRuntimeModule<ReactNativeRuntimeDbConfig> {
   override readonly supportsBrowserWorker = false;
   override readonly supportsPolicyBypass = false;
@@ -65,7 +56,7 @@ export class ReactNativeRuntimeModule extends DbRuntimeModule<ReactNativeRuntime
   }
 
   override mintLocalFirstToken(options: RuntimeTokenOptions): string {
-    return identityBinding().mintLocalFirstToken(
+    return jazzRn.jazz_rn.mintLocalFirstToken(
       options.secret,
       options.audience,
       BigInt(options.ttlSeconds),
@@ -73,7 +64,7 @@ export class ReactNativeRuntimeModule extends DbRuntimeModule<ReactNativeRuntime
   }
 
   override mintAnonymousToken(options: RuntimeTokenOptions): string {
-    return identityBinding().mintAnonymousToken(
+    return jazzRn.jazz_rn.mintAnonymousToken(
       options.secret,
       options.audience,
       BigInt(options.ttlSeconds),

--- a/packages/jazz-tools/src/runtime/db-runtime-module.ts
+++ b/packages/jazz-tools/src/runtime/db-runtime-module.ts
@@ -59,11 +59,11 @@ export abstract class DbRuntimeModule<RuntimeConfig extends DbConfig = DbConfig>
     return null;
   }
 
-  mintLocalFirstToken(_options: RuntimeTokenOptions): string | Promise<string> | null {
-    return null;
+  mintLocalFirstToken(_options: RuntimeTokenOptions): string {
+    throw new Error("Db runtime module does not support local-first auth");
   }
 
-  mintAnonymousToken(_options: RuntimeTokenOptions): string | Promise<string> {
+  mintAnonymousToken(_options: RuntimeTokenOptions): string {
     throw new Error("Db runtime module does not support anonymous auth");
   }
 }

--- a/packages/jazz-tools/src/runtime/db-runtime-module.ts
+++ b/packages/jazz-tools/src/runtime/db-runtime-module.ts
@@ -1,0 +1,69 @@
+import type { WasmSchema } from "../drivers/types.js";
+import type { JazzClient } from "./client.js";
+import type { DbConfig } from "./db.js";
+import type { AuthFailureReason } from "./sync-transport.js";
+
+export interface RuntimeTokenOptions {
+  secret: string;
+  audience: string;
+  ttlSeconds: number;
+  nowSeconds: bigint;
+}
+
+export interface DbRuntimeClientContext<RuntimeConfig extends DbConfig = DbConfig> {
+  config: RuntimeConfig;
+  schema: WasmSchema;
+  hasWorker: boolean;
+  useBinaryEncoding: boolean;
+  onAuthFailure: (reason: AuthFailureReason) => void;
+  onRejectedBatchAcknowledged: (batchId: string) => void;
+}
+
+export interface DbRuntimeTelemetryContext<RuntimeConfig extends DbConfig = DbConfig> {
+  config: RuntimeConfig;
+  collectorUrl: string;
+  runtimeThread: "main" | "worker";
+}
+
+export abstract class DbRuntimeModule<RuntimeConfig extends DbConfig = DbConfig> {
+  /** Set to false for runtimes, such as React Native, that cannot use browser workers. */
+  readonly supportsBrowserWorker: boolean = true;
+  /** Set to false when the runtime must receive schemas exactly as declared. */
+  readonly supportsPolicyBypass: boolean = true;
+  private hasLoadedRuntime = false;
+  private loadedRuntimeValue: unknown;
+
+  async load(config: RuntimeConfig): Promise<void> {
+    if (this.hasLoadedRuntime) {
+      return;
+    }
+
+    this.loadedRuntimeValue = await this.loadRuntime(config);
+    this.hasLoadedRuntime = true;
+  }
+
+  protected abstract loadRuntime(config: RuntimeConfig): Promise<unknown>;
+
+  protected get loadedRuntime(): unknown {
+    if (!this.hasLoadedRuntime) {
+      throw new Error("Db runtime module is not loaded");
+    }
+    return this.loadedRuntimeValue;
+  }
+
+  abstract createClient(context: DbRuntimeClientContext<RuntimeConfig>): JazzClient;
+
+  installTelemetry(
+    _context: DbRuntimeTelemetryContext<RuntimeConfig>,
+  ): (() => void) | null | undefined {
+    return null;
+  }
+
+  mintLocalFirstToken(_options: RuntimeTokenOptions): string | Promise<string> | null {
+    return null;
+  }
+
+  mintAnonymousToken(_options: RuntimeTokenOptions): string | Promise<string> {
+    throw new Error("Db runtime module does not support anonymous auth");
+  }
+}

--- a/packages/jazz-tools/src/runtime/db.local-first-auth.test.ts
+++ b/packages/jazz-tools/src/runtime/db.local-first-auth.test.ts
@@ -45,7 +45,7 @@ describe("getLocalFirstIdentityProof", () => {
       secret: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
     });
 
-    const token = await db.getLocalFirstIdentityProof({ audience: "test-audience" });
+    const token = db.getLocalFirstIdentityProof({ audience: "test-audience" });
     expect(token).toBeTypeOf("string");
     expect(token!.split(".")).toHaveLength(3);
     await db.shutdown();
@@ -58,7 +58,7 @@ describe("getLocalFirstIdentityProof", () => {
       jwtToken: "dummy-jwt",
     });
 
-    const token = await db.getLocalFirstIdentityProof({ audience: "test-audience" });
+    const token = db.getLocalFirstIdentityProof({ audience: "test-audience" });
     expect(token).toBeNull();
     await db.shutdown();
   });

--- a/packages/jazz-tools/src/runtime/db.telemetry.test.ts
+++ b/packages/jazz-tools/src/runtime/db.telemetry.test.ts
@@ -1,4 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { JazzClient } from "./client.js";
+import { Db, type DbConfig } from "./db.js";
+import {
+  DbRuntimeModule,
+  type DbRuntimeClientContext,
+  type DbRuntimeTelemetryContext,
+} from "./db-runtime-module.js";
 
 const TELEMETRY_ENV_KEYS = [
   "VITE_JAZZ_TELEMETRY_COLLECTOR_URL",
@@ -7,79 +14,70 @@ const TELEMETRY_ENV_KEYS = [
   "EXPO_PUBLIC_JAZZ_TELEMETRY_COLLECTOR_URL",
 ] as const;
 
-async function loadDbWithTelemetryMocks(wasmModule: unknown = {}) {
-  vi.resetModules();
+class TestRuntimeModule extends DbRuntimeModule<DbConfig> {
+  readonly installTelemetryMock = vi.fn(
+    (_context: DbRuntimeTelemetryContext<DbConfig>) => this.disposeTelemetry,
+  );
 
-  const loadWasmModuleMock = vi.fn().mockResolvedValue(wasmModule);
-  const disposeWasmTelemetryMock = vi.fn();
-  const installWasmTelemetryMock = vi.fn(() => disposeWasmTelemetryMock);
+  constructor(private readonly disposeTelemetry?: () => void) {
+    super();
+  }
 
-  vi.doMock("./client.js", async (importOriginal) => {
-    const actual = await importOriginal<typeof import("./client.js")>();
-    return {
-      ...actual,
-      loadWasmModule: loadWasmModuleMock,
-    };
-  });
+  protected override async loadRuntime(): Promise<void> {
+    return;
+  }
 
-  vi.doMock("./sync-telemetry.js", () => ({
-    installWasmTelemetry: installWasmTelemetryMock,
-    resolveTelemetryCollectorUrlFromEnv: vi.fn(() => undefined),
-  }));
+  override createClient(_context: DbRuntimeClientContext<DbConfig>): JazzClient {
+    throw new Error("createClient should not be called by telemetry tests");
+  }
 
-  const { Db } = await import("./db.js");
-  return {
-    Db,
-    disposeWasmTelemetryMock,
-    installWasmTelemetryMock,
-    loadWasmModuleMock,
-  };
+  override installTelemetry(context: DbRuntimeTelemetryContext<DbConfig>): (() => void) | null {
+    return this.installTelemetryMock(context) ?? null;
+  }
+}
+
+async function createTestDb(config: DbConfig, runtimeModule: TestRuntimeModule): Promise<Db> {
+  await runtimeModule.load(config);
+  return Db.create(config, runtimeModule);
 }
 
 afterEach(() => {
-  vi.doUnmock("./client.js");
-  vi.doUnmock("./sync-telemetry.js");
   vi.restoreAllMocks();
   for (const key of TELEMETRY_ENV_KEYS) {
     delete process.env[key];
   }
 });
 
-describe("Db WASM telemetry", () => {
+describe("Db runtime telemetry", () => {
   it("does not start main-thread telemetry when telemetry is disabled", async () => {
-    const { Db, installWasmTelemetryMock } = await loadDbWithTelemetryMocks();
-    const db = await Db.create({ appId: "main-no-telemetry" });
+    const runtimeModule = new TestRuntimeModule();
+    const db = await createTestDb({ appId: "main-no-telemetry" }, runtimeModule);
 
     (db as any).installMainThreadWasmTelemetry();
 
-    expect(installWasmTelemetryMock).not.toHaveBeenCalled();
+    expect(runtimeModule.installTelemetryMock).not.toHaveBeenCalled();
     await db.shutdown();
   });
 
   it("starts main-thread telemetry only when a collector URL exists", async () => {
-    const wasmModule = {
-      setTraceEntryCollectionEnabled: vi.fn(),
-      drainTraceEntries: vi.fn(),
-      subscribeTraceEntries: vi.fn(() => vi.fn()),
-    };
-    const { Db, disposeWasmTelemetryMock, installWasmTelemetryMock } =
-      await loadDbWithTelemetryMocks(wasmModule);
-    const db = await Db.create({
+    const disposeTelemetryMock = vi.fn();
+    const runtimeModule = new TestRuntimeModule(disposeTelemetryMock);
+    const config = {
       appId: "main-with-telemetry",
       telemetryCollectorUrl: "http://127.0.0.1:54418",
-    });
+    };
+    const db = await createTestDb(config, runtimeModule);
 
     (db as any).installMainThreadWasmTelemetry();
 
-    expect(installWasmTelemetryMock).toHaveBeenCalledTimes(1);
-    expect(installWasmTelemetryMock).toHaveBeenCalledWith({
-      wasmModule,
+    expect(runtimeModule.installTelemetryMock).toHaveBeenCalledTimes(1);
+    expect(runtimeModule.installTelemetryMock).toHaveBeenCalledWith({
+      config,
       collectorUrl: "http://127.0.0.1:54418",
-      appId: "main-with-telemetry",
       runtimeThread: "main",
     });
 
     await db.shutdown();
-    expect(disposeWasmTelemetryMock).toHaveBeenCalledTimes(1);
+    expect(disposeTelemetryMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/jazz-tools/src/runtime/db.transport.test.ts
+++ b/packages/jazz-tools/src/runtime/db.transport.test.ts
@@ -241,7 +241,7 @@ describe("runtime/Db direct path upstream wiring", () => {
         (_context: DbRuntimeClientContext<DbConfig>) => client,
       );
       override readonly mintLocalFirstToken = vi.fn(
-        async (options: RuntimeTokenOptions) =>
+        (options: RuntimeTokenOptions) =>
           `jwt:${options.secret}:${options.audience}:${options.ttlSeconds}`,
       );
 
@@ -262,7 +262,7 @@ describe("runtime/Db direct path upstream wiring", () => {
 
     const inserted = db.insert(app.todos, { title: "Buy milk" });
     db.updateAuthToken("fresh-jwt");
-    const proof = await db.getLocalFirstIdentityProof({
+    const proof = db.getLocalFirstIdentityProof({
       audience: "proof-audience",
       ttlSeconds: 7,
     });

--- a/packages/jazz-tools/src/runtime/db.transport.test.ts
+++ b/packages/jazz-tools/src/runtime/db.transport.test.ts
@@ -1,14 +1,62 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { JazzClient } from "./client.js";
-import { Db, type DbConfig } from "./db.js";
+import { schema as s } from "../index.js";
+import { JazzClient, WriteResult, type DirectInsertResult } from "./client.js";
+import { createDbWithRuntimeModule, Db, type DbConfig } from "./db.js";
+import {
+  DbRuntimeModule,
+  type DbRuntimeClientContext,
+  type RuntimeTokenOptions,
+} from "./db-runtime-module.js";
 import type { WasmSchema } from "../drivers/types.js";
 
 class TestDb extends Db {
-  constructor(config: DbConfig) {
-    super(config, { WasmRuntime: class {} } as never);
+  static readonly runtime = { WasmRuntime: class {} };
+
+  constructor(
+    config: DbConfig,
+    runtimeModule: DbRuntimeModule<DbConfig> = new TestDirectRuntimeModule(),
+  ) {
+    super(config, runtimeModule);
   }
   public exposeGetClient(schema: WasmSchema): JazzClient {
     return this.getClient(schema);
+  }
+}
+
+class TestDirectRuntimeModule extends DbRuntimeModule<DbConfig> {
+  protected override async loadRuntime(): Promise<typeof TestDb.runtime> {
+    return TestDb.runtime;
+  }
+
+  override createClient({
+    config,
+    schema,
+    hasWorker,
+    useBinaryEncoding,
+    onAuthFailure,
+    onRejectedBatchAcknowledged,
+  }: DbRuntimeClientContext<DbConfig>): JazzClient {
+    return JazzClient.connectSync(
+      TestDb.runtime as never,
+      {
+        appId: config.appId,
+        schema,
+        driver: config.driver,
+        serverUrl: hasWorker ? undefined : config.serverUrl,
+        env: config.env,
+        userBranch: config.userBranch,
+        jwtToken: config.jwtToken,
+        cookieSession: config.cookieSession,
+        adminSecret: config.adminSecret,
+        tier: hasWorker ? undefined : "local",
+        defaultDurabilityTier: hasWorker ? undefined : config.serverUrl ? "edge" : undefined,
+      },
+      {
+        useBinaryEncoding,
+        onAuthFailure,
+        onRejectedBatchAcknowledged,
+      },
+    );
   }
 }
 
@@ -16,6 +64,14 @@ function makeSchema(): WasmSchema {
   return {
     todos: { columns: [{ name: "title", column_type: { type: "Text" }, nullable: false }] },
   };
+}
+
+function makeTodosApp() {
+  return s.defineApp({
+    todos: s.table({
+      title: s.string(),
+    }),
+  });
 }
 
 function makeClientStub() {
@@ -87,14 +143,7 @@ describe("runtime/Db direct path upstream wiring", () => {
   it("DBRT-U03 strips local policies for memory-driver admin-secret clients", () => {
     const client = makeClientStub();
     const connectSyncSpy = vi.spyOn(JazzClient, "connectSync").mockReturnValue(client);
-
-    const db = new TestDb({
-      appId: "app",
-      serverUrl: "https://example.test",
-      adminSecret: "admin-y",
-      driver: { type: "memory" },
-    });
-    db.exposeGetClient({
+    const schema: WasmSchema = {
       todos: {
         columns: [{ name: "title", column_type: { type: "Text" }, nullable: false }],
         policies: {
@@ -105,15 +154,148 @@ describe("runtime/Db direct path upstream wiring", () => {
           },
         },
       },
+    };
+
+    const db = new TestDb({
+      appId: "app",
+      serverUrl: "https://example.test",
+      adminSecret: "admin-y",
+      driver: { type: "memory" },
     });
+    db.exposeGetClient(schema);
 
     expect(connectSyncSpy).toHaveBeenCalledTimes(1);
-    expect(connectSyncSpy.mock.calls[0]?.[1]).toMatchObject({
-      schema: {
-        todos: {
-          columns: [{ name: "title", column_type: { type: "Text" }, nullable: false }],
+    const runtimeSchema = connectSyncSpy.mock.calls[0]?.[1].schema;
+    expect(runtimeSchema.todos.policies).toBeUndefined();
+    expect(runtimeSchema).toMatchObject({
+      todos: {
+        columns: [{ name: "title", column_type: { type: "Text" }, nullable: false }],
+      },
+    });
+  });
+
+  it("DBRT-U03b preserves local policies when the runtime does not support policy bypass", () => {
+    const client = makeClientStub();
+    const connectSyncSpy = vi.spyOn(JazzClient, "connectSync").mockReturnValue(client);
+    class PolicyEvaluatingRuntimeModule extends TestDirectRuntimeModule {
+      override readonly supportsPolicyBypass = false;
+    }
+    const schema: WasmSchema = {
+      todos: {
+        columns: [{ name: "title", column_type: { type: "Text" }, nullable: false }],
+        policies: {
+          update: {
+            using: {
+              type: "False",
+            },
+          },
+        },
+      },
+    };
+
+    const db = new TestDb(
+      {
+        appId: "app",
+        serverUrl: "https://example.test",
+        adminSecret: "admin-y",
+        driver: { type: "memory" },
+      },
+      new PolicyEvaluatingRuntimeModule(),
+    );
+    db.exposeGetClient(schema);
+
+    expect(connectSyncSpy).toHaveBeenCalledTimes(1);
+    const runtimeSchema = connectSyncSpy.mock.calls[0]?.[1].schema;
+    expect(runtimeSchema.todos).toHaveProperty("policies", {
+      update: {
+        using: {
+          type: "False",
         },
       },
     });
+  });
+
+  it("DBRT-U04 routes Db runtime wiring through an injected runtime module", async () => {
+    const app = makeTodosApp();
+    const schema = app.todos._schema;
+    const loadedRuntime = { kind: "test-runtime" };
+    const runtimeRow: DirectInsertResult = {
+      id: "todo-1",
+      values: [{ type: "Text", value: "Buy milk" }],
+      batchId: "batch-1",
+    };
+    const client = {
+      create: vi.fn(() => new WriteResult(runtimeRow, runtimeRow.batchId, client)),
+      shutdown: vi.fn(async () => undefined),
+      updateAuthToken: vi.fn(),
+      connectTransport: vi.fn(),
+      getRuntime: vi.fn(() => ({}) as never),
+    } as unknown as JazzClient & {
+      create: ReturnType<typeof vi.fn>;
+      shutdown: ReturnType<typeof vi.fn>;
+      updateAuthToken: ReturnType<typeof vi.fn>;
+    };
+    class TestRuntimeModule extends DbRuntimeModule<DbConfig> {
+      readonly loadRuntimeMock = vi.fn(async (_config: DbConfig) => loadedRuntime);
+      override readonly createClient = vi.fn(
+        (_context: DbRuntimeClientContext<DbConfig>) => client,
+      );
+      override readonly mintLocalFirstToken = vi.fn(
+        async (options: RuntimeTokenOptions) =>
+          `jwt:${options.secret}:${options.audience}:${options.ttlSeconds}`,
+      );
+
+      protected override async loadRuntime(config: DbConfig): Promise<typeof loadedRuntime> {
+        return await this.loadRuntimeMock(config);
+      }
+    }
+    const runtimeModule = new TestRuntimeModule();
+
+    const db = await createDbWithRuntimeModule(
+      {
+        appId: "facade-app",
+        secret: "alice-secret",
+        serverUrl: "https://example.test",
+      },
+      runtimeModule,
+    );
+
+    const inserted = db.insert(app.todos, { title: "Buy milk" });
+    db.updateAuthToken("fresh-jwt");
+    const proof = await db.getLocalFirstIdentityProof({
+      audience: "proof-audience",
+      ttlSeconds: 7,
+    });
+    await db.shutdown();
+
+    expect(inserted.value).toEqual({ id: "todo-1", title: "Buy milk" });
+    expect(runtimeModule.loadRuntimeMock).toHaveBeenCalledTimes(1);
+    expect(runtimeModule.mintLocalFirstToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        secret: "alice-secret",
+        audience: "facade-app",
+        ttlSeconds: 3600,
+      }),
+    );
+    expect(runtimeModule.createClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        schema,
+        hasWorker: false,
+        useBinaryEncoding: false,
+        config: expect.objectContaining({
+          appId: "facade-app",
+          jwtToken: "jwt:alice-secret:facade-app:3600",
+          serverUrl: "https://example.test",
+        }),
+        onAuthFailure: expect.any(Function),
+        onRejectedBatchAcknowledged: expect.any(Function),
+      }),
+    );
+    const createClientContext = runtimeModule.createClient.mock.calls[0]?.[0];
+    expect(createClientContext).toBeDefined();
+    expect("loadedRuntime" in createClientContext!).toBe(false);
+    expect(client.updateAuthToken).toHaveBeenCalledWith("fresh-jwt");
+    expect(proof).toBe("jwt:alice-secret:proof-audience:7");
+    expect(client.shutdown).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -867,21 +867,20 @@ export class Db {
     // Refresh at 80% of TTL
     const refreshMs = ttlSeconds * 800; // 80% of TTL in ms
     this.localFirstRefreshTimer = setTimeout(() => {
-      void this.refreshLocalFirstToken();
+      this.refreshLocalFirstToken();
     }, refreshMs);
   }
 
-  private async refreshLocalFirstToken(): Promise<void> {
+  private refreshLocalFirstToken(): void {
     if (!this._localFirstSecret || this.isShuttingDown) return;
 
     try {
       const ttlSeconds = 3600;
-      const newToken = await this.mintLocalFirstToken(
+      const newToken = this.mintLocalFirstToken(
         this._localFirstSecret,
         this.config.appId,
         ttlSeconds,
       );
-      if (!newToken) return;
       this.updateAuthToken(newToken);
       this.scheduleLocalFirstRefresh(ttlSeconds);
     } catch (e) {
@@ -889,16 +888,18 @@ export class Db {
     }
   }
 
-  private async mintLocalFirstToken(
+  private mintLocalFirstToken(
     secret: string,
     audience: string,
     ttlSeconds: number,
-  ): Promise<string | null> {
+  ): string {
     if (!this.runtimeModule) {
-      return null;
+      throw new Error(
+        "Db runtime module is not initialized for this Db implementation",
+      );
     }
 
-    return await this.runtimeModule.mintLocalFirstToken({
+    return this.runtimeModule.mintLocalFirstToken({
       secret,
       audience,
       ttlSeconds,
@@ -1663,17 +1664,17 @@ export class Db {
    * Mint a short-lived local-first JWT proving possession of the current identity.
    * Returns `null` if the current session is not local-first.
    */
-  async getLocalFirstIdentityProof(options?: {
+  getLocalFirstIdentityProof(options?: {
     ttlSeconds?: number;
     audience?: string;
-  }): Promise<string | null> {
+  }): string | null {
     if (!this._localFirstSecret) {
       return null;
     }
 
     const ttl = options?.ttlSeconds ?? 60;
     const audience = options?.audience ?? this.config.appId;
-    return await this.mintLocalFirstToken(this._localFirstSecret, audience, ttl);
+    return this.mintLocalFirstToken(this._localFirstSecret, audience, ttl);
   }
 
   onAuthChanged(listener: (state: AuthState) => void): () => void {
@@ -2580,19 +2581,16 @@ export async function createDbWithRuntimeModule<RuntimeConfig extends DbConfig>(
     const secret = config.secret;
     localFirstSecret = secret;
 
-    const jwtToken = await runtimeModule.mintLocalFirstToken(
+    const jwtToken = runtimeModule.mintLocalFirstToken(
       createRuntimeTokenOptions(secret, config.appId, 3600),
     );
-    if (!jwtToken) {
-      throw new Error("Db runtime module does not support local-first auth");
-    }
     resolvedConfig = { ...resolvedConfig, jwtToken };
   } else if (!config.jwtToken && !config.cookieSession && !config.adminSecret) {
     // Anonymous: mint an ephemeral keypair + anonymous JWT.
     // Admin-secret clients intentionally stay sessionless so local policy
     // evaluation does not preempt backend-authorized transport writes.
     const ephemeralSeed = generateEphemeralSeedBase64Url();
-    const jwtToken = await runtimeModule.mintAnonymousToken(
+    const jwtToken = runtimeModule.mintAnonymousToken(
       createRuntimeTokenOptions(ephemeralSeed, config.appId, 3600),
     );
     resolvedConfig = { ...resolvedConfig, jwtToken };

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -888,15 +888,9 @@ export class Db {
     }
   }
 
-  private mintLocalFirstToken(
-    secret: string,
-    audience: string,
-    ttlSeconds: number,
-  ): string {
+  private mintLocalFirstToken(secret: string, audience: string, ttlSeconds: number): string {
     if (!this.runtimeModule) {
-      throw new Error(
-        "Db runtime module is not initialized for this Db implementation",
-      );
+      throw new Error("Db runtime module is not initialized for this Db implementation");
     }
 
     return this.runtimeModule.mintLocalFirstToken({
@@ -1664,10 +1658,7 @@ export class Db {
    * Mint a short-lived local-first JWT proving possession of the current identity.
    * Returns `null` if the current session is not local-first.
    */
-  getLocalFirstIdentityProof(options?: {
-    ttlSeconds?: number;
-    audience?: string;
-  }): string | null {
+  getLocalFirstIdentityProof(options?: { ttlSeconds?: number; audience?: string }): string | null {
     if (!this._localFirstSecret) {
       return null;
     }

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -5,7 +5,7 @@
  * Handles query translation, execution, and result transformation.
  *
  * Key design:
- * - createDb() is async (pre-loads WASM module)
+ * - createDb() is async (pre-loads the runtime module)
  * - insert/update/delete are sync (local-first immediate writes, no durability wait)
  * - all/one are async (need storage I/O for queries)
  */
@@ -19,13 +19,11 @@ import {
   JazzClient,
   type LocalBatchRecord,
   type MutationErrorEvent,
-  loadWasmModule,
   Transaction as RuntimeTransaction,
   WriteHandle,
   type CreateOptions,
   type UpdateOptions,
   type UpsertOptions,
-  type WasmModule,
   type DurabilityTier,
   type QueryExecutionOptions,
   type QueryPropagation,
@@ -33,6 +31,8 @@ import {
   resolveEffectiveQueryExecutionOptions,
   runInBatch,
 } from "./client.js";
+import { type DbRuntimeModule, type RuntimeTokenOptions } from "./db-runtime-module.js";
+import { WasmRuntimeModule } from "./wasm-runtime-module.js";
 import { WorkerBridge, type PeerSyncBatch, type WorkerBridgeOptions } from "./worker-bridge.js";
 import type { AuthFailureReason } from "./sync-transport.js";
 import { translateQuery } from "./query-adapter.js";
@@ -40,7 +40,7 @@ import { transformRow, transformRows } from "./row-transformer.js";
 import { toInsertRecord, toUpdateRecord } from "./value-converter.js";
 import { SubscriptionManager, type SubscriptionDelta } from "./subscription-manager.js";
 import { createAuthStateStore, type AuthState, type AuthStateStoreOptions } from "./auth-state.js";
-import { resolveClientSessionSync, ANONYMOUS_JWT_ISSUER } from "./client-session.js";
+import { resolveClientSessionSync } from "./client-session.js";
 import {
   createConventionalFileStorage,
   type ConventionalFileApp,
@@ -57,7 +57,7 @@ import {
   resolveWorkerBootstrapWasmUrl,
   resolveRuntimeConfigWorkerUrl,
 } from "./runtime-config.js";
-import { installWasmTelemetry, resolveTelemetryCollectorUrlFromEnv } from "./sync-telemetry.js";
+import { resolveTelemetryCollectorUrlFromEnv } from "./sync-telemetry.js";
 import {
   isTabSyncMessage,
   resolveBroadcastChannelCtor,
@@ -70,10 +70,7 @@ import {
 import { StorageResetCoordinator, type StorageResetHost } from "./storage-reset-coordinator.js";
 
 type WasmLogLevel = "error" | "warn" | "info" | "debug" | "trace";
-const DEFAULT_WASM_LOG_LEVEL: WasmLogLevel = "warn";
-function setGlobalWasmLogLevel(level?: WasmLogLevel): void {
-  (globalThis as any).__JAZZ_WASM_LOG_LEVEL = level ?? DEFAULT_WASM_LOG_LEVEL;
-}
+type AnyDbRuntimeModule = DbRuntimeModule<any>;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -784,7 +781,7 @@ export type DbBatchScope = Omit<DbDirectBatch, "commit">;
 export class Db {
   private clients = new Map<string, JazzClient>();
   private config: DbConfig;
-  private wasmModule: WasmModule | null;
+  private readonly runtimeModule: AnyDbRuntimeModule | null;
   private readonly authStateStore;
   private workerBridge: WorkerBridge | null = null;
   private worker: Worker | null = null;
@@ -849,11 +846,11 @@ export class Db {
    */
   protected constructor(
     config: DbConfig,
-    wasmModule: WasmModule | null,
+    runtimeModule: AnyDbRuntimeModule | null,
     authStateOptions?: AuthStateStoreOptions,
   ) {
     this.config = config;
-    this.wasmModule = wasmModule;
+    this.runtimeModule = runtimeModule;
     this.authStateStore = createAuthStateStore(config, authStateOptions);
   }
 
@@ -870,31 +867,43 @@ export class Db {
     // Refresh at 80% of TTL
     const refreshMs = ttlSeconds * 800; // 80% of TTL in ms
     this.localFirstRefreshTimer = setTimeout(() => {
-      this.refreshLocalFirstToken();
+      void this.refreshLocalFirstToken();
     }, refreshMs);
   }
 
-  private refreshLocalFirstToken(): void {
+  private async refreshLocalFirstToken(): Promise<void> {
     if (!this._localFirstSecret || this.isShuttingDown) return;
 
     try {
-      const wasmModule = this.wasmModule;
-      if (!wasmModule) return;
-
       const ttlSeconds = 3600;
-      const nowSeconds = BigInt(Math.floor(Date.now() / 1000));
-      const newToken = wasmModule.WasmRuntime.mintJazzSelfSignedToken(
+      const newToken = await this.mintLocalFirstToken(
         this._localFirstSecret,
-        "urn:jazz:local-first",
         this.config.appId,
-        BigInt(ttlSeconds),
-        nowSeconds,
+        ttlSeconds,
       );
+      if (!newToken) return;
       this.updateAuthToken(newToken);
       this.scheduleLocalFirstRefresh(ttlSeconds);
     } catch (e) {
       console.error("Failed to refresh local-first token:", e);
     }
+  }
+
+  private async mintLocalFirstToken(
+    secret: string,
+    audience: string,
+    ttlSeconds: number,
+  ): Promise<string | null> {
+    if (!this.runtimeModule) {
+      return null;
+    }
+
+    return await this.runtimeModule.mintLocalFirstToken({
+      secret,
+      audience,
+      ttlSeconds,
+      nowSeconds: BigInt(Math.floor(Date.now() / 1000)),
+    });
   }
 
   protected markUnauthenticated(reason: AuthFailureReason): void {
@@ -950,12 +959,11 @@ export class Db {
   }
 
   /**
-   * Create a Db instance with pre-loaded WASM module.
+   * Create a Db instance with a loaded runtime module.
    * @internal Use createDb() instead.
    */
-  static async create(config: DbConfig): Promise<Db> {
-    const wasmModule = await loadWasmModule(config.runtimeSources);
-    return new Db(config, wasmModule);
+  static create(config: DbConfig, runtimeModule: AnyDbRuntimeModule): Db {
+    return new Db(config, runtimeModule);
   }
 
   /**
@@ -967,9 +975,8 @@ export class Db {
    *
    * @internal Use createDb() instead — it auto-detects browser.
    */
-  static async createWithWorker(config: DbConfig): Promise<Db> {
-    const wasmModule = await loadWasmModule(config.runtimeSources);
-    const db = new Db(config, wasmModule);
+  static async createWithWorker(config: DbConfig, runtimeModule: AnyDbRuntimeModule): Promise<Db> {
+    const db = new Db(config, runtimeModule);
     const persistentDriver = resolveStorageDriver(config.driver);
     if (persistentDriver.type !== "persistent") {
       throw new Error("Worker-backed Db requires driver.type='persistent'");
@@ -1022,63 +1029,40 @@ export class Db {
 
   /**
    * Get or create a JazzClient for the given schema.
-   * Synchronous because WASM module is pre-loaded.
+   * Synchronous because the runtime module is loaded before Db is created.
    *
    * In worker mode, the first call per schema also initializes the
    * WorkerBridge (async). Subsequent calls are sync.
    */
   protected getClient(schema: WasmSchema): JazzClient {
-    if (!this.wasmModule) {
+    if (!this.runtimeModule) {
       throw new Error("Db runtime module is not initialized for this Db implementation");
     }
 
-    const runtimeSchema = shouldBypassLocalPolicies(this.config)
-      ? getPolicyStrippedSchema(schema)
-      : schema;
+    const runtimeSchema =
+      this.runtimeModule.supportsPolicyBypass && shouldBypassLocalPolicies(this.config)
+        ? getPolicyStrippedSchema(schema)
+        : schema;
 
     // Use the canonical schema JSON as the client cache key, but memoize it by
     // schema identity so write-heavy paths don't stringify the same schema per row.
     const key = getRuntimeSchemaCacheKey(runtimeSchema);
 
     if (!this.clients.has(key)) {
-      setGlobalWasmLogLevel(this.config.logLevel);
       this.installMainThreadWasmTelemetry();
 
-      // Create in-memory runtime (works for both direct and worker mode)
-      const client = JazzClient.connectSync(
-        this.wasmModule,
-        {
-          appId: this.config.appId,
-          schema: runtimeSchema,
-          driver: this.config.driver,
-          // In worker mode, don't connect to server directly — worker handles it
-          serverUrl: this.worker ? undefined : this.config.serverUrl,
-          env: this.config.env,
-          userBranch: this.config.userBranch,
-          jwtToken: this.config.jwtToken,
-          cookieSession: this.config.cookieSession,
-          adminSecret: this.config.adminSecret,
-          tier: this.worker ? undefined : "local",
-          // Keep worker-bridged browser clients on local durability by default.
-          // For direct (non-worker) clients connected to a server, default to edge.
-          defaultDurabilityTier: this.worker
-            ? undefined
-            : this.config.serverUrl
-              ? "edge"
-              : undefined,
+      const client = this.runtimeModule.createClient({
+        config: { ...this.config },
+        schema: runtimeSchema,
+        hasWorker: this.worker !== null,
+        useBinaryEncoding: this.worker !== null,
+        onAuthFailure: (reason) => {
+          this.markUnauthenticated(reason);
         },
-        {
-          // Worker-bridged runtimes exchange postcard payloads with peers;
-          // direct browser/server routing keeps JSON payloads.
-          useBinaryEncoding: this.worker !== null,
-          onAuthFailure: (reason) => {
-            this.markUnauthenticated(reason);
-          },
-          onRejectedBatchAcknowledged: (batchId) => {
-            this.workerBridge?.acknowledgeRejectedBatch(batchId);
-          },
+        onRejectedBatchAcknowledged: (batchId) => {
+          this.workerBridge?.acknowledgeRejectedBatch(batchId);
         },
-      );
+      });
 
       this.attachMutationErrorHandler(client);
       // In worker mode, set up the bridge for this client
@@ -1212,16 +1196,16 @@ export class Db {
 
   private installMainThreadWasmTelemetry(): void {
     const collectorUrl = this.resolveTelemetryCollectorUrl();
-    if (!collectorUrl || !this.wasmModule || this.disposeWasmTelemetry) {
+    if (!collectorUrl || !this.runtimeModule || this.disposeWasmTelemetry) {
       return;
     }
 
-    this.disposeWasmTelemetry = installWasmTelemetry({
-      wasmModule: this.wasmModule,
-      collectorUrl,
-      appId: this.config.appId,
-      runtimeThread: "main",
-    });
+    this.disposeWasmTelemetry =
+      this.runtimeModule.installTelemetry?.({
+        config: this.config,
+        collectorUrl,
+        runtimeThread: "main",
+      }) ?? null;
   }
 
   private resolveTelemetryCollectorUrl(): string | undefined {
@@ -1687,22 +1671,9 @@ export class Db {
       return null;
     }
 
-    const wasmModule = this.wasmModule;
-    if (!wasmModule) {
-      return null;
-    }
-
     const ttl = options?.ttlSeconds ?? 60;
     const audience = options?.audience ?? this.config.appId;
-    const nowSeconds = BigInt(Math.floor(Date.now() / 1000));
-
-    return wasmModule.WasmRuntime.mintJazzSelfSignedToken(
-      this._localFirstSecret,
-      "urn:jazz:local-first",
-      audience,
-      BigInt(ttl),
-      nowSeconds,
-    );
+    return await this.mintLocalFirstToken(this._localFirstSecret, audience, ttl);
   }
 
   onAuthChanged(listener: (state: AuthState) => void): () => void {
@@ -2558,7 +2529,7 @@ function generateEphemeralSeedBase64Url(): string {
 /**
  * Create a new Db instance with the given configuration.
  *
- * This is an **async** factory function that pre-loads the WASM module.
+ * This is an **async** factory function that pre-loads the runtime module.
  * After creation, local-first mutations (`insert`/`update`/`delete`) are synchronous.
  * Use the `wait` method when you need a Promise that resolves at a durability tier.
  *
@@ -2576,7 +2547,23 @@ function generateEphemeralSeedBase64Url(): string {
  * });
  * ```
  */
-export async function createDb(config: DbConfig): Promise<Db> {
+function createRuntimeTokenOptions(
+  secret: string,
+  audience: string,
+  ttlSeconds: number,
+): RuntimeTokenOptions {
+  return {
+    secret,
+    audience,
+    ttlSeconds,
+    nowSeconds: BigInt(Math.floor(Date.now() / 1000)),
+  };
+}
+
+export async function createDbWithRuntimeModule<RuntimeConfig extends DbConfig>(
+  config: RuntimeConfig,
+  runtimeModule: DbRuntimeModule<RuntimeConfig>,
+): Promise<Db> {
   if (config.secret && (config.jwtToken || config.cookieSession)) {
     throw new Error("DbConfig error: secret, jwtToken, and cookieSession are mutually exclusive");
   }
@@ -2585,6 +2572,7 @@ export async function createDb(config: DbConfig): Promise<Db> {
   }
 
   let resolvedConfig = { ...config };
+  await runtimeModule.load(config);
 
   // Local-first auth: resolve seed and mint a JWT
   let localFirstSecret: string | null = null;
@@ -2592,29 +2580,20 @@ export async function createDb(config: DbConfig): Promise<Db> {
     const secret = config.secret;
     localFirstSecret = secret;
 
-    const wasmModule = await loadWasmModule(config.runtimeSources);
-    const nowSeconds = BigInt(Math.floor(Date.now() / 1000));
-    const jwtToken = wasmModule.WasmRuntime.mintJazzSelfSignedToken(
-      secret,
-      "urn:jazz:local-first",
-      config.appId,
-      BigInt(3600),
-      nowSeconds,
+    const jwtToken = await runtimeModule.mintLocalFirstToken(
+      createRuntimeTokenOptions(secret, config.appId, 3600),
     );
+    if (!jwtToken) {
+      throw new Error("Db runtime module does not support local-first auth");
+    }
     resolvedConfig = { ...resolvedConfig, jwtToken };
   } else if (!config.jwtToken && !config.cookieSession && !config.adminSecret) {
     // Anonymous: mint an ephemeral keypair + anonymous JWT.
     // Admin-secret clients intentionally stay sessionless so local policy
     // evaluation does not preempt backend-authorized transport writes.
-    const wasmModule = await loadWasmModule(config.runtimeSources);
     const ephemeralSeed = generateEphemeralSeedBase64Url();
-    const nowSeconds = BigInt(Math.floor(Date.now() / 1000));
-    const jwtToken = wasmModule.WasmRuntime.mintJazzSelfSignedToken(
-      ephemeralSeed,
-      ANONYMOUS_JWT_ISSUER,
-      config.appId,
-      BigInt(3600),
-      nowSeconds,
+    const jwtToken = await runtimeModule.mintAnonymousToken(
+      createRuntimeTokenOptions(ephemeralSeed, config.appId, 3600),
     );
     resolvedConfig = { ...resolvedConfig, jwtToken };
   }
@@ -2626,10 +2605,14 @@ export async function createDb(config: DbConfig): Promise<Db> {
   }
 
   let db: Db;
-  if (isBrowser() && driver.type === "persistent") {
-    db = await Db.createWithWorker(resolvedConfig);
+  if (
+    runtimeModule.supportsBrowserWorker !== false &&
+    isBrowser() &&
+    driver.type === "persistent"
+  ) {
+    db = await Db.createWithWorker(resolvedConfig, runtimeModule as AnyDbRuntimeModule);
   } else {
-    db = await Db.create(resolvedConfig);
+    db = Db.create(resolvedConfig, runtimeModule as AnyDbRuntimeModule);
   }
 
   if (localFirstSecret) {
@@ -2637,6 +2620,10 @@ export async function createDb(config: DbConfig): Promise<Db> {
   }
 
   return db;
+}
+
+export async function createDb(config: DbConfig): Promise<Db> {
+  return await createDbWithRuntimeModule(config, new WasmRuntimeModule());
 }
 
 export function createDbFromClient(

--- a/packages/jazz-tools/src/runtime/db.worker-bootstrap.test.ts
+++ b/packages/jazz-tools/src/runtime/db.worker-bootstrap.test.ts
@@ -50,11 +50,18 @@ vi.mock("./tab-leader-election.js", async (importOriginal) => {
   };
 });
 
-import { Db } from "./db.js";
+import { Db, type DbConfig } from "./db.js";
+import { WasmRuntimeModule } from "./wasm-runtime-module.js";
 
 const originalWindow = (globalThis as Record<string, unknown>).window;
 const originalLocation = globalThis.location;
 const originalWorker = (globalThis as Record<string, unknown>).Worker;
+
+async function createWorkerDb(config: DbConfig): Promise<Db> {
+  const runtimeModule = new WasmRuntimeModule();
+  await runtimeModule.load(config);
+  return await Db.createWithWorker(config, runtimeModule);
+}
 
 afterEach(() => {
   loadWasmModuleMock.mockClear();
@@ -107,7 +114,7 @@ describe("Db worker runtime bootstrap", () => {
     };
     (globalThis as Record<string, unknown>).Worker = FakeWorker;
 
-    const db = await Db.createWithWorker({
+    const db = await createWorkerDb({
       appId: "worker-bootstrap-explicit-urls",
       driver: { type: "persistent", dbName: "worker-bootstrap-explicit-urls" },
       runtimeSources: {
@@ -152,7 +159,7 @@ describe("Db worker runtime bootstrap", () => {
     };
     (globalThis as Record<string, unknown>).Worker = FakeWorker;
 
-    const db = await Db.createWithWorker({
+    const db = await createWorkerDb({
       appId: "worker-bootstrap-base-url",
       driver: { type: "persistent", dbName: "worker-bootstrap-base-url" },
       runtimeSources: {
@@ -195,7 +202,7 @@ describe("Db worker runtime bootstrap", () => {
     };
     (globalThis as Record<string, unknown>).Worker = FakeWorker;
 
-    const db = await Db.createWithWorker({
+    const db = await createWorkerDb({
       appId: "worker-bootstrap-browser-assets",
       driver: { type: "persistent", dbName: "worker-bootstrap-browser-assets" },
     });
@@ -232,7 +239,7 @@ describe("Db worker runtime bootstrap", () => {
     };
     (globalThis as Record<string, unknown>).Worker = FakeWorker;
 
-    const db = await Db.createWithWorker({
+    const db = await createWorkerDb({
       appId: "worker-bootstrap-fallback-wasm",
       driver: { type: "persistent", dbName: "worker-bootstrap-fallback-wasm" },
     });
@@ -268,7 +275,7 @@ describe("Db worker runtime bootstrap", () => {
     };
     (globalThis as Record<string, unknown>).Worker = FakeWorker;
 
-    const db = await Db.createWithWorker({
+    const db = await createWorkerDb({
       appId: "worker-bootstrap-telemetry",
       driver: { type: "persistent", dbName: "worker-bootstrap-telemetry" },
       telemetryCollectorUrl: "http://127.0.0.1:54418",
@@ -308,7 +315,7 @@ describe("Db worker runtime bootstrap", () => {
     };
     (globalThis as Record<string, unknown>).Worker = FakeWorker;
 
-    const db = await Db.createWithWorker({
+    const db = await createWorkerDb({
       appId: "worker-bootstrap-wasm-source",
       driver: { type: "persistent", dbName: "worker-bootstrap-wasm-source" },
       runtimeSources: {

--- a/packages/jazz-tools/src/runtime/wasm-runtime-module.ts
+++ b/packages/jazz-tools/src/runtime/wasm-runtime-module.ts
@@ -1,0 +1,123 @@
+import {
+  JazzClient,
+  loadWasmModule,
+  type ConnectSyncRuntimeOptions,
+  type WasmModule,
+} from "./client.js";
+import { ANONYMOUS_JWT_ISSUER, LOCAL_FIRST_JWT_ISSUER } from "./client-session.js";
+import type { DbConfig } from "./db.js";
+import {
+  DbRuntimeModule,
+  type DbRuntimeClientContext,
+  type DbRuntimeTelemetryContext,
+  type RuntimeTokenOptions,
+} from "./db-runtime-module.js";
+import { installWasmTelemetry } from "./sync-telemetry.js";
+
+const DEFAULT_WASM_LOG_LEVEL = "warn";
+
+function setGlobalWasmLogLevel(level?: DbConfig["logLevel"]): void {
+  (globalThis as any).__JAZZ_WASM_LOG_LEVEL = level ?? DEFAULT_WASM_LOG_LEVEL;
+}
+
+function mintWasmToken(
+  wasmModule: WasmModule,
+  secret: string,
+  issuer: string,
+  audience: string,
+  ttlSeconds: number,
+  nowSeconds: bigint,
+): string {
+  return wasmModule.WasmRuntime.mintJazzSelfSignedToken(
+    secret,
+    issuer,
+    audience,
+    BigInt(ttlSeconds),
+    nowSeconds,
+  );
+}
+
+export class WasmRuntimeModule extends DbRuntimeModule<DbConfig> {
+  private get wasmModule(): WasmModule {
+    return this.loadedRuntime as WasmModule;
+  }
+
+  protected override async loadRuntime(config: DbConfig): Promise<WasmModule> {
+    return await loadWasmModule(config.runtimeSources);
+  }
+
+  override createClient({
+    config,
+    schema,
+    hasWorker,
+    useBinaryEncoding,
+    onAuthFailure,
+    onRejectedBatchAcknowledged,
+  }: DbRuntimeClientContext<DbConfig>): JazzClient {
+    setGlobalWasmLogLevel(config.logLevel);
+
+    const runtimeOptions: ConnectSyncRuntimeOptions = {
+      // Worker-bridged runtimes exchange postcard payloads with peers;
+      // direct browser/server routing keeps JSON payloads.
+      useBinaryEncoding,
+      onAuthFailure,
+      onRejectedBatchAcknowledged,
+    };
+
+    return JazzClient.connectSync(
+      this.wasmModule,
+      {
+        appId: config.appId,
+        schema,
+        driver: config.driver,
+        // In worker mode, don't connect to server directly — worker handles it.
+        serverUrl: hasWorker ? undefined : config.serverUrl,
+        env: config.env,
+        userBranch: config.userBranch,
+        jwtToken: config.jwtToken,
+        cookieSession: config.cookieSession,
+        adminSecret: config.adminSecret,
+        tier: hasWorker ? undefined : "local",
+        // Keep worker-bridged browser clients on local durability by default.
+        // For direct (non-worker) clients connected to a server, default to edge.
+        defaultDurabilityTier: hasWorker ? undefined : config.serverUrl ? "edge" : undefined,
+      },
+      runtimeOptions,
+    );
+  }
+
+  override installTelemetry({
+    config,
+    collectorUrl,
+    runtimeThread,
+  }: DbRuntimeTelemetryContext<DbConfig>): (() => void) | null {
+    return installWasmTelemetry({
+      wasmModule: this.wasmModule,
+      collectorUrl,
+      appId: config.appId,
+      runtimeThread,
+    });
+  }
+
+  override mintLocalFirstToken(options: RuntimeTokenOptions): string {
+    return mintWasmToken(
+      this.wasmModule,
+      options.secret,
+      LOCAL_FIRST_JWT_ISSUER,
+      options.audience,
+      options.ttlSeconds,
+      options.nowSeconds,
+    );
+  }
+
+  override mintAnonymousToken(options: RuntimeTokenOptions): string {
+    return mintWasmToken(
+      this.wasmModule,
+      options.secret,
+      ANONYMOUS_JWT_ISSUER,
+      options.audience,
+      options.ttlSeconds,
+      options.nowSeconds,
+    );
+  }
+}

--- a/packages/jazz-tools/test-support/jazz-rn-vitest-stub.ts
+++ b/packages/jazz-tools/test-support/jazz-rn-vitest-stub.ts
@@ -2,6 +2,8 @@ class RnRuntime {}
 
 const jazz_rn = {
   RnRuntime,
+  mintLocalFirstToken: () => "local-first-token",
+  mintAnonymousToken: () => "anonymous-token",
 };
 
 async function uniffiInitAsync(): Promise<void> {


### PR DESCRIPTION
Refactor db.ts to make the native runtime injected.

This will make it easier to split db in multiple "pluggable" modules as well as moving more stuff on Rust.

This PR also adds anonymous auth to the RN runtime.