### PR TITLE
Serve markdown to AI agents from docs routes

### DIFF
--- a/docs/app/(home)/page.tsx
+++ b/docs/app/(home)/page.tsx
@@ -1,6 +1,11 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { PricingCalculator } from "@/components/home/pricing-calculator";
 import { pricingMeters } from "@/lib/home-pricing";
+
+export const metadata: Metadata = {
+  title: "Jazz - The database that syncs.",
+};
 
 const homepageSections = [
   {

--- a/docs/app/llms-full.txt/route.ts
+++ b/docs/app/llms-full.txt/route.ts
@@ -6,5 +6,9 @@ export async function GET() {
   const scan = source.getPages().map(getLLMText);
   const scanned = await Promise.all(scan);
 
-  return new Response(scanned.join("\n\n"));
+  return new Response(scanned.join("\n\n"), {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+    },
+  });
 }

--- a/docs/app/llms.mdx/docs/[[...slug]]/route.ts
+++ b/docs/app/llms.mdx/docs/[[...slug]]/route.ts
@@ -10,7 +10,8 @@ export async function GET(_req: Request, { params }: RouteContext<"/llms.mdx/doc
 
   return new Response(await getLLMText(page), {
     headers: {
-      "Content-Type": "text/markdown",
+      "Content-Type": "text/markdown; charset=utf-8",
+      Vary: "Accept",
     },
   });
 }

--- a/docs/app/llms.txt/route.ts
+++ b/docs/app/llms.txt/route.ts
@@ -9,5 +9,9 @@ export async function GET() {
   for (const page of source.getPages()) {
     lines.push(`- [${page.data.title}](${page.url}): ${page.data.description}`);
   }
-  return new Response(lines.join("\n"));
+  return new Response(lines.join("\n"), {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+    },
+  });
 }

--- a/docs/proxy.ts
+++ b/docs/proxy.ts
@@ -1,0 +1,32 @@
+import { isMarkdownPreferred } from "fumadocs-core/negotiation";
+import { type NextRequest, NextResponse } from "next/server";
+
+function rewriteToMarkdown(request: NextRequest, slugPath: string) {
+  const url = request.nextUrl.clone();
+  url.pathname = `/llms.mdx/docs${slugPath}`;
+  const res = NextResponse.rewrite(url);
+  res.headers.set("Vary", "Accept");
+  return res;
+}
+
+export function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  if (pathname === "/docs.md" || (pathname.startsWith("/docs/") && pathname.endsWith(".md"))) {
+    const slugPath = pathname === "/docs.md" ? "" : pathname.slice("/docs".length, -".md".length);
+    return rewriteToMarkdown(request, slugPath);
+  }
+
+  if (pathname === "/docs" || pathname.startsWith("/docs/")) {
+    if (isMarkdownPreferred(request)) {
+      const slugPath = pathname.slice("/docs".length);
+      return rewriteToMarkdown(request, slugPath);
+    }
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/docs", "/docs.md", "/docs/:path*"],
+};


### PR DESCRIPTION
## Summary
- Add a proxy that rewrites `/docs/*` to the markdown route when the request prefers markdown (via `Accept` header or `.md` suffix), using `fumadocs-core/negotiation`.
- Set `Content-Type: text/markdown; charset=utf-8` and `Vary: Accept` on the `llms.txt`, `llms-full.txt`, and `llms.mdx` routes so UTF-8 content renders correctly.
- Add a homepage `<title>` via Next metadata.

## Test plan
- [ ] `curl -H "Accept: text/markdown" https://<preview>/docs` returns markdown
- [ ] `curl https://<preview>/docs.md` returns markdown
- [ ] `curl https://<preview>/docs` (no Accept) returns HTML as before
- [ ] Homepage tab title reads "Jazz - The database that syncs."