### PR TITLE
Pin actions and harden CI caches

### DIFF
--- a/.github/actions/source-code/action.yml
+++ b/.github/actions/source-code/action.yml
@@ -19,11 +19,18 @@ runs:
         corepack enable
         pnpm --version
 
+    - name: Write cache scope
+      shell: bash
+      run: echo "${{ github.event.pull_request.head.repo.id || github.repository_id }}" > .github-cache-scope
+
     - name: Install Node.js
       uses: useblacksmith/setup-node@65c6ca86fdeb0ab3d85e78f57e4f6a7e4780b391
       with:
         node-version-file: ".nvmrc"
         cache: ${{ inputs.cache == 'true' && 'pnpm' || '' }}
+        cache-dependency-path: |
+          pnpm-lock.yaml
+          .github-cache-scope
 
     - name: Get pnpm store directory
       if: inputs.cache == 'true'
@@ -36,9 +43,9 @@ runs:
       name: Setup pnpm cache
       with:
         path: ${{ env.STORE_PATH }}
-        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        key: ${{ github.event.pull_request.head.repo.id || github.repository_id }}-${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
-          ${{ runner.os }}-pnpm-store-
+          ${{ github.event.pull_request.head.repo.id || github.repository_id }}-${{ runner.os }}-pnpm-store-
 
     - name: Install dependencies
       shell: bash

--- a/.github/actions/source-code/action.yml
+++ b/.github/actions/source-code/action.yml
@@ -20,7 +20,7 @@ runs:
         pnpm --version
 
     - name: Install Node.js
-      uses: useblacksmith/setup-node@v5
+      uses: useblacksmith/setup-node@65c6ca86fdeb0ab3d85e78f57e4f6a7e4780b391
       with:
         node-version-file: ".nvmrc"
         cache: ${{ inputs.cache == 'true' && 'pnpm' || '' }}
@@ -31,7 +31,7 @@ runs:
       run: |
         echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
-    - uses: useblacksmith/cache@v5
+    - uses: useblacksmith/cache@71c7c918062ba3861252d84b07fe5ab2a6b467a6
       if: inputs.cache == 'true'
       name: Setup pnpm cache
       with:

--- a/.github/actions/source-code/action.yml
+++ b/.github/actions/source-code/action.yml
@@ -24,7 +24,7 @@ runs:
       run: echo "${{ github.event.pull_request.head.repo.id || github.repository_id }}" > .github-cache-scope
 
     - name: Install Node.js
-      uses: useblacksmith/setup-node@65c6ca86fdeb0ab3d85e78f57e4f6a7e4780b391
+      uses: useblacksmith/setup-node@65c6ca86fdeb0ab3d85e78f57e4f6a7e4780b391 # v5
       with:
         node-version-file: ".nvmrc"
         cache: ${{ inputs.cache == 'true' && 'pnpm' || '' }}
@@ -38,7 +38,7 @@ runs:
       run: |
         echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
-    - uses: useblacksmith/cache@71c7c918062ba3861252d84b07fe5ab2a6b467a6
+    - uses: useblacksmith/cache@71c7c918062ba3861252d84b07fe5ab2a6b467a6 # v5
       if: inputs.cache == 'true'
       name: Setup pnpm cache
       with:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -57,16 +57,16 @@ jobs:
     timeout-minutes: 180
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: 1.93.1
 
       - name: Prepare libclang for bindgen
         run: bash dev/benchmarks/realistic/prepare_libclang_env.sh
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .nvmrc
 
@@ -198,7 +198,7 @@ jobs:
           done
 
       - name: Upload native artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: realistic-native-${{ github.run_id }}-${{ github.run_attempt }}
           path: bench-out/native
@@ -225,9 +225,9 @@ jobs:
     timeout-minutes: 180
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: 1.93.1
           targets: wasm32-unknown-unknown
@@ -235,14 +235,14 @@ jobs:
       - name: Prepare libclang for bindgen
         run: bash dev/benchmarks/realistic/prepare_libclang_env.sh
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .nvmrc
 
       - run: corepack enable
       - run: pnpm install --frozen-lockfile
       - name: Set up CMake
-        uses: jwlawson/actions-setup-cmake@v2
+        uses: jwlawson/actions-setup-cmake@0d6a7d60b009d01c9e7523be22153ff8f19460d3
         with:
           cmake-version: "3.31.x"
       - run: pnpm --filter jazz-napi build
@@ -350,7 +350,7 @@ jobs:
             }' > bench-out/browser/manifest.json
 
       - name: Upload browser artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: realistic-browser-${{ github.run_id }}-${{ github.run_attempt }}
           path: bench-out/browser
@@ -373,23 +373,23 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .nvmrc
 
       - name: Download native artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
         with:
           name: realistic-native-${{ github.run_id }}-${{ github.run_attempt }}
           path: site-input/native
 
       - name: Download browser artifacts
         if: ${{ needs.browser.result == 'success' }}
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
         with:
           name: realistic-browser-${{ github.run_id }}-${{ github.run_attempt }}
           path: site-input/browser
@@ -601,7 +601,7 @@ jobs:
           cat bench-out/pr-report.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload site artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: realistic-site-${{ github.run_id }}-${{ github.run_attempt }}
           path: dev/benchmarks/realistic/site
@@ -610,7 +610,7 @@ jobs:
       - name: Update PR benchmark comment
         if: ${{ github.event_name == 'pull_request' }}
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         env:
           REPORT_PATH: bench-out/pr-report.md
         with:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -57,16 +57,16 @@ jobs:
     timeout-minutes: 180
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: 1.93.1
 
       - name: Prepare libclang for bindgen
         run: bash dev/benchmarks/realistic/prepare_libclang_env.sh
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: .nvmrc
 
@@ -198,7 +198,7 @@ jobs:
           done
 
       - name: Upload native artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: realistic-native-${{ github.run_id }}-${{ github.run_attempt }}
           path: bench-out/native
@@ -225,9 +225,9 @@ jobs:
     timeout-minutes: 180
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: 1.93.1
           targets: wasm32-unknown-unknown
@@ -235,14 +235,14 @@ jobs:
       - name: Prepare libclang for bindgen
         run: bash dev/benchmarks/realistic/prepare_libclang_env.sh
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: .nvmrc
 
       - run: corepack enable
       - run: pnpm install --frozen-lockfile
       - name: Set up CMake
-        uses: jwlawson/actions-setup-cmake@0d6a7d60b009d01c9e7523be22153ff8f19460d3
+        uses: jwlawson/actions-setup-cmake@0d6a7d60b009d01c9e7523be22153ff8f19460d3 # v2
         with:
           cmake-version: "3.31.x"
       - run: pnpm --filter jazz-napi build
