### PR TITLE
Fix client direct batch fates persistence

### DIFF
--- a/.changeset/fix-client-direct-batch-fates.md
+++ b/.changeset/fix-client-direct-batch-fates.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Persist authoritative direct batch fate when a server accepts sealed client-originated direct batches, preventing reconnect replays from being answered as missing.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,10 +144,6 @@ jobs:
         with:
           tool: sccache
 
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: wasm-pack
-
       - name: Mount sccache sticky disk
         uses: useblacksmith/stickydisk@v1
         with:

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -20,6 +20,20 @@ struct AppliedRowBatch {
     visibility_change: Option<RowVisibilityChange>,
 }
 
+/// Whether applying a visible row should also record this server's
+/// authoritative fate for the row's batch.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum AuthoritativeFateRecording {
+    Skip,
+    AcceptedByLocalAuthority,
+}
+
+impl AuthoritativeFateRecording {
+    fn should_record(self) -> bool {
+        matches!(self, Self::AcceptedByLocalAuthority)
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum SealedBatchMode {
     Direct,
@@ -322,7 +336,7 @@ impl SyncManager {
         storage: &mut H,
         metadata: Option<RowMetadata>,
         mut row: StoredRowBatch,
-        record_local_fate: bool,
+        fate_recording: AuthoritativeFateRecording,
     ) -> Option<AppliedRowBatch> {
         let authoritative_tier = match (row.confirmed_tier, self.max_local_durability_tier()) {
             (Some(incoming), Some(local)) => Some(incoming.max(local)),
@@ -382,7 +396,7 @@ impl SyncManager {
                     }
                 }
             };
-        if record_local_fate
+        if fate_recording.should_record()
             && let Some(confirmed_tier) = authoritative_tier
             && row.state.is_visible()
         {
@@ -1044,8 +1058,12 @@ impl SyncManager {
                     %branch_name,
                     "server→row-batch payload"
                 );
-                if let Some(applied) = self.apply_row_updated(storage, metadata, row.clone(), true)
-                {
+                if let Some(applied) = self.apply_row_updated(
+                    storage,
+                    metadata,
+                    row.clone(),
+                    AuthoritativeFateRecording::AcceptedByLocalAuthority,
+                ) {
                     self.apply_authoritative_transaction_fate_for_row(storage, &applied.row);
 
                     if let Some(update) = applied.visibility_change {
@@ -1184,7 +1202,12 @@ impl SyncManager {
                 let branch_name = BranchName::new("main");
                 match client.role {
                     ClientRole::Peer | ClientRole::Admin => {
-                        self.apply_payload_from_client(storage, client_id, payload, false);
+                        self.apply_payload_from_client(
+                            storage,
+                            client_id,
+                            payload,
+                            AuthoritativeFateRecording::Skip,
+                        );
                     }
                     ClientRole::Backend => {
                         self.outbox.push(OutboxEntry {
@@ -1209,7 +1232,12 @@ impl SyncManager {
                         if self.allow_unprivileged_schema_catalogue_writes
                             && entry.is_structural_schema_catalogue()
                         {
-                            self.apply_payload_from_client(storage, client_id, payload, false);
+                            self.apply_payload_from_client(
+                                storage,
+                                client_id,
+                                payload,
+                                AuthoritativeFateRecording::Skip,
+                            );
                             return;
                         }
                         self.outbox.push(OutboxEntry {
@@ -1228,7 +1256,12 @@ impl SyncManager {
                 let branch_name = BranchName::new(&row.branch);
                 match client.role {
                     ClientRole::Peer | ClientRole::Admin => {
-                        self.apply_payload_from_client(storage, client_id, payload, false);
+                        self.apply_payload_from_client(
+                            storage,
+                            client_id,
+                            payload,
+                            AuthoritativeFateRecording::Skip,
+                        );
                     }
                     ClientRole::Backend => {
                         if payload.is_catalogue() {
@@ -1241,7 +1274,12 @@ impl SyncManager {
                             });
                             return;
                         }
-                        self.apply_payload_from_client(storage, client_id, payload, false);
+                        self.apply_payload_from_client(
+                            storage,
+                            client_id,
+                            payload,
+                            AuthoritativeFateRecording::Skip,
+                        );
                     }
                     ClientRole::User => {
                         let Some(session) = &client.session else {
@@ -1258,7 +1296,12 @@ impl SyncManager {
                             if self.allow_unprivileged_schema_catalogue_writes
                                 && payload.is_structural_schema_catalogue()
                             {
-                                self.apply_payload_from_client(storage, client_id, payload, false);
+                                self.apply_payload_from_client(
+                                    storage,
+                                    client_id,
+                                    payload,
+                                    AuthoritativeFateRecording::Skip,
+                                );
                                 return;
                             }
                             self.outbox.push(OutboxEntry {
@@ -1347,7 +1390,12 @@ impl SyncManager {
                 }
             }
             SyncPayload::SealBatch { .. } => {
-                self.apply_payload_from_client(storage, client_id, payload, false);
+                self.apply_payload_from_client(
+                    storage,
+                    client_id,
+                    payload,
+                    AuthoritativeFateRecording::Skip,
+                );
             }
             // Handle query subscription with full Query struct
             // Queue for QueryManager to process (SyncManager doesn't know about QueryGraph)
@@ -1493,7 +1541,7 @@ impl SyncManager {
         storage: &mut H,
         client_id: ClientId,
         payload: SyncPayload,
-        _was_pending: bool,
+        fate_recording: AuthoritativeFateRecording,
     ) {
         match payload {
             SyncPayload::CatalogueEntryUpdated { entry } => {
@@ -1513,7 +1561,8 @@ impl SyncManager {
                     .or_default()
                     .insert(client_id);
 
-                if let Some(applied) = self.apply_row_updated(storage, metadata, row.clone(), false)
+                if let Some(applied) =
+                    self.apply_row_updated(storage, metadata, row.clone(), fate_recording)
                 {
                     self.forward_row_batch_to_servers(
                         storage,

--- a/crates/jazz-tools/src/sync_manager/permissions.rs
+++ b/crates/jazz-tools/src/sync_manager/permissions.rs
@@ -1,3 +1,4 @@
+use super::inbox::AuthoritativeFateRecording;
 use super::*;
 use crate::batch_fate::BatchFate;
 use crate::query_manager::policy::Operation;
@@ -42,7 +43,12 @@ impl SyncManager {
             self.queue_batch_fate_to_client(check.client_id, fate);
             return;
         }
-        self.apply_payload_from_client(storage, check.client_id, check.payload, true);
+        self.apply_payload_from_client(
+            storage,
+            check.client_id,
+            check.payload,
+            AuthoritativeFateRecording::Skip,
+        );
         if let Some(batch_id) = batch_id {
             self.try_accept_completed_sealed_batch_from_client(storage, check.client_id, batch_id);
         }

--- a/crates/jazz-tools/src/sync_manager/tests/settlements.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/settlements.rs
@@ -166,6 +166,157 @@ fn client_durability_ack_is_not_authoritative() {
 }
 
 #[test]
+fn sealed_direct_client_write_persists_authoritative_fate() {
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
+    let mut io = MemoryStorage::new();
+    let client_id = ClientId::new();
+    let row = visible_row(ObjectId::new(), "main", Vec::new(), 1_000, b"alice");
+
+    seed_users_schema(&mut io);
+    add_client(&mut sm, &io, client_id);
+    sm.set_client_role(client_id, ClientRole::Peer);
+    sm.take_outbox();
+
+    sm.process_from_client(
+        &mut io,
+        client_id,
+        SyncPayload::RowBatchCreated {
+            metadata: Some(RowMetadata {
+                id: row.row_id,
+                metadata: row_metadata("users"),
+            }),
+            row: row.clone(),
+        },
+    );
+    assert_eq!(
+        io.load_authoritative_batch_fate(row.batch_id).unwrap(),
+        None,
+        "an unsealed direct batch should not become globally authoritative from row arrival alone"
+    );
+
+    sm.process_from_client(
+        &mut io,
+        client_id,
+        SyncPayload::SealBatch {
+            submission: sealed_submission(
+                row.batch_id,
+                "main",
+                vec![SealedBatchMember {
+                    object_id: row.row_id,
+                    row_digest: row.content_digest(),
+                }],
+                Vec::new(),
+            ),
+        },
+    );
+
+    assert_eq!(
+        io.load_authoritative_batch_fate(row.batch_id).unwrap(),
+        Some(BatchFate::DurableDirect {
+            batch_id: row.batch_id,
+            confirmed_tier: DurabilityTier::Local,
+        }),
+        "an authoritative server that accepts a visible direct client write must persist its durable fate"
+    );
+}
+
+#[test]
+fn replayed_approved_user_write_returns_durable_fate_not_missing() {
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
+    let mut io = MemoryStorage::new();
+    let client_id = ClientId::new();
+    let row = visible_row(ObjectId::new(), "main", Vec::new(), 1_000, b"alice");
+
+    seed_users_schema(&mut io);
+    add_client(&mut sm, &io, client_id);
+    sm.set_client_role(client_id, ClientRole::User);
+    sm.set_client_session(
+        client_id,
+        crate::query_manager::session::Session::new("alice"),
+    );
+    sm.take_outbox();
+
+    sm.process_from_client(
+        &mut io,
+        client_id,
+        SyncPayload::RowBatchCreated {
+            metadata: Some(RowMetadata {
+                id: row.row_id,
+                metadata: row_metadata("users"),
+            }),
+            row: row.clone(),
+        },
+    );
+
+    let pending = sm.take_pending_permission_checks();
+    assert_eq!(
+        pending.len(),
+        1,
+        "first user write should wait for permission approval"
+    );
+    sm.approve_permission_check(&mut io, pending.into_iter().next().unwrap());
+    sm.take_outbox();
+
+    sm.process_from_client(
+        &mut io,
+        client_id,
+        SyncPayload::SealBatch {
+            submission: sealed_submission(
+                row.batch_id,
+                "main",
+                vec![SealedBatchMember {
+                    object_id: row.row_id,
+                    row_digest: row.content_digest(),
+                }],
+                Vec::new(),
+            ),
+        },
+    );
+    sm.take_outbox();
+
+    sm.push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::RowBatchCreated {
+            metadata: Some(RowMetadata {
+                id: row.row_id,
+                metadata: row_metadata("users"),
+            }),
+            row: row.clone(),
+        },
+    });
+    sm.process_inbox(&mut io);
+
+    let outbox = sm.take_outbox();
+    assert!(
+        outbox.iter().any(|entry| matches!(
+            entry,
+            OutboxEntry {
+                destination: Destination::Client(id),
+                payload: SyncPayload::BatchFate {
+                    fate: BatchFate::DurableDirect {
+                        batch_id,
+                        confirmed_tier: DurabilityTier::Local,
+                    },
+                },
+            } if *id == client_id && *batch_id == row.batch_id
+        )),
+        "idempotent replay should return the authoritative durable fate, got {outbox:?}"
+    );
+    assert!(
+        outbox.iter().all(|entry| !matches!(
+            entry,
+            OutboxEntry {
+                destination: Destination::Client(id),
+                payload: SyncPayload::BatchFate {
+                    fate: BatchFate::Missing { batch_id },
+                },
+            } if *id == client_id && *batch_id == row.batch_id
+        )),
+        "accepted client writes must not be reported as missing on replay, got {outbox:?}"
+    );
+}
+
+#[test]
 fn initial_query_sync_sends_only_current_row_for_deep_history() {
     let mut sm = SyncManager::new();
     let mut io = MemoryStorage::new();


### PR DESCRIPTION
## What

- Persist authoritative batch fate when a local authority accepts a sealed client-originated direct batch.
- Keep unsealed direct batch rows out of global reads until `SealBatch` is processed.
- Replace the ambiguous local fate boolean with `AuthoritativeFateRecording` so call sites state whether they are minting local authority from confirmed rows.
- Remove CI's redundant `taiki-e/install-action` wasm-pack step; `ensure:rust-toolchain` already installs wasm-pack successfully, while the duplicate action now resolves to missing release URLs.
- Add regressions for sealed direct client writes and permission-approved user write replay returning `DurableDirect` instead of `Missing`.
- Add a patch changeset for `jazz-tools`.

## Why

Direct client writes could be applied to row history without an authoritative `BatchFate`. On reconnect/idempotent replay, the server could find the row but not its fate, fall back to `BatchFate::Missing`, and trigger the client replay loop.

The first PR version recorded fate too early for unsealed direct batches; CI caught that in browser transaction-read tests. This version keeps direct-batch authority at the seal boundary.

Client-sent fates remain non-authoritative; the persisted fate comes from the server accepting the sealed batch.

## Validation

- `cargo fmt --check`
- `cargo test -p jazz-tools sync_manager::tests -- --nocapture`
- `cargo test -p jazz-tools`
- `pnpm lint`
- `pnpm build:ci`
- `pnpm --dir packages/jazz-tools exec vitest run --config vitest.config.browser.ts tests/browser/db.transaction-reads.test.ts`