### PR TITLE
Add Transactions & Batches docs page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ dist/
 # Build artifacts
 *.tsbuildinfo
 .svelte-kit/
-examples/nextjs-csr-ssr/next-env.d.ts
+**/next-env.d.ts
 
 # IDE
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist/
 # Build artifacts
 *.tsbuildinfo
 .svelte-kit/
+examples/nextjs-csr-ssr/next-env.d.ts
 
 # IDE
 .idea/

--- a/docs/content/docs/writing/meta.json
+++ b/docs/content/docs/writing/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Writing Data",
-  "pages": ["writing-data", "files-and-blobs"]
+  "pages": ["writing-data", "transactions-and-batches", "files-and-blobs"]
 }

--- a/docs/content/docs/writing/transactions-and-batches.mdx
+++ b/docs/content/docs/writing/transactions-and-batches.mdx
@@ -8,7 +8,7 @@ import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
 A single `insert`, `update`, or `delete` settles on its own. Group writes when several
 changes should become visible together and share one accept-or-reject fate. Batches and
-transactions both do this; they differ in _when_ the group becomes visible.
+transactions both do this; they differ in _when_ the changes become visible.
 
 ## When to use which
 

--- a/docs/content/docs/writing/transactions-and-batches.mdx
+++ b/docs/content/docs/writing/transactions-and-batches.mdx
@@ -1,7 +1,7 @@
 ---
 title: Transactions & Batches
 description: "Grouping writes so they settle together: differences between transactions and batches, callback vs explicit forms, committing and durability."
-reviewedAt: "110909624"
+reviewedAt: "17f6af400"
 ---
 
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
@@ -20,11 +20,9 @@ transactions both do this; they differ in _when_ the group becomes visible.
 
 ## Opening a transaction or batch
 
-There are two ways to open a group write.
-
 ### Callback
 
-Use a callback to create a group write in a single step with either `db.transaction(cb)` or `db.batch(cb)`. The group write commits when the callback returns and rolls back if it throws. You can use synchronous or async callbacks. If you choose to provide a return value, you can access it on the result:
+Use a callback to create a group write in a single step with either `db.transaction(cb)` or `db.batch(cb)`. The group write commits when the callback returns and rolls back if it throws. You can use synchronous or async callbacks. Any value the callback returns is available on the result:
 
 <include cwd lang="ts">
   ../examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts#writing-tx-callback-ts
@@ -35,15 +33,9 @@ callback's return value), `.batchId`, and `.wait({ tier })`. The handle passed t
 callback is scoped: it has no `commit()` or `rollback()`. A read-only callback commits
 nothing and still resolves with its `.value`.
 
-<Callout type="warn">
-  A `commit()` succeeding locally does not mean that the write was accepted. If you need to observe
-  the writes successfully landing together durably, await the `wait({tier})` call separately, and
-  handle any errors it throws.
-</Callout>
-
 ### Explicit form
 
-The **explicit form** gives you a handle you use to commit or roll back yourself. This is particularly useful if
+The **explicit form** gives you a handle you use to commit or roll back yourself. Useful when
 your writes span multiple call sites:
 
 <include cwd lang="ts">
