### PR TITLE
Extract local-first auth from Db

### DIFF
--- a/packages/jazz-tools/src/runtime/db-auth.test.ts
+++ b/packages/jazz-tools/src/runtime/db-auth.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDbWithRuntimeModule, type DbConfig } from "./db.js";
+import { LocalFirstAuthManager, resolveDbAuthConfig } from "./db-auth.js";
+import type { DbRuntimeModule, RuntimeTokenOptions } from "./db-runtime-module.js";
+
+function createRuntimeModuleStub() {
+  return {
+    mintLocalFirstToken: vi.fn(
+      (options: RuntimeTokenOptions) =>
+        `local:${options.secret}:${options.audience}:${options.ttlSeconds}`,
+    ),
+    mintAnonymousToken: vi.fn(
+      (options: RuntimeTokenOptions) =>
+        `anonymous:${options.secret}:${options.audience}:${options.ttlSeconds}`,
+    ),
+  } as Pick<DbRuntimeModule<DbConfig>, "mintLocalFirstToken" | "mintAnonymousToken"> & {
+    mintLocalFirstToken: ReturnType<typeof vi.fn<(options: RuntimeTokenOptions) => string>>;
+    mintAnonymousToken: ReturnType<typeof vi.fn<(options: RuntimeTokenOptions) => string>>;
+  };
+}
+
+class LoadingRuntimeModuleStub implements Pick<
+  DbRuntimeModule<DbConfig>,
+  "load" | "createClient" | "mintLocalFirstToken" | "mintAnonymousToken"
+> {
+  readonly load = vi.fn(async (_config: DbConfig) => undefined);
+  readonly createClient = vi.fn(() => {
+    throw new Error("createClient should not be called");
+  });
+  readonly mintLocalFirstToken = vi.fn((_options: RuntimeTokenOptions) => "local-jwt");
+  readonly mintAnonymousToken = vi.fn((_options: RuntimeTokenOptions) => "anonymous-jwt");
+}
+
+describe("resolveDbAuthConfig", () => {
+  it("rejects secret and jwtToken before runtime setup", async () => {
+    const runtimeModule = createRuntimeModuleStub();
+    const loadingRuntimeModule = new LoadingRuntimeModuleStub();
+
+    expect(() =>
+      resolveDbAuthConfig(
+        {
+          appId: "test-app",
+          secret: "alice-secret",
+          jwtToken: "existing-jwt",
+        },
+        runtimeModule,
+      ),
+    ).toThrow("mutually exclusive");
+
+    expect(runtimeModule.mintLocalFirstToken).not.toHaveBeenCalled();
+    expect(runtimeModule.mintAnonymousToken).not.toHaveBeenCalled();
+
+    await expect(
+      createDbWithRuntimeModule(
+        {
+          appId: "test-app",
+          secret: "alice-secret",
+          jwtToken: "existing-jwt",
+        },
+        loadingRuntimeModule as unknown as DbRuntimeModule<DbConfig>,
+      ),
+    ).rejects.toThrow("mutually exclusive");
+    expect(loadingRuntimeModule.load).not.toHaveBeenCalled();
+  });
+
+  it("rejects jwtToken and cookieSession before minting auth tokens", () => {
+    const runtimeModule = createRuntimeModuleStub();
+
+    expect(() =>
+      resolveDbAuthConfig(
+        {
+          appId: "test-app",
+          jwtToken: "existing-jwt",
+          cookieSession: {
+            user_id: "alice",
+            claims: { role: "reader" },
+            authMode: "external",
+          },
+        },
+        runtimeModule,
+      ),
+    ).toThrow("mutually exclusive");
+
+    expect(runtimeModule.mintLocalFirstToken).not.toHaveBeenCalled();
+    expect(runtimeModule.mintAnonymousToken).not.toHaveBeenCalled();
+  });
+
+  it("mints a local-first startup token when secret is present", () => {
+    const runtimeModule = createRuntimeModuleStub();
+
+    const resolved = resolveDbAuthConfig(
+      {
+        appId: "auth-app",
+        secret: "alice-secret",
+        serverUrl: "https://example.test",
+      },
+      runtimeModule,
+    );
+
+    expect(resolved.localFirstSecret).toBe("alice-secret");
+    expect(resolved.config.secret).toBe("alice-secret");
+    expect(resolved.config.jwtToken).toBe("local:alice-secret:auth-app:3600");
+    expect(runtimeModule.mintLocalFirstToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        secret: "alice-secret",
+        audience: "auth-app",
+        ttlSeconds: 3600,
+      }),
+    );
+    const tokenOptions = runtimeModule.mintLocalFirstToken.mock.calls[0]?.[0];
+    expect(tokenOptions?.nowSeconds).toBeTypeOf("bigint");
+    expect(runtimeModule.mintAnonymousToken).not.toHaveBeenCalled();
+  });
+
+  it("mints an anonymous startup token when user auth is absent", () => {
+    const runtimeModule = createRuntimeModuleStub();
+
+    const resolved = resolveDbAuthConfig({ appId: "anonymous-app" }, runtimeModule);
+
+    expect(resolved.localFirstSecret).toBeNull();
+    expect(resolved.config.jwtToken).toMatch(/^anonymous:[A-Za-z0-9_-]{43}:anonymous-app:3600$/);
+    expect(runtimeModule.mintLocalFirstToken).not.toHaveBeenCalled();
+    expect(runtimeModule.mintAnonymousToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        audience: "anonymous-app",
+        ttlSeconds: 3600,
+      }),
+    );
+  });
+
+  it("does not mint anonymous auth for admin-secret clients", () => {
+    const runtimeModule = createRuntimeModuleStub();
+
+    const resolved = resolveDbAuthConfig(
+      {
+        appId: "admin-app",
+        adminSecret: "admin-secret",
+      },
+      runtimeModule,
+    );
+
+    expect(resolved.localFirstSecret).toBeNull();
+    expect(resolved.config.jwtToken).toBeUndefined();
+    expect(runtimeModule.mintLocalFirstToken).not.toHaveBeenCalled();
+    expect(runtimeModule.mintAnonymousToken).not.toHaveBeenCalled();
+  });
+});
+
+describe("LocalFirstAuthManager", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("mints identity proofs with default ttl 60", () => {
+    const runtimeModule = createRuntimeModuleStub();
+    const manager = new LocalFirstAuthManager({
+      appId: "auth-app",
+      secret: "alice-secret",
+      runtimeModule,
+      applyToken: vi.fn(),
+      isShuttingDown: () => false,
+    });
+
+    const proof = manager.getIdentityProof({ audience: "proof-audience" });
+
+    expect(proof).toBe("local:alice-secret:proof-audience:60");
+    expect(runtimeModule.mintLocalFirstToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        secret: "alice-secret",
+        audience: "proof-audience",
+        ttlSeconds: 60,
+      }),
+    );
+  });
+
+  it("refreshes app auth at 80 percent of the 3600 second ttl", async () => {
+    vi.useFakeTimers();
+    const runtimeModule = createRuntimeModuleStub();
+    const applyToken = vi.fn();
+    const manager = new LocalFirstAuthManager({
+      appId: "auth-app",
+      secret: "alice-secret",
+      runtimeModule,
+      applyToken,
+      isShuttingDown: () => false,
+    });
+
+    manager.start();
+
+    await vi.advanceTimersByTimeAsync(2_879_999);
+    expect(applyToken).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(applyToken).toHaveBeenCalledWith("local:alice-secret:auth-app:3600");
+    expect(runtimeModule.mintLocalFirstToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        secret: "alice-secret",
+        audience: "auth-app",
+        ttlSeconds: 3600,
+      }),
+    );
+    expect(vi.getTimerCount()).toBe(1);
+
+    manager.stop();
+  });
+
+  it("clears the refresh timer on stop", async () => {
+    vi.useFakeTimers();
+    const runtimeModule = createRuntimeModuleStub();
+    const applyToken = vi.fn();
+    const manager = new LocalFirstAuthManager({
+      appId: "auth-app",
+      secret: "alice-secret",
+      runtimeModule,
+      applyToken,
+      isShuttingDown: () => false,
+    });
+
+    manager.start();
+    expect(vi.getTimerCount()).toBe(1);
+
+    manager.stop();
+
+    expect(vi.getTimerCount()).toBe(0);
+    await vi.advanceTimersByTimeAsync(2_880_000);
+    expect(applyToken).not.toHaveBeenCalled();
+  });
+});

