### PR TITLE
Add DevServer migration runner

### DIFF
--- a/crates/jazz-tools/src/sync_manager/mod.rs
+++ b/crates/jazz-tools/src/sync_manager/mod.rs
@@ -169,6 +169,10 @@ fn short_hash(hash: &impl ToString) -> String {
     hash.to_string().chars().take(12).collect()
 }
 
+fn dev_server_migration_create_console_call() -> &'static str {
+    "runJazzMigrations()"
+}
+
 pub(crate) fn log_schema_warning(
     warning: &SchemaWarning,
     origin: Option<&str>,
@@ -202,11 +206,12 @@ pub(crate) fn log_connection_schema_diagnostics(
             origin = origin,
             client_schema_hash = %client_hash,
             permissions_schema_hash = %permissions_hash,
-            "Your declared schema {} is disconnected from the schema used to enforce permissions: {}. Reads and writes may fail until you add a migration. To recover, run `npx jazz-tools@alpha migrations create --fromHash {} --toHash {}`.",
+            "Your declared schema {} is disconnected from the schema used to enforce permissions: {}. Reads and writes may fail until you add a migration. To recover, run `npx jazz-tools@alpha migrations create --fromHash {} --toHash {}`. If this app is running through a DevServer, open the app console and call `{}`.",
             client_hash,
             permissions_hash,
             permissions_hash,
             client_hash,
+            dev_server_migration_create_console_call(),
         );
     }
 

--- a/crates/jazz-tools/src/sync_manager/tests.rs
+++ b/crates/jazz-tools/src/sync_manager/tests.rs
@@ -22,6 +22,14 @@ fn users_schema_hash() -> SchemaHash {
     SchemaHash::compute(&users_test_schema())
 }
 
+#[test]
+fn dev_server_migration_create_console_call_names_global_runner() {
+    assert_eq!(
+        dev_server_migration_create_console_call(),
+        "runJazzMigrations()"
+    );
+}
+
 fn seed_users_schema(storage: &mut MemoryStorage) {
     persist_test_schema(storage, &users_test_schema());
 }

--- a/packages/jazz-tools/src/dev/dev-server.ts
+++ b/packages/jazz-tools/src/dev/dev-server.ts
@@ -1,8 +1,10 @@
 import { createServer as createNetServer } from "node:net";
 import { mkdtemp, rm } from "node:fs/promises";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DevServer } from "jazz-napi";
