### PR TITLE
ci: run jazz-napi macOS builds on Blacksmith

### DIFF
--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -575,11 +575,11 @@ jobs:
             target: x86_64-unknown-linux-gnu
             platform: linux-x64-gnu
             use_sccache: true
-          - os: macos-14
+          - os: blacksmith-6vcpu-macos-15
             target: x86_64-apple-darwin
             platform: darwin-x64
             use_sccache: false
-          - os: macos-14
+          - os: blacksmith-6vcpu-macos-15
             target: aarch64-apple-darwin
             platform: darwin-arm64
             use_sccache: false


### PR DESCRIPTION
## Summary
- Switch the two macOS entries in the `build-napi` matrix of `publish-jazz-tools-alpha.yml` from GitHub-hosted `macos-14` to `blacksmith-6vcpu-macos-15`, matching the other macOS jobs in the same workflow.

## Test plan
- [ ] Trigger the `publish-jazz-tools-alpha` workflow (dry-run) and confirm the `build-napi` darwin-x64 and darwin-arm64 jobs run on Blacksmith and produce the expected artifacts.