### PR TITLE
feat: make `expectAllowed` & `expectDenied` side-effect free

### DIFF
--- a/.changeset/sixty-pugs-punch.md
+++ b/.changeset/sixty-pugs-punch.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Modify the permission tests API to make `expectAllowed`/`expectDenied` side-effect free.

--- a/docs/content/docs/auth/permissions.mdx
+++ b/docs/content/docs/auth/permissions.mdx
@@ -247,14 +247,14 @@ describe("todo permissions", () => {
       authMode: "local-first",
     });
 
-    testApp.expectAllowed(() =>
-      alice.update(app.todos, todo.id, {
+    alice.expectAllowed((db) =>
+      db.update(app.todos, todo.id, {
         title: "Buy oat milk",
       }),
     );
 
-    testApp.expectDenied(() =>
-      bob.update(app.todos, todo.id, {
+    bob.expectDenied((db) =>
+      db.update(app.todos, todo.id, {
         title: "Buy orange juice",
       }),
     );
@@ -267,11 +267,11 @@ permissions object created with `definePermissions(...)`, and your test runner's
 
 The returned `PolicyTestApp` provides:
 
-- `seed(fn)` — run setup writes as an admin, bypassing policy checks
-- `as(session)` — create a `Db` client scoped to a specific session
-- `expectAllowed(fn)` — assert that a write does not throw a policy error
-- `expectDenied(fn)` — assert that a write is rejected by a policy
-- `shutdown()` — stop the local client and server
+- `testApp.seed(fn)` — run setup writes as an admin, bypassing policy checks
+- `testApp.as(session)` — create a `TestDb` client scoped to a specific session
+- `testDb.expectAllowed(fn)` — assert that a write does not throw a policy error
+- `testDb.expectDenied(fn)` — assert that a write is rejected by a policy
+- `testApp.shutdown()` — stop the local client and server
 
 For read policies, assert on returned rows directly. Denied reads are filtered out rather than
 throwing.

--- a/docs/content/docs/writing/writing-data.mdx
+++ b/docs/content/docs/writing/writing-data.mdx
@@ -165,7 +165,7 @@ db.onMutationError((error) => {
 
 ## Transactions and batches
 
-Use an explicit transaction when several writes should settle together after an authority validates the sealed batch:
+Use a transaction when several writes should settle together after an authority validates the sealed batch:
 
 ```ts
 const result = await db.transaction(async (tx) => {
@@ -180,28 +180,41 @@ console.log(result.batchId);
 The changes made as part of the transaction are scoped to it, and will only be
 globally visible once it's committed and accepted by the authority.
 
-`DbTransaction` can also read its own staged state through `all(...)` and `one(...)` before commit.
-Call `tx.rollback()` to explicitly abandon an open transaction handle without committing it:
+`DbTransaction` can read its own staged state through `all(...)` and `one(...)` before commit.
 
-```ts
-const tx = db.beginTransaction();
-
-tx.insert(app.todos, { title: "Maybe later", done: false });
-tx.rollback();
-
-// Any later write, read, commit, or rollback call on this transaction throws.
-```
-
-Rollback prevents the same transaction handle from being committed or used again.
-
-You can also use a batch when you want to group several ordinary writes under one batch id, but still want them
+You can also use batches when you want to group several ordinary writes under one batch id, but still want them
 to be locally visible immediately:
 
 ```ts
 const result = db.batch((batch) => {
-  batch.insert(app.todos, { title: "Grouped direct write", done: false });
+  batch.insert(app.todos, { title: "Grouped write", done: false });
   batch.update(app.todos, todoId, { done: true });
 });
 await result.wait({ tier: "edge" });
 console.log(result.batchId);
+```
+
+When using `transaction` and `batch`, changes are automatically committed once the callback finishes running and,
+in the case of transactions, if an error is thrown inside the callback, the whole transaction will be rolled back.
+
+Alternatively, you can use `beginTransaction` and `beginBatch` to get a transaction or batch object, respectively.
+This can be useful when making writes across multiple contexts. In this case however, you need to commit or rollback
+the transaction/batch explicitly.
+
+```ts
+let transaction: DbTransaction;
+beforeEach(() => {
+  transaction = db.beginTransaction();
+});
+
+afterEach(() => {
+  // Writes performed in tests will be rolled back at the end,
+  // preventing tests from interfering with each other
+  transaction.rollback();
+});
+
+it("tasks have a title", () => {
+  const task = transaction.insert(todos, { title: "Test task", done: false });
+  expect(task.title).toEqual("Test task");
+});
 ```

--- a/examples/chat-react/tests/permissions/permissions.test.ts
+++ b/examples/chat-react/tests/permissions/permissions.test.ts
@@ -70,8 +70,8 @@ describe("chat permissions", () => {
     const aliceDb = testApp.as({ user_id: "alice", claims: {}, authMode: "local-first" });
     const bobDb = testApp.as({ user_id: "bob", claims: {}, authMode: "local-first" });
 
-    testApp.expectAllowed(() =>
-      aliceDb.insert(app.messages, {
+    aliceDb.expectAllowed((db) =>
+      db.insert(app.messages, {
         chatId: privateChat.id,
         text: "hello from alice",
         senderId: aliceProfile.id,
@@ -79,8 +79,8 @@ describe("chat permissions", () => {
       }),
     );
 
-    testApp.expectDenied(() =>
-      bobDb.insert(app.messages, {
+    bobDb.expectDenied((db) =>
+      db.insert(app.messages, {
         chatId: privateChat.id,
         text: "hello from bob",
         senderId: bobProfile.id,
@@ -96,8 +96,8 @@ describe("chat permissions", () => {
       });
     });
 
-    testApp.expectAllowed(() =>
-      bobDb.insert(app.messages, {
+    bobDb.expectAllowed((db) =>
+      db.insert(app.messages, {
         chatId: privateChat.id,
         text: "hello from bob after joining",
         senderId: bobProfile.id,

--- a/packages/jazz-tools/bin/docs-index.txt
+++ b/packages/jazz-tools/bin/docs-index.txt
@@ -5918,7 +5918,7 @@ db.onMutationError((error) => {
 
 ## Transactions and batches
 
-Use an explicit transaction when several writes should settle together after an authority validates the sealed batch:
+Use a transaction when several writes should settle together after an authority validates the sealed batch:
 
 ```ts
 const result = await db.transaction(async (tx) => {
@@ -5935,14 +5935,39 @@ globally visible once it's committed and accepted by the authority.
 
 `DbTransaction` can read its own staged state through `all(...)` and `one(...)` before commit.
 
-You can also use a batch when you want to group several ordinary writes under one batch id, but still want them
+You can also use batches when you want to group several ordinary writes under one batch id, but still want them
 to be locally visible immediately:
 
 ```ts
 const result = db.batch((batch) => {
-  batch.insert(app.todos, { title: "Grouped direct write", done: false });
+  batch.insert(app.todos, { title: "Grouped write", done: false });
   batch.update(app.todos, todoId, { done: true });
 });
 await result.wait({ tier: "edge" });
 console.log(result.batchId);
+```
+
+When using `transaction` and `batch`, changes are automatically committed once the callback finishes running and,
+in the case of transactions, if an error is thrown inside the callback, the whole transaction will be rolled back.
+
+Alternatively, you can use `beginTransaction` and `beginBatch` to get a transaction or batch object, respectively.
+This can be useful when making writes across multiple contexts. In this case however, you need to commit or rollback
+the transaction/batch explicitly.
+
+```ts
+let transaction: DbTransaction;
+beforeEach(() => {
+  transaction = db.beginTransaction();
+});
+
+afterEach(() => {
+  // Writes performed in tests will be rolled back at the end,
+  // preventing tests from interfering with each other
+  transaction.rollback();
+});
+
+it("tasks have a title", () => {
+  const task = transaction.insert(todos, { title: "Test task", done: false });
+  expect(task.title).toEqual("Test task");
+});
 ```

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -784,9 +784,9 @@ export type DbBatchScope = Omit<DbDirectBatch, "commit">;
  */
 export class Db {
   private clients = new Map<string, JazzClient>();
-  private config: DbConfig;
-  private wasmModule: WasmModule | null;
-  private readonly authStateStore;
+  protected config: DbConfig;
+  protected wasmModule: WasmModule | null;
+  protected readonly authStateStore;
   private workerBridge: WorkerBridge | null = null;
   private worker: Worker | null = null;
   private disposeWasmTelemetry: (() => void) | null = null;
@@ -846,7 +846,7 @@ export class Db {
   };
 
   /**
-   * Protected constructor - use createDb() in regular app code.
+   * Protected constructor - use {@link createDb} in regular app code.
    */
   protected constructor(
     config: DbConfig,
@@ -966,7 +966,7 @@ export class Db {
    * The worker runs a persistent WASM runtime (OPFS).
    * WorkerBridge wires them together via postMessage.
    *
-   * @internal Use createDb() instead — it auto-detects browser.
+   * @internal Use {@link createDb} instead — it auto-detects browser.
    */
   static async createWithWorker(config: DbConfig): Promise<Db> {
     const wasmModule = await loadWasmModule(config.runtimeSources);

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -784,9 +784,9 @@ export type DbBatchScope = Omit<DbDirectBatch, "commit">;
  */
 export class Db {
   private clients = new Map<string, JazzClient>();
-  protected config: DbConfig;
-  protected wasmModule: WasmModule | null;
-  protected readonly authStateStore;
+  private config: DbConfig;
+  private wasmModule: WasmModule | null;
+  private readonly authStateStore;
   private workerBridge: WorkerBridge | null = null;
   private worker: Worker | null = null;
   private disposeWasmTelemetry: (() => void) | null = null;

--- a/packages/jazz-tools/src/testing/index.test.ts
+++ b/packages/jazz-tools/src/testing/index.test.ts
@@ -366,5 +366,35 @@ describe("createPolicyTestApp", () => {
     } finally {
       await policyTestApp.shutdown();
     }
-  }, 30_000);
+  }, 10_000);
+
+  it("exposes expectAllowed and expectDenied on session-scoped test dbs", async () => {
+    const policyTestApp = await createPolicyTestApp(testApp, testPermissions, expect);
+
+    try {
+      const alice = policyTestApp.as({ user_id: "alice", claims: {}, authMode: "local-first" });
+      const bob = policyTestApp.as({ user_id: "bob", claims: {}, authMode: "local-first" });
+
+      alice.expectAllowed((db) => {
+        db.insert(testApp.todos, {
+          title: "Alice can insert her own todo",
+          done: false,
+          ownerId: "alice",
+        });
+      });
+
+      bob.expectDenied((db) => {
+        db.insert(testApp.todos, {
+          title: "Bob cannot insert Alice's todo",
+          done: false,
+          ownerId: "alice",
+        });
+      });
+
+      await expect(alice.all(testApp.todos)).resolves.toEqual([]);
+      await expect(bob.all(testApp.todos)).resolves.toEqual([]);
+    } finally {
+      await policyTestApp.shutdown();
+    }
+  }, 10_000);
 });

--- a/packages/jazz-tools/src/testing/index.ts
+++ b/packages/jazz-tools/src/testing/index.ts
@@ -7,3 +7,4 @@ export {
   type StartLocalJazzServerOptions,
 } from "./local-jazz-server.js";
 export { createPolicyTestApp, PolicyTestApp } from "./policy-test-app.js";
+export type { TestDb } from "./policy-test-app.js";

--- a/packages/jazz-tools/src/testing/policy-test-app.ts
+++ b/packages/jazz-tools/src/testing/policy-test-app.ts
@@ -24,7 +24,16 @@ type TestDbMethodCallback = (db: DbTransactionScope) => unknown;
  * helpers to test write operations without producing side effects on the test database.
  */
 export type TestDb = Db & {
+  /**
+   * Assert that the callback does not throw a policy error.
+   * Write operations performed inside the callback are not persisted.
+   */
   expectAllowed(callback: TestDbMethodCallback): void;
+
+  /**
+   * Assert that the callback throws a policy error.
+   * Write operations performed inside the callback are not persisted.
+   */
   expectDenied(callback: TestDbMethodCallback): void;
 };
 

--- a/packages/jazz-tools/src/testing/policy-test-app.ts
+++ b/packages/jazz-tools/src/testing/policy-test-app.ts
@@ -1,5 +1,6 @@
 import { createJazzContext, Db, Session, type JazzContext } from "../backend/index.js";
 import type { WasmSchema } from "../drivers/types.js";
+import { DbTransactionScope } from "../index.js";
 import type { CompiledPermissions } from "../permissions/index.js";
 import {
   fetchPermissionsHead,
@@ -9,6 +10,46 @@ import {
 import { startLocalJazzServer, type LocalJazzServerHandle } from "./local-jazz-server.js";
 
 type PolicyTestAppSchema = { wasmSchema: WasmSchema };
+type ExpectLike = (value: unknown) => {
+  not: {
+    toThrow(expected?: unknown): void;
+  };
+  toThrow(expected?: unknown): void;
+};
+type TestDbMethodCallback = (db: DbTransactionScope) => unknown;
+
+/**
+ * Db used for testing permissions.
+ * Supports all {@link Db} operations plus the {@link TestDb.expectAllowed} and {@link TestDb.expectDenied}
+ * helpers to test write operations without producing side effects on the test database.
+ */
+export type TestDb = Db & {
+  expectAllowed(callback: TestDbMethodCallback): void;
+  expectDenied(callback: TestDbMethodCallback): void;
+};
+
+function asTestDb(db: Db, expect: ExpectLike): TestDb {
+  const testDb = db as TestDb;
+
+  Object.defineProperties(testDb, {
+    expectAllowed: {
+      value: (callback: TestDbMethodCallback) => {
+        const tx = db.beginTransaction();
+        expect(() => callback(tx)).not.toThrow();
+        tx.rollback();
+      },
+    },
+    expectDenied: {
+      value: (callback: TestDbMethodCallback) => {
+        const tx = db.beginTransaction();
+        expect(() => callback(tx)).toThrow('WriteError("policy denied');
+        tx.rollback();
+      },
+    },
+  });
+
+  return testDb;
+}
 
 /**
  * A test app for permissions tests. Simplifies setting up a test app and provides methods
@@ -16,7 +57,7 @@ type PolicyTestAppSchema = { wasmSchema: WasmSchema };
  */
 export class PolicyTestApp {
   constructor(
-    private readonly expect: Function,
+    private readonly expect: ExpectLike,
     private readonly app: any,
     private readonly jazzContext: JazzContext,
     private readonly server: LocalJazzServerHandle,
@@ -34,24 +75,9 @@ export class PolicyTestApp {
   /**
    * Get a database client for the given session.
    */
-  as(session: Session): Db {
-    return this.jazzContext.forSession(session, this.app);
-  }
-
-  /**
-   * Assert that the callback does not throw a policy error.
-   * TODO: rollback mutations performed as part of the callback (once we support transactions).
-   */
-  expectAllowed(callback: () => unknown): void {
-    this.expect(callback).not.toThrow();
-  }
-
-  /**
-   * Assert that the callback throws a policy error.
-   * TODO: rollback mutations performed as part of the callback (once we support transactions).
-   */
-  expectDenied(callback: () => unknown): void {
-    this.expect(callback).toThrow('WriteError("policy denied');
+  as(session: Session): TestDb {
+    const db = this.jazzContext.forSession(session, this.app);
+    return asTestDb(db, this.expect);
   }
 
   /**
@@ -74,7 +100,7 @@ export class PolicyTestApp {
 export async function createPolicyTestApp(
   app: PolicyTestAppSchema,
   permissions: CompiledPermissions,
-  expectFn: Function,
+  expectFn: ExpectLike,
 ): Promise<PolicyTestApp> {
   const backendSecret = `backend-secret`;
   const adminSecret = `admin-secret`;


### PR DESCRIPTION
## Description

Adjusts the permission tests API to make `expectAllowed`/`expectDenied` side-effect free.

Also adds `beginTransaction` and `beginBatch` to the docs.