### PR TITLE
Fix MCP server crash when node:sqlite is unavailable

### DIFF
--- a/.changeset/mcp-sqlite-fallback-no-crash.md
+++ b/.changeset/mcp-sqlite-fallback-no-crash.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix the MCP server crashing with `ERR_UNKNOWN_BUILTIN_MODULE` on Node.js < 22 (and non-Node runtimes). The text-search fallback used when `node:sqlite` is unavailable no longer transitively imports `node:sqlite`: the pure MDX parsing helpers now live in a sqlite-free module, so the fallback loads and serves docs instead of failing. The fallback also emits a loud deprecation warning, since Node.js < 22 is no longer supported.

--- a/docs/content/docs/reference/mcp.mdx
+++ b/docs/content/docs/reference/mcp.mdx
@@ -11,9 +11,9 @@ The docs served are always matched to the version of `jazz-tools` you install, s
 assistant is reading documentation for the exact API you have available. To use a different
 version's docs, specify a version tag instead (e.g. `pnpm dlx jazz-tools@2.0.0 mcp`).
 
-<Callout type="info">
-  Node 22.13 or later is recommended for the best search results. Earlier versions fall back to
-  basic keyword search.
+<Callout type="warn">
+  Node.js 22.12 or later is required. Older runtimes (and any runtime without `node:sqlite`) fall
+  back to a basic keyword search that is deprecated and will be removed in a future release.
 </Callout>
 
 ## Installation

--- a/packages/jazz-tools/src/mcp/__fixtures__/block-node-sqlite.hooks.mjs
+++ b/packages/jazz-tools/src/mcp/__fixtures__/block-node-sqlite.hooks.mjs
@@ -1,0 +1,14 @@
+// Module customization hooks that make `node:sqlite` look unavailable,
+// reproducing the behaviour of Node.js < 22 (and non-Node runtimes) where
+// the builtin does not exist.
+//
+// Used by fallback-no-sqlite.test.ts via block-node-sqlite.register.mjs.
+
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier === "node:sqlite" || specifier === "sqlite") {
+    throw Object.assign(new Error(`No such built-in module: ${specifier}`), {
+      code: "ERR_UNKNOWN_BUILTIN_MODULE",
+    });
+  }
+  return nextResolve(specifier, context);
+}

--- a/packages/jazz-tools/src/mcp/__fixtures__/block-node-sqlite.register.mjs
+++ b/packages/jazz-tools/src/mcp/__fixtures__/block-node-sqlite.register.mjs
@@ -1,0 +1,7 @@
+// Bootstrap passed via `node --import` so the spawned MCP server runs as if
+// `node:sqlite` did not exist. register() loads the hooks on a separate
+// thread, so the hooks live in their own module.
+
+import { register } from "node:module";
+
+register("./block-node-sqlite.hooks.mjs", import.meta.url);

--- a/packages/jazz-tools/src/mcp/backend-naive.test.ts
+++ b/packages/jazz-tools/src/mcp/backend-naive.test.ts
@@ -91,18 +91,21 @@ describe("createNaiveBackend", () => {
     expect(typeof backend.listPages).toBe("function");
   });
 
