### PR TITLE
Fix React Native UI freeze on db.all by making jazz-rn query async

### DIFF
--- a/.changeset/rn-async-query.md
+++ b/.changeset/rn-async-query.md
@@ -1,0 +1,8 @@
+---
+"jazz-tools": patch
+"jazz-rn": patch
+---
+
+`jazz-rn`: `query` is now `async` and no longer blocks the React Native JS thread on one-shot reads.
+
+The native uniffi export used `block_on` on the JS thread, so any `db.all(...)` that needed a later `batched_tick` to settle (e.g. queries that wait on server-sourced data or parked sync messages) could deadlock — the JS thread was blocked, so the `batched_tick` callback could never fire to fulfil the query future. The export is now `async fn` and uniffi-bindgen-react-native generates a Promise-returning JSI call, polled off the JS thread. `JazzRnRuntimeAdapter.query` now `await`s the binding before parsing.

--- a/crates/jazz-rn/rust/src/lib.rs
+++ b/crates/jazz-rn/rust/src/lib.rs
@@ -82,20 +82,23 @@ fn panic_payload_to_string(payload: Box<dyn std::any::Any + Send>) -> String {
     "non-string panic payload".to_string()
 }
 
+fn panic_to_jazz_error(
+    context: &'static str,
+    payload: Box<dyn std::any::Any + Send>,
+) -> JazzRnError {
+    let panic_message = panic_payload_to_string(payload);
+    let backtrace = std::backtrace::Backtrace::force_capture();
+    JazzRnError::Internal {
+        message: format!("panic in {context}: {panic_message}\n{backtrace}"),
+    }
+}
+
 fn with_panic_boundary<T, F>(context: &'static str, f: F) -> Result<T, JazzRnError>
 where
     F: FnOnce() -> Result<T, JazzRnError>,
 {
-    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
-        Ok(result) => result,
-        Err(payload) => {
-            let panic_message = panic_payload_to_string(payload);
-            let backtrace = std::backtrace::Backtrace::force_capture();
-            Err(JazzRnError::Internal {
-                message: format!("panic in {context}: {panic_message}\n{backtrace}"),
-            })
-        }
-    }
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(f))
+        .unwrap_or_else(|payload| Err(panic_to_jazz_error(context, payload)))
 }
 
 async fn with_async_panic_boundary<T, F, Fut>(context: &'static str, f: F) -> Result<T, JazzRnError>
@@ -103,16 +106,10 @@ where
     F: FnOnce() -> Fut,
     Fut: Future<Output = Result<T, JazzRnError>>,
 {
-    match std::panic::AssertUnwindSafe(f()).catch_unwind().await {
-        Ok(result) => result,
-        Err(payload) => {
-            let panic_message = panic_payload_to_string(payload);
-            let backtrace = std::backtrace::Backtrace::force_capture();
-            Err(JazzRnError::Internal {
-                message: format!("panic in {context}: {panic_message}\n{backtrace}"),
-            })
-        }
-    }
+    std::panic::AssertUnwindSafe(f())
+        .catch_unwind()
+        .await
+        .unwrap_or_else(|payload| Err(panic_to_jazz_error(context, payload)))
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/jazz-rn/rust/src/lib.rs
+++ b/crates/jazz-rn/rust/src/lib.rs
@@ -5,10 +5,11 @@
 uniffi::setup_scaffolding!();
 
 use std::collections::HashMap;
+use std::future::Future;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
-use futures::executor::block_on;
+use futures::future::FutureExt;
 use serde::Deserialize;
 
 use jazz_tools::binding_support::{
@@ -86,6 +87,23 @@ where
     F: FnOnce() -> Result<T, JazzRnError>,
 {
     match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
+        Ok(result) => result,
+        Err(payload) => {
+            let panic_message = panic_payload_to_string(payload);
+            let backtrace = std::backtrace::Backtrace::force_capture();
+            Err(JazzRnError::Internal {
+                message: format!("panic in {context}: {panic_message}\n{backtrace}"),
+            })
+        }
+    }
+}
+
+async fn with_async_panic_boundary<T, F, Fut>(context: &'static str, f: F) -> Result<T, JazzRnError>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Result<T, JazzRnError>>,
+{
+    match std::panic::AssertUnwindSafe(f()).catch_unwind().await {
         Ok(result) => result,
         Err(payload) => {
             let panic_message = panic_payload_to_string(payload);
@@ -582,20 +600,24 @@ impl RnRuntime {
 
     /// One-shot query returning a JSON string:
     /// `[{ "id": "<uuid>", "values": [ {type, value}, ... ] }, ...]`.
-    pub fn query(
+    ///
+    /// `async` so the JS thread is not blocked while the query future is
+    /// waiting on a later `batched_tick` to settle (which is itself driven
+    /// from JS via the `on_batched_tick_needed` callback). A synchronous
+    /// `block_on` here can deadlock for any query that needs more than the
+    /// inline `immediate_tick` to resolve.
+    pub async fn query(
         &self,
         query_json: String,
         session_json: Option<String>,
         tier: Option<String>,
     ) -> Result<String, JazzRnError> {
-        with_panic_boundary("query", || {
+        with_async_panic_boundary("query", || async move {
             let query = parse_query(&query_json)?;
             let query_for_alignment = query.clone();
             let session = parse_session(session_json)?;
             let tier = tier.as_deref().map(parse_tier).transpose()?;
 
-            // NOTE: query() triggers immediate_tick() internally.
-            // We then block for the first callback result to be delivered.
             let (fut, runtime_schema) = {
                 let mut core = self.core.lock().map_err(|_| JazzRnError::Internal {
                     message: "lock poisoned".into(),
@@ -610,7 +632,7 @@ impl RnRuntime {
                     core.current_schema().clone(),
                 )
             };
-            let results = block_on(fut).map_err(runtime_err)?;
+            let results = fut.await.map_err(runtime_err)?;
             let results = align_query_rows_to_declared_schema(
                 &self.declared_schema,
                 &runtime_schema,
@@ -630,6 +652,7 @@ impl RnRuntime {
 
             serde_json::to_string(&rows_json).map_err(json_err)
         })
+        .await
     }
 
     // =========================================================================

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.test.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.test.ts
@@ -27,7 +27,7 @@ function createBinding(overrides: Partial<JazzRnRuntimeBinding> = {}): JazzRnRun
     onBatchedTickNeeded: vi.fn(),
     onSyncMessageReceived: vi.fn(),
     onSyncMessageReceivedFromClient: vi.fn(),
-    query: vi.fn(() => JSON.stringify([{ id: "row-1", values: [] }])),
+    query: vi.fn(() => Promise.resolve(JSON.stringify([{ id: "row-1", values: [] }]))),
     removeServer: vi.fn(),
     setClientRole: vi.fn(),
     subscribe: vi.fn(() => 7n),
@@ -91,9 +91,7 @@ describe("JazzRnRuntimeAdapter", () => {
           resolveBinding = resolve;
         }),
     );
-    const binding = createBinding({
-      query: queryMock as unknown as JazzRnRuntimeBinding["query"],
-    });
+    const binding = createBinding({ query: queryMock });
     const adapter = new JazzRnRuntimeAdapter(binding, {});
 
     let otherJsDidRun = false;
@@ -326,9 +324,7 @@ describe("JazzRnRuntimeAdapter", () => {
       insert: vi.fn(() => {
         throw runtimeError;
       }),
-      query: vi.fn(() => {
-        throw runtimeError;
-      }),
+      query: vi.fn(() => Promise.reject(runtimeError)),
       update: vi.fn(() => {
         throw runtimeError;
       }),

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.test.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.test.ts
@@ -77,6 +77,36 @@ describe("JazzRnRuntimeAdapter", () => {
     await expect(adapter.query("{}", null, null)).resolves.toEqual([{ id: "row-1", values: [] }]);
   });
 
+  it("yields the JS event loop while a query is in flight", async () => {
+    // Simulates a slow native query: the binding returns a Promise that we
+    // resolve only from a setTimeout(0), i.e. after the event loop has had a
+    // chance to run other tasks. A correct adapter awaits the binding's
+    // Promise, so the timeout fires, resolves the binding, and the query
+    // returns. A blocking adapter (e.g. one that parses the result without
+    // awaiting) never yields and the query never settles.
+    let resolveBinding!: (value: string) => void;
+    const queryMock = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveBinding = resolve;
+        }),
+    );
+    const binding = createBinding({
+      query: queryMock as unknown as JazzRnRuntimeBinding["query"],
+    });
+    const adapter = new JazzRnRuntimeAdapter(binding, {});
+
+    let otherJsDidRun = false;
+    const queryPromise = adapter.query("{}", null, null);
+    setTimeout(() => {
+      otherJsDidRun = true;
+      resolveBinding(JSON.stringify([{ id: "row-1", values: [] }]));
+    }, 0);
+
+    await expect(queryPromise).resolves.toEqual([{ id: "row-1", values: [] }]);
+    expect(otherJsDidRun).toBe(true);
+  });
+
   it("encodes Bytea mutations with an explicit FFI transport shape", () => {
     const binding = createBinding();
     const adapter = new JazzRnRuntimeAdapter(binding, {});

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
@@ -52,7 +52,11 @@ export interface JazzRnRuntimeBinding {
   ): void;
   onSyncMessageReceived(messageJson: string, seq?: number | null): void;
   onSyncMessageReceivedFromClient(clientId: string, messageJson: string): void;
-  query(queryJson: string, sessionJson: string | undefined, tier: string | undefined): string;
+  query(
+    queryJson: string,
+    sessionJson: string | undefined,
+    tier: string | undefined,
+  ): Promise<string>;
   removeServer(): void;
   setClientRole(clientId: string, role: string): void;
   createSubscription(
@@ -296,7 +300,11 @@ export class JazzRnRuntimeAdapter implements Runtime {
     tier?: string | null,
   ): Promise<any> {
     try {
-      const rowsJson = this.binding.query(query_json, session_json ?? undefined, tier ?? undefined);
+      const rowsJson = await this.binding.query(
+        query_json,
+        session_json ?? undefined,
+        tier ?? undefined,
+      );
       return JSON.parse(rowsJson);
     } catch (error) {
       throw normalizeJazzRnError(error);


### PR DESCRIPTION
## Summary
- `jazz-rn`'s native `query` export ran `block_on` on the JS thread, which froze the UI for the duration of a query and could deadlock entirely: queries that need a later `batched_tick` to settle (e.g. server-sourced reads) cannot make progress while JS is blocked, since `batched_tick` is JS-driven.
- `query` is now `async fn`. uniffi-bindgen-react-native generates a Promise-returning JSI call and polls the future off the JS thread, so `batched_tick` callbacks keep firing while the query waits.
- The TS adapter now `await`s the binding's Promise; `JazzRnRuntimeBinding.query` is typed as `Promise<string>`. NAPI already shipped this shape.

## Test plan
- [ ] `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/react-native` — 30 tests pass, including the new `yields the JS event loop while a query is in flight` regression.
- [ ] `cargo test -p jazz-rn && cargo clippy -p jazz-rn --all-targets` — clean.
- [ ] Build the RN bindings (`pnpm --filter jazz-rn build`) and confirm the generated TypeScript surface for `query` becomes `Promise<string>`.