### PR TITLE
ci: switch from goto-bus-stop/setup-zig to mlugg/setup-zig

### DIFF
--- a/.github/workflows/expo-android-maestro-e2e.yml
+++ b/.github/workflows/expo-android-maestro-e2e.yml
@@ -56,6 +56,7 @@ jobs:
       - uses: mlugg/setup-zig@v2
         with:
           version: 0.14.0
+          cache-key: ${{ matrix.target }}
 
       - uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/expo-android-maestro-e2e.yml
+++ b/.github/workflows/expo-android-maestro-e2e.yml
@@ -53,7 +53,7 @@ jobs:
           toolchain: 1.93.1
           targets: ${{ matrix.target }}
 
-      - uses: goto-bus-stop/setup-zig@v2
+      - uses: mlugg/setup-zig@v2
         with:
           version: 0.14.0
 

--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -421,7 +421,7 @@ jobs:
         with:
           cache-on-failure: true
 
-      - uses: goto-bus-stop/setup-zig@v2
+      - uses: mlugg/setup-zig@v2
         with:
           version: 0.14.0
 

--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -424,6 +424,7 @@ jobs:
       - uses: mlugg/setup-zig@v2
         with:
           version: 0.14.0
+          cache-key: ${{ matrix.target }}
 
       - uses: taiki-e/install-action@v2
         with:


### PR DESCRIPTION
## Summary
- Replace `goto-bus-stop/setup-zig@v2` with `mlugg/setup-zig@v2` in both Zig-using workflows (`expo-android-maestro-e2e.yml`, `publish-jazz-tools-alpha.yml`).
- Same `version: 0.14.0` input — drop-in replacement.

## Why
`goto-bus-stop/setup-zig` is unmaintained and downloads Zig from a hardcoded URL that's been returning HTTP 500 in CI:

```
no cached version found. downloading zig zig-linux-x86_64-0.14.0
aborted
Waiting 15 seconds before trying again
aborted
Waiting 10 seconds before trying again
Error: Unexpected HTTP response: 500
```

`mlugg/setup-zig` is the actively maintained successor recommended by the Zig project. It uses the official Zig mirror list with retry/fallback, so transient mirror failures don't fail the job.

## Test plan
- [ ] `expo-android-maestro-e2e` workflow runs green (matrix: `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`).
- [ ] Next `publish-jazz-tools-alpha` run succeeds at the Zig setup step.