### PR TITLE
Add reactive LocalFirstAuth for Svelte and Vue

### DIFF
--- a/.changeset/reactive-local-first-auth.md
+++ b/.changeset/reactive-local-first-auth.md
@@ -1,0 +1,12 @@
+---
+"jazz-tools": patch
+---
+
+Added reactive local-first auth helpers for Svelte and Vue, matching `useLocalFirstAuth` in `jazz-tools/react`:
+
+- **Svelte:** new `LocalFirstAuth` reactive class in `jazz-tools/svelte`. Exposes `secret`, `isLoading`, `login`, and `signOut`; the secret store is read inside `$effect`, so SvelteKit server renders never touch `localStorage`.
+- **Vue:** new `useLocalFirstAuth()` composable in `jazz-tools/vue`. Returns `Ref<string | null>` and `Ref<boolean>` for the secret/loading state plus async `login`/`signOut`; gated on `typeof window` so SSR setup never touches `localStorage`.
+
+In both frameworks `login`/`signOut` notify every live instance backed by the same store, and a `console.warn` surfaces secret-store failures that previously fell through silently. `BrowserAuthSecretStore` now also throws a clearer error when used outside a browser environment, with `localStorage` resolved lazily so server-side imports of the module-level singleton don't break.
+
+Note for anyone copying the documented Svelte backup/restore snippets: their signatures changed to take a `LocalFirstAuth` instance (e.g. `createRecoveryPhraseRestore(auth)` returning a callback) so they can call `auth.login()` directly instead of `BrowserAuthSecretStore.saveSecret()` + `location.reload()`.

--- a/.changeset/svelte-local-first-auth.md
+++ b/.changeset/svelte-local-first-auth.md
@@ -2,4 +2,6 @@
 "jazz-tools": patch
 ---
 
-Added `LocalFirstAuth` reactive class to `jazz-tools/svelte` for SSR-safe parity with `useLocalFirstAuth` in `jazz-tools/react`. The class exposes `secret`, `isLoading`, `login`, and `signOut`; the secret store is read inside `$effect`, so SvelteKit server renders never touch `localStorage`. `login`/`signOut` notify every live instance backed by the same store. `BrowserAuthSecretStore` now also throws a clearer error when used outside a browser environment.
+Added `LocalFirstAuth` reactive class to `jazz-tools/svelte` for SSR-safe parity with `useLocalFirstAuth` in `jazz-tools/react`. The class exposes `secret`, `isLoading`, `login`, and `signOut`; the secret store is read inside `$effect`, so SvelteKit server renders never touch `localStorage`. `login`/`signOut` notify every live instance backed by the same store, and a `console.warn` surfaces secret-store failures that previously fell through silently. `BrowserAuthSecretStore` now also throws a clearer error when used outside a browser environment.
+
+Note for anyone copying the documented Svelte backup/restore snippets: their signatures changed to take a `LocalFirstAuth` instance (e.g. `createRecoveryPhraseRestore(auth)` returning a callback) so they can call `auth.login()` directly instead of `BrowserAuthSecretStore.saveSecret()` + `location.reload()`.

--- a/.changeset/svelte-local-first-auth.md
+++ b/.changeset/svelte-local-first-auth.md
@@ -1,7 +1,0 @@
----
-"jazz-tools": patch
----
-
-Added `LocalFirstAuth` reactive class to `jazz-tools/svelte` for SSR-safe parity with `useLocalFirstAuth` in `jazz-tools/react`. The class exposes `secret`, `isLoading`, `login`, and `signOut`; the secret store is read inside `$effect`, so SvelteKit server renders never touch `localStorage`. `login`/`signOut` notify every live instance backed by the same store, and a `console.warn` surfaces secret-store failures that previously fell through silently. `BrowserAuthSecretStore` now also throws a clearer error when used outside a browser environment.
-
-Note for anyone copying the documented Svelte backup/restore snippets: their signatures changed to take a `LocalFirstAuth` instance (e.g. `createRecoveryPhraseRestore(auth)` returning a callback) so they can call `auth.login()` directly instead of `BrowserAuthSecretStore.saveSecret()` + `location.reload()`.

--- a/.changeset/svelte-local-first-auth.md
+++ b/.changeset/svelte-local-first-auth.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Added `LocalFirstAuth` reactive class to `jazz-tools/svelte` for SSR-safe parity with `useLocalFirstAuth` in `jazz-tools/react`. The class exposes `secret`, `isLoading`, `login`, and `signOut`; the secret store is read inside `$effect`, so SvelteKit server renders never touch `localStorage`. `login`/`signOut` notify every live instance backed by the same store. `BrowserAuthSecretStore` now also throws a clearer error when used outside a browser environment.

--- a/.changeset/sveltekit-config-hook-env-injection.md
+++ b/.changeset/sveltekit-config-hook-env-injection.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+`jazzSvelteKit` now starts the managed Jazz dev server and populates `PUBLIC_JAZZ_APP_ID` / `PUBLIC_JAZZ_SERVER_URL` from an `enforce: "pre"` Vite `config` hook, before SvelteKit's `vite-plugin-sveltekit-setup` captures env into `$env/dynamic/public`. The previous approach set these in `configureServer` — after SvelteKit had already frozen its env — and recovered by triggering a fire-and-forget dev-server restart. On a freshly scaffolded starter the first paint reliably rendered with `PUBLIC_JAZZ_SERVER_URL` undefined, and recovery was race-dependent. The restart is removed entirely; the dynamically allocated server URL is now correct on the first request for both cold and warm starts, matching how the Next.js plugin awaits `runtime.initialize()` during config resolution. Plugin order in `vite.config.ts` is no longer load-bearing.

--- a/.changeset/sveltekit-warm-start-server-url.md
+++ b/.changeset/sveltekit-warm-start-server-url.md
@@ -1,5 +1,0 @@
----
-"jazz-tools": patch
----
-
-`jazzSvelteKit` now restarts the Vite dev server on warm starts too when `PUBLIC_JAZZ_SERVER_URL` was missing from SvelteKit's captured env. Previously the restart only fired on the first-ever cold start (when no `PUBLIC_JAZZ_APP_ID` was persisted yet). On every subsequent run, the local Jazz server was allocated on a fresh dynamic port and written to `process.env`, but SvelteKit's `config({ order: 'pre' })` hook had already captured env, so `$env/dynamic/public.PUBLIC_JAZZ_SERVER_URL` stayed `undefined` and apps could not reach the dev server. The restart is now triggered whenever either `PUBLIC_JAZZ_APP_ID` or `PUBLIC_JAZZ_SERVER_URL` was missing from `process.env` before initialisation; `process.env` survives the restart and `runtime.initialize()` is idempotent, so the post-restart pass reuses the in-flight Jazz server with no reallocation.

--- a/.changeset/sveltekit-warm-start-server-url.md
+++ b/.changeset/sveltekit-warm-start-server-url.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+`jazzSvelteKit` now restarts the Vite dev server on warm starts too when `PUBLIC_JAZZ_SERVER_URL` was missing from SvelteKit's captured env. Previously the restart only fired on the first-ever cold start (when no `PUBLIC_JAZZ_APP_ID` was persisted yet). On every subsequent run, the local Jazz server was allocated on a fresh dynamic port and written to `process.env`, but SvelteKit's `config({ order: 'pre' })` hook had already captured env, so `$env/dynamic/public.PUBLIC_JAZZ_SERVER_URL` stayed `undefined` and apps could not reach the dev server. The restart is now triggered whenever either `PUBLIC_JAZZ_APP_ID` or `PUBLIC_JAZZ_SERVER_URL` was missing from `process.env` before initialisation; `process.env` survives the restart and `runtime.initialize()` is idempotent, so the post-restart pass reuses the in-flight Jazz server with no reallocation.

--- a/docs/content/docs/auth/lifecycle.mdx
+++ b/docs/content/docs/auth/lifecycle.mdx
@@ -115,13 +115,14 @@ proof-token flow.
 
 ## Related APIs
 
-| API                               | Use it for                                                       |
-| --------------------------------- | ---------------------------------------------------------------- |
-| `BrowserAuthSecretStore`          | Browser local-first secret storage                               |
-| `ExpoAuthSecretStore`             | Expo secure local-first secret storage                           |
-| `useLocalFirstAuth()`             | React/Expo hook for loading, replacing, and clearing the secret  |
-| `db.updateAuthToken(jwt)`         | Refreshing a bearer JWT for the same principal                   |
-| `db.updateCookieSession(session)` | Updating a mirrored cookie-backed session for the same principal |
-| `db.logout()`                     | Shutting down a client during logout or principal switch         |
-| `db.logout({ wipeData: true })`   | Logout plus browser OPFS database wipe                           |
-| `db.deleteClientStorage()`        | Development-only browser OPFS storage reset                      |
+| API                               | Use it for                                                            |
+| --------------------------------- | --------------------------------------------------------------------- |
+| `BrowserAuthSecretStore`          | Browser local-first secret storage                                    |
+| `ExpoAuthSecretStore`             | Expo secure local-first secret storage                                |
+| `useLocalFirstAuth()`             | React/Expo hook for loading, replacing, and clearing the secret       |
+| `LocalFirstAuth`                  | Svelte reactive class for loading, replacing, and clearing the secret |
+| `db.updateAuthToken(jwt)`         | Refreshing a bearer JWT for the same principal                        |
+| `db.updateCookieSession(session)` | Updating a mirrored cookie-backed session for the same principal      |
+| `db.logout()`                     | Shutting down a client during logout or principal switch              |
+| `db.logout({ wipeData: true })`   | Logout plus browser OPFS database wipe                                |
+| `db.deleteClientStorage()`        | Development-only browser OPFS storage reset                           |

--- a/docs/content/docs/auth/lifecycle.mdx
+++ b/docs/content/docs/auth/lifecycle.mdx
@@ -115,14 +115,14 @@ proof-token flow.
 
 ## Related APIs
 
-| API                               | Use it for                                                            |
-| --------------------------------- | --------------------------------------------------------------------- |
-| `BrowserAuthSecretStore`          | Browser local-first secret storage                                    |
-| `ExpoAuthSecretStore`             | Expo secure local-first secret storage                                |
-| `useLocalFirstAuth()`             | React/Expo hook for loading, replacing, and clearing the secret       |
-| `LocalFirstAuth`                  | Svelte reactive class for loading, replacing, and clearing the secret |
-| `db.updateAuthToken(jwt)`         | Refreshing a bearer JWT for the same principal                        |
-| `db.updateCookieSession(session)` | Updating a mirrored cookie-backed session for the same principal      |
-| `db.logout()`                     | Shutting down a client during logout or principal switch              |
-| `db.logout({ wipeData: true })`   | Logout plus browser OPFS database wipe                                |
-| `db.deleteClientStorage()`        | Development-only browser OPFS storage reset                           |
+| API                               | Use it for                                                                           |
+| --------------------------------- | ------------------------------------------------------------------------------------ |
+| `BrowserAuthSecretStore`          | Browser local-first secret storage                                                   |
+| `ExpoAuthSecretStore`             | Expo secure local-first secret storage                                               |
+| `useLocalFirstAuth()`             | React/Expo hook (and Vue composable) for loading, replacing, and clearing the secret |
+| `LocalFirstAuth`                  | Svelte reactive class for loading, replacing, and clearing the secret                |
+| `db.updateAuthToken(jwt)`         | Refreshing a bearer JWT for the same principal                                       |
+| `db.updateCookieSession(session)` | Updating a mirrored cookie-backed session for the same principal                     |
+| `db.logout()`                     | Shutting down a client during logout or principal switch                             |
+| `db.logout({ wipeData: true })`   | Logout plus browser OPFS database wipe                                               |
+| `db.deleteClientStorage()`        | Development-only browser OPFS storage reset                                          |

--- a/docs/content/docs/auth/local-first-auth.mdx
+++ b/docs/content/docs/auth/local-first-auth.mdx
@@ -50,6 +50,8 @@ Fetch or create a secret and pass it to your Jazz client. Jazz stores the secret
     <include cwd lang="svelte" meta='title="App.svelte"'>
       ../examples/docs/todo-client-localfirst-svelte/src/AuthLocalfirst.svelte#auth-localfirst-svelte
     </include>
+    `LocalFirstAuth` from `jazz-tools/svelte` also exposes `login` and `signOut` for switching or
+    clearing accounts.
   </Tab>
   <Tab value="TypeScript">
     <include cwd lang="ts" meta='title="jazz-client.ts"'>
@@ -154,9 +156,11 @@ The parser is case-insensitive and tolerant of extra whitespace between words. I
 `invalid-checksum`.
 
 <Callout type="info">
-  In React and Expo, `useLocalFirstAuth().login()` updates the mounted `JazzProvider` immediately.
-  Other frameworks use `BrowserAuthSecretStore.saveSecret()` directly, which doesn't notify the live
-  client — the snippets above reload the page so the new secret is picked up on the next load.
+  In React, Expo, and Svelte, calling `login()` on the local-first auth handle
+  (`useLocalFirstAuth()` in React/Expo, `LocalFirstAuth` in Svelte) updates the mounted provider
+  immediately. Other frameworks use `BrowserAuthSecretStore.saveSecret()` directly, which doesn't
+  notify the live client — the snippets above reload the page so the new secret is picked up on the
+  next load.
 </Callout>
 
 ### Passkey backup

--- a/docs/content/docs/auth/local-first-auth.mdx
+++ b/docs/content/docs/auth/local-first-auth.mdx
@@ -156,11 +156,10 @@ The parser is case-insensitive and tolerant of extra whitespace between words. I
 `invalid-checksum`.
 
 <Callout type="info">
-  In React, Expo, and Svelte, calling `login()` on the local-first auth handle
-  (`useLocalFirstAuth()` in React/Expo, `LocalFirstAuth` in Svelte) updates the mounted provider
-  immediately. Other frameworks use `BrowserAuthSecretStore.saveSecret()` directly, which doesn't
-  notify the live client — the snippets above reload the page so the new secret is picked up on the
-  next load.
+  Calling `login()` on the framework-specific local-first auth handle (`useLocalFirstAuth()` in
+  React/Expo/Vue, `LocalFirstAuth` in Svelte) updates the mounted provider immediately. Plain
+  TypeScript uses `BrowserAuthSecretStore.saveSecret()` directly, which doesn't notify the live
+  client — the snippets above reload the page so the new secret is picked up on the next load.
 </Callout>
 
 ### Passkey backup

