### PR TITLE
Stack 03: Use binary sync transport frames

### DIFF
--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -22,6 +22,8 @@ use super::types::{
     Value,
 };
 
+const MAX_INITIAL_QUERY_REPLAY_OUTBOX_PER_PASS: usize = 32;
+
 enum WriteSchemaResolution {
     Resolved(Box<TableSchema>),
     PendingSchema,
@@ -791,7 +793,7 @@ impl QueryManager {
         let mut deferred = Vec::new();
         let mut schema_warning_notifications = Vec::new();
 
-        for key in pending_keys {
+        for (key_index, key) in pending_keys.iter().copied().enumerate() {
             let Some(sub) = pending_by_key.remove(&key) else {
                 continue;
             };
@@ -1074,6 +1076,15 @@ impl QueryManager {
                     reported_schema_warnings,
                 },
             );
+
+            if self.sync_manager.outbox().len() >= MAX_INITIAL_QUERY_REPLAY_OUTBOX_PER_PASS {
+                for remaining_key in pending_keys.iter().skip(key_index + 1) {
+                    if let Some(sub) = pending_by_key.remove(remaining_key) {
+                        deferred.push(sub);
+                    }
+                }
+                break;
+            }
         }
 
         for (client_id, warning) in schema_warning_notifications {

--- a/crates/jazz-tools/src/query_manager/types/branch.rs
+++ b/crates/jazz-tools/src/query_manager/types/branch.rs
@@ -1,4 +1,6 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
 
 use crate::object::BranchName;
 
@@ -42,6 +44,26 @@ impl SchemaHash {
         hex::encode(&self.0[..6])
     }
 
+    pub fn to_hex(&self) -> String {
+        static CACHE: OnceLock<Mutex<HashMap<SchemaHash, String>>> = OnceLock::new();
+        let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+        if let Some(cached) = cache
+            .lock()
+            .expect("schema hash hex cache poisoned")
+            .get(self)
+            .cloned()
+        {
+            return cached;
+        }
+
+        let encoded = hex::encode(&self.0);
+        cache
+            .lock()
+            .expect("schema hash hex cache poisoned")
+            .insert(*self, encoded.clone());
+        encoded
+    }
+
     /// Convert to an ObjectId for storage in the catalogue.
     ///
     /// Uses UUIDv5 with DNS namespace over the hash bytes.
@@ -75,13 +97,13 @@ impl SchemaHash {
 
 impl std::fmt::Display for SchemaHash {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", hex::encode(&self.0))
+        f.write_str(&self.to_hex())
     }
 }
 
 impl Serialize for SchemaHash {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&hex::encode(&self.0))
+        serializer.serialize_str(&self.to_hex())
     }
 }
 

--- a/crates/jazz-tools/src/row_histories/types.rs
+++ b/crates/jazz-tools/src/row_histories/types.rs
@@ -85,7 +85,11 @@ impl Serialize for BatchId {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        if serializer.is_human_readable() {
+            self.to_string().serialize(serializer)
+        } else {
+            self.0.serialize(serializer)
+        }
     }
 }
 
@@ -94,8 +98,12 @@ impl<'de> Deserialize<'de> for BatchId {
     where
         D: Deserializer<'de>,
     {
-        let raw = String::deserialize(deserializer)?;
-        raw.parse().map_err(serde::de::Error::custom)
+        if deserializer.is_human_readable() {
+            let raw = String::deserialize(deserializer)?;
+            raw.parse().map_err(serde::de::Error::custom)
+        } else {
+            <[u8; 16]>::deserialize(deserializer).map(Self)
+        }
     }
 }
 

--- a/crates/jazz-tools/src/runtime_core/ticks.rs
+++ b/crates/jazz-tools/src/runtime_core/ticks.rs
@@ -797,6 +797,9 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                         self.park_sync_message(*entry);
                     }
                 }
+                crate::transport_manager::TransportInbound::SyncBatch { entries } => {
+                    self.park_sync_message_batch(entries);
+                }
                 crate::transport_manager::TransportInbound::Disconnected => {
                     self.remove_server(server_id);
                 }
@@ -955,6 +958,58 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         }
     }
 
+    fn park_sync_message_batch(
+        &mut self,
+        entries: Vec<crate::transport_manager::SequencedInboxEntry>,
+    ) {
+        let mut parked_any = false;
+        for crate::transport_manager::SequencedInboxEntry { entry, sequence } in entries {
+            if let Some(sequence) = sequence {
+                match entry.source {
+                    crate::sync_manager::Source::Server(server_id) => {
+                        let next_expected = self
+                            .next_expected_server_seq
+                            .entry(server_id)
+                            .or_insert(sequence);
+                        if sequence < *next_expected {
+                            trace!(
+                                ?server_id,
+                                sequence,
+                                next_expected = *next_expected,
+                                "dropping already-applied sequenced sync message"
+                            );
+                            continue;
+                        }
+
+                        if let Some((ref tracer, ref name)) = self.sync_tracer {
+                            tracer.record_incoming(&entry.source, name, &entry.payload);
+                        }
+
+                        self.parked_sync_messages_by_server_seq
+                            .entry(server_id)
+                            .or_default()
+                            .insert(sequence, entry);
+                        parked_any = true;
+                    }
+                    _ => {
+                        self.parked_sync_messages.push(entry);
+                        parked_any = true;
+                    }
+                }
+            } else {
+                if let Some((ref tracer, ref name)) = self.sync_tracer {
+                    tracer.record_incoming(&entry.source, name, &entry.payload);
+                }
+                self.parked_sync_messages.push(entry);
+                parked_any = true;
+            }
+        }
+
+        if parked_any {
+            self.scheduler.schedule_batched_tick();
+        }
+    }
+
     /// Set the next expected sequenced message for a server stream.
     pub fn set_next_expected_server_sequence(&mut self, server_id: ServerId, next_sequence: u64) {
         let next_sequence = next_sequence.max(1);
@@ -997,6 +1052,9 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                 } else {
                     self.park_sync_message(*entry);
                 }
