### PR TITLE
Fix jazz-napi changeset bump

### DIFF
--- a/.changeset/edge-upstream-sync.md
+++ b/.changeset/edge-upstream-sync.md
@@ -1,6 +1,6 @@
 ---
 "jazz-tools": minor
-"jazz-napi": minor
+"jazz-napi": patch
 ---
 
 Add edge upstream sync support for self-hosted Jazz servers.


### PR DESCRIPTION
## What changed

Changes the `jazz-napi` entry in `.changeset/edge-upstream-sync.md` from `minor` to `patch`.

## Why

The edge upstream sync changeset should still trigger a minor release for `jazz-tools`, but the accompanying `jazz-napi` change should only be a patch bump. This prevents the release plan from showing `jazz-napi@2.0.0-alpha.47` under Minor Changes for commit `3d7e00f`.

## Validation

- Reviewed the diff for the changeset metadata
- Ran `pnpm changeset status --since=origin/main` (not package-diff useful because this edits an existing changeset already on `main`)
- Pre-commit hook ran `oxfmt`
