### PR TITLE
fix: preserve sync auth_mode

### DIFF
--- a/.changeset/fix-query-subscription-auth-mode.md
+++ b/.changeset/fix-query-subscription-auth-mode.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix query subscription sync by preserving local-first auth mode through binary payloads.

--- a/crates/jazz-tools/src/sync_manager/types.rs
+++ b/crates/jazz-tools/src/sync_manager/types.rs
@@ -355,13 +355,14 @@ impl ConnectionSchemaDiagnostics {
 /// postcard does not support the dynamic deserialization style it expects (deserialize_any)
 /// so we need a custom serializer/deserializer to serialize/deserialize the claims as a string.
 mod query_subscription_session_serde {
-    use super::Session;
+    use crate::query_manager::session::{AuthMode, Session};
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     struct SessionWire {
         user_id: String,
         claims_json: String,
+        auth_mode: AuthMode,
     }
 
     pub fn serialize<S>(value: &Option<Session>, serializer: S) -> Result<S::Ok, S::Error>
@@ -380,6 +381,7 @@ mod query_subscription_session_serde {
                 Ok(SessionWire {
                     user_id: session.user_id.clone(),
                     claims_json,
+                    auth_mode: session.auth_mode,
                 })
             })
             .transpose()?;
@@ -402,7 +404,7 @@ mod query_subscription_session_serde {
             Ok(Session {
                 user_id: session_wire.user_id,
                 claims,
-                auth_mode: Default::default(),
+                auth_mode: session_wire.auth_mode,
             })
         })
         .transpose()
@@ -568,4 +570,32 @@ pub struct PendingPermissionCheck {
     pub new_content: Option<Vec<u8>>,
     /// Inferred operation type.
     pub operation: Operation,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query_manager::session::AuthMode;
+
+    #[test]
+    fn query_subscription_postcard_roundtrip_preserves_session_auth_mode() {
+        let payload = SyncPayload::QuerySubscription {
+            query_id: QueryId(7),
+            query: Box::new(Query::new("todos")),
+            session: Some(Session::new("alice").with_auth_mode(AuthMode::LocalFirst)),
+            propagation: QueryPropagation::Full,
+            policy_context_tables: Vec::new(),
+        };
+
+        let bytes = payload.to_bytes().expect("encode payload");
+        let decoded = SyncPayload::from_bytes(&bytes).expect("decode payload");
+
+        match decoded {
+            SyncPayload::QuerySubscription {
+                session: Some(session),
+                ..
+            } => assert_eq!(session.auth_mode, AuthMode::LocalFirst),
+            other => panic!("expected QuerySubscription with session, got {other:?}"),
+        }
+    }
 }

--- a/dev/stress-tests/todo-react/package.json
+++ b/dev/stress-tests/todo-react/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --port 5477",
-    "build": "node ../../packages/jazz-tools/dist/cli.js validate && vite build",
+    "build": "node ../../../packages/jazz-tools/dist/cli.js validate && vite build",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/dev/stress-tests/todo-react/permissions.ts
+++ b/dev/stress-tests/todo-react/permissions.ts
@@ -2,6 +2,11 @@ import { definePermissions } from "jazz-tools/permissions";
 import { app } from "./schema";
 
 export default definePermissions(app, ({ policy, session }) => {
+  policy.projects.allowRead.always();
+  policy.projects.allowInsert.always();
+  policy.projects.allowUpdate.always();
+  policy.projects.allowDelete.always();
+
   policy.todos.allowRead.always();
   policy.todos.allowInsert.always();
   policy.todos.allowUpdate.always();


### PR DESCRIPTION
## Summary

- Preserve `Session.auth_mode` when `QuerySubscription` payloads are encoded through postcard.
- Add explicit `projects` table policies for the todo-react stress test.
- Fix the todo-react stress test build script path to the workspace `jazz-tools` CLI.
- Add a patch changeset for the `jazz-tools` library fix.

## Investigation

Traces from `dev/stress-tests/todo-react` showed local-first browser sessions reaching the sync boundary, but the binary `QuerySubscription` hop decoded them as `auth_mode = External`. The custom postcard session wire format only carried `user_id` and serialized claims JSON, so deserialization rebuilt the session with the default auth mode.

After fixing that, fresh stress-test traces still showed rejected project inserts: `Insert denied on table projects - missing explicit policy`. The app generates `projects` first and then creates todos linked to those projects, but `permissions.ts` only defined policies for `todos`.

## Why This Fix Is The Right One

The session fix stores `auth_mode` in the existing binary-only `SessionWire` format, beside the other session fields. That keeps human-readable serde unchanged while making the postcard roundtrip preserve the full session contract. The regression test checks the observable behavior directly: a local-first query subscription comes back local-first after binary encode/decode.

The permission fix makes the generated data match the app's declared policy surface. Since todo-react really does create and read projects, granting explicit project CRUD policies is clearer than relying on todo policies or changing the generator.

The build-script fix corrects the relative path from the package that owns the script, so `pnpm --filter stress-test-todo-react build` validates the schema the same way a developer or CI command would.