### PR TITLE
Use postcard for WebSocket sync frames

### DIFF
--- a/crates/jazz-tools/src/server/mod.rs
+++ b/crates/jazz-tools/src/server/mod.rs
@@ -326,7 +326,7 @@ impl ServerState {
     /// Process a raw binary payload received from a WebSocket client and push it
     /// into the runtime sync inbox.
     ///
-    /// Frames are expected to be `OutboxEntry` JSON (as serialised by
+    /// Frames are expected to be `OutboxEntry` postcard bytes (as serialised by
     /// `TransportManager::run_connected`). If that parse fails we fall back to a
     /// raw `SyncBatchRequest` shape, which some callers send directly.
     pub async fn process_ws_client_frame(
@@ -334,8 +334,7 @@ impl ServerState {
         client_id: ClientId,
         payload: &[u8],
     ) -> Result<(), String> {
-        if let Ok(entry) =
-            serde_json::from_slice::<crate::sync_manager::types::OutboxEntry>(payload)
+        if let Ok(entry) = postcard::from_bytes::<crate::sync_manager::types::OutboxEntry>(payload)
         {
             let inbox = InboxEntry {
                 source: Source::Client(client_id),
@@ -347,7 +346,7 @@ impl ServerState {
                 .map_err(|e| e.to_string());
         }
 
-        match serde_json::from_slice::<crate::transport_protocol::SyncBatchRequest>(payload) {
+        match postcard::from_bytes::<crate::transport_protocol::SyncBatchRequest>(payload) {
             Ok(batch) => {
                 for p in batch.payloads {
                     let inbox = InboxEntry {

--- a/crates/jazz-tools/src/server/routes/mod.rs
+++ b/crates/jazz-tools/src/server/routes/mod.rs
@@ -317,13 +317,37 @@ mod tests {
             payloads: vec![p1, p2],
             client_id,
         };
-        let frame_payload = serde_json::to_vec(&batch).unwrap();
+        let frame_payload = postcard::to_allocvec(&batch).unwrap();
         let result = state
             .process_ws_client_frame(client_id, &frame_payload)
             .await;
         assert!(
             result.is_ok(),
             "two-payload batch should be accepted: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn ws_sync_batch_rejects_json_payload() {
+        let state = make_sync_test_state("test-backend-secret").await;
+        let client_id = ClientId::new();
+        let _ = state.runtime.ensure_client_as_backend(client_id);
+
+        let batch = SyncBatchRequest {
+            payloads: vec![row_version_created_payload(
+                "00000000-0000-0000-0000-000000000001",
+            )],
+            client_id,
+        };
+        let json_payload = serde_json::to_vec(&batch).unwrap();
+
+        let result = state
+            .process_ws_client_frame(client_id, &json_payload)
+            .await;
+
+        assert!(
+            result.is_err(),
+            "JSON websocket sync payloads should be rejected after the postcard switch"
         );
     }
 
@@ -606,7 +630,7 @@ mod tests {
             payloads,
             client_id,
         };
-        let frame_payload = serde_json::to_vec(&batch).unwrap();
+        let frame_payload = postcard::to_allocvec(&batch).unwrap();
         let result = state
             .process_ws_client_frame(client_id, &frame_payload)
             .await;
@@ -2133,9 +2157,10 @@ mod tests {
             catalogue_state_hash: None,
             declared_schema_hash: None,
         };
-        let payload = serde_json::to_vec(&handshake).expect("serialize handshake");
         ws.send(WsMessage::Binary(
-            crate::transport_manager::frame_encode(&payload).into(),
+            crate::transport_manager::frame_encode_postcard(&handshake)
+                .expect("serialize handshake")
+                .into(),
         ))
         .await
         .expect("send handshake");
@@ -2148,10 +2173,9 @@ mod tests {
         let WsMessage::Binary(connected_frame) = connected else {
             panic!("expected binary ConnectedResponse frame, got {connected:?}");
         };
-        let connected_payload = crate::transport_manager::frame_decode(&connected_frame)
-            .expect("decode ConnectedResponse frame");
         let connected_response: crate::transport_manager::ConnectedResponse =
-            serde_json::from_slice(connected_payload).expect("parse ConnectedResponse");
+            crate::transport_manager::frame_decode_postcard(&connected_frame)
+                .expect("parse ConnectedResponse");
         assert_eq!(
             connected_response.sync_protocol_version,
             crate::transport_manager::SYNC_PROTOCOL_VERSION
@@ -2176,7 +2200,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn ws_handler_rejects_pre_versioned_handshake_loudly() {
+    async fn ws_handler_rejects_old_protocol_postcard_handshake_loudly() {
         let state = make_sync_test_state("test-backend-secret").await;
         let app = create_router(state);
 
@@ -2190,17 +2214,20 @@ mod tests {
 
         let ws_url = format!("ws://{addr}{}", test_app_route("/ws"));
         let (mut ws, _) = connect_async(&ws_url).await.expect("connect ws");
-        let payload = serde_json::to_vec(&serde_json::json!({
-            "client_id": ClientId::new().to_string(),
-            "auth": {
-                "backend_secret": "test-backend-secret"
+        let handshake = crate::transport_manager::AuthHandshake {
+            sync_protocol_version: 2,
+            client_id: ClientId::new().to_string(),
+            auth: crate::transport_manager::AuthConfig {
+                backend_secret: Some("test-backend-secret".to_string()),
+                ..Default::default()
             },
-            "catalogue_state_hash": null,
-            "declared_schema_hash": null
-        }))
-        .expect("serialize old handshake");
+            catalogue_state_hash: None,
+            declared_schema_hash: None,
+        };
         ws.send(WsMessage::Binary(
-            crate::transport_manager::frame_encode(&payload).into(),
+            crate::transport_manager::frame_encode_postcard(&handshake)
+                .expect("serialize old handshake")
+                .into(),
         ))
         .await
         .expect("send handshake");
@@ -2213,10 +2240,9 @@ mod tests {
         let WsMessage::Binary(error_frame) = error_frame else {
             panic!("expected binary ServerEvent::Error frame, got {error_frame:?}");
         };
-        let payload =
-            crate::transport_manager::frame_decode(&error_frame).expect("decode error frame");
         let event: crate::jazz_transport::ServerEvent =
-            serde_json::from_slice(payload).expect("parse error event");
+            crate::transport_manager::frame_decode_postcard(&error_frame)
+                .expect("parse error event");
         match event {
             crate::jazz_transport::ServerEvent::Error { message, code } => {
                 assert_eq!(code, crate::jazz_transport::ErrorCode::BadRequest);
@@ -2225,7 +2251,7 @@ mod tests {
                     "unexpected error message: {message}"
                 );
                 assert!(
-                    message.contains("client sent 0"),
+                    message.contains("client sent 2"),
                     "unexpected error message: {message}"
                 );
             }

--- a/crates/jazz-tools/src/server/routes/websocket.rs
+++ b/crates/jazz-tools/src/server/routes/websocket.rs
@@ -256,12 +256,8 @@ async fn send_ws_error_with_code(
         message: message.to_string(),
         code,
     };
-    if let Ok(bytes) = serde_json::to_vec(&event) {
-        let _ = socket
-            .send(Message::Binary(crate::transport_manager::frame_encode(
-                &bytes,
-            )))
-            .await;
+    if let Ok(frame) = crate::transport_manager::frame_encode_postcard(&event) {
+        let _ = socket.send(Message::Binary(frame)).await;
     }
 }
 
@@ -288,21 +284,16 @@ async fn handle_ws_connection(
             return;
         }
     };
-    let payload = match crate::transport_manager::frame_decode(&first) {
-        Some(p) => p.to_vec(),
+    let handshake = match crate::transport_manager::frame_decode_postcard::<
+        crate::transport_manager::AuthHandshake,
+    >(&first)
+    {
+        Some(h) => h,
         None => {
             let _ = socket.close().await;
             return;
         }
     };
-    let handshake =
-        match serde_json::from_slice::<crate::transport_manager::AuthHandshake>(&payload) {
-            Ok(h) => h,
-            Err(_) => {
-                let _ = socket.close().await;
-                return;
-            }
-        };
 
     // Older, pre-versioned clients deserialize as protocol version 0. Reject
     // them explicitly so developers see an actionable update prompt instead
@@ -402,21 +393,15 @@ async fn handle_ws_connection(
         next_sync_seq: Some(next_sync_seq),
         catalogue_state_hash: state.runtime.catalogue_state_hash().ok(),
     };
-    let resp_bytes = match serde_json::to_vec(&resp) {
-        Ok(b) => b,
+    let resp_frame = match crate::transport_manager::frame_encode_postcard(&resp) {
+        Ok(frame) => frame,
         Err(_) => {
             ws_cleanup(&state, connection_id, client_id).await;
             let _ = socket.close().await;
             return;
         }
     };
-    if socket
-        .send(Message::Binary(crate::transport_manager::frame_encode(
-            &resp_bytes,
-        )))
-        .await
-        .is_err()
-    {
+    if socket.send(Message::Binary(resp_frame)).await.is_err() {
         ws_cleanup(&state, connection_id, client_id).await;
         return;
     }
@@ -469,14 +454,12 @@ async fn handle_ws_connection(
                 } else {
                     crate::jazz_transport::ServerEvent::SyncUpdateBatch { updates }
                 };
-                let bytes = match serde_json::to_vec(&event) {
-                    Ok(b) => b,
+                let frame = match crate::transport_manager::frame_encode_postcard(&event) {
+                    Ok(frame) => frame,
                     Err(_) => continue,
                 };
                 if socket
-                    .send(Message::Binary(
-                        crate::transport_manager::frame_encode(&bytes),
-                    ))
+                    .send(Message::Binary(frame))
                     .await
                     .is_err()
                 {
@@ -485,11 +468,9 @@ async fn handle_ws_connection(
             }
             _ = heartbeat.tick() => {
                 let event = crate::jazz_transport::ServerEvent::Heartbeat;
-                let Ok(bytes) = serde_json::to_vec(&event) else { continue };
+                let Ok(frame) = crate::transport_manager::frame_encode_postcard(&event) else { continue };
                 if socket
-                    .send(Message::Binary(
-                        crate::transport_manager::frame_encode(&bytes),
-                    ))
+                    .send(Message::Binary(frame))
                     .await
                     .is_err()
                 {

--- a/crates/jazz-tools/src/transport_manager.rs
+++ b/crates/jazz-tools/src/transport_manager.rs
@@ -6,8 +6,9 @@
 use crate::query_manager::types::SchemaHash;
 use crate::sync_manager::types::{ClientId, InboxEntry, OutboxEntry, ServerId};
 use futures::channel::mpsc;
+use serde::de::DeserializeOwned;
 
-pub const SYNC_PROTOCOL_VERSION: u32 = 2;
+pub const SYNC_PROTOCOL_VERSION: u32 = 3;
 
 pub trait TickNotifier: 'static {
     fn notify(&self);
@@ -146,7 +147,41 @@ pub struct AuthConfig {
     pub backend_secret: Option<String>,
     pub admin_secret: Option<String>,
     pub peer_secret: Option<String>,
+    #[serde(default, with = "auth_backend_session_serde")]
     pub backend_session: Option<serde_json::Value>,
+}
+
+mod auth_backend_session_serde {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S>(value: &Option<serde_json::Value>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if serializer.is_human_readable() {
+            return value.serialize(serializer);
+        }
+
+        let json: Option<String> = value
+            .as_ref()
+            .map(|session| serde_json::to_string(session).map_err(serde::ser::Error::custom))
+            .transpose()?;
+
+        json.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<serde_json::Value>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            return Option::<serde_json::Value>::deserialize(deserializer);
+        }
+
+        let json = Option::<String>::deserialize(deserializer)?;
+        json.map(|session| serde_json::from_str(&session).map_err(serde::de::Error::custom))
+            .transpose()
+    }
 }
 
 impl std::fmt::Debug for AuthConfig {
@@ -253,6 +288,26 @@ mod handshake_tests {
     }
 
     #[test]
+    fn connected_response_postcard_frame_roundtrip() {
+        let response = ConnectedResponse {
+            sync_protocol_version: SYNC_PROTOCOL_VERSION,
+            connection_id: "conn-1".to_string(),
+            client_id: "client-1".to_string(),
+            next_sync_seq: Some(42),
+            catalogue_state_hash: Some("digest-123".to_string()),
+        };
+
+        let frame = frame_encode_postcard(&response).expect("encode ConnectedResponse");
+        let decoded: ConnectedResponse =
+            frame_decode_postcard(&frame).expect("decode ConnectedResponse");
+
+        assert_eq!(decoded.sync_protocol_version, SYNC_PROTOCOL_VERSION);
+        assert_eq!(decoded.connection_id, "conn-1");
+        assert_eq!(decoded.next_sync_seq, Some(42));
+        assert_eq!(decoded.catalogue_state_hash.as_deref(), Some("digest-123"));
+    }
+
+    #[test]
     fn auth_config_serializes_peer_secret_and_redacts_it_from_debug() {
         let auth = AuthConfig {
             peer_secret: Some("cluster-secret".to_string()),
@@ -265,6 +320,37 @@ mod handshake_tests {
         let debug = format!("{auth:?}");
         assert!(debug.contains("peer_secret"));
         assert!(!debug.contains("cluster-secret"));
+    }
+
+    #[test]
+    fn auth_handshake_postcard_roundtrip_preserves_backend_session() {
+        let handshake = AuthHandshake {
+            sync_protocol_version: SYNC_PROTOCOL_VERSION,
+            client_id: "client-1".to_string(),
+            auth: AuthConfig {
+                backend_secret: Some("backend-secret".to_string()),
+                backend_session: Some(serde_json::json!({
+                    "user_id": "alice",
+                    "claims": {
+                        "role": "admin",
+                    },
+                    "auth_mode": "trusted",
+                })),
+                ..Default::default()
+            },
+            catalogue_state_hash: Some("catalogue-digest".to_string()),
+            declared_schema_hash: Some(SchemaHash::from_bytes([9; 32]).to_string()),
+        };
+
+        let frame = frame_encode_postcard(&handshake).expect("encode postcard handshake");
+        let decoded: AuthHandshake =
+            frame_decode_postcard(&frame).expect("decode postcard handshake");
+
+        assert_eq!(decoded.sync_protocol_version, SYNC_PROTOCOL_VERSION);
+        assert_eq!(
+            decoded.auth.backend_session, handshake.auth.backend_session,
+            "backend session claims should survive postcard framing"
+        );
     }
 }
 
@@ -399,6 +485,15 @@ pub(crate) fn frame_encode(payload: &[u8]) -> Vec<u8> {
     out
 }
 
+/// Encode a value as a 4-byte big-endian length-prefixed postcard frame.
+pub(crate) fn frame_encode_postcard<T>(value: &T) -> Result<Vec<u8>, postcard::Error>
+where
+    T: serde::Serialize + ?Sized,
+{
+    let payload = postcard::to_allocvec(value)?;
+    Ok(frame_encode(&payload))
+}
+
 /// Decode a 4-byte big-endian length-prefixed frame, returning the payload slice.
 pub(crate) fn frame_decode(data: &[u8]) -> Option<&[u8]> {
     if data.len() < 4 {
@@ -409,6 +504,15 @@ pub(crate) fn frame_decode(data: &[u8]) -> Option<&[u8]> {
         return None;
     }
     Some(&data[4..4 + len])
+}
+
+/// Decode a single length-prefixed postcard frame.
+pub(crate) fn frame_decode_postcard<T>(data: &[u8]) -> Option<T>
+where
+    T: DeserializeOwned,
+{
+    let payload = frame_decode(data)?;
+    postcard::from_bytes(payload).ok()
 }
 
 /// Outcome of the auth handshake.
@@ -443,9 +547,7 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
             catalogue_state_hash,
             declared_schema_hash,
         };
-        let payload =
-            serde_json::to_vec(&handshake).expect("AuthHandshake serialisation infallible");
-        frame_encode(&payload)
+        frame_encode_postcard(&handshake).expect("AuthHandshake serialisation infallible")
     }
 
     /// Send the pre-built handshake frame and wait for the server's response.
@@ -472,7 +574,7 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
         };
 
         // First try to parse as the success path.
-        if let Ok(resp) = serde_json::from_slice::<ConnectedResponse>(resp_payload) {
+        if let Ok(resp) = postcard::from_bytes::<ConnectedResponse>(resp_payload) {
             if resp.sync_protocol_version != SYNC_PROTOCOL_VERSION {
                 return HandshakeResult::NetworkError(format!(
                     "incompatible Jazz sync protocol: server sent {}, client requires {}. Please update Jazz.",
@@ -484,7 +586,7 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
 
         // Fall back: check whether the server sent an explicit Error event.
         if let Ok(crate::transport_protocol::ServerEvent::Error { message, code }) =
-            serde_json::from_slice::<crate::transport_protocol::ServerEvent>(resp_payload)
+            postcard::from_bytes::<crate::transport_protocol::ServerEvent>(resp_payload)
         {
             if code == crate::transport_protocol::ErrorCode::Unauthorized {
                 return HandshakeResult::AuthFailure(message);
@@ -711,15 +813,13 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
                     // outbox closed = handle dropped; control_rx will also return None shortly.
                     // Route to Shutdown so the same clean-exit path is taken.
                     let Some(entry) = out else { return ConnectedExit::Shutdown; };
-                    let Ok(bytes) = serde_json::to_vec(&entry) else { continue; };
-                    let frame = frame_encode(&bytes);
+                    let Ok(frame) = frame_encode_postcard(&entry) else { continue; };
                     if ws.send(&frame).await.is_err() { return ConnectedExit::NetworkError; }
                 }
                 incoming = ws.recv() => {
                     match incoming {
                         Ok(Some(data)) => {
-                            let Some(payload) = frame_decode(&data) else { continue; };
-                            let Ok(event) = serde_json::from_slice::<crate::transport_protocol::ServerEvent>(payload) else { continue; };
+                            let Some(event) = frame_decode_postcard::<crate::transport_protocol::ServerEvent>(&data) else { continue; };
                             self.dispatch_server_event(event);
                         }
                         Ok(None) | Err(_) => return ConnectedExit::NetworkError,
@@ -898,15 +998,13 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
                     // outbox closed = handle dropped; control_rx will also return None shortly.
                     // Route to Shutdown so the same clean-exit path is taken.
                     let Some(entry) = out else { return WasmConnectedExit::Shutdown; };
-                    let Ok(bytes) = serde_json::to_vec(&entry) else { continue; };
-                    let frame = frame_encode(&bytes);
+                    let Ok(frame) = frame_encode_postcard(&entry) else { continue; };
                     if ws.send(&frame).await.is_err() { return WasmConnectedExit::NetworkError; }
                 }
                 incoming = ws.recv().fuse() => {
                     match incoming {
                         Ok(Some(data)) => {
-                            let Some(payload) = frame_decode(&data) else { continue; };
-                            let Ok(event) = serde_json::from_slice::<crate::transport_protocol::ServerEvent>(payload) else { continue; };
+                            let Some(event) = frame_decode_postcard::<crate::transport_protocol::ServerEvent>(&data) else { continue; };
                             self.dispatch_server_event(event);
                         }
                         Ok(None) | Err(_) => return WasmConnectedExit::NetworkError,
@@ -947,8 +1045,7 @@ mod tests {
                 next_sync_seq: Some(0),
                 catalogue_state_hash: None,
             };
-            let payload = serde_json::to_vec(&resp).unwrap();
-            let frame = frame_encode(&payload);
+            let frame = frame_encode_postcard(&resp).unwrap();
             let mut inbound = VecDeque::new();
             inbound.push_back(frame);
             Ok(MockStream {
@@ -1052,8 +1149,7 @@ mod tests {
             next_sync_seq: Some(0),
             catalogue_state_hash: None,
         };
-        let payload = serde_json::to_vec(&resp).unwrap();
-        frame_encode(&payload)
+        frame_encode_postcard(&resp).unwrap()
     }
 
     #[derive(Clone)]
@@ -1236,10 +1332,7 @@ mod tests {
         let latest_handshake = frames
             .iter()
             .rev()
-            .find_map(|f| {
-                let payload = frame_decode(f)?;
-                serde_json::from_slice::<AuthHandshake>(payload).ok()
-            })
+            .find_map(|f| frame_decode_postcard::<AuthHandshake>(f))
             .expect("at least one AuthHandshake frame sent after update_auth");
         assert_eq!(
             latest_handshake.auth.jwt_token.as_deref(),
@@ -1302,10 +1395,7 @@ mod tests {
         let latest_handshake = frames
             .iter()
             .rev()
-            .find_map(|f| {
-                let payload = frame_decode(f)?;
-                serde_json::from_slice::<AuthHandshake>(payload).ok()
-            })
+            .find_map(|f| frame_decode_postcard::<AuthHandshake>(f))
             .expect("at least one AuthHandshake frame");
         assert_eq!(
             latest_handshake.auth.jwt_token.as_deref(),

--- a/crates/jazz-tools/src/transport_protocol.rs
+++ b/crates/jazz-tools/src/transport_protocol.rs
@@ -13,7 +13,7 @@
 //!
 //! # Wire Format
 //!
-//! Each frame: `[4 bytes: u32 big-endian length][N bytes: JSON]`
+//! Each frame: `[4 bytes: u32 big-endian length][N bytes: postcard]`
 
 use serde::{Deserialize, Serialize};
 
@@ -63,7 +63,6 @@ pub struct SyncBatchResponse {
 /// underlying objects, and the client's local QueryManager handles query
 /// notifications based on the synced data.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type")]
 pub enum ServerEvent {
     /// Connection established, server sends connection ID and confirms client ID.
     Connected {
@@ -73,7 +72,6 @@ pub enum ServerEvent {
         /// Next stream sequence expected from server for this connection.
         next_sync_seq: Option<u64>,
         /// Canonical digest of the server's catalogue state, when available.
-        #[serde(skip_serializing_if = "Option::is_none")]
         catalogue_state_hash: Option<String>,
     },
 
@@ -260,13 +258,13 @@ impl UnauthenticatedResponse {
 impl ServerEvent {
     /// Encode as a length-prefixed binary frame.
     ///
-    /// Format: `[4 bytes: u32 big-endian length][N bytes: JSON]`
+    /// Format: `[4 bytes: u32 big-endian length][N bytes: postcard]`
     pub fn encode_frame(&self) -> Vec<u8> {
-        let json = serde_json::to_vec(self).unwrap_or_default();
-        let len = (json.len() as u32).to_be_bytes();
-        let mut buf = Vec::with_capacity(4 + json.len());
+        let payload = postcard::to_allocvec(self).unwrap_or_default();
+        let len = (payload.len() as u32).to_be_bytes();
+        let mut buf = Vec::with_capacity(4 + payload.len());
         buf.extend_from_slice(&len);
-        buf.extend_from_slice(&json);
+        buf.extend_from_slice(&payload);
         buf
     }
 
@@ -282,7 +280,7 @@ impl ServerEvent {
         if buf.len() < 4 + len {
             return None;
         }
-        let event: ServerEvent = serde_json::from_slice(&buf[4..4 + len]).ok()?;
+        let event: ServerEvent = postcard::from_bytes(&buf[4..4 + len]).ok()?;
         Some((event, 4 + len))
     }
 }
@@ -327,6 +325,33 @@ mod tests {
     }
 
     #[test]
+    fn server_event_frame_payload_is_postcard_not_json() {
+        let event = ServerEvent::Heartbeat;
+        let frame = event.encode_frame();
+        let inner = &frame[4..];
+
+        assert!(
+            serde_json::from_slice::<serde_json::Value>(inner).is_err(),
+            "websocket ServerEvent payloads should be postcard bytes, not JSON"
+        );
+        assert!(ServerEvent::decode_frame(&frame).is_some());
+    }
+
+    #[test]
+    fn server_event_decode_rejects_json_frame_payload() {
+        let event = ServerEvent::Heartbeat;
+        let json = serde_json::to_vec(&event).unwrap();
+        let mut frame = Vec::with_capacity(4 + json.len());
+        frame.extend_from_slice(&(json.len() as u32).to_be_bytes());
+        frame.extend_from_slice(&json);
+
+        assert!(
+            ServerEvent::decode_frame(&frame).is_none(),
+            "JSON websocket frames should not decode after the postcard wire-format switch"
+        );
+    }
+
+    #[test]
     fn test_decode_frame_incomplete() {
         // Too short for length prefix
         assert!(ServerEvent::decode_frame(&[0, 0]).is_none());
@@ -352,7 +377,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sync_batch_request_serialization() {
+    fn test_sync_batch_request_postcard_roundtrip() {
         use crate::metadata::RowProvenance;
         use crate::object::ObjectId;
         use crate::row_histories::{RowState, StoredRowBatch};
@@ -377,12 +402,13 @@ mod tests {
             client_id: ClientId::new(),
         };
 
-        let json = serde_json::to_string(&request).unwrap();
-        assert!(json.contains("payloads"));
-        assert!(json.contains("RowBatchCreated"));
-        assert!(json.contains("main"));
+        let bytes = postcard::to_allocvec(&request).unwrap();
+        assert!(
+            serde_json::from_slice::<serde_json::Value>(&bytes).is_err(),
+            "websocket SyncBatchRequest payloads should be postcard, not JSON"
+        );
 
-        let parsed: SyncBatchRequest = serde_json::from_str(&json).unwrap();
+        let parsed: SyncBatchRequest = postcard::from_bytes(&bytes).unwrap();
         assert_eq!(parsed.payloads.len(), 1);
         assert!(matches!(
             parsed.payloads[0],

--- a/crates/jazz-tools/tests/auth_test.rs
+++ b/crates/jazz-tools/tests/auth_test.rs
@@ -119,7 +119,7 @@ async fn ws_handshake_open(
         catalogue_state_hash: None,
         declared_schema_hash: None,
     };
-    let payload = serde_json::to_vec(&handshake).expect("serialize AuthHandshake");
+    let payload = postcard::to_allocvec(&handshake).expect("serialize AuthHandshake");
     ws.send(Message::Binary(frame_encode(&payload).into()))
         .await
         .map_err(|e| format!("ws send failed: {e}"))?;
@@ -128,17 +128,19 @@ async fn ws_handshake_open(
     match ws.next().await {
         Some(Ok(Message::Binary(bytes))) => {
             let inner = frame_decode(&bytes).ok_or("malformed response frame")?;
-            if let Ok(connected) = serde_json::from_slice::<ConnectedResponse>(inner) {
+            if let Ok(connected) = postcard::from_bytes::<ConnectedResponse>(inner) {
                 Ok((ws, connected))
             } else {
-                let msg = serde_json::from_slice::<serde_json::Value>(inner)
-                    .ok()
-                    .and_then(|v| {
-                        v.get("message")
-                            .and_then(|m| m.as_str())
-                            .map(str::to_string)
-                    })
-                    .unwrap_or_else(|| "auth rejected".to_string());
+                let msg =
+                    postcard::from_bytes::<jazz_tools::transport_protocol::ServerEvent>(inner)
+                        .ok()
+                        .and_then(|event| match event {
+                            jazz_tools::transport_protocol::ServerEvent::Error {
+                                message, ..
+                            } => Some(message),
+                            _ => None,
+                        })
+                        .unwrap_or_else(|| "auth rejected".to_string());
                 Err(msg)
             }
         }
@@ -153,7 +155,7 @@ async fn ws_send_sync_payload(ws: &mut WsStream, payload: SyncPayload) -> Result
         client_id: ClientId::new(),
         payloads: vec![payload],
     };
-    let bytes = serde_json::to_vec(&batch).expect("serialize SyncBatchRequest");
+    let bytes = postcard::to_allocvec(&batch).expect("serialize SyncBatchRequest");
     ws.send(Message::Binary(frame_encode(&bytes).into()))
         .await
         .map_err(|e| format!("ws send sync payload failed: {e}"))
@@ -171,7 +173,7 @@ async fn ws_recv_server_event(
     match message {
         Some(Ok(Message::Binary(bytes))) => {
             let inner = frame_decode(&bytes).ok_or("malformed response frame")?;
-            serde_json::from_slice(inner).map_err(|e| format!("invalid server event: {e}"))
+            postcard::from_bytes(inner).map_err(|e| format!("invalid server event: {e}"))
         }
         Some(Ok(Message::Close(_))) | None => Err("server closed connection".to_string()),
         Some(Ok(other)) => Err(format!("unexpected WS message: {other:?}")),

--- a/crates/jazz-tools/tests/integration.rs
+++ b/crates/jazz-tools/tests/integration.rs
@@ -71,7 +71,7 @@ async fn ws_handshake(port: u16, jwt_token: &str) -> Result<ConnectedResponse, S
         catalogue_state_hash: None,
         declared_schema_hash: None,
     };
-    let payload = serde_json::to_vec(&handshake).expect("serialize AuthHandshake");
+    let payload = postcard::to_allocvec(&handshake).expect("serialize AuthHandshake");
     ws.send(Message::Binary(frame_encode(&payload).into()))
         .await
         .map_err(|e| format!("ws send failed: {e}"))?;
@@ -79,15 +79,16 @@ async fn ws_handshake(port: u16, jwt_token: &str) -> Result<ConnectedResponse, S
     match ws.next().await {
         Some(Ok(Message::Binary(bytes))) => {
             let inner = frame_decode(&bytes).ok_or("malformed response frame")?;
-            if let Ok(connected) = serde_json::from_slice::<ConnectedResponse>(inner) {
+            if let Ok(connected) = postcard::from_bytes::<ConnectedResponse>(inner) {
                 return Ok(connected);
             }
-            let msg = serde_json::from_slice::<serde_json::Value>(inner)
+            let msg = postcard::from_bytes::<jazz_tools::transport_protocol::ServerEvent>(inner)
                 .ok()
-                .and_then(|v| {
-                    v.get("message")
-                        .and_then(|m| m.as_str())
-                        .map(str::to_string)
+                .and_then(|event| match event {
+                    jazz_tools::transport_protocol::ServerEvent::Error { message, .. } => {
+                        Some(message)
+                    }
+                    _ => None,
                 })
                 .unwrap_or_else(|| "auth rejected".to_string());
             Err(msg)
@@ -370,7 +371,7 @@ async fn test_ws_connection_stays_open_after_handshake() {
         catalogue_state_hash: None,
         declared_schema_hash: None,
     };
-    let payload = serde_json::to_vec(&handshake).expect("serialize AuthHandshake");
+    let payload = postcard::to_allocvec(&handshake).expect("serialize AuthHandshake");
     ws.send(Message::Binary(frame_encode(&payload).into()))
         .await
         .expect("ws send handshake");

--- a/crates/jazz-tools/tests/policies_integration/authorship_policies.rs
+++ b/crates/jazz-tools/tests/policies_integration/authorship_policies.rs
@@ -101,7 +101,7 @@ async fn create_note_with_backend_attribution(
         payloads,
         client_id,
     };
-    let frame_payload = serde_json::to_vec(&batch).expect("serialize SyncBatchRequest");
+    let frame_payload = postcard::to_allocvec(&batch).expect("serialize SyncBatchRequest");
     let state = server.server_state();
     // Ensure the client is registered as a backend client before processing.
     state

--- a/crates/jazz-tools/tests/support/mod.rs
+++ b/crates/jazz-tools/tests/support/mod.rs
@@ -343,7 +343,7 @@ fn build_catalogue_runtime(
             let push_errors = push_errors.clone();
             let in_flight_pushes = in_flight_pushes.clone();
             tokio::spawn(async move {
-                let frame = serde_json::to_vec(&jazz_tools::sync_manager::OutboxEntry {
+                let frame = postcard::to_allocvec(&jazz_tools::sync_manager::OutboxEntry {
                     destination: Destination::Server(ServerId::default()),
                     payload,
                 })

--- a/specs/status-quo/http_transport.md
+++ b/specs/status-quo/http_transport.md
@@ -21,6 +21,9 @@ carrying payloads such as:
 - `Error`
 - `Heartbeat`
 
+Each WebSocket message is a binary frame with a 4-byte big-endian length prefix
+followed by postcard-encoded transport payload bytes.
+
 The connection is app-scoped, so every non-health server interaction uses the same `/apps/<app_id>/...`
 prefix as the cloud server.
 


### PR DESCRIPTION
## Summary

- Switch the WebSocket sync wire payloads from length-prefixed JSON to length-prefixed postcard while keeping the existing 4-byte big-endian frame prefix.
- Bump the sync protocol version to `3` so JSON-frame clients fail loudly instead of silently misreading frames.
- Preserve JSON-based helper APIs and HTTP/local fallback behavior outside the WebSocket path.
- Add postcard-safe handling for `backend_session` in auth handshakes.

## Size Percentiles

Trace set: sync payload traces older than 24h, `2026-05-07 11:42:15-2026-05-08 12:52:16 UTC` (`12,637,197` JSON sync payloads, `5,022,531,305` bytes). The table compares traced `payload_json` bytes against the same payloads re-encoded through this PR's postcard `SyncPayload` encoder. Payload bytes only; the shared 4-byte frame prefix is excluded.

| Payload | Samples | p50 JSON -> postcard | p50 saved | p95 JSON -> postcard | p95 saved | Total saved |
|---|---:|---:|---:|---:|---:|---:|
| All sync payloads | 12,637,197 | 82 B -> 35 B | 57.3% | 1,018 B -> 471 B | 53.7% | 53.8% |
| `RowBatchCreated` | 4,435,700 | 1,007 B -> 469 B | 53.4% | 1,029 B -> 472 B | 54.1% | 53.2% |
| `SealBatch` | 36,785 | 470 B -> 139 B | 70.4% | 477 B -> 139 B | 70.9% | 70.9% |
| `BatchFate` | 8,162,757 | 82 B -> 35 B | 57.3% | 82 B -> 35 B | 57.3% | 57.3% |
| `RowBatchNeeded` | 1,300 | 936 B -> 394 B | 57.9% | 954 B -> 397 B | 58.4% | 58.0% |
| `QuerySettled` | 73 | 6,576 B -> 3,906 B | 40.6% | 6,583 B -> 3,907 B | 40.7% | 40.6% |
| `CatalogueEntryUpdated` | 553 | 534 B -> 212 B | 60.3% | 758 B -> 338 B | 55.4% | 57.7% |
| `QuerySubscription` | 20 | 611 B -> 176 B | 71.2% | 611 B -> 176 B | 71.2% | 71.2% |

## Checks

- `pnpm build:core`
- `dev/stress-tests/todo-react`: generated `10,000` projects / `50,000` todos; list rendered `100` todos.
- Re-encoded `12,637,197` traced sync payloads through the postcard encoder for the table above.