@@ -65,15 +57,15 @@ An explicit transaction is a tidy test-isolation primitive: open one in `beforeE
 </Accordion>
 </Accordions>
 
-## Transaction isolation
+## Read isolation
 
 While a transaction or batch is open, its writes are _staged_, not yet committed. This
 produces a deliberate split in what different reads observe:
 
 - **Reads outside the transaction**&hairsp;—&hairsp;`db.all(...)`, `db.one(...)`&hairsp;—&hairsp;never observe
   staged writes. They return only committed data until the transaction or batch commits.
-- **Batch-scoped reads**&hairsp;—&hairsp;`tx.all(...)`, `tx.one(...)` (and the same on a batch)&hairsp;—&hairsp;see
-  the transaction's _own_ staged writes layered over committed data.
+- **Batch-scoped reads**&hairsp;—&hairsp;`tx.all(...)`, `tx.one(...)` (and the same on a batch)&hairsp;—&hairsp;run
+  against all current committed data layered with the transaction's _own_ staged writes.
 
 The handle for batch-scoped reads is available either as an argument passed to the callback, or returned from the `beginBatch()` or `beginTransaction()` call.
 
@@ -86,8 +78,6 @@ Concurrent group writes never observe each other's staged writes, even when they
 <include cwd lang="ts">
   ../examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts#writing-tx-concurrent-ts
 </include>
-
-Batch-scoped reads run against _all_ current committed data (there's no 'snapshot' at the start), plus your own staged writes.
 
 ## Committing & durability
 
@@ -103,7 +93,7 @@ When connected to a sync server, await `result.wait({ tier })` before relying on
 Staged writes live locally only until they are committed. A `rollback()` discards the staged
 writes entirely, and they are never synced.
 
-If a group write is rejected it rejects with `PersistedWriteRejectedError`. With a batch, all
+A rejected group write throws a `PersistedWriteRejectedError`. With a batch, all
 grouped writes are visible between the commit and the rejection; with a transaction, rejected
 writes never become visible.
 
@@ -113,7 +103,7 @@ consistency model.
 
 ## Atomic multi-table writes
 
-The main reason transactions exist is to ensure that changes across more than one table land together with no partially-visible state.
+Use a transaction when changes across multiple tables must land together with no partially-visible state.
 
 Neither row below is visible to any other read until the transaction commits&hairsp;—&hairsp;there
 is no window where the todo exists without its project.

--- a/docs/content/docs/writing/transactions-and-batches.mdx
+++ b/docs/content/docs/writing/transactions-and-batches.mdx
@@ -1,0 +1,123 @@
+---
+title: Transactions & Batches
+description: "Grouping writes so they settle together: differences between transactions and batches, callback vs explicit forms, committing and durability."
+reviewedAt: "110909624"
+---
+
+import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
+
+A single `insert`, `update`, or `delete` settles on its own. Group writes when several
+changes should become visible together and share one accept-or-reject fate. Batches and
+transactions both do this; they differ in _when_ the group becomes visible.
+
+## When to use which
+
+| Use             | When                                                                                                     |
+| --------------- | -------------------------------------------------------------------------------------------------------- |
+| Single write    | The change stands alone. Returns an awaitable write handle.                                              |
+| **Batch**       | Immediately readable locally after committing. If rejected at a higher tier, the whole batch rolls back. |
+| **Transaction** | Readable only once accepted at a higher tier.                                                            |
+
+## Opening a transaction or batch
+
+There are two ways to open a group write.
+
+### Callback
+
+Use a callback to create a group write in a single step with either `db.transaction(cb)` or `db.batch(cb)`. The group write commits when the callback returns and rolls back if it throws. You can use synchronous or async callbacks. If you choose to provide a return value, you can access it on the result:
+
+<include cwd lang="ts">
+  ../examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts#writing-tx-callback-ts
+</include>
+
+`db.transaction(cb)` and `db.batch(cb)` return a write result carrying `.value` (the
+callback's return value), `.batchId`, and `.wait({ tier })`. The handle passed to the
+callback is scoped: it has no `commit()` or `rollback()`. A read-only callback commits
+nothing and still resolves with its `.value`.
+
+<Callout type="warn">
+  A `commit()` succeeding locally does not mean that the write was accepted. If you need to observe
+  the writes successfully landing together durably, await the `wait({tier})` call separately, and
+  handle any errors it throws.
+</Callout>
+
+### Explicit form
+
+The **explicit form** gives you a handle you use to commit or roll back yourself. This is particularly useful if
+your writes span multiple call sites:
+
+<include cwd lang="ts">
+  ../examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts#writing-tx-explicit-ts
+</include>
+
+`beginTransaction()` and `beginBatch()` require explicit `commit()` or `rollback()`.
+
+<Accordions type="single">
+<Accordion id="transaction-per-test-isolation" title="Tip: transaction-per-test isolation">
+
+An explicit transaction is a tidy test-isolation primitive: open one in `beforeEach`,
+`rollback()` in `afterEach`, and each test's writes are discarded without touching the next.
+
+<include cwd lang="ts">
+  ../examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts#writing-tx-test-fixture-ts
+</include>
+
+</Accordion>
+</Accordions>
+
+## Transaction isolation
+
+While a transaction or batch is open, its writes are _staged_, not yet committed. This
+produces a deliberate split in what different reads observe:
+
+- **Reads outside the transaction**&hairsp;—&hairsp;`db.all(...)`, `db.one(...)`&hairsp;—&hairsp;never observe
+  staged writes. They return only committed data until the transaction or batch commits.
+- **Batch-scoped reads**&hairsp;—&hairsp;`tx.all(...)`, `tx.one(...)` (and the same on a batch)&hairsp;—&hairsp;see
+  the transaction's _own_ staged writes layered over committed data.
+
+The handle for batch-scoped reads is available either as an argument passed to the callback, or returned from the `beginBatch()` or `beginTransaction()` call.
+
+<include cwd lang="ts">
+  ../examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts#writing-tx-isolation-ts
+</include>
+
+Concurrent group writes never observe each other's staged writes, even when they touch the same row.
+
+<include cwd lang="ts">
+  ../examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts#writing-tx-concurrent-ts
+</include>
+
+Batch-scoped reads run against _all_ current committed data (there's no 'snapshot' at the start), plus your own staged writes.
+
+## Committing & durability
+
+`commit()` returns a write handle with `.batchId` and `.wait({ tier })`. A batch becomes visible to indexed reads as soon as `commit()`
+returns, while a transaction becomes globally visible only once it's accepted.
+
+When connected to a sync server, await `result.wait({ tier })` before relying on the write being visible to reads elsewhere.
+
+<include cwd lang="ts">
+  ../examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts#writing-tx-commit-visibility-ts
+</include>
+
+Staged writes live locally only until they are committed. A `rollback()` discards the staged
+writes entirely, and they are never synced.
+
+If a group write is rejected it rejects with `PersistedWriteRejectedError`. With a batch, all
+grouped writes are visible between the commit and the rejection; with a transaction, rejected
+writes never become visible.
+
+See [Writing Data](/docs/writing/writing-data#write-durability-tiers) for `wait({ tier })`
+and `onMutationError`, and [Durability Tiers](/docs/reference/durability-tiers) for the full
+consistency model.
+
+## Atomic multi-table writes
+
+The main reason transactions exist is to ensure that changes across more than one table land together with no partially-visible state.
+
+Neither row below is visible to any other read until the transaction commits&hairsp;—&hairsp;there
+is no window where the todo exists without its project.
+
+<include cwd lang="ts">
+  ../examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts#writing-tx-multitable-ts
+</include>

--- a/docs/content/docs/writing/writing-data.mdx
+++ b/docs/content/docs/writing/writing-data.mdx
@@ -164,55 +164,25 @@ db.onMutationError((error) => {
 
 ## Transactions and batches
 
-Use a transaction when several writes should settle together after an authority validates the sealed batch:
+Group several writes so they settle together. A **direct batch** makes its writes visible
+the moment it commits; a **transaction** settles atomically once an authority accepts the
+sealed batch. Both offer a callback form that auto-commits (and rolls back if the callback
+throws) and an explicit `beginTransaction()` / `beginBatch()` form for writes that span
+multiple call sites.
 
-```ts
-const result = await db.transaction(async (tx) => {
-  tx.insert(app.todos, { title: "Draft copy", done: false });
-  const stagedDrafts = await tx.all(app.todos.where({ done: false }));
-  tx.update(app.todos, todoId, { done: true });
-});
-await result.wait({ tier: "edge" });
-console.log(result.batchId);
-```
+### Transaction isolation
 
-The changes made as part of the transaction are scoped to it, and will only be
-globally visible once it's committed and accepted by the authority.
+While a transaction or batch is open, its writes are staged. Reads from outside it —
+`db.all(...)`, `db.one(...)` — do not see staged writes; they return only committed data.
+Batch-scoped reads — `tx.all(...)`, `tx.one(...)` — do see the transaction's own staged
+writes. Once it commits, those writes become visible to ordinary indexed reads too. This is
+why a write you just made inside a transaction shows up via `tx.all(...)` but not yet via
+`db.all(...)`:
 
-You can also use batches when you want to group several ordinary writes and commit them together:
+<include cwd lang="ts">
+  ../examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts#writing-tx-isolation-ts
+</include>
 
-```ts
-const result = db.batch((batch) => {
-  batch.insert(app.todos, { title: "Grouped write", done: false });
-  batch.update(app.todos, todoId, { done: true });
-});
-await result.wait({ tier: "edge" });
-console.log(result.batchId);
-```
-
-Transactions and batches can read its own local writes through `all(...)` and `one(...)` before commit.
-
-When using `transaction` and `batch`, changes are automatically committed once the callback finishes running and,
-if an error is thrown inside the callback, the open transaction or batch is rolled back instead of committed.
-
-Alternatively, you can use `beginTransaction` and `beginBatch` to get a transaction or batch object, respectively.
-This can be useful when making writes across multiple contexts. In this case however, you need to commit or rollback
-the transaction/batch explicitly.
-
-```ts
-let transaction: DbTransaction;
-beforeEach(() => {
-  transaction = db.beginTransaction();
-});
-
-afterEach(() => {
-  // Writes performed in tests will be rolled back at the end,
-  // preventing tests from interfering with each other
-  transaction.rollback();
-});
-
-it("tasks have a title", () => {
-  const task = transaction.insert(todos, { title: "Test task", done: false });
-  expect(task.title).toEqual("Test task");
-});
-```
+See [Transactions & Batches](/docs/writing/transactions-and-batches) for the full treatment:
+when to use which, the callback and explicit forms, concurrent-transaction isolation, commit
+and durability, the error edges, and atomic multi-table writes.

--- a/docs/content/docs/writing/writing-data.mdx
+++ b/docs/content/docs/writing/writing-data.mdx
@@ -182,22 +182,24 @@ db.onMutationError((error) => {
 
 ## Transactions and batches
 
-Use a transaction when several writes should settle together after an authority validates the sealed batch:
+Group several writes so they settle together. A **direct batch** makes its writes visible
+the moment it commits; a **transaction** settles atomically once an authority accepts the
+sealed batch. Both offer a callback form that auto-commits (and rolls back if the callback
+throws) and an explicit `beginTransaction()` / `beginBatch()` form for writes that span
+multiple call sites.
 
-```ts
-const result = await db.transaction(async (tx) => {
-  tx.insert(app.todos, { title: "Draft copy", done: false });
-  const stagedDrafts = await tx.all(app.todos.where({ done: false }));
-  tx.update(app.todos, todoId, { done: true });
-});
-await result.wait({ tier: "edge" });
-console.log(result.batchId);
-```
+### Transaction isolation
 
-The changes made as part of the transaction are scoped to it, and will only be
-globally visible once it's committed and accepted by the authority.
+While a transaction or batch is open, its writes are staged. Reads from outside it —
+`db.all(...)`, `db.one(...)` — do not see staged writes; they return only committed data.
+Batch-scoped reads — `tx.all(...)`, `tx.one(...)` — do see the transaction's own staged
+writes. Once it commits, those writes become visible to ordinary indexed reads too. This is
+why a write you just made inside a transaction shows up via `tx.all(...)` but not yet via
+`db.all(...)`:
 
-You can also use batches when you want to group several ordinary writes and commit them together:
+<include cwd lang="ts">
+  ../examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts#writing-tx-isolation-ts
+</include>
 
 ```ts
 const result = db.batch((batch) => {
@@ -234,3 +236,7 @@ it("tasks have a title", () => {
   expect(task.title).toEqual("Test task");
 });
 ```
+
+See [Transactions & Batches](/docs/writing/transactions-and-batches) for the full treatment:
+when to use which, the callback and explicit forms, concurrent-transaction isolation, commit
+and durability, the error edges, and atomic multi-table writes.

--- a/examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts
@@ -43,6 +43,10 @@ const urgent = openTodos.where({ title: { contains: "urgent" } });
 const incompleteTodos = app.todos.where({ done: false }).orderBy("title", "asc").limit(50);
 // #endregion reading-chained-query-ts
 
+// The query objects above are illustrative snippet fragments not referenced
+// elsewhere; re-export them so they count as used.
+export { byNewest, byTitle, urgent, incompleteTodos };
+
 // #region reading-filters-ts
 export async function readTodosWithFilters(db: Db) {
   return db.all(app.todos.where({ done: false, title: { contains: "docs" } }));

--- a/examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts
@@ -1,4 +1,4 @@
-import type { Db } from "jazz-tools";
+import type { Db, DbTransaction } from "jazz-tools";
 import { app } from "../schema.js";
 
 const EXAMPLE_PROJECT_ID = "00000000-0000-0000-0000-000000000000";
@@ -285,3 +285,147 @@ export async function combinedQuery(db: Db) {
   return results;
 }
 // #endregion combining-ts
+
+// #region writing-tx-isolation-ts
+export async function transactionIsolation(db: Db) {
+  const tx = db.beginTransaction();
+  tx.insert(app.todos, { title: "Draft launch post", done: false });
+
+  // Using the tx handle here means we can read the staged write
+  const stagedInTx = await tx.all(app.todos.where({ done: false }));
+
+  // Using the db handle only shows us the committed state, so the new todo is still invisible.
+  const visibleOutside = await db.all(app.todos.where({ done: false }));
+
+  tx.commit();
+
+  // After commit the write is visible to ordinary reads too.
+  const visibleAfterCommit = await db.all(app.todos.where({ done: false }));
+
+  return { stagedInTx, visibleOutside, visibleAfterCommit };
+}
+// #endregion writing-tx-isolation-ts
+
+// #region writing-tx-concurrent-ts
+export async function concurrentTransactionIsolation(db: Db) {
+  const aliceTx = db.beginTransaction();
+  const bobTx = db.beginTransaction();
+
+  aliceTx.insert(app.todos, { title: "Alice draft", done: false });
+  bobTx.insert(app.todos, { title: "Bob draft", done: false });
+
+  // Open transactions never observe each other's staged writes —
+  // each list contains only that transaction's own draft.
+  const aliceSees = await aliceTx.all(app.todos.where({ done: false }));
+  const bobSees = await bobTx.all(app.todos.where({ done: false }));
+
+  aliceTx.rollback(); // staged write discarded — visible to no reader
+  bobTx.commit();
+
+  // Only Bob's committed draft is visible to indexed reads.
+  const visible = await db.all(app.todos.where({ done: false }));
+
+  return { aliceSees, bobSees, visible };
+}
+// #endregion writing-tx-concurrent-ts
+
+// #region writing-tx-commit-visibility-ts
+export async function directBatchCommitVisibility(db: Db) {
+  const batch = db.beginBatch();
+  batch.insert(app.todos, { title: "Grouped write", done: false });
+
+  // Staged writes are invisible to indexed reads while the batch is open.
+  const beforeCommit = await db.all(app.todos.where({ done: false }));
+
+  batch.commit();
+
+  // A direct batch is visible to indexed reads as soon as it commits —
+  // there is no authority round-trip. A transaction instead becomes
+  // globally visible only once the authority accepts it; when connected
+  // to a sync server, await result.wait({ tier }) before relying on that.
+  const afterCommit = await db.all(app.todos.where({ done: false }));
+
+  return { beforeCommit, afterCommit };
+}
+// #endregion writing-tx-commit-visibility-ts
+
+// #region writing-tx-callback-ts
+export async function markAllOpenToDosAsDone(db: Db) {
+  // The callback may be async. Return a value and it flows through
+  // the WriteResult. Throw and the whole transaction rolls back.
+  const result = await db.transaction(async (tx) => {
+    const open = await tx.all(app.todos.where({ done: false }));
+    for (const todo of open) {
+      tx.update(app.todos, todo.id, { done: true });
+    }
+    return open.length;
+  });
+
+  return { closedCount: result.value, batchId: result.batchId };
+}
+// #endregion writing-tx-callback-ts
+
+// #region writing-tx-explicit-ts
+export function importProjectPlan(db: Db, plan: { name: string; tasks: string[] }) {
+  const tx = db.beginTransaction();
+  try {
+    const projectId = stageProject(tx, plan.name);
+    for (const title of plan.tasks) {
+      stageTask(tx, projectId, title);
+    }
+    return tx.commit().batchId;
+  } catch (error) {
+    tx.rollback();
+    throw error;
+  }
+}
+
+function stageProject(tx: DbTransaction, name: string) {
+  return tx.insert(app.projects, { name }).id;
+}
+
+function stageTask(tx: DbTransaction, projectId: string, title: string) {
+  tx.insert(app.todos, { title, done: false, projectId });
+}
+// #endregion writing-tx-explicit-ts
+
+// #region writing-tx-multitable-ts
+export async function createProjectWithFirstTodo(db: Db) {
+  // Both rows settle together: neither the project nor its first todo
+  // is visible to other reads until the transaction commits.
+  const result = db.transaction((tx) => {
+    const project = tx.insert(app.projects, { name: "Launch" });
+    const todo = tx.insert(app.todos, {
+      title: "Write the brief",
+      done: false,
+      projectId: project.id,
+    });
+    return { projectId: project.id, todoId: todo.id };
+  });
+
+  await result.wait({ tier: "edge" });
+  return result.value;
+}
+// #endregion writing-tx-multitable-ts
+
+// #region writing-tx-test-fixture-ts
+// An explicit transaction doubles as a test-isolation primitive: open one
+// before each test, roll it back after, and a test's writes never reach the
+// next. Wire `open` into beforeEach and `discard` into afterEach.
+export function transactionTestFixture(db: Db) {
+  let tx: DbTransaction;
+
+  return {
+    open: () => {
+      tx = db.beginTransaction();
+    },
+    discard: () => {
+      tx.rollback(); // every staged write from this test is thrown away
+    },
+    addTask: () => {
+      const task = tx.insert(app.todos, { title: "Test task", done: false });
+      return task.title;
+    },
+  };
+}
+// #endregion writing-tx-test-fixture-ts

--- a/examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts
@@ -1,4 +1,4 @@
-import type { Db } from "jazz-tools";
+import type { Db, DbTransaction } from "jazz-tools";
 import { app } from "../schema.js";
 
 const EXAMPLE_PROJECT_ID = "00000000-0000-0000-0000-000000000000";
@@ -310,3 +310,147 @@ export async function combinedQuery(db: Db) {
   return results;
 }
 // #endregion combining-ts
+
+// #region writing-tx-isolation-ts
+export async function transactionIsolation(db: Db) {
+  const tx = db.beginTransaction();
+  tx.insert(app.todos, { title: "Draft launch post", done: false });
+
+  // Using the tx handle here means we can read the staged write
+  const stagedInTx = await tx.all(app.todos.where({ done: false }));
+
+  // Using the db handle only shows us the committed state, so the new todo is still invisible.
+  const visibleOutside = await db.all(app.todos.where({ done: false }));
+
+  tx.commit();
+
+  // After commit the write is visible to ordinary reads too.
+  const visibleAfterCommit = await db.all(app.todos.where({ done: false }));
+
+  return { stagedInTx, visibleOutside, visibleAfterCommit };
+}
+// #endregion writing-tx-isolation-ts
+
+// #region writing-tx-concurrent-ts
+export async function concurrentTransactionIsolation(db: Db) {
+  const aliceTx = db.beginTransaction();
+  const bobTx = db.beginTransaction();
+
+  aliceTx.insert(app.todos, { title: "Alice draft", done: false });
+  bobTx.insert(app.todos, { title: "Bob draft", done: false });
+
+  // Open transactions never observe each other's staged writes —
+  // each list contains only that transaction's own draft.
+  const aliceSees = await aliceTx.all(app.todos.where({ done: false }));
+  const bobSees = await bobTx.all(app.todos.where({ done: false }));
+
+  aliceTx.rollback(); // staged write discarded — visible to no reader
+  bobTx.commit();
+
+  // Only Bob's committed draft is visible to indexed reads.
+  const visible = await db.all(app.todos.where({ done: false }));
+
+  return { aliceSees, bobSees, visible };
+}
+// #endregion writing-tx-concurrent-ts
+
+// #region writing-tx-commit-visibility-ts
+export async function directBatchCommitVisibility(db: Db) {
+  const batch = db.beginBatch();
+  batch.insert(app.todos, { title: "Grouped write", done: false });
+
+  // Staged writes are invisible to indexed reads while the batch is open.
+  const beforeCommit = await db.all(app.todos.where({ done: false }));
+
+  batch.commit();
+
+  // A direct batch is visible to indexed reads as soon as it commits —
+  // there is no authority round-trip. A transaction instead becomes
+  // globally visible only once the authority accepts it; when connected
+  // to a sync server, await result.wait({ tier }) before relying on that.
+  const afterCommit = await db.all(app.todos.where({ done: false }));
+
+  return { beforeCommit, afterCommit };
+}
+// #endregion writing-tx-commit-visibility-ts
+
+// #region writing-tx-callback-ts
+export async function markAllOpenToDosAsDone(db: Db) {
+  // The callback may be async. Return a value and it flows through
+  // the WriteResult. Throw and the whole transaction rolls back.
+  const result = await db.transaction(async (tx) => {
+    const open = await tx.all(app.todos.where({ done: false }));
+    for (const todo of open) {
+      tx.update(app.todos, todo.id, { done: true });
+    }
+    return open.length;
+  });
+
+  return { closedCount: result.value, batchId: result.batchId };
+}
+// #endregion writing-tx-callback-ts
+
+// #region writing-tx-explicit-ts
+export function importProjectPlan(db: Db, plan: { name: string; tasks: string[] }) {
+  const tx = db.beginTransaction();
+  try {
+    const projectId = stageProject(tx, plan.name);
+    for (const title of plan.tasks) {
+      stageTask(tx, projectId, title);
+    }
+    return tx.commit().batchId;
+  } catch (error) {
+    tx.rollback();
+    throw error;
+  }
+}
+
+function stageProject(tx: DbTransaction, name: string) {
+  return tx.insert(app.projects, { name }).id;
+}
+
+function stageTask(tx: DbTransaction, projectId: string, title: string) {
+  tx.insert(app.todos, { title, done: false, projectId });
+}
+// #endregion writing-tx-explicit-ts
+
+// #region writing-tx-multitable-ts
+export async function createProjectWithFirstTodo(db: Db) {
+  // Both rows settle together: neither the project nor its first todo
+  // is visible to other reads until the transaction commits.
+  const result = db.transaction((tx) => {
+    const project = tx.insert(app.projects, { name: "Launch" });
+    const todo = tx.insert(app.todos, {
+      title: "Write the brief",
+      done: false,
+      projectId: project.id,
+    });
+    return { projectId: project.id, todoId: todo.id };
+  });
+
+  await result.wait({ tier: "edge" });
+  return result.value;
+}
+// #endregion writing-tx-multitable-ts
+
+// #region writing-tx-test-fixture-ts
+// An explicit transaction doubles as a test-isolation primitive: open one
+// before each test, roll it back after, and a test's writes never reach the
+// next. Wire `open` into beforeEach and `discard` into afterEach.
+export function transactionTestFixture(db: Db) {
+  let tx: DbTransaction;
+
+  return {
+    open: () => {
+      tx = db.beginTransaction();
+    },
+    discard: () => {
+      tx.rollback(); // every staged write from this test is thrown away
+    },
+    addTask: () => {
+      const task = tx.insert(app.todos, { title: "Test task", done: false });
+      return task.title;
+    },
+  };
+}
+// #endregion writing-tx-test-fixture-ts


### PR DESCRIPTION
## Summary
- New `/docs/writing/transactions-and-batches` page covering when to use a batch vs a transaction, the callback and explicit forms, read isolation, commit/durability semantics, and atomic multi-table writes.
- Snippets extracted into `examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts` so they are type-checked by the build.
- `writing-data.mdx` trimmed to a short summary that links to the new page; nav updated.
- Drive-by: gitignore the generated `next-env.d.ts` in the `nextjs-csr-ssr` example.

## Test plan
- [ ] `pnpm --filter docs build` succeeds (snippets are type-checked against `jazz-tools`)
- [ ] Visit `/docs/writing/transactions-and-batches` locally and confirm `<include>` blocks render with the expected snippets
- [ ] Confirm the "When to use which" table and the transactions-vs-batches distinction read correctly