### PR TITLE
Stack 02: Optimize query settlement replay

### DIFF
--- a/crates/jazz-tools/src/query_manager/graph/mod.rs
+++ b/crates/jazz-tools/src/query_manager/graph/mod.rs
@@ -292,9 +292,14 @@ impl QueryGraph {
 
     /// Get the current output tuples in output order.
     pub fn current_output_tuples(&self) -> Vec<Tuple> {
+        self.current_output_tuples_ref().to_vec()
+    }
+
+    /// Borrow the current output tuples in output order.
+    pub fn current_output_tuples_ref(&self) -> &[Tuple] {
         match self.get_node(self.output_node) {
-            Some(GraphNode::Output(node)) => node.ordered_tuples().to_vec(),
-            _ => vec![],
+            Some(GraphNode::Output(node)) => node.ordered_tuples(),
+            _ => &[],
         }
     }
 

--- a/crates/jazz-tools/src/query_manager/graph/mod.rs
+++ b/crates/jazz-tools/src/query_manager/graph/mod.rs
@@ -199,13 +199,27 @@ impl QueryGraph {
     /// After calling `settle()`, this method returns the (ObjectId, BranchName) pairs
     /// for all rows currently in the query result.
     pub fn contributing_object_ids(&self) -> HashSet<(ObjectId, BranchName)> {
-        self.scope_from_tuples(&self.current_output_tuples())
+        self.current_output_scope().cloned().unwrap_or_default()
     }
 
     /// Returns ObjectIds that must be synced for the client to reproduce the
     /// current query result locally.
     pub fn sync_scope_object_ids(&self) -> HashSet<(ObjectId, BranchName)> {
+        if self.pagination_node.is_none() {
+            return self.current_output_scope().cloned().unwrap_or_default();
+        }
+
         self.scope_from_tuples(&self.sync_scope_tuples())
+    }
+
+    /// Returns a borrowed sync scope when it is maintained directly by the
+    /// output node. Paginated queries need the prefix before windowing, so they
+    /// still compute scope from the pagination node's sync input.
+    pub fn sync_scope_object_ids_ref(&self) -> Option<&HashSet<(ObjectId, BranchName)>> {
+        if self.pagination_node.is_some() {
+            return None;
+        }
+        self.current_output_scope()
     }
 
     /// Returns tuples that must be synced for the client to reproduce the current
@@ -259,6 +273,13 @@ impl QueryGraph {
             .iter()
             .flat_map(|tuple| tuple.provenance().iter().copied())
             .collect()
+    }
+
+    fn current_output_scope(&self) -> Option<&HashSet<(ObjectId, BranchName)>> {
+        match self.get_node(self.output_node) {
+            Some(GraphNode::Output(node)) => Some(node.sync_scope()),
+            _ => None,
+        }
     }
 
     /// Get current result from output node.

--- a/crates/jazz-tools/src/query_manager/graph_nodes/materialize.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/materialize.rs
@@ -27,9 +27,16 @@ pub struct MaterializeNode {
     rows: AHashMap<ObjectId, Row>,
     /// Current tuples (fully or partially materialized).
     current_tuples: AHashSet<Tuple>,
+    /// Reverse index for materialized tuples, keyed by any object ID contained
+    /// in the tuple.
+    current_tuples_by_id: AHashMap<ObjectId, AHashSet<Tuple>>,
     /// Current upstream tuples, including rows that are in scope but not yet
     /// materializable at the requested durability.
     known_tuples: AHashSet<Tuple>,
+    /// Reverse index for known tuples, keyed by any object ID contained in the
+    /// tuple. This keeps row update handling proportional to the affected
+    /// tuples instead of scanning every tuple in the materializer.
+    known_tuples_by_id: AHashMap<ObjectId, AHashSet<Tuple>>,
     /// IDs to check for content updates (row data may have changed).
     updated_ids: AHashSet<ObjectId>,
     /// IDs that were deleted (emit removal delta during settle).
@@ -57,11 +64,50 @@ impl MaterializeNode {
             elements_to_materialize,
             rows: AHashMap::new(),
             current_tuples: AHashSet::new(),
+            current_tuples_by_id: AHashMap::new(),
             known_tuples: AHashSet::new(),
+            known_tuples_by_id: AHashMap::new(),
             updated_ids: AHashSet::new(),
             deleted_ids: AHashSet::new(),
             dirty: true,
         }
+    }
+
+    fn insert_current_tuple(&mut self, tuple: Tuple) {
+        if self.current_tuples.insert(tuple.clone()) {
+            for id in tuple.id_iter() {
+                self.current_tuples_by_id
+                    .entry(id)
+                    .or_default()
+                    .insert(tuple.clone());
+            }
+        }
+    }
+
+    fn remove_current_tuple_from_index(&mut self, tuple: &Tuple) {
+        for id in tuple.id_iter() {
+            if let Some(tuples) = self.current_tuples_by_id.get_mut(&id) {
+                tuples.remove(tuple);
+                if tuples.is_empty() {
+                    self.current_tuples_by_id.remove(&id);
+                }
+            }
+        }
+    }
+
+    fn remove_current_tuple(&mut self, tuple: &Tuple) -> bool {
+        if let Some(existing) = self.current_tuples.take(tuple) {
+            self.remove_current_tuple_from_index(&existing);
+            true
+        } else {
+            false
+        }
+    }
+
+    fn take_current_tuple(&mut self, tuple: &Tuple) -> Option<Tuple> {
+        let existing = self.current_tuples.take(tuple)?;
+        self.remove_current_tuple_from_index(&existing);
+        Some(existing)
     }
 
     /// Create a new materialize node that materializes ALL elements.
@@ -108,6 +154,30 @@ impl MaterializeNode {
         self.dirty
     }
 
+    fn insert_known_tuple(&mut self, tuple: Tuple) {
+        if self.known_tuples.insert(tuple.clone()) {
+            for id in tuple.id_iter() {
+                self.known_tuples_by_id
+                    .entry(id)
+                    .or_default()
+                    .insert(tuple.clone());
+            }
+        }
+    }
+
+    fn remove_known_tuple(&mut self, tuple: &Tuple) {
+        if self.known_tuples.remove(tuple) {
+            for id in tuple.id_iter() {
+                if let Some(tuples) = self.known_tuples_by_id.get_mut(&id) {
+                    tuples.remove(tuple);
+                    if tuples.is_empty() {
+                        self.known_tuples_by_id.remove(&id);
+                    }
+                }
+            }
+        }
+    }
+
     // ========================================================================
     // Tuple-based methods for unified tuple model
     // ========================================================================
@@ -123,7 +193,7 @@ impl MaterializeNode {
 
         // Handle removed tuples - find the materialized version from current_tuples
         for tuple in delta.removed {
-            self.known_tuples.remove(&tuple);
+            self.remove_known_tuple(&tuple);
             // Find the materialized tuple in current_tuples (uses ID-based equality)
             let materialized_tuple = self.current_tuples.get(&tuple).cloned();
 
@@ -139,7 +209,7 @@ impl MaterializeNode {
                 self.updated_ids.remove(&id);
                 self.rows.remove(&id);
             }
-            self.current_tuples.remove(&tuple);
+            self.remove_current_tuple(&tuple);
 
             // Emit the materialized version
             result.removed.push(materialized_tuple.unwrap());
@@ -147,9 +217,9 @@ impl MaterializeNode {
 
         // Handle added tuples - materialize each element
         for tuple in delta.added {
-            self.known_tuples.insert(tuple.clone());
+            self.insert_known_tuple(tuple.clone());
             if let Some(materialized) = self.materialize_tuple(&tuple, &mut loader) {
-                self.current_tuples.insert(materialized.clone());
+                self.insert_current_tuple(materialized.clone());
                 result.added.push(materialized);
             }
             // If materialize_tuple returns None, the tuple is dropped (unavailable row)
@@ -157,11 +227,11 @@ impl MaterializeNode {
 
         // Handle updated tuples
         for (old_tuple, new_tuple) in delta.updated {
-            self.known_tuples.remove(&old_tuple);
-            self.known_tuples.insert(new_tuple.clone());
-            self.current_tuples.remove(&old_tuple);
+            self.remove_known_tuple(&old_tuple);
+            self.insert_known_tuple(new_tuple.clone());
+            self.remove_current_tuple(&old_tuple);
             if let Some(materialized) = self.materialize_tuple(&new_tuple, &mut loader) {
-                self.current_tuples.insert(materialized.clone());
+                self.insert_current_tuple(materialized.clone());
                 result.updated.push((old_tuple, materialized));
             } else {
                 // New version unavailable - emit as removal
@@ -269,14 +339,13 @@ impl MaterializeNode {
 
             // Find and remove tuples containing this ID
             let tuples_to_remove: Vec<Tuple> = self
-                .current_tuples
-                .iter()
-                .filter(|t| t.ids().contains(&id))
-                .cloned()
-                .collect();
+                .current_tuples_by_id
+                .get(&id)
+                .map(|tuples| tuples.iter().cloned().collect())
+                .unwrap_or_default();
 
             for tuple in tuples_to_remove {
-                self.current_tuples.remove(&tuple);
+                self.remove_current_tuple(&tuple);
                 result.removed.push(tuple);
             }
         }
@@ -291,33 +360,31 @@ impl MaterializeNode {
     {
         let mut result = TupleDelta::new();
         let ids_to_check: Vec<_> = self.updated_ids.drain().collect();
+        let mut affected_tuples = AHashSet::new();
 
         for id in ids_to_check {
             // Find tuples containing this ID, including rows that were previously
             // in scope but not materializable at the requested durability.
-            let affected_tuples: Vec<Tuple> = self
-                .known_tuples
-                .iter()
-                .filter(|t| t.ids().contains(&id))
-                .cloned()
-                .collect();
+            if let Some(tuples) = self.known_tuples_by_id.get(&id) {
+                affected_tuples.extend(tuples.iter().cloned());
+            }
+        }
 
-            for tuple in affected_tuples {
-                let previous_materialized = self.current_tuples.take(&tuple);
+        for tuple in affected_tuples {
+            let previous_materialized = self.take_current_tuple(&tuple);
 
-                if let Some(new_tuple) = self.materialize_tuple(&tuple, &mut loader) {
-                    self.current_tuples.insert(new_tuple.clone());
-                    match previous_materialized {
-                        Some(old_tuple) => {
-                            if has_content_changed(&old_tuple, &new_tuple) {
-                                result.updated.push((old_tuple, new_tuple));
-                            }
+            if let Some(new_tuple) = self.materialize_tuple(&tuple, &mut loader) {
+                self.insert_current_tuple(new_tuple.clone());
+                match previous_materialized {
+                    Some(old_tuple) => {
+                        if has_content_changed(&old_tuple, &new_tuple) {
+                            result.updated.push((old_tuple, new_tuple));
                         }
-                        None => result.added.push(new_tuple),
                     }
-                } else if let Some(old_tuple) = previous_materialized {
-                    result.removed.push(old_tuple);
+                    None => result.added.push(new_tuple),
                 }
+            } else if let Some(old_tuple) = previous_materialized {
+                result.removed.push(old_tuple);
             }
         }
 

--- a/crates/jazz-tools/src/query_manager/graph_nodes/output.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/output.rs
@@ -1,5 +1,7 @@
 use ahash::AHashSet;
+use std::collections::{HashMap, HashSet};
 
+use crate::object::{BranchName, ObjectId};
 use crate::query_manager::encoding::decode_row;
 use crate::query_manager::types::{
     Row, RowDelta, RowDescriptor, Tuple, TupleDelta, TupleDescriptor, Value,
@@ -34,6 +36,11 @@ pub struct OutputNode {
     current_tuples: AHashSet<Tuple>,
     /// Ordered tuples for deterministic output (preserves sort order).
     ordered_tuples: Vec<Tuple>,
+    /// Current sync scope derived from output tuple provenance.
+    sync_scope: HashSet<(ObjectId, BranchName)>,
+    /// Reference counts for scope entries, since several output tuples can
+    /// depend on the same source object.
+    sync_scope_counts: HashMap<(ObjectId, BranchName), usize>,
     /// Pending tuple deltas to deliver.
     pending_tuple_deltas: Vec<TupleDelta>,
     /// True if subscriber has received initial snapshot.
@@ -54,6 +61,8 @@ impl OutputNode {
             mode,
             current_tuples: AHashSet::new(),
             ordered_tuples: Vec::new(),
+            sync_scope: HashSet::new(),
+            sync_scope_counts: HashMap::new(),
             pending_tuple_deltas: Vec::new(),
             subscriber_initialized: false,
             dirty: true,
@@ -98,10 +107,51 @@ impl OutputNode {
         &self.ordered_tuples
     }
 
+    /// Current sync scope derived incrementally from output tuple provenance.
+    pub fn sync_scope(&self) -> &HashSet<(ObjectId, BranchName)> {
+        &self.sync_scope
+    }
+
+    fn add_tuple_to_scope(&mut self, tuple: &Tuple) {
+        for scoped_object in tuple.provenance().iter().copied() {
+            let count = self.sync_scope_counts.entry(scoped_object).or_insert(0);
+            *count += 1;
+            if *count == 1 {
+                self.sync_scope.insert(scoped_object);
+            }
+        }
+    }
+
+    fn remove_tuple_from_scope(&mut self, tuple: &Tuple) {
+        for scoped_object in tuple.provenance() {
+            if let Some(count) = self.sync_scope_counts.get_mut(scoped_object) {
+                *count -= 1;
+                if *count == 0 {
+                    self.sync_scope_counts.remove(scoped_object);
+                    self.sync_scope.remove(scoped_object);
+                }
+            }
+        }
+    }
+
+    fn apply_delta_to_scope(&mut self, delta: &TupleDelta) {
+        for tuple in &delta.removed {
+            self.remove_tuple_from_scope(tuple);
+        }
+        for (old_tuple, new_tuple) in &delta.updated {
+            self.remove_tuple_from_scope(old_tuple);
+            self.add_tuple_to_scope(new_tuple);
+        }
+        for tuple in &delta.added {
+            self.add_tuple_to_scope(tuple);
+        }
+    }
+
     /// Rebuild ordered output from a full ordered upstream input.
     pub fn process_with_ordered_input(&mut self, ordered_tuples: &[Tuple]) -> TupleDelta {
         let delta = compute_tuple_delta(&self.ordered_tuples, ordered_tuples);
 
+        self.apply_delta_to_scope(&delta);
         self.ordered_tuples = ordered_tuples.to_vec();
         self.current_tuples = self.ordered_tuples.iter().cloned().collect();
         self.dirty = false;
@@ -161,6 +211,8 @@ impl RowNode for OutputNode {
     }
 
     fn process(&mut self, input: TupleDelta) -> TupleDelta {
+        self.apply_delta_to_scope(&input);
+
         // Apply changes to current_tuples and ordered_tuples
         for tuple in &input.removed {
             self.current_tuples.remove(tuple);
@@ -381,6 +433,60 @@ mod tests {
         let deltas = node.take_tuple_deltas();
         assert_eq!(deltas.len(), 1);
         assert_eq!(deltas[0].added.len(), 1);
+    }
+
+    #[test]
+    fn sync_scope_is_maintained_incrementally_with_shared_provenance() {
+        let mut node = make_output_node(OutputMode::Delta);
+        let branch = BranchName::new("main");
+        let shared_id = ObjectId::new();
+        let id1 = ObjectId::new();
+        let id2 = ObjectId::new();
+
+        let tuple1 = Tuple::new_with_provenance(
+            vec![TupleElement::Id(id1)],
+            [(shared_id, branch), (id1, branch)].into_iter().collect(),
+        );
+        let tuple2 = Tuple::new_with_provenance(
+            vec![TupleElement::Id(id2)],
+            [(shared_id, branch), (id2, branch)].into_iter().collect(),
+        );
+
+        node.process(TupleDelta {
+            added: vec![tuple1.clone(), tuple2.clone()],
+            removed: vec![],
+            moved: vec![],
+            updated: vec![],
+        });
+        assert_eq!(node.sync_scope().len(), 3);
+        assert!(node.sync_scope().contains(&(shared_id, branch)));
+        assert!(node.sync_scope().contains(&(id1, branch)));
+        assert!(node.sync_scope().contains(&(id2, branch)));
+
+        node.process(TupleDelta {
+            added: vec![],
+            removed: vec![tuple1],
+            moved: vec![],
+            updated: vec![],
+        });
+        assert_eq!(node.sync_scope().len(), 2);
+        assert!(node.sync_scope().contains(&(shared_id, branch)));
+        assert!(!node.sync_scope().contains(&(id1, branch)));
+        assert!(node.sync_scope().contains(&(id2, branch)));
+
+        let tuple2_without_shared = Tuple::new_with_provenance(
+            vec![TupleElement::Id(id2)],
+            [(id2, branch)].into_iter().collect(),
+        );
+        node.process(TupleDelta {
+            added: vec![],
+            removed: vec![],
+            moved: vec![],
+            updated: vec![(tuple2, tuple2_without_shared)],
+        });
+        assert_eq!(node.sync_scope().len(), 1);
+        assert!(!node.sync_scope().contains(&(shared_id, branch)));
+        assert!(node.sync_scope().contains(&(id2, branch)));
     }
 
     #[test]

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -1129,7 +1129,6 @@ impl QueryManager {
                 .is_some_and(|required_tier| confirmed_tier >= required_tier)
             {
                 subscription.needs_visibility_recompute = true;
-                subscription.graph.mark_all_dirty();
             }
         }
     }

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -434,6 +434,11 @@ pub struct QueryManager {
     /// reached yet.
     pub(super) pending_local_row_batches: HashMap<ObjectId, RowBatchKey>,
 
+    /// Visible rows observed through normal row visibility processing, keyed by
+    /// batch. Batch fate processing uses this to mark affected query rows
+    /// without rescanning and decoding every subscribed visible region.
+    pub(super) visible_rows_by_batch: HashMap<BatchId, Vec<(String, ObjectId)>>,
+
     /// Known schemas (for server-mode operation).
     /// Synced from SchemaManager's known_schemas to enable lazy branch activation.
     /// When a row arrives with unknown branch, we parse the branch name to extract
@@ -536,6 +541,7 @@ impl QueryManager {
             branch_schema_map: HashMap::new(),
             pending_row_visibility_changes: Vec::new(),
             pending_local_row_batches: HashMap::new(),
+            visible_rows_by_batch: HashMap::new(),
             known_schemas: Arc::new(HashMap::new()),
             pending_catalogue_schema_hashes: HashSet::new(),
             catalogued_storage_namespaces: HashSet::new(),
@@ -1076,59 +1082,39 @@ impl QueryManager {
         }
     }
 
-    fn mark_visible_rows_updated_for_batch<H: Storage>(&mut self, storage: &H, batch_id: BatchId) {
-        let mut rows = Vec::new();
-        let mut subscription_tables = Vec::new();
-        subscription_tables.extend(self.subscriptions.values().map(|subscription| {
-            (
-                subscription.graph.table.as_str().to_string(),
-                subscription.branches.clone(),
-            )
-        }));
-        subscription_tables.extend(self.server_subscriptions.values().map(|subscription| {
-            (
-                subscription.graph.table.as_str().to_string(),
-                subscription.branches.clone(),
-            )
-        }));
-        subscription_tables.sort();
-        subscription_tables.dedup();
-
-        for (table, branches) in subscription_tables {
-            for branch in &branches {
-                let Ok(visible_rows) = storage.scan_visible_region(&table, branch.as_str()) else {
-                    continue;
-                };
-                rows.extend(
-                    visible_rows
-                        .into_iter()
-                        .filter(|row| row.batch_id == batch_id)
-                        .map(|row| (table.clone(), row.row_id)),
-                );
-            }
-        }
-        rows.sort();
-        rows.dedup();
-        for (table, row_id) in rows {
-            self.mark_local_row_updated_in_subscriptions(&table, row_id);
-        }
-    }
-
     fn apply_pending_batch_fate_effects<H: Storage>(&mut self, storage: &H) {
         let batch_fates = self.sync_manager.pending_batch_fates().to_vec();
-        for settlement in &batch_fates {
-            if let Some(confirmed_tier) = settlement.confirmed_tier() {
-                self.mark_subscriptions_visibility_recompute_for_tier(confirmed_tier);
-            }
-            self.mark_subscriptions_visibility_recompute_for_batch(settlement.batch_id());
-            self.mark_visible_rows_updated_for_batch(storage, settlement.batch_id());
-            if let Ok(Some(record)) = storage.load_local_batch_record(settlement.batch_id()) {
+        let max_confirmed_tier = batch_fates
+            .iter()
+            .filter_map(BatchFate::confirmed_tier)
+            .max();
+        if let Some(confirmed_tier) = max_confirmed_tier {
+            self.mark_subscriptions_visibility_recompute_for_tier(confirmed_tier);
+        }
+
+        let mut batch_ids = batch_fates
+            .iter()
+            .map(BatchFate::batch_id)
+            .collect::<Vec<_>>();
+        batch_ids.sort();
+        batch_ids.dedup();
+
+        for batch_id in batch_ids {
+            self.mark_subscriptions_visibility_recompute_for_batch(batch_id);
+            let mut rows = self
+                .visible_rows_by_batch
+                .get(&batch_id)
+                .cloned()
+                .unwrap_or_default();
+            if let Ok(Some(record)) = storage.load_local_batch_record(batch_id) {
                 for member in record.members {
-                    self.mark_local_row_updated_in_subscriptions(
-                        member.table_name.as_str(),
-                        member.object_id,
-                    );
+                    rows.push((member.table_name, member.object_id));
                 }
+            }
+            rows.sort();
+            rows.dedup();
+            for (table_name, object_id) in rows {
+                self.mark_local_row_updated_in_subscriptions(table_name.as_str(), object_id);
             }
         }
     }
@@ -1586,6 +1572,28 @@ impl QueryManager {
         let old_row = update.previous_row.as_ref();
         let current_batch_id = update.row.batch_id;
         let current_row_key = RowBatchKey::from_row(&update.row);
+
+        if let Some(previous_row) = old_row
+            && previous_row.state.is_visible()
+            && let Some(rows) = self.visible_rows_by_batch.get_mut(&previous_row.batch_id)
+        {
+            rows.retain(|(table, row_id)| {
+                table.as_str() != logical_table.as_str() || *row_id != update.object_id
+            });
+            if rows.is_empty() {
+                self.visible_rows_by_batch.remove(&previous_row.batch_id);
+            }
+        }
+        if update.row.state.is_visible() {
+            let rows = self
+                .visible_rows_by_batch
+                .entry(current_batch_id)
+                .or_default();
+            let member = (logical_table.clone(), update.object_id);
+            if !rows.contains(&member) {
+                rows.push(member);
+            }
+        }
 
         if local_update {
             self.pending_local_row_batches

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -1375,6 +1375,11 @@ impl QueryManager {
             let local_durability_satisfies_subscription = subscription
                 .durability_tier
                 .is_some_and(|tier| self.sync_manager.has_local_durability_at_least(tier));
+            let remote_scope_satisfies_subscription =
+                subscription.durability_tier.is_none_or(|tier| {
+                    self.sync_manager
+                        .has_remote_query_scope_snapshot_at_least(QueryId(sub_id.0), tier)
+                });
 
             let delta = {
                 let schema_context = &self.schema_context;
@@ -1383,10 +1388,7 @@ impl QueryManager {
                     |id: ObjectId, table_hint: Option<TableName>| -> Option<LoadedRow> {
                         let lacks_authoritative_remote_scope = subscription.sync_backed
                             && subscription.local_updates == LocalUpdates::Immediate
-                            && !local_durability_satisfies_subscription
-                            && !self
-                                .sync_manager
-                                .has_remote_query_scope_snapshot(QueryId(sub_id.0));
+                            && !remote_scope_satisfies_subscription;
                         let durability_tier = if lacks_authoritative_remote_scope
                             || (subscription.local_updates == LocalUpdates::Immediate
                                 && subscription.pending_local_row_ids.contains(&id))
@@ -1482,7 +1484,7 @@ impl QueryManager {
 
             if subscription.sync_backed
                 && Self::subscription_query_frontier_satisfied(&subscription)
-                && !local_durability_satisfies_subscription
+                && (!local_durability_satisfies_subscription || remote_scope_satisfies_subscription)
                 && self
                     .sync_manager
                     .has_remote_query_scope_snapshot(QueryId(sub_id.0))
@@ -1491,6 +1493,7 @@ impl QueryManager {
             {
                 visible_tuples = Cow::Owned(self.filter_synced_query_scope_tuples(
                     QueryId(sub_id.0),
+                    subscription.durability_tier,
                     &subscription.pending_local_row_ids,
                     visible_tuples.into_owned(),
                 ));
@@ -2623,10 +2626,16 @@ impl QueryManager {
     fn filter_synced_query_scope_tuples(
         &self,
         query_id: QueryId,
+        durability_tier: Option<DurabilityTier>,
         pending_local_row_ids: &HashSet<ObjectId>,
         tuples: Vec<Tuple>,
     ) -> Vec<Tuple> {
-        let remote_scope = self.sync_manager.remote_query_scope(query_id);
+        let remote_scope = match durability_tier {
+            Some(tier) => self
+                .sync_manager
+                .remote_query_scope_at_least(query_id, tier),
+            None => self.sync_manager.remote_query_scope(query_id),
+        };
         tuples
             .into_iter()
             .filter(|tuple| {

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -1110,7 +1111,7 @@ impl QueryManager {
         for subscription in self.subscriptions.values_mut() {
             if subscription
                 .graph
-                .current_output_tuples()
+                .current_output_tuples_ref()
                 .iter()
                 .any(|tuple| tuple.batch_provenance().contains(&batch_id))
             {
@@ -1464,15 +1465,15 @@ impl QueryManager {
             let mut visible_tuples = if subscription.uses_explicit_authorization_filtering {
                 let auth_schema_context = self.schema_context.clone();
                 let auth_branch_schema_map = self.branch_schema_map.clone();
-                self.authorized_tuples_from_graph(
+                Cow::Owned(self.authorized_tuples_from_graph(
                     storage_ref,
                     &subscription.graph,
                     &auth_schema_context,
                     &auth_branch_schema_map,
                     subscription.session.as_ref(),
-                )
+                ))
             } else {
-                subscription.graph.current_output_tuples()
+                Cow::Borrowed(subscription.graph.current_output_tuples_ref())
             };
 
             if subscription.sync_backed
@@ -1483,11 +1484,11 @@ impl QueryManager {
                 && (subscription.propagation == QueryPropagation::Full
                     || !self.sync_manager.has_durability_identity())
             {
-                visible_tuples = self.filter_synced_query_scope_tuples(
+                visible_tuples = Cow::Owned(self.filter_synced_query_scope_tuples(
                     QueryId(sub_id.0),
                     &subscription.pending_local_row_ids,
-                    visible_tuples,
-                );
+                    visible_tuples.into_owned(),
+                ));
             }
 
             visible_tuples = self.filter_transaction_visible_tuples(
@@ -1496,7 +1497,7 @@ impl QueryManager {
                 visible_tuples,
             );
 
-            let visible_rows = Self::rows_from_tuples(&subscription.graph, &visible_tuples);
+            let visible_rows = Self::rows_from_tuples(&subscription.graph, visible_tuples.as_ref());
             let visible_rows_by_id: HashMap<_, _> = visible_rows
                 .iter()
                 .cloned()
@@ -2663,36 +2664,59 @@ impl QueryManager {
             || query_scope.is_subset(local_scope)
     }
 
-    fn filter_transaction_visible_tuples(
+    fn filter_transaction_visible_tuples<'a>(
         &self,
         storage: &dyn Storage,
         query_id: QueryId,
-        tuples: Vec<Tuple>,
-    ) -> Vec<Tuple> {
+        tuples: Cow<'a, [Tuple]>,
+    ) -> Cow<'a, [Tuple]> {
         if tuples.is_empty() {
             return tuples;
         }
 
-        let local_scope = Self::scope_from_tuples(&tuples);
+        let local_scope = Self::scope_from_tuples(tuples.as_ref());
         let mut query_scope = local_scope.clone();
         query_scope.extend(self.sync_manager.remote_query_scope(query_id));
 
         let mut settlement_cache: HashMap<BatchId, Option<BatchFate>> = HashMap::new();
+        let mut first_hidden = None;
 
-        tuples
-            .into_iter()
-            .filter(|tuple| {
-                tuple.batch_provenance().iter().copied().all(|batch_id| {
-                    Self::transactional_batch_complete_for_query_scope(
-                        storage,
-                        &mut settlement_cache,
-                        batch_id,
-                        &local_scope,
-                        &query_scope,
-                    )
-                })
-            })
-            .collect()
+        for (index, tuple) in tuples.as_ref().iter().enumerate() {
+            let is_visible = tuple.batch_provenance().iter().copied().all(|batch_id| {
+                Self::transactional_batch_complete_for_query_scope(
+                    storage,
+                    &mut settlement_cache,
+                    batch_id,
+                    &local_scope,
+                    &query_scope,
+                )
+            });
+            if !is_visible {
+                first_hidden = Some(index);
+                break;
+            }
+        }
+
+        let Some(first_hidden) = first_hidden else {
+            return tuples;
+        };
+
+        let mut filtered = Vec::with_capacity(tuples.len().saturating_sub(1));
+        filtered.extend_from_slice(&tuples.as_ref()[..first_hidden]);
+        for tuple in &tuples.as_ref()[first_hidden + 1..] {
+            if tuple.batch_provenance().iter().copied().all(|batch_id| {
+                Self::transactional_batch_complete_for_query_scope(
+                    storage,
+                    &mut settlement_cache,
+                    batch_id,
+                    &local_scope,
+                    &query_scope,
+                )
+            }) {
+                filtered.push(tuple.clone());
+            }
+        }
+        Cow::Owned(filtered)
     }
     // ========================================================================
     // No-op storage driver (for tests)

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -1179,7 +1179,6 @@ impl QueryManager {
                 sub.needs_visibility_recompute = true;
             }
         }
-        self.apply_pending_batch_fate_effects(storage);
         self.pending_catalogue_updates.extend(
             self.sync_manager
                 .take_pending_catalogue_updates()

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -1372,6 +1372,9 @@ impl QueryManager {
             let table = subscription.graph.table.as_str().to_string();
             let mut schema_warnings = SchemaWarningAccumulator::default();
             let include_deleted = subscription.query.include_deleted;
+            let local_durability_satisfies_subscription = subscription
+                .durability_tier
+                .is_some_and(|tier| self.sync_manager.has_local_durability_at_least(tier));
 
             let delta = {
                 let schema_context = &self.schema_context;
@@ -1380,6 +1383,7 @@ impl QueryManager {
                     |id: ObjectId, table_hint: Option<TableName>| -> Option<LoadedRow> {
                         let lacks_authoritative_remote_scope = subscription.sync_backed
                             && subscription.local_updates == LocalUpdates::Immediate
+                            && !local_durability_satisfies_subscription
                             && !self
                                 .sync_manager
                                 .has_remote_query_scope_snapshot(QueryId(sub_id.0));
@@ -1478,6 +1482,7 @@ impl QueryManager {
 
             if subscription.sync_backed
                 && Self::subscription_query_frontier_satisfied(&subscription)
+                && !local_durability_satisfies_subscription
                 && self
                     .sync_manager
                     .has_remote_query_scope_snapshot(QueryId(sub_id.0))

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -300,6 +300,20 @@ pub(super) struct ServerQuerySubscription {
     /// Extra tables whose rows must be synced so downstream clients can
     /// reproduce bundled policy context locally.
     pub(super) policy_context_tables: Vec<String>,
+    /// Durability tier requested by the downstream subscriber. `None` means the
+    /// subscriber did not request frontier gating.
+    pub(super) required_tier: Option<DurabilityTier>,
+    /// Lower-tier settlements are useful as an initial remote scope snapshot,
+    /// but repeated below-required settlements should not churn downstream
+    /// subscribers that are still waiting for their requested tier.
+    pub(super) sent_below_required_settled: bool,
+    /// Highest query settlement tier that has actually been emitted downstream.
+    ///
+    /// Dirty graph passes can leave a server subscription's scope unchanged. In
+    /// that case a repeated QuerySettled at the same tier carries no new
+    /// information, but large scopes are expensive for clients to decode and
+    /// apply.
+    pub(super) last_emitted_settled_tier: Option<DurabilityTier>,
     /// Last computed scope (for detecting changes).
     pub(super) last_scope: HashSet<(ObjectId, BranchName)>,
     /// Flag indicating this subscription needs recompilation due to schema change.
@@ -439,6 +453,15 @@ pub struct QueryManager {
     /// without rescanning and decoding every subscribed visible region.
     pub(super) visible_rows_by_batch: HashMap<BatchId, Vec<(String, ObjectId)>>,
 
+    /// Currently queued SyncManager batch fates whose query effects have
+    /// already been applied by this manager.
+    ///
+    /// RuntimeCore owns draining the pending fate queue so write waiters and
+    /// persisted fate state still see the same events. QueryManager may process
+    /// multiple times before that drain happens, so it must only apply the
+    /// subscription dirtiness effects for the newly appended suffix.
+    pub(super) applied_pending_batch_fates: Vec<BatchFate>,
+
     /// Known schemas (for server-mode operation).
     /// Synced from SchemaManager's known_schemas to enable lazy branch activation.
     /// When a row arrives with unknown branch, we parse the branch name to extract
@@ -542,6 +565,7 @@ impl QueryManager {
             pending_row_visibility_changes: Vec::new(),
             pending_local_row_batches: HashMap::new(),
             visible_rows_by_batch: HashMap::new(),
+            applied_pending_batch_fates: Vec::new(),
             known_schemas: Arc::new(HashMap::new()),
             pending_catalogue_schema_hashes: HashSet::new(),
             catalogued_storage_namespaces: HashSet::new(),
@@ -1050,11 +1074,24 @@ impl QueryManager {
         let sub_id = QuerySubscriptionId(query_id.0);
         if let Some(sub) = self.subscriptions.get_mut(&sub_id) {
             let was_unsatisfied = !Self::subscription_query_frontier_satisfied(sub);
+            let before = sub.query_frontier_settled_tier;
+            let required_tier = sub.durability_tier;
             sub.query_frontier_settled_tier = Some(
                 sub.query_frontier_settled_tier
                     .map_or(tier, |current| current.max(tier)),
             );
-            if was_unsatisfied && Self::subscription_query_frontier_satisfied(sub) {
+            let now_satisfied = Self::subscription_query_frontier_satisfied(sub);
+            tracing::trace!(
+                query_id = query_id.0,
+                tier = ?tier,
+                required_tier = ?required_tier,
+                before = ?before,
+                after = ?sub.query_frontier_settled_tier,
+                was_unsatisfied,
+                now_satisfied,
+                "jazz trace query settled applied"
+            );
+            if was_unsatisfied && now_satisfied {
                 sub.needs_visibility_recompute = true;
             }
         }
@@ -1083,7 +1120,25 @@ impl QueryManager {
     }
 
     fn apply_pending_batch_fate_effects<H: Storage>(&mut self, storage: &H) {
-        let batch_fates = self.sync_manager.pending_batch_fates().to_vec();
+        let pending_batch_fates = self.sync_manager.pending_batch_fates();
+        let already_applied_count =
+            if pending_batch_fates.starts_with(&self.applied_pending_batch_fates) {
+                self.applied_pending_batch_fates.len()
+            } else {
+                // RuntimeCore may have drained the queue and SyncManager may have
+                // appended new fates before QueryManager gets another process pass.
+                // In that case, the current queue is a new sequence, not a suffix
+                // of the old one.
+                0
+            };
+
+        let batch_fates = pending_batch_fates[already_applied_count..].to_vec();
+        self.applied_pending_batch_fates = pending_batch_fates.to_vec();
+        let fate_count = batch_fates.len();
+        if fate_count == 0 {
+            return;
+        }
+
         let max_confirmed_tier = batch_fates
             .iter()
             .filter_map(BatchFate::confirmed_tier)
@@ -1099,6 +1154,8 @@ impl QueryManager {
         batch_ids.sort();
         batch_ids.dedup();
 
+        let unique_batch_count = batch_ids.len();
+        let mut marked_row_count = 0usize;
         for batch_id in batch_ids {
             self.mark_subscriptions_visibility_recompute_for_batch(batch_id);
             let mut rows = self
@@ -1113,10 +1170,18 @@ impl QueryManager {
             }
             rows.sort();
             rows.dedup();
+            marked_row_count += rows.len();
             for (table_name, object_id) in rows {
                 self.mark_local_row_updated_in_subscriptions(table_name.as_str(), object_id);
             }
         }
+        tracing::trace!(
+            fate_count,
+            unique_batch_count,
+            marked_row_count,
+            max_confirmed_tier = ?max_confirmed_tier,
+            "jazz trace batch fate effects applied"
+        );
     }
 
     pub(crate) fn mark_subscriptions_visibility_recompute_for_tier(
@@ -1242,6 +1307,13 @@ impl QueryManager {
             let mut blocked = Vec::new();
             for pending_settled in pending_query_settled {
                 if pending_settled.through_seq == 0 {
+                    if let Some(server_id) = pending_settled.server_id {
+                        self.sync_manager.relay_query_settled_to_origins(
+                            server_id,
+                            pending_settled.query_id,
+                            pending_settled.tier,
+                        );
+                    }
                     self.apply_query_settled(pending_settled.query_id, pending_settled.tier);
                 } else {
                     blocked.push(pending_settled);
@@ -1373,6 +1445,18 @@ impl QueryManager {
                 // initial upstream frontier has been replayed — or until every
                 // still-pending server has exceeded PENDING_SERVER_TIMEOUT,
                 // which means nothing upstream is going to replay.
+                tracing::trace!(
+                    sub_id = sub_id.0,
+                    table = %table,
+                    required_tier = ?subscription.durability_tier,
+                    settled_tier = ?subscription.query_frontier_settled_tier,
+                    dirty = subscription.graph.has_dirty_nodes(),
+                    needs_recompile = subscription.needs_recompile,
+                    needs_visibility_recompute = subscription.needs_visibility_recompute,
+                    pending_local_updates = subscription.has_pending_local_updates,
+                    has_servers_or_pending_servers = self.sync_manager.has_servers_or_pending_servers(),
+                    "jazz trace subscription waiting for initial frontier"
+                );
                 self.subscriptions.insert(sub_id, subscription);
                 continue;
             }
@@ -1426,6 +1510,18 @@ impl QueryManager {
             let ordered_ids_after: Vec<ObjectId> = visible_rows.iter().map(|row| row.id).collect();
 
             if !subscription.settled_once {
+                tracing::trace!(
+                    sub_id = sub_id.0,
+                    table = %table,
+                    rows = visible_rows.len(),
+                    added = visible_delta.added.len(),
+                    removed = visible_delta.removed.len(),
+                    updated = visible_delta.updated.len(),
+                    moved = visible_delta.moved.len(),
+                    settled_tier = ?subscription.query_frontier_settled_tier,
+                    required_tier = ?subscription.durability_tier,
+                    "jazz trace subscription first delivery"
+                );
                 subscription.settled_once = true;
                 let ordered = build_ordered_delta_with_post_ids(
                     &subscription.current_ordered_ids,

--- a/crates/jazz-tools/src/query_manager/manager_tests.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests.rs
@@ -1284,6 +1284,7 @@ fn push_query_subscription(
             query_id: QueryId(query_id),
             query: Box::new(query),
             session: None,
+            required_tier: None,
             propagation: crate::sync_manager::QueryPropagation::Full,
             policy_context_tables: vec![],
         },

--- a/crates/jazz-tools/src/query_manager/manager_tests.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests.rs
@@ -27,7 +27,7 @@ use crate::storage::{
     HistoryRowBytes, IndexMutation, MemoryStorage, OpfsBTreeStorage, OwnedHistoryRowBytes,
     OwnedVisibleRowBytes, RawTableMutation, RawTableRows, Storage, StorageError, VisibleRowBytes,
 };
-use crate::sync_manager::{InboxEntry, ServerId, Source, SyncManager, SyncPayload};
+use crate::sync_manager::{DurabilityTier, InboxEntry, ServerId, Source, SyncManager, SyncPayload};
 use crate::test_support::{
     apply_test_row_batch, create_test_row, load_test_row_metadata, load_test_row_tip_ids,
     persist_test_schema, put_test_row_metadata, seeded_memory_storage,
@@ -131,6 +131,7 @@ struct CountingCatalogueUpsertsStorage {
     catalogue_upserts: Cell<usize>,
     catalogue_loads: Cell<usize>,
     visible_query_loads: Cell<usize>,
+    visible_region_scans: Cell<usize>,
 }
 
 impl CountingCatalogueUpsertsStorage {
@@ -144,6 +145,7 @@ impl CountingCatalogueUpsertsStorage {
             catalogue_upserts: Cell::new(0),
             catalogue_loads: Cell::new(0),
             visible_query_loads: Cell::new(0),
+            visible_region_scans: Cell::new(0),
         }
     }
 
@@ -165,6 +167,14 @@ impl CountingCatalogueUpsertsStorage {
 
     fn reset_visible_query_loads(&self) {
         self.visible_query_loads.set(0);
+    }
+
+    fn visible_region_scans(&self) -> usize {
+        self.visible_region_scans.get()
+    }
+
+    fn reset_visible_region_scans(&self) {
+        self.visible_region_scans.set(0);
     }
 }
 
@@ -276,6 +286,16 @@ impl Storage for CountingCatalogueUpsertsStorage {
         self.visible_query_loads
             .set(self.visible_query_loads.get() + 1);
         self.inner.load_visible_query_row(table, branch, row_id)
+    }
+
+    fn scan_visible_region(
+        &self,
+        table: &str,
+        branch: &str,
+    ) -> Result<Vec<StoredRowBatch>, StorageError> {
+        self.visible_region_scans
+            .set(self.visible_region_scans.get() + 1);
+        self.inner.scan_visible_region(table, branch)
     }
 }
 

--- a/crates/jazz-tools/src/query_manager/manager_tests/joins.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests/joins.rs
@@ -1333,6 +1333,7 @@ fn server_join_query_uses_current_permissions_for_joined_provenance() {
             query_id: QueryId(1),
             query: Box::new(query),
             session: Some(session),
+            required_tier: None,
             propagation: crate::sync_manager::QueryPropagation::Full,
             policy_context_tables: vec![],
         },

--- a/crates/jazz-tools/src/query_manager/manager_tests/recursive_queries.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests/recursive_queries.rs
@@ -108,6 +108,123 @@ fn recursive_query_with_hop_expands_transitive_closure() {
 }
 
 #[test]
+fn recursive_query_with_self_referential_hop_expands_ancestors() {
+    use crate::query_manager::query::Query;
+    use crate::query_manager::relation_ir::{
+        ColumnRef, JoinCondition, JoinKind, KeyRef, PredicateCmpOp, PredicateExpr, ProjectColumn,
+        ProjectExpr, RelExpr, RowIdRef, ValueRef,
+    };
+
+    let sync_manager = SyncManager::new();
+    let mut schema = Schema::new();
+    schema.insert(
+        TableName::new("teams"),
+        RowDescriptor::new(vec![
+            ColumnDescriptor::new("name", ColumnType::Text),
+            ColumnDescriptor::new("org_id", ColumnType::Uuid).nullable(),
+            ColumnDescriptor::new("parent_id", ColumnType::Uuid).nullable(),
+        ])
+        .into(),
+    );
+    let (mut qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    let root = qm
+        .insert(
+            &mut storage,
+            "teams",
+            &[Value::Text("root".into()), Value::Null, Value::Null],
+        )
+        .unwrap();
+    let mid = qm
+        .insert(
+            &mut storage,
+            "teams",
+            &[
+                Value::Text("mid".into()),
+                Value::Null,
+                Value::Uuid(root.row_id),
+            ],
+        )
+        .unwrap();
+    let leaf = qm
+        .insert(
+            &mut storage,
+            "teams",
+            &[
+                Value::Text("leaf".into()),
+                Value::Null,
+                Value::Uuid(mid.row_id),
+            ],
+        )
+        .unwrap();
+
+    let mut query = Query::new("teams");
+    query.relation_ir = RelExpr::Gather {
+        seed: Box::new(RelExpr::Filter {
+            input: Box::new(RelExpr::TableScan {
+                table: TableName::new("teams"),
+            }),
+            predicate: PredicateExpr::Cmp {
+                left: ColumnRef::scoped("teams", "id"),
+                op: PredicateCmpOp::Eq,
+                right: ValueRef::Literal(Value::Uuid(leaf.row_id)),
+            },
+        }),
+        step: Box::new(RelExpr::Project {
+            input: Box::new(RelExpr::Join {
+                left: Box::new(RelExpr::Filter {
+                    input: Box::new(RelExpr::TableScan {
+                        table: TableName::new("teams"),
+                    }),
+                    predicate: PredicateExpr::Cmp {
+                        left: ColumnRef::scoped("teams", "id"),
+                        op: PredicateCmpOp::Eq,
+                        right: ValueRef::RowId(RowIdRef::Frontier),
+                    },
+                }),
+                right: Box::new(RelExpr::TableScan {
+                    table: TableName::new("teams"),
+                }),
+                on: vec![JoinCondition {
+                    left: ColumnRef::scoped("teams", "parent_id"),
+                    right: ColumnRef::scoped("__recursive_hop_0", "id"),
+                }],
+                join_kind: JoinKind::Inner,
+            }),
+            columns: vec![
+                ProjectColumn {
+                    alias: "id".into(),
+                    expr: ProjectExpr::Column(ColumnRef::scoped("__recursive_hop_0", "id")),
+                },
+                ProjectColumn {
+                    alias: "name".into(),
+                    expr: ProjectExpr::Column(ColumnRef::scoped("__recursive_hop_0", "name")),
+                },
+                ProjectColumn {
+                    alias: "parent_id".into(),
+                    expr: ProjectExpr::Column(ColumnRef::scoped("__recursive_hop_0", "parent_id")),
+                },
+                ProjectColumn {
+                    alias: "org_id".into(),
+                    expr: ProjectExpr::Column(ColumnRef::scoped("__recursive_hop_0", "org_id")),
+                },
+            ],
+        }),
+        frontier_key: KeyRef::RowId(RowIdRef::Current),
+        max_depth: 10,
+        dedupe_key: vec![KeyRef::RowId(RowIdRef::Current)],
+    };
+
+    let results = execute_query(&mut qm, &mut storage, query).unwrap();
+    let mut ids: Vec<ObjectId> = results.into_iter().map(|(id, _)| id).collect();
+    ids.sort();
+
+    let mut expected = vec![root.row_id, mid.row_id, leaf.row_id];
+    expected.sort();
+    assert_eq!(ids, expected);
+}
+
+#[test]
 fn recursive_query_with_join_project_step_is_rejected() {
     let sync_manager = SyncManager::new();
     let schema = recursive_hop_team_schema();

--- a/crates/jazz-tools/src/query_manager/manager_tests/server_subscriptions.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests/server_subscriptions.rs
@@ -64,6 +64,7 @@ fn server_builds_query_graph_on_subscription() {
             query_id: QueryId(1),
             query: Box::new(query),
             session: None,
+            required_tier: None,
             propagation: crate::sync_manager::QueryPropagation::Full,
             policy_context_tables: vec![],
         },
@@ -93,6 +94,298 @@ fn server_builds_query_graph_on_subscription() {
 
     assert!(sent_ids.contains(&handle1.row_id), "Alice should be sent");
     assert!(sent_ids.contains(&handle3.row_id), "Charlie should be sent");
+}
+
+#[test]
+fn initial_query_settled_is_not_queued_behind_later_query_scope_rows() {
+    use crate::sync_manager::{ClientId, Destination, InboxEntry, QueryId, Source, SyncPayload};
+    use uuid::Uuid;
+
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let (mut server_qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    let alice = server_qm
+        .insert(
+            &mut storage,
+            "users",
+            &[Value::Text("Alice".into()), Value::Integer(100)],
+        )
+        .unwrap();
+    let bob = server_qm
+        .insert(
+            &mut storage,
+            "users",
+            &[Value::Text("Bob".into()), Value::Integer(30)],
+        )
+        .unwrap();
+    let _charlie = server_qm
+        .insert(
+            &mut storage,
+            "users",
+            &[Value::Text("Charlie".into()), Value::Integer(75)],
+        )
+        .unwrap();
+    server_qm.process(&mut storage);
+
+    let client_id = ClientId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+    connect_client(&mut server_qm, &storage, client_id);
+    server_qm.sync_manager_mut().take_outbox();
+
+    let small_query = server_qm
+        .query("users")
+        .filter_gt("score", Value::Integer(90))
+        .build();
+    let broad_query = server_qm
+        .query("users")
+        .filter_gt("score", Value::Integer(0))
+        .build();
+
+    for (query_id, query) in [(QueryId(1), small_query), (QueryId(2), broad_query)] {
+        server_qm.sync_manager_mut().push_inbox(InboxEntry {
+            source: Source::Client(client_id),
+            payload: SyncPayload::QuerySubscription {
+                query_id,
+                query: Box::new(query),
+                session: None,
+                required_tier: None,
+                propagation: crate::sync_manager::QueryPropagation::Full,
+                policy_context_tables: vec![],
+            },
+        });
+    }
+
+    server_qm.process(&mut storage);
+
+    let outbox = server_qm.sync_manager_mut().take_outbox();
+    let first_settled_idx = outbox
+        .iter()
+        .position(|entry| {
+            matches!(
+                entry,
+                crate::sync_manager::OutboxEntry {
+                    destination: Destination::Client(id),
+                    payload: SyncPayload::QuerySettled { query_id: QueryId(1), .. },
+                } if *id == client_id
+            )
+        })
+        .expect("first query should settle");
+    let second_query_only_row_idx = outbox
+        .iter()
+        .position(|entry| {
+            matches!(
+                entry,
+                crate::sync_manager::OutboxEntry {
+                    destination: Destination::Client(id),
+                    payload: SyncPayload::RowBatchNeeded { row, .. },
+                } if *id == client_id && row.row_id == bob.row_id
+            )
+        })
+        .expect("second query should queue its additional rows");
+
+    assert!(
+        first_settled_idx < second_query_only_row_idx,
+        "query 1 settlement should follow query 1 rows ({}) before query 2 rows ({}); outbox={outbox:?}",
+        alice.row_id,
+        bob.row_id
+    );
+}
+
+#[test]
+fn server_subscription_does_not_repeat_same_scope_same_tier_settlement() {
+    use crate::sync_manager::{ClientId, Destination, InboxEntry, QueryId, Source, SyncPayload};
+
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let (mut server_qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    server_qm
+        .insert(
+            &mut storage,
+            "users",
+            &[Value::Text("Alice".into()), Value::Integer(100)],
+        )
+        .unwrap();
+    server_qm.process(&mut storage);
+
+    let client_id = ClientId::new();
+    connect_client(&mut server_qm, &storage, client_id);
+    let _ = server_qm.sync_manager_mut().take_outbox();
+
+    let query = server_qm
+        .query("users")
+        .filter_gt("score", Value::Integer(50))
+        .build();
+
+    server_qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::QuerySubscription {
+            query_id: QueryId(1),
+            query: Box::new(query),
+            session: None,
+            required_tier: None,
+            propagation: crate::sync_manager::QueryPropagation::Full,
+            policy_context_tables: vec![],
+        },
+    });
+
+    server_qm.process(&mut storage);
+    let outbox = server_qm.sync_manager_mut().take_outbox();
+    assert!(
+        outbox.iter().any(|entry| matches!(
+            entry,
+            crate::sync_manager::OutboxEntry {
+                destination: Destination::Client(id),
+                payload: SyncPayload::QuerySettled { query_id: QueryId(1), .. },
+            } if *id == client_id
+        )),
+        "initial settlement should still be emitted"
+    );
+
+    server_qm
+        .insert(
+            &mut storage,
+            "users",
+            &[Value::Text("Bob".into()), Value::Integer(10)],
+        )
+        .unwrap();
+    server_qm.process(&mut storage);
+
+    let outbox = server_qm.sync_manager_mut().take_outbox();
+    assert!(
+        outbox.iter().all(|entry| !matches!(
+            entry,
+            crate::sync_manager::OutboxEntry {
+                destination: Destination::Client(id),
+                payload: SyncPayload::QuerySettled { query_id: QueryId(1), .. },
+            } if *id == client_id
+        )),
+        "dirty graph passes with unchanged scope and unchanged tier should not resend QuerySettled"
+    );
+}
+
+#[test]
+fn duplicate_server_subscription_does_not_replay_same_scope_same_tier_settlement() {
+    use crate::sync_manager::{ClientId, Destination, InboxEntry, QueryId, Source, SyncPayload};
+
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let (mut server_qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    server_qm
+        .insert(
+            &mut storage,
+            "users",
+            &[Value::Text("Alice".into()), Value::Integer(100)],
+        )
+        .unwrap();
+    server_qm.process(&mut storage);
+
+    let client_id = ClientId::new();
+    connect_client(&mut server_qm, &storage, client_id);
+    let _ = server_qm.sync_manager_mut().take_outbox();
+
+    let query = server_qm
+        .query("users")
+        .filter_gt("score", Value::Integer(50))
+        .build();
+
+    for _ in 0..2 {
+        server_qm.sync_manager_mut().push_inbox(InboxEntry {
+            source: Source::Client(client_id),
+            payload: SyncPayload::QuerySubscription {
+                query_id: QueryId(1),
+                query: Box::new(query.clone()),
+                session: None,
+                required_tier: None,
+                propagation: crate::sync_manager::QueryPropagation::Full,
+                policy_context_tables: vec![],
+            },
+        });
+
+        server_qm.process(&mut storage);
+    }
+
+    let outbox = server_qm.sync_manager_mut().take_outbox();
+    let settled_count = outbox
+        .iter()
+        .filter(|entry| {
+            matches!(
+                entry,
+                crate::sync_manager::OutboxEntry {
+                    destination: Destination::Client(id),
+                    payload: SyncPayload::QuerySettled { query_id: QueryId(1), .. },
+                } if *id == client_id
+            )
+        })
+        .count();
+
+    assert_eq!(
+        settled_count, 1,
+        "re-registering an equivalent active subscription should not replay an unchanged settlement"
+    );
+}
+
+#[test]
+fn pending_duplicate_server_subscription_is_compiled_once() {
+    use crate::sync_manager::{ClientId, Destination, InboxEntry, QueryId, Source, SyncPayload};
+
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let (mut server_qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    server_qm
+        .insert(
+            &mut storage,
+            "users",
+            &[Value::Text("Alice".into()), Value::Integer(100)],
+        )
+        .unwrap();
+    server_qm.process(&mut storage);
+
+    let client_id = ClientId::new();
+    connect_client(&mut server_qm, &storage, client_id);
+    let _ = server_qm.sync_manager_mut().take_outbox();
+
+    let query = server_qm
+        .query("users")
+        .filter_gt("score", Value::Integer(50))
+        .build();
+
+    for _ in 0..2 {
+        server_qm.sync_manager_mut().push_inbox(InboxEntry {
+            source: Source::Client(client_id),
+            payload: SyncPayload::QuerySubscription {
+                query_id: QueryId(1),
+                query: Box::new(query.clone()),
+                session: None,
+                required_tier: None,
+                propagation: crate::sync_manager::QueryPropagation::Full,
+                policy_context_tables: vec![],
+            },
+        });
+    }
+
+    server_qm.process(&mut storage);
+
+    let outbox = server_qm.sync_manager_mut().take_outbox();
+    let settled_count = outbox
+        .iter()
+        .filter(|entry| {
+            matches!(
+                entry,
+                crate::sync_manager::OutboxEntry {
+                    destination: Destination::Client(id),
+                    payload: SyncPayload::QuerySettled { query_id: QueryId(1), .. },
+                } if *id == client_id
+            )
+        })
+        .count();
+
+    assert_eq!(
+        settled_count, 1,
+        "duplicate pending registrations for the same client/query should compile and settle once"
+    );
 }
 
 #[test]
@@ -128,6 +421,7 @@ fn server_subscription_reads_visible_region_after_legacy_commit_history_is_remov
             query_id: QueryId(1),
             query: Box::new(query),
             session: None,
+            required_tier: None,
             propagation: crate::sync_manager::QueryPropagation::Full,
             policy_context_tables: vec![],
         },
@@ -191,6 +485,7 @@ fn server_authorizes_subscription_sync_scope_without_rechecking_output_scope() {
             query_id: QueryId(1),
             query: Box::new(query),
             session: Some(Session::new("alice")),
+            required_tier: None,
             propagation: QueryPropagation::Full,
             policy_context_tables: vec![],
         },
@@ -296,6 +591,7 @@ fn server_sends_error_for_uncompilable_query_subscription() {
             query_id: QueryId(42),
             query: Box::new(invalid_query),
             session: None,
+            required_tier: None,
             propagation: crate::sync_manager::QueryPropagation::Full,
             policy_context_tables: vec![],
         },
@@ -356,6 +652,7 @@ fn server_stale_recompile_failure_drops_subscription_and_notifies_client() {
             query_id: QueryId(7),
             query: Box::new(valid_query),
             session: None,
+            required_tier: None,
             propagation: crate::sync_manager::QueryPropagation::Full,
             policy_context_tables: vec![],
         },
@@ -463,6 +760,7 @@ fn server_pushes_new_matches() {
             query_id: QueryId(1),
             query: Box::new(query),
             session: None,
+            required_tier: None,
             propagation: crate::sync_manager::QueryPropagation::Full,
             policy_context_tables: vec![],
         },
@@ -563,6 +861,7 @@ fn server_subscription_telemetry_tracks_grouping_and_unsubscribe_lifecycle() {
                 query_id,
                 query: Box::new(query),
                 session: None,
+                required_tier: None,
                 propagation,
                 policy_context_tables: vec![],
             },
@@ -627,6 +926,7 @@ fn server_does_not_push_non_matching() {
             query_id: QueryId(1),
             query: Box::new(query),
             session: None,
+            required_tier: None,
             propagation: crate::sync_manager::QueryPropagation::Full,
             policy_context_tables: vec![],
         },

--- a/crates/jazz-tools/src/query_manager/manager_tests/subscriptions.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests/subscriptions.rs
@@ -1140,6 +1140,61 @@ fn subscribe_with_sync_local_only_on_persistence_tier_does_not_send_upstream() {
 }
 
 #[test]
+fn local_durability_tier_subscription_ignores_stale_upstream_scope() {
+    use crate::sync_manager::{DurabilityTier, InboxEntry, QueryId, ServerId, Source, SyncPayload};
+    use uuid::Uuid;
+
+    let sync_manager = SyncManager::new().with_durability_tier(DurabilityTier::EdgeServer);
+    let schema = test_schema();
+    let (mut edge_qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    let row_id = edge_qm
+        .insert(
+            &mut storage,
+            "users",
+            &[Value::Text("Alice".into()), Value::Integer(100)],
+        )
+        .unwrap()
+        .row_id;
+    edge_qm.process(&mut storage);
+    let _ = edge_qm.take_updates();
+
+    let upstream_id = ServerId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+    connect_server(&mut edge_qm, &storage, upstream_id);
+    let _ = edge_qm.sync_manager_mut().take_outbox();
+
+    let query = edge_qm.query("users").build();
+    let sub_id = edge_qm
+        .subscribe_with_sync(query, None, Some(DurabilityTier::EdgeServer))
+        .unwrap();
+
+    edge_qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Server(upstream_id),
+        payload: SyncPayload::QuerySettled {
+            query_id: QueryId(sub_id.0),
+            tier: DurabilityTier::Local,
+            scope: vec![],
+            through_seq: 0,
+        },
+    });
+    edge_qm.process(&mut storage);
+
+    let updates = edge_qm.take_updates();
+    assert_eq!(updates.len(), 1);
+    assert_eq!(updates[0].subscription_id, sub_id);
+    assert_eq!(
+        updates[0]
+            .delta
+            .added
+            .iter()
+            .map(|row| row.id)
+            .collect::<Vec<_>>(),
+        vec![row_id],
+        "edge-tier reads on an edge runtime are satisfied locally and must not be clipped by a stale upstream scope snapshot"
+    );
+}
+
+#[test]
 fn add_server_replays_existing_local_query_subscriptions() {
     use crate::sync_manager::{Destination, QueryId, ServerId, SyncPayload};
     use uuid::Uuid;

--- a/crates/jazz-tools/src/query_manager/manager_tests/subscriptions.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests/subscriptions.rs
@@ -65,6 +65,45 @@ fn settled_clean_subscription_does_not_request_visibility_recompute_on_idle_proc
 }
 
 #[test]
+fn batch_fate_processing_does_not_scan_visible_regions_to_find_members() {
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let mut qm = QueryManager::new(sync_manager);
+    qm.set_current_schema(schema, "dev", "main");
+    let mut storage = CountingCatalogueUpsertsStorage::with_inner(seeded_memory_storage(
+        &qm.schema_context().current_schema,
+    ));
+
+    let query = qm.query("users").build();
+    qm.subscribe(query).unwrap();
+
+    let handle = qm
+        .insert(
+            &mut storage,
+            "users",
+            &[Value::Text("Alice".into()), Value::Integer(100)],
+        )
+        .unwrap();
+    qm.process(&mut storage);
+    qm.take_updates();
+    storage.reset_visible_region_scans();
+
+    qm.sync_manager_mut()
+        .push_pending_batch_fate(crate::batch_fate::BatchFate::DurableDirect {
+            batch_id: handle.batch_id,
+            confirmed_tier: DurabilityTier::GlobalServer,
+        });
+
+    qm.process(&mut storage);
+
+    assert_eq!(
+        storage.visible_region_scans(),
+        0,
+        "batch fate processing should use batch records and subscription provenance, not scan/decode every visible row"
+    );
+}
+
+#[test]
 fn sorted_limited_subscription_reorders_when_new_top_row_arrives() {
     let sync_manager = SyncManager::new();
     let schema = test_schema();

--- a/crates/jazz-tools/src/query_manager/manager_tests/subscriptions.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests/subscriptions.rs
@@ -1298,12 +1298,20 @@ fn mid_tier_forwards_query_subscription_upstream() {
             query_id: crate::sync_manager::QueryId(42),
             query: Box::new(query),
             session: None,
+            required_tier: None,
             propagation: crate::sync_manager::QueryPropagation::Full,
             policy_context_tables: vec![],
         },
     });
 
     // Process the subscription
+    mid_tier
+        .insert(
+            &mut storage,
+            "users",
+            &[Value::Text("Alice".into()), Value::Integer(100)],
+        )
+        .unwrap();
     mid_tier.process(&mut storage);
 
     // Check that QuerySubscription was forwarded to upstream server
@@ -1319,6 +1327,137 @@ fn mid_tier_forwards_query_subscription_upstream() {
         forwarded.len(),
         1,
         "Mid-tier should forward QuerySubscription to upstream server"
+    );
+}
+
+#[test]
+fn mid_tier_suppresses_repeated_local_query_settled_for_global_downstream_subscription() {
+    use crate::sync_manager::{
+        ClientId, Destination, DurabilityTier, InboxEntry, OutboxEntry, ServerId, Source,
+        SyncPayload,
+    };
+    use uuid::Uuid;
+
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let (mut mid_tier, mut storage) = create_query_manager(sync_manager, schema);
+
+    let upstream_id = ServerId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+    connect_server(&mut mid_tier, &storage, upstream_id);
+
+    let client_id = ClientId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+    connect_client(&mut mid_tier, &storage, client_id);
+    let _ = mid_tier.sync_manager_mut().take_outbox();
+
+    let query = mid_tier.query("users").build();
+
+    mid_tier.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::QuerySubscription {
+            query_id: crate::sync_manager::QueryId(42),
+            query: Box::new(query),
+            session: None,
+            required_tier: Some(DurabilityTier::GlobalServer),
+            propagation: crate::sync_manager::QueryPropagation::Full,
+            policy_context_tables: vec![],
+        },
+    });
+
+    mid_tier.process(&mut storage);
+
+    let outbox = mid_tier.sync_manager_mut().take_outbox();
+    assert!(
+        outbox.iter().any(|entry| matches!(
+            entry,
+            OutboxEntry {
+                destination: Destination::Server(id),
+                payload: SyncPayload::QuerySubscription { query_id, required_tier: None, .. },
+            } if *id == upstream_id
+                && *query_id == crate::sync_manager::QueryId(42)
+        )),
+        "mid-tier should forward the subscription upstream without imposing the downstream-local tier gate on the upstream server"
+    );
+    assert!(
+        outbox.iter().any(|entry| matches!(
+            entry,
+            OutboxEntry {
+                destination: Destination::Client(id),
+                payload: SyncPayload::QuerySettled {
+                    query_id,
+                    tier: DurabilityTier::Local,
+                    ..
+                },
+            } if *id == client_id && *query_id == crate::sync_manager::QueryId(42)
+        )),
+        "the first lower-tier settled signal is preserved as the initial remote scope snapshot"
+    );
+
+    mid_tier.process(&mut storage);
+    let outbox = mid_tier.sync_manager_mut().take_outbox();
+    assert!(
+        outbox.iter().all(|entry| !matches!(
+            entry,
+            OutboxEntry {
+                destination: Destination::Client(id),
+                payload: SyncPayload::QuerySettled {
+                    query_id,
+                    tier: DurabilityTier::Local,
+                    ..
+                },
+            } if *id == client_id && *query_id == crate::sync_manager::QueryId(42)
+        )),
+        "after the initial scope snapshot, below-required settled signals should be suppressed"
+    );
+}
+
+#[test]
+fn mid_tier_keeps_local_query_settled_for_legacy_downstream_subscription() {
+    use crate::sync_manager::{
+        ClientId, Destination, InboxEntry, OutboxEntry, ServerId, Source, SyncPayload,
+    };
+    use uuid::Uuid;
+
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let (mut mid_tier, mut storage) = create_query_manager(sync_manager, schema);
+
+    let upstream_id = ServerId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+    connect_server(&mut mid_tier, &storage, upstream_id);
+
+    let client_id = ClientId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+    connect_client(&mut mid_tier, &storage, client_id);
+    let _ = mid_tier.sync_manager_mut().take_outbox();
+
+    let query = mid_tier.query("users").build();
+
+    mid_tier.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::QuerySubscription {
+            query_id: crate::sync_manager::QueryId(42),
+            query: Box::new(query),
+            session: None,
+            required_tier: None,
+            propagation: crate::sync_manager::QueryPropagation::Full,
+            policy_context_tables: vec![],
+        },
+    });
+
+    mid_tier.process(&mut storage);
+
+    let outbox = mid_tier.sync_manager_mut().take_outbox();
+    assert!(
+        outbox.iter().any(|entry| matches!(
+            entry,
+            OutboxEntry {
+                destination: Destination::Client(id),
+                payload: SyncPayload::QuerySettled {
+                    query_id,
+                    tier: crate::sync_manager::DurabilityTier::Local,
+                    ..
+                },
+            } if *id == client_id && *query_id == crate::sync_manager::QueryId(42)
+        )),
+        "subscriptions without an explicit required tier should retain the legacy local settled signal"
     );
 }
 
@@ -1349,6 +1488,7 @@ fn mid_tier_does_not_forward_local_only_query_subscription_upstream() {
             query_id: crate::sync_manager::QueryId(42),
             query: Box::new(query),
             session: None,
+            required_tier: None,
             propagation: crate::sync_manager::QueryPropagation::LocalOnly,
             policy_context_tables: vec![],
         },
@@ -1392,6 +1532,7 @@ fn add_server_does_not_replay_downstream_local_only_query_subscription() {
             query_id: crate::sync_manager::QueryId(77),
             query: Box::new(query),
             session: None,
+            required_tier: None,
             propagation: crate::sync_manager::QueryPropagation::LocalOnly,
             policy_context_tables: vec![],
         },
@@ -1446,6 +1587,7 @@ fn mid_tier_forwards_query_unsubscription_upstream() {
             query_id,
             query: Box::new(query),
             session: None,
+            required_tier: None,
             propagation: crate::sync_manager::QueryPropagation::Full,
             policy_context_tables: vec![],
         },
@@ -1522,6 +1664,7 @@ fn mid_tier_relays_objects_to_clients_with_matching_scope() {
             query_id: crate::sync_manager::QueryId(42),
             query: Box::new(query),
             session: None,
+            required_tier: None,
             propagation: crate::sync_manager::QueryPropagation::Full,
             policy_context_tables: vec![],
         },

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -9,7 +9,7 @@ use crate::row_histories::BatchId;
 use crate::schema_manager::LensTransformer;
 use crate::storage::Storage;
 use crate::sync_manager::{
-    ClientId, ClientRole, DurabilityTier, PendingPermissionCheck, QueryId, SyncPayload,
+    ClientId, ClientRole, DurabilityTier, PendingPermissionCheck, SyncPayload,
 };
 
 use super::manager::{QueryManager, SchemaWarningAccumulator, ServerQuerySubscription};
@@ -72,6 +72,33 @@ struct UpdatePermissionRequest<'a> {
 }
 
 impl QueryManager {
+    fn should_emit_query_settled_to_downstream(
+        required_tier: Option<DurabilityTier>,
+        tier: DurabilityTier,
+        sent_below_required_settled: &mut bool,
+        last_emitted_settled_tier: &mut Option<DurabilityTier>,
+        scope_changed: bool,
+    ) -> bool {
+        let is_required_tier = required_tier.is_none_or(|required_tier| tier >= required_tier);
+
+        if is_required_tier
+            && (scope_changed || last_emitted_settled_tier.is_none_or(|last_tier| tier > last_tier))
+        {
+            *last_emitted_settled_tier =
+                Some(last_emitted_settled_tier.map_or(tier, |last_tier| last_tier.max(tier)));
+            return true;
+        }
+
+        if !is_required_tier && !*sent_below_required_settled {
+            *sent_below_required_settled = true;
+            *last_emitted_settled_tier =
+                Some(last_emitted_settled_tier.map_or(tier, |last_tier| last_tier.max(tier)));
+            return true;
+        }
+
+        false
+    }
+
     pub(super) fn missing_permissions_head_reason() -> &'static str {
         "backend has no published permissions head; push permissions before running session-scoped queries or writes against this backend"
     }
@@ -759,11 +786,22 @@ impl QueryManager {
     /// 3. Set the scope in SyncManager (which triggers initial sync)
     pub(super) fn process_pending_query_subscriptions<H: Storage>(&mut self, storage: &mut H) {
         let pending = self.sync_manager.take_pending_query_subscriptions();
+        let mut pending_by_key = HashMap::new();
+        let mut pending_keys = Vec::new();
+        for sub in pending {
+            let key = (sub.client_id, sub.query_id);
+            if !pending_by_key.contains_key(&key) {
+                pending_keys.push(key);
+            }
+            pending_by_key.insert(key, sub);
+        }
         let mut deferred = Vec::new();
         let mut schema_warning_notifications = Vec::new();
-        let mut settled_notifications = Vec::new();
 
-        for sub in pending {
+        for key in pending_keys {
+            let Some(sub) = pending_by_key.remove(&key) else {
+                continue;
+            };
             let Some((schema_for_compile, subscription_context)) =
                 self.build_server_subscription_context(&sub.query)
             else {
@@ -781,6 +819,62 @@ impl QueryManager {
                     .get_client(sub.client_id)
                     .and_then(|c| c.session.clone())
             });
+            let existing_subscription_state = self
+                .server_subscriptions
+                .get(&(sub.client_id, sub.query_id))
+                .map(|existing| {
+                    (
+                        existing.query == sub.query
+                            && existing.session == session_for_policy
+                            && existing.required_tier == sub.required_tier
+                            && existing.propagation == sub.propagation
+                            && existing.policy_context_tables == sub.policy_context_tables,
+                        existing.sent_below_required_settled,
+                        existing.last_emitted_settled_tier,
+                        existing.last_scope.clone(),
+                        existing.settled_once,
+                    )
+                });
+            let equivalent_existing_subscription = existing_subscription_state
+                .as_ref()
+                .is_some_and(|(equivalent, ..)| *equivalent);
+
+            if equivalent_existing_subscription
+                && existing_subscription_state
+                    .as_ref()
+                    .is_some_and(|(_, _, _, _, settled_once)| *settled_once)
+            {
+                let settled_tier = self
+                    .sync_manager
+                    .max_local_durability_tier()
+                    .unwrap_or(DurabilityTier::Local);
+                let mut emission_scope = None;
+
+                if let Some(existing) = self
+                    .server_subscriptions
+                    .get_mut(&(sub.client_id, sub.query_id))
+                    && Self::should_emit_query_settled_to_downstream(
+                        existing.required_tier,
+                        settled_tier,
+                        &mut existing.sent_below_required_settled,
+                        &mut existing.last_emitted_settled_tier,
+                        false,
+                    )
+                {
+                    emission_scope = Some(existing.last_scope.clone());
+                }
+
+                if let Some(scope) = emission_scope.as_ref() {
+                    self.sync_manager.emit_query_settled(
+                        sub.client_id,
+                        sub.query_id,
+                        settled_tier,
+                        scope,
+                    );
+                }
+
+                continue;
+            }
 
             // Build QueryGraph with client's session for policy filtering (schema-aware)
             let query_for_compile =
@@ -900,38 +994,72 @@ impl QueryManager {
                     session_for_policy.as_ref(),
                 )
             };
-            if let Some(scope) = scope.as_ref() {
-                // Set scope in SyncManager (triggers initial sync)
-                self.sync_manager.set_client_query_scope_with_storage(
-                    storage_ref,
-                    sub.client_id,
-                    sub.query_id,
-                    scope.clone(),
-                    session_for_policy.clone(),
-                );
-            }
-
             let settled_once = scope.is_some();
+            let mut sent_below_required_settled = existing_subscription_state
+                .as_ref()
+                .filter(|(equivalent, ..)| *equivalent)
+                .map(|(_, sent_below_required_settled, ..)| *sent_below_required_settled)
+                .unwrap_or(false);
+            let mut last_emitted_settled_tier = existing_subscription_state
+                .as_ref()
+                .filter(|(equivalent, ..)| *equivalent)
+                .and_then(|(_, _, last_emitted_settled_tier, _, _)| *last_emitted_settled_tier);
+
             if let Some(scope) = scope.as_ref() {
+                let scope_changed = !equivalent_existing_subscription
+                    || existing_subscription_state
+                        .as_ref()
+                        .is_none_or(|(_, _, _, last_scope, _)| *last_scope != *scope);
+
+                if scope_changed {
+                    self.sync_manager.set_client_query_scope_with_storage(
+                        storage_ref,
+                        sub.client_id,
+                        sub.query_id,
+                        scope.clone(),
+                        session_for_policy.clone(),
+                    );
+                }
+
                 let settled_tier = self
                     .sync_manager
                     .max_local_durability_tier()
                     .unwrap_or(DurabilityTier::Local);
-                settled_notifications.push((
-                    sub.client_id,
-                    sub.query_id,
+                if Self::should_emit_query_settled_to_downstream(
+                    sub.required_tier,
                     settled_tier,
-                    scope.clone(),
-                ));
+                    &mut sent_below_required_settled,
+                    &mut last_emitted_settled_tier,
+                    scope_changed,
+                ) {
+                    // Keep the QuerySettled marker immediately after the rows
+                    // for this query's scope. Deferring all settlements until
+                    // after every pending subscription lets one huge query put
+                    // unrelated smaller queries' first callbacks behind its
+                    // entire row replay.
+                    self.sync_manager.emit_query_settled(
+                        sub.client_id,
+                        sub.query_id,
+                        settled_tier,
+                        scope,
+                    );
+                }
             }
 
             // Forward QuerySubscription to upstream servers (multi-tier forwarding)
             // This allows hub servers to know about the query and push matching data
             if sub.propagation == crate::sync_manager::QueryPropagation::Full {
+                tracing::trace!(
+                    %sub.client_id,
+                    query_id = sub.query_id.0,
+                    table = %sub.query.table,
+                    "jazz trace forwarding downstream query subscription upstream"
+                );
                 self.sync_manager.send_query_subscription_to_servers(
                     sub.query_id,
                     sub.query.clone(),
                     session_for_policy.clone(),
+                    None,
                     sub.propagation,
                     sub.policy_context_tables.clone(),
                 );
@@ -947,6 +1075,9 @@ impl QueryManager {
                     session: session_for_policy,
                     branches,
                     policy_context_tables: sub.policy_context_tables,
+                    required_tier: sub.required_tier,
+                    sent_below_required_settled,
+                    last_emitted_settled_tier,
                     last_scope: scope.unwrap_or_default(),
                     needs_recompile: false,
                     settled_once,
@@ -958,11 +1089,6 @@ impl QueryManager {
 
         for (client_id, warning) in schema_warning_notifications {
             self.sync_manager.emit_schema_warning(client_id, warning);
-        }
-
-        for (client_id, query_id, tier, scope) in settled_notifications {
-            self.sync_manager
-                .emit_query_settled(client_id, query_id, tier, &scope);
         }
 
         // Re-queue subscriptions whose schema wasn't available yet
@@ -1001,19 +1127,6 @@ impl QueryManager {
     /// a client's query subscription.
     #[allow(clippy::type_complexity)]
     pub(super) fn settle_server_subscriptions(&mut self, storage: &dyn Storage) {
-        // Collect updates to avoid borrow issues
-        let mut scope_updates: Vec<(
-            ClientId,
-            QueryId,
-            HashSet<(ObjectId, BranchName)>,
-            Option<Session>,
-        )> = Vec::new();
-        let mut settled_notifications: Vec<(
-            ClientId,
-            QueryId,
-            DurabilityTier,
-            HashSet<(ObjectId, BranchName)>,
-        )> = Vec::new();
         let mut schema_warning_notifications: Vec<(ClientId, crate::sync_manager::SchemaWarning)> =
             Vec::new();
 
@@ -1097,12 +1210,13 @@ impl QueryManager {
             if let Some(new_scope) = new_scope {
                 let scope_changed = new_scope != sub.last_scope;
                 if scope_changed {
-                    scope_updates.push((
+                    self.sync_manager.set_client_query_scope_with_storage(
+                        storage,
                         client_id,
                         query_id,
                         new_scope.clone(),
                         sub.session.clone(),
-                    ));
+                    );
                     sub.last_scope = new_scope.clone();
                 }
 
@@ -1116,39 +1230,61 @@ impl QueryManager {
                         .sync_manager
                         .max_local_durability_tier()
                         .unwrap_or(DurabilityTier::Local);
-                    settled_notifications.push((client_id, query_id, settled_tier, new_scope));
+                    if Self::should_emit_query_settled_to_downstream(
+                        sub.required_tier,
+                        settled_tier,
+                        &mut sub.sent_below_required_settled,
+                        &mut sub.last_emitted_settled_tier,
+                        true,
+                    ) {
+                        tracing::trace!(
+                            %client_id,
+                            query_id = query_id.0,
+                            tier = ?settled_tier,
+                            scope_len = new_scope.len(),
+                            "jazz trace server subscription settled"
+                        );
+                        self.sync_manager.emit_query_settled(
+                            client_id,
+                            query_id,
+                            settled_tier,
+                            &new_scope,
+                        );
+                    }
                 } else if scope_changed || had_dirty_graph {
                     let settled_tier = self
                         .sync_manager
                         .max_local_durability_tier()
                         .unwrap_or(DurabilityTier::Local);
-                    settled_notifications.push((
-                        client_id,
-                        query_id,
+                    if Self::should_emit_query_settled_to_downstream(
+                        sub.required_tier,
                         settled_tier,
-                        sub.last_scope.clone(),
-                    ));
+                        &mut sub.sent_below_required_settled,
+                        &mut sub.last_emitted_settled_tier,
+                        scope_changed,
+                    ) {
+                        tracing::trace!(
+                            %client_id,
+                            query_id = query_id.0,
+                            tier = ?settled_tier,
+                            scope_len = sub.last_scope.len(),
+                            "jazz trace server subscription settled"
+                        );
+                        self.sync_manager.emit_query_settled(
+                            client_id,
+                            query_id,
+                            settled_tier,
+                            &sub.last_scope,
+                        );
+                    }
                 }
             }
 
             self.server_subscriptions.insert((client_id, query_id), sub);
         }
 
-        // Apply scope updates
-        for (client_id, query_id, new_scope, session) in scope_updates {
-            self.sync_manager.set_client_query_scope_with_storage(
-                storage, client_id, query_id, new_scope, session,
-            );
-        }
-
         for (client_id, warning) in schema_warning_notifications {
             self.sync_manager.emit_schema_warning(client_id, warning);
-        }
-
-        // Emit QuerySettled notifications
-        for (client_id, query_id, tier, scope) in settled_notifications {
-            self.sync_manager
-                .emit_query_settled(client_id, query_id, tier, &scope);
         }
     }
 

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -700,14 +701,6 @@ impl QueryManager {
         })
     }
 
-    fn should_sync_policy_context_rows(
-        &self,
-        client_id: ClientId,
-        session: Option<&Session>,
-    ) -> bool {
-        self.client_bypasses_authorization_filtering(client_id, session)
-    }
-
     fn client_bypasses_authorization_filtering(
         &self,
         client_id: ClientId,
@@ -919,8 +912,6 @@ impl QueryManager {
                 continue;
             };
 
-            let sync_policy_context_rows =
-                self.should_sync_policy_context_rows(sub.client_id, session_for_policy.as_ref());
             let branch_schema_map = Self::branch_schema_map_for_context(&subscription_context);
 
             // Initial settle to populate the graph
@@ -973,18 +964,16 @@ impl QueryManager {
                 .client_bypasses_authorization_filtering(sub.client_id, session_for_policy.as_ref())
             {
                 let result_scope = graph.sync_scope_object_ids();
-                Some(
-                    if sync_policy_context_rows || !policy_context_tables.is_empty() {
-                        Self::scope_with_policy_context_rows_for_tables(
-                            &result_scope,
-                            &policy_context_tables,
-                            &branches,
-                            storage_ref,
-                        )
-                    } else {
-                        result_scope
-                    },
-                )
+                Some(if !policy_context_tables.is_empty() {
+                    Self::scope_with_policy_context_rows_for_tables(
+                        &result_scope,
+                        &policy_context_tables,
+                        &branches,
+                        storage_ref,
+                    )
+                } else {
+                    result_scope
+                })
             } else {
                 self.authorized_scope_from_graph_if_available(
                     storage_ref,
@@ -1144,7 +1133,7 @@ impl QueryManager {
             let had_dirty_graph = sub.graph.has_dirty_nodes();
 
             // Row loader for this subscription
-            let new_scope = {
+            let new_scope: Option<Cow<'_, HashSet<(ObjectId, BranchName)>>> = {
                 {
                     let row_loader =
                         |id: ObjectId, table_hint: Option<TableName>| -> Option<LoadedRow> {
@@ -1182,21 +1171,19 @@ impl QueryManager {
                 let policy_context_tables =
                     Self::merged_policy_context_tables(&sub.graph, &sub.policy_context_tables);
                 if self.client_bypasses_authorization_filtering(client_id, sub.session.as_ref()) {
-                    let result_scope = sub.graph.sync_scope_object_ids();
-                    Some(
-                        if self.should_sync_policy_context_rows(client_id, sub.session.as_ref())
-                            || !policy_context_tables.is_empty()
-                        {
-                            Self::scope_with_policy_context_rows_for_tables(
-                                &result_scope,
-                                &policy_context_tables,
-                                branches,
-                                storage,
-                            )
-                        } else {
-                            result_scope
-                        },
-                    )
+                    if !policy_context_tables.is_empty() {
+                        let result_scope = sub.graph.sync_scope_object_ids();
+                        Some(Cow::Owned(Self::scope_with_policy_context_rows_for_tables(
+                            &result_scope,
+                            &policy_context_tables,
+                            branches,
+                            storage,
+                        )))
+                    } else if let Some(scope) = sub.graph.sync_scope_object_ids_ref() {
+                        Some(Cow::Borrowed(scope))
+                    } else {
+                        Some(Cow::Owned(sub.graph.sync_scope_object_ids()))
+                    }
                 } else {
                     self.authorized_scope_from_graph_if_available(
                         storage,
@@ -1205,19 +1192,21 @@ impl QueryManager {
                         &branch_schema_map,
                         sub.session.as_ref(),
                     )
+                    .map(Cow::Owned)
                 }
             };
             if let Some(new_scope) = new_scope {
-                let scope_changed = new_scope != sub.last_scope;
+                let scope_changed = new_scope.as_ref() != &sub.last_scope;
                 if scope_changed {
+                    let owned_scope = new_scope.into_owned();
                     self.sync_manager.set_client_query_scope_with_storage(
                         storage,
                         client_id,
                         query_id,
-                        new_scope.clone(),
+                        owned_scope.clone(),
                         sub.session.clone(),
                     );
-                    sub.last_scope = new_scope.clone();
+                    sub.last_scope = owned_scope;
                 }
 
                 // Emit an authoritative QuerySettled once the scope for this
@@ -1241,14 +1230,14 @@ impl QueryManager {
                             %client_id,
                             query_id = query_id.0,
                             tier = ?settled_tier,
-                            scope_len = new_scope.len(),
+                            scope_len = sub.last_scope.len(),
                             "jazz trace server subscription settled"
                         );
                         self.sync_manager.emit_query_settled(
                             client_id,
                             query_id,
                             settled_tier,
-                            &new_scope,
+                            &sub.last_scope,
                         );
                     }
                 } else if scope_changed || had_dirty_graph {

--- a/crates/jazz-tools/src/query_manager/subscriptions.rs
+++ b/crates/jazz-tools/src/query_manager/subscriptions.rs
@@ -158,6 +158,8 @@ impl QueryManager {
         let id = QuerySubscriptionId(self.next_subscription_id);
         self.next_subscription_id += 1;
         let query_frontier_settled_tier = (durability_tier.is_none()
+            || durability_tier
+                .is_some_and(|tier| self.sync_manager.has_local_durability_at_least(tier))
             || !self.should_send_local_subscription_upstream(propagation)
             || !self.sync_manager.has_servers_or_pending_servers())
         .then_some(DurabilityTier::GlobalServer);

--- a/crates/jazz-tools/src/query_manager/subscriptions.rs
+++ b/crates/jazz-tools/src/query_manager/subscriptions.rs
@@ -6,8 +6,8 @@ use std::{
 use crate::object::ObjectId;
 use crate::row_histories::RowVisibilityChange;
 use crate::storage::Storage;
-use crate::sync_manager::QueryPropagation;
 use crate::sync_manager::{DurabilityTier, QueryId, ServerId};
+use crate::sync_manager::{OutgoingQuerySubscription, QueryPropagation};
 
 #[cfg(test)]
 use super::encoding::decode_row;
@@ -26,6 +26,7 @@ type ReplayableQuerySubscription = (
     QueryId,
     Query,
     Option<Session>,
+    Option<DurabilityTier>,
     QueryPropagation,
     Vec<String>,
 );
@@ -403,6 +404,7 @@ impl QueryManager {
                 query_id,
                 sync_query,
                 session,
+                durability_tier,
                 propagation,
                 policy_context_tables,
             );
@@ -465,21 +467,33 @@ impl QueryManager {
                     QueryId(sub_id.0),
                     self.sync_query_payload_for_upstream(&sub.query),
                     sub.session.clone(),
+                    sub.durability_tier,
                     sub.propagation,
                     sub.policy_context_tables.clone(),
                 )
             })
             .collect();
 
-        for (query_id, query, session, propagation, policy_context_tables) in local_subs {
+        for (query_id, query, session, required_tier, propagation, policy_context_tables) in
+            local_subs
+        {
+            if self
+                .sync_manager
+                .consume_pending_query_subscription_marker(server_id, query_id)
+            {
+                continue;
+            }
             if self.should_send_local_subscription_upstream(propagation) {
                 self.sync_manager.send_query_subscription_to_server(
                     server_id,
-                    query_id,
-                    query,
-                    session,
-                    propagation,
-                    policy_context_tables,
+                    OutgoingQuerySubscription {
+                        query_id,
+                        query,
+                        session,
+                        required_tier,
+                        propagation,
+                        policy_context_tables,
+                    },
                 );
             }
         }
@@ -493,20 +507,32 @@ impl QueryManager {
                     *query_id,
                     sub.query.clone(),
                     sub.session.clone(),
+                    sub.required_tier,
                     sub.propagation,
                     sub.policy_context_tables.clone(),
                 )
             })
             .collect();
 
-        for (query_id, query, session, propagation, policy_context_tables) in downstream_subs {
+        for (query_id, query, session, required_tier, propagation, policy_context_tables) in
+            downstream_subs
+        {
+            if self
+                .sync_manager
+                .consume_pending_query_subscription_marker(server_id, query_id)
+            {
+                continue;
+            }
             self.sync_manager.send_query_subscription_to_server(
                 server_id,
-                query_id,
-                query,
-                session,
-                propagation,
-                policy_context_tables,
+                OutgoingQuerySubscription {
+                    query_id,
+                    query,
+                    session,
+                    required_tier,
+                    propagation,
+                    policy_context_tables,
+                },
             );
         }
     }

--- a/crates/jazz-tools/src/runtime_core/ticks.rs
+++ b/crates/jazz-tools/src/runtime_core/ticks.rs
@@ -494,8 +494,25 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                         >= pending_settled.through_seq
                 });
                 if is_ready {
+                    tracing::trace!(
+                        server_id = ?pending_settled.server_id,
+                        query_id = pending_settled.query_id.0,
+                        tier = ?pending_settled.tier,
+                        through_seq = pending_settled.through_seq,
+                        "jazz trace query settled ready for query manager"
+                    );
                     ready.push(pending_settled);
                 } else {
+                    tracing::trace!(
+                        server_id = ?pending_settled.server_id,
+                        query_id = pending_settled.query_id.0,
+                        tier = ?pending_settled.tier,
+                        through_seq = pending_settled.through_seq,
+                        last_applied = pending_settled.server_id.and_then(|server_id| {
+                            self.last_applied_server_seq.get(&server_id).copied()
+                        }),
+                        "jazz trace query settled blocked on stream sequence"
+                    );
                     blocked.push(pending_settled);
                 }
             }
@@ -514,6 +531,15 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             {
                 let query_manager = self.schema_manager.query_manager_mut();
                 for pending_settled in ready_query_settled {
+                    if let Some(server_id) = pending_settled.server_id {
+                        query_manager
+                            .sync_manager_mut()
+                            .relay_query_settled_to_origins(
+                                server_id,
+                                pending_settled.query_id,
+                                pending_settled.tier,
+                            );
+                    }
                     query_manager
                         .apply_query_settled(pending_settled.query_id, pending_settled.tier);
                 }

--- a/crates/jazz-tools/src/server/routes/mod.rs
+++ b/crates/jazz-tools/src/server/routes/mod.rs
@@ -1974,6 +1974,7 @@ mod tests {
                         query: Box::new(query),
                         session: None,
                         propagation,
+                        required_tier: None,
                         policy_context_tables: vec![],
                     },
                 })

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -197,7 +197,7 @@ impl SyncManager {
         storage
             .upsert_authoritative_batch_fate(fate)
             .map_err(|error| {
-                tracing::warn!(
+                tracing::trace!(
                     batch_id = ?fate.batch_id(),
                     %error,
                     "failed to persist authoritative batch fate"
@@ -214,7 +214,7 @@ impl SyncManager {
         storage
             .upsert_sealed_batch_submission(submission)
             .map_err(|error| {
-                tracing::warn!(
+                tracing::trace!(
                     batch_id = ?submission.batch_id,
                     %error,
                     "failed to persist sealed batch submission"
@@ -1098,20 +1098,8 @@ impl SyncManager {
                     through_seq,
                 });
 
-                // Relay to interested clients
-                if let Some(clients) = self.query_origin.get(&query_id) {
-                    for &cid in clients {
-                        self.outbox.push(OutboxEntry {
-                            destination: Destination::Client(cid),
-                            payload: SyncPayload::QuerySettled {
-                                query_id,
-                                tier,
-                                scope: scope.clone(),
-                                through_seq,
-                            },
-                        });
-                    }
-                }
+                // RuntimeCore relays this to interested clients once the
+                // upstream stream watermark proves the scope's rows are local.
             }
             SyncPayload::SchemaWarning(warning) => {
                 super::log_schema_warning(&warning, Some("server"), None);
@@ -1349,6 +1337,7 @@ impl SyncManager {
                 query_id,
                 query,
                 session,
+                required_tier,
                 propagation,
                 policy_context_tables,
             } => {
@@ -1397,12 +1386,20 @@ impl SyncManager {
                     .entry(*query_id)
                     .or_default()
                     .insert(client_id);
+                tracing::trace!(
+                    %client_id,
+                    query_id = query_id.0,
+                    table = %query.table,
+                    ?propagation,
+                    "jazz trace received query subscription from client"
+                );
                 self.pending_query_subscriptions
                     .push(PendingQuerySubscription {
                         client_id,
                         query_id: *query_id,
                         query: query.as_ref().clone(),
                         session: effective_session,
+                        required_tier: *required_tier,
                         propagation: *propagation,
                         policy_context_tables: policy_context_tables.clone(),
                     });
@@ -1410,6 +1407,11 @@ impl SyncManager {
             // Handle query unsubscription
             // Queue for QueryManager to process (remove server-side QueryGraph, forward upstream)
             SyncPayload::QueryUnsubscription { query_id } => {
+                tracing::trace!(
+                    %client_id,
+                    query_id = query_id.0,
+                    "jazz trace received query unsubscription from client"
+                );
                 // Clean up query origin
                 if let Some(clients) = self.query_origin.get_mut(query_id) {
                     clients.remove(&client_id);

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -1083,9 +1083,15 @@ impl SyncManager {
                     .remote_query_scopes
                     .get(&(server_id, query_id))
                     .is_none_or(|previous_scope| previous_scope != &scope_set);
+                let tier_changed = self
+                    .remote_query_scope_tiers
+                    .get(&(server_id, query_id))
+                    .is_none_or(|previous_tier| *previous_tier != tier);
                 self.remote_query_scopes
                     .insert((server_id, query_id), scope_set);
-                if scope_changed {
+                self.remote_query_scope_tiers
+                    .insert((server_id, query_id), tier);
+                if scope_changed || tier_changed {
                     self.remote_query_scope_dirty.insert(query_id);
                 }
 

--- a/crates/jazz-tools/src/sync_manager/mod.rs
+++ b/crates/jazz-tools/src/sync_manager/mod.rs
@@ -32,6 +32,16 @@ pub use types::*;
 /// treat it as offline.
 pub const PENDING_SERVER_TIMEOUT: Duration = Duration::from_secs(2);
 
+#[derive(Clone)]
+pub(crate) struct OutgoingQuerySubscription {
+    pub(crate) query_id: QueryId,
+    pub(crate) query: Query,
+    pub(crate) session: Option<Session>,
+    pub(crate) required_tier: Option<DurabilityTier>,
+    pub(crate) propagation: QueryPropagation,
+    pub(crate) policy_context_tables: Vec<String>,
+}
+
 // ============================================================================
 // SyncManager
 // ============================================================================
@@ -49,6 +59,7 @@ pub struct SyncManager {
 
     pub(super) servers: HashMap<ServerId, ServerState>,
     pub(super) pending_servers: HashMap<ServerId, Instant>,
+    pub(super) pending_server_query_subscriptions: HashSet<(ServerId, QueryId)>,
     pub(super) clients: HashMap<ClientId, ClientState>,
 
     pub(super) inbox: Vec<InboxEntry>,
@@ -189,7 +200,7 @@ pub(crate) fn log_connection_schema_diagnostics(
             .iter()
             .map(short_hash)
             .collect();
-        tracing::warn!(
+        tracing::trace!(
             origin = origin,
             client_schema_hash = %client_hash,
             unreachable_schema_hashes = ?unreachable_hashes,
@@ -209,6 +220,7 @@ impl SyncManager {
             allow_unprivileged_schema_catalogue_writes: false,
             servers: HashMap::new(),
             pending_servers: HashMap::new(),
+            pending_server_query_subscriptions: HashSet::new(),
             clients: HashMap::new(),
             inbox: Vec::new(),
             outbox: Vec::new(),
@@ -407,6 +419,8 @@ impl SyncManager {
 
     pub fn remove_pending_server(&mut self, server_id: ServerId) {
         self.pending_servers.remove(&server_id);
+        self.pending_server_query_subscriptions
+            .retain(|(id, _)| *id != server_id);
     }
 
     pub fn server_ids(&self) -> impl Iterator<Item = ServerId> + '_ {
@@ -441,15 +455,7 @@ impl SyncManager {
     }
 
     pub fn seal_batch_to_servers(&mut self, submission: SealedBatchSubmission) {
-        let now = Instant::now();
-        let mut server_ids: Vec<_> = self.servers.keys().copied().collect();
-        server_ids.extend(
-            self.pending_servers
-                .iter()
-                .filter(|(_, since)| now.duration_since(**since) < PENDING_SERVER_TIMEOUT)
-                .map(|(server_id, _)| *server_id),
-        );
-        for server_id in server_ids {
+        for server_id in self.outbound_server_ids() {
             self.outbox.push(OutboxEntry {
                 destination: Destination::Server(server_id),
                 payload: SyncPayload::SealBatch {
@@ -459,10 +465,24 @@ impl SyncManager {
         }
     }
 
+    fn outbound_server_ids(&self) -> Vec<ServerId> {
+        let now = Instant::now();
+        let mut server_ids: Vec<_> = self.servers.keys().copied().collect();
+        server_ids.extend(
+            self.pending_servers
+                .iter()
+                .filter(|(_, since)| now.duration_since(**since) < PENDING_SERVER_TIMEOUT)
+                .map(|(server_id, _)| *server_id),
+        );
+        server_ids
+    }
+
     /// Remove a server connection.
     pub fn remove_server(&mut self, server_id: ServerId) {
         self.servers.remove(&server_id);
         self.pending_servers.remove(&server_id);
+        self.pending_server_query_subscriptions
+            .retain(|(id, _)| *id != server_id);
         let mut removed_query_ids = HashSet::new();
         self.remote_query_scopes
             .retain(|(remote_server_id, query_id), _| {
@@ -762,18 +782,29 @@ impl SyncManager {
         query_id: QueryId,
         query: Query,
         session: Option<Session>,
+        required_tier: Option<DurabilityTier>,
         propagation: QueryPropagation,
         policy_context_tables: Vec<String>,
     ) {
-        let server_ids: Vec<ServerId> = self.servers.keys().copied().collect();
+        let server_ids = self.outbound_server_ids();
+        tracing::trace!(
+            server_count = server_ids.len(),
+            query_id = query_id.0,
+            table = %query.table,
+            ?propagation,
+            "jazz trace send query subscription to servers"
+        );
         for server_id in server_ids {
             self.send_query_subscription_to_server(
                 server_id,
-                query_id,
-                query.clone(),
-                session.clone(),
-                propagation,
-                policy_context_tables.clone(),
+                OutgoingQuerySubscription {
+                    query_id,
+                    query: query.clone(),
+                    session: session.clone(),
+                    required_tier,
+                    propagation,
+                    policy_context_tables: policy_context_tables.clone(),
+                },
             );
         }
     }
@@ -781,36 +812,64 @@ impl SyncManager {
     /// Send a QuerySubscription to one specific server.
     ///
     /// Used when replaying existing subscriptions after a late server connect.
-    pub fn send_query_subscription_to_server(
+    pub(crate) fn send_query_subscription_to_server(
         &mut self,
         server_id: ServerId,
-        query_id: QueryId,
-        query: Query,
-        session: Option<Session>,
-        propagation: QueryPropagation,
-        policy_context_tables: Vec<String>,
+        subscription: OutgoingQuerySubscription,
     ) {
-        if !self.servers.contains_key(&server_id) {
+        let OutgoingQuerySubscription {
+            query_id,
+            query,
+            session,
+            required_tier,
+            propagation,
+            policy_context_tables,
+        } = subscription;
+        let is_connected = self.servers.contains_key(&server_id);
+        let is_pending = self.pending_servers.contains_key(&server_id);
+        if !is_connected && !is_pending {
             return;
         }
 
+        tracing::trace!(
+            %server_id,
+            query_id = query_id.0,
+            table = %query.table,
+            ?propagation,
+            "jazz trace sending query subscription upstream"
+        );
         self.outbox.push(OutboxEntry {
             destination: Destination::Server(server_id),
             payload: SyncPayload::QuerySubscription {
                 query_id,
                 query: Box::new(query),
                 session,
+                required_tier,
                 propagation,
                 policy_context_tables,
             },
         });
+
+        if !is_connected && is_pending {
+            self.pending_server_query_subscriptions
+                .insert((server_id, query_id));
+        }
+    }
+
+    pub(crate) fn consume_pending_query_subscription_marker(
+        &mut self,
+        server_id: ServerId,
+        query_id: QueryId,
+    ) -> bool {
+        self.pending_server_query_subscriptions
+            .remove(&(server_id, query_id))
     }
 
     /// Send a QueryUnsubscription to all connected servers.
     ///
     /// Called by QueryManager when a client unsubscribes from a synced query.
     pub fn send_query_unsubscription_to_servers(&mut self, query_id: QueryId) {
-        for &server_id in self.servers.keys() {
+        for server_id in self.outbound_server_ids() {
             self.outbox.push(OutboxEntry {
                 destination: Destination::Server(server_id),
                 payload: SyncPayload::QueryUnsubscription { query_id },
@@ -894,6 +953,13 @@ impl SyncManager {
         tier: DurabilityTier,
         scope: &HashSet<(ObjectId, BranchName)>,
     ) {
+        tracing::trace!(
+            %client_id,
+            query_id = query_id.0,
+            ?tier,
+            scope_len = scope.len(),
+            "jazz trace emitting query settled to client"
+        );
         self.outbox.push(OutboxEntry {
             destination: Destination::Client(client_id),
             payload: SyncPayload::QuerySettled {
@@ -903,6 +969,28 @@ impl SyncManager {
                 through_seq: 0,
             },
         });
+    }
+
+    pub(crate) fn relay_query_settled_to_origins(
+        &mut self,
+        server_id: ServerId,
+        query_id: QueryId,
+        tier: DurabilityTier,
+    ) {
+        let Some(scope) = self
+            .remote_query_scopes
+            .get(&(server_id, query_id))
+            .cloned()
+        else {
+            return;
+        };
+        let Some(clients) = self.query_origin.get(&query_id).cloned() else {
+            return;
+        };
+
+        for client_id in clients {
+            self.emit_query_settled(client_id, query_id, tier, &scope);
+        }
     }
 
     /// Emit a schema warning to a client.

--- a/crates/jazz-tools/src/sync_manager/mod.rs
+++ b/crates/jazz-tools/src/sync_manager/mod.rs
@@ -86,6 +86,8 @@ pub struct SyncManager {
     pub(super) query_origin: HashMap<QueryId, HashSet<ClientId>>,
     /// Latest remote scope snapshots keyed by upstream server and query id.
     pub(super) remote_query_scopes: HashMap<(ServerId, QueryId), HashSet<(ObjectId, BranchName)>>,
+    /// Durability tier associated with each latest remote scope snapshot.
+    pub(super) remote_query_scope_tiers: HashMap<(ServerId, QueryId), DurabilityTier>,
     /// Query ids whose remote scope changed since the last QueryManager process.
     pub(super) remote_query_scope_dirty: HashSet<QueryId>,
     /// Pending QuerySettled notifications for QueryManager to process.
@@ -132,6 +134,7 @@ impl std::fmt::Debug for SyncManager {
             .field("row_batch_interest", &self.row_batch_interest)
             .field("query_origin", &self.query_origin)
             .field("remote_query_scopes", &self.remote_query_scopes)
+            .field("remote_query_scope_tiers", &self.remote_query_scope_tiers)
             .field("pending_query_settled", &self.pending_query_settled)
             .field("pending_query_rejections", &self.pending_query_rejections)
             .field("pending_batch_fates", &self.pending_batch_fates)
@@ -234,6 +237,7 @@ impl SyncManager {
             row_batch_interest: HashMap::new(),
             query_origin: HashMap::new(),
             remote_query_scopes: HashMap::new(),
+            remote_query_scope_tiers: HashMap::new(),
             remote_query_scope_dirty: HashSet::new(),
             pending_query_settled: Vec::new(),
             pending_query_rejections: Vec::new(),
@@ -492,6 +496,8 @@ impl SyncManager {
                 }
                 keep
             });
+        self.remote_query_scope_tiers
+            .retain(|(remote_server_id, _), _| *remote_server_id != server_id);
         self.remote_query_scope_dirty.extend(removed_query_ids);
     }
 
@@ -901,11 +907,45 @@ impl SyncManager {
             .collect()
     }
 
+    /// Return the union of latest upstream scope snapshots at or above the
+    /// requested tier for this query.
+    pub fn remote_query_scope_at_least(
+        &self,
+        query_id: QueryId,
+        requested_tier: DurabilityTier,
+    ) -> HashSet<(ObjectId, BranchName)> {
+        self.remote_query_scopes
+            .iter()
+            .filter(|((server_id, remote_query_id), _)| {
+                *remote_query_id == query_id
+                    && self
+                        .remote_query_scope_tiers
+                        .get(&(*server_id, *remote_query_id))
+                        .is_some_and(|tier| *tier >= requested_tier)
+            })
+            .flat_map(|(_, scope)| scope.iter().copied())
+            .collect()
+    }
+
     /// Whether we have received at least one upstream scope snapshot for this query.
     pub fn has_remote_query_scope_snapshot(&self, query_id: QueryId) -> bool {
         self.remote_query_scopes
             .keys()
             .any(|(_, remote_query_id)| *remote_query_id == query_id)
+    }
+
+    /// Whether we have received at least one upstream scope snapshot for this
+    /// query at a tier that can authoritatively satisfy the requested tier.
+    pub fn has_remote_query_scope_snapshot_at_least(
+        &self,
+        query_id: QueryId,
+        requested_tier: DurabilityTier,
+    ) -> bool {
+        self.remote_query_scope_tiers
+            .iter()
+            .any(|((_, remote_query_id), tier)| {
+                *remote_query_id == query_id && *tier >= requested_tier
+            })
     }
 
     /// Take query ids whose upstream scope changed since the last process pass.

--- a/crates/jazz-tools/src/sync_manager/tests.rs
+++ b/crates/jazz-tools/src/sync_manager/tests.rs
@@ -330,6 +330,7 @@ fn push_query_subscription(
             query_id: QueryId(1),
             query: Box::new(query),
             session: payload_session,
+            required_tier: None,
             propagation: QueryPropagation::Full,
             policy_context_tables: vec![],
         },

--- a/crates/jazz-tools/src/sync_manager/tests/basic.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/basic.rs
@@ -76,6 +76,7 @@ fn memory_size_separates_sync_state_buckets() {
             query_id: QueryId(8),
             query: query.clone(),
             session: Some(session.clone()),
+            required_tier: None,
             propagation: QueryPropagation::Full,
             policy_context_tables: vec![],
         });

--- a/crates/jazz-tools/src/sync_manager/tests/query_scope.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/query_scope.rs
@@ -66,7 +66,7 @@ fn query_settled_from_server_stores_scope_for_query() {
 }
 
 #[test]
-fn query_settled_from_server_relays_scope_to_interested_clients() {
+fn query_settled_from_server_can_be_relayed_to_interested_clients_after_ready() {
     let mut sm = SyncManager::new();
     let mut io = MemoryStorage::new();
     let client_id = ClientId::new();
@@ -91,6 +91,12 @@ fn query_settled_from_server_relays_scope_to_interested_clients() {
             through_seq: 0,
         },
     );
+
+    assert!(
+        sm.take_outbox().is_empty(),
+        "server QuerySettled should wait for RuntimeCore's stream watermark before relay"
+    );
+    sm.relay_query_settled_to_origins(server_id, query_id, DurabilityTier::Local);
 
     assert!(sm.take_outbox().into_iter().any(|entry| matches!(
         entry,

--- a/crates/jazz-tools/src/sync_manager/tests/subscriptions.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/subscriptions.rs
@@ -15,6 +15,7 @@ fn send_query_subscription_includes_session() {
         QueryId(7),
         query.clone(),
         Some(session.clone()),
+        None,
         QueryPropagation::Full,
         vec![],
     );
@@ -46,6 +47,35 @@ fn send_query_subscription_includes_session() {
         }
         other => panic!("expected QuerySubscription to server, got {other:?}"),
     }
+}
+
+#[test]
+fn send_query_subscription_targets_pending_server() {
+    let mut sm = SyncManager::new();
+    let server_id = ServerId::new();
+    sm.add_pending_server(server_id);
+
+    let query = QueryBuilder::new("users").branch("main").build();
+    sm.send_query_subscription_to_servers(
+        QueryId(7),
+        query,
+        None,
+        None,
+        QueryPropagation::Full,
+        vec![],
+    );
+
+    let outbox = sm.take_outbox();
+    assert!(
+        outbox.iter().any(|entry| matches!(
+            entry,
+            OutboxEntry {
+                destination: Destination::Server(id),
+                payload: SyncPayload::QuerySubscription { query_id, .. },
+            } if *id == server_id && *query_id == QueryId(7)
+        )),
+        "query subscriptions must be queued for pending upstream transports"
+    );
 }
 
 #[test]
@@ -86,6 +116,7 @@ fn remove_client_cleans_pending_query_subscriptions() {
             query_id: QueryId(1),
             query: query.clone(),
             session: None,
+            required_tier: None,
             propagation: QueryPropagation::Full,
             policy_context_tables: vec![],
         });
@@ -95,6 +126,7 @@ fn remove_client_cleans_pending_query_subscriptions() {
             query_id: QueryId(2),
             query,
             session: None,
+            required_tier: None,
             propagation: QueryPropagation::Full,
             policy_context_tables: vec![],
         });

--- a/crates/jazz-tools/src/sync_manager/types.rs
+++ b/crates/jazz-tools/src/sync_manager/types.rs
@@ -291,6 +291,8 @@ pub enum SyncPayload {
         #[serde(with = "query_subscription_session_serde")]
         session: Option<Session>,
         #[serde(default)]
+        required_tier: Option<DurabilityTier>,
+        #[serde(default)]
         propagation: QueryPropagation,
         #[serde(default)]
         policy_context_tables: Vec<String>,
@@ -540,6 +542,7 @@ pub struct PendingQuerySubscription {
     pub query_id: QueryId,
     pub query: Query,
     pub session: Option<Session>,
+    pub required_tier: Option<DurabilityTier>,
     pub propagation: QueryPropagation,
     pub policy_context_tables: Vec<String>,
 }

--- a/crates/jazz-tools/src/sync_manager/types.rs
+++ b/crates/jazz-tools/src/sync_manager/types.rs
@@ -586,6 +586,7 @@ mod tests {
             query_id: QueryId(7),
             query: Box::new(Query::new("todos")),
             session: Some(Session::new("alice").with_auth_mode(AuthMode::LocalFirst)),
+            required_tier: None,
             propagation: QueryPropagation::Full,
             policy_context_tables: Vec::new(),
         };

--- a/crates/jazz-tools/src/transport_manager.rs
+++ b/crates/jazz-tools/src/transport_manager.rs
@@ -4,7 +4,7 @@
 //! TransportManager owns the live WebSocket connection and reconnects on failure.
 
 use crate::query_manager::types::SchemaHash;
-use crate::sync_manager::types::{ClientId, InboxEntry, OutboxEntry, ServerId};
+use crate::sync_manager::types::{ClientId, InboxEntry, OutboxEntry, ServerId, SyncPayload};
 use futures::channel::mpsc;
 
 pub const SYNC_PROTOCOL_VERSION: u32 = 2;
@@ -88,6 +88,38 @@ impl TransportHandle {
         self.inbound_rx.try_recv().ok()
     }
     pub fn send_outbox(&self, entry: OutboxEntry) {
+        match &entry.payload {
+            SyncPayload::QuerySubscription {
+                query_id,
+                query,
+                propagation,
+                ..
+            } => {
+                tracing::trace!(
+                    %self.server_id,
+                    query_id = query_id.0,
+                    table = %query.table,
+                    ?propagation,
+                    "jazz trace transport enqueue query subscription"
+                );
+            }
+            SyncPayload::QuerySettled {
+                query_id,
+                tier,
+                scope,
+                through_seq,
+            } => {
+                tracing::trace!(
+                    %self.server_id,
+                    query_id = query_id.0,
+                    ?tier,
+                    scope_len = scope.len(),
+                    through_seq,
+                    "jazz trace transport enqueue query settled"
+                );
+            }
+            _ => {}
+        }
         let _ = self.outbox_tx.unbounded_send(entry);
     }
     pub fn has_ever_connected(&self) -> bool {
@@ -526,6 +558,40 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
         sequence: Option<u64>,
         payload: crate::sync_manager::types::SyncPayload,
     ) {
+        match &payload {
+            crate::sync_manager::types::SyncPayload::QuerySettled {
+                query_id,
+                tier,
+                scope,
+                through_seq,
+            } => {
+                tracing::trace!(
+                    %self.server_id,
+                    sequence,
+                    query_id = query_id.0,
+                    ?tier,
+                    scope_len = scope.len(),
+                    through_seq,
+                    "jazz trace transport received query settled"
+                );
+            }
+            crate::sync_manager::types::SyncPayload::QuerySubscription {
+                query_id,
+                query,
+                propagation,
+                ..
+            } => {
+                tracing::trace!(
+                    %self.server_id,
+                    sequence,
+                    query_id = query_id.0,
+                    table = %query.table,
+                    ?propagation,
+                    "jazz trace transport received query subscription"
+                );
+            }
+            _ => {}
+        }
         let entry = InboxEntry {
             source: crate::sync_manager::types::Source::Server(self.server_id),
             payload,
@@ -711,6 +777,38 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
                     // outbox closed = handle dropped; control_rx will also return None shortly.
                     // Route to Shutdown so the same clean-exit path is taken.
                     let Some(entry) = out else { return ConnectedExit::Shutdown; };
+                    match &entry.payload {
+                        crate::sync_manager::types::SyncPayload::QuerySubscription {
+                            query_id,
+                            query,
+                            propagation,
+                            ..
+                        } => {
+                            tracing::trace!(
+                                %self.server_id,
+                                query_id = query_id.0,
+                                table = %query.table,
+                                ?propagation,
+                                "jazz trace transport socket send query subscription"
+                            );
+                        }
+                        crate::sync_manager::types::SyncPayload::QuerySettled {
+                            query_id,
+                            tier,
+                            scope,
+                            through_seq,
+                        } => {
+                            tracing::trace!(
+                                %self.server_id,
+                                query_id = query_id.0,
+                                ?tier,
+                                scope_len = scope.len(),
+                                through_seq,
+                                "jazz trace transport socket send query settled"
+                            );
+                        }
+                        _ => {}
+                    }
                     let Ok(bytes) = serde_json::to_vec(&entry) else { continue; };
                     let frame = frame_encode(&bytes);
                     if ws.send(&frame).await.is_err() { return ConnectedExit::NetworkError; }
@@ -898,6 +996,38 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
                     // outbox closed = handle dropped; control_rx will also return None shortly.
                     // Route to Shutdown so the same clean-exit path is taken.
                     let Some(entry) = out else { return WasmConnectedExit::Shutdown; };
+                    match &entry.payload {
+                        crate::sync_manager::types::SyncPayload::QuerySubscription {
+                            query_id,
+                            query,
+                            propagation,
+                            ..
+                        } => {
+                            tracing::trace!(
+                                %self.server_id,
+                                query_id = query_id.0,
+                                table = %query.table,
+                                ?propagation,
+                                "jazz trace transport socket send query subscription"
+                            );
+                        }
+                        crate::sync_manager::types::SyncPayload::QuerySettled {
+                            query_id,
+                            tier,
+                            scope,
+                            through_seq,
+                        } => {
+                            tracing::trace!(
+                                %self.server_id,
+                                query_id = query_id.0,
+                                ?tier,
+                                scope_len = scope.len(),
+                                through_seq,
+                                "jazz trace transport socket send query settled"
+                            );
+                        }
+                        _ => {}
+                    }
                     let Ok(bytes) = serde_json::to_vec(&entry) else { continue; };
                     let frame = frame_encode(&bytes);
                     if ws.send(&frame).await.is_err() { return WasmConnectedExit::NetworkError; }

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -51,7 +51,11 @@ import {
 import { analyzeRelations } from "../codegen/relation-analyzer.js";
 import { TabLeaderElection, type LeaderRole, type LeaderSnapshot } from "./tab-leader-election.js";
 import type { WorkerLifecycleEvent } from "../worker/worker-protocol.js";
-import { normalizeBuiltQuery, type BuiltRelation } from "./query-builder-shape.js";
+import {
+  normalizeBuiltQuery,
+  type BuiltRelation,
+  type NormalizedBuiltQuery,
+} from "./query-builder-shape.js";
 import {
   appendWorkerRuntimeWasmUrl,
   resolveRuntimeConfigSyncInitInput,
@@ -196,6 +200,10 @@ export type QueryOptions = QueryExecutionOptions;
 
 function ordinaryDbQueryOptions(options?: QueryOptions): QueryOptions {
   return { localUpdates: "deferred", ...options };
+}
+
+function queryUsesRelationTraversal(builtQuery: NormalizedBuiltQuery): boolean {
+  return builtQuery.hops.length > 0 || builtQuery.gather !== undefined;
 }
 
 export interface ActiveQuerySubscriptionTrace {
@@ -1080,10 +1088,12 @@ export class Db {
       }
       const existingRecord = client.localBatchRecord(batch.batchId);
       const replayableFromWorker = client.hasHydratedWorkerBatch(batch.batchId);
-      client.replayRejectedBatchRecord(batch);
       if (client.hasPendingBatchWaiter(batch.batchId)) {
+        client.replayRejectedBatchRecord(batch);
+        client.markReplayedRejectedBatchDelivered(batch.batchId);
         return;
       }
+      client.replayRejectedBatchRecord(batch);
       if (existingRecord && !replayableFromWorker) {
         return;
       }
@@ -1882,7 +1892,7 @@ export class Db {
     await this.ensureQueryReady(queryOptions, client);
     const wasmQuery = translateQuery(builderJson, planningSchema);
     const rows =
-      builtQuery.hops.length > 0 &&
+      queryUsesRelationTraversal(builtQuery) &&
       "queryInternal" in client &&
       typeof client.queryInternal === "function"
         ? await client.queryInternal(
@@ -2368,7 +2378,9 @@ class ClientBackedDb extends Db {
     const rows = await this.runtimeClient.queryInternal(
       translateQuery(builderJson, planningSchema),
       this.session,
-      builtQuery.hops.length > 0 ? { ...queryOptions, runtimeSettledTier: null } : queryOptions,
+      queryUsesRelationTraversal(builtQuery)
+        ? { ...queryOptions, runtimeSettledTier: null }
+        : queryOptions,
       runtimeSchema.peek(),
     );
     const outputIncludes = outputTable !== builtQuery.table ? {} : builtQuery.includes;

--- a/packages/jazz-tools/src/runtime/worker-bridge.race-harness.test.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.race-harness.test.ts
@@ -157,13 +157,19 @@ class FakeWorker {
 function createRuntimeHarness() {
   let outboundHandler: ((...args: unknown[]) => void) | null = null;
   const receivedFromWorker: Uint8Array[] = [];
+  const receivedSequences: Array<number | null | undefined> = [];
+  let batchedTickCount = 0;
 
   const runtime = {
     onSyncMessageToSend(handler: (...args: unknown[]) => void) {
       outboundHandler = handler;
     },
-    onSyncMessageReceived(payload: Uint8Array) {
+    onSyncMessageReceived(payload: Uint8Array, sequence?: number | null) {
       receivedFromWorker.push(payload);
+      receivedSequences.push(sequence);
+    },
+    batchedTick() {
+      batchedTickCount += 1;
     },
     addServer() {},
     removeServer() {},
@@ -172,6 +178,8 @@ function createRuntimeHarness() {
   return {
     runtime,
     receivedFromWorker,
+    receivedSequences,
+    getBatchedTickCount: () => batchedTickCount,
     emitServerPayload(payload: unknown) {
       if (!outboundHandler) {
         throw new Error("Runtime sync handler is not installed");
@@ -271,6 +279,25 @@ describe("WorkerBridge race harness", () => {
 
     worker.script.completeInit("worker-client-3");
     await initPromise;
+  });
+
+  it("WB-U04a wakes the main runtime after worker->main sync batches", () => {
+    const worker = new FakeWorker();
+    const { runtime, receivedFromWorker, receivedSequences, getBatchedTickCount } =
+      createRuntimeHarness();
+    new WorkerBridge(worker as unknown as Worker, runtime);
+
+    const first = enc({ kind: "from-worker", seq: 1 });
+    const second = enc({ kind: "from-worker", seq: 2 });
+
+    worker.emitToMain({
+      type: "sync",
+      payload: [first, { payload: second, sequence: 7 }],
+    });
+
+    expect(receivedFromWorker).toEqual([first, second]);
+    expect(receivedSequences).toEqual([undefined, 7]);
+    expect(getBatchedTickCount()).toBe(1);
   });
 
   it("WB-U04b waits for a direct upstream connection before resolving edge readiness", async () => {

--- a/packages/jazz-tools/src/runtime/worker-bridge.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.ts
@@ -128,6 +128,7 @@ export class WorkerBridge {
           const sequence = isSequencedSyncPayload(entry) ? entry.sequence : undefined;
           this.runtime.onSyncMessageReceived(payload, sequence);
         }
+        this.runtime.batchedTick?.();
       } else if (msg.type === "upstream-connected") {
         this.markUpstreamServerConnected();
       } else if (msg.type === "upstream-disconnected") {
@@ -354,6 +355,7 @@ export class WorkerBridge {
   applyIncomingServerPayload(payload: Uint8Array): void {
     if (this.isDisposedLike()) return;
     this.runtime.onSyncMessageReceived(payload);
+    this.runtime.batchedTick?.();
   }
 
   replayServerConnection(): void {


### PR DESCRIPTION
## Summary

Stack PR 2 of the Jazz load-performance split. This slice improves query settlement and replay behavior after stack 1 made batch fate the write-batch lifecycle source of truth.

The main goal is to reduce repeated query/replay work while preserving tiered query correctness and rejected-write rollback behavior.

## What changed

- Avoids repeated visible-region scans during replay and settlement processing.
- Prevents over-broad graph dirtiness during tier recomputation.
- Processes batch-fate effects once per query pass.
- Indexes materialized tuples by row id to speed replay-heavy query updates.
- Maintains query sync scope incrementally instead of rebuilding it eagerly.
- Stabilizes tiered query scope and rejected rollback paths.
- Extends query subscription payloads with explicit required-tier metadata while preserving the default no-tier behavior.

## Review notes

- OPFS correctness remains out of scope here because `main` already contains PR #816.
- This PR builds directly on stack 1's batch-fate lifecycle and keeps the focus on query settlement/replay behavior.

## Validation

- `cargo test --workspace --lib --bins --tests --exclude jazz-rn --features test`
- GitHub CI passed: `lint`, `test-rust`, `test-ts`, Vercel docs, and Vercel inspector.
