### PR TITLE
ci: prepend rustup proxies to PATH on macOS jobs

### DIFF
--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -467,6 +467,9 @@ jobs:
           toolchain: 1.93.1
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
+      - name: Prepend rustup proxies to PATH
+        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -591,6 +594,9 @@ jobs:
           toolchain: 1.93.1
           targets: ${{ matrix.target }}
 
+      - name: Prepend rustup proxies to PATH
+        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -662,6 +668,9 @@ jobs:
         with:
           toolchain: 1.93.1
           targets: aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios
+
+      - name: Prepend rustup proxies to PATH
+        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/rn-build-reusable.yml
+++ b/.github/workflows/rn-build-reusable.yml
@@ -111,6 +111,9 @@ jobs:
             aarch64-apple-ios-sim
             x86_64-apple-ios
 
+      - name: Prepend rustup proxies to PATH
+        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
       - name: Build iOS artifacts
         run: pnpm --filter ${{ env.PACKAGE_NAME }} run build:rn:ios
 


### PR DESCRIPTION
## Summary

The `macos-14-arm64` runner image `20260512.0058` (rolled out 2026-05-13/14) ships a broken preinstalled `cargo` shim that executes as `rustup-init`. Any `cargo <subcmd>` call on an affected runner dies with:

```
error: unexpected argument '<subcmd>' found
Usage: rustup-init[EXE] [OPTIONS]
```

This breaks every macOS Rust step in the alpha release pipeline (`build-macos`, `build-napi` matrix entries, `build-rn-ios`, and the reusable RN iOS build). It appears flaky because the runner pool is mid-rollout — old-image runners (`20260427.0019`) still pass — but every failure I've seen is 100% correlated with the new image. See run [25852151391](https://github.com/garden-co/jazz/actions/runs/25852151391) for the smoking gun: napi `darwin-arm64` and CLI `darwin-x64` (both on the new image) fail; napi `darwin-x64` and CLI `darwin-arm64` (both on the old image) pass.

`dtolnay/rust-toolchain@stable` only appends `$CARGO_HOME/bin` to `GITHUB_PATH` when it has to install rustup itself. Because the runner ships with rustup preinstalled (`info: self-update is disabled for this build of rustup`), that branch is skipped — `rustup default 1.93.1` succeeds and installs working proxies in `~/.cargo/bin/`, but the broken system `cargo` earlier on PATH still wins the shell lookup.

The fix is an explicit `echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"` step right after each `dtolnay/rust-toolchain@stable` block in macOS jobs. It's a one-liner per job and is a safe no-op on the existing fully-broken vs. partially-broken images alike, since rustup proxies are the correct binaries to call.

Patched jobs:
- `publish-jazz-tools-alpha.yml`: `build-macos`, `build-napi` (matrix), `build-rn-ios`
- `rn-build-reusable.yml`: `build-ios`

Linux jobs are unaffected (they run on Blacksmith runners and `dtolnay/rust-toolchain` already adds the path there, since rustup isn't preinstalled).

## Test plan
- [ ] Re-run the failing preview alpha release; macOS jobs that draw a new-image runner should now succeed
- [ ] Confirm Linux napi job still passes (no regression from shared dtolnay step in matrix)