### PR TITLE
Fix jazz-tools CLI silently no-opping under a pnpm symlink

### DIFF
--- a/.changeset/cli-pnpm-symlink-main-module.md
+++ b/.changeset/cli-pnpm-symlink-main-module.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix the `jazz-tools` CLI silently exiting 0 without running any command when `dist/cli.js` is invoked through a pnpm symlink. `isMainModule()` now compares the realpaths of both `process.argv[1]` and `import.meta.url`, so the symlinked package path resolves and the CLI dispatches as expected.

--- a/packages/jazz-tools/src/cli.test.ts
+++ b/packages/jazz-tools/src/cli.test.ts
@@ -9,6 +9,7 @@ import {
   readFile,
   readdir,
   rm,
+  symlink,
   writeFile,
 } from "node:fs/promises";
 import { dirname, join } from "node:path";
@@ -34,6 +35,7 @@ import {
 const dslPath = fileURLToPath(new URL("./dsl.ts", import.meta.url));
 const indexPath = fileURLToPath(new URL("./index.ts", import.meta.url));
 const distIndexPath = fileURLToPath(new URL("../dist/index.js", import.meta.url));
+const distCliPath = fileURLToPath(new URL("../dist/cli.js", import.meta.url));
 const binPath = fileURLToPath(new URL("../bin/jazz-tools.js", import.meta.url));
 const bootstrapVerifierPath = fileURLToPath(
   new URL("../scripts/verify-packed-runtime-bootstrap.mjs", import.meta.url),
@@ -3114,5 +3116,29 @@ exit 0
     expect(result.stdout).toContain("migrations push");
     expect(result.stdout).toContain("server");
     expect(result.stdout).toContain("create");
+  });
+});
+
+describe("dist/cli.js entrypoint under a pnpm symlink", () => {
+  it("dispatches when invoked through a symlinked package directory", async () => {
+    await mkdir(tmpBase, { recursive: true });
+    const root = await mkdtemp(join(tmpBase, "jazz-tools-pnpm-symlink-"));
+    tempRoots.push(root);
+
+    // pnpm symlinks node_modules/jazz-tools to node_modules/.pnpm/.../jazz-tools.
+    // Running dist/cli.js through that symlink must still run the CLI body
+    // instead of silently exiting 0.
+    const realPackageDir = dirname(dirname(distCliPath));
+    const linkedPackageDir = join(root, "jazz-tools");
+    await symlink(realPackageDir, linkedPackageDir, "dir");
+
+    const result = spawnSync(process.execPath, [join(linkedPackageDir, "dist", "cli.js")], {
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(
+      "Usage: node <path-to-jazz-tools>/dist/cli.js <command> [options]",
+    );
   });
 });

--- a/packages/jazz-tools/src/cli.ts
+++ b/packages/jazz-tools/src/cli.ts
@@ -2,10 +2,10 @@
 
 // CLI for jazz-tools schema tooling
 
-import { existsSync, readFileSync } from "fs";
+import { existsSync, readFileSync, realpathSync } from "fs";
 import { access, mkdir, readFile, readdir, rm, writeFile } from "fs/promises";
 import { basename, dirname, join, resolve } from "path";
-import { pathToFileURL } from "url";
+import { fileURLToPath, pathToFileURL } from "url";
 import { build } from "esbuild";
 import type {
   ColumnDescriptor,
@@ -1937,12 +1937,22 @@ export async function deploy(options: DeployOptions): Promise<void> {
   console.log(`Published permissions as ${describePermissionsHead(nextHead)}.`);
 }
 
+function realpathOrSelf(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return path;
+  }
+}
+
 function isMainModule(): boolean {
   const entry = process.argv[1];
   if (!entry) {
     return false;
   }
-  return pathToFileURL(entry).href === import.meta.url;
+  // pnpm reaches the CLI through a symlinked package path, so argv[1] and
+  // import.meta.url differ only by symlink resolution. Compare realpaths.
+  return realpathOrSelf(entry) === realpathOrSelf(fileURLToPath(import.meta.url));
 }
 
 if (isMainModule()) {


### PR DESCRIPTION
## Summary
- `dist/cli.js` exited 0 without running any command when invoked through a pnpm symlink: `isMainModule()` compared the symlinked `process.argv[1]` against the realpath `import.meta.url`, so the entire CLI dispatch was skipped — migrations/deploys silently no-opped.
- `isMainModule()` now compares the realpaths of *both* sides (falling back to the raw path when one can't be resolved), so the CLI dispatches whether reached directly or through pnpm's symlinked package path.
- Added a regression test that invokes the built `dist/cli.js` through a symlinked package directory and asserts it dispatches.

## Test plan
- [ ] `cd packages/jazz-tools && pnpm exec vitest run --config vitest.config.ts src/cli.test.ts` — full file green (82/82), incl. "dist/cli.js entrypoint under a pnpm symlink"
- [ ] In a pnpm project: `node node_modules/jazz-tools/dist/cli.js` prints usage instead of exiting silently

Fixes garden-co/jazz#860