### PR TITLE
Make contains index scans explicit

### DIFF
--- a/crates/jazz-tools/src/query_manager/graph/compile.rs
+++ b/crates/jazz-tools/src/query_manager/graph/compile.rs
@@ -2103,6 +2103,7 @@ fn apply_condition_to_builder(mut builder: QueryBuilder, condition: &Condition) 
 fn condition_to_scan(cond: &Condition) -> ScanCondition {
     match cond {
         Condition::Eq { value, .. } => ScanCondition::Eq(value.clone()),
+        Condition::Contains { value, .. } => ScanCondition::Contains(value.clone()),
         Condition::Lt { value, .. } => ScanCondition::Range {
             min: Bound::Unbounded,
             max: Bound::Excluded(value.clone()),

--- a/crates/jazz-tools/src/query_manager/graph/compile.rs
+++ b/crates/jazz-tools/src/query_manager/graph/compile.rs
@@ -167,6 +167,34 @@ fn best_available_index_condition<'a>(
                 condition.is_index_scannable() && table_schema.is_indexed_column(condition.column())
             })
         })
+        .or_else(|| {
+            disjunct.conditions.iter().find(|condition| {
+                condition_contains_can_use_expanded_index(condition, table_schema)
+                    && table_schema.is_indexed_column(condition.column())
+            })
+        })
+}
+
+fn condition_contains_can_use_expanded_index(
+    condition: &Condition,
+    table_schema: &crate::query_manager::types::TableSchema,
+) -> bool {
+    let Condition::Contains { value, .. } = condition else {
+        return false;
+    };
+    if value.is_null() {
+        return false;
+    }
+    let Some(column) = table_schema.columns.column(condition.column()) else {
+        return false;
+    };
+
+    column.references.is_some()
+        && matches!(
+            &column.column_type,
+            crate::query_manager::types::ColumnType::Array { element }
+                if matches!(element.as_ref(), crate::query_manager::types::ColumnType::Uuid)
+        )
 }
 
 fn collect_magic_refs_from_project_columns(

--- a/crates/jazz-tools/src/query_manager/graph_nodes/index_scan.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/index_scan.rs
@@ -4,7 +4,7 @@ use std::ops::Bound;
 use crate::object::{BranchName, ObjectId};
 use crate::query_manager::index::ScanCondition;
 use crate::query_manager::types::{
-    ColumnName, RowDescriptor, TableName, Tuple, TupleDelta, TupleDescriptor, Value,
+    ColumnName, ColumnType, RowDescriptor, TableName, Tuple, TupleDelta, TupleDescriptor, Value,
 };
 use crate::row_format::decode_row;
 
@@ -76,7 +76,8 @@ impl IndexScanNode {
         };
         match &self.condition {
             ScanCondition::All => true,
-            ScanCondition::Eq(expected) => value == *expected || array_contains(&value, expected),
+            ScanCondition::Eq(expected) => value == *expected,
+            ScanCondition::Contains(expected) => value_contains(&value, expected),
             ScanCondition::Range { min, max } => {
                 bound_matches(min, &value, true) && bound_matches(max, &value, false)
             }
@@ -122,10 +123,32 @@ impl IndexScanNode {
             }
         }
     }
+
+    fn contains_can_use_expanded_index(&self) -> bool {
+        let Some(column_index) = self.row_descriptor.column_index(self.column.as_str()) else {
+            return false;
+        };
+        let Some(column) = self.row_descriptor.columns.get(column_index) else {
+            return false;
+        };
+
+        column.references.is_some()
+            && matches!(
+                &column.column_type,
+                ColumnType::Array { element } if matches!(element.as_ref(), ColumnType::Uuid)
+            )
+    }
 }
 
