### PR TITLE
docs: schema hash CLI, JWT sub guidance, indexOnly, counter merges, permission columns in includes

### DIFF
--- a/docs/content/docs/auth/authentication.mdx
+++ b/docs/content/docs/auth/authentication.mdx
@@ -76,7 +76,7 @@ If your provider doesn't provide a stable ID in `sub` by default, either configu
 or remint the token through your own JWT layer that rewrites `sub`.
 
 <Callout type="info">
-  Policies are enforced based on the `sub` claim, If you ever change what you use for `sub` in your
+  Policies are enforced based on the `sub` claim. If you ever change what you use for `sub` in your
   application, Jazz will consider this to be a different user, which may lead to unintended
   consequences when enforcing policies.
 </Callout>

--- a/docs/content/docs/auth/authentication.mdx
+++ b/docs/content/docs/auth/authentication.mdx
@@ -1,7 +1,7 @@
 ---
 title: Authentication
 description: "How and when to use Jazz's auth modes, and how to manage JWT auth over the lifetime of a live client."
-reviewedAt: "f52c2c62"
+reviewedAt: "2e983ef11"
 ---
 
 Jazz has three auth modes: `anonymous`, `local-first`, and `external`. You pick the mode implicitly by what you pass in `DbConfig`: nothing for anonymous, `secret` for local-first, or `jwtToken` for external.
