### PR TITLE
Add batch sync timing instrumentation

### DIFF
--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::time::Instant;
 
 use serde::Serialize;
 use sha2::{Digest, Sha256};
@@ -30,6 +31,22 @@ use super::types::{
     Schema, SchemaHash, TableName, TablePolicies, TableSchema, Tuple, Value,
     build_ordered_delta_with_post_ids,
 };
+
+#[cfg(not(target_arch = "wasm32"))]
+fn timing_now() -> Option<Instant> {
+    Some(Instant::now())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn timing_now() -> Option<Instant> {
+    None
+}
+
+fn timing_elapsed_ms(started: Option<Instant>) -> u64 {
+    started
+        .map(|started| started.elapsed().as_millis() as u64)
+        .unwrap_or(0)
+}
 
 /// Error types for QueryManager operations.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1222,11 +1239,30 @@ impl QueryManager {
         // RuntimeCore, which tracks per-server stream progress.
         let pending_query_settled = self.sync_manager.take_pending_query_settled();
         if !pending_query_settled.is_empty() {
+            tracing::debug!(
+                target: "jazz_timing",
+                count = pending_query_settled.len(),
+                "[jazz timing] client/runtime pending QuerySettled messages"
+            );
             let mut blocked = Vec::new();
             for pending_settled in pending_query_settled {
                 if pending_settled.through_seq == 0 {
+                    tracing::debug!(
+                        target: "jazz_timing",
+                        query_id = pending_settled.query_id.0,
+                        ?pending_settled.tier,
+                        through_seq = pending_settled.through_seq,
+                        "[jazz timing] client/runtime applying QuerySettled immediately"
+                    );
                     self.apply_query_settled(pending_settled.query_id, pending_settled.tier);
                 } else {
+                    tracing::debug!(
+                        target: "jazz_timing",
+                        query_id = pending_settled.query_id.0,
+                        ?pending_settled.tier,
+                        through_seq = pending_settled.through_seq,
+                        "[jazz timing] client/runtime QuerySettled blocked on stream watermark"
+                    );
                     blocked.push(pending_settled);
                 }
             }
@@ -1261,6 +1297,7 @@ impl QueryManager {
         let subscription_ids: Vec<_> = self.subscriptions.keys().copied().collect();
 
         for sub_id in subscription_ids {
+            let subscription_started = timing_now();
             let should_process_subscription =
                 self.subscriptions.get(&sub_id).is_some_and(|subscription| {
                     subscription.needs_recompile
@@ -1284,6 +1321,7 @@ impl QueryManager {
             let include_deleted = subscription.query.include_deleted;
 
             let delta = {
+                let settle_started = timing_now();
                 let schema_context = &self.schema_context;
                 let branch_schema_map = &self.branch_schema_map;
                 let row_loader =
@@ -1329,7 +1367,18 @@ impl QueryManager {
                         )
                     };
 
-                subscription.graph.settle(storage_ref, row_loader)
+                let delta = subscription.graph.settle(storage_ref, row_loader);
+                tracing::debug!(
+                    target: "jazz_timing",
+                    sub_id = sub_id.0,
+                    table = %table,
+                    elapsed_ms = timing_elapsed_ms(settle_started),
+                    added = delta.added.len(),
+                    removed = delta.removed.len(),
+                    settled_once = subscription.settled_once,
+                    "[jazz timing] client/runtime subscription graph settled"
+                );
+                delta
             };
             subscription.needs_visibility_recompute = false;
             let new_schema_warnings = Self::finalize_schema_warnings(
@@ -1356,6 +1405,14 @@ impl QueryManager {
                 // initial upstream frontier has been replayed — or until every
                 // still-pending server has exceeded PENDING_SERVER_TIMEOUT,
                 // which means nothing upstream is going to replay.
+                tracing::debug!(
+                    target: "jazz_timing",
+                    sub_id = sub_id.0,
+                    table = %table,
+                    elapsed_ms = timing_elapsed_ms(subscription_started),
+                    has_servers_or_pending = self.sync_manager.has_servers_or_pending_servers(),
+                    "[jazz timing] client/runtime query frontier incomplete; holding first delivery"
+                );
                 self.subscriptions.insert(sub_id, subscription);
                 continue;
             }
@@ -1418,6 +1475,14 @@ impl QueryManager {
                 );
                 subscription.current_ordered_ids = ordered.ordered_ids_after;
                 subscription.current_visible_rows = visible_rows_by_id;
+                tracing::warn!(
+                    target: "jazz_timing",
+                    sub_id = sub_id.0,
+                    table = %table,
+                    added = visible_delta.added.len(),
+                    elapsed_ms = timing_elapsed_ms(subscription_started),
+                    "[jazz timing] client/runtime first delivery queued"
+                );
                 self.update_outbox.push(QueryUpdate {
                     subscription_id: sub_id,
                     delta: visible_delta,

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -40,6 +40,22 @@ pub(super) struct ResolvedSchemaRow {
 
 const SCHEMA_RESOLUTION_TIMEOUT: Duration = Duration::from_secs(10);
 
+#[cfg(not(target_arch = "wasm32"))]
+fn timing_now() -> Option<Instant> {
+    Some(Instant::now())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn timing_now() -> Option<Instant> {
+    None
+}
+
+fn timing_elapsed_ms(started: Option<Instant>) -> u64 {
+    started
+        .map(|started| started.elapsed().as_millis() as u64)
+        .unwrap_or(0)
+}
+
 pub(super) struct RowTransformContext<'a> {
     pub(super) table: &'a str,
     pub(super) branch_schema_map:
@@ -759,14 +775,33 @@ impl QueryManager {
     /// 3. Set the scope in SyncManager (which triggers initial sync)
     pub(super) fn process_pending_query_subscriptions<H: Storage>(&mut self, storage: &mut H) {
         let pending = self.sync_manager.take_pending_query_subscriptions();
+        if !pending.is_empty() {
+            tracing::warn!(
+                target: "jazz_timing",
+                count = pending.len(),
+                "[jazz timing] server pending query subscriptions"
+            );
+        }
         let mut deferred = Vec::new();
         let mut schema_warning_notifications = Vec::new();
         let mut settled_notifications = Vec::new();
 
         for sub in pending {
+            let timing_started = timing_now();
+            let query_id_for_timing = sub.query_id;
+            let client_id_for_timing = sub.client_id;
+            let table_for_timing = sub.query.table.as_str().to_string();
             let Some((schema_for_compile, subscription_context)) =
                 self.build_server_subscription_context(&sub.query)
             else {
+                tracing::warn!(
+                    target: "jazz_timing",
+                    %client_id_for_timing,
+                    query_id = query_id_for_timing.0,
+                    table = %table_for_timing,
+                    elapsed_ms = timing_elapsed_ms(timing_started),
+                    "[jazz timing] server subscription deferred: missing schema context"
+                );
                 deferred.push(sub);
                 continue;
             };
@@ -822,6 +857,14 @@ impl QueryManager {
                     "query_compilation_failed",
                     reason,
                 );
+                tracing::warn!(
+                    target: "jazz_timing",
+                    %client_id_for_timing,
+                    query_id = query_id_for_timing.0,
+                    table = %table_for_timing,
+                    elapsed_ms = timing_elapsed_ms(timing_started),
+                    "[jazz timing] server subscription rejected: compile failed"
+                );
                 continue;
             };
 
@@ -838,6 +881,7 @@ impl QueryManager {
             let mut schema_warnings = SchemaWarningAccumulator::default();
             let include_deleted = sub.query.include_deleted;
             {
+                let settle_started = timing_now();
                 let row_loader =
                     |id: ObjectId, table_hint: Option<TableName>| -> Option<LoadedRow> {
                         Self::load_visible_row_for_query(
@@ -859,6 +903,14 @@ impl QueryManager {
                     };
 
                 let _delta = graph.settle(storage_ref, row_loader);
+                tracing::warn!(
+                    target: "jazz_timing",
+                    %client_id_for_timing,
+                    query_id = query_id_for_timing.0,
+                    table = %table_for_timing,
+                    elapsed_ms = timing_elapsed_ms(settle_started),
+                    "[jazz timing] server subscription initial graph settled"
+                );
             }
             let mut reported_schema_warnings = HashSet::new();
             let new_schema_warnings = Self::finalize_schema_warnings(
@@ -878,8 +930,9 @@ impl QueryManager {
             let scope = if self
                 .client_bypasses_authorization_filtering(sub.client_id, session_for_policy.as_ref())
             {
+                let scope_started = timing_now();
                 let result_scope = graph.sync_scope_object_ids();
-                Some(
+                let scope = Some(
                     if sync_policy_context_rows || !policy_context_tables.is_empty() {
                         Self::scope_with_policy_context_rows_for_tables(
                             &result_scope,
@@ -890,15 +943,37 @@ impl QueryManager {
                     } else {
                         result_scope
                     },
-                )
+                );
+                tracing::warn!(
+                    target: "jazz_timing",
+                    %client_id_for_timing,
+                    query_id = query_id_for_timing.0,
+                    table = %table_for_timing,
+                    elapsed_ms = timing_elapsed_ms(scope_started),
+                    scope_size = scope.as_ref().map(|scope| scope.len()).unwrap_or(0),
+                    "[jazz timing] server subscription scope computed: bypass auth"
+                );
+                scope
             } else {
-                self.authorized_scope_from_graph_if_available(
+                let scope_started = timing_now();
+                let scope = self.authorized_scope_from_graph_if_available(
                     storage_ref,
                     &graph,
                     &subscription_context,
                     &branch_schema_map,
                     session_for_policy.as_ref(),
-                )
+                );
+                tracing::warn!(
+                    target: "jazz_timing",
+                    %client_id_for_timing,
+                    query_id = query_id_for_timing.0,
+                    table = %table_for_timing,
+                    elapsed_ms = timing_elapsed_ms(scope_started),
+                    scope_ready = scope.is_some(),
+                    scope_size = scope.as_ref().map(|scope| scope.len()).unwrap_or(0),
+                    "[jazz timing] server subscription authorized scope computed"
+                );
+                scope
             };
             if let Some(scope) = scope.as_ref() {
                 // Set scope in SyncManager (triggers initial sync)
@@ -917,6 +992,16 @@ impl QueryManager {
                     .sync_manager
                     .max_local_durability_tier()
                     .unwrap_or(DurabilityTier::Local);
+                tracing::warn!(
+                    target: "jazz_timing",
+                    %client_id_for_timing,
+                    query_id = query_id_for_timing.0,
+                    table = %table_for_timing,
+                    ?settled_tier,
+                    scope_size = scope.len(),
+                    elapsed_ms = timing_elapsed_ms(timing_started),
+                    "[jazz timing] server subscription initial QuerySettled queued"
+                );
                 settled_notifications.push((
                     sub.client_id,
                     sub.query_id,
@@ -954,6 +1039,16 @@ impl QueryManager {
                     reported_schema_warnings,
                 },
             );
+
+            tracing::warn!(
+                target: "jazz_timing",
+                %client_id_for_timing,
+                query_id = query_id_for_timing.0,
+                table = %table_for_timing,
+                settled_once,
+                elapsed_ms = timing_elapsed_ms(timing_started),
+                "[jazz timing] server subscription processed"
+            );
         }
 
         for (client_id, warning) in schema_warning_notifications {
@@ -961,6 +1056,14 @@ impl QueryManager {
         }
 
         for (client_id, query_id, tier, scope) in settled_notifications {
+            tracing::warn!(
+                target: "jazz_timing",
+                %client_id,
+                query_id = query_id.0,
+                ?tier,
+                scope_size = scope.len(),
+                "[jazz timing] server emitting QuerySettled"
+            );
             self.sync_manager
                 .emit_query_settled(client_id, query_id, tier, &scope);
         }
@@ -1018,8 +1121,16 @@ impl QueryManager {
             Vec::new();
 
         let subscription_keys: Vec<_> = self.server_subscriptions.keys().copied().collect();
+        if !subscription_keys.is_empty() {
+            tracing::debug!(
+                target: "jazz_timing",
+                count = subscription_keys.len(),
+                "[jazz timing] server settling active subscriptions"
+            );
+        }
 
         for (client_id, query_id) in subscription_keys {
+            let timing_started = timing_now();
             let Some(mut sub) = self.server_subscriptions.remove(&(client_id, query_id)) else {
                 continue;
             };
@@ -1033,6 +1144,7 @@ impl QueryManager {
             // Row loader for this subscription
             let new_scope = {
                 {
+                    let settle_started = timing_now();
                     let row_loader =
                         |id: ObjectId, table_hint: Option<TableName>| -> Option<LoadedRow> {
                             Self::load_visible_row_for_query(
@@ -1054,6 +1166,14 @@ impl QueryManager {
                         };
 
                     let _delta = sub.graph.settle(storage, row_loader);
+                    tracing::debug!(
+                        target: "jazz_timing",
+                        %client_id,
+                        query_id = query_id.0,
+                        table = %table,
+                        elapsed_ms = timing_elapsed_ms(settle_started),
+                        "[jazz timing] server active subscription graph settled"
+                    );
                 }
                 let new_schema_warnings = Self::finalize_schema_warnings(
                     &mut sub.reported_schema_warnings,
@@ -1069,8 +1189,9 @@ impl QueryManager {
                 let policy_context_tables =
                     Self::merged_policy_context_tables(&sub.graph, &sub.policy_context_tables);
                 if self.client_bypasses_authorization_filtering(client_id, sub.session.as_ref()) {
+                    let scope_started = timing_now();
                     let result_scope = sub.graph.sync_scope_object_ids();
-                    Some(
+                    let scope = Some(
                         if self.should_sync_policy_context_rows(client_id, sub.session.as_ref())
                             || !policy_context_tables.is_empty()
                         {
@@ -1083,17 +1204,40 @@ impl QueryManager {
                         } else {
                             result_scope
                         },
-                    )
+                    );
+                    tracing::debug!(
+                        target: "jazz_timing",
+                        %client_id,
+                        query_id = query_id.0,
+                        table = %table,
+                        elapsed_ms = timing_elapsed_ms(scope_started),
+                        scope_size = scope.as_ref().map(|scope| scope.len()).unwrap_or(0),
+                        "[jazz timing] server active subscription scope computed: bypass auth"
+                    );
+                    scope
                 } else {
-                    self.authorized_scope_from_graph_if_available(
+                    let scope_started = timing_now();
+                    let scope = self.authorized_scope_from_graph_if_available(
                         storage,
                         &sub.graph,
                         &sub.schema_context,
                         &branch_schema_map,
                         sub.session.as_ref(),
-                    )
+                    );
+                    tracing::debug!(
+                        target: "jazz_timing",
+                        %client_id,
+                        query_id = query_id.0,
+                        table = %table,
+                        elapsed_ms = timing_elapsed_ms(scope_started),
+                        scope_ready = scope.is_some(),
+                        scope_size = scope.as_ref().map(|scope| scope.len()).unwrap_or(0),
+                        "[jazz timing] server active subscription authorized scope computed"
+                    );
+                    scope
                 }
             };
+            let scope_unavailable = new_scope.is_none();
             if let Some(new_scope) = new_scope {
                 let scope_changed = new_scope != sub.last_scope;
                 if scope_changed {
@@ -1116,6 +1260,16 @@ impl QueryManager {
                         .sync_manager
                         .max_local_durability_tier()
                         .unwrap_or(DurabilityTier::Local);
+                    tracing::warn!(
+                        target: "jazz_timing",
+                        %client_id,
+                        query_id = query_id.0,
+                        table = %table,
+                        ?settled_tier,
+                        elapsed_ms = timing_elapsed_ms(timing_started),
+                        scope_size = new_scope.len(),
+                        "[jazz timing] server active subscription first QuerySettled queued"
+                    );
                     settled_notifications.push((client_id, query_id, settled_tier, new_scope));
                 } else if scope_changed || had_dirty_graph {
                     let settled_tier = self
@@ -1129,6 +1283,17 @@ impl QueryManager {
                         sub.last_scope.clone(),
                     ));
                 }
+            }
+
+            if scope_unavailable {
+                tracing::debug!(
+                    target: "jazz_timing",
+                    ?query_id,
+                    %client_id,
+                    table = %table,
+                    elapsed_ms = timing_elapsed_ms(timing_started),
+                    "[jazz timing] server subscription scope unavailable; holding QuerySettled"
+                );
             }
 
             self.server_subscriptions.insert((client_id, query_id), sub);
@@ -1147,6 +1312,14 @@ impl QueryManager {
 
         // Emit QuerySettled notifications
         for (client_id, query_id, tier, scope) in settled_notifications {
+            tracing::warn!(
+                target: "jazz_timing",
+                %client_id,
+                query_id = query_id.0,
+                ?tier,
+                scope_size = scope.len(),
+                "[jazz timing] server emitting active QuerySettled"
+            );
             self.sync_manager
                 .emit_query_settled(client_id, query_id, tier, &scope);
         }

--- a/crates/jazz-tools/src/runtime_core/mod.rs
+++ b/crates/jazz-tools/src/runtime_core/mod.rs
@@ -35,6 +35,7 @@ use std::task::{Context, Poll};
 
 use futures::channel::oneshot;
 use tracing::{debug, debug_span, info, trace, trace_span};
+use web_time::Instant;
 
 use crate::object::{BranchName, ObjectId};
 use crate::query_manager::QuerySubscriptionId;
@@ -273,6 +274,76 @@ struct PendingOneShotQuery {
     sender: Option<QuerySender>,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct SyncReceiveStats {
+    started_at: Instant,
+    highest_received_seq: u64,
+    highest_applied_seq: u64,
+    received_total: u64,
+    applied_total: u64,
+    received_by_type: BTreeMap<&'static str, u64>,
+    applied_by_type: BTreeMap<&'static str, u64>,
+    received_settlement_batches: HashMap<BatchId, u64>,
+    applied_settlement_batches: HashMap<BatchId, u64>,
+    next_log_at: u64,
+}
+
+impl SyncReceiveStats {
+    fn new() -> Self {
+        Self {
+            started_at: Instant::now(),
+            highest_received_seq: 0,
+            highest_applied_seq: 0,
+            received_total: 0,
+            applied_total: 0,
+            received_by_type: BTreeMap::new(),
+            applied_by_type: BTreeMap::new(),
+            received_settlement_batches: HashMap::new(),
+            applied_settlement_batches: HashMap::new(),
+            next_log_at: 500,
+        }
+    }
+
+    fn elapsed_ms(&self) -> u128 {
+        self.started_at.elapsed().as_millis()
+    }
+
+    fn received_settlement_duplicates(&self) -> u64 {
+        self.received_settlement_batches
+            .values()
+            .map(|count| count.saturating_sub(1))
+            .sum()
+    }
+
+    fn applied_settlement_duplicates(&self) -> u64 {
+        self.applied_settlement_batches
+            .values()
+            .map(|count| count.saturating_sub(1))
+            .sum()
+    }
+
+    fn top_received_settlement_duplicates(&self) -> Vec<(BatchId, u64)> {
+        top_settlement_duplicates(&self.received_settlement_batches)
+    }
+
+    fn top_applied_settlement_duplicates(&self) -> Vec<(BatchId, u64)> {
+        top_settlement_duplicates(&self.applied_settlement_batches)
+    }
+}
+
+fn top_settlement_duplicates(counts: &HashMap<BatchId, u64>) -> Vec<(BatchId, u64)> {
+    let mut top: Vec<_> = counts
+        .iter()
+        .filter_map(|(batch_id, count)| {
+            let duplicates = count.saturating_sub(1);
+            (duplicates > 0).then_some((*batch_id, duplicates))
+        })
+        .collect();
+    top.sort_by(|(_, left), (_, right)| right.cmp(left));
+    top.truncate(8);
+    top
+}
+
 /// Unified runtime core for both native and WASM platforms.
 ///
 /// Generic over `Storage` for data persistence and `Scheduler` for tick scheduling.
@@ -298,6 +369,9 @@ pub struct RuntimeCore<S: Storage, Sch: Scheduler> {
     next_expected_server_seq: HashMap<ServerId, u64>,
     /// Highest per-server stream sequence already applied to the inbox.
     last_applied_server_seq: HashMap<ServerId, u64>,
+    /// Lightweight receive-side counters for diagnosing watermarked query release.
+    sync_receive_stats: HashMap<ServerId, SyncReceiveStats>,
+
     /// Subscription tracking with callbacks.
     subscriptions: HashMap<SubscriptionHandle, SubscriptionState>,
     /// Reverse map for routing updates.
@@ -360,6 +434,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             parked_sync_messages_by_server_seq: HashMap::new(),
             next_expected_server_seq: HashMap::new(),
             last_applied_server_seq: HashMap::new(),
+            sync_receive_stats: HashMap::new(),
             subscriptions: HashMap::new(),
             subscription_reverse: HashMap::new(),
             next_subscription_handle: 0,

--- a/crates/jazz-tools/src/runtime_core/ticks.rs
+++ b/crates/jazz-tools/src/runtime_core/ticks.rs
@@ -4,6 +4,102 @@ use crate::row_histories::{RowState, patch_row_batch_state};
 use crate::storage::metadata_from_row_locator;
 
 impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
+    fn sync_receive_stats_mut(
+        &mut self,
+        server_id: crate::sync_manager::ServerId,
+    ) -> &mut SyncReceiveStats {
+        self.sync_receive_stats
+            .entry(server_id)
+            .or_insert_with(SyncReceiveStats::new)
+    }
+
+    fn record_sequenced_sync_received(
+        &mut self,
+        server_id: crate::sync_manager::ServerId,
+        sequence: u64,
+        payload: &crate::sync_manager::SyncPayload,
+    ) {
+        let kind = payload.variant_name();
+        let stats = self.sync_receive_stats_mut(server_id);
+        stats.received_total += 1;
+        stats.highest_received_seq = stats.highest_received_seq.max(sequence);
+        *stats.received_by_type.entry(kind).or_default() += 1;
+        if let crate::sync_manager::SyncPayload::BatchSettlement { settlement } = payload {
+            *stats
+                .received_settlement_batches
+                .entry(settlement.batch_id())
+                .or_default() += 1;
+        }
+
+        if matches!(
+            payload,
+            crate::sync_manager::SyncPayload::QuerySettled { .. }
+        ) || stats.received_total >= stats.next_log_at
+        {
+            tracing::warn!(
+                target: "jazz_timing",
+                ?server_id,
+                sequence,
+                kind,
+                elapsed_ms = stats.elapsed_ms(),
+                received_total = stats.received_total,
+                applied_total = stats.applied_total,
+                highest_received_seq = stats.highest_received_seq,
+                highest_applied_seq = stats.highest_applied_seq,
+                received_by_type = ?stats.received_by_type,
+                settlement_unique_batches = stats.received_settlement_batches.len(),
+                settlement_duplicate_messages = stats.received_settlement_duplicates(),
+                top_settlement_duplicates = ?stats.top_received_settlement_duplicates(),
+                "[jazz timing] runtime sequenced sync received summary"
+            );
+            while stats.received_total >= stats.next_log_at {
+                stats.next_log_at += 500;
+            }
+        }
+    }
+
+    fn record_sequenced_sync_applied(
+        &mut self,
+        server_id: crate::sync_manager::ServerId,
+        sequence: u64,
+        payload: &crate::sync_manager::SyncPayload,
+    ) {
+        let kind = payload.variant_name();
+        let stats = self.sync_receive_stats_mut(server_id);
+        stats.applied_total += 1;
+        stats.highest_applied_seq = stats.highest_applied_seq.max(sequence);
+        *stats.applied_by_type.entry(kind).or_default() += 1;
+        if let crate::sync_manager::SyncPayload::BatchSettlement { settlement } = payload {
+            *stats
+                .applied_settlement_batches
+                .entry(settlement.batch_id())
+                .or_default() += 1;
+        }
+
+        if matches!(
+            payload,
+            crate::sync_manager::SyncPayload::QuerySettled { .. }
+        ) || stats.applied_total.is_multiple_of(500)
+        {
+            tracing::warn!(
+                target: "jazz_timing",
+                ?server_id,
+                sequence,
+                kind,
+                elapsed_ms = stats.elapsed_ms(),
+                received_total = stats.received_total,
+                applied_total = stats.applied_total,
+                highest_received_seq = stats.highest_received_seq,
+                highest_applied_seq = stats.highest_applied_seq,
+                applied_by_type = ?stats.applied_by_type,
+                settlement_unique_batches = stats.applied_settlement_batches.len(),
+                settlement_duplicate_messages = stats.applied_settlement_duplicates(),
+                top_settlement_duplicates = ?stats.top_applied_settlement_duplicates(),
+                "[jazz timing] runtime sequenced sync applied summary"
+            );
+        }
+    }
+
     fn local_batch_rows(
         &self,
         batch_id: crate::row_histories::BatchId,
@@ -340,13 +436,54 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                         >= pending_settled.through_seq
                 });
                 if is_ready {
+                    let stats = pending_settled
+                        .server_id
+                        .and_then(|server_id| self.sync_receive_stats.get(&server_id));
+                    tracing::warn!(
+                        target: "jazz_timing",
+                        query_id = pending_settled.query_id.0,
+                        ?pending_settled.tier,
+                        ?pending_settled.server_id,
+                        through_seq = pending_settled.through_seq,
+                        received_total = stats.map(|stats| stats.received_total).unwrap_or(0),
+                        applied_total = stats.map(|stats| stats.applied_total).unwrap_or(0),
+                        highest_received_seq = stats.map(|stats| stats.highest_received_seq).unwrap_or(0),
+                        highest_applied_seq = stats.map(|stats| stats.highest_applied_seq).unwrap_or(0),
+                        received_by_type = ?stats.map(|stats| &stats.received_by_type),
+                        applied_by_type = ?stats.map(|stats| &stats.applied_by_type),
+                        "[jazz timing] runtime QuerySettled watermark ready"
+                    );
                     ready.push(pending_settled);
                 } else {
+                    let applied_seq = pending_settled
+                        .server_id
+                        .and_then(|server_id| self.last_applied_server_seq.get(&server_id).copied())
+                        .unwrap_or(0);
+                    let stats = pending_settled
+                        .server_id
+                        .and_then(|server_id| self.sync_receive_stats.get(&server_id));
+                    tracing::debug!(
+                        target: "jazz_timing",
+                        query_id = pending_settled.query_id.0,
+                        ?pending_settled.tier,
+                        ?pending_settled.server_id,
+                        through_seq = pending_settled.through_seq,
+                        applied_seq,
+                        seq_lag = pending_settled.through_seq.saturating_sub(applied_seq),
+                        highest_received_seq = stats.map(|stats| stats.highest_received_seq).unwrap_or(0),
+                        highest_applied_seq = stats.map(|stats| stats.highest_applied_seq).unwrap_or(0),
+                        "[jazz timing] runtime QuerySettled watermark blocked"
+                    );
                     blocked.push(pending_settled);
                 }
             }
 
             if !blocked.is_empty() {
+                tracing::debug!(
+                    target: "jazz_timing",
+                    count = blocked.len(),
+                    "[jazz timing] runtime requeueing blocked QuerySettled messages"
+                );
                 self.schema_manager
                     .query_manager_mut()
                     .sync_manager_mut()
@@ -360,6 +497,12 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             {
                 let query_manager = self.schema_manager.query_manager_mut();
                 for pending_settled in ready_query_settled {
+                    tracing::warn!(
+                        target: "jazz_timing",
+                        query_id = pending_settled.query_id.0,
+                        ?pending_settled.tier,
+                        "[jazz timing] runtime applying ready QuerySettled"
+                    );
                     query_manager
                         .apply_query_settled(pending_settled.query_id, pending_settled.tier);
                 }
@@ -526,6 +669,60 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             .take_outbox();
         if !outbox.is_empty() {
             debug!(count = outbox.len(), "{log_message}");
+            let mut row_batches = 0usize;
+            let mut query_subscriptions = 0usize;
+            let mut query_settled = 0usize;
+            let mut batch_settlements = 0usize;
+            let mut settlement_batches =
+                std::collections::HashMap::<crate::row_histories::BatchId, usize>::new();
+            let mut other = 0usize;
+            for msg in &outbox {
+                match &msg.payload {
+                    crate::sync_manager::SyncPayload::RowBatchCreated { .. }
+                    | crate::sync_manager::SyncPayload::RowBatchNeeded { .. } => {
+                        row_batches += 1;
+                    }
+                    crate::sync_manager::SyncPayload::QuerySubscription { .. } => {
+                        query_subscriptions += 1;
+                    }
+                    crate::sync_manager::SyncPayload::QuerySettled { .. } => {
+                        query_settled += 1;
+                    }
+                    crate::sync_manager::SyncPayload::BatchSettlement { settlement } => {
+                        batch_settlements += 1;
+                        *settlement_batches.entry(settlement.batch_id()).or_default() += 1;
+                    }
+                    _ => {
+                        other += 1;
+                    }
+                }
+            }
+            let settlement_duplicate_messages: usize = settlement_batches
+                .values()
+                .map(|count| count.saturating_sub(1))
+                .sum();
+            let mut top_settlement_duplicates: Vec<_> = settlement_batches
+                .iter()
+                .filter_map(|(batch_id, count)| {
+                    let duplicates = count.saturating_sub(1);
+                    (duplicates > 0).then_some((*batch_id, duplicates))
+                })
+                .collect();
+            top_settlement_duplicates.sort_by(|(_, left), (_, right)| right.cmp(left));
+            top_settlement_duplicates.truncate(8);
+            tracing::warn!(
+                target: "jazz_timing",
+                count = outbox.len(),
+                row_batches,
+                query_subscriptions,
+                query_settled,
+                batch_settlements,
+                settlement_unique_batches = settlement_batches.len(),
+                settlement_duplicate_messages,
+                top_settlement_duplicates = ?top_settlement_duplicates,
+                other,
+                "[jazz timing] runtime flushing outbox"
+            );
         }
 
         let mut unsent = Vec::new();
@@ -566,6 +763,80 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             while let Some(message) = handle.try_recv_inbound() {
                 inbound.push(message);
             }
+        }
+
+        if !inbound.is_empty() {
+            let mut first_seq = None;
+            let mut last_seq = None;
+            let mut row_batches = 0usize;
+            let mut query_settled = 0usize;
+            let mut batch_settlements = 0usize;
+            let mut settlement_batches =
+                std::collections::HashMap::<crate::row_histories::BatchId, usize>::new();
+            let mut other = 0usize;
+
+            for message in &inbound {
+                match message {
+                    crate::transport_manager::TransportInbound::Sync { entry, sequence } => {
+                        if let Some(sequence) = *sequence {
+                            first_seq = Some(
+                                first_seq.map_or(sequence, |current: u64| current.min(sequence)),
+                            );
+                            last_seq = Some(
+                                last_seq.map_or(sequence, |current: u64| current.max(sequence)),
+                            );
+                        }
+                        match &entry.payload {
+                            crate::sync_manager::SyncPayload::RowBatchCreated { .. }
+                            | crate::sync_manager::SyncPayload::RowBatchNeeded { .. } => {
+                                row_batches += 1;
+                            }
+                            crate::sync_manager::SyncPayload::QuerySettled { .. } => {
+                                query_settled += 1;
+                            }
+                            crate::sync_manager::SyncPayload::BatchSettlement { settlement } => {
+                                batch_settlements += 1;
+                                *settlement_batches.entry(settlement.batch_id()).or_default() += 1;
+                            }
+                            _ => {
+                                other += 1;
+                            }
+                        }
+                    }
+                    _ => {
+                        other += 1;
+                    }
+                }
+            }
+            let settlement_duplicate_messages: usize = settlement_batches
+                .values()
+                .map(|count| count.saturating_sub(1))
+                .sum();
+            let mut top_settlement_duplicates: Vec<_> = settlement_batches
+                .iter()
+                .filter_map(|(batch_id, count)| {
+                    let duplicates = count.saturating_sub(1);
+                    (duplicates > 0).then_some((*batch_id, duplicates))
+                })
+                .collect();
+            top_settlement_duplicates.sort_by(|(_, left), (_, right)| right.cmp(left));
+            top_settlement_duplicates.truncate(8);
+
+            tracing::warn!(
+                target: "jazz_timing",
+                %server_id,
+                count = inbound.len(),
+                ?first_seq,
+                ?last_seq,
+                row_batches,
+                query_settled,
+                batch_settlements,
+                settlement_unique_batches = settlement_batches.len(),
+                settlement_duplicate_messages,
+                top_settlement_duplicates = ?top_settlement_duplicates,
+                other,
+                "[jazz timing] runtime drained transport inbound"
+            );
         }
 
         for message in inbound {
@@ -657,6 +928,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                 if msg.payload.writes_storage() {
                     self.mark_storage_write_pending_flush();
                 }
+                self.record_sequenced_sync_applied(server_id, sequence, &msg.payload);
                 self.push_sync_inbox(msg);
                 applied_messages += 1;
                 last_applied = sequence;
@@ -717,6 +989,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                     tracer.record_incoming(&message.source, name, &message.payload);
                 }
 
+                self.record_sequenced_sync_received(server_id, sequence, &message.payload);
                 self.parked_sync_messages_by_server_seq
                     .entry(server_id)
                     .or_default()
@@ -734,6 +1007,17 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             .insert(server_id, next_sequence);
         self.last_applied_server_seq
             .insert(server_id, next_sequence.saturating_sub(1));
+        {
+            let stats = self.sync_receive_stats_mut(server_id);
+            stats.highest_applied_seq = next_sequence.saturating_sub(1);
+            tracing::warn!(
+                target: "jazz_timing",
+                ?server_id,
+                next_sequence,
+                highest_applied_seq = stats.highest_applied_seq,
+                "[jazz timing] runtime server stream sequence initialized"
+            );
+        }
         if let Some(buffered) = self.parked_sync_messages_by_server_seq.get_mut(&server_id) {
             buffered.retain(|seq, _| *seq >= next_sequence);
         }

--- a/crates/jazz-tools/src/server/mod.rs
+++ b/crates/jazz-tools/src/server/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -41,6 +41,9 @@ struct ConnectionStreamState {
     client_id: ClientId,
     next_sync_seq: u64,
     sender: mpsc::UnboundedSender<SequencedSyncUpdate>,
+    sent_total: u64,
+    sent_by_type: BTreeMap<&'static str, u64>,
+    next_log_at: u64,
 }
 
 #[derive(Default)]
@@ -62,6 +65,9 @@ impl ConnectionEventHub {
                 client_id,
                 next_sync_seq: 1,
                 sender,
+                sent_total: 0,
+                sent_by_type: BTreeMap::new(),
+                next_log_at: 500,
             },
         );
         (1, receiver)
@@ -100,6 +106,27 @@ impl ConnectionEventHub {
                 },
                 _ => payload.clone(),
             };
+            let kind = payload.variant_name();
+            state.sent_total += 1;
+            *state.sent_by_type.entry(kind).or_default() += 1;
+            if matches!(payload, SyncPayload::QuerySettled { .. })
+                || state.sent_total >= state.next_log_at
+            {
+                tracing::warn!(
+                    target: "jazz_timing",
+                    connection_id,
+                    %client_id,
+                    seq,
+                    kind,
+                    sent_total = state.sent_total,
+                    sent_by_type = ?state.sent_by_type,
+                    "[jazz timing] server stream fanout summary"
+                );
+                while state.sent_total >= state.next_log_at {
+                    state.next_log_at += 500;
+                }
+            }
+
             prepared.push(PreparedSyncDispatch {
                 connection_id,
                 sender: state.sender.clone(),

--- a/crates/jazz-tools/src/server/routes/websocket.rs
+++ b/crates/jazz-tools/src/server/routes/websocket.rs
@@ -458,6 +458,67 @@ async fn handle_ws_connection(
                     Ok(b) => b,
                     Err(_) => continue,
                 };
+                let mut batch_settlements = 0usize;
+                let mut settlement_batches =
+                    std::collections::HashMap::<crate::row_histories::BatchId, usize>::new();
+                let mut row_batches = 0usize;
+                let mut query_settled = 0usize;
+                let mut count_payload = |payload: &crate::sync_manager::SyncPayload| {
+                    match payload {
+                        crate::sync_manager::SyncPayload::BatchSettlement { settlement } => {
+                            batch_settlements += 1;
+                            *settlement_batches.entry(settlement.batch_id()).or_default() += 1;
+                        }
+                        crate::sync_manager::SyncPayload::RowBatchCreated { .. }
+                        | crate::sync_manager::SyncPayload::RowBatchNeeded { .. } => {
+                            row_batches += 1;
+                        }
+                        crate::sync_manager::SyncPayload::QuerySettled { .. } => {
+                            query_settled += 1;
+                        }
+                        _ => {}
+                    }
+                };
+                match &event {
+                    crate::jazz_transport::ServerEvent::SyncUpdate { payload, .. } => {
+                        count_payload(payload);
+                    }
+                    crate::jazz_transport::ServerEvent::SyncUpdateBatch { updates } => {
+                        for update in updates {
+                            count_payload(&update.payload);
+                        }
+                    }
+                    _ => {}
+                }
+                let settlement_duplicate_messages: usize = settlement_batches
+                    .values()
+                    .map(|count| count.saturating_sub(1))
+                    .sum();
+                let mut top_settlement_duplicates: Vec<_> = settlement_batches
+                    .iter()
+                    .filter_map(|(batch_id, count)| {
+                        let duplicates = count.saturating_sub(1);
+                        (duplicates > 0).then_some((*batch_id, duplicates))
+                    })
+                    .collect();
+                top_settlement_duplicates.sort_by(|(_, left), (_, right)| right.cmp(left));
+                top_settlement_duplicates.truncate(8);
+                tracing::warn!(
+                    target: "jazz_timing",
+                    update_count = match &event {
+                        crate::jazz_transport::ServerEvent::SyncUpdate { .. } => 1,
+                        crate::jazz_transport::ServerEvent::SyncUpdateBatch { updates } => updates.len(),
+                        _ => 0,
+                    },
+                    bytes = bytes.len(),
+                    row_batches,
+                    query_settled,
+                    batch_settlements,
+                    settlement_unique_batches = settlement_batches.len(),
+                    settlement_duplicate_messages,
+                    top_settlement_duplicates = ?top_settlement_duplicates,
+                    "[jazz timing] server websocket sending sync frame"
+                );
                 if socket
                     .send(Message::Binary(
                         crate::transport_manager::frame_encode(&bytes),

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -1337,6 +1337,21 @@ impl SyncManager {
                 scope,
                 through_seq,
             } => {
+                let relay_client_count = self
+                    .query_origin
+                    .get(&query_id)
+                    .map(|clients| clients.len())
+                    .unwrap_or(0);
+                tracing::warn!(
+                    target: "jazz_timing",
+                    %server_id,
+                    query_id = query_id.0,
+                    ?tier,
+                    scope_size = scope.len(),
+                    through_seq,
+                    relay_client_count,
+                    "[jazz timing] server QuerySettled received for relay"
+                );
                 let scope_set: HashSet<(ObjectId, BranchName)> = scope.iter().copied().collect();
                 let scope_changed = self
                     .remote_query_scopes
@@ -1360,6 +1375,16 @@ impl SyncManager {
                 // Relay to interested clients
                 if let Some(clients) = self.query_origin.get(&query_id) {
                     for &cid in clients {
+                        tracing::warn!(
+                            target: "jazz_timing",
+                            %server_id,
+                            %cid,
+                            query_id = query_id.0,
+                            ?tier,
+                            scope_size = scope.len(),
+                            through_seq,
+                            "[jazz timing] server QuerySettled relayed to client"
+                        );
                         self.outbox.push(OutboxEntry {
                             destination: Destination::Client(cid),
                             payload: SyncPayload::QuerySettled {


### PR DESCRIPTION
## What changed

This is stacked on top of #774 and contains the timing/debug instrumentation split out from the base batch-settlement PR.

- Adds `jazz_timing` logs for sequenced receive/apply progress in `RuntimeCore`.
- Adds runtime payload counters for `BatchSettlement`, `RowBatchNeeded`, `QuerySettled`, row batches, and other sync messages.
- Adds duplicate-settlement diagnostics: unique settlement batch count, duplicate message count, and top duplicate batch IDs.
- Adds server WebSocket frame instrumentation for update count, byte size, payload mix, and settlement duplicates per frame.
- Adds runtime outbox/inbound drain instrumentation to locate whether duplication happens before transport, during WebSocket fanout, or during client apply.
- Adds server query subscription timing around graph settle, scope computation, and `QuerySettled` fanout.

## Why

#774 keeps the batch durability model and correctness fixes focused. This PR keeps the diagnostics available for BoredM follow-up work without mixing debug volume into the semantic change.

## Validation

This branch is code-identical to the previously green #774 head for the instrumentation parts, now stacked above the cleaned base. Fresh CI will run on this PR.
