### PR TITLE
Add repro for worker hydration durability wait

### DIFF
--- a/packages/jazz-tools/src/runtime/client.test.ts
+++ b/packages/jazz-tools/src/runtime/client.test.ts
@@ -252,6 +252,7 @@ describe("JazzClient worker batch hydration", () => {
       }),
     ]);
 
+    // Current result: this still returns the runtime's older "local" settlement.
     expect(client.localBatchRecord(batchId)?.latestSettlement).toMatchObject({
       confirmedTier: "global",
     });

--- a/packages/jazz-tools/src/runtime/client.test.ts
+++ b/packages/jazz-tools/src/runtime/client.test.ts
@@ -100,6 +100,18 @@ function makeContext(): AppContext {
   };
 }
 
+function makeLocalBatchRecord(
+  batchId: string,
+  latestSettlement: LocalBatchRecord["latestSettlement"] = null,
+): LocalBatchRecord {
+  return {
+    batchId,
+    mode: "direct",
+    sealed: true,
+    latestSettlement,
+  };
+}
+
 describe("JazzClient onAuthFailure wiring", () => {
   it("registers runtimeOptions.onAuthFailure with runtime.onAuthFailure on construction", () => {
     const runtime = makeFakeRuntime();
@@ -211,6 +223,41 @@ describe("JazzClient.updateCookieSession", () => {
     expect(runtime.updateAuth).toHaveBeenCalledTimes(1);
     const arg = runtime.updateAuth.mock.calls[0][0] as string;
     expect(JSON.parse(arg)).toMatchObject({ jwt_token: null });
+  });
+});
+
+describe("JazzClient worker batch hydration", () => {
+  it.fails("unblocks edge waits when the worker has a stronger durable settlement", async () => {
+    const batchId = "batch-chat";
+    const runtime = makeFakeRuntime();
+    const runtimeRecord = makeLocalBatchRecord(batchId, {
+      kind: "durableDirect",
+      batchId,
+      confirmedTier: "local",
+    });
+    runtime.loadLocalBatchRecord.mockImplementation((requestedBatchId: string) => {
+      if (requestedBatchId !== batchId) return null;
+      return runtimeRecord;
+    });
+    runtime.loadLocalBatchRecords.mockReturnValue([runtimeRecord]);
+    runtime.waitForBatch.mockImplementation(() => new Promise(() => {}));
+    delete (runtime as Partial<Runtime>).loadBatchFate;
+    const client = JazzClient.connectWithRuntime(runtime as any, makeContext());
+
+    client.hydrateLocalBatchRecords([
+      makeLocalBatchRecord(batchId, {
+        kind: "durableDirect",
+        batchId,
+        confirmedTier: "global",
+      }),
+    ]);
+
+    expect(client.localBatchRecord(batchId)?.latestSettlement).toMatchObject({
+      confirmedTier: "global",
+    });
+    expect(client.hasPendingHydratedBatchReconciliation("edge")).toBe(false);
+    await expect(client.waitForBatch(batchId, "edge")).resolves.toBeUndefined();
+    expect(runtime.waitForBatch).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## What

Adds an expected-failing regression test for the invite durability wait issue described in #828.

The test models the browser runtime case where the main runtime has an older `local` settlement for a batch, then the worker hydrates a stronger `global` settlement for the same batch. The expected behavior is that `waitForBatch(batchId, "edge")` can resolve from the stronger worker-hydrated record.

## Repro steps from #828

1. The chat app creates the initial chat with an `edge` durability wait.
2. The main browser runtime records the new write batch as durable only at `local`.
3. The worker runtime syncs that same batch to the server.
4. The server confirms the batch and the worker observes a stronger settlement, for example `global` durability.
5. The worker hydrates its local batch records back into the main runtime.
6. The main runtime already has a batch record for the same batch id, so `localBatchRecord(batchId)` keeps returning the main runtime's older `local` settlement.
7. `waitForBatch(batchId, "edge")` looks at that older `local` settlement, decides it has not reached `edge`, and stays pending.
8. In the invite test, that means `CreateChatRedirect` stays on `Creating chat...`; the user never reaches the chat view, so the invite flow cannot continue.

## Validation

- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/runtime/client.test.ts -t "worker batch hydration"`
  - Result: 1 expected fail, 31 skipped.