### PR TITLE
Use MessagePack for WebSocket transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1800,6 +1800,7 @@ dependencies = [
  "rand 0.8.5",
  "rcgen",
  "reqwest",
+ "rmp-serde",
  "rocksdb",
  "rusqlite",
  "rustls",
@@ -3079,6 +3080,25 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1790,6 +1790,7 @@ dependencies = [
  "internment",
  "jsonschema",
  "jsonwebtoken",
+ "lz4_flex",
  "mimalloc",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -2069,6 +2070,15 @@ checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+dependencies = [
+ "twox-hash",
 ]
 
 [[package]]
@@ -4254,6 +4264,12 @@ dependencies = [
  "thiserror 1.0.69",
  "utf-8",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"

--- a/crates/jazz-tools/Cargo.toml
+++ b/crates/jazz-tools/Cargo.toml
@@ -120,6 +120,7 @@ opentelemetry-otlp = { version = "0.31", features = [
 ], optional = true }
 opentelemetry-stdout = { version = "0.31", features = ["trace"], optional = true }
 tracing-opentelemetry = { version = "0.32", optional = true }
+lz4_flex = "0.11"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 gloo-timers = { version = "0.3", features = ["futures"] }

--- a/crates/jazz-tools/Cargo.toml
+++ b/crates/jazz-tools/Cargo.toml
@@ -64,6 +64,7 @@ hex = "0.4"
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+rmp-serde = "1"
 serde_bytes = "0.11"
 postcard = { version = "1", features = ["alloc"] }
 jsonschema = { version = "0.42", default-features = false }

--- a/crates/jazz-tools/src/catalogue.rs
+++ b/crates/jazz-tools/src/catalogue.rs
@@ -11,6 +11,7 @@ use crate::row_format::{decode_row, encode_row};
 pub struct CatalogueEntry {
     pub object_id: ObjectId,
     pub metadata: HashMap<String, String>,
+    #[serde(with = "serde_bytes")]
     pub content: Vec<u8>,
 }
 

--- a/crates/jazz-tools/src/lib.rs
+++ b/crates/jazz-tools/src/lib.rs
@@ -35,7 +35,7 @@ pub use runtime_tokio as jazz_tokio;
 pub mod transport_protocol;
 pub use transport_protocol as jazz_transport;
 pub mod transport_manager;
-mod transport_wire;
+pub mod transport_wire;
 #[cfg(feature = "transport-websocket")]
 pub mod ws_stream;
 

--- a/crates/jazz-tools/src/lib.rs
+++ b/crates/jazz-tools/src/lib.rs
@@ -35,6 +35,7 @@ pub use runtime_tokio as jazz_tokio;
 pub mod transport_protocol;
 pub use transport_protocol as jazz_transport;
 pub mod transport_manager;
+mod transport_wire;
 #[cfg(feature = "transport-websocket")]
 pub mod ws_stream;
 

--- a/crates/jazz-tools/src/server/mod.rs
+++ b/crates/jazz-tools/src/server/mod.rs
@@ -326,7 +326,7 @@ impl ServerState {
     /// Process a raw binary payload received from a WebSocket client and push it
     /// into the runtime sync inbox.
     ///
-    /// Frames are expected to be `OutboxEntry` JSON (as serialised by
+    /// Frames are expected to be `OutboxEntry` MessagePack (as serialised by
     /// `TransportManager::run_connected`). If that parse fails we fall back to a
     /// raw `SyncBatchRequest` shape, which some callers send directly.
     pub async fn process_ws_client_frame(
@@ -335,7 +335,7 @@ impl ServerState {
         payload: &[u8],
     ) -> Result<(), String> {
         if let Ok(entry) =
-            serde_json::from_slice::<crate::sync_manager::types::OutboxEntry>(payload)
+            crate::transport_wire::decode::<crate::sync_manager::types::OutboxEntry>(payload)
         {
             let inbox = InboxEntry {
                 source: Source::Client(client_id),
@@ -347,7 +347,8 @@ impl ServerState {
                 .map_err(|e| e.to_string());
         }
 
-        match serde_json::from_slice::<crate::transport_protocol::SyncBatchRequest>(payload) {
+        match crate::transport_wire::decode::<crate::transport_protocol::SyncBatchRequest>(payload)
+        {
             Ok(batch) => {
                 for p in batch.payloads {
                     let inbox = InboxEntry {

--- a/crates/jazz-tools/src/server/routes/mod.rs
+++ b/crates/jazz-tools/src/server/routes/mod.rs
@@ -317,7 +317,7 @@ mod tests {
             payloads: vec![p1, p2],
             client_id,
         };
-        let frame_payload = serde_json::to_vec(&batch).unwrap();
+        let frame_payload = rmp_serde::to_vec_named(&batch).unwrap();
         let result = state
             .process_ws_client_frame(client_id, &frame_payload)
             .await;
@@ -606,7 +606,7 @@ mod tests {
             payloads,
             client_id,
         };
-        let frame_payload = serde_json::to_vec(&batch).unwrap();
+        let frame_payload = rmp_serde::to_vec_named(&batch).unwrap();
         let result = state
             .process_ws_client_frame(client_id, &frame_payload)
             .await;
@@ -2133,7 +2133,7 @@ mod tests {
             catalogue_state_hash: None,
             declared_schema_hash: None,
         };
-        let payload = serde_json::to_vec(&handshake).expect("serialize handshake");
+        let payload = crate::transport_wire::encode(&handshake).expect("serialize handshake");
         ws.send(WsMessage::Binary(
             crate::transport_manager::frame_encode(&payload).into(),
         ))
@@ -2151,7 +2151,7 @@ mod tests {
         let connected_payload = crate::transport_manager::frame_decode(&connected_frame)
             .expect("decode ConnectedResponse frame");
         let connected_response: crate::transport_manager::ConnectedResponse =
-            serde_json::from_slice(connected_payload).expect("parse ConnectedResponse");
+            crate::transport_wire::decode(connected_payload).expect("parse ConnectedResponse");
         assert_eq!(
             connected_response.sync_protocol_version,
             crate::transport_manager::SYNC_PROTOCOL_VERSION
@@ -2190,7 +2190,7 @@ mod tests {
 
         let ws_url = format!("ws://{addr}{}", test_app_route("/ws"));
         let (mut ws, _) = connect_async(&ws_url).await.expect("connect ws");
-        let payload = serde_json::to_vec(&serde_json::json!({
+        let payload = crate::transport_wire::encode(&serde_json::json!({
             "client_id": ClientId::new().to_string(),
             "auth": {
                 "backend_secret": "test-backend-secret"
@@ -2216,7 +2216,7 @@ mod tests {
         let payload =
             crate::transport_manager::frame_decode(&error_frame).expect("decode error frame");
         let event: crate::jazz_transport::ServerEvent =
-            serde_json::from_slice(payload).expect("parse error event");
+            crate::transport_wire::decode(payload).expect("parse error event");
         match event {
             crate::jazz_transport::ServerEvent::Error { message, code } => {
                 assert_eq!(code, crate::jazz_transport::ErrorCode::BadRequest);

--- a/crates/jazz-tools/src/server/routes/mod.rs
+++ b/crates/jazz-tools/src/server/routes/mod.rs
@@ -317,7 +317,7 @@ mod tests {
             payloads: vec![p1, p2],
             client_id,
         };
-        let frame_payload = rmp_serde::to_vec_named(&batch).unwrap();
+        let frame_payload = crate::transport_wire::encode(&batch).unwrap();
         let result = state
             .process_ws_client_frame(client_id, &frame_payload)
             .await;
@@ -606,7 +606,7 @@ mod tests {
             payloads,
             client_id,
         };
-        let frame_payload = rmp_serde::to_vec_named(&batch).unwrap();
+        let frame_payload = crate::transport_wire::encode(&batch).unwrap();
         let result = state
             .process_ws_client_frame(client_id, &frame_payload)
             .await;

--- a/crates/jazz-tools/src/server/routes/websocket.rs
+++ b/crates/jazz-tools/src/server/routes/websocket.rs
@@ -256,12 +256,8 @@ async fn send_ws_error_with_code(
         message: message.to_string(),
         code,
     };
-    if let Ok(bytes) = serde_json::to_vec(&event) {
-        let _ = socket
-            .send(Message::Binary(crate::transport_manager::frame_encode(
-                &bytes,
-            )))
-            .await;
+    if let Ok(frame) = crate::transport_wire::encode_frame(&event) {
+        let _ = socket.send(Message::Binary(frame)).await;
     }
 }
 
@@ -296,7 +292,7 @@ async fn handle_ws_connection(
         }
     };
     let handshake =
-        match serde_json::from_slice::<crate::transport_manager::AuthHandshake>(&payload) {
+        match crate::transport_wire::decode::<crate::transport_manager::AuthHandshake>(&payload) {
             Ok(h) => h,
             Err(_) => {
                 let _ = socket.close().await;
@@ -402,7 +398,7 @@ async fn handle_ws_connection(
         next_sync_seq: Some(next_sync_seq),
         catalogue_state_hash: state.runtime.catalogue_state_hash().ok(),
     };
-    let resp_bytes = match serde_json::to_vec(&resp) {
+    let resp_frame = match crate::transport_wire::encode_frame(&resp) {
         Ok(b) => b,
         Err(_) => {
             ws_cleanup(&state, connection_id, client_id).await;
@@ -410,13 +406,7 @@ async fn handle_ws_connection(
             return;
         }
     };
-    if socket
-        .send(Message::Binary(crate::transport_manager::frame_encode(
-            &resp_bytes,
-        )))
-        .await
-        .is_err()
-    {
+    if socket.send(Message::Binary(resp_frame)).await.is_err() {
         ws_cleanup(&state, connection_id, client_id).await;
         return;
     }
@@ -469,14 +459,12 @@ async fn handle_ws_connection(
                 } else {
                     crate::jazz_transport::ServerEvent::SyncUpdateBatch { updates }
                 };
-                let bytes = match serde_json::to_vec(&event) {
+                let frame = match crate::transport_wire::encode_frame(&event) {
                     Ok(b) => b,
                     Err(_) => continue,
                 };
                 if socket
-                    .send(Message::Binary(
-                        crate::transport_manager::frame_encode(&bytes),
-                    ))
+                    .send(Message::Binary(frame))
                     .await
                     .is_err()
                 {
@@ -485,11 +473,9 @@ async fn handle_ws_connection(
             }
             _ = heartbeat.tick() => {
                 let event = crate::jazz_transport::ServerEvent::Heartbeat;
-                let Ok(bytes) = serde_json::to_vec(&event) else { continue };
+                let Ok(frame) = crate::transport_wire::encode_frame(&event) else { continue };
                 if socket
-                    .send(Message::Binary(
-                        crate::transport_manager::frame_encode(&bytes),
-                    ))
+                    .send(Message::Binary(frame))
                     .await
                     .is_err()
                 {

--- a/crates/jazz-tools/src/transport_manager.rs
+++ b/crates/jazz-tools/src/transport_manager.rs
@@ -1060,7 +1060,7 @@ mod tests {
         );
 
         let decoded: AuthHandshake =
-            rmp_serde::from_slice(payload).expect("handshake payload should be MessagePack");
+            transport_wire::decode(payload).expect("handshake payload should be MessagePack");
         assert_eq!(decoded.sync_protocol_version, SYNC_PROTOCOL_VERSION);
         assert_eq!(decoded.client_id, manager.client_id.to_string());
     }

--- a/crates/jazz-tools/src/transport_manager.rs
+++ b/crates/jazz-tools/src/transport_manager.rs
@@ -5,9 +5,12 @@
 
 use crate::query_manager::types::SchemaHash;
 use crate::sync_manager::types::{ClientId, InboxEntry, OutboxEntry, ServerId};
+use crate::transport_wire;
 use futures::channel::mpsc;
 
-pub const SYNC_PROTOCOL_VERSION: u32 = 2;
+pub(crate) use crate::transport_wire::{frame_decode, frame_encode};
+
+pub const SYNC_PROTOCOL_VERSION: u32 = 3;
 
 pub trait TickNotifier: 'static {
     fn notify(&self);
@@ -387,30 +390,6 @@ pub fn create<W: StreamAdapter, T: TickNotifier>(
     (handle, manager)
 }
 
-/// Encode a payload as a 4-byte big-endian length-prefixed frame.
-pub(crate) fn frame_encode(payload: &[u8]) -> Vec<u8> {
-    debug_assert!(
-        payload.len() <= u32::MAX as usize,
-        "frame payload exceeds u32 limit"
-    );
-    let mut out = Vec::with_capacity(4 + payload.len());
-    out.extend_from_slice(&(payload.len() as u32).to_be_bytes());
-    out.extend_from_slice(payload);
-    out
-}
-
-/// Decode a 4-byte big-endian length-prefixed frame, returning the payload slice.
-pub(crate) fn frame_decode(data: &[u8]) -> Option<&[u8]> {
-    if data.len() < 4 {
-        return None;
-    }
-    let len = u32::from_be_bytes(data[0..4].try_into().unwrap()) as usize;
-    if data.len() < 4 + len {
-        return None;
-    }
-    Some(&data[4..4 + len])
-}
-
 /// Outcome of the auth handshake.
 pub(crate) enum HandshakeResult {
     /// Server accepted; connection is open.
@@ -444,7 +423,7 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
             declared_schema_hash,
         };
         let payload =
-            serde_json::to_vec(&handshake).expect("AuthHandshake serialisation infallible");
+            transport_wire::encode(&handshake).expect("AuthHandshake serialisation infallible");
         frame_encode(&payload)
     }
 
@@ -472,7 +451,7 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
         };
 
         // First try to parse as the success path.
-        if let Ok(resp) = serde_json::from_slice::<ConnectedResponse>(resp_payload) {
+        if let Ok(resp) = transport_wire::decode::<ConnectedResponse>(resp_payload) {
             if resp.sync_protocol_version != SYNC_PROTOCOL_VERSION {
                 return HandshakeResult::NetworkError(format!(
                     "incompatible Jazz sync protocol: server sent {}, client requires {}. Please update Jazz.",
@@ -484,7 +463,7 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
 
         // Fall back: check whether the server sent an explicit Error event.
         if let Ok(crate::transport_protocol::ServerEvent::Error { message, code }) =
-            serde_json::from_slice::<crate::transport_protocol::ServerEvent>(resp_payload)
+            transport_wire::decode::<crate::transport_protocol::ServerEvent>(resp_payload)
         {
             if code == crate::transport_protocol::ErrorCode::Unauthorized {
                 return HandshakeResult::AuthFailure(message);
@@ -711,7 +690,7 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
                     // outbox closed = handle dropped; control_rx will also return None shortly.
                     // Route to Shutdown so the same clean-exit path is taken.
                     let Some(entry) = out else { return ConnectedExit::Shutdown; };
-                    let Ok(bytes) = serde_json::to_vec(&entry) else { continue; };
+                    let Ok(bytes) = transport_wire::encode(&entry) else { continue; };
                     let frame = frame_encode(&bytes);
                     if ws.send(&frame).await.is_err() { return ConnectedExit::NetworkError; }
                 }
@@ -719,7 +698,7 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
                     match incoming {
                         Ok(Some(data)) => {
                             let Some(payload) = frame_decode(&data) else { continue; };
-                            let Ok(event) = serde_json::from_slice::<crate::transport_protocol::ServerEvent>(payload) else { continue; };
+                            let Ok(event) = transport_wire::decode::<crate::transport_protocol::ServerEvent>(payload) else { continue; };
                             self.dispatch_server_event(event);
                         }
                         Ok(None) | Err(_) => return ConnectedExit::NetworkError,
@@ -898,7 +877,7 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
                     // outbox closed = handle dropped; control_rx will also return None shortly.
                     // Route to Shutdown so the same clean-exit path is taken.
                     let Some(entry) = out else { return WasmConnectedExit::Shutdown; };
-                    let Ok(bytes) = serde_json::to_vec(&entry) else { continue; };
+                    let Ok(bytes) = transport_wire::encode(&entry) else { continue; };
                     let frame = frame_encode(&bytes);
                     if ws.send(&frame).await.is_err() { return WasmConnectedExit::NetworkError; }
                 }
@@ -906,7 +885,7 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
                     match incoming {
                         Ok(Some(data)) => {
                             let Some(payload) = frame_decode(&data) else { continue; };
-                            let Ok(event) = serde_json::from_slice::<crate::transport_protocol::ServerEvent>(payload) else { continue; };
+                            let Ok(event) = transport_wire::decode::<crate::transport_protocol::ServerEvent>(payload) else { continue; };
                             self.dispatch_server_event(event);
                         }
                         Ok(None) | Err(_) => return WasmConnectedExit::NetworkError,
@@ -947,7 +926,7 @@ mod tests {
                 next_sync_seq: Some(0),
                 catalogue_state_hash: None,
             };
-            let payload = serde_json::to_vec(&resp).unwrap();
+            let payload = transport_wire::encode(&resp).unwrap();
             let frame = frame_encode(&payload);
             let mut inbound = VecDeque::new();
             inbound.push_back(frame);
@@ -1052,7 +1031,7 @@ mod tests {
             next_sync_seq: Some(0),
             catalogue_state_hash: None,
         };
-        let payload = serde_json::to_vec(&resp).unwrap();
+        let payload = transport_wire::encode(&resp).unwrap();
         frame_encode(&payload)
     }
 
@@ -1062,6 +1041,28 @@ mod tests {
         fn notify(&self) {
             self.0.fetch_add(1, Ordering::SeqCst);
         }
+    }
+
+    #[tokio::test]
+    async fn auth_handshake_frame_uses_messagepack_payload() {
+        let (_handle, manager) = create::<MockStream, CountingTick>(
+            "mock://".to_string(),
+            AuthConfig::default(),
+            CountingTick(Arc::new(AtomicUsize::new(0))),
+        );
+
+        let frame = manager.build_handshake_frame();
+        let payload = frame_decode(&frame).expect("handshake frame has payload");
+
+        assert!(
+            serde_json::from_slice::<serde_json::Value>(payload).is_err(),
+            "handshake payload should not be JSON"
+        );
+
+        let decoded: AuthHandshake =
+            rmp_serde::from_slice(payload).expect("handshake payload should be MessagePack");
+        assert_eq!(decoded.sync_protocol_version, SYNC_PROTOCOL_VERSION);
+        assert_eq!(decoded.client_id, manager.client_id.to_string());
     }
 
     #[tokio::test]
@@ -1238,7 +1239,7 @@ mod tests {
             .rev()
             .find_map(|f| {
                 let payload = frame_decode(f)?;
-                serde_json::from_slice::<AuthHandshake>(payload).ok()
+                transport_wire::decode::<AuthHandshake>(payload).ok()
             })
             .expect("at least one AuthHandshake frame sent after update_auth");
         assert_eq!(
@@ -1304,7 +1305,7 @@ mod tests {
             .rev()
             .find_map(|f| {
                 let payload = frame_decode(f)?;
-                serde_json::from_slice::<AuthHandshake>(payload).ok()
+                transport_wire::decode::<AuthHandshake>(payload).ok()
             })
             .expect("at least one AuthHandshake frame");
         assert_eq!(

--- a/crates/jazz-tools/src/transport_protocol.rs
+++ b/crates/jazz-tools/src/transport_protocol.rs
@@ -13,7 +13,7 @@
 //!
 //! # Wire Format
 //!
-//! Each frame: `[4 bytes: u32 big-endian length][N bytes: JSON]`
+//! Each frame: `[4 bytes: u32 big-endian length][N bytes: MessagePack]`
 
 use serde::{Deserialize, Serialize};
 
@@ -260,14 +260,9 @@ impl UnauthenticatedResponse {
 impl ServerEvent {
     /// Encode as a length-prefixed binary frame.
     ///
-    /// Format: `[4 bytes: u32 big-endian length][N bytes: JSON]`
+    /// Format: `[4 bytes: u32 big-endian length][N bytes: MessagePack]`
     pub fn encode_frame(&self) -> Vec<u8> {
-        let json = serde_json::to_vec(self).unwrap_or_default();
-        let len = (json.len() as u32).to_be_bytes();
-        let mut buf = Vec::with_capacity(4 + json.len());
-        buf.extend_from_slice(&len);
-        buf.extend_from_slice(&json);
-        buf
+        crate::transport_wire::encode_frame(self).unwrap_or_default()
     }
 
     /// Decode a single frame from a buffer.
@@ -282,7 +277,7 @@ impl ServerEvent {
         if buf.len() < 4 + len {
             return None;
         }
-        let event: ServerEvent = serde_json::from_slice(&buf[4..4 + len]).ok()?;
+        let event: ServerEvent = crate::transport_wire::decode(&buf[4..4 + len]).ok()?;
         Some((event, 4 + len))
     }
 }
@@ -302,6 +297,10 @@ mod tests {
 
         let frame = event.encode_frame();
         assert!(frame.len() > 4);
+        assert!(
+            serde_json::from_slice::<serde_json::Value>(&frame[4..]).is_err(),
+            "ServerEvent frames should carry MessagePack payloads, not JSON"
+        );
 
         let (decoded, consumed) = ServerEvent::decode_frame(&frame).unwrap();
         assert_eq!(consumed, frame.len());

--- a/crates/jazz-tools/src/transport_wire.rs
+++ b/crates/jazz-tools/src/transport_wire.rs
@@ -1,0 +1,74 @@
+//! WebSocket wire helpers shared by the client transport and server route.
+//!
+//! The outer frame stays intentionally tiny: a 4-byte big-endian payload
+//! length followed by one MessagePack-encoded transport value.
+
+use serde::{Serialize, de::DeserializeOwned};
+
+/// Encode a payload as a 4-byte big-endian length-prefixed frame.
+pub(crate) fn frame_encode(payload: &[u8]) -> Vec<u8> {
+    debug_assert!(
+        payload.len() <= u32::MAX as usize,
+        "frame payload exceeds u32 limit"
+    );
+    let mut out = Vec::with_capacity(4 + payload.len());
+    out.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+    out.extend_from_slice(payload);
+    out
+}
+
+/// Decode a 4-byte big-endian length-prefixed frame, returning the payload slice.
+pub(crate) fn frame_decode(data: &[u8]) -> Option<&[u8]> {
+    if data.len() < 4 {
+        return None;
+    }
+    let len = u32::from_be_bytes(data[0..4].try_into().unwrap()) as usize;
+    if data.len() < 4 + len {
+        return None;
+    }
+    Some(&data[4..4 + len])
+}
+
+pub(crate) fn encode<T: Serialize>(value: &T) -> Result<Vec<u8>, rmp_serde::encode::Error> {
+    let mut buf = Vec::new();
+    let mut serializer = rmp_serde::Serializer::new(&mut buf).with_struct_map();
+    value.serialize(&mut serializer)?;
+    Ok(buf)
+}
+
+pub(crate) fn decode<T: DeserializeOwned>(payload: &[u8]) -> Result<T, rmp_serde::decode::Error> {
+    rmp_serde::from_slice(payload)
+}
+
+pub(crate) fn encode_frame<T: Serialize>(value: &T) -> Result<Vec<u8>, rmp_serde::encode::Error> {
+    let payload = encode(value)?;
+    Ok(frame_encode(&payload))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_prefers_messagepack_binary_for_row_bytes() {
+        #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+        struct Payload {
+            bytes: crate::query_manager::types::RowBytes,
+        }
+
+        let payload = Payload {
+            bytes: vec![1_u8, 2, 3].into(),
+        };
+        let encoded = encode(&payload).expect("encode bytes");
+
+        assert!(
+            encoded
+                .windows(5)
+                .any(|window| window == [0xc4, 3, 1, 2, 3]),
+            "row bytes should use MessagePack bin8, not an integer array"
+        );
+
+        let decoded: Payload = decode(&encoded).expect("decode bytes");
+        assert_eq!(decoded, payload);
+    }
+}

--- a/crates/jazz-tools/src/transport_wire.rs
+++ b/crates/jazz-tools/src/transport_wire.rs
@@ -1,12 +1,46 @@
 //! WebSocket wire helpers shared by the client transport and server route.
 //!
 //! The outer frame stays intentionally tiny: a 4-byte big-endian payload
-//! length followed by one MessagePack-encoded transport value.
+//! length followed by one tagged transport value. The transport value is
+//! MessagePack, optionally compressed with LZ4 when that reduces the payload.
+
+use std::{borrow::Cow, error::Error, fmt};
 
 use serde::{Serialize, de::DeserializeOwned};
 
+const WIRE_MESSAGEPACK: u8 = 0;
+const WIRE_LZ4_MESSAGEPACK: u8 = 1;
+
+#[derive(Debug)]
+pub enum DecodeError {
+    EmptyPayload,
+    UnknownWireKind(u8),
+    Lz4(String),
+    MessagePack(rmp_serde::decode::Error),
+}
+
+impl fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyPayload => f.write_str("empty transport payload"),
+            Self::UnknownWireKind(kind) => write!(f, "unknown transport payload kind {kind}"),
+            Self::Lz4(err) => write!(f, "invalid LZ4 transport payload: {err}"),
+            Self::MessagePack(err) => write!(f, "invalid MessagePack transport payload: {err}"),
+        }
+    }
+}
+
+impl Error for DecodeError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::MessagePack(err) => Some(err),
+            Self::EmptyPayload | Self::UnknownWireKind(_) | Self::Lz4(_) => None,
+        }
+    }
+}
+
 /// Encode a payload as a 4-byte big-endian length-prefixed frame.
-pub(crate) fn frame_encode(payload: &[u8]) -> Vec<u8> {
+pub fn frame_encode(payload: &[u8]) -> Vec<u8> {
     debug_assert!(
         payload.len() <= u32::MAX as usize,
         "frame payload exceeds u32 limit"
@@ -18,7 +52,7 @@ pub(crate) fn frame_encode(payload: &[u8]) -> Vec<u8> {
 }
 
 /// Decode a 4-byte big-endian length-prefixed frame, returning the payload slice.
-pub(crate) fn frame_decode(data: &[u8]) -> Option<&[u8]> {
+pub fn frame_decode(data: &[u8]) -> Option<&[u8]> {
     if data.len() < 4 {
         return None;
     }
@@ -29,18 +63,40 @@ pub(crate) fn frame_decode(data: &[u8]) -> Option<&[u8]> {
     Some(&data[4..4 + len])
 }
 
-pub(crate) fn encode<T: Serialize>(value: &T) -> Result<Vec<u8>, rmp_serde::encode::Error> {
+pub fn encode<T: Serialize>(value: &T) -> Result<Vec<u8>, rmp_serde::encode::Error> {
     let mut buf = Vec::new();
     let mut serializer = rmp_serde::Serializer::new(&mut buf).with_struct_map();
     value.serialize(&mut serializer)?;
-    Ok(buf)
+
+    let compressed = lz4_flex::compress_prepend_size(&buf);
+    if compressed.len() < buf.len() {
+        let mut out = Vec::with_capacity(1 + compressed.len());
+        out.push(WIRE_LZ4_MESSAGEPACK);
+        out.extend_from_slice(&compressed);
+        Ok(out)
+    } else {
+        let mut out = Vec::with_capacity(1 + buf.len());
+        out.push(WIRE_MESSAGEPACK);
+        out.extend_from_slice(&buf);
+        Ok(out)
+    }
 }
 
-pub(crate) fn decode<T: DeserializeOwned>(payload: &[u8]) -> Result<T, rmp_serde::decode::Error> {
-    rmp_serde::from_slice(payload)
+pub fn decode<T: DeserializeOwned>(payload: &[u8]) -> Result<T, DecodeError> {
+    let (kind, inner) = payload.split_first().ok_or(DecodeError::EmptyPayload)?;
+    let messagepack = match *kind {
+        WIRE_MESSAGEPACK => Cow::Borrowed(inner),
+        WIRE_LZ4_MESSAGEPACK => Cow::Owned(
+            lz4_flex::decompress_size_prepended(inner)
+                .map_err(|err| DecodeError::Lz4(err.to_string()))?,
+        ),
+        other => return Err(DecodeError::UnknownWireKind(other)),
+    };
+
+    rmp_serde::from_slice(&messagepack).map_err(DecodeError::MessagePack)
 }
 
-pub(crate) fn encode_frame<T: Serialize>(value: &T) -> Result<Vec<u8>, rmp_serde::encode::Error> {
+pub fn encode_frame<T: Serialize>(value: &T) -> Result<Vec<u8>, rmp_serde::encode::Error> {
     let payload = encode(value)?;
     Ok(frame_encode(&payload))
 }
@@ -48,6 +104,15 @@ pub(crate) fn encode_frame<T: Serialize>(value: &T) -> Result<Vec<u8>, rmp_serde
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn raw_messagepack<T: Serialize>(value: &T) -> Vec<u8> {
+        let mut buf = Vec::new();
+        let mut serializer = rmp_serde::Serializer::new(&mut buf).with_struct_map();
+        value
+            .serialize(&mut serializer)
+            .expect("encode raw MessagePack");
+        buf
+    }
 
     #[test]
     fn encode_prefers_messagepack_binary_for_row_bytes() {
@@ -69,6 +134,53 @@ mod tests {
         );
 
         let decoded: Payload = decode(&encoded).expect("decode bytes");
+        assert_eq!(decoded, payload);
+    }
+
+    #[test]
+    fn encode_compresses_large_payloads_when_lz4_is_smaller() {
+        #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+        struct Payload {
+            bytes: crate::query_manager::types::RowBytes,
+        }
+
+        let payload = Payload {
+            bytes: vec![7_u8; 4096].into(),
+        };
+        let raw = raw_messagepack(&payload);
+        let encoded = encode(&payload).expect("encode payload");
+
+        assert!(
+            encoded.len() < raw.len(),
+            "large repetitive payload should be smaller on the wire: raw={} wire={}",
+            raw.len(),
+            encoded.len()
+        );
+
+        let decoded: Payload = decode(&encoded).expect("decode payload");
+        assert_eq!(decoded, payload);
+    }
+
+    #[test]
+    fn encode_keeps_small_payloads_uncompressed() {
+        #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+        struct Payload {
+            bytes: crate::query_manager::types::RowBytes,
+        }
+
+        let payload = Payload {
+            bytes: vec![1_u8, 2, 3].into(),
+        };
+        let raw = raw_messagepack(&payload);
+        let encoded = encode(&payload).expect("encode payload");
+
+        assert_eq!(
+            encoded.len(),
+            raw.len() + 1,
+            "small payloads should only pay the compression tag byte"
+        );
+
+        let decoded: Payload = decode(&encoded).expect("decode payload");
         assert_eq!(decoded, payload);
     }
 }

--- a/crates/jazz-tools/tests/auth_test.rs
+++ b/crates/jazz-tools/tests/auth_test.rs
@@ -119,7 +119,7 @@ async fn ws_handshake_open(
         catalogue_state_hash: None,
         declared_schema_hash: None,
     };
-    let payload = rmp_serde::to_vec_named(&handshake).expect("serialize AuthHandshake");
+    let payload = jazz_tools::transport_wire::encode(&handshake).expect("serialize AuthHandshake");
     ws.send(Message::Binary(frame_encode(&payload).into()))
         .await
         .map_err(|e| format!("ws send failed: {e}"))?;
@@ -128,10 +128,10 @@ async fn ws_handshake_open(
     match ws.next().await {
         Some(Ok(Message::Binary(bytes))) => {
             let inner = frame_decode(&bytes).ok_or("malformed response frame")?;
-            if let Ok(connected) = rmp_serde::from_slice::<ConnectedResponse>(inner) {
+            if let Ok(connected) = jazz_tools::transport_wire::decode::<ConnectedResponse>(inner) {
                 Ok((ws, connected))
             } else {
-                let msg = rmp_serde::from_slice::<serde_json::Value>(inner)
+                let msg = jazz_tools::transport_wire::decode::<serde_json::Value>(inner)
                     .ok()
                     .and_then(|v| {
                         v.get("message")
@@ -153,7 +153,7 @@ async fn ws_send_sync_payload(ws: &mut WsStream, payload: SyncPayload) -> Result
         client_id: ClientId::new(),
         payloads: vec![payload],
     };
-    let bytes = rmp_serde::to_vec_named(&batch).expect("serialize SyncBatchRequest");
+    let bytes = jazz_tools::transport_wire::encode(&batch).expect("serialize SyncBatchRequest");
     ws.send(Message::Binary(frame_encode(&bytes).into()))
         .await
         .map_err(|e| format!("ws send sync payload failed: {e}"))
@@ -171,7 +171,8 @@ async fn ws_recv_server_event(
     match message {
         Some(Ok(Message::Binary(bytes))) => {
             let inner = frame_decode(&bytes).ok_or("malformed response frame")?;
-            rmp_serde::from_slice(inner).map_err(|e| format!("invalid server event: {e}"))
+            jazz_tools::transport_wire::decode(inner)
+                .map_err(|e| format!("invalid server event: {e}"))
         }
         Some(Ok(Message::Close(_))) | None => Err("server closed connection".to_string()),
         Some(Ok(other)) => Err(format!("unexpected WS message: {other:?}")),

--- a/crates/jazz-tools/tests/auth_test.rs
+++ b/crates/jazz-tools/tests/auth_test.rs
@@ -119,7 +119,7 @@ async fn ws_handshake_open(
         catalogue_state_hash: None,
         declared_schema_hash: None,
     };
-    let payload = serde_json::to_vec(&handshake).expect("serialize AuthHandshake");
+    let payload = rmp_serde::to_vec_named(&handshake).expect("serialize AuthHandshake");
     ws.send(Message::Binary(frame_encode(&payload).into()))
         .await
         .map_err(|e| format!("ws send failed: {e}"))?;
@@ -128,10 +128,10 @@ async fn ws_handshake_open(
     match ws.next().await {
         Some(Ok(Message::Binary(bytes))) => {
             let inner = frame_decode(&bytes).ok_or("malformed response frame")?;
-            if let Ok(connected) = serde_json::from_slice::<ConnectedResponse>(inner) {
+            if let Ok(connected) = rmp_serde::from_slice::<ConnectedResponse>(inner) {
                 Ok((ws, connected))
             } else {
-                let msg = serde_json::from_slice::<serde_json::Value>(inner)
+                let msg = rmp_serde::from_slice::<serde_json::Value>(inner)
                     .ok()
                     .and_then(|v| {
                         v.get("message")
@@ -153,7 +153,7 @@ async fn ws_send_sync_payload(ws: &mut WsStream, payload: SyncPayload) -> Result
         client_id: ClientId::new(),
         payloads: vec![payload],
     };
-    let bytes = serde_json::to_vec(&batch).expect("serialize SyncBatchRequest");
+    let bytes = rmp_serde::to_vec_named(&batch).expect("serialize SyncBatchRequest");
     ws.send(Message::Binary(frame_encode(&bytes).into()))
         .await
         .map_err(|e| format!("ws send sync payload failed: {e}"))
@@ -171,7 +171,7 @@ async fn ws_recv_server_event(
     match message {
         Some(Ok(Message::Binary(bytes))) => {
             let inner = frame_decode(&bytes).ok_or("malformed response frame")?;
-            serde_json::from_slice(inner).map_err(|e| format!("invalid server event: {e}"))
+            rmp_serde::from_slice(inner).map_err(|e| format!("invalid server event: {e}"))
         }
         Some(Ok(Message::Close(_))) | None => Err("server closed connection".to_string()),
         Some(Ok(other)) => Err(format!("unexpected WS message: {other:?}")),

--- a/crates/jazz-tools/tests/integration.rs
+++ b/crates/jazz-tools/tests/integration.rs
@@ -71,7 +71,7 @@ async fn ws_handshake(port: u16, jwt_token: &str) -> Result<ConnectedResponse, S
         catalogue_state_hash: None,
         declared_schema_hash: None,
     };
-    let payload = serde_json::to_vec(&handshake).expect("serialize AuthHandshake");
+    let payload = rmp_serde::to_vec_named(&handshake).expect("serialize AuthHandshake");
     ws.send(Message::Binary(frame_encode(&payload).into()))
         .await
         .map_err(|e| format!("ws send failed: {e}"))?;
@@ -79,10 +79,10 @@ async fn ws_handshake(port: u16, jwt_token: &str) -> Result<ConnectedResponse, S
     match ws.next().await {
         Some(Ok(Message::Binary(bytes))) => {
             let inner = frame_decode(&bytes).ok_or("malformed response frame")?;
-            if let Ok(connected) = serde_json::from_slice::<ConnectedResponse>(inner) {
+            if let Ok(connected) = rmp_serde::from_slice::<ConnectedResponse>(inner) {
                 return Ok(connected);
             }
-            let msg = serde_json::from_slice::<serde_json::Value>(inner)
+            let msg = rmp_serde::from_slice::<serde_json::Value>(inner)
                 .ok()
                 .and_then(|v| {
                     v.get("message")
@@ -370,7 +370,7 @@ async fn test_ws_connection_stays_open_after_handshake() {
         catalogue_state_hash: None,
         declared_schema_hash: None,
     };
-    let payload = serde_json::to_vec(&handshake).expect("serialize AuthHandshake");
+    let payload = rmp_serde::to_vec_named(&handshake).expect("serialize AuthHandshake");
     ws.send(Message::Binary(frame_encode(&payload).into()))
         .await
         .expect("ws send handshake");

--- a/crates/jazz-tools/tests/integration.rs
+++ b/crates/jazz-tools/tests/integration.rs
@@ -71,7 +71,7 @@ async fn ws_handshake(port: u16, jwt_token: &str) -> Result<ConnectedResponse, S
         catalogue_state_hash: None,
         declared_schema_hash: None,
     };
-    let payload = rmp_serde::to_vec_named(&handshake).expect("serialize AuthHandshake");
+    let payload = jazz_tools::transport_wire::encode(&handshake).expect("serialize AuthHandshake");
     ws.send(Message::Binary(frame_encode(&payload).into()))
         .await
         .map_err(|e| format!("ws send failed: {e}"))?;
@@ -79,10 +79,10 @@ async fn ws_handshake(port: u16, jwt_token: &str) -> Result<ConnectedResponse, S
     match ws.next().await {
         Some(Ok(Message::Binary(bytes))) => {
             let inner = frame_decode(&bytes).ok_or("malformed response frame")?;
-            if let Ok(connected) = rmp_serde::from_slice::<ConnectedResponse>(inner) {
+            if let Ok(connected) = jazz_tools::transport_wire::decode::<ConnectedResponse>(inner) {
                 return Ok(connected);
             }
-            let msg = rmp_serde::from_slice::<serde_json::Value>(inner)
+            let msg = jazz_tools::transport_wire::decode::<serde_json::Value>(inner)
                 .ok()
                 .and_then(|v| {
                     v.get("message")
@@ -370,7 +370,7 @@ async fn test_ws_connection_stays_open_after_handshake() {
         catalogue_state_hash: None,
         declared_schema_hash: None,
     };
-    let payload = rmp_serde::to_vec_named(&handshake).expect("serialize AuthHandshake");
+    let payload = jazz_tools::transport_wire::encode(&handshake).expect("serialize AuthHandshake");
     ws.send(Message::Binary(frame_encode(&payload).into()))
         .await
         .expect("ws send handshake");

--- a/crates/jazz-tools/tests/policies_integration/authorship_policies.rs
+++ b/crates/jazz-tools/tests/policies_integration/authorship_policies.rs
@@ -101,7 +101,7 @@ async fn create_note_with_backend_attribution(
         payloads,
         client_id,
     };
-    let frame_payload = serde_json::to_vec(&batch).expect("serialize SyncBatchRequest");
+    let frame_payload = rmp_serde::to_vec_named(&batch).expect("serialize SyncBatchRequest");
     let state = server.server_state();
     // Ensure the client is registered as a backend client before processing.
     state

--- a/crates/jazz-tools/tests/policies_integration/authorship_policies.rs
+++ b/crates/jazz-tools/tests/policies_integration/authorship_policies.rs
@@ -101,7 +101,8 @@ async fn create_note_with_backend_attribution(
         payloads,
         client_id,
     };
-    let frame_payload = rmp_serde::to_vec_named(&batch).expect("serialize SyncBatchRequest");
+    let frame_payload =
+        jazz_tools::transport_wire::encode(&batch).expect("serialize SyncBatchRequest");
     let state = server.server_state();
     // Ensure the client is registered as a backend client before processing.
     state

--- a/crates/jazz-tools/tests/support/mod.rs
+++ b/crates/jazz-tools/tests/support/mod.rs
@@ -324,6 +324,14 @@ fn make_jwt(sub: &str, claims: JsonValue) -> String {
     .expect("encode jwt")
 }
 
+fn encode_ws_payload<T: serde::Serialize>(payload: &T) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    payload
+        .serialize(&mut rmp_serde::Serializer::new(&mut bytes).with_struct_map())
+        .expect("serialize websocket payload");
+    bytes
+}
+
 fn build_catalogue_runtime(
     schema_manager: SchemaManager,
     storage: MemoryStorage,
@@ -343,11 +351,10 @@ fn build_catalogue_runtime(
             let push_errors = push_errors.clone();
             let in_flight_pushes = in_flight_pushes.clone();
             tokio::spawn(async move {
-                let frame = serde_json::to_vec(&jazz_tools::sync_manager::OutboxEntry {
+                let frame = encode_ws_payload(&jazz_tools::sync_manager::OutboxEntry {
                     destination: Destination::Server(ServerId::default()),
                     payload,
-                })
-                .expect("serialize OutboxEntry");
+                });
                 if let Err(error) = state.process_ws_client_frame(client_id, &frame).await {
                     if let Ok(mut errors) = push_errors.lock() {
                         errors.push(error);
@@ -437,6 +444,7 @@ pub async fn push_catalogue_in_memory(
     }
 
     wait_for_in_flight_pushes(&in_flight_pushes).await;
+    state.runtime.flush().await?;
 
     let errors = push_errors.lock().unwrap().clone();
     if !errors.is_empty() {

--- a/crates/jazz-tools/tests/support/mod.rs
+++ b/crates/jazz-tools/tests/support/mod.rs
@@ -325,11 +325,7 @@ fn make_jwt(sub: &str, claims: JsonValue) -> String {
 }
 
 fn encode_ws_payload<T: serde::Serialize>(payload: &T) -> Vec<u8> {
-    let mut bytes = Vec::new();
-    payload
-        .serialize(&mut rmp_serde::Serializer::new(&mut bytes).with_struct_map())
-        .expect("serialize websocket payload");
-    bytes
+    jazz_tools::transport_wire::encode(payload).expect("serialize websocket payload")
 }
 
 fn build_catalogue_runtime(


### PR DESCRIPTION
## Summary

- Switch the WebSocket wire payloads from JSON to MessagePack while keeping the existing 4-byte length-prefixed frame format.
- Compress MessagePack payloads with LZ4 only when compression makes the payload smaller; otherwise send raw MessagePack behind the same one-byte wire tag.
- Add a shared transport wire helper used by the client transport manager, server WebSocket routes, server events, and WebSocket tests.
- Bump the sync protocol version to `3` and update WebSocket tests/helpers to encode and decode the new format.
- Keep row bytes encoded as MessagePack binary fields, including catalogue content bytes.

## Size Percentiles

Trace set: sync payload traces older than 24h, `2026-05-07 11:42:15-2026-05-08 12:52:16 UTC` (`12,637,197` JSON sync payloads, `5,022,531,305` bytes). The table compares traced `payload_json` bytes against the same payloads re-encoded through this PR's MessagePack+LZ4 `SyncPayload` encoder. Payload bytes only; the one-byte wire-kind tag is included and the shared 4-byte frame prefix is excluded.

| Payload | Samples | p50 JSON -> MessagePack+LZ4 | p50 saved | p95 JSON -> MessagePack+LZ4 | p95 saved | Total saved |
|---|---:|---:|---:|---:|---:|---:|
| All sync payloads | 12,637,197 | 82 B -> 71 B | 13.4% | 1,019 B -> 478 B | 53.1% | 46.3% |
| `RowBatchCreated` | 4,435,700 | 1,007 B -> 475 B | 52.8% | 1,031 B -> 494 B | 52.1% | 51.4% |
| `SealBatch` | 36,785 | 470 B -> 290 B | 38.3% | 477 B -> 296 B | 37.9% | 43.3% |
| `BatchFate` | 8,162,757 | 82 B -> 71 B | 13.4% | 82 B -> 71 B | 13.4% | 13.4% |
| `RowBatchNeeded` | 1,300 | 936 B -> 458 B | 51.1% | 954 B -> 464 B | 51.4% | 50.9% |
| `QuerySettled` | 73 | 6,576 B -> 1,088 B | 83.5% | 6,583 B -> 1,177 B | 82.1% | 82.8% |
| `CatalogueEntryUpdated` | 553 | 534 B -> 264 B | 50.6% | 758 B -> 379 B | 50.0% | 49.6% |
| `QuerySubscription` | 20 | 611 B -> 451 B | 26.2% | 611 B -> 457 B | 25.2% | 26.0% |
| `BatchFateNeeded` | 1 | 2,008,650 B -> 978,601 B | 51.3% | 2,008,650 B -> 978,601 B | 51.3% | 51.3% |
| `Error` | 8 | 108 B -> 76 B | 29.6% | 108 B -> 76 B | 29.6% | 29.6% |

## Checks

- `git diff --check`
- `cargo test -p jazz-tools --features test transport_wire::tests:: -- --nocapture`
- `cargo test -p jazz-tools --features test`
- `pnpm build:core`
- pre-commit hook: clippy + rustfmt
- Re-encoded `12,637,197` traced sync payloads through the MessagePack+LZ4 encoder for the table above.