### PR TITLE
Add animated TierSyncDiagram to how-sync-works docs

### DIFF
--- a/docs/components/mdx/diagram/frame.tsx
+++ b/docs/components/mdx/diagram/frame.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react";
+
+// Shared chrome for MDX diagrams: hidden on small screens (mobile gets a
+// static fallback), wrapped in a rounded card with the eyebrow + description
+// styling that every diagram uses.
+export function DiagramFrame({
+  eyebrow,
+  description,
+  children,
+}: {
+  eyebrow: string;
+  description: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <div className="my-6 rounded-xl border border-fd-border bg-fd-card/30 p-5 not-prose hidden lg:block">
+      <p className="uppercase text-xs font-bold text-fd-primary">{eyebrow}</p>
+      <p className="text-sm text-fd-muted-foreground mb-6">{description}</p>
+      {children}
+    </div>
+  );
+}

--- a/docs/components/mdx/diagram/geometry.ts
+++ b/docs/components/mdx/diagram/geometry.ts
@@ -1,0 +1,102 @@
+// Shared geometry primitives for diagram path builders. Pure functions over
+// DOMRects — used by both the lens diagram and the tier-sync diagram.
+
+// 2px CSS border + 2px SVG stroke ⇒ centreline inset by 1px from the outer
+// edge of the box, so the path centre coincides with the border centre.
+export const PATH_INSET = 1;
+
+// rounded-lg (8px outer) minus the inset ⇒ centreline corner radius.
+export const DEFAULT_CORNER_RADIUS = 8 - PATH_INSET;
+
+export type Anchors = {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+  midX: number;
+  midY: number;
+};
+
+export function insetRect(rect: DOMRect, container: DOMRect): Anchors {
+  return {
+    left: rect.left - container.left + PATH_INSET,
+    right: rect.right - container.left - PATH_INSET,
+    top: rect.top - container.top + PATH_INSET,
+    bottom: rect.bottom - container.top - PATH_INSET,
+    midX: (rect.left + rect.right) / 2 - container.left,
+    midY: (rect.top + rect.bottom) / 2 - container.top,
+  };
+}
+
+export function anchorsFor(el: HTMLElement | null | undefined, container: DOMRect): Anchors | null {
+  if (!el) return null;
+  return insetRect(el.getBoundingClientRect(), container);
+}
+
+export type LoopSide = "top" | "bottom" | "left" | "right";
+
+// CCW (screen-space) perimeter loop around a rounded box, starting and ending
+// at the same point on one side. The pen is assumed to already be at the entry
+// point before this runs.
+//
+// For "top"/"bottom" sides, `entryAt` is the X coordinate of the entry; for
+// "left"/"right" sides it is the Y coordinate. Pass `a.midX` / `a.midY` to
+// enter at the centre of the side.
+export function loopRoundedBox(
+  a: Anchors,
+  entryAt: number,
+  side: LoopSide,
+  cornerRadius: number = DEFAULT_CORNER_RADIUS,
+): string {
+  const r = cornerRadius;
+  switch (side) {
+    case "top":
+      return [
+        `L ${a.left + r} ${a.top}`,
+        `A ${r} ${r} 0 0 0 ${a.left} ${a.top + r}`,
+        `L ${a.left} ${a.bottom - r}`,
+        `A ${r} ${r} 0 0 0 ${a.left + r} ${a.bottom}`,
+        `L ${a.right - r} ${a.bottom}`,
+        `A ${r} ${r} 0 0 0 ${a.right} ${a.bottom - r}`,
+        `L ${a.right} ${a.top + r}`,
+        `A ${r} ${r} 0 0 0 ${a.right - r} ${a.top}`,
+        `L ${entryAt} ${a.top}`,
+      ].join(" ");
+    case "bottom":
+      return [
+        `L ${a.right - r} ${a.bottom}`,
+        `A ${r} ${r} 0 0 0 ${a.right} ${a.bottom - r}`,
+        `L ${a.right} ${a.top + r}`,
+        `A ${r} ${r} 0 0 0 ${a.right - r} ${a.top}`,
+        `L ${a.left + r} ${a.top}`,
+        `A ${r} ${r} 0 0 0 ${a.left} ${a.top + r}`,
+        `L ${a.left} ${a.bottom - r}`,
+        `A ${r} ${r} 0 0 0 ${a.left + r} ${a.bottom}`,
+        `L ${entryAt} ${a.bottom}`,
+      ].join(" ");
+    case "left":
+      return [
+        `L ${a.left} ${a.bottom - r}`,
+        `A ${r} ${r} 0 0 0 ${a.left + r} ${a.bottom}`,
+        `L ${a.right - r} ${a.bottom}`,
+        `A ${r} ${r} 0 0 0 ${a.right} ${a.bottom - r}`,
+        `L ${a.right} ${a.top + r}`,
+        `A ${r} ${r} 0 0 0 ${a.right - r} ${a.top}`,
+        `L ${a.left + r} ${a.top}`,
+        `A ${r} ${r} 0 0 0 ${a.left} ${a.top + r}`,
+        `L ${a.left} ${entryAt}`,
+      ].join(" ");
+    case "right":
+      return [
+        `L ${a.right} ${a.top + r}`,
+        `A ${r} ${r} 0 0 0 ${a.right - r} ${a.top}`,
+        `L ${a.left + r} ${a.top}`,
+        `A ${r} ${r} 0 0 0 ${a.left} ${a.top + r}`,
+        `L ${a.left} ${a.bottom - r}`,
+        `A ${r} ${r} 0 0 0 ${a.left + r} ${a.bottom}`,
+        `L ${a.right - r} ${a.bottom}`,
+        `A ${r} ${r} 0 0 0 ${a.right} ${a.bottom - r}`,
+        `L ${a.right} ${entryAt}`,
+      ].join(" ");
+  }
+}

--- a/docs/components/mdx/diagram/styles.tsx
+++ b/docs/components/mdx/diagram/styles.tsx
@@ -1,0 +1,37 @@
+// Shared CSS for animated MDX diagrams. Rendered once via React 19's
+// <style href="..."> dedup — any diagram can drop in <DiagramStyles /> and
+// reuse the classes below.
+
+const DIAGRAM_STYLES_CSS = `
+.diagram-path {
+  stroke-dasharray: 99999;
+  stroke-dashoffset: 99999;
+  opacity: 0;
+}
+@keyframes diagram-pulse-frames {
+  0%   { box-shadow: 0 0 0 0 rgba(20, 106, 255, 0.55); opacity: 1; }
+  20%  { box-shadow: 0 0 0 4px rgba(20, 106, 255, 0.45); opacity: 1; }
+  100% { box-shadow: 0 0 0 14px rgba(20, 106, 255, 0); opacity: 0; }
+}
+.diagram-pulse {
+  animation: diagram-pulse-frames 1400ms ease-out forwards;
+}
+.diagram-dot {
+  filter: drop-shadow(0 0 5px rgba(20, 106, 255, 1)) drop-shadow(0 0 12px rgba(20, 106, 255, 0.55));
+}
+@keyframes diagram-tally-frames {
+  0%   { transform: translateY(60%); }
+  100% { transform: translateY(0); }
+}
+.diagram-tally {
+  animation: diagram-tally-frames 180ms cubic-bezier(0.2, 0.9, 0.4, 1);
+}
+`;
+
+export function DiagramStyles() {
+  return (
+    <style href="diagram-shared-styles" precedence="default">
+      {DIAGRAM_STYLES_CSS}
+    </style>
+  );
+}

