### PR TITLE
Drop fetch polyfill from jazz-tools/expo

### DIFF
--- a/.changeset/drop-expo-fetch-polyfill.md
+++ b/.changeset/drop-expo-fetch-polyfill.md
@@ -1,0 +1,9 @@
+---
+"jazz-tools": patch
+---
+
+Drop the `fetch` polyfill from `jazz-tools/expo`.
+
+Nothing in jazz-tools consumes a streaming `response.body`, sync runs over WebSocket, and every fetch call site uses buffered methods like `.json()`/`.text()`. The `expo/fetch` swap (and its accompanying `fetchSpecCompliant` URL/Request coercion) was working around `expo/fetch`'s string-only native bridge, but with `expo/fetch` gone, RN's default fetch — which is `whatwg-fetch` under the hood — already accepts URL and Request inputs natively. Better-auth's URL-input path therefore works without the wrapper.
+
+The `ReadableStream` polyfill stays — it's still consumed by `runtime/file-storage.ts` for the chunked-file API, which Hermes can't service without it.

--- a/packages/jazz-tools/src/expo/polyfills.ts
+++ b/packages/jazz-tools/src/expo/polyfills.ts
@@ -1,31 +1,9 @@
 /// <reference path="./vendor.d.ts" />
 
 import { polyfillGlobal } from "react-native/Libraries/Utilities/PolyfillFunctions";
-import { fetch as expoFetch } from "expo/fetch";
 
 import { ReadableStream as PonyfillReadableStream } from "web-streams-polyfill";
 
 const readableStreamCtor = globalThis.ReadableStream ?? PonyfillReadableStream;
 
-// expo/fetch's native bridge only accepts a string for `input`, but the
-// WHATWG fetch spec also accepts URL and Request. Normalise here so callers
-// that pass a URL object (e.g. better-auth's client) don't blow up with
-// "The 2nd argument cannot be cast to type URL" inside the native bridge.
-const fetchSpecCompliant: typeof globalThis.fetch = async (input, init) => {
-  if (typeof input === "string") return expoFetch(input, init);
-  if (input instanceof URL) return expoFetch(input.toString(), init);
-  const req = input as Request;
-  const body = req.body ? await req.arrayBuffer() : undefined;
-  return expoFetch(req.url, {
-    method: req.method,
-    headers: req.headers,
-    credentials: req.credentials,
-    redirect: req.redirect,
-    signal: req.signal,
-    body,
-    ...init,
-  });
-};
-
-polyfillGlobal("fetch", () => fetchSpecCompliant);
 polyfillGlobal("ReadableStream", () => readableStreamCtor);

--- a/packages/jazz-tools/src/expo/vendor.d.ts
+++ b/packages/jazz-tools/src/expo/vendor.d.ts
@@ -5,16 +5,6 @@ declare module "react-native/Libraries/Utilities/PolyfillFunctions" {
   export function polyfillGlobal(name: string, getValue: () => unknown): void;
 }
 
-declare module "react-native/Libraries/Network/fetch" {
-  export const Headers: typeof globalThis.Headers | undefined;
-  export const Request: typeof globalThis.Request | undefined;
-  export const Response: typeof globalThis.Response | undefined;
-}
-
-declare module "expo/fetch" {
-  export const fetch: typeof globalThis.fetch;
-}
-
 declare module "web-streams-polyfill" {
   export const ReadableStream: typeof globalThis.ReadableStream;
 }


### PR DESCRIPTION
Follow-up to #802.

## Summary
- Removed `polyfillGlobal("fetch", ...)`, the `fetchSpecCompliant` URL/Request coercion, and the `expo/fetch` import. RN's default fetch (`whatwg-fetch` under the hood) already accepts URL and Request inputs per the WHATWG spec, so better-auth's URL-input path keeps working without the wrapper.
- `expo/fetch` was originally swapped in for streamable response bodies, but nothing in jazz-tools consumes `response.body` as a stream — sync runs over the Rust WebSocket transport, and every `fetch()` call site uses buffered methods (`.json()`, `.text()`).
- Cleaned up the now-unused `expo/fetch` and `react-native/Libraries/Network/fetch` ambients in `vendor.d.ts`.
- `ReadableStream` polyfill stays — `runtime/file-storage.ts` constructs `new ReadableStream(...)` for the chunked-file API, which Hermes can't service.

## Test plan
- [ ] `pnpm --filter jazz-tools test src/better-auth-adapter` still passes.
- [ ] In an Expo app, a better-auth round-trip (URL input) completes without "The 2nd argument cannot be cast to type URL" or any other native-bridge error — i.e. RN's default fetch genuinely handles URL inputs in Hermes.
- [ ] In an Expo app, the file-storage API (`db.fileFromStream` / `db.fileToStream`) still works — `ReadableStream` global is intact.
- [ ] Existing Expo todo example still syncs end-to-end.