### PR TITLE
Use jemalloc for Rust and RocksDB allocators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1804,7 +1804,6 @@ dependencies = [
  "jsonschema",
  "jsonwebtoken",
  "lz4_flex",
- "mimalloc",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-stdout",
@@ -1827,6 +1826,7 @@ dependencies = [
  "smolset",
  "tempfile",
  "thiserror 1.0.69",
+ "tikv-jemallocator",
  "tokio",
  "tokio-tungstenite",
  "tower",
@@ -1995,15 +1995,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "libmimalloc-sys"
-version = "0.1.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "libmimalloc-sys2"
 version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2108,15 +2099,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "mimalloc"
-version = "0.1.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
-dependencies = [
- "libmimalloc-sys",
-]
 
 [[package]]
 name = "mimalloc-safe"
@@ -3747,6 +3729,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3822,12 +3814,12 @@ dependencies = [
  "http-body-util",
  "jazz-tools",
  "jsonwebtoken",
- "mimalloc",
  "reqwest",
  "reqwest-eventsource",
  "serde",
  "serde_json",
  "tempfile",
+ "tikv-jemallocator",
  "tokio",
  "tokio-stream",
  "tower",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3115,6 +3115,7 @@ dependencies = [
  "libc",
  "libz-sys",
  "lz4-sys",
+ "tikv-jemalloc-sys",
  "zstd-sys",
 ]
 
@@ -3733,6 +3734,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]

--- a/crates/jazz-tools/Cargo.toml
+++ b/crates/jazz-tools/Cargo.toml
@@ -77,7 +77,7 @@ ahash = "0.8"
 sha2 = "0.10"
 
 tokio = { version = "1", features = ["full"], optional = true }
-rocksdb = { package = "rust-rocksdb", version = "0.48.0", default-features = false, features = ["lz4", "zstd"], optional = true }
+rocksdb = { package = "rust-rocksdb", version = "0.48.0", default-features = false, features = ["jemalloc", "lz4", "zstd"], optional = true }
 rusqlite = { version = "0.34", features = ["bundled"], optional = true }
 
 axum = { version = "0.7", features = ["ws"], optional = true }

--- a/crates/jazz-tools/Cargo.toml
+++ b/crates/jazz-tools/Cargo.toml
@@ -41,7 +41,7 @@ server = [
   "dep:bytes",
   "dep:reqwest",
 ]
-cli = ["server", "rocksdb", "dep:clap", "dep:mimalloc"]
+cli = ["server", "rocksdb", "dep:clap", "dep:tikv-jemallocator"]
 test-utils = ["server", "client", "sqlite"]
 test = ["test-utils", "cli"]
 otel-core = [
@@ -101,7 +101,7 @@ async-stream = { version = "0.3", optional = true }
 jsonwebtoken = { version = "9", optional = true }
 base64 = "0.22"
 ed25519-dalek = { version = "2", features = ["rand_core"] }
-mimalloc = { version = "0.1", default-features = false, optional = true }
+tikv-jemallocator = { version = "0.6", default-features = false, optional = true }
 
 reqwest = { version = "0.12", default-features = false, features = [
   "json",

--- a/crates/jazz-tools/src/main.rs
+++ b/crates/jazz-tools/src/main.rs
@@ -7,12 +7,12 @@
 //! jazz-tools server <APP_ID> [--port 1625] [--data-dir ./data] [--in-memory]
 //! ```
 
-// mimalloc replaces the system allocator for ~12-26% throughput on the server's
-// allocation-heavy paths (query/insert/observer). The global allocator is a
-// per-binary choice; library code in `jazz-tools` does not declare one so that
-// consumers (jazz-napi, todo-server, third-party embedders) keep theirs.
+// jemalloc replaces the system allocator on the server's allocation-heavy paths
+// (query/insert/observer). The global allocator is a per-binary choice; library
+// code in `jazz-tools` does not declare one so that consumers (jazz-napi,
+// todo-server, third-party embedders) keep theirs.
 #[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 mod commands;
 

--- a/crates/opfs-btree/Cargo.toml
+++ b/crates/opfs-btree/Cargo.toml
@@ -23,6 +23,7 @@ xxhash-rust = { version = "0.8", features = ["xxh3"] }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 bf-tree = { version = "0.4.8", optional = true }
 rocksdb = { package = "rust-rocksdb", version = "0.48.0", default-features = false, features = [
+  "jemalloc",
   "lz4",
 ], optional = true }
 

--- a/examples/todo-server-rs/Cargo.toml
+++ b/examples/todo-server-rs/Cargo.toml
@@ -22,7 +22,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tower-http = { version = "0.5", features = ["cors", "trace"] }
 uuid = { version = "1", features = ["v4"] }
 futures-util = "0.3"
-mimalloc = { version = "0.1", default-features = false }
+tikv-jemallocator = { version = "0.6", default-features = false }
 
 [dev-dependencies]
 jazz_tools = { package = "jazz-tools", path = "../../crates/jazz-tools", features = ["sqlite"] }

--- a/examples/todo-server-rs/src/main.rs
+++ b/examples/todo-server-rs/src/main.rs
@@ -24,11 +24,11 @@
 //! | `/todos/:id` | DELETE | Delete item |
 //! | `/updates` | GET | SSE stream of add/remove events |
 
-// mimalloc replaces the system allocator for ~25% throughput on Rust-side
-// allocation-heavy paths (query/insert/observer). Single-process, single-language —
-// no FFI ownership concerns here.
+// jemalloc replaces the system allocator on Rust-side allocation-heavy paths
+// (query/insert/observer). Single-process, single-language; no FFI ownership
+// concerns here.
 #[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 mod routes;
 


### PR DESCRIPTION
## Summary

This switches the production allocator setup to jemalloc in both places that matter for the RocksDB-backed server path:

- Rust global allocator: `tikv-jemallocator`
- RocksDB allocator: `rust-rocksdb` with its `jemalloc` feature enabled

The goal is to avoid the split allocator setup where Rust used mimalloc while RocksDB stayed on the system allocator. The benchmark results point to the unified jemalloc setup as the best real production configuration.

## Benchmark Rationale

Benchmarked 36 cells across 4 allocator configurations, with 3 repeats and median results.

Configuration meanings:

- `unified`: jemalloc for both Rust and RocksDB
- `hybrid`: mimalloc for Rust, jemalloc for RocksDB
- `system`: no custom allocator
- `current`: the previous shipping setup

Throughput vs `current`:

| scenario | unified | hybrid | system |
| --- | ---: | ---: | ---: |
| write_heavy | +16.4% | -6.3% | +13.1% |
| read_heavy | +19.8% | +15.4% | +20.5% |
| balanced | +1.8% | +2.3% | +2.5% |

Server CPU/op vs `current`:

- `unified`: -18% / -20.5% / -0.6%

Server peak RSS vs `current`:

- `unified`: -3.8% / +7.8% / -10.2%, effectively neutral overall

Key interpretation:

- `unified` wins the important read/write-heavy cases, with roughly +16-20% throughput and about 20% lower server CPU/op.
- `hybrid` is worse than unified and loses write-heavy throughput, which suggests mixing allocator runtimes costs memory and does not buy enough back.
- `system` can beat the previous current setup, but the unified jemalloc setup is the recommendation because it performs well without the Rust/RocksDB allocator split.

## Changes

- Enables `jemalloc` on direct `rust-rocksdb` consumers.
- Uses `tikv-jemallocator` as the Rust global allocator for `jazz-tools`.
- Uses `tikv-jemallocator` in the Rust todo-server example.
- Updates `Cargo.lock` so Rust and RocksDB allocator paths converge through `tikv-jemalloc-sys`.

`jazz-napi` intentionally stays on `mimalloc-safe`; that crate documents a separate Node/NAPI allocator boundary.

## Validation

- `cargo tree -p jazz-tools --features cli -i tikv-jemalloc-sys`
- `cargo tree -p jazz-tools --features rocksdb -e features -i rust-rocksdb`
- `cargo tree -p opfs-btree --features rocksdb -e features -i rust-rocksdb`
- `cargo check -p jazz-tools --features cli`
- `cargo check -p todo-server`
- `cargo fmt --check`
- `git diff --check`
- pre-commit hook: `clippy` and `rustfmt`
