### PR TITLE
feat(otel): export logs via OTLP and drop JAZZ_OTEL gate

### DIFF
--- a/.changeset/otel-log-export.md
+++ b/.changeset/otel-log-export.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Export `tracing` events as OpenTelemetry logs over OTLP, correlated with traces via the active span's `trace_id`/`span_id`. The CLI now keys both trace and log export off `OTEL_EXPORTER_OTLP_ENDPOINT`; the `JAZZ_OTEL=1` opt-in and the stdout span-exporter fallback are removed. Stdout continues to emit human-readable text logs.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1806,6 +1806,7 @@ dependencies = [
  "lz4_flex",
  "mimalloc",
  "opentelemetry",
+ "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
  "opentelemetry-stdout",
  "opentelemetry_sdk",
@@ -2422,6 +2423,18 @@ dependencies = [
  "pin-project-lite",
  "thiserror 2.0.18",
  "tracing",
+]
+
+[[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef6a1ac5ca3accf562b8c306fa8483c85f4390f768185ab775f242f7fe8fdcc2"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/jazz-tools/Cargo.toml
+++ b/crates/jazz-tools/Cargo.toml
@@ -50,6 +50,7 @@ otel-core = [
   "dep:opentelemetry_sdk",
   "dep:opentelemetry-otlp",
   "dep:opentelemetry-stdout",
+  "dep:opentelemetry-appender-tracing",
   "dep:tracing-opentelemetry",
 ]
 otel = ["cli", "otel-core"]
@@ -111,13 +112,15 @@ reqwest = { version = "0.12", default-features = false, features = [
 thiserror = { version = "1", optional = true }
 
 opentelemetry = { version = "0.31", optional = true }
-opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"], optional = true }
+opentelemetry_sdk = { version = "0.31", features = ["rt-tokio", "logs"], optional = true }
 opentelemetry-otlp = { version = "0.31", features = [
   "grpc-tonic",
   "http-json",
   "reqwest-blocking-client",
+  "logs",
 ], optional = true }
 opentelemetry-stdout = { version = "0.31", features = ["trace"], optional = true }
+opentelemetry-appender-tracing = { version = "0.31", optional = true }
 tracing-opentelemetry = { version = "0.32", optional = true }
 lz4_flex = "0.13.1"
 

--- a/crates/jazz-tools/ENV.md
+++ b/crates/jazz-tools/ENV.md
@@ -9,4 +9,4 @@
 | `JAZZ_ALLOW_LOCAL_FIRST_AUTH` | `--allow-local-first-auth` | see NODE_ENV | Allow local-first bearer auth |
 | `JAZZ_JWKS_CACHE_TTL_SECS` | — | `300` | JWKS cache TTL in seconds |
 | `JAZZ_JWKS_MAX_STALE_SECS` | — | `300` | Max time (past TTL) to serve stale JWKS on fetch failure |
-| `JAZZ_OTEL` | — | `0` | Set to `1` to enable OpenTelemetry tracing |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | — | — | When set, enables OpenTelemetry trace + log export via OTLP/HTTP. Stdout keeps emitting human-readable logs. |

--- a/crates/jazz-tools/src/commands/server.rs
+++ b/crates/jazz-tools/src/commands/server.rs
@@ -25,11 +25,15 @@ pub async fn run(
     let app_id_string = app_id.to_string();
     let admin_secret = auth_config.admin_secret.clone();
 
-    info!("Starting Jazz server for app: {}", app_id);
-    if in_memory {
-        info!("Storage mode: in-memory");
-    } else {
-        info!("Data directory: {}", data_dir);
+    {
+        let startup_span = tracing::info_span!("server_startup", app_id = %app_id);
+        let _guard = startup_span.enter();
+        info!("Starting Jazz server for app: {}", app_id);
+        if in_memory {
+            info!("Storage mode: in-memory");
+        } else {
+            info!("Data directory: {}", data_dir);
+        }
     }
 
     let builder = ServerBuilder::new(app_id)

--- a/crates/jazz-tools/src/commands/server.rs
+++ b/crates/jazz-tools/src/commands/server.rs
@@ -25,15 +25,11 @@ pub async fn run(
     let app_id_string = app_id.to_string();
     let admin_secret = auth_config.admin_secret.clone();
 
-    {
-        let startup_span = tracing::info_span!("server_startup", app_id = %app_id);
-        let _guard = startup_span.enter();
-        info!("Starting Jazz server for app: {}", app_id);
-        if in_memory {
-            info!("Storage mode: in-memory");
-        } else {
-            info!("Data directory: {}", data_dir);
-        }
+    info!("Starting Jazz server for app: {}", app_id);
+    if in_memory {
+        info!("Storage mode: in-memory");
+    } else {
+        info!("Data directory: {}", data_dir);
     }
 
     let builder = ServerBuilder::new(app_id)

--- a/crates/jazz-tools/src/main.rs
+++ b/crates/jazz-tools/src/main.rs
@@ -527,23 +527,34 @@ mod tests {
 }
 
 #[cfg(feature = "otel")]
-static OTEL_PROVIDER: std::sync::OnceLock<opentelemetry_sdk::trace::SdkTracerProvider> =
+static OTEL_TRACER_PROVIDER: std::sync::OnceLock<opentelemetry_sdk::trace::SdkTracerProvider> =
+    std::sync::OnceLock::new();
+#[cfg(feature = "otel")]
+static OTEL_LOGGER_PROVIDER: std::sync::OnceLock<opentelemetry_sdk::logs::SdkLoggerProvider> =
     std::sync::OnceLock::new();
 
 fn init_tracing() {
     use tracing_subscriber::layer::SubscriberExt;
     use tracing_subscriber::util::SubscriberInitExt;
 
+    let fmt_layer = tracing_subscriber::fmt::layer();
+
     #[cfg(feature = "otel")]
     {
-        if std::env::var("JAZZ_OTEL").map_or(false, |v| v == "1") {
-            let provider = otel::init_tracer_provider();
-            let otel_layer = otel::layer(&provider);
-            let _ = OTEL_PROVIDER.set(provider);
+        if std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").is_ok() {
+            let tracer_provider = otel::init_tracer_provider();
+            let otel_trace_layer = otel::layer(&tracer_provider);
+            let _ = OTEL_TRACER_PROVIDER.set(tracer_provider);
+
+            let logger_provider = otel::init_logger_provider();
+            let otel_log_layer = otel::log_bridge::<tracing_subscriber::Registry>(&logger_provider);
+            let _ = OTEL_LOGGER_PROVIDER.set(logger_provider);
+
             tracing_subscriber::registry()
                 .with(make_env_filter())
-                .with(tracing_subscriber::fmt::layer())
-                .with(otel_layer)
+                .with(fmt_layer)
+                .with(otel_trace_layer)
+                .with(otel_log_layer)
                 .init();
             return;
         }
@@ -551,16 +562,21 @@ fn init_tracing() {
 
     tracing_subscriber::registry()
         .with(make_env_filter())
-        .with(tracing_subscriber::fmt::layer())
+        .with(fmt_layer)
         .init();
 }
 
 fn shutdown_tracing() {
     #[cfg(feature = "otel")]
     {
-        if let Some(provider) = OTEL_PROVIDER.get() {
+        if let Some(provider) = OTEL_TRACER_PROVIDER.get() {
             if let Err(e) = provider.shutdown() {
-                eprintln!("OTel shutdown error: {e}");
+                eprintln!("OTel tracer shutdown error: {e}");
+            }
+        }
+        if let Some(provider) = OTEL_LOGGER_PROVIDER.get() {
+            if let Err(e) = provider.shutdown() {
+                eprintln!("OTel logger shutdown error: {e}");
             }
         }
     }

--- a/crates/jazz-tools/src/otel.rs
+++ b/crates/jazz-tools/src/otel.rs
@@ -1,40 +1,33 @@
 //! OpenTelemetry tracer initialization.
 //!
-//! Activated by the `otel` feature + `JAZZ_OTEL=1` env var at runtime in the CLI,
-//! or by explicit dev-server telemetry configuration in NAPI.
-//! Standard OTel env vars (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`,
-//! `OTEL_TRACES_SAMPLER`, etc.) are respected automatically by the SDK.
+//! Activated by the `otel` feature + `OTEL_EXPORTER_OTLP_ENDPOINT` being set
+//! at runtime in the CLI, or by explicit dev-server telemetry configuration
+//! in NAPI. Standard OTel env vars (`OTEL_SERVICE_NAME`, `OTEL_TRACES_SAMPLER`,
+//! etc.) are respected automatically by the SDK.
 
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_otlp::{Protocol, WithExportConfig};
+use opentelemetry_sdk::logs::SdkLoggerProvider;
 use opentelemetry_sdk::trace::SdkTracerProvider;
 
 const DEFAULT_SERVICE_NAME: &str = "jazz-server";
 
-/// Build an OTel TracerProvider.
-///
-/// - If `OTEL_EXPORTER_OTLP_ENDPOINT` is set → OTLP/HTTP JSON exporter.
-/// - Otherwise → stdout exporter for local dev.
+/// Build an OTel TracerProvider exporting to the OTLP/HTTP endpoint
+/// configured via `OTEL_EXPORTER_OTLP_ENDPOINT`.
 pub fn init_tracer_provider() -> SdkTracerProvider {
-    let mut builder = tracer_provider_builder(
+    let builder = tracer_provider_builder(
         std::env::var("OTEL_SERVICE_NAME")
             .unwrap_or_else(|_| DEFAULT_SERVICE_NAME.into())
             .as_str(),
     );
 
-    if std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").is_ok() {
-        let exporter = opentelemetry_otlp::SpanExporter::builder()
-            .with_http()
-            .with_protocol(Protocol::HttpJson)
-            .build()
-            .expect("failed to build OTLP exporter");
-        builder = builder.with_batch_exporter(exporter);
-    } else {
-        let exporter = opentelemetry_stdout::SpanExporter::default();
-        builder = builder.with_simple_exporter(exporter);
-    }
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_http()
+        .with_protocol(Protocol::HttpJson)
+        .build()
+        .expect("failed to build OTLP exporter");
 
-    builder.build()
+    builder.with_batch_exporter(exporter).build()
 }
 
 /// Build an OTel TracerProvider for a specific service and optional OTLP/HTTP traces endpoint.
@@ -91,4 +84,44 @@ where
 {
     let tracer = provider.tracer("jazz-server");
     tracing_opentelemetry::layer().with_tracer(tracer)
+}
+
+/// Build an OTel LoggerProvider exporting to the OTLP/HTTP endpoint
+/// configured via `OTEL_EXPORTER_OTLP_ENDPOINT`.
+pub fn init_logger_provider() -> SdkLoggerProvider {
+    let exporter = opentelemetry_otlp::LogExporter::builder()
+        .with_http()
+        .with_protocol(Protocol::HttpJson)
+        .build()
+        .expect("failed to build OTLP log exporter");
+
+    SdkLoggerProvider::builder()
+        .with_resource(
+            opentelemetry_sdk::Resource::builder()
+                .with_service_name(
+                    std::env::var("OTEL_SERVICE_NAME")
+                        .unwrap_or_else(|_| DEFAULT_SERVICE_NAME.into()),
+                )
+                .with_attribute(opentelemetry::KeyValue::new(
+                    "service.version",
+                    env!("CARGO_PKG_VERSION"),
+                ))
+                .build(),
+        )
+        .with_batch_exporter(exporter)
+        .build()
+}
+
+/// Build the `opentelemetry-appender-tracing` bridge layer from a logger provider.
+/// Converts `tracing` events into OTel `LogRecord`s with trace context attached.
+pub fn log_bridge<S>(
+    provider: &SdkLoggerProvider,
+) -> opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge<
+    SdkLoggerProvider,
+    opentelemetry_sdk::logs::SdkLogger,
+>
+where
+    S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
+{
+    opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge::new(provider)
 }

--- a/dev/observability/README.md
+++ b/dev/observability/README.md
@@ -1,13 +1,13 @@
 # Local Observability Stack
 
-OTel Collector + Grafana/Tempo/Prometheus/Loki for viewing traces locally.
+OTel Collector + Grafana/Tempo/Prometheus/Loki for viewing traces and logs locally.
 
 ```
-jazz-server ──OTLP gRPC:4317──→ OTel Collector ──OTLP:4317──→ grafana/otel-lgtm
-                                                                 ├── Tempo (traces)
-                                                                 ├── Prometheus (metrics)
-                                                                 ├── Loki (logs)
-                                                                 └── Grafana UI (:3000)
+jazz-server ──OTLP HTTP:4318──→ OTel Collector ──OTLP:4317──→ grafana/otel-lgtm
+                                                                ├── Tempo (traces)
+                                                                ├── Prometheus (metrics)
+                                                                ├── Loki (logs)
+                                                                └── Grafana UI (:3000)
 ```
 
 ## Prerequisites
@@ -30,8 +30,7 @@ cargo build -p jazz-tools --features otel
 ## Run an instrumented server
 
 ```sh
-JAZZ_OTEL=1 \
-OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \
 RUST_LOG=jazz_tools=debug,groove=debug \
 cargo run -p jazz-tools --features otel -- server <APP_ID>
 ```
@@ -39,6 +38,10 @@ cargo run -p jazz-tools --features otel -- server <APP_ID>
 ## View traces
 
 Open http://localhost:3000 → Explore → Tempo → Search.
+
+## View logs
+
+Open http://localhost:3000 → Explore → Loki → Search.
 
 ## Stop
 
@@ -49,9 +52,8 @@ docker compose down -v   # stop + wipe data
 
 ## Environment variables
 
-| Variable                      | Purpose                                       | Default                 |
-| ----------------------------- | --------------------------------------------- | ----------------------- |
-| `JAZZ_OTEL`                   | Enable the OTel tracing layer (`1` to enable) | off                     |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | Collector endpoint                            | `http://localhost:4317` |
-| `OTEL_SERVICE_NAME`           | Service name in traces                        | `jazz-server`           |
-| `RUST_LOG`                    | Log filter for `tracing` subscriber           | —                       |
+| Variable                      | Purpose                             | Default                 |
+| ----------------------------- | ----------------------------------- | ----------------------- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Collector endpoint                  | `http://localhost:4318` |
+| `OTEL_SERVICE_NAME`           | Service name in traces              | `jazz-server`           |
+| `RUST_LOG`                    | Log filter for `tracing` subscriber | —                       |

--- a/dev/observability/docker-compose.yml
+++ b/dev/observability/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     volumes:
       - ./otel-collector.yml:/etc/otelcol-contrib/config.yaml:ro
     ports:
-      - "4317:4317" # OTLP gRPC — jazz server connects here
+      - "4317:4317" # OTLP gRPC
+      - "4318:4318" # OTLP HTTP — jazz server connects here
     depends_on:
       - lgtm
 

--- a/dev/observability/otel-collector.yml
+++ b/dev/observability/otel-collector.yml
@@ -3,6 +3,8 @@ receivers:
     protocols:
       grpc:
         endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
 
 exporters:
   otlp/lgtm:
@@ -13,5 +15,8 @@ exporters:
 service:
   pipelines:
     traces:
+      receivers: [otlp]
+      exporters: [otlp/lgtm]
+    logs:
       receivers: [otlp]
       exporters: [otlp/lgtm]


### PR DESCRIPTION
## Summary

- Wire `opentelemetry-appender-tracing` so every `tracing::` event becomes an OTel `LogRecord` with the active trace context attached. Logs + traces now correlate on `(trace_id, span_id)` in the backend.
- Single knob: `OTEL_EXPORTER_OTLP_ENDPOINT`. When set, the CLI initializes both the tracer and logger providers and ships traces + logs over OTLP/HTTP. When unset, neither is initialized.
- Stdout continues to emit human-readable text logs unchanged — durable, simple, no format flag.
- Drop the redundant `JAZZ_OTEL=1` opt-in and the stdout span-exporter fallback inside `init_tracer_provider`.
- Wrap the synchronous startup logs in a `server_startup` span so they carry trace_id/span_id when exported.

## Why

Before: traces and stdout text were two unrelated streams; correlating a log to its span required eyeball + timestamp guessing. Adding the OTel logs appender — the official `tracing` → OTel-logs bridge in the Rust SDK — gives us proper correlation without rolling a custom JSON formatter, and keeps stdout as the human-readable channel.

The `JAZZ_OTEL` gate predated the SDK honoring `OTEL_EXPORTER_OTLP_ENDPOINT`; with the stdout-fallback exporter removed, the endpoint env var is the natural on/off signal.

## Verification

Ran the CLI against a local OTLP collector with `OTEL_EXPORTER_OTLP_ENDPOINT` set:

- `otel_traces` shows the `server_startup` span.
- `otel_logs` shows the two in-span startup messages carrying the same `trace_id` + `span_id`.
- Logs emitted outside the span correctly have empty trace context.
- Builds clean with `--features otel` and with `--features cli` (no otel).

## Test plan

- [ ] CI passes
- [ ] `cargo build -p jazz-tools --features otel` succeeds
- [ ] Run `jazz-tools server` with `OTEL_EXPORTER_OTLP_ENDPOINT` unset → only stdout text logs, no OTLP traffic
- [ ] Run with the endpoint set → traces + logs land in collector, in-span logs carry trace context