### PR TITLE
Remove redundant captured frontier validation

### DIFF
--- a/crates/jazz-tools/src/batch_fate.rs
+++ b/crates/jazz-tools/src/batch_fate.rs
@@ -229,6 +229,9 @@ pub struct SealedBatchSubmission {
     pub target_branch_name: BranchName,
     pub batch_digest: Digest32,
     pub members: Vec<SealedBatchMember>,
+    // Compatibility payload only. Authorities no longer validate transactions
+    // against this family-wide frontier; row write conflicts are detected from
+    // each staged row's parents. Remove this in the next storage-format break.
     pub captured_frontier: Vec<CapturedFrontierMember>,
 }
 
@@ -240,6 +243,9 @@ pub struct SealedBatchMember {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CapturedFrontierMember {
+    // See `SealedBatchSubmission::captured_frontier`: this is preserved only so
+    // older persisted submissions can round-trip until a compat-breaking format
+    // refactor removes the field.
     pub object_id: ObjectId,
     pub branch_name: BranchName,
     pub batch_id: BatchId,
@@ -576,6 +582,8 @@ impl SealedBatchSubmission {
         });
         members.dedup();
         let batch_digest = Self::compute_batch_digest(&members);
+        // Preserve deterministic storage/wire round-trips for compatibility
+        // payload that is no longer used for transaction validation.
         captured_frontier.sort_by(|left, right| {
             left.object_id
                 .uuid()
@@ -1099,6 +1107,8 @@ mod tests {
 
     #[test]
     fn sealed_batch_submission_storage_row_roundtrips() {
+        // `captured_frontier` is still round-tripped for storage compatibility,
+        // but it is intentionally inert for transaction validation.
         let batch_id = BatchId::new();
         let object_id = ObjectId::new();
         let row_digest = Digest32([7; 32]);

--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/persisted.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/persisted.rs
@@ -833,6 +833,9 @@ fn rc_add_server_requests_pending_batch_fate_reconciliation() {
 
 #[test]
 fn rc_missing_batch_fate_retransmits_original_captured_frontier() {
+    // `captured_frontier` is compatibility payload now. This test only proves
+    // old-format sealed submissions are preserved while retransmitting; it is
+    // not a transaction conflict validation contract.
     let mut s = create_3tier_rc();
     let existing_row_id = ObjectId::new();
     let later_row_id = ObjectId::new();

--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/rejection_recovery.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/rejection_recovery.rs
@@ -1543,7 +1543,7 @@ fn rc_worker_accepts_local_batch_replay_payloads_from_peer() {
 // }
 
 #[test]
-fn rc_restart_rejects_stale_family_frontier_sealed_batch_from_storage() {
+fn rc_restart_accepts_stale_unrelated_family_frontier_sealed_batch_from_storage() {
     let schema = test_schema();
     let schema_hash = SchemaHash::compute(&schema);
     let batch_id = BatchId::new();
@@ -1671,18 +1671,19 @@ fn rc_restart_rejects_stale_family_frontier_sealed_batch_from_storage() {
             .storage()
             .load_authoritative_batch_fate(batch_id)
             .unwrap(),
-        Some(crate::batch_fate::BatchFate::Rejected {
+        Some(crate::batch_fate::BatchFate::AcceptedTransaction {
             batch_id,
-            code: "transaction_conflict".to_string(),
-            reason: "family-visible frontier changed since batch was sealed".to_string(),
+            confirmed_tier: DurabilityTier::Local,
         })
     );
+    let visible = restarted
+        .storage()
+        .load_visible_region_row("users", target_branch.as_str(), staged_row_id)
+        .unwrap()
+        .expect("accepted sealed batch should publish staged row");
     assert_eq!(
-        restarted
-            .storage()
-            .load_visible_region_row("users", target_branch.as_str(), staged_row_id)
-            .unwrap(),
-        None
+        visible.state,
+        crate::row_histories::RowState::VisibleTransactional
     );
     assert_eq!(
         restarted
@@ -1690,7 +1691,7 @@ fn rc_restart_rejects_stale_family_frontier_sealed_batch_from_storage() {
             .scan_history_row_batches("users", staged_row_id)
             .unwrap()[0]
             .state,
-        crate::row_histories::RowState::Rejected
+        crate::row_histories::RowState::VisibleTransactional
     );
     assert_eq!(
         restarted

--- a/crates/jazz-tools/src/runtime_core/writes.rs
+++ b/crates/jazz-tools/src/runtime_core/writes.rs
@@ -303,6 +303,10 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
     ) -> Result<SealedBatchSubmission, RuntimeError> {
         let (target_branch_name, members) = Self::sealed_batch_members_from_record(record)?;
         let captured_frontier = if record.mode == BatchMode::Transactional {
+            // Compatibility payload only. The authority ignores this frontier
+            // for validation now; transactional conflicts are detected from the
+            // staged rows' parent frontiers. Remove this capture when the sealed
+            // batch storage/wire format can break compatibility.
             self.storage
                 .capture_family_visible_frontier(target_branch_name)
                 .map_err(|err| {

--- a/crates/jazz-tools/src/storage/conformance.rs
+++ b/crates/jazz-tools/src/storage/conformance.rs
@@ -948,6 +948,8 @@ pub fn test_local_batch_record_round_trip(factory: &dyn Fn() -> Box<dyn Storage>
             object_id: ObjectId::from_uuid(uuid::Uuid::from_u128(92)),
             row_digest: Digest32([9; 32]),
         }],
+        // Compatibility payload only: storage must preserve it until the next
+        // format break, but transaction validation no longer reads it.
         vec![CapturedFrontierMember {
             object_id: ObjectId::from_uuid(uuid::Uuid::from_u128(93)),
             branch_name: crate::object::BranchName::new("dev-bbbbbbbbbbbb-main"),

--- a/crates/jazz-tools/src/storage/memory.rs
+++ b/crates/jazz-tools/src/storage/memory.rs
@@ -859,6 +859,9 @@ impl Storage for MemoryStorage {
         &self,
         target_branch_name: BranchName,
     ) -> Result<Vec<CapturedFrontierMember>, StorageError> {
+        // Compatibility helper for the legacy `captured_frontier` field on
+        // sealed submissions. This is no longer part of transaction conflict
+        // validation; remove it with the next storage-format break.
         let family_branches: BTreeSet<_> = self
             .row_histories
             .values()
@@ -2102,6 +2105,8 @@ mod tests {
 
     #[test]
     fn capture_family_visible_frontier_reads_synced_branches_without_branch_ords() {
+        // Compatibility coverage for the legacy captured frontier payload. The
+        // captured values are no longer consulted when validating transactions.
         use crate::row_histories::VisibleRowEntry;
 
         let mut storage = CountingCatalogueLoadsStorage::new();

--- a/crates/jazz-tools/src/storage/mod.rs
+++ b/crates/jazz-tools/src/storage/mod.rs
@@ -2457,6 +2457,9 @@ fn encode_sealed_batch_submission_with_branch_ords<H: Storage + ?Sized>(
         .captured_frontier
         .iter()
         .map(|member| {
+            // Legacy compatibility payload: persisted for old sealed batch rows
+            // but ignored by transaction validation. Drop this column in the
+            // next compat-breaking storage format refactor.
             let branch_ord = storage.resolve_or_alloc_branch_ord(member.branch_name)?;
             Ok(Value::Row {
                 id: None,
@@ -2599,6 +2602,8 @@ fn decode_sealed_batch_submission_with_branch_ords<H: Storage + ?Sized>(
         }
     };
 
+    // Decode the legacy compatibility payload so old sealed submissions keep
+    // round-tripping. It has no transaction validation semantics anymore.
     let captured_frontier = match captured_frontier {
         Value::Array(elements) => elements
             .iter()

--- a/crates/jazz-tools/src/storage/storage_trait.rs
+++ b/crates/jazz-tools/src/storage/storage_trait.rs
@@ -1137,6 +1137,9 @@ pub trait Storage {
         &self,
         target_branch_name: BranchName,
     ) -> Result<Vec<CapturedFrontierMember>, StorageError> {
+        // Compatibility helper for the legacy `captured_frontier` field on
+        // sealed submissions. This is no longer part of transaction conflict
+        // validation; remove it with the next storage-format break.
         let mut frontier = Vec::new();
         let visible_tables = scan_row_raw_table_headers_with_storage(self)?
             .into_iter()

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -74,14 +74,6 @@ impl SyncManager {
         Ok(submission.target_branch_name)
     }
 
-    fn frontier_conflict_fate(&self, batch_id: crate::row_histories::BatchId) -> BatchFate {
-        BatchFate::Rejected {
-            batch_id,
-            code: "transaction_conflict".to_string(),
-            reason: "family-visible frontier changed since batch was sealed".to_string(),
-        }
-    }
-
     fn validate_batch_rows_target_branch(
         &self,
         submission: &SealedBatchSubmission,
@@ -138,25 +130,6 @@ impl SyncManager {
         }
 
         Ok(mode)
-    }
-
-    fn validate_captured_frontier<H: Storage>(
-        &self,
-        storage: &H,
-        submission: &SealedBatchSubmission,
-    ) -> Result<(), BatchFate> {
-        let current_frontier = storage
-            .capture_family_visible_frontier(submission.target_branch_name)
-            .map_err(|error| BatchFate::Rejected {
-                batch_id: submission.batch_id,
-                code: "invalid_batch_submission".to_string(),
-                reason: format!("failed to capture family-visible frontier: {error}"),
-            })?;
-        if current_frontier != submission.captured_frontier {
-            return Err(self.frontier_conflict_fate(submission.batch_id));
-        }
-
-        Ok(())
     }
 
     fn parent_frontier_conflict_fate(&self, batch_id: crate::row_histories::BatchId) -> BatchFate {
@@ -1061,17 +1034,6 @@ impl SyncManager {
             }
         };
         if mode == SealedBatchMode::Transactional
-            && let Err(rejection) = self.validate_captured_frontier(storage, &submission)
-        {
-            self.reject_sealed_transactional_batch(
-                storage,
-                Some(client_id),
-                rejection,
-                &batch_rows,
-            );
-            return;
-        }
-        if mode == SealedBatchMode::Transactional
             && let Err(rejection) =
                 self.validate_transactional_parent_frontiers(storage, &submission, &declared_rows)
         {
@@ -1145,13 +1107,6 @@ impl SyncManager {
                     continue;
                 }
             };
-            if mode == SealedBatchMode::Transactional
-                && let Err(rejection) = self.validate_captured_frontier(storage, &submission)
-            {
-                self.reject_sealed_transactional_batch(storage, None, rejection, &batch_rows);
-                recovered_any = true;
-                continue;
-            }
             if mode == SealedBatchMode::Transactional
                 && let Err(rejection) = self.validate_transactional_parent_frontiers(
                     storage,

--- a/crates/jazz-tools/src/sync_manager/tests/transaction_sealing.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/transaction_sealing.rs
@@ -1182,7 +1182,7 @@ fn seal_batch_acceptance_stops_when_submission_persistence_fails() {
 }
 
 #[test]
-fn seal_batch_rejects_when_family_visible_frontier_changed() {
+fn seal_batch_accepts_when_unrelated_family_visible_frontier_changed() {
     let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
     let mut io = MemoryStorage::new();
     let client_id = ClientId::new();
@@ -1263,24 +1263,25 @@ fn seal_batch_rejects_when_family_visible_frontier_changed() {
 
     assert_eq!(
         io.load_authoritative_batch_fate(batch_id).unwrap(),
-        Some(BatchFate::Rejected {
+        Some(BatchFate::AcceptedTransaction {
             batch_id,
-            code: "transaction_conflict".to_string(),
-            reason: "family-visible frontier changed since batch was sealed".to_string(),
+            confirmed_tier: DurabilityTier::Local,
         })
     );
+    let visible = io
+        .load_visible_region_row("users", target_branch, staged_row_id)
+        .unwrap()
+        .expect("accepted sealed batch should publish its staged row");
     assert_eq!(
-        io.load_visible_region_row("users", target_branch, staged_row_id)
-            .unwrap(),
-        None,
-        "conflicted sealed batch should not publish its staged row"
+        visible.state,
+        crate::row_histories::RowState::VisibleTransactional
     );
 
     let history_rows = io.scan_history_row_batches("users", staged_row_id).unwrap();
     assert_eq!(history_rows.len(), 1);
     assert_eq!(
         history_rows[0].state,
-        crate::row_histories::RowState::Rejected
+        crate::row_histories::RowState::VisibleTransactional
     );
 }
 

--- a/crates/jazz-tools/tests/rocksdb_storage_integration.rs
+++ b/crates/jazz-tools/tests/rocksdb_storage_integration.rs
@@ -352,7 +352,7 @@ async fn rocksdb_server_storage() {
     restart_preserves_data().await;
     catalogue_entries_survive_restart().await;
     sealed_batch_acceptance_recovers_after_restart().await;
-    sealed_batch_frontier_conflict_rejects_after_restart().await;
+    sealed_batch_unrelated_frontier_change_accepts_after_restart().await;
 }
 
 /// Alice creates 200 todos. Bob connects fresh and must see all 200 with
@@ -1166,7 +1166,7 @@ async fn sealed_batch_acceptance_recovers_after_restart() {
     reopened.close().expect("close reopened rocksdb storage");
 }
 
-async fn sealed_batch_frontier_conflict_rejects_after_restart() {
+async fn sealed_batch_unrelated_frontier_change_accepts_after_restart() {
     let data_dir = TempDir::new().expect("temp data dir");
     let db_path = data_dir.path().join("jazz.rocksdb");
     let schema = todos_schema();
@@ -1202,24 +1202,22 @@ async fn sealed_batch_frontier_conflict_rejects_after_restart() {
     assert_eq!(
         reopened
             .load_authoritative_batch_fate(batch_id)
-            .expect("load rejected settlement"),
-        Some(BatchFate::Rejected {
+            .expect("load accepted settlement"),
+        Some(BatchFate::AcceptedTransaction {
             batch_id,
-            code: "transaction_conflict".to_string(),
-            reason: "family-visible frontier changed since batch was sealed".to_string(),
+            confirmed_tier: DurabilityTier::GlobalServer,
         })
     );
     assert_eq!(
         reopened
             .load_sealed_batch_submission(batch_id)
-            .expect("load sealed submission after rejection"),
+            .expect("load sealed submission after acceptance"),
         None
     );
-    assert_eq!(
-        reopened
-            .load_visible_region_row("todos", target_branch.as_str(), staged_row_id)
-            .expect("load staged row visibility"),
-        None
-    );
+    let visible = reopened
+        .load_visible_region_row("todos", target_branch.as_str(), staged_row_id)
+        .expect("load staged row visibility")
+        .expect("accepted row should remain visible");
+    assert_eq!(visible.state, RowState::VisibleTransactional);
     reopened.close().expect("close reopened rocksdb storage");
 }

--- a/crates/jazz-tools/tests/sqlite_storage_integration.rs
+++ b/crates/jazz-tools/tests/sqlite_storage_integration.rs
@@ -349,7 +349,7 @@ async fn sqlite_server_storage() {
     restart_preserves_data().await;
     catalogue_entries_survive_restart().await;
     sealed_batch_acceptance_recovers_after_restart().await;
-    sealed_batch_frontier_conflict_rejects_after_restart().await;
+    sealed_batch_unrelated_frontier_change_accepts_after_restart().await;
 }
 
 /// Alice creates 200 todos. Bob connects fresh and must see all 200 with
@@ -1162,7 +1162,7 @@ async fn sealed_batch_acceptance_recovers_after_restart() {
     reopened.close().expect("close reopened sqlite storage");
 }
 
-async fn sealed_batch_frontier_conflict_rejects_after_restart() {
+async fn sealed_batch_unrelated_frontier_change_accepts_after_restart() {
     let data_dir = TempDir::new().expect("temp data dir");
     let db_path = data_dir.path().join("jazz.sqlite");
     let schema = todos_schema();
@@ -1197,24 +1197,22 @@ async fn sealed_batch_frontier_conflict_rejects_after_restart() {
     assert_eq!(
         reopened
             .load_authoritative_batch_fate(batch_id)
-            .expect("load rejected settlement"),
-        Some(BatchFate::Rejected {
+            .expect("load accepted settlement"),
+        Some(BatchFate::AcceptedTransaction {
             batch_id,
-            code: "transaction_conflict".to_string(),
-            reason: "family-visible frontier changed since batch was sealed".to_string(),
+            confirmed_tier: DurabilityTier::GlobalServer,
         })
     );
     assert_eq!(
         reopened
             .load_sealed_batch_submission(batch_id)
-            .expect("load sealed submission after rejection"),
+            .expect("load sealed submission after acceptance"),
         None
     );
-    assert_eq!(
-        reopened
-            .load_visible_region_row("todos", target_branch.as_str(), staged_row_id)
-            .expect("load staged row visibility"),
-        None
-    );
+    let visible = reopened
+        .load_visible_region_row("todos", target_branch.as_str(), staged_row_id)
+        .expect("load staged row visibility")
+        .expect("accepted row should remain visible");
+    assert_eq!(visible.state, RowState::VisibleTransactional);
     reopened.close().expect("close reopened sqlite storage");
 }


### PR DESCRIPTION
## Summary

- remove the redundant captured family-frontier validation from sealed transactional batch acceptance
- keep transactional conflict detection scoped to each staged row parent frontier
- update memory, runtime restart, SQLite, and RocksDB coverage so unrelated frontier changes still accept

## Compatibility note

`captured_frontier` is now compatibility-only payload: it is preserved for existing storage/wire round-trips, but no longer participates in transaction validation. This PR adds comments at the definition, capture/storage sites, and compatibility tests to flag it for removal in a future compat-breaking storage format refactor.

## Validation

- `cargo fmt`
- `cargo test -p jazz-tools --features test sync_manager::tests::transaction_sealing -- --nocapture`
- `cargo test -p jazz-tools --features test rc_restart_accepts_stale_unrelated_family_frontier_sealed_batch_from_storage -- --nocapture`
- `cargo test -p jazz-tools --features test --test sqlite_storage_integration sqlite_server_storage -- --nocapture`
- `cargo test -p jazz-tools --features test,rocksdb --test rocksdb_storage_integration rocksdb_server_storage -- --nocapture`
- pre-commit hook: `clippy`, `rustfmt`