@@ -350,7 +350,7 @@ jobs:
             }' > bench-out/browser/manifest.json
 
       - name: Upload browser artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: realistic-browser-${{ github.run_id }}-${{ github.run_attempt }}
           path: bench-out/browser
@@ -373,23 +373,23 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: .nvmrc
 
       - name: Download native artifacts
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
           name: realistic-native-${{ github.run_id }}-${{ github.run_attempt }}
           path: site-input/native
 
       - name: Download browser artifacts
         if: ${{ needs.browser.result == 'success' }}
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
           name: realistic-browser-${{ github.run_id }}-${{ github.run_attempt }}
           path: site-input/browser
@@ -601,7 +601,7 @@ jobs:
           cat bench-out/pr-report.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload site artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: realistic-site-${{ github.run_id }}-${{ github.run_attempt }}
           path: dev/benchmarks/realistic/site
@@ -610,7 +610,7 @@ jobs:
       - name: Update PR benchmark comment
         if: ${{ github.event_name == 'pull_request' }}
         continue-on-error: true
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           REPORT_PATH: bench-out/pr-report.md
         with:

--- a/.github/workflows/changesets-release-pr.yml
+++ b/.github/workflows/changesets-release-pr.yml
@@ -19,11 +19,11 @@ jobs:
   release-pr:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .nvmrc
 
@@ -37,7 +37,7 @@ jobs:
 
       - name: Create or update release PR
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b
         with:
           version: pnpm release:version
           title: "Version Packages (alpha)"

--- a/.github/workflows/changesets-release-pr.yml
+++ b/.github/workflows/changesets-release-pr.yml
@@ -19,11 +19,11 @@ jobs:
   release-pr:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: .nvmrc
 
@@ -37,7 +37,7 @@ jobs:
 
       - name: Create or update release PR
         id: changesets
-        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1
         with:
           version: pnpm release:version
           title: "Version Packages (alpha)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,15 +24,15 @@ jobs:
       SCCACHE_CACHE_SIZE: 8G
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: 1.93.1
           targets: wasm32-unknown-unknown
           components: clippy, rustfmt
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .nvmrc
 
@@ -42,17 +42,17 @@ jobs:
       - name: Install Rust prerequisites
         run: pnpm run ensure:rust-toolchain
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-on-failure: true
           prefix-key: rocksdb-v1
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
         with:
           tool: sccache
 
       - name: Mount sccache sticky disk
-        uses: useblacksmith/stickydisk@v1
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88
         with:
           key: sccache-${{ github.repository_id }}-${{ runner.os }}-v1
           path: /home/runner/.cache/sccache
@@ -71,15 +71,15 @@ jobs:
       SCCACHE_CACHE_SIZE: 8G
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: 1.93.1
           targets: wasm32-unknown-unknown
           components: clippy, rustfmt
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .nvmrc
 
@@ -89,17 +89,17 @@ jobs:
       - name: Install Rust prerequisites
         run: pnpm run ensure:rust-toolchain
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-on-failure: true
           prefix-key: rocksdb-v1
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
         with:
           tool: sccache
 
       - name: Mount sccache sticky disk
-        uses: useblacksmith/stickydisk@v1
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88
         with:
           key: sccache-${{ github.repository_id }}-${{ runner.os }}-v1
           path: /home/runner/.cache/sccache
@@ -117,15 +117,15 @@ jobs:
       SCCACHE_CACHE_SIZE: 8G
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: 1.93.1
           targets: wasm32-unknown-unknown
           components: clippy, rustfmt
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .nvmrc
 
@@ -135,30 +135,30 @@ jobs:
       - name: Install Rust prerequisites
         run: pnpm run ensure:rust-toolchain
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-on-failure: true
           prefix-key: rocksdb-v1
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
         with:
           tool: sccache
 
       - name: Mount sccache sticky disk
-        uses: useblacksmith/stickydisk@v1
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88
         with:
           key: sccache-${{ github.repository_id }}-${{ runner.os }}-v1
           path: /home/runner/.cache/sccache
 
       - name: Mount Turbo sticky disk
-        uses: useblacksmith/stickydisk@v1
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88
         with:
           key: turbo-cache-${{ github.repository_id }}-${{ runner.os }}-v1
           path: ${{ github.workspace }}/.turbo/cache
 
       - run: pnpm build:ci
       - name: Mount Playwright sticky disk
-        uses: useblacksmith/stickydisk@v1
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88
         with:
           key: playwright-browsers-${{ github.repository_id }}-${{ runner.os }}-v1
           path: /home/runner/.cache/ms-playwright

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
   cancel-in-progress: true
 
+env:
+  CACHE_SCOPE_REPOSITORY_ID: ${{ github.event.pull_request.head.repo.id || github.repository_id }}
+
 jobs:
   lint:
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -46,6 +49,7 @@ jobs:
         with:
           cache-on-failure: true
           prefix-key: rocksdb-v1
+          key: repo-${{ env.CACHE_SCOPE_REPOSITORY_ID }}
 
       - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
         with:
@@ -54,7 +58,7 @@ jobs:
       - name: Mount sccache sticky disk
         uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88
         with:
-          key: sccache-${{ github.repository_id }}-${{ runner.os }}-v1
+          key: sccache-${{ env.CACHE_SCOPE_REPOSITORY_ID }}-${{ runner.os }}-v1
           path: /home/runner/.cache/sccache
 
       - run: pnpm format:check
@@ -93,6 +97,7 @@ jobs:
         with:
           cache-on-failure: true
           prefix-key: rocksdb-v1
+          key: repo-${{ env.CACHE_SCOPE_REPOSITORY_ID }}
 
       - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
         with:
@@ -101,7 +106,7 @@ jobs:
       - name: Mount sccache sticky disk
         uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88
         with:
-          key: sccache-${{ github.repository_id }}-${{ runner.os }}-v1
+          key: sccache-${{ env.CACHE_SCOPE_REPOSITORY_ID }}-${{ runner.os }}-v1
           path: /home/runner/.cache/sccache
 
       - run: cargo test --workspace --lib --bins --tests --exclude jazz-rn --features test
@@ -139,6 +144,7 @@ jobs:
         with:
           cache-on-failure: true
           prefix-key: rocksdb-v1
+          key: repo-${{ env.CACHE_SCOPE_REPOSITORY_ID }}
 
       - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
         with:
@@ -147,20 +153,20 @@ jobs:
       - name: Mount sccache sticky disk
         uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88
         with:
-          key: sccache-${{ github.repository_id }}-${{ runner.os }}-v1
+          key: sccache-${{ env.CACHE_SCOPE_REPOSITORY_ID }}-${{ runner.os }}-v1
           path: /home/runner/.cache/sccache
 
       - name: Mount Turbo sticky disk
         uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88
         with:
