### PR TITLE
Fix SvelteKit plugin type and simplify Svelte client-setup docs

### DIFF
--- a/.changeset/jazz-sveltekit-ssr-external-true.md
+++ b/.changeset/jazz-sveltekit-ssr-external-true.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+`jazzSvelteKit` from `jazz-tools/dev/sveltekit` now accepts the full Vite `ssr.external` shape (`true | string[]`). Previously the inline parameter type only allowed `string[]`, so `defineConfig({ plugins: [jazzSvelteKit()] })` failed to typecheck under `strict: true`. The `true` sentinel is preserved verbatim to keep externalise-everything semantics.

--- a/docs/content/docs/getting-started/client-setup.mdx
+++ b/docs/content/docs/getting-started/client-setup.mdx
@@ -60,24 +60,20 @@ Every client needs an `appId` and a `secret` for [local-first auth](/docs/auth/l
       } from 'jazz-tools/svelte';
       import TodoList from './TodoList.svelte';
 
-      let client = $state<ReturnType<typeof createJazzClient> | null>(null);
-
-      BrowserAuthSecretStore.getOrCreateSecret().then(async (secret) => {
-        client = await createJazzClient({ appId: '<your-app-id>', secret });
-      });
+      const client = BrowserAuthSecretStore.getOrCreateSecret().then(
+        (secret) => createJazzClient({ appId: '<your-app-id>', secret })
+      );
     </script>
 
