### PR TITLE
fix(sync-manager): block User clients forging BatchFate

### DIFF
--- a/crates/jazz-tools/src/sync_manager/tests/permissions.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/permissions.rs
@@ -333,3 +333,77 @@ fn row_batch_created_from_user_with_older_exact_history_match_skips_permission_c
         "idempotent replay of an older history row should re-emit its cached settlement, got {outbox:?}",
     );
 }
+
+/// `BatchFate` is a server-authority output: it tells the world whether a
+/// batch was durably committed, accepted as a transaction, or rejected. The
+/// only legitimate inbound source is `process_from_server` (a trusted
+/// upstream). A `User`-role client must not be able to forge fate by sending
+/// `SyncPayload::BatchFate` over the client edge — doing so would let any
+/// authenticated user write authoritative durability into storage and
+/// fan-out the lie to every other subscribed client.
+#[test]
+fn batch_fate_from_user_client_must_not_forge_authoritative_fate() {
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
+    let mut io = MemoryStorage::new();
+    let client_id = ClientId::new();
+    let forged_batch_id = BatchId::new();
+
+    add_client(&mut sm, &io, client_id);
+    sm.set_client_role(client_id, ClientRole::User);
+    sm.set_client_session(
+        client_id,
+        crate::query_manager::session::Session::new("mallory"),
+    );
+    sm.take_outbox();
+
+    sm.push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::BatchFate {
+            fate: BatchFate::DurableDirect {
+                batch_id: forged_batch_id,
+                confirmed_tier: DurabilityTier::Local,
+            },
+        },
+    });
+    sm.process_inbox(&mut io);
+
+    let stored_fate = io
+        .load_authoritative_batch_fate(forged_batch_id)
+        .expect("authoritative fate read should succeed");
+    assert!(
+        stored_fate.is_none(),
+        "User client forged a DurableDirect for an unknown batch and the \
+         server accepted it as authoritative: {stored_fate:?}",
+    );
+
+    let stored_record = io
+        .load_local_batch_record(forged_batch_id)
+        .expect("local batch record read should succeed");
+    assert!(
+        stored_record.is_none(),
+        "User client forging a DurableDirect must not synthesize a phantom \
+         LocalBatchRecord on the server: {stored_record:?}",
+    );
+
+    let pending_fates = sm.take_pending_batch_fates();
+    assert!(
+        pending_fates.is_empty(),
+        "Forged fate from a User client must not be queued for fan-out, \
+         got {pending_fates:?}",
+    );
+
+    let outbox = sm.take_outbox();
+    assert!(
+        !outbox.iter().any(|entry| matches!(
+            entry,
+            OutboxEntry {
+                payload: SyncPayload::BatchFate {
+                    fate: BatchFate::DurableDirect { batch_id, .. },
+                },
+                ..
+            } if *batch_id == forged_batch_id
+        )),
+        "Forged fate from a User client must not be relayed to other peers, \
+         got {outbox:?}",
+    );
+}


### PR DESCRIPTION
## Summary

`process_from_client` accepts `SyncPayload::BatchFate` from any role and persists it into authoritative storage. A `User`-role client with a session can forge whole-batch durability outcomes for arbitrary `BatchId`s and have the lie fanned out to every other subscribed client.

This PR opens **draft / TDD-red**: it carries only the failing test that pins the contract. The gate itself follows once the design call (which roles may legitimately produce fate over the client edge) is settled.

## What's in this PR

A single new test in `crates/jazz-tools/src/sync_manager/tests/permissions.rs`:

```rust
#[test]
fn batch_fate_from_user_client_must_not_forge_authoritative_fate() { ... }
```

It drives `process_from_client` with a `User`-role client sending `BatchFate::DurableDirect { batch_id: <fresh UUIDv7>, confirmed_tier: Local }` and asserts:

- no row is written to the authoritative-fate table
- no `LocalBatchRecord` is synthesised for the unknown `batch_id`
- the forged fate is not queued in `pending_batch_fates`
- no outbox relay of the forged fate to other peers

Currently fails at the first assertion:

> `User client forged a DurableDirect for an unknown batch and the server accepted it as authoritative: Some(DurableDirect { ... })`

The other three would surface in turn once the storage write is gated.

## What's missing (the fix itself)

The dangerous path is `inbox.rs:1570-1573`:

```rust
SyncPayload::BatchFate { fate } => {
    self.retain_client_batch_fate(storage, fate);
    self.pending_batch_fates.push(fate.clone());
}
```

`retain_client_batch_fate` calls `storage.upsert_local_batch_record(&record)`, which at `storage_trait.rs:469-471` writes `latest_fate` into the authoritative table via `upsert_authoritative_batch_fate`. For `BatchFate::DurableDirect` with an unknown `batch_id`, `retain_client_batch_fate` even synthesises a phantom `LocalBatchRecord::new(...)` (`inbox.rs:152-160`). No `ClientRole` check guards any of this.

The fix is to role-gate the arm against `process_from_client.client.role` — same precedent already in the file for `CatalogueEntryUpdated` (1319-1362), `RowBatchCreated`/`RowBatchNeeded` (1363-1486), and the explicit log-and-ignore for `SchemaWarning`/`ConnectionSchemaDiagnostics` (1595-1607).

## Open questions before the gate lands

- **Which roles may legitimately send `BatchFate` over the client edge?** My read: none — fate is server-authority output and should only flow inbound via `process_from_server`. But `Peer` is documented as "trusted relay (server-to-server), bypasses all auth"; if peer-as-client topologies exist, those connections may need the pass-through. Worth grepping how `Peer`-role connections are established before locking it in.
- **Scope.** While the file is open, the same gap exists in sibling arms — `SealBatch` (1487-1489), `BatchFateNeeded` (1574-1580), `QuerySettled` (1581-1594). Narrow fix or sweep?
- **Stretch.** Even gated correctly, should the storage write happen from the client edge at all? The legitimate "client tells us a fate it learned downstream" flow is already handled by `process_from_server` at line 1190.

## Provenance

The settlements→fate refactor merged to main via PR #820 (`c739040a`). Before that, the equivalent arm just pushed onto `pending_batch_settlements` and did not touch storage. The fan-out leak pre-dates the refactor; the authoritative-storage forge and phantom-record synthesis are post-refactor regressions and are now live on `main`.

Issue doc: `specs/todo/issues/client-batch-fate-forgery.md` (on branch `docs/issue-batch-fate-client-bypass`).

## Test plan

- [ ] CI runs the new test on this branch — confirm it's red at the first `assert!`.
- [ ] Once the gate lands on top of this commit, the same test must pass without changes to its assertions.
- [ ] Add a positive test alongside the gate confirming a `Peer`/`Backend`/`Admin` (whichever roles end up allowed) can still send `BatchFate` and have it applied.
- [ ] If the sweep includes `SealBatch`/`BatchFateNeeded`/`QuerySettled`, add equivalent forgery tests for each.