-          key: turbo-cache-${{ github.repository_id }}-${{ runner.os }}-v1
+          key: turbo-cache-${{ env.CACHE_SCOPE_REPOSITORY_ID }}-${{ runner.os }}-v1
           path: ${{ github.workspace }}/.turbo/cache
 
       - run: pnpm build:ci
       - name: Mount Playwright sticky disk
         uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88
         with:
-          key: playwright-browsers-${{ github.repository_id }}-${{ runner.os }}-v1
+          key: playwright-browsers-${{ env.CACHE_SCOPE_REPOSITORY_ID }}-${{ runner.os }}-v1
           path: /home/runner/.cache/ms-playwright
       - run: pnpm exec playwright install chromium
       - run: pnpm test --filter=!moon-lander-react --filter=!@jazz/rust --filter=!jazz-rn --concurrency=2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,15 +27,15 @@ jobs:
       SCCACHE_CACHE_SIZE: 8G
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: 1.93.1
           targets: wasm32-unknown-unknown
           components: clippy, rustfmt
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: .nvmrc
 
@@ -45,18 +45,18 @@ jobs:
       - name: Install Rust prerequisites
         run: pnpm run ensure:rust-toolchain
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
           prefix-key: rocksdb-v1
           key: repo-${{ env.CACHE_SCOPE_REPOSITORY_ID }}
 
-      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
+      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
         with:
           tool: sccache
 
       - name: Mount sccache sticky disk
-        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1
         with:
           key: sccache-${{ env.CACHE_SCOPE_REPOSITORY_ID }}-${{ runner.os }}-v1
           path: /home/runner/.cache/sccache
@@ -75,15 +75,15 @@ jobs:
       SCCACHE_CACHE_SIZE: 8G
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: 1.93.1
           targets: wasm32-unknown-unknown
           components: clippy, rustfmt
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: .nvmrc
 
@@ -93,18 +93,18 @@ jobs:
       - name: Install Rust prerequisites
         run: pnpm run ensure:rust-toolchain
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
           prefix-key: rocksdb-v1
           key: repo-${{ env.CACHE_SCOPE_REPOSITORY_ID }}
 
-      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
+      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
         with:
           tool: sccache
 
       - name: Mount sccache sticky disk
-        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1
         with:
           key: sccache-${{ env.CACHE_SCOPE_REPOSITORY_ID }}-${{ runner.os }}-v1
           path: /home/runner/.cache/sccache
@@ -122,15 +122,15 @@ jobs:
       SCCACHE_CACHE_SIZE: 8G
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: 1.93.1
           targets: wasm32-unknown-unknown
           components: clippy, rustfmt
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: .nvmrc
 
@@ -140,31 +140,31 @@ jobs:
       - name: Install Rust prerequisites
         run: pnpm run ensure:rust-toolchain
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
           prefix-key: rocksdb-v1
           key: repo-${{ env.CACHE_SCOPE_REPOSITORY_ID }}
 
-      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
+      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
         with:
           tool: sccache
 
       - name: Mount sccache sticky disk
-        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1
         with:
           key: sccache-${{ env.CACHE_SCOPE_REPOSITORY_ID }}-${{ runner.os }}-v1
           path: /home/runner/.cache/sccache
 
       - name: Mount Turbo sticky disk
-        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1
         with:
           key: turbo-cache-${{ env.CACHE_SCOPE_REPOSITORY_ID }}-${{ runner.os }}-v1
           path: ${{ github.workspace }}/.turbo/cache
 
       - run: pnpm build:ci
       - name: Mount Playwright sticky disk
-        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1
         with:
           key: playwright-browsers-${{ env.CACHE_SCOPE_REPOSITORY_ID }}-${{ runner.os }}-v1
           path: /home/runner/.cache/ms-playwright

--- a/.github/workflows/expo-android-maestro-e2e.yml
+++ b/.github/workflows/expo-android-maestro-e2e.yml
@@ -20,6 +20,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  CACHE_SCOPE_REPOSITORY_ID: ${{ github.event.pull_request.head.repo.id || github.repository_id }}
+
 jobs:
   build-rn:
     name: Build jazz-rn (Android) artifacts
@@ -47,7 +50,7 @@ jobs:
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29
         with:
           version: 0.14.0
-          cache-key: ${{ env.JAZZ_TOOLS_SANDBOX_TARGET }}
+          cache-key: ${{ env.CACHE_SCOPE_REPOSITORY_ID }}-${{ env.JAZZ_TOOLS_SANDBOX_TARGET }}
 
       - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
         with:
@@ -56,6 +59,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-on-failure: true
+          key: repo-${{ env.CACHE_SCOPE_REPOSITORY_ID }}
 
       - name: Build sandbox binary
         run: |
@@ -112,6 +116,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-on-failure: true
+          key: repo-${{ env.CACHE_SCOPE_REPOSITORY_ID }}
 
       - name: Build Expo E2E JS dependencies
         run: |
@@ -127,12 +132,16 @@ jobs:
       - name: Expo prebuild (Android)
         run: pnpm --filter todo-client-localfirst-expo run verify:expo:android
 
+      - name: Write Gradle cache scope
+        run: echo "${{ env.CACHE_SCOPE_REPOSITORY_ID }}" > .github-cache-scope
+
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
         with:
           distribution: temurin
           java-version: "17"
           cache: gradle
           cache-dependency-path: |
+            .github-cache-scope
             examples/todo-client-localfirst-expo/android/**/*.gradle*
             examples/todo-client-localfirst-expo/android/gradle/wrapper/gradle-wrapper.properties
             crates/jazz-rn/android/**/*.gradle*

--- a/.github/workflows/expo-android-maestro-e2e.yml
+++ b/.github/workflows/expo-android-maestro-e2e.yml
@@ -37,23 +37,23 @@ jobs:
       CARGO_ZIGBUILD_CACHE_DIR: /tmp/cargo-zigbuild-cache
       JAZZ_TOOLS_SANDBOX_TARGET: x86_64-unknown-linux-musl
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: 1.93.1
           targets: ${{ env.JAZZ_TOOLS_SANDBOX_TARGET }}
 
-      - uses: mlugg/setup-zig@v2
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29
         with:
           version: 0.14.0
           cache-key: ${{ env.JAZZ_TOOLS_SANDBOX_TARGET }}
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
         with:
           tool: cargo-zigbuild
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-on-failure: true
 
@@ -64,7 +64,7 @@ jobs:
           cp "target/${JAZZ_TOOLS_SANDBOX_TARGET}/release/jazz-tools" ".artifacts/jazz-tools/jazz-tools-${JAZZ_TOOLS_SANDBOX_TARGET}"
 
       - name: Upload sandbox binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: jazz-tools-sandbox-${{ env.JAZZ_TOOLS_SANDBOX_TARGET }}
           if-no-files-found: error
