### PR TITLE
Add alpha.46 NAPI SQLite compatibility tests

### DIFF
--- a/crates/jazz-tools/src/query_manager/types/tests.rs
+++ b/crates/jazz-tools/src/query_manager/types/tests.rs
@@ -692,6 +692,32 @@ fn schema_hash_changes_when_indexed_columns_override_changes() {
 }
 
 #[test]
+fn schema_hash_distinguishes_explicit_empty_index_override() {
+    let schema_without_override = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("todos")
+                .column("title", ColumnType::Text)
+                .column("done", ColumnType::Boolean),
+        )
+        .build();
+
+    let schema_with_empty_override = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("todos")
+                .column("title", ColumnType::Text)
+                .column("done", ColumnType::Boolean)
+                .index_only(std::iter::empty::<&str>()),
+        )
+        .build();
+
+    assert_ne!(
+        SchemaHash::compute(&schema_without_override),
+        SchemaHash::compute(&schema_with_empty_override),
+        "an explicit empty index override changes indexing semantics",
+    );
+}
+
+#[test]
 fn schema_hash_changes_when_column_default_changes() {
     let schema1 = SchemaBuilder::new()
         .table(TableSchema::builder("users").column("role", ColumnType::Text))

--- a/packages/jazz-tools/src/runtime/napi.sqlite-compat.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.sqlite-compat.test.ts
@@ -10,6 +10,15 @@ import { loadNapiModule } from "./testing/napi-runtime-test-utils.js";
 const ALPHA46_TODOS_FIXTURE = fileURLToPath(
   new URL("./fixtures/alpha46-todos.sqlite", import.meta.url),
 );
+const ALPHA46_TODOS_SCHEMA_HASH =
+  "bfd77d25b0696da75df2ca82ab129c6289432decaaad8b86adcb31a366bdd217";
+const ALPHA46_TODO_ROW = {
+  id: "00000000-0000-4000-8000-000000000046",
+  values: [
+    { type: "Text", value: "alpha.46 sqlite fixture" },
+    { type: "Boolean", value: false },
+  ],
+};
 
 const ALPHA46_TODOS_SCHEMA: WasmSchema = {
   todos: {
@@ -20,42 +29,61 @@ const ALPHA46_TODOS_SCHEMA: WasmSchema = {
   },
 };
 
+type CurrentNapiRuntime = {
+  getSchemaHash(): string;
+  query(queryJson: string): Promise<Array<{ id: string; values: unknown[] }>>;
+  close(): void;
+};
+
+async function openCurrentRuntimeWithAlpha46Db(): Promise<{
+  runtime: CurrentNapiRuntime;
+  cleanup: () => Promise<void>;
+}> {
+  const { NapiRuntime } = await loadNapiModule();
+  const dataRoot = await mkdtemp(join(tmpdir(), "jazz-alpha46-sqlite-"));
+  const dataPath = join(dataRoot, "runtime.sqlite");
+
+  await copyFile(ALPHA46_TODOS_FIXTURE, dataPath);
+
+  const runtime = new NapiRuntime(
+    serializeRuntimeSchema(ALPHA46_TODOS_SCHEMA),
+    "00000000-0000-0000-0000-000000000046",
+    "prod",
+    "main",
+    dataPath,
+  ) as unknown as CurrentNapiRuntime;
+
+  return {
+    runtime,
+    cleanup: async () => {
+      runtime.close();
+      await rm(dataRoot, { recursive: true, force: true });
+    },
+  };
+}
+
 describe("NAPI SQLite compatibility", () => {
-  it("reads rows from a SQLite database written by alpha.46", async () => {
-    const { NapiRuntime } = await loadNapiModule();
-    const dataRoot = await mkdtemp(join(tmpdir(), "jazz-alpha46-sqlite-"));
-    const dataPath = join(dataRoot, "runtime.sqlite");
+  it("uses the alpha.46 schema hash when the current runtime opens the fixture", async () => {
+    const { runtime, cleanup } = await openCurrentRuntimeWithAlpha46Db();
 
-    await copyFile(ALPHA46_TODOS_FIXTURE, dataPath);
+    try {
+      expect(runtime.getSchemaHash()).toBe(ALPHA46_TODOS_SCHEMA_HASH);
+    } finally {
+      await cleanup();
+    }
+  });
 
-    const runtime = new NapiRuntime(
-      serializeRuntimeSchema(ALPHA46_TODOS_SCHEMA),
-      "00000000-0000-0000-0000-000000000046",
-      "prod",
-      "main",
-      dataPath,
-    ) as unknown as {
-      query(queryJson: string): Promise<Array<{ id: string; values: unknown[] }>>;
-      close(): void;
-    };
+  it("reads row data when the current runtime opens a SQLite database written by alpha.46", async () => {
+    const { runtime, cleanup } = await openCurrentRuntimeWithAlpha46Db();
 
     try {
       const rows = await runtime.query(
         JSON.stringify({ table: "todos", relation_ir: { TableScan: { table: "todos" } } }),
       );
 
-      expect(rows).toEqual([
-        {
-          id: "00000000-0000-4000-8000-000000000046",
-          values: [
-            { type: "Text", value: "alpha.46 sqlite fixture" },
-            { type: "Boolean", value: false },
-          ],
-        },
-      ]);
+      expect(rows).toEqual([ALPHA46_TODO_ROW]);
     } finally {
-      runtime.close();
-      await rm(dataRoot, { recursive: true, force: true });
+      await cleanup();
     }
   });
 });


### PR DESCRIPTION
## What changed

- Added a schema hash regression test for explicit empty index overrides.
- Split the NAPI SQLite alpha.46 fixture coverage into explicit schema-hash and row-data checks.
- Renamed the fixture helper to make the intent clear: it opens the current NAPI runtime with an alpha.46 SQLite database.

## Verification

- `cargo test -p jazz-tools schema_hash_ --lib`
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/runtime/napi.sqlite-compat.test.ts`