### PR TITLE
Support broader query membership filters

### DIFF
--- a/.changeset/wide-in-operator-types.md
+++ b/.changeset/wide-in-operator-types.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Allow typed queries to use `in` filters on scalar and reference columns, and cover `contains` filters for non-text array element types.

--- a/packages/jazz-tools/src/runtime/query-adapter-tests/condition-translation.test.ts
+++ b/packages/jazz-tools/src/runtime/query-adapter-tests/condition-translation.test.ts
@@ -309,6 +309,61 @@ describe("condition translation", () => {
     });
   });
 
+  it("translates contains condition with non-text array element values", () => {
+    const reviewedAt = "2026-02-03T04:05:06.000Z";
+    const builderJson = JSON.stringify({
+      table: "todos",
+      conditions: [
+        { column: "checkpoints", op: "contains", value: 3 },
+        { column: "flags", op: "contains", value: true },
+        {
+          column: "reviewers",
+          op: "contains",
+          value: "00000000-0000-0000-0000-000000000123",
+        },
+        { column: "status_history", op: "contains", value: "done" },
+        { column: "reviewed_at", op: "contains", value: reviewedAt },
+      ],
+      includes: {},
+      orderBy: [],
+    });
+
+    const result = parseTranslatedQuery(builderJson, basicSchema);
+    expect(expectFilterPredicate(result)).toEqual({
+      type: "And",
+      exprs: [
+        {
+          type: "Contains",
+          left: { scope: "todos", column: "checkpoints" },
+          value: { type: "Literal", value: { Integer: 3 } },
+        },
+        {
+          type: "Contains",
+          left: { scope: "todos", column: "flags" },
+          value: { type: "Literal", value: { Boolean: true } },
+        },
+        {
+          type: "Contains",
+          left: { scope: "todos", column: "reviewers" },
+          value: {
+            type: "Literal",
+            value: { Uuid: "00000000-0000-0000-0000-000000000123" },
+          },
+        },
+        {
+          type: "Contains",
+          left: { scope: "todos", column: "status_history" },
+          value: { type: "Literal", value: { Text: "done" } },
+        },
+        {
+          type: "Contains",
+          left: { scope: "todos", column: "reviewed_at" },
+          value: { type: "Literal", value: { Timestamp: Date.parse(reviewedAt) } },
+        },
+      ],
+    });
+  });
+
   it("translates ne condition", () => {
     const builderJson = JSON.stringify({
       table: "todos",

--- a/packages/jazz-tools/src/runtime/query-adapter-tests/support.ts
+++ b/packages/jazz-tools/src/runtime/query-adapter-tests/support.ts
@@ -37,6 +37,34 @@ export const basicSchema: WasmSchema = {
         column_type: { type: "Array", element: { type: "Text" } },
         nullable: false,
       },
+      {
+        name: "checkpoints",
+        column_type: { type: "Array", element: { type: "Integer" } },
+        nullable: false,
+      },
+      {
+        name: "flags",
+        column_type: { type: "Array", element: { type: "Boolean" } },
+        nullable: false,
+      },
+      {
+        name: "reviewers",
+        column_type: { type: "Array", element: { type: "Uuid" } },
+        nullable: false,
+      },
+      {
+        name: "status_history",
+        column_type: {
+          type: "Array",
+          element: { type: "Enum", variants: ["done", "in_progress", "todo"] },
+        },
+        nullable: false,
+      },
+      {
+        name: "reviewed_at",
+        column_type: { type: "Array", element: { type: "Timestamp" } },
+        nullable: false,
+      },
       { name: "metadata", column_type: { type: "Json" }, nullable: true },
       { name: "created_at", column_type: { type: "Timestamp" }, nullable: true },
     ],

--- a/packages/jazz-tools/src/runtime/query-adapter.ts
+++ b/packages/jazz-tools/src/runtime/query-adapter.ts
@@ -363,7 +363,7 @@ function conditionToRelPredicate(
   }
   const valueTypeForCondition =
     cond.op === "contains" && columnType.type === "Array" ? columnType.element : columnType;
-  const rightLiteral =
+  const rightLiteral = () =>
     isFrontierRowIdToken(cond.value) && cond.op === "eq"
       ? { RowId: "Frontier" as const }
       : {
@@ -384,7 +384,7 @@ function conditionToRelPredicate(
       if (cond.value === null) {
         return { IsNull: { column: columnRef } };
       }
-      return { Cmp: { left: columnRef, op: "Eq", right: rightLiteral } };
+      return { Cmp: { left: columnRef, op: "Eq", right: rightLiteral() } };
     case "ne":
       if (cond.value === null) {
         return { IsNotNull: { column: columnRef } };
@@ -393,7 +393,7 @@ function conditionToRelPredicate(
         Cmp: {
           left: columnRef,
           op: "Ne",
-          right: rightLiteral,
+          right: rightLiteral(),
         },
       };
     case "gt":
@@ -401,7 +401,7 @@ function conditionToRelPredicate(
         Cmp: {
           left: columnRef,
           op: "Gt",
-          right: rightLiteral,
+          right: rightLiteral(),
         },
       };
     case "gte":
@@ -409,7 +409,7 @@ function conditionToRelPredicate(
         Cmp: {
           left: columnRef,
           op: "Ge",
-          right: rightLiteral,
+          right: rightLiteral(),
         },
       };
     case "lt":
@@ -417,7 +417,7 @@ function conditionToRelPredicate(
         Cmp: {
           left: columnRef,
           op: "Lt",
-          right: rightLiteral,
+          right: rightLiteral(),
         },
       };
     case "lte":
@@ -425,7 +425,7 @@ function conditionToRelPredicate(
         Cmp: {
           left: columnRef,
           op: "Le",
-          right: rightLiteral,
+          right: rightLiteral(),
         },
       };
     case "isNull":
@@ -434,7 +434,7 @@ function conditionToRelPredicate(
       }
       return isNullValue ? { IsNull: { column: columnRef } } : { IsNotNull: { column: columnRef } };
     case "contains":
-      return { Contains: { left: columnRef, right: rightLiteral } };
+      return { Contains: { left: columnRef, right: rightLiteral() } };
     case "in":
       if (!Array.isArray(cond.value)) {
         throw new Error('"in" operator requires an array value');

--- a/packages/jazz-tools/src/typed-app.ts
+++ b/packages/jazz-tools/src/typed-app.ts
@@ -240,6 +240,7 @@ type WhereEqNe<T, TOptional extends boolean, TExtra extends object = {}> =
   | ({
       eq?: MaybeNullableWhere<T, TOptional>;
       ne?: MaybeNullableWhere<T, TOptional>;
+      in?: T[];
     } & TExtra);
 type NumberWhere<T extends number, TOptional extends boolean> = WhereEqNe<
   T,
@@ -258,17 +259,13 @@ type TimestampWhere<TOptional extends boolean> = WhereEqNe<
 >;
 type UuidWhere<TOptional extends boolean, TRef extends string | undefined> = TRef extends string
   ? WhereEqNe<string, TOptional, TOptional extends true ? { isNull?: boolean } : {}>
-  : WhereEqNe<
-      string,
-      TOptional,
-      TOptional extends true ? { in?: string[]; isNull?: boolean } : { in?: string[] }
-    >;
+  : WhereEqNe<string, TOptional, TOptional extends true ? { isNull?: boolean } : {}>;
 
 type WhereInputForBuilder<TBuilder extends AnyTypedColumnBuilder> =
   ColumnBuilderSqlType<TBuilder> extends "TEXT"
     ? WhereEqNe<string, ColumnBuilderOptional<TBuilder>, { contains?: string }>
     : ColumnBuilderSqlType<TBuilder> extends "BOOLEAN"
-      ? boolean
+      ? WhereEqNe<boolean, ColumnBuilderOptional<TBuilder>>
       : ColumnBuilderSqlType<TBuilder> extends "INTEGER" | "REAL"
         ? NumberWhere<number, ColumnBuilderOptional<TBuilder>>
         : ColumnBuilderSqlType<TBuilder> extends "TIMESTAMP"

--- a/packages/jazz-tools/tests/ts-dsl/factories.ts
+++ b/packages/jazz-tools/tests/ts-dsl/factories.ts
@@ -20,6 +20,8 @@ export function insertTodo(db: Db, data: Partial<Todo>): Todo {
     title: data.title ?? "Test Todo",
     done: data.done ?? false,
     tags: data.tags ?? [],
+    checkpoints: data.checkpoints ?? [],
+    flags: data.flags ?? [],
     projectId: data.projectId ?? insertProject(db).id,
     ownerId: data.ownerId,
     assigneesIds: data.assigneesIds ?? [],

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/basic/schema.ts
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/basic/schema.ts
@@ -23,6 +23,8 @@ export const schema = {
       title: s.string(),
       done: s.boolean().default(false),
       tags: s.array(s.string()).default([]),
+      checkpoints: s.array(s.int()).default([]),
+      flags: s.array(s.boolean()).default([]),
       projectId: s.ref("projects"),
       ownerId: s.ref("users").optional(),
       assigneesIds: s.array(s.ref("users")).default([]),

--- a/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
@@ -41,6 +41,42 @@ describe("TS Query API", () => {
       expect(results[0]!.name).toBe("Project A");
     });
 
+    it("filters scalar and reference columns with in lists", async () => {
+      const launchProject = insertProject(db, "Launch");
+      const archiveProject = insertProject(db, "Archive");
+      const alice = insertUser(db, "Alice");
+      const bob = insertUser(db, "Bob");
+      const writePlan = insertTodo(db, {
+        title: "Write launch plan",
+        done: false,
+        projectId: launchProject.id,
+        ownerId: alice.id,
+      });
+      const reviewPlan = insertTodo(db, {
+        title: "Review launch plan",
+        done: true,
+        projectId: launchProject.id,
+        ownerId: bob.id,
+      });
+      insertTodo(db, {
+        title: "Archive launch notes",
+        done: true,
+        projectId: archiveProject.id,
+        ownerId: alice.id,
+      });
+
+      const results = await db.all(
+        app.todos.where({
+          title: { in: ["Write launch plan", "Review launch plan"] },
+          done: { in: [false, true] },
+          projectId: { in: [launchProject.id] },
+          ownerId: { in: [alice.id, bob.id] },
+        }),
+      );
+
+      expect(results.map((todo) => todo.id)).toEqual([writePlan.id, reviewPlan.id]);
+    });
+
     it("filters nullable columns with isNull:true", async () => {
       const todoWithoutOwner = insertTodo(db, {
         title: "Todo without owner",
@@ -140,6 +176,40 @@ describe("TS Query API", () => {
         expect(todosWithTags.length).toBe(2);
         expect(todosWithTags).toContainEqual(expect.objectContaining({ id: id1 }));
         expect(todosWithTags).toContainEqual(expect.objectContaining({ id: id3 }));
+      });
+
+      it("using contains with number, boolean, and ref array elements", async () => {
+        const alice = insertUser(db, "Alice");
+        const bob = insertUser(db, "Bob");
+        const { id: id1 } = insertTodo(db, {
+          title: "Todo 1",
+          checkpoints: [1, 3],
+          flags: [false],
+          assigneesIds: [alice.id],
+        });
+        const { id: id2 } = insertTodo(db, {
+          title: "Todo 2",
+          checkpoints: [2, 3],
+          flags: [true],
+          assigneesIds: [alice.id, bob.id],
+        });
+        insertTodo(db, {
+          title: "Todo 3",
+          checkpoints: [5],
+          flags: [false],
+          assigneesIds: [bob.id],
+        });
+
+        const todosWithCheckpoint = await db.all(app.todos.where({ checkpoints: { contains: 3 } }));
+        expect(todosWithCheckpoint.map((todo) => todo.id)).toEqual([id1, id2]);
+
+        const todosWithFlag = await db.all(app.todos.where({ flags: { contains: true } }));
+        expect(todosWithFlag.map((todo) => todo.id)).toEqual([id2]);
+
+        const todosAssignedToAlice = await db.all(
+          app.todos.where({ assigneesIds: { contains: alice.id } }),
+        );
+        expect(todosAssignedToAlice.map((todo) => todo.id)).toEqual([id1, id2]);
       });
     });
   });
@@ -483,6 +553,8 @@ describe("TS Query API", () => {
         title: "Write tests",
         done: false,
         tags: ["dev"],
+        checkpoints: [],
+        flags: [],
         projectId,
         ownerId,
         assigneesIds: [],
@@ -585,6 +657,8 @@ describe("TS Query API", () => {
         title: "Draft docs",
         done: false,
         tags: ["dev"],
+        checkpoints: [],
+        flags: [],
         projectId,
         ownerId: null,
         assigneesIds: [],

--- a/packages/jazz-tools/tests/ts-dsl/typed-app.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/typed-app.test.ts
@@ -25,8 +25,11 @@ const schema = {
       title: s.string(),
       done: s.boolean(),
       tags: s.array(s.string()),
+      checkpoints: s.array(s.int()),
+      flags: s.array(s.boolean()),
       project: s.ref("projects"),
       owner: s.ref("users").optional(),
+      assigneeIds: s.array(s.ref("users")),
     })
     .index("by_done", ["done"]),
 };
@@ -276,13 +279,33 @@ describe("typed app prototype", () => {
     expectTypeOf(todoInsert.owner).toEqualTypeOf<string | null | undefined>();
 
     expectTypeOf<TodoWhere["project"]>().toEqualTypeOf<
-      string | { eq?: string; ne?: string } | undefined
+      string | { eq?: string; ne?: string; in?: string[] } | undefined
     >();
     expectTypeOf<TodoWhere["owner"]>().branded.toEqualTypeOf<
-      string | null | { eq?: string | null; ne?: string | null; isNull?: boolean } | undefined
+      | string
+      | null
+      | { eq?: string | null; ne?: string | null; in?: string[]; isNull?: boolean }
+      | undefined
     >();
     expectTypeOf<TodoWhere["tags"]>().branded.toEqualTypeOf<
-      string[] | { eq?: string[]; ne?: string[]; contains?: string } | undefined
+      string[] | { eq?: string[]; ne?: string[]; in?: string[][]; contains?: string } | undefined
+    >();
+    expectTypeOf<TodoWhere["checkpoints"]>().branded.toEqualTypeOf<
+      number[] | { eq?: number[]; ne?: number[]; in?: number[][]; contains?: number } | undefined
+    >();
+    expectTypeOf<TodoWhere["flags"]>().branded.toEqualTypeOf<
+      | boolean[]
+      | { eq?: boolean[]; ne?: boolean[]; in?: boolean[][]; contains?: boolean }
+      | undefined
+    >();
+    expectTypeOf<TodoWhere["assigneeIds"]>().branded.toEqualTypeOf<
+      string[] | { eq?: string[]; ne?: string[]; in?: string[][]; contains?: string } | undefined
+    >();
+    expectTypeOf<TodoWhere["title"]>().branded.toEqualTypeOf<
+      string | { eq?: string; ne?: string; in?: string[]; contains?: string } | undefined
+    >();
+    expectTypeOf<TodoWhere["done"]>().branded.toEqualTypeOf<
+      boolean | { eq?: boolean; ne?: boolean; in?: boolean[] } | undefined
     >();
 
     const projectRecord: ProjectRecord | null = todoWithProject.project;
@@ -393,6 +416,7 @@ describe("typed app prototype", () => {
           gte?: number;
           lt?: number;
           lte?: number;
+          in?: number[];
         }
       | undefined
     >();


### PR DESCRIPTION
## What changed

- Added a patch changeset for `jazz-tools`.
- Widened typed query `where` inputs so `in` works on scalar and reference columns, not only row ids.
- Fixed query translation so scalar `in` lists are converted element-by-element instead of being treated as one scalar array literal.
- Added coverage for array-column `contains` with non-text element types: numbers, booleans, refs/UUIDs, enums, and timestamps.
- Added TS DSL coverage for text, boolean, required refs, nullable refs, array-column `in`, transformed numeric where inputs, and non-text array `contains` filters.

## Why

The query runtime already had general membership predicate shapes, but the typed TS query surface and tests only proved a narrow subset. This makes the public DSL match the relational behavior for easy scalar/reference `in` cases and confirms literal-in-array-column `contains` behavior across the scalar element types that the runtime already supports.

## Validation

- `pnpm lint`
- `pnpm --filter jazz-tools exec tsc --project tsconfig.tests.json --noEmit`
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts tests/ts-dsl/typed-app.test.ts tests/ts-dsl/query-api.test.ts src/runtime/query-adapter-tests/condition-translation.test.ts`
- `pnpm --filter jazz-wasm run build`