### PR TITLE
docs: add RSS feed for blog

### DIFF
--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -17,6 +17,16 @@ export const metadata: Metadata = {
         ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
         : "http://localhost:3000"),
   ),
+  alternates: {
+    types: {
+      "application/rss+xml": [
+        {
+          title: "Jazz Blog",
+          url: "/rss.xml",
+        },
+      ],
+    },
+  },
 };
 
 export default function Layout({ children }: LayoutProps<"/">) {

--- a/docs/app/rss.xml/route.ts
+++ b/docs/app/rss.xml/route.ts
@@ -1,0 +1,11 @@
+import { getRSS } from "@/lib/rss";
+
+export const revalidate = false;
+
+export function GET() {
+  return new Response(getRSS(), {
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+    },
+  });
+}

--- a/docs/lib/rss.ts
+++ b/docs/lib/rss.ts
@@ -1,0 +1,35 @@
+import { Feed } from "feed";
+import { blogSource } from "@/lib/source";
+
+const baseUrl =
+  process.env.NEXT_PUBLIC_SITE_URL ??
+  (process.env.VERCEL_PROJECT_PRODUCTION_URL
+    ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
+    : "http://localhost:3000");
+
+export function getRSS() {
+  const feed = new Feed({
+    title: "Jazz Blog",
+    description: "Long-form writing about Jazz, local-first systems, sync, and the cloud.",
+    id: `${baseUrl}/blog`,
+    link: `${baseUrl}/blog`,
+    language: "en",
+  });
+
+  const posts = [...blogSource.getPages()].sort(
+    (a, b) => new Date(a.data.date).getTime() - new Date(b.data.date).getTime(),
+  );
+
+  for (const page of posts) {
+    feed.addItem({
+      id: `${baseUrl}${page.url}`,
+      title: page.data.title,
+      description: page.data.description,
+      link: `${baseUrl}${page.url}`,
+      date: new Date(page.data.date),
+      author: [{ name: page.data.author }],
+    });
+  }
+
+  return feed.rss2();
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@vercel/analytics": "^2.0.1",
+    "feed": "^5.2.1",
     "fumadocs-core": "16.6.2",
     "fumadocs-mdx": "14.2.7",
     "fumadocs-ui": "16.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,6 +250,9 @@ importers:
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.53.6)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.53.6)(typescript@6.0.2)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(next@16.1.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(svelte@5.53.6)(vue@3.5.29(typescript@6.0.2))
+      feed:
+        specifier: ^5.2.1
+        version: 5.2.1
       fumadocs-core:
         specifier: 16.6.2
         version: 16.6.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6)
@@ -640,7 +643,7 @@ importers:
         version: 19.2.14
       babel-preset-expo:
         specifier: ~54.0.10
-        version: 54.0.10(@babel/core@7.29.0)(@babel/runtime@7.28.6)(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-refresh@0.14.2)
+        version: 54.0.10(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-refresh@0.17.0)
       typescript:
         specifier: catalog:default
         version: 6.0.2
@@ -6513,6 +6516,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
@@ -8455,6 +8459,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  feed@5.2.1:
+    resolution: {integrity: sha512-jTynzYPWs9ALjro0GW8j7sv9y7cJBeOdD4Y88kVqYy/eyusIX3g+499JiTDIlD9Ge/unebx57T4Uzo6vpYvMtA==}
+    engines: {node: '>=20', pnpm: '>=10'}
 
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
@@ -12815,6 +12823,10 @@ packages:
   xcode@3.0.1:
     resolution: {integrity: sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==}
     engines: {node: '>=10.0.0'}
+
+  xml-js@1.6.11:
+    resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
+    hasBin: true
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -20592,6 +20604,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  feed@5.2.1:
+    dependencies:
+      xml-js: 1.6.11
+
   fflate@0.8.2: {}
 
   file-entry-cache@8.0.0:
@@ -26164,6 +26180,10 @@ snapshots:
     dependencies:
       simple-plist: 1.3.1
       uuid: 7.0.3
+
+  xml-js@1.6.11:
+    dependencies:
+      sax: 1.5.0
 
   xml-name-validator@5.0.0: {}
 


### PR DESCRIPTION
## Summary
- Adds an RSS 2.0 feed at `/rss.xml` built from `blogSource`, sorted newest-first, with each post's author and date drawn from frontmatter.
- Registers the feed in the root layout via `alternates.types['application/rss+xml']` so browsers and feed readers can auto-discover it.
- Adds `feed` to the `docs` workspace.

## Test plan
- [ ] Run `pnpm dev` in `docs/`, visit `http://localhost:3000/rss.xml`, confirm valid RSS XML listing all blog posts.
- [ ] View source on `/blog` and confirm the `<link rel="alternate" type="application/rss+xml" ...>` tag is in `<head>`.
- [ ] `pnpm types:check` in `docs/` passes.