### PR TITLE
Fix worker flush timeout and sealed batch mode replay

### DIFF
--- a/crates/jazz-tools/src/batch_fate.rs
+++ b/crates/jazz-tools/src/batch_fate.rs
@@ -225,6 +225,7 @@ pub struct LocalBatchRecord {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SealedBatchSubmission {
     pub batch_id: BatchId,
+    pub mode: BatchMode,
     pub target_branch_name: BranchName,
     pub batch_digest: Digest32,
     pub members: Vec<SealedBatchMember>,
@@ -561,6 +562,7 @@ impl SealedBatchSubmission {
 
     pub fn new(
         batch_id: BatchId,
+        mode: BatchMode,
         target_branch_name: BranchName,
         mut members: Vec<SealedBatchMember>,
         mut captured_frontier: Vec<CapturedFrontierMember>,
@@ -585,6 +587,7 @@ impl SealedBatchSubmission {
         captured_frontier.dedup();
         Self {
             batch_id,
+            mode,
             target_branch_name,
             batch_digest,
             members,
@@ -595,6 +598,7 @@ impl SealedBatchSubmission {
     pub fn encode_storage_row(&self) -> Result<Vec<u8>, String> {
         let values = vec![
             Value::Bytea(self.batch_id.as_bytes().to_vec()),
+            Value::Text(self.mode.as_str().to_string()),
             Value::Text(self.target_branch_name.as_str().to_string()),
             Value::Bytea(self.batch_digest.0.to_vec()),
             Value::Array(
@@ -632,6 +636,7 @@ impl SealedBatchSubmission {
             .map_err(|err| format!("decode sealed batch submission row: {err}"))?;
         let [
             batch_id,
+            mode,
             target_branch_name,
             batch_digest,
             members,
@@ -642,6 +647,10 @@ impl SealedBatchSubmission {
         };
 
         let batch_id = decode_batch_id_value(batch_id, "decode sealed batch submission batch id")?;
+        let mode = match mode {
+            Value::Text(raw) => BatchMode::parse(raw)?,
+            other => return Err(format!("expected sealed batch mode text, got {other:?}")),
+        };
         let target_branch_name = match target_branch_name {
             Value::Text(raw) => BranchName::new(raw),
             other => return Err(format!("expected target branch text, got {other:?}")),
@@ -748,7 +757,13 @@ impl SealedBatchSubmission {
             other => return Err(format!("expected captured frontier array, got {other:?}")),
         };
 
-        let submission = Self::new(batch_id, target_branch_name, members, captured_frontier);
+        let submission = Self::new(
+            batch_id,
+            mode,
+            target_branch_name,
+            members,
+            captured_frontier,
+        );
         if submission.batch_digest != batch_digest {
             return Err(format!(
                 "sealed batch submission batch digest mismatch: expected {batch_digest:?}, computed {:?}",
@@ -840,6 +855,7 @@ fn storage_descriptor() -> RowDescriptor {
 fn sealed_batch_submission_storage_descriptor() -> RowDescriptor {
     RowDescriptor::new(vec![
         ColumnDescriptor::new("batch_id", ColumnType::BatchId),
+        ColumnDescriptor::new("mode", ColumnType::Text),
         ColumnDescriptor::new("target_branch_name", ColumnType::Text),
         ColumnDescriptor::new("batch_digest", ColumnType::Bytea),
         ColumnDescriptor::new(
@@ -1062,6 +1078,7 @@ mod tests {
         let mut record = LocalBatchRecord::new(batch_id, BatchMode::Transactional, false, None);
         record.mark_sealed(SealedBatchSubmission::new(
             batch_id,
+            BatchMode::Transactional,
             BranchName::new("dev-aaaaaaaaaaaa-main"),
             vec![SealedBatchMember {
                 object_id: ObjectId::from_uuid(uuid::Uuid::from_u128(42)),
@@ -1087,6 +1104,7 @@ mod tests {
         let row_digest = Digest32([7; 32]);
         let submission = SealedBatchSubmission::new(
             batch_id,
+            BatchMode::Direct,
             BranchName::new("main"),
             vec![
                 SealedBatchMember {
@@ -1115,6 +1133,7 @@ mod tests {
             decoded,
             SealedBatchSubmission {
                 batch_id,
+                mode: BatchMode::Direct,
                 target_branch_name: BranchName::new("main"),
                 batch_digest: submission.batch_digest,
                 members: vec![SealedBatchMember {
@@ -1135,6 +1154,7 @@ mod tests {
         let object_id = ObjectId::from_uuid(uuid::Uuid::from_u128(11));
         let first = SealedBatchSubmission::new(
             BatchId::new(),
+            BatchMode::Direct,
             BranchName::new("main"),
             vec![SealedBatchMember {
                 object_id,
@@ -1144,6 +1164,7 @@ mod tests {
         );
         let second = SealedBatchSubmission::new(
             BatchId::new(),
+            BatchMode::Direct,
             BranchName::new("main"),
             vec![SealedBatchMember {
                 object_id,

--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/direct.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/direct.rs
@@ -421,6 +421,7 @@ fn rc_restart_recovers_completed_sealed_batch_from_storage() {
         .storage_mut()
         .upsert_sealed_batch_submission(&SealedBatchSubmission::new(
             batch_id,
+            crate::batch_fate::BatchMode::Direct,
             crate::object::BranchName::new("main"),
             vec![SealedBatchMember {
                 object_id: row_id,

--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/rejection_recovery.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/rejection_recovery.rs
@@ -1122,6 +1122,7 @@ fn rc_rejected_replay_record_can_be_synthesized_from_sealed_submission() {
         .unwrap()
         .expect("sealed rejected batches should remain replayable");
     assert_eq!(record.batch_id, batch_id);
+    assert_eq!(record.mode, crate::batch_fate::BatchMode::Direct);
     assert!(record.sealed);
     assert!(matches!(
         record.latest_fate,
@@ -1130,6 +1131,62 @@ fn rc_rejected_replay_record_can_be_synthesized_from_sealed_submission() {
     assert_eq!(record.members.len(), 1);
     assert_eq!(record.members[0].object_id, row_id);
     assert!(record.sealed_submission.is_some());
+}
+
+#[test]
+fn rc_transactional_rejected_replay_record_keeps_sealed_submission_mode() {
+    let mut core = create_runtime_with_schema(
+        test_schema(),
+        "transactional-reject-replay-record-mode-test",
+    );
+
+    let write_context = WriteContext::from_session(Session::new("alice"))
+        .with_batch_mode(crate::batch_fate::BatchMode::Transactional);
+    let ((row_id, _row_values), _receiver) = core
+        .insert_persisted(
+            "users",
+            user_insert_values(ObjectId::new(), "Alice"),
+            Some(&write_context),
+            DurabilityTier::Local,
+        )
+        .unwrap();
+
+    let history_rows = core
+        .storage()
+        .scan_history_row_batches("users", row_id)
+        .unwrap();
+    assert_eq!(history_rows.len(), 1);
+    let batch_id = history_rows[0].batch_id;
+    core.seal_batch(batch_id).unwrap();
+
+    core.storage_mut()
+        .delete_local_batch_record(batch_id)
+        .unwrap();
+    core.storage_mut()
+        .upsert_authoritative_batch_fate(&crate::batch_fate::BatchFate::Rejected {
+            batch_id,
+            code: "permission_denied".to_string(),
+            reason: "writer lacks publish rights".to_string(),
+        })
+        .unwrap();
+
+    let record = core
+        .local_batch_record_for_rejection_replay(batch_id)
+        .unwrap()
+        .expect("sealed rejected transactional batches should remain replayable");
+    assert_eq!(record.batch_id, batch_id);
+    assert_eq!(record.mode, crate::batch_fate::BatchMode::Transactional);
+    assert!(record.sealed);
+    assert_eq!(record.members.len(), 1);
+    assert_eq!(record.members[0].object_id, row_id);
+    assert_eq!(
+        record
+            .sealed_submission
+            .as_ref()
+            .expect("replay should retain the sealed submission")
+            .mode,
+        crate::batch_fate::BatchMode::Transactional
+    );
 }
 
 #[test]
@@ -1367,6 +1424,7 @@ fn rc_persisting_invalid_multibranch_sealed_batch_submission_fails() {
         .storage_mut()
         .upsert_sealed_batch_submission(&SealedBatchSubmission::new(
             batch_id,
+            crate::batch_fate::BatchMode::Direct,
             crate::object::BranchName::new("main"),
             vec![
                 SealedBatchMember {
@@ -1512,6 +1570,7 @@ fn rc_restart_rejects_stale_family_frontier_sealed_batch_from_storage() {
         .storage_mut()
         .upsert_sealed_batch_submission(&SealedBatchSubmission::new(
             batch_id,
+            crate::batch_fate::BatchMode::Transactional,
             target_branch,
             vec![SealedBatchMember {
                 object_id: staged_row_id,

--- a/crates/jazz-tools/src/runtime_core/ticks.rs
+++ b/crates/jazz-tools/src/runtime_core/ticks.rs
@@ -210,6 +210,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         }
         Some(SealedBatchSubmission::new(
             batch_id,
+            crate::batch_fate::BatchMode::Direct,
             first_branch,
             rows.iter()
                 .map(|(member, _, _)| SealedBatchMember {

--- a/crates/jazz-tools/src/runtime_core/writes.rs
+++ b/crates/jazz-tools/src/runtime_core/writes.rs
@@ -267,6 +267,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         };
         Ok(SealedBatchSubmission::new(
             record.batch_id,
+            record.mode,
             target_branch_name,
             members,
             captured_frontier,
@@ -756,7 +757,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         fate: Option<BatchFate>,
     ) -> Result<Option<LocalBatchRecord>, RuntimeError> {
         let mut record =
-            LocalBatchRecord::new(submission.batch_id, BatchMode::Direct, true, fate.clone());
+            LocalBatchRecord::new(submission.batch_id, submission.mode, true, fate.clone());
         record.sealed_submission = Some(submission.clone());
 
         for sealed_member in submission.members {

--- a/crates/jazz-tools/src/storage/conformance.rs
+++ b/crates/jazz-tools/src/storage/conformance.rs
@@ -942,6 +942,7 @@ pub fn test_local_batch_record_round_trip(factory: &dyn Fn() -> Box<dyn Storage>
     });
     record.sealed_submission = Some(SealedBatchSubmission::new(
         batch_id,
+        crate::batch_fate::BatchMode::Direct,
         crate::object::BranchName::new("dev-aaaaaaaaaaaa-main"),
         vec![SealedBatchMember {
             object_id: ObjectId::from_uuid(uuid::Uuid::from_u128(92)),
@@ -1047,6 +1048,7 @@ pub fn test_sealed_batch_submission_round_trip(factory: &dyn Fn() -> Box<dyn Sto
     let bob = ObjectId::from_uuid(uuid::Uuid::from_u128(302));
     let submission = SealedBatchSubmission::new(
         batch_id,
+        crate::batch_fate::BatchMode::Transactional,
         crate::object::BranchName::new("main"),
         vec![
             SealedBatchMember {
@@ -1075,6 +1077,7 @@ pub fn test_sealed_batch_submission_round_trip(factory: &dyn Fn() -> Box<dyn Sto
         storage.load_sealed_batch_submission(batch_id).unwrap(),
         Some(SealedBatchSubmission::new(
             batch_id,
+            crate::batch_fate::BatchMode::Transactional,
             crate::object::BranchName::new("main"),
             vec![
                 SealedBatchMember {
@@ -1113,6 +1116,7 @@ pub fn test_sealed_batch_submission_delete_removes_record(factory: &dyn Fn() -> 
     let batch_id = crate::row_histories::BatchId::new();
     let submission = SealedBatchSubmission::new(
         batch_id,
+        crate::batch_fate::BatchMode::Direct,
         crate::object::BranchName::new("main"),
         vec![SealedBatchMember {
             object_id: ObjectId::from_uuid(uuid::Uuid::from_u128(401)),
@@ -1218,6 +1222,7 @@ pub fn test_local_batch_record_survives_close_reopen(factory: &PersistentStorage
     );
     record.sealed_submission = Some(SealedBatchSubmission::new(
         batch_id,
+        crate::batch_fate::BatchMode::Direct,
         crate::object::BranchName::new("dev-aaaaaaaaaaaa-main"),
         vec![SealedBatchMember {
             object_id: ObjectId::from_uuid(uuid::Uuid::from_u128(112)),
@@ -1292,6 +1297,7 @@ pub fn test_sealed_batch_submission_survives_close_reopen(factory: &PersistentSt
     let batch_id = crate::row_histories::BatchId::new();
     let submission = SealedBatchSubmission::new(
         batch_id,
+        crate::batch_fate::BatchMode::Direct,
         crate::object::BranchName::new("main"),
         vec![
             SealedBatchMember {

--- a/crates/jazz-tools/src/storage/memory.rs
+++ b/crates/jazz-tools/src/storage/memory.rs
@@ -2965,6 +2965,7 @@ mod tests {
         });
         let submission = SealedBatchSubmission::new(
             batch_id,
+            crate::batch_fate::BatchMode::Direct,
             BranchName::new("main"),
             vec![SealedBatchMember {
                 object_id,

--- a/crates/jazz-tools/src/storage/mod.rs
+++ b/crates/jazz-tools/src/storage/mod.rs
@@ -1626,6 +1626,7 @@ fn exact_visible_row_table_locator_for_delete<H: Storage + ?Sized>(
 fn sealed_batch_submission_storage_descriptor_with_branch_ords() -> RowDescriptor {
     RowDescriptor::new(vec![
         ColumnDescriptor::new("batch_id", ColumnType::BatchId),
+        ColumnDescriptor::new("mode", ColumnType::Text),
         ColumnDescriptor::new("target_branch_ord", ColumnType::Integer),
         ColumnDescriptor::new("batch_digest", ColumnType::Bytea),
         ColumnDescriptor::new(
@@ -2471,6 +2472,7 @@ fn encode_sealed_batch_submission_with_branch_ords<H: Storage + ?Sized>(
         &sealed_batch_submission_storage_descriptor_with_branch_ords(),
         &[
             Value::BatchId(*submission.batch_id.as_bytes()),
+            Value::Text(encode_batch_mode(submission.mode).to_string()),
             Value::Integer(target_branch_ord),
             Value::Bytea(submission.batch_digest.0.to_vec()),
             Value::Array(member_values),
@@ -2491,6 +2493,7 @@ fn decode_sealed_batch_submission_with_branch_ords<H: Storage + ?Sized>(
     .map_err(|err| StorageError::IoError(format!("decode sealed batch submission: {err}")))?;
     let [
         batch_id,
+        mode,
         target_branch_ord,
         batch_digest,
         members,
@@ -2503,6 +2506,14 @@ fn decode_sealed_batch_submission_with_branch_ords<H: Storage + ?Sized>(
     };
 
     let batch_id = decode_storage_batch_id_value(batch_id, "decode sealed batch id")?;
+    let mode = match mode {
+        Value::Text(raw) => decode_batch_mode(raw)?,
+        other => {
+            return Err(StorageError::IoError(format!(
+                "expected sealed batch mode text, got {other:?}"
+            )));
+        }
+    };
     let target_branch_ord = match target_branch_ord {
         Value::Integer(raw) => *raw,
         other => {
@@ -2650,8 +2661,13 @@ fn decode_sealed_batch_submission_with_branch_ords<H: Storage + ?Sized>(
         }
     };
 
-    let submission =
-        SealedBatchSubmission::new(batch_id, target_branch_name, members, captured_frontier);
+    let submission = SealedBatchSubmission::new(
+        batch_id,
+        mode,
+        target_branch_name,
+        members,
+        captured_frontier,
+    );
     if submission.batch_digest != batch_digest {
         return Err(StorageError::IoError(format!(
             "sealed batch digest mismatch: expected {batch_digest:?}, computed {:?}",

--- a/crates/jazz-tools/src/sync_manager/tests.rs
+++ b/crates/jazz-tools/src/sync_manager/tests.rs
@@ -279,8 +279,14 @@ fn sealed_submission(
     members: Vec<SealedBatchMember>,
     captured_frontier: Vec<CapturedFrontierMember>,
 ) -> SealedBatchSubmission {
+    let mode = if captured_frontier.is_empty() {
+        crate::batch_fate::BatchMode::Direct
+    } else {
+        crate::batch_fate::BatchMode::Transactional
+    };
     SealedBatchSubmission::new(
         batch_id,
+        mode,
         BranchName::new(target_branch_name),
         members,
         captured_frontier,

--- a/crates/jazz-tools/tests/rocksdb_storage_integration.rs
+++ b/crates/jazz-tools/tests/rocksdb_storage_integration.rs
@@ -6,7 +6,7 @@ use std::collections::{BTreeSet, HashMap};
 use std::time::Duration;
 
 use jazz_tools::batch_fate::{
-    BatchFate, CapturedFrontierMember, SealedBatchMember, SealedBatchSubmission,
+    BatchFate, BatchMode, CapturedFrontierMember, SealedBatchMember, SealedBatchSubmission,
 };
 use jazz_tools::catalogue::CatalogueEntry;
 use jazz_tools::metadata::{MetadataKey, ObjectType, RowProvenance};
@@ -120,6 +120,7 @@ fn seed_rocksdb_sealed_batch_acceptance(
     storage
         .upsert_sealed_batch_submission(&SealedBatchSubmission::new(
             batch_id,
+            BatchMode::Direct,
             BranchName::new("main"),
             vec![SealedBatchMember {
                 object_id: row_id,
@@ -212,6 +213,7 @@ fn seed_rocksdb_sealed_batch_frontier_conflict(
     storage
         .upsert_sealed_batch_submission(&SealedBatchSubmission::new(
             batch_id,
+            BatchMode::Transactional,
             BranchName::new(target_branch.clone()),
             vec![SealedBatchMember {
                 object_id: staged_row_id,

--- a/crates/jazz-tools/tests/sqlite_storage_integration.rs
+++ b/crates/jazz-tools/tests/sqlite_storage_integration.rs
@@ -6,7 +6,7 @@ use std::collections::{BTreeSet, HashMap};
 use std::time::Duration;
 
 use jazz_tools::batch_fate::{
-    BatchFate, CapturedFrontierMember, SealedBatchMember, SealedBatchSubmission,
+    BatchFate, BatchMode, CapturedFrontierMember, SealedBatchMember, SealedBatchSubmission,
 };
 use jazz_tools::catalogue::CatalogueEntry;
 use jazz_tools::metadata::{MetadataKey, ObjectType, RowProvenance};
@@ -120,6 +120,7 @@ fn seed_sqlite_sealed_batch_acceptance(
     storage
         .upsert_sealed_batch_submission(&SealedBatchSubmission::new(
             batch_id,
+            BatchMode::Direct,
             BranchName::new("main"),
             vec![SealedBatchMember {
                 object_id: row_id,
@@ -212,6 +213,7 @@ fn seed_sqlite_sealed_batch_frontier_conflict(
     storage
         .upsert_sealed_batch_submission(&SealedBatchSubmission::new(
             batch_id,
+            BatchMode::Transactional,
             BranchName::new(target_branch.clone()),
             vec![SealedBatchMember {
                 object_id: staged_row_id,

--- a/packages/jazz-tools/src/runtime/worker-bridge.test.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { WorkerBridge, type PeerSyncBatch } from "./worker-bridge.js";
 import type { Runtime } from "./client.js";
@@ -426,6 +426,33 @@ describe("WorkerBridge", () => {
 
     bridge.applyIncomingServerPayload(enc("from-peer-leader"));
     expect(runtimeMock.receivedFromWorker).toEqual([enc("from-peer-leader")]);
+  });
+
+  it("does not hang forever when a local sync flush ack is dropped", async () => {
+    vi.useFakeTimers();
+    try {
+      const worker = new MockWorker();
+      const runtimeMock = createRuntimeMock();
+      const bridge = new WorkerBridge(worker as unknown as Worker, runtimeMock.runtime);
+
+      const waitPromise = bridge.waitForLocalSyncFlush("batch-dropped-ack");
+      await Promise.resolve();
+
+      expect(worker.posted).toContainEqual({
+        type: "sync",
+        payload: [],
+        ackId: 1,
+        ackBatchId: "batch-dropped-ack",
+      });
+      expect((bridge as any).state.pendingSyncAcks.size).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(2_001);
+
+      await expect(waitPromise).resolves.toBeUndefined();
+      expect((bridge as any).state.pendingSyncAcks.size).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("forwards lifecycle hints to worker", () => {

--- a/packages/jazz-tools/src/runtime/worker-bridge.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.ts
@@ -74,6 +74,7 @@ interface WorkerBridgeState {
 
 const INIT_RESPONSE_TIMEOUT_MS = 12_000;
 const SHUTDOWN_ACK_TIMEOUT_MS = 5_000;
+const LOCAL_SYNC_ACK_TIMEOUT_MS = 2_000;
 
 function createDeferredPromise(): { promise: Promise<void>; resolve: () => void } {
   let resolve!: () => void;
@@ -324,7 +325,7 @@ export class WorkerBridge {
   async waitForLocalSyncFlush(batchId?: string): Promise<void> {
     if (this.isDisposedLike()) return;
     await this.state.initPromise;
-    const deadline = Date.now() + 2_000;
+    const deadline = Date.now() + LOCAL_SYNC_ACK_TIMEOUT_MS;
 
     while (true) {
       this.runtime.batchedTick?.();
@@ -344,7 +345,15 @@ export class WorkerBridge {
         ackId,
         ackBatchId: batchId,
       });
-      const ack = await ackPromise;
+      const remainingMs = Math.max(0, deadline - Date.now());
+      const ack = await Promise.race([
+        ackPromise,
+        new Promise<null>((resolve) => setTimeout(() => resolve(null), remainingMs)),
+      ]);
+      this.state.pendingSyncAcks.delete(ackId);
+      if (ack === null || this.isDisposedLike()) {
+        return;
+      }
       if (!batchId || ack.batchReconciled === true || Date.now() >= deadline) {
         return;
       }


### PR DESCRIPTION
## What

- Race local worker sync flush acknowledgements against the existing 2s deadline and clear pending ack resolvers on timeout.
- Persist sealed batch submissions with their batch mode, then use that mode when synthesizing replay records from sealed submissions.
- Add coverage for dropped worker acks and transactional replay metadata.

## Validation

- pnpm --dir packages/jazz-tools exec vitest run --config vitest.config.ts src/runtime/worker-bridge.test.ts
- cargo test -p jazz-tools rc_transactional_rejected_replay_record_keeps_sealed_submission_mode
- cargo test -p jazz-tools rc_rejected_replay_record_can_be_synthesized_from_sealed_submission
- pre-commit hook: clippy, oxfmt, oxlint, rustfmt
