### PR TITLE
Avoid owned string when deserializing SharedString

### DIFF
--- a/crates/jazz-tools/src/query_manager/types/row.rs
+++ b/crates/jazz-tools/src/query_manager/types/row.rs
@@ -1,6 +1,7 @@
 use std::ops::Deref;
 use std::sync::Arc;
 
+use serde::de::Visitor;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_bytes::ByteBuf;
 
@@ -159,7 +160,38 @@ impl Serialize for SharedString {
 
 impl<'de> Deserialize<'de> for SharedString {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Ok(Self::from(String::deserialize(deserializer)?))
+        struct SharedStringVisitor;
+
+        impl Visitor<'_> for SharedStringVisitor {
+            type Value = SharedString;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a string")
+            }
+
+            fn visit_borrowed_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(SharedString::from(value))
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(SharedString::from(value))
+            }
+
+            fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(SharedString::from(value))
+            }
+        }
+
+        deserializer.deserialize_str(SharedStringVisitor)
     }
 }
 


### PR DESCRIPTION
## Summary
- deserialize SharedString via a serde visitor
- allow borrowed string deserializers to avoid an intermediate owned String when possible

## Verification
- cargo fmt --package jazz-tools
- git diff --check
- pnpm lint (completed with existing oxlint warnings; clippy passed)