### PR TITLE
fix: correctly resolve magic columns in subqueries

### DIFF
--- a/.changeset/fix-subquery-magic-columns.md
+++ b/.changeset/fix-subquery-magic-columns.md
@@ -1,0 +1,7 @@
+---
+"jazz-tools": patch
+---
+
+Fix reverse and nested relation includes that selected provenance magic columns such as `$createdAt` and `$updatedAt`.
+
+Included relation rows now remain present when those magic timestamp columns are selected, instead of resolving as missing, null, or empty because subquery row descriptors dropped non-physical magic columns.

--- a/crates/jazz-tools/src/query_manager/graph/compile.rs
+++ b/crates/jazz-tools/src/query_manager/graph/compile.rs
@@ -29,7 +29,7 @@ use super::super::graph_nodes::subgraph::SubgraphTemplate;
 use super::super::graph_nodes::union::UnionNode;
 use super::super::graph_nodes::{NodeId, RowNode};
 use super::super::index::ScanCondition;
-use super::super::magic_columns::{MagicColumnKind, magic_column_kind};
+use super::super::magic_columns::{MagicColumnKind, magic_column_descriptor, magic_column_kind};
 use super::super::policy::PolicyExpr;
 use super::super::query::{ArraySubquerySpec, Condition, Conjunction, Query, QueryBuilder};
 use super::super::relation_ir::{ProjectColumn, ProjectExpr, RelExpr};
@@ -275,6 +275,28 @@ fn project_columns_for_tuple_descriptor(tuple_descriptor: &TupleDescriptor) -> V
                 })
         })
         .collect()