@@ -83,33 +83,33 @@ jobs:
       COREPACK_HOME: /home/runner/.local/share/corepack
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Source Code
         uses: ./.github/actions/source-code/
 
       - name: Download React Native Android artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
         with:
           name: jazz-rn-android
           path: crates/jazz-rn
 
       - name: Download jazz-tools sandbox binaries
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
         with:
           name: jazz-tools-sandbox-x86_64-unknown-linux-musl
           path: .artifacts/jazz-tools
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: 1.93.1
           targets: wasm32-unknown-unknown
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
         with:
           tool: wasm-pack@0.13.1
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-on-failure: true
 
@@ -127,7 +127,7 @@ jobs:
       - name: Expo prebuild (Android)
         run: pnpm --filter todo-client-localfirst-expo run verify:expo:android
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
         with:
           distribution: temurin
           java-version: "17"
@@ -139,7 +139,7 @@ jobs:
             crates/jazz-rn/android/gradle.properties
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407
 
       - name: Install Android NDK
         run: |
@@ -272,7 +272,7 @@ jobs:
 
       - name: Run Maestro Cloud flows
         id: maestro
-        uses: mobile-dev-inc/action-maestro-cloud@v2
+        uses: mobile-dev-inc/action-maestro-cloud@34906065ba3e85fd57ed533b178187eefb042aed
         with:
           api-key: ${{ secrets.MAESTRO_KEY }}
           project-id: ${{ secrets.MAESTRO_PROJECT_ID }}
@@ -308,7 +308,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: expo-android-maestro-e2e-logs-${{ github.run_id }}-${{ github.run_attempt }}
           path: |

--- a/.github/workflows/expo-android-maestro-e2e.yml
+++ b/.github/workflows/expo-android-maestro-e2e.yml
@@ -40,23 +40,23 @@ jobs:
       CARGO_ZIGBUILD_CACHE_DIR: /tmp/cargo-zigbuild-cache
       JAZZ_TOOLS_SANDBOX_TARGET: x86_64-unknown-linux-musl
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: 1.93.1
           targets: ${{ env.JAZZ_TOOLS_SANDBOX_TARGET }}
 
-      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
           version: 0.14.0
           cache-key: ${{ env.CACHE_SCOPE_REPOSITORY_ID }}-${{ env.JAZZ_TOOLS_SANDBOX_TARGET }}
 
-      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
+      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
         with:
           tool: cargo-zigbuild
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
           key: repo-${{ env.CACHE_SCOPE_REPOSITORY_ID }}
@@ -68,7 +68,7 @@ jobs:
           cp "target/${JAZZ_TOOLS_SANDBOX_TARGET}/release/jazz-tools" ".artifacts/jazz-tools/jazz-tools-${JAZZ_TOOLS_SANDBOX_TARGET}"
 
       - name: Upload sandbox binary
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: jazz-tools-sandbox-${{ env.JAZZ_TOOLS_SANDBOX_TARGET }}
           if-no-files-found: error
@@ -87,33 +87,33 @@ jobs:
       COREPACK_HOME: /home/runner/.local/share/corepack
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Source Code
         uses: ./.github/actions/source-code/
 
       - name: Download React Native Android artifact
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
           name: jazz-rn-android
           path: crates/jazz-rn
 
       - name: Download jazz-tools sandbox binaries
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
           name: jazz-tools-sandbox-x86_64-unknown-linux-musl
           path: .artifacts/jazz-tools
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: 1.93.1
           targets: wasm32-unknown-unknown
 
-      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
+      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
         with:
           tool: wasm-pack@0.13.1
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
           key: repo-${{ env.CACHE_SCOPE_REPOSITORY_ID }}
@@ -135,7 +135,7 @@ jobs:
       - name: Write Gradle cache scope
         run: echo "${{ env.CACHE_SCOPE_REPOSITORY_ID }}" > .github-cache-scope
 
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: temurin
           java-version: "17"
@@ -148,7 +148,7 @@ jobs:
             crates/jazz-rn/android/gradle.properties
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
 
       - name: Install Android NDK
         run: |
@@ -281,7 +281,7 @@ jobs:
 
       - name: Run Maestro Cloud flows
         id: maestro
-        uses: mobile-dev-inc/action-maestro-cloud@34906065ba3e85fd57ed533b178187eefb042aed
+        uses: mobile-dev-inc/action-maestro-cloud@34906065ba3e85fd57ed533b178187eefb042aed # v2
         with:
           api-key: ${{ secrets.MAESTRO_KEY }}
           project-id: ${{ secrets.MAESTRO_PROJECT_ID }}
@@ -317,7 +317,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: expo-android-maestro-e2e-logs-${{ github.run_id }}-${{ github.run_attempt }}
           path: |

--- a/.github/workflows/preview-jazz-tools-alpha-release.yml
+++ b/.github/workflows/preview-jazz-tools-alpha-release.yml
@@ -24,7 +24,7 @@ jobs:
     if: startsWith(github.ref, 'refs/heads/changeset-release/')
     steps:
       - name: Set pending commit status
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -51,7 +51,7 @@ jobs:
     needs: [mark-preview-pending, preview]
     steps:
       - name: Set final commit status
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           PREVIEW_RESULT: ${{ needs.preview.result }}
         with:

--- a/.github/workflows/preview-jazz-tools-alpha-release.yml
+++ b/.github/workflows/preview-jazz-tools-alpha-release.yml
@@ -24,7 +24,7 @@ jobs:
     if: startsWith(github.ref, 'refs/heads/changeset-release/')
     steps:
       - name: Set pending commit status
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -51,7 +51,7 @@ jobs:
     needs: [mark-preview-pending, preview]
     steps:
       - name: Set final commit status
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
         env:
           PREVIEW_RESULT: ${{ needs.preview.result }}
         with:

--- a/.github/workflows/publish-jazz-crates-alpha.yml
+++ b/.github/workflows/publish-jazz-crates-alpha.yml
@@ -22,9 +22,9 @@ jobs:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: 1.93.1
 

--- a/.github/workflows/publish-jazz-crates-alpha.yml
+++ b/.github/workflows/publish-jazz-crates-alpha.yml
@@ -22,9 +22,9 @@ jobs:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: 1.93.1
 

--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -28,6 +28,9 @@ on:
         required: false
         type: string
 
+env:
+  CACHE_SCOPE_REPOSITORY_ID: ${{ github.event.pull_request.head.repo.id || github.repository_id }}
+
 jobs:
   release-push-gate:
     name: Gate release push trigger
@@ -420,12 +423,12 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-on-failure: true
-          cache-bin: false
+          key: repo-${{ env.CACHE_SCOPE_REPOSITORY_ID }}
 
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29
         with:
           version: 0.14.0
