### PR TITLE
fix: concurrent write transaction conflicts

### DIFF
--- a/.changeset/transaction-parent-conflicts.md
+++ b/.changeset/transaction-parent-conflicts.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix: reject stale transactional writes when the authority sees that a sealed transaction's staged row parents no longer match the current visible row frontier.

--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/transactional.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/transactional.rs
@@ -1095,8 +1095,10 @@ fn assert_single_user_named(core: &mut TestCore, row_id: ObjectId, name: &str, m
     );
 }
 
+/// Two transactions modify the same object unaware of each other.
+/// The server accepts the first tx and rejects the second.
 #[test]
-fn rc_two_clients_reject_stale_transactional_update_after_first_client_commits() {
+fn rc_authority_rejects_stale_update_after_concurrent_commit() {
     let mut harness = create_two_client_transaction_harness("two-client-transaction-conflict");
 
     let alice_context = transactional_write_context();
@@ -1149,9 +1151,12 @@ fn rc_two_clients_reject_stale_transactional_update_after_first_client_commits()
     ));
 }
 
+/// Two transactions modify the same object.
+/// Alice's tx commits first and Bob's tx sees Alice's update
+/// AFTER its write (and before its commit).
+/// The server accepts the first tx and rejects the second.
 #[test]
-fn rc_two_clients_accept_second_transactional_update_if_second_client_receives_first_before_commit()
-{
+fn rc_authority_rejects_update_staged_before_receiving_concurrent_commit() {
     let mut harness =
         create_two_client_transaction_harness("two-client-transaction-conflict-after-sync");
 
@@ -1202,17 +1207,103 @@ fn rc_two_clients_accept_second_transactional_update_if_second_client_receives_f
             },
         ],
     );
-    // Right now transactions have a "read committed" isolation level, which means
-    // transactions can read data written after they began (including other transactions
-    // that were concurrently committed).
-    // We want to move into snapshot or serializable isolation, so that transactions can
-    // only read writes that happened BEFORE they began
     assert_single_user_named(
         &mut harness.bob,
         harness.row_id,
         "Alice",
         "Bob should learn Alice's accepted transaction before sealing his own",
     );
