### PR TITLE
Document authority HLC row stamps

### DIFF
--- a/docs/superpowers/specs/2026-05-25-authority-hlc-design.md
+++ b/docs/superpowers/specs/2026-05-25-authority-hlc-design.md
@@ -5,9 +5,10 @@
 Approved design for an additive row-history metadata change.
 
 This design keeps existing wall-clock provenance timestamps and adds a separate
-global-authority Hybrid Logical Clock stamp per row-batch member. The first
-implementation is greenfield: storage and sync formats may change without
-supporting old persisted rows or mixed-version peers.
+global-authority Hybrid Logical Clock stamp per batch, copied into each
+row-batch member for direct row scans. The first implementation is greenfield:
+storage and sync formats may change without supporting old persisted rows or
+mixed-version peers.
 
 ## Context
 
@@ -24,13 +25,15 @@ global snapshots.
 ## Goals
 
 - Persist the writer's wall-clock provenance separately from global sequencing.
-- Add a nullable, immutable `authority_hlc` to each concrete row-batch member.
-- Allow only the single global authority to assign `authority_hlc`.
+- Add a nullable, immutable `authority_hlc` copy to each concrete row-batch
+  member.
+- Allow only the single global authority to assign one `authority_hlc` per
+  logical batch.
 - Keep local-first writes visible without waiting for a global stamp.
 - Preserve current query visibility, LWW ordering, merge behavior, and public
   timestamp APIs.
 - Make future row scans for deterministic global snapshots simple by storing the
-  stamp directly on each row-batch member.
+  batch stamp directly on each row-batch member.
 
 ## Non-Goals
 
@@ -55,17 +58,18 @@ global snapshots.
 
 - It is nullable.
 - It is stamped only by the global authority.
-- It is scoped to one concrete `(row_id, branch_name, batch_id)` row-batch
-  member.
+- It is scoped to one logical `batch_id`.
+- Every row-batch member with that `batch_id` stores the same stamp.
 - It is intended for future deterministic global snapshots.
 
-### 2. Stamp Per Row-Batch Member
+### 2. Stamp Per Batch, Store Per Row-Batch Member
 
-Each row-batch member gets its own `authority_hlc`. A multi-row batch therefore
-receives one HLC value per touched row.
+Each logical batch gets one `authority_hlc`. A multi-row batch therefore
+receives one HLC value, and every touched row stores a copy of that same value.
 
-This is intentionally row-local. Future snapshot scans can read, filter, and
-order row history without joining through batch fate or another side table.
+This keeps the global sequence batch-scoped while making future row scans
+simple. Snapshot scans can read, filter, and order row history without joining
+through batch fate or another side table.
 
 ### 3. Leave Optimistic Rows Unstamped
 
@@ -152,16 +156,19 @@ is copied from the coarse metadata row already chosen for `batch_id`,
 
 ## Stamping Flow
 
-1. A client or edge creates a row-batch member with `authority_hlc = None`.
-2. The row syncs upstream through the existing row-batch payload path.
-3. The global authority accepts or durably records the row-batch member.
-4. The global authority stamps that member with the next `AuthorityHlc`.
-5. The stamped row is persisted in history and the visible-row copy is refreshed
-   if the row remains current.
-6. Normal row sync carries the stamped row back to edges and clients.
+1. A client or edge creates row-batch members with `authority_hlc = None`.
+2. The rows sync upstream through the existing row-batch payload path.
+3. The global authority accepts or durably records the logical batch.
+4. The global authority stamps the batch with the next `AuthorityHlc`.
+5. The same stamp is persisted into every known row-batch member for that
+   `batch_id`, and visible-row copies are refreshed for stamped rows that remain
+   current.
+6. If the authority later learns another member of an already-stamped batch, it
+   applies the existing batch stamp rather than allocating a new one.
+7. Normal row sync carries stamped rows back to edges and clients.
 
-The stamp is immutable once assigned. Restamping the same row-batch member with
-a different value is protocol corruption.
+The stamp is immutable once assigned to the batch. Restamping the same
+`batch_id` with a different value is protocol corruption.
 
 ## Sync Semantics
 
