### PR TITLE
Fix invite write durability waits

### DIFF
--- a/.changeset/fix-worker-hydrated-batch-records.md
+++ b/.changeset/fix-worker-hydrated-batch-records.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Use stronger worker-hydrated batch settlements when resolving durability waits in browser runtimes.

--- a/packages/jazz-tools/src/runtime/client.test.ts
+++ b/packages/jazz-tools/src/runtime/client.test.ts
@@ -3,6 +3,7 @@ import {
   WriteResult,
   JazzClient,
   resolveDefaultDurabilityTier,
+  type LocalBatchRecord,
   type MutationErrorEvent,
   type Runtime,
   WriteHandle,
@@ -84,6 +85,18 @@ function makeContext(): AppContext {
     schema: {},
     serverUrl: "https://example.test",
     jwtToken: "initial.jwt.token",
+  };
+}
+
+function makeLocalBatchRecord(
+  batchId: string,
+  latestSettlement: LocalBatchRecord["latestSettlement"] = null,
+): LocalBatchRecord {
+  return {
+    batchId,
+    mode: "direct",
+    sealed: true,
+    latestSettlement,
   };
 }
 
@@ -198,6 +211,51 @@ describe("JazzClient.updateCookieSession", () => {
     expect(runtime.updateAuth).toHaveBeenCalledTimes(1);
     const arg = runtime.updateAuth.mock.calls[0][0] as string;
     expect(JSON.parse(arg)).toMatchObject({ jwt_token: null });
+  });
+});
+
+describe("JazzClient worker batch hydration", () => {
+  it("unblocks waits when the worker has a more durable settlement than the main runtime", async () => {
+    vi.useFakeTimers();
+    try {
+      const runtime = makeFakeRuntime();
+      runtime.loadLocalBatchRecord.mockImplementation((batchId: string) => {
+        if (batchId !== "batch-chat") return null;
+        return makeLocalBatchRecord("batch-chat", {
+          kind: "durableDirect",
+          batchId: "batch-chat",
+          confirmedTier: "local",
+        });
+      });
+      runtime.loadLocalBatchRecords.mockReturnValue([
+        makeLocalBatchRecord("batch-chat", {
+          kind: "durableDirect",
+          batchId: "batch-chat",
+          confirmedTier: "local",
+        }),
+      ]);
+      const client = JazzClient.connectWithRuntime(runtime as any, makeContext());
+
+      const wait = client.waitForPersistedBatch("batch-chat", "edge");
+
+      client.hydrateLocalBatchRecords([
+        makeLocalBatchRecord("batch-chat", {
+          kind: "durableDirect",
+          batchId: "batch-chat",
+          confirmedTier: "global",
+        }),
+      ]);
+
+      expect(client.localBatchRecord("batch-chat")?.latestSettlement).toMatchObject({
+        confirmedTier: "global",
+      });
+      expect(client.hasPendingHydratedBatchReconciliation("edge")).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(20);
+      await expect(wait).resolves.toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -735,6 +735,41 @@ function settlementSatisfiesTier(
   return durabilityTierRank(settlement.confirmedTier) >= durabilityTierRank(tier);
 }
 
+function settlementConfirmedTierRank(settlement: BatchFate | null | undefined): number | null {
+  if (!settlement) {
+    return null;
+  }
+  if (settlement.kind !== "durableDirect" && settlement.kind !== "acceptedTransaction") {
+    return null;
+  }
+  return durabilityTierRank(settlement.confirmedTier);
+}
+
+function hydratedRecordShouldOverrideRuntime(
+  runtimeRecord: LocalBatchRecord | null | undefined,
+  hydratedRecord: LocalBatchRecord | null | undefined,
+): boolean {
+  if (!hydratedRecord) {
+    return false;
+  }
+  if (!runtimeRecord) {
+    return true;
+  }
+
+  const hydratedSettlement = hydratedRecord.latestSettlement;
+  const runtimeSettlement = runtimeRecord.latestSettlement;
+  if (hydratedSettlement?.kind === "rejected" && runtimeSettlement?.kind !== "rejected") {
+    return true;
+  }
+  if (runtimeSettlement?.kind === "rejected") {
+    return false;
+  }
+
+  const hydratedTier = settlementConfirmedTierRank(hydratedSettlement);
+  const runtimeTier = settlementConfirmedTierRank(runtimeSettlement);
+  return hydratedTier !== null && (runtimeTier === null || hydratedTier > runtimeTier);
+}
+
 function rejectionFromSettlement(
   settlement: BatchFate | null | undefined,
 ): PersistedWriteRejectedError | null {
@@ -1271,7 +1306,7 @@ export class JazzClient {
    */
   private readonly mutationErrorListeners = new Set<(event: MutationErrorEvent) => void>();
   private readonly acknowledgedRejectedBatchErrors = new Map<string, PersistedWriteRejectedError>();
-  private readonly replayedRejectedBatchRecords = new Map<string, LocalBatchRecord>();
+  private readonly hydratedWorkerBatchRecords = new Map<string, LocalBatchRecord>();
   private readonly hydratedWorkerBatchIds = new Set<string>();
   private readonly completedEmptyBatchIds = new Set<string>();
   private readonly pendingReplayedRejectedBatchIds = new Set<string>();
@@ -1539,14 +1574,11 @@ export class JazzClient {
 
   localBatchRecord(batchId: string): LocalBatchRecord | null {
     const runtimeRecord = this.requireBatchRecordMethod("loadLocalBatchRecord")(batchId);
-    const replayedRecord = this.replayedRejectedBatchRecords.get(batchId) ?? null;
-    if (
-      replayedRecord?.latestSettlement?.kind === "rejected" &&
-      runtimeRecord?.latestSettlement?.kind !== "rejected"
-    ) {
-      return replayedRecord;
+    const hydratedRecord = this.hydratedWorkerBatchRecords.get(batchId) ?? null;
+    if (hydratedRecordShouldOverrideRuntime(runtimeRecord, hydratedRecord)) {
+      return hydratedRecord;
     }
-    return runtimeRecord ?? replayedRecord ?? null;
+    return runtimeRecord ?? hydratedRecord ?? null;
   }
 
   localBatchRecords(): LocalBatchRecord[] {
@@ -1556,13 +1588,9 @@ export class JazzClient {
         record,
       ]),
     );
-    for (const [batchId, record] of this.replayedRejectedBatchRecords) {
+    for (const [batchId, record] of this.hydratedWorkerBatchRecords) {
       const runtimeRecord = records.get(batchId);
-      if (
-        !runtimeRecord ||
-        (record.latestSettlement?.kind === "rejected" &&
-          runtimeRecord.latestSettlement?.kind !== "rejected")
-      ) {
+      if (hydratedRecordShouldOverrideRuntime(runtimeRecord, record)) {
         records.set(batchId, record);
       }
     }
@@ -1607,7 +1635,7 @@ export class JazzClient {
     const acknowledgedInRuntime = this.requireBatchRecordMethod("acknowledgeRejectedBatch")(
       batchId,
     );
-    const acknowledgedReplayed = this.replayedRejectedBatchRecords.delete(batchId);
+    const acknowledgedReplayed = this.hydratedWorkerBatchRecords.delete(batchId);
     this.pendingReplayedRejectedBatchIds.delete(batchId);
     const acknowledged = acknowledgedInRuntime || acknowledgedReplayed;
     if (acknowledged && rejection) {
@@ -1624,16 +1652,10 @@ export class JazzClient {
     for (const record of records) {
       this.hydratedWorkerBatchIds.add(record.batchId);
       const runtimeRecord = loadLocalBatchRecord(record.batchId);
-      if (
-        runtimeRecord &&
-        !(
-          record.latestSettlement?.kind === "rejected" &&
-          runtimeRecord.latestSettlement?.kind !== "rejected"
-        )
-      ) {
+      if (!hydratedRecordShouldOverrideRuntime(runtimeRecord, record)) {
         continue;
       }
-      this.replayedRejectedBatchRecords.set(record.batchId, record);
+      this.hydratedWorkerBatchRecords.set(record.batchId, record);
       if (record.latestSettlement?.kind === "rejected") {
         this.pendingReplayedRejectedBatchIds.add(record.batchId);
       }
@@ -1645,7 +1667,7 @@ export class JazzClient {
     if (record.latestSettlement?.kind !== "rejected") {
       return;
     }
-    this.replayedRejectedBatchRecords.set(record.batchId, record);
+    this.hydratedWorkerBatchRecords.set(record.batchId, record);
     this.pendingReplayedRejectedBatchIds.add(record.batchId);
   }
 


### PR DESCRIPTION
## What

Fixes the invite flow getting stuck while waiting for writes to reach the configured durability tier.

## Broken message flow before

1. The chat app creates the initial chat with an `edge` durability wait.
2. The main browser runtime records the new write batch as durable only at `local`.
3. The worker runtime syncs that same batch to the server.
4. The server confirms the batch and the worker observes a stronger settlement, for example `global` durability.
5. The worker hydrates its local batch records back into the main runtime.
6. The main runtime already has a batch record for the same batch id, so `localBatchRecord(batchId)` kept returning the main runtime's older `local` settlement.
7. `waitForPersistedBatch(batchId, "edge")` looked at that older `local` settlement, decided it had not reached `edge`, and stayed pending.
8. In the invite test, that meant `CreateChatRedirect` stayed on `Creating chat...`; the user never reached the chat view, so the invite flow could not continue.

## Why it works now

When worker-hydrated batch records arrive, the main client now compares the worker settlement with the runtime settlement for the same batch id.

If the worker record has a stronger durable settlement, such as `global` over `local`, the hydrated worker record is allowed to override the main runtime record for wait/reconciliation checks. So the same flow now becomes:

1. Main runtime still starts with a `local` batch record.
2. Worker still receives the stronger server-confirmed settlement.
3. Worker hydrates that stronger settlement back to main.
4. Main chooses the stronger worker-hydrated record.
5. `waitForPersistedBatch(batchId, "edge")` sees `global >= edge` and resolves.
6. The chat creation flow navigates to the chat, and the invite flow can continue.

Rejected worker-hydrated records still keep their previous behavior: they override non-rejected runtime records so mutation errors are surfaced.

## Changes

- Let worker-hydrated batch records override main runtime records when they carry a stronger durable settlement.
- Add a regression test for the worker hydration case.

## Validation

- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/runtime/client.test.ts -t "worker batch hydration"`
- `cargo test -p jazz-tools rc_query_settled_before_data_should_not_drop_upstream_rows --lib --features test`
- `pnpm --filter jazz-tools build:runtime`
- `pnpm --filter chat-react exec vitest run --config vitest.config.browser.ts tests/browser/invite.test.tsx -t "allows a user to join a private chat via invite link"`