### PR TITLE
Add Dashboard link to docs site nav

### DIFF
--- a/docs/lib/layout.shared.tsx
+++ b/docs/lib/layout.shared.tsx
@@ -41,6 +41,11 @@ export function baseOptions(): BaseLayoutProps {
         active: "nested-url",
       },
       {
+        text: "Dashboard",
+        url: "https://v2.dashboard.jazz.tools",
+        external: true,
+      },
+      {
         type: "icon",
         label: "Jazz GitHub",
         text: "GitHub",


### PR DESCRIPTION
## Summary
- Adds a "Dashboard" link to the docs-site top nav, alongside Blog and Docs, pointing to https://v2.dashboard.jazz.tools
- Plain text link (fumadocs `MainItemType`, like the existing Blog/Docs entries) with `external: true`

## Test plan
- [ ] Run the docs site and confirm "Dashboard" appears in the nav next to Blog/Docs, styled as plain text, and opens https://v2.dashboard.jazz.tools in a new tab