@@ -179,35 +186,38 @@ Sync replay rules:
 - Receiving a stamped row stores and relays the stamp.
 - Receiving the same row-batch member with the same stamp is idempotent.
 - Receiving the same row-batch member with a different stamp is an error.
+- Receiving two row-batch members for the same `batch_id` with different stamps
+  is an error.
 - Non-authority runtimes must not assign missing stamps while relaying.
 
 If the global authority receives a row from a non-authority peer with an
 already-populated `authority_hlc`, it should accept it only when it matches the
-authority's existing record for that row-batch member. If the authority has no
-record of assigning that stamp, or the stamp differs, reject the payload rather
-than silently overwrite it. This keeps legitimate replay idempotent while making
+authority's existing record for that batch. If the authority has no record of
+assigning that stamp, or the stamp differs, reject the payload rather than
+silently overwrite it. This keeps legitimate replay idempotent while making
 authority-boundary bugs and malicious clients visible.
 
 ## Storage API Shape
 
-The global authority needs a narrow patch path for stamping an existing
-row-batch member:
+The global authority needs a narrow patch path for stamping known row-batch
+members of an existing batch:
 
 ```text
-stamp_row_batch_authority_hlc(table, branch, row_id, batch_id, authority_hlc)
+stamp_batch_authority_hlc(batch_id, authority_hlc)
 ```
 
 The operation must:
 
-- load the exact row-batch member
-- fail if the row already has a different stamp
-- no-op if the row already has the same stamp
+- find known row-batch members with that `batch_id`
+- fail if any member already has a different stamp
+- no-op for members already carrying the same stamp
 - write only the stamp metadata, not app data or wall-clock provenance
-- rebuild the visible-row entry when the stamped row is the current visible row
+- rebuild visible-row entries when stamped rows are current visible rows
 - update any digest or sync freshness bookkeeping that includes the stamp
 
-This can be implemented as a storage-level patch or as an existing row mutation
-path with a stamp-only operation, but the public behavior should stay narrow.
+The implementation may also expose a member-level helper for replaying a single
+stamped row, but it must enforce the batch-scoped invariant: all local rows with
+the same `batch_id` have the same `authority_hlc`.
 
 ## Error Handling
 
@@ -215,8 +225,8 @@ Use explicit failures for protocol violations:
 
 - Non-authority payload includes an unrecognized or conflicting
   `authority_hlc`: reject at the authority.
-- Same row-batch member receives conflicting stamps: reject the incoming row and
-  emit diagnostics.
+- Same batch receives conflicting stamps: reject the incoming row and emit
+  diagnostics.
 - Authority clock logical counter overflows: return an authority clock error and
   retry after physical time advances.
 - Malformed encoded HLC: treat as row-format corruption and fail closed.
@@ -230,12 +240,15 @@ Prefer black-box integration coverage where possible:
 
 - Local write persists with no `authority_hlc`.
 - Edge or client syncs an unstamped write to the global authority.
-- Global authority stamps each row-batch member separately.
+- Global authority stamps a batch once and writes that stamp into each known
+  row-batch member.
 - Stamped rows sync back to clients and survive storage reload.
-- Multi-row batches receive per-member stamps.
+- Multi-row batches store the same stamp on every member.
+- A later-arriving member of an already-stamped batch receives the existing
+  batch stamp.
 - Current query ordering and `$updatedAt` behavior remain unchanged after rows
   are stamped.
-- A conflicting stamp for the same row-batch member is rejected.
+- A conflicting stamp for the same batch is rejected.
 - An unrecognized non-authority-supplied stamp is rejected by the global
   authority.
 
@@ -249,7 +262,8 @@ scan boundary:
 
 - include only rows with `authority_hlc <= snapshot_hlc`
 - ignore unstamped rows by default
