### PR TITLE
Use dynamic Jazz port for world-tour tests

### DIFF
--- a/examples/world-tour/tests/browser/global-setup.ts
+++ b/examples/world-tour/tests/browser/global-setup.ts
@@ -1,32 +1,25 @@
 import { join } from "node:path";
-import { TestingServer, pushSchemaCatalogue } from "jazz-tools/testing";
-import { ADMIN_SECRET, APP_ID, TEST_PORT } from "./test-constants.js";
+import { pushSchemaCatalogue, startLocalJazzServer } from "jazz-tools/testing";
+import type { TestProject } from "vitest/node";
+import { ADMIN_SECRET, APP_ID } from "./test-constants.js";
 
-let server: Promise<TestingServer> | null = null;
-
-export async function setup(): Promise<void> {
-  if (server) {
-    await server;
-    return;
-  }
-
-  server = TestingServer.start({
+export async function setup(project: TestProject): Promise<() => Promise<void>> {
+  const handle = await startLocalJazzServer({
     appId: APP_ID,
-    port: TEST_PORT,
     adminSecret: ADMIN_SECRET,
+    inMemory: true,
   });
-
-  const handle = await server;
 
   await pushSchemaCatalogue({
     serverUrl: handle.url,
     appId: handle.appId,
-    adminSecret: handle.adminSecret,
+    adminSecret: ADMIN_SECRET,
     schemaDir: join(import.meta.dirname, "../.."),
   });
-}
 
-export async function teardown(): Promise<void> {
-  const s = await server;
-  await s?.stop();
+  project.provide("worldTourJazzServerUrl", handle.url);
+
+  return async () => {
+    await handle.stop();
+  };
 }

--- a/examples/world-tour/tests/browser/jazz-vue.test.ts
+++ b/examples/world-tour/tests/browser/jazz-vue.test.ts
@@ -2,7 +2,7 @@
  * Browser tests for the world-tour Jazz + Vue integration.
  *
  * Mounts small Vue components inside a JazzProvider against a Jazz client
- * connected to the per-suite TestingServer (see global-setup.ts), then
+ * connected to the per-suite local Jazz server (see global-setup.ts), then
  * exercises the schema through the public composables (useDb, useAll,
  * useSession).
  *
@@ -15,7 +15,7 @@
  * Inserts use `scope.tag(...)` to stamp every row, so even though all tests
  * share one server, every assertion only sees its own test's data.
  */
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, inject, it } from "vitest";
 import { type App, createApp, defineComponent, h } from "vue";
 import {
   type JazzClient,
@@ -26,9 +26,9 @@ import {
   useSession,
 } from "jazz-tools/vue";
 import { app } from "../../schema.js";
-import { APP_ID, TEST_PORT } from "./test-constants.js";
+import { APP_ID } from "./test-constants.js";
 
-const SERVER_URL = `http://127.0.0.1:${TEST_PORT}`;
+const SERVER_URL = inject("worldTourJazzServerUrl");
 
 interface Scope {
   marker: string;

--- a/examples/world-tour/tests/browser/test-constants.ts
+++ b/examples/world-tour/tests/browser/test-constants.ts
@@ -1,3 +1,2 @@
-export const TEST_PORT = 19882;
 export const ADMIN_SECRET = "test-admin-secret-for-world-tour-browser-tests";
 export const APP_ID = "019d4abc-7700-4001-8000-000000000001";

--- a/examples/world-tour/tests/browser/vitest-provided-context.d.ts
+++ b/examples/world-tour/tests/browser/vitest-provided-context.d.ts
@@ -1,0 +1,7 @@
+import "vitest";
+
+declare module "vitest" {
+  export interface ProvidedContext {
+    worldTourJazzServerUrl: string;
+  }
+}


### PR DESCRIPTION
## Summary

- Start the `world-tour` browser test Jazz server through `startLocalJazzServer()` without a fixed port.
- Pass the dynamically allocated server URL from Vitest global setup into the browser test with `provide`/`inject`.
- Remove the hardcoded `TEST_PORT` constant from the `world-tour` browser test setup.

## Root Cause

The failed CI job hit `world-tour` with a permissions error while inserting into `bands`. The failing package was unrelated to the PR changes, and the same class of failure had already appeared on `main`.

Locally, the concrete flake vector was that `world-tour` and `todo-client-localfirst-vue` both used the same fixed Jazz server port. Under concurrent Turbo test execution, those suites can interfere through the shared port. Using the DevServer dynamic port allocation makes `world-tour` independent of any other suite's chosen port.

## Validation

- `pnpm --filter world-tour test`
- `pnpm test --filter=world-tour --filter=todo-client-localfirst-vue --concurrency=2`