+
+    harness.bob.seal_batch(bob_batch_id).unwrap();
+    sync_server_with_clients(
+        &mut harness.server,
+        &mut [
+            ClientForServer {
+                core: &mut harness.alice,
+                server_id: harness.alice_server_id,
+                client_id: harness.alice_client_id,
+            },
+            ClientForServer {
+                core: &mut harness.bob,
+                server_id: harness.bob_server_id,
+                client_id: harness.bob_client_id,
+            },
+        ],
+    );
+    assert!(matches!(
+        harness.server.batch_fate(bob_batch_id).unwrap(),
+        Some(crate::batch_fate::BatchFate::Rejected { code, .. })
+            if code == "transaction_conflict"
+    ));
+    assert_single_user_named(
+        &mut harness.server,
+        harness.row_id,
+        "Alice",
+        "Bob's stale staged transaction should not replace Alice's accepted transaction",
+    );
+}
+
+/// Two transactions modify the same object.
+/// Alice's tx commits first and Bob's tx sees Alice's update BEFORE its write.
+/// The server accepts both transactions.
+#[test]
+fn rc_authority_accepts_update_staged_after_receiving_concurrent_commit() {
+    let mut harness =
+        create_two_client_transaction_harness("two-client-transaction-conflict-after-stage");
+
+    let alice_context = transactional_write_context();
+    let alice_batch_id = harness
+        .alice
+        .update(
+            harness.row_id,
+            vec![("name".to_string(), Value::Text("Alice".to_string()))],
+            Some(&alice_context),
+        )
+        .unwrap();
+
+    harness.alice.seal_batch(alice_batch_id).unwrap();
+    pump_client_messages_to_server(
+        &mut harness.alice,
+        &mut harness.server,
+        harness.alice_server_id,
+        harness.alice_client_id,
+    );
+    assert!(matches!(
+        harness.server.batch_fate(alice_batch_id).unwrap(),
+        Some(crate::batch_fate::BatchFate::AcceptedTransaction { .. })
+    ));
+
+    sync_server_with_clients(
+        &mut harness.server,
+        &mut [
+            ClientForServer {
+                core: &mut harness.alice,
+                server_id: harness.alice_server_id,
+                client_id: harness.alice_client_id,
+            },
+            ClientForServer {
+                core: &mut harness.bob,
+                server_id: harness.bob_server_id,
+                client_id: harness.bob_client_id,
+            },
+        ],
+    );
+    assert_single_user_named(
+        &mut harness.bob,
+        harness.row_id,
+        "Alice",
+        "Bob should stage his transaction from Alice's visible row",
+    );
+
+    let bob_context = transactional_write_context();
+    let bob_batch_id = harness
+        .bob
+        .update(
+            harness.row_id,
+            vec![("name".to_string(), Value::Text("Bob".to_string()))],
+            Some(&bob_context),
+        )
+        .unwrap();
 
     harness.bob.seal_batch(bob_batch_id).unwrap();
     sync_server_with_clients(

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -159,6 +159,52 @@ impl SyncManager {
         Ok(())
     }
 
+    fn parent_frontier_conflict_fate(&self, batch_id: crate::row_histories::BatchId) -> BatchFate {
+        BatchFate::Rejected {
+            batch_id,
+            code: "transaction_conflict".to_string(),
+            reason: "row visible parent changed since transaction write was staged".to_string(),
+        }
+    }
+
+    fn normalize_frontier(
+        mut frontier: Vec<crate::row_histories::BatchId>,
+    ) -> Vec<crate::row_histories::BatchId> {
+        frontier.sort();
+        frontier.dedup();
+        frontier
+    }
+
+    fn validate_transactional_parent_frontiers<H: Storage>(
+        &self,
+        storage: &H,
+        submission: &SealedBatchSubmission,
+        declared_rows: &[(String, StoredRowBatch)],
+    ) -> Result<(), BatchFate> {
+        for (table, row) in declared_rows {
+            let expected_frontier = Self::normalize_frontier(row.parents.iter().copied().collect());
+            let current_frontier = storage
+                .load_visible_region_frontier(
+                    table,
+                    submission.target_branch_name.as_str(),
+                    row.row_id,
+                )
+                .map_err(|error| BatchFate::Rejected {
+                    batch_id: submission.batch_id,
+                    code: "invalid_batch_submission".to_string(),
+                    reason: format!("failed to load row visible parent frontier: {error}"),
+                })?
+                .map(Self::normalize_frontier)
+                .unwrap_or_default();
+
+            if current_frontier != expected_frontier {
+                return Err(self.parent_frontier_conflict_fate(submission.batch_id));
+            }
+        }
+
+        Ok(())
+    }
+
     fn persist_authoritative_batch_fate<H: Storage>(
         &self,
         storage: &mut H,
@@ -1025,6 +1071,18 @@ impl SyncManager {
             );
             return;
         }
+        if mode == SealedBatchMode::Transactional
+            && let Err(rejection) =
+                self.validate_transactional_parent_frontiers(storage, &submission, &declared_rows)
+        {
+            self.reject_sealed_transactional_batch(
+                storage,
+                Some(client_id),
+                rejection,
+                &batch_rows,
+            );
+            return;
+        }
 
         self.settle_sealed_batch(
             storage,
@@ -1089,6 +1147,17 @@ impl SyncManager {
             };
             if mode == SealedBatchMode::Transactional
                 && let Err(rejection) = self.validate_captured_frontier(storage, &submission)
+            {
+                self.reject_sealed_transactional_batch(storage, None, rejection, &batch_rows);
+                recovered_any = true;
+                continue;
+            }
+            if mode == SealedBatchMode::Transactional
+                && let Err(rejection) = self.validate_transactional_parent_frontiers(
+                    storage,
+                    &submission,
+                    &declared_rows,
+                )
             {
                 self.reject_sealed_transactional_batch(storage, None, rejection, &batch_rows);
                 recovered_any = true;

--- a/crates/jazz-tools/src/sync_manager/tests/transaction_sealing.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/transaction_sealing.rs
@@ -1352,6 +1352,400 @@ fn seal_batch_accepts_when_family_visible_frontier_matches() {
 }
 
 #[test]
+fn seal_batch_rejects_when_transactional_row_parent_frontier_changed() {
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
+    let mut io = MemoryStorage::new();
+    let client_id = ClientId::new();
+    let batch_id = crate::row_histories::BatchId::new();
+    let row_id = ObjectId::new();
+    let target_branch = "dev-aaaaaaaaaaaa-main";
+    seed_users_schema(&mut io);
+
+    add_client(&mut sm, &io, client_id);
+    sm.set_client_role(client_id, ClientRole::Peer);
+    sm.take_outbox();
+
+    let base_row = visible_row(row_id, target_branch, Vec::new(), 900, b"base");
+    seed_visible_row(&mut sm, &mut io, "users", base_row.clone());
+
+    let staged_row = row_with_batch_state(
+        visible_row(
+            row_id,
+            target_branch,
+            vec![base_row.batch_id()],
+            1_000,
+            b"alice",
+        ),
+        batch_id,
+        crate::row_histories::RowState::StagingPending,
+        None,
+    );
+    sm.process_from_client(
+        &mut io,
+        client_id,
+        SyncPayload::RowBatchCreated {
+            metadata: Some(RowMetadata {
+                id: staged_row.row_id,
+                metadata: row_metadata("users"),
+            }),
+            row: staged_row.clone(),
+        },
+    );
+    sm.take_outbox();
+
+    let newer_row = visible_row(
+        row_id,
+        target_branch,
+        vec![base_row.batch_id()],
+        1_100,
+        b"bob",
+    );
+    io.append_history_region_rows("users", std::slice::from_ref(&newer_row))
+        .unwrap();
+    io.upsert_visible_region_rows(
+        "users",
+        std::slice::from_ref(&crate::row_histories::VisibleRowEntry::rebuild(
+            newer_row.clone(),
+            &[base_row.clone(), newer_row.clone()],
+        )),
+    )
+    .unwrap();
+
+    sm.process_from_client(
+        &mut io,
+        client_id,
+        SyncPayload::SealBatch {
+            submission: sealed_submission(
+                batch_id,
+                target_branch,
+                vec![SealedBatchMember {
+                    object_id: row_id,
+                    row_digest: staged_row.content_digest(),
+                }],
+                vec![CapturedFrontierMember {
+                    object_id: row_id,
+                    branch_name: BranchName::new(target_branch),
+                    batch_id: newer_row.batch_id(),
+                }],
+            ),
+        },
+    );
+
+    assert_eq!(
+        io.load_authoritative_batch_fate(batch_id).unwrap(),
+        Some(BatchFate::Rejected {
+            batch_id,
+            code: "transaction_conflict".to_string(),
+            reason: "row visible parent changed since transaction write was staged".to_string(),
+        })
+    );
+    assert_eq!(
+        io.load_visible_region_row("users", target_branch, row_id)
+            .unwrap()
+            .expect("newer visible row should remain visible")
+            .batch_id(),
+        newer_row.batch_id()
+    );
+}
+
+#[test]
+fn seal_batch_accepts_when_transactional_row_parent_frontier_matches() {
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
+    let mut io = MemoryStorage::new();
+    let client_id = ClientId::new();
+    let batch_id = crate::row_histories::BatchId::new();
+    let row_id = ObjectId::new();
+    let target_branch = "dev-aaaaaaaaaaaa-main";
+    seed_users_schema(&mut io);
+
+    add_client(&mut sm, &io, client_id);
+    sm.set_client_role(client_id, ClientRole::Peer);
+    sm.take_outbox();
+
+    let base_row = visible_row(row_id, target_branch, Vec::new(), 900, b"base");
+    seed_visible_row(&mut sm, &mut io, "users", base_row.clone());
+
+    let staged_row = row_with_batch_state(
+        visible_row(
+            row_id,
+            target_branch,
+            vec![base_row.batch_id()],
+            1_000,
+            b"alice",
+        ),
+        batch_id,
+        crate::row_histories::RowState::StagingPending,
+        None,
+    );
+    sm.process_from_client(
+        &mut io,
+        client_id,
+        SyncPayload::RowBatchCreated {
+            metadata: Some(RowMetadata {
+                id: staged_row.row_id,
+                metadata: row_metadata("users"),
+            }),
+            row: staged_row.clone(),
+        },
+    );
+    sm.take_outbox();
+
+    sm.process_from_client(
+        &mut io,
+        client_id,
+        SyncPayload::SealBatch {
+            submission: sealed_submission(
+                batch_id,
+                target_branch,
+                vec![SealedBatchMember {
+                    object_id: row_id,
+                    row_digest: staged_row.content_digest(),
+                }],
+                vec![CapturedFrontierMember {
+                    object_id: row_id,
+                    branch_name: BranchName::new(target_branch),
+                    batch_id: base_row.batch_id(),
+                }],
+            ),
+        },
+    );
+
+    assert!(matches!(
+        io.load_authoritative_batch_fate(batch_id).unwrap(),
+        Some(BatchFate::AcceptedTransaction {
+            batch_id: settled_batch_id,
+            confirmed_tier: DurabilityTier::Local,
+        }) if settled_batch_id == batch_id
+    ));
+}
+
+#[test]
+fn seal_batch_rejects_transactional_insert_when_row_is_already_visible() {
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
+    let mut io = MemoryStorage::new();
+    let client_id = ClientId::new();
+    let batch_id = crate::row_histories::BatchId::new();
+    let row_id = ObjectId::new();
+    let target_branch = "dev-aaaaaaaaaaaa-main";
+    seed_users_schema(&mut io);
+
+    add_client(&mut sm, &io, client_id);
+    sm.set_client_role(client_id, ClientRole::Peer);
+    sm.take_outbox();
+
+    let existing_row = visible_row(row_id, target_branch, Vec::new(), 900, b"base");
+    seed_visible_row(&mut sm, &mut io, "users", existing_row.clone());
+
+    let staged_row = row_with_batch_state(
+        visible_row(row_id, target_branch, Vec::new(), 1_000, b"alice"),
+        batch_id,
+        crate::row_histories::RowState::StagingPending,
+        None,
+    );
+    sm.process_from_client(
+        &mut io,
+        client_id,
+        SyncPayload::RowBatchCreated {
+            metadata: Some(RowMetadata {
+                id: staged_row.row_id,
+                metadata: row_metadata("users"),
+            }),
+            row: staged_row.clone(),
+        },
+    );
+    sm.take_outbox();
+
+    sm.process_from_client(
+        &mut io,
+        client_id,
+        SyncPayload::SealBatch {
+            submission: sealed_submission(
+                batch_id,
+                target_branch,
+                vec![SealedBatchMember {
+                    object_id: row_id,
+                    row_digest: staged_row.content_digest(),
+                }],
+                vec![CapturedFrontierMember {
+                    object_id: row_id,
+                    branch_name: BranchName::new(target_branch),
+                    batch_id: existing_row.batch_id(),
+                }],
+            ),
+        },
+    );
+
+    assert_eq!(
+        io.load_authoritative_batch_fate(batch_id).unwrap(),
+        Some(BatchFate::Rejected {
+            batch_id,
+            code: "transaction_conflict".to_string(),
+            reason: "row visible parent changed since transaction write was staged".to_string(),
+        })
+    );
+}
+
+#[test]
+fn seal_batch_accepts_transactional_insert_when_row_is_not_visible() {
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
+    let mut io = MemoryStorage::new();
+    let client_id = ClientId::new();
+    let batch_id = crate::row_histories::BatchId::new();
+    let row_id = ObjectId::new();
+    let target_branch = "dev-aaaaaaaaaaaa-main";
+    seed_users_schema(&mut io);
+
+    add_client(&mut sm, &io, client_id);
+    sm.set_client_role(client_id, ClientRole::Peer);
+    sm.take_outbox();
+
+    let staged_row = row_with_batch_state(
+        visible_row(row_id, target_branch, Vec::new(), 1_000, b"alice"),
+        batch_id,
+        crate::row_histories::RowState::StagingPending,
+        None,
+    );
+    sm.process_from_client(
+        &mut io,
+        client_id,
+        SyncPayload::RowBatchCreated {
+            metadata: Some(RowMetadata {
+                id: staged_row.row_id,
+                metadata: row_metadata("users"),
+            }),
+            row: staged_row.clone(),
+        },
+    );
+    sm.take_outbox();
+
+    sm.process_from_client(
+        &mut io,
+        client_id,
+        SyncPayload::SealBatch {
+            submission: transactional_sealed_submission(
+                batch_id,
+                target_branch,
+                vec![SealedBatchMember {
+                    object_id: row_id,
+                    row_digest: staged_row.content_digest(),
+                }],
+                Vec::new(),
+            ),
+        },
+    );
+
+    assert!(matches!(
+        io.load_authoritative_batch_fate(batch_id).unwrap(),
+        Some(BatchFate::AcceptedTransaction {
+            batch_id: settled_batch_id,
+            confirmed_tier: DurabilityTier::Local,
+        }) if settled_batch_id == batch_id
+    ));
+}
+
+#[test]
+fn seal_batch_validates_full_transactional_parent_frontier() {
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
+    let mut io = MemoryStorage::new();
+    let client_id = ClientId::new();
+    let batch_id = crate::row_histories::BatchId::new();
+    let row_id = ObjectId::new();
+    let target_branch = "dev-aaaaaaaaaaaa-main";
+    seed_users_schema(&mut io);
+
+    add_client(&mut sm, &io, client_id);
+    sm.set_client_role(client_id, ClientRole::Peer);
+    sm.take_outbox();
+
+    let base_row = visible_row(row_id, target_branch, Vec::new(), 900, b"base");
+    let left_row = visible_row(
+        row_id,
+        target_branch,
+        vec![base_row.batch_id()],
+        1_000,
+        b"left",
+    );
+    let right_row = visible_row(
+        row_id,
+        target_branch,
+        vec![base_row.batch_id()],
+        1_001,
+        b"right",
+    );
+    create_test_row_with_id(&mut io, row_id, Some(row_metadata("users")));
+    io.append_history_region_rows(
+        "users",
+        &[base_row.clone(), left_row.clone(), right_row.clone()],
+    )
+    .unwrap();
+    io.upsert_visible_region_rows(
+        "users",
+        std::slice::from_ref(&crate::row_histories::VisibleRowEntry::rebuild(
+            right_row.clone(),
+            &[base_row.clone(), left_row.clone(), right_row.clone()],
+        )),
+    )
+    .unwrap();
+    let current_frontier = io
+        .load_visible_region_frontier("users", target_branch, row_id)
+        .unwrap()
+        .expect("multi-parent visible row should expose a frontier");
+    assert_eq!(current_frontier.len(), 2);
+    let captured_frontier = io
+        .capture_family_visible_frontier(BranchName::new(target_branch))
+        .unwrap();
+
+    let staged_row = row_with_batch_state(
+        visible_row(
+            row_id,
+            target_branch,
+            current_frontier.iter().rev().copied().collect(),
+            1_100,
+            b"alice",
+        ),
+        batch_id,
+        crate::row_histories::RowState::StagingPending,
+        None,
+    );
+    sm.process_from_client(
+        &mut io,
+        client_id,
+        SyncPayload::RowBatchCreated {
+            metadata: Some(RowMetadata {
+                id: staged_row.row_id,
+                metadata: row_metadata("users"),
+            }),
+            row: staged_row.clone(),
+        },
+    );
+    sm.take_outbox();
+
+    sm.process_from_client(
+        &mut io,
+        client_id,
+        SyncPayload::SealBatch {
+            submission: sealed_submission(
+                batch_id,
+                target_branch,
+                vec![SealedBatchMember {
+                    object_id: row_id,
+                    row_digest: staged_row.content_digest(),
+                }],
+                captured_frontier,
+            ),
+        },
+    );
+
+    assert!(matches!(
+        io.load_authoritative_batch_fate(batch_id).unwrap(),
+        Some(BatchFate::AcceptedTransaction {
+            batch_id: settled_batch_id,
+            confirmed_tier: DurabilityTier::Local,
+        }) if settled_batch_id == batch_id
+    ));
+}
+
+#[test]
 fn seal_batch_replay_returns_existing_settlement_after_frontier_moves() {
     let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
     let mut io = MemoryStorage::new();

--- a/packages/jazz-tools/tests/browser/db.transaction-reads.test.ts
+++ b/packages/jazz-tools/tests/browser/db.transaction-reads.test.ts
@@ -279,7 +279,7 @@ describe("db transaction reads browser integration", () => {
     });
   });
 
-  it.fails("two concurrent transactions that modify the same data can both commit", async () => {
+  it("concurrent transactions cannot modify the same data", async () => {
     const { value: base } = db.insert(todos, { title: "Shared", done: false });
 
     const aliceTx = db.beginTransaction();
@@ -289,9 +289,9 @@ describe("db transaction reads browser integration", () => {
     bobTx.update(todos, base.id, { title: "Bob's title" });
 
     await aliceTx.commit().wait({ tier: "local" });
-    // Currently, Alice's change becomes visible to Bob before it commits,
-    // so Bob's commit succeeds as well
-    await expect(bobTx.commit().wait({ tier: "local" })).rejects.toThrow("transaction_conflict");
+    await expect(bobTx.commit().wait({ tier: "local" })).rejects.toThrow(
+      "(transaction_conflict): row visible parent changed since transaction write was staged",
+    );
 
     expect((await db.one<Todo>(makeTodoQuery()))?.title).toEqual("Alice's title");
   });


### PR DESCRIPTION
## Description

FUP to https://github.com/garden-co/jazz/pull/903. Prevents transaction conflicts where multiple transaction write to the same object concurrently.

When a transaction stages a row, the staged `StoredRowBatch.parents` records the visible row frontier that the write was based on. When validating the transaction, the authority now loads the current visible frontier for each declared row in the sealed transaction and compares it to those recorded parents. If there's a mismatch, the transaction is rejected.

## Discussion

To me the new check is enough to prevent write conflicts from transactions writing to the same object, so we _should_ be able to remove the previous [captured frontier validation](https://github.com/garden-co/jazz/blob/fix/concurrent-write-tx-conflicts/crates/jazz-tools/src/sync_manager/inbox.rs#L143). Didn't want to make that change just yet in case I'm missing something. @aeplay if you agree the previous check is redundant, I'll go ahead and remove it.