### PR TITLE
Fix browser benchmark CMake setup

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -235,6 +235,12 @@ jobs:
 
       - run: corepack enable
       - run: pnpm install --frozen-lockfile
+      - name: Install CMake
+        run: |
+          if ! command -v cmake >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y cmake
+          fi
       - run: pnpm --filter jazz-napi build
       - run: pnpm exec playwright install chromium
 


### PR DESCRIPTION
## Root Cause

The browser benchmark job builds `jazz-napi`, which now pulls in `libmimalloc-sys2`. That crate runs CMake during its build, but the self-hosted benchmark runner did not guarantee CMake was installed.
