### PR TITLE
ci: reduce workflow build cost

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,12 @@ jobs:
           key: sccache-${{ github.repository_id }}-${{ runner.os }}-v1
           path: /home/runner/.cache/sccache
 
+      - name: Mount Turbo sticky disk
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: turbo-cache-${{ github.repository_id }}-${{ runner.os }}-v1
+          path: ${{ github.workspace }}/.turbo/cache
+
       - run: pnpm build:ci
       - name: Mount Playwright sticky disk
         uses: useblacksmith/stickydisk@v1

--- a/.github/workflows/expo-android-maestro-e2e.yml
+++ b/.github/workflows/expo-android-maestro-e2e.yml
@@ -30,29 +30,24 @@ jobs:
       disableIOS: true
 
   build-jazz-tools-sandbox:
-    name: Build jazz-tools sandbox binary (${{ matrix.target }})
+    name: Build jazz-tools sandbox binary (x86_64-unknown-linux-musl)
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - x86_64-unknown-linux-musl
-          - aarch64-unknown-linux-musl
     env:
       CARGO_ZIGBUILD_CACHE_DIR: /tmp/cargo-zigbuild-cache
+      JAZZ_TOOLS_SANDBOX_TARGET: x86_64-unknown-linux-musl
     steps:
       - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.93.1
-          targets: ${{ matrix.target }}
+          targets: ${{ env.JAZZ_TOOLS_SANDBOX_TARGET }}
 
       - uses: mlugg/setup-zig@v2
         with:
           version: 0.14.0
-          cache-key: ${{ matrix.target }}
+          cache-key: ${{ env.JAZZ_TOOLS_SANDBOX_TARGET }}
 
       - uses: taiki-e/install-action@v2
         with:
@@ -65,15 +60,15 @@ jobs:
       - name: Build sandbox binary
         run: |
           mkdir -p .artifacts/jazz-tools
-          cargo zigbuild --release -p jazz-tools --bin jazz-tools --features cli --target "${{ matrix.target }}"
-          cp "target/${{ matrix.target }}/release/jazz-tools" ".artifacts/jazz-tools/jazz-tools-${{ matrix.target }}"
+          cargo zigbuild --release -p jazz-tools --bin jazz-tools --features cli --target "${JAZZ_TOOLS_SANDBOX_TARGET}"
+          cp "target/${JAZZ_TOOLS_SANDBOX_TARGET}/release/jazz-tools" ".artifacts/jazz-tools/jazz-tools-${JAZZ_TOOLS_SANDBOX_TARGET}"
 
       - name: Upload sandbox binary
         uses: actions/upload-artifact@v4
         with:
-          name: jazz-tools-sandbox-${{ matrix.target }}
+          name: jazz-tools-sandbox-${{ env.JAZZ_TOOLS_SANDBOX_TARGET }}
           if-no-files-found: error
-          path: .artifacts/jazz-tools/jazz-tools-${{ matrix.target }}
+          path: .artifacts/jazz-tools/jazz-tools-${{ env.JAZZ_TOOLS_SANDBOX_TARGET }}
 
   expo-android-e2e:
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -102,9 +97,8 @@ jobs:
       - name: Download jazz-tools sandbox binaries
         uses: actions/download-artifact@v5
         with:
-          pattern: jazz-tools-sandbox-*
+          name: jazz-tools-sandbox-x86_64-unknown-linux-musl
           path: .artifacts/jazz-tools
-          merge-multiple: true
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -224,9 +218,13 @@ jobs:
           echo "SERVER_PUBLIC_URL=$SERVER_PUBLIC_URL" >> "$GITHUB_ENV"
 
           ARCH="$(sandbox exec "${COMMON[@]}" "$SANDBOX_ID" uname -m | tr -d '\r' | tail -n1)"
+          echo "Sandbox architecture: $ARCH"
           case "$ARCH" in
             x86_64|amd64) BINARY=".artifacts/jazz-tools/jazz-tools-x86_64-unknown-linux-musl" ;;
-            aarch64|arm64) BINARY=".artifacts/jazz-tools/jazz-tools-aarch64-unknown-linux-musl" ;;
+            aarch64|arm64)
+              echo "::error::Sandbox architecture $ARCH needs an aarch64 binary, but this workflow only builds x86_64 to avoid building unused targets."
+              exit 1
+              ;;
             *) echo "::error::Unsupported sandbox arch: $ARCH"; exit 1 ;;
           esac
           if [ ! -f "$BINARY" ]; then


### PR DESCRIPTION
## Summary

- persist Turbo's local cache for the `test-ts` CI job before `pnpm build:ci`
- build only the x86_64 `jazz-tools` sandbox binary for Expo Android E2E
- keep a runtime sandbox architecture check so an arm64 sandbox fails with a clear message

## Measured results

Rerunning the same CI workflow showed the Turbo sticky disk cache working:

| Metric | First run | Rerun |
| --- | ---: | ---: |
| Whole `CI` workflow | 8m29s | 5m21s |
| `test-ts` job | 8m17s | 2m59s |
| `pnpm build:ci` | 5m23s | 4s |

The Expo E2E change also removes the unused arm64 sandbox binary build. On the PR run, Expo E2E used about 20.6 job-minutes versus comparable recent runs around 24.6-25.6 job-minutes.

## Validation

- `git diff --check -- .github/workflows/ci.yml .github/workflows/expo-android-maestro-e2e.yml`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "#{f}: yaml ok" }' .github/workflows/ci.yml .github/workflows/expo-android-maestro-e2e.yml`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore 'label "blacksmith-4vcpu-ubuntu-2404" is unknown' .github/workflows/ci.yml .github/workflows/expo-android-maestro-e2e.yml`
- `gh run rerun 25603438207 --repo garden-co/jazz` then `gh run watch 25603438207 --repo garden-co/jazz --exit-status --interval 30`