### PR TITLE
Stack 06: Deliver subscription rows in native format

### DIFF
--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -28,9 +28,9 @@ use super::policy_graph::PolicyGraph;
 use super::query::Query;
 use super::session::Session;
 use super::types::{
-    ColumnName, ComposedBranchName, LoadedRow, OrderedRowDelta, Row, RowDelta, RowDescriptor,
-    RowPolicyMode, Schema, SchemaHash, TableName, TablePolicies, TableSchema, Tuple, Value,
-    build_ordered_delta_with_post_ids,
+    ColumnName, ComposedBranchName, LoadedRow, OrderedAdded, OrderedRowDelta, Row, RowDelta,
+    RowDescriptor, RowPolicyMode, Schema, SchemaHash, TableName, TablePolicies, TableSchema, Tuple,
+    Value, build_ordered_delta_with_post_ids,
 };
 
 /// Error types for QueryManager operations.
@@ -1519,52 +1519,78 @@ impl QueryManager {
                 visible_tuples,
             );
 
-            let visible_rows = Self::rows_from_tuples(&subscription.graph, visible_tuples.as_ref());
-            let visible_rows_by_id: HashMap<_, _> = visible_rows
-                .iter()
-                .cloned()
-                .map(|row| (row.id, row))
-                .collect();
-            let visible_delta = Self::row_delta_from_rows(
-                &subscription.current_visible_rows,
-                &subscription.current_ordered_ids,
-                &visible_rows,
-            );
-            let ordered_ids_after: Vec<ObjectId> = visible_rows.iter().map(|row| row.id).collect();
-
             if !subscription.settled_once {
+                let visible_rows =
+                    Self::rows_from_tuples(&subscription.graph, visible_tuples.as_ref());
+                let row_count = visible_rows.len();
+                let ordered_ids_after: Vec<_> = visible_rows.iter().map(|row| row.id).collect();
+                let ordered_delta = OrderedRowDelta {
+                    added: visible_rows
+                        .iter()
+                        .cloned()
+                        .enumerate()
+                        .map(|(index, row)| OrderedAdded {
+                            id: row.id,
+                            index,
+                            row,
+                        })
+                        .collect(),
+                    removed: Vec::new(),
+                    updated: Vec::new(),
+                    pending: false,
+                };
+                let visible_rows_by_id: HashMap<_, _> = visible_rows
+                    .iter()
+                    .cloned()
+                    .map(|row| (row.id, row))
+                    .collect();
+                let visible_delta = RowDelta {
+                    added: visible_rows,
+                    removed: Vec::new(),
+                    moved: Vec::new(),
+                    updated: Vec::new(),
+                };
                 tracing::trace!(
                     sub_id = sub_id.0,
                     table = %table,
-                    rows = visible_rows.len(),
+                    rows = row_count,
                     added = visible_delta.added.len(),
-                    removed = visible_delta.removed.len(),
-                    updated = visible_delta.updated.len(),
-                    moved = visible_delta.moved.len(),
                     settled_tier = ?subscription.query_frontier_settled_tier,
                     required_tier = ?subscription.durability_tier,
                     "jazz trace subscription first delivery"
                 );
                 subscription.settled_once = true;
-                let ordered = build_ordered_delta_with_post_ids(
-                    &subscription.current_ordered_ids,
-                    &ordered_ids_after,
-                    &visible_delta,
-                    false,
-                );
-                subscription.current_ordered_ids = ordered.ordered_ids_after;
+                subscription.current_ordered_ids = ordered_ids_after;
                 subscription.current_visible_rows = visible_rows_by_id;
                 self.update_outbox.push(QueryUpdate {
                     subscription_id: sub_id,
                     delta: visible_delta,
-                    ordered_delta: ordered.delta,
+                    ordered_delta,
                     descriptor: subscription.graph.combined_descriptor.clone(),
                 });
                 subscription.has_pending_local_updates = false;
                 subscription
                     .pending_local_row_ids
                     .retain(|id| self.pending_local_row_batches.contains_key(id));
-            } else if !visible_delta.is_empty() {
+            } else {
+                let visible_rows =
+                    Self::rows_from_tuples(&subscription.graph, visible_tuples.as_ref());
+                let visible_rows_by_id: HashMap<_, _> = visible_rows
+                    .iter()
+                    .cloned()
+                    .map(|row| (row.id, row))
+                    .collect();
+                let visible_delta = Self::row_delta_from_rows(
+                    &subscription.current_visible_rows,
+                    &subscription.current_ordered_ids,
+                    &visible_rows,
+                );
+                if visible_delta.is_empty() {
+                    self.subscriptions.insert(sub_id, subscription);
+                    continue;
+                }
+                let ordered_ids_after: Vec<ObjectId> =
+                    visible_rows.iter().map(|row| row.id).collect();
                 let ordered = build_ordered_delta_with_post_ids(
                     &subscription.current_ordered_ids,
                     &ordered_ids_after,

--- a/crates/jazz-wasm/src/runtime.rs
+++ b/crates/jazz-wasm/src/runtime.rs
@@ -21,6 +21,8 @@ use std::sync::Once;
 use jazz_tools::binding_support::parse_external_object_id;
 use js_sys::Function;
 use js_sys::Uint8Array;
+#[cfg(target_arch = "wasm32")]
+use js_sys::{Object, Reflect};
 use serde::Serialize;
 #[cfg(target_arch = "wasm32")]
 use tracing::warn;
@@ -88,14 +90,10 @@ use jazz_tools::binding_support::{
 };
 use jazz_tools::identity;
 use jazz_tools::object::ObjectId;
-#[cfg(target_arch = "wasm32")]
-use jazz_tools::query_manager::encoding::decode_row;
 use jazz_tools::query_manager::manager::LocalUpdates;
 #[cfg(target_arch = "wasm32")]
 use jazz_tools::query_manager::query::Query;
 use jazz_tools::query_manager::session::{Session, WriteContext};
-#[cfg(target_arch = "wasm32")]
-use jazz_tools::query_manager::types::{Row, RowDescriptor};
 use jazz_tools::query_manager::types::{SchemaHash, Value};
 use jazz_tools::runtime_core::{
     QueryLocalOverlay, ReadDurabilityOptions, RuntimeCore, Scheduler, SyncSender,
@@ -116,11 +114,6 @@ use jazz_tools::sync_manager::{
 
 use crate::query::parse_query;
 use crate::types::SubscriptionRow;
-#[cfg(target_arch = "wasm32")]
-use crate::types::{
-    SubscriptionRowAdded, SubscriptionRowChange, SubscriptionRowDelta, SubscriptionRowRemoved,
-    SubscriptionRowUpdated,
-};
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -303,53 +296,88 @@ fn parse_subscription_inputs(
 #[cfg(target_arch = "wasm32")]
 fn make_subscription_callback(on_update: Function) -> impl Fn(SubscriptionDelta) + 'static {
     move |delta: SubscriptionDelta| {
-        let row_to_wasm = |row: &Row, descriptor: &RowDescriptor| -> SubscriptionRow {
-            let values = decode_row(descriptor, &row.data)
-                .map(|vals| vals.into_iter().map(Value::from).collect::<Vec<_>>())
-                .unwrap_or_default();
-            SubscriptionRow {
-                id: row.id.uuid().to_string(),
-                values,
-            }
-        };
-
-        let descriptor = &delta.descriptor;
-        let wasm_delta = SubscriptionRowDelta(
-            delta
-                .ordered_delta
-                .removed
-                .iter()
-                .map(|change| {
-                    SubscriptionRowChange::Removed(SubscriptionRowRemoved {
-                        kind: 1,
-                        id: change.id.uuid().to_string(),
-                        index: change.index,
-                    })
-                })
-                .chain(delta.ordered_delta.updated.iter().map(|change| {
-                    SubscriptionRowChange::Updated(SubscriptionRowUpdated {
-                        kind: 2,
-                        id: change.id.uuid().to_string(),
-                        index: change.new_index,
-                        row: change.row.as_ref().map(|row| row_to_wasm(row, descriptor)),
-                    })
-                }))
-                .chain(delta.ordered_delta.added.iter().map(|change| {
-                    SubscriptionRowChange::Added(SubscriptionRowAdded {
-                        kind: 0,
-                        id: change.id.uuid().to_string(),
-                        index: change.index,
-                        row: row_to_wasm(&change.row, descriptor),
-                    })
-                }))
-                .collect::<Vec<_>>(),
-        );
-
-        let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
-        if let Ok(delta_value) = wasm_delta.serialize(&serializer) {
+        let delta_value = native_subscription_delta_to_js(&delta);
+        if !delta_value.is_undefined() {
             let _ = on_update.call1(&JsValue::NULL, &delta_value);
         }
     }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn push_u32(buffer: &mut Vec<u8>, value: usize) {
+    buffer.extend_from_slice(&(value as u32).to_le_bytes());
+}
+
+#[cfg(target_arch = "wasm32")]
+fn push_row_record(buffer: &mut Vec<u8>, id: ObjectId, index: usize, data: &[u8]) {
+    buffer.extend_from_slice(id.uuid().as_bytes());
+    push_u32(buffer, index);
+    push_u32(buffer, data.len());
+    buffer.extend_from_slice(data);
+}
+
+#[cfg(target_arch = "wasm32")]
+fn set_property(object: &Object, key: &str, value: &JsValue) {
+    let _ = Reflect::set(object, &JsValue::from_str(key), value);
+}
+
+#[cfg(target_arch = "wasm32")]
+fn native_subscription_delta_to_js(delta: &SubscriptionDelta) -> JsValue {
+    let mut added = Vec::new();
+    let mut removed = Vec::new();
+    let mut updated = Vec::new();
+
+    for change in &delta.ordered_delta.added {
+        push_row_record(&mut added, change.id, change.index, &change.row.data);
+    }
+
+    for change in &delta.ordered_delta.removed {
+        removed.extend_from_slice(change.id.uuid().as_bytes());
+        push_u32(&mut removed, change.index);
+    }
+
+    for change in &delta.ordered_delta.updated {
+        updated.extend_from_slice(change.id.uuid().as_bytes());
+        push_u32(&mut updated, change.new_index);
+        match &change.row {
+            Some(row) => {
+                updated.push(1);
+                push_u32(&mut updated, row.data.len());
+                updated.extend_from_slice(&row.data);
+            }
+            None => updated.push(0),
+        }
+    }
+
+    let object = Object::new();
+    set_property(&object, "__jazzNativeRowDelta", &JsValue::from_bool(true));
+    set_property(&object, "added", &Uint8Array::from(added.as_slice()).into());
+    set_property(
+        &object,
+        "removed",
+        &Uint8Array::from(removed.as_slice()).into(),
+    );
+    set_property(
+        &object,
+        "updated",
+        &Uint8Array::from(updated.as_slice()).into(),
+    );
+    set_property(
+        &object,
+        "addedCount",
+        &JsValue::from_f64(delta.ordered_delta.added.len() as f64),
+    );
+    set_property(
+        &object,
+        "removedCount",
+        &JsValue::from_f64(delta.ordered_delta.removed.len() as f64),
+    );
+    set_property(
+        &object,
+        "updatedCount",
+        &JsValue::from_f64(delta.ordered_delta.updated.len() as f64),
+    );
+    object.into()
 }
 
 fn parse_node_durability_tiers(tier: Option<&str>) -> Result<Vec<DurabilityTier>, JsError> {

--- a/packages/jazz-tools/src/drivers/index.ts
+++ b/packages/jazz-tools/src/drivers/index.ts
@@ -9,4 +9,6 @@ export type {
   WasmSchema,
   WasmRow,
   RowDelta as WireRowDelta,
+  NativeRowDelta,
+  SubscriptionWireDelta,
 } from "./types.js";

--- a/packages/jazz-tools/src/drivers/types.ts
+++ b/packages/jazz-tools/src/drivers/types.ts
@@ -60,6 +60,18 @@ export type WireRowChange = WireRowDeltaAdded | WireRowDeltaRemoved | WireRowDel
 
 export type RowDelta = WireRowChange[];
 
+export interface NativeRowDelta {
+  __jazzNativeRowDelta: true;
+  added: Uint8Array;
+  removed: Uint8Array;
+  updated: Uint8Array;
+  addedCount: number;
+  removedCount: number;
+  updatedCount: number;
+}
+
+export type SubscriptionWireDelta = RowDelta | NativeRowDelta;
+
 export type ColumnType =
   | { type: "Integer" }
   | { type: "BigInt" }

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -6,7 +6,13 @@
  */
 
 import type { AppContext, RuntimeSourcesConfig, Session } from "./context.js";
-import type { InsertValues, Value, RowDelta, WasmSchema } from "../drivers/types.js";
+import type {
+  InsertValues,
+  Value,
+  RowDelta,
+  SubscriptionWireDelta,
+  WasmSchema,
+} from "../drivers/types.js";
 import { normalizeRuntimeSchema, serializeRuntimeSchema } from "../drivers/schema-wire.js";
 import {
   applyUserAuthHeaders,
@@ -314,7 +320,7 @@ interface PersistedMutationResult {
 /**
  * Subscription callback type.
  */
-export type SubscriptionCallback = (delta: RowDelta) => void;
+export type SubscriptionCallback = (delta: SubscriptionWireDelta) => void;
 
 export interface ConnectSyncRuntimeOptions {
   useBinaryEncoding?: boolean;
@@ -587,13 +593,15 @@ function readHeader(request: RequestLike, name: string): string | undefined {
   return raw;
 }
 
-function normalizeSubscriptionCallbackArgs(args: unknown[]): RowDelta | string | undefined {
+function normalizeSubscriptionCallbackArgs(
+  args: unknown[],
+): SubscriptionWireDelta | string | undefined {
   if (args.length === 1) {
-    return args[0] as RowDelta | string;
+    return args[0] as SubscriptionWireDelta | string;
   }
 
   if (args.length === 2 && args[0] == null) {
-    return args[1] as RowDelta | string | undefined;
+    return args[1] as SubscriptionWireDelta | string | undefined;
   }
 
   console.error("Invalid subscription callback arguments", args);
@@ -2045,9 +2053,9 @@ export class JazzClient {
 
   private alignSubscriptionDeltaToDeclaredSchema(
     queryJson: string,
-    delta: RowDelta,
+    delta: SubscriptionWireDelta,
     runtimeSchema?: WasmSchema,
-  ): RowDelta {
+  ): SubscriptionWireDelta {
     if (this.returnsDeclaredSchemaRows()) {
       return delta;
     }
@@ -2434,7 +2442,7 @@ export class JazzClient {
           return;
         }
 
-        const delta: RowDelta =
+        const delta: SubscriptionWireDelta =
           typeof deltaJsonOrObject === "string" ? JSON.parse(deltaJsonOrObject) : deltaJsonOrObject;
         callback(
           this.alignSubscriptionDeltaToDeclaredSchema(queryJson, delta, effectiveRuntimeSchema),

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -2022,6 +2022,7 @@ export class Db {
     );
     const outputTable = resolveBuiltQueryOutputTable(planningSchema, builtQuery);
     const outputSchema = resolveSchemaWithTable(query._schema, runtimeSchema.get, outputTable);
+    const nativeOutputColumns = outputSchema[outputTable]?.columns;
     const outputIncludes = outputTable !== builtQuery.table ? {} : builtQuery.includes;
     const wasmQuery = translateQuery(builderJson, planningSchema);
 
@@ -2032,7 +2033,7 @@ export class Db {
       );
 
     const handleDelta = (delta: Parameters<SubscriptionManager<T>["handleDelta"]>[0]) => {
-      const typedDelta = manager.handleDelta(delta, transform);
+      const typedDelta = manager.handleDelta(delta, transform, nativeOutputColumns);
       callback(typedDelta);
     };
 
@@ -2420,6 +2421,7 @@ class ClientBackedDb extends Db {
     );
     const outputTable = resolveBuiltQueryOutputTable(planningSchema, builtQuery);
     const outputSchema = resolveSchemaWithTable(query._schema, runtimeSchema.get, outputTable);
+    const nativeOutputColumns = outputSchema[outputTable]?.columns;
     const outputIncludes = outputTable !== builtQuery.table ? {} : builtQuery.includes;
     const wasmQuery = translateQuery(builderJson, planningSchema);
 
@@ -2433,7 +2435,7 @@ class ClientBackedDb extends Db {
     const subId = this.runtimeClient.subscribeInternal(
       wasmQuery,
       (delta) => {
-        const typedDelta = manager.handleDelta(delta, transform);
+        const typedDelta = manager.handleDelta(delta, transform, nativeOutputColumns);
         callback(typedDelta);
       },
       this.session,

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -2031,9 +2031,19 @@ export class Db {
         outputTable === builtQuery.table ? query : {},
         transformRow(row, outputSchema, outputTable, outputIncludes, builtQuery.select),
       );
+    const nativeTransform =
+      Object.keys(outputIncludes).length === 0 && builtQuery.select.length === 0
+        ? (row: Record<string, unknown>): T =>
+            transformOutputRow(outputTable === builtQuery.table ? query : {}, row)
+        : undefined;
 
     const handleDelta = (delta: Parameters<SubscriptionManager<T>["handleDelta"]>[0]) => {
-      const typedDelta = manager.handleDelta(delta, transform, nativeOutputColumns);
+      const typedDelta = manager.handleDelta(
+        delta,
+        transform,
+        nativeOutputColumns,
+        nativeTransform,
+      );
       callback(typedDelta);
     };
 
@@ -2430,12 +2440,22 @@ class ClientBackedDb extends Db {
         outputTable === builtQuery.table ? query : {},
         transformRow(row, outputSchema, outputTable, outputIncludes, builtQuery.select),
       );
+    const nativeTransform =
+      Object.keys(outputIncludes).length === 0 && builtQuery.select.length === 0
+        ? (row: Record<string, unknown>): T =>
+            transformOutputRow(outputTable === builtQuery.table ? query : {}, row)
+        : undefined;
     const queryOptions = ordinaryDbQueryOptions(options);
 
     const subId = this.runtimeClient.subscribeInternal(
       wasmQuery,
       (delta) => {
-        const typedDelta = manager.handleDelta(delta, transform, nativeOutputColumns);
+        const typedDelta = manager.handleDelta(
+          delta,
+          transform,
+          nativeOutputColumns,
+          nativeTransform,
+        );
         callback(typedDelta);
       },
       this.session,

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -10,7 +10,13 @@
  * - all/one are async (need storage I/O for queries)
  */
 
-import type { WasmSchema, WasmRow, StorageDriver } from "../drivers/types.js";
+import type {
+  ColumnDescriptor,
+  ColumnType,
+  WasmSchema,
+  WasmRow,
+  StorageDriver,
+} from "../drivers/types.js";
 import { getRuntimeSchemaCacheKey, normalizeRuntimeSchema } from "../drivers/schema-wire.js";
 import type { RuntimeSourcesConfig, Session } from "./context.js";
 import {
@@ -49,13 +55,16 @@ import {
   type FileWriteOptions,
 } from "./file-storage.js";
 import { analyzeRelations } from "../codegen/relation-analyzer.js";
+import { isPermissionIntrospectionColumn, magicColumnType } from "../magic-columns.js";
 import { TabLeaderElection, type LeaderRole, type LeaderSnapshot } from "./tab-leader-election.js";
 import type { WorkerLifecycleEvent } from "../worker/worker-protocol.js";
 import {
   normalizeBuiltQuery,
   type BuiltRelation,
+  type NormalizedIncludeSpec,
   type NormalizedBuiltQuery,
 } from "./query-builder-shape.js";
+import { resolveSelectedColumns } from "./select-projection.js";
 import {
   appendWorkerRuntimeWasmUrl,
   resolveRuntimeConfigSyncInitInput,
@@ -346,6 +355,67 @@ function resolveSchemaWithTable(
   }
 
   return typeof fallbackSchema === "function" ? fallbackSchema() : fallbackSchema;
+}
+
+function resolveOutputColumnDescriptor(
+  tableName: string,
+  schema: WasmSchema,
+  columnName: string,
+): ColumnDescriptor | undefined {
+  const magicType = magicColumnType(columnName);
+  if (magicType) {
+    return {
+      name: columnName,
+      column_type: magicType,
+      nullable: isPermissionIntrospectionColumn(columnName),
+    };
+  }
+
+  return schema[tableName]?.columns.find((column) => column.name === columnName);
+}
+
+function resolveNativeSubscriptionColumns(
+  tableName: string,
+  schema: WasmSchema,
+  includes: NormalizedIncludeSpec,
+  projection?: readonly string[],
+): ColumnDescriptor[] {
+  const columns = resolveSelectedColumns(tableName, schema, projection)
+    .map((columnName) => resolveOutputColumnDescriptor(tableName, schema, columnName))
+    .filter((column): column is ColumnDescriptor => column !== undefined);
+
+  if (Object.keys(includes).length === 0) {
+    return columns;
+  }
+
+  const relationsByTable = analyzeRelations(schema);
+  const relations = relationsByTable.get(tableName) ?? [];
+
+  for (const [relationName, include] of Object.entries(includes)) {
+    const relation = relations.find((candidate) => candidate.name === relationName);
+    if (!relation) {
+      throw new Error(`Unknown relation "${relationName}" on table "${tableName}"`);
+    }
+
+    const nestedColumns = resolveNativeSubscriptionColumns(
+      relation.toTable,
+      schema,
+      include.includes,
+      include.select.length > 0 ? include.select : undefined,
+    );
+    const columnType: ColumnType = {
+      type: "Array",
+      element: { type: "Row", columns: nestedColumns },
+    };
+
+    columns.push({
+      name: relationName,
+      column_type: columnType,
+      nullable: false,
+    });
+  }
+
+  return columns;
 }
 
 function createRuntimeSchemaResolver(getRuntimeSchema: () => WasmSchema): {
@@ -2022,8 +2092,13 @@ export class Db {
     );
     const outputTable = resolveBuiltQueryOutputTable(planningSchema, builtQuery);
     const outputSchema = resolveSchemaWithTable(query._schema, runtimeSchema.get, outputTable);
-    const nativeOutputColumns = outputSchema[outputTable]?.columns;
     const outputIncludes = outputTable !== builtQuery.table ? {} : builtQuery.includes;
+    const nativeOutputColumns = resolveNativeSubscriptionColumns(
+      outputTable,
+      outputSchema,
+      outputIncludes,
+      builtQuery.select,
+    );
     const wasmQuery = translateQuery(builderJson, planningSchema);
 
     const transform = (row: WasmRow): T =>
@@ -2431,8 +2506,13 @@ class ClientBackedDb extends Db {
     );
     const outputTable = resolveBuiltQueryOutputTable(planningSchema, builtQuery);
     const outputSchema = resolveSchemaWithTable(query._schema, runtimeSchema.get, outputTable);
-    const nativeOutputColumns = outputSchema[outputTable]?.columns;
     const outputIncludes = outputTable !== builtQuery.table ? {} : builtQuery.includes;
+    const nativeOutputColumns = resolveNativeSubscriptionColumns(
+      outputTable,
+      outputSchema,
+      outputIncludes,
+      builtQuery.select,
+    );
     const wasmQuery = translateQuery(builderJson, planningSchema);
 
     const transform = (row: WasmRow): T =>

--- a/packages/jazz-tools/src/runtime/native-row-format.ts
+++ b/packages/jazz-tools/src/runtime/native-row-format.ts
@@ -1,0 +1,231 @@
+import type { ColumnDescriptor, ColumnType, Value, WasmRow } from "../drivers/types.js";
+
+const textDecoder = new TextDecoder();
+
+type Reader = {
+  data: Uint8Array;
+  view: DataView;
+};
+
+function readU32(reader: Reader, offset: number): number {
+  return reader.view.getUint32(offset, true);
+}
+
+function uuidString(bytes: Uint8Array): string {
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(
+    16,
+    20,
+  )}-${hex.slice(20)}`;
+}
+
+function fixedSize(type: ColumnType): number | null {
+  switch (type.type) {
+    case "Integer":
+      return 4;
+    case "BigInt":
+    case "Double":
+    case "Timestamp":
+      return 8;
+    case "Boolean":
+      return 1;
+    case "Uuid":
+      return 16;
+    case "Enum":
+      return type.variants.length <= 256 ? 1 : null;
+    default:
+      return null;
+  }
+}
+
+type LayoutColumn = {
+  fixedOffset?: number;
+  fixedTotalSize?: number;
+  fixedValueSize?: number;
+  variableIndex?: number;
+  nullable: boolean;
+};
+
+type RowLayout = {
+  columns: LayoutColumn[];
+  fixedSectionSize: number;
+  variableColumnCount: number;
+};
+
+function compileLayout(columns: readonly ColumnDescriptor[]): RowLayout {
+  const layoutColumns: LayoutColumn[] = [];
+  let fixedOffset = 0;
+  let variableIndex = 0;
+
+  for (const column of columns) {
+    const size = fixedSize(column.column_type);
+    if (size === null) {
+      layoutColumns.push({ variableIndex, nullable: column.nullable });
+      variableIndex += 1;
+    } else {
+      layoutColumns.push({
+        fixedOffset,
+        fixedTotalSize: size + (column.nullable ? 1 : 0),
+        fixedValueSize: size,
+        nullable: column.nullable,
+      });
+      fixedOffset += size + (column.nullable ? 1 : 0);
+    }
+  }
+
+  return {
+    columns: layoutColumns,
+    fixedSectionSize: fixedOffset,
+    variableColumnCount: variableIndex,
+  };
+}
+
+function columnBytes(
+  row: Uint8Array,
+  columns: readonly ColumnDescriptor[],
+  layout: RowLayout,
+  columnIndex: number,
+): { bytes: Uint8Array; isNull: boolean } {
+  const columnLayout = layout.columns[columnIndex];
+  if (!columnLayout) {
+    throw new Error(`Column index ${columnIndex} out of bounds`);
+  }
+
+  if (columnLayout.variableIndex === undefined) {
+    const offset = columnLayout.fixedOffset!;
+    const totalSize = columnLayout.fixedTotalSize!;
+    const valueSize = columnLayout.fixedValueSize!;
+    if (offset + totalSize > row.byteLength) {
+      throw new Error(`Native row is too short for column ${columns[columnIndex]?.name}`);
+    }
+    if (columnLayout.nullable) {
+      return {
+        bytes: row.subarray(offset + 1, offset + totalSize),
+        isNull: row[offset] === 0,
+      };
+    }
+    return { bytes: row.subarray(offset, offset + valueSize), isNull: false };
+  }
+
+  const fixedSizeBytes = layout.fixedSectionSize;
+  const offsetTableSize = layout.variableColumnCount > 1 ? (layout.variableColumnCount - 1) * 4 : 0;
+  const varDataStart = fixedSizeBytes + offsetTableSize;
+  if (varDataStart > row.byteLength) {
+    throw new Error("Native row variable section is truncated");
+  }
+
+  const varIndex = columnLayout.variableIndex;
+  const view = new DataView(row.buffer, row.byteOffset, row.byteLength);
+  const startOffset =
+    varIndex === 0 ? 0 : view.getUint32(fixedSizeBytes + (varIndex - 1) * 4, true);
+  const endOffset =
+    varIndex + 1 < layout.variableColumnCount
+      ? view.getUint32(fixedSizeBytes + varIndex * 4, true)
+      : row.byteLength - varDataStart;
+  if (startOffset > endOffset || varDataStart + endOffset > row.byteLength) {
+    throw new Error("Native row variable column offsets are invalid");
+  }
+
+  const bytes = row.subarray(varDataStart + startOffset, varDataStart + endOffset);
+  if (columnLayout.nullable) {
+    if (bytes.byteLength === 0) {
+      throw new Error("Nullable native row variable column has no null marker");
+    }
+    return { bytes: bytes.subarray(1), isNull: bytes[0] === 0 };
+  }
+
+  return { bytes, isNull: false };
+}
+
+function decodeNonNullValue(bytes: Uint8Array, type: ColumnType): Value {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  switch (type.type) {
+    case "Integer":
+      return { type: "Integer", value: view.getInt32(0, true) };
+    case "BigInt":
+      return { type: "BigInt", value: Number(view.getBigInt64(0, true)) };
+    case "Double":
+      return { type: "Double", value: view.getFloat64(0, true) };
+    case "Boolean":
+      return { type: "Boolean", value: bytes[0] !== 0 };
+    case "Timestamp":
+      return { type: "Timestamp", value: Number(view.getBigUint64(0, true)) };
+    case "Uuid":
+      return { type: "Uuid", value: uuidString(bytes.subarray(0, 16)) };
+    case "Bytea":
+      return { type: "Bytea", value: bytes.slice() };
+    case "Text":
+    case "Json":
+      return { type: "Text", value: textDecoder.decode(bytes) };
+    case "Enum":
+      if (type.variants.length <= 256 && bytes.byteLength === 1) {
+        return { type: "Text", value: type.variants[bytes[0]] ?? "" };
+      }
+      return { type: "Text", value: textDecoder.decode(bytes) };
+    case "Array":
+      return { type: "Array", value: decodeArray(bytes, type.element) };
+    case "Row": {
+      if (bytes.byteLength === 0) {
+        throw new Error("Native nested row is missing id flag");
+      }
+      const hasId = bytes[0] === 1;
+      const id = hasId ? uuidString(bytes.subarray(1, 17)) : undefined;
+      const rowData = bytes.subarray(hasId ? 17 : 1);
+      return { type: "Row", value: { id, values: decodeNativeRowValues(type.columns, rowData) } };
+    }
+  }
+}
+
+function decodeArray(bytes: Uint8Array, elementType: ColumnType): Value[] {
+  if (bytes.byteLength < 4) {
+    throw new Error("Native array is missing element count");
+  }
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const count = view.getUint32(0, true);
+  const fixed = fixedSize(elementType);
+  if (fixed !== null) {
+    const values: Value[] = [];
+    let offset = 4;
+    for (let i = 0; i < count; i++) {
+      values.push(decodeNonNullValue(bytes.subarray(offset, offset + fixed), elementType));
+      offset += fixed;
+    }
+    return values;
+  }
+
+  const offsetsStart = 4;
+  const offsetTableSize = count > 0 ? (count - 1) * 4 : 0;
+  const values: Value[] = [];
+  const payloadStart = 4 + offsetTableSize;
+  for (let i = 0; i < count; i++) {
+    const start = i === 0 ? 0 : view.getUint32(offsetsStart + (i - 1) * 4, true);
+    const end =
+      i + 1 < count ? view.getUint32(offsetsStart + i * 4, true) : bytes.byteLength - payloadStart;
+    values.push(
+      decodeNonNullValue(bytes.subarray(payloadStart + start, payloadStart + end), elementType),
+    );
+  }
+  return values;
+}
+
+export function decodeNativeRowValues(
+  columns: readonly ColumnDescriptor[],
+  rowData: Uint8Array,
+): Value[] {
+  const layout = compileLayout(columns);
+  return columns.map((column, index) => {
+    const { bytes, isNull } = columnBytes(rowData, columns, layout, index);
+    return isNull ? { type: "Null" } : decodeNonNullValue(bytes, column.column_type);
+  });
+}
+
+export function decodeNativeRow(
+  id: string,
+  columns: readonly ColumnDescriptor[],
+  data: Uint8Array,
+): WasmRow {
+  return {
+    id,
+    values: decodeNativeRowValues(columns, data),
+  };
+}

--- a/packages/jazz-tools/src/runtime/native-row-format.ts
+++ b/packages/jazz-tools/src/runtime/native-row-format.ts
@@ -1,4 +1,5 @@
 import type { ColumnDescriptor, ColumnType, Value, WasmRow } from "../drivers/types.js";
+import { isProvenanceMagicTimestampColumn } from "../magic-columns.js";
 
 const textDecoder = new TextDecoder();
 
@@ -52,6 +53,8 @@ type RowLayout = {
   variableColumnCount: number;
 };
 
+const layoutCache = new WeakMap<readonly ColumnDescriptor[], RowLayout>();
+
 function compileLayout(columns: readonly ColumnDescriptor[]): RowLayout {
   const layoutColumns: LayoutColumn[] = [];
   let fixedOffset = 0;
@@ -78,6 +81,16 @@ function compileLayout(columns: readonly ColumnDescriptor[]): RowLayout {
     fixedSectionSize: fixedOffset,
     variableColumnCount: variableIndex,
   };
+}
+
+function getLayout(columns: readonly ColumnDescriptor[]): RowLayout {
+  const cached = layoutCache.get(columns);
+  if (cached) {
+    return cached;
+  }
+  const layout = compileLayout(columns);
+  layoutCache.set(columns, layout);
+  return layout;
 }
 
 function columnBytes(
@@ -176,6 +189,85 @@ function decodeNonNullValue(bytes: Uint8Array, type: ColumnType): Value {
   }
 }
 
+function timestampToDate(value: number, columnName?: string): Date {
+  if (columnName && isProvenanceMagicTimestampColumn(columnName)) {
+    return new Date(Math.trunc(value / 1_000));
+  }
+  return new Date(value);
+}
+
+function decodeNativePlainValue(bytes: Uint8Array, type: ColumnType, columnName?: string): unknown {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  switch (type.type) {
+    case "Integer":
+      return view.getInt32(0, true);
+    case "BigInt":
+      return Number(view.getBigInt64(0, true));
+    case "Double":
+      return view.getFloat64(0, true);
+    case "Boolean":
+      return bytes[0] !== 0;
+    case "Timestamp":
+      return timestampToDate(Number(view.getBigUint64(0, true)), columnName);
+    case "Uuid":
+      return uuidString(bytes.subarray(0, 16));
+    case "Bytea":
+      return bytes.slice();
+    case "Text":
+      return textDecoder.decode(bytes);
+    case "Json":
+      return JSON.parse(textDecoder.decode(bytes));
+    case "Enum":
+      if (type.variants.length <= 256 && bytes.byteLength === 1) {
+        return type.variants[bytes[0]] ?? "";
+      }
+      return textDecoder.decode(bytes);
+    case "Array":
+      return decodeNativePlainArray(bytes, type.element);
+    case "Row": {
+      if (bytes.byteLength === 0) {
+        throw new Error("Native nested row is missing id flag");
+      }
+      const hasId = bytes[0] === 1;
+      const id = hasId ? uuidString(bytes.subarray(1, 17)) : undefined;
+      const rowData = bytes.subarray(hasId ? 17 : 1);
+      return decodeNativeRowObject(id, type.columns, rowData);
+    }
+  }
+}
+
+function decodeNativePlainArray(bytes: Uint8Array, elementType: ColumnType): unknown[] {
+  if (bytes.byteLength < 4) {
+    throw new Error("Native array is missing element count");
+  }
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const count = view.getUint32(0, true);
+  const fixed = fixedSize(elementType);
+  if (fixed !== null) {
+    const values: unknown[] = [];
+    let offset = 4;
+    for (let i = 0; i < count; i++) {
+      values.push(decodeNativePlainValue(bytes.subarray(offset, offset + fixed), elementType));
+      offset += fixed;
+    }
+    return values;
+  }
+
+  const offsetsStart = 4;
+  const offsetTableSize = count > 0 ? (count - 1) * 4 : 0;
+  const values: unknown[] = [];
+  const payloadStart = 4 + offsetTableSize;
+  for (let i = 0; i < count; i++) {
+    const start = i === 0 ? 0 : view.getUint32(offsetsStart + (i - 1) * 4, true);
+    const end =
+      i + 1 < count ? view.getUint32(offsetsStart + i * 4, true) : bytes.byteLength - payloadStart;
+    values.push(
+      decodeNativePlainValue(bytes.subarray(payloadStart + start, payloadStart + end), elementType),
+    );
+  }
+  return values;
+}
+
 function decodeArray(bytes: Uint8Array, elementType: ColumnType): Value[] {
   if (bytes.byteLength < 4) {
     throw new Error("Native array is missing element count");
@@ -212,7 +304,7 @@ export function decodeNativeRowValues(
   columns: readonly ColumnDescriptor[],
   rowData: Uint8Array,
 ): Value[] {
-  const layout = compileLayout(columns);
+  const layout = getLayout(columns);
   return columns.map((column, index) => {
     const { bytes, isNull } = columnBytes(rowData, columns, layout, index);
     return isNull ? { type: "Null" } : decodeNonNullValue(bytes, column.column_type);
@@ -228,4 +320,27 @@ export function decodeNativeRow(
     id,
     values: decodeNativeRowValues(columns, data),
   };
+}
+
+export function decodeNativeRowObject(
+  id: string | undefined,
+  columns: readonly ColumnDescriptor[],
+  data: Uint8Array,
+): Record<string, unknown> {
+  const layout = getLayout(columns);
+  const obj: Record<string, unknown> = {};
+  if (id !== undefined) {
+    obj.id = id;
+  }
+
+  for (let i = 0; i < columns.length; i++) {
+    const column = columns[i];
+    if (!column) continue;
+    const { bytes, isNull } = columnBytes(data, columns, layout, i);
+    obj[column.name] = isNull
+      ? null
+      : decodeNativePlainValue(bytes, column.column_type, column.name);
+  }
+
+  return obj;
 }

--- a/packages/jazz-tools/src/runtime/native-row-format.ts
+++ b/packages/jazz-tools/src/runtime/native-row-format.ts
@@ -3,15 +3,6 @@ import { isProvenanceMagicTimestampColumn } from "../magic-columns.js";
 
 const textDecoder = new TextDecoder();
 
-type Reader = {
-  data: Uint8Array;
-  view: DataView;
-};
-
-function readU32(reader: Reader, offset: number): number {
-  return reader.view.getUint32(offset, true);
-}
-
 function uuidString(bytes: Uint8Array): string {
   const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(

--- a/packages/jazz-tools/src/runtime/subscription-manager.test.ts
+++ b/packages/jazz-tools/src/runtime/subscription-manager.test.ts
@@ -70,13 +70,15 @@ function nativeAddedRecord(id: string, index: number, name: string, count: numbe
 }
 
 describe("SubscriptionManager", () => {
-  it("passes delta by reference (zero-copy)", () => {
+  it("transforms wire deltas into typed deltas", () => {
     const manager = new SubscriptionManager<TestItem>();
     const input = makeDelta([{ kind: 0, id: "1", index: 0, row: makeRow("1", "item1", 10) }]);
 
     const result = manager.handleDelta(input, transform);
 
-    expect(result.delta).toBe(input);
+    expect(result.delta).toEqual([
+      { kind: 0, id: "1", index: 0, item: { id: "1", name: "item1", count: 10 } },
+    ]);
     expect(result.all.map((item) => item.id)).toEqual(["1"]);
   });
 
@@ -117,7 +119,37 @@ describe("SubscriptionManager", () => {
         kind: 0,
         id,
         index: 0,
-        row: makeRow(id, "native", 42),
+        item: { id, name: "native", count: 42 },
+      },
+    ]);
+  });
+
+  it("decodes native subscription additions directly to typed rows", () => {
+    const manager = new SubscriptionManager<TestItem>();
+    const id = "00000000-0000-4000-8000-000000000002";
+    const delta: NativeRowDelta = {
+      __jazzNativeRowDelta: true,
+      added: nativeAddedRecord(id, 0, "direct", 7),
+      removed: new Uint8Array(),
+      updated: new Uint8Array(),
+      addedCount: 1,
+      removedCount: 0,
+      updatedCount: 0,
+    };
+
+    const result = manager.handleDelta(delta, transform, nativeColumns, (row) => ({
+      id: row.id as string,
+      name: row.name as string,
+      count: row.count as number,
+    }));
+
+    expect(result.all).toEqual([{ id, name: "direct", count: 7 }]);
+    expect(result.delta).toEqual([
+      {
+        kind: 0,
+        id,
+        index: 0,
+        item: { id, name: "direct", count: 7 },
       },
     ]);
   });
@@ -135,7 +167,12 @@ describe("SubscriptionManager", () => {
       transform,
     );
 
-    expect(result.delta[0]).toEqual({ kind: 2, id: "1", index: 0, row: makeRow("1", "item1", 15) });
+    expect(result.delta[0]).toEqual({
+      kind: 2,
+      id: "1",
+      index: 0,
+      item: { id: "1", name: "item1", count: 15 },
+    });
     expect(result.all[0]!.count).toBe(15);
   });
 

--- a/packages/jazz-tools/src/runtime/subscription-manager.test.ts
+++ b/packages/jazz-tools/src/runtime/subscription-manager.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect } from "vitest";
 import { SubscriptionManager } from "./subscription-manager.js";
-import type { WasmRow, RowDelta } from "../drivers/types.js";
+import type { ColumnDescriptor, NativeRowDelta, WasmRow, RowDelta } from "../drivers/types.js";
 
 interface TestItem {
   id: string;
@@ -34,6 +34,41 @@ function makeDelta(changes: RowDelta = []): RowDelta {
   return changes;
 }
 
+const nativeColumns: ColumnDescriptor[] = [
+  { name: "name", column_type: { type: "Text" }, nullable: false },
+  { name: "count", column_type: { type: "Integer" }, nullable: false },
+];
+
+function uuidBytes(id: string): Uint8Array {
+  return Uint8Array.from(
+    id
+      .replaceAll("-", "")
+      .match(/../g)!
+      .map((hex) => Number.parseInt(hex, 16)),
+  );
+}
+
+function pushU32(target: number[], value: number): void {
+  target.push(value & 0xff, (value >>> 8) & 0xff, (value >>> 16) & 0xff, (value >>> 24) & 0xff);
+}
+
+function nativeRowData(name: string, count: number): Uint8Array {
+  const text = new TextEncoder().encode(name);
+  const data = new Uint8Array(4 + text.byteLength);
+  new DataView(data.buffer).setInt32(0, count, true);
+  data.set(text, 4);
+  return data;
+}
+
+function nativeAddedRecord(id: string, index: number, name: string, count: number): Uint8Array {
+  const data = nativeRowData(name, count);
+  const bytes: number[] = [...uuidBytes(id)];
+  pushU32(bytes, index);
+  pushU32(bytes, data.byteLength);
+  bytes.push(...data);
+  return Uint8Array.from(bytes);
+}
+
 describe("SubscriptionManager", () => {
   it("passes delta by reference (zero-copy)", () => {
     const manager = new SubscriptionManager<TestItem>();
@@ -59,6 +94,32 @@ describe("SubscriptionManager", () => {
     expect(result.delta).toHaveLength(2);
     expect(result.all.map((item) => item.id)).toEqual(["1", "2"]);
     expect(manager.size).toBe(2);
+  });
+
+  it("decodes native subscription additions", () => {
+    const manager = new SubscriptionManager<TestItem>();
+    const id = "00000000-0000-4000-8000-000000000001";
+    const delta: NativeRowDelta = {
+      __jazzNativeRowDelta: true,
+      added: nativeAddedRecord(id, 0, "native", 42),
+      removed: new Uint8Array(),
+      updated: new Uint8Array(),
+      addedCount: 1,
+      removedCount: 0,
+      updatedCount: 0,
+    };
+
+    const result = manager.handleDelta(delta, transform, nativeColumns);
+
+    expect(result.all).toEqual([{ id, name: "native", count: 42 }]);
+    expect(result.delta).toEqual([
+      {
+        kind: 0,
+        id,
+        index: 0,
+        row: makeRow(id, "native", 42),
+      },
+    ]);
   });
 
   it("tracks content updates", () => {

--- a/packages/jazz-tools/src/runtime/subscription-manager.ts
+++ b/packages/jazz-tools/src/runtime/subscription-manager.ts
@@ -5,7 +5,14 @@
  * WASM row deltas into typed object deltas with full state tracking.
  */
 
-import type { WasmRow, RowDelta as WireRowDelta } from "../drivers/types.js";
+import type {
+  ColumnDescriptor,
+  NativeRowDelta,
+  SubscriptionWireDelta,
+  WasmRow,
+  RowDelta as WireRowDelta,
+} from "../drivers/types.js";
+import { decodeNativeRow } from "./native-row-format.js";
 
 const RowChangeKind = {
   Added: 0 as const,
@@ -63,7 +70,25 @@ export class SubscriptionManager<T extends { id: string }> {
    * @param transform Function to convert WasmRow to typed object T
    * @returns Typed delta with full state and changes
    */
-  handleDelta(delta: WireRowDelta, transform: (row: WasmRow) => T): SubscriptionDelta<T> {
+  handleDelta(
+    delta: SubscriptionWireDelta,
+    transform: (row: WasmRow) => T,
+    nativeColumns?: readonly ColumnDescriptor[],
+  ): SubscriptionDelta<T> {
+    if (isNativeRowDelta(delta)) {
+      if (!nativeColumns) {
+        throw new Error("Native subscription delta requires output columns for decoding");
+      }
+      return this.handleWireDelta(decodeNativeDelta(delta, nativeColumns), transform);
+    }
+
+    return this.handleWireDelta(delta, transform);
+  }
+
+  private handleWireDelta(
+    delta: WireRowDelta,
+    transform: (row: WasmRow) => T,
+  ): SubscriptionDelta<T> {
     delta.sort((a, b) => a.index - b.index);
 
     for (const change of delta) {
@@ -114,4 +139,90 @@ export class SubscriptionManager<T extends { id: string }> {
   get size(): number {
     return this.currentResults.size;
   }
+}
+
+function isNativeRowDelta(delta: SubscriptionWireDelta): delta is NativeRowDelta {
+  return !Array.isArray(delta) && delta.__jazzNativeRowDelta === true;
+}
+
+function readUuid(bytes: Uint8Array, offset: number): string {
+  const hex = Array.from(bytes.subarray(offset, offset + 16), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(
+    16,
+    20,
+  )}-${hex.slice(20)}`;
+}
+
+function decodeNativeDelta(
+  native: NativeRowDelta,
+  columns: readonly ColumnDescriptor[],
+): WireRowDelta {
+  const delta: WireRowDelta = [];
+
+  {
+    const bytes = native.added;
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    let offset = 0;
+    for (let i = 0; i < native.addedCount; i++) {
+      const id = readUuid(bytes, offset);
+      offset += 16;
+      const index = view.getUint32(offset, true);
+      offset += 4;
+      const len = view.getUint32(offset, true);
+      offset += 4;
+      const data = bytes.subarray(offset, offset + len);
+      offset += len;
+      delta.push({
+        kind: RowChangeKind.Added,
+        id,
+        index,
+        row: decodeNativeRow(id, columns, data),
+      });
+    }
+  }
+
+  {
+    const bytes = native.removed;
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    let offset = 0;
+    for (let i = 0; i < native.removedCount; i++) {
+      const id = readUuid(bytes, offset);
+      offset += 16;
+      const index = view.getUint32(offset, true);
+      offset += 4;
+      delta.push({ kind: RowChangeKind.Removed, id, index });
+    }
+  }
+
+  {
+    const bytes = native.updated;
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    let offset = 0;
+    for (let i = 0; i < native.updatedCount; i++) {
+      const id = readUuid(bytes, offset);
+      offset += 16;
+      const index = view.getUint32(offset, true);
+      offset += 4;
+      const flags = bytes[offset] ?? 0;
+      offset += 1;
+      if (flags & 1) {
+        const len = view.getUint32(offset, true);
+        offset += 4;
+        const data = bytes.subarray(offset, offset + len);
+        offset += len;
+        delta.push({
+          kind: RowChangeKind.Updated,
+          id,
+          index,
+          row: decodeNativeRow(id, columns, data),
+        });
+      } else {
+        delta.push({ kind: RowChangeKind.Updated, id, index });
+      }
+    }
+  }
+
+  return delta;
 }

--- a/packages/jazz-tools/src/runtime/subscription-manager.ts
+++ b/packages/jazz-tools/src/runtime/subscription-manager.ts
@@ -12,7 +12,7 @@ import type {
   WasmRow,
   RowDelta as WireRowDelta,
 } from "../drivers/types.js";
-import { decodeNativeRow } from "./native-row-format.js";
+import { decodeNativeRow, decodeNativeRowObject } from "./native-row-format.js";
 
 const RowChangeKind = {
   Added: 0 as const,
@@ -74,10 +74,14 @@ export class SubscriptionManager<T extends { id: string }> {
     delta: SubscriptionWireDelta,
     transform: (row: WasmRow) => T,
     nativeColumns?: readonly ColumnDescriptor[],
+    nativeTransform?: (row: Record<string, unknown>) => T,
   ): SubscriptionDelta<T> {
     if (isNativeRowDelta(delta)) {
       if (!nativeColumns) {
         throw new Error("Native subscription delta requires output columns for decoding");
+      }
+      if (nativeTransform) {
+        return this.handleTypedDelta(decodeNativeTypedDelta(delta, nativeColumns, nativeTransform));
       }
       return this.handleWireDelta(decodeNativeDelta(delta, nativeColumns), transform);
     }
@@ -89,13 +93,38 @@ export class SubscriptionManager<T extends { id: string }> {
     delta: WireRowDelta,
     transform: (row: WasmRow) => T,
   ): SubscriptionDelta<T> {
+    return this.handleTypedDelta(
+      delta.map((change) => {
+        switch (change.kind) {
+          case RowChangeKind.Added:
+            return {
+              kind: RowChangeKind.Added,
+              id: change.id,
+              index: change.index,
+              item: transform(change.row),
+            };
+          case RowChangeKind.Removed:
+            return change;
+          case RowChangeKind.Updated:
+            return {
+              kind: RowChangeKind.Updated,
+              id: change.id,
+              index: change.index,
+              item: change.row ? transform(change.row) : undefined,
+            };
+        }
+      }),
+    );
+  }
+
+  private handleTypedDelta(delta: RowDelta<T>[]): SubscriptionDelta<T> {
     delta.sort((a, b) => a.index - b.index);
 
     for (const change of delta) {
       switch (change.kind) {
         case RowChangeKind.Added:
           const alreadyPresent = this.currentResults.has(change.id);
-          this.currentResults.set(change.id, transform(change.row));
+          this.currentResults.set(change.id, change.item);
           if (alreadyPresent) {
             this.removeId(change.id);
           }
@@ -108,8 +137,8 @@ export class SubscriptionManager<T extends { id: string }> {
         case RowChangeKind.Updated:
           this.removeId(change.id);
           this.insertIdAt(change.id, change.index);
-          if (change.row) {
-            this.currentResults.set(change.id, transform(change.row));
+          if (change.item !== undefined) {
+            this.currentResults.set(change.id, change.item);
           }
           break;
       }
@@ -119,7 +148,7 @@ export class SubscriptionManager<T extends { id: string }> {
       all: this.orderedIds
         .map((id) => this.currentResults.get(id))
         .filter((item): item is T => item !== undefined),
-      delta: delta as RowDelta<T>[],
+      delta,
     };
   }
 
@@ -139,6 +168,79 @@ export class SubscriptionManager<T extends { id: string }> {
   get size(): number {
     return this.currentResults.size;
   }
+}
+
+function decodeNativeTypedDelta<T extends { id: string }>(
+  native: NativeRowDelta,
+  columns: readonly ColumnDescriptor[],
+  transform: (row: Record<string, unknown>) => T,
+): RowDelta<T>[] {
+  const delta: RowDelta<T>[] = [];
+
+  {
+    const bytes = native.added;
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    let offset = 0;
+    for (let i = 0; i < native.addedCount; i++) {
+      const id = readUuid(bytes, offset);
+      offset += 16;
+      const index = view.getUint32(offset, true);
+      offset += 4;
+      const len = view.getUint32(offset, true);
+      offset += 4;
+      const data = bytes.subarray(offset, offset + len);
+      offset += len;
+      delta.push({
+        kind: RowChangeKind.Added,
+        id,
+        index,
+        item: transform(decodeNativeRowObject(id, columns, data)),
+      });
+    }
+  }
+
+  {
+    const bytes = native.removed;
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    let offset = 0;
+    for (let i = 0; i < native.removedCount; i++) {
+      const id = readUuid(bytes, offset);
+      offset += 16;
+      const index = view.getUint32(offset, true);
+      offset += 4;
+      delta.push({ kind: RowChangeKind.Removed, id, index });
+    }
+  }
+
+  {
+    const bytes = native.updated;
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    let offset = 0;
+    for (let i = 0; i < native.updatedCount; i++) {
+      const id = readUuid(bytes, offset);
+      offset += 16;
+      const index = view.getUint32(offset, true);
+      offset += 4;
+      const flags = bytes[offset] ?? 0;
+      offset += 1;
+      if (flags & 1) {
+        const len = view.getUint32(offset, true);
+        offset += 4;
+        const data = bytes.subarray(offset, offset + len);
+        offset += len;
+        delta.push({
+          kind: RowChangeKind.Updated,
+          id,
+          index,
+          item: transform(decodeNativeRowObject(id, columns, data)),
+        });
+      } else {
+        delta.push({ kind: RowChangeKind.Updated, id, index });
+      }
+    }
+  }
+
+  return delta;
 }
 
 function isNativeRowDelta(delta: SubscriptionWireDelta): delta is NativeRowDelta {


### PR DESCRIPTION
## Summary

Stack PR 6 of the Jazz load-performance split. This slice moves subscription snapshot and delta delivery across the WASM boundary in native row format so JavaScript can decode rows directly.

The goal is to avoid eager Rust/WASM object materialization for subscription rows and let the JS side decode with schema descriptors it already knows.

## What changed

- Adds native binary subscription delta payloads for added, removed, and updated rows.
- Fast-paths initial subscription snapshots using ordered native row deltas.
- Adds JS native row decoding, including typed-object fast paths where no projection/include transform is needed.
- Handles projected subscriptions, includes, nullable selected columns, and permission/provenance magic columns by building the JS decode descriptor from the actual query output shape.
- Removes unused native row reader helper code after the decode path moved.

## Review notes

- The native decode descriptor intentionally follows the query output descriptor, not just the full table schema, because projected/include subscription rows are encoded in output shape.

## Validation

- `pnpm --filter jazz-tools exec tsc --noEmit --pretty false`
- `pnpm exec oxfmt --ignore-path .oxfmtignore . packages/jazz-tools/src/runtime/db.ts && pnpm exec oxlint packages/jazz-tools/src/runtime/db.ts`
- GitHub CI passed: `lint`, `test-rust`, `test-ts`, and Vercel docs. Inspector was pending at merge time under the authorized core-CI merge flow.