-- order row-history entries by `authority_hlc` for deterministic replay
+- order row-history entries by `authority_hlc`, with a stable tie-breaker such
+  as `(batch_id, row_id)` when a total order is needed
 
 That future work can decide whether to add snapshot query APIs, historical
 indices, or global-tier-only read modes. This design only persists the metadata

--- a/docs/superpowers/specs/2026-05-25-authority-hlc-design.md
+++ b/docs/superpowers/specs/2026-05-25-authority-hlc-design.md
@@ -257,14 +257,17 @@ encoding, nullable storage, visible-row copy, and digest/replay equality.
 
 ## Future Work
 
-Future deterministic global snapshots can use `authority_hlc` as the global
-scan boundary:
+Future deterministic global snapshots can combine `authority_hlc` with dotted
+versions:
 
-- include only rows with `authority_hlc <= snapshot_hlc`
+- use `authority_hlc <= snapshot_hlc` as the simple global bookmark for
+  globally eligible batches
+- use dotted versions to represent the precise per-object or per-row causal
+  frontier inside that global cutoff
 - ignore unstamped rows by default
 - order row-history entries by `authority_hlc`, with a stable tie-breaker such
   as `(batch_id, row_id)` when a total order is needed
 
 That future work can decide whether to add snapshot query APIs, historical
 indices, or global-tier-only read modes. This design only persists the metadata
-needed to make that work straightforward.
+needed to provide the global bookmark for that model.

