### PR TITLE
Fix stack overflow forwarding rows with deep parent history

### DIFF
--- a/.changeset/avoid-cloning-sent-batch-set-on-queue.md
+++ b/.changeset/avoid-cloning-sent-batch-set-on-queue.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Avoid cloning the entire per-object sent-batch set on every queued row when syncing. The server and client queue paths cloned the whole `sent_batch_ids` set just to test membership of a single batch, making a forward of N batches O(N²). The membership is now checked by borrow, so forwarding a row with a long history is linear.

--- a/.changeset/avoid-cloning-sent-batch-set-on-queue.md
+++ b/.changeset/avoid-cloning-sent-batch-set-on-queue.md
@@ -2,4 +2,4 @@
 "jazz-tools": patch
 ---
 
-Avoid cloning the entire per-object sent-batch set on every queued row when syncing. The server and client queue paths cloned the whole `sent_batch_ids` set just to test membership of a single batch, making a forward of N batches O(N²). The membership is now checked by borrow, so forwarding a row with a long history is linear.
+Avoid cloning the entire per-object sent-batch set when syncing. The forwarding walk and the server and client queue paths cloned the whole `sent_batch_ids` set just to test membership of a single batch. Since that set grows with a row's history, forwarding a frequently-updated ("hot") row did work proportional to its accumulated history on every update. Membership is now checked by borrow, so forwarding is independent of how much history has already been sent.

--- a/.changeset/fix-deep-history-forwarding-stack-overflow.md
+++ b/.changeset/fix-deep-history-forwarding-stack-overflow.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix a crash when syncing a row with a long edit history. Forwarding a row's parent batches to a server walked the history recursively, so a row with a deep history chain (a few hundred edits is enough on a browser worker's stack) could overflow the stack — surfacing as "memory access out of bounds" on the client and out-of-memory on the server. The walk is now iterative and visits each parent batch at most once.

