### PR TITLE
Lean branch query and permissions

### DIFF
--- a/crates/jazz-tools/src/query_manager/graph/compile.rs
+++ b/crates/jazz-tools/src/query_manager/graph/compile.rs
@@ -4,7 +4,7 @@ use std::{cmp::Ordering, ops::Bound};
 use crate::object::{BranchName, ObjectId};
 use crate::query_manager::types::{
     ColumnDescriptor, ColumnName, ColumnType, ComposedBranchName, RowDescriptor, RowPolicyMode,
-    Schema, SchemaHash, TableName, TupleDescriptor, Value,
+    Schema, SchemaHash, TableName, TableSchema, TupleDescriptor, Value,
 };
 use crate::schema_manager::{
     SchemaContext, translate_column_for_index, translate_table_name_to_schema,
@@ -18,7 +18,7 @@ use super::super::graph_nodes::limit_offset::LimitOffsetNode;
 use super::super::graph_nodes::magic_columns::{MagicColumnRequest, MagicColumnsNode};
 use super::super::graph_nodes::materialize::MaterializeNode;
 use super::super::graph_nodes::output::{OutputMode, OutputNode};
-use super::super::graph_nodes::policy_filter::PolicyFilterNode;
+use super::super::graph_nodes::policy_filter::{PolicyFilterNode, PolicyFilterOptions};
 use super::super::graph_nodes::project::ProjectNode;
 use super::super::graph_nodes::recursive_relation::{
     CorrelationSource, RecursiveHop, RecursiveRelationNode,
@@ -30,10 +30,11 @@ use super::super::graph_nodes::union::UnionNode;
 use super::super::graph_nodes::{NodeId, RowNode};
 use super::super::index::ScanCondition;
 use super::super::magic_columns::{MagicColumnKind, magic_column_descriptor, magic_column_kind};
-use super::super::policy::PolicyExpr;
 use super::super::query::{ArraySubquerySpec, Condition, Conjunction, Query, QueryBuilder};
 use super::super::relation_ir::{ProjectColumn, ProjectExpr, RelExpr};
-use super::super::relation_ir_query_plan::{ExecutionQueryPlan, lower_relation_to_execution_plan};
+use super::super::relation_ir_query_plan::{
+    ExecutionQueryPlan, QueryEnvelope, lower_relation_to_execution_plan, unwrap_query_envelope,
+};
 use super::super::session::Session;
 use uuid::Uuid;
 
@@ -48,15 +49,65 @@ fn resolve_branch_schema_hash(schema_context: &SchemaContext, branch: &str) -> O
         .find(|hash| hash.short() == composed.schema_hash.short())
 }
 
-fn effective_select_policy(
-    table_schema: &crate::query_manager::types::TableSchema,
-    row_policy_mode: RowPolicyMode,
-) -> Option<PolicyExpr> {
-    table_schema.policies.select_policy().cloned().or_else(|| {
-        row_policy_mode
-            .denies_missing_explicit_policy()
-            .then_some(PolicyExpr::False)
-    })
+struct BranchCompileContext {
+    branches: Vec<String>,
+    schema_hash_by_branch: HashMap<String, SchemaHash>,
+    policy_branch: String,
+}
+
+impl BranchCompileContext {
+    fn new(requested_branches: &[String], schema_context: &SchemaContext) -> Self {
+        let branches = if requested_branches.is_empty() {
+            schema_context
+                .all_branch_names()
+                .into_iter()
+                .map(|branch| branch.as_str().to_string())
+                .collect()
+        } else {
+            requested_branches.to_vec()
+        };
+        let mut schema_hash_by_branch = HashMap::new();
+        for schema_hash in schema_context.all_live_hashes() {
+            let branch_name = ComposedBranchName::new(
+                &schema_context.env,
+                schema_hash,
+                &schema_context.user_branch,
+            )
+            .to_branch_name();
+            schema_hash_by_branch.insert(branch_name.as_str().to_string(), schema_hash);
+        }
+        let policy_branch = branches
+            .first()
+            .cloned()
+            .unwrap_or_else(|| "main".to_string());
+
+        Self {
+            branches,
+            schema_hash_by_branch,
+            policy_branch,
+        }
+    }
+
+    fn branches(&self) -> &[String] {
+        &self.branches
+    }
+
+    fn policy_branch(&self) -> &str {
+        &self.policy_branch
+    }
+
+    fn schema_hash_for(&self, schema_context: &SchemaContext, branch: &str) -> Option<SchemaHash> {
+        self.schema_hash_by_branch
+            .get(branch)
+            .copied()
+            .or_else(|| resolve_branch_schema_hash(schema_context, branch))
+    }
+}
+
+fn needs_select_policy_filter(table_schema: &TableSchema, row_policy_mode: RowPolicyMode) -> bool {
+    row_policy_mode.denies_missing_explicit_policy()
+        || table_schema.policies.select_policy().is_some()
+        || !table_schema.policies.for_branch.is_empty()
 }
 
 fn natural_row_projection_element_index(
@@ -124,6 +175,46 @@ fn translate_scan_table_name(
     };
 
     translated_table.map(|name| TableName::new(&name))
+}
+
+fn translate_scan_column_name(
+    schema_context: &SchemaContext,
+    table: &str,
+    column: &str,
+    branch_schema_hash: Option<SchemaHash>,
+) -> String {
+    if let Some(target_hash) = branch_schema_hash
+        && target_hash != schema_context.current_hash
+    {
+        return translate_column_for_index(schema_context, table, column, &target_hash)
+            .unwrap_or_else(|| column.to_string());
+    }
+
+    column.to_string()
+}
+
+struct BranchIndexScanSpec {
+    column: String,
+    condition: ScanCondition,
+    translate_column: bool,
+}
+
+impl BranchIndexScanSpec {
+    fn translated(column: impl Into<String>, condition: ScanCondition) -> Self {
+        Self {
+            column: column.into(),
+            condition,
+            translate_column: true,
+        }
+    }
+
+    fn raw(column: impl Into<String>, condition: ScanCondition) -> Self {
+        Self {
+            column: column.into(),
+            condition,
+            translate_column: false,
+        }
+    }
 }
 
 fn push_unique_magic_ref(
@@ -328,6 +419,61 @@ impl QueryGraph {
         Some(remap(other.output_node))
     }
 
+    fn compile_branch_index_scans(
+        &mut self,
+        schema_context: &SchemaContext,
+        branch_context: &BranchCompileContext,
+        table: TableName,
+        descriptor: &RowDescriptor,
+        scan_specs: &[BranchIndexScanSpec],
+    ) -> Option<NodeId> {
+        let mut scan_ids = Vec::new();
+        let table_str = table.as_str();
+        for branch in branch_context.branches() {
+            let branch_schema_hash = branch_context.schema_hash_for(schema_context, branch);
+            let Some(scan_table_name) =
+                translate_scan_table_name(schema_context, table_str, branch_schema_hash)
+            else {
+                continue;
+            };
+
+            for spec in scan_specs {
+                let scan_column = if spec.translate_column {
+                    translate_scan_column_name(
+                        schema_context,
+                        table_str,
+                        &spec.column,
+                        branch_schema_hash,
+                    )
+                } else {
+                    spec.column.clone()
+                };
+                let scan_column_name = ColumnName::new(&scan_column);
+                let scan_node = IndexScanNode::new_with_branch(
+                    scan_table_name,
+                    scan_column_name,
+                    branch,
+                    spec.condition.clone(),
+                    descriptor.clone(),
+                );
+                let scan_id = self.add_node(GraphNode::IndexScan(scan_node));
+                self.index_scan_nodes
+                    .push((scan_id, scan_table_name, scan_column_name));
+                scan_ids.push(scan_id);
+            }
+        }
+
+        if scan_ids.len() > 1 {
+            let union_id = self.add_node(GraphNode::Union(UnionNode::new()));
+            for scan_id in scan_ids {
+                self.add_edge(union_id, scan_id);
+            }
+            Some(union_id)
+        } else {
+            scan_ids.first().copied()
+        }
+    }
+
     /// Compile a query into a graph (without policy filtering).
     pub fn compile(query: &Query, schema: &Schema) -> Option<Self> {
         let schema_context = Self::default_schema_context(schema);
@@ -436,15 +582,38 @@ impl QueryGraph {
         features: RelationCompileFeatures,
         row_policy_mode: RowPolicyMode,
     ) -> Option<Self> {
-        if let RelExpr::Union { inputs } = relation {
-            return Self::compile_relation_ir_union_with_schema_context_and_features(
+        if let RelExpr::Branch {
+            input,
+            branches: branch_scope,
+        } = relation
+        {
+            let effective_branches = if branch_scope.is_empty() {
+                branches
+            } else {
+                branch_scope.as_slice()
+            };
+            return Self::compile_relation_ir_with_schema_context_and_features(
+                input,
+                schema,
+                effective_branches,
+                session,
+                schema_context,
+                features,
+                row_policy_mode,
+            );
+        }
+
+        let envelope = unwrap_query_envelope(relation);
+        if let RelExpr::Union { inputs } = envelope.core {
+            let graph = Self::compile_relation_ir_union_with_schema_context_and_features(
                 inputs,
                 schema,
                 branches,
                 session,
                 schema_context,
                 row_policy_mode,
-            );
+            )?;
+            return Self::append_query_envelope_to_graph(graph, envelope);
         }
         let plan = lower_relation_to_execution_plan(
             relation,
@@ -529,6 +698,48 @@ impl QueryGraph {
         Some(graph)
     }
 
+    fn append_query_envelope_to_graph(mut graph: Self, envelope: QueryEnvelope) -> Option<Self> {
+        if envelope.order_by.is_empty() && envelope.offset == 0 && envelope.limit.is_none() {
+            return Some(graph);
+        }
+
+        let output_tuple_descriptor = match graph.get_node(graph.output_node) {
+            Some(GraphNode::Output(node)) => node.output_tuple_descriptor().clone(),
+            _ => return None,
+        };
+        let output_descriptor = output_tuple_descriptor.combined_descriptor();
+        let mut phase_input = graph.output_node;
+
+        let sort_keys = sort_keys_from_order_by(&envelope.order_by, &output_descriptor);
+        if !sort_keys.is_empty() {
+            let sort_node =
+                SortNode::with_tuple_descriptor(output_tuple_descriptor.clone(), sort_keys);
+            let sort_id = graph.add_node(GraphNode::Sort(sort_node));
+            graph.add_edge(sort_id, phase_input);
+            phase_input = sort_id;
+        }
+
+        if envelope.limit.is_some() || envelope.offset > 0 {
+            let limit_offset_node = LimitOffsetNode::with_tuple_descriptor(
+                output_tuple_descriptor.clone(),
+                envelope.limit,
+                envelope.offset,
+            );
+            let limit_offset_id = graph.add_node(GraphNode::LimitOffset(limit_offset_node));
+            graph.add_edge(limit_offset_id, phase_input);
+            graph.pagination_node = Some(limit_offset_id);
+            phase_input = limit_offset_id;
+        }
+
+        let output_node =
+            OutputNode::with_tuple_descriptor(output_tuple_descriptor, OutputMode::Delta);
+        let output_id = graph.add_node(GraphNode::Output(output_node));
+        graph.add_edge(output_id, phase_input);
+        graph.output_node = output_id;
+
+        Some(graph)
+    }
+
     fn compile_execution_plan_with_schema_context(
         plan: &ExecutionQueryPlan,
         schema: &Schema,
@@ -536,36 +747,13 @@ impl QueryGraph {
         schema_context: &SchemaContext,
         row_policy_mode: RowPolicyMode,
     ) -> Option<Self> {
-        // Build branch -> schema hash map for column translation.
-        // Use full hashes from SchemaContext (do not re-parse branch strings, which only encode
-        // a shortened hash prefix).
-        let mut branch_schema_map: HashMap<String, SchemaHash> = HashMap::new();
-        for schema_hash in schema_context.all_live_hashes() {
-            let branch_name = ComposedBranchName::new(
-                &schema_context.env,
-                schema_hash,
-                &schema_context.user_branch,
-            )
-            .to_branch_name();
-            branch_schema_map.insert(branch_name.as_str().to_string(), schema_hash);
-        }
-
-        // Expand branches to include all live schema branches if not specified
-        let branches: Vec<String> = if plan.branches.is_empty() {
-            schema_context
-                .all_branch_names()
-                .into_iter()
-                .map(|b| b.as_str().to_string())
-                .collect()
-        } else {
-            plan.branches.clone()
-        };
+        let branch_context = BranchCompileContext::new(&plan.branches, schema_context);
 
         if plan.seed_relation.is_some() || !plan.joins.is_empty() {
             return Self::compile_join_plan(
                 plan,
                 schema,
-                &branches,
+                &branch_context,
                 session.clone(),
                 schema_context,
                 row_policy_mode,
@@ -574,99 +762,32 @@ impl QueryGraph {
 
         let table_schema = schema.get(&plan.table)?;
         let descriptor = table_schema.columns.clone();
-        let select_policy = effective_select_policy(table_schema, row_policy_mode);
         let mut graph = QueryGraph::new(plan.table, descriptor.clone());
-        let table_str = plan.table.as_str();
 
-        // Phase 1: Build IndexScan nodes (one per disjunct per branch)
-        // For multi-branch queries, we create scans for each branch and union them
-        // Column names are translated for old schema branches
-        let mut phase1_outputs: Vec<NodeId> = Vec::new();
         let scan_plans: Vec<_> = plan
             .disjuncts
             .iter()
             .map(|disjunct| index_scan_plan(disjunct, table_schema))
             .collect();
-
-        for branch in &branches {
-            // Get schema hash for this branch to determine if column translation is needed
-            let branch_schema_hash = branch_schema_map
-                .get(branch)
-                .copied()
-                .or_else(|| resolve_branch_schema_hash(schema_context, branch));
-            let Some(scan_table_name) =
-                translate_scan_table_name(schema_context, table_str, branch_schema_hash)
-            else {
-                continue;
-            };
-            for scan_plan in &scan_plans {
-                let scan_column = &scan_plan.column;
-
-                // Translate column name for old schema branches
-                let translated_column = if let Some(target_hash) = branch_schema_hash {
-                    if target_hash != schema_context.current_hash {
-                        // This branch uses an old schema - translate column name
-                        translate_column_for_index(
-                            schema_context,
-                            table_str,
-                            scan_column,
-                            &target_hash,
-                        )
-                        .unwrap_or_else(|| scan_column.clone())
-                    } else {
-                        scan_column.clone()
-                    }
-                } else {
-                    scan_column.clone()
-                };
-
-                let scan_column_name = ColumnName::new(&translated_column);
-
-                let scan_node = IndexScanNode::new_with_branch(
-                    scan_table_name,
-                    scan_column_name,
-                    branch,
+        let mut scan_specs: Vec<_> = scan_plans
+            .iter()
+            .map(|scan_plan| {
+                BranchIndexScanSpec::translated(
+                    scan_plan.column.clone(),
                     scan_plan.condition.clone(),
-                    descriptor.clone(),
-                );
-                let scan_id = graph.add_node(GraphNode::IndexScan(scan_node));
-                graph
-                    .index_scan_nodes
-                    .push((scan_id, scan_table_name, scan_column_name));
-                phase1_outputs.push(scan_id);
-            }
-
-            // If include_deleted is set, also scan _id_deleted index for this branch
-            if plan.include_deleted {
-                let deleted_column = ColumnName::new("_id_deleted");
-                let deleted_scan_node = IndexScanNode::new_with_branch(
-                    scan_table_name,
-                    deleted_column,
-                    branch,
-                    ScanCondition::All,
-                    descriptor.clone(),
-                );
-                let deleted_scan_id = graph.add_node(GraphNode::IndexScan(deleted_scan_node));
-                graph
-                    .index_scan_nodes
-                    .push((deleted_scan_id, scan_table_name, deleted_column));
-                phase1_outputs.push(deleted_scan_id);
-            }
+                )
+            })
+            .collect();
+        if plan.include_deleted {
+            scan_specs.push(BranchIndexScanSpec::raw("_id_deleted", ScanCondition::All));
         }
-
-        // If multiple outputs, add Union node
-        let phase1_output = if phase1_outputs.len() > 1 {
-            let union_node = UnionNode::new();
-            let union_id = graph.add_node(GraphNode::Union(union_node));
-            for scan_id in &phase1_outputs {
-                graph.add_edge(union_id, *scan_id);
-            }
-            union_id
-        } else if !phase1_outputs.is_empty() {
-            phase1_outputs[0]
-        } else {
-            return None;
-        };
+        let phase1_output = graph.compile_branch_index_scans(
+            schema_context,
+            &branch_context,
+            plan.table,
+            &descriptor,
+            &scan_specs,
+        )?;
 
         // Materialize node (boundary between Phase 1 and Phase 2). Lens transforms are
         // applied in the row_loader using the current schema, but the materialize hint
@@ -686,20 +807,18 @@ impl QueryGraph {
         );
         let scope_table_map = HashMap::from([(plan.base_scope.clone(), plan.table)]);
 
-        // Policy filter node (if session provided and table has SELECT policy)
-        if let (Some(session), Some(policy)) = (&session, select_policy) {
-            let branch_for_policy = branches
-                .first()
-                .cloned()
-                .unwrap_or_else(|| "main".to_string());
-            let policy_node = PolicyFilterNode::new_with_branch_and_policy_mode(
+        // Policy filter node (if session provided and table needs SELECT policy routing)
+        if let Some(session) = &session
+            && needs_select_policy_filter(table_schema, row_policy_mode)
+        {
+            let policy_node = PolicyFilterNode::new_for_table_policy(
                 current_descriptor.clone(),
-                policy,
                 session.clone(),
                 schema.clone(),
                 plan.table.as_str(),
-                branch_for_policy,
-                row_policy_mode,
+                PolicyFilterOptions::for_branch(branch_context.policy_branch())
+                    .with_schema_context(schema_context)
+                    .with_row_policy_mode(row_policy_mode),
             );
             let inherits_tables: Vec<TableName> = policy_node
                 .inherits_tables()
@@ -720,7 +839,7 @@ impl QueryGraph {
                 subquery_spec,
                 &current_descriptor,
                 schema,
-                &branches,
+                branch_context.branches(),
                 schema_context,
                 session.as_ref(),
                 row_policy_mode,
@@ -783,10 +902,7 @@ impl QueryGraph {
                     &requests,
                     session.clone(),
                     schema.clone(),
-                    branches
-                        .first()
-                        .cloned()
-                        .unwrap_or_else(|| "main".to_string()),
+                    branch_context.policy_branch(),
                     row_policy_mode,
                 )?;
                 let dependency_tables: Vec<TableName> = magic_node
@@ -854,10 +970,7 @@ impl QueryGraph {
                     &requests,
                     session.clone(),
                     schema.clone(),
-                    branches
-                        .first()
-                        .cloned()
-                        .unwrap_or_else(|| "main".to_string()),
+                    branch_context.policy_branch(),
                     row_policy_mode,
                 )?;
                 let dependency_tables: Vec<TableName> = magic_node
@@ -902,7 +1015,7 @@ impl QueryGraph {
                 recursive_spec,
                 &current_descriptor,
                 schema,
-                &branches,
+                branch_context.branches(),
                 schema_context,
                 session.as_ref(),
                 row_policy_mode,
@@ -973,26 +1086,29 @@ impl QueryGraph {
         };
         ensure_relation_tables_exist(&query.relation_ir, schema)?;
 
-        let plan = lower_relation_to_execution_plan(
+        let features = RelationCompileFeatures {
+            include_deleted: query.include_deleted,
+            array_subqueries: query.array_subqueries.clone(),
+            select_columns: query.select_columns.clone(),
+        };
+
+        if let Some(plan) = lower_relation_to_execution_plan(
             &query.relation_ir,
             &branches,
-            query.include_deleted,
-            query.array_subqueries.clone(),
-            query.select_columns.clone(),
-        )
-        .ok_or_else(|| {
-            QueryCompileError::InvalidPlan(
-                "unsupported relation_ir shape for schema-context query compilation".to_string(),
-            )
-        })?;
+            features.include_deleted,
+            features.array_subqueries.clone(),
+            features.select_columns.clone(),
+        ) {
+            validate_execution_plan(&plan, schema)?;
+        }
 
-        validate_execution_plan(&plan, schema)?;
-
-        Self::compile_execution_plan_with_schema_context(
-            &plan,
+        Self::compile_relation_ir_with_schema_context_and_features(
+            &query.relation_ir,
             schema,
+            &branches,
             session,
             schema_context,
+            features,
             row_policy_mode,
         )
         .ok_or_else(|| {
@@ -1031,10 +1147,15 @@ impl QueryGraph {
             None => return None,
         };
 
-        // Build base query for subgraph, inheriting branches from outer query.
+        // Build base query for subgraph, using explicit subquery branches or inheriting outer branches.
         let mut base_builder = QueryBuilder::new(spec.table);
-        if !branches.is_empty() {
-            let branch_refs: Vec<&str> = branches.iter().map(String::as_str).collect();
+        let effective_branches = if spec.branches.is_empty() {
+            branches
+        } else {
+            &spec.branches
+        };
+        if !effective_branches.is_empty() {
+            let branch_refs: Vec<&str> = effective_branches.iter().map(String::as_str).collect();
             base_builder = base_builder.branches(&branch_refs);
         }
         for join_spec in &spec.joins {
@@ -1294,31 +1415,14 @@ impl QueryGraph {
     fn compile_join_plan(
         plan: &ExecutionQueryPlan,
         schema: &Schema,
-        branches: &[String],
+        branch_context: &BranchCompileContext,
         session: Option<Session>,
         schema_context: &SchemaContext,
         row_policy_mode: RowPolicyMode,
     ) -> Option<Self> {
-        let mut branch_schema_map: HashMap<String, SchemaHash> = HashMap::new();
-        for schema_hash in schema_context.all_live_hashes() {
-            let branch_name = ComposedBranchName::new(
-                &schema_context.env,
-                schema_hash,
-                &schema_context.user_branch,
-            )
-            .to_branch_name();
-            branch_schema_map.insert(branch_name.as_str().to_string(), schema_hash);
-        }
-
         let base_table_schema = schema.get(&plan.table)?;
         let base_descriptor = base_table_schema.columns.clone();
         let mut graph = QueryGraph::new(plan.table, base_descriptor.clone());
-
-        let join_branches: Vec<&str> = if branches.is_empty() {
-            vec!["main"]
-        } else {
-            branches.iter().map(String::as_str).collect()
-        };
 
         // Track all table names and descriptors for TupleDescriptor
         let mut table_names = vec![plan.base_scope.clone()];
@@ -1329,7 +1433,7 @@ impl QueryGraph {
             let seed_graph = Self::compile_relation_ir_with_schema_context_and_features(
                 seed_relation,
                 schema,
-                branches,
+                branch_context.branches(),
                 session.clone(),
                 schema_context,
                 RelationCompileFeatures::default(),
@@ -1352,41 +1456,13 @@ impl QueryGraph {
             table_descriptors[0] = seed_output_descriptor.clone();
             (seed_output_id, seed_output_descriptor)
         } else {
-            // Build pipeline for base table: per-branch IndexScan (+Union) -> Materialize.
-            let mut base_scan_ids = Vec::new();
-            for branch in &join_branches {
-                let branch_schema_hash = branch_schema_map.get(*branch).copied();
-                let Some(base_scan_table) = translate_scan_table_name(
-                    schema_context,
-                    plan.table.as_str(),
-                    branch_schema_hash,
-                ) else {
-                    continue;
-                };
-                let id_column = ColumnName::new("_id");
-                let base_scan = IndexScanNode::new_with_branch(
-                    base_scan_table,
-                    id_column,
-                    *branch,
-                    ScanCondition::All,
-                    base_descriptor.clone(),
-                );
-                let base_scan_id = graph.add_node(GraphNode::IndexScan(base_scan));
-                graph
-                    .index_scan_nodes
-                    .push((base_scan_id, base_scan_table, id_column));
-                base_scan_ids.push(base_scan_id);
-            }
-            let base_scan_output = if base_scan_ids.len() > 1 {
-                let union_node = UnionNode::new();
-                let union_id = graph.add_node(GraphNode::Union(union_node));
-                for scan_id in base_scan_ids {
-                    graph.add_edge(union_id, scan_id);
-                }
-                union_id
-            } else {
-                *base_scan_ids.first()?
-            };
+            let base_scan_output = graph.compile_branch_index_scans(
+                schema_context,
+                branch_context,
+                plan.table,
+                &base_descriptor,
+                &[BranchIndexScanSpec::raw("_id", ScanCondition::All)],
+            )?;
 
             let base_tuple_desc = TupleDescriptor::single_with_materialization(
                 plan.base_scope.as_str(),
@@ -1399,22 +1475,17 @@ impl QueryGraph {
 
             // Track current left side descriptor (accumulates columns from joins)
             let mut left_id = base_mat_id;
-            if let (Some(session), Some(policy)) = (
-                &session,
-                effective_select_policy(base_table_schema, row_policy_mode),
-            ) {
-                let branch_for_policy = branches
-                    .first()
-                    .cloned()
-                    .unwrap_or_else(|| "main".to_string());
-                let policy_node = PolicyFilterNode::new_with_branch_and_policy_mode(
+            if let Some(session) = &session
+                && needs_select_policy_filter(base_table_schema, row_policy_mode)
+            {
+                let policy_node = PolicyFilterNode::new_for_table_policy(
                     base_descriptor.clone(),
-                    policy,
                     session.clone(),
                     schema.clone(),
                     plan.table.as_str(),
-                    branch_for_policy,
-                    row_policy_mode,
+                    PolicyFilterOptions::for_branch(branch_context.policy_branch())
+                        .with_schema_context(schema_context)
+                        .with_row_policy_mode(row_policy_mode),
                 );
                 let inherits_tables: Vec<TableName> = policy_node
                     .inherits_tables()
@@ -1436,7 +1507,7 @@ impl QueryGraph {
                 recursive_spec,
                 &left_descriptor,
                 schema,
-                branches,
+                branch_context.branches(),
                 schema_context,
                 session.as_ref(),
                 row_policy_mode,
@@ -1464,41 +1535,13 @@ impl QueryGraph {
             let right_table_schema = schema.get(&join_spec.table)?;
             let right_descriptor = right_table_schema.columns.clone();
 
-            // Build pipeline for right table: per-branch IndexScan (+Union) -> Materialize.
-            let mut right_scan_ids = Vec::new();
-            for branch in &join_branches {
-                let branch_schema_hash = branch_schema_map.get(*branch).copied();
-                let Some(right_scan_table) = translate_scan_table_name(
-                    schema_context,
-                    join_spec.table.as_str(),
-                    branch_schema_hash,
-                ) else {
-                    continue;
-                };
-                let id_column = ColumnName::new("_id");
-                let right_scan = IndexScanNode::new_with_branch(
-                    right_scan_table,
-                    id_column,
-                    *branch,
-                    ScanCondition::All,
-                    right_descriptor.clone(),
-                );
-                let right_scan_id = graph.add_node(GraphNode::IndexScan(right_scan));
-                graph
-                    .index_scan_nodes
-                    .push((right_scan_id, right_scan_table, id_column));
-                right_scan_ids.push(right_scan_id);
-            }
-            let right_scan_output = if right_scan_ids.len() > 1 {
-                let union_node = UnionNode::new();
-                let union_id = graph.add_node(GraphNode::Union(union_node));
-                for scan_id in right_scan_ids {
-                    graph.add_edge(union_id, scan_id);
-                }
-                union_id
-            } else {
-                *right_scan_ids.first()?
-            };
+            let right_scan_output = graph.compile_branch_index_scans(
+                schema_context,
+                branch_context,
+                join_spec.table,
+                &right_descriptor,
+                &[BranchIndexScanSpec::raw("_id", ScanCondition::All)],
+            )?;
 
             let right_tuple_desc = TupleDescriptor::single_with_materialization(
                 join_spec.effective_name(),
@@ -1509,22 +1552,17 @@ impl QueryGraph {
             let right_mat_id = graph.add_node(GraphNode::Materialize(right_mat));
             graph.add_edge(right_mat_id, right_scan_output);
             let mut right_input_id = right_mat_id;
-            if let (Some(session), Some(policy)) = (
-                &session,
-                effective_select_policy(right_table_schema, row_policy_mode),
-            ) {
-                let branch_for_policy = branches
-                    .first()
-                    .cloned()
-                    .unwrap_or_else(|| "main".to_string());
-                let policy_node = PolicyFilterNode::new_with_branch_and_policy_mode(
+            if let Some(session) = &session
+                && needs_select_policy_filter(right_table_schema, row_policy_mode)
+            {
+                let policy_node = PolicyFilterNode::new_for_table_policy(
                     right_descriptor.clone(),
-                    policy,
                     session.clone(),
                     schema.clone(),
                     join_spec.table.as_str(),
-                    branch_for_policy,
-                    row_policy_mode,
+                    PolicyFilterOptions::for_branch(branch_context.policy_branch())
+                        .with_schema_context(schema_context)
+                        .with_row_policy_mode(row_policy_mode),
                 );
                 let inherits_tables: Vec<TableName> = policy_node
                     .inherits_tables()
@@ -1633,10 +1671,7 @@ impl QueryGraph {
                     &requests,
                     session.clone(),
                     schema.clone(),
-                    branches
-                        .first()
-                        .cloned()
-                        .unwrap_or_else(|| "main".to_string()),
+                    branch_context.policy_branch(),
                     row_policy_mode,
                 )?;
                 let dependency_tables: Vec<TableName> = magic_node
@@ -1701,10 +1736,7 @@ impl QueryGraph {
                     &requests,
                     session.clone(),
                     schema.clone(),
-                    branches
-                        .first()
-                        .cloned()
-                        .unwrap_or_else(|| "main".to_string()),
+                    branch_context.policy_branch(),
                     row_policy_mode,
                 )?;
                 let dependency_tables: Vec<TableName> = magic_node
@@ -1816,6 +1848,7 @@ fn ensure_relation_tables_exist(
             Ok(())
         }
         RelExpr::Filter { input, .. }
+        | RelExpr::Branch { input, .. }
         | RelExpr::Project { input, .. }
         | RelExpr::Distinct { input, .. }
         | RelExpr::OrderBy { input, .. }

--- a/crates/jazz-tools/src/query_manager/graph/execute.rs
+++ b/crates/jazz-tools/src/query_manager/graph/execute.rs
@@ -876,6 +876,7 @@ impl QueryGraph {
             .filter_map(|dep| match &self.nodes[dep.0 as usize].node {
                 GraphNode::IndexScan(n) => Some(n.current_tuples().clone()),
                 GraphNode::Union(n) => Some(n.current_tuples().clone()),
+                GraphNode::Output(n) => Some(n.current_tuples().clone()),
                 _ => None,
             })
             .collect()

--- a/crates/jazz-tools/src/query_manager/graph/mod.rs
+++ b/crates/jazz-tools/src/query_manager/graph/mod.rs
@@ -179,6 +179,19 @@ impl QueryGraph {
         self.nodes.get_mut(id.0 as usize).map(|c| &mut c.node)
     }
 
+    pub(crate) fn scan_branches(&self) -> Vec<String> {
+        let mut branches = Vec::new();
+        for compact in &self.nodes {
+            let GraphNode::IndexScan(scan) = &compact.node else {
+                continue;
+            };
+            if !branches.iter().any(|branch| branch == &scan.branch) {
+                branches.push(scan.branch.clone());
+            }
+        }
+        branches
+    }
+
     /// Get input edges for a node.
     pub(super) fn get_inputs(&self, id: NodeId) -> &[NodeId] {
         &self.nodes[id.0 as usize].inputs

--- a/crates/jazz-tools/src/query_manager/graph_nodes/policy_eval.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/policy_eval.rs
@@ -2,8 +2,8 @@ use std::collections::HashSet;
 
 use crate::object::ObjectId;
 use crate::query_manager::policy::{
-    Operation, PolicyExpr, bind_outer_row_refs, bind_relation_refs,
-    evaluate_expr_recursive_with_row_id, normalize_recursive_max_depth,
+    BranchPolicyContext, Operation, PolicyExpr, bind_branch_refs, bind_outer_row_refs,
+    bind_relation_refs, evaluate_expr_recursive_with_context, normalize_recursive_max_depth,
 };
 use crate::query_manager::policy_graph::PolicyGraph;
 use crate::query_manager::relation_ir::RelExpr;
@@ -21,6 +21,7 @@ pub(crate) struct PolicyContextEvaluator<'a> {
     session: &'a Session,
     branch: &'a str,
     row_policy_mode: RowPolicyMode,
+    branch_context: Option<&'a BranchPolicyContext<'a>>,
     settlement_eval_cache: Option<&'a mut SettlementEvalCache>,
 }
 
@@ -36,8 +37,17 @@ impl<'a> PolicyContextEvaluator<'a> {
             session,
             branch,
             row_policy_mode,
+            branch_context: None,
             settlement_eval_cache: None,
         }
+    }
+
+    pub(crate) fn with_branch_context(
+        mut self,
+        branch_context: &'a BranchPolicyContext<'a>,
+    ) -> Self {
+        self.branch_context = Some(branch_context);
+        self
     }
 
     pub(crate) fn with_settlement_eval_cache(
@@ -307,13 +317,14 @@ impl<'a> PolicyContextEvaluator<'a> {
                 visited,
                 visited_referencing,
             ),
-            _ => evaluate_expr_recursive_with_row_id(
+            _ => evaluate_expr_recursive_with_context(
                 expr,
                 &row.data,
                 &row.provenance,
                 descriptor,
                 self.session,
                 Some(row.id),
+                self.branch_context,
                 depth,
             ),
         }
@@ -466,6 +477,14 @@ impl<'a> PolicyContextEvaluator<'a> {
                 Some(expr) => expr,
                 None => return false,
             };
+        let bound_condition = if let Some(branch_context) = self.branch_context {
+            match bind_branch_refs(&bound_condition, branch_context) {
+                Some(expr) => expr,
+                None => return false,
+            }
+        } else {
+            bound_condition
+        };
 
         let table_name = TableName::new(table);
         let mut graph = match PolicyGraph::for_exists(
@@ -510,11 +529,17 @@ impl<'a> PolicyContextEvaluator<'a> {
             return false;
         }
 
-        let bound_rel =
-            match bind_relation_refs(rel, &row.data, descriptor, self.session, Some(row.id)) {
-                Some(expr) => expr,
-                None => return false,
-            };
+        let bound_rel = match bind_relation_refs(
+            rel,
+            &row.data,
+            descriptor,
+            self.session,
+            Some(row.id),
+            self.branch_context,
+        ) {
+            Some(expr) => expr,
+            None => return false,
+        };
 
         let current_table = TableName::new(table_name);
         let mut graph = match PolicyGraph::for_exists_rel(
@@ -615,6 +640,7 @@ fn collect_relation_tables(rel: &RelExpr, tables: &mut HashSet<String>) {
             }
         }
         RelExpr::Filter { input, .. }
+        | RelExpr::Branch { input, .. }
         | RelExpr::Project { input, .. }
         | RelExpr::Distinct { input, .. }
         | RelExpr::OrderBy { input, .. }

--- a/crates/jazz-tools/src/query_manager/graph_nodes/policy_filter.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/policy_filter.rs
@@ -6,19 +6,24 @@
 use ahash::AHashSet;
 use std::collections::HashSet;
 
-use crate::object::ObjectId;
+use crate::object::{BranchName, ObjectId};
 use crate::query_manager::encoding::column_is_null;
 use crate::query_manager::graph_nodes::policy_eval::{
     PolicyContextEvaluator, collect_policy_dependency_tables,
+};
+use crate::query_manager::permission_routing::{
+    BranchBackingResolution, PermissionRoute, ResolvedBranchPolicyBacking, branch_policy_scope,
+    resolve_permission_route_with_backing_loader,
 };
 use crate::query_manager::policy::{
     Operation, PolicyExpr, evaluate_expr_recursive, normalize_recursive_max_depth,
 };
 use crate::query_manager::session::Session;
 use crate::query_manager::types::{
-    LoadedRow, Row, RowDescriptor, RowPolicyMode, Schema, TableName, Tuple, TupleDelta,
-    TupleElement,
+    ComposedBranchName, LoadedRow, PermissionPhase, Row, RowDescriptor, RowPolicyMode, Schema,
+    SchemaHash, TableName, Tuple, TupleDelta, TupleElement,
 };
+use crate::schema_manager::{LensTransformer, SchemaContext};
 
 use crate::storage::Storage;
 
@@ -31,7 +36,7 @@ use super::RowNode;
 #[derive(Debug)]
 pub struct PolicyFilterNode {
     descriptor: RowDescriptor,
-    policy: PolicyExpr,
+    policy: Option<PolicyExpr>,
     policy_operation: Operation,
     session: Session,
     /// Schema for INHERITS lookups (resolving foreign key references).
@@ -40,6 +45,9 @@ pub struct PolicyFilterNode {
     table_name: String,
     /// Branch name for index lookups.
     branch: String,
+    /// Current authorization schema context, used to lens-transform branch
+    /// backing rows before exposing them as `$branch`.
+    schema_context: Option<SchemaContext>,
     row_policy_mode: RowPolicyMode,
     /// Initial recursion depth used for policy evaluation.
     initial_depth: usize,
@@ -59,6 +67,7 @@ pub struct PolicyFilterNode {
 #[derive(Debug)]
 pub(crate) struct PolicyFilterOptions {
     branch: String,
+    schema_context: Option<SchemaContext>,
     initial_depth: usize,
     row_policy_mode: RowPolicyMode,
     policy_operation: Operation,
@@ -77,6 +86,11 @@ impl PolicyFilterOptions {
         self
     }
 
+    pub(crate) fn with_schema_context(mut self, schema_context: &SchemaContext) -> Self {
+        self.schema_context = Some(schema_context.clone());
+        self
+    }
+
     pub(crate) fn with_row_policy_mode(mut self, row_policy_mode: RowPolicyMode) -> Self {
         self.row_policy_mode = row_policy_mode;
         self
@@ -92,6 +106,7 @@ impl Default for PolicyFilterOptions {
     fn default() -> Self {
         Self {
             branch: "main".to_string(),
+            schema_context: None,
             initial_depth: 0,
             row_policy_mode: RowPolicyMode::PermissiveLocal,
             policy_operation: Operation::Select,
@@ -134,25 +149,6 @@ impl PolicyFilterNode {
             schema,
             table_name,
             PolicyFilterOptions::for_branch(branch),
-        )
-    }
-
-    pub fn new_with_branch_and_policy_mode(
-        descriptor: RowDescriptor,
-        policy: PolicyExpr,
-        session: Session,
-        schema: Schema,
-        table_name: impl Into<String>,
-        branch: impl Into<String>,
-        row_policy_mode: RowPolicyMode,
-    ) -> Self {
-        Self::new_with_options(
-            descriptor,
-            policy,
-            session,
-            schema,
-            table_name,
-            PolicyFilterOptions::for_branch(branch).with_row_policy_mode(row_policy_mode),
         )
     }
 
@@ -207,19 +203,63 @@ impl PolicyFilterNode {
         table_name: impl Into<String>,
         options: PolicyFilterOptions,
     ) -> Self {
+        let policy = Some(policy);
+        Self::new_with_options_internal(descriptor, policy, session, schema, table_name, options)
+    }
+
+    pub(crate) fn new_for_table_policy(
+        descriptor: RowDescriptor,
+        session: Session,
+        schema: Schema,
+        table_name: impl Into<String>,
+        options: PolicyFilterOptions,
+    ) -> Self {
+        Self::new_with_options_internal(descriptor, None, session, schema, table_name, options)
+    }
+
+    fn new_with_options_internal(
+        descriptor: RowDescriptor,
+        policy: Option<PolicyExpr>,
+        session: Session,
+        schema: Schema,
+        table_name: impl Into<String>,
+        options: PolicyFilterOptions,
+    ) -> Self {
+        let PolicyFilterOptions {
+            branch,
+            schema_context,
+            initial_depth,
+            row_policy_mode,
+            policy_operation,
+        } = options;
         let table_name = table_name.into();
-        let inherits_tables = collect_policy_dependency_tables(&policy, &descriptor);
-        let has_inherits = !inherits_tables.is_empty();
+        let mut inherits_tables = policy
+            .as_ref()
+            .map(|policy| collect_policy_dependency_tables(policy, &descriptor))
+            .unwrap_or_default();
+        if policy.is_none()
+            && let Some(table_schema) = schema.get(&TableName::new(&table_name))
+            && let Some(table_policy) = table_schema
+                .policies
+                .policy_for_operation(policy_operation, PermissionPhase::Using)
+        {
+            inherits_tables.extend(collect_policy_dependency_tables(table_policy, &descriptor));
+        }
+        let (has_branch_policy, branch_dependency_tables) =
+            branch_policy_dependency_tables(&schema, &descriptor, &table_name, policy_operation);
+        inherits_tables.extend(branch_dependency_tables);
+        let has_inherits = has_branch_policy || !inherits_tables.is_empty();
         Self {
             descriptor,
             policy,
-            policy_operation: options.policy_operation,
+            policy_operation,
             session,
             schema,
             table_name,
-            branch: options.branch,
-            row_policy_mode: options.row_policy_mode,
-            initial_depth: options.initial_depth,
+            branch,
+            schema_context,
+            row_policy_mode,
+            initial_depth,
             current_tuples: AHashSet::new(),
             input_tuples: AHashSet::new(),
             dirty: true,
@@ -279,7 +319,8 @@ impl PolicyFilterNode {
                 continue;
             };
 
-            if self.evaluate_with_context(&row, io, &mut row_loader) {
+            let policy_branch = tuple_branch_for_row(&tuple, row.id, &self.branch);
+            if self.evaluate_with_context(&row, policy_branch, io, &mut row_loader) {
                 self.current_tuples.insert(tuple.clone());
                 result.added.push(tuple);
             }
@@ -302,10 +343,16 @@ impl PolicyFilterNode {
             let new_row = tuple_to_row(&new_tuple);
 
             let old_passes = old_row
-                .map(|r| self.evaluate_with_context(&r, io, &mut row_loader))
+                .map(|r| {
+                    let policy_branch = tuple_branch_for_row(&old_tuple, r.id, &self.branch);
+                    self.evaluate_with_context(&r, policy_branch, io, &mut row_loader)
+                })
                 .unwrap_or(false);
             let new_passes = new_row
-                .map(|r| self.evaluate_with_context(&r, io, &mut row_loader))
+                .map(|r| {
+                    let policy_branch = tuple_branch_for_row(&new_tuple, r.id, &self.branch);
+                    self.evaluate_with_context(&r, policy_branch, io, &mut row_loader)
+                })
                 .unwrap_or(false);
 
             match (old_passes, new_passes) {
@@ -340,7 +387,10 @@ impl PolicyFilterNode {
 
         for tuple in all_tuples {
             let passes = tuple_to_row(&tuple)
-                .map(|row| self.evaluate_with_context(&row, io, row_loader))
+                .map(|row| {
+                    let policy_branch = tuple_branch_for_row(&tuple, row.id, &self.branch);
+                    self.evaluate_with_context(&row, policy_branch, io, row_loader)
+                })
                 .unwrap_or(false);
             let currently_visible = self.current_tuples.contains(&tuple);
 
@@ -365,13 +415,28 @@ impl PolicyFilterNode {
     fn evaluate_with_context(
         &self,
         row: &Row,
+        policy_branch: BranchName,
         io: &dyn Storage,
         row_loader: &mut dyn FnMut(ObjectId, Option<TableName>) -> Option<LoadedRow>,
     ) -> bool {
+        if let Some(result) =
+            self.evaluate_branch_scoped_with_context(row, policy_branch, io, row_loader)
+        {
+            return result;
+        }
+
+        let policy = self
+            .policy
+            .as_ref()
+            .or_else(|| self.table_policy_for_current_operation());
+        let Some(policy) = policy else {
+            return !self.row_policy_mode.denies_missing_explicit_policy();
+        };
+
         let mut evaluator = PolicyContextEvaluator::new(
             &self.schema,
             &self.session,
-            &self.branch,
+            policy_branch.as_str(),
             self.row_policy_mode,
         );
         let mut visited_referencing = HashSet::new();
@@ -380,7 +445,7 @@ impl PolicyFilterNode {
             row,
             &self.descriptor,
             &self.table_name,
-            Some(&self.policy),
+            Some(policy),
             io,
             row_loader,
             self.initial_depth,
@@ -388,9 +453,231 @@ impl PolicyFilterNode {
         )
     }
 
+    fn evaluate_branch_scoped_with_context(
+        &self,
+        row: &Row,
+        policy_branch: BranchName,
+        io: &dyn Storage,
+        row_loader: &mut dyn FnMut(ObjectId, Option<TableName>) -> Option<LoadedRow>,
+    ) -> Option<bool> {
+        let target_table = TableName::new(&self.table_name);
+        let route = self.resolve_permission_route(io, policy_branch, target_table)?;
+        if route.is_denied() {
+            return Some(false);
+        }
+        let policy = route.policy_for_operation(self.policy_operation, PermissionPhase::Using);
+        let Some(policy) = policy else {
+            return Some(route.allows_missing_policy(self.policy_operation, self.row_policy_mode));
+        };
+
+        let branch_context = route.branch_context();
+        let mut evaluator = PolicyContextEvaluator::new(
+            &self.schema,
+            &self.session,
+            policy_branch.as_str(),
+            self.row_policy_mode,
+        );
+        if let Some(branch_context) = branch_context.as_ref() {
+            evaluator = evaluator.with_branch_context(branch_context);
+        }
+        let mut visited_referencing = HashSet::new();
+        Some(evaluator.evaluate_row_access(
+            self.policy_operation,
+            row,
+            &self.descriptor,
+            &self.table_name,
+            Some(policy),
+            io,
+            row_loader,
+            self.initial_depth,
+            &mut visited_referencing,
+        ))
+    }
+
+    fn resolve_permission_route(
+        &self,
+        io: &dyn Storage,
+        policy_branch: BranchName,
+        target_table: TableName,
+    ) -> Option<PermissionRoute<'_>> {
+        branch_policy_scope(&policy_branch)?;
+        Some(resolve_permission_route_with_backing_loader(
+            policy_branch,
+            target_table,
+            &self.schema,
+            self.row_policy_mode,
+            |backing_table, backing_schema, branch_object_id, current_branch| {
+                let Ok(Some(backing_row)) = io.load_visible_region_row(
+                    backing_table.as_str(),
+                    current_branch.as_str(),
+                    branch_object_id,
+                ) else {
+                    return BranchBackingResolution::NotFound;
+                };
+                if backing_row.is_hard_deleted() {
+                    return BranchBackingResolution::Denied;
+                }
+
+                let backing_provenance = backing_row.row_provenance();
+                let Some(backing_content) = self.transform_content_for_schema(
+                    backing_table.as_str(),
+                    &backing_row.data,
+                    backing_row.batch_id,
+                    current_branch,
+                ) else {
+                    return BranchBackingResolution::Denied;
+                };
+                let backing_policy = backing_schema.policies.select_policy();
+                let backing_allowed = if let Some(policy) = backing_policy {
+                    let backing_row_for_policy = Row::new(
+                        branch_object_id,
+                        backing_content.clone(),
+                        backing_row.batch_id,
+                        backing_provenance.clone(),
+                    );
+                    let mut evaluator = PolicyContextEvaluator::new(
+                        &self.schema,
+                        &self.session,
+                        current_branch.as_str(),
+                        self.row_policy_mode,
+                    );
+                    let mut visited_referencing = HashSet::new();
+                    let mut backing_dependency_loader =
+                        |id: ObjectId, table_hint: Option<TableName>| -> Option<LoadedRow> {
+                            let table_hint = table_hint?;
+                            let Ok(Some(row)) = io.load_visible_region_row(
+                                table_hint.as_str(),
+                                current_branch.as_str(),
+                                id,
+                            ) else {
+                                return None;
+                            };
+                            if row.is_hard_deleted() {
+                                return None;
+                            }
+                            let row_branch = BranchName::new(row.branch.as_str());
+                            let row_data = self.transform_content_for_schema(
+                                table_hint.as_str(),
+                                &row.data,
+                                row.batch_id,
+                                row_branch,
+                            )?;
+                            Some(LoadedRow::new(
+                                row_data,
+                                row.row_provenance(),
+                                [(id, row_branch)].into_iter().collect(),
+                                row.batch_id,
+                            ))
+                        };
+                    evaluator.evaluate_row_access(
+                        Operation::Select,
+                        &backing_row_for_policy,
+                        &backing_schema.columns,
+                        backing_table.as_str(),
+                        Some(policy),
+                        io,
+                        &mut backing_dependency_loader,
+                        0,
+                        &mut visited_referencing,
+                    )
+                } else {
+                    !self.row_policy_mode.denies_missing_explicit_policy()
+                };
+                if !backing_allowed {
+                    return BranchBackingResolution::Denied;
+                }
+
+                BranchBackingResolution::Found(ResolvedBranchPolicyBacking {
+                    backing_table: *backing_table,
+                    row_id: branch_object_id,
+                    descriptor: backing_schema.columns.clone(),
+                    content: backing_content,
+                    provenance: backing_provenance,
+                })
+            },
+        ))
+    }
+
+    fn transform_content_for_schema(
+        &self,
+        table: &str,
+        content: &[u8],
+        batch_id: crate::row_histories::BatchId,
+        branch_name: BranchName,
+    ) -> Option<Vec<u8>> {
+        let Some(schema_context) = &self.schema_context else {
+            return Some(content.to_vec());
+        };
+
+        let source_hash = self
+            .schema_hash_for_branch(schema_context, &branch_name)
+            .or_else(|| {
+                (branch_name.as_str() == schema_context.branch_name().as_str())
+                    .then_some(schema_context.current_hash)
+            })
+            .or_else(|| {
+                ComposedBranchName::parse(&branch_name).and_then(|composed| {
+                    self.find_schema_by_short_hash(schema_context, &composed.schema_hash)
+                })
+            });
+        let source_hash = match source_hash {
+            Some(source_hash) => source_hash,
+            None if ComposedBranchName::parse(&branch_name).is_some() => return None,
+            None => return Some(content.to_vec()),
+        };
+
+        if source_hash == schema_context.current_hash {
+            return Some(content.to_vec());
+        }
+
+        LensTransformer::new(schema_context, table)
+            .transform(content, batch_id, source_hash)
+            .ok()
+            .map(|result| result.data)
+    }
+
+    fn schema_hash_for_branch(
+        &self,
+        schema_context: &SchemaContext,
+        branch_name: &BranchName,
+    ) -> Option<SchemaHash> {
+        if branch_name.as_str() == schema_context.branch_name().as_str() {
+            return Some(schema_context.current_hash);
+        }
+
+        for hash in schema_context.live_schemas.keys() {
+            let live_branch =
+                ComposedBranchName::new(&schema_context.env, *hash, &schema_context.user_branch)
+                    .to_branch_name();
+            if live_branch.as_str() == branch_name.as_str() {
+                return Some(*hash);
+            }
+        }
+
+        None
+    }
+
+    fn find_schema_by_short_hash(
+        &self,
+        schema_context: &SchemaContext,
+        short_hash: &SchemaHash,
+    ) -> Option<SchemaHash> {
+        schema_context
+            .all_live_hashes()
+            .into_iter()
+            .find(|hash| hash.short() == short_hash.short())
+    }
+
     /// Evaluate the policy expression against a row.
     pub fn evaluate(&self, row: &Row) -> bool {
-        self.evaluate_expr(&self.policy, row, self.initial_depth)
+        let Some(policy) = self
+            .policy
+            .as_ref()
+            .or_else(|| self.table_policy_for_current_operation())
+        else {
+            return !self.row_policy_mode.denies_missing_explicit_policy();
+        };
+        self.evaluate_expr(policy, row, self.initial_depth)
     }
 
     /// Evaluate a policy expression with recursion depth tracking.
@@ -429,6 +716,16 @@ impl PolicyFilterNode {
                 depth,
             ),
         }
+    }
+
+    fn table_policy_for_current_operation(&self) -> Option<&PolicyExpr> {
+        self.schema
+            .get(&TableName::new(&self.table_name))
+            .and_then(|table_schema| {
+                table_schema
+                    .policies
+                    .policy_for_operation(self.policy_operation, PermissionPhase::Using)
+            })
     }
 
     /// Evaluate INHERITS without context - fails closed.
@@ -471,6 +768,40 @@ impl PolicyFilterNode {
         // that have INHERITS clauses.
         false
     }
+}
+
+fn branch_policy_dependency_tables(
+    schema: &Schema,
+    descriptor: &RowDescriptor,
+    table_name: &str,
+    policy_operation: Operation,
+) -> (bool, HashSet<String>) {
+    let Some(table_schema) = schema.get(&TableName::new(table_name)) else {
+        return (false, HashSet::new());
+    };
+    if table_schema.policies.for_branch.is_empty() {
+        return (false, HashSet::new());
+    }
+
+    let mut dependency_tables = HashSet::new();
+    for (backing_table, branch_policies) in &table_schema.policies.for_branch {
+        if let Some(branch_policy) =
+            branch_policies.policy_for_operation(policy_operation, PermissionPhase::Using)
+        {
+            dependency_tables.extend(collect_policy_dependency_tables(branch_policy, descriptor));
+        }
+        dependency_tables.insert(backing_table.as_str().to_string());
+        if let Some(backing_select) = schema.get(backing_table).and_then(|backing_schema| {
+            backing_schema
+                .policies
+                .select_policy()
+                .map(|policy| collect_policy_dependency_tables(policy, &backing_schema.columns))
+        }) {
+            dependency_tables.extend(backing_select);
+        }
+    }
+
+    (true, dependency_tables)
 }
 
 impl RowNode for PolicyFilterNode {
@@ -582,14 +913,26 @@ fn tuple_to_row(tuple: &Tuple) -> Option<Row> {
     }
 }
 
+fn tuple_branch_for_row(tuple: &Tuple, row_id: ObjectId, fallback_branch: &str) -> BranchName {
+    tuple
+        .provenance()
+        .iter()
+        .find_map(|(id, branch)| (*id == row_id).then_some(*branch))
+        .unwrap_or_else(|| BranchName::new(fallback_branch))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::object::ObjectId;
     use crate::query_manager::encoding::encode_row;
     use crate::query_manager::relation_ir::RelExpr;
-    use crate::query_manager::types::{ColumnDescriptor, ColumnType, TableName, Value};
+    use crate::query_manager::types::{
+        ColumnDescriptor, ColumnType, ComposedBranchName, SchemaHash, TableName, TablePolicies,
+        TableSchema, Value,
+    };
     use serde_json::json;
+    use std::collections::HashMap;
 
     fn test_descriptor() -> RowDescriptor {
         RowDescriptor::new(vec![
@@ -832,10 +1175,11 @@ mod tests {
         let storage = crate::storage::MemoryStorage::new();
         let mut seen = Vec::new();
 
-        let allowed = node.evaluate_with_context(&row, &storage, &mut |id, hint| {
-            seen.push((id, hint));
-            None
-        });
+        let allowed =
+            node.evaluate_with_context(&row, BranchName::new("main"), &storage, &mut |id, hint| {
+                seen.push((id, hint));
+                None
+            });
 
         assert!(!allowed);
         assert_eq!(seen, vec![(parent_id, Some(TableName::new("folders")))]);
@@ -858,6 +1202,57 @@ mod tests {
 
         assert!(node.has_inherits());
         assert!(node.inherits_tables().contains("memberships"));
+    }
+
+    #[test]
+    fn branch_policy_filter_registers_backing_select_dependency_tables() {
+        let mut doc_policies = TablePolicies::default();
+        doc_policies.for_branch = HashMap::from([(
+            TableName::new("branches"),
+            TablePolicies::new().with_select(PolicyExpr::True),
+        )]);
+        let mut schema = Schema::new();
+        schema.insert(
+            TableName::new("documents"),
+            TableSchema::with_policies(test_descriptor(), doc_policies),
+        );
+        schema.insert(
+            TableName::new("branches"),
+            TableSchema::builder("branches")
+                .column("owner_id", ColumnType::Text)
+                .policies(TablePolicies::new().with_select(PolicyExpr::Exists {
+                    table: "branch_access".into(),
+                    condition: Box::new(PolicyExpr::True),
+                }))
+                .build(),
+        );
+        schema.insert(
+            TableName::new("branch_access"),
+            TableSchema::builder("branch_access")
+                .column("owner_id", ColumnType::Text)
+                .policies(TablePolicies::new().with_select(PolicyExpr::True))
+                .build(),
+        );
+        let branch = ComposedBranchName::new(
+            "dev",
+            SchemaHash::compute(&schema),
+            &ObjectId::new().to_string(),
+        )
+        .to_branch_name()
+        .as_str()
+        .to_string();
+
+        let node = PolicyFilterNode::new_with_options(
+            test_descriptor(),
+            PolicyExpr::True,
+            Session::new("user1"),
+            schema,
+            "documents",
+            PolicyFilterOptions::for_branch(branch).with_row_policy_mode(RowPolicyMode::Enforcing),
+        );
+
+        assert!(node.inherits_tables().contains("branches"));
+        assert!(node.inherits_tables().contains("branch_access"));
     }
 
     #[test]

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -811,27 +811,53 @@ impl QueryManager {
         &self,
         session: Option<&Session>,
     ) -> bool {
-        session.is_some()
-            && self
-                .authorization_schema
-                .as_ref()
-                .map(|auth_schema| auth_schema.as_ref() != self.schema.as_ref())
-                .unwrap_or(false)
+        let (_, _, uses_explicit_authorization_filtering) =
+            self.local_subscription_compile_options(session);
+        uses_explicit_authorization_filtering
     }
 
-    pub(super) fn local_subscription_compile_schema(&self, session: Option<&Session>) -> Schema {
-        if self.local_subscription_uses_explicit_authorization(session) {
-            self.schema
-                .iter()
-                .map(|(table_name, table_schema)| {
-                    let mut structural = table_schema.clone();
-                    structural.policies = TablePolicies::default();
-                    (*table_name, structural)
-                })
-                .collect()
-        } else {
-            self.schema.as_ref().clone()
+    pub(super) fn local_subscription_compile_options(
+        &self,
+        session: Option<&Session>,
+    ) -> (Schema, RowPolicyMode, bool) {
+        Self::compile_options_with_authorization_schema(
+            self.schema.as_ref(),
+            self.authorization_schema.as_deref(),
+            self.row_policy_mode,
+            session,
+        )
+    }
+
+    pub(super) fn compile_options_with_authorization_schema(
+        structural_schema: &Schema,
+        authorization_schema: Option<&Schema>,
+        fallback_row_policy_mode: RowPolicyMode,
+        session: Option<&Session>,
+    ) -> (Schema, RowPolicyMode, bool) {
+        let Some(auth_schema) = authorization_schema.filter(|_| session.is_some()) else {
+            return (structural_schema.clone(), fallback_row_policy_mode, false);
+        };
+
+        if auth_schema == structural_schema {
+            return (structural_schema.clone(), fallback_row_policy_mode, false);
         }
+
+        (
+            Self::schema_without_policies(structural_schema),
+            RowPolicyMode::PermissiveLocal,
+            true,
+        )
+    }
+
+    pub(super) fn schema_without_policies(schema: &Schema) -> Schema {
+        schema
+            .iter()
+            .map(|(table_name, table_schema)| {
+                let mut structural = table_schema.clone();
+                structural.policies = TablePolicies::default();
+                (*table_name, structural)
+            })
+            .collect()
     }
 
     pub(crate) fn schema_has_any_explicit_policies(schema: &Schema) -> bool {
@@ -932,36 +958,18 @@ impl QueryManager {
         // Recompile local subscriptions
         for (sub_id, sub) in &mut self.subscriptions {
             if sub.needs_recompile {
-                // Resolve next branches from current schema context.
-                let next_branches: Vec<String> = current_schema_context
-                    .all_branch_names()
-                    .into_iter()
-                    .map(|b| b.as_str().to_string())
-                    .collect();
-                let uses_explicit_authorization_filtering = sub.session.is_some()
-                    && authorization_schema
-                        .as_ref()
-                        .map(|auth_schema| auth_schema.as_ref() != current_schema.as_ref())
-                        .unwrap_or(false);
-                let compile_schema = if uses_explicit_authorization_filtering {
-                    current_schema
-                        .iter()
-                        .map(|(table_name, table_schema)| {
-                            let mut structural = table_schema.clone();
-                            structural.policies = TablePolicies::default();
-                            (*table_name, structural)
-                        })
-                        .collect()
-                } else {
-                    current_schema.as_ref().clone()
-                };
+                let (
+                    compile_schema,
+                    compile_row_policy_mode,
+                    uses_explicit_authorization_filtering,
+                ) = Self::compile_options_with_authorization_schema(
+                    current_schema.as_ref(),
+                    authorization_schema.as_deref(),
+                    self.row_policy_mode,
+                    sub.session.as_ref(),
+                );
 
                 // Recompile the graph
-                let compile_row_policy_mode = if uses_explicit_authorization_filtering {
-                    RowPolicyMode::PermissiveLocal
-                } else {
-                    self.row_policy_mode
-                };
                 match Self::compile_graph(
                     &sub.query,
                     &compile_schema,
@@ -972,6 +980,11 @@ impl QueryManager {
                     Ok(new_graph) => {
                         let policy_context_tables =
                             Self::policy_context_tables_for_graph(&new_graph);
+                        let next_branches = Self::resolved_subscription_branches(
+                            &sub.query,
+                            &current_schema_context,
+                            &new_graph,
+                        );
                         sub.graph = new_graph;
                         sub.branches = next_branches;
                         sub.policy_context_tables = policy_context_tables;
@@ -1019,28 +1032,26 @@ impl QueryManager {
             if sub.needs_recompile {
                 let query_for_compile =
                     Self::query_for_server_compile(&sub.query, &sub.schema_context);
-                let compile_schema: Schema = sub
-                    .schema_context
-                    .current_schema
-                    .iter()
-                    .map(|(table_name, table_schema)| {
-                        let mut structural = table_schema.clone();
-                        structural.policies = TablePolicies::default();
-                        (*table_name, structural)
-                    })
-                    .collect();
+                let (compile_schema, compile_row_policy_mode, _) =
+                    Self::compile_options_with_authorization_schema(
+                        &sub.schema_context.current_schema,
+                        authorization_schema.as_deref(),
+                        self.row_policy_mode,
+                        sub.session.as_ref(),
+                    );
                 // Recompile the graph
                 match Self::compile_graph(
                     &query_for_compile,
                     &compile_schema,
                     sub.session.clone(),
                     &sub.schema_context,
-                    RowPolicyMode::PermissiveLocal,
+                    compile_row_policy_mode,
                 ) {
                     Ok(new_graph) => {
-                        sub.branches = Self::resolved_server_query_branches(
+                        sub.branches = Self::resolved_server_query_branches_for_graph(
                             &query_for_compile,
                             &sub.schema_context,
+                            &new_graph,
                         );
                         sub.graph = new_graph;
                         sub.needs_recompile = false;

--- a/crates/jazz-tools/src/query_manager/manager_tests/array_subqueries.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests/array_subqueries.rs
@@ -1689,6 +1689,65 @@ fn contributing_ids_for_array_subquery_include_inner_rows() {
 }
 
 #[test]
+// Array include branch materialization:
+//
+//   users on main branch
+//          |
+//          v
+//   include posts from draft branch
+//
+//   Row location                 Expected result
+//   ---------------------------  ------------------------
+//   users[Alice] on main         outer row is visible
+//   posts[Draft post] on draft   nested array has 1 row
+fn subscription_array_subquery_materializes_rows_from_explicit_inner_branch() {
+    let sync_manager = SyncManager::new();
+    let schema = users_posts_schema();
+    let (mut qm, mut storage) = create_query_manager(sync_manager, schema);
+    let draft_branch = get_branch_for_user_branch(&qm, "draft");
+
+    qm.insert(
+        &mut storage,
+        "users",
+        &[Value::Integer(1), Value::Text("Alice".into())],
+    )
+    .unwrap();
+    qm.insert_on_branch(
+        &mut storage,
+        "posts",
+        &draft_branch,
+        &[
+            Value::Integer(100),
+            Value::Text("Draft post".into()),
+            Value::Integer(1),
+        ],
+        None,
+    )
+    .unwrap();
+
+    let query = qm
+        .query("users")
+        .with_array("posts", |sub| {
+            sub.from("posts")
+                .branch(&draft_branch)
+                .correlate("author_id", "users.id")
+        })
+        .build();
+    let sub_id = qm.subscribe(query).unwrap();
+
+    qm.process(&mut storage);
+
+    let results = qm.get_subscription_results(sub_id);
+    assert_eq!(results.len(), 1, "outer main row should remain visible");
+    let posts = results[0].1[2].as_array().expect("posts array");
+    assert_eq!(
+        posts.len(),
+        1,
+        "array subquery should materialize rows from its explicit branch"
+    );
+}
+
+#[test]
 fn e2e_client_receives_array_subquery_server_data_via_subscription() {
     use crate::sync_manager::{ClientId, ServerId};
     use uuid::Uuid;

--- a/crates/jazz-tools/src/query_manager/manager_tests/branches.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests/branches.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::query_manager::relation_ir::{ColumnRef, OrderByExpr, OrderDirection, RelExpr};
 
 #[test]
 fn index_key_includes_branch() {
@@ -84,8 +85,9 @@ fn query_builder_explicit_main_branch() {
     )
     .unwrap();
 
-    // Explicit .branch("main") should work same as default
-    let query_explicit = qm.query("users").build();
+    // Explicit current/main branch should work same as default.
+    let main_branch = get_branch(&qm);
+    let query_explicit = qm.query("users").branch(&main_branch).build();
     let query_default = qm.query("users").build();
 
     let results_explicit = execute_query(&mut qm, &mut storage, query_explicit).unwrap();
@@ -121,6 +123,199 @@ fn query_on_composed_noncurrent_branch_reads_rows() {
     let results = execute_query(&mut qm, &mut storage, query).unwrap();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].1[0], Value::Text("Dora".into()));
+}
+
+#[test]
+fn union_query_with_branch_arms_reads_rows_from_each_branch() {
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let (mut qm, mut storage) = create_query_manager(sync_manager, schema);
+    let main_branch = get_branch(&qm);
+    let draft_branch = get_branch_for_user_branch(&qm, "draft");
+
+    qm.insert(
+        &mut storage,
+        "users",
+        &[Value::Text("Main Alice".into()), Value::Integer(100)],
+    )
+    .unwrap();
+    qm.insert_on_branch(
+        &mut storage,
+        "users",
+        &draft_branch,
+        &[Value::Text("Draft Dora".into()), Value::Integer(42)],
+        None,
+    )
+    .unwrap();
+
+    let mut query = qm.query("users").build();
+    query.relation_ir = RelExpr::Union {
+        inputs: vec![
+            RelExpr::Branch {
+                input: Box::new(RelExpr::TableScan {
+                    table: TableName::new("users"),
+                }),
+                branches: vec![main_branch],
+            },
+            RelExpr::Branch {
+                input: Box::new(RelExpr::TableScan {
+                    table: TableName::new("users"),
+                }),
+                branches: vec![draft_branch],
+            },
+        ],
+    };
+
+    let results = execute_query(&mut qm, &mut storage, query).unwrap();
+    let mut names: Vec<_> = results
+        .iter()
+        .map(|(_, values)| match &values[0] {
+            Value::Text(value) => value.clone(),
+            other => panic!("expected text name, got {other:?}"),
+        })
+        .collect();
+    names.sort();
+    assert_eq!(
+        names,
+        vec!["Draft Dora".to_string(), "Main Alice".to_string()]
+    );
+}
+
+#[test]
+fn branch_query_applies_order_by_and_limit_on_selected_branch() {
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let (mut qm, mut storage) = create_query_manager(sync_manager, schema);
+    let draft_branch = get_branch_for_user_branch(&qm, "draft");
+
+    qm.insert(
+        &mut storage,
+        "users",
+        &[Value::Text("Main Alice".into()), Value::Integer(999)],
+    )
+    .unwrap();
+    qm.insert_on_branch(
+        &mut storage,
+        "users",
+        &draft_branch,
+        &[Value::Text("Draft Low".into()), Value::Integer(10)],
+        None,
+    )
+    .unwrap();
+    qm.insert_on_branch(
+        &mut storage,
+        "users",
+        &draft_branch,
+        &[Value::Text("Draft High".into()), Value::Integer(30)],
+        None,
+    )
+    .unwrap();
+    qm.insert_on_branch(
+        &mut storage,
+        "users",
+        &draft_branch,
+        &[Value::Text("Draft Mid".into()), Value::Integer(20)],
+        None,
+    )
+    .unwrap();
+
+    let query = qm
+        .query("users")
+        .branch(&draft_branch)
+        .order_by_desc("score")
+        .limit(2)
+        .build();
+    let results = execute_query(&mut qm, &mut storage, query).unwrap();
+
+    assert_eq!(
+        results
+            .iter()
+            .map(|(_, values)| values[0].clone())
+            .collect::<Vec<_>>(),
+        vec![
+            Value::Text("Draft High".into()),
+            Value::Text("Draft Mid".into())
+        ]
+    );
+}
+
+#[test]
+fn union_query_with_branch_arms_applies_order_by_and_limit() {
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let (mut qm, mut storage) = create_query_manager(sync_manager, schema);
+    let main_branch = get_branch(&qm);
+    let draft_branch = get_branch_for_user_branch(&qm, "draft");
+
+    qm.insert(
+        &mut storage,
+        "users",
+        &[Value::Text("Main Low".into()), Value::Integer(10)],
+    )
+    .unwrap();
+    qm.insert(
+        &mut storage,
+        "users",
+        &[Value::Text("Main High".into()), Value::Integer(40)],
+    )
+    .unwrap();
+    qm.insert_on_branch(
+        &mut storage,
+        "users",
+        &draft_branch,
+        &[Value::Text("Draft Mid".into()), Value::Integer(30)],
+        None,
+    )
+    .unwrap();
+    qm.insert_on_branch(
+        &mut storage,
+        "users",
+        &draft_branch,
+        &[Value::Text("Draft Lower".into()), Value::Integer(20)],
+        None,
+    )
+    .unwrap();
+
+    let branch_union = RelExpr::Union {
+        inputs: vec![
+            RelExpr::Branch {
+                input: Box::new(RelExpr::TableScan {
+                    table: TableName::new("users"),
+                }),
+                branches: vec![main_branch],
+            },
+            RelExpr::Branch {
+                input: Box::new(RelExpr::TableScan {
+                    table: TableName::new("users"),
+                }),
+                branches: vec![draft_branch],
+            },
+        ],
+    };
+    let mut query = qm.query("users").build();
+    query.relation_ir = RelExpr::Limit {
+        input: Box::new(RelExpr::OrderBy {
+            input: Box::new(branch_union),
+            terms: vec![OrderByExpr {
+                column: ColumnRef::unscoped("score"),
+                direction: OrderDirection::Desc,
+            }],
+        }),
+        limit: 2,
+    };
+
+    let results = execute_query(&mut qm, &mut storage, query).unwrap();
+
+    assert_eq!(
+        results
+            .iter()
+            .map(|(_, values)| values[0].clone())
+            .collect::<Vec<_>>(),
+        vec![
+            Value::Text("Main High".into()),
+            Value::Text("Draft Mid".into())
+        ]
+    );
 }
 
 #[test]

--- a/crates/jazz-tools/src/query_manager/mod.rs
+++ b/crates/jazz-tools/src/query_manager/mod.rs
@@ -6,6 +6,7 @@ pub mod index;
 pub mod indices;
 pub mod magic_columns;
 pub mod manager;
+pub(crate) mod permission_routing;
 pub mod policy;
 pub mod policy_counters;
 pub mod policy_graph;

--- a/crates/jazz-tools/src/query_manager/permission_routing.rs
+++ b/crates/jazz-tools/src/query_manager/permission_routing.rs
@@ -1,0 +1,457 @@
+use std::collections::HashMap;
+
+use crate::metadata::RowProvenance;
+use crate::object::{BranchName, ObjectId};
+use crate::storage::Storage;
+
+use super::graph_nodes::policy_eval::PolicyContextEvaluator;
+use super::manager::QueryManager;
+use super::policy::{BranchPolicyContext, Operation, PolicyExpr};
+use super::session::Session;
+use super::settlement_eval_cache::SettlementEvalCache;
+use super::types::{
+    ComposedBranchName, PermissionPhase, Row, RowDescriptor, RowPolicyMode, Schema, SchemaHash,
+    TableName, TablePolicies, TableSchema,
+};
+
+/// Inputs for evaluating one already-selected policy expression.
+///
+/// This is the low-level evaluation shape: the caller has already decided which
+/// policy applies. `branch_context` is present only when a `forBranch` policy is
+/// being evaluated and `$branch.*` references need backing-row values.
+pub(crate) struct AuthorizationPolicyRequest<'a> {
+    pub(crate) object_id: ObjectId,
+    pub(crate) branch_name: BranchName,
+    pub(crate) table_name: TableName,
+    pub(crate) policy: &'a PolicyExpr,
+    pub(crate) content: &'a [u8],
+    pub(crate) provenance: &'a RowProvenance,
+    pub(crate) session: &'a Session,
+    pub(crate) auth_schema: &'a Schema,
+    pub(crate) auth_context: &'a crate::schema_manager::SchemaContext,
+    pub(crate) source_branch_schema_map: &'a HashMap<String, SchemaHash>,
+    pub(crate) operation: Operation,
+    pub(crate) settlement_eval_cache: Option<&'a mut SettlementEvalCache>,
+    pub(crate) branch_context: Option<&'a BranchPolicyContext<'a>>,
+}
+
+/// Inputs for evaluating a permission route.
+///
+/// This is the preferred shape for permission checks. The caller supplies the
+/// row and operation, while the route decides which policy expression applies
+/// and whether a missing policy should allow or deny.
+pub(crate) struct PermissionEvaluationRequest<'a> {
+    pub(crate) object_id: ObjectId,
+    pub(crate) branch_name: BranchName,
+    pub(crate) table_name: TableName,
+    pub(crate) content: &'a [u8],
+    pub(crate) provenance: &'a RowProvenance,
+    pub(crate) session: &'a Session,
+    pub(crate) auth_schema: &'a Schema,
+    pub(crate) auth_context: &'a crate::schema_manager::SchemaContext,
+    pub(crate) source_branch_schema_map: &'a HashMap<String, SchemaHash>,
+    pub(crate) operation: Operation,
+    pub(crate) phase: super::types::PermissionPhase,
+    pub(crate) settlement_eval_cache: Option<&'a mut SettlementEvalCache>,
+}
+
+/// Backing row resolved from a composed branch id for `forBranch` policies.
+///
+/// For a branch like `<env>/<schema>/<row-id>`, the user branch segment points
+/// at a row on the composed main branch. That row becomes the `$branch` context
+/// exposed to branch policies.
+pub(crate) struct ResolvedBranchPolicyBacking {
+    pub(crate) backing_table: TableName,
+    pub(crate) row_id: ObjectId,
+    pub(crate) descriptor: RowDescriptor,
+    pub(crate) content: Vec<u8>,
+    pub(crate) provenance: RowProvenance,
+}
+
+/// Permission route for a row.
+///
+/// Normal rows use table policies directly. Composed non-main branches never
+/// fall back to normal policies; they either use a resolved `forBranch` policy,
+/// carry no branch policy so missing-policy rules apply, or deny immediately.
+pub(crate) enum PermissionRoute<'a> {
+    Normal {
+        policies: &'a TablePolicies,
+    },
+    Branch {
+        policies: Option<&'a TablePolicies>,
+        backing: Option<ResolvedBranchPolicyBacking>,
+    },
+    Denied,
+}
+
+/// Result of evaluating a route.
+///
+/// Callers use this when they need different error messages for missing policy,
+/// route resolution failure, and policy expression failure.
+pub(crate) enum PermissionDecision {
+    Allowed,
+    DeniedRoute,
+    DeniedMissingPolicy,
+    DeniedPolicy,
+}
+
+/// Result of trying one `forBranch` backing table.
+///
+/// `NotFound` means this backing table did not contain the branch row, so the
+/// router may try another `forBranch` entry. `Denied` means a row existed or was
+/// otherwise resolved far enough to fail hard, so resolution must stop.
+pub(crate) enum BranchBackingResolution {
+    Found(ResolvedBranchPolicyBacking),
+    NotFound,
+    Denied,
+}
+
+pub(crate) fn branch_policy_scope(branch_name: &BranchName) -> Option<ComposedBranchName> {
+    ComposedBranchName::parse_non_main(branch_name)
+}
+
+pub(crate) fn branch_main_name(composed: &ComposedBranchName) -> BranchName {
+    ComposedBranchName::new(&composed.env, composed.schema_hash, "main").to_branch_name()
+}
+
+impl PermissionRoute<'_> {
+    pub(crate) fn policies(&self) -> Option<&TablePolicies> {
+        match self {
+            Self::Normal { policies } => Some(policies),
+            Self::Branch { policies, .. } => *policies,
+            Self::Denied => None,
+        }
+    }
+
+    pub(crate) fn is_branch(&self) -> bool {
+        matches!(self, Self::Branch { .. })
+    }
+
+    pub(crate) fn is_denied(&self) -> bool {
+        matches!(self, Self::Denied)
+    }
+
+    pub(crate) fn policy_for_operation(
+        &self,
+        operation: Operation,
+        phase: super::types::PermissionPhase,
+    ) -> Option<&PolicyExpr> {
+        self.policies()
+            .and_then(|policies| policies.policy_for_operation(operation, phase))
+    }
+
+    pub(crate) fn branch_context(&self) -> Option<BranchPolicyContext<'_>> {
+        match self {
+            Self::Branch {
+                backing: Some(backing),
+                ..
+            } => Some(BranchPolicyContext {
+                table_name: &backing.backing_table,
+                row_id: backing.row_id,
+                descriptor: &backing.descriptor,
+                content: &backing.content,
+                provenance: &backing.provenance,
+            }),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn allows_missing_policy(
+        &self,
+        operation: Operation,
+        row_policy_mode: RowPolicyMode,
+    ) -> bool {
+        let Some(policies) = self.policies() else {
+            return !row_policy_mode.denies_missing_explicit_policy();
+        };
+
+        if operation == Operation::Update && policies.has_explicit_update_policy() {
+            return true;
+        }
+
+        !row_policy_mode.denies_missing_explicit_policy()
+    }
+
+    pub(crate) fn missing_policy_decision(
+        &self,
+        operation: Operation,
+        row_policy_mode: RowPolicyMode,
+    ) -> PermissionDecision {
+        if self.allows_missing_policy(operation, row_policy_mode) {
+            PermissionDecision::Allowed
+        } else {
+            PermissionDecision::DeniedMissingPolicy
+        }
+    }
+
+    pub(crate) fn has_policy_for_operation(
+        &self,
+        operation: Operation,
+        phase: PermissionPhase,
+    ) -> bool {
+        self.policy_for_operation(operation, phase).is_some()
+    }
+}
+
+pub(crate) fn resolve_permission_route_with_backing_loader<'a, F>(
+    branch_name: BranchName,
+    table_name: TableName,
+    auth_schema: &'a Schema,
+    row_policy_mode: RowPolicyMode,
+    mut resolve_backing: F,
+) -> PermissionRoute<'a>
+where
+    F: FnMut(&TableName, &TableSchema, ObjectId, BranchName) -> BranchBackingResolution,
+{
+    // Routing owns the branch-shape rules. The caller-owned callback owns the
+    // storage/evaluation details, which differ between QueryManager and graph
+    // policy filters.
+    let Some(target_schema) = auth_schema.get(&table_name) else {
+        return PermissionRoute::Denied;
+    };
+    let Some(composed) = branch_policy_scope(&branch_name) else {
+        return PermissionRoute::Normal {
+            policies: &target_schema.policies,
+        };
+    };
+
+    if target_schema.policies.for_branch.is_empty() {
+        return PermissionRoute::Branch {
+            policies: None,
+            backing: None,
+        };
+    }
+
+    let Ok(branch_uuid) = uuid::Uuid::parse_str(&composed.user_branch) else {
+        return PermissionRoute::Denied;
+    };
+    let branch_object_id = ObjectId::from_uuid(branch_uuid);
+    let main_branch = branch_main_name(&composed);
+
+    for (backing_table, branch_policies) in &target_schema.policies.for_branch {
+        let Some(backing_schema) = auth_schema.get(backing_table) else {
+            return PermissionRoute::Denied;
+        };
+        let backing =
+            match resolve_backing(backing_table, backing_schema, branch_object_id, main_branch) {
+                BranchBackingResolution::Found(backing) => backing,
+                BranchBackingResolution::NotFound => continue,
+                BranchBackingResolution::Denied => return PermissionRoute::Denied,
+            };
+
+        return PermissionRoute::Branch {
+            policies: Some(branch_policies),
+            backing: Some(backing),
+        };
+    }
+
+    let _ = row_policy_mode;
+    PermissionRoute::Denied
+}
+
+impl QueryManager {
+    pub(crate) fn evaluate_authorization_policy(
+        &mut self,
+        storage: &dyn Storage,
+        request: AuthorizationPolicyRequest<'_>,
+    ) -> bool {
+        let AuthorizationPolicyRequest {
+            object_id,
+            branch_name,
+            table_name,
+            policy,
+            content,
+            provenance,
+            session,
+            auth_schema,
+            auth_context,
+            source_branch_schema_map,
+            operation,
+            settlement_eval_cache,
+            branch_context,
+        } = request;
+
+        let Some(table_schema) = auth_schema.get(&table_name) else {
+            return false;
+        };
+        let Some(transformed) = self.transform_content_to_authorization_schema(
+            table_name.as_str(),
+            content,
+            crate::row_histories::BatchId([0; 16]),
+            branch_name,
+            source_branch_schema_map,
+            auth_context,
+        ) else {
+            return false;
+        };
+
+        let mut evaluator = PolicyContextEvaluator::new(
+            auth_schema,
+            session,
+            branch_name.as_str(),
+            self.row_policy_mode,
+        )
+        .with_settlement_eval_cache(settlement_eval_cache);
+        if let Some(branch_context) = branch_context {
+            evaluator = evaluator.with_branch_context(branch_context);
+        }
+        let row = Row::new(
+            object_id,
+            transformed,
+            crate::row_histories::BatchId([0; 16]),
+            provenance.clone(),
+        );
+        let mut visited = std::collections::HashSet::new();
+        let mut row_loader = |related_id: ObjectId, _table_hint: Option<TableName>| {
+            self.load_row_for_authorization_context(
+                storage,
+                related_id,
+                branch_name,
+                source_branch_schema_map,
+                auth_context,
+            )
+        };
+
+        evaluator.evaluate_row_access(
+            operation,
+            &row,
+            &table_schema.columns,
+            table_name.as_str(),
+            Some(policy),
+            storage,
+            &mut row_loader,
+            0,
+            &mut visited,
+        )
+    }
+
+    pub(crate) fn evaluate_permission_route(
+        &mut self,
+        storage: &dyn Storage,
+        route: &PermissionRoute<'_>,
+        request: PermissionEvaluationRequest<'_>,
+    ) -> bool {
+        matches!(
+            self.evaluate_permission_route_decision(storage, route, request),
+            PermissionDecision::Allowed
+        )
+    }
+
+    pub(crate) fn evaluate_permission_route_decision(
+        &mut self,
+        storage: &dyn Storage,
+        route: &PermissionRoute<'_>,
+        request: PermissionEvaluationRequest<'_>,
+    ) -> PermissionDecision {
+        if route.is_denied() {
+            return PermissionDecision::DeniedRoute;
+        }
+        let Some(policy) = route
+            .policies()
+            .and_then(|policies| policies.policy_for_operation(request.operation, request.phase))
+        else {
+            return route.missing_policy_decision(request.operation, self.row_policy_mode);
+        };
+
+        let branch_context = route.branch_context();
+        if self.evaluate_authorization_policy(
+            storage,
+            AuthorizationPolicyRequest {
+                object_id: request.object_id,
+                branch_name: request.branch_name,
+                table_name: request.table_name,
+                policy,
+                content: request.content,
+                provenance: request.provenance,
+                session: request.session,
+                auth_schema: request.auth_schema,
+                auth_context: request.auth_context,
+                source_branch_schema_map: request.source_branch_schema_map,
+                operation: request.operation,
+                settlement_eval_cache: request.settlement_eval_cache,
+                branch_context: branch_context.as_ref(),
+            },
+        ) {
+            PermissionDecision::Allowed
+        } else {
+            PermissionDecision::DeniedPolicy
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn resolve_permission_route<'a>(
+        &mut self,
+        storage: &dyn Storage,
+        branch_name: BranchName,
+        table_name: TableName,
+        session: &Session,
+        auth_schema: &'a Schema,
+        auth_context: &crate::schema_manager::SchemaContext,
+        source_branch_schema_map: &HashMap<String, SchemaHash>,
+    ) -> PermissionRoute<'a> {
+        resolve_permission_route_with_backing_loader(
+            branch_name,
+            table_name,
+            auth_schema,
+            self.row_policy_mode,
+            |backing_table, backing_schema, branch_object_id, main_branch| {
+                let Ok(Some(backing_row)) = storage.load_visible_region_row(
+                    backing_table.as_str(),
+                    main_branch.as_str(),
+                    branch_object_id,
+                ) else {
+                    return BranchBackingResolution::NotFound;
+                };
+                if backing_row.is_hard_deleted() {
+                    return BranchBackingResolution::Denied;
+                };
+                let backing_provenance = backing_row.row_provenance();
+                let Some(transformed_backing_content) = self
+                    .transform_content_to_authorization_schema(
+                        backing_table.as_str(),
+                        &backing_row.data,
+                        backing_row.batch_id,
+                        main_branch,
+                        source_branch_schema_map,
+                        auth_context,
+                    )
+                else {
+                    return BranchBackingResolution::Denied;
+                };
+
+                if let Some(backing_select) = backing_schema.policies.select_policy() {
+                    if !self.evaluate_authorization_policy(
+                        storage,
+                        AuthorizationPolicyRequest {
+                            object_id: branch_object_id,
+                            branch_name: main_branch,
+                            table_name: *backing_table,
+                            policy: backing_select,
+                            content: &backing_row.data,
+                            provenance: &backing_provenance,
+                            session,
+                            auth_schema,
+                            auth_context,
+                            source_branch_schema_map,
+                            operation: Operation::Select,
+                            settlement_eval_cache: None,
+                            branch_context: None,
+                        },
+                    ) {
+                        return BranchBackingResolution::Denied;
+                    }
+                } else if self.row_policy_mode.denies_missing_explicit_policy() {
+                    return BranchBackingResolution::Denied;
+                }
+
+                BranchBackingResolution::Found(ResolvedBranchPolicyBacking {
+                    backing_table: *backing_table,
+                    row_id: branch_object_id,
+                    descriptor: backing_schema.columns.clone(),
+                    content: transformed_backing_content,
+                    provenance: backing_provenance,
+                })
+            },
+        )
+    }
+}

--- a/crates/jazz-tools/src/query_manager/policy.rs
+++ b/crates/jazz-tools/src/query_manager/policy.rs
@@ -8,8 +8,9 @@ use super::encoding::{column_is_null, decode_column};
 use super::magic_columns::{MagicColumnKind, magic_column_kind};
 use super::relation_ir::{PredicateExpr, RelExpr, RowIdRef, ValueRef};
 use super::session::Session;
-use super::types::{RowDescriptor, Value};
+use super::types::{ColumnName, RowDescriptor, TableName, Value};
 use crate::metadata::RowProvenance;
+use crate::object::ObjectId;
 use serde::{Deserialize, Serialize};
 
 /// Comparison operators for policy expressions.
@@ -31,6 +32,24 @@ pub enum PolicyValue {
     Literal(Value),
     /// Reference to a session variable, e.g., ["user_id"] or ["claims", "teams"].
     SessionRef(Vec<String>),
+    /// Reference to the resolved backing row for a branch-scoped policy.
+    BranchRef(ColumnName),
+}
+
+pub struct ResolvedBranchRow<'a> {
+    pub table_name: &'a TableName,
+    pub row_id: ObjectId,
+    pub descriptor: &'a RowDescriptor,
+    pub content: &'a [u8],
+    pub provenance: &'a RowProvenance,
+}
+
+pub type BranchPolicyContext<'a> = ResolvedBranchRow<'a>;
+
+#[derive(Clone, Copy, Default)]
+pub struct PolicyEvalRefs<'a> {
+    pub row_id: Option<ObjectId>,
+    pub branch: Option<&'a ResolvedBranchRow<'a>>,
 }
 
 /// Reserved session path prefix used to encode outer-row references in correlated EXISTS clauses.
@@ -197,6 +216,7 @@ pub enum PolicyExpr {
 enum PolicyValueSerde {
     Literal { value: Value },
     SessionRef { path: Vec<String> },
+    BranchRef { column: ColumnName },
 }
 
 impl From<PolicyValueSerde> for PolicyValue {
@@ -204,6 +224,7 @@ impl From<PolicyValueSerde> for PolicyValue {
         match value {
             PolicyValueSerde::Literal { value } => PolicyValue::Literal(value),
             PolicyValueSerde::SessionRef { path } => PolicyValue::SessionRef(path),
+            PolicyValueSerde::BranchRef { column } => PolicyValue::BranchRef(column),
         }
     }
 }
@@ -213,6 +234,7 @@ impl From<PolicyValue> for PolicyValueSerde {
         match value {
             PolicyValue::Literal(value) => PolicyValueSerde::Literal { value },
             PolicyValue::SessionRef(path) => PolicyValueSerde::SessionRef { path },
+            PolicyValue::BranchRef(column) => PolicyValueSerde::BranchRef { column },
         }
     }
 }
@@ -536,10 +558,9 @@ impl PolicyExpr {
 
 use std::collections::HashSet;
 
-use crate::object::ObjectId;
 use uuid::Uuid;
 
-use super::types::{Schema, TableName};
+use super::types::Schema;
 
 /// Context for policy evaluation with INHERITS support.
 pub struct EvalContext<'a, F>
@@ -549,6 +570,7 @@ where
     pub session: &'a Session,
     pub schema: &'a Schema,
     pub table_name: &'a TableName,
+    pub branch_context: Option<&'a BranchPolicyContext<'a>>,
     pub row_loader: F,
     /// Track visited ObjectIds to detect cycles in INHERITS chains.
     visited: HashSet<ObjectId>,
@@ -568,9 +590,15 @@ where
             session,
             schema,
             table_name,
+            branch_context: None,
             row_loader,
             visited: HashSet::new(),
         }
+    }
+
+    pub fn with_branch_context(mut self, branch_context: &'a BranchPolicyContext<'a>) -> Self {
+        self.branch_context = Some(branch_context);
+        self
     }
 }
 
@@ -618,6 +646,7 @@ where
             provenance,
             descriptor,
             ctx.session,
+            ctx.branch_context,
         ),
         PolicyExpr::SessionCmp { path, op, value } => {
             evaluate_session_cmp(path, op, value, ctx.session)
@@ -641,9 +670,15 @@ where
             matches!(resolve_session_value(path, ctx.session), Some(value) if !value.is_null())
         }
 
-        PolicyExpr::Contains { column, value } => {
-            evaluate_contains(column, value, content, provenance, descriptor, ctx.session)
-        }
+        PolicyExpr::Contains { column, value } => evaluate_contains(
+            column,
+            value,
+            content,
+            provenance,
+            descriptor,
+            ctx.session,
+            ctx.branch_context,
+        ),
         PolicyExpr::SessionContains { path, value } => {
             evaluate_session_contains(path, value, ctx.session)
         }
@@ -660,9 +695,15 @@ where
             ctx.session,
         ),
 
-        PolicyExpr::InList { column, values } => {
-            evaluate_in_list(column, values, content, provenance, descriptor, ctx.session)
-        }
+        PolicyExpr::InList { column, values } => evaluate_in_list(
+            column,
+            values,
+            content,
+            provenance,
+            descriptor,
+            ctx.session,
+            ctx.branch_context,
+        ),
         PolicyExpr::SessionInList { path, values } => {
             evaluate_session_in_list(path, values, ctx.session)
         }
@@ -811,6 +852,22 @@ fn evaluate_expr_simple_with_row_id(
     row_id: Option<ObjectId>,
     depth: usize,
 ) -> bool {
+    evaluate_expr_simple_with_branch_context(
+        expr, content, provenance, descriptor, session, row_id, None, depth,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn evaluate_expr_simple_with_branch_context(
+    expr: &PolicyExpr,
+    content: &[u8],
+    provenance: &RowProvenance,
+    descriptor: &RowDescriptor,
+    session: &Session,
+    row_id: Option<ObjectId>,
+    branch_context: Option<&BranchPolicyContext<'_>>,
+    depth: usize,
+) -> bool {
     if depth > RECURSIVE_POLICY_MAX_DEPTH_HARD_CAP {
         return false;
     }
@@ -819,7 +876,15 @@ fn evaluate_expr_simple_with_row_id(
         PolicyExpr::True => true,
         PolicyExpr::False => false,
         PolicyExpr::Cmp { column, op, value } => evaluate_cmp_with_row_id(
-            column, op, value, content, provenance, descriptor, session, row_id,
+            column,
+            op,
+            value,
+            content,
+            provenance,
+            descriptor,
+            session,
+            row_id,
+            branch_context,
         ),
         PolicyExpr::SessionCmp { path, op, value } => {
             evaluate_session_cmp(path, op, value, session)
@@ -841,7 +906,14 @@ fn evaluate_expr_simple_with_row_id(
             matches!(resolve_session_value(path, session), Some(value) if !value.is_null())
         }
         PolicyExpr::Contains { column, value } => evaluate_contains_with_row_id(
-            column, value, content, provenance, descriptor, session, row_id,
+            column,
+            value,
+            content,
+            provenance,
+            descriptor,
+            session,
+            row_id,
+            branch_context,
         ),
         PolicyExpr::SessionContains { path, value } => {
             evaluate_session_contains(path, value, session)
@@ -859,23 +931,51 @@ fn evaluate_expr_simple_with_row_id(
             row_id,
         ),
         PolicyExpr::InList { column, values } => evaluate_in_list_with_row_id(
-            column, values, content, provenance, descriptor, session, row_id,
+            column,
+            values,
+            content,
+            provenance,
+            descriptor,
+            session,
+            row_id,
+            branch_context,
         ),
         PolicyExpr::SessionInList { path, values } => {
             evaluate_session_in_list(path, values, session)
         }
         PolicyExpr::And(exprs) => exprs.iter().all(|e| {
-            evaluate_expr_simple_with_row_id(
-                e, content, provenance, descriptor, session, row_id, depth,
+            evaluate_expr_simple_with_branch_context(
+                e,
+                content,
+                provenance,
+                descriptor,
+                session,
+                row_id,
+                branch_context,
+                depth,
             )
         }),
         PolicyExpr::Or(exprs) => exprs.iter().any(|e| {
-            evaluate_expr_simple_with_row_id(
-                e, content, provenance, descriptor, session, row_id, depth,
+            evaluate_expr_simple_with_branch_context(
+                e,
+                content,
+                provenance,
+                descriptor,
+                session,
+                row_id,
+                branch_context,
+                depth,
             )
         }),
-        PolicyExpr::Not(inner) => !evaluate_expr_simple_with_row_id(
-            inner, content, provenance, descriptor, session, row_id, depth,
+        PolicyExpr::Not(inner) => !evaluate_expr_simple_with_branch_context(
+            inner,
+            content,
+            provenance,
+            descriptor,
+            session,
+            row_id,
+            branch_context,
+            depth,
         ),
         PolicyExpr::Exists { .. } => true,
         PolicyExpr::ExistsRel { .. } => true,
@@ -893,21 +993,33 @@ pub fn evaluate_expr_recursive(
     session: &Session,
     depth: usize,
 ) -> bool {
-    evaluate_expr_recursive_with_row_id(expr, content, provenance, descriptor, session, None, depth)
+    evaluate_expr_recursive_with_context(
+        expr, content, provenance, descriptor, session, None, None, depth,
+    )
 }
 
-pub fn evaluate_expr_recursive_with_row_id(
+#[allow(clippy::too_many_arguments)]
+pub fn evaluate_expr_recursive_with_context(
     expr: &PolicyExpr,
     content: &[u8],
     provenance: &RowProvenance,
     descriptor: &RowDescriptor,
     session: &Session,
     row_id: Option<ObjectId>,
+    branch_context: Option<&BranchPolicyContext<'_>>,
     depth: usize,
 ) -> bool {
-    evaluate_expr_simple_with_row_id(
-        expr, content, provenance, descriptor, session, row_id, depth,
-    )
+    let result = evaluate_simple_recursive(
+        expr,
+        content,
+        provenance,
+        descriptor,
+        session,
+        row_id,
+        branch_context,
+        depth,
+    );
+    result.passed && result.complex_clauses.is_empty()
 }
 
 fn provenance_value(kind: MagicColumnKind, provenance: &RowProvenance) -> Value {
@@ -967,12 +1079,13 @@ fn evaluate_cmp_with_row_id(
     descriptor: &RowDescriptor,
     session: &Session,
     row_id: Option<ObjectId>,
+    branch_context: Option<&BranchPolicyContext<'_>>,
 ) -> bool {
     let Some(left) = decode_policy_column_value(column, provenance, content, descriptor, row_id)
     else {
         return false;
     };
-    let Some(right) = resolve_policy_value(value, session) else {
+    let Some(right) = resolve_policy_value(value, session, branch_context) else {
         return false;
     };
     let right = normalize_cmp_value_for_decoded_column(&left, right);
@@ -989,6 +1102,7 @@ fn normalize_cmp_value_for_decoded_column(left: &Value, right: Value) -> Value {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn evaluate_cmp(
     column: &str,
     op: &CmpOp,
@@ -997,9 +1111,18 @@ pub fn evaluate_cmp(
     provenance: &RowProvenance,
     descriptor: &RowDescriptor,
     session: &Session,
+    branch_context: Option<&BranchPolicyContext<'_>>,
 ) -> bool {
     evaluate_cmp_with_row_id(
-        column, op, value, content, provenance, descriptor, session, None,
+        column,
+        op,
+        value,
+        content,
+        provenance,
+        descriptor,
+        session,
+        None,
+        branch_context,
     )
 }
 
@@ -1055,11 +1178,30 @@ fn compare_values_for_ordering(left: &Value, right: &Value) -> Option<std::cmp::
     }
 }
 
-fn resolve_policy_value(value: &PolicyValue, session: &Session) -> Option<Value> {
+fn resolve_policy_value(
+    value: &PolicyValue,
+    session: &Session,
+    branch_context: Option<&BranchPolicyContext<'_>>,
+) -> Option<Value> {
     match value {
         PolicyValue::Literal(v) => Some(v.clone()),
         PolicyValue::SessionRef(path) => resolve_session_value(path, session),
+        PolicyValue::BranchRef(column) => resolve_branch_ref(column.as_str(), branch_context),
     }
+}
+
+fn resolve_branch_ref(
+    column: &str,
+    branch_context: Option<&BranchPolicyContext<'_>>,
+) -> Option<Value> {
+    let context = branch_context?;
+    decode_policy_column_value(
+        column,
+        context.provenance,
+        context.content,
+        context.descriptor,
+        Some(context.row_id),
+    )
 }
 
 /// Resolve an outer-row column reference to a literal `Value`.
@@ -1096,31 +1238,45 @@ pub fn bind_outer_row_refs(
     outer_descriptor: &RowDescriptor,
     outer_row_id: Option<ObjectId>,
 ) -> Option<PolicyExpr> {
-    match expr {
-        PolicyExpr::Cmp { column, op, value } => {
-            let bound_value = match value {
-                PolicyValue::Literal(v) => PolicyValue::Literal(v.clone()),
-                PolicyValue::SessionRef(path) => {
-                    if let Some(outer_col) = outer_row_ref_column(path) {
-                        let resolved = resolve_outer_col(
-                            outer_col,
-                            outer_content,
-                            outer_descriptor,
-                            outer_row_id,
-                        )?;
-                        PolicyValue::Literal(resolved)
-                    } else {
-                        PolicyValue::SessionRef(path.clone())
-                    }
-                }
-            };
-
-            Some(PolicyExpr::Cmp {
-                column: column.clone(),
-                op: op.clone(),
-                value: bound_value,
-            })
+    bind_policy_values(expr, true, false, &mut |value| match value {
+        PolicyValue::SessionRef(path) => {
+            if let Some(outer_col) = outer_row_ref_column(path) {
+                Some(PolicyValue::Literal(resolve_outer_col(
+                    outer_col,
+                    outer_content,
+                    outer_descriptor,
+                    outer_row_id,
+                )?))
+            } else {
+                Some(value.clone())
+            }
         }
+        _ => Some(value.clone()),
+    })
+}
+
+fn outer_row_ref_column(path: &[String]) -> Option<&str> {
+    if path.len() != 2 {
+        return None;
+    }
+    if path[0] != OUTER_ROW_SESSION_PREFIX {
+        return None;
+    }
+    Some(path[1].as_str())
+}
+
+fn bind_policy_values(
+    expr: &PolicyExpr,
+    reject_outer_row_in_path: bool,
+    bind_nested_exists: bool,
+    bind_value: &mut impl FnMut(&PolicyValue) -> Option<PolicyValue>,
+) -> Option<PolicyExpr> {
+    match expr {
+        PolicyExpr::Cmp { column, op, value } => Some(PolicyExpr::Cmp {
+            column: column.clone(),
+            op: op.clone(),
+            value: bind_value(value)?,
+        }),
         PolicyExpr::SessionCmp { path, op, value } => Some(PolicyExpr::SessionCmp {
             path: path.clone(),
             op: op.clone(),
@@ -1138,28 +1294,10 @@ pub fn bind_outer_row_refs(
         PolicyExpr::SessionIsNotNull { path } => {
             Some(PolicyExpr::SessionIsNotNull { path: path.clone() })
         }
-        PolicyExpr::Contains { column, value } => {
-            let bound_value = match value {
-                PolicyValue::Literal(v) => PolicyValue::Literal(v.clone()),
-                PolicyValue::SessionRef(path) => {
-                    if let Some(outer_col) = outer_row_ref_column(path) {
-                        let resolved = resolve_outer_col(
-                            outer_col,
-                            outer_content,
-                            outer_descriptor,
-                            outer_row_id,
-                        )?;
-                        PolicyValue::Literal(resolved)
-                    } else {
-                        PolicyValue::SessionRef(path.clone())
-                    }
-                }
-            };
-            Some(PolicyExpr::Contains {
-                column: column.clone(),
-                value: bound_value,
-            })
-        }
+        PolicyExpr::Contains { column, value } => Some(PolicyExpr::Contains {
+            column: column.clone(),
+            value: bind_value(value)?,
+        }),
         PolicyExpr::SessionContains { path, value } => Some(PolicyExpr::SessionContains {
             path: path.clone(),
             value: value.clone(),
@@ -1168,7 +1306,7 @@ pub fn bind_outer_row_refs(
             column,
             session_path,
         } => {
-            if outer_row_ref_column(session_path).is_some() {
+            if reject_outer_row_in_path && outer_row_ref_column(session_path).is_some() {
                 return None;
             }
             Some(PolicyExpr::In {
@@ -1176,40 +1314,26 @@ pub fn bind_outer_row_refs(
                 session_path: session_path.clone(),
             })
         }
-        PolicyExpr::InList { column, values } => {
-            let bound_values = values
-                .iter()
-                .map(|value| match value {
-                    PolicyValue::Literal(v) => Some(PolicyValue::Literal(v.clone())),
-                    PolicyValue::SessionRef(path) => {
-                        if let Some(outer_col) = outer_row_ref_column(path) {
-                            let resolved = resolve_outer_col(
-                                outer_col,
-                                outer_content,
-                                outer_descriptor,
-                                outer_row_id,
-                            )?;
-                            Some(PolicyValue::Literal(resolved))
-                        } else {
-                            Some(PolicyValue::SessionRef(path.clone()))
-                        }
-                    }
-                })
-                .collect::<Option<Vec<_>>>()?;
-            Some(PolicyExpr::InList {
-                column: column.clone(),
-                values: bound_values,
-            })
-        }
+        PolicyExpr::InList { column, values } => Some(PolicyExpr::InList {
+            column: column.clone(),
+            values: values.iter().map(bind_value).collect::<Option<Vec<_>>>()?,
+        }),
         PolicyExpr::SessionInList { path, values } => Some(PolicyExpr::SessionInList {
             path: path.clone(),
             values: values.clone(),
         }),
         PolicyExpr::Exists { table, condition } => Some(PolicyExpr::Exists {
             table: table.clone(),
-            // Keep nested EXISTS conditions unbound at this level so they can be
-            // correlated against their immediate outer row when evaluated.
-            condition: condition.clone(),
+            condition: if bind_nested_exists {
+                Box::new(bind_policy_values(
+                    condition,
+                    reject_outer_row_in_path,
+                    bind_nested_exists,
+                    bind_value,
+                )?)
+            } else {
+                condition.clone()
+            },
         }),
         PolicyExpr::ExistsRel { rel } => Some(PolicyExpr::ExistsRel { rel: rel.clone() }),
         PolicyExpr::Inherits {
@@ -1236,7 +1360,12 @@ pub fn bind_outer_row_refs(
             exprs
                 .iter()
                 .map(|expr| {
-                    bind_outer_row_refs(expr, outer_content, outer_descriptor, outer_row_id)
+                    bind_policy_values(
+                        expr,
+                        reject_outer_row_in_path,
+                        bind_nested_exists,
+                        bind_value,
+                    )
                 })
                 .collect::<Option<Vec<_>>>()?,
         )),
@@ -1244,35 +1373,54 @@ pub fn bind_outer_row_refs(
             exprs
                 .iter()
                 .map(|expr| {
-                    bind_outer_row_refs(expr, outer_content, outer_descriptor, outer_row_id)
+                    bind_policy_values(
+                        expr,
+                        reject_outer_row_in_path,
+                        bind_nested_exists,
+                        bind_value,
+                    )
                 })
                 .collect::<Option<Vec<_>>>()?,
         )),
-        PolicyExpr::Not(expr) => Some(PolicyExpr::Not(Box::new(bind_outer_row_refs(
+        PolicyExpr::Not(expr) => Some(PolicyExpr::Not(Box::new(bind_policy_values(
             expr,
-            outer_content,
-            outer_descriptor,
-            outer_row_id,
+            reject_outer_row_in_path,
+            bind_nested_exists,
+            bind_value,
         )?))),
         PolicyExpr::True => Some(PolicyExpr::True),
         PolicyExpr::False => Some(PolicyExpr::False),
     }
 }
 
-fn outer_row_ref_column(path: &[String]) -> Option<&str> {
-    if path.len() != 2 {
-        return None;
+fn bind_branch_value_ref(
+    value: &PolicyValue,
+    branch_context: &BranchPolicyContext<'_>,
+) -> Option<PolicyValue> {
+    match value {
+        PolicyValue::Literal(value) => Some(PolicyValue::Literal(value.clone())),
+        PolicyValue::SessionRef(path) => Some(PolicyValue::SessionRef(path.clone())),
+        PolicyValue::BranchRef(column) => Some(PolicyValue::Literal(resolve_branch_ref(
+            column.as_str(),
+            Some(branch_context),
+        )?)),
     }
-    if path[0] != OUTER_ROW_SESSION_PREFIX {
-        return None;
-    }
-    Some(path[1].as_str())
+}
+
+pub fn bind_branch_refs(
+    expr: &PolicyExpr,
+    branch_context: &BranchPolicyContext<'_>,
+) -> Option<PolicyExpr> {
+    bind_policy_values(expr, false, true, &mut |value| {
+        bind_branch_value_ref(value, branch_context)
+    })
 }
 
 /// Bind relation references that depend on session or outer-row context.
 ///
 /// Rewrites:
 /// - `SessionRef(path)` => `Literal(resolve_session_value(path))`
+/// - `BranchRef(column)` => `Literal(resolve_branch_row_value(column))`
 /// - `OuterColumn(col)` => `Literal(outer_row[col])`
 /// - `RowId(Outer)` => `Literal(outer_row_id)` when provided
 ///
@@ -1283,6 +1431,7 @@ pub fn bind_relation_refs(
     outer_descriptor: &RowDescriptor,
     session: &Session,
     outer_row_id: Option<ObjectId>,
+    branch_context: Option<&BranchPolicyContext<'_>>,
 ) -> Option<RelExpr> {
     fn bind_value_ref(
         value_ref: &ValueRef,
@@ -1290,11 +1439,16 @@ pub fn bind_relation_refs(
         outer_descriptor: &RowDescriptor,
         session: &Session,
         outer_row_id: Option<ObjectId>,
+        branch_context: Option<&BranchPolicyContext<'_>>,
     ) -> Option<ValueRef> {
         match value_ref {
             ValueRef::Literal(value) => Some(ValueRef::Literal(value.clone())),
             ValueRef::SessionRef(path) => {
                 let resolved = resolve_session_value(path, session)?;
+                Some(ValueRef::Literal(resolved))
+            }
+            ValueRef::BranchRef(column) => {
+                let resolved = resolve_branch_ref(column, branch_context)?;
                 Some(ValueRef::Literal(resolved))
             }
             ValueRef::OuterColumn(column) => {
@@ -1321,6 +1475,7 @@ pub fn bind_relation_refs(
         outer_descriptor: &RowDescriptor,
         session: &Session,
         outer_row_id: Option<ObjectId>,
+        branch_context: Option<&BranchPolicyContext<'_>>,
     ) -> Option<PredicateExpr> {
         match predicate {
             PredicateExpr::Cmp { left, op, right } => Some(PredicateExpr::Cmp {
@@ -1332,6 +1487,7 @@ pub fn bind_relation_refs(
                     outer_descriptor,
                     session,
                     outer_row_id,
+                    branch_context,
                 )?,
             }),
             PredicateExpr::Contains { left, right } => Some(PredicateExpr::Contains {
@@ -1342,6 +1498,7 @@ pub fn bind_relation_refs(
                     outer_descriptor,
                     session,
                     outer_row_id,
+                    branch_context,
                 )?,
             }),
             PredicateExpr::IsNull { column } => Some(PredicateExpr::IsNull {
@@ -1361,6 +1518,7 @@ pub fn bind_relation_refs(
                             outer_descriptor,
                             session,
                             outer_row_id,
+                            branch_context,
                         )
                     })
                     .collect::<Option<Vec<_>>>()?,
@@ -1369,7 +1527,14 @@ pub fn bind_relation_refs(
                 exprs
                     .iter()
                     .map(|expr| {
-                        bind_predicate(expr, outer_content, outer_descriptor, session, outer_row_id)
+                        bind_predicate(
+                            expr,
+                            outer_content,
+                            outer_descriptor,
+                            session,
+                            outer_row_id,
+                            branch_context,
+                        )
                     })
                     .collect::<Option<Vec<_>>>()?,
             )),
@@ -1377,7 +1542,14 @@ pub fn bind_relation_refs(
                 exprs
                     .iter()
                     .map(|expr| {
-                        bind_predicate(expr, outer_content, outer_descriptor, session, outer_row_id)
+                        bind_predicate(
+                            expr,
+                            outer_content,
+                            outer_descriptor,
+                            session,
+                            outer_row_id,
+                            branch_context,
+                        )
                     })
                     .collect::<Option<Vec<_>>>()?,
             )),
@@ -1387,6 +1559,7 @@ pub fn bind_relation_refs(
                 outer_descriptor,
                 session,
                 outer_row_id,
+                branch_context,
             )?))),
             PredicateExpr::True => Some(PredicateExpr::True),
             PredicateExpr::False => Some(PredicateExpr::False),
@@ -1399,9 +1572,21 @@ pub fn bind_relation_refs(
         outer_descriptor: &RowDescriptor,
         session: &Session,
         outer_row_id: Option<ObjectId>,
+        branch_context: Option<&BranchPolicyContext<'_>>,
     ) -> Option<RelExpr> {
         match rel {
             RelExpr::TableScan { table } => Some(RelExpr::TableScan { table: *table }),
+            RelExpr::Branch { input, branches } => Some(RelExpr::Branch {
+                input: Box::new(bind_rel_expr(
+                    input,
+                    outer_content,
+                    outer_descriptor,
+                    session,
+                    outer_row_id,
+                    branch_context,
+                )?),
+                branches: branches.clone(),
+            }),
             RelExpr::Filter { input, predicate } => Some(RelExpr::Filter {
                 input: Box::new(bind_rel_expr(
                     input,
@@ -1409,6 +1594,7 @@ pub fn bind_relation_refs(
                     outer_descriptor,
                     session,
                     outer_row_id,
+                    branch_context,
                 )?),
                 predicate: bind_predicate(
                     predicate,
@@ -1416,6 +1602,7 @@ pub fn bind_relation_refs(
                     outer_descriptor,
                     session,
                     outer_row_id,
+                    branch_context,
                 )?,
             }),
             RelExpr::Union { inputs } => Some(RelExpr::Union {
@@ -1428,6 +1615,7 @@ pub fn bind_relation_refs(
                             outer_descriptor,
                             session,
                             outer_row_id,
+                            branch_context,
                         )
                     })
                     .collect::<Option<Vec<_>>>()?,
@@ -1444,6 +1632,7 @@ pub fn bind_relation_refs(
                     outer_descriptor,
                     session,
                     outer_row_id,
+                    branch_context,
                 )?),
                 right: Box::new(bind_rel_expr(
                     right,
@@ -1451,6 +1640,7 @@ pub fn bind_relation_refs(
                     outer_descriptor,
                     session,
                     outer_row_id,
+                    branch_context,
                 )?),
                 on: on.clone(),
                 join_kind: *join_kind,
@@ -1462,6 +1652,7 @@ pub fn bind_relation_refs(
                     outer_descriptor,
                     session,
                     outer_row_id,
+                    branch_context,
                 )?),
                 columns: columns.clone(),
             }),
@@ -1478,6 +1669,7 @@ pub fn bind_relation_refs(
                     outer_descriptor,
                     session,
                     outer_row_id,
+                    branch_context,
                 )?),
                 step: Box::new(bind_rel_expr(
                     step,
@@ -1485,6 +1677,7 @@ pub fn bind_relation_refs(
                     outer_descriptor,
                     session,
                     outer_row_id,
+                    branch_context,
                 )?),
                 frontier_key: frontier_key.clone(),
                 max_depth: *max_depth,
@@ -1497,6 +1690,7 @@ pub fn bind_relation_refs(
                     outer_descriptor,
                     session,
                     outer_row_id,
+                    branch_context,
                 )?),
                 key: key.clone(),
             }),
@@ -1507,6 +1701,7 @@ pub fn bind_relation_refs(
                     outer_descriptor,
                     session,
                     outer_row_id,
+                    branch_context,
                 )?),
                 terms: terms.clone(),
             }),
@@ -1517,6 +1712,7 @@ pub fn bind_relation_refs(
                     outer_descriptor,
                     session,
                     outer_row_id,
+                    branch_context,
                 )?),
                 offset: *offset,
             }),
@@ -1527,13 +1723,21 @@ pub fn bind_relation_refs(
                     outer_descriptor,
                     session,
                     outer_row_id,
+                    branch_context,
                 )?),
                 limit: *limit,
             }),
         }
     }
 
-    bind_rel_expr(rel, outer_content, outer_descriptor, session, outer_row_id)
+    bind_rel_expr(
+        rel,
+        outer_content,
+        outer_descriptor,
+        session,
+        outer_row_id,
+        branch_context,
+    )
 }
 
 /// Evaluate an IN expression. Public for use by PolicyFilterNode.
@@ -1592,6 +1796,7 @@ pub fn evaluate_in(
 }
 
 /// Evaluate a CONTAINS expression.
+#[allow(clippy::too_many_arguments)]
 fn evaluate_contains_with_row_id(
     column: &str,
     value: &PolicyValue,
@@ -1600,8 +1805,9 @@ fn evaluate_contains_with_row_id(
     descriptor: &RowDescriptor,
     session: &Session,
     row_id: Option<ObjectId>,
+    branch_context: Option<&BranchPolicyContext<'_>>,
 ) -> bool {
-    let right_value = match resolve_policy_value(value, session) {
+    let right_value = match resolve_policy_value(value, session, branch_context) {
         Some(v) => v,
         None => return false,
     };
@@ -1629,13 +1835,22 @@ pub fn evaluate_contains(
     provenance: &RowProvenance,
     descriptor: &RowDescriptor,
     session: &Session,
+    branch_context: Option<&BranchPolicyContext<'_>>,
 ) -> bool {
     evaluate_contains_with_row_id(
-        column, value, content, provenance, descriptor, session, None,
+        column,
+        value,
+        content,
+        provenance,
+        descriptor,
+        session,
+        None,
+        branch_context,
     )
 }
 
 /// Evaluate an IN-list expression.
+#[allow(clippy::too_many_arguments)]
 fn evaluate_in_list_with_row_id(
     column: &str,
     values: &[PolicyValue],
@@ -1644,6 +1859,7 @@ fn evaluate_in_list_with_row_id(
     descriptor: &RowDescriptor,
     session: &Session,
     row_id: Option<ObjectId>,
+    branch_context: Option<&BranchPolicyContext<'_>>,
 ) -> bool {
     if values.is_empty() {
         return false;
@@ -1656,7 +1872,7 @@ fn evaluate_in_list_with_row_id(
         };
 
     values.iter().any(|candidate| {
-        resolve_policy_value(candidate, session)
+        resolve_policy_value(candidate, session, branch_context)
             .map(|resolved| resolved == column_value)
             .unwrap_or(false)
     })
@@ -1669,9 +1885,17 @@ pub fn evaluate_in_list(
     provenance: &RowProvenance,
     descriptor: &RowDescriptor,
     session: &Session,
+    branch_context: Option<&BranchPolicyContext<'_>>,
 ) -> bool {
     evaluate_in_list_with_row_id(
-        column, values, content, provenance, descriptor, session, None,
+        column,
+        values,
+        content,
+        provenance,
+        descriptor,
+        session,
+        None,
+        branch_context,
     )
 }
 
@@ -1846,9 +2070,40 @@ pub fn evaluate_simple_parts_with_row_id(
     session: &Session,
     row_id: Option<ObjectId>,
 ) -> SimpleEvalResult {
-    evaluate_simple_recursive(expr, content, provenance, descriptor, session, row_id, 0)
+    evaluate_simple_parts_with_context(
+        expr,
+        content,
+        provenance,
+        descriptor,
+        session,
+        PolicyEvalRefs {
+            row_id,
+            branch: None,
+        },
+    )
 }
 
+pub fn evaluate_simple_parts_with_context(
+    expr: &PolicyExpr,
+    content: &[u8],
+    provenance: &RowProvenance,
+    descriptor: &RowDescriptor,
+    session: &Session,
+    refs: PolicyEvalRefs<'_>,
+) -> SimpleEvalResult {
+    evaluate_simple_recursive(
+        expr,
+        content,
+        provenance,
+        descriptor,
+        session,
+        refs.row_id,
+        refs.branch,
+        0,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
 fn evaluate_simple_recursive(
     expr: &PolicyExpr,
     content: &[u8],
@@ -1856,6 +2111,7 @@ fn evaluate_simple_recursive(
     descriptor: &RowDescriptor,
     session: &Session,
     row_id: Option<ObjectId>,
+    branch_context: Option<&BranchPolicyContext<'_>>,
     depth: usize,
 ) -> SimpleEvalResult {
     // Prevent infinite recursion
@@ -1869,7 +2125,15 @@ fn evaluate_simple_recursive(
 
         PolicyExpr::Cmp { column, op, value } => {
             if evaluate_cmp_with_row_id(
-                column, op, value, content, provenance, descriptor, session, row_id,
+                column,
+                op,
+                value,
+                content,
+                provenance,
+                descriptor,
+                session,
+                row_id,
+                branch_context,
             ) {
                 SimpleEvalResult::pass()
             } else {
@@ -1924,7 +2188,14 @@ fn evaluate_simple_recursive(
 
         PolicyExpr::Contains { column, value } => {
             if evaluate_contains_with_row_id(
-                column, value, content, provenance, descriptor, session, row_id,
+                column,
+                value,
+                content,
+                provenance,
+                descriptor,
+                session,
+                row_id,
+                branch_context,
             ) {
                 SimpleEvalResult::pass()
             } else {
@@ -1967,7 +2238,14 @@ fn evaluate_simple_recursive(
 
         PolicyExpr::InList { column, values } => {
             if evaluate_in_list_with_row_id(
-                column, values, content, provenance, descriptor, session, row_id,
+                column,
+                values,
+                content,
+                provenance,
+                descriptor,
+                session,
+                row_id,
+                branch_context,
             ) {
                 SimpleEvalResult::pass()
             } else {
@@ -1979,7 +2257,14 @@ fn evaluate_simple_recursive(
             let mut all_complex = Vec::new();
             for e in exprs {
                 let result = evaluate_simple_recursive(
-                    e, content, provenance, descriptor, session, row_id, depth,
+                    e,
+                    content,
+                    provenance,
+                    descriptor,
+                    session,
+                    row_id,
+                    branch_context,
+                    depth,
                 );
                 if !result.passed {
                     return SimpleEvalResult::fail();
@@ -2002,7 +2287,14 @@ fn evaluate_simple_recursive(
 
             for e in exprs {
                 let result = evaluate_simple_recursive(
-                    e, content, provenance, descriptor, session, row_id, depth,
+                    e,
+                    content,
+                    provenance,
+                    descriptor,
+                    session,
+                    row_id,
+                    branch_context,
+                    depth,
                 );
                 if result.passed && result.complex_clauses.is_empty() {
                     // Simple pass - entire OR passes
@@ -2031,7 +2323,14 @@ fn evaluate_simple_recursive(
 
         PolicyExpr::Not(inner) => {
             let result = evaluate_simple_recursive(
-                inner, content, provenance, descriptor, session, row_id, depth,
+                inner,
+                content,
+                provenance,
+                descriptor,
+                session,
+                row_id,
+                branch_context,
+                depth,
             );
             if !result.complex_clauses.is_empty() {
                 // NOT of complex clause is complex - can't evaluate simply
@@ -2082,10 +2381,11 @@ fn evaluate_simple_recursive(
             })
         }
         PolicyExpr::ExistsRel { rel } => {
-            let bound = match bind_relation_refs(rel, content, descriptor, session, None) {
-                Some(expr) => expr,
-                None => return SimpleEvalResult::fail(),
-            };
+            let bound =
+                match bind_relation_refs(rel, content, descriptor, session, None, branch_context) {
+                    Some(expr) => expr,
+                    None => return SimpleEvalResult::fail(),
+                };
             SimpleEvalResult::with_complex(ComplexClause::ExistsRel { rel: bound })
         }
     }
@@ -2407,7 +2707,7 @@ mod tests {
             },
         };
 
-        let bound = bind_relation_refs(&rel, &content, &descriptor, &session, Some(row_id))
+        let bound = bind_relation_refs(&rel, &content, &descriptor, &session, Some(row_id), None)
             .expect("bind relation refs");
 
         let RelExpr::Filter { predicate, .. } = bound else {
@@ -2420,6 +2720,60 @@ mod tests {
                 op: crate::query_manager::relation_ir::PredicateCmpOp::Eq,
                 right: ValueRef::Literal(Value::Uuid(bound_id)),
             } if left.column == "todo_id" && bound_id == row_id
+        ));
+    }
+
+    #[test]
+    fn test_bind_relation_refs_branch_ref_binds_to_branch_row_literal() {
+        let descriptor = RowDescriptor::new(vec![ColumnDescriptor::new("title", ColumnType::Text)]);
+        let content = encode_row(&descriptor, &[Value::Text("Doc 1".into())]).unwrap();
+        let session = Session::new("user-1");
+        let project_id = ObjectId::from_uuid(uuid::Uuid::from_u128(
+            0xfeed_face_cafe_0000_0000_0000_0000_0002,
+        ));
+        let branch_descriptor =
+            RowDescriptor::new(vec![ColumnDescriptor::new("projectId", ColumnType::Uuid)]);
+        let branch_content = encode_row(&branch_descriptor, &[Value::Uuid(project_id)]).unwrap();
+        let branch_provenance = test_row_provenance();
+        let branch_context = BranchPolicyContext {
+            table_name: &TableName::new("branches"),
+            row_id: ObjectId::new(),
+            descriptor: &branch_descriptor,
+            content: &branch_content,
+            provenance: &branch_provenance,
+        };
+
+        let rel = RelExpr::Filter {
+            input: Box::new(RelExpr::TableScan {
+                table: TableName::new("projects"),
+            }),
+            predicate: PredicateExpr::Cmp {
+                left: crate::query_manager::relation_ir::ColumnRef::unscoped("id"),
+                op: crate::query_manager::relation_ir::PredicateCmpOp::Eq,
+                right: ValueRef::BranchRef("projectId".into()),
+            },
+        };
+
+        let bound = bind_relation_refs(
+            &rel,
+            &content,
+            &descriptor,
+            &session,
+            None,
+            Some(&branch_context),
+        )
+        .expect("bind relation refs");
+
+        let RelExpr::Filter { predicate, .. } = bound else {
+            panic!("expected bound filter relation");
+        };
+        assert!(matches!(
+            predicate,
+            PredicateExpr::Cmp {
+                left,
+                op: crate::query_manager::relation_ir::PredicateCmpOp::Eq,
+                right: ValueRef::Literal(Value::Uuid(bound_id)),
+            } if left.column == "id" && bound_id == project_id
         ));
     }
 

--- a/crates/jazz-tools/src/query_manager/query.rs
+++ b/crates/jazz-tools/src/query_manager/query.rs
@@ -5,7 +5,10 @@ use crate::query_manager::encoding::encode_value_with_type;
 use crate::query_manager::graph_nodes::filter::Predicate;
 use crate::query_manager::graph_nodes::sort::{SortDirection, SortKey, SortTarget};
 use crate::query_manager::magic_columns::is_magic_column_name;
-use crate::query_manager::types::{ColumnType, RowDescriptor, TableName, TupleDescriptor, Value};
+use crate::query_manager::types::{
+    ColumnType, ComposedBranchName, RowDescriptor, TableName, TupleDescriptor, Value,
+};
+use crate::schema_manager::SchemaContext;
 
 use super::query_to_relation_ir::normalize_query_to_rel_expr;
 use super::relation_ir::ColumnRef;
@@ -496,6 +499,9 @@ pub struct ArraySubquerySpec {
     /// Optional requirement for whether the correlated result must exist.
     #[serde(default)]
     pub requirement: ArraySubqueryRequirement,
+    /// Branches to query for this array subquery. Empty means inherit outer query branches.
+    #[serde(default)]
+    pub branches: Vec<String>,
     /// Nested array subqueries (for recursive structures).
     pub nested_arrays: Vec<ArraySubquerySpec>,
 }
@@ -514,6 +520,7 @@ impl ArraySubquerySpec {
             order_by: Vec::new(),
             limit: None,
             requirement: ArraySubqueryRequirement::Optional,
+            branches: Vec::new(),
             nested_arrays: Vec::new(),
         }
     }
@@ -618,6 +625,83 @@ fn default_disjuncts() -> Vec<Conjunction> {
 }
 
 impl Query {
+    fn runtime_branch_for_logical_branch(
+        schema_context: &SchemaContext,
+        user_branch: &str,
+    ) -> String {
+        ComposedBranchName::new(
+            &schema_context.env,
+            schema_context.current_hash,
+            user_branch,
+        )
+        .to_branch_name()
+        .as_str()
+        .to_string()
+    }
+
+    fn compose_logical_branch_list(branches: &mut [String], schema_context: &SchemaContext) {
+        for branch in branches {
+            *branch = Self::runtime_branch_for_logical_branch(schema_context, branch);
+        }
+    }
+
+    fn compose_logical_array_subquery_branches(
+        specs: &mut [ArraySubquerySpec],
+        schema_context: &SchemaContext,
+    ) {
+        for spec in specs {
+            Self::compose_logical_branch_list(&mut spec.branches, schema_context);
+            Self::compose_logical_array_subquery_branches(&mut spec.nested_arrays, schema_context);
+        }
+    }
+
+    fn compose_logical_relation_branches(
+        relation: &mut crate::query_manager::relation_ir::RelExpr,
+        schema_context: &SchemaContext,
+    ) {
+        use crate::query_manager::relation_ir::RelExpr;
+
+        match relation {
+            RelExpr::TableScan { .. } => {}
+            RelExpr::Branch { input, branches } => {
+                Self::compose_logical_branch_list(branches, schema_context);
+                Self::compose_logical_relation_branches(input, schema_context);
+            }
+            RelExpr::Filter { input, .. }
+            | RelExpr::Project { input, .. }
+            | RelExpr::Distinct { input, .. }
+            | RelExpr::OrderBy { input, .. }
+            | RelExpr::Offset { input, .. }
+            | RelExpr::Limit { input, .. } => {
+                Self::compose_logical_relation_branches(input, schema_context);
+            }
+            RelExpr::Union { inputs } => {
+                for input in inputs {
+                    Self::compose_logical_relation_branches(input, schema_context);
+                }
+            }
+            RelExpr::Join { left, right, .. } => {
+                Self::compose_logical_relation_branches(left, schema_context);
+                Self::compose_logical_relation_branches(right, schema_context);
+            }
+            RelExpr::Gather { seed, step, .. } => {
+                Self::compose_logical_relation_branches(seed, schema_context);
+                Self::compose_logical_relation_branches(step, schema_context);
+            }
+        }
+    }
+
+    /// Convert public query branch ids into runtime branch names for this schema context.
+    ///
+    /// This is called at runtime API ingress. QueryManager internals still use
+    /// composed branch names so internal callers can keep constructing
+    /// low-level queries directly.
+    pub fn compose_logical_branches_for_context(&mut self, schema_context: &SchemaContext) {
+        Self::compose_logical_branch_list(&mut self.branches, schema_context);
+        Self::compose_logical_array_subquery_branches(&mut self.array_subqueries, schema_context);
+        Self::compose_logical_relation_branches(&mut self.relation_ir, schema_context);
+    }
+
     fn validate_conditions(conditions: &[Condition]) -> Result<(), QueryBuildError> {
         for condition in conditions {
             match condition {
@@ -687,6 +771,23 @@ impl Query {
     /// Check if this query has array subqueries.
     pub fn has_array_subqueries(&self) -> bool {
         !self.array_subqueries.is_empty()
+    }
+
+    pub(crate) fn explicit_array_subquery_branches(&self) -> Vec<String> {
+        fn collect(specs: &[ArraySubquerySpec], branches: &mut Vec<String>) {
+            for spec in specs {
+                for branch in &spec.branches {
+                    if !branches.iter().any(|existing| existing == branch) {
+                        branches.push(branch.clone());
+                    }
+                }
+                collect(&spec.nested_arrays, branches);
+            }
+        }
+
+        let mut branches = Vec::new();
+        collect(&self.array_subqueries, &mut branches);
+        branches
     }
 
     /// Check if this query has a recursive expansion.
@@ -1091,6 +1192,7 @@ pub struct ArraySubqueryBuilder {
     order_by: Vec<(String, SortDirection)>,
     limit: Option<usize>,
     requirement: ArraySubqueryRequirement,
+    branches: Vec<String>,
     nested_arrays: Vec<ArraySubquerySpec>,
 }
 
@@ -1108,6 +1210,7 @@ impl ArraySubqueryBuilder {
             order_by: Vec::new(),
             limit: None,
             requirement: ArraySubqueryRequirement::Optional,
+            branches: Vec::new(),
             nested_arrays: Vec::new(),
         }
     }
@@ -1201,6 +1304,18 @@ impl ArraySubqueryBuilder {
         self
     }
 
+    /// Query a single branch for this array subquery.
+    pub fn branch(mut self, branch: impl Into<String>) -> Self {
+        self.branches = vec![branch.into()];
+        self
+    }
+
+    /// Query multiple branches for this array subquery.
+    pub fn branches(mut self, branches: &[&str]) -> Self {
+        self.branches = branches.iter().map(|branch| branch.to_string()).collect();
+        self
+    }
+
     /// Add a nested array subquery.
     ///
     /// # Example
@@ -1235,6 +1350,7 @@ impl ArraySubqueryBuilder {
             order_by: self.order_by,
             limit: self.limit,
             requirement: self.requirement,
+            branches: self.branches,
             nested_arrays: self.nested_arrays,
         }
     }

--- a/crates/jazz-tools/src/query_manager/rebac_tests.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests.rs
@@ -39,6 +39,7 @@ use crate::query_manager::types::{
     SchemaHash, TableName, TablePolicies, TableSchema, Value,
 };
 use crate::row_histories::{RowState, StoredRowBatch};
+use crate::schema_manager::{Lens, LensOp, LensTransform};
 
 /// Helper to create QueryManager with schema on default branch.
 fn create_query_manager(sync_manager: SyncManager, schema: Schema) -> QueryManager {
@@ -818,6 +819,7 @@ fn declared_file_inheritance_schema(array_edge: bool) -> Schema {
     schema
 }
 
+mod branch_policies;
 mod declared_fk_inheritance;
 mod exists_policies;
 mod exists_rel_policies;

--- a/crates/jazz-tools/src/query_manager/rebac_tests/branch_policies.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests/branch_policies.rs
@@ -1,0 +1,2563 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::object::ObjectId;
+use crate::query_manager::policy::{CmpOp, PolicyValue};
+use crate::query_manager::query::QueryBuilder;
+use crate::query_manager::relation_ir::{
+    ColumnRef, PredicateCmpOp, PredicateExpr, RelExpr, ValueRef,
+};
+use crate::query_manager::types::{OperationPolicy, SchemaBuilder};
+use crate::query_manager::writes::RowBranchWrite;
+use crate::sync_manager::ServerId;
+
+use super::*;
+
+fn project_matches_branch_policy() -> PolicyExpr {
+    PolicyExpr::Cmp {
+        column: "projectId".into(),
+        op: CmpOp::Eq,
+        value: PolicyValue::BranchRef("projectId".into()),
+    }
+}
+
+fn branch_schema_with_todo_policies(todo_policies: TablePolicies) -> Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("branches")
+                .column("projectId", ColumnType::Uuid)
+                .column("ownerId", ColumnType::Text)
+                .policies(TablePolicies::new().with_select(PolicyExpr::Cmp {
+                    column: "ownerId".into(),
+                    op: CmpOp::Eq,
+                    value: PolicyValue::SessionRef(vec!["user_id".into()]),
+                })),
+        )
+        .table(
+            TableSchema::builder("todos")
+                .column("projectId", ColumnType::Uuid)
+                .column("title", ColumnType::Text)
+                .policies(todo_policies),
+        )
+        .build()
+}
+
+fn branch_schema_with_backing_and_todo_policies(
+    backing_policies: TablePolicies,
+    todo_policies: TablePolicies,
+) -> Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("branches")
+                .column("projectId", ColumnType::Uuid)
+                .column("ownerId", ColumnType::Text)
+                .policies(backing_policies),
+        )
+        .table(
+            TableSchema::builder("todos")
+                .column("projectId", ColumnType::Uuid)
+                .column("title", ColumnType::Text)
+                .policies(todo_policies),
+        )
+        .build()
+}
+
+fn branch_schema_without_backing_policy(todo_policies: TablePolicies) -> Schema {
+    branch_schema_with_backing_and_todo_policies(TablePolicies::new(), todo_policies)
+}
+
+fn branch_schema_with_approvals(todo_policies: TablePolicies) -> Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("branches")
+                .column("projectId", ColumnType::Uuid)
+                .column("ownerId", ColumnType::Text)
+                .policies(TablePolicies::new().with_select(PolicyExpr::Cmp {
+                    column: "ownerId".into(),
+                    op: CmpOp::Eq,
+                    value: PolicyValue::SessionRef(vec!["user_id".into()]),
+                })),
+        )
+        .table(
+            TableSchema::builder("todos")
+                .column("projectId", ColumnType::Uuid)
+                .column("title", ColumnType::Text)
+                .policies(todo_policies),
+        )
+        .table(
+            TableSchema::builder("approvals")
+                .column("projectId", ColumnType::Uuid)
+                .policies(TablePolicies::default()),
+        )
+        .build()
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SelectPolicyMode {
+    True,
+    False,
+    Missing,
+}
+
+fn policies_with_select_mode(mode: SelectPolicyMode) -> TablePolicies {
+    match mode {
+        SelectPolicyMode::True => TablePolicies::new().with_select(PolicyExpr::True),
+        SelectPolicyMode::False => TablePolicies::new().with_select(PolicyExpr::False),
+        SelectPolicyMode::Missing => TablePolicies::new(),
+    }
+}
+
+fn branch_query_matrix_schema(
+    normal_select: SelectPolicyMode,
+    branch_select: SelectPolicyMode,
+    backing_select: SelectPolicyMode,
+) -> Schema {
+    let mut todo_policies = policies_with_select_mode(normal_select);
+    todo_policies.for_branch = HashMap::from([(
+        TableName::new("branches"),
+        policies_with_select_mode(branch_select),
+    )]);
+
+    branch_schema_with_backing_and_todo_policies(
+        policies_with_select_mode(backing_select),
+        todo_policies,
+    )
+}
+
+fn branch_schema_with_backing_project_dependency() -> Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("projects")
+                .column("ownerId", ColumnType::Text)
+                .policies(
+                    TablePolicies::new()
+                        .with_select(PolicyExpr::Cmp {
+                            column: "ownerId".into(),
+                            op: CmpOp::Eq,
+                            value: PolicyValue::SessionRef(vec!["user_id".into()]),
+                        })
+                        .with_insert(PolicyExpr::True)
+                        .with_update(Some(PolicyExpr::True), PolicyExpr::True),
+                ),
+        )
+        .table(
+            TableSchema::builder("branches")
+                .fk_column("projectId", "projects")
+                .column("ownerId", ColumnType::Text)
+                .policies(
+                    TablePolicies::new()
+                        .with_select(PolicyExpr::Inherits {
+                            operation: Operation::Select,
+                            via_column: "projectId".into(),
+                            max_depth: None,
+                        })
+                        .with_insert(PolicyExpr::True),
+                ),
+        )
+        .table(
+            TableSchema::builder("todos")
+                .column("projectId", ColumnType::Uuid)
+                .column("title", ColumnType::Text)
+                .policies({
+                    let mut todo_policies = TablePolicies::new().with_insert(PolicyExpr::True);
+                    todo_policies.for_branch = HashMap::from([(
+                        TableName::new("branches"),
+                        TablePolicies::new().with_select(PolicyExpr::True),
+                    )]);
+                    todo_policies
+                }),
+        )
+        .build()
+}
+
+fn branch_schema(include_todo_branch_policy: bool) -> Schema {
+    let mut todo_policies = TablePolicies::default();
+    if include_todo_branch_policy {
+        todo_policies.for_branch = HashMap::from([(
+            TableName::new("branches"),
+            TablePolicies::new()
+                .with_select(project_matches_branch_policy())
+                .with_insert(project_matches_branch_policy()),
+        )]);
+    }
+
+    branch_schema_with_todo_policies(todo_policies)
+}
+
+fn todos_metadata() -> HashMap<String, String> {
+    HashMap::from([(MetadataKey::Table.to_string(), "todos".to_string())])
+}
+
+fn projects_metadata() -> HashMap<String, String> {
+    HashMap::from([(MetadataKey::Table.to_string(), "projects".to_string())])
+}
+
+fn branches_metadata() -> HashMap<String, String> {
+    HashMap::from([(MetadataKey::Table.to_string(), "branches".to_string())])
+}
+
+fn manager_with_branch_schema(
+    include_todo_branch_policy: bool,
+) -> (QueryManager, MemoryStorage, Schema) {
+    let schema = branch_schema(include_todo_branch_policy);
+    let sync_manager = SyncManager::new();
+    let qm = create_query_manager_with_policy_mode(
+        sync_manager,
+        schema.clone(),
+        RowPolicyMode::Enforcing,
+    );
+    let storage = seeded_memory_storage(&qm.schema_context().current_schema);
+    (qm, storage, schema)
+}
+
+fn branch_name_for(schema: &Schema, branch_id: ObjectId) -> String {
+    ComposedBranchName::new("dev", SchemaHash::compute(schema), &branch_id.to_string())
+        .to_branch_name()
+        .as_str()
+        .to_string()
+}
+
+fn strip_test_policies(schema: &Schema) -> Schema {
+    schema
+        .iter()
+        .map(|(table_name, table_schema)| {
+            let mut structural = table_schema.clone();
+            structural.policies = TablePolicies::default();
+            (*table_name, structural)
+        })
+        .collect()
+}
+
+fn seed_branch_and_todo(
+    qm: &mut QueryManager,
+    storage: &mut MemoryStorage,
+    schema: &Schema,
+    project_id: ObjectId,
+    owner: &str,
+) -> ObjectId {
+    let branch_id = qm
+        .insert(
+            storage,
+            "branches",
+            &[Value::Uuid(project_id), Value::Text(owner.into())],
+        )
+        .expect("insert branch row")
+        .row_id;
+
+    let branch_name = branch_name_for(schema, branch_id);
+    qm.insert_on_branch(
+        storage,
+        "todos",
+        &branch_name,
+        &[
+            Value::Uuid(project_id),
+            Value::Text("Write API docs".into()),
+        ],
+        None,
+    )
+    .expect("insert branch-visible todo");
+
+    branch_id
+}
+
+#[test]
+// Missing branch policy:
+//
+//   backing branch select passes
+//   todos.for_branch["branches"] is absent
+//
+//   Query                         Expected
+//   ----------------------------  --------
+//   todos.branch(branch_id)       0 rows
+fn branch_read_denies_when_for_branch_block_is_missing() {
+    let (mut qm, mut storage, schema) = manager_with_branch_schema(false);
+    let project_id = ObjectId::new();
+    let branch_id = seed_branch_and_todo(&mut qm, &mut storage, &schema, project_id, "alice");
+    let branch_name = branch_name_for(&schema, branch_id);
+
+    let rows = query_rows(
+        &mut qm,
+        &mut storage,
+        QueryBuilder::new("todos").branch(branch_name).build(),
+        Some(Session::new("alice")),
+    );
+
+    assert!(rows.is_empty());
+}
+
+#[test]
+// Matrix shape:
+//
+//   normal select  x  branch select  x  backing select
+//   true/false/missing for each axis
+//
+//   Query                         Controlling policy
+//   ----------------------------  ------------------
+//   todos on main                 normal select
+//   todos on branch               branch select AND backing select
+fn branch_read_matrix_covers_missing_normal_branch_and_backing_select_policies() {
+    let modes = [
+        SelectPolicyMode::True,
+        SelectPolicyMode::False,
+        SelectPolicyMode::Missing,
+    ];
+
+    for normal_select in modes {
+        for branch_select in modes {
+            for backing_select in modes {
+                let schema =
+                    branch_query_matrix_schema(normal_select, branch_select, backing_select);
+                let mut writer = create_query_manager_with_policy_mode(
+                    SyncManager::new(),
+                    schema.clone(),
+                    RowPolicyMode::PermissiveLocal,
+                );
+                let mut storage = seeded_memory_storage(&writer.schema_context().current_schema);
+                let project_id = ObjectId::new();
+                writer
+                    .insert(
+                        &mut storage,
+                        "todos",
+                        &[Value::Uuid(project_id), Value::Text("Main todo".into())],
+                    )
+                    .expect("seed main todo");
+                let branch_id =
+                    seed_branch_and_todo(&mut writer, &mut storage, &schema, project_id, "alice");
+                let branch_name = branch_name_for(&schema, branch_id);
+                let mut reader = create_query_manager_with_policy_mode(
+                    SyncManager::new(),
+                    schema,
+                    RowPolicyMode::Enforcing,
+                );
+
+                let main_rows = query_rows(
+                    &mut reader,
+                    &mut storage,
+                    QueryBuilder::new("todos").build(),
+                    Some(Session::new("alice")),
+                );
+                let expected_main = usize::from(normal_select == SelectPolicyMode::True);
+                assert_eq!(
+                    main_rows.len(),
+                    expected_main,
+                    "normal select mode {normal_select:?} should control main reads"
+                );
+
+                let branch_rows = query_rows(
+                    &mut reader,
+                    &mut storage,
+                    QueryBuilder::new("todos").branch(branch_name).build(),
+                    Some(Session::new("alice")),
+                );
+                let expected_branch = usize::from(
+                    branch_select == SelectPolicyMode::True
+                        && backing_select == SelectPolicyMode::True,
+                );
+                assert_eq!(
+                    branch_rows.len(),
+                    expected_branch,
+                    "branch select {branch_select:?} and backing select {backing_select:?} should control branch reads independently from normal select {normal_select:?}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+// Server subscription path:
+//
+//   structural schema compiles graph
+//             |
+//             v
+//   authorization schema applies for_branch select=false
+//
+//   Sent row batch for branch todo: no
+//   Settled scope: empty
+fn synced_branch_read_uses_branch_select_policy_after_structural_graph_compile() {
+    // Regression coverage for browser/dev-server subscriptions: the server
+    // compiles query scopes from the structural schema, then re-authorizes
+    // candidate rows with the separately published permissions head. Branch
+    // reads must therefore check the published `for_branch` select policy
+    // instead of falling back to the normal table select policy.
+    let mut todo_policies = TablePolicies::new()
+        .with_select(PolicyExpr::True)
+        .with_insert(PolicyExpr::True);
+    todo_policies.for_branch = HashMap::from([(
+        TableName::new("branches"),
+        TablePolicies::new()
+            .with_select(PolicyExpr::False)
+            .with_insert(PolicyExpr::True),
+    )]);
+    let auth_schema = branch_schema_with_backing_and_todo_policies(
+        TablePolicies::new()
+            .with_select(PolicyExpr::True)
+            .with_insert(PolicyExpr::True),
+        todo_policies,
+    );
+    let structural_schema = strip_test_policies(&auth_schema);
+    let mut qm = create_query_manager(SyncManager::new(), structural_schema.clone());
+    let mut storage = seeded_memory_storage(&qm.schema_context().current_schema);
+    let project_id = ObjectId::new();
+    let branch_id = qm
+        .insert(
+            &mut storage,
+            "branches",
+            &[Value::Uuid(project_id), Value::Text("alice".into())],
+        )
+        .expect("seed branch row")
+        .row_id;
+    let branch_name = branch_name_for(&structural_schema, branch_id);
+    let branch_todo = qm
+        .insert_on_branch(
+            &mut storage,
+            "todos",
+            &branch_name,
+            &[
+                Value::Uuid(project_id),
+                Value::Text("Hidden branch todo".into()),
+            ],
+            None,
+        )
+        .expect("seed branch todo");
+    qm.process(&mut storage);
+    qm.set_authorization_schema(auth_schema);
+
+    let client_id = ClientId::new();
+    connect_client(&mut qm, &storage, client_id);
+    qm.sync_manager_mut()
+        .set_client_session(client_id, Session::new("alice"));
+    qm.sync_manager_mut().take_outbox();
+
+    qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::QuerySubscription {
+            query_id: QueryId(1),
+            query: Box::new(QueryBuilder::new("todos").branch(branch_name).build()),
+            session: Some(Session::new("alice")),
+            required_tier: None,
+            propagation: crate::sync_manager::QueryPropagation::Full,
+            policy_context_tables: vec![],
+        },
+    });
+
+    qm.process(&mut storage);
+
+    let outbox = qm.sync_manager_mut().take_outbox();
+    let sent_rows: Vec<_> = outbox
+        .iter()
+        .filter_map(|entry| match &entry.payload {
+            SyncPayload::RowBatchNeeded { row, .. } => Some(row.row_id),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        !sent_rows.contains(&branch_todo.row_id),
+        "branch todo should not be sent when forBranch read is false"
+    );
+    let settled_scope = outbox.iter().find_map(|entry| match &entry.payload {
+        SyncPayload::QuerySettled {
+            query_id: QueryId(1),
+            scope,
+            ..
+        } => Some(scope),
+        _ => None,
+    });
+    assert_eq!(settled_scope, Some(&Vec::new()));
+}
+
+#[test]
+fn synced_union_branch_read_uses_branch_select_policy_after_structural_graph_compile() {
+    let mut todo_policies = TablePolicies::new()
+        .with_select(PolicyExpr::True)
+        .with_insert(PolicyExpr::True);
+    todo_policies.for_branch = HashMap::from([(
+        TableName::new("branches"),
+        TablePolicies::new()
+            .with_select(PolicyExpr::False)
+            .with_insert(PolicyExpr::True),
+    )]);
+    let auth_schema = branch_schema_with_backing_and_todo_policies(
+        TablePolicies::new()
+            .with_select(PolicyExpr::True)
+            .with_insert(PolicyExpr::True),
+        todo_policies,
+    );
+    let structural_schema = strip_test_policies(&auth_schema);
+    let mut qm = create_query_manager(SyncManager::new(), structural_schema.clone());
+    let mut storage = seeded_memory_storage(&qm.schema_context().current_schema);
+    let project_id = ObjectId::new();
+    let branch_id = qm
+        .insert(
+            &mut storage,
+            "branches",
+            &[Value::Uuid(project_id), Value::Text("alice".into())],
+        )
+        .expect("seed branch row")
+        .row_id;
+    let branch_name = branch_name_for(&structural_schema, branch_id);
+    let branch_todo = qm
+        .insert_on_branch(
+            &mut storage,
+            "todos",
+            &branch_name,
+            &[
+                Value::Uuid(project_id),
+                Value::Text("Hidden branch todo".into()),
+            ],
+            None,
+        )
+        .expect("seed branch todo");
+    qm.process(&mut storage);
+    qm.set_authorization_schema(auth_schema);
+
+    let client_id = ClientId::new();
+    connect_client(&mut qm, &storage, client_id);
+    qm.sync_manager_mut()
+        .set_client_session(client_id, Session::new("alice"));
+    qm.sync_manager_mut().take_outbox();
+
+    let mut query = QueryBuilder::new("todos").build();
+    query.relation_ir = RelExpr::Union {
+        inputs: vec![RelExpr::Branch {
+            input: Box::new(RelExpr::Filter {
+                input: Box::new(RelExpr::TableScan {
+                    table: TableName::new("todos"),
+                }),
+                predicate: PredicateExpr::Cmp {
+                    left: ColumnRef::unscoped("projectId"),
+                    op: PredicateCmpOp::Eq,
+                    right: ValueRef::Literal(Value::Uuid(project_id)),
+                },
+            }),
+            branches: vec![branch_name],
+        }],
+    };
+    qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::QuerySubscription {
+            query_id: QueryId(1),
+            query: Box::new(query),
+            session: Some(Session::new("alice")),
+            required_tier: None,
+            propagation: crate::sync_manager::QueryPropagation::Full,
+            policy_context_tables: vec![],
+        },
+    });
+
+    qm.process(&mut storage);
+
+    let outbox = qm.sync_manager_mut().take_outbox();
+    let sent_rows: Vec<_> = outbox
+        .iter()
+        .filter_map(|entry| match &entry.payload {
+            SyncPayload::RowBatchNeeded { row, .. } => Some(row.row_id),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        !sent_rows.contains(&branch_todo.row_id),
+        "branch todo should not be sent from a union when forBranch read is false"
+    );
+    let settled_scope = outbox.iter().find_map(|entry| match &entry.payload {
+        SyncPayload::QuerySettled {
+            query_id: QueryId(1),
+            scope,
+            ..
+        } => Some(scope),
+        _ => None,
+    });
+    assert_eq!(settled_scope, Some(&Vec::new()));
+}
+
+#[test]
+fn local_union_branch_read_uses_branch_select_policy_in_graph_filter() {
+    let schema = branch_query_matrix_schema(
+        SelectPolicyMode::True,
+        SelectPolicyMode::False,
+        SelectPolicyMode::True,
+    );
+    let sync_manager = SyncManager::new();
+    let mut qm = create_query_manager_with_policy_mode(
+        sync_manager,
+        schema.clone(),
+        RowPolicyMode::Enforcing,
+    );
+    let mut storage = seeded_memory_storage(&qm.schema_context().current_schema);
+    let project_id = ObjectId::new();
+    let branch_id = qm
+        .insert(
+            &mut storage,
+            "branches",
+            &[Value::Uuid(project_id), Value::Text("alice".into())],
+        )
+        .expect("seed branch row")
+        .row_id;
+    let branch_name = branch_name_for(&schema, branch_id);
+    qm.insert_on_branch(
+        &mut storage,
+        "todos",
+        &branch_name,
+        &[
+            Value::Uuid(project_id),
+            Value::Text("Hidden branch todo".into()),
+        ],
+        None,
+    )
+    .expect("seed branch todo");
+
+    let mut query = QueryBuilder::new("todos").build();
+    query.relation_ir = RelExpr::Union {
+        inputs: vec![RelExpr::Branch {
+            input: Box::new(RelExpr::TableScan {
+                table: TableName::new("todos"),
+            }),
+            branches: vec![branch_name],
+        }],
+    };
+    let sub_id = qm
+        .subscribe_with_session(query, Some(Session::new("alice")), None)
+        .expect("subscribe union branch query");
+    qm.process(&mut storage);
+
+    assert!(qm.get_subscription_results(sub_id).is_empty());
+}
+
+#[test]
+fn multi_branch_read_uses_each_rows_branch_for_branch_ref_policy() {
+    let (mut qm, mut storage, schema) = manager_with_branch_schema(true);
+    let project_a = ObjectId::new();
+    let project_b = ObjectId::new();
+    let branch_a = qm
+        .insert(
+            &mut storage,
+            "branches",
+            &[Value::Uuid(project_a), Value::Text("alice".into())],
+        )
+        .expect("insert branch A")
+        .row_id;
+    let branch_b = qm
+        .insert(
+            &mut storage,
+            "branches",
+            &[Value::Uuid(project_b), Value::Text("alice".into())],
+        )
+        .expect("insert branch B")
+        .row_id;
+    let branch_a_name = branch_name_for(&schema, branch_a);
+    let branch_b_name = branch_name_for(&schema, branch_b);
+    let allowed_a = qm
+        .insert_on_branch(
+            &mut storage,
+            "todos",
+            &branch_a_name,
+            &[Value::Uuid(project_a), Value::Text("allowed A".into())],
+            None,
+        )
+        .expect("insert branch A todo")
+        .row_id;
+    let allowed_b = qm
+        .insert_on_branch(
+            &mut storage,
+            "todos",
+            &branch_b_name,
+            &[Value::Uuid(project_b), Value::Text("allowed B".into())],
+            None,
+        )
+        .expect("insert branch B todo")
+        .row_id;
+    let denied_b = qm
+        .insert_on_branch(
+            &mut storage,
+            "todos",
+            &branch_b_name,
+            &[Value::Uuid(project_a), Value::Text("denied B".into())],
+            None,
+        )
+        .expect("insert branch B todo with branch A project")
+        .row_id;
+
+    let rows = query_rows(
+        &mut qm,
+        &mut storage,
+        QueryBuilder::new("todos")
+            .branches(&[branch_a_name.as_str(), branch_b_name.as_str()])
+            .build(),
+        Some(Session::new("alice")),
+    );
+    let returned_ids: HashSet<_> = rows.into_iter().map(|(id, _)| id).collect();
+
+    assert_eq!(
+        returned_ids,
+        HashSet::from([allowed_a, allowed_b]),
+        "each branch row should be checked against its own backing row"
+    );
+    assert!(!returned_ids.contains(&denied_b));
+}
+
+#[test]
+fn explicit_auth_drops_same_id_tuple_when_any_content_branch_is_denied() {
+    let auth_schema = branch_schema(true);
+    let structural_schema = strip_test_policies(&auth_schema);
+    let mut qm = create_query_manager(SyncManager::new(), structural_schema.clone());
+    qm.set_authorization_schema(auth_schema);
+    let mut storage = seeded_memory_storage(&qm.schema_context().current_schema);
+    let project_a = ObjectId::new();
+    let project_b = ObjectId::new();
+    let branch_a = qm
+        .insert(
+            &mut storage,
+            "branches",
+            &[Value::Uuid(project_a), Value::Text("alice".into())],
+        )
+        .expect("insert branch A")
+        .row_id;
+    let branch_b = qm
+        .insert(
+            &mut storage,
+            "branches",
+            &[Value::Uuid(project_b), Value::Text("alice".into())],
+        )
+        .expect("insert branch B")
+        .row_id;
+    let branch_a_name = branch_name_for(&structural_schema, branch_a);
+    let branch_b_name = branch_name_for(&structural_schema, branch_b);
+    let shared_todo_id = ObjectId::new();
+    let todos_descriptor = structural_schema
+        .get(&TableName::new("todos"))
+        .expect("todos table should exist")
+        .columns
+        .clone();
+    for (branch_name, project_id, title, timestamp) in [
+        (&branch_b_name, project_a, "denied branch B content", 2_000),
+        (&branch_a_name, project_a, "allowed branch A content", 1_000),
+    ] {
+        let commit = stored_row_commit(
+            smallvec![],
+            encode_row(
+                &todos_descriptor,
+                &[Value::Uuid(project_id), Value::Text(title.into())],
+            )
+            .unwrap(),
+            timestamp,
+            "alice",
+            None,
+        );
+        qm.sync_manager_mut().push_inbox(InboxEntry {
+            source: Source::Server(ServerId::new()),
+            payload: row_batch_created_payload(
+                shared_todo_id,
+                branch_name,
+                Some(RowMetadata {
+                    id: shared_todo_id,
+                    metadata: todos_metadata(),
+                }),
+                &commit,
+            ),
+        });
+    }
+    qm.process(&mut storage);
+
+    let mut query = QueryBuilder::new("todos").build();
+    query.relation_ir = RelExpr::Union {
+        inputs: vec![
+            RelExpr::Branch {
+                input: Box::new(RelExpr::TableScan {
+                    table: TableName::new("todos"),
+                }),
+                branches: vec![branch_b_name],
+            },
+            RelExpr::Branch {
+                input: Box::new(RelExpr::TableScan {
+                    table: TableName::new("todos"),
+                }),
+                branches: vec![branch_a_name],
+            },
+        ],
+    };
+
+    let rows = query_rows(&mut qm, &mut storage, query, Some(Session::new("alice")));
+
+    assert!(
+        rows.is_empty(),
+        "same-id tuple should be dropped when it may carry denied branch content"
+    );
+}
+
+#[test]
+// Non-row-id branch path:
+//
+//   Branch name = dev/<schema-hash>/alice-draft
+//   No backing row can be resolved from the branch name.
+//
+//   Normal select = true
+//   Branch select = false
+//   Expected: forBranch resolution fails and denies instead of using normal select.
+fn branch_read_denies_when_for_branch_resolution_fails_for_non_row_id_branch() {
+    let mut todo_policies = TablePolicies::new()
+        .with_select(PolicyExpr::True)
+        .with_insert(PolicyExpr::True);
+    todo_policies.for_branch = HashMap::from([(
+        TableName::new("branches"),
+        TablePolicies::new()
+            .with_select(PolicyExpr::False)
+            .with_insert(PolicyExpr::True),
+    )]);
+    let schema = branch_schema_with_todo_policies(todo_policies);
+    let sync_manager = SyncManager::new();
+    let mut qm = create_query_manager_with_policy_mode(
+        sync_manager,
+        schema.clone(),
+        RowPolicyMode::Enforcing,
+    );
+    let mut storage = seeded_memory_storage(&qm.schema_context().current_schema);
+    let branch_name = ComposedBranchName::new("dev", SchemaHash::compute(&schema), "alice-draft")
+        .to_branch_name()
+        .as_str()
+        .to_string();
+
+    qm.insert_on_branch(
+        &mut storage,
+        "todos",
+        &branch_name,
+        &[Value::Uuid(ObjectId::new()), Value::Text("Draft".into())],
+        None,
+    )
+    .expect("seed non-row-id branch todo");
+
+    let rows = query_rows(
+        &mut qm,
+        &mut storage,
+        QueryBuilder::new("todos").branch(branch_name).build(),
+        Some(Session::new("alice")),
+    );
+
+    assert!(rows.is_empty());
+}
+
+#[test]
+// Explicit-policy detection:
+//
+//   todos policies:
+//     normal select/insert/update/delete = missing
+//     for_branch insert                  = true
+//
+//   Schema should be enforcing because for_branch is explicit.
+//   Branch read with missing select must deny.
+fn for_branch_only_schema_infers_enforcing_policy_mode() {
+    let mut todo_policies = TablePolicies::default();
+    todo_policies.for_branch = HashMap::from([(
+        TableName::new("branches"),
+        TablePolicies::new().with_insert(PolicyExpr::True),
+    )]);
+    let schema = branch_schema_without_backing_policy(todo_policies);
+
+    let mut writer = create_query_manager_with_policy_mode(
+        SyncManager::new(),
+        schema.clone(),
+        RowPolicyMode::PermissiveLocal,
+    );
+    let mut storage = seeded_memory_storage(&writer.schema_context().current_schema);
+    let project_id = ObjectId::new();
+    let branch_id = seed_branch_and_todo(&mut writer, &mut storage, &schema, project_id, "alice");
+    let branch_name = branch_name_for(&schema, branch_id);
+
+    let mut reader = create_query_manager(SyncManager::new(), schema);
+    let rows = query_rows(
+        &mut reader,
+        &mut storage,
+        QueryBuilder::new("todos").branch(branch_name).build(),
+        Some(Session::new("alice")),
+    );
+
+    assert!(rows.is_empty());
+}
+
+#[test]
+// Subscription invalidation:
+//
+//   branch backing owner alice -> visible branch todo
+//   branch backing owner bob   -> unreadable branch todo
+//
+//   Update branches[ownerId] should dirty the branch policy filter.
+fn branch_select_reacts_when_backing_row_becomes_unreadable() {
+    let backing_policies = TablePolicies::new()
+        .with_select(PolicyExpr::Cmp {
+            column: "ownerId".into(),
+            op: CmpOp::Eq,
+            value: PolicyValue::SessionRef(vec!["user_id".into()]),
+        })
+        .with_update(Some(PolicyExpr::True), PolicyExpr::True);
+    let mut todo_policies = TablePolicies::default();
+    todo_policies.for_branch = HashMap::from([(
+        TableName::new("branches"),
+        TablePolicies::new()
+            .with_select(PolicyExpr::True)
+            .with_insert(PolicyExpr::True),
+    )]);
+    let schema = branch_schema_with_backing_and_todo_policies(backing_policies, todo_policies);
+    let mut qm = create_query_manager_with_policy_mode(
+        SyncManager::new(),
+        schema.clone(),
+        RowPolicyMode::Enforcing,
+    );
+    let mut storage = seeded_memory_storage(&qm.schema_context().current_schema);
+    let project_id = ObjectId::new();
+    let branch_id = seed_branch_and_todo(&mut qm, &mut storage, &schema, project_id, "alice");
+    let branch_name = branch_name_for(&schema, branch_id);
+    let sub_id = qm
+        .subscribe_with_session(
+            QueryBuilder::new("todos").branch(branch_name).build(),
+            Some(Session::new("alice")),
+            None,
+        )
+        .expect("subscribe branch query");
+
+    qm.process(&mut storage);
+    assert_eq!(qm.get_subscription_results(sub_id).len(), 1);
+
+    qm.update(
+        &mut storage,
+        branch_id,
+        &[Value::Uuid(project_id), Value::Text("bob".into())],
+    )
+    .expect("update backing branch owner");
+    qm.process(&mut storage);
+
+    assert!(qm.get_subscription_results(sub_id).is_empty());
+    qm.unsubscribe_with_sync(sub_id);
+}
+
+#[test]
+// Dependency invalidation:
+//
+//   projects[ownerId=alice]
+//          ^
+//          | branches.projectId inherits project select
+//          ` branch todo visibility
+//
+//   Changing project owner to bob should remove the branch todo from
+//   an alice subscription even though the branch row itself did not change.
+fn branch_select_reacts_when_backing_row_policy_dependency_changes() {
+    let schema = branch_schema_with_backing_project_dependency();
+    let mut qm = create_query_manager_with_policy_mode(
+        SyncManager::new(),
+        schema.clone(),
+        RowPolicyMode::Enforcing,
+    );
+    let mut storage = seeded_memory_storage(&qm.schema_context().current_schema);
+    let project_id = qm
+        .insert(&mut storage, "projects", &[Value::Text("alice".into())])
+        .expect("seed readable project")
+        .row_id;
+    qm.process(&mut storage);
+    let branch_id = seed_branch_and_todo(&mut qm, &mut storage, &schema, project_id, "alice");
+    let branch_name = branch_name_for(&schema, branch_id);
+    qm.process(&mut storage);
+    let sub_id = qm
+        .subscribe_with_session(
+            QueryBuilder::new("todos").branch(branch_name).build(),
+            Some(Session::new("alice")),
+            None,
+        )
+        .expect("subscribe branch query");
+
+    qm.process(&mut storage);
+    assert_eq!(qm.get_subscription_results(sub_id).len(), 1);
+
+    qm.update(&mut storage, project_id, &[Value::Text("bob".into())])
+        .expect("make backing branch row unreadable through project dependency");
+    qm.process(&mut storage);
+
+    assert!(qm.get_subscription_results(sub_id).is_empty());
+    qm.unsubscribe_with_sync(sub_id);
+}
+
+#[test]
+// BranchRef inside EXISTS:
+//
+//   branch row projectId = P
+//   approvals on branch contains projectId = P
+//   todos.for_branch select = exists approvals where projectId == $branch.projectId
+//
+//   Expected: branch todo is readable.
+fn branch_read_with_exists_branch_policy_can_match_branch_ref() {
+    let mut todo_policies = TablePolicies::default();
+    todo_policies.for_branch = HashMap::from([(
+        TableName::new("branches"),
+        TablePolicies::new().with_select(PolicyExpr::Exists {
+            table: "approvals".into(),
+            condition: Box::new(project_matches_branch_policy()),
+        }),
+    )]);
+    let schema = branch_schema_with_approvals(todo_policies);
+    let sync_manager = SyncManager::new();
+    let mut qm = create_query_manager_with_policy_mode(
+        sync_manager,
+        schema.clone(),
+        RowPolicyMode::Enforcing,
+    );
+    let mut storage = seeded_memory_storage(&qm.schema_context().current_schema);
+    let project_id = ObjectId::new();
+    let branch_id = seed_branch_and_todo(&mut qm, &mut storage, &schema, project_id, "alice");
+    let branch_name = branch_name_for(&schema, branch_id);
+    qm.insert_on_branch(
+        &mut storage,
+        "approvals",
+        &branch_name,
+        &[Value::Uuid(project_id)],
+        None,
+    )
+    .expect("insert branch approval");
+
+    let rows = query_rows(
+        &mut qm,
+        &mut storage,
+        QueryBuilder::new("todos").branch(branch_name).build(),
+        Some(Session::new("alice")),
+    );
+
+    assert_eq!(rows.len(), 1);
+}
+
+#[test]
+// Optional include with denied branch rows:
+//
+//   projects[P] on main
+//          |
+//          v
+//   include todos.branch(B) where branch todo read = false
+//
+//   Expected query result
+//   ---------------------
+//   project P remains visible with an empty todosViaProject array.
+fn branch_include_keeps_outer_row_when_inner_branch_read_denies() {
+    let mut todo_policies = TablePolicies::new().with_select(PolicyExpr::True);
+    todo_policies.for_branch = HashMap::from([(
+        TableName::new("branches"),
+        TablePolicies::new()
+            .with_select(PolicyExpr::False)
+            .with_insert(PolicyExpr::True),
+    )]);
+    let schema = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("projects")
+                .column("name", ColumnType::Text)
+                .policies(
+                    TablePolicies::new()
+                        .with_select(PolicyExpr::True)
+                        .with_insert(PolicyExpr::True),
+                ),
+        )
+        .table(
+            TableSchema::builder("branches")
+                .fk_column("projectId", "projects")
+                .column("ownerId", ColumnType::Text)
+                .policies(
+                    TablePolicies::new()
+                        .with_select(PolicyExpr::True)
+                        .with_insert(PolicyExpr::True),
+                ),
+        )
+        .table(
+            TableSchema::builder("todos")
+                .fk_column("projectId", "projects")
+                .column("title", ColumnType::Text)
+                .policies(todo_policies),
+        )
+        .build();
+    let mut qm = create_query_manager_with_policy_mode(
+        SyncManager::new(),
+        schema.clone(),
+        RowPolicyMode::Enforcing,
+    );
+    let mut storage = seeded_memory_storage(&qm.schema_context().current_schema);
+    let project_id = qm
+        .insert(&mut storage, "projects", &[Value::Text("Project".into())])
+        .expect("insert project")
+        .row_id;
+    let branch_id = qm
+        .insert(
+            &mut storage,
+            "branches",
+            &[Value::Uuid(project_id), Value::Text("alice".into())],
+        )
+        .expect("insert branch row")
+        .row_id;
+    let branch_name = branch_name_for(&schema, branch_id);
+    qm.insert_on_branch(
+        &mut storage,
+        "todos",
+        &branch_name,
+        &[Value::Uuid(project_id), Value::Text("Hidden".into())],
+        None,
+    )
+    .expect("seed branch todo");
+
+    let rows = query_rows(
+        &mut qm,
+        &mut storage,
+        QueryBuilder::new("projects")
+            .with_array("todosViaProject", |sub| {
+                sub.from("todos")
+                    .branch(&branch_name)
+                    .correlate("projectId", "projects.id")
+            })
+            .build(),
+        Some(Session::new("alice")),
+    );
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].1[1], Value::Array(vec![]));
+}
+
+#[test]
+// Server subscription include path:
+//
+//   structural schema compiles:
+//     projects[P] --include todos.branch(B)--> todos on branch B
+//
+//   authorization schema applies:
+//     projects.select = true
+//     todos.for_branch.select = false
+//
+//   Expected server result:
+//     project P remains in scope; branch todo is not sent.
+fn synced_branch_include_keeps_outer_row_when_inner_branch_read_denies() {
+    let mut todo_policies = TablePolicies::new()
+        .with_select(PolicyExpr::True)
+        .with_insert(PolicyExpr::True);
+    todo_policies.for_branch = HashMap::from([(
+        TableName::new("branches"),
+        TablePolicies::new()
+            .with_select(PolicyExpr::False)
+            .with_insert(PolicyExpr::True),
+    )]);
+    let auth_schema = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("projects")
+                .column("name", ColumnType::Text)
+                .policies(
+                    TablePolicies::new()
+                        .with_select(PolicyExpr::True)
+                        .with_insert(PolicyExpr::True),
+                ),
+        )
+        .table(
+            TableSchema::builder("branches")
+                .fk_column("projectId", "projects")
+                .column("ownerId", ColumnType::Text)
+                .policies(
+                    TablePolicies::new()
+                        .with_select(PolicyExpr::True)
+                        .with_insert(PolicyExpr::True),
+                ),
+        )
+        .table(
+            TableSchema::builder("todos")
+                .fk_column("projectId", "projects")
+                .column("title", ColumnType::Text)
+                .policies(todo_policies),
+        )
+        .build();
+    let structural_schema = strip_test_policies(&auth_schema);
+    let mut qm = create_query_manager(SyncManager::new(), structural_schema.clone());
+    let mut storage = seeded_memory_storage(&qm.schema_context().current_schema);
+    let project_id = qm
+        .insert(&mut storage, "projects", &[Value::Text("Project".into())])
+        .expect("insert project")
+        .row_id;
+    let branch_id = qm
+        .insert(
+            &mut storage,
+            "branches",
+            &[Value::Uuid(project_id), Value::Text("alice".into())],
+        )
+        .expect("insert branch row")
+        .row_id;
+    let branch_name = branch_name_for(&structural_schema, branch_id);
+    let branch_todo = qm
+        .insert_on_branch(
+            &mut storage,
+            "todos",
+            &branch_name,
+            &[Value::Uuid(project_id), Value::Text("Hidden".into())],
+            None,
+        )
+        .expect("seed branch todo");
+    qm.process(&mut storage);
+    qm.set_authorization_schema(auth_schema);
+
+    let client_id = ClientId::new();
+    connect_client(&mut qm, &storage, client_id);
+    qm.sync_manager_mut()
+        .set_client_session(client_id, Session::new("alice"));
+    qm.sync_manager_mut().take_outbox();
+
+    qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::QuerySubscription {
+            query_id: QueryId(1),
+            query: Box::new(
+                QueryBuilder::new("projects")
+                    .with_array("todosViaProject", |sub| {
+                        sub.from("todos")
+                            .branch(branch_name)
+                            .correlate("projectId", "projects.id")
+                    })
+                    .build(),
+            ),
+            session: Some(Session::new("alice")),
+            required_tier: None,
+            propagation: crate::sync_manager::QueryPropagation::Full,
+            policy_context_tables: vec![],
+        },
+    });
+
+    qm.process(&mut storage);
+
+    let outbox = qm.sync_manager_mut().take_outbox();
+    let sent_rows: Vec<_> = outbox
+        .iter()
+        .filter_map(|entry| match &entry.payload {
+            SyncPayload::RowBatchNeeded { row, .. } => Some(row.row_id),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        sent_rows.contains(&project_id),
+        "server should send the visible outer project row"
+    );
+    assert!(
+        !sent_rows.contains(&branch_todo.row_id),
+        "server should not send branch todo denied by forBranch read"
+    );
+    let settled_scope = outbox.iter().find_map(|entry| match &entry.payload {
+        SyncPayload::QuerySettled {
+            query_id: QueryId(1),
+            scope,
+            ..
+        } => Some(scope),
+        _ => None,
+    });
+    assert!(
+        settled_scope.is_some_and(|scope| scope.iter().any(|(row_id, _)| *row_id == project_id)),
+        "server query scope should keep the visible outer project row"
+    );
+}
+
+#[test]
+// Branch insert:
+//
+//   branches[projectId=P] -> todos insert projectId=P
+//
+//   Insert target                    Policy used
+//   -------------------------------  -----------------------
+//   insert_on_branch("todos", ...)   for_branch insert policy
+fn branch_insert_uses_matching_branch_policy() {
+    let (mut qm, mut storage, schema) = manager_with_branch_schema(true);
+    let project_id = ObjectId::new();
+    let branch_id = qm
+        .insert(
+            &mut storage,
+            "branches",
+            &[Value::Uuid(project_id), Value::Text("alice".into())],
+        )
+        .expect("insert branch row")
+        .row_id;
+    let branch_name = branch_name_for(&schema, branch_id);
+    let write_context = WriteContext::from_session(Session::new("alice"));
+
+    let inserted = qm
+        .insert_on_branch(
+            &mut storage,
+            "todos",
+            &branch_name,
+            &[
+                Value::Uuid(project_id),
+                Value::Text("Write API docs".into()),
+            ],
+            Some(&write_context),
+        )
+        .expect("branch insert should use branch-scoped policy");
+
+    assert_ne!(inserted.row_id, branch_id);
+}
+
+#[test]
+// Non-row-id branch insert:
+//
+//   Branch name = dev/<schema-hash>/alice-draft
+//   No backing row can be resolved from the branch name.
+//
+//   Normal insert = true
+//   Branch insert = false
+//   Expected: forBranch resolution fails and denies instead of using normal insert.
+fn branch_insert_denies_when_for_branch_resolution_fails_for_non_row_id_branch() {
+    let mut todo_policies = TablePolicies::new().with_insert(PolicyExpr::True);
+    todo_policies.for_branch = HashMap::from([(
+        TableName::new("branches"),
+        TablePolicies::new().with_insert(PolicyExpr::False),
+    )]);
+    let schema = branch_schema_with_todo_policies(todo_policies);
+    let mut qm = create_query_manager_with_policy_mode(
+        SyncManager::new(),
+        schema.clone(),
+        RowPolicyMode::Enforcing,
+    );
+    let mut storage = seeded_memory_storage(&qm.schema_context().current_schema);
+    let branch_name = ComposedBranchName::new("dev", SchemaHash::compute(&schema), "alice-draft")
+        .to_branch_name()
+        .as_str()
+        .to_string();
+    let write_context = WriteContext::from_session(Session::new("alice"));
+
+    let denied = qm.insert_on_branch(
+        &mut storage,
+        "todos",
+        &branch_name,
+        &[Value::Uuid(ObjectId::new()), Value::Text("Draft".into())],
+        Some(&write_context),
+    );
+
+    assert!(matches!(
+        denied,
+        Err(QueryError::PolicyDenied {
+            operation: Operation::Insert,
+            ..
+        })
+    ));
+}
+
+#[test]
+// Branch update with only WITH CHECK:
+//
+//   old clause = missing
+//   new clause = projectId == $branch.projectId
+//
+//   Expected: branch update can rely on the new-row check without requiring
+//   both old and new policy clauses to be present.
+fn branch_update_allows_missing_using_when_with_check_matches() {
+    let mut todo_policies = TablePolicies::default();
+    todo_policies.for_branch = HashMap::from([(
+        TableName::new("branches"),
+        TablePolicies::new().with_update(None, project_matches_branch_policy()),
+    )]);
+    let schema = branch_schema_with_todo_policies(todo_policies);
+    let sync_manager = SyncManager::new();
+    let mut qm = create_query_manager_with_policy_mode(
+        sync_manager,
+        schema.clone(),
+        RowPolicyMode::Enforcing,
+    );
+    let mut storage = seeded_memory_storage(&qm.schema_context().current_schema);
+    let project_id = ObjectId::new();
+    let branch_id = qm
+        .insert(
+            &mut storage,
+            "branches",
+            &[Value::Uuid(project_id), Value::Text("alice".into())],
+        )
+        .expect("insert branch row")
+        .row_id;
+    let branch_name = branch_name_for(&schema, branch_id);
+    let todo = qm
+        .insert_on_branch(
+            &mut storage,
+            "todos",
+            &branch_name,
+            &[
+                Value::Uuid(project_id),
+                Value::Text("Write API docs".into()),
+            ],
+            None,
+        )
+        .expect("seed branch-visible todo");
+    let row = storage
+        .load_visible_region_row("todos", &branch_name, todo.row_id)
+        .expect("load visible branch row")
+        .expect("branch row should exist");
+    let old_data = row.data.clone();
+    let old_provenance = row.row_provenance();
+    let write_context = WriteContext::from_session(Session::new("alice"));
+
+    qm.write_existing_row_on_branch_with_schema_and_write_context(
+        &mut storage,
+        RowBranchWrite {
+            table: "todos",
+            branch: &branch_name,
+            id: todo.row_id,
+            values: &[
+                Value::Uuid(project_id),
+                Value::Text("Update API docs".into()),
+            ],
+            old_data_for_policy: &old_data,
+            old_provenance_for_policy: &old_provenance,
+        },
+        &schema,
+        Some(&write_context),
+        true,
+    )
+    .expect("branch update should not require both update clauses");
+}
+
+#[test]
+// Synced branch insert:
+//
+//   Client write batch -> branch "dev/<schema>/<branch_id>"
+//
+//   Policy table
+//   -----------------------------  --------
+//   normal todos insert            missing
+//   for_branch todos insert        matches P
+//   expected server decision       accept
+fn synced_branch_insert_uses_branch_policy_without_normal_insert_policy() {
+    let (mut qm, mut storage, schema) = manager_with_branch_schema(true);
+    let project_id = ObjectId::new();
+    let branch_id = qm
+        .insert(
+            &mut storage,
+            "branches",
+            &[Value::Uuid(project_id), Value::Text("alice".into())],
+        )
+        .expect("insert branch row")
+        .row_id;
+    let branch_name = branch_name_for(&schema, branch_id);
+    let todos_descriptor = schema
+        .get(&TableName::new("todos"))
+        .unwrap()
+        .columns
+        .clone();
+    let todo_id = create_test_row(&mut storage, Some(todos_metadata()));
+    let client_id = ClientId::new();
+    connect_client(&mut qm, &storage, client_id);
+    qm.sync_manager_mut()
+        .set_client_session(client_id, Session::new("alice"));
+    set_client_query_scope(
+        &mut qm,
+        &storage,
+        client_id,
+        QueryId(1),
+        HashSet::from([(todo_id, BranchName::new(&branch_name))]),
+        None,
+    );
+    qm.sync_manager_mut().take_outbox();
+
+    let content = encode_row(
+        &todos_descriptor,
+        &[
+            Value::Uuid(project_id),
+            Value::Text("Write branch sync docs".into()),
+        ],
+    )
+    .unwrap();
+    let commit = stored_row_commit(
+        smallvec![],
+        content,
+        1_000,
+        ObjectId::new().to_string(),
+        None,
+    );
+    qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: row_batch_created_payload(
+            todo_id,
+            &branch_name,
+            Some(RowMetadata {
+                id: todo_id,
+                metadata: todos_metadata(),
+            }),
+            &commit,
+        ),
+    });
+
+    for _ in 0..10 {
+        qm.process(&mut storage);
+    }
+
+    let batch_id = row_batch_id_for_commit(todo_id, &branch_name, &commit);
+    let outbox = qm.sync_manager_mut().take_outbox();
+    assert!(!client_write_was_rejected(&outbox, client_id, batch_id));
+    assert!(
+        test_row_tip_ids(&storage, todo_id, &branch_name)
+            .unwrap()
+            .contains(&batch_id)
+    );
+}
+
+#[test]
+// Synced non-row-id branch insert:
+//
+//   Branch name = dev/<schema-hash>/alice-draft
+//   Normal insert = true
+//   Branch insert = false
+//   Expected: forBranch resolution fails and denies instead of using normal insert.
+fn synced_branch_insert_denies_when_for_branch_resolution_fails_for_non_row_id_branch() {
+    let mut todo_policies = TablePolicies::new().with_insert(PolicyExpr::True);
+    todo_policies.for_branch = HashMap::from([(
+        TableName::new("branches"),
+        TablePolicies::new().with_insert(PolicyExpr::False),
+    )]);
+    let schema = branch_schema_with_todo_policies(todo_policies);
+    let mut qm = create_query_manager_with_policy_mode(
+        SyncManager::new(),
+        schema.clone(),
+        RowPolicyMode::Enforcing,
+    );
+    let mut storage = seeded_memory_storage(&qm.schema_context().current_schema);
+    let branch_name = ComposedBranchName::new("dev", SchemaHash::compute(&schema), "alice-draft")
+        .to_branch_name()
+        .as_str()
+        .to_string();
+    let todos_descriptor = schema
+        .get(&TableName::new("todos"))
+        .unwrap()
+        .columns
+        .clone();
+    let todo_id = create_test_row(&mut storage, Some(todos_metadata()));
+    let client_id = ClientId::new();
+    connect_client(&mut qm, &storage, client_id);
+    qm.sync_manager_mut()
+        .set_client_session(client_id, Session::new("alice"));
+    set_client_query_scope(
+        &mut qm,
+        &storage,
+        client_id,
+        QueryId(1),
+        HashSet::from([(todo_id, BranchName::new(&branch_name))]),
+        None,
+    );
+    qm.sync_manager_mut().take_outbox();
+
+    let content = encode_row(
+        &todos_descriptor,
+        &[Value::Uuid(ObjectId::new()), Value::Text("Draft".into())],
+    )
+    .unwrap();
+    let commit = stored_row_commit(
+        smallvec![],
+        content,
+        1_000,
+        ObjectId::new().to_string(),
+        None,
+    );
+    qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: row_batch_created_payload(
+            todo_id,
+            &branch_name,
+            Some(RowMetadata {
+                id: todo_id,
+                metadata: todos_metadata(),
+            }),
+            &commit,
+        ),
+    });
+
+    for _ in 0..10 {
+        qm.process(&mut storage);
+    }
+
+    let batch_id = row_batch_id_for_commit(todo_id, &branch_name, &commit);
+    let outbox = qm.sync_manager_mut().take_outbox();
+    assert!(client_write_was_rejected(&outbox, client_id, batch_id));
+    let tips = test_row_tip_ids(&storage, todo_id, &branch_name);
+    assert!(tips.is_err() || !tips.unwrap().contains(&batch_id));
+}
+
+#[test]
+// Synced branch insert with complex branch policy:
+//
+//   client todo insert on branch B
+//              |
+//              v
+//   todos.for_branch insert = todo.projectId == $branch.projectId
+//                             AND exists approvals(projectId == $branch.projectId)
+//
+//   Stored rows on branch B         Expected server decision
+//   ------------------------------  ------------------------
+//   approvals[projectId=P]          accept todo[projectId=P]
+fn synced_branch_insert_allows_complex_branch_policy_after_simple_parts_pass() {
+    let mut todo_policies = TablePolicies::default();
+    todo_policies.for_branch = HashMap::from([(
+        TableName::new("branches"),
+        TablePolicies::new().with_insert(PolicyExpr::And(vec![
+            project_matches_branch_policy(),
+            PolicyExpr::Exists {
+                table: "approvals".into(),
+                condition: Box::new(project_matches_branch_policy()),
+            },
+        ])),
+    )]);
+    let schema = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("branches")
+                .column("projectId", ColumnType::Uuid)
+                .column("ownerId", ColumnType::Text)
+                .policies(
+                    TablePolicies::new()
+                        .with_select(PolicyExpr::True)
+                        .with_insert(PolicyExpr::True),
+                ),
+        )
+        .table(
+            TableSchema::builder("todos")
+                .column("projectId", ColumnType::Uuid)
+                .column("title", ColumnType::Text)
+                .policies(todo_policies),
+        )
+        .table(
+            TableSchema::builder("approvals")
+                .column("projectId", ColumnType::Uuid)
+                .policies(
+                    TablePolicies::new()
+                        .with_select(PolicyExpr::True)
+                        .with_insert(PolicyExpr::True),
+                ),
+        )
+        .build();
+    let mut qm = create_query_manager_with_policy_mode(
+        SyncManager::new(),
+        schema.clone(),
+        RowPolicyMode::Enforcing,
+    );
+    let mut storage = seeded_memory_storage(&qm.schema_context().current_schema);
+    let project_id = ObjectId::new();
+    let branch_id = qm
+        .insert(
+            &mut storage,
+            "branches",
+            &[Value::Uuid(project_id), Value::Text("alice".into())],
+        )
+        .expect("insert branch row")
+        .row_id;
+    let branch_name = branch_name_for(&schema, branch_id);
+    qm.insert_on_branch(
+        &mut storage,
+        "approvals",
+        &branch_name,
+        &[Value::Uuid(project_id)],
+        None,
+    )
+    .expect("seed branch approval");
+
+    let todos_descriptor = schema
+        .get(&TableName::new("todos"))
+        .unwrap()
+        .columns
+        .clone();
+    let todo_id = create_test_row(&mut storage, Some(todos_metadata()));
+    let client_id = ClientId::new();
+    connect_client(&mut qm, &storage, client_id);
+    qm.sync_manager_mut()
+        .set_client_session(client_id, Session::new("alice"));
+    set_client_query_scope(
+        &mut qm,
+        &storage,
+        client_id,
+        QueryId(1),
+        HashSet::from([(todo_id, BranchName::new(&branch_name))]),
+        None,
+    );
+    qm.sync_manager_mut().take_outbox();
+
+    let content = encode_row(
+        &todos_descriptor,
+        &[
+            Value::Uuid(project_id),
+            Value::Text("Write branch sync docs through approval".into()),
+        ],
+    )
+    .unwrap();
+    let commit = stored_row_commit(
+        smallvec![],
+        content,
+        1_000,
+        ObjectId::new().to_string(),
+        None,
+    );
+    qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: row_batch_created_payload(
+            todo_id,
+            &branch_name,
+            Some(RowMetadata {
+                id: todo_id,
+                metadata: todos_metadata(),
+            }),
+            &commit,
+        ),
+    });
+
+    for _ in 0..10 {
+        qm.process(&mut storage);
+    }
+
+    let batch_id = row_batch_id_for_commit(todo_id, &branch_name, &commit);
+    let outbox = qm.sync_manager_mut().take_outbox();
+    assert!(!client_write_was_rejected(&outbox, client_id, batch_id));
+    assert!(
+        test_row_tip_ids(&storage, todo_id, &branch_name)
+            .unwrap()
+            .contains(&batch_id)
+    );
+}
+
+#[test]
+// Synced branch delete:
+//
+//   Existing branch todo -> client soft-delete batch
+//
+//   Policy table
+//   -----------------------------  --------
+//   normal todos delete            missing
+//   for_branch todos delete        matches P
+//   expected server decision       accept
+fn synced_branch_delete_uses_branch_policy_without_normal_delete_policy() {
+    let mut todo_policies = TablePolicies::default();
+    todo_policies.for_branch = HashMap::from([(
+        TableName::new("branches"),
+        TablePolicies::new()
+            .with_insert(project_matches_branch_policy())
+            .with_delete(project_matches_branch_policy()),
+    )]);
+    let schema = branch_schema_with_todo_policies(todo_policies);
+    let mut qm = create_query_manager_with_policy_mode(
+        SyncManager::new(),
+        schema.clone(),
+        RowPolicyMode::Enforcing,
+    );
+    let mut storage = seeded_memory_storage(&qm.schema_context().current_schema);
+    let project_id = ObjectId::new();
+    let branch_id = qm
+        .insert(
+            &mut storage,
+            "branches",
+            &[Value::Uuid(project_id), Value::Text("alice".into())],
+        )
+        .expect("insert branch row")
+        .row_id;
+    let branch_name = branch_name_for(&schema, branch_id);
+    let todo = qm
+        .insert_on_branch(
+            &mut storage,
+            "todos",
+            &branch_name,
+            &[
+                Value::Uuid(project_id),
+                Value::Text("Write branch sync docs".into()),
+            ],
+            None,
+        )
+        .expect("seed branch-visible todo");
+    let todos_descriptor = schema
+        .get(&TableName::new("todos"))
+        .unwrap()
+        .columns
+        .clone();
+    let client_id = ClientId::new();
+    connect_client(&mut qm, &storage, client_id);
+    qm.sync_manager_mut()
+        .set_client_session(client_id, Session::new("alice"));
+    set_client_query_scope(
+        &mut qm,
+        &storage,
+        client_id,
+        QueryId(1),
+        HashSet::from([(todo.row_id, BranchName::new(&branch_name))]),
+        None,
+    );
+    qm.sync_manager_mut().take_outbox();
+
+    let content = encode_row(
+        &todos_descriptor,
+        &[
+            Value::Uuid(project_id),
+            Value::Text("Write branch sync docs".into()),
+        ],
+    )
+    .unwrap();
+    let commit = stored_row_commit(
+        smallvec![todo.batch_id],
+        content,
+        2_000,
+        ObjectId::new().to_string(),
+        Some(DeleteKind::Soft),
+    );
+    qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: row_batch_created_payload(
+            todo.row_id,
+            &branch_name,
+            Some(RowMetadata {
+                id: todo.row_id,
+                metadata: todos_metadata(),
+            }),
+            &commit,
+        ),
+    });
+
+    for _ in 0..10 {
+        qm.process(&mut storage);
+    }
+
+    let batch_id = row_batch_id_for_commit(todo.row_id, &branch_name, &commit);
+    let outbox = qm.sync_manager_mut().take_outbox();
+    assert!(!client_write_was_rejected(&outbox, client_id, batch_id));
+    assert!(
+        test_row_tip_ids(&storage, todo.row_id, &branch_name)
+            .unwrap()
+            .contains(&batch_id)
+    );
+}
+
+#[test]
+// Synced update bypass guard:
+//
+//   UUID branch has a readable backing row,
+//   but todos has no for_branch block.
+//
+//   Write path                      Expected
+//   ------------------------------  ----------------
+//   branch update from client       reject
+//   normal update policy            must not bypass
+fn synced_branch_update_on_uuid_branch_without_for_branch_denies_normal_policy_bypass() {
+    let schema = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("branches")
+                .column("projectId", ColumnType::Uuid)
+                .column("ownerId", ColumnType::Text)
+                .policies(
+                    TablePolicies::new()
+                        .with_select(PolicyExpr::True)
+                        .with_insert(PolicyExpr::True),
+                ),
+        )
+        .table(
+            TableSchema::builder("todos")
+                .column("projectId", ColumnType::Uuid)
+                .column("title", ColumnType::Text)
+                .policies(
+                    TablePolicies::new().with_update(Some(PolicyExpr::True), PolicyExpr::True),
+                ),
+        )
+        .build();
+    let mut qm = create_query_manager_with_policy_mode(
+        SyncManager::new(),
+        schema.clone(),
+        RowPolicyMode::Enforcing,
+    );
+    let mut storage = seeded_memory_storage(&qm.schema_context().current_schema);
+    let project_id = ObjectId::new();
+    let branch_id = qm
+        .insert(
+            &mut storage,
+            "branches",
+            &[Value::Uuid(project_id), Value::Text("alice".into())],
+        )
+        .expect("insert branch row")
+        .row_id;
+    let branch_name = branch_name_for(&schema, branch_id);
+    let todos_descriptor = schema
+        .get(&TableName::new("todos"))
+        .unwrap()
+        .columns
+        .clone();
+    let todo_id = create_test_row(&mut storage, Some(todos_metadata()));
+    let seed_content = encode_row(
+        &todos_descriptor,
+        &[
+            Value::Uuid(project_id),
+            Value::Text("Original branch title".into()),
+        ],
+    )
+    .unwrap();
+    let seed_commit = stored_row_commit(
+        smallvec![],
+        seed_content,
+        1_000,
+        ObjectId::new().to_string(),
+        None,
+    );
+    let seed_batch_id = row_batch_id_for_commit(todo_id, &branch_name, &seed_commit);
+    apply_test_row_batch(
+        &mut storage,
+        todo_id,
+        &branch_name,
+        seed_commit.to_row(todo_id, &branch_name, RowState::VisibleDirect),
+    )
+    .expect("seed branch row");
+    let client_id = ClientId::new();
+    connect_client(&mut qm, &storage, client_id);
+    qm.sync_manager_mut()
+        .set_client_session(client_id, Session::new("alice"));
+    set_client_query_scope(
+        &mut qm,
+        &storage,
+        client_id,
+        QueryId(1),
+        HashSet::from([(todo_id, BranchName::new(&branch_name))]),
+        None,
+    );
+    qm.sync_manager_mut().take_outbox();
+
+    let update_content = encode_row(
+        &todos_descriptor,
+        &[
+            Value::Uuid(project_id),
+            Value::Text("Unauthorized branch title".into()),
+        ],
+    )
+    .unwrap();
+    let update_commit = stored_row_commit(
+        smallvec![seed_batch_id],
+        update_content,
+        2_000,
+        ObjectId::new().to_string(),
+        None,
+    );
+    qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: row_batch_created_payload(
+            todo_id,
+            &branch_name,
+            Some(RowMetadata {
+                id: todo_id,
+                metadata: todos_metadata(),
+            }),
+            &update_commit,
+        ),
+    });
+
+    for _ in 0..10 {
+        qm.process(&mut storage);
+    }
+
+    let update_batch_id = row_batch_id_for_commit(todo_id, &branch_name, &update_commit);
+    let outbox = qm.sync_manager_mut().take_outbox();
+    assert!(client_write_was_rejected(
+        &outbox,
+        client_id,
+        update_batch_id
+    ));
+    assert!(
+        !test_row_tip_ids(&storage, todo_id, &branch_name)
+            .unwrap()
+            .contains(&update_batch_id)
+    );
+}
+
+#[test]
+// Lens-aware local insert:
+//
+//   legacy todos(projectId,title)
+//        --lens adds ownerId=alice-->
+//   auth todos(projectId,title,ownerId)
+//
+//   Session alice insert: accept
+//   Session bob insert: deny
+fn local_branch_insert_uses_current_permissions_after_lens_transform() {
+    let legacy = branch_schema_without_backing_policy(TablePolicies::new());
+    let mut auth_todo_policies = TablePolicies::default();
+    auth_todo_policies.for_branch = HashMap::from([(
+        TableName::new("branches"),
+        TablePolicies::new().with_insert(PolicyExpr::Cmp {
+            column: "ownerId".into(),
+            op: CmpOp::Eq,
+            value: PolicyValue::SessionRef(vec!["user_id".into()]),
+        }),
+    )]);
+    let auth = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("branches")
+                .column("projectId", ColumnType::Uuid)
+                .column("ownerId", ColumnType::Text)
+                .policies(TablePolicies::new().with_select(PolicyExpr::Cmp {
+                    column: "ownerId".into(),
+                    op: CmpOp::Eq,
+                    value: PolicyValue::SessionRef(vec!["user_id".into()]),
+                })),
+        )
+        .table(
+            TableSchema::builder("todos")
+                .column("projectId", ColumnType::Uuid)
+                .column("title", ColumnType::Text)
+                .column("ownerId", ColumnType::Text)
+                .policies(auth_todo_policies),
+        )
+        .build();
+    let legacy_hash = SchemaHash::compute(&legacy);
+    let auth_hash = SchemaHash::compute(&auth);
+    let mut transform = LensTransform::new();
+    transform.push(
+        LensOp::AddColumn {
+            table: "todos".to_string(),
+            column: "ownerId".to_string(),
+            column_type: ColumnType::Text,
+            default: Value::Text("alice".to_string()),
+        },
+        false,
+    );
+    let lens = Lens::new(legacy_hash, auth_hash, transform);
+    let mut qm = create_query_manager_with_policy_mode(
+        SyncManager::new(),
+        legacy.clone(),
+        RowPolicyMode::Enforcing,
+    );
+    qm.set_known_schemas(Arc::new(HashMap::from([
+        (legacy_hash, legacy.clone()),
+        (auth_hash, auth.clone()),
+    ])));
+    qm.register_lens(lens);
+    qm.set_authorization_schema(auth);
+    let mut storage = seeded_memory_storage(&qm.schema_context().current_schema);
+    let project_id = ObjectId::new();
+    let branch_id = qm
+        .insert(
+            &mut storage,
+            "branches",
+            &[Value::Uuid(project_id), Value::Text("alice".into())],
+        )
+        .expect("insert branch row")
+        .row_id;
+    let branch_name = branch_name_for(&legacy, branch_id);
+
+    qm.insert_on_branch(
+        &mut storage,
+        "todos",
+        &branch_name,
+        &[
+            Value::Uuid(project_id),
+            Value::Text("Write lens-aware branch docs".into()),
+        ],
+        Some(&WriteContext::from_session(Session::new("alice"))),
+    )
+    .expect("branch policy should evaluate against transformed authorization row");
+
+    let err = qm
+        .insert_on_branch(
+            &mut storage,
+            "todos",
+            &branch_name,
+            &[
+                Value::Uuid(project_id),
+                Value::Text("Bob should not write this".into()),
+            ],
+            Some(&WriteContext::from_session(Session::new("bob"))),
+        )
+        .expect_err("bob should not satisfy transformed owner policy");
+    assert!(matches!(
+        err,
+        QueryError::PolicyDenied {
+            table,
+            operation: Operation::Insert
+        } if table == TableName::new("todos")
+    ));
+}
+
+fn branch_ref_lens_schemas() -> (Schema, Schema, Lens, SchemaHash, SchemaHash) {
+    let legacy = SchemaBuilder::new()
+        .table(TableSchema::builder("branches").column("projectId", ColumnType::Uuid))
+        .table(
+            TableSchema::builder("todos")
+                .column("projectId", ColumnType::Uuid)
+                .column("title", ColumnType::Text),
+        )
+        .build();
+    let mut auth_todo_policies = TablePolicies::default();
+    auth_todo_policies.for_branch = HashMap::from([(
+        TableName::new("branches"),
+        TablePolicies::new().with_insert(PolicyExpr::Cmp {
+            column: "createdBy".into(),
+            op: CmpOp::Eq,
+            value: PolicyValue::BranchRef("ownerId".into()),
+        }),
+    )]);
+    let auth = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("branches")
+                .column("projectId", ColumnType::Uuid)
+                .column("ownerId", ColumnType::Text)
+                .policies(
+                    TablePolicies::new()
+                        .with_select(PolicyExpr::True)
+                        .with_insert(PolicyExpr::True),
+                ),
+        )
+        .table(
+            TableSchema::builder("todos")
+                .column("projectId", ColumnType::Uuid)
+                .column("title", ColumnType::Text)
+                .column("createdBy", ColumnType::Text)
+                .policies(auth_todo_policies),
+        )
+        .build();
+    let legacy_hash = SchemaHash::compute(&legacy);
+    let auth_hash = SchemaHash::compute(&auth);
+    let mut transform = LensTransform::new();
+    transform.push(
+        LensOp::AddColumn {
+            table: "branches".to_string(),
+            column: "ownerId".to_string(),
+            column_type: ColumnType::Text,
+            default: Value::Text("alice".to_string()),
+        },
+        false,
+    );
+    transform.push(
+        LensOp::AddColumn {
+            table: "todos".to_string(),
+            column: "createdBy".to_string(),
+            column_type: ColumnType::Text,
+            default: Value::Text("alice".to_string()),
+        },
+        false,
+    );
+    let lens = Lens::new(legacy_hash, auth_hash, transform);
+    (legacy, auth, lens, legacy_hash, auth_hash)
+}
+
+fn branch_ref_read_lens_schemas() -> (Schema, Schema, Lens, SchemaHash, SchemaHash) {
+    let (legacy, mut auth, lens, legacy_hash, auth_hash) = branch_ref_lens_schemas();
+    let todo_policies = auth
+        .get_mut(&TableName::new("todos"))
+        .expect("todos table should exist")
+        .policies
+        .for_branch
+        .get_mut(&TableName::new("branches"))
+        .expect("branch policies should exist");
+    todo_policies.select = OperationPolicy::using(PolicyExpr::Cmp {
+        column: "createdBy".into(),
+        op: CmpOp::Eq,
+        value: PolicyValue::BranchRef("ownerId".into()),
+    });
+    (legacy, auth, lens, legacy_hash, auth_hash)
+}
+
+fn branch_backing_inherits_lens_schemas() -> (Schema, Schema, Lens, SchemaHash, SchemaHash) {
+    let legacy = SchemaBuilder::new()
+        .table(TableSchema::builder("projects").column("name", ColumnType::Text))
+        .table(TableSchema::builder("branches").fk_column("projectId", "projects"))
+        .table(
+            TableSchema::builder("todos")
+                .fk_column("projectId", "projects")
+                .column("title", ColumnType::Text),
+        )
+        .build();
+
+    let auth = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("projects")
+                .column("name", ColumnType::Text)
+                .column("ownerId", ColumnType::Text)
+                .policies(TablePolicies::new().with_select(PolicyExpr::Cmp {
+                    column: "ownerId".into(),
+                    op: CmpOp::Eq,
+                    value: PolicyValue::SessionRef(vec!["user_id".into()]),
+                })),
+        )
+        .table(
+            TableSchema::builder("branches")
+                .fk_column("projectId", "projects")
+                .policies(TablePolicies::new().with_select(PolicyExpr::Inherits {
+                    operation: Operation::Select,
+                    via_column: "projectId".into(),
+                    max_depth: None,
+                })),
+        )
+        .table(
+            TableSchema::builder("todos")
+                .fk_column("projectId", "projects")
+                .column("title", ColumnType::Text)
+                .policies({
+                    let mut todo_policies = TablePolicies::default();
+                    todo_policies.for_branch = HashMap::from([(
+                        TableName::new("branches"),
+                        TablePolicies::new().with_select(PolicyExpr::True),
+                    )]);
+                    todo_policies
+                }),
+        )
+        .build();
+
+    let legacy_hash = SchemaHash::compute(&legacy);
+    let auth_hash = SchemaHash::compute(&auth);
+    let mut transform = LensTransform::new();
+    transform.push(
+        LensOp::AddColumn {
+            table: "projects".to_string(),
+            column: "ownerId".to_string(),
+            column_type: ColumnType::Text,
+            default: Value::Text("alice".to_string()),
+        },
+        false,
+    );
+    let lens = Lens::new(legacy_hash, auth_hash, transform);
+
+    (legacy, auth, lens, legacy_hash, auth_hash)
+}
+
+#[test]
+// BranchRef lens path for graph read filtering:
+//
+//   legacy backing branch row lacks ownerId
+//        --lens adds ownerId=alice-->
+//   auth branch select compares todo.createdBy == $branch.ownerId
+//
+//   Expected: graph policy filtering transforms the backing row before
+//   evaluating `$branch.ownerId`.
+fn branch_read_transforms_backing_row_before_branch_ref_policy() {
+    let (legacy, auth, lens, legacy_hash, auth_hash) = branch_ref_read_lens_schemas();
+    let mut qm = create_query_manager_with_policy_mode(
+        SyncManager::new(),
+        auth.clone(),
+        RowPolicyMode::PermissiveLocal,
+    );
+    qm.set_known_schemas(Arc::new(HashMap::from([
+        (legacy_hash, legacy.clone()),
+        (auth_hash, auth.clone()),
+    ])));
+    qm.add_live_schema(legacy.clone());
+    qm.register_lens(lens);
+    let mut storage = seeded_memory_storage(&qm.schema_context().current_schema);
+    let project_id = ObjectId::new();
+    let legacy_main_branch = ComposedBranchName::new("dev", legacy_hash, "main")
+        .to_branch_name()
+        .as_str()
+        .to_string();
+    let branch_id = ObjectId::new();
+    let legacy_branch_descriptor = legacy
+        .get(&TableName::new("branches"))
+        .expect("legacy branches table should exist")
+        .columns
+        .clone();
+    let branch_commit = stored_row_commit(
+        smallvec![],
+        encode_row(&legacy_branch_descriptor, &[Value::Uuid(project_id)]).unwrap(),
+        1_000,
+        "alice",
+        None,
+    );
+    qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Server(ServerId::new()),
+        payload: row_batch_created_payload(
+            branch_id,
+            &legacy_main_branch,
+            Some(RowMetadata {
+                id: branch_id,
+                metadata: branches_metadata(),
+            }),
+            &branch_commit,
+        ),
+    });
+    let branch_name = branch_name_for(&legacy, branch_id);
+    let todo_id = ObjectId::new();
+    let legacy_todo_descriptor = legacy
+        .get(&TableName::new("todos"))
+        .expect("legacy todos table should exist")
+        .columns
+        .clone();
+    let todo_commit = stored_row_commit(
+        smallvec![],
+        encode_row(
+            &legacy_todo_descriptor,
+            &[
+                Value::Uuid(project_id),
+                Value::Text("Read branch-ref lens docs".into()),
+            ],
+        )
+        .unwrap(),
+        1_001,
+        "alice",
+        None,
+    );
+    qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Server(ServerId::new()),
+        payload: row_batch_created_payload(
+            todo_id,
+            &branch_name,
+            Some(RowMetadata {
+                id: todo_id,
+                metadata: todos_metadata(),
+            }),
+            &todo_commit,
+        ),
+    });
+    qm.process(&mut storage);
+
+    let rows = query_rows(
+        &mut qm,
+        &mut storage,
+        QueryBuilder::new("todos").branch(&branch_name).build(),
+        Some(Session::new("alice")),
+    );
+    assert_eq!(
+        rows.len(),
+        1,
+        "branch read should use transformed backing row for BranchRef"
+    );
+}
+
+#[test]
+// Inherited backing-row select through a lens:
+//
+//   legacy projects(name)
+//        --lens adds ownerId=alice-->
+//   auth branches.select inherits projects.select(ownerId == session.user_id)
+//
+//   Expected: graph policy filtering transforms the inherited project row before
+//   evaluating the backing branch row's select policy.
+fn branch_backing_select_transforms_related_rows_before_policy_eval() {
+    let (legacy, auth, lens, legacy_hash, auth_hash) = branch_backing_inherits_lens_schemas();
+    let mut qm = create_query_manager_with_policy_mode(
+        SyncManager::new(),
+        auth.clone(),
+        RowPolicyMode::PermissiveLocal,
+    );
+    qm.set_known_schemas(Arc::new(HashMap::from([
+        (legacy_hash, legacy.clone()),
+        (auth_hash, auth.clone()),
+    ])));
+    qm.add_live_schema(legacy.clone());
+    qm.register_lens(lens);
+    let mut storage = seeded_memory_storage(&qm.schema_context().current_schema);
+
+    let legacy_main_branch = ComposedBranchName::new("dev", legacy_hash, "main")
+        .to_branch_name()
+        .as_str()
+        .to_string();
+
+    let project_id = ObjectId::new();
+    let legacy_project_descriptor = legacy
+        .get(&TableName::new("projects"))
+        .expect("legacy projects table should exist")
+        .columns
+        .clone();
+    let project_commit = stored_row_commit(
+        smallvec![],
+        encode_row(
+            &legacy_project_descriptor,
+            &[Value::Text("Legacy project".into())],
+        )
+        .unwrap(),
+        1_000,
+        "alice",
+        None,
+    );
+    qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Server(ServerId::new()),
+        payload: row_batch_created_payload(
+            project_id,
+            &legacy_main_branch,
+            Some(RowMetadata {
+                id: project_id,
+                metadata: projects_metadata(),
+            }),
+            &project_commit,
+        ),
+    });
+
+    let branch_id = ObjectId::new();
+    let legacy_branch_descriptor = legacy
+        .get(&TableName::new("branches"))
+        .expect("legacy branches table should exist")
+        .columns
+        .clone();
+    let branch_commit = stored_row_commit(
+        smallvec![],
+        encode_row(&legacy_branch_descriptor, &[Value::Uuid(project_id)]).unwrap(),
+        1_001,
+        "alice",
+        None,
+    );
+    qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Server(ServerId::new()),
+        payload: row_batch_created_payload(
+            branch_id,
+            &legacy_main_branch,
+            Some(RowMetadata {
+                id: branch_id,
+                metadata: branches_metadata(),
+            }),
+            &branch_commit,
+        ),
+    });
+
+    let branch_name = branch_name_for(&legacy, branch_id);
+    let todo_id = ObjectId::new();
+    let legacy_todo_descriptor = legacy
+        .get(&TableName::new("todos"))
+        .expect("legacy todos table should exist")
+        .columns
+        .clone();
+    let todo_commit = stored_row_commit(
+        smallvec![],
+        encode_row(
+            &legacy_todo_descriptor,
+            &[
+                Value::Uuid(project_id),
+                Value::Text("Read through inherited project policy".into()),
+            ],
+        )
+        .unwrap(),
+        1_002,
+        "alice",
+        None,
+    );
+    qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Server(ServerId::new()),
+        payload: row_batch_created_payload(
+            todo_id,
+            &branch_name,
+            Some(RowMetadata {
+                id: todo_id,
+                metadata: todos_metadata(),
+            }),
+            &todo_commit,
+        ),
+    });
+    qm.process(&mut storage);
+
+    let rows = query_rows(
+        &mut qm,
+        &mut storage,
+        QueryBuilder::new("todos").branch(&branch_name).build(),
+        Some(Session::new("alice")),
+    );
+    assert_eq!(
+        rows.len(),
+        1,
+        "backing branch select should transform inherited project rows before policy eval"
+    );
+}
+
+#[test]
+// BranchRef lens path for local write:
+//
+//   legacy branches(projectId)
+//        --lens adds ownerId=alice-->
+//   auth branch policy compares todo.createdBy == $branch.ownerId
+//
+//   Expected: transformed backing row supplies ownerId for BranchRef.
+fn local_branch_insert_transforms_backing_row_before_branch_ref_policy() {
+    let (legacy, auth, lens, legacy_hash, auth_hash) = branch_ref_lens_schemas();
+    let mut qm = create_query_manager_with_policy_mode(
+        SyncManager::new(),
+        legacy.clone(),
+        RowPolicyMode::PermissiveLocal,
+    );
+    qm.set_known_schemas(Arc::new(HashMap::from([
+        (legacy_hash, legacy.clone()),
+        (auth_hash, auth.clone()),
+    ])));
+    qm.register_lens(lens);
+    let mut storage = seeded_memory_storage(&qm.schema_context().current_schema);
+    let project_id = ObjectId::new();
+    let branch_id = qm
+        .insert(&mut storage, "branches", &[Value::Uuid(project_id)])
+        .expect("insert legacy branch row")
+        .row_id;
+    let branch_name = branch_name_for(&legacy, branch_id);
+    qm.set_authorization_schema(auth);
+
+    qm.insert_on_branch(
+        &mut storage,
+        "todos",
+        &branch_name,
+        &[
+            Value::Uuid(project_id),
+            Value::Text("Write branch-ref lens docs".into()),
+        ],
+        Some(&WriteContext::from_session(Session::new("alice"))),
+    )
+    .expect("branch ref should use transformed backing row");
+}
+
+#[test]
+// BranchRef lens path for synced write:
+//
+//   client row batch on legacy branch
+//        -> server authorization schema
+//        -> transformed backing branch row
+//
+//   Expected: BranchRef reads ownerId after lens transform and accepts write.
+fn synced_branch_insert_transforms_backing_row_before_branch_ref_policy() {
+    let (legacy, auth, lens, legacy_hash, auth_hash) = branch_ref_lens_schemas();
+    let mut qm = create_query_manager_with_policy_mode(
+        SyncManager::new(),
+        legacy.clone(),
+        RowPolicyMode::PermissiveLocal,
+    );
+    qm.set_known_schemas(Arc::new(HashMap::from([
+        (legacy_hash, legacy.clone()),
+        (auth_hash, auth.clone()),
+    ])));
+    qm.register_lens(lens);
+    let mut storage = seeded_memory_storage(&qm.schema_context().current_schema);
+    let project_id = ObjectId::new();
+    let branch_id = qm
+        .insert(&mut storage, "branches", &[Value::Uuid(project_id)])
+        .expect("insert legacy branch row")
+        .row_id;
+    let branch_name = branch_name_for(&legacy, branch_id);
+    qm.set_authorization_schema(auth);
+
+    let todos_descriptor = legacy
+        .get(&TableName::new("todos"))
+        .unwrap()
+        .columns
+        .clone();
+    let todo_id = create_test_row(&mut storage, Some(todos_metadata()));
+    let client_id = ClientId::new();
+    connect_client(&mut qm, &storage, client_id);
+    qm.sync_manager_mut()
+        .set_client_session(client_id, Session::new("alice"));
+    set_client_query_scope(
+        &mut qm,
+        &storage,
+        client_id,
+        QueryId(1),
+        HashSet::from([(todo_id, BranchName::new(&branch_name))]),
+        None,
+    );
+    qm.sync_manager_mut().take_outbox();
+
+    let content = encode_row(
+        &todos_descriptor,
+        &[
+            Value::Uuid(project_id),
+            Value::Text("Write branch-ref sync docs".into()),
+        ],
+    )
+    .unwrap();
+    let commit = stored_row_commit(
+        smallvec![],
+        content,
+        1_000,
+        ObjectId::new().to_string(),
+        None,
+    );
+    qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: row_batch_created_payload(
+            todo_id,
+            &branch_name,
+            Some(RowMetadata {
+                id: todo_id,
+                metadata: todos_metadata(),
+            }),
+            &commit,
+        ),
+    });
+
+    for _ in 0..10 {
+        qm.process(&mut storage);
+    }
+
+    let batch_id = row_batch_id_for_commit(todo_id, &branch_name, &commit);
+    let outbox = qm.sync_manager_mut().take_outbox();
+    assert!(!client_write_was_rejected(&outbox, client_id, batch_id));
+    assert!(
+        test_row_tip_ids(&storage, todo_id, &branch_name)
+            .unwrap()
+            .contains(&batch_id)
+    );
+}

--- a/crates/jazz-tools/src/query_manager/relation_ir.rs
+++ b/crates/jazz-tools/src/query_manager/relation_ir.rs
@@ -43,6 +43,7 @@ pub enum RowIdRef {
 pub enum ValueRef {
     Literal(Value),
     SessionRef(Vec<String>),
+    BranchRef(String),
     OuterColumn(ColumnRef),
     FrontierColumn(ColumnRef),
     RowId(RowIdRef),
@@ -143,6 +144,10 @@ pub enum RelExpr {
     TableScan {
         table: TableName,
     },
+    Branch {
+        input: Box<RelExpr>,
+        branches: Vec<String>,
+    },
     Filter {
         input: Box<RelExpr>,
         predicate: PredicateExpr,
@@ -225,6 +230,10 @@ pub fn normalize_gather_depth(requested: Option<usize>) -> Result<usize, Relatio
 pub fn canonicalize_rel_expr(expr: RelExpr) -> Result<RelExpr, RelationIrError> {
     match expr {
         RelExpr::TableScan { .. } => Ok(expr),
+        RelExpr::Branch { input, branches } => Ok(RelExpr::Branch {
+            input: Box::new(canonicalize_rel_expr(*input)?),
+            branches,
+        }),
         RelExpr::Filter { input, predicate } => Ok(RelExpr::Filter {
             input: Box::new(canonicalize_rel_expr(*input)?),
             predicate: canonicalize_predicate(predicate),

--- a/crates/jazz-tools/src/query_manager/relation_ir_query_plan.rs
+++ b/crates/jazz-tools/src/query_manager/relation_ir_query_plan.rs
@@ -9,11 +9,11 @@ use super::relation_ir::{
 use super::types::TableName;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct QueryEnvelope<'a> {
-    core: &'a RelExpr,
-    order_by: Vec<(String, SortDirection)>,
-    offset: usize,
-    limit: Option<usize>,
+pub(crate) struct QueryEnvelope<'a> {
+    pub(crate) core: &'a RelExpr,
+    pub(crate) order_by: Vec<(String, SortDirection)>,
+    pub(crate) offset: usize,
+    pub(crate) limit: Option<usize>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -29,6 +29,7 @@ struct LinearJoinInfo {
 struct RuntimeCorePlan {
     table: TableName,
     base_scope: String,
+    branches: Option<Vec<String>>,
     disjuncts: Vec<Conjunction>,
     joins: Vec<JoinSpec>,
     result_element_index: Option<usize>,
@@ -528,6 +529,7 @@ fn parse_projected_result_element_plan(
         RuntimeCorePlan {
             table: linear.base_table,
             base_scope: linear.scope_order[0].clone(),
+            branches: None,
             disjuncts: linear.disjuncts,
             joins: linear.joins.clone(),
             result_element_index: Some(index),
@@ -582,6 +584,7 @@ fn parse_gather_core(seed: &RelExpr, step: &RelExpr, max_depth: usize) -> Option
             return Some(RuntimeCorePlan {
                 table: seed_info.base_table,
                 base_scope: seed_info.scope_order[0].clone(),
+                branches: None,
                 disjuncts: seed_info.disjuncts.clone(),
                 joins: Vec::new(),
                 result_element_index: None,
@@ -702,6 +705,7 @@ fn parse_gather_core(seed: &RelExpr, step: &RelExpr, max_depth: usize) -> Option
     Some(RuntimeCorePlan {
         table,
         base_scope,
+        branches: None,
         disjuncts,
         joins: Vec::new(),
         result_element_index: None,
@@ -783,6 +787,13 @@ fn parse_gather_join_info(expr: &RelExpr) -> Option<GatherJoinInfo> {
 
 fn parse_runtime_core_plan(core: &RelExpr) -> Option<RuntimeCorePlan> {
     match core {
+        RelExpr::Branch { input, branches } => {
+            let mut plan = parse_runtime_core_plan(input)?;
+            if !branches.is_empty() {
+                plan.branches = Some(branches.clone());
+            }
+            Some(plan)
+        }
         RelExpr::Gather {
             seed,
             step,
@@ -815,6 +826,7 @@ fn parse_runtime_core_plan(core: &RelExpr) -> Option<RuntimeCorePlan> {
             Some(RuntimeCorePlan {
                 table: linear.base_table,
                 base_scope: linear.scope_order[0].clone(),
+                branches: None,
                 disjuncts: linear.disjuncts,
                 joins: linear.joins,
                 result_element_index: None,
@@ -837,6 +849,7 @@ fn parse_runtime_core_plan(core: &RelExpr) -> Option<RuntimeCorePlan> {
             Some(RuntimeCorePlan {
                 table: linear.base_table,
                 base_scope: linear.scope_order[0].clone(),
+                branches: None,
                 disjuncts: linear.disjuncts,
                 joins: linear.joins.clone(),
                 result_element_index,
@@ -854,6 +867,7 @@ fn parse_runtime_core_plan(core: &RelExpr) -> Option<RuntimeCorePlan> {
             Some(RuntimeCorePlan {
                 table: linear.base_table,
                 base_scope: linear.scope_order[0].clone(),
+                branches: None,
                 disjuncts: linear.disjuncts,
                 joins: linear.joins,
                 result_element_index: None,
@@ -865,7 +879,7 @@ fn parse_runtime_core_plan(core: &RelExpr) -> Option<RuntimeCorePlan> {
     }
 }
 
-fn unwrap_query_envelope(expr: &RelExpr) -> QueryEnvelope<'_> {
+pub(crate) fn unwrap_query_envelope(expr: &RelExpr) -> QueryEnvelope<'_> {
     let mut current = expr;
     let mut order_by = Vec::new();
     let mut offset = 0;
@@ -930,7 +944,7 @@ pub(crate) fn lower_relation_to_execution_plan(
     Some(ExecutionQueryPlan {
         table: core_plan.table,
         base_scope: core_plan.base_scope,
-        branches: branches.to_vec(),
+        branches: core_plan.branches.unwrap_or_else(|| branches.to_vec()),
         disjuncts: core_plan.disjuncts,
         joins: core_plan.joins,
         recursive: core_plan.recursive,
@@ -1002,6 +1016,33 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn lower_relation_to_execution_plan_uses_branch_wrapper_branches() {
+        let relation: RelExpr = serde_json::from_value(serde_json::json!({
+            "Branch": {
+                "input": {
+                    "TableScan": {
+                        "table": "todos"
+                    }
+                },
+                "branches": ["branch-a"]
+            }
+        }))
+        .expect("branch relation IR should deserialize");
+
+        let inherited_branches = vec!["main".to_string()];
+        let plan = lower_relation_to_execution_plan(
+            &relation,
+            &inherited_branches,
+            false,
+            Vec::new(),
+            None,
+        )
+        .expect("branch relation IR should lower");
+
+        assert_eq!(plan.branches, vec!["branch-a"]);
     }
 
     #[test]

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant};
 
 use crate::metadata::{MetadataKey, RowProvenance};
 use crate::object::{BranchName, ObjectId};
-use crate::query_manager::graph_nodes::policy_eval::PolicyContextEvaluator;
+use crate::query_manager::encoding::{decode_row, encode_row};
 use crate::row_histories::BatchId;
 use crate::schema_manager::LensTransformer;
 use crate::storage::Storage;
@@ -14,13 +14,16 @@ use crate::sync_manager::{
 };
 
 use super::manager::{QueryManager, SchemaWarningAccumulator, ServerQuerySubscription};
-use super::policy::{ComplexClause, Operation, PolicyExpr};
+use super::permission_routing::{
+    PermissionDecision, PermissionEvaluationRequest, branch_policy_scope,
+};
+use super::policy::{ComplexClause, Operation};
 use super::policy_graph::{PolicyGraph, PolicyGraphBuildOptions};
 use super::session::Session;
 use super::settlement_eval_cache::SettlementEvalCache;
 use super::types::{
-    ComposedBranchName, LoadedRow, Row, RowDescriptor, Schema, SchemaHash, TableName, TableSchema,
-    Value,
+    ComposedBranchName, LoadedRow, PermissionPhase, RowDescriptor, Schema, SchemaHash, TableName,
+    TableSchema, Tuple, TupleElement, TupleProvenance, Value,
 };
 
 const MAX_INITIAL_QUERY_REPLAY_OUTBOX_PER_PASS: usize = 32;
@@ -50,21 +53,6 @@ pub(super) struct RowTransformContext<'a> {
         &'a std::collections::HashMap<String, crate::query_manager::types::SchemaHash>,
     pub(super) schema_context: &'a crate::schema_manager::SchemaContext,
     pub(super) schema_warnings: &'a mut SchemaWarningAccumulator,
-}
-
-pub(crate) struct AuthorizationPolicyRequest<'a> {
-    pub(crate) object_id: ObjectId,
-    pub(crate) branch_name: BranchName,
-    pub(crate) table_name: TableName,
-    pub(crate) policy: &'a PolicyExpr,
-    pub(crate) content: &'a [u8],
-    pub(crate) provenance: &'a crate::metadata::RowProvenance,
-    pub(crate) session: &'a Session,
-    pub(crate) auth_schema: &'a Schema,
-    pub(crate) auth_context: &'a crate::schema_manager::SchemaContext,
-    pub(crate) source_branch_schema_map: &'a std::collections::HashMap<String, SchemaHash>,
-    pub(crate) operation: Operation,
-    pub(crate) settlement_eval_cache: Option<&'a mut SettlementEvalCache>,
 }
 
 struct UpdatePermissionRequest<'a> {
@@ -281,7 +269,7 @@ impl QueryManager {
         None
     }
 
-    fn transform_content_to_authorization_schema(
+    pub(super) fn transform_content_to_authorization_schema(
         &self,
         table: &str,
         content: &[u8],
@@ -318,7 +306,7 @@ impl QueryManager {
             .map(|result| result.data)
     }
 
-    fn load_row_for_authorization_context(
+    pub(super) fn load_row_for_authorization_context(
         &mut self,
         storage: &dyn Storage,
         object_id: ObjectId,
@@ -360,72 +348,6 @@ impl QueryManager {
         ))
     }
 
-    pub(super) fn evaluate_authorization_policy(
-        &mut self,
-        storage: &dyn Storage,
-        request: AuthorizationPolicyRequest<'_>,
-    ) -> bool {
-        let AuthorizationPolicyRequest {
-            object_id,
-            branch_name,
-            table_name,
-            policy,
-            content,
-            provenance,
-            session,
-            auth_schema,
-            auth_context,
-            source_branch_schema_map,
-            operation,
-            settlement_eval_cache,
-        } = request;
-
-        let Some(table_schema) = auth_schema.get(&table_name) else {
-            return false;
-        };
-        let Some(transformed) = self.transform_content_to_authorization_schema(
-            table_name.as_str(),
-            content,
-            BatchId([0; 16]),
-            branch_name,
-            source_branch_schema_map,
-            auth_context,
-        ) else {
-            return false;
-        };
-
-        let mut evaluator = PolicyContextEvaluator::new(
-            auth_schema,
-            session,
-            branch_name.as_str(),
-            self.row_policy_mode,
-        )
-        .with_settlement_eval_cache(settlement_eval_cache);
-        let row = Row::new(object_id, transformed, BatchId([0; 16]), provenance.clone());
-        let mut visited = HashSet::new();
-        let mut row_loader = |related_id: ObjectId, _table_hint: Option<TableName>| {
-            self.load_row_for_authorization_context(
-                storage,
-                related_id,
-                branch_name,
-                source_branch_schema_map,
-                auth_context,
-            )
-        };
-
-        evaluator.evaluate_row_access(
-            operation,
-            &row,
-            &table_schema.columns,
-            table_name.as_str(),
-            Some(policy),
-            storage,
-            &mut row_loader,
-            0,
-            &mut visited,
-        )
-    }
-
     #[allow(clippy::too_many_arguments)]
     pub(super) fn provenance_row_matches_current_select_policy(
         &mut self,
@@ -457,24 +379,37 @@ impl QueryManager {
         let tip_provenance = row.row_provenance();
 
         let table_name = TableName::new(&table);
-        let Some(select_policy) = auth_schema
-            .get(&table_name)
-            .and_then(|table_schema| table_schema.policies.select_policy())
-        else {
-            return !self.row_policy_mode.denies_missing_explicit_policy()
-                && auth_schema.contains_key(&table_name);
-        };
         let Some(session) = session else {
-            return false;
+            if branch_policy_scope(&branch_name).is_some() {
+                return false;
+            }
+            let Some(table_schema) = auth_schema.get(&table_name) else {
+                return false;
+            };
+            return table_schema.policies.select_policy().is_none()
+                && !self.row_policy_mode.denies_missing_explicit_policy();
         };
 
-        self.evaluate_authorization_policy(
+        let route = self.resolve_permission_route(
             storage,
-            AuthorizationPolicyRequest {
+            branch_name,
+            table_name,
+            session,
+            auth_schema,
+            auth_context,
+            source_branch_schema_map,
+        );
+        if route.is_denied() {
+            return false;
+        }
+
+        self.evaluate_permission_route(
+            storage,
+            &route,
+            PermissionEvaluationRequest {
                 object_id,
                 branch_name,
                 table_name,
-                policy: select_policy,
                 content: &tip_content,
                 provenance: &tip_provenance,
                 session,
@@ -482,9 +417,161 @@ impl QueryManager {
                 auth_context,
                 source_branch_schema_map,
                 operation: Operation::Select,
+                phase: PermissionPhase::Using,
                 settlement_eval_cache: Some(settlement_eval_cache),
             },
         )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn authorized_tuple_provenance(
+        &mut self,
+        storage: &dyn Storage,
+        settlement_eval_cache: &mut SettlementEvalCache,
+        tuple: &Tuple,
+        session: Option<&Session>,
+        auth_schema: &Schema,
+        auth_context: &crate::schema_manager::SchemaContext,
+        source_branch_schema_map: &std::collections::HashMap<String, SchemaHash>,
+        authorization_cache: &mut HashMap<(ObjectId, BranchName), bool>,
+    ) -> Option<TupleProvenance> {
+        let mut authorized = TupleProvenance::new();
+        for (object_id, branch_name) in tuple.provenance().iter().copied() {
+            let allowed = *authorization_cache
+                .entry((object_id, branch_name))
+                .or_insert_with(|| {
+                    self.provenance_row_matches_current_select_policy(
+                        storage,
+                        settlement_eval_cache,
+                        object_id,
+                        branch_name,
+                        session,
+                        auth_schema,
+                        auth_context,
+                        source_branch_schema_map,
+                    )
+                });
+            if allowed {
+                authorized.insert((object_id, branch_name));
+            }
+        }
+
+        let output_rows_are_visible = tuple.iter().all(|element| {
+            Self::nested_row_authorized(element.id(), tuple.provenance(), &authorized)
+        });
+        output_rows_are_visible.then_some(authorized)
+    }
+
+    fn nested_row_authorized(
+        object_id: ObjectId,
+        tuple_provenance: &TupleProvenance,
+        authorized_provenance: &TupleProvenance,
+    ) -> bool {
+        let mut saw_denied_scope = false;
+        let mut saw_authorized_scope = false;
+
+        for scoped_object @ (scoped_id, _) in tuple_provenance.iter().copied() {
+            if scoped_id != object_id {
+                continue;
+            }
+            if authorized_provenance.contains(&scoped_object) {
+                saw_authorized_scope = true;
+            } else {
+                saw_denied_scope = true;
+            }
+        }
+
+        saw_authorized_scope && !saw_denied_scope
+    }
+
+    fn filter_unauthorized_nested_rows(
+        value: &mut Value,
+        tuple_provenance: &TupleProvenance,
+        authorized_provenance: &TupleProvenance,
+    ) {
+        match value {
+            Value::Array(values) => {
+                values.retain_mut(|value| match value {
+                    Value::Row {
+                        id: Some(object_id),
+                        values,
+                    } => {
+                        if !Self::nested_row_authorized(
+                            *object_id,
+                            tuple_provenance,
+                            authorized_provenance,
+                        ) {
+                            return false;
+                        }
+                        for value in values {
+                            Self::filter_unauthorized_nested_rows(
+                                value,
+                                tuple_provenance,
+                                authorized_provenance,
+                            );
+                        }
+                        true
+                    }
+                    other => {
+                        Self::filter_unauthorized_nested_rows(
+                            other,
+                            tuple_provenance,
+                            authorized_provenance,
+                        );
+                        true
+                    }
+                });
+            }
+            Value::Row { values, .. } => {
+                for value in values {
+                    Self::filter_unauthorized_nested_rows(
+                        value,
+                        tuple_provenance,
+                        authorized_provenance,
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn tuple_with_authorized_scope(
+        mut tuple: Tuple,
+        descriptor: &RowDescriptor,
+        authorized_provenance: TupleProvenance,
+    ) -> Option<Tuple> {
+        let tuple_provenance = tuple.provenance().clone();
+        if !tuple.iter().all(|element| {
+            Self::nested_row_authorized(element.id(), &tuple_provenance, &authorized_provenance)
+        }) {
+            return None;
+        }
+
+        if tuple.len() == 1
+            && let Some(TupleElement::Row { content, .. }) = tuple.get_mut(0)
+        {
+            let mut values = decode_row(descriptor, content).ok()?;
+            for value in &mut values {
+                Self::filter_unauthorized_nested_rows(
+                    value,
+                    &tuple_provenance,
+                    &authorized_provenance,
+                );
+            }
+            *content = encode_row(descriptor, &values).ok()?.into();
+        }
+
+        Some(tuple.with_provenance(authorized_provenance))
+    }
+
+    fn tuple_provenance_key(tuple: &Tuple) -> Vec<(ObjectId, BranchName)> {
+        let mut key: Vec<_> = tuple.provenance().iter().copied().collect();
+        key.sort_by(|left, right| {
+            left.0
+                .cmp(&right.0)
+                .then_with(|| left.1.as_str().cmp(right.1.as_str()))
+        });
+        key
     }
 
     fn authorized_tuples_from_graph_result(
@@ -510,9 +597,7 @@ impl QueryManager {
         };
 
         if !self.row_policy_mode.denies_missing_explicit_policy()
-            && auth_schema
-                .values()
-                .all(|table_schema| table_schema.policies.select.using.is_none())
+            && Self::schema_has_no_explicit_select_policies(&auth_schema)
         {
             return AuthorizedTuplesResult::Ready(graph.current_output_tuples());
         }
@@ -524,27 +609,21 @@ impl QueryManager {
                 .current_output_tuples()
                 .into_iter()
                 .filter_map(|tuple| {
-                    tuple
-                        .provenance()
-                        .iter()
-                        .copied()
-                        .all(|(object_id, branch_name)| {
-                            *authorization_cache
-                                .entry((object_id, branch_name))
-                                .or_insert_with(|| {
-                                    self.provenance_row_matches_current_select_policy(
-                                        storage,
-                                        settlement_eval_cache,
-                                        object_id,
-                                        branch_name,
-                                        session,
-                                        &auth_schema,
-                                        &auth_context,
-                                        source_branch_schema_map,
-                                    )
-                                })
-                        })
-                        .then_some(tuple)
+                    let authorized_provenance = self.authorized_tuple_provenance(
+                        storage,
+                        settlement_eval_cache,
+                        &tuple,
+                        session,
+                        &auth_schema,
+                        &auth_context,
+                        source_branch_schema_map,
+                        &mut authorization_cache,
+                    )?;
+                    Self::tuple_with_authorized_scope(
+                        tuple,
+                        &graph.combined_descriptor,
+                        authorized_provenance,
+                    )
                 })
                 .collect(),
         )
@@ -591,42 +670,44 @@ impl QueryManager {
         };
 
         if !self.row_policy_mode.denies_missing_explicit_policy()
-            && auth_schema
-                .values()
-                .all(|table_schema| table_schema.policies.select.using.is_none())
+            && Self::schema_has_no_explicit_select_policies(&auth_schema)
         {
             return Some(graph.sync_scope_object_ids());
         }
 
         let mut authorization_cache: HashMap<(ObjectId, BranchName), bool> = HashMap::new();
+        let mut authorized_scope_by_tuple: HashMap<Vec<(ObjectId, BranchName)>, TupleProvenance> =
+            HashMap::new();
 
         let authorized_scope_tuples = graph.filtered_sync_scope_tuples(|tuple| {
-            tuple
-                .provenance()
-                .iter()
-                .copied()
-                .all(|(object_id, branch_name)| {
-                    *authorization_cache
-                        .entry((object_id, branch_name))
-                        .or_insert_with(|| {
-                            self.provenance_row_matches_current_select_policy(
-                                storage,
-                                settlement_eval_cache,
-                                object_id,
-                                branch_name,
-                                session,
-                                &auth_schema,
-                                &auth_context,
-                                source_branch_schema_map,
-                            )
-                        })
-                })
+            let key = Self::tuple_provenance_key(tuple);
+            match self.authorized_tuple_provenance(
+                storage,
+                settlement_eval_cache,
+                tuple,
+                session,
+                &auth_schema,
+                &auth_context,
+                source_branch_schema_map,
+                &mut authorization_cache,
+            ) {
+                Some(provenance) => {
+                    authorized_scope_by_tuple.insert(key, provenance);
+                    true
+                }
+                None => false,
+            }
         });
 
         Some(
             authorized_scope_tuples
                 .into_iter()
-                .flat_map(|tuple| tuple.provenance().clone().into_iter())
+                .flat_map(|tuple| {
+                    authorized_scope_by_tuple
+                        .remove(&Self::tuple_provenance_key(&tuple))
+                        .unwrap_or_default()
+                        .into_iter()
+                })
                 .collect(),
         )
     }
@@ -653,6 +734,31 @@ impl QueryManager {
         }
 
         query.branches.clone()
+    }
+
+    pub(super) fn resolved_server_query_branches_for_graph(
+        query: &crate::query_manager::query::Query,
+        schema_context: &crate::schema_manager::SchemaContext,
+        graph: &crate::query_manager::graph::QueryGraph,
+    ) -> Vec<String> {
+        fn push_unique(branches: &mut Vec<String>, branch: String) {
+            if !branches.iter().any(|existing| existing == &branch) {
+                branches.push(branch);
+            }
+        }
+
+        let scan_branches = graph.scan_branches();
+        let mut branches = if !scan_branches.is_empty() {
+            scan_branches
+        } else {
+            Self::resolved_server_query_branches(query, schema_context)
+        };
+
+        for branch in query.explicit_array_subquery_branches() {
+            push_unique(&mut branches, branch);
+        }
+
+        branches
     }
 
     pub(super) fn query_for_server_compile(
@@ -729,6 +835,17 @@ impl QueryManager {
                         && session.is_none()
             })
             .unwrap_or(false)
+    }
+
+    fn schema_has_no_explicit_select_policies(schema: &Schema) -> bool {
+        schema.values().all(|table_schema| {
+            table_schema.policies.select.using.is_none()
+                && table_schema
+                    .policies
+                    .for_branch
+                    .values()
+                    .all(|policies| policies.select.using.is_none())
+        })
     }
 
     fn scope_with_policy_context_rows_for_tables<H: Storage + ?Sized>(
@@ -886,22 +1003,22 @@ impl QueryManager {
             // Build QueryGraph with client's session for policy filtering (schema-aware)
             let query_for_compile =
                 Self::query_for_server_compile(&sub.query, &subscription_context);
-            let compile_row_policy_mode = if self
+            let authorization_schema = self
                 .authorization_schema_for_context(
                     &subscription_context.env,
                     &subscription_context.user_branch,
                 )
-                .as_ref()
-                .map(|(auth_schema, _)| auth_schema.as_ref() != schema_for_compile.as_ref())
-                .unwrap_or(false)
-            {
-                crate::query_manager::types::RowPolicyMode::PermissiveLocal
-            } else {
-                self.row_policy_mode
-            };
+                .map(|(auth_schema, _)| auth_schema);
+            let (compile_schema, compile_row_policy_mode, _) =
+                Self::compile_options_with_authorization_schema(
+                    schema_for_compile.as_ref(),
+                    authorization_schema.as_deref(),
+                    self.row_policy_mode,
+                    session_for_policy.as_ref(),
+                );
             let graph = Self::compile_graph(
                 &query_for_compile,
-                &schema_for_compile,
+                &compile_schema,
                 session_for_policy.clone(),
                 &subscription_context,
                 compile_row_policy_mode,
@@ -931,8 +1048,11 @@ impl QueryManager {
             // Initial settle to populate the graph
             let storage_ref: &dyn Storage = storage;
 
-            let branches =
-                Self::resolved_server_query_branches(&query_for_compile, &subscription_context);
+            let branches = Self::resolved_server_query_branches_for_graph(
+                &query_for_compile,
+                &subscription_context,
+                &graph,
+            );
             let table = sub.query.table.as_str().to_string();
             let mut schema_warnings = SchemaWarningAccumulator::default();
             let include_deleted = sub.query.include_deleted;
@@ -1553,7 +1673,7 @@ impl QueryManager {
                 return;
             }
         };
-        let Some(auth_table_schema) = auth_schema.get(&table_name) else {
+        let Some(_) = auth_schema.get(&table_name) else {
             let reason = format!(
                 "{:?} denied on table {} - table missing from current permission schema",
                 check.operation, table_name.0
@@ -1578,33 +1698,6 @@ impl QueryManager {
             );
             return;
         }
-
-        let policy = match check.operation {
-            Operation::Insert => auth_table_schema.policies.insert_policy(),
-            Operation::Update => unreachable!(),
-            Operation::Delete => auth_table_schema.policies.effective_delete_using(),
-            Operation::Select => {
-                self.sync_manager.approve_permission_check(storage, check);
-                return;
-            }
-        };
-
-        let policy = match policy {
-            Some(p) => p,
-            None => {
-                if self.row_policy_mode.denies_missing_explicit_policy() {
-                    let reason = format!(
-                        "{:?} denied on table {} - missing explicit policy",
-                        check.operation, table_name.0
-                    );
-                    self.sync_manager
-                        .reject_permission_check(storage, check, reason);
-                } else {
-                    self.sync_manager.approve_permission_check(storage, check);
-                }
-                return;
-            }
-        };
 
         let content = match check.operation {
             Operation::Insert => check.new_content.as_ref(),
@@ -1653,13 +1746,22 @@ impl QueryManager {
         };
         let source_branch_schema_map = self.branch_schema_map.clone();
 
-        if !self.evaluate_authorization_policy(
+        let route = self.resolve_permission_route(
             storage,
-            AuthorizationPolicyRequest {
+            branch_name,
+            table_name,
+            &check.session,
+            &auth_schema,
+            &auth_context,
+            &source_branch_schema_map,
+        );
+        match self.evaluate_permission_route_decision(
+            storage,
+            &route,
+            PermissionEvaluationRequest {
                 object_id,
                 branch_name,
                 table_name,
-                policy,
                 content,
                 provenance: &provenance,
                 session: &check.session,
@@ -1667,19 +1769,52 @@ impl QueryManager {
                 auth_context: &auth_context,
                 source_branch_schema_map: &source_branch_schema_map,
                 operation: check.operation,
+                phase: PermissionPhase::Check,
                 settlement_eval_cache: None,
             },
         ) {
-            let reason = format!(
-                "{:?} denied by policy on table {}",
-                check.operation, table_name.0
-            );
-            self.sync_manager
-                .reject_permission_check(storage, check, reason);
-            return;
+            PermissionDecision::Allowed => {
+                self.sync_manager.approve_permission_check(storage, check);
+            }
+            PermissionDecision::DeniedRoute => {
+                let reason = format!(
+                    "{:?} denied by branch policy on table {}",
+                    check.operation, table_name.0
+                );
+                self.sync_manager
+                    .reject_permission_check(storage, check, reason);
+            }
+            PermissionDecision::DeniedMissingPolicy => {
+                let reason = if route.is_branch() {
+                    format!(
+                        "{:?} denied by branch policy on table {}",
+                        check.operation, table_name.0
+                    )
+                } else {
+                    format!(
+                        "{:?} denied on table {} - missing explicit policy",
+                        check.operation, table_name.0
+                    )
+                };
+                self.sync_manager
+                    .reject_permission_check(storage, check, reason);
+            }
+            PermissionDecision::DeniedPolicy => {
+                let reason = if route.is_branch() {
+                    format!(
+                        "{:?} denied by branch policy on table {}",
+                        check.operation, table_name.0
+                    )
+                } else {
+                    format!(
+                        "{:?} denied by policy on table {}",
+                        check.operation, table_name.0
+                    )
+                };
+                self.sync_manager
+                    .reject_permission_check(storage, check, reason);
+            }
         }
-
-        self.sync_manager.approve_permission_check(storage, check);
     }
 
     /// Evaluate UPDATE permission with both USING (old row) and WITH CHECK (new row).
@@ -1726,7 +1861,7 @@ impl QueryManager {
             check.old_content = Some(previous_row.data.to_vec());
         }
 
-        let Some(table_schema) = auth_schema.get(&table_name) else {
+        if auth_schema.get(&table_name).is_none() {
             self.sync_manager.reject_permission_check(
                 storage,
                 check,
@@ -1737,14 +1872,42 @@ impl QueryManager {
             );
             return;
         };
-        let using_policy = table_schema.policies.update_using_policy();
-        let check_policy = table_schema.policies.update_check_policy();
         let source_branch_schema_map = self.branch_schema_map.clone();
         let old_provenance = self.current_row_provenance(storage, object_id, branch_name);
         let new_provenance = Self::payload_row_provenance(&check.payload);
 
-        if using_policy.is_none() && check_policy.is_none() {
-            if self.row_policy_mode.denies_missing_explicit_policy() {
+        let route = self.resolve_permission_route(
+            storage,
+            branch_name,
+            table_name,
+            &check.session,
+            auth_schema,
+            auth_context,
+            &source_branch_schema_map,
+        );
+        if route.is_denied() {
+            self.sync_manager.reject_permission_check(
+                storage,
+                check,
+                format!("Update denied by branch policy on table {}", table_name.0),
+            );
+            return;
+        }
+
+        let has_using_policy =
+            route.has_policy_for_operation(Operation::Update, PermissionPhase::Using);
+        let has_check_policy =
+            route.has_policy_for_operation(Operation::Update, PermissionPhase::Check);
+        if !has_using_policy && !has_check_policy {
+            if route.allows_missing_policy(Operation::Update, self.row_policy_mode) {
+                self.sync_manager.approve_permission_check(storage, check);
+            } else if route.is_branch() {
+                self.sync_manager.reject_permission_check(
+                    storage,
+                    check,
+                    format!("Update denied by branch policy on table {}", table_name.0),
+                );
+            } else {
                 self.sync_manager.reject_permission_check(
                     storage,
                     check,
@@ -1753,42 +1916,54 @@ impl QueryManager {
                         table_name.0
                     ),
                 );
-            } else {
-                self.sync_manager.approve_permission_check(storage, check);
             }
             return;
         }
 
-        if let Some(using) = using_policy {
+        if has_using_policy {
             let old_content = match check.old_content.as_ref() {
                 Some(c) if !c.is_empty() => c,
                 _ => {
-                    let reason = format!(
-                        "Update denied by USING policy on table {} - no old content",
-                        table_name.0
-                    );
+                    let reason = if route.is_branch() {
+                        format!(
+                            "Update denied by branch policy on table {} - no old content",
+                            table_name.0
+                        )
+                    } else {
+                        format!(
+                            "Update denied by USING policy on table {} - no old content",
+                            table_name.0
+                        )
+                    };
                     self.sync_manager
                         .reject_permission_check(storage, check, reason);
                     return;
                 }
             };
             let Some(old_provenance) = old_provenance.as_ref() else {
-                let reason = format!(
-                    "Update denied by USING policy on table {} - missing old provenance",
-                    table_name.0
-                );
+                let reason = if route.is_branch() {
+                    format!(
+                        "Update denied by branch policy on table {} - missing old provenance",
+                        table_name.0
+                    )
+                } else {
+                    format!(
+                        "Update denied by USING policy on table {} - missing old provenance",
+                        table_name.0
+                    )
+                };
                 self.sync_manager
                     .reject_permission_check(storage, check, reason);
                 return;
             };
 
-            if !self.evaluate_authorization_policy(
+            if !self.evaluate_permission_route(
                 storage,
-                AuthorizationPolicyRequest {
+                &route,
+                PermissionEvaluationRequest {
                     object_id,
                     branch_name,
                     table_name,
-                    policy: using,
                     content: old_content,
                     provenance: old_provenance,
                     session: &check.session,
@@ -1796,51 +1971,71 @@ impl QueryManager {
                     auth_context,
                     source_branch_schema_map: &source_branch_schema_map,
                     operation: Operation::Update,
+                    phase: PermissionPhase::Using,
                     settlement_eval_cache: None,
                 },
             ) {
-                let reason = format!(
-                    "Update denied by USING policy on table {} - cannot see old row",
-                    table_name.0
-                );
+                let reason = if route.is_branch() {
+                    format!(
+                        "Update denied by branch USING policy on table {}",
+                        table_name.0
+                    )
+                } else {
+                    format!(
+                        "Update denied by USING policy on table {} - cannot see old row",
+                        table_name.0
+                    )
+                };
                 self.sync_manager
                     .reject_permission_check(storage, check, reason);
                 return;
             }
         }
 
-        if let Some(with_check) = check_policy {
+        if has_check_policy {
             let new_content = match check.new_content.as_ref() {
                 Some(c) => c,
                 None => {
-                    self.sync_manager.reject_permission_check(
-                        storage,
-                        check,
+                    let reason = if route.is_branch() {
+                        format!(
+                            "Update denied by branch policy on table {} - missing new content",
+                            table_name.0
+                        )
+                    } else {
                         format!(
                             "Update denied by WITH CHECK policy on table {} - missing new content",
                             table_name.0
-                        ),
-                    );
+                        )
+                    };
+                    self.sync_manager
+                        .reject_permission_check(storage, check, reason);
                     return;
                 }
             };
             let Some(new_provenance) = new_provenance.as_ref() else {
-                let reason = format!(
-                    "Update denied by WITH CHECK policy on table {} - missing new provenance",
-                    table_name.0
-                );
+                let reason = if route.is_branch() {
+                    format!(
+                        "Update denied by branch policy on table {} - missing new provenance",
+                        table_name.0
+                    )
+                } else {
+                    format!(
+                        "Update denied by WITH CHECK policy on table {} - missing new provenance",
+                        table_name.0
+                    )
+                };
                 self.sync_manager
                     .reject_permission_check(storage, check, reason);
                 return;
             };
 
-            if !self.evaluate_authorization_policy(
+            if !self.evaluate_permission_route(
                 storage,
-                AuthorizationPolicyRequest {
+                &route,
+                PermissionEvaluationRequest {
                     object_id,
                     branch_name,
                     table_name,
-                    policy: with_check,
                     content: new_content,
                     provenance: new_provenance,
                     session: &check.session,
@@ -1848,13 +2043,21 @@ impl QueryManager {
                     auth_context,
                     source_branch_schema_map: &source_branch_schema_map,
                     operation: Operation::Update,
+                    phase: PermissionPhase::Check,
                     settlement_eval_cache: None,
                 },
             ) {
-                let reason = format!(
-                    "Update denied by WITH CHECK policy on table {}",
-                    table_name.0
-                );
+                let reason = if route.is_branch() {
+                    format!(
+                        "Update denied by branch WITH CHECK policy on table {}",
+                        table_name.0
+                    )
+                } else {
+                    format!(
+                        "Update denied by WITH CHECK policy on table {}",
+                        table_name.0
+                    )
+                };
                 self.sync_manager
                     .reject_permission_check(storage, check, reason);
                 return;
@@ -1914,12 +2117,9 @@ impl QueryManager {
                     // Get parent's policy for the specified operation
                     let parent_schema = self.schema.get(&parent_table)?;
 
-                    let parent_policy = match operation {
-                        Operation::Select => parent_schema.policies.select_policy(),
-                        Operation::Insert => parent_schema.policies.insert_policy(),
-                        Operation::Update => parent_schema.policies.update_using_policy(),
-                        Operation::Delete => parent_schema.policies.effective_delete_using(),
-                    };
+                    let parent_policy = parent_schema
+                        .policies
+                        .policy_for_operation(*operation, PermissionPhase::Using);
                     let Some(parent_policy) = parent_policy else {
                         if self.row_policy_mode.denies_missing_explicit_policy() {
                             return None;
@@ -2054,5 +2254,37 @@ impl QueryManager {
                     .reject_permission_check(storage, state.pending_check, reason);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query_manager::types::{ColumnDescriptor, ColumnType};
+
+    #[test]
+    fn tuple_with_authorized_scope_drops_row_when_same_id_has_denied_scope() {
+        let descriptor = RowDescriptor::new(vec![ColumnDescriptor::new("title", ColumnType::Text)]);
+        let row_id = ObjectId::new();
+        let allowed_branch = BranchName::new("allowed");
+        let denied_branch = BranchName::new("denied");
+        let content = encode_row(&descriptor, &[Value::Text("denied content".into())]).unwrap();
+        let tuple = Tuple::new_with_provenance(
+            vec![TupleElement::Row {
+                id: row_id,
+                content: content.into(),
+                batch_id: BatchId::new(),
+                row_provenance: RowProvenance::for_insert("jazz:test", 0),
+            }],
+            [(row_id, allowed_branch), (row_id, denied_branch)]
+                .into_iter()
+                .collect(),
+        );
+        let authorized_provenance = [(row_id, allowed_branch)].into_iter().collect();
+
+        assert!(
+            QueryManager::tuple_with_authorized_scope(tuple, &descriptor, authorized_provenance,)
+                .is_none()
+        );
     }
 }

--- a/crates/jazz-tools/src/query_manager/subscriptions.rs
+++ b/crates/jazz-tools/src/query_manager/subscriptions.rs
@@ -11,6 +11,7 @@ use crate::sync_manager::{OutgoingQuerySubscription, QueryPropagation};
 
 #[cfg(test)]
 use super::encoding::decode_row;
+use super::graph::QueryGraph;
 use super::graph_nodes::output::QuerySubscriptionId;
 use super::manager::{
     CatalogueUpdate, LocalUpdates, QueryError, QueryManager, QuerySubscription,
@@ -56,6 +57,37 @@ impl QueryManager {
     /// Create a query builder for a table.
     pub fn query(&self, table: &str) -> QueryBuilder {
         QueryBuilder::new(table)
+    }
+
+    pub(super) fn resolved_subscription_branches(
+        query: &Query,
+        schema_context: &crate::schema_manager::SchemaContext,
+        graph: &QueryGraph,
+    ) -> Vec<String> {
+        fn push_unique(branches: &mut Vec<String>, branch: String) {
+            if !branches.iter().any(|existing| existing == &branch) {
+                branches.push(branch);
+            }
+        }
+
+        let scan_branches = graph.scan_branches();
+        let mut branches = if !scan_branches.is_empty() {
+            scan_branches
+        } else if !query.branches.is_empty() {
+            query.branches.clone()
+        } else {
+            schema_context
+                .all_branch_names()
+                .into_iter()
+                .map(|b| b.as_str().to_string())
+                .collect()
+        };
+
+        for branch in query.explicit_array_subquery_branches() {
+            push_unique(&mut branches, branch);
+        }
+
+        branches
     }
 
     /// Subscribe to query results (delta mode).
@@ -122,29 +154,14 @@ impl QueryManager {
         } = options;
         let _span =
             tracing::debug_span!("QM::subscribe", table = %query.table, ?durability_tier).entered();
-        // Determine branches
-        let branches: Vec<String> = if !query.branches.is_empty() {
-            query.branches.clone()
-        } else if self.schema_context.is_initialized() {
-            self.schema_context
-                .all_branch_names()
-                .into_iter()
-                .map(|b| b.as_str().to_string())
-                .collect()
-        } else {
+        if query.branches.is_empty() && !self.schema_context.is_initialized() {
             return Err(QueryError::QueryCompilationError(
                 "schema context not initialized - call set_current_schema() first".into(),
             ));
-        };
+        }
 
-        let uses_explicit_authorization_filtering =
-            self.local_subscription_uses_explicit_authorization(session.as_ref());
-        let compile_schema = self.local_subscription_compile_schema(session.as_ref());
-        let compile_row_policy_mode = if uses_explicit_authorization_filtering {
-            crate::query_manager::types::RowPolicyMode::PermissiveLocal
-        } else {
-            self.row_policy_mode
-        };
+        let (compile_schema, compile_row_policy_mode, uses_explicit_authorization_filtering) =
+            self.local_subscription_compile_options(session.as_ref());
         let graph = Self::compile_graph(
             &query,
             &compile_schema,
@@ -154,6 +171,7 @@ impl QueryManager {
         )
         .map_err(|err| QueryError::QueryCompilationError(err.to_string()))?;
         let policy_context_tables = Self::policy_context_tables_for_graph(&graph);
+        let branches = Self::resolved_subscription_branches(&query, &self.schema_context, &graph);
 
         let id = QuerySubscriptionId(self.next_subscription_id);
         self.next_subscription_id += 1;
@@ -226,17 +244,6 @@ impl QueryManager {
             })
             .collect();
 
-        // Determine branches from query or context
-        let branches: Vec<String> = if !query.branches.is_empty() {
-            query.branches.clone()
-        } else {
-            schema_context
-                .all_branch_names()
-                .into_iter()
-                .map(|b| b.as_str().to_string())
-                .collect()
-        };
-
         // Compile query graph with explicit schema context
         let graph = Self::compile_graph(
             &query,
@@ -247,6 +254,7 @@ impl QueryManager {
         )
         .map_err(|err| QueryError::QueryCompilationError(err.to_string()))?;
         let policy_context_tables = Self::policy_context_tables_for_graph(&graph);
+        let branches = Self::resolved_subscription_branches(&query, schema_context, &graph);
 
         let id = QuerySubscriptionId(self.next_subscription_id);
         self.next_subscription_id += 1;

--- a/crates/jazz-tools/src/query_manager/types/branch.rs
+++ b/crates/jazz-tools/src/query_manager/types/branch.rs
@@ -398,6 +398,11 @@ impl ComposedBranchName {
         })
     }
 
+    pub fn parse_non_main(name: &BranchName) -> Option<Self> {
+        let composed = Self::parse(name)?;
+        (composed.user_branch != "main").then_some(composed)
+    }
+
     /// Check if this branch matches an environment and user branch,
     /// ignoring the schema hash (for finding related branches).
     pub fn matches_env_and_branch(&self, env: &str, user_branch: &str) -> bool {

--- a/crates/jazz-tools/src/query_manager/types/mod.rs
+++ b/crates/jazz-tools/src/query_manager/types/mod.rs
@@ -19,8 +19,8 @@ pub use schema::*;
 pub use tuple::*;
 pub use value::*;
 
-// Import PolicyExpr for use by schema module
-pub(crate) use crate::query_manager::policy::PolicyExpr;
+// Import policy types for use by schema module
+pub(crate) use crate::query_manager::policy::{Operation, PolicyExpr};
 
 // Tests module
 #[cfg(test)]

--- a/crates/jazz-tools/src/query_manager/types/policy.rs
+++ b/crates/jazz-tools/src/query_manager/types/policy.rs
@@ -1,5 +1,6 @@
 use super::*;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum RowPolicyMode {
@@ -12,6 +13,12 @@ impl RowPolicyMode {
     pub fn denies_missing_explicit_policy(self) -> bool {
         matches!(self, Self::Enforcing)
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PermissionPhase {
+    Using,
+    Check,
 }
 
 /// Policy for a specific operation (SELECT, INSERT, UPDATE, DELETE).
@@ -62,6 +69,7 @@ pub struct TablePolicies {
     pub insert: OperationPolicy,
     pub update: OperationPolicy,
     pub delete: OperationPolicy,
+    pub for_branch: HashMap<TableName, TablePolicies>,
 }
 
 impl TablePolicies {
@@ -113,6 +121,10 @@ impl TablePolicies {
             || self.update.using.is_some()
             || self.update.with_check.is_some()
             || self.delete.using.is_some()
+            || self
+                .for_branch
+                .values()
+                .any(TablePolicies::has_any_explicit_policy)
     }
 
     pub fn select_policy(&self) -> Option<&PolicyExpr> {
@@ -133,5 +145,19 @@ impl TablePolicies {
 
     pub fn has_explicit_update_policy(&self) -> bool {
         self.update.using.is_some() || self.update.with_check.is_some()
+    }
+
+    pub(crate) fn policy_for_operation(
+        &self,
+        operation: Operation,
+        phase: PermissionPhase,
+    ) -> Option<&PolicyExpr> {
+        match (operation, phase) {
+            (Operation::Select, _) => self.select_policy(),
+            (Operation::Insert, _) => self.insert_policy(),
+            (Operation::Update, PermissionPhase::Using) => self.update_using_policy(),
+            (Operation::Update, PermissionPhase::Check) => self.update_check_policy(),
+            (Operation::Delete, _) => self.effective_delete_using(),
+        }
     }
 }

--- a/crates/jazz-tools/src/query_manager/writes.rs
+++ b/crates/jazz-tools/src/query_manager/writes.rs
@@ -21,12 +21,18 @@ use super::manager::{
     DeleteHandle, InsertResult, QueryError, QueryManager, SchemaWarningAccumulator,
     WriteTableCacheEntry,
 };
-use super::policy::{ComplexClause, Operation, evaluate_simple_parts_with_row_id};
-use super::server_queries::{AuthorizationPolicyRequest, RowTransformContext};
+use super::permission_routing::{
+    PermissionDecision, PermissionEvaluationRequest, branch_policy_scope,
+};
+use super::policy::{
+    BranchPolicyContext, ComplexClause, Operation, PolicyEvalRefs,
+    evaluate_simple_parts_with_context,
+};
+use super::server_queries::RowTransformContext;
 use super::session::{AuthMode, Session, WriteContext};
 use super::types::{
-    ColumnName, ColumnType, ComposedBranchName, LoadedRow, RowDescriptor, Schema, SchemaHash,
-    TableName, Value,
+    ColumnName, ColumnType, ComposedBranchName, LoadedRow, PermissionPhase, RowDescriptor, Schema,
+    SchemaHash, TableName, Value,
 };
 
 pub struct RowBranchWrite<'a> {
@@ -75,6 +81,14 @@ pub struct RowBranchDelete<'a> {
     pub id: ObjectId,
     pub old_data_for_policy: &'a [u8],
     pub old_provenance_for_policy: &'a RowProvenance,
+}
+
+#[derive(Clone, Copy)]
+struct WritePolicyCheck<'a> {
+    operation: Operation,
+    phase: PermissionPhase,
+    content: &'a [u8],
+    provenance: &'a RowProvenance,
 }
 
 impl QueryManager {
@@ -704,62 +718,37 @@ impl QueryManager {
             if let Some((auth_schema, auth_context)) =
                 self.local_write_authorization_context(branch, Some(session))
             {
-                let Some(auth_table_schema) = auth_schema.get(&table_name) else {
-                    return Err(QueryError::PolicyDenied {
-                        table: table_name,
+                self.authorize_local_write_policy(
+                    storage,
+                    id,
+                    branch,
+                    table_name,
+                    session,
+                    &auth_schema,
+                    &auth_context,
+                    WritePolicyCheck {
                         operation: Operation::Update,
-                    });
-                };
-                if self.row_policy_mode.denies_missing_explicit_policy()
-                    && !auth_table_schema.policies.has_explicit_update_policy()
-                {
-                    return Err(QueryError::PolicyDenied {
-                        table: table_name,
-                        operation: Operation::Update,
-                    });
-                }
+                        phase: PermissionPhase::Using,
+                        content: old_data_for_policy,
+                        provenance: old_provenance_for_policy,
+                    },
+                )?;
 
-                if let Some(policy) = auth_table_schema.policies.update_using_policy()
-                    && !self.evaluate_current_authorization_policy_for_content(
-                        storage,
-                        id,
-                        branch,
-                        table_name,
-                        policy,
-                        old_data_for_policy,
-                        old_provenance_for_policy,
-                        session,
-                        Operation::Update,
-                        &auth_schema,
-                        &auth_context,
-                    )
-                {
-                    return Err(QueryError::PolicyDenied {
-                        table: table_name,
+                self.authorize_local_write_policy(
+                    storage,
+                    id,
+                    branch,
+                    table_name,
+                    session,
+                    &auth_schema,
+                    &auth_context,
+                    WritePolicyCheck {
                         operation: Operation::Update,
-                    });
-                }
-
-                if let Some(policy) = auth_table_schema.policies.update_check_policy()
-                    && !self.evaluate_current_authorization_policy_for_content(
-                        storage,
-                        id,
-                        branch,
-                        table_name,
-                        policy,
-                        &new_data,
-                        new_provenance,
-                        session,
-                        Operation::Update,
-                        &auth_schema,
-                        &auth_context,
-                    )
-                {
-                    return Err(QueryError::PolicyDenied {
-                        table: table_name,
-                        operation: Operation::Update,
-                    });
-                }
+                        phase: PermissionPhase::Check,
+                        content: &new_data,
+                        provenance: new_provenance,
+                    },
+                )?;
             } else {
                 if self.row_policy_mode.denies_missing_explicit_policy()
                     && using_policy.is_none()
@@ -1069,34 +1058,21 @@ impl QueryManager {
             if let Some((auth_schema, auth_context)) =
                 self.local_write_authorization_context(branch, Some(session))
             {
-                let allowed = auth_schema
-                    .get(&table_name)
-                    .and_then(|table_schema| table_schema.policies.insert_policy())
-                    .map(|policy| {
-                        self.evaluate_current_authorization_policy_for_content(
-                            storage,
-                            object_id,
-                            branch,
-                            table_name,
-                            policy,
-                            &data,
-                            &provenance,
-                            session,
-                            Operation::Insert,
-                            &auth_schema,
-                            &auth_context,
-                        )
-                    })
-                    .unwrap_or_else(|| {
-                        !self.row_policy_mode.denies_missing_explicit_policy()
-                            && auth_schema.contains_key(&table_name)
-                    });
-                if !allowed {
-                    return Err(QueryError::PolicyDenied {
-                        table: table_name,
+                self.authorize_local_write_policy(
+                    storage,
+                    object_id,
+                    branch,
+                    table_name,
+                    session,
+                    &auth_schema,
+                    &auth_context,
+                    WritePolicyCheck {
                         operation: Operation::Insert,
-                    });
-                }
+                        phase: PermissionPhase::Check,
+                        content: &data,
+                        provenance: &provenance,
+                    },
+                )?;
             } else {
                 if self.row_policy_mode.denies_missing_explicit_policy() && insert_policy.is_none()
                 {
@@ -1293,44 +1269,66 @@ impl QueryManager {
         std::sync::Arc<Schema>,
         std::sync::Arc<crate::schema_manager::SchemaContext>,
     )> {
-        self.local_subscription_uses_explicit_authorization(session)
-            .then(|| self.authorization_schema_for_branch(&BranchName::new(branch)))
-            .flatten()
+        session?;
+
+        if branch_policy_scope(&BranchName::new(branch)).is_none()
+            && !self.local_subscription_uses_explicit_authorization(session)
+        {
+            return None;
+        }
+
+        self.authorization_schema_for_branch(&BranchName::new(branch))
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn evaluate_current_authorization_policy_for_content<H: Storage>(
+    fn authorize_local_write_policy<H: Storage>(
         &mut self,
         storage: &mut H,
         object_id: ObjectId,
         branch: &str,
         table_name: TableName,
-        policy: &crate::query_manager::policy::PolicyExpr,
-        content: &[u8],
-        provenance: &RowProvenance,
         session: &Session,
-        operation: Operation,
         auth_schema: &Schema,
         auth_context: &crate::schema_manager::SchemaContext,
-    ) -> bool {
+        check: WritePolicyCheck<'_>,
+    ) -> Result<(), QueryError> {
+        let branch_name = BranchName::new(branch);
         let source_branch_schema_map = self.branch_schema_map.clone();
-        self.evaluate_authorization_policy(
+        let route = self.resolve_permission_route(
             storage,
-            AuthorizationPolicyRequest {
+            branch_name,
+            table_name,
+            session,
+            auth_schema,
+            auth_context,
+            &source_branch_schema_map,
+        );
+        match self.evaluate_permission_route_decision(
+            storage,
+            &route,
+            PermissionEvaluationRequest {
                 object_id,
-                branch_name: BranchName::new(branch),
+                branch_name,
                 table_name,
-                policy,
-                content,
-                provenance,
+                content: check.content,
+                provenance: check.provenance,
                 session,
                 auth_schema,
                 auth_context,
                 source_branch_schema_map: &source_branch_schema_map,
-                operation,
+                operation: check.operation,
+                phase: check.phase,
                 settlement_eval_cache: None,
             },
-        )
+        ) {
+            PermissionDecision::Allowed => Ok(()),
+            PermissionDecision::DeniedRoute
+            | PermissionDecision::DeniedMissingPolicy
+            | PermissionDecision::DeniedPolicy => Err(QueryError::PolicyDenied {
+                table: table_name,
+                operation: check.operation,
+            }),
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1360,6 +1358,7 @@ impl QueryManager {
             branch,
             operation,
             Some(row_id),
+            None,
             depth,
             visited,
         )
@@ -1378,14 +1377,23 @@ impl QueryManager {
         branch: &str,
         operation: Operation,
         row_id: Option<ObjectId>,
+        branch_context: Option<&BranchPolicyContext<'_>>,
         depth: usize,
         visited: &mut HashSet<(TableName, ObjectId, Operation)>,
     ) -> bool {
         if depth > crate::query_manager::policy::RECURSIVE_POLICY_MAX_DEPTH_HARD_CAP {
             return false;
         }
-        let simple_result = evaluate_simple_parts_with_row_id(
-            policy, content, provenance, descriptor, session, row_id,
+        let simple_result = evaluate_simple_parts_with_context(
+            policy,
+            content,
+            provenance,
+            descriptor,
+            session,
+            PolicyEvalRefs {
+                row_id,
+                branch: branch_context,
+            },
         );
         if !simple_result.passed {
             return false;
@@ -2011,44 +2019,21 @@ impl QueryManager {
             if let Some((auth_schema, auth_context)) =
                 self.local_write_authorization_context(branch, Some(session))
             {
-                let Some(auth_table_schema) = auth_schema.get(&table_name) else {
-                    return Err(QueryError::PolicyDenied {
-                        table: table_name,
+                self.authorize_local_write_policy(
+                    storage,
+                    id,
+                    branch,
+                    table_name,
+                    session,
+                    &auth_schema,
+                    &auth_context,
+                    WritePolicyCheck {
                         operation: Operation::Delete,
-                    });
-                };
-                if self.row_policy_mode.denies_missing_explicit_policy()
-                    && auth_table_schema
-                        .policies
-                        .effective_delete_using()
-                        .is_none()
-                {
-                    return Err(QueryError::PolicyDenied {
-                        table: table_name,
-                        operation: Operation::Delete,
-                    });
-                }
-
-                if let Some(policy) = auth_table_schema.policies.effective_delete_using()
-                    && !self.evaluate_current_authorization_policy_for_content(
-                        storage,
-                        id,
-                        branch,
-                        table_name,
-                        policy,
-                        old_data_for_policy,
-                        old_provenance_for_policy,
-                        session,
-                        Operation::Delete,
-                        &auth_schema,
-                        &auth_context,
-                    )
-                {
-                    return Err(QueryError::PolicyDenied {
-                        table: table_name,
-                        operation: Operation::Delete,
-                    });
-                }
+                        phase: PermissionPhase::Using,
+                        content: old_data_for_policy,
+                        provenance: old_provenance_for_policy,
+                    },
+                )?;
             } else {
                 if self.row_policy_mode.denies_missing_explicit_policy() && using_policy.is_none() {
                     return Err(QueryError::PolicyDenied {

--- a/crates/jazz-tools/src/runtime_core/subscriptions.rs
+++ b/crates/jazz-tools/src/runtime_core/subscriptions.rs
@@ -348,7 +348,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
 
     fn query_with_overlay_rows(
         &mut self,
-        query: Query,
+        mut query: Query,
         session: Option<Session>,
         durability: ReadDurabilityOptions,
         propagation: QueryPropagation,
@@ -362,6 +362,9 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         )
         .entered();
         let (sender, receiver) = oneshot::channel();
+        query.compose_logical_branches_for_context(
+            self.schema_manager.query_manager().schema_context(),
+        );
 
         let sub_id = match self
             .schema_manager

--- a/crates/jazz-tools/src/runtime_core/tests.rs
+++ b/crates/jazz-tools/src/runtime_core/tests.rs
@@ -4,7 +4,8 @@ use crate::query_manager::policy::PolicyExpr;
 use crate::query_manager::query::QueryBuilder;
 use crate::query_manager::session::WriteContext;
 use crate::query_manager::types::{
-    ColumnType, SchemaBuilder, SchemaHash, TableName, TablePolicies, TableSchema,
+    ColumnType, ComposedBranchName, SchemaBuilder, SchemaHash, TableName, TablePolicies,
+    TableSchema,
 };
 use crate::row_format::encode_row;
 use crate::row_histories::BatchId;

--- a/crates/jazz-tools/src/runtime_core/tests/basic.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/basic.rs
@@ -30,6 +30,126 @@ fn test_runtime_core_insert_query() {
 }
 
 #[test]
+fn runtime_query_composes_logical_branch_ids() {
+    let mut core = create_runtime_with_schema(test_schema(), "runtime-logical-branch-query");
+    let draft_branch =
+        ComposedBranchName::new("dev", core.schema_manager().current_hash(), "draft")
+            .to_branch_name()
+            .as_str()
+            .to_string();
+    let write_context = WriteContext::default().with_target_branch_name(draft_branch);
+    let ((object_id, row_values), _) = core
+        .insert(
+            "users",
+            user_insert_values(ObjectId::new(), "Draft"),
+            Some(&write_context),
+        )
+        .unwrap();
+
+    core.immediate_tick();
+    core.batched_tick();
+
+    let query = QueryBuilder::new("users").branch("draft").build();
+    let results = execute_runtime_query(&mut core, query, None);
+
+    assert_eq!(results, vec![(object_id, row_values)]);
+}
+
+#[test]
+fn runtime_branch_include_keeps_outer_row_when_inner_branch_read_denies() {
+    let mut todo_policies = TablePolicies::new()
+        .with_select(PolicyExpr::True)
+        .with_insert(PolicyExpr::True);
+    todo_policies.for_branch = HashMap::from([(
+        TableName::new("branches"),
+        TablePolicies::new()
+            .with_select(PolicyExpr::False)
+            .with_insert(PolicyExpr::True),
+    )]);
+    let schema = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("projects")
+                .column("name", ColumnType::Text)
+                .policies(
+                    TablePolicies::new()
+                        .with_select(PolicyExpr::True)
+                        .with_insert(PolicyExpr::True),
+                ),
+        )
+        .table(
+            TableSchema::builder("branches")
+                .fk_column("projectId", "projects")
+                .column("ownerId", ColumnType::Text)
+                .policies(
+                    TablePolicies::new()
+                        .with_select(PolicyExpr::True)
+                        .with_insert(PolicyExpr::True),
+                ),
+        )
+        .table(
+            TableSchema::builder("todos")
+                .fk_column("projectId", "projects")
+                .column("title", ColumnType::Text)
+                .policies(todo_policies),
+        )
+        .build();
+    let mut core = create_runtime_with_schema(schema, "runtime-branch-include-denied");
+    let (project, _) = core
+        .insert(
+            "projects",
+            HashMap::from([("name".to_string(), Value::Text("Project".into()))]),
+            None,
+        )
+        .expect("insert project");
+    let (branch, _) = core
+        .insert(
+            "branches",
+            HashMap::from([
+                ("projectId".to_string(), Value::Uuid(project.0)),
+                ("ownerId".to_string(), Value::Text("alice".into())),
+            ]),
+            None,
+        )
+        .expect("insert branch row");
+    let branch_name = ComposedBranchName::new(
+        "dev",
+        core.schema_manager().current_hash(),
+        &branch.0.to_string(),
+    )
+    .to_branch_name()
+    .as_str()
+    .to_string();
+    let branch_write = WriteContext::default().with_target_branch_name(branch_name);
+    core.insert(
+        "todos",
+        HashMap::from([
+            ("projectId".to_string(), Value::Uuid(project.0)),
+            ("title".to_string(), Value::Text("Hidden".into())),
+        ]),
+        Some(&branch_write),
+    )
+    .expect("insert branch todo");
+
+    core.immediate_tick();
+    core.batched_tick();
+
+    let rows = execute_runtime_query(
+        &mut core,
+        QueryBuilder::new("projects")
+            .with_array("todosViaProject", |sub| {
+                sub.from("todos")
+                    .branch(&branch.0.to_string())
+                    .correlate("projectId", "projects.id")
+            })
+            .build(),
+        Some(Session::new("alice")),
+    );
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].1[1], Value::Array(vec![]));
+}
+
+#[test]
 fn add_server_rehydrates_visible_rows_from_storage_after_restart() {
     let mut old_runtime = create_runtime_with_schema(test_schema(), "restart-sync-test");
     let user_id = ObjectId::new();

--- a/crates/jazz-tools/src/schema_manager/encoding.rs
+++ b/crates/jazz-tools/src/schema_manager/encoding.rs
@@ -19,7 +19,7 @@ use super::lens::{LensOp, LensTransform};
 /// Current encoding version.
 const SCHEMA_VERSION: u8 = SchemaEncodingVersion::V6 as u8;
 const LENS_VERSION: u8 = 2;
-const PERMISSIONS_VERSION: u8 = 1;
+const PERMISSIONS_VERSION: u8 = 2;
 const PERMISSIONS_BUNDLE_VERSION: u8 = 2;
 const PERMISSIONS_HEAD_VERSION: u8 = 2;
 
@@ -1004,12 +1004,26 @@ const POLICY_EXPR_SESSION_IN_LIST: u8 = 21;
 
 const POLICY_VALUE_LITERAL: u8 = 1;
 const POLICY_VALUE_SESSION_REF: u8 = 2;
+const POLICY_VALUE_BRANCH_REF: u8 = 3;
 
 fn encode_table_policies(buf: &mut Vec<u8>, policies: &TablePolicies) {
     encode_operation_policy(buf, &policies.select);
     encode_operation_policy(buf, &policies.insert);
     encode_operation_policy(buf, &policies.update);
     encode_operation_policy(buf, &policies.delete);
+}
+
+fn encode_permissions_table_policies(buf: &mut Vec<u8>, policies: &TablePolicies) {
+    encode_table_policies(buf, policies);
+
+    let mut entries: Vec<_> = policies.for_branch.iter().collect();
+    entries.sort_by_key(|(name, _)| name.as_str());
+    write_u32(buf, entries.len() as u32);
+
+    for (backing_table, branch_policies) in entries {
+        write_string(buf, backing_table.as_str());
+        encode_permissions_table_policies(buf, branch_policies);
+    }
 }
 
 fn decode_table_policies(
@@ -1021,7 +1035,29 @@ fn decode_table_policies(
         insert: decode_operation_policy(data, offset)?,
         update: decode_operation_policy(data, offset)?,
         delete: decode_operation_policy(data, offset)?,
+        for_branch: HashMap::new(),
     })
+}
+
+fn decode_permissions_table_policies(
+    data: &[u8],
+    offset: &mut usize,
+    version: u8,
+) -> Result<TablePolicies, CatalogueEncodingError> {
+    let mut policies = decode_table_policies(data, offset)?;
+
+    if version >= 2 {
+        let count = read_u32(data, offset)? as usize;
+        let mut for_branch = HashMap::with_capacity(count);
+        for _ in 0..count {
+            let backing_table = TableName::new(read_string(data, offset, "branch_policy_table")?);
+            let branch_policies = decode_permissions_table_policies(data, offset, version)?;
+            for_branch.insert(backing_table, branch_policies);
+        }
+        policies.for_branch = for_branch;
+    }
+
+    Ok(policies)
 }
 
 pub fn encode_permissions(permissions: &HashMap<TableName, TablePolicies>) -> Vec<u8> {
@@ -1034,7 +1070,7 @@ pub fn encode_permissions(permissions: &HashMap<TableName, TablePolicies>) -> Ve
 
     for (table_name, policies) in entries {
         write_string(&mut buf, table_name.as_str());
-        encode_table_policies(&mut buf, policies);
+        encode_permissions_table_policies(&mut buf, policies);
     }
 
     buf
@@ -1051,7 +1087,7 @@ pub fn decode_permissions(
     }
 
     let version = data[0];
-    if version != PERMISSIONS_VERSION {
+    if version != 1 && version != PERMISSIONS_VERSION {
         return Err(CatalogueEncodingError::UnsupportedVersion {
             found: version,
             expected: PERMISSIONS_VERSION,
@@ -1064,7 +1100,7 @@ pub fn decode_permissions(
 
     for _ in 0..table_count {
         let table_name = TableName::new(read_string(data, &mut offset, "table_name")?);
-        let policies = decode_table_policies(data, &mut offset)?;
+        let policies = decode_permissions_table_policies(data, &mut offset, version)?;
         permissions.insert(table_name, policies);
     }
 
@@ -1647,6 +1683,10 @@ fn encode_policy_value(buf: &mut Vec<u8>, value: &PolicyValue) {
                 write_string(buf, part);
             }
         }
+        PolicyValue::BranchRef(column) => {
+            buf.push(POLICY_VALUE_BRANCH_REF);
+            write_string(buf, column.as_str());
+        }
     }
 }
 
@@ -1665,6 +1705,11 @@ fn decode_policy_value(
             }
             Ok(PolicyValue::SessionRef(path))
         }
+        POLICY_VALUE_BRANCH_REF => Ok(PolicyValue::BranchRef(ColumnName::new(read_string(
+            data,
+            offset,
+            "policy_branch_ref_column",
+        )?))),
         _ => Err(CatalogueEncodingError::InvalidTypeTag {
             tag,
             context: "policy_value",
@@ -2502,6 +2547,27 @@ mod tests {
             decoded.get(&TableName::new("todos")),
             permissions.get(&TableName::new("todos"))
         );
+    }
+
+    #[test]
+    fn permissions_roundtrip_preserves_branch_policies() {
+        let branch_select = PolicyExpr::Cmp {
+            column: "projectId".to_string(),
+            op: CmpOp::Eq,
+            value: PolicyValue::BranchRef(ColumnName::new("projectId")),
+        };
+        let mut todo_policies = TablePolicies::new().with_select(PolicyExpr::True);
+        todo_policies.for_branch = HashMap::from([(
+            TableName::new("branches"),
+            TablePolicies::new().with_select(branch_select),
+        )]);
+        let permissions = HashMap::from([(TableName::new("todos"), todo_policies)]);
+
+        let encoded = encode_permissions(&permissions);
+        assert_eq!(encoded[0], PERMISSIONS_VERSION);
+        let decoded = decode_permissions(&encoded).expect("permissions should decode");
+
+        assert_eq!(decoded, permissions);
     }
 
     #[test]

--- a/crates/jazz-tools/src/schema_manager/integration_tests/tests/writes.rs
+++ b/crates/jazz-tools/src/schema_manager/integration_tests/tests/writes.rs
@@ -285,6 +285,225 @@ fn transactional_insert_uses_frozen_target_branch_schema() {
 }
 
 #[test]
+fn transactional_insert_preserves_same_schema_target_user_branch() {
+    let schema = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("users")
+                .column("id", ColumnType::Uuid)
+                .column("email", ColumnType::Text),
+        )
+        .build();
+
+    let mut manager =
+        SchemaManager::new(SyncManager::new(), schema, test_app_id(), "dev", "main").unwrap();
+    let mut storage = MemoryStorage::new();
+    let main_branch = manager.branch_name().as_str().to_string();
+    let target_branch = crate::query_manager::types::ComposedBranchName::new(
+        "dev",
+        manager.current_hash(),
+        "branch-row-1",
+    )
+    .to_branch_name()
+    .as_str()
+    .to_string();
+
+    let write_context = WriteContext::default()
+        .with_batch_mode(crate::batch_fate::BatchMode::Transactional)
+        .with_target_branch_name(target_branch.clone());
+
+    let inserted = manager
+        .insert(
+            &mut storage,
+            "users",
+            HashMap::from([
+                ("id".to_string(), Value::Uuid(ObjectId::new())),
+                (
+                    "email".to_string(),
+                    Value::Text("alice@example.com".to_string()),
+                ),
+            ]),
+            None,
+            Some(&write_context),
+        )
+        .expect("same-schema target branch should be accepted");
+
+    let target_rows = execute_query_with_local_overlay(
+        &mut manager,
+        &mut storage,
+        QueryBuilder::new("users")
+            .branch(target_branch.clone())
+            .build(),
+        inserted.row_id,
+        &target_branch,
+        inserted.batch_id,
+    );
+    assert_eq!(target_rows.len(), 1);
+    assert_eq!(target_rows[0].0, inserted.row_id);
+
+    let main_rows = execute_query(
+        &mut manager,
+        &mut storage,
+        QueryBuilder::new("users").branch(main_branch).build(),
+    );
+    assert!(
+        main_rows.is_empty(),
+        "same-schema target branch writes should not be canonicalized back to main"
+    );
+}
+
+#[test]
+fn update_preserves_same_schema_target_user_branch() {
+    let schema = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("users")
+                .column("id", ColumnType::Uuid)
+                .column("email", ColumnType::Text),
+        )
+        .build();
+
+    let mut manager =
+        SchemaManager::new(SyncManager::new(), schema, test_app_id(), "dev", "main").unwrap();
+    let mut storage = MemoryStorage::new();
+    let main_branch = manager.branch_name().as_str().to_string();
+    let target_branch = crate::query_manager::types::ComposedBranchName::new(
+        "dev",
+        manager.current_hash(),
+        "branch-row-1",
+    )
+    .to_branch_name()
+    .as_str()
+    .to_string();
+    let write_context = WriteContext::default().with_target_branch_name(target_branch.clone());
+    let column_id = ObjectId::new();
+
+    let inserted = manager
+        .insert(
+            &mut storage,
+            "users",
+            HashMap::from([
+                ("id".to_string(), Value::Uuid(column_id)),
+                (
+                    "email".to_string(),
+                    Value::Text("alice@example.com".to_string()),
+                ),
+            ]),
+            None,
+            Some(&write_context),
+        )
+        .expect("same-schema target branch insert should succeed");
+
+    manager
+        .update(
+            &mut storage,
+            inserted.row_id,
+            &[(
+                "email".to_string(),
+                Value::Text("alice+branch@example.com".to_string()),
+            )],
+            Some(&write_context),
+        )
+        .expect("same-schema target branch update should find the branch row");
+
+    let target_rows = execute_query(
+        &mut manager,
+        &mut storage,
+        QueryBuilder::new("users").branch(target_branch).build(),
+    );
+    assert_eq!(target_rows.len(), 1);
+    assert_eq!(target_rows[0].0, inserted.row_id);
+    assert_eq!(
+        target_rows[0].1,
+        vec![
+            Value::Uuid(column_id),
+            Value::Text("alice+branch@example.com".to_string()),
+        ]
+    );
+
+    let main_rows = execute_query(
+        &mut manager,
+        &mut storage,
+        QueryBuilder::new("users").branch(main_branch).build(),
+    );
+    assert!(
+        main_rows.is_empty(),
+        "same-schema target branch update should not write to main"
+    );
+}
+
+#[test]
+fn delete_preserves_same_schema_target_user_branch() {
+    let schema = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("users")
+                .column("id", ColumnType::Uuid)
+                .column("email", ColumnType::Text),
+        )
+        .build();
+
+    let mut manager =
+        SchemaManager::new(SyncManager::new(), schema, test_app_id(), "dev", "main").unwrap();
+    let mut storage = MemoryStorage::new();
+    let main_branch = manager.branch_name().as_str().to_string();
+    let target_branch = crate::query_manager::types::ComposedBranchName::new(
+        "dev",
+        manager.current_hash(),
+        "branch-row-1",
+    )
+    .to_branch_name()
+    .as_str()
+    .to_string();
+    let write_context = WriteContext::default().with_target_branch_name(target_branch.clone());
+
+    let inserted = manager
+        .insert(
+            &mut storage,
+            "users",
+            HashMap::from([
+                ("id".to_string(), Value::Uuid(ObjectId::new())),
+                (
+                    "email".to_string(),
+                    Value::Text("alice@example.com".to_string()),
+                ),
+            ]),
+            None,
+            Some(&write_context),
+        )
+        .expect("same-schema target branch insert should succeed");
+
+    manager
+        .delete(&mut storage, inserted.row_id, Some(&write_context))
+        .expect("same-schema target branch delete should find the branch row");
+
+    let target_rows = execute_query(
+        &mut manager,
+        &mut storage,
+        QueryBuilder::new("users")
+            .branch(target_branch.clone())
+            .build(),
+    );
+    assert!(
+        target_rows.is_empty(),
+        "same-schema target branch delete should hide the branch row"
+    );
+    assert!(manager.query_manager().row_is_deleted_on_branch(
+        &storage,
+        "users",
+        &target_branch,
+        inserted.row_id
+    ));
+
+    let main_rows = execute_query(
+        &mut manager,
+        &mut storage,
+        QueryBuilder::new("users").branch(main_branch).build(),
+    );
+    assert!(
+        main_rows.is_empty(),
+        "same-schema target branch delete should not write to main"
+    );
+}
+
+#[test]
 fn transactional_insert_rejects_target_branch_outside_current_family() {
     let schema = SchemaBuilder::new()
         .table(

--- a/crates/jazz-tools/src/schema_manager/manager.rs
+++ b/crates/jazz-tools/src/schema_manager/manager.rs
@@ -353,12 +353,16 @@ impl SchemaManager {
     fn resolve_target_branch(
         &self,
         write_context: Option<&WriteContext>,
-    ) -> Result<(String, SchemaHash), QueryError> {
+    ) -> Result<(String, SchemaHash, String), QueryError> {
         let current_branch = self.context.branch_name().as_str().to_string();
         let current_hash = self.context.current_hash;
         let Some(target_branch_name) = write_context.and_then(WriteContext::target_branch_name)
         else {
-            return Ok((current_branch, current_hash));
+            return Ok((
+                current_branch,
+                current_hash,
+                self.context.user_branch.clone(),
+            ));
         };
 
         let parsed =
@@ -368,7 +372,7 @@ impl SchemaManager {
                 ))
             })?;
 
-        if !parsed.matches_env_and_branch(&self.context.env, &self.context.user_branch) {
+        if parsed.env != self.context.env {
             return Err(QueryError::EncodingError(format!(
                 "target_branch_name `{target_branch_name}` is outside the current schema family {}/*/{}",
                 self.context.env, self.context.user_branch
@@ -376,7 +380,14 @@ impl SchemaManager {
         }
 
         if parsed.schema_hash.short() == current_hash.short() {
-            return Ok((current_branch, current_hash));
+            let canonical =
+                ComposedBranchName::new(&self.context.env, current_hash, &parsed.user_branch)
+                    .to_branch_name();
+            return Ok((
+                canonical.as_str().to_string(),
+                current_hash,
+                parsed.user_branch,
+            ));
         }
 
         if let Some(hash) = self
@@ -386,10 +397,9 @@ impl SchemaManager {
             .copied()
             .find(|hash| hash.short() == parsed.schema_hash.short())
         {
-            let canonical =
-                ComposedBranchName::new(&self.context.env, hash, &self.context.user_branch)
-                    .to_branch_name();
-            return Ok((canonical.as_str().to_string(), hash));
+            let canonical = ComposedBranchName::new(&self.context.env, hash, &parsed.user_branch)
+                .to_branch_name();
+            return Ok((canonical.as_str().to_string(), hash, parsed.user_branch));
         }
 
         Err(QueryError::UnknownSchema(parsed.schema_hash))
@@ -398,16 +408,14 @@ impl SchemaManager {
     fn schema_context_for_hash(
         &self,
         schema_hash: SchemaHash,
+        user_branch: &str,
     ) -> Result<SchemaContext, QueryError> {
         let target_schema = self
             .schema_for_hash(schema_hash)
             .ok_or(QueryError::UnknownSchema(schema_hash))?
             .clone();
-        let mut temp_context = SchemaContext::new(
-            target_schema.clone(),
-            &self.context.env,
-            &self.context.user_branch,
-        );
+        let mut temp_context =
+            SchemaContext::new(target_schema.clone(), &self.context.env, user_branch);
 
         for lens in self.context.lenses.values() {
             temp_context.register_lens(lens.clone());
@@ -1653,7 +1661,8 @@ impl SchemaManager {
         write_context: Option<&WriteContext>,
     ) -> Result<InsertResult, QueryError> {
         let _ = self.ensure_current_schema_persisted(storage);
-        let (target_branch, target_hash) = self.resolve_target_branch(write_context)?;
+        let (target_branch, target_hash, _target_user_branch) =
+            self.resolve_target_branch(write_context)?;
         let table_name = TableName::new(table);
 
         let context = &self.context;
@@ -1693,8 +1702,9 @@ impl SchemaManager {
         write_context: Option<&WriteContext>,
     ) -> Result<crate::row_histories::BatchId, QueryError> {
         let _ = self.ensure_current_schema_persisted(storage);
-        let (target_branch, target_hash) = self.resolve_target_branch(write_context)?;
-        let target_context = self.schema_context_for_hash(target_hash)?;
+        let (target_branch, target_hash, target_user_branch) =
+            self.resolve_target_branch(write_context)?;
+        let target_context = self.schema_context_for_hash(target_hash, &target_user_branch)?;
         let branches = target_context
             .all_branch_names()
             .into_iter()
@@ -1748,12 +1758,13 @@ impl SchemaManager {
         write_context: Option<&WriteContext>,
     ) -> Result<crate::row_histories::BatchId, QueryError> {
         let _ = self.ensure_current_schema_persisted(storage);
-        let (target_branch, target_hash) = self.resolve_target_branch(write_context)?;
+        let (target_branch, target_hash, target_user_branch) =
+            self.resolve_target_branch(write_context)?;
         let target_schema = self
             .schema_for_hash(target_hash)
             .ok_or(QueryError::UnknownSchema(target_hash))?
             .clone();
-        let target_context = self.schema_context_for_hash(target_hash)?;
+        let target_context = self.schema_context_for_hash(target_hash, &target_user_branch)?;
         let branches = target_context
             .all_branch_names()
             .into_iter()
@@ -1839,12 +1850,13 @@ impl SchemaManager {
         write_context: Option<&WriteContext>,
     ) -> Result<DeleteHandle, QueryError> {
         let _ = self.ensure_current_schema_persisted(storage);
-        let (target_branch, target_hash) = self.resolve_target_branch(write_context)?;
+        let (target_branch, target_hash, target_user_branch) =
+            self.resolve_target_branch(write_context)?;
         let target_schema = self
             .schema_for_hash(target_hash)
             .ok_or(QueryError::UnknownSchema(target_hash))?
             .clone();
-        let target_context = self.schema_context_for_hash(target_hash)?;
+        let target_context = self.schema_context_for_hash(target_hash, &target_user_branch)?;
         let branches = target_context
             .all_branch_names()
             .into_iter()

--- a/crates/jazz-tools/src/sync_manager/mod.rs
+++ b/crates/jazz-tools/src/sync_manager/mod.rs
@@ -169,6 +169,10 @@ fn short_hash(hash: &impl ToString) -> String {
     hash.to_string().chars().take(12).collect()
 }
 
+fn dev_server_migration_create_console_call() -> &'static str {
+    "runJazzMigrations()"
+}
+
 pub(crate) fn log_schema_warning(
     warning: &SchemaWarning,
     origin: Option<&str>,
@@ -202,11 +206,12 @@ pub(crate) fn log_connection_schema_diagnostics(
             origin = origin,
             client_schema_hash = %client_hash,
             permissions_schema_hash = %permissions_hash,
-            "Your declared schema {} is disconnected from the schema used to enforce permissions: {}. Reads and writes may fail until you add a migration. To recover, run `npx jazz-tools@alpha migrations create --fromHash {} --toHash {}`.",
+            "Your declared schema {} is disconnected from the schema used to enforce permissions: {}. Reads and writes may fail until you add a migration. To recover, run `npx jazz-tools@alpha migrations create --fromHash {} --toHash {}`. If this app is running through a DevServer, open the app console and call `{}`.",
             client_hash,
             permissions_hash,
             permissions_hash,
             client_hash,
+            dev_server_migration_create_console_call(),
         );
     }
 

--- a/crates/jazz-tools/src/sync_manager/tests.rs
+++ b/crates/jazz-tools/src/sync_manager/tests.rs
@@ -22,6 +22,14 @@ fn users_schema_hash() -> SchemaHash {
     SchemaHash::compute(&users_test_schema())
 }
 
+#[test]
+fn dev_server_migration_create_console_call_names_global_runner() {
+    assert_eq!(
+        dev_server_migration_create_console_call(),
+        "runJazzMigrations()"
+    );
+}
+
 fn seed_users_schema(storage: &mut MemoryStorage) {
     persist_test_schema(storage, &users_test_schema());
 }

--- a/examples/moon-lander-react/tests/browser/global-setup.ts
+++ b/examples/moon-lander-react/tests/browser/global-setup.ts
@@ -11,7 +11,6 @@ import { TestingServer, pushSchemaCatalogue } from "jazz-tools/testing";
 const TEST_PORT = parseInt(process.env.TEST_PORT!, 10);
 const ADMIN_SECRET = "test-admin-secret-for-moon-lander-tests";
 const APP_ID = "00000000-0000-0000-0000-000000000003";
-const APP_ID_MULTI = "00000000-0000-0000-0000-000000000004";
 
 let server: Promise<TestingServer> | null = null;
 
@@ -33,14 +32,6 @@ export async function setup(): Promise<void> {
   await pushSchemaCatalogue({
     serverUrl: handle.url,
     appId: APP_ID,
-    adminSecret: ADMIN_SECRET,
-    schemaDir,
-  });
-  // Register schema for the isolated multi-player namespace so test 837
-  // starts with an empty event history (no stream connect timeout).
-  await pushSchemaCatalogue({
-    serverUrl: handle.url,
-    appId: APP_ID_MULTI,
     adminSecret: ADMIN_SECRET,
     schemaDir,
   });

--- a/examples/moon-lander-react/tests/browser/multiplayer.test.tsx
+++ b/examples/moon-lander-react/tests/browser/multiplayer.test.tsx
@@ -87,6 +87,7 @@ async function mountApp(opts: {
     10000,
     "App should render game canvas",
   );
+  await waitFrames(2);
 
   return el;
 }
@@ -133,7 +134,7 @@ describe("Moon Lander — Cross-Client Sync", () => {
       });
 
       pressKey("e", "KeyE");
-      await waitForAttr(el, "player-mode", "walking", 3000);
+      await waitForAttr(el, "player-mode", "walking", 10000);
       releaseKey("e", "KeyE");
 
       expect(readStr(el, "inventory")).toBe("");

--- a/examples/moon-lander-react/tests/browser/writes.test.ts
+++ b/examples/moon-lander-react/tests/browser/writes.test.ts
@@ -6,7 +6,7 @@
  *   - `reconcileDeposits`  — inserts missing deposits and trims excess per type
  *
  * These are isolated function tests (the CLAUDE.md exception for pure functions).
- * `reconcileDeposits` uses a thin db mock to capture insert/update calls.
+ * `reconcileDeposits` uses a thin db mock to capture insert/update wait calls.
  */
 
 import { describe, it, expect, vi } from "vitest";
@@ -138,7 +138,7 @@ function makeDeposit(overrides: Partial<FuelDeposit> & { fuelType: string }): Fu
 /**
  * Minimal db mock that captures insert and update calls.
  *
- * reconcileDeposits only uses these two methods, both returning a promise.
+ * reconcileDeposits only uses insert/update handles and waits for edge durability.
  */
 function mockDb() {
   const inserts: Array<{ table: unknown; data: Record<string, unknown>; tier: string }> = [];
@@ -151,23 +151,20 @@ function mockDb() {
 
   return {
     db: {
-      insertDurable: vi.fn(
-        async (table: unknown, data: Record<string, unknown>, options?: { tier?: string }) => {
-          const id = `new-${inserts.length}`;
-          inserts.push({ table, data, tier: options?.tier ?? "edge" });
-          return { id, ...data };
-        },
-      ),
-      updateDurable: vi.fn(
-        async (
-          table: unknown,
-          id: string,
-          data: Record<string, unknown>,
-          options?: { tier?: string },
-        ) => {
+      insert: vi.fn((table: unknown, data: Record<string, unknown>) => {
+        return {
+          wait: vi.fn(async (options?: { tier?: string }) => {
+            const id = `new-${inserts.length}`;
+            inserts.push({ table, data, tier: options?.tier ?? "edge" });
+            return { id, ...data };
+          }),
+        };
+      }),
+      update: vi.fn((table: unknown, id: string, data: Record<string, unknown>) => ({
+        wait: vi.fn(async (options?: { tier?: string }) => {
           updates.push({ table, id, data, tier: options?.tier ?? "edge" });
-        },
-      ),
+        }),
+      })),
     } as any,
     inserts,
     updates,

--- a/packages/inspector/src/test/setup.ts
+++ b/packages/inspector/src/test/setup.ts
@@ -1,6 +1,46 @@
 const dialogPrototype =
   globalThis.HTMLDialogElement?.prototype ?? globalThis.HTMLElement?.prototype;
 
+function createMemoryStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      return store.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value);
+    },
+  };
+}
+
+if (typeof globalThis.localStorage?.clear !== "function") {
+  const storage = createMemoryStorage();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    enumerable: true,
+    value: storage,
+  });
+  if (globalThis.window) {
+    Object.defineProperty(globalThis.window, "localStorage", {
+      configurable: true,
+      enumerable: true,
+      value: storage,
+    });
+  }
+}
+
 if (typeof globalThis.confirm !== "function") {
   globalThis.confirm = () => false;
 }

--- a/packages/jazz-tools/src/codegen/schema-reader.ts
+++ b/packages/jazz-tools/src/codegen/schema-reader.ts
@@ -34,6 +34,12 @@ const map: Record<ScalarSqlType, ColumnType> = {
   BYTEA: { type: "Bytea" },
 };
 
+type DslOperationPolicy =
+  | DslTablePolicies["select"]
+  | DslTablePolicies["insert"]
+  | DslTablePolicies["update"]
+  | DslTablePolicies["delete"];
+
 /**
  * Convert a DSL SqlType to WasmColumnType format.
  */
@@ -199,9 +205,7 @@ function clonePolicyExpr(expr: DslPolicyExpr): PolicyExpr {
   }
 }
 
-function cloneOperationPolicy(
-  policy: DslTablePolicies[keyof DslTablePolicies],
-): TablePolicies["select"] {
+function cloneOperationPolicy(policy: DslOperationPolicy): TablePolicies["select"] {
   const out: TablePolicies["select"] = {};
   if (!policy) {
     return out;
@@ -216,12 +220,21 @@ function cloneOperationPolicy(
 }
 
 function clonePolicies(policies: DslTablePolicies): TablePolicies {
-  return {
+  const out: TablePolicies = {
     select: cloneOperationPolicy(policies.select),
     insert: cloneOperationPolicy(policies.insert),
     update: cloneOperationPolicy(policies.update),
     delete: cloneOperationPolicy(policies.delete),
   };
+  if (policies.for_branch) {
+    out.for_branch = Object.fromEntries(
+      Object.entries(policies.for_branch).map(([backingTable, branchPolicies]) => [
+        backingTable,
+        clonePolicies(branchPolicies),
+      ]),
+    );
+  }
+  return out;
 }
 
 /**

--- a/packages/jazz-tools/src/dev/dev-server.test.ts
+++ b/packages/jazz-tools/src/dev/dev-server.test.ts
@@ -8,21 +8,21 @@ describe("dev-server re-export compatibility", () => {
     const testing = await import("../testing/index.js");
     expect(typeof testing.startLocalJazzServer).toBe("function");
     expect(typeof testing.pushSchemaCatalogue).toBe("function");
-  });
+  }, 30_000);
 
   it("exports the same functions from dev/index.ts", async () => {
     const dev = await import("./index.js");
     expect(typeof dev.startLocalJazzServer).toBe("function");
     expect(typeof dev.pushSchemaCatalogue).toBe("function");
     expect(typeof dev.watchSchema).toBe("function");
-  });
+  }, 30_000);
 
   it("testing and dev export the same startLocalJazzServer reference", async () => {
     const testing = await import("../testing/index.js");
     const dev = await import("./index.js");
     expect(testing.startLocalJazzServer).toBe(dev.startLocalJazzServer);
     expect(testing.pushSchemaCatalogue).toBe(dev.pushSchemaCatalogue);
-  });
+  }, 30_000);
 });
 
 describe("startLocalJazzServer via DevServer", () => {

--- a/packages/jazz-tools/src/drivers/types.ts
+++ b/packages/jazz-tools/src/drivers/types.ts
@@ -102,7 +102,8 @@ export type PolicyCmpOp = "Eq" | "Ne" | "Lt" | "Le" | "Gt" | "Ge";
 
 export type PolicyValue =
   | { type: "Literal"; value: Value }
-  | { type: "SessionRef"; path: string[] };
+  | { type: "SessionRef"; path: string[] }
+  | { type: "BranchRef"; column: string };
 
 export type PolicyLiteralValue = Value;
 
@@ -144,6 +145,7 @@ export interface TablePolicies {
   insert?: OperationPolicy;
   update?: OperationPolicy;
   delete?: OperationPolicy;
+  for_branch?: Record<string, TablePolicies>;
 }
 
 export interface TableSchema {

--- a/packages/jazz-tools/src/ir.ts
+++ b/packages/jazz-tools/src/ir.ts
@@ -8,6 +8,7 @@ export type RelRowIdRef = "Current" | "Outer" | "Frontier";
 export type RelValueRef =
   | { Literal: unknown }
   | { SessionRef: string[] }
+  | { BranchRef: string }
   | { OuterColumn: RelColumnRef }
   | { FrontierColumn: RelColumnRef }
   | { RowId: RelRowIdRef };
@@ -57,6 +58,7 @@ export type RelOrderByExpr = {
 
 export type RelExpr =
   | { TableScan: { table: string } }
+  | { Branch: { input: RelExpr; branches: string[] } }
   | { Filter: { input: RelExpr; predicate: RelPredicateExpr } }
   | { Union: { inputs: RelExpr[] } }
   | { Join: { left: RelExpr; right: RelExpr; on: RelJoinCondition[]; join_kind: RelJoinKind } }

--- a/packages/jazz-tools/src/permissions/index.ts
+++ b/packages/jazz-tools/src/permissions/index.ts
@@ -83,6 +83,11 @@ interface RowRefValue {
   readonly column: string;
 }
 
+interface BranchRowRefValue {
+  readonly __jazzPermissionKind: "branch-row-ref";
+  readonly column: string;
+}
+
 interface ExistsCondition {
   readonly __jazzPermissionKind: "exists";
   readonly table: string;
@@ -142,9 +147,9 @@ function relationJoinAlias(
   return join.viaHop ? `__hop_${index}` : `__join_${index}`;
 }
 
-interface TableJoinTarget {
+interface TableJoinTarget<TTable extends string = string> {
   readonly __jazzPermissionKind: "table-builder";
-  readonly __jazzPermissionTable: string;
+  readonly __jazzPermissionTable: TTable;
 }
 
 type RelationJoinTarget = string | TableJoinTarget;
@@ -425,12 +430,17 @@ interface Rule {
   action: PolicyAction;
   using?: Condition;
   withCheck?: Condition;
+  branchTable?: string;
 }
 
 type RuleLike = Rule | UpdateRuleBuilder<unknown, unknown>;
 
 type RowContext<Row> = {
   [K in keyof Row & string]: RowRefValue;
+};
+
+type BranchRowContext<Row> = {
+  [K in keyof Row & string]: BranchRowRefValue;
 };
 
 export type WhereInputOrCallback<WhereInput, Row> =
@@ -483,14 +493,19 @@ interface ActionBuilder<WhereInput, Row> {
   never(): Rule;
 }
 
-interface TableRelationBuilder<WhereInput, Row> extends TableJoinTarget, PermissionRelation {
+interface TableRelationBuilder<WhereInput, Row, TTable extends string = string>
+  extends TableJoinTarget<TTable>, PermissionRelation {
   where(
     input: PermissionWhereInput<WhereInput> | ((row: RowContext<Row>) => unknown),
   ): PermissionRelation;
   select(columns: Record<string, string>): PermissionRelation;
 }
 
-interface TablePolicyBuilder<WhereInput, Row> extends TableRelationBuilder<WhereInput, Row> {
+interface TablePolicyBuilder<
+  WhereInput,
+  Row,
+  TTable extends string = string,
+> extends TableRelationBuilder<WhereInput, Row, TTable> {
   allowRead: ActionBuilder<WhereInput, Row>;
   allowReads: ActionBuilder<WhereInput, Row>;
   allowInsert: ActionBuilder<WhereInput, Row>;
@@ -503,15 +518,37 @@ interface TablePolicyBuilder<WhereInput, Row> extends TableRelationBuilder<Where
   exists: ExistsBuilder<WhereInput>;
 }
 
+type BranchPolicyContext<TApp extends AppLike, TBranchKey extends TableKey<TApp>> = {
+  $branch: BranchRowContext<RowFor<QueryBuilderFor<TApp, TBranchKey>>>;
+  branchPolicy: {
+    [K in TableKey<TApp>]: TablePolicyBuilder<
+      WhereFor<QueryBuilderFor<TApp, K>>,
+      RowFor<QueryBuilderFor<TApp, K>>,
+      K
+    >;
+  };
+};
+
+type BranchTarget<TApp extends AppLike, TBranchKey extends TableKey<TApp>> = TablePolicyBuilder<
+  WhereFor<QueryBuilderFor<TApp, TBranchKey>>,
+  RowFor<QueryBuilderFor<TApp, TBranchKey>>,
+  TBranchKey
+>;
+
 export type PolicyContext<TApp extends AppLike> = {
   policy: {
     [K in TableKey<TApp>]: TablePolicyBuilder<
       WhereFor<QueryBuilderFor<TApp, K>>,
-      RowFor<QueryBuilderFor<TApp, K>>
+      RowFor<QueryBuilderFor<TApp, K>>,
+      K
     >;
   } & {
     exists(relation: PermissionRelation): ExistsRelationCondition;
     union(relations: readonly PermissionRelation[]): PermissionRelation;
+    forBranch<TBranchKey extends TableKey<TApp>>(
+      branchTable: BranchTarget<TApp, TBranchKey>,
+      callback: (ctx: BranchPolicyContext<TApp, TBranchKey>) => void,
+    ): void;
   };
   anyOf: (conditions: readonly unknown[]) => Condition;
   allOf: (conditions: readonly unknown[]) => Condition;
@@ -522,18 +559,29 @@ export type PolicyContext<TApp extends AppLike> = {
 
 export type CompiledPermissions = Record<string, TablePolicies>;
 
-type PermissionWhereLeaf<T> = T | SessionRefValue | RowRefValue | RecursiveCurrentValue;
+type PermissionWhereLeaf<T> =
+  | T
+  | SessionRefValue
+  | RowRefValue
+  | BranchRowRefValue
+  | RecursiveCurrentValue;
 
 type PermissionWhereObjectBase<T> = {
   [K in keyof T]?:
     | PermissionWhereInput<T[K]>
     | SessionRefValue
     | RowRefValue
+    | BranchRowRefValue
     | RecursiveCurrentValue;
 };
 
 type QualifiedPermissionWhereEntries = {
-  [K in `${string}.${string}`]?: unknown | SessionRefValue | RowRefValue | RecursiveCurrentValue;
+  [K in `${string}.${string}`]?:
+    | unknown
+    | SessionRefValue
+    | RowRefValue
+    | BranchRowRefValue
+    | RecursiveCurrentValue;
 };
 
 type PermissionWhereObject<T> =
@@ -555,6 +603,7 @@ class UpdateRuleBuilder<WhereInput, Row> {
   constructor(
     private readonly table: string,
     private readonly registerRule?: (ruleLike: RuleLike) => void,
+    private readonly branchTable?: string,
   ) {}
 
   where(
@@ -564,6 +613,7 @@ class UpdateRuleBuilder<WhereInput, Row> {
     const rule: Rule = {
       table: this.table,
       action: "update",
+      branchTable: this.branchTable,
       using: condition,
       withCheck: condition,
     };
@@ -610,6 +660,7 @@ class UpdateRuleBuilder<WhereInput, Row> {
     return {
       table: this.table,
       action: "update",
+      branchTable: this.branchTable,
       using: this.oldCondition ?? this.newCondition,
       withCheck: this.newCondition ?? this.oldCondition,
     };
@@ -699,6 +750,37 @@ function buildPolicyContext(
   });
   context.union = (relations: readonly PermissionRelation[]): PermissionRelation =>
     createUnionRelation(relations, relationsByTable);
+  context.forBranch = (
+    branchTableBuilder: unknown,
+    callback: (ctx: {
+      $branch: BranchRowContext<unknown>;
+      branchPolicy: Record<string, unknown>;
+    }) => void,
+  ): void => {
+    const branchTable = expectPolicyTableBuilder(branchTableBuilder);
+    callback({
+      $branch: createBranchRowContext(),
+      branchPolicy: buildBranchPolicyContext(
+        tableNames,
+        relationsByTable,
+        collectRule,
+        branchTable,
+      ),
+    });
+  };
+  return context;
+}
+
+function buildBranchPolicyContext(
+  tableNames: string[],
+  relationsByTable: Map<string, Relation[]>,
+  collectRule: (ruleLike: RuleLike) => void,
+  branchTable: string,
+): Record<string, unknown> {
+  const context: Record<string, unknown> = {};
+  for (const table of tableNames) {
+    context[table] = buildTablePolicyBuilder(table, relationsByTable, collectRule, branchTable);
+  }
   return context;
 }
 
@@ -706,10 +788,12 @@ function buildTablePolicyBuilder(
   table: string,
   relationsByTable: Map<string, Relation[]>,
   collectRule: (ruleLike: RuleLike) => void,
+  branchTable?: string,
 ): Record<string, unknown> {
   const registerRule = (rule: Rule): Rule => {
-    collectRule(rule);
-    return rule;
+    const branchRule = { ...rule, branchTable };
+    collectRule(branchRule);
+    return branchRule;
   };
   const read: ActionBuilder<unknown, unknown> = {
     where: (input) => registerRule({ table, action: "read", using: resolveWhereInput(input) }),
@@ -728,7 +812,7 @@ function buildTablePolicyBuilder(
     never: () => del.where(neverCondition()),
   };
   const updateFactory = (): UpdateRuleBuilder<unknown, unknown> =>
-    new UpdateRuleBuilder(table, collectRule);
+    new UpdateRuleBuilder(table, collectRule, branchTable);
   const managedByCreator = (): void => {
     read.where(CREATOR_CONDITION);
     insert.where(CREATOR_CONDITION);
@@ -996,6 +1080,18 @@ function relationJoinTargetToTable(target: RelationJoinTarget): string {
   throw new Error("join(...) expects a table builder (policy.<table>) or table name string.");
 }
 
+function expectPolicyTableBuilder(input: unknown): string {
+  if (
+    input &&
+    typeof input === "object" &&
+    (input as { __jazzPermissionKind?: unknown }).__jazzPermissionKind === "table-builder" &&
+    typeof (input as { __jazzPermissionTable?: unknown }).__jazzPermissionTable === "string"
+  ) {
+    return (input as { __jazzPermissionTable: string }).__jazzPermissionTable;
+  }
+  throw new Error("policy.forBranch(...) expects a table builder such as policy.branches.");
+}
+
 function resolveNamedRelation(
   relationsByTable: Map<string, Relation[]>,
   table: string,
@@ -1164,6 +1260,9 @@ function toRelValueRef(value: unknown, options: { allowRowRefs: boolean }): RelV
   if (isSessionRefValue(value)) {
     return { SessionRef: value.path };
   }
+  if (isBranchRowRefValue(value)) {
+    return { BranchRef: value.column };
+  }
   if (isRowRefValue(value)) {
     if (!options.allowRowRefs) {
       throw new Error("Row references are only valid inside exists() clauses.");
@@ -1182,7 +1281,7 @@ function relationFilterToPredicates(filter: RelationFilterEntry): RelPredicateEx
   if (raw === null) {
     return [{ IsNull: { column: left } }];
   }
-  if (isSessionRefValue(raw) || isRowRefValue(raw)) {
+  if (isSessionRefValue(raw) || isBranchRowRefValue(raw) || isRowRefValue(raw)) {
     return [
       {
         Cmp: {
@@ -1582,6 +1681,20 @@ function createRowContext(): RowContext<Record<string, unknown>> {
   });
 }
 
+function createBranchRowContext(): BranchRowContext<Record<string, unknown>> {
+  return new Proxy({} as BranchRowContext<Record<string, unknown>>, {
+    get(_target, prop) {
+      if (typeof prop === "string") {
+        return {
+          __jazzPermissionKind: "branch-row-ref",
+          column: prop,
+        } satisfies BranchRowRefValue;
+      }
+      return undefined;
+    },
+  });
+}
+
 function normalizeWhereObject(input: unknown): Record<string, unknown> {
   if (!isPlainObject(input)) {
     throw new Error("Expected a where-object condition.");
@@ -1748,6 +1861,9 @@ function columnFilterToExprs(
   if (isSessionRefValue(raw)) {
     return [cmpExpr(column, "Eq", raw, options)];
   }
+  if (isBranchRowRefValue(raw)) {
+    return [cmpExpr(column, "Eq", raw, options)];
+  }
   if (isRowRefValue(raw)) {
     if (!options.allowRowRefs) {
       throw new Error("Row references are only valid inside exists() clauses.");
@@ -1844,6 +1960,7 @@ function sessionPathFilterToExprs(path: string, raw: unknown): PolicyExpr[] {
     !isPlainObject(raw) ||
     isSessionRefValue(raw) ||
     isRowRefValue(raw) ||
+    isBranchRowRefValue(raw) ||
     isRecursiveCurrentValue(raw) ||
     isExistsCondition(raw) ||
     isExistsRelationCondition(raw) ||
@@ -1967,6 +2084,12 @@ function toPolicyValue(value: unknown, options: { allowRowRefs: boolean }): Poli
       path: [OUTER_ROW_SESSION_PREFIX, value.column],
     };
   }
+  if (isBranchRowRefValue(value)) {
+    return {
+      type: "BranchRef",
+      column: value.column,
+    };
+  }
   return { type: "Literal", value };
 }
 
@@ -1983,6 +2106,9 @@ function assertSessionWhereLiteralValue(value: unknown, context: string): void {
   }
   if (isRowRefValue(value)) {
     throw new Error(`${context} only accepts literal values; row references are not supported.`);
+  }
+  if (isBranchRowRefValue(value)) {
+    throw new Error(`${context} only accepts literal values; branch references are not supported.`);
   }
   if (isRecursiveCurrentValue(value)) {
     throw new Error(
@@ -2064,14 +2190,17 @@ function compileRules(
       compiled[rule.table] = emptyTablePolicies();
     }
     const tablePolicies = compiled[rule.table]!;
+    const targetPolicies = rule.branchTable
+      ? ((tablePolicies.for_branch ??= {})[rule.branchTable] ??= emptyTablePolicies())
+      : tablePolicies;
     switch (rule.action) {
       case "read":
-        tablePolicies.select = mergeOperationPolicy(tablePolicies.select, {
+        targetPolicies.select = mergeOperationPolicy(targetPolicies.select, {
           using: compileCondition(rule.using, rule.table, fkReferencesByTable, relationsByTable),
         });
         break;
       case "insert":
-        tablePolicies.insert = mergeOperationPolicy(tablePolicies.insert, {
+        targetPolicies.insert = mergeOperationPolicy(targetPolicies.insert, {
           with_check: compileCondition(
             rule.withCheck,
             rule.table,
@@ -2081,7 +2210,7 @@ function compileRules(
         });
         break;
       case "update":
-        tablePolicies.update = mergeOperationPolicy(tablePolicies.update, {
+        targetPolicies.update = mergeOperationPolicy(targetPolicies.update, {
           using: compileCondition(rule.using, rule.table, fkReferencesByTable, relationsByTable),
           with_check: compileCondition(
             rule.withCheck,
@@ -2092,7 +2221,7 @@ function compileRules(
         });
         break;
       case "delete":
-        tablePolicies.delete = mergeOperationPolicy(tablePolicies.delete, {
+        targetPolicies.delete = mergeOperationPolicy(targetPolicies.delete, {
           using: compileCondition(rule.using, rule.table, fkReferencesByTable, relationsByTable),
         });
         break;
@@ -2337,6 +2466,14 @@ function isRowRefValue(input: unknown): input is RowRefValue {
   return (
     isPlainObject(input) &&
     input.__jazzPermissionKind === "row-ref" &&
+    typeof input.column === "string"
+  );
+}
+
+function isBranchRowRefValue(input: unknown): input is BranchRowRefValue {
+  return (
+    isPlainObject(input) &&
+    input.__jazzPermissionKind === "branch-row-ref" &&
     typeof input.column === "string"
   );
 }

--- a/packages/jazz-tools/src/react-core/index.ts
+++ b/packages/jazz-tools/src/react-core/index.ts
@@ -8,7 +8,7 @@ export {
   type JazzClientProviderProps,
   type JazzProviderProps,
 } from "./provider.js";
-export { useAll, useAllSuspense } from "./use-all.js";
+export { useAll, useAllSuspense, type UseAllQueryOptions } from "./use-all.js";
 export { useAuthState, type AuthStateInfo } from "./use-auth-state.js";
 export { createUseLocalFirstAuth, type LocalFirstAuth } from "./use-local-first-auth.js";
 

--- a/packages/jazz-tools/src/react-core/use-all.ts
+++ b/packages/jazz-tools/src/react-core/use-all.ts
@@ -1,9 +1,12 @@
 import * as React from "react";
 import { type Usable, use } from "react";
-import type { QueryBuilder, QueryOptions } from "../runtime/db.js";
+import type { QueryBuilder } from "../runtime/db.js";
+import type { QuerySubscriptionOptions } from "../subscriptions-orchestrator.js";
 import { useJazzClient } from "./provider.js";
 
-type UseAllOptions = {
+export type UseAllQueryOptions = QuerySubscriptionOptions;
+
+type UseAllBaseOptions = {
   suspense?: boolean;
 };
 
@@ -11,8 +14,8 @@ const SUSPEND_FOREVER: Promise<never> = new Promise(() => {});
 
 function useAllBase<T extends { id: string }>(
   query?: QueryBuilder<T>,
-  queryOptions?: QueryOptions,
-  options?: UseAllOptions,
+  queryOptions?: UseAllQueryOptions,
+  options?: UseAllBaseOptions,
 ): T[] | undefined {
   const { suspense = false } = options ?? {};
   const { manager } = useJazzClient();
@@ -74,7 +77,7 @@ function useAllBase<T extends { id: string }>(
  */
 export function useAll<T extends { id: string }>(
   query?: QueryBuilder<T>,
-  options?: QueryOptions,
+  options?: UseAllQueryOptions,
 ): T[] | undefined {
   return useAllBase(query, options, { suspense: false });
 }
@@ -89,7 +92,7 @@ export function useAll<T extends { id: string }>(
  */
 export function useAllSuspense<T extends { id: string }>(
   query?: QueryBuilder<T>,
-  options?: QueryOptions,
+  options?: UseAllQueryOptions,
 ): T[] {
   return useAllBase(query, options, { suspense: true }) as T[];
 }

--- a/packages/jazz-tools/src/react-native/index.ts
+++ b/packages/jazz-tools/src/react-native/index.ts
@@ -2,7 +2,7 @@ export { createDb, Db, type DbConfig } from "./db.js";
 export { createJazzClient, type JazzClient } from "./create-jazz-client.js";
 export { loadJazzRn } from "./jazz-rn-loader.js";
 export type { JazzRnRuntimeBinding } from "./jazz-rn-runtime-adapter.js";
-export { useAll, useAllSuspense } from "./use-all.js";
+export { useAll, useAllSuspense, type UseAllQueryOptions } from "./use-all.js";
 export {
   JazzProvider,
   type JazzProviderProps,

--- a/packages/jazz-tools/src/react-native/use-all.ts
+++ b/packages/jazz-tools/src/react-native/use-all.ts
@@ -1,1 +1,1 @@
-export { useAll, useAllSuspense } from "../react-core/use-all.js";
+export { useAll, useAllSuspense, type UseAllQueryOptions } from "../react-core/use-all.js";

--- a/packages/jazz-tools/src/react/index.ts
+++ b/packages/jazz-tools/src/react/index.ts
@@ -13,7 +13,7 @@ export {
   useJazzClient,
   useSession,
 } from "./provider.js";
-export { useAll, useAllSuspense } from "./use-all.js";
+export { useAll, useAllSuspense, type UseAllQueryOptions } from "./use-all.js";
 export { useLocalFirstAuth, type LocalFirstAuth } from "./use-local-first-auth.js";
 export { useAuthState, type AuthStateInfo } from "../react-core/use-auth-state.js";
 export type { QueryOptions, RuntimeSourcesConfig } from "../runtime/index.js";

--- a/packages/jazz-tools/src/react/use-all.ts
+++ b/packages/jazz-tools/src/react/use-all.ts
@@ -1,1 +1,1 @@
-export { useAll, useAllSuspense } from "../react-core/use-all.js";
+export { useAll, useAllSuspense, type UseAllQueryOptions } from "../react-core/use-all.js";

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -110,6 +110,13 @@ export interface Runtime {
   onAuthFailure?(callback: (reason: string) => void): void;
 }
 
+type WasmRuntimeConstructor = new (...args: unknown[]) => Runtime;
+
+function createWasmRuntime(wasmModule: WasmModule, ...args: unknown[]): Runtime {
+  const RuntimeCtor = wasmModule.WasmRuntime as unknown as WasmRuntimeConstructor;
+  return new RuntimeCtor(...args);
+}
+
 /**
  * Authentication configuration for connecting to a Jazz server.
  *
@@ -859,7 +866,7 @@ abstract class BatchHandleBase {
     this.markTouchedRow(options.id);
   }
 
-  update(objectId: string, updates: Record<string, Value>): void {
+  update(objectId: string, updates: Record<string, Value>, updatedAt?: number): void {
     this.ensureActive();
     this.client.updateInternal(
       objectId,
@@ -867,6 +874,7 @@ abstract class BatchHandleBase {
       this.session,
       this.attribution,
       this.batchContext,
+      updatedAt,
     );
     this.markTouchedRow(objectId);
   }
@@ -1012,7 +1020,8 @@ export class JazzClient {
 
     // Create WASM runtime (storage is now synchronous in-memory)
     const schemaJson = serializeRuntimeSchema(context.schema);
-    const runtime = new wasmModule.WasmRuntime(
+    const runtime = createWasmRuntime(
+      wasmModule,
       schemaJson,
       context.appId,
       context.env ?? "dev",
@@ -1047,7 +1056,8 @@ export class JazzClient {
   ): JazzClient {
     // Create WASM runtime (storage is now synchronous in-memory)
     const schemaJson = serializeRuntimeSchema(context.schema);
-    const runtime = new wasmModule.WasmRuntime(
+    const runtime = createWasmRuntime(
+      wasmModule,
       schemaJson,
       context.appId,
       context.env ?? "dev",
@@ -1108,27 +1118,43 @@ export class JazzClient {
     return runInBatch(batch, callback, this);
   }
 
-  private createBatchContext(batchMode: BatchMode): BatchWriteContext {
+  branchNameForUserBranch(userBranch: string): string {
+    return composeTargetBranchName({ ...this.getSchemaContext(), user_branch: userBranch });
+  }
+
+  branchNameForBranchId(branchId: string): string {
+    return composeTargetBranchName({ ...this.getSchemaContext(), user_branch: branchId });
+  }
+
+  private createBatchContext(batchMode: BatchMode, targetBranchName?: string): BatchWriteContext {
     return {
       batchMode,
       batchId: generateBatchId(),
-      targetBranchName: composeTargetBranchName(this.getSchemaContext()),
+      targetBranchName: targetBranchName ?? composeTargetBranchName(this.getSchemaContext()),
     };
   }
 
-  beginTransactionInternal(session?: Session, attribution?: string): Transaction {
+  beginTransactionInternal(
+    session?: Session,
+    attribution?: string,
+    targetBranchName?: string,
+  ): Transaction {
     return new Transaction(
       this,
-      this.createBatchContext("transactional"),
+      this.createBatchContext("transactional", targetBranchName),
       this.resolveWriteSession(session, attribution),
       attribution,
     );
   }
 
-  beginBatchInternal(session?: Session, attribution?: string): DirectBatch {
+  beginBatchInternal(
+    session?: Session,
+    attribution?: string,
+    targetBranchName?: string,
+  ): DirectBatch {
     return new DirectBatch(
       this,
-      this.createBatchContext("direct"),
+      this.createBatchContext("direct", targetBranchName),
       this.resolveWriteSession(session, attribution),
       attribution,
     );

--- a/packages/jazz-tools/src/runtime/db.branch.test.ts
+++ b/packages/jazz-tools/src/runtime/db.branch.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it, vi } from "vitest";
+import { schema as s } from "../index.js";
+import { Db } from "./db.js";
+import { WriteHandle, type JazzClient, type MutationErrorEvent, type Row } from "./client.js";
+import type { WasmSchema } from "../drivers/types.js";
+
+const app = s.defineApp({
+  projects: s.table({
+    name: s.string(),
+  }),
+  todos: s.table({
+    projectId: s.ref("projects"),
+    title: s.string(),
+  }),
+});
+
+class TestDb extends Db {
+  constructor(private readonly testClient: JazzClient) {
+    super({ appId: "branch-db-test", env: "test", userBranch: "main" }, null);
+  }
+
+  protected override getClient(_schema: WasmSchema): JazzClient {
+    return this.testClient;
+  }
+}
+
+function makeClient() {
+  const writeHandle = new WriteHandle("batch-1", {
+    waitForBatch: vi.fn(async () => undefined),
+    localBatchRecord: vi.fn(),
+  } as unknown as JazzClient);
+
+  const directBatch = {
+    batchId: vi.fn(() => "batch-1"),
+    create: vi.fn(
+      (): Row =>
+        ({
+          id: "todo-1",
+          values: [{ type: "Text", value: "Draft todo" }],
+          batchId: "batch-1",
+        }) as Row,
+    ),
+    upsert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    query: vi.fn(async () => []),
+    commit: vi.fn(() => writeHandle),
+    rollback: vi.fn(),
+  };
+
+  const client = {
+    getSchema: () => new Map(Object.entries(app.wasmSchema)),
+    getSchemaContext: () => ({
+      env: "test",
+      schema_hash: "1234567890abcdef",
+      user_branch: "main",
+    }),
+    branchNameForBranchId: vi.fn((branchId: string) => `test-1234567890ab-${branchId}`),
+    query: vi.fn(async () => []),
+    queryInternal: vi.fn(async () => []),
+    beginBatchInternal: vi.fn(() => directBatch),
+    waitForBatch: vi.fn(async () => undefined),
+  } as unknown as JazzClient;
+
+  return { client, directBatch };
+}
+
+describe("Db.branch", () => {
+  it("returns a prototype-derived db view without shadowing branch()", () => {
+    const { client } = makeClient();
+    const db = new TestDb(client);
+
+    const branchDb = db.branch("branch-row-1");
+
+    expect(Object.getPrototypeOf(branchDb)).toBe(db);
+    expect(Object.prototype.hasOwnProperty.call(branchDb, "branch")).toBe(false);
+    expect(typeof branchDb.branch).toBe("function");
+    expect(branchDb.getConfig()).toEqual(db.getConfig());
+  });
+
+  it("returns a db view that injects the selected branch into reads", async () => {
+    const { client } = makeClient();
+    const db = new TestDb(client);
+
+    await db.branch("branch-row-1").all(app.todos);
+
+    expect(client.branchNameForBranchId).not.toHaveBeenCalled();
+    expect(client.query).toHaveBeenCalledWith(
+      expect.stringContaining('"branches":["branch-row-1"]'),
+      expect.anything(),
+    );
+  });
+
+  it("lets nested branch views override the inherited branch scope", async () => {
+    const { client } = makeClient();
+    const db = new TestDb(client);
+    const branchA = db.branch("branch-row-1");
+    const branchB = branchA.branch("branch-row-2");
+
+    await branchB.all(app.todos);
+
+    expect(Object.getPrototypeOf(branchB)).toBe(branchA);
+    expect(client.query).toHaveBeenCalledWith(
+      expect.stringContaining('"branches":["branch-row-2"]'),
+      expect.anything(),
+    );
+    expect(client.query).not.toHaveBeenCalledWith(
+      expect.stringContaining('"branches":["branch-row-1"]'),
+      expect.anything(),
+    );
+  });
+
+  it("treats branch-looking scope input as a logical branch id", async () => {
+    const { client } = makeClient();
+    const db = new TestDb(client);
+    const branchLikeInput = "otherenv-deadbeefcafe-branch-row-1";
+
+    await db.branch(branchLikeInput).all(app.todos);
+
+    expect(client.branchNameForBranchId).not.toHaveBeenCalled();
+    expect(client.query).toHaveBeenCalledWith(
+      expect.stringContaining(`"branches":["${branchLikeInput}"]`),
+      expect.anything(),
+    );
+  });
+
+  it("uses a branch-targeted direct batch for immediate inserts", () => {
+    const { client, directBatch } = makeClient();
+    const db = new TestDb(client);
+
+    db.branch("branch-row-1").insert(app.todos, {
+      projectId: "project-1",
+      title: "Draft todo",
+    });
+
+    expect(client.beginBatchInternal).toHaveBeenCalledWith(
+      undefined,
+      undefined,
+      "test-1234567890ab-branch-row-1",
+    );
+    expect(directBatch.create).toHaveBeenCalledWith(
+      "todos",
+      {
+        projectId: { type: "Uuid", value: "project-1" },
+        title: { type: "Text", value: "Draft todo" },
+      },
+      undefined,
+    );
+    expect(directBatch.commit).toHaveBeenCalled();
+  });
+
+  it("applies the db branch view to plain included relations", async () => {
+    const { client } = makeClient();
+    vi.mocked(client.query).mockResolvedValueOnce([
+      {
+        id: "project-1",
+        values: [
+          { type: "Text", value: "Draft project" },
+          {
+            type: "Array",
+            value: [
+              {
+                type: "Row",
+                value: {
+                  id: "todo-1",
+                  values: [
+                    { type: "Uuid", value: "project-1" },
+                    { type: "Text", value: "Draft todo" },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+    const db = new TestDb(client);
+
+    const rows = await db.branch("outer-branch").all(
+      app.projects.include({
+        todosViaProject: true,
+      }),
+    );
+
+    expect(client.branchNameForBranchId).not.toHaveBeenCalled();
+
+    const [queryJson] = vi.mocked(client.query).mock.calls.at(-1)! as [string];
+    const query = JSON.parse(queryJson);
+    expect(query.branches).toEqual(["outer-branch"]);
+    expect(rows).toEqual([
+      {
+        id: "project-1",
+        name: "Draft project",
+        todosViaProject: [
+          {
+            id: "todo-1",
+            projectId: "project-1",
+            title: "Draft todo",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("delegates branch mutation error listeners to the parent db", () => {
+    const { client } = makeClient();
+    const db = new TestDb(client);
+    const branchDb = db.branch("branch-row-1");
+    const listener = vi.fn();
+    const unsubscribeFromParent = vi.fn();
+    const event = {
+      code: "permission_denied",
+      reason: "denied",
+      batch: {
+        batchId: "batch-1",
+        mode: "direct",
+        sealed: true,
+        latestSettlement: null,
+      },
+    } as MutationErrorEvent;
+    let parentListener: ((event: MutationErrorEvent) => void) | undefined;
+    const parentOnMutationError = vi.spyOn(db, "onMutationError").mockImplementation((callback) => {
+      parentListener = callback;
+      return unsubscribeFromParent;
+    });
+
+    const unsubscribe = branchDb.onMutationError(listener);
+    parentListener?.(event);
+    unsubscribe();
+
+    expect(parentOnMutationError).toHaveBeenCalledWith(listener);
+    expect(listener).toHaveBeenCalledWith(event);
+    expect(unsubscribeFromParent).toHaveBeenCalled();
+  });
+});

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -202,6 +202,12 @@ export interface QueryBuilder<T> {
 
 export type QueryOptions = QueryExecutionOptions;
 
+const DB_BRANCH_SCOPE = Symbol("JazzDbBranchScope");
+
+type BranchScopedDb = Db & {
+  [DB_BRANCH_SCOPE]?: string;
+};
+
 type DbRuntimeOperationContext = {
   session?: Session;
   attribution?: string;
@@ -212,7 +218,33 @@ function ordinaryDbQueryOptions(options?: QueryOptions): QueryOptions {
 }
 
 function queryUsesRelationTraversal(builtQuery: NormalizedBuiltQuery): boolean {
-  return builtQuery.hops.length > 0 || builtQuery.gather !== undefined;
+  return (
+    builtQuery.hops.length > 0 || builtQuery.gather !== undefined || builtQuery.union !== undefined
+  );
+}
+
+function withDefaultQueryBranch(queryJson: string, defaultBranchId: string | null): string {
+  if (!defaultBranchId) {
+    return queryJson;
+  }
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(queryJson) as Record<string, unknown>;
+  } catch {
+    return queryJson;
+  }
+
+  const branches = parsed.branches;
+  if (
+    Array.isArray(branches) &&
+    branches.some((branch): branch is string => typeof branch === "string")
+  ) {
+    return queryJson;
+  }
+
+  parsed.branches = [defaultBranchId];
+  return JSON.stringify(parsed);
 }
 
 export interface ActiveQuerySubscriptionTrace {
@@ -333,6 +365,10 @@ function resolveBuiltQueryOutputTable(
   schema: WasmSchema,
   builtQuery: ReturnType<typeof normalizeBuiltQuery>,
 ): string {
+  if (builtQuery.union) {
+    return resolveBuiltRelationOutputTable(schema, { union: builtQuery.union });
+  }
+
   if (builtQuery.gather?.seed) {
     const gatherTable = resolveBuiltRelationOutputTable(schema, builtQuery.gather.seed);
     return builtQuery.hops.length > 0
@@ -546,6 +582,8 @@ abstract class DbBatchHandleBase<TRuntimeHandle extends RuntimeTransaction | Run
     private readonly bindingName: "DbTransaction" | "DbDirectBatch",
     private readonly resolveClient: (schema: WasmSchema) => JazzClient,
     private readonly beginRuntimeHandle: (client: JazzClient) => TRuntimeHandle,
+    private readonly resolveDefaultRuntimeBranch: (client: JazzClient) => string | null,
+    private readonly resolveDefaultQueryBranch: () => string | null,
   ) {}
 
   private bindTable<T, Init>(table: TableProxy<T, Init>, operation: string): DbBatchHandleBinding {
@@ -659,7 +697,9 @@ abstract class DbBatchHandleBase<TRuntimeHandle extends RuntimeTransaction | Run
     const planningSchema = resolveSchemaWithTable(query._schema, runtimeSchema, builtQuery.table);
     const outputTable = resolveBuiltQueryOutputTable(planningSchema, builtQuery);
     const outputSchema = resolveSchemaWithTable(query._schema, runtimeSchema, outputTable);
-    const rows = await runtimeHandle.query(translateQuery(builderJson, planningSchema), options);
+    const translatedQuery = translateQuery(builderJson, planningSchema);
+    const wasmQuery = withDefaultQueryBranch(translatedQuery, this.resolveDefaultQueryBranch());
+    const rows = await runtimeHandle.query(wasmQuery, options);
     const outputIncludes = outputTable !== builtQuery.table ? {} : builtQuery.includes;
     const transformedRows = transformRows(
       rows,
@@ -695,8 +735,16 @@ export class DbTransaction extends DbBatchHandleBase<RuntimeTransaction> {
   constructor(
     resolveClient: (schema: WasmSchema) => JazzClient,
     beginRuntimeTransaction: (client: JazzClient) => RuntimeTransaction,
+    resolveDefaultRuntimeBranch: (client: JazzClient) => string | null,
+    resolveDefaultQueryBranch: () => string | null,
   ) {
-    super("DbTransaction", resolveClient, beginRuntimeTransaction);
+    super(
+      "DbTransaction",
+      resolveClient,
+      beginRuntimeTransaction,
+      resolveDefaultRuntimeBranch,
+      resolveDefaultQueryBranch,
+    );
   }
 }
 
@@ -713,8 +761,16 @@ export class DbDirectBatch extends DbBatchHandleBase<RuntimeDirectBatch> {
   constructor(
     resolveClient: (schema: WasmSchema) => JazzClient,
     beginRuntimeBatch: (client: JazzClient) => RuntimeDirectBatch,
+    resolveDefaultRuntimeBranch: (client: JazzClient) => string | null,
+    resolveDefaultQueryBranch: () => string | null,
   ) {
-    super("DbDirectBatch", resolveClient, beginRuntimeBatch);
+    super(
+      "DbDirectBatch",
+      resolveClient,
+      beginRuntimeBatch,
+      resolveDefaultRuntimeBranch,
+      resolveDefaultQueryBranch,
+    );
   }
 }
 
@@ -1045,6 +1101,30 @@ export class Db {
 
   protected getRuntimeOperationContext(): DbRuntimeOperationContext | null {
     return null;
+  }
+
+  /** @internal */
+  getClientForBranchView(schema: WasmSchema): JazzClient {
+    return this.getClient(schema);
+  }
+
+  /** @internal */
+  getRuntimeOperationContextForBranchView(): DbRuntimeOperationContext | null {
+    return this.getRuntimeOperationContext();
+  }
+
+  /** @internal */
+  async ensureBranchViewQueryReady(options?: QueryOptions): Promise<void> {
+    await this.ensureQueryReady(options);
+  }
+
+  protected resolveDefaultRuntimeBranch(_client: JazzClient): string | null {
+    const branchId = (this as BranchScopedDb)[DB_BRANCH_SCOPE];
+    return branchId ? _client.branchNameForBranchId(branchId) : null;
+  }
+
+  protected resolveDefaultQueryBranch(): string | null {
+    return (this as BranchScopedDb)[DB_BRANCH_SCOPE] ?? null;
   }
 
   /**
@@ -1617,6 +1697,21 @@ export class Db {
     return structuredClone(this.config);
   }
 
+  branch(branchId: string): Db {
+    const scopedDb = Object.create(this) as BranchScopedDb;
+    Object.defineProperty(scopedDb, DB_BRANCH_SCOPE, {
+      value: branchId,
+      enumerable: false,
+      configurable: true,
+    });
+    Object.defineProperty(scopedDb, "shutdown", {
+      value: async () => undefined,
+      enumerable: false,
+      configurable: true,
+    });
+    return scopedDb;
+  }
+
   setDevMode(enabled: boolean): void {
     this.config.devMode = enabled;
   }
@@ -1657,6 +1752,17 @@ export class Db {
     const transformedData = transformInputColumns(table, data);
     const values = toInsertRecord(transformedData, table._schema, table._table);
     const context = this.getRuntimeOperationContext();
+    const branchName = this.resolveDefaultRuntimeBranch(client);
+    if (branchName) {
+      const batch = context
+        ? client.beginBatchInternal(context.session, context.attribution, branchName)
+        : client.beginBatchInternal(undefined, undefined, branchName);
+      const row = batch.create(table._table, values, options);
+      const handle = batch.commit();
+      return new WriteResult(row, handle.batchId, client).mapValue((createdRow) =>
+        transformOutputRow(table, transformRow(createdRow, table._schema, table._table)),
+      );
+    }
     const inserted = context
       ? client.createHandleInternal(
           table._table,
@@ -1685,6 +1791,14 @@ export class Db {
     const transformedData = transformInputColumns(table, data);
     const values = toUpdateRecord(transformedData, table._schema, table._table);
     const context = this.getRuntimeOperationContext();
+    const branchName = this.resolveDefaultRuntimeBranch(client);
+    if (branchName) {
+      const batch = context
+        ? client.beginBatchInternal(context.session, context.attribution, branchName)
+        : client.beginBatchInternal(undefined, undefined, branchName);
+      batch.upsert(table._table, values, options);
+      return batch.commit();
+    }
     return context
       ? client.upsertHandleInternal(
           table._table,
@@ -1712,6 +1826,14 @@ export class Db {
     const transformedData = transformInputColumns(table, data);
     const updates = toUpdateRecord(transformedData, table._schema, table._table);
     const context = this.getRuntimeOperationContext();
+    const branchName = this.resolveDefaultRuntimeBranch(client);
+    if (branchName) {
+      const batch = context
+        ? client.beginBatchInternal(context.session, context.attribution, branchName)
+        : client.beginBatchInternal(undefined, undefined, branchName);
+      batch.update(id, updates, options?.updatedAt);
+      return batch.commit();
+    }
     return context
       ? client.updateHandleInternal(
           id,
@@ -1732,6 +1854,14 @@ export class Db {
   delete<T, Init>(table: TableProxy<T, Init>, id: string): WriteHandle {
     const client = this.getClient(table._schema);
     const context = this.getRuntimeOperationContext();
+    const branchName = this.resolveDefaultRuntimeBranch(client);
+    if (branchName) {
+      const batch = context
+        ? client.beginBatchInternal(context.session, context.attribution, branchName)
+        : client.beginBatchInternal(undefined, undefined, branchName);
+      batch.delete(id);
+      return batch.commit();
+    }
     return context
       ? client.deleteHandleInternal(id, context.session, context.attribution)
       : client.delete(id);
@@ -1750,7 +1880,14 @@ export class Db {
     const context = this.getRuntimeOperationContext();
     return new DbTransaction(
       (schema) => this.getClient(schema),
-      (client) => client.beginTransactionInternal(context?.session, context?.attribution),
+      (client) => {
+        const branchName = this.resolveDefaultRuntimeBranch(client);
+        return branchName
+          ? client.beginTransactionInternal(context?.session, context?.attribution, branchName)
+          : client.beginTransactionInternal(context?.session, context?.attribution);
+      },
+      (client) => this.resolveDefaultRuntimeBranch(client),
+      () => this.resolveDefaultQueryBranch(),
     );
   }
 
@@ -1789,7 +1926,14 @@ export class Db {
     const context = this.getRuntimeOperationContext();
     return new DbDirectBatch(
       (schema) => this.getClient(schema),
-      (client) => client.beginBatchInternal(context?.session, context?.attribution),
+      (client) => {
+        const branchName = this.resolveDefaultRuntimeBranch(client);
+        return branchName
+          ? client.beginBatchInternal(context?.session, context?.attribution, branchName)
+          : client.beginBatchInternal(context?.session, context?.attribution);
+      },
+      (client) => this.resolveDefaultRuntimeBranch(client),
+      () => this.resolveDefaultQueryBranch(),
     );
   }
 
@@ -1894,7 +2038,8 @@ export class Db {
     const outputSchema = resolveSchemaWithTable(query._schema, runtimeSchema.get, outputTable);
     const queryOptions = ordinaryDbQueryOptions(options);
     await this.ensureQueryReady(queryOptions);
-    const wasmQuery = translateQuery(builderJson, planningSchema);
+    const translatedQuery = translateQuery(builderJson, planningSchema);
+    const wasmQuery = withDefaultQueryBranch(translatedQuery, this.resolveDefaultQueryBranch());
     const usesRelationTraversal = queryUsesRelationTraversal(builtQuery);
     const runtimeQueryOptions = usesRelationTraversal
       ? { ...queryOptions, runtimeSettledTier: null }
@@ -2036,7 +2181,8 @@ export class Db {
       outputIncludes,
       builtQuery.select,
     );
-    const wasmQuery = translateQuery(builderJson, planningSchema);
+    const translatedQuery = translateQuery(builderJson, planningSchema);
+    const wasmQuery = withDefaultQueryBranch(translatedQuery, this.resolveDefaultQueryBranch());
 
     const transform = (row: WasmRow): T =>
       transformOutputRow(

--- a/packages/jazz-tools/src/runtime/query-adapter.ts
+++ b/packages/jazz-tools/src/runtime/query-adapter.ts
@@ -723,7 +723,23 @@ export function translateBuilderToRelationIr(builderJson: string, schema: WasmSc
   let relation: RelExpr;
   let relationTable: string;
 
-  if (builder.gather?.seed) {
+  if (builder.union) {
+    const translated = translateBuiltRelationToRelExpr(
+      {
+        union: builder.union,
+      },
+      relations,
+      schema,
+    );
+    relation = translated.expr;
+    relationTable = translated.outputTable;
+    relation = applyFilter(
+      relation,
+      conditionsToRelPredicate(builder.conditions, schema, relationTable, relationTable),
+    );
+    relation = lowerHopsToRelExpr(relation, relationTable, hops, relations, schema);
+    relationTable = resolveHopsOutputTable(relationTable, hops, relations);
+  } else if (builder.gather?.seed) {
     const seed = translateBuiltRelationToRelExpr(builder.gather.seed, relations, schema);
     relation = gatherToRelExpr(builder.gather, seed.outputTable, seed.expr, relations, schema);
     relationTable = seed.outputTable;

--- a/packages/jazz-tools/src/runtime/query-builder-shape.ts
+++ b/packages/jazz-tools/src/runtime/query-builder-shape.ts
@@ -53,6 +53,7 @@ export interface NormalizedBuiltQuery {
   offset?: number;
   hops: string[];
   gather?: BuiltGather;
+  union?: BuiltRelation["union"];
 }
 
 type BuiltQueryShape = {
@@ -66,6 +67,7 @@ type BuiltQueryShape = {
   offset?: unknown;
   hops?: unknown;
   gather?: unknown;
+  union?: unknown;
 };
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -263,5 +265,11 @@ export function normalizeBuiltQuery(raw: unknown, fallbackTable: string): Normal
       ? value.hops.filter((hop): hop is string => typeof hop === "string")
       : [],
     gather: normalizeGather(value.gather),
+    union:
+      isPlainObject(value.union) && Array.isArray(value.union.inputs)
+        ? {
+            inputs: value.union.inputs.map((input) => normalizeBuiltRelation(input)),
+          }
+        : undefined,
   };
 }

--- a/packages/jazz-tools/src/schema-permissions.ts
+++ b/packages/jazz-tools/src/schema-permissions.ts
@@ -146,7 +146,7 @@ function normalizeWasmLiteral(value: unknown): WasmValue {
 }
 
 function normalizePolicyValueForWasm(value: PolicyValue): WasmPolicyValue {
-  if (value.type === "SessionRef") {
+  if (value.type === "SessionRef" || value.type === "BranchRef") {
     return value;
   }
   return {
@@ -224,6 +224,15 @@ function normalizeRelationPredicateForWasm(predicate: RelPredicateExpr): RelPred
 function normalizeRelationExprForWasm(expr: RelExpr): RelExpr {
   if ("TableScan" in expr) {
     return expr;
+  }
+
+  if ("Branch" in expr) {
+    return {
+      Branch: {
+        ...expr.Branch,
+        input: normalizeRelationExprForWasm(expr.Branch.input),
+      },
+    };
   }
 
   if ("Filter" in expr) {
@@ -407,7 +416,7 @@ function normalizeOperationPolicyForWasm(
   if (policy.with_check) {
     normalized.with_check = normalizePolicyExprForWasm(policy.with_check);
   }
-  return normalized;
+  return normalized.using || normalized.with_check ? normalized : undefined;
 }
 
 function validatePermissionTables(
@@ -423,6 +432,16 @@ function validatePermissionTables(
     throw new Error(
       `permissions.ts defines permissions for unknown table(s): ${unknownTables.join(", ")}.`,
     );
+  }
+
+  for (const [targetTable, tablePolicies] of Object.entries(compiledPermissions)) {
+    for (const backingTable of Object.keys(tablePolicies.for_branch ?? {})) {
+      if (!knownTables.has(backingTable)) {
+        throw new Error(
+          `Unknown branch backing table "${backingTable}" in permissions for table "${targetTable}".`,
+        );
+      }
+    }
   }
 }
 
@@ -492,13 +511,28 @@ export function normalizePermissionsForWasm(
 ): Record<string, WasmTablePolicies> {
   const normalized: Record<string, WasmTablePolicies> = {};
   for (const [tableName, tablePolicies] of Object.entries(compiledPermissions)) {
-    normalized[tableName] = {
-      select: normalizeOperationPolicyForWasm(tablePolicies.select),
-      insert: normalizeOperationPolicyForWasm(tablePolicies.insert),
-      update: normalizeOperationPolicyForWasm(tablePolicies.update),
-      delete: normalizeOperationPolicyForWasm(tablePolicies.delete),
-    };
+    normalized[tableName] = normalizeTablePoliciesForWasm(tablePolicies);
   }
+  return normalized;
+}
+
+function normalizeTablePoliciesForWasm(tablePolicies: TablePolicies): WasmTablePolicies {
+  const normalized: WasmTablePolicies = {
+    select: normalizeOperationPolicyForWasm(tablePolicies.select),
+    insert: normalizeOperationPolicyForWasm(tablePolicies.insert),
+    update: normalizeOperationPolicyForWasm(tablePolicies.update),
+    delete: normalizeOperationPolicyForWasm(tablePolicies.delete),
+  };
+
+  if (tablePolicies.for_branch) {
+    normalized.for_branch = Object.fromEntries(
+      Object.entries(tablePolicies.for_branch).map(([backingTable, branchPolicies]) => [
+        backingTable,
+        normalizeTablePoliciesForWasm(branchPolicies),
+      ]),
+    );
+  }
+
   return normalized;
 }
 

--- a/packages/jazz-tools/src/schema.ts
+++ b/packages/jazz-tools/src/schema.ts
@@ -100,6 +100,11 @@ export type PolicyValue =
   | {
       type: "SessionRef";
       path: string[];
+    }
+  | {
+      type: "BranchRef";
+      column: string;
+      value?: never;
     };
 
 export type PolicyLiteralValue = Extract<PolicyValue, { type: "Literal" }>;
@@ -204,11 +209,14 @@ export interface OperationPolicy {
   with_check?: PolicyExpr;
 }
 
+export type BranchTablePolicies = Record<string, TablePolicies>;
+
 export interface TablePolicies {
   select?: OperationPolicy;
   insert?: OperationPolicy;
   update?: OperationPolicy;
   delete?: OperationPolicy;
+  for_branch?: BranchTablePolicies;
 }
 
 export interface Table {

--- a/packages/jazz-tools/src/subscriptions-orchestrator.test.ts
+++ b/packages/jazz-tools/src/subscriptions-orchestrator.test.ts
@@ -20,6 +20,7 @@ type SubscribeCall = {
   options?: QueryOptions;
   session?: Session;
   unsubscribe: ReturnType<typeof vi.fn>;
+  branch?: string;
 };
 
 type UnitHarness = {
@@ -31,6 +32,16 @@ type UnitHarness = {
   calls: SubscribeCall[];
   emit: (index: number, delta: SubscriptionDelta<Todo>) => void;
   setThrowOnSubscribe: (error: Error | null) => void;
+};
+
+type DbMock = {
+  subscribeAll<T extends { id: string }>(
+    query: QueryBuilder<T>,
+    callback: (delta: SubscriptionDelta<T>) => void,
+    options?: QueryOptions,
+    session?: Session,
+  ): () => void;
+  branch(branchId: string): DbMock;
 };
 
 function makeTodo(id: string, title = `todo-${id}`): Todo {
@@ -69,14 +80,7 @@ function createUnitHarness(
   const calls: SubscribeCall[] = [];
   let throwOnSubscribe: Error | null = null;
 
-  const db: {
-    subscribeAll<T extends { id: string }>(
-      query: QueryBuilder<T>,
-      callback: (delta: SubscriptionDelta<T>) => void,
-      options?: QueryOptions,
-      session?: Session,
-    ): () => void;
-  } = {
+  const createDb = (branch?: string): DbMock => ({
     subscribeAll<T extends { id: string }>(
       query: QueryBuilder<T>,
       callback: (delta: SubscriptionDelta<T>) => void,
@@ -93,10 +97,15 @@ function createUnitHarness(
         options,
         session,
         unsubscribe,
+        branch,
       });
       return unsubscribe;
     },
-  };
+    branch(branchId: string) {
+      return createDb(branchId);
+    },
+  });
+  const db = createDb();
 
   const manager = new SubscriptionsOrchestrator({ appId }, db, initialSession);
 

--- a/packages/jazz-tools/src/subscriptions-orchestrator.ts
+++ b/packages/jazz-tools/src/subscriptions-orchestrator.ts
@@ -2,6 +2,10 @@ import { SubscriptionManager, type SubscriptionDelta } from "./runtime/subscript
 import type { QueryBuilder, QueryOptions } from "./runtime/db.js";
 import type { Session } from "./runtime/context.js";
 
+export type QuerySubscriptionOptions = QueryOptions & {
+  branch?: string;
+};
+
 type UseAllStatePending<T> = {
   status: "pending";
   data: undefined;
@@ -15,7 +19,7 @@ type UseAllStatefulfilledData<T> = {
   error: null;
 };
 
-type UseAllStateError<T> = {
+type UseAllStateError = {
   status: "rejected";
   data: undefined;
   error: unknown;
@@ -24,7 +28,7 @@ type UseAllStateError<T> = {
 export type UseAllState<T extends { id: string }> =
   | UseAllStatePending<T>
   | UseAllStatefulfilledData<T>
-  | UseAllStateError<T>;
+  | UseAllStateError;
 
 export type QueryEntryCallbacks<T extends { id: string }> = {
   onfulfilled?: (data: T[]) => void;
@@ -123,6 +127,7 @@ export function makeDeferred<T>(snapshot?: {
 interface QueryDefinition<T extends { id: string }> {
   query: QueryBuilder<T>;
   options?: QueryOptions;
+  branch?: string;
   snapshot?: T[];
 }
 
@@ -130,6 +135,7 @@ interface InternalCacheEntry<T extends { id: string }> {
   key: string;
   query: QueryBuilder<T>;
   options?: QueryOptions;
+  branch?: string;
   state: UseAllState<T>;
   promise: TrackedPromise<T[]>;
   resolvefulfilled: (data: T[]) => void;
@@ -150,6 +156,7 @@ interface DbLike {
     options?: QueryOptions,
     session?: Session,
   ): () => void;
+  branch(branchId: string): DbLike;
 }
 
 export class SubscriptionsOrchestrator {
@@ -190,13 +197,18 @@ export class SubscriptionsOrchestrator {
 
   makeQueryKey<T extends { id: string }>(
     query: QueryBuilder<T>,
-    options?: QueryOptions,
+    options?: QuerySubscriptionOptions,
     snapshot?: T[],
   ): string {
-    const key = `${this.config.appId}:${serializeQueryOptions(options)}:${query._build()}`;
+    const { branch, options: queryOptions } = splitQuerySubscriptionOptions(options);
+    const key = `${this.config.appId}:${serializeQuerySubscriptionOptions(
+      branch,
+      queryOptions,
+    )}:${query._build()}`;
     this.queryDefinitions.set(key, {
       query,
-      options,
+      options: queryOptions,
+      branch,
       snapshot: snapshot ? [...snapshot] : undefined,
     });
 
@@ -239,6 +251,7 @@ export class SubscriptionsOrchestrator {
       key,
       query: queryDef.query,
       options: queryDef.options,
+      branch: queryDef.branch,
       state: initialState,
       promise: deferred,
       resolvefulfilled: (data) => {
@@ -321,7 +334,8 @@ export class SubscriptionsOrchestrator {
         entry.subscriptionManager = new SubscriptionManager<T>();
       }
 
-      entry.unsubscribe = this.db.subscribeAll<T>(
+      const db = entry.branch ? this.db.branch(entry.branch) : this.db;
+      entry.unsubscribe = db.subscribeAll<T>(
         entry.query,
         (delta) => {
           const wasPending = entry.state.status === "pending";
@@ -384,4 +398,28 @@ function serializeQueryOptions(options?: QueryOptions): string {
   }
 
   return JSON.stringify(options);
+}
+
+function splitQuerySubscriptionOptions(options?: QuerySubscriptionOptions): {
+  branch?: string;
+  options?: QueryOptions;
+} {
+  if (!options) {
+    return {};
+  }
+  const { branch, ...queryOptions } = options;
+  return {
+    ...(branch ? { branch } : {}),
+    options: Object.keys(queryOptions).length > 0 ? queryOptions : undefined,
+  };
+}
+
+function serializeQuerySubscriptionOptions(branch?: string, options?: QueryOptions): string {
+  if (!branch) {
+    return serializeQueryOptions(options);
+  }
+  return JSON.stringify({
+    ...options,
+    branch,
+  });
 }

--- a/packages/jazz-tools/src/typed-app.ts
+++ b/packages/jazz-tools/src/typed-app.ts
@@ -1395,9 +1395,10 @@ function createAppForTables(
 
       const first = relations[0]!;
       const builder = new TypedTableQueryBuilder(first._table, wasmSchema);
+      const inputs = relations.map((relation) => relation._serializeRelation() as BuiltRelation);
       (builder as any)._unionVal = {
         union: {
-          inputs: relations.map((relation) => relation._serializeRelation() as BuiltRelation),
+          inputs,
         },
       };
       return builder;

--- a/packages/jazz-tools/src/vue/index.ts
+++ b/packages/jazz-tools/src/vue/index.ts
@@ -12,6 +12,6 @@ export {
   type JazzClientContextValue,
   type JazzProviderProps,
 } from "./provider.js";
-export { useAll } from "./use-all.js";
+export { useAll, type UseAllQueryOptions } from "./use-all.js";
 export { useLocalFirstAuth, type UseLocalFirstAuth } from "./use-local-first-auth.js";
 export type { DurabilityTier, QueryOptions, RuntimeSourcesConfig } from "../runtime/index.js";

--- a/packages/jazz-tools/src/vue/use-all.ts
+++ b/packages/jazz-tools/src/vue/use-all.ts
@@ -1,9 +1,15 @@
 import { ref, toValue, watchEffect, type MaybeRefOrGetter, type Ref } from "vue";
-import type { QueryBuilder, QueryOptions } from "../runtime/db.js";
+import type { QueryBuilder } from "../runtime/db.js";
 import type { SubscriptionDelta } from "../runtime/subscription-manager.js";
 import { applyDelta } from "../reconcile-array.js";
-import type { CacheEntryHandle, UseAllState } from "../subscriptions-orchestrator.js";
+import type {
+  CacheEntryHandle,
+  QuerySubscriptionOptions,
+  UseAllState,
+} from "../subscriptions-orchestrator.js";
 import { useJazzClient } from "./provider.js";
+
+export type UseAllQueryOptions = QuerySubscriptionOptions;
 
 function applyEntryState<T extends { id: string }>(
   state: UseAllState<T>,
@@ -48,7 +54,7 @@ function subscribeToEntry<T extends { id: string }>(
  */
 export function useAll<T extends { id: string }>(
   query: MaybeRefOrGetter<QueryBuilder<T> | undefined>,
-  options?: MaybeRefOrGetter<QueryOptions | undefined>,
+  options?: MaybeRefOrGetter<UseAllQueryOptions | undefined>,
 ): Ref<T[] | undefined> {
   const { manager } = useJazzClient();
   const data = ref<T[] | undefined>(undefined) as Ref<T[] | undefined>;

--- a/packages/jazz-tools/tests/browser/branch-permissions.integration.test.ts
+++ b/packages/jazz-tools/tests/browser/branch-permissions.integration.test.ts
@@ -1,0 +1,1791 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createDb, type Db, type QueryBuilder } from "../../src/runtime/db.js";
+import { schema as s } from "../../src/index.js";
+import { mergePermissionsIntoWasmSchema } from "../../src/schema-permissions.js";
+import {
+  fetchPermissionsHead,
+  publishStoredPermissions,
+  publishStoredSchema,
+} from "../../src/runtime/schema-fetch.js";
+import { getTestingServerInfo, getTestingServerJwtForUser } from "./testing-server.js";
+import { TestCleanup, uniqueDbName, withTimeout } from "./support.js";
+
+const snakeCaseSchema = {
+  branches: s.table({
+    name: s.string(),
+    owner_id: s.string(),
+  }),
+  todos: s.table({
+    title: s.string(),
+    owner_id: s.string(),
+  }),
+};
+const snakeCaseApp = s.defineApp(snakeCaseSchema);
+const branchQuerySchema = {
+  projects: s.table({
+    name: s.string(),
+  }),
+  branches: s.table({
+    projectId: s.ref("projects"),
+    name: s.string(),
+    ownerId: s.string(),
+  }),
+  todos: s.table({
+    projectId: s.ref("projects"),
+    title: s.string(),
+    ownerId: s.string(),
+  }),
+};
+const branchQueryApp = s.defineApp(branchQuerySchema);
+
+type Actor = "alice" | "bob" | "carol";
+type TodoRow = s.RowOf<typeof snakeCaseApp.todos>;
+type BranchRow = s.RowOf<typeof snakeCaseApp.branches>;
+type SimplePolicyMode = "always" | "owner" | "never";
+type ReadPolicyMode = SimplePolicyMode | "missing";
+type UpdatePolicyMode =
+  | "always"
+  | "never"
+  | "oldOwner"
+  | "newOwner"
+  | "oldAndNewOwner"
+  | "oldOwnerNewAlways"
+  | "oldAlwaysNewOwner";
+
+const actors = ["alice", "bob", "carol"] as const satisfies readonly Actor[];
+const simplePolicyModes = [
+  "always",
+  "owner",
+  "never",
+] as const satisfies readonly SimplePolicyMode[];
+const updatePolicyModes = [
+  "always",
+  "never",
+  "oldOwner",
+  "newOwner",
+  "oldAndNewOwner",
+  "oldOwnerNewAlways",
+  "oldAlwaysNewOwner",
+] as const satisfies readonly UpdatePolicyMode[];
+
+type SimpleAction = "read" | "insert" | "delete";
+type CrudMatrixCase =
+  | {
+      actionUnderTest: SimpleAction;
+      normalMode: SimplePolicyMode;
+      branchMode: SimplePolicyMode;
+    }
+  | {
+      actionUnderTest: "update";
+      normalMode: UpdatePolicyMode;
+      branchMode: UpdatePolicyMode;
+    };
+
+type SimpleActionBuilder = {
+  always(): unknown;
+  never(): unknown;
+  where(input: Record<string, unknown>): unknown;
+};
+
+type UpdateActionBuilder = {
+  always(): unknown;
+  never(): unknown;
+  whereOld(input: Record<string, unknown>): UpdateActionBuilder;
+  whereNew(input: Record<string, unknown>): UpdateActionBuilder;
+};
+
+type MutationHandle<T = unknown> = {
+  batchId?: string;
+  wait(options: { tier: "local" | "edge" }): Promise<T>;
+};
+
+const readMatrixCases = createSimpleMatrixCases("read");
+const insertMatrixCases = createSimpleMatrixCases("insert");
+const deleteMatrixCases = createSimpleMatrixCases("delete");
+const updateMatrixCases = updatePolicyModes.flatMap((normalMode) =>
+  updatePolicyModes.map((branchMode) => ({
+    actionUnderTest: "update" as const,
+    normalMode,
+    branchMode,
+  })),
+);
+const simpleMutationScenarios = [
+  { name: "owner actor", actor: "alice", owner: "alice" },
+  { name: "non-owner actor", actor: "alice", owner: "bob" },
+] as const satisfies readonly {
+  name: string;
+  actor: Actor;
+  owner: Actor;
+}[];
+const updateMutationScenarios = [
+  {
+    name: "owner-preserving",
+    actor: "alice",
+    oldOwner: "alice",
+    newOwner: "alice",
+  },
+  {
+    name: "owner-changing-away",
+    actor: "alice",
+    oldOwner: "alice",
+    newOwner: "bob",
+  },
+  {
+    name: "owner-changing-to-actor",
+    actor: "alice",
+    oldOwner: "bob",
+    newOwner: "alice",
+  },
+  {
+    name: "non-owner-preserving",
+    actor: "alice",
+    oldOwner: "bob",
+    newOwner: "bob",
+  },
+] as const satisfies readonly {
+  name: string;
+  actor: Actor;
+  oldOwner: Actor;
+  newOwner: Actor;
+}[];
+
+const ctx = new TestCleanup();
+
+afterEach(async () => {
+  await ctx.cleanup();
+});
+
+function session(userId: string) {
+  return {
+    user_id: userId,
+    claims: {},
+    authMode: "external" as const,
+  };
+}
+
+function createAppWithPermissions(config: CrudMatrixCase): typeof snakeCaseApp {
+  const app = s.defineApp(snakeCaseSchema);
+  const wasmSchema = mergePermissionsIntoWasmSchema(
+    app.wasmSchema,
+    defineSnakeCaseCrudPermissions(config),
+  );
+
+  (app as unknown as { wasmSchema: typeof wasmSchema }).wasmSchema = wasmSchema;
+  (app.branches as unknown as { _schema: typeof wasmSchema })._schema = wasmSchema;
+  (app.todos as unknown as { _schema: typeof wasmSchema })._schema = wasmSchema;
+
+  return app;
+}
+
+type BranchQueryProjectRow = s.RowOf<typeof branchQueryApp.projects>;
+type BranchQueryBranchRow = s.RowOf<typeof branchQueryApp.branches>;
+type BranchQueryTodoRow = s.RowOf<typeof branchQueryApp.todos>;
+
+type BranchQueryReadPolicyConfig = {
+  normalReadMode: ReadPolicyMode;
+  branchReadMode: ReadPolicyMode;
+  branchBackingReadMode?: ReadPolicyMode;
+  includeForBranchBlock?: boolean;
+  includeBranchTodoRead?: boolean;
+};
+
+const readPolicyModes = [
+  "always",
+  "owner",
+  "never",
+  "missing",
+] as const satisfies readonly ReadPolicyMode[];
+const branchQueryReadCases = readPolicyModes.flatMap((normalReadMode) =>
+  readPolicyModes.map((branchReadMode) => ({
+    normalReadMode,
+    branchReadMode,
+  })),
+);
+
+function createSimpleMatrixCases(actionUnderTest: SimpleAction) {
+  return simplePolicyModes.flatMap((normalMode) =>
+    simplePolicyModes.map((branchMode) => ({
+      actionUnderTest,
+      normalMode,
+      branchMode,
+    })),
+  );
+}
+
+function applySimplePolicy(
+  builder: SimpleActionBuilder,
+  mode: SimplePolicyMode,
+  sessionUserId: unknown,
+) {
+  switch (mode) {
+    case "always":
+      builder.always();
+      break;
+    case "owner":
+      builder.where({ owner_id: sessionUserId });
+      break;
+    case "never":
+      builder.never();
+      break;
+  }
+}
+
+function applyReadPolicyForOwnerColumn(
+  builder: SimpleActionBuilder,
+  mode: ReadPolicyMode,
+  ownerColumn: "owner_id" | "ownerId",
+  sessionUserId: unknown,
+) {
+  switch (mode) {
+    case "always":
+      builder.always();
+      break;
+    case "owner":
+      builder.where({ [ownerColumn]: sessionUserId });
+      break;
+    case "never":
+      builder.never();
+      break;
+    case "missing":
+      break;
+  }
+}
+
+function applyUpdatePolicy(
+  builder: UpdateActionBuilder,
+  mode: UpdatePolicyMode,
+  sessionUserId: unknown,
+) {
+  const ownerCondition = { owner_id: sessionUserId };
+  const alwaysCondition = {};
+  switch (mode) {
+    case "always":
+      builder.always();
+      break;
+    case "never":
+      builder.never();
+      break;
+    case "oldOwner":
+      builder.whereOld(ownerCondition);
+      break;
+    case "newOwner":
+      builder.whereNew(ownerCondition);
+      break;
+    case "oldAndNewOwner":
+      builder.whereOld(ownerCondition).whereNew(ownerCondition);
+      break;
+    case "oldOwnerNewAlways":
+      builder.whereOld(ownerCondition).whereNew(alwaysCondition);
+      break;
+    case "oldAlwaysNewOwner":
+      builder.whereOld(alwaysCondition).whereNew(ownerCondition);
+      break;
+  }
+}
+
+function defineSnakeCaseCrudPermissions(config: CrudMatrixCase) {
+  return s.definePermissions(snakeCaseApp, ({ policy, session }) => {
+    policy.branches.allowRead.always();
+    policy.branches.allowInsert.where({ owner_id: session.user_id });
+    policy.branches.allowUpdate
+      .whereOld({ owner_id: session.user_id })
+      .whereNew({ owner_id: session.user_id });
+    policy.branches.allowDelete.where({ owner_id: session.user_id });
+
+    applySimplePolicy(
+      policy.todos.allowRead,
+      config.actionUnderTest === "read" ? config.normalMode : "always",
+      session.user_id,
+    );
+    applySimplePolicy(
+      policy.todos.allowInsert,
+      config.actionUnderTest === "insert" ? config.normalMode : "always",
+      session.user_id,
+    );
+    applyUpdatePolicy(
+      policy.todos.allowUpdate,
+      config.actionUnderTest === "update" ? config.normalMode : "always",
+      session.user_id,
+    );
+    applySimplePolicy(
+      policy.todos.allowDelete,
+      config.actionUnderTest === "delete" ? config.normalMode : "always",
+      session.user_id,
+    );
+
+    policy.forBranch(policy.branches, ({ branchPolicy, $branch: _branch }) => {
+      applySimplePolicy(
+        branchPolicy.todos.allowRead,
+        config.actionUnderTest === "read" ? config.branchMode : "always",
+        session.user_id,
+      );
+      applySimplePolicy(
+        branchPolicy.todos.allowInsert,
+        config.actionUnderTest === "insert" ? config.branchMode : "always",
+        session.user_id,
+      );
+      applyUpdatePolicy(
+        branchPolicy.todos.allowUpdate,
+        config.actionUnderTest === "update" ? config.branchMode : "always",
+        session.user_id,
+      );
+      applySimplePolicy(
+        branchPolicy.todos.allowDelete,
+        config.actionUnderTest === "delete" ? config.branchMode : "always",
+        session.user_id,
+      );
+    });
+  });
+}
+
+function defineBranchQueryPermissions(
+  app: typeof branchQueryApp,
+  config: BranchQueryReadPolicyConfig,
+) {
+  return s.definePermissions(app, ({ policy, session }) => {
+    policy.projects.allowRead.always();
+    policy.projects.allowInsert.always();
+    policy.projects.allowUpdate.always();
+    policy.projects.allowDelete.always();
+
+    applyReadPolicyForOwnerColumn(
+      policy.branches.allowRead,
+      config.branchBackingReadMode ?? "always",
+      "ownerId",
+      session.user_id,
+    );
+    policy.branches.allowInsert.always();
+    policy.branches.allowUpdate.always();
+    policy.branches.allowDelete.always();
+
+    applyReadPolicyForOwnerColumn(
+      policy.todos.allowRead,
+      config.normalReadMode,
+      "ownerId",
+      session.user_id,
+    );
+    policy.todos.allowInsert.always();
+    policy.todos.allowUpdate.always();
+    policy.todos.allowDelete.always();
+
+    if (config.includeForBranchBlock !== false) {
+      policy.forBranch(policy.branches, ({ branchPolicy }) => {
+        branchPolicy.projects.allowRead.always();
+        branchPolicy.projects.allowInsert.always();
+        branchPolicy.projects.allowUpdate.always();
+        branchPolicy.projects.allowDelete.always();
+
+        if (config.includeBranchTodoRead !== false) {
+          applyReadPolicyForOwnerColumn(
+            branchPolicy.todos.allowRead,
+            config.branchReadMode,
+            "ownerId",
+            session.user_id,
+          );
+        }
+        branchPolicy.todos.allowInsert.always();
+        branchPolicy.todos.allowUpdate.always();
+        branchPolicy.todos.allowDelete.always();
+      });
+    }
+  });
+}
+
+function simplePolicyAllows(mode: SimplePolicyMode, actor: Actor, owner: Actor) {
+  switch (mode) {
+    case "always":
+      return true;
+    case "owner":
+      return actor === owner;
+    case "never":
+      return false;
+  }
+}
+
+function updatePolicyAllows(
+  mode: UpdatePolicyMode,
+  actor: Actor,
+  oldOwner: Actor,
+  newOwner: Actor,
+) {
+  const oldMatches = actor === oldOwner;
+  const newMatches = actor === newOwner;
+  switch (mode) {
+    case "always":
+      return true;
+    case "never":
+      return false;
+    case "oldOwner":
+    case "newOwner":
+    case "oldAndNewOwner":
+      return oldMatches && newMatches;
+    case "oldOwnerNewAlways":
+      return oldMatches;
+    case "oldAlwaysNewOwner":
+      return newMatches;
+  }
+}
+
+async function createAdminDb(appId: string, dbName: string): Promise<Db> {
+  return ctx.track(
+    await createDb({
+      appId,
+      env: "test",
+      adminSecret: "branch-permissions-admin",
+      driver: { type: "persistent", dbName },
+    }),
+  );
+}
+
+async function createActorDb(appId: string, dbName: string, actor: Actor): Promise<Db> {
+  return ctx.track(
+    await createDb({
+      appId,
+      env: "test",
+      cookieSession: session(actor),
+      driver: { type: "persistent", dbName },
+    }),
+  );
+}
+
+async function createCaseDbs(config: CrudMatrixCase, label: string) {
+  const app = createAppWithPermissions(config);
+  const appId = uniqueDbName(`branch-permissions-${label}`);
+  const dbName = uniqueDbName(`branch-permissions-data-${label}`);
+  const adminDb = await createAdminDb(appId, dbName);
+  return {
+    app,
+    adminDb,
+    actorDb: (actor: Actor) => createActorDb(appId, dbName, actor),
+  };
+}
+
+async function publishBranchQueryPermissions(label: string, config: BranchQueryReadPolicyConfig) {
+  const testingServer = await getTestingServerInfo(uniqueDbName(`branch-query-${label}`));
+  const { appId, serverUrl, adminSecret } = testingServer;
+  const structuralApp = s.defineApp(branchQuerySchema);
+  const permissions = defineBranchQueryPermissions(structuralApp, config);
+  const { hash: schemaHash } = await publishStoredSchema(serverUrl, {
+    appId,
+    adminSecret,
+    schema: structuralApp.wasmSchema,
+  });
+  const { head } = await fetchPermissionsHead(serverUrl, { appId, adminSecret });
+  await publishStoredPermissions(serverUrl, {
+    appId,
+    adminSecret,
+    schemaHash,
+    permissions,
+    expectedParentBundleObjectId: head?.bundleObjectId ?? null,
+  });
+
+  return {
+    app: structuralApp,
+    testingServer,
+  };
+}
+
+async function createSyncedBranchQueryActorDb(
+  testingServer: Awaited<ReturnType<typeof getTestingServerInfo>>,
+  label: string,
+  actor: Actor,
+): Promise<Db> {
+  const jwtToken = await getTestingServerJwtForUser(actor, {}, testingServer.appId);
+  return ctx.track(
+    await createDb({
+      appId: testingServer.appId,
+      serverUrl: testingServer.serverUrl,
+      jwtToken,
+      driver: { type: "persistent", dbName: uniqueDbName(label) },
+    }),
+  );
+}
+
+async function createSyncedBranchQueryAdminDb(
+  testingServer: Awaited<ReturnType<typeof getTestingServerInfo>>,
+  label: string,
+): Promise<Db> {
+  return ctx.track(
+    await createDb({
+      appId: testingServer.appId,
+      serverUrl: testingServer.serverUrl,
+      adminSecret: testingServer.adminSecret,
+      driver: { type: "persistent", dbName: uniqueDbName(label) },
+    }),
+  );
+}
+
+async function createSyncedBranchQueryCaseDbs(config: BranchQueryReadPolicyConfig, label: string) {
+  const { app, testingServer } = await publishBranchQueryPermissions(label, config);
+  return {
+    app,
+    seedDb: await createSyncedBranchQueryActorDb(testingServer, `${label}-seed`, "alice"),
+    actorDb: (actor: Actor) =>
+      createSyncedBranchQueryActorDb(testingServer, `${label}-${actor}`, actor),
+  };
+}
+
+function expectedReadIdsForMode(
+  mode: ReadPolicyMode,
+  rows: readonly { id: string; owner: Actor }[],
+  actor: Actor,
+) {
+  switch (mode) {
+    case "always":
+      return rows.map((row) => row.id);
+    case "owner":
+      return rows.filter((row) => row.owner === actor).map((row) => row.id);
+    case "never":
+    case "missing":
+      return [];
+  }
+}
+
+async function closeTrackedDb(db: Db) {
+  ctx.untrack(db);
+  await db.shutdown();
+}
+
+function expectedTodo(row: { id: string }, title: string, owner: Actor) {
+  return [
+    expect.objectContaining({
+      id: row.id,
+      title,
+      owner_id: owner,
+    }),
+  ];
+}
+
+async function expectRows<T>(
+  db: Db,
+  query: QueryBuilder<T>,
+  expectedRows: unknown[],
+  label: string,
+) {
+  const rows = await withTimeout(
+    db.all(query, { tier: "local" }),
+    15_000,
+    `${label}: query did not resolve`,
+  );
+  expect(rows, label).toEqual(expectedRows);
+}
+
+async function expectRowIds<T extends { id: string }>(
+  db: Db,
+  query: QueryBuilder<T>,
+  expectedIds: string[],
+  label: string,
+  tier: "local" | "edge" = "local",
+) {
+  const rows = await withTimeout(
+    db.all(query, { tier }),
+    15_000,
+    `${label}: query did not resolve`,
+  );
+  expect(rows.map((row) => row.id).sort(), label).toEqual([...expectedIds].sort());
+}
+
+async function expectRowTitlesInOrder<T extends { title: string }>(
+  db: Db,
+  query: QueryBuilder<T>,
+  expectedTitles: string[],
+  label: string,
+  tier: "local" | "edge" = "local",
+) {
+  const rows = await withTimeout(
+    db.all(query, { tier }),
+    15_000,
+    `${label}: query did not resolve`,
+  );
+  expect(
+    rows.map((row) => row.title),
+    label,
+  ).toEqual(expectedTitles);
+}
+
+async function expectMutationAllowed<T>(
+  label: string,
+  mutate: () => MutationHandle<T>,
+  tier: "local" | "edge" = "local",
+): Promise<T> {
+  try {
+    const mutation = mutate();
+    return await withTimeout(mutation.wait({ tier }), 20_000, `${label}: mutation did not settle`);
+  } catch (error) {
+    throw new Error(`${label}: expected mutation to be allowed, got ${String(error)}`);
+  }
+}
+
+async function expectMutationDenied(label: string, mutate: () => MutationHandle<unknown>) {
+  let mutation: MutationHandle<unknown>;
+  try {
+    mutation = mutate();
+  } catch (error) {
+    expect(String(error), label).toMatch(/permission_denied|policy denied/i);
+    return;
+  }
+
+  try {
+    await withTimeout(
+      mutation.wait({ tier: "local" }),
+      20_000,
+      `${label}: mutation did not settle`,
+    );
+  } catch (error) {
+    expect(String(error), label).toMatch(/permission_denied|policy denied/i);
+    return;
+  }
+
+  throw new Error(`${label}: expected mutation to be denied`);
+}
+
+async function seedMainTodo(
+  app: typeof snakeCaseApp,
+  adminDb: Db,
+  owner: Actor,
+  title: string,
+): Promise<TodoRow> {
+  return await expectMutationAllowed(`seed main todo ${title}`, () =>
+    adminDb.insert(app.todos, {
+      title,
+      owner_id: owner,
+    }),
+  );
+}
+
+async function seedBranch(
+  app: typeof snakeCaseApp,
+  adminDb: Db,
+  owner: Actor,
+  name: string,
+): Promise<BranchRow> {
+  return await expectMutationAllowed(`seed branch ${name}`, () =>
+    adminDb.insert(app.branches, {
+      name,
+      owner_id: owner,
+    }),
+  );
+}
+
+async function seedBranchTodo(
+  app: typeof snakeCaseApp,
+  adminDb: Db,
+  branchId: string,
+  owner: Actor,
+  title: string,
+): Promise<TodoRow> {
+  return await expectMutationAllowed(`seed branch todo ${title}`, () =>
+    adminDb.branch(branchId).insert(app.todos, {
+      title,
+      owner_id: owner,
+    }),
+  );
+}
+
+async function seedBranchQueryProject(
+  app: typeof branchQueryApp,
+  adminDb: Db,
+  name: string,
+  tier: "local" | "edge" = "local",
+): Promise<BranchQueryProjectRow> {
+  return await expectMutationAllowed(
+    `seed branch query project ${name}`,
+    () =>
+      adminDb.insert(app.projects, {
+        name,
+      }),
+    tier,
+  );
+}
+
+async function seedBranchQueryBranch(
+  app: typeof branchQueryApp,
+  adminDb: Db,
+  projectId: string,
+  owner: Actor,
+  name: string,
+  tier: "local" | "edge" = "local",
+): Promise<BranchQueryBranchRow> {
+  return await expectMutationAllowed(
+    `seed branch query branch ${name}`,
+    () =>
+      adminDb.insert(app.branches, {
+        projectId,
+        name,
+        ownerId: owner,
+      }),
+    tier,
+  );
+}
+
+async function seedBranchQueryMainTodo(
+  app: typeof branchQueryApp,
+  adminDb: Db,
+  projectId: string,
+  owner: Actor,
+  title: string,
+  tier: "local" | "edge" = "local",
+): Promise<BranchQueryTodoRow> {
+  return await expectMutationAllowed(
+    `seed branch query main todo ${title}`,
+    () =>
+      adminDb.insert(app.todos, {
+        projectId,
+        title,
+        ownerId: owner,
+      }),
+    tier,
+  );
+}
+
+async function seedBranchQueryBranchTodo(
+  app: typeof branchQueryApp,
+  adminDb: Db,
+  branchId: string,
+  projectId: string,
+  owner: Actor,
+  title: string,
+  tier: "local" | "edge" = "local",
+): Promise<BranchQueryTodoRow> {
+  return await expectMutationAllowed(
+    `seed branch query branch todo ${title}`,
+    () =>
+      adminDb.branch(branchId).insert(app.todos, {
+        projectId,
+        title,
+        ownerId: owner,
+      }),
+    tier,
+  );
+}
+
+describe("branch permissions browser integration", () => {
+  describe.each(readMatrixCases)(
+    "read matrix: normal=$normalMode branch=$branchMode",
+    ({ normalMode, branchMode }) => {
+      /*
+       * Each generated read case checks the policy split:
+       *
+       *   main storage                 branch storage
+       *   todos(main: alice)           branches(alice) -> todos(branch: bob)
+       *        | normal read policy          | branch read policy
+       *        v                             v
+       *      reader                       reader.branch(branch_id)
+       *
+       *   Surface                              Expected policy
+       *   -----------------------------------  ----------------
+       *   db.all(todos where main title)       normal read
+       *   db.all(todos where branch title)     normal read, no branch leak
+       *   db.branch(id).all(todos)             branch read
+       *   db.branch(id).branch(id).all(todos)  branch read
+       */
+      it("applies normal read policy on main and branch read policy on branches", async () => {
+        const caseName = `read normal=${normalMode} branch=${branchMode}`;
+        const { app, adminDb, actorDb } = await createCaseDbs(
+          {
+            actionUnderTest: "read",
+            normalMode,
+            branchMode,
+          },
+          caseName,
+        );
+        const mainTitle = `Main todo ${caseName}`;
+        const branchTitle = `Branch todo ${caseName}`;
+        const mainOwner = "alice";
+        const branchTodoOwner = "bob";
+        const mainTodo = await seedMainTodo(app, adminDb, mainOwner, mainTitle);
+        const branch = await seedBranch(app, adminDb, "alice", `Draft ${caseName}`);
+        const branchTodo = await seedBranchTodo(
+          app,
+          adminDb,
+          branch.id,
+          branchTodoOwner,
+          branchTitle,
+        );
+
+        await expectRows(
+          adminDb,
+          app.todos.where({ title: mainTitle }),
+          expectedTodo(mainTodo, mainTitle, mainOwner),
+          `${caseName} admin sees main seed`,
+        );
+        await expectRows(
+          adminDb.branch(branch.id),
+          app.todos.where({ title: branchTitle }),
+          expectedTodo(branchTodo, branchTitle, branchTodoOwner),
+          `${caseName} admin sees branch seed`,
+        );
+        await closeTrackedDb(adminDb);
+
+        for (const reader of actors) {
+          const readerDb = await actorDb(reader);
+          const readerCase = `${caseName} reader=${reader}`;
+          const expectedMain = simplePolicyAllows(normalMode, reader, mainOwner)
+            ? expectedTodo(mainTodo, mainTitle, mainOwner)
+            : [];
+          const expectedBranch = simplePolicyAllows(branchMode, reader, branchTodoOwner)
+            ? expectedTodo(branchTodo, branchTitle, branchTodoOwner)
+            : [];
+
+          await expectRows(
+            readerDb,
+            app.todos.where({ title: mainTitle }),
+            expectedMain,
+            `${readerCase} main title`,
+          );
+          await expectRows(
+            readerDb,
+            app.todos.where({ title: branchTitle }),
+            [],
+            `${readerCase} branch title on main`,
+          );
+          await expectRows(readerDb, app.todos.where({}), expectedMain, `${readerCase} all main`);
+          await expectRows(
+            readerDb,
+            app.branches.where({ id: branch.id }),
+            [
+              expect.objectContaining({
+                id: branch.id,
+                name: `Draft ${caseName}`,
+                owner_id: "alice",
+              }),
+            ],
+            `${readerCase} branch backing row`,
+          );
+          await expectRows(
+            readerDb.branch(branch.id),
+            app.todos.where({ title: branchTitle }),
+            expectedBranch,
+            `${readerCase} branch db`,
+          );
+          await expectRows(
+            readerDb.branch(branch.id),
+            app.todos.where({ title: branchTitle }),
+            expectedBranch,
+            `${readerCase} scoped branch query`,
+          );
+          await expectRows(
+            readerDb.branch(branch.id).branch(branch.id),
+            app.todos.where({ title: branchTitle }),
+            expectedBranch,
+            `${readerCase} nested branch scope`,
+          );
+        }
+      });
+    },
+  );
+
+  describe.each(insertMatrixCases)(
+    "insert matrix: normal=$normalMode branch=$branchMode",
+    ({ normalMode, branchMode }) => {
+      /*
+       * Each generated insert case targets exactly one branch family:
+       *
+       *   Write target                         Policy used
+       *   -----------------------------------  ----------------
+       *   writerDb.insert(todos)               normal insert
+       *   writerDb.branch(id).insert(todos)    branch insert
+       *
+       *   Actor/owner rows:
+       *   alice -> owner alice  => owner policy allows
+       *   alice -> owner bob    => owner policy denies
+       */
+      it("applies insert policy for the targeted branch only", async () => {
+        const caseName = `insert normal=${normalMode} branch=${branchMode}`;
+        const { app, adminDb, actorDb } = await createCaseDbs(
+          {
+            actionUnderTest: "insert",
+            normalMode,
+            branchMode,
+          },
+          caseName,
+        );
+        const branch = await seedBranch(app, adminDb, "alice", `Draft ${caseName}`);
+        await closeTrackedDb(adminDb);
+        const writerDb = await actorDb("alice");
+        await expectRows(
+          writerDb,
+          app.branches.where({ id: branch.id }),
+          [
+            expect.objectContaining({
+              id: branch.id,
+              name: `Draft ${caseName}`,
+              owner_id: "alice",
+            }),
+          ],
+          `${caseName} writer sees branch backing row`,
+        );
+
+        for (const scenario of simpleMutationScenarios) {
+          const mainTitle = `Main ${caseName} ${scenario.name}`;
+          const branchTitle = `Branch ${caseName} ${scenario.name}`;
+          const mainAllowed = simplePolicyAllows(normalMode, scenario.actor, scenario.owner);
+          const branchAllowed = simplePolicyAllows(branchMode, scenario.actor, scenario.owner);
+
+          if (mainAllowed) {
+            const row = await expectMutationAllowed(`${caseName} main ${scenario.name}`, () =>
+              writerDb.insert(app.todos, {
+                title: mainTitle,
+                owner_id: scenario.owner,
+              }),
+            );
+            await expectRows(
+              writerDb,
+              app.todos.where({ title: mainTitle }),
+              expectedTodo(row, mainTitle, scenario.owner),
+              `${caseName} main inserted row survives ${scenario.name}`,
+            );
+          } else {
+            await expectMutationDenied(`${caseName} main ${scenario.name}`, () =>
+              writerDb.insert(app.todos, {
+                title: mainTitle,
+                owner_id: scenario.owner,
+              }),
+            );
+            await expectRows(
+              writerDb,
+              app.todos.where({ title: mainTitle }),
+              [],
+              `${caseName} main denied row absent ${scenario.name}`,
+            );
+          }
+
+          if (branchAllowed) {
+            const row = await expectMutationAllowed(`${caseName} branch ${scenario.name}`, () =>
+              writerDb.branch(branch.id).insert(app.todos, {
+                title: branchTitle,
+                owner_id: scenario.owner,
+              }),
+            );
+            await expectRows(
+              writerDb.branch(branch.id),
+              app.todos.where({ title: branchTitle }),
+              expectedTodo(row, branchTitle, scenario.owner),
+              `${caseName} branch inserted row survives ${scenario.name}`,
+            );
+          } else {
+            await expectMutationDenied(`${caseName} branch ${scenario.name}`, () =>
+              writerDb.branch(branch.id).insert(app.todos, {
+                title: branchTitle,
+                owner_id: scenario.owner,
+              }),
+            );
+            await expectRows(
+              writerDb.branch(branch.id),
+              app.todos.where({ title: branchTitle }),
+              [],
+              `${caseName} branch denied row absent ${scenario.name}`,
+            );
+          }
+        }
+      });
+    },
+  );
+
+  describe.each(updateMatrixCases)(
+    "update matrix: normal=$normalMode branch=$branchMode",
+    ({ normalMode, branchMode }) => {
+      /*
+       * Each generated update case isolates old/new-owner policy clauses:
+       *
+       *   Existing row owner ----update----> New row owner
+       *          |                              |
+       *       whereOld                      whereNew
+       *
+       *   Write target                         Policy used
+       *   -----------------------------------  ----------------
+       *   writerDb.update(todos, id)           normal update
+       *   writerDb.branch(id).update(todos)    branch update
+       */
+      it("applies update policy for the targeted branch only", async () => {
+        const caseName = `update normal=${normalMode} branch=${branchMode}`;
+        const { app, adminDb, actorDb } = await createCaseDbs(
+          {
+            actionUnderTest: "update",
+            normalMode,
+            branchMode,
+          },
+          caseName,
+        );
+        const branch = await seedBranch(app, adminDb, "alice", `Draft ${caseName}`);
+        const seededScenarios = [];
+
+        for (const scenario of updateMutationScenarios) {
+          const mainTitle = `Main ${caseName} ${scenario.name}`;
+          const mainNewTitle = `${mainTitle} updated`;
+          const branchTitle = `Branch ${caseName} ${scenario.name}`;
+          const branchNewTitle = `${branchTitle} updated`;
+          const mainRow = await seedMainTodo(app, adminDb, scenario.oldOwner, mainTitle);
+          const branchRow = await seedBranchTodo(
+            app,
+            adminDb,
+            branch.id,
+            scenario.oldOwner,
+            branchTitle,
+          );
+          seededScenarios.push({
+            scenario,
+            mainTitle,
+            mainNewTitle,
+            branchTitle,
+            branchNewTitle,
+            mainRow,
+            branchRow,
+          });
+        }
+
+        await closeTrackedDb(adminDb);
+        const writerDb = await actorDb("alice");
+        await expectRows(
+          writerDb,
+          app.branches.where({ id: branch.id }),
+          [
+            expect.objectContaining({
+              id: branch.id,
+              name: `Draft ${caseName}`,
+              owner_id: "alice",
+            }),
+          ],
+          `${caseName} writer sees branch backing row`,
+        );
+
+        for (const seeded of seededScenarios) {
+          const {
+            scenario,
+            mainTitle,
+            mainNewTitle,
+            branchTitle,
+            branchNewTitle,
+            mainRow,
+            branchRow,
+          } = seeded;
+          await expectRows(
+            writerDb,
+            app.todos.where({ id: mainRow.id }),
+            expectedTodo(mainRow, mainTitle, scenario.oldOwner),
+            `${caseName} main row loaded before update ${scenario.name}`,
+          );
+          await expectRows(
+            writerDb.branch(branch.id),
+            app.todos.where({ id: branchRow.id }),
+            expectedTodo(branchRow, branchTitle, scenario.oldOwner),
+            `${caseName} branch row loaded before update ${scenario.name}`,
+          );
+          const mainAllowed = updatePolicyAllows(
+            normalMode,
+            scenario.actor,
+            scenario.oldOwner,
+            scenario.newOwner,
+          );
+          const branchAllowed = updatePolicyAllows(
+            branchMode,
+            scenario.actor,
+            scenario.oldOwner,
+            scenario.newOwner,
+          );
+
+          if (mainAllowed) {
+            await expectMutationAllowed(`${caseName} main ${scenario.name}`, () =>
+              writerDb.update(app.todos, mainRow.id, {
+                title: mainNewTitle,
+                owner_id: scenario.newOwner,
+              }),
+            );
+            await expectRows(
+              writerDb,
+              app.todos.where({ id: mainRow.id }),
+              expectedTodo(mainRow, mainNewTitle, scenario.newOwner),
+              `${caseName} main allowed update persisted ${scenario.name}`,
+            );
+          } else {
+            await expectMutationDenied(`${caseName} main ${scenario.name}`, () =>
+              writerDb.update(app.todos, mainRow.id, {
+                title: mainNewTitle,
+                owner_id: scenario.newOwner,
+              }),
+            );
+            await expectRows(
+              writerDb,
+              app.todos.where({ id: mainRow.id }),
+              expectedTodo(mainRow, mainTitle, scenario.oldOwner),
+              `${caseName} main denied update preserved ${scenario.name}`,
+            );
+          }
+
+          if (branchAllowed) {
+            await expectMutationAllowed(`${caseName} branch ${scenario.name}`, () =>
+              writerDb.branch(branch.id).update(app.todos, branchRow.id, {
+                title: branchNewTitle,
+                owner_id: scenario.newOwner,
+              }),
+            );
+            await expectRows(
+              writerDb.branch(branch.id),
+              app.todos.where({ id: branchRow.id }),
+              expectedTodo(branchRow, branchNewTitle, scenario.newOwner),
+              `${caseName} branch allowed update persisted ${scenario.name}`,
+            );
+          } else {
+            await expectMutationDenied(`${caseName} branch ${scenario.name}`, () =>
+              writerDb.branch(branch.id).update(app.todos, branchRow.id, {
+                title: branchNewTitle,
+                owner_id: scenario.newOwner,
+              }),
+            );
+            await expectRows(
+              writerDb.branch(branch.id),
+              app.todos.where({ id: branchRow.id }),
+              expectedTodo(branchRow, branchTitle, scenario.oldOwner),
+              `${caseName} branch denied update preserved ${scenario.name}`,
+            );
+          }
+        }
+      });
+    },
+  );
+
+  describe.each(deleteMatrixCases)(
+    "delete matrix: normal=$normalMode branch=$branchMode",
+    ({ normalMode, branchMode }) => {
+      /*
+       * Each generated delete case proves deletes do not cross branches:
+       *
+       *   Main row         --delete--> normal delete policy
+       *   Branch row       --delete--> branch delete policy
+       *
+       *   Policy result    Expected row state
+       *   ---------------  ------------------
+       *   allowed          gone from that branch family
+       *   denied           still readable from that branch family
+       */
+      it("applies delete policy for the targeted branch only", async () => {
+        const caseName = `delete normal=${normalMode} branch=${branchMode}`;
+        const { app, adminDb, actorDb } = await createCaseDbs(
+          {
+            actionUnderTest: "delete",
+            normalMode,
+            branchMode,
+          },
+          caseName,
+        );
+        const branch = await seedBranch(app, adminDb, "alice", `Draft ${caseName}`);
+        const seededScenarios = [];
+
+        for (const scenario of simpleMutationScenarios) {
+          const mainTitle = `Main ${caseName} ${scenario.name}`;
+          const branchTitle = `Branch ${caseName} ${scenario.name}`;
+          const mainRow = await seedMainTodo(app, adminDb, scenario.owner, mainTitle);
+          const branchRow = await seedBranchTodo(
+            app,
+            adminDb,
+            branch.id,
+            scenario.owner,
+            branchTitle,
+          );
+          seededScenarios.push({
+            scenario,
+            mainTitle,
+            branchTitle,
+            mainRow,
+            branchRow,
+          });
+        }
+
+        await closeTrackedDb(adminDb);
+        const writerDb = await actorDb("alice");
+        await expectRows(
+          writerDb,
+          app.branches.where({ id: branch.id }),
+          [
+            expect.objectContaining({
+              id: branch.id,
+              name: `Draft ${caseName}`,
+              owner_id: "alice",
+            }),
+          ],
+          `${caseName} writer sees branch backing row`,
+        );
+
+        for (const seeded of seededScenarios) {
+          const { scenario, mainTitle, branchTitle, mainRow, branchRow } = seeded;
+          await expectRows(
+            writerDb,
+            app.todos.where({ id: mainRow.id }),
+            expectedTodo(mainRow, mainTitle, scenario.owner),
+            `${caseName} main row loaded before delete ${scenario.name}`,
+          );
+          await expectRows(
+            writerDb.branch(branch.id),
+            app.todos.where({ id: branchRow.id }),
+            expectedTodo(branchRow, branchTitle, scenario.owner),
+            `${caseName} branch row loaded before delete ${scenario.name}`,
+          );
+          const mainAllowed = simplePolicyAllows(normalMode, scenario.actor, scenario.owner);
+          const branchAllowed = simplePolicyAllows(branchMode, scenario.actor, scenario.owner);
+
+          if (mainAllowed) {
+            await expectMutationAllowed(`${caseName} main ${scenario.name}`, () =>
+              writerDb.delete(app.todos, mainRow.id),
+            );
+            await expectRows(
+              writerDb,
+              app.todos.where({ id: mainRow.id }),
+              [],
+              `${caseName} main allowed delete removed row ${scenario.name}`,
+            );
+          } else {
+            await expectMutationDenied(`${caseName} main ${scenario.name}`, () =>
+              writerDb.delete(app.todos, mainRow.id),
+            );
+            await expectRows(
+              writerDb,
+              app.todos.where({ id: mainRow.id }),
+              expectedTodo(mainRow, mainTitle, scenario.owner),
+              `${caseName} main denied delete preserved row ${scenario.name}`,
+            );
+          }
+
+          if (branchAllowed) {
+            await expectMutationAllowed(`${caseName} branch ${scenario.name}`, () =>
+              writerDb.branch(branch.id).delete(app.todos, branchRow.id),
+            );
+            await expectRows(
+              writerDb.branch(branch.id),
+              app.todos.where({ id: branchRow.id }),
+              [],
+              `${caseName} branch allowed delete removed row ${scenario.name}`,
+            );
+          } else {
+            await expectMutationDenied(`${caseName} branch ${scenario.name}`, () =>
+              writerDb.branch(branch.id).delete(app.todos, branchRow.id),
+            );
+            await expectRows(
+              writerDb.branch(branch.id),
+              app.todos.where({ id: branchRow.id }),
+              expectedTodo(branchRow, branchTitle, scenario.owner),
+              `${caseName} branch denied delete preserved row ${scenario.name}`,
+            );
+          }
+        }
+      });
+    },
+  );
+});
+
+async function seedBranchQueryFixture(
+  app: typeof branchQueryApp,
+  adminDb: Db,
+  caseName: string,
+  tier: "local" | "edge" = "local",
+) {
+  const project = await seedBranchQueryProject(app, adminDb, `Project ${caseName}`, tier);
+  const mainTodo = await seedBranchQueryMainTodo(
+    app,
+    adminDb,
+    project.id,
+    "alice",
+    `Main todo ${caseName}`,
+    tier,
+  );
+  const otherMainTodo = await seedBranchQueryMainTodo(
+    app,
+    adminDb,
+    project.id,
+    "bob",
+    `Other main todo ${caseName}`,
+    tier,
+  );
+  const branchA = await seedBranchQueryBranch(
+    app,
+    adminDb,
+    project.id,
+    "alice",
+    `Draft A ${caseName}`,
+    tier,
+  );
+  const branchB = await seedBranchQueryBranch(
+    app,
+    adminDb,
+    project.id,
+    "alice",
+    `Draft B ${caseName}`,
+    tier,
+  );
+  const branchATodo = await seedBranchQueryBranchTodo(
+    app,
+    adminDb,
+    branchA.id,
+    project.id,
+    "bob",
+    `Branch A todo ${caseName}`,
+    tier,
+  );
+  const branchBTodo = await seedBranchQueryBranchTodo(
+    app,
+    adminDb,
+    branchB.id,
+    project.id,
+    "alice",
+    `Branch B todo ${caseName}`,
+    tier,
+  );
+
+  return {
+    project,
+    mainTodo,
+    otherMainTodo,
+    branchA,
+    branchB,
+    branchATodo,
+    branchBTodo,
+  };
+}
+
+describe("branch query permissions browser integration", () => {
+  describe.each(branchQueryReadCases)(
+    "read surfaces: normal=$normalReadMode branch=$branchReadMode",
+    ({ normalReadMode, branchReadMode }) => {
+      /*
+       * Each generated browser case uses the same fixture:
+       *
+       *   main branch
+       *   project P
+       *     |- todo M1 owner alice
+       *     `- todo M2 owner bob
+       *
+       *   branch A backing row owner alice -> todo A owner bob
+       *   branch B backing row owner alice -> todo B owner alice
+       *
+       *   Query surface                         Branch chosen  Policy used
+       *   ------------------------------------  -------------  -----------
+       *   db.all(todos where project=P)         main           normal read
+       *   db.branch(A).all(todos)               A              branch read
+       *   db.branch(A).branch(A).all(todos)     A              branch read
+       *   db.branch(A).branch(B).all(todos)     B              branch read
+       */
+      it("applies normal, branch, and override read policies", async () => {
+        const caseName = `normal=${normalReadMode} branch=${branchReadMode}`;
+        const { app, seedDb } = await createSyncedBranchQueryCaseDbs(
+          {
+            normalReadMode,
+            branchReadMode,
+            branchBackingReadMode: "always",
+          },
+          caseName,
+        );
+        const fixture = await seedBranchQueryFixture(app, seedDb, caseName, "edge");
+        const reader = "alice";
+        const expectedMain = expectedReadIdsForMode(
+          normalReadMode,
+          [
+            { id: fixture.mainTodo.id, owner: "alice" },
+            { id: fixture.otherMainTodo.id, owner: "bob" },
+          ],
+          reader,
+        );
+        const expectedBranchA = expectedReadIdsForMode(
+          branchReadMode,
+          [{ id: fixture.branchATodo.id, owner: "bob" }],
+          reader,
+        );
+        const expectedBranchB = expectedReadIdsForMode(
+          branchReadMode,
+          [{ id: fixture.branchBTodo.id, owner: "alice" }],
+          reader,
+        );
+
+        await expectRowIds(
+          seedDb,
+          app.todos.where({ projectId: fixture.project.id }),
+          expectedMain,
+          `${caseName} main project query uses normal read policy`,
+          "edge",
+        );
+        await expectRowIds(
+          seedDb,
+          app.todos.where({ title: `Branch A todo ${caseName}` }),
+          [],
+          `${caseName} branch A row does not leak into main reads`,
+          "edge",
+        );
+        await expectRowIds(
+          seedDb.branch(fixture.branchA.id),
+          app.todos.where({ projectId: fixture.project.id }),
+          expectedBranchA,
+          `${caseName} branch db uses branch read policy`,
+          "edge",
+        );
+        await expectRowIds(
+          seedDb.branch(fixture.branchA.id),
+          app.todos.where({ projectId: fixture.project.id }),
+          expectedBranchA,
+          `${caseName} db branch uses branch read policy`,
+          "edge",
+        );
+        await expectRowIds(
+          seedDb.branch(fixture.branchA.id).branch(fixture.branchB.id),
+          app.todos.where({ projectId: fixture.project.id }),
+          expectedBranchB,
+          `${caseName} nested db branch overrides branch db view`,
+          "edge",
+        );
+      });
+    },
+  );
+
+  /*
+   * Include relation path:
+   *
+   *   db.branch(A).all(projects.include({ todosViaProject: true }))
+   *
+   *   projects.allowRead = always
+   *   branch todos allowRead = never
+   *
+   *   Expected: [project P { todosViaProject: [] }]
+   */
+  it("does not leak denied branch rows through included relations", async () => {
+    const caseName = "include-denied-branch-read";
+    const { app, seedDb } = await createSyncedBranchQueryCaseDbs(
+      {
+        normalReadMode: "always",
+        branchReadMode: "never",
+        branchBackingReadMode: "always",
+      },
+      caseName,
+    );
+    const backingProject = await seedBranchQueryProject(
+      app,
+      seedDb,
+      `Backing project ${caseName}`,
+      "edge",
+    );
+    const branch = await seedBranchQueryBranch(
+      app,
+      seedDb,
+      backingProject.id,
+      "alice",
+      `Draft ${caseName}`,
+      "edge",
+    );
+    const branchProject = await expectMutationAllowed(
+      "seed branch-local project for denied include",
+      () =>
+        seedDb.branch(branch.id).insert(app.projects, {
+          name: `Branch project ${caseName}`,
+        }),
+      "edge",
+    );
+    await seedBranchQueryBranchTodo(
+      app,
+      seedDb,
+      branch.id,
+      branchProject.id,
+      "alice",
+      `Branch include todo ${caseName}`,
+      "edge",
+    );
+
+    const projectRows = await withTimeout(
+      seedDb.branch(branch.id).all(
+        app.projects.where({ id: branchProject.id }).include({
+          todosViaProject: true,
+        }),
+        { tier: "edge" },
+      ),
+      15_000,
+      "denied branch include query did not resolve",
+    );
+    expect(projectRows, "project row remains visible when include is empty").toHaveLength(1);
+    expect(projectRows[0]!.todosViaProject).toEqual([]);
+  });
+
+  /*
+   * Branch DB include inheritance path:
+   *
+   *   db.branch(A).all(projects.include({ todosViaProject: true }))
+   *
+   *   Expected: parent project and plain included todos both read from branch A.
+   */
+  it("applies a branch db view to plain included relations", async () => {
+    const caseName = "branch-db-plain-include";
+    const { app, seedDb } = await createSyncedBranchQueryCaseDbs(
+      {
+        normalReadMode: "always",
+        branchReadMode: "always",
+        branchBackingReadMode: "always",
+      },
+      caseName,
+    );
+    const backingProject = await seedBranchQueryProject(
+      app,
+      seedDb,
+      `Backing project ${caseName}`,
+      "edge",
+    );
+    const branch = await seedBranchQueryBranch(
+      app,
+      seedDb,
+      backingProject.id,
+      "alice",
+      `Draft ${caseName}`,
+      "edge",
+    );
+    const branchProject = await expectMutationAllowed(
+      "seed branch-local project for plain include",
+      () =>
+        seedDb.branch(branch.id).insert(app.projects, {
+          name: `Branch project ${caseName}`,
+        }),
+      "edge",
+    );
+    const branchTodo = await seedBranchQueryBranchTodo(
+      app,
+      seedDb,
+      branch.id,
+      branchProject.id,
+      "alice",
+      `Branch include todo ${caseName}`,
+      "edge",
+    );
+
+    const projectRows = await withTimeout(
+      seedDb.branch(branch.id).all(
+        app.projects.where({ id: branchProject.id }).include({
+          todosViaProject: true,
+        }),
+        { tier: "edge" },
+      ),
+      15_000,
+      "branch db plain include query did not resolve",
+    );
+    expect(projectRows, "project row remains visible through branch db view").toHaveLength(1);
+    expect(
+      projectRows[0]!.todosViaProject.map((todo) => todo.id),
+      "plain include reads from the branch db view",
+    ).toEqual([branchTodo.id]);
+  });
+
+  /*
+   * Branch-local ordering path:
+   *
+   *   branch A contains Z and M titles
+   *   main contains a lexically larger title
+   *
+   *   Query: db.branch(A).all(todos.orderBy(title desc).limit(2))
+   *   Expected: branch-local sorted window only.
+   */
+  it("applies orderBy and limit within the selected branch", async () => {
+    const caseName = "branch-order-limit";
+    const { app, seedDb } = await createSyncedBranchQueryCaseDbs(
+      {
+        normalReadMode: "always",
+        branchReadMode: "always",
+        branchBackingReadMode: "always",
+      },
+      caseName,
+    );
+    const project = await seedBranchQueryProject(app, seedDb, `Project ${caseName}`, "edge");
+    await seedBranchQueryMainTodo(app, seedDb, project.id, "alice", "ZZZ main leak", "edge");
+    const branch = await seedBranchQueryBranch(
+      app,
+      seedDb,
+      project.id,
+      "alice",
+      `Draft ${caseName}`,
+      "edge",
+    );
+    await seedBranchQueryBranchTodo(app, seedDb, branch.id, project.id, "alice", "A-low", "edge");
+    await seedBranchQueryBranchTodo(app, seedDb, branch.id, project.id, "alice", "Z-top", "edge");
+    await seedBranchQueryBranchTodo(app, seedDb, branch.id, project.id, "alice", "M-mid", "edge");
+
+    await expectRowTitlesInOrder(
+      seedDb.branch(branch.id),
+      app.todos.where({ projectId: project.id }).orderBy("title", "desc").limit(2),
+      ["Z-top", "M-mid"],
+      "branch query applies descending order and limit",
+      "edge",
+    );
+  });
+
+  /*
+   * Missing forBranch block:
+   *
+   *   normal todos read = always
+   *   branches read     = always
+   *   forBranch(...)    = absent
+   *
+   *   db.branch(A).all(todos) must deny by default.
+   */
+  it("denies branch reads when no forBranch block is defined", async () => {
+    const caseName = "missing-for-branch-block";
+    const { app, testingServer } = await publishBranchQueryPermissions(caseName, {
+      normalReadMode: "always",
+      branchReadMode: "always",
+      branchBackingReadMode: "always",
+      includeForBranchBlock: false,
+    });
+    const seedDb = await createSyncedBranchQueryAdminDb(testingServer, `${caseName}-seed`);
+    const fixture = await seedBranchQueryFixture(app, seedDb, caseName, "edge");
+    const readerDb = await createSyncedBranchQueryActorDb(
+      testingServer,
+      `${caseName}-alice`,
+      "alice",
+    );
+
+    await expectRowIds(
+      readerDb.branch(fixture.branchA.id),
+      app.todos.where({ projectId: fixture.project.id }),
+      [],
+      "branch reads deny when forBranch is absent",
+      "edge",
+    );
+  });
+
+  /*
+   * Missing table clause inside forBranch:
+   *
+   *   policy.forBranch(branches, ({ branchPolicy }) => {
+   *     // branchPolicy.todos.allowRead is not called
+   *   })
+   *
+   *   Branch-specific reads must fail closed, not fall back to normal read.
+   */
+  it("denies branch reads when forBranch omits the target table read clause", async () => {
+    const caseName = "missing-branch-todo-read";
+    const { app, testingServer } = await publishBranchQueryPermissions(caseName, {
+      normalReadMode: "always",
+      branchReadMode: "always",
+      branchBackingReadMode: "always",
+      includeBranchTodoRead: false,
+    });
+    const seedDb = await createSyncedBranchQueryAdminDb(testingServer, `${caseName}-seed`);
+    const fixture = await seedBranchQueryFixture(app, seedDb, caseName, "edge");
+    const readerDb = await createSyncedBranchQueryActorDb(
+      testingServer,
+      `${caseName}-alice`,
+      "alice",
+    );
+
+    await expectRowIds(
+      readerDb.branch(fixture.branchA.id),
+      app.todos.where({ projectId: fixture.project.id }),
+      [],
+      "branch reads deny when branch todo read is omitted",
+      "edge",
+    );
+  });
+
+  describe.each(["missing", "never"] as const satisfies readonly ReadPolicyMode[])(
+    "backing branch read mode $0",
+    (branchBackingReadMode) => {
+      /*
+       * Backing-row gate:
+       *
+       *   db.branch(A).all(todos)
+       *          |
+       *          +-- branches[A].allowRead must pass
+       *          `-- branchPolicy.todos.allowRead must pass
+       *
+       *   This generated case varies the first gate as missing/never.
+       */
+      it("denies branch reads when the backing row is not readable", async () => {
+        const caseName = `backing=${branchBackingReadMode}`;
+        const { app, testingServer } = await publishBranchQueryPermissions(caseName, {
+          normalReadMode: "always",
+          branchReadMode: "always",
+          branchBackingReadMode,
+        });
+        const seedDb = await createSyncedBranchQueryAdminDb(testingServer, `${caseName}-seed`);
+        const fixture = await seedBranchQueryFixture(app, seedDb, caseName, "edge");
+        const readerDb = await createSyncedBranchQueryActorDb(
+          testingServer,
+          `${caseName}-alice`,
+          "alice",
+        );
+
+        await expectRowIds(
+          readerDb.branch(fixture.branchA.id),
+          app.todos.where({ projectId: fixture.project.id }),
+          [],
+          `${caseName} branch read requires readable backing row`,
+          "edge",
+        );
+      });
+    },
+  );
+
+  describe.each([
+    { name: "never", branchReadMode: "never" as const },
+    { name: "missing", branchReadMode: "missing" as const },
+  ])("synced branch read mode $name", ({ name, branchReadMode }) => {
+    /*
+     * Published-permissions server path:
+     *
+     *   browser DB -> edge query -> structural schema graph
+     *                         `-> published permissions head
+     *
+     *   normal read = always, branch read = never/missing.
+     *   Expected: edge branch query and include both return no todo rows.
+     */
+    it("uses published branch read permissions for edge branch queries", async () => {
+      const { app, testingServer } = await publishBranchQueryPermissions(`synced-${name}`, {
+        normalReadMode: "always",
+        branchReadMode,
+        branchBackingReadMode: "always",
+      });
+      const db = await createSyncedBranchQueryActorDb(
+        testingServer,
+        `synced-branch-query-${name}`,
+        "alice",
+      );
+      const project = await seedBranchQueryProject(app, db, `Synced project ${name}`, "edge");
+      const branch = await seedBranchQueryBranch(
+        app,
+        db,
+        project.id,
+        "alice",
+        `Synced branch ${name}`,
+        "edge",
+      );
+      const branchProject = await expectMutationAllowed(
+        `synced ${name} branch-local project`,
+        () =>
+          db.branch(branch.id).insert(app.projects, {
+            name: `Synced branch project ${name}`,
+          }),
+        "edge",
+      );
+
+      await seedBranchQueryBranchTodo(
+        app,
+        db,
+        branch.id,
+        branchProject.id,
+        "alice",
+        `Synced hidden todo ${name}`,
+        "edge",
+      );
+
+      await expectRowIds(
+        db.branch(branch.id),
+        app.todos.where({ projectId: branchProject.id }),
+        [],
+        `synced ${name} edge branch read`,
+        "edge",
+      );
+
+      const projectRows = await withTimeout(
+        db.branch(branch.id).all(
+          app.projects.where({ id: branchProject.id }).include({
+            todosViaProject: true,
+          }),
+          { tier: "edge" },
+        ),
+        15_000,
+        `synced ${name} include query did not resolve`,
+      );
+      expect(projectRows, `synced ${name} project row visible for include`).toHaveLength(1);
+      expect(projectRows[0]!.todosViaProject).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add prototype-derived `db.branch(id)` scoping with hidden branch state for DB reads, writes, batches, transactions, subscriptions, and included rows.
- Move framework branch selection to adapter options, so React, React Native, and Vue `useAll` accept `{ branch }` while DB APIs stay scoped through `db.branch(id)`.
- Remove public TypeScript query-builder branch APIs while keeping internal runtime/Rust multi-branch query support.
- Add Rust branch policy routing around a `PolicyRouter` path and carry branch policy support through writes, graph filters, subscriptions, server query authorization, and magic permission context.
- Carry over and adapt browser/Rust branch-permission coverage, plus focused DB scoping and hook/cache tests.

## Validation

- `cargo test -p jazz-tools --features test query_manager::rebac_tests::branch_policies`
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/runtime/db.branch.test.ts src/subscriptions-orchestrator.test.ts src/vue/use-all.test.ts`
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.browser.ts tests/browser/branch-permissions.integration.test.ts tests/browser/useAll.test.tsx`
- `pnpm test`
- `pnpm build:core`

Pre-commit hooks also ran on the final commit; `oxlint` reported 0 warnings and 0 errors after the amend.