-fn array_contains(value: &Value, expected: &Value) -> bool {
-    matches!(value, Value::Array(values) if values.iter().any(|value| value == expected))
+fn value_contains(value: &Value, expected: &Value) -> bool {
+    match value {
+        Value::Array(values) => values.iter().any(|value| value == expected),
+        Value::Text(text) => match expected {
+            Value::Text(substr) => text.contains(substr),
+            _ => false,
+        },
+        _ => false,
+    }
 }
 
 fn compare_values_for_ordering(left: &Value, right: &Value) -> Option<std::cmp::Ordering> {
@@ -190,6 +213,21 @@ impl SourceNode for IndexScanNode {
                     &self.branch,
                     value,
                 )
+                .into_iter()
+                .collect(),
+            ScanCondition::Contains(value) if self.contains_can_use_expanded_index() => ctx
+                .storage
+                .index_lookup(
+                    self.table.as_str(),
+                    self.column.as_str(),
+                    &self.branch,
+                    value,
+                )
+                .into_iter()
+                .collect(),
+            ScanCondition::Contains(_) => ctx
+                .storage
+                .index_scan_all(self.table.as_str(), self.column.as_str(), &self.branch)
                 .into_iter()
                 .collect(),
             ScanCondition::Range { min, max } => {

--- a/crates/jazz-tools/src/query_manager/index/mod.rs
+++ b/crates/jazz-tools/src/query_manager/index/mod.rs
@@ -9,6 +9,8 @@ pub enum ScanCondition {
     All,
     /// Exact match on value.
     Eq(Value),
+    /// Containment match on value.
+    Contains(Value),
     /// Range scan with bounds (inclusive, exclusive, or unbounded).
     Range {
         min: Bound<Value>,

--- a/crates/jazz-tools/src/query_manager/query.rs
+++ b/crates/jazz-tools/src/query_manager/query.rs
@@ -275,7 +275,6 @@ impl Condition {
             | Condition::Gt { value, .. }
             | Condition::Ge { value, .. } => !value.is_null(),
             Condition::Between { min, max, .. } => !min.is_null() && !max.is_null(),
-            Condition::Contains { value, .. } => !value.is_null(),
             _ => false,
         }
     }

--- a/crates/jazz-tools/src/query_manager/query.rs
+++ b/crates/jazz-tools/src/query_manager/query.rs
@@ -275,6 +275,7 @@ impl Condition {
             | Condition::Gt { value, .. }
             | Condition::Ge { value, .. } => !value.is_null(),
             Condition::Between { min, max, .. } => !min.is_null() && !max.is_null(),
+            Condition::Contains { value, .. } => !value.is_null(),
             _ => false,
         }
     }

--- a/crates/jazz-tools/src/runtime_core/tests/query_subscription.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/query_subscription.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::query_manager::types::{ColumnDescriptor, RowDescriptor};
 
 fn persist_direct_settlement_for_row(
     core: &mut TestCore,
@@ -563,6 +564,104 @@ fn rc_query_local_transaction_overlay_handles_indexed_update_filters() {
         shared_overlay_rows,
         Vec::<(ObjectId, Vec<Value>)>::new(),
         "transaction indexed reads should use the staged value, not the branch index value"
+    );
+}
+
+#[test]
+fn rc_query_local_transaction_overlay_uses_contains_not_eq_for_array_refs() {
+    let mut schema = Schema::new();
+    schema.insert(
+        TableName::new("file_parts"),
+        TableSchema::builder("file_parts")
+            .column("label", ColumnType::Text)
+            .build(),
+    );
+    schema.insert(
+        TableName::new("files"),
+        TableSchema {
+            columns: RowDescriptor::new(vec![
+                ColumnDescriptor::new("title", ColumnType::Text),
+                ColumnDescriptor::new(
+                    "parts",
+                    ColumnType::Array {
+                        element: Box::new(ColumnType::Uuid),
+                    },
+                )
+                .references("file_parts"),
+            ]),
+            indexed_columns: None,
+            policies: TablePolicies::default(),
+        },
+    );
+    let mut core = create_runtime_with_schema(schema, "query-local-overlay-array-refs");
+    let branch_name = core.schema_manager().branch_name();
+
+    let ((part_id, _), _) = core
+        .insert(
+            "file_parts",
+            HashMap::from([("label".to_string(), Value::Text("cover".into()))]),
+            None,
+        )
+        .unwrap();
+
+    let batch_id = BatchId::new();
+    let write_context = WriteContext {
+        session: None,
+        attribution: None,
+        updated_at: None,
+        batch_mode: Some(crate::batch_fate::BatchMode::Transactional),
+        batch_id: Some(batch_id),
+        target_branch_name: None,
+    };
+    let ((file_id, _), _) = core
+        .insert(
+            "files",
+            HashMap::from([
+                ("title".to_string(), Value::Text("Launch plan".into())),
+                (
+                    "parts".to_string(),
+                    Value::Array(vec![Value::Uuid(part_id)]),
+                ),
+            ]),
+            Some(&write_context),
+        )
+        .unwrap();
+
+    let contains_rows = execute_runtime_query_with_local_overlay(
+        &mut core,
+        QueryBuilder::new("files")
+            .filter_contains("parts", Value::Uuid(part_id))
+            .build(),
+        None,
+        ReadDurabilityOptions::default(),
+        crate::sync_manager::QueryPropagation::Full,
+        QueryLocalOverlay {
+            batch_id,
+            branch_name: branch_name.clone(),
+            row_ids: vec![file_id],
+        },
+    );
+    assert_eq!(contains_rows.len(), 1);
+    assert_eq!(contains_rows[0].0, file_id);
+
+    let eq_rows = execute_runtime_query_with_local_overlay(
+        &mut core,
+        QueryBuilder::new("files")
+            .filter_eq("parts", Value::Uuid(part_id))
+            .build(),
+        None,
+        ReadDurabilityOptions::default(),
+        crate::sync_manager::QueryPropagation::Full,
+        QueryLocalOverlay {
+            batch_id,
+            branch_name,
+            row_ids: vec![file_id],
+        },
+    );
+    assert_eq!(
+        eq_rows,
+        Vec::<(ObjectId, Vec<Value>)>::new(),
+        "array reference membership must not be folded into equality"
     );
 }
 


### PR DESCRIPTION
## What changed

- Add an explicit `ScanCondition::Contains` for index scans.
- Lower `Condition::Contains` / `filter_contains` to that scan condition instead of scanning all rows.
- Keep equality overlay evaluation as strict equality only.
- Route referenced UUID-array contains scans through the existing expanded index lookup path while keeping that storage detail named as contains behavior.
- Add a runtime overlay regression test proving `filter_contains` sees a staged array-ref row while `filter_eq` does not match array membership.

## Why

PR #849 made local overlay evaluation treat equality as `equals OR array contains`, leaking the physical reference-array index expansion into query semantics. Query semantics already have an explicit contains operator, so equality should not broaden to arbitrary membership.

## Validation

- `cargo fmt --check`
- `pnpm lint`
- `cargo test -p jazz-tools rc_query_local_transaction_overlay_uses_contains_not_eq_for_array_refs -- --nocapture`
- `cargo test -p jazz-tools runtime_core::tests::query_subscription -- --nocapture`
- `cargo test -p jazz-tools query_manager::manager_tests::array_subqueries -- --nocapture`
- `cargo test -p jazz-tools graph_nodes::index_scan -- --nocapture`

## Notes

Attempted `pnpm --filter jazz-tools test:browser tests/browser/db.transaction-reads.test.ts`, but this worktree cannot load the browser Vitest config because `jazz-napi` is unresolved. A broader `pnpm --filter jazz-tools test ...` attempt similarly failed on unresolved `jazz-napi` / `jazz-wasm` and missing built `dist` artifacts.