--- a/docs/superpowers/specs/2026-05-25-authority-hlc-design.md
+++ b/docs/superpowers/specs/2026-05-25-authority-hlc-design.md
@@ -1,0 +1,256 @@
+# Authority HLC Row Stamps Design
+
+## Status
+
+Approved design for an additive row-history metadata change.
+
+This design keeps existing wall-clock provenance timestamps and adds a separate
+global-authority Hybrid Logical Clock stamp per row-batch member. The first
+implementation is greenfield: storage and sync formats may change without
+supporting old persisted rows or mixed-version peers.
+
+## Context
+
+Jazz currently stores row provenance with `created_at` and `updated_at` `u64`
+timestamps. These values are client-provided wall-clock microseconds and are
+also exposed through public provenance surfaces such as `$createdAt` and
+`$updatedAt`.
+
+Those timestamps currently participate in row-history ordering and visible-row
+merge decisions. This design does not change that behavior in the first phase.
+Instead, it introduces a distinct authority stamp for future deterministic
+global snapshots.
+
+## Goals
+
+- Persist the writer's wall-clock provenance separately from global sequencing.
+- Add a nullable, immutable `authority_hlc` to each concrete row-batch member.
+- Allow only the single global authority to assign `authority_hlc`.
+- Keep local-first writes visible without waiting for a global stamp.
+- Preserve current query visibility, LWW ordering, merge behavior, and public
+  timestamp APIs.
+- Make future row scans for deterministic global snapshots simple by storing the
+  stamp directly on each row-batch member.
+
+## Non-Goals
+
+- Do not use `authority_hlc` for current conflict resolution.
+- Do not replace `$createdAt` or `$updatedAt` with HLC values.
+- Do not support mixed-version sync peers in the first implementation.
+- Do not store the stamp only in batch fate or batch-level metadata.
+- Do not assign provisional HLCs on clients or edges.
+
+## Core Decisions
+
+### 1. Keep Two Separate Time Concepts
+
+`created_at` and `updated_at` remain wall-clock provenance:
+
+- They are still client-provided epoch microseconds.
+- They continue to power `$createdAt` and `$updatedAt`.
+- The TypeScript public API continues to expose them as `Date` values.
+- Current read and merge behavior continues to use them where it already does.
+
+`authority_hlc` is global sequencing metadata:
+
+- It is nullable.
+- It is stamped only by the global authority.
+- It is scoped to one concrete `(row_id, branch_name, batch_id)` row-batch
+  member.
+- It is intended for future deterministic global snapshots.
+
+### 2. Stamp Per Row-Batch Member
+
+Each row-batch member gets its own `authority_hlc`. A multi-row batch therefore
+receives one HLC value per touched row.
+
+This is intentionally row-local. Future snapshot scans can read, filter, and
+order row history without joining through batch fate or another side table.
+
+### 3. Leave Optimistic Rows Unstamped
+
+Local and edge runtimes do not create provisional HLCs. A local write persists
+and syncs with `authority_hlc = None` until the global authority stamps it.
+
+Rows without `authority_hlc` may remain visible in today's local-first query
+model. Future deterministic global snapshots must ignore unstamped rows unless
+they explicitly choose to include local, non-global data.
+
+### 4. Current Visible Behavior Is Unchanged
+
+The first implementation must not consult `authority_hlc` for:
+
+- visible-row selection
+- LWW column merge choice
+- branch frontier resolution
+- durability-tier preview choice
+- `$createdAt` / `$updatedAt`
+- current subscription delivery
+
+This keeps the change additive and isolates global snapshot semantics for a
+future feature.
+
+## HLC Format
+
+Introduce a dedicated fixed-width `AuthorityHlc` value rather than packing the
+stamp into the existing `u64` timestamp type.
+
+Recommended binary layout:
+
+```text
+AuthorityHlc:
+  physical_micros: u64
+  logical_counter: u32
+  authority_epoch: u32
+```
+
+The encoded form is 16 bytes. If it is used in ordered keys or raw byte
+comparisons, encode each component in big-endian order so byte ordering matches
+`(physical_micros, logical_counter, authority_epoch)`. Since there is a single
+global authority, `authority_epoch` can start at zero. It is reserved to make
+future authority key rotation or epoching explicit without changing the row
+format again.
+
+The global authority clock advances as follows:
+
+- Read current wall-clock microseconds.
+- If wall-clock time is greater than the last stamped physical component, stamp
+  `(now_micros, 0, authority_epoch)`.
+- Otherwise stamp `(last_physical_micros, last_logical_counter + 1,
+authority_epoch)`.
+- If the logical counter overflows within one physical microsecond, wait until
+  wall-clock time advances or return an explicit authority clock error.
+
+Because only the global authority stamps rows, non-authority runtimes never
+merge remote HLCs into their local clocks.
+
+## Data Model
+
+Add nullable `authority_hlc` fields to the row-history runtime shapes:
+
+- `StoredRowBatch`
+- `QueryRowBatch`
+- visible-row metadata carried through `VisibleRowEntry.current_row`
+
+Add a reserved nullable system column to flat row storage:
+
+- history rows: `_jazz_authority_hlc`
+- visible rows: `_jazz_authority_hlc`
+
+The visible-row copy is metadata for the current materialized row only. It does
+not affect how the visible row is chosen. For synthetic merged visible rows, it
+is copied from the coarse metadata row already chosen for `batch_id`,
+`updated_at`, and `updated_by`; it is not per-column provenance.
+
+`authority_hlc` should also participate in row identity freshness where needed:
+
+- Sync replay equality must compare it.
+- Row digests should include it if the digest is used to detect exact row-batch
+  content equality.
+- Storage conformance helpers should preserve it when rows are encoded,
+  decoded, replayed, patched, or materialized.
+
+## Stamping Flow
+
+1. A client or edge creates a row-batch member with `authority_hlc = None`.
+2. The row syncs upstream through the existing row-batch payload path.
+3. The global authority accepts or durably records the row-batch member.
+4. The global authority stamps that member with the next `AuthorityHlc`.
+5. The stamped row is persisted in history and the visible-row copy is refreshed
+   if the row remains current.
+6. Normal row sync carries the stamped row back to edges and clients.
+
+The stamp is immutable once assigned. Restamping the same row-batch member with
+a different value is protocol corruption.
+
+## Sync Semantics
+
+`StoredRowBatch` already travels through:
+
+- `RowBatchCreated`
+- `RowBatchNeeded`
+
+Adding `authority_hlc` to `StoredRowBatch` is enough for basic row sync. Batch
+fate remains batch-scoped and does not own HLC values.
+
+Sync replay rules:
+
+- Receiving an unstamped row stores and relays it normally.
+- Receiving a stamped row stores and relays the stamp.
+- Receiving the same row-batch member with the same stamp is idempotent.
+- Receiving the same row-batch member with a different stamp is an error.
+- Non-authority runtimes must not assign missing stamps while relaying.
+
+If the global authority receives a row from a non-authority peer with an
+already-populated `authority_hlc`, it should accept it only when it matches the
+authority's existing record for that row-batch member. If the authority has no
+record of assigning that stamp, or the stamp differs, reject the payload rather
+than silently overwrite it. This keeps legitimate replay idempotent while making
+authority-boundary bugs and malicious clients visible.
+
+## Storage API Shape
+
+The global authority needs a narrow patch path for stamping an existing
+row-batch member:
+
+```text
+stamp_row_batch_authority_hlc(table, branch, row_id, batch_id, authority_hlc)
+```
+
+The operation must:
+
+- load the exact row-batch member
+- fail if the row already has a different stamp
+- no-op if the row already has the same stamp
+- write only the stamp metadata, not app data or wall-clock provenance
+- rebuild the visible-row entry when the stamped row is the current visible row
+- update any digest or sync freshness bookkeeping that includes the stamp
+
+This can be implemented as a storage-level patch or as an existing row mutation
+path with a stamp-only operation, but the public behavior should stay narrow.
+
+## Error Handling
+
+Use explicit failures for protocol violations:
+
+- Non-authority payload includes an unrecognized or conflicting
+  `authority_hlc`: reject at the authority.
+- Same row-batch member receives conflicting stamps: reject the incoming row and
+  emit diagnostics.
+- Authority clock logical counter overflows: return an authority clock error and
+  retry after physical time advances.
+- Malformed encoded HLC: treat as row-format corruption and fail closed.
+
+Missing `authority_hlc` is not an error. It is the normal state for local,
+edge-only, unstamped, and not-yet-globally-observed writes.
+
+## Testing
+
+Prefer black-box integration coverage where possible:
+
+- Local write persists with no `authority_hlc`.
+- Edge or client syncs an unstamped write to the global authority.
+- Global authority stamps each row-batch member separately.
+- Stamped rows sync back to clients and survive storage reload.
+- Multi-row batches receive per-member stamps.
+- Current query ordering and `$updatedAt` behavior remain unchanged after rows
+  are stamped.
+- A conflicting stamp for the same row-batch member is rejected.
+- An unrecognized non-authority-supplied stamp is rejected by the global
+  authority.
+
+Focused codec/storage conformance tests should cover the fixed-width HLC
+encoding, nullable storage, visible-row copy, and digest/replay equality.
+
+## Future Work
+
+Future deterministic global snapshots can use `authority_hlc` as the global
+scan boundary:
+
+- include only rows with `authority_hlc <= snapshot_hlc`
+- ignore unstamped rows by default
+- order row-history entries by `authority_hlc` for deterministic replay
+
+That future work can decide whether to add snapshot query APIs, historical
+indices, or global-tier-only read modes. This design only persists the metadata
+needed to make that work straightforward.