-  it("emits the node:sqlite unavailable warning to stderr on construction", async () => {
+  it("emits a loud deprecation warning to stderr on construction", async () => {
     const spy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     await createNaiveBackend(txtPath);
-    const calls = spy.mock.calls.map((c) => String(c[0]));
-    expect(calls.some((msg) => msg.includes("node:sqlite not available"))).toBe(true);
+    const msg = spy.mock.calls.map((c) => String(c[0])).join("");
+    expect(spy).toHaveBeenCalled();
+    expect(msg).toContain("DEPRECATED");
+    expect(msg).toContain("node:sqlite");
   });
 
-  it("warning message names the missing capability", async () => {
+  it("warning names the missing capability and the supported runtime", async () => {
     const spy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     await createNaiveBackend(txtPath);
-    const calls = spy.mock.calls.map((c) => String(c[0]));
-    expect(calls.some((msg) => msg.includes("node:sqlite + FTS5"))).toBe(true);
+    const msg = spy.mock.calls.map((c) => String(c[0])).join("");
+    expect(msg).toContain("FTS5");
+    expect(msg).toContain("Node.js 22");
   });
 });
 

--- a/packages/jazz-tools/src/mcp/backend-naive.ts
+++ b/packages/jazz-tools/src/mcp/backend-naive.ts
@@ -1,6 +1,9 @@
 import { readFile } from "node:fs/promises";
 
-import { splitIntoSections, type Section } from "./build-index.js";
+// Import from parse.js, NOT build-index.js: build-index statically imports
+// node:sqlite, which would crash this fallback on Node < 22. parse.js is
+// deliberately sqlite-free.
+import { splitIntoSections, type Section } from "./parse.js";
 import type { DocResult, DocsBackend, PageInfo, SearchResult } from "./backend-sqlite.js";
 
 export type { DocResult, DocsBackend, PageInfo, SearchResult };
@@ -11,11 +14,26 @@ export type { DocResult, DocsBackend, PageInfo, SearchResult };
 // deduplication is not needed here.
 // ---------------------------------------------------------------------------
 
+const DEPRECATION_BANNER = [
+  "",
+  "════════════════════════════════════════════════════════════════════",
+  "  ⚠  DEPRECATED: Jazz MCP server running in text-search fallback mode",
+  "════════════════════════════════════════════════════════════════════",
+  "  node:sqlite is unavailable, so the server fell back to basic",
+  "  text search — results are markedly worse than SQLite FTS5.",
+  "",
+  "  This fallback is DEPRECATED and will be REMOVED in a future",
+  "  release. Node.js < 22 is no longer supported.",
+  "",
+  '  Upgrade to Node.js 22.12+ (the current "Jod" LTS) so the MCP',
+  "  server can use full-quality SQLite FTS5 search.",
+  "════════════════════════════════════════════════════════════════════",
+  "",
+  "",
+].join("\n");
+
 function emitWarning(): void {
-  process.stderr.write(
-    "node:sqlite not available — using basic text search. " +
-      "Full-text search requires a runtime with node:sqlite + FTS5.\n",
-  );
+  process.stderr.write(DEPRECATION_BANNER);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/jazz-tools/src/mcp/build-index.ts
+++ b/packages/jazz-tools/src/mcp/build-index.ts
@@ -3,20 +3,29 @@ import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { DatabaseSync } from "node:sqlite";
 
+import {
+  extractDescription,
+  parseFrontmatter,
+  resolveIncludes,
+  splitIntoSections,
+  stripJsx,
+} from "./parse.js";
+
+// Re-exported so existing importers (and tests) keep a single entry point.
+// The implementations live in parse.ts, which has no node:sqlite dependency —
+// the text-search fallback imports them from there, never from this module.
+export {
+  extractDescription,
+  parseFrontmatter,
+  resolveIncludes,
+  splitIntoSections,
+  stripJsx,
+} from "./parse.js";
+export type { FrontmatterResult, Section } from "./parse.js";
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
-
-export interface FrontmatterResult {
-  title?: string;
-  description?: string;
-  body: string;
-}
-
-export interface Section {
-  heading: string;
-  body: string;
-}
 
 export interface BuildIndexOptions {
   /** Path to the content/docs directory containing .mdx files. */
@@ -29,170 +38,6 @@ export interface BuildIndexOptions {
    * Defaults to contentDir when not specified.
    */
   fileCwd?: string;
-}
-
-// ---------------------------------------------------------------------------
-// Pure helpers (exported for unit testing)
-// ---------------------------------------------------------------------------
-
-/**
- * Splits YAML frontmatter from MDX content.
- * Returns title, optional description, and the body after the closing `---`.
- */
-export function parseFrontmatter(content: string): FrontmatterResult {
-  const match = content.match(/^---\n([\s\S]*?)\n---\n*([\s\S]*)$/);
-  if (!match) {
-    return { body: content };
-  }
-
-  const fm = match[1];
-  const bodyMatch = match[2];
-  if (fm === undefined || bodyMatch === undefined) {
-    return { body: content };
-  }
-  const body = bodyMatch.trimStart();
-
-  const titleMatch = fm.match(/^title:\s*(.+)$/m);
-  const descMatch = fm.match(/^description:\s*(.+)$/m);
-
-  return {
-    title: titleMatch?.[1]?.trim(),
-    description: descMatch?.[1]?.trim(),
-    body,
-  };
-}
-
-/**
- * Extracts a description from rendered body text.
- * Strips fenced code blocks and headings, then returns the first three sentences.
- */
-export function extractDescription(body: string): string {
-  if (!body) return "";
-
-  // Strip all fenced code blocks
-  let text = body.replace(/```[\s\S]*?```/g, "");
-  // Strip markdown headings
-  text = text.replace(/^#{1,6}\s+.*/gm, "");
-  // Strip JSX tags (in case they weren't stripped already)
-  text = text.replace(/<\/?[A-Z][a-zA-Z]*[^>]*>/g, "");
-  // Collapse all whitespace to single spaces
-  text = text.replace(/\s+/g, " ").trim();
-
-  const sentences: string[] = [];
-  const sentenceRe = /[^.!?]+[.!?]+/g;
-  let m: RegExpExecArray | null;
-  while ((m = sentenceRe.exec(text)) !== null && sentences.length < 3) {
-    sentences.push(m[0].trim());
-  }
-
-  return sentences.join(" ");
-}
-
-/**
- * Resolves `<include cwd lang="…">path[#anchor]</include>` directives in MDX
- * content, replacing each with a fenced code block.  Paths are resolved
- * relative to the MDX file's directory unless the `cwd` attribute is present,
- * in which case fileCwd is used (mirrors fumadocs' file.cwd semantics).
- * Additional attributes (e.g. meta='…') are tolerated and ignored.
- */
-export async function resolveIncludes(
-  content: string,
-  mdxFilePath: string,
-  fileCwd?: string,
-): Promise<string> {
-  // Match <include ...attrs...>path</include> — any attribute combination.
-  const includeRe = /<include\s+([^>]*?)>\s*([\s\S]*?)\s*<\/include>/g;
-
-  // Collect all replacements first, then apply (to avoid regex state issues)
-  const replacements: Array<{ original: string; replacement: string }> = [];
-  let m: RegExpExecArray | null;
-
-  while ((m = includeRe.exec(content)) !== null) {
-    const attrs = m[1];
-    const includePath = m[2];
-    if (attrs === undefined || includePath === undefined) continue;
-    const hasCwd = /\bcwd\b/.test(attrs);
-    const langMatch = attrs.match(/\blang="([^"]+)"/);
-    if (!langMatch) continue; // not a code include — leave untouched
-    const lang = langMatch[1];
-    if (lang === undefined) continue;
-    const rawPath = includePath.trim();
-    const hashIdx = rawPath.indexOf("#");
-    const filePath = hashIdx === -1 ? rawPath : rawPath.slice(0, hashIdx);
-    const anchor = hashIdx === -1 ? null : rawPath.slice(hashIdx + 1);
-
-    const base = hasCwd && fileCwd ? fileCwd : dirname(mdxFilePath);
-    const resolvedPath = resolve(base, filePath.trim());
-    let fileContent = await readFile(resolvedPath, "utf8");
-
-    if (anchor) {
-      const regionRe = new RegExp(`// #region ${anchor}\\n([\\s\\S]*?)// #endregion ${anchor}`);
-      const regionMatch = fileContent.match(regionRe);
-      const regionBody = regionMatch?.[1];
-      if (regionBody !== undefined) {
-        fileContent = regionBody.trimEnd();
-      }
-    }
-
-    replacements.push({
-      original: m[0],
-      replacement: `\`\`\`${lang}\n${fileContent}\n\`\`\``,
-    });
-  }
-
-  let result = content;
-  for (const { original, replacement } of replacements) {
-    result = result.replace(original, replacement);
-  }
-  return result;
-}
-
-/**
- * Strips JSX component tags (uppercase-initial or namespaced) from content,
- * preserving text and fenced code blocks inside them.
- * Also strips MDX import/export declarations.
- */
-export function stripJsx(content: string): string {
-  let result = content;
-  // Strip MDX import/export lines
-  result = result.replace(/^(?:import|export)\s+.*$/gm, "");
-  // Self-closing JSX: <Component />
-  result = result.replace(/<[A-Z][a-zA-Z]*(?:\.[a-zA-Z]+)?[^>]*\/>/g, "");
-  // Opening JSX: <Component ...>
-  result = result.replace(/<[A-Z][a-zA-Z]*(?:\.[a-zA-Z]+)?[^>]*>/g, "");
-  // Closing JSX: </Component>
-  result = result.replace(/<\/[A-Z][a-zA-Z]*(?:\.[a-zA-Z]+)?>/g, "");
-  // Strip region marker lines left over from include expansion
-  // Covers: // #region, # #region, <!-- #region, /* #region */
-  result = result.replace(/^[ \t]*(?:\/\/|#|<!--|\/\*)\s*#?(?:end)?region\b.*$/gm, "");
-  // Collapse lines that contain only whitespace into empty lines
-  // (artefact of Tab/Tabs wrapper components being stripped)
-  result = result.replace(/^[ \t]+$/gm, "");
-  // Collapse 3+ blank lines to 2
-  result = result.replace(/\n{3,}/g, "\n\n");
-  return result.trim();
-}
-
-/**
- * Splits a body string into sections on `## ` heading boundaries.
- * Content before the first heading is returned as a section with an empty heading.
- */
-export function splitIntoSections(body: string): Section[] {
-  const parts = body.split(/(?=^## )/m);
-
-  return parts
-    .map((part): Section => {
-      const headingMatch = part.match(/^## (.+)\n/);
-      if (!headingMatch) {
-        return { heading: "", body: part.trim() };
-      }
-      const heading = headingMatch[1];
-      return {
-        heading: heading?.trim() ?? "",
-        body: part.replace(/^## .+\n/, "").trim(),
-      };
-    })
-    .filter((s) => s.body.length > 0 || s.heading.length > 0);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/jazz-tools/src/mcp/fallback-no-sqlite.test.ts
+++ b/packages/jazz-tools/src/mcp/fallback-no-sqlite.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Reproduces a user report: installing the MCP server under Node.js < 22
+ * (no `node:sqlite`) crashed with ERR_UNKNOWN_BUILTIN_MODULE instead of
+ * falling back to text search.
+ *
+ * Spawns the real server via the shim with a module hook that makes
+ * `node:sqlite` unavailable (see __fixtures__/block-node-sqlite.*), then
+ * drives it over stdio like a real MCP client.
+ *
+ * Requires: `pnpm build` before running (dist/mcp/server.js must exist).
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const shimPath = join(here, "../../bin/jazz-tools.js");
+const registerHook = join(here, "__fixtures__/block-node-sqlite.register.mjs");
+
+interface Server {
+  send(msg: object): void;
+  recv(): Promise<Record<string, unknown>>;
+  stderr(): string;
+  close(): Promise<number>;
+}
+
+function spawnMcpWithoutSqlite(): {
+  server: Server;
+  proc: ChildProcessWithoutNullStreams;
+} {
+  const proc = spawn(process.execPath, ["--import", registerHook, shimPath, "mcp"], {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  let stderrBuf = "";
+  proc.stderr.on("data", (c: Buffer) => {
+    stderrBuf += c.toString("utf8");
+  });
+
+  const queued: string[] = [];
+  const waiters: Array<(line: string) => void> = [];
+  let buf = "";
+  proc.stdout.on("data", (chunk: Buffer) => {
+    buf += chunk.toString("utf8");
+    const parts = buf.split("\n");
+    buf = parts.pop() ?? "";
+    for (const line of parts) {
+      if (!line.trim()) continue;
+      const waiter = waiters.shift();
+      if (waiter) {
+        waiter(line);
+      } else {
+        queued.push(line);
+      }
+    }
+  });
+
+  let exitCode: number | null = null;
+  const exited = new Promise<number>((resolve) => {
+    proc.on("close", (code) => {
+      exitCode = code ?? 0;
+      resolve(exitCode);
+    });
+  });
+
+  const server: Server = {
+    send(msg: object) {
+      proc.stdin.write(JSON.stringify(msg) + "\n");
+    },
+    recv(): Promise<Record<string, unknown>> {
+      return new Promise((resolve, reject) => {
+        const line = queued.shift();
+        if (line !== undefined) {
+          resolve(JSON.parse(line) as Record<string, unknown>);
+          return;
+        }
+        let settled = false;
+        waiters.push((l) => {
+          if (settled) return;
+          settled = true;
+          resolve(JSON.parse(l) as Record<string, unknown>);
+        });
+        // If the process dies before answering, fail loudly with its stderr
+        // rather than hanging until the test timeout.
+        void exited.then((code) => {
+          if (settled) return;
+          settled = true;
+          reject(
+            new Error(
+              `MCP server exited (code ${code}) before responding.\n--- stderr ---\n${stderrBuf}`,
+            ),
+          );
+        });
+      });
+    },
+    stderr: () => stderrBuf,
+    close(): Promise<number> {
+      proc.stdin.end();
+      return exited;
+    },
+  };
+
+  return { server, proc };
+}
+
+let server: Server;
+let proc: ChildProcessWithoutNullStreams;
+
+beforeEach(() => {
+  ({ server, proc } = spawnMcpWithoutSqlite());
+});
+
+afterEach(async () => {
+  if (proc.exitCode === null && !proc.killed) {
+    proc.stdin.end();
+    await new Promise<void>((res) => proc.on("close", () => res()));
+  }
+});
+
+describe("MCP server without node:sqlite (Node < 22)", () => {
+  it("falls back to text search and answers search_docs instead of crashing", async () => {
+    server.send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+    const init = await server.recv();
+    expect(init.id).toBe(1);
+
+    server.send({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/call",
+      params: { name: "search_docs", arguments: { query: "schema" } },
+    });
+    const res = await server.recv();
+
+    expect(res.error).toBeUndefined();
+    const content = (
+      (res.result as Record<string, unknown>).content as Array<{ type: string; text: string }>
+    )[0];
+    expect(content).toBeDefined();
+    expect(content!.type).toBe("text");
+    expect(content!.text).not.toBe("No results found.");
+    expect(content!.text.length).toBeGreaterThan(0);
+  });
+
+  it("exits cleanly (code 0) on stdin EOF", async () => {
+    server.send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+    await server.recv();
+    const code = await server.close();
+    expect(code).toBe(0);
+  });
+
+  it("emits a loud deprecation warning to stderr", async () => {
+    server.send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+    await server.recv();
+    await server.close();
+
+    const err = server.stderr();
+    expect(err).toMatch(/DEPRECATED/);
+    expect(err).toMatch(/REMOVED/);
+    expect(err).toMatch(/Node\.js 22/);
+  });
+});

--- a/packages/jazz-tools/src/mcp/parse.ts
+++ b/packages/jazz-tools/src/mcp/parse.ts
@@ -1,0 +1,188 @@
+// Pure MDX → pages/sections parsing helpers.
+//
+// This module deliberately has NO `node:sqlite` dependency (directly or
+// transitively) so it stays importable on Node < 22 and non-Node runtimes.
+// The text-search fallback backend depends on it; only the index *writer*
+// (build-index.ts) needs node:sqlite.
+
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface FrontmatterResult {
+  title?: string;
+  description?: string;
+  body: string;
+}
+
+export interface Section {
+  heading: string;
+  body: string;
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for unit testing)
+// ---------------------------------------------------------------------------
+
+/**
+ * Splits YAML frontmatter from MDX content.
+ * Returns title, optional description, and the body after the closing `---`.
+ */
+export function parseFrontmatter(content: string): FrontmatterResult {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n*([\s\S]*)$/);
+  if (!match) {
+    return { body: content };
+  }
+
+  const fm = match[1];
+  const bodyMatch = match[2];
+  if (fm === undefined || bodyMatch === undefined) {
+    return { body: content };
+  }
+  const body = bodyMatch.trimStart();
+
+  const titleMatch = fm.match(/^title:\s*(.+)$/m);
+  const descMatch = fm.match(/^description:\s*(.+)$/m);
+
+  return {
+    title: titleMatch?.[1]?.trim(),
+    description: descMatch?.[1]?.trim(),
+    body,
+  };
+}
+
+/**
+ * Extracts a description from rendered body text.
+ * Strips fenced code blocks and headings, then returns the first three sentences.
+ */
+export function extractDescription(body: string): string {
+  if (!body) return "";
+
+  // Strip all fenced code blocks
+  let text = body.replace(/```[\s\S]*?```/g, "");
+  // Strip markdown headings
+  text = text.replace(/^#{1,6}\s+.*/gm, "");
+  // Strip JSX tags (in case they weren't stripped already)
+  text = text.replace(/<\/?[A-Z][a-zA-Z]*[^>]*>/g, "");
+  // Collapse all whitespace to single spaces
+  text = text.replace(/\s+/g, " ").trim();
+
+  const sentences: string[] = [];
+  const sentenceRe = /[^.!?]+[.!?]+/g;
+  let m: RegExpExecArray | null;
+  while ((m = sentenceRe.exec(text)) !== null && sentences.length < 3) {
+    sentences.push(m[0].trim());
+  }
+
+  return sentences.join(" ");
+}
+
+/**
+ * Resolves `<include cwd lang="…">path[#anchor]</include>` directives in MDX
+ * content, replacing each with a fenced code block.  Paths are resolved
+ * relative to the MDX file's directory unless the `cwd` attribute is present,
+ * in which case fileCwd is used (mirrors fumadocs' file.cwd semantics).
+ * Additional attributes (e.g. meta='…') are tolerated and ignored.
+ */
+export async function resolveIncludes(
+  content: string,
+  mdxFilePath: string,
+  fileCwd?: string,
+): Promise<string> {
+  // Match <include ...attrs...>path</include> — any attribute combination.
+  const includeRe = /<include\s+([^>]*?)>\s*([\s\S]*?)\s*<\/include>/g;
+
+  // Collect all replacements first, then apply (to avoid regex state issues)
+  const replacements: Array<{ original: string; replacement: string }> = [];
+  let m: RegExpExecArray | null;
+
+  while ((m = includeRe.exec(content)) !== null) {
+    const attrs = m[1];
+    const includePath = m[2];
+    if (attrs === undefined || includePath === undefined) continue;
+    const hasCwd = /\bcwd\b/.test(attrs);
+    const langMatch = attrs.match(/\blang="([^"]+)"/);
+    if (!langMatch) continue; // not a code include — leave untouched
+    const lang = langMatch[1];
+    if (lang === undefined) continue;
+    const rawPath = includePath.trim();
+    const hashIdx = rawPath.indexOf("#");
+    const filePath = hashIdx === -1 ? rawPath : rawPath.slice(0, hashIdx);
+    const anchor = hashIdx === -1 ? null : rawPath.slice(hashIdx + 1);
+
+    const base = hasCwd && fileCwd ? fileCwd : dirname(mdxFilePath);
+    const resolvedPath = resolve(base, filePath.trim());
+    let fileContent = await readFile(resolvedPath, "utf8");
+
+    if (anchor) {
+      const regionRe = new RegExp(`// #region ${anchor}\\n([\\s\\S]*?)// #endregion ${anchor}`);
+      const regionMatch = fileContent.match(regionRe);
+      const regionBody = regionMatch?.[1];
+      if (regionBody !== undefined) {
+        fileContent = regionBody.trimEnd();
+      }
+    }
+
+    replacements.push({
+      original: m[0],
+      replacement: `\`\`\`${lang}\n${fileContent}\n\`\`\``,
+    });
+  }
+
+  let result = content;
+  for (const { original, replacement } of replacements) {
+    result = result.replace(original, replacement);
+  }
+  return result;
+}
+
+/**
+ * Strips JSX component tags (uppercase-initial or namespaced) from content,
+ * preserving text and fenced code blocks inside them.
+ * Also strips MDX import/export declarations.
+ */
+export function stripJsx(content: string): string {
+  let result = content;
+  // Strip MDX import/export lines
+  result = result.replace(/^(?:import|export)\s+.*$/gm, "");
+  // Self-closing JSX: <Component />
+  result = result.replace(/<[A-Z][a-zA-Z]*(?:\.[a-zA-Z]+)?[^>]*\/>/g, "");
+  // Opening JSX: <Component ...>
+  result = result.replace(/<[A-Z][a-zA-Z]*(?:\.[a-zA-Z]+)?[^>]*>/g, "");
+  // Closing JSX: </Component>
+  result = result.replace(/<\/[A-Z][a-zA-Z]*(?:\.[a-zA-Z]+)?>/g, "");
+  // Strip region marker lines left over from include expansion
+  // Covers: // #region, # #region, <!-- #region, /* #region */
+  result = result.replace(/^[ \t]*(?:\/\/|#|<!--|\/\*)\s*#?(?:end)?region\b.*$/gm, "");
+  // Collapse lines that contain only whitespace into empty lines
+  // (artefact of Tab/Tabs wrapper components being stripped)
+  result = result.replace(/^[ \t]+$/gm, "");
+  // Collapse 3+ blank lines to 2
+  result = result.replace(/\n{3,}/g, "\n\n");
+  return result.trim();
+}
+
+/**
+ * Splits a body string into sections on `## ` heading boundaries.
+ * Content before the first heading is returned as a section with an empty heading.
+ */
+export function splitIntoSections(body: string): Section[] {
+  const parts = body.split(/(?=^## )/m);
+
+  return parts
+    .map((part): Section => {
+      const headingMatch = part.match(/^## (.+)\n/);
+      if (!headingMatch) {
+        return { heading: "", body: part.trim() };
+      }
+      const heading = headingMatch[1];
+      return {
+        heading: heading?.trim() ?? "",
+        body: part.replace(/^## .+\n/, "").trim(),
+      };
+    })
+    .filter((s) => s.body.length > 0 || s.heading.length > 0);
+}


### PR DESCRIPTION
## Summary

- The text-search fallback ran via `await import("./backend-naive.js")` after `node:sqlite` rejected — but `backend-naive` statically imported `splitIntoSections` from `build-index`, and `build-index` has a top-level `import { DatabaseSync } from "node:sqlite"`. On Node <22 the module linker threw `ERR_UNKNOWN_BUILTIN_MODULE` while resolving the fallback subgraph (the `at async ModuleJob._link` frame in the user report). The bin shim doesn't wrap the top-level `await`, so it surfaced as an uncaught crash → "Connection closed" in the MCP client.
- Extract the pure MDX parsers (`splitIntoSections`, `parseFrontmatter`, `extractDescription`, `resolveIncludes`, `stripJsx`) into a new sqlite-free `parse.ts`. `build-index.ts` re-exports them and keeps `node:sqlite` only for the index *writer*. `backend-naive.ts` now imports from `parse.ts`, so the fallback's module graph never touches `node:sqlite`.
- Make the fallback warning a loud deprecation banner: Node.js <22 is no longer supported and the text-search path will be removed in a future release. Updated the two `backend-naive` unit tests that pinned the old copy.
- Reference docs callout changed from "recommended" to a deprecation warning.

## Why this is effectively free

We don't support Node.js <22 any more — to be clear, we're not committing to keep it working long term. But the text-search fallback already exists for non-Node runtimes that lack `node:sqlite` (Bun, older Deno, workerd, bundled environments), and we maintain that path regardless. This change doesn't add a new code branch or a new runtime to support — it just makes the existing fallback actually reachable. The upside is that Node <22 now degrades gracefully with a loud deprecation banner instead of an uncaught ESM crash, at no extra surface area for us.

## Runtime behaviour on `node:sqlite` (empirical)

| Runtime | Behaviour |
|---|---|
| Node <22 | `ERR_UNKNOWN_BUILTIN_MODULE` "No such built-in module: node:sqlite" — catchable as a dynamic-import rejection; static link throws at `ModuleJob._link` |
| Bun 1.2.21 | `ResolveMessage`, same `code: ERR_UNKNOWN_BUILTIN_MODULE`, same message — identical shape to Node <22 |
| Deno | `node:sqlite` only on recent versions; older throws a catchable module-resolution error (not tested locally — no Deno here) |
| workerd / bundlers / browsers | No `node:sqlite` — resolution fails |

The bare `catch {}` in `selectBackend` already absorbs whatever the runtime throws; the only defect was the fallback re-importing `node:sqlite` statically.

## Test plan

- [ ] `pnpm --filter jazz-tools build:runtime && pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/mcp/` — all 6 MCP test files green, including the new `fallback-no-sqlite.test.ts` that spawns the server under a module hook making `node:sqlite` absent and asserts it falls back instead of crashing.
- [ ] Eyeball the loud deprecation banner on stderr when the fallback runs (visible in the new test's output).