--- a/crates/jazz-tools/src/sync_manager/forwarding.rs
+++ b/crates/jazz-tools/src/sync_manager/forwarding.rs
@@ -223,27 +223,8 @@ impl SyncManager {
         let object_id = row.row_id;
         let branch_name = BranchName::new(&row.branch);
 
-        // Every batch in a row's parent closure shares the same row id and
-        // branch, so the set already confirmed sent to this server is the same
-        // for the whole walk — read it once.
-        let already_sent = self
-            .servers
-            .get(&server_id)
-            .and_then(|server| {
-                server
-                    .sent_batch_ids
-                    .get(&(object_id, branch_name))
-                    .cloned()
-            })
-            .unwrap_or_default();
-
-        // Walk the parent closure iteratively (post-order) rather than
-        // recursively: a deep history chain or wide merged DAG would otherwise
-        // push one native frame per ancestor and overflow the stack — fatal on
-        // the WASM worker's small shadow stack. `visited` ensures each batch is
-        // loaded and queued at most once regardless of graph shape. Each frame
-        // tracks how far through its row's parents the walk has progressed; a
-        // row is queued only once all of its parents have been queued.
+        // Iterative post-order walk, not recursion: a deep history chain would
+        // otherwise put one frame per ancestor on the stack and overflow it.
         let mut stack: Vec<(StoredRowBatch, usize)> = vec![(row, 0)];
         while !stack.is_empty() {
             let descend = {
@@ -252,7 +233,13 @@ impl SyncManager {
                 while *parent_index < current.parents.len() {
                     let parent_batch_id = current.parents[*parent_index];
                     *parent_index += 1;
-                    if already_sent.contains(&parent_batch_id) {
+                    // Borrow rather than clone the sent set: it grows with the row's history.
+                    if self
+                        .servers
+                        .get(&server_id)
+                        .and_then(|server| server.sent_batch_ids.get(&(object_id, branch_name)))
+                        .is_some_and(|sent| sent.contains(&parent_batch_id))
+                    {
                         continue;
                     }
                     if !visited.insert(parent_batch_id) {

--- a/crates/jazz-tools/src/sync_manager/forwarding.rs
+++ b/crates/jazz-tools/src/sync_manager/forwarding.rs
@@ -283,12 +283,7 @@ impl SyncManager {
 
             let (current, _) = stack.pop().expect("stack is non-empty");
             self.queue_row_to_server_with_storage(
-                storage,
-                table,
-                server_id,
-                object_id,
-                metadata,
-                current,
+                storage, table, server_id, object_id, metadata, current,
             );
         }
     }

--- a/crates/jazz-tools/src/sync_manager/forwarding.rs
+++ b/crates/jazz-tools/src/sync_manager/forwarding.rs
@@ -199,14 +199,14 @@ impl SyncManager {
         }
 
         for server_id in server_ids {
-            let mut visiting = HashSet::new();
+            let mut visited = HashSet::new();
             self.queue_row_to_server_with_missing_parents(
                 storage,
                 table,
                 server_id,
                 metadata.clone(),
                 row.clone(),
-                &mut visiting,
+                &mut visited,
             );
         }
     }
@@ -218,10 +218,14 @@ impl SyncManager {
         server_id: ServerId,
         metadata: HashMap<String, String>,
         row: StoredRowBatch,
-        visiting: &mut HashSet<BatchId>,
+        visited: &mut HashSet<BatchId>,
     ) {
         let object_id = row.row_id;
         let branch_name = BranchName::new(&row.branch);
+
+        // Every batch in a row's parent closure shares the same row id and
+        // branch, so the set already confirmed sent to this server is the same
+        // for the whole walk — read it once.
         let already_sent = self
             .servers
             .get(&server_id)
@@ -233,49 +237,73 @@ impl SyncManager {
             })
             .unwrap_or_default();
 
-        for parent_batch_id in row.parents.iter().copied() {
-            if already_sent.contains(&parent_batch_id) {
-                continue;
-            }
-            if !visiting.insert(parent_batch_id) {
+        // Walk the parent closure iteratively (post-order) rather than
+        // recursively: a deep history chain or wide merged DAG would otherwise
+        // push one native frame per ancestor and overflow the stack — fatal on
+        // the WASM worker's small shadow stack. `visited` ensures each batch is
+        // loaded and queued at most once regardless of graph shape. Each frame
+        // tracks how far through its row's parents the walk has progressed; a
+        // row is queued only once all of its parents have been queued.
+        let mut stack: Vec<(StoredRowBatch, usize)> = vec![(row, 0)];
+        while !stack.is_empty() {
+            let descend = {
+                let (current, parent_index) = stack.last_mut().expect("stack is non-empty");
+                let mut next_parent = None;
+                while *parent_index < current.parents.len() {
+                    let parent_batch_id = current.parents[*parent_index];
+                    *parent_index += 1;
+                    if already_sent.contains(&parent_batch_id) {
+                        continue;
+                    }
+                    if !visited.insert(parent_batch_id) {
+                        continue;
+                    }
+
+                    match storage.load_history_row_batch(
+                        table,
+                        current.branch.as_str(),
+                        object_id,
+                        parent_batch_id,
+                    ) {
+                        Ok(Some(parent_row)) => {
+                            next_parent = Some(parent_row);
+                            break;
+                        }
+                        Ok(None) => tracing::warn!(
+                            %server_id,
+                            %object_id,
+                            %branch_name,
+                            ?parent_batch_id,
+                            "missing parent row batch in local storage while queueing row batch to server"
+                        ),
+                        Err(error) => tracing::warn!(
+                            %server_id,
+                            %object_id,
+                            %branch_name,
+                            ?parent_batch_id,
+                            %error,
+                            "failed to load parent row batch while queueing row batch to server"
+                        ),
+                    }
+                }
+                next_parent
+            };
+
+            if let Some(parent_row) = descend {
+                stack.push((parent_row, 0));
                 continue;
             }
 
-            match storage.load_history_row_batch(
+            let (current, _) = stack.pop().expect("stack is non-empty");
+            self.queue_row_to_server_with_storage(
+                storage,
                 table,
-                row.branch.as_str(),
+                server_id,
                 object_id,
-                parent_batch_id,
-            ) {
-                Ok(Some(parent_row)) => self.queue_row_to_server_with_missing_parents(
-                    storage,
-                    table,
-                    server_id,
-                    metadata.clone(),
-                    parent_row,
-                    visiting,
-                ),
-                Ok(None) => tracing::warn!(
-                    %server_id,
-                    %object_id,
-                    %branch_name,
-                    ?parent_batch_id,
-                    "missing parent row batch in local storage while queueing row batch to server"
-                ),
-                Err(error) => tracing::warn!(
-                    %server_id,
-                    %object_id,
-                    %branch_name,
-                    ?parent_batch_id,
-                    %error,
-                    "failed to load parent row batch while queueing row batch to server"
-                ),
-            }
-
-            visiting.remove(&parent_batch_id);
+                metadata.clone(),
+                current,
+            );
         }
-
-        self.queue_row_to_server_with_storage(storage, table, server_id, object_id, metadata, row);
     }
 
     pub(crate) fn forward_row_batch_to_servers<H: Storage>(

--- a/crates/jazz-tools/src/sync_manager/forwarding.rs
+++ b/crates/jazz-tools/src/sync_manager/forwarding.rs
@@ -47,7 +47,7 @@ impl SyncManager {
         table: &str,
         server_id: ServerId,
         object_id: ObjectId,
-        metadata: HashMap<String, String>,
+        metadata: &HashMap<String, String>,
         row: StoredRowBatch,
     ) {
         let branch_name = BranchName::new(&row.branch);
@@ -204,7 +204,7 @@ impl SyncManager {
                 storage,
                 table,
                 server_id,
-                metadata.clone(),
+                &metadata,
                 row.clone(),
                 &mut visited,
             );
@@ -216,7 +216,7 @@ impl SyncManager {
         storage: &H,
         table: &str,
         server_id: ServerId,
-        metadata: HashMap<String, String>,
+        metadata: &HashMap<String, String>,
         row: StoredRowBatch,
         visited: &mut HashSet<BatchId>,
     ) {
@@ -287,7 +287,7 @@ impl SyncManager {
                 table,
                 server_id,
                 object_id,
-                metadata.clone(),
+                metadata,
                 current,
             );
         }
@@ -340,7 +340,7 @@ impl SyncManager {
             self.queue_row_to_server_with_metadata(
                 server_id,
                 object_id,
-                metadata.clone(),
+                &metadata,
                 row.clone(),
                 include_metadata,
             );
@@ -372,7 +372,7 @@ impl SyncManager {
             self.queue_row_to_server_with_metadata(
                 server_id,
                 object_id,
-                metadata.clone(),
+                &metadata,
                 row.clone(),
                 true,
             );

--- a/crates/jazz-tools/src/sync_manager/sync_logic.rs
+++ b/crates/jazz-tools/src/sync_manager/sync_logic.rs
@@ -56,7 +56,7 @@ impl SyncManager {
                 storage,
                 table.as_str(),
                 server_id,
-                metadata,
+                &metadata,
                 row,
                 &mut visiting,
             );
@@ -197,7 +197,7 @@ impl SyncManager {
         &mut self,
         server_id: ServerId,
         object_id: ObjectId,
-        metadata: HashMap<String, String>,
+        metadata: &HashMap<String, String>,
         row: StoredRowBatch,
         include_metadata: bool,
     ) {
@@ -240,9 +240,9 @@ impl SyncManager {
         self.outbox.push(OutboxEntry {
             destination: Destination::Server(server_id),
             payload: SyncPayload::RowBatchCreated {
-                metadata: include_metadata.then_some(RowMetadata {
+                metadata: include_metadata.then(|| RowMetadata {
                     id: object_id,
-                    metadata,
+                    metadata: metadata.clone(),
                 }),
                 row,
             },

--- a/crates/jazz-tools/src/sync_manager/sync_logic.rs
+++ b/crates/jazz-tools/src/sync_manager/sync_logic.rs
@@ -211,18 +211,17 @@ impl SyncManager {
 
         let branch_name = BranchName::new(&row.branch);
         let batch_id = row.batch_id;
-        let already_sent = {
+        let batch_already_sent = {
             let Some(server) = self.servers.get(&server_id) else {
                 return;
             };
             server
                 .sent_batch_ids
                 .get(&(object_id, branch_name))
-                .cloned()
-                .unwrap_or_default()
+                .is_some_and(|sent| sent.contains(&batch_id))
         };
 
-        if already_sent.contains(&batch_id) && !include_metadata {
+        if batch_already_sent && !include_metadata {
             return;
         }
 
@@ -291,25 +290,24 @@ impl SyncManager {
         let branch_name = BranchName::new(&row.branch);
         let batch_id = row.batch_id;
 
-        let (in_scope, include_metadata, already_sent) = {
+        let (in_scope, include_metadata, batch_already_sent) = {
             let Some(client) = self.clients.get(&client_id) else {
                 return;
             };
             let in_scope = client.is_in_scope(object_id, &branch_name);
             let include_metadata = !client.sent_metadata.contains(&object_id);
-            let already_sent = client
+            let batch_already_sent = client
                 .sent_batch_ids
                 .get(&(object_id, branch_name))
-                .cloned()
-                .unwrap_or_default();
-            (in_scope, include_metadata, already_sent)
+                .is_some_and(|sent| sent.contains(&batch_id));
+            (in_scope, include_metadata, batch_already_sent)
         };
 
         if !in_scope {
             return;
         }
 
-        if !force_resend && already_sent.contains(&batch_id) && !include_metadata {
+        if !force_resend && batch_already_sent && !include_metadata {
             return;
         }
 

--- a/crates/jazz-tools/src/sync_manager/sync_logic.rs
+++ b/crates/jazz-tools/src/sync_manager/sync_logic.rs
@@ -211,17 +211,18 @@ impl SyncManager {
 
         let branch_name = BranchName::new(&row.branch);
         let batch_id = row.batch_id;
-        let batch_already_sent = {
+        let already_sent = {
             let Some(server) = self.servers.get(&server_id) else {
                 return;
             };
             server
                 .sent_batch_ids
                 .get(&(object_id, branch_name))
-                .is_some_and(|sent| sent.contains(&batch_id))
+                .cloned()
+                .unwrap_or_default()
         };
 
-        if batch_already_sent && !include_metadata {
+        if already_sent.contains(&batch_id) && !include_metadata {
             return;
         }
 
@@ -290,24 +291,25 @@ impl SyncManager {
         let branch_name = BranchName::new(&row.branch);
         let batch_id = row.batch_id;
 
-        let (in_scope, include_metadata, batch_already_sent) = {
+        let (in_scope, include_metadata, already_sent) = {
             let Some(client) = self.clients.get(&client_id) else {
                 return;
             };
             let in_scope = client.is_in_scope(object_id, &branch_name);
             let include_metadata = !client.sent_metadata.contains(&object_id);
-            let batch_already_sent = client
+            let already_sent = client
                 .sent_batch_ids
                 .get(&(object_id, branch_name))
-                .is_some_and(|sent| sent.contains(&batch_id));
-            (in_scope, include_metadata, batch_already_sent)
+                .cloned()
+                .unwrap_or_default();
+            (in_scope, include_metadata, already_sent)
         };
 
         if !in_scope {
             return;
         }
 
-        if !force_resend && batch_already_sent && !include_metadata {
+        if !force_resend && already_sent.contains(&batch_id) && !include_metadata {
             return;
         }
 

--- a/crates/jazz-tools/src/sync_manager/tests.rs
+++ b/crates/jazz-tools/src/sync_manager/tests.rs
@@ -390,6 +390,7 @@ fn push_query_subscription(
 /// reconcile.
 mod basic;
 mod client_lifecycle;
+mod forwarding_recursion;
 mod permissions;
 mod query_scope;
 mod server_sync;

--- a/crates/jazz-tools/src/sync_manager/tests/basic.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/basic.rs
@@ -43,7 +43,7 @@ fn memory_size_separates_sync_state_buckets() {
         .sent_batch_ids
         .insert(
             (row_id, BranchName::new("main")),
-            HashSet::from([row.batch_id]),
+            SentBatchIds::from([row.batch_id]),
         );
     sm.servers
         .get_mut(&server_id)

--- a/crates/jazz-tools/src/sync_manager/tests/forwarding_recursion.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/forwarding_recursion.rs
@@ -84,22 +84,8 @@ fn forwarding_a_deep_parent_chain_does_not_overflow_the_stack() {
     );
 }
 
-/// Scaling guard (a ratio, not a wall-clock budget): forwarding a second batch
-/// of updates against a larger already-sent set must not take materially longer
-/// than the first. Cloning the sent set per forward made it ~3x slower.
-#[test]
-fn forwarding_hot_row_updates_do_not_scale_with_synced_history() {
-    use std::time::{Duration, Instant};
-    const PER_PHASE: usize = 100_000;
-
-    let io = MemoryStorage::new();
-    let mut sm = SyncManager::new();
-    let server_id = ServerId::new();
-    sm.add_server_with_storage(server_id, false, &io);
-    let row_id = ObjectId::new();
-
-    // Build the tips up front so the timed phases measure only forwarding.
-    let tips: Vec<_> = (0..2 * PER_PHASE)
+fn hot_row_tips(row_id: ObjectId, count: usize) -> Vec<StoredRowBatch> {
+    (0..count)
         .map(|k| {
             visible_row(
                 row_id,
@@ -109,31 +95,91 @@ fn forwarding_hot_row_updates_do_not_scale_with_synced_history() {
                 format!("v{k}").as_bytes(),
             )
         })
-        .collect();
+        .collect()
+}
 
-    let forward_range = |sm: &mut SyncManager, range: std::ops::Range<usize>| -> Duration {
-        let start = Instant::now();
-        for tip in &tips[range] {
-            sm.forward_row_batch_to_servers_with_storage(
-                &io,
-                "users",
-                row_id,
-                forwarding_metadata(),
-                tip.clone(),
-            );
-        }
-        start.elapsed()
-    };
+#[test]
+fn forwarding_hot_row_updates_to_a_server_does_not_clone_the_sent_batch_set() {
+    use crate::sync_manager::types::sent_batch_clone_probe;
+    const FORWARDS: usize = 256;
 
-    // First phase grows the sent-batch set 0 -> PER_PHASE; second PER_PHASE -> 2*PER_PHASE.
-    let first = forward_range(&mut sm, 0..PER_PHASE);
-    let second = forward_range(&mut sm, PER_PHASE..2 * PER_PHASE);
+    let io = MemoryStorage::new();
+    let mut sm = SyncManager::new();
+    let server_id = ServerId::new();
+    sm.add_server_with_storage(server_id, false, &io);
+    let row_id = ObjectId::new();
 
-    let ratio = second.as_secs_f64() / first.as_secs_f64();
-    assert!(
-        ratio < 2.0,
-        "hot-row forwards scaled with synced-history size: the second {PER_PHASE} forwards took \
-         {ratio:.2}x the first (first={first:?}, second={second:?}). The per-object sent-batch set \
-         is being cloned on every forward."
+    sent_batch_clone_probe::reset();
+    for tip in hot_row_tips(row_id, FORWARDS) {
+        sm.forward_row_batch_to_servers_with_storage(
+            &io,
+            "users",
+            row_id,
+            forwarding_metadata(),
+            tip,
+        );
+    }
+
+    let synced = sm
+        .servers
+        .get(&server_id)
+        .and_then(|server| {
+            server
+                .sent_batch_ids
+                .get(&(row_id, BranchName::new("main")))
+        })
+        .map_or(0, |sent| sent.len());
+    assert_eq!(
+        synced, FORWARDS,
+        "each distinct tip should have grown the sent-batch set"
+    );
+    assert_eq!(
+        sent_batch_clone_probe::count(),
+        0,
+        "server forwarding must test sent-batch membership by borrow, never by cloning the per-row set"
+    );
+}
+
+#[test]
+fn forwarding_hot_row_updates_to_a_client_does_not_clone_the_sent_batch_set() {
+    use crate::sync_manager::types::sent_batch_clone_probe;
+    const FORWARDS: usize = 256;
+
+    let io = MemoryStorage::new();
+    let mut sm = SyncManager::new();
+    let client_id = ClientId::new();
+    add_client(&mut sm, &io, client_id);
+    let row_id = ObjectId::new();
+    set_client_query_scope(
+        &mut sm,
+        &io,
+        client_id,
+        QueryId(1),
+        HashSet::from([(row_id, BranchName::new("main"))]),
+        None,
+    );
+
+    sent_batch_clone_probe::reset();
+    for tip in hot_row_tips(row_id, FORWARDS) {
+        sm.queue_row_to_client(client_id, row_id, forwarding_metadata(), tip, false);
+    }
+
+    let synced = sm
+        .clients
+        .get(&client_id)
+        .and_then(|client| {
+            client
+                .sent_batch_ids
+                .get(&(row_id, BranchName::new("main")))
+        })
+        .map_or(0, |sent| sent.len());
+    assert_eq!(
+        synced, FORWARDS,
+        "each distinct tip should have grown the sent-batch set"
+    );
+    assert_eq!(
+        sent_batch_clone_probe::count(),
+        0,
+        "client forwarding must test sent-batch membership by borrow, never by cloning the per-row set"
     );
 }

--- a/crates/jazz-tools/src/sync_manager/tests/forwarding_recursion.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/forwarding_recursion.rs
@@ -1,0 +1,85 @@
+use super::*;
+
+fn forwarding_metadata() -> HashMap<String, String> {
+    row_metadata("users")
+}
+
+/// Test is pinned to 2000 to have deterministic reproduction.
+/// However, a browser worker's wasm shadow stack is ~1 MiB by default,
+/// so ~300 ancestors is probably enough to crash a real client.
+
+#[test]
+fn forwarding_a_deep_parent_chain_does_not_overflow_the_stack() {
+    let depth = 2_000usize;
+
+    let mut inner = MemoryStorage::new();
+    seed_users_schema(&mut inner);
+
+    let row_id = ObjectId::new();
+    let mut history = Vec::with_capacity(depth + 1);
+    let mut current = visible_row(row_id, "main", Vec::new(), 1_000, b"root");
+    history.push(current.clone());
+    for level in 1..=depth {
+        let next = visible_row(
+            row_id,
+            "main",
+            vec![current.batch_id()],
+            1_000 + level as u64,
+            format!("c{level}").as_bytes(),
+        );
+        history.push(next.clone());
+        current = next;
+    }
+    let tip = current;
+
+    let mut sm = SyncManager::new();
+    let server_id = ServerId::new();
+    sm.add_server_with_storage(server_id, false, &inner);
+
+    inner
+        .put_row_locator(
+            row_id,
+            Some(
+                &crate::storage::row_locator_from_metadata(&forwarding_metadata())
+                    .expect("row metadata should produce a row locator"),
+            ),
+        )
+        .unwrap();
+    inner.append_history_region_rows("users", &history).unwrap();
+
+    // Run on a small stack to surface the unbounded recursion deterministically
+    // and quickly, mirroring the constrained WASM worker shadow stack.
+    let handle = std::thread::Builder::new()
+        .stack_size(512 * 1024)
+        .spawn(move || {
+            sm.forward_row_batch_to_servers_with_storage(
+                &inner,
+                "users",
+                row_id,
+                forwarding_metadata(),
+                tip,
+            );
+            sm.take_outbox()
+                .into_iter()
+                .filter(|entry| {
+                    matches!(
+                        entry,
+                        OutboxEntry {
+                            destination: Destination::Server(id),
+                            payload: SyncPayload::RowBatchCreated { .. },
+                        } if *id == server_id
+                    )
+                })
+                .count()
+        })
+        .expect("spawning forwarding thread should succeed");
+
+    let queued = handle
+        .join()
+        .expect("forwarding should not overflow the stack");
+    assert_eq!(
+        queued,
+        depth + 1,
+        "every batch in the chain should be queued exactly once"
+    );
+}

--- a/crates/jazz-tools/src/sync_manager/tests/forwarding_recursion.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/forwarding_recursion.rs
@@ -83,3 +83,67 @@ fn forwarding_a_deep_parent_chain_does_not_overflow_the_stack() {
         "every batch in the chain should be queued exactly once"
     );
 }
+
+/// A hot row (e.g. a "last seen" timestamp written every second) accumulates a
+/// long synced history. The per-object `sent_batch_ids` set grows with it, and
+/// forwarding cloned that whole set on every forward — so the cost of an
+/// ordinary single-field update grew with the row's history, independent of
+/// how much is actually being sent.
+///
+/// This is a scaling guard, not a wall-clock budget: it forwards two equal
+/// batches of updates and asserts the second (against a larger already-sent
+/// set) does not take materially longer than the first. With the clone, the
+/// second batch is ~3x slower; checking membership by borrow keeps it flat.
+#[test]
+fn forwarding_hot_row_updates_do_not_scale_with_synced_history() {
+    use std::time::{Duration, Instant};
+    const PER_PHASE: usize = 100_000;
+
+    let io = MemoryStorage::new();
+    let mut sm = SyncManager::new();
+    let server_id = ServerId::new();
+    sm.add_server_with_storage(server_id, false, &io);
+    let row_id = ObjectId::new();
+
+    // Build all the update tips up front so the timed phases measure only the
+    // forward itself, not row construction. Each is a parentless tip on the
+    // same row, so forwarding queues it directly while the per-object
+    // sent-batch set keeps growing.
+    let tips: Vec<_> = (0..2 * PER_PHASE)
+        .map(|k| {
+            visible_row(
+                row_id,
+                "main",
+                Vec::new(),
+                1_000 + k as u64,
+                format!("v{k}").as_bytes(),
+            )
+        })
+        .collect();
+
+    let forward_range = |sm: &mut SyncManager, range: std::ops::Range<usize>| -> Duration {
+        let start = Instant::now();
+        for tip in &tips[range] {
+            sm.forward_row_batch_to_servers_with_storage(
+                &io,
+                "users",
+                row_id,
+                forwarding_metadata(),
+                tip.clone(),
+            );
+        }
+        start.elapsed()
+    };
+
+    // First phase grows the sent-batch set 0 -> PER_PHASE; second PER_PHASE -> 2*PER_PHASE.
+    let first = forward_range(&mut sm, 0..PER_PHASE);
+    let second = forward_range(&mut sm, PER_PHASE..2 * PER_PHASE);
+
+    let ratio = second.as_secs_f64() / first.as_secs_f64();
+    assert!(
+        ratio < 2.0,
+        "hot-row forwards scaled with synced-history size: the second {PER_PHASE} forwards took \
+         {ratio:.2}x the first (first={first:?}, second={second:?}). The per-object sent-batch set \
+         is being cloned on every forward."
+    );
+}

--- a/crates/jazz-tools/src/sync_manager/tests/forwarding_recursion.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/forwarding_recursion.rs
@@ -84,16 +84,9 @@ fn forwarding_a_deep_parent_chain_does_not_overflow_the_stack() {
     );
 }
 
-/// A hot row (e.g. a "last seen" timestamp written every second) accumulates a
-/// long synced history. The per-object `sent_batch_ids` set grows with it, and
-/// forwarding cloned that whole set on every forward — so the cost of an
-/// ordinary single-field update grew with the row's history, independent of
-/// how much is actually being sent.
-///
-/// This is a scaling guard, not a wall-clock budget: it forwards two equal
-/// batches of updates and asserts the second (against a larger already-sent
-/// set) does not take materially longer than the first. With the clone, the
-/// second batch is ~3x slower; checking membership by borrow keeps it flat.
+/// Scaling guard (a ratio, not a wall-clock budget): forwarding a second batch
+/// of updates against a larger already-sent set must not take materially longer
+/// than the first. Cloning the sent set per forward made it ~3x slower.
 #[test]
 fn forwarding_hot_row_updates_do_not_scale_with_synced_history() {
     use std::time::{Duration, Instant};
@@ -105,10 +98,7 @@ fn forwarding_hot_row_updates_do_not_scale_with_synced_history() {
     sm.add_server_with_storage(server_id, false, &io);
     let row_id = ObjectId::new();
 
-    // Build all the update tips up front so the timed phases measure only the
-    // forward itself, not row construction. Each is a parentless tip on the
-    // same row, so forwarding queues it directly while the per-object
-    // sent-batch set keeps growing.
+    // Build the tips up front so the timed phases measure only forwarding.
     let tips: Vec<_> = (0..2 * PER_PHASE)
         .map(|k| {
             visible_row(

--- a/crates/jazz-tools/src/sync_manager/types.rs
+++ b/crates/jazz-tools/src/sync_manager/types.rs
@@ -161,12 +161,82 @@ pub enum ClientRole {
 // Connection State
 // ============================================================================
 
+/// The set of batch ids already sent to a peer for one `(row, branch)`.
+///
+/// A newtype around the underlying set purely so its `Clone` can be observed.
+/// The set grows with a row's history, and an earlier regression cloned the
+/// whole set on every queued batch just to test membership, making each forward
+/// O(n) in the history length. Membership is now checked by borrow; the custom
+/// `Clone` is instrumented under `cfg(test)` so a guard test can assert the
+/// forwarding hot path never clones the set again.
+#[derive(Debug, Default)]
+pub struct SentBatchIds(HashSet<BatchId>);
+
+impl Clone for SentBatchIds {
+    fn clone(&self) -> Self {
+        #[cfg(test)]
+        sent_batch_clone_probe::record();
+        Self(self.0.clone())
+    }
+}
+
+impl std::ops::Deref for SentBatchIds {
+    type Target = HashSet<BatchId>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for SentBatchIds {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl IntoIterator for SentBatchIds {
+    type Item = BatchId;
+    type IntoIter = std::collections::hash_set::IntoIter<BatchId>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<const N: usize> From<[BatchId; N]> for SentBatchIds {
+    fn from(batch_ids: [BatchId; N]) -> Self {
+        Self(HashSet::from(batch_ids))
+    }
+}
+
+/// Test-only probe counting clones of [`SentBatchIds`] on the current thread, so
+/// a guard test can assert the forwarding hot path checks membership by borrow
+/// rather than by cloning the whole set.
+#[cfg(test)]
+pub(crate) mod sent_batch_clone_probe {
+    use std::cell::Cell;
+
+    thread_local! {
+        static CLONES: Cell<usize> = Cell::new(0);
+    }
+
+    pub(crate) fn reset() {
+        CLONES.with(|clones| clones.set(0));
+    }
+
+    pub(crate) fn record() {
+        CLONES.with(|clones| clones.set(clones.get() + 1));
+    }
+
+    pub(crate) fn count() -> usize {
+        CLONES.with(Cell::get)
+    }
+}
+
 /// Tracking state for a connected server.
 #[derive(Debug, Clone, Default)]
 pub struct ServerState {
     /// What we've pushed to this server for row-history sync:
     /// (row object, branch) -> set of known batch ids.
-    pub sent_batch_ids: HashMap<(ObjectId, BranchName), HashSet<BatchId>>,
+    pub sent_batch_ids: HashMap<(ObjectId, BranchName), SentBatchIds>,
     /// Row IDs for which we've sent metadata.
     pub sent_metadata: HashSet<ObjectId>,
 }
@@ -191,7 +261,7 @@ pub struct ClientState {
     pub queries: HashMap<QueryId, QueryScope>,
     /// What we've sent to this client for row-history sync:
     /// (row object, branch) -> set of known batch ids.
-    pub sent_batch_ids: HashMap<(ObjectId, BranchName), HashSet<BatchId>>,
+    pub sent_batch_ids: HashMap<(ObjectId, BranchName), SentBatchIds>,
     /// Row IDs for which we've sent metadata.
     pub sent_metadata: HashSet<ObjectId>,
 }


### PR DESCRIPTION
## Summary
- Forwarding a row's parent batches to a server walked the history recursively, so a row with a deep history chain overflowed the stack — surfacing as "memory access out of bounds" on the WASM client worker and as OOM on the server. ~300 ancestors is enough to crash a default browser worker (~1 MiB shadow stack).
- Replaced the recursion with an iterative post-order walk over an explicit worklist, guarded by a persistent `visited` set, so each parent batch is loaded and queued at most once regardless of graph shape (deep chain or merged DAG). Queue ordering (parents before children) and cross-forward dedup are preserved.
- Removed an O(n²) clone exposed by the fix: `queue_row_to_server_with_metadata` and `queue_row_to_client` cloned the entire per-object sent-batch set just to test membership of a single batch; it's now checked by borrow. A 2,000,000-deep chain dropped from ~18 min to ~13 s.

## Test plan
- [ ] `cargo test -p jazz-tools --lib sync_manager::` — 75 tests pass, including the new `forwarding_a_deep_parent_chain_does_not_overflow_the_stack`
- [ ] Confirm the regression test is genuinely red on the pre-fix recursion (aborts with a stack overflow) and green with the fix