### PR TITLE
Use LocalFirstAuth framework hooks in starters

### DIFF
--- a/starters/next-hybrid/README.md
+++ b/starters/next-hybrid/README.md
@@ -47,9 +47,9 @@ lib/auth-client.ts                  ← Better Auth React client
 ## How it works
 
 `JazzProvider` in `components/jazz-provider.tsx` watches the Better Auth session via
-`authClient.useSession()`. When there is no session, it calls
-`BrowserAuthSecretStore.getOrCreateSecret()` and passes the secret to
-`<JazzProvider>` as `secret`. When a session exists, it
+`authClient.useSession()`. When there is no session, it reads `secret`
+from `useLocalFirstAuth()` (a React hook from `jazz-tools/react`) and
+passes it to `<JazzProvider>` as `secret`. When a session exists, it
 fetches a Better Auth JWT and passes it to `<JazzProvider>` as
 `jwtToken` instead.
 

--- a/starters/next-hybrid/app/page.tsx
+++ b/starters/next-hybrid/app/page.tsx
@@ -6,16 +6,17 @@ import { useRouter } from "next/navigation";
 import { TodoWidget } from "@/components/todo-widget";
 import { AuthBackup } from "@/components/auth-backup";
 import { authClient } from "@/lib/auth-client";
-import { BrowserAuthSecretStore } from "jazz-tools";
+import { useLocalFirstAuth } from "jazz-tools/react";
 
 function HeaderActions() {
   const router = useRouter();
   const { data: authSession } = authClient.useSession();
+  const auth = useLocalFirstAuth();
 
   if (authSession?.session) {
     async function handleSignOut() {
       await authClient.signOut();
-      await BrowserAuthSecretStore.clearSecret();
+      await auth.signOut();
       router.push("/");
     }
 

--- a/starters/next-hybrid/components/auth-backup.tsx
+++ b/starters/next-hybrid/components/auth-backup.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { BrowserAuthSecretStore } from "jazz-tools";
+import { useLocalFirstAuth } from "jazz-tools/react";
 
 type Status =
   | { kind: "idle" }
@@ -20,12 +20,10 @@ export function AuthBackup({
   redirectAfterRestore?: string;
   mode?: "full" | "restore-only";
 } = {}) {
+  const auth = useLocalFirstAuth();
+
   function navigate() {
-    if (redirectAfterRestore) {
-      location.assign(redirectAfterRestore);
-    } else {
-      location.reload();
-    }
+    if (redirectAfterRestore) location.assign(redirectAfterRestore);
   }
   const [phrase, setPhrase] = useState<string | null>(null);
   const [restoreInput, setRestoreInput] = useState("");
@@ -36,13 +34,12 @@ export function AuthBackup({
     setStatus({ kind: "idle" });
     setBusy(true);
     try {
-      const secret = await BrowserAuthSecretStore.loadSecret();
-      if (!secret) {
+      if (!auth.secret) {
         setStatus({ kind: "error", message: "No local secret to reveal yet." });
         return;
       }
       const { RecoveryPhrase } = await import("jazz-tools/passphrase");
-      setPhrase(RecoveryPhrase.fromSecret(secret));
+      setPhrase(RecoveryPhrase.fromSecret(auth.secret));
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
     } finally {
@@ -70,10 +67,11 @@ export function AuthBackup({
     try {
       const { RecoveryPhrase } = await import("jazz-tools/passphrase");
       const secret = RecoveryPhrase.toSecret(restoreInput.trim());
-      await BrowserAuthSecretStore.saveSecret(secret);
+      await auth.login(secret);
       navigate();
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
+    } finally {
       setBusy(false);
     }
   }
@@ -82,8 +80,7 @@ export function AuthBackup({
     setStatus({ kind: "idle" });
     setBusy(true);
     try {
-      const secret = await BrowserAuthSecretStore.loadSecret();
-      if (!secret) {
+      if (!auth.secret) {
         setStatus({ kind: "error", message: "No local secret to back up yet." });
         return;
       }
@@ -92,7 +89,7 @@ export function AuthBackup({
         appName: PASSKEY_APP_NAME,
         appHostname: PASSKEY_APP_HOSTNAME,
       });
-      await pb.backup(secret, "My account");
+      await pb.backup(auth.secret, "My account");
       setStatus({ kind: "success", message: "Passkey backup created." });
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
@@ -111,10 +108,11 @@ export function AuthBackup({
         appHostname: PASSKEY_APP_HOSTNAME,
       });
       const secret = await pb.restore();
-      await BrowserAuthSecretStore.saveSecret(secret);
+      await auth.login(secret);
       navigate();
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
+    } finally {
       setBusy(false);
     }
   }

--- a/starters/next-hybrid/components/jazz-provider.tsx
+++ b/starters/next-hybrid/components/jazz-provider.tsx
@@ -1,9 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { type DbConfig, BrowserAuthSecretStore } from "jazz-tools";
-import { JazzProvider as JazzBaseProvider, useDb } from "jazz-tools/react";
+import { useEffect, useMemo, useState } from "react";
+import type { DbConfig } from "jazz-tools";
+import { JazzProvider as JazzBaseProvider, useDb, useLocalFirstAuth } from "jazz-tools/react";
 import { authClient } from "@/lib/auth-client";
+
+const APP_ID = process.env.NEXT_PUBLIC_JAZZ_APP_ID;
+const SERVER_URL = process.env.NEXT_PUBLIC_JAZZ_SERVER_URL;
 
 function JwtRefresh() {
   const db = useDb();
@@ -20,9 +23,6 @@ function JwtRefresh() {
   return null;
 }
 
-const APP_ID = process.env.NEXT_PUBLIC_JAZZ_APP_ID;
-const SERVER_URL = process.env.NEXT_PUBLIC_JAZZ_SERVER_URL;
-
 /**
  * Jazz provider for the local-first + BetterAuth starter. Watches the
  * Better Auth session and builds the appropriate DbConfig — an anonymous
@@ -31,23 +31,43 @@ const SERVER_URL = process.env.NEXT_PUBLIC_JAZZ_SERVER_URL;
  */
 export function JazzProvider({ children }: React.PropsWithChildren) {
   const { data: authSession, isPending } = authClient.useSession();
-  const [config, setConfig] = useState<DbConfig | null>(null);
+  const { secret, isLoading: secretLoading } = useLocalFirstAuth();
+  const [jwtToken, setJwtToken] = useState<string | null>(null);
   const authenticated = Boolean(authSession?.session);
 
   useEffect(() => {
-    if (isPending) return;
+    if (!authenticated) {
+      setJwtToken(null);
+      return;
+    }
     let cancelled = false;
-    setConfig(null);
-
-    (async () => {
-      const next = authenticated ? await buildJwtConfig() : await buildLocalFirstConfig();
-      if (!cancelled && next) setConfig(next);
-    })();
-
+    authClient.token().then(({ data, error }) => {
+      if (cancelled) return;
+      if (!error && data?.token) setJwtToken(data.token);
+    });
     return () => {
       cancelled = true;
     };
-  }, [isPending, authenticated]);
+  }, [authenticated]);
+
+  const config = useMemo<DbConfig | null>(() => {
+    if (!APP_ID || !SERVER_URL) {
+      const missing = [
+        !APP_ID && "NEXT_PUBLIC_JAZZ_APP_ID",
+        !SERVER_URL && "NEXT_PUBLIC_JAZZ_SERVER_URL",
+      ]
+        .filter((v) => !!v)
+        .join(" & ");
+      throw new Error(
+        `${missing} not set. The withJazz Next plugin injects these at dev time; in production, set them explicitly in your environment.`,
+      );
+    }
+    if (authenticated) {
+      return jwtToken ? { appId: APP_ID, serverUrl: SERVER_URL, jwtToken } : null;
+    }
+    if (secretLoading || !secret) return null;
+    return { appId: APP_ID, serverUrl: SERVER_URL, secret };
+  }, [authenticated, jwtToken, secret, secretLoading]);
 
   if (isPending || !config) return null;
 
@@ -57,33 +77,4 @@ export function JazzProvider({ children }: React.PropsWithChildren) {
       {children}
     </JazzBaseProvider>
   );
-}
-
-function baseConfig(): Omit<DbConfig, "jwtToken" | "secret"> {
-  if (!APP_ID || !SERVER_URL) {
-    const missing = [
-      !APP_ID && "NEXT_PUBLIC_JAZZ_APP_ID",
-      !SERVER_URL && "NEXT_PUBLIC_JAZZ_SERVER_URL",
-    ]
-      .filter((v) => !!v)
-      .join(" & ");
-    throw new Error(
-      `${missing} not set. The withJazz Next plugin injects these at dev time; in production, set them explicitly in your environment.`,
-    );
-  }
-  return {
-    appId: APP_ID,
-    serverUrl: SERVER_URL,
-  };
-}
-
-async function buildLocalFirstConfig(): Promise<DbConfig> {
-  const secret = await BrowserAuthSecretStore.getOrCreateSecret();
-  return { ...baseConfig(), secret };
-}
-
-async function buildJwtConfig(): Promise<DbConfig | null> {
-  const { data, error } = await authClient.token();
-  if (error || !data?.token) return null;
-  return { ...baseConfig(), jwtToken: data.token };
 }

--- a/starters/next-localfirst/README.md
+++ b/starters/next-localfirst/README.md
@@ -47,10 +47,11 @@ permissions.ts                 ← row-level access policy ($createdBy)
 
 Every browser gets its own Ed25519 secret, generated and stored by
 `BrowserAuthSecretStore` on first load. That secret becomes the identity
-Jazz uses for all subsequent writes. `LocalFirstProvider` in
+Jazz uses for all subsequent writes. The `JazzProvider` in
 `components/jazz-provider.tsx` does exactly one thing: call
-`BrowserAuthSecretStore.getOrCreateSecret()` and hand the result to
-`<JazzProvider>` as `secret`.
+`useLocalFirstAuth()` (a React hook from `jazz-tools/react` that loads
+or generates the secret client-side) and hand `secret` to the underlying
+`<JazzProvider>`.
 
 Data syncs to the Jazz server under that anonymous identity. There is no
 concept of a user account, no sign-in, no sign-out — the device _is_ the

--- a/starters/next-localfirst/components/auth-backup.tsx
+++ b/starters/next-localfirst/components/auth-backup.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { BrowserAuthSecretStore } from "jazz-tools";
+import { useLocalFirstAuth } from "jazz-tools/react";
 
 type Status =
   | { kind: "idle" }
@@ -20,12 +20,10 @@ export function AuthBackup({
   redirectAfterRestore?: string;
   mode?: "full" | "restore-only";
 } = {}) {
+  const auth = useLocalFirstAuth();
+
   function navigate() {
-    if (redirectAfterRestore) {
-      location.assign(redirectAfterRestore);
-    } else {
-      location.reload();
-    }
+    if (redirectAfterRestore) location.assign(redirectAfterRestore);
   }
   const [phrase, setPhrase] = useState<string | null>(null);
   const [restoreInput, setRestoreInput] = useState("");
@@ -36,13 +34,12 @@ export function AuthBackup({
     setStatus({ kind: "idle" });
     setBusy(true);
     try {
-      const secret = await BrowserAuthSecretStore.loadSecret();
-      if (!secret) {
+      if (!auth.secret) {
         setStatus({ kind: "error", message: "No local secret to reveal yet." });
         return;
       }
       const { RecoveryPhrase } = await import("jazz-tools/passphrase");
-      setPhrase(RecoveryPhrase.fromSecret(secret));
+      setPhrase(RecoveryPhrase.fromSecret(auth.secret));
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
     } finally {
@@ -70,10 +67,11 @@ export function AuthBackup({
     try {
       const { RecoveryPhrase } = await import("jazz-tools/passphrase");
       const secret = RecoveryPhrase.toSecret(restoreInput.trim());
-      await BrowserAuthSecretStore.saveSecret(secret);
+      await auth.login(secret);
       navigate();
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
+    } finally {
       setBusy(false);
     }
   }
@@ -82,8 +80,7 @@ export function AuthBackup({
     setStatus({ kind: "idle" });
     setBusy(true);
     try {
-      const secret = await BrowserAuthSecretStore.loadSecret();
-      if (!secret) {
+      if (!auth.secret) {
         setStatus({ kind: "error", message: "No local secret to back up yet." });
         return;
       }
@@ -92,7 +89,7 @@ export function AuthBackup({
         appName: PASSKEY_APP_NAME,
         appHostname: PASSKEY_APP_HOSTNAME,
       });
-      await pb.backup(secret, "My account");
+      await pb.backup(auth.secret, "My account");
       setStatus({ kind: "success", message: "Passkey backup created." });
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
@@ -111,10 +108,11 @@ export function AuthBackup({
         appHostname: PASSKEY_APP_HOSTNAME,
       });
       const secret = await pb.restore();
-      await BrowserAuthSecretStore.saveSecret(secret);
+      await auth.login(secret);
       navigate();
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
+    } finally {
       setBusy(false);
     }
   }

--- a/starters/next-localfirst/components/jazz-provider.tsx
+++ b/starters/next-localfirst/components/jazz-provider.tsx
@@ -1,31 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { type DbConfig, BrowserAuthSecretStore } from "jazz-tools";
-import { JazzProvider as JazzBaseProvider } from "jazz-tools/react";
+import { JazzProvider as JazzBaseProvider, useLocalFirstAuth } from "jazz-tools/react";
 
 const APP_ID = process.env.NEXT_PUBLIC_JAZZ_APP_ID;
 const SERVER_URL = process.env.NEXT_PUBLIC_JAZZ_SERVER_URL;
 
 export function JazzProvider({ children }: React.PropsWithChildren) {
-  const [config, setConfig] = useState<DbConfig | null>(null);
-
-  useEffect(() => {
-    BrowserAuthSecretStore.getOrCreateSecret().then((secret) => {
-      setConfig(buildConfig(secret));
-    });
-  }, []);
-
-  if (!config) return null;
-
-  return (
-    <JazzBaseProvider config={config} fallback={<p>Loading...</p>}>
-      {children}
-    </JazzBaseProvider>
-  );
-}
-
-function buildConfig(secret: string): DbConfig {
   if (!APP_ID || !SERVER_URL) {
     const missing = [
       !APP_ID && "NEXT_PUBLIC_JAZZ_APP_ID",
@@ -37,9 +17,16 @@ function buildConfig(secret: string): DbConfig {
       `${missing} not set. The withJazz Next plugin injects these at dev time; in production, set them explicitly in your environment.`,
     );
   }
-  return {
-    appId: APP_ID,
-    serverUrl: SERVER_URL,
-    secret,
-  };
+
+  const { secret, isLoading } = useLocalFirstAuth();
+  if (isLoading || !secret) return null;
+
+  return (
+    <JazzBaseProvider
+      config={{ appId: APP_ID, serverUrl: SERVER_URL, secret }}
+      fallback={<p>Loading...</p>}
+    >
+      {children}
+    </JazzBaseProvider>
+  );
 }

--- a/starters/react-hybrid/README.md
+++ b/starters/react-hybrid/README.md
@@ -71,9 +71,13 @@ identity ID, so the Jazz principal carries over seamlessly.
 Both sides use the audience string `"react-localfirst-signup"` — the
 client proof and the server verification must match.
 
-`BetterAuthProvider` in `src/main.tsx` watches the Better Auth session. When a
-session exists, it fetches a JWT and passes it to `<JazzProvider>` as
-`jwtToken`. The Jazz dev server verifies that JWT against the JWKS endpoint.
+`HybridProvider` in `src/main.tsx` watches the Better Auth session via
+`authClient.useSession()`. When there is no session, it reads `secret`
+from `useLocalFirstAuth()` (a React hook from `jazz-tools/react`) and
+passes it to `<JazzProvider>` as `secret`. When a session exists, it
+fetches a Better Auth JWT and passes it to `<JazzProvider>` as
+`jwtToken` instead. The Jazz dev server verifies that JWT against the
+JWKS endpoint.
 
 ## Extending the schema
 

--- a/starters/react-hybrid/src/App.tsx
+++ b/starters/react-hybrid/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { BrowserAuthSecretStore } from "jazz-tools";
+import { useLocalFirstAuth } from "jazz-tools/react";
 import { authClient, useSession } from "./auth-client";
 import { AuthBackup } from "./auth-backup";
 import { SignInForm } from "./sign-in-form";
@@ -10,12 +10,13 @@ type View = "dashboard" | "signin" | "signup";
 
 export function App() {
   const { data: session, isPending } = useSession();
+  const auth = useLocalFirstAuth();
   const [view, setView] = useState<View>("dashboard");
 
   if (isPending) return <div>Loading…</div>;
 
   async function handleSignOut() {
-    await BrowserAuthSecretStore.clearSecret();
+    await auth.signOut();
     await authClient.signOut();
     setView("dashboard");
   }

--- a/starters/react-hybrid/src/auth-backup.tsx
+++ b/starters/react-hybrid/src/auth-backup.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { BrowserAuthSecretStore } from "jazz-tools";
+import { useLocalFirstAuth } from "jazz-tools/react";
 
 type Status =
   | { kind: "idle" }
@@ -18,12 +18,10 @@ export function AuthBackup({
   redirectAfterRestore?: string;
   mode?: "full" | "restore-only";
 } = {}) {
+  const auth = useLocalFirstAuth();
+
   function navigate() {
-    if (redirectAfterRestore) {
-      location.assign(redirectAfterRestore);
-    } else {
-      location.reload();
-    }
+    if (redirectAfterRestore) location.assign(redirectAfterRestore);
   }
   const [phrase, setPhrase] = useState<string | null>(null);
   const [restoreInput, setRestoreInput] = useState("");
@@ -34,13 +32,12 @@ export function AuthBackup({
     setStatus({ kind: "idle" });
     setBusy(true);
     try {
-      const secret = await BrowserAuthSecretStore.loadSecret();
-      if (!secret) {
+      if (!auth.secret) {
         setStatus({ kind: "error", message: "No local secret to reveal yet." });
         return;
       }
       const { RecoveryPhrase } = await import("jazz-tools/passphrase");
-      setPhrase(RecoveryPhrase.fromSecret(secret));
+      setPhrase(RecoveryPhrase.fromSecret(auth.secret));
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
     } finally {
@@ -68,10 +65,11 @@ export function AuthBackup({
     try {
       const { RecoveryPhrase } = await import("jazz-tools/passphrase");
       const secret = RecoveryPhrase.toSecret(restoreInput.trim());
-      await BrowserAuthSecretStore.saveSecret(secret);
+      await auth.login(secret);
       navigate();
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
+    } finally {
       setBusy(false);
     }
   }
@@ -80,8 +78,7 @@ export function AuthBackup({
     setStatus({ kind: "idle" });
     setBusy(true);
     try {
-      const secret = await BrowserAuthSecretStore.loadSecret();
-      if (!secret) {
+      if (!auth.secret) {
         setStatus({ kind: "error", message: "No local secret to back up yet." });
         return;
       }
@@ -90,7 +87,7 @@ export function AuthBackup({
         appName: PASSKEY_APP_NAME,
         appHostname: PASSKEY_APP_HOSTNAME,
       });
-      await pb.backup(secret, "My account");
+      await pb.backup(auth.secret, "My account");
       setStatus({ kind: "success", message: "Passkey backup created." });
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
@@ -109,10 +106,11 @@ export function AuthBackup({
         appHostname: PASSKEY_APP_HOSTNAME,
       });
       const secret = await pb.restore();
-      await BrowserAuthSecretStore.saveSecret(secret);
+      await auth.login(secret);
       navigate();
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
+    } finally {
       setBusy(false);
     }
   }

--- a/starters/react-hybrid/src/main.tsx
+++ b/starters/react-hybrid/src/main.tsx
@@ -1,7 +1,7 @@
-import { StrictMode, useEffect, useState } from "react";
+import { StrictMode, useEffect, useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
-import { JazzProvider as JazzBaseProvider, useDb } from "jazz-tools/react";
-import { type DbConfig, BrowserAuthSecretStore } from "jazz-tools";
+import { JazzProvider as JazzBaseProvider, useDb, useLocalFirstAuth } from "jazz-tools/react";
+import type { DbConfig } from "jazz-tools";
 import { authClient } from "./auth-client";
 import { App } from "./App";
 import "./App.css";
@@ -24,54 +24,48 @@ function JwtRefresh() {
   return null;
 }
 
-function baseConfig(): Omit<DbConfig, "jwtToken" | "secret"> {
-  if (!APP_ID || !SERVER_URL) {
-    const missing = [!APP_ID && "VITE_JAZZ_APP_ID", !SERVER_URL && "VITE_JAZZ_SERVER_URL"]
-      .filter((v) => !!v)
-      .join(" & ");
-    throw new Error(
-      `${missing} not set. The jazzPlugin Vite plugin injects these at dev time; in production, set them explicitly in your environment.`,
-    );
-  }
-  return { appId: APP_ID, serverUrl: SERVER_URL };
-}
-
-async function buildLocalFirstConfig(): Promise<DbConfig> {
-  const secret = await BrowserAuthSecretStore.getOrCreateSecret();
-  return { ...baseConfig(), secret };
-}
-
-async function buildJwtConfig(): Promise<DbConfig | null> {
-  const { data, error } = await authClient.token();
-  if (error || !data?.token) return null;
-  return { ...baseConfig(), jwtToken: data.token };
-}
-
 /**
  * Hybrid provider: renders JazzProvider regardless of BetterAuth session state.
- * Anonymous visitors get a local-first identity (from BrowserAuthSecretStore);
+ * Anonymous visitors get a local-first identity (from useLocalFirstAuth);
  * signed-in users get a BetterAuth-issued JWT. Switching between the two
  * triggers JazzProvider to rebuild against the new config.
  */
 function HybridProvider({ children }: React.PropsWithChildren) {
   const { data: authSession, isPending } = authClient.useSession();
-  const [config, setConfig] = useState<DbConfig | null>(null);
+  const { secret, isLoading: secretLoading } = useLocalFirstAuth();
+  const [jwtToken, setJwtToken] = useState<string | null>(null);
   const authenticated = Boolean(authSession?.session);
 
   useEffect(() => {
-    if (isPending) return;
+    if (!authenticated) {
+      setJwtToken(null);
+      return;
+    }
     let cancelled = false;
-    setConfig(null);
-
-    (async () => {
-      const next = authenticated ? await buildJwtConfig() : await buildLocalFirstConfig();
-      if (!cancelled && next) setConfig(next);
-    })();
-
+    authClient.token().then(({ data, error }) => {
+      if (cancelled) return;
+      if (!error && data?.token) setJwtToken(data.token);
+    });
     return () => {
       cancelled = true;
     };
-  }, [isPending, authenticated]);
+  }, [authenticated]);
+
+  const config = useMemo<DbConfig | null>(() => {
+    if (!APP_ID || !SERVER_URL) {
+      const missing = [!APP_ID && "VITE_JAZZ_APP_ID", !SERVER_URL && "VITE_JAZZ_SERVER_URL"]
+        .filter((v) => !!v)
+        .join(" & ");
+      throw new Error(
+        `${missing} not set. The jazzPlugin Vite plugin injects these at dev time; in production, set them explicitly in your environment.`,
+      );
+    }
+    if (authenticated) {
+      return jwtToken ? { appId: APP_ID, serverUrl: SERVER_URL, jwtToken } : null;
+    }
+    if (secretLoading || !secret) return null;
+    return { appId: APP_ID, serverUrl: SERVER_URL, secret };
+  }, [authenticated, jwtToken, secret, secretLoading]);
 
   if (isPending || !config) return null;
 

--- a/starters/react-localfirst/README.md
+++ b/starters/react-localfirst/README.md
@@ -41,9 +41,9 @@ permissions.ts                   ← row-level access policy ($createdBy)
 Every browser gets its own Ed25519 secret, generated and stored by
 `BrowserAuthSecretStore` on first load. That secret becomes the identity
 Jazz uses for all subsequent writes. `LocalFirstProvider` in
-`src/main.tsx` does exactly one thing: call
-`BrowserAuthSecretStore.getOrCreateSecret()` and hand the result to
-`<JazzProvider>` as `secret`.
+`src/main.tsx` does exactly one thing: call `useLocalFirstAuth()` (a
+React hook from `jazz-tools/react` that loads or generates the secret
+client-side) and hand `secret` to `<JazzProvider>`.
 
 Data syncs to the Jazz server under that anonymous identity. There is no
 concept of a user account, no sign-in, no sign-out — the device _is_ the

--- a/starters/react-localfirst/src/auth-backup.tsx
+++ b/starters/react-localfirst/src/auth-backup.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { BrowserAuthSecretStore } from "jazz-tools";
+import { useLocalFirstAuth } from "jazz-tools/react";
 
 type Status =
   | { kind: "idle" }
@@ -18,12 +18,10 @@ export function AuthBackup({
   redirectAfterRestore?: string;
   mode?: "full" | "restore-only";
 } = {}) {
+  const auth = useLocalFirstAuth();
+
   function navigate() {
-    if (redirectAfterRestore) {
-      location.assign(redirectAfterRestore);
-    } else {
-      location.reload();
-    }
+    if (redirectAfterRestore) location.assign(redirectAfterRestore);
   }
   const [phrase, setPhrase] = useState<string | null>(null);
   const [restoreInput, setRestoreInput] = useState("");
@@ -34,13 +32,12 @@ export function AuthBackup({
     setStatus({ kind: "idle" });
     setBusy(true);
     try {
-      const secret = await BrowserAuthSecretStore.loadSecret();
-      if (!secret) {
+      if (!auth.secret) {
         setStatus({ kind: "error", message: "No local secret to reveal yet." });
         return;
       }
       const { RecoveryPhrase } = await import("jazz-tools/passphrase");
-      setPhrase(RecoveryPhrase.fromSecret(secret));
+      setPhrase(RecoveryPhrase.fromSecret(auth.secret));
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
     } finally {
@@ -68,10 +65,11 @@ export function AuthBackup({
     try {
       const { RecoveryPhrase } = await import("jazz-tools/passphrase");
       const secret = RecoveryPhrase.toSecret(restoreInput.trim());
-      await BrowserAuthSecretStore.saveSecret(secret);
+      await auth.login(secret);
       navigate();
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
+    } finally {
       setBusy(false);
     }
   }
@@ -80,8 +78,7 @@ export function AuthBackup({
     setStatus({ kind: "idle" });
     setBusy(true);
     try {
-      const secret = await BrowserAuthSecretStore.loadSecret();
-      if (!secret) {
+      if (!auth.secret) {
         setStatus({ kind: "error", message: "No local secret to back up yet." });
         return;
       }
@@ -90,7 +87,7 @@ export function AuthBackup({
         appName: PASSKEY_APP_NAME,
         appHostname: PASSKEY_APP_HOSTNAME,
       });
-      await pb.backup(secret, "My account");
+      await pb.backup(auth.secret, "My account");
       setStatus({ kind: "success", message: "Passkey backup created." });
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
@@ -109,10 +106,11 @@ export function AuthBackup({
         appHostname: PASSKEY_APP_HOSTNAME,
       });
       const secret = await pb.restore();
-      await BrowserAuthSecretStore.saveSecret(secret);
+      await auth.login(secret);
       navigate();
     } catch (err) {
       setStatus({ kind: "error", message: describeError(err) });
+    } finally {
       setBusy(false);
     }
   }

--- a/starters/react-localfirst/src/main.tsx
+++ b/starters/react-localfirst/src/main.tsx
@@ -1,14 +1,13 @@
-import { StrictMode, useEffect, useState } from "react";
+import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { type DbConfig, BrowserAuthSecretStore } from "jazz-tools";
-import { JazzProvider } from "jazz-tools/react";
+import { JazzProvider, useLocalFirstAuth } from "jazz-tools/react";
 import { App } from "./App";
 import "./App.css";
 
 const APP_ID = import.meta.env.VITE_JAZZ_APP_ID as string | undefined;
 const SERVER_URL = import.meta.env.VITE_JAZZ_SERVER_URL as string | undefined;
 
-function buildConfig(secret: string): DbConfig {
+function LocalFirstProvider({ children }: React.PropsWithChildren) {
   if (!APP_ID || !SERVER_URL) {
     const missing = [!APP_ID && "VITE_JAZZ_APP_ID", !SERVER_URL && "VITE_JAZZ_SERVER_URL"]
       .filter((v) => !!v)
@@ -17,26 +16,15 @@ function buildConfig(secret: string): DbConfig {
       `${missing} not set. The jazzPlugin Vite plugin injects these at dev time; in production, set them explicitly in your environment.`,
     );
   }
-  return {
-    appId: APP_ID,
-    serverUrl: SERVER_URL,
-    secret,
-  };
-}
 
-function LocalFirstProvider({ children }: React.PropsWithChildren) {
-  const [config, setConfig] = useState<DbConfig | null>(null);
-
-  useEffect(() => {
-    BrowserAuthSecretStore.getOrCreateSecret().then((secret) => {
-      setConfig(buildConfig(secret));
-    });
-  }, []);
-
-  if (!config) return null;
+  const { secret, isLoading } = useLocalFirstAuth();
+  if (isLoading || !secret) return null;
 
   return (
-    <JazzProvider config={config} fallback={<p>Loading...</p>}>
+    <JazzProvider
+      config={{ appId: APP_ID, serverUrl: SERVER_URL, secret }}
+      fallback={<p>Loading...</p>}
+    >
       {children}
     </JazzProvider>
   );

--- a/starters/sveltekit-hybrid/README.md
+++ b/starters/sveltekit-hybrid/README.md
@@ -51,15 +51,16 @@ src/
 ## How it works
 
 `src/routes/+layout.svelte` watches the Better Auth session via
-`authClient.useSession()`. When there is no session, it calls
-`BrowserAuthSecretStore.getOrCreateSecret()` and passes the secret to
-`createJazzClient` as `secret`. When a session exists, it
-fetches a Better Auth JWT and creates the client with `jwtToken` instead.
-
-The layout uses a `clientAuth` gate so the `<JazzSvelteProvider>` only
-renders when the active client matches the current session state. This
-prevents a race where the UI would briefly interact with the stale
-anonymous client during a sign-up → authenticated transition.
+`authClient.useSession()` and forwards the result to
+`JazzClientProvider.svelte`. That provider holds a `LocalFirstAuth`
+instance (from `jazz-tools/svelte`) for the anonymous path and fetches
+a Better Auth JWT for the authenticated path. A `$derived` picks the
+right `createJazzClient(...)` config — `secret` from `auth.secret`
+when no session, `jwtToken` when there is one — so the
+`<JazzSvelteProvider>` only renders once the active client matches the
+current session state. That prevents a race where the UI would briefly
+interact with a stale anonymous client during a sign-up → authenticated
+transition.
 
 ### Identity continuity
 

--- a/starters/sveltekit-hybrid/README.md
+++ b/starters/sveltekit-hybrid/README.md
@@ -169,9 +169,9 @@ manually:
    `src/lib/auth-client.ts`, `src/routes/signin/`, and
    `src/routes/signup/`.
 2. In `src/routes/+layout.svelte`, remove the `authClient`, `session`,
-   `clientAuth`, and `ready` logic — reduce the effect to: resolve
-   `BrowserAuthSecretStore.getOrCreateSecret()`, build a `DbConfig` with
-   `auth: { localFirstSecret: secret }`, and call `createJazzClient`.
+   `clientAuth`, and `ready` logic — reduce it to: instantiate
+   `LocalFirstAuth` from `jazz-tools/svelte` and `$derived` a client
+   from `auth.secret`.
 3. In `src/routes/+page.svelte`, remove the auth-nav block and the
    `handleSignOut` function — the page renders just the header and the
    `<TodoWidget />`.

--- a/starters/sveltekit-hybrid/src/lib/AuthBackup.svelte
+++ b/starters/sveltekit-hybrid/src/lib/AuthBackup.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { BrowserAuthSecretStore } from "jazz-tools/svelte";
+  import { LocalFirstAuth } from "jazz-tools/svelte";
   import { goto } from "$app/navigation";
 
   // In production, pin this to your deployed hostname so passkeys remain
@@ -21,18 +21,15 @@
     mode?: "full" | "restore-only";
   } = $props();
 
+  const auth = new LocalFirstAuth();
+
   let phrase = $state<string | null>(null);
   let restoreInput = $state("");
   let status = $state<Status>({ kind: "idle" });
   let busy = $state(false);
 
   async function navigate() {
-    if (redirectAfterRestore) {
-      await goto(redirectAfterRestore);
-      location.reload();
-    } else {
-      location.reload();
-    }
+    if (redirectAfterRestore) await goto(redirectAfterRestore);
   }
 
   function describeError(err: unknown): string {
@@ -47,13 +44,12 @@
     status = { kind: "idle" };
     busy = true;
     try {
-      const secret = await BrowserAuthSecretStore.loadSecret();
-      if (!secret) {
+      if (!auth.secret) {
         status = { kind: "error", message: "No local secret to reveal yet." };
         return;
       }
       const { RecoveryPhrase } = await import("jazz-tools/passphrase");
-      phrase = RecoveryPhrase.fromSecret(secret);
+      phrase = RecoveryPhrase.fromSecret(auth.secret);
     } catch (err) {
       status = { kind: "error", message: describeError(err) };
     } finally {
@@ -81,10 +77,11 @@
     try {
       const { RecoveryPhrase } = await import("jazz-tools/passphrase");
       const secret = RecoveryPhrase.toSecret(restoreInput.trim());
-      await BrowserAuthSecretStore.saveSecret(secret);
+      await auth.login(secret);
       await navigate();
     } catch (err) {
       status = { kind: "error", message: describeError(err) };
+    } finally {
       busy = false;
     }
   }
@@ -93,8 +90,7 @@
     status = { kind: "idle" };
     busy = true;
     try {
-      const secret = await BrowserAuthSecretStore.loadSecret();
-      if (!secret) {
+      if (!auth.secret) {
         status = { kind: "error", message: "No local secret to back up yet." };
         return;
       }
@@ -103,7 +99,7 @@
         appName: PASSKEY_APP_NAME,
         appHostname: PASSKEY_APP_HOSTNAME,
       });
-      await pb.backup(secret, "My account");
+      await pb.backup(auth.secret, "My account");
       status = { kind: "success", message: "Passkey backup created." };
     } catch (err) {
       status = { kind: "error", message: describeError(err) };
@@ -122,10 +118,11 @@
         appHostname: PASSKEY_APP_HOSTNAME,
       });
       const secret = await pb.restore();
-      await BrowserAuthSecretStore.saveSecret(secret);
+      await auth.login(secret);
       await navigate();
     } catch (err) {
       status = { kind: "error", message: describeError(err) };
+    } finally {
       busy = false;
     }
   }

--- a/starters/sveltekit-hybrid/src/lib/JazzClientProvider.svelte
+++ b/starters/sveltekit-hybrid/src/lib/JazzClientProvider.svelte
@@ -1,47 +1,26 @@
 <script lang="ts">
-  import { onMount } from "svelte";
   import {
     createJazzClient,
     JazzSvelteProvider,
-    BrowserAuthSecretStore,
+    LocalFirstAuth,
   } from "jazz-tools/svelte";
-  import type { DbConfig } from "jazz-tools";
+  import type { AuthState } from "jazz-tools";
   import type { Snippet } from "svelte";
   import { env } from "$env/dynamic/public";
-  import { authClient, getToken } from "$lib/auth-client";
+  import { getToken } from "$lib/auth-client";
 
   let {
     authenticated,
     children: pageChildren,
   }: { authenticated: boolean; children: Snippet } = $props();
 
-  let client = $state<ReturnType<typeof createJazzClient> | null>(null);
+  const appId = env.PUBLIC_JAZZ_APP_ID;
+  const serverUrl = env.PUBLIC_JAZZ_SERVER_URL;
 
-  onMount(() => {
-    let unsubRefresh: (() => void) | undefined;
+  const auth = new LocalFirstAuth();
+  let jwtToken = $state<string | null>(null);
 
-    (async () => {
-      const config = await buildConfig(authenticated);
-      if (!config) return;
-      const jazzClient = createJazzClient(config);
-      client = jazzClient;
-
-      if (authenticated) {
-        const resolved = await jazzClient;
-        unsubRefresh = resolved.db.onAuthChanged(async (state) => {
-          if (state.error !== "expired") return;
-          const fresh = await getToken();
-          if (fresh) resolved.db.updateAuthToken(fresh);
-        });
-      }
-    })();
-
-    return () => unsubRefresh?.();
-  });
-
-  async function buildConfig(auth: boolean): Promise<DbConfig | null> {
-    const appId = env.PUBLIC_JAZZ_APP_ID;
-    const serverUrl = env.PUBLIC_JAZZ_SERVER_URL;
+  $effect(() => {
     if (!appId || !serverUrl) {
       const missing = [
         !appId && "PUBLIC_JAZZ_APP_ID",
@@ -52,21 +31,52 @@
       console.error(
         `${missing} not set — the jazzSvelteKit() plugin should inject these.`,
       );
-      return Promise.resolve(null);
     }
-    const base: Omit<DbConfig, "jwtToken" | "secret"> = { appId, serverUrl };
+  });
 
-    if (auth) {
-      return getToken().then((token) =>
-        token ? { ...base, jwtToken: token } : null,
-      );
+  $effect(() => {
+    if (!authenticated) {
+      jwtToken = null;
+      return;
     }
+    let cancelled = false;
+    void getToken().then((token) => {
+      if (!cancelled) jwtToken = token;
+    });
+    return () => {
+      cancelled = true;
+    };
+  });
 
-    return BrowserAuthSecretStore.getOrCreateSecret().then((secret) => ({
-      ...base,
-      secret,
-    }));
-  }
+  let client = $derived.by(() => {
+    if (!appId || !serverUrl) return null;
+    if (authenticated) {
+      return jwtToken ? createJazzClient({ appId, serverUrl, jwtToken }) : null;
+    }
+    return !auth.isLoading && auth.secret
+      ? createJazzClient({ appId, serverUrl, secret: auth.secret })
+      : null;
+  });
+
+  $effect(() => {
+    if (!client || !authenticated) return;
+    const currentClient = client;
+    let cancelled = false;
+    let unsubRefresh: (() => void) | undefined;
+    void (async () => {
+      const resolved = await currentClient;
+      if (cancelled) return;
+      unsubRefresh = resolved.db.onAuthChanged(async (state: AuthState) => {
+        if (state.error !== "expired") return;
+        const fresh = await getToken();
+        if (fresh) resolved.db.updateAuthToken(fresh);
+      });
+    })();
+    return () => {
+      cancelled = true;
+      unsubRefresh?.();
+    };
+  });
 </script>
 
 {#if client}

--- a/starters/sveltekit-hybrid/src/routes/+page.svelte
+++ b/starters/sveltekit-hybrid/src/routes/+page.svelte
@@ -1,16 +1,17 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import { authClient } from "$lib/auth-client";
-  import { BrowserAuthSecretStore } from "jazz-tools/svelte";
+  import { LocalFirstAuth } from "jazz-tools/svelte";
   import TodoWidget from "$lib/TodoWidget.svelte";
   import AuthBackup from "$lib/AuthBackup.svelte";
 
   const session = authClient.useSession();
+  // Auto-syncs with the layout's LocalFirstAuth instance via the shared
+  // per-store notifier, so signOut here clears the secret everywhere.
+  const auth = new LocalFirstAuth();
 
   async function handleSignOut() {
-    // Clear the anonymous secret before signOut so that the reactive $effect
-    // in the layout gets a fresh anonymous identity when it rebuilds the client.
-    await BrowserAuthSecretStore.clearSecret();
+    await auth.signOut();
     await authClient.signOut();
     await goto("/");
   }

--- a/starters/sveltekit-localfirst/README.md
+++ b/starters/sveltekit-localfirst/README.md
@@ -45,8 +45,9 @@ src/
 Every browser gets its own Ed25519 secret, generated and stored by
 `BrowserAuthSecretStore` on first load. That secret becomes the identity
 Jazz uses for all subsequent writes. `src/routes/+layout.svelte` does
-exactly one thing: call `BrowserAuthSecretStore.getOrCreateSecret()` and
-hand the result to `createJazzClient` as `secret`.
+exactly one thing: instantiate `LocalFirstAuth` (a reactive class from
+`jazz-tools/svelte` that loads or generates the secret client-side) and
+hand `auth.secret` to `createJazzClient`.
 
 Data syncs to the Jazz server under that anonymous identity. There is no
 concept of a user account, no sign-in, no sign-out — the device _is_ the

--- a/starters/sveltekit-localfirst/src/lib/AuthBackup.svelte
+++ b/starters/sveltekit-localfirst/src/lib/AuthBackup.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { BrowserAuthSecretStore } from "jazz-tools/svelte";
+  import { LocalFirstAuth } from "jazz-tools/svelte";
   import { goto } from "$app/navigation";
 
   // In production, pin this to your deployed hostname so passkeys remain
@@ -21,18 +21,15 @@
     mode?: "full" | "restore-only";
   } = $props();
 
+  const auth = new LocalFirstAuth();
+
   let phrase = $state<string | null>(null);
   let restoreInput = $state("");
   let status = $state<Status>({ kind: "idle" });
   let busy = $state(false);
 
   async function navigate() {
-    if (redirectAfterRestore) {
-      await goto(redirectAfterRestore);
-      location.reload();
-    } else {
-      location.reload();
-    }
+    if (redirectAfterRestore) await goto(redirectAfterRestore);
   }
 
   function describeError(err: unknown): string {
@@ -47,13 +44,12 @@
     status = { kind: "idle" };
     busy = true;
     try {
-      const secret = await BrowserAuthSecretStore.loadSecret();
-      if (!secret) {
+      if (!auth.secret) {
         status = { kind: "error", message: "No local secret to reveal yet." };
         return;
       }
       const { RecoveryPhrase } = await import("jazz-tools/passphrase");
-      phrase = RecoveryPhrase.fromSecret(secret);
+      phrase = RecoveryPhrase.fromSecret(auth.secret);
     } catch (err) {
       status = { kind: "error", message: describeError(err) };
     } finally {
@@ -81,10 +77,11 @@
     try {
       const { RecoveryPhrase } = await import("jazz-tools/passphrase");
       const secret = RecoveryPhrase.toSecret(restoreInput.trim());
-      await BrowserAuthSecretStore.saveSecret(secret);
+      await auth.login(secret);
       await navigate();
     } catch (err) {
       status = { kind: "error", message: describeError(err) };
+    } finally {
       busy = false;
     }
   }
@@ -93,8 +90,7 @@
     status = { kind: "idle" };
     busy = true;
     try {
-      const secret = await BrowserAuthSecretStore.loadSecret();
-      if (!secret) {
+      if (!auth.secret) {
         status = { kind: "error", message: "No local secret to back up yet." };
         return;
       }
@@ -103,7 +99,7 @@
         appName: PASSKEY_APP_NAME,
         appHostname: PASSKEY_APP_HOSTNAME,
       });
-      await pb.backup(secret, "My account");
+      await pb.backup(auth.secret, "My account");
       status = { kind: "success", message: "Passkey backup created." };
     } catch (err) {
       status = { kind: "error", message: describeError(err) };
@@ -122,10 +118,11 @@
         appHostname: PASSKEY_APP_HOSTNAME,
       });
       const secret = await pb.restore();
-      await BrowserAuthSecretStore.saveSecret(secret);
+      await auth.login(secret);
       await navigate();
     } catch (err) {
       status = { kind: "error", message: describeError(err) };
+    } finally {
       busy = false;
     }
   }

--- a/starters/sveltekit-localfirst/src/routes/+layout.svelte
+++ b/starters/sveltekit-localfirst/src/routes/+layout.svelte
@@ -1,39 +1,34 @@
 <script lang="ts">
   import "../app.css";
-  import { onMount } from "svelte";
-  import { createJazzClient, JazzSvelteProvider, BrowserAuthSecretStore } from "jazz-tools/svelte";
-  import type { DbConfig } from "jazz-tools";
+  import { createJazzClient, JazzSvelteProvider, LocalFirstAuth } from "jazz-tools/svelte";
   import { env } from "$env/dynamic/public";
 
   let { children: pageChildren } = $props();
 
-  let client = $state<ReturnType<typeof createJazzClient> | null>(null);
+  const auth = new LocalFirstAuth();
 
-  onMount(() => {
-    (async () => {
-      const appId = env.PUBLIC_JAZZ_APP_ID;
-      const serverUrl = env.PUBLIC_JAZZ_SERVER_URL;
-      if (!appId || !serverUrl) {
-        const missing = [
-          !appId && "PUBLIC_JAZZ_APP_ID",
-          !serverUrl && "PUBLIC_JAZZ_SERVER_URL",
-        ]
-          .filter((v) => !!v)
-          .join(" & ");
-        console.error(
-          `${missing} not set — the jazzSvelteKit() plugin should inject these.`,
-        );
-        return;
-      }
-      const secret = await BrowserAuthSecretStore.getOrCreateSecret();
-      const config: DbConfig = {
-        appId,
-        serverUrl,
-        secret,
-      };
-      client = createJazzClient(config);
-    })();
+  const appId = env.PUBLIC_JAZZ_APP_ID;
+  const serverUrl = env.PUBLIC_JAZZ_SERVER_URL;
+
+  $effect(() => {
+    if (!appId || !serverUrl) {
+      const missing = [
+        !appId && "PUBLIC_JAZZ_APP_ID",
+        !serverUrl && "PUBLIC_JAZZ_SERVER_URL",
+      ]
+        .filter((v) => !!v)
+        .join(" & ");
+      console.error(
+        `${missing} not set — the jazzSvelteKit() plugin should inject these.`,
+      );
+    }
   });
+
+  let client = $derived(
+    !auth.isLoading && auth.secret && appId && serverUrl
+      ? createJazzClient({ appId, serverUrl, secret: auth.secret })
+      : null,
+  );
 </script>
 
 {#if client}


### PR DESCRIPTION
Stacked on #879 — review/merge that first. This branch's diff is starters-only; the `LocalFirstAuth` library work and the SvelteKit dev-env fix live in #879. GitHub will retarget this to `main` once #879 merges.

## Summary
- Migrate the SvelteKit local-first and hybrid starters to the `LocalFirstAuth` reactive class — provider, sign-out and recovery-phrase backup wiring.
- Migrate the React and Next local-first and hybrid starters to the `useLocalFirstAuth` hook/composable.
- No library changes here: all `jazz-tools` changes (the `svelte`/`vue` hooks and the `jazzSvelteKit` dev-env fix) are in #879.

## Test plan
- [ ] With #879 checked out under this branch, boot each SvelteKit starter (`pnpm dev`) and confirm the app renders and recovery-phrase backup/restore works
- [ ] Boot a React and a Next starter (local-first + hybrid) and confirm auth + a todo round-trips across reload