### PR TITLE
fix: mark local batch rows rejected only for replayble

### DIFF
--- a/crates/jazz-tools/src/runtime_core/mod.rs
+++ b/crates/jazz-tools/src/runtime_core/mod.rs
@@ -367,8 +367,14 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             .scan_acknowledged_rejected_batch_fates()
             .map(|batch_ids| batch_ids.into_iter().collect())
             .unwrap_or_default();
+        let replayable_rejected_batch_fates = rejected_batch_fates
+            .into_iter()
+            .filter(|fate| {
+                Self::has_startup_rejected_batch_replay_metadata(&storage, fate.batch_id())
+            })
+            .collect::<Vec<_>>();
         let pending_mutation_error_events: BTreeMap<BatchId, MutationErrorEvent> =
-            rejected_batch_fates
+            replayable_rejected_batch_fates
                 .iter()
                 .filter_map(|fate| {
                     let crate::batch_fate::BatchFate::Rejected {
@@ -428,12 +434,19 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         // "delete visible row + retract subscriptions", lingering visible
         // rows would render on reload and then get retracted by the next
         // network-delivered settlement — a visible flash. Re-apply stored
-        // rejections before any query can observe the visible region.
-        for fate in rejected_batch_fates {
-            core.mark_local_batch_rows_rejected(fate.batch_id());
+        // rejections before any query can observe the visible region. Only
+        // batches with local replay metadata can own such optimistic rows;
+        // orphan authoritative fates are server history, not startup work.
+        for fate in replayable_rejected_batch_fates {
+            core.mark_indexed_local_batch_rows_rejected(fate.batch_id());
         }
 
         core
+    }
+
+    fn has_startup_rejected_batch_replay_metadata(storage: &S, batch_id: BatchId) -> bool {
+        matches!(storage.load_sealed_batch_submission(batch_id), Ok(Some(_)))
+            || matches!(storage.load_local_batch_record(batch_id), Ok(Some(_)))
     }
 
     /// Set the tier label used in tracing spans.

--- a/crates/jazz-tools/src/runtime_core/tests.rs
+++ b/crates/jazz-tools/src/runtime_core/tests.rs
@@ -36,6 +36,7 @@ struct RowRegionReadFailingStorage {
     inner: MemoryStorage,
     fail_visible_row_reads: bool,
     fail_row_locator_scans: bool,
+    history_row_batch_scan_calls: Option<Arc<Mutex<usize>>>,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -70,6 +71,7 @@ impl RowRegionReadFailingStorage {
             inner: MemoryStorage::new(),
             fail_visible_row_reads: true,
             fail_row_locator_scans: false,
+            history_row_batch_scan_calls: None,
         }
     }
 
@@ -78,6 +80,16 @@ impl RowRegionReadFailingStorage {
             inner: MemoryStorage::new(),
             fail_visible_row_reads: false,
             fail_row_locator_scans: true,
+            history_row_batch_scan_calls: None,
+        }
+    }
+
+    fn with_history_row_batch_scan_counter(calls: Arc<Mutex<usize>>) -> Self {
+        Self {
+            inner: MemoryStorage::new(),
+            fail_visible_row_reads: false,
+            fail_row_locator_scans: false,
+            history_row_batch_scan_calls: Some(calls),
         }
     }
 }
@@ -344,6 +356,9 @@ impl Storage for RowRegionReadFailingStorage {
         table: &str,
         row_id: ObjectId,
     ) -> Result<Vec<crate::row_histories::StoredRowBatch>, StorageError> {
+        if let Some(calls) = &self.history_row_batch_scan_calls {
+            *calls.lock().unwrap() += 1;
+        }
         self.inner.scan_history_row_batches(table, row_id)
     }
 

--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/rejection_recovery.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/rejection_recovery.rs
@@ -1397,6 +1397,55 @@ fn rc_restart_retracts_visible_rows_with_stored_rejected_settlement() {
 }
 
 #[test]
+fn rc_startup_ignores_orphan_rejected_fates_without_replay_metadata() {
+    let schema = test_schema();
+    let schema_hash = SchemaHash::compute(&schema);
+    let batch_id = BatchId::new();
+    let history_row_batch_scan_calls = Arc::new(Mutex::new(0));
+    let mut storage = RowRegionReadFailingStorage::with_history_row_batch_scan_counter(
+        history_row_batch_scan_calls.clone(),
+    );
+
+    for _ in 0..3 {
+        storage
+            .put_row_locator(
+                ObjectId::new(),
+                Some(&RowLocator {
+                    table: "users".into(),
+                    origin_schema_hash: Some(schema_hash),
+                }),
+            )
+            .unwrap();
+    }
+    storage
+        .upsert_authoritative_batch_fate(&crate::batch_fate::BatchFate::Rejected {
+            batch_id,
+            code: "permission_denied".to_string(),
+            reason: "server-side rejected fate without local replay metadata".to_string(),
+        })
+        .unwrap();
+
+    let app_id = AppId::from_name("rc-startup-orphan-rejected-fate-test");
+    let schema_manager =
+        SchemaManager::new(SyncManager::new(), schema, app_id, "dev", "main").unwrap();
+    let mut restarted = new_test_core(
+        schema_manager,
+        Box::new(storage) as Box<dyn Storage>,
+        NoopScheduler,
+    );
+
+    assert_eq!(
+        *history_row_batch_scan_calls.lock().unwrap(),
+        0,
+        "startup should not globally scan row histories for rejected fates with no local replay metadata"
+    );
+    assert!(
+        restarted.drain_mutation_error_events().is_empty(),
+        "orphan server-side rejected fates should not be surfaced as local mutation errors"
+    );
+}
+
+#[test]
 fn rc_persisting_invalid_multibranch_sealed_batch_submission_fails() {
     let schema = test_schema();
     let schema_hash = SchemaHash::compute(&schema);

--- a/crates/jazz-tools/src/runtime_core/ticks.rs
+++ b/crates/jazz-tools/src/runtime_core/ticks.rs
@@ -32,6 +32,29 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         crate::storage::RowLocator,
         crate::row_histories::StoredRowBatch,
     )> {
+        self.local_batch_rows_with_scan_policy(batch_id, true)
+    }
+
+    fn indexed_local_batch_rows(
+        &self,
+        batch_id: crate::row_histories::BatchId,
+    ) -> Vec<(
+        LocalBatchMember,
+        crate::storage::RowLocator,
+        crate::row_histories::StoredRowBatch,
+    )> {
+        self.local_batch_rows_with_scan_policy(batch_id, false)
+    }
+
+    fn local_batch_rows_with_scan_policy(
+        &self,
+        batch_id: crate::row_histories::BatchId,
+        include_unindexed_history_scan: bool,
+    ) -> Vec<(
+        LocalBatchMember,
+        crate::storage::RowLocator,
+        crate::row_histories::StoredRowBatch,
+    )> {
         let mut rows = Vec::new();
         if let Ok(Some(submission)) = self.storage.load_sealed_batch_submission(batch_id) {
             for sealed_member in submission.members {
@@ -136,6 +159,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             }
         }
         if rows.is_empty()
+            && include_unindexed_history_scan
             && let Ok(row_locators) = self.storage.scan_row_locators()
         {
             for (object_id, row_locator) in row_locators {
@@ -298,10 +322,31 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         &mut self,
         batch_id: crate::row_histories::BatchId,
     ) {
+        self.mark_local_batch_rows_rejected_with_scan_policy(batch_id, true);
+    }
+
+    pub(crate) fn mark_indexed_local_batch_rows_rejected(
+        &mut self,
+        batch_id: crate::row_histories::BatchId,
+    ) {
+        self.mark_local_batch_rows_rejected_with_scan_policy(batch_id, false);
+    }
+
+    fn mark_local_batch_rows_rejected_with_scan_policy(
+        &mut self,
+        batch_id: crate::row_histories::BatchId,
+        include_unindexed_history_scan: bool,
+    ) {
         let mut cleared_rows = Vec::new();
         let mut batch_patch_succeeded_by_table = std::collections::HashMap::new();
 
-        for (member, row_locator, row) in self.local_batch_rows(batch_id) {
+        let local_batch_rows = if include_unindexed_history_scan {
+            self.local_batch_rows(batch_id)
+        } else {
+            self.indexed_local_batch_rows(batch_id)
+        };
+
+        for (member, row_locator, row) in local_batch_rows {
             let was_visible = matches!(row.state, RowState::VisibleDirect)
                 || (matches!(row.state, RowState::Rejected)
                     && self


### PR DESCRIPTION
## Summary

Fix server startup hanging on large databases when stored authoritative `Rejected` batch fates have no local replay metadata.

## Cause

Startup replay was scanning all stored authoritative `Rejected` fates and treating each one as a local rejected batch that might need optimistic rows retracted.

For rejected fates that no longer had a local batch record or sealed batch submission, `local_batch_rows()` fell back to a global history scan across all row locators. On the reported database this meant roughly:

- 3,015 rejected fates without local replay metadata
- 18,891 row locators
- ~57M worst-case row-history scans before the server could bind its port

These fates are server-side authoritative history, not necessarily local optimistic writes. Replaying them at startup was both semantically too broad and very expensive.

## Fix

Startup now only replays stored rejected fates when there is local replay metadata proving the batch may own optimistic local rows:

- persisted sealed batch submission
- persisted local batch record

The startup replay path also uses an indexed/member-based lookup only, avoiding the unindexed global row-history scan during `RuntimeCore::new`.

The global fallback remains available for the recovery/reconciliation paths that still need it.

## Why This Fix

The original startup replay check existed to cover a real crash-recovery case: if the runtime crashes after persisting a rejection settlement but before retracting the optimistic visible row, restart must apply the rejection before queries can observe stale data.

That case still has local replay metadata, so it continues to be handled.

Orphan authoritative rejected fates without local replay metadata cannot reliably be attributed to local optimistic rows. Treating them as startup replay work causes pathological startup cost on server databases that retain many historical rejected fates.

## Consequences

Startup no longer surfaces orphan server-side rejected fates as local mutation errors.

If a database contains a corrupted local optimistic row whose rejected batch has lost both its sealed submission and local batch record, startup will not repair it through the global scan anymore. That state is not reliably distinguishable from ordinary server history, so repairing it should be handled by an explicit migration/diagnostic path rather than blocking every startup.

Expected effect: large server databases with retained rejected fates should reach the listening state without the rejected-fate × row-locator scan explosion.

## Tests

Added regression coverage for orphan rejected fates with row locators but no local replay metadata.

Verified:

```bash
cargo test -p jazz-tools --features test --lib
```

Result: `1398 passed, 0 failed`.