--- a/packages/jazz-tools/src/runtime/db-auth.ts
+++ b/packages/jazz-tools/src/runtime/db-auth.ts
@@ -1,0 +1,155 @@
+import type { DbConfig } from "./db.js";
+import type { DbRuntimeModule, RuntimeTokenOptions } from "./db-runtime-module.js";
+
+const LOCAL_FIRST_TOKEN_TTL_SECONDS = 3600;
+const LOCAL_FIRST_REFRESH_RATIO = 0.8;
+const IDENTITY_PROOF_TTL_SECONDS = 60;
+
+type TokenMintingRuntime<RuntimeConfig extends DbConfig> = Pick<
+  DbRuntimeModule<RuntimeConfig>,
+  "mintLocalFirstToken" | "mintAnonymousToken"
+>;
+
+type LocalFirstTokenRuntime<RuntimeConfig extends DbConfig> = Pick<
+  DbRuntimeModule<RuntimeConfig>,
+  "mintLocalFirstToken"
+>;
+
+export interface ResolvedDbAuthConfig<RuntimeConfig extends DbConfig> {
+  config: RuntimeConfig & DbConfig;
+  localFirstSecret: string | null;
+}
+
+export interface LocalFirstAuthManagerOptions<RuntimeConfig extends DbConfig = DbConfig> {
+  appId: string;
+  secret: string;
+  runtimeModule: LocalFirstTokenRuntime<RuntimeConfig>;
+  applyToken: (jwtToken: string) => void;
+  isShuttingDown: () => boolean;
+  ttlSeconds?: number;
+}
+
+export interface LocalFirstIdentityProofOptions {
+  ttlSeconds?: number;
+  audience?: string;
+}
+
+export function validateDbAuthConfig(config: DbConfig): void {
+  if (config.secret && (config.jwtToken || config.cookieSession)) {
+    throw new Error("DbConfig error: secret, jwtToken, and cookieSession are mutually exclusive");
+  }
+  if (config.jwtToken && config.cookieSession) {
+    throw new Error("DbConfig error: jwtToken and cookieSession are mutually exclusive");
+  }
+}
+
+export function resolveDbAuthConfig<RuntimeConfig extends DbConfig>(
+  config: RuntimeConfig,
+  runtimeModule: TokenMintingRuntime<RuntimeConfig>,
+): ResolvedDbAuthConfig<RuntimeConfig> {
+  validateDbAuthConfig(config);
+
+  if (config.secret) {
+    const jwtToken = runtimeModule.mintLocalFirstToken(
+      createRuntimeTokenOptions(config.secret, config.appId, LOCAL_FIRST_TOKEN_TTL_SECONDS),
+    );
+    return {
+      config: { ...config, jwtToken },
+      localFirstSecret: config.secret,
+    };
+  }
+
+  if (!config.jwtToken && !config.cookieSession && !config.adminSecret) {
+    const ephemeralSeed = generateEphemeralSeedBase64Url();
+    const jwtToken = runtimeModule.mintAnonymousToken(
+      createRuntimeTokenOptions(ephemeralSeed, config.appId, LOCAL_FIRST_TOKEN_TTL_SECONDS),
+    );
+
+    return {
+      config: { ...config, jwtToken },
+      localFirstSecret: null,
+    };
+  }
+
+  return {
+    config: { ...config },
+    localFirstSecret: null,
+  };
+}
+
+export class LocalFirstAuthManager<RuntimeConfig extends DbConfig = DbConfig> {
+  private refreshTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly ttlSeconds: number;
+
+  constructor(private readonly options: LocalFirstAuthManagerOptions<RuntimeConfig>) {
+    this.ttlSeconds = options.ttlSeconds ?? LOCAL_FIRST_TOKEN_TTL_SECONDS;
+  }
+
+  start(): void {
+    this.scheduleRefresh();
+  }
+
+  stop(): void {
+    if (!this.refreshTimer) {
+      return;
+    }
+    clearTimeout(this.refreshTimer);
+    this.refreshTimer = null;
+  }
+
+  getIdentityProof(options?: LocalFirstIdentityProofOptions): string {
+    return this.mintToken(
+      options?.audience ?? this.options.appId,
+      options?.ttlSeconds ?? IDENTITY_PROOF_TTL_SECONDS,
+    );
+  }
+
+  private scheduleRefresh(): void {
+    this.stop();
+    const refreshMs = this.ttlSeconds * LOCAL_FIRST_REFRESH_RATIO * 1000;
+    this.refreshTimer = setTimeout(() => {
+      this.refresh();
+    }, refreshMs);
+  }
+
+  private refresh(): void {
+    if (this.options.isShuttingDown()) {
+      return;
+    }
+
+    try {
+      const newToken = this.mintToken(this.options.appId, this.ttlSeconds);
+      this.options.applyToken(newToken);
+      this.scheduleRefresh();
+    } catch (e) {
+      console.error("Failed to refresh local-first token:", e);
+    }
+  }
+
+  private mintToken(audience: string, ttlSeconds: number): string {
+    return this.options.runtimeModule.mintLocalFirstToken(
+      createRuntimeTokenOptions(this.options.secret, audience, ttlSeconds),
+    );
+  }
+}
+
+function createRuntimeTokenOptions(
+  secret: string,
+  audience: string,
+  ttlSeconds: number,
+): RuntimeTokenOptions {
+  return {
+    secret,
+    audience,
+    ttlSeconds,
+    nowSeconds: BigInt(Math.floor(Date.now() / 1000)),
+  };
+}
+
+function generateEphemeralSeedBase64Url(): string {
+  const bytes = new Uint8Array(32);
+  globalThis.crypto.getRandomValues(bytes);
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}