+            }
+            crate::transport_manager::TransportInbound::SyncBatch { entries } => {
+                self.park_sync_message_batch(entries);
             }
             crate::transport_manager::TransportInbound::Disconnected => {
                 self.remove_server(server_id);

--- a/crates/jazz-tools/src/runtime_core/ticks.rs
+++ b/crates/jazz-tools/src/runtime_core/ticks.rs
@@ -679,8 +679,27 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
 
         self.handle_transport_messages();
 
+        if !self.has_outbound()
+            && self
+                .schema_manager
+                .query_manager()
+                .sync_manager()
+                .has_pending_query_subscriptions()
+        {
+            self.immediate_tick();
+        }
+
         // 1. Send all outgoing sync messages
         self.flush_runtime_outbox("flushing outbox");
+        if self
+            .schema_manager
+            .query_manager()
+            .sync_manager()
+            .has_pending_query_subscriptions()
+        {
+            self.scheduler.schedule_batched_tick();
+            return;
+        }
 
         // 2. Process parked sync messages
         self.handle_sync_messages();
@@ -689,6 +708,15 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         // The scheduler's debounce prevents immediate_tick() from scheduling
         // another batched_tick while we're inside one, so we must flush here.
         self.flush_runtime_outbox("flushing post-process outbox");
+        if self
+            .schema_manager
+            .query_manager()
+            .sync_manager()
+            .has_pending_query_subscriptions()
+        {
+            self.scheduler.schedule_batched_tick();
+            return;
+        }
 
         // Flush the storage durability barrier so writes survive a hard kill (tab close, crash).
         if self.storage_write_pending_flush {
@@ -814,6 +842,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             .keys()
             .copied()
             .collect();
+        let mut applied_since_last_tick = applied_messages > 0;
         for server_id in server_ids {
             let mut next_expected = *self.next_expected_server_seq.get(&server_id).unwrap_or(&1);
             let mut ready_messages = Vec::new();
@@ -834,12 +863,29 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                 .copied()
                 .unwrap_or(next_expected.saturating_sub(1));
             for (sequence, msg) in ready_messages {
+                let is_query_settled = matches!(
+                    &msg.payload,
+                    crate::sync_manager::SyncPayload::QuerySettled { .. }
+                );
                 if msg.payload.writes_storage() {
                     self.mark_storage_write_pending_flush();
                 }
                 self.push_sync_inbox(msg);
                 applied_messages += 1;
+                applied_since_last_tick = true;
                 last_applied = sequence;
+
+                // QuerySettled is an ordered stream barrier for first-callback
+                // delivery. If we queue many later rows before ticking, an
+                // early settled query waits behind unrelated replay work that
+                // merely arrived in the same transport drain.
+                if is_query_settled {
+                    self.next_expected_server_seq
+                        .insert(server_id, sequence.saturating_add(1));
+                    self.last_applied_server_seq.insert(server_id, last_applied);
+                    self.immediate_tick();
+                    applied_since_last_tick = false;
+                }
             }
             self.next_expected_server_seq
                 .insert(server_id, next_expected);
@@ -851,7 +897,9 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
 
         if applied_messages > 0 {
             debug!(count = applied_messages, "applied parked sync messages");
-            self.immediate_tick();
+            if applied_since_last_tick {
+                self.immediate_tick();
+            }
         }
     }
 

--- a/crates/jazz-tools/src/runtime_tokio.rs
+++ b/crates/jazz-tools/src/runtime_tokio.rs
@@ -571,6 +571,18 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
         Ok(())
     }
 
+    /// Push multiple sync messages to the inbox under a single core lock.
+    pub fn push_sync_inbox_batch(&self, entries: Vec<InboxEntry>) -> Result<(), RuntimeError> {
+        if entries.is_empty() {
+            return Ok(());
+        }
+        let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
+        for entry in entries {
+            core.park_sync_message(entry);
+        }
+        Ok(())
+    }
+
     /// Push a sync message with an explicit stream sequence (from network).
     pub fn push_sync_inbox_with_sequence(
         &self,

--- a/crates/jazz-tools/src/schema_manager/encoding.rs
+++ b/crates/jazz-tools/src/schema_manager/encoding.rs
@@ -156,6 +156,46 @@ pub fn decode_schema(data: &[u8]) -> Result<Schema, CatalogueEncodingError> {
     decode_schema_with_version(data, version)
 }
 
+/// Decode only one table descriptor from an encoded schema.
+///
+/// Structural schemas in large apps can be much larger than the row descriptor
+/// needed for a single incoming history row. This keeps row replay from
+/// materializing the entire schema map just to find one table.
+pub fn decode_table_descriptor_from_schema(
+    data: &[u8],
+    table_name: &str,
+) -> Result<Option<RowDescriptor>, CatalogueEncodingError> {
+    if data.is_empty() {
+        return Err(CatalogueEncodingError::TruncatedData {
+            expected: 1,
+            actual: 0,
+        });
+    }
+
+    let Some(version) = SchemaEncodingVersion::from_byte(data[0]) else {
+        return Err(CatalogueEncodingError::UnsupportedVersion {
+            found: data[0],
+            expected: SCHEMA_VERSION,
+        });
+    };
+
+    let mut offset = 1;
+    let table_count = read_u32(data, &mut offset)?;
+    for _ in 0..table_count {
+        let name = read_string(data, &mut offset, "table_name")?;
+        if name == table_name {
+            return decode_row_descriptor_with_version(data, &mut offset, version).map(Some);
+        }
+
+        skip_row_descriptor_with_version(data, &mut offset, version)?;
+        if version.has_table_policies() {
+            decode_table_policies(data, &mut offset)?;
+        }
+    }
+
+    Ok(None)
+}
+
 fn encode_table_entry_with_version(
     buf: &mut Vec<u8>,
     name: &TableName,
@@ -234,6 +274,18 @@ fn decode_row_descriptor_with_version(
     }
 
     Ok(RowDescriptor::new(columns))
+}
+
+fn skip_row_descriptor_with_version(
+    data: &[u8],
+    offset: &mut usize,
+    version: SchemaEncodingVersion,
+) -> Result<(), CatalogueEncodingError> {
+    let count = read_u32(data, offset)?;
+    for _ in 0..count {
+        skip_column_descriptor_with_version(data, offset, version)?;
+    }
+    Ok(())
 }
 
 fn encode_column_descriptor_with_version(
@@ -333,6 +385,42 @@ fn decode_column_descriptor_with_version(
         default,
         merge_strategy,
     })
+}
+
+fn skip_column_descriptor_with_version(
+    data: &[u8],
+    offset: &mut usize,
+    version: SchemaEncodingVersion,
+) -> Result<(), CatalogueEncodingError> {
+    skip_string(data, offset)?;
+    skip_column_type_with_version(data, offset, version)?;
+    let _nullable = read_u8(data, offset)?;
+    let has_ref = read_u8(data, offset)? != 0;
+    if has_ref {
+        skip_string(data, offset)?;
+    }
+    if version.has_legacy_inherit_policy_byte() {
+        let _legacy_inherit_policy = read_u8(data, offset)?;
+    }
+    if version.has_column_defaults() {
+        let has_default = read_u8(data, offset)? != 0;
+        if has_default {
+            skip_value(data, offset)?;
+        }
+    }
+    if version.has_column_merge_strategies() {
+        let has_merge_strategy = read_u8(data, offset)? != 0;
+        if has_merge_strategy {
+            let tag = read_u8(data, offset)?;
+            if tag != 1 {
+                return Err(CatalogueEncodingError::InvalidTypeTag {
+                    tag,
+                    context: "column_merge_strategy",
+                });
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Column type tags.
@@ -451,6 +539,39 @@ fn decode_column_type_with_version(
                 columns: Box::new(desc),
             })
         }
+        _ => Err(CatalogueEncodingError::InvalidTypeTag {
+            tag,
+            context: "column_type",
+        }),
+    }
+}
+
+fn skip_column_type_with_version(
+    data: &[u8],
+    offset: &mut usize,
+    version: SchemaEncodingVersion,
+) -> Result<(), CatalogueEncodingError> {
+    let tag = read_u8(data, offset)?;
+    match tag {
+        TYPE_INTEGER | TYPE_BIGINT | TYPE_DOUBLE | TYPE_BOOLEAN | TYPE_TEXT | TYPE_TIMESTAMP
+        | TYPE_UUID | TYPE_BATCH_ID | TYPE_BYTEA => Ok(()),
+        TYPE_JSON => {
+            let has_schema = read_u8(data, offset)? != 0;
+            if has_schema {
+                let len = read_u32(data, offset)? as usize;
+                read_bytes(data, offset, len)?;
+            }
+            Ok(())
+        }
+        TYPE_ENUM => {
+            let variant_count = read_u32(data, offset)? as usize;
+            for _ in 0..variant_count {
+                skip_string(data, offset)?;
+            }
+            Ok(())
+        }
+        TYPE_ARRAY => skip_column_type_with_version(data, offset, version),
+        TYPE_ROW => skip_row_descriptor_with_version(data, offset, version),
         _ => Err(CatalogueEncodingError::InvalidTypeTag {
             tag,
             context: "column_type",
@@ -1687,6 +1808,33 @@ fn decode_value(data: &[u8], offset: &mut usize) -> Result<Value, CatalogueEncod
     }
 }
 
+fn skip_value(data: &[u8], offset: &mut usize) -> Result<(), CatalogueEncodingError> {
+    let tag = read_u8(data, offset)?;
+    match tag {
+        VALUE_NULL => Ok(()),
+        VALUE_INTEGER => read_bytes(data, offset, 4).map(|_| ()),
+        VALUE_BIGINT | VALUE_DOUBLE | VALUE_TIMESTAMP => read_bytes(data, offset, 8).map(|_| ()),
+        VALUE_BOOLEAN => read_u8(data, offset).map(|_| ()),
+        VALUE_TEXT => skip_string(data, offset),
+        VALUE_UUID | VALUE_BATCH_ID => read_bytes(data, offset, 16).map(|_| ()),
+        VALUE_BYTEA => {
+            let len = read_u32(data, offset)? as usize;
+            read_bytes(data, offset, len).map(|_| ())
+        }
+        VALUE_ARRAY | VALUE_ROW => {
+            let count = read_u32(data, offset)?;
+            for _ in 0..count {
+                skip_value(data, offset)?;
+            }
+            Ok(())
+        }
+        _ => Err(CatalogueEncodingError::InvalidTypeTag {
+            tag,
+            context: "value",
+        }),
+    }
+}
+
 // ============================================================================
 // Primitive Helpers
 // ============================================================================
@@ -1751,6 +1899,11 @@ fn read_string(
     let len = read_u32(data, offset)? as usize;
     let bytes = read_bytes(data, offset, len)?;
     String::from_utf8(bytes.to_vec()).map_err(|_| CatalogueEncodingError::InvalidUtf8 { context })
+}
+
+fn skip_string(data: &[u8], offset: &mut usize) -> Result<(), CatalogueEncodingError> {
+    let len = read_u32(data, offset)? as usize;
+    read_bytes(data, offset, len).map(|_| ())
 }
 
 #[cfg(test)]

--- a/crates/jazz-tools/src/server/mod.rs
+++ b/crates/jazz-tools/src/server/mod.rs
@@ -326,20 +326,18 @@ impl ServerState {
     /// Process a raw binary payload received from a WebSocket client and push it
     /// into the runtime sync inbox.
     ///
-    /// Frames are expected to be `OutboxEntry` JSON (as serialised by
-    /// `TransportManager::run_connected`). If that parse fails we fall back to a
-    /// raw `SyncBatchRequest` shape, which some callers send directly.
+    /// Frames are expected to be post-handshake postcard payloads: either an
+    /// `OutboxEntry` for a single message or a `SyncBatchRequest` for batched
+    /// messages.
     pub async fn process_ws_client_frame(
         &self,
         client_id: ClientId,
         payload: &[u8],
     ) -> Result<(), String> {
-        if let Ok(entry) =
-            serde_json::from_slice::<crate::sync_manager::types::OutboxEntry>(payload)
-        {
+        if let Ok(payload) = crate::transport_protocol::decode_outbox_entry_payload(payload) {
             let inbox = InboxEntry {
                 source: Source::Client(client_id),
-                payload: entry.payload,
+                payload,
             };
             return self
                 .runtime
@@ -347,7 +345,7 @@ impl ServerState {
                 .map_err(|e| e.to_string());
         }
 
-        match serde_json::from_slice::<crate::transport_protocol::SyncBatchRequest>(payload) {
+        match crate::transport_protocol::SyncBatchRequest::decode_payload(payload) {
             Ok(batch) => {
                 let entries = batch
                     .payloads

--- a/crates/jazz-tools/src/server/mod.rs
+++ b/crates/jazz-tools/src/server/mod.rs
@@ -349,16 +349,17 @@ impl ServerState {
 
         match serde_json::from_slice::<crate::transport_protocol::SyncBatchRequest>(payload) {
             Ok(batch) => {
-                for p in batch.payloads {
-                    let inbox = InboxEntry {
+                let entries = batch
+                    .payloads
+                    .into_iter()
+                    .map(|payload| InboxEntry {
                         source: Source::Client(client_id),
-                        payload: p,
-                    };
-                    self.runtime
-                        .push_sync_inbox(inbox)
-                        .map_err(|e| e.to_string())?;
-                }
-                Ok(())
+                        payload,
+                    })
+                    .collect();
+                self.runtime
+                    .push_sync_inbox_batch(entries)
+                    .map_err(|e| e.to_string())
             }
             Err(e) => Err(format!("invalid ws payload: {e}")),
         }

--- a/crates/jazz-tools/src/server/routes/mod.rs
+++ b/crates/jazz-tools/src/server/routes/mod.rs
@@ -317,7 +317,7 @@ mod tests {
             payloads: vec![p1, p2],
             client_id,
         };
-        let frame_payload = serde_json::to_vec(&batch).unwrap();
+        let frame_payload = batch.encode_payload().unwrap();
         let result = state
             .process_ws_client_frame(client_id, &frame_payload)
             .await;
@@ -606,7 +606,7 @@ mod tests {
             payloads,
             client_id,
         };
-        let frame_payload = serde_json::to_vec(&batch).unwrap();
+        let frame_payload = batch.encode_payload().unwrap();
         let result = state
             .process_ws_client_frame(client_id, &frame_payload)
             .await;

--- a/crates/jazz-tools/src/server/routes/websocket.rs
+++ b/crates/jazz-tools/src/server/routes/websocket.rs
@@ -471,7 +471,7 @@ async fn handle_ws_connection(
                 } else {
                     crate::jazz_transport::ServerEvent::SyncUpdateBatch { updates }
                 };
-                let bytes = match serde_json::to_vec(&event) {
+                let bytes = match event.encode_payload() {
                     Ok(b) => b,
                     Err(_) => continue,
                 };
@@ -487,7 +487,7 @@ async fn handle_ws_connection(
             }
             _ = heartbeat.tick() => {
                 let event = crate::jazz_transport::ServerEvent::Heartbeat;
-                let Ok(bytes) = serde_json::to_vec(&event) else { continue };
+                let Ok(bytes) = event.encode_payload() else { continue };
                 if socket
                     .send(Message::Binary(
                         crate::transport_manager::frame_encode(&bytes),

--- a/crates/jazz-tools/src/server/routes/websocket.rs
+++ b/crates/jazz-tools/src/server/routes/websocket.rs
@@ -19,6 +19,8 @@ use crate::sync_manager::ClientId;
 
 use super::utils::connection_schema_diagnostics_from_handshake;
 
+const MAX_WS_SYNC_UPDATES_PER_FRAME: usize = 256;
+
 pub(super) async fn ws_handler(
     ws: WebSocketUpgrade,
     State(state): State<Arc<ServerState>>,
@@ -445,12 +447,12 @@ async fn handle_ws_connection(
             },
             update = sync_rx.recv() => {
                 let Some(u) = update else { break };
-                let mut updates = Vec::with_capacity(256);
+                let mut updates = Vec::with_capacity(MAX_WS_SYNC_UPDATES_PER_FRAME);
                 updates.push(crate::jazz_transport::SequencedSyncPayload {
                     seq: Some(u.seq),
                     payload: u.payload,
                 });
-                while updates.len() < 256 {
+                while updates.len() < MAX_WS_SYNC_UPDATES_PER_FRAME {
                     match sync_rx.try_recv() {
                         Ok(u) => updates.push(crate::jazz_transport::SequencedSyncPayload {
                             seq: Some(u.seq),

--- a/crates/jazz-tools/src/storage/mod.rs
+++ b/crates/jazz-tools/src/storage/mod.rs
@@ -508,6 +508,9 @@ pub(crate) struct PreparedRowWriteContext {
 
 type RowRawTableIdCache = HashMap<(RowRawTableKind, String, SchemaHash), RowRawTableId>;
 type CatalogueUserDescriptorCache = HashMap<(usize, String, SchemaHash), Arc<RowDescriptor>>;
+type BranchSchemaHashCache = HashMap<(usize, String), Vec<SchemaHash>>;
+type TableCatalogueDescriptorCache =
+    HashMap<(usize, String), Vec<(SchemaHash, crate::query_manager::types::RowDescriptor)>>;
 
 fn row_raw_table_id_cache() -> &'static Mutex<RowRawTableIdCache> {
     static CACHE: OnceLock<Mutex<RowRawTableIdCache>> = OnceLock::new();
@@ -621,6 +624,32 @@ fn cache_row_descriptor(raw_table: &str, descriptor: Arc<RowDescriptor>) {
 fn catalogue_user_descriptor_cache() -> &'static Mutex<CatalogueUserDescriptorCache> {
     static CACHE: OnceLock<Mutex<CatalogueUserDescriptorCache>> = OnceLock::new();
     CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn branch_schema_hash_cache() -> &'static Mutex<BranchSchemaHashCache> {
+    static CACHE: OnceLock<Mutex<BranchSchemaHashCache>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn table_catalogue_descriptor_cache() -> &'static Mutex<TableCatalogueDescriptorCache> {
+    static CACHE: OnceLock<Mutex<TableCatalogueDescriptorCache>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+pub(crate) fn invalidate_catalogue_lookup_caches_with_storage<H: Storage + ?Sized>(storage: &H) {
+    let namespace = storage.storage_cache_namespace();
+    catalogue_user_descriptor_cache()
+        .lock()
+        .expect("catalogue user descriptor cache poisoned")
+        .retain(|(cached_namespace, _, _), _| *cached_namespace != namespace);
+    branch_schema_hash_cache()
+        .lock()
+        .expect("branch schema hash cache poisoned")
+        .retain(|(cached_namespace, _), _| *cached_namespace != namespace);
+    table_catalogue_descriptor_cache()
+        .lock()
+        .expect("table catalogue descriptor cache poisoned")
+        .retain(|(cached_namespace, _), _| *cached_namespace != namespace);
 }
 
 fn cached_catalogue_user_descriptor_with_storage<H: Storage + ?Sized>(
@@ -1648,14 +1677,15 @@ fn load_history_user_descriptor_for_schema_hash<H: Storage + ?Sized>(
     let Some(entry) = storage.load_catalogue_entry(schema_hash.to_object_id())? else {
         return Ok(None);
     };
-    let schema = crate::schema_manager::encoding::decode_schema(&entry.content)
-        .map_err(|err| StorageError::IoError(format!("decode schema for row history: {err}")))?;
-
-    let hinted_table_name = crate::query_manager::types::TableName::new(table_hint);
-    let Some(table_schema) = schema.get(&hinted_table_name) else {
+    let Some(descriptor) = crate::schema_manager::encoding::decode_table_descriptor_from_schema(
+        &entry.content,
+        table_hint,
+    )
+    .map_err(|err| StorageError::IoError(format!("decode schema for row history: {err}")))?
+    else {
         return Ok(None);
     };
-    let descriptor = Arc::new(table_schema.columns.clone());
+    let descriptor = Arc::new(descriptor);
     cache_catalogue_user_descriptor_with_storage(
         storage,
         table_hint,
@@ -1683,8 +1713,23 @@ fn schema_hashes_matching_branch<H: Storage + ?Sized>(
     storage: &H,
     branch: &str,
 ) -> Result<Vec<SchemaHash>, StorageError> {
+    let cache_key = (storage.storage_cache_namespace(), branch.to_string());
+    if let Some(cached) = branch_schema_hash_cache()
+        .lock()
+        .expect("branch schema hash cache poisoned")
+        .get(&cache_key)
+        .cloned()
+    {
+        return Ok(cached);
+    }
+
     let Some(composed) = ComposedBranchName::parse(&BranchName::new(branch)) else {
-        return Ok(Vec::new());
+        let hashes = Vec::new();
+        branch_schema_hash_cache()
+            .lock()
+            .expect("branch schema hash cache poisoned")
+            .insert(cache_key, hashes.clone());
+        return Ok(hashes);
     };
 
     let mut hashes = storage
@@ -1695,6 +1740,10 @@ fn schema_hashes_matching_branch<H: Storage + ?Sized>(
         .collect::<Vec<_>>();
     hashes.sort_by_key(|schema_hash| schema_hash.to_string());
     hashes.dedup();
+    branch_schema_hash_cache()
+        .lock()
+        .expect("branch schema hash cache poisoned")
+        .insert(cache_key, hashes.clone());
     Ok(hashes)
 }
 
@@ -1702,6 +1751,16 @@ fn catalogue_row_descriptors_for_table<H: Storage + ?Sized>(
     storage: &H,
     table_hint: &str,
 ) -> Result<Vec<(SchemaHash, crate::query_manager::types::RowDescriptor)>, StorageError> {
+    let cache_key = (storage.storage_cache_namespace(), table_hint.to_string());
+    if let Some(cached) = table_catalogue_descriptor_cache()
+        .lock()
+        .expect("table catalogue descriptor cache poisoned")
+        .get(&cache_key)
+        .cloned()
+    {
+        return Ok(cached);
+    }
+
     let table_name = crate::query_manager::types::TableName::new(table_hint);
     let mut candidates = Vec::new();
 
@@ -1718,6 +1777,10 @@ fn catalogue_row_descriptors_for_table<H: Storage + ?Sized>(
 
     candidates.sort_by_key(|(schema_hash, _)| schema_hash.to_string());
     candidates.dedup_by(|(left_hash, _), (right_hash, _)| left_hash == right_hash);
+    table_catalogue_descriptor_cache()
+        .lock()
+        .expect("table catalogue descriptor cache poisoned")
+        .insert(cache_key, candidates.clone());
     Ok(candidates)
 }
 

--- a/crates/jazz-tools/src/storage/storage_trait.rs
+++ b/crates/jazz-tools/src/storage/storage_trait.rs
@@ -357,6 +357,7 @@ pub trait Storage {
         let bytes = entry
             .encode_storage_row()
             .map_err(|err| StorageError::IoError(format!("encode catalogue entry: {err}")))?;
+        invalidate_catalogue_lookup_caches_with_storage(self);
         self.raw_table_put(
             "catalogue",
             &key_codec::catalogue_entry_key(entry.object_id),

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -22,7 +22,7 @@ enum SealedBatchMode {
 }
 
 impl SyncManager {
-    fn queue_batch_durability_ack_to_server(
+    pub(super) fn queue_batch_durability_ack_to_server(
         &mut self,
         server_id: ServerId,
         tier: DurabilityTier,
@@ -34,6 +34,14 @@ impl SyncManager {
         }
 
         let is_transactional = matches!(row.state, RowState::VisibleTransactional);
+        if !self.sent_server_batch_fate_acks.insert((
+            server_id,
+            row.batch_id,
+            tier,
+            is_transactional,
+        )) {
+            return;
+        }
 
         for entry in self.outbox.iter_mut().rev() {
             if entry.destination != Destination::Server(server_id) {

--- a/crates/jazz-tools/src/sync_manager/mod.rs
+++ b/crates/jazz-tools/src/sync_manager/mod.rs
@@ -640,6 +640,10 @@ impl SyncManager {
         std::mem::take(&mut self.pending_query_subscriptions)
     }
 
+    pub fn has_pending_query_subscriptions(&self) -> bool {
+        !self.pending_query_subscriptions.is_empty()
+    }
+
     /// Re-queue pending query subscriptions that couldn't be processed yet.
     ///
     /// Called by QueryManager when schema isn't available for some subscriptions.

--- a/crates/jazz-tools/src/sync_manager/mod.rs
+++ b/crates/jazz-tools/src/sync_manager/mod.rs
@@ -99,6 +99,10 @@ pub struct SyncManager {
 
     /// Batch fates to send to clients after a full inbox batch has been processed.
     pub(super) pending_client_batch_fates: HashMap<ClientId, HashSet<BatchId>>,
+    /// Durability acknowledgements already sent to an upstream server during
+    /// this connection. A large replay can deliver many rows from the same
+    /// sealed batch across several ticks, so outbox-local dedupe is not enough.
+    pub(super) sent_server_batch_fate_acks: HashSet<(ServerId, BatchId, DurabilityTier, bool)>,
 }
 
 impl std::fmt::Debug for SyncManager {
@@ -243,6 +247,7 @@ impl SyncManager {
             pending_query_rejections: Vec::new(),
             pending_batch_fates: Vec::new(),
             pending_client_batch_fates: HashMap::new(),
+            sent_server_batch_fate_acks: HashSet::new(),
         }
     }
 
@@ -487,6 +492,8 @@ impl SyncManager {
         self.pending_servers.remove(&server_id);
         self.pending_server_query_subscriptions
             .retain(|(id, _)| *id != server_id);
+        self.sent_server_batch_fate_acks
+            .retain(|(id, ..)| *id != server_id);
         let mut removed_query_ids = HashSet::new();
         self.remote_query_scopes
             .retain(|(remote_server_id, query_id), _| {

--- a/crates/jazz-tools/src/sync_manager/tests/settlements.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/settlements.rs
@@ -94,6 +94,59 @@ fn initial_query_sync_prefers_authoritative_settlement_over_retained_client_loca
 }
 
 #[test]
+fn upstream_durability_ack_is_queued_once_per_replayed_batch() {
+    let mut sm = SyncManager::new();
+    let server_id = ServerId::new();
+    let batch_id = BatchId::new();
+    let row_a = row_with_batch_state(
+        visible_row(ObjectId::new(), "main", Vec::new(), 1_000, b"alice"),
+        batch_id,
+        crate::row_histories::RowState::VisibleDirect,
+        Some(DurabilityTier::Local),
+    );
+    let row_b = row_with_batch_state(
+        visible_row(ObjectId::new(), "main", Vec::new(), 1_001, b"bob"),
+        batch_id,
+        crate::row_histories::RowState::VisibleDirect,
+        Some(DurabilityTier::Local),
+    );
+
+    sm.queue_batch_durability_ack_to_server(
+        server_id,
+        DurabilityTier::Local,
+        &row_a,
+        BranchName::new("main"),
+    );
+    sm.queue_batch_durability_ack_to_server(
+        server_id,
+        DurabilityTier::Local,
+        &row_b,
+        BranchName::new("main"),
+    );
+
+    let outbox = sm.take_outbox();
+    assert_eq!(
+        outbox
+            .iter()
+            .filter(|entry| matches!(
+                entry,
+                OutboxEntry {
+                    destination: Destination::Server(id),
+                    payload: SyncPayload::BatchFate {
+                        fate: BatchFate::DurableDirect {
+                            batch_id: id_batch,
+                            confirmed_tier: DurabilityTier::Local,
+                        },
+                    },
+                } if *id == server_id && *id_batch == batch_id
+            ))
+            .count(),
+        1,
+        "a replay can process many rows from the same batch across ticks, but the upstream durability ack is batch-scoped"
+    );
+}
+
+#[test]
 fn initial_query_sync_sends_only_current_row_for_deep_history() {
     let mut sm = SyncManager::new();
     let mut io = MemoryStorage::new();

--- a/crates/jazz-tools/src/transport_manager.rs
+++ b/crates/jazz-tools/src/transport_manager.rs
@@ -7,7 +7,7 @@ use crate::query_manager::types::SchemaHash;
 use crate::sync_manager::types::{ClientId, InboxEntry, OutboxEntry, ServerId, SyncPayload};
 use futures::channel::mpsc;
 
-pub const SYNC_PROTOCOL_VERSION: u32 = 2;
+pub const SYNC_PROTOCOL_VERSION: u32 = 3;
 const MAX_OUTBOUND_SYNC_PAYLOADS_PER_FRAME: usize = 256;
 
 pub trait TickNotifier: 'static {
@@ -512,16 +512,17 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
     fn encode_outbound_payload_batch(&self, payloads: Vec<SyncPayload>) -> Option<Vec<u8>> {
         if payloads.len() == 1 {
             let payload = payloads.into_iter().next()?;
-            serde_json::to_vec(&OutboxEntry {
+            crate::transport_protocol::encode_outbox_entry_payload(&OutboxEntry {
                 destination: crate::sync_manager::types::Destination::Server(self.server_id),
                 payload,
             })
             .ok()
         } else {
-            serde_json::to_vec(&crate::transport_protocol::SyncBatchRequest {
+            crate::transport_protocol::SyncBatchRequest {
                 payloads,
                 client_id: self.client_id,
-            })
+            }
+            .encode_payload()
             .ok()
         }
     }
@@ -586,9 +587,12 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
         }
 
         // Fall back: check whether the server sent an explicit Error event.
-        if let Ok(crate::transport_protocol::ServerEvent::Error { message, code }) =
-            serde_json::from_slice::<crate::transport_protocol::ServerEvent>(resp_payload)
-        {
+        let error_event = crate::transport_protocol::ServerEvent::decode_payload(resp_payload)
+            .ok()
+            .or_else(|| {
+                serde_json::from_slice::<crate::transport_protocol::ServerEvent>(resp_payload).ok()
+            });
+        if let Some(crate::transport_protocol::ServerEvent::Error { message, code }) = error_event {
             if code == crate::transport_protocol::ErrorCode::Unauthorized {
                 return HandshakeResult::AuthFailure(message);
             }
@@ -857,7 +861,7 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
                     match incoming {
                         Ok(Some(data)) => {
                             let Some(payload) = frame_decode(&data) else { continue; };
-                            let Ok(event) = serde_json::from_slice::<crate::transport_protocol::ServerEvent>(payload) else { continue; };
+                            let Ok(event) = crate::transport_protocol::ServerEvent::decode_payload(payload) else { continue; };
                             self.dispatch_server_event(event);
                         }
                         Ok(None) | Err(_) => return ConnectedExit::NetworkError,
@@ -1045,7 +1049,7 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
                     match incoming {
                         Ok(Some(data)) => {
                             let Some(payload) = frame_decode(&data) else { continue; };
-                            let Ok(event) = serde_json::from_slice::<crate::transport_protocol::ServerEvent>(payload) else { continue; };
+                            let Ok(event) = crate::transport_protocol::ServerEvent::decode_payload(payload) else { continue; };
                             self.dispatch_server_event(event);
                         }
                         Ok(None) | Err(_) => return WasmConnectedExit::NetworkError,

--- a/crates/jazz-tools/src/transport_manager.rs
+++ b/crates/jazz-tools/src/transport_manager.rs
@@ -33,6 +33,9 @@ pub enum TransportInbound {
         entry: Box<InboxEntry>,
         sequence: Option<u64>,
     },
+    SyncBatch {
+        entries: Vec<SequencedInboxEntry>,
+    },
     Disconnected,
     /// First connect/handshake attempt after `install_transport` failed before
     /// the handshake completed (DNS/TCP/TLS error, or handshake network error).
@@ -48,6 +51,12 @@ pub enum TransportInbound {
     AuthFailure {
         reason: String,
     },
+}
+
+#[derive(Debug)]
+pub struct SequencedInboxEntry {
+    pub entry: InboxEntry,
+    pub sequence: Option<u64>,
 }
 
 #[derive(Debug)]
@@ -608,9 +617,7 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
                 self.dispatch_sync_update(seq, *payload);
             }
             crate::transport_protocol::ServerEvent::SyncUpdateBatch { updates } => {
-                for update in updates {
-                    self.dispatch_sync_update(update.seq, update.payload);
-                }
+                self.dispatch_sync_update_batch(updates);
             }
             crate::transport_protocol::ServerEvent::Heartbeat => {}
             crate::transport_protocol::ServerEvent::Connected { .. } => {
@@ -628,12 +635,12 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
         }
     }
 
-    fn dispatch_sync_update(
-        &mut self,
+    fn trace_sync_payload(
+        &self,
         sequence: Option<u64>,
-        payload: crate::sync_manager::types::SyncPayload,
+        payload: &crate::sync_manager::types::SyncPayload,
     ) {
-        match &payload {
+        match payload {
             crate::sync_manager::types::SyncPayload::QuerySettled {
                 query_id,
                 tier,
@@ -667,6 +674,14 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
             }
             _ => {}
         }
+    }
+
+    fn dispatch_sync_update(
+        &mut self,
+        sequence: Option<u64>,
+        payload: crate::sync_manager::types::SyncPayload,
+    ) {
+        self.trace_sync_payload(sequence, &payload);
         let entry = InboxEntry {
             source: crate::sync_manager::types::Source::Server(self.server_id),
             payload,
@@ -675,6 +690,27 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
             entry: Box::new(entry),
             sequence,
         });
+        self.tick.notify();
+    }
+
+    fn dispatch_sync_update_batch(
+        &mut self,
+        updates: Vec<crate::transport_protocol::SequencedSyncPayload>,
+    ) {
+        let mut entries = Vec::with_capacity(updates.len());
+        for update in updates {
+            self.trace_sync_payload(update.seq, &update.payload);
+            entries.push(SequencedInboxEntry {
+                entry: InboxEntry {
+                    source: crate::sync_manager::types::Source::Server(self.server_id),
+                    payload: update.payload,
+                },
+                sequence: update.seq,
+            });
+        }
+        let _ = self
+            .inbound_tx
+            .unbounded_send(TransportInbound::SyncBatch { entries });
         self.tick.notify();
     }
 }

--- a/crates/jazz-tools/src/transport_manager.rs
+++ b/crates/jazz-tools/src/transport_manager.rs
@@ -8,6 +8,7 @@ use crate::sync_manager::types::{ClientId, InboxEntry, OutboxEntry, ServerId, Sy
 use futures::channel::mpsc;
 
 pub const SYNC_PROTOCOL_VERSION: u32 = 2;
+const MAX_OUTBOUND_SYNC_PAYLOADS_PER_FRAME: usize = 256;
 
 pub trait TickNotifier: 'static {
     fn notify(&self);
@@ -455,6 +456,76 @@ pub(crate) enum HandshakeResult {
 
 /// Handshake helpers shared between the Tokio and WASM run loops.
 impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, T> {
+    fn trace_outbound_payload(&self, payload: &SyncPayload) {
+        match payload {
+            crate::sync_manager::types::SyncPayload::QuerySubscription {
+                query_id,
+                query,
+                propagation,
+                ..
+            } => {
+                tracing::trace!(
+                    %self.server_id,
+                    query_id = query_id.0,
+                    table = %query.table,
+                    ?propagation,
+                    "jazz trace transport socket send query subscription"
+                );
+            }
+            crate::sync_manager::types::SyncPayload::QuerySettled {
+                query_id,
+                tier,
+                scope,
+                through_seq,
+            } => {
+                tracing::trace!(
+                    %self.server_id,
+                    query_id = query_id.0,
+                    ?tier,
+                    scope_len = scope.len(),
+                    through_seq,
+                    "jazz trace transport socket send query settled"
+                );
+            }
+            _ => {}
+        }
+    }
+
+    fn drain_outbound_payload_batch(&mut self, first: OutboxEntry) -> Vec<SyncPayload> {
+        self.trace_outbound_payload(&first.payload);
+        let mut payloads = Vec::with_capacity(MAX_OUTBOUND_SYNC_PAYLOADS_PER_FRAME);
+        payloads.push(first.payload);
+
+        while payloads.len() < MAX_OUTBOUND_SYNC_PAYLOADS_PER_FRAME {
+            match self.outbox_rx.try_recv() {
+                Ok(entry) => {
+                    self.trace_outbound_payload(&entry.payload);
+                    payloads.push(entry.payload);
+                }
+                Err(_) => break,
+            }
+        }
+
+        payloads
+    }
+
+    fn encode_outbound_payload_batch(&self, payloads: Vec<SyncPayload>) -> Option<Vec<u8>> {
+        if payloads.len() == 1 {
+            let payload = payloads.into_iter().next()?;
+            serde_json::to_vec(&OutboxEntry {
+                destination: crate::sync_manager::types::Destination::Server(self.server_id),
+                payload,
+            })
+            .ok()
+        } else {
+            serde_json::to_vec(&crate::transport_protocol::SyncBatchRequest {
+                payloads,
+                client_id: self.client_id,
+            })
+            .ok()
+        }
+    }
+
     /// Build the length-prefixed handshake frame from the current client identity, auth,
     /// and the latest catalogue + declared schema hashes known to the caller.
     fn build_handshake_frame(&self) -> Vec<u8> {
@@ -777,39 +848,8 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
                     // outbox closed = handle dropped; control_rx will also return None shortly.
                     // Route to Shutdown so the same clean-exit path is taken.
                     let Some(entry) = out else { return ConnectedExit::Shutdown; };
-                    match &entry.payload {
-                        crate::sync_manager::types::SyncPayload::QuerySubscription {
-                            query_id,
-                            query,
-                            propagation,
-                            ..
-                        } => {
-                            tracing::trace!(
-                                %self.server_id,
-                                query_id = query_id.0,
-                                table = %query.table,
-                                ?propagation,
-                                "jazz trace transport socket send query subscription"
-                            );
-                        }
-                        crate::sync_manager::types::SyncPayload::QuerySettled {
-                            query_id,
-                            tier,
-                            scope,
-                            through_seq,
-                        } => {
-                            tracing::trace!(
-                                %self.server_id,
-                                query_id = query_id.0,
-                                ?tier,
-                                scope_len = scope.len(),
-                                through_seq,
-                                "jazz trace transport socket send query settled"
-                            );
-                        }
-                        _ => {}
-                    }
-                    let Ok(bytes) = serde_json::to_vec(&entry) else { continue; };
+                    let payloads = self.drain_outbound_payload_batch(entry);
+                    let Some(bytes) = self.encode_outbound_payload_batch(payloads) else { continue; };
                     let frame = frame_encode(&bytes);
                     if ws.send(&frame).await.is_err() { return ConnectedExit::NetworkError; }
                 }
@@ -996,39 +1036,8 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
                     // outbox closed = handle dropped; control_rx will also return None shortly.
                     // Route to Shutdown so the same clean-exit path is taken.
                     let Some(entry) = out else { return WasmConnectedExit::Shutdown; };
-                    match &entry.payload {
-                        crate::sync_manager::types::SyncPayload::QuerySubscription {
-                            query_id,
-                            query,
-                            propagation,
-                            ..
-                        } => {
-                            tracing::trace!(
-                                %self.server_id,
-                                query_id = query_id.0,
-                                table = %query.table,
-                                ?propagation,
-                                "jazz trace transport socket send query subscription"
-                            );
-                        }
-                        crate::sync_manager::types::SyncPayload::QuerySettled {
-                            query_id,
-                            tier,
-                            scope,
-                            through_seq,
-                        } => {
-                            tracing::trace!(
-                                %self.server_id,
-                                query_id = query_id.0,
-                                ?tier,
-                                scope_len = scope.len(),
-                                through_seq,
-                                "jazz trace transport socket send query settled"
-                            );
-                        }
-                        _ => {}
-                    }
-                    let Ok(bytes) = serde_json::to_vec(&entry) else { continue; };
+                    let payloads = self.drain_outbound_payload_batch(entry);
+                    let Some(bytes) = self.encode_outbound_payload_batch(payloads) else { continue; };
                     let frame = frame_encode(&bytes);
                     if ws.send(&frame).await.is_err() { return WasmConnectedExit::NetworkError; }
                 }

--- a/crates/jazz-tools/src/transport_protocol.rs
+++ b/crates/jazz-tools/src/transport_protocol.rs
@@ -13,9 +13,12 @@
 //!
 //! # Wire Format
 //!
-//! Each frame: `[4 bytes: u32 big-endian length][N bytes: JSON]`
+//! Handshake frames are length-prefixed JSON so pre-versioned peers can report
+//! readable protocol errors. After both sides confirm `SYNC_PROTOCOL_VERSION`,
+//! sync transport frames are length-prefixed postcard payloads.
 
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use crate::sync_manager::{ClientId, QueryId, SyncPayload};
 
@@ -257,34 +260,382 @@ impl UnauthenticatedResponse {
 // Binary Frame Encoding/Decoding Helpers
 // ============================================================================
 
-impl ServerEvent {
-    /// Encode as a length-prefixed binary frame.
-    ///
-    /// Format: `[4 bytes: u32 big-endian length][N bytes: JSON]`
-    pub fn encode_frame(&self) -> Vec<u8> {
-        let json = serde_json::to_vec(self).unwrap_or_default();
-        let len = (json.len() as u32).to_be_bytes();
-        let mut buf = Vec::with_capacity(4 + json.len());
-        buf.extend_from_slice(&len);
-        buf.extend_from_slice(&json);
-        buf
+const SERVER_CONNECTED: u8 = 0;
+const SERVER_SUBSCRIBED: u8 = 1;
+const SERVER_SYNC_UPDATE: u8 = 2;
+const SERVER_SYNC_UPDATE_BATCH: u8 = 3;
+const SERVER_ERROR: u8 = 4;
+const SERVER_HEARTBEAT: u8 = 5;
+
+const CLIENT_OUTBOX_ENTRY: u8 = 1;
+const CLIENT_SYNC_BATCH_REQUEST: u8 = 2;
+
+#[derive(Debug, Clone)]
+pub enum DecodeError {
+    UnexpectedEof,
+    InvalidTag(u8),
+    InvalidUtf8,
+    InvalidUuid,
+    InvalidPayload,
+    TrailingBytes,
+    LengthOverflow,
+}
+
+impl std::fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl std::error::Error for DecodeError {}
+
+type DecodeResult<T> = Result<T, DecodeError>;
+
+struct WireReader<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> WireReader<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, pos: 0 }
     }
 
-    /// Decode a single frame from a buffer.
-    ///
-    /// Returns `Some((event, bytes_consumed))` if a complete frame was available,
-    /// or `None` if the buffer doesn't contain a complete frame yet.
-    pub fn decode_frame(buf: &[u8]) -> Option<(Self, usize)> {
-        if buf.len() < 4 {
-            return None;
+    fn read_exact(&mut self, len: usize) -> DecodeResult<&'a [u8]> {
+        let end = self
+            .pos
+            .checked_add(len)
+            .ok_or(DecodeError::LengthOverflow)?;
+        if end > self.bytes.len() {
+            return Err(DecodeError::UnexpectedEof);
         }
-        let len = u32::from_be_bytes(buf[..4].try_into().unwrap()) as usize;
-        if buf.len() < 4 + len {
-            return None;
-        }
-        let event: ServerEvent = serde_json::from_slice(&buf[4..4 + len]).ok()?;
-        Some((event, 4 + len))
+        let slice = &self.bytes[self.pos..end];
+        self.pos = end;
+        Ok(slice)
     }
+
+    fn read_u8(&mut self) -> DecodeResult<u8> {
+        Ok(self.read_exact(1)?[0])
+    }
+
+    fn read_u32(&mut self) -> DecodeResult<u32> {
+        Ok(u32::from_be_bytes(
+            self.read_exact(4)?.try_into().expect("fixed length"),
+        ))
+    }
+
+    fn read_u64(&mut self) -> DecodeResult<u64> {
+        Ok(u64::from_be_bytes(
+            self.read_exact(8)?.try_into().expect("fixed length"),
+        ))
+    }
+
+    fn read_string(&mut self) -> DecodeResult<String> {
+        let bytes = self.read_bytes()?;
+        std::str::from_utf8(bytes)
+            .map(str::to_owned)
+            .map_err(|_| DecodeError::InvalidUtf8)
+    }
+
+    fn read_bytes(&mut self) -> DecodeResult<&'a [u8]> {
+        let len = self.read_u32()? as usize;
+        self.read_exact(len)
+    }
+
+    fn read_uuid(&mut self) -> DecodeResult<Uuid> {
+        Uuid::from_slice(self.read_exact(16)?).map_err(|_| DecodeError::InvalidUuid)
+    }
+
+    fn read_option_u64(&mut self) -> DecodeResult<Option<u64>> {
+        match self.read_u8()? {
+            0 => Ok(None),
+            1 => Ok(Some(self.read_u64()?)),
+            tag => Err(DecodeError::InvalidTag(tag)),
+        }
+    }
+
+    fn read_option_string(&mut self) -> DecodeResult<Option<String>> {
+        match self.read_u8()? {
+            0 => Ok(None),
+            1 => Ok(Some(self.read_string()?)),
+            tag => Err(DecodeError::InvalidTag(tag)),
+        }
+    }
+
+    fn read_sync_payload(&mut self) -> DecodeResult<SyncPayload> {
+        SyncPayload::from_bytes(self.read_bytes()?).map_err(|_| DecodeError::InvalidPayload)
+    }
+
+    fn finish(self) -> DecodeResult<()> {
+        if self.pos == self.bytes.len() {
+            Ok(())
+        } else {
+            Err(DecodeError::TrailingBytes)
+        }
+    }
+}
+
+fn push_u8(out: &mut Vec<u8>, value: u8) {
+    out.push(value);
+}
+
+fn push_u32(out: &mut Vec<u8>, value: usize) -> Result<(), DecodeError> {
+    let value = u32::try_from(value).map_err(|_| DecodeError::LengthOverflow)?;
+    out.extend_from_slice(&value.to_be_bytes());
+    Ok(())
+}
+
+fn push_u64(out: &mut Vec<u8>, value: u64) {
+    out.extend_from_slice(&value.to_be_bytes());
+}
+
+fn push_string(out: &mut Vec<u8>, value: &str) -> Result<(), DecodeError> {
+    push_bytes(out, value.as_bytes())
+}
+
+fn push_bytes(out: &mut Vec<u8>, bytes: &[u8]) -> Result<(), DecodeError> {
+    push_u32(out, bytes.len())?;
+    out.extend_from_slice(bytes);
+    Ok(())
+}
+
+fn push_uuid(out: &mut Vec<u8>, uuid: Uuid) {
+    out.extend_from_slice(uuid.as_bytes());
+}
+
+fn push_option_u64(out: &mut Vec<u8>, value: Option<u64>) {
+    match value {
+        Some(value) => {
+            push_u8(out, 1);
+            push_u64(out, value);
+        }
+        None => push_u8(out, 0),
+    }
+}
+
+fn push_option_string(out: &mut Vec<u8>, value: Option<&str>) -> Result<(), DecodeError> {
+    match value {
+        Some(value) => {
+            push_u8(out, 1);
+            push_string(out, value)
+        }
+        None => {
+            push_u8(out, 0);
+            Ok(())
+        }
+    }
+}
+
+fn push_sync_payload(out: &mut Vec<u8>, payload: &SyncPayload) -> Result<(), DecodeError> {
+    let bytes = payload
+        .to_bytes()
+        .map_err(|_| DecodeError::InvalidPayload)?;
+    push_bytes(out, &bytes)
+}
+
+fn encode_error_code(code: ErrorCode) -> u8 {
+    match code {
+        ErrorCode::BadRequest => 0,
+        ErrorCode::IncompatibleProtocol => 1,
+        ErrorCode::Unauthorized => 2,
+        ErrorCode::Forbidden => 3,
+        ErrorCode::NotFound => 4,
+        ErrorCode::Internal => 5,
+        ErrorCode::RateLimited => 6,
+    }
+}
+
+fn decode_error_code(tag: u8) -> DecodeResult<ErrorCode> {
+    match tag {
+        0 => Ok(ErrorCode::BadRequest),
+        1 => Ok(ErrorCode::IncompatibleProtocol),
+        2 => Ok(ErrorCode::Unauthorized),
+        3 => Ok(ErrorCode::Forbidden),
+        4 => Ok(ErrorCode::NotFound),
+        5 => Ok(ErrorCode::Internal),
+        6 => Ok(ErrorCode::RateLimited),
+        tag => Err(DecodeError::InvalidTag(tag)),
+    }
+}
+
+impl ServerEvent {
+    /// Encode the post-handshake event payload as a compact binary envelope.
+    ///
+    /// The envelope mirrors the worker bridge: sync rows remain postcard
+    /// `SyncPayload` bytes, while transport metadata is a tiny explicit binary
+    /// header around those payload bytes.
+    pub fn encode_payload(&self) -> DecodeResult<Vec<u8>> {
+        let mut out = Vec::new();
+        match self {
+            ServerEvent::Connected {
+                connection_id,
+                client_id,
+                next_sync_seq,
+                catalogue_state_hash,
+            } => {
+                push_u8(&mut out, SERVER_CONNECTED);
+                push_u64(&mut out, connection_id.0);
+                push_string(&mut out, client_id)?;
+                push_option_u64(&mut out, *next_sync_seq);
+                push_option_string(&mut out, catalogue_state_hash.as_deref())?;
+            }
+            ServerEvent::Subscribed { query_id } => {
+                push_u8(&mut out, SERVER_SUBSCRIBED);
+                push_u64(&mut out, query_id.0);
+            }
+            ServerEvent::SyncUpdate { seq, payload } => {
+                push_u8(&mut out, SERVER_SYNC_UPDATE);
+                push_option_u64(&mut out, *seq);
+                push_sync_payload(&mut out, payload)?;
+            }
+            ServerEvent::SyncUpdateBatch { updates } => {
+                push_u8(&mut out, SERVER_SYNC_UPDATE_BATCH);
+                push_u32(&mut out, updates.len())?;
+                for update in updates {
+                    push_option_u64(&mut out, update.seq);
+                    push_sync_payload(&mut out, &update.payload)?;
+                }
+            }
+            ServerEvent::Error { message, code } => {
+                push_u8(&mut out, SERVER_ERROR);
+                push_u8(&mut out, encode_error_code(*code));
+                push_string(&mut out, message)?;
+            }
+            ServerEvent::Heartbeat => {
+                push_u8(&mut out, SERVER_HEARTBEAT);
+            }
+        }
+        Ok(out)
+    }
+
+    /// Decode a post-handshake event payload from the compact binary envelope.
+    pub fn decode_payload(bytes: &[u8]) -> DecodeResult<Self> {
+        let mut reader = WireReader::new(bytes);
+        let event = match reader.read_u8()? {
+            SERVER_CONNECTED => ServerEvent::Connected {
+                connection_id: ConnectionId(reader.read_u64()?),
+                client_id: reader.read_string()?,
+                next_sync_seq: reader.read_option_u64()?,
+                catalogue_state_hash: reader.read_option_string()?,
+            },
+            SERVER_SUBSCRIBED => ServerEvent::Subscribed {
+                query_id: QueryId(reader.read_u64()?),
+            },
+            SERVER_SYNC_UPDATE => ServerEvent::SyncUpdate {
+                seq: reader.read_option_u64()?,
+                payload: Box::new(reader.read_sync_payload()?),
+            },
+            SERVER_SYNC_UPDATE_BATCH => {
+                let len = reader.read_u32()? as usize;
+                let mut updates = Vec::with_capacity(len);
+                for _ in 0..len {
+                    updates.push(SequencedSyncPayload {
+                        seq: reader.read_option_u64()?,
+                        payload: reader.read_sync_payload()?,
+                    });
+                }
+                ServerEvent::SyncUpdateBatch { updates }
+            }
+            SERVER_ERROR => ServerEvent::Error {
+                code: decode_error_code(reader.read_u8()?)?,
+                message: reader.read_string()?,
+            },
+            SERVER_HEARTBEAT => ServerEvent::Heartbeat,
+            tag => return Err(DecodeError::InvalidTag(tag)),
+        };
+        reader.finish()?;
+        Ok(event)
+    }
+
+    /// Test/helper convenience: encode as a length-prefixed post-handshake frame.
+    pub fn encode_frame(&self) -> Vec<u8> {
+        crate::transport_manager::frame_encode(&self.encode_payload().unwrap_or_default())
+    }
+
+    /// Test/helper convenience: decode a length-prefixed post-handshake frame.
+    pub fn decode_frame(buf: &[u8]) -> Option<(Self, usize)> {
+        let payload = crate::transport_manager::frame_decode(buf)?;
+        let event = Self::decode_payload(payload).ok()?;
+        Some((event, 4 + payload.len()))
+    }
+}
+
+impl SyncBatchRequest {
+    pub fn encode_payload(&self) -> DecodeResult<Vec<u8>> {
+        let mut out = Vec::new();
+        push_u8(&mut out, CLIENT_SYNC_BATCH_REQUEST);
+        push_uuid(&mut out, self.client_id.0);
+        push_u32(&mut out, self.payloads.len())?;
+        for payload in &self.payloads {
+            push_sync_payload(&mut out, payload)?;
+        }
+        Ok(out)
+    }
+
+    pub fn decode_payload(bytes: &[u8]) -> DecodeResult<Self> {
+        let mut reader = WireReader::new(bytes);
+        match reader.read_u8()? {
+            CLIENT_SYNC_BATCH_REQUEST => {}
+            tag => return Err(DecodeError::InvalidTag(tag)),
+        }
+        let client_id = ClientId(reader.read_uuid()?);
+        let len = reader.read_u32()? as usize;
+        let mut payloads = Vec::with_capacity(len);
+        for _ in 0..len {
+            payloads.push(reader.read_sync_payload()?);
+        }
+        reader.finish()?;
+        Ok(Self {
+            client_id,
+            payloads,
+        })
+    }
+}
+
+impl SyncBatchResponse {
+    pub fn encode_payload(&self) -> DecodeResult<Vec<u8>> {
+        let mut out = Vec::new();
+        push_u32(&mut out, self.results.len())?;
+        for result in &self.results {
+            push_u8(&mut out, u8::from(result.ok));
+            push_option_string(&mut out, result.error.as_deref())?;
+        }
+        Ok(out)
+    }
+
+    pub fn decode_payload(bytes: &[u8]) -> DecodeResult<Self> {
+        let mut reader = WireReader::new(bytes);
+        let len = reader.read_u32()? as usize;
+        let mut results = Vec::with_capacity(len);
+        for _ in 0..len {
+            results.push(SyncPayloadResult {
+                ok: reader.read_u8()? != 0,
+                error: reader.read_option_string()?,
+            });
+        }
+        reader.finish()?;
+        Ok(Self { results })
+    }
+}
+
+pub fn encode_outbox_entry_payload(
+    entry: &crate::sync_manager::types::OutboxEntry,
+) -> DecodeResult<Vec<u8>> {
+    let mut out = Vec::new();
+    push_u8(&mut out, CLIENT_OUTBOX_ENTRY);
+    push_sync_payload(&mut out, &entry.payload)?;
+    Ok(out)
+}
+
+pub fn decode_outbox_entry_payload(bytes: &[u8]) -> DecodeResult<SyncPayload> {
+    let mut reader = WireReader::new(bytes);
+    match reader.read_u8()? {
+        CLIENT_OUTBOX_ENTRY => {}
+        tag => return Err(DecodeError::InvalidTag(tag)),
+    }
+    let payload = reader.read_sync_payload()?;
+    reader.finish()?;
+    Ok(payload)
 }
 
 #[cfg(test)]
@@ -352,7 +703,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sync_batch_request_serialization() {
+    fn test_sync_batch_request_postcard_roundtrip() {
         use crate::metadata::RowProvenance;
         use crate::object::ObjectId;
         use crate::row_histories::{RowState, StoredRowBatch};
@@ -377,12 +728,10 @@ mod tests {
             client_id: ClientId::new(),
         };
 
-        let json = serde_json::to_string(&request).unwrap();
-        assert!(json.contains("payloads"));
-        assert!(json.contains("RowBatchCreated"));
-        assert!(json.contains("main"));
+        let bytes = request.encode_payload().unwrap();
+        assert!(bytes.len() < 512);
 
-        let parsed: SyncBatchRequest = serde_json::from_str(&json).unwrap();
+        let parsed = SyncBatchRequest::decode_payload(&bytes).unwrap();
         assert_eq!(parsed.payloads.len(), 1);
         assert!(matches!(
             parsed.payloads[0],
@@ -391,7 +740,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sync_batch_response_serialization() {
+    fn test_sync_batch_response_postcard_roundtrip() {
         let response = SyncBatchResponse {
             results: vec![
                 SyncPayloadResult {
@@ -404,12 +753,10 @@ mod tests {
                 },
             ],
         };
-        let json = serde_json::to_string(&response).unwrap();
-        assert!(json.contains("results"));
-        assert!(json.contains("\"ok\":true"));
-        assert!(json.contains("bad payload"));
-
-        // ok:true entries must not include the error field
-        assert!(!json.contains("\"error\":null"));
+        let bytes = response.encode_payload().unwrap();
+        let decoded = SyncBatchResponse::decode_payload(&bytes).unwrap();
+        assert_eq!(decoded.results.len(), 2);
+        assert!(decoded.results[0].ok);
+        assert_eq!(decoded.results[1].error.as_deref(), Some("bad payload"));
     }
 }

--- a/crates/jazz-tools/tests/auth_test.rs
+++ b/crates/jazz-tools/tests/auth_test.rs
@@ -153,7 +153,9 @@ async fn ws_send_sync_payload(ws: &mut WsStream, payload: SyncPayload) -> Result
         client_id: ClientId::new(),
         payloads: vec![payload],
     };
-    let bytes = serde_json::to_vec(&batch).expect("serialize SyncBatchRequest");
+    let bytes = batch
+        .encode_payload()
+        .expect("encode SyncBatchRequest payload");
     ws.send(Message::Binary(frame_encode(&bytes).into()))
         .await
         .map_err(|e| format!("ws send sync payload failed: {e}"))
@@ -171,7 +173,8 @@ async fn ws_recv_server_event(
     match message {
         Some(Ok(Message::Binary(bytes))) => {
             let inner = frame_decode(&bytes).ok_or("malformed response frame")?;
-            serde_json::from_slice(inner).map_err(|e| format!("invalid server event: {e}"))
+            jazz_tools::transport_protocol::ServerEvent::decode_payload(inner)
+                .map_err(|e| format!("invalid server event: {e}"))
         }
         Some(Ok(Message::Close(_))) | None => Err("server closed connection".to_string()),
         Some(Ok(other)) => Err(format!("unexpected WS message: {other:?}")),

--- a/crates/jazz-tools/tests/policies_integration/authorship_policies.rs
+++ b/crates/jazz-tools/tests/policies_integration/authorship_policies.rs
@@ -101,7 +101,9 @@ async fn create_note_with_backend_attribution(
         payloads,
         client_id,
     };
-    let frame_payload = serde_json::to_vec(&batch).expect("serialize SyncBatchRequest");
+    let frame_payload = batch
+        .encode_payload()
+        .expect("encode SyncBatchRequest payload");
     let state = server.server_state();
     // Ensure the client is registered as a backend client before processing.
     state

--- a/crates/jazz-tools/tests/support/mod.rs
+++ b/crates/jazz-tools/tests/support/mod.rs
@@ -9,6 +9,7 @@ use jazz_tools::schema_manager::{AppId, Lens, SchemaManager};
 use jazz_tools::server::{ServerState, TestingServer};
 use jazz_tools::storage::MemoryStorage;
 use jazz_tools::sync_manager::{ClientId, Destination, OutboxEntry, ServerId, SyncManager};
+use jazz_tools::transport_protocol::encode_outbox_entry_payload;
 use jazz_tools::{
     AppContext, ClientStorage, DurabilityTier, JazzClient, ObjectId, OrderedRowDelta, Query,
     QueryBuilder, Schema, SubscriptionStream, Value,
@@ -343,11 +344,20 @@ fn build_catalogue_runtime(
             let push_errors = push_errors.clone();
             let in_flight_pushes = in_flight_pushes.clone();
             tokio::spawn(async move {
-                let frame = serde_json::to_vec(&jazz_tools::sync_manager::OutboxEntry {
+                let entry = jazz_tools::sync_manager::OutboxEntry {
                     destination: Destination::Server(ServerId::default()),
                     payload,
-                })
-                .expect("serialize OutboxEntry");
+                };
+                let frame = match encode_outbox_entry_payload(&entry) {
+                    Ok(frame) => frame,
+                    Err(error) => {
+                        if let Ok(mut errors) = push_errors.lock() {
+                            errors.push(format!("encode sync frame: {error}"));
+                        }
+                        in_flight_pushes.fetch_sub(1, Ordering::AcqRel);
+                        return;
+                    }
+                };
                 if let Err(error) = state.process_ws_client_frame(client_id, &frame).await {
                     if let Ok(mut errors) = push_errors.lock() {
                         errors.push(error);


### PR DESCRIPTION
## Summary

Stack PR 3 of the Jazz load-performance split. This slice changes post-handshake sync transport from JSON messages to postcard-encoded binary frames and adds the replay batching needed to move larger sync payloads efficiently.

The logical sync protocol stays the same; the transport representation after handshake becomes binary bytes instead of JSON objects.

## What changed

- Sends sync payloads as postcard-encoded binary websocket frames after the handshake.
- Adds support for larger/coalesced sync payload batches and replay acknowledgement flow.
- Threads inbound sync batches through `RuntimeCore`, `runtime_tokio`, server routing, and websocket handling.
- Preserves inbound sync batches across the runtime boundary instead of repeatedly expanding/repacking them.
- Yields initial query replay before very large scopes monopolize a tick.
- Optimizes schema/branch decoding used by replay-heavy transport paths.
- Adds settlement replay coverage for one-settlement-per-batch behavior after inbox batching.

## Review notes

- Tests and helpers were updated to use the same binary frame path as production after the websocket handshake, including route tests, auth websocket helpers, catalogue sync support, and authorship policy tests.

## Validation

- `cargo test -p jazz-tools --lib --features test ws_sync_batch`
- `cargo test -p jazz-tools --test auth_test structural_schema --features test`
- `cargo test -p jazz-tools --test catalogue_sync_integration --features test`
- `cargo test -p jazz-tools --test integration --test auth_test --test catalogue_sync_integration --features test`
- GitHub CI passed: `lint`, `test-rust`, `test-ts`, Vercel docs, and Vercel inspector.
