### PR TITLE
Add Vue todo example

### DIFF
--- a/examples/todo-client-localfirst-vue/index.html
+++ b/examples/todo-client-localfirst-vue/index.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Todo App - Jazz Vue Client</title>
+    <style>
+      body {
+        font-family: system-ui;
+        max-width: 600px;
+        margin: 2rem auto;
+        padding: 0 1rem;
+      }
+      .done {
+        text-decoration: line-through;
+        opacity: 0.6;
+      }
+      li {
+        padding: 0.5rem 0;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+      .delete-btn {
+        margin-left: auto;
+        cursor: pointer;
+      }
+      small {
+        color: #666;
+      }
+      form {
+        margin-bottom: 1rem;
+        display: flex;
+        gap: 0.5rem;
+      }
+      input[type="text"] {
+        flex: 1;
+        padding: 0.5rem;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/todo-client-localfirst-vue/package.json
+++ b/examples/todo-client-localfirst-vue/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "todo-client-localfirst-vue",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "node ../../packages/jazz-tools/dist/cli.js validate && vite build",
+    "preview": "vite preview",
+    "test": "vitest run --config vitest.config.browser.ts"
+  },
+  "dependencies": {
+    "jazz-tools": "workspace:*",
+    "vue": "^3.5.22",
+    "vue-sonner": "^2.0.9"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "catalog:default",
+    "@vitest/browser": "catalog:default",
+    "@vitest/browser-playwright": "catalog:default",
+    "typescript": "catalog:default",
+    "vite": "catalog:default",
+    "vite-plugin-top-level-await": "catalog:default",
+    "vite-plugin-wasm": "catalog:default",
+    "vitest": "catalog:default",
+    "vue-tsc": "^2.1.10"
+  }
+}

--- a/examples/todo-client-localfirst-vue/src/App.vue
+++ b/examples/todo-client-localfirst-vue/src/App.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { JazzProvider, createJazzClient } from "jazz-tools/vue";
+import { generateAuthSecret, type DbConfig } from "jazz-tools";
+import { Toaster } from "vue-sonner";
+import TodoList from "./TodoList.vue";
+
+interface Props {
+  config?: Partial<DbConfig>;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  config: () => ({}),
+});
+
+function readEnv(name: string): string | undefined {
+  return (import.meta as ImportMeta & { env?: Record<string, string | undefined> }).env?.[name];
+}
+
+function secretStorageKey(appId: string): string {
+  return `jazz-auth-secret:${encodeURIComponent(appId)}`;
+}
+
+function getOrCreateSecretSync(appId: string): string {
+  const stored = localStorage.getItem(secretStorageKey(appId));
+  if (stored) return stored;
+  const secret = generateAuthSecret();
+  localStorage.setItem(secretStorageKey(appId), secret);
+  return secret;
+}
+
+// #region context-setup-vue
+function defaultConfig(overrides: Partial<DbConfig> = {}): DbConfig {
+  const appId = overrides.appId ?? readEnv("VITE_JAZZ_APP_ID");
+  const serverUrl = overrides.serverUrl ?? readEnv("VITE_JAZZ_SERVER_URL");
+  if (!appId)
+    throw new Error("Missing appId: add jazzPlugin() to vite.config.ts or set VITE_JAZZ_APP_ID");
+  const secret = overrides.auth?.localFirstSecret ?? getOrCreateSecretSync(appId);
+
+  return {
+    appId,
+    env: "dev",
+    userBranch: "main",
+    auth: { localFirstSecret: secret },
+    ...(serverUrl ? { serverUrl } : {}),
+    ...overrides,
+  };
+}
+// #endregion context-setup-vue
+
+const client = computed(() => createJazzClient(defaultConfig(props.config)));
+</script>
+
+<template>
+  <JazzProvider :client="client">
+    <h1>Todos</h1>
+    <TodoList />
+    <Toaster />
+    <template #fallback>
+      <p>Loading...</p>
+    </template>
+  </JazzProvider>
+</template>

