### PR TITLE
Drop no-op Headers/Request/Response polyfills from jazz-tools/expo

### DIFF
--- a/.changeset/drop-expo-headers-request-response-polyfills.md
+++ b/.changeset/drop-expo-headers-request-response-polyfills.md
@@ -1,0 +1,7 @@
+---
+"jazz-tools": patch
+---
+
+Drop no-op `Headers`/`Request`/`Response` polyfills from `jazz-tools/expo`.
+
+These were imported from `react-native/Libraries/Network/fetch`, which just re-exports `global.*` — so each polyfill collapsed to `globalThis.X = globalThis.X` at best, and to `globalThis.X = undefined` if the polyfill module evaluated before RN installed its networking globals. The latter case broke any consumer that touched `Headers.prototype` (e.g. Clerk's `new Headers(...)` in `fapiClient`), which surfaced as `TypeError: Cannot read property 'prototype' of undefined`. The `fetch` and `ReadableStream` polyfills, which do real work, are kept.

--- a/packages/jazz-tools/src/expo/polyfills.ts
+++ b/packages/jazz-tools/src/expo/polyfills.ts
@@ -1,11 +1,6 @@
 /// <reference path="./vendor.d.ts" />
 
 import { polyfillGlobal } from "react-native/Libraries/Utilities/PolyfillFunctions";
-import {
-  Headers as ReactNativeHeaders,
-  Request as ReactNativeRequest,
-  Response as ReactNativeResponse,
-} from "react-native/Libraries/Network/fetch";
 import { fetch as expoFetch } from "expo/fetch";
 
 import { ReadableStream as PonyfillReadableStream } from "web-streams-polyfill";
@@ -33,7 +28,4 @@ const fetchSpecCompliant: typeof globalThis.fetch = async (input, init) => {
 };
 
 polyfillGlobal("fetch", () => fetchSpecCompliant);
-polyfillGlobal("Headers", () => ReactNativeHeaders ?? globalThis.Headers);
-polyfillGlobal("Request", () => ReactNativeRequest ?? globalThis.Request);
-polyfillGlobal("Response", () => ReactNativeResponse ?? globalThis.Response);
 polyfillGlobal("ReadableStream", () => readableStreamCtor);


### PR DESCRIPTION
## Summary
- Removed three `polyfillGlobal` calls for `Headers`/`Request`/`Response` and the dead `react-native/Libraries/Network/fetch` imports they relied on.
- Those imports just re-export `global.*`, so each polyfill was either an identity assignment or — when this module evaluated before RN installed its networking globals — clobbered `globalThis.X` with `undefined`, breaking any consumer that touched `Headers.prototype` (e.g. Clerk's `new Headers(...)` surfacing as `TypeError: Cannot read property 'prototype' of undefined`).
- Kept `fetch` (streaming via `expo/fetch`) and `ReadableStream` (Hermes lacks WHATWG streams).

## Test plan
- [ ] `pnpm --filter jazz-tools test src/better-auth-adapter` still passes (URL/Request coercion in `fetchSpecCompliant` is unchanged).
- [ ] In an Expo app using both `jazz-tools/expo/polyfills` and Clerk, sign-in no longer throws `Cannot read property 'prototype' of undefined`.
- [ ] Existing Expo todo example still syncs end-to-end.