### PR TITLE
Harden graceful server shutdown lifecycle

### DIFF
--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -1288,13 +1288,17 @@ impl NapiRuntime {
             .core
             .lock()
             .map_err(|_| napi::Error::from_reason("lock"))?;
-        core.storage()
-            .flush()
+        let flush_result = core.storage().flush();
+        let flush_wal_result = core.storage().flush_wal();
+        let close_result = core.storage().close();
+
+        flush_result
             .map_err(|e| napi::Error::from_reason(format!("Failed to flush storage: {:?}", e)))?;
-        core.storage()
-            .close()
-            .map_err(|e| napi::Error::from_reason(format!("Failed to close storage: {:?}", e)))?;
-        Ok(())
+        flush_wal_result.map_err(|e| {
+            napi::Error::from_reason(format!("Failed to flush storage WAL: {:?}", e))
+        })?;
+        close_result
+            .map_err(|e| napi::Error::from_reason(format!("Failed to close storage: {:?}", e)))
     }
 
     #[napi(js_name = "deriveUserId")]

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -1275,7 +1275,9 @@ impl NapiRuntime {
             .core
             .lock()
             .map_err(|_| napi::Error::from_reason("lock"))?;
-        core.storage().flush();
+        core.storage()
+            .flush()
+            .map_err(|e| napi::Error::from_reason(format!("Failed to flush storage: {:?}", e)))?;
         Ok(())
     }
 
@@ -1286,7 +1288,9 @@ impl NapiRuntime {
             .core
             .lock()
             .map_err(|_| napi::Error::from_reason("lock"))?;
-        core.storage().flush();
+        core.storage()
+            .flush()
+            .map_err(|e| napi::Error::from_reason(format!("Failed to flush storage: {:?}", e)))?;
         core.storage()
             .close()
             .map_err(|e| napi::Error::from_reason(format!("Failed to close storage: {:?}", e)))?;

--- a/crates/jazz-rn/rust/src/lib.rs
+++ b/crates/jazz-rn/rust/src/lib.rs
@@ -489,6 +489,9 @@ impl RnRuntime {
                 })?;
                 core.scheduler_mut().clear_scheduled();
                 core.batched_tick();
+                if let Some(error) = core.take_storage_flush_error() {
+                    return Err(runtime_err(format!("storage WAL flush failed: {error}")));
+                }
             }
             Ok(())
         })

--- a/crates/jazz-rn/rust/src/lib.rs
+++ b/crates/jazz-rn/rust/src/lib.rs
@@ -1031,7 +1031,7 @@ impl RnRuntime {
             let core = self.core.lock().map_err(|_| JazzRnError::Internal {
                 message: "lock poisoned".into(),
             })?;
-            core.flush_storage();
+            core.flush_storage().map_err(runtime_err)?;
             Ok(())
         })
     }
@@ -1096,7 +1096,7 @@ impl RnRuntime {
             let core = self.core.lock().map_err(|_| JazzRnError::Internal {
                 message: "lock poisoned".into(),
             })?;
-            core.flush_storage();
+            core.flush_storage().map_err(runtime_err)?;
             core.storage().close().map_err(runtime_err)?;
             Ok(())
         })

--- a/crates/jazz-rn/rust/src/lib.rs
+++ b/crates/jazz-rn/rust/src/lib.rs
@@ -1096,9 +1096,13 @@ impl RnRuntime {
             let core = self.core.lock().map_err(|_| JazzRnError::Internal {
                 message: "lock poisoned".into(),
             })?;
-            core.flush_storage().map_err(runtime_err)?;
-            core.storage().close().map_err(runtime_err)?;
-            Ok(())
+            let flush_result = core.flush_storage();
+            let flush_wal_result = core.flush_wal();
+            let close_result = core.storage().close();
+
+            flush_result.map_err(runtime_err)?;
+            flush_wal_result.map_err(runtime_err)?;
+            close_result.map_err(runtime_err)
         })
     }
 

--- a/crates/jazz-rn/rust/src/lib.rs
+++ b/crates/jazz-rn/rust/src/lib.rs
@@ -1031,7 +1031,7 @@ impl RnRuntime {
 
     pub fn flush(&self) -> Result<(), JazzRnError> {
         with_panic_boundary("flush", || {
-            let core = self.core.lock().map_err(|_| JazzRnError::Internal {
+            let mut core = self.core.lock().map_err(|_| JazzRnError::Internal {
                 message: "lock poisoned".into(),
             })?;
             core.flush_storage().map_err(runtime_err)?;
@@ -1096,7 +1096,7 @@ impl RnRuntime {
     /// Flush and close the underlying storage, releasing filesystem locks.
     pub fn close(&self) -> Result<(), JazzRnError> {
         with_panic_boundary("close", || {
-            let core = self.core.lock().map_err(|_| JazzRnError::Internal {
+            let mut core = self.core.lock().map_err(|_| JazzRnError::Internal {
                 message: "lock poisoned".into(),
             })?;
             let flush_result = core.flush_storage();

--- a/crates/jazz-tools/benches/realistic_phase1.rs
+++ b/crates/jazz-tools/benches/realistic_phase1.rs
@@ -1007,7 +1007,7 @@ impl ColdLoadSeededDb {
                 create_rocksdb_runtime(project_board_schema(), &db_path, scenario.cache_size_bytes);
             let seeded =
                 seed_project_board_dataset(&mut runtime, profile, profile.seed ^ scenario.seed);
-            runtime.flush_storage();
+            runtime.flush_storage().unwrap();
             runtime.storage().close().expect("close seeded rocksdb");
             seeded
         };
@@ -1037,7 +1037,7 @@ impl ColdLoadSeededDb {
             let mut runtime = create_sqlite_runtime(project_board_schema(), &db_path);
             let seeded =
                 seed_project_board_dataset(&mut runtime, profile, profile.seed ^ scenario.seed);
-            runtime.flush_storage();
+            runtime.flush_storage().unwrap();
             runtime.storage().close().expect("close seeded sqlite");
             seeded
         };
@@ -2016,7 +2016,7 @@ fn realistic_r1_crud_rocksdb(c: &mut Criterion) {
                 let executed = state.run_crud_batch(scenario);
                 black_box(executed);
             });
-            state.runtime.flush_storage();
+            state.runtime.flush_storage().unwrap();
             state.runtime.storage().close().expect("close rocksdb");
         },
     );
@@ -2054,7 +2054,7 @@ fn realistic_r1_crud_sqlite(c: &mut Criterion) {
                 let executed = state.run_crud_batch(scenario);
                 black_box(executed);
             });
-            state.runtime.flush_storage();
+            state.runtime.flush_storage().unwrap();
             state.runtime.storage().close().expect("close sqlite");
         },
     );
@@ -2093,7 +2093,7 @@ fn realistic_r2_reads_rocksdb(c: &mut Criterion) {
                 let total_rows = state.run_read_batch(scenario);
                 black_box(total_rows);
             });
-            state.runtime.flush_storage();
+            state.runtime.flush_storage().unwrap();
             state.runtime.storage().close().expect("close rocksdb");
         },
     );
@@ -2131,7 +2131,7 @@ fn realistic_r2_reads_sqlite(c: &mut Criterion) {
                 let total_rows = state.run_read_batch(scenario);
                 black_box(total_rows);
             });
-            state.runtime.flush_storage();
+            state.runtime.flush_storage().unwrap();
             state.runtime.storage().close().expect("close sqlite");
         },
     );
@@ -2181,7 +2181,7 @@ fn realistic_r3_cold_load_rocksdb(c: &mut Criterion) {
                 let rows = block_on(runtime.query(query, None)).expect("cold-load query");
                 let query_elapsed = query_start.elapsed();
 
-                runtime.flush_storage();
+                runtime.flush_storage().unwrap();
                 runtime.storage().close().expect("close cold-load rocksdb");
 
                 black_box(open_elapsed);
@@ -2232,7 +2232,7 @@ fn realistic_r3_cold_load_sqlite(c: &mut Criterion) {
                 let rows = block_on(runtime.query(query, None)).expect("cold-load query");
                 let query_elapsed = query_start.elapsed();
 
-                runtime.flush_storage();
+                runtime.flush_storage().unwrap();
                 runtime.storage().close().expect("close cold-load sqlite");
 
                 black_box(open_elapsed);
@@ -2839,7 +2839,7 @@ fn realistic_r8_many_branches_cold_load_rocksdb(c: &mut Criterion) {
                     &seeded.branch_names,
                     &seeded.prefix,
                 );
-                storage.flush();
+                storage.flush().unwrap();
                 storage
                     .close()
                     .expect("close many-branches rocksdb storage");
@@ -2887,7 +2887,7 @@ fn realistic_r8_many_branches_cold_load_sqlite(c: &mut Criterion) {
                     &seeded.branch_names,
                     &seeded.prefix,
                 );
-                storage.flush();
+                storage.flush().unwrap();
                 storage.close().expect("close many-branches sqlite storage");
                 black_box(scan);
             });
@@ -3005,7 +3005,7 @@ fn realistic_r8_many_branches_rocksdb(c: &mut Criterion) {
                 let mut storage = RocksDBStorage::open(&db_path, scenario.cache_size_bytes)
                     .expect("open rocksdb for many-branches write benchmark");
                 let dataset = build_many_branches_dataset(&mut storage, scenario);
-                storage.flush();
+                storage.flush().unwrap();
                 storage.close().expect("close many-branches rocksdb write");
                 black_box(dataset.object_id);
                 black_box(dataset.branch_names.len());
@@ -3070,7 +3070,7 @@ fn realistic_r8_many_branches_rocksdb(c: &mut Criterion) {
         },
     );
     scan_leaf_group.finish();
-    loaded_storage.flush();
+    loaded_storage.flush().unwrap();
     loaded_storage
         .close()
         .expect("close many-branches rocksdb scan storage");
@@ -3095,7 +3095,7 @@ fn realistic_r8_many_branches_rocksdb(c: &mut Criterion) {
                     &seeded.branch_names,
                     &seeded.prefix,
                 );
-                storage.flush();
+                storage.flush().unwrap();
                 storage
                     .close()
                     .expect("close many-branches rocksdb cold-load");