+}
+
+fn selected_output_descriptor(
+    columns: &[ColumnDescriptor],
+    select_columns: Option<&[String]>,
+) -> RowDescriptor {
+    let Some(select_columns) = select_columns else {
+        return RowDescriptor::new(columns.to_vec());
+    };
+
+    RowDescriptor::new(
+        select_columns
+            .iter()
+            .filter_map(|name| {
+                columns
+                    .iter()
+                    .find(|column| column.name.as_str() == name)
+                    .cloned()
+                    .or_else(|| magic_column_kind(name).map(magic_column_descriptor))
+            })
+            .collect(),
+    )
 }
 
 impl QueryGraph {
@@ -1075,22 +1097,11 @@ impl QueryGraph {
 
         let combined_descriptor = RowDescriptor::new(combined_columns);
 
-        // Build output descriptor for inner query
-        let inner_output_descriptor = if let Some(cols) = &spec.select_columns {
-            let columns = cols
-                .iter()
-                .filter_map(|name| {
-                    combined_descriptor
-                        .columns
-                        .iter()
-                        .find(|c| c.name.as_str() == name)
-                        .cloned()
-                })
-                .collect();
-            RowDescriptor::new(columns)
-        } else {
-            combined_descriptor
-        };
+        // Build output descriptor for inner query, including requested magic columns.
+        let inner_output_descriptor = selected_output_descriptor(
+            &combined_descriptor.columns,
+            spec.select_columns.as_deref(),
+        );
 
         // Create subgraph template
         let subgraph_template = SubgraphTemplate::new(
@@ -1150,18 +1161,12 @@ impl QueryGraph {
             }
         }
 
-        // Apply select_columns if specified
-        let base_columns = if let Some(cols) = &spec.select_columns {
-            cols.iter()
-                .filter_map(|name| columns.iter().find(|c| c.name.as_str() == name).cloned())
-                .collect()
-        } else {
-            columns
-        };
-
         // Row id is carried in Value::Row { id: Some(...), .. } rather than
         // as a prepended column.
-        Some(RowDescriptor::new(base_columns))
+        Some(selected_output_descriptor(
+            &columns,
+            spec.select_columns.as_deref(),
+        ))
     }
 
     /// Compile a recursive relation specification into a RecursiveRelationNode.

--- a/crates/jazz-tools/src/query_manager/graph_nodes/magic_columns.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/magic_columns.rs
@@ -6,12 +6,12 @@ use crate::query_manager::encoding::{decode_row, encode_row};
 use crate::query_manager::graph_nodes::policy_eval::{
     PolicyContextEvaluator, collect_policy_dependency_tables,
 };
-use crate::query_manager::magic_columns::MagicColumnKind;
+use crate::query_manager::magic_columns::{MagicColumnKind, magic_column_descriptor};
 use crate::query_manager::policy::Operation;
 use crate::query_manager::session::Session;
 use crate::query_manager::types::{
-    ColumnDescriptor, ColumnName, ColumnType, LoadedRow, Row, RowDescriptor, RowPolicyMode, Schema,
-    TableName, Tuple, TupleDelta, TupleDescriptor, TupleElement, Value,
+    LoadedRow, Row, RowDescriptor, RowPolicyMode, Schema, TableName, Tuple, TupleDelta,
+    TupleDescriptor, TupleElement, Value,
 };
 use crate::storage::Storage;
 
@@ -106,29 +106,7 @@ impl MagicColumnsNode {
 
             if let Some(requests) = grouped.get(&element_index) {
                 for kind in &requests.kinds {
-                    descriptor.columns.push(ColumnDescriptor {
-                        name: ColumnName::new(kind.column_name()),
-                        column_type: match kind {
-                            MagicColumnKind::CanRead
-                            | MagicColumnKind::CanEdit
-                            | MagicColumnKind::CanDelete => ColumnType::Boolean,
-                            MagicColumnKind::CreatedBy | MagicColumnKind::UpdatedBy => {
-                                ColumnType::Text
-                            }
-                            MagicColumnKind::CreatedAt | MagicColumnKind::UpdatedAt => {
-                                ColumnType::Timestamp
-                            }
-                        },
-                        nullable: matches!(
-                            kind,
-                            MagicColumnKind::CanRead
-                                | MagicColumnKind::CanEdit
-                                | MagicColumnKind::CanDelete
-                        ),
-                        references: None,
-                        default: None,
-                        merge_strategy: None,
-                    });
+                    descriptor.columns.push(magic_column_descriptor(*kind));
                 }
 
                 if session.is_some()

--- a/crates/jazz-tools/src/query_manager/magic_columns.rs
+++ b/crates/jazz-tools/src/query_manager/magic_columns.rs
@@ -1,3 +1,5 @@
+use crate::query_manager::types::{ColumnDescriptor, ColumnType};
+
 pub const RESERVED_MAGIC_COLUMN_PREFIX: char = '$';
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -35,6 +37,28 @@ pub fn magic_column_kind(name: &str) -> Option<MagicColumnKind> {
         "$updatedBy" => Some(MagicColumnKind::UpdatedBy),
         "$updatedAt" => Some(MagicColumnKind::UpdatedAt),
         _ => None,
+    }
+}
+
+pub(crate) fn magic_column_descriptor(kind: MagicColumnKind) -> ColumnDescriptor {
+    let descriptor = ColumnDescriptor::new(
+        kind.column_name(),
+        match kind {
+            MagicColumnKind::CanRead | MagicColumnKind::CanEdit | MagicColumnKind::CanDelete => {
+                ColumnType::Boolean
+            }
+            MagicColumnKind::CreatedBy | MagicColumnKind::UpdatedBy => ColumnType::Text,
+            MagicColumnKind::CreatedAt | MagicColumnKind::UpdatedAt => ColumnType::Timestamp,
+        },
+    );
+
+    if matches!(
+        kind,
+        MagicColumnKind::CanRead | MagicColumnKind::CanEdit | MagicColumnKind::CanDelete
+    ) {
+        descriptor.nullable()
+    } else {
+        descriptor
     }
 }
 

--- a/crates/jazz-tools/src/query_manager/manager_tests/array_subqueries.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests/array_subqueries.rs
@@ -1157,6 +1157,83 @@ fn array_subquery_with_select_columns() {
 }
 
 #[test]
+fn array_subquery_with_magic_timestamp_select_columns() {
+    let sync_manager = SyncManager::new();
+    let schema = users_posts_schema();
+    let (mut qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    qm.insert(
+        &mut storage,
+        "users",
+        &[Value::Integer(1), Value::Text("Alice".into())],
+    )
+    .unwrap();
+    qm.insert(
+        &mut storage,
+        "posts",
+        &[
+            Value::Integer(100),
+            Value::Text("Post Title".into()),
+            Value::Integer(1),
+        ],
+    )
+    .unwrap();
+
+    let query = qm
+        .query("users")
+        .with_array("posts", |sub| {
+            sub.from("posts")
+                .correlate("author_id", "users.id")
+                .select(&["id", "title", "$createdAt", "$updatedAt"])
+        })
+        .build();
+
+    let sub_id = qm.subscribe(query).unwrap();
+    qm.process(&mut storage);
+
+    let updates = qm.take_updates();
+    let delta = updates
+        .iter()
+        .find(|u| u.subscription_id == sub_id)
+        .map(|u| &u.delta)
+        .expect("Should have update");
+
+    let posts_row_desc = RowDescriptor::new(vec![
+        ColumnDescriptor::new("id", ColumnType::Integer),
+        ColumnDescriptor::new("title", ColumnType::Text),
+        ColumnDescriptor::new("$createdAt", ColumnType::Timestamp),
+        ColumnDescriptor::new("$updatedAt", ColumnType::Timestamp),
+    ]);
+    let output_descriptor = RowDescriptor::new(vec![
+        ColumnDescriptor::new("id", ColumnType::Integer),
+        ColumnDescriptor::new("name", ColumnType::Text),
+        ColumnDescriptor::new(
+            "posts",
+            ColumnType::Array {
+                element: Box::new(ColumnType::Row {
+                    columns: Box::new(posts_row_desc),
+                }),
+            },
+        ),
+    ]);
+
+    let values = decode_row(&output_descriptor, &delta.added[0].data).expect("decode");
+    let posts = values[2].as_array().expect("posts array");
+
+    assert_eq!(posts.len(), 1, "Should have 1 post");
+    let post_row = posts[0].as_row().expect("post Row");
+    assert_eq!(
+        post_row.len(),
+        4,
+        "Post should include selected magic columns"
+    );
+    assert_eq!(post_row[0], Value::Integer(100));
+    assert_eq!(post_row[1], Value::Text("Post Title".into()));
+    assert!(matches!(post_row[2], Value::Timestamp(_)));
+    assert!(matches!(post_row[3], Value::Timestamp(_)));
+}
+
+#[test]
 fn array_subquery_nested() {
     // Test: nested array subqueries
     // users with_array(posts with_array(comments))

--- a/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
@@ -673,6 +673,77 @@ describe("TS Query API", () => {
       expect("project" in result.todosViaProject[0]!).toBe(false);
     });
 
+    it("include builders can project reverse relation magic timestamp columns", async () => {
+      const startedAt = Date.now();
+      const { id: projectId } = insertProject(db, "Announcements");
+      const { id: todoId } = insertTodo(db, {
+        title: "Write tests",
+        done: false,
+        tags: ["dev"],
+        projectId,
+        assigneesIds: [],
+      });
+
+      const result = await db.one(
+        app.projects
+          .where({ id: { eq: projectId } })
+          .include({
+            todosViaProject: app.todos.limit(1).select("*", "$createdAt", "$updatedAt"),
+          })
+          .requireIncludes(),
+      );
+
+      assert(result, "Result is not defined");
+      expect(result.todosViaProject).toHaveLength(1);
+      const todo = result.todosViaProject[0];
+      assert(todo, "Included todo is not defined");
+      expect(todo.id).toBe(todoId);
+      expect(todo.title).toBe("Write tests");
+      expect(todo.$createdAt).toBeInstanceOf(Date);
+      expect(todo.$updatedAt).toBeInstanceOf(Date);
+      expect(todo.$createdAt.getTime()).toBeGreaterThanOrEqual(startedAt - 60_000);
+      expect(todo.$updatedAt.getTime()).toBeGreaterThanOrEqual(startedAt - 60_000);
+    });
+
+    it("include builders can project magic timestamp columns on nested array relations", async () => {
+      const startedAt = Date.now();
+      const { id: projectId } = insertProject(db, "Announcements");
+      const { id: assigneeId } = insertUser(db, "Alice");
+      const { id: todoId } = insertTodo(db, {
+        title: "Write tests",
+        done: false,
+        tags: ["dev"],
+        projectId,
+        assigneesIds: [assigneeId],
+      });
+
+      const result = await db.one(
+        app.projects
+          .where({ id: { eq: projectId } })
+          .include({
+            todosViaProject: app.todos.select("title").include({
+              assignees: app.users.select("name", "$createdAt", "$updatedAt"),
+            }),
+          })
+          .requireIncludes(),
+      );
+
+      assert(result, "Result is not defined");
+      expect(result.todosViaProject).toHaveLength(1);
+      const todo = result.todosViaProject[0];
+      assert(todo, "Included todo is not defined");
+      expect(todo.id).toBe(todoId);
+      expect(todo.assignees).toHaveLength(1);
+      const assignee = todo.assignees[0];
+      assert(assignee, "Nested assignee is not defined");
+      expect(assignee.id).toBe(assigneeId);
+      expect(assignee.name).toBe("Alice");
+      expect(assignee.$createdAt).toBeInstanceOf(Date);
+      expect(assignee.$updatedAt).toBeInstanceOf(Date);
+      expect(assignee.$createdAt.getTime()).toBeGreaterThanOrEqual(startedAt - 60_000);
+      expect(assignee.$updatedAt.getTime()).toBeGreaterThanOrEqual(startedAt - 60_000);
+    });
+
     it("subscribeAll preserves projected root columns with includes", async () => {
       const { id: projectId } = insertProject(db, "Announcements");
       const { id: ownerId } = insertUser(db);


### PR DESCRIPTION
## Summary

- Fix magic-column projection inside array subqueries and nested/reverse relation includes.
- Ensure selected magic columns like `$createdAt` and `$updatedAt` are added to subquery row descriptors even though they are not physical table columns.
- Centralize magic-column descriptor creation and add Rust + TS DSL coverage for timestamp magic columns in subquery/include projections.

## Motivation / Problem

Issue #825 reported that including a reverse relation worked with `.select("*")`, but returned a missing/null/empty included row when the relation selected Jazz magic columns such as `$createdAt` and `$updatedAt`.

The expected behavior is that selecting magic columns should only add those fields to the included entity, not change whether the related row is returned.

## Testing
- Added Rust query-manager coverage for array subqueries selecting `$createdAt` and `$updatedAt`.
- Added TS DSL tests for reverse relation includes and nested array relation includes projecting magic timestamp columns.

## Follow-up
This change also surfaced a separate issue around permission-introspection magic columns like `$canRead`, `$canEdit`, and `$canDelete`.
Those columns are more complex than provenance timestamps because they are relational: their values depend on policy evaluation, the active session/auth context, and related tables used by the permission graph. Supporting them correctly in subqueries would likely require forwarding the parent query session into subgraph compilation and subscribing relation/subquery nodes to the relevant policy and magic-column dependency tables, not just the directly included relation table.

Closes #825 