### PR TITLE
fix: null field update is lost on sync

### DIFF
--- a/.changeset/orange-bikes-lose.md
+++ b/.changeset/orange-bikes-lose.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+fix: prevent null field updates from getting lost on sync

--- a/crates/jazz-tools/src/row_histories/resolution.rs
+++ b/crates/jazz-tools/src/row_histories/resolution.rs
@@ -312,13 +312,14 @@ pub(super) fn build_computed_visible_preview(
     let mut merged_values = Vec::with_capacity(user_descriptor.columns.len());
     let mut contributing_rows: Vec<&StoredRowBatch> = Vec::new();
     let mut winner_batch_ids = Vec::with_capacity(user_descriptor.columns.len());
+    let null_ancestor = Value::Null;
 
     for column_index in 0..user_descriptor.columns.len() {
         let column = &user_descriptor.columns[column_index];
         let ancestor_value = ancestor_values
             .as_ref()
-            .map(|values| values[column_index].clone())
-            .unwrap_or(Value::Null);
+            .map(|values| &values[column_index])
+            .unwrap_or(&null_ancestor);
         let changed_contenders = frontier
             .iter()
             .zip(frontier_values.iter())
@@ -343,7 +344,7 @@ pub(super) fn build_computed_visible_preview(
             })
             .collect::<Vec<_>>();
         let (best_value, best_changed) =
-            merge_column_with_strategy(column, &ancestor_value, &changed_contenders)?;
+            merge_column_with_strategy(column, ancestor_value, &changed_contenders)?;
 
         merged_values.push(best_value);
         let winner_row = best_changed.or(ancestor).unwrap_or(latest_tip);

--- a/crates/jazz-tools/src/row_histories/resolution.rs
+++ b/crates/jazz-tools/src/row_histories/resolution.rs
@@ -301,14 +301,9 @@ pub(super) fn build_computed_visible_preview(
         .collect::<HashMap<_, _>>();
     let ancestor = latest_common_ancestor(&frontier, &row_by_batch_id);
 
-    let ancestor_values = match ancestor {
-        Some(row) => flat_user_values(user_descriptor, &row.data)?,
-        None => user_descriptor
-            .columns
-            .iter()
-            .map(|_| Value::Null)
-            .collect(),
-    };
+    let ancestor_values = ancestor
+        .map(|row| flat_user_values(user_descriptor, &row.data))
+        .transpose()?;
     let frontier_values = frontier
         .iter()
         .map(|row| flat_user_values(user_descriptor, &row.data))
@@ -319,23 +314,35 @@ pub(super) fn build_computed_visible_preview(
     let mut winner_batch_ids = Vec::with_capacity(user_descriptor.columns.len());
 
     for column_index in 0..user_descriptor.columns.len() {
-        let ancestor_value = ancestor_values[column_index].clone();
+        let column = &user_descriptor.columns[column_index];
+        let ancestor_value = ancestor_values
+            .as_ref()
+            .map(|values| values[column_index].clone())
+            .unwrap_or(Value::Null);
         let changed_contenders = frontier
             .iter()
             .zip(frontier_values.iter())
             .filter_map(|(row, row_values)| {
                 let candidate_value = &row_values[column_index];
-                (candidate_value != &ancestor_value).then_some(ColumnContender {
+                let changed_from_ancestor = ancestor_values
+                    .as_ref()
+                    .map(|values| candidate_value != &values[column_index])
+                    .unwrap_or_else(|| {
+                        // With no common ancestor, Null is an explicit value,
+                        // not "unchanged from absence".
+                        !matches!(
+                            (column.merge_strategy, candidate_value),
+                            (Some(ColumnMergeStrategy::Counter), Value::Null)
+                        )
+                    });
+                changed_from_ancestor.then_some(ColumnContender {
                     row,
                     value: candidate_value,
                 })
             })
             .collect::<Vec<_>>();
-        let (best_value, best_changed) = merge_column_with_strategy(
-            &user_descriptor.columns[column_index],
-            &ancestor_value,
-            &changed_contenders,
-        )?;
+        let (best_value, best_changed) =
+            merge_column_with_strategy(column, &ancestor_value, &changed_contenders)?;
 
         merged_values.push(best_value);
         let winner_row = best_changed.or(ancestor).unwrap_or(latest_tip);

--- a/crates/jazz-tools/src/row_histories/resolution.rs
+++ b/crates/jazz-tools/src/row_histories/resolution.rs
@@ -328,8 +328,9 @@ pub(super) fn build_computed_visible_preview(
                     .as_ref()
                     .map(|values| candidate_value != &values[column_index])
                     .unwrap_or_else(|| {
-                        // With no common ancestor, Null is an explicit value,
-                        // not "unchanged from absence".
+                        // With no common ancestor, Null is an explicit value, not "unchanged from absence".
+                        // The only exception is counters: for counter merge logic, we don’t want a
+                        // missing/no-ancestor snapshot to look like a counter update of “null”.
                         !matches!(
                             (column.merge_strategy, candidate_value),
                             (Some(ColumnMergeStrategy::Counter), Value::Null)

--- a/crates/jazz-tools/src/runtime_core/tests.rs
+++ b/crates/jazz-tools/src/runtime_core/tests.rs
@@ -1845,6 +1845,10 @@ struct ThreeTierRC {
 
 fn create_3tier_rc() -> ThreeTierRC {
     let schema = test_schema();
+    create_3tier_rc_with_schema(schema)
+}
+
+fn create_3tier_rc_with_schema(schema: Schema) -> ThreeTierRC {
     let app_id = AppId::from_name("durability-test");
 
     // A = client (no tier)

--- a/crates/jazz-tools/src/runtime_core/tests/query_subscription.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/query_subscription.rs
@@ -216,6 +216,78 @@ fn rc_query_remote_tier_immediate_local_updates_survives_empty_remote_scope_snap
 }
 
 #[test]
+fn rc_query_synced_nullable_update_to_null_preserves_null_snapshot() {
+    let schema = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("todos")
+                .column("title", ColumnType::Text)
+                .column("done", ColumnType::Boolean)
+                .nullable_column("description", ColumnType::Text),
+        )
+        .build();
+    let mut s = create_3tier_rc_with_schema(schema);
+
+    let ((todo_id, _), _) =
+        s.a.insert(
+            "todos",
+            HashMap::from([
+                (
+                    "title".to_string(),
+                    Value::Text("nullable-description-repro".into()),
+                ),
+                ("done".to_string(), Value::Boolean(false)),
+                (
+                    "description".to_string(),
+                    Value::Text("server-original".into()),
+                ),
+            ]),
+            None,
+        )
+        .unwrap();
+    pump_3tier(&mut s);
+
+    let update_batch_id =
+        s.a.update(
+            todo_id,
+            vec![("description".to_string(), Value::Null)],
+            None,
+        )
+        .unwrap();
+
+    let mut future = s.a.query_with_propagation(
+        Query::new("todos"),
+        None,
+        ReadDurabilityOptions {
+            tier: Some(DurabilityTier::Local),
+            local_updates: crate::query_manager::manager::LocalUpdates::Immediate,
+        },
+        crate::sync_manager::QueryPropagation::Full,
+    );
+
+    let waker = noop_waker();
+    let mut cx = std::task::Context::from_waker(&waker);
+    assert!(
+        Pin::new(&mut future).poll(&mut cx).is_pending(),
+        "Full-propagation Local query should wait for the local server frontier"
+    );
+
+    pump_a_to_b(&mut s);
+    pump_b_to_a(&mut s);
+
+    match Pin::new(&mut future).poll(&mut cx) {
+        Poll::Ready(Ok(results)) => {
+            assert_eq!(results.len(), 1, "synced query should return the todo");
+            assert_eq!(results[0].0, todo_id);
+            assert_eq!(results[0].1[2], Value::Null);
+        }
+        Poll::Ready(Err(e)) => panic!("Query failed: {:?}", e),
+        Poll::Pending => {
+            panic!("Local query should resolve after server settlement for {update_batch_id:?}")
+        }
+    }
+}
+
+#[test]
 fn rc_query_local_transaction_overlay_shows_only_the_requested_staged_insert() {
     let mut core = create_runtime_with_schema(test_schema(), "query-local-transaction-overlay");
     let branch_name = core.schema_manager().branch_name();

--- a/crates/jazz-tools/src/runtime_core/tests/query_subscription.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/query_subscription.rs
@@ -216,7 +216,7 @@ fn rc_query_remote_tier_immediate_local_updates_survives_empty_remote_scope_snap
 }
 
 #[test]
-fn rc_query_synced_nullable_update_to_null_preserves_null_snapshot() {
+fn rc_query_synced_update_to_null_is_preserved() {
     let schema = SchemaBuilder::new()
         .table(
             TableSchema::builder("todos")
@@ -230,17 +230,11 @@ fn rc_query_synced_nullable_update_to_null_preserves_null_snapshot() {
     let ((todo_id, _), _) =
         s.a.insert(
             "todos",
-            HashMap::from([
-                (
-                    "title".to_string(),
-                    Value::Text("nullable-description-repro".into()),
-                ),
-                ("done".to_string(), Value::Boolean(false)),
-                (
-                    "description".to_string(),
-                    Value::Text("server-original".into()),
-                ),
-            ]),
+            crate::row_input!(
+                "title" => "nullable-description-repro",
+                "done" => false,
+                "description" => "server-original",
+            ),
             None,
         )
         .unwrap();

--- a/crates/jazz-tools/src/sync_manager/sync_logic.rs
+++ b/crates/jazz-tools/src/sync_manager/sync_logic.rs
@@ -279,18 +279,6 @@ impl SyncManager {
         row: StoredRowBatch,
         force_resend: bool,
     ) {
-        self.queue_row_to_client_internal(client_id, object_id, metadata, row, force_resend, true);
-    }
-
-    fn queue_row_to_client_internal(
-        &mut self,
-        client_id: ClientId,
-        object_id: ObjectId,
-        metadata: HashMap<String, String>,
-        row: StoredRowBatch,
-        force_resend: bool,
-        require_scope: bool,
-    ) {
         let row = Self::scope_delivery_row(row);
         if metadata
             .get(crate::metadata::MetadataKey::NoSync.as_str())
@@ -317,7 +305,7 @@ impl SyncManager {
             (in_scope, include_metadata, already_sent)
         };
 
-        if require_scope && !in_scope {
+        if !in_scope {
             return;
         }
 

--- a/packages/jazz-tools/src/runtime/napi.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.integration.test.ts
@@ -1,12 +1,13 @@
 import { randomUUID } from "node:crypto";
 import { mkdtemp, rm } from "node:fs/promises";
+import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { serializeRuntimeSchema } from "../drivers/schema-wire.js";
 import type { WasmSchema } from "../drivers/types.js";
-import type { Row } from "./client.js";
+import { type MutationErrorEvent, type Row } from "./client.js";
 import type { Db, QueryBuilder, TableProxy } from "./db.js";
 import { translateQuery } from "./query-adapter.js";
 import { loadCompiledSchema, type LoadedSchemaProject } from "../schema-loader.js";
@@ -546,6 +547,88 @@ describe("NAPI integration", () => {
         },
         { timeout: 20_000 },
       );
+    } finally {
+      if (context) {
+        await context.shutdown();
+      }
+      await settleAsyncSyncWork();
+      await cleanupTempRuntimeData(runtimeData);
+      await server.stop();
+    }
+  }, 60_000);
+
+  it("can update an optional row field to null", async () => {
+    const appId = randomUUID();
+    const backendSecret = "napi-null-update-secret";
+    const adminSecret = "napi-null-update-admin-secret";
+    let runtimeData: TempRuntimeData | null = null;
+    const server = await startLocalJazzServer({
+      appId,
+      backendSecret,
+      adminSecret,
+    });
+    let context: {
+      asBackend(): Db;
+      forSession(session: { user_id: string; claims: Record<string, unknown> }): Db;
+      shutdown(): Promise<void>;
+    } | null = null;
+
+    try {
+      const { createJazzContext } = await import("../backend/create-jazz-context.js");
+
+      await pushSchemaCatalogue({
+        serverUrl: server.url,
+        appId,
+        adminSecret,
+        schemaDir: TODO_SERVER_SCHEMA_DIR,
+        env: "test",
+        userBranch: "main",
+      });
+      const todoServerProject = await loadTodoServerProject();
+      const todoServerSchema = todoServerProject.wasmSchema;
+      const policyTodosTable = makePolicyTodosTable(todoServerSchema);
+
+      runtimeData = await createTempRuntimeData("jazz-napi-null-update-runtime-");
+      context = createJazzContext({
+        appId,
+        app: { wasmSchema: todoServerSchema },
+        permissions: todoServerProject.permissions ?? {},
+        driver: { type: "persistent", dataPath: runtimeData.dataPath },
+        serverUrl: server.url,
+        backendSecret,
+        env: "test",
+        userBranch: "main",
+      });
+      await settleAsyncSyncWork();
+
+      const aliceDb = context.forSession({
+        user_id: "alice",
+        claims: { role: "editor", team: "alpha" },
+      });
+
+      const createdTodo = await aliceDb
+        .insert(policyTodosTable, {
+          title: "nullable-description-repro",
+          done: false,
+          description: "server-original",
+          owner_id: "alice",
+        })
+        .wait({ tier: "edge" });
+
+      const nullUpdate = aliceDb.update(policyTodosTable, createdTodo.id, {
+        description: null,
+      } as unknown as Partial<PolicyTodoInit>);
+      await nullUpdate.wait({ tier: "local" });
+
+      const rowAfterUpdate = await aliceDb.one(
+        makePolicyTodoByIdQuery(todoServerSchema, createdTodo.id),
+        {
+          tier: "local",
+          localUpdates: "immediate",
+        },
+      );
+      expect(rowAfterUpdate).not.toBeNull();
+      expect(rowAfterUpdate?.description ?? null).toBeNull();
     } finally {
       if (context) {
         await context.shutdown();

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { createDb, Db, type QueryBuilder } from "../../src/runtime/db.js";
-import type { WasmSchema } from "../../src/drivers/types.js";
+import type { Schema, WasmSchema } from "../../src/drivers/types.js";
 import { generateAuthSecret } from "../../src/runtime/auth-secret-store.js";
 import {
   TestCleanup,
@@ -107,6 +107,17 @@ const noDeletePermissions = s.definePermissions(app, ({ policy }) => [
   policy.todos.allowUpdate.always(),
   policy.todos.allowDelete.never(),
 ]);
+
+const nullableSchema = {
+  todos: s.table({
+    title: s.string(),
+    done: s.boolean(),
+    description: s.string().optional(),
+  }),
+};
+
+type NullableSchema = s.Schema<typeof nullableSchema>;
+const nullableApp: s.App<NullableSchema> = s.defineApp(nullableSchema);
 
 interface WorkerMessageDebugEvent {
   atMs: number;
@@ -2030,6 +2041,41 @@ describe("Worker Bridge with OPFS", () => {
       "Reopened tab and current leader should converge after re-election",
     );
   });
+
+  it("can update an optional row field to null", async () => {
+    const syncServer = await publishSyncServerSchemaAndPermissions(
+      "null-update-repro",
+      undefined,
+      nullableApp.wasmSchema,
+    );
+    const sharedLocalAuthToken = generateAuthSecret();
+    const db = await createSyncedDb(
+      ctx,
+      "sync-null-update-repro",
+      sharedLocalAuthToken,
+      syncServer,
+    );
+
+    const inserted = db.insert(nullableApp.todos, {
+      title: "nullable-description-repro",
+      done: false,
+      description: "server-original",
+    });
+    const insertedTodo = inserted.value;
+    await inserted.wait({ tier: "local" });
+
+    const updateResult = db.update(nullableApp.todos, insertedTodo.id, {
+      description: null,
+    });
+    await updateResult.wait({ tier: "local" });
+
+    const rowAfterNullUpdate = await db.one(nullableApp.todos.where({ id: insertedTodo.id }), {
+      tier: "local",
+      localUpdates: "immediate",
+    });
+    expect(rowAfterNullUpdate).not.toBeNull();
+    expect(rowAfterNullUpdate?.description ?? null).toBeNull();
+  }, 60000);
 });
 
 // ---------------------------------------------------------------------------
@@ -2049,13 +2095,14 @@ async function waitForTodos(
 async function publishSyncServerSchemaAndPermissions(
   scope: string,
   permissions?: CompiledPermissions,
+  schema?: Schema,
 ): Promise<TestingServerInfo> {
   const testingServer = await getTestingServerInfo(uniqueDbName(`worker-bridge-${scope}`));
   const { appId, serverUrl, adminSecret } = testingServer;
   const { hash: schemaHash } = await publishStoredSchema(serverUrl, {
     appId,
     adminSecret,
-    schema: app.wasmSchema,
+    schema: schema ?? app.wasmSchema,
   });
   const { head } = await fetchPermissionsHead(serverUrl, { appId, adminSecret });
   const permissionsToPublish = permissions ?? {


### PR DESCRIPTION
## Description

A user reported an issue when updating optional fields to `null`. The update would be "lost", and the previous value preserved. If there were other intermediate updates, they would also be lost and the initial value would be visible instead.

I was able to repro this issue both in browser and napi integration tests, but not in single-DB setups (i.e. `update-api.test.ts` worked properly).

The problem was related to a combination of how row forwarding works across nodes, and the per-column merge strategy:
- for query-scope delivery we intentionally strip parents before sending visible rows to subscribers (see `scope_delivery_row`)
- the client then sees two parent-less visible rows (originally inserted row and updated row) with no common ancestor
- when there's no ancestor the "default" ancestor is a row with all fields set to `null` and, since the updated row also contains a null field, it's treated as if no change had been made.

The fix was to modify the merge strategy to consider the explicit `null` field as a new field.