@@ -62,6 +62,23 @@ For more details, the [Auth0 docs](https://auth0.com/docs/secure/tokens/json-web
   user changes. Recreate the client for sign-in, sign-out, or principal switches. Reserve
   `db.updateAuthToken(...)` for refreshing a JWT for the same user on an already-authenticated
   client.
+</Callout>
+
+Jazz uses the JWT `sub` claim as `session.user_id`. This is used internally by Jazz to record the
+identity for every write, permission check, and `$createdBy` reference. Use a stable value.
+
+- In most cases, use your provider's internal user ID, as this is generally fixed for the lifetime
+  of the user account
+- Avoid email addresses, as these can and do change.
+- Do not use any ephemeral identifier (e.g. a session ID).
+
+If your provider doesn't provide a stable ID in `sub` by default, either configure it
+or remint the token through your own JWT layer that rewrites `sub`.
+
+<Callout type="info">
+  Policies are enforced based on the `sub` claim, If you ever change what you use for `sub` in your
+  application, Jazz will consider this to be a different user, which may lead to unintended
+  consequences when enforcing policies.
 </Callout>
 
 ### Managing JWT changes on a live client

--- a/docs/content/docs/auth/permissions.mdx
+++ b/docs/content/docs/auth/permissions.mdx
@@ -1,7 +1,7 @@
 ---
 title: Permissions
 description: Jazz's approach to row-level security using relationship-based access controls, and how to build policies of varying complexity.
-reviewedAt: "f6535a533"
+reviewedAt: "2e983ef11"
 ---
 
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
@@ -166,6 +166,21 @@ schema, and they are omitted from `select("*")`, so opt in explicitly when you w
   <Tab value="Rust">
     <include cwd lang="rs">
       ../examples/docs/todo-server-rs/src/docs_snippets.rs#reading-magic-columns-rust
+    </include>
+  </Tab>
+</Tabs>
+
+Permission columns work the same way inside `include(...)` subqueries: the booleans are evaluated **per row**, against the policy on the included table, not inherited from the parent. A query that loads a project with its todos can ask whether the current session can edit each individual todo, driving per-row UI affordances like edit buttons or delete confirmations without mirroring your permission policy on the client.
+
+<Tabs groupId="jazz-environment" items={["TypeScript", "Rust"]} persist updateAnchor>
+  <Tab value="TypeScript">
+    <include cwd lang="ts">
+      ../examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts#reading-magic-columns-include-ts
+    </include>
+  </Tab>
+  <Tab value="Rust">
+    <include cwd lang="rs">
+      ../examples/docs/todo-server-rs/src/docs_snippets.rs#reading-magic-columns-include-rust
     </include>
   </Tab>
 </Tabs>

--- a/docs/content/docs/reference/internals.mdx
+++ b/docs/content/docs/reference/internals.mdx
@@ -1,7 +1,7 @@
 ---
 title: Advanced Internals
 description: "How Jazz works under the hood: raw tables, row histories, sync, the query pipeline, and the browser architecture."
-reviewedAt: "6027cae2"
+reviewedAt: "2e983ef11"
 ---
 
 This page describes Jazz's internal architecture. You do not need any of this to use Jazz, but it
@@ -57,17 +57,47 @@ Both storage shapes are flat rows:
 - history rows use reserved `_jazz_*` columns plus the user columns
 - visible rows use a slightly larger `_jazz_*` prefix plus the same user columns
 
-### Automatic column indexing
+### Indexing
 
-Every column in every table gets a single-column index automatically. There is no manual index
-management.
+By default, **every column on every table is indexed**. This keeps `where`, `orderBy`, and
+join lookups fast on any column without you having to think about it, at the cost of one
+index entry per column per row. The `_id` index for each table doubles as the authoritative
+row manifest, so discovering all rows in a table is just an `_id` index scan.
 
-The `_id` index for each table doubles as the authoritative row manifest, so discovering all rows
-in a table is just an `_id` index scan.
+Sometimes you'll want to optimise for write performance or storage cost instead. Use
+`indexOnly()` to specify which columns in the table need indexes; only the columns you
+specify will be indexed.
 
-This is a deliberate trade-off: local-first databases are usually small enough that automatic
-indexing is worth the storage overhead, and it guarantees that ordinary `where(...)` filters do not
-fall back to surprise table scans.
+<Callout type="warn" title="Avoid overuse">
+  `table.indexOnly(["title", "done"])` does **not** mean "add indexes on `title` and `done`". It
+  means "**drop** the indexes on every other column on this table". Read it as _"index only these"_.
+  `indexOnly` is an optimisation that you're unlikely to need to begin with, and if not used
+  correctly, can significantly impact the performance of your app, especially on reads.
+</Callout>
+
+```ts title="schema.ts"
+import { schema as s } from "jazz-tools";
+
+const schema = {
+  todos: s
+    .table({
+      title: s.string(),
+      done: s.boolean(),
+      description: s.string().optional(),
+      activityLog: s.string().optional(),
+    })
+    .indexOnly(["title", "done"]),
+};
+```
+
+In this example, `where({ title: ... })` and `where({ done: ... })` are still index-backed.
+A query that filters on `description` or `activityLog` works, but falls back to scanning
+every row in the table.
+
+Use `indexOnly` when you're seeing slow writes and:
+
+- The column holds large or rarely-queried data (long text, serialised metadata, audit logs).
+- The table is write-heavy and the per-column index cost is showing up in your performance data.
 
 ### Deletion
 
@@ -93,6 +123,47 @@ visible state, but it is not a normal application-facing feature yet.
 Each runtime instance maintains a small monotonic clock for direct writes. New row versions created
 by that runtime get strictly increasing local timestamps, which makes deterministic last-writer-wins
 ordering straightforward within a single device or process.
+
+### Merge strategies
+
+By default, Jazz adopts a last-writer-wins strategy to resolve concurrent edits. This means that if
+two clients update the same row simultaneously, the one with the later timestamp overwrites the earlier one.
+
+This is a sensible default, but can cause some unexpected behaviour with certain types of data. For example,
+imagine a voting app. Alice and Bob both read the current `voteCount` value as 2. They each want to increment
+the value. If they simultaneously write 3, then the new value will be 3, even though they actually each wanted
+to increment by one.
+
+Use `.merge("counter")` on the column to keep deltas additive instead:
+
+```ts title="schema.ts"
+import { schema as s } from "jazz-tools";
+
+const schema = {
+  votes: s.table({
+    proposal: s.string(),
+    voteCount: s.int().merge("counter"),
+  }),
+};
+```
+
+With `merge("counter")`, every `update(...)` on the column is recorded as a delta from the
+value the writer was looking at. When concurrent edits meet, the deltas are summed: Alice's
+`+1` and Bob's `+1` both apply, and the `voteCount` correctly lands on `4`.
+
+Counter merges are useful for things like:
+
+- A shared score or vote tally.
+- An inventory level being incremented and decremented from multiple devices.
+- Any other counter where you care about preserving every increment rather than which device
+  wrote last.
+
+<Callout type="warn">
+  `merge("counter")` is only valid on **non-nullable integer columns**. Calling it on a string, on a
+  nullable integer (`s.int().optional()`), or on any other type throws at schema construction time.
+  `"counter"` is currently the only non-default merge strategy, but more merge strategies are
+  planned in future.
+</Callout>
 
 ### Cold start
 

--- a/docs/content/docs/reference/internals.mdx
+++ b/docs/content/docs/reference/internals.mdx
@@ -126,7 +126,7 @@ ordering straightforward within a single device or process.
 
 ### Merge strategies
 
-By default, Jazz adopts a last-writer-wins strategy to resolve concurrent edits. This means that if
+By default, Jazz adopts a per-column last-writer-wins strategy to resolve concurrent edits. This means that if
 two clients update the same row simultaneously, the one with the later timestamp overwrites the earlier one.
 
 This is a sensible default, but can cause some unexpected behaviour with certain types of data. For example,

--- a/docs/content/docs/reference/internals.mdx
+++ b/docs/content/docs/reference/internals.mdx
@@ -127,7 +127,7 @@ ordering straightforward within a single device or process.
 ### Merge strategies
 
 By default, Jazz adopts a per-column last-writer-wins strategy to resolve concurrent edits. This means that if
-two clients update the same row simultaneously, the one with the later timestamp overwrites the earlier one.
+two clients update the same column of the same row simultaneously, the one with the later timestamp overwrites the earlier one.
 
 This is a sensible default, but can cause some unexpected behaviour with certain types of data. For example,
 imagine a voting app. Alice and Bob both read the current `voteCount` value as 2. They each want to increment

--- a/docs/content/docs/schemas/migrations.mdx
+++ b/docs/content/docs/schemas/migrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrations
 description: Structural schema evolution workflow and reviewed migration edges.
-reviewedAt: "c799b8dfd"
+reviewedAt: "2e983ef11"
 ---
 
 <Callout type="info" title="You can skip this first">
@@ -139,6 +139,14 @@ pnpm dlx jazz-tools@alpha migrations create <appId> --fromHash <fromHash> --toHa
 
 `--toHash` defaults to the current local schema. When a requested hash is not already saved locally, Jazz resolves it from the
 server and saves a snapshot in `migrations/snapshots/`.
+
+## Inspecting the local schema hash
+
+`pnpm dlx jazz-tools@alpha schema hash` prints the hash of the local `schema.ts` without contacting a server or writing a snapshot, giving you a simple way to compare your local schema against what's deployed.
+
+```bash
+pnpm dlx jazz-tools@alpha schema hash
+```
 
 ## Exporting the compiled schema
 

--- a/examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts
@@ -177,6 +177,16 @@ export async function readDeletableTodos(db: Db) {
 }
 // #endregion reading-magic-columns-ts
 
+// #region reading-magic-columns-include-ts
+export async function readProjectsWithTodoPermissions(db: Db) {
+  return db.all(
+    app.projects.include({
+      todosViaProject: app.todos.select("title", "$canEdit", "$canDelete").orderBy("title", "asc"),
+    }),
+  );
+}
+// #endregion reading-magic-columns-include-ts
+
 // #region reading-edit-metadata-magic-columns-ts
 export async function readTodoEditMetadata(db: Db, currentUserId: string, updatedSinceMs: number) {
   return db.all(

--- a/examples/docs/todo-server-rs/src/docs_snippets.rs
+++ b/examples/docs/todo-server-rs/src/docs_snippets.rs
@@ -232,6 +232,23 @@ pub async fn read_todos_with_permissions(client: &JazzClient) -> jazz_tools::Res
 }
 // #endregion reading-magic-columns-rust
 
+// #region reading-magic-columns-include-rust
+pub async fn read_projects_with_todo_permissions(client: &JazzClient) -> jazz_tools::Result<usize> {
+    let query = QueryBuilder::new("projects")
+        .with_array("todos_via_project", |sub| {
+            sub.from("todos").correlate("project_id", "_id").select(&[
+                "title",
+                "$canEdit",
+                "$canDelete",
+            ])
+        })
+        .build();
+
+    let rows = client.query(query, None).await?;
+    Ok(rows.len())
+}
+// #endregion reading-magic-columns-include-rust
+
 // #region reading-recursive-rust
 pub fn build_todo_lineage_query() -> jazz_tools::Query {
     QueryBuilder::new("todos")


### PR DESCRIPTION
## Summary
- New `## Inspecting the local schema hash` section in `migrations.mdx` covering the `pnpm dlx jazz-tools@alpha schema hash` command.
- JWT `sub` claim guidance in `authentication.mdx`: what to put in `sub`, what to avoid, and a Callout on the policy-enforcement consequence of changing it later.
- Permission magic columns (`$canRead`/`$canEdit`/`$canDelete`) extended in `auth/permissions.mdx` with a paragraph and TS + Rust snippets showing per-row evaluation inside `include(...)` subqueries.
- New `### Indexing` (with `.indexOnly()`) and `### Merge strategies` (with `.merge("counter")`) subsections under `reference/internals.mdx` — placed alongside the existing internals content rather than on `defining-tables.mdx`, since they're rarely-needed optimisations rather than core schema concepts.
- `reviewedAt` stamps bumped to `2e983ef11` on all four pages.

## Test plan
- [ ] `pnpm --filter docs build` succeeds (snippets are type-checked against `jazz-tools`).
- [ ] Visit the four pages locally and confirm the new sections render with their `<include>` blocks and Callouts.
- [ ] Spot-check the `pnpm dlx jazz-tools@alpha schema hash` command actually runs.