@@ -3138,7 +3138,7 @@ fn realistic_r8_many_branches_sqlite(c: &mut Criterion) {
                 let mut storage = SqliteStorage::open(&db_path)
                     .expect("open sqlite for many-branches write benchmark");
                 let dataset = build_many_branches_dataset(&mut storage, scenario);
-                storage.flush();
+                storage.flush().unwrap();
                 storage.close().expect("close many-branches sqlite write");
                 black_box(dataset.object_id);
                 black_box(dataset.branch_names.len());
@@ -3224,7 +3224,7 @@ fn realistic_r8_many_branches_sqlite(c: &mut Criterion) {
                     &seeded.branch_names,
                     &seeded.prefix,
                 );
-                storage.flush();
+                storage.flush().unwrap();
                 storage
                     .close()
                     .expect("close many-branches sqlite cold-load");
@@ -3431,7 +3431,7 @@ impl ManyBranchesSeededDb {
         let mut storage = RocksDBStorage::open(&db_path, scenario.cache_size_bytes)
             .expect("open rocksdb for many-branches seed");
         let dataset = build_many_branches_dataset(&mut storage, scenario);
-        storage.flush();
+        storage.flush().unwrap();
         storage
             .close()
             .expect("close seeded many-branches rocksdb storage");
@@ -3455,7 +3455,7 @@ impl ManyBranchesSeededDb {
         let mut storage =
             SqliteStorage::open(&db_path).expect("open sqlite for many-branches seed");
         let dataset = build_many_branches_dataset(&mut storage, scenario);
-        storage.flush();
+        storage.flush().unwrap();
         storage
             .close()
             .expect("close seeded many-branches sqlite storage");
@@ -3966,7 +3966,7 @@ fn workspace_path(path: &str) -> PathBuf {
 }
 
 fn flush_and_close_runtime<S: Storage>(runtime: &mut BenchRuntime<S>) {
-    runtime.flush_storage();
+    runtime.flush_storage().unwrap();
     runtime.storage().close().expect("close benchmark storage");
 }
 

--- a/crates/jazz-tools/src/client.rs
+++ b/crates/jazz-tools/src/client.rs
@@ -492,7 +492,8 @@ impl JazzClient {
         // Flush storage state to disk for persistence
         self.runtime
             .with_storage(|storage| {
-                storage.flush();
+                storage.flush()?;
+                storage.flush_wal()?;
                 storage.close()
             })
             .map_err(|e| JazzError::Storage(e.to_string()))?
@@ -941,7 +942,7 @@ mod tests {
         }
 
         let storage = runtime.into_storage();
-        storage.flush();
+        storage.flush().expect("flush seeded client storage");
         storage.close().expect("close seeded client storage");
 
         (bundled_hash, learned_hash)

--- a/crates/jazz-tools/src/client.rs
+++ b/crates/jazz-tools/src/client.rs
@@ -484,13 +484,15 @@ impl JazzClient {
         }
 
         // Flush pending operations
-        self.runtime
+        let runtime_flush_result = self
+            .runtime
             .flush()
             .await
-            .map_err(|e| JazzError::Connection(e.to_string()))?;
+            .map_err(|e| JazzError::Connection(e.to_string()));
 
         // Flush storage state to disk for persistence
-        self.runtime
+        let storage_result = self
+            .runtime
             .with_storage(|storage| {
                 let flush_result = storage.flush();
                 let flush_wal_result = storage.flush_wal();
@@ -500,8 +502,11 @@ impl JazzClient {
                 flush_wal_result?;
                 close_result
             })
-            .map_err(|e| JazzError::Storage(e.to_string()))?
-            .map_err(|e| JazzError::Storage(e.to_string()))?;
+            .map_err(|e| JazzError::Storage(e.to_string()))
+            .and_then(|result| result.map_err(|e| JazzError::Storage(e.to_string())));
+
+        runtime_flush_result?;
+        storage_result?;
 
         Ok(())
     }

--- a/crates/jazz-tools/src/client.rs
+++ b/crates/jazz-tools/src/client.rs
@@ -492,9 +492,13 @@ impl JazzClient {
         // Flush storage state to disk for persistence
         self.runtime
             .with_storage(|storage| {
-                storage.flush()?;
-                storage.flush_wal()?;
-                storage.close()
+                let flush_result = storage.flush();
+                let flush_wal_result = storage.flush_wal();
+                let close_result = storage.close();
+
+                flush_result?;
+                flush_wal_result?;
+                close_result
             })
             .map_err(|e| JazzError::Storage(e.to_string()))?
             .map_err(|e| JazzError::Storage(e.to_string()))?;

--- a/crates/jazz-tools/src/commands/server.rs
+++ b/crates/jazz-tools/src/commands/server.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use jazz_tools::middleware::AuthConfig;
 use jazz_tools::schema_manager::AppId;
-use jazz_tools::server::{ServerBuilder, StorageBackend};
+use jazz_tools::server::{ServerBuilder, ShutdownPhase, StorageBackend};
 use tracing::info;
 
 const STANDALONE_INSPECTOR_URL: &str = "https://jazz2-inspector.vercel.app/";
@@ -66,23 +66,80 @@ pub async fn run(
     info!("Open the inspector: {}", inspector_link);
 
     let state = built.state.clone();
+    let shutdown = state.shutdown.clone();
+    let shutdown_budget = shutdown_timeout
+        .saturating_mul(2)
+        .saturating_add(Duration::from_secs(5));
     let (serve_shutdown_tx, serve_shutdown_rx) = tokio::sync::oneshot::channel();
-    let shutdown_task = tokio::spawn(async move {
+    let mut shutdown_task = tokio::spawn(async move {
         state.shutdown.wait_requested().await;
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        state.run_shutdown_finalization().await;
+        let phase = state.run_shutdown_finalization().await;
         let _ = serve_shutdown_tx.send(());
+        phase
     });
 
-    let serve_result = axum::serve(listener, built.app)
-        .with_graceful_shutdown(async {
-            let _ = serve_shutdown_rx.await;
-        })
-        .await;
+    let mut serve_task = tokio::spawn(async move {
+        axum::serve(listener, built.app)
+            .with_graceful_shutdown(async {
+                let _ = serve_shutdown_rx.await;
+            })
+            .await
+    });
 
-    shutdown_task.abort();
-    let _ = shutdown_task.await;
-    serve_result?;
+    let mut forced_shutdown = false;
+    let serve_join_result = tokio::select! {
+        result = &mut serve_task => result,
+        _ = async {
+            shutdown.wait_requested().await;
+            tokio::time::sleep(shutdown_budget).await;
+        } => {
+            forced_shutdown = true;
+            serve_task.abort();
+            match tokio::time::timeout(Duration::from_millis(50), &mut serve_task).await {
+                Ok(result) => result,
+                Err(_) => Ok(Ok(())),
+            }
+        }
+    };
+
+    let serve_result = match serve_join_result {
+        Ok(result) => result,
+        Err(error) if forced_shutdown && error.is_cancelled() => Ok(()),
+        Err(error) => {
+            shutdown_task.abort();
+            let _ = tokio::time::timeout(Duration::from_millis(50), shutdown_task).await;
+            return Err(Box::new(error));
+        }
+    };
+
+    if let Err(error) = serve_result {
+        shutdown_task.abort();
+        let _ = tokio::time::timeout(Duration::from_millis(50), shutdown_task).await;
+        return Err(Box::new(error));
+    }
+
+    if forced_shutdown {
+        return Err("server shutdown timed out while waiting for active requests to finish".into());
+    }
+
+    if shutdown.is_shutting_down() {
+        let final_phase =
+            match tokio::time::timeout(Duration::from_secs(5), &mut shutdown_task).await {
+                Ok(Ok(phase)) => phase,
+                Ok(Err(error)) => return Err(Box::new(error)),
+                Err(_) => {
+                    shutdown_task.abort();
+                    return Err("server shutdown finalization did not finish".into());
+                }
+            };
+        if final_phase == ShutdownPhase::Failed {
+            return Err("server shutdown finalization failed".into());
+        }
+    } else {
+        shutdown_task.abort();
+        let _ = tokio::time::timeout(Duration::from_millis(50), shutdown_task).await;
+    }
 
     Ok(())
 }

--- a/crates/jazz-tools/src/commands/server.rs
+++ b/crates/jazz-tools/src/commands/server.rs
@@ -1,6 +1,7 @@
 //! Server command implementation.
 
 use std::net::SocketAddr;
+use std::time::Duration;
 
 use jazz_tools::middleware::AuthConfig;
 use jazz_tools::schema_manager::AppId;
@@ -18,6 +19,7 @@ pub async fn run(
     auth_config: AuthConfig,
     upstream_url: Option<String>,
     bound_port_file: Option<String>,
+    shutdown_timeout: Duration,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let app_id = AppId::from_string(app_id_str)?;
     let app_id_string = app_id.to_string();
@@ -30,7 +32,9 @@ pub async fn run(
         info!("Data directory: {}", data_dir);
     }
 
-    let builder = ServerBuilder::new(app_id).with_auth_config(auth_config);
+    let builder = ServerBuilder::new(app_id)
+        .with_auth_config(auth_config)
+        .with_shutdown_timeout(shutdown_timeout);
     let builder = match upstream_url {
         Some(upstream_url) => builder.with_upstream_url(upstream_url),
         None => builder,

--- a/crates/jazz-tools/src/commands/server.rs
+++ b/crates/jazz-tools/src/commands/server.rs
@@ -60,7 +60,24 @@ pub async fn run(
 
     info!("Listening on http://{}", bound_addr);
     info!("Open the inspector: {}", inspector_link);
-    axum::serve(listener, built.app).await?;
+
+    let state = built.state.clone();
+    let (serve_shutdown_tx, serve_shutdown_rx) = tokio::sync::oneshot::channel();
+    let shutdown_task = tokio::spawn(async move {
+        state.shutdown.wait_requested().await;
+        state.run_shutdown_finalization().await;
+        let _ = serve_shutdown_tx.send(());
+    });
+
+    let serve_result = axum::serve(listener, built.app)
+        .with_graceful_shutdown(async {
+            let _ = serve_shutdown_rx.await;
+        })
+        .await;
+
+    shutdown_task.abort();
+    let _ = shutdown_task.await;
+    serve_result?;
 
     Ok(())
 }

--- a/crates/jazz-tools/src/commands/server.rs
+++ b/crates/jazz-tools/src/commands/server.rs
@@ -65,6 +65,7 @@ pub async fn run(
     let (serve_shutdown_tx, serve_shutdown_rx) = tokio::sync::oneshot::channel();
     let shutdown_task = tokio::spawn(async move {
         state.shutdown.wait_requested().await;
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         state.run_shutdown_finalization().await;
         let _ = serve_shutdown_tx.send(());
     });

--- a/crates/jazz-tools/src/main.rs
+++ b/crates/jazz-tools/src/main.rs
@@ -133,6 +133,10 @@ enum Commands {
         #[arg(long, env = "JAZZ_PEER_SECRET")]
         peer_secret: Option<String>,
 
+        /// Graceful shutdown network-drain timeout in seconds.
+        #[arg(long, env = "JAZZ_SHUTDOWN_TIMEOUT_SECS", default_value_t = 30)]
+        shutdown_timeout_secs: u64,
+
         /// Internal testing hook: write the resolved listen port after binding.
         #[arg(long, env = "JAZZ_BOUND_PORT_FILE", hide = true)]
         bound_port_file: Option<String>,
@@ -180,6 +184,7 @@ async fn main() {
             admin_secret,
             upstream_url,
             peer_secret,
+            shutdown_timeout_secs,
             bound_port_file,
         } => {
             let node_env_mode = resolve_node_env_mode();
@@ -215,6 +220,7 @@ async fn main() {
                 auth_config,
                 upstream_url,
                 bound_port_file,
+                std::time::Duration::from_secs(shutdown_timeout_secs),
             )
             .await
             {
@@ -291,6 +297,26 @@ mod tests {
 
         match cli.command {
             Commands::Server { .. } => {}
+            _ => panic!("expected server command"),
+        }
+    }
+
+    #[test]
+    fn server_command_parses_shutdown_timeout_secs() {
+        let cli = Cli::try_parse_from([
+            "jazz-tools",
+            "server",
+            "test-app",
+            "--shutdown-timeout-secs",
+            "7",
+        ])
+        .expect("server command should parse");
+
+        match cli.command {
+            Commands::Server {
+                shutdown_timeout_secs,
+                ..
+            } => assert_eq!(shutdown_timeout_secs, 7),
             _ => panic!("expected server command"),
         }
     }

--- a/crates/jazz-tools/src/main.rs
+++ b/crates/jazz-tools/src/main.rs
@@ -287,6 +287,9 @@ fn make_env_filter() -> tracing_subscriber::EnvFilter {
 mod tests {
     use super::*;
 
+    // Clap reads env-backed args during parsing, so every Cli::try_parse_from
+    // test in this module holds this lock. The tests that mutate env vars keep
+    // it held until their EnvVarGuard restores the previous value.
     static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     struct EnvVarGuard {
@@ -297,7 +300,8 @@ mod tests {
     impl EnvVarGuard {
         fn set(key: &'static str, value: &str) -> Self {
             let previous = std::env::var_os(key);
-            // SAFETY: tests using process env vars hold ENV_LOCK for the full mutation window.
+            // SAFETY: all CLI parser tests hold ENV_LOCK, and env-mutating tests
+            // keep holding it until EnvVarGuard restores the previous value.
             unsafe {
                 std::env::set_var(key, value);
             }
@@ -306,7 +310,8 @@ mod tests {
 
         fn remove(key: &'static str) -> Self {
             let previous = std::env::var_os(key);
-            // SAFETY: tests using process env vars hold ENV_LOCK for the full mutation window.
+            // SAFETY: all CLI parser tests hold ENV_LOCK, and env-mutating tests
+            // keep holding it until EnvVarGuard restores the previous value.
             unsafe {
                 std::env::remove_var(key);
             }
@@ -316,7 +321,8 @@ mod tests {
 
     impl Drop for EnvVarGuard {
         fn drop(&mut self) {
-            // SAFETY: tests using process env vars hold ENV_LOCK until after this guard drops.
+            // SAFETY: all CLI parser tests hold ENV_LOCK, and env-mutating tests
+            // keep holding it until EnvVarGuard restores the previous value.
             unsafe {
                 match &self.previous {
                     Some(value) => std::env::set_var(self.key, value),
@@ -328,6 +334,7 @@ mod tests {
 
     #[test]
     fn server_command_parses_allow_local_first_auth_flag() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
         let cli = Cli::try_parse_from([
             "jazz-tools",
             "server",
@@ -347,6 +354,7 @@ mod tests {
 
     #[test]
     fn server_command_parses_jwt_public_key_flag() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
         let cli = Cli::try_parse_from([
             "jazz-tools",
             "server",
@@ -380,6 +388,7 @@ mod tests {
 
     #[test]
     fn server_command_parses_shutdown_timeout_secs() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
         let cli = Cli::try_parse_from([
             "jazz-tools",
             "server",
@@ -416,6 +425,7 @@ mod tests {
 
     #[test]
     fn server_command_rejects_shutdown_timeout_secs_above_limit() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
         let error = match Cli::try_parse_from([
             "jazz-tools",
             "server",
@@ -436,6 +446,7 @@ mod tests {
 
     #[test]
     fn server_command_parses_upstream_url_and_peer_secret() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
         let cli = Cli::try_parse_from([
             "jazz-tools",
             "server",
@@ -462,6 +473,7 @@ mod tests {
 
     #[test]
     fn server_cli_validation_requires_peer_secret_in_edge_mode() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
         let cli = Cli::try_parse_from([
             "jazz-tools",
             "server",
@@ -480,6 +492,7 @@ mod tests {
 
     #[test]
     fn server_cli_validation_requires_admin_secret_in_edge_mode() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
         let cli = Cli::try_parse_from([
             "jazz-tools",
             "server",

--- a/crates/jazz-tools/src/main.rs
+++ b/crates/jazz-tools/src/main.rs
@@ -21,6 +21,9 @@ use jazz_tools::middleware::AuthConfig;
 #[cfg(feature = "otel")]
 use jazz_tools::otel;
 
+const DEFAULT_SHUTDOWN_TIMEOUT_SECS: u64 = 30;
+const MAX_SHUTDOWN_TIMEOUT_SECS: u64 = 60 * 60;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum NodeEnvMode {
     Production,
@@ -62,6 +65,20 @@ fn resolve_jwt_public_key_input(value: String) -> Result<String, String> {
     }
 
     Ok(trimmed.to_string())
+}
+
+fn parse_shutdown_timeout_secs(value: &str) -> Result<u64, String> {
+    let seconds = value
+        .parse::<u64>()
+        .map_err(|error| format!("invalid shutdown timeout: {error}"))?;
+
+    if !(1..=MAX_SHUTDOWN_TIMEOUT_SECS).contains(&seconds) {
+        return Err(format!(
+            "shutdown timeout must be between 1 and {MAX_SHUTDOWN_TIMEOUT_SECS} seconds"
+        ));
+    }
+
+    Ok(seconds)
 }
 
 #[derive(Parser)]
@@ -134,7 +151,12 @@ enum Commands {
         peer_secret: Option<String>,
 
         /// Graceful shutdown network-drain timeout in seconds.
-        #[arg(long, env = "JAZZ_SHUTDOWN_TIMEOUT_SECS", default_value_t = 30)]
+        #[arg(
+            long,
+            env = "JAZZ_SHUTDOWN_TIMEOUT_SECS",
+            default_value_t = DEFAULT_SHUTDOWN_TIMEOUT_SECS,
+            value_parser = parse_shutdown_timeout_secs,
+        )]
         shutdown_timeout_secs: u64,
 
         /// Internal testing hook: write the resolved listen port after binding.
@@ -265,6 +287,45 @@ fn make_env_filter() -> tracing_subscriber::EnvFilter {
 mod tests {
     use super::*;
 
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var_os(key);
+            // SAFETY: tests using process env vars hold ENV_LOCK for the full mutation window.
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var_os(key);
+            // SAFETY: tests using process env vars hold ENV_LOCK for the full mutation window.
+            unsafe {
+                std::env::remove_var(key);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            // SAFETY: tests using process env vars hold ENV_LOCK until after this guard drops.
+            unsafe {
+                match &self.previous {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
     #[test]
     fn server_command_parses_allow_local_first_auth_flag() {
         let cli = Cli::try_parse_from([
@@ -302,6 +363,22 @@ mod tests {
     }
 
     #[test]
+    fn server_command_defaults_shutdown_timeout_secs() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _env_guard = EnvVarGuard::remove("JAZZ_SHUTDOWN_TIMEOUT_SECS");
+        let cli = Cli::try_parse_from(["jazz-tools", "server", "test-app"])
+            .expect("server command should parse");
+
+        match cli.command {
+            Commands::Server {
+                shutdown_timeout_secs,
+                ..
+            } => assert_eq!(shutdown_timeout_secs, DEFAULT_SHUTDOWN_TIMEOUT_SECS),
+            _ => panic!("expected server command"),
+        }
+    }
+
+    #[test]
     fn server_command_parses_shutdown_timeout_secs() {
         let cli = Cli::try_parse_from([
             "jazz-tools",
@@ -319,6 +396,42 @@ mod tests {
             } => assert_eq!(shutdown_timeout_secs, 7),
             _ => panic!("expected server command"),
         }
+    }
+
+    #[test]
+    fn server_command_reads_shutdown_timeout_secs_from_env() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _env_guard = EnvVarGuard::set("JAZZ_SHUTDOWN_TIMEOUT_SECS", "11");
+        let cli = Cli::try_parse_from(["jazz-tools", "server", "test-app"])
+            .expect("server command should parse");
+
+        match cli.command {
+            Commands::Server {
+                shutdown_timeout_secs,
+                ..
+            } => assert_eq!(shutdown_timeout_secs, 11),
+            _ => panic!("expected server command"),
+        }
+    }
+
+    #[test]
+    fn server_command_rejects_shutdown_timeout_secs_above_limit() {
+        let error = match Cli::try_parse_from([
+            "jazz-tools",
+            "server",
+            "test-app",
+            "--shutdown-timeout-secs",
+            "18446744073709551615",
+        ]) {
+            Ok(_) => panic!("absurd shutdown timeout should be rejected"),
+            Err(error) => error,
+        };
+
+        assert!(
+            error
+                .to_string()
+                .contains("shutdown timeout must be between 1 and")
+        );
     }
 
     #[test]

--- a/crates/jazz-tools/src/runtime_core/mod.rs
+++ b/crates/jazz-tools/src/runtime_core/mod.rs
@@ -564,17 +564,23 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
     }
 
     /// Flush the storage to persistent medium.
-    pub fn flush_storage(&self) -> Result<(), StorageError> {
-        self.storage.flush()
+    pub fn flush_storage(&mut self) -> Result<(), StorageError> {
+        self.storage.flush()?;
+        self.clear_storage_write_pending_flush();
+        Ok(())
     }
 
     /// Flush only the WAL buffer (not the full snapshot).
-    pub fn flush_wal(&self) -> Result<(), StorageError> {
-        self.storage.flush_wal()
+    pub fn flush_wal(&mut self) -> Result<(), StorageError> {
+        self.flush_wal_barrier()
     }
 
     pub(crate) fn mark_storage_write_pending_flush(&mut self) {
         self.storage_write_pending_flush = true;
+    }
+
+    pub(crate) fn has_storage_write_pending_flush(&self) -> bool {
+        self.storage_write_pending_flush
     }
 
     pub(crate) fn clear_storage_write_pending_flush(&mut self) {
@@ -588,6 +594,19 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
 
     pub fn take_storage_flush_error(&mut self) -> Option<StorageError> {
         self.storage_flush_error.take()
+    }
+
+    pub(crate) fn flush_wal_barrier(&mut self) -> Result<(), StorageError> {
+        match self.storage.flush_wal() {
+            Ok(()) => {
+                self.clear_storage_write_pending_flush();
+                Ok(())
+            }
+            Err(error) => {
+                self.record_storage_flush_error(error.clone());
+                Err(error)
+            }
+        }
     }
 
     /// Consume RuntimeCore and return the Storage.

--- a/crates/jazz-tools/src/runtime_core/mod.rs
+++ b/crates/jazz-tools/src/runtime_core/mod.rs
@@ -598,6 +598,10 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         self.storage_flush_error.is_some()
     }
 
+    pub(crate) fn has_storage_flush_retry_scheduled(&self) -> bool {
+        self.storage_flush_retry_scheduled
+    }
+
     pub(crate) fn clear_storage_write_pending_flush(&mut self) {
         self.storage_write_pending_flush = false;
         self.storage_flush_retry_scheduled = false;

--- a/crates/jazz-tools/src/runtime_core/mod.rs
+++ b/crates/jazz-tools/src/runtime_core/mod.rs
@@ -565,9 +565,16 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
 
     /// Flush the storage to persistent medium.
     pub fn flush_storage(&mut self) -> Result<(), StorageError> {
-        self.storage.flush()?;
-        self.clear_storage_write_pending_flush();
-        Ok(())
+        match self.storage.flush() {
+            Ok(()) => {
+                self.clear_storage_write_pending_flush();
+                Ok(())
+            }
+            Err(error) => {
+                self.record_storage_flush_error(error.clone());
+                Err(error)
+            }
+        }
     }
 
     /// Flush only the WAL buffer (not the full snapshot).

--- a/crates/jazz-tools/src/runtime_core/mod.rs
+++ b/crates/jazz-tools/src/runtime_core/mod.rs
@@ -306,6 +306,8 @@ pub struct RuntimeCore<S: Storage, Sch: Scheduler> {
     scheduler: Sch,
     /// True when storage was mutated since the last WAL flush barrier.
     storage_write_pending_flush: bool,
+    /// True after scheduling one retry for the current failed WAL flush barrier.
+    storage_flush_retry_scheduled: bool,
     /// Last storage flush error recorded by a durability barrier.
     storage_flush_error: Option<StorageError>,
     /// Transport handle for WebSocket sync.
@@ -447,6 +449,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             storage,
             scheduler,
             storage_write_pending_flush: false,
+            storage_flush_retry_scheduled: false,
             storage_flush_error: None,
             transport: None,
             sync_sender: None,
@@ -584,15 +587,29 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
 
     pub(crate) fn mark_storage_write_pending_flush(&mut self) {
         self.storage_write_pending_flush = true;
+        self.storage_flush_retry_scheduled = false;
     }
 
     pub(crate) fn has_storage_write_pending_flush(&self) -> bool {
         self.storage_write_pending_flush
     }
 
+    pub(crate) fn has_storage_flush_error(&self) -> bool {
+        self.storage_flush_error.is_some()
+    }
+
     pub(crate) fn clear_storage_write_pending_flush(&mut self) {
         self.storage_write_pending_flush = false;
+        self.storage_flush_retry_scheduled = false;
         self.storage_flush_error = None;
+    }
+
+    pub(crate) fn should_schedule_storage_flush_retry(&mut self) -> bool {
+        if self.storage_flush_retry_scheduled {
+            return false;
+        }
+        self.storage_flush_retry_scheduled = true;
+        true
     }
 
     pub(crate) fn record_storage_flush_error(&mut self, error: StorageError) {

--- a/crates/jazz-tools/src/runtime_core/mod.rs
+++ b/crates/jazz-tools/src/runtime_core/mod.rs
@@ -306,7 +306,7 @@ pub struct RuntimeCore<S: Storage, Sch: Scheduler> {
     scheduler: Sch,
     /// True when storage was mutated since the last WAL flush barrier.
     storage_write_pending_flush: bool,
-    /// Last WAL flush error recorded by a scheduled or explicit batched tick.
+    /// Last storage flush error recorded by a durability barrier.
     storage_flush_error: Option<StorageError>,
     /// Transport handle for WebSocket sync.
     pub(crate) transport: Option<crate::transport_manager::TransportHandle>,

--- a/crates/jazz-tools/src/runtime_core/mod.rs
+++ b/crates/jazz-tools/src/runtime_core/mod.rs
@@ -47,7 +47,7 @@ use crate::query_manager::types::{
 use crate::row_format::decode_row;
 use crate::row_histories::BatchId;
 use crate::schema_manager::{Lens, SchemaManager};
-use crate::storage::Storage;
+use crate::storage::{Storage, StorageError};
 use crate::sync_manager::{ClientId, DurabilityTier, InboxEntry, OutboxEntry, ServerId};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -561,13 +561,13 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
     }
 
     /// Flush the storage to persistent medium.
-    pub fn flush_storage(&self) {
-        self.storage.flush();
+    pub fn flush_storage(&self) -> Result<(), StorageError> {
+        self.storage.flush()
     }
 
     /// Flush only the WAL buffer (not the full snapshot).
-    pub fn flush_wal(&self) {
-        self.storage.flush_wal();
+    pub fn flush_wal(&self) -> Result<(), StorageError> {
+        self.storage.flush_wal()
     }
 
     pub(crate) fn mark_storage_write_pending_flush(&mut self) {

--- a/crates/jazz-tools/src/runtime_core/mod.rs
+++ b/crates/jazz-tools/src/runtime_core/mod.rs
@@ -306,6 +306,8 @@ pub struct RuntimeCore<S: Storage, Sch: Scheduler> {
     scheduler: Sch,
     /// True when storage was mutated since the last WAL flush barrier.
     storage_write_pending_flush: bool,
+    /// Last WAL flush error recorded by a scheduled or explicit batched tick.
+    storage_flush_error: Option<StorageError>,
     /// Transport handle for WebSocket sync.
     pub(crate) transport: Option<crate::transport_manager::TransportHandle>,
     /// Fallback outbox sender used when no `TransportHandle` is set (e.g. on
@@ -445,6 +447,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             storage,
             scheduler,
             storage_write_pending_flush: false,
+            storage_flush_error: None,
             transport: None,
             sync_sender: None,
             parked_sync_messages: Vec::new(),
@@ -576,6 +579,15 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
 
     pub(crate) fn clear_storage_write_pending_flush(&mut self) {
         self.storage_write_pending_flush = false;
+        self.storage_flush_error = None;
+    }
+
+    pub(crate) fn record_storage_flush_error(&mut self, error: StorageError) {
+        self.storage_flush_error = Some(error);
+    }
+
+    pub fn take_storage_flush_error(&mut self) -> Option<StorageError> {
+        self.storage_flush_error.take()
     }
 
     /// Consume RuntimeCore and return the Storage.

--- a/crates/jazz-tools/src/runtime_core/tests.rs
+++ b/crates/jazz-tools/src/runtime_core/tests.rs
@@ -502,12 +502,12 @@ impl Storage for RowRegionReadFailingStorage {
         self.inner.index_scan_all(table, column, branch)
     }
 
-    fn flush(&self) {
-        self.inner.flush();
+    fn flush(&self) -> Result<(), StorageError> {
+        self.inner.flush()
     }
 
-    fn flush_wal(&self) {
-        self.inner.flush_wal();
+    fn flush_wal(&self) -> Result<(), StorageError> {
+        self.inner.flush_wal()
     }
 
     fn close(&self) -> Result<(), StorageError> {
@@ -895,12 +895,12 @@ impl Storage for LegacyPersistenceObservingStorage {
         self.inner.index_scan_all(table, column, branch)
     }
 
-    fn flush(&self) {
-        self.inner.flush();
+    fn flush(&self) -> Result<(), StorageError> {
+        self.inner.flush()
     }
 
-    fn flush_wal(&self) {
-        self.inner.flush_wal();
+    fn flush_wal(&self) -> Result<(), StorageError> {
+        self.inner.flush_wal()
     }
 
     fn close(&self) -> Result<(), StorageError> {
@@ -1313,13 +1313,13 @@ impl Storage for RowMutationObservingStorage {
         self.inner.index_scan_all(table, column, branch)
     }
 
-    fn flush(&self) {
-        self.inner.flush();
+    fn flush(&self) -> Result<(), StorageError> {
+        self.inner.flush()
     }
 
-    fn flush_wal(&self) {
+    fn flush_wal(&self) -> Result<(), StorageError> {
         self.calls.lock().unwrap().flush_wal_calls += 1;
-        self.inner.flush_wal();
+        self.inner.flush_wal()
     }
 
     fn close(&self) -> Result<(), StorageError> {

--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/storage_flush.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/storage_flush.rs
@@ -118,6 +118,29 @@ fn rc_batched_tick_flushes_wal_after_local_write() {
 }
 
 #[test]
+fn rc_flush_storage_records_error_and_clears_after_transient_success() {
+    let flush_error = StorageError::IoError("transient full flush failure".to_string());
+    let app_id = AppId::from_name("row-full-flush-transient-failure");
+    let schema_manager =
+        SchemaManager::new(SyncManager::new(), test_schema(), app_id, "dev", "main").unwrap();
+    let storage = MemoryStorage::new().with_transient_flush_failures(flush_error.clone(), 1);
+    let mut core = new_test_core(schema_manager, storage, NoopScheduler);
+
+    core.insert("users", user_insert_values(ObjectId::new(), "Alice"), None)
+        .unwrap();
+
+    let error = core.flush_storage().expect_err("first flush should fail");
+    assert_eq!(error, flush_error);
+    assert!(core.has_storage_write_pending_flush());
+    assert_eq!(core.take_storage_flush_error(), Some(flush_error));
+
+    core.flush_storage()
+        .expect("second flush should clear transient failure");
+    assert!(!core.has_storage_write_pending_flush());
+    assert_eq!(core.take_storage_flush_error(), None);
+}
+
+#[test]
 fn rc_batched_tick_skips_flush_wal_for_query_settled_only_message() {
     let calls = Arc::new(Mutex::new(RowMutationCallCounts::default()));
     let mut core = create_runtime_with_boxed_storage(

--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/storage_flush.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/storage_flush.rs
@@ -141,6 +141,34 @@ fn rc_flush_storage_records_error_and_clears_after_transient_success() {
 }
 
 #[test]
+fn rc_batched_tick_reschedules_after_transient_wal_flush_failure() {
+    let flush_error = StorageError::IoError("transient WAL flush failure".to_string());
+    let scheduler = CountingScheduler::default();
+    let app_id = AppId::from_name("row-reschedule-wal-flush-failure");
+    let schema_manager =
+        SchemaManager::new(SyncManager::new(), test_schema(), app_id, "dev", "main").unwrap();
+    let storage = MemoryStorage::new().with_transient_flush_wal_failures(flush_error.clone(), 1);
+    let mut core = new_test_core(schema_manager, storage, scheduler.clone());
+
+    core.insert("users", user_insert_values(ObjectId::new(), "Alice"), None)
+        .unwrap();
+    let scheduled_after_write = scheduler.schedule_count();
+
+    core.batched_tick();
+
+    assert!(core.has_storage_write_pending_flush());
+    assert_eq!(core.take_storage_flush_error(), Some(flush_error));
+    assert!(
+        scheduler.schedule_count() > scheduled_after_write,
+        "a transient WAL flush failure should schedule a retry tick"
+    );
+
+    core.batched_tick();
+    assert!(!core.has_storage_write_pending_flush());
+    assert_eq!(core.take_storage_flush_error(), None);
+}
+
+#[test]
 fn rc_batched_tick_skips_flush_wal_for_query_settled_only_message() {
     let calls = Arc::new(Mutex::new(RowMutationCallCounts::default()));
     let mut core = create_runtime_with_boxed_storage(

--- a/crates/jazz-tools/src/runtime_core/ticks.rs
+++ b/crates/jazz-tools/src/runtime_core/ticks.rs
@@ -743,7 +743,10 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             let _span = tracing::debug_span!("flush_wal").entered();
             match self.storage.flush_wal() {
                 Ok(()) => self.clear_storage_write_pending_flush(),
-                Err(error) => tracing::error!(%error, "storage WAL flush failed"),
+                Err(error) => {
+                    tracing::error!(%error, "storage WAL flush failed");
+                    self.record_storage_flush_error(error);
+                }
             }
         }
     }

--- a/crates/jazz-tools/src/runtime_core/ticks.rs
+++ b/crates/jazz-tools/src/runtime_core/ticks.rs
@@ -741,12 +741,8 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         // Flush the storage durability barrier so writes survive a hard kill (tab close, crash).
         if self.storage_write_pending_flush {
             let _span = tracing::debug_span!("flush_wal").entered();
-            match self.storage.flush_wal() {
-                Ok(()) => self.clear_storage_write_pending_flush(),
-                Err(error) => {
-                    tracing::error!(%error, "storage WAL flush failed");
-                    self.record_storage_flush_error(error);
-                }
+            if let Err(error) = self.flush_wal_barrier() {
+                tracing::error!(%error, "storage WAL flush failed");
             }
         }
     }

--- a/crates/jazz-tools/src/runtime_core/ticks.rs
+++ b/crates/jazz-tools/src/runtime_core/ticks.rs
@@ -743,6 +743,9 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             let _span = tracing::debug_span!("flush_wal").entered();
             if let Err(error) = self.flush_wal_barrier() {
                 tracing::error!(%error, "storage WAL flush failed");
+                if self.should_schedule_storage_flush_retry() {
+                    self.scheduler.schedule_batched_tick();
+                }
             }
         }
     }

--- a/crates/jazz-tools/src/runtime_core/ticks.rs
+++ b/crates/jazz-tools/src/runtime_core/ticks.rs
@@ -741,8 +741,10 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         // Flush the storage durability barrier so writes survive a hard kill (tab close, crash).
         if self.storage_write_pending_flush {
             let _span = tracing::debug_span!("flush_wal").entered();
-            self.storage.flush_wal();
-            self.clear_storage_write_pending_flush();
+            match self.storage.flush_wal() {
+                Ok(()) => self.clear_storage_write_pending_flush(),
+                Err(error) => tracing::error!(%error, "storage WAL flush failed"),
+            }
         }
     }
 

--- a/crates/jazz-tools/src/runtime_tokio.rs
+++ b/crates/jazz-tools/src/runtime_tokio.rs
@@ -412,6 +412,7 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
     /// and then runs additional ticks until all storage is flushed.
     pub async fn flush(&self) -> Result<(), RuntimeError> {
         let mut attempts = 0;
+        let mut last_storage_flush_error = None;
         loop {
             // Wait for any scheduled batched_tick to complete
             loop {
@@ -435,18 +436,13 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
             // Synchronous tick and check if more work was generated
             let has_more_work = {
                 let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
-                if let Some(error) = core.take_storage_flush_error() {
-                    return Err(RuntimeError::WriteError(format!(
-                        "storage WAL flush failed: {error}"
-                    )));
-                }
                 core.batched_tick();
                 if let Some(error) = core.take_storage_flush_error() {
-                    return Err(RuntimeError::WriteError(format!(
-                        "storage WAL flush failed: {error}"
-                    )));
+                    last_storage_flush_error = Some(error);
                 }
-                core.has_outbound() || core.scheduler().is_scheduled()
+                core.has_outbound()
+                    || core.scheduler().is_scheduled()
+                    || core.has_storage_write_pending_flush()
             };
 
             if !has_more_work {
@@ -464,6 +460,18 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
             return Err(RuntimeError::WriteError(format!(
                 "storage WAL flush failed: {error}"
             )));
+        }
+        if core.has_storage_write_pending_flush()
+            && let Some(error) = last_storage_flush_error
+        {
+            return Err(RuntimeError::WriteError(format!(
+                "storage WAL flush failed: {error}"
+            )));
+        }
+        if core.has_storage_write_pending_flush() {
+            return Err(RuntimeError::WriteError(
+                "storage WAL flush did not complete".to_string(),
+            ));
         }
 
         Ok(())
@@ -987,6 +995,30 @@ mod tests {
             error.to_string().contains("injected WAL flush failure"),
             "unexpected error: {error}"
         );
+    }
+
+    #[tokio::test]
+    async fn flush_recovers_after_transient_wal_flush_failure() {
+        let schema = test_schema();
+        let app_id = AppId::from_name("test-transient-wal-flush-failure");
+        let sync_manager = SyncManager::new();
+        let schema_manager =
+            SchemaManager::new(sync_manager, schema, app_id, "dev", "main").unwrap();
+
+        let storage = MemoryStorage::new().with_transient_flush_wal_failures(
+            StorageError::IoError("transient WAL flush failure".to_string()),
+            1,
+        );
+        let runtime = TokioRuntime::new(schema_manager, storage, |_| {});
+
+        runtime
+            .insert("users", user_insert_values(ObjectId::new(), "Alice"), None)
+            .unwrap();
+
+        runtime
+            .flush()
+            .await
+            .expect("explicit runtime flush should retry transient WAL flush failure");
     }
 
     #[tokio::test]

--- a/crates/jazz-tools/src/runtime_tokio.rs
+++ b/crates/jazz-tools/src/runtime_tokio.rs
@@ -436,6 +436,7 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
             let has_more_work = {
                 let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
                 if core.has_storage_write_pending_flush()
+                    && core.has_storage_flush_retry_scheduled()
                     && core.has_storage_flush_error()
                     && let Some(error) = core.take_storage_flush_error()
                 {
@@ -1023,6 +1024,34 @@ mod tests {
             .flush()
             .await
             .expect("explicit runtime flush should retry transient WAL flush failure");
+    }
+
+    #[tokio::test]
+    async fn flush_retries_stored_wal_error_before_returning_failure() {
+        let schema = test_schema();
+        let app_id = AppId::from_name("test-stored-wal-flush-error");
+        let sync_manager = SyncManager::new();
+        let schema_manager =
+            SchemaManager::new(sync_manager, schema, app_id, "dev", "main").unwrap();
+        let runtime = TokioRuntime::new(schema_manager, MemoryStorage::new(), |_| {});
+
+        {
+            let mut core = runtime.core.lock().expect("lock runtime core");
+            core.mark_storage_write_pending_flush();
+            core.record_storage_flush_error(StorageError::IoError(
+                "previous transient WAL flush failure".to_string(),
+            ));
+        }
+
+        runtime
+            .flush()
+            .await
+            .expect("explicit runtime flush should retry the pending WAL barrier");
+
+        let flush_wal_calls = runtime
+            .with_storage(|storage| storage.flush_wal_call_count())
+            .expect("inspect storage calls");
+        assert_eq!(flush_wal_calls, 1);
     }
 
     #[tokio::test]

--- a/crates/jazz-tools/src/runtime_tokio.rs
+++ b/crates/jazz-tools/src/runtime_tokio.rs
@@ -435,12 +435,13 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
             // Synchronous tick and check if more work was generated
             let has_more_work = {
                 let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
-                if core.has_storage_write_pending_flush() && core.has_storage_flush_error() {
-                    if let Some(error) = core.take_storage_flush_error() {
-                        return Err(RuntimeError::WriteError(format!(
-                            "storage WAL flush failed: {error}"
-                        )));
-                    }
+                if core.has_storage_write_pending_flush()
+                    && core.has_storage_flush_error()
+                    && let Some(error) = core.take_storage_flush_error()
+                {
+                    return Err(RuntimeError::WriteError(format!(
+                        "storage WAL flush failed: {error}"
+                    )));
                 }
                 core.batched_tick();
                 core.has_outbound()

--- a/crates/jazz-tools/src/runtime_tokio.rs
+++ b/crates/jazz-tools/src/runtime_tokio.rs
@@ -412,7 +412,6 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
     /// and then runs additional ticks until all storage is flushed.
     pub async fn flush(&self) -> Result<(), RuntimeError> {
         let mut attempts = 0;
-        let mut last_storage_flush_error = None;
         loop {
             // Wait for any scheduled batched_tick to complete
             loop {
@@ -436,10 +435,14 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
             // Synchronous tick and check if more work was generated
             let has_more_work = {
                 let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
-                core.batched_tick();
-                if let Some(error) = core.take_storage_flush_error() {
-                    last_storage_flush_error = Some(error);
+                if core.has_storage_write_pending_flush() && core.has_storage_flush_error() {
+                    if let Some(error) = core.take_storage_flush_error() {
+                        return Err(RuntimeError::WriteError(format!(
+                            "storage WAL flush failed: {error}"
+                        )));
+                    }
                 }
+                core.batched_tick();
                 core.has_outbound()
                     || core.scheduler().is_scheduled()
                     || core.has_storage_write_pending_flush()
@@ -457,13 +460,6 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
 
         let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
         if let Some(error) = core.take_storage_flush_error() {
-            return Err(RuntimeError::WriteError(format!(
-                "storage WAL flush failed: {error}"
-            )));
-        }
-        if core.has_storage_write_pending_flush()
-            && let Some(error) = last_storage_flush_error
-        {
             return Err(RuntimeError::WriteError(format!(
                 "storage WAL flush failed: {error}"
             )));
@@ -994,6 +990,13 @@ mod tests {
         assert!(
             error.to_string().contains("injected WAL flush failure"),
             "unexpected error: {error}"
+        );
+        let flush_wal_calls = runtime
+            .with_storage(|storage| storage.flush_wal_call_count())
+            .expect("inspect storage calls");
+        assert!(
+            flush_wal_calls <= 2,
+            "persistent WAL flush failures should not be retried in a tight loop, got {flush_wal_calls} attempts"
         );
     }
 

--- a/crates/jazz-tools/src/runtime_tokio.rs
+++ b/crates/jazz-tools/src/runtime_tokio.rs
@@ -435,7 +435,17 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
             // Synchronous tick and check if more work was generated
             let has_more_work = {
                 let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
+                if let Some(error) = core.take_storage_flush_error() {
+                    return Err(RuntimeError::WriteError(format!(
+                        "storage WAL flush failed: {error}"
+                    )));
+                }
                 core.batched_tick();
+                if let Some(error) = core.take_storage_flush_error() {
+                    return Err(RuntimeError::WriteError(format!(
+                        "storage WAL flush failed: {error}"
+                    )));
+                }
                 core.has_outbound() || core.scheduler().is_scheduled()
             };
 
@@ -447,6 +457,13 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
             if attempts > 200 {
                 break;
             }
+        }
+
+        let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
+        if let Some(error) = core.take_storage_flush_error() {
+            return Err(RuntimeError::WriteError(format!(
+                "storage WAL flush failed: {error}"
+            )));
         }
 
         Ok(())
@@ -847,7 +864,7 @@ mod tests {
     use super::*;
     use crate::query_manager::types::{ColumnType, SchemaBuilder, TableSchema};
     use crate::schema_manager::AppId;
-    use crate::storage::MemoryStorage;
+    use crate::storage::{MemoryStorage, StorageError};
     use crate::sync_manager::SyncManager;
     use std::sync::atomic::AtomicUsize;
 
@@ -943,6 +960,33 @@ mod tests {
             .unwrap();
         let results = future.await.unwrap();
         assert_eq!(results.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn flush_returns_error_when_wal_flush_fails() {
+        let schema = test_schema();
+        let app_id = AppId::from_name("test-wal-flush-failure");
+        let sync_manager = SyncManager::new();
+        let schema_manager =
+            SchemaManager::new(sync_manager, schema, app_id, "dev", "main").unwrap();
+
+        let storage = MemoryStorage::new().with_flush_wal_error(StorageError::IoError(
+            "injected WAL flush failure".to_string(),
+        ));
+        let runtime = TokioRuntime::new(schema_manager, storage, |_| {});
+
+        runtime
+            .insert("users", user_insert_values(ObjectId::new(), "Alice"), None)
+            .unwrap();
+
+        let error = runtime
+            .flush()
+            .await
+            .expect_err("explicit runtime flush should surface WAL flush failure");
+        assert!(
+            error.to_string().contains("injected WAL flush failure"),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]

--- a/crates/jazz-tools/src/schema_manager/integration_tests/tests/locator_only_storage.rs
+++ b/crates/jazz-tools/src/schema_manager/integration_tests/tests/locator_only_storage.rs
@@ -597,12 +597,12 @@ impl Storage for LocatorOnlyStorage {
         self.inner.index_scan_all(table, column, branch)
     }
 
-    fn flush(&self) {
-        self.inner.flush();
+    fn flush(&self) -> Result<(), StorageError> {
+        self.inner.flush()
     }
 
-    fn flush_wal(&self) {
-        self.inner.flush_wal();
+    fn flush_wal(&self) -> Result<(), StorageError> {
+        self.inner.flush_wal()
     }
 
     fn close(&self) -> Result<(), StorageError> {

--- a/crates/jazz-tools/src/server/builder.rs
+++ b/crates/jazz-tools/src/server/builder.rs
@@ -25,6 +25,7 @@ use crate::sync_manager::{Destination, DurabilityTier, SyncManager};
 
 #[cfg(feature = "rocksdb")]
 const STORAGE_CACHE_SIZE_BYTES: usize = 64 * 1024 * 1024;
+const DEFAULT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub struct BuiltServer {
     #[cfg_attr(not(test), allow(dead_code))]
@@ -66,6 +67,7 @@ pub struct ServerBuilder {
     storage_backend: StorageBackend,
     sync_tracer: Option<crate::sync_tracer::SyncTracer>,
     upstream_url: Option<String>,
+    shutdown_timeout: Duration,
 }
 
 impl ServerBuilder {
@@ -82,6 +84,7 @@ impl ServerBuilder {
             },
             sync_tracer: None,
             upstream_url: None,
+            shutdown_timeout: DEFAULT_SHUTDOWN_TIMEOUT,
         }
     }
 
@@ -102,6 +105,11 @@ impl ServerBuilder {
 
     pub fn with_upstream_url(mut self, upstream_url: impl Into<String>) -> Self {
         self.upstream_url = Some(upstream_url.into());
+        self
+    }
+
+    pub fn with_shutdown_timeout(mut self, timeout: Duration) -> Self {
+        self.shutdown_timeout = timeout;
         self
     }
 
@@ -157,6 +165,7 @@ impl ServerBuilder {
             disconnect_candidates: RwLock::new(HashMap::new()),
             client_ttl: RwLock::new(Duration::from_secs(300)),
             sync_tracer: self.sync_tracer.clone(),
+            shutdown: crate::server::ShutdownController::new(self.shutdown_timeout),
         });
 
         // Spawn periodic client state sweep (uses Weak so the task exits

--- a/crates/jazz-tools/src/server/hosted.rs
+++ b/crates/jazz-tools/src/server/hosted.rs
@@ -15,7 +15,7 @@ use crate::schema_manager::AppId;
 pub struct HostedServer {
     pub state: Arc<ServerState>,
     task: Option<JoinHandle<()>>,
-    shutdown_tx: Option<oneshot::Sender<()>>,
+    shutdown_task: Option<JoinHandle<()>>,
     pub port: u16,
     pub app_id: AppId,
     pub data_dir: PathBuf,
@@ -38,11 +38,17 @@ impl HostedServer {
             .expect("bind server listener");
         let port = listener.local_addr().expect("local addr").port();
 
-        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let (serve_shutdown_tx, serve_shutdown_rx) = oneshot::channel();
+        let shutdown_state = built.state.clone();
+        let shutdown_task = tokio::spawn(async move {
+            shutdown_state.shutdown.wait_requested().await;
+            shutdown_state.run_shutdown_finalization().await;
+            let _ = serve_shutdown_tx.send(());
+        });
         let task = tokio::spawn(async move {
             axum::serve(listener, built.app)
                 .with_graceful_shutdown(async {
-                    let _ = shutdown_rx.await;
+                    let _ = serve_shutdown_rx.await;
                 })
                 .await
                 .expect("serve jazz server");
@@ -51,7 +57,7 @@ impl HostedServer {
         let server = Self {
             state: built.state,
             task: Some(task),
-            shutdown_tx: Some(shutdown_tx),
+            shutdown_task: Some(shutdown_task),
             port,
             app_id,
             data_dir,
@@ -66,17 +72,17 @@ impl HostedServer {
         format!("http://127.0.0.1:{}", self.port)
     }
 
-    /// Gracefully shut down: flush runtime, send shutdown signal, await task,
-    /// flush+close storage, close external identity store.
+    /// Gracefully shut down: request shutdown, finalize runtime/storage, and await task.
     pub async fn shutdown(&mut self) {
-        self.state
-            .runtime
-            .flush()
-            .await
-            .expect("flush server runtime");
+        self.state.shutdown.request_shutdown();
 
-        if let Some(tx) = self.shutdown_tx.take() {
-            let _ = tx.send(());
+        if let Some(mut shutdown_task) = self.shutdown_task.take()
+            && tokio::time::timeout(Duration::from_secs(5), &mut shutdown_task)
+                .await
+                .is_err()
+        {
+            shutdown_task.abort();
+            let _ = shutdown_task.await;
         }
 
         if let Some(mut task) = self.task.take()
@@ -87,15 +93,6 @@ impl HostedServer {
             task.abort();
             let _ = task.await;
         }
-
-        self.state
-            .runtime
-            .with_storage(|storage| {
-                storage.flush();
-                storage.flush_wal();
-                let _ = storage.close();
-            })
-            .expect("flush and close server storage");
     }
 
     async fn wait_ready(&self) {
@@ -115,8 +112,9 @@ impl HostedServer {
 
 impl Drop for HostedServer {
     fn drop(&mut self) {
-        if let Some(tx) = self.shutdown_tx.take() {
-            let _ = tx.send(());
+        self.state.shutdown.request_shutdown();
+        if let Some(task) = self.shutdown_task.take() {
+            task.abort();
         }
         if let Some(task) = self.task.take() {
             task.abort();

--- a/crates/jazz-tools/src/server/hosted.rs
+++ b/crates/jazz-tools/src/server/hosted.rs
@@ -76,9 +76,10 @@ impl HostedServer {
     /// Gracefully shut down: request shutdown, finalize runtime/storage, and await task.
     pub async fn shutdown(&mut self) {
         self.state.shutdown.request_shutdown();
+        let shutdown_budget = self.state.shutdown.timeout() + Duration::from_secs(5);
 
         if let Some(mut shutdown_task) = self.shutdown_task.take()
-            && tokio::time::timeout(Duration::from_secs(5), &mut shutdown_task)
+            && tokio::time::timeout(shutdown_budget, &mut shutdown_task)
                 .await
                 .is_err()
         {
@@ -87,7 +88,7 @@ impl HostedServer {
         }
 
         if let Some(mut task) = self.task.take()
-            && tokio::time::timeout(Duration::from_millis(500), &mut task)
+            && tokio::time::timeout(shutdown_budget, &mut task)
                 .await
                 .is_err()
         {

--- a/crates/jazz-tools/src/server/hosted.rs
+++ b/crates/jazz-tools/src/server/hosted.rs
@@ -9,7 +9,7 @@ use super::ServerState;
 use super::builder::BuiltServer;
 use crate::schema_manager::AppId;
 
-/// A running Jazz server that owns its task, shutdown channel, and metadata.
+/// A running Jazz server that owns its tasks and metadata.
 ///
 /// Shared abstraction used by both `TestingServer` and `DevServer`.
 pub struct HostedServer {

--- a/crates/jazz-tools/src/server/hosted.rs
+++ b/crates/jazz-tools/src/server/hosted.rs
@@ -42,6 +42,7 @@ impl HostedServer {
         let shutdown_state = built.state.clone();
         let shutdown_task = tokio::spawn(async move {
             shutdown_state.shutdown.wait_requested().await;
+            tokio::time::sleep(Duration::from_millis(50)).await;
             shutdown_state.run_shutdown_finalization().await;
             let _ = serve_shutdown_tx.send(());
         });

--- a/crates/jazz-tools/src/server/hosted.rs
+++ b/crates/jazz-tools/src/server/hosted.rs
@@ -76,7 +76,7 @@ impl HostedServer {
     /// Gracefully shut down: request shutdown, finalize runtime/storage, and await task.
     pub async fn shutdown(&mut self) {
         self.state.shutdown.request_shutdown();
-        let shutdown_budget = self.state.shutdown.timeout() + Duration::from_secs(5);
+        let shutdown_budget = self.state.shutdown.timeout() * 2 + Duration::from_secs(5);
 
         if let Some(mut shutdown_task) = self.shutdown_task.take()
             && tokio::time::timeout(shutdown_budget, &mut shutdown_task)

--- a/crates/jazz-tools/src/server/hosted.rs
+++ b/crates/jazz-tools/src/server/hosted.rs
@@ -78,13 +78,17 @@ impl HostedServer {
         self.state.shutdown.request_shutdown();
         let shutdown_budget = self.state.shutdown.timeout() * 2 + Duration::from_secs(5);
 
+        let mut finalization_completed = false;
         if let Some(mut shutdown_task) = self.shutdown_task.take()
             && tokio::time::timeout(shutdown_budget, &mut shutdown_task)
                 .await
-                .is_err()
+                .is_ok()
         {
-            shutdown_task.abort();
-            let _ = tokio::time::timeout(Duration::from_millis(50), shutdown_task).await;
+            finalization_completed = true;
+        }
+
+        if !finalization_completed {
+            return;
         }
 
         if let Some(mut task) = self.task.take()

--- a/crates/jazz-tools/src/server/hosted.rs
+++ b/crates/jazz-tools/src/server/hosted.rs
@@ -84,7 +84,7 @@ impl HostedServer {
                 .is_err()
         {
             shutdown_task.abort();
-            let _ = shutdown_task.await;
+            let _ = tokio::time::timeout(Duration::from_millis(50), shutdown_task).await;
         }
 
         if let Some(mut task) = self.task.take()
@@ -93,7 +93,7 @@ impl HostedServer {
                 .is_err()
         {
             task.abort();
-            let _ = task.await;
+            let _ = tokio::time::timeout(Duration::from_millis(50), task).await;
         }
     }
 

--- a/crates/jazz-tools/src/server/mod.rs
+++ b/crates/jazz-tools/src/server/mod.rs
@@ -194,16 +194,22 @@ pub struct ConnectionState {
 
 impl ServerState {
     pub async fn run_shutdown_finalization(&self) {
+        if !self.shutdown.try_begin_finalization() {
+            return;
+        }
+
         self.shutdown.set_phase(ShutdownPhase::DrainingConnections);
         #[cfg(feature = "transport-websocket")]
         self.runtime.disconnect();
 
+        let mut failed = false;
         let websockets_drained = self.shutdown.wait_for_websocket_drain().await;
         if !websockets_drained {
             tracing::warn!(
                 active_websockets = self.shutdown.active_websockets(),
                 "shutdown websocket drain timed out"
             );
+            failed = true;
         }
 
         let app_requests_drained = self.shutdown.wait_for_app_request_drain().await;
@@ -212,10 +218,10 @@ impl ServerState {
                 active_app_requests = self.shutdown.active_app_requests(),
                 "shutdown app request drain timed out"
             );
+            failed = true;
         }
 
         self.shutdown.set_phase(ShutdownPhase::FlushingRuntime);
-        let mut failed = false;
         if let Err(error) = self.runtime.flush().await {
             tracing::error!(%error, "shutdown runtime flush failed");
             failed = true;
@@ -223,22 +229,26 @@ impl ServerState {
 
         self.shutdown.set_phase(ShutdownPhase::ClosingStorage);
         let storage_result = self.runtime.with_storage(|storage| {
-            storage.flush();
-            storage.flush_wal();
-            storage.close()
+            let flush_result = storage.flush();
+            let flush_wal_result = storage.flush_wal();
+            let close_result = storage.close();
+            (flush_result, flush_wal_result, close_result)
         });
 
         match storage_result {
-            Ok(Ok(())) => {
-                if failed {
-                    self.shutdown.set_phase(ShutdownPhase::Failed);
-                } else {
-                    self.shutdown.set_phase(ShutdownPhase::StorageClosed);
+            Ok((flush_result, flush_wal_result, close_result)) => {
+                if let Err(error) = flush_result {
+                    tracing::error!(%error, "shutdown storage flush failed");
+                    failed = true;
                 }
-            }
-            Ok(Err(error)) => {
-                tracing::error!(%error, "shutdown storage close failed");
-                failed = true;
+                if let Err(error) = flush_wal_result {
+                    tracing::error!(%error, "shutdown storage WAL flush failed");
+                    failed = true;
+                }
+                if let Err(error) = close_result {
+                    tracing::error!(%error, "shutdown storage close failed");
+                    failed = true;
+                }
             }
             Err(error) => {
                 tracing::error!(%error, "shutdown storage lock failed");
@@ -248,6 +258,8 @@ impl ServerState {
 
         if failed {
             self.shutdown.set_phase(ShutdownPhase::Failed);
+        } else {
+            self.shutdown.set_phase(ShutdownPhase::StorageClosed);
         }
     }
 
@@ -413,9 +425,14 @@ mod tests {
     use crate::server::builder::{ServerBuilder, StorageBackend};
 
     async fn build_test_state() -> Arc<ServerState> {
+        build_test_state_with_shutdown_timeout(Duration::from_secs(30)).await
+    }
+
+    async fn build_test_state_with_shutdown_timeout(timeout: Duration) -> Arc<ServerState> {
         let app_id = AppId::from_name("lifecycle-test");
         let built = ServerBuilder::new(app_id)
             .with_storage(StorageBackend::InMemory)
+            .with_shutdown_timeout(timeout)
             .build()
             .await
             .expect("build test server");
@@ -460,6 +477,20 @@ mod tests {
             candidates.contains_key(&alice),
             "alice should be a disconnect candidate"
         );
+    }
+
+    #[tokio::test]
+    async fn shutdown_finalization_marks_failed_after_app_request_drain_timeout() {
+        let state = build_test_state_with_shutdown_timeout(Duration::from_millis(10)).await;
+        let _request_guard = state
+            .shutdown
+            .try_enter_app_request()
+            .expect("running server accepts request");
+
+        state.shutdown.request_shutdown();
+        state.run_shutdown_finalization().await;
+
+        assert_eq!(state.shutdown.phase(), ShutdownPhase::Failed);
     }
 
     #[tokio::test]

--- a/crates/jazz-tools/src/server/mod.rs
+++ b/crates/jazz-tools/src/server/mod.rs
@@ -193,9 +193,9 @@ pub struct ConnectionState {
 }
 
 impl ServerState {
-    pub async fn run_shutdown_finalization(&self) {
+    pub async fn run_shutdown_finalization(&self) -> ShutdownPhase {
         if !self.shutdown.try_begin_finalization() {
-            return;
+            return self.shutdown.phase();
         }
 
         self.shutdown.set_phase(ShutdownPhase::DrainingConnections);
@@ -258,8 +258,10 @@ impl ServerState {
 
         if failed {
             self.shutdown.set_phase(ShutdownPhase::Failed);
+            ShutdownPhase::Failed
         } else {
             self.shutdown.set_phase(ShutdownPhase::StorageClosed);
+            ShutdownPhase::StorageClosed
         }
     }
 
@@ -488,8 +490,9 @@ mod tests {
             .expect("running server accepts request");
 
         state.shutdown.request_shutdown();
-        state.run_shutdown_finalization().await;
+        let phase = state.run_shutdown_finalization().await;
 
+        assert_eq!(phase, ShutdownPhase::Failed);
         assert_eq!(state.shutdown.phase(), ShutdownPhase::Failed);
     }
 

--- a/crates/jazz-tools/src/server/mod.rs
+++ b/crates/jazz-tools/src/server/mod.rs
@@ -221,6 +221,11 @@ impl ServerState {
             failed = true;
         }
 
+        if failed {
+            self.shutdown.set_phase(ShutdownPhase::Failed);
+            return ShutdownPhase::Failed;
+        }
+
         self.shutdown.set_phase(ShutdownPhase::FlushingRuntime);
         if let Err(error) = self.runtime.flush().await {
             tracing::error!(%error, "shutdown runtime flush failed");
@@ -387,6 +392,10 @@ impl ServerState {
         client_id: ClientId,
         payload: &[u8],
     ) -> Result<(), String> {
+        if self.shutdown.is_shutting_down() {
+            return Err("server is shutting down".to_string());
+        }
+
         if let Ok(payload) = crate::transport_protocol::decode_outbox_entry_payload(payload) {
             let inbox = InboxEntry {
                 source: Source::Client(client_id),
@@ -420,11 +429,38 @@ impl ServerState {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
     use super::*;
+    use crate::middleware::AuthConfig;
+    use crate::query_manager::types::{ColumnType, Schema, SchemaBuilder, TableSchema};
     use crate::schema_manager::AppId;
+    use crate::schema_manager::SchemaManager;
     use crate::server::builder::{ServerBuilder, StorageBackend};
+    use crate::storage::StorageError;
+    use crate::sync_manager::SyncManager;
+
+    struct CloseObservingStorage {
+        close_calls: Arc<AtomicUsize>,
+    }
+
+    impl Storage for CloseObservingStorage {
+        fn close(&self) -> Result<(), StorageError> {
+            self.close_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    fn shutdown_test_schema() -> Schema {
+        SchemaBuilder::new()
+            .table(
+                TableSchema::builder("users")
+                    .column("id", ColumnType::Uuid)
+                    .column("name", ColumnType::Text),
+            )
+            .build()
+    }
 
     async fn build_test_state() -> Arc<ServerState> {
         build_test_state_with_shutdown_timeout(Duration::from_secs(30)).await
@@ -439,6 +475,36 @@ mod tests {
             .await
             .expect("build test server");
         built.state
+    }
+
+    fn build_test_state_with_storage(storage: DynStorage, timeout: Duration) -> Arc<ServerState> {
+        let app_id = AppId::from_name("shutdown-storage-test");
+        let schema_manager = SchemaManager::new(
+            SyncManager::new(),
+            shutdown_test_schema(),
+            app_id,
+            "dev",
+            "main",
+        )
+        .expect("build schema manager");
+        Arc::new(ServerState {
+            runtime: TokioRuntime::new(schema_manager, storage, |_| {}),
+            app_id,
+            connections: RwLock::new(HashMap::new()),
+            next_connection_id: std::sync::atomic::AtomicU64::new(1),
+            connection_event_hub: Arc::new(ConnectionEventHub::default()),
+            auth_config: AuthConfig::default(),
+            upstream_http_url: None,
+            topology: ServerTopology::Core,
+            http_client: reqwest::Client::builder()
+                .build()
+                .expect("build HTTP client"),
+            jwt_verifier: None,
+            disconnect_candidates: RwLock::new(HashMap::new()),
+            client_ttl: RwLock::new(Duration::from_secs(300)),
+            sync_tracer: None,
+            shutdown: ShutdownController::new(timeout),
+        })
     }
 
     /// Simulate adding a connection (like events_handler does).
@@ -494,6 +560,44 @@ mod tests {
 
         assert_eq!(phase, ShutdownPhase::Failed);
         assert_eq!(state.shutdown.phase(), ShutdownPhase::Failed);
+    }
+
+    #[tokio::test]
+    async fn shutdown_finalization_does_not_close_storage_when_app_requests_remain_active() {
+        let close_calls = Arc::new(AtomicUsize::new(0));
+        let state = build_test_state_with_storage(
+            Box::new(CloseObservingStorage {
+                close_calls: Arc::clone(&close_calls),
+            }),
+            Duration::from_millis(10),
+        );
+        let _request_guard = state
+            .shutdown
+            .try_enter_app_request()
+            .expect("running server accepts request");
+
+        state.shutdown.request_shutdown();
+        let phase = state.run_shutdown_finalization().await;
+
+        assert_eq!(phase, ShutdownPhase::Failed);
+        assert_eq!(
+            close_calls.load(Ordering::SeqCst),
+            0,
+            "storage must not be closed while app request guards are still active"
+        );
+    }
+
+    #[tokio::test]
+    async fn websocket_frames_are_rejected_after_shutdown_is_requested() {
+        let state = build_test_state().await;
+        state.shutdown.request_shutdown();
+
+        let error = state
+            .process_ws_client_frame(ClientId::new(), b"not a sync frame")
+            .await
+            .expect_err("websocket frame should be rejected during shutdown");
+
+        assert_eq!(error, "server is shutting down");
     }
 
     #[tokio::test]

--- a/crates/jazz-tools/src/server/mod.rs
+++ b/crates/jazz-tools/src/server/mod.rs
@@ -206,13 +206,19 @@ impl ServerState {
             );
         }
 
-        self.shutdown.wait_for_app_request_drain().await;
+        let app_requests_drained = self.shutdown.wait_for_app_request_drain().await;
+        if !app_requests_drained {
+            tracing::warn!(
+                active_app_requests = self.shutdown.active_app_requests(),
+                "shutdown app request drain timed out"
+            );
+        }
 
         self.shutdown.set_phase(ShutdownPhase::FlushingRuntime);
+        let mut failed = false;
         if let Err(error) = self.runtime.flush().await {
             tracing::error!(%error, "shutdown runtime flush failed");
-            self.shutdown.set_phase(ShutdownPhase::Failed);
-            return;
+            failed = true;
         }
 
         self.shutdown.set_phase(ShutdownPhase::ClosingStorage);
@@ -224,16 +230,24 @@ impl ServerState {
 
         match storage_result {
             Ok(Ok(())) => {
-                self.shutdown.set_phase(ShutdownPhase::StorageClosed);
+                if failed {
+                    self.shutdown.set_phase(ShutdownPhase::Failed);
+                } else {
+                    self.shutdown.set_phase(ShutdownPhase::StorageClosed);
+                }
             }
             Ok(Err(error)) => {
                 tracing::error!(%error, "shutdown storage close failed");
-                self.shutdown.set_phase(ShutdownPhase::Failed);
+                failed = true;
             }
             Err(error) => {
                 tracing::error!(%error, "shutdown storage lock failed");
-                self.shutdown.set_phase(ShutdownPhase::Failed);
+                failed = true;
             }
+        }
+
+        if failed {
+            self.shutdown.set_phase(ShutdownPhase::Failed);
         }
     }
 

--- a/crates/jazz-tools/src/server/mod.rs
+++ b/crates/jazz-tools/src/server/mod.rs
@@ -15,11 +15,13 @@ use crate::sync_manager::{ClientId, InboxEntry, Source, SyncPayload};
 mod builder;
 mod hosted;
 pub mod routes;
+mod shutdown;
 #[cfg(feature = "test-utils")]
 mod testing;
 
 pub use builder::{BuiltServer, ServerBuilder, StorageBackend};
 pub use hosted::HostedServer;
+pub use shutdown::{ShutdownController, ShutdownPhase};
 #[cfg(feature = "test-utils")]
 pub use testing::{TestingJwksServer, TestingServer, TestingServerBuilder};
 
@@ -182,6 +184,7 @@ pub struct ServerState {
     pub client_ttl: RwLock<Duration>,
     /// Optional sync message tracer for test observability.
     pub sync_tracer: Option<crate::sync_tracer::SyncTracer>,
+    pub shutdown: ShutdownController,
 }
 
 /// State for a single SSE connection.

--- a/crates/jazz-tools/src/server/mod.rs
+++ b/crates/jazz-tools/src/server/mod.rs
@@ -193,6 +193,50 @@ pub struct ConnectionState {
 }
 
 impl ServerState {
+    pub async fn run_shutdown_finalization(&self) {
+        self.shutdown.set_phase(ShutdownPhase::DrainingConnections);
+        #[cfg(feature = "transport-websocket")]
+        self.runtime.disconnect();
+
+        let websockets_drained = self.shutdown.wait_for_websocket_drain().await;
+        if !websockets_drained {
+            tracing::warn!(
+                active_websockets = self.shutdown.active_websockets(),
+                "shutdown websocket drain timed out"
+            );
+        }
+
+        self.shutdown.wait_for_app_request_drain().await;
+
+        self.shutdown.set_phase(ShutdownPhase::FlushingRuntime);
+        if let Err(error) = self.runtime.flush().await {
+            tracing::error!(%error, "shutdown runtime flush failed");
+            self.shutdown.set_phase(ShutdownPhase::Failed);
+            return;
+        }
+
+        self.shutdown.set_phase(ShutdownPhase::ClosingStorage);
+        let storage_result = self.runtime.with_storage(|storage| {
+            storage.flush();
+            storage.flush_wal();
+            storage.close()
+        });
+
+        match storage_result {
+            Ok(Ok(())) => {
+                self.shutdown.set_phase(ShutdownPhase::StorageClosed);
+            }
+            Ok(Err(error)) => {
+                tracing::error!(%error, "shutdown storage close failed");
+                self.shutdown.set_phase(ShutdownPhase::Failed);
+            }
+            Err(error) => {
+                tracing::error!(%error, "shutdown storage lock failed");
+                self.shutdown.set_phase(ShutdownPhase::Failed);
+            }
+        }
+    }
+
     /// Record that a connection closed. If this was the last SSE connection
     /// for the given client_id, add it to disconnect_candidates.
     ///

--- a/crates/jazz-tools/src/server/routes/http.rs
+++ b/crates/jazz-tools/src/server/routes/http.rs
@@ -17,7 +17,7 @@ use crate::query_manager::types::{
     ColumnType, Schema, SchemaHash, TableName, TablePolicies, Value,
 };
 use crate::schema_manager::{Lens, LensOp, LensTransform};
-use crate::server::ServerState;
+use crate::server::{ServerState, ShutdownPhase};
 
 use super::utils::{
     parse_app_id_param, parse_object_id_param, parse_schema_hash_param, permissions_head_view,
@@ -1161,12 +1161,15 @@ pub(super) async fn internal_shutdown_handler(
 }
 
 pub(super) async fn health_handler(State(state): State<Arc<ServerState>>) -> impl IntoResponse {
-    let phase = state.shutdown.phase();
-    if phase.is_running() {
+    let mut phase = state.shutdown.phase();
+    if !state.shutdown.is_shutting_down() && phase.is_running() {
         return Json(serde_json::json!({
             "status": "healthy"
         }))
         .into_response();
+    }
+    if phase.is_running() {
+        phase = ShutdownPhase::ShuttingDown;
     }
 
     (

--- a/crates/jazz-tools/src/server/routes/http.rs
+++ b/crates/jazz-tools/src/server/routes/http.rs
@@ -145,6 +145,11 @@ pub(super) struct SchemaConnectivityResponse {
 }
 
 #[derive(Debug, Serialize)]
+pub(super) struct ShutdownResponse {
+    status: &'static str,
+}
+
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(super) struct PublishMigrationResponse {
     object_id: String,
@@ -1130,8 +1135,46 @@ pub(super) async fn admin_subscription_introspection_handler(
     }
 }
 
-pub(super) async fn health_handler() -> impl IntoResponse {
-    Json(serde_json::json!({
-        "status": "healthy"
-    }))
+pub(super) async fn internal_shutdown_handler(
+    State(state): State<Arc<ServerState>>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    let admin_secret = headers
+        .get("X-Jazz-Admin-Secret")
+        .and_then(|v| v.to_str().ok());
+
+    match validate_admin_secret(admin_secret, &state.auth_config) {
+        Ok(()) => {}
+        Err((status, msg)) => {
+            return (status, Json(ErrorResponse::unauthorized(msg))).into_response();
+        }
+    }
+
+    let first_request = state.shutdown.request_shutdown();
+    let status = if first_request {
+        "shutting_down"
+    } else {
+        "already_shutting_down"
+    };
+
+    (StatusCode::ACCEPTED, Json(ShutdownResponse { status })).into_response()
+}
+
+pub(super) async fn health_handler(State(state): State<Arc<ServerState>>) -> impl IntoResponse {
+    let phase = state.shutdown.phase();
+    if phase.is_running() {
+        return Json(serde_json::json!({
+            "status": "healthy"
+        }))
+        .into_response();
+    }
+
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(serde_json::json!({
+            "status": "shutting_down",
+            "phase": phase
+        })),
+    )
+        .into_response()
 }

--- a/crates/jazz-tools/src/server/routes/mod.rs
+++ b/crates/jazz-tools/src/server/routes/mod.rs
@@ -2501,6 +2501,74 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn shutdown_closes_active_websocket_with_service_restart_code() {
+        let state = make_sync_test_state("test-backend-secret").await;
+        let app = create_router(state.clone());
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind ws listener");
+        let addr = listener.local_addr().expect("ws local addr");
+        let server_task = tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve ws app");
+        });
+
+        let ws_url = format!("ws://{addr}{}", test_app_route("/ws"));
+        let (mut ws, _) = connect_async(&ws_url).await.expect("connect ws");
+
+        let handshake = crate::transport_manager::AuthHandshake {
+            sync_protocol_version: crate::transport_manager::SYNC_PROTOCOL_VERSION,
+            client_id: ClientId::new().to_string(),
+            auth: crate::transport_manager::AuthConfig {
+                backend_secret: Some("test-backend-secret".to_string()),
+                ..Default::default()
+            },
+            catalogue_state_hash: None,
+            declared_schema_hash: None,
+        };
+        let payload = serde_json::to_vec(&handshake).expect("serialize handshake");
+        ws.send(WsMessage::Binary(
+            crate::transport_manager::frame_encode(&payload).into(),
+        ))
+        .await
+        .expect("send handshake");
+
+        let connected = tokio::time::timeout(Duration::from_secs(5), ws.next())
+            .await
+            .expect("wait for ConnectedResponse")
+            .expect("ws frame")
+            .expect("ws result");
+        assert!(matches!(connected, WsMessage::Binary(_)));
+
+        assert_eq!(state.shutdown.active_websockets(), 1);
+        assert!(state.shutdown.request_shutdown());
+
+        let close_frame = tokio::time::timeout(Duration::from_secs(5), ws.next())
+            .await
+            .expect("wait for close")
+            .expect("ws frame")
+            .expect("ws result");
+        let WsMessage::Close(Some(close)) = close_frame else {
+            panic!("expected close frame, got {close_frame:?}");
+        };
+        assert_eq!(
+            close.code,
+            tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode::Restart
+        );
+        assert_eq!(close.reason.as_ref(), "server shutting down");
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while state.shutdown.active_websockets() != 0 {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("websocket cleanup");
+
+        server_task.abort();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn ws_handler_rejects_pre_versioned_handshake_loudly() {
         let state = make_sync_test_state("test-backend-secret").await;
         let app = create_router(state);

--- a/crates/jazz-tools/src/server/routes/mod.rs
+++ b/crates/jazz-tools/src/server/routes/mod.rs
@@ -2431,7 +2431,9 @@ mod tests {
         // upgrade, handshake, and ConnectedResponse path the server uses.
         let collector = EventCollector::default();
         let subscriber = Registry::default().with(collector.clone());
-        let _guard = tracing::subscriber::set_default(subscriber);
+        let dispatch = tracing::Dispatch::new(subscriber);
+        let _ = tracing::dispatcher::set_global_default(dispatch.clone());
+        let _guard = tracing::dispatcher::set_default(&dispatch);
 
         let state = make_sync_test_state("test-backend-secret").await;
         let app = create_router(state);
@@ -2440,7 +2442,9 @@ mod tests {
             .await
             .expect("bind ws listener");
         let addr = listener.local_addr().expect("ws local addr");
+        let server_dispatch = dispatch.clone();
         let server_task = tokio::spawn(async move {
+            let _guard = tracing::dispatcher::set_default(&server_dispatch);
             axum::serve(listener, app).await.expect("serve ws app");
         });
 
@@ -2482,19 +2486,27 @@ mod tests {
             crate::transport_manager::SYNC_PROTOCOL_VERSION
         );
 
-        tokio::time::sleep(Duration::from_millis(50)).await;
-
-        let events = collector.snapshot();
-        assert!(
-            events.iter().any(|event| {
-                event.level == tracing::Level::INFO
-                    && event.message.as_deref() == Some("ws client connected")
-                    && event.fields.get("client_id").map(String::as_str) == Some(client_id.as_str())
-                    && event.fields.get("connection_id").map(String::as_str) == Some("1")
-                    && event.fields.get("role").map(String::as_str) == Some("backend")
-            }),
-            "expected ws client connected log, captured events: {events:#?}"
-        );
+        let mut events = Vec::new();
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                events = collector.snapshot();
+                if events.iter().any(|event| {
+                    event.level == tracing::Level::INFO
+                        && event.message.as_deref() == Some("ws client connected")
+                        && event.fields.get("client_id").map(String::as_str)
+                            == Some(client_id.as_str())
+                        && event.fields.get("connection_id").map(String::as_str) == Some("1")
+                        && event.fields.get("role").map(String::as_str) == Some("backend")
+                }) {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| {
+            panic!("expected ws client connected log, captured events: {events:#?}")
+        });
 
         let _ = ws.close(None).await;
         server_task.abort();
@@ -2541,6 +2553,57 @@ mod tests {
         assert!(matches!(connected, WsMessage::Binary(_)));
 
         assert_eq!(state.shutdown.active_websockets(), 1);
+        assert!(state.shutdown.request_shutdown());
+
+        let close_frame = tokio::time::timeout(Duration::from_secs(5), ws.next())
+            .await
+            .expect("wait for close")
+            .expect("ws frame")
+            .expect("ws result");
+        let WsMessage::Close(Some(close)) = close_frame else {
+            panic!("expected close frame, got {close_frame:?}");
+        };
+        assert_eq!(
+            close.code,
+            tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode::Restart
+        );
+        assert_eq!(close.reason.as_ref(), "server shutting down");
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while state.shutdown.active_websockets() != 0 {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("websocket cleanup");
+
+        server_task.abort();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn shutdown_closes_upgraded_websocket_before_handshake() {
+        let state = make_sync_test_state("test-backend-secret").await;
+        let app = create_router(state.clone());
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind ws listener");
+        let addr = listener.local_addr().expect("ws local addr");
+        let server_task = tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve ws app");
+        });
+
+        let ws_url = format!("ws://{addr}{}", test_app_route("/ws"));
+        let (mut ws, _) = connect_async(&ws_url).await.expect("connect ws");
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while state.shutdown.active_websockets() != 1 {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("upgraded websocket should be tracked before handshake");
+
         assert!(state.shutdown.request_shutdown());
 
         let close_frame = tokio::time::timeout(Duration::from_secs(5), ws.next())

--- a/crates/jazz-tools/src/server/routes/mod.rs
+++ b/crates/jazz-tools/src/server/routes/mod.rs
@@ -24,9 +24,10 @@ use tower_http::trace::TraceLayer;
 use crate::server::ServerState;
 
 use http::{
-    admin_subscription_introspection_handler, health_handler, permissions_handler,
-    permissions_head_handler, publish_migration_handler, publish_permissions_handler,
-    publish_schema_handler, schema_connectivity_handler, schema_handler, schema_hashes_handler,
+    admin_subscription_introspection_handler, health_handler, internal_shutdown_handler,
+    permissions_handler, permissions_head_handler, publish_migration_handler,
+    publish_permissions_handler, publish_schema_handler, schema_connectivity_handler,
+    schema_handler, schema_hashes_handler,
 };
 use websocket::ws_handler;
 
@@ -56,6 +57,7 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
 
     Router::new()
         .route("/health", get(health_handler))
+        .route("/internal/shutdown", post(internal_shutdown_handler))
         .nest(&app_route_prefix, traced_routes)
         .layer(CorsLayer::permissive())
         .with_state(state)
@@ -85,7 +87,7 @@ mod tests {
     use crate::jazz_transport::SyncBatchRequest;
     use crate::query_manager::query::QueryBuilder;
     use crate::query_manager::types::{
-        ColumnType, SchemaBuilder, TableSchema, Value as QueryValue,
+        ColumnType, Schema, SchemaBuilder, TableSchema, Value as QueryValue,
     };
     use crate::sync_manager::{
         ClientId, ConnectionSchemaDiagnostics, InboxEntry, QueryId, QueryPropagation, Source,
@@ -179,6 +181,21 @@ mod tests {
 
     fn make_test_router(state: Arc<ServerState>) -> axum::Router {
         create_router(state)
+    }
+
+    async fn post_internal_shutdown(
+        app: axum::Router,
+        admin_secret: Option<&str>,
+    ) -> axum::response::Response {
+        let mut builder = axum::http::Request::builder()
+            .method("POST")
+            .uri("/internal/shutdown");
+        if let Some(admin_secret) = admin_secret {
+            builder = builder.header("X-Jazz-Admin-Secret", admin_secret);
+        }
+        app.oneshot(builder.body(axum::body::Body::empty()).unwrap())
+            .await
+            .unwrap()
     }
 
     fn test_app_id_text() -> String {
@@ -295,6 +312,86 @@ mod tests {
         fn record_u64(&mut self, field: &Field, value: u64) {
             self.record_value(field, value.to_string());
         }
+    }
+
+    #[tokio::test]
+    async fn internal_shutdown_requires_configured_admin_secret() {
+        let auth_config = AuthConfig {
+            admin_secret: None,
+            allow_local_first_auth: true,
+            ..Default::default()
+        };
+        let state = ServerBuilder::new(AppId::from_name("test-app"))
+            .with_auth_config(auth_config)
+            .with_storage(StorageBackend::InMemory)
+            .build()
+            .await
+            .expect("build server without admin secret")
+            .state;
+
+        let response = post_internal_shutdown(make_test_router(state), Some("admin-secret")).await;
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn internal_shutdown_requires_admin_secret_header() {
+        let state = make_state_with_schema(Schema::new()).await;
+        let response = post_internal_shutdown(make_test_router(state), None).await;
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn internal_shutdown_rejects_wrong_admin_secret() {
+        let state = make_state_with_schema(Schema::new()).await;
+        let response = post_internal_shutdown(make_test_router(state), Some("wrong-secret")).await;
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn internal_shutdown_accepts_valid_admin_secret_and_marks_health_unhealthy() {
+        let state = make_state_with_schema(Schema::new()).await;
+        let app = make_test_router(state.clone());
+
+        let response = post_internal_shutdown(app.clone(), Some("admin-secret")).await;
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+        let body = body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("shutdown body");
+        let json: Value = serde_json::from_slice(&body).expect("shutdown json");
+        assert_eq!(json["status"].as_str(), Some("shutting_down"));
+
+        let repeated = post_internal_shutdown(app.clone(), Some("admin-secret")).await;
+        assert_eq!(repeated.status(), StatusCode::ACCEPTED);
+        let repeated_body = body::to_bytes(repeated.into_body(), usize::MAX)
+            .await
+            .expect("repeated shutdown body");
+        let repeated_json: Value = serde_json::from_slice(&repeated_body).expect("repeated json");
+        assert_eq!(
+            repeated_json["status"].as_str(),
+            Some("already_shutting_down")
+        );
+
+        let health = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/health")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(health.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let health_body = body::to_bytes(health.into_body(), usize::MAX)
+            .await
+            .expect("health body");
+        let health_json: Value = serde_json::from_slice(&health_body).expect("health json");
+        assert_eq!(health_json["status"].as_str(), Some("shutting_down"));
+        assert_eq!(health_json["phase"].as_str(), Some("shutting_down"));
+
+        assert_eq!(
+            state.shutdown.phase(),
+            crate::server::ShutdownPhase::ShuttingDown
+        );
     }
 
     #[tokio::test]

--- a/crates/jazz-tools/src/server/routes/mod.rs
+++ b/crates/jazz-tools/src/server/routes/mod.rs
@@ -16,6 +16,11 @@ use std::sync::Arc;
 
 use axum::{
     Router,
+    body::Body,
+    extract::State,
+    http::{Request, StatusCode},
+    middleware::{self, Next},
+    response::{IntoResponse, Response},
     routing::{get, post},
 };
 use tower_http::cors::CorsLayer;
@@ -30,6 +35,24 @@ use http::{
     schema_handler, schema_hashes_handler,
 };
 use websocket::ws_handler;
+
+async fn app_shutdown_gate(
+    State(state): State<Arc<ServerState>>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    let Some(_guard) = state.shutdown.try_enter_app_request() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            axum::Json(crate::jazz_transport::ErrorResponse::internal(
+                "server is shutting down".to_string(),
+            )),
+        )
+            .into_response();
+    };
+
+    next.run(request).await
+}
 
 pub fn create_router(state: Arc<ServerState>) -> Router {
     // TODO: Accept app-name aliases in app-scoped route matching
@@ -53,6 +76,10 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
         .route("/schema/:hash", get(schema_handler))
         .route("/schemas", get(schema_hashes_handler))
         .nest("/admin", admin_routes)
+        .route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            app_shutdown_gate,
+        ))
         .layer(TraceLayer::new_for_http());
 
     Router::new()
@@ -392,6 +419,42 @@ mod tests {
             state.shutdown.phase(),
             crate::server::ShutdownPhase::ShuttingDown
         );
+    }
+
+    #[tokio::test]
+    async fn shutdown_rejects_new_app_scoped_http_requests_but_keeps_internal_routes_available() {
+        let state = make_state_with_schema(Schema::new()).await;
+        let app = make_test_router(state);
+
+        let shutdown = post_internal_shutdown(app.clone(), Some("admin-secret")).await;
+        assert_eq!(shutdown.status(), StatusCode::ACCEPTED);
+
+        let app_scoped = app
+            .clone()
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri(test_app_route("/schemas"))
+                    .header("X-Jazz-Admin-Secret", "admin-secret")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(app_scoped.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        let repeated = post_internal_shutdown(app.clone(), Some("admin-secret")).await;
+        assert_eq!(repeated.status(), StatusCode::ACCEPTED);
+
+        let health = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/health")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(health.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 
     #[tokio::test]

--- a/crates/jazz-tools/src/server/routes/websocket.rs
+++ b/crates/jazz-tools/src/server/routes/websocket.rs
@@ -8,7 +8,7 @@ use axum::{
     extract::State,
     extract::ws::{CloseFrame, Message, WebSocket, WebSocketUpgrade, close_code},
     http::HeaderMap,
-    response::Response,
+    response::{IntoResponse, Response},
 };
 
 use crate::middleware::auth::{
@@ -26,6 +26,16 @@ pub(super) async fn ws_handler(
     State(state): State<Arc<ServerState>>,
     headers: HeaderMap,
 ) -> Response {
+    if state.shutdown.is_shutting_down() {
+        return (
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            axum::Json(crate::jazz_transport::ErrorResponse::internal(
+                "server is shutting down".to_string(),
+            )),
+        )
+            .into_response();
+    }
+
     ws.on_upgrade(move |socket| handle_ws_connection(socket, state, headers))
 }
 
@@ -274,6 +284,15 @@ async fn close_ws_with_protocol_reason(socket: &mut WebSocket, reason: &str) {
         .await;
 }
 
+async fn close_ws_for_shutdown(socket: &mut WebSocket) {
+    let _ = socket
+        .send(Message::Close(Some(CloseFrame {
+            code: close_code::RESTART,
+            reason: "server shutting down".into(),
+        })))
+        .await;
+}
+
 async fn handle_ws_connection(
     mut socket: WebSocket,
     state: Arc<ServerState>,
@@ -349,6 +368,11 @@ async fn handle_ws_connection(
         WsClientSetup::Session(_) => "session",
     };
 
+    let Some(_websocket_guard) = state.shutdown.try_enter_websocket() else {
+        close_ws_for_shutdown(&mut socket).await;
+        return;
+    };
+
     // 4. Register with ConnectionEventHub (mirrors events_handler).
     let connection_id = state
         .next_connection_id
@@ -418,6 +442,7 @@ async fn handle_ws_connection(
 
     // 7. Bidirectional loop: inbound frames from client + outbound updates from hub.
     //    Also fires a periodic heartbeat so idle connections don't look half-open.
+    let mut shutdown_rx = state.shutdown.subscribe();
     let mut heartbeat = tokio::time::interval(std::time::Duration::from_secs(30));
     // Don't emit a heartbeat immediately after Connected — wait a full tick.
     heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -476,6 +501,12 @@ async fn handle_ws_connection(
                 let Ok(bytes) = event.encode_payload() else { continue };
                 let frame = crate::transport_manager::frame_encode(&bytes);
                 if socket.send(Message::Binary(frame)).await.is_err() {
+                    break;
+                }
+            }
+            changed = shutdown_rx.changed() => {
+                if changed.is_ok() && state.shutdown.is_shutting_down() {
+                    close_ws_for_shutdown(&mut socket).await;
                     break;
                 }
             }

--- a/crates/jazz-tools/src/server/routes/websocket.rs
+++ b/crates/jazz-tools/src/server/routes/websocket.rs
@@ -368,10 +368,15 @@ async fn handle_ws_connection(
         WsClientSetup::Session(_) => "session",
     };
 
+    let mut shutdown_rx = state.shutdown.subscribe();
     let Some(_websocket_guard) = state.shutdown.try_enter_websocket() else {
         close_ws_for_shutdown(&mut socket).await;
         return;
     };
+    if state.shutdown.is_shutting_down() {
+        close_ws_for_shutdown(&mut socket).await;
+        return;
+    }
 
     // 4. Register with ConnectionEventHub (mirrors events_handler).
     let connection_id = state
@@ -442,7 +447,6 @@ async fn handle_ws_connection(
 
     // 7. Bidirectional loop: inbound frames from client + outbound updates from hub.
     //    Also fires a periodic heartbeat so idle connections don't look half-open.
-    let mut shutdown_rx = state.shutdown.subscribe();
     let mut heartbeat = tokio::time::interval(std::time::Duration::from_secs(30));
     // Don't emit a heartbeat immediately after Connected — wait a full tick.
     heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);

--- a/crates/jazz-tools/src/server/routes/websocket.rs
+++ b/crates/jazz-tools/src/server/routes/websocket.rs
@@ -298,11 +298,31 @@ async fn handle_ws_connection(
     state: Arc<ServerState>,
     request_headers: HeaderMap,
 ) {
+    let mut shutdown_rx = state.shutdown.subscribe();
+    let Some(_websocket_guard) = state.shutdown.try_enter_websocket() else {
+        close_ws_for_shutdown(&mut socket).await;
+        return;
+    };
+    if state.shutdown.is_shutting_down() {
+        close_ws_for_shutdown(&mut socket).await;
+        return;
+    }
+
     // 1. Read the first binary frame — expected to be AuthHandshake.
-    let first = match socket.recv().await {
-        Some(Ok(Message::Binary(b))) => b,
-        _ => {
-            let _ = socket.close().await;
+    let first = tokio::select! {
+        msg = socket.recv() => match msg {
+            Some(Ok(Message::Binary(b))) => b,
+            _ => {
+                let _ = socket.close().await;
+                return;
+            }
+        },
+        changed = shutdown_rx.changed() => {
+            if changed.is_ok() && state.shutdown.is_shutting_down() {
+                close_ws_for_shutdown(&mut socket).await;
+            } else {
+                let _ = socket.close().await;
+            }
             return;
         }
     };
@@ -354,11 +374,21 @@ async fn handle_ws_connection(
     };
 
     // 3. Authenticate.
-    let setup = match authenticate_ws_handshake(&handshake, &request_headers, &state).await {
-        Ok(s) => s,
-        Err(msg) => {
-            send_ws_error(&mut socket, &msg).await;
-            let _ = socket.close().await;
+    let setup = tokio::select! {
+        auth = authenticate_ws_handshake(&handshake, &request_headers, &state) => match auth {
+            Ok(s) => s,
+            Err(msg) => {
+                send_ws_error(&mut socket, &msg).await;
+                let _ = socket.close().await;
+                return;
+            }
+        },
+        changed = shutdown_rx.changed() => {
+            if changed.is_ok() && state.shutdown.is_shutting_down() {
+                close_ws_for_shutdown(&mut socket).await;
+            } else {
+                let _ = socket.close().await;
+            }
             return;
         }
     };
@@ -367,16 +397,6 @@ async fn handle_ws_connection(
         WsClientSetup::Backend => "backend",
         WsClientSetup::Session(_) => "session",
     };
-
-    let mut shutdown_rx = state.shutdown.subscribe();
-    let Some(_websocket_guard) = state.shutdown.try_enter_websocket() else {
-        close_ws_for_shutdown(&mut socket).await;
-        return;
-    };
-    if state.shutdown.is_shutting_down() {
-        close_ws_for_shutdown(&mut socket).await;
-        return;
-    }
 
     // 4. Register with ConnectionEventHub (mirrors events_handler).
     let connection_id = state

--- a/crates/jazz-tools/src/server/routes/websocket.rs
+++ b/crates/jazz-tools/src/server/routes/websocket.rs
@@ -473,6 +473,13 @@ async fn handle_ws_connection(
     heartbeat.tick().await; // consume the immediate first tick
     loop {
         tokio::select! {
+            biased;
+            changed = shutdown_rx.changed() => {
+                if changed.is_ok() && state.shutdown.is_shutting_down() {
+                    close_ws_for_shutdown(&mut socket).await;
+                    break;
+                }
+            }
             msg = socket.recv() => match msg {
                 Some(Ok(Message::Binary(data))) => {
                     let Some(payload) = crate::transport_manager::frame_decode(&data) else {
@@ -525,12 +532,6 @@ async fn handle_ws_connection(
                 let Ok(bytes) = event.encode_payload() else { continue };
                 let frame = crate::transport_manager::frame_encode(&bytes);
                 if socket.send(Message::Binary(frame)).await.is_err() {
-                    break;
-                }
-            }
-            changed = shutdown_rx.changed() => {
-                if changed.is_ok() && state.shutdown.is_shutting_down() {
-                    close_ws_for_shutdown(&mut socket).await;
                     break;
                 }
             }

--- a/crates/jazz-tools/src/server/shutdown.rs
+++ b/crates/jazz-tools/src/server/shutdown.rs
@@ -68,14 +68,14 @@ impl ShutdownController {
     }
 
     pub fn is_shutting_down(&self) -> bool {
-        !self.phase().is_running()
+        self.inner.requested.load(Ordering::SeqCst) || !self.phase().is_running()
     }
 
     pub fn subscribe(&self) -> watch::Receiver<ShutdownPhase> {
         self.inner.phase_tx.subscribe()
     }
 
-    pub fn set_phase(&self, phase: ShutdownPhase) {
+    pub(crate) fn set_phase(&self, phase: ShutdownPhase) {
         self.inner.phase_tx.send_replace(phase);
     }
 
@@ -240,6 +240,19 @@ mod tests {
         assert!(controller.try_enter_app_request().is_none());
     }
 
+    #[test]
+    fn guards_reject_after_shutdown_is_requested_before_phase_updates() {
+        let controller = ShutdownController::new(std::time::Duration::from_secs(30));
+        controller.inner.requested.store(true, Ordering::SeqCst);
+
+        assert_eq!(controller.phase(), ShutdownPhase::Running);
+        assert!(controller.is_shutting_down());
+        assert!(controller.try_enter_app_request().is_none());
+        assert!(controller.try_enter_websocket().is_none());
+        assert_eq!(controller.active_app_requests(), 0);
+        assert_eq!(controller.active_websockets(), 0);
+    }
+
     #[tokio::test]
     async fn wait_for_shutdown_request_observes_request() {
         let controller = ShutdownController::new(std::time::Duration::from_secs(30));
@@ -297,5 +310,15 @@ mod tests {
             .expect("websocket drain should complete after guard drop")
             .expect("wait task");
         assert!(drained);
+    }
+
+    #[tokio::test]
+    async fn wait_for_websocket_drain_returns_false_after_timeout() {
+        let controller = ShutdownController::new(std::time::Duration::from_millis(10));
+        let _guard = controller
+            .try_enter_websocket()
+            .expect("running server accepts websocket");
+
+        assert!(!controller.wait_for_websocket_drain().await);
     }
 }

--- a/crates/jazz-tools/src/server/shutdown.rs
+++ b/crates/jazz-tools/src/server/shutdown.rs
@@ -173,18 +173,29 @@ impl ShutdownController {
         }
     }
 
-    pub async fn wait_for_app_request_drain(&self) {
+    pub async fn wait_for_app_request_drain(&self) -> bool {
+        let deadline = tokio::time::Instant::now() + self.timeout();
         let notified = self.inner.drain_notify.notified();
         tokio::pin!(notified);
 
         loop {
             notified.as_mut().enable();
             if self.active_app_requests() == 0 {
-                return;
+                return true;
             }
 
-            notified.as_mut().await;
-            notified.set(self.inner.drain_notify.notified());
+            let now = tokio::time::Instant::now();
+            if now >= deadline {
+                return false;
+            }
+
+            let sleep = tokio::time::sleep_until(deadline);
+            tokio::select! {
+                _ = notified.as_mut() => {
+                    notified.set(self.inner.drain_notify.notified());
+                }
+                _ = sleep => return self.active_app_requests() == 0,
+            }
         }
     }
 }
@@ -290,6 +301,16 @@ mod tests {
             .expect("drain wait should complete after guard drop")
             .expect("wait task");
         assert_eq!(active, 0);
+    }
+
+    #[tokio::test]
+    async fn wait_for_app_request_drain_returns_false_after_timeout() {
+        let controller = ShutdownController::new(std::time::Duration::from_millis(10));
+        let _guard = controller
+            .try_enter_app_request()
+            .expect("running server accepts request");
+
+        assert!(!controller.wait_for_app_request_drain().await);
     }
 
     #[tokio::test]

--- a/crates/jazz-tools/src/server/shutdown.rs
+++ b/crates/jazz-tools/src/server/shutdown.rs
@@ -29,6 +29,7 @@ pub struct ShutdownController {
 
 struct ShutdownInner {
     requested: AtomicBool,
+    finalization_started: AtomicBool,
     timeout: Duration,
     phase_tx: watch::Sender<ShutdownPhase>,
     drain_notify: Notify,
@@ -50,6 +51,7 @@ impl ShutdownController {
         Self {
             inner: Arc::new(ShutdownInner {
                 requested: AtomicBool::new(false),
+                finalization_started: AtomicBool::new(false),
                 timeout,
                 phase_tx,
                 drain_notify: Notify::new(),
@@ -86,6 +88,10 @@ impl ShutdownController {
             self.inner.drain_notify.notify_waiters();
         }
         !was_requested
+    }
+
+    pub(crate) fn try_begin_finalization(&self) -> bool {
+        !self.inner.finalization_started.swap(true, Ordering::SeqCst)
     }
 
     pub async fn wait_requested(&self) {

--- a/crates/jazz-tools/src/server/shutdown.rs
+++ b/crates/jazz-tools/src/server/shutdown.rs
@@ -149,7 +149,11 @@ impl ShutdownController {
 
     pub async fn wait_for_websocket_drain(&self) -> bool {
         let deadline = tokio::time::Instant::now() + self.timeout();
+        let notified = self.inner.drain_notify.notified();
+        tokio::pin!(notified);
+
         loop {
+            notified.as_mut().enable();
             if self.active_websockets() == 0 {
                 return true;
             }
@@ -161,15 +165,26 @@ impl ShutdownController {
 
             let sleep = tokio::time::sleep_until(deadline);
             tokio::select! {
-                _ = self.inner.drain_notify.notified() => {}
+                _ = notified.as_mut() => {
+                    notified.set(self.inner.drain_notify.notified());
+                }
                 _ = sleep => return self.active_websockets() == 0,
             }
         }
     }
 
     pub async fn wait_for_app_request_drain(&self) {
-        while self.active_app_requests() > 0 {
-            self.inner.drain_notify.notified().await;
+        let notified = self.inner.drain_notify.notified();
+        tokio::pin!(notified);
+
+        loop {
+            notified.as_mut().enable();
+            if self.active_app_requests() == 0 {
+                return;
+            }
+
+            notified.as_mut().await;
+            notified.set(self.inner.drain_notify.notified());
         }
     }
 }
@@ -239,5 +254,48 @@ mod tests {
 
         let phase = task.await.expect("wait task");
         assert_eq!(phase, ShutdownPhase::ShuttingDown);
+    }
+
+    #[tokio::test]
+    async fn wait_for_app_request_drain_observes_guard_drop() {
+        let controller = ShutdownController::new(std::time::Duration::from_secs(30));
+        let guard = controller
+            .try_enter_app_request()
+            .expect("running server accepts request");
+        let waiter = controller.clone();
+
+        let task = tokio::spawn(async move {
+            waiter.wait_for_app_request_drain().await;
+            waiter.active_app_requests()
+        });
+
+        tokio::task::yield_now().await;
+        drop(guard);
+
+        let active = tokio::time::timeout(std::time::Duration::from_secs(1), task)
+            .await
+            .expect("drain wait should complete after guard drop")
+            .expect("wait task");
+        assert_eq!(active, 0);
+    }
+
+    #[tokio::test]
+    async fn wait_for_websocket_drain_observes_guard_drop() {
+        let controller = ShutdownController::new(std::time::Duration::from_secs(30));
+        let guard = controller
+            .try_enter_websocket()
+            .expect("running server accepts websocket");
+        let waiter = controller.clone();
+
+        let task = tokio::spawn(async move { waiter.wait_for_websocket_drain().await });
+
+        tokio::task::yield_now().await;
+        drop(guard);
+
+        let drained = tokio::time::timeout(std::time::Duration::from_secs(1), task)
+            .await
+            .expect("websocket drain should complete after guard drop")
+            .expect("wait task");
+        assert!(drained);
     }
 }

--- a/crates/jazz-tools/src/server/shutdown.rs
+++ b/crates/jazz-tools/src/server/shutdown.rs
@@ -1,0 +1,243 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::Duration;
+
+use tokio::sync::{Notify, watch};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ShutdownPhase {
+    Running,
+    ShuttingDown,
+    DrainingConnections,
+    FlushingRuntime,
+    ClosingStorage,
+    StorageClosed,
+    Failed,
+}
+
+impl ShutdownPhase {
+    pub fn is_running(self) -> bool {
+        matches!(self, Self::Running)
+    }
+}
+
+#[derive(Clone)]
+pub struct ShutdownController {
+    inner: Arc<ShutdownInner>,
+}
+
+struct ShutdownInner {
+    requested: AtomicBool,
+    timeout: Duration,
+    phase_tx: watch::Sender<ShutdownPhase>,
+    drain_notify: Notify,
+    active_app_requests: AtomicUsize,
+    active_websockets: AtomicUsize,
+}
+
+pub struct ActiveAppRequestGuard {
+    controller: ShutdownController,
+}
+
+pub struct ActiveWebSocketGuard {
+    controller: ShutdownController,
+}
+
+impl ShutdownController {
+    pub fn new(timeout: Duration) -> Self {
+        let (phase_tx, _) = watch::channel(ShutdownPhase::Running);
+        Self {
+            inner: Arc::new(ShutdownInner {
+                requested: AtomicBool::new(false),
+                timeout,
+                phase_tx,
+                drain_notify: Notify::new(),
+                active_app_requests: AtomicUsize::new(0),
+                active_websockets: AtomicUsize::new(0),
+            }),
+        }
+    }
+
+    pub fn timeout(&self) -> Duration {
+        self.inner.timeout
+    }
+
+    pub fn phase(&self) -> ShutdownPhase {
+        *self.inner.phase_tx.borrow()
+    }
+
+    pub fn is_shutting_down(&self) -> bool {
+        !self.phase().is_running()
+    }
+
+    pub fn subscribe(&self) -> watch::Receiver<ShutdownPhase> {
+        self.inner.phase_tx.subscribe()
+    }
+
+    pub fn set_phase(&self, phase: ShutdownPhase) {
+        self.inner.phase_tx.send_replace(phase);
+    }
+
+    pub fn request_shutdown(&self) -> bool {
+        let was_requested = self.inner.requested.swap(true, Ordering::SeqCst);
+        if !was_requested {
+            self.set_phase(ShutdownPhase::ShuttingDown);
+            self.inner.drain_notify.notify_waiters();
+        }
+        !was_requested
+    }
+
+    pub async fn wait_requested(&self) {
+        if self.inner.requested.load(Ordering::SeqCst) {
+            return;
+        }
+
+        let mut rx = self.subscribe();
+        while rx.borrow().is_running() {
+            if rx.changed().await.is_err() {
+                break;
+            }
+        }
+    }
+
+    pub fn try_enter_app_request(&self) -> Option<ActiveAppRequestGuard> {
+        if self.is_shutting_down() {
+            return None;
+        }
+
+        self.inner
+            .active_app_requests
+            .fetch_add(1, Ordering::SeqCst);
+        if self.is_shutting_down() {
+            self.inner
+                .active_app_requests
+                .fetch_sub(1, Ordering::SeqCst);
+            self.inner.drain_notify.notify_waiters();
+            return None;
+        }
+
+        Some(ActiveAppRequestGuard {
+            controller: self.clone(),
+        })
+    }
+
+    pub fn try_enter_websocket(&self) -> Option<ActiveWebSocketGuard> {
+        if self.is_shutting_down() {
+            return None;
+        }
+
+        self.inner.active_websockets.fetch_add(1, Ordering::SeqCst);
+        if self.is_shutting_down() {
+            self.inner.active_websockets.fetch_sub(1, Ordering::SeqCst);
+            self.inner.drain_notify.notify_waiters();
+            return None;
+        }
+
+        Some(ActiveWebSocketGuard {
+            controller: self.clone(),
+        })
+    }
+
+    pub fn active_app_requests(&self) -> usize {
+        self.inner.active_app_requests.load(Ordering::SeqCst)
+    }
+
+    pub fn active_websockets(&self) -> usize {
+        self.inner.active_websockets.load(Ordering::SeqCst)
+    }
+
+    pub async fn wait_for_websocket_drain(&self) -> bool {
+        let deadline = tokio::time::Instant::now() + self.timeout();
+        loop {
+            if self.active_websockets() == 0 {
+                return true;
+            }
+
+            let now = tokio::time::Instant::now();
+            if now >= deadline {
+                return false;
+            }
+
+            let sleep = tokio::time::sleep_until(deadline);
+            tokio::select! {
+                _ = self.inner.drain_notify.notified() => {}
+                _ = sleep => return self.active_websockets() == 0,
+            }
+        }
+    }
+
+    pub async fn wait_for_app_request_drain(&self) {
+        while self.active_app_requests() > 0 {
+            self.inner.drain_notify.notified().await;
+        }
+    }
+}
+
+impl Drop for ActiveAppRequestGuard {
+    fn drop(&mut self) {
+        self.controller
+            .inner
+            .active_app_requests
+            .fetch_sub(1, Ordering::SeqCst);
+        self.controller.inner.drain_notify.notify_waiters();
+    }
+}
+
+impl Drop for ActiveWebSocketGuard {
+    fn drop(&mut self) {
+        self.controller
+            .inner
+            .active_websockets
+            .fetch_sub(1, Ordering::SeqCst);
+        self.controller.inner.drain_notify.notify_waiters();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_shutdown_is_idempotent() {
+        let controller = ShutdownController::new(std::time::Duration::from_secs(30));
+
+        assert_eq!(controller.phase(), ShutdownPhase::Running);
+        assert!(controller.request_shutdown());
+        assert_eq!(controller.phase(), ShutdownPhase::ShuttingDown);
+        assert!(!controller.request_shutdown());
+        assert_eq!(controller.phase(), ShutdownPhase::ShuttingDown);
+    }
+
+    #[test]
+    fn app_request_guard_rejects_after_shutdown_starts() {
+        let controller = ShutdownController::new(std::time::Duration::from_secs(30));
+        assert_eq!(controller.active_app_requests(), 0);
+
+        let guard = controller
+            .try_enter_app_request()
+            .expect("running server accepts request");
+        assert_eq!(controller.active_app_requests(), 1);
+        drop(guard);
+        assert_eq!(controller.active_app_requests(), 0);
+
+        assert!(controller.request_shutdown());
+        assert!(controller.try_enter_app_request().is_none());
+    }
+
+    #[tokio::test]
+    async fn wait_for_shutdown_request_observes_request() {
+        let controller = ShutdownController::new(std::time::Duration::from_secs(30));
+        let waiter = controller.clone();
+
+        let task = tokio::spawn(async move {
+            waiter.wait_requested().await;
+            waiter.phase()
+        });
+
+        assert!(controller.request_shutdown());
+
+        let phase = task.await.expect("wait task");
+        assert_eq!(phase, ShutdownPhase::ShuttingDown);
+    }
+}

--- a/crates/jazz-tools/src/server/testing.rs
+++ b/crates/jazz-tools/src/server/testing.rs
@@ -526,6 +526,33 @@ mod tests {
     use super::*;
 
     #[tokio::test]
+    async fn internal_shutdown_stops_hosted_server() {
+        let server = TestingServer::start().await;
+        let base_url = server.base_url();
+        let admin_secret = server.admin_secret().to_string();
+        let client = reqwest::Client::new();
+
+        let response = client
+            .post(format!("{base_url}/internal/shutdown"))
+            .header("X-Jazz-Admin-Secret", admin_secret)
+            .send()
+            .await
+            .expect("shutdown request");
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+        for _ in 0..80 {
+            match client.get(format!("{base_url}/health")).send().await {
+                Ok(response) if response.status() == StatusCode::SERVICE_UNAVAILABLE => {}
+                Err(_) => return,
+                _ => {}
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        panic!("hosted server did not stop after internal shutdown");
+    }
+
+    #[tokio::test]
     async fn default_testing_server_keeps_built_in_jwt_helpers_enabled() {
         let server = TestingServer::start().await;
         let context = server.make_client_context_for_user(Schema::new(), "default-helper-user");

--- a/crates/jazz-tools/src/server/testing.rs
+++ b/crates/jazz-tools/src/server/testing.rs
@@ -540,10 +540,13 @@ mod tests {
             .expect("shutdown request");
         assert_eq!(response.status(), StatusCode::ACCEPTED);
 
+        let mut saw_unavailable = false;
         for _ in 0..80 {
             match client.get(format!("{base_url}/health")).send().await {
-                Ok(response) if response.status() == StatusCode::SERVICE_UNAVAILABLE => {}
-                Err(_) => return,
+                Ok(response) if response.status() == StatusCode::SERVICE_UNAVAILABLE => {
+                    saw_unavailable = true;
+                }
+                Err(_) if saw_unavailable => return,
                 _ => {}
             }
             tokio::time::sleep(Duration::from_millis(50)).await;

--- a/crates/jazz-tools/src/server/testing.rs
+++ b/crates/jazz-tools/src/server/testing.rs
@@ -523,6 +523,8 @@ mod tests {
 
     use reqwest::StatusCode;
 
+    use crate::server::ShutdownPhase;
+
     use super::*;
 
     #[tokio::test]
@@ -546,7 +548,13 @@ mod tests {
                 Ok(response) if response.status() == StatusCode::SERVICE_UNAVAILABLE => {
                     saw_unavailable = true;
                 }
-                Err(_) if saw_unavailable => return,
+                Err(_) if saw_unavailable => {
+                    assert_eq!(
+                        server.server_state().shutdown.phase(),
+                        ShutdownPhase::StorageClosed
+                    );
+                    return;
+                }
                 _ => {}
             }
             tokio::time::sleep(Duration::from_millis(50)).await;

--- a/crates/jazz-tools/src/storage/conformance.rs
+++ b/crates/jazz-tools/src/storage/conformance.rs
@@ -1176,7 +1176,7 @@ pub fn test_persistence_survives_close_reopen(factory: &PersistentStorageFactory
                 row_id,
             )
             .unwrap();
-        storage.flush();
+        storage.flush().unwrap();
         storage.close().unwrap();
     }
 
@@ -1238,7 +1238,7 @@ pub fn test_local_batch_record_survives_close_reopen(factory: &PersistentStorage
     {
         let mut storage = factory(path);
         storage.upsert_local_batch_record(&record).unwrap();
-        storage.flush();
+        storage.flush().unwrap();
         storage.close().unwrap();
     }
 
@@ -1278,7 +1278,7 @@ pub fn test_authoritative_batch_fate_survives_close_reopen(factory: &PersistentS
         storage
             .upsert_authoritative_batch_fate(&settlement)
             .unwrap();
-        storage.flush();
+        storage.flush().unwrap();
         storage.close().unwrap();
     }
 
@@ -1319,7 +1319,7 @@ pub fn test_sealed_batch_submission_survives_close_reopen(factory: &PersistentSt
     {
         let mut storage = factory(path);
         storage.upsert_sealed_batch_submission(&submission).unwrap();
-        storage.flush();
+        storage.flush().unwrap();
         storage.close().unwrap();
     }
 
@@ -1354,7 +1354,7 @@ pub fn test_branch_ord_survives_close_reopen(factory: &PersistentStorageFactory)
         let mut storage = factory(path);
         let main_ord = storage.resolve_or_alloc_branch_ord(main).unwrap();
         let draft_ord = storage.resolve_or_alloc_branch_ord(draft).unwrap();
-        storage.flush();
+        storage.flush().unwrap();
         storage.close().unwrap();
         (main_ord, draft_ord)
     };

--- a/crates/jazz-tools/src/storage/memory.rs
+++ b/crates/jazz-tools/src/storage/memory.rs
@@ -3024,7 +3024,7 @@ mod tests {
         let (schema_hash, row_id, row) = {
             let mut storage = SqliteStorage::open(&path).unwrap();
             let seeded = seed_common_case_visible_task_row(&mut storage);
-            storage.flush();
+            storage.flush().unwrap();
             storage.close().unwrap();
             seeded
         };
@@ -3060,7 +3060,7 @@ mod tests {
         let (schema_hash, row_id, row) = {
             let mut storage = RocksDBStorage::open(&path, 8 * 1024 * 1024).unwrap();
             let seeded = seed_common_case_visible_task_row(&mut storage);
-            storage.flush();
+            storage.flush().unwrap();
             storage.close().unwrap();
             seeded
         };

--- a/crates/jazz-tools/src/storage/memory.rs
+++ b/crates/jazz-tools/src/storage/memory.rs
@@ -43,7 +43,7 @@ impl TableRowHistories {
 pub struct MemoryStorage {
     cache_namespace: usize,
     #[cfg(test)]
-    flush_wal_error: Option<StorageError>,
+    flush_wal_failures: std::cell::RefCell<Option<(StorageError, Option<usize>)>>,
     /// Ordered raw-table storage.
     raw_tables: HashMap<String, RawTableEntries>,
     authoritative_batch_fates: std::cell::RefCell<HashMap<BatchId, BatchFate>>,
@@ -65,7 +65,17 @@ impl MemoryStorage {
 
     #[cfg(test)]
     pub(crate) fn with_flush_wal_error(mut self, error: StorageError) -> Self {
-        self.flush_wal_error = Some(error);
+        self.flush_wal_failures = std::cell::RefCell::new(Some((error, None)));
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_transient_flush_wal_failures(
+        mut self,
+        error: StorageError,
+        failures: usize,
+    ) -> Self {
+        self.flush_wal_failures = std::cell::RefCell::new(Some((error, Some(failures))));
         self
     }
 
@@ -101,7 +111,7 @@ impl Default for MemoryStorage {
         Self {
             cache_namespace: next_storage_cache_namespace(),
             #[cfg(test)]
-            flush_wal_error: None,
+            flush_wal_failures: std::cell::RefCell::new(None),
             raw_tables: HashMap::new(),
             authoritative_batch_fates: std::cell::RefCell::new(HashMap::new()),
             ensured_raw_table_headers: HashSet::new(),
@@ -1141,8 +1151,15 @@ impl Storage for MemoryStorage {
 
     #[cfg(test)]
     fn flush_wal(&self) -> Result<(), StorageError> {
-        if let Some(error) = &self.flush_wal_error {
-            return Err(error.clone());
+        if let Some((error, remaining)) = self.flush_wal_failures.borrow_mut().as_mut() {
+            match remaining {
+                Some(0) => {}
+                Some(count) => {
+                    *count -= 1;
+                    return Err(error.clone());
+                }
+                None => return Err(error.clone()),
+            }
         }
         Ok(())
     }

--- a/crates/jazz-tools/src/storage/memory.rs
+++ b/crates/jazz-tools/src/storage/memory.rs
@@ -43,6 +43,8 @@ impl TableRowHistories {
 pub struct MemoryStorage {
     cache_namespace: usize,
     #[cfg(test)]
+    flush_failures: std::cell::RefCell<Option<(StorageError, Option<usize>)>>,
+    #[cfg(test)]
     flush_wal_failures: std::cell::RefCell<Option<(StorageError, Option<usize>)>>,
     /// Ordered raw-table storage.
     raw_tables: HashMap<String, RawTableEntries>,
@@ -66,6 +68,16 @@ impl MemoryStorage {
     #[cfg(test)]
     pub(crate) fn with_flush_wal_error(mut self, error: StorageError) -> Self {
         self.flush_wal_failures = std::cell::RefCell::new(Some((error, None)));
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_transient_flush_failures(
+        mut self,
+        error: StorageError,
+        failures: usize,
+    ) -> Self {
+        self.flush_failures = std::cell::RefCell::new(Some((error, Some(failures))));
         self
     }
 
@@ -110,6 +122,8 @@ impl Default for MemoryStorage {
     fn default() -> Self {
         Self {
             cache_namespace: next_storage_cache_namespace(),
+            #[cfg(test)]
+            flush_failures: std::cell::RefCell::new(None),
             #[cfg(test)]
             flush_wal_failures: std::cell::RefCell::new(None),
             raw_tables: HashMap::new(),
@@ -1147,6 +1161,21 @@ impl Storage for MemoryStorage {
             )
         });
         Ok(rows)
+    }
+
+    #[cfg(test)]
+    fn flush(&self) -> Result<(), StorageError> {
+        if let Some((error, remaining)) = self.flush_failures.borrow_mut().as_mut() {
+            match remaining {
+                Some(0) => {}
+                Some(count) => {
+                    *count -= 1;
+                    return Err(error.clone());
+                }
+                None => return Err(error.clone()),
+            }
+        }
+        Ok(())
     }
 
     #[cfg(test)]

--- a/crates/jazz-tools/src/storage/memory.rs
+++ b/crates/jazz-tools/src/storage/memory.rs
@@ -42,6 +42,8 @@ impl TableRowHistories {
 /// - Main thread in browser (acts as cache of worker state)
 pub struct MemoryStorage {
     cache_namespace: usize,
+    #[cfg(test)]
+    flush_wal_error: Option<StorageError>,
     /// Ordered raw-table storage.
     raw_tables: HashMap<String, RawTableEntries>,
     authoritative_batch_fates: std::cell::RefCell<HashMap<BatchId, BatchFate>>,
@@ -59,6 +61,12 @@ impl MemoryStorage {
     /// Create a new empty MemoryStorage.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_flush_wal_error(mut self, error: StorageError) -> Self {
+        self.flush_wal_error = Some(error);
+        self
     }
 
     fn ensure_cached_raw_table_header(
@@ -92,6 +100,8 @@ impl Default for MemoryStorage {
     fn default() -> Self {
         Self {
             cache_namespace: next_storage_cache_namespace(),
+            #[cfg(test)]
+            flush_wal_error: None,
             raw_tables: HashMap::new(),
             authoritative_batch_fates: std::cell::RefCell::new(HashMap::new()),
             ensured_raw_table_headers: HashSet::new(),
@@ -1127,6 +1137,14 @@ impl Storage for MemoryStorage {
             )
         });
         Ok(rows)
+    }
+
+    #[cfg(test)]
+    fn flush_wal(&self) -> Result<(), StorageError> {
+        if let Some(error) = &self.flush_wal_error {
+            return Err(error.clone());
+        }
+        Ok(())
     }
 }
 

--- a/crates/jazz-tools/src/storage/memory.rs
+++ b/crates/jazz-tools/src/storage/memory.rs
@@ -46,6 +46,8 @@ pub struct MemoryStorage {
     flush_failures: std::cell::RefCell<Option<(StorageError, Option<usize>)>>,
     #[cfg(test)]
     flush_wal_failures: std::cell::RefCell<Option<(StorageError, Option<usize>)>>,
+    #[cfg(test)]
+    flush_wal_call_count: std::cell::RefCell<usize>,
     /// Ordered raw-table storage.
     raw_tables: HashMap<String, RawTableEntries>,
     authoritative_batch_fates: std::cell::RefCell<HashMap<BatchId, BatchFate>>,
@@ -91,6 +93,11 @@ impl MemoryStorage {
         self
     }
 
+    #[cfg(test)]
+    pub(crate) fn flush_wal_call_count(&self) -> usize {
+        *self.flush_wal_call_count.borrow()
+    }
+
     fn ensure_cached_raw_table_header(
         &mut self,
         raw_table: &str,
@@ -126,6 +133,8 @@ impl Default for MemoryStorage {
             flush_failures: std::cell::RefCell::new(None),
             #[cfg(test)]
             flush_wal_failures: std::cell::RefCell::new(None),
+            #[cfg(test)]
+            flush_wal_call_count: std::cell::RefCell::new(0),
             raw_tables: HashMap::new(),
             authoritative_batch_fates: std::cell::RefCell::new(HashMap::new()),
             ensured_raw_table_headers: HashSet::new(),
@@ -1180,6 +1189,7 @@ impl Storage for MemoryStorage {
 
     #[cfg(test)]
     fn flush_wal(&self) -> Result<(), StorageError> {
+        *self.flush_wal_call_count.borrow_mut() += 1;
         if let Some((error, remaining)) = self.flush_wal_failures.borrow_mut().as_mut() {
             match remaining {
                 Some(0) => {}

--- a/crates/jazz-tools/src/storage/opfs_btree/mod.rs
+++ b/crates/jazz-tools/src/storage/opfs_btree/mod.rs
@@ -432,17 +432,15 @@ impl Storage for OpfsBTreeStorage {
         )
     }
 
-    fn flush(&self) {
+    fn flush(&self) -> Result<(), StorageError> {
         let _span = tracing::debug_span!("OpfsBTreeStorage::flush").entered();
-        if let Err(error) = self.with_tree_mut(|tree| tree.checkpoint().map_err(map_storage_err)) {
-            tracing::warn!(?error, "OpfsBTreeStorage flush failed");
-        }
+        self.with_tree_mut(|tree| tree.checkpoint().map_err(map_storage_err))
     }
 
-    fn flush_wal(&self) {
+    fn flush_wal(&self) -> Result<(), StorageError> {
         let _span = tracing::debug_span!("OpfsBTreeStorage::flush_wal").entered();
         // opfs-btree has no separate WAL; flush_wal maps to an incremental checkpoint.
-        self.flush();
+        self.flush()
     }
 }
 
@@ -590,7 +588,7 @@ mod tests {
                 &crate::storage::encode_store_manifest(&bad_manifest).unwrap(),
             )
             .unwrap();
-        storage.flush();
+        storage.flush().unwrap();
         drop(storage);
 
         let err = match OpfsBTreeStorage::open(&path, 4 * 1024 * 1024) {
@@ -613,7 +611,7 @@ mod tests {
         storage
             .tree_delete(crate::storage::STORE_MANIFEST_KEY)
             .unwrap();
-        storage.flush();
+        storage.flush().unwrap();
         drop(storage);
 
         let err = match OpfsBTreeStorage::open(&path, 4 * 1024 * 1024) {
@@ -801,7 +799,7 @@ mod tests {
                 )
                 .unwrap();
 
-            storage.flush();
+            storage.flush().unwrap();
         }
 
         {

--- a/crates/jazz-tools/src/storage/rocksdb.rs
+++ b/crates/jazz-tools/src/storage/rocksdb.rs
@@ -739,22 +739,22 @@ impl Storage for RocksDBStorage {
         )
     }
 
-    fn flush(&self) {
-        let _ = self.with_inner(|inner| {
+    fn flush(&self) -> Result<(), StorageError> {
+        self.with_inner(|inner| {
             inner
                 .db
                 .flush()
                 .map_err(|e| StorageError::IoError(format!("rocksdb flush: {e}")))
-        });
+        })
     }
 
-    fn flush_wal(&self) {
-        let _ = self.with_inner(|inner| {
+    fn flush_wal(&self) -> Result<(), StorageError> {
+        self.with_inner(|inner| {
             inner
                 .db
                 .flush_wal(true)
                 .map_err(|e| StorageError::IoError(format!("rocksdb flush_wal: {e}")))
-        });
+        })
     }
 
     fn close(&self) -> Result<(), StorageError> {

--- a/crates/jazz-tools/src/storage/sqlite.rs
+++ b/crates/jazz-tools/src/storage/sqlite.rs
@@ -790,22 +790,24 @@ impl Storage for SqliteStorage {
         )
     }
 
-    fn flush_wal(&self) {
-        let Ok(mut inner) = self.lock_inner() else {
-            return;
-        };
+    fn flush_wal(&self) -> Result<(), StorageError> {
+        let mut inner = self.lock_inner()?;
         if let Some(inner) = inner.as_mut() {
             // Commit the open write transaction so writes land in the WAL
             // and survive a process crash.
-            let _ = inner.commit_write_tx();
+            inner.commit_write_tx()?;
             // PASSIVE checkpoint: moves WAL pages into the main db file without
             // blocking concurrent readers.
-            let _ = inner.conn.execute_batch("PRAGMA wal_checkpoint(PASSIVE)");
+            inner
+                .conn
+                .execute_batch("PRAGMA wal_checkpoint(PASSIVE)")
+                .map_err(|e| StorageError::IoError(format!("sqlite wal checkpoint: {e}")))?;
         }
+        Ok(())
     }
 
-    fn flush(&self) {
-        self.flush_wal();
+    fn flush(&self) -> Result<(), StorageError> {
+        self.flush_wal()
     }
 
     fn close(&self) -> Result<(), StorageError> {
@@ -866,8 +868,8 @@ mod tests {
                 .unwrap();
         }
 
-        // flush() should not panic or return an error (it returns ())
-        storage.flush();
+        // flush() should not panic or return an error for an open empty store.
+        storage.flush().unwrap();
     }
 
     #[test]

--- a/crates/jazz-tools/src/storage/storage_trait.rs
+++ b/crates/jazz-tools/src/storage/storage_trait.rs
@@ -1611,10 +1611,14 @@ pub trait Storage {
     }
 
     /// Flush buffered data to persistent storage. No-op for in-memory storage.
-    fn flush(&self) {}
+    fn flush(&self) -> Result<(), StorageError> {
+        Ok(())
+    }
 
     /// Flush only the WAL buffer (not the snapshot). No-op for storage without WAL.
-    fn flush_wal(&self) {}
+    fn flush_wal(&self) -> Result<(), StorageError> {
+        Ok(())
+    }
 
     /// Close and release storage resources (e.g. file locks). No-op by default.
     fn close(&self) -> Result<(), StorageError> {
@@ -2156,12 +2160,12 @@ impl<T: Storage + ?Sized> Storage for Box<T> {
         (**self).index_scan_all(table, column, branch)
     }
 
-    fn flush(&self) {
-        (**self).flush();
+    fn flush(&self) -> Result<(), StorageError> {
+        (**self).flush()
     }
 
-    fn flush_wal(&self) {
-        (**self).flush_wal();
+    fn flush_wal(&self) -> Result<(), StorageError> {
+        (**self).flush_wal()
     }
 
     fn close(&self) -> Result<(), StorageError> {

--- a/crates/jazz-tools/tests/policies_integration/claims_policies.rs
+++ b/crates/jazz-tools/tests/policies_integration/claims_policies.rs
@@ -470,6 +470,25 @@ async fn claim_array_id_policy_gates_updates_by_primary_key() {
     let query = QueryBuilder::new(table_name).build();
 
     wait_for_query(
+        &alice,
+        query.clone(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(3),
+        "alice sees seeded documents before updates",
+        |rows| {
+            (rows.len() == 2
+                && rows.iter().any(|(id, values)| {
+                    *id == allowed_doc && *values == title_document_values("allowed")
+                })
+                && rows.iter().any(|(id, values)| {
+                    *id == blocked_doc && *values == title_document_values("blocked")
+                }))
+            .then_some(())
+        },
+    )
+    .await;
+
+    wait_for_query(
         &observer,
         query.clone(),
         Some(DurabilityTier::EdgeServer),

--- a/crates/jazz-tools/tests/rocksdb_storage_integration.rs
+++ b/crates/jazz-tools/tests/rocksdb_storage_integration.rs
@@ -1123,7 +1123,7 @@ async fn sealed_batch_acceptance_recovers_after_restart() {
         let mut storage =
             RocksDBStorage::open(&db_path, 8 * 1024 * 1024).expect("open rocksdb storage");
         let seeded = seed_rocksdb_sealed_batch_acceptance(&mut storage, &schema);
-        storage.flush();
+        storage.flush().unwrap();
         storage.close().expect("close seeded rocksdb storage");
         seeded
     };
@@ -1174,7 +1174,7 @@ async fn sealed_batch_frontier_conflict_rejects_after_restart() {
         let mut storage =
             RocksDBStorage::open(&db_path, 8 * 1024 * 1024).expect("open rocksdb storage");
         let seeded = seed_rocksdb_sealed_batch_frontier_conflict(&mut storage, &schema);
-        storage.flush();
+        storage.flush().unwrap();
         storage.close().expect("close seeded rocksdb storage");
         seeded
     };

--- a/crates/jazz-tools/tests/sqlite_storage_integration.rs
+++ b/crates/jazz-tools/tests/sqlite_storage_integration.rs
@@ -1119,7 +1119,7 @@ async fn sealed_batch_acceptance_recovers_after_restart() {
     let (batch_id, row_id) = {
         let mut storage = SqliteStorage::open(&db_path).expect("open sqlite storage");
         let seeded = seed_sqlite_sealed_batch_acceptance(&mut storage, &schema);
-        storage.flush();
+        storage.flush().unwrap();
         storage.close().expect("close seeded sqlite storage");
         seeded
     };
@@ -1169,7 +1169,7 @@ async fn sealed_batch_frontier_conflict_rejects_after_restart() {
     let (batch_id, target_branch, staged_row_id, _existing_row_id) = {
         let mut storage = SqliteStorage::open(&db_path).expect("open sqlite storage");
         let seeded = seed_sqlite_sealed_batch_frontier_conflict(&mut storage, &schema);
-        storage.flush();
+        storage.flush().unwrap();
         storage.close().expect("close seeded sqlite storage");
         seeded
     };

--- a/crates/jazz-wasm/src/runtime.rs
+++ b/crates/jazz-wasm/src/runtime.rs
@@ -1983,7 +1983,7 @@ impl WasmRuntime {
     pub fn flush(&self) -> Result<(), JsValue> {
         let _span = debug_span!("wasm::flush", tier = self.tier_label).entered();
         self.core
-            .borrow()
+            .borrow_mut()
             .flush_storage()
             .map_err(|e| JsValue::from_str(&format!("flush failed: {e}")))
     }
@@ -1993,7 +1993,7 @@ impl WasmRuntime {
     pub fn flush_wal(&self) -> Result<(), JsValue> {
         let _span = debug_span!("wasm::flushWal", tier = self.tier_label).entered();
         self.core
-            .borrow()
+            .borrow_mut()
             .flush_wal()
             .map_err(|e| JsValue::from_str(&format!("flush WAL failed: {e}")))
     }

--- a/crates/jazz-wasm/src/runtime.rs
+++ b/crates/jazz-wasm/src/runtime.rs
@@ -1980,16 +1980,22 @@ impl WasmRuntime {
 
     /// Flush all data to persistent storage (snapshot).
     #[wasm_bindgen]
-    pub fn flush(&self) {
+    pub fn flush(&self) -> Result<(), JsValue> {
         let _span = debug_span!("wasm::flush", tier = self.tier_label).entered();
-        self.core.borrow().flush_storage();
+        self.core
+            .borrow()
+            .flush_storage()
+            .map_err(|e| JsValue::from_str(&format!("flush failed: {e}")))
     }
 
     /// Flush only the WAL buffer to OPFS (not the snapshot).
     #[wasm_bindgen(js_name = flushWal)]
-    pub fn flush_wal(&self) {
+    pub fn flush_wal(&self) -> Result<(), JsValue> {
         let _span = debug_span!("wasm::flushWal", tier = self.tier_label).entered();
-        self.core.borrow().flush_wal();
+        self.core
+            .borrow()
+            .flush_wal()
+            .map_err(|e| JsValue::from_str(&format!("flush WAL failed: {e}")))
     }
 
     /// Create a persistent WasmRuntime backed by OPFS.

--- a/crates/jazz-wasm/src/worker_bridge.rs
+++ b/crates/jazz-wasm/src/worker_bridge.rs
@@ -374,7 +374,7 @@ impl WasmWorkerBridge {
     pub fn simulate_crash(&self) -> js_sys::Promise {
         let inner = Rc::clone(&self.inner);
         wasm_bindgen_futures::future_to_promise(async move {
-            let (tx, rx) = oneshot::channel::<()>();
+            let (tx, rx) = oneshot::channel::<Result<(), String>>();
             *inner.shutdown_resolver.borrow_mut() = Some(tx);
             post_wire(&inner.worker, &MainToWorkerWire::SimulateCrash);
             let timeout = make_timeout(SHUTDOWN_ACK_TIMEOUT_MS);
@@ -442,20 +442,27 @@ impl WasmWorkerBridge {
         self.inner.sender.set_server_payload_forwarder(None);
         self.inner.runtime.remove_server();
 
-        let (tx, rx) = oneshot::channel::<()>();
+        let (tx, rx) = oneshot::channel::<Result<(), String>>();
         *self.inner.shutdown_resolver.borrow_mut() = Some(tx);
         post_wire(&self.inner.worker, &MainToWorkerWire::Shutdown);
 
         let inner = Rc::clone(&self.inner);
         wasm_bindgen_futures::future_to_promise(async move {
             let timeout = make_timeout(SHUTDOWN_ACK_TIMEOUT_MS);
-            let _ = select(rx, timeout).await;
             // Clear `worker.onmessage` so late inbound messages don't invoke
             // a freed Rust trampoline. `Closure::drop` alone does NOT clear
             // the JS slot.
+            let shutdown_result = match select(rx, timeout).await {
+                Either::Left((Ok(Ok(())), _)) => Ok(()),
+                Either::Left((Ok(Err(message)), _)) => Err(message),
+                Either::Left((Err(_), _)) => Err("shutdown resolver dropped".to_string()),
+                Either::Right(_) => Ok(()),
+            };
             inner.worker.set_onmessage(None);
             inner.transition_shutdown_finished();
-            Ok(JsValue::UNDEFINED)
+            shutdown_result
+                .map(|()| JsValue::UNDEFINED)
+                .map_err(|message| JsValue::from_str(&message))
         })
     }
 }
@@ -525,7 +532,7 @@ struct BridgeInner {
     on_message_closure: RefCell<Option<Closure<dyn FnMut(MessageEvent)>>>,
     init_resolver: RefCell<Option<oneshot::Sender<Result<String, String>>>>,
     init_promise: RefCell<Option<js_sys::Promise>>,
-    shutdown_resolver: RefCell<Option<oneshot::Sender<()>>>,
+    shutdown_resolver: RefCell<Option<oneshot::Sender<Result<(), String>>>>,
     expects_upstream: Cell<bool>,
     upstream_connected: Cell<bool>,
     has_forwarder: Cell<bool>,
@@ -846,7 +853,14 @@ impl BridgeInner {
             }
             WorkerToMainWire::ShutdownOk => {
                 if let Some(tx) = self.shutdown_resolver.borrow_mut().take() {
-                    let _ = tx.send(());
+                    let _ = tx.send(Ok(()));
+                }
+            }
+            WorkerToMainWire::ShutdownFailed { message } => {
+                if let Some(tx) = self.shutdown_resolver.borrow_mut().take() {
+                    let _ = tx.send(Err(message));
+                } else {
+                    tracing::warn!("worker shutdown failed without pending shutdown: {message}");
                 }
             }
             WorkerToMainWire::DebugSchemaStateOk { .. }

--- a/crates/jazz-wasm/src/worker_host.rs
+++ b/crates/jazz-wasm/src/worker_host.rs
@@ -653,10 +653,15 @@ fn process_main_message(msg: MainToWorkerMessage) {
         },
         MainToWorkerWire::DebugSeedLiveSchema { schema_json } => match runtime.as_ref() {
             Some(rt) => match rt.debug_seed_live_schema(&schema_json) {
-                Ok(()) => {
-                    let _ = rt.flush_wal();
-                    post_to_main(&WorkerToMainWire::DebugSeedLiveSchemaOk);
-                }
+                Ok(()) => match rt.flush_wal() {
+                    Ok(()) => post_to_main(&WorkerToMainWire::DebugSeedLiveSchemaOk),
+                    Err(err) => post_to_main(&WorkerToMainWire::Error {
+                        message: format!(
+                            "debug-seed-live-schema flush failed: {}",
+                            js_error_message(&err)
+                        ),
+                    }),
+                },
                 Err(err) => post_to_main(&WorkerToMainWire::Error {
                     message: format!(
                         "debug-seed-live-schema failed: {}",
@@ -767,7 +772,11 @@ fn handle_shutdown(runtime: Option<&Rc<WasmRuntime>>, _simulate_crash: bool) {
         // the same effect on storage; the distinction is preserved in case
         // a future storage backend introduces a separate snapshot path.
         rt.batched_tick();
-        let _ = rt.flush_wal();
+        if let Err(err) = rt.flush_wal() {
+            post_to_main(&WorkerToMainWire::Error {
+                message: format!("shutdown flush failed: {}", js_error_message(&err)),
+            });
+        }
         rt.install_noop_sync_sender();
         // (No forwarder on worker side — `install_noop_sync_sender` below
         // replaces the active sender wholesale, so any future outbox emission

--- a/crates/jazz-wasm/src/worker_host.rs
+++ b/crates/jazz-wasm/src/worker_host.rs
@@ -654,7 +654,7 @@ fn process_main_message(msg: MainToWorkerMessage) {
         MainToWorkerWire::DebugSeedLiveSchema { schema_json } => match runtime.as_ref() {
             Some(rt) => match rt.debug_seed_live_schema(&schema_json) {
                 Ok(()) => {
-                    rt.flush_wal();
+                    let _ = rt.flush_wal();
                     post_to_main(&WorkerToMainWire::DebugSeedLiveSchemaOk);
                 }
                 Err(err) => post_to_main(&WorkerToMainWire::Error {
@@ -705,7 +705,7 @@ fn handle_lifecycle_hint(event: WorkerLifecycleEvent, runtime: Option<&Rc<WasmRu
         | WorkerLifecycleEvent::Pagehide
         | WorkerLifecycleEvent::Freeze => {
             if let Some(rt) = runtime {
-                rt.flush_wal();
+                let _ = rt.flush_wal();
             }
         }
         _ => {}
@@ -767,7 +767,7 @@ fn handle_shutdown(runtime: Option<&Rc<WasmRuntime>>, _simulate_crash: bool) {
         // the same effect on storage; the distinction is preserved in case
         // a future storage backend introduces a separate snapshot path.
         rt.batched_tick();
-        rt.flush_wal();
+        let _ = rt.flush_wal();
         rt.install_noop_sync_sender();
         // (No forwarder on worker side — `install_noop_sync_sender` below
         // replaces the active sender wholesale, so any future outbox emission

--- a/crates/jazz-wasm/src/worker_host.rs
+++ b/crates/jazz-wasm/src/worker_host.rs
@@ -755,12 +755,14 @@ fn update_auth(jwt: Option<String>, runtime: Option<&Rc<WasmRuntime>>) {
     }
 }
 
-fn handle_shutdown(runtime: Option<&Rc<WasmRuntime>>, _simulate_crash: bool) {
+fn handle_shutdown(runtime: Option<&Rc<WasmRuntime>>, simulate_crash: bool) {
     HOST.with(|cell| {
         if let Some(h) = cell.borrow_mut().as_mut() {
             h.state = HostState::ShuttingDown;
         }
     });
+
+    let mut shutdown_failure = None;
 
     if let Some(rt) = runtime {
         // Drain any parked main/peer sync messages so their writes reach
@@ -777,9 +779,12 @@ fn handle_shutdown(runtime: Option<&Rc<WasmRuntime>>, _simulate_crash: bool) {
         // a future storage backend introduces a separate snapshot path.
         rt.batched_tick();
         if let Err(err) = rt.flush_wal() {
-            post_to_main(&WorkerToMainWire::Error {
-                message: format!("shutdown flush failed: {}", js_error_message(&err)),
-            });
+            let message = format!("shutdown flush failed: {}", js_error_message(&err));
+            if simulate_crash {
+                post_to_main(&WorkerToMainWire::Error { message });
+            } else {
+                shutdown_failure = Some(message);
+            }
         }
         rt.install_noop_sync_sender();
         // (No forwarder on worker side — `install_noop_sync_sender` below
@@ -802,7 +807,11 @@ fn handle_shutdown(runtime: Option<&Rc<WasmRuntime>>, _simulate_crash: bool) {
         g.main_client_id = None;
     });
 
-    post_to_main(&WorkerToMainWire::ShutdownOk);
+    if let Some(message) = shutdown_failure {
+        post_to_main(&WorkerToMainWire::ShutdownFailed { message });
+    } else {
+        post_to_main(&WorkerToMainWire::ShutdownOk);
+    }
     global.close();
     HOST.with(|cell| *cell.borrow_mut() = None);
 }

--- a/crates/jazz-wasm/src/worker_host.rs
+++ b/crates/jazz-wasm/src/worker_host.rs
@@ -710,7 +710,11 @@ fn handle_lifecycle_hint(event: WorkerLifecycleEvent, runtime: Option<&Rc<WasmRu
         | WorkerLifecycleEvent::Pagehide
         | WorkerLifecycleEvent::Freeze => {
             if let Some(rt) = runtime {
-                let _ = rt.flush_wal();
+                if let Err(err) = rt.flush_wal() {
+                    post_to_main(&WorkerToMainWire::Error {
+                        message: format!("lifecycle WAL flush failed: {}", js_error_message(&err)),
+                    });
+                }
             }
         }
         _ => {}

--- a/crates/jazz-wasm/src/worker_protocol.rs
+++ b/crates/jazz-wasm/src/worker_protocol.rs
@@ -155,6 +155,9 @@ pub enum WorkerToMainWire {
         reason: String,
     },
     ShutdownOk,
+    ShutdownFailed {
+        message: String,
+    },
     /// `DebugSchemaState` serialised as JSON.
     DebugSchemaStateOk {
         state_json: String,
@@ -345,6 +348,13 @@ pub fn encode_worker_to_main_js(value: JsValue) -> Result<Uint8Array, JsError> {
                 .unwrap_or_default();
             WorkerToMainWire::Error { message }
         }
+        "shutdown-failed" => {
+            let message = Reflect::get(&value, &JsValue::from_str("message"))
+                .ok()
+                .and_then(|v| v.as_string())
+                .unwrap_or_default();
+            WorkerToMainWire::ShutdownFailed { message }
+        }
         "debug-schema-state-ok" => {
             let state_value =
                 Reflect::get(&value, &JsValue::from_str("state")).unwrap_or(JsValue::UNDEFINED);
@@ -423,6 +433,10 @@ pub fn decode_worker_to_main_js(bytes: &Uint8Array) -> Result<JsValue, JsError> 
     match wire {
         WorkerToMainWire::Error { message } => {
             set("type", &JsValue::from_str("error"))?;
+            set("message", &JsValue::from_str(&message))?;
+        }
+        WorkerToMainWire::ShutdownFailed { message } => {
+            set("type", &JsValue::from_str("shutdown-failed"))?;
             set("message", &JsValue::from_str(&message))?;
         }
         WorkerToMainWire::DebugSchemaStateOk { state_json } => {
@@ -543,6 +557,9 @@ mod tests {
             reason: "expired".into(),
         });
         rt_worker(&WorkerToMainWire::ShutdownOk);
+        rt_worker(&WorkerToMainWire::ShutdownFailed {
+            message: "flush failed".into(),
+        });
         rt_worker(&WorkerToMainWire::DebugSchemaStateOk {
             state_json: "{}".into(),
         });

--- a/crates/jazz-wasm/tests/opfs.rs
+++ b/crates/jazz-wasm/tests/opfs.rs
@@ -150,7 +150,7 @@ async fn opfs_persistence_across_reopen() {
         insert_todo(&runtime, "Task 2", true);
         insert_todo(&runtime, "Task 3", false);
 
-        runtime.flush();
+        runtime.flush().unwrap();
     }
 
     // Phase 2: Reopen and verify data persisted

--- a/docs/superpowers/plans/2026-05-17-internal-server-shutdown.md
+++ b/docs/superpowers/plans/2026-05-17-internal-server-shutdown.md
@@ -1,0 +1,1285 @@
+# Internal Server Shutdown Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `POST /internal/shutdown`, authenticated by admin secret, that starts a controlled server shutdown with WebSocket drain, runtime flush, RocksDB flush/WAL flush, and storage close.
+
+**Architecture:** Add a reusable shutdown controller to `ServerState`, then wire HTTP, health, route gating, WebSocket close notification, and server-command lifecycle around that single controller. Request handlers only request shutdown; the server host owns finalization and Axum listener shutdown.
+
+**Tech Stack:** Rust 2024, Axum 0.7, Tokio, `tokio::sync::watch`/`Notify`, Jazz `TokioRuntime`, existing `Storage` trait.
+
+---
+
+## File Structure
+
+- Create `crates/jazz-tools/src/server/shutdown.rs`: shutdown phase enum, controller, active request/socket guards, wait helpers.
+- Modify `crates/jazz-tools/src/server/mod.rs`: include the controller in `ServerState` and add finalization helpers.
+- Modify `crates/jazz-tools/src/server/builder.rs`: carry shutdown timeout from builder into state.
+- Modify `crates/jazz-tools/src/server/routes/http.rs`: add shutdown DTO/handler and make health state-aware.
+- Modify `crates/jazz-tools/src/server/routes/mod.rs`: add `/internal/shutdown`, add app-scoped shutdown gate, and route tests.
+- Modify `crates/jazz-tools/src/server/routes/websocket.rs`: reject new shutdown-era upgrades and close active sockets on shutdown notification.
+- Modify `crates/jazz-tools/src/server/hosted.rs`: use the shared shutdown driver for test/dev hosted servers.
+- Modify `crates/jazz-tools/src/commands/server.rs`: serve with Axum graceful shutdown driven by the shared controller.
+- Modify `crates/jazz-tools/src/main.rs`: add `--shutdown-timeout-secs` / `JAZZ_SHUTDOWN_TIMEOUT_SECS`.
+- Modify `crates/jazz-tools/src/server/testing.rs`: add an end-to-end hosted-server shutdown test.
+
+---
+
+### Task 1: Add Shutdown Controller
+
+**Files:**
+
+- Create: `crates/jazz-tools/src/server/shutdown.rs`
+- Modify: `crates/jazz-tools/src/server/mod.rs`
+- Modify: `crates/jazz-tools/src/server/builder.rs`
+- Test: `crates/jazz-tools/src/server/shutdown.rs`
+
+- [ ] **Step 1: Write failing tests for controller state and idempotency**
+
+Add this test module to the new file `crates/jazz-tools/src/server/shutdown.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_shutdown_is_idempotent() {
+        let controller = ShutdownController::new(std::time::Duration::from_secs(30));
+
+        assert_eq!(controller.phase(), ShutdownPhase::Running);
+        assert!(controller.request_shutdown());
+        assert_eq!(controller.phase(), ShutdownPhase::ShuttingDown);
+        assert!(!controller.request_shutdown());
+        assert_eq!(controller.phase(), ShutdownPhase::ShuttingDown);
+    }
+
+    #[test]
+    fn app_request_guard_rejects_after_shutdown_starts() {
+        let controller = ShutdownController::new(std::time::Duration::from_secs(30));
+        assert_eq!(controller.active_app_requests(), 0);
+
+        let guard = controller.try_enter_app_request().expect("running server accepts request");
+        assert_eq!(controller.active_app_requests(), 1);
+        drop(guard);
+        assert_eq!(controller.active_app_requests(), 0);
+
+        assert!(controller.request_shutdown());
+        assert!(controller.try_enter_app_request().is_none());
+    }
+
+    #[tokio::test]
+    async fn wait_for_shutdown_request_observes_request() {
+        let controller = ShutdownController::new(std::time::Duration::from_secs(30));
+        let waiter = controller.clone();
+
+        let task = tokio::spawn(async move {
+            waiter.wait_requested().await;
+            waiter.phase()
+        });
+
+        assert!(controller.request_shutdown());
+
+        let phase = task.await.expect("wait task");
+        assert_eq!(phase, ShutdownPhase::ShuttingDown);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p jazz-tools --features test shutdown::tests
+```
+
+Expected: FAIL because `crates/jazz-tools/src/server/shutdown.rs` does not exist and `ShutdownController` is undefined.
+
+- [ ] **Step 3: Implement the controller**
+
+Create `crates/jazz-tools/src/server/shutdown.rs`:
+
+```rust
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::Duration;
+
+use tokio::sync::{Notify, watch};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ShutdownPhase {
+    Running,
+    ShuttingDown,
+    DrainingConnections,
+    FlushingRuntime,
+    ClosingStorage,
+    StorageClosed,
+    Failed,
+}
+
+impl ShutdownPhase {
+    pub fn is_running(self) -> bool {
+        matches!(self, Self::Running)
+    }
+}
+
+#[derive(Clone)]
+pub struct ShutdownController {
+    inner: Arc<ShutdownInner>,
+}
+
+struct ShutdownInner {
+    requested: AtomicBool,
+    timeout: Duration,
+    phase_tx: watch::Sender<ShutdownPhase>,
+    drain_notify: Notify,
+    active_app_requests: AtomicUsize,
+    active_websockets: AtomicUsize,
+}
+
+pub struct ActiveAppRequestGuard {
+    controller: ShutdownController,
+}
+
+pub struct ActiveWebSocketGuard {
+    controller: ShutdownController,
+}
+
+impl ShutdownController {
+    pub fn new(timeout: Duration) -> Self {
+        let (phase_tx, _) = watch::channel(ShutdownPhase::Running);
+        Self {
+            inner: Arc::new(ShutdownInner {
+                requested: AtomicBool::new(false),
+                timeout,
+                phase_tx,
+                drain_notify: Notify::new(),
+                active_app_requests: AtomicUsize::new(0),
+                active_websockets: AtomicUsize::new(0),
+            }),
+        }
+    }
+
+    pub fn timeout(&self) -> Duration {
+        self.inner.timeout
+    }
+
+    pub fn phase(&self) -> ShutdownPhase {
+        *self.inner.phase_tx.borrow()
+    }
+
+    pub fn is_shutting_down(&self) -> bool {
+        !self.phase().is_running()
+    }
+
+    pub fn subscribe(&self) -> watch::Receiver<ShutdownPhase> {
+        self.inner.phase_tx.subscribe()
+    }
+
+    pub fn set_phase(&self, phase: ShutdownPhase) {
+        let _ = self.inner.phase_tx.send(phase);
+    }
+
+    pub fn request_shutdown(&self) -> bool {
+        let was_requested = self.inner.requested.swap(true, Ordering::SeqCst);
+        if !was_requested {
+            self.set_phase(ShutdownPhase::ShuttingDown);
+            self.inner.drain_notify.notify_waiters();
+        }
+        !was_requested
+    }
+
+    pub async fn wait_requested(&self) {
+        if self.inner.requested.load(Ordering::SeqCst) {
+            return;
+        }
+
+        let mut rx = self.subscribe();
+        while rx.borrow().is_running() {
+            if rx.changed().await.is_err() {
+                break;
+            }
+        }
+    }
+
+    pub fn try_enter_app_request(&self) -> Option<ActiveAppRequestGuard> {
+        if self.is_shutting_down() {
+            return None;
+        }
+
+        self.inner.active_app_requests.fetch_add(1, Ordering::SeqCst);
+        if self.is_shutting_down() {
+            self.inner.active_app_requests.fetch_sub(1, Ordering::SeqCst);
+            self.inner.drain_notify.notify_waiters();
+            return None;
+        }
+
+        Some(ActiveAppRequestGuard {
+            controller: self.clone(),
+        })
+    }
+
+    pub fn try_enter_websocket(&self) -> Option<ActiveWebSocketGuard> {
+        if self.is_shutting_down() {
+            return None;
+        }
+
+        self.inner.active_websockets.fetch_add(1, Ordering::SeqCst);
+        if self.is_shutting_down() {
+            self.inner.active_websockets.fetch_sub(1, Ordering::SeqCst);
+            self.inner.drain_notify.notify_waiters();
+            return None;
+        }
+
+        Some(ActiveWebSocketGuard {
+            controller: self.clone(),
+        })
+    }
+
+    pub fn active_app_requests(&self) -> usize {
+        self.inner.active_app_requests.load(Ordering::SeqCst)
+    }
+
+    pub fn active_websockets(&self) -> usize {
+        self.inner.active_websockets.load(Ordering::SeqCst)
+    }
+
+    pub async fn wait_for_websocket_drain(&self) -> bool {
+        let deadline = tokio::time::Instant::now() + self.timeout();
+        loop {
+            if self.active_websockets() == 0 {
+                return true;
+            }
+
+            let now = tokio::time::Instant::now();
+            if now >= deadline {
+                return false;
+            }
+
+            let sleep = tokio::time::sleep_until(deadline);
+            tokio::select! {
+                _ = self.inner.drain_notify.notified() => {}
+                _ = sleep => return self.active_websockets() == 0,
+            }
+        }
+    }
+
+    pub async fn wait_for_app_request_drain(&self) {
+        while self.active_app_requests() > 0 {
+            self.inner.drain_notify.notified().await;
+        }
+    }
+}
+
+impl Drop for ActiveAppRequestGuard {
+    fn drop(&mut self) {
+        self.controller
+            .inner
+            .active_app_requests
+            .fetch_sub(1, Ordering::SeqCst);
+        self.controller.inner.drain_notify.notify_waiters();
+    }
+}
+
+impl Drop for ActiveWebSocketGuard {
+    fn drop(&mut self) {
+        self.controller
+            .inner
+            .active_websockets
+            .fetch_sub(1, Ordering::SeqCst);
+        self.controller.inner.drain_notify.notify_waiters();
+    }
+}
+```
+
+- [ ] **Step 4: Wire the controller into server state and builder**
+
+In `crates/jazz-tools/src/server/mod.rs`, add the module and imports:
+
+```rust
+mod shutdown;
+
+pub use shutdown::{ShutdownController, ShutdownPhase};
+```
+
+Add this field to `ServerState`:
+
+```rust
+pub shutdown: ShutdownController,
+```
+
+In `crates/jazz-tools/src/server/builder.rs`, add a default:
+
+```rust
+const DEFAULT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
+```
+
+Add this field to `ServerBuilder`:
+
+```rust
+shutdown_timeout: Duration,
+```
+
+Initialize it in `ServerBuilder::new`:
+
+```rust
+shutdown_timeout: DEFAULT_SHUTDOWN_TIMEOUT,
+```
+
+Add this builder method:
+
+```rust
+pub fn with_shutdown_timeout(mut self, timeout: Duration) -> Self {
+    self.shutdown_timeout = timeout;
+    self
+}
+```
+
+Set the field when constructing `ServerState`:
+
+```rust
+shutdown: crate::server::ShutdownController::new(self.shutdown_timeout),
+```
+
+- [ ] **Step 5: Run tests to verify green**
+
+Run:
+
+```bash
+cargo test -p jazz-tools --features test shutdown::tests
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/jazz-tools/src/server/shutdown.rs crates/jazz-tools/src/server/mod.rs crates/jazz-tools/src/server/builder.rs
+git commit -m "feat: add server shutdown controller"
+```
+
+---
+
+### Task 2: Add Internal Shutdown and Health Contract
+
+**Files:**
+
+- Modify: `crates/jazz-tools/src/server/routes/http.rs`
+- Modify: `crates/jazz-tools/src/server/routes/mod.rs`
+- Test: `crates/jazz-tools/src/server/routes/mod.rs`
+
+- [ ] **Step 1: Write failing route tests**
+
+Add these helpers inside the existing `#[cfg(test)] mod tests` in `crates/jazz-tools/src/server/routes/mod.rs`:
+
+```rust
+async fn post_internal_shutdown(
+    app: axum::Router,
+    admin_secret: Option<&str>,
+) -> axum::response::Response {
+    let mut builder = axum::http::Request::builder()
+        .method("POST")
+        .uri("/internal/shutdown");
+    if let Some(admin_secret) = admin_secret {
+        builder = builder.header("X-Jazz-Admin-Secret", admin_secret);
+    }
+    app.oneshot(builder.body(axum::body::Body::empty()).unwrap())
+        .await
+        .unwrap()
+}
+```
+
+Add these tests:
+
+```rust
+#[tokio::test]
+async fn internal_shutdown_requires_configured_admin_secret() {
+    let auth_config = AuthConfig {
+        admin_secret: None,
+        allow_local_first_auth: true,
+        ..Default::default()
+    };
+    let state = ServerBuilder::new(AppId::from_name("test-app"))
+        .with_auth_config(auth_config)
+        .with_storage(StorageBackend::InMemory)
+        .build()
+        .await
+        .expect("build server without admin secret")
+        .state;
+
+    let response = post_internal_shutdown(make_test_router(state), Some("admin-secret")).await;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn internal_shutdown_requires_admin_secret_header() {
+    let state = make_state_with_schema(Schema::new()).await;
+    let response = post_internal_shutdown(make_test_router(state), None).await;
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn internal_shutdown_rejects_wrong_admin_secret() {
+    let state = make_state_with_schema(Schema::new()).await;
+    let response = post_internal_shutdown(make_test_router(state), Some("wrong-secret")).await;
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn internal_shutdown_accepts_valid_admin_secret_and_marks_health_unhealthy() {
+    let state = make_state_with_schema(Schema::new()).await;
+    let app = make_test_router(state.clone());
+
+    let response = post_internal_shutdown(app.clone(), Some("admin-secret")).await;
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let body = body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("shutdown body");
+    let json: Value = serde_json::from_slice(&body).expect("shutdown json");
+    assert_eq!(json["status"].as_str(), Some("shutting_down"));
+
+    let repeated = post_internal_shutdown(app.clone(), Some("admin-secret")).await;
+    assert_eq!(repeated.status(), StatusCode::ACCEPTED);
+    let repeated_body = body::to_bytes(repeated.into_body(), usize::MAX)
+        .await
+        .expect("repeated shutdown body");
+    let repeated_json: Value = serde_json::from_slice(&repeated_body).expect("repeated json");
+    assert_eq!(repeated_json["status"].as_str(), Some("already_shutting_down"));
+
+    let health = app
+        .oneshot(
+            axum::http::Request::builder()
+                .uri("/health")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(health.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let health_body = body::to_bytes(health.into_body(), usize::MAX)
+        .await
+        .expect("health body");
+    let health_json: Value = serde_json::from_slice(&health_body).expect("health json");
+    assert_eq!(health_json["status"].as_str(), Some("shutting_down"));
+    assert_eq!(health_json["phase"].as_str(), Some("shutting_down"));
+
+    assert_eq!(state.shutdown.phase(), crate::server::ShutdownPhase::ShuttingDown);
+}
+```
+
+- [ ] **Step 2: Run tests to verify red**
+
+Run:
+
+```bash
+cargo test -p jazz-tools --features test internal_shutdown
+```
+
+Expected: FAIL because `/internal/shutdown` is not routed and `/health` is not state-aware.
+
+- [ ] **Step 3: Implement route DTOs and handlers**
+
+In `crates/jazz-tools/src/server/routes/http.rs`, add:
+
+```rust
+#[derive(Debug, Serialize)]
+pub(super) struct ShutdownResponse {
+    status: &'static str,
+}
+```
+
+Add this handler:
+
+```rust
+pub(super) async fn internal_shutdown_handler(
+    State(state): State<Arc<ServerState>>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    let admin_secret = headers
+        .get("X-Jazz-Admin-Secret")
+        .and_then(|v| v.to_str().ok());
+
+    match validate_admin_secret(admin_secret, &state.auth_config) {
+        Ok(()) => {}
+        Err((status, msg)) => {
+            return (status, Json(ErrorResponse::unauthorized(msg))).into_response();
+        }
+    }
+
+    let first_request = state.shutdown.request_shutdown();
+    let status = if first_request {
+        "shutting_down"
+    } else {
+        "already_shutting_down"
+    };
+
+    (StatusCode::ACCEPTED, Json(ShutdownResponse { status })).into_response()
+}
+```
+
+Replace `health_handler` with:
+
+```rust
+pub(super) async fn health_handler(State(state): State<Arc<ServerState>>) -> impl IntoResponse {
+    let phase = state.shutdown.phase();
+    if phase.is_running() {
+        return Json(serde_json::json!({
+            "status": "healthy"
+        }))
+        .into_response();
+    }
+
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(serde_json::json!({
+            "status": "shutting_down",
+            "phase": phase
+        })),
+    )
+        .into_response()
+}
+```
+
+- [ ] **Step 4: Route `/internal/shutdown`**
+
+In `crates/jazz-tools/src/server/routes/mod.rs`, include the handler in the existing grouped `use http` import:
+
+```rust
+internal_shutdown_handler,
+```
+
+Add the route to the root router before `.nest(&app_route_prefix, traced_routes)`:
+
+```rust
+.route("/internal/shutdown", post(internal_shutdown_handler))
+```
+
+- [ ] **Step 5: Run tests to verify green**
+
+Run:
+
+```bash
+cargo test -p jazz-tools --features test internal_shutdown
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/jazz-tools/src/server/routes/http.rs crates/jazz-tools/src/server/routes/mod.rs
+git commit -m "feat: add internal shutdown endpoint"
+```
+
+---
+
+### Task 3: Gate App-Scoped Requests During Shutdown
+
+**Files:**
+
+- Modify: `crates/jazz-tools/src/server/routes/mod.rs`
+- Test: `crates/jazz-tools/src/server/routes/mod.rs`
+
+- [ ] **Step 1: Write failing route-gating test**
+
+Add this test to `crates/jazz-tools/src/server/routes/mod.rs`:
+
+```rust
+#[tokio::test]
+async fn shutdown_rejects_new_app_scoped_http_requests_but_keeps_internal_routes_available() {
+    let state = make_state_with_schema(Schema::new()).await;
+    let app = make_test_router(state);
+
+    let shutdown = post_internal_shutdown(app.clone(), Some("admin-secret")).await;
+    assert_eq!(shutdown.status(), StatusCode::ACCEPTED);
+
+    let app_scoped = app
+        .clone()
+        .oneshot(
+            axum::http::Request::builder()
+                .uri(test_app_route("/schemas"))
+                .header("X-Jazz-Admin-Secret", "admin-secret")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(app_scoped.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+    let repeated = post_internal_shutdown(app.clone(), Some("admin-secret")).await;
+    assert_eq!(repeated.status(), StatusCode::ACCEPTED);
+
+    let health = app
+        .oneshot(
+            axum::http::Request::builder()
+                .uri("/health")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(health.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+```
+
+- [ ] **Step 2: Run test to verify red**
+
+Run:
+
+```bash
+cargo test -p jazz-tools --features test shutdown_rejects_new_app_scoped_http_requests_but_keeps_internal_routes_available
+```
+
+Expected: FAIL because app-scoped routes still execute after shutdown starts.
+
+- [ ] **Step 3: Implement app-scoped gate middleware**
+
+In `crates/jazz-tools/src/server/routes/mod.rs`, add imports:
+
+```rust
+use axum::{
+    Router,
+    body::Body,
+    extract::State,
+    http::{Request, StatusCode},
+    middleware::{self, Next},
+    response::{IntoResponse, Response},
+    routing::{get, post},
+};
+```
+
+Add this middleware function:
+
+```rust
+async fn app_shutdown_gate(
+    State(state): State<Arc<ServerState>>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    let Some(_guard) = state.shutdown.try_enter_app_request() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            axum::Json(crate::jazz_transport::ErrorResponse::internal(
+                "server is shutting down".to_string(),
+            )),
+        )
+            .into_response();
+    };
+
+    next.run(request).await
+}
+```
+
+Apply it only to the app-scoped router:
+
+```rust
+let traced_routes = Router::new()
+    .route("/ws", axum::routing::any(ws_handler))
+    .route("/schema/:hash", get(schema_handler))
+    .route("/schemas", get(schema_hashes_handler))
+    .nest("/admin", admin_routes)
+    .route_layer(middleware::from_fn_with_state(
+        state.clone(),
+        app_shutdown_gate,
+    ))
+    .layer(TraceLayer::new_for_http());
+```
+
+- [ ] **Step 4: Run test to verify green**
+
+Run:
+
+```bash
+cargo test -p jazz-tools --features test shutdown_rejects_new_app_scoped_http_requests_but_keeps_internal_routes_available
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/jazz-tools/src/server/routes/mod.rs
+git commit -m "feat: gate app routes during shutdown"
+```
+
+---
+
+### Task 4: Close Active WebSockets on Shutdown
+
+**Files:**
+
+- Modify: `crates/jazz-tools/src/server/routes/websocket.rs`
+- Test: `crates/jazz-tools/src/server/routes/mod.rs`
+
+- [ ] **Step 1: Write failing WebSocket shutdown test**
+
+Add this test to `crates/jazz-tools/src/server/routes/mod.rs` near the existing WebSocket route tests:
+
+```rust
+#[tokio::test(flavor = "current_thread")]
+async fn shutdown_closes_active_websocket_with_service_restart_code() {
+    let state = make_sync_test_state("test-backend-secret").await;
+    let app = create_router(state.clone());
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind ws listener");
+    let addr = listener.local_addr().expect("ws local addr");
+    let server_task = tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve ws app");
+    });
+
+    let ws_url = format!("ws://{addr}{}", test_app_route("/ws"));
+    let (mut ws, _) = connect_async(&ws_url).await.expect("connect ws");
+
+    let handshake = crate::transport_manager::AuthHandshake {
+        sync_protocol_version: crate::transport_manager::SYNC_PROTOCOL_VERSION,
+        client_id: ClientId::new().to_string(),
+        auth: crate::transport_manager::AuthConfig {
+            backend_secret: Some("test-backend-secret".to_string()),
+            ..Default::default()
+        },
+        catalogue_state_hash: None,
+        declared_schema_hash: None,
+    };
+    let payload = serde_json::to_vec(&handshake).expect("serialize handshake");
+    ws.send(WsMessage::Binary(
+        crate::transport_manager::frame_encode(&payload).into(),
+    ))
+    .await
+    .expect("send handshake");
+
+    let connected = tokio::time::timeout(Duration::from_secs(5), ws.next())
+        .await
+        .expect("wait for ConnectedResponse")
+        .expect("ws frame")
+        .expect("ws result");
+    assert!(matches!(connected, WsMessage::Binary(_)));
+
+    assert_eq!(state.shutdown.active_websockets(), 1);
+    assert!(state.shutdown.request_shutdown());
+
+    let close_frame = tokio::time::timeout(Duration::from_secs(5), ws.next())
+        .await
+        .expect("wait for close")
+        .expect("ws frame")
+        .expect("ws result");
+    let WsMessage::Close(Some(close)) = close_frame else {
+        panic!("expected close frame, got {close_frame:?}");
+    };
+    assert_eq!(
+        close.code,
+        tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode::Restart
+    );
+    assert_eq!(close.reason.as_ref(), "server shutting down");
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while state.shutdown.active_websockets() != 0 {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("websocket cleanup");
+
+    server_task.abort();
+}
+```
+
+- [ ] **Step 2: Run test to verify red**
+
+Run:
+
+```bash
+cargo test -p jazz-tools --features test shutdown_closes_active_websocket_with_service_restart_code
+```
+
+Expected: FAIL because active WebSocket loops do not subscribe to shutdown.
+
+- [ ] **Step 3: Implement shutdown rejection and active socket close**
+
+In `crates/jazz-tools/src/server/routes/websocket.rs`, change `ws_handler`:
+
+```rust
+pub(super) async fn ws_handler(
+    ws: WebSocketUpgrade,
+    State(state): State<Arc<ServerState>>,
+    headers: HeaderMap,
+) -> Response {
+    if state.shutdown.is_shutting_down() {
+        return (
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            axum::Json(crate::jazz_transport::ErrorResponse::internal(
+                "server is shutting down".to_string(),
+            )),
+        )
+            .into_response();
+    }
+
+    ws.on_upgrade(move |socket| handle_ws_connection(socket, state, headers))
+}
+```
+
+Add the missing import:
+
+```rust
+use axum::response::IntoResponse;
+```
+
+After authentication succeeds but before registering the connection, enter the WebSocket guard:
+
+```rust
+let Some(_websocket_guard) = state.shutdown.try_enter_websocket() else {
+    close_ws_for_shutdown(&mut socket).await;
+    return;
+};
+```
+
+Add this helper:
+
+```rust
+async fn close_ws_for_shutdown(socket: &mut WebSocket) {
+    let _ = socket
+        .send(Message::Close(Some(CloseFrame {
+            code: close_code::RESTART,
+            reason: "server shutting down".into(),
+        })))
+        .await;
+}
+```
+
+Before the bidirectional loop, subscribe to shutdown:
+
+```rust
+let mut shutdown_rx = state.shutdown.subscribe();
+```
+
+Add this branch to the `tokio::select!` loop:
+
+```rust
+changed = shutdown_rx.changed() => {
+    if changed.is_ok() && state.shutdown.is_shutting_down() {
+        close_ws_for_shutdown(&mut socket).await;
+        break;
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify green**
+
+Run:
+
+```bash
+cargo test -p jazz-tools --features test shutdown_closes_active_websocket_with_service_restart_code
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/jazz-tools/src/server/routes/websocket.rs crates/jazz-tools/src/server/routes/mod.rs
+git commit -m "feat: close websockets during shutdown"
+```
+
+---
+
+### Task 5: Finalize Runtime and Storage from the Server Lifecycle
+
+**Files:**
+
+- Modify: `crates/jazz-tools/src/server/mod.rs`
+- Modify: `crates/jazz-tools/src/server/hosted.rs`
+- Modify: `crates/jazz-tools/src/commands/server.rs`
+- Test: `crates/jazz-tools/src/server/testing.rs`
+
+- [ ] **Step 1: Write failing hosted-server shutdown test**
+
+Add this test to `crates/jazz-tools/src/server/testing.rs`:
+
+```rust
+#[tokio::test]
+async fn internal_shutdown_stops_hosted_server() {
+    let server = TestingServer::start().await;
+    let base_url = server.base_url();
+    let admin_secret = server.admin_secret().to_string();
+    let client = reqwest::Client::new();
+
+    let response = client
+        .post(format!("{base_url}/internal/shutdown"))
+        .header("X-Jazz-Admin-Secret", admin_secret)
+        .send()
+        .await
+        .expect("shutdown request");
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+    let mut saw_unavailable = false;
+    for _ in 0..80 {
+        match client.get(format!("{base_url}/health")).send().await {
+            Ok(response) if response.status() == StatusCode::SERVICE_UNAVAILABLE => {
+                saw_unavailable = true;
+            }
+            Err(_) if saw_unavailable => return,
+            _ => {}
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    panic!("hosted server did not stop after internal shutdown");
+}
+```
+
+- [ ] **Step 2: Run test to verify red**
+
+Run:
+
+```bash
+cargo test -p jazz-tools --features test internal_shutdown_stops_hosted_server
+```
+
+Expected: FAIL because shutdown request changes health but does not stop the hosted Axum server.
+
+- [ ] **Step 3: Add server finalization helper**
+
+In `crates/jazz-tools/src/server/mod.rs`, add:
+
+```rust
+impl ServerState {
+    pub async fn run_shutdown_finalization(&self) {
+        self.shutdown.set_phase(ShutdownPhase::DrainingConnections);
+        #[cfg(feature = "transport-websocket")]
+        self.runtime.disconnect();
+
+        let websockets_drained = self.shutdown.wait_for_websocket_drain().await;
+        if !websockets_drained {
+            tracing::warn!(
+                active_websockets = self.shutdown.active_websockets(),
+                "shutdown websocket drain timed out"
+            );
+        }
+
+        self.shutdown.wait_for_app_request_drain().await;
+
+        self.shutdown.set_phase(ShutdownPhase::FlushingRuntime);
+        if let Err(error) = self.runtime.flush().await {
+            tracing::error!(%error, "shutdown runtime flush failed");
+            self.shutdown.set_phase(ShutdownPhase::Failed);
+            return;
+        }
+
+        self.shutdown.set_phase(ShutdownPhase::ClosingStorage);
+        let storage_result = self.runtime.with_storage(|storage| {
+            storage.flush();
+            storage.flush_wal();
+            storage.close()
+        });
+
+        match storage_result {
+            Ok(Ok(())) => {
+                self.shutdown.set_phase(ShutdownPhase::StorageClosed);
+            }
+            Ok(Err(error)) => {
+                tracing::error!(%error, "shutdown storage close failed");
+                self.shutdown.set_phase(ShutdownPhase::Failed);
+            }
+            Err(error) => {
+                tracing::error!(%error, "shutdown storage lock failed");
+                self.shutdown.set_phase(ShutdownPhase::Failed);
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Drive shutdown from `HostedServer`**
+
+In `crates/jazz-tools/src/server/hosted.rs`, add a field:
+
+```rust
+shutdown_task: Option<JoinHandle<()>>,
+```
+
+Remove the old field:
+
+```rust
+shutdown_tx: Option<oneshot::Sender<()>>,
+```
+
+In `HostedServer::start`, replace the existing `shutdown_tx` behavior with a serve signal and a shutdown driver:
+
+```rust
+let (serve_shutdown_tx, serve_shutdown_rx) = oneshot::channel();
+let shutdown_state = built.state.clone();
+let shutdown_task = tokio::spawn(async move {
+    shutdown_state.shutdown.wait_requested().await;
+    shutdown_state.run_shutdown_finalization().await;
+    let _ = serve_shutdown_tx.send(());
+});
+let task = tokio::spawn(async move {
+    axum::serve(listener, built.app)
+        .with_graceful_shutdown(async {
+            let _ = serve_shutdown_rx.await;
+        })
+        .await
+        .expect("serve jazz server");
+});
+```
+
+Update `HostedServer::shutdown`:
+
+```rust
+pub async fn shutdown(&mut self) {
+    self.state.shutdown.request_shutdown();
+
+    if let Some(mut shutdown_task) = self.shutdown_task.take()
+        && tokio::time::timeout(Duration::from_secs(5), &mut shutdown_task)
+            .await
+            .is_err()
+    {
+        shutdown_task.abort();
+        let _ = shutdown_task.await;
+    }
+
+    if let Some(mut task) = self.task.take()
+        && tokio::time::timeout(Duration::from_millis(500), &mut task)
+            .await
+            .is_err()
+    {
+        task.abort();
+        let _ = task.await;
+    }
+}
+```
+
+Update `Drop` to request shutdown, abort `shutdown_task`, and abort `task`:
+
+```rust
+fn drop(&mut self) {
+    self.state.shutdown.request_shutdown();
+    if let Some(task) = self.shutdown_task.take() {
+        task.abort();
+    }
+    if let Some(task) = self.task.take() {
+        task.abort();
+    }
+}
+```
+
+- [ ] **Step 5: Drive shutdown from the CLI server command**
+
+In `crates/jazz-tools/src/commands/server.rs`, replace the final `axum::serve` call:
+
+```rust
+let state = built.state.clone();
+let (serve_shutdown_tx, serve_shutdown_rx) = tokio::sync::oneshot::channel();
+let shutdown_task = tokio::spawn(async move {
+    state.shutdown.wait_requested().await;
+    state.run_shutdown_finalization().await;
+    let _ = serve_shutdown_tx.send(());
+});
+
+let serve_result = axum::serve(listener, built.app)
+    .with_graceful_shutdown(async {
+        let _ = serve_shutdown_rx.await;
+    })
+    .await;
+
+shutdown_task.abort();
+let _ = shutdown_task.await;
+serve_result?;
+```
+
+- [ ] **Step 6: Run hosted shutdown test to verify green**
+
+Run:
+
+```bash
+cargo test -p jazz-tools --features test internal_shutdown_stops_hosted_server
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/jazz-tools/src/server/mod.rs crates/jazz-tools/src/server/hosted.rs crates/jazz-tools/src/commands/server.rs crates/jazz-tools/src/server/testing.rs
+git commit -m "feat: finalize server shutdown lifecycle"
+```
+
+---
+
+### Task 6: Add Shutdown Timeout CLI and Env Configuration
+
+**Files:**
+
+- Modify: `crates/jazz-tools/src/main.rs`
+- Modify: `crates/jazz-tools/src/commands/server.rs`
+- Test: `crates/jazz-tools/src/main.rs`
+
+- [ ] **Step 1: Write failing CLI parse test**
+
+Add this test to `crates/jazz-tools/src/main.rs`:
+
+```rust
+#[test]
+fn server_command_parses_shutdown_timeout_secs() {
+    let cli = Cli::try_parse_from([
+        "jazz-tools",
+        "server",
+        "test-app",
+        "--shutdown-timeout-secs",
+        "7",
+    ])
+    .expect("server command should parse");
+
+    match cli.command {
+        Commands::Server {
+            shutdown_timeout_secs,
+            ..
+        } => assert_eq!(shutdown_timeout_secs, 7),
+        _ => panic!("expected server command"),
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify red**
+
+Run:
+
+```bash
+cargo test -p jazz-tools --features test server_command_parses_shutdown_timeout_secs
+```
+
+Expected: FAIL because the CLI field does not exist.
+
+- [ ] **Step 3: Add CLI argument and pass it through**
+
+In the `Commands::Server` variant in `crates/jazz-tools/src/main.rs`, add:
+
+```rust
+/// Graceful shutdown network-drain timeout in seconds.
+#[arg(long, env = "JAZZ_SHUTDOWN_TIMEOUT_SECS", default_value_t = 30)]
+shutdown_timeout_secs: u64,
+```
+
+In the match arm destructuring, include:
+
+```rust
+shutdown_timeout_secs,
+```
+
+Pass it to `commands::server::run`:
+
+```rust
+std::time::Duration::from_secs(shutdown_timeout_secs),
+```
+
+In `crates/jazz-tools/src/commands/server.rs`, import `Duration` and update the signature:
+
+```rust
+use std::time::Duration;
+
+pub async fn run(
+    app_id_str: &str,
+    port: u16,
+    data_dir: &str,
+    in_memory: bool,
+    auth_config: AuthConfig,
+    upstream_url: Option<String>,
+    bound_port_file: Option<String>,
+    shutdown_timeout: Duration,
+) -> Result<(), Box<dyn std::error::Error>> {
+```
+
+Apply it to the builder:
+
+```rust
+let builder = ServerBuilder::new(app_id)
+    .with_auth_config(auth_config)
+    .with_shutdown_timeout(shutdown_timeout);
+```
+
+- [ ] **Step 4: Run CLI test to verify green**
+
+Run:
+
+```bash
+cargo test -p jazz-tools --features test server_command_parses_shutdown_timeout_secs
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/jazz-tools/src/main.rs crates/jazz-tools/src/commands/server.rs
+git commit -m "feat: configure server shutdown timeout"
+```
+
+---
+
+### Task 7: Full Verification
+
+**Files:**
+
+- No code changes expected.
+
+- [ ] **Step 1: Run focused shutdown tests**
+
+Run:
+
+```bash
+cargo test -p jazz-tools --features test internal_shutdown
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run WebSocket shutdown test**
+
+Run:
+
+```bash
+cargo test -p jazz-tools --features test shutdown_closes_active_websocket_with_service_restart_code
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run hosted lifecycle test**
+
+Run:
+
+```bash
+cargo test -p jazz-tools --features test internal_shutdown_stops_hosted_server
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run server module tests**
+
+Run:
+
+```bash
+cargo test -p jazz-tools --features test server::
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run formatting and lint hooks**
+
+Run:
+
+```bash
+pnpm exec lefthook run pre-commit
+```
+
+Expected: PASS or only documented skips for unrelated file types.
+
+- [ ] **Step 6: Final commit if verification required edits**
+
+If verification forced any edits, commit them:
+
+```bash
+git add crates/jazz-tools/src docs/superpowers/plans/2026-05-17-internal-server-shutdown.md
+git commit -m "test: verify internal server shutdown"
+```

--- a/docs/superpowers/specs/2026-05-17-internal-shutdown-design.md
+++ b/docs/superpowers/specs/2026-05-17-internal-shutdown-design.md
@@ -1,0 +1,181 @@
+# Internal Server Shutdown Design
+
+## Goal
+
+Add an internal server shutdown API that lets infrastructure request a controlled process shutdown before a container is terminated.
+
+The first trigger is `POST /internal/shutdown`, authenticated with the existing admin secret. The shutdown mechanism itself should be independent of HTTP so a later `SIGTERM` handler can reuse the same lifecycle.
+
+## Non-Goals
+
+- Add a polling status endpoint.
+- Wait for `/internal/shutdown` to complete all shutdown work before responding.
+- Guarantee upstream replication before exit. The required durability guarantee is local RocksDB persistence.
+- Introduce a second administrative secret or a separate auth system.
+
+## Existing Context
+
+The production `jazz-tools server` command currently serves Axum directly and has no signal or shutdown hook. Test and dev hosted servers already perform the important storage sequence:
+
+1. `runtime.flush().await`
+2. stop the Axum server task
+3. `storage.flush()`
+4. `storage.flush_wal()`
+5. `storage.close()`
+
+RocksDB storage already implements `flush`, `flush_wal(true)`, and `close`. WebSocket handlers already register active connections in `ServerState.connections` and `ConnectionEventHub`, which gives us a natural place to reject new connections and close existing ones.
+
+## External Contract
+
+### `POST /internal/shutdown`
+
+Authentication:
+
+- Requires `X-Jazz-Admin-Secret`.
+- Uses the existing `validate_admin_secret` behavior.
+- If no admin secret is configured, returns `403`.
+- If the header is missing or wrong, returns the existing `401` admin-auth shape.
+
+Response:
+
+- Returns `202 Accepted` immediately after the shutdown request is accepted.
+- Does not wait for WebSocket drain, runtime flush, RocksDB flush, or process exit.
+- Is idempotent. A repeated valid call while shutdown is already in progress returns `202 Accepted` with an `already_shutting_down` status.
+
+Response body:
+
+```json
+{
+  "status": "shutting_down"
+}
+```
+
+Repeated valid call response body:
+
+```json
+{
+  "status": "already_shutting_down"
+}
+```
+
+### `GET /health`
+
+`/health` remains the external shutdown observation mechanism.
+
+- Before shutdown: `200 OK`, `{ "status": "healthy" }`
+- After shutdown is accepted and while work is still in progress: `503 Service Unavailable`, with `status: "shutting_down"` and a `phase` value such as `draining_connections`, `flushing_runtime`, or `closing_storage`.
+- After storage is closed, the server asks Axum to stop. Pollers then observe connection failure once the listener exits.
+
+This lets infrastructure call `POST /internal/shutdown`, then poll `/health`. `503` means shutdown is in progress. Connection failure means shutdown finalization reached the point where the listener has been stopped.
+
+## Lifecycle State
+
+Add a shared shutdown controller owned by `ServerState`.
+
+State phases:
+
+- `Running`
+- `ShuttingDown`
+- `DrainingConnections`
+- `FlushingRuntime`
+- `ClosingStorage`
+- `StorageClosed`
+
+Required controller behavior:
+
+- Phase changes are observable by handlers through a cheap read.
+- WebSocket handlers can subscribe to a shutdown notification.
+- The server command can wait for shutdown completion before stopping Axum.
+- The first caller wins. Later callers see the already-started state and do not spawn duplicate shutdown tasks.
+
+The default graceful budget is `30s`, configurable with `JAZZ_SHUTDOWN_TIMEOUT_SECS` and a `--shutdown-timeout-secs` CLI option.
+
+## Shutdown Sequence
+
+When `/internal/shutdown` accepts a valid request:
+
+1. Atomically transition from `Running` to `ShuttingDown`.
+2. Return `202 Accepted` to the caller.
+3. Mark `/health` as unhealthy.
+4. Reject new app-scoped HTTP and WebSocket requests with `503 Service Unavailable`.
+5. Notify active WebSocket handlers to close.
+6. Active WebSocket handlers send a close frame with a service-restart reason and then run normal cleanup.
+7. If this server has an upstream WebSocket transport, disconnect it so no new upstream traffic is accepted during local shutdown.
+8. Wait for active app requests and WebSocket handlers to drain.
+9. Run `runtime.flush().await` to drain scheduled runtime work.
+10. Run storage finalization through `runtime.with_storage`: `flush()`, `flush_wal()`, then `close()`.
+11. Transition to `StorageClosed`.
+12. Notify the server command to stop Axum gracefully.
+
+The configured graceful budget applies to network drain. WebSocket handlers are expected to close locally without waiting for client acknowledgement. If app-scoped HTTP handlers are still active when the budget expires, the server logs the active counts and keeps `/health` at `503`; it does not close storage underneath active handlers. The container's external termination grace period remains the final backstop for a genuinely stuck handler.
+
+## Request Gating
+
+After shutdown starts:
+
+- `/health` remains available and reports unhealthy progress.
+- `POST /internal/shutdown` remains available and idempotent.
+- App-scoped routes under `/apps/:app_id/...` return `503`.
+- New WebSocket handshakes are rejected even if they slip past route-level gating.
+
+The app-scoped gate should also track active app HTTP requests so shutdown can wait for short in-flight admin/schema requests before closing storage. WebSocket handlers are tracked separately through the existing connection state and shutdown notification.
+
+## WebSocket Behavior
+
+Existing connections should not be allowed to keep the process alive indefinitely.
+
+The WebSocket loop adds a shutdown branch to its `tokio::select!`:
+
+- on shutdown notification, send a close frame best-effort
+- break the loop
+- run existing `ws_cleanup`
+
+The close reason should be stable and human-readable, for example `server shutting down`. Use WebSocket close code `1012` (service restart).
+
+Inbound frames received after shutdown starts should not be processed. The shutdown branch wins by exiting the loop.
+
+## Storage Durability
+
+The durability sequence is:
+
+1. `runtime.flush().await`
+2. `storage.flush()`
+3. `storage.flush_wal()`
+4. `storage.close()`
+
+For RocksDB this forces memtable flush, synchronous WAL flush, and release of DB resources. `close()` is idempotent today and should remain safe if tests call it after shutdown.
+
+Storage finalization errors should be logged and surfaced in the shutdown phase state. The server should still stop serving after a failed close attempt, because retrying indefinitely inside a terminating container is less useful than making the failure visible to logs and orchestrator restart behavior.
+
+## Server Command Integration
+
+`commands::server::run` should switch from plain `axum::serve(listener, built.app).await?` to a controlled lifecycle:
+
+1. build server state and router
+2. serve Axum normally
+3. wait for the shutdown controller's completion signal
+4. stop Axum with `with_graceful_shutdown`
+5. return from `run`, letting the process exit normally
+
+The shutdown finalization task should be owned by the server command, not by a request handler. The handler only requests shutdown. This keeps shutdown work alive even after the HTTP response is returned.
+
+## Testing Strategy
+
+Use TDD and prefer integration-style server tests.
+
+Tests to cover:
+
+- `POST /internal/shutdown` without admin secret configured returns `403`.
+- `POST /internal/shutdown` without a header returns `401`.
+- `POST /internal/shutdown` with a wrong admin secret returns `401`.
+- `POST /internal/shutdown` with a valid admin secret returns `202`.
+- A repeated valid shutdown call returns `202` and does not start a second finalization task.
+- `/health` returns `503` after shutdown starts.
+- New app-scoped HTTP requests return `503` after shutdown starts.
+- A WebSocket connected before shutdown receives a close and is cleaned up.
+- Runtime flush and storage flush/close are called in order by using a test storage backend or test-only instrumentation.
+- `jazz-tools server` stops after `/internal/shutdown` and the health endpoint eventually becomes unavailable.
+
+## Future Extension
+
+Add `SIGTERM` handling as another caller of the same shutdown controller. It should follow the same phases and durability path, with no separate signal-only implementation.


### PR DESCRIPTION
## Summary
- Adds an internal HTTP shutdown path gated by admin secret
- Coordinates graceful shutdown across websocket drain, runtime flush, and storage close
- Propagates shutdown failures through server, client, WASM, NAPI, and RN bindings
- Adds coverage for shutdown lifecycle, websocket gating, and storage flush failure handling

## Testing
- `cargo test -p jazz-tools --features test --lib server::`
- `cargo test -p jazz-tools --features test --lib storage_flush`
- `cargo test -p jazz-tools --features test --lib runtime_tokio::tests::flush`
- `cargo test -p jazz-tools --features test --bin jazz-tools`
- `git diff --check`