+import { createMigration } from "../cli.js";
 import { loadCompiledSchema } from "../schema-loader.js";
 import {
   fetchPermissionsHead,
@@ -13,6 +15,7 @@ import {
 const DEFAULT_APP_ID = "00000000-0000-0000-0000-000000000001";
 const AUTO_PORT_MIN = 20_000;
 const AUTO_PORT_RANGE = 20_000;
+export const DEV_SERVER_MIGRATION_CREATE_PATH = "/_jazz/migrations/create";
 
 const autoAllocatedPorts = new Set<number>();
 
@@ -51,6 +54,28 @@ export interface PushSchemaCatalogueOptions {
   env?: string;
   userBranch?: string;
   enableLogs?: boolean;
+}
+
+export interface DevServerMigrationCreateOptions {
+  serverUrl: string;
+  appId: string;
+  adminSecret: string;
+  schemaDir: string;
+}
+
+interface DevServerMigrationCreateBody {
+  fromHash?: unknown;
+  toHash?: unknown;
+  name?: unknown;
+}
+
+class DevServerMigrationCreateError extends Error {
+  constructor(
+    readonly status: number,
+    message: string,
+  ) {
+    super(message);
+  }
 }
 
 async function canBindPort(port: number): Promise<boolean> {
@@ -191,4 +216,145 @@ export async function pushSchemaCatalogue(
   }
 
   return { hash: result.hash };
+}
+
+async function readRequestBody(req: IncomingMessage): Promise<string> {
+  let body = "";
+
+  for await (const chunk of req) {
+    body += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+    if (body.length > 16_384) {
+      throw new DevServerMigrationCreateError(413, "Request body is too large.");
+    }
+  }
+
+  return body;
+}
+
+function parseMigrationCreateBody(rawBody: string): {
+  fromHash?: string;
+  toHash?: string;
+  name?: string;
+} {
+  let body: DevServerMigrationCreateBody;
+  try {
+    body = JSON.parse(rawBody) as DevServerMigrationCreateBody;
+  } catch {
+    throw new DevServerMigrationCreateError(400, "Request body must be valid JSON.");
+  }
+
+  if (
+    body.fromHash !== undefined &&
+    (typeof body.fromHash !== "string" || body.fromHash.trim().length === 0)
+  ) {
+    throw new DevServerMigrationCreateError(400, "fromHash must be a non-empty string.");
+  }
+  if (
+    body.toHash !== undefined &&
+    (typeof body.toHash !== "string" || body.toHash.trim().length === 0)
+  ) {
+    throw new DevServerMigrationCreateError(400, "toHash must be a non-empty string.");
+  }
+  if ((body.fromHash === undefined) !== (body.toHash === undefined)) {
+    throw new DevServerMigrationCreateError(
+      400,
+      "Provide both fromHash and toHash, or omit both to infer them.",
+    );
+  }
+  if (body.name !== undefined && typeof body.name !== "string") {
+    throw new DevServerMigrationCreateError(400, "name must be a string when provided.");
+  }
+
+  return {
+    fromHash: body.fromHash?.trim(),
+    toHash: body.toHash?.trim(),
+    name: body.name?.trim() || undefined,
+  };
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  res.statusCode = status;
+  res.setHeader("Content-Type", "application/json");
+  res.end(JSON.stringify(body));
+}
+
+export function createDevServerMigrationCreateHandler(options: DevServerMigrationCreateOptions) {
+  return async (
+    req: IncomingMessage,
+    res: ServerResponse,
+    next: (error?: unknown) => void,
+  ): Promise<void> => {
+    if (req.method !== "POST") {
+      sendJson(res, 405, { error: "Use POST to create a migration." });
+      return;
+    }
+
+    try {
+      const request = parseMigrationCreateBody(await readRequestBody(req));
+      let fromHash = request.fromHash;
+      const toHash = request.toHash;
+
+      if (!fromHash && !toHash) {
+        const { head } = await fetchPermissionsHead(options.serverUrl, {
+          appId: options.appId,
+          adminSecret: options.adminSecret,
+        });
+        if (!head) {
+          throw new DevServerMigrationCreateError(
+            409,
+            "Cannot infer migration source because the server has no permissions head.",
+          );
+        }
+        fromHash = head.schemaHash;
+      }
+
+      const filePath = await createMigration({
+        appId: options.appId,
+        serverUrl: options.serverUrl,
+        adminSecret: options.adminSecret,
+        schemaDir: options.schemaDir,
+        migrationsDir: join(options.schemaDir, "migrations"),
+        fromHash,
+        toHash,
+        name: request.name,
+      });
+
+      sendJson(res, 200, { filePath });
+    } catch (error) {
+      if (error instanceof DevServerMigrationCreateError) {
+        sendJson(res, error.status, { error: error.message });
+        return;
+      }
+
+      if (error instanceof Error) {
+        sendJson(res, 500, { error: error.message });
+        return;
+      }
+
+      next(error);
+    }
+  };
+}
+
+export function devServerMigrationRunnerScript(): string {
+  return `<script>
+globalThis.runJazzMigrations = async function runJazzMigrations() {
+  const response = await fetch(${JSON.stringify(DEV_SERVER_MIGRATION_CREATE_PATH)}, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({}),
+  });
+  const body = await response.json().catch(() => null);
+  if (!response.ok) {
+    const detail = body && typeof body.error === "string" ? \`: \${body.error}\` : "";
+    throw new Error(\`Jazz migration creation failed (\${response.status} \${response.statusText})\${detail}\`);
+  }
+  if (body && typeof body.filePath === "string") {
+    console.log(\`[jazz] Migration created: \${body.filePath}\`);
+  } else {
+    console.log("[jazz] No migration file created.", body);
+  }
+  return body;
+};
+</script>`;
 }

--- a/packages/jazz-tools/src/dev/sveltekit.ts
+++ b/packages/jazz-tools/src/dev/sveltekit.ts
@@ -1,4 +1,9 @@
 import { join, resolve } from "node:path";
+import {
+  createDevServerMigrationCreateHandler,
+  DEV_SERVER_MIGRATION_CREATE_PATH,
+  devServerMigrationRunnerScript,
+} from "./dev-server.js";
 import { loadEnvFileIntoProcessEnv } from "./env-file.js";
 import { ManagedDevRuntime, type ManagedRuntime } from "./managed-runtime.js";
 import { resolveJazzWasmEntry } from "./vite.js";
@@ -156,6 +161,15 @@ export function jazzSvelteKit(options: JazzPluginOptions = {}) {
       return ensureInitialised(config.server, root).then(() => merged);
     },
 
+    transformIndexHtml(html: string, ctx?: { server?: unknown }) {
+      if (!ctx?.server || options.server === false) return html;
+      const script = devServerMigrationRunnerScript();
+      if (html.includes("</head>")) {
+        return html.replace("</head>", `${script}</head>`);
+      }
+      return `${script}${html}`;
+    },
+
     async configureServer(viteServer: ViteDevServer): Promise<void> {
       viteServerRef = viteServer;
       if (viteServer.config.command !== "serve" || options.server === false) return;
@@ -182,6 +196,16 @@ export function jazzSvelteKit(options: JazzPluginOptions = {}) {
         viteServer.config.env.PUBLIC_JAZZ_TELEMETRY_COLLECTOR_URL =
           resolvedRuntime.telemetryCollectorUrl;
       }
+
+      viteServer.middlewares?.use(
+        DEV_SERVER_MIGRATION_CREATE_PATH,
+        createDevServerMigrationCreateHandler({
+          serverUrl: resolvedRuntime.serverUrl,
+          appId: resolvedRuntime.appId,
+          adminSecret: resolvedRuntime.adminSecret,
+          schemaDir: options.schemaDir ?? join(viteServer.config.root, "src", "lib"),
+        }),
+      );
     },
   };
 }

