### PR TITLE
feat: batches can read their own writes and be rolled back

### DIFF
--- a/.changeset/batch-rollback-and-reads.md
+++ b/.changeset/batch-rollback-and-reads.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Add rollback and scoped read support to explicit batches. `DirectBatch`/`DbDirectBatch` now expose `rollback()`, and batch handles can read their own local writes before commit through `DirectBatch.query(...)` and `DbDirectBatch.all(...)`/`one(...)`.

--- a/docs/content/docs/writing/writing-data.mdx
+++ b/docs/content/docs/writing/writing-data.mdx
@@ -10,7 +10,6 @@ All writes execute against the local database first. `insert`, `update`, and `de
 
 Jazz also allows grouping writes together using [batches and transactions](#transactions-and-batches).
 Writes made through an open transaction or batch are not individually waitable. Call `.wait({ tier })` on the returned write result instead.
-Call `rollback()` on an open transaction if you want to close that transaction handle without committing it.
 
 <Callout type="info">
 For browser `Blob`, `File`, or `ReadableStream` uploads, use `db.createFileFromBlob(...)`
@@ -180,10 +179,7 @@ console.log(result.batchId);
 The changes made as part of the transaction are scoped to it, and will only be
 globally visible once it's committed and accepted by the authority.
 
-`DbTransaction` can read its own staged state through `all(...)` and `one(...)` before commit.
-
-You can also use batches when you want to group several ordinary writes under one batch id, but still want them
-to be locally visible immediately:
+You can also use batches when you want to group several ordinary writes and commit them together:
 
 ```ts
 const result = db.batch((batch) => {
@@ -194,8 +190,10 @@ await result.wait({ tier: "edge" });
 console.log(result.batchId);
 ```
 
+Transactions and batches can read its own local writes through `all(...)` and `one(...)` before commit.
+
 When using `transaction` and `batch`, changes are automatically committed once the callback finishes running and,
-in the case of transactions, if an error is thrown inside the callback, the whole transaction will be rolled back.
+if an error is thrown inside the callback, the open transaction or batch is rolled back instead of committed.
 
 Alternatively, you can use `beginTransaction` and `beginBatch` to get a transaction or batch object, respectively.
 This can be useful when making writes across multiple contexts. In this case however, you need to commit or rollback

--- a/packages/jazz-tools/src/runtime/client.test.ts
+++ b/packages/jazz-tools/src/runtime/client.test.ts
@@ -302,20 +302,16 @@ describe("JazzClient runtime schema caching", () => {
 });
 
 describe("JazzClient transactions", () => {
-  it("returns a write handle from commit so callers can wait on the batch", async () => {
+  it("returns a completed write handle when committing an empty transaction", async () => {
     const runtime = makeFakeRuntime();
     const client = JazzClient.connectWithRuntime(runtime as any, makeContext());
-    const waitForPersistedBatch = vi
-      .spyOn(client, "waitForPersistedBatch")
-      .mockResolvedValue(undefined);
 
     const committed = client.beginTransaction().commit();
 
-    expect(runtime.sealBatch).toHaveBeenCalledTimes(1);
+    expect(runtime.sealBatch).not.toHaveBeenCalled();
     expect(committed).toBeInstanceOf(WriteHandle);
     expect(committed.batchId).toBeDefined();
     await expect(committed.wait({ tier: "edge" })).resolves.toBeUndefined();
-    expect(waitForPersistedBatch).toHaveBeenCalledWith(committed.batchId, "edge");
   });
 
   it("rolls back an open transaction without sealing the batch", () => {
@@ -350,20 +346,16 @@ describe("JazzClient transactions", () => {
     expect(() => tx.commit()).toThrow(/committed/i);
   });
 
-  it("returns a write handle from batch commit so callers can wait on the batch", async () => {
+  it("returns a completed write handle when committing an empty batch", async () => {
     const runtime = makeFakeRuntime();
     const client = JazzClient.connectWithRuntime(runtime as any, makeContext());
-    const waitForPersistedBatch = vi
-      .spyOn(client, "waitForPersistedBatch")
-      .mockResolvedValue(undefined);
 
     const committed = client.beginBatch().commit();
 
-    expect(runtime.sealBatch).toHaveBeenCalledTimes(1);
+    expect(runtime.sealBatch).not.toHaveBeenCalled();
     expect(committed).toBeInstanceOf(WriteHandle);
     expect(committed.batchId).toBeDefined();
     await expect(committed.wait({ tier: "edge" })).resolves.toBeUndefined();
-    expect(waitForPersistedBatch).toHaveBeenCalledWith(committed.batchId, "edge");
   });
 
   it("rolls back an open batch without sealing the batch", () => {
@@ -416,33 +408,26 @@ describe("JazzClient transactions", () => {
     });
   });
 
-  it("commits a sync callback transaction and returns the callback result handle", async () => {
+  it("completes an empty sync callback transaction and returns the callback result handle", async () => {
     const runtime = makeFakeRuntime();
     const client = JazzClient.connectWithRuntime(runtime as any, makeContext());
-    const waitForPersistedBatch = vi
-      .spyOn(client, "waitForPersistedBatch")
-      .mockResolvedValue(undefined);
 
     const handle = client.transaction(() => {
       return { title: "Callback transaction" };
     });
 
     expect(handle).not.toBeInstanceOf(Promise);
-    expect(runtime.sealBatch).toHaveBeenCalledTimes(1);
+    expect(runtime.sealBatch).not.toHaveBeenCalled();
     expect(handle).toBeInstanceOf(WriteResult);
     expect(handle.value).toEqual({ title: "Callback transaction" });
     await expect(handle.wait({ tier: "global" })).resolves.toEqual({
       title: "Callback transaction",
     });
-    expect(waitForPersistedBatch).toHaveBeenCalledWith(handle.batchId, "global");
   });
 
-  it("commits an async callback transaction after the callback resolves", async () => {
+  it("completes an empty async callback transaction after the callback resolves", async () => {
     const runtime = makeFakeRuntime();
     const client = JazzClient.connectWithRuntime(runtime as any, makeContext());
-    const waitForPersistedBatch = vi
-      .spyOn(client, "waitForPersistedBatch")
-      .mockResolvedValue(undefined);
 
     const handlePromise = client.transaction(async () => {
       expect(runtime.sealBatch).not.toHaveBeenCalled();
@@ -451,42 +436,34 @@ describe("JazzClient transactions", () => {
 
     expect(handlePromise).toBeInstanceOf(Promise);
     const handle = await handlePromise;
-    expect(runtime.sealBatch).toHaveBeenCalledTimes(1);
+    expect(runtime.sealBatch).not.toHaveBeenCalled();
     expect(handle).toBeInstanceOf(WriteResult);
     expect(handle.value).toEqual({ title: "Async callback transaction" });
     await expect(handle.wait({ tier: "global" })).resolves.toEqual({
       title: "Async callback transaction",
     });
-    expect(waitForPersistedBatch).toHaveBeenCalledWith(handle.batchId, "global");
   });
 
-  it("commits a sync callback batch and returns the callback result handle", async () => {
+  it("completes an empty sync callback batch and returns the callback result handle", async () => {
     const runtime = makeFakeRuntime();
     const client = JazzClient.connectWithRuntime(runtime as any, makeContext());
-    const waitForPersistedBatch = vi
-      .spyOn(client, "waitForPersistedBatch")
-      .mockResolvedValue(undefined);
 
     const handle = client.batch(() => {
       return { title: "Callback batch" };
     });
 
     expect(handle).not.toBeInstanceOf(Promise);
-    expect(runtime.sealBatch).toHaveBeenCalledTimes(1);
+    expect(runtime.sealBatch).not.toHaveBeenCalled();
     expect(handle).toBeInstanceOf(WriteResult);
     expect(handle.value).toEqual({ title: "Callback batch" });
     await expect(handle.wait({ tier: "edge" })).resolves.toEqual({
       title: "Callback batch",
     });
-    expect(waitForPersistedBatch).toHaveBeenCalledWith(handle.batchId, "edge");
   });
 
-  it("commits an async callback batch after the callback resolves", async () => {
+  it("completes an empty async callback batch after the callback resolves", async () => {
     const runtime = makeFakeRuntime();
     const client = JazzClient.connectWithRuntime(runtime as any, makeContext());
-    const waitForPersistedBatch = vi
-      .spyOn(client, "waitForPersistedBatch")
-      .mockResolvedValue(undefined);
 
     const handlePromise = client.batch(async () => {
       expect(runtime.sealBatch).not.toHaveBeenCalled();
@@ -495,13 +472,12 @@ describe("JazzClient transactions", () => {
 
     expect(handlePromise).toBeInstanceOf(Promise);
     const handle = await handlePromise;
-    expect(runtime.sealBatch).toHaveBeenCalledTimes(1);
+    expect(runtime.sealBatch).not.toHaveBeenCalled();
     expect(handle).toBeInstanceOf(WriteResult);
     expect(handle.value).toEqual({ title: "Async callback batch" });
     await expect(handle.wait({ tier: "edge" })).resolves.toEqual({
       title: "Async callback batch",
     });
-    expect(waitForPersistedBatch).toHaveBeenCalledWith(handle.batchId, "edge");
   });
 
   it("does not commit a callback batch when the callback throws", () => {

--- a/packages/jazz-tools/src/runtime/client.test.ts
+++ b/packages/jazz-tools/src/runtime/client.test.ts
@@ -16,6 +16,14 @@ function makeFakeRuntime() {
     onAuthFailure: vi.fn<(callback: (reason: string) => void) => void>(),
     // Runtime interface stubs
     insert: vi.fn(),
+    insertWithSession: vi.fn((table: string, values: any, writeContextJson?: string | null) => {
+      const writeContext = writeContextJson ? JSON.parse(writeContextJson) : {};
+      return {
+        id: "todo-batch-query",
+        values: [],
+        batchId: writeContext.batch_id ?? "batch-query",
+      };
+    }),
     update: vi.fn(),
     delete: vi.fn(),
     query:
@@ -383,6 +391,29 @@ describe("JazzClient transactions", () => {
     batch.commit();
 
     expect(() => batch.rollback()).toThrow(/committed/i);
+  });
+
+  it("supports raw reads scoped to the open batch", async () => {
+    const runtime = makeFakeRuntime();
+    runtime.query.mockResolvedValue([{ id: "todo-batch-query", values: [] }]);
+    const client = JazzClient.connectWithRuntime(runtime as any, makeContext());
+    const batch = client.beginBatch();
+
+    batch.create("todos", {});
+
+    await expect(
+      batch.query({ _build: () => JSON.stringify({ table: "todos" }) }),
+    ).resolves.toEqual([{ id: "todo-batch-query", values: [] }]);
+
+    expect(runtime.query).toHaveBeenCalledTimes(1);
+    const optionsJson = runtime.query.mock.calls[0][3];
+    expect(JSON.parse(optionsJson as string)).toMatchObject({
+      local_updates: "deferred",
+      transaction_overlay: {
+        batch_id: batch.batchId(),
+        row_ids: ["todo-batch-query"],
+      },
+    });
   });
 
   it("commits a sync callback transaction and returns the callback result handle", async () => {

--- a/packages/jazz-tools/src/runtime/client.test.ts
+++ b/packages/jazz-tools/src/runtime/client.test.ts
@@ -358,6 +358,33 @@ describe("JazzClient transactions", () => {
     expect(waitForPersistedBatch).toHaveBeenCalledWith(committed.batchId, "edge");
   });
 
+  it("rolls back an open batch without sealing the batch", () => {
+    const runtime = makeFakeRuntime();
+    const client = JazzClient.connectWithRuntime(runtime as any, makeContext());
+    const batch = client.beginBatch();
+
+    batch.rollback();
+
+    expect(runtime.sealBatch).not.toHaveBeenCalled();
+    expect(() => batch.commit()).toThrow(/rolled back/i);
+    expect(() => batch.rollback()).toThrow(/rolled back/i);
+    expect(() =>
+      batch.create("todos", {
+        title: { type: "Text", value: "Nope" },
+      }),
+    ).toThrow(/rolled back/i);
+  });
+
+  it("rejects rollback after a batch has been committed", () => {
+    const runtime = makeFakeRuntime();
+    const client = JazzClient.connectWithRuntime(runtime as any, makeContext());
+    const batch = client.beginBatch();
+
+    batch.commit();
+
+    expect(() => batch.rollback()).toThrow(/committed/i);
+  });
+
   it("commits a sync callback transaction and returns the callback result handle", async () => {
     const runtime = makeFakeRuntime();
     const client = JazzClient.connectWithRuntime(runtime as any, makeContext());

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -855,16 +855,16 @@ function createBatchScope<TBatchOrTx extends object>(batchOrTx: TBatchOrTx): Sco
   }) as Scoped<TBatchOrTx>;
 }
 
-function rollbackIfAvailable(batchOrTx: { rollback?: () => void }): void {
+function rollback(batchOrTx: { rollback: () => void }): void {
   try {
-    batchOrTx.rollback?.();
+    batchOrTx.rollback();
   } catch {
     // Preserve the original callback error.
   }
 }
 
 export function runInBatch<
-  TBatchOrTx extends { commit(): WriteHandle; rollback?: () => void },
+  TBatchOrTx extends { commit(): WriteHandle; rollback: () => void },
   TResult,
 >(
   batchOrTx: TBatchOrTx,
@@ -876,7 +876,7 @@ export function runInBatch<
     const scope = createBatchScope(batchOrTx);
     value = callback(scope);
   } catch (error) {
-    rollbackIfAvailable(batchOrTx);
+    rollback(batchOrTx);
     throw error;
   }
   const resultClient = typeof client === "function" ? client : () => client;
@@ -891,7 +891,7 @@ export function runInBatch<
         );
       },
       (error) => {
-        rollbackIfAvailable(batchOrTx);
+        rollback(batchOrTx);
         throw error;
       },
     ) as RunInBatchResult<TResult>;
@@ -946,7 +946,10 @@ abstract class BatchHandleBase {
 
   commit(): WriteHandle {
     this.ensureActive();
-    const handle = this.client.sealBatch(this.batchId());
+    const handle =
+      this.touchedRowIds.size === 0
+        ? this.client.completeEmptyBatch(this.batchId())
+        : this.client.sealBatch(this.batchId());
     this.status = "committed";
     return handle;
   }
@@ -1270,6 +1273,7 @@ export class JazzClient {
   private readonly acknowledgedRejectedBatchErrors = new Map<string, PersistedWriteRejectedError>();
   private readonly replayedRejectedBatchRecords = new Map<string, LocalBatchRecord>();
   private readonly hydratedWorkerBatchIds = new Set<string>();
+  private readonly completedEmptyBatchIds = new Set<string>();
   private readonly pendingReplayedRejectedBatchIds = new Set<string>();
   private readonly onRejectedBatchAcknowledged?: (batchId: string) => void;
   private pendingBatchWaitPollTimer: ReturnType<typeof setTimeout> | null = null;
@@ -1657,6 +1661,11 @@ export class JazzClient {
 
   sealBatch(batchId: string): WriteHandle {
     this.requireBatchRecordMethod("sealBatch")(batchId);
+    return new WriteHandle(batchId, this);
+  }
+
+  completeEmptyBatch(batchId: string): WriteHandle {
+    this.completedEmptyBatchIds.add(batchId);
     return new WriteHandle(batchId, this);
   }
 
@@ -2462,6 +2471,10 @@ export class JazzClient {
     const acknowledgedRejection = this.acknowledgedRejectedBatchErrors.get(batchId);
     if (acknowledgedRejection) {
       return { settled: true, error: acknowledgedRejection };
+    }
+
+    if (this.completedEmptyBatchIds.has(batchId)) {
+      return { settled: true, error: null };
     }
 
     const settlement = this.localBatchRecord(batchId)?.latestSettlement;

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -830,7 +830,7 @@ type RunInBatchResult<TResult> =
     ? Promise<WriteResult<Awaited<TResult>>>
     : WriteResult<TResult>;
 
-type Scoped<TBatchOrTx> = Omit<TBatchOrTx, "commit" | "rollback">;
+export type Scoped<TBatchOrTx> = Omit<TBatchOrTx, "commit" | "rollback">;
 
 function createBatchScope<TBatchOrTx extends object>(batchOrTx: TBatchOrTx): Scoped<TBatchOrTx> {
   return new Proxy(batchOrTx, {
@@ -1023,6 +1023,7 @@ export type TransactionScope = Scoped<Transaction>;
 
 export class DirectBatch {
   private committedHandle: WriteHandle | null = null;
+  private batchStatus: "active" | "rolledBack" = "active";
 
   constructor(
     private readonly client: JazzClient,
@@ -1039,15 +1040,21 @@ export class DirectBatch {
     if (this.committedHandle) {
       throw new Error(`Direct batch ${this.batchContext.batchId} is already committed`);
     }
+    if (this.batchStatus === "rolledBack") {
+      throw new Error(`Direct batch ${this.batchContext.batchId} has already been rolled back`);
+    }
   }
 
   commit(): WriteHandle {
-    if (this.committedHandle) {
-      return this.committedHandle;
-    }
+    this.ensureActive();
     const handle = this.client.sealBatch(this.batchId());
     this.committedHandle = handle;
     return handle;
+  }
+
+  rollback(): void {
+    this.ensureActive();
+    this.batchStatus = "rolledBack";
   }
 
   create(table: string, values: InsertValues, options?: CreateOptions): Row {

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -900,11 +900,15 @@ export function runInBatch<
   return new WriteResult(value, committed.batchId, resultClient()) as RunInBatchResult<TResult>;
 }
 
-export class Transaction {
-  private transactionStatus: "active" | "committed" | "rolledBack" = "active";
+type BatchHandleStatus = "active" | "committed" | "rolledBack";
+type BatchHandleKind = "Transaction" | "Direct batch";
+
+abstract class BatchHandleBase {
+  private status: BatchHandleStatus = "active";
   private readonly touchedRowIds = new Set<string>();
 
   constructor(
+    private readonly kind: BatchHandleKind,
     private readonly client: JazzClient,
     private readonly batchContext: BatchWriteContext,
     private readonly session?: Session,
@@ -912,11 +916,11 @@ export class Transaction {
   ) {}
 
   private ensureActive(): void {
-    if (this.transactionStatus === "committed") {
-      throw new Error(`Transaction ${this.batchContext.batchId} is already committed`);
+    if (this.status === "committed") {
+      throw new Error(`${this.kind} ${this.batchContext.batchId} is already committed`);
     }
-    if (this.transactionStatus === "rolledBack") {
-      throw new Error(`Transaction ${this.batchContext.batchId} has already been rolled back`);
+    if (this.status === "rolledBack") {
+      throw new Error(`${this.kind} ${this.batchContext.batchId} has already been rolled back`);
     }
   }
 
@@ -943,13 +947,13 @@ export class Transaction {
   commit(): WriteHandle {
     this.ensureActive();
     const handle = this.client.sealBatch(this.batchId());
-    this.transactionStatus = "committed";
+    this.status = "committed";
     return handle;
   }
 
   rollback(): void {
     this.ensureActive();
-    this.transactionStatus = "rolledBack";
+    this.status = "rolledBack";
   }
 
   create(table: string, values: InsertValues, options?: CreateOptions): Row {
@@ -1017,97 +1021,38 @@ export class Transaction {
 }
 
 /**
+ * Transactions group a set of writes that should settle together after an authority validates them.
+ *
+ * Data read and written through this transaction is scoped to it, and will only be
+ * globally visible once it's committed and accepted by the authority.
+ */
+export class Transaction extends BatchHandleBase {
+  constructor(
+    client: JazzClient,
+    batchContext: BatchWriteContext,
+    session?: Session,
+    attribution?: string,
+  ) {
+    super("Transaction", client, batchContext, session, attribution);
+  }
+}
+
+/**
  * Transaction object available inside {@link JazzClient.transaction}'s callback.
  */
 export type TransactionScope = Scoped<Transaction>;
 
-export class DirectBatch {
-  private committedHandle: WriteHandle | null = null;
-  private batchStatus: "active" | "rolledBack" = "active";
-
+/**
+ * Direct batches group a set of writes under one batch id and publish them when committed.
+ */
+export class DirectBatch extends BatchHandleBase {
   constructor(
-    private readonly client: JazzClient,
-    private readonly batchContext: BatchWriteContext,
-    private readonly session?: Session,
-    private readonly attribution?: string,
-  ) {}
-
-  batchId(): string {
-    return this.batchContext.batchId;
-  }
-
-  private ensureActive(): void {
-    if (this.committedHandle) {
-      throw new Error(`Direct batch ${this.batchContext.batchId} is already committed`);
-    }
-    if (this.batchStatus === "rolledBack") {
-      throw new Error(`Direct batch ${this.batchContext.batchId} has already been rolled back`);
-    }
-  }
-
-  commit(): WriteHandle {
-    this.ensureActive();
-    const handle = this.client.sealBatch(this.batchId());
-    this.committedHandle = handle;
-    return handle;
-  }
-
-  rollback(): void {
-    this.ensureActive();
-    this.batchStatus = "rolledBack";
-  }
-
-  create(table: string, values: InsertValues, options?: CreateOptions): Row {
-    this.ensureActive();
-    return this.client.createInternal(
-      table,
-      values,
-      this.session,
-      this.attribution,
-      options,
-      this.batchContext,
-    );
-  }
-
-  upsert(table: string, values: InsertValues, options: UpsertOptions): void {
-    this.ensureActive();
-    this.client.upsertInternal(
-      table,
-      values,
-      options.id,
-      this.session,
-      this.attribution,
-      options.updatedAt,
-      this.batchContext,
-    );
-  }
-
-  update(objectId: string, updates: Record<string, Value>): void {
-    this.ensureActive();
-    this.client.updateInternal(
-      objectId,
-      updates,
-      this.session,
-      this.attribution,
-      this.batchContext,
-    );
-  }
-
-  delete(objectId: string): void {
-    this.ensureActive();
-    this.client.deleteInternal(objectId, this.session, this.attribution, this.batchContext);
-  }
-
-  localBatchRecord(batchId = this.batchId()): LocalBatchRecord | null {
-    return this.client.localBatchRecord(batchId);
-  }
-
-  localBatchRecords(): LocalBatchRecord[] {
-    return this.client.localBatchRecords();
-  }
-
-  acknowledgeRejectedBatch(batchId = this.batchId()): boolean {
-    return this.client.acknowledgeRejectedBatch(batchId);
+    client: JazzClient,
+    batchContext: BatchWriteContext,
+    session?: Session,
+    attribution?: string,
+  ) {
+    super("Direct batch", client, batchContext, session, attribution);
   }
 }
 

--- a/packages/jazz-tools/src/runtime/db.transaction.test.ts
+++ b/packages/jazz-tools/src/runtime/db.transaction.test.ts
@@ -1082,6 +1082,57 @@ describe("Db transactions", () => {
     });
   });
 
+  it("supports typed reads scoped to the open batch", async () => {
+    const table = todoTable();
+    const query = todoQuery();
+    const runtimeRow: Row = {
+      id: "todo-direct-read-1",
+      values: [
+        { type: "Text", value: "Direct batch read" },
+        { type: "Boolean", value: false },
+      ],
+    };
+    const runtimeBatch = {
+      batchId: vi.fn(() => "batch-direct-read"),
+      create: vi.fn(() => runtimeRow),
+      update: vi.fn(),
+      delete: vi.fn(),
+      query: vi.fn(async () => [runtimeRow]),
+      commit: vi.fn(() => makeWriteHandle("batch-direct-read", "direct").handle),
+      rollback: vi.fn(),
+      localBatchRecord: vi.fn((batchId = "batch-direct-read") =>
+        makeLocalBatchRecord(batchId, "direct"),
+      ),
+      localBatchRecords: vi.fn(() => [makeLocalBatchRecord("batch-direct-read", "direct")]),
+      acknowledgeRejectedBatch: vi.fn(() => false),
+    };
+    const client = {
+      getSchema: () => new Map(Object.entries(todoSchema())),
+      beginBatchInternal: vi.fn(() => runtimeBatch),
+      localBatchRecord: vi.fn((batchId: string) => makeLocalBatchRecord(batchId, "direct")),
+      acknowledgeRejectedBatch: vi.fn(() => false),
+    } as unknown as JazzClient;
+    const db = new TestDb(client);
+
+    const batch = db.beginBatch();
+    batch.insert(table, { title: "Direct batch read", done: false });
+
+    await expect(batch.all(query)).resolves.toEqual([
+      {
+        id: "todo-direct-read-1",
+        title: "Direct batch read",
+        done: false,
+      },
+    ]);
+    await expect(batch.one(query)).resolves.toEqual({
+      id: "todo-direct-read-1",
+      title: "Direct batch read",
+      done: false,
+    });
+
+    expect(runtimeBatch.query).toHaveBeenCalledTimes(2);
+  });
+
   it("commits a callback batch and returns the callback result handle", async () => {
     const table = todoTable();
     const runtimeRow: Row = {

--- a/packages/jazz-tools/src/runtime/db.transaction.test.ts
+++ b/packages/jazz-tools/src/runtime/db.transaction.test.ts
@@ -1277,6 +1277,154 @@ describe("Db transactions", () => {
     expect(beginBatchInternal).not.toHaveBeenCalled();
   });
 
+  it("rolls back db batches without committing the underlying batch", () => {
+    const table = todoTable();
+    let status: TestTransactionStatus = "active";
+    const runtimeBatch = {
+      batchId: vi.fn(() => "batch-direct-rollback"),
+      create: vi.fn(() => {
+        assertTestTransactionActive(status, "batch-direct-rollback");
+        return {
+          id: "todo-direct-rollback",
+          values: [
+            { type: "Text", value: "Direct rollback" },
+            { type: "Boolean", value: false },
+          ],
+          batchId: "batch-direct-rollback",
+        } as Row;
+      }),
+      update: vi.fn(() => {
+        assertTestTransactionActive(status, "batch-direct-rollback");
+      }),
+      delete: vi.fn(() => {
+        assertTestTransactionActive(status, "batch-direct-rollback");
+      }),
+      commit: vi.fn(() => {
+        assertTestTransactionActive(status, "batch-direct-rollback");
+        status = "committed";
+        return makeWriteHandle("batch-direct-rollback", "direct").handle;
+      }),
+      rollback: vi.fn(() => {
+        assertTestTransactionActive(status, "batch-direct-rollback");
+        status = "rolledBack";
+      }),
+      localBatchRecord: vi.fn((batchId = "batch-direct-rollback") =>
+        makeLocalBatchRecord(batchId, "direct"),
+      ),
+      localBatchRecords: vi.fn(() => [makeLocalBatchRecord("batch-direct-rollback", "direct")]),
+      acknowledgeRejectedBatch: vi.fn(() => false),
+    };
+    const runtimeClient = {
+      getSchema: () => new Map(Object.entries(todoSchema())),
+      beginBatchInternal: vi.fn(() => runtimeBatch),
+      localBatchRecord: vi.fn((batchId: string) => makeLocalBatchRecord(batchId, "direct")),
+      acknowledgeRejectedBatch: vi.fn(() => false),
+    };
+    const db = createDbFromClient(
+      { appId: "client-backed-batch-rollback" },
+      runtimeClient as unknown as JazzClient,
+    );
+
+    const batch = db.beginBatch();
+    batch.update(table, "todo-direct-rollback", { done: false });
+    batch.rollback();
+
+    expect(runtimeBatch.rollback).toHaveBeenCalledTimes(1);
+    expect(runtimeBatch.commit).not.toHaveBeenCalled();
+    expect(() => batch.commit()).toThrow(/rolled back/i);
+    expect(() => batch.rollback()).toThrow(/rolled back/i);
+    expect(() => batch.insert(table, { title: "Nope", done: false })).toThrow(/rolled back/i);
+  });
+
+  it("rejects db batch rollback after commit", () => {
+    const table = todoTable();
+    let status: TestTransactionStatus = "active";
+    const runtimeBatch = {
+      batchId: vi.fn(() => "batch-direct-commit-before-rollback"),
+      create: vi.fn(),
+      update: vi.fn(() => {
+        assertTestTransactionActive(status, "batch-direct-commit-before-rollback");
+      }),
+      delete: vi.fn(),
+      commit: vi.fn(() => {
+        assertTestTransactionActive(status, "batch-direct-commit-before-rollback");
+        status = "committed";
+        return makeWriteHandle("batch-direct-commit-before-rollback", "direct").handle;
+      }),
+      rollback: vi.fn(() => {
+        assertTestTransactionActive(status, "batch-direct-commit-before-rollback");
+        status = "rolledBack";
+      }),
+      localBatchRecord: vi.fn((batchId = "batch-direct-commit-before-rollback") =>
+        makeLocalBatchRecord(batchId, "direct"),
+      ),
+      localBatchRecords: vi.fn(() => [
+        makeLocalBatchRecord("batch-direct-commit-before-rollback", "direct"),
+      ]),
+      acknowledgeRejectedBatch: vi.fn(() => false),
+    };
+    const runtimeClient = {
+      getSchema: () => new Map(Object.entries(todoSchema())),
+      beginBatchInternal: vi.fn(() => runtimeBatch),
+      localBatchRecord: vi.fn((batchId: string) => makeLocalBatchRecord(batchId, "direct")),
+      acknowledgeRejectedBatch: vi.fn(() => false),
+    };
+    const db = createDbFromClient(
+      { appId: "client-backed-batch-commit-before-rollback" },
+      runtimeClient as unknown as JazzClient,
+    );
+
+    const batch = db.beginBatch();
+    batch.update(table, "todo-direct-commit-before-rollback", { done: false });
+    batch.commit();
+
+    expect(() => batch.rollback()).toThrow(/committed/i);
+  });
+
+  it("rolls back a callback batch when the callback throws after a write", () => {
+    const table = todoTable();
+    const runtimeBatch = {
+      batchId: vi.fn(() => "batch-direct-thrown-callback"),
+      create: vi.fn(() => ({
+        id: "todo-direct-thrown-callback",
+        values: [
+          { type: "Text", value: "Thrown callback batch" },
+          { type: "Boolean", value: false },
+        ],
+        batchId: "batch-direct-thrown-callback",
+      })),
+      update: vi.fn(),
+      delete: vi.fn(),
+      commit: vi.fn(() => makeWriteHandle("batch-direct-thrown-callback", "direct").handle),
+      rollback: vi.fn(),
+      localBatchRecord: vi.fn((batchId = "batch-direct-thrown-callback") =>
+        makeLocalBatchRecord(batchId, "direct"),
+      ),
+      localBatchRecords: vi.fn(() => [
+        makeLocalBatchRecord("batch-direct-thrown-callback", "direct"),
+      ]),
+      acknowledgeRejectedBatch: vi.fn(() => false),
+    };
+    const client = {
+      getSchema: () => new Map(Object.entries(todoSchema())),
+      beginBatchInternal: vi.fn(() => runtimeBatch),
+      localBatchRecord: vi.fn((batchId: string) => makeLocalBatchRecord(batchId, "direct")),
+      acknowledgeRejectedBatch: vi.fn(() => false),
+    } as unknown as JazzClient;
+    const db = new TestDb(client);
+    const error = new Error("callback failed");
+
+    expect(() =>
+      db.batch((batch) => {
+        batch.insert(table, { title: "Thrown callback batch", done: false });
+        throw error;
+      }),
+    ).toThrow(error);
+
+    expect(runtimeBatch.commit).not.toHaveBeenCalled();
+    expect(runtimeBatch.rollback).toHaveBeenCalledTimes(1);
+  });
+
   it("rejects db batch writes against a different client/schema", () => {
     const primaryTable = todoTable();
     const secondaryTable = {

--- a/packages/jazz-tools/src/runtime/db.transaction.test.ts
+++ b/packages/jazz-tools/src/runtime/db.transaction.test.ts
@@ -157,10 +157,14 @@ describe("Db transactions", () => {
       title: "Transactional",
       done: false,
     });
-    expect(runtimeTransaction.create).toHaveBeenCalledWith("todos", {
-      title: { type: "Text", value: "Transactional" },
-      done: { type: "Boolean", value: false },
-    });
+    expect(runtimeTransaction.create).toHaveBeenCalledWith(
+      "todos",
+      {
+        title: { type: "Text", value: "Transactional" },
+        done: { type: "Boolean", value: false },
+      },
+      undefined,
+    );
     expect(runtimeTransaction.update).toHaveBeenCalledWith("todo-1", {
       done: { type: "Boolean", value: true },
     });
@@ -220,10 +224,14 @@ describe("Db transactions", () => {
 
     expect(getSchema).not.toHaveBeenCalled();
     expect(getSchemaHash).not.toHaveBeenCalled();
-    expect(runtimeTransaction.create).toHaveBeenCalledWith("todos", {
-      title: { type: "Text", value: "Fast transaction" },
-      done: { type: "Boolean", value: false },
-    });
+    expect(runtimeTransaction.create).toHaveBeenCalledWith(
+      "todos",
+      {
+        title: { type: "Text", value: "Fast transaction" },
+        done: { type: "Boolean", value: false },
+      },
+      undefined,
+    );
     expect(runtimeTransaction.upsert).toHaveBeenCalledWith(
       "todos",
       { title: { type: "Text", value: "Fast transaction upsert" } },
@@ -1000,10 +1008,14 @@ describe("Db transactions", () => {
       title: "Direct batch",
       done: false,
     });
-    expect(runtimeBatch.create).toHaveBeenCalledWith("todos", {
-      title: { type: "Text", value: "Direct batch" },
-      done: { type: "Boolean", value: false },
-    });
+    expect(runtimeBatch.create).toHaveBeenCalledWith(
+      "todos",
+      {
+        title: { type: "Text", value: "Direct batch" },
+        done: { type: "Boolean", value: false },
+      },
+      undefined,
+    );
     expect(runtimeBatch.update).toHaveBeenCalledWith("todo-direct-1", {
       done: { type: "Boolean", value: true },
     });
@@ -1068,10 +1080,14 @@ describe("Db transactions", () => {
 
     expect(getSchema).not.toHaveBeenCalled();
     expect(getSchemaHash).not.toHaveBeenCalled();
-    expect(runtimeBatch.create).toHaveBeenCalledWith("todos", {
-      title: { type: "Text", value: "Fast batch" },
-      done: { type: "Boolean", value: false },
-    });
+    expect(runtimeBatch.create).toHaveBeenCalledWith(
+      "todos",
+      {
+        title: { type: "Text", value: "Fast batch" },
+        done: { type: "Boolean", value: false },
+      },
+      undefined,
+    );
     expect(runtimeBatch.upsert).toHaveBeenCalledWith(
       "todos",
       { title: { type: "Text", value: "Fast batch upsert" } },

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -30,6 +30,7 @@ import {
   type QueryVisibility,
   resolveEffectiveQueryExecutionOptions,
   runInBatch,
+  Scoped,
 } from "./client.js";
 import { type DbRuntimeModule, type RuntimeTokenOptions } from "./db-runtime-module.js";
 import { WasmRuntimeModule } from "./wasm-runtime-module.js";
@@ -642,11 +643,11 @@ export class DbTransaction {
 /**
  * Transaction object available inside {@link Db.transaction}'s callback.
  */
-export type DbTransactionScope = Omit<DbTransaction, "commit" | "rollback">;
+export type DbTransactionScope = Scoped<DbTransaction>;
 
 /**
- * Direct batches group a set of writes that should settle immediately, without an authority,
- * while still being part of the same batch.
+ * Direct batches group a set of writes that should become visible together on batch commit,
+ * without waiting for an authority approval.
  */
 export class DbDirectBatch {
   private committedHandle: WriteHandle | null = null;
@@ -689,8 +690,8 @@ export class DbDirectBatch {
    * Commit the direct batch. Data is visible optimistically once committed and
    * can be waited on through the returned handle.
    *
-   * Only available on transactions created with {@link Db.beginTransaction}.
-   * When using {@link Db.transaction}, the transaction is committed automatically
+   * Only available on batches created with {@link Db.beginBatch}.
+   * When using {@link Db.batch}, the batch is committed automatically
    * once the callback finishes running.
    */
   commit(): WriteHandle {
@@ -700,6 +701,19 @@ export class DbDirectBatch {
     const handle = this.requireRuntimeBatch("commit").commit();
     this.committedHandle = handle;
     return handle;
+  }
+
+  /**
+   * Roll back this direct batch locally.
+   *
+   * Pending rows remain pending, but this batch handle can no longer be committed.
+   *
+   * Only available on batches created with {@link Db.beginBatch}.
+   * When using {@link Db.batch}, throw an error inside the callback
+   * to roll back the batch.
+   */
+  rollback(): void {
+    this.requireRuntimeBatch("rollback").rollback();
   }
 
   insert<T, Init>(table: TableProxy<T, Init>, data: Init, options?: CreateOptions): T {
@@ -752,7 +766,7 @@ export class DbDirectBatch {
 /**
  * Batch object available inside {@link Db.batch}'s callback.
  */
-export type DbBatchScope = Omit<DbDirectBatch, "commit">;
+export type DbBatchScope = Scoped<DbDirectBatch>;
 
 /**
  * High-level database interface for typed queries and mutations.

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -398,34 +398,22 @@ export interface ColumnTransform {
 
 export type ColumnTransformMap = Record<string, ColumnTransform>;
 
-type DbTransactionBinding = {
+type DbBatchHandleBinding = {
   client: JazzClient;
-  runtimeTransaction: RuntimeTransaction;
+  runtimeHandle: RuntimeTransaction;
 };
+type AnyDbBatchHandle = DbBatchHandleBase<RuntimeTransaction | RuntimeDirectBatch>;
 
-type DbDirectBatchBinding = {
-  client: JazzClient;
-  runtimeBatch: RuntimeDirectBatch;
-};
+const dbBatchHandleBindings = new WeakMap<AnyDbBatchHandle, DbBatchHandleBinding>();
 
-const dbTransactionBindings = new WeakMap<DbTransaction, DbTransactionBinding>();
-const dbDirectBatchBindings = new WeakMap<DbDirectBatch, DbDirectBatchBinding>();
-
-function getDbTransactionBinding(
-  transaction: DbTransaction,
+function getDbBatchHandleBinding(
+  handle: AnyDbBatchHandle,
   operation: string,
-): DbTransactionBinding {
-  const binding = dbTransactionBindings.get(transaction);
+  bindingName: "DbTransaction" | "DbDirectBatch",
+): DbBatchHandleBinding {
+  const binding = dbBatchHandleBindings.get(handle);
   if (!binding) {
-    throw new Error(`DbTransaction.${operation}() requires at least one table operation first`);
-  }
-  return binding;
-}
-
-function getDbDirectBatchBinding(batch: DbDirectBatch, operation: string): DbDirectBatchBinding {
-  const binding = dbDirectBatchBindings.get(batch);
-  if (!binding) {
-    throw new Error(`DbDirectBatch.${operation}() requires at least one table operation first`);
+    throw new Error(`${bindingName}.${operation}() requires at least one table operation first`);
   }
   return binding;
 }
@@ -473,135 +461,127 @@ function transformInputColumns(
 }
 
 /**
- * Transactions group a set of writes that should settle together after an authority validates them.
- *
- * Data read and written through this transaction is scoped to it, and will only be
- * globally visible once it's committed using {@link DbTransaction.commit} and
- * accepted by the authority.
+ * Shared implementation for batches and transactions.
  */
-export class DbTransaction {
+abstract class DbBatchHandleBase<TRuntimeHandle extends RuntimeTransaction | RuntimeDirectBatch> {
   constructor(
+    private readonly bindingName: "DbTransaction" | "DbDirectBatch",
     private readonly resolveClient: (schema: WasmSchema) => JazzClient,
-    private readonly beginRuntimeTransaction: (client: JazzClient) => RuntimeTransaction,
+    private readonly beginRuntimeHandle: (client: JazzClient) => TRuntimeHandle,
   ) {}
 
-  private bindTable<T, Init>(table: TableProxy<T, Init>, operation: string): DbTransactionBinding {
-    const existingBinding = dbTransactionBindings.get(this);
+  private bindTable<T, Init>(table: TableProxy<T, Init>, operation: string): DbBatchHandleBinding {
+    const existingBinding = dbBatchHandleBindings.get(this);
     if (existingBinding) {
       assertTableBelongsToClient(table, existingBinding.client, this.resolveClient, operation);
       return existingBinding;
     }
 
     const client = this.resolveClient(table._schema);
-    const runtimeTransaction = this.beginRuntimeTransaction(client);
-    const binding = { client, runtimeTransaction };
-    dbTransactionBindings.set(this, binding);
+    const runtimeHandle = this.beginRuntimeHandle(client);
+    const binding = { client, runtimeHandle };
+    dbBatchHandleBindings.set(this, binding);
     return binding;
   }
 
-  private bindQuery<T>(query: QueryBuilder<T>): DbTransactionBinding {
-    return this.bindTable(query as unknown as TableProxy<T, never>, "DbTransaction");
+  private bindQuery<T>(query: QueryBuilder<T>): DbBatchHandleBinding {
+    return this.bindTable(query as unknown as TableProxy<T, never>, this.bindingName);
   }
 
-  private requireRuntimeTransaction(operation: string): RuntimeTransaction {
-    return getDbTransactionBinding(this, operation).runtimeTransaction;
+  private requireRuntimeHandle(operation: string): TRuntimeHandle {
+    return getDbBatchHandleBinding(this, operation, this.bindingName)
+      .runtimeHandle as TRuntimeHandle;
   }
 
   batchId(): string {
-    return this.requireRuntimeTransaction("batchId").batchId();
+    return this.requireRuntimeHandle("batchId").batchId();
   }
 
   /**
-   * Commit the transaction. Data will be globally visible once it's accepted by the authority.
+   * Commit this batch.
    */
   commit(): WriteHandle {
-    return this.requireRuntimeTransaction("commit").commit();
+    return this.requireRuntimeHandle("commit").commit();
   }
 
   /**
-   * Roll back this transaction locally.
+   * Roll back this batch locally.
    *
-   * Pending rows remain pending, but this transaction handle can no longer be committed.
+   * Pending rows remain pending, but this batch can no longer be committed.
    *
-   * Only available on transactions created with {@link Db.beginTransaction}.
-   * When using {@link Db.transaction}, throw an error inside the callback
-   * to roll back the transaction.
+   * Only available on batches/transactions created with {@link Db.beginBatch}/{@link Db.beginTransaction}.
+   * When using {@link Db.batch}/{@link Db.transaction}, throw an error inside the callback to roll back.
    */
   rollback(): void {
-    this.requireRuntimeTransaction("rollback").rollback();
+    this.requireRuntimeHandle("rollback").rollback();
   }
 
   /**
    * Insert a new row into a table.
    *
-   * The insert is scoped to this transaction, and will only be globally visible
-   * once it's committed with {@link DbTransaction.commit}.
+   * The insert is scoped to this batch, and will only be globally visible
+   * once it's committed.
    */
   insert<T, Init>(table: TableProxy<T, Init>, data: Init, options?: CreateOptions): T {
-    this.bindTable(table, "DbTransaction");
+    this.bindTable(table, this.bindingName);
     const transformedData = transformInputColumns(table, data);
     const values = toInsertRecord(transformedData, table._schema, table._table);
-    const runtimeTransaction = this.requireRuntimeTransaction("insert");
-    const row = options
-      ? runtimeTransaction.create(table._table, values, options)
-      : runtimeTransaction.create(table._table, values);
+    const runtimeHandle = this.requireRuntimeHandle("insert");
+    const row = runtimeHandle.create(table._table, values, options);
     return transformOutputRow(table, transformRow(row, table._schema, table._table));
   }
 
   /**
    * Create or update a row with a caller-supplied id.
    *
-   * The upsert is scoped to this transaction, and will only be globally visible
-   * once it's committed with {@link DbTransaction.commit}.
+   * The upsert is scoped to this batch, and will only be globally visible
+   * once it's committed.
    */
   upsert<T, Init>(table: TableProxy<T, Init>, data: Partial<Init>, options: UpsertOptions): void {
-    this.bindTable(table, "DbTransaction");
+    this.bindTable(table, this.bindingName);
     const transformedData = transformInputColumns(table, data);
     const values = toUpdateRecord(transformedData, table._schema, table._table);
-    this.requireRuntimeTransaction("upsert").upsert(table._table, values, options);
+    this.requireRuntimeHandle("upsert").upsert(table._table, values, options);
   }
 
   /**
    * Update an existing row in a table.
    *
-   * The update is scoped to this transaction, and will only be globally visible
-   * once it's committed with {@link DbTransaction.commit}.
+   * The update is scoped to this batch, and will only be globally visible
+   * once it's committed.
    */
   update<T, Init>(table: TableProxy<T, Init>, id: string, data: Partial<Init>): void {
-    this.bindTable(table, "DbTransaction");
+    this.bindTable(table, this.bindingName);
     const transformedData = transformInputColumns(table, data);
     const updates = toUpdateRecord(transformedData, table._schema, table._table);
-    this.requireRuntimeTransaction("update").update(id, updates);
+    this.requireRuntimeHandle("update").update(id, updates);
   }
 
   /**
    * Delete an existing row from a table.
    *
-   * The delete is scoped to this transaction, and will only be globally visible
-   * once it's committed with {@link DbTransaction.commit}.
+   * The delete is scoped to this batch, and will only be globally visible
+   * once it's committed.
    */
   delete<T, Init>(table: TableProxy<T, Init>, id: string): void {
-    const { runtimeTransaction } = this.bindTable(table, "DbTransaction");
-    runtimeTransaction.delete(id);
+    const { runtimeHandle } = this.bindTable(table, this.bindingName);
+    runtimeHandle.delete(id);
   }
 
   /**
    * Execute a query and return all matching rows.
    *
-   * Read data is scoped to this transaction.
+   * Read data is scoped to this batch.
    */
   async all<T>(query: QueryBuilder<T>, options?: QueryOptions): Promise<T[]> {
-    const { client, runtimeTransaction } = this.bindQuery(query);
+    const { client, runtimeHandle } = this.bindQuery(query);
     const runtimeSchema = normalizeRuntimeSchema(client.getSchema());
     const builderJson = query._build();
     const builtQuery = normalizeBuiltQuery(JSON.parse(builderJson), query._table);
     const planningSchema = resolveSchemaWithTable(query._schema, runtimeSchema, builtQuery.table);
     const outputTable = resolveBuiltQueryOutputTable(planningSchema, builtQuery);
     const outputSchema = resolveSchemaWithTable(query._schema, runtimeSchema, outputTable);
-    const rows = await runtimeTransaction.query(
-      translateQuery(builderJson, planningSchema),
-      options,
-    );
+    const rows = await runtimeHandle.query(translateQuery(builderJson, planningSchema), options);
     const outputIncludes = outputTable !== builtQuery.table ? {} : builtQuery.includes;
     const transformedRows = transformRows(
       rows,
@@ -618,7 +598,7 @@ export class DbTransaction {
   /**
    * Execute a query and return the first matching row, or null.
    *
-   * Read data is scoped to this transaction.
+   * Read data is scoped to this batch.
    */
   async one<T>(query: QueryBuilder<T>, options?: QueryOptions): Promise<T | null> {
     const results = await this.all(query, options);
@@ -626,17 +606,31 @@ export class DbTransaction {
   }
 
   localBatchRecord(batchId = this.batchId()): LocalBatchRecord | null {
-    return this.requireRuntimeTransaction("localBatchRecord").localBatchRecord(batchId);
+    return this.requireRuntimeHandle("localBatchRecord").localBatchRecord(batchId);
   }
 
   localBatchRecords(): LocalBatchRecord[] {
-    return this.requireRuntimeTransaction("localBatchRecords").localBatchRecords();
+    return this.requireRuntimeHandle("localBatchRecords").localBatchRecords();
   }
 
   acknowledgeRejectedBatch(batchId = this.batchId()): boolean {
-    return this.requireRuntimeTransaction("acknowledgeRejectedBatch").acknowledgeRejectedBatch(
-      batchId,
-    );
+    return this.requireRuntimeHandle("acknowledgeRejectedBatch").acknowledgeRejectedBatch(batchId);
+  }
+}
+
+/**
+ * Transactions group a set of writes that should settle together after an authority validates them.
+ *
+ * Data read and written through this transaction is scoped to it, and will only be
+ * globally visible once it's committed using {@link DbTransaction.commit} and
+ * accepted by the authority.
+ */
+export class DbTransaction extends DbBatchHandleBase<RuntimeTransaction> {
+  constructor(
+    resolveClient: (schema: WasmSchema) => JazzClient,
+    beginRuntimeTransaction: (client: JazzClient) => RuntimeTransaction,
+  ) {
+    super("DbTransaction", resolveClient, beginRuntimeTransaction);
   }
 }
 
@@ -649,117 +643,12 @@ export type DbTransactionScope = Scoped<DbTransaction>;
  * Direct batches group a set of writes that should become visible together on batch commit,
  * without waiting for an authority approval.
  */
-export class DbDirectBatch {
-  private committedHandle: WriteHandle | null = null;
-
+export class DbDirectBatch extends DbBatchHandleBase<RuntimeDirectBatch> {
   constructor(
-    private readonly resolveClient: (schema: WasmSchema) => JazzClient,
-    private readonly beginRuntimeBatch: (client: JazzClient) => RuntimeDirectBatch,
-  ) {}
-
-  private bindTable<T, Init>(table: TableProxy<T, Init>, operation: string): DbDirectBatchBinding {
-    const existingBinding = dbDirectBatchBindings.get(this);
-    if (existingBinding) {
-      assertTableBelongsToClient(table, existingBinding.client, this.resolveClient, operation);
-      return existingBinding;
-    }
-
-    const client = this.resolveClient(table._schema);
-    const runtimeBatch = this.beginRuntimeBatch(client);
-    const binding = { client, runtimeBatch };
-    dbDirectBatchBindings.set(this, binding);
-    return binding;
-  }
-
-  private requireRuntimeBatch(operation: string): RuntimeDirectBatch {
-    return getDbDirectBatchBinding(this, operation).runtimeBatch;
-  }
-
-  batchId(): string {
-    return this.requireRuntimeBatch("batchId").batchId();
-  }
-
-  private ensureActive(): void {
-    if (this.committedHandle) {
-      const batchId = dbDirectBatchBindings.get(this)?.runtimeBatch.batchId() ?? "unbound";
-      throw new Error(`Direct batch ${batchId} is already committed`);
-    }
-  }
-
-  /**
-   * Commit the direct batch. Data is visible optimistically once committed and
-   * can be waited on through the returned handle.
-   *
-   * Only available on batches created with {@link Db.beginBatch}.
-   * When using {@link Db.batch}, the batch is committed automatically
-   * once the callback finishes running.
-   */
-  commit(): WriteHandle {
-    if (this.committedHandle) {
-      return this.committedHandle;
-    }
-    const handle = this.requireRuntimeBatch("commit").commit();
-    this.committedHandle = handle;
-    return handle;
-  }
-
-  /**
-   * Roll back this direct batch locally.
-   *
-   * Pending rows remain pending, but this batch handle can no longer be committed.
-   *
-   * Only available on batches created with {@link Db.beginBatch}.
-   * When using {@link Db.batch}, throw an error inside the callback
-   * to roll back the batch.
-   */
-  rollback(): void {
-    this.requireRuntimeBatch("rollback").rollback();
-  }
-
-  insert<T, Init>(table: TableProxy<T, Init>, data: Init, options?: CreateOptions): T {
-    this.ensureActive();
-    this.bindTable(table, "DbDirectBatch");
-    const transformedData = transformInputColumns(table, data);
-    const values = toInsertRecord(transformedData, table._schema, table._table);
-    const runtimeBatch = this.requireRuntimeBatch("insert");
-    const row = options
-      ? runtimeBatch.create(table._table, values, options)
-      : runtimeBatch.create(table._table, values);
-    return transformOutputRow(table, transformRow(row, table._schema, table._table));
-  }
-
-  upsert<T, Init>(table: TableProxy<T, Init>, data: Partial<Init>, options: UpsertOptions): void {
-    this.ensureActive();
-    this.bindTable(table, "DbDirectBatch");
-    const transformedData = transformInputColumns(table, data);
-    const values = toUpdateRecord(transformedData, table._schema, table._table);
-    this.requireRuntimeBatch("upsert").upsert(table._table, values, options);
-  }
-
-  update<T, Init>(table: TableProxy<T, Init>, id: string, data: Partial<Init>): void {
-    this.ensureActive();
-    this.bindTable(table, "DbDirectBatch");
-    const transformedData = transformInputColumns(table, data);
-    const updates = toUpdateRecord(transformedData, table._schema, table._table);
-    this.requireRuntimeBatch("update").update(id, updates);
-  }
-
-  delete<T, Init>(table: TableProxy<T, Init>, id: string): void {
-    this.ensureActive();
-    const { runtimeBatch } = this.bindTable(table, "DbDirectBatch");
-    runtimeBatch.delete(id);
-  }
-
-  localBatchRecord(batchId = this.batchId()): LocalBatchRecord | null {
-    return this.requireRuntimeBatch("localBatchRecord").localBatchRecord(batchId);
-  }
-
-  localBatchRecords(): LocalBatchRecord[] {
-    return this.requireRuntimeBatch("localBatchRecords").localBatchRecords();
-  }
-
-  acknowledgeRejectedBatch(batchId = this.batchId()): boolean {
-    return this.requireRuntimeBatch("acknowledgeRejectedBatch").acknowledgeRejectedBatch(batchId);
+    resolveClient: (schema: WasmSchema) => JazzClient,
+    beginRuntimeBatch: (client: JazzClient) => RuntimeDirectBatch,
+  ) {
+    super("DbDirectBatch", resolveClient, beginRuntimeBatch);
   }
 }
 
@@ -1847,7 +1736,7 @@ export class Db {
     return runInBatch(
       transaction,
       callback,
-      () => getDbTransactionBinding(transaction, "result").client,
+      () => getDbBatchHandleBinding(transaction, "result", "DbTransaction").client,
     );
   }
 
@@ -1882,7 +1771,11 @@ export class Db {
     callback: (batch: DbBatchScope) => TResult | Promise<TResult>,
   ): WriteResult<TResult> | Promise<WriteResult<Awaited<TResult>>> {
     const batch = this.beginBatch();
-    return runInBatch(batch, callback, () => getDbDirectBatchBinding(batch, "result").client);
+    return runInBatch(
+      batch,
+      callback,
+      () => getDbBatchHandleBinding(batch, "result", "DbDirectBatch").client,
+    );
   }
 
   /**
@@ -2397,7 +2290,7 @@ class ClientBackedDb extends Db {
     return runInBatch(
       transaction,
       callback,
-      () => getDbTransactionBinding(transaction, "result").client,
+      () => getDbBatchHandleBinding(transaction, "result", "DbTransaction").client,
     );
   }
 
@@ -2417,7 +2310,11 @@ class ClientBackedDb extends Db {
     callback: (batch: DbBatchScope) => TResult | Promise<TResult>,
   ): WriteResult<TResult> | Promise<WriteResult<Awaited<TResult>>> {
     const batch = this.beginBatch();
-    return runInBatch(batch, callback, () => getDbDirectBatchBinding(batch, "result").client);
+    return runInBatch(
+      batch,
+      callback,
+      () => getDbBatchHandleBinding(batch, "result", "DbDirectBatch").client,
+    );
   }
 
   override async all<T>(query: QueryBuilder<T>, options?: QueryOptions): Promise<T[]> {

--- a/packages/jazz-tools/tests/browser/db.transaction-reads.test.ts
+++ b/packages/jazz-tools/tests/browser/db.transaction-reads.test.ts
@@ -175,6 +175,39 @@ describe("db transaction reads browser integration", () => {
   });
 
   describe("db.transaction(cb)", () => {
+    it("returns the callback value when an async transaction only reads", async () => {
+      const { value: existingTodo } = db.insert(todos, {
+        title: "Alice checked the roadmap",
+        done: false,
+      });
+
+      await expect(
+        db.transaction(async (tx) => {
+          const rows = await tx.all<Todo>(makeTodoQuery());
+          expect(rows).toEqual([existingTodo]);
+          return "no writes needed";
+        }),
+      ).resolves.toMatchObject({ value: "no writes needed" });
+    });
+
+    it("rolls back cleanly when an async transaction reads then throws before writing", async () => {
+      const { value: existingTodo } = db.insert(todos, {
+        title: "Alice checked rollback",
+        done: false,
+      });
+      const error = new Error("no write transaction failed");
+
+      await expect(
+        db.transaction(async (tx) => {
+          const rows = await tx.all<Todo>(makeTodoQuery());
+          expect(rows).toEqual([existingTodo]);
+          throw error;
+        }),
+      ).rejects.toBe(error);
+
+      await expect(db.all<Todo>(makeTodoQuery())).resolves.toEqual([existingTodo]);
+    });
+
     it("commits changes once the callback resolves and the authority accepts the transaction", async () => {
       const txResult = db.transaction((tx) => {
         return tx.insert(todos, { title: "Batch", done: false });
@@ -266,6 +299,39 @@ describe("db batch reads browser integration", () => {
   });
 
   describe("db.batch(cb)", () => {
+    it("returns the callback value when an async batch only reads", async () => {
+      const { value: existingTodo } = db.insert(todos, {
+        title: "Alice reviewed the plan",
+        done: false,
+      });
+
+      await expect(
+        db.batch(async (batch) => {
+          const rows = await batch.all<Todo>(makeTodoQuery());
+          expect(rows).toEqual([existingTodo]);
+          return "no writes needed";
+        }),
+      ).resolves.toMatchObject({ value: "no writes needed" });
+    });
+
+    it("rolls back cleanly when an async batch reads then throws before writing", async () => {
+      const { value: existingTodo } = db.insert(todos, {
+        title: "Alice reviewed rollback",
+        done: false,
+      });
+      const error = new Error("no write batch failed");
+
+      await expect(
+        db.batch(async (batch) => {
+          const rows = await batch.all<Todo>(makeTodoQuery());
+          expect(rows).toEqual([existingTodo]);
+          throw error;
+        }),
+      ).rejects.toBe(error);
+
+      await expect(db.all<Todo>(makeTodoQuery())).resolves.toEqual([existingTodo]);
+    });
+
     it("commits changes once the callback resolves", async () => {
       const batchResult = db.batch((batch) => {
         return batch.insert(todos, { title: "Batch", done: false });

--- a/specs/status-quo/batches.md
+++ b/specs/status-quo/batches.md
@@ -488,12 +488,13 @@ After this point the transactional batch is no longer writable.
 
 ### 4a. Explicit rollback
 
-`rollback()` on a TypeScript transaction handle marks only that handle as rolled back:
+`rollback()` on a TypeScript explicit batch or transaction handle marks only that handle as rolled
+back:
 
 - the batch is not sealed
 - no `SyncPayload::SealBatch` is emitted
 - pending staged rows are not deleted or rewritten
-- later writes, reads, `commit()`, or `rollback()` calls on that same transaction handle fail
+- later writes, reads, `commit()`, or `rollback()` calls on that same handle fail
 
 ### 5. Authority decision
 
@@ -564,6 +565,7 @@ Important APIs:
 - `tx.commit()`
 - `tx.rollback()`
 - `batch.commit()`
+- `batch.rollback()`
 - `db.beginBatch()`
 - `db.beginTransaction()`
 
@@ -582,8 +584,9 @@ Open explicit batch writes are not individually waitable:
 - `Transaction.update(...)`, `Transaction.delete(...)`, `DirectBatch.update(...)`, and
   `DirectBatch.delete(...)` return `void`
 - `Transaction.commit()` and `DirectBatch.commit()` return the waitable batch handle
-- `Transaction.rollback()` / `DbTransaction.rollback()` return `void` and close the transaction
-  handle without sealing the batch
+- `Transaction.rollback()` / `DbTransaction.rollback()` and
+  `DirectBatch.rollback()` / `DbDirectBatch.rollback()` return `void` and close the handle without
+  sealing the batch
 
 `PersistedWrite` also stays batch-shaped:
 

--- a/specs/status-quo/batches.md
+++ b/specs/status-quo/batches.md
@@ -572,11 +572,14 @@ Important APIs:
 The `Db` batch handles bind lazily: the first table operation chooses the runtime client/schema,
 and later writes through the same handle must stay on that client-bound schema surface.
 
-Transactional handles also support transaction-scoped reads before commit:
+Explicit transaction and batch handles also support scoped reads before commit:
 
 - `Transaction.query(...)`
 - `DbTransaction.all(...)`
 - `DbTransaction.one(...)`
+- `DirectBatch.query(...)`
+- `DbDirectBatch.all(...)`
+- `DbDirectBatch.one(...)`
 
 Open explicit batch writes are not individually waitable:
 

--- a/specs/status-quo/ts_client.md
+++ b/specs/status-quo/ts_client.md
@@ -130,7 +130,7 @@ Open batch writes are intentionally not individually waitable:
 - `tx.insert(...)` and `batch.insert(...)` return the inserted row
 - `tx.update(...)`, `tx.delete(...)`, `batch.update(...)`, and `batch.delete(...)` return `void`
 - `tx.commit()` and `batch.commit()` return the batch-shaped write handle
-- `tx.rollback()` closes an open transaction handle without sealing or committing the batch
+- `tx.rollback()` and `batch.rollback()` close an open handle without sealing or committing the batch
 
 That makes the common durable path explicit in the type shape:
 
@@ -155,9 +155,14 @@ Both explicit batch handles add the explicit completion step:
 - `tx.commit()` in TypeScript
 - `batch.commit()` in TypeScript
 
-Transactional handles also expose `tx.rollback()` / `DbTransaction.rollback()`. Rollback only marks
-that transaction handle as rolled back: it does not seal the batch, does not remove pending staged
-rows, and makes any later write, read, `commit()`, or `rollback()` call on the same transaction fail.
+Explicit transaction and batch handles also expose rollback:
+
+- `tx.rollback()` / `DbTransaction.rollback()`
+- `batch.rollback()` / `DbDirectBatch.rollback()`
+
+Rollback only marks that handle as rolled back: it does not seal the batch, does not remove pending
+staged rows, and makes any later write, read, `commit()`, or `rollback()` call on the same handle
+fail.
 
 Persisted writes are batch-shaped too:
 

--- a/specs/status-quo/ts_client.md
+++ b/specs/status-quo/ts_client.md
@@ -144,11 +144,14 @@ tx.update(app.todos, "todo-1", { done: true });
 await tx.commit().wait({ tier: "global" });
 ```
 
-Transactional handles also expose transaction-scoped reads over their own staged rows:
+Explicit transaction and batch handles also expose reads over their own staged rows:
 
 - `Transaction.query(...)`
 - `DbTransaction.all(...)`
 - `DbTransaction.one(...)`
+- `DirectBatch.query(...)`
+- `DbDirectBatch.all(...)`
+- `DbDirectBatch.one(...)`
 
 Both explicit batch handles add the explicit completion step:
 


### PR DESCRIPTION
## Description

Now that batched writes are not immediately visible globally until the batch is committed, it makes sense for batches to allow reading their own writes, and also be rolled back.

This makes the API of transactions and batches identical, so we can simplify the code a lot as a bonus.