-          cache-key: ${{ matrix.target }}
+          cache-key: ${{ env.CACHE_SCOPE_REPOSITORY_ID }}-${{ matrix.target }}
 
       - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
         with:
@@ -471,7 +474,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-on-failure: true
-          cache-bin: false
+          key: repo-${{ env.CACHE_SCOPE_REPOSITORY_ID }}
 
       - name: Build CLI binary
         run: cargo build -p jazz-tools --bin jazz-tools --features cli --release --target ${{ matrix.target }}
@@ -504,11 +507,16 @@ jobs:
           version: 10.14.0
           run_install: false
 
+      - name: Write cache scope
+        run: echo "${{ env.CACHE_SCOPE_REPOSITORY_ID }}" > .github-cache-scope
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .nvmrc
           cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            .github-cache-scope
 
       - run: pnpm install --frozen-lockfile
 
@@ -520,7 +528,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-on-failure: true
-          cache-bin: false
+          key: repo-${{ env.CACHE_SCOPE_REPOSITORY_ID }}
 
       - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
         with:
@@ -533,7 +541,7 @@ jobs:
       - name: Mount sccache sticky disk
         uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88
         with:
-          key: release-wasm-sccache-${{ github.repository_id }}-v1
+          key: release-wasm-sccache-${{ env.CACHE_SCOPE_REPOSITORY_ID }}-v1
           path: /home/runner/.cache/sccache
 
       - name: Build jazz-wasm npm package
@@ -581,11 +589,16 @@ jobs:
           version: 10.14.0
           run_install: false
 
+      - name: Write cache scope
+        run: echo "${{ env.CACHE_SCOPE_REPOSITORY_ID }}" > .github-cache-scope
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .nvmrc
           cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            .github-cache-scope
 
       - run: pnpm install --frozen-lockfile
 
@@ -597,7 +610,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-on-failure: true
-          cache-bin: false
+          key: repo-${{ env.CACHE_SCOPE_REPOSITORY_ID }}
 
       - if: ${{ matrix.use_sccache }}
         uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
@@ -608,7 +621,7 @@ jobs:
         name: Mount sccache sticky disk
         uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88
         with:
-          key: release-napi-sccache-${{ github.repository_id }}-${{ matrix.platform }}-v1
+          key: release-napi-sccache-${{ env.CACHE_SCOPE_REPOSITORY_ID }}-${{ matrix.platform }}-v1
           path: /home/runner/.cache/sccache
 
       - name: Build jazz-napi binding (Linux)
@@ -654,11 +667,16 @@ jobs:
           version: 10.14.0
           run_install: false
 
+      - name: Write cache scope
+        run: echo "${{ env.CACHE_SCOPE_REPOSITORY_ID }}" > .github-cache-scope
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .nvmrc
           cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            .github-cache-scope
 
       - run: pnpm install --frozen-lockfile
 
@@ -670,7 +688,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-on-failure: true
-          cache-bin: false
+          key: repo-${{ env.CACHE_SCOPE_REPOSITORY_ID }}
 
       - name: Install/build React Native iOS prerequisites
         env:
@@ -723,11 +741,16 @@ jobs:
           version: 10.14.0
           run_install: false
 
+      - name: Write cache scope
+        run: echo "${{ env.CACHE_SCOPE_REPOSITORY_ID }}" > .github-cache-scope
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .nvmrc
           cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            .github-cache-scope
 
       - run: pnpm install --frozen-lockfile
 
@@ -738,7 +761,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-on-failure: true
-          cache-bin: false
+          key: repo-${{ env.CACHE_SCOPE_REPOSITORY_ID }}
 
       - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
         with:
@@ -809,12 +832,17 @@ jobs:
           version: 10.14.0
           run_install: false
 
+      - name: Write cache scope
+        run: echo "${{ env.CACHE_SCOPE_REPOSITORY_ID }}" > .github-cache-scope
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .nvmrc
           registry-url: https://registry.npmjs.org
           cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            .github-cache-scope
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -420,6 +420,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          cache-bin: false
 
       - uses: mlugg/setup-zig@v2
         with:
@@ -470,6 +471,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          cache-bin: false
 
       - name: Build CLI binary
         run: cargo build -p jazz-tools --bin jazz-tools --features cli --release --target ${{ matrix.target }}
@@ -518,6 +520,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          cache-bin: false
 
       - uses: taiki-e/install-action@v2
         with:
@@ -594,6 +597,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          cache-bin: false
 
       - if: ${{ matrix.use_sccache }}
         uses: taiki-e/install-action@v2
@@ -666,6 +670,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          cache-bin: false
 
       - name: Install/build React Native iOS prerequisites
         env:
@@ -733,6 +738,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          cache-bin: false
 
       - uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -423,6 +423,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-on-failure: true
+          cache-bin: false
           key: repo-${{ env.CACHE_SCOPE_REPOSITORY_ID }}
 
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29
@@ -474,6 +475,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-on-failure: true
+          cache-bin: false
           key: repo-${{ env.CACHE_SCOPE_REPOSITORY_ID }}
 
       - name: Build CLI binary
@@ -528,6 +530,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-on-failure: true
+          cache-bin: false
           key: repo-${{ env.CACHE_SCOPE_REPOSITORY_ID }}
 
       - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
@@ -610,6 +613,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-on-failure: true
+          cache-bin: false
           key: repo-${{ env.CACHE_SCOPE_REPOSITORY_ID }}
 
       - if: ${{ matrix.use_sccache }}
@@ -688,6 +692,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-on-failure: true
+          cache-bin: false
           key: repo-${{ env.CACHE_SCOPE_REPOSITORY_ID }}
 
       - name: Install/build React Native iOS prerequisites
@@ -761,6 +766,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-on-failure: true
+          cache-bin: false
           key: repo-${{ env.CACHE_SCOPE_REPOSITORY_ID }}
 
       - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9

--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -46,7 +46,7 @@ jobs:
       release_pr_head_sha: ${{ steps.gate.outputs.release_pr_head_sha }}
     steps:
       - id: gate
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           EVENT_NAME: ${{ github.event_name }}
           REF: ${{ github.ref }}
@@ -212,7 +212,7 @@ jobs:
       reason: ${{ steps.resolve.outputs.reason }}
     steps:
       - id: resolve
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           EVENT_NAME: ${{ github.event_name }}
           REF: ${{ github.ref }}
@@ -413,25 +413,25 @@ jobs:
             output: jazz-tools-linux-arm64
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: 1.93.1
           targets: x86_64-unknown-linux-musl,aarch64-unknown-linux-musl
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
           cache-bin: false
           key: repo-${{ env.CACHE_SCOPE_REPOSITORY_ID }}
 
