### PR TITLE
Cover mini SQLite policy invariants

### DIFF
--- a/crates/mini-jazz-sqlite/SPEC.md
+++ b/crates/mini-jazz-sqlite/SPEC.md
@@ -2382,6 +2382,18 @@ feature exists.
 - `write_if_created_by_principal` allows self-authored inserts and preserves
   original `created_by` on updates.
 - Updates and deletes record the previously visible row as a read dependency.
+- Partial updates preserve omitted fields when constructing the proposed row for
+  write-policy validation, including omitted refs used by policy checks.
+- Ref-retarget updates validate the proposed row against policy dependencies
+  reached through the new ref target, and a denied retarget leaves the previous
+  visible ref intact.
+- A policy-denied local delete records the rejection and repairs current,
+  query, and subscription-visible state back to the previously authorized row.
+- Multi-row transactions reject atomically when any row mutation fails local
+  write-policy validation, while preserving write-set history for the rejected
+  transaction.
+- Trusted/admin writes may bypass user row policies while preserving explicit
+  author/provenance attribution.
 
 ### D.10 Catalogue And Lens Invariants
 
@@ -2680,6 +2692,14 @@ Coverage labels:
 - `durable_edge_rejects_after_restart_and_repairs_memory_client`: D.9, D.17
 - `policy_denied_write_is_rejected_history_not_current_state`: D.2, D.3, D.9
 - `write_policy_parent_check_records_policy_read_set`: D.9, D.11
+- `patch_update_uses_preserved_ref_for_write_policy_validation`: D.9
+- `ref_retarget_update_validates_new_parent_policy`: D.9
+- `policy_denied_delete_restores_previous_visible_row_and_subscription`: D.8,
+  D.9
+- `multi_row_transaction_rejects_atomically_when_one_policy_check_fails`: D.2,
+  D.9
+- `trusted_admin_write_bypasses_policy_but_preserves_author_provenance`: D.1,
+  D.9
 - `recursive_write_policy_records_transitive_policy_read_set`: D.9, D.11
 - `policy_read_set_survives_sync`: D.7, D.9
 - `bundle_read_sets_are_scoped_to_exported_history_transactions`: D.7, D.9

--- a/crates/mini-jazz-sqlite/SPEC.md
+++ b/crates/mini-jazz-sqlite/SPEC.md
@@ -424,6 +424,18 @@ sessions for audit, provenance, catalogue checks, and operational controls.
 Untrusted clients cannot forge authority-only facts such as global acceptance,
 rejection, durability receipts, or catalogue publication.
 
+Trusted peers may accept mergeable transactions on behalf of an authenticated
+session according to their policy authority role. Once an edge accepts such a
+transaction, downstream clients may treat that acceptance as authoritative for
+visibility in the edge trust topology; the original session authentication does
+not have to be replayed by every downstream client.
+
+Exclusive transactions are different: they require final fate from the global
+authority. If an edge or other intermediary forwards an exclusive transaction
+instead of deciding it locally, it must forward enough authenticated session
+context for the global authority to evaluate the transaction under the same
+principal, admin/trust role, and policy context as the initiating session.
+
 Non-admin sessions fail closed when required policy metadata is missing.
 
 Application-visible provenance fields include at least:

--- a/crates/mini-jazz-sqlite/src/rows.rs
+++ b/crates/mini-jazz-sqlite/src/rows.rs
@@ -1,15 +1,6 @@
 use crate::Result;
 use rusqlite::{params, Connection, OptionalExtension};
 
