### PR TITLE
feat(docs): WriteTierDiagram — pick a tier, watch the write propagate

### DIFF
--- a/docs/components/mdx/colour.ts
+++ b/docs/components/mdx/colour.ts
@@ -1,0 +1,71 @@
+// Colour-propagation payload policy, shared by the animated sync diagrams
+// (tier-sync & write-tier). The diagram engine owns the propagation
+// *mechanism*; choosing the next colour to write is diagram *policy*, so it
+// lives here alongside the definitions rather than inside the engine.
+
+const MIN_HUE_GAP = 40;
+export const INITIAL_COLOR = "#146aff";
+
+function hexToHue(hex: string): number | null {
+  const m = /^#([0-9a-f]{6})$/i.exec(hex);
+  if (!m) return null;
+  const n = parseInt(m[1], 16);
+  const r = ((n >> 16) & 0xff) / 255;
+  const g = ((n >> 8) & 0xff) / 255;
+  const b = (n & 0xff) / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const d = max - min;
+  if (d === 0) return 0;
+  let h: number;
+  if (max === r) h = ((g - b) / d) % 6;
+  else if (max === g) h = (b - r) / d + 2;
+  else h = (r - g) / d + 4;
+  h *= 60;
+  return h < 0 ? h + 360 : h;
+}
+
+function hslToHex(h: number, s: number, l: number): string {
+  const sat = s / 100;
+  const lit = l / 100;
+  const c = (1 - Math.abs(2 * lit - 1)) * sat;
+  const hh = (h % 360) / 60;
+  const x = c * (1 - Math.abs((hh % 2) - 1));
+  const [r1, g1, b1] =
+    hh < 1
+      ? [c, x, 0]
+      : hh < 2
+        ? [x, c, 0]
+        : hh < 3
+          ? [0, c, x]
+          : hh < 4
+            ? [0, x, c]
+            : hh < 5
+              ? [x, 0, c]
+              : [c, 0, x];
+  const m = lit - c / 2;
+  const to255 = (v: number) =>
+    Math.round((v + m) * 255)
+      .toString(16)
+      .padStart(2, "0");
+  return `#${to255(r1)}${to255(g1)}${to255(b1)}`;
+}
+
+function hueDistance(a: number, b: number): number {
+  const d = Math.abs(a - b) % 360;
+  return d > 180 ? 360 - d : d;
+}
+
+// A fresh, saturated colour whose hue is at least MIN_HUE_GAP away from the
+// current one, so consecutive writes are always visibly distinct.
+export function pickNextColor(current: string | null): string {
+  const prev = current ? hexToHue(current) : null;
+  let hue = Math.floor(Math.random() * 360);
+  if (prev !== null) {
+    for (let i = 0; i < 8 && hueDistance(hue, prev) < MIN_HUE_GAP; i++) {
+      hue = Math.floor(Math.random() * 360);
+    }
+  }
+  const saturation = 75 + Math.floor(Math.random() * 20);
+  return hslToHex(hue, saturation, 50);
+}

--- a/docs/components/mdx/diagram/README.md
+++ b/docs/components/mdx/diagram/README.md
@@ -218,7 +218,7 @@ look without Tailwind or `fd-*`.
 | `NodeTitle`    | `div.dg-node-title`     | 0.75rem, weight 600, `--diagram-fg`. The canonical node header (sequence actor boxes match this).               |
 | `NodeSubtitle` | `div.dg-node-subtitle`  | 0.625rem, muted.                                                                                                |
 | `NodeFooter`   | `div.dg-node-footer`    | Layout slot for actions/extras.                                                                                 |
-| `NodeAction`   | `button.dg-node-action` | Clickable affordance; `onClick`, `aria-label`.                                                                  |
+| `NodeAction`   | `button.dg-node-action` | Clickable affordance; `onClick`, `disabled`, `aria-label`. `disabled` greys it out (not-allowed, no hover).     |
 
 Genuine outliers (the lens diagram's phone frame, tier-sync's hex tally
 swatch) stay diagram-side and are dropped into `NodeShell` as raw children.