-      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
           version: 0.14.0
           cache-key: ${{ env.CACHE_SCOPE_REPOSITORY_ID }}-${{ matrix.target }}
 
-      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
+      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
         with:
           tool: cargo-zigbuild
 
@@ -443,7 +443,7 @@ jobs:
           mkdir -p dist
           cp target/${{ matrix.target }}/release/jazz-tools dist/${{ matrix.output }}
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.output }}
           path: dist/${{ matrix.output }}
@@ -465,14 +465,14 @@ jobs:
             output: jazz-tools-darwin-x64
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: 1.93.1
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
           cache-bin: false
@@ -486,7 +486,7 @@ jobs:
           mkdir -p dist
           cp target/${{ matrix.target }}/release/jazz-tools dist/${{ matrix.output }}
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.output }}
           path: dist/${{ matrix.output }}
@@ -502,9 +502,9 @@ jobs:
       SCCACHE_CACHE_SIZE: 8G
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.14.0
           run_install: false
@@ -512,7 +512,7 @@ jobs:
       - name: Write cache scope
         run: echo "${{ env.CACHE_SCOPE_REPOSITORY_ID }}" > .github-cache-scope
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -522,27 +522,27 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: 1.93.1
           targets: wasm32-unknown-unknown
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
           cache-bin: false
           key: repo-${{ env.CACHE_SCOPE_REPOSITORY_ID }}
 
-      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
+      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
         with:
           tool: wasm-pack@0.13.1
 
-      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
+      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
         with:
           tool: sccache
 
       - name: Mount sccache sticky disk
-        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1
         with:
           key: release-wasm-sccache-${{ env.CACHE_SCOPE_REPOSITORY_ID }}-v1
           path: /home/runner/.cache/sccache
@@ -556,7 +556,7 @@ jobs:
           test -f crates/jazz-wasm/pkg/jazz_wasm.js
           test -f crates/jazz-wasm/pkg/jazz_wasm.d.ts
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: jazz-wasm-pkg
           path: crates/jazz-wasm/pkg
@@ -585,9 +585,9 @@ jobs:
             use_sccache: false
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.14.0
           run_install: false
@@ -595,7 +595,7 @@ jobs:
       - name: Write cache scope
         run: echo "${{ env.CACHE_SCOPE_REPOSITORY_ID }}" > .github-cache-scope
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -605,25 +605,25 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: 1.93.1
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
           cache-bin: false
           key: repo-${{ env.CACHE_SCOPE_REPOSITORY_ID }}
 
       - if: ${{ matrix.use_sccache }}
-        uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
+        uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
         with:
           tool: sccache
 
       - if: ${{ matrix.use_sccache }}
         name: Mount sccache sticky disk
-        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1
         with:
           key: release-napi-sccache-${{ env.CACHE_SCOPE_REPOSITORY_ID }}-${{ matrix.platform }}-v1
           path: /home/runner/.cache/sccache
@@ -640,13 +640,13 @@ jobs:
         if: runner.os == 'macOS'
         run: pnpm --filter jazz-napi exec napi build --platform --release --target ${{ matrix.target }}
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: jazz-napi-binding-${{ matrix.platform }}
           path: crates/jazz-napi/jazz-napi.${{ matrix.platform }}.node
           if-no-files-found: error
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: matrix.platform == 'linux-x64-gnu'
         with:
           name: jazz-napi-loader
@@ -664,9 +664,9 @@ jobs:
       HOMEBREW_NO_AUTO_UPDATE: 1
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.14.0
           run_install: false
@@ -674,7 +674,7 @@ jobs:
       - name: Write cache scope
         run: echo "${{ env.CACHE_SCOPE_REPOSITORY_ID }}" > .github-cache-scope
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -684,12 +684,12 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: 1.93.1
           targets: aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
           cache-bin: false
@@ -714,7 +714,7 @@ jobs:
           cp -R crates/jazz-rn/JazzRnFramework.xcframework dist/rn-ios/
           cp -R crates/jazz-rn/cpp/generated dist/rn-ios/cpp-generated
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: jazz-rn-ios-payload
           path: dist/rn-ios
@@ -739,9 +739,9 @@ jobs:
             abi: x86_64
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.14.0
           run_install: false
@@ -749,7 +749,7 @@ jobs:
       - name: Write cache scope
         run: echo "${{ env.CACHE_SCOPE_REPOSITORY_ID }}" > .github-cache-scope
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -759,17 +759,17 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: 1.93.1
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
           cache-bin: false
           key: repo-${{ env.CACHE_SCOPE_REPOSITORY_ID }}
 
-      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
+      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
         with:
           tool: cargo-ndk
 
@@ -790,7 +790,7 @@ jobs:
           mkdir -p dist/rn-android/jniLibs
           cp -R crates/jazz-rn/android/src/main/jniLibs/${{ matrix.abi }} dist/rn-android/jniLibs/
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: jazz-rn-android-payload-${{ matrix.abi }}
           path: dist/rn-android
@@ -831,9 +831,9 @@ jobs:
       RELEASE_MODE: ${{ inputs.mode || github.event.inputs.mode || 'publish' }}
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.14.0
           run_install: false
@@ -841,7 +841,7 @@ jobs:
       - name: Write cache scope
         run: echo "${{ env.CACHE_SCOPE_REPOSITORY_ID }}" > .github-cache-scope
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: .nvmrc
           registry-url: https://registry.npmjs.org
@@ -861,46 +861,46 @@ jobs:
           fi
           echo "Artifact decision reason: ${{ needs.resolve-preview-artifacts.outputs.reason }}"
 
-      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts != 'true'
         with:
           pattern: jazz-tools-*
           path: dist
           merge-multiple: true
 
-      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts != 'true'
         with:
           name: jazz-wasm-pkg
           path: crates/jazz-wasm/pkg
 
-      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts != 'true'
         with:
           name: jazz-napi-loader
           path: crates/jazz-napi
 
-      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts != 'true'
         with:
           pattern: jazz-napi-binding-*
           path: crates/jazz-napi/artifacts
           merge-multiple: true
 
-      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts != 'true'
         with:
           name: jazz-rn-ios-payload
           path: dist/rn-ios
 
-      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts != 'true'
         with:
           pattern: jazz-rn-android-payload-*
           path: dist/rn-android
           merge-multiple: true
 
-      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts == 'true'
         with:
           github-token: ${{ github.token }}
@@ -910,7 +910,7 @@ jobs:
           path: dist
           merge-multiple: true
 
-      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts == 'true'
         with:
           github-token: ${{ github.token }}
@@ -919,7 +919,7 @@ jobs:
           name: jazz-wasm-pkg
           path: crates/jazz-wasm/pkg
 
-      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts == 'true'
         with:
           github-token: ${{ github.token }}
