### PR TITLE
Add invite-links access-control recipe

### DIFF
--- a/docs/content/docs/recipes/access-control/invite-links.mdx
+++ b/docs/content/docs/recipes/access-control/invite-links.mdx
@@ -1,0 +1,113 @@
+---
+title: "Invite links"
+description: Let users share a URL that grants another user access to a private resource without knowing their identity in advance.
+reviewedAt: "9712a744f"
+---
+
+import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
+
+Invite links are a pattern that let a resource owner share a URL that grants access to anyone who has it without knowing the recipient's identity in advance. The URL carries the resource ID plus a secret that the owner stores on the resource row.
+
+When an invitee opens the URL, your application validates the code against the stored value and inserts a membership row for them. From that point on, access flows through the normal membership rule.
+
+The primary pattern in this recipe uses a small server route to validate the code and insert the membership row. For [local-first auth](/docs/auth/local-first-auth), or applications with no server component, [it is possible to do the same check](#secondary-pattern-jwt-claim-local-first-auth-only) inside a permission rule. This removes the need for a server route but requires the client to mint a JWT with a claim.
+
+## Schema
+
+Add a `joinCode` column to the resource table. The members table records which code each user used to join, so you can audit or revoke individual memberships later.
+
+<include cwd lang="ts" meta='title="schema.ts"'>
+  ../examples/docs/todo-server-ts/src/invite-snippets.ts#invite-schema
+</include>
+
+## Permissions
+
+A user can read a chat once they have a membership row. A chat creator can bootstrap their own membership, but no other user can write a `chatMembers` row, so the only way for an invitee to join is via the server route below. The server has a [backend identity](/docs/getting-started/server-setup#backend-identity-pattern) and inserts the row on their behalf after validating the join code.
+
+<include cwd lang="ts" meta='title="permissions.ts"'>
+  ../examples/docs/todo-server-ts/src/invite-snippets.ts#invite-permissions
+</include>
+
+See [Permissions](/docs/auth/permissions) for more on `exists.where`, `allOf`, and `anyOf`, and [Session identity and authorship](/docs/auth/sessions#session-identity-and-authorship) for how the backend stamps the user as the row's author while keeping backend permissions.
+
+## Generating a link
+
+The creator inserts the chat and their own membership client-side. Both writes are allowed by the permission rules above because the creator's `createdBy` matches their session. The join code goes on the row and into the URL.
+
+<include cwd lang="ts" meta='title="createInviteLink.ts"'>
+  ../examples/docs/todo-client-localfirst-react/src/invite-snippets.tsx#invite-create-link
+</include>
+
+<Callout type="warn">
+  The code lives in the URL fragment (after `#`) to keep it out of server access logs, CDN logs, and
+  `Referer` headers. Don't pass the code as a route parameter or query string&hairsp;—&hairsp;those
+  land in server logs.
+</Callout>
+
+## Accepting an invite
+
+The invitee opens the link while signed in. The client posts the chat ID and code to a server route. The server reads the chat with backend privileges, checks the code against the stored value, and inserts the membership row.
+
+### Server route
+
+The route reads and writes as the backend: the invitee has no read access to the chat until they're a member, and the `chatMembers.allowInsert` rule only admits the chat's creator, so they can't insert their own membership directly. Authorship is stamped to the user via `withAttribution`, so edit metadata still records who joined.
+
+The `context` referenced below is the backend Jazz context for your app&hairsp;—&hairsp;see [Backend context setup](/docs/getting-started/server-setup#backend-context-setup) for how to create one.
+
+<include cwd lang="ts" meta='title="api/invite/redeem.ts"'>
+  ../examples/docs/todo-server-ts/src/invite-snippets.ts#invite-redeem-route
+</include>
+
+<Accordions type="single">
+<Accordion title="Single-use, expiring, or role-scoped codes">
+
+For single-use codes, rotate the code in your server route after a successful redeem. For richer requirements (expiry, codes that grant specific roles, audit metadata), put codes in their own table alongside the data you need to colocate with each one&hairsp;—&hairsp;creation date, granted role, expiry timestamp, and so on.
+
+</Accordion>
+</Accordions>
+
+### Client handler
+
+Route `/#/invite/:chatId/:code` to a component that calls the server route and then redirects.
+
+<include cwd lang="tsx" meta='title="InviteHandler.tsx"'>
+  ../examples/docs/todo-client-localfirst-react/src/invite-snippets.tsx#invite-handler-primary
+</include>
+
+Once the route returns, the user's subscription picks the chat up via the membership rule, and access persists for as long as the membership row exists.
+
+## Revoking access
+
+Delete a member's row to revoke their access immediately. The server stops syncing the resource to them as soon as the row is gone.
+
+<include cwd lang="ts" meta='title="revokeMember.ts"'>
+  ../examples/docs/todo-client-localfirst-react/src/invite-snippets.tsx#invite-revoke
+</include>
+
+If you also want to invalidate the link itself for any future redeemers, clear or rotate the `joinCode` on the chat row.
+
+## Secondary pattern: JWT claim (local-first auth only)
+
+If you are using [local-first auth](/docs/auth/local-first-auth), the client mints its own JWTs and can attach arbitrary claims. You can use this to do the invite check entirely inside the permission rule, with no server route.
+
+This pattern only fits applications where the client controls JWT minting. In most stacks the server or an external auth provider issues JWTs, so the pattern above is the right choice.
+
+### Permissions
+
+Extend both the read rule and the `chatMembers.allowInsert` rule with a second branch that accepts the claim:
+
+<include cwd lang="ts" meta='title="permissions.ts"'>
+  ../examples/docs/todo-server-ts/src/invite-snippets.ts#invite-permissions-jwt-claim
+</include>
+
+The claim branch is temporary&hairsp;—&hairsp;once the invitee has inserted their `chatMembers` row, future reads match the membership branch and the claim is never consulted again.
+
+### Client handler
+
+Subscribe with the invite code as a JWT claim, wait for the chat row to arrive, then insert the membership row directly from the client.
+
+<include cwd lang="tsx" meta='title="InviteHandler.tsx"'>
+  ../examples/docs/todo-client-localfirst-react/src/invite-snippets.tsx#invite-handler-jwt-claim
+</include>
+
+`authMode: "external"` tells the Jazz client to authenticate using the supplied claims object rather than the user's normal session token. The `session["claims.join_code"]` reference in the permission rule reads the claim from that token.

--- a/docs/content/docs/recipes/access-control/invite-links.mdx
+++ b/docs/content/docs/recipes/access-control/invite-links.mdx
@@ -46,7 +46,7 @@ The creator inserts the chat and their own membership client-side. Both writes a
 
 ## Accepting an invite
 
-The invitee opens the link while signed in. The client posts the chat ID and code to a server route. The server reads the chat with backend privileges, checks the code against the stored value, and inserts the membership row.
+The invitee opens the link while signed in. The client posts the chat ID and code to a server route. The server reads the chat with backend privileges, checks the code against the stored value, and inserts the membership row. The route is idempotent&hairsp;—&hairsp;it skips the insert if the user already has a membership, so re-opening the link or retrying after a transient error won't create duplicate rows.
 
 ### Server route
 
@@ -62,6 +62,8 @@ The `context` referenced below is the backend Jazz context for your app&hairsp;�
 <Accordion title="Single-use, expiring, or role-scoped codes">
 
 For single-use codes, rotate the code in your server route after a successful redeem. For richer requirements (expiry, codes that grant specific roles, audit metadata), put codes in their own table alongside the data you need to colocate with each one&hairsp;—&hairsp;creation date, granted role, expiry timestamp, and so on.
+
+The 8-character code above (~32 bits) keeps the example URL readable and is fine paired with an unguessable chat ID. A code that isn't single-use or expiring is worth widening&hairsp;—&hairsp;use the full `crypto.randomUUID()` so it can't be brute-forced on its own.
 
 </Accordion>
 </Accordions>

--- a/docs/content/docs/recipes/access-control/invite-links.mdx
+++ b/docs/content/docs/recipes/access-control/invite-links.mdx
@@ -10,7 +10,7 @@ Invite links are a pattern that let a resource owner share a URL that grants acc
 
 When an invitee opens the URL, your application validates the code against the stored value and inserts a membership row for them. From that point on, access flows through the normal membership rule.
 
-The primary pattern in this recipe uses a small server route to validate the code and insert the membership row. For [local-first auth](/docs/auth/local-first-auth), or applications with no server component, [it is possible to do the same check](#secondary-pattern-jwt-claim-local-first-auth-only) inside a permission rule. This removes the need for a server route but requires the client to mint a JWT with a claim.
+The primary pattern in this recipe uses a small server route to validate the code and insert the membership row. For [local-first auth](/docs/auth/local-first-auth), or applications with no server component, [it is possible to do the same check](#secondary-pattern-session-claim-local-first-auth-only) inside a permission rule. This removes the need for a server route but requires the client to attach a claim to its session.
 
 ## Schema
 
@@ -32,7 +32,7 @@ See [Permissions](/docs/auth/permissions) for more on `exists.where`, `allOf`, a
 
 ## Generating a link
 
-The creator inserts the chat and their own membership client-side. Both writes are allowed by the permission rules above because the creator's `createdBy` matches their session. The join code goes on the row and into the URL.
+The creator inserts the chat and their own membership client-side. Both writes are allowed by the permission rules above&hairsp;—&hairsp;the chat row is open to insert, and the membership rule lets the creator add themselves because they match the row's `$createdBy`. The join code goes on the row and into the URL.
 
 <include cwd lang="ts" meta='title="createInviteLink.ts"'>
   ../examples/docs/todo-client-localfirst-react/src/invite-snippets.tsx#invite-create-link
@@ -86,28 +86,34 @@ Delete a member's row to revoke their access immediately. The server stops synci
 
 If you also want to invalidate the link itself for any future redeemers, clear or rotate the `joinCode` on the chat row.
 
-## Secondary pattern: JWT claim (local-first auth only)
+## Secondary pattern: session claim (local-first auth only)
 
-If you are using [local-first auth](/docs/auth/local-first-auth), the client mints its own JWTs and can attach arbitrary claims. You can use this to do the invite check entirely inside the permission rule, with no server route.
+If you are using [local-first auth](/docs/auth/local-first-auth), your client controls its own session and can attach arbitrary claims to it. You can use this to do the invite check entirely inside the permission rule, with no server route.
 
-This pattern only fits applications where the client controls JWT minting. In most stacks the server or an external auth provider issues JWTs, so the pattern above is the right choice.
+This pattern only fits applications where the client controls its session. In most stacks the server or an external auth provider issues a session token, so the pattern above is the right choice.
 
 ### Permissions
 
 Extend both the read rule and the `chatMembers.allowInsert` rule with a second branch that accepts the claim:
 
 <include cwd lang="ts" meta='title="permissions.ts"'>
-  ../examples/docs/todo-server-ts/src/invite-snippets.ts#invite-permissions-jwt-claim
+  ../examples/docs/todo-server-ts/src/invite-claim-snippets.ts#invite-permissions-jwt-claim
 </include>
 
 The claim branch is temporary&hairsp;—&hairsp;once the invitee has inserted their `chatMembers` row, future reads match the membership branch and the claim is never consulted again.
 
 ### Client handler
 
-Subscribe with the invite code as a JWT claim, wait for the chat row to arrive, then insert the membership row directly from the client.
+Subscribe with the invite code as a session claim, wait for the chat row to arrive, then insert the membership row directly from the client.
 
 <include cwd lang="tsx" meta='title="InviteHandler.tsx"'>
-  ../examples/docs/todo-client-localfirst-react/src/invite-snippets.tsx#invite-handler-jwt-claim
+  ../examples/docs/todo-client-localfirst-react/src/invite-claim-snippets.tsx#invite-handler-jwt-claim
 </include>
 
-`authMode: "external"` tells the Jazz client to authenticate using the supplied claims object rather than the user's normal session token. The `session["claims.join_code"]` reference in the permission rule reads the claim from that token.
+<Callout type="info">
+  Identity (`user_id`) comes from the server-verified authentication handshake and can't be
+  overridden by a subscription payload. Claims set during that handshake also take precedence over
+  payload claims of the same name, so a client can't escalate by passing
+  `claims: { role: "admin" }`&hairsp;—&hairsp;only claims your auth provider doesn't already issue
+  (like `join_code`) can be supplied this way.
+</Callout>

--- a/docs/content/docs/recipes/access-control/meta.json
+++ b/docs/content/docs/recipes/access-control/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Access Control",
-  "pages": ["user-owned-data", "shared-access", "group-permissions"]
+  "pages": ["user-owned-data", "shared-access", "invite-links", "group-permissions"]
 }

--- a/examples/docs/todo-client-localfirst-react/src/invite-claim-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/invite-claim-snippets.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useRef, useState } from "react";
+import { schema as s } from "jazz-tools";
+import { useDb, useSession } from "jazz-tools/react";
+
+const schema = {
+  chats: s.table({
+    joinCode: s.string().optional(),
+  }),
+  chatMembers: s.table({
+    chatId: s.ref("chats"),
+    user_id: s.string(),
+    joinCode: s.string().optional(),
+  }),
+};
+
+type AppSchema = s.Schema<typeof schema>;
+export const app: s.App<AppSchema> = s.defineApp(schema);
+
+function navigate(to: string) {
+  window.location.hash = to;
+}
+
+// #region invite-handler-jwt-claim
+export function InviteHandlerWithClaim({ chatId, code }: { chatId: string; code: string }) {
+  const db = useDb();
+  const session = useSession();
+  const userId = session?.user_id ?? null;
+  const [chatLoaded, setChatLoaded] = useState(false);
+  const handled = useRef(false);
+
+  useEffect(() => {
+    if (!userId) return;
+    return db.subscribeAll(
+      app.chats.where({ id: chatId }),
+      (delta) => {
+        if (delta.all.length > 0) setChatLoaded(true);
+      },
+      undefined,
+      { user_id: userId, claims: { join_code: code } },
+    );
+  }, [db, userId, chatId, code]);
+
+  useEffect(() => {
+    if (!chatLoaded || handled.current || !userId) return;
+    handled.current = true;
+
+    db.insert(app.chatMembers, { chatId, user_id: userId, joinCode: code })
+      .wait({ tier: "local" })
+      .then(() => navigate(`/#/chat/${chatId}`))
+      .catch((err) => {
+        console.error("failed to join", err);
+        handled.current = false;
+      });
+  }, [chatLoaded, db, userId, chatId, code]);
+
+  return <p>Joining…</p>;
+}
+// #endregion invite-handler-jwt-claim

--- a/examples/docs/todo-client-localfirst-react/src/invite-claim-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/invite-claim-snippets.tsx
@@ -46,7 +46,7 @@ export function InviteHandlerWithClaim({ chatId, code }: { chatId: string; code:
 
     db.insert(app.chatMembers, { chatId, user_id: userId, joinCode: code })
       .wait({ tier: "local" })
-      .then(() => navigate(`/#/chat/${chatId}`))
+      .then(() => navigate(`/chat/${chatId}`))
       .catch((err) => {
         console.error("failed to join", err);
         handled.current = false;

--- a/examples/docs/todo-client-localfirst-react/src/invite-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/invite-snippets.tsx
@@ -55,7 +55,7 @@ export function InviteHandler({ chatId, code }: { chatId: string; code: string }
     })
       .then((res) => {
         if (!res.ok) throw new Error(`redeem failed: ${res.status}`);
-        navigate(`/#/chat/${chatId}`);
+        navigate(`/chat/${chatId}`);
       })
       .catch((err) => {
         console.error("failed to join", err);

--- a/examples/docs/todo-client-localfirst-react/src/invite-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/invite-snippets.tsx
@@ -1,16 +1,14 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import { schema as s } from "jazz-tools";
-import { useDb, useSession } from "jazz-tools/react";
+import { useDb } from "jazz-tools/react";
 
 const schema = {
   chats: s.table({
-    isPublic: s.boolean(),
-    createdBy: s.string(),
     joinCode: s.string().optional(),
   }),
   chatMembers: s.table({
     chatId: s.ref("chats"),
-    userId: s.string(),
+    user_id: s.string(),
     joinCode: s.string().optional(),
   }),
 };
@@ -28,13 +26,9 @@ function navigate(to: string) {
 export function createInviteLink(db: ReturnType<typeof useDb>, userId: string): string {
   const joinCode = crypto.randomUUID().slice(0, 8);
 
-  const { value: chat } = db.insert(app.chats, {
-    isPublic: false,
-    createdBy: userId,
-    joinCode,
-  });
+  const { value: chat } = db.insert(app.chats, { joinCode });
 
-  db.insert(app.chatMembers, { chatId: chat.id, userId, joinCode });
+  db.insert(app.chatMembers, { chatId: chat.id, user_id: userId, joinCode });
 
   return `${window.location.origin}/#/invite/${chat.id}/${joinCode}`;
 }
@@ -72,40 +66,3 @@ export function InviteHandler({ chatId, code }: { chatId: string; code: string }
   return <p>Joining…</p>;
 }
 // #endregion invite-handler-primary
-
-// #region invite-handler-jwt-claim
-export function InviteHandlerWithClaim({ chatId, code }: { chatId: string; code: string }) {
-  const db = useDb();
-  const session = useSession();
-  const userId = session?.user_id ?? null;
-  const [chatLoaded, setChatLoaded] = useState(false);
-  const handled = useRef(false);
-
-  useEffect(() => {
-    if (!userId) return;
-    return db.subscribeAll(
-      app.chats.where({ id: chatId }),
-      (delta) => {
-        if (delta.all.length > 0) setChatLoaded(true);
-      },
-      undefined,
-      { user_id: userId, claims: { join_code: code }, authMode: "external" },
-    );
-  }, [db, userId, chatId, code]);
-
-  useEffect(() => {
-    if (!chatLoaded || handled.current || !userId) return;
-    handled.current = true;
-
-    db.insert(app.chatMembers, { chatId, userId, joinCode: code })
-      .wait({ tier: "local" })
-      .then(() => navigate(`/#/chat/${chatId}`))
-      .catch((err) => {
-        console.error("failed to join", err);
-        handled.current = false;
-      });
-  }, [chatLoaded, db, userId, chatId, code]);
-
-  return <p>Joining…</p>;
-}
-// #endregion invite-handler-jwt-claim

--- a/examples/docs/todo-client-localfirst-react/src/invite-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/invite-snippets.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useRef, useState } from "react";
+import { schema as s } from "jazz-tools";
+import { useDb, useSession } from "jazz-tools/react";
+
+const schema = {
+  chats: s.table({
+    isPublic: s.boolean(),
+    createdBy: s.string(),
+    joinCode: s.string().optional(),
+  }),
+  chatMembers: s.table({
+    chatId: s.ref("chats"),
+    userId: s.string(),
+    joinCode: s.string().optional(),
+  }),
+};
+
+type AppSchema = s.Schema<typeof schema>;
+export const app: s.App<AppSchema> = s.defineApp(schema);
+
+// Stand-in for the reader's router. With React Router, this would be
+// `const navigate = useNavigate()` inside the component.
+function navigate(to: string) {
+  window.location.hash = to;
+}
+
+// #region invite-create-link
+export function createInviteLink(db: ReturnType<typeof useDb>, userId: string): string {
+  const joinCode = crypto.randomUUID().slice(0, 8);
+
+  const { value: chat } = db.insert(app.chats, {
+    isPublic: false,
+    createdBy: userId,
+    joinCode,
+  });
+
+  db.insert(app.chatMembers, { chatId: chat.id, userId, joinCode });
+
+  return `${window.location.origin}/#/invite/${chat.id}/${joinCode}`;
+}
+// #endregion invite-create-link
+
+// #region invite-revoke
+export function revokeMember(db: ReturnType<typeof useDb>, memberId: string) {
+  db.delete(app.chatMembers, memberId);
+}
+// #endregion invite-revoke
+
+// #region invite-handler-primary
+export function InviteHandler({ chatId, code }: { chatId: string; code: string }) {
+  const handled = useRef(false);
+
+  useEffect(() => {
+    if (handled.current) return;
+    handled.current = true;
+
+    fetch("/api/invite/redeem", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ chatId, code }),
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error(`redeem failed: ${res.status}`);
+        navigate(`/#/chat/${chatId}`);
+      })
+      .catch((err) => {
+        console.error("failed to join", err);
+        handled.current = false;
+      });
+  }, [chatId, code]);
+
+  return <p>Joining…</p>;
+}
+// #endregion invite-handler-primary
+
+// #region invite-handler-jwt-claim
+export function InviteHandlerWithClaim({ chatId, code }: { chatId: string; code: string }) {
+  const db = useDb();
+  const session = useSession();
+  const userId = session?.user_id ?? null;
+  const [chatLoaded, setChatLoaded] = useState(false);
+  const handled = useRef(false);
+
+  useEffect(() => {
+    if (!userId) return;
+    return db.subscribeAll(
+      app.chats.where({ id: chatId }),
+      (delta) => {
+        if (delta.all.length > 0) setChatLoaded(true);
+      },
+      undefined,
+      { user_id: userId, claims: { join_code: code }, authMode: "external" },
+    );
+  }, [db, userId, chatId, code]);
+
+  useEffect(() => {
+    if (!chatLoaded || handled.current || !userId) return;
+    handled.current = true;
+
+    db.insert(app.chatMembers, { chatId, userId, joinCode: code })
+      .wait({ tier: "local" })
+      .then(() => navigate(`/#/chat/${chatId}`))
+      .catch((err) => {
+        console.error("failed to join", err);
+        handled.current = false;
+      });
+  }, [chatLoaded, db, userId, chatId, code]);
+
+  return <p>Joining…</p>;
+}
+// #endregion invite-handler-jwt-claim

--- a/examples/docs/todo-server-ts/src/invite-claim-snippets.ts
+++ b/examples/docs/todo-server-ts/src/invite-claim-snippets.ts
@@ -1,0 +1,54 @@
+import { schema as s } from "jazz-tools";
+
+const schema = {
+  chats: s.table({
+    joinCode: s.string().optional(),
+  }),
+  chatMembers: s.table({
+    chatId: s.ref("chats"),
+    user_id: s.string(),
+    joinCode: s.string().optional(),
+  }),
+};
+
+type AppSchema = s.Schema<typeof schema>;
+export const app: s.App<AppSchema> = s.defineApp(schema);
+
+// #region invite-permissions-jwt-claim
+s.definePermissions(app, ({ policy, allOf, anyOf, session }) => {
+  policy.chats.allowRead.where((chat) =>
+    anyOf([
+      policy.chatMembers.exists.where({ chatId: chat.id, user_id: session.user_id }),
+      { joinCode: session["claims.join_code"] },
+    ]),
+  );
+  policy.chats.allowInsert.always();
+
+  policy.chatMembers.allowRead.where((member) =>
+    anyOf([
+      { user_id: session.user_id },
+      policy.chats.exists.where({ id: member.chatId, $createdBy: session.user_id }),
+    ]),
+  );
+
+  policy.chatMembers.allowInsert.where((member) =>
+    allOf([
+      { user_id: session.user_id },
+      anyOf([
+        policy.chats.exists.where({ id: member.chatId, $createdBy: session.user_id }),
+        policy.chats.exists.where({
+          id: member.chatId,
+          joinCode: session["claims.join_code"],
+        }),
+      ]),
+    ]),
+  );
+
+  policy.chatMembers.allowDelete.where((member) =>
+    anyOf([
+      { user_id: session.user_id },
+      policy.chats.exists.where({ id: member.chatId, $createdBy: session.user_id }),
+    ]),
+  );
+});
+// #endregion invite-permissions-jwt-claim

--- a/examples/docs/todo-server-ts/src/invite-snippets.ts
+++ b/examples/docs/todo-server-ts/src/invite-snippets.ts
@@ -4,13 +4,11 @@ import type { JazzContext } from "jazz-tools/backend";
 // #region invite-schema
 const schema = {
   chats: s.table({
-    isPublic: s.boolean(),
-    createdBy: s.string(),
     joinCode: s.string().optional(),
   }),
   chatMembers: s.table({
     chatId: s.ref("chats"),
-    userId: s.string(),
+    user_id: s.string(),
     joinCode: s.string().optional(),
   }),
 };
@@ -18,22 +16,21 @@ const schema = {
 
 type AppSchema = s.Schema<typeof schema>;
 export const app: s.App<AppSchema> = s.defineApp(schema);
-export const claimsApp: s.App<AppSchema> = s.defineApp(schema);
 
 // #region invite-permissions
 s.definePermissions(app, ({ policy, allOf, anyOf, session }) => {
   policy.chats.allowRead.where((chat) =>
-    policy.chatMembers.exists.where({ chatId: chat.id, userId: session.user_id }),
+    policy.chatMembers.exists.where({ chatId: chat.id, user_id: session.user_id }),
   );
-  policy.chats.allowInsert.where({ createdBy: session.user_id });
+  policy.chats.allowInsert.always();
 
   // Users can read their own membership row; chat creators can read every
   // member of their chats. Explicit because the row carries the join code,
   // and we don't want it leaking through other members' rows.
   policy.chatMembers.allowRead.where((member) =>
     anyOf([
-      { userId: session.user_id },
-      policy.chats.exists.where({ id: member.chatId, createdBy: session.user_id }),
+      { user_id: session.user_id },
+      policy.chats.exists.where({ id: member.chatId, $createdBy: session.user_id }),
     ]),
   );
 
@@ -42,51 +39,20 @@ s.definePermissions(app, ({ policy, allOf, anyOf, session }) => {
   // privileges.
   policy.chatMembers.allowInsert.where((member) =>
     allOf([
-      { userId: session.user_id },
-      policy.chats.exists.where({ id: member.chatId, createdBy: session.user_id }),
+      { user_id: session.user_id },
+      policy.chats.exists.where({ id: member.chatId, $createdBy: session.user_id }),
     ]),
   );
 
   // Users can leave; chat creators can remove any member.
   policy.chatMembers.allowDelete.where((member) =>
     anyOf([
-      { userId: session.user_id },
-      policy.chats.exists.where({ id: member.chatId, createdBy: session.user_id }),
+      { user_id: session.user_id },
+      policy.chats.exists.where({ id: member.chatId, $createdBy: session.user_id }),
     ]),
   );
 });
 // #endregion invite-permissions
-
-// #region invite-permissions-jwt-claim
-s.definePermissions(claimsApp, ({ policy, allOf, anyOf, session }) => {
-  policy.chats.allowRead.where((chat) =>
-    anyOf([
-      policy.chatMembers.exists.where({ chatId: chat.id, userId: session.user_id }),
-      { joinCode: session["claims.join_code"] },
-    ]),
-  );
-
-  policy.chatMembers.allowRead.where((member) =>
-    anyOf([
-      { userId: session.user_id },
-      policy.chats.exists.where({ id: member.chatId, createdBy: session.user_id }),
-    ]),
-  );
-
-  policy.chatMembers.allowInsert.where((member) =>
-    allOf([
-      { userId: session.user_id },
-      anyOf([
-        policy.chats.exists.where({ id: member.chatId, createdBy: session.user_id }),
-        policy.chats.exists.where({
-          id: member.chatId,
-          joinCode: session["claims.join_code"],
-        }),
-      ]),
-    ]),
-  );
-});
-// #endregion invite-permissions-jwt-claim
 
 declare const context: JazzContext;
 
@@ -107,7 +73,7 @@ export async function POST(req: AuthenticatedRequest): Promise<Response> {
 
   await context
     .withAttribution(userId, app)
-    .insert(app.chatMembers, { chatId, userId, joinCode: code })
+    .insert(app.chatMembers, { chatId, user_id: userId, joinCode: code })
     .wait({ tier: "edge" });
 
   return Response.json({ ok: true });

--- a/examples/docs/todo-server-ts/src/invite-snippets.ts
+++ b/examples/docs/todo-server-ts/src/invite-snippets.ts
@@ -71,6 +71,13 @@ export async function POST(req: AuthenticatedRequest): Promise<Response> {
     return new Response("invalid invite", { status: 400 });
   }
 
+  // Idempotent: a repeated redeem (link reopened, retry after a transient error)
+  // must not insert a second membership row.
+  const existing = await context
+    .asBackend(app)
+    .one(app.chatMembers.where({ chatId, user_id: userId }));
+  if (existing) return Response.json({ ok: true });
+
   await context
     .withAttribution(userId, app)
     .insert(app.chatMembers, { chatId, user_id: userId, joinCode: code })

--- a/examples/docs/todo-server-ts/src/invite-snippets.ts
+++ b/examples/docs/todo-server-ts/src/invite-snippets.ts
@@ -1,0 +1,115 @@
+import { schema as s } from "jazz-tools";
+import type { JazzContext } from "jazz-tools/backend";
+
+// #region invite-schema
+const schema = {
+  chats: s.table({
+    isPublic: s.boolean(),
+    createdBy: s.string(),
+    joinCode: s.string().optional(),
+  }),
+  chatMembers: s.table({
+    chatId: s.ref("chats"),
+    userId: s.string(),
+    joinCode: s.string().optional(),
+  }),
+};
+// #endregion invite-schema
+
+type AppSchema = s.Schema<typeof schema>;
+export const app: s.App<AppSchema> = s.defineApp(schema);
+export const claimsApp: s.App<AppSchema> = s.defineApp(schema);
+
+// #region invite-permissions
+s.definePermissions(app, ({ policy, allOf, anyOf, session }) => {
+  policy.chats.allowRead.where((chat) =>
+    policy.chatMembers.exists.where({ chatId: chat.id, userId: session.user_id }),
+  );
+  policy.chats.allowInsert.where({ createdBy: session.user_id });
+
+  // Users can read their own membership row; chat creators can read every
+  // member of their chats. Explicit because the row carries the join code,
+  // and we don't want it leaking through other members' rows.
+  policy.chatMembers.allowRead.where((member) =>
+    anyOf([
+      { userId: session.user_id },
+      policy.chats.exists.where({ id: member.chatId, createdBy: session.user_id }),
+    ]),
+  );
+
+  // The creator can insert their own membership in their own chat. Everyone
+  // else must come through the server route, which writes with backend
+  // privileges.
+  policy.chatMembers.allowInsert.where((member) =>
+    allOf([
+      { userId: session.user_id },
+      policy.chats.exists.where({ id: member.chatId, createdBy: session.user_id }),
+    ]),
+  );
+
+  // Users can leave; chat creators can remove any member.
+  policy.chatMembers.allowDelete.where((member) =>
+    anyOf([
+      { userId: session.user_id },
+      policy.chats.exists.where({ id: member.chatId, createdBy: session.user_id }),
+    ]),
+  );
+});
+// #endregion invite-permissions
+
+// #region invite-permissions-jwt-claim
+s.definePermissions(claimsApp, ({ policy, allOf, anyOf, session }) => {
+  policy.chats.allowRead.where((chat) =>
+    anyOf([
+      policy.chatMembers.exists.where({ chatId: chat.id, userId: session.user_id }),
+      { joinCode: session["claims.join_code"] },
+    ]),
+  );
+
+  policy.chatMembers.allowRead.where((member) =>
+    anyOf([
+      { userId: session.user_id },
+      policy.chats.exists.where({ id: member.chatId, createdBy: session.user_id }),
+    ]),
+  );
+
+  policy.chatMembers.allowInsert.where((member) =>
+    allOf([
+      { userId: session.user_id },
+      anyOf([
+        policy.chats.exists.where({ id: member.chatId, createdBy: session.user_id }),
+        policy.chats.exists.where({
+          id: member.chatId,
+          joinCode: session["claims.join_code"],
+        }),
+      ]),
+    ]),
+  );
+});
+// #endregion invite-permissions-jwt-claim
+
+declare const context: JazzContext;
+
+// Supplied by the reader's auth middleware.
+type AuthenticatedRequest = Request & { session: { user_id: string | null } };
+
+// #region invite-redeem-route
+export async function POST(req: AuthenticatedRequest): Promise<Response> {
+  const userId = req.session.user_id;
+  if (!userId) return new Response("unauthenticated", { status: 401 });
+
+  const { chatId, code } = (await req.json()) as { chatId: string; code: string };
+
+  const chat = await context.asBackend(app).one(app.chats.where({ id: chatId }));
+  if (!chat || chat.joinCode !== code) {
+    return new Response("invalid invite", { status: 400 });
+  }
+
+  await context
+    .withAttribution(userId, app)
+    .insert(app.chatMembers, { chatId, userId, joinCode: code })
+    .wait({ tier: "edge" });
+
+  return Response.json({ ok: true });
+}
+// #endregion invite-redeem-route


### PR DESCRIPTION
## Summary
- Add an "Invite links" recipe to the access-control docs: a resource owner shares a URL carrying a resource ID plus a secret, and an invitee redeems it to get a membership row.
- Primary pattern uses a small server route to validate the code and insert the membership (with backend privileges); secondary pattern does the check inside a permission rule via a session claim, for local-first auth with no server.
- Redeem route is idempotent (no duplicate membership on re-redeem); post-redeem navigation targets corrected; note added that the short join code should be widened when it isn't single-use.
- Worked, type-checked snippets in `todo-server-ts` and `todo-client-localfirst-react`.

## Test plan
- [ ] `pnpm build` and confirm the recipe page renders with every `<include>` snippet resolving
- [ ] Open the recipe and sanity-check the primary vs secondary pattern guidance reads correctly