--- a/docs/content/docs/getting-started/client-setup.mdx
+++ b/docs/content/docs/getting-started/client-setup.mdx
@@ -51,30 +51,11 @@ Every client needs an `appId` and a `secret` for [local-first auth](/docs/auth/l
 
   </Tab>
   <Tab value="Svelte">
-    ```svelte title="App.svelte"
-    <script lang="ts">
-      import {
-        createJazzClient,
-        JazzSvelteProvider,
-        BrowserAuthSecretStore,
-      } from 'jazz-tools/svelte';
-      import TodoList from './TodoList.svelte';
+    <include cwd lang="svelte" meta='title="App.svelte"'>
+      ../examples/docs/todo-client-localfirst-svelte/src/AuthLocalfirst.svelte#auth-localfirst-svelte
+    </include>
 
-      const client = BrowserAuthSecretStore.getOrCreateSecret().then(
-        (secret) => createJazzClient({ appId: '<your-app-id>', secret })
-      );
-    </script>
-
-    <JazzSvelteProvider {client}>
-      {#snippet children()}
-        <h1>Todos</h1>
-        <TodoList />
-      {/snippet}
-      {#snippet fallback()}
-        <p>Loading...</p>
-      {/snippet}
-    </JazzSvelteProvider>
-    ```
+    `LocalFirstAuth` from `jazz-tools/svelte` loads the device secret (or generates one on first run) and exposes `login` / `signOut` for switching identity.
 
   </Tab>
   <Tab value="Expo">

--- a/docs/content/docs/getting-started/client-setup.mdx
+++ b/docs/content/docs/getting-started/client-setup.mdx
@@ -27,27 +27,11 @@ Every client needs an `appId` and a `secret` for [local-first auth](/docs/auth/l
 
   </Tab>
   <Tab value="Vue">
-    ```vue title="App.vue"
-    <script setup lang="ts">
-    import { createJazzClient, JazzProvider } from "jazz-tools/vue";
-    import { BrowserAuthSecretStore } from "jazz-tools";
-    import TodoList from "./TodoList.vue";
+    <include cwd lang="vue" meta='title="App.vue"'>
+      ../examples/docs/todo-client-localfirst-vue/src/AuthLocalfirst.vue
+    </include>
 
-    const secret = await BrowserAuthSecretStore.getOrCreateSecret();
-
-    const client = await createJazzClient({
-      appId: "<your-app-id>",
-      secret,
-    });
-    </script>
-
-    <template>
-      <JazzProvider :client="client">
-        <h1>Todos</h1>
-        <TodoList />
-      </JazzProvider>
-    </template>
-    ```
+    `useLocalFirstAuth()` from `jazz-tools/vue` loads the device secret (or generates one on first run) and exposes `login` / `signOut` for switching identity.
 
   </Tab>
   <Tab value="Svelte">

--- a/examples/docs/todo-client-localfirst-svelte/src/AuthLocalfirst.svelte
+++ b/examples/docs/todo-client-localfirst-svelte/src/AuthLocalfirst.svelte
@@ -1,16 +1,26 @@
 <!-- #region auth-localfirst-svelte -->
 <script lang="ts">
-  import { BrowserAuthSecretStore, createJazzClient, JazzSvelteProvider } from 'jazz-tools/svelte';
+  import {
+    LocalFirstAuth,
+    createJazzClient,
+    JazzSvelteProvider,
+  } from 'jazz-tools/svelte';
   import type { Snippet } from 'svelte';
 
   let { children }: { children: Snippet } = $props();
 
-  const client = BrowserAuthSecretStore.getOrCreateSecret().then((secret) =>
-    createJazzClient({ appId: 'my-app', secret }),
+  const auth = new LocalFirstAuth();
+
+  let client = $derived(
+    !auth.isLoading && auth.secret
+      ? createJazzClient({ appId: 'my-app', secret: auth.secret })
+      : null,
   );
 </script>
 
-<JazzSvelteProvider {client}>
-  {@render children()}
-</JazzSvelteProvider>
+{#if client}
+  <JazzSvelteProvider {client}>
+    {@render children()}
+  </JazzSvelteProvider>
+{/if}
 <!-- #endregion auth-localfirst-svelte -->

--- a/examples/docs/todo-client-localfirst-svelte/src/auth-snippets.svelte.ts
+++ b/examples/docs/todo-client-localfirst-svelte/src/auth-snippets.svelte.ts
@@ -1,36 +1,26 @@
-import { onMount } from "svelte";
-import { BrowserAuthSecretStore } from "jazz-tools/svelte";
+import { LocalFirstAuth } from "jazz-tools/svelte";
 import { RecoveryPhrase } from "jazz-tools/passphrase";
 import { BrowserPasskeyBackup } from "jazz-tools/passkey-backup";
 
 // #region auth-localfirst-svelte-backup
-export function createRecoveryPhraseBackup() {
-  let isLoading = $state(true);
-  let recoveryPhrase = $state<string | null>(null);
-
-  onMount(async () => {
-    const secret = await BrowserAuthSecretStore.loadSecret();
-    recoveryPhrase = secret ? RecoveryPhrase.fromSecret(secret) : null;
-    isLoading = false;
-  });
-
+export function createRecoveryPhraseBackup(auth: LocalFirstAuth) {
   return {
     get isLoading() {
-      return isLoading;
+      return auth.isLoading;
     },
     get recoveryPhrase() {
-      return recoveryPhrase;
+      return auth.secret ? RecoveryPhrase.fromSecret(auth.secret) : null;
     },
   };
 }
 // #endregion auth-localfirst-svelte-backup
 
 // #region auth-localfirst-svelte-restore
-export async function restoreFromRecoveryPhrase(userInput: string) {
-  const restoredSecret = RecoveryPhrase.toSecret(userInput);
-  await BrowserAuthSecretStore.saveSecret(restoredSecret);
-  // Reload so the mounted JazzSvelteProvider picks up the restored secret.
-  location.reload();
+export function createRecoveryPhraseRestore(auth: LocalFirstAuth) {
+  return async (userInput: string) => {
+    const restoredSecret = RecoveryPhrase.toSecret(userInput);
+    await auth.login(restoredSecret);
+  };
 }
 // #endregion auth-localfirst-svelte-restore
 
@@ -42,17 +32,19 @@ const passkeyBackup = new BrowserPasskeyBackup({
   appHostname: "myapp.com",
 });
 
-export async function backupToPasskey(displayName: string) {
-  const secret = await BrowserAuthSecretStore.loadSecret();
-  if (!secret) throw new Error("No local secret to back up yet");
-  await passkeyBackup.backup(secret, displayName);
+export function createPasskeyBackup(auth: LocalFirstAuth) {
+  return async (displayName: string) => {
+    if (!auth.secret) throw new Error("No local secret to back up yet");
+    await passkeyBackup.backup(auth.secret, displayName);
+  };
 }
 // #endregion auth-localfirst-svelte-passkey-backup
 
 // #region auth-localfirst-svelte-passkey-restore
-export async function restoreFromPasskey() {
-  const restoredSecret = await passkeyBackup.restore();
-  await BrowserAuthSecretStore.saveSecret(restoredSecret);
-  location.reload();
+export function createPasskeyRestore(auth: LocalFirstAuth) {
+  return async () => {
+    const restoredSecret = await passkeyBackup.restore();
+    await auth.login(restoredSecret);
+  };
 }
 // #endregion auth-localfirst-svelte-passkey-restore

--- a/examples/docs/todo-client-localfirst-vue/src/AuthLocalfirst.vue
+++ b/examples/docs/todo-client-localfirst-vue/src/AuthLocalfirst.vue
@@ -1,17 +1,14 @@
 <script setup lang="ts">
-import { ref, onMounted } from "vue";
-import { createJazzClient, JazzProvider } from "jazz-tools/vue";
-import { BrowserAuthSecretStore } from "jazz-tools";
+import { computed } from "vue";
+import { createJazzClient, JazzProvider, useLocalFirstAuth } from "jazz-tools/vue";
 
-const client = ref<ReturnType<typeof createJazzClient> | null>(null);
+const { secret, isLoading } = useLocalFirstAuth();
 
-onMounted(async () => {
-  const secret = await BrowserAuthSecretStore.getOrCreateSecret();
-  client.value = createJazzClient({
-    appId: "my-app",
-    secret,
-  });
-});
+const client = computed(() =>
+  !isLoading.value && secret.value
+    ? createJazzClient({ appId: "my-app", secret: secret.value })
+    : null,
+);
 </script>
 
 <template>

--- a/examples/docs/todo-client-localfirst-vue/src/auth-snippets.ts
+++ b/examples/docs/todo-client-localfirst-vue/src/auth-snippets.ts
@@ -1,30 +1,24 @@
-import { ref, onMounted } from "vue";
-import { BrowserAuthSecretStore } from "jazz-tools";
+import { computed } from "vue";
+import { useLocalFirstAuth } from "jazz-tools/vue";
 import { RecoveryPhrase } from "jazz-tools/passphrase";
 import { BrowserPasskeyBackup } from "jazz-tools/passkey-backup";
 
 // #region auth-localfirst-vue-backup
 export function useRecoveryPhraseBackup() {
-  const isLoading = ref(true);
-  const recoveryPhrase = ref<string | null>(null);
-
-  onMounted(async () => {
-    const secret = await BrowserAuthSecretStore.loadSecret();
-    recoveryPhrase.value = secret ? RecoveryPhrase.fromSecret(secret) : null;
-    isLoading.value = false;
-  });
-
+  const { secret, isLoading } = useLocalFirstAuth();
+  const recoveryPhrase = computed(() =>
+    secret.value ? RecoveryPhrase.fromSecret(secret.value) : null,
+  );
   return { isLoading, recoveryPhrase };
 }
 // #endregion auth-localfirst-vue-backup
 
 // #region auth-localfirst-vue-restore
 export function useRecoveryPhraseRestore() {
+  const { login } = useLocalFirstAuth();
   return async (userInput: string) => {
     const restoredSecret = RecoveryPhrase.toSecret(userInput);
-    await BrowserAuthSecretStore.saveSecret(restoredSecret);
-    // Reload so the mounted JazzProvider picks up the restored secret.
-    location.reload();
+    await login(restoredSecret);
   };
 }
 // #endregion auth-localfirst-vue-restore
@@ -38,20 +32,20 @@ const passkeyBackup = new BrowserPasskeyBackup({
 });
 
 export function usePasskeyBackup() {
+  const { secret } = useLocalFirstAuth();
   return async (displayName: string) => {
-    const secret = await BrowserAuthSecretStore.loadSecret();
-    if (!secret) throw new Error("No local secret to back up yet");
-    await passkeyBackup.backup(secret, displayName);
+    if (!secret.value) throw new Error("No local secret to back up yet");
+    await passkeyBackup.backup(secret.value, displayName);
   };
 }
 // #endregion auth-localfirst-vue-passkey-backup
 
 // #region auth-localfirst-vue-passkey-restore
 export function usePasskeyRestore() {
+  const { login } = useLocalFirstAuth();
   return async () => {
     const restoredSecret = await passkeyBackup.restore();
-    await BrowserAuthSecretStore.saveSecret(restoredSecret);
-    location.reload();
+    await login(restoredSecret);
   };
 }
 // #endregion auth-localfirst-vue-passkey-restore

--- a/packages/jazz-tools/src/dev/sveltekit.test.ts
+++ b/packages/jazz-tools/src/dev/sveltekit.test.ts
@@ -161,7 +161,11 @@ describe("jazzSvelteKit", () => {
     expect(viteServer.restart).toHaveBeenCalledTimes(1);
   }, 30_000);
 
-  it("does not restart when appId is already persisted in .env (warm start)", async () => {
+  it("restarts on a warm start so SvelteKit's $env captures the freshly allocated server URL", async () => {
+    // .env persists PUBLIC_JAZZ_APP_ID across runs, but the local Jazz server
+    // port is dynamic per run and never persisted. SvelteKit captures env
+    // before configureServer fires, so a warm start sees APP_ID but not the
+    // fresh SERVER_URL until we restart.
     const persistedAppId = "00000000-0000-0000-0000-000000000099";
     vi.spyOn(devServer, "startLocalJazzServer").mockResolvedValue({
       appId: persistedAppId,
@@ -178,6 +182,65 @@ describe("jazzSvelteKit", () => {
 
     const plugin = jazzSvelteKit({
       server: { port: 19990, adminSecret: "warm-start-admin" },
+    });
+    const viteServer = makeViteServer("serve", root);
+    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(viteServer);
+
+    expect(viteServer.restart).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not restart when both PUBLIC_JAZZ_* vars are already in process.env (post-restart pass)", async () => {
+    // process.env survives Vite restarts within the same Node process, so on
+    // the post-restart pass both APP_ID and SERVER_URL are populated and
+    // SvelteKit's captured env has them — no further restart needed.
+    const persistedAppId = "00000000-0000-0000-0000-000000000098";
+    process.env.PUBLIC_JAZZ_APP_ID = persistedAppId;
+    process.env.PUBLIC_JAZZ_SERVER_URL = "http://127.0.0.1:19991";
+
+    vi.spyOn(devServer, "startLocalJazzServer").mockResolvedValue({
+      appId: persistedAppId,
+      port: 19991,
+      url: "http://127.0.0.1:19991",
+      dataDir: undefined as unknown as string,
+      stop: vi.fn().mockResolvedValue(undefined),
+    });
+    vi.spyOn(devServer, "pushSchemaCatalogue").mockResolvedValue({ hash: "abc" });
+    vi.spyOn(schemaWatcher, "watchSchema").mockReturnValue({ close: vi.fn() });
+
+    const root = await tempRoots.create("jazz-sveltekit-post-restart-");
+    await writeFile(join(root, ".env"), `PUBLIC_JAZZ_APP_ID=${persistedAppId}\n`);
+
+    const plugin = jazzSvelteKit({
+      server: { port: 19991, adminSecret: "post-restart-admin" },
+    });
+    const viteServer = makeViteServer("serve", root);
+    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(viteServer);
+
+    expect(viteServer.restart).not.toHaveBeenCalled();
+  });
+
+  it("treats explicitly-empty PUBLIC_JAZZ_* env vars as set (no restart loop)", async () => {
+    // If a user has `PUBLIC_JAZZ_APP_ID=""` (deliberately empty) in their env,
+    // Vite's captured env has the key set to "" — not missing. Restarting
+    // wouldn't help: managed-runtime would write the empty value back to
+    // process.env post-restart and the next pass would loop. Only restart
+    // when the var was genuinely never set (=== undefined).
+    process.env.PUBLIC_JAZZ_APP_ID = "";
+    process.env.PUBLIC_JAZZ_SERVER_URL = "";
+
+    vi.spyOn(devServer, "startLocalJazzServer").mockResolvedValue({
+      appId: "00000000-0000-0000-0000-000000000097",
+      port: 19992,
+      url: "http://127.0.0.1:19992",
+      dataDir: undefined as unknown as string,
+      stop: vi.fn().mockResolvedValue(undefined),
+    });
+    vi.spyOn(devServer, "pushSchemaCatalogue").mockResolvedValue({ hash: "abc" });
+    vi.spyOn(schemaWatcher, "watchSchema").mockReturnValue({ close: vi.fn() });
+
+    const root = await tempRoots.create("jazz-sveltekit-empty-env-");
+    const plugin = jazzSvelteKit({
+      server: { port: 19992, adminSecret: "empty-env-admin" },
     });
     const viteServer = makeViteServer("serve", root);
     await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(viteServer);

--- a/packages/jazz-tools/src/dev/sveltekit.test.ts
+++ b/packages/jazz-tools/src/dev/sveltekit.test.ts
@@ -77,12 +77,16 @@ afterEach(async () => {
 describe("jazzSvelteKit", () => {
   it("config hook accepts both Vite ssr.external shapes (true and string[])", () => {
     const plugin = jazzSvelteKit();
+    // Without a serve ConfigEnv the hook returns the merged config synchronously
+    // (the async runtime path only runs for `command: "serve"`).
+    const runConfig = (c: Record<string, unknown>) =>
+      plugin.config(c) as { ssr: { external: true | string[] } };
 
-    const arrayResult = plugin.config({ ssr: { external: ["other-pkg"] } });
+    const arrayResult = runConfig({ ssr: { external: ["other-pkg"] } });
     expect(arrayResult.ssr.external).toContain("jazz-napi");
     expect(arrayResult.ssr.external).toContain("other-pkg");
 
-    const externaliseAll = plugin.config({ ssr: { external: true } });
+    const externaliseAll = runConfig({ ssr: { external: true } });
     expect(externaliseAll.ssr.external).toBe(true);
   });
 
@@ -146,26 +150,11 @@ describe("jazzSvelteKit", () => {
     expect(logSpy).toHaveBeenCalledWith("[jazz] telemetry collector: http://127.0.0.1:54418");
   });
 
-  it("restarts the dev server on first-ever cold start so SvelteKit's $env capture sees the freshly allocated appId", async () => {
-    const port = await getAvailablePort();
-    const root = await tempRoots.create("jazz-sveltekit-cold-start-");
-    await mkdir(join(root, "src", "lib"), { recursive: true });
-    await writeFile(join(root, "src", "lib", "schema.ts"), todoSchema());
+  it("is enforce:'pre' so its config hook precedes SvelteKit's env capture", () => {
+    expect(jazzSvelteKit().enforce).toBe("pre");
+  });
 
-    const plugin = jazzSvelteKit({
-      server: { port, adminSecret: "cold-start-admin" },
-    });
-    const viteServer = makeViteServer("serve", root);
-    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(viteServer);
-
-    expect(viteServer.restart).toHaveBeenCalledTimes(1);
-  }, 30_000);
-
-  it("restarts on a warm start so SvelteKit's $env captures the freshly allocated server URL", async () => {
-    // .env persists PUBLIC_JAZZ_APP_ID across runs, but the local Jazz server
-    // port is dynamic per run and never persisted. SvelteKit captures env
-    // before configureServer fires, so a warm start sees APP_ID but not the
-    // fresh SERVER_URL until we restart.
+  it("config hook populates process.env with PUBLIC_JAZZ_* before SvelteKit captures env", async () => {
     const persistedAppId = "00000000-0000-0000-0000-000000000099";
     vi.spyOn(devServer, "startLocalJazzServer").mockResolvedValue({
       appId: persistedAppId,
@@ -177,28 +166,31 @@ describe("jazzSvelteKit", () => {
     vi.spyOn(devServer, "pushSchemaCatalogue").mockResolvedValue({ hash: "abc" });
     vi.spyOn(schemaWatcher, "watchSchema").mockReturnValue({ close: vi.fn() });
 
-    const root = await tempRoots.create("jazz-sveltekit-warm-start-");
-    await writeFile(join(root, ".env"), `PUBLIC_JAZZ_APP_ID=${persistedAppId}\n`);
-
+    const root = await tempRoots.create("jazz-sveltekit-config-hook-");
     const plugin = jazzSvelteKit({
-      server: { port: 19990, adminSecret: "warm-start-admin" },
+      appId: persistedAppId,
+      server: { port: 19990, adminSecret: "config-hook-admin" },
     });
-    const viteServer = makeViteServer("serve", root);
-    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(viteServer);
 
-    expect(viteServer.restart).toHaveBeenCalledTimes(1);
+    const config = plugin.config as (
+      c: Record<string, unknown>,
+      e?: { command: "serve" | "build"; mode?: string },
+    ) => unknown;
+    const merged = (await config({ root }, { command: "serve", mode: "development" })) as {
+      ssr?: { external?: string[] };
+    };
+
+    // The merged Vite config is still returned for Vite to consume.
+    expect(merged.ssr?.external).toContain("jazz-napi");
+    // …and the env is populated by the time the config hook resolves, so
+    // SvelteKit's later config({order:'pre'}) capture sees it on the first pass.
+    expect(process.env.PUBLIC_JAZZ_APP_ID).toBe(persistedAppId);
+    expect(process.env.PUBLIC_JAZZ_SERVER_URL).toBe("http://127.0.0.1:19990");
   });
 
-  it("does not restart when both PUBLIC_JAZZ_* vars are already in process.env (post-restart pass)", async () => {
-    // process.env survives Vite restarts within the same Node process, so on
-    // the post-restart pass both APP_ID and SERVER_URL are populated and
-    // SvelteKit's captured env has them — no further restart needed.
-    const persistedAppId = "00000000-0000-0000-0000-000000000098";
-    process.env.PUBLIC_JAZZ_APP_ID = persistedAppId;
-    process.env.PUBLIC_JAZZ_SERVER_URL = "http://127.0.0.1:19991";
-
+  it("never restarts the dev server (env is injected in the config hook instead)", async () => {
     vi.spyOn(devServer, "startLocalJazzServer").mockResolvedValue({
-      appId: persistedAppId,
+      appId: "00000000-0000-0000-0000-000000000098",
       port: 19991,
       url: "http://127.0.0.1:19991",
       dataDir: undefined as unknown as string,
@@ -207,45 +199,21 @@ describe("jazzSvelteKit", () => {
     vi.spyOn(devServer, "pushSchemaCatalogue").mockResolvedValue({ hash: "abc" });
     vi.spyOn(schemaWatcher, "watchSchema").mockReturnValue({ close: vi.fn() });
 
-    const root = await tempRoots.create("jazz-sveltekit-post-restart-");
-    await writeFile(join(root, ".env"), `PUBLIC_JAZZ_APP_ID=${persistedAppId}\n`);
-
+    const root = await tempRoots.create("jazz-sveltekit-no-restart-");
     const plugin = jazzSvelteKit({
-      server: { port: 19991, adminSecret: "post-restart-admin" },
+      server: { port: 19991, adminSecret: "no-restart-admin" },
     });
+    const config = plugin.config as (
+      c: Record<string, unknown>,
+      e?: { command: "serve" | "build"; mode?: string },
+    ) => unknown;
+    await config({ root }, { command: "serve", mode: "development" });
+
     const viteServer = makeViteServer("serve", root);
     await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(viteServer);
 
     expect(viteServer.restart).not.toHaveBeenCalled();
-  });
-
-  it("treats explicitly-empty PUBLIC_JAZZ_* env vars as set (no restart loop)", async () => {
-    // If a user has `PUBLIC_JAZZ_APP_ID=""` (deliberately empty) in their env,
-    // Vite's captured env has the key set to "" — not missing. Restarting
-    // wouldn't help: managed-runtime would write the empty value back to
-    // process.env post-restart and the next pass would loop. Only restart
-    // when the var was genuinely never set (=== undefined).
-    process.env.PUBLIC_JAZZ_APP_ID = "";
-    process.env.PUBLIC_JAZZ_SERVER_URL = "";
-
-    vi.spyOn(devServer, "startLocalJazzServer").mockResolvedValue({
-      appId: "00000000-0000-0000-0000-000000000097",
-      port: 19992,
-      url: "http://127.0.0.1:19992",
-      dataDir: undefined as unknown as string,
-      stop: vi.fn().mockResolvedValue(undefined),
-    });
-    vi.spyOn(devServer, "pushSchemaCatalogue").mockResolvedValue({ hash: "abc" });
-    vi.spyOn(schemaWatcher, "watchSchema").mockReturnValue({ close: vi.fn() });
-
-    const root = await tempRoots.create("jazz-sveltekit-empty-env-");
-    const plugin = jazzSvelteKit({
-      server: { port: 19992, adminSecret: "empty-env-admin" },
-    });
-    const viteServer = makeViteServer("serve", root);
-    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(viteServer);
-
-    expect(viteServer.restart).not.toHaveBeenCalled();
+    expect(viteServer.config.env!.PUBLIC_JAZZ_SERVER_URL).toBe("http://127.0.0.1:19991");
   });
 
   it("does not start a server during build", async () => {

--- a/packages/jazz-tools/src/dev/sveltekit.ts
+++ b/packages/jazz-tools/src/dev/sveltekit.ts
@@ -1,6 +1,6 @@
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { loadEnvFileIntoProcessEnv } from "./env-file.js";
-import { ManagedDevRuntime } from "./managed-runtime.js";
+import { ManagedDevRuntime, type ManagedRuntime } from "./managed-runtime.js";
 import { resolveJazzWasmEntry } from "./vite.js";
 import type {
   JazzServerOptions as BaseJazzServerOptions,
@@ -23,8 +23,25 @@ export interface JazzPluginOptions extends Omit<BaseJazzPluginOptions, "server">
   server?: boolean | string | JazzServerOptions;
 }
 
-function resolveViteOrigin(viteServer: ViteDevServer): string {
-  const server = viteServer.config.server;
+interface ViteServerConfigLike {
+  port?: number;
+  host?: string | boolean;
+  https?: unknown;
+}
+
+interface ViteUserConfigLike {
+  root?: string;
+  server?: ViteServerConfigLike;
+  ssr?: { external?: true | string[] };
+  optimizeDeps?: { exclude?: string[] };
+}
+
+interface ViteConfigEnvLike {
+  command: "build" | "serve";
+  mode?: string;
+}
+
+function resolveOrigin(server: ViteServerConfigLike | undefined): string {
   const port = server?.port ?? 5173;
   const hostOpt = server?.host;
   // Vite's `server.host` accepts boolean (true = listen on all, undefined/false
@@ -42,96 +59,110 @@ const runtime = new ManagedDevRuntime({
 });
 
 export function jazzSvelteKit(options: JazzPluginOptions = {}) {
+  // Set once configureServer runs. The schema watcher's reload/error callbacks
+  // read it lazily: the runtime is started in the `config` hook (before any
+  // dev server exists), but watch pushes only fire later, by which point this
+  // is populated. Initial-push callbacks during `config` see `null` and no-op,
+  // which is correct — there's no browser to reload yet.
+  let viteServerRef: ViteDevServer | null = null;
+  let managed: ManagedRuntime | null = null;
+
+  function buildMergedConfig(config: ViteUserConfigLike) {
+    const existingSsr = config.ssr?.external;
+    const existingExclude = config.optimizeDeps?.exclude ?? [];
+    const jazzWasmEntry = resolveJazzWasmEntry();
+    // `ssr.external: true` means "externalize everything", so jazz-napi is
+    // already covered — preserve the bool rather than coercing to an array.
+    const ssrExternal: true | string[] =
+      existingSsr === true ? true : Array.from(new Set([...(existingSsr ?? []), "jazz-napi"]));
+    return {
+      worker: { format: "es" as const },
+      optimizeDeps: {
+        exclude: Array.from(new Set([...existingExclude, "jazz-wasm"])),
+      },
+      ssr: { external: ssrExternal },
+      ...(jazzWasmEntry
+        ? { resolve: { alias: [{ find: /^jazz-wasm$/, replacement: jazzWasmEntry }] } }
+        : {}),
+    };
+  }
+
+  function buildInitOptions(serverConfig: ViteServerConfigLike | undefined, root: string) {
+    const schemaDir = options.schemaDir ?? join(root, "src", "lib");
+    const serverOpt = options.server ?? true;
+
+    // Extract backendSecret from the server config object (SvelteKit-only option).
+    const serverConfigObj: JazzServerOptions =
+      typeof serverOpt === "object" && serverOpt !== null ? serverOpt : {};
+    const backendSecret = serverConfigObj.backendSecret ?? process.env.BACKEND_SECRET;
+
+    return {
+      server: resolveServerWithJwks(serverOpt, serverConfig),
+      schemaDir,
+      envDir: root,
+      adminSecret: options.adminSecret,
+      appId: options.appId,
+      telemetry: options.telemetry,
+      backendSecret,
+      onSchemaError: (error: Error) => {
+        viteServerRef?.ws.send({
+          type: "error",
+          err: {
+            message: `${LOG_PREFIX} schema push failed: ${error.message}`,
+            stack: error.stack,
+          },
+        });
+      },
+      onSchemaPush: () => {
+        viteServerRef?.ws.send({ type: "full-reload" });
+      },
+    };
+  }
+
+  // Start the managed runtime and populate process.env exactly once. Called
+  // from the `config` hook in real usage (so SvelteKit's later env capture
+  // sees the vars on the first pass — no restart needed); also reachable from
+  // configureServer for direct/programmatic callers that never run `config`.
+  // runtime.initialize() is idempotent, but we additionally cache here so a
+  // second caller does not re-run the env-file backfill or re-resolve jwks.
+  async function ensureInitialised(
+    serverConfig: ViteServerConfigLike | undefined,
+    root: string,
+  ): Promise<ManagedRuntime> {
+    if (managed) return managed;
+    loadEnvFileIntoProcessEnv(root);
+    managed = await runtime.initialize(buildInitOptions(serverConfig, root));
+    return managed;
+  }
+
   return {
     name: "jazz-sveltekit",
+    // `enforce: "pre"` puts this plugin's `config` hook in Vite's pre bucket,
+    // which runs before SvelteKit's `vite-plugin-sveltekit-setup` (a normal-
+    // bucket plugin whose `config({order:'pre'})` hook captures env via
+    // loadEnv into the static `$env/dynamic/public` module). Vite awaits each
+    // config hook in order, so by the time SvelteKit captures env, the runtime
+    // has started and PUBLIC_JAZZ_* are in process.env — first paint is
+    // correct with no dev-server restart. Mirrors how the Next plugin awaits
+    // runtime.initialize() inside the next-config factory.
+    enforce: "pre" as const,
 
-    config(config: {
-      ssr?: { external?: true | string[] };
-      optimizeDeps?: { exclude?: string[] };
-    }) {
-      const existingSsr = config.ssr?.external;
-      const existingExclude = config.optimizeDeps?.exclude ?? [];
-      const jazzWasmEntry = resolveJazzWasmEntry();
-      // `ssr.external: true` means "externalize everything", so jazz-napi is
-      // already covered — preserve the bool rather than coercing to an array.
-      const ssrExternal: true | string[] =
-        existingSsr === true ? true : Array.from(new Set([...(existingSsr ?? []), "jazz-napi"]));
-      return {
-        worker: { format: "es" as const },
-        optimizeDeps: {
-          exclude: Array.from(new Set([...existingExclude, "jazz-wasm"])),
-        },
-        ssr: { external: ssrExternal },
-        ...(jazzWasmEntry
-          ? { resolve: { alias: [{ find: /^jazz-wasm$/, replacement: jazzWasmEntry }] } }
-          : {}),
-      };
+    config(config: ViteUserConfigLike, env?: ViteConfigEnvLike) {
+      const merged = buildMergedConfig(config);
+      if (env?.command !== "serve" || options.server === false) {
+        return merged;
+      }
+      const root = config.root ? resolve(config.root) : process.cwd();
+      return ensureInitialised(config.server, root).then(() => merged);
     },
 
     async configureServer(viteServer: ViteDevServer): Promise<void> {
+      viteServerRef = viteServer;
       if (viteServer.config.command !== "serve" || options.server === false) return;
 
-      // Vite (and SvelteKit-via-Vite) doesn't populate process.env from .env
-      // for unprefixed keys, so the managed runtime's env-driven cloud-mode check
-      // would otherwise never fire. Backfill before reading.
-      loadEnvFileIntoProcessEnv(viteServer.config.root);
-
-      // SvelteKit's vite-plugin captures env in its `config: { order: 'pre' }`
-      // hook, before configureServer ever runs. That capture sources from
-      // .env files plus process.env, so anything missing here is also missing
-      // from `$env/dynamic/public` at runtime. PUBLIC_JAZZ_APP_ID is missing
-      // on the first-ever run (no persisted .env yet). PUBLIC_JAZZ_SERVER_URL
-      // is missing every warm start — the port is allocated dynamically and
-      // is never persisted to .env. In either case we restart after the
-      // managed runtime populates process.env, so SvelteKit's config hook
-      // re-runs and the captured env picks up the fresh values. process.env
-      // survives the restart (same Node process) and runtime.initialize() is
-      // idempotent, so the restarted pass reuses the in-flight Jazz server.
-      //
-      // Strict `=== undefined` check: an explicitly empty string is a user
-      // assertion that the var has no value, and managed-runtime would write
-      // that empty back to process.env post-restart — looping forever.
-      const appIdMissingFromCapturedEnv = process.env.PUBLIC_JAZZ_APP_ID === undefined;
-      const serverUrlMissingFromCapturedEnv = process.env.PUBLIC_JAZZ_SERVER_URL === undefined;
-
-      const schemaDir = options.schemaDir ?? join(viteServer.config.root, "src", "lib");
-      const serverOpt = options.server ?? true;
-
-      // Extract backendSecret from the server config object (SvelteKit-only option).
-      const serverConfig: JazzServerOptions =
-        typeof serverOpt === "object" && serverOpt !== null ? serverOpt : {};
-      const backendSecret = serverConfig.backendSecret ?? process.env.BACKEND_SECRET;
-
-      // Pre-resolve jwksUrl from Vite's configured host/port when starting a
-      // local server. Precedence: explicit option → APP_ORIGIN env → Vite config
-      // → localhost:5173. Known limitation: Vite auto-port-increment means the
-      // configured port may differ from the actual one; set APP_ORIGIN explicitly
-      // to work around that.
-      const resolvedServer = resolveServerWithJwks(serverOpt, viteServer);
-
-      let managed;
+      let resolvedRuntime: ManagedRuntime;
       try {
-        managed = await runtime.initialize({
-          server: resolvedServer,
-          schemaDir,
-          envDir: viteServer.config.root,
-          adminSecret: options.adminSecret,
-          appId: options.appId,
-          telemetry: options.telemetry,
-          backendSecret,
-          onSchemaError: (error) => {
-            viteServer.ws.send({
-              type: "error",
-              err: {
-                message: `${LOG_PREFIX} schema push failed: ${error.message}`,
-                stack: error.stack,
-              },
-            });
-          },
-          onSchemaPush: () => {
-            viteServer.ws.send({ type: "full-reload" });
-          },
-        });
+        resolvedRuntime = await ensureInitialised(viteServer.config.server, viteServer.config.root);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         viteServer.ws.send({
@@ -145,20 +176,11 @@ export function jazzSvelteKit(options: JazzPluginOptions = {}) {
       }
 
       viteServer.config.env ??= {};
-      viteServer.config.env.PUBLIC_JAZZ_APP_ID = managed.appId;
-      viteServer.config.env.PUBLIC_JAZZ_SERVER_URL = managed.serverUrl;
-      if (managed.telemetryCollectorUrl) {
-        viteServer.config.env.PUBLIC_JAZZ_TELEMETRY_COLLECTOR_URL = managed.telemetryCollectorUrl;
-      }
-
-      if (
-        (appIdMissingFromCapturedEnv && managed.appId) ||
-        (serverUrlMissingFromCapturedEnv && managed.serverUrl)
-      ) {
-        console.log(
-          `${LOG_PREFIX} restarting dev server so SvelteKit's $env captures the populated PUBLIC_JAZZ_* vars`,
-        );
-        void viteServer.restart?.();
+      viteServer.config.env.PUBLIC_JAZZ_APP_ID = resolvedRuntime.appId;
+      viteServer.config.env.PUBLIC_JAZZ_SERVER_URL = resolvedRuntime.serverUrl;
+      if (resolvedRuntime.telemetryCollectorUrl) {
+        viteServer.config.env.PUBLIC_JAZZ_TELEMETRY_COLLECTOR_URL =
+          resolvedRuntime.telemetryCollectorUrl;
       }
     },
   };
@@ -170,18 +192,23 @@ export async function __resetJazzSvelteKitPluginForTests(): Promise<void> {
 
 function resolveServerWithJwks(
   serverOpt: JazzPluginOptions["server"] | true,
-  viteServer: ViteDevServer,
+  serverConfig: ViteServerConfigLike | undefined,
 ): BaseJazzPluginOptions["server"] {
   if (serverOpt === false || typeof serverOpt === "string") return serverOpt;
 
-  const serverConfig: JazzServerOptions =
+  const serverConfigObj: JazzServerOptions =
     typeof serverOpt === "object" && serverOpt !== null ? serverOpt : {};
 
-  if (serverConfig.jwksUrl !== undefined) return serverConfig as BaseJazzServerOptions;
+  if (serverConfigObj.jwksUrl !== undefined) return serverConfigObj as BaseJazzServerOptions;
 
-  const appOrigin = process.env.APP_ORIGIN ?? resolveViteOrigin(viteServer);
+  // Pre-resolve jwksUrl from the configured host/port when starting a local
+  // server. Precedence: explicit option → APP_ORIGIN env → Vite config →
+  // localhost:5173. Known limitation: Vite auto-port-increment means the
+  // configured port may differ from the actual one; set APP_ORIGIN explicitly
+  // to work around that.
+  const appOrigin = process.env.APP_ORIGIN ?? resolveOrigin(serverConfig);
   return {
-    ...serverConfig,
+    ...serverConfigObj,
     jwksUrl: `${appOrigin}/api/auth/jwks`,
   } as BaseJazzServerOptions;
 }

--- a/packages/jazz-tools/src/dev/sveltekit.ts
+++ b/packages/jazz-tools/src/dev/sveltekit.ts
@@ -77,11 +77,22 @@ export function jazzSvelteKit(options: JazzPluginOptions = {}) {
       loadEnvFileIntoProcessEnv(viteServer.config.root);
 
       // SvelteKit's vite-plugin captures env in its `config: { order: 'pre' }`
-      // hook, before configureServer ever runs. If this is the first-ever start
-      // (no persisted appId yet), SvelteKit's captured env is empty when we
-      // allocate one below. Trigger a restart so its config hook re-runs and
-      // re-reads the now-populated .env. No-ops on warm starts.
-      const wasColdStart = !process.env.PUBLIC_JAZZ_APP_ID;
+      // hook, before configureServer ever runs. That capture sources from
+      // .env files plus process.env, so anything missing here is also missing
+      // from `$env/dynamic/public` at runtime. PUBLIC_JAZZ_APP_ID is missing
+      // on the first-ever run (no persisted .env yet). PUBLIC_JAZZ_SERVER_URL
+      // is missing every warm start — the port is allocated dynamically and
+      // is never persisted to .env. In either case we restart after the
+      // managed runtime populates process.env, so SvelteKit's config hook
+      // re-runs and the captured env picks up the fresh values. process.env
+      // survives the restart (same Node process) and runtime.initialize() is
+      // idempotent, so the restarted pass reuses the in-flight Jazz server.
+      //
+      // Strict `=== undefined` check: an explicitly empty string is a user
+      // assertion that the var has no value, and managed-runtime would write
+      // that empty back to process.env post-restart — looping forever.
+      const appIdMissingFromCapturedEnv = process.env.PUBLIC_JAZZ_APP_ID === undefined;
+      const serverUrlMissingFromCapturedEnv = process.env.PUBLIC_JAZZ_SERVER_URL === undefined;
 
       const schemaDir = options.schemaDir ?? join(viteServer.config.root, "src", "lib");
       const serverOpt = options.server ?? true;
@@ -140,9 +151,12 @@ export function jazzSvelteKit(options: JazzPluginOptions = {}) {
         viteServer.config.env.PUBLIC_JAZZ_TELEMETRY_COLLECTOR_URL = managed.telemetryCollectorUrl;
       }
 
-      if (wasColdStart && managed.appId) {
+      if (
+        (appIdMissingFromCapturedEnv && managed.appId) ||
+        (serverUrlMissingFromCapturedEnv && managed.serverUrl)
+      ) {
         console.log(
-          `${LOG_PREFIX} initial appId allocated, restarting dev server so SvelteKit's $env captures it`,
+          `${LOG_PREFIX} restarting dev server so SvelteKit's $env captures the populated PUBLIC_JAZZ_* vars`,
         );
         void viteServer.restart?.();
       }

--- a/packages/jazz-tools/src/runtime/auth-secret-store.test.ts
+++ b/packages/jazz-tools/src/runtime/auth-secret-store.test.ts
@@ -128,6 +128,20 @@ describe("BrowserAuthSecretStore", () => {
     expect(aliceAgainSecret).toBe(aliceSecret);
   });
 
+  it("throws a clear error if used in a non-browser env (no localStorage)", async () => {
+    const original = (globalThis as { localStorage?: Storage }).localStorage;
+    delete (globalThis as { localStorage?: Storage }).localStorage;
+    try {
+      const ssrStore = new BrowserAuthSecretStore();
+      expect(() => ssrStore.getOrCreateSecret()).toThrow(/browser environment/);
+      await expect(ssrStore.loadSecret()).rejects.toThrow(/browser environment/);
+    } finally {
+      if (original !== undefined) {
+        (globalThis as { localStorage?: Storage }).localStorage = original;
+      }
+    }
+  });
+
   it("static helpers can isolate secrets by namespace hints", async () => {
     const aliceSecret = await BrowserAuthSecretStore.getOrCreateSecret({
       storage,

--- a/packages/jazz-tools/src/runtime/auth-secret-store.ts
+++ b/packages/jazz-tools/src/runtime/auth-secret-store.ts
@@ -88,12 +88,23 @@ export class BrowserAuthSecretStore implements AuthSecretStore {
     Map<string, BrowserAuthSecretStore>
   >();
   private readonly key: string;
-  private readonly storage: Pick<Storage, "getItem" | "setItem" | "removeItem">;
+  private readonly explicitStorage: Pick<Storage, "getItem" | "setItem" | "removeItem"> | undefined;
   private cachedPromise: Promise<string> | null = null;
 
   constructor(options: BrowserAuthSecretStoreOptions = {}) {
     this.key = resolveBrowserAuthSecretKey(options);
-    this.storage = options.storage ?? globalThis.localStorage;
+    this.explicitStorage = options.storage;
+  }
+
+  private requireStorage(): Pick<Storage, "getItem" | "setItem" | "removeItem"> {
+    const storage = this.explicitStorage ?? globalThis.localStorage;
+    if (!storage) {
+      throw new Error(
+        "BrowserAuthSecretStore requires a browser environment. " +
+          "Defer reads to a client-only context, or pass `options.storage`.",
+      );
+    }
+    return storage;
   }
 
   static getDefault(options: BrowserAuthSecretStoreOptions = {}): BrowserAuthSecretStore {
@@ -124,27 +135,28 @@ export class BrowserAuthSecretStore implements AuthSecretStore {
   }
 
   async loadSecret(): Promise<string | null> {
-    return this.storage.getItem(this.key);
+    return this.requireStorage().getItem(this.key);
   }
 
   async saveSecret(secret: string): Promise<void> {
-    this.storage.setItem(this.key, secret);
+    this.requireStorage().setItem(this.key, secret);
     this.cachedPromise = Promise.resolve(secret);
   }
 
   async clearSecret(): Promise<void> {
-    this.storage.removeItem(this.key);
+    this.requireStorage().removeItem(this.key);
     this.cachedPromise = null;
   }
 
   getOrCreateSecret(): Promise<string> {
     if (!this.cachedPromise) {
-      const existing = this.storage.getItem(this.key);
+      const storage = this.requireStorage();
+      const existing = storage.getItem(this.key);
       if (existing) {
         this.cachedPromise = Promise.resolve(existing);
       } else {
         const secret = generateAuthSecret();
-        this.storage.setItem(this.key, secret);
+        storage.setItem(this.key, secret);
         this.cachedPromise = Promise.resolve(secret);
       }
     }

--- a/packages/jazz-tools/src/svelte/index.ts
+++ b/packages/jazz-tools/src/svelte/index.ts
@@ -6,6 +6,7 @@ export {
 } from "./create-jazz-client.js";
 export { getDb, getSession, getJazzContext, type JazzContext } from "./context.svelte.js";
 export { QuerySubscription } from "./use-all.svelte.js";
+export { LocalFirstAuth } from "./local-first-auth.svelte.js";
 export { attachDevTools, type DevToolsAttachment } from "../dev-tools/dev-tools.js";
 export type { DurabilityTier, QueryOptions, RuntimeSourcesConfig } from "../runtime/index.js";
 export {

--- a/packages/jazz-tools/src/svelte/local-first-auth.svelte.test.ts
+++ b/packages/jazz-tools/src/svelte/local-first-auth.svelte.test.ts
@@ -202,7 +202,125 @@ describe("svelte/LocalFirstAuth", () => {
     cleanup();
   });
 
-  it("rejected getOrCreateSecret resolves to secret=null with isLoading=false", async () => {
+  it("an in-flight refetch is discarded if a later refetch overtakes it", async () => {
+    const releases: Array<(secret: string) => void> = [];
+    const slowStore: AuthSecretStore = {
+      loadSecret: async () => null,
+      saveSecret: async () => {},
+      clearSecret: async () => {},
+      getOrCreateSecret() {
+        return new Promise<string>((r) => releases.push(r));
+      },
+    };
+
+    let auth!: InstanceType<typeof LocalFirstAuth>;
+    const cleanup = $effect.root(() => {
+      auth = new LocalFirstAuth(slowStore);
+    });
+
+    await waitUntil(() => expect(releases.length).toBe(1));
+
+    void auth.login("login-bump");
+    await waitUntil(() => expect(releases.length).toBe(2));
+
+    // Resolve the SECOND call first, then the (older) first.
+    releases[1]("newer-secret-cccccccccccccccccccccccccc");
+    await waitUntil(() => expect(auth.secret).toBe("newer-secret-cccccccccccccccccccccccccc"));
+
+    releases[0]("older-secret-dddddddddddddddddddddddddd");
+    await Promise.resolve();
+    flushSync();
+    expect(auth.secret).toBe("newer-secret-cccccccccccccccccccccccccc");
+
+    cleanup();
+  });
+
+  it("rejected login still notifies siblings — partial-commit saves reconverge on store truth", async () => {
+    let underlying: string | null = "initial-secret-aaaaaaaaaaaaaaaaaaaaaaaa";
+    const partialCommitStore: AuthSecretStore = {
+      async loadSecret() {
+        return underlying;
+      },
+      async saveSecret(secret) {
+        underlying = secret;
+        throw new Error("save partially failed");
+      },
+      async clearSecret() {
+        underlying = null;
+      },
+      getOrCreateSecret() {
+        if (underlying) return Promise.resolve(underlying);
+        underlying = "generated";
+        return Promise.resolve(underlying);
+      },
+    };
+
+    let alice!: InstanceType<typeof LocalFirstAuth>;
+    let bob!: InstanceType<typeof LocalFirstAuth>;
+    const cleanup = $effect.root(() => {
+      alice = new LocalFirstAuth(partialCommitStore);
+      bob = new LocalFirstAuth(partialCommitStore);
+    });
+    await waitUntil(() => {
+      expect(alice.isLoading).toBe(false);
+      expect(bob.isLoading).toBe(false);
+    });
+
+    await expect(alice.login("new-secret-eeeeeeeeeeeeeeeeeeeeeeee")).rejects.toThrow(
+      "save partially failed",
+    );
+
+    await waitUntil(() => {
+      expect(alice.secret).toBe("new-secret-eeeeeeeeeeeeeeeeeeeeeeee");
+      expect(bob.secret).toBe("new-secret-eeeeeeeeeeeeeeeeeeeeeeee");
+    });
+
+    cleanup();
+  });
+
+  it("rejected signOut still notifies siblings — partial-commit clears reconverge on store truth", async () => {
+    let underlying: string | null = "initial-secret-ffffffffffffffffffffffff";
+    const partialCommitStore: AuthSecretStore = {
+      async loadSecret() {
+        return underlying;
+      },
+      async saveSecret(secret) {
+        underlying = secret;
+      },
+      async clearSecret() {
+        underlying = null;
+        throw new Error("clear partially failed");
+      },
+      getOrCreateSecret() {
+        if (underlying) return Promise.resolve(underlying);
+        underlying = "generated-gggggggggggggggggggggggggggg";
+        return Promise.resolve(underlying);
+      },
+    };
+
+    let alice!: InstanceType<typeof LocalFirstAuth>;
+    let bob!: InstanceType<typeof LocalFirstAuth>;
+    const cleanup = $effect.root(() => {
+      alice = new LocalFirstAuth(partialCommitStore);
+      bob = new LocalFirstAuth(partialCommitStore);
+    });
+    await waitUntil(() => {
+      expect(alice.isLoading).toBe(false);
+      expect(bob.isLoading).toBe(false);
+    });
+
+    await expect(alice.signOut()).rejects.toThrow("clear partially failed");
+
+    await waitUntil(() => {
+      expect(alice.secret).toBe("generated-gggggggggggggggggggggggggggg");
+      expect(bob.secret).toBe("generated-gggggggggggggggggggggggggggg");
+    });
+
+    cleanup();
+  });
+
+  it("rejected getOrCreateSecret resolves to secret=null with isLoading=false and warns", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const failingStore: AuthSecretStore = {
       loadSecret: async () => null,
       saveSecret: async () => {},
@@ -221,7 +339,9 @@ describe("svelte/LocalFirstAuth", () => {
       expect(auth.isLoading).toBe(false);
       expect(auth.secret).toBeNull();
     });
+    expect(warn).toHaveBeenCalledWith("[LocalFirstAuth] secret store failed:", expect.any(Error));
 
     cleanup();
+    warn.mockRestore();
   });
 });

--- a/packages/jazz-tools/src/svelte/local-first-auth.svelte.test.ts
+++ b/packages/jazz-tools/src/svelte/local-first-auth.svelte.test.ts
@@ -1,0 +1,227 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { flushSync } from "svelte";
+import "./test-helpers.svelte.js";
+import type { AuthSecretStore } from "../runtime/auth-secret-store.js";
+
+const { LocalFirstAuth } = await import("./local-first-auth.svelte.js");
+
+function makeInMemoryStore(): AuthSecretStore {
+  let value: string | null = null;
+  let cached: Promise<string> | null = null;
+  return {
+    async loadSecret() {
+      return value;
+    },
+    async saveSecret(secret) {
+      value = secret;
+      cached = Promise.resolve(secret);
+    },
+    async clearSecret() {
+      value = null;
+      cached = null;
+    },
+    getOrCreateSecret() {
+      if (!cached) {
+        value = value ?? `generated-${Math.random().toString(36).slice(2)}`;
+        cached = Promise.resolve(value);
+      }
+      return cached;
+    },
+  };
+}
+
+function waitUntil(check: () => void) {
+  return vi.waitFor(() => {
+    flushSync();
+    check();
+  });
+}
+
+describe("svelte/LocalFirstAuth", () => {
+  let store: AuthSecretStore;
+
+  beforeEach(() => {
+    store = makeInMemoryStore();
+  });
+
+  it("starts loading=true secret=null, then resolves with a secret", async () => {
+    let auth!: InstanceType<typeof LocalFirstAuth>;
+    const cleanup = $effect.root(() => {
+      auth = new LocalFirstAuth(store);
+    });
+
+    expect(auth.isLoading).toBe(true);
+    expect(auth.secret).toBeNull();
+
+    await waitUntil(() => expect(auth.isLoading).toBe(false));
+    expect(typeof auth.secret).toBe("string");
+
+    cleanup();
+  });
+
+  it("login writes the store and updates secret", async () => {
+    let auth!: InstanceType<typeof LocalFirstAuth>;
+    const cleanup = $effect.root(() => {
+      auth = new LocalFirstAuth(store);
+    });
+    await waitUntil(() => expect(auth.isLoading).toBe(false));
+
+    await auth.login("provided-secret-aaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    await waitUntil(() => expect(auth.secret).toBe("provided-secret-aaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+    expect(auth.isLoading).toBe(false);
+
+    cleanup();
+  });
+
+  it("signOut clears the store and rotates the secret on re-resolve", async () => {
+    let auth!: InstanceType<typeof LocalFirstAuth>;
+    const cleanup = $effect.root(() => {
+      auth = new LocalFirstAuth(store);
+    });
+    await waitUntil(() => expect(auth.isLoading).toBe(false));
+
+    const before = auth.secret;
+
+    await auth.signOut();
+    await waitUntil(() => {
+      expect(auth.secret).not.toBeNull();
+      expect(auth.secret).not.toBe(before);
+    });
+
+    cleanup();
+  });
+
+  it("login from one instance updates a second instance backed by the same store", async () => {
+    let aliceAuth!: InstanceType<typeof LocalFirstAuth>;
+    let bobAuth!: InstanceType<typeof LocalFirstAuth>;
+    const cleanup = $effect.root(() => {
+      aliceAuth = new LocalFirstAuth(store);
+      bobAuth = new LocalFirstAuth(store);
+    });
+    await waitUntil(() => expect(bobAuth.isLoading).toBe(false));
+
+    await aliceAuth.login("shared-secret-aaaaaaaaaaaaaaaaaaaaaaaa");
+    await waitUntil(() => {
+      expect(aliceAuth.secret).toBe("shared-secret-aaaaaaaaaaaaaaaaaaaaaaaa");
+      expect(bobAuth.secret).toBe("shared-secret-aaaaaaaaaaaaaaaaaaaaaaaa");
+    });
+
+    cleanup();
+  });
+
+  it("instances backed by different stores do not cross-notify", async () => {
+    const storeA = makeInMemoryStore();
+    const storeB = makeInMemoryStore();
+    let authA!: InstanceType<typeof LocalFirstAuth>;
+    let authB!: InstanceType<typeof LocalFirstAuth>;
+    const cleanup = $effect.root(() => {
+      authA = new LocalFirstAuth(storeA);
+      authB = new LocalFirstAuth(storeB);
+    });
+    await waitUntil(() => {
+      expect(authA.isLoading).toBe(false);
+      expect(authB.isLoading).toBe(false);
+    });
+
+    await authA.login("secret-A-aaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    await waitUntil(() => expect(authA.secret).toBe("secret-A-aaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+    expect(authB.secret).not.toBe("secret-A-aaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+    cleanup();
+  });
+
+  it("cleanup unsubscribes — later notifier bumps do not touch the instance", async () => {
+    let auth!: InstanceType<typeof LocalFirstAuth>;
+    const cleanup = $effect.root(() => {
+      auth = new LocalFirstAuth(store);
+    });
+    await waitUntil(() => expect(auth.isLoading).toBe(false));
+
+    const before = auth.secret;
+    cleanup();
+
+    let other!: InstanceType<typeof LocalFirstAuth>;
+    const cleanup2 = $effect.root(() => {
+      other = new LocalFirstAuth(store);
+    });
+    await waitUntil(() => expect(other.isLoading).toBe(false));
+
+    await other.login("post-cleanup-secret-bbbbbbbbbbbbbbbbbbbbbb");
+    await waitUntil(() => expect(other.secret).toBe("post-cleanup-secret-bbbbbbbbbbbbbbbbbbbbbb"));
+    expect(auth.secret).toBe(before);
+
+    cleanup2();
+  });
+
+  it("isLoading flips back to true while a bump-driven refetch is in flight", async () => {
+    let release!: (secret: string) => void;
+    let pending: Promise<string> | null = null;
+    let resolved: string | null = "initial-secret-aaaaaaaaaaaaaaaaaaaaaaaaa";
+    const slowStore: AuthSecretStore = {
+      loadSecret: async () => resolved,
+      saveSecret: async (s) => {
+        resolved = s;
+      },
+      clearSecret: async () => {
+        resolved = null;
+      },
+      getOrCreateSecret() {
+        pending = new Promise<string>((r) => {
+          release = (s) => {
+            resolved = s;
+            r(s);
+          };
+        });
+        return pending;
+      },
+    };
+
+    let auth!: InstanceType<typeof LocalFirstAuth>;
+    const cleanup = $effect.root(() => {
+      auth = new LocalFirstAuth(slowStore);
+    });
+
+    await waitUntil(() => expect(pending).not.toBeNull());
+    expect(auth.isLoading).toBe(true);
+    release("initial-secret-aaaaaaaaaaaaaaaaaaaaaaaaa");
+    await waitUntil(() => expect(auth.isLoading).toBe(false));
+
+    pending = null;
+    void auth.login("new-secret-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+    await waitUntil(() => {
+      expect(auth.isLoading).toBe(true);
+      expect(pending).not.toBeNull();
+    });
+
+    release("new-secret-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+    await waitUntil(() => {
+      expect(auth.isLoading).toBe(false);
+      expect(auth.secret).toBe("new-secret-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+    });
+
+    cleanup();
+  });
+
+  it("rejected getOrCreateSecret resolves to secret=null with isLoading=false", async () => {
+    const failingStore: AuthSecretStore = {
+      loadSecret: async () => null,
+      saveSecret: async () => {},
+      clearSecret: async () => {},
+      getOrCreateSecret: async () => {
+        throw new Error("store unavailable");
+      },
+    };
+
+    let auth!: InstanceType<typeof LocalFirstAuth>;
+    const cleanup = $effect.root(() => {
+      auth = new LocalFirstAuth(failingStore);
+    });
+
+    await waitUntil(() => {
+      expect(auth.isLoading).toBe(false);
+      expect(auth.secret).toBeNull();
+    });
+
+    cleanup();
+  });
+});

--- a/packages/jazz-tools/src/svelte/local-first-auth.svelte.ts
+++ b/packages/jazz-tools/src/svelte/local-first-auth.svelte.ts
@@ -66,37 +66,47 @@ export class LocalFirstAuth {
     };
 
     this.login = async (secret: string) => {
-      await store.saveSecret(secret);
-      notify();
+      try {
+        await store.saveSecret(secret);
+      } finally {
+        notify();
+      }
     };
 
     this.signOut = async () => {
-      await store.clearSecret();
-      notify();
+      try {
+        await store.clearSecret();
+      } finally {
+        notify();
+      }
     };
 
     $effect(() => {
       let cancelled = false;
+      let latestCallId = 0;
 
       const refetch = () => {
+        const callId = ++latestCallId;
+        const stale = () => cancelled || callId !== latestCallId;
+        const onError = (err: unknown) => {
+          if (stale()) return;
+          console.warn("[LocalFirstAuth] secret store failed:", err);
+          this.secret = null;
+          this.isLoading = false;
+        };
+
         this.isLoading = true;
         try {
           store
             .getOrCreateSecret()
             .then((resolved) => {
-              if (cancelled) return;
+              if (stale()) return;
               this.secret = resolved;
               this.isLoading = false;
             })
-            .catch(() => {
-              if (cancelled) return;
-              this.secret = null;
-              this.isLoading = false;
-            });
-        } catch {
-          if (cancelled) return;
-          this.secret = null;
-          this.isLoading = false;
+            .catch(onError);
+        } catch (err) {
+          onError(err);
         }
       };
 

--- a/packages/jazz-tools/src/svelte/local-first-auth.svelte.ts
+++ b/packages/jazz-tools/src/svelte/local-first-auth.svelte.ts
@@ -1,0 +1,112 @@
+import { browserAuthSecretStore, type AuthSecretStore } from "../runtime/auth-secret-store.js";
+
+const listenersByStore = new WeakMap<AuthSecretStore, Set<() => void>>();
+
+function getListeners(store: AuthSecretStore): Set<() => void> {
+  let listeners = listenersByStore.get(store);
+  if (!listeners) {
+    listeners = new Set();
+    listenersByStore.set(store, listeners);
+  }
+  return listeners;
+}
+
+/**
+ * Reactive local-first auth secret. Mirrors `useLocalFirstAuth()` from
+ * `jazz-tools/react`. Instantiate in a Svelte component `<script>` block.
+ *
+ * The secret store is only read inside `$effect`, which the Svelte compiler
+ * skips on the server, so SvelteKit server renders see `secret: null,
+ * isLoading: true` and never touch `localStorage`.
+ *
+ * `login` and `signOut` update every live instance backed by the same store,
+ * so a sign-out button anywhere in the tree invalidates a provider mounted
+ * higher up without a manual reload.
+ *
+ * ```svelte
+ * <script lang="ts">
+ *   import { LocalFirstAuth, createJazzClient, JazzSvelteProvider } from 'jazz-tools/svelte';
+ *   import TodoList from './TodoList.svelte';
+ *
+ *   const auth = new LocalFirstAuth();
+ *
+ *   let client = $derived(
+ *     !auth.isLoading && auth.secret
+ *       ? createJazzClient({ appId: '<your-app-id>', secret: auth.secret })
+ *       : null,
+ *   );
+ * </script>
+ *
+ * {#if client}
+ *   <JazzSvelteProvider {client}>
+ *     {#snippet children()}
+ *       <TodoList />
+ *     {/snippet}
+ *   </JazzSvelteProvider>
+ * {/if}
+ * ```
+ *
+ * @param store - optional {@link AuthSecretStore} override. Defaults to the
+ *   shared {@link browserAuthSecretStore} singleton. Pass a custom store to
+ *   isolate secrets per app, user, or session, or to swap in an alternative
+ *   storage backend.
+ */
+export class LocalFirstAuth {
+  secret: string | null = $state(null);
+  isLoading: boolean = $state(true);
+
+  login: (secret: string) => Promise<void>;
+  signOut: () => Promise<void>;
+
+  constructor(store: AuthSecretStore = browserAuthSecretStore) {
+    const listeners = getListeners(store);
+
+    const notify = () => {
+      for (const fn of listeners) fn();
+    };
+
+    this.login = async (secret: string) => {
+      await store.saveSecret(secret);
+      notify();
+    };
+
+    this.signOut = async () => {
+      await store.clearSecret();
+      notify();
+    };
+
+    $effect(() => {
+      let cancelled = false;
+
+      const refetch = () => {
+        this.isLoading = true;
+        try {
+          store
+            .getOrCreateSecret()
+            .then((resolved) => {
+              if (cancelled) return;
+              this.secret = resolved;
+              this.isLoading = false;
+            })
+            .catch(() => {
+              if (cancelled) return;
+              this.secret = null;
+              this.isLoading = false;
+            });
+        } catch {
+          if (cancelled) return;
+          this.secret = null;
+          this.isLoading = false;
+        }
+      };
+
+      refetch();
+      listeners.add(refetch);
+
+      return () => {
+        cancelled = true;
+        listeners.delete(refetch);
+      };
+    });
+  }
+}

--- a/packages/jazz-tools/src/svelte/rune-patterns.svelte.test.ts
+++ b/packages/jazz-tools/src/svelte/rune-patterns.svelte.test.ts
@@ -137,8 +137,8 @@ describe("applyDelta only touches changed rows", () => {
 
 describe("$state callback patterns", () => {
   it("onfulfilled delivers data and clears loading", () => {
-    let current: any[] | undefined = $state();
-    let loading: boolean = $state(true);
+    let current: any[] | undefined;
+    let loading = true;
 
     const onfulfilled = (data: any[]) => {
       current = data;
@@ -148,7 +148,7 @@ describe("$state callback patterns", () => {
     onfulfilled([{ id: "1", title: "Alice's todo" }]);
     flushSync();
 
-    expect($state.snapshot(current)).toEqual([{ id: "1", title: "Alice's todo" }]);
+    expect(current).toEqual([{ id: "1", title: "Alice's todo" }]);
     expect(loading).toBe(false);
   });
 
@@ -270,9 +270,9 @@ describe("$state callback patterns", () => {
   });
 
   it("onError surfaces error and clears current", () => {
-    let current: any[] | undefined = $state([{ id: "1" }]);
-    let loading: boolean = $state(false);
-    let error: Error | null = $state(null);
+    let current: any[] | undefined = [{ id: "1" }];
+    let loading = false;
+    let error: Error | null = null;
 
     const onError = (e: unknown) => {
       error = e instanceof Error ? e : new Error(String(e));
@@ -290,7 +290,7 @@ describe("$state callback patterns", () => {
   });
 
   it("onError wraps non-Error values in Error", () => {
-    let error: Error | null = $state(null);
+    let error: Error | null = null;
 
     const onError = (e: unknown) => {
       error = e instanceof Error ? e : new Error(String(e));
@@ -304,10 +304,9 @@ describe("$state callback patterns", () => {
   });
 
   it("synchronous throw during setup is caught and surfaced", () => {
-    let error: Error | null = $state(null);
-    let loading: boolean = $state(true);
+    let error: Error | null = null;
+    let loading = true;
 
-    // Mirrors the try/catch in the $effect body
     try {
       throw new Error("getCacheEntry exploded");
     } catch (e) {
@@ -349,15 +348,15 @@ describe("fulfilled cache entry provides initial data", () => {
       subscribe: vi.fn(() => vi.fn()),
     };
 
-    let current: any[] | undefined = $state();
-    let loading: boolean = $state(true);
+    let current: any[] | undefined;
+    let loading = true;
 
     if (entry.state.status === "fulfilled") {
       current = entry.state.data;
       loading = false;
     }
 
-    expect($state.snapshot(current)).toEqual([alice]);
+    expect(current).toEqual([alice]);
     expect(loading).toBe(false);
   });
 });

--- a/packages/jazz-tools/src/vue/index.ts
+++ b/packages/jazz-tools/src/vue/index.ts
@@ -13,4 +13,5 @@ export {
   type JazzProviderProps,
 } from "./provider.js";
 export { useAll } from "./use-all.js";
+export { useLocalFirstAuth, type UseLocalFirstAuth } from "./use-local-first-auth.js";
 export type { DurabilityTier, QueryOptions, RuntimeSourcesConfig } from "../runtime/index.js";

--- a/packages/jazz-tools/src/vue/use-local-first-auth.test.ts
+++ b/packages/jazz-tools/src/vue/use-local-first-auth.test.ts
@@ -1,0 +1,299 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { effectScope } from "vue";
+import type { AuthSecretStore } from "../runtime/auth-secret-store.js";
+
+import { useLocalFirstAuth } from "./use-local-first-auth.js";
+
+function makeInMemoryStore(): AuthSecretStore {
+  let value: string | null = null;
+  let cached: Promise<string> | null = null;
+  return {
+    async loadSecret() {
+      return value;
+    },
+    async saveSecret(secret) {
+      value = secret;
+      cached = Promise.resolve(secret);
+    },
+    async clearSecret() {
+      value = null;
+      cached = null;
+    },
+    getOrCreateSecret() {
+      if (!cached) {
+        value = value ?? `generated-${Math.random().toString(36).slice(2)}`;
+        cached = Promise.resolve(value);
+      }
+      return cached;
+    },
+  };
+}
+
+async function waitUntil(check: () => void) {
+  return vi.waitFor(check);
+}
+
+describe("vue/useLocalFirstAuth", () => {
+  let store: AuthSecretStore;
+
+  beforeEach(() => {
+    store = makeInMemoryStore();
+  });
+
+  it("starts loading=true secret=null, then resolves with a secret", async () => {
+    const scope = effectScope();
+    const auth = scope.run(() => useLocalFirstAuth(store))!;
+
+    expect(auth.isLoading.value).toBe(true);
+    expect(auth.secret.value).toBeNull();
+
+    await waitUntil(() => expect(auth.isLoading.value).toBe(false));
+    expect(typeof auth.secret.value).toBe("string");
+
+    scope.stop();
+  });
+
+  it("login writes the store and updates secret", async () => {
+    const scope = effectScope();
+    const auth = scope.run(() => useLocalFirstAuth(store))!;
+    await waitUntil(() => expect(auth.isLoading.value).toBe(false));
+
+    await auth.login("provided-secret-aaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    await waitUntil(() =>
+      expect(auth.secret.value).toBe("provided-secret-aaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+    );
+    expect(auth.isLoading.value).toBe(false);
+
+    scope.stop();
+  });
+
+  it("signOut clears the store and rotates the secret on re-resolve", async () => {
+    const scope = effectScope();
+    const auth = scope.run(() => useLocalFirstAuth(store))!;
+    await waitUntil(() => expect(auth.isLoading.value).toBe(false));
+
+    const before = auth.secret.value;
+    await auth.signOut();
+    await waitUntil(() => {
+      expect(auth.secret.value).not.toBeNull();
+      expect(auth.secret.value).not.toBe(before);
+    });
+
+    scope.stop();
+  });
+
+  it("login from one consumer updates another consumer backed by the same store", async () => {
+    const aliceScope = effectScope();
+    const bobScope = effectScope();
+    const alice = aliceScope.run(() => useLocalFirstAuth(store))!;
+    const bob = bobScope.run(() => useLocalFirstAuth(store))!;
+    await waitUntil(() => {
+      expect(alice.isLoading.value).toBe(false);
+      expect(bob.isLoading.value).toBe(false);
+    });
+
+    await alice.login("shared-secret-aaaaaaaaaaaaaaaaaaaaaaaa");
+    await waitUntil(() => {
+      expect(alice.secret.value).toBe("shared-secret-aaaaaaaaaaaaaaaaaaaaaaaa");
+      expect(bob.secret.value).toBe("shared-secret-aaaaaaaaaaaaaaaaaaaaaaaa");
+    });
+
+    aliceScope.stop();
+    bobScope.stop();
+  });
+
+  it("consumers backed by different stores do not cross-notify", async () => {
+    const storeA = makeInMemoryStore();
+    const storeB = makeInMemoryStore();
+    const aScope = effectScope();
+    const bScope = effectScope();
+    const authA = aScope.run(() => useLocalFirstAuth(storeA))!;
+    const authB = bScope.run(() => useLocalFirstAuth(storeB))!;
+    await waitUntil(() => {
+      expect(authA.isLoading.value).toBe(false);
+      expect(authB.isLoading.value).toBe(false);
+    });
+
+    await authA.login("secret-A-aaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    await waitUntil(() => expect(authA.secret.value).toBe("secret-A-aaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+    expect(authB.secret.value).not.toBe("secret-A-aaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+    aScope.stop();
+    bScope.stop();
+  });
+
+  it("scope.stop unsubscribes — later notifier bumps do not touch the consumer", async () => {
+    const scope = effectScope();
+    const auth = scope.run(() => useLocalFirstAuth(store))!;
+    await waitUntil(() => expect(auth.isLoading.value).toBe(false));
+
+    const before = auth.secret.value;
+    scope.stop();
+
+    const otherScope = effectScope();
+    const other = otherScope.run(() => useLocalFirstAuth(store))!;
+    await waitUntil(() => expect(other.isLoading.value).toBe(false));
+
+    await other.login("post-cleanup-secret-bbbbbbbbbbbbbbbbbbbbbb");
+    await waitUntil(() =>
+      expect(other.secret.value).toBe("post-cleanup-secret-bbbbbbbbbbbbbbbbbbbbbb"),
+    );
+    expect(auth.secret.value).toBe(before);
+
+    otherScope.stop();
+  });
+
+  it("an in-flight refetch is discarded if a later refetch overtakes it", async () => {
+    const releases: Array<(secret: string) => void> = [];
+    const slowStore: AuthSecretStore = {
+      loadSecret: async () => null,
+      saveSecret: async () => {},
+      clearSecret: async () => {},
+      getOrCreateSecret() {
+        return new Promise<string>((r) => releases.push(r));
+      },
+    };
+
+    const scope = effectScope();
+    const auth = scope.run(() => useLocalFirstAuth(slowStore))!;
+
+    await waitUntil(() => expect(releases.length).toBe(1));
+
+    void auth.login("login-bump");
+    await waitUntil(() => expect(releases.length).toBe(2));
+
+    releases[1]("newer-secret-cccccccccccccccccccccccccc");
+    await waitUntil(() =>
+      expect(auth.secret.value).toBe("newer-secret-cccccccccccccccccccccccccc"),
+    );
+
+    releases[0]("older-secret-dddddddddddddddddddddddddd");
+    await Promise.resolve();
+    expect(auth.secret.value).toBe("newer-secret-cccccccccccccccccccccccccc");
+
+    scope.stop();
+  });
+
+  it("rejected login still notifies siblings — partial-commit saves reconverge on store truth", async () => {
+    let underlying: string | null = "initial-secret-aaaaaaaaaaaaaaaaaaaaaaaa";
+    const partialCommitStore: AuthSecretStore = {
+      async loadSecret() {
+        return underlying;
+      },
+      async saveSecret(secret) {
+        underlying = secret;
+        throw new Error("save partially failed");
+      },
+      async clearSecret() {
+        underlying = null;
+      },
+      getOrCreateSecret() {
+        if (underlying) return Promise.resolve(underlying);
+        underlying = "generated";
+        return Promise.resolve(underlying);
+      },
+    };
+
+    const aliceScope = effectScope();
+    const bobScope = effectScope();
+    const alice = aliceScope.run(() => useLocalFirstAuth(partialCommitStore))!;
+    const bob = bobScope.run(() => useLocalFirstAuth(partialCommitStore))!;
+    await waitUntil(() => {
+      expect(alice.isLoading.value).toBe(false);
+      expect(bob.isLoading.value).toBe(false);
+    });
+
+    await expect(alice.login("new-secret-eeeeeeeeeeeeeeeeeeeeeeee")).rejects.toThrow(
+      "save partially failed",
+    );
+
+    await waitUntil(() => {
+      expect(alice.secret.value).toBe("new-secret-eeeeeeeeeeeeeeeeeeeeeeee");
+      expect(bob.secret.value).toBe("new-secret-eeeeeeeeeeeeeeeeeeeeeeee");
+    });
+
+    aliceScope.stop();
+    bobScope.stop();
+  });
+
+  it("rejected signOut still notifies siblings — partial-commit clears reconverge on store truth", async () => {
+    let underlying: string | null = "initial-secret-ffffffffffffffffffffffff";
+    const partialCommitStore: AuthSecretStore = {
+      async loadSecret() {
+        return underlying;
+      },
+      async saveSecret(secret) {
+        underlying = secret;
+      },
+      async clearSecret() {
+        underlying = null;
+        throw new Error("clear partially failed");
+      },
+      getOrCreateSecret() {
+        if (underlying) return Promise.resolve(underlying);
+        underlying = "generated-gggggggggggggggggggggggggggg";
+        return Promise.resolve(underlying);
+      },
+    };
+
+    const aliceScope = effectScope();
+    const bobScope = effectScope();
+    const alice = aliceScope.run(() => useLocalFirstAuth(partialCommitStore))!;
+    const bob = bobScope.run(() => useLocalFirstAuth(partialCommitStore))!;
+    await waitUntil(() => {
+      expect(alice.isLoading.value).toBe(false);
+      expect(bob.isLoading.value).toBe(false);
+    });
+
+    await expect(alice.signOut()).rejects.toThrow("clear partially failed");
+
+    await waitUntil(() => {
+      expect(alice.secret.value).toBe("generated-gggggggggggggggggggggggggggg");
+      expect(bob.secret.value).toBe("generated-gggggggggggggggggggggggggggg");
+    });
+
+    aliceScope.stop();
+    bobScope.stop();
+  });
+
+  it("warns when called outside an active effect scope (listener would leak)", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const auth = useLocalFirstAuth(store);
+    await waitUntil(() => expect(auth.isLoading.value).toBe(false));
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("[useLocalFirstAuth] called outside an active effect scope"),
+    );
+
+    warn.mockRestore();
+  });
+
+  it("rejected getOrCreateSecret resolves to secret=null with isLoading=false and warns", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const failingStore: AuthSecretStore = {
+      loadSecret: async () => null,
+      saveSecret: async () => {},
+      clearSecret: async () => {},
+      getOrCreateSecret: async () => {
+        throw new Error("store unavailable");
+      },
+    };
+
+    const scope = effectScope();
+    const auth = scope.run(() => useLocalFirstAuth(failingStore))!;
+
+    await waitUntil(() => {
+      expect(auth.isLoading.value).toBe(false);
+      expect(auth.secret.value).toBeNull();
+    });
+    expect(warn).toHaveBeenCalledWith(
+      "[useLocalFirstAuth] secret store failed:",
+      expect.any(Error),
+    );
+
+    scope.stop();
+    warn.mockRestore();
+  });
+});

--- a/packages/jazz-tools/src/vue/use-local-first-auth.ts
+++ b/packages/jazz-tools/src/vue/use-local-first-auth.ts
@@ -1,0 +1,134 @@
+import { getCurrentScope, onScopeDispose, ref, type Ref } from "vue";
+import { browserAuthSecretStore, type AuthSecretStore } from "../runtime/auth-secret-store.js";
+
+const listenersByStore = new WeakMap<AuthSecretStore, Set<() => void>>();
+
+function getListeners(store: AuthSecretStore): Set<() => void> {
+  let listeners = listenersByStore.get(store);
+  if (!listeners) {
+    listeners = new Set();
+    listenersByStore.set(store, listeners);
+  }
+  return listeners;
+}
+
+export interface UseLocalFirstAuth {
+  secret: Ref<string | null>;
+  isLoading: Ref<boolean>;
+  login: (secret: string) => Promise<void>;
+  signOut: () => Promise<void>;
+}
+
+/**
+ * Reactive local-first auth secret for Vue. Mirrors `useLocalFirstAuth()`
+ * from `jazz-tools/react` and the `LocalFirstAuth` class from
+ * `jazz-tools/svelte`. Call inside a Vue `<script setup>` block or any
+ * `effectScope`.
+ *
+ * The secret store is only read on the client (guarded by `typeof window`),
+ * so calling this composable during Vue SSR setup is a no-op — the server
+ * render sees `secret: null, isLoading: true` and never touches
+ * `localStorage`.
+ *
+ * `login` and `signOut` notify every live consumer backed by the same store,
+ * so a sign-out button anywhere in the tree invalidates a provider mounted
+ * higher up without a manual reload.
+ *
+ * ```vue
+ * <script setup lang="ts">
+ * import { computed } from 'vue';
+ * import { useLocalFirstAuth, createJazzClient, JazzProvider } from 'jazz-tools/vue';
+ * import TodoList from './TodoList.vue';
+ *
+ * const { secret, isLoading } = useLocalFirstAuth();
+ *
+ * const client = computed(() =>
+ *   !isLoading.value && secret.value
+ *     ? createJazzClient({ appId: '<your-app-id>', secret: secret.value })
+ *     : null,
+ * );
+ * </script>
+ *
+ * <template>
+ *   <JazzProvider v-if="client" :client="client">
+ *     <TodoList />
+ *   </JazzProvider>
+ * </template>
+ * ```
+ *
+ * @param store - optional {@link AuthSecretStore} override. Defaults to the
+ *   shared {@link browserAuthSecretStore} singleton. Pass a custom store to
+ *   isolate secrets per app, user, or session, or to swap in an alternative
+ *   storage backend.
+ */
+export function useLocalFirstAuth(
+  store: AuthSecretStore = browserAuthSecretStore,
+): UseLocalFirstAuth {
+  const secret = ref<string | null>(null);
+  const isLoading = ref(true);
+  const listeners = getListeners(store);
+
+  let cancelled = false;
+  let latestCallId = 0;
+
+  const refetch = () => {
+    const callId = ++latestCallId;
+    const stale = () => cancelled || callId !== latestCallId;
+    const onError = (err: unknown) => {
+      if (stale()) return;
+      console.warn("[useLocalFirstAuth] secret store failed:", err);
+      secret.value = null;
+      isLoading.value = false;
+    };
+
+    isLoading.value = true;
+    try {
+      store
+        .getOrCreateSecret()
+        .then((resolved) => {
+          if (stale()) return;
+          secret.value = resolved;
+          isLoading.value = false;
+        })
+        .catch(onError);
+    } catch (err) {
+      onError(err);
+    }
+  };
+
+  if (typeof window !== "undefined") {
+    refetch();
+    listeners.add(refetch);
+  }
+
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      cancelled = true;
+      listeners.delete(refetch);
+    });
+  } else if (typeof window !== "undefined") {
+    console.warn(
+      "[useLocalFirstAuth] called outside an active effect scope; the secret-store listener will leak until the page unloads. " +
+        "Call this composable inside <script setup> or effectScope().",
+    );
+  }
+
+  return {
+    secret,
+    isLoading,
+    async login(s: string) {
+      try {
+        await store.saveSecret(s);
+      } finally {
+        for (const fn of listeners) fn();
+      }
+    },
+    async signOut() {
+      try {
+        await store.clearSecret();
+      } finally {
+        for (const fn of listeners) fn();
+      }
+    },
+  };
+}

--- a/starters/next-hybrid/README.md
+++ b/starters/next-hybrid/README.md
@@ -47,9 +47,9 @@ lib/auth-client.ts                  ← Better Auth React client
 ## How it works
 
 `JazzProvider` in `components/jazz-provider.tsx` watches the Better Auth session via
-`authClient.useSession()`. When there is no session, it calls
-`BrowserAuthSecretStore.getOrCreateSecret()` and passes the secret to
-`<JazzProvider>` as `secret`. When a session exists, it
+`authClient.useSession()`. When there is no session, it reads `secret`
+from `useLocalFirstAuth()` (a React hook from `jazz-tools/react`) and
+passes it to `<JazzProvider>` as `secret`. When a session exists, it
 fetches a Better Auth JWT and passes it to `<JazzProvider>` as
 `jwtToken` instead.
 

--- a/starters/next-hybrid/app/page.tsx
+++ b/starters/next-hybrid/app/page.tsx
@@ -6,16 +6,17 @@ import { useRouter } from "next/navigation";
 import { TodoWidget } from "@/components/todo-widget";
 import { AuthBackup } from "@/components/auth-backup";
 import { authClient } from "@/lib/auth-client";
-import { BrowserAuthSecretStore } from "jazz-tools";
+import { useLocalFirstAuth } from "jazz-tools/react";
 
 function HeaderActions() {
   const router = useRouter();
   const { data: authSession } = authClient.useSession();
+  const auth = useLocalFirstAuth();
 
   if (authSession?.session) {
     async function handleSignOut() {
       await authClient.signOut();
-      await BrowserAuthSecretStore.clearSecret();
+      await auth.signOut();
       router.push("/");
     }
 

--- a/starters/next-hybrid/components/auth-backup.tsx
+++ b/starters/next-hybrid/components/auth-backup.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { BrowserAuthSecretStore } from "jazz-tools";
+import { useLocalFirstAuth } from "jazz-tools/react";
 
 type Status =
   | { kind: "idle" }
@@ -20,12 +20,10 @@ export function AuthBackup({
   redirectAfterRestore?: string;
   mode?: "full" | "restore-only";
 } = {}) {
+  const auth = useLocalFirstAuth();
+
   function navigate() {
-    if (redirectAfterRestore) {
-      location.assign(redirectAfterRestore);
-    } else {
-      location.reload();
-    }
+    if (redirectAfterRestore) location.assign(redirectAfterRestore);
   }
   const [phrase, setPhrase] = useState<string | null>(null);
   const [restoreInput, setRestoreInput] = useState("");
@@ -36,13 +34,12 @@ export function AuthBackup({
     setStatus({ kind: "idle" });
     setBusy(true);
     try {
-      const secret = await BrowserAuthSecretStore.loadSecret();
-      if (!secret) {
+      if (!auth.secret) {
         setStatus({ kind: "error", message: "No local secret to reveal yet." });
         return;
       }
       const { RecoveryPhrase } = await import("jazz-tools/passphrase");
-      setPhrase(RecoveryPhrase.fromSecret(secret));
+      setPhrase(RecoveryPhrase.fromSecret(auth.secret));
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
     } finally {
@@ -70,10 +67,11 @@ export function AuthBackup({
     try {
       const { RecoveryPhrase } = await import("jazz-tools/passphrase");
       const secret = RecoveryPhrase.toSecret(restoreInput.trim());
-      await BrowserAuthSecretStore.saveSecret(secret);
+      await auth.login(secret);
       navigate();
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
+    } finally {
       setBusy(false);
     }
   }
@@ -82,8 +80,7 @@ export function AuthBackup({
     setStatus({ kind: "idle" });
     setBusy(true);
     try {
-      const secret = await BrowserAuthSecretStore.loadSecret();
-      if (!secret) {
+      if (!auth.secret) {
         setStatus({ kind: "error", message: "No local secret to back up yet." });
         return;
       }
@@ -92,7 +89,7 @@ export function AuthBackup({
         appName: PASSKEY_APP_NAME,
         appHostname: PASSKEY_APP_HOSTNAME,
       });
-      await pb.backup(secret, "My account");
+      await pb.backup(auth.secret, "My account");
       setStatus({ kind: "success", message: "Passkey backup created." });
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
@@ -111,10 +108,11 @@ export function AuthBackup({
         appHostname: PASSKEY_APP_HOSTNAME,
       });
       const secret = await pb.restore();
-      await BrowserAuthSecretStore.saveSecret(secret);
+      await auth.login(secret);
       navigate();
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
+    } finally {
       setBusy(false);
     }
   }

--- a/starters/next-hybrid/components/jazz-provider.tsx
+++ b/starters/next-hybrid/components/jazz-provider.tsx
@@ -1,9 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { type DbConfig, BrowserAuthSecretStore } from "jazz-tools";
-import { JazzProvider as JazzBaseProvider, useDb } from "jazz-tools/react";
+import { useEffect, useMemo, useState } from "react";
+import type { DbConfig } from "jazz-tools";
+import { JazzProvider as JazzBaseProvider, useDb, useLocalFirstAuth } from "jazz-tools/react";
 import { authClient } from "@/lib/auth-client";
+
+const APP_ID = process.env.NEXT_PUBLIC_JAZZ_APP_ID;
+const SERVER_URL = process.env.NEXT_PUBLIC_JAZZ_SERVER_URL;
 
 function JwtRefresh() {
   const db = useDb();
@@ -20,9 +23,6 @@ function JwtRefresh() {
   return null;
 }
 
-const APP_ID = process.env.NEXT_PUBLIC_JAZZ_APP_ID;
-const SERVER_URL = process.env.NEXT_PUBLIC_JAZZ_SERVER_URL;
-
 /**
  * Jazz provider for the local-first + BetterAuth starter. Watches the
  * Better Auth session and builds the appropriate DbConfig — an anonymous
@@ -31,23 +31,43 @@ const SERVER_URL = process.env.NEXT_PUBLIC_JAZZ_SERVER_URL;
  */
 export function JazzProvider({ children }: React.PropsWithChildren) {
   const { data: authSession, isPending } = authClient.useSession();
-  const [config, setConfig] = useState<DbConfig | null>(null);
+  const { secret, isLoading: secretLoading } = useLocalFirstAuth();
+  const [jwtToken, setJwtToken] = useState<string | null>(null);
   const authenticated = Boolean(authSession?.session);
 
   useEffect(() => {
-    if (isPending) return;
+    if (!authenticated) {
+      setJwtToken(null);
+      return;
+    }
     let cancelled = false;
-    setConfig(null);
-
-    (async () => {
-      const next = authenticated ? await buildJwtConfig() : await buildLocalFirstConfig();
-      if (!cancelled && next) setConfig(next);
-    })();
-
+    authClient.token().then(({ data, error }) => {
+      if (cancelled) return;
+      if (!error && data?.token) setJwtToken(data.token);
+    });
     return () => {
       cancelled = true;
     };
-  }, [isPending, authenticated]);
+  }, [authenticated]);
+
+  const config = useMemo<DbConfig | null>(() => {
+    if (!APP_ID || !SERVER_URL) {
+      const missing = [
+        !APP_ID && "NEXT_PUBLIC_JAZZ_APP_ID",
+        !SERVER_URL && "NEXT_PUBLIC_JAZZ_SERVER_URL",
+      ]
+        .filter((v) => !!v)
+        .join(" & ");
+      throw new Error(
+        `${missing} not set. The withJazz Next plugin injects these at dev time; in production, set them explicitly in your environment.`,
+      );
+    }
+    if (authenticated) {
+      return jwtToken ? { appId: APP_ID, serverUrl: SERVER_URL, jwtToken } : null;
+    }
+    if (secretLoading || !secret) return null;
+    return { appId: APP_ID, serverUrl: SERVER_URL, secret };
+  }, [authenticated, jwtToken, secret, secretLoading]);
 
   if (isPending || !config) return null;
 
@@ -57,33 +77,4 @@ export function JazzProvider({ children }: React.PropsWithChildren) {
       {children}
     </JazzBaseProvider>
   );
-}
-
-function baseConfig(): Omit<DbConfig, "jwtToken" | "secret"> {
-  if (!APP_ID || !SERVER_URL) {
-    const missing = [
-      !APP_ID && "NEXT_PUBLIC_JAZZ_APP_ID",
-      !SERVER_URL && "NEXT_PUBLIC_JAZZ_SERVER_URL",
-    ]
-      .filter((v) => !!v)
-      .join(" & ");
-    throw new Error(
-      `${missing} not set. The withJazz Next plugin injects these at dev time; in production, set them explicitly in your environment.`,
-    );
-  }
-  return {
-    appId: APP_ID,
-    serverUrl: SERVER_URL,
-  };
-}
-
-async function buildLocalFirstConfig(): Promise<DbConfig> {
-  const secret = await BrowserAuthSecretStore.getOrCreateSecret();
-  return { ...baseConfig(), secret };
-}
-
-async function buildJwtConfig(): Promise<DbConfig | null> {
-  const { data, error } = await authClient.token();
-  if (error || !data?.token) return null;
-  return { ...baseConfig(), jwtToken: data.token };
 }

--- a/starters/next-localfirst/README.md
+++ b/starters/next-localfirst/README.md
@@ -47,10 +47,11 @@ permissions.ts                 ← row-level access policy ($createdBy)
 
 Every browser gets its own Ed25519 secret, generated and stored by
 `BrowserAuthSecretStore` on first load. That secret becomes the identity
-Jazz uses for all subsequent writes. `LocalFirstProvider` in
+Jazz uses for all subsequent writes. The `JazzProvider` in
 `components/jazz-provider.tsx` does exactly one thing: call
-`BrowserAuthSecretStore.getOrCreateSecret()` and hand the result to
-`<JazzProvider>` as `secret`.
+`useLocalFirstAuth()` (a React hook from `jazz-tools/react` that loads
+or generates the secret client-side) and hand `secret` to the underlying
+`<JazzProvider>`.
 
 Data syncs to the Jazz server under that anonymous identity. There is no
 concept of a user account, no sign-in, no sign-out — the device _is_ the

--- a/starters/next-localfirst/components/auth-backup.tsx
+++ b/starters/next-localfirst/components/auth-backup.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { BrowserAuthSecretStore } from "jazz-tools";
+import { useLocalFirstAuth } from "jazz-tools/react";
 
 type Status =
   | { kind: "idle" }
@@ -20,12 +20,10 @@ export function AuthBackup({
   redirectAfterRestore?: string;
   mode?: "full" | "restore-only";
 } = {}) {
+  const auth = useLocalFirstAuth();
+
   function navigate() {
-    if (redirectAfterRestore) {
-      location.assign(redirectAfterRestore);
-    } else {
-      location.reload();
-    }
+    if (redirectAfterRestore) location.assign(redirectAfterRestore);
   }
   const [phrase, setPhrase] = useState<string | null>(null);
   const [restoreInput, setRestoreInput] = useState("");
@@ -36,13 +34,12 @@ export function AuthBackup({
     setStatus({ kind: "idle" });
     setBusy(true);
     try {
-      const secret = await BrowserAuthSecretStore.loadSecret();
-      if (!secret) {
+      if (!auth.secret) {
         setStatus({ kind: "error", message: "No local secret to reveal yet." });
         return;
       }
       const { RecoveryPhrase } = await import("jazz-tools/passphrase");
-      setPhrase(RecoveryPhrase.fromSecret(secret));
+      setPhrase(RecoveryPhrase.fromSecret(auth.secret));
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
     } finally {
@@ -70,10 +67,11 @@ export function AuthBackup({
     try {
       const { RecoveryPhrase } = await import("jazz-tools/passphrase");
       const secret = RecoveryPhrase.toSecret(restoreInput.trim());
-      await BrowserAuthSecretStore.saveSecret(secret);
+      await auth.login(secret);
       navigate();
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
+    } finally {
       setBusy(false);
     }
   }
@@ -82,8 +80,7 @@ export function AuthBackup({
     setStatus({ kind: "idle" });
     setBusy(true);
     try {
-      const secret = await BrowserAuthSecretStore.loadSecret();
-      if (!secret) {
+      if (!auth.secret) {
         setStatus({ kind: "error", message: "No local secret to back up yet." });
         return;
       }
@@ -92,7 +89,7 @@ export function AuthBackup({
         appName: PASSKEY_APP_NAME,
         appHostname: PASSKEY_APP_HOSTNAME,
       });
-      await pb.backup(secret, "My account");
+      await pb.backup(auth.secret, "My account");
       setStatus({ kind: "success", message: "Passkey backup created." });
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
@@ -111,10 +108,11 @@ export function AuthBackup({
         appHostname: PASSKEY_APP_HOSTNAME,
       });
       const secret = await pb.restore();
-      await BrowserAuthSecretStore.saveSecret(secret);
+      await auth.login(secret);
       navigate();
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
+    } finally {
       setBusy(false);
     }
   }

--- a/starters/next-localfirst/components/jazz-provider.tsx
+++ b/starters/next-localfirst/components/jazz-provider.tsx
@@ -1,31 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { type DbConfig, BrowserAuthSecretStore } from "jazz-tools";
-import { JazzProvider as JazzBaseProvider } from "jazz-tools/react";
+import { JazzProvider as JazzBaseProvider, useLocalFirstAuth } from "jazz-tools/react";
 
 const APP_ID = process.env.NEXT_PUBLIC_JAZZ_APP_ID;
 const SERVER_URL = process.env.NEXT_PUBLIC_JAZZ_SERVER_URL;
 
 export function JazzProvider({ children }: React.PropsWithChildren) {
-  const [config, setConfig] = useState<DbConfig | null>(null);
-
-  useEffect(() => {
-    BrowserAuthSecretStore.getOrCreateSecret().then((secret) => {
-      setConfig(buildConfig(secret));
-    });
-  }, []);
-
-  if (!config) return null;
-
-  return (
-    <JazzBaseProvider config={config} fallback={<p>Loading...</p>}>
-      {children}
-    </JazzBaseProvider>
-  );
-}
-
-function buildConfig(secret: string): DbConfig {
   if (!APP_ID || !SERVER_URL) {
     const missing = [
       !APP_ID && "NEXT_PUBLIC_JAZZ_APP_ID",
@@ -37,9 +17,16 @@ function buildConfig(secret: string): DbConfig {
       `${missing} not set. The withJazz Next plugin injects these at dev time; in production, set them explicitly in your environment.`,
     );
   }
-  return {
-    appId: APP_ID,
-    serverUrl: SERVER_URL,
-    secret,
-  };
+
+  const { secret, isLoading } = useLocalFirstAuth();
+  if (isLoading || !secret) return null;
+
+  return (
+    <JazzBaseProvider
+      config={{ appId: APP_ID, serverUrl: SERVER_URL, secret }}
+      fallback={<p>Loading...</p>}
+    >
+      {children}
+    </JazzBaseProvider>
+  );
 }

--- a/starters/react-hybrid/README.md
+++ b/starters/react-hybrid/README.md
@@ -71,9 +71,13 @@ identity ID, so the Jazz principal carries over seamlessly.
 Both sides use the audience string `"react-localfirst-signup"` — the
 client proof and the server verification must match.
 
-`BetterAuthProvider` in `src/main.tsx` watches the Better Auth session. When a
-session exists, it fetches a JWT and passes it to `<JazzProvider>` as
-`jwtToken`. The Jazz dev server verifies that JWT against the JWKS endpoint.
+`HybridProvider` in `src/main.tsx` watches the Better Auth session via
+`authClient.useSession()`. When there is no session, it reads `secret`
+from `useLocalFirstAuth()` (a React hook from `jazz-tools/react`) and
+passes it to `<JazzProvider>` as `secret`. When a session exists, it
+fetches a Better Auth JWT and passes it to `<JazzProvider>` as
+`jwtToken` instead. The Jazz dev server verifies that JWT against the
+JWKS endpoint.
 
 ## Extending the schema
 

--- a/starters/react-hybrid/src/App.tsx
+++ b/starters/react-hybrid/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { BrowserAuthSecretStore } from "jazz-tools";
+import { useLocalFirstAuth } from "jazz-tools/react";
 import { authClient, useSession } from "./auth-client";
 import { AuthBackup } from "./auth-backup";
 import { SignInForm } from "./sign-in-form";
@@ -10,12 +10,13 @@ type View = "dashboard" | "signin" | "signup";
 
 export function App() {
   const { data: session, isPending } = useSession();
+  const auth = useLocalFirstAuth();
   const [view, setView] = useState<View>("dashboard");
 
   if (isPending) return <div>Loading…</div>;
 
   async function handleSignOut() {
-    await BrowserAuthSecretStore.clearSecret();
+    await auth.signOut();
     await authClient.signOut();
     setView("dashboard");
   }

--- a/starters/react-hybrid/src/auth-backup.tsx
+++ b/starters/react-hybrid/src/auth-backup.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { BrowserAuthSecretStore } from "jazz-tools";
+import { useLocalFirstAuth } from "jazz-tools/react";
 
 type Status =
   | { kind: "idle" }
@@ -18,12 +18,10 @@ export function AuthBackup({
   redirectAfterRestore?: string;
   mode?: "full" | "restore-only";
 } = {}) {
+  const auth = useLocalFirstAuth();
+
   function navigate() {
-    if (redirectAfterRestore) {
-      location.assign(redirectAfterRestore);
-    } else {
-      location.reload();
-    }
+    if (redirectAfterRestore) location.assign(redirectAfterRestore);
   }
   const [phrase, setPhrase] = useState<string | null>(null);
   const [restoreInput, setRestoreInput] = useState("");
@@ -34,13 +32,12 @@ export function AuthBackup({
     setStatus({ kind: "idle" });
     setBusy(true);
     try {
-      const secret = await BrowserAuthSecretStore.loadSecret();
-      if (!secret) {
+      if (!auth.secret) {
         setStatus({ kind: "error", message: "No local secret to reveal yet." });
         return;
       }
       const { RecoveryPhrase } = await import("jazz-tools/passphrase");
-      setPhrase(RecoveryPhrase.fromSecret(secret));
+      setPhrase(RecoveryPhrase.fromSecret(auth.secret));
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
     } finally {
@@ -68,10 +65,11 @@ export function AuthBackup({
     try {
       const { RecoveryPhrase } = await import("jazz-tools/passphrase");
       const secret = RecoveryPhrase.toSecret(restoreInput.trim());
-      await BrowserAuthSecretStore.saveSecret(secret);
+      await auth.login(secret);
       navigate();
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
+    } finally {
       setBusy(false);
     }
   }
@@ -80,8 +78,7 @@ export function AuthBackup({
     setStatus({ kind: "idle" });
     setBusy(true);
     try {
-      const secret = await BrowserAuthSecretStore.loadSecret();
-      if (!secret) {
+      if (!auth.secret) {
         setStatus({ kind: "error", message: "No local secret to back up yet." });
         return;
       }
@@ -90,7 +87,7 @@ export function AuthBackup({
         appName: PASSKEY_APP_NAME,
         appHostname: PASSKEY_APP_HOSTNAME,
       });
-      await pb.backup(secret, "My account");
+      await pb.backup(auth.secret, "My account");
       setStatus({ kind: "success", message: "Passkey backup created." });
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
@@ -109,10 +106,11 @@ export function AuthBackup({
         appHostname: PASSKEY_APP_HOSTNAME,
       });
       const secret = await pb.restore();
-      await BrowserAuthSecretStore.saveSecret(secret);
+      await auth.login(secret);
       navigate();
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
+    } finally {
       setBusy(false);
     }
   }

--- a/starters/react-hybrid/src/main.tsx
+++ b/starters/react-hybrid/src/main.tsx
@@ -1,7 +1,7 @@
-import { StrictMode, useEffect, useState } from "react";
+import { StrictMode, useEffect, useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
-import { JazzProvider as JazzBaseProvider, useDb } from "jazz-tools/react";
-import { type DbConfig, BrowserAuthSecretStore } from "jazz-tools";
+import { JazzProvider as JazzBaseProvider, useDb, useLocalFirstAuth } from "jazz-tools/react";
+import type { DbConfig } from "jazz-tools";
 import { authClient } from "./auth-client";
 import { App } from "./App";
 import "./App.css";
@@ -24,54 +24,48 @@ function JwtRefresh() {
   return null;
 }
 
-function baseConfig(): Omit<DbConfig, "jwtToken" | "secret"> {
-  if (!APP_ID || !SERVER_URL) {
-    const missing = [!APP_ID && "VITE_JAZZ_APP_ID", !SERVER_URL && "VITE_JAZZ_SERVER_URL"]
-      .filter((v) => !!v)
-      .join(" & ");
-    throw new Error(
-      `${missing} not set. The jazzPlugin Vite plugin injects these at dev time; in production, set them explicitly in your environment.`,
-    );
-  }
-  return { appId: APP_ID, serverUrl: SERVER_URL };
-}
-
-async function buildLocalFirstConfig(): Promise<DbConfig> {
-  const secret = await BrowserAuthSecretStore.getOrCreateSecret();
-  return { ...baseConfig(), secret };
-}
-
-async function buildJwtConfig(): Promise<DbConfig | null> {
-  const { data, error } = await authClient.token();
-  if (error || !data?.token) return null;
-  return { ...baseConfig(), jwtToken: data.token };
-}
-
 /**
  * Hybrid provider: renders JazzProvider regardless of BetterAuth session state.
- * Anonymous visitors get a local-first identity (from BrowserAuthSecretStore);
+ * Anonymous visitors get a local-first identity (from useLocalFirstAuth);
  * signed-in users get a BetterAuth-issued JWT. Switching between the two
  * triggers JazzProvider to rebuild against the new config.
  */
 function HybridProvider({ children }: React.PropsWithChildren) {
   const { data: authSession, isPending } = authClient.useSession();
-  const [config, setConfig] = useState<DbConfig | null>(null);
+  const { secret, isLoading: secretLoading } = useLocalFirstAuth();
+  const [jwtToken, setJwtToken] = useState<string | null>(null);
   const authenticated = Boolean(authSession?.session);
 
   useEffect(() => {
-    if (isPending) return;
+    if (!authenticated) {
+      setJwtToken(null);
+      return;
+    }
     let cancelled = false;
-    setConfig(null);
-
-    (async () => {
-      const next = authenticated ? await buildJwtConfig() : await buildLocalFirstConfig();
-      if (!cancelled && next) setConfig(next);
-    })();
-
+    authClient.token().then(({ data, error }) => {
+      if (cancelled) return;
+      if (!error && data?.token) setJwtToken(data.token);
+    });
     return () => {
       cancelled = true;
     };
-  }, [isPending, authenticated]);
+  }, [authenticated]);
+
+  const config = useMemo<DbConfig | null>(() => {
+    if (!APP_ID || !SERVER_URL) {
+      const missing = [!APP_ID && "VITE_JAZZ_APP_ID", !SERVER_URL && "VITE_JAZZ_SERVER_URL"]
+        .filter((v) => !!v)
+        .join(" & ");
+      throw new Error(
+        `${missing} not set. The jazzPlugin Vite plugin injects these at dev time; in production, set them explicitly in your environment.`,
+      );
+    }
+    if (authenticated) {
+      return jwtToken ? { appId: APP_ID, serverUrl: SERVER_URL, jwtToken } : null;
+    }
+    if (secretLoading || !secret) return null;
+    return { appId: APP_ID, serverUrl: SERVER_URL, secret };
+  }, [authenticated, jwtToken, secret, secretLoading]);
 
   if (isPending || !config) return null;
 

--- a/starters/react-localfirst/README.md
+++ b/starters/react-localfirst/README.md
@@ -41,9 +41,9 @@ permissions.ts                   ← row-level access policy ($createdBy)
 Every browser gets its own Ed25519 secret, generated and stored by
 `BrowserAuthSecretStore` on first load. That secret becomes the identity
 Jazz uses for all subsequent writes. `LocalFirstProvider` in
-`src/main.tsx` does exactly one thing: call
-`BrowserAuthSecretStore.getOrCreateSecret()` and hand the result to
-`<JazzProvider>` as `secret`.
+`src/main.tsx` does exactly one thing: call `useLocalFirstAuth()` (a
+React hook from `jazz-tools/react` that loads or generates the secret
+client-side) and hand `secret` to `<JazzProvider>`.
 
 Data syncs to the Jazz server under that anonymous identity. There is no
 concept of a user account, no sign-in, no sign-out — the device _is_ the

--- a/starters/react-localfirst/src/auth-backup.tsx
+++ b/starters/react-localfirst/src/auth-backup.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { BrowserAuthSecretStore } from "jazz-tools";
+import { useLocalFirstAuth } from "jazz-tools/react";
 
 type Status =
   | { kind: "idle" }
@@ -18,12 +18,10 @@ export function AuthBackup({
   redirectAfterRestore?: string;
   mode?: "full" | "restore-only";
 } = {}) {
+  const auth = useLocalFirstAuth();
+
   function navigate() {
-    if (redirectAfterRestore) {
-      location.assign(redirectAfterRestore);
-    } else {
-      location.reload();
-    }
+    if (redirectAfterRestore) location.assign(redirectAfterRestore);
   }
   const [phrase, setPhrase] = useState<string | null>(null);
   const [restoreInput, setRestoreInput] = useState("");
@@ -34,13 +32,12 @@ export function AuthBackup({
     setStatus({ kind: "idle" });
     setBusy(true);
     try {
-      const secret = await BrowserAuthSecretStore.loadSecret();
-      if (!secret) {
+      if (!auth.secret) {
         setStatus({ kind: "error", message: "No local secret to reveal yet." });
         return;
       }
       const { RecoveryPhrase } = await import("jazz-tools/passphrase");
-      setPhrase(RecoveryPhrase.fromSecret(secret));
+      setPhrase(RecoveryPhrase.fromSecret(auth.secret));
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
     } finally {
@@ -68,10 +65,11 @@ export function AuthBackup({
     try {
       const { RecoveryPhrase } = await import("jazz-tools/passphrase");
       const secret = RecoveryPhrase.toSecret(restoreInput.trim());
-      await BrowserAuthSecretStore.saveSecret(secret);
+      await auth.login(secret);
       navigate();
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
+    } finally {
       setBusy(false);
     }
   }
@@ -80,8 +78,7 @@ export function AuthBackup({
     setStatus({ kind: "idle" });
     setBusy(true);
     try {
-      const secret = await BrowserAuthSecretStore.loadSecret();
-      if (!secret) {
+      if (!auth.secret) {
         setStatus({ kind: "error", message: "No local secret to back up yet." });
         return;
       }
@@ -90,7 +87,7 @@ export function AuthBackup({
         appName: PASSKEY_APP_NAME,
         appHostname: PASSKEY_APP_HOSTNAME,
       });
-      await pb.backup(secret, "My account");
+      await pb.backup(auth.secret, "My account");
       setStatus({ kind: "success", message: "Passkey backup created." });
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
@@ -109,10 +106,11 @@ export function AuthBackup({
         appHostname: PASSKEY_APP_HOSTNAME,
       });
       const secret = await pb.restore();
-      await BrowserAuthSecretStore.saveSecret(secret);
+      await auth.login(secret);
       navigate();
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
+    } finally {
       setBusy(false);
     }
   }

--- a/starters/react-localfirst/src/main.tsx
+++ b/starters/react-localfirst/src/main.tsx
@@ -1,14 +1,13 @@
-import { StrictMode, useEffect, useState } from "react";
+import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { type DbConfig, BrowserAuthSecretStore } from "jazz-tools";
-import { JazzProvider } from "jazz-tools/react";
+import { JazzProvider, useLocalFirstAuth } from "jazz-tools/react";
 import { App } from "./App";
 import "./App.css";
 
 const APP_ID = import.meta.env.VITE_JAZZ_APP_ID as string | undefined;
 const SERVER_URL = import.meta.env.VITE_JAZZ_SERVER_URL as string | undefined;
 
-function buildConfig(secret: string): DbConfig {
+function LocalFirstProvider({ children }: React.PropsWithChildren) {
   if (!APP_ID || !SERVER_URL) {
     const missing = [!APP_ID && "VITE_JAZZ_APP_ID", !SERVER_URL && "VITE_JAZZ_SERVER_URL"]
       .filter((v) => !!v)
@@ -17,26 +16,15 @@ function buildConfig(secret: string): DbConfig {
       `${missing} not set. The jazzPlugin Vite plugin injects these at dev time; in production, set them explicitly in your environment.`,
     );
   }
-  return {
-    appId: APP_ID,
-    serverUrl: SERVER_URL,
-    secret,
-  };
-}
 
-function LocalFirstProvider({ children }: React.PropsWithChildren) {
-  const [config, setConfig] = useState<DbConfig | null>(null);
-
-  useEffect(() => {
-    BrowserAuthSecretStore.getOrCreateSecret().then((secret) => {
-      setConfig(buildConfig(secret));
-    });
-  }, []);
-
-  if (!config) return null;
+  const { secret, isLoading } = useLocalFirstAuth();
+  if (isLoading || !secret) return null;
 
   return (
-    <JazzProvider config={config} fallback={<p>Loading...</p>}>
+    <JazzProvider
+      config={{ appId: APP_ID, serverUrl: SERVER_URL, secret }}
+      fallback={<p>Loading...</p>}
+    >
       {children}
     </JazzProvider>
   );

--- a/starters/sveltekit-hybrid/README.md
+++ b/starters/sveltekit-hybrid/README.md
@@ -51,15 +51,16 @@ src/
 ## How it works
 
 `src/routes/+layout.svelte` watches the Better Auth session via
-`authClient.useSession()`. When there is no session, it calls
-`BrowserAuthSecretStore.getOrCreateSecret()` and passes the secret to
-`createJazzClient` as `secret`. When a session exists, it
-fetches a Better Auth JWT and creates the client with `jwtToken` instead.
-
-The layout uses a `clientAuth` gate so the `<JazzSvelteProvider>` only
-renders when the active client matches the current session state. This
-prevents a race where the UI would briefly interact with the stale
-anonymous client during a sign-up → authenticated transition.
+`authClient.useSession()` and forwards the result to
+`JazzClientProvider.svelte`. That provider holds a `LocalFirstAuth`
+instance (from `jazz-tools/svelte`) for the anonymous path and fetches
+a Better Auth JWT for the authenticated path. A `$derived` picks the
+right `createJazzClient(...)` config — `secret` from `auth.secret`
+when no session, `jwtToken` when there is one — so the
+`<JazzSvelteProvider>` only renders once the active client matches the
+current session state. That prevents a race where the UI would briefly
+interact with a stale anonymous client during a sign-up → authenticated
+transition.
 
 ### Identity continuity
 

--- a/starters/sveltekit-hybrid/README.md
+++ b/starters/sveltekit-hybrid/README.md
@@ -169,9 +169,9 @@ manually:
    `src/lib/auth-client.ts`, `src/routes/signin/`, and
    `src/routes/signup/`.
 2. In `src/routes/+layout.svelte`, remove the `authClient`, `session`,
-   `clientAuth`, and `ready` logic — reduce the effect to: resolve
-   `BrowserAuthSecretStore.getOrCreateSecret()`, build a `DbConfig` with
-   `auth: { localFirstSecret: secret }`, and call `createJazzClient`.
+   `clientAuth`, and `ready` logic — reduce it to: instantiate
+   `LocalFirstAuth` from `jazz-tools/svelte` and `$derived` a client
+   from `auth.secret`.
 3. In `src/routes/+page.svelte`, remove the auth-nav block and the
    `handleSignOut` function — the page renders just the header and the
    `<TodoWidget />`.

--- a/starters/sveltekit-hybrid/src/lib/AuthBackup.svelte
+++ b/starters/sveltekit-hybrid/src/lib/AuthBackup.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { BrowserAuthSecretStore } from "jazz-tools/svelte";
+  import { LocalFirstAuth } from "jazz-tools/svelte";
   import { goto } from "$app/navigation";
 
   // In production, pin this to your deployed hostname so passkeys remain
@@ -21,18 +21,15 @@
     mode?: "full" | "restore-only";
   } = $props();
 
+  const auth = new LocalFirstAuth();
+
   let phrase = $state<string | null>(null);
   let restoreInput = $state("");
   let status = $state<Status>({ kind: "idle" });
   let busy = $state(false);
 
   async function navigate() {
-    if (redirectAfterRestore) {
-      await goto(redirectAfterRestore);
-      location.reload();
-    } else {
-      location.reload();
-    }
+    if (redirectAfterRestore) await goto(redirectAfterRestore);
   }
 
   function describeError(err: unknown): string {
@@ -47,13 +44,12 @@
     status = { kind: "idle" };
     busy = true;
     try {
-      const secret = await BrowserAuthSecretStore.loadSecret();
-      if (!secret) {
+      if (!auth.secret) {
         status = { kind: "error", message: "No local secret to reveal yet." };
         return;
       }
       const { RecoveryPhrase } = await import("jazz-tools/passphrase");
-      phrase = RecoveryPhrase.fromSecret(secret);
+      phrase = RecoveryPhrase.fromSecret(auth.secret);
     } catch (err) {
       status = { kind: "error", message: describeError(err) };
     } finally {
@@ -81,10 +77,11 @@
     try {
       const { RecoveryPhrase } = await import("jazz-tools/passphrase");
       const secret = RecoveryPhrase.toSecret(restoreInput.trim());
-      await BrowserAuthSecretStore.saveSecret(secret);
+      await auth.login(secret);
       await navigate();
     } catch (err) {
       status = { kind: "error", message: describeError(err) };
+    } finally {
       busy = false;
     }
   }
@@ -93,8 +90,7 @@
     status = { kind: "idle" };
     busy = true;
     try {
-      const secret = await BrowserAuthSecretStore.loadSecret();
-      if (!secret) {
+      if (!auth.secret) {
         status = { kind: "error", message: "No local secret to back up yet." };
         return;
       }
@@ -103,7 +99,7 @@
         appName: PASSKEY_APP_NAME,
         appHostname: PASSKEY_APP_HOSTNAME,
       });
-      await pb.backup(secret, "My account");
+      await pb.backup(auth.secret, "My account");
       status = { kind: "success", message: "Passkey backup created." };
     } catch (err) {
       status = { kind: "error", message: describeError(err) };
@@ -122,10 +118,11 @@
         appHostname: PASSKEY_APP_HOSTNAME,
       });
       const secret = await pb.restore();
-      await BrowserAuthSecretStore.saveSecret(secret);
+      await auth.login(secret);
       await navigate();
     } catch (err) {
       status = { kind: "error", message: describeError(err) };
+    } finally {
       busy = false;
     }
   }

--- a/starters/sveltekit-hybrid/src/lib/JazzClientProvider.svelte
+++ b/starters/sveltekit-hybrid/src/lib/JazzClientProvider.svelte
@@ -1,47 +1,26 @@
 <script lang="ts">
-  import { onMount } from "svelte";
   import {
     createJazzClient,
     JazzSvelteProvider,
-    BrowserAuthSecretStore,
+    LocalFirstAuth,
   } from "jazz-tools/svelte";
-  import type { DbConfig } from "jazz-tools";
+  import type { AuthState } from "jazz-tools";
   import type { Snippet } from "svelte";
   import { env } from "$env/dynamic/public";
-  import { authClient, getToken } from "$lib/auth-client";
+  import { getToken } from "$lib/auth-client";
 
   let {
     authenticated,
     children: pageChildren,
   }: { authenticated: boolean; children: Snippet } = $props();
 
-  let client = $state<ReturnType<typeof createJazzClient> | null>(null);
+  const appId = env.PUBLIC_JAZZ_APP_ID;
+  const serverUrl = env.PUBLIC_JAZZ_SERVER_URL;
 
-  onMount(() => {
-    let unsubRefresh: (() => void) | undefined;
+  const auth = new LocalFirstAuth();
+  let jwtToken = $state<string | null>(null);
 
-    (async () => {
-      const config = await buildConfig(authenticated);
-      if (!config) return;
-      const jazzClient = createJazzClient(config);
-      client = jazzClient;
-
-      if (authenticated) {
-        const resolved = await jazzClient;
-        unsubRefresh = resolved.db.onAuthChanged(async (state) => {
-          if (state.error !== "expired") return;
-          const fresh = await getToken();
-          if (fresh) resolved.db.updateAuthToken(fresh);
-        });
-      }
-    })();
-
-    return () => unsubRefresh?.();
-  });
-
-  async function buildConfig(auth: boolean): Promise<DbConfig | null> {
-    const appId = env.PUBLIC_JAZZ_APP_ID;
-    const serverUrl = env.PUBLIC_JAZZ_SERVER_URL;
+  $effect(() => {
     if (!appId || !serverUrl) {
       const missing = [
         !appId && "PUBLIC_JAZZ_APP_ID",
@@ -52,21 +31,52 @@
       console.error(
         `${missing} not set — the jazzSvelteKit() plugin should inject these.`,
       );
-      return Promise.resolve(null);
     }
-    const base: Omit<DbConfig, "jwtToken" | "secret"> = { appId, serverUrl };
+  });
 
-    if (auth) {
-      return getToken().then((token) =>
-        token ? { ...base, jwtToken: token } : null,
-      );
+  $effect(() => {
+    if (!authenticated) {
+      jwtToken = null;
+      return;
     }
+    let cancelled = false;
+    void getToken().then((token) => {
+      if (!cancelled) jwtToken = token;
+    });
+    return () => {
+      cancelled = true;
+    };
+  });
 
-    return BrowserAuthSecretStore.getOrCreateSecret().then((secret) => ({
-      ...base,
-      secret,
-    }));
-  }
+  let client = $derived.by(() => {
+    if (!appId || !serverUrl) return null;
+    if (authenticated) {
+      return jwtToken ? createJazzClient({ appId, serverUrl, jwtToken }) : null;
+    }
+    return !auth.isLoading && auth.secret
+      ? createJazzClient({ appId, serverUrl, secret: auth.secret })
+      : null;
+  });
+
+  $effect(() => {
+    if (!client || !authenticated) return;
+    const currentClient = client;
+    let cancelled = false;
+    let unsubRefresh: (() => void) | undefined;
+    void (async () => {
+      const resolved = await currentClient;
+      if (cancelled) return;
+      unsubRefresh = resolved.db.onAuthChanged(async (state: AuthState) => {
+        if (state.error !== "expired") return;
+        const fresh = await getToken();
+        if (fresh) resolved.db.updateAuthToken(fresh);
+      });
+    })();
+    return () => {
+      cancelled = true;
+      unsubRefresh?.();
+    };
+  });
 </script>
 
 {#if client}

--- a/starters/sveltekit-hybrid/src/routes/+page.svelte
+++ b/starters/sveltekit-hybrid/src/routes/+page.svelte
@@ -1,16 +1,17 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import { authClient } from "$lib/auth-client";
-  import { BrowserAuthSecretStore } from "jazz-tools/svelte";
+  import { LocalFirstAuth } from "jazz-tools/svelte";
   import TodoWidget from "$lib/TodoWidget.svelte";
   import AuthBackup from "$lib/AuthBackup.svelte";
 
   const session = authClient.useSession();
+  // Auto-syncs with the layout's LocalFirstAuth instance via the shared
+  // per-store notifier, so signOut here clears the secret everywhere.
+  const auth = new LocalFirstAuth();
 
   async function handleSignOut() {
-    // Clear the anonymous secret before signOut so that the reactive $effect
-    // in the layout gets a fresh anonymous identity when it rebuilds the client.
-    await BrowserAuthSecretStore.clearSecret();
+    await auth.signOut();
     await authClient.signOut();
     await goto("/");
   }

--- a/starters/sveltekit-localfirst/README.md
+++ b/starters/sveltekit-localfirst/README.md
@@ -45,8 +45,9 @@ src/
 Every browser gets its own Ed25519 secret, generated and stored by
 `BrowserAuthSecretStore` on first load. That secret becomes the identity
 Jazz uses for all subsequent writes. `src/routes/+layout.svelte` does
-exactly one thing: call `BrowserAuthSecretStore.getOrCreateSecret()` and
-hand the result to `createJazzClient` as `secret`.
+exactly one thing: instantiate `LocalFirstAuth` (a reactive class from
+`jazz-tools/svelte` that loads or generates the secret client-side) and
+hand `auth.secret` to `createJazzClient`.
 
 Data syncs to the Jazz server under that anonymous identity. There is no
 concept of a user account, no sign-in, no sign-out — the device _is_ the

--- a/starters/sveltekit-localfirst/src/lib/AuthBackup.svelte
+++ b/starters/sveltekit-localfirst/src/lib/AuthBackup.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { BrowserAuthSecretStore } from "jazz-tools/svelte";
+  import { LocalFirstAuth } from "jazz-tools/svelte";
   import { goto } from "$app/navigation";
 
   // In production, pin this to your deployed hostname so passkeys remain
@@ -21,18 +21,15 @@
     mode?: "full" | "restore-only";
   } = $props();
 
+  const auth = new LocalFirstAuth();
+
   let phrase = $state<string | null>(null);
   let restoreInput = $state("");
   let status = $state<Status>({ kind: "idle" });
   let busy = $state(false);
 
   async function navigate() {
-    if (redirectAfterRestore) {
-      await goto(redirectAfterRestore);
-      location.reload();
-    } else {
-      location.reload();
-    }
+    if (redirectAfterRestore) await goto(redirectAfterRestore);
   }
 
   function describeError(err: unknown): string {
@@ -47,13 +44,12 @@
     status = { kind: "idle" };
     busy = true;
     try {
-      const secret = await BrowserAuthSecretStore.loadSecret();
-      if (!secret) {
+      if (!auth.secret) {
         status = { kind: "error", message: "No local secret to reveal yet." };
         return;
       }
       const { RecoveryPhrase } = await import("jazz-tools/passphrase");
-      phrase = RecoveryPhrase.fromSecret(secret);
+      phrase = RecoveryPhrase.fromSecret(auth.secret);
     } catch (err) {
       status = { kind: "error", message: describeError(err) };
     } finally {
@@ -81,10 +77,11 @@
     try {
       const { RecoveryPhrase } = await import("jazz-tools/passphrase");
       const secret = RecoveryPhrase.toSecret(restoreInput.trim());
-      await BrowserAuthSecretStore.saveSecret(secret);
+      await auth.login(secret);
       await navigate();
     } catch (err) {
       status = { kind: "error", message: describeError(err) };
+    } finally {
       busy = false;
     }
   }
@@ -93,8 +90,7 @@
     status = { kind: "idle" };
     busy = true;
     try {
-      const secret = await BrowserAuthSecretStore.loadSecret();
-      if (!secret) {
+      if (!auth.secret) {
         status = { kind: "error", message: "No local secret to back up yet." };
         return;
       }
@@ -103,7 +99,7 @@
         appName: PASSKEY_APP_NAME,
         appHostname: PASSKEY_APP_HOSTNAME,
       });
-      await pb.backup(secret, "My account");
+      await pb.backup(auth.secret, "My account");
       status = { kind: "success", message: "Passkey backup created." };
     } catch (err) {
       status = { kind: "error", message: describeError(err) };
@@ -122,10 +118,11 @@
         appHostname: PASSKEY_APP_HOSTNAME,
       });
       const secret = await pb.restore();
-      await BrowserAuthSecretStore.saveSecret(secret);
+      await auth.login(secret);
       await navigate();
     } catch (err) {
       status = { kind: "error", message: describeError(err) };
+    } finally {
       busy = false;
     }
   }

--- a/starters/sveltekit-localfirst/src/routes/+layout.svelte
+++ b/starters/sveltekit-localfirst/src/routes/+layout.svelte
@@ -1,39 +1,34 @@
 <script lang="ts">
   import "../app.css";
-  import { onMount } from "svelte";
-  import { createJazzClient, JazzSvelteProvider, BrowserAuthSecretStore } from "jazz-tools/svelte";
-  import type { DbConfig } from "jazz-tools";
+  import { createJazzClient, JazzSvelteProvider, LocalFirstAuth } from "jazz-tools/svelte";
   import { env } from "$env/dynamic/public";
 
   let { children: pageChildren } = $props();
 
-  let client = $state<ReturnType<typeof createJazzClient> | null>(null);
+  const auth = new LocalFirstAuth();
 
-  onMount(() => {
-    (async () => {
-      const appId = env.PUBLIC_JAZZ_APP_ID;
-      const serverUrl = env.PUBLIC_JAZZ_SERVER_URL;
-      if (!appId || !serverUrl) {
-        const missing = [
-          !appId && "PUBLIC_JAZZ_APP_ID",
-          !serverUrl && "PUBLIC_JAZZ_SERVER_URL",
-        ]
-          .filter((v) => !!v)
-          .join(" & ");
-        console.error(
-          `${missing} not set — the jazzSvelteKit() plugin should inject these.`,
-        );
-        return;
-      }
-      const secret = await BrowserAuthSecretStore.getOrCreateSecret();
-      const config: DbConfig = {
-        appId,
-        serverUrl,
-        secret,
-      };
-      client = createJazzClient(config);
-    })();
+  const appId = env.PUBLIC_JAZZ_APP_ID;
+  const serverUrl = env.PUBLIC_JAZZ_SERVER_URL;
+
+  $effect(() => {
+    if (!appId || !serverUrl) {
+      const missing = [
+        !appId && "PUBLIC_JAZZ_APP_ID",
+        !serverUrl && "PUBLIC_JAZZ_SERVER_URL",
+      ]
+        .filter((v) => !!v)
+        .join(" & ");
+      console.error(
+        `${missing} not set — the jazzSvelteKit() plugin should inject these.`,
+      );
+    }
   });
+
+  let client = $derived(
+    !auth.isLoading && auth.secret && appId && serverUrl
+      ? createJazzClient({ appId, serverUrl, secret: auth.secret })
+      : null,
+  );
 </script>
 
 {#if client}


### PR DESCRIPTION
## Summary
- New `LocalFirstAuth` reactive class in `jazz-tools/svelte` and `useLocalFirstAuth` composable in `jazz-tools/vue`, mirroring the existing React hook. Both read the secret store only on the client and notify sibling instances on `login`/`signOut` so a single sign-out invalidates the whole tree.
- `BrowserAuthSecretStore` throws a clearer error when used outside a browser and resolves `localStorage` lazily, so server-side imports of the module singleton don't blow up.
- `jazzSvelteKit` plugin restarts the dev server on warm starts when `PUBLIC_JAZZ_SERVER_URL` is missing from the captured env — previously only the first-ever cold start triggered a restart, leaving warm runs unable to reach the dev server.

## Test plan
- [ ] `pnpm test` in `packages/jazz-tools` (vue + svelte + sveltekit configs).
- [ ] Scaffold a SvelteKit app using the docs snippet, log in / sign out / refresh — verify the provider remounts cleanly each time and `$env/dynamic/public.PUBLIC_JAZZ_SERVER_URL` resolves on warm starts.
- [ ] Same for a Vue + Vite app via the docs snippet.