### PR TITLE
fix: correctly resolve same-column where conditions

### DIFF
--- a/.changeset/fix-same-column-where-conditions.md
+++ b/.changeset/fix-same-column-where-conditions.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix query planning so multiple conditions on the same column are combined correctly, preserving accurate results for same-column where clauses.

--- a/crates/jazz-tools/src/query_manager/graph/compile.rs
+++ b/crates/jazz-tools/src/query_manager/graph/compile.rs
@@ -1,10 +1,10 @@
 use std::collections::{HashMap, HashSet};
-use std::ops::Bound;
+use std::{cmp::Ordering, ops::Bound};
 
 use crate::object::BranchName;
 use crate::query_manager::types::{
     ColumnDescriptor, ColumnName, ColumnType, ComposedBranchName, RowDescriptor, RowPolicyMode,
-    Schema, SchemaHash, TableName, TupleDescriptor,
+    Schema, SchemaHash, TableName, TupleDescriptor, Value,
 };
 use crate::schema_manager::{
     SchemaContext, translate_column_for_index, translate_table_name_to_schema,
@@ -578,7 +578,7 @@ impl QueryGraph {
         // For multi-branch queries, we create scans for each branch and union them
         // Column names are translated for old schema branches
         let mut phase1_outputs: Vec<NodeId> = Vec::new();
-        let mut index_columns: Vec<String> = Vec::new();
+        let scan_plans: Vec<_> = plan.disjuncts.iter().map(index_scan_plan).collect();
 
         for branch in &branches {
             // Get schema hash for this branch to determine if column translation is needed
@@ -592,17 +592,19 @@ impl QueryGraph {
                 continue;
             };
 
-            for disjunct in &plan.disjuncts {
-                // Find best index condition for this disjunct
-                let (scan_column, scan_condition) =
-                    if let Some(cond) = best_available_index_condition(disjunct, table_schema) {
-                        let column = cond.column().to_string();
-                        let scan_cond = condition_to_scan(cond);
-                        (column, scan_cond)
-                    } else {
-                        // No index condition, use "_id" for full scan
-                        ("_id".to_string(), ScanCondition::All)
-                    };
+//             for disjunct in &plan.disjuncts {
+//                 // Find best index condition for this disjunct
+//                 let (scan_column, scan_condition) =
+//                     if let Some(cond) = best_available_index_condition(disjunct, table_schema) {
+//                         let column = cond.column().to_string();
+//                         let scan_cond = condition_to_scan(cond);
+//                         (column, scan_cond)
+//                     } else {
+//                         // No index condition, use "_id" for full scan
+//                         ("_id".to_string(), ScanCondition::All)
+//                     };
+            for scan_plan in &scan_plans {
+                let scan_column = &scan_plan.column;
 
                 // Translate column name for old schema branches
                 let translated_column = if let Some(target_hash) = branch_schema_hash {
@@ -611,7 +613,7 @@ impl QueryGraph {
                         translate_column_for_index(
                             schema_context,
                             table_str,
-                            &scan_column,
+                            scan_column,
                             &target_hash,
                         )
                         .unwrap_or_else(|| scan_column.clone())
@@ -622,14 +624,13 @@ impl QueryGraph {
                     scan_column.clone()
                 };
 
-                index_columns.push(scan_column.clone());
                 let scan_column_name = ColumnName::new(&translated_column);
 
                 let scan_node = IndexScanNode::new_with_branch(
                     scan_table_name,
                     scan_column_name,
                     branch,
-                    scan_condition,
+                    scan_plan.condition.clone(),
                     descriptor.clone(),
                 );
                 let scan_id = graph.add_node(GraphNode::IndexScan(scan_node));
@@ -799,7 +800,7 @@ impl QueryGraph {
         // Phase 2: Filter node (only if there are remaining conditions not covered by index)
         let predicate = build_remaining_predicate_from_disjuncts(
             &plan.disjuncts,
-            &index_columns,
+            &scan_plans,
             &current_tuple_descriptor,
         );
         if !matches!(predicate, Predicate::True) {
@@ -2048,36 +2049,314 @@ fn sort_keys_from_order_by(
 
 fn build_remaining_predicate_from_disjuncts(
     disjuncts: &[Conjunction],
-    index_columns: &[String],
+    scan_plans: &[IndexScanPlan],
     tuple_descriptor: &TupleDescriptor,
 ) -> Predicate {
-    // Check if all disjuncts are fully covered by their respective index scans
-    let all_fully_covered = disjuncts
-        .iter()
-        .zip(index_columns.iter())
-        .all(|(disjunct, index_col)| disjunct.is_fully_covered_by_index(index_col));
+    let all_fully_covered = disjuncts.len() == scan_plans.len()
+        && scan_plans.iter().all(|scan_plan| scan_plan.fully_covers);
 
     if all_fully_covered {
         return Predicate::True;
     }
 
-    // Build remaining predicates for each disjunct
-    let remaining_predicates: Vec<Predicate> = disjuncts
-        .iter()
-        .zip(index_columns.iter())
-        .map(|(disjunct, index_col)| {
-            disjunct.remaining_tuple_predicate(index_col, tuple_descriptor)
-        })
-        .filter(|p| !matches!(p, Predicate::True))
-        .collect();
+    // Fall back to the full predicate for partial coverage cases. Applying the full predicate
+    // after the union keeps mixed disjuncts correct: rows produced by fully-covered scans still
+    // satisfy the OR, while rows from partial scans get their residual conditions checked.
+    disjuncts_to_predicate(disjuncts, tuple_descriptor)
+}
 
-    // If any disjunct needs filtering, we must use the full predicate for correctness
-    // (because we can't tell which disjunct a row came from after union)
-    if remaining_predicates.is_empty() {
-        Predicate::True
-    } else {
-        // Fall back to full predicate for partial coverage cases
-        disjuncts_to_predicate(disjuncts, tuple_descriptor)
+#[derive(Debug, Clone)]
+struct IndexScanPlan {
+    column: String,
+    condition: ScanCondition,
+    fully_covers: bool,
+}
+
+#[derive(Debug)]
+struct ColumnScanPlan {
+    column: String,
+    condition: ScanCondition,
+    exact: bool,
+}
+
+#[derive(Debug)]
+struct ScanIntersection {
+    eq: Option<Value>,
+    min: Bound<Value>,
+    max: Bound<Value>,
+    empty: bool,
+}
+
+impl Default for ScanIntersection {
+    fn default() -> Self {
+        Self {
+            eq: None,
+            min: Bound::Unbounded,
+            max: Bound::Unbounded,
+            empty: false,
+        }
+    }
+}
+
+fn index_scan_plan(disjunct: &Conjunction) -> IndexScanPlan {
+    if disjunct.conditions.is_empty() {
+        return IndexScanPlan {
+            column: "_id".to_string(),
+            condition: ScanCondition::All,
+            fully_covers: true,
+        };
+    }
+
+    let mut column_plans = Vec::new();
+    for condition in disjunct
+        .conditions
+        .iter()
+        .filter(|c| c.is_index_scannable())
+    {
+        if !column_plans
+            .iter()
+            .any(|plan: &ColumnScanPlan| plan.column == condition.column())
+        {
+            column_plans.push(column_scan_plan(disjunct, condition.column()));
+        }
+    }
+
+    if let Some(empty_plan) = column_plans
+        .iter()
+        .find(|plan| plan.exact && matches!(plan.condition, ScanCondition::Empty))
+    {
+        return IndexScanPlan {
+            column: empty_plan.column.clone(),
+            condition: ScanCondition::Empty,
+            fully_covers: true,
+        };
+    }
+
+    let Some(selected) = column_plans
+        .iter()
+        .find(|plan| matches!(plan.condition, ScanCondition::Eq(_)))
+        .or_else(|| column_plans.first())
+    else {
+        return IndexScanPlan {
+            column: "_id".to_string(),
+            condition: ScanCondition::All,
+            fully_covers: false,
+        };
+    };
+
+    let fully_covers = selected.exact
+        && disjunct.conditions.iter().all(|condition| {
+            condition.column() == selected.column && condition.is_index_scannable()
+        });
+
+    IndexScanPlan {
+        column: selected.column.clone(),
+        condition: selected.condition.clone(),
+        fully_covers,
+    }
+}
+
+fn column_scan_plan(disjunct: &Conjunction, column: &str) -> ColumnScanPlan {
+    let mut intersection = ScanIntersection::default();
+    let mut first_scan = None;
+
+    for condition in disjunct
+        .conditions
+        .iter()
+        .filter(|c| c.column() == column && c.is_index_scannable())
+    {
+        first_scan.get_or_insert_with(|| condition_to_scan(condition));
+        if !intersection.add(condition) {
+            return ColumnScanPlan {
+                column: column.to_string(),
+                condition: first_scan.unwrap_or(ScanCondition::All),
+                exact: false,
+            };
+        }
+    }
+
+    match intersection.into_scan_condition() {
+        Some(condition) => ColumnScanPlan {
+            column: column.to_string(),
+            condition,
+            exact: true,
+        },
+        None => ColumnScanPlan {
+            column: column.to_string(),
+            condition: first_scan.unwrap_or(ScanCondition::All),
+            exact: false,
+        },
+    }
+}
+
+impl ScanIntersection {
+    fn add(&mut self, condition: &Condition) -> bool {
+        match condition {
+            Condition::Eq { value, .. } => {
+                if self.eq.as_ref().is_some_and(|existing| existing != value) {
+                    self.empty = true;
+                } else {
+                    self.eq = Some(value.clone());
+                }
+                true
+            }
+            Condition::Lt { value, .. } => self.tighten_upper(Bound::Excluded(value.clone())),
+            Condition::Le { value, .. } => self.tighten_upper(Bound::Included(value.clone())),
+            Condition::Gt { value, .. } => self.tighten_lower(Bound::Excluded(value.clone())),
+            Condition::Ge { value, .. } => self.tighten_lower(Bound::Included(value.clone())),
+            Condition::Between {
+                min: lower,
+                max: upper,
+                ..
+            } => {
+                self.tighten_lower(Bound::Included(lower.clone()))
+                    && self.tighten_upper(Bound::Included(upper.clone()))
+            }
+            _ => true,
+        }
+    }
+
+    fn tighten_lower(&mut self, candidate: Bound<Value>) -> bool {
+        let Some(bound) = stricter_lower_bound(&self.min, &candidate) else {
+            return false;
+        };
+        self.min = bound;
+        true
+    }
+
+    fn tighten_upper(&mut self, candidate: Bound<Value>) -> bool {
+        let Some(bound) = stricter_upper_bound(&self.max, &candidate) else {
+            return false;
+        };
+        self.max = bound;
+        true
+    }
+
+    fn into_scan_condition(self) -> Option<ScanCondition> {
+        if self.empty {
+            return Some(ScanCondition::Empty);
+        }
+
+        if let Some(value) = self.eq {
+            return value_satisfies_bounds(&value, &self.min, &self.max).map(|matches| {
+                if matches {
+                    ScanCondition::Eq(value)
+                } else {
+                    ScanCondition::Empty
+                }
+            });
+        }
+
+        scan_condition_from_bounds(self.min, self.max)
+    }
+}
+
+fn stricter_lower_bound(current: &Bound<Value>, candidate: &Bound<Value>) -> Option<Bound<Value>> {
+    match (current, candidate) {
+        (Bound::Unbounded, _) => Some(candidate.clone()),
+        (_, Bound::Unbounded) => Some(current.clone()),
+        (
+            Bound::Included(current_value) | Bound::Excluded(current_value),
+            Bound::Included(candidate_value) | Bound::Excluded(candidate_value),
+        ) => match compare_index_values(current_value, candidate_value)? {
+            Ordering::Less => Some(candidate.clone()),
+            Ordering::Greater => Some(current.clone()),
+            Ordering::Equal => Some(
+                if matches!(current, Bound::Excluded(_)) || matches!(candidate, Bound::Excluded(_))
+                {
+                    Bound::Excluded(current_value.clone())
+                } else {
+                    Bound::Included(current_value.clone())
+                },
+            ),
+        },
+    }
+}
+
+fn stricter_upper_bound(current: &Bound<Value>, candidate: &Bound<Value>) -> Option<Bound<Value>> {
+    match (current, candidate) {
+        (Bound::Unbounded, _) => Some(candidate.clone()),
+        (_, Bound::Unbounded) => Some(current.clone()),
+        (
+            Bound::Included(current_value) | Bound::Excluded(current_value),
+            Bound::Included(candidate_value) | Bound::Excluded(candidate_value),
+        ) => match compare_index_values(current_value, candidate_value)? {
+            Ordering::Less => Some(current.clone()),
+            Ordering::Greater => Some(candidate.clone()),
+            Ordering::Equal => Some(
+                if matches!(current, Bound::Excluded(_)) || matches!(candidate, Bound::Excluded(_))
+                {
+                    Bound::Excluded(current_value.clone())
+                } else {
+                    Bound::Included(current_value.clone())
+                },
+            ),
+        },
+    }
+}
+
+fn value_satisfies_bounds(value: &Value, min: &Bound<Value>, max: &Bound<Value>) -> Option<bool> {
+    Some(value_satisfies_lower_bound(value, min)? && value_satisfies_upper_bound(value, max)?)
+}
+
+fn value_satisfies_lower_bound(value: &Value, min: &Bound<Value>) -> Option<bool> {
+    match min {
+        Bound::Unbounded => Some(true),
+        Bound::Included(bound) => Some(matches!(
+            compare_index_values(value, bound)?,
+            Ordering::Equal | Ordering::Greater
+        )),
+        Bound::Excluded(bound) => Some(compare_index_values(value, bound)? == Ordering::Greater),
+    }
+}
+
+fn value_satisfies_upper_bound(value: &Value, max: &Bound<Value>) -> Option<bool> {
+    match max {
+        Bound::Unbounded => Some(true),
+        Bound::Included(bound) => Some(matches!(
+            compare_index_values(value, bound)?,
+            Ordering::Less | Ordering::Equal
+        )),
+        Bound::Excluded(bound) => Some(compare_index_values(value, bound)? == Ordering::Less),
+    }
+}
+
+fn scan_condition_from_bounds(min: Bound<Value>, max: Bound<Value>) -> Option<ScanCondition> {
+    match (&min, &max) {
+        (Bound::Unbounded, Bound::Unbounded) => Some(ScanCondition::All),
+        (
+            Bound::Included(lower) | Bound::Excluded(lower),
+            Bound::Included(upper) | Bound::Excluded(upper),
+        ) => match compare_index_values(lower, upper)? {
+            Ordering::Greater => Some(ScanCondition::Empty),
+            Ordering::Equal => {
+                if matches!(min, Bound::Included(_)) && matches!(max, Bound::Included(_)) {
+                    Some(ScanCondition::Eq(lower.clone()))
+                } else {
+                    Some(ScanCondition::Empty)
+                }
+            }
+            Ordering::Less => Some(ScanCondition::Range { min, max }),
+        },
+        _ => Some(ScanCondition::Range { min, max }),
+    }
+}
+
+fn compare_index_values(left: &Value, right: &Value) -> Option<Ordering> {
+    match (left, right) {
+        (Value::Integer(left), Value::Integer(right)) => Some(left.cmp(right)),
+        (Value::BigInt(left), Value::BigInt(right)) => Some(left.cmp(right)),
+        (Value::Double(left), Value::Double(right)) => Some(left.total_cmp(right)),
+        (Value::Boolean(left), Value::Boolean(right)) => Some(left.cmp(right)),
+        (Value::Text(left), Value::Text(right)) => Some(left.cmp(right)),
+        (Value::Timestamp(left), Value::Timestamp(right)) => Some(left.cmp(right)),
+        (Value::Uuid(left), Value::Uuid(right)) => Some(left.cmp(right)),
+        (Value::BatchId(left), Value::BatchId(right)) => Some(left.cmp(right)),
+        (Value::Bytea(left), Value::Bytea(right)) => Some(left.cmp(right)),
+        (Value::Null, Value::Null) => Some(Ordering::Equal),
+        (Value::Null, _) => Some(Ordering::Less),
+        (_, Value::Null) => Some(Ordering::Greater),
+        _ => None,
     }
 }
 

--- a/crates/jazz-tools/src/query_manager/graph/compile.rs
+++ b/crates/jazz-tools/src/query_manager/graph/compile.rs
@@ -150,25 +150,6 @@ fn collect_magic_refs_from_disjuncts(
     refs
 }
 
-fn best_available_index_condition<'a>(
-    disjunct: &'a Conjunction,
-    table_schema: &crate::query_manager::types::TableSchema,
-) -> Option<&'a Condition> {
-    disjunct
-        .conditions
-        .iter()
-        .find(|condition| {
-            matches!(condition, Condition::Eq { .. })
-                && condition.is_index_scannable()
-                && table_schema.is_indexed_column(condition.column())
-        })
-        .or_else(|| {
-            disjunct.conditions.iter().find(|condition| {
-                condition.is_index_scannable() && table_schema.is_indexed_column(condition.column())
-            })
-        })
-}
-
 fn collect_magic_refs_from_project_columns(
     columns: Option<&[ProjectColumn]>,
 ) -> Vec<(Option<String>, MagicColumnKind)> {
@@ -578,7 +559,11 @@ impl QueryGraph {
         // For multi-branch queries, we create scans for each branch and union them
         // Column names are translated for old schema branches
         let mut phase1_outputs: Vec<NodeId> = Vec::new();
-        let scan_plans: Vec<_> = plan.disjuncts.iter().map(index_scan_plan).collect();
+        let scan_plans: Vec<_> = plan
+            .disjuncts
+            .iter()
+            .map(|disjunct| index_scan_plan(disjunct, table_schema))
+            .collect();
 
         for branch in &branches {
             // Get schema hash for this branch to determine if column translation is needed
@@ -591,18 +576,6 @@ impl QueryGraph {
             else {
                 continue;
             };
-
-//             for disjunct in &plan.disjuncts {
-//                 // Find best index condition for this disjunct
-//                 let (scan_column, scan_condition) =
-//                     if let Some(cond) = best_available_index_condition(disjunct, table_schema) {
-//                         let column = cond.column().to_string();
-//                         let scan_cond = condition_to_scan(cond);
-//                         (column, scan_cond)
-//                     } else {
-//                         // No index condition, use "_id" for full scan
-//                         ("_id".to_string(), ScanCondition::All)
-//                     };
             for scan_plan in &scan_plans {
                 let scan_column = &scan_plan.column;
 
@@ -2098,7 +2071,10 @@ impl Default for ScanIntersection {
     }
 }
 
-fn index_scan_plan(disjunct: &Conjunction) -> IndexScanPlan {
+fn index_scan_plan(
+    disjunct: &Conjunction,
+    table_schema: &crate::query_manager::types::TableSchema,
+) -> IndexScanPlan {
     if disjunct.conditions.is_empty() {
         return IndexScanPlan {
             column: "_id".to_string(),
@@ -2111,7 +2087,7 @@ fn index_scan_plan(disjunct: &Conjunction) -> IndexScanPlan {
     for condition in disjunct
         .conditions
         .iter()
-        .filter(|c| c.is_index_scannable())
+        .filter(|c| c.is_index_scannable() && table_schema.is_indexed_column(c.column()))
     {
         if !column_plans
             .iter()

--- a/crates/jazz-tools/src/query_manager/graph/tests.rs
+++ b/crates/jazz-tools/src/query_manager/graph/tests.rs
@@ -8,7 +8,7 @@ use crate::query_manager::relation_ir::{
     ProjectColumn, ProjectExpr, RelExpr, RowIdRef, ValueRef,
 };
 use crate::query_manager::types::{
-    ColumnDescriptor, ColumnType, RowDescriptor, RowPolicyMode, Schema, Value,
+    ColumnDescriptor, ColumnType, RowDescriptor, RowPolicyMode, Schema, TableSchema, Value,
 };
 use std::ops::Bound;
 
@@ -328,6 +328,66 @@ fn same_column_contradiction_elides_filter_with_empty_scan() {
         only_index_scan_condition(&graph),
         ScanCondition::Empty
     ));
+}
+
+#[test]
+fn same_column_unindexed_bounds_keep_filter_and_scan_id() {
+    let mut schema = Schema::new();
+    schema.insert(
+        TableName::new("users"),
+        TableSchema::builder("users")
+            .column("name", ColumnType::Text)
+            .column("score", ColumnType::Integer)
+            .index_only(["name"])
+            .build(),
+    );
+    let query = QueryBuilder::new("users")
+        .filter_gt("score", Value::Integer(10))
+        .filter_lt("score", Value::Integer(20))
+        .build();
+
+    let graph = QueryGraph::compile(&query, &schema).unwrap();
+    let scan = only_index_scan(&graph);
+
+    assert_eq!(scan.column.as_str(), "_id");
+    assert!(matches!(&scan.condition, ScanCondition::All));
+    assert!(
+        has_filter_node(&graph),
+        "unindexed same-column bounds must remain as a residual predicate"
+    );
+}
+
+#[test]
+fn unindexed_eq_predicate_does_not_preempt_indexed_scan() {
+    let mut schema = Schema::new();
+    schema.insert(
+        TableName::new("users"),
+        TableSchema::builder("users")
+            .column("name", ColumnType::Text)
+            .column("score", ColumnType::Integer)
+            .index_only(["score"])
+            .build(),
+    );
+    let query = QueryBuilder::new("users")
+        .filter_eq("name", Value::Text("Alice".into()))
+        .filter_gt("score", Value::Integer(50))
+        .build();
+
+    let graph = QueryGraph::compile(&query, &schema).unwrap();
+    let scan = only_index_scan(&graph);
+
+    assert_eq!(scan.column.as_str(), "score");
+    assert!(matches!(
+        &scan.condition,
+        ScanCondition::Range {
+            min: Bound::Excluded(Value::Integer(50)),
+            max: Bound::Unbounded,
+        }
+    ));
+    assert!(
+        has_filter_node(&graph),
+        "unindexed equality predicates must not be treated as index-covered"
+    );
 }
 
 #[test]

--- a/crates/jazz-tools/src/query_manager/graph/tests.rs
+++ b/crates/jazz-tools/src/query_manager/graph/tests.rs
@@ -1,6 +1,7 @@
 //! Tests for QueryGraph compile and execute.
 
 use super::*;
+use crate::query_manager::index::ScanCondition;
 use crate::query_manager::query::QueryBuilder;
 use crate::query_manager::relation_ir::{
     ColumnRef, JoinCondition, KeyRef, OrderByExpr, OrderDirection, PredicateCmpOp, PredicateExpr,
@@ -9,6 +10,7 @@ use crate::query_manager::relation_ir::{
 use crate::query_manager::types::{
     ColumnDescriptor, ColumnType, RowDescriptor, RowPolicyMode, Schema, Value,
 };
+use std::ops::Bound;
 
 fn test_schema() -> Schema {
     let mut schema = Schema::new();
@@ -159,6 +161,32 @@ fn has_filter_node(graph: &QueryGraph) -> bool {
         .any(|c| matches!(c.node, GraphNode::Filter(_)))
 }
 
+fn only_index_scan_condition(graph: &QueryGraph) -> &ScanCondition {
+    let scan_conditions: Vec<_> = graph
+        .nodes
+        .iter()
+        .filter_map(|c| match &c.node {
+            GraphNode::IndexScan(scan) => Some(&scan.condition),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(scan_conditions.len(), 1);
+    scan_conditions[0]
+}
+
+fn only_index_scan(graph: &QueryGraph) -> &IndexScanNode {
+    let scans: Vec<_> = graph
+        .nodes
+        .iter()
+        .filter_map(|c| match &c.node {
+            GraphNode::IndexScan(scan) => Some(scan),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(scans.len(), 1);
+    scans[0]
+}
+
 #[test]
 fn single_eq_condition_elides_filter() {
     let schema = test_schema();
@@ -209,6 +237,119 @@ fn single_between_condition_elides_filter() {
         "FilterNode should be elided for single Between condition"
     );
     assert_eq!(graph.nodes.len(), 4);
+}
+
+#[test]
+fn same_column_redundant_lower_bounds_elide_filter_with_strictest_scan() {
+    let schema = test_schema();
+    let query = QueryBuilder::new("users")
+        .filter_gt("score", Value::Integer(10))
+        .filter_ge("score", Value::Integer(5))
+        .build();
+
+    let graph = QueryGraph::compile(&query, &schema).unwrap();
+
+    assert!(
+        !has_filter_node(&graph),
+        "redundant same-column lower bounds should be fully covered by the merged scan"
+    );
+    assert_eq!(graph.nodes.len(), 4);
+    assert!(matches!(
+        only_index_scan_condition(&graph),
+        ScanCondition::Range {
+            min: Bound::Excluded(Value::Integer(10)),
+            max: Bound::Unbounded,
+        }
+    ));
+}
+
+#[test]
+fn same_column_redundant_upper_bounds_elide_filter_with_strictest_scan() {
+    let schema = test_schema();
+    let query = QueryBuilder::new("users")
+        .filter_lt("score", Value::Integer(20))
+        .filter_le("score", Value::Integer(15))
+        .build();
+
+    let graph = QueryGraph::compile(&query, &schema).unwrap();
+
+    assert!(
+        !has_filter_node(&graph),
+        "redundant same-column upper bounds should be fully covered by the merged scan"
+    );
+    assert_eq!(graph.nodes.len(), 4);
+    assert!(matches!(
+        only_index_scan_condition(&graph),
+        ScanCondition::Range {
+            min: Bound::Unbounded,
+            max: Bound::Included(Value::Integer(15)),
+        }
+    ));
+}
+
+#[test]
+fn same_column_eq_inside_range_elides_filter_with_eq_scan() {
+    let schema = test_schema();
+    let query = QueryBuilder::new("users")
+        .filter_eq("score", Value::Integer(10))
+        .filter_ge("score", Value::Integer(5))
+        .filter_lt("score", Value::Integer(20))
+        .build();
+
+    let graph = QueryGraph::compile(&query, &schema).unwrap();
+
+    assert!(
+        !has_filter_node(&graph),
+        "an equality within same-column bounds should be fully covered by the eq scan"
+    );
+    assert_eq!(graph.nodes.len(), 4);
+    assert!(matches!(
+        only_index_scan_condition(&graph),
+        ScanCondition::Eq(Value::Integer(10))
+    ));
+}
+
+#[test]
+fn same_column_contradiction_elides_filter_with_empty_scan() {
+    let schema = test_schema();
+    let query = QueryBuilder::new("users")
+        .filter_eq("score", Value::Integer(10))
+        .filter_lt("score", Value::Integer(10))
+        .build();
+
+    let graph = QueryGraph::compile(&query, &schema).unwrap();
+
+    assert!(
+        !has_filter_node(&graph),
+        "a proven same-column contradiction should scan no rows and need no residual filter"
+    );
+    assert_eq!(graph.nodes.len(), 4);
+    assert!(matches!(
+        only_index_scan_condition(&graph),
+        ScanCondition::Empty
+    ));
+}
+
+#[test]
+fn multi_column_conjunction_prefers_eq_scan_and_keeps_filter() {
+    let schema = test_schema();
+    let query = QueryBuilder::new("users")
+        .filter_ge("score", Value::Integer(50))
+        .filter_eq("name", Value::Text("Alice".into()))
+        .build();
+
+    let graph = QueryGraph::compile(&query, &schema).unwrap();
+    let scan = only_index_scan(&graph);
+
+    assert_eq!(scan.column.as_str(), "name");
+    assert!(matches!(
+        &scan.condition,
+        ScanCondition::Eq(Value::Text(name)) if name == "Alice"
+    ));
+    assert!(
+        has_filter_node(&graph),
+        "score >= 50 must remain as a residual predicate after the name index scan"
+    );
 }
 
 #[test]
@@ -267,6 +408,25 @@ fn or_with_single_conditions_elides_filter() {
         "FilterNode should be elided when all disjuncts are fully covered"
     );
     assert_eq!(graph.nodes.len(), 6);
+}
+
+#[test]
+fn or_with_partial_disjunct_keeps_filter() {
+    let schema = test_schema();
+    let query = QueryBuilder::new("users")
+        .filter_eq("score", Value::Integer(50))
+        .or()
+        .filter_eq("score", Value::Integer(100))
+        .filter_eq("name", Value::Text("Alice".into()))
+        .build();
+
+    let graph = QueryGraph::compile(&query, &schema).unwrap();
+
+    assert_eq!(graph.index_scan_nodes.len(), 2);
+    assert!(
+        has_filter_node(&graph),
+        "mixed fully-covered and partial disjuncts need the full residual OR predicate"
+    );
 }
 
 // ========================================================================

--- a/crates/jazz-tools/src/query_manager/graph_nodes/index_scan.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/index_scan.rs
@@ -70,6 +70,7 @@ impl IndexScanNode {
 impl SourceNode for IndexScanNode {
     fn scan(&mut self, ctx: &SourceContext) -> TupleDelta {
         let new_ids: AHashSet<ObjectId> = match &self.condition {
+            ScanCondition::Empty => AHashSet::new(),
             ScanCondition::All => ctx
                 .storage
                 .index_scan_all(self.table.as_str(), self.column.as_str(), &self.branch)

--- a/crates/jazz-tools/src/query_manager/graph_nodes/index_scan.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/index_scan.rs
@@ -76,6 +76,7 @@ impl IndexScanNode {
         };
         match &self.condition {
             ScanCondition::All => true,
+            ScanCondition::Empty => false,
             ScanCondition::Eq(expected) => value == *expected || array_contains(&value, expected),
             ScanCondition::Range { min, max } => {
                 bound_matches(min, &value, true) && bound_matches(max, &value, false)

--- a/crates/jazz-tools/src/query_manager/index/mod.rs
+++ b/crates/jazz-tools/src/query_manager/index/mod.rs
@@ -3,10 +3,12 @@ use std::ops::Bound;
 use crate::query_manager::types::Value;
 
 /// Condition for index scan.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ScanCondition {
     /// No condition - scan all entries (uses "_id" index).
     All,
+    /// Empty condition - scan no entries.
+    Empty,
     /// Exact match on value.
     Eq(Value),
     /// Range scan with bounds (inclusive, exclusive, or unbounded).

--- a/crates/jazz-tools/src/query_manager/query.rs
+++ b/crates/jazz-tools/src/query_manager/query.rs
@@ -424,59 +424,6 @@ impl Conjunction {
         self.conditions.push(condition);
     }
 
-    /// Find the best condition for index scanning.
-    /// Prefers Eq over range conditions.
-    pub fn best_index_condition(&self) -> Option<&Condition> {
-        // First look for Eq conditions
-        if let Some(cond) = self
-            .conditions
-            .iter()
-            .find(|c| matches!(c, Condition::Eq { .. }) && c.is_index_scannable())
-        {
-            return Some(cond);
-        }
-        // Then any other index-scannable condition
-        self.conditions.iter().find(|c| c.is_index_scannable())
-    }
-
-    /// Get remaining conditions after removing the index condition.
-    pub fn remaining_conditions(&self, index_column: &str) -> Vec<&Condition> {
-        self.conditions
-            .iter()
-            .filter(|c| c.column() != index_column)
-            .collect()
-    }
-
-    /// Check if all conditions are fully covered by index scan on the given column.
-    /// Returns true if the only condition(s) are on the index column and are index-scannable.
-    pub fn is_fully_covered_by_index(&self, index_column: &str) -> bool {
-        if self.conditions.is_empty() {
-            return true;
-        }
-        // All conditions must be on the index column and index-scannable
-        self.conditions
-            .iter()
-            .all(|c| c.column() == index_column && c.is_index_scannable())
-    }
-
-    /// Convert remaining (non-indexed) conditions to a Predicate.
-    /// Returns Predicate::True if all conditions are covered by the index.
-    pub fn remaining_predicate(&self, index_column: &str, descriptor: &RowDescriptor) -> Predicate {
-        let remaining: Vec<_> = self
-            .remaining_conditions(index_column)
-            .into_iter()
-            .filter_map(|c| c.to_predicate(descriptor))
-            .collect();
-
-        if remaining.is_empty() {
-            Predicate::True
-        } else if remaining.len() == 1 {
-            remaining.into_iter().next().unwrap()
-        } else {
-            Predicate::And(remaining)
-        }
-    }
-
     /// Convert to a Predicate.
     pub fn to_predicate(&self, descriptor: &RowDescriptor) -> Predicate {
         if self.conditions.is_empty() {
@@ -512,27 +459,6 @@ impl Conjunction {
             predicates.into_iter().next().unwrap()
         } else {
             Predicate::And(predicates)
-        }
-    }
-
-    /// Convert remaining (non-indexed) conditions to a Predicate using a TupleDescriptor.
-    pub fn remaining_tuple_predicate(
-        &self,
-        index_column: &str,
-        tuple_descriptor: &TupleDescriptor,
-    ) -> Predicate {
-        let remaining: Vec<_> = self
-            .remaining_conditions(index_column)
-            .into_iter()
-            .filter_map(|c| c.to_tuple_predicate(tuple_descriptor))
-            .collect();
-
-        if remaining.is_empty() {
-            Predicate::True
-        } else if remaining.len() == 1 {
-            remaining.into_iter().next().unwrap()
-        } else {
-            Predicate::And(remaining)
         }
     }
 }
@@ -1534,23 +1460,6 @@ mod tests {
     }
 
     #[test]
-    fn conjunction_best_index_condition() {
-        let mut conj = Conjunction::new();
-        conj.add(Condition::Ge {
-            column: "score".into(),
-            value: Value::Integer(50),
-        });
-        conj.add(Condition::Eq {
-            column: "status".into(),
-            value: Value::Text("active".into()),
-        });
-
-        // Should prefer Eq over Ge
-        let best = conj.best_index_condition().unwrap();
-        assert!(matches!(best, Condition::Eq { column, .. } if column == "status"));
-    }
-
-    #[test]
     fn query_to_predicate() {
         let descriptor = test_descriptor();
         let query = QueryBuilder::new("users")
@@ -1623,7 +1532,7 @@ mod tests {
 
         let predicate = query.to_predicate(&descriptor);
         assert!(matches!(predicate, Predicate::IsNull { col_index: 1 }));
-        assert!(query.disjuncts[0].best_index_condition().is_none());
+        assert!(!query.disjuncts[0].conditions[0].is_index_scannable());
     }
 
     #[test]

--- a/packages/jazz-tools/src/runtime/query-adapter.ts
+++ b/packages/jazz-tools/src/runtime/query-adapter.ts
@@ -152,8 +152,13 @@ function toWasmValue(value: unknown, columnType: ColumnType, columnName?: string
     if (columnType?.type === "Timestamp") {
       return { type: "Timestamp", value: toRuntimeTimestampValue(value, columnName) };
     }
-    // Use Integer for all numbers - WASM will handle type coercion
-    return { type: "Integer", value };
+    if (
+      columnType.type === "Double" ||
+      columnType.type === "BigInt" ||
+      columnType.type === "Integer"
+    ) {
+      return { type: columnType.type, value };
+    }
   }
   if (typeof value === "string") {
     if (columnType?.type === "Timestamp") {

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/basic/schema.ts
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/basic/schema.ts
@@ -40,6 +40,7 @@ export const schema = {
     array: s.array(s.string()).default(["a", "b", "c"]),
     boolean: s.boolean().default(true),
     nullable: s.string().optional().default(null),
+    nullableInteger: s.int().optional().default(null),
     refId: s.ref("todos").optional().default("00000000-0000-0000-0000-000000000000"),
   }),
 };

--- a/packages/jazz-tools/tests/ts-dsl/insert-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/insert-api.test.ts
@@ -113,6 +113,7 @@ describe("TS Insert API", () => {
       array: ["a", "b", "c"],
       boolean: true,
       nullable: null,
+      nullableInteger: null,
       refId: "00000000-0000-0000-0000-000000000000",
     });
   });
@@ -136,6 +137,7 @@ describe("TS Insert API", () => {
       array: ["a", "b", "c"],
       boolean: true,
       nullable: null,
+      nullableInteger: null,
       refId: null,
     });
   });

--- a/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
@@ -102,6 +102,152 @@ describe("TS Query API", () => {
       expect(results.map((todo) => todo.id)).toEqual([todoWithoutOwner.id, todoWithOwner.id]);
     });
 
+    it("filters int columns with multiple range operators on the same column", async () => {
+      db.insert(app.table_with_defaults, { integer: 5 });
+      const { value: aliceTask } = db.insert(app.table_with_defaults, { integer: 10 });
+      const { value: bobTask } = db.insert(app.table_with_defaults, { integer: 15 });
+      db.insert(app.table_with_defaults, { integer: 20 });
+
+      const results = await db.all(
+        app.table_with_defaults
+          .where({ integer: { gt: 5, lt: 20 } })
+          .select("integer")
+          .orderBy("integer", "asc"),
+      );
+
+      expect(results).toEqual([
+        { id: aliceTask.id, integer: 10 },
+        { id: bobTask.id, integer: 15 },
+      ]);
+    });
+
+    it("filters nullable int columns with range and not-null predicates", async () => {
+      db.insert(app.table_with_defaults, { nullableInteger: null });
+      const { value: aliceTask } = db.insert(app.table_with_defaults, { nullableInteger: 5 });
+      db.insert(app.table_with_defaults, { nullableInteger: 10 });
+      db.insert(app.table_with_defaults, { nullableInteger: 15 });
+
+      const results = await db.all(
+        app.table_with_defaults
+          .where({ nullableInteger: { lt: 10, ne: null } })
+          .select("nullableInteger")
+          .orderBy("nullableInteger", "asc"),
+      );
+
+      expect(results).toEqual([{ id: aliceTask.id, nullableInteger: 5 }]);
+    });
+
+    it("filters nullable int columns with range and null equality predicates", async () => {
+      db.insert(app.table_with_defaults, { nullableInteger: null });
+      db.insert(app.table_with_defaults, { nullableInteger: 5 });
+      db.insert(app.table_with_defaults, { nullableInteger: 10 });
+      db.insert(app.table_with_defaults, { nullableInteger: 15 });
+
+      const results = await db.all(
+        app.table_with_defaults
+          .where({ nullableInteger: { lt: 10, eq: null } })
+          .select("nullableInteger")
+          .orderBy("nullableInteger", "asc"),
+      );
+
+      expect(results).toEqual([]);
+    });
+
+    it("filters float columns with multiple range operators on the same column", async () => {
+      db.insert(app.table_with_defaults, { float: 1.5 });
+      const { value: aliceTask } = db.insert(app.table_with_defaults, { float: 2.5 });
+      const { value: bobTask } = db.insert(app.table_with_defaults, { float: 3.5 });
+      db.insert(app.table_with_defaults, { float: 4.5 });
+
+      const results = await db.all(
+        app.table_with_defaults
+          .where({ float: { gt: 1.5, lt: 4.5 } })
+          .select("float")
+          .orderBy("float", "asc"),
+      );
+
+      expect(results).toEqual([
+        { id: aliceTask.id, float: 2.5 },
+        { id: bobTask.id, float: 3.5 },
+      ]);
+    });
+
+    it("filters timestamp columns with multiple range operators on the same column", async () => {
+      const lowerBound = new Date("2026-02-01T00:00:00.000Z");
+      const aliceDueAt = new Date("2026-02-02T00:00:00.000Z");
+      const bobDueAt = new Date("2026-02-03T00:00:00.000Z");
+      const upperBound = new Date("2026-02-04T00:00:00.000Z");
+
+      db.insert(app.table_with_defaults, { timestampDate: lowerBound });
+      const { value: aliceTask } = db.insert(app.table_with_defaults, {
+        timestampDate: aliceDueAt,
+      });
+      const { value: bobTask } = db.insert(app.table_with_defaults, { timestampDate: bobDueAt });
+      db.insert(app.table_with_defaults, { timestampDate: upperBound });
+
+      const results = await db.all(
+        app.table_with_defaults
+          .where({ timestampDate: { gt: lowerBound, lt: upperBound } })
+          .select("timestampDate")
+          .orderBy("timestampDate", "asc"),
+      );
+
+      expect(results).toEqual([
+        { id: aliceTask.id, timestampDate: aliceDueAt },
+        { id: bobTask.id, timestampDate: bobDueAt },
+      ]);
+    });
+
+    it("filters same-column numeric bounds by the full predicate after index scanning", async () => {
+      const { value: aliceTask } = db.insert(app.table_with_defaults, { integer: 5 });
+      const { value: daveTask } = db.insert(app.table_with_defaults, { integer: 10 });
+      const { value: bobTask } = db.insert(app.table_with_defaults, { integer: 15 });
+      const { value: carolTask } = db.insert(app.table_with_defaults, { integer: 20 });
+
+      const duplicateLowerBoundResults = await db.all(
+        app.table_with_defaults
+          .where({ integer: { gt: 10, gte: 5 } })
+          .select("integer")
+          .orderBy("integer", "asc"),
+      );
+
+      expect(duplicateLowerBoundResults).toEqual([
+        { id: bobTask.id, integer: 15 },
+        { id: carolTask.id, integer: 20 },
+      ]);
+
+      const duplicateUpperBoundResults = await db.all(
+        app.table_with_defaults
+          .where({ integer: { lt: 20, lte: 15 } })
+          .select("integer")
+          .orderBy("integer", "asc"),
+      );
+
+      expect(duplicateUpperBoundResults).toEqual([
+        { id: aliceTask.id, integer: 5 },
+        { id: daveTask.id, integer: 10 },
+        { id: bobTask.id, integer: 15 },
+      ]);
+
+      const eqInsideRangeResults = await db.all(
+        app.table_with_defaults
+          .where({ integer: { eq: 15, gte: 5, lt: 20 } })
+          .select("integer")
+          .orderBy("integer", "asc"),
+      );
+
+      expect(eqInsideRangeResults).toEqual([{ id: bobTask.id, integer: 15 }]);
+
+      const impossibleRangeResults = await db.all(
+        app.table_with_defaults
+          .where({ integer: { eq: 10, lt: 10 } })
+          .select("integer")
+          .orderBy("integer", "asc"),
+      );
+
+      expect(impossibleRangeResults).toEqual([]);
+    });
+
     describe("query by array column", () => {
       it("using eq", async () => {
         const { id: id1 } = insertTodo(db, {


### PR DESCRIPTION
## Summary

Fixes query planning for conjunctions that place multiple predicates on the same indexed column, and adds a changeset for the `jazz-tools` patch release.

## Motivation

The planner previously picked one index-scannable condition per disjunct and then considered all predicates on that same column to be covered by the index scan. That was incorrect for same-column conjunctions because a scan for only one bound could return rows that failed the other bound, while the residual filter had already been elided.

Examples that now return the correct rows:

```ts
// rows with values of [5, 10, 15, 20]
await db.all(
  app.table_with_defaults
    .where({ integer: { gt: 5, lt: 20 } })
    .select("integer")
    .orderBy("integer", "asc"),
);
// returns integer 10 and 15; excludes 5 and 20

// ----

// rows with values of [5, 10, 15, 20]
await db.all(
  app.table_with_defaults
    .where({ integer: { gt: 10, gte: 5 } })
    .select("integer")
    .orderBy("integer", "asc"),
);
// returns values greater than 10, not everything >= 5

// ----

await db.all(
  app.table_with_defaults
    .where({ nullableInteger: { lt: 10, ne: null } })
    .select("nullableInteger"),
);
// returns only non-null values below 10
```

## Planner behavior

Same-column scan conditions are now intersected before choosing the index scan. Redundant bounds collapse to the strictest scan, equality inside a range becomes an exact lookup, and contradictions become an empty scan.

Optimization examples:

```ts
await db.all(
  app.table_with_defaults.where({ integer: { eq: 15, gte: 5, lt: 20 } }),
);
// planned as an exact integer = 15 scan

await db.all(
  app.table_with_defaults.where({ integer: { eq: 10, lt: 10 } }),
);
// planned as ScanCondition::Empty and short-circuits to zero results

await db.all(
  app.table_with_defaults.where({ nullableInteger: { lt: 10, eq: null } }),
);
// impossible same-column predicate; returns []
```

For mixed-column predicates, the planner still keeps the residual filter when one index scan cannot fully cover the whole conjunction.

## Tests

- Added Rust query graph tests for redundant lower/upper bounds, equality within ranges, contradiction-to-empty scans, and mixed disjunct residual filtering.
- Added TS DSL integration coverage for integer, nullable integer, float, and timestamp same-column predicates.