--- a/packages/jazz-tools/src/dev/vite.test.ts
+++ b/packages/jazz-tools/src/dev/vite.test.ts
@@ -1,5 +1,7 @@
-import { readFile, writeFile } from "node:fs/promises";
+import { readdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { Readable } from "node:stream";
+import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { jazzPlugin } from "./vite.js";
 import * as devServer from "./dev-server.js";
@@ -7,6 +9,7 @@ import * as schemaWatcher from "./schema-watcher.js";
 import { createTempRootTracker, getAvailablePort, todoSchema } from "./test-helpers.js";
 
 const tempRoots = createTempRootTracker();
+const indexPath = fileURLToPath(new URL("../index.ts", import.meta.url));
 const originalJazzServerUrl = process.env.VITE_JAZZ_SERVER_URL;
 const originalJazzAppId = process.env.VITE_JAZZ_APP_ID;
 const originalJazzTelemetryCollectorUrl = process.env.VITE_JAZZ_TELEMETRY_COLLECTOR_URL;
@@ -94,6 +97,21 @@ describe("jazzPlugin", () => {
     expect(alias!.replacement).toMatch(/jazz_wasm\.js$/);
   });
 
+  it("injects runJazzMigrations into dev HTML", () => {
+    const plugin = jazzPlugin();
+    const transform = (
+      plugin as {
+        transformIndexHtml?: (html: string, ctx: { server?: object }) => string;
+      }
+    ).transformIndexHtml;
+
+    expect(transform).toBeDefined();
+    const html = transform!("<html><head></head><body></body></html>", { server: {} });
+
+    expect(html).toContain("globalThis.runJazzMigrations");
+    expect(html).toContain("/_jazz/migrations/create");
+  });
+
   it("starts a server and pushes schema via configureServer hook", async () => {
     const port = await getAvailablePort();
     const schemaDir = await tempRoots.create("jazz-vite-test-");
@@ -158,6 +176,112 @@ describe("jazzPlugin", () => {
     }
 
     await expect(fetch(`http://127.0.0.1:${port}/health`).then((r) => r.ok)).rejects.toThrow();
+  }, 30_000);
+
+  it("creates an inferred migration through the dev-server fetch endpoint", async () => {
+    const port = await getAvailablePort();
+    const schemaDir = await tempRoots.create("jazz-vite-migration-endpoint-test-");
+    await writeFile(join(schemaDir, "schema.ts"), todoSchema());
+    await writeFile(
+      join(schemaDir, "permissions.ts"),
+      `
+import { schema as s } from ${JSON.stringify(indexPath)};
+import { app } from "./schema.ts";
+
+export default s.definePermissions(app, ({ policy }) => [
+  policy.todos.allowRead.always(),
+  policy.todos.allowInsert.never(),
+  policy.todos.allowUpdate.never(),
+  policy.todos.allowDelete.never(),
+]);
+`,
+    );
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    let migrationRoute:
+      | ((
+          req: Readable & { method?: string; url?: string; headers?: Record<string, string> },
+          res: {
+            statusCode: number;
+            setHeader(name: string, value: string): void;
+            end(body?: string): void;
+          },
+          next: (error?: unknown) => void,
+        ) => void | Promise<void>)
+      | undefined;
+
+    const fakeViteServer = {
+      config: {
+        root: schemaDir,
+        command: "serve" as const,
+        env: {} as Record<string, string>,
+      },
+      httpServer: {
+        once(_event: string, _cb: () => void) {},
+      },
+      middlewares: {
+        use(path: string, handler: typeof migrationRoute) {
+          if (path === "/_jazz/migrations/create") {
+            migrationRoute = handler;
+          }
+        },
+      },
+      ws: { send() {} },
+    };
+
+    const plugin = jazzPlugin({
+      server: { port, adminSecret: "vite-migration-admin" },
+      schemaDir,
+    });
+    const configureServer = plugin.configureServer as (
+      server: typeof fakeViteServer,
+    ) => Promise<void>;
+    await configureServer(fakeViteServer);
+
+    expect(migrationRoute).toBeDefined();
+
+    const fromHash = await devServer.pushSchemaCatalogue({
+      serverUrl: `http://127.0.0.1:${port}`,
+      appId: fakeViteServer.config.env.VITE_JAZZ_APP_ID,
+      adminSecret: "vite-migration-admin",
+      schemaDir,
+    });
+
+    await writeFile(
+      join(schemaDir, "schema.ts"),
+      todoSchema().replace(
+        "    done: s.boolean(),",
+        "    done: s.boolean(),\n    priority: s.int(),",
+      ),
+    );
+
+    let responseBody = "";
+    const request = Readable.from([JSON.stringify({})]) as Readable & {
+      method?: string;
+      url?: string;
+      headers?: Record<string, string>;
+    };
+    request.method = "POST";
+    request.url = "/_jazz/migrations/create";
+    request.headers = { "content-type": "application/json" };
+    const response = {
+      statusCode: 200,
+      setHeader(_name: string, _value: string) {},
+      end(body = "") {
+        responseBody = body;
+      },
+    };
+
+    await migrationRoute!(request, response, (error?: unknown) => {
+      if (error) throw error;
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(responseBody) as { filePath?: string };
+    expect(body.filePath).toContain(`${fromHash.hash.slice(0, 12)}-`);
+    await expect(readdir(join(schemaDir, "migrations"))).resolves.toEqual(
+      expect.arrayContaining([expect.stringContaining(`${fromHash.hash.slice(0, 12)}-`)]),
+    );
   }, 30_000);
 
   it("does not inject a dev server url during build", async () => {

--- a/packages/jazz-tools/src/dev/vite.ts
+++ b/packages/jazz-tools/src/dev/vite.ts
@@ -1,7 +1,13 @@
 import { createRequire } from "node:module";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import { loadEnvFileIntoProcessEnv } from "./env-file.js";
 import { buildInspectorLink } from "./inspector-link.js";
 import { ManagedDevRuntime } from "./managed-runtime.js";
+import {
+  createDevServerMigrationCreateHandler,
+  DEV_SERVER_MIGRATION_CREATE_PATH,
+  devServerMigrationRunnerScript,
+} from "./dev-server.js";
 import type { TelemetryOptions } from "../runtime/sync-telemetry.js";
 
 // jazz-tools contains a dynamic `import("jazz-wasm")` that we intentionally
@@ -55,6 +61,16 @@ export interface ViteDevServer {
     };
   };
   httpServer: { once(event: string, cb: () => void): void } | null;
+  middlewares?: {
+    use(
+      path: string,
+      handler: (
+        req: IncomingMessage,
+        res: ServerResponse,
+        next: (error?: unknown) => void,
+      ) => void | Promise<void>,
+    ): void;
+  };
   ws: {
     send(payload: { type: string; err?: { message: string; stack?: string } }): void;
   };
@@ -95,6 +111,15 @@ export function jazzPlugin(options: JazzPluginOptions = {}) {
       };
     },
 
+    transformIndexHtml(html: string, ctx?: { server?: unknown }) {
+      if (!ctx?.server || options.server === false) return html;
+      const script = devServerMigrationRunnerScript();
+      if (html.includes("</head>")) {
+        return html.replace("</head>", `${script}</head>`);
+      }
+      return `${script}${html}`;
+    },
+
     async configureServer(viteServer: ViteDevServer) {
       if (viteServer.config.command !== "serve") return;
 
@@ -129,6 +154,16 @@ export function jazzPlugin(options: JazzPluginOptions = {}) {
         });
         return;
       }
+
+      viteServer.middlewares?.use(
+        DEV_SERVER_MIGRATION_CREATE_PATH,
+        createDevServerMigrationCreateHandler({
+          serverUrl: managed.serverUrl,
+          appId: managed.appId,
+          adminSecret: managed.adminSecret,
+          schemaDir,
+        }),
+      );
 
       // Vite only exposes VITE_*-prefixed keys to the client bundle via
       // import.meta.env. process.env gets the same values via the managed


### PR DESCRIPTION
## Summary

- add a DevServer-only migration creation endpoint at `/_jazz/migrations/create`
- inject `runJazzMigrations()` into Vite/SvelteKit dev pages so users can trigger migration generation from the browser console
- update schema disconnect diagnostics to point DevServer users at `runJazzMigrations()` while retaining the CLI command

## Validation

- `pnpm -C packages/jazz-tools exec vitest run --config vitest.config.ts src/dev/vite.test.ts`
- `pnpm -C packages/jazz-tools exec vitest run --config vitest.config.ts src/dev/sveltekit.test.ts src/dev/dev-server.test.ts`
- `pnpm -C packages/jazz-tools exec tsc --noEmit --project tsconfig.json`
- `cargo test -p jazz-tools dev_server_migration_create_console_call_names_global_runner`
- `cargo fmt --check`
- `git diff --check`

Note: the fresh worktree needed local `jazz-wasm` and `jazz-napi` build artifacts before the TypeScript checks could resolve those workspace packages.