### PR TITLE
Fix realistic-bench infrastructure

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -609,7 +609,6 @@ jobs:
           REPORT_PATH: bench-out/pr-report.md
         with:
           script: |
-            const core = require("@actions/core");
             const fs = require("fs");
             const marker = "<!-- realistic-bench-report -->";
             const body = `${marker}\n${fs.readFileSync(process.env.REPORT_PATH, "utf8")}`;

--- a/packages/jazz-tools/tests/browser/realistic-bench.test.ts
+++ b/packages/jazz-tools/tests/browser/realistic-bench.test.ts
@@ -557,7 +557,9 @@ async function seedDataset(db: Db, config: ProfileConfig): Promise<SeedState> {
   const ts = nowMicros();
   for (let i = 0; i < config.users; i += 1) {
     reportLoopProgress("seed users", i, config.users);
-    const { id } = await db.insert(usersTable, {
+    const {
+      value: { id },
+    } = await db.insert(usersTable, {
       display_name: `User ${i}`,
       email: `user${i}@bench.test`,
     });
@@ -566,7 +568,9 @@ async function seedDataset(db: Db, config: ProfileConfig): Promise<SeedState> {
 
   for (let i = 0; i < config.organizations; i += 1) {
     reportLoopProgress("seed organizations", i, config.organizations);
-    const { id } = await db.insert(organizationsTable, {
+    const {
+      value: { id },
+    } = await db.insert(organizationsTable, {
       name: `Org ${i}`,
       created_at: ts + i,
     });
@@ -584,7 +588,9 @@ async function seedDataset(db: Db, config: ProfileConfig): Promise<SeedState> {
 
   for (let i = 0; i < config.projects; i += 1) {
     reportLoopProgress("seed projects", i, config.projects);
-    const { id } = await db.insert(projectsTable, {
+    const {
+      value: { id },
+    } = await db.insert(projectsTable, {
       organization_id: organizations[i % organizations.length],
       name: `Project ${i}`,
       archived: false,
@@ -598,7 +604,9 @@ async function seedDataset(db: Db, config: ProfileConfig): Promise<SeedState> {
     reportLoopProgress("seed tasks", i, config.tasks);
     const projectIdx = i % projects.length;
     const assigneeIdx = i % users.length;
-    const { id } = await db.insert(tasksTable, {
+    const {
+      value: { id },
+    } = await db.insert(tasksTable, {
       project_id: projects[projectIdx],
       title: `Task ${i}`,
       status: statuses[i % statuses.length],
@@ -986,7 +994,9 @@ async function runB1(config: ProfileConfig): Promise<ScenarioResult> {
       const batch = await measureBatchedLatency(insertCount - i, async (batchIndex) => {
         const currentIndex = i + batchIndex;
         const taskIdx = rng.nextInt(state.taskIds.length);
-        const { id } = await db.insert(commentsTable, {
+        const {
+          value: { id },
+        } = await db.insert(commentsTable, {
           task_id: state.taskIds[taskIdx],
           author_id: state.users[rng.nextInt(state.users.length)],
           body: `b1_insert_comment_${currentIndex}`,


### PR DESCRIPTION
Two unrelated regressions that together hid the browser benchmark suite from CI:

- **Seed** (`packages/jazz-tools/tests/browser/realistic-bench.test.ts`): since the `*Durable` removal refactor (`84cf43688`), `db.insert` returns a `WriteResult` whose row lives at `result.value`, not on the result itself. Five seed sites destructured `{ id }` directly off the result and got `undefined`, which failed memberships encoding and aborted every browser benchmark at the seed phase.
- **Workflow** (`.github/workflows/benchmarks.yml`): the "Update PR benchmark comment" step ran inline JS through `actions/github-script@v7`, which already exposes `core` as a parameter. Redeclaring `const core = require("@actions/core")` threw `SyntaxError` before the script could read the report, so the PR comment never posted even when the bench succeeded.

## Test plan
- [ ] CI bench job posts a `<!-- realistic-bench-report -->` comment on this PR (proves workflow fix).
- [ ] Browser benchmarks attempt scenarios end-to-end rather than aborting on the seed (proves seed fix).