### PR TITLE
feat(docs): ConcurrentWritesDiagram — watch concurrent writes converge

### DIFF
--- a/docs/components/mdx/concurrent-writes-diagram.tsx
+++ b/docs/components/mdx/concurrent-writes-diagram.tsx
@@ -1,0 +1,346 @@
+"use client";
+
+import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+
+import { cn } from "@/lib/cn";
+import {
+  Graph,
+  type GraphEdge,
+  type GraphNode,
+  type GraphOverlayCtx,
+  type Hop,
+  hopEdgeId,
+  NodeShell,
+  NodeSubtitle,
+  NodeTitle,
+  playWaves,
+  useDiagramTraces,
+} from "./diagram";
+
+type NodeId = "v1" | "a2" | "b2" | "m3";
+
+type VersionVisual = {
+  id: NodeId;
+  rank: number;
+  order?: number;
+  author?: "a" | "b";
+  title: string;
+  done: boolean;
+};
+
+// Alice renames "Buy milk" → "oat milk"; Bob marks the same baseline complete.
+// Different fields, so both writes survive on m4. Every node carries the full
+// row state — the reader can read each version as a complete snapshot.
+const NODES: readonly VersionVisual[] = [
+  { id: "v1", rank: 0, title: "Buy milk", done: false },
+  { id: "a2", rank: 1, order: 0, author: "a", title: "Buy oat milk", done: false },
+  { id: "b2", rank: 1, order: 1, author: "b", title: "Buy milk", done: true },
+  { id: "m3", rank: 2, title: "Buy oat milk", done: true },
+] as const;
+
+const EDGES = [
+  { from: "v1", to: "a2" },
+  { from: "v1", to: "b2" },
+  { from: "a2", to: "m3" },
+  { from: "b2", to: "m3" },
+] as const;
+
+// Cumulative reveal: which nodes/edges are visible at each beat. Each beat is
+// triggered by a setTimeout chain; the last beat lights m3.
+type Beat = {
+  delayMs: number;
+  newNodes: NodeId[];
+  newEdges: string[];
+};
+
+const BEATS: readonly Beat[] = [
+  { delayMs: 0, newNodes: ["v1"], newEdges: [] },
+  { delayMs: 700, newNodes: ["a2"], newEdges: ["v1->a2"] },
+  { delayMs: 900, newNodes: ["b2"], newEdges: ["v1->b2"] },
+  { delayMs: 1800, newNodes: ["m3"], newEdges: ["a2->m3", "b2->m3"] },
+] as const;
+
+// Waves for the periodic pulse that re-flows root → leaves. Defined explicitly
+// rather than via bfsWaves: BFS visits each node once, which would drop the
+// second edge into the converging m3 (b2->m3). We want BOTH branches to pulse.
+const PULSE_WAVES: Hop[][] = [
+  [
+    { from: "v1", to: "a2" },
+    { from: "v1", to: "b2" },
+  ],
+  [
+    { from: "a2", to: "m3" },
+    { from: "b2", to: "m3" },
+  ],
+];
+
+const PULSE_TIMING = { min: 350, max: 700, perPx: 1.8 } as const;
+const BUILD_MS = BEATS[BEATS.length - 1].delayMs + 1200;
+const PULSE_INTERVAL_MS = 5000;
+
+function VersionCard({ v, revealed }: { v: VersionVisual; revealed: boolean }) {
+  const tint = v.author
+    ? {
+        borderColor: `var(--diagram-author-${v.author})`,
+        background: `rgb(var(--diagram-author-${v.author}-rgb) / 0.08)`,
+      }
+    : undefined;
+  return (
+    <NodeShell className={cn("cwd-card", !revealed && "cwd-card--hidden")} style={tint}>
+      <NodeTitle className="cwd-header">
+        <span className="cwd-version">{v.id}</span>
+        {v.author && (
+          <span className="cwd-by" style={{ color: `var(--diagram-author-${v.author})` }}>
+            {v.author === "a" ? "Alice" : "Bob"}
+          </span>
+        )}
+      </NodeTitle>
+      <div className="cwd-field">
+        <NodeSubtitle>title</NodeSubtitle>
+        <span className="cwd-field-value">&ldquo;{v.title}&rdquo;</span>
+      </div>
+      <div className="cwd-field">
+        <NodeSubtitle>done</NodeSubtitle>
+        <span className="cwd-field-value">{v.done ? "true" : "false"}</span>
+      </div>
+    </NodeShell>
+  );
+}
+
+export function ConcurrentWritesDiagram() {
+  const [revealedNodes, setRevealedNodes] = useState<Set<NodeId>>(new Set());
+  const [revealedEdges, setRevealedEdges] = useState<Set<string>>(new Set());
+  const [geomReady, setGeomReady] = useState(false);
+
+  const traces = useDiagramTraces();
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const overlayCtxRef = useRef<GraphOverlayCtx | null>(null);
+  const pathEls = useRef<Map<string, SVGPathElement | null>>(new Map());
+  const playedRef = useRef(false);
+  const pulseIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Kick the sequence the first time geometry settles. A ref (not state)
+  // tracks "played" so flipping it doesn't tear down pending beat timers via
+  // the effect's cleanup. inView/IntersectionObserver isn't worth the
+  // complexity — the diagram is small enough that running on mount is fine.
+  useEffect(() => {
+    if (!geomReady || playedRef.current) return;
+    playedRef.current = true;
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    for (const beat of BEATS) {
+      const t = setTimeout(() => {
+        if (beat.newNodes.length) {
+          setRevealedNodes((prev) => {
+            const next = new Set(prev);
+            for (const id of beat.newNodes) next.add(id);
+            return next;
+          });
+        }
+        // A node with no incoming edge this beat (the v1 origin) pulses on
+        // reveal; nodes reached by an edge pulse when the trace arrives.
+        const edgeTargets = new Set(beat.newEdges.map((id) => id.split("->")[1]));
+        for (const id of beat.newNodes) {
+          if (!edgeTargets.has(id)) traces.pulse(id);
+        }
+        for (const edgeId of beat.newEdges) {
+          const ctx = overlayCtxRef.current;
+          const r = ctx?.byId(edgeId);
+          const to = edgeId.split("->")[1];
+          if (r) {
+            // Pulse fades after drawing; the engine's grey structural edge
+            // (revealed below) is what persists as the resting line.
+            traces.play({
+              id: edgeId,
+              d: r.d,
+              length: r.length,
+              follow: true,
+              fadeAfter: true,
+              timing: PULSE_TIMING,
+              onArrive: () => traces.pulse(to),
+            });
+          }
+          setRevealedEdges((prev) => {
+            const next = new Set(prev);
+            next.add(edgeId);
+            return next;
+          });
+        }
+      }, beat.delayMs);
+      timers.push(t);
+    }
+    return () => timers.forEach((t) => clearTimeout(t));
+  }, [geomReady, traces]);
+
+  // After the build settles, re-flow a pulse root → leaves on an interval so
+  // the diagram stays alive without controls.
+  useEffect(() => {
+    if (!geomReady) return;
+    const start = setTimeout(() => {
+      const fire = () => {
+        const ctx = overlayCtxRef.current;
+        if (!ctx) return;
+        traces.pulse("v1");
+        playWaves(traces, PULSE_WAVES, {
+          byId: ctx.byId,
+          traceId: hopEdgeId,
+          gapMs: 450,
+          timing: PULSE_TIMING,
+          onArrive: (node) => traces.pulse(node),
+        });
+      };
+      fire();
+      const interval = setInterval(fire, PULSE_INTERVAL_MS);
+      pulseIntervalRef.current = interval;
+    }, BUILD_MS);
+    return () => {
+      clearTimeout(start);
+      if (pulseIntervalRef.current) clearInterval(pulseIntervalRef.current);
+    };
+  }, [geomReady, traces]);
+
+  const onGeometry = useCallback((ctx: GraphOverlayCtx) => {
+    overlayCtxRef.current = ctx;
+    setGeomReady(true);
+  }, []);
+
+  const overlay = useCallback(
+    (ctx: GraphOverlayCtx) => (
+      <g>
+        {EDGES.map((e) => {
+          const id = `${e.from}->${e.to}`;
+          const r = ctx.byId(id);
+          if (!r) return null;
+          return (
+            <g key={id}>
+              <path
+                ref={(el) => {
+                  traces.pathRef(id)(el);
+                  pathEls.current.set(id, el);
+                }}
+                className="diagram-path"
+                d={r.d}
+                fill="none"
+                stroke="var(--diagram-accent)"
+                strokeWidth={2}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <circle
+                ref={traces.dotRef(id)}
+                r={4}
+                cx={0}
+                cy={0}
+                fill="var(--diagram-accent)"
+                style={{ opacity: 0 }}
+                className="diagram-dot"
+              />
+            </g>
+          );
+        })}
+      </g>
+    ),
+    [traces],
+  );
+
+  const nodes: GraphNode[] = NODES.map((v) => {
+    const revealed = revealedNodes.has(v.id);
+    return {
+      id: v.id,
+      ...(v.order != null ? { rank: v.rank, order: v.order } : { rank: v.rank }),
+      content: <VersionCard v={v} revealed={revealed} />,
+    };
+  });
+
+  const edges: GraphEdge[] = EDGES.map(({ from, to }) => ({
+    from,
+    to,
+    variant: revealedEdges.has(`${from}->${to}`) ? "solid" : "hidden",
+  }));
+
+  return (
+    <div ref={rootRef} className="cwd-root">
+      <CwdStyles />
+      <Graph
+        eyebrow="Row version history"
+        description={
+          <>
+            Starting from a baseline row, Alice and Bob edit it concurrently — Alice renames it, Bob
+            marks it complete. They touch different fields, so both writes survive in the reconciled
+            visible state. Every peer ends up at the same <code>m3</code>.
+          </>
+        }
+        direction="LR"
+        converge
+        grid={{ gap: "1.5rem 3.5rem" }}
+        nodes={nodes}
+        edges={edges}
+        traces={traces}
+        overlay={overlay}
+        onGeometry={onGeometry}
+      />
+    </div>
+  );
+}
+
+const CWD_STYLES_CSS = `
+.cwd-root {
+  position: relative;
+}
+.cwd-card {
+  /* NodeShell provides border/radius/card-bg via tokens. Card flow + reveal
+     transition is the consumer's. A fixed width keeps all four columns equal
+     so the converge routing forks/merges symmetrically (the author label
+     would otherwise widen a2/b2). */
+  box-sizing: border-box;
+  width: 10rem;
+  padding: 0.45rem 0.65rem 0.55rem;
+  gap: 0.3rem;
+  display: flex;
+  flex-direction: column;
+  transition: opacity 0.45s ease;
+}
+.cwd-card--hidden {
+  opacity: 0;
+}
+/* The engine pulses by appending a .diagram-pulse span with an inline
+   border-radius:inherit; the (class-less) node wrapper has no radius, so it
+   inherits 0 and ripples as a square. Override the inline value (hence
+   !important) to roughly match the card's 8px corners plus the -2px inset. */
+.cwd-root .diagram-pulse {
+  border-radius: 10px !important;
+}
+.cwd-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.6rem;
+  border-bottom: 1px solid var(--diagram-border);
+  padding-bottom: 0.25rem;
+}
+.cwd-by {
+  font-size: 0.62rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.cwd-field {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  align-items: baseline;
+}
+.cwd-field-value {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, monospace;
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: var(--diagram-fg);
+}
+`;
+
+function CwdStyles(): ReactNode {
+  return (
+    <style href="cwd-styles" precedence="default">
+      {CWD_STYLES_CSS}
+    </style>
+  );
+}

