### PR TITLE
ci: run Expo Android E2E on main and RN-impacting PRs

### DIFF
--- a/.github/workflows/expo-android-maestro-e2e.yml
+++ b/.github/workflows/expo-android-maestro-e2e.yml
@@ -4,18 +4,13 @@ on:
   workflow_dispatch:
   push:
     branches:
+      - main
       - changeset-release/*
   pull_request:
     branches: [main]
     paths:
-      - crates/**
-      - packages/jazz-tools/**
-      - examples/todo-client-localfirst-expo/**
-      - Cargo.toml
-      - Cargo.lock
-      - pnpm-lock.yaml
-      - pnpm-workspace.yaml
-      - turbo.json
+      - crates/jazz-rn/**
+      - packages/jazz-tools/src/react-native/**
       - .github/workflows/expo-android-maestro-e2e.yml
 
 concurrency:
@@ -28,7 +23,6 @@ permissions:
 jobs:
   build-rn:
     name: Build jazz-rn (Android) artifacts
-    if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'changeset-release/') }}
     uses: ./.github/workflows/rn-build-reusable.yml
     with:
       concurrency: e2e-rn-test
@@ -37,7 +31,6 @@ jobs:
 
   build-jazz-tools-sandbox:
     name: Build jazz-tools sandbox binary (${{ matrix.target }})
-    if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'changeset-release/') }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     strategy:
@@ -84,7 +77,6 @@ jobs:
 
   expo-android-e2e:
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'changeset-release/') }}
     needs:
       - build-rn
       - build-jazz-tools-sandbox


### PR DESCRIPTION
## Summary
- Trigger the Expo Android Maestro E2E on every push to `main` so post-merge regressions surface without waiting for a changeset-release cut.
- Run on PRs to `main` whenever `crates/jazz-rn/**` or `packages/jazz-tools/src/react-native/**` change (plus the workflow file itself).
- Drop the per-job `changeset-release/*` `if:` gate; PR scoping is now handled by the workflow-level `paths:` filter.

## When it runs

| Event | Condition |
|---|---|
| Manual | Anyone clicks "Run workflow" (`workflow_dispatch`) |
| Push to `main` | Every commit (no path filter) — so every PR merge |
| Push to `changeset-release/*` | Every commit on those branches (no path filter) |
| PR targeting `main` | Only when the diff touches `crates/jazz-rn/**`, `packages/jazz-tools/src/react-native/**`, or `.github/workflows/expo-android-maestro-e2e.yml` |

It does **not** run on:
- Push to feature branches (no PR open)
- PRs to non-`main` branches
- PRs that don't touch the three RN-related path patterns

Concurrency: a new run on the same `ref` (or same SHA on push) cancels the previous in-progress run.

## Test plan
- [ ] PR build itself triggers (this PR touches the workflow file).
- [ ] After merge, push-to-main triggers a run on the merge commit.
- [ ] PRs that touch only unrelated code (e.g. docs, web packages) do not trigger this workflow.
- [ ] Existing `changeset-release/*` push runs still fire (no path filter on push).