### PR TITLE
Fix policy relation review followups

### DIFF
--- a/crates/jazz-tools/src/query_manager/graph_nodes/policy_eval.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/policy_eval.rs
@@ -399,12 +399,18 @@ impl<'a> PolicyContextEvaluator<'a> {
         let parent_table_name = *parent_table;
         let parent_row = match row_loader(parent_id, Some(parent_table_name)) {
             Some(content) => content,
-            None => return false,
+            None => {
+                visited.remove(&parent_id);
+                return false;
+            }
         };
 
         let parent_schema = match self.schema.get(&parent_table_name) {
             Some(schema) => schema,
-            None => return false,
+            None => {
+                visited.remove(&parent_id);
+                return false;
+            }
         };
 
         let parent_policy = match operation {
@@ -416,7 +422,10 @@ impl<'a> PolicyContextEvaluator<'a> {
 
         let parent_policy = match parent_policy {
             Some(p) => p,
-            None => return false,
+            None => {
+                visited.remove(&parent_id);
+                return false;
+            }
         };
 
         let parent_row = Row::new(
@@ -442,6 +451,7 @@ impl<'a> PolicyContextEvaluator<'a> {
         {
             cache.ref_access_insert(cache_key, result);
         }
+        visited.remove(&parent_id);
         result
     }
 

--- a/crates/jazz-tools/src/query_manager/policy_graph.rs
+++ b/crates/jazz-tools/src/query_manager/policy_graph.rs
@@ -260,22 +260,32 @@ impl PolicyGraph {
         current_table: Option<&TableName>,
         structural_scans: bool,
     ) -> Option<Self> {
-        let use_structural_rows = structural_scans
-            || current_table
-                .and_then(|table| {
-                    Self::exists_rel_output_table(rel, branch).map(|output| output == *table)
-                })
-                .unwrap_or(false);
-        let compile_schema: Schema = if use_structural_rows {
-            // Same-table relation closures and explicitly structural policy
-            // checks must inspect raw relation rows rather than re-running
-            // SELECT policies on the scanned tables.
+        let output_is_current_table = current_table
+            .and_then(|table| {
+                Self::exists_rel_output_table(rel, branch).map(|output| output == *table)
+            })
+            .unwrap_or(false);
+        let compile_schema: Schema = if structural_scans {
+            // Explicitly structural policy checks must inspect raw relation rows
+            // rather than re-running SELECT policies on scanned tables.
             schema
                 .iter()
                 .map(|(table_name, table_schema)| {
                     let mut structural = table_schema.clone();
                     structural.policies = crate::query_manager::types::TablePolicies::default();
                     (*table_name, structural)
+                })
+                .collect()
+        } else if output_is_current_table {
+            schema
+                .iter()
+                .map(|(table_name, table_schema)| {
+                    let mut table_schema = table_schema.clone();
+                    if Some(table_name) == current_table {
+                        table_schema.policies =
+                            table_schema.policies.clone().with_select(PolicyExpr::True);
+                    }
+                    (*table_name, table_schema)
                 })
                 .collect()
         } else {
@@ -290,7 +300,7 @@ impl PolicyGraph {
             session,
             &schema_context,
             RelationCompileFeatures::default(),
-            if use_structural_rows {
+            if structural_scans {
                 RowPolicyMode::PermissiveLocal
             } else {
                 row_policy_mode
@@ -557,7 +567,7 @@ mod tests {
     }
 
     #[test]
-    fn test_for_exists_rel_ignores_select_policies_on_relation_tables() {
+    fn test_for_exists_rel_compiles_same_table_structural_scan() {
         let schema = test_schema();
         let session = Session::new("user1");
         let current_table = TableName::new("documents");
@@ -583,14 +593,15 @@ mod tests {
         )
         .expect("exists-rel graph");
 
-        assert!(
-            !graph
+        assert_eq!(graph.table().as_str(), "documents");
+        assert!(matches!(
+            graph
                 .graph
                 .nodes
-                .iter()
-                .any(|ctx| matches!(ctx.node, GraphNode::PolicyFilter(_))),
-            "exists-rel evaluation should inspect raw relation rows without injecting select-policy filters"
-        );
+                .get(graph.exists_node.0 as usize)
+                .map(|c| &c.node),
+            Some(GraphNode::ExistsOutput(_))
+        ));
     }
 
     #[test]
@@ -799,14 +810,6 @@ mod tests {
                 .nodes
                 .iter()
                 .any(|ctx| matches!(ctx.node, GraphNode::Join(_)))
-        );
-        assert!(
-            !graph
-                .graph
-                .nodes
-                .iter()
-                .any(|ctx| matches!(ctx.node, GraphNode::PolicyFilter(_))),
-            "recursive exists-rel graphs should not inject select-policy filters for relation tables"
         );
     }
 }

--- a/crates/jazz-tools/src/query_manager/rebac_tests.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests.rs
@@ -31,7 +31,7 @@ use crate::query_manager::policy::Operation;
 use crate::query_manager::policy::PolicyExpr;
 use crate::query_manager::query::{Query, QueryBuilder};
 use crate::query_manager::relation_ir::{
-    ColumnRef, PredicateCmpOp, PredicateExpr, RelExpr, ValueRef,
+    ColumnRef, JoinCondition, JoinKind, PredicateCmpOp, PredicateExpr, RelExpr, ValueRef,
 };
 use crate::query_manager::session::{Session, WriteContext};
 use crate::query_manager::types::{

--- a/crates/jazz-tools/src/query_manager/rebac_tests/exists_rel_policies.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests/exists_rel_policies.rs
@@ -207,6 +207,150 @@ fn local_insert_with_exists_rel_policy_requires_explicit_select_on_scanned_table
 }
 
 #[test]
+fn local_update_with_same_table_exists_rel_keeps_select_policies_on_joined_tables() {
+    let mut schema = Schema::new();
+    let projects_descriptor = RowDescriptor::new(vec![
+        ColumnDescriptor::new("secret_id", ColumnType::Uuid).references("secrets"),
+        ColumnDescriptor::new("name", ColumnType::Text),
+    ]);
+    let projects_policies = TablePolicies::new().with_update(
+        Some(PolicyExpr::ExistsRel {
+            rel: RelExpr::Filter {
+                input: Box::new(RelExpr::Join {
+                    left: Box::new(RelExpr::TableScan {
+                        table: TableName::new("projects"),
+                    }),
+                    right: Box::new(RelExpr::TableScan {
+                        table: TableName::new("secrets"),
+                    }),
+                    on: vec![JoinCondition {
+                        left: ColumnRef::scoped("projects", "secret_id"),
+                        right: ColumnRef::scoped("__join_0", "id"),
+                    }],
+                    join_kind: JoinKind::Inner,
+                }),
+                predicate: PredicateExpr::True,
+            },
+        }),
+        PolicyExpr::True,
+    );
+    schema.insert(
+        TableName::new("projects"),
+        TableSchema::with_policies(projects_descriptor, projects_policies),
+    );
+    schema.insert(
+        TableName::new("secrets"),
+        TableSchema::new(RowDescriptor::new(vec![ColumnDescriptor::new(
+            "label",
+            ColumnType::Text,
+        )])),
+    );
+
+    let sync_manager = SyncManager::new();
+    let mut qm = create_query_manager(sync_manager, schema);
+    let mut storage = seeded_memory_storage(&qm.schema_context().current_schema);
+
+    let secret = qm
+        .insert(
+            &mut storage,
+            "secrets",
+            &[Value::Text("launch codes".into())],
+        )
+        .expect("seed protected secret");
+    let project = qm
+        .insert(
+            &mut storage,
+            "projects",
+            &[Value::Uuid(secret.row_id), Value::Text("roadmap".into())],
+        )
+        .expect("seed project");
+
+    let err = qm
+        .update_with_session(
+            &mut storage,
+            project.row_id,
+            &[Value::Uuid(secret.row_id), Value::Text("renamed".into())],
+            Some(&Session::new("alice")),
+        )
+        .expect_err("same-table EXISTS_REL should not bypass joined-table SELECT policies");
+    assert!(matches!(
+        err,
+        QueryError::PolicyDenied {
+            table,
+            operation: Operation::Update
+        } if table == TableName::new("projects")
+    ));
+}
+
+#[test]
+fn local_update_with_same_table_exists_rel_allows_visible_joined_tables() {
+    let mut schema = Schema::new();
+    let projects_descriptor = RowDescriptor::new(vec![
+        ColumnDescriptor::new("secret_id", ColumnType::Uuid).references("secrets"),
+        ColumnDescriptor::new("name", ColumnType::Text),
+    ]);
+    let projects_policies = TablePolicies::new().with_update(
+        Some(PolicyExpr::ExistsRel {
+            rel: RelExpr::Filter {
+                input: Box::new(RelExpr::Join {
+                    left: Box::new(RelExpr::TableScan {
+                        table: TableName::new("projects"),
+                    }),
+                    right: Box::new(RelExpr::TableScan {
+                        table: TableName::new("secrets"),
+                    }),
+                    on: vec![JoinCondition {
+                        left: ColumnRef::scoped("projects", "secret_id"),
+                        right: ColumnRef::scoped("__join_0", "id"),
+                    }],
+                    join_kind: JoinKind::Inner,
+                }),
+                predicate: PredicateExpr::True,
+            },
+        }),
+        PolicyExpr::True,
+    );
+    schema.insert(
+        TableName::new("projects"),
+        TableSchema::with_policies(projects_descriptor, projects_policies),
+    );
+    schema.insert(
+        TableName::new("secrets"),
+        TableSchema::with_policies(
+            RowDescriptor::new(vec![ColumnDescriptor::new("label", ColumnType::Text)]),
+            TablePolicies::new().with_select(PolicyExpr::True),
+        ),
+    );
+
+    let sync_manager = SyncManager::new();
+    let mut qm = create_query_manager(sync_manager, schema);
+    let mut storage = seeded_memory_storage(&qm.schema_context().current_schema);
+
+    let secret = qm
+        .insert(
+            &mut storage,
+            "secrets",
+            &[Value::Text("launch codes".into())],
+        )
+        .expect("seed visible secret");
+    let project = qm
+        .insert(
+            &mut storage,
+            "projects",
+            &[Value::Uuid(secret.row_id), Value::Text("roadmap".into())],
+        )
+        .expect("seed project");
+
+    qm.update_with_session(
+        &mut storage,
+        project.row_id,
+        &[Value::Uuid(secret.row_id), Value::Text("renamed".into())],
+        Some(&Session::new("alice")),
+    )
+    .expect("same-table EXISTS_REL should allow joins through visible tables");
+}
+
+#[test]
 fn local_insert_with_exists_rel_null_literal_predicate_matches_null_rows() {
     let mut schema = Schema::new();
     let admins_descriptor = RowDescriptor::new(vec![

--- a/crates/jazz-tools/src/query_manager/rebac_tests/inherited_policies.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests/inherited_policies.rs
@@ -575,6 +575,145 @@ fn local_update_with_inherits_referencing_allows_missing_source_policy_in_permis
 }
 
 #[test]
+fn local_query_allows_sibling_inherits_checks_through_same_parent_row() {
+    let mut schema = Schema::new();
+    let projects_descriptor =
+        RowDescriptor::new(vec![ColumnDescriptor::new("owner_id", ColumnType::Text)]);
+    let projects_policies = TablePolicies::new()
+        .with_select(PolicyExpr::eq_session("owner_id", vec!["user_id".into()]))
+        .with_update(
+            Some(PolicyExpr::eq_session("owner_id", vec!["user_id".into()])),
+            PolicyExpr::True,
+        );
+    schema.insert(
+        TableName::new("projects"),
+        TableSchema::with_policies(projects_descriptor, projects_policies),
+    );
+
+    let documents_descriptor = RowDescriptor::new(vec![
+        ColumnDescriptor::new("project_id", ColumnType::Uuid).references("projects"),
+        ColumnDescriptor::new("title", ColumnType::Text),
+    ]);
+    let documents_policies = TablePolicies::new().with_select(PolicyExpr::And(vec![
+        PolicyExpr::Inherits {
+            operation: Operation::Select,
+            via_column: "project_id".into(),
+            max_depth: None,
+        },
+        PolicyExpr::Inherits {
+            operation: Operation::Update,
+            via_column: "project_id".into(),
+            max_depth: None,
+        },
+    ]));
+    schema.insert(
+        TableName::new("documents"),
+        TableSchema::with_policies(documents_descriptor, documents_policies),
+    );
+
+    let sync_manager = SyncManager::new();
+    let mut qm = create_query_manager(sync_manager, schema);
+    let mut storage = seeded_memory_storage(&qm.schema_context().current_schema);
+
+    let project = qm
+        .insert(&mut storage, "projects", &[Value::Text("alice".into())])
+        .expect("seed alice project");
+    let document = qm
+        .insert(
+            &mut storage,
+            "documents",
+            &[
+                Value::Uuid(project.row_id),
+                Value::Text("Launch plan".into()),
+            ],
+        )
+        .expect("seed project document");
+
+    let rows = query_rows(
+        &mut qm,
+        &mut storage,
+        QueryBuilder::new("documents").select(&["title"]).build(),
+        Some(Session::new("alice")),
+    );
+
+    assert_eq!(
+        rows,
+        vec![(document.row_id, vec![Value::Text("Launch plan".into())])],
+        "sibling inherited checks through the same parent should each evaluate independently"
+    );
+}
+
+#[test]
+fn local_update_allows_sibling_inherits_checks_through_same_parent_row() {
+    let mut schema = Schema::new();
+    let projects_descriptor =
+        RowDescriptor::new(vec![ColumnDescriptor::new("owner_id", ColumnType::Text)]);
+    let projects_policies = TablePolicies::new()
+        .with_select(PolicyExpr::eq_session("owner_id", vec!["user_id".into()]))
+        .with_update(
+            Some(PolicyExpr::eq_session("owner_id", vec!["user_id".into()])),
+            PolicyExpr::True,
+        );
+    schema.insert(
+        TableName::new("projects"),
+        TableSchema::with_policies(projects_descriptor, projects_policies),
+    );
+
+    let documents_descriptor = RowDescriptor::new(vec![
+        ColumnDescriptor::new("project_id", ColumnType::Uuid).references("projects"),
+        ColumnDescriptor::new("title", ColumnType::Text),
+    ]);
+    let documents_policies = TablePolicies::new().with_update(
+        Some(PolicyExpr::And(vec![
+            PolicyExpr::Inherits {
+                operation: Operation::Select,
+                via_column: "project_id".into(),
+                max_depth: None,
+            },
+            PolicyExpr::Inherits {
+                operation: Operation::Update,
+                via_column: "project_id".into(),
+                max_depth: None,
+            },
+        ])),
+        PolicyExpr::True,
+    );
+    schema.insert(
+        TableName::new("documents"),
+        TableSchema::with_policies(documents_descriptor, documents_policies),
+    );
+
+    let sync_manager = SyncManager::new();
+    let mut qm = create_query_manager(sync_manager, schema);
+    let mut storage = seeded_memory_storage(&qm.schema_context().current_schema);
+
+    let project = qm
+        .insert(&mut storage, "projects", &[Value::Text("alice".into())])
+        .expect("seed alice project");
+    let document = qm
+        .insert(
+            &mut storage,
+            "documents",
+            &[
+                Value::Uuid(project.row_id),
+                Value::Text("Launch plan".into()),
+            ],
+        )
+        .expect("seed project document");
+
+    qm.update_with_session(
+        &mut storage,
+        document.row_id,
+        &[
+            Value::Uuid(project.row_id),
+            Value::Text("Updated launch plan".into()),
+        ],
+        Some(&Session::new("alice")),
+    )
+    .expect("sibling inherited checks through the same parent should each evaluate independently");
+}
+
+#[test]
 fn local_update_with_check_inherits_denies_when_parent_is_not_updateable() {
     let mut schema = Schema::new();
     let folders_descriptor = RowDescriptor::new(vec![


### PR DESCRIPTION
Follow-up to Guido's review comments on #913.

## What changed
- Keep same-table EXISTS_REL scans structural only for the current table, while preserving SELECT policy enforcement on other joined tables.
- Scope inherited-policy cycle tracking to the active traversal path so sibling inherited checks through the same parent row can both evaluate.
- Add ReBAC regression coverage for both cases.

## Tests
- cargo test -p jazz-tools query_manager::rebac_tests
- pre-commit hook: clippy + rustfmt