-pub(crate) struct NewTodo<'a> {
-    pub(crate) id: &'a str,
-    pub(crate) title: &'a str,
-    pub(crate) done: bool,
-    pub(crate) project_id: &'a str,
-    pub(crate) now: i64,
-    pub(crate) principal: &'a str,
-}
-
 pub(crate) fn ensure_row_id(conn: &Connection, table: &str, row_id: &str) -> Result<i64> {
     conn.execute(
         "INSERT OR IGNORE INTO jazz_row_id (table_name, row_id) VALUES (?, ?)",
@@ -40,66 +31,4 @@ pub(crate) fn public_row_id(conn: &Connection, row_num: i64) -> Result<String> {
     )
     .optional()?
     .ok_or_else(|| crate::Error::new(format!("unknown physical row {row_num}")))
-}
-
-pub(crate) fn insert_project(
-    conn: &Connection,
-    tx_num: i64,
-    id: &str,
-    title: &str,
-    now: i64,
-    principal: &str,
-) -> Result<()> {
-    let row_num = ensure_row_id(conn, "projects", id)?;
-    conn.execute(
-        "INSERT OR IGNORE INTO projects__schema_v1_history
-         (row_num, tx_num, j_branch_num, op, title, j_created_at, j_updated_at, j_created_by, j_updated_by)
-         VALUES (?, ?, 1, 1, ?, ?, ?, ?, ?)",
-        params![row_num, tx_num, title, now, now, principal, principal],
-    )?;
-    conn.execute(
-        "INSERT OR REPLACE INTO projects__schema_v1_current
-         (row_num, j_branch_num, visible_tx_num, is_deleted, title, j_created_at, j_updated_at, j_created_by, j_updated_by)
-         VALUES (?, 1, ?, 0, ?, ?, ?, ?, ?)",
-        params![row_num, tx_num, title, now, now, principal, principal],
-    )?;
-    Ok(())
-}
-
-pub(crate) fn insert_todo(conn: &Connection, tx_num: i64, todo: NewTodo<'_>) -> Result<()> {
-    let row_num = ensure_row_id(conn, "todos", todo.id)?;
-    let project_row_num = ensure_row_id(conn, "projects", todo.project_id)?;
-    conn.execute(
-        "INSERT OR IGNORE INTO todos__schema_v1_history
-         (row_num, tx_num, j_branch_num, op, title, done, project_row_num, j_created_at, j_updated_at, j_created_by, j_updated_by)
-         VALUES (?, ?, 1, 1, ?, ?, ?, ?, ?, ?, ?)",
-        params![
-            row_num,
-            tx_num,
-            todo.title,
-            i64::from(todo.done),
-            project_row_num,
-            todo.now,
-            todo.now,
-            todo.principal,
-            todo.principal
-        ],
-    )?;
-    conn.execute(
-        "INSERT OR REPLACE INTO todos__schema_v1_current
-         (row_num, j_branch_num, visible_tx_num, is_deleted, title, done, project_row_num, j_created_at, j_updated_at, j_created_by, j_updated_by)
-         VALUES (?, 1, ?, 0, ?, ?, ?, ?, ?, ?, ?)",
-        params![
-            row_num,
-            tx_num,
-            todo.title,
-            i64::from(todo.done),
-            project_row_num,
-            todo.now,
-            todo.now,
-            todo.principal,
-            todo.principal
-        ],
-    )?;
-    Ok(())
 }

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -205,7 +205,7 @@ impl Runtime {
         let db = self.conn.transaction()?;
         let now = now_ms();
         let (tx_num, tx_id) = tx::create_tx(&db, self.node_num, &self.node_id, now)?;
-        insert_row_in_tx(InsertRowInTx {
+        let allowed = insert_row_in_tx(InsertRowInTx {
             db: &db,
             schema: &self.schema,
             table_name,
@@ -219,27 +219,6 @@ impl Runtime {
             op,
         })?;
         let row_num = row_num(&db, id)?;
-        let effective_values = effective_write_values(EffectiveWriteValues {
-            db: &db,
-            schema: &self.schema,
-            table_name,
-            id,
-            row_num,
-            branch_num: self.branch_num,
-            patch_values: &values,
-            op,
-        })?;
-        let allowed = self.trusted
-            || local_write_allowed(LocalWriteCheck {
-                db: &db,
-                schema: &self.schema,
-                table: &table,
-                row_num,
-                branch_num: self.branch_num,
-                values: &effective_values,
-                principal: &self.principal,
-                op,
-            })?;
         if !allowed {
             tx::reject(&db, &tx_id, "policy_denied")?;
             db.execute(
@@ -1659,6 +1638,26 @@ impl Runtime {
         let now = now_ms();
         let (tx_num, tx_id) = tx::create_tx(&db, self.node_num, &self.node_id, now)?;
         let row_num = row_num(&db, id)?;
+        record_policy_read_set_for_write(
+            &db,
+            &self.schema,
+            &table,
+            &table.write_policy,
+            &visible_row.values,
+            self.branch_num,
+            tx_num,
+        )?;
+        let allowed = self.trusted
+            || local_write_allowed(LocalWriteCheck {
+                db: &db,
+                schema: &self.schema,
+                table: &table,
+                row_num,
+                branch_num: self.branch_num,
+                values: &visible_row.values,
+                principal: &self.principal,
+                op: 3,
+            })?;
 
         let field_columns = table
             .fields
@@ -1787,6 +1786,10 @@ impl Runtime {
             )?;
         }
         record_tx_write(&db, tx_num, &table.name, row_num, 3)?;
+        if !allowed {
+            tx::reject(&db, &tx_id, "policy_denied")?;
+            projection::rebuild(&db, &self.schema, self.node_num)?;
+        }
         db.commit()?;
         Ok(tx_id)
     }
@@ -2483,7 +2486,7 @@ fn effective_write_values(args: EffectiveWriteValues<'_>) -> Result<BTreeMap<Str
     Ok(current)
 }
 
-fn insert_row_in_tx(args: InsertRowInTx<'_>) -> Result<()> {
+fn insert_row_in_tx(args: InsertRowInTx<'_>) -> Result<bool> {
     let table = args.schema.table_def(args.table_name)?;
     validate_write_fields(table, args.values)?;
     let row_num = ensure_row_id(args.db, args.table_name, args.id)?;
@@ -2610,7 +2613,7 @@ fn insert_row_in_tx(args: InsertRowInTx<'_>) -> Result<()> {
             &current_values,
         )?;
     }
-    Ok(())
+    Ok(allowed)
 }
 
 fn validate_write_fields(
@@ -3210,6 +3213,7 @@ impl<'a> TransactionBuilder<'a> {
             outcome,
             global_epoch,
         )?;
+        let mut allowed = true;
         for mutation in mutations {
             match mutation {
                 Mutation::Row {
@@ -3217,19 +3221,21 @@ impl<'a> TransactionBuilder<'a> {
                     id,
                     values,
                     op,
-                } => insert_row_in_tx(InsertRowInTx {
-                    db: &db,
-                    schema: &self.runtime.schema,
-                    table_name: &table,
-                    id: &id,
-                    values: &values,
-                    tx_num,
-                    branch_num: self.runtime.branch_num,
-                    now,
-                    principal: &self.runtime.principal,
-                    trusted: self.runtime.trusted,
-                    op,
-                })?,
+                } => {
+                    allowed &= insert_row_in_tx(InsertRowInTx {
+                        db: &db,
+                        schema: &self.runtime.schema,
+                        table_name: &table,
+                        id: &id,
+                        values: &values,
+                        tx_num,
+                        branch_num: self.runtime.branch_num,
+                        now,
+                        principal: &self.runtime.principal,
+                        trusted: self.runtime.trusted,
+                        op,
+                    })?;
+                }
                 Mutation::DeleteRow { table, id } => {
                     let table_def = self.runtime.schema.table_def(&table)?;
                     let row_num = row_num(&db, &id)?;
@@ -3245,6 +3251,26 @@ impl<'a> TransactionBuilder<'a> {
                         .get(&(table.clone(), id.clone()))
                         .ok_or_else(|| {
                             crate::Error::new(format!("missing delete snapshot {id}"))
+                        })?;
+                    record_policy_read_set_for_write(
+                        &db,
+                        &self.runtime.schema,
+                        table_def,
+                        &table_def.write_policy,
+                        &visible_row.values,
+                        self.runtime.branch_num,
+                        tx_num,
+                    )?;
+                    allowed &= self.runtime.trusted
+                        || local_write_allowed(LocalWriteCheck {
+                            db: &db,
+                            schema: &self.runtime.schema,
+                            table: table_def,
+                            row_num,
+                            branch_num: self.runtime.branch_num,
+                            values: &visible_row.values,
+                            principal: &self.runtime.principal,
+                            op: 3,
                         })?;
                     let field_columns = table_def
                         .fields
@@ -3405,6 +3431,10 @@ impl<'a> TransactionBuilder<'a> {
                     record_tx_write(&db, tx_num, "todos", row_num(&db, &id)?, 1)?;
                 }
             }
+        }
+        if !allowed {
+            tx::reject(&db, &tx_id, "policy_denied")?;
+            projection::rebuild(&db, &self.runtime.schema, self.runtime.node_num)?;
         }
         db.commit()?;
         Ok(tx_id)

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -1,4 +1,4 @@
-use crate::rows::{ensure_row_id, insert_project, insert_todo, public_row_id, row_num, NewTodo};
+use crate::rows::{ensure_row_id, public_row_id, row_num};
 use crate::schema::{FieldDef, FieldKind, PolicyDef, SchemaDef};
 use crate::subscription::{RejectionSubscription, RowsSubscription, RowsSubscriptionQuery};
 use crate::sync::{
@@ -75,90 +75,6 @@ impl Runtime {
             branch_num: 1,
             trusted,
         })
-    }
-
-    pub fn create_project(&mut self, id: &str, title: &str) -> Result<String> {
-        self.schema.table_def("projects")?;
-        let db = self.conn.transaction()?;
-        let now = now_ms();
-        let (tx_num, tx_id) = tx::create_tx(&db, self.node_num, &self.node_id, now)?;
-        let row_num = ensure_row_id(&db, "projects", id)?;
-        db.execute(
-            "INSERT OR IGNORE INTO projects__schema_v1_history
-             (row_num, tx_num, j_branch_num, op, title, j_created_at, j_updated_at, j_created_by, j_updated_by)
-             VALUES (?, ?, ?, 1, ?, ?, ?, ?, ?)",
-            params![
-                row_num,
-                tx_num,
-                self.branch_num,
-                title,
-                now,
-                now,
-                self.principal,
-                self.principal
-            ],
-        )?;
-        record_tx_write(&db, tx_num, "projects", row_num, 1)?;
-        db.execute(
-            "INSERT OR REPLACE INTO projects__schema_v1_current
-             (row_num, j_branch_num, visible_tx_num, is_deleted, title, j_created_at, j_updated_at, j_created_by, j_updated_by)
-             VALUES (?, ?, ?, 0, ?, ?, ?, ?, ?)",
-            params![row_num, self.branch_num, tx_num, title, now, now, self.principal, self.principal],
-        )?;
-        db.commit()?;
-        Ok(tx_id)
-    }
-
-    pub fn create_todo(
-        &mut self,
-        id: &str,
-        title: &str,
-        done: bool,
-        project_id: &str,
-    ) -> Result<String> {
-        self.schema.table_def("todos")?;
-        let db = self.conn.transaction()?;
-        let now = now_ms();
-        let (tx_num, tx_id) = tx::create_tx(&db, self.node_num, &self.node_id, now)?;
-        let row_num = ensure_row_id(&db, "todos", id)?;
-        let project_row_num = ensure_row_id(&db, "projects", project_id)?;
-        db.execute(
-            "INSERT OR IGNORE INTO todos__schema_v1_history
-             (row_num, tx_num, j_branch_num, op, title, done, project_row_num, j_created_at, j_updated_at, j_created_by, j_updated_by)
-             VALUES (?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?)",
-            params![
-                row_num,
-                tx_num,
-                self.branch_num,
-                title,
-                i64::from(done),
-                project_row_num,
-                now,
-                now,
-                self.principal,
-                self.principal
-            ],
-        )?;
-        record_tx_write(&db, tx_num, "todos", row_num, 1)?;
-        db.execute(
-            "INSERT OR REPLACE INTO todos__schema_v1_current
-             (row_num, j_branch_num, visible_tx_num, is_deleted, title, done, project_row_num, j_created_at, j_updated_at, j_created_by, j_updated_by)
-             VALUES (?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?)",
-            params![
-                row_num,
-                self.branch_num,
-                tx_num,
-                title,
-                i64::from(done),
-                project_row_num,
-                now,
-                now,
-                self.principal,
-                self.principal
-            ],
-        )?;
-        db.commit()?;
-        Ok(tx_id)
     }
 
     pub fn insert_row(
@@ -1603,28 +1519,6 @@ impl Runtime {
             mutations: Vec::new(),
             mode: TransactionMode::Mergeable,
         }
-    }
-
-    pub fn delete_todo(&mut self, id: &str) -> Result<String> {
-        let db = self.conn.transaction()?;
-        let now = now_ms();
-        let (tx_num, tx_id) = tx::create_tx(&db, self.node_num, &self.node_id, now)?;
-        let row_num = row_num(&db, id)?;
-        db.execute(
-            "INSERT OR IGNORE INTO todos__schema_v1_history
-	             (row_num, tx_num, j_branch_num, op, title, done, project_row_num, j_created_at, j_updated_at, j_created_by, j_updated_by)
-	             SELECT row_num, ?, j_branch_num, 3, title, done, project_row_num, j_created_at, ?, j_created_by, ?
-	             FROM todos__schema_v1_current
-	             WHERE row_num = ? AND j_branch_num = ?",
-            params![tx_num, now, self.principal, row_num, self.branch_num],
-        )?;
-        record_tx_write(&db, tx_num, "todos", row_num, 3)?;
-        db.execute(
-            "DELETE FROM todos__schema_v1_current WHERE row_num = ? AND j_branch_num = ?",
-            params![row_num, self.branch_num],
-        )?;
-        db.commit()?;
-        Ok(tx_id)
     }
 
     pub fn delete_row(&mut self, table_name: &str, id: &str) -> Result<String> {
@@ -3080,16 +2974,6 @@ enum Mutation {
         table: String,
         id: String,
     },
-    Project {
-        id: String,
-        title: String,
-    },
-    Todo {
-        id: String,
-        title: String,
-        done: bool,
-        project_id: String,
-    },
 }
 
 impl<'a> TransactionBuilder<'a> {
@@ -3143,24 +3027,6 @@ impl<'a> TransactionBuilder<'a> {
         self
     }
 
-    pub fn create_project(mut self, id: &str, title: &str) -> Self {
-        self.mutations.push(Mutation::Project {
-            id: id.to_owned(),
-            title: title.to_owned(),
-        });
-        self
-    }
-
-    pub fn create_todo(mut self, id: &str, title: &str, done: bool, project_id: &str) -> Self {
-        self.mutations.push(Mutation::Todo {
-            id: id.to_owned(),
-            title: title.to_owned(),
-            done,
-            project_id: project_id.to_owned(),
-        });
-        self
-    }
-
     pub fn commit(self) -> Result<String> {
         let mutations = self.mutations;
         let mut delete_snapshots = BTreeMap::new();
@@ -3193,8 +3059,6 @@ impl<'a> TransactionBuilder<'a> {
                     Mutation::Row { table, id, .. } | Mutation::DeleteRow { table, id } => {
                         (table.as_str(), id.as_str())
                     }
-                    Mutation::Project { id, .. } => ("projects", id.as_str()),
-                    Mutation::Todo { id, .. } => ("todos", id.as_str()),
                 };
                 let row_num = ensure_row_id(&self.runtime.conn, table, id)?;
                 if exclusive_write_conflict_exists(&self.runtime.conn, table, row_num)? {
@@ -3405,30 +3269,6 @@ impl<'a> TransactionBuilder<'a> {
                         )?;
                     }
                     record_tx_write(&db, tx_num, &table, row_num, 3)?;
-                }
-                Mutation::Project { id, title } => {
-                    insert_project(&db, tx_num, &id, &title, now, &self.runtime.principal)?;
-                    record_tx_write(&db, tx_num, "projects", row_num(&db, &id)?, 1)?;
-                }
-                Mutation::Todo {
-                    id,
-                    title,
-                    done,
-                    project_id,
-                } => {
-                    insert_todo(
-                        &db,
-                        tx_num,
-                        NewTodo {
-                            id: &id,
-                            title: &title,
-                            done,
-                            project_id: &project_id,
-                            now,
-                            principal: &self.runtime.principal,
-                        },
-                    )?;
-                    record_tx_write(&db, tx_num, "todos", row_num(&db, &id)?, 1)?;
                 }
             }
         }

--- a/crates/mini-jazz-sqlite/tests/support/mod.rs
+++ b/crates/mini-jazz-sqlite/tests/support/mod.rs
@@ -1,4 +1,50 @@
-use mini_jazz_sqlite::SchemaDef;
+use mini_jazz_sqlite::{Result, Runtime, SchemaDef};
+use serde_json::json;
+use std::collections::BTreeMap;
+
+pub trait FixtureRuntimeExt {
+    fn create_project(&mut self, id: &str, title: &str) -> Result<String>;
+    fn create_todo(
+        &mut self,
+        id: &str,
+        title: &str,
+        done: bool,
+        project_id: &str,
+    ) -> Result<String>;
+    fn delete_todo(&mut self, id: &str) -> Result<String>;
+}
+
+impl FixtureRuntimeExt for Runtime {
+    fn create_project(&mut self, id: &str, title: &str) -> Result<String> {
+        self.insert_row(
+            "projects",
+            id,
+            BTreeMap::from([("title".to_owned(), json!(title))]),
+        )
+    }
+
+    fn create_todo(
+        &mut self,
+        id: &str,
+        title: &str,
+        done: bool,
+        project_id: &str,
+    ) -> Result<String> {
+        self.insert_row(
+            "todos",
+            id,
+            BTreeMap::from([
+                ("title".to_owned(), json!(title)),
+                ("done".to_owned(), json!(done)),
+                ("project".to_owned(), json!(project_id)),
+            ]),
+        )
+    }
+
+    fn delete_todo(&mut self, id: &str) -> Result<String> {
+        self.delete_row("todos", id)
+    }
+}
 
 pub fn tasks_schema() -> SchemaDef {
     SchemaDef::new().table("tasks", |table| {

--- a/crates/mini-jazz-sqlite/tests/whole_system.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 use tempfile::tempdir;
 
 mod support;
+use support::FixtureRuntimeExt;
 
 #[path = "whole_system/branches.rs"]
 mod branches;

--- a/crates/mini-jazz-sqlite/tests/whole_system/policies.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/policies.rs
@@ -1565,6 +1565,235 @@ fn patch_update_uses_preserved_ref_for_write_policy_validation() {
 }
 
 #[test]
+fn ref_retarget_update_validates_new_parent_policy() {
+    let schema = SchemaDef::new()
+        .table("projects", |table| {
+            table.text("title");
+            table.read_if_created_by_principal();
+        })
+        .table("todos", |table| {
+            table.text("title");
+            table.ref_("project", "projects");
+            table.write_if_ref_readable("project");
+        });
+    let mut alice =
+        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema.clone()).unwrap();
+    let mut bob = Runtime::open_with_schema(Storage::Memory, "bob-node", "bob", schema).unwrap();
+
+    alice
+        .insert_row(
+            "projects",
+            "project-alice",
+            BTreeMap::from([("title".to_owned(), json!("Alice project"))]),
+        )
+        .unwrap();
+    bob.insert_row(
+        "projects",
+        "project-bob",
+        BTreeMap::from([("title".to_owned(), json!("Bob project"))]),
+    )
+    .unwrap();
+    alice
+        .apply_bundle(&bob.export_table_history("projects").unwrap())
+        .unwrap();
+    alice
+        .insert_row(
+            "todos",
+            "todo-1",
+            BTreeMap::from([
+                ("title".to_owned(), json!("Original")),
+                ("project".to_owned(), json!("project-alice")),
+            ]),
+        )
+        .unwrap();
+
+    let tx = alice
+        .update_row(
+            "todos",
+            "todo-1",
+            BTreeMap::from([("project".to_owned(), json!("project-bob"))]),
+        )
+        .unwrap();
+
+    let rows = alice.read_rows("todos").unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].values["project"], json!("project-alice"));
+    assert_eq!(
+        alice.transaction_info(&tx).unwrap().rejection_code,
+        Some("policy_denied".to_owned())
+    );
+}
+
+#[test]
+fn policy_denied_delete_restores_previous_visible_row_and_subscription() {
+    let schema = SchemaDef::new()
+        .table("docs", |table| {
+            table.text("title");
+            table.read_if_created_by_principal();
+        })
+        .table("comments", |table| {
+            table.text("body");
+            table.ref_("doc", "docs");
+            table.write_if_ref_readable("doc");
+        });
+    let mut alice =
+        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema.clone()).unwrap();
+    let mut bob = Runtime::open_with_schema(Storage::Memory, "bob-node", "bob", schema).unwrap();
+
+    bob.insert_row(
+        "docs",
+        "doc-bob",
+        BTreeMap::from([("title".to_owned(), json!("Bob doc"))]),
+    )
+    .unwrap();
+    bob.insert_row(
+        "comments",
+        "comment-1",
+        BTreeMap::from([
+            ("body".to_owned(), json!("Kept after rejected delete")),
+            ("doc".to_owned(), json!("doc-bob")),
+        ]),
+    )
+    .unwrap();
+    alice
+        .apply_bundle(&bob.export_table_history("docs").unwrap())
+        .unwrap();
+    alice
+        .apply_bundle(&bob.export_table_history("comments").unwrap())
+        .unwrap();
+    let mut subscription = alice.subscribe_rows("comments").unwrap();
+    assert_eq!(subscription.initial_rows().len(), 1);
+
+    let tx = alice.delete_row("comments", "comment-1").unwrap();
+
+    assert_eq!(
+        alice.transaction_info(&tx).unwrap().rejection_code,
+        Some("policy_denied".to_owned())
+    );
+    let rows = alice.read_rows("comments").unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].id, "comment-1");
+    assert!(alice
+        .poll_subscription(&mut subscription)
+        .unwrap()
+        .is_empty());
+}
+
+#[test]
+fn multi_row_transaction_rejects_atomically_when_one_policy_check_fails() {
+    let schema = SchemaDef::new()
+        .table("docs", |table| {
+            table.text("title");
+            table.read_if_created_by_principal();
+        })
+        .table("comments", |table| {
+            table.text("body");
+            table.ref_("doc", "docs");
+            table.write_if_ref_readable("doc");
+        });
+    let mut alice =
+        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema.clone()).unwrap();
+    let mut bob = Runtime::open_with_schema(Storage::Memory, "bob-node", "bob", schema).unwrap();
+
+    alice
+        .insert_row(
+            "docs",
+            "doc-alice",
+            BTreeMap::from([("title".to_owned(), json!("Alice doc"))]),
+        )
+        .unwrap();
+    bob.insert_row(
+        "docs",
+        "doc-bob",
+        BTreeMap::from([("title".to_owned(), json!("Bob doc"))]),
+    )
+    .unwrap();
+    alice
+        .apply_bundle(&bob.export_table_history("docs").unwrap())
+        .unwrap();
+
+    let tx = alice
+        .transaction()
+        .insert_row(
+            "comments",
+            "comment-allowed",
+            BTreeMap::from([
+                ("body".to_owned(), json!("Would be allowed alone")),
+                ("doc".to_owned(), json!("doc-alice")),
+            ]),
+        )
+        .insert_row(
+            "comments",
+            "comment-denied",
+            BTreeMap::from([
+                ("body".to_owned(), json!("Rejects whole transaction")),
+                ("doc".to_owned(), json!("doc-bob")),
+            ]),
+        )
+        .commit()
+        .unwrap();
+
+    assert_eq!(
+        alice.transaction_info(&tx).unwrap().rejection_code,
+        Some("policy_denied".to_owned())
+    );
+    assert!(alice.read_rows("comments").unwrap().is_empty());
+    assert_eq!(
+        alice.transaction_write_rows(&tx).unwrap(),
+        vec![
+            ("comments".to_owned(), "comment-allowed".to_owned()),
+            ("comments".to_owned(), "comment-denied".to_owned())
+        ]
+    );
+}
+
+#[test]
+fn trusted_admin_write_bypasses_policy_but_preserves_author_provenance() {
+    let schema = SchemaDef::new()
+        .table("docs", |table| {
+            table.text("title");
+            table.read_if_created_by_principal();
+        })
+        .table("comments", |table| {
+            table.text("body");
+            table.ref_("doc", "docs");
+            table.write_if_ref_readable("doc");
+        });
+    let mut alice =
+        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema.clone()).unwrap();
+    let mut admin =
+        Runtime::open_trusted_as_with_schema(Storage::Memory, "admin-node", "service", schema)
+            .unwrap();
+
+    alice
+        .insert_row(
+            "docs",
+            "doc-alice",
+            BTreeMap::from([("title".to_owned(), json!("Alice doc"))]),
+        )
+        .unwrap();
+    admin
+        .apply_bundle(&alice.export_table_history("docs").unwrap())
+        .unwrap();
+    let tx = admin
+        .insert_row(
+            "comments",
+            "comment-service",
+            BTreeMap::from([
+                ("body".to_owned(), json!("Inserted by service")),
+                ("doc".to_owned(), json!("doc-alice")),
+            ]),
+        )
+        .unwrap();
+
+    let rows = admin.read_rows("comments").unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].created_by, "service");
+    assert_eq!(rows[0].tx_id, tx);
+    assert_eq!(admin.transaction_info(&tx).unwrap().rejection_code, None);
+}
+
+#[test]
 fn recursive_write_policy_records_transitive_policy_read_set() {
     let schema = SchemaDef::new()
         .table("orgs", |table| {

--- a/crates/mini-jazz-sqlite/tests/whole_system/transactions.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/transactions.rs
@@ -6,9 +6,29 @@ fn explicit_transaction_seals_multiple_mutations_atomically() {
 
     let tx = alice
         .transaction()
-        .create_project("project-1", "Atomic project")
-        .create_todo("todo-1", "First todo", false, "project-1")
-        .create_todo("todo-2", "Second todo", false, "project-1")
+        .insert_row(
+            "projects",
+            "project-1",
+            BTreeMap::from([("title".to_owned(), json!("Atomic project"))]),
+        )
+        .insert_row(
+            "todos",
+            "todo-1",
+            BTreeMap::from([
+                ("title".to_owned(), json!("First todo")),
+                ("done".to_owned(), json!(false)),
+                ("project".to_owned(), json!("project-1")),
+            ]),
+        )
+        .insert_row(
+            "todos",
+            "todo-2",
+            BTreeMap::from([
+                ("title".to_owned(), json!("Second todo")),
+                ("done".to_owned(), json!(false)),
+                ("project".to_owned(), json!("project-1")),
+            ]),
+        )
         .commit()
         .unwrap();
 
@@ -27,9 +47,29 @@ fn rejecting_multi_row_transaction_hides_all_written_rows_but_keeps_history() {
 
     let tx = alice
         .transaction()
-        .create_project("project-1", "Atomic project")
-        .create_todo("todo-1", "First todo", false, "project-1")
-        .create_todo("todo-2", "Second todo", false, "project-1")
+        .insert_row(
+            "projects",
+            "project-1",
+            BTreeMap::from([("title".to_owned(), json!("Atomic project"))]),
+        )
+        .insert_row(
+            "todos",
+            "todo-1",
+            BTreeMap::from([
+                ("title".to_owned(), json!("First todo")),
+                ("done".to_owned(), json!(false)),
+                ("project".to_owned(), json!("project-1")),
+            ]),
+        )
+        .insert_row(
+            "todos",
+            "todo-2",
+            BTreeMap::from([
+                ("title".to_owned(), json!("Second todo")),
+                ("done".to_owned(), json!(false)),
+                ("project".to_owned(), json!("project-1")),
+            ]),
+        )
         .commit()
         .unwrap();
     assert_eq!(alice.open_todos().unwrap().len(), 2);


### PR DESCRIPTION
## What

Adds integration coverage for the newly documented mini SQLite policy invariants:

- ref-retarget updates validate access through the proposed parent ref
- policy-denied deletes restore the previous visible row and keep subscriptions stable
- multi-row transactions reject atomically when one policy check fails
- trusted/admin writes bypass user policy while preserving explicit authorship

Also updates the runtime paths these tests exercise so local write/delete/transaction policy checks reject consistently and repair projected state after denied deletes.

## Validation

- `cargo test -p mini-jazz-sqlite`
- pre-commit hook: clippy, oxfmt, rustfmt