### PR TITLE
Stack 07: Optimize sync replay storage hot paths

### DIFF
--- a/crates/jazz-tools/src/batch_fate.rs
+++ b/crates/jazz-tools/src/batch_fate.rs
@@ -2,6 +2,7 @@ use crate::digest::Digest32;
 use blake3::Hasher;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
+use std::sync::OnceLock;
 
 use crate::object::{BranchName, ObjectId};
 use crate::query_manager::types::SchemaHash;
@@ -150,7 +151,7 @@ impl BatchFate {
         };
 
         encode_row(
-            &batch_fate_storage_descriptor(),
+            batch_fate_storage_descriptor(),
             &[
                 Value::Text(kind.to_string()),
                 Value::BatchId(*self.batch_id().as_bytes()),
@@ -164,7 +165,7 @@ impl BatchFate {
     }
 
     pub fn decode_storage_row(bytes: &[u8]) -> Result<Self, String> {
-        let values = decode_row(&batch_fate_storage_descriptor(), bytes)
+        let values = decode_row(batch_fate_storage_descriptor(), bytes)
             .map_err(|err| format!("decode batch fate row: {err}"))?;
         let [
             kind,
@@ -867,45 +868,48 @@ fn sealed_batch_submission_storage_descriptor() -> RowDescriptor {
     ])
 }
 
-fn batch_fate_storage_descriptor() -> RowDescriptor {
-    RowDescriptor::new(vec![
-        ColumnDescriptor::new(
-            "kind",
-            ColumnType::Enum {
-                variants: vec![
-                    "missing".to_string(),
-                    "rejected".to_string(),
-                    "durable_direct".to_string(),
-                    "accepted_transaction".to_string(),
-                ],
-            },
-        ),
-        ColumnDescriptor::new("batch_id", ColumnType::BatchId),
-        ColumnDescriptor::new("code", ColumnType::Text).nullable(),
-        ColumnDescriptor::new("reason", ColumnType::Text).nullable(),
-        ColumnDescriptor::new(
-            "confirmed_tier",
-            ColumnType::Enum {
-                variants: vec![
-                    "local".to_string(),
-                    "edge".to_string(),
-                    "global".to_string(),
-                ],
-            },
-        )
-        .nullable(),
-        ColumnDescriptor::new(
-            "visible_members",
-            ColumnType::Array {
-                element: Box::new(ColumnType::Row {
-                    columns: Box::new(RowDescriptor::new(vec![
-                        ColumnDescriptor::new("object_id", ColumnType::Bytea),
-                        ColumnDescriptor::new("branch_name", ColumnType::Text),
-                    ])),
-                }),
-            },
-        ),
-    ])
+fn batch_fate_storage_descriptor() -> &'static RowDescriptor {
+    static DESCRIPTOR: OnceLock<RowDescriptor> = OnceLock::new();
+    DESCRIPTOR.get_or_init(|| {
+        RowDescriptor::new(vec![
+            ColumnDescriptor::new(
+                "kind",
+                ColumnType::Enum {
+                    variants: vec![
+                        "missing".to_string(),
+                        "rejected".to_string(),
+                        "durable_direct".to_string(),
+                        "accepted_transaction".to_string(),
+                    ],
+                },
+            ),
+            ColumnDescriptor::new("batch_id", ColumnType::BatchId),
+            ColumnDescriptor::new("code", ColumnType::Text).nullable(),
+            ColumnDescriptor::new("reason", ColumnType::Text).nullable(),
+            ColumnDescriptor::new(
+                "confirmed_tier",
+                ColumnType::Enum {
+                    variants: vec![
+                        "local".to_string(),
+                        "edge".to_string(),
+                        "global".to_string(),
+                    ],
+                },
+            )
+            .nullable(),
+            ColumnDescriptor::new(
+                "visible_members",
+                ColumnType::Array {
+                    element: Box::new(ColumnType::Row {
+                        columns: Box::new(RowDescriptor::new(vec![
+                            ColumnDescriptor::new("object_id", ColumnType::Bytea),
+                            ColumnDescriptor::new("branch_name", ColumnType::Text),
+                        ])),
+                    }),
+                },
+            ),
+        ])
+    })
 }
 
 #[cfg(test)]

--- a/crates/jazz-tools/src/query_manager/graph/execute.rs
+++ b/crates/jazz-tools/src/query_manager/graph/execute.rs
@@ -221,6 +221,34 @@ impl QueryGraph {
         }
     }
 
+    /// Mark multiple row IDs as updated, dirtying each materializer once.
+    pub fn mark_rows_updated(&mut self, ids: &AHashSet<ObjectId>) {
+        if ids.is_empty() {
+            return;
+        }
+
+        let materialize_node_ids: Vec<NodeId> = self
+            .nodes
+            .iter_mut()
+            .enumerate()
+            .filter_map(|(idx, compact)| {
+                if let GraphNode::Materialize(mat_node) = &mut compact.node {
+                    for id in ids {
+                        mat_node.mark_updated(*id);
+                    }
+                    Some(NodeId(idx as u64))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        for node_id in materialize_node_ids {
+            self.mark_dirty(node_id);
+            self.mark_downstream_dirty(node_id);
+        }
+    }
+
     /// Mark a row ID as deleted for removal delta emission.
     /// This tells MaterializeNodes to emit a removal delta for this row.
     pub fn mark_row_deleted(&mut self, id: ObjectId) {
@@ -240,6 +268,34 @@ impl QueryGraph {
             .collect();
 
         // Second pass: mark dirty and propagate downstream
+        for node_id in materialize_node_ids {
+            self.mark_dirty(node_id);
+            self.mark_downstream_dirty(node_id);
+        }
+    }
+
+    /// Mark multiple row IDs as deleted, dirtying each materializer once.
+    pub fn mark_rows_deleted(&mut self, ids: &AHashSet<ObjectId>) {
+        if ids.is_empty() {
+            return;
+        }
+
+        let materialize_node_ids: Vec<NodeId> = self
+            .nodes
+            .iter_mut()
+            .enumerate()
+            .filter_map(|(idx, compact)| {
+                if let GraphNode::Materialize(mat_node) = &mut compact.node {
+                    for id in ids {
+                        mat_node.mark_deleted(*id);
+                    }
+                    Some(NodeId(idx as u64))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
         for node_id in materialize_node_ids {
             self.mark_dirty(node_id);
             self.mark_downstream_dirty(node_id);

--- a/crates/jazz-tools/src/query_manager/graph_nodes/materialize.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/materialize.rs
@@ -21,8 +21,8 @@ pub struct MaterializeNode {
     output_descriptor: TupleDescriptor,
     /// Descriptor for the row format (for backward compatibility).
     descriptor: RowDescriptor,
-    /// Which elements to materialize (indices).
-    elements_to_materialize: HashSet<usize>,
+    /// Which elements to materialize, indexed by tuple element position.
+    elements_to_materialize: Vec<bool>,
     /// Current materialized rows, keyed by ObjectId.
     rows: AHashMap<ObjectId, Row>,
     /// Current tuples (fully or partially materialized).
@@ -58,10 +58,16 @@ impl MaterializeNode {
             .clone()
             .with_materialized(&elements_to_materialize);
         let descriptor = input_desc.combined_descriptor();
+        let mut materialize_flags = vec![false; input_desc.element_count()];
+        for index in elements_to_materialize {
+            if let Some(flag) = materialize_flags.get_mut(index) {
+                *flag = true;
+            }
+        }
         Self {
             output_descriptor,
             descriptor,
-            elements_to_materialize,
+            elements_to_materialize: materialize_flags,
             rows: AHashMap::new(),
             current_tuples: AHashSet::new(),
             current_tuples_by_id: AHashMap::new(),
@@ -124,7 +130,10 @@ impl MaterializeNode {
 
     /// Check if an element should be materialized.
     fn should_materialize(&self, element_index: usize) -> bool {
-        self.elements_to_materialize.contains(&element_index)
+        self.elements_to_materialize
+            .get(element_index)
+            .copied()
+            .unwrap_or(false)
     }
 
     /// Mark an ID for content update checking (only if we're tracking it).

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -227,6 +227,88 @@ pub enum LocalUpdates {
     Deferred,
 }
 
+#[derive(Debug, Clone, Copy)]
+enum SubscriptionRowMark {
+    Updated,
+    Deleted,
+    UpdatedAndDeleted,
+}
+
+#[derive(Debug, Clone)]
+struct SubscriptionVisibilityEffect {
+    table: String,
+    row_id: ObjectId,
+    local_dirty: bool,
+    row_mark: SubscriptionRowMark,
+    local_row_overlay: bool,
+}
+
+#[derive(Debug, Default)]
+struct BatchedSubscriptionVisibilityEffects {
+    remote_dirty_tables: HashSet<String>,
+    local_dirty_tables: HashSet<String>,
+    remote_updated: HashMap<String, ahash::AHashSet<ObjectId>>,
+    local_updated: HashMap<String, ahash::AHashSet<ObjectId>>,
+    remote_deleted: HashMap<String, ahash::AHashSet<ObjectId>>,
+    local_deleted: HashMap<String, ahash::AHashSet<ObjectId>>,
+}
+
+impl BatchedSubscriptionVisibilityEffects {
+    fn push(&mut self, effect: SubscriptionVisibilityEffect) {
+        let SubscriptionVisibilityEffect {
+            table,
+            row_id,
+            local_dirty,
+            row_mark,
+            local_row_overlay,
+        } = effect;
+
+        if local_dirty {
+            self.local_dirty_tables.insert(table.clone());
+        } else {
+            self.remote_dirty_tables.insert(table.clone());
+        }
+
+        match (row_mark, local_row_overlay) {
+            (SubscriptionRowMark::Updated, true) => {
+                self.local_updated.entry(table).or_default().insert(row_id);
+            }
+            (SubscriptionRowMark::Updated, false) => {
+                self.remote_updated.entry(table).or_default().insert(row_id);
+            }
+            (SubscriptionRowMark::Deleted, true) => {
+                self.local_deleted.entry(table).or_default().insert(row_id);
+            }
+            (SubscriptionRowMark::Deleted, false) => {
+                self.remote_deleted.entry(table).or_default().insert(row_id);
+            }
+            (SubscriptionRowMark::UpdatedAndDeleted, true) => {
+                self.local_updated
+                    .entry(table.clone())
+                    .or_default()
+                    .insert(row_id);
+                self.local_deleted.entry(table).or_default().insert(row_id);
+            }
+            (SubscriptionRowMark::UpdatedAndDeleted, false) => {
+                self.remote_updated
+                    .entry(table.clone())
+                    .or_default()
+                    .insert(row_id);
+                self.remote_deleted.entry(table).or_default().insert(row_id);
+            }
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.remote_dirty_tables.is_empty()
+            && self.local_dirty_tables.is_empty()
+            && self.remote_updated.is_empty()
+            && self.local_updated.is_empty()
+            && self.remote_deleted.is_empty()
+            && self.local_deleted.is_empty()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ServerSubscriptionTelemetryGroup {
     #[serde(rename = "groupKey")]
@@ -1280,9 +1362,7 @@ impl QueryManager {
                 "processing row visibility changes"
             );
         }
-        for update in row_visibility_changes {
-            self.handle_row_update(storage, update);
-        }
+        self.handle_row_updates_batched(storage, row_visibility_changes);
 
         // 3. Process pending query unsubscriptions from downstream clients
         // before new subscriptions from the same tick. One-shot query helpers
@@ -1309,9 +1389,7 @@ impl QueryManager {
                 "processing row visibility changes from accepted permission checks"
             );
         }
-        for update in post_permission_row_visibility_changes {
-            self.handle_row_update(storage, update);
-        }
+        self.handle_row_updates_batched(storage, post_permission_row_visibility_changes);
         self.apply_pending_batch_fate_effects(storage);
 
         // 4c. Apply QuerySettled messages that do not depend on any earlier
@@ -1635,6 +1713,23 @@ impl QueryManager {
         local_update: bool,
         apply_index_mutations: bool,
     ) {
+        if let Some(effect) = self.prepare_row_update_with_origin(
+            storage,
+            update,
+            local_update,
+            apply_index_mutations,
+        ) {
+            self.apply_subscription_visibility_effect(effect);
+        }
+    }
+
+    fn prepare_row_update_with_origin(
+        &mut self,
+        storage: &mut dyn Storage,
+        update: RowVisibilityChange,
+        local_update: bool,
+        apply_index_mutations: bool,
+    ) -> Option<SubscriptionVisibilityEffect> {
         let original_table = update.row_locator.table.to_string();
         let branch = update.row.branch.as_str();
         let origin_schema_hash = update.row_locator.origin_schema_hash;
@@ -1656,7 +1751,7 @@ impl QueryManager {
                             "buffering row update for unknown schema hash; schema not yet known"
                         );
                         self.pending_row_visibility_changes.push(update);
-                        return;
+                        return None;
                     }
                 } else {
                     tracing::error!(
@@ -1666,7 +1761,7 @@ impl QueryManager {
                         "buffering row update for unknown branch; cannot parse schema hash"
                     );
                     self.pending_row_visibility_changes.push(update);
-                    return;
+                    return None;
                 }
             }
         };
@@ -1688,17 +1783,17 @@ impl QueryManager {
         let table_schema = if schema_hash == self.schema_context.current_hash {
             match self.schema.get(&table_name) {
                 Some(schema) => schema.clone(),
-                None => return,
+                None => return None,
             }
         } else if let Some(schema) = self.schema_context.get_schema(&schema_hash) {
             match schema.get(&table_name) {
                 Some(table_schema) => table_schema.clone(),
-                None => return,
+                None => return None,
             }
         } else if let Some(schema) = self.known_schemas.get(&schema_hash) {
             match schema.get(&table_name) {
                 Some(table_schema) => table_schema.clone(),
-                None => return,
+                None => return None,
             }
         } else {
             tracing::error!(
@@ -1708,7 +1803,7 @@ impl QueryManager {
                 "buffering row update because schema for branch is not available yet"
             );
             self.pending_row_visibility_changes.push(update);
-            return;
+            return None;
         };
 
         let descriptor = table_schema.columns.clone();
@@ -1750,7 +1845,7 @@ impl QueryManager {
         if self.visible_row_is_hard_deleted(storage, update.object_id, &update.row.branch)
             && !update.row.is_hard_deleted()
         {
-            return;
+            return None;
         }
 
         if update.row.is_hard_deleted() {
@@ -1766,17 +1861,13 @@ impl QueryManager {
                     table_schema.indexed_columns.as_deref(),
                 );
             }
-            if local_update {
-                self.mark_subscriptions_dirty_local(&logical_table);
-            } else {
-                self.mark_subscriptions_dirty(&logical_table);
-            }
-            if local_update {
-                self.mark_local_row_deleted_in_subscriptions(&logical_table, update.object_id);
-            } else {
-                self.mark_row_deleted_in_subscriptions(&logical_table, update.object_id);
-            }
-            return;
+            return Some(SubscriptionVisibilityEffect {
+                table: logical_table,
+                row_id: update.object_id,
+                local_dirty: local_update,
+                row_mark: SubscriptionRowMark::Deleted,
+                local_row_overlay: local_update,
+            });
         }
 
         if update.row.is_soft_deleted() {
@@ -1816,13 +1907,13 @@ impl QueryManager {
                     }
                 }
             }
-            if local_update {
-                self.mark_subscriptions_dirty_local(&logical_table);
-            } else {
-                self.mark_subscriptions_dirty(&logical_table);
-            }
-            self.mark_row_deleted_in_subscriptions(&logical_table, update.object_id);
-            return;
+            return Some(SubscriptionVisibilityEffect {
+                table: logical_table,
+                row_id: update.object_id,
+                local_dirty: local_update,
+                row_mark: SubscriptionRowMark::Deleted,
+                local_row_overlay: false,
+            });
         }
 
         let was_soft_deleted = old_row.is_some_and(StoredRowBatch::is_soft_deleted);
@@ -1848,17 +1939,13 @@ impl QueryManager {
                     "failed to update indices for synced undelete"
                 );
             }
-            if local_update {
-                self.mark_subscriptions_dirty_local(&logical_table);
-            } else {
-                self.mark_subscriptions_dirty(&logical_table);
-            }
-            if local_update {
-                self.mark_local_row_updated_in_subscriptions(&logical_table, update.object_id);
-            } else {
-                self.mark_row_updated_in_subscriptions(&logical_table, update.object_id);
-            }
-            return;
+            return Some(SubscriptionVisibilityEffect {
+                table: logical_table,
+                row_id: update.object_id,
+                local_dirty: local_update,
+                row_mark: SubscriptionRowMark::Updated,
+                local_row_overlay: local_update,
+            });
         }
 
         if old_row.is_none() {
@@ -1907,12 +1994,13 @@ impl QueryManager {
         }
 
         if local_update {
-            self.mark_subscriptions_dirty_local(&logical_table);
-        } else {
-            self.mark_subscriptions_dirty(&logical_table);
-        }
-        if local_update {
-            self.mark_local_row_updated_in_subscriptions(&logical_table, update.object_id);
+            Some(SubscriptionVisibilityEffect {
+                table: logical_table,
+                row_id: update.object_id,
+                local_dirty: true,
+                row_mark: SubscriptionRowMark::Updated,
+                local_row_overlay: true,
+            })
         } else {
             let self_referential_table_update = old_row.is_some()
                 && table_schema.columns.columns.iter().any(|column| {
@@ -1931,9 +2019,21 @@ impl QueryManager {
                     new_data,
                 )
             {
-                self.mark_row_deleted_in_subscriptions(&logical_table, update.object_id);
+                return Some(SubscriptionVisibilityEffect {
+                    table: logical_table,
+                    row_id: update.object_id,
+                    local_dirty: false,
+                    row_mark: SubscriptionRowMark::UpdatedAndDeleted,
+                    local_row_overlay: false,
+                });
             }
-            self.mark_row_updated_in_subscriptions(&logical_table, update.object_id);
+            Some(SubscriptionVisibilityEffect {
+                table: logical_table,
+                row_id: update.object_id,
+                local_dirty: false,
+                row_mark: SubscriptionRowMark::Updated,
+                local_row_overlay: false,
+            })
         }
     }
 
@@ -2031,6 +2131,61 @@ impl QueryManager {
     ) {
         self.handle_row_update_with_origin(storage, update, false, true);
     }
+
+    fn handle_row_updates_batched(
+        &mut self,
+        storage: &mut dyn Storage,
+        updates: Vec<RowVisibilityChange>,
+    ) {
+        if updates.is_empty() {
+            return;
+        }
+
+        let mut effects = BatchedSubscriptionVisibilityEffects::default();
+        for update in updates {
+            if let Some(effect) = self.prepare_row_update_with_origin(storage, update, false, true)
+            {
+                effects.push(effect);
+            }
+        }
+        self.apply_batched_subscription_visibility_effects(effects);
+    }
+
+    fn apply_subscription_visibility_effect(&mut self, effect: SubscriptionVisibilityEffect) {
+        let mut effects = BatchedSubscriptionVisibilityEffects::default();
+        effects.push(effect);
+        self.apply_batched_subscription_visibility_effects(effects);
+    }
+
+    fn apply_batched_subscription_visibility_effects(
+        &mut self,
+        effects: BatchedSubscriptionVisibilityEffects,
+    ) {
+        if effects.is_empty() {
+            return;
+        }
+
+        for table in &effects.remote_dirty_tables {
+            self.mark_subscriptions_dirty(table);
+        }
+        for table in &effects.local_dirty_tables {
+            self.mark_subscriptions_dirty_local(table);
+        }
+
+        for (table, ids) in &effects.remote_updated {
+            self.mark_rows_updated_in_subscriptions(table, ids, false);
+        }
+        for (table, ids) in &effects.local_updated {
+            self.mark_rows_updated_in_subscriptions(table, ids, true);
+        }
+        for (table, ids) in &effects.remote_deleted {
+            self.mark_rows_deleted_in_subscriptions(table, ids, false);
+        }
+        for (table, ids) in &effects.local_deleted {
+            self.mark_rows_deleted_in_subscriptions(table, ids, true);
+        }
+    }
+
     /// Mark subscriptions dirty for a table based on update origin.
     fn mark_subscriptions_dirty_with_origin(&mut self, table: &str, local_update: bool) {
         // Mark local subscriptions dirty
@@ -2064,20 +2219,25 @@ impl QueryManager {
         self.mark_subscriptions_dirty_with_origin(table, true);
     }
 
-    /// Mark a row as updated in all subscriptions for a table.
-    /// This triggers content change detection during settle().
-    /// Checks all tables involved in the subscription (including joined tables).
-    pub(crate) fn mark_row_updated_in_subscriptions(&mut self, table: &str, id: ObjectId) {
-        // Mark local subscriptions
+    fn mark_rows_updated_in_subscriptions(
+        &mut self,
+        table: &str,
+        ids: &ahash::AHashSet<ObjectId>,
+        local_overlay: bool,
+    ) {
         for subscription in self.subscriptions.values_mut() {
             if Self::subscription_involves_table(&subscription.graph, table) {
-                subscription.graph.mark_row_updated(id);
+                subscription.graph.mark_rows_updated(ids);
+                if local_overlay {
+                    subscription
+                        .pending_local_row_ids
+                        .extend(ids.iter().copied());
+                }
             }
         }
-        // Mark server subscriptions (serving downstream clients)
         for server_sub in self.server_subscriptions.values_mut() {
             if Self::subscription_involves_table(&server_sub.graph, table) {
-                server_sub.graph.mark_row_updated(id);
+                server_sub.graph.mark_rows_updated(ids);
             }
         }
     }
@@ -2096,20 +2256,25 @@ impl QueryManager {
         }
     }
 
-    /// Mark a row as deleted in all subscriptions for a table.
-    /// This triggers removal delta emission during settle().
-    /// Checks all tables involved in the subscription (including joined tables).
-    pub(super) fn mark_row_deleted_in_subscriptions(&mut self, table: &str, id: ObjectId) {
-        // Mark local subscriptions
+    fn mark_rows_deleted_in_subscriptions(
+        &mut self,
+        table: &str,
+        ids: &ahash::AHashSet<ObjectId>,
+        local_overlay: bool,
+    ) {
         for subscription in self.subscriptions.values_mut() {
             if Self::subscription_involves_table(&subscription.graph, table) {
-                subscription.graph.mark_row_deleted(id);
+                subscription.graph.mark_rows_deleted(ids);
+                if local_overlay {
+                    subscription
+                        .pending_local_row_ids
+                        .extend(ids.iter().copied());
+                }
             }
         }
-        // Mark server subscriptions (serving downstream clients)
         for server_sub in self.server_subscriptions.values_mut() {
             if Self::subscription_involves_table(&server_sub.graph, table) {
-                server_sub.graph.mark_row_deleted(id);
+                server_sub.graph.mark_rows_deleted(ids);
             }
         }
     }

--- a/crates/jazz-tools/src/row_format.rs
+++ b/crates/jazz-tools/src/row_format.rs
@@ -708,7 +708,7 @@ fn encode_variable_value(buf: &mut Vec<u8>, col: &ColumnDescriptor, val: &Value)
     match val {
         Value::Text(s) => buf.extend_from_slice(s.as_bytes()),
         Value::Bytea(bytes) => buf.extend_from_slice(bytes),
-        Value::Array(elements) => buf.extend(encode_array(elements, &col.column_type)),
+        Value::Array(elements) => encode_array_into(buf, elements, &col.column_type),
         Value::Row { id, values } => {
             // Encode row using its descriptor from the column type
             if let ColumnType::Row { columns: desc } = &col.column_type {
@@ -1396,17 +1396,23 @@ fn encode_array_simple(elements: &[Value]) -> Vec<u8> {
 /// The `array_type` parameter is needed to properly encode Row elements,
 /// which require their descriptor for encoding.
 pub fn encode_array(elements: &[Value], array_type: &ColumnType) -> Vec<u8> {
+    let mut result = Vec::new();
+    encode_array_into(&mut result, elements, array_type);
+    result
+}
+
+fn encode_array_into(buf: &mut Vec<u8>, elements: &[Value], array_type: &ColumnType) {
     let count = elements.len() as u32;
-    let mut result = count.to_le_bytes().to_vec();
+    buf.extend_from_slice(&count.to_le_bytes());
 
     if elements.is_empty() {
-        return result;
+        return;
     }
 
     // Get the element type from the array type
     let element_type = match array_type {
         ColumnType::Array { element: elem_type } => elem_type.as_ref(),
-        _ => return result, // Not an array type
+        _ => return, // Not an array type
     };
 
     // Check if element type is fixed-size
@@ -1415,7 +1421,7 @@ pub fn encode_array(elements: &[Value], array_type: &ColumnType) -> Vec<u8> {
     if is_fixed {
         // Fixed-size elements: just concatenate encoded values (no offset table)
         for elem in elements {
-            result.extend(encode_value_with_type(elem, element_type));
+            encode_value_with_type_into(buf, elem, element_type);
         }
     } else {
         // Variable-length elements: build offset table (skip first) + data
@@ -1428,16 +1434,30 @@ pub fn encode_array(elements: &[Value], array_type: &ColumnType) -> Vec<u8> {
         let mut offset: u32 = 0;
         for data in &element_data[..element_data.len().saturating_sub(1)] {
             offset += data.len() as u32;
-            result.extend(offset.to_le_bytes());
+            buf.extend(offset.to_le_bytes());
         }
 
         // Append element data
         for data in element_data {
-            result.extend(data);
+            buf.extend(data);
         }
     }
+}
 
-    result
+fn encode_value_with_type_into(buf: &mut Vec<u8>, value: &Value, col_type: &ColumnType) {
+    match (value, col_type) {
+        (Value::Text(raw), ColumnType::Enum { variants }) if col_type.fixed_size().is_some() => {
+            buf.push(encode_enum_variant_index(variants, raw).unwrap_or_else(|_| unreachable!()));
+        }
+        (Value::Integer(n), _) => buf.extend_from_slice(&n.to_le_bytes()),
+        (Value::BigInt(n), _) => buf.extend_from_slice(&n.to_le_bytes()),
+        (Value::Double(f), _) => buf.extend_from_slice(&f.to_le_bytes()),
+        (Value::Boolean(b), _) => buf.push(if *b { 1 } else { 0 }),
+        (Value::Timestamp(t), _) => buf.extend_from_slice(&t.to_le_bytes()),
+        (Value::Uuid(id), _) => buf.extend_from_slice(id.uuid().as_bytes()),
+        (Value::BatchId(bytes), _) => buf.extend_from_slice(bytes),
+        _ => buf.extend(encode_value_with_type(value, col_type)),
+    }
 }
 
 /// Decode an array from binary format.

--- a/crates/jazz-tools/src/row_format.rs
+++ b/crates/jazz-tools/src/row_format.rs
@@ -263,6 +263,214 @@ pub(crate) fn encode_row_with_layout(
     Ok(result)
 }
 
+/// Encode a destination row whose leading columns are supplied as values and
+/// whose remaining columns are projected from an already-encoded source row.
+///
+/// This is used by flat row-history storage: Jazz system columns are new, but
+/// user columns already arrive in native row format. Copying their encoded
+/// bytes avoids decode-then-reencode work on replay hot paths.
+pub(crate) fn encode_row_with_prefix_and_projected_tail(
+    dst_descriptor: &RowDescriptor,
+    dst_layout: &CompiledRowLayout,
+    prefix_values: &[Value],
+    src_descriptor: &RowDescriptor,
+    src_layout: &CompiledRowLayout,
+    src_data: &[u8],
+) -> Result<Vec<u8>, EncodingError> {
+    if prefix_values.len() > dst_descriptor.columns.len() {
+        return Err(EncodingError::ColumnCountMismatch {
+            expected: dst_descriptor.columns.len(),
+            actual: prefix_values.len(),
+        });
+    }
+    let projected_column_count = dst_descriptor.columns.len() - prefix_values.len();
+    if projected_column_count != src_descriptor.columns.len() {
+        return Err(EncodingError::ColumnCountMismatch {
+            expected: projected_column_count,
+            actual: src_descriptor.columns.len(),
+        });
+    }
+
+    let offset_table_size = dst_layout.variable_column_count.saturating_sub(1) * size_of::<u32>();
+    let estimated_prefix_var_data_len = dst_descriptor
+        .columns
+        .iter()
+        .zip(prefix_values.iter())
+        .filter(|(col, _)| col.column_type.is_variable())
+        .map(|(col, val)| estimated_variable_value_len(col, val))
+        .sum::<usize>();
+
+    let mut fixed_data = Vec::with_capacity(dst_layout.fixed_section_size);
+    let mut var_data = Vec::with_capacity(estimated_prefix_var_data_len + src_data.len());
+    let mut var_offsets: Vec<u32> = Vec::with_capacity(dst_layout.variable_column_count);
+
+    for (dst_col_index, dst_col) in dst_descriptor.columns.iter().enumerate() {
+        if dst_col.column_type.is_variable() {
+            continue;
+        }
+
+        if dst_col_index < prefix_values.len() {
+            let value = &prefix_values[dst_col_index];
+            validate_column_value(dst_col, value)?;
+            encode_fixed_value(&mut fixed_data, dst_col, value);
+        } else {
+            let src_col_index = dst_col_index - prefix_values.len();
+            copy_projected_fixed_column(
+                &mut fixed_data,
+                src_descriptor,
+                src_layout,
+                src_data,
+                src_col_index,
+                dst_col,
+            )?;
+        }
+    }
+
+    for (dst_col_index, dst_col) in dst_descriptor.columns.iter().enumerate() {
+        if !dst_col.column_type.is_variable() {
+            continue;
+        }
+
+        var_offsets.push(var_data.len() as u32);
+
+        if dst_col_index < prefix_values.len() {
+            let value = &prefix_values[dst_col_index];
+            validate_column_value(dst_col, value)?;
+            encode_variable_value(&mut var_data, dst_col, value);
+        } else {
+            let src_col_index = dst_col_index - prefix_values.len();
+            copy_projected_variable_column(
+                &mut var_data,
+                src_descriptor,
+                src_layout,
+                src_data,
+                src_col_index,
+                dst_col,
+            )?;
+        }
+    }
+
+    let mut result =
+        Vec::with_capacity(dst_layout.fixed_section_size + offset_table_size + var_data.len());
+    result.extend(fixed_data);
+    for offset in var_offsets.iter().skip(1) {
+        result.extend_from_slice(&offset.to_le_bytes());
+    }
+    result.extend(var_data);
+
+    Ok(result)
+}
+
+fn validate_column_value(col: &ColumnDescriptor, val: &Value) -> Result<(), EncodingError> {
+    if !val.is_null() && !value_matches_column_type(val, &col.column_type) {
+        return Err(EncodingError::TypeMismatch {
+            column: col.name.to_string(),
+            expected: col.column_type.clone(),
+            actual: val.column_type(),
+        });
+    }
+
+    if val.is_null() && !col.nullable {
+        return Err(EncodingError::NullNotAllowed {
+            column: col.name.to_string(),
+        });
+    }
+
+    if !val.is_null() {
+        validate_value_size(val, &col.column_type, col.name_str())?;
+    }
+
+    Ok(())
+}
+
+fn copy_projected_fixed_column(
+    fixed_data: &mut Vec<u8>,
+    src_descriptor: &RowDescriptor,
+    src_layout: &CompiledRowLayout,
+    src_data: &[u8],
+    src_col_index: usize,
+    dst_col: &ColumnDescriptor,
+) -> Result<(), EncodingError> {
+    let value_size =
+        dst_col
+            .column_type
+            .fixed_size()
+            .ok_or_else(|| EncodingError::MalformedData {
+                message: format!("destination column {} is not fixed-size", dst_col.name),
+            })?;
+
+    if src_data.is_empty() {
+        if dst_col.nullable {
+            fixed_data.push(0);
+            fixed_data.extend(std::iter::repeat_n(0, value_size));
+            return Ok(());
+        }
+        return Err(EncodingError::NullNotAllowed {
+            column: dst_col.name.to_string(),
+        });
+    }
+
+    let (bytes, is_null) =
+        column_bytes_internal_with_layout(src_descriptor, src_layout, src_data, src_col_index)?;
+
+    if dst_col.nullable {
+        if is_null {
+            fixed_data.push(0);
+            fixed_data.extend(std::iter::repeat_n(0, value_size));
+        } else {
+            fixed_data.push(1);
+            fixed_data.extend_from_slice(bytes);
+        }
+    } else if is_null {
+        return Err(EncodingError::NullNotAllowed {
+            column: dst_col.name.to_string(),
+        });
+    } else {
+        fixed_data.extend_from_slice(bytes);
+    }
+
+    Ok(())
+}
+
+fn copy_projected_variable_column(
+    var_data: &mut Vec<u8>,
+    src_descriptor: &RowDescriptor,
+    src_layout: &CompiledRowLayout,
+    src_data: &[u8],
+    src_col_index: usize,
+    dst_col: &ColumnDescriptor,
+) -> Result<(), EncodingError> {
+    if src_data.is_empty() {
+        if dst_col.nullable {
+            var_data.push(0);
+            return Ok(());
+        }
+        return Err(EncodingError::NullNotAllowed {
+            column: dst_col.name.to_string(),
+        });
+    }
+
+    let (bytes, is_null) =
+        column_bytes_internal_with_layout(src_descriptor, src_layout, src_data, src_col_index)?;
+
+    if dst_col.nullable {
+        if is_null {
+            var_data.push(0);
+        } else {
+            var_data.push(1);
+            var_data.extend_from_slice(bytes);
+        }
+    } else if is_null {
+        return Err(EncodingError::NullNotAllowed {
+            column: dst_col.name.to_string(),
+        });
+    } else {
+        var_data.extend_from_slice(bytes);
+    }
+
+    Ok(())
+}
+
 fn estimated_variable_value_len(col: &ColumnDescriptor, val: &Value) -> usize {
     let nullable_prefix = usize::from(col.nullable);
     if val.is_null() {
@@ -2542,6 +2750,71 @@ mod tests {
 
         assert_eq!(encoded, vec![2]);
         assert_eq!(decoded, vec![Value::Text("done".to_string())]);
+    }
+
+    #[test]
+    fn encode_prefix_and_projected_tail_matches_value_encoding() {
+        let src_descriptor = RowDescriptor::new(vec![
+            ColumnDescriptor::new("name", ColumnType::Text),
+            ColumnDescriptor::new("age", ColumnType::Integer).nullable(),
+            ColumnDescriptor::new(
+                "tags",
+                ColumnType::Array {
+                    element: Box::new(ColumnType::Text),
+                },
+            )
+            .nullable(),
+        ]);
+        let dst_descriptor = RowDescriptor::new(vec![
+            ColumnDescriptor::new("_jazz_updated_at", ColumnType::Timestamp),
+            ColumnDescriptor::new(
+                "_jazz_state",
+                ColumnType::Enum {
+                    variants: vec!["pending".to_string(), "visible".to_string()],
+                },
+            ),
+            ColumnDescriptor::new("name", ColumnType::Text).nullable(),
+            ColumnDescriptor::new("age", ColumnType::Integer).nullable(),
+            ColumnDescriptor::new(
+                "tags",
+                ColumnType::Array {
+                    element: Box::new(ColumnType::Text),
+                },
+            )
+            .nullable(),
+        ]);
+
+        let src_values = vec![
+            Value::Text("Alpha".to_string()),
+            Value::Integer(42),
+            Value::Array(vec![
+                Value::Text("one".to_string()),
+                Value::Text("two".to_string()),
+            ]),
+        ];
+        let prefix_values = vec![Value::Timestamp(1234), Value::Text("visible".to_string())];
+        let src_data = encode_row(&src_descriptor, &src_values).unwrap();
+        let dst_layout = compiled_row_layout(&dst_descriptor);
+        let src_layout = compiled_row_layout(&src_descriptor);
+        let projected = encode_row_with_prefix_and_projected_tail(
+            &dst_descriptor,
+            dst_layout.as_ref(),
+            &prefix_values,
+            &src_descriptor,
+            src_layout.as_ref(),
+            &src_data,
+        )
+        .unwrap();
+
+        let mut expected_values = prefix_values;
+        expected_values.extend(src_values);
+        let expected = encode_row(&dst_descriptor, &expected_values).unwrap();
+
+        assert_eq!(projected, expected);
+        assert_eq!(
+            decode_row(&dst_descriptor, &projected).unwrap(),
+            expected_values
+        );
     }
 
     #[test]

--- a/crates/jazz-tools/src/row_format.rs
+++ b/crates/jazz-tools/src/row_format.rs
@@ -300,9 +300,10 @@ pub(crate) fn encode_row_with_prefix_and_projected_tail(
         .map(|(col, val)| estimated_variable_value_len(col, val))
         .sum::<usize>();
 
-    let mut fixed_data = Vec::with_capacity(dst_layout.fixed_section_size);
     let mut var_data = Vec::with_capacity(estimated_prefix_var_data_len + src_data.len());
     let mut var_offsets: Vec<u32> = Vec::with_capacity(dst_layout.variable_column_count);
+    let mut result =
+        Vec::with_capacity(dst_layout.fixed_section_size + offset_table_size + var_data.capacity());
 
     for (dst_col_index, dst_col) in dst_descriptor.columns.iter().enumerate() {
         if dst_col.column_type.is_variable() {
@@ -312,11 +313,11 @@ pub(crate) fn encode_row_with_prefix_and_projected_tail(
         if dst_col_index < prefix_values.len() {
             let value = &prefix_values[dst_col_index];
             validate_column_value(dst_col, value)?;
-            encode_fixed_value(&mut fixed_data, dst_col, value);
+            encode_fixed_value(&mut result, dst_col, value);
         } else {
             let src_col_index = dst_col_index - prefix_values.len();
             copy_projected_fixed_column(
-                &mut fixed_data,
+                &mut result,
                 src_descriptor,
                 src_layout,
                 src_data,
@@ -350,9 +351,6 @@ pub(crate) fn encode_row_with_prefix_and_projected_tail(
         }
     }
 
-    let mut result =
-        Vec::with_capacity(dst_layout.fixed_section_size + offset_table_size + var_data.len());
-    result.extend(fixed_data);
     for offset in var_offsets.iter().skip(1) {
         result.extend_from_slice(&offset.to_le_bytes());
     }

--- a/crates/jazz-tools/src/row_histories/codecs.rs
+++ b/crates/jazz-tools/src/row_histories/codecs.rs
@@ -12,7 +12,8 @@ use crate::object::ObjectId;
 use crate::query_manager::types::{ColumnDescriptor, ColumnType, RowBytes, RowDescriptor, Value};
 use crate::row_format::{
     CompiledRowLayout, EncodingError, column_bytes_with_layout, column_is_null_with_layout,
-    compiled_row_layout, decode_row, encode_row_with_layout, project_row_with_layout,
+    compiled_row_layout, decode_row, encode_row_with_prefix_and_projected_tail,
+    project_row_with_layout,
 };
 use crate::sync_manager::DurabilityTier;
 
@@ -246,6 +247,7 @@ const VISIBLE_ROW_SYSTEM_COLUMN_COUNT: usize = 18;
 #[derive(Debug, Clone)]
 pub(crate) struct FlatRowCodecs {
     user_descriptor: Arc<RowDescriptor>,
+    user_layout: Arc<CompiledRowLayout>,
     history_descriptor: Arc<RowDescriptor>,
     history_layout: Arc<CompiledRowLayout>,
     history_user_projection: Vec<(usize, usize)>,
@@ -278,6 +280,7 @@ pub(crate) fn flat_row_codecs(user_descriptor: &RowDescriptor) -> Arc<FlatRowCod
     let user_projection_len = user_descriptor.columns.len();
     let codecs = Arc::new(FlatRowCodecs {
         user_descriptor: user_descriptor.clone(),
+        user_layout: compiled_row_layout(user_descriptor.as_ref()),
         history_layout: compiled_row_layout(history_descriptor.as_ref()),
         history_descriptor,
         history_user_projection: (0..user_projection_len)
@@ -339,13 +342,13 @@ pub fn encode_flat_history_row(
     row: &StoredRowBatch,
 ) -> Result<Vec<u8>, EncodingError> {
     let codecs = flat_row_codecs(user_descriptor);
-    let mut values = history_row_system_values(row);
-    values.extend(flat_user_values(user_descriptor, &row.data)?);
-
-    encode_row_with_layout(
+    encode_row_with_prefix_and_projected_tail(
         codecs.history_descriptor.as_ref(),
         codecs.history_layout.as_ref(),
-        &values,
+        &history_row_system_values(row),
+        user_descriptor,
+        codecs.user_layout.as_ref(),
+        &row.data,
     )
 }
 
@@ -366,12 +369,13 @@ pub fn encode_flat_visible_row_entry(
     entry: &VisibleRowEntry,
 ) -> Result<Vec<u8>, EncodingError> {
     let codecs = flat_row_codecs(user_descriptor);
-    let mut values = visible_row_system_values(entry);
-    values.extend(flat_user_values(user_descriptor, &entry.current_row.data)?);
-    encode_row_with_layout(
+    encode_row_with_prefix_and_projected_tail(
         codecs.visible_descriptor.as_ref(),
         codecs.visible_layout.as_ref(),
-        &values,
+        &visible_row_system_values(entry),
+        user_descriptor,
+        codecs.user_layout.as_ref(),
+        &entry.current_row.data,
     )
 }
 

--- a/crates/jazz-tools/src/row_histories/codecs.rs
+++ b/crates/jazz-tools/src/row_histories/codecs.rs
@@ -163,9 +163,7 @@ fn history_row_system_values(row: &StoredRowBatch) -> Vec<Value> {
     ]
 }
 
-fn history_row_system_column_count() -> usize {
-    history_row_system_columns().len()
-}
+const HISTORY_ROW_SYSTEM_COLUMN_COUNT: usize = 10;
 
 fn visible_row_system_columns() -> Vec<ColumnDescriptor> {
     let mut columns = vec![
@@ -243,9 +241,7 @@ fn visible_row_system_values(entry: &VisibleRowEntry) -> Vec<Value> {
     values
 }
 
-fn visible_row_system_column_count() -> usize {
-    visible_row_system_columns().len()
-}
+const VISIBLE_ROW_SYSTEM_COLUMN_COUNT: usize = 18;
 
 #[derive(Debug, Clone)]
 pub(crate) struct FlatRowCodecs {
@@ -277,8 +273,8 @@ pub(crate) fn flat_row_codecs(user_descriptor: &RowDescriptor) -> Arc<FlatRowCod
     let user_descriptor = Arc::new(user_descriptor.clone());
     let history_descriptor = Arc::new(history_row_physical_descriptor(user_descriptor.as_ref()));
     let visible_descriptor = Arc::new(visible_row_physical_descriptor(user_descriptor.as_ref()));
-    let history_system_count = history_row_system_column_count();
-    let visible_system_count = visible_row_system_column_count();
+    let history_system_count = HISTORY_ROW_SYSTEM_COLUMN_COUNT;
+    let visible_system_count = VISIBLE_ROW_SYSTEM_COLUMN_COUNT;
     let user_projection_len = user_descriptor.columns.len();
     let codecs = Arc::new(FlatRowCodecs {
         user_descriptor: user_descriptor.clone(),

--- a/crates/jazz-tools/src/row_histories/mutations.rs
+++ b/crates/jazz-tools/src/row_histories/mutations.rs
@@ -211,7 +211,7 @@ pub(crate) fn apply_row_batch_with_context<H: Storage>(
             &table,
             object_id,
             &branch,
-            context.user_descriptor.as_ref(),
+            context.user_descriptor().as_ref(),
         )?
     };
     let previous_visible = previous_entry
@@ -257,7 +257,7 @@ pub(crate) fn apply_row_batch_with_context<H: Storage>(
         patched_history.push(row.clone());
     }
     let current_entry =
-        visible_entry_from_history_rows(context.user_descriptor.as_ref(), &patched_history)
+        visible_entry_from_history_rows(context.user_descriptor().as_ref(), &patched_history)
             .map_err(|err| {
                 RowHistoryError::StorageError(StorageError::IoError(format!(
                     "rebuild visible entry after append: {err}"
@@ -354,7 +354,7 @@ pub fn patch_row_batch_state<H: Storage>(
         &table,
         object_id,
         &branch,
-        context.user_descriptor.as_ref(),
+        context.user_descriptor().as_ref(),
     )?;
     let previous_visible = previous_entry
         .as_ref()
@@ -378,13 +378,12 @@ pub fn patch_row_batch_state<H: Storage>(
     };
     *existing = patched_row.clone();
     let patched_entry =
-        visible_entry_from_history_rows(context.user_descriptor.as_ref(), &history_rows).map_err(
-            |err| {
+        visible_entry_from_history_rows(context.user_descriptor().as_ref(), &history_rows)
+            .map_err(|err| {
                 RowHistoryError::StorageError(StorageError::IoError(format!(
                     "rebuild visible entry after patch: {err}"
                 )))
-            },
-        )?;
+            })?;
     let visible_entries: Vec<_> = patched_entry.iter().cloned().collect();
     if patched_entry.is_some() {
         io.apply_row_mutation(

--- a/crates/jazz-tools/src/row_histories/mutations.rs
+++ b/crates/jazz-tools/src/row_histories/mutations.rs
@@ -230,39 +230,45 @@ pub(crate) fn apply_row_batch_with_context<H: Storage>(
         }
     }
 
-    let mut patched_history = if is_known_new_object {
-        Vec::new()
+    let current_entry = if is_known_new_object {
+        visible_entry_from_history_rows(
+            context.user_descriptor().as_ref(),
+            std::slice::from_ref(&row),
+        )
+        .map_err(|err| {
+            RowHistoryError::StorageError(StorageError::IoError(format!(
+                "rebuild visible entry after append: {err}"
+            )))
+        })?
     } else {
-        load_branch_history(io, &table, object_id, &branch)?
-    };
+        let mut patched_history = load_branch_history(io, &table, object_id, &branch)?;
 
-    if !is_known_new_object
-        && let Some(existing_row) = io
+        if let Some(existing_row) = io
             .load_history_row_batch(&table, branch_name.as_str(), object_id, batch_id)
             .map_err(RowHistoryError::StorageError)?
-        && existing_row == row
-    {
-        return Ok(ApplyRowBatchResult {
-            batch_id,
-            row_locator,
-            visibility_change: None,
-        });
-    }
-    if let Some(existing) = patched_history
-        .iter_mut()
-        .find(|candidate| candidate.batch_id() == batch_id)
-    {
-        *existing = row.clone();
-    } else {
-        patched_history.push(row.clone());
-    }
-    let current_entry =
+            && existing_row == row
+        {
+            return Ok(ApplyRowBatchResult {
+                batch_id,
+                row_locator,
+                visibility_change: None,
+            });
+        }
+        if let Some(existing) = patched_history
+            .iter_mut()
+            .find(|candidate| candidate.batch_id() == batch_id)
+        {
+            *existing = row.clone();
+        } else {
+            patched_history.push(row.clone());
+        }
         visible_entry_from_history_rows(context.user_descriptor().as_ref(), &patched_history)
             .map_err(|err| {
                 RowHistoryError::StorageError(StorageError::IoError(format!(
                     "rebuild visible entry after append: {err}"
                 )))
-            })?;
+            })?
+    };
     let current_visible = current_entry
         .as_ref()
         .map(|entry| entry.current_row.clone());

--- a/crates/jazz-tools/src/runtime_core/ticks.rs
+++ b/crates/jazz-tools/src/runtime_core/ticks.rs
@@ -866,10 +866,6 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                 .copied()
                 .unwrap_or(next_expected.saturating_sub(1));
             for (sequence, msg) in ready_messages {
-                let is_query_settled = matches!(
-                    &msg.payload,
-                    crate::sync_manager::SyncPayload::QuerySettled { .. }
-                );
                 if msg.payload.writes_storage() {
                     self.mark_storage_write_pending_flush();
                 }
@@ -877,18 +873,6 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                 applied_messages += 1;
                 applied_since_last_tick = true;
                 last_applied = sequence;
-
-                // QuerySettled is an ordered stream barrier for first-callback
-                // delivery. If we queue many later rows before ticking, an
-                // early settled query waits behind unrelated replay work that
-                // merely arrived in the same transport drain.
-                if is_query_settled {
-                    self.next_expected_server_seq
-                        .insert(server_id, sequence.saturating_add(1));
-                    self.last_applied_server_seq.insert(server_id, last_applied);
-                    self.immediate_tick();
-                    applied_since_last_tick = false;
-                }
             }
             self.next_expected_server_seq
                 .insert(server_id, next_expected);

--- a/crates/jazz-tools/src/storage/memory.rs
+++ b/crates/jazz-tools/src/storage/memory.rs
@@ -73,6 +73,19 @@ impl MemoryStorage {
         self.ensured_raw_table_headers.insert(raw_table.to_string());
         Ok(())
     }
+
+    fn ensure_cached_row_raw_table_header(
+        &mut self,
+        raw_table: &str,
+        row_raw_table_id: &RowRawTableId,
+        user_descriptor: &RowDescriptor,
+    ) -> Result<(), StorageError> {
+        if self.ensured_raw_table_headers.contains(raw_table) {
+            return Ok(());
+        }
+        let header = row_raw_table_header(row_raw_table_id, user_descriptor);
+        self.ensure_cached_raw_table_header(raw_table, &header)
+    }
 }
 
 impl Default for MemoryStorage {
@@ -131,9 +144,10 @@ impl Storage for MemoryStorage {
         let table = table.to_string();
 
         for (row, encoded) in history_rows.iter().zip(encoded_history_rows) {
-            self.ensure_cached_raw_table_header(
+            self.ensure_cached_row_raw_table_header(
                 encoded.row_raw_table.as_str(),
-                &row_raw_table_header(&encoded.row_raw_table_id, &encoded.user_descriptor),
+                &encoded.row_raw_table_id,
+                &encoded.user_descriptor,
             )?;
             if encoded.needs_exact_locator {
                 self.put_history_row_batch_table_locator(
@@ -166,9 +180,10 @@ impl Storage for MemoryStorage {
         }
 
         for (entry, encoded) in visible_entries.iter().zip(encoded_visible_rows) {
-            self.ensure_cached_raw_table_header(
+            self.ensure_cached_row_raw_table_header(
                 encoded.row_raw_table.as_str(),
-                &row_raw_table_header(&encoded.row_raw_table_id, &encoded.user_descriptor),
+                &encoded.row_raw_table_id,
+                &encoded.user_descriptor,
             )?;
             if encoded.needs_exact_locator {
                 self.put_visible_row_table_locator(
@@ -206,9 +221,10 @@ impl Storage for MemoryStorage {
         let table = table.to_string();
 
         for row in history_rows {
-            self.ensure_cached_raw_table_header(
+            self.ensure_cached_row_raw_table_header(
                 row.row_raw_table.as_str(),
-                &row_raw_table_header(&row.row_raw_table_id, &row.user_descriptor),
+                &row.row_raw_table_id,
+                &row.user_descriptor,
             )?;
             if row.needs_exact_locator {
                 self.put_history_row_batch_table_locator(
@@ -249,9 +265,10 @@ impl Storage for MemoryStorage {
         }
 
         for row in visible_rows {
-            self.ensure_cached_raw_table_header(
+            self.ensure_cached_row_raw_table_header(
                 row.row_raw_table.as_str(),
-                &row_raw_table_header(&row.row_raw_table_id, &row.user_descriptor),
+                &row.row_raw_table_id,
+                &row.user_descriptor,
             )?;
             if row.needs_exact_locator {
                 self.put_visible_row_table_locator(
@@ -538,9 +555,10 @@ impl Storage for MemoryStorage {
             }
         }
         for row in &encoded_rows {
-            self.ensure_cached_raw_table_header(
+            self.ensure_cached_row_raw_table_header(
                 row.row_raw_table.as_str(),
-                &row_raw_table_header(&row.row_raw_table_id, &row.user_descriptor),
+                &row.row_raw_table_id,
+                &row.user_descriptor,
             )?;
             if row.needs_exact_locator {
                 self.put_history_row_batch_table_locator(
@@ -597,9 +615,10 @@ impl Storage for MemoryStorage {
             }
         }
         for row in encoded_rows {
-            self.ensure_cached_raw_table_header(
+            self.ensure_cached_row_raw_table_header(
                 row.row_raw_table.as_str(),
-                &row_raw_table_header(&row.row_raw_table_id, &row.user_descriptor),
+                &row.row_raw_table_id,
+                &row.user_descriptor,
             )?;
             if row.needs_exact_locator {
                 self.put_visible_row_table_locator(

--- a/crates/jazz-tools/src/storage/memory.rs
+++ b/crates/jazz-tools/src/storage/memory.rs
@@ -94,6 +94,16 @@ impl Storage for MemoryStorage {
         self.cache_namespace
     }
 
+    fn scan_row_locators(&self) -> Result<RowLocatorRows, StorageError> {
+        let mut rows = self
+            .row_locators
+            .iter()
+            .map(|(object_id, locator)| (*object_id, locator.clone()))
+            .collect::<Vec<_>>();
+        rows.sort_by_key(|(object_id, _)| *object_id);
+        Ok(rows)
+    }
+
     fn apply_prepared_row_mutation(
         &mut self,
         table: &str,
@@ -298,20 +308,8 @@ impl Storage for MemoryStorage {
         locator: Option<&RowLocator>,
     ) -> Result<(), StorageError> {
         if let Some(locator) = locator {
-            self.ensure_cached_raw_table_header(
-                ROW_LOCATOR_TABLE,
-                &RawTableHeader::system(STORAGE_KIND_ROW_LOCATOR, ROW_LOCATOR_STORAGE_FORMAT_V1),
-            )?;
-            let locator_bytes = encode_row_locator(locator)?;
-            self.raw_tables
-                .entry(ROW_LOCATOR_TABLE.to_string())
-                .or_default()
-                .insert(metadata_raw_key(id), locator_bytes);
             self.row_locators.insert(id, locator.clone());
         } else {
-            if let Some(rows) = self.raw_tables.get_mut(ROW_LOCATOR_TABLE) {
-                rows.remove(&metadata_raw_key(id));
-            }
             self.row_locators.remove(&id);
         }
 

--- a/crates/jazz-tools/src/storage/memory.rs
+++ b/crates/jazz-tools/src/storage/memory.rs
@@ -875,13 +875,13 @@ impl Storage for MemoryStorage {
         else {
             return Ok(None);
         };
-        let context = resolve_history_row_write_context(self, table, &entry.current_row)?;
         let current_tier = row_confirmed_tier_with_batch_fate(self, &entry.current_row)?;
         if current_tier.is_some_and(|tier| tier >= required_tier) {
             let mut current_row = entry.current_row.clone();
             current_row.confirmed_tier = current_tier;
             return Ok(Some(current_row));
         }
+        let context = resolve_history_row_write_context(self, table, &entry.current_row)?;
         let mut history_rows = regions.history_rows_for(branch, row_id);
         apply_batch_fate_tiers_to_rows(self, &mut history_rows)?;
         crate::row_histories::visible_row_preview_from_history_rows(

--- a/crates/jazz-tools/src/storage/memory.rs
+++ b/crates/jazz-tools/src/storage/memory.rs
@@ -696,7 +696,7 @@ impl Storage for MemoryStorage {
         for (branch, row_id, context_row, history_rows) in rebuild_inputs {
             let context = resolve_history_row_write_context(self, table, &context_row)?;
             if let Some(entry) = VisibleRowEntry::rebuild_with_descriptor(
-                context.user_descriptor.as_ref(),
+                context.user_descriptor().as_ref(),
                 &history_rows,
             )
             .map_err(|err| StorageError::IoError(format!("rebuild visible entry: {err}")))?
@@ -868,7 +868,7 @@ impl Storage for MemoryStorage {
         let mut history_rows = regions.history_rows_for(branch, row_id);
         apply_batch_fate_tiers_to_rows(self, &mut history_rows)?;
         crate::row_histories::visible_row_preview_from_history_rows(
-            context.user_descriptor.as_ref(),
+            context.user_descriptor().as_ref(),
             &history_rows,
             Some(required_tier),
         )

--- a/crates/jazz-tools/src/storage/mod.rs
+++ b/crates/jazz-tools/src/storage/mod.rs
@@ -525,39 +525,10 @@ impl PreparedRowWriteContext {
     }
 }
 
-type RowRawTableIdCache = HashMap<(RowRawTableKind, String, SchemaHash), RowRawTableId>;
 type CatalogueUserDescriptorCache = HashMap<(usize, String, SchemaHash), Arc<RowDescriptor>>;
 type BranchSchemaHashCache = HashMap<(usize, String), Vec<SchemaHash>>;
 type TableCatalogueDescriptorCache =
     HashMap<(usize, String), Vec<(SchemaHash, crate::query_manager::types::RowDescriptor)>>;
-
-fn row_raw_table_id_cache() -> &'static Mutex<RowRawTableIdCache> {
-    static CACHE: OnceLock<Mutex<RowRawTableIdCache>> = OnceLock::new();
-    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
-}
-
-fn cached_row_raw_table_id(
-    kind: RowRawTableKind,
-    table: &str,
-    schema_hash: SchemaHash,
-) -> RowRawTableId {
-    let cache_key = (kind, table.to_string(), schema_hash);
-    if let Some(cached) = row_raw_table_id_cache()
-        .lock()
-        .expect("row raw table id cache poisoned")
-        .get(&cache_key)
-        .cloned()
-    {
-        return cached;
-    }
-
-    let created = RowRawTableId::new(kind, table, schema_hash);
-    row_raw_table_id_cache()
-        .lock()
-        .expect("row raw table id cache poisoned")
-        .insert(cache_key, created.clone());
-    created
-}
 
 fn row_raw_table_descriptor_cache() -> &'static Mutex<HashMap<String, Arc<RowDescriptor>>> {
     static CACHE: OnceLock<Mutex<HashMap<String, Arc<RowDescriptor>>>> = OnceLock::new();
@@ -1207,11 +1178,11 @@ fn ensure_raw_table_header<H: Storage + ?Sized>(
 }
 
 fn history_row_raw_table_id(table: &str, schema_hash: SchemaHash) -> RowRawTableId {
-    cached_row_raw_table_id(RowRawTableKind::History, table, schema_hash)
+    RowRawTableId::new(RowRawTableKind::History, table, schema_hash)
 }
 
 fn visible_row_raw_table_id(table: &str, schema_hash: SchemaHash) -> RowRawTableId {
-    cached_row_raw_table_id(RowRawTableKind::Visible, table, schema_hash)
+    RowRawTableId::new(RowRawTableKind::Visible, table, schema_hash)
 }
 
 fn load_user_descriptor_for_schema_hash<H: Storage + ?Sized>(

--- a/crates/jazz-tools/src/storage/mod.rs
+++ b/crates/jazz-tools/src/storage/mod.rs
@@ -499,11 +499,30 @@ struct ResolvedRowTable {
 }
 
 #[derive(Clone)]
-pub(crate) struct PreparedRowWriteContext {
+pub(crate) struct PreparedRowTableContext {
     pub history_row_raw_table_id: RowRawTableId,
     pub visible_row_raw_table_id: RowRawTableId,
     pub user_descriptor: Arc<RowDescriptor>,
+}
+
+#[derive(Clone)]
+pub(crate) struct PreparedRowWriteContext {
+    pub table_context: Arc<PreparedRowTableContext>,
     pub needs_exact_locator: bool,
+}
+
+impl PreparedRowWriteContext {
+    pub(crate) fn history_row_raw_table_id(&self) -> &RowRawTableId {
+        &self.table_context.history_row_raw_table_id
+    }
+
+    pub(crate) fn visible_row_raw_table_id(&self) -> &RowRawTableId {
+        &self.table_context.visible_row_raw_table_id
+    }
+
+    pub(crate) fn user_descriptor(&self) -> &Arc<RowDescriptor> {
+        &self.table_context.user_descriptor
+    }
 }
 
 type RowRawTableIdCache = HashMap<(RowRawTableKind, String, SchemaHash), RowRawTableId>;
@@ -1215,12 +1234,50 @@ fn prepared_row_write_context_for_descriptor(
     user_descriptor: Arc<RowDescriptor>,
     needs_exact_locator: bool,
 ) -> Result<PreparedRowWriteContext, StorageError> {
-    Ok(PreparedRowWriteContext {
+    let table_context =
+        prepared_row_table_context_for_descriptor(table_name, schema_hash, user_descriptor)?;
+    Ok(prepared_row_write_context_from_table_context(
+        table_context,
+        needs_exact_locator,
+    ))
+}
+
+pub(crate) fn prepared_row_table_context_for_descriptor(
+    table_name: &str,
+    schema_hash: SchemaHash,
+    user_descriptor: Arc<RowDescriptor>,
+) -> Result<Arc<PreparedRowTableContext>, StorageError> {
+    Ok(Arc::new(PreparedRowTableContext {
         history_row_raw_table_id: history_row_raw_table_id(table_name, schema_hash),
         visible_row_raw_table_id: visible_row_raw_table_id(table_name, schema_hash),
         user_descriptor,
+    }))
+}
+
+pub(crate) fn prepared_row_write_context_from_table_context(
+    table_context: Arc<PreparedRowTableContext>,
+    needs_exact_locator: bool,
+) -> PreparedRowWriteContext {
+    PreparedRowWriteContext {
+        table_context,
         needs_exact_locator,
-    })
+    }
+}
+
+pub(crate) fn prepared_row_write_context_for_table_context<H: Storage + ?Sized>(
+    storage: &H,
+    table_context: Arc<PreparedRowTableContext>,
+    row_id: ObjectId,
+) -> Result<PreparedRowWriteContext, StorageError> {
+    let schema_hash = table_context.history_row_raw_table_id.schema_hash;
+    let needs_exact_locator = storage
+        .load_row_locator(row_id)?
+        .and_then(|locator| locator.origin_schema_hash)
+        != Some(schema_hash);
+    Ok(prepared_row_write_context_from_table_context(
+        table_context,
+        needs_exact_locator,
+    ))
 }
 
 pub(crate) fn prepared_row_write_context_for_known_exact_locator(
@@ -1248,6 +1305,15 @@ pub(crate) fn prepared_row_write_context_for_schema_hash_and_descriptor<H: Stora
         user_descriptor,
         needs_exact_locator,
     )
+}
+
+pub(crate) fn prepared_row_table_context_for_schema_hash<H: Storage + ?Sized>(
+    storage: &H,
+    table_name: &str,
+    schema_hash: SchemaHash,
+) -> Result<Arc<PreparedRowTableContext>, StorageError> {
+    let user_descriptor = load_user_descriptor_for_schema_hash(storage, table_name, schema_hash)?;
+    prepared_row_table_context_for_descriptor(table_name, schema_hash, user_descriptor)
 }
 
 fn prepared_row_write_context_for_schema_hash<H: Storage + ?Sized>(
@@ -1897,16 +1963,16 @@ pub(crate) fn encode_history_row_bytes_with_context(
     row: &StoredRowBatch,
 ) -> Result<OwnedHistoryRowBytes, StorageError> {
     let bytes =
-        crate::row_histories::encode_flat_history_row(context.user_descriptor.as_ref(), row)
+        crate::row_histories::encode_flat_history_row(context.user_descriptor().as_ref(), row)
             .map_err(|err| StorageError::IoError(format!("encode flat history row: {err}")))?;
 
     Ok(OwnedHistoryRowBytes {
         row_raw_table: context
-            .history_row_raw_table_id
+            .history_row_raw_table_id()
             .raw_table_name()
             .to_string(),
-        row_raw_table_id: context.history_row_raw_table_id.clone(),
-        user_descriptor: context.user_descriptor.clone(),
+        row_raw_table_id: context.history_row_raw_table_id().clone(),
+        user_descriptor: context.user_descriptor().clone(),
         branch: row.branch.to_string(),
         row_id: row.row_id,
         batch_id: row.batch_id(),
@@ -1920,18 +1986,18 @@ pub(crate) fn encode_visible_row_bytes_with_context(
     entry: &VisibleRowEntry,
 ) -> Result<OwnedVisibleRowBytes, StorageError> {
     let bytes = crate::row_histories::encode_flat_visible_row_entry(
-        context.user_descriptor.as_ref(),
+        context.user_descriptor().as_ref(),
         entry,
     )
     .map_err(|err| StorageError::IoError(format!("encode flat visible row: {err}")))?;
 
     Ok(OwnedVisibleRowBytes {
         row_raw_table: context
-            .visible_row_raw_table_id
+            .visible_row_raw_table_id()
             .raw_table_name()
             .to_string(),
-        row_raw_table_id: context.visible_row_raw_table_id.clone(),
-        user_descriptor: context.user_descriptor.clone(),
+        row_raw_table_id: context.visible_row_raw_table_id().clone(),
+        user_descriptor: context.user_descriptor().clone(),
         branch: entry.current_row.branch.to_string(),
         row_id: entry.current_row.row_id,
         needs_exact_locator: context.needs_exact_locator,
@@ -2291,7 +2357,7 @@ pub(crate) fn patch_row_region_rows_by_batch_with_storage<H: Storage + ?Sized>(
             continue;
         };
         if let Some(entry) = VisibleRowEntry::rebuild_with_descriptor(
-            context.user_descriptor.as_ref(),
+            context.user_descriptor().as_ref(),
             &history_rows,
         )
         .map_err(|err| StorageError::IoError(format!("rebuild visible entry: {err}")))?
@@ -2314,7 +2380,7 @@ pub(crate) fn patch_row_region_rows_by_batch_with_storage<H: Storage + ?Sized>(
 
         if current.state.is_visible() {
             if let Some(entry) = VisibleRowEntry::rebuild_with_descriptor(
-                context.user_descriptor.as_ref(),
+                context.user_descriptor().as_ref(),
                 &history_rows,
             )
             .map_err(|err| StorageError::IoError(format!("rebuild visible entry: {err}")))?
@@ -2368,7 +2434,7 @@ pub(crate) fn patch_exact_row_batch_with_storage<H: Storage + ?Sized>(
     let context = resolve_history_row_write_context(storage, table, &row)?;
 
     let visible_entries = VisibleRowEntry::rebuild_with_descriptor(
-        context.user_descriptor.as_ref(),
+        context.user_descriptor().as_ref(),
         &patched_history,
     )
     .map_err(|err| StorageError::IoError(format!("rebuild visible entry: {err}")))?

--- a/crates/jazz-tools/src/storage/mod.rs
+++ b/crates/jazz-tools/src/storage/mod.rs
@@ -1264,22 +1264,6 @@ pub(crate) fn prepared_row_write_context_from_table_context(
     }
 }
 
-pub(crate) fn prepared_row_write_context_for_table_context<H: Storage + ?Sized>(
-    storage: &H,
-    table_context: Arc<PreparedRowTableContext>,
-    row_id: ObjectId,
-) -> Result<PreparedRowWriteContext, StorageError> {
-    let schema_hash = table_context.history_row_raw_table_id.schema_hash;
-    let needs_exact_locator = storage
-        .load_row_locator(row_id)?
-        .and_then(|locator| locator.origin_schema_hash)
-        != Some(schema_hash);
-    Ok(prepared_row_write_context_from_table_context(
-        table_context,
-        needs_exact_locator,
-    ))
-}
-
 pub(crate) fn prepared_row_write_context_for_known_exact_locator(
     table_name: &str,
     schema_hash: SchemaHash,

--- a/crates/jazz-tools/src/storage/storage_trait.rs
+++ b/crates/jazz-tools/src/storage/storage_trait.rs
@@ -1326,7 +1326,7 @@ pub trait Storage {
             current_row.row_id,
         )?;
         let visible_entries = VisibleRowEntry::rebuild_with_descriptor(
-            context.user_descriptor.as_ref(),
+            context.user_descriptor().as_ref(),
             &patched_history,
         )
         .map_err(|err| StorageError::IoError(format!("rebuild visible entry: {err}")))?

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -250,13 +250,15 @@ impl SyncManager {
         storage: &mut H,
         object_id: ObjectId,
         metadata: HashMap<String, String>,
-    ) {
+    ) -> bool {
         let existing_row_locator = storage.load_row_locator(object_id).ok().flatten();
         if existing_row_locator.is_none()
             && let Some(row_locator) = crate::storage::row_locator_from_metadata(&metadata)
         {
             let _ = storage.put_row_locator(object_id, Some(&row_locator));
+            return true;
         }
+        false
     }
 
     fn row_metadata_from_payload<H: Storage>(
@@ -383,7 +385,8 @@ impl SyncManager {
         row.confirmed_tier = None;
 
         let metadata = self.row_metadata_from_payload(storage, &row, metadata.as_ref())?;
-        self.ensure_object_metadata(storage, row.row_id, metadata.clone());
+        let is_newly_located_object =
+            self.ensure_object_metadata(storage, row.row_id, metadata.clone());
         let branch_name = BranchName::new(&row.branch);
         let visibility_change = match self.row_context_from_metadata(storage, row.row_id, &metadata)
         {
@@ -401,7 +404,7 @@ impl SyncManager {
                         table,
                         branch,
                         context,
-                        is_known_new_object: false,
+                        is_known_new_object: is_newly_located_object && row.parents.is_empty(),
                     },
                 ) {
                     Ok(applied) => applied.visibility_change,

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -9,7 +9,7 @@ use crate::row_histories::{
 };
 use crate::storage::{
     PreparedRowWriteContext, RowLocator, Storage, metadata_from_row_locator,
-    prepared_row_table_context_for_schema_hash, prepared_row_write_context_for_table_context,
+    prepared_row_table_context_for_schema_hash, prepared_row_write_context_from_table_context,
     row_locator_from_metadata,
 };
 use std::collections::{HashMap, HashSet};
@@ -250,15 +250,23 @@ impl SyncManager {
         storage: &mut H,
         object_id: ObjectId,
         metadata: HashMap<String, String>,
-    ) -> bool {
+    ) -> (bool, bool) {
         let existing_row_locator = storage.load_row_locator(object_id).ok().flatten();
-        if existing_row_locator.is_none()
-            && let Some(row_locator) = crate::storage::row_locator_from_metadata(&metadata)
-        {
-            let _ = storage.put_row_locator(object_id, Some(&row_locator));
-            return true;
+        let Some(metadata_row_locator) = crate::storage::row_locator_from_metadata(&metadata)
+        else {
+            return (false, false);
+        };
+        let metadata_schema_hash = metadata_row_locator.origin_schema_hash;
+        match existing_row_locator {
+            Some(existing_row_locator) => (
+                false,
+                existing_row_locator.origin_schema_hash != metadata_schema_hash,
+            ),
+            None => {
+                let _ = storage.put_row_locator(object_id, Some(&metadata_row_locator));
+                (true, false)
+            }
         }
-        false
     }
 
     fn row_metadata_from_payload<H: Storage>(
@@ -281,8 +289,8 @@ impl SyncManager {
     fn row_context_from_metadata<H: Storage>(
         &mut self,
         storage: &H,
-        row_id: ObjectId,
         metadata: &HashMap<String, String>,
+        needs_exact_locator: bool,
     ) -> Option<(RowLocator, PreparedRowWriteContext)> {
         let row_locator = row_locator_from_metadata(metadata)?;
         let schema_hash = row_locator.origin_schema_hash?;
@@ -298,7 +306,7 @@ impl SyncManager {
             context
         };
         let write_context =
-            prepared_row_write_context_for_table_context(storage, table_context, row_id).ok()?;
+            prepared_row_write_context_from_table_context(table_context, needs_exact_locator);
         Some((row_locator, write_context))
     }
 
@@ -385,53 +393,55 @@ impl SyncManager {
         row.confirmed_tier = None;
 
         let metadata = self.row_metadata_from_payload(storage, &row, metadata.as_ref())?;
-        let is_newly_located_object =
+        let (is_newly_located_object, needs_exact_locator) =
             self.ensure_object_metadata(storage, row.row_id, metadata.clone());
         let branch_name = BranchName::new(&row.branch);
-        let visibility_change = match self.row_context_from_metadata(storage, row.row_id, &metadata)
-        {
-            Some((row_locator, context)) => {
-                let table = row_locator.table.to_string();
-                let branch = row.branch.clone();
-                match apply_row_batch_with_context(
-                    storage,
-                    ApplyRowBatchWithContext {
-                        object_id: row.row_id,
-                        branch_name: &branch_name,
-                        row: row.clone(),
-                        index_mutations: &[],
-                        row_locator,
-                        table,
-                        branch,
-                        context,
-                        is_known_new_object: is_newly_located_object && row.parents.is_empty(),
-                    },
-                ) {
-                    Ok(applied) => applied.visibility_change,
-                    Err(err) => {
-                        tracing::warn!(
-                            row_id = %row.row_id,
-                            %branch_name,
-                            ?err,
-                            "failed to apply synced row batch"
-                        );
-                        return None;
+        let visibility_change =
+            match self.row_context_from_metadata(storage, &metadata, needs_exact_locator) {
+                Some((row_locator, context)) => {
+                    let table = row_locator.table.to_string();
+                    let branch = row.branch.clone();
+                    match apply_row_batch_with_context(
+                        storage,
+                        ApplyRowBatchWithContext {
+                            object_id: row.row_id,
+                            branch_name: &branch_name,
+                            row: row.clone(),
+                            index_mutations: &[],
+                            row_locator,
+                            table,
+                            branch,
+                            context,
+                            is_known_new_object: is_newly_located_object && row.parents.is_empty(),
+                        },
+                    ) {
+                        Ok(applied) => applied.visibility_change,
+                        Err(err) => {
+                            tracing::warn!(
+                                row_id = %row.row_id,
+                                %branch_name,
+                                ?err,
+                                "failed to apply synced row batch"
+                            );
+                            return None;
+                        }
                     }
                 }
-            }
-            None => match apply_row_batch(storage, row.row_id, &branch_name, row.clone(), &[]) {
-                Ok(applied) => applied.visibility_change,
-                Err(err) => {
-                    tracing::warn!(
-                        row_id = %row.row_id,
-                        %branch_name,
-                        ?err,
-                        "failed to apply synced row batch"
-                    );
-                    return None;
+                None => {
+                    match apply_row_batch(storage, row.row_id, &branch_name, row.clone(), &[]) {
+                        Ok(applied) => applied.visibility_change,
+                        Err(err) => {
+                            tracing::warn!(
+                                row_id = %row.row_id,
+                                %branch_name,
+                                ?err,
+                                "failed to apply synced row batch"
+                            );
+                            return None;
+                        }
+                    }
                 }
-            },
-        };
+            };
         if record_local_fate
             && let Some(confirmed_tier) = authoritative_tier
             && row.state.is_visible()

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -4,9 +4,14 @@ use crate::metadata::MetadataKey;
 use crate::object::{BranchName, ObjectId};
 use crate::query_manager::policy::Operation;
 use crate::row_histories::{
-    RowState, RowVisibilityChange, StoredRowBatch, apply_row_batch, patch_row_batch_state,
+    ApplyRowBatchWithContext, RowState, RowVisibilityChange, StoredRowBatch, apply_row_batch,
+    apply_row_batch_with_context, patch_row_batch_state,
 };
-use crate::storage::{Storage, metadata_from_row_locator};
+use crate::storage::{
+    PreparedRowWriteContext, RowLocator, Storage, metadata_from_row_locator,
+    prepared_row_table_context_for_schema_hash, prepared_row_write_context_for_table_context,
+    row_locator_from_metadata,
+};
 use std::collections::{HashMap, HashSet};
 
 struct AppliedRowBatch {
@@ -271,6 +276,30 @@ impl SyncManager {
             .map(|locator| metadata_from_row_locator(&locator))
     }
 
+    fn row_context_from_metadata<H: Storage>(
+        &mut self,
+        storage: &H,
+        row_id: ObjectId,
+        metadata: &HashMap<String, String>,
+    ) -> Option<(RowLocator, PreparedRowWriteContext)> {
+        let row_locator = row_locator_from_metadata(metadata)?;
+        let schema_hash = row_locator.origin_schema_hash?;
+        let table = row_locator.table.to_string();
+        let cache_key = (table.clone(), schema_hash);
+        let table_context = if let Some(context) = self.replay_table_contexts.get(&cache_key) {
+            context.clone()
+        } else {
+            let context =
+                prepared_row_table_context_for_schema_hash(storage, &table, schema_hash).ok()?;
+            self.replay_table_contexts
+                .insert(cache_key, context.clone());
+            context
+        };
+        let write_context =
+            prepared_row_write_context_for_table_context(storage, table_context, row_id).ok()?;
+        Some((row_locator, write_context))
+    }
+
     fn matches_replayed_row_batch(existing: &StoredRowBatch, incoming: &StoredRowBatch) -> bool {
         existing.row_id == incoming.row_id
             && existing.batch_id == incoming.batch_id
@@ -330,7 +359,7 @@ impl SyncManager {
             .filter(|candidate| included_batch_ids.contains(&candidate.batch_id()))
             .collect::<Vec<_>>();
         crate::row_histories::visible_row_preview_from_history_rows(
-            context.user_descriptor.as_ref(),
+            context.user_descriptor().as_ref(),
             &pre_batch_rows,
             None,
         )
@@ -356,8 +385,38 @@ impl SyncManager {
         let metadata = self.row_metadata_from_payload(storage, &row, metadata.as_ref())?;
         self.ensure_object_metadata(storage, row.row_id, metadata.clone());
         let branch_name = BranchName::new(&row.branch);
-        let visibility_change =
-            match apply_row_batch(storage, row.row_id, &branch_name, row.clone(), &[]) {
+        let visibility_change = match self.row_context_from_metadata(storage, row.row_id, &metadata)
+        {
+            Some((row_locator, context)) => {
+                let table = row_locator.table.to_string();
+                let branch = row.branch.clone();
+                match apply_row_batch_with_context(
+                    storage,
+                    ApplyRowBatchWithContext {
+                        object_id: row.row_id,
+                        branch_name: &branch_name,
+                        row: row.clone(),
+                        index_mutations: &[],
+                        row_locator,
+                        table,
+                        branch,
+                        context,
+                        is_known_new_object: false,
+                    },
+                ) {
+                    Ok(applied) => applied.visibility_change,
+                    Err(err) => {
+                        tracing::warn!(
+                            row_id = %row.row_id,
+                            %branch_name,
+                            ?err,
+                            "failed to apply synced row batch"
+                        );
+                        return None;
+                    }
+                }
+            }
+            None => match apply_row_batch(storage, row.row_id, &branch_name, row.clone(), &[]) {
                 Ok(applied) => applied.visibility_change,
                 Err(err) => {
                     tracing::warn!(
@@ -368,7 +427,8 @@ impl SyncManager {
                     );
                     return None;
                 }
-            };
+            },
+        };
         if record_local_fate
             && let Some(confirmed_tier) = authoritative_tier
             && row.state.is_visible()

--- a/crates/jazz-tools/src/sync_manager/mod.rs
+++ b/crates/jazz-tools/src/sync_manager/mod.rs
@@ -8,8 +8,9 @@ use crate::catalogue::CatalogueEntry;
 use crate::object::{BranchName, ObjectId};
 use crate::query_manager::query::Query;
 use crate::query_manager::session::Session;
+use crate::query_manager::types::SchemaHash;
 use crate::row_histories::{BatchId, RowVisibilityChange};
-use crate::storage::Storage;
+use crate::storage::{PreparedRowTableContext, Storage};
 
 // Module declarations
 pub mod clock;
@@ -103,6 +104,14 @@ pub struct SyncManager {
     /// this connection. A large replay can deliver many rows from the same
     /// sealed batch across several ticks, so outbox-local dedupe is not enough.
     pub(super) sent_server_batch_fate_acks: HashSet<(ServerId, BatchId, DurabilityTier, bool)>,
+    /// Per-sync-manager replay cache for table/schema row write context.
+    ///
+    /// Incoming sync rows usually carry table + origin schema metadata. Rows in
+    /// a large replay share this context, so cache it above the per-row
+    /// visibility work instead of re-resolving descriptors and raw table IDs
+    /// from storage for every row.
+    pub(super) replay_table_contexts:
+        HashMap<(String, SchemaHash), std::sync::Arc<PreparedRowTableContext>>,
 }
 
 impl std::fmt::Debug for SyncManager {
@@ -248,6 +257,7 @@ impl SyncManager {
             pending_batch_fates: Vec::new(),
             pending_client_batch_fates: HashMap::new(),
             sent_server_batch_fate_acks: HashSet::new(),
+            replay_table_contexts: HashMap::new(),
         }
     }
 


### PR DESCRIPTION
## Summary

Stack PR 7 of the Jazz load-performance split. This slice optimizes sync replay and storage hot paths that became the next bottlenecks after native subscription row delivery landed.

## What changed

- Reuses row table context, locator lookups, storage descriptors, and decoded memory row locators during sync replay.
- Fast-paths parentless replay rows and direct row/table id construction.
- Avoids redundant row system-column rebuilds for codec counts.
- Splices user row bytes directly into flat history rows.
- Writes projected row prefixes directly and encodes row-format arrays into output buffers.
- Coalesces replay settlement ticks.
- Batches subscription marking during replay.
- Uses materialize flags for tuple elements to avoid unnecessary tuple work.
- Defers visible-tier descriptor resolution where possible.

## Review notes

- This is the broadest low-level performance slice in the stack; the commits are grouped around replay/storage hot paths rather than user-facing API changes.

## Validation

- GitHub CI passed: `lint`, `test-rust`, `test-ts`, Vercel docs, and Vercel inspector.
