### PR TITLE
Cache policy evaluation during server settlement

### DIFF
--- a/.changeset/policy-eval-settlement-cache.md
+++ b/.changeset/policy-eval-settlement-cache.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Cache repeated policy evaluation work across server-side query settlement so large authorized loads avoid rechecking the same rows, inherited references, and recursive relation expansions.

--- a/crates/jazz-tools/src/query_manager/graph/execute.rs
+++ b/crates/jazz-tools/src/query_manager/graph/execute.rs
@@ -2,6 +2,7 @@ use ahash::{AHashMap, AHashSet};
 use smallvec::SmallVec;
 
 use crate::object::ObjectId;
+use crate::query_manager::server_queries::PolicyEvalCache;
 use crate::query_manager::types::{LoadedRow, RowDelta, TableName, Tuple, TupleDelta};
 use crate::storage::Storage;
 
@@ -392,6 +393,18 @@ impl QueryGraph {
     where
         F: FnMut(ObjectId, Option<TableName>) -> Option<LoadedRow>,
     {
+        self.settle_with_policy_eval_cache(storage, None, &mut row_loader)
+    }
+
+    pub(crate) fn settle_with_policy_eval_cache<F>(
+        &mut self,
+        storage: &dyn Storage,
+        mut policy_eval_cache: Option<&mut PolicyEvalCache>,
+        mut row_loader: F,
+    ) -> RowDelta
+    where
+        F: FnMut(ObjectId, Option<TableName>) -> Option<LoadedRow>,
+    {
         let order = self.topo_sort_dirty();
         if !order.is_empty() {
             tracing::trace!(dirty_nodes = order.len(), table = %self.table, "settling query graph");
@@ -555,6 +568,7 @@ impl QueryGraph {
                         let delta = recursive_node.process_with_context(
                             input_delta,
                             storage,
+                            policy_eval_cache.as_deref_mut(),
                             &mut |id, hint| row_loader(id, hint),
                         );
                         tracing::debug!(

--- a/crates/jazz-tools/src/query_manager/graph_nodes/magic_columns.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/magic_columns.rs
@@ -384,7 +384,7 @@ impl MagicColumnsNode {
                     return Value::Null;
                 };
 
-                let evaluator = PolicyContextEvaluator::new(
+                let mut evaluator = PolicyContextEvaluator::new(
                     &self.schema,
                     session,
                     &self.branch,

--- a/crates/jazz-tools/src/query_manager/graph_nodes/policy_eval.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/policy_eval.rs
@@ -7,6 +7,7 @@ use crate::query_manager::policy::{
 };
 use crate::query_manager::policy_graph::PolicyGraph;
 use crate::query_manager::relation_ir::RelExpr;
+use crate::query_manager::server_queries::{InheritedRefCacheKey, PolicyEvalCache};
 use crate::query_manager::session::Session;
 use crate::query_manager::types::{
     ColumnType, LoadedRow, Row, RowDescriptor, RowPolicyMode, Schema, TableName, Value,
@@ -20,6 +21,7 @@ pub(crate) struct PolicyContextEvaluator<'a> {
     session: &'a Session,
     branch: &'a str,
     row_policy_mode: RowPolicyMode,
+    policy_eval_cache: Option<&'a mut PolicyEvalCache>,
 }
 
 impl<'a> PolicyContextEvaluator<'a> {
@@ -34,12 +36,21 @@ impl<'a> PolicyContextEvaluator<'a> {
             session,
             branch,
             row_policy_mode,
+            policy_eval_cache: None,
         }
+    }
+
+    pub(crate) fn with_policy_eval_cache(
+        mut self,
+        policy_eval_cache: Option<&'a mut PolicyEvalCache>,
+    ) -> Self {
+        self.policy_eval_cache = policy_eval_cache;
+        self
     }
 
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn evaluate_row_access(
-        &self,
+        &mut self,
         operation: Operation,
         row: &Row,
         descriptor: &RowDescriptor,
@@ -55,17 +66,30 @@ impl<'a> PolicyContextEvaluator<'a> {
         }
 
         let table = TableName::new(table_name);
+        crate::query_manager::policy_counters::increment(
+            "row_access",
+            format!(
+                "table={} op={:?} depth={} row={}",
+                table_name, operation, depth, row.id
+            ),
+        );
+        crate::query_manager::policy_counters::increment(
+            "row_access_shape",
+            format!("table={} op={:?} depth={}", table_name, operation, depth),
+        );
         let key = (table, row.id, operation);
         if !visited_referencing.insert(key) {
             return false;
         }
 
-        let local_allow = local_policy_override
-            .or_else(|| self.policy_for_operation(table, operation))
-            .map(|policy| {
+        let local_policy = local_policy_override
+            .cloned()
+            .or_else(|| self.policy_for_operation(table, operation).cloned());
+        let local_allow = match local_policy {
+            Some(policy) => {
                 let mut visited_inherits = HashSet::new();
                 self.evaluate_expr_with_context(
-                    policy,
+                    &policy,
                     operation,
                     row,
                     descriptor,
@@ -76,15 +100,16 @@ impl<'a> PolicyContextEvaluator<'a> {
                     &mut visited_inherits,
                     visited_referencing,
                 )
-            })
-            .unwrap_or(!self.row_policy_mode.denies_missing_explicit_policy());
+            }
+            None => !self.row_policy_mode.denies_missing_explicit_policy(),
+        };
 
         visited_referencing.remove(&(table, row.id, operation));
         local_allow
     }
 
     fn policy_for_operation(
-        &self,
+        &mut self,
         table_name: TableName,
         operation: Operation,
     ) -> Option<&PolicyExpr> {
@@ -99,7 +124,7 @@ impl<'a> PolicyContextEvaluator<'a> {
 
     #[allow(clippy::too_many_arguments)]
     fn evaluate_inherits_referencing_with_context(
-        &self,
+        &mut self,
         operation: Operation,
         source_table: &str,
         via_column: &str,
@@ -185,7 +210,7 @@ impl<'a> PolicyContextEvaluator<'a> {
 
     #[allow(clippy::too_many_arguments)]
     fn evaluate_expr_with_context(
-        &self,
+        &mut self,
         expr: &PolicyExpr,
         operation: Operation,
         row: &Row,
@@ -303,7 +328,7 @@ impl<'a> PolicyContextEvaluator<'a> {
 
     #[allow(clippy::too_many_arguments)]
     fn evaluate_inherits_with_context(
-        &self,
+        &mut self,
         operation: Operation,
         via_column: &str,
         max_depth: Option<usize>,
@@ -343,6 +368,46 @@ impl<'a> PolicyContextEvaluator<'a> {
             _ => return false,
         };
 
+        let cache_key = if depth == 0 && visited.is_empty() {
+            Some(InheritedRefCacheKey {
+                table: *parent_table,
+                id: parent_id,
+                operation,
+                parent_eval_depth: depth + 1,
+            })
+        } else {
+            None
+        };
+
+        if let Some(cache_key) = &cache_key {
+            if let Some(result) = self
+                .policy_eval_cache
+                .as_ref()
+                .and_then(|cache| cache.inherited_ref_authorization_get(cache_key))
+            {
+                crate::query_manager::policy_counters::increment(
+                    "inherits_ref_cache",
+                    format!(
+                        "hit table={} op={:?} depth={}",
+                        cache_key.table.as_str(),
+                        operation,
+                        cache_key.parent_eval_depth
+                    ),
+                );
+                return result;
+            }
+
+            crate::query_manager::policy_counters::increment(
+                "inherits_ref_cache",
+                format!(
+                    "miss table={} op={:?} depth={}",
+                    cache_key.table.as_str(),
+                    operation,
+                    cache_key.parent_eval_depth
+                ),
+            );
+        }
+
         if visited.contains(&parent_id) {
             return false;
         }
@@ -377,7 +442,7 @@ impl<'a> PolicyContextEvaluator<'a> {
             parent_row.batch_id,
             parent_row.row_provenance,
         );
-        self.evaluate_expr_with_context(
+        let result = self.evaluate_expr_with_context(
             parent_policy,
             operation,
             &parent_row,
@@ -388,12 +453,20 @@ impl<'a> PolicyContextEvaluator<'a> {
             depth + 1,
             visited,
             visited_referencing,
-        )
+        );
+
+        if let Some(cache_key) = cache_key
+            && let Some(cache) = self.policy_eval_cache.as_mut()
+        {
+            cache.inherited_ref_authorization_insert(cache_key, result);
+        }
+
+        result
     }
 
     #[allow(clippy::too_many_arguments)]
     fn evaluate_exists_with_context(
-        &self,
+        &mut self,
         table: &str,
         condition: &PolicyExpr,
         operation: Operation,
@@ -428,7 +501,11 @@ impl<'a> PolicyContextEvaluator<'a> {
         };
 
         for _ in 0..100 {
-            if graph.settle(io, row_loader) {
+            if graph.settle_with_policy_eval_cache(
+                io,
+                self.policy_eval_cache.as_deref_mut(),
+                row_loader,
+            ) {
                 break;
             }
         }
@@ -438,7 +515,7 @@ impl<'a> PolicyContextEvaluator<'a> {
 
     #[allow(clippy::too_many_arguments)]
     fn evaluate_exists_rel_with_context(
-        &self,
+        &mut self,
         rel: &RelExpr,
         structural_scans: bool,
         row: &Row,
@@ -459,6 +536,20 @@ impl<'a> PolicyContextEvaluator<'a> {
             };
 
         let current_table = TableName::new(table_name);
+        crate::query_manager::policy_counters::increment(
+            "exists_rel",
+            format!(
+                "table={} row={} structural_scans={} rel={:?}",
+                table_name, row.id, structural_scans, bound_rel
+            ),
+        );
+        crate::query_manager::policy_counters::increment(
+            "exists_rel_shape",
+            format!(
+                "table={} structural_scans={} rel={:?}",
+                table_name, structural_scans, bound_rel
+            ),
+        );
         let mut graph = match PolicyGraph::for_exists_rel(
             &bound_rel,
             self.schema,
@@ -473,7 +564,11 @@ impl<'a> PolicyContextEvaluator<'a> {
         };
 
         for _ in 0..100 {
-            if graph.settle(io, row_loader) {
+            if graph.settle_with_policy_eval_cache(
+                io,
+                self.policy_eval_cache.as_deref_mut(),
+                row_loader,
+            ) {
                 break;
             }
         }

--- a/crates/jazz-tools/src/query_manager/graph_nodes/policy_filter.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/policy_filter.rs
@@ -368,7 +368,7 @@ impl PolicyFilterNode {
         io: &dyn Storage,
         row_loader: &mut dyn FnMut(ObjectId, Option<TableName>) -> Option<LoadedRow>,
     ) -> bool {
-        let evaluator = PolicyContextEvaluator::new(
+        let mut evaluator = PolicyContextEvaluator::new(
             &self.schema,
             &self.session,
             &self.branch,

--- a/crates/jazz-tools/src/query_manager/graph_nodes/recursive_relation.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/recursive_relation.rs
@@ -6,11 +6,14 @@
 //! - deterministic dedupe by normalized row content.
 
 use ahash::{AHashMap, AHashSet};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use uuid::Uuid;
 
 use crate::metadata::{RowProvenance, SYSTEM_PRINCIPAL_ID};
 use crate::object::ObjectId;
 use crate::query_manager::encoding::{decode_row, encode_row};
+use crate::query_manager::server_queries::PolicyEvalCache;
 use crate::query_manager::types::{
     LoadedRow, Row, RowDescriptor, Schema, TableName, Tuple, TupleBatchProvenance, TupleDelta,
     TupleDescriptor, TupleElement, TupleProvenance, Value,
@@ -102,10 +105,11 @@ impl RecursiveRelationNode {
     }
 
     /// Process seed tuple deltas with query context.
-    pub fn process_with_context<F>(
+    pub(crate) fn process_with_context<F>(
         &mut self,
         input: TupleDelta,
         io: &dyn Storage,
+        policy_eval_cache: Option<&mut PolicyEvalCache>,
         mut row_loader: F,
     ) -> TupleDelta
     where
@@ -117,7 +121,7 @@ impl RecursiveRelationNode {
             return TupleDelta::default();
         }
 
-        let next = self.recompute(io, &mut row_loader);
+        let next = self.recompute(io, policy_eval_cache, &mut row_loader);
         let delta = diff_sets(&self.current_tuples, &next);
 
         self.current_tuples = next;
@@ -158,14 +162,16 @@ impl RecursiveRelationNode {
     fn recompute(
         &self,
         io: &dyn Storage,
+        policy_eval_cache: Option<&mut PolicyEvalCache>,
         row_loader: &mut dyn FnMut(ObjectId, Option<TableName>) -> Option<LoadedRow>,
     ) -> AHashSet<Tuple> {
         if self.hop.is_some() {
-            return self.recompute_with_hop(io, row_loader);
+            return self.recompute_with_hop(io, policy_eval_cache, row_loader);
         }
         if matches!(self.correlation_source, CorrelationSource::ObjectId) {
             return self.recompute_with_object_id(io, row_loader);
         }
+        self.count_recompute("plain");
 
         let mut seen_contents = AHashMap::<Vec<u8>, (TupleProvenance, TupleBatchProvenance)>::new();
         let mut frontier_contents = Vec::<(Vec<u8>, TupleProvenance, TupleBatchProvenance)>::new();
@@ -255,6 +261,7 @@ impl RecursiveRelationNode {
         io: &dyn Storage,
         row_loader: &mut dyn FnMut(ObjectId, Option<TableName>) -> Option<LoadedRow>,
     ) -> AHashSet<Tuple> {
+        self.count_recompute("object_id");
         let mut seen_rows = AHashMap::<
             ObjectId,
             (
@@ -444,8 +451,62 @@ impl RecursiveRelationNode {
     fn recompute_with_hop(
         &self,
         io: &dyn Storage,
+        policy_eval_cache: Option<&mut PolicyEvalCache>,
         row_loader: &mut dyn FnMut(ObjectId, Option<TableName>) -> Option<LoadedRow>,
     ) -> AHashSet<Tuple> {
+        let Some(cache) = policy_eval_cache else {
+            return self.recompute_with_hop_uncached(io, row_loader);
+        };
+        let key = self.recompute_cache_key("hop");
+        if let Some(cached) = cache.recursive_recompute_get(&key) {
+            crate::query_manager::policy_counters::increment(
+                "recursive_recompute_cache",
+                format!("hit kind=hop key={key:016x}"),
+            );
+            return cached;
+        }
+
+        crate::query_manager::policy_counters::increment(
+            "recursive_recompute_cache",
+            format!("miss kind=hop key={key:016x}"),
+        );
+        let result = self.recompute_with_hop_uncached(io, row_loader);
+        cache.recursive_recompute_insert(key, result.clone());
+        result
+    }
+
+    fn recompute_cache_key(&self, kind: &'static str) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        kind.hash(&mut hasher);
+        self.input_descriptor
+            .combined_descriptor()
+            .content_hash()
+            .hash(&mut hasher);
+        self.output_descriptor.content_hash().hash(&mut hasher);
+        self.max_depth.hash(&mut hasher);
+        format!("{:?}", self.correlation_source).hash(&mut hasher);
+        self.hop
+            .as_ref()
+            .map(|hop| hop.table.as_str())
+            .hash(&mut hasher);
+        self.hop
+            .as_ref()
+            .map(|hop| hop.step_column_index)
+            .hash(&mut hasher);
+
+        let mut seed_ids = self.seed_tuples.keys().copied().collect::<Vec<_>>();
+        seed_ids.sort_unstable();
+        seed_ids.hash(&mut hasher);
+
+        hasher.finish()
+    }
+
+    fn recompute_with_hop_uncached(
+        &self,
+        io: &dyn Storage,
+        row_loader: &mut dyn FnMut(ObjectId, Option<TableName>) -> Option<LoadedRow>,
+    ) -> AHashSet<Tuple> {
+        self.count_recompute("hop");
         let Some(hop) = &self.hop else {
             return AHashSet::new();
         };
@@ -720,6 +781,19 @@ impl RecursiveRelationNode {
         TupleProvenance,
         TupleBatchProvenance,
     )> {
+        crate::query_manager::policy_counters::increment(
+            "recursive_step",
+            format!(
+                "output_cols={} max_depth={} hop={} corr={:?}",
+                self.output_descriptor.columns.len(),
+                self.max_depth,
+                self.hop
+                    .as_ref()
+                    .map(|hop| hop.table.as_str())
+                    .unwrap_or("<none>"),
+                correlation_value
+            ),
+        );
         let mut instance = match self
             .step_template
             .instantiate(correlation_value.clone(), &self.schema)
@@ -752,6 +826,30 @@ impl RecursiveRelationNode {
                 ))
             })
             .collect()
+    }
+
+    fn count_recompute(&self, kind: &'static str) {
+        let mut seed_ids = self.seed_tuples.keys().copied().collect::<Vec<_>>();
+        seed_ids.sort_unstable();
+        let seed_ids = seed_ids
+            .into_iter()
+            .map(|id| id.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+        crate::query_manager::policy_counters::increment(
+            "recursive_recompute",
+            format!(
+                "kind={} output_cols={} max_depth={} hop={} seeds=[{}]",
+                kind,
+                self.output_descriptor.columns.len(),
+                self.max_depth,
+                self.hop
+                    .as_ref()
+                    .map(|hop| hop.table.as_str())
+                    .unwrap_or("<none>"),
+                seed_ids
+            ),
+        );
     }
 
     fn normalize_step_row(

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -26,6 +26,7 @@ use super::graph_nodes::output::QuerySubscriptionId;
 use super::policy::{Operation, PolicyExpr};
 use super::policy_graph::PolicyGraph;
 use super::query::Query;
+use super::server_queries::PolicyEvalCache;
 use super::session::Session;
 use super::types::{
     ColumnName, ComposedBranchName, LoadedRow, OrderedAdded, OrderedRowDelta, Row, RowDelta,
@@ -511,6 +512,9 @@ pub struct QueryManager {
     /// Server-side query subscriptions from downstream clients.
     /// Key is (client_id, query_id) to allow multiple queries per client.
     pub(super) server_subscriptions: HashMap<(ClientId, QueryId), ServerQuerySubscription>,
+    /// Policy evaluation reuse shared across a downstream client's active
+    /// server-side settlement generation.
+    pub(super) server_policy_eval_caches: HashMap<ClientId, PolicyEvalCache>,
 
     /// Schema context for multi-schema queries.
     /// Starts empty; initialized via set_current_schema().
@@ -651,6 +655,7 @@ impl QueryManager {
             failed_subscriptions: Vec::new(),
             active_policy_checks: HashMap::new(),
             server_subscriptions: HashMap::new(),
+            server_policy_eval_caches: HashMap::new(),
             schema_context: SchemaContext::empty(),
             branch_schema_map: HashMap::new(),
             pending_row_visibility_changes: Vec::new(),
@@ -1296,6 +1301,7 @@ impl QueryManager {
         }
         self.server_subscriptions
             .retain(|&(cid, _), _| cid != client_id);
+        self.server_policy_eval_caches.remove(&client_id);
         self.active_policy_checks
             .retain(|_, state| state.pending_check.client_id != client_id);
         true
@@ -1554,8 +1560,10 @@ impl QueryManager {
             let mut visible_tuples = if subscription.uses_explicit_authorization_filtering {
                 let auth_schema_context = self.schema_context.clone();
                 let auth_branch_schema_map = self.branch_schema_map.clone();
-                Cow::Owned(self.authorized_tuples_from_graph(
+                let mut policy_eval_cache = PolicyEvalCache::default();
+                Cow::Owned(self.authorized_tuples_from_graph_with_cache(
                     storage_ref,
+                    &mut policy_eval_cache,
                     &subscription.graph,
                     &auth_schema_context,
                     &auth_branch_schema_map,

--- a/crates/jazz-tools/src/query_manager/manager_tests/server_subscriptions.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests/server_subscriptions.rs
@@ -15,6 +15,16 @@ fn owned_items_schema() -> Schema {
     schema
 }
 
+fn structural_items_schema() -> Schema {
+    let mut schema = Schema::new();
+    let descriptor = RowDescriptor::new(vec![
+        ColumnDescriptor::new("owner_id", ColumnType::Text),
+        ColumnDescriptor::new("name", ColumnType::Text),
+    ]);
+    schema.insert(TableName::new("items"), TableSchema::new(descriptor));
+    schema
+}
+
 #[test]
 fn server_builds_query_graph_on_subscription() {
     use crate::sync_manager::{ClientId, Destination, InboxEntry, QueryId, Source, SyncPayload};
@@ -497,6 +507,119 @@ fn server_authorizes_subscription_sync_scope_without_rechecking_output_scope() {
         storage.visible_query_loads() <= 12,
         "server subscription should not re-run an extra output-scope authorization pass, got {} visible row loads",
         storage.visible_query_loads()
+    );
+}
+
+#[test]
+fn server_subscription_policy_eval_cache_is_cleared_after_initial_settlement_and_dirty_recompute() {
+    use crate::query_manager::policy::Operation;
+    use crate::query_manager::session::Session;
+    use crate::sync_manager::{
+        ClientId, Destination, InboxEntry, QueryId, QueryPropagation, Source, SyncPayload,
+    };
+
+    let mut server_qm = QueryManager::new(SyncManager::new());
+    server_qm.set_current_schema(structural_items_schema(), "dev", "main");
+    server_qm.set_authorization_schema(owned_items_schema());
+    let inner = seeded_memory_storage(&server_qm.schema_context().current_schema);
+    let mut storage = CountingCatalogueUpsertsStorage::with_inner(inner);
+
+    let alice_item = server_qm
+        .insert(
+            &mut storage,
+            "items",
+            &[
+                Value::Text("alice".to_string()),
+                Value::Text("Alice item".to_string()),
+            ],
+        )
+        .expect("insert alice item");
+    server_qm.process(&mut storage);
+
+    let client_id = ClientId::new();
+    connect_client(&mut server_qm, &storage, client_id);
+    let _ = server_qm.sync_manager_mut().take_outbox();
+
+    let query_id = QueryId(1);
+    let query = server_qm.query("items").build();
+    server_qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::QuerySubscription {
+            query_id,
+            query: Box::new(query),
+            session: Some(Session::new("alice")),
+            required_tier: None,
+            propagation: QueryPropagation::Full,
+            policy_context_tables: vec![],
+        },
+    });
+
+    server_qm.process(&mut storage);
+    let outbox = server_qm.sync_manager_mut().take_outbox();
+    assert!(
+        outbox.iter().any(|entry| matches!(
+            entry,
+            crate::sync_manager::OutboxEntry {
+                destination: Destination::Client(id),
+                payload: SyncPayload::QuerySettled { query_id: settled_query_id, .. },
+            } if *id == client_id && *settled_query_id == query_id
+        )),
+        "initial subscription should settle"
+    );
+    {
+        let sub = server_qm
+            .server_subscriptions
+            .get(&(client_id, query_id))
+            .expect("server subscription should exist after initial settlement");
+        assert!(sub.settled_once);
+        assert!(
+            server_qm.server_policy_eval_caches.contains_key(&client_id),
+            "initial settlement should retain a client policy cache for the active settlement generation"
+        );
+    }
+
+    let branch_name = server_qm.schema_context().branch_name();
+    {
+        server_qm
+            .server_policy_eval_caches
+            .entry(client_id)
+            .or_default()
+            .insert_row_authorization_for_test(
+                alice_item.row_id,
+                branch_name,
+                Operation::Select,
+                false,
+            );
+        assert!(
+            !server_qm.server_policy_eval_caches[&client_id].is_empty(),
+            "test setup should poison the existing generation cache"
+        );
+    }
+
+    server_qm
+        .insert(
+            &mut storage,
+            "items",
+            &[
+                Value::Text("bob".to_string()),
+                Value::Text("Bob item".to_string()),
+            ],
+        )
+        .expect("insert bob item");
+    server_qm.process(&mut storage);
+
+    let scope = server_qm
+        .sync_manager()
+        .get_client(client_id)
+        .expect("client should exist")
+        .queries
+        .get(&query_id)
+        .expect("query scope should still exist")
+        .scope
+        .clone();
+    assert!(
+        scope.contains(&(alice_item.row_id, branch_name)),
+        "dirty recompute must clear stale policy cache entries before filtering"
     );
 }
 

--- a/crates/jazz-tools/src/query_manager/mod.rs
+++ b/crates/jazz-tools/src/query_manager/mod.rs
@@ -7,6 +7,7 @@ pub mod indices;
 pub mod magic_columns;
 pub mod manager;
 pub mod policy;
+pub mod policy_counters;
 pub mod policy_graph;
 pub mod policy_ir;
 pub mod query;

--- a/crates/jazz-tools/src/query_manager/policy_counters.rs
+++ b/crates/jazz-tools/src/query_manager/policy_counters.rs
@@ -1,0 +1,100 @@
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+const REPORT_INTERVAL: Duration = Duration::from_secs(5);
+const TOP_N: usize = 12;
+
+#[derive(Default)]
+struct Bucket {
+    total: u64,
+    keys: HashMap<String, u64>,
+}
+
+impl Bucket {
+    fn increment(&mut self, key: String) {
+        self.total += 1;
+        *self.keys.entry(key).or_insert(0) += 1;
+    }
+}
+
+struct PolicyCounters {
+    started_at: Instant,
+    last_report: Instant,
+    buckets: HashMap<&'static str, Bucket>,
+}
+
+impl PolicyCounters {
+    fn new() -> Self {
+        let now = Instant::now();
+        Self {
+            started_at: now,
+            last_report: now,
+            buckets: HashMap::new(),
+        }
+    }
+}
+
+static COUNTERS: OnceLock<Mutex<PolicyCounters>> = OnceLock::new();
+
+fn enabled() -> bool {
+    std::env::var_os("JAZZ_POLICY_COUNTERS").is_some()
+}
+
+pub(crate) fn increment(bucket: &'static str, key: impl Into<String>) {
+    if !enabled() {
+        return;
+    }
+
+    let counters = COUNTERS.get_or_init(|| Mutex::new(PolicyCounters::new()));
+    let Ok(mut counters) = counters.lock() else {
+        return;
+    };
+
+    counters
+        .buckets
+        .entry(bucket)
+        .or_default()
+        .increment(key.into());
+
+    if counters.last_report.elapsed() >= REPORT_INTERVAL {
+        counters.last_report = Instant::now();
+        print_report(&counters);
+    }
+}
+
+fn print_report(counters: &PolicyCounters) {
+    eprintln!(
+        "[jazz-policy-counters] elapsed={:.1}s",
+        counters.started_at.elapsed().as_secs_f64()
+    );
+
+    let mut bucket_names = counters.buckets.keys().copied().collect::<Vec<_>>();
+    bucket_names.sort_unstable();
+
+    for bucket_name in bucket_names {
+        let Some(bucket) = counters.buckets.get(bucket_name) else {
+            continue;
+        };
+        eprintln!(
+            "[jazz-policy-counters] bucket={} total={} unique={}",
+            bucket_name,
+            bucket.total,
+            bucket.keys.len()
+        );
+
+        let mut top = bucket.keys.iter().collect::<Vec<_>>();
+        top.sort_by(|(left_key, left_count), (right_key, right_count)| {
+            right_count
+                .cmp(left_count)
+                .then_with(|| left_key.cmp(right_key))
+        });
+
+        for (key, count) in top.into_iter().take(TOP_N) {
+            eprintln!(
+                "[jazz-policy-counters] bucket={} count={} key={}",
+                bucket_name, count, key
+            );
+        }
+    }
+}

--- a/crates/jazz-tools/src/query_manager/policy_graph.rs
+++ b/crates/jazz-tools/src/query_manager/policy_graph.rs
@@ -19,6 +19,7 @@ use super::index::ScanCondition;
 use super::policy::{Operation, PolicyExpr};
 use super::relation_ir::RelExpr;
 use super::relation_ir_query_plan::lower_relation_to_execution_plan;
+use super::server_queries::PolicyEvalCache;
 use super::session::Session;
 use super::types::ColumnName;
 use super::types::{LoadedRow, RowPolicyMode, Schema, TableName, TupleDescriptor, Value};
@@ -327,7 +328,20 @@ impl PolicyGraph {
         io: &dyn Storage,
         row_loader: &mut dyn FnMut(ObjectId, Option<TableName>) -> Option<LoadedRow>,
     ) -> bool {
-        let _delta = self.graph.settle(io, &mut |id, hint| row_loader(id, hint));
+        self.settle_with_policy_eval_cache(io, None, row_loader)
+    }
+
+    pub(crate) fn settle_with_policy_eval_cache(
+        &mut self,
+        io: &dyn Storage,
+        policy_eval_cache: Option<&mut PolicyEvalCache>,
+        row_loader: &mut dyn FnMut(ObjectId, Option<TableName>) -> Option<LoadedRow>,
+    ) -> bool {
+        let _delta =
+            self.graph
+                .settle_with_policy_eval_cache(io, policy_eval_cache, &mut |id, hint| {
+                    row_loader(id, hint)
+                });
         true
     }
 

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -6,6 +6,7 @@ use std::time::{Duration, Instant};
 use crate::metadata::{MetadataKey, RowProvenance};
 use crate::object::{BranchName, ObjectId};
 use crate::query_manager::graph_nodes::policy_eval::PolicyContextEvaluator;
+use crate::query_manager::types::Tuple;
 use crate::row_histories::BatchId;
 use crate::schema_manager::LensTransformer;
 use crate::storage::Storage;
@@ -63,6 +64,83 @@ pub(crate) struct AuthorizationPolicyRequest<'a> {
     pub(crate) auth_context: &'a crate::schema_manager::SchemaContext,
     pub(crate) source_branch_schema_map: &'a std::collections::HashMap<String, SchemaHash>,
     pub(crate) operation: Operation,
+    pub(crate) policy_eval_cache: Option<&'a mut PolicyEvalCache>,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+struct RowAuthorizationCacheKey {
+    object_id: ObjectId,
+    branch_name: BranchName,
+    operation: Operation,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub(crate) struct InheritedRefCacheKey {
+    pub(crate) table: TableName,
+    pub(crate) id: ObjectId,
+    pub(crate) operation: Operation,
+    pub(crate) parent_eval_depth: usize,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct PolicyEvalCache {
+    row_authorization: HashMap<RowAuthorizationCacheKey, bool>,
+    inherited_ref_authorization: HashMap<InheritedRefCacheKey, bool>,
+    recursive_recompute: HashMap<u64, ahash::AHashSet<Tuple>>,
+}
+
+impl PolicyEvalCache {
+    pub(super) fn clear(&mut self) {
+        self.row_authorization.clear();
+        self.inherited_ref_authorization.clear();
+        self.recursive_recompute.clear();
+    }
+
+    #[cfg(test)]
+    pub(super) fn is_empty(&self) -> bool {
+        self.row_authorization.is_empty()
+    }
+
+    #[cfg(test)]
+    pub(super) fn insert_row_authorization_for_test(
+        &mut self,
+        object_id: ObjectId,
+        branch_name: BranchName,
+        operation: Operation,
+        result: bool,
+    ) {
+        self.row_authorization.insert(
+            RowAuthorizationCacheKey {
+                object_id,
+                branch_name,
+                operation,
+            },
+            result,
+        );
+    }
+
+    pub(super) fn inherited_ref_authorization_get(
+        &self,
+        key: &InheritedRefCacheKey,
+    ) -> Option<bool> {
+        self.inherited_ref_authorization.get(key).copied()
+    }
+
+    pub(super) fn inherited_ref_authorization_insert(
+        &mut self,
+        key: InheritedRefCacheKey,
+        result: bool,
+    ) {
+        self.inherited_ref_authorization.insert(key, result);
+    }
+
+    pub(crate) fn recursive_recompute_get(&self, key: &u64) -> Option<ahash::AHashSet<Tuple>> {
+        self.recursive_recompute.get(key).cloned()
+    }
+
+    pub(crate) fn recursive_recompute_insert(&mut self, key: u64, value: ahash::AHashSet<Tuple>) {
+        self.recursive_recompute.insert(key, value);
+    }
 }
 
 struct UpdatePermissionRequest<'a> {
@@ -375,6 +453,7 @@ impl QueryManager {
             auth_context,
             source_branch_schema_map,
             operation,
+            policy_eval_cache,
         } = request;
 
         let Some(table_schema) = auth_schema.get(&table_name) else {
@@ -391,12 +470,13 @@ impl QueryManager {
             return false;
         };
 
-        let evaluator = PolicyContextEvaluator::new(
+        let mut evaluator = PolicyContextEvaluator::new(
             auth_schema,
             session,
             branch_name.as_str(),
             self.row_policy_mode,
-        );
+        )
+        .with_policy_eval_cache(policy_eval_cache);
         let row = Row::new(object_id, transformed, BatchId([0; 16]), provenance.clone());
         let mut visited = HashSet::new();
         let mut row_loader = |related_id: ObjectId, _table_hint: Option<TableName>| {
@@ -426,6 +506,7 @@ impl QueryManager {
     pub(super) fn provenance_row_matches_current_select_policy(
         &mut self,
         storage: &dyn Storage,
+        policy_eval_cache: &mut PolicyEvalCache,
         object_id: ObjectId,
         branch_name: BranchName,
         session: Option<&Session>,
@@ -433,6 +514,22 @@ impl QueryManager {
         auth_context: &crate::schema_manager::SchemaContext,
         source_branch_schema_map: &std::collections::HashMap<String, SchemaHash>,
     ) -> bool {
+        let cache_key = session.map(|_| RowAuthorizationCacheKey {
+            object_id,
+            branch_name,
+            operation: Operation::Select,
+        });
+
+        if let Some(cache_key) = &cache_key
+            && let Some(result) = policy_eval_cache.row_authorization.get(cache_key).copied()
+        {
+            crate::query_manager::policy_counters::increment(
+                "row_authorization_cache",
+                "hit".to_string(),
+            );
+            return result;
+        }
+
         let branches = vec![branch_name.as_str().to_string()];
         let Some((table, row)) = self.load_best_visible_row_batch(
             storage,
@@ -442,9 +539,15 @@ impl QueryManager {
             auth_context,
             source_branch_schema_map,
         ) else {
+            if let Some(cache_key) = cache_key {
+                policy_eval_cache.row_authorization.insert(cache_key, false);
+            }
             return false;
         };
         if row.is_hard_deleted() {
+            if let Some(cache_key) = cache_key {
+                policy_eval_cache.row_authorization.insert(cache_key, false);
+            }
             return false;
         }
 
@@ -456,14 +559,24 @@ impl QueryManager {
             .get(&table_name)
             .and_then(|table_schema| table_schema.policies.select_policy())
         else {
-            return !self.row_policy_mode.denies_missing_explicit_policy()
+            let result = !self.row_policy_mode.denies_missing_explicit_policy()
                 && auth_schema.contains_key(&table_name);
+            if let Some(cache_key) = cache_key {
+                policy_eval_cache
+                    .row_authorization
+                    .insert(cache_key, result);
+            }
+            return result;
         };
         let Some(session) = session else {
             return false;
         };
 
-        self.evaluate_authorization_policy(
+        crate::query_manager::policy_counters::increment(
+            "row_authorization_cache",
+            format!("miss table={}", table_name.as_str()),
+        );
+        let result = self.evaluate_authorization_policy(
             storage,
             AuthorizationPolicyRequest {
                 object_id,
@@ -477,13 +590,21 @@ impl QueryManager {
                 auth_context,
                 source_branch_schema_map,
                 operation: Operation::Select,
+                policy_eval_cache: Some(policy_eval_cache),
             },
-        )
+        );
+        if let Some(cache_key) = cache_key {
+            policy_eval_cache
+                .row_authorization
+                .insert(cache_key, result);
+        }
+        result
     }
 
     fn authorized_tuples_from_graph_result(
         &mut self,
         storage: &dyn Storage,
+        policy_eval_cache: &mut PolicyEvalCache,
         graph: &super::graph::QueryGraph,
         schema_context: &crate::schema_manager::SchemaContext,
         source_branch_schema_map: &std::collections::HashMap<String, SchemaHash>,
@@ -527,6 +648,7 @@ impl QueryManager {
                                 .or_insert_with(|| {
                                     self.provenance_row_matches_current_select_policy(
                                         storage,
+                                        policy_eval_cache,
                                         object_id,
                                         branch_name,
                                         session,
@@ -542,9 +664,10 @@ impl QueryManager {
         )
     }
 
-    pub(super) fn authorized_tuples_from_graph(
+    pub(super) fn authorized_tuples_from_graph_with_cache(
         &mut self,
         storage: &dyn Storage,
+        policy_eval_cache: &mut PolicyEvalCache,
         graph: &super::graph::QueryGraph,
         schema_context: &crate::schema_manager::SchemaContext,
         source_branch_schema_map: &std::collections::HashMap<String, SchemaHash>,
@@ -552,6 +675,7 @@ impl QueryManager {
     ) -> Vec<super::types::Tuple> {
         match self.authorized_tuples_from_graph_result(
             storage,
+            policy_eval_cache,
             graph,
             schema_context,
             source_branch_schema_map,
@@ -565,6 +689,7 @@ impl QueryManager {
     fn authorized_scope_from_graph_if_available(
         &mut self,
         storage: &dyn Storage,
+        policy_eval_cache: &mut PolicyEvalCache,
         graph: &super::graph::QueryGraph,
         schema_context: &crate::schema_manager::SchemaContext,
         source_branch_schema_map: &std::collections::HashMap<String, SchemaHash>,
@@ -600,6 +725,7 @@ impl QueryManager {
                         .or_insert_with(|| {
                             self.provenance_row_matches_current_select_policy(
                                 storage,
+                                policy_eval_cache,
                                 object_id,
                                 branch_name,
                                 session,
@@ -962,6 +1088,10 @@ impl QueryManager {
             // locally, including any ordered prefix required by pagination.
             let policy_context_tables =
                 Self::merged_policy_context_tables(&graph, &sub.policy_context_tables);
+            let mut policy_eval_cache = self
+                .server_policy_eval_caches
+                .remove(&sub.client_id)
+                .unwrap_or_default();
             let scope = if self
                 .client_bypasses_authorization_filtering(sub.client_id, session_for_policy.as_ref())
             {
@@ -979,6 +1109,7 @@ impl QueryManager {
             } else {
                 self.authorized_scope_from_graph_if_available(
                     storage_ref,
+                    &mut policy_eval_cache,
                     &graph,
                     &subscription_context,
                     &branch_schema_map,
@@ -1057,6 +1188,8 @@ impl QueryManager {
             }
 
             // Store the server subscription for reactive updates
+            self.server_policy_eval_caches
+                .insert(sub.client_id, policy_eval_cache);
             self.server_subscriptions.insert(
                 (sub.client_id, sub.query_id),
                 ServerQuerySubscription {
@@ -1142,6 +1275,13 @@ impl QueryManager {
             let branch_schema_map = Self::branch_schema_map_for_context(&sub.schema_context);
             let mut schema_warnings = SchemaWarningAccumulator::default();
             let had_dirty_graph = sub.graph.has_dirty_nodes();
+            let mut policy_eval_cache = self
+                .server_policy_eval_caches
+                .remove(&client_id)
+                .unwrap_or_default();
+            if had_dirty_graph && sub.settled_once {
+                policy_eval_cache.clear();
+            }
 
             // Row loader for this subscription
             let new_scope: Option<Cow<'_, HashSet<(ObjectId, BranchName)>>> = {
@@ -1198,6 +1338,7 @@ impl QueryManager {
                 } else {
                     self.authorized_scope_from_graph_if_available(
                         storage,
+                        &mut policy_eval_cache,
                         &sub.graph,
                         &sub.schema_context,
                         &branch_schema_map,
@@ -1280,6 +1421,8 @@ impl QueryManager {
                 }
             }
 
+            self.server_policy_eval_caches
+                .insert(client_id, policy_eval_cache);
             self.server_subscriptions.insert((client_id, query_id), sub);
         }
 
@@ -1620,6 +1763,7 @@ impl QueryManager {
                 auth_context: &auth_context,
                 source_branch_schema_map: &source_branch_schema_map,
                 operation: check.operation,
+                policy_eval_cache: None,
             },
         ) {
             let reason = format!(
@@ -1748,6 +1892,7 @@ impl QueryManager {
                     auth_context,
                     source_branch_schema_map: &source_branch_schema_map,
                     operation: Operation::Update,
+                    policy_eval_cache: None,
                 },
             ) {
                 let reason = format!(
@@ -1799,6 +1944,7 @@ impl QueryManager {
                     auth_context,
                     source_branch_schema_map: &source_branch_schema_map,
                     operation: Operation::Update,
+                    policy_eval_cache: None,
                 },
             ) {
                 let reason = format!(

--- a/crates/jazz-tools/src/query_manager/writes.rs
+++ b/crates/jazz-tools/src/query_manager/writes.rs
@@ -1683,6 +1683,7 @@ impl QueryManager {
                 auth_context,
                 source_branch_schema_map: &source_branch_schema_map,
                 operation,
+                policy_eval_cache: None,
             },
         )
     }


### PR DESCRIPTION
## Summary

- add a settlement-scoped `PolicyEvalCache` shared across a downstream client's active server-side query settlement generation
- reuse row authorization, inherited reference authorization, and recursive relation recompute results while settling authorized server query scopes
- clear client cache state on dirty recompute/client removal and add regression coverage for stale cache poisoning after initial settlement
- include a patch changeset for `jazz-tools`

## Validation

- `pnpm lint`
- `cargo fmt --check`
- `cargo check -p jazz-tools`
- `cargo clippy -p jazz-tools --lib -- -D warnings`
- `cargo test -p jazz-tools server_subscription_policy_eval_cache_is_cleared_after_initial_settlement_and_dirty_recompute -- --nocapture`
