### PR TITLE
Stack 05: Add selective table index metadata

### DIFF
--- a/crates/jazz-tools/src/query_manager/graph/compile.rs
+++ b/crates/jazz-tools/src/query_manager/graph/compile.rs
@@ -150,6 +150,25 @@ fn collect_magic_refs_from_disjuncts(
     refs
 }
 
+fn best_available_index_condition<'a>(
+    disjunct: &'a Conjunction,
+    table_schema: &crate::query_manager::types::TableSchema,
+) -> Option<&'a Condition> {
+    disjunct
+        .conditions
+        .iter()
+        .find(|condition| {
+            matches!(condition, Condition::Eq { .. })
+                && condition.is_index_scannable()
+                && table_schema.is_indexed_column(condition.column())
+        })
+        .or_else(|| {
+            disjunct.conditions.iter().find(|condition| {
+                condition.is_index_scannable() && table_schema.is_indexed_column(condition.column())
+            })
+        })
+}
+
 fn collect_magic_refs_from_project_columns(
     columns: Option<&[ProjectColumn]>,
 ) -> Vec<(Option<String>, MagicColumnKind)> {
@@ -576,7 +595,7 @@ impl QueryGraph {
             for disjunct in &plan.disjuncts {
                 // Find best index condition for this disjunct
                 let (scan_column, scan_condition) =
-                    if let Some(cond) = disjunct.best_index_condition() {
+                    if let Some(cond) = best_available_index_condition(disjunct, table_schema) {
                         let column = cond.column().to_string();
                         let scan_cond = condition_to_scan(cond);
                         (column, scan_cond)

--- a/crates/jazz-tools/src/query_manager/indices.rs
+++ b/crates/jazz-tools/src/query_manager/indices.rs
@@ -6,7 +6,7 @@ use crate::row_format::CompiledRowLayout;
 
 use super::encoding::decode_column;
 use super::manager::{QueryError, QueryManager};
-use super::types::{ColumnDescriptor, ColumnType, RowDescriptor, TableName, Value};
+use super::types::{ColumnDescriptor, ColumnName, ColumnType, RowDescriptor, TableName, Value};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct IndexUpdateError {
@@ -28,6 +28,13 @@ impl std::error::Error for IndexUpdateError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         Some(&self.source)
     }
+}
+
+pub(super) struct BranchIndexTarget<'a> {
+    pub table: &'a str,
+    pub branch: &'a str,
+    pub descriptor: &'a RowDescriptor,
+    pub indexed_columns: Option<&'a [ColumnName]>,
 }
 
 impl QueryManager {
@@ -87,13 +94,24 @@ impl QueryManager {
         branch: &str,
         values: &[Value],
         descriptor: &RowDescriptor,
+        indexed_columns: Option<&[ColumnName]>,
     ) -> Result<(), QueryError> {
         for (column, value) in descriptor.columns.iter().zip(values.iter()) {
+            if !Self::should_index_column(indexed_columns, column) {
+                continue;
+            }
             if *value != Value::Null {
                 Self::validate_column_index_values(table, column, branch, value)?;
             }
         }
         Ok(())
+    }
+
+    fn should_index_column(
+        indexed_columns: Option<&[ColumnName]>,
+        column: &ColumnDescriptor,
+    ) -> bool {
+        indexed_columns.is_none_or(|columns| columns.contains(&column.name))
     }
 
     fn push_insert_column_index_values<'a>(
@@ -140,10 +158,17 @@ impl QueryManager {
         object_id: ObjectId,
         data: &[u8],
         descriptor: &'a RowDescriptor,
+        indexed_columns: Option<&'a [ColumnName]>,
     ) -> Vec<IndexMutation<'a>> {
         let layout = crate::row_format::compiled_row_layout(descriptor);
         Self::index_mutations_for_insert_on_branch_with_layout(
-            table, branch, object_id, data, descriptor, &layout,
+            table,
+            branch,
+            object_id,
+            data,
+            descriptor,
+            indexed_columns,
+            &layout,
         )
     }
 
@@ -153,6 +178,7 @@ impl QueryManager {
         object_id: ObjectId,
         data: &[u8],
         descriptor: &'a RowDescriptor,
+        indexed_columns: Option<&'a [ColumnName]>,
         layout: &CompiledRowLayout,
     ) -> Vec<IndexMutation<'a>> {
         let mut mutations = vec![IndexMutation::Insert {
@@ -164,6 +190,9 @@ impl QueryManager {
         }];
 
         for (col_idx, col) in descriptor.columns.iter().enumerate() {
+            if !Self::should_index_column(indexed_columns, col) {
+                continue;
+            }
             if let Ok(value) =
                 crate::row_format::decode_column_with_layout(descriptor, layout, data, col_idx)
                 && value != Value::Null
@@ -189,10 +218,14 @@ impl QueryManager {
         old_data: &[u8],
         new_data: &[u8],
         descriptor: &'a RowDescriptor,
+        indexed_columns: Option<&'a [ColumnName]>,
     ) -> Vec<IndexMutation<'a>> {
         let mut mutations = Vec::new();
 
         for (col_idx, col) in descriptor.columns.iter().enumerate() {
+            if !Self::should_index_column(indexed_columns, col) {
+                continue;
+            }
             let Ok(old_value) = decode_column(descriptor, old_data, col_idx) else {
                 continue;
             };
@@ -235,6 +268,7 @@ impl QueryManager {
         object_id: ObjectId,
         old_data: &[u8],
         descriptor: &'a RowDescriptor,
+        indexed_columns: Option<&'a [ColumnName]>,
     ) -> Vec<IndexMutation<'a>> {
         let mut mutations = vec![IndexMutation::Remove {
             table,
@@ -245,6 +279,9 @@ impl QueryManager {
         }];
 
         for (col_idx, col) in descriptor.columns.iter().enumerate() {
+            if !Self::should_index_column(indexed_columns, col) {
+                continue;
+            }
             if let Ok(value) = decode_column(descriptor, old_data, col_idx)
                 && value != Value::Null
             {
@@ -276,6 +313,7 @@ impl QueryManager {
         object_id: ObjectId,
         old_data: Option<&[u8]>,
         descriptor: &'a RowDescriptor,
+        indexed_columns: Option<&'a [ColumnName]>,
     ) -> Vec<IndexMutation<'a>> {
         let mut mutations = vec![IndexMutation::Remove {
             table,
@@ -287,6 +325,9 @@ impl QueryManager {
 
         if let Some(data) = old_data {
             for (col_idx, col) in descriptor.columns.iter().enumerate() {
+                if !Self::should_index_column(indexed_columns, col) {
+                    continue;
+                }
                 if let Ok(value) = decode_column(descriptor, data, col_idx)
                     && value != Value::Null
                 {
@@ -319,6 +360,7 @@ impl QueryManager {
         object_id: ObjectId,
         new_data: &[u8],
         descriptor: &'a RowDescriptor,
+        indexed_columns: Option<&'a [ColumnName]>,
     ) -> Vec<IndexMutation<'a>> {
         let mut mutations = vec![
             IndexMutation::Remove {
@@ -338,6 +380,9 @@ impl QueryManager {
         ];
 
         for (col_idx, col) in descriptor.columns.iter().enumerate() {
+            if !Self::should_index_column(indexed_columns, col) {
+                continue;
+            }
             if let Ok(value) = decode_column(descriptor, new_data, col_idx)
                 && value != Value::Null
             {
@@ -363,9 +408,16 @@ impl QueryManager {
         object_id: ObjectId,
         data: &[u8],
         descriptor: &RowDescriptor,
+        indexed_columns: Option<&[ColumnName]>,
     ) -> Result<(), IndexUpdateError> {
-        let mutations =
-            Self::index_mutations_for_insert_on_branch(table, branch, object_id, data, descriptor);
+        let mutations = Self::index_mutations_for_insert_on_branch(
+            table,
+            branch,
+            object_id,
+            data,
+            descriptor,
+            indexed_columns,
+        );
         for mutation in &mutations {
             if let Err(error) = storage.apply_index_mutations(std::slice::from_ref(mutation)) {
                 let column = match mutation {
@@ -385,15 +437,19 @@ impl QueryManager {
     /// Update indices when a row is updated on a specific branch.
     pub(super) fn update_indices_for_update_on_branch(
         storage: &mut dyn Storage,
-        table: &str,
-        branch: &str,
+        target: BranchIndexTarget<'_>,
         object_id: ObjectId,
         old_data: &[u8],
         new_data: &[u8],
-        descriptor: &RowDescriptor,
     ) -> Result<(), QueryError> {
         let mutations = Self::index_mutations_for_update_on_branch(
-            table, branch, object_id, old_data, new_data, descriptor,
+            target.table,
+            target.branch,
+            object_id,
+            old_data,
+            new_data,
+            target.descriptor,
+            target.indexed_columns,
         );
         storage
             .apply_index_mutations(&mutations)
@@ -408,9 +464,15 @@ impl QueryManager {
         object_id: ObjectId,
         old_data: &[u8],
         descriptor: &RowDescriptor,
+        indexed_columns: Option<&[ColumnName]>,
     ) -> Result<(), QueryError> {
         let mutations = Self::index_mutations_for_soft_delete_on_branch(
-            table, branch, object_id, old_data, descriptor,
+            table,
+            branch,
+            object_id,
+            old_data,
+            descriptor,
+            indexed_columns,
         );
         storage
             .apply_index_mutations(&mutations)
@@ -425,9 +487,15 @@ impl QueryManager {
         object_id: ObjectId,
         old_data: Option<&[u8]>,
         descriptor: &RowDescriptor,
+        indexed_columns: Option<&[ColumnName]>,
     ) -> Result<(), QueryError> {
         let mutations = Self::index_mutations_for_hard_delete_on_branch(
-            table, branch, object_id, old_data, descriptor,
+            table,
+            branch,
+            object_id,
+            old_data,
+            descriptor,
+            indexed_columns,
         );
         storage
             .apply_index_mutations(&mutations)
@@ -442,9 +510,15 @@ impl QueryManager {
         object_id: ObjectId,
         new_data: &[u8],
         descriptor: &RowDescriptor,
+        indexed_columns: Option<&[ColumnName]>,
     ) -> Result<(), QueryError> {
         let mutations = Self::index_mutations_for_undelete_on_branch(
-            table, branch, object_id, new_data, descriptor,
+            table,
+            branch,
+            object_id,
+            new_data,
+            descriptor,
+            indexed_columns,
         );
         storage
             .apply_index_mutations(&mutations)
@@ -490,6 +564,7 @@ impl QueryManager {
             row_id,
             Some(row_data),
             &table_schema.columns,
+            table_schema.indexed_columns.as_deref(),
         ) {
             tracing::warn!(
                 table,
@@ -551,6 +626,7 @@ impl QueryManager {
                 row_id,
                 restored_data,
                 &table_schema.columns,
+                table_schema.indexed_columns.as_deref(),
             )
         {
             tracing::warn!(

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -28,8 +28,8 @@ use super::policy_graph::PolicyGraph;
 use super::query::Query;
 use super::session::Session;
 use super::types::{
-    ComposedBranchName, LoadedRow, OrderedRowDelta, Row, RowDelta, RowDescriptor, RowPolicyMode,
-    Schema, SchemaHash, TableName, TablePolicies, TableSchema, Tuple, Value,
+    ColumnName, ComposedBranchName, LoadedRow, OrderedRowDelta, Row, RowDelta, RowDescriptor,
+    RowPolicyMode, Schema, SchemaHash, TableName, TablePolicies, TableSchema, Tuple, Value,
     build_ordered_delta_with_post_ids,
 };
 
@@ -273,6 +273,7 @@ pub(super) struct PolicyCheckState {
 #[derive(Debug)]
 pub(super) struct WriteTableCacheEntry {
     pub(super) descriptor: Arc<RowDescriptor>,
+    pub(super) indexed_columns: Option<Arc<Vec<ColumnName>>>,
     pub(super) row_layout: Arc<crate::row_format::CompiledRowLayout>,
     pub(super) row_locator: RowLocator,
     pub(super) insert_policy: Option<Arc<PolicyExpr>>,
@@ -1736,6 +1737,7 @@ impl QueryManager {
                     update.object_id,
                     old_data,
                     &descriptor,
+                    table_schema.indexed_columns.as_deref(),
                 );
             }
             if local_update {
@@ -1761,6 +1763,7 @@ impl QueryManager {
                         update.object_id,
                         &old_row.data,
                         &descriptor,
+                        table_schema.indexed_columns.as_deref(),
                     );
                 } else {
                     let _ = storage.index_remove(
@@ -1808,6 +1811,7 @@ impl QueryManager {
                     update.object_id,
                     new_data,
                     &descriptor,
+                    table_schema.indexed_columns.as_deref(),
                 )
             {
                 tracing::error!(
@@ -1840,6 +1844,7 @@ impl QueryManager {
                     update.object_id,
                     new_data,
                     &descriptor,
+                    table_schema.indexed_columns.as_deref(),
                 )
             {
                 tracing::error!(
@@ -1855,12 +1860,15 @@ impl QueryManager {
             && apply_index_mutations
             && let Err(error) = Self::update_indices_for_update_on_branch(
                 storage,
-                &branch_table,
-                branch,
+                super::indices::BranchIndexTarget {
+                    table: &branch_table,
+                    branch,
+                    descriptor: &descriptor,
+                    indexed_columns: table_schema.indexed_columns.as_deref(),
+                },
                 update.object_id,
                 &old_row.data,
                 new_data,
-                &descriptor,
             )
         {
             tracing::error!(

--- a/crates/jazz-tools/src/query_manager/manager_tests/joins.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests/joins.rs
@@ -1422,6 +1422,7 @@ fn sync_backed_joined_exists_rel_session_subscription_keeps_local_rows_when_serv
         TableName::new("teams"),
         TableSchema {
             columns: RowDescriptor::new(vec![ColumnDescriptor::new("name", ColumnType::Text)]),
+            indexed_columns: None,
             policies: TablePolicies::new().with_select(PolicyExpr::ExistsRel {
                 rel: RelExpr::Filter {
                     input: Box::new(RelExpr::Join {

--- a/crates/jazz-tools/src/query_manager/manager_tests/policies.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests/policies.rs
@@ -419,6 +419,7 @@ fn e2e_permissions_prevent_sync() {
                 ColumnDescriptor::new("title", ColumnType::Text),
                 ColumnDescriptor::new("owner_id", ColumnType::Text), // Text to match user_id string
             ]),
+            indexed_columns: None,
             policies: TablePolicies::new()
                 .with_select(PolicyExpr::eq_session("owner_id", vec!["user_id".into()])),
         },
@@ -506,6 +507,7 @@ fn e2e_permissions_prevent_new_row_sync() {
                 ColumnDescriptor::new("title", ColumnType::Text),
                 ColumnDescriptor::new("owner_id", ColumnType::Text), // Text to match user_id string
             ]),
+            indexed_columns: None,
             policies: TablePolicies::new()
                 .with_select(PolicyExpr::eq_session("owner_id", vec!["user_id".into()])),
         },
@@ -606,6 +608,7 @@ fn sync_backed_session_subscription_keeps_local_rows_when_server_scope_is_empty(
                 ColumnDescriptor::new("title", ColumnType::Text),
                 ColumnDescriptor::new("owner_id", ColumnType::Text),
             ]),
+            indexed_columns: None,
             policies: TablePolicies::new()
                 .with_select(PolicyExpr::eq_session("owner_id", vec!["user_id".into()])),
         },
@@ -679,6 +682,7 @@ fn sync_backed_exists_rel_session_subscription_keeps_local_rows_when_server_scop
         TableName::new("teams"),
         TableSchema {
             columns: RowDescriptor::new(vec![ColumnDescriptor::new("name", ColumnType::Text)]),
+            indexed_columns: None,
             policies: TablePolicies::new().with_select(PolicyExpr::ExistsRel {
                 rel: RelExpr::Filter {
                     input: Box::new(RelExpr::TableScan {
@@ -784,6 +788,7 @@ fn sync_backed_local_tier_exists_rel_keeps_confirmed_local_rows_when_server_scop
         TableName::new("teams"),
         TableSchema {
             columns: RowDescriptor::new(vec![ColumnDescriptor::new("name", ColumnType::Text)]),
+            indexed_columns: None,
             policies: TablePolicies::new().with_select(PolicyExpr::ExistsRel {
                 rel: RelExpr::Filter {
                     input: Box::new(RelExpr::TableScan {
@@ -877,6 +882,7 @@ fn sync_backed_exists_session_subscription_keeps_local_rows_when_server_scope_is
         TableName::new("teams"),
         TableSchema {
             columns: RowDescriptor::new(vec![ColumnDescriptor::new("name", ColumnType::Text)]),
+            indexed_columns: None,
             policies: TablePolicies::new().with_select(PolicyExpr::Exists {
                 table: "user_team_edges".into(),
                 condition: Box::new(PolicyExpr::And(vec![
@@ -978,6 +984,7 @@ fn fail_closed_server_withholds_session_scope_before_permissions_head() {
         TableName::new("teams"),
         TableSchema {
             columns: RowDescriptor::new(vec![ColumnDescriptor::new("name", ColumnType::Text)]),
+            indexed_columns: None,
             policies: TablePolicies::new().with_select(PolicyExpr::ExistsRel {
                 rel: RelExpr::Filter {
                     input: Box::new(RelExpr::Join {
@@ -1106,6 +1113,7 @@ fn synced_session_query_for_exists_rel_sends_policy_context_tables_upstream() {
         TableName::new("teams"),
         TableSchema {
             columns: RowDescriptor::new(vec![ColumnDescriptor::new("name", ColumnType::Text)]),
+            indexed_columns: None,
             policies: TablePolicies::new().with_select(PolicyExpr::ExistsRel {
                 rel: RelExpr::Filter {
                     input: Box::new(RelExpr::Join {
@@ -1190,6 +1198,7 @@ fn backend_sync_subscription_without_handshake_session_stays_unscoped_without_pe
                 ColumnDescriptor::new("name", ColumnType::Text),
                 ColumnDescriptor::new("identity_key", ColumnType::Text).nullable(),
             ]),
+            indexed_columns: None,
             policies: TablePolicies::new().with_select(PolicyExpr::eq_session(
                 "identity_key",
                 vec!["user_id".into()],

--- a/crates/jazz-tools/src/query_manager/manager_tests/subscriptions.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests/subscriptions.rs
@@ -34,6 +34,66 @@ fn subscription_updates_after_insert_and_process() {
 }
 
 #[test]
+fn unindexed_where_predicate_falls_back_to_id_scan() {
+    let sync_manager = SyncManager::new();
+    let mut schema = Schema::new();
+    schema.insert(
+        TableName::new("users"),
+        TableSchema::builder("users")
+            .column("name", ColumnType::Text)
+            .column("score", ColumnType::Integer)
+            .index_only(["score"])
+            .build(),
+    );
+    let (mut qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    qm.insert(
+        &mut storage,
+        "users",
+        &[Value::Text("Alice".into()), Value::Integer(100)],
+    )
+    .unwrap();
+    qm.insert(
+        &mut storage,
+        "users",
+        &[Value::Text("Bob".into()), Value::Integer(100)],
+    )
+    .unwrap();
+    qm.process(&mut storage);
+    qm.take_updates();
+
+    assert!(
+        storage
+            .index_lookup(
+                "users",
+                "name",
+                qm.current_branch().as_str(),
+                &Value::Text("Alice".into())
+            )
+            .is_empty(),
+        "indexOnly should avoid maintaining an index for omitted columns"
+    );
+
+    let query = qm
+        .query("users")
+        .filter_eq("name", Value::Text("Alice".into()))
+        .build();
+    let sub_id = qm.subscribe(query).unwrap();
+    qm.process(&mut storage);
+
+    let updates = qm.take_updates();
+    assert_eq!(updates.len(), 1);
+    assert_eq!(updates[0].subscription_id, sub_id);
+    assert_eq!(updates[0].delta.added.len(), 1);
+    let values = decode_row(
+        &qm.schema[&TableName::new("users")].columns,
+        &updates[0].delta.added[0].data,
+    )
+    .unwrap();
+    assert_eq!(values[0], Value::Text("Alice".into()));
+}
+
+#[test]
 fn settled_clean_subscription_does_not_request_visibility_recompute_on_idle_process() {
     let sync_manager = SyncManager::new();
     let schema = test_schema();

--- a/crates/jazz-tools/src/query_manager/rebac_tests.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests.rs
@@ -543,6 +543,7 @@ fn seed_folder_on_branch(
         folder_id,
         &folder_content,
         folders_descriptor,
+        None,
     )
     .unwrap();
     qm.persist_row_region_tip(storage, "folders", folder_id, branch);

--- a/crates/jazz-tools/src/query_manager/rebac_tests/inherited_policies.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests/inherited_policies.rs
@@ -209,6 +209,7 @@ fn rebac_inherited_insert_uses_requested_branch_instead_of_reusing_cached_branch
         folder_id,
         &encode_folder("alice", "Dev Folder"),
         &folders_descriptor,
+        None,
     )
     .unwrap();
     seed_qm.persist_row_region_tip(&mut storage, "folders", folder_id, &branch);

--- a/crates/jazz-tools/src/query_manager/types/branch.rs
+++ b/crates/jazz-tools/src/query_manager/types/branch.rs
@@ -89,6 +89,20 @@ impl SchemaHash {
 
             // Hash row descriptor in declared column order
             hash_row_descriptor(&mut hasher, &table_schema.columns);
+
+            // Hash the optional index override. Absence means historical
+            // "index every declared user column"; an explicit subset changes
+            // query-planning/index-maintenance semantics and therefore belongs
+            // to the schema identity.
+            hasher.update(&[1]);
+            if let Some(indexed_columns) = &table_schema.indexed_columns {
+                let mut columns: Vec<_> = indexed_columns.iter().map(|c| c.as_str()).collect();
+                columns.sort_unstable();
+                for column in columns {
+                    hasher.update(column.as_bytes());
+                    hasher.update(&[0]);
+                }
+            }
         }
 
         Self(*hasher.finalize().as_bytes())

--- a/crates/jazz-tools/src/query_manager/types/schema.rs
+++ b/crates/jazz-tools/src/query_manager/types/schema.rs
@@ -380,6 +380,13 @@ impl RowDescriptor {
 pub struct TableSchema {
     /// Row structure definition.
     pub columns: RowDescriptor,
+    /// User columns that should have secondary indexes.
+    ///
+    /// `None` preserves historical behavior and indexes every declared user
+    /// column. `Some(columns)` opts into indexing only that explicit subset.
+    /// Internal `_id` and `_id_deleted` indexes are always maintained.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub indexed_columns: Option<Vec<ColumnName>>,
     /// Access control policies.
     #[serde(default, skip_serializing_if = "table_policies_are_default")]
     pub policies: TablePolicies,
@@ -396,18 +403,36 @@ impl TableSchema {
     pub fn new(columns: RowDescriptor) -> Self {
         Self {
             columns,
+            indexed_columns: None,
             policies: TablePolicies::default(),
         }
     }
 
     /// Create a table schema with policies.
     pub fn with_policies(columns: RowDescriptor, policies: TablePolicies) -> Self {
-        Self { columns, policies }
+        Self {
+            columns,
+            indexed_columns: None,
+            policies,
+        }
     }
 
     /// Start building a new table schema.
     pub fn builder(name: &str) -> TableSchemaBuilder {
         TableSchemaBuilder::new(name)
+    }
+
+    /// Return true when the given user column has a maintained secondary index.
+    ///
+    /// The implicit object-id indexes are always available and are handled here
+    /// too so query planning can use one predicate path.
+    pub fn is_indexed_column(&self, column: &str) -> bool {
+        if column == "_id" || column == "_id_deleted" {
+            return true;
+        }
+        self.indexed_columns
+            .as_ref()
+            .is_none_or(|columns| columns.iter().any(|name| name.as_str() == column))
     }
 }
 
@@ -422,6 +447,7 @@ impl From<RowDescriptor> for TableSchema {
 pub struct TableSchemaBuilder {
     name: String,
     columns: Vec<ColumnDescriptor>,
+    indexed_columns: Option<Vec<ColumnName>>,
     policies: TablePolicies,
 }
 
@@ -431,6 +457,7 @@ impl TableSchemaBuilder {
         Self {
             name: name.to_string(),
             columns: Vec::new(),
+            indexed_columns: None,
             policies: TablePolicies::default(),
         }
     }
@@ -483,6 +510,18 @@ impl TableSchemaBuilder {
         self
     }
 
+    /// Index only this explicit user-column subset.
+    ///
+    /// Internal `_id` and `_id_deleted` indexes are always maintained.
+    pub fn index_only<I, S>(mut self, columns: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<ColumnName>,
+    {
+        self.indexed_columns = Some(columns.into_iter().map(Into::into).collect());
+        self
+    }
+
     /// Get the table name.
     pub fn name(&self) -> &str {
         &self.name
@@ -492,6 +531,7 @@ impl TableSchemaBuilder {
     pub fn build(self) -> TableSchema {
         TableSchema {
             columns: RowDescriptor::new(self.columns),
+            indexed_columns: self.indexed_columns,
             policies: self.policies,
         }
     }
@@ -501,6 +541,7 @@ impl TableSchemaBuilder {
         let name = TableName::new(&self.name);
         let schema = TableSchema {
             columns: RowDescriptor::new(self.columns),
+            indexed_columns: self.indexed_columns,
             policies: self.policies,
         };
         (name, schema)

--- a/crates/jazz-tools/src/query_manager/writes.rs
+++ b/crates/jazz-tools/src/query_manager/writes.rs
@@ -25,7 +25,8 @@ use super::policy::{ComplexClause, Operation, evaluate_simple_parts_with_row_id}
 use super::server_queries::{AuthorizationPolicyRequest, RowTransformContext};
 use super::session::{AuthMode, Session, WriteContext};
 use super::types::{
-    ColumnType, ComposedBranchName, LoadedRow, RowDescriptor, Schema, SchemaHash, TableName, Value,
+    ColumnName, ColumnType, ComposedBranchName, LoadedRow, RowDescriptor, Schema, SchemaHash,
+    TableName, Value,
 };
 
 pub struct RowBranchWrite<'a> {
@@ -40,6 +41,7 @@ pub struct RowBranchWrite<'a> {
 struct PreparedUpdateWrite {
     new_data: Vec<u8>,
     descriptor: Arc<RowDescriptor>,
+    indexed_columns: Option<Arc<Vec<ColumnName>>>,
     row_layout: Arc<crate::row_format::CompiledRowLayout>,
 }
 
@@ -103,6 +105,7 @@ impl QueryManager {
             .ok_or(QueryError::TableNotFound(table_name))?;
         let entry = Arc::new(WriteTableCacheEntry {
             descriptor: Arc::new(table_schema.columns.clone()),
+            indexed_columns: table_schema.indexed_columns.clone().map(Arc::new),
             row_layout: compiled_row_layout(&table_schema.columns),
             row_locator: RowLocator {
                 table: table_name.as_str().to_string().into(),
@@ -701,7 +704,13 @@ impl QueryManager {
         }
 
         self.validate_json_for_values(descriptor, values)?;
-        Self::validate_write_index_values_on_branch(table, branch, values, descriptor)?;
+        Self::validate_write_index_values_on_branch(
+            table,
+            branch,
+            values,
+            descriptor,
+            table_write.indexed_columns.as_deref().map(Vec::as_slice),
+        )?;
 
         let new_data =
             encode_row(descriptor, values).map_err(|e| QueryError::EncodingError(e.to_string()))?;
@@ -831,6 +840,7 @@ impl QueryManager {
         Ok(PreparedUpdateWrite {
             new_data,
             descriptor: table_write.descriptor.clone(),
+            indexed_columns: table_write.indexed_columns.clone(),
             row_layout: table_write.row_layout.clone(),
         })
     }
@@ -1011,6 +1021,7 @@ impl QueryManager {
             self.current_branch().as_str(),
             values,
             descriptor,
+            table_write.indexed_columns.as_deref().map(Vec::as_slice),
         )?;
 
         // Encode to binary
@@ -1106,6 +1117,7 @@ impl QueryManager {
             object_id,
             &data,
             descriptor,
+            table_write.indexed_columns.as_deref().map(Vec::as_slice),
             &table_write.row_layout,
         );
         let row = self.authored_row_batch(
@@ -1225,7 +1237,13 @@ impl QueryManager {
         }
 
         self.validate_json_for_values(descriptor, values)?;
-        Self::validate_write_index_values_on_branch(table, branch, values, descriptor)?;
+        Self::validate_write_index_values_on_branch(
+            table,
+            branch,
+            values,
+            descriptor,
+            table_write.indexed_columns.as_deref().map(Vec::as_slice),
+        )?;
 
         // Encode to binary
         let data =
@@ -1310,6 +1328,7 @@ impl QueryManager {
             object_id,
             &data,
             descriptor,
+            table_write.indexed_columns.as_deref().map(Vec::as_slice),
             &table_write.row_layout,
         );
         let row = self.authored_row_batch(
@@ -1400,7 +1419,13 @@ impl QueryManager {
         }
 
         self.validate_json_for_values(descriptor, values)?;
-        Self::validate_write_index_values_on_branch(table, branch, values, descriptor)?;
+        Self::validate_write_index_values_on_branch(
+            table,
+            branch,
+            values,
+            descriptor,
+            table_write.indexed_columns.as_deref().map(Vec::as_slice),
+        )?;
 
         let data =
             encode_row(descriptor, values).map_err(|e| QueryError::EncodingError(e.to_string()))?;
@@ -1465,6 +1490,7 @@ impl QueryManager {
             object_id,
             &data,
             descriptor,
+            table_write.indexed_columns.as_deref().map(Vec::as_slice),
             &table_write.row_layout,
         );
         let row = self.authored_row_batch(
@@ -1887,12 +1913,32 @@ impl QueryManager {
 
         match &col.column_type {
             crate::query_manager::types::ColumnType::Uuid => {
-                let candidate_ids = storage.index_lookup(
-                    source_table_name.as_str(),
-                    col.name.as_str(),
-                    branch,
-                    &Value::Uuid(target_row_id),
-                );
+                let candidate_ids = if source_schema.is_indexed_column(col.name.as_str()) {
+                    storage.index_lookup(
+                        source_table_name.as_str(),
+                        col.name.as_str(),
+                        branch,
+                        &Value::Uuid(target_row_id),
+                    )
+                } else {
+                    storage
+                        .index_scan_all(source_table_name.as_str(), "_id", branch)
+                        .into_iter()
+                        .filter(|source_row_id| {
+                            let Some(source_content) =
+                                self.load_row_content_on_branch(storage, *source_row_id, branch)
+                            else {
+                                return false;
+                            };
+                            declared_edge_references_target(
+                                &source_descriptor,
+                                &source_content,
+                                col_idx,
+                                target_row_id,
+                            )
+                        })
+                        .collect()
+                };
                 for source_row_id in candidate_ids {
                     if self.evaluate_source_row_access_for_operation(
                         storage,
@@ -1912,8 +1958,15 @@ impl QueryManager {
             crate::query_manager::types::ColumnType::Array { element }
                 if **element == crate::query_manager::types::ColumnType::Uuid =>
             {
-                let candidate_ids =
-                    storage.index_scan_all(source_table_name.as_str(), col.name.as_str(), branch);
+                let candidate_ids = storage.index_scan_all(
+                    source_table_name.as_str(),
+                    if source_schema.is_indexed_column(col.name.as_str()) {
+                        col.name.as_str()
+                    } else {
+                        "_id"
+                    },
+                    branch,
+                );
                 for source_row_id in candidate_ids {
                     let Some(source_content) =
                         self.load_row_content_on_branch(storage, source_row_id, branch)
@@ -2122,6 +2175,7 @@ impl QueryManager {
             &old_data,
             &prepared.new_data,
             prepared.descriptor.as_ref(),
+            prepared.indexed_columns.as_deref().map(Vec::as_slice),
         );
         let batch_id = self.commit_prepared_update_write(
             storage,
@@ -2218,6 +2272,7 @@ impl QueryManager {
                 id,
                 &prepared.new_data,
                 prepared.descriptor.as_ref(),
+                prepared.indexed_columns.as_deref().map(Vec::as_slice),
             )
         } else if let Some(old_branch_data) = existing_branch_data.as_deref() {
             Self::index_mutations_for_update_on_branch(
@@ -2227,6 +2282,7 @@ impl QueryManager {
                 old_branch_data,
                 &prepared.new_data,
                 prepared.descriptor.as_ref(),
+                prepared.indexed_columns.as_deref().map(Vec::as_slice),
             )
         } else {
             Self::index_mutations_for_insert_on_branch_with_layout(
@@ -2235,6 +2291,7 @@ impl QueryManager {
                 id,
                 &prepared.new_data,
                 prepared.descriptor.as_ref(),
+                prepared.indexed_columns.as_deref().map(Vec::as_slice),
                 &prepared.row_layout,
             )
         };
@@ -2442,6 +2499,7 @@ impl QueryManager {
             id,
             &old_data,
             descriptor,
+            table_write.indexed_columns.as_deref().map(Vec::as_slice),
         );
         let branch_name = BranchName::new(branch.as_str());
         let (delete_batch_id, visibility_change) = self.apply_local_row_history_write(
@@ -2641,6 +2699,7 @@ impl QueryManager {
             id,
             old_data_for_policy,
             descriptor,
+            table_write.indexed_columns.as_deref().map(Vec::as_slice),
         );
         let branch_name = BranchName::new(branch);
         let (delete_batch_id, visibility_change) = self.apply_local_row_history_write(
@@ -2732,7 +2791,13 @@ impl QueryManager {
         }
 
         self.validate_json_for_values(descriptor, values)?;
-        Self::validate_write_index_values_on_branch(&table, &current_branch, values, descriptor)?;
+        Self::validate_write_index_values_on_branch(
+            &table,
+            &current_branch,
+            values,
+            descriptor,
+            table_write.indexed_columns.as_deref().map(Vec::as_slice),
+        )?;
 
         // Encode new row data
         let new_data =
@@ -2763,6 +2828,7 @@ impl QueryManager {
             id,
             &new_data,
             descriptor,
+            table_write.indexed_columns.as_deref().map(Vec::as_slice),
         );
         let branch_name = BranchName::new(branch.as_str());
         let (row_batch_id, visibility_change) = self.apply_local_row_history_write(
@@ -2863,6 +2929,7 @@ impl QueryManager {
             id,
             old_data.as_deref(),
             descriptor,
+            table_write.indexed_columns.as_deref().map(Vec::as_slice),
         );
         let branch_name = BranchName::new(branch.as_str());
         let (delete_batch_id, visibility_change) = self.apply_local_row_history_write(

--- a/crates/jazz-tools/src/schema_manager/encoding.rs
+++ b/crates/jazz-tools/src/schema_manager/encoding.rs
@@ -17,7 +17,7 @@ use crate::query_manager::types::{
 use super::lens::{LensOp, LensTransform};
 
 /// Current encoding version.
-const SCHEMA_VERSION: u8 = SchemaEncodingVersion::V5 as u8;
+const SCHEMA_VERSION: u8 = SchemaEncodingVersion::V6 as u8;
 const LENS_VERSION: u8 = 2;
 const PERMISSIONS_VERSION: u8 = 1;
 const PERMISSIONS_BUNDLE_VERSION: u8 = 2;
@@ -36,6 +36,8 @@ enum SchemaEncodingVersion {
     V4 = 4,
     // v5 schemas include column merge strategies.
     V5 = 5,
+    // v6 schemas include per-table indexed-column overrides.
+    V6 = 6,
 }
 
 impl SchemaEncodingVersion {
@@ -46,6 +48,7 @@ impl SchemaEncodingVersion {
             3 => Some(Self::V3),
             4 => Some(Self::V4),
             5 => Some(Self::V5),
+            6 => Some(Self::V6),
             _ => None,
         }
     }
@@ -59,11 +62,15 @@ impl SchemaEncodingVersion {
     }
 
     fn has_column_defaults(self) -> bool {
-        matches!(self, Self::V4 | Self::V5)
+        matches!(self, Self::V4 | Self::V5 | Self::V6)
     }
 
     fn has_column_merge_strategies(self) -> bool {
-        matches!(self, Self::V5)
+        matches!(self, Self::V5 | Self::V6)
+    }
+
+    fn has_indexed_columns(self) -> bool {
+        matches!(self, Self::V6)
     }
 }
 
@@ -121,7 +128,7 @@ impl std::error::Error for CatalogueEncodingError {}
 /// table is preserved exactly as declared.
 pub fn encode_schema(schema: &Schema) -> Vec<u8> {
     let mut buf = Vec::new();
-    let version = SchemaEncodingVersion::V5;
+    let version = SchemaEncodingVersion::V6;
     buf.push(version as u8);
 
     // Sort tables by name for deterministic ordering
@@ -188,6 +195,9 @@ pub fn decode_table_descriptor_from_schema(
         }
 
         skip_row_descriptor_with_version(data, &mut offset, version)?;
+        if version.has_indexed_columns() {
+            skip_indexed_columns(data, &mut offset)?;
+        }
         if version.has_table_policies() {
             decode_table_policies(data, &mut offset)?;
         }
@@ -204,6 +214,9 @@ fn encode_table_entry_with_version(
 ) {
     write_string(buf, name.as_str());
     encode_row_descriptor_with_version(buf, &schema.columns, version);
+    if version.has_indexed_columns() {
+        encode_indexed_columns(buf, schema.indexed_columns.as_deref());
+    }
     if version.has_table_policies() {
         encode_table_policies(buf, &schema.policies);
     }
@@ -216,6 +229,11 @@ fn decode_table_entry_with_version(
 ) -> Result<(TableName, TableSchema), CatalogueEncodingError> {
     let name = read_string(data, offset, "table_name")?;
     let descriptor = decode_row_descriptor_with_version(data, offset, version)?;
+    let indexed_columns = if version.has_indexed_columns() {
+        decode_indexed_columns(data, offset)?
+    } else {
+        None
+    };
     if version.has_table_policies() {
         // Legacy schema versions encoded policies inline, but structural schema
         // decode intentionally drops them now that permissions are catalogued
@@ -227,9 +245,57 @@ fn decode_table_entry_with_version(
         TableName::new(name),
         TableSchema {
             columns: descriptor,
+            indexed_columns,
             policies: TablePolicies::default(),
         },
     ))
+}
+
+fn encode_indexed_columns(buf: &mut Vec<u8>, indexed_columns: Option<&[ColumnName]>) {
+    match indexed_columns {
+        None => write_u32(buf, u32::MAX),
+        Some(columns) => {
+            write_u32(buf, columns.len() as u32);
+            let mut columns: Vec<_> = columns.iter().map(|column| column.as_str()).collect();
+            columns.sort_unstable();
+            for column in columns {
+                write_string(buf, column);
+            }
+        }
+    }
+}
+
+fn decode_indexed_columns(
+    data: &[u8],
+    offset: &mut usize,
+) -> Result<Option<Vec<ColumnName>>, CatalogueEncodingError> {
+    let count = read_u32(data, offset)?;
+    if count == u32::MAX {
+        return Ok(None);
+    }
+
+    let mut columns = Vec::with_capacity(count as usize);
+    for _ in 0..count {
+        columns.push(ColumnName::new(read_string(
+            data,
+            offset,
+            "indexed_column",
+        )?));
+    }
+    Ok(Some(columns))
+}
+
+fn skip_indexed_columns(data: &[u8], offset: &mut usize) -> Result<(), CatalogueEncodingError> {
+    let count = read_u32(data, offset)?;
+    if count == u32::MAX {
+        return Ok(());
+    }
+
+    for _ in 0..count {
+        let len = read_u32(data, offset)? as usize;
+        read_bytes(data, offset, len)?;
+    }
+    Ok(())
 }
 
 fn decode_schema_with_version(
@@ -892,6 +958,7 @@ fn decode_table_schema(
     let descriptor = decode_row_descriptor(data, offset)?;
     Ok(TableSchema {
         columns: descriptor,
+        indexed_columns: None,
         policies: TablePolicies::default(),
     })
 }
@@ -904,6 +971,7 @@ fn decode_table_schema_v1(
     decode_table_policies(data, offset)?;
     Ok(TableSchema {
         columns: descriptor,
+        indexed_columns: None,
         policies: TablePolicies::default(),
     })
 }
@@ -2090,6 +2158,57 @@ mod tests {
         let column = table.columns.column("value").expect("counter column");
 
         assert_eq!(column.merge_strategy, Some(ColumnMergeStrategy::Counter));
+    }
+
+    #[test]
+    fn schema_roundtrip_preserves_indexed_columns() {
+        let schema = SchemaBuilder::new()
+            .table(
+                TableSchema::builder("todos")
+                    .column("title", ColumnType::Text)
+                    .column("done", ColumnType::Boolean)
+                    .index_only(["done"]),
+            )
+            .build();
+
+        let encoded = encode_schema(&schema);
+        assert_eq!(encoded[0], SCHEMA_VERSION);
+
+        let decoded = decode_schema(&encoded).unwrap();
+        let todos = decoded
+            .get(&TableName::new("todos"))
+            .expect("decoded todos table");
+        assert_eq!(todos.indexed_columns, Some(vec![ColumnName::new("done")]));
+    }
+
+    #[test]
+    fn table_descriptor_lookup_skips_indexed_column_metadata() {
+        let schema = SchemaBuilder::new()
+            .table(
+                TableSchema::builder("a")
+                    .column("name", ColumnType::Text)
+                    .index_only(["name"]),
+            )
+            .table(
+                TableSchema::builder("b")
+                    .column("done", ColumnType::Boolean)
+                    .column("count", ColumnType::Integer),
+            )
+            .build();
+
+        let encoded = encode_schema(&schema);
+        let descriptor = decode_table_descriptor_from_schema(&encoded, "b")
+            .unwrap()
+            .expect("descriptor for b");
+
+        assert_eq!(
+            descriptor
+                .columns
+                .iter()
+                .map(|column| column.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["done", "count"]
+        );
     }
 
     #[test]

--- a/packages/jazz-tools/src/cli.test.ts
+++ b/packages/jazz-tools/src/cli.test.ts
@@ -164,6 +164,22 @@ export const app: s.App<AppSchema> = s.defineApp(schema);
 `;
 }
 
+function rootSchemaWithIndexedTodo(indexImportPath: string = indexPath): string {
+  return `
+import { schema as s } from ${JSON.stringify(indexImportPath)};
+
+const schema = {
+  todos: s.table({
+    title: s.string(),
+    ownerId: s.string(),
+  }).indexOnly(["ownerId"]),
+};
+
+type AppSchema = s.Schema<typeof schema>;
+export const app: s.App<AppSchema> = s.defineApp(schema);
+`;
+}
+
 function rootSchemaWithTodoNotes(indexImportPath: string = indexPath): string {
   return `
 import { schema as s } from ${JSON.stringify(indexImportPath)};
@@ -2292,6 +2308,70 @@ describe("cli deploy", () => {
 
     expect(permissionsPublishBody.schemaHash).toBe(schemaHash);
     expect(permissionsPublishBody.expectedParentBundleObjectId).toBe(currentHead.bundleObjectId);
+  });
+
+  it("publishes a new structural schema when only indexed columns changed", async () => {
+    const { root } = await createWorkspace();
+    await writeFile(join(root, "schema.ts"), rootSchemaWithIndexedTodo());
+    await writeFile(join(root, "permissions.ts"), rootPermissionsSchema());
+
+    const previousSchemaHash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const nextSchemaHash = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    let schemaPublishBody: any;
+
+    const fetchMock = vi.fn(async (input: string, init?: RequestInit) => {
+      if (input.endsWith(`/apps/${APP_ID}/schemas`)) {
+        return new Response(JSON.stringify({ hashes: [previousSchemaHash] }), { status: 200 });
+      }
+
+      if (input.endsWith(`/apps/${APP_ID}/schema/${previousSchemaHash}`)) {
+        return storedSchemaResponse({
+          todos: storedRootSchema().todos,
+        });
+      }
+
+      if (input.endsWith(`/apps/${APP_ID}/admin/schemas`)) {
+        schemaPublishBody = JSON.parse(String(init?.body));
+        return new Response(
+          JSON.stringify({
+            objectId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            hash: nextSchemaHash,
+          }),
+          { status: 201 },
+        );
+      }
+
+      if (input.endsWith(`/apps/${APP_ID}/admin/permissions/head`)) {
+        return new Response(JSON.stringify({ head: null }), { status: 200 });
+      }
+
+      if (input.endsWith(`/apps/${APP_ID}/admin/permissions`)) {
+        return new Response(
+          JSON.stringify({
+            head: {
+              schemaHash: nextSchemaHash,
+              version: 1,
+              parentBundleObjectId: null,
+              bundleObjectId: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            },
+          }),
+          { status: 201 },
+        );
+      }
+
+      throw new Error(`Unexpected fetch: ${input}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await deploy({
+      appId: APP_ID,
+      serverUrl: "http://localhost:1625",
+      adminSecret: "admin-secret",
+      schemaDir: root,
+      migrationsDir: join(root, "migrations"),
+    });
+
+    expect(schemaPublishBody.schema.todos.indexed_columns).toEqual(["ownerId"]);
   });
 
   it("fails when retargeting permissions to a schema with no local migration path from the previous head", async () => {

--- a/packages/jazz-tools/src/cli.ts
+++ b/packages/jazz-tools/src/cli.ts
@@ -664,6 +664,22 @@ function columnsEqual(left: ColumnDescriptor, right: ColumnDescriptor): boolean 
   );
 }
 
+function indexedColumnsEqual(
+  left: readonly string[] | undefined,
+  right: readonly string[] | undefined,
+): boolean {
+  if (!left && !right) {
+    return true;
+  }
+  if (!left || !right || left.length !== right.length) {
+    return false;
+  }
+
+  const leftColumns = [...left].sort();
+  const rightColumns = [...right].sort();
+  return leftColumns.every((column, index) => column === rightColumns[index]);
+}
+
 function tableSchemasEqual(
   left: WasmSchema[string] | undefined,
   right: WasmSchema[string] | undefined,
@@ -673,6 +689,10 @@ function tableSchemasEqual(
   }
 
   if (left.columns.length !== right.columns.length) {
+    return false;
+  }
+
+  if (!indexedColumnsEqual(left.indexed_columns, right.indexed_columns)) {
     return false;
   }
 

--- a/packages/jazz-tools/src/codegen/schema-reader.ts
+++ b/packages/jazz-tools/src/codegen/schema-reader.ts
@@ -259,6 +259,7 @@ export function schemaToWasm(schema: Schema): WasmSchema {
 
     tables[table.name] = {
       columns,
+      ...(table.indexedColumns ? { indexed_columns: [...table.indexedColumns] } : {}),
       policies: table.policies ? clonePolicies(table.policies) : undefined,
     };
   }

--- a/packages/jazz-tools/src/drivers/types.ts
+++ b/packages/jazz-tools/src/drivers/types.ts
@@ -136,6 +136,7 @@ export interface TablePolicies {
 
 export interface TableSchema {
   columns: ColumnDescriptor[];
+  indexed_columns?: string[];
   policies?: TablePolicies;
 }
 

--- a/packages/jazz-tools/src/index.ts
+++ b/packages/jazz-tools/src/index.ts
@@ -26,7 +26,6 @@ import type {
   SchemaDefinition as TypedSchemaDefinition,
   SliceableApp as TypedSliceableApp,
   TableDefinition as TypedTableDefinition,
-  TableIndex as TypedTableIndex,
   TableMetaOf as TypedTableMetaOf,
   WhereOf as TypedWhereOf,
 } from "./typed-app.js";
@@ -122,7 +121,6 @@ export type {
   Simplify,
   CompactSchema,
   DefinedSchema,
-  TableIndex,
   DefinedTable,
   TableRow,
   TableInit,
@@ -184,8 +182,6 @@ export const schema: RuntimeSchemaNamespace = Object.assign({}, col, {
 export namespace schema {
   export type TableDefinition = TypedTableDefinition;
   export type SchemaDefinition = TypedSchemaDefinition;
-  export type TableIndex<TColumns extends TypedTableDefinition = TypedTableDefinition> =
-    TypedTableIndex<TColumns>;
   /**
    * Normalized type for a schema definition.
    */

--- a/packages/jazz-tools/src/migrations.ts
+++ b/packages/jazz-tools/src/migrations.ts
@@ -742,6 +742,17 @@ function tableMatchesAfterApplyingColumnOperations(
   return true;
 }
 
+function unwrapSchemaTables<TSchema extends SchemaLike>(
+  definition: NormalizedSchema<TSchema>,
+): Record<string, Record<string, AnyTypedColumnBuilder>> {
+  return Object.fromEntries(
+    Object.entries(definition).map(([tableName, tableDefinition]) => [
+      tableName,
+      unwrapTableDefinition(tableDefinition as TableDefinition | DefinedTable<TableDefinition>),
+    ]),
+  );
+}
+
 function buildForwardLenses<
   TFrom extends SchemaLike,
   TTo extends SchemaLike,
@@ -793,8 +804,8 @@ function buildForwardLenses<
       ...Object.keys(migrate ?? {}),
     ]),
   ];
-  const sourceTables = fromDefinition as Record<string, Record<string, AnyTypedColumnBuilder>>;
-  const targetTables = toDefinition as Record<string, Record<string, AnyTypedColumnBuilder>>;
+  const sourceTables = unwrapSchemaTables(fromDefinition);
+  const targetTables = unwrapSchemaTables(toDefinition);
 
   for (const tableName of orderedTableNames) {
     const added = addedTableSet.has(tableName) ? true : undefined;

--- a/packages/jazz-tools/src/migrations.ts
+++ b/packages/jazz-tools/src/migrations.ts
@@ -18,13 +18,12 @@ import type {
 } from "./schema.js";
 import type {
   CompactSchema,
-  DefinedTable,
   Schema as AppSchema,
   SchemaDefinition,
   Simplify,
   TableDefinition,
 } from "./typed-app.js";
-import { unwrapTableDefinition } from "./typed-app.js";
+import { DefinedTable, unwrapTableDefinition } from "./typed-app.js";
 
 type SchemaLike = SchemaDefinition | AppSchema<any>;
 
@@ -527,22 +526,27 @@ function tableDefinitionToAst(
   definition: TableDefinition | DefinedTable<TableDefinition>,
 ): SchemaAstTable {
   const columnsDefinition = unwrapTableDefinition(definition);
+  const indexedColumns =
+    definition instanceof DefinedTable && definition.indexedColumns
+      ? [...definition.indexedColumns]
+      : undefined;
   return {
     name: tableName,
     columns: Object.entries(columnsDefinition).map(([columnName, builder]) => {
       assertUserColumnNameAllowed(columnName);
       return builder._build(columnName);
     }),
+    ...(indexedColumns ? { indexedColumns } : {}),
   };
 }
 
 function normalizeSchemaDefinition(
   definition: SchemaDefinition | AppSchema<any>,
-): Record<string, TableDefinition> {
+): Record<string, TableDefinition | DefinedTable<TableDefinition>> {
   return Object.fromEntries(
     Object.entries(definition as SchemaDefinition).map(([tableName, tableDefinition]) => [
       tableName,
-      unwrapTableDefinition(tableDefinition as TableDefinition | DefinedTable<TableDefinition>),
+      tableDefinition as TableDefinition | DefinedTable<TableDefinition>,
     ]),
   );
 }

--- a/packages/jazz-tools/src/schema-loader.ts
+++ b/packages/jazz-tools/src/schema-loader.ts
@@ -149,6 +149,7 @@ function wasmTableToAst(name: string, table: TableSchema): Schema["tables"][numb
   return {
     name,
     columns: table.columns.map(wasmColumnToAst),
+    indexedColumns: table.indexed_columns ? [...table.indexed_columns] : undefined,
     policies: table.policies as TablePolicies | undefined,
   };
 }
@@ -171,11 +172,6 @@ function isTypedAppLike(value: Record<string, unknown>): value is { wasmSchema: 
 }
 
 function schemaFromLoadedModule(loaded: Record<string, unknown>): Schema | null {
-  const collected = getCollectedSchema();
-  if (collected.tables.length > 0) {
-    return collected;
-  }
-
   const candidates = [loaded.schema, loaded.schemaDef, loaded.default, loaded.app].filter(
     (candidate): candidate is Record<string, unknown> =>
       typeof candidate === "object" && candidate !== null,
@@ -191,6 +187,11 @@ function schemaFromLoadedModule(loaded: Record<string, unknown>): Schema | null 
     } catch {
       // Try the next supported export shape.
     }
+  }
+
+  const collected = getCollectedSchema();
+  if (collected.tables.length > 0) {
+    return collected;
   }
 
   return null;

--- a/packages/jazz-tools/src/schema.ts
+++ b/packages/jazz-tools/src/schema.ts
@@ -214,6 +214,7 @@ export interface TablePolicies {
 export interface Table {
   name: string;
   columns: Column[];
+  indexedColumns?: string[];
   policies?: TablePolicies;
 }
 

--- a/packages/jazz-tools/src/typed-app.ts
+++ b/packages/jazz-tools/src/typed-app.ts
@@ -21,47 +21,30 @@ import type { Column, Schema as SchemaAst, SqlType, TSTypeFromSqlType } from "./
 
 export type TableDefinition = Record<string, AnyTypedColumnBuilder>;
 
-export interface TableIndex<TColumns extends TableDefinition = TableDefinition> {
-  readonly name: string;
-  readonly columns: readonly Extract<keyof TColumns, string>[];
-}
-
-// Wrap table columns so we can hang chained modifiers like .index(...) off tables
+// Wrap table columns so we can hang chained modifiers like .indexOnly(...) off tables
 // without changing the column-level schema representation the runtime uses today.
 export class DefinedTable<TColumns extends TableDefinition = TableDefinition> {
   public readonly __jazzTableDefinition = true as const;
 
   constructor(
     public readonly columns: TColumns,
-    public readonly indexes: readonly TableIndex[] = [],
+    public readonly indexedColumns?: readonly Extract<keyof TColumns, string>[],
   ) {}
 
-  index<
-    const TName extends string,
+  indexOnly<
     const TColumnsForIndex extends readonly [
       Extract<keyof TColumns, string>,
       ...Extract<keyof TColumns, string>[],
     ],
-  >(name: TName, columns: TColumnsForIndex): DefinedTable<TColumns> {
-    const normalizedName = name.trim();
-    if (!normalizedName) {
-      throw new Error("table.index(...) requires a non-empty index name.");
-    }
-
+  >(columns: TColumnsForIndex): DefinedTable<TColumns> {
     const normalizedColumns = [...columns] as Extract<keyof TColumns, string>[];
     for (const column of normalizedColumns) {
       if (!(column in this.columns)) {
-        throw new Error(`table.index(...) references unknown column "${column}".`);
+        throw new Error(`table.indexOnly(...) references unknown column "${column}".`);
       }
     }
 
-    return new DefinedTable(this.columns, [
-      ...this.indexes,
-      {
-        name: normalizedName,
-        columns: normalizedColumns,
-      },
-    ]);
+    return new DefinedTable(this.columns, normalizedColumns);
   }
 }
 
@@ -86,9 +69,7 @@ export function defineTable<const TColumns extends TableDefinition>(
   return new DefinedTable(columns);
 }
 
-type TableSource<TColumns extends TableDefinition = TableDefinition> =
-  | TColumns
-  | DefinedTable<TColumns>;
+type TableSource<TColumns extends TableDefinition = any> = TColumns | DefinedTable<TColumns>;
 
 type NormalizeTableDefinition<TTable extends TableSource> =
   TTable extends DefinedTable<infer TColumns>
@@ -97,7 +78,7 @@ type NormalizeTableDefinition<TTable extends TableSource> =
       ? Simplify<TTable>
       : never;
 
-export type SchemaDefinition = Record<string, TableSource<TableDefinition>>;
+export type SchemaDefinition = Record<string, TableSource>;
 export type Simplify<T> = { [K in keyof T]: T[K] } & {};
 export type CompactSchema<TSchema extends SchemaDefinition> = Simplify<{
   [TTable in keyof TSchema]: NormalizeTableDefinition<TSchema[TTable]>;
@@ -1225,6 +1206,26 @@ export function unwrapTableDefinition<const TColumns extends TableDefinition>(
   return definition;
 }
 
+function tableIndexedColumns(
+  definition: TableDefinition | DefinedTable<TableDefinition>,
+): string[] | undefined {
+  if (definition instanceof DefinedTable) {
+    return definition.indexedColumns ? [...definition.indexedColumns] : undefined;
+  }
+
+  if (typeof definition === "object" && definition !== null) {
+    const maybeDefinedTable = definition as {
+      __jazzTableDefinition?: unknown;
+      indexedColumns?: readonly string[];
+    };
+    if (maybeDefinedTable.__jazzTableDefinition === true) {
+      return maybeDefinedTable.indexedColumns ? [...maybeDefinedTable.indexedColumns] : undefined;
+    }
+  }
+
+  return undefined;
+}
+
 function definitionToColumns(
   definition: TableDefinition | DefinedTable<TableDefinition>,
 ): Column[] {
@@ -1256,10 +1257,14 @@ function columnTransformsForTable(
 
 function definitionToSchema<TSchema extends SchemaDefinition>(definition: TSchema): SchemaAst {
   return {
-    tables: Object.entries(definition).map(([tableName, tableDefinition]) => ({
-      name: tableName,
-      columns: definitionToColumns(tableDefinition),
-    })),
+    tables: Object.entries(definition).map(([tableName, tableDefinition]) => {
+      const indexedColumns = tableIndexedColumns(tableDefinition);
+      return {
+        name: tableName,
+        columns: definitionToColumns(tableDefinition),
+        ...(indexedColumns ? { indexedColumns } : {}),
+      };
+    }),
   };
 }
 

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/basic/schema.ts
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/basic/schema.ts
@@ -27,7 +27,7 @@ export const schema = {
       ownerId: s.ref("users").optional(),
       assigneesIds: s.array(s.ref("users")).default([]),
     })
-    .index("by_done", ["done"]),
+    .indexOnly(["done"]),
   table_with_defaults: s.table({
     integer: s.int().default(1),
     float: s.float().default(1),

--- a/packages/jazz-tools/tests/ts-dsl/typed-app.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/typed-app.test.ts
@@ -28,7 +28,7 @@ const schema = {
       project: s.ref("projects"),
       owner: s.ref("users").optional(),
     })
-    .index("by_done", ["done"]),
+    .indexOnly(["done"]),
 };
 type AppSchema = s.Schema<typeof schema>;
 const app: s.App<AppSchema> = s.defineApp(schema);
@@ -162,6 +162,11 @@ describe("typed app prototype", () => {
     expectTypeOf(row.title).toEqualTypeOf<string>();
     expectTypeOf(row.$createdBy).toEqualTypeOf<string>();
     expectTypeOf(row.$updatedAt).toEqualTypeOf<Date>();
+  });
+
+  it("emits indexOnly metadata into the runtime schema", () => {
+    expect(app.wasmSchema.todos?.indexed_columns).toEqual(["done"]);
+    expect(app.wasmSchema.users?.indexed_columns).toBeUndefined();
   });
 
   it("serializes gather seeded from the current relation", () => {


### PR DESCRIPTION
## Summary

Stack PR 5 of the Jazz load-performance split. This slice adds table-level selective index metadata so later storage and replay paths can cheaply know which tables/indexes need index work.

## What changed

- Adds `indexOnly`/selective table index metadata to the typed schema path.
- Emits indexed-column metadata into the runtime/wasm schema shape.
- Publishes schema changes when only indexed columns change.
- Keeps migration validation focused on real columns by unwrapping `DefinedTable` metadata before add/drop/rename checks.

## Review notes

- This is intentionally a narrow metadata layer so the later native-row and replay optimizations can depend on a reviewed schema shape.

## Validation

- Targeted migration/CLI tests for add/drop/rename operations and table renames.
- `pnpm --filter jazz-tools exec tsc --noEmit --pretty false`
- GitHub CI passed: `lint`, `test-rust`, `test-ts`, and Vercel docs. Inspector was pending at merge time under the authorized core-CI merge flow.