--- a/docs/superpowers/specs/2026-05-25-authority-hlc-design.md
+++ b/docs/superpowers/specs/2026-05-25-authority-hlc-design.md
@@ -103,27 +103,40 @@ Recommended binary layout:
 
 ```text
 AuthorityHlc:
-  physical_micros: u64
+  physical_millis: u64
   logical_counter: u32
   authority_epoch: u32
 ```
 
 The encoded form is 16 bytes. If it is used in ordered keys or raw byte
 comparisons, encode each component in big-endian order so byte ordering matches
-`(physical_micros, logical_counter, authority_epoch)`. Since there is a single
+`(physical_millis, logical_counter, authority_epoch)`. Since there is a single
 global authority, `authority_epoch` can start at zero. It is reserved to make
 future authority key rotation or epoching explicit without changing the row
 format again.
 
+Use millisecond physical precision for the authority HLC. The HLC is a snapshot
+bookmark, not a public event timestamp. Millisecond precision is enough for a
+human-scale global cutoff, and the logical counter orders all batches stamped
+inside the same millisecond.
+
 The global authority clock advances as follows:
 
-- Read current wall-clock microseconds.
+- Read current wall-clock milliseconds.
 - If wall-clock time is greater than the last stamped physical component, stamp
-  `(now_micros, 0, authority_epoch)`.
-- Otherwise stamp `(last_physical_micros, last_logical_counter + 1,
+  `(now_millis, 0, authority_epoch)`.
+- Otherwise stamp `(last_physical_millis, last_logical_counter + 1,
 authority_epoch)`.
-- If the logical counter overflows within one physical microsecond, wait until
+- If the logical counter overflows within one physical millisecond, wait until
   wall-clock time advances or return an explicit authority clock error.
+
+On restart, the authority must load the last recorded `authority_hlc` before
+stamping new batches. If local wall time is behind or equal to the last recorded
+physical component, keep stamping at the recorded physical millisecond and
+increment the logical counter until wall time catches up and exceeds it. Once
+local wall time advances past the recorded physical component, reset the logical
+counter to zero at the new physical millisecond. This preserves monotonic
+authority stamps across restarts without rewriting client-provided timestamps.
 
 Because only the global authority stamps rows, non-authority runtimes never
 merge remote HLCs into their local clocks.

--- a/docs/superpowers/specs/2026-05-25-authority-hlc-proposal.md
+++ b/docs/superpowers/specs/2026-05-25-authority-hlc-proposal.md
@@ -51,6 +51,28 @@ authority_hlc:
    in the durable global sequence?"
 ```
 
