### PR TITLE
Preserve backend session in postcard auth

### DIFF
--- a/crates/jazz-tools/src/transport_manager.rs
+++ b/crates/jazz-tools/src/transport_manager.rs
@@ -188,7 +188,41 @@ pub struct AuthConfig {
     pub backend_secret: Option<String>,
     pub admin_secret: Option<String>,
     pub peer_secret: Option<String>,
+    #[serde(default, with = "auth_backend_session_serde")]
     pub backend_session: Option<serde_json::Value>,
+}
+
+mod auth_backend_session_serde {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S>(value: &Option<serde_json::Value>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if serializer.is_human_readable() {
+            return value.serialize(serializer);
+        }
+
+        let json = value
+            .as_ref()
+            .map(|session| serde_json::to_string(session).map_err(serde::ser::Error::custom))
+            .transpose()?;
+
+        json.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<serde_json::Value>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            return Option::<serde_json::Value>::deserialize(deserializer);
+        }
+
+        let json = Option::<String>::deserialize(deserializer)?;
+        json.map(|session| serde_json::from_str(&session).map_err(serde::de::Error::custom))
+            .transpose()
+    }
 }
 
 impl std::fmt::Debug for AuthConfig {
@@ -307,6 +341,37 @@ mod handshake_tests {
         let debug = format!("{auth:?}");
         assert!(debug.contains("peer_secret"));
         assert!(!debug.contains("cluster-secret"));
+    }
+
+    #[test]
+    fn auth_handshake_postcard_roundtrip_preserves_backend_session() {
+        let handshake = AuthHandshake {
+            sync_protocol_version: SYNC_PROTOCOL_VERSION,
+            client_id: "client-1".to_string(),
+            auth: AuthConfig {
+                backend_secret: Some("backend-secret".to_string()),
+                backend_session: Some(serde_json::json!({
+                    "user_id": "alice",
+                    "claims": {
+                        "role": "admin",
+                    },
+                    "auth_mode": "trusted",
+                })),
+                ..Default::default()
+            },
+            catalogue_state_hash: Some("catalogue-digest".to_string()),
+            declared_schema_hash: Some(SchemaHash::from_bytes([9; 32]).to_string()),
+        };
+
+        let bytes = postcard::to_allocvec(&handshake).expect("encode postcard handshake");
+        let decoded: AuthHandshake =
+            postcard::from_bytes(&bytes).expect("decode postcard handshake");
+
+        assert_eq!(decoded.sync_protocol_version, SYNC_PROTOCOL_VERSION);
+        assert_eq!(
+            decoded.auth.backend_session, handshake.auth.backend_session,
+            "backend session claims should survive postcard encoding"
+        );
     }
 }
 

--- a/specs/status-quo/http_transport.md
+++ b/specs/status-quo/http_transport.md
@@ -18,8 +18,25 @@ carrying payloads such as:
 
 - `Connected`
 - `SyncUpdate`
+- `SyncUpdateBatch`
 - `Error`
 - `Heartbeat`
+
+Every WebSocket message uses the same outer frame shape:
+
+```text
+[4 bytes: u32 big-endian payload length][N bytes: payload]
+```
+
+The initial auth handshake payload is JSON. That keeps protocol-version and
+auth failures readable for older or mismatched peers. Once both sides confirm
+`SYNC_PROTOCOL_VERSION`, post-handshake sync transport payloads are binary
+postcard payloads:
+
+- client-to-server frames carry either a single outbox entry payload or a
+  `SyncBatchRequest`
+- server-to-client frames carry `ServerEvent` payloads, including coalesced
+  `SyncUpdateBatch` events
 
 The connection is app-scoped, so every non-health server interaction uses the same `/apps/<app_id>/...`
 prefix as the cloud server.
@@ -111,7 +128,7 @@ The in-repo server keeps a small route set:
 | File                                                | Purpose                                |
 | --------------------------------------------------- | -------------------------------------- |
 | `crates/jazz-tools/src/transport_protocol.rs`       | Shared request/event types and framing |
-| `crates/jazz-tools/src/routes.rs`                   | In-repo server routes                  |
+| `crates/jazz-tools/src/server/routes/`              | In-repo server routes                  |
 | `crates/jazz-tools/src/middleware/auth.rs`          | HTTP auth handling                     |
 | `crates/jazz-tools/src/transport_manager.rs`        | Rust WebSocket transport manager       |
 | `crates/jazz-tools/src/ws_stream/`                  | Concrete WebSocket stream adapters     |


### PR DESCRIPTION
## Summary

- Add postcard-safe serialization for `AuthConfig.backend_session` while keeping JSON handshakes JSON-shaped.
- Add a regression test proving an `AuthHandshake` with backend session claims round-trips through postcard.
- Update the HTTP/WebSocket transport status-quo doc for the current post-#831 framing state.

## Validation

- `cargo test -p jazz-tools --lib transport_manager::handshake_tests::auth_handshake_postcard_roundtrip_preserves_backend_session --features test`
- `cargo test -p jazz-tools --lib transport_manager::handshake_tests --features test`
- pre-commit hook: clippy, oxfmt, rustfmt
