### PR TITLE
Prevent upstream durability acks from server replay

### DIFF
--- a/.changeset/quiet-server-replay-acks.md
+++ b/.changeset/quiet-server-replay-acks.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Stop server row replay from sending local durability acknowledgements back upstream, and ignore client-sent durability acknowledgements as authoritative server state.

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -27,70 +27,6 @@ enum SealedBatchMode {
 }
 
 impl SyncManager {
-    pub(super) fn queue_batch_durability_ack_to_server(
-        &mut self,
-        server_id: ServerId,
-        tier: DurabilityTier,
-        row: &StoredRowBatch,
-        _branch_name: BranchName,
-    ) {
-        if !row.state.is_visible() {
-            return;
-        }
-
-        let is_transactional = matches!(row.state, RowState::VisibleTransactional);
-        if !self.sent_server_batch_fate_acks.insert((
-            server_id,
-            row.batch_id,
-            tier,
-            is_transactional,
-        )) {
-            return;
-        }
-
-        for entry in self.outbox.iter_mut().rev() {
-            if entry.destination != Destination::Server(server_id) {
-                continue;
-            }
-            let SyncPayload::BatchFate { fate } = &mut entry.payload else {
-                continue;
-            };
-
-            match fate {
-                BatchFate::DurableDirect {
-                    batch_id,
-                    confirmed_tier,
-                } if !is_transactional && *batch_id == row.batch_id && *confirmed_tier == tier => {
-                    return;
-                }
-                BatchFate::AcceptedTransaction {
-                    batch_id,
-                    confirmed_tier,
-                } if is_transactional && *batch_id == row.batch_id && *confirmed_tier == tier => {
-                    return;
-                }
-                _ => {}
-            }
-        }
-
-        let fate = if is_transactional {
-            BatchFate::AcceptedTransaction {
-                batch_id: row.batch_id,
-                confirmed_tier: tier,
-            }
-        } else {
-            BatchFate::DurableDirect {
-                batch_id: row.batch_id,
-                confirmed_tier: tier,
-            }
-        };
-
-        self.outbox.push(OutboxEntry {
-            destination: Destination::Server(server_id),
-            payload: SyncPayload::BatchFate { fate },
-        });
-    }
-
     fn retain_client_batch_fate<H: Storage>(&mut self, storage: &mut H, fate: &BatchFate) -> bool {
         self.persist_authoritative_batch_fate(storage, fate).is_ok()
     }
@@ -1099,7 +1035,6 @@ impl SyncManager {
             | SyncPayload::RowBatchNeeded { metadata, row } => {
                 let object_id = row.row_id;
                 let branch_name = BranchName::new(&row.branch);
-                let incoming_confirmed_tier = row.confirmed_tier;
                 tracing::debug!(
                     %object_id,
                     %branch_name,
@@ -1108,19 +1043,6 @@ impl SyncManager {
                 if let Some(applied) = self.apply_row_updated(storage, metadata, row.clone(), true)
                 {
                     self.apply_authoritative_transaction_fate_for_row(storage, &applied.row);
-
-                    let local_tiers = self.my_tiers.iter().copied().collect::<Vec<_>>();
-                    for tier in local_tiers {
-                        if incoming_confirmed_tier.is_some_and(|confirmed| confirmed >= tier) {
-                            continue;
-                        }
-                        self.queue_batch_durability_ack_to_server(
-                            server_id,
-                            tier,
-                            &applied.row,
-                            branch_name,
-                        );
-                    }
 
                     if let Some(update) = applied.visibility_change {
                         self.pending_row_visibility_changes.push(update);

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -27,8 +27,12 @@ enum SealedBatchMode {
 }
 
 impl SyncManager {
-    fn retain_client_batch_fate<H: Storage>(&mut self, storage: &mut H, fate: &BatchFate) -> bool {
-        self.persist_authoritative_batch_fate(storage, fate).is_ok()
+    fn retain_client_batch_fate(&mut self, fate: &BatchFate) -> bool {
+        tracing::debug!(
+            batch_id = ?fate.batch_id(),
+            "ignoring client-sent batch fate; authoritative fates are server-owned"
+        );
+        false
     }
 
     fn validate_sealed_batch_submission(
@@ -1440,7 +1444,7 @@ impl SyncManager {
                     });
             }
             SyncPayload::BatchFate { fate } => {
-                if self.retain_client_batch_fate(storage, fate) {
+                if self.retain_client_batch_fate(fate) {
                     self.pending_batch_fates.push(fate.clone());
                 }
             }
@@ -1590,7 +1594,7 @@ impl SyncManager {
                 );
             }
             SyncPayload::BatchFate { fate } => {
-                if self.retain_client_batch_fate(storage, &fate) {
+                if self.retain_client_batch_fate(&fate) {
                     self.pending_batch_fates.push(fate.clone());
                 }
             }

--- a/crates/jazz-tools/src/sync_manager/mod.rs
+++ b/crates/jazz-tools/src/sync_manager/mod.rs
@@ -100,10 +100,6 @@ pub struct SyncManager {
 
     /// Batch fates to send to clients after a full inbox batch has been processed.
     pub(super) pending_client_batch_fates: HashMap<ClientId, HashSet<BatchId>>,
-    /// Durability acknowledgements already sent to an upstream server during
-    /// this connection. A large replay can deliver many rows from the same
-    /// sealed batch across several ticks, so outbox-local dedupe is not enough.
-    pub(super) sent_server_batch_fate_acks: HashSet<(ServerId, BatchId, DurabilityTier, bool)>,
     /// Per-sync-manager replay cache for table/schema row write context.
     ///
     /// Incoming sync rows usually carry table + origin schema metadata. Rows in
@@ -256,7 +252,6 @@ impl SyncManager {
             pending_query_rejections: Vec::new(),
             pending_batch_fates: Vec::new(),
             pending_client_batch_fates: HashMap::new(),
-            sent_server_batch_fate_acks: HashSet::new(),
             replay_table_contexts: HashMap::new(),
         }
     }
@@ -502,8 +497,6 @@ impl SyncManager {
         self.pending_servers.remove(&server_id);
         self.pending_server_query_subscriptions
             .retain(|(id, _)| *id != server_id);
-        self.sent_server_batch_fate_acks
-            .retain(|(id, ..)| *id != server_id);
         let mut removed_query_ids = HashSet::new();
         self.remote_query_scopes
             .retain(|(remote_server_id, query_id), _| {

--- a/crates/jazz-tools/src/sync_manager/tests/settlements.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/settlements.rs
@@ -94,55 +94,42 @@ fn initial_query_sync_prefers_authoritative_settlement_over_retained_client_loca
 }
 
 #[test]
-fn upstream_durability_ack_is_queued_once_per_replayed_batch() {
-    let mut sm = SyncManager::new();
+fn server_replay_does_not_send_local_durability_ack_upstream() {
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
+    let mut io = MemoryStorage::new();
     let server_id = ServerId::new();
-    let batch_id = BatchId::new();
-    let row_a = row_with_batch_state(
+    let row = row_with_batch_state(
         visible_row(ObjectId::new(), "main", Vec::new(), 1_000, b"alice"),
-        batch_id,
+        BatchId::new(),
         crate::row_histories::RowState::VisibleDirect,
-        Some(DurabilityTier::Local),
-    );
-    let row_b = row_with_batch_state(
-        visible_row(ObjectId::new(), "main", Vec::new(), 1_001, b"bob"),
-        batch_id,
-        crate::row_histories::RowState::VisibleDirect,
-        Some(DurabilityTier::Local),
+        None,
     );
 
-    sm.queue_batch_durability_ack_to_server(
+    seed_users_schema(&mut io);
+    add_server(&mut sm, &io, server_id);
+    sm.take_outbox();
+
+    sm.process_from_server(
+        &mut io,
         server_id,
-        DurabilityTier::Local,
-        &row_a,
-        BranchName::new("main"),
-    );
-    sm.queue_batch_durability_ack_to_server(
-        server_id,
-        DurabilityTier::Local,
-        &row_b,
-        BranchName::new("main"),
+        SyncPayload::RowBatchCreated {
+            metadata: Some(RowMetadata {
+                id: row.row_id,
+                metadata: row_metadata("users"),
+            }),
+            row,
+        },
     );
 
-    let outbox = sm.take_outbox();
-    assert_eq!(
-        outbox
-            .iter()
-            .filter(|entry| matches!(
-                entry,
-                OutboxEntry {
-                    destination: Destination::Server(id),
-                    payload: SyncPayload::BatchFate {
-                        fate: BatchFate::DurableDirect {
-                            batch_id: id_batch,
-                            confirmed_tier: DurabilityTier::Local,
-                        },
-                    },
-                } if *id == server_id && *id_batch == batch_id
-            ))
-            .count(),
-        1,
-        "a replay can process many rows from the same batch across ticks, but the upstream durability ack is batch-scoped"
+    assert!(
+        sm.take_outbox().into_iter().all(|entry| !matches!(
+            entry,
+            OutboxEntry {
+                destination: Destination::Server(id),
+                payload: SyncPayload::BatchFate { .. },
+            } if id == server_id
+        )),
+        "lower-tier nodes must not turn server replay into upstream durability acknowledgements"
     );
 }
 

--- a/crates/jazz-tools/src/sync_manager/tests/settlements.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/settlements.rs
@@ -134,6 +134,38 @@ fn server_replay_does_not_send_local_durability_ack_upstream() {
 }
 
 #[test]
+fn client_durability_ack_is_not_authoritative() {
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::EdgeServer);
+    let mut io = MemoryStorage::new();
+    let client_id = ClientId::new();
+    let batch_id = BatchId::new();
+
+    add_client(&mut sm, &io, client_id);
+    sm.take_outbox();
+
+    sm.process_from_client(
+        &mut io,
+        client_id,
+        SyncPayload::BatchFate {
+            fate: BatchFate::DurableDirect {
+                batch_id,
+                confirmed_tier: DurabilityTier::Local,
+            },
+        },
+    );
+
+    assert_eq!(
+        io.load_authoritative_batch_fate(batch_id).unwrap(),
+        None,
+        "clients must not be able to create authoritative durability settlements"
+    );
+    assert!(
+        sm.take_pending_batch_fates().is_empty(),
+        "ignored client acknowledgements must not be replayed through RuntimeCore"
+    );
+}
+
+#[test]
 fn initial_query_sync_sends_only_current_row_for_deep_history() {
     let mut sm = SyncManager::new();
     let mut io = MemoryStorage::new();

--- a/crates/jazz-tools/src/sync_manager/tests/transaction_sealing.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/transaction_sealing.rs
@@ -217,7 +217,7 @@ fn direct_batch_seal_promotes_existing_local_settlement_to_authority_tier() {
 }
 
 #[test]
-fn direct_client_settlement_retains_replayable_sealed_submission() {
+fn direct_client_settlement_is_not_authoritative() {
     let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
     let mut io = MemoryStorage::new();
     let client_id = ClientId::new();
@@ -259,18 +259,15 @@ fn direct_client_settlement_retains_replayable_sealed_submission() {
 
     assert_eq!(
         io.load_authoritative_batch_fate(batch_id).unwrap(),
-        Some(BatchFate::DurableDirect {
-            batch_id,
-            confirmed_tier: DurabilityTier::Local,
-        }),
-        "direct client fate should be retained without rebuilding a local batch record"
+        None,
+        "direct client fate must not become an authoritative settlement"
     );
     assert_eq!(io.load_local_batch_record(batch_id).unwrap(), None);
     assert_eq!(io.load_sealed_batch_submission(batch_id).unwrap(), None);
 }
 
 #[test]
-fn direct_client_settlement_before_row_retains_replayable_sealed_submission_after_row() {
+fn direct_client_settlement_before_row_is_not_authoritative_after_row() {
     let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
     let mut io = MemoryStorage::new();
     let client_id = ClientId::new();
@@ -314,10 +311,8 @@ fn direct_client_settlement_before_row_retains_replayable_sealed_submission_afte
 
     assert_eq!(
         io.load_authoritative_batch_fate(batch_id).unwrap(),
-        Some(BatchFate::DurableDirect {
-            batch_id,
-            confirmed_tier: DurabilityTier::Local,
-        }),
+        None,
+        "direct client fate must not become authoritative after the row arrives"
     );
     let outbox = sm.take_outbox();
     assert!(
@@ -369,10 +364,8 @@ fn direct_client_settlement_before_row_keeps_sealed_submission_without_server() 
 
     assert_eq!(
         io.load_authoritative_batch_fate(batch_id).unwrap(),
-        Some(BatchFate::DurableDirect {
-            batch_id,
-            confirmed_tier: DurabilityTier::Local,
-        }),
+        None,
+        "direct client fate must not become authoritative"
     );
     assert_eq!(
         io.load_sealed_batch_submission(batch_id).unwrap(),


### PR DESCRIPTION
## Summary
- stop server replay from generating server-directed durability BatchFate acknowledgements
- ignore client-sent BatchFate durability acknowledgements as authoritative server state
- remove the now-unused upstream ack dedupe state
- add regression coverage for both lower-tier replay not sending BatchFate upstream and higher-tier servers ignoring client-sent durability acks
- add a patch changeset

## Verification
- cargo test -p jazz-tools sync_manager::tests::settlements --lib
- cargo test -p jazz-tools sync_manager::tests --lib
- pre-commit hook: clippy, oxfmt, rustfmt
- pnpm lint

Previous measurement was about 26.8s and dominated by apply_received_batch_fates on the server.