--- a/examples/todo-client-localfirst-vue/src/TodoList.vue
+++ b/examples/todo-client-localfirst-vue/src/TodoList.vue
@@ -45,20 +45,11 @@ function deleteTodo(todoId: string) {
 
 <template>
   <form @submit="handleSubmit">
-    <input
-      type="text"
-      v-model="title"
-      placeholder="What needs to be done?"
-      required
-    />
+    <input type="text" v-model="title" placeholder="What needs to be done?" required />
     <button type="submit" :disabled="!sessionUserId">Add</button>
   </form>
   <ul id="todo-list">
-    <li
-      v-for="todo in todos ?? []"
-      :key="todo.id"
-      :class="{ done: todo.done }"
-    >
+    <li v-for="todo in todos ?? []" :key="todo.id" :class="{ done: todo.done }">
       <input
         type="checkbox"
         :checked="todo.done"

--- a/examples/todo-client-localfirst-vue/src/TodoList.vue
+++ b/examples/todo-client-localfirst-vue/src/TodoList.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { useAll, useDb, useSession } from "jazz-tools/vue";
+import { toast } from "vue-sonner";
+import { app } from "./lib/schema.js";
+
+const db = useDb();
+// #region reading-reactive-vue
+const todos = useAll(app.todos);
+// #endregion reading-reactive-vue
+const session = useSession();
+const sessionUserId = computed(() => session?.user_id ?? null);
+const title = ref("");
+
+function handleSubmit(e: Event) {
+  e.preventDefault();
+  if (!title.value.trim() || !sessionUserId.value) return;
+  db.insert(app.todos, {
+    title: title.value.trim(),
+    done: false,
+    owner_id: sessionUserId.value,
+  });
+  title.value = "";
+}
+
+function toggleTodo(todo: { id: string; done: boolean }, event: Event) {
+  const checkbox = event.currentTarget as HTMLInputElement;
+
+  try {
+    db.update(app.todos, todo.id, { done: !todo.done });
+  } catch {
+    checkbox.checked = todo.done;
+    toast.error("You don't have permission to update this task");
+  }
+}
+
+function deleteTodo(todoId: string) {
+  try {
+    db.delete(app.todos, todoId);
+  } catch {
+    toast.error("You don't have permission to delete this task");
+  }
+}
+</script>
+
+<template>
+  <form @submit="handleSubmit">
+    <input
+      type="text"
+      v-model="title"
+      placeholder="What needs to be done?"
+      required
+    />
+    <button type="submit" :disabled="!sessionUserId">Add</button>
+  </form>
+  <ul id="todo-list">
+    <li
+      v-for="todo in todos ?? []"
+      :key="todo.id"
+      :class="{ done: todo.done }"
+    >
+      <input
+        type="checkbox"
+        :checked="todo.done"
+        @change="(event) => toggleTodo(todo, event)"
+        class="toggle"
+      />
+      <span>{{ todo.title }}</span>
+      <small v-if="todo.description">{{ todo.description }}</small>
+      <button class="delete-btn" @click="deleteTodo(todo.id)">&times;</button>
+    </li>
+  </ul>
+</template>

--- a/examples/todo-client-localfirst-vue/src/lib/permissions.ts
+++ b/examples/todo-client-localfirst-vue/src/lib/permissions.ts
@@ -1,0 +1,11 @@
+import { schema as s } from "jazz-tools";
+import { app } from "./schema.js";
+
+export default s.definePermissions(app, ({ policy, session }) => {
+  policy.todos.allowRead.where({});
+  policy.todos.allowInsert.where({ owner_id: session.user_id });
+  policy.todos.allowUpdate
+    .whereOld({ owner_id: session.user_id })
+    .whereNew({ owner_id: session.user_id });
+  policy.todos.allowDelete.where({ owner_id: session.user_id });
+});

--- a/examples/todo-client-localfirst-vue/src/lib/schema.ts
+++ b/examples/todo-client-localfirst-vue/src/lib/schema.ts
@@ -1,0 +1,20 @@
+import { schema as s } from "jazz-tools";
+
+const schema = {
+  projects: s.table({
+    name: s.string(),
+  }),
+  todos: s.table({
+    title: s.string(),
+    done: s.boolean(),
+    description: s.string().optional(),
+    owner_id: s.string(),
+    parentId: s.ref("todos").optional(),
+    projectId: s.ref("projects").optional(),
+  }),
+};
+
+type AppSchema = s.Schema<typeof schema>;
+export const app: s.App<AppSchema> = s.defineApp(schema);
+
+export type Todo = s.RowOf<typeof app.todos>;

--- a/examples/todo-client-localfirst-vue/src/main.ts
+++ b/examples/todo-client-localfirst-vue/src/main.ts
@@ -1,0 +1,4 @@
+import { createApp } from "vue";
+import App from "./App.vue";
+
+createApp(App).mount("#app");

--- a/examples/todo-client-localfirst-vue/src/shims-vue.d.ts
+++ b/examples/todo-client-localfirst-vue/src/shims-vue.d.ts
@@ -1,0 +1,5 @@
+declare module "*.vue" {
+  import type { DefineComponent } from "vue";
+  const component: DefineComponent<Record<string, unknown>, Record<string, unknown>, unknown>;
+  export default component;
+}

--- a/examples/todo-client-localfirst-vue/tests/browser/global-setup.ts
+++ b/examples/todo-client-localfirst-vue/tests/browser/global-setup.ts
@@ -1,0 +1,34 @@
+import { join } from "node:path";
+import { TestingServer, pushSchemaCatalogue } from "jazz-tools/testing";
+import { TEST_PORT, ADMIN_SECRET, APP_ID } from "./test-constants.js";
+
+export { TEST_PORT, ADMIN_SECRET, APP_ID };
+
+let server: Promise<TestingServer> | null = null;
+
+export async function setup(): Promise<void> {
+  if (server) {
+    await server;
+    return;
+  }
+
+  server = TestingServer.start({
+    appId: APP_ID,
+    port: TEST_PORT,
+    adminSecret: ADMIN_SECRET,
+  });
+
+  const serverHandle = await server;
+
+  await pushSchemaCatalogue({
+    serverUrl: serverHandle.url,
+    appId: serverHandle.appId,
+    adminSecret: serverHandle.adminSecret,
+    schemaDir: join(import.meta.dirname ?? __dirname, "../../src/lib"),
+  });
+}
+
+export async function teardown(): Promise<void> {
+  const s = await server;
+  await s?.stop();
+}

--- a/examples/todo-client-localfirst-vue/tests/browser/test-constants.ts
+++ b/examples/todo-client-localfirst-vue/tests/browser/test-constants.ts
@@ -1,0 +1,5 @@
+/** Shared constants for browser tests — no Node.js imports. */
+export const TEST_PORT = 19882;
+export const JWT_SECRET = "test-jwt-secret-for-vue-browser-tests";
+export const ADMIN_SECRET = "test-admin-secret-for-vue-browser-tests";
+export const APP_ID = "a95ab3f0-9605-4c0b-a3f3-8fb5ab6d8a12";

--- a/examples/todo-client-localfirst-vue/tests/browser/todo-app.test.ts
+++ b/examples/todo-client-localfirst-vue/tests/browser/todo-app.test.ts
@@ -1,0 +1,297 @@
+/**
+ * E2E browser tests for the Vue todo app.
+ *
+ * Mounts the real App component in a Chromium browser via @vitest/browser + playwright.
+ * Interacts through the actual DOM the app renders — no test-only components.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { createApp, type App as VueApp } from "vue";
+import { TEST_PORT, APP_ID } from "./test-constants.js";
+import type { DbConfig } from "jazz-tools";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function uniqueDbName(label: string): string {
+  return `test-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function waitFor(check: () => boolean, timeoutMs: number, message: string): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (check()) return;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(`Timeout: ${message}`);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Vue Todo App E2E", () => {
+  const mounts: Array<{ app: VueApp; container: HTMLDivElement }> = [];
+
+  /** Mount the real App. Returns the container element. */
+  async function mountApp(config: Partial<DbConfig>): Promise<HTMLDivElement> {
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+
+    // Dynamic import so the Vue compiler processes the SFC
+    const { default: App } = await import("../../src/App.vue");
+
+    const app = createApp(App, { config: { appId: config.appId ?? "test-app", ...config } });
+    app.mount(el);
+    mounts.push({ app, container: el });
+
+    // Wait for JazzProvider to initialise and TodoList to render
+    await waitFor(
+      () => el.querySelector("#todo-list") !== null,
+      5000,
+      "App should render the todo list",
+    );
+
+    return el;
+  }
+
+  /** Unmount a specific app instance (triggers JazzProvider shutdown). */
+  async function unmountApp(el: HTMLDivElement): Promise<void> {
+    const idx = mounts.findIndex((m) => m.container === el);
+    if (idx === -1) return;
+    const { app } = mounts[idx];
+    app.unmount();
+    el.remove();
+    mounts.splice(idx, 1);
+    // Give OPFS handles time to release
+    await new Promise((r) => setTimeout(r, 200));
+  }
+
+  afterEach(async () => {
+    for (const { app, container } of mounts) {
+      try {
+        app.unmount();
+      } catch {
+        /* best effort */
+      }
+      container.remove();
+    }
+    mounts.length = 0;
+  });
+
+  // -------------------------------------------------------------------------
+  // 1. App renders with empty list
+  // -------------------------------------------------------------------------
+
+  it("renders the app with an empty todo list", async () => {
+    const el = await mountApp({ driver: { type: "persistent", dbName: uniqueDbName("empty") } });
+
+    expect(el.querySelector("h1")!.textContent).toBe("Todos");
+    expect(el.querySelector("#todo-list")).toBeTruthy();
+    expect(el.querySelectorAll("#todo-list li").length).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. Add todo via form
+  // -------------------------------------------------------------------------
+
+  it("adds a todo via the form", async () => {
+    const el = await mountApp({ driver: { type: "persistent", dbName: uniqueDbName("add") } });
+
+    const input = el.querySelector<HTMLInputElement>("input[type='text']")!;
+    const form = input.closest("form")!;
+
+    input.value = "Buy milk";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+
+    await waitFor(
+      () => el.querySelectorAll("#todo-list li").length === 1,
+      3000,
+      "Todo should appear after form submit",
+    );
+
+    const li = el.querySelector("#todo-list li")!;
+    expect(li.querySelector("span")!.textContent).toBe("Buy milk");
+    expect(li.classList.contains("done")).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. Toggle todo
+  // -------------------------------------------------------------------------
+
+  it("toggles a todo's done state via checkbox", async () => {
+    const el = await mountApp({ driver: { type: "persistent", dbName: uniqueDbName("toggle") } });
+
+    // Add a todo first
+    const input = el.querySelector<HTMLInputElement>("input[type='text']")!;
+    const form = input.closest("form")!;
+    input.value = "Toggle me";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+
+    await waitFor(
+      () => el.querySelectorAll("#todo-list li").length === 1,
+      3000,
+      "Todo should appear",
+    );
+
+    const li = el.querySelector("#todo-list li")!;
+    expect(li.classList.contains("done")).toBe(false);
+
+    // Click the checkbox
+    const checkbox = li.querySelector<HTMLInputElement>("input.toggle")!;
+    checkbox.click();
+
+    await waitFor(
+      () => el.querySelector("#todo-list li")!.classList.contains("done"),
+      3000,
+      "Todo should be marked done",
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. Delete todo
+  // -------------------------------------------------------------------------
+
+  it("deletes a todo via the delete button", async () => {
+    const el = await mountApp({ driver: { type: "persistent", dbName: uniqueDbName("delete") } });
+
+    // Add a todo
+    const input = el.querySelector<HTMLInputElement>("input[type='text']")!;
+    const form = input.closest("form")!;
+    input.value = "Delete me";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+
+    await waitFor(
+      () => el.querySelectorAll("#todo-list li").length === 1,
+      3000,
+      "Todo should appear",
+    );
+
+    // Click the delete button
+    const deleteBtn = el.querySelector<HTMLButtonElement>(".delete-btn")!;
+    deleteBtn.click();
+
+    await waitFor(
+      () => el.querySelectorAll("#todo-list li").length === 0,
+      3000,
+      "Todo should be removed",
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. Multiple todos render correctly
+  // -------------------------------------------------------------------------
+
+  it("renders multiple todos with correct state", async () => {
+    const el = await mountApp({ driver: { type: "persistent", dbName: uniqueDbName("multi") } });
+
+    const input = el.querySelector<HTMLInputElement>("input[type='text']")!;
+    const form = input.closest("form")!;
+
+    // Add three todos
+    for (const title of ["First", "Second", "Third"]) {
+      input.value = title;
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+      // Brief pause so each insert completes
+      await new Promise((r) => setTimeout(r, 100));
+    }
+
+    await waitFor(
+      () => el.querySelectorAll("#todo-list li").length === 3,
+      3000,
+      "Should have 3 todos",
+    );
+
+    const titles = [...el.querySelectorAll("#todo-list li span")].map((s) => s.textContent);
+    expect(titles.sort()).toEqual(["First", "Second", "Third"]);
+  });
+
+  // -------------------------------------------------------------------------
+  // 6. OPFS persistence across reload
+  // -------------------------------------------------------------------------
+
+  it("persists todos across app unmount and remount (OPFS)", async () => {
+    const dbName = uniqueDbName("opfs");
+
+    // First session: mount app, add a todo via the form
+    const el1 = await mountApp({ driver: { type: "persistent", dbName } });
+    const input1 = el1.querySelector<HTMLInputElement>("input[type='text']")!;
+    const form1 = input1.closest("form")!;
+
+    input1.value = "Survive reload";
+    input1.dispatchEvent(new Event("input", { bubbles: true }));
+    form1.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+
+    await waitFor(
+      () => el1.querySelectorAll("#todo-list li").length === 1,
+      3000,
+      "Todo should appear in first session",
+    );
+
+    // Unmount (triggers db.shutdown, flushes OPFS)
+    await unmountApp(el1);
+
+    // Second session: remount with same dbName — OPFS data should load
+    const el2 = await mountApp({ driver: { type: "persistent", dbName } });
+
+    await waitFor(
+      () => el2.querySelectorAll("#todo-list li").length === 1,
+      5000,
+      "Todo should survive remount from OPFS",
+    );
+
+    expect(el2.querySelector("#todo-list li span")!.textContent).toBe("Survive reload");
+  });
+
+  // -------------------------------------------------------------------------
+  // 7. Server sync between two app instances
+  // -------------------------------------------------------------------------
+
+  // Longer timeout: sync can take up to 20s under full-suite load.
+  it("syncs a todo between two app instances through the server", async () => {
+    const serverUrl = `http://127.0.0.1:${TEST_PORT}`;
+
+    // Mount two independent app instances connected to the same server
+    const el1 = await mountApp({
+      appId: APP_ID,
+      driver: { type: "persistent", dbName: uniqueDbName("sync-a") },
+      serverUrl,
+    });
+    const el2 = await mountApp({
+      appId: APP_ID,
+      driver: { type: "persistent", dbName: uniqueDbName("sync-b") },
+      serverUrl,
+    });
+
+    // Let both app instances finish server/event-stream setup before mutating.
+    await new Promise((r) => setTimeout(r, 750));
+
+    // Add a todo in app 1 via the form
+    const input1 = el1.querySelector<HTMLInputElement>("input[type='text']")!;
+    const form1 = input1.closest("form")!;
+
+    input1.value = "Synced todo";
+    input1.dispatchEvent(new Event("input", { bubbles: true }));
+    form1.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+
+    await waitFor(
+      () => el1.querySelectorAll("#todo-list li").length === 1,
+      3000,
+      "Todo should appear in app 1",
+    );
+
+    // Wait for it to appear in app 2 via server sync
+    await waitFor(
+      () => el2.querySelectorAll("#todo-list li").length === 1,
+      25000,
+      "Todo should sync to app 2 through the server",
+    );
+
+    expect(el2.querySelector("#todo-list li span")!.textContent).toBe("Synced todo");
+  }, 60000);
+});

--- a/examples/todo-client-localfirst-vue/tsconfig.json
+++ b/examples/todo-client-localfirst-vue/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "jsx": "preserve",
+    "isolatedModules": true,
+    "useDefineForClassFields": true
+  },
+  "include": ["src", "src/**/*.vue"]
+}

--- a/examples/todo-client-localfirst-vue/vite.config.ts
+++ b/examples/todo-client-localfirst-vue/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+import vue from "@vitejs/plugin-vue";
+import { jazzPlugin } from "jazz-tools/dev/vite";
+
+export default defineConfig({
+  plugins: [vue(), jazzPlugin()],
+});

--- a/examples/todo-client-localfirst-vue/vitest.config.browser.ts
+++ b/examples/todo-client-localfirst-vue/vitest.config.browser.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "vitest/config";
+import wasm from "vite-plugin-wasm";
+import topLevelAwait from "vite-plugin-top-level-await";
+import vue from "@vitejs/plugin-vue";
+import { playwright } from "@vitest/browser-playwright";
+
+export default defineConfig({
+  plugins: [wasm(), topLevelAwait(), vue()],
+  worker: {
+    plugins: () => [wasm(), topLevelAwait()],
+  },
+  test: {
+    browser: {
+      enabled: true,
+      provider: playwright(),
+      instances: [{ browser: "chromium", headless: true }],
+    },
+    include: ["tests/browser/**/*.test.ts"],
+    globalSetup: ["tests/browser/global-setup.ts"],
+    testTimeout: 30000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -670,7 +670,7 @@ importers:
         version: 19.2.14
       babel-preset-expo:
         specifier: ~54.0.10
-        version: 54.0.10(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-refresh@0.17.0)
+        version: 54.0.10(@babel/core@7.29.0)(@babel/runtime@7.28.6)(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-refresh@0.14.2)
       typescript:
         specifier: catalog:default
         version: 6.0.2
@@ -1097,6 +1097,46 @@ importers:
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+
+  examples/todo-client-localfirst-vue:
+    dependencies:
+      jazz-tools:
+        specifier: workspace:*
+        version: link:../../packages/jazz-tools
+      vue:
+        specifier: ^3.5.22
+        version: 3.5.29(typescript@6.0.2)
+      vue-sonner:
+        specifier: ^2.0.9
+        version: 2.0.9
+    devDependencies:
+      '@vitejs/plugin-vue':
+        specifier: catalog:default
+        version: 6.0.4(vite@8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.29(typescript@6.0.2))
+      '@vitest/browser':
+        specifier: catalog:default
+        version: 4.1.0(vite@8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)
+      '@vitest/browser-playwright':
+        specifier: catalog:default
+        version: 4.1.0(playwright@1.58.2)(vite@8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)
+      typescript:
+        specifier: catalog:default
+        version: 6.0.2
+      vite:
+        specifier: catalog:default
+        version: 8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite-plugin-top-level-await:
+        specifier: catalog:default
+        version: 1.6.0(rollup@4.59.0)(vite@8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vite-plugin-wasm:
+        specifier: catalog:default
+        version: 3.6.0(vite@8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest:
+        specifier: catalog:default
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vue-tsc:
+        specifier: ^2.1.10
+        version: 2.2.12(typescript@6.0.2)
 
   examples/todo-server-ts:
     dependencies:
@@ -6642,6 +6682,15 @@ packages:
   '@vitest/utils@4.1.0':
     resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
 
+  '@volar/language-core@2.4.15':
+    resolution: {integrity: sha512-3VHw+QZU0ZG9IuQmzT68IyN4hZNd9GchGPhbD9+pa8CVv7rnoOZwo7T8weIbrRmihqy3ATpdfXFnqRrfPVK6CA==}
+
+  '@volar/source-map@2.4.15':
+    resolution: {integrity: sha512-CPbMWlUN6hVZJYGcU/GSoHu4EnCHiLaXI9n8c9la6RaI9W5JHX+NqG+GSQcB0JdC2FIBLdZJwGsfKyBB71VlTg==}
+
+  '@volar/typescript@2.4.15':
+    resolution: {integrity: sha512-2aZ8i0cqPGjXb4BhkMsPYDkkuc2ZQ6yOpqwAuNwUoncELqoy5fRgOQtLR9gB0g902iS0NAkvpIzs27geVyVdPg==}
+
   '@vscode/sudo-prompt@9.3.2':
     resolution: {integrity: sha512-gcXoCN00METUNFeQOFJ+C9xUI0DKB+0EGMVg7wbVYRHBw2Eq3fKisDZOkRdOz3kqXRKOENMfShPOmypw1/8nOw==}
 
@@ -6656,6 +6705,17 @@ packages:
 
   '@vue/compiler-ssr@3.5.29':
     resolution: {integrity: sha512-Y/ARJZE6fpjzL5GH/phJmsFwx3g6t2KmHKHx5q+MLl2kencADKIrhH5MLF6HHpRMmlRAYBRSvv347Mepf1zVNw==}
+
+  '@vue/compiler-vue2@2.7.16':
+    resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
+
+  '@vue/language-core@2.2.12':
+    resolution: {integrity: sha512-IsGljWbKGU1MZpBPN+BvPAdr55YPkj2nB/TBNGNC32Vy2qLG25DYu/NBN2vNtZqdRbTRjaoYrahLrToim2NanA==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@vue/reactivity@3.5.29':
     resolution: {integrity: sha512-zcrANcrRdcLtmGZETBxWqIkoQei8HaFpZWx/GHKxx79JZsiZ8j1du0VUJtu4eJjgFvU/iKL5lRXFXksVmI+5DA==}
@@ -6730,6 +6790,9 @@ packages:
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  alien-signals@1.0.13:
+    resolution: {integrity: sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==}
 
   anser@1.4.10:
     resolution: {integrity: sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==}
@@ -7752,6 +7815,9 @@ packages:
 
   dayjs@1.11.19:
     resolution: {integrity: sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==}
+
+  de-indent@1.0.2:
+    resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -8910,6 +8976,10 @@ packages:
 
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
+
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
 
   hermes-estree@0.28.1:
     resolution: {integrity: sha512-w3nxl/RGM7LBae0v8LH2o36+8VqwOZGv9rX1wyoWT6YaKZLqpJZ0YQ5P0LVr3tuRpf7vCx0iIG4i/VmBJejxTQ==}
@@ -10449,6 +10519,9 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  muggle-string@0.4.1:
+    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
+
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -10838,6 +10911,9 @@ packages:
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
   path-data-parser@0.1.0:
     resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
@@ -12563,6 +12639,26 @@ packages:
 
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
+  vue-sonner@2.0.9:
+    resolution: {integrity: sha512-i6BokNlNDL93fpzNxN/LZSn6D6MzlO+i3qXt6iVZne3x1k7R46d5HlFB4P8tYydhgqOrRbIZEsnRd3kG7qGXyw==}
+    peerDependencies:
+      '@nuxt/kit': ^4.0.3
+      '@nuxt/schema': ^4.0.3
+      nuxt: ^4.0.3
+    peerDependenciesMeta:
+      '@nuxt/kit':
+        optional: true
+      '@nuxt/schema':
+        optional: true
+      nuxt:
+        optional: true
+
+  vue-tsc@2.2.12:
+    resolution: {integrity: sha512-P7OP77b2h/Pmk+lZdJ0YWs+5tJ6J2+uOQPo7tlBnY44QqQSPYvS0qVT4wqDJgwrZaLe47etJLLQRFia71GYITw==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.0.0'
 
   vue@3.5.29:
     resolution: {integrity: sha512-BZqN4Ze6mDQVNAni0IHeMJ5mwr8VAJ3MQC9FmprRhcBYENw+wOAAjRj8jfmN6FLl0j96OXbR+CjWhmAmM+QGnA==}
@@ -17992,7 +18088,7 @@ snapshots:
       '@vitest/mocker': 4.1.0(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       playwright: 1.58.2
       tinyrainbow: 3.0.3
-      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@26.1.0)(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -18052,7 +18148,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.0.3
-      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@26.1.0)(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
@@ -18171,6 +18267,18 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.0.3
 
+  '@volar/language-core@2.4.15':
+    dependencies:
+      '@volar/source-map': 2.4.15
+
+  '@volar/source-map@2.4.15': {}
+
+  '@volar/typescript@2.4.15':
+    dependencies:
+      '@volar/language-core': 2.4.15
+      path-browserify: 1.0.1
+      vscode-uri: 3.1.0
+
   '@vscode/sudo-prompt@9.3.2': {}
 
   '@vue/compiler-core@3.5.29':
@@ -18202,6 +18310,24 @@ snapshots:
     dependencies:
       '@vue/compiler-dom': 3.5.29
       '@vue/shared': 3.5.29
+
+  '@vue/compiler-vue2@2.7.16':
+    dependencies:
+      de-indent: 1.0.2
+      he: 1.2.0
+
+  '@vue/language-core@2.2.12(typescript@6.0.2)':
+    dependencies:
+      '@volar/language-core': 2.4.15
+      '@vue/compiler-dom': 3.5.29
+      '@vue/compiler-vue2': 2.7.16
+      '@vue/shared': 3.5.29
+      alien-signals: 1.0.13
+      minimatch: 9.0.9
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+    optionalDependencies:
+      typescript: 6.0.2
 
   '@vue/reactivity@3.5.29':
     dependencies:
@@ -18287,6 +18413,8 @@ snapshots:
       fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  alien-signals@1.0.13: {}
 
   anser@1.4.10: {}
 
@@ -19531,6 +19659,8 @@ snapshots:
       is-data-view: 1.0.2
 
   dayjs@1.11.19: {}
+
+  de-indent@1.0.2: {}
 
   debug@2.6.9:
     dependencies:
@@ -20959,6 +21089,8 @@ snapshots:
       hast-util-parse-selector: 4.0.0
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
+
+  he@1.2.0: {}
 
   hermes-estree@0.28.1: {}
 
@@ -23090,6 +23222,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  muggle-string@0.4.1: {}
+
   mute-stream@2.0.0: {}
 
   mute-stream@3.0.0: {}
@@ -23542,6 +23676,8 @@ snapshots:
       entities: 6.0.1
 
   parseurl@1.3.3: {}
+
+  path-browserify@1.0.1: {}
 
   path-data-parser@0.1.0: {}
 
@@ -25675,6 +25811,14 @@ snapshots:
       vscode-languageserver-protocol: 3.17.5
 
   vscode-uri@3.1.0: {}
+
+  vue-sonner@2.0.9: {}
+
+  vue-tsc@2.2.12(typescript@6.0.2):
+    dependencies:
+      '@volar/typescript': 2.4.15
+      '@vue/language-core': 2.2.12(typescript@6.0.2)
+      typescript: 6.0.2
 
   vue@3.5.29(typescript@6.0.2):
     dependencies:


### PR DESCRIPTION
## Summary
- Adds a Vue 3 + Vite local-first todo example, mirroring the existing React, Svelte and TS siblings under `examples/`
- Provides Jazz schema and permissions in `src/lib/`, plus a small UI in `App.vue` / `TodoList.vue`
- Includes browser tests via `@vitest/browser` with Playwright

## Test plan
- [ ] `cd examples/todo-client-localfirst-vue && pnpm dev` — app loads and todos can be added/toggled/deleted
- [ ] `pnpm -C examples/todo-client-localfirst-vue test` — browser tests pass