### PR TITLE
Fix schema hash compatibility for index metadata

### DIFF
--- a/.changeset/schema-hash-index-metadata.md
+++ b/.changeset/schema-hash-index-metadata.md
@@ -1,0 +1,8 @@
+---
+"jazz-tools": patch
+"jazz-napi": patch
+"jazz-wasm": patch
+"jazz-rn": patch
+---
+
+Keep schema hashes stable when table index metadata changes, so newer runtimes can read databases created before selective index metadata existed.

--- a/crates/jazz-tools/src/query_manager/types/branch.rs
+++ b/crates/jazz-tools/src/query_manager/types/branch.rs
@@ -89,20 +89,6 @@ impl SchemaHash {
 
             // Hash row descriptor in declared column order
             hash_row_descriptor(&mut hasher, &table_schema.columns);
-
-            // Hash the optional index override. Absence means historical
-            // "index every declared user column"; an explicit subset changes
-            // query-planning/index-maintenance semantics and therefore belongs
-            // to the schema identity.
-            hasher.update(&[1]);
-            if let Some(indexed_columns) = &table_schema.indexed_columns {
-                let mut columns: Vec<_> = indexed_columns.iter().map(|c| c.as_str()).collect();
-                columns.sort_unstable();
-                for column in columns {
-                    hasher.update(column.as_bytes());
-                    hasher.update(&[0]);
-                }
-            }
         }
 
         Self(*hasher.finalize().as_bytes())

--- a/crates/jazz-tools/src/query_manager/types/tests.rs
+++ b/crates/jazz-tools/src/query_manager/types/tests.rs
@@ -651,6 +651,48 @@ fn schema_hash_ignores_policies() {
 }
 
 #[test]
+fn schema_hash_preserves_existing_todo_schema_identity() {
+    let schema = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("todos")
+                .column("title", ColumnType::Text)
+                .column("done", ColumnType::Boolean),
+        )
+        .build();
+
+    assert_eq!(
+        SchemaHash::compute(&schema).to_string(),
+        "bfd77d25b0696da75df2ca82ab129c6289432decaaad8b86adcb31a366bdd217",
+    );
+}
+
+#[test]
+fn schema_hash_ignores_index_metadata() {
+    let schema_with_default_indexes = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("todos")
+                .column("title", ColumnType::Text)
+                .column("done", ColumnType::Boolean),
+        )
+        .build();
+
+    let schema_with_selective_indexes = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("todos")
+                .column("title", ColumnType::Text)
+                .column("done", ColumnType::Boolean)
+                .index_only(["done"]),
+        )
+        .build();
+
+    assert_eq!(
+        SchemaHash::compute(&schema_with_default_indexes),
+        SchemaHash::compute(&schema_with_selective_indexes),
+        "Index metadata should not affect row storage identity",
+    );
+}
+
+#[test]
 fn schema_hash_changes_when_column_default_changes() {
     let schema1 = SchemaBuilder::new()
         .table(TableSchema::builder("users").column("role", ColumnType::Text))


### PR DESCRIPTION
## What

Keep table index metadata out of `SchemaHash::compute` so schema hashes stay stable for existing row layouts.

## Why

Selective index metadata changed the hash for schemas that otherwise had the same table and column layout. Since row storage uses the schema hash in branch/table names, newer runtimes could look in a different place and miss rows written by older runtimes.

## Validation

- `cargo test -p jazz-tools schema_hash_`
- pre-commit hook: clippy, oxfmt, rustfmt