### PR TITLE
fix: update indexes on tx/batch commit

### DIFF
--- a/.changeset/fix-batch-overlay-deleted-reads.md
+++ b/.changeset/fix-batch-overlay-deleted-reads.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Keep transaction and direct-batch writes isolated from ordinary indexed queries until commit, while still letting batch-scoped reads see their own staged inserts, updates, and deletes.

--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -24,9 +24,9 @@ export declare class NapiRuntime {
   deleteWithSession(objectId: string, writeContextJson?: string | undefined | null): any
   loadLocalBatchRecord(batchId: string): any | null
   loadLocalBatchRecords(): any[]
+  loadBatchFate(batchId: string): any | null
   acknowledgeRejectedBatch(batchId: string): boolean
   onMutationError(callback: (event: any) => void): void
-  loadBatchFate(batchId: string): any | null
   discardLocalBatch(batchId: string): boolean
   sealBatch(batchId: string): void
   waitForBatch(batchId: string, tier: string): Promise<void>

--- a/crates/jazz-tools/src/query_manager/graph/execute.rs
+++ b/crates/jazz-tools/src/query_manager/graph/execute.rs
@@ -1,9 +1,11 @@
 use ahash::{AHashMap, AHashSet};
 use smallvec::SmallVec;
+use std::collections::HashMap;
 
 use crate::object::ObjectId;
 use crate::query_manager::types::{LoadedRow, RowDelta, TableName, Tuple, TupleDelta};
 use crate::storage::Storage;
+use crate::sync_manager::RowBatchKey;
 
 use super::super::graph_nodes::{NodeId, RowNode, SourceContext, SourceNode, TransformNode};
 use super::{GraphNode, QueryGraph};
@@ -392,13 +394,28 @@ impl QueryGraph {
     where
         F: FnMut(ObjectId, Option<TableName>) -> Option<LoadedRow>,
     {
+        self.settle_with_source_overlay(storage, None, &mut row_loader)
+    }
+
+    pub(crate) fn settle_with_source_overlay<F>(
+        &mut self,
+        storage: &dyn Storage,
+        local_overlay_rows: Option<&HashMap<ObjectId, RowBatchKey>>,
+        mut row_loader: F,
+    ) -> RowDelta
+    where
+        F: FnMut(ObjectId, Option<TableName>) -> Option<LoadedRow>,
+    {
         let order = self.topo_sort_dirty();
         if !order.is_empty() {
             tracing::trace!(dirty_nodes = order.len(), table = %self.table, "settling query graph");
         }
         let mut tuple_deltas: AHashMap<NodeId, TupleDelta> = AHashMap::new();
 
-        let ctx = SourceContext { storage };
+        let ctx = SourceContext {
+            storage,
+            local_overlay_rows,
+        };
 
         for node_id in order {
             let node_type = match self.get_node(node_id) {

--- a/crates/jazz-tools/src/query_manager/graph_nodes/index_scan.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/index_scan.rs
@@ -113,7 +113,9 @@ impl IndexScanNode {
             ) else {
                 continue;
             };
-            if row.is_soft_deleted() || row.is_hard_deleted() {
+            if self.column.as_str() == "_id_deleted" && row.is_soft_deleted() {
+                new_ids.insert(row_id);
+            } else if row.is_soft_deleted() || row.is_hard_deleted() {
                 new_ids.remove(&row_id);
             } else if self.overlay_value_matches_condition(row_id, &row.data) {
                 new_ids.insert(row_id);

--- a/crates/jazz-tools/src/query_manager/graph_nodes/index_scan.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/index_scan.rs
@@ -1,10 +1,12 @@
 use ahash::AHashSet;
+use std::ops::Bound;
 
 use crate::object::{BranchName, ObjectId};
 use crate::query_manager::index::ScanCondition;
 use crate::query_manager::types::{
-    ColumnName, RowDescriptor, TableName, Tuple, TupleDelta, TupleDescriptor,
+    ColumnName, RowDescriptor, TableName, Tuple, TupleDelta, TupleDescriptor, Value,
 };
+use crate::row_format::decode_row;
 
 use super::{SourceContext, SourceNode};
 
@@ -19,6 +21,7 @@ pub struct IndexScanNode {
 
     /// Output tuple descriptor (single element, unmaterialized).
     output_descriptor: TupleDescriptor,
+    row_descriptor: RowDescriptor,
 
     /// Current set of tuples (length-1) matching the condition.
     current_tuples: AHashSet<Tuple>,
@@ -38,13 +41,14 @@ impl IndexScanNode {
         row_descriptor: RowDescriptor,
     ) -> Self {
         let table = table.into();
-        let output_descriptor = TupleDescriptor::single(table.as_str(), row_descriptor);
+        let output_descriptor = TupleDescriptor::single(table.as_str(), row_descriptor.clone());
         Self {
             table,
             column: column.into(),
             branch: branch.into(),
             condition,
             output_descriptor,
+            row_descriptor,
             current_tuples: AHashSet::new(),
             last_scanned_ids: AHashSet::new(),
             dirty: true,
@@ -65,11 +69,114 @@ impl IndexScanNode {
     pub fn output_tuple_descriptor(&self) -> &TupleDescriptor {
         &self.output_descriptor
     }
+
+    fn overlay_value_matches_condition(&self, row_id: ObjectId, data: &[u8]) -> bool {
+        let Some(value) = self.overlay_index_value(row_id, data) else {
+            return false;
+        };
+        match &self.condition {
+            ScanCondition::All => true,
+            ScanCondition::Eq(expected) => value == *expected || array_contains(&value, expected),
+            ScanCondition::Range { min, max } => {
+                bound_matches(min, &value, true) && bound_matches(max, &value, false)
+            }
+        }
+    }
+
+    fn overlay_index_value(&self, row_id: ObjectId, data: &[u8]) -> Option<Value> {
+        if self.column.as_str() == "_id" {
+            return Some(Value::Uuid(row_id));
+        }
+        if self.column.as_str() == "_id_deleted" {
+            return None;
+        }
+
+        let column_index = self.row_descriptor.column_index(self.column.as_str())?;
+        let values = decode_row(&self.row_descriptor, data).ok()?;
+        values.get(column_index).cloned()
+    }
+
+    fn apply_local_overlay_rows(&self, ctx: &SourceContext, new_ids: &mut AHashSet<ObjectId>) {
+        let Some(local_overlay_rows) = ctx.local_overlay_rows else {
+            return;
+        };
+
+        for (&row_id, row_batch_key) in local_overlay_rows {
+            if row_batch_key.branch_name.as_str() != self.branch {
+                continue;
+            }
+            let Ok(Some(row)) = ctx.storage.load_history_query_row_batch(
+                self.table.as_str(),
+                self.branch.as_str(),
+                row_id,
+                row_batch_key.batch_id,
+            ) else {
+                continue;
+            };
+            if row.is_soft_deleted() || row.is_hard_deleted() {
+                new_ids.remove(&row_id);
+            } else if self.overlay_value_matches_condition(row_id, &row.data) {
+                new_ids.insert(row_id);
+            } else {
+                new_ids.remove(&row_id);
+            }
+        }
+    }
+}
+
+fn array_contains(value: &Value, expected: &Value) -> bool {
+    matches!(value, Value::Array(values) if values.iter().any(|value| value == expected))
+}
+
+fn compare_values_for_ordering(left: &Value, right: &Value) -> Option<std::cmp::Ordering> {
+    match (left, right) {
+        (Value::Integer(a), Value::Integer(b)) => Some(a.cmp(b)),
+        (Value::BigInt(a), Value::BigInt(b)) => Some(a.cmp(b)),
+        (Value::Double(a), Value::Double(b)) => Some(a.total_cmp(b)),
+        (Value::Boolean(a), Value::Boolean(b)) => Some(a.cmp(b)),
+        (Value::Text(a), Value::Text(b)) => Some(a.cmp(b)),
+        (Value::Timestamp(a), Value::Timestamp(b)) => Some(a.cmp(b)),
+        (Value::Uuid(a), Value::Uuid(b)) => Some(a.cmp(b)),
+        (Value::Null, Value::Null) => Some(std::cmp::Ordering::Equal),
+        (Value::Null, _) => Some(std::cmp::Ordering::Less),
+        (_, Value::Null) => Some(std::cmp::Ordering::Greater),
+        _ => None,
+    }
+}
+
+fn bound_matches(bound: &Bound<Value>, value: &Value, is_lower: bool) -> bool {
+    match bound {
+        Bound::Unbounded => true,
+        Bound::Included(bound) => compare_values_for_ordering(value, bound)
+            .map(|ordering| {
+                if is_lower {
+                    matches!(
+                        ordering,
+                        std::cmp::Ordering::Greater | std::cmp::Ordering::Equal
+                    )
+                } else {
+                    matches!(
+                        ordering,
+                        std::cmp::Ordering::Less | std::cmp::Ordering::Equal
+                    )
+                }
+            })
+            .unwrap_or(false),
+        Bound::Excluded(bound) => compare_values_for_ordering(value, bound)
+            .map(|ordering| {
+                if is_lower {
+                    ordering == std::cmp::Ordering::Greater
+                } else {
+                    ordering == std::cmp::Ordering::Less
+                }
+            })
+            .unwrap_or(false),
+    }
 }
 
 impl SourceNode for IndexScanNode {
     fn scan(&mut self, ctx: &SourceContext) -> TupleDelta {
-        let new_ids: AHashSet<ObjectId> = match &self.condition {
+        let mut new_ids: AHashSet<ObjectId> = match &self.condition {
             ScanCondition::All => ctx
                 .storage
                 .index_scan_all(self.table.as_str(), self.column.as_str(), &self.branch)
@@ -100,6 +207,7 @@ impl SourceNode for IndexScanNode {
                     .collect()
             }
         };
+        self.apply_local_overlay_rows(ctx, &mut new_ids);
 
         // Diff against last scan
         let added: Vec<ObjectId> = new_ids
@@ -165,7 +273,10 @@ mod tests {
     use std::ops::Bound;
 
     fn make_ctx(storage: &dyn crate::storage::Storage) -> SourceContext<'_> {
-        SourceContext { storage }
+        SourceContext {
+            storage,
+            local_overlay_rows: None,
+        }
     }
 
     fn test_descriptor() -> RowDescriptor {

--- a/crates/jazz-tools/src/query_manager/graph_nodes/mod.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/mod.rs
@@ -18,10 +18,14 @@ pub mod subgraph;
 pub mod tuple_delta;
 pub mod union;
 
+use std::collections::HashMap;
+
 use ahash::AHashSet;
 
 use super::types::{RowDescriptor, Tuple, TupleDelta};
+use crate::object::ObjectId;
 use crate::storage::Storage;
+use crate::sync_manager::RowBatchKey;
 
 /// Unique identifier for a node in the query graph.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -30,6 +34,7 @@ pub struct NodeId(pub u64);
 /// Context for source nodes that need external data.
 pub struct SourceContext<'a> {
     pub storage: &'a dyn Storage,
+    pub local_overlay_rows: Option<&'a HashMap<ObjectId, RowBatchKey>>,
 }
 
 // ============================================================================

--- a/crates/jazz-tools/src/query_manager/indices.rs
+++ b/crates/jazz-tools/src/query_manager/indices.rs
@@ -525,17 +525,6 @@ impl QueryManager {
             .map_err(Self::map_index_storage_error)
     }
 
-    pub(crate) fn retract_local_pending_transaction_row(
-        &mut self,
-        storage: &mut dyn Storage,
-        table: &str,
-        branch: &str,
-        row_id: ObjectId,
-        row_data: &[u8],
-    ) {
-        self.retract_local_rejected_row(storage, table, branch, row_id, row_data, false);
-    }
-
     pub(crate) fn retract_local_rejected_row(
         &mut self,
         storage: &mut dyn Storage,

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -1508,7 +1508,22 @@ impl QueryManager {
                         )
                     };
 
-                subscription.graph.settle(storage_ref, row_loader)
+                let source_overlay_rows = if !subscription.local_overlay_rows.is_empty() {
+                    Some(&subscription.local_overlay_rows)
+                } else if subscription.local_updates == LocalUpdates::Immediate
+                    && subscription.sync_backed
+                    && subscription.durability_tier.is_some()
+                    && !self.pending_local_row_batches.is_empty()
+                {
+                    Some(&self.pending_local_row_batches)
+                } else {
+                    None
+                };
+                subscription.graph.settle_with_source_overlay(
+                    storage_ref,
+                    source_overlay_rows,
+                    row_loader,
+                )
             };
             subscription.needs_visibility_recompute = false;
             let new_schema_warnings = Self::finalize_schema_warnings(
@@ -2115,7 +2130,7 @@ impl QueryManager {
         }
     }
 
-    pub(super) fn handle_row_update(
+    pub(crate) fn handle_row_update(
         &mut self,
         storage: &mut dyn Storage,
         update: RowVisibilityChange,

--- a/crates/jazz-tools/src/query_manager/writes.rs
+++ b/crates/jazz-tools/src/query_manager/writes.rs
@@ -199,10 +199,18 @@ impl QueryManager {
         row_provenance_metadata(provenance, delete_kind)
     }
 
+    fn write_context_is_open_batch(write_context: Option<&WriteContext>) -> bool {
+        matches!(
+            write_context.map(WriteContext::batch_mode),
+            Some(BatchMode::Transactional)
+        ) || write_context.and_then(WriteContext::batch_id).is_some()
+    }
+
     fn resolve_write_row_state(write_context: Option<&WriteContext>) -> RowState {
-        match write_context.map(WriteContext::batch_mode) {
-            Some(BatchMode::Transactional) => RowState::StagingPending,
-            Some(BatchMode::Direct) | None => RowState::VisibleDirect,
+        if Self::write_context_is_open_batch(write_context) {
+            RowState::StagingPending
+        } else {
+            RowState::VisibleDirect
         }
     }
 
@@ -353,7 +361,7 @@ impl QueryManager {
             .map_err(|err| QueryError::EncodingError(format!("persist batch settlement: {err}")))
     }
 
-    fn maybe_track_local_pending_transaction_overlay(
+    fn maybe_track_local_pending_batch_overlay(
         &mut self,
         table: &str,
         row_batch_key: RowBatchKey,
@@ -361,12 +369,7 @@ impl QueryManager {
         deleted: bool,
         visibility_change: &Option<RowVisibilityChange>,
     ) {
-        if visibility_change.is_some()
-            || !matches!(
-                write_context.map(WriteContext::batch_mode),
-                Some(BatchMode::Transactional)
-            )
-        {
+        if visibility_change.is_some() || !Self::write_context_is_open_batch(write_context) {
             return;
         }
 
@@ -626,16 +629,14 @@ impl QueryManager {
         self.load_branch_tip_ids(storage, table, row_id, branch_name)
     }
 
-    fn transactional_staged_row_for_write(
+    fn staged_row_for_write(
         &self,
         storage: &dyn Storage,
         row_id: ObjectId,
         branch_name: &str,
         write_context: Option<&WriteContext>,
     ) -> Option<QueryRowBatch> {
-        let batch_id = write_context
-            .filter(|ctx| ctx.batch_mode() == BatchMode::Transactional)
-            .and_then(WriteContext::batch_id)?;
+        let batch_id = write_context.and_then(WriteContext::batch_id)?;
         self.load_latest_transactional_staged_row_on_branch(storage, row_id, branch_name, batch_id)
             .map(|(_, row)| row)
     }
@@ -877,7 +878,7 @@ impl QueryManager {
             row,
             index_mutations,
         )?;
-        self.maybe_track_local_pending_transaction_overlay(
+        self.maybe_track_local_pending_batch_overlay(
             table,
             RowBatchKey::new(id, branch_name, batch_id),
             write_context,
@@ -1111,15 +1112,19 @@ impl QueryManager {
         self.persist_row_locator(storage, object_id, &table_write.row_locator);
 
         // Add commit with row data
-        let index_mutations = Self::index_mutations_for_insert_on_branch_with_layout(
-            table,
-            &current_branch,
-            object_id,
-            &data,
-            descriptor,
-            table_write.indexed_columns.as_deref().map(Vec::as_slice),
-            &table_write.row_layout,
-        );
+        let index_mutations = if Self::write_context_is_open_batch(write_context) {
+            Vec::new()
+        } else {
+            Self::index_mutations_for_insert_on_branch_with_layout(
+                table,
+                &current_branch,
+                object_id,
+                &data,
+                descriptor,
+                table_write.indexed_columns.as_deref().map(Vec::as_slice),
+                &table_write.row_layout,
+            )
+        };
         let row = self.authored_row_batch(
             object_id,
             &current_branch,
@@ -1141,7 +1146,7 @@ impl QueryManager {
                     descriptor: table_write.descriptor.clone(),
                 },
             )?;
-        self.maybe_track_local_pending_transaction_overlay(
+        self.maybe_track_local_pending_batch_overlay(
             table,
             RowBatchKey::new(object_id, branch_name, row_batch_id),
             write_context,
@@ -1322,15 +1327,19 @@ impl QueryManager {
         self.persist_row_locator(storage, object_id, &table_write.row_locator);
 
         // Add commit with row data to specified branch
-        let index_mutations = Self::index_mutations_for_insert_on_branch_with_layout(
-            table,
-            branch,
-            object_id,
-            &data,
-            descriptor,
-            table_write.indexed_columns.as_deref().map(Vec::as_slice),
-            &table_write.row_layout,
-        );
+        let index_mutations = if Self::write_context_is_open_batch(write_context) {
+            Vec::new()
+        } else {
+            Self::index_mutations_for_insert_on_branch_with_layout(
+                table,
+                branch,
+                object_id,
+                &data,
+                descriptor,
+                table_write.indexed_columns.as_deref().map(Vec::as_slice),
+                &table_write.row_layout,
+            )
+        };
         let row = self.authored_row_batch(
             object_id,
             branch,
@@ -1347,7 +1356,7 @@ impl QueryManager {
             row,
             &index_mutations,
         )?;
-        self.maybe_track_local_pending_transaction_overlay(
+        self.maybe_track_local_pending_batch_overlay(
             table,
             RowBatchKey::new(object_id, branch_name, row_batch_id),
             write_context,
@@ -1484,15 +1493,19 @@ impl QueryManager {
 
         self.persist_row_locator(storage, object_id, &table_write.row_locator);
 
-        let index_mutations = Self::index_mutations_for_insert_on_branch_with_layout(
-            table,
-            branch,
-            object_id,
-            &data,
-            descriptor,
-            table_write.indexed_columns.as_deref().map(Vec::as_slice),
-            &table_write.row_layout,
-        );
+        let index_mutations = if Self::write_context_is_open_batch(write_context) {
+            Vec::new()
+        } else {
+            Self::index_mutations_for_insert_on_branch_with_layout(
+                table,
+                branch,
+                object_id,
+                &data,
+                descriptor,
+                table_write.indexed_columns.as_deref().map(Vec::as_slice),
+                &table_write.row_layout,
+            )
+        };
         let row = self.authored_row_batch(
             object_id,
             branch,
@@ -1509,7 +1522,7 @@ impl QueryManager {
             row,
             &index_mutations,
         )?;
-        self.maybe_track_local_pending_transaction_overlay(
+        self.maybe_track_local_pending_batch_overlay(
             table,
             RowBatchKey::new(object_id, branch_name, row_batch_id),
             write_context,
@@ -2138,12 +2151,7 @@ impl QueryManager {
         }
 
         let current_row = self
-            .transactional_staged_row_for_write(
-                storage,
-                id,
-                self.current_branch().as_str(),
-                write_context,
-            )
+            .staged_row_for_write(storage, id, self.current_branch().as_str(), write_context)
             .or_else(|| {
                 self.load_visible_row_on_branch(storage, id, self.current_branch().as_str())
                     .map(|(_, row)| row)
@@ -2168,15 +2176,19 @@ impl QueryManager {
             write_context,
             &new_provenance,
         )?;
-        let index_mutations = Self::index_mutations_for_update_on_branch(
-            &table,
-            branch.as_str(),
-            id,
-            &old_data,
-            &prepared.new_data,
-            prepared.descriptor.as_ref(),
-            prepared.indexed_columns.as_deref().map(Vec::as_slice),
-        );
+        let index_mutations = if Self::write_context_is_open_batch(write_context) {
+            Vec::new()
+        } else {
+            Self::index_mutations_for_update_on_branch(
+                &table,
+                branch.as_str(),
+                id,
+                &old_data,
+                &prepared.new_data,
+                prepared.descriptor.as_ref(),
+                prepared.indexed_columns.as_deref().map(Vec::as_slice),
+            )
+        };
         let batch_id = self.commit_prepared_update_write(
             storage,
             PreparedUpdateCommit {
@@ -2250,8 +2262,7 @@ impl QueryManager {
             &new_provenance,
         )?;
 
-        let staged_branch_row =
-            self.transactional_staged_row_for_write(storage, id, branch, write_context);
+        let staged_branch_row = self.staged_row_for_write(storage, id, branch, write_context);
         let existing_branch_data = staged_branch_row
             .as_ref()
             .map(|row| row.data.clone())
@@ -2265,7 +2276,9 @@ impl QueryManager {
             .as_ref()
             .map(QueryRowBatch::is_soft_deleted)
             .unwrap_or_else(|| self.row_is_deleted_on_branch(storage, table, branch, id));
-        let index_mutations = if was_soft_deleted {
+        let index_mutations = if Self::write_context_is_open_batch(write_context) {
+            Vec::new()
+        } else if was_soft_deleted {
             Self::index_mutations_for_undelete_on_branch(
                 table,
                 branch,
@@ -2362,8 +2375,7 @@ impl QueryManager {
 
         // Check if already soft-deleted
         let current_branch = self.current_branch().to_string();
-        let staged_row =
-            self.transactional_staged_row_for_write(storage, id, &current_branch, write_context);
+        let staged_row = self.staged_row_for_write(storage, id, &current_branch, write_context);
         if staged_row
             .as_ref()
             .map(QueryRowBatch::is_soft_deleted)
@@ -2493,14 +2505,18 @@ impl QueryManager {
             old_data.to_vec(),
             self.row_batch_authoring(&delete_provenance, Some(DeleteKind::Soft), write_context),
         );
-        let index_mutations = Self::index_mutations_for_soft_delete_on_branch(
-            &table,
-            branch.as_str(),
-            id,
-            &old_data,
-            descriptor,
-            table_write.indexed_columns.as_deref().map(Vec::as_slice),
-        );
+        let index_mutations = if Self::write_context_is_open_batch(write_context) {
+            Vec::new()
+        } else {
+            Self::index_mutations_for_soft_delete_on_branch(
+                &table,
+                branch.as_str(),
+                id,
+                &old_data,
+                descriptor,
+                table_write.indexed_columns.as_deref().map(Vec::as_slice),
+            )
+        };
         let branch_name = BranchName::new(branch.as_str());
         let (delete_batch_id, visibility_change) = self.apply_local_row_history_write(
             storage,
@@ -2510,7 +2526,7 @@ impl QueryManager {
             delete_row,
             &index_mutations,
         )?;
-        self.maybe_track_local_pending_transaction_overlay(
+        self.maybe_track_local_pending_batch_overlay(
             &table,
             RowBatchKey::new(id, branch_name, delete_batch_id),
             write_context,
@@ -2581,8 +2597,7 @@ impl QueryManager {
             return Err(QueryError::RowHardDeleted(id));
         }
 
-        let staged_branch_row =
-            self.transactional_staged_row_for_write(storage, id, branch, write_context);
+        let staged_branch_row = self.staged_row_for_write(storage, id, branch, write_context);
         let table_name = TableName::new(table);
         // Check if already soft-deleted on this branch
         if staged_branch_row
@@ -2693,14 +2708,18 @@ impl QueryManager {
             old_data_for_policy.to_vec(),
             self.row_batch_authoring(&delete_provenance, Some(DeleteKind::Soft), write_context),
         );
-        let index_mutations = Self::index_mutations_for_soft_delete_on_branch(
-            table,
-            branch,
-            id,
-            old_data_for_policy,
-            descriptor,
-            table_write.indexed_columns.as_deref().map(Vec::as_slice),
-        );
+        let index_mutations = if Self::write_context_is_open_batch(write_context) {
+            Vec::new()
+        } else {
+            Self::index_mutations_for_soft_delete_on_branch(
+                table,
+                branch,
+                id,
+                old_data_for_policy,
+                descriptor,
+                table_write.indexed_columns.as_deref().map(Vec::as_slice),
+            )
+        };
         let branch_name = BranchName::new(branch);
         let (delete_batch_id, visibility_change) = self.apply_local_row_history_write(
             storage,
@@ -2710,7 +2729,7 @@ impl QueryManager {
             delete_row,
             &index_mutations,
         )?;
-        self.maybe_track_local_pending_transaction_overlay(
+        self.maybe_track_local_pending_batch_overlay(
             table,
             RowBatchKey::new(id, branch_name, delete_batch_id),
             write_context,
@@ -2839,7 +2858,7 @@ impl QueryManager {
             row,
             &index_mutations,
         )?;
-        self.maybe_track_local_pending_transaction_overlay(
+        self.maybe_track_local_pending_batch_overlay(
             &table,
             RowBatchKey::new(id, branch_name, row_batch_id),
             None,
@@ -2940,7 +2959,7 @@ impl QueryManager {
             delete_row,
             &index_mutations,
         )?;
-        self.maybe_track_local_pending_transaction_overlay(
+        self.maybe_track_local_pending_batch_overlay(
             &table,
             RowBatchKey::new(id, branch_name, delete_batch_id),
             None,

--- a/crates/jazz-tools/src/runtime_core/tests/query_subscription.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/query_subscription.rs
@@ -629,6 +629,53 @@ fn rc_query_local_transaction_overlay_keeps_indexed_deletes_isolated() {
 }
 
 #[test]
+fn rc_query_local_transaction_overlay_include_deleted_returns_staged_delete() {
+    let mut core =
+        create_runtime_with_schema(test_schema(), "query-local-transaction-include-deleted");
+    let branch_name = core.schema_manager().branch_name();
+
+    let ((row_id, _), _) = core
+        .insert("users", user_insert_values(ObjectId::new(), "shared"), None)
+        .unwrap();
+
+    let batch_id = BatchId::new();
+    let write_context = WriteContext {
+        session: None,
+        attribution: None,
+        updated_at: None,
+        batch_mode: Some(crate::batch_fate::BatchMode::Transactional),
+        batch_id: Some(batch_id),
+        target_branch_name: None,
+    };
+
+    core.delete(row_id, Some(&write_context)).unwrap();
+
+    let deleted_query = QueryBuilder::new("users")
+        .filter_eq("name", Value::Text("shared".into()))
+        .include_deleted()
+        .build();
+
+    let overlay_rows = execute_runtime_query_with_local_overlay(
+        &mut core,
+        deleted_query,
+        None,
+        ReadDurabilityOptions::default(),
+        crate::sync_manager::QueryPropagation::Full,
+        QueryLocalOverlay {
+            batch_id,
+            branch_name,
+            row_ids: vec![row_id],
+        },
+    );
+    assert_eq!(
+        overlay_rows.len(),
+        1,
+        "include_deleted transaction reads should include the row deleted by that transaction"
+    );
+    assert_eq!(overlay_rows[0].0, row_id);
+}
+
+#[test]
 fn rc_query_local_direct_batch_overlay_handles_indexed_filters_until_commit() {
     let mut core =
         create_runtime_with_schema(test_schema(), "query-local-direct-batch-index-update");

--- a/crates/jazz-tools/src/runtime_core/tests/query_subscription.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/query_subscription.rs
@@ -424,6 +424,320 @@ fn rc_query_local_transaction_overlay_keeps_same_row_updates_isolated_by_batch()
 }
 
 #[test]
+fn rc_query_local_transaction_overlay_handles_indexed_insert_filters() {
+    let mut core =
+        create_runtime_with_schema(test_schema(), "query-local-transaction-index-insert");
+    let branch_name = core.schema_manager().branch_name();
+
+    let batch_id = BatchId::new();
+    let write_context = WriteContext {
+        session: None,
+        attribution: None,
+        updated_at: None,
+        batch_mode: Some(crate::batch_fate::BatchMode::Transactional),
+        batch_id: Some(batch_id),
+        target_branch_name: None,
+    };
+
+    let ((row_id, _), _) = core
+        .insert(
+            "users",
+            user_insert_values(ObjectId::new(), "alice-draft"),
+            Some(&write_context),
+        )
+        .unwrap();
+
+    let query = QueryBuilder::new("users")
+        .filter_eq("name", Value::Text("alice-draft".into()))
+        .build();
+
+    let visible_rows = execute_runtime_query(&mut core, query.clone(), None);
+    assert_eq!(
+        visible_rows,
+        Vec::<(ObjectId, Vec<Value>)>::new(),
+        "ordinary indexed reads should not see staged transaction inserts"
+    );
+
+    let overlay_rows = execute_runtime_query_with_local_overlay(
+        &mut core,
+        query,
+        None,
+        ReadDurabilityOptions::default(),
+        crate::sync_manager::QueryPropagation::Full,
+        QueryLocalOverlay {
+            batch_id,
+            branch_name,
+            row_ids: vec![row_id],
+        },
+    );
+
+    assert_eq!(overlay_rows.len(), 1);
+    assert_eq!(overlay_rows[0].0, row_id);
+    assert_eq!(overlay_rows[0].1[1], Value::Text("alice-draft".into()));
+}
+
+#[test]
+fn rc_query_local_transaction_overlay_handles_indexed_update_filters() {
+    let mut core =
+        create_runtime_with_schema(test_schema(), "query-local-transaction-index-update");
+    let branch_name = core.schema_manager().branch_name();
+
+    let ((row_id, _), _) = core
+        .insert("users", user_insert_values(ObjectId::new(), "shared"), None)
+        .unwrap();
+
+    let batch_id = BatchId::new();
+    let write_context = WriteContext {
+        session: None,
+        attribution: None,
+        updated_at: None,
+        batch_mode: Some(crate::batch_fate::BatchMode::Transactional),
+        batch_id: Some(batch_id),
+        target_branch_name: None,
+    };
+
+    core.update(
+        row_id,
+        vec![("name".into(), Value::Text("alice-draft".into()))],
+        Some(&write_context),
+    )
+    .unwrap();
+
+    let draft_query = QueryBuilder::new("users")
+        .filter_eq("name", Value::Text("alice-draft".into()))
+        .build();
+    let shared_query = QueryBuilder::new("users")
+        .filter_eq("name", Value::Text("shared".into()))
+        .build();
+
+    assert_eq!(
+        execute_runtime_query(&mut core, draft_query.clone(), None),
+        Vec::<(ObjectId, Vec<Value>)>::new(),
+        "ordinary indexed reads should not see staged transaction updates"
+    );
+    assert_eq!(
+        core.storage().index_lookup(
+            "users",
+            "name",
+            branch_name.as_str(),
+            &Value::Text("alice-draft".into())
+        ),
+        Vec::<ObjectId>::new(),
+        "staged transaction updates should not update the branch index"
+    );
+    let shared_rows = execute_runtime_query(&mut core, shared_query.clone(), None);
+    assert_eq!(shared_rows.len(), 1);
+    assert_eq!(shared_rows[0].1[1], Value::Text("shared".into()));
+
+    let draft_overlay_rows = execute_runtime_query_with_local_overlay(
+        &mut core,
+        draft_query,
+        None,
+        ReadDurabilityOptions::default(),
+        crate::sync_manager::QueryPropagation::Full,
+        QueryLocalOverlay {
+            batch_id,
+            branch_name: branch_name.clone(),
+            row_ids: vec![row_id],
+        },
+    );
+    assert_eq!(draft_overlay_rows.len(), 1);
+    assert_eq!(
+        draft_overlay_rows[0].1[1],
+        Value::Text("alice-draft".into())
+    );
+
+    let shared_overlay_rows = execute_runtime_query_with_local_overlay(
+        &mut core,
+        shared_query,
+        None,
+        ReadDurabilityOptions::default(),
+        crate::sync_manager::QueryPropagation::Full,
+        QueryLocalOverlay {
+            batch_id,
+            branch_name,
+            row_ids: vec![row_id],
+        },
+    );
+    assert_eq!(
+        shared_overlay_rows,
+        Vec::<(ObjectId, Vec<Value>)>::new(),
+        "transaction indexed reads should use the staged value, not the branch index value"
+    );
+}
+
+#[test]
+fn rc_query_local_transaction_overlay_keeps_indexed_deletes_isolated() {
+    let mut core =
+        create_runtime_with_schema(test_schema(), "query-local-transaction-index-delete");
+    let branch_name = core.schema_manager().branch_name();
+
+    let ((row_id, _), _) = core
+        .insert("users", user_insert_values(ObjectId::new(), "shared"), None)
+        .unwrap();
+
+    let batch_id = BatchId::new();
+    let write_context = WriteContext {
+        session: None,
+        attribution: None,
+        updated_at: None,
+        batch_mode: Some(crate::batch_fate::BatchMode::Transactional),
+        batch_id: Some(batch_id),
+        target_branch_name: None,
+    };
+
+    core.delete(row_id, Some(&write_context)).unwrap();
+
+    let shared_query = QueryBuilder::new("users")
+        .filter_eq("name", Value::Text("shared".into()))
+        .build();
+
+    let visible_rows = execute_runtime_query(&mut core, shared_query.clone(), None);
+    assert_eq!(visible_rows.len(), 1);
+    assert_eq!(
+        visible_rows[0].0, row_id,
+        "ordinary indexed reads should still see the committed row while the delete is staged"
+    );
+    assert_eq!(
+        core.storage().index_lookup(
+            "users",
+            "name",
+            branch_name.as_str(),
+            &Value::Text("shared".into())
+        ),
+        vec![row_id],
+        "staged transaction deletes should not remove the branch index entry"
+    );
+
+    let overlay_rows = execute_runtime_query_with_local_overlay(
+        &mut core,
+        shared_query,
+        None,
+        ReadDurabilityOptions::default(),
+        crate::sync_manager::QueryPropagation::Full,
+        QueryLocalOverlay {
+            batch_id,
+            branch_name,
+            row_ids: vec![row_id],
+        },
+    );
+    assert_eq!(
+        overlay_rows,
+        Vec::<(ObjectId, Vec<Value>)>::new(),
+        "transaction indexed reads should hide the row deleted by that transaction"
+    );
+}
+
+#[test]
+fn rc_query_local_direct_batch_overlay_handles_indexed_filters_until_commit() {
+    let mut core =
+        create_runtime_with_schema(test_schema(), "query-local-direct-batch-index-update");
+    let branch_name = core.schema_manager().branch_name();
+
+    let ((row_id, _), _) = core
+        .insert("users", user_insert_values(ObjectId::new(), "shared"), None)
+        .unwrap();
+
+    let batch_id = BatchId::new();
+    let write_context = WriteContext::default()
+        .with_batch_mode(crate::batch_fate::BatchMode::Direct)
+        .with_batch_id(batch_id);
+
+    core.update(
+        row_id,
+        vec![("name".into(), Value::Text("alice-batch".into()))],
+        Some(&write_context),
+    )
+    .unwrap();
+
+    let batch_query = QueryBuilder::new("users")
+        .filter_eq("name", Value::Text("alice-batch".into()))
+        .build();
+    let shared_query = QueryBuilder::new("users")
+        .filter_eq("name", Value::Text("shared".into()))
+        .build();
+
+    assert_eq!(
+        execute_runtime_query(&mut core, batch_query.clone(), None),
+        Vec::<(ObjectId, Vec<Value>)>::new(),
+        "ordinary indexed reads should not see open direct batch updates"
+    );
+    assert_eq!(
+        core.storage().index_lookup(
+            "users",
+            "name",
+            branch_name.as_str(),
+            &Value::Text("alice-batch".into())
+        ),
+        Vec::<ObjectId>::new(),
+        "open direct batch updates should not update the branch index"
+    );
+
+    let batch_overlay_rows = execute_runtime_query_with_local_overlay(
+        &mut core,
+        batch_query.clone(),
+        None,
+        ReadDurabilityOptions::default(),
+        crate::sync_manager::QueryPropagation::Full,
+        QueryLocalOverlay {
+            batch_id,
+            branch_name: branch_name.clone(),
+            row_ids: vec![row_id],
+        },
+    );
+    assert_eq!(batch_overlay_rows.len(), 1);
+    assert_eq!(
+        batch_overlay_rows[0].1[1],
+        Value::Text("alice-batch".into())
+    );
+
+    let shared_overlay_rows = execute_runtime_query_with_local_overlay(
+        &mut core,
+        shared_query,
+        None,
+        ReadDurabilityOptions::default(),
+        crate::sync_manager::QueryPropagation::Full,
+        QueryLocalOverlay {
+            batch_id,
+            branch_name,
+            row_ids: vec![row_id],
+        },
+    );
+    assert_eq!(
+        shared_overlay_rows,
+        Vec::<(ObjectId, Vec<Value>)>::new(),
+        "direct batch indexed reads should use the staged value while the batch is open"
+    );
+
+    core.seal_batch(batch_id).unwrap();
+
+    assert_eq!(
+        core.storage().index_lookup(
+            "users",
+            "name",
+            branch_name.as_str(),
+            &Value::Text("alice-batch".into())
+        ),
+        vec![row_id],
+        "sealing a direct batch should apply its index mutations"
+    );
+    assert_eq!(
+        core.storage().index_lookup(
+            "users",
+            "name",
+            branch_name.as_str(),
+            &Value::Text("shared".into())
+        ),
+        Vec::<ObjectId>::new(),
+        "sealing a direct batch should remove stale index entries"
+    );
+
+    let committed_rows = execute_runtime_query(&mut core, batch_query, None);
+    assert_eq!(committed_rows.len(), 1);
+    assert_eq!(committed_rows[0].1[1], Value::Text("alice-batch".into()));
+}
+
+#[test]
 fn rc_query_remote_tier_session_exists_rel_waits_without_permissions_head() {
     let schema = session_exists_rel_teams_schema();
     let mut client = create_runtime_with_schema(schema, "session-exists-rel-query");

--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/direct.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/direct.rs
@@ -167,7 +167,7 @@ fn rc_delete_sync() {
 }
 
 #[test]
-fn rc_same_row_direct_batch_overwrites_in_place() {
+fn rc_same_row_direct_batch_overwrites_staged_member_in_place() {
     let mut core = create_test_runtime();
     let batch_id = BatchId::new();
     let write_context = WriteContext::default().with_batch_id(batch_id);
@@ -200,13 +200,31 @@ fn rc_same_row_direct_batch_overwrites_in_place() {
     assert_eq!(history_rows[0].batch_id, batch_id);
     assert_eq!(history_rows[0].batch_id(), batch_id);
 
+    assert_eq!(
+        core.storage()
+            .load_visible_region_row("users", branch_name.as_str(), row_id)
+            .unwrap(),
+        None,
+        "open direct batch rows should stay staged until the batch is sealed"
+    );
+    assert_eq!(
+        history_rows[0].state,
+        crate::row_histories::RowState::StagingPending
+    );
+
+    core.seal_batch(batch_id).unwrap();
+
     let visible_row = core
         .storage()
         .load_visible_region_row("users", branch_name.as_str(), row_id)
         .unwrap()
-        .expect("direct batch row should stay visible");
+        .expect("sealed direct batch row should become visible");
     assert_eq!(visible_row.batch_id, batch_id);
     assert_eq!(visible_row.batch_id(), batch_id);
+    assert_eq!(
+        visible_row.state,
+        crate::row_histories::RowState::VisibleDirect
+    );
 }
 
 #[test]
@@ -445,7 +463,7 @@ fn rc_restart_recovers_completed_sealed_batch_from_storage() {
         .expect("restart should recover and settle completed sealed batch");
     assert!(matches!(
         settlement,
-        crate::batch_fate::BatchFate::AcceptedTransaction {
+        crate::batch_fate::BatchFate::DurableDirect {
             batch_id: settled_batch_id,
             confirmed_tier: DurabilityTier::Local,
         } if settled_batch_id == batch_id
@@ -455,11 +473,8 @@ fn rc_restart_recovers_completed_sealed_batch_from_storage() {
         .storage()
         .load_visible_region_row("users", "main", row_id)
         .unwrap()
-        .expect("restart recovery should publish the accepted row");
-    assert_eq!(
-        visible.state,
-        crate::row_histories::RowState::VisibleTransactional
-    );
+        .expect("restart recovery should publish the durable direct row");
+    assert_eq!(visible.state, crate::row_histories::RowState::VisibleDirect);
     assert_eq!(visible.batch_id, batch_id);
     assert_eq!(
         restarted

--- a/crates/jazz-tools/src/runtime_core/ticks.rs
+++ b/crates/jazz-tools/src/runtime_core/ticks.rs
@@ -208,6 +208,12 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         {
             return None;
         }
+        if rows
+            .iter()
+            .any(|(_, _, row)| !matches!(row.state, crate::row_histories::RowState::VisibleDirect))
+        {
+            return None;
+        }
         Some(SealedBatchSubmission::new(
             batch_id,
             crate::batch_fate::BatchMode::Direct,
@@ -423,13 +429,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                     );
                 }
             } else {
-                query_manager.retract_local_pending_transaction_row(
-                    &mut self.storage,
-                    &table,
-                    &branch,
-                    row_id,
-                    &row_data,
-                );
+                query_manager.clear_local_pending_row_overlay(&table, row_id);
             }
         }
     }

--- a/crates/jazz-tools/src/runtime_core/writes.rs
+++ b/crates/jazz-tools/src/runtime_core/writes.rs
@@ -5,7 +5,7 @@ use crate::batch_fate::{
 };
 use crate::object::BranchName;
 use crate::query_manager::types::SchemaHash;
-use crate::row_histories::BatchId;
+use crate::row_histories::{BatchId, RowState, patch_row_batch_state};
 use crate::storage::StorageError;
 
 impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
@@ -312,6 +312,66 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             members,
             captured_frontier,
         ))
+    }
+
+    fn publish_direct_batch_rows(&mut self, record: &LocalBatchRecord) -> Result<(), RuntimeError> {
+        let members = record.members.clone();
+        let mut visibility_changes = Vec::new();
+
+        for member in members {
+            let row = self
+                .storage
+                .load_history_row_batch_for_schema_hash(
+                    member.table_name.as_str(),
+                    member.schema_hash,
+                    member.branch_name.as_str(),
+                    member.object_id,
+                    record.batch_id,
+                )
+                .map_err(|err| RuntimeError::WriteError(format!("load direct batch row: {err}")))?
+                .or_else(|| {
+                    self.storage
+                        .scan_history_row_batches(member.table_name.as_str(), member.object_id)
+                        .ok()
+                        .and_then(|rows| {
+                            rows.into_iter().find(|row| {
+                                row.batch_id == record.batch_id
+                                    && row.branch.as_str() == member.branch_name.as_str()
+                            })
+                        })
+                });
+            let Some(row) = row else {
+                continue;
+            };
+
+            if !matches!(row.state, RowState::StagingPending) {
+                continue;
+            }
+
+            let visibility_change = patch_row_batch_state(
+                &mut self.storage,
+                member.object_id,
+                &member.branch_name,
+                record.batch_id,
+                Some(RowState::VisibleDirect),
+                None,
+            )
+            .map_err(|err| {
+                RuntimeError::WriteError(format!("publish direct batch row: {err:?}"))
+            })?;
+
+            if let Some(visibility_change) = visibility_change {
+                visibility_changes.push(visibility_change);
+            }
+        }
+
+        for visibility_change in visibility_changes {
+            self.schema_manager
+                .query_manager_mut()
+                .handle_row_update(&mut self.storage, visibility_change);
+        }
+
+        Ok(())
     }
 
     // =========================================================================
@@ -835,6 +895,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             self.storage
                 .upsert_authoritative_batch_fate(&settlement)
                 .map_err(|err| RuntimeError::WriteError(format!("persist batch fate: {err}")))?;
+            self.publish_direct_batch_rows(&record)?;
         }
         self.storage
             .upsert_sealed_batch_submission(&submission)

--- a/crates/jazz-tools/src/schema_manager/integration_tests/tests/writes.rs
+++ b/crates/jazz-tools/src/schema_manager/integration_tests/tests/writes.rs
@@ -506,7 +506,7 @@ fn transactional_delete_uses_frozen_target_branch_schema() {
         .with_batch_mode(crate::batch_fate::BatchMode::Transactional)
         .with_target_branch_name(v1_branch.clone());
 
-    manager
+    let delete = manager
         .delete(&mut storage, row_id, Some(&write_context))
         .expect("frozen-target delete should use the target branch schema");
 
@@ -528,11 +528,16 @@ fn transactional_delete_uses_frozen_target_branch_schema() {
             .build(),
     );
     assert_eq!(current_rows.len(), 1);
-    assert!(
-        manager
-            .query_manager()
-            .row_is_deleted_on_branch(&storage, "users", &v1_branch, row_id),
-        "target branch should carry the delete marker"
+    let target_delete = storage
+        .scan_history_row_batches("users", row_id)
+        .unwrap()
+        .into_iter()
+        .find(|row| row.batch_id() == delete.batch_id && row.branch.as_str() == v1_branch)
+        .expect("target branch should carry the staged delete marker");
+    assert!(target_delete.is_soft_deleted());
+    assert_eq!(
+        target_delete.state,
+        crate::row_histories::RowState::StagingPending
     );
     assert!(
         !manager.query_manager().row_is_deleted_on_branch(

--- a/crates/jazz-tools/src/schema_manager/manager.rs
+++ b/crates/jazz-tools/src/schema_manager/manager.rs
@@ -1734,7 +1734,6 @@ impl SchemaManager {
             .collect::<Vec<_>>();
 
         if let Some(existing_table) = write_context
-            .filter(|ctx| ctx.batch_mode() == crate::batch_fate::BatchMode::Transactional)
             .and_then(WriteContext::batch_id)
             .and_then(|batch_id| {
                 self.query_manager
@@ -1800,7 +1799,6 @@ impl SchemaManager {
             .collect::<Vec<_>>();
         let (table, source_branch, old_current_data, _source_commit_id, old_current_provenance) =
             write_context
-                .filter(|ctx| ctx.batch_mode() == crate::batch_fate::BatchMode::Transactional)
                 .and_then(WriteContext::batch_id)
                 .and_then(|batch_id| {
                     self.query_manager
@@ -1902,7 +1900,6 @@ impl SchemaManager {
             .collect::<Vec<_>>();
         let (table, source_branch, old_current_data, _source_commit_id, old_current_provenance) =
             write_context
-                .filter(|ctx| ctx.batch_mode() == crate::batch_fate::BatchMode::Transactional)
                 .and_then(WriteContext::batch_id)
                 .and_then(|batch_id| {
                     self.query_manager

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::batch_fate::{BatchFate, SealedBatchSubmission};
+use crate::batch_fate::{BatchFate, BatchMode, SealedBatchSubmission};
 use crate::metadata::MetadataKey;
 use crate::object::{BranchName, ObjectId};
 use crate::query_manager::policy::Operation;
@@ -96,7 +96,10 @@ impl SyncManager {
         for (_, row) in batch_rows {
             let row_mode = match row.state {
                 RowState::VisibleDirect => SealedBatchMode::Direct,
-                RowState::StagingPending => SealedBatchMode::Transactional,
+                RowState::StagingPending => match submission.mode {
+                    BatchMode::Direct => SealedBatchMode::Direct,
+                    BatchMode::Transactional => SealedBatchMode::Transactional,
+                },
                 _ => {
                     return Err(BatchFate::Rejected {
                         batch_id: submission.batch_id,
@@ -547,6 +550,66 @@ impl SyncManager {
     ) {
         let server_ids: Vec<_> = self.servers.keys().copied().collect();
         match fate {
+            BatchFate::DurableDirect { .. } => {
+                for (_table, row) in batch_rows {
+                    let row_id = row.row_id;
+                    let branch_name = BranchName::new(&row.branch);
+                    let mut direct_row = row.clone();
+                    direct_row.state = RowState::VisibleDirect;
+                    direct_row.confirmed_tier = None;
+                    let applied =
+                        apply_row_batch(storage, row_id, &branch_name, direct_row.clone(), &[])
+                            .ok();
+
+                    let metadata = storage
+                        .load_row_locator(row_id)
+                        .ok()
+                        .flatten()
+                        .map(|locator| metadata_from_row_locator(&locator));
+
+                    if let Some(metadata) = metadata {
+                        for server_id in &server_ids {
+                            self.outbox.push(OutboxEntry {
+                                destination: Destination::Server(*server_id),
+                                payload: SyncPayload::RowBatchNeeded {
+                                    metadata: Some(RowMetadata {
+                                        id: row_id,
+                                        metadata: metadata.clone(),
+                                    }),
+                                    row: direct_row.clone(),
+                                },
+                            });
+                        }
+                    }
+
+                    if let Some(applied) = applied
+                        && let Some(update) = applied.visibility_change
+                    {
+                        self.pending_row_visibility_changes.push(update);
+                        if let Some(client_id) = origin_client_id {
+                            self.forward_update_to_clients_except_with_storage(
+                                storage,
+                                row_id,
+                                branch_name,
+                                client_id,
+                            );
+                        } else {
+                            self.forward_update_to_clients_with_storage(
+                                storage,
+                                row_id,
+                                branch_name,
+                            );
+                        }
+                    }
+                }
+
+                for server_id in &server_ids {
+                    self.outbox.push(OutboxEntry {
+                        destination: Destination::Server(*server_id),
+                        payload: SyncPayload::BatchFate { fate: fate.clone() },
+                    });
+                }
+            }
             BatchFate::AcceptedTransaction { confirmed_tier, .. } => {
                 for (_table, row) in batch_rows {
                     let row_id = row.row_id;
@@ -641,7 +704,11 @@ impl SyncManager {
                     }
                 }
             }
-            BatchFate::DurableDirect { .. } | BatchFate::Missing { .. } => return,
+            BatchFate::Missing { .. } => return,
+        }
+
+        if matches!(fate, BatchFate::DurableDirect { .. }) {
+            return;
         }
 
         if let Some(client_id) = origin_client_id {
@@ -793,6 +860,20 @@ impl SyncManager {
         {
             tracing::warn!(?batch_id, %error, "failed to delete sealed batch submission");
         }
+        let rows_to_patch: &[(String, StoredRowBatch)] = match fate {
+            BatchFate::DurableDirect { .. } | BatchFate::AcceptedTransaction { .. } => {
+                &declared_rows
+            }
+            BatchFate::Rejected { .. } => &batch_rows,
+            BatchFate::Missing { .. } => &[],
+        };
+        self.apply_transactional_batch_fate_to_rows(
+            storage,
+            origin_client_id,
+            &fate,
+            rows_to_patch,
+        );
+
         if matches!(fate, BatchFate::DurableDirect { .. }) {
             let mut interested_clients = self.interested_clients_for_batch_fate(storage, &fate);
             if let Some(client_id) = origin_client_id {
@@ -802,19 +883,7 @@ impl SyncManager {
             for client_id in interested_clients {
                 self.queue_batch_fate_to_client(client_id, fate.clone());
             }
-            return;
         }
-        let rows_to_patch: &[(String, StoredRowBatch)] = match fate {
-            BatchFate::AcceptedTransaction { .. } => &declared_rows,
-            BatchFate::Rejected { .. } => &batch_rows,
-            BatchFate::DurableDirect { .. } | BatchFate::Missing { .. } => &[],
-        };
-        self.apply_transactional_batch_fate_to_rows(
-            storage,
-            origin_client_id,
-            &fate,
-            rows_to_patch,
-        );
     }
 
     pub(super) fn try_accept_completed_sealed_batch_from_client<H: Storage>(

--- a/crates/jazz-tools/src/sync_manager/tests.rs
+++ b/crates/jazz-tools/src/sync_manager/tests.rs
@@ -284,6 +284,37 @@ fn sealed_submission(
     } else {
         crate::batch_fate::BatchMode::Transactional
     };
+    sealed_submission_with_mode(
+        batch_id,
+        mode,
+        target_branch_name,
+        members,
+        captured_frontier,
+    )
+}
+
+fn transactional_sealed_submission(
+    batch_id: BatchId,
+    target_branch_name: &str,
+    members: Vec<SealedBatchMember>,
+    captured_frontier: Vec<CapturedFrontierMember>,
+) -> SealedBatchSubmission {
+    sealed_submission_with_mode(
+        batch_id,
+        crate::batch_fate::BatchMode::Transactional,
+        target_branch_name,
+        members,
+        captured_frontier,
+    )
+}
+
+fn sealed_submission_with_mode(
+    batch_id: BatchId,
+    mode: crate::batch_fate::BatchMode,
+    target_branch_name: &str,
+    members: Vec<SealedBatchMember>,
+    captured_frontier: Vec<CapturedFrontierMember>,
+) -> SealedBatchSubmission {
     SealedBatchSubmission::new(
         batch_id,
         mode,

--- a/crates/jazz-tools/src/sync_manager/tests/settlements.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/settlements.rs
@@ -627,7 +627,7 @@ fn seal_batch_accepts_all_staged_transactional_rows_as_one_settlement() {
         &mut io,
         client_id,
         SyncPayload::SealBatch {
-            submission: sealed_submission(
+            submission: transactional_sealed_submission(
                 batch_id,
                 "main",
                 vec![

--- a/crates/jazz-tools/src/sync_manager/tests/transaction_sealing.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/transaction_sealing.rs
@@ -542,7 +542,7 @@ fn seal_batch_collapses_same_row_to_latest_visible_member() {
         &mut io,
         client_id,
         SyncPayload::SealBatch {
-            submission: sealed_submission(
+            submission: transactional_sealed_submission(
                 batch_id,
                 "main",
                 vec![SealedBatchMember {
@@ -665,7 +665,7 @@ fn seal_batch_same_row_preserves_pre_transaction_parent_frontier() {
         &mut io,
         client_id,
         SyncPayload::SealBatch {
-            submission: sealed_submission(
+            submission: transactional_sealed_submission(
                 batch_id,
                 "main",
                 vec![SealedBatchMember {
@@ -736,7 +736,7 @@ fn seal_batch_waits_for_all_declared_rows_before_accepting() {
         &mut io,
         client_id,
         SyncPayload::SealBatch {
-            submission: sealed_submission(
+            submission: transactional_sealed_submission(
                 batch_id,
                 "main",
                 vec![
@@ -831,7 +831,7 @@ fn seal_batch_waits_for_declared_latest_row_batch_before_accepting() {
         &mut io,
         client_id,
         SyncPayload::SealBatch {
-            submission: sealed_submission(
+            submission: transactional_sealed_submission(
                 batch_id,
                 "main",
                 vec![SealedBatchMember {

--- a/crates/jazz-tools/tests/rocksdb_storage_integration.rs
+++ b/crates/jazz-tools/tests/rocksdb_storage_integration.rs
@@ -122,7 +122,7 @@ fn seed_rocksdb_sealed_batch_acceptance(
     storage
         .upsert_sealed_batch_submission(&SealedBatchSubmission::new(
             batch_id,
-            BatchMode::Direct,
+            BatchMode::Transactional,
             BranchName::new("main"),
             vec![SealedBatchMember {
                 object_id: row_id,

--- a/crates/jazz-tools/tests/sqlite_storage_integration.rs
+++ b/crates/jazz-tools/tests/sqlite_storage_integration.rs
@@ -122,7 +122,7 @@ fn seed_sqlite_sealed_batch_acceptance(
     storage
         .upsert_sealed_batch_submission(&SealedBatchSubmission::new(
             batch_id,
-            BatchMode::Direct,
+            BatchMode::Transactional,
             BranchName::new("main"),
             vec![SealedBatchMember {
                 object_id: row_id,

--- a/packages/jazz-tools/tests/browser/db.transaction-reads.test.ts
+++ b/packages/jazz-tools/tests/browser/db.transaction-reads.test.ts
@@ -97,6 +97,20 @@ describe("db transaction reads browser integration", () => {
     });
   });
 
+  it("keeps staged deletes isolated to the transaction that issued them", async () => {
+    const { value: todo } = db.insert(todos, { title: "Shared", done: false });
+    const tx = db.beginTransaction();
+
+    tx.delete(todos, todo.id);
+
+    expect(await db.one<Todo>(makeTodoQuery())).toEqual(todo);
+    expect(await tx.one<Todo>(makeTodoQuery())).toBeNull();
+
+    tx.commit();
+
+    expect(await db.one<Todo>(makeTodoQuery())).toBeNull();
+  });
+
   it("makes transaction writes visible globally once the transaction commits and the authority accepts the transaction", async () => {
     const tx = db.beginTransaction();
     const insertedTodo = tx.insert(todos, { title: "Batch", done: false });
@@ -219,15 +233,49 @@ describe("db transaction reads browser integration", () => {
       expect(await db.one<Todo>(makeTodoQuery())).toMatchObject(insertedTodo);
     });
 
-    it("does not commit changes if the callback rejects", async () => {
-      expect(() =>
-        db.transaction((tx) => {
-          tx.insert(todos, { title: "Batch", done: false });
-          throw new Error("callback failed");
-        }),
-      ).toThrow("callback failed");
+    describe("rolls back changes if the callback rejects", () => {
+      it("insert", async () => {
+        await expect(() =>
+          db.transaction(async (tx) => {
+            const todo = tx.insert(todos, { title: "Todo", done: false });
+            expect(await tx.one(makeTodoQuery())).toEqual(todo);
+            expect(await db.one(makeTodoQuery())).toBeNull();
+            throw new Error("callback failed");
+          }),
+        ).rejects.toThrow("callback failed");
 
-      expect(await db.one<Todo>(makeTodoQuery())).toBeNull();
+        expect(await db.one<Todo>(makeTodoQuery())).toBeNull();
+      });
+
+      it("update", async () => {
+        const { value: todo } = db.insert(todos, { title: "Todo", done: false });
+
+        await expect(() =>
+          db.transaction(async (tx) => {
+            tx.update(todos, todo.id, { title: "Updated todo" });
+            expect((await tx.one(makeTodoQuery()))?.title).toEqual("Updated todo");
+            expect((await db.one(makeTodoQuery()))?.title).toEqual("Todo");
+            throw new Error("callback failed");
+          }),
+        ).rejects.toThrow("callback failed");
+
+        expect((await db.one(makeTodoQuery()))?.title).toEqual("Todo");
+      });
+
+      it("delete", async () => {
+        const { value: todo } = db.insert(todos, { title: "Todo", done: false });
+
+        await expect(() =>
+          db.transaction(async (tx) => {
+            tx.delete(todos, todo.id);
+            expect(await tx.one(makeTodoQuery())).toBeNull();
+            expect(await db.one(makeTodoQuery())).toEqual(todo);
+            throw new Error("callback failed");
+          }),
+        ).rejects.toThrow("callback failed");
+
+        expect(await db.one(makeTodoQuery())).toEqual(todo);
+      });
     });
   });
 });
@@ -341,15 +389,49 @@ describe("db batch reads browser integration", () => {
       expect(await db.one<Todo>(makeTodoQuery())).toMatchObject(insertedTodo);
     });
 
-    it("rolls back changes if the callback rejects", async () => {
-      expect(() =>
-        db.batch((batch) => {
-          batch.insert(todos, { title: "Batch", done: false });
-          throw new Error("callback failed");
-        }),
-      ).toThrow("callback failed");
+    describe("rolls back changes if the callback rejects", () => {
+      it("insert", async () => {
+        await expect(() =>
+          db.batch(async (batch) => {
+            const todo = batch.insert(todos, { title: "Batch", done: false });
+            expect(await batch.one(makeTodoQuery())).toEqual(todo);
+            expect(await db.one(makeTodoQuery())).toBeNull();
+            throw new Error("callback failed");
+          }),
+        ).rejects.toThrow("callback failed");
 
-      expect(await db.one<Todo>(makeTodoQuery())).toBeNull();
+        expect(await db.one<Todo>(makeTodoQuery())).toBeNull();
+      });
+
+      it("update", async () => {
+        const { value: todo } = db.insert(todos, { title: "Todo", done: false });
+
+        await expect(() =>
+          db.batch(async (batch) => {
+            batch.update(todos, todo.id, { title: "Updated todo" });
+            expect((await batch.one(makeTodoQuery()))?.title).toEqual("Updated todo");
+            expect((await db.one(makeTodoQuery()))?.title).toEqual("Todo");
+            throw new Error("callback failed");
+          }),
+        ).rejects.toThrow("callback failed");
+
+        expect((await db.one(makeTodoQuery()))?.title).toEqual("Todo");
+      });
+
+      it("delete", async () => {
+        const { value: todo } = db.insert(todos, { title: "Todo", done: false });
+
+        await expect(() =>
+          db.batch(async (batch) => {
+            batch.delete(todos, todo.id);
+            expect(await batch.one(makeTodoQuery())).toBeNull();
+            expect(await db.one(makeTodoQuery())).toEqual(todo);
+            throw new Error("callback failed");
+          }),
+        ).rejects.toThrow("callback failed");
+
+        expect(await db.one(makeTodoQuery())).toEqual(todo);
+      });
     });
   });
 });


### PR DESCRIPTION
## Description

Batched/transaction writes used to modify indexes, which are shared with "regular" queries. That means e.g. that deleting a row in a tx would also make it disappear from db.one/all queries.

This PR modifies batched/transaction writes to not modify indexes until the batch/tx is committed, and wires batch/tx queries to retrieve these rows from the overlay instead