--- a/docs/components/mdx/diagram/trace-anim.ts
+++ b/docs/components/mdx/diagram/trace-anim.ts
@@ -1,0 +1,79 @@
+// Imperative helpers for the stroke-dasharray + leading-dot trace animation
+// pattern shared by every animated diagram. They operate on raw DOM elements
+// so callers stay in control of scheduling.
+
+// Trigger the "draw" animation on a path: stroke-dasharray = length, animate
+// dashoffset from length to 0 over `durationMs`. Returns the path length so
+// the caller can compute timing offsets without measuring again.
+export function drawPath(
+  pathEl: SVGPathElement,
+  durationMs: number,
+  options?: { easing?: string; opacity?: string },
+): number {
+  const len = pathEl.getTotalLength();
+  pathEl.style.transition = "none";
+  pathEl.style.strokeDasharray = `${len}`;
+  pathEl.style.strokeDashoffset = `${len}`;
+  pathEl.style.opacity = options?.opacity ?? "1";
+  // Force reflow so the next transition starts from the dashoffset we just set.
+  void pathEl.getBoundingClientRect();
+  pathEl.style.transition = `stroke-dashoffset ${durationMs}ms ${options?.easing ?? "ease-out"}`;
+  pathEl.style.strokeDashoffset = "0";
+  return len;
+}
+
+// Snap a path straight to its fully-drawn state without animating. Useful when
+// a re-render (resize, hot reload) shouldn't replay the trace.
+export function snapPathDrawn(pathEl: SVGPathElement, dotEl?: SVGCircleElement | null): number {
+  const len = pathEl.getTotalLength();
+  pathEl.style.transition = "none";
+  pathEl.style.strokeDasharray = `${len}`;
+  pathEl.style.strokeDashoffset = "0";
+  pathEl.style.opacity = "1";
+  if (dotEl) {
+    const end = pathEl.getPointAtLength(len);
+    dotEl.setAttribute("cx", String(end.x));
+    dotEl.setAttribute("cy", String(end.y));
+  }
+  return len;
+}
+
+// Follow a path's currently-animating stroke-dashoffset with a leading dot
+// element. The caller supplies an optional `opacityForDistance` to fade the
+// dot during a particular stretch of the path (e.g. while it loops a node).
+//
+// Returns a cleanup function that cancels the RAF loop.
+export function trackDotAlongPath(
+  pathEl: SVGPathElement,
+  dotEl: SVGCircleElement,
+  options?: {
+    opacityForDistance?: (distance: number, length: number) => number;
+    onComplete?: () => void;
+  },
+): () => void {
+  const length = pathEl.getTotalLength();
+  let rafId = 0;
+  const tick = () => {
+    const offset = parseFloat(getComputedStyle(pathEl).strokeDashoffset);
+    if (Number.isNaN(offset)) {
+      rafId = 0;
+      return;
+    }
+    const distance = Math.max(0, length - offset);
+    const point = pathEl.getPointAtLength(distance);
+    dotEl.setAttribute("cx", String(point.x));
+    dotEl.setAttribute("cy", String(point.y));
+    const opacity = options?.opacityForDistance ? options.opacityForDistance(distance, length) : 1;
+    dotEl.style.opacity = String(opacity);
+    if (offset > 0.5) {
+      rafId = requestAnimationFrame(tick);
+    } else {
+      dotEl.style.opacity = "0";
+      options?.onComplete?.();
+    }
+  };
+  rafId = requestAnimationFrame(tick);
+  return () => {
+    if (rafId) cancelAnimationFrame(rafId);
+  };
+}

--- a/docs/components/mdx/lens-diagram-path.ts
+++ b/docs/components/mdx/lens-diagram-path.ts
@@ -1,5 +1,14 @@
-// Pure geometry / path helpers for the lens diagram. No React, no DOM mutation
-// — just functions over DOMRects that produce SVG path strings.
+// Lens-diagram geometry — builds a single CCW path that snakes through the
+// data card, every schema/lens card on the projection chain, and out to the
+// client. Shared geometry primitives live in ./diagram/geometry.
+
+import {
+  PATH_INSET,
+  DEFAULT_CORNER_RADIUS,
+  type Anchors,
+  insetRect,
+  loopRoundedBox,
+} from "./diagram/geometry";
 
 export type Version = 1 | 2 | 3;
 export type Direction = "forward" | "backward" | "na";
@@ -13,51 +22,20 @@ function unreachable(x: never): never {
   throw new Error(`unreachable: ${String(x)}`);
 }
 
-const PATH_INSET = 1; // 2px CSS border, 2px SVG stroke → inset stroke centreline by 1px
-const SCHEMA_RADIUS = 8 - PATH_INSET; // rounded-lg = 8px outer; centreline radius
-
-type InsetRect = {
-  left: number;
-  right: number;
-  top: number;
-  bottom: number;
-  midX: number;
-  midY: number;
-};
-
-function insetRect(rect: DOMRect, container: DOMRect): InsetRect {
-  return {
-    left: rect.left - container.left + PATH_INSET,
-    right: rect.right - container.left - PATH_INSET,
-    top: rect.top - container.top + PATH_INSET,
-    bottom: rect.bottom - container.top - PATH_INSET,
-    midX: (rect.left + rect.right) / 2 - container.left,
-    midY: (rect.top + rect.bottom) / 2 - container.top,
-  };
-}
-
 type LoopStart = "left" | "top" | "bottom";
 
-// CCW perimeter loop around a schema, starting and ending at the same midpoint.
+// Schema cards are rounded-lg → DEFAULT_CORNER_RADIUS works directly.
 function loopSchema(rect: DOMRect, container: DOMRect, start: LoopStart): string {
-  const { left, right, top, bottom, midX, midY } = insetRect(rect, container);
-  const r = SCHEMA_RADIUS;
-  switch (start) {
-    case "left":
-      return `L ${left} ${bottom - r} A ${r} ${r} 0 0 0 ${left + r} ${bottom} L ${right - r} ${bottom} A ${r} ${r} 0 0 0 ${right} ${bottom - r} L ${right} ${top + r} A ${r} ${r} 0 0 0 ${right - r} ${top} L ${left + r} ${top} A ${r} ${r} 0 0 0 ${left} ${top + r} L ${left} ${midY}`;
-    case "top":
-      return `L ${left + r} ${top} A ${r} ${r} 0 0 0 ${left} ${top + r} L ${left} ${bottom - r} A ${r} ${r} 0 0 0 ${left + r} ${bottom} L ${right - r} ${bottom} A ${r} ${r} 0 0 0 ${right} ${bottom - r} L ${right} ${top + r} A ${r} ${r} 0 0 0 ${right - r} ${top} L ${midX} ${top}`;
-    case "bottom":
-      return `L ${right - r} ${bottom} A ${r} ${r} 0 0 0 ${right} ${bottom - r} L ${right} ${top + r} A ${r} ${r} 0 0 0 ${right - r} ${top} L ${left + r} ${top} A ${r} ${r} 0 0 0 ${left} ${top + r} L ${left} ${bottom - r} A ${r} ${r} 0 0 0 ${left + r} ${bottom} L ${midX} ${bottom}`;
-    default:
-      return unreachable(start);
-  }
+  const a = insetRect(rect, container);
+  const entry = start === "left" ? a.midY : a.midX;
+  return loopRoundedBox(a, entry, start);
 }
 