--- a/packages/jazz-tools/src/runtime/db-auth.ts
+++ b/packages/jazz-tools/src/runtime/db-auth.ts
@@ -77,6 +77,13 @@ export function resolveDbAuthConfig<RuntimeConfig extends DbConfig>(
   };
 }
 
+/**
+ * Manages the in-memory token lifecycle for a Db created with a local-first secret.
+ *
+ * The manager does not persist, load, or rotate the secret itself. It only keeps
+ * the resolved secret available for identity proofs and periodically mints a
+ * fresh app auth token before the current one expires.
+ */
 export class LocalFirstAuthManager<RuntimeConfig extends DbConfig = DbConfig> {
   private refreshTimer: ReturnType<typeof setTimeout> | null = null;
   private readonly ttlSeconds: number;

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -31,7 +31,7 @@ import {
   resolveEffectiveQueryExecutionOptions,
   runInBatch,
 } from "./client.js";
-import { type DbRuntimeModule, type RuntimeTokenOptions } from "./db-runtime-module.js";
+import { type DbRuntimeModule } from "./db-runtime-module.js";
 import { WasmRuntimeModule } from "./wasm-runtime-module.js";
 import { WorkerBridge, type PeerSyncBatch, type WorkerBridgeOptions } from "./worker-bridge.js";
 import type { AuthFailureReason } from "./sync-transport.js";
@@ -68,6 +68,7 @@ import {
   type TabSyncMessage,
 } from "./tab-sync-protocol.js";
 import { StorageResetCoordinator, type StorageResetHost } from "./storage-reset-coordinator.js";
+import { LocalFirstAuthManager, resolveDbAuthConfig, validateDbAuthConfig } from "./db-auth.js";
 
 type WasmLogLevel = "error" | "warn" | "info" | "debug" | "trace";
 type AnyDbRuntimeModule = DbRuntimeModule<any>;
@@ -800,8 +801,7 @@ export class Db {
   private activeRemoteLeaderTabId: string | null = null;
   private workerReconfigure: Promise<void> = Promise.resolve();
   private storageReset: StorageResetCoordinator | null = null;
-  private _localFirstSecret: string | null = null;
-  private localFirstRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+  private localFirstAuth: LocalFirstAuthManager | null = null;
   private isShuttingDown = false;
   private shutdownPromise: Promise<void> | null = null;
   private lifecycleHooksAttached = false;
@@ -854,51 +854,17 @@ export class Db {
     this.authStateStore = createAuthStateStore(config, authStateOptions);
   }
 
-  /** @internal Store the seed used for local-first auth and schedule token refresh. */
-  initLocalFirstAuth(seed: string, ttlSeconds: number): void {
-    this._localFirstSecret = seed;
-    this.scheduleLocalFirstRefresh(ttlSeconds);
-  }
-
-  private scheduleLocalFirstRefresh(ttlSeconds: number): void {
-    if (this.localFirstRefreshTimer) {
-      clearTimeout(this.localFirstRefreshTimer);
-    }
-    // Refresh at 80% of TTL
-    const refreshMs = ttlSeconds * 800; // 80% of TTL in ms
-    this.localFirstRefreshTimer = setTimeout(() => {
-      this.refreshLocalFirstToken();
-    }, refreshMs);
-  }
-
-  private refreshLocalFirstToken(): void {
-    if (!this._localFirstSecret || this.isShuttingDown) return;
-
-    try {
-      const ttlSeconds = 3600;
-      const newToken = this.mintLocalFirstToken(
-        this._localFirstSecret,
-        this.config.appId,
-        ttlSeconds,
-      );
-      this.updateAuthToken(newToken);
-      this.scheduleLocalFirstRefresh(ttlSeconds);
-    } catch (e) {
-      console.error("Failed to refresh local-first token:", e);
-    }
-  }
-
-  private mintLocalFirstToken(secret: string, audience: string, ttlSeconds: number): string {
-    if (!this.runtimeModule) {
-      throw new Error("Db runtime module is not initialized for this Db implementation");
-    }
-
-    return this.runtimeModule.mintLocalFirstToken({
+  /** @internal Attach local-first auth state and schedule token refresh. */
+  initLocalFirstAuth(secret: string, runtimeModule: AnyDbRuntimeModule): void {
+    this.localFirstAuth?.stop();
+    this.localFirstAuth = new LocalFirstAuthManager({
+      appId: this.config.appId,
       secret,
-      audience,
-      ttlSeconds,
-      nowSeconds: BigInt(Math.floor(Date.now() / 1000)),
+      runtimeModule,
+      applyToken: (jwtToken) => this.updateAuthToken(jwtToken),
+      isShuttingDown: () => this.isShuttingDown,
     });
+    this.localFirstAuth.start();
   }
 
   protected markUnauthenticated(reason: AuthFailureReason): void {
@@ -1659,13 +1625,7 @@ export class Db {
    * Returns `null` if the current session is not local-first.
    */
   getLocalFirstIdentityProof(options?: { ttlSeconds?: number; audience?: string }): string | null {
-    if (!this._localFirstSecret) {
-      return null;
-    }
-
-    const ttl = options?.ttlSeconds ?? 60;
-    const audience = options?.audience ?? this.config.appId;
-    return this.mintLocalFirstToken(this._localFirstSecret, audience, ttl);
+    return this.localFirstAuth?.getIdentityProof(options) ?? null;
   }
 
   onAuthChanged(listener: (state: AuthState) => void): () => void {
@@ -2126,10 +2086,8 @@ export class Db {
 
   private async runShutdown(): Promise<void> {
     this.isShuttingDown = true;
-    if (this.localFirstRefreshTimer) {
-      clearTimeout(this.localFirstRefreshTimer);
-      this.localFirstRefreshTimer = null;
-    }
+    this.localFirstAuth?.stop();
+    this.localFirstAuth = null;
     this.clearActiveQuerySubscriptionTraces();
     this.sendFollowerClose(this.activeRemoteLeaderTabId, this.currentLeaderTerm);
     this.activeRemoteLeaderTabId = null;
@@ -2505,20 +2463,6 @@ function isBrowser(): boolean {
 }
 
 /**
- * Generate a 32-byte ephemeral seed for anonymous auth.
- *
- * Uses `globalThis.crypto.getRandomValues`, which is available in all
- * supported environments (browser, Node ≥15, React Native, edge workers).
- */
-function generateEphemeralSeedBase64Url(): string {
-  const bytes = new Uint8Array(32);
-  globalThis.crypto.getRandomValues(bytes);
-  let binary = "";
-  for (const b of bytes) binary += String.fromCharCode(b);
-  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-}
-
-/**
  * Create a new Db instance with the given configuration.
  *
  * This is an **async** factory function that pre-loads the runtime module.
@@ -2539,53 +2483,13 @@ function generateEphemeralSeedBase64Url(): string {
  * });
  * ```
  */
-function createRuntimeTokenOptions(
-  secret: string,
-  audience: string,
-  ttlSeconds: number,
-): RuntimeTokenOptions {
-  return {
-    secret,
-    audience,
-    ttlSeconds,
-    nowSeconds: BigInt(Math.floor(Date.now() / 1000)),
-  };
-}
-
 export async function createDbWithRuntimeModule<RuntimeConfig extends DbConfig>(
   config: RuntimeConfig,
   runtimeModule: DbRuntimeModule<RuntimeConfig>,
 ): Promise<Db> {
-  if (config.secret && (config.jwtToken || config.cookieSession)) {
-    throw new Error("DbConfig error: secret, jwtToken, and cookieSession are mutually exclusive");
-  }
-  if (config.jwtToken && config.cookieSession) {
-    throw new Error("DbConfig error: jwtToken and cookieSession are mutually exclusive");
-  }
-
-  let resolvedConfig = { ...config };
+  validateDbAuthConfig(config);
   await runtimeModule.load(config);
-
-  // Local-first auth: resolve seed and mint a JWT
-  let localFirstSecret: string | null = null;
-  if (config.secret) {
-    const secret = config.secret;
-    localFirstSecret = secret;
-
-    const jwtToken = runtimeModule.mintLocalFirstToken(
-      createRuntimeTokenOptions(secret, config.appId, 3600),
-    );
-    resolvedConfig = { ...resolvedConfig, jwtToken };
-  } else if (!config.jwtToken && !config.cookieSession && !config.adminSecret) {
-    // Anonymous: mint an ephemeral keypair + anonymous JWT.
-    // Admin-secret clients intentionally stay sessionless so local policy
-    // evaluation does not preempt backend-authorized transport writes.
-    const ephemeralSeed = generateEphemeralSeedBase64Url();
-    const jwtToken = runtimeModule.mintAnonymousToken(
-      createRuntimeTokenOptions(ephemeralSeed, config.appId, 3600),
-    );
-    resolvedConfig = { ...resolvedConfig, jwtToken };
-  }
+  const { config: resolvedConfig, localFirstSecret } = resolveDbAuthConfig(config, runtimeModule);
 
   const driver = resolveStorageDriver(resolvedConfig.driver);
 
@@ -2605,7 +2509,7 @@ export async function createDbWithRuntimeModule<RuntimeConfig extends DbConfig>(
   }
 
   if (localFirstSecret) {
-    db.initLocalFirstAuth(localFirstSecret, 3600);
+    db.initLocalFirstAuth(localFirstSecret, runtimeModule as AnyDbRuntimeModule);
   }
 
   return db;

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -855,12 +855,16 @@ export class Db {
   }
 
   /** @internal Attach local-first auth state and schedule token refresh. */
-  initLocalFirstAuth(secret: string, runtimeModule: AnyDbRuntimeModule): void {
+  initLocalFirstAuth(secret: string): void {
+    if (!this.runtimeModule) {
+      throw new Error("Db runtime module is not initialized for this Db implementation");
+    }
+
     this.localFirstAuth?.stop();
     this.localFirstAuth = new LocalFirstAuthManager({
       appId: this.config.appId,
       secret,
-      runtimeModule,
+      runtimeModule: this.runtimeModule,
       applyToken: (jwtToken) => this.updateAuthToken(jwtToken),
       isShuttingDown: () => this.isShuttingDown,
     });
@@ -2509,7 +2513,7 @@ export async function createDbWithRuntimeModule<RuntimeConfig extends DbConfig>(
   }
 
   if (localFirstSecret) {
-    db.initLocalFirstAuth(localFirstSecret, runtimeModule as AnyDbRuntimeModule);
+    db.initLocalFirstAuth(localFirstSecret);
   }
 
   return db;


### PR DESCRIPTION
## Summary
- Move local-first auth config resolution, anonymous token minting, refresh scheduling, and identity proof minting into `db-auth.ts`.
- Keep `Db` responsible for coordinating auth state updates while removing token/timer details from `db.ts`.
- Add focused coverage for the extracted auth helper and refresh behavior.

## Test Plan
- `pnpm --dir packages/jazz-tools exec vitest run --config vitest.config.ts src/runtime/db-auth.test.ts src/runtime/db.local-first-auth.test.ts src/runtime/db.anonymous.test.ts src/runtime/db.transport.test.ts src/react-native/db.test.ts`
- `pnpm --dir packages/jazz-tools build`

## Notes
- This is stacked on `refactor/db-cleanup-and-extract-cross-tab`.