### PR TITLE
Stack 04: Optimize row storage hot paths

### DIFF
--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -452,7 +452,7 @@ pub struct QueryManager {
     /// Visible rows observed through normal row visibility processing, keyed by
     /// batch. Batch fate processing uses this to mark affected query rows
     /// without rescanning and decoding every subscribed visible region.
-    pub(super) visible_rows_by_batch: HashMap<BatchId, Vec<(String, ObjectId)>>,
+    pub(super) visible_rows_by_batch: HashMap<BatchId, HashSet<(String, ObjectId)>>,
 
     /// Currently queued SyncManager batch fates whose query effects have
     /// already been applied by this manager.
@@ -1166,11 +1166,9 @@ impl QueryManager {
                 .unwrap_or_default();
             if let Ok(Some(record)) = storage.load_local_batch_record(batch_id) {
                 for member in record.members {
-                    rows.push((member.table_name, member.object_id));
+                    rows.insert((member.table_name, member.object_id));
                 }
             }
-            rows.sort();
-            rows.dedup();
             marked_row_count += rows.len();
             for (table_name, object_id) in rows {
                 self.mark_local_row_updated_in_subscriptions(table_name.as_str(), object_id);
@@ -1680,9 +1678,7 @@ impl QueryManager {
             && previous_row.state.is_visible()
             && let Some(rows) = self.visible_rows_by_batch.get_mut(&previous_row.batch_id)
         {
-            rows.retain(|(table, row_id)| {
-                table.as_str() != logical_table.as_str() || *row_id != update.object_id
-            });
+            rows.remove(&(logical_table.clone(), update.object_id));
             if rows.is_empty() {
                 self.visible_rows_by_batch.remove(&previous_row.batch_id);
             }
@@ -1692,10 +1688,7 @@ impl QueryManager {
                 .visible_rows_by_batch
                 .entry(current_batch_id)
                 .or_default();
-            let member = (logical_table.clone(), update.object_id);
-            if !rows.contains(&member) {
-                rows.push(member);
-            }
+            rows.insert((logical_table.clone(), update.object_id));
         }
 
         if local_update {

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -454,6 +454,13 @@ pub struct QueryManager {
     /// without rescanning and decoding every subscribed visible region.
     pub(super) visible_rows_by_batch: HashMap<BatchId, HashSet<(String, ObjectId)>>,
 
+    /// Authoritative batch fates loaded while settling subscriptions.
+    ///
+    /// A single replay can ask whether the same batch is transactional and
+    /// complete for every subscribed query. Keep that storage fact at manager
+    /// scope instead of reloading it once per subscription emission.
+    pub(super) authoritative_batch_fate_cache: HashMap<BatchId, Option<BatchFate>>,
+
     /// Currently queued SyncManager batch fates whose query effects have
     /// already been applied by this manager.
     ///
@@ -566,6 +573,7 @@ impl QueryManager {
             pending_row_visibility_changes: Vec::new(),
             pending_local_row_batches: HashMap::new(),
             visible_rows_by_batch: HashMap::new(),
+            authoritative_batch_fate_cache: HashMap::new(),
             applied_pending_batch_fates: Vec::new(),
             known_schemas: Arc::new(HashMap::new()),
             pending_catalogue_schema_hashes: HashSet::new(),
@@ -1158,6 +1166,13 @@ impl QueryManager {
         let unique_batch_count = batch_ids.len();
         let mut marked_row_count = 0usize;
         for batch_id in batch_ids {
+            self.authoritative_batch_fate_cache.insert(
+                batch_id,
+                storage
+                    .load_authoritative_batch_fate(batch_id)
+                    .ok()
+                    .flatten(),
+            );
             self.mark_subscriptions_visibility_recompute_for_batch(batch_id);
             let mut rows = self
                 .visible_rows_by_batch
@@ -2650,29 +2665,42 @@ impl QueryManager {
             .collect()
     }
 
-    fn transactional_batch_complete_for_query_scope(
+    fn authoritative_batch_fate_cached(
+        &mut self,
         storage: &dyn Storage,
-        settlement_cache: &mut HashMap<BatchId, Option<BatchFate>>,
+        batch_id: BatchId,
+    ) -> Option<BatchFate> {
+        if let Some(settlement) = self.authoritative_batch_fate_cache.get(&batch_id) {
+            return settlement.clone();
+        }
+
+        let settlement = match storage.load_authoritative_batch_fate(batch_id) {
+            Ok(settlement) => settlement,
+            Err(error) => {
+                tracing::warn!(?batch_id, %error, "failed to load authoritative batch settlement");
+                None
+            }
+        };
+        self.authoritative_batch_fate_cache
+            .insert(batch_id, settlement.clone());
+        settlement
+    }
+
+    fn transactional_batch_complete_for_query_scope(
+        &mut self,
+        storage: &dyn Storage,
         batch_id: BatchId,
         local_scope: &HashSet<(ObjectId, BranchName)>,
         query_scope: &HashSet<(ObjectId, BranchName)>,
     ) -> bool {
-        let settlement = settlement_cache
-            .entry(batch_id)
-            .or_insert_with(|| match storage.load_authoritative_batch_fate(batch_id) {
-                Ok(settlement) => settlement,
-                Err(error) => {
-                    tracing::warn!(?batch_id, %error, "failed to load authoritative batch settlement");
-                    None
-                }
-            });
+        let settlement = self.authoritative_batch_fate_cached(storage, batch_id);
 
         !matches!(settlement, Some(BatchFate::AcceptedTransaction { .. }))
             || query_scope.is_subset(local_scope)
     }
 
     fn filter_transaction_visible_tuples<'a>(
-        &self,
+        &mut self,
         storage: &dyn Storage,
         query_id: QueryId,
         tuples: Cow<'a, [Tuple]>,
@@ -2685,14 +2713,12 @@ impl QueryManager {
         let mut query_scope = local_scope.clone();
         query_scope.extend(self.sync_manager.remote_query_scope(query_id));
 
-        let mut settlement_cache: HashMap<BatchId, Option<BatchFate>> = HashMap::new();
         let mut first_hidden = None;
 
         for (index, tuple) in tuples.as_ref().iter().enumerate() {
             let is_visible = tuple.batch_provenance().iter().copied().all(|batch_id| {
-                Self::transactional_batch_complete_for_query_scope(
+                self.transactional_batch_complete_for_query_scope(
                     storage,
-                    &mut settlement_cache,
                     batch_id,
                     &local_scope,
                     &query_scope,
@@ -2712,9 +2738,8 @@ impl QueryManager {
         filtered.extend_from_slice(&tuples.as_ref()[..first_hidden]);
         for tuple in &tuples.as_ref()[first_hidden + 1..] {
             if tuple.batch_provenance().iter().copied().all(|batch_id| {
-                Self::transactional_batch_complete_for_query_scope(
+                self.transactional_batch_complete_for_query_scope(
                     storage,
-                    &mut settlement_cache,
                     batch_id,
                     &local_scope,
                     &query_scope,

--- a/crates/jazz-tools/src/row_format.rs
+++ b/crates/jazz-tools/src/row_format.rs
@@ -187,9 +187,19 @@ pub fn encode_row(descriptor: &RowDescriptor, values: &[Value]) -> Result<Vec<u8
         });
     }
 
-    let mut fixed_data = Vec::new();
-    let mut var_data = Vec::new();
-    let mut var_offsets: Vec<u32> = Vec::new();
+    let layout = compiled_row_layout(descriptor);
+    let offset_table_size = layout.variable_column_count.saturating_sub(1) * size_of::<u32>();
+    let estimated_var_data_len = descriptor
+        .columns
+        .iter()
+        .zip(values.iter())
+        .filter(|(col, _)| col.column_type.is_variable())
+        .map(|(col, val)| estimated_variable_value_len(col, val))
+        .sum::<usize>();
+
+    let mut fixed_data = Vec::with_capacity(layout.fixed_section_size);
+    let mut var_data = Vec::with_capacity(estimated_var_data_len);
+    let mut var_offsets: Vec<u32> = Vec::with_capacity(layout.variable_column_count);
 
     // Separate fixed and variable columns while maintaining order
     let mut var_columns: Vec<(usize, &ColumnDescriptor, &Value)> = Vec::new();
@@ -231,7 +241,9 @@ pub fn encode_row(descriptor: &RowDescriptor, values: &[Value]) -> Result<Vec<u8
     }
 
     // Build final binary: fixed_data + offset_table (skip first) + var_data
-    let mut result = fixed_data;
+    let mut result =
+        Vec::with_capacity(layout.fixed_section_size + offset_table_size + var_data.len());
+    result.extend(fixed_data);
 
     // Write offsets (skip first, as it's implicitly 0)
     for offset in var_offsets.iter().skip(1) {
@@ -241,6 +253,73 @@ pub fn encode_row(descriptor: &RowDescriptor, values: &[Value]) -> Result<Vec<u8
     result.extend(var_data);
 
     Ok(result)
+}
+
+fn estimated_variable_value_len(col: &ColumnDescriptor, val: &Value) -> usize {
+    let nullable_prefix = usize::from(col.nullable);
+    if val.is_null() {
+        return nullable_prefix;
+    }
+
+    nullable_prefix
+        + match val {
+            Value::Text(s) => s.len(),
+            Value::Bytea(bytes) => bytes.len(),
+            Value::Array(elements) => estimated_array_len(elements, &col.column_type),
+            Value::Row { id, values } => {
+                let id_len = 1 + id.map(|_| 16).unwrap_or(0);
+                if let ColumnType::Row { columns } = &col.column_type {
+                    id_len + estimated_row_len(columns, values)
+                } else {
+                    id_len
+                }
+            }
+            _ => 0,
+        }
+}
+
+fn estimated_row_len(descriptor: &RowDescriptor, values: &[Value]) -> usize {
+    let layout = compiled_row_layout(descriptor);
+    layout.fixed_section_size
+        + layout.variable_column_count.saturating_sub(1) * size_of::<u32>()
+        + descriptor
+            .columns
+            .iter()
+            .zip(values.iter())
+            .filter(|(col, _)| col.column_type.is_variable())
+            .map(|(col, val)| estimated_variable_value_len(col, val))
+            .sum::<usize>()
+}
+
+fn estimated_array_len(elements: &[Value], column_type: &ColumnType) -> usize {
+    let element_type = match column_type {
+        ColumnType::Array { element } => element.as_ref(),
+        _ => return 0,
+    };
+
+    let offsets_len = elements.len().saturating_sub(1) * size_of::<u32>();
+    let data_len = elements
+        .iter()
+        .map(|element| match (element, element_type) {
+            (Value::Text(value), ColumnType::Text)
+            | (Value::Text(value), ColumnType::Json { .. })
+            | (Value::Text(value), ColumnType::Enum { .. }) => value.len(),
+            (Value::Bytea(bytes), ColumnType::Bytea) => bytes.len(),
+            (Value::Array(_), ColumnType::Array { .. }) => {
+                let nested_col = ColumnDescriptor::new("", column_type.clone());
+                estimated_variable_value_len(&nested_col, element)
+            }
+            (
+                Value::Row { id, values },
+                ColumnType::Row {
+                    columns: descriptor,
+                },
+            ) => 1 + id.map(|_| 16).unwrap_or(0) + estimated_row_len(descriptor, values),
+            _ => element_type.fixed_size().unwrap_or(0),
+        })
+        .sum::<usize>();
+
+    size_of::<u32>() + offsets_len + data_len
 }
 
 fn value_matches_column_type(value: &Value, column_type: &ColumnType) -> bool {

--- a/crates/jazz-tools/src/row_format.rs
+++ b/crates/jazz-tools/src/row_format.rs
@@ -180,6 +180,15 @@ pub fn compiled_row_layout(descriptor: &RowDescriptor) -> Arc<CompiledRowLayout>
 ///   - Subsequent offsets are u32 values
 /// - Variable data follows offset table
 pub fn encode_row(descriptor: &RowDescriptor, values: &[Value]) -> Result<Vec<u8>, EncodingError> {
+    let layout = compiled_row_layout(descriptor);
+    encode_row_with_layout(descriptor, layout.as_ref(), values)
+}
+
+pub(crate) fn encode_row_with_layout(
+    descriptor: &RowDescriptor,
+    layout: &CompiledRowLayout,
+    values: &[Value],
+) -> Result<Vec<u8>, EncodingError> {
     if values.len() != descriptor.columns.len() {
         return Err(EncodingError::ColumnCountMismatch {
             expected: descriptor.columns.len(),
@@ -187,7 +196,6 @@ pub fn encode_row(descriptor: &RowDescriptor, values: &[Value]) -> Result<Vec<u8
         });
     }
 
-    let layout = compiled_row_layout(descriptor);
     let offset_table_size = layout.variable_column_count.saturating_sub(1) * size_of::<u32>();
     let estimated_var_data_len = descriptor
         .columns

--- a/crates/jazz-tools/src/row_histories/codecs.rs
+++ b/crates/jazz-tools/src/row_histories/codecs.rs
@@ -12,7 +12,7 @@ use crate::object::ObjectId;
 use crate::query_manager::types::{ColumnDescriptor, ColumnType, RowBytes, RowDescriptor, Value};
 use crate::row_format::{
     CompiledRowLayout, EncodingError, column_bytes_with_layout, column_is_null_with_layout,
-    compiled_row_layout, decode_row, encode_row, project_row_with_layout,
+    compiled_row_layout, decode_row, encode_row_with_layout, project_row_with_layout,
 };
 use crate::sync_manager::DurabilityTier;
 
@@ -346,7 +346,11 @@ pub fn encode_flat_history_row(
     let mut values = history_row_system_values(row);
     values.extend(flat_user_values(user_descriptor, &row.data)?);
 
-    encode_row(codecs.history_descriptor.as_ref(), &values)
+    encode_row_with_layout(
+        codecs.history_descriptor.as_ref(),
+        codecs.history_layout.as_ref(),
+        &values,
+    )
 }
 
 /// Decode a flat physical row back into the current `StoredRowBatch` shape.
@@ -368,7 +372,11 @@ pub fn encode_flat_visible_row_entry(
     let codecs = flat_row_codecs(user_descriptor);
     let mut values = visible_row_system_values(entry);
     values.extend(flat_user_values(user_descriptor, &entry.current_row.data)?);
-    encode_row(codecs.visible_descriptor.as_ref(), &values)
+    encode_row_with_layout(
+        codecs.visible_descriptor.as_ref(),
+        codecs.visible_layout.as_ref(),
+        &values,
+    )
 }
 
 pub fn decode_flat_visible_row_entry(

--- a/crates/jazz-tools/src/storage/memory.rs
+++ b/crates/jazz-tools/src/storage/memory.rs
@@ -44,6 +44,7 @@ pub struct MemoryStorage {
     cache_namespace: usize,
     /// Ordered raw-table storage.
     raw_tables: HashMap<String, RawTableEntries>,
+    authoritative_batch_fates: std::cell::RefCell<HashMap<BatchId, BatchFate>>,
     /// Raw table headers already validated/inserted in this storage instance.
     ensured_raw_table_headers: HashSet<String>,
     /// Decoded row locators keyed by logical row id.
@@ -79,6 +80,7 @@ impl Default for MemoryStorage {
         Self {
             cache_namespace: next_storage_cache_namespace(),
             raw_tables: HashMap::new(),
+            authoritative_batch_fates: std::cell::RefCell::new(HashMap::new()),
             ensured_raw_table_headers: HashSet::new(),
             row_locators: HashMap::new(),
             row_histories: HashMap::new(),
@@ -365,6 +367,67 @@ impl Storage for MemoryStorage {
             .get(table)
             .and_then(|rows| rows.get(key))
             .cloned())
+    }
+
+    fn upsert_authoritative_batch_fate(
+        &mut self,
+        settlement: &BatchFate,
+    ) -> Result<(), StorageError> {
+        let settlement = self
+            .authoritative_batch_fates
+            .borrow()
+            .get(&settlement.batch_id())
+            .map(|existing| existing.merged_with(settlement))
+            .unwrap_or_else(|| settlement.clone());
+        ensure_raw_table_header(
+            self,
+            AUTHORITATIVE_BATCH_SETTLEMENT_TABLE,
+            &RawTableHeader::system(
+                STORAGE_KIND_AUTHORITATIVE_BATCH_SETTLEMENT,
+                AUTHORITATIVE_BATCH_SETTLEMENT_FORMAT_V2,
+            ),
+        )?;
+        let bytes = settlement.encode_storage_row().map_err(|err| {
+            StorageError::IoError(format!("encode authoritative batch settlement: {err}"))
+        })?;
+        self.raw_table_put(
+            AUTHORITATIVE_BATCH_SETTLEMENT_TABLE,
+            &local_batch_record_key(settlement.batch_id()),
+            &bytes,
+        )?;
+        self.authoritative_batch_fates
+            .borrow_mut()
+            .insert(settlement.batch_id(), settlement);
+        Ok(())
+    }
+
+    fn load_authoritative_batch_fate(
+        &self,
+        batch_id: BatchId,
+    ) -> Result<Option<BatchFate>, StorageError> {
+        if let Some(settlement) = self.authoritative_batch_fates.borrow().get(&batch_id) {
+            return Ok(Some(settlement.clone()));
+        }
+        let Some(bytes) = self.raw_table_get(
+            AUTHORITATIVE_BATCH_SETTLEMENT_TABLE,
+            &local_batch_record_key(batch_id),
+        )?
+        else {
+            return Ok(None);
+        };
+        ensure_system_raw_table_header_validated_once(
+            self,
+            AUTHORITATIVE_BATCH_SETTLEMENT_TABLE,
+            STORAGE_KIND_AUTHORITATIVE_BATCH_SETTLEMENT,
+            AUTHORITATIVE_BATCH_SETTLEMENT_FORMAT_V2,
+        )?;
+        let settlement = BatchFate::decode_storage_row(&bytes).map_err(|err| {
+            StorageError::IoError(format!("decode authoritative batch settlement: {err}"))
+        })?;
+        self.authoritative_batch_fates
+            .borrow_mut()
+            .insert(batch_id, settlement.clone());
+        Ok(Some(settlement))
     }
 
     fn raw_table_scan_prefix(

--- a/crates/jazz-tools/src/storage/mod.rs
+++ b/crates/jazz-tools/src/storage/mod.rs
@@ -805,7 +805,16 @@ fn history_row_batch_table_locator_key(
 }
 
 fn local_batch_record_key(batch_id: BatchId) -> String {
-    format!("batch:{}", hex::encode(batch_id.as_bytes()))
+    const PREFIX: &str = "batch:";
+    const HEX_DIGITS: &[u8; 16] = b"0123456789abcdef";
+
+    let mut key = String::with_capacity(PREFIX.len() + batch_id.as_bytes().len() * 2);
+    key.push_str(PREFIX);
+    for &byte in batch_id.as_bytes() {
+        key.push(HEX_DIGITS[(byte >> 4) as usize] as char);
+        key.push(HEX_DIGITS[(byte & 0x0f) as usize] as char);
+    }
+    key
 }
 
 fn decode_local_batch_record_key(key: &str) -> Result<BatchId, StorageError> {

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -86,8 +86,9 @@ impl SyncManager {
         });
     }
 
-    fn retain_client_batch_fate<H: Storage>(&mut self, storage: &mut H, fate: &BatchFate) {
-        let _ = storage.upsert_authoritative_batch_fate(fate);
+    fn retain_client_batch_fate<H: Storage>(&mut self, storage: &mut H, fate: &BatchFate) -> bool {
+        self.persist_authoritative_batch_fate(storage, fate)
+            .unwrap_or(false)
     }
 
     fn validate_sealed_batch_submission(
@@ -201,9 +202,17 @@ impl SyncManager {
         &self,
         storage: &mut H,
         fate: &BatchFate,
-    ) -> Result<(), crate::storage::StorageError> {
+    ) -> Result<bool, crate::storage::StorageError> {
+        let previous = storage.load_authoritative_batch_fate(fate.batch_id())?;
+        let merged = match previous.as_ref() {
+            Some(existing) => existing.merged_with(fate),
+            None => fate.clone(),
+        };
+        if previous.as_ref() == Some(&merged) {
+            return Ok(false);
+        }
         storage
-            .upsert_authoritative_batch_fate(fate)
+            .upsert_authoritative_batch_fate(&merged)
             .map_err(|error| {
                 tracing::trace!(
                     batch_id = ?fate.batch_id(),
@@ -211,7 +220,8 @@ impl SyncManager {
                     "failed to persist authoritative batch fate"
                 );
                 error
-            })
+            })?;
+        Ok(true)
     }
 
     fn persist_sealed_batch_submission<H: Storage>(
@@ -377,10 +387,10 @@ impl SyncManager {
                     unreachable!("row.state.is_visible() guarded non-visible states")
                 }
             };
-            if self
-                .persist_authoritative_batch_fate(storage, &fate)
-                .is_ok()
-            {
+            if matches!(
+                self.persist_authoritative_batch_fate(storage, &fate),
+                Ok(true)
+            ) {
                 self.pending_batch_fates.push(fate.clone());
             }
         }
@@ -667,13 +677,11 @@ impl SyncManager {
         fate: BatchFate,
         batch_rows: &[(String, StoredRowBatch)],
     ) {
-        if self
-            .persist_authoritative_batch_fate(storage, &fate)
-            .is_err()
-        {
-            return;
+        match self.persist_authoritative_batch_fate(storage, &fate) {
+            Ok(true) => self.pending_batch_fates.push(fate.clone()),
+            Ok(false) => {}
+            Err(_) => return,
         }
-        self.pending_batch_fates.push(fate.clone());
         if let Err(error) = storage.delete_sealed_batch_submission(fate.batch_id()) {
             tracing::warn!(
                 batch_id = ?fate.batch_id(),
@@ -722,11 +730,12 @@ impl SyncManager {
                     batch_id,
                     confirmed_tier,
                 };
-                if self
-                    .persist_authoritative_batch_fate(storage, &fate)
-                    .is_err()
-                {
-                    return;
+                let changed = match self.persist_authoritative_batch_fate(storage, &fate) {
+                    Ok(changed) => changed,
+                    Err(_) => return,
+                };
+                if changed {
+                    self.pending_batch_fates.push(fate.clone());
                 }
                 fate
             }
@@ -748,11 +757,12 @@ impl SyncManager {
                             confirmed_tier,
                         },
                     };
-                    if self
-                        .persist_authoritative_batch_fate(storage, &fate)
-                        .is_err()
-                    {
-                        return;
+                    let changed = match self.persist_authoritative_batch_fate(storage, &fate) {
+                        Ok(changed) => changed,
+                        Err(_) => return,
+                    };
+                    if changed {
+                        self.pending_batch_fates.push(fate.clone());
                     }
                     fate
                 }
@@ -763,11 +773,10 @@ impl SyncManager {
             }
         };
 
-        if !matches!(fate, BatchFate::Missing { .. }) {
-            self.pending_batch_fates.push(fate.clone());
-            if let Err(error) = storage.delete_sealed_batch_submission(batch_id) {
-                tracing::warn!(?batch_id, %error, "failed to delete sealed batch submission");
-            }
+        if !matches!(fate, BatchFate::Missing { .. })
+            && let Err(error) = storage.delete_sealed_batch_submission(batch_id)
+        {
+            tracing::warn!(?batch_id, %error, "failed to delete sealed batch submission");
         }
         if matches!(fate, BatchFate::DurableDirect { .. }) {
             let mut interested_clients = self.interested_clients_for_batch_fate(storage, &fate);
@@ -1052,13 +1061,13 @@ impl SyncManager {
                 }
             }
             SyncPayload::BatchFate { fate } => {
-                if self
-                    .persist_authoritative_batch_fate(storage, &fate)
-                    .is_err()
-                {
-                    return;
+                let changed = match self.persist_authoritative_batch_fate(storage, &fate) {
+                    Ok(changed) => changed,
+                    Err(_) => return,
+                };
+                if changed {
+                    self.pending_batch_fates.push(fate.clone());
                 }
-                self.pending_batch_fates.push(fate.clone());
                 if let BatchFate::AcceptedTransaction { batch_id, .. } = fate {
                     let rows = self.known_transactional_batch_rows_for_fate(storage, batch_id);
                     self.apply_transactional_batch_fate_to_rows(storage, None, &fate, &rows);
@@ -1440,8 +1449,9 @@ impl SyncManager {
                     });
             }
             SyncPayload::BatchFate { fate } => {
-                self.retain_client_batch_fate(storage, fate);
-                self.pending_batch_fates.push(fate.clone());
+                if self.retain_client_batch_fate(storage, fate) {
+                    self.pending_batch_fates.push(fate.clone());
+                }
             }
             SyncPayload::BatchFateNeeded { batch_ids } => {
                 self.respond_to_batch_fate_request(
@@ -1589,8 +1599,9 @@ impl SyncManager {
                 );
             }
             SyncPayload::BatchFate { fate } => {
-                self.retain_client_batch_fate(storage, &fate);
-                self.pending_batch_fates.push(fate.clone());
+                if self.retain_client_batch_fate(storage, &fate) {
+                    self.pending_batch_fates.push(fate.clone());
+                }
             }
             SyncPayload::BatchFateNeeded { batch_ids } => {
                 self.respond_to_batch_fate_request(

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -87,8 +87,7 @@ impl SyncManager {
     }
 
     fn retain_client_batch_fate<H: Storage>(&mut self, storage: &mut H, fate: &BatchFate) -> bool {
-        self.persist_authoritative_batch_fate(storage, fate)
-            .unwrap_or(false)
+        self.persist_authoritative_batch_fate(storage, fate).is_ok()
     }
 
     fn validate_sealed_batch_submission(
@@ -1061,12 +1060,9 @@ impl SyncManager {
                 }
             }
             SyncPayload::BatchFate { fate } => {
-                let changed = match self.persist_authoritative_batch_fate(storage, &fate) {
-                    Ok(changed) => changed,
+                match self.persist_authoritative_batch_fate(storage, &fate) {
+                    Ok(_) => self.pending_batch_fates.push(fate.clone()),
                     Err(_) => return,
-                };
-                if changed {
-                    self.pending_batch_fates.push(fate.clone());
                 }
                 if let BatchFate::AcceptedTransaction { batch_id, .. } = fate {
                     let rows = self.known_transactional_batch_rows_for_fate(storage, batch_id);

--- a/packages/jazz-tools/src/runtime/subscription-manager.ts
+++ b/packages/jazz-tools/src/runtime/subscription-manager.ts
@@ -69,8 +69,11 @@ export class SubscriptionManager<T extends { id: string }> {
     for (const change of delta) {
       switch (change.kind) {
         case RowChangeKind.Added:
+          const alreadyPresent = this.currentResults.has(change.id);
           this.currentResults.set(change.id, transform(change.row));
-          this.removeId(change.id);
+          if (alreadyPresent) {
+            this.removeId(change.id);
+          }
           this.insertIdAt(change.id, change.index);
           break;
         case RowChangeKind.Removed:


### PR DESCRIPTION
## Summary

Stack PR 4 of the Jazz load-performance split. This is the first low-level row/storage micro-optimization slice, focused on reducing allocation and redundant bookkeeping in replay and row encoding paths.

## What changed

- Avoids formatted batch record keys in hot storage paths.
- Pre-sizes row encoding buffers.
- Avoids redundant subscription id removal churn.
- Uses set-backed visible-row bookkeeping per batch.
- Reuses cached row layouts for flat row encoding.
- Caches authoritative batch fates during replay.
- Dedupes storage writes for unchanged authoritative batch fates while still notifying RuntimeCore waiters for received/replayed fate messages.

## Review notes

- The fate dedupe behavior is intentionally scoped to storage writes; client/server `BatchFate` messages still enqueue notifications so persisted write waiters resolve correctly.

## Validation

- `cargo test -p jazz-tools --lib runtime_core::tests::write_batch::persisted --features test`
- `cargo test -p jazz-tools --lib --features test`
- GitHub CI passed: `lint`, `test-rust`, `test-ts`, and Vercel docs. Inspector was pending at merge time under the authorized core-CI merge flow.
