### PR TITLE
Fix OPFS coalesced reads past persisted file length

### DIFF
--- a/.changeset/fix-opfs-coalesced-eof.md
+++ b/.changeset/fix-opfs-coalesced-eof.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix OPFS-backed storage reads so coalesced disk reads stop at the current file length instead of reading past EOF after uncheckpointed growth.

--- a/crates/opfs-btree/src/db.rs
+++ b/crates/opfs-btree/src/db.rs
@@ -1049,8 +1049,17 @@ impl<F: SyncFile> OpfsBTree<F> {
             )));
         }
 
+        let file_pages = self.file.len()? / self.options.page_size as u64;
+        let readable_pages = self.total_pages.min(file_pages);
+        if page_id >= readable_pages {
+            return Err(BTreeError::Corrupt(format!(
+                "page id {} out of bounds for persisted pages {}",
+                page_id, readable_pages
+            )));
+        }
+
         let run_pages =
-            (self.total_pages - page_id).min(self.options.read_coalesce_pages as u64) as usize;
+            (readable_pages - page_id).min(self.options.read_coalesce_pages as u64) as usize;
         let run_bytes = run_pages
             .checked_mul(self.options.page_size)
             .ok_or_else(|| BTreeError::Io("read run size overflow".to_string()))?;
@@ -2175,6 +2184,33 @@ mod tests {
             coalesced_reads,
             baseline_reads
         );
+    }
+
+    #[test]
+    fn coalesced_read_stops_at_file_len_after_uncheckpointed_growth() {
+        let file = MemoryFile::new();
+        let mut options = small_options();
+        options.read_coalesce_pages = 4;
+        let mut tree = OpfsBTree::open(file.clone(), options).expect("open tree");
+
+        tree.put(b"alice", b"first").expect("put");
+        tree.checkpoint().expect("checkpoint");
+
+        let root_page_id = tree.root_page_id.expect("root page");
+        assert_eq!(
+            file.len().expect("file len") / options.page_size as u64,
+            tree.total_pages,
+            "checkpoint should extend the file through total_pages"
+        );
+
+        for _ in 0..3 {
+            let _ = tree.alloc_page();
+        }
+        tree.remove_page(root_page_id);
+
+        tree.ensure_page_loaded(root_page_id)
+            .expect("coalesced read should not cross the persisted file length");
+        assert!(tree.pages.contains_key(&root_page_id));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Cap OPFS coalesced page reads to pages that actually exist in the persisted file.
- Add a regression test for coalesced reads after in-memory page growth that has not been checkpointed yet.

## Investigation

The browser stress driver showed repeated index-update failures while generating todo-react stress data:

`index error: opfs-btree: io error: unexpected eof: read 16384 of 65536 bytes`

Clearing browser OPFS storage did not remove the problem. A clean run still produced thousands of fresh `failed to update indices for synced insert` errors, so this was not stale local data.

The failing read size was the key clue. OPFS uses 16 KiB pages, and the read tried to coalesce four pages into a 64 KiB read. The tree's `total_pages` can grow in memory as writes allocate new pages before the next checkpoint extends the file on disk. `read_page_run_from_disk` used `total_pages` to decide how many pages to read, so it could ask OPFS for pages that were valid in memory but not yet persisted. The browser correctly returned a short read, which surfaced as `unexpected eof`.

## Why This Fix Is The Right One

The fix keeps coalesced reads, but caps their run length with the current file length. That preserves the optimization when pages are actually on disk and prevents reads from crossing into not-yet-persisted pages.

This is better than disabling coalescing because the issue is not coalescing itself; the issue is choosing the upper bound from in-memory `total_pages` instead of the persisted file. It is also better than treating short reads as empty pages, because reading a page that does not exist on disk should not fabricate storage state.

The regression test recreates the exact shape of the bug: checkpoint a page, grow `total_pages` in memory without checkpointing, evict the persisted page, then reload it with coalescing enabled. Before the fix this failed with an EOF; after the fix it reads only the persisted page range.

## Validation

- `cargo test -p opfs-btree coalesced_read_stops_at_file_len_after_uncheckpointed_growth`
- `cargo test -p opfs-btree`
- Browser stress drive after OPFS reset: `eofCount=0`, `indexCount=0`