### PR TITLE
docs(install): pin jazz-rn to @alpha in Expo quickstart

### DIFF
--- a/docs/content/docs/install/client.mdx
+++ b/docs/content/docs/install/client.mdx
@@ -74,7 +74,7 @@ Start with a fresh app. If you already have one, skip to [Install](#install).
   </Tab>
   <Tab value="Expo">
     ```bash title="Terminal"
-    pnpm add jazz-tools@alpha jazz-rn expo
+    pnpm add jazz-tools@alpha jazz-rn@alpha expo
     pnpm add -D @babel/plugin-transform-flow-strip-types
     ```
 


### PR DESCRIPTION
## Summary

The Expo install instructions tell users to run:

```bash
pnpm add jazz-tools@alpha jazz-rn expo
```

Note that `jazz-rn` is missing the `@alpha` tag. Without it, npm/pnpm resolves `jazz-rn` via the `latest` dist-tag.

For `jazz-rn`, `latest` is stuck at `2.0.0-alpha.6` (Feb 26) — the publish workflow at `.github/workflows/publish-jazz-tools-alpha.yml` only ever publishes with `--tag alpha` and never moves `latest` (compare with the `create-jazz` step which does `npm dist-tag add … latest`). So the first lockstepped publish (`alpha.6`, uniffi 0.29 era, `bindingsContractVersion = 29`) has held the `latest` tag ever since.

What users following the docs end up with:

1. `jazz-tools@2.0.0-alpha.49` installed (current alpha).
2. `jazz-rn@2.0.0-alpha.6` hoisted at the top of `node_modules` (the `latest`-tagged version).
3. `jazz-tools@2.0.0-alpha.49` declares `peerDependencies.jazz-rn = "2.0.0-alpha.49"`, so pnpm installs a second `jazz-rn@2.0.0-alpha.49` nested under `.pnpm/` to satisfy the peer.
4. CocoaPods autolinking finds two `JazzRn.podspec` files and picks the newer (`alpha.49`) one → native xcframework with uniffi contract **30**.
5. Metro resolves `import('jazz-rn')` to the top-level (`alpha.6`) → JS bundle with `bindingsContractVersion = 29`.
6. At startup: `uniffiEnsureInitialized` throws `ContractVersionMismatch: JS (29) from Rust (30)`.

This is what produced the production issue in the linked report (open since May 12). Pinning `jazz-rn@alpha` puts both packages on the same lockstepped alpha and removes the duplicate install entirely.

## Follow-ups (out of scope here)

- Move the npm `latest` dist-tag for `jazz-rn` (and ideally `jazz-tools`, `jazz-wasm`, `jazz-napi`) forward to the current alpha so users who type `pnpm add jazz-rn` without copying our docs verbatim aren't trapped on `alpha.6`. Two parts: (a) `npm dist-tag add jazz-rn@2.0.0-alpha.49 latest` once now, (b) add an equivalent step to the publish workflow so it stays in sync.
- Harden the publish workflow so the JS bindings shipped in the npm tarball can't drift from the native xcframework's uniffi contract (separate concern from this PR — different failure mode than the dist-tag bug, but related to how easily contract-version mismatches can ship).

## Test plan

- [ ] Spot-check rendered docs page after merge to confirm the Expo install snippet shows `jazz-rn@alpha`.
- [ ] In a scratch directory, run `pnpm add jazz-tools@alpha jazz-rn@alpha expo` and verify a single `jazz-rn` version is resolved (`pnpm why jazz-rn` shows one entry, both `package.json` versions match).