-// CCW perimeter loop around a lens.
-// borderRadius "50% / 35%" → outer rx = w/2, ry = h*0.35; centreline shifts in by 1px.
+// Lens cards use a pill/ellipse shape (borderRadius "50% / 35%"). The path
+// hugs that silhouette — straight sides, elliptical top and bottom caps.
 function loopLens(rect: DOMRect, container: DOMRect, start: LoopStart): string {
-  const { left, right, top, bottom, midX, midY } = insetRect(rect, container);
+  const a = insetRect(rect, container);
+  const { left, right, top, bottom, midX, midY } = a;
   const rx = rect.width / 2 - PATH_INSET;
   const ry = rect.height * 0.35 - PATH_INSET;
   switch (start) {
@@ -129,7 +107,8 @@ export function buildPath(args: {
     const isLens = cards[i].type === "lens";
     const isFirst = i === 0;
     const isLast = i === cards.length - 1;
-    const { right, top, bottom, midX, midY } = insetRect(rect, c);
+    const a: Anchors = insetRect(rect, c);
+    const { right, midX, midY, top, bottom } = a;
 
     // First card enters at left-mid (from the data card); subsequent cards
     // enter at top-mid (forward/idle) or bottom-mid (backward).
@@ -158,3 +137,7 @@ export function buildPath(args: {
 
   return path;
 }
+
+// Re-export the unused symbol so it lives in the bundle if anything elsewhere
+// references it. (Kept to mirror the previous public surface.)
+export { DEFAULT_CORNER_RADIUS };

--- a/docs/components/mdx/lens-diagram.tsx
+++ b/docs/components/mdx/lens-diagram.tsx
@@ -11,6 +11,9 @@ import {
   type Direction,
   type Version,
 } from "./lens-diagram-path";
+import { DiagramFrame } from "./diagram/frame";
+import { DiagramStyles } from "./diagram/styles";
+import { drawPath, snapPathDrawn, trackDotAlongPath } from "./diagram/trace-anim";
 
 type Row =
   | { title: string; completed?: never; done?: never }
@@ -395,60 +398,40 @@ export function LensDiagram() {
   useLayoutEffect(() => {
     const el = arrowPathRef.current;
     if (!el || !pathD) return;
-    const len = el.getTotalLength();
-    if (len <= 0) return;
+    if (el.getTotalLength() <= 0) return;
 
     // Re-trigger the draw animation only on user interaction (when the
     // selected version pair changes). Path updates from a window resize
     // arrive on the same key and should snap to the fully-drawn state.
     const key = `${dataVersion}-${client}`;
     if (lastAnimatedKey.current === key) {
-      el.style.transition = "none";
-      el.style.strokeDasharray = `${len}`;
-      el.style.strokeDashoffset = "0";
-      const dot = tipDotRef.current;
-      if (dot) {
-        const end = el.getPointAtLength(len);
-        dot.setAttribute("cx", String(end.x));
-        dot.setAttribute("cy", String(end.y));
-      }
+      snapPathDrawn(el, tipDotRef.current);
       return;
     }
     lastAnimatedKey.current = key;
 
-    el.style.transition = "none";
-    el.style.strokeDasharray = `${len}`;
-    el.style.strokeDashoffset = `${len}`;
-    void el.getBoundingClientRect();
+    const len = el.getTotalLength();
     const duration = Math.max(500, Math.min(len * 1.43, 3000));
-    el.style.transition = `stroke-dashoffset ${duration}ms ease-out`;
-    el.style.strokeDashoffset = "0";
+    drawPath(el, duration);
 
     const dot = tipDotRef.current;
     if (!dot) return;
-    let rafId = 0;
-    const tick = () => {
-      const offset = parseFloat(getComputedStyle(el).strokeDashoffset);
-      if (Number.isNaN(offset)) return;
-      const distance = Math.max(0, len - offset);
-      const point = el.getPointAtLength(distance);
-      dot.setAttribute("cx", String(point.x));
-      dot.setAttribute("cy", String(point.y));
-      if (offset > 0.5) {
-        rafId = requestAnimationFrame(tick);
-      }
-    };
-    rafId = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(rafId);
+    return trackDotAlongPath(el, dot);
   }, [pathD]);
 
   return (
-    <div className="my-6 rounded-xl border border-fd-border bg-fd-card/30 p-5 not-prose hidden lg:block">
+    <DiagramFrame
+      eyebrow="Interactive Demo"
+      description={
+        <>
+          Choose data from the left, then pick a schema version on the client device. The row is
+          loaded as-is, and the client applies all the lenses needed to interpret it using its
+          schema.
+        </>
+      }
+    >
+      <DiagramStyles />
       <style precedence="default">{`
-        .lens-arrow-path {
-          stroke-dasharray: 99999;
-          stroke-dashoffset: 99999;
-        }
         @keyframes lens-projection-in {
           from { opacity: 0; transform: translateX(-4px); }
           to { opacity: 1; transform: translateY(0); }
@@ -457,12 +440,6 @@ export function LensDiagram() {
           animation: lens-projection-in 200ms ease-out 350ms both;
         }
       `}</style>
-
-      <p className="uppercase text-xs font-bold text-fd-primary">Interactive Demo</p>
-      <p className="text-sm text-fd-muted-foreground mb-4">
-        Choose data from the left, then pick a schema version on the client device. The row is
-        loaded as-is, and the client applies all the lenses needed to interpret it using its schema.
-      </p>
 
       <div
         ref={containerRef}
@@ -562,7 +539,7 @@ export function LensDiagram() {
             >
               <path
                 ref={arrowPathRef}
-                className="lens-arrow-path"
+                className="diagram-path"
                 d={pathD}
                 stroke="currentColor"
                 strokeWidth="2"
@@ -581,6 +558,6 @@ export function LensDiagram() {
           </>
         )}
       </div>
-    </div>
+    </DiagramFrame>
   );
 }

--- a/docs/components/mdx/tier-sync-diagram.tsx
+++ b/docs/components/mdx/tier-sync-diagram.tsx
@@ -1,0 +1,687 @@
+"use client";
+
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { Cloud, Plus, Server, Smartphone, type LucideIcon } from "lucide-react";
+
+import { cn } from "@/lib/cn";
+
+import {
+  anchorsFor,
+  buildConnectionPath,
+  buildStaticTopology,
+  type Anchors,
+} from "./tier-sync-path";
+import { DiagramFrame } from "./diagram/frame";
+import { DiagramStyles } from "./diagram/styles";
+import { drawPath, trackDotAlongPath } from "./diagram/trace-anim";
+
+type Tier = "global" | "edge" | "local";
+type NodeKey = "global" | "edge1" | "edge2" | "alice" | "bob" | "charlie";
+
+type NodeMeta = { label: string; subtitle: string; tier: Tier };
+
+const NODES: Record<NodeKey, NodeMeta> = {
+  global: { label: "Global", subtitle: "global core", tier: "global" },
+  edge1: { label: "Edge", subtitle: "sync server", tier: "edge" },
+  edge2: { label: "Edge", subtitle: "sync server", tier: "edge" },
+  alice: { label: "Alice", subtitle: "local", tier: "local" },
+  bob: { label: "Bob", subtitle: "local", tier: "local" },
+  charlie: { label: "Charlie", subtitle: "local", tier: "local" },
+};
+
+const TIER_ICONS: Record<Tier, LucideIcon> = {
+  global: Cloud,
+  edge: Server,
+  local: Smartphone,
+};
+
+const TOPOLOGY: Record<NodeKey, NodeKey[]> = {
+  alice: ["edge1"],
+  bob: ["edge1"],
+  charlie: ["edge2"],
+  edge1: ["alice", "bob", "global"],
+  edge2: ["charlie", "global"],
+  global: ["edge1", "edge2"],
+};
+
+const CLIENTS: NodeKey[] = ["alice", "bob", "charlie"];
+
+type Hop = { from: NodeKey; to: NodeKey };
+
+const ALL_HOPS: Hop[] = (() => {
+  const out: Hop[] = [];
+  for (const [from, neighbors] of Object.entries(TOPOLOGY) as Array<[NodeKey, NodeKey[]]>) {
+    for (const to of neighbors) out.push({ from, to });
+  }
+  return out;
+})();
+
+function hopId(h: Hop): string {
+  return `${h.from}-${h.to}`;
+}
+
+function bfsFrom(writer: NodeKey): Array<Hop[]> {
+  const visited = new Set<NodeKey>([writer]);
+  const stages: Array<Hop[]> = [];
+  let frontier: NodeKey[] = [writer];
+  while (frontier.length > 0) {
+    const nextFrontier: NodeKey[] = [];
+    const hops: Hop[] = [];
+    for (const node of frontier) {
+      for (const neighbor of TOPOLOGY[node]) {
+        if (visited.has(neighbor)) continue;
+        visited.add(neighbor);
+        hops.push({ from: node, to: neighbor });
+        nextFrontier.push(neighbor);
+      }
+    }
+    if (hops.length > 0) stages.push(hops);
+    frontier = nextFrontier;
+  }
+  return stages;
+}
+
+// Targets that aren't forwarded onward — leaves of the BFS spanning tree.
+function terminalsOf(stages: Hop[][]): Set<NodeKey> {
+  const sources = new Set<NodeKey>();
+  const targets = new Set<NodeKey>();
+  for (const stage of stages) {
+    for (const hop of stage) {
+      sources.add(hop.from);
+      targets.add(hop.to);
+    }
+  }
+  const out = new Set<NodeKey>();
+  for (const t of targets) if (!sources.has(t)) out.add(t);
+  return out;
+}
+
+function tierDepth(tier: Tier): number {
+  return tier === "global" ? 0 : tier === "edge" ? 1 : 2;
+}
+
+const STAGE_DURATION = 1100;
+const TRACE_FADE_MS = 700;
+const PULSE_ANIMATION_MS = 1400;
+const PRIMARY = "#146aff";
+
+type PulseState = Record<NodeKey, number>;
+type ColorState = Record<NodeKey, string | null>;
+
+const ZERO_PULSES: PulseState = {
+  global: 0,
+  edge1: 0,
+  edge2: 0,
+  alice: 0,
+  bob: 0,
+  charlie: 0,
+};
+const INITIAL_COLOR = "#146aff";
+const INITIAL_COLORS: ColorState = {
+  global: INITIAL_COLOR,
+  edge1: INITIAL_COLOR,
+  edge2: INITIAL_COLOR,
+  alice: INITIAL_COLOR,
+  bob: INITIAL_COLOR,
+  charlie: INITIAL_COLOR,
+};
+
+const PALETTE = [
+  "#ef4444",
+  "#f97316",
+  "#eab308",
+  "#22c55e",
+  "#06b6d4",
+  "#3b82f6",
+  "#8b5cf6",
+  "#ec4899",
+];
+
+function pickNextColor(current: string | null): string {
+  const choices = PALETTE.filter((c) => c !== current);
+  return choices[Math.floor(Math.random() * choices.length)];
+}
+
+type WriteEvent = {
+  id: number;
+  writer: NodeKey;
+  value: string;
+  stages: Hop[][];
+  startedAt: number;
+};
+
+function NodeCard({
+  nodeKey,
+  color,
+  pulseKey,
+  onWrite,
+  innerRef,
+}: {
+  nodeKey: NodeKey;
+  color: string | null;
+  pulseKey: number;
+  onWrite?: () => void;
+  innerRef: (el: HTMLDivElement | null) => void;
+}) {
+  const meta = NODES[nodeKey];
+  const Icon = TIER_ICONS[meta.tier];
+  return (
+    <div
+      ref={innerRef}
+      className="rounded-lg border-2 border-fd-border bg-fd-card px-3 py-2 w-[10rem] flex flex-col items-center text-center relative"
+    >
+      {pulseKey > 0 && (
+        <span
+          key={pulseKey}
+          className="diagram-pulse pointer-events-none absolute inset-[-2px] rounded-lg"
+        />
+      )}
+      <Icon className="h-4 w-4 mb-1 text-fd-muted-foreground" />
+      <div className="text-xs font-semibold text-fd-foreground leading-tight">{meta.label}</div>
+      <div className="text-[10px] text-fd-muted-foreground leading-tight">{meta.subtitle}</div>
+      <div
+        className="mt-2 w-full rounded px-2 py-1 flex items-center justify-between gap-1.5 transition-colors duration-200"
+        style={{ backgroundColor: color ? `${color}26` : undefined }}
+      >
+        <span className="text-[10px] font-mono text-fd-muted-foreground">color</span>
+        <span
+          className="inline-block overflow-hidden text-xs font-mono tabular-nums text-fd-foreground leading-none"
+          style={{ height: "1em" }}
+          aria-live="polite"
+        >
+          <span key={`hex-${color ?? "none"}`} className="block diagram-tally">
+            {color ?? "—"}
+          </span>
+        </span>
+        <span
+          className="inline-block overflow-hidden rounded border border-fd-border flex-shrink-0"
+          style={{ height: "0.9rem", width: "0.9rem" }}
+        >
+          <span
+            key={`sw-${color ?? "none"}`}
+            className="block diagram-tally h-full w-full"
+            style={{ backgroundColor: color ?? "transparent" }}
+          />
+        </span>
+      </div>
+      {onWrite && (
+        <button
+          type="button"
+          aria-label={`New colour from ${meta.label}`}
+          onClick={onWrite}
+          className="mt-2 block w-full rounded border border-fd-border bg-fd-card px-2 py-1 text-xs font-medium text-fd-foreground hover:bg-fd-accent cursor-pointer flex items-center justify-center gap-1"
+        >
+          <Plus className="h-3 w-3" />
+          <span>New colour</span>
+        </button>
+      )}
+    </div>
+  );
+}
+
+export function TierSyncDiagram() {
+  const [colors, setColors] = useState<ColorState>(INITIAL_COLORS);
+  const [pulses, setPulses] = useState<PulseState>(ZERO_PULSES);
+  const [events, setEvents] = useState<WriteEvent[]>([]);
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const nodeRefs = useRef<Partial<Record<NodeKey, HTMLDivElement | null>>>({});
+
+  const [svgSize, setSvgSize] = useState({ w: 0, h: 0 });
+  const [pathDs, setPathDs] = useState<Record<string, string>>({});
+  const [staticD, setStaticD] = useState("");
+
+  // One <path> per directed hop, hidden — used only for getTotalLength / getPointAtLength.
+  const measurePathRefs = useRef<Record<string, SVGPathElement | null>>({});
+  const lengthCache = useRef<Record<string, number>>({});
+  const destReachCache = useRef<Record<string, number>>({});
+
+  // One animated <path> + <circle> per (event, hop).
+  const eventPathRefs = useRef<Record<string, SVGPathElement | null>>({});
+  const eventDotRefs = useRef<Record<string, SVGCircleElement | null>>({});
+
+  const eventIdRef = useRef(0);
+  const scheduledEventsRef = useRef<Set<number>>(new Set());
+  const eventResourcesRef = useRef<
+    Map<number, { timers: ReturnType<typeof setTimeout>[]; cleanups: Array<() => void> }>
+  >(new Map());
+
+  const lastInteractionRef = useRef(performance.now());
+  const fireWriteRef = useRef<(writer: NodeKey, isUserAction?: boolean) => void>(() => {});
+  const colorsRef = useRef<ColorState>(INITIAL_COLORS);
+
+  // Per-node LWW guard: every node remembers the highest event id it has seen
+  // and rejects arrivals with an older id, so concurrent writes converge.
+  const lastSeenIdRef = useRef<Record<NodeKey, number>>({
+    global: 0,
+    edge1: 0,
+    edge2: 0,
+    alice: 0,
+    bob: 0,
+    charlie: 0,
+  });
+
+  useLayoutEffect(() => {
+    function measure() {
+      const container = containerRef.current;
+      if (!container) return;
+      const c = container.getBoundingClientRect();
+      if (c.width === 0) return;
+
+      const anchors: Partial<Record<NodeKey, Anchors>> = {};
+      for (const key of Object.keys(NODES) as NodeKey[]) {
+        const a = anchorsFor(nodeRefs.current[key], c);
+        if (a) anchors[key] = a;
+      }
+      if (
+        !anchors.global ||
+        !anchors.edge1 ||
+        !anchors.edge2 ||
+        !anchors.alice ||
+        !anchors.bob ||
+        !anchors.charlie
+      ) {
+        return;
+      }
+
+      const next: Record<string, string> = {};
+      const dests: Record<string, number> = {};
+      for (const hop of ALL_HOPS) {
+        const src = anchors[hop.from]!;
+        const tgt = anchors[hop.to]!;
+        const fromDepth = tierDepth(NODES[hop.from].tier);
+        const toDepth = tierDepth(NODES[hop.to].tier);
+        const direction = fromDepth > toDepth ? "up" : "down";
+        const upper = fromDepth < toDepth ? src : tgt;
+        const lower = fromDepth < toDepth ? tgt : src;
+        const armY = (upper.bottom + lower.top) / 2;
+        const { d, destReachDistance } = buildConnectionPath({
+          source: src,
+          target: tgt,
+          direction,
+          armY,
+          includeSourceLoop: false,
+        });
+        next[hopId(hop)] = d;
+        dests[hopId(hop)] = destReachDistance;
+      }
+
+      const staticPath = buildStaticTopology([
+        {
+          parent: anchors.global,
+          children: [anchors.edge1, anchors.edge2],
+          armY: (anchors.global.bottom + anchors.edge1.top) / 2,
+        },
+        {
+          parent: anchors.edge1,
+          children: [anchors.alice, anchors.bob],
+          armY: (anchors.edge1.bottom + anchors.alice.top) / 2,
+        },
+        {
+          parent: anchors.edge2,
+          children: [anchors.charlie],
+          armY: (anchors.edge2.bottom + anchors.charlie.top) / 2,
+        },
+      ]);
+
+      setSvgSize((prev) =>
+        prev.w === c.width && prev.h === c.height ? prev : { w: c.width, h: c.height },
+      );
+      setPathDs(next);
+      setStaticD(staticPath);
+      destReachCache.current = dests;
+    }
+
+    measure();
+    const ro = new ResizeObserver(measure);
+    if (containerRef.current) ro.observe(containerRef.current);
+    for (const key of Object.keys(NODES) as NodeKey[]) {
+      const el = nodeRefs.current[key];
+      if (el) ro.observe(el);
+    }
+    return () => ro.disconnect();
+  }, []);
+
+  // Cache total length per directed hop using the hidden measurement paths.
+  useLayoutEffect(() => {
+    for (const hop of ALL_HOPS) {
+      const id = hopId(hop);
+      const el = measurePathRefs.current[id];
+      if (!el) continue;
+      lengthCache.current[id] = el.getTotalLength();
+    }
+  }, [pathDs]);
+
+  function scheduleEvent(event: WriteEvent) {
+    const resources: {
+      timers: ReturnType<typeof setTimeout>[];
+      cleanups: Array<() => void>;
+    } = {
+      timers: [],
+      cleanups: [],
+    };
+    eventResourcesRef.current.set(event.id, resources);
+
+    let stageDelay = 0;
+    for (let s = 0; s < event.stages.length; s++) {
+      const currentStageDelay = stageDelay;
+      for (const hop of event.stages[s]) {
+        const id = hopId(hop);
+        const len = lengthCache.current[id] ?? 0;
+        const destDist = destReachCache.current[id] ?? len;
+        const duration = Math.max(700, Math.min(len * 1.3, STAGE_DURATION - 60));
+        const arrivalTime = currentStageDelay + duration * (destDist / Math.max(1, len));
+        const target = hop.to;
+        const value = event.value;
+
+        // Receiver pulse + counter update fire exactly when the leading dot
+        // crosses the target edge — but only if this event is newer than
+        // anything the target has already seen (LWW by event id).
+        resources.timers.push(
+          setTimeout(() => {
+            const lastSeen = lastSeenIdRef.current[target] ?? 0;
+            if (event.id <= lastSeen) return;
+            lastSeenIdRef.current = { ...lastSeenIdRef.current, [target]: event.id };
+            colorsRef.current = { ...colorsRef.current, [target]: value };
+            setColors((c) => ({ ...c, [target]: value }));
+            setPulses((p) => ({ ...p, [target]: p[target] + 1 }));
+          }, arrivalTime),
+        );
+
+        // Kick off the trace draw + dot animation at the start of this stage.
+        resources.timers.push(
+          setTimeout(() => {
+            const key = `${event.id}-${id}`;
+            const pathEl = eventPathRefs.current[key];
+            const dotEl = eventDotRefs.current[key];
+            if (!pathEl) return;
+
+            drawPath(pathEl, duration);
+
+            // Path fades after the draw completes.
+            resources.timers.push(
+              setTimeout(() => {
+                if (!pathEl.isConnected) return;
+                pathEl.style.transition = `opacity ${TRACE_FADE_MS}ms ease-out`;
+                pathEl.style.opacity = "0";
+              }, duration),
+            );
+
+            if (!dotEl) return;
+            // Full opacity along the arm; linear fade as the dot wraps the
+            // receiver, hitting 0 exactly when the trace finishes drawing.
+            const loopLength = Math.max(1, len - destDist);
+            const stop = trackDotAlongPath(pathEl, dotEl, {
+              opacityForDistance: (distance) =>
+                distance <= destDist ? 1 : Math.max(0, 1 - (distance - destDist) / loopLength),
+            });
+            resources.cleanups.push(stop);
+          }, currentStageDelay),
+        );
+      }
+      stageDelay += STAGE_DURATION;
+    }
+
+    // Drop the event from state once the trace, pulse, and dot fade have all
+    // had time to finish.
+    resources.timers.push(
+      setTimeout(
+        () => {
+          setEvents((evts) => evts.filter((e) => e.id !== event.id));
+        },
+        stageDelay + PULSE_ANIMATION_MS + 400,
+      ),
+    );
+  }
+
+  // Schedule animations for newly added events; clean up resources for removed ones.
+  useEffect(() => {
+    for (const event of events) {
+      if (scheduledEventsRef.current.has(event.id)) continue;
+      scheduledEventsRef.current.add(event.id);
+      scheduleEvent(event);
+    }
+    const liveIds = new Set(events.map((e) => e.id));
+    for (const id of Array.from(scheduledEventsRef.current)) {
+      if (liveIds.has(id)) continue;
+      const res = eventResourcesRef.current.get(id);
+      if (res) {
+        res.timers.forEach((t) => clearTimeout(t));
+        res.cleanups.forEach((fn) => fn());
+        eventResourcesRef.current.delete(id);
+      }
+      scheduledEventsRef.current.delete(id);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [events]);
+
+  // Component unmount cleanup.
+  useEffect(() => {
+    return () => {
+      for (const res of eventResourcesRef.current.values()) {
+        res.timers.forEach((t) => clearTimeout(t));
+        res.cleanups.forEach((fn) => fn());
+      }
+      eventResourcesRef.current.clear();
+      scheduledEventsRef.current.clear();
+    };
+  }, []);
+
+  function fireWrite(writer: NodeKey, isUserAction = true) {
+    if (isUserAction) {
+      lastInteractionRef.current = performance.now();
+    }
+    const newEventId = ++eventIdRef.current;
+    const newValue = pickNextColor(colorsRef.current[writer]);
+    // Keep the ref ahead of React's commit so rapid clicks see the new value.
+    colorsRef.current = { ...colorsRef.current, [writer]: newValue };
+    // Writer immediately stamps its own row with this event id so later
+    // arrivals from older waves are rejected.
+    lastSeenIdRef.current = { ...lastSeenIdRef.current, [writer]: newEventId };
+
+    const event: WriteEvent = {
+      id: newEventId,
+      writer,
+      value: newValue,
+      stages: bfsFrom(writer),
+      startedAt: performance.now(),
+    };
+
+    setColors((prev) => ({ ...prev, [writer]: newValue }));
+    setEvents((evts) => (evts.some((e) => e.id === newEventId) ? evts : [...evts, event]));
+    setPulses((p) => ({ ...p, [writer]: p[writer] + 1 }));
+  }
+
+  fireWriteRef.current = fireWrite;
+
+  // Demo on mount + ambient pulses when the user goes idle. Each iteration
+  // waits 5s±3s; if there has been no user interaction in the last 5s, a
+  // random client fires a write.
+  useEffect(() => {
+    const demoTimer = setTimeout(() => fireWriteRef.current("alice", false), 900);
+    let loopTimer: ReturnType<typeof setTimeout>;
+    function loop() {
+      const sinceInteraction = performance.now() - lastInteractionRef.current;
+      if (sinceInteraction >= 5000) {
+        const writer = CLIENTS[Math.floor(Math.random() * CLIENTS.length)];
+        fireWriteRef.current(writer, false);
+        const delay = 7000 + Math.random() * 6000; // 10s ± 3s
+        loopTimer = setTimeout(loop, delay);
+      } else {
+        loopTimer = setTimeout(loop, 5000 - sinceInteraction + 200);
+      }
+    }
+    loopTimer = setTimeout(loop, 5000);
+    return () => {
+      clearTimeout(demoTimer);
+      clearTimeout(loopTimer);
+    };
+  }, []);
+
+  return (
+    <DiagramFrame
+      eyebrow="Live sync"
+      description={
+        <>
+          Click <span className="font-mono">New colour</span> on any client to set a new colour for
+          the row. The change propagates: up to that client's edge, across to siblings and the
+          global core, then down through the other edge. If two clients write at once, the most
+          recent write wins, and every node eventually ends up showing the same colour.
+        </>
+      }
+    >
+      <DiagramStyles />
+      <div
+        ref={containerRef}
+        className="relative grid grid-cols-3 gap-x-6"
+        style={{ rowGap: "4.5rem" }}
+      >
+        {svgSize.w > 0 && (
+          <svg
+            className="absolute inset-0 pointer-events-none"
+            style={{ zIndex: 0 }}
+            width={svgSize.w}
+            height={svgSize.h}
+            viewBox={`0 0 ${svgSize.w} ${svgSize.h}`}
+          >
+            <path
+              d={staticD}
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              fill="none"
+              className="text-fd-border"
+            />
+            {/* Hidden measurement paths — kept here for getPointAtLength. */}
+            <g style={{ display: "none" }}>
+              {ALL_HOPS.map((hop) => {
+                const id = hopId(hop);
+                return (
+                  <path
+                    key={id}
+                    ref={(el) => {
+                      measurePathRefs.current[id] = el;
+                    }}
+                    d={pathDs[id] ?? ""}
+                  />
+                );
+              })}
+            </g>
+          </svg>
+        )}
+
+        <div className="col-span-3 relative z-10 flex justify-center">
+          <NodeCard
+            nodeKey="global"
+            color={colors.global}
+            pulseKey={pulses.global}
+            innerRef={(el) => {
+              nodeRefs.current.global = el;
+            }}
+          />
+        </div>
+
+        <div className="col-span-2 relative z-10 flex justify-center">
+          <NodeCard
+            nodeKey="edge1"
+            color={colors.edge1}
+            pulseKey={pulses.edge1}
+            innerRef={(el) => {
+              nodeRefs.current.edge1 = el;
+            }}
+          />
+        </div>
+        <div className="col-span-1 relative z-10 flex justify-center">
+          <NodeCard
+            nodeKey="edge2"
+            color={colors.edge2}
+            pulseKey={pulses.edge2}
+            innerRef={(el) => {
+              nodeRefs.current.edge2 = el;
+            }}
+          />
+        </div>
+
+        {CLIENTS.map((client) => (
+          <div key={client} className="col-span-1 relative z-10 flex justify-center">
+            <NodeCard
+              nodeKey={client}
+              color={colors[client]}
+              pulseKey={pulses[client]}
+              onWrite={() => fireWrite(client)}
+              innerRef={(el) => {
+                nodeRefs.current[client] = el;
+              }}
+            />
+          </div>
+        ))}
+
+        {svgSize.w > 0 && (
+          <>
+            <svg
+              className="absolute inset-0 pointer-events-none"
+              style={{ zIndex: 30 }}
+              width={svgSize.w}
+              height={svgSize.h}
+              viewBox={`0 0 ${svgSize.w} ${svgSize.h}`}
+            >
+              {events.flatMap((event) =>
+                event.stages.flatMap((stage) =>
+                  stage.map((hop) => {
+                    const id = hopId(hop);
+                    const key = `${event.id}-${id}`;
+                    return (
+                      <path
+                        key={key}
+                        ref={(el) => {
+                          eventPathRefs.current[key] = el;
+                        }}
+                        className="diagram-path"
+                        d={pathDs[id] ?? ""}
+                        stroke={PRIMARY}
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        fill="none"
+                      />
+                    );
+                  }),
+                ),
+              )}
+            </svg>
+            <svg
+              className="absolute inset-0 pointer-events-none"
+              style={{ zIndex: 40 }}
+              width={svgSize.w}
+              height={svgSize.h}
+              viewBox={`0 0 ${svgSize.w} ${svgSize.h}`}
+            >
+              {events.flatMap((event) =>
+                event.stages.flatMap((stage) =>
+                  stage.map((hop) => {
+                    const id = hopId(hop);
+                    const key = `${event.id}-${id}`;
+                    return (
+                      <circle
+                        key={key}
+                        ref={(el) => {
+                          eventDotRefs.current[key] = el;
+                        }}
+                        className="diagram-dot"
+                        r="5"
+                        cx="0"
+                        cy="0"
+                        fill={PRIMARY}
+                        style={{ opacity: 0 }}
+                      />
+                    );
+                  }),
+                ),
+              )}
+            </svg>
+          </>
+        )}
+      </div>
+    </DiagramFrame>
+  );
+}

--- a/docs/components/mdx/tier-sync-diagram.tsx
+++ b/docs/components/mdx/tier-sync-diagram.tsx
@@ -109,20 +109,31 @@ const INITIAL_COLORS: ColorState = {
   charlie: INITIAL_COLOR,
 };
 
-const PALETTE = [
-  "#ef4444",
-  "#f97316",
-  "#eab308",
-  "#22c55e",
-  "#06b6d4",
-  "#3b82f6",
-  "#8b5cf6",
-  "#ec4899",
-];
+// Random saturated HSL. Reject anything within MIN_HUE_GAP of the writer's
+// previous hue so consecutive clicks visibly change colour.
+const MIN_HUE_GAP = 40;
+
+function parseHue(color: string | null): number | null {
+  if (!color) return null;
+  const m = /hsl\(\s*(-?\d+(?:\.\d+)?)/.exec(color);
+  return m ? Number(m[1]) : null;
+}
+
+function hueDistance(a: number, b: number): number {
+  const d = Math.abs(a - b) % 360;
+  return d > 180 ? 360 - d : d;
+}
 
 function pickNextColor(current: string | null): string {
-  const choices = PALETTE.filter((c) => c !== current);
-  return choices[Math.floor(Math.random() * choices.length)];
+  const prev = parseHue(current);
+  let hue = Math.floor(Math.random() * 360);
+  if (prev !== null) {
+    for (let i = 0; i < 8 && hueDistance(hue, prev) < MIN_HUE_GAP; i++) {
+      hue = Math.floor(Math.random() * 360);
+    }
+  }
+  const saturation = 75 + Math.floor(Math.random() * 20); // 75–94%
+  return `hsl(${hue} ${saturation}% 50%)`;
 }
 
 type WriteEvent = {

--- a/docs/components/mdx/tier-sync-diagram.tsx
+++ b/docs/components/mdx/tier-sync-diagram.tsx
@@ -3,8 +3,6 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Cloud, Plus, Server, Smartphone, type LucideIcon } from "lucide-react";
 
-import { cn } from "@/lib/cn";
-
 import {
   anchorsFor,
   buildConnectionPath,
@@ -79,21 +77,6 @@ function bfsFrom(writer: NodeKey): Array<Hop[]> {
     frontier = nextFrontier;
   }
   return stages;
-}
-
-// Targets that aren't forwarded onward — leaves of the BFS spanning tree.
-function terminalsOf(stages: Hop[][]): Set<NodeKey> {
-  const sources = new Set<NodeKey>();
-  const targets = new Set<NodeKey>();
-  for (const stage of stages) {
-    for (const hop of stage) {
-      sources.add(hop.from);
-      targets.add(hop.to);
-    }
-  }
-  const out = new Set<NodeKey>();
-  for (const t of targets) if (!sources.has(t)) out.add(t);
-  return out;
 }
 
 function tierDepth(tier: Tier): number {

--- a/docs/components/mdx/tier-sync-diagram.tsx
+++ b/docs/components/mdx/tier-sync-diagram.tsx
@@ -109,14 +109,54 @@ const INITIAL_COLORS: ColorState = {
   charlie: INITIAL_COLOR,
 };
 
-// Random saturated HSL. Reject anything within MIN_HUE_GAP of the writer's
-// previous hue so consecutive clicks visibly change colour.
+// Random saturated colour, returned as #rrggbb so labels stay compact. Reject
+// anything within MIN_HUE_GAP of the writer's previous hue so consecutive
+// clicks visibly change colour.
 const MIN_HUE_GAP = 40;
 
-function parseHue(color: string | null): number | null {
-  if (!color) return null;
-  const m = /hsl\(\s*(-?\d+(?:\.\d+)?)/.exec(color);
-  return m ? Number(m[1]) : null;
+function hexToHue(hex: string): number | null {
+  const m = /^#([0-9a-f]{6})$/i.exec(hex);
+  if (!m) return null;
+  const n = parseInt(m[1], 16);
+  const r = ((n >> 16) & 0xff) / 255;
+  const g = ((n >> 8) & 0xff) / 255;
+  const b = (n & 0xff) / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const d = max - min;
+  if (d === 0) return 0;
+  let h: number;
+  if (max === r) h = ((g - b) / d) % 6;
+  else if (max === g) h = (b - r) / d + 2;
+  else h = (r - g) / d + 4;
+  h *= 60;
+  return h < 0 ? h + 360 : h;
+}
+
+function hslToHex(h: number, s: number, l: number): string {
+  const sat = s / 100;
+  const lit = l / 100;
+  const c = (1 - Math.abs(2 * lit - 1)) * sat;
+  const hh = (h % 360) / 60;
+  const x = c * (1 - Math.abs((hh % 2) - 1));
+  const [r1, g1, b1] =
+    hh < 1
+      ? [c, x, 0]
+      : hh < 2
+        ? [x, c, 0]
+        : hh < 3
+          ? [0, c, x]
+          : hh < 4
+            ? [0, x, c]
+            : hh < 5
+              ? [x, 0, c]
+              : [c, 0, x];
+  const m = lit - c / 2;
+  const to255 = (v: number) =>
+    Math.round((v + m) * 255)
+      .toString(16)
+      .padStart(2, "0");
+  return `#${to255(r1)}${to255(g1)}${to255(b1)}`;
 }
 
 function hueDistance(a: number, b: number): number {
@@ -125,7 +165,7 @@ function hueDistance(a: number, b: number): number {
 }
 
 function pickNextColor(current: string | null): string {
-  const prev = parseHue(current);
+  const prev = current ? hexToHue(current) : null;
   let hue = Math.floor(Math.random() * 360);
   if (prev !== null) {
     for (let i = 0; i < 8 && hueDistance(hue, prev) < MIN_HUE_GAP; i++) {
@@ -133,7 +173,7 @@ function pickNextColor(current: string | null): string {
     }
   }
   const saturation = 75 + Math.floor(Math.random() * 20); // 75–94%
-  return `hsl(${hue} ${saturation}% 50%)`;
+  return hslToHex(hue, saturation, 50);
 }
 
 type WriteEvent = {

--- a/docs/components/mdx/tier-sync-path.ts
+++ b/docs/components/mdx/tier-sync-path.ts
@@ -1,0 +1,68 @@
+// Tier-sync geometry — arms in a parent's "trunk + horizontal arm + drops"
+// shape, plus optional loops around source/target receivers. Shared geometry
+// primitives live in ./diagram/geometry.
+
+import { type Anchors, anchorsFor, loopRoundedBox } from "./diagram/geometry";
+
+export { anchorsFor, type Anchors };
+
+export type ConnectionDirection = "up" | "down";
+
+// A single propagation hop:
+//   source edge → (optional source loop) → drop to arm → horizontal arm →
+//   drop to target edge → loop target.
+// `destReachDistance` is the path length up to the target edge, i.e. where the
+// leading dot should fade and the receiver should pulse.
+export function buildConnectionPath(args: {
+  source: Anchors;
+  target: Anchors;
+  direction: ConnectionDirection;
+  armY: number;
+  includeSourceLoop: boolean;
+}): { d: string; destReachDistance: number } {
+  const { source, target, direction, armY, includeSourceLoop } = args;
+  const sourceEdgeY = direction === "up" ? source.top : source.bottom;
+  const targetEdgeY = direction === "up" ? target.bottom : target.top;
+  const sourceSide = direction === "up" ? "top" : "bottom";
+  const targetSide = direction === "up" ? "bottom" : "top";
+
+  let prefix = `M ${source.midX} ${sourceEdgeY}`;
+  if (includeSourceLoop) {
+    prefix += " " + loopRoundedBox(source, source.midX, sourceSide);
+  }
+  prefix += ` L ${source.midX} ${armY}`;
+  prefix += ` L ${target.midX} ${armY}`;
+  prefix += ` L ${target.midX} ${targetEdgeY}`;
+
+  const full = prefix + " " + loopRoundedBox(target, target.midX, targetSide);
+
+  let destReachDistance = 0;
+  if (typeof document !== "undefined") {
+    const tmp = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    tmp.setAttribute("d", prefix);
+    destReachDistance = tmp.getTotalLength();
+  }
+
+  return { d: full, destReachDistance };
+}
+
+// Tree-shaped static topology: a trunk drops from each parent, joins a
+// horizontal arm spanning its children, and a vertical drop reaches each child.
+export function buildStaticTopology(
+  groups: Array<{ parent: Anchors; children: Anchors[]; armY: number }>,
+): string {
+  const segs: string[] = [];
+  for (const { parent, children, armY } of groups) {
+    segs.push(`M ${parent.midX} ${parent.bottom} L ${parent.midX} ${armY}`);
+    const xs = [parent.midX, ...children.map((c) => c.midX)];
+    const minX = Math.min(...xs);
+    const maxX = Math.max(...xs);
+    if (maxX - minX > 0.5) {
+      segs.push(`M ${minX} ${armY} L ${maxX} ${armY}`);
+    }
+    for (const c of children) {
+      segs.push(`M ${c.midX} ${armY} L ${c.midX} ${c.top}`);
+    }
+  }
+  return segs.join(" ");
+}

--- a/docs/content/docs/concepts/how-sync-works.mdx
+++ b/docs/content/docs/concepts/how-sync-works.mdx
@@ -62,12 +62,16 @@ replayed automatically.
 
 Jazz sync runs across three tiers:
 
-```mermaid
-graph TD
-    G["Global\n(global core)"] --- E1["Edge\n(sync server)"] & E2["Edge\n(sync server)"]
+<TierSyncDiagram />
+
+<div className="lg:hidden">
+  <Mermaid
+    chart={`graph TD
+    G["Global\\n(global core)"] --- E1["Edge\\n(sync server)"] & E2["Edge\\n(sync server)"]
     E1 --- W1["Local"] & W2["Local"]
-    E2 --- W3["Local"]
-```
+    E2 --- W3["Local"]`}
+  />
+</div>
 
 **Local** is the first tier on the client itself. In browser persistent mode, a dedicated worker
 hosts that local durable copy in OPFS so it can respond immediately while updates from higher tiers

--- a/docs/mdx-components.tsx
+++ b/docs/mdx-components.tsx
@@ -7,6 +7,7 @@ import { GenerateAppId } from "./components/mdx/generate-app-id";
 import { CloudConfig } from "./components/mdx/cloud-config";
 import { DeployCommand } from "./components/mdx/deploy-command";
 import { LensDiagram } from "./components/mdx/lens-diagram";
+import { TierSyncDiagram } from "./components/mdx/tier-sync-diagram";
 import { JazzLogo } from "./components/brand/jazz-logo";
 
 function SlideCodeCell({ children, title }: { children: ReactNode; title: string }) {
@@ -29,6 +30,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     CloudConfig,
     DeployCommand,
     LensDiagram,
+    TierSyncDiagram,
     JazzLogo,
     SlideCodeCell,
     ...components,


### PR DESCRIPTION
## What

Adds an animated `TierSyncDiagram` to the **how-sync-works** concepts doc, illustrating how writes propagate across tiers.

## Changes

- Extract shared diagram primitives (geometry, frame, styles, trace animation) out of `LensDiagram` into reusable `docs/components/mdx/diagram/` modules
- Add `TierSyncDiagram` + its path module, wired into `how-sync-works.mdx` and `mdx-components`
- Randomise writer colours via HSL, returned as hex

## Notes

- Docs-only; no library or runtime code touched.
- Built on shared primitives so `LensDiagram` and `TierSyncDiagram` stay consistent.