+## Why This Is Additive
+
+This is not a replacement for wall-clock timestamps. It adds a second timeline
+because we need two different tools:
+
+```text
+client timestamp:
+  normal conflict resolution
+  existing LWW behavior
+  human-facing provenance
+
+authority_hlc:
+  global snapshot bookmark
+  deterministic global sequence
+  future "show me the database as of this global point" reads
+```
+
+Keeping conflict resolution on client time avoids mixing server receipt time
+into today's merge behavior. The authority HLC can stay simple: it is a durable
+bookmark for globally observed batches, not a new rule for deciding which local
+edit wins.
+
 ## What A Row Looks Like
 
 Before:

--- a/docs/superpowers/specs/2026-05-25-authority-hlc-proposal.md
+++ b/docs/superpowers/specs/2026-05-25-authority-hlc-proposal.md
@@ -1,0 +1,174 @@
+# Proposal: Authority HLC Row Stamps
+
+Add one nullable global stamp to each row-batch member, while keeping the
+existing client timestamp exactly what it is today: human-facing provenance.
+
+The point is not to change conflict resolution now. The point is to make future
+deterministic global snapshots possible.
+
+## The Problem
+
+Today, row batches carry wall-clock timestamps from the writer:
+
+```text
+row batch
+  updated_at = client wall clock
+```
+
+That timestamp is useful for people:
+
+```text
+$updatedAt
+audit display
+app-level timestamp comparisons
+```
+
+But a client wall clock is not a good global sequencing source. Different
+devices can be ahead, behind, offline, or manually changed.
+
+For deterministic global snapshots, we need a timeline produced by one global
+authority.
+
+## The Proposal
+
+Keep the current timestamp, and add a second field:
+
+```text
+row batch
+  updated_at     = client wall clock, for people and current behavior
+  authority_hlc  = global authority stamp, for future global snapshots
+```
+
+The two fields answer different questions:
+
+```text
+updated_at:
+  "When did the writer say this happened?"
+
+authority_hlc:
+  "Where did the global authority place this row-batch member
+   in the durable global sequence?"
+```
+
+## What A Row Looks Like
+
+Before:
+
+```text
+StoredRowBatch
+  row_id
+  branch
+  batch_id
+  parents
+  updated_at
+  created_at
+  data
+```
+
+After:
+
+```text
+StoredRowBatch
+  row_id
+  branch
+  batch_id
+  parents
+  updated_at        unchanged
+  created_at        unchanged
+  authority_hlc     new, nullable
+  data
+```
+
+`authority_hlc = null` is normal. It means the row exists locally or at the
+edge, but the global authority has not stamped that row-batch member yet.
+
+## Write Flow
+
+```text
+Client or edge writes
+
+  updated_at    = client time
+  authority_hlc = null
+
+          |
+          | sync upstream
+          v
+
+Global authority records the row-batch member
+
+  updated_at    = unchanged
+  authority_hlc = next global HLC
+
+          |
+          | sync downstream
+          v
+
+Clients and edges store the stamp
+
+  current reads behave the same as before
+```
+
+Only the global authority can create the stamp. Clients and edges can store and
+relay a stamp they received, but they do not invent one.
+
+## Multi-Row Batches
+
+The stamp is per row-batch member, not per batch:
+
+```text
+batch A
+  row 1 -> authority_hlc = HLC 100
+  row 2 -> authority_hlc = HLC 101
+  row 3 -> authority_hlc = HLC 102
+```
+
+This keeps future row scans simple. A snapshot scan can inspect row history
+directly instead of joining through batch metadata.
+
+## What Does Not Change
+
+This proposal does not change current visible behavior:
+
+```text
+current LWW merge ordering       unchanged
+current visible-row selection    unchanged
+$createdAt / $updatedAt          unchanged
+local-first optimistic reads     unchanged
+batch fate                       unchanged
+```
+
+That is the main safety property of the proposal. The new field prepares a
+future capability without changing what applications see today.
+
+## Future Snapshot Shape
+
+Later, a deterministic global snapshot can use the authority timeline:
+
+```text
+snapshot at HLC 500
+
+include row-batch members where:
+  authority_hlc is not null
+  authority_hlc <= HLC 500
+
+ignore by default:
+  local-only rows
+  edge-only rows
+  rows not yet observed by the global authority
+```
+
+The snapshot then has one global ordering source, independent from client wall
+clocks.
+
+## Why This Is The Smallest Useful Step
+
+```text
+client timestamp remains human time
+authority_hlc becomes global sequence time
+current reads keep their behavior
+future global snapshots get a direct scan key
+```
+
+The proposal separates concepts that are currently easy to conflate, without
+forcing the engine to switch conflict resolution or public timestamp APIs at the
+same time.

