### PR TITLE
Add per-frame LZ4 WebSocket compression

### DIFF
--- a/.changeset/lz4-websocket-messages.md
+++ b/.changeset/lz4-websocket-messages.md
@@ -1,0 +1,7 @@
+---
+"jazz-tools": patch
+"jazz-wasm": patch
+"jazz-napi": patch
+---
+
+Compress WebSocket transport frame payloads with LZ4 by default.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1790,6 +1790,7 @@ dependencies = [
  "internment",
  "jsonschema",
  "jsonwebtoken",
+ "lz4_flex",
  "mimalloc",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -2068,6 +2069,15 @@ checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
+dependencies = [
+ "twox-hash",
 ]
 
 [[package]]
@@ -4234,6 +4244,12 @@ dependencies = [
  "thiserror 1.0.69",
  "utf-8",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"

--- a/crates/jazz-tools/Cargo.toml
+++ b/crates/jazz-tools/Cargo.toml
@@ -119,6 +119,7 @@ opentelemetry-otlp = { version = "0.31", features = [
 ], optional = true }
 opentelemetry-stdout = { version = "0.31", features = ["trace"], optional = true }
 tracing-opentelemetry = { version = "0.32", optional = true }
+lz4_flex = "0.13.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 gloo-timers = { version = "0.3", features = ["futures"] }

--- a/crates/jazz-tools/src/server/routes/mod.rs
+++ b/crates/jazz-tools/src/server/routes/mod.rs
@@ -2152,7 +2152,7 @@ mod tests {
         let connected_payload = crate::transport_manager::frame_decode(&connected_frame)
             .expect("decode ConnectedResponse frame");
         let connected_response: crate::transport_manager::ConnectedResponse =
-            serde_json::from_slice(connected_payload).expect("parse ConnectedResponse");
+            serde_json::from_slice(connected_payload.as_ref()).expect("parse ConnectedResponse");
         assert_eq!(
             connected_response.sync_protocol_version,
             crate::transport_manager::SYNC_PROTOCOL_VERSION
@@ -2217,7 +2217,7 @@ mod tests {
         let payload =
             crate::transport_manager::frame_decode(&error_frame).expect("decode error frame");
         let event: crate::jazz_transport::ServerEvent =
-            serde_json::from_slice(payload).expect("parse error event");
+            serde_json::from_slice(payload.as_ref()).expect("parse error event");
         match event {
             crate::jazz_transport::ServerEvent::Error { message, code } => {
                 assert_eq!(code, crate::jazz_transport::ErrorCode::BadRequest);

--- a/crates/jazz-tools/src/server/routes/websocket.rs
+++ b/crates/jazz-tools/src/server/routes/websocket.rs
@@ -259,11 +259,8 @@ async fn send_ws_error_with_code(
         code,
     };
     if let Ok(bytes) = serde_json::to_vec(&event) {
-        let _ = socket
-            .send(Message::Binary(crate::transport_manager::frame_encode(
-                &bytes,
-            )))
-            .await;
+        let frame = crate::transport_manager::frame_encode(&bytes);
+        let _ = socket.send(Message::Binary(frame)).await;
     }
 }
 
@@ -291,7 +288,7 @@ async fn handle_ws_connection(
         }
     };
     let payload = match crate::transport_manager::frame_decode(&first) {
-        Some(p) => p.to_vec(),
+        Some(payload) => payload,
         None => {
             let _ = socket.close().await;
             return;
@@ -412,13 +409,8 @@ async fn handle_ws_connection(
             return;
         }
     };
-    if socket
-        .send(Message::Binary(crate::transport_manager::frame_encode(
-            &resp_bytes,
-        )))
-        .await
-        .is_err()
-    {
+    let connected_frame = crate::transport_manager::frame_encode(&resp_bytes);
+    if socket.send(Message::Binary(connected_frame)).await.is_err() {
         ws_cleanup(&state, connection_id, client_id).await;
         return;
     }
@@ -434,11 +426,10 @@ async fn handle_ws_connection(
         tokio::select! {
             msg = socket.recv() => match msg {
                 Some(Ok(Message::Binary(data))) => {
-                    let Some(inner) = crate::transport_manager::frame_decode(&data) else {
+                    let Some(payload) = crate::transport_manager::frame_decode(&data) else {
                         continue;
                     };
-                    let inner = inner.to_vec();
-                    if let Err(e) = state.process_ws_client_frame(client_id, &inner).await {
+                    if let Err(e) = state.process_ws_client_frame(client_id, &payload).await {
                         tracing::warn!(error = ?e, "ws client frame rejected");
                     }
                 }
@@ -475,26 +466,16 @@ async fn handle_ws_connection(
                     Ok(b) => b,
                     Err(_) => continue,
                 };
-                if socket
-                    .send(Message::Binary(
-                        crate::transport_manager::frame_encode(&bytes),
-                    ))
-                    .await
-                    .is_err()
-                {
+                let frame = crate::transport_manager::frame_encode(&bytes);
+                if socket.send(Message::Binary(frame)).await.is_err() {
                     break;
                 }
             }
             _ = heartbeat.tick() => {
                 let event = crate::jazz_transport::ServerEvent::Heartbeat;
                 let Ok(bytes) = event.encode_payload() else { continue };
-                if socket
-                    .send(Message::Binary(
-                        crate::transport_manager::frame_encode(&bytes),
-                    ))
-                    .await
-                    .is_err()
-                {
+                let frame = crate::transport_manager::frame_encode(&bytes);
+                if socket.send(Message::Binary(frame)).await.is_err() {
                     break;
                 }
             }

--- a/crates/jazz-tools/src/transport_manager.rs
+++ b/crates/jazz-tools/src/transport_manager.rs
@@ -506,20 +506,19 @@ pub fn create<W: StreamAdapter, T: TickNotifier>(
     (handle, manager)
 }
 
-/// Encode a payload as a 4-byte big-endian length-prefixed frame.
 pub(crate) fn frame_encode(payload: &[u8]) -> Vec<u8> {
+    let compressed = lz4_flex::compress_prepend_size(payload);
     debug_assert!(
-        payload.len() <= u32::MAX as usize,
+        compressed.len() <= u32::MAX as usize,
         "frame payload exceeds u32 limit"
     );
-    let mut out = Vec::with_capacity(4 + payload.len());
-    out.extend_from_slice(&(payload.len() as u32).to_be_bytes());
-    out.extend_from_slice(payload);
+    let mut out = Vec::with_capacity(4 + compressed.len());
+    out.extend_from_slice(&(compressed.len() as u32).to_be_bytes());
+    out.extend_from_slice(&compressed);
     out
 }
 
-/// Decode a 4-byte big-endian length-prefixed frame, returning the payload slice.
-pub(crate) fn frame_decode(data: &[u8]) -> Option<&[u8]> {
+pub(crate) fn frame_decode(data: &[u8]) -> Option<Vec<u8>> {
     if data.len() < 4 {
         return None;
     }
@@ -527,7 +526,7 @@ pub(crate) fn frame_decode(data: &[u8]) -> Option<&[u8]> {
     if data.len() < 4 + len {
         return None;
     }
-    Some(&data[4..4 + len])
+    lz4_flex::decompress_size_prepended(&data[4..4 + len]).ok()
 }
 
 /// Outcome of the auth handshake.
@@ -662,7 +661,7 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
         };
 
         // First try to parse as the success path.
-        if let Ok(resp) = serde_json::from_slice::<ConnectedResponse>(resp_payload) {
+        if let Ok(resp) = serde_json::from_slice::<ConnectedResponse>(&resp_payload) {
             if resp.sync_protocol_version != SYNC_PROTOCOL_VERSION {
                 return HandshakeResult::NetworkError(format!(
                     "incompatible Jazz sync protocol: server sent {}, client requires {}. Please update Jazz.",
@@ -673,10 +672,10 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
         }
 
         // Fall back: check whether the server sent an explicit Error event.
-        let error_event = crate::transport_protocol::ServerEvent::decode_payload(resp_payload)
+        let error_event = crate::transport_protocol::ServerEvent::decode_payload(&resp_payload)
             .ok()
             .or_else(|| {
-                serde_json::from_slice::<crate::transport_protocol::ServerEvent>(resp_payload).ok()
+                serde_json::from_slice::<crate::transport_protocol::ServerEvent>(&resp_payload).ok()
             });
         if let Some(crate::transport_protocol::ServerEvent::Error { message, code }) = error_event {
             if code == crate::transport_protocol::ErrorCode::Unauthorized {
@@ -974,7 +973,7 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
                     match incoming {
                         Ok(Some(data)) => {
                             let Some(payload) = frame_decode(&data) else { continue; };
-                            let Ok(event) = crate::transport_protocol::ServerEvent::decode_payload(payload) else { continue; };
+                            let Ok(event) = crate::transport_protocol::ServerEvent::decode_payload(&payload) else { continue; };
                             self.dispatch_server_event(event);
                         }
                         Ok(None) | Err(_) => return ConnectedExit::NetworkError,
@@ -1162,7 +1161,7 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
                     match incoming {
                         Ok(Some(data)) => {
                             let Some(payload) = frame_decode(&data) else { continue; };
-                            let Ok(event) = crate::transport_protocol::ServerEvent::decode_payload(payload) else { continue; };
+                            let Ok(event) = crate::transport_protocol::ServerEvent::decode_payload(&payload) else { continue; };
                             self.dispatch_server_event(event);
                         }
                         Ok(None) | Err(_) => return WasmConnectedExit::NetworkError,
@@ -1494,7 +1493,7 @@ mod tests {
             .rev()
             .find_map(|f| {
                 let payload = frame_decode(f)?;
-                serde_json::from_slice::<AuthHandshake>(payload).ok()
+                serde_json::from_slice::<AuthHandshake>(payload.as_ref()).ok()
             })
             .expect("at least one AuthHandshake frame sent after update_auth");
         assert_eq!(
@@ -1560,7 +1559,7 @@ mod tests {
             .rev()
             .find_map(|f| {
                 let payload = frame_decode(f)?;
-                serde_json::from_slice::<AuthHandshake>(payload).ok()
+                serde_json::from_slice::<AuthHandshake>(payload.as_ref()).ok()
             })
             .expect("at least one AuthHandshake frame");
         assert_eq!(
@@ -1593,5 +1592,32 @@ mod tests {
             .await
             .expect("dropping the handle should shut down the manager")
             .unwrap();
+    }
+
+    #[test]
+    fn websocket_frames_compress_payload_inside_length_prefix() {
+        let payload = br#"{"type":"SyncUpdateBatch","updates":[{"payload":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]}"#;
+
+        let frame = frame_encode(payload);
+        let compressed_len = u32::from_be_bytes(frame[0..4].try_into().unwrap()) as usize;
+        let decoded = frame_decode(&frame).expect("compressed frame should decode");
+
+        assert_eq!(frame.len(), 4 + compressed_len);
+        assert_ne!(&frame[4..], payload);
+        assert_eq!(decoded.as_slice(), payload);
+        assert!(
+            frame.len() < 4 + payload.len(),
+            "lz4 frame compression should reduce repetitive payload size"
+        );
+    }
+
+    #[test]
+    fn legacy_plain_length_prefixed_frames_are_rejected() {
+        let payload = br#"{"type":"Heartbeat"}"#;
+        let mut frame = Vec::with_capacity(4 + payload.len());
+        frame.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+        frame.extend_from_slice(payload);
+
+        assert!(frame_decode(&frame).is_none());
     }
 }

--- a/crates/jazz-tools/src/transport_protocol.rs
+++ b/crates/jazz-tools/src/transport_protocol.rs
@@ -7,15 +7,15 @@
 //! # Protocol Overview
 //!
 //! - Clients connect to `/ws` and authenticate via an initial `AuthHandshake` frame
-//! - Both directions use the same length-prefixed binary framing
+//! - Both directions send each WebSocket message as a length-prefixed LZ4 frame
 //! - Server → client frames carry [`ServerEvent`] values
 //! - Client → server frames carry [`SyncBatchRequest`] payloads
 //!
 //! # Wire Format
 //!
-//! Handshake frames are length-prefixed JSON so pre-versioned peers can report
-//! readable protocol errors. After both sides confirm `SYNC_PROTOCOL_VERSION`,
-//! sync transport frames are length-prefixed postcard payloads.
+//! Each WebSocket message is `[4 bytes: u32 big-endian compressed length][N bytes:
+//! LZ4-compressed payload]`. Handshake payloads are JSON before compression.
+//! Once both sides confirm `SYNC_PROTOCOL_VERSION`, sync payloads use postcard.
 
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -547,16 +547,15 @@ impl ServerEvent {
         Ok(event)
     }
 
-    /// Test/helper convenience: encode as a length-prefixed post-handshake frame.
+    /// Test/helper convenience: encode as a compressed post-handshake frame.
     pub fn encode_frame(&self) -> Vec<u8> {
         crate::transport_manager::frame_encode(&self.encode_payload().unwrap_or_default())
     }
 
-    /// Test/helper convenience: decode a length-prefixed post-handshake frame.
-    pub fn decode_frame(buf: &[u8]) -> Option<(Self, usize)> {
+    /// Test/helper convenience: decode a compressed post-handshake frame.
+    pub fn decode_frame(buf: &[u8]) -> Option<Self> {
         let payload = crate::transport_manager::frame_decode(buf)?;
-        let event = Self::decode_payload(payload).ok()?;
-        Some((event, 4 + payload.len()))
+        Self::decode_payload(&payload).ok()
     }
 }
 
@@ -654,8 +653,7 @@ mod tests {
         let frame = event.encode_frame();
         assert!(frame.len() > 4);
 
-        let (decoded, consumed) = ServerEvent::decode_frame(&frame).unwrap();
-        assert_eq!(consumed, frame.len());
+        let decoded = ServerEvent::decode_frame(&frame).unwrap();
         match decoded {
             ServerEvent::Connected {
                 catalogue_state_hash,
@@ -672,8 +670,7 @@ mod tests {
         let event = ServerEvent::Heartbeat;
         let frame = event.encode_frame();
 
-        let (decoded, consumed) = ServerEvent::decode_frame(&frame).unwrap();
-        assert_eq!(consumed, frame.len());
+        let decoded = ServerEvent::decode_frame(&frame).unwrap();
         assert!(matches!(decoded, ServerEvent::Heartbeat));
     }
 

--- a/crates/jazz-tools/tests/auth_test.rs
+++ b/crates/jazz-tools/tests/auth_test.rs
@@ -81,16 +81,15 @@ fn encode_session(session: &Session) -> String {
     base64::engine::general_purpose::STANDARD.encode(json.as_bytes())
 }
 
-/// Encode a 4-byte big-endian length-prefixed frame.
 fn frame_encode(payload: &[u8]) -> Vec<u8> {
-    let mut out = Vec::with_capacity(4 + payload.len());
-    out.extend_from_slice(&(payload.len() as u32).to_be_bytes());
-    out.extend_from_slice(payload);
+    let compressed = lz4_flex::compress_prepend_size(payload);
+    let mut out = Vec::with_capacity(4 + compressed.len());
+    out.extend_from_slice(&(compressed.len() as u32).to_be_bytes());
+    out.extend_from_slice(&compressed);
     out
 }
 
-/// Decode a 4-byte big-endian length-prefixed frame.
-fn frame_decode(data: &[u8]) -> Option<&[u8]> {
+fn frame_decode(data: &[u8]) -> Option<Vec<u8>> {
     if data.len() < 4 {
         return None;
     }
@@ -98,7 +97,7 @@ fn frame_decode(data: &[u8]) -> Option<&[u8]> {
     if data.len() < 4 + len {
         return None;
     }
-    Some(&data[4..4 + len])
+    lz4_flex::decompress_size_prepended(&data[4..4 + len]).ok()
 }
 
 type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
@@ -128,10 +127,10 @@ async fn ws_handshake_open(
     match ws.next().await {
         Some(Ok(Message::Binary(bytes))) => {
             let inner = frame_decode(&bytes).ok_or("malformed response frame")?;
-            if let Ok(connected) = serde_json::from_slice::<ConnectedResponse>(inner) {
+            if let Ok(connected) = serde_json::from_slice::<ConnectedResponse>(&inner) {
                 Ok((ws, connected))
             } else {
-                let msg = serde_json::from_slice::<serde_json::Value>(inner)
+                let msg = serde_json::from_slice::<serde_json::Value>(&inner)
                     .ok()
                     .and_then(|v| {
                         v.get("message")
@@ -173,7 +172,7 @@ async fn ws_recv_server_event(
     match message {
         Some(Ok(Message::Binary(bytes))) => {
             let inner = frame_decode(&bytes).ok_or("malformed response frame")?;
-            jazz_tools::transport_protocol::ServerEvent::decode_payload(inner)
+            jazz_tools::transport_protocol::ServerEvent::decode_payload(&inner)
                 .map_err(|e| format!("invalid server event: {e}"))
         }
         Some(Ok(Message::Close(_))) | None => Err("server closed connection".to_string()),

--- a/crates/jazz-tools/tests/integration.rs
+++ b/crates/jazz-tools/tests/integration.rs
@@ -3,7 +3,7 @@
 //! E2E integration tests for jazz-tools server.
 //!
 //! These tests spawn the actual `jazz-tools` binary and interact via HTTP
-//! and WebSocket with binary length-prefixed frames.
+//! and WebSocket with binary transport frames.
 
 use std::io::Read;
 use std::path::PathBuf;
@@ -32,16 +32,15 @@ fn mint_test_token(audience: &str) -> String {
     .unwrap()
 }
 
-/// Encode a 4-byte big-endian length-prefixed frame.
 fn frame_encode(payload: &[u8]) -> Vec<u8> {
-    let mut out = Vec::with_capacity(4 + payload.len());
-    out.extend_from_slice(&(payload.len() as u32).to_be_bytes());
-    out.extend_from_slice(payload);
+    let compressed = lz4_flex::compress_prepend_size(payload);
+    let mut out = Vec::with_capacity(4 + compressed.len());
+    out.extend_from_slice(&(compressed.len() as u32).to_be_bytes());
+    out.extend_from_slice(&compressed);
     out
 }
 
-/// Decode a 4-byte big-endian length-prefixed frame, returning the payload slice.
-fn frame_decode(data: &[u8]) -> Option<&[u8]> {
+fn frame_decode(data: &[u8]) -> Option<Vec<u8>> {
     if data.len() < 4 {
         return None;
     }
@@ -49,7 +48,7 @@ fn frame_decode(data: &[u8]) -> Option<&[u8]> {
     if data.len() < 4 + len {
         return None;
     }
-    Some(&data[4..4 + len])
+    lz4_flex::decompress_size_prepended(&data[4..4 + len]).ok()
 }
 
 /// Perform a WS handshake against `ws://host/apps/<appId>/ws` using a local-first JWT token.
@@ -79,10 +78,10 @@ async fn ws_handshake(port: u16, jwt_token: &str) -> Result<ConnectedResponse, S
     match ws.next().await {
         Some(Ok(Message::Binary(bytes))) => {
             let inner = frame_decode(&bytes).ok_or("malformed response frame")?;
-            if let Ok(connected) = serde_json::from_slice::<ConnectedResponse>(inner) {
+            if let Ok(connected) = serde_json::from_slice::<ConnectedResponse>(&inner) {
                 return Ok(connected);
             }
-            let msg = serde_json::from_slice::<serde_json::Value>(inner)
+            let msg = serde_json::from_slice::<serde_json::Value>(&inner)
                 .ok()
                 .and_then(|v| {
                     v.get("message")

--- a/specs/status-quo/http_transport.md
+++ b/specs/status-quo/http_transport.md
@@ -25,13 +25,12 @@ carrying payloads such as:
 Every WebSocket message uses the same outer frame shape:
 
 ```text
-[4 bytes: u32 big-endian payload length][N bytes: payload]
+[4 bytes: u32 big-endian compressed payload length][N bytes: LZ4-compressed payload]
 ```
 
-The initial auth handshake payload is JSON. That keeps protocol-version and
-auth failures readable for older or mismatched peers. Once both sides confirm
-`SYNC_PROTOCOL_VERSION`, post-handshake sync transport payloads are binary
-postcard payloads:
+The initial auth handshake payload is JSON before compression. Once both sides
+confirm `SYNC_PROTOCOL_VERSION`, post-handshake sync transport payloads are
+binary postcard payloads:
 
 - client-to-server frames carry either a single outbox entry payload or a
   `SyncBatchRequest`


### PR DESCRIPTION
## Summary

- Compresses each WebSocket transport frame payload with LZ4.
- Keeps batching intact: client `SyncBatchRequest` and server `SyncUpdateBatch` messages are compressed after batching.
- Removes the compression config surface; there is no TypeScript option or environment toggle.
- Drops plain length-prefixed frame decoding. This relies on the upcoming sync protocol version bump for compatibility.

## Comparison

Stress run: `dev/stress-tests/todo-react`, comparing server-observed client-to-server sync traffic.

| Option | Frames | Payload bytes | Wire bytes | Wire / payload | Notes | Decision |
| --- | ---: | ---: | ---: | ---: | --- | --- |
| Per-frame LZ4 | 1,413 | 1,382,632 | 958,705 | 0.693 | Compresses the payload inside each length-prefixed frame | Chosen |
| Per-message LZ4 | 906 | 860,744 | 605,051 | 0.703 | Compresses the whole legacy frame with an extra wrapper | Dropped |

Per-frame is slightly smaller in the measured stress run and simpler with a protocol version bump: the frame format itself changes, so we do not need an extra `JZ4M` message wrapper or a plain-frame fallback path.