### PR TITLE
Bind inspector production deploy to alpha release

### DIFF
--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -1199,3 +1199,164 @@ jobs:
           fi
 
           npm dist-tag add "create-jazz@${CREATE_JAZZ_VERSION}" latest
+
+  deploy-inspector-production:
+    name: Promote inspector production
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs:
+      - release-push-gate
+      - publish-npm
+    if: >-
+      always() &&
+      needs.release-push-gate.outputs.should_run == 'true' &&
+      needs.publish-npm.result == 'success' &&
+      (inputs.mode || github.event.inputs.mode || 'publish') == 'publish'
+    concurrency:
+      group: inspector-production
+      cancel-in-progress: false
+    permissions:
+      contents: read
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_INSPECTOR_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_INSPECTOR_PROJECT_ID }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_INSPECTOR_TOKEN }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.14.0
+          run_install: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: Guard Vercel credentials
+        run: |
+          for name in VERCEL_ORG_ID VERCEL_PROJECT_ID VERCEL_TOKEN; do
+            if [ -z "${!name}" ]; then
+              echo "::error::Missing ${name}. Configure the matching Vercel inspector GitHub secret."
+              exit 1
+            fi
+          done
+
+      - name: Resolve staged inspector deployment
+        id: inspector-deployment
+        env:
+          RELEASE_SHA: ${{ github.sha }}
+        run: |
+          node <<'NODE'
+          const fs = require("node:fs");
+          const setTimeout = require("node:timers/promises").setTimeout;
+
+          async function main() {
+            const required = ["VERCEL_ORG_ID", "VERCEL_PROJECT_ID", "VERCEL_TOKEN", "RELEASE_SHA"];
+            for (const name of required) {
+              if (!process.env[name]) {
+                throw new Error(`Missing required environment variable ${name}.`);
+              }
+            }
+
+            const params = new URLSearchParams({
+              projectId: process.env.VERCEL_PROJECT_ID,
+              target: "production",
+              state: "READY",
+              branch: "main",
+              sha: process.env.RELEASE_SHA,
+              limit: "20",
+              teamId: process.env.VERCEL_ORG_ID,
+            });
+
+            const listUrl = `https://api.vercel.com/v6/deployments?${params}`;
+            const attempts = 30;
+            const delayMs = 20_000;
+
+            async function listDeployments() {
+              const response = await fetch(listUrl, {
+                headers: {
+                  Authorization: `Bearer ${process.env.VERCEL_TOKEN}`,
+                },
+              });
+
+              if (!response.ok) {
+                const body = await response.text();
+                throw new Error(`Vercel deployment lookup failed (${response.status}): ${body}`);
+              }
+
+              const body = await response.json();
+              return Array.isArray(body.deployments) ? body.deployments : [];
+            }
+
+            function describeDeployment(deployment) {
+              return [
+                deployment.url,
+                `state=${deployment.readyState ?? "unknown"}`,
+                `target=${deployment.target ?? "unknown"}`,
+                `substate=${deployment.readySubstate ?? "unknown"}`,
+              ].join(" ");
+            }
+
+            let lastDeployments = [];
+            for (let attempt = 1; attempt <= attempts; attempt += 1) {
+              lastDeployments = await listDeployments();
+              const staged = lastDeployments.find(
+                (deployment) => deployment.url && deployment.readySubstate === "STAGED",
+              );
+              const alreadyPromoted = lastDeployments.find(
+                (deployment) => deployment.url && deployment.readySubstate === "PROMOTED",
+              );
+
+              if (staged || alreadyPromoted) {
+                const deployment = staged ?? alreadyPromoted;
+                const deploymentUrl = `https://${deployment.url}`;
+                const output = [
+                  `deployment_url=${deploymentUrl}`,
+                  `already_promoted=${alreadyPromoted && !staged ? "true" : "false"}`,
+                ].join("\n");
+
+                fs.appendFileSync(process.env.GITHUB_OUTPUT, `${output}\n`);
+                console.log(`Resolved inspector deployment: ${describeDeployment(deployment)}`);
+                return;
+              }
+
+              console.log(
+                `No staged inspector production deployment for ${process.env.RELEASE_SHA} yet (${attempt}/${attempts}).`,
+              );
+
+              if (lastDeployments.length > 0) {
+                console.log("Matching READY production deployments:");
+                for (const deployment of lastDeployments) {
+                  console.log(`- ${describeDeployment(deployment)}`);
+                }
+              }
+
+              if (attempt < attempts) {
+                await setTimeout(delayMs);
+              }
+            }
+
+            throw new Error(
+              [
+                `No staged inspector production deployment found for ${process.env.RELEASE_SHA}.`,
+                "Make sure the inspector Vercel project builds main as production and has auto-assign custom production domains disabled.",
+                lastDeployments.length > 0
+                  ? `Last matching deployments:\n${lastDeployments.map((deployment) => `- ${describeDeployment(deployment)}`).join("\n")}`
+                  : "No matching READY production deployments were returned by Vercel.",
+              ].join("\n"),
+            );
+          }
+
+          main().catch((error) => {
+            console.error(error);
+            process.exit(1);
+          });
+          NODE
+
+      - name: Promote staged inspector deployment
+        if: steps.inspector-deployment.outputs.already_promoted != 'true'
+        run: pnpm dlx vercel@latest promote "${{ steps.inspector-deployment.outputs.deployment_url }}" --yes --timeout=5m --token="${VERCEL_TOKEN}"
+
+      - name: Skip already promoted inspector deployment
+        if: steps.inspector-deployment.outputs.already_promoted == 'true'
+        run: echo "Inspector deployment ${{ steps.inspector-deployment.outputs.deployment_url }} is already promoted."

--- a/packages/inspector/vercel.json
+++ b/packages/inspector/vercel.json
@@ -1,4 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "pnpm build:vercel",
+  "outputDirectory": "dist",
   "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
 }


### PR DESCRIPTION
Change the inspector release flow to promote the staged main relelases into production when we do merge the version PR.

This should align the released version with the version we use in the inspector.