### PR TITLE
test: concurrent transactions

### DIFF
--- a/crates/jazz-tools/src/runtime_core/tests.rs
+++ b/crates/jazz-tools/src/runtime_core/tests.rs
@@ -1743,10 +1743,13 @@ fn pump_client_messages_to_server(
     server: &mut TestCore,
     server_id: ServerId,
     client_id: ClientId,
-) {
+) -> bool {
+    let mut any_messages = false;
+
     client.batched_tick();
     for entry in client.sync_sender().take() {
         if entry.destination == Destination::Server(server_id) {
+            any_messages = true;
             server.park_sync_message(InboxEntry {
                 source: Source::Client(client_id),
                 payload: entry.payload,
@@ -1755,95 +1758,71 @@ fn pump_client_messages_to_server(
     }
     server.batched_tick();
     server.immediate_tick();
+
+    any_messages
 }
 
-#[allow(clippy::too_many_arguments)]
-fn pump_server_with_three_clients(
+struct ClientForServer<'a> {
+    core: &'a mut TestCore,
+    server_id: ServerId,
+    client_id: ClientId,
+}
+
+fn pump_server_messages_to_clients(
     server: &mut TestCore,
-    writer: &mut TestCore,
-    writer_server_id: ServerId,
-    writer_client_id: ClientId,
-    alice_reader: &mut TestCore,
-    alice_reader_server_id: ServerId,
-    alice_reader_client_id: ClientId,
-    bob_reader: &mut TestCore,
-    bob_reader_server_id: ServerId,
-    bob_reader_client_id: ClientId,
+    clients: &mut [ClientForServer<'_>],
+    server_outputs: &mut Vec<OutboxEntry>,
+) -> bool {
+    let mut any_messages = false;
+
+    server.batched_tick();
+
+    let server_out = server.sync_sender().take();
+    server_outputs.extend(server_out.iter().cloned());
+    for entry in server_out {
+        let Destination::Client(destination_client_id) = entry.destination else {
+            continue;
+        };
+
+        if let Some(client) = clients
+            .iter_mut()
+            .find(|client| client.client_id == destination_client_id)
+        {
+            any_messages = true;
+            client.core.park_sync_message(InboxEntry {
+                source: Source::Server(client.server_id),
+                payload: entry.payload,
+            });
+        }
+    }
+
+    any_messages
+}
+
+fn sync_server_with_clients(
+    server: &mut TestCore,
+    clients: &mut [ClientForServer<'_>],
 ) -> Vec<OutboxEntry> {
     let mut server_outputs = Vec::new();
 
     for _ in 0..10 {
         let mut any_messages = false;
 
-        writer.batched_tick();
-        for entry in writer.sync_sender().take() {
-            if entry.destination == Destination::Server(writer_server_id) {
-                any_messages = true;
-                server.park_sync_message(InboxEntry {
-                    source: Source::Client(writer_client_id),
-                    payload: entry.payload,
-                });
-            }
+        for client in clients.iter_mut() {
+            any_messages |= pump_client_messages_to_server(
+                client.core,
+                server,
+                client.server_id,
+                client.client_id,
+            );
         }
 
-        alice_reader.batched_tick();
-        for entry in alice_reader.sync_sender().take() {
-            if entry.destination == Destination::Server(alice_reader_server_id) {
-                any_messages = true;
-                server.park_sync_message(InboxEntry {
-                    source: Source::Client(alice_reader_client_id),
-                    payload: entry.payload,
-                });
-            }
-        }
+        any_messages |= pump_server_messages_to_clients(server, clients, &mut server_outputs);
 
-        bob_reader.batched_tick();
-        for entry in bob_reader.sync_sender().take() {
-            if entry.destination == Destination::Server(bob_reader_server_id) {
-                any_messages = true;
-                server.park_sync_message(InboxEntry {
-                    source: Source::Client(bob_reader_client_id),
-                    payload: entry.payload,
-                });
-            }
+        for client in clients.iter_mut() {
+            client.core.batched_tick();
+            client.core.immediate_tick();
         }
-
-        server.batched_tick();
-        let server_out = server.sync_sender().take();
-        server_outputs.extend(server_out.iter().cloned());
-        for entry in server_out {
-            match entry.destination {
-                Destination::Client(client_id) if client_id == writer_client_id => {
-                    any_messages = true;
-                    writer.park_sync_message(InboxEntry {
-                        source: Source::Server(writer_server_id),
-                        payload: entry.payload,
-                    });
-                }
-                Destination::Client(client_id) if client_id == alice_reader_client_id => {
-                    any_messages = true;
-                    alice_reader.park_sync_message(InboxEntry {
-                        source: Source::Server(alice_reader_server_id),
-                        payload: entry.payload,
-                    });
-                }
-                Destination::Client(client_id) if client_id == bob_reader_client_id => {
-                    any_messages = true;
-                    bob_reader.park_sync_message(InboxEntry {
-                        source: Source::Server(bob_reader_server_id),
-                        payload: entry.payload,
-                    });
-                }
-                _ => {}
-            }
-        }
-
-        writer.batched_tick();
-        writer.immediate_tick();
-        alice_reader.batched_tick();
-        alice_reader.immediate_tick();
-        bob_reader.batched_tick();
-        bob_reader.immediate_tick();
 
         if !any_messages {
             break;

--- a/crates/jazz-tools/src/runtime_core/tests/basic.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/basic.rs
@@ -352,17 +352,25 @@ fn rc_user_subscription_does_not_forward_rows_to_other_sessions() {
         )
         .expect("bob reader subscription should be created");
 
-    pump_server_with_three_clients(
+    sync_server_with_clients(
         &mut server,
-        &mut writer,
-        writer_server_id,
-        writer_client_id,
-        &mut alice_reader,
-        alice_reader_server_id,
-        alice_reader_client_id,
-        &mut bob_reader,
-        bob_reader_server_id,
-        bob_reader_client_id,
+        &mut [
+            ClientForServer {
+                core: &mut writer,
+                server_id: writer_server_id,
+                client_id: writer_client_id,
+            },
+            ClientForServer {
+                core: &mut alice_reader,
+                server_id: alice_reader_server_id,
+                client_id: alice_reader_client_id,
+            },
+            ClientForServer {
+                core: &mut bob_reader,
+                server_id: bob_reader_server_id,
+                client_id: bob_reader_client_id,
+            },
+        ],
     );
 
     assert_eq!(
@@ -398,17 +406,25 @@ fn rc_user_subscription_does_not_forward_rows_to_other_sessions() {
         )
         .expect("alice insert should succeed through the public client API");
 
-    let server_outputs_after_write = pump_server_with_three_clients(
+    let server_outputs_after_write = sync_server_with_clients(
         &mut server,
-        &mut writer,
-        writer_server_id,
-        writer_client_id,
-        &mut alice_reader,
-        alice_reader_server_id,
-        alice_reader_client_id,
-        &mut bob_reader,
-        bob_reader_server_id,
-        bob_reader_client_id,
+        &mut [
+            ClientForServer {
+                core: &mut writer,
+                server_id: writer_server_id,
+                client_id: writer_client_id,
+            },
+            ClientForServer {
+                core: &mut alice_reader,
+                server_id: alice_reader_server_id,
+                client_id: alice_reader_client_id,
+            },
+            ClientForServer {
+                core: &mut bob_reader,
+                server_id: bob_reader_server_id,
+                client_id: bob_reader_client_id,
+            },
+        ],
     );
 
     let server_results = execute_runtime_query(
@@ -498,17 +514,25 @@ fn rc_user_subscription_does_not_forward_rows_to_other_sessions() {
         "fresh bob full query should wait for Local settlement instead of resolving from local empty state"
     );
 
-    let server_outputs_after_fresh_bob_query = pump_server_with_three_clients(
+    let server_outputs_after_fresh_bob_query = sync_server_with_clients(
         &mut server,
-        &mut writer,
-        writer_server_id,
-        writer_client_id,
-        &mut alice_reader,
-        alice_reader_server_id,
-        alice_reader_client_id,
-        &mut bob_reader,
-        bob_reader_server_id,
-        bob_reader_client_id,
+        &mut [
+            ClientForServer {
+                core: &mut writer,
+                server_id: writer_server_id,
+                client_id: writer_client_id,
+            },
+            ClientForServer {
+                core: &mut alice_reader,
+                server_id: alice_reader_server_id,
+                client_id: alice_reader_client_id,
+            },
+            ClientForServer {
+                core: &mut bob_reader,
+                server_id: bob_reader_server_id,
+                client_id: bob_reader_client_id,
+            },
+        ],
     );
     assert!(
         !outbox_has_object_update_for_client(

--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/transactional.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/transactional.rs
@@ -1202,6 +1202,11 @@ fn rc_two_clients_accept_second_transactional_update_if_second_client_receives_f
             },
         ],
     );
+    // Right now transactions have a "read committed" isolation level, which means
+    // transactions can read data written after they began (including other transactions
+    // that were concurrently committed).
+    // We want to move into snapshot or serializable isolation, so that transactions can
+    // only read writes that happened BEFORE they began
     assert_single_user_named(
         &mut harness.bob,
         harness.row_id,

--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/transactional.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/transactional.rs
@@ -942,3 +942,297 @@ fn rc_missing_batch_fate_retransmits_local_transactional_rows_without_row_locato
             }]
     )));
 }
+
+struct TwoClientTransactionHarness {
+    alice: TestCore,
+    bob: TestCore,
+    server: TestCore,
+    alice_client_id: ClientId,
+    alice_server_id: ServerId,
+    bob_client_id: ClientId,
+    bob_server_id: ServerId,
+    row_id: ObjectId,
+    base_batch_id: BatchId,
+}
+
+fn create_two_client_transaction_harness(app_name: &str) -> TwoClientTransactionHarness {
+    let schema = test_schema();
+    let mut alice = create_runtime_with_schema(schema.clone(), app_name);
+    let mut bob = create_runtime_with_schema(schema.clone(), app_name);
+    let mut server = create_runtime_with_schema_and_sync_manager(
+        schema,
+        app_name,
+        SyncManager::new().with_durability_tier(DurabilityTier::Local),
+    );
+
+    let alice_client_id = ClientId::new();
+    let alice_server_id = ServerId::new();
+    let bob_client_id = ClientId::new();
+    let bob_server_id = ServerId::new();
+
+    server.add_client(alice_client_id, None);
+    server
+        .schema_manager_mut()
+        .query_manager_mut()
+        .sync_manager_mut()
+        .set_client_role(alice_client_id, ClientRole::Peer);
+    server.add_client(bob_client_id, None);
+    server
+        .schema_manager_mut()
+        .query_manager_mut()
+        .sync_manager_mut()
+        .set_client_role(bob_client_id, ClientRole::Peer);
+    alice.add_server(alice_server_id);
+    bob.add_server(bob_server_id);
+
+    alice.immediate_tick();
+    bob.immediate_tick();
+    server.immediate_tick();
+    alice.batched_tick();
+    bob.batched_tick();
+    server.batched_tick();
+    alice.sync_sender().take();
+    bob.sync_sender().take();
+    server.sync_sender().take();
+
+    let _bob_subscription = bob
+        .subscribe(QueryBuilder::new("users").build(), |_| {}, None)
+        .expect("bob should be able to subscribe to users");
+
+    let mut harness = TwoClientTransactionHarness {
+        alice,
+        bob,
+        server,
+        alice_client_id,
+        alice_server_id,
+        bob_client_id,
+        bob_server_id,
+        row_id: ObjectId::new(),
+        base_batch_id: BatchId::default(),
+    };
+
+    sync_server_with_clients(
+        &mut harness.server,
+        &mut [
+            ClientForServer {
+                core: &mut harness.alice,
+                server_id: harness.alice_server_id,
+                client_id: harness.alice_client_id,
+            },
+            ClientForServer {
+                core: &mut harness.bob,
+                server_id: harness.bob_server_id,
+                client_id: harness.bob_client_id,
+            },
+        ],
+    );
+
+    let ((row_id, _row_values), base_batch_id) = harness
+        .alice
+        .insert("users", user_insert_values(ObjectId::new(), "Shared"), None)
+        .expect("Alice should insert the shared base row through RuntimeCore");
+    harness.row_id = row_id;
+    harness.base_batch_id = base_batch_id;
+
+    sync_server_with_clients(
+        &mut harness.server,
+        &mut [
+            ClientForServer {
+                core: &mut harness.alice,
+                server_id: harness.alice_server_id,
+                client_id: harness.alice_client_id,
+            },
+            ClientForServer {
+                core: &mut harness.bob,
+                server_id: harness.bob_server_id,
+                client_id: harness.bob_client_id,
+            },
+        ],
+    );
+    assert_single_user_named(
+        &mut harness.bob,
+        row_id,
+        "Shared",
+        "Bob should learn the shared base row through sync before either transaction starts",
+    );
+
+    harness
+}
+
+fn transactional_write_context() -> WriteContext {
+    WriteContext {
+        session: None,
+        attribution: None,
+        updated_at: None,
+        batch_mode: Some(crate::batch_fate::BatchMode::Transactional),
+        batch_id: None,
+        target_branch_name: None,
+    }
+}
+
+fn users_named(core: &mut TestCore, name: &str) -> Vec<(ObjectId, Vec<Value>)> {
+    execute_local_runtime_query(
+        core,
+        QueryBuilder::new("users")
+            .filter_eq("name", Value::Text(name.to_string()))
+            .build(),
+        None,
+    )
+}
+
+fn assert_single_user_named(core: &mut TestCore, row_id: ObjectId, name: &str, message: &str) {
+    let rows = users_named(core, name);
+    assert_eq!(
+        rows.len(),
+        1,
+        "{message}: expected exactly one row, got {rows:?}"
+    );
+    assert_eq!(rows[0].0, row_id, "{message}: row id mismatch");
+    assert_eq!(
+        rows[0].1[1],
+        Value::Text(name.to_string()),
+        "{message}: name column mismatch"
+    );
+}
+
+#[test]
+fn rc_two_clients_reject_stale_transactional_update_after_first_client_commits() {
+    let mut harness = create_two_client_transaction_harness("two-client-transaction-conflict");
+
+    let alice_context = transactional_write_context();
+    let bob_context = transactional_write_context();
+
+    let alice_batch_id = harness
+        .alice
+        .update(
+            harness.row_id,
+            vec![("name".to_string(), Value::Text("Alice".to_string()))],
+            Some(&alice_context),
+        )
+        .unwrap();
+    let bob_batch_id = harness
+        .bob
+        .update(
+            harness.row_id,
+            vec![("name".to_string(), Value::Text("Bob".to_string()))],
+            Some(&bob_context),
+        )
+        .unwrap();
+
+    harness.alice.seal_batch(alice_batch_id).unwrap();
+    pump_client_messages_to_server(
+        &mut harness.alice,
+        &mut harness.server,
+        harness.alice_server_id,
+        harness.alice_client_id,
+    );
+    assert!(matches!(
+        harness.server.batch_fate(alice_batch_id).unwrap(),
+        Some(crate::batch_fate::BatchFate::AcceptedTransaction { .. })
+    ));
+    harness.server.sync_sender().take();
+
+    harness.bob.seal_batch(bob_batch_id).unwrap();
+    pump_client_messages_to_server(
+        &mut harness.bob,
+        &mut harness.server,
+        harness.bob_server_id,
+        harness.bob_client_id,
+    );
+    assert!(matches!(
+        harness
+            .server
+            .batch_fate(bob_batch_id)
+            .unwrap(),
+        Some(crate::batch_fate::BatchFate::Rejected { code, .. })
+            if code == "transaction_conflict"
+    ));
+}
+
+#[test]
+fn rc_two_clients_accept_second_transactional_update_if_second_client_receives_first_before_commit()
+{
+    let mut harness =
+        create_two_client_transaction_harness("two-client-transaction-conflict-after-sync");
+
+    let alice_context = transactional_write_context();
+    let bob_context = transactional_write_context();
+
+    let alice_batch_id = harness
+        .alice
+        .update(
+            harness.row_id,
+            vec![("name".to_string(), Value::Text("Alice".to_string()))],
+            Some(&alice_context),
+        )
+        .unwrap();
+    let bob_batch_id = harness
+        .bob
+        .update(
+            harness.row_id,
+            vec![("name".to_string(), Value::Text("Bob".to_string()))],
+            Some(&bob_context),
+        )
+        .unwrap();
+
+    harness.alice.seal_batch(alice_batch_id).unwrap();
+    pump_client_messages_to_server(
+        &mut harness.alice,
+        &mut harness.server,
+        harness.alice_server_id,
+        harness.alice_client_id,
+    );
+    assert!(matches!(
+        harness.server.batch_fate(alice_batch_id).unwrap(),
+        Some(crate::batch_fate::BatchFate::AcceptedTransaction { .. })
+    ));
+
+    sync_server_with_clients(
+        &mut harness.server,
+        &mut [
+            ClientForServer {
+                core: &mut harness.alice,
+                server_id: harness.alice_server_id,
+                client_id: harness.alice_client_id,
+            },
+            ClientForServer {
+                core: &mut harness.bob,
+                server_id: harness.bob_server_id,
+                client_id: harness.bob_client_id,
+            },
+        ],
+    );
+    assert_single_user_named(
+        &mut harness.bob,
+        harness.row_id,
+        "Alice",
+        "Bob should learn Alice's accepted transaction before sealing his own",
+    );
+
+    harness.bob.seal_batch(bob_batch_id).unwrap();
+    sync_server_with_clients(
+        &mut harness.server,
+        &mut [
+            ClientForServer {
+                core: &mut harness.alice,
+                server_id: harness.alice_server_id,
+                client_id: harness.alice_client_id,
+            },
+            ClientForServer {
+                core: &mut harness.bob,
+                server_id: harness.bob_server_id,
+                client_id: harness.bob_client_id,
+            },
+        ],
+    );
+    assert!(matches!(
+        harness.server.batch_fate(bob_batch_id).unwrap(),
+        Some(crate::batch_fate::BatchFate::AcceptedTransaction { .. })
+    ));
+    assert_single_user_named(
+        &mut harness.server,
+        harness.row_id,
+        "Bob",
+        "Bob's transaction should publish after sealing against the updated visible frontier",
+    );
+}

--- a/packages/jazz-tools/tests/browser/db.transaction-reads.test.ts
+++ b/packages/jazz-tools/tests/browser/db.transaction-reads.test.ts
@@ -279,7 +279,7 @@ describe("db transaction reads browser integration", () => {
     });
   });
 
-  it("two concurrent transactions that modify the same data can both commit", async () => {
+  it.fails("two concurrent transactions that modify the same data can both commit", async () => {
     const { value: base } = db.insert(todos, { title: "Shared", done: false });
 
     const aliceTx = db.beginTransaction();
@@ -289,10 +289,11 @@ describe("db transaction reads browser integration", () => {
     bobTx.update(todos, base.id, { title: "Bob's title" });
 
     await aliceTx.commit().wait({ tier: "local" });
-    // Alice's change becomes visible to Bob before it commits, so Bob's commit succeeds as well
-    await bobTx.commit().wait({ tier: "local" });
+    // Currently, Alice's change becomes visible to Bob before it commits,
+    // so Bob's commit succeeds as well
+    await expect(bobTx.commit().wait({ tier: "local" })).rejects.toThrow("transaction_conflict");
 
-    expect((await db.one<Todo>(makeTodoQuery()))?.title).toEqual("Bob's title");
+    expect((await db.one<Todo>(makeTodoQuery()))?.title).toEqual("Alice's title");
   });
 });
 

--- a/packages/jazz-tools/tests/browser/db.transaction-reads.test.ts
+++ b/packages/jazz-tools/tests/browser/db.transaction-reads.test.ts
@@ -278,6 +278,22 @@ describe("db transaction reads browser integration", () => {
       });
     });
   });
+
+  it("two concurrent transactions that modify the same data can both commit", async () => {
+    const { value: base } = db.insert(todos, { title: "Shared", done: false });
+
+    const aliceTx = db.beginTransaction();
+    const bobTx = db.beginTransaction();
+
+    aliceTx.update(todos, base.id, { title: "Alice's title" });
+    bobTx.update(todos, base.id, { title: "Bob's title" });
+
+    await aliceTx.commit().wait({ tier: "local" });
+    // Alice's change becomes visible to Bob before it commits, so Bob's commit succeeds as well
+    await bobTx.commit().wait({ tier: "local" });
+
+    expect((await db.one<Todo>(makeTodoQuery()))?.title).toEqual("Bob's title");
+  });
 });
 
 describe("db batch reads browser integration", () => {


### PR DESCRIPTION
## Description

Found that concurrent transactions that modify the same data can both commit if the changes made by one of them become visible to the second before it commits. Added Rust and TS tests for these scenarios.