### PR TITLE
Improve sync error logging

### DIFF
--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -1258,7 +1258,7 @@ impl SyncManager {
                     });
                 }
                 _ => {
-                    tracing::warn!(?server_id, error = ?err, "error from server");
+                    tracing::warn!("error from server server={server_id:?} error={err:?}");
                 }
             },
             // Servers shouldn't send these to us

--- a/crates/jazz-wasm/src/worker_host.rs
+++ b/crates/jazz-wasm/src/worker_host.rs
@@ -570,7 +570,17 @@ fn process_main_message(msg: MainToWorkerMessage) {
                 if let Err(err) =
                     rt.on_sync_message_received_from_client(&main_client_id, arr.into())
                 {
-                    tracing::warn!("onSyncMessageReceivedFromClient main: {err:?}");
+                    let preview = payload
+                        .iter()
+                        .take(12)
+                        .map(|byte| format!("{byte:02x}"))
+                        .collect::<Vec<_>>()
+                        .join("");
+                    tracing::warn!(
+                        "onSyncMessageReceivedFromClient main len={} preview={} err={err:?}",
+                        payload.len(),
+                        preview
+                    );
                 }
             }
             rt.batched_tick();


### PR DESCRIPTION
## What

Make sync error logs include useful details in the log body.

## Why

Some collectors do not preserve structured fields in the body view. Putting the server id, error, payload length, and a short payload preview into the message makes local debugging usable without changing behavior.

## Checks

- `cargo check -p jazz-tools`
- `RUSTFLAGS='--cfg=web_sys_unstable_apis --cfg getrandom_backend="wasm_js"' pnpm --filter jazz-wasm build`
- pre-commit `clippy`
- pre-commit `rustfmt`