### PR TITLE
Fix loss of reactivity for query subscriptions with deep includes

### DIFF
--- a/.changeset/deep-include-reactivity.md
+++ b/.changeset/deep-include-reactivity.md
@@ -1,0 +1,8 @@
+---
+"jazz-tools": patch
+"jazz-wasm": patch
+"jazz-napi": patch
+"jazz-rn": patch
+---
+
+Fix loss of reactivity for query subscriptions with deeply-nested includes. Subscriptions built from depth-2+ `via` include chains (`org.include({ todoViaOrg: { user_checkViaTodo: true } })`) now correctly receive deltas when a row at the bottom of the chain is inserted, updated, or deleted. Previously only the immediate child table was tracked as a dependency of the outer subscription, so mutations further down the chain were silently missed.

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -609,7 +609,6 @@ jobs:
           REPORT_PATH: bench-out/pr-report.md
         with:
           script: |
-            const core = require("@actions/core");
             const fs = require("fs");
             const marker = "<!-- realistic-bench-report -->";
             const body = `${marker}\n${fs.readFileSync(process.env.REPORT_PATH, "utf8")}`;

--- a/crates/jazz-tools/src/query_manager/graph/compile.rs
+++ b/crates/jazz-tools/src/query_manager/graph/compile.rs
@@ -727,6 +727,16 @@ impl QueryGraph {
                 graph
                     .array_subquery_tables
                     .push((node_id, subquery_spec.table));
+                // Nested arrays live inside this node's inner subgraph, so
+                // their tables won't otherwise appear in the outer graph's
+                // dependency list — register them against this node so a
+                // mutation deep in the chain still drives re-evaluation.
+                let mut nested_stack: Vec<&ArraySubquerySpec> =
+                    subquery_spec.nested_arrays.iter().collect();
+                while let Some(nested) = nested_stack.pop() {
+                    graph.array_subquery_tables.push((node_id, nested.table));
+                    nested_stack.extend(nested.nested_arrays.iter());
+                }
                 phase2_input = node_id;
                 current_descriptor = new_descriptor;
                 current_tuple_descriptor = TupleDescriptor::single_with_materialization(

--- a/crates/jazz-tools/src/query_manager/graph/tests.rs
+++ b/crates/jazz-tools/src/query_manager/graph/tests.rs
@@ -937,6 +937,72 @@ fn compile_relation_ir_with_array_subqueries_adds_array_nodes() {
 }
 
 #[test]
+fn compile_relation_ir_with_nested_array_subqueries_tracks_all_tables() {
+    let mut schema = join_schema();
+    schema.insert(
+        TableName::new("comments"),
+        RowDescriptor::new(vec![
+            ColumnDescriptor::new("id", ColumnType::Integer),
+            ColumnDescriptor::new("text", ColumnType::Text),
+            ColumnDescriptor::new("post_id", ColumnType::Integer),
+        ])
+        .into(),
+    );
+    schema.insert(
+        TableName::new("reactions"),
+        RowDescriptor::new(vec![
+            ColumnDescriptor::new("id", ColumnType::Integer),
+            ColumnDescriptor::new("emoji", ColumnType::Text),
+            ColumnDescriptor::new("comment_id", ColumnType::Integer),
+        ])
+        .into(),
+    );
+    let relation = RelExpr::TableScan {
+        table: TableName::new("users"),
+    };
+    let branches = vec!["main".to_string()];
+
+    let query_with_arrays = QueryBuilder::new("users")
+        .with_array("posts", |posts| {
+            posts
+                .from("posts")
+                .correlate("author_id", "users.id")
+                .with_array("comments", |comments| {
+                    comments
+                        .from("comments")
+                        .correlate("post_id", "posts.id")
+                        .with_array("reactions", |reactions| {
+                            reactions
+                                .from("reactions")
+                                .correlate("comment_id", "comments.id")
+                        })
+                })
+        })
+        .build();
+
+    let graph = QueryGraph::compile_relation_ir_with_features(
+        &relation,
+        &schema,
+        &branches,
+        None,
+        RelationCompileFeatures {
+            include_deleted: false,
+            array_subqueries: query_with_arrays.array_subqueries,
+            select_columns: None,
+        },
+        RowPolicyMode::PermissiveLocal,
+    )
+    .expect("Graph should compile");
+
+    let tracked_tables: Vec<_> = graph
+        .array_subquery_tables
+        .iter()
+        .map(|(_, table)| table.as_str())
+        .collect();
+    assert_eq!(tracked_tables, vec!["posts", "comments", "reactions"]);
+}
+
+#[test]
 fn compile_relation_ir_with_select_columns_adds_project_node() {
     let schema = test_schema();
     let relation = RelExpr::TableScan {

--- a/packages/jazz-tools/tests/browser/realistic-bench.test.ts
+++ b/packages/jazz-tools/tests/browser/realistic-bench.test.ts
@@ -557,7 +557,9 @@ async function seedDataset(db: Db, config: ProfileConfig): Promise<SeedState> {
   const ts = nowMicros();
   for (let i = 0; i < config.users; i += 1) {
     reportLoopProgress("seed users", i, config.users);
-    const { id } = await db.insert(usersTable, {
+    const {
+      value: { id },
+    } = await db.insert(usersTable, {
       display_name: `User ${i}`,
       email: `user${i}@bench.test`,
     });
@@ -566,7 +568,9 @@ async function seedDataset(db: Db, config: ProfileConfig): Promise<SeedState> {
 
   for (let i = 0; i < config.organizations; i += 1) {
     reportLoopProgress("seed organizations", i, config.organizations);
-    const { id } = await db.insert(organizationsTable, {
+    const {
+      value: { id },
+    } = await db.insert(organizationsTable, {
       name: `Org ${i}`,
       created_at: ts + i,
     });
@@ -584,7 +588,9 @@ async function seedDataset(db: Db, config: ProfileConfig): Promise<SeedState> {
 
   for (let i = 0; i < config.projects; i += 1) {
     reportLoopProgress("seed projects", i, config.projects);
-    const { id } = await db.insert(projectsTable, {
+    const {
+      value: { id },
+    } = await db.insert(projectsTable, {
       organization_id: organizations[i % organizations.length],
       name: `Project ${i}`,
       archived: false,
@@ -598,7 +604,9 @@ async function seedDataset(db: Db, config: ProfileConfig): Promise<SeedState> {
     reportLoopProgress("seed tasks", i, config.tasks);
     const projectIdx = i % projects.length;
     const assigneeIdx = i % users.length;
-    const { id } = await db.insert(tasksTable, {
+    const {
+      value: { id },
+    } = await db.insert(tasksTable, {
       project_id: projects[projectIdx],
       title: `Task ${i}`,
       status: statuses[i % statuses.length],
@@ -986,7 +994,9 @@ async function runB1(config: ProfileConfig): Promise<ScenarioResult> {
       const batch = await measureBatchedLatency(insertCount - i, async (batchIndex) => {
         const currentIndex = i + batchIndex;
         const taskIdx = rng.nextInt(state.taskIds.length);
-        const { id } = await db.insert(commentsTable, {
+        const {
+          value: { id },
+        } = await db.insert(commentsTable, {
           task_id: state.taskIds[taskIdx],
           author_id: state.users[rng.nextInt(state.users.length)],
           body: `b1_insert_comment_${currentIndex}`,

--- a/packages/jazz-tools/tests/ts-dsl/deep-include-reactivity.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/deep-include-reactivity.test.ts
@@ -76,12 +76,24 @@ describe("deep-include reactivity", () => {
     );
 
     const initialSnapshotCount = deltas.length;
-    db.insert(app.user_checks, { todo_id: todoId });
+    const {
+      value: { id: userCheckId },
+    } = db.insert(app.user_checks, { todo_id: todoId });
 
     await waitForCondition(
-      () => deltas.length > initialSnapshotCount,
+      () => {
+        if (deltas.length <= initialSnapshotCount) return false;
+        const latest = deltas[deltas.length - 1]!;
+        const todo = latest.all[0] as
+          | undefined
+          | {
+              user_checksViaTodo?: Array<{ id: string }>;
+            };
+        const userChecks = todo?.user_checksViaTodo;
+        return Array.isArray(userChecks) && userChecks.some((check) => check.id === userCheckId);
+      },
       4000,
-      "expected depth-1 subscription to fire on user_checks insert",
+      "expected depth-1 subscription to deliver fresh nested user_checks",
     );
 
     unsubscribe();
@@ -108,12 +120,26 @@ describe("deep-include reactivity", () => {
     );
 
     const initialSnapshotCount = deltas.length;
-    db.insert(app.user_checks, { todo_id: todoId });
+    const {
+      value: { id: userCheckId },
+    } = db.insert(app.user_checks, { todo_id: todoId });
 
     await waitForCondition(
-      () => deltas.length > initialSnapshotCount,
+      () => {
+        if (deltas.length <= initialSnapshotCount) return false;
+        const latest = deltas[deltas.length - 1]!;
+        const org = latest.all[0] as
+          | undefined
+          | {
+              todosViaOrg?: Array<{
+                user_checksViaTodo?: Array<{ id: string }>;
+              }>;
+            };
+        const userChecks = org?.todosViaOrg?.[0]?.user_checksViaTodo;
+        return Array.isArray(userChecks) && userChecks.some((check) => check.id === userCheckId);
+      },
       4000,
-      "expected depth-2 subscription to fire on user_checks insert",
+      "expected depth-2 subscription to deliver fresh nested user_checks",
     );
 
     unsubscribe();

--- a/packages/jazz-tools/tests/ts-dsl/deep-include-reactivity.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/deep-include-reactivity.test.ts
@@ -1,98 +1,29 @@
 import { afterEach, beforeEach, describe, it } from "vitest";
-import { createDb, type Db, type QueryBuilder, type TableProxy } from "../../src/runtime/db.js";
+import { schema as s } from "../../src/index.js";
+import { createDb, type Db } from "../../src/runtime/db.js";
 import type { SubscriptionDelta } from "../../src/runtime/subscription-manager.js";
-import type { WasmSchema } from "../../src/drivers/types.js";
 
-const schema: WasmSchema = {
-  orgs: {
-    columns: [{ name: "name", column_type: { type: "Text" }, nullable: false }],
-  },
-  todos: {
-    columns: [
-      { name: "title", column_type: { type: "Text" }, nullable: false },
-      { name: "org_id", column_type: { type: "Uuid" }, nullable: false, references: "orgs" },
-    ],
-  },
-  user_checks: {
-    columns: [
-      { name: "todo_id", column_type: { type: "Uuid" }, nullable: false, references: "todos" },
-    ],
-  },
-  check_notes: {
-    columns: [
-      { name: "body", column_type: { type: "Text" }, nullable: false },
-      {
-        name: "user_check_id",
-        column_type: { type: "Uuid" },
-        nullable: false,
-        references: "user_checks",
-      },
-    ],
-  },
+const schema = {
+  orgs: s.table({
+    name: s.string(),
+  }),
+  todos: s.table({
+    title: s.string(),
+    org_id: s.ref("orgs"),
+  }),
+  user_checks: s.table({
+    todo_id: s.ref("todos"),
+  }),
+  check_notes: s.table({
+    body: s.string(),
+    user_check_id: s.ref("user_checks"),
+  }),
 };
+type AppSchema = s.Schema<typeof schema>;
+const app: s.App<AppSchema> = s.defineApp(schema);
 
-interface Org {
-  id: string;
-  name: string;
-}
-interface Todo {
-  id: string;
-  title: string;
-  org_id: string;
-}
-interface UserCheck {
-  id: string;
-  todo_id: string;
-}
-interface CheckNote {
-  id: string;
-  body: string;
-  user_check_id: string;
-}
-
-const orgs: TableProxy<Org, Omit<Org, "id">> = {
-  _table: "orgs",
-  _schema: schema,
-  _rowType: {} as Org,
-  _initType: {} as Omit<Org, "id">,
-};
-const todos: TableProxy<Todo, Omit<Todo, "id">> = {
-  _table: "todos",
-  _schema: schema,
-  _rowType: {} as Todo,
-  _initType: {} as Omit<Todo, "id">,
-};
-const userChecks: TableProxy<UserCheck, Omit<UserCheck, "id">> = {
-  _table: "user_checks",
-  _schema: schema,
-  _rowType: {} as UserCheck,
-  _initType: {} as Omit<UserCheck, "id">,
-};
-const checkNotes: TableProxy<CheckNote, Omit<CheckNote, "id">> = {
-  _table: "check_notes",
-  _schema: schema,
-  _rowType: {} as CheckNote,
-  _initType: {} as Omit<CheckNote, "id">,
-};
-
-function makeQuery<T>(
-  table: string,
-  body: { includes?: Record<string, boolean | object> },
-): QueryBuilder<T> {
-  return {
-    _table: table,
-    _schema: schema,
-    _rowType: {} as T,
-    _build() {
-      return JSON.stringify({
-        table,
-        conditions: [],
-        includes: body.includes ?? {},
-        orderBy: [],
-      });
-    },
-  };
-}
+type Org = s.RowOf<typeof app.orgs>;
+type Todo = s.RowOf<typeof app.todos>;
 
 async function waitForCondition(
   check: () => boolean,
@@ -128,15 +59,14 @@ describe("deep-include reactivity", () => {
   it("fires when a depth-1 via dependency is inserted (baseline)", async () => {
     const {
       value: { id: orgId },
-    } = db.insert(orgs, { name: "Acme" });
+    } = db.insert(app.orgs, { name: "Acme" });
     const {
       value: { id: todoId },
-    } = db.insert(todos, { title: "ship it", org_id: orgId });
+    } = db.insert(app.todos, { title: "ship it", org_id: orgId });
 
     const deltas: Array<SubscriptionDelta<Todo>> = [];
-    const unsubscribe = db.subscribeAll(
-      makeQuery<Todo>("todos", { includes: { user_checksViaTodo: true } }),
-      (delta) => deltas.push(delta),
+    const unsubscribe = db.subscribeAll(app.todos.include({ user_checksViaTodo: true }), (delta) =>
+      deltas.push(delta),
     );
 
     await waitForCondition(
@@ -146,7 +76,7 @@ describe("deep-include reactivity", () => {
     );
 
     const initialSnapshotCount = deltas.length;
-    db.insert(userChecks, { todo_id: todoId });
+    db.insert(app.user_checks, { todo_id: todoId });
 
     await waitForCondition(
       () => deltas.length > initialSnapshotCount,
@@ -160,16 +90,14 @@ describe("deep-include reactivity", () => {
   it("fires when a depth-2 via dependency is inserted", async () => {
     const {
       value: { id: orgId },
-    } = db.insert(orgs, { name: "Acme" });
+    } = db.insert(app.orgs, { name: "Acme" });
     const {
       value: { id: todoId },
-    } = db.insert(todos, { title: "ship it", org_id: orgId });
+    } = db.insert(app.todos, { title: "ship it", org_id: orgId });
 
     const deltas: Array<SubscriptionDelta<Org>> = [];
     const unsubscribe = db.subscribeAll(
-      makeQuery<Org>("orgs", {
-        includes: { todosViaOrg: { user_checksViaTodo: true } },
-      }),
+      app.orgs.include({ todosViaOrg: { user_checksViaTodo: true } }),
       (delta) => deltas.push(delta),
     );
 
@@ -180,7 +108,7 @@ describe("deep-include reactivity", () => {
     );
 
     const initialSnapshotCount = deltas.length;
-    db.insert(userChecks, { todo_id: todoId });
+    db.insert(app.user_checks, { todo_id: todoId });
 
     await waitForCondition(
       () => deltas.length > initialSnapshotCount,
@@ -194,20 +122,18 @@ describe("deep-include reactivity", () => {
   it("fires when a depth-3 via dependency is inserted", async () => {
     const {
       value: { id: orgId },
-    } = db.insert(orgs, { name: "Acme" });
+    } = db.insert(app.orgs, { name: "Acme" });
     const {
       value: { id: todoId },
-    } = db.insert(todos, { title: "ship it", org_id: orgId });
+    } = db.insert(app.todos, { title: "ship it", org_id: orgId });
     const {
       value: { id: userCheckId },
-    } = db.insert(userChecks, { todo_id: todoId });
+    } = db.insert(app.user_checks, { todo_id: todoId });
 
     const deltas: Array<SubscriptionDelta<Org>> = [];
     const unsubscribe = db.subscribeAll(
-      makeQuery<Org>("orgs", {
-        includes: {
-          todosViaOrg: { user_checksViaTodo: { check_notesViaUser_check: true } },
-        },
+      app.orgs.include({
+        todosViaOrg: { user_checksViaTodo: { check_notesViaUser_check: true } },
       }),
       (delta) => deltas.push(delta),
     );
@@ -221,7 +147,7 @@ describe("deep-include reactivity", () => {
     const initialSnapshotCount = deltas.length;
     const {
       value: { id: noteId },
-    } = db.insert(checkNotes, { body: "looks good", user_check_id: userCheckId });
+    } = db.insert(app.check_notes, { body: "looks good", user_check_id: userCheckId });
 
     await waitForCondition(
       () => {

--- a/packages/jazz-tools/tests/ts-dsl/deep-include-reactivity.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/deep-include-reactivity.test.ts
@@ -1,0 +1,248 @@
+import { afterEach, beforeEach, describe, it } from "vitest";
+import { createDb, type Db, type QueryBuilder, type TableProxy } from "../../src/runtime/db.js";
+import type { SubscriptionDelta } from "../../src/runtime/subscription-manager.js";
+import type { WasmSchema } from "../../src/drivers/types.js";
+
+const schema: WasmSchema = {
+  orgs: {
+    columns: [{ name: "name", column_type: { type: "Text" }, nullable: false }],
+  },
+  todos: {
+    columns: [
+      { name: "title", column_type: { type: "Text" }, nullable: false },
+      { name: "org_id", column_type: { type: "Uuid" }, nullable: false, references: "orgs" },
+    ],
+  },
+  user_checks: {
+    columns: [
+      { name: "todo_id", column_type: { type: "Uuid" }, nullable: false, references: "todos" },
+    ],
+  },
+  check_notes: {
+    columns: [
+      { name: "body", column_type: { type: "Text" }, nullable: false },
+      {
+        name: "user_check_id",
+        column_type: { type: "Uuid" },
+        nullable: false,
+        references: "user_checks",
+      },
+    ],
+  },
+};
+
+interface Org {
+  id: string;
+  name: string;
+}
+interface Todo {
+  id: string;
+  title: string;
+  org_id: string;
+}
+interface UserCheck {
+  id: string;
+  todo_id: string;
+}
+interface CheckNote {
+  id: string;
+  body: string;
+  user_check_id: string;
+}
+
+const orgs: TableProxy<Org, Omit<Org, "id">> = {
+  _table: "orgs",
+  _schema: schema,
+  _rowType: {} as Org,
+  _initType: {} as Omit<Org, "id">,
+};
+const todos: TableProxy<Todo, Omit<Todo, "id">> = {
+  _table: "todos",
+  _schema: schema,
+  _rowType: {} as Todo,
+  _initType: {} as Omit<Todo, "id">,
+};
+const userChecks: TableProxy<UserCheck, Omit<UserCheck, "id">> = {
+  _table: "user_checks",
+  _schema: schema,
+  _rowType: {} as UserCheck,
+  _initType: {} as Omit<UserCheck, "id">,
+};
+const checkNotes: TableProxy<CheckNote, Omit<CheckNote, "id">> = {
+  _table: "check_notes",
+  _schema: schema,
+  _rowType: {} as CheckNote,
+  _initType: {} as Omit<CheckNote, "id">,
+};
+
+function makeQuery<T>(
+  table: string,
+  body: { includes?: Record<string, boolean | object> },
+): QueryBuilder<T> {
+  return {
+    _table: table,
+    _schema: schema,
+    _rowType: {} as T,
+    _build() {
+      return JSON.stringify({
+        table,
+        conditions: [],
+        includes: body.includes ?? {},
+        orderBy: [],
+      });
+    },
+  };
+}
+
+async function waitForCondition(
+  check: () => boolean,
+  timeoutMs: number,
+  errorMessage: string,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (check()) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(errorMessage);
+}
+
+function uniqueDbName(label: string): string {
+  return `deep-include-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+describe("deep-include reactivity", () => {
+  let db: Db;
+
+  beforeEach(async () => {
+    db = await createDb({
+      appId: "deep-include-reactivity",
+      driver: { type: "persistent", dbName: uniqueDbName("repro") },
+    });
+  });
+
+  afterEach(async () => {
+    await db.shutdown();
+  });
+
+  it("fires when a depth-1 via dependency is inserted (baseline)", async () => {
+    const {
+      value: { id: orgId },
+    } = db.insert(orgs, { name: "Acme" });
+    const {
+      value: { id: todoId },
+    } = db.insert(todos, { title: "ship it", org_id: orgId });
+
+    const deltas: Array<SubscriptionDelta<Todo>> = [];
+    const unsubscribe = db.subscribeAll(
+      makeQuery<Todo>("todos", { includes: { user_checksViaTodo: true } }),
+      (delta) => deltas.push(delta),
+    );
+
+    await waitForCondition(
+      () => deltas.length > 0 && deltas[deltas.length - 1]!.all.length === 1,
+      4000,
+      "expected initial snapshot",
+    );
+
+    const initialSnapshotCount = deltas.length;
+    db.insert(userChecks, { todo_id: todoId });
+
+    await waitForCondition(
+      () => deltas.length > initialSnapshotCount,
+      4000,
+      "expected depth-1 subscription to fire on user_checks insert",
+    );
+
+    unsubscribe();
+  });
+
+  it("fires when a depth-2 via dependency is inserted", async () => {
+    const {
+      value: { id: orgId },
+    } = db.insert(orgs, { name: "Acme" });
+    const {
+      value: { id: todoId },
+    } = db.insert(todos, { title: "ship it", org_id: orgId });
+
+    const deltas: Array<SubscriptionDelta<Org>> = [];
+    const unsubscribe = db.subscribeAll(
+      makeQuery<Org>("orgs", {
+        includes: { todosViaOrg: { user_checksViaTodo: true } },
+      }),
+      (delta) => deltas.push(delta),
+    );
+
+    await waitForCondition(
+      () => deltas.length > 0 && deltas[deltas.length - 1]!.all.length === 1,
+      4000,
+      "expected initial snapshot",
+    );
+
+    const initialSnapshotCount = deltas.length;
+    db.insert(userChecks, { todo_id: todoId });
+
+    await waitForCondition(
+      () => deltas.length > initialSnapshotCount,
+      4000,
+      "expected depth-2 subscription to fire on user_checks insert",
+    );
+
+    unsubscribe();
+  });
+
+  it("fires when a depth-3 via dependency is inserted", async () => {
+    const {
+      value: { id: orgId },
+    } = db.insert(orgs, { name: "Acme" });
+    const {
+      value: { id: todoId },
+    } = db.insert(todos, { title: "ship it", org_id: orgId });
+    const {
+      value: { id: userCheckId },
+    } = db.insert(userChecks, { todo_id: todoId });
+
+    const deltas: Array<SubscriptionDelta<Org>> = [];
+    const unsubscribe = db.subscribeAll(
+      makeQuery<Org>("orgs", {
+        includes: {
+          todosViaOrg: { user_checksViaTodo: { check_notesViaUser_check: true } },
+        },
+      }),
+      (delta) => deltas.push(delta),
+    );
+
+    await waitForCondition(
+      () => deltas.length > 0 && deltas[deltas.length - 1]!.all.length === 1,
+      4000,
+      "expected initial snapshot",
+    );
+
+    const initialSnapshotCount = deltas.length;
+    const {
+      value: { id: noteId },
+    } = db.insert(checkNotes, { body: "looks good", user_check_id: userCheckId });
+
+    await waitForCondition(
+      () => {
+        if (deltas.length <= initialSnapshotCount) return false;
+        const latest = deltas[deltas.length - 1]!;
+        const org = latest.all[0] as
+          | undefined
+          | {
+              todosViaOrg?: Array<{
+                user_checksViaTodo?: Array<{
+                  check_notesViaUser_check?: Array<{ id: string }>;
+                }>;
+              }>;
+            };
+        const notes = org?.todosViaOrg?.[0]?.user_checksViaTodo?.[0]?.check_notesViaUser_check;
+        return Array.isArray(notes) && notes.some((n) => n.id === noteId);
+      },
+      4000,
+      "expected depth-3 subscription to deliver fresh nested check_notes",
+    );
+
+    unsubscribe();
+  });
+});

--- a/specs/TODO.md
+++ b/specs/TODO.md
@@ -63,6 +63,10 @@
 - [**storage-limits-and-eviction**](todo/ideas/1_mvp/storage-limits-and-eviction.md) — Bounded storage with LRU eviction of cold data on clients and edge servers, with lazy re-fetch from upstream.
 - [**sync-protocol-reliability**](todo/ideas/1_mvp/sync-protocol-reliability.md) — Fix critical reliability gaps in the sync path and unify the transport layer across network sync (client-server), worker communication (main thread-worker), and peer replication (server-server).
 
+### Later
+
+- [**dedupe-array-subquery-tables**](todo/ideas/3_later/dedupe-array-subquery-tables.md) — `QueryGraph.array_subquery_tables` is a `Vec<(NodeId, TableName)>` populated by `compile.rs` and consumed by `involves_table` / `mark_dirty_for_table`. The list can carry duplicate `(node_id, table)` pairs — already possible pre-existing, and more likely now that nested array subqueries register their tables against the outer node. Consumers tolerate duplicates (idempotent dirty bits, short-circuit `.iter().any`), so the cost is a few wasted bool writes per mutation. Worth deduping defensively to keep the list small and make consumer code easier to reason about.
+
 ## Projects
 
 - [**ordered-index-topk-query-path**](todo/projects/ordered-index-topk-query-path/)

--- a/specs/todo/ideas/3_later/dedupe-array-subquery-tables.md
+++ b/specs/todo/ideas/3_later/dedupe-array-subquery-tables.md
@@ -1,0 +1,14 @@
+# Dedupe array_subquery_tables entries
+
+## What
+
+`QueryGraph.array_subquery_tables` is a `Vec<(NodeId, TableName)>` populated by `compile.rs` and consumed by `involves_table` / `mark_dirty_for_table`. The list can carry duplicate `(node_id, table)` pairs — already possible pre-existing, and more likely now that nested array subqueries register their tables against the outer node. Consumers tolerate duplicates (idempotent dirty bits, short-circuit `.iter().any`), so the cost is a few wasted bool writes per mutation. Worth deduping defensively to keep the list small and make consumer code easier to reason about.
+
+## Notes
+
+Options:
+
+- Dedupe at registration in `compile.rs` (`.iter().any(...)` check before push — O(N) per push, fine for small N).
+- Dedupe at consumption in `execute.rs` by collecting affected node ids into a `HashSet` before iterating.
+
+Either is a self-contained change with no behaviour shift. Same applies to `policy_filter_tables` / `magic_column_tables` / `recursive_relation_tables` if they have similar shape.


### PR DESCRIPTION
Closes #773.

## Summary
- During graph compilation, walk `nested_arrays` of each top-level `ArraySubquerySpec` and register every nested table against the outer `ArraySubquery` node, so depth-2+ via-include subscriptions get invalidated when deeply-nested rows mutate.
- Add a regression test covering depth-1 (baseline/control), depth-2, and depth-3 cases — the depth-3 assertion checks the materialised payload reflects the newly-inserted row, not just that a delta fires.
- File a follow-up idea (`specs/todo/ideas/3_later/dedupe-array-subquery-tables.md`) to dedupe `array_subquery_tables` entries; safe but wasteful when the same table appears multiple times in a chain.

## Test plan
- [ ] `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts tests/ts-dsl/deep-include-reactivity.test.ts` — 3/3 green
- [ ] `cargo test -p jazz-tools --lib` — full crate suite passes