### PR TITLE
Seed catalogue in dynamic permissions tests

### DIFF
--- a/crates/jazz-tools/tests/catalogue_sync_integration.rs
+++ b/crates/jazz-tools/tests/catalogue_sync_integration.rs
@@ -61,12 +61,26 @@ fn v1_to_v2_lens() -> Lens {
     generate_lens(&schema_v1(), &schema_v2())
 }
 
+async fn seed_schema_catalogue(server: &TestingServer, schema: &jazz_tools::Schema) {
+    push_catalogue_in_memory(
+        server.server_state(),
+        server.app_id(),
+        "dev",
+        "main",
+        std::slice::from_ref(schema),
+        &[],
+    )
+    .await
+    .expect("push schema catalogue");
+}
+
 /// A dynamic server should fail closed before any permissions head is
 /// published, then expose rows once an explicit head is installed.
 #[tokio::test]
 async fn dynamic_server_denies_reads_until_permissions_head_is_published() {
     let server = TestingServer::start().await;
     let schema = schema_v1();
+    seed_schema_catalogue(&server, &schema).await;
 
     let mut reader_context = server.make_client_context_for_user(schema.clone(), "reader-dynamic");
     reader_context.backend_secret = None;
@@ -140,6 +154,7 @@ async fn dynamic_server_denies_reads_until_permissions_head_is_published() {
 async fn dynamic_server_keeps_pre_permissions_user_write_hidden_after_publish() {
     let server = TestingServer::start().await;
     let schema = schema_v1();
+    seed_schema_catalogue(&server, &schema).await;
     let query = QueryBuilder::new("users").build();
     let observer = TestingClient::builder()
         .with_server(&server)
@@ -298,6 +313,7 @@ async fn dynamic_server_keeps_pre_permissions_user_write_hidden_after_publish() 
 async fn dynamic_server_rejects_user_write_after_permissions_timeout() {
     let server = TestingServer::start().await;
     let schema = schema_v1();
+    seed_schema_catalogue(&server, &schema).await;
     let query = QueryBuilder::new("users").build();
     let observer = TestingClient::builder()
         .with_server(&server)
@@ -384,6 +400,7 @@ async fn dynamic_server_rejects_user_write_after_permissions_timeout() {
 async fn dynamic_server_live_subscription_replays_on_first_permissions_head_and_retightening() {
     let server = TestingServer::start().await;
     let schema = schema_v1();
+    seed_schema_catalogue(&server, &schema).await;
     let query = QueryBuilder::new("users").build();
 
     let reader = TestingClient::builder()

--- a/crates/jazz-tools/tests/rocksdb_storage_integration.rs
+++ b/crates/jazz-tools/tests/rocksdb_storage_integration.rs
@@ -22,7 +22,9 @@ use jazz_tools::{
     AppContext, ClientStorage, ColumnType, JazzClient, QueryBuilder, SchemaBuilder, TableSchema,
     Value,
 };
-use support::{TestingClient, publish_allow_all_permissions, wait_for_query};
+use support::{
+    TestingClient, publish_allow_all_permissions, push_catalogue_in_memory, wait_for_query,
+};
 use tempfile::TempDir;
 
 const READY_TIMEOUT: Duration = Duration::from_secs(30);
@@ -234,6 +236,17 @@ async fn make_client(
     user_id: &str,
     ready_table: &str,
 ) -> JazzClient {
+    push_catalogue_in_memory(
+        server.server_state(),
+        server.app_id(),
+        "dev",
+        "main",
+        std::slice::from_ref(&schema),
+        &[],
+    )
+    .await
+    .expect("push schema catalogue");
+
     let client = TestingClient::builder()
         .with_server(server)
         .with_schema(schema.clone())
@@ -269,6 +282,17 @@ async fn make_client_external_jwks(
     user_id: &str,
     ready_table: &str,
 ) -> JazzClient {
+    push_catalogue_in_memory(
+        server.server_state(),
+        server.app_id(),
+        "dev",
+        "main",
+        std::slice::from_ref(&schema),
+        &[],
+    )
+    .await
+    .expect("push schema catalogue");
+
     let context = AppContext {
         app_id: server.app_id(),
         client_id: None,

--- a/crates/jazz-tools/tests/sqlite_storage_integration.rs
+++ b/crates/jazz-tools/tests/sqlite_storage_integration.rs
@@ -22,7 +22,9 @@ use jazz_tools::{
     AppContext, ClientStorage, ColumnType, JazzClient, QueryBuilder, SchemaBuilder, TableSchema,
     Value,
 };
-use support::{TestingClient, publish_allow_all_permissions, wait_for_query};
+use support::{
+    TestingClient, publish_allow_all_permissions, push_catalogue_in_memory, wait_for_query,
+};
 use tempfile::TempDir;
 
 const READY_TIMEOUT: Duration = Duration::from_secs(30);
@@ -234,6 +236,17 @@ async fn make_client(
     user_id: &str,
     ready_table: &str,
 ) -> JazzClient {
+    push_catalogue_in_memory(
+        server.server_state(),
+        server.app_id(),
+        "dev",
+        "main",
+        std::slice::from_ref(&schema),
+        &[],
+    )
+    .await
+    .expect("push schema catalogue");
+
     let client = TestingClient::builder()
         .with_server(server)
         .with_schema(schema.clone())
@@ -269,6 +282,17 @@ async fn make_client_external_jwks(
     user_id: &str,
     ready_table: &str,
 ) -> JazzClient {
+    push_catalogue_in_memory(
+        server.server_state(),
+        server.app_id(),
+        "dev",
+        "main",
+        std::slice::from_ref(&schema),
+        &[],
+    )
+    .await
+    .expect("push schema catalogue");
+
     let context = AppContext {
         app_id: server.app_id(),
         client_id: None,

--- a/examples/docs/todo-server-rs/tests/integration.rs
+++ b/examples/docs/todo-server-rs/tests/integration.rs
@@ -596,6 +596,25 @@ fn make_test_jwt(user_id: &str) -> String {
     encode(&header, &claims, &key).unwrap()
 }
 
+async fn publish_test_schema(base_url: &str, app_id: AppId) {
+    let response = reqwest::Client::new()
+        .post(format!("{base_url}/apps/{app_id}/admin/schemas"))
+        .header("X-Jazz-Admin-Secret", TEST_ADMIN_SECRET)
+        .json(&serde_json::json!({
+            "schema": test_schema(),
+            "permissions": null,
+        }))
+        .send()
+        .await
+        .expect("publish test schema request");
+
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::CREATED,
+        "publish test schema"
+    );
+}
+
 impl TestServer {
     /// Start a test server on the given port.
     async fn start(port: u16) -> Self {
@@ -756,6 +775,7 @@ async fn test_server_resync() {
         };
         let client = JazzClient::connect(context).await.unwrap();
         let permissions_schema = test_schema();
+        publish_test_schema(&server.base_url(), test_app_id).await;
         permissions_support::publish_allow_all_permissions(
             &server.base_url(),
             test_app_id,

--- a/examples/todo-server-rs/tests/integration.rs
+++ b/examples/todo-server-rs/tests/integration.rs
@@ -596,6 +596,25 @@ fn make_test_jwt(user_id: &str) -> String {
     encode(&header, &claims, &key).unwrap()
 }
 
+async fn publish_test_schema(base_url: &str, app_id: AppId) {
+    let response = reqwest::Client::new()
+        .post(format!("{base_url}/apps/{app_id}/admin/schemas"))
+        .header("X-Jazz-Admin-Secret", TEST_ADMIN_SECRET)
+        .json(&serde_json::json!({
+            "schema": test_schema(),
+            "permissions": null,
+        }))
+        .send()
+        .await
+        .expect("publish test schema request");
+
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::CREATED,
+        "publish test schema"
+    );
+}
+
 impl TestServer {
     /// Start a test server on the given port.
     async fn start(port: u16) -> Self {
@@ -756,6 +775,7 @@ async fn test_server_resync() {
         };
         let client = JazzClient::connect(context).await.unwrap();
         let permissions_schema = test_schema();
+        publish_test_schema(&server.base_url(), test_app_id).await;
         permissions_support::publish_allow_all_permissions(
             &server.base_url(),
             test_app_id,


### PR DESCRIPTION
## Summary

- Seed schema catalogue explicitly in dynamic permissions integration tests
- Keep the new PR #819 behavior: unprivileged clients no longer publish catalogue during replay

## Verification

- cargo fmt --check
- cargo test -p jazz-tools --test catalogue_sync_integration --features test -- --test-threads=1