@@ -928,7 +928,7 @@ jobs:
           name: jazz-napi-loader
           path: crates/jazz-napi
 
-      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts == 'true'
         with:
           github-token: ${{ github.token }}
@@ -938,7 +938,7 @@ jobs:
           path: crates/jazz-napi/artifacts
           merge-multiple: true
 
-      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts == 'true'
         with:
           github-token: ${{ github.token }}
@@ -947,7 +947,7 @@ jobs:
           name: jazz-rn-ios-payload
           path: dist/rn-ios
 
-      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts == 'true'
         with:
           github-token: ${{ github.token }}
@@ -1261,14 +1261,14 @@ jobs:
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_INSPECTOR_PROJECT_ID }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_INSPECTOR_TOKEN }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.14.0
           run_install: false
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: .nvmrc
 

--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -43,7 +43,7 @@ jobs:
       release_pr_head_sha: ${{ steps.gate.outputs.release_pr_head_sha }}
     steps:
       - id: gate
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
         env:
           EVENT_NAME: ${{ github.event_name }}
           REF: ${{ github.ref }}
@@ -209,7 +209,7 @@ jobs:
       reason: ${{ steps.resolve.outputs.reason }}
     steps:
       - id: resolve
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
         env:
           EVENT_NAME: ${{ github.event_name }}
           REF: ${{ github.ref }}
@@ -410,24 +410,24 @@ jobs:
             output: jazz-tools-linux-arm64
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: 1.93.1
           targets: x86_64-unknown-linux-musl,aarch64-unknown-linux-musl
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-on-failure: true
           cache-bin: false
 
-      - uses: mlugg/setup-zig@v2
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29
         with:
           version: 0.14.0
           cache-key: ${{ matrix.target }}
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
         with:
           tool: cargo-zigbuild
 