--- a/docs/superpowers/specs/2026-05-25-authority-hlc-proposal.md
+++ b/docs/superpowers/specs/2026-05-25-authority-hlc-proposal.md
@@ -1,7 +1,8 @@
 # Proposal: Authority HLC Row Stamps
 
-Add one nullable global stamp to each row-batch member, while keeping the
-existing client timestamp exactly what it is today: human-facing provenance.
+Add one nullable global batch stamp, copied into each row-batch member, while
+keeping the existing client timestamp exactly what it is today: human-facing
+provenance.
 
 The point is not to change conflict resolution now. The point is to make future
 deterministic global snapshots possible.
@@ -46,7 +47,7 @@ updated_at:
   "When did the writer say this happened?"
 
 authority_hlc:
-  "Where did the global authority place this row-batch member
+  "Where did the global authority place this batch
    in the durable global sequence?"
 ```
 
@@ -75,12 +76,12 @@ StoredRowBatch
   parents
   updated_at        unchanged
   created_at        unchanged
-  authority_hlc     new, nullable
+  authority_hlc     new, nullable copy of the batch stamp
   data
 ```
 
 `authority_hlc = null` is normal. It means the row exists locally or at the
-edge, but the global authority has not stamped that row-batch member yet.
+edge, but the global authority has not stamped its batch yet.
 
 ## Write Flow
 
@@ -94,10 +95,10 @@ Client or edge writes
           | sync upstream
           v
 
-Global authority records the row-batch member
+Global authority records the batch
 
   updated_at    = unchanged
-  authority_hlc = next global HLC
+  authority_hlc = next global HLC for the batch
 
           |
           | sync downstream