--- a/docs/components/mdx/diagram/styles.tsx
+++ b/docs/components/mdx/diagram/styles.tsx
@@ -24,6 +24,15 @@ const DIAGRAM_STYLES_CSS = `
     --diagram-card-muted: #f4f4f5;
     --diagram-fg: #18181b;
     --diagram-muted: #71717a;
+    /* Two-author palette for diagrams that need to show "who wrote what".
+       Generic names (a / b) so the engine stays domain-free; the consumer
+       maps actors to slots. Author-a defaults to the brand accent (so a
+       single-author diagram looks identical to one with author-a styling),
+       author-b to a warm contrast. */
+    --diagram-author-a: var(--diagram-accent);
+    --diagram-author-a-rgb: var(--diagram-accent-rgb);
+    --diagram-author-b: #f59e0b;
+    --diagram-author-b-rgb: 245 158 11;
   }
 }
 .diagram-path {

--- a/docs/content/docs/concepts/local-first-data-model.mdx
+++ b/docs/content/docs/concepts/local-first-data-model.mdx
@@ -76,35 +76,9 @@ single current visible result.
 
 You can think of it like this:
 
-<Graph
-  eyebrow="Row version history"
-  description={
-    <>
-      One device edits linearly. Concurrent edits branch into separate row versions, then reconcile
-      into a single current visible result.
-    </>
-  }
-  direction="LR"
-  converge
-  grid={{ gap: "1.25rem 3rem" }}
-  nodes={[
-    { id: "v1", rank: 0, label: "v1" },
-    { id: "v2", rank: 1, label: "v2" },
-    { id: "a3", rank: 2, order: 0, label: "a3" },
-    { id: "b3", rank: 2, order: 1, label: "b3" },
-    { id: "m4", rank: 3, label: "m4" },
-  ]}
-  edges={[
-    { from: "v1", to: "v2" },
-    { from: "v2", to: "a3" },
-    { from: "v2", to: "b3" },
-    { from: "a3", to: "m4" },
-    { from: "b3", to: "m4" },
-  ]}
-/>
+<ConcurrentWritesDiagram />
 
-The important point is not the exact shape of the graph. The important point is that Jazz preserves
-enough row history to converge deterministically after peers reconnect.
+All updates are preserved by Jazz, so peers all converge deterministically after peers connect.
 
 ## Conflict resolution
 
@@ -117,10 +91,10 @@ row state. Even row versions that lose out in the current visible result remain 
 no local-first reconciliation information is discarded.
 
 <Callout type="warn" title="Beware of unexpected results">
-  Jazz can resolve structural conflicts for you, but it cannot fully understand the meaning of your
-  data. If Alice renames a to-do while Bob marks it complete, both changes may be preserved even if
-  the new title changes what the task means. You still need application-level judgment about what
-  kinds of concurrent editing should be allowed.
+  Notice above, Alice changed the title to "Buy oat milk" and Bob marked the task complete *before*
+  he saw Alice's change. He may have bought cow's milk. This merge is mechanically correct but
+  semantically wrong. Jazz can resolve *structural* conflicts, but it cannot understand the meaning
+  of your data.
 </Callout>
 
 ## How this differs from traditional apps

--- a/docs/mdx-components.tsx
+++ b/docs/mdx-components.tsx
@@ -9,6 +9,7 @@ import { LensDiagram } from "./components/mdx/lens-diagram";
 import { TierSyncDiagram } from "./components/mdx/tier-sync-diagram";
 import { Graph, Sequence } from "./components/mdx/diagram";
 import { WriteTierDiagram } from "./components/mdx/write-tier-diagram";
+import { ConcurrentWritesDiagram } from "./components/mdx/concurrent-writes-diagram";
 import { JazzLogo } from "./components/brand/jazz-logo";
 
 function SlideCodeCell({ children, title }: { children: ReactNode; title: string }) {
@@ -34,6 +35,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     Graph,
     Sequence,
     WriteTierDiagram,
+    ConcurrentWritesDiagram,
     JazzLogo,
     SlideCodeCell,
     ...components,

--- a/docs/mdx-components.tsx
+++ b/docs/mdx-components.tsx
@@ -10,6 +10,7 @@ import { LensDiagram } from "./components/mdx/lens-diagram";
 import { TierSyncDiagram } from "./components/mdx/tier-sync-diagram";
 import { Graph, Sequence } from "./components/mdx/diagram";
 import { WriteTierDiagram } from "./components/mdx/write-tier-diagram";
+import { ConcurrentWritesDiagram } from "./components/mdx/concurrent-writes-diagram";
 import { JazzLogo } from "./components/brand/jazz-logo";
 
 type CodeBlockPreProps = CodeBlockProps & {
@@ -61,6 +62,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     Graph,
     Sequence,
     WriteTierDiagram,
+    ConcurrentWritesDiagram,
     JazzLogo,
     SlideCodeCell,
     ...components,


### PR DESCRIPTION
## Summary

Adds an auto-playing diagram to the **Local-First Data Model** docs page (`concepts/local-first-data-model.mdx`), replacing the static `<Graph converge>` version-history example.

It tells the deterministic-merge story concretely: starting from a baseline row, Alice and Bob edit it concurrently — Alice renames it, Bob marks it complete. They touch *different fields*, so both writes survive, and every peer converges on the same `m3`. The Callout below now grounds the "beware of unexpected results" warning in this exact example (the merge is mechanically correct but semantically wrong — Bob may have bought cow's milk).

- Each node is a card showing the full row state (`title`, `done`) so the diff between branches reads at a glance; a2/b2 carry Alice/Bob author tints.
- Builds itself once on mount: v1 → a2/b2 → m3, with a trace + node pulse as each write lands.
- A blue pulse re-flows root → leaves every 5s to keep it alive, with no controls.
- Built on the existing diagram engine (`Graph` + `useDiagramTraces` + `playWaves` + node kit). Adds two engine colour tokens (`--diagram-author-a` / `--diagram-author-b`) with sensible defaults.

No changeset: `docs` is a private package.

## Test plan

- [ ] `pnpm --filter docs types:check` passes
- [ ] `pnpm --filter docs test` passes
- [ ] Visit `/docs/concepts/local-first-data-model`: diagram builds on load, columns/arrows are symmetric, node pulses are rounded, both branches (incl. b2→m3) pulse on the recurring flow, hover/tap shows nothing extraneous
- [ ] Check light + dark mode and a narrow (mobile) width