@@ -439,7 +439,7 @@ jobs:
           mkdir -p dist
           cp target/${{ matrix.target }}/release/jazz-tools dist/${{ matrix.output }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: ${{ matrix.output }}
           path: dist/${{ matrix.output }}
@@ -461,14 +461,14 @@ jobs:
             output: jazz-tools-darwin-x64
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: 1.93.1
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-on-failure: true
           cache-bin: false
@@ -481,7 +481,7 @@ jobs:
           mkdir -p dist
           cp target/${{ matrix.target }}/release/jazz-tools dist/${{ matrix.output }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: ${{ matrix.output }}
           path: dist/${{ matrix.output }}
@@ -497,14 +497,14 @@ jobs:
       SCCACHE_CACHE_SIZE: 8G
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
         with:
           version: 10.14.0
           run_install: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -512,26 +512,26 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: 1.93.1
           targets: wasm32-unknown-unknown
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-on-failure: true
           cache-bin: false
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
         with:
           tool: wasm-pack@0.13.1
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
         with:
           tool: sccache
 
       - name: Mount sccache sticky disk
-        uses: useblacksmith/stickydisk@v1
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88
         with:
           key: release-wasm-sccache-${{ github.repository_id }}-v1
           path: /home/runner/.cache/sccache
@@ -545,7 +545,7 @@ jobs:
           test -f crates/jazz-wasm/pkg/jazz_wasm.js
           test -f crates/jazz-wasm/pkg/jazz_wasm.d.ts
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: jazz-wasm-pkg
           path: crates/jazz-wasm/pkg
@@ -574,14 +574,14 @@ jobs:
             use_sccache: false
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
         with:
           version: 10.14.0
           run_install: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -589,24 +589,24 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: 1.93.1
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-on-failure: true
           cache-bin: false
 
       - if: ${{ matrix.use_sccache }}
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
         with:
           tool: sccache
 
       - if: ${{ matrix.use_sccache }}
         name: Mount sccache sticky disk
-        uses: useblacksmith/stickydisk@v1
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88
         with:
           key: release-napi-sccache-${{ github.repository_id }}-${{ matrix.platform }}-v1
           path: /home/runner/.cache/sccache
@@ -623,13 +623,13 @@ jobs:
         if: runner.os == 'macOS'
         run: pnpm --filter jazz-napi exec napi build --platform --release --target ${{ matrix.target }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: jazz-napi-binding-${{ matrix.platform }}
           path: crates/jazz-napi/jazz-napi.${{ matrix.platform }}.node
           if-no-files-found: error
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         if: matrix.platform == 'linux-x64-gnu'
         with:
           name: jazz-napi-loader
@@ -647,14 +647,14 @@ jobs:
       HOMEBREW_NO_AUTO_UPDATE: 1
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
         with:
           version: 10.14.0
           run_install: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -662,12 +662,12 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: 1.93.1
           targets: aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-on-failure: true
           cache-bin: false
@@ -691,7 +691,7 @@ jobs:
           cp -R crates/jazz-rn/JazzRnFramework.xcframework dist/rn-ios/
           cp -R crates/jazz-rn/cpp/generated dist/rn-ios/cpp-generated
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: jazz-rn-ios-payload
           path: dist/rn-ios
@@ -716,14 +716,14 @@ jobs:
             abi: x86_64
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
         with:
           version: 10.14.0
           run_install: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -731,16 +731,16 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: 1.93.1
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-on-failure: true
           cache-bin: false
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
         with:
           tool: cargo-ndk
 
@@ -761,7 +761,7 @@ jobs:
           mkdir -p dist/rn-android/jniLibs
           cp -R crates/jazz-rn/android/src/main/jniLibs/${{ matrix.abi }} dist/rn-android/jniLibs/
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: jazz-rn-android-payload-${{ matrix.abi }}
           path: dist/rn-android
@@ -802,14 +802,14 @@ jobs:
       RELEASE_MODE: ${{ inputs.mode || github.event.inputs.mode || 'publish' }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
         with:
           version: 10.14.0
           run_install: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .nvmrc
           registry-url: https://registry.npmjs.org
@@ -827,46 +827,46 @@ jobs:
           fi
           echo "Artifact decision reason: ${{ needs.resolve-preview-artifacts.outputs.reason }}"
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
         if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts != 'true'
         with:
           pattern: jazz-tools-*
           path: dist
           merge-multiple: true
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
         if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts != 'true'
         with:
           name: jazz-wasm-pkg
           path: crates/jazz-wasm/pkg
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
         if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts != 'true'
         with:
           name: jazz-napi-loader
           path: crates/jazz-napi
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
         if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts != 'true'
         with:
           pattern: jazz-napi-binding-*
           path: crates/jazz-napi/artifacts
           merge-multiple: true
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
         if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts != 'true'
         with:
           name: jazz-rn-ios-payload
           path: dist/rn-ios
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
         if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts != 'true'
         with:
           pattern: jazz-rn-android-payload-*
           path: dist/rn-android
           merge-multiple: true
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
         if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts == 'true'
         with:
           github-token: ${{ github.token }}
@@ -876,7 +876,7 @@ jobs:
           path: dist
           merge-multiple: true
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
         if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts == 'true'
         with:
           github-token: ${{ github.token }}
@@ -885,7 +885,7 @@ jobs:
           name: jazz-wasm-pkg
           path: crates/jazz-wasm/pkg
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
         if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts == 'true'
         with:
           github-token: ${{ github.token }}
@@ -894,7 +894,7 @@ jobs:
           name: jazz-napi-loader
           path: crates/jazz-napi
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
         if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts == 'true'
         with:
           github-token: ${{ github.token }}
@@ -904,7 +904,7 @@ jobs:
           path: crates/jazz-napi/artifacts
           merge-multiple: true
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
         if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts == 'true'
         with:
           github-token: ${{ github.token }}
@@ -913,7 +913,7 @@ jobs:
           name: jazz-rn-ios-payload
           path: dist/rn-ios
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
         if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts == 'true'
         with:
           github-token: ${{ github.token }}
@@ -1227,14 +1227,14 @@ jobs:
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_INSPECTOR_PROJECT_ID }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_INSPECTOR_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
         with:
           version: 10.14.0
           run_install: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .nvmrc
 

--- a/.github/workflows/rn-build-reusable.yml
+++ b/.github/workflows/rn-build-reusable.yml
@@ -21,6 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  CACHE_SCOPE_REPOSITORY_ID: ${{ github.event.pull_request.head.repo.id || github.repository_id }}
   PACKAGE_PATH: crates/jazz-rn
   PACKAGE_NAME: jazz-rn
 
@@ -59,6 +60,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-on-failure: true
+          key: repo-${{ env.CACHE_SCOPE_REPOSITORY_ID }}
 
       - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
         with:
@@ -67,7 +69,7 @@ jobs:
       - name: Mount sccache sticky disk
         uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88
         with:
-          key: sccache-${{ github.repository_id }}-${{ runner.os }}-v1
+          key: sccache-${{ env.CACHE_SCOPE_REPOSITORY_ID }}-${{ runner.os }}-v1
           path: /home/runner/.cache/sccache
 
       - name: Show sccache stats (before build)

--- a/.github/workflows/rn-build-reusable.yml
+++ b/.github/workflows/rn-build-reusable.yml
@@ -36,13 +36,13 @@ jobs:
     if: ${{ !inputs.disableAndroid }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Source Code
         uses: ./.github/actions/source-code/
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: 1.93.1
           targets: |
@@ -52,22 +52,22 @@ jobs:
             x86_64-linux-android
 
       - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@bbd0a7de0e936c8c626fa0e93584169d58ff1307
+        uses: cargo-bins/cargo-binstall@bbd0a7de0e936c8c626fa0e93584169d58ff1307 # main
 
       - name: Install cargo-ndk
         run: cargo binstall cargo-ndk
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
           key: repo-${{ env.CACHE_SCOPE_REPOSITORY_ID }}
 
-      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
+      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
         with:
           tool: sccache
 
       - name: Mount sccache sticky disk
-        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1
         with:
           key: sccache-${{ env.CACHE_SCOPE_REPOSITORY_ID }}-${{ runner.os }}-v1
           path: /home/runner/.cache/sccache
@@ -82,7 +82,7 @@ jobs:
         run: sccache --show-stats || true
 
       - name: Upload Android artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: jazz-rn-android
           if-no-files-found: error
@@ -97,7 +97,7 @@ jobs:
     if: ${{ !inputs.disableIOS }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Source Code
         uses: ./.github/actions/source-code/
@@ -105,7 +105,7 @@ jobs:
           cache: "false"
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: 1.93.1
           targets: |
@@ -117,7 +117,7 @@ jobs:
         run: pnpm --filter ${{ env.PACKAGE_NAME }} run build:rn:ios
 
       - name: Upload iOS artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: jazz-rn-ios
           if-no-files-found: error

--- a/.github/workflows/rn-build-reusable.yml
+++ b/.github/workflows/rn-build-reusable.yml
@@ -35,13 +35,13 @@ jobs:
     if: ${{ !inputs.disableAndroid }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Source Code
         uses: ./.github/actions/source-code/
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: 1.93.1
           targets: |
@@ -51,21 +51,21 @@ jobs:
             x86_64-linux-android
 
       - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@main
+        uses: cargo-bins/cargo-binstall@bbd0a7de0e936c8c626fa0e93584169d58ff1307
 
       - name: Install cargo-ndk
         run: cargo binstall cargo-ndk
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-on-failure: true
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9
         with:
           tool: sccache
 
       - name: Mount sccache sticky disk
-        uses: useblacksmith/stickydisk@v1
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88
         with:
           key: sccache-${{ github.repository_id }}-${{ runner.os }}-v1
           path: /home/runner/.cache/sccache
@@ -80,7 +80,7 @@ jobs:
         run: sccache --show-stats || true
 
       - name: Upload Android artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: jazz-rn-android
           if-no-files-found: error
@@ -95,7 +95,7 @@ jobs:
     if: ${{ !inputs.disableIOS }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Source Code
         uses: ./.github/actions/source-code/
@@ -103,7 +103,7 @@ jobs:
           cache: "false"
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: 1.93.1
           targets: |
@@ -115,7 +115,7 @@ jobs:
         run: pnpm --filter ${{ env.PACKAGE_NAME }} run build:rn:ios
 
       - name: Upload iOS artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: jazz-rn-ios
           if-no-files-found: error


### PR DESCRIPTION
## What

- Pin external GitHub Actions references to commit SHAs across `.github` workflows and composite actions.
- Add inline comments beside each pinned action showing the original tag or ref, like `# v6` or `# stable`.
- Scope CI cache keys to the source repository id: fork PRs use the fork repo id, while normal runs use this repository id.
- Stop the release workflow Rust cache from saving or restoring `${CARGO_HOME}/bin`.

## Why

Pinned actions avoid mutable tag or branch refs changing workflow code without an explicit update.

The inline comments make the pinned SHA easier to maintain because the intended upstream tag/ref stays visible next to the pin.

Fork-scoped cache keys keep untrusted fork PRs from sharing the same cache entries as trusted runs from this repository.

Disabling Cargo bin caching in release builds avoids restoring broken Cargo-installed executables while keeping registry, git, and target caching.

## Checks

- pinned action comment check: `pinned action comments ok`
- release Rust cache check: `release rust-cache cache-bin ok`
- cache scope check: `cache scope ok`
- external action pin check: `all external actions are pinned`
- workflow YAML parse: `yaml ok`
- `git diff --check`