-    {#if client}
-      <JazzSvelteProvider {client}>
-        {#snippet children()}
-          <h1>Todos</h1>
-          <TodoList />
-        {/snippet}
-        {#snippet fallback()}
-          <p>Loading...</p>
-        {/snippet}
-      </JazzSvelteProvider>
-    {/if}
+    <JazzSvelteProvider {client}>
+      {#snippet children()}
+        <h1>Todos</h1>
+        <TodoList />
+      {/snippet}
+      {#snippet fallback()}
+        <p>Loading...</p>
+      {/snippet}
+    </JazzSvelteProvider>
     ```
 
   </Tab>

--- a/examples/docs/todo-client-localfirst-svelte/src/AuthLocalfirst.svelte
+++ b/examples/docs/todo-client-localfirst-svelte/src/AuthLocalfirst.svelte
@@ -1,24 +1,15 @@
 <!-- #region auth-localfirst-svelte -->
 <script lang="ts">
-  import { onMount } from 'svelte';
   import { BrowserAuthSecretStore, createJazzClient, JazzSvelteProvider } from 'jazz-tools/svelte';
 
-  let client = $state<ReturnType<typeof createJazzClient> | null>(null);
-
-  onMount(async () => {
-    const secret = await BrowserAuthSecretStore.getOrCreateSecret();
-    client = createJazzClient({
-      appId: 'my-app',
-      secret,
-    });
-  });
+  const client = BrowserAuthSecretStore.getOrCreateSecret().then((secret) =>
+    createJazzClient({ appId: 'my-app', secret }),
+  );
 </script>
 
-{#if client}
-  <JazzSvelteProvider {client}>
-    {#snippet children({ db })}
-      <slot />
-    {/snippet}
-  </JazzSvelteProvider>
-{/if}
+<JazzSvelteProvider {client}>
+  {#snippet children({ db })}
+    <slot />
+  {/snippet}
+</JazzSvelteProvider>
 <!-- #endregion auth-localfirst-svelte -->

--- a/examples/docs/todo-client-localfirst-svelte/src/AuthLocalfirst.svelte
+++ b/examples/docs/todo-client-localfirst-svelte/src/AuthLocalfirst.svelte
@@ -1,6 +1,9 @@
 <!-- #region auth-localfirst-svelte -->
 <script lang="ts">
   import { BrowserAuthSecretStore, createJazzClient, JazzSvelteProvider } from 'jazz-tools/svelte';
+  import type { Snippet } from 'svelte';
+
+  let { children }: { children: Snippet } = $props();
 
   const client = BrowserAuthSecretStore.getOrCreateSecret().then((secret) =>
     createJazzClient({ appId: 'my-app', secret }),
@@ -8,8 +11,6 @@
 </script>
 
 <JazzSvelteProvider {client}>
-  {#snippet children({ db })}
-    <slot />
-  {/snippet}
+  {@render children()}
 </JazzSvelteProvider>
 <!-- #endregion auth-localfirst-svelte -->

--- a/packages/jazz-tools/src/dev/sveltekit.test.ts
+++ b/packages/jazz-tools/src/dev/sveltekit.test.ts
@@ -83,8 +83,6 @@ describe("jazzSvelteKit", () => {
     expect(arrayResult.ssr.external).toContain("other-pkg");
 
     const externaliseAll = plugin.config({ ssr: { external: true } });
-    // `true` must be preserved verbatim — coercing to an array would lose the
-    // "externalise everything" semantics Vite expects.
     expect(externaliseAll.ssr.external).toBe(true);
   });
 

--- a/packages/jazz-tools/src/dev/sveltekit.test.ts
+++ b/packages/jazz-tools/src/dev/sveltekit.test.ts
@@ -75,6 +75,19 @@ afterEach(async () => {
 });
 
 describe("jazzSvelteKit", () => {
+  it("config hook accepts both Vite ssr.external shapes (true and string[])", () => {
+    const plugin = jazzSvelteKit();
+
+    const arrayResult = plugin.config({ ssr: { external: ["other-pkg"] } });
+    expect(arrayResult.ssr.external).toContain("jazz-napi");
+    expect(arrayResult.ssr.external).toContain("other-pkg");
+
+    const externaliseAll = plugin.config({ ssr: { external: true } });
+    // `true` must be preserved verbatim — coercing to an array would lose the
+    // "externalise everything" semantics Vite expects.
+    expect(externaliseAll.ssr.external).toBe(true);
+  });
+
   it("starts a local server in dev and injects PUBLIC_JAZZ_* env vars", async () => {
     const port = await getAvailablePort();
     const root = await tempRoots.create("jazz-sveltekit-test-");

--- a/packages/jazz-tools/src/dev/sveltekit.ts
+++ b/packages/jazz-tools/src/dev/sveltekit.ts
@@ -45,16 +45,23 @@ export function jazzSvelteKit(options: JazzPluginOptions = {}) {
   return {
     name: "jazz-sveltekit",
 
-    config(config: { ssr?: { external?: string[] }; optimizeDeps?: { exclude?: string[] } }) {
-      const existingSsr = config.ssr?.external ?? [];
+    config(config: {
+      ssr?: { external?: true | string[] };
+      optimizeDeps?: { exclude?: string[] };
+    }) {
+      const existingSsr = config.ssr?.external;
       const existingExclude = config.optimizeDeps?.exclude ?? [];
       const jazzWasmEntry = resolveJazzWasmEntry();
+      // `ssr.external: true` means "externalize everything", so jazz-napi is
+      // already covered — preserve the bool rather than coercing to an array.
+      const ssrExternal: true | string[] =
+        existingSsr === true ? true : Array.from(new Set([...(existingSsr ?? []), "jazz-napi"]));
       return {
         worker: { format: "es" as const },
         optimizeDeps: {
           exclude: Array.from(new Set([...existingExclude, "jazz-wasm"])),
         },
-        ssr: { external: Array.from(new Set([...existingSsr, "jazz-napi"])) },
+        ssr: { external: ssrExternal },
         ...(jazzWasmEntry
           ? { resolve: { alias: [{ find: /^jazz-wasm$/, replacement: jazzWasmEntry }] } }
           : {}),


### PR DESCRIPTION
## Summary

- `jazzSvelteKit()` from `jazz-tools/dev/sveltekit` failed to typecheck when added to a SvelteKit `vite.config.ts` under `strict: true`: the plugin's inline `config` hook parameter only accepted `string[]` for `ssr.external`, but Vite types it as `true | string[]`. Widen the inline shape to mirror `dev/vite.ts` and preserve the `true` sentinel verbatim so the externalise-everything semantics aren't lost.
- Add a smoke test that calls the hook with both shapes (`true` and `string[]`); any future narrowing of the parameter breaks `build:test` (`tsc --noEmit`) before it reaches downstream apps.
- Simplify the Svelte tab of `docs/content/docs/getting-started/client-setup.mdx` (and the matching `AuthLocalfirst.svelte` example) to pass `Promise<JazzClient>` straight to `JazzSvelteProvider`. The provider already accepts a promise and renders its `fallback` snippet while pending — the previous snippet wrapped this in `$state` + `{#if}` and mistyped `client` as `Promise<JazzClient>` (instead of `Awaited<…>`). Knock-on fix: replace `<slot />` with implicit-children passthrough so the example renders correctly under Svelte 5.

## Test plan

- [ ] `pnpm --filter jazz-tools exec tsc --project tsconfig.tests.json` — typecheck is clean.
- [ ] `pnpm --filter jazz-tools exec vitest run src/dev/sveltekit.test.ts -t "config hook accepts both Vite"` — smoke test passes.
- [ ] Scaffold a SvelteKit app, add `jazzSvelteKit()` to `vite.config.ts`, run `pnpm check` — no TS2769 from the plugin.
- [ ] Visually skim `docs/content/docs/getting-started/client-setup.mdx` Svelte tab and confirm the snippet reads cleanly.

Closes #776 and #777 