@@ -311,10 +311,15 @@ playWaves(traces, bfsWaves(adjacency, source), {
 For overlays that draw bespoke connectors rather than relying on `edges`:
 
 - `connectChain` — orthogonal rounded path through an ordered point list.
+- `roundedPath(points, r)` — the low-level builder behind `connectChain`:
+  a polyline through `Point[]` with genuine bends rounded by quadratic arcs
+  (collinear vertices stay straight). Use it for fully bespoke elbow
+  connectors.
 - `loopRoundedBox` — a rounded self-loop around a box (`LoopSide`).
 - `RoutedEdge` — `{ id, from, to, d, reverse, length, source, target }`;
   `reverse` is the same path reversed (use it to animate an upward hop along a
   downward-drawn link).
+- `Point` — `{ x, y }`; the input to `roundedPath`.
 - `Anchors` — per-node edge anchor points in natural coordinates.
 - `PATH_INSET`, `DEFAULT_CORNER_RADIUS` — shared constants.
 

--- a/docs/components/mdx/diagram/README.md
+++ b/docs/components/mdx/diagram/README.md
@@ -6,8 +6,8 @@ the engine handles layout, measurement, orthogonal edge routing, responsive
 scaling, theming and animation.
 
 Two primitives cover every diagram today: `<Graph>` (data-flow graphs and
-DAGs, static or interactive — the version-history DAG, tier-sync and lens are
-all `<Graph>`) and `<Sequence>` (sequence diagrams).
+DAGs, static or interactive — the version-history DAG, tier-sync, lens and
+write-tier are all `<Graph>`) and `<Sequence>` (sequence diagrams).
 
 ## Design posture: extract-ready island
 
@@ -314,7 +314,7 @@ For overlays that draw bespoke connectors rather than relying on `edges`:
 - `roundedPath(points, r)` — the low-level builder behind `connectChain`:
   a polyline through `Point[]` with genuine bends rounded by quadratic arcs
   (collinear vertices stay straight). Use it for fully bespoke elbow
-  connectors.
+  connectors — the write-tier trunk/branch is built from it.
 - `loopRoundedBox` — a rounded self-loop around a box (`LoopSide`).
 - `RoutedEdge` — `{ id, from, to, d, reverse, length, source, target }`;
   `reverse` is the same path reversed (use it to animate an upward hop along a

--- a/docs/components/mdx/diagram/geometry.ts
+++ b/docs/components/mdx/diagram/geometry.ts
@@ -154,7 +154,7 @@ function straightLength(pts: Point[]): number {
 // Polyline through `pts`, with genuine bends rounded by a quadratic arc
 // (corner radius clamped to half the shorter adjacent segment). Collinear
 // vertices stay as straight `L`s so straight runs are byte-identical.
-function roundedPath(pts: Point[], r: number): string {
+export function roundedPath(pts: Point[], r: number): string {
   if (pts.length === 0) return "";
   const seg = (p: Point, cmd: "M" | "L") => `${cmd} ${fmt(p.x)} ${fmt(p.y)}`;
   if (pts.length < 3 || r <= 0) {

--- a/docs/components/mdx/diagram/index.ts
+++ b/docs/components/mdx/diagram/index.ts
@@ -24,5 +24,11 @@ export { NodeShell, NodeIcon, NodeTitle, NodeSubtitle, NodeFooter, NodeAction } 
 export { useDiagramTraces, traceDuration } from "./traces";
 export type { DiagramTraces, TraceSpec } from "./traces";
 
-export { connectChain, loopRoundedBox, PATH_INSET, DEFAULT_CORNER_RADIUS } from "./geometry";
-export type { RouteDirection, RoutedEdge, Anchors, LoopSide } from "./geometry";
+export {
+  connectChain,
+  loopRoundedBox,
+  roundedPath,
+  PATH_INSET,
+  DEFAULT_CORNER_RADIUS,
+} from "./geometry";
+export type { Point, RouteDirection, RoutedEdge, Anchors, LoopSide } from "./geometry";

--- a/docs/components/mdx/diagram/kit.tsx
+++ b/docs/components/mdx/diagram/kit.tsx
@@ -60,11 +60,13 @@ export function NodeFooter({
 
 export function NodeAction({
   onClick,
+  disabled,
   className,
   "aria-label": ariaLabel,
   children,
 }: {
   onClick?: () => void;
+  disabled?: boolean;
   className?: string;
   "aria-label"?: string;
   children: ReactNode;
@@ -73,6 +75,7 @@ export function NodeAction({
     <button
       type="button"
       onClick={onClick}
+      disabled={disabled}
       aria-label={ariaLabel}
       className={cx("dg-node-action", className)}
     >

--- a/docs/components/mdx/diagram/phone-chrome.tsx
+++ b/docs/components/mdx/diagram/phone-chrome.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { type CSSProperties, type ReactNode, useEffect, useState } from "react";
+
+// Portable, framework-agnostic by the engine-island contract: no @/lib/cn, no
+// lucide-react, no Tailwind utilities. Styling is inline CSS + the shared
+// `diagram-pulse` class; icons are inline SVG. The consumer's `className` is
+// forwarded untouched (sizing is the consumer's concern).
+function cx(...parts: Array<string | false | undefined>): string {
+  return parts.filter(Boolean).join(" ");
+}
+
+// The bezel + notch are physical device chrome — fixed near-black in every
+// host theme, never themed. The screen *inside* does follow the host theme;
+// in dark mode it's a lighter dark than this bezel, so the frame still reads
+// as a distinct bezel either way.
+const BEZEL = "#0b0b0d";
+
+// Signal bars + wifi waves, cropped from the original 80×18 icon set.
+function SignalWifiIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="22"
+      height="9"
+      fill="currentColor"
+      viewBox="0 0 46 18"
+      aria-hidden="true"
+    >
+      <path
+        fillRule="evenodd"
+        d="M19.528 4.033c0-.633-.477-1.146-1.066-1.146h-1.067c-.59 0-1.067.513-1.067 1.146v9.934c0 .633.478 1.146 1.067 1.146h1.067c.589 0 1.066-.513 1.066-1.146zm-7.434 1.3h1.067c.589 0 1.066.525 1.066 1.173v7.434c0 .648-.477 1.173-1.066 1.173h-1.067c-.59 0-1.067-.525-1.067-1.173V6.506c0-.648.478-1.174 1.067-1.174M7.762 7.98H6.696c-.59 0-1.067.532-1.067 1.189v4.755c0 .656.477 1.188 1.067 1.188h1.066c.59 0 1.067-.532 1.067-1.188V9.17c0-.657-.478-1.189-1.067-1.189m-5.3 2.446H1.394c-.59 0-1.067.524-1.067 1.171v2.344c0 .647.478 1.171 1.067 1.171H2.46c.59 0 1.067-.524 1.067-1.171v-2.344c0-.647-.477-1.171-1.067-1.171M36.1 5.302c2.487 0 4.879.923 6.681 2.576a.355.355 0 0 0 .487-.004l1.297-1.263a.34.34 0 0 0-.003-.494c-4.73-4.375-12.195-4.375-16.926 0a.342.342 0 0 0-.003.494l1.298 1.263c.133.13.35.132.486.004 1.803-1.654 4.195-2.576 6.683-2.576m-.004 4.22c1.358 0 2.667.512 3.673 1.436.136.131.35.129.483-.006l1.287-1.32a.367.367 0 0 0-.005-.518 7.9 7.9 0 0 0-10.873 0 .367.367 0 0 0-.005.519l1.287 1.319a.343.343 0 0 0 .483.006 5.43 5.43 0 0 1 3.67-1.435m2.525 2.794a.4.4 0 0 1-.103.28l-2.176 2.456a.32.32 0 0 1-.242.112.32.32 0 0 1-.242-.112l-2.177-2.455a.4.4 0 0 1-.102-.28.4.4 0 0 1 .113-.277c1.39-1.314 3.426-1.314 4.816 0 .07.071.11.17.113.276"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}
+
+// Battery casing + fill, cropped from the original icon set.
+function BatteryIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="14"
+      height="9"
+      fill="currentColor"
+      viewBox="54 0 26 18"
+      aria-hidden="true"
+    >
+      <path
+        d="M71.17 14.5v1h-12v-1zm5.5-5.5c0-1.039 0-1.767-.04-2.338-.04-.56-.113-.894-.223-1.152a3.3 3.3 0 0 0-1.747-1.747c-.258-.11-.591-.184-1.152-.223-.57-.04-1.299-.04-2.338-.04h-12c-1.04 0-1.767 0-2.338.04-.56.04-.894.113-1.152.223a3.3 3.3 0 0 0-1.747 1.747c-.11.258-.184.591-.223 1.152-.04.57-.04 1.299-.04 2.338s0 1.768.04 2.338c.04.561.113.894.223 1.152.334.787.96 1.413 1.747 1.748.258.11.591.183 1.152.222.57.04 1.299.04 2.338.04v1l-1.358-.005c-1.192-.016-1.92-.08-2.524-.338a4.3 4.3 0 0 1-2.19-2.085l-.085-.19c-.343-.806-.343-1.831-.343-3.882 0-1.922 0-2.943.282-3.727l.06-.155a4.3 4.3 0 0 1 2.087-2.19l.19-.085c.604-.257 1.331-.322 2.523-.338L59.17 2.5h12c2.05 0 3.076 0 3.882.343a4.3 4.3 0 0 1 2.275 2.275c.343.806.343 1.832.343 3.882s0 3.076-.343 3.882l-.086.19a4.3 4.3 0 0 1-2.19 2.085l-.154.061c-.784.282-1.805.282-3.727.282v-1c1.04 0 1.767 0 2.338-.04.56-.039.894-.113 1.152-.223a3.3 3.3 0 0 0 1.747-1.747c.11-.258.184-.591.223-1.152.04-.57.04-1.299.04-2.338"
+        opacity=".35"
+      />
+      <path
+        d="M78.67 7.281v4.076a2.21 2.21 0 0 0 1.328-2.038c0-.89-.523-1.693-1.328-2.038"
+        opacity=".4"
+      />
+      <path d="M54.67 8.5c0-1.4 0-2.1.272-2.635a2.5 2.5 0 0 1 1.093-1.092C56.57 4.5 57.27 4.5 58.67 4.5h13c1.4 0 2.1 0 2.635.273a2.5 2.5 0 0 1 1.092 1.092c.273.535.273 1.235.273 2.635v1c0 1.4 0 2.1-.273 2.635a2.5 2.5 0 0 1-1.092 1.093c-.535.272-1.235.272-2.635.272h-13c-1.4 0-2.1 0-2.635-.272a2.5 2.5 0 0 1-1.093-1.093C54.67 11.6 54.67 10.9 54.67 9.5z" />
+    </svg>
+  );
+}
+
+// Aeroplane-mode glyph (inline so the island stays lucide-free).
+function PlaneIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="11"
+      height="11"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <path d="M21 16v-2l-8-5V3.5c0-.83-.67-1.5-1.5-1.5S10 2.67 10 3.5V9l-8 5v2l8-2.5V19l-2 1.5V22l3.5-1 3.5 1v-1.5L13 19v-5.5z" />
+    </svg>
+  );
+}
+
+function StatusIcons({ offline }: { offline?: boolean }) {
+  return (
+    <span style={{ display: "flex", alignItems: "center", gap: "0.25rem", lineHeight: 1 }}>
+      <span
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "flex-end",
+          width: "22px",
+          height: "10px",
+        }}
+      >
+        {offline ? <PlaneIcon /> : <SignalWifiIcon />}
+      </span>
+      <BatteryIcon />
+    </span>
+  );
+}
+
+function useWallClock(): string {
+  // Render nothing on the server so the clock text can't mismatch the
+  // client's locale-formatted output during hydration.
+  const [time, setTime] = useState<Date | null>(null);
+  useEffect(() => {
+    setTime(new Date());
+    let timeoutId: ReturnType<typeof setTimeout>;
+    const tick = () => {
+      setTime(new Date());
+      timeoutId = setTimeout(tick, 60_000 - (Date.now() % 60_000));
+    };
+    timeoutId = setTimeout(tick, 60_000 - (Date.now() % 60_000));
+    return () => clearTimeout(timeoutId);
+  }, []);
+  if (!time) return "";
+  return time.toLocaleTimeString("en-GB", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
+const shellStyle: CSSProperties = {
+  position: "relative",
+  boxSizing: "border-box",
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.5rem",
+  padding: "0.5rem",
+  paddingTop: "1.25rem",
+  borderWidth: "5px",
+  borderStyle: "solid",
+  borderColor: BEZEL,
+  borderRadius: "1rem",
+  background: "var(--diagram-card, #fff)",
+  color: "var(--diagram-fg, #18181b)",
+};
+
+// Reusable phone chrome: a fixed near-black device bezel + notch (never
+// themed — a phone's shell looks the same everywhere) wrapped around a screen
+// that DOES follow the host theme. Status bar (clock + camera notch +
+// signal/wifi/battery icons) along the top edge; when `offline` is set the
+// signal/wifi icons collapse into a single plane icon — the convention iOS
+// uses for aeroplane mode.
+export function PhoneChrome({
+  innerRef,
+  pulseKey,
+  className,
+  offline,
+  children,
+}: {
+  innerRef?: (el: HTMLDivElement | null) => void;
+  pulseKey?: number;
+  className?: string;
+  offline?: boolean;
+  children: ReactNode;
+}) {
+  const time = useWallClock();
+  return (
+    <div ref={innerRef} className={cx(className)} style={shellStyle}>
+      {pulseKey !== undefined && pulseKey > 0 && (
+        <span
+          key={pulseKey}
+          className="diagram-pulse"
+          style={{
+            position: "absolute",
+            inset: "-3px",
+            borderRadius: "1rem",
+            pointerEvents: "none",
+          }}
+        />
+      )}
+      <div
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          right: 0,
+          height: "1.25rem",
+          display: "grid",
+          gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+          alignItems: "center",
+          padding: "0 0.75rem",
+        }}
+      >
+        <span
+          style={{
+            fontSize: "10px",
+            fontWeight: 500,
+            fontVariantNumeric: "tabular-nums",
+            lineHeight: 1,
+          }}
+        >
+          {time}
+        </span>
+        <span
+          style={{
+            alignSelf: "start",
+            justifySelf: "center",
+            height: "0.5rem",
+            width: "3rem",
+            borderBottomLeftRadius: "0.375rem",
+            borderBottomRightRadius: "0.375rem",
+            backgroundColor: BEZEL,
+          }}
+        />
+        <span
+          style={{
+            justifySelf: "end",
+            color: "var(--diagram-fg, #18181b)",
+            opacity: 0.8,
+          }}
+        >
+          <StatusIcons offline={offline} />
+        </span>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/docs/components/mdx/diagram/styles.tsx
+++ b/docs/components/mdx/diagram/styles.tsx
@@ -125,6 +125,13 @@ const DIAGRAM_STYLES_CSS = `
 .dg-node-action:hover {
   background: var(--diagram-accent-soft);
 }
+.dg-node-action:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.dg-node-action:disabled:hover {
+  background: var(--diagram-card);
+}
 
 /* Shared diagram frame chrome. */
 .dg-frame {

--- a/docs/components/mdx/lens-diagram.tsx
+++ b/docs/components/mdx/lens-diagram.tsx
@@ -11,6 +11,7 @@ import {
   type GraphOverlayCtx,
   useDiagramTraces,
 } from "./diagram";
+import { PhoneChrome } from "./diagram/phone-chrome";
 import {
   buildPath,
   CLIENT_ID,
@@ -210,33 +211,6 @@ function LensCard({
   );
 }
 
-function StatusBarIcons() {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="80"
-      height="18"
-      fill="currentColor"
-      viewBox="0 0 80 18"
-    >
-      <path
-        fillRule="evenodd"
-        d="M19.528 4.033c0-.633-.477-1.146-1.066-1.146h-1.067c-.59 0-1.067.513-1.067 1.146v9.934c0 .633.478 1.146 1.067 1.146h1.067c.589 0 1.066-.513 1.066-1.146zm-7.434 1.3h1.067c.589 0 1.066.525 1.066 1.173v7.434c0 .648-.477 1.173-1.066 1.173h-1.067c-.59 0-1.067-.525-1.067-1.173V6.506c0-.648.478-1.174 1.067-1.174M7.762 7.98H6.696c-.59 0-1.067.532-1.067 1.189v4.755c0 .656.477 1.188 1.067 1.188h1.066c.59 0 1.067-.532 1.067-1.188V9.17c0-.657-.478-1.189-1.067-1.189m-5.3 2.446H1.394c-.59 0-1.067.524-1.067 1.171v2.344c0 .647.478 1.171 1.067 1.171H2.46c.59 0 1.067-.524 1.067-1.171v-2.344c0-.647-.477-1.171-1.067-1.171M36.1 5.302c2.487 0 4.879.923 6.681 2.576a.355.355 0 0 0 .487-.004l1.297-1.263a.34.34 0 0 0-.003-.494c-4.73-4.375-12.195-4.375-16.926 0a.342.342 0 0 0-.003.494l1.298 1.263c.133.13.35.132.486.004 1.803-1.654 4.195-2.576 6.683-2.576m-.004 4.22c1.358 0 2.667.512 3.673 1.436.136.131.35.129.483-.006l1.287-1.32a.367.367 0 0 0-.005-.518 7.9 7.9 0 0 0-10.873 0 .367.367 0 0 0-.005.519l1.287 1.319a.343.343 0 0 0 .483.006 5.43 5.43 0 0 1 3.67-1.435m2.525 2.794a.4.4 0 0 1-.103.28l-2.176 2.456a.32.32 0 0 1-.242.112.32.32 0 0 1-.242-.112l-2.177-2.455a.4.4 0 0 1-.102-.28.4.4 0 0 1 .113-.277c1.39-1.314 3.426-1.314 4.816 0 .07.071.11.17.113.276"
-        clipRule="evenodd"
-      />
-      <path
-        d="M71.17 14.5v1h-12v-1zm5.5-5.5c0-1.039 0-1.767-.04-2.338-.04-.56-.113-.894-.223-1.152a3.3 3.3 0 0 0-1.747-1.747c-.258-.11-.591-.184-1.152-.223-.57-.04-1.299-.04-2.338-.04h-12c-1.04 0-1.767 0-2.338.04-.56.04-.894.113-1.152.223a3.3 3.3 0 0 0-1.747 1.747c-.11.258-.184.591-.223 1.152-.04.57-.04 1.299-.04 2.338s0 1.768.04 2.338c.04.561.113.894.223 1.152.334.787.96 1.413 1.747 1.748.258.11.591.183 1.152.222.57.04 1.299.04 2.338.04v1l-1.358-.005c-1.192-.016-1.92-.08-2.524-.338a4.3 4.3 0 0 1-2.19-2.085l-.085-.19c-.343-.806-.343-1.831-.343-3.882 0-1.922 0-2.943.282-3.727l.06-.155a4.3 4.3 0 0 1 2.087-2.19l.19-.085c.604-.257 1.331-.322 2.523-.338L59.17 2.5h12c2.05 0 3.076 0 3.882.343a4.3 4.3 0 0 1 2.275 2.275c.343.806.343 1.832.343 3.882s0 3.076-.343 3.882l-.086.19a4.3 4.3 0 0 1-2.19 2.085l-.154.061c-.784.282-1.805.282-3.727.282v-1c1.04 0 1.767 0 2.338-.04.56-.039.894-.113 1.152-.223a3.3 3.3 0 0 0 1.747-1.747c.11-.258.184-.591.223-1.152.04-.57.04-1.299.04-2.338"
-        opacity=".35"
-      />
-      <path
-        d="M78.67 7.281v4.076a2.21 2.21 0 0 0 1.328-2.038c0-.89-.523-1.693-1.328-2.038"
-        opacity=".4"
-      />
-      <path d="M54.67 8.5c0-1.4 0-2.1.272-2.635a2.5 2.5 0 0 1 1.093-1.092C56.57 4.5 57.27 4.5 58.67 4.5h13c1.4 0 2.1 0 2.635.273a2.5 2.5 0 0 1 1.092 1.092c.273.535.273 1.235.273 2.635v1c0 1.4 0 2.1-.273 2.635a2.5 2.5 0 0 1-1.092 1.093c-.535.272-1.235.272-2.635.272h-13c-1.4 0-2.1 0-2.635-.272a2.5 2.5 0 0 1-1.093-1.093C54.67 11.6 54.67 10.9 54.67 9.5z" />
-    </svg>
-  );
-}
-
 const PROJECTION_CSS = `
 @keyframes lens-projection-in {
   from { opacity: 0; transform: translateX(-4px); }
@@ -256,30 +230,11 @@ function ClientDevice({
   projectedRow: Row;
   dataVersion: Version;
 }) {
-  const [time, setTime] = useState(() => new Date());
-  useEffect(() => {
-    let timeoutId: ReturnType<typeof setTimeout>;
-    const tick = () => {
-      setTime(new Date());
-      timeoutId = setTimeout(tick, 60_000 - (Date.now() % 60_000));
-    };
-    timeoutId = setTimeout(tick, 60_000 - (Date.now() % 60_000));
-    return () => clearTimeout(timeoutId);
-  }, []);
   return (
-    <div className="relative rounded-2xl border-5 border-fd-primary bg-fd-card p-2 pt-4 h-full flex flex-col gap-2">
+    <PhoneChrome className="h-full">
       <style href="lens-projection" precedence="default">
         {PROJECTION_CSS}
       </style>
-      <div className="grid grid-cols-3 w-full absolute h-4 top-0 left-0 rounded-b-lg gap-2">
-        <div className="col-span-1 ps-5 flex flex-col text-xs pt-1.5 uppercase">
-          {time.toLocaleTimeString("en-GB", { hour: "numeric", minute: "2-digit", hour12: false })}
-        </div>
-        <div className="bg-fd-primary rounded-b-lg"></div>
-        <div className="flex justify-end pt-1.5 pe-4 items-center">
-          <StatusBarIcons />
-        </div>
-      </div>
       <div>
         <div className="flex items-center gap-2 pt-2">
           <span className="text-xs font-medium text-fd-foreground">Schema:</span>
@@ -331,7 +286,7 @@ function ClientDevice({
             : `v${dataVersion} row, read through the lens chain by a client on schema v${client}.`}
         </div>
       </div>
-    </div>
+    </PhoneChrome>
   );
 }
 

--- a/docs/components/mdx/tier-sync-diagram.tsx
+++ b/docs/components/mdx/tier-sync-diagram.tsx
@@ -20,6 +20,7 @@ import {
   NodeTitle,
   useDiagramTraces,
 } from "./diagram";
+import { INITIAL_COLOR, pickNextColor } from "./colour";
 
 type Tier = "global" | "edge" | "local";
 type NodeKey = "global" | "edge1" | "edge2" | "alice" | "bob" | "charlie";
@@ -63,70 +64,6 @@ const SLOTS: Record<NodeKey, { row: number; col: string }> = {
 const TIER_DEPTH: Record<Tier, number> = { global: 0, edge: 1, local: 2 };
 const STAGE_DURATION = 1100;
 const PULSE_MS = 1400;
-const MIN_HUE_GAP = 40;
-const INITIAL_COLOR = "#146aff";
-
-function hexToHue(hex: string): number | null {
-  const m = /^#([0-9a-f]{6})$/i.exec(hex);
-  if (!m) return null;
-  const n = parseInt(m[1], 16);
-  const r = ((n >> 16) & 0xff) / 255;
-  const g = ((n >> 8) & 0xff) / 255;
-  const b = (n & 0xff) / 255;
-  const max = Math.max(r, g, b);
-  const min = Math.min(r, g, b);
-  const d = max - min;
-  if (d === 0) return 0;
-  let h: number;
-  if (max === r) h = ((g - b) / d) % 6;
-  else if (max === g) h = (b - r) / d + 2;
-  else h = (r - g) / d + 4;
-  h *= 60;
-  return h < 0 ? h + 360 : h;
-}
-
-function hslToHex(h: number, s: number, l: number): string {
-  const sat = s / 100;
-  const lit = l / 100;
-  const c = (1 - Math.abs(2 * lit - 1)) * sat;
-  const hh = (h % 360) / 60;
-  const x = c * (1 - Math.abs((hh % 2) - 1));
-  const [r1, g1, b1] =
-    hh < 1
-      ? [c, x, 0]
-      : hh < 2
-        ? [x, c, 0]
-        : hh < 3
-          ? [0, c, x]
-          : hh < 4
-            ? [0, x, c]
-            : hh < 5
-              ? [x, 0, c]
-              : [c, 0, x];
-  const m = lit - c / 2;
-  const to255 = (v: number) =>
-    Math.round((v + m) * 255)
-      .toString(16)
-      .padStart(2, "0");
-  return `#${to255(r1)}${to255(g1)}${to255(b1)}`;
-}
-
-function hueDistance(a: number, b: number): number {
-  const d = Math.abs(a - b) % 360;
-  return d > 180 ? 360 - d : d;
-}
-
-function pickNextColor(current: string | null): string {
-  const prev = current ? hexToHue(current) : null;
-  let hue = Math.floor(Math.random() * 360);
-  if (prev !== null) {
-    for (let i = 0; i < 8 && hueDistance(hue, prev) < MIN_HUE_GAP; i++) {
-      hue = Math.floor(Math.random() * 360);
-    }
-  }
-  const saturation = 75 + Math.floor(Math.random() * 20);
-  return hslToHex(hue, saturation, 50);
-}
 
 type ColorState = Record<NodeKey, string | null>;
 const INITIAL_COLORS: ColorState = {

--- a/docs/components/mdx/write-tier-diagram.tsx
+++ b/docs/components/mdx/write-tier-diagram.tsx
@@ -1,0 +1,807 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Check,
+  Cloud,
+  Loader2,
+  Plane,
+  Plus,
+  Server,
+  Smartphone,
+  type LucideIcon,
+} from "lucide-react";
+
+import { cn } from "@/lib/cn";
+import {
+  type Anchors,
+  DEFAULT_CORNER_RADIUS,
+  Graph,
+  type GraphNode,
+  type GraphOverlayCtx,
+  NodeAction,
+  NodeFooter,
+  NodeIcon,
+  NodeShell,
+  NodeSubtitle,
+  NodeTitle,
+  type Point,
+  roundedPath,
+  useDiagramTraces,
+} from "./diagram";
+import { PhoneChrome } from "./diagram/phone-chrome";
+import { INITIAL_COLOR, pickNextColor } from "./colour";
+
+type Tier = "local" | "edge" | "global";
+const TIERS: Tier[] = ["local", "edge", "global"];
+
+const TIER_LABEL: Record<Tier, string> = {
+  local: "Local",
+  edge: "Edge",
+  global: "Global",
+};
+
+const TIER_DESCRIPTION: Record<Tier, string> = {
+  local: "Durable on this device. No network round-trip required.",
+  edge: "Durable on a regional sync server. Survives the device going offline.",
+  global: "Durable in the global core. Replicated across regions.",
+};
+
+type NodeKey = "phone" | "edge" | "global" | "receiver";
+// The three cards stacked on the right, each driven off the edge.
+type CardKey = "global" | "edge" | "receiver";
+const CARD_META: Record<CardKey, { icon: LucideIcon; title: string; subtitle: string }> = {
+  global: { icon: Cloud, title: "Global", subtitle: "global core" },
+  edge: { icon: Server, title: "Edge", subtitle: "regional sync server" },
+  receiver: { icon: Smartphone, title: "Other device", subtitle: "receives updates" },
+};
+
+// hop key ⇒ the routed segment it animates along (built in connectorPaths).
+type Hop = "edge" | "global" | "receiver";
+const HOPS: Hop[] = ["edge", "global", "receiver"];
+
+type EventPhase = "writing" | "settled";
+type WriteEvent = {
+  id: number;
+  tier: Tier;
+  value: string;
+  phase: EventPhase;
+  startedAt: number;
+  // When non-null, the event is parked: no animation runs until the device
+  // reconnects and queuedSince is cleared.
+  queuedSince: number | null;
+  // Flipped to true the moment the wave reaches the edge tier — at that
+  // point the write is no longer durable only on the device.
+  reachedEdge: boolean;
+};
+
+type Status =
+  | { kind: "idle" }
+  | { kind: "writing"; tier: Tier; eventId: number }
+  | { kind: "settled"; tier: Tier; eventId: number };
+
+type PulseState = { key: number };
+
+const STAGE_MS = 850;
+const TICK_LINGER_MS = 1500;
+const FADE_MS = 600;
+// Gap between consecutive queued writes when the device reconnects, so the
+// user sees the propagation waves separated rather than blurred together.
+const RECONNECT_STAGGER_MS = 280;
+// Where the other-device branch leaves the edge's bottom edge, as a fraction
+// of its half-width right of centre — far enough off the trunk to read as a
+// fork, but inside the card so nothing leaves the measured layout.
+const BRANCH_OFFSET = 0.6;
+
+// Bespoke connector over the engine-measured node geometry: an L-shaped arm
+// from the phone into the edge tier, a riser up to the global tier, and a
+// riser down to the other device. The three hops animate along these paths.
+// (Same pattern as LensDiagram, which also draws its own connector from
+// `ctx.anchors`.)
+function connectorPaths(
+  anchors: Record<string, Anchors>,
+  branchDx: number,
+): Record<Hop, string> | null {
+  const phone = anchors.phone;
+  const edge = anchors.edge;
+  const global = anchors.global;
+  const receiver = anchors.receiver;
+  if (!phone || !edge || !global || !receiver) return null;
+  const armX = (phone.right + edge.left) / 2;
+  // Trunk (phone → edge → global) runs up the column centreline. The other
+  // device sits `branchDx` to the right (the card is shifted by the same
+  // amount), so the branch is one clean side-step off the trunk into it. On
+  // mobile branchDx is 0 ⇒ a straight riser, nothing leaves the layout.
+  const branchY = (edge.bottom + receiver.top) / 2;
+  const branchX = receiver.midX + branchDx;
+  // Rounded elbows, matching the engine's own routed edges.
+  const route = (pts: Point[]) => roundedPath(pts, DEFAULT_CORNER_RADIUS);
+  return {
+    edge: route([
+      { x: phone.right, y: phone.midY },
+      { x: armX, y: phone.midY },
+      { x: armX, y: edge.midY },
+      { x: edge.left, y: edge.midY },
+    ]),
+    global: route([
+      { x: edge.midX, y: edge.top },
+      { x: edge.midX, y: global.bottom },
+    ]),
+    receiver: route([
+      { x: edge.midX, y: edge.bottom },
+      { x: edge.midX, y: branchY },
+      { x: branchX, y: branchY },
+      { x: branchX, y: receiver.top },
+    ]),
+  };
+}
+
+function StatusBody({ status }: { status: Status }) {
+  if (status.kind === "idle") {
+    return <span className="text-fd-muted-foreground italic">Ready</span>;
+  }
+  if (status.kind === "writing") {
+    return (
+      <>
+        <Loader2 className="h-3.5 w-3.5 animate-spin text-fd-primary" />
+        <span className="text-fd-foreground">Awaiting {TIER_LABEL[status.tier]}…</span>
+      </>
+    );
+  }
+  return (
+    <>
+      <Check className="h-3.5 w-3.5 text-[#16a34a]" />
+      <span className="text-fd-foreground">
+        {status.tier === "local" ? "Settled locally" : `Settled at ${TIER_LABEL[status.tier]}`}
+      </span>
+    </>
+  );
+}
+
+function AeroplaneToggle({ offline, onToggle }: { offline: boolean; onToggle: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-pressed={offline}
+      className={cn(
+        "rounded-md border px-2 py-1.5 text-[11px] font-medium flex items-center justify-between gap-2 transition-colors cursor-pointer",
+        offline
+          ? "border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300 dark:bg-amber-500/15"
+          : "border-fd-border text-fd-muted-foreground hover:bg-fd-accent",
+      )}
+    >
+      <span className="flex items-center gap-1.5">
+        <Plane className="h-3 w-3" />
+        Aeroplane mode
+      </span>
+      <span
+        className={cn(
+          "relative inline-block rounded-full transition-colors",
+          offline ? "bg-amber-500" : "bg-fd-border",
+        )}
+        style={{ width: "28px", height: "14px" }}
+      >
+        <span
+          className="absolute rounded-full bg-white shadow"
+          style={{
+            width: "10px",
+            height: "10px",
+            top: "2px",
+            left: offline ? "16px" : "2px",
+            transition: "left 200ms ease",
+          }}
+        />
+      </span>
+    </button>
+  );
+}
+
+// Hex label + swatch, animating in on change. Themed (engine tokens) — used
+// by both the cards and the phone's "what you wrote" row, which follow the
+// host theme.
+function ColourTag({ colour, compact }: { colour: string | null; compact?: boolean }) {
+  const box = compact ? "0.85rem" : "0.9rem";
+  const fg = "var(--diagram-fg)";
+  const swatchBorder = "var(--diagram-border, #e4e4e7)";
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: "0.375rem" }}>
+      <span
+        style={{
+          fontSize: compact ? "0.6875rem" : "0.75rem",
+          fontFamily: "var(--font-mono, ui-monospace, monospace)",
+          color: fg,
+          overflow: "hidden",
+        }}
+      >
+        <span key={colour ?? "none"} className="diagram-tally" style={{ display: "inline-block" }}>
+          {colour ?? "—"}
+        </span>
+      </span>
+      <span
+        style={{
+          display: "inline-block",
+          overflow: "hidden",
+          borderRadius: "2px",
+          border: `1px solid ${swatchBorder}`,
+          height: box,
+          width: box,
+          flexShrink: 0,
+        }}
+      >
+        <span
+          key={`sw-${colour ?? "none"}`}
+          className="diagram-tally"
+          style={{
+            display: "block",
+            height: "100%",
+            width: "100%",
+            backgroundColor: colour ?? "transparent",
+          }}
+        />
+      </span>
+    </span>
+  );
+}
+
+function PhoneScreen({
+  tier,
+  setTier,
+  status,
+  onWrite,
+  offline,
+  onToggleOffline,
+  unsynced,
+  colour,
+}: {
+  tier: Tier;
+  setTier: (t: Tier) => void;
+  status: Status;
+  onWrite: () => void;
+  offline: boolean;
+  onToggleOffline: () => void;
+  unsynced: number;
+  colour: string | null;
+}) {
+  // A pending promise blocks further writes whether or not the device is
+  // online — offline simply means it stays pending until reconnect.
+  const locked = status.kind === "writing";
+  return (
+    <div className="flex flex-col gap-3 px-1 py-1">
+      <AeroplaneToggle offline={offline} onToggle={onToggleOffline} />
+
+      <div>
+        <div className="text-[10px] uppercase tracking-wide text-fd-muted-foreground font-semibold mb-2">
+          Wait for
+        </div>
+        <div className="grid grid-cols-3 rounded-lg border border-fd-border bg-fd-card p-1 gap-1">
+          {TIERS.map((t) => (
+            <button
+              key={t}
+              type="button"
+              disabled={locked}
+              onClick={() => setTier(t)}
+              className={cn(
+                "px-2 py-1 rounded text-xs font-medium transition-colors",
+                tier === t
+                  ? "bg-fd-primary text-fd-primary-foreground"
+                  : "text-fd-foreground hover:bg-fd-accent",
+                locked && tier !== t && "opacity-40",
+                locked && "cursor-not-allowed",
+              )}
+            >
+              {TIER_LABEL[t]}
+            </button>
+          ))}
+        </div>
+        <p className="text-[11px] text-fd-muted-foreground mt-2 italic text-balance min-h-[2.7em]">
+          {TIER_DESCRIPTION[tier]}
+        </p>
+      </div>
+
+      <div
+        className="rounded-md flex items-center justify-center px-3 py-2 transition-colors"
+        style={{ backgroundColor: colour ? `${colour}26` : undefined }}
+      >
+        <ColourTag colour={colour} compact />
+      </div>
+
+      <NodeAction disabled={locked} onClick={onWrite} aria-label="Write a new colour">
+        {locked ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        ) : (
+          <Plus className="h-3.5 w-3.5" aria-hidden="true" />
+        )}
+        <span>{locked ? "Waiting…" : "New colour"}</span>
+      </NodeAction>
+
+      <div className="rounded-md bg-fd-muted/40 px-3 py-2 flex items-center justify-between text-xs">
+        <span className="text-fd-muted-foreground">Status</span>
+        <span className="flex items-center gap-1.5 font-medium">
+          <StatusBody status={status} />
+        </span>
+      </div>
+
+      <div
+        className={cn(
+          "rounded-md px-3 py-2 flex items-center justify-between text-xs transition-colors",
+          unsynced > 0 ? "bg-amber-500/10" : "bg-fd-muted/40",
+        )}
+      >
+        <span className="text-fd-muted-foreground">Local-only</span>
+        <span
+          className={cn(
+            "font-medium tabular-nums",
+            unsynced > 0 ? "text-amber-700 dark:text-amber-300" : "text-fd-muted-foreground italic",
+          )}
+        >
+          {unsynced === 0 ? "all synced" : `${unsynced} write${unsynced === 1 ? "" : "s"}`}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// Edge / global / receiver card on the engine's node kit, showing the colour
+// it currently holds. The pulse is dim-aware (a write past the awaited tier
+// still lands, just faintly).
+function Card({ k, pulse, colour }: { k: CardKey; pulse: PulseState; colour: string | null }) {
+  const meta = CARD_META[k];
+  const Icon = meta.icon;
+  return (
+    <NodeShell
+      style={{
+        width: "11rem",
+        padding: "0.625rem 0.875rem",
+        alignItems: "center",
+        textAlign: "center",
+        gap: "0.2rem",
+        // The other device is a leaf the write is replicated out to, not part
+        // of the authoritative durability spine — let it sit back a little.
+        opacity: k === "receiver" ? 0.75 : 0.9,
+      }}
+    >
+      {pulse.key > 0 && (
+        <span
+          key={pulse.key}
+          className="diagram-pulse"
+          style={{
+            position: "absolute",
+            inset: "-2px",
+            borderRadius: "inherit",
+            pointerEvents: "none",
+          }}
+        />
+      )}
+      <NodeIcon>
+        <Icon />
+      </NodeIcon>
+      <NodeTitle>{meta.title}</NodeTitle>
+      <NodeSubtitle>{meta.subtitle}</NodeSubtitle>
+      <NodeFooter
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          borderRadius: "0.25rem",
+          padding: "0.2rem 0.4rem",
+          marginTop: "0.4rem",
+          backgroundColor: colour ? `${colour}26` : undefined,
+          transition: "background-color 0.2s",
+        }}
+      >
+        <ColourTag colour={colour} compact />
+      </NodeFooter>
+    </NodeShell>
+  );
+}
+
+export function WriteTierDiagram() {
+  const [tier, setTier] = useState<Tier>("edge");
+  const [offline, setOffline] = useState(false);
+  const [status, setStatus] = useState<Status>({ kind: "idle" });
+  const [events, setEvents] = useState<WriteEvent[]>([]);
+  const [colours, setColours] = useState<Record<NodeKey, string | null>>({
+    phone: INITIAL_COLOR,
+    edge: INITIAL_COLOR,
+    global: INITIAL_COLOR,
+    receiver: INITIAL_COLOR,
+  });
+  const [pulse, setPulse] = useState<Record<NodeKey, PulseState>>({
+    phone: { key: 0 },
+    edge: { key: 0 },
+    global: { key: 0 },
+    receiver: { key: 0 },
+  });
+
+  const traces = useDiagramTraces();
+  const geomRef = useRef<GraphOverlayCtx | null>(null);
+  const [geomReady, setGeomReady] = useState(false);
+  // Desktop offset (px) of the other-device card off the trunk centreline,
+  // measured from the edge card. Dropped to 0 on narrow screens so the shifted
+  // card never leaves the layout (a transform isn't seen by the engine's
+  // measurement, so an offset card overflows the frame on mobile).
+  const [branchBase, setBranchBase] = useState(0);
+  const [isNarrow, setIsNarrow] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia("(max-width: 640px)");
+    const sync = () => setIsNarrow(mq.matches);
+    sync();
+    mq.addEventListener("change", sync);
+    return () => mq.removeEventListener("change", sync);
+  }, []);
+  const branchDx = isNarrow ? 0 : branchBase;
+
+  const eventIdRef = useRef(0);
+  const scheduledRef = useRef<Set<number>>(new Set());
+  const timersRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set());
+  // Live <path>s of in-flight traces, so a finished trace can fade out after a
+  // linger (the engine's draw leaves it solid until we unmount the event).
+  const pathElsRef = useRef<Record<string, SVGPathElement | null>>({});
+  // Mirrors of colour state for handlers, plus the last event id each node has
+  // applied (last-write-wins: an older queued write never clobbers a newer).
+  const coloursRef = useRef<Record<NodeKey, string | null>>({
+    phone: INITIAL_COLOR,
+    edge: INITIAL_COLOR,
+    global: INITIAL_COLOR,
+    receiver: INITIAL_COLOR,
+  });
+  const lastSeenRef = useRef<Record<NodeKey, number>>({
+    phone: 0,
+    edge: 0,
+    global: 0,
+    receiver: 0,
+  });
+
+  // Latest events list, readable from event handlers without re-binding them.
+  const eventsRef = useRef(events);
+  useEffect(() => {
+    eventsRef.current = events;
+  });
+
+  const after = useCallback((ms: number, fn: () => void) => {
+    const t = setTimeout(() => {
+      timersRef.current.delete(t);
+      fn();
+    }, ms);
+    timersRef.current.add(t);
+    return t;
+  }, []);
+
+  useEffect(() => {
+    const timers = timersRef.current;
+    return () => {
+      timers.forEach(clearTimeout);
+      timers.clear();
+    };
+  }, []);
+
+  function pulseNode(node: NodeKey) {
+    setPulse((p) => ({ ...p, [node]: { key: p[node].key + 1 } }));
+  }
+
+  // Last-write-wins: only the newest write to reach a node sticks.
+  function applyColour(node: NodeKey, event: WriteEvent) {
+    if (event.id <= lastSeenRef.current[node]) return;
+    lastSeenRef.current = { ...lastSeenRef.current, [node]: event.id };
+    coloursRef.current = { ...coloursRef.current, [node]: event.value };
+    setColours((c) => ({ ...c, [node]: event.value }));
+  }
+
+  function scheduleStatusRevert(eventId: number) {
+    after(TICK_LINGER_MS, () => {
+      setStatus((s) => (s.kind === "settled" && s.eventId === eventId ? { kind: "idle" } : s));
+    });
+  }
+
+  function markSettled(event: WriteEvent) {
+    pulseNode("phone");
+    setEvents((evts) => evts.map((e) => (e.id === event.id ? { ...e, phase: "settled" } : e)));
+    setStatus((s) =>
+      s.kind === "writing" && s.eventId === event.id
+        ? { kind: "settled", tier: event.tier, eventId: event.id }
+        : s,
+    );
+    scheduleStatusRevert(event.id);
+  }
+
+  const scheduleEvent = useCallback(
+    (event: WriteEvent) => {
+      const anchors = geomRef.current?.anchors;
+      const paths = anchors ? connectorPaths(anchors, branchDx) : null;
+      if (!paths) return false;
+
+      const playHop = (hop: Hop, onArrive: () => void) =>
+        traces.play({
+          id: `${event.id}-${hop}`,
+          d: paths[hop],
+          durationMs: STAGE_MS,
+          follow: true,
+          onArrive,
+        });
+
+      // Hop 1: phone → edge. The dot's arrival is the moment the write
+      // becomes durable on the sync server.
+      playHop("edge", () => {
+        applyColour("edge", event);
+        pulseNode("edge");
+        setEvents((evts) => evts.map((e) => (e.id === event.id ? { ...e, reachedEdge: true } : e)));
+        if (event.tier === "edge") markSettled(event);
+      });
+
+      // One stage later the edge fans out: up to the global core, and across
+      // to the other device — concurrently.
+      after(STAGE_MS, () => {
+        playHop("global", () => {
+          applyColour("global", event);
+          pulseNode("global");
+          if (event.tier === "global") markSettled(event);
+        });
+        playHop("receiver", () => {
+          applyColour("receiver", event);
+          pulseNode("receiver");
+        });
+      });
+
+      // Linger, fade the drawn paths, then drop the event (unmounts the SVG).
+      after(2 * STAGE_MS + TICK_LINGER_MS, () => {
+        for (const hop of HOPS) {
+          const p = pathElsRef.current[`${event.id}-${hop}`];
+          if (!p) continue;
+          p.style.transition = `opacity ${FADE_MS}ms ease-out`;
+          p.style.opacity = "0";
+        }
+      });
+      after(2 * STAGE_MS + TICK_LINGER_MS + FADE_MS, () => {
+        setEvents((evts) => evts.filter((e) => e.id !== event.id));
+      });
+      return true;
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    },
+    [traces, after, branchDx],
+  );
+
+  // Schedule newly-added events once geometry is available. Queued (offline)
+  // events are skipped until reconnect clears their queuedSince.
+  useEffect(() => {
+    if (!geomReady) return;
+    for (const event of events) {
+      if (event.queuedSince !== null) continue;
+      if (scheduledRef.current.has(event.id)) continue;
+      if (scheduleEvent(event)) scheduledRef.current.add(event.id);
+    }
+    const liveIds = new Set(events.map((e) => e.id));
+    for (const id of Array.from(scheduledRef.current)) {
+      if (!liveIds.has(id)) scheduledRef.current.delete(id);
+    }
+  }, [events, geomReady, scheduleEvent]);
+
+  function runWrite() {
+    if (status.kind === "writing") return;
+    const id = ++eventIdRef.current;
+    const isLocal = tier === "local";
+    const value = pickNextColor(coloursRef.current.phone);
+    const queuedSince = offline ? performance.now() : null;
+
+    // The device has the write the instant you make it — colour and pulse
+    // land locally regardless of the network or the awaited tier.
+    lastSeenRef.current = { ...lastSeenRef.current, phone: id };
+    coloursRef.current = { ...coloursRef.current, phone: value };
+    setColours((c) => ({ ...c, phone: value }));
+    pulseNode("phone");
+
+    // Local is durable on the device itself — its promise resolves even
+    // without the network, so the tick fires straight away. The propagation
+    // to edge / global / the other device is what gets queued when offline.
+    if (isLocal) {
+      setStatus({ kind: "settled", tier, eventId: id });
+      after(TICK_LINGER_MS, () => {
+        setStatus((s) => (s.kind === "settled" && s.eventId === id ? { kind: "idle" } : s));
+      });
+    } else {
+      setStatus({ kind: "writing", tier, eventId: id });
+    }
+
+    setEvents((evts) => [
+      ...evts,
+      {
+        id,
+        tier,
+        value,
+        phase: isLocal ? "settled" : "writing",
+        startedAt: performance.now(),
+        queuedSince,
+        reachedEdge: false,
+      },
+    ]);
+  }
+
+  function toggleOffline() {
+    if (!offline) {
+      setOffline(true);
+      return;
+    }
+    setOffline(false);
+    // Release queued events one at a time so the user sees the propagation
+    // waves as a sequence rather than a single chord.
+    const queued = eventsRef.current
+      .filter((e) => e.queuedSince !== null)
+      .sort((a, b) => (a.queuedSince ?? 0) - (b.queuedSince ?? 0));
+    queued.forEach((event, idx) => {
+      after(idx * RECONNECT_STAGGER_MS, () => {
+        setEvents((evts) => evts.map((e) => (e.id === event.id ? { ...e, queuedSince: null } : e)));
+      });
+    });
+  }
+
+  const onGeometry = useCallback((ctx: GraphOverlayCtx) => {
+    geomRef.current = ctx;
+    setGeomReady(true);
+    const e = ctx.anchors.edge;
+    if (e) {
+      const base = (e.right - e.midX) * BRANCH_OFFSET;
+      setBranchBase((p) => (Math.abs(p - base) < 0.5 ? p : base));
+    }
+  }, []);
+
+  // Static resting connector + per-event, per-hop traces, drawn from the
+  // engine-measured anchors and stroked in each write's colour.
+  const overlay = useCallback(
+    (ctx: GraphOverlayCtx) => {
+      const conn = connectorPaths(ctx.anchors, branchDx);
+      return (
+        <>
+          {conn && (
+            <>
+              {/* Authoritative durability spine: device → edge → global core,
+                  drawn solid as the trunk. */}
+              <path
+                d={`${conn.edge} ${conn.global}`}
+                fill="none"
+                stroke="var(--diagram-edge, #9ca3af)"
+                strokeWidth={1.5}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              {/* The other device hangs off the edge as a leaf — a replicated
+                  copy, not part of the durability chain. Dashed + faded so the
+                  hierarchy reads as a tree, not a symmetric fan-out. */}
+              <path
+                d={conn.receiver}
+                fill="none"
+                stroke="var(--diagram-edge, #9ca3af)"
+                strokeWidth={1.5}
+                strokeDasharray="3 4"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                opacity={0.55}
+              />
+            </>
+          )}
+          <g>
+            {events.flatMap((event) =>
+              HOPS.map((hop) => {
+                const id = `${event.id}-${hop}`;
+                return (
+                  <path
+                    key={id}
+                    ref={(el) => {
+                      traces.pathRef(id)(el);
+                      pathElsRef.current[id] = el;
+                    }}
+                    className="diagram-path"
+                    d={conn?.[hop] ?? ""}
+                    fill="none"
+                    stroke={event.value}
+                    strokeWidth={2}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                );
+              }),
+            )}
+          </g>
+          <g>
+            {events.flatMap((event) =>
+              HOPS.map((hop) => {
+                const id = `${event.id}-${hop}`;
+                return (
+                  <circle
+                    key={id}
+                    ref={traces.dotRef(id)}
+                    className="diagram-dot"
+                    r={5}
+                    cx={0}
+                    cy={0}
+                    fill={event.value}
+                    style={{ opacity: 0 }}
+                  />
+                );
+              }),
+            )}
+          </g>
+        </>
+      );
+    },
+    [events, traces, branchDx],
+  );
+
+  // Phone on the left spanning all three rows; global (top), edge (middle)
+  // and the other device (bottom) stacked on the right. No structural edges —
+  // the overlay draws the connector itself from the measured anchors.
+  const nodes: GraphNode[] = [
+    {
+      id: "phone",
+      slot: { row: "1 / 4", col: 1 },
+      content: (
+        <PhoneChrome
+          className="w-[clamp(13rem,46vw,17rem)]"
+          pulseKey={pulse.phone.key}
+          offline={offline}
+        >
+          <PhoneScreen
+            tier={tier}
+            setTier={setTier}
+            status={status}
+            onWrite={runWrite}
+            offline={offline}
+            onToggleOffline={toggleOffline}
+            unsynced={events.filter((e) => !e.reachedEdge).length}
+            colour={colours.phone}
+          />
+        </PhoneChrome>
+      ),
+    },
+    {
+      id: "global",
+      slot: { row: 1, col: 2 },
+      content: <Card k="global" pulse={pulse.global} colour={colours.global} />,
+    },
+    {
+      id: "edge",
+      slot: { row: 2, col: 2 },
+      content: <Card k="edge" pulse={pulse.edge} colour={colours.edge} />,
+    },
+    {
+      id: "receiver",
+      slot: { row: 3, col: 2 },
+      // Shifted to sit under its branch endpoint (branchDx). Visual only — the
+      // engine measures the wrapper (still column-centred), and connectorPaths
+      // routes to receiver.midX + branchDx, so card and branch stay locked.
+      content: (
+        <div style={{ transform: `translateX(${branchDx}px)` }}>
+          <Card k="receiver" pulse={pulse.receiver} colour={colours.receiver} />
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <Graph
+      eyebrow="Pick a tier"
+      description={
+        <>
+          Each write picks a fresh colour. Choose how durable it must be before it's confirmed — it
+          lands on this device at once, then syncs up through the tiers and across to the other
+          device whenever the network is available; the promise resolves once it reaches the tier
+          you picked. Turn on aeroplane mode to watch writes queue on the device and flush when you
+          reconnect. Local always confirms instantly, even offline.
+        </>
+      }
+      direction="LR"
+      nodes={nodes}
+      edges={[]}
+      grid={{
+        columns: "auto auto",
+        rows: "auto auto auto",
+        // Row gap fixed; column gap tightens on narrow screens so the phone +
+        // tier column don't get pushed apart (and off-screen) on mobile.
+        gap: "2rem clamp(0.75rem, 5vw, 3.5rem)",
+      }}
+      arrows={false}
+      traces={traces}
+      overlay={overlay}
+      onGeometry={onGeometry}
+    />
+  );
+}

--- a/docs/content/docs/writing/writing-data.mdx
+++ b/docs/content/docs/writing/writing-data.mdx
@@ -117,6 +117,10 @@ When using `insert(...).wait({ tier })`, `update(...).wait({ tier })`, or `delet
 | `edge`   | Acknowledged by nearest sync server | Backend/server |
 | `global` | Propagated to global core           | —              |
 
+<WriteTierDiagram />
+
+Offline, only `local` resolves; `edge` and `global` waits stay pending until the device reconnects and the queued write propagates upstream. The write itself is durable locally either way, so picking a higher tier is purely about _when the promise resolves_, never about whether the data is safe.
+
 <Tabs groupId="jazz-environment" items={["TypeScript", "Rust"]} persist updateAnchor>
   <Tab value="TypeScript">
     <include cwd lang="ts">

--- a/docs/mdx-components.tsx
+++ b/docs/mdx-components.tsx
@@ -8,6 +8,7 @@ import { DeployCommand } from "./components/mdx/deploy-command";
 import { LensDiagram } from "./components/mdx/lens-diagram";
 import { TierSyncDiagram } from "./components/mdx/tier-sync-diagram";
 import { Graph, Sequence } from "./components/mdx/diagram";
+import { WriteTierDiagram } from "./components/mdx/write-tier-diagram";
 import { JazzLogo } from "./components/brand/jazz-logo";
 
 function SlideCodeCell({ children, title }: { children: ReactNode; title: string }) {
@@ -32,6 +33,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     TierSyncDiagram,
     Graph,
     Sequence,
+    WriteTierDiagram,
     JazzLogo,
     SlideCodeCell,
     ...components,


### PR DESCRIPTION
An interactive diagram for the durability-tiers section of `writing-data.mdx` that makes the wait-tier story concrete: pick a tier, hit "New colour", and watch the write light up the phone, race up the trunk to the chosen tier, fan out from edge to the global core and to another device, and resolve at the tier you picked. Aeroplane mode queues every non-local write on the device; flipping it off releases the queue, staggered so each propagation wave reads as its own event rather than a chord.

Stacks on `joe/mobile-diagrams` — review only the last four commits here.

## What's in the diff

- `feat(docs): expose roundedPath/Point and a disabled NodeAction` — engine surface gains a public `roundedPath` (so consumer diagrams can build bespoke elbow connectors without re-deriving the corner-arc maths) and a `disabled` prop on `NodeAction` (dimmed + not-allowed via existing CSS, for in-flight affordances).
- `refactor(docs): lift the colour-write policy out of tier-sync` — moves `pickNextColor` and the hue-gap helpers from `tier-sync-diagram.tsx` to a shared `components/mdx/colour.ts`. Pure relocation; both propagation diagrams want the same "consecutive writes are visibly distinct" guarantee.
- `refactor(docs): extract reusable PhoneChrome from lens-diagram` — pulls the lens diagram's phone bezel (status bar, themed screen inside a near-black shell) into `diagram/phone-chrome.tsx`. Obeys engine portability rules (no Tailwind, no `fd-*`, no `lucide-react`); the screen follows `--diagram-*` tokens, the bezel/notch stay near-black either way. Optional `offline` prop swaps wifi/signal for an iOS-style aeroplane glyph. Lens output is byte-equivalent.
- `feat(docs): WriteTierDiagram — pick a tier, watch the write propagate` — the new component plus a one-line caption in `writing-data.mdx` tying it to the offline behaviour described above.

## Domain policy lives in the definition

The engine just measures, lays out, and animates. The diagram itself owns:

- last-write-wins per node
- the "local-only" counter that only clears once a write reaches the edge
- the writing → settled lifecycle on the in-flight pill
- queue release ordering when aeroplane mode flips off

The trunk and branch connectors are drawn from measured anchors via the newly-exported `roundedPath`. The in-flight "Write" affordance uses `NodeAction`'s new `disabled` state.

## Testing

Pure functions (geometry, BFS waves, colour gap) covered by the existing `vitest` suite. Interactive behaviour and look — desktop and mobile widths, light and dark, aeroplane on/off, every tier — checked by eye.
