### PR TITLE
Flush worker WAL after sync payloads

### DIFF
--- a/crates/jazz-wasm/src/worker_host.rs
+++ b/crates/jazz-wasm/src/worker_host.rs
@@ -574,6 +574,7 @@ fn process_main_message(msg: MainToWorkerMessage) {
                 }
             }
             rt.batched_tick();
+            rt.flush_wal();
         }
         MainToWorkerWire::PeerOpen { peer_id } => {
             if let Some(rt) = runtime.as_ref() {


### PR DESCRIPTION
## What

Flush the worker WAL after processing sync payloads received from the main thread.

## Why

Without this flush, local reads can wait on state that has already been received but not persisted through the worker runtime yet. This makes local wait paths look slow or stuck even though the sync payload arrived.

## Checks

- `RUSTFLAGS='--cfg=web_sys_unstable_apis --cfg getrandom_backend="wasm_js"' pnpm --filter jazz-wasm build`
- pre-commit `clippy`
- pre-commit `rustfmt`