### PR TITLE
fix: permission magic columns in array subqueries

### DIFF
--- a/.changeset/fix-subquery-permission-magic-columns.md
+++ b/.changeset/fix-subquery-permission-magic-columns.md
@@ -1,0 +1,7 @@
+---
+"jazz-tools": patch
+---
+
+Fix queries with reverse relations that select permission magic columns such as `$canRead`, `$canEdit`, and `$canDelete`.
+
+Included rows now preserve those permission values for reverse, nested, and recursive relation results instead of dropping the subquery table dependency needed to compute them.

--- a/crates/jazz-tools/src/query_manager/graph/compile.rs
+++ b/crates/jazz-tools/src/query_manager/graph/compile.rs
@@ -721,6 +721,8 @@ impl QueryGraph {
                 schema,
                 &branches,
                 schema_context,
+                session.as_ref(),
+                row_policy_mode,
             ) {
                 let node_id = graph.add_node(GraphNode::ArraySubquery(node));
                 graph.add_edge(node_id, phase2_input);
@@ -891,6 +893,8 @@ impl QueryGraph {
                 schema,
                 &branches,
                 schema_context,
+                session.as_ref(),
+                row_policy_mode,
             )
         {
             let node_id = graph.add_node(GraphNode::RecursiveRelation(node));
@@ -989,6 +993,7 @@ impl QueryGraph {
 
     /// Compile an array subquery specification into an ArraySubqueryNode.
     /// Returns the node and the new output descriptor (outer + array column).
+    #[allow(clippy::too_many_arguments)]
     fn compile_array_subquery(
         &self,
         spec: &crate::query_manager::query::ArraySubquerySpec,
@@ -996,6 +1001,8 @@ impl QueryGraph {
         schema: &Schema,
         branches: &[String],
         schema_context: &SchemaContext,
+        session: Option<&Session>,
+        row_policy_mode: RowPolicyMode,
     ) -> Option<(ArraySubqueryNode, RowDescriptor)> {
         // Get inner table descriptor
         let inner_descriptor = schema.get(&spec.table)?.columns.clone();
@@ -1084,6 +1091,8 @@ impl QueryGraph {
             spec.select_columns.clone().unwrap_or_default(),
             inner_output_descriptor,
             schema_context.clone(),
+            session.cloned(),
+            row_policy_mode,
         );
 
         // Create outer tuple descriptor
@@ -1144,6 +1153,7 @@ impl QueryGraph {
     }
 
     /// Compile a recursive relation specification into a RecursiveRelationNode.
+    #[allow(clippy::too_many_arguments)]
     fn compile_recursive_relation(
         &self,
         spec: &crate::query_manager::query::RecursiveSpec,
@@ -1151,6 +1161,8 @@ impl QueryGraph {
         schema: &Schema,
         branches: &[String],
         schema_context: &SchemaContext,
+        session: Option<&Session>,
+        row_policy_mode: RowPolicyMode,
     ) -> Option<(RecursiveRelationNode, RowDescriptor, TableName)> {
         let step_table_schema = schema.get(&spec.table)?;
         let step_table_descriptor = step_table_schema.columns.clone();
@@ -1249,6 +1261,8 @@ impl QueryGraph {
             spec.select_columns.clone().unwrap_or_default(),
             step_output_descriptor,
             schema_context.clone(),
+            session.cloned(),
+            row_policy_mode,
         );
 
         let input_descriptor =
@@ -1413,6 +1427,8 @@ impl QueryGraph {
                 schema,
                 branches,
                 schema_context,
+                session.as_ref(),
+                row_policy_mode,
             )
         {
             let node_id = graph.add_node(GraphNode::RecursiveRelation(node));

--- a/crates/jazz-tools/src/query_manager/graph_nodes/subgraph.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/subgraph.rs
@@ -229,6 +229,8 @@ pub struct SubgraphBuilder {
     filters: Vec<(String, Value)>, // Simple equality filters for now
     order_by: Vec<(String, bool)>, // (column, is_descending)
     limit: Option<usize>,
+    session: Option<Session>,
+    row_policy_mode: RowPolicyMode,
 }
 
 impl SubgraphBuilder {
@@ -241,6 +243,8 @@ impl SubgraphBuilder {
             filters: Vec::new(),
             order_by: Vec::new(),
             limit: None,
+            session: None,
+            row_policy_mode: RowPolicyMode::PermissiveLocal,
         }
     }
 
@@ -277,6 +281,18 @@ impl SubgraphBuilder {
     /// Set a limit on results.
     pub fn limit(mut self, n: usize) -> Self {
         self.limit = Some(n);
+        self
+    }
+
+    /// Set the session used when compiling subgraph instances.
+    pub fn with_session(mut self, session: Session) -> Self {
+        self.session = Some(session);
+        self
+    }
+
+    /// Set the row policy mode used when compiling subgraph instances.
+    pub fn with_row_policy_mode(mut self, row_policy_mode: RowPolicyMode) -> Self {
+        self.row_policy_mode = row_policy_mode;
         self
     }
 
@@ -330,8 +346,8 @@ impl SubgraphBuilder {
             self.select_columns,
             output_descriptor,
             SchemaContext::with_defaults(schema.clone(), "main"),
-            None,
-            RowPolicyMode::PermissiveLocal,
+            self.session,
+            self.row_policy_mode,
         ))
     }
 }
@@ -409,17 +425,39 @@ mod tests {
     }
 
     #[test]
+    fn subgraph_builder_accepts_session_and_row_policy_mode() {
+        let schema = test_schema();
+
+        let template = SubgraphBuilder::new("posts")
+            .correlate("author_id")
+            .with_session(Session::new("alice"))
+            .with_row_policy_mode(RowPolicyMode::Enforcing)
+            .build(&schema)
+            .unwrap();
+
+        assert_eq!(
+            template
+                .session
+                .as_ref()
+                .map(|session| session.user_id.as_str()),
+            Some("alice")
+        );
+        assert_eq!(template.row_policy_mode, RowPolicyMode::Enforcing);
+    }
+
+    #[test]
     fn array_subgraph_inherits_parent_session_for_permission_magic_columns() {
         let schema = SchemaBuilder::new()
             .table(
                 TableSchema::builder("users")
                     .column("user_id", ColumnType::Text)
-                    .column("name", ColumnType::Text)
+                    .column("team_id", ColumnType::Text)
                     .policies(TablePolicies::new().with_select(PolicyExpr::True)),
             )
             .table(
                 TableSchema::builder("documents")
                     .column("owner_id", ColumnType::Text)
+                    .column("team_id", ColumnType::Text)
                     .column("title", ColumnType::Text)
                     .policies(
                         TablePolicies::new()
@@ -438,21 +476,35 @@ mod tests {
         qm.insert(
             &mut storage,
             "users",
-            &[Value::Text("alice".into()), Value::Text("Alice".into())],
+            &[Value::Text("alice".into()), Value::Text("eng".into())],
         )
         .expect("insert user");
         qm.insert(
             &mut storage,
             "documents",
-            &[Value::Text("alice".into()), Value::Text("Draft".into())],
+            &[
+                Value::Text("alice".into()),
+                Value::Text("eng".into()),
+                Value::Text("Alice Draft".into()),
+            ],
         )
-        .expect("insert document");
+        .expect("insert alice document");
+        qm.insert(
+            &mut storage,
+            "documents",
+            &[
+                Value::Text("bob".into()),
+                Value::Text("eng".into()),
+                Value::Text("Bob Plan".into()),
+            ],
+        )
+        .expect("insert bob document");
 
         let query = qm
             .query("users")
             .with_array("documents", |sub| {
                 sub.from("documents")
-                    .correlate("owner_id", "users.user_id")
+                    .correlate("team_id", "users.team_id")
                     .select(&["title", "$canEdit"])
             })
             .build();
@@ -470,10 +522,24 @@ mod tests {
         let values = decode_row(&update.descriptor, &update.delta.added[0].data)
             .expect("decode subscription row");
         let documents = values[2].as_array().expect("documents should be an array");
-        let document = documents[0].as_row().expect("document should be a row");
+        let permissions_by_title: HashMap<String, bool> = documents
+            .iter()
+            .map(|document| {
+                let values = document.as_row().expect("document should be a row");
+                let title = match &values[0] {
+                    Value::Text(title) => title.clone(),
+                    other => panic!("expected document title text, got {other:?}"),
+                };
+                let can_edit = match &values[1] {
+                    Value::Boolean(can_edit) => *can_edit,
+                    other => panic!("expected $canEdit boolean, got {other:?}"),
+                };
+                (title, can_edit)
+            })
+            .collect();
 
-        assert_eq!(document[0], Value::Text("Draft".into()));
-        assert_eq!(document[1], Value::Boolean(true));
+        assert_eq!(permissions_by_title.get("Alice Draft"), Some(&true));
+        assert_eq!(permissions_by_title.get("Bob Plan"), Some(&false));
     }
 
     #[test]

--- a/crates/jazz-tools/src/query_manager/graph_nodes/subgraph.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/subgraph.rs
@@ -6,6 +6,7 @@
 
 use crate::query_manager::graph::QueryGraph;
 use crate::query_manager::query::{Query, QueryBuilder};
+use crate::query_manager::session::Session;
 use crate::query_manager::types::{RowDescriptor, Schema, Value};
 use crate::schema_manager::SchemaContext;
 
@@ -330,11 +331,16 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
+    use crate::query_manager::encoding::decode_row;
     use crate::query_manager::graph::GraphNode;
+    use crate::query_manager::manager::QueryManager;
+    use crate::query_manager::policy::PolicyExpr;
     use crate::query_manager::query::QueryBuilder;
-    use crate::query_manager::types::{ColumnDescriptor, ColumnType, TableName};
+    use crate::query_manager::types::{ColumnDescriptor, ColumnType, TableName, TablePolicies};
     use crate::query_manager::types::{ComposedBranchName, SchemaBuilder, SchemaHash, TableSchema};
     use crate::schema_manager::{Lens, LensOp, LensTransform};
+    use crate::sync_manager::SyncManager;
+    use crate::test_support::seeded_memory_storage;
 
     fn test_schema() -> Schema {
         let mut schema = HashMap::new();
@@ -390,6 +396,74 @@ mod tests {
 
         let instance = instance.unwrap();
         assert_eq!(instance.correlation_value, Value::Integer(42));
+    }
+
+    #[test]
+    fn array_subgraph_inherits_parent_session_for_permission_magic_columns() {
+        let schema = SchemaBuilder::new()
+            .table(
+                TableSchema::builder("users")
+                    .column("user_id", ColumnType::Text)
+                    .column("name", ColumnType::Text)
+                    .policies(TablePolicies::new().with_select(PolicyExpr::True)),
+            )
+            .table(
+                TableSchema::builder("documents")
+                    .column("owner_id", ColumnType::Text)
+                    .column("title", ColumnType::Text)
+                    .policies(
+                        TablePolicies::new()
+                            .with_select(PolicyExpr::True)
+                            .with_update(
+                                Some(PolicyExpr::eq_session("owner_id", vec!["user_id".into()])),
+                                PolicyExpr::True,
+                            ),
+                    ),
+            )
+            .build();
+        let mut qm = QueryManager::new(SyncManager::new());
+        qm.set_current_schema(schema, "dev", "main");
+        let mut storage = seeded_memory_storage(&qm.schema_context().current_schema);
+
+        qm.insert(
+            &mut storage,
+            "users",
+            &[Value::Text("alice".into()), Value::Text("Alice".into())],
+        )
+        .expect("insert user");
+        qm.insert(
+            &mut storage,
+            "documents",
+            &[Value::Text("alice".into()), Value::Text("Draft".into())],
+        )
+        .expect("insert document");
+
+        let query = qm
+            .query("users")
+            .with_array("documents", |sub| {
+                sub.from("documents")
+                    .correlate("owner_id", "users.user_id")
+                    .select(&["title", "$canEdit"])
+            })
+            .build();
+        let sub_id = qm
+            .subscribe_with_session(query, Some(Session::new("alice")), None)
+            .expect("subscribe with session");
+
+        qm.process(&mut storage);
+
+        let update = qm
+            .take_updates()
+            .into_iter()
+            .find(|update| update.subscription_id == sub_id)
+            .expect("subscription should produce initial update");
+        let values = decode_row(&update.descriptor, &update.delta.added[0].data)
+            .expect("decode subscription row");
+        let documents = values[2].as_array().expect("documents should be an array");
+        let document = documents[0].as_row().expect("document should be a row");
+
+        assert_eq!(document[0], Value::Text("Draft".into()));
+        assert_eq!(document[1], Value::Boolean(true));
     }
 
     #[test]

--- a/crates/jazz-tools/src/query_manager/graph_nodes/subgraph.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/subgraph.rs
@@ -7,7 +7,7 @@
 use crate::query_manager::graph::QueryGraph;
 use crate::query_manager::query::{Query, QueryBuilder};
 use crate::query_manager::session::Session;
-use crate::query_manager::types::{RowDescriptor, Schema, Value};
+use crate::query_manager::types::{RowDescriptor, RowPolicyMode, Schema, Value};
 use crate::schema_manager::SchemaContext;
 
 /// Template for creating subgraph instances.
@@ -28,6 +28,10 @@ pub struct SubgraphTemplate {
     output_descriptor: RowDescriptor,
     /// Schema context inherited from the parent graph compile.
     schema_context: SchemaContext,
+    /// Session inherited from the parent graph compile.
+    session: Option<Session>,
+    /// Policy mode inherited from the parent graph compile.
+    row_policy_mode: RowPolicyMode,
 }
 
 impl SubgraphTemplate {
@@ -44,6 +48,8 @@ impl SubgraphTemplate {
         select_columns: Vec<String>,
         output_descriptor: RowDescriptor,
         schema_context: SchemaContext,
+        session: Option<Session>,
+        row_policy_mode: RowPolicyMode,
     ) -> Self {
         Self {
             base_query,
@@ -51,6 +57,8 @@ impl SubgraphTemplate {
             select_columns,
             output_descriptor,
             schema_context,
+            session,
+            row_policy_mode,
         }
     }
 
@@ -162,9 +170,9 @@ impl SubgraphTemplate {
         let graph = QueryGraph::try_compile_with_schema_context(
             &query,
             schema,
-            None,
+            self.session.clone(),
             &self.schema_context,
-            crate::query_manager::types::RowPolicyMode::PermissiveLocal,
+            self.row_policy_mode,
         )
         .ok()?;
 
@@ -322,6 +330,8 @@ impl SubgraphBuilder {
             self.select_columns,
             output_descriptor,
             SchemaContext::with_defaults(schema.clone(), "main"),
+            None,
+            RowPolicyMode::PermissiveLocal,
         ))
     }
 }
@@ -534,6 +544,8 @@ mod tests {
             Vec::new(),
             output_descriptor,
             schema_context,
+            None,
+            RowPolicyMode::PermissiveLocal,
         );
 
         let instance = template

--- a/crates/jazz-tools/src/query_manager/manager_tests/recursive_queries.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests/recursive_queries.rs
@@ -108,6 +108,97 @@ fn recursive_query_with_hop_expands_transitive_closure() {
 }
 
 #[test]
+fn recursive_query_step_magic_columns_inherit_parent_session() {
+    let sync_manager = SyncManager::new();
+    let mut schema = Schema::new();
+    schema.insert(
+        TableName::new("teams"),
+        TableSchema::with_policies(
+            RowDescriptor::new(vec![ColumnDescriptor::new("name", ColumnType::Text)]),
+            TablePolicies::new().with_select(PolicyExpr::True),
+        ),
+    );
+    schema.insert(
+        TableName::new("team_edges"),
+        TableSchema::with_policies(
+            RowDescriptor::new(vec![
+                ColumnDescriptor::new("child_team", ColumnType::Uuid),
+                ColumnDescriptor::new("parent_team", ColumnType::Uuid),
+                ColumnDescriptor::new("owner_id", ColumnType::Text),
+            ]),
+            TablePolicies::new()
+                .with_select(PolicyExpr::True)
+                .with_update(
+                    Some(PolicyExpr::eq_session("owner_id", vec!["user_id".into()])),
+                    PolicyExpr::True,
+                ),
+        ),
+    );
+    let (mut qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    let platform = qm
+        .insert(&mut storage, "teams", &[Value::Text("Platform".into())])
+        .unwrap();
+    let api = qm
+        .insert(&mut storage, "teams", &[Value::Text("API".into())])
+        .unwrap();
+    let finance = qm
+        .insert(&mut storage, "teams", &[Value::Text("Finance".into())])
+        .unwrap();
+
+    qm.insert(
+        &mut storage,
+        "team_edges",
+        &[
+            Value::Uuid(platform.row_id),
+            Value::Uuid(api.row_id),
+            Value::Text("alice".into()),
+        ],
+    )
+    .unwrap();
+    qm.insert(
+        &mut storage,
+        "team_edges",
+        &[
+            Value::Uuid(api.row_id),
+            Value::Uuid(finance.row_id),
+            Value::Text("bob".into()),
+        ],
+    )
+    .unwrap();
+
+    let query = qm
+        .query("teams")
+        .filter_eq("name", Value::Text("Platform".into()))
+        .with_recursive(|r| {
+            r.from("team_edges")
+                .correlate("child_team", "_id")
+                .filter_eq("$canEdit", Value::Boolean(true))
+                .hop("teams", "parent_team")
+                .max_depth(10)
+        })
+        .build();
+    let sub_id = qm
+        .subscribe_with_session(query, Some(PolicySession::new("alice")), None)
+        .unwrap();
+
+    qm.process(&mut storage);
+
+    let mut names: Vec<String> = qm
+        .get_subscription_results(sub_id)
+        .into_iter()
+        .filter_map(|(_, values)| match values.first() {
+            Some(Value::Text(name)) => Some(name.clone()),
+            _ => None,
+        })
+        .collect();
+    names.sort();
+    qm.unsubscribe_with_sync(sub_id);
+
+    assert_eq!(names, vec!["API", "Platform"]);
+}
+
+#[test]
 fn recursive_query_with_self_referential_hop_expands_ancestors() {
     use crate::query_manager::query::Query;
     use crate::query_manager::relation_ir::{

--- a/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
@@ -890,6 +890,114 @@ describe("TS Query API", () => {
       expect(assignee.$updatedAt.getTime()).toBeGreaterThanOrEqual(startedAt - 60_000);
     });
 
+    it("include builders resolve permission magic columns on reverse relations", async () => {
+      const { id: projectId } = insertProject(db, "Announcements");
+      const { id: todoId } = insertTodo(db, {
+        title: "Draft docs",
+        done: false,
+        tags: ["dev"],
+        projectId,
+        assigneesIds: [],
+      });
+      const { id: lockedTodoId } = insertTodo(db, {
+        title: "Shipped docs",
+        done: true,
+        tags: ["docs"],
+        projectId,
+        assigneesIds: [],
+      });
+
+      const result = await db.one(
+        app.projects.where({ id: { eq: projectId } }).include({
+          todosViaProject: app.todos
+            .select("title", "$canRead", "$canEdit", "$canDelete")
+            .orderBy("title", "asc"),
+        }),
+      );
+
+      assert(result, "Result is not defined");
+      expect(result.todosViaProject).toHaveLength(2);
+      const todo = result.todosViaProject[0];
+      assert(todo, "Included todo is not defined");
+      expectTypeOf(todo.$canRead).toEqualTypeOf<boolean | null>();
+      expect(result.todosViaProject).toEqual([
+        {
+          id: todoId,
+          title: "Draft docs",
+          $canRead: true,
+          $canEdit: true,
+          $canDelete: true,
+        },
+        {
+          id: lockedTodoId,
+          title: "Shipped docs",
+          $canRead: true,
+          $canEdit: false,
+          $canDelete: false,
+        },
+      ]);
+    });
+
+    it("include builders resolve permission magic columns on nested array relations", async () => {
+      const alice = insertUser(db, "Alice");
+      const bob = insertUser(db, "Bob");
+      makeFriends(db, alice, bob);
+      const { id: projectId } = insertProject(db, "Announcements");
+      const { id: todoId } = insertTodo(db, {
+        title: "Draft docs",
+        done: false,
+        tags: ["dev"],
+        projectId,
+        ownerId: bob.id,
+        assigneesIds: [],
+      });
+      const { id: lockedTodoId } = insertTodo(db, {
+        title: "Shipped docs",
+        done: true,
+        tags: ["docs"],
+        projectId,
+        ownerId: bob.id,
+        assigneesIds: [],
+      });
+
+      const result = await db.one(
+        app.users.where({ id: { eq: alice.id } }).include({
+          friends: app.users.include({
+            todosViaOwner: app.todos
+              .select("title", "$canRead", "$canEdit", "$canDelete")
+              .orderBy("title", "asc"),
+          }),
+        }),
+      );
+
+      assert(result, "Result is not defined");
+      expect(result.friends).toHaveLength(1);
+      const friend = result.friends[0];
+      assert(friend, "Friend is not defined");
+      expect(friend.id).toBe(bob.id);
+      expect(friend.todosViaOwner).toHaveLength(2);
+      const todo = friend.todosViaOwner[0];
+      assert(todo, "Nested todo is not defined");
+      expectTypeOf(todo.$canRead).toEqualTypeOf<boolean | null>();
+      expectTypeOf(todo.$canEdit).toEqualTypeOf<boolean | null>();
+      expect(friend.todosViaOwner).toEqual([
+        {
+          id: todoId,
+          title: "Draft docs",
+          $canRead: true,
+          $canEdit: true,
+          $canDelete: true,
+        },
+        {
+          id: lockedTodoId,
+          title: "Shipped docs",
+          $canRead: true,
+          $canEdit: false,
+          $canDelete: false,
+        },
+      ]);
+    });
+
     it("subscribeAll preserves projected root columns with includes", async () => {
       const { id: projectId } = insertProject(db, "Announcements");
       const { id: ownerId } = insertUser(db);


### PR DESCRIPTION
Follow-up on #840 

## Summary
- Preserve the parent session and row policy mode when compiling array and recursive subqueries.
- Fix reverse and nested include queries that select permission magic columns like `$canRead`, `$canEdit`, and `$canDelete`.
- Add regression coverage plus a patch changeset for `jazz-tools`.

## Testing
Added coverage:
- Rust regression test for array subgraphs inheriting the parent session when resolving permission magic columns.
- TS Query API regression tests for `$canRead`, `$canEdit`, and `$canDelete` on reverse relation includes and nested array relation includes.

Verified:
- `cargo test -p jazz-tools --lib` passed: 1193 passed, 0 failed.
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts tests/ts-dsl/query-api.test.ts` passed: 39 passed, 0 failed.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
