### PR TITLE
Reduce policy evaluation schema cloning

### DIFF
--- a/.changeset/policy-eval-borrow-schema-context.md
+++ b/.changeset/policy-eval-borrow-schema-context.md
@@ -1,0 +1,8 @@
+---
+"jazz-tools": patch
+"jazz-wasm": patch
+"jazz-napi": patch
+"jazz-rn": patch
+---
+
+Reduce policy evaluation schema cloning by borrowing authorization schema context and avoiding unnecessary schema copies while compiling policy relation graphs.

--- a/crates/jazz-tools/src/query_manager/graph_nodes/policy_eval.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/policy_eval.rs
@@ -25,7 +25,7 @@ pub(crate) struct PolicyContextEvaluator<'a> {
     branch: &'a str,
     row_policy_mode: RowPolicyMode,
     settlement_eval_cache: Option<&'a mut SettlementEvalCache>,
-    schema_context: Option<Arc<SchemaContext>>,
+    schema_context: Option<&'a SchemaContext>,
     structural_exists_rel_scans: bool,
     phase: &'a str,
 }
@@ -58,13 +58,13 @@ impl<'a> PolicyContextEvaluator<'a> {
     }
 
     pub(crate) fn with_schema_context(mut self, schema_context: Option<&'a SchemaContext>) -> Self {
-        self.schema_context = schema_context.cloned().map(Arc::new);
+        self.schema_context = schema_context;
         self
     }
 
     pub(crate) fn with_shared_schema_context(
         mut self,
-        schema_context: Option<Arc<SchemaContext>>,
+        schema_context: Option<&'a SchemaContext>,
     ) -> Self {
         self.schema_context = schema_context;
         self
@@ -529,7 +529,7 @@ impl<'a> PolicyContextEvaluator<'a> {
             self.branch,
             operation,
             self.row_policy_mode,
-            self.schema_context.as_deref(),
+            self.schema_context,
         ) {
             Some(g) => g,
             None => return false,
@@ -588,7 +588,7 @@ impl<'a> PolicyContextEvaluator<'a> {
             self.row_policy_mode,
             Some(&current_table),
             structural_scans,
-            self.schema_context.as_ref().map(Arc::clone),
+            self.schema_context.map(|context| Arc::new(context.clone())),
         ) {
             Some(g) => g,
             None => return false,

--- a/crates/jazz-tools/src/query_manager/graph_nodes/policy_filter.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/policy_filter.rs
@@ -394,7 +394,7 @@ impl PolicyFilterNode {
             &self.branch,
             self.row_policy_mode,
         )
-        .with_shared_schema_context(self.schema_context.as_ref().map(Arc::clone))
+        .with_shared_schema_context(self.schema_context.as_deref())
         .with_structural_exists_rel_scans(self.structural_exists_rel_scans);
         let mut visited_referencing = HashSet::new();
         evaluator.evaluate_row_access(

--- a/crates/jazz-tools/src/query_manager/policy_graph.rs
+++ b/crates/jazz-tools/src/query_manager/policy_graph.rs
@@ -299,20 +299,22 @@ impl PolicyGraph {
                     output_is_current || Self::relation_references_table(rel, table)
                 })
                 .unwrap_or(false);
-        let compile_schema: Schema = if use_structural_rows {
+        let structural_compile_schema;
+        let compile_schema: &Schema = if use_structural_rows {
             // Same-table relation closures and explicitly structural policy
             // checks must inspect raw relation rows rather than re-running
             // SELECT policies on the scanned tables.
-            schema
+            structural_compile_schema = schema
                 .iter()
                 .map(|(table_name, table_schema)| {
                     let mut structural = table_schema.clone();
                     structural.policies = crate::query_manager::types::TablePolicies::default();
                     (*table_name, structural)
                 })
-                .collect()
+                .collect();
+            &structural_compile_schema
         } else {
-            schema.clone()
+            schema
         };
         let branches = vec![branch.to_string()];
         let fallback_context;
@@ -320,7 +322,7 @@ impl PolicyGraph {
             Some(context) => context,
             None => {
                 fallback_context = Arc::new(SchemaContext::with_branch_name(
-                    compile_schema.clone(),
+                    (*compile_schema).clone(),
                     &BranchName::new(branch),
                 ));
                 fallback_context
@@ -328,7 +330,7 @@ impl PolicyGraph {
         };
         let mut graph = QueryGraph::compile_relation_ir_with_shared_schema_context_and_features(
             rel,
-            &compile_schema,
+            compile_schema,
             &branches,
             session,
             schema_context,


### PR DESCRIPTION
## Summary
- borrow authorization schema context inside policy evaluation instead of cloning it for every evaluator
- avoid cloning the full schema when compiling non-structural policy relation graphs
- add a changeset for the runtime packages

## Validation
- cargo check -p jazz-tools --features cli
- pnpm --filter @jazz/rust build:crates && pnpm --filter jazz-wasm build && pnpm --filter jazz-tools build:runtime
- pre-commit hook: clippy, oxfmt, rustfmt

## Perf
Against the BoreDM-shaped holder load as jon@boredmlogs.com, release server + rebuilt wasm:
- before: profiled loader run ~17.8s total
- after: profiled loader run 3.819s app time, 5.88s wall including profiler overhead
- after unprofiled sanity runs: ~3.55s, ~3.75s, ~3.79s for the slowest dropdown_entry wave

Profile output: /Users/anselm/jazz-private/profiles/load-profile-20260522T201759Z-shared-context