@@ -113,17 +114,19 @@ relay a stamp they received, but they do not invent one.
 
 ## Multi-Row Batches
 
-The stamp is per row-batch member, not per batch:
+The stamp is per batch, but stored inside every row member:
 
 ```text
-batch A
-  row 1 -> authority_hlc = HLC 100
-  row 2 -> authority_hlc = HLC 101
-  row 3 -> authority_hlc = HLC 102
+batch A -> authority_hlc = HLC 100
+
+  row 1 stores authority_hlc = HLC 100
+  row 2 stores authority_hlc = HLC 100
+  row 3 stores authority_hlc = HLC 100
 ```
 
-This keeps future row scans simple. A snapshot scan can inspect row history
-directly instead of joining through batch metadata.
+This gives the batch one place in the global sequence while still keeping
+future row scans simple. A snapshot scan can inspect row history directly
+instead of joining through batch metadata.
 
 ## What Does Not Change
 

--- a/docs/superpowers/specs/2026-05-25-authority-hlc-proposal.md
+++ b/docs/superpowers/specs/2026-05-25-authority-hlc-proposal.md
@@ -167,23 +167,29 @@ future capability without changing what applications see today.
 
 ## Future Snapshot Shape
 
-Later, a deterministic global snapshot can use the authority timeline:
+Later, a deterministic global snapshot can combine the authority timeline with
+dotted versions:
 
 ```text
-snapshot at HLC 500
-
-include row-batch members where:
-  authority_hlc is not null
+snapshot bookmark:
   authority_hlc <= HLC 500
 
-ignore by default:
+dotted versions:
+  per-object/per-row causal frontier inside that global cutoff
+
+include by default:
+  globally stamped rows inside the bookmark
+  versions selected by the dotted-version frontier
+
+exclude by default:
   local-only rows
   edge-only rows
   rows not yet observed by the global authority
 ```
 
-The snapshot then has one global ordering source, independent from client wall
-clocks.
+The HLC is the simple global bookmark: "everything globally observed up to this
+point is eligible." Dotted versions keep the exact row/object frontier precise
+inside that bookmark.
 
 ## Why This Is The Smallest Useful Step
 

--- a/docs/superpowers/specs/2026-05-25-authority-hlc-proposal.md
+++ b/docs/superpowers/specs/2026-05-25-authority-hlc-proposal.md
@@ -73,6 +73,37 @@ into today's merge behavior. The authority HLC can stay simple: it is a durable
 bookmark for globally observed batches, not a new rule for deciding which local
 edit wins.
 
+## Precision And Restarts
+
+The authority stamp should use millisecond physical precision:
+
+```text
+authority_hlc
+  physical_millis
+  logical_counter
+```
+
+Milliseconds are enough for a snapshot bookmark. If the global authority stamps
+multiple batches in the same millisecond, the counter gives them a stable order.
+
+On restart, the authority loads the last recorded `authority_hlc` before
+stamping anything new:
+
+```text
+last recorded stamp:  HLC(2000ms, counter 7)
+local clock on restart: 1998ms
+
+next batch:            HLC(2000ms, counter 8)
+next batch:            HLC(2000ms, counter 9)
+
+when local clock reaches 2001ms:
+next batch:            HLC(2001ms, counter 0)
+```
+
+So restart drift does not move the global sequence backwards. The authority
+keeps increasing the counter until local time catches up with the last recorded
+stamp.
+
 ## What A Row Looks Like
 
 Before:


### PR DESCRIPTION
## Summary

- Add a structured design spec for authority-stamped HLC metadata on row batches.
- Add a shorter proposal companion that explains the idea visually and reviewably.
- Clarify that the HLC is additive: client timestamps remain the source for current conflict resolution, while the authority HLC provides a future global snapshot bookmark.
- Clarify that the authority HLC is batch-scoped and copied into each row member for simple row scans.
- Describe future snapshot shape using the global sequence plus dotted versions.

## Validation

- Pre-commit formatting hook passed for the touched Markdown files.
- Full test suite not run; docs-only change.