### PR TITLE
Add trusted topology test harness

### DIFF
--- a/crates/mini-jazz-sqlite/SPEC.md
+++ b/crates/mini-jazz-sqlite/SPEC.md
@@ -187,15 +187,17 @@ Physical ids are not part of API or wire semantics.
 A node is a local writer identity such as a device, process, browser worker, or
 authority participant. One user may have many nodes. A tab may either be its own
 node or use a shared worker node, depending on topology. Node ids are durable
-writer identities; principals are authorization identities.
+writer identities; users are authorization identities.
 
-### 5.4 Principal And Session
+### 5.4 User And Session
 
-A principal is the actor the database believes is acting: user, admin, service
-actor, or trusted runtime peer.
+A user is the authorization identity the database believes is acting. The
+identity may represent a human user, a service user, or an admin user. A trusted
+runtime peer is not itself a user merely because it is trusted; it executes work
+under an explicit session user or under an admin session.
 
 A session is the execution context for a query, write, or sync connection. It
-carries principal, trust role, auth mode, policy context, and runtime context.
+carries user, trust role, auth mode, policy context, and runtime context.
 
 ### 5.5 Trust Role
 
@@ -402,7 +404,7 @@ The core:
 Later, an edge or global authority may add durability receipts or reject the
 transaction. The public transaction id does not change.
 
-## 7. Auth, Principals, Sessions, And Roles
+## 7. Auth, Users, Sessions, And Roles
 
 Every query, write, and incoming sync application is evaluated under a session.
 The session feeds policy evaluation, observed facts, sync delivery, validation,
@@ -411,30 +413,83 @@ write provenance, and error reporting.
 Policy evaluation should see the same session context whether work is evaluated
 in a local client, browser worker, edge server, or global authority.
 
-Hosted auth integrations authenticate sessions and produce principals according
+An untrusted client always has an associated user for each live connection
+to a trusted peer. The trusted peer authenticates that connection and evaluates
+client-originated queries, sync requests, and writes under the authenticated
+session. A client may reconnect with refreshed auth, but the user for a
+live session must remain stable.
+
+A trusted peer, such as an edge worker or global core, has a node identity and
+authority role but no ambient user. It offers operations that execute
+either:
+
+- as a specific authenticated user, for ordinary user/service queries,
+  writes, and forwarded sync validation
+- as admin/system, for operational work that bypasses row policy and is
+  attributed to a reserved system actor
+- as a privileged backend operation attributed to a specific user, for work
+  that intentionally bypasses row policy but should preserve user-facing
+  provenance
+
+Trusted-peer-to-trusted-peer sync must preserve the initiating session context
+where policy validation is still pending. It must not rely on the receiving
+peer's own node identity as a stand-in user.
+
+Policy authority and write attribution are distinct concepts:
+
+- **As user** evaluates reads and writes under that user's policies and records
+  normal provenance for that user.
+- **Admin/system** bypasses row policy and records provenance under a reserved
+  system actor, not under an ordinary user id such as `admin`.
+- **Attributing to user** bypasses row policy as a privileged backend operation
+  while recording `$createdBy`/`$updatedBy` as the named user.
+
+Current Jazz already has this product distinction: backend request/session APIs
+evaluate policy with a request session, backend/admin credentials provide
+privileged transport or catalogue authority, and attribution helpers stamp
+write provenance without switching policy evaluation to that user. The new core
+should model this directly instead of deriving both policy input and provenance
+from one string.
+
+Runtime APIs and in-memory data structures should preserve this distinction.
+Opening an ordinary client runtime requires a user. Opening a trusted peer
+requires only node/storage/schema identity and starts in an admin session. In
+the prototype runtime API, "user" is also the protocol/security term for
+recorded authorization identity. Trusted peers may then execute scoped work as
+an authenticated user, but that user is session state, not part of the peer
+identity. The term "principal" should only appear when describing external auth
+standards, such as mapping a JWT principal/subject claim onto a Jazz user id.
+This shape should be visible in tests and harnesses: topology constructors model
+clients separately from trusted peers, and helpers that execute as a user must
+only be valid for trusted peers.
+
+Hosted auth integrations authenticate sessions and produce users according
 to app configuration. For JWT-based auth, the app configuration chooses which
-claim becomes the Jazz principal id.
+claim becomes the Jazz user id.
 
-Local anonymous users may have durable local principals, but account-linking or
-migration from anonymous principals to hosted principals is not specified here.
+Local anonymous users may have durable local users, but account-linking or
+migration from anonymous users to hosted users is not specified here.
 
-Local-first auth is a product mode. A device may mint a durable local principal
+Local-first auth is a product mode. A device may mint a durable local user
 from a platform-generated secret without requiring login. For compatibility with
 current Jazz, the baseline local-first identity is a 32-byte CSPRNG secret used
-to derive an Ed25519 signing key, a self-signed Jazz JWT, and a stable principal
+to derive an Ed25519 signing key, a self-signed Jazz JWT, and a stable user
 id derived from the public key, for example UUIDv5 over the public-key bytes in
 a Jazz namespace. Exact token fields may evolve, but the durable invariant is
-that the same local secret reproduces the same principal and clearing local
+that the same local secret reproduces the same user and clearing local
 storage can lose account continuity.
 
 Auth mode is policy input. Policies may distinguish hosted/external,
 local-first, anonymous, backend, service, and admin sessions. A live client must
-not hot-swap principals: token refresh may update auth state only when the
-principal remains the same. Hybrid account upgrade should preserve identity by
-binding hosted auth to the existing local-first Jazz principal where possible.
+not hot-swap users: token refresh may update auth state only when the
+user remains the same. Hybrid account upgrade should preserve identity by
+binding hosted auth to the existing local-first Jazz user where possible.
 
-Admin sessions bypass row policy entirely. They are still represented as
-sessions for audit, provenance, catalogue checks, and operational controls.
+Admin/system and privileged attribution sessions bypass row policy entirely.
+They are still represented as sessions for audit, provenance, catalogue checks,
+and operational controls. The reserved system actor namespace must not collide
+with app user ids; the Rust spike currently uses `@system/admin` for the admin
+session's provenance.
 
 Untrusted clients cannot forge authority-only facts such as global acceptance,
 rejection, durability receipts, or catalogue publication.
@@ -445,11 +500,19 @@ transaction, downstream clients may treat that acceptance as authoritative for
 visibility in the edge trust topology; the original session authentication does
 not have to be replayed by every downstream client.
 
+When a trusted peer receives sync from an untrusted connection, policy
+validation uses the authenticated user attached to that connection, not
+`$createdBy`, `$updatedBy`, or any other provenance field carried in the bundle.
+Bundle provenance is public data and cannot authorize a write. If the receiving
+trusted peer does not know the authenticated user for a pending mergeable
+transaction, it must reject or await auth context rather than infer authority
+from history rows.
+
 Exclusive transactions are different: they require final fate from the global
 authority. If an edge or other intermediary forwards an exclusive transaction
 instead of deciding it locally, it must forward enough authenticated session
 context for the global authority to evaluate the transaction under the same
-principal, admin/trust role, and policy context as the initiating session.
+user, admin/trust role, and policy context as the initiating session.
 
 Non-admin sessions fail closed when required policy metadata is missing.
 
@@ -464,7 +527,8 @@ Open issues:
 - valid JWT/auth claim configuration
 - exact local-first JWT validation and TTL/skew rules
 - anonymous-to-hosted and local-first-to-hosted migration UX
-- whether service actors and admins share one principal namespace with users
+- exact reserved namespace for system actors and whether service accounts are
+  ordinary app users or system actors
 - which provenance fields are visible by default under policy
 
 ## 8. Product Surface Goals
@@ -1492,11 +1556,11 @@ This is a security invariant: old locally observed policy facts do not authorize
 an exclusive transaction if current authority policy no longer allows it.
 
 Stale read-set comparison, however, must use the same effective policy-filtered
-view as the writer principal whose transaction is being validated. Hidden rows
+view as the writer user whose transaction is being validated. Hidden rows
 must not make a row, absence, predicate, or range read look stale merely because
 they exist in authority storage. This avoids false conflicts and avoids leaking
 the existence of rows the writer could not see. The validation read context is
-therefore parameterized by writer principal, branch/source view, current
+therefore parameterized by writer user, branch/source view, current
 catalogue/policy, and current authority-trusted history.
 
 Validation checks:
@@ -2508,7 +2572,7 @@ Recommended harness shape:
 - mix in-memory SQLite nodes and durable SQLite-file nodes
 - model multiple in-memory browser-tab nodes connected to one durable
   worker/tab-broker node
-- assign each runtime a node id, principal/session, catalogue revision, and
+- assign each runtime a node id, user/session, catalogue revision, and
   optional upstream peer
 - support local, edge, and global roles
 - allow explicit message passing rather than hidden synchronous replication
@@ -2610,7 +2674,7 @@ High-value things to try next:
 - add a small `COUNT` aggregate primitive over versioned/lensed tables
 - build an account-aggregator-shaped example that stresses aggregation, joins,
   policies, schema versions, sync scope, and subscriptions
-- validate exclusive predicate/range read sets under writer-principal policy
+- validate exclusive predicate/range read sets under writer-user policy
   context
 - compare column-history with JSON/BLOB-history layouts
 - test SQLite VFS/page or range compression for deep histories, including
@@ -2678,8 +2742,8 @@ feature exists.
 - Rehydrating the same public id on one replica returns the same physical id.
 - Different replicas may assign different physical ids to the same public id.
 - Logical row ids are globally unique.
-- Node ids are writer identities, not authorization principals.
-- One principal may write from multiple nodes.
+- Node ids are writer identities, not authorization users.
+- One user may write from multiple nodes.
 - Public-id/physical-id and branch-id/ordinal mappings are crash-atomic; a
   public identity cannot hydrate to two local physical identities after restart.
 
@@ -2866,14 +2930,20 @@ feature exists.
 
 - Policy sees the same session context across local, worker, edge, and global
   evaluation.
-- Local-first auth can derive a stable principal from a durable local secret.
-- Auth refresh may update session state only when principal identity is
+- Local-first auth can derive a stable user from a durable local secret.
+- Auth refresh may update session state only when user identity is
   preserved.
 - Auth mode is available as policy input.
 - Non-admin sessions fail closed when policy metadata is missing.
+- Trusted-peer policy authority and write attribution are distinct: running
+  as a user enforces that user's policies, admin/system work bypasses policy
+  with system attribution, and privileged attribution bypasses policy while
+  recording the named user as provenance.
+- System actor provenance uses a reserved namespace that cannot collide with
+  ordinary app user ids.
 - Admin sessions bypass row policy but remain auditable sessions.
 - Trusted peers may read applied policy-scoped facts without an end-user
-  principal when acting as infrastructure.
+  user when acting as infrastructure.
 - Read policy affects query results and sync delivery.
 - Insert/update/delete policy affects transaction acceptance.
 - Delete may fall back to update semantics where explicit delete rules are not
@@ -2885,7 +2955,7 @@ feature exists.
 - Exclusive transactions are validated by global authority against
   authority-visible history and the authority's current trusted policy
   catalogue.
-- Exclusive stale-read validation uses the writer principal's current
+- Exclusive stale-read validation uses the writer user's current
   policy-filtered view; rows hidden from that writer do not invalidate row,
   absence, predicate, or range reads.
 - Recursive policies over acyclic ref chains are SQL-lowerable.
@@ -2896,7 +2966,7 @@ feature exists.
 - Historical snapshot policy evaluates referenced parents at the same snapshot
   epoch recursively, not through current projection.
 - Branch-local parent rows override base parents for branch policy checks.
-- `write_if_created_by_principal` allows self-authored inserts and preserves
+- `write_if_created_by_user` allows self-authored inserts and preserves
   original `created_by` on updates.
 - Updates and deletes record the previously visible row as a read dependency.
 - Partial updates preserve omitted fields when constructing the proposed row for
@@ -2940,7 +3010,7 @@ feature exists.
   projections polluted by proposals.
 - Authority validation uses current authority policy, not stale locally observed
   policy, for security.
-- Stale-read comparison is parameterized by the writer principal's
+- Stale-read comparison is parameterized by the writer user's
   policy-filtered read context so hidden rows do not cause false conflicts or
   leak existence.
 - Row reads still observe the same visible version at validation time.
@@ -3122,7 +3192,7 @@ Coverage labels:
 
 | Group                      | Current status        | Notes                                                                                                                                                                                                                                              |
 | -------------------------- | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| D.1 Identity               | covered for prototype | Public row ids, physical id locality, replica-local physical ids, and one principal writing from multiple nodes are tested.                                                                                                                        |
+| D.1 Identity               | covered for prototype | Public row ids, physical id locality, replica-local physical ids, and one user writing from multiple nodes are tested.                                                                                                                             |
 | D.2 Transactions           | partial               | Sealing, explicit transactions, edge/global receipts, rejection, idempotence, non-unique global epochs, and monotonic fate are tested. Awaiting-dependencies semantics and audit-grade receipt history are not.                                    |
 | D.3 History/projection     | partial               | Append-only ordinary deletes, rebuild, rejection repair, global ordering, remote pending constraints, and broad repair are tested. Hard delete/truncate and full merge/conflict projection semantics remain partial.                               |
 | D.4 Visibility/snapshots   | partial               | Global epoch and pinned branch snapshot behavior is tested. Full vector snapshots are not implemented/tested.                                                                                                                                      |
@@ -3241,7 +3311,7 @@ Coverage labels:
 
 - `policy_filters_reads_through_required_parent_ref`: D.6, D.9
 - `policy_scoped_sync_includes_required_parent_rows_only`: D.6, D.7, D.9
-- `trusted_peer_can_read_applied_policy_scoped_facts_without_user_principal`:
+- `trusted_peer_can_read_applied_policy_scoped_facts_without_user_user`:
   D.7, D.9
 - `trusted_peer_generic_transaction_bypasses_user_write_policy`: D.9
 - `trusted_edge_accepts_mergeable_tx_then_untrusted_peers_enforce_policy`:
@@ -3337,11 +3407,11 @@ them concrete:
 - recursive query-scope export must include deleted descendant subtrees
 - recursive write-policy read sets are transitive
 - historical and branch policy evaluation must use the correct read context
-- `write_if_created_by_principal` has distinct create and update ownership
+- `write_if_created_by_user` has distinct create and update ownership
   semantics
 - generic schema installation must not be defined by the todo fixture
 - trusted infrastructure peers may read applied policy-scoped facts without a
-  user principal
+  user user
 - transaction-info APIs must propagate receipts, global epochs, and rejection
   details consistently after sync
 

--- a/crates/mini-jazz-sqlite/src/policy.rs
+++ b/crates/mini-jazz-sqlite/src/policy.rs
@@ -13,13 +13,13 @@ pub(crate) struct WriteCheck<'a> {
     pub(crate) row_num: i64,
     pub(crate) branch_num: i64,
     pub(crate) values: &'a BTreeMap<String, JsonValue>,
-    pub(crate) principal: &'a str,
+    pub(crate) user: &'a str,
 }
 
 pub(crate) fn write_allowed(check: WriteCheck<'_>) -> Result<bool> {
     match &check.table.write_policy {
         PolicyDef::AllowAll => Ok(true),
-        PolicyDef::CreatedByPrincipal => {
+        PolicyDef::CreatedByUser => {
             let count: i64 = check.db.query_row(
                 &format!(
                     "SELECT COUNT(*)
@@ -29,7 +29,7 @@ pub(crate) fn write_allowed(check: WriteCheck<'_>) -> Result<bool> {
                        AND current.j_created_by = ?",
                     crate::schema::current_table(&check.table.name)
                 ),
-                params![check.row_num, check.branch_num, check.principal],
+                params![check.row_num, check.branch_num, check.user],
                 |row| row.get(0),
             )?;
             Ok(count > 0)
@@ -71,7 +71,7 @@ pub(crate) fn write_allowed(check: WriteCheck<'_>) -> Result<bool> {
                             check.schema,
                             ref_table,
                             ref_row_num,
-                            check.principal,
+                            check.user,
                             base_epoch,
                         );
                     }
@@ -82,7 +82,7 @@ pub(crate) fn write_allowed(check: WriteCheck<'_>) -> Result<bool> {
                 ref_table,
                 "current",
                 &ref_table.read_policy,
-                check.principal,
+                check.user,
                 Some(check.branch_num),
                 0,
             )?;
@@ -133,11 +133,10 @@ fn snapshot_write_ref_allowed(
     schema: &SchemaDef,
     ref_table: &TableDef,
     ref_row_num: i64,
-    principal: &str,
+    user: &str,
     base_epoch: i64,
 ) -> Result<bool> {
-    let policy_sql =
-        snapshot_read_policy_sql_for_alias(schema, ref_table, "h", principal, base_epoch)?;
+    let policy_sql = snapshot_read_policy_sql_for_alias(schema, ref_table, "h", user, base_epoch)?;
     let count: i64 = conn.query_row(
         &format!(
             "SELECT COUNT(*)
@@ -192,27 +191,15 @@ fn effective_branch_sql(alias: &str, table_name: &str, branch_num: i64) -> Strin
     )
 }
 
-pub(crate) fn read_policy_sql(
-    schema: &SchemaDef,
-    table: &TableDef,
-    principal: &str,
-) -> Result<String> {
-    lower_policy(
-        schema,
-        table,
-        "current",
-        &table.read_policy,
-        principal,
-        None,
-        0,
-    )
+pub(crate) fn read_policy_sql(schema: &SchemaDef, table: &TableDef, user: &str) -> Result<String> {
+    lower_policy(schema, table, "current", &table.read_policy, user, None, 0)
 }
 
 pub(crate) fn branch_read_policy_sql_for_alias(
     schema: &SchemaDef,
     table: &TableDef,
     alias: &str,
-    principal: &str,
+    user: &str,
     branch_num: i64,
 ) -> Result<String> {
     lower_policy(
@@ -220,7 +207,7 @@ pub(crate) fn branch_read_policy_sql_for_alias(
         table,
         alias,
         &table.read_policy,
-        principal,
+        user,
         Some(branch_num),
         0,
     )
@@ -230,7 +217,7 @@ pub(crate) fn snapshot_read_policy_sql_for_alias(
     schema: &SchemaDef,
     table: &TableDef,
     alias: &str,
-    principal: &str,
+    user: &str,
     base_epoch: i64,
 ) -> Result<String> {
     lower_snapshot_policy(
@@ -238,7 +225,7 @@ pub(crate) fn snapshot_read_policy_sql_for_alias(
         table,
         alias,
         &table.read_policy,
-        principal,
+        user,
         base_epoch,
         0,
     )
@@ -249,7 +236,7 @@ fn lower_policy(
     table: &TableDef,
     alias: &str,
     policy: &PolicyDef,
-    principal: &str,
+    user: &str,
     branch_num: Option<i64>,
     depth: usize,
 ) -> Result<String> {
@@ -258,9 +245,9 @@ fn lower_policy(
     }
     match policy {
         PolicyDef::AllowAll => Ok("1 = 1".to_owned()),
-        PolicyDef::CreatedByPrincipal => Ok(format!(
+        PolicyDef::CreatedByUser => Ok(format!(
             "{alias}.j_created_by = '{}'",
-            principal.replace('\'', "''")
+            user.replace('\'', "''")
         )),
         PolicyDef::RefReadable { field } => {
             let field = table
@@ -285,7 +272,7 @@ fn lower_policy(
                 ref_table,
                 &parent_alias,
                 &ref_table.read_policy,
-                principal,
+                user,
                 branch_num,
                 depth + 1,
             )?;
@@ -322,7 +309,7 @@ fn lower_snapshot_policy(
     table: &TableDef,
     alias: &str,
     policy: &PolicyDef,
-    principal: &str,
+    user: &str,
     base_epoch: i64,
     depth: usize,
 ) -> Result<String> {
@@ -333,9 +320,9 @@ fn lower_snapshot_policy(
     }
     match policy {
         PolicyDef::AllowAll => Ok("1 = 1".to_owned()),
-        PolicyDef::CreatedByPrincipal => Ok(format!(
+        PolicyDef::CreatedByUser => Ok(format!(
             "{alias}.j_created_by = '{}'",
-            principal.replace('\'', "''")
+            user.replace('\'', "''")
         )),
         PolicyDef::RefReadable { field } => {
             let field = table
@@ -362,7 +349,7 @@ fn lower_snapshot_policy(
                 ref_table,
                 &parent_alias,
                 &ref_table.read_policy,
-                principal,
+                user,
                 base_epoch,
                 depth + 1,
             )?;

--- a/crates/mini-jazz-sqlite/src/query.rs
+++ b/crates/mini-jazz-sqlite/src/query.rs
@@ -10,8 +10,8 @@ pub(crate) struct QueryContext<'a> {
     pub(crate) conn: &'a Connection,
     pub(crate) schema: &'a SchemaDef,
     pub(crate) branch_num: i64,
-    pub(crate) principal: &'a str,
-    pub(crate) trusted: bool,
+    pub(crate) user: &'a str,
+    pub(crate) bypass_policy: bool,
 }
 
 impl QueryContext<'_> {
@@ -316,7 +316,7 @@ impl QueryContext<'_> {
                 self.schema,
                 table,
                 "child",
-                self.principal,
+                self.user,
                 self.branch_num
             )?,
         );
@@ -384,14 +384,14 @@ impl QueryContext<'_> {
     }
 
     fn read_policy_sql(&self, table: &crate::schema::TableDef) -> Result<String> {
-        if self.trusted {
+        if self.bypass_policy {
             Ok("1 = 1".to_owned())
         } else {
             policy::branch_read_policy_sql_for_alias(
                 self.schema,
                 table,
                 "current",
-                self.principal,
+                self.user,
                 self.branch_num,
             )
         }
@@ -402,7 +402,7 @@ impl QueryContext<'_> {
         table_name: &str,
         rows: Vec<RowView>,
     ) -> Result<Vec<RowView>> {
-        if self.trusted {
+        if self.bypass_policy {
             return Ok(rows);
         }
         let table = self.schema.table_def(table_name)?;
@@ -442,13 +442,13 @@ impl QueryContext<'_> {
         row: &RowView,
         branch_num: i64,
     ) -> Result<bool> {
-        if self.trusted {
+        if self.bypass_policy {
             return Ok(true);
         }
         let table = self.schema.table_def(table_name)?;
         match &table.read_policy {
             PolicyDef::AllowAll => Ok(true),
-            PolicyDef::CreatedByPrincipal => Ok(row.created_by == self.principal),
+            PolicyDef::CreatedByUser => Ok(row.created_by == self.user),
             PolicyDef::RefReadable { field } => {
                 let field = table
                     .fields
@@ -884,14 +884,14 @@ impl QueryContext<'_> {
 
     fn read_main_snapshot_rows(&self, table_name: &str, base_epoch: i64) -> Result<Vec<RowView>> {
         let table = self.schema.table_def(table_name)?;
-        let policy_sql = if self.trusted {
+        let policy_sql = if self.bypass_policy {
             "1 = 1".to_owned()
         } else {
             policy::snapshot_read_policy_sql_for_alias(
                 self.schema,
                 table,
                 "h",
-                self.principal,
+                self.user,
                 base_epoch,
             )?
         };

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -19,24 +19,46 @@ pub struct Runtime {
     conn: Connection,
     schema: SchemaDef,
     node_id: String,
-    principal: String,
+    auth: RuntimeAuth,
     node_num: i64,
     branch_num: i64,
-    trusted: bool,
+}
+
+pub const ADMIN_SYSTEM_USER: &str = "@system/admin";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RuntimeAuth {
+    Client(User),
+    TrustedPeer { session: TrustedSession },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct User(pub String);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TrustedSession {
+    Admin,
+    AsUser(User),
+    AttributingToUser(User),
 }
 
 impl Runtime {
-    pub fn open(storage: Storage, node_id: &str, principal: &str) -> Result<Self> {
-        Self::open_with_schema(storage, node_id, principal, SchemaDef::attempt3_fixture())
+    pub fn open(storage: Storage, node_id: &str, user: &str) -> Result<Self> {
+        Self::open_with_schema(storage, node_id, user, SchemaDef::attempt3_fixture())
     }
 
     pub fn open_with_schema(
         storage: Storage,
         node_id: &str,
-        principal: &str,
+        user: &str,
         schema_def: SchemaDef,
     ) -> Result<Self> {
-        Self::open_with_schema_and_trust(storage, node_id, principal, schema_def, false)
+        Self::open_with_schema_and_auth(
+            storage,
+            node_id,
+            RuntimeAuth::Client(User(user.to_owned())),
+            schema_def,
+        )
     }
 
     pub fn open_trusted_with_schema(
@@ -44,24 +66,53 @@ impl Runtime {
         node_id: &str,
         schema_def: SchemaDef,
     ) -> Result<Self> {
-        Self::open_with_schema_and_trust(storage, node_id, "trusted", schema_def, true)
+        Self::open_with_schema_and_auth(
+            storage,
+            node_id,
+            RuntimeAuth::TrustedPeer {
+                session: TrustedSession::Admin,
+            },
+            schema_def,
+        )
     }
 
-    pub fn open_trusted_as_with_schema(
+    pub fn open_trusted_with_session_user(
         storage: Storage,
         node_id: &str,
-        principal: &str,
+        user: &str,
         schema_def: SchemaDef,
     ) -> Result<Self> {
-        Self::open_with_schema_and_trust(storage, node_id, principal, schema_def, true)
+        Self::open_with_schema_and_auth(
+            storage,
+            node_id,
+            RuntimeAuth::TrustedPeer {
+                session: TrustedSession::AsUser(User(user.to_owned())),
+            },
+            schema_def,
+        )
     }
 
-    fn open_with_schema_and_trust(
+    pub fn open_trusted_attributing_to_user(
         storage: Storage,
         node_id: &str,
-        principal: &str,
+        user: &str,
         schema_def: SchemaDef,
-        trusted: bool,
+    ) -> Result<Self> {
+        Self::open_with_schema_and_auth(
+            storage,
+            node_id,
+            RuntimeAuth::TrustedPeer {
+                session: TrustedSession::AttributingToUser(User(user.to_owned())),
+            },
+            schema_def,
+        )
+    }
+
+    fn open_with_schema_and_auth(
+        storage: Storage,
+        node_id: &str,
+        auth: RuntimeAuth,
+        schema_def: SchemaDef,
     ) -> Result<Self> {
         let conn = storage::open(storage)?;
         schema::install(&conn, &schema_def)?;
@@ -70,11 +121,87 @@ impl Runtime {
             conn,
             schema: schema_def,
             node_id: node_id.to_owned(),
-            principal: principal.to_owned(),
+            auth,
             node_num,
             branch_num: 1,
-            trusted,
         })
+    }
+
+    pub fn is_trusted(&self) -> bool {
+        matches!(self.auth, RuntimeAuth::TrustedPeer { .. })
+    }
+
+    pub fn session_user(&self) -> &str {
+        self.policy_user()
+    }
+
+    fn policy_user(&self) -> &str {
+        match &self.auth {
+            RuntimeAuth::Client(User(user)) => user,
+            RuntimeAuth::TrustedPeer {
+                session: TrustedSession::AsUser(User(user)),
+            } => user,
+            RuntimeAuth::TrustedPeer {
+                session: TrustedSession::AttributingToUser(User(user)),
+            } => user,
+            RuntimeAuth::TrustedPeer {
+                session: TrustedSession::Admin,
+            } => ADMIN_SYSTEM_USER,
+        }
+    }
+
+    fn attribution_user(&self) -> &str {
+        match &self.auth {
+            RuntimeAuth::Client(User(user)) => user,
+            RuntimeAuth::TrustedPeer {
+                session:
+                    TrustedSession::AsUser(User(user)) | TrustedSession::AttributingToUser(User(user)),
+            } => user,
+            RuntimeAuth::TrustedPeer {
+                session: TrustedSession::Admin,
+            } => ADMIN_SYSTEM_USER,
+        }
+    }
+
+    fn bypasses_policy(&self) -> bool {
+        matches!(
+            &self.auth,
+            RuntimeAuth::TrustedPeer {
+                session: TrustedSession::Admin | TrustedSession::AttributingToUser(_)
+            }
+        )
+    }
+
+    pub fn run_as_user<T>(&mut self, user: &str, f: impl FnOnce(&mut Runtime) -> T) -> T {
+        assert!(
+            self.is_trusted(),
+            "run_as_user is only valid for trusted peers"
+        );
+        let previous = self.auth.clone();
+        self.auth = RuntimeAuth::TrustedPeer {
+            session: TrustedSession::AsUser(User(user.to_owned())),
+        };
+        let result = f(self);
+        self.auth = previous;
+        result
+    }
+
+    pub fn run_attributing_to_user<T>(
+        &mut self,
+        user: &str,
+        f: impl FnOnce(&mut Runtime) -> T,
+    ) -> T {
+        assert!(
+            self.is_trusted(),
+            "run_attributing_to_user is only valid for trusted peers"
+        );
+        let previous = self.auth.clone();
+        self.auth = RuntimeAuth::TrustedPeer {
+            session: TrustedSession::AttributingToUser(User(user.to_owned())),
+        };
+        let result = f(self);
+        self.auth = previous;
+        result
     }
 
     pub fn insert_row(
@@ -118,6 +245,8 @@ impl Runtime {
         op: i64,
     ) -> Result<String> {
         let table = self.schema.table_def(table_name)?.clone();
+        let user = self.attribution_user().to_owned();
+        let bypass_policy = self.bypasses_policy();
         let db = self.conn.transaction()?;
         let now = now_ms();
         let (tx_num, tx_id) = tx::create_tx(&db, self.node_num, &self.node_id, now)?;
@@ -130,8 +259,8 @@ impl Runtime {
             tx_num,
             branch_num: self.branch_num,
             now,
-            principal: &self.principal,
-            trusted: self.trusted,
+            user: &user,
+            bypass_policy,
             op,
         })?;
         let row_num = row_num(&db, id)?;
@@ -170,13 +299,15 @@ impl Runtime {
 
     pub fn export_table_history(&self, table_name: &str) -> Result<Bundle> {
         self.schema.table_def(table_name)?;
+        let user = self.policy_user();
+        let bypass_policy = self.bypasses_policy();
         let txs = export_txs(&self.conn)?;
         let history = export_table_history(
             &self.conn,
             &self.schema,
             table_name,
-            &self.principal,
-            self.trusted,
+            user,
+            bypass_policy,
             self.branch_num,
         )?;
         let reads = export_reads_for_history(&self.conn, &history)?;
@@ -196,7 +327,7 @@ impl Runtime {
         &self,
         table_name: &str,
         tx_id: &str,
-        auth_principal: &str,
+        auth_user: &str,
     ) -> Result<Bundle> {
         let mut bundle = self.export_table_history(table_name)?;
         let tx_record = bundle
@@ -213,7 +344,7 @@ impl Runtime {
         tx_record.outcome = tx::OUTCOME_PENDING;
         tx_record.global_epoch = None;
         tx_record.receipt_tiers.clear();
-        tx_record.auth_principal = Some(auth_principal.to_owned());
+        tx_record.auth_user = Some(auth_user.to_owned());
         Ok(bundle)
     }
 
@@ -224,6 +355,8 @@ impl Runtime {
         parent_field: &str,
     ) -> Result<Bundle> {
         self.schema.table_def(table_name)?;
+        let user = self.policy_user();
+        let bypass_policy = self.bypasses_policy();
         let rows = self.read_recursive_refs(table_name, root_id, parent_field)?;
         let row_nums = rows
             .iter()
@@ -235,8 +368,8 @@ impl Runtime {
             &self.conn,
             &self.schema,
             table_name,
-            &self.principal,
-            self.trusted,
+            user,
+            bypass_policy,
             &branch_nums,
             Some(&row_nums),
         )?;
@@ -262,8 +395,8 @@ impl Runtime {
             PolicyDependencyExport {
                 table_name,
                 policy: &self.schema.table_def(table_name)?.read_policy,
-                principal: &self.principal,
-                trusted: self.trusted,
+                user,
+                bypass_policy,
                 branch_nums: &branch_nums,
                 child_row_nums: Some(&row_nums),
             },
@@ -281,8 +414,8 @@ impl Runtime {
                     &self.conn,
                     &self.schema,
                     table_name,
-                    &self.principal,
-                    self.trusted,
+                    user,
+                    bypass_policy,
                     base_epoch,
                     Some(&row_nums),
                 )?);
@@ -364,7 +497,7 @@ impl Runtime {
         }
         for tx_record in &bundle.txs {
             let node_num = tx::ensure_node(&db, &tx_record.node_id)?;
-            let metadata_json = tx_metadata_json(tx_record.auth_principal.as_deref())?;
+            let metadata_json = tx_metadata_json(tx_record.auth_user.as_deref())?;
             db.execute(
                 "INSERT INTO jazz_tx
                  (tx_id, node_num, local_epoch, global_epoch, kind, conflict_mode, outcome, created_at, metadata_json)
@@ -634,16 +767,28 @@ impl Runtime {
     }
 
     pub fn apply_untrusted_bundle(&mut self, bundle: &Bundle) -> Result<()> {
+        self.apply_untrusted_bundle_with_auth_user(bundle, None)
+    }
+
+    pub fn apply_untrusted_bundle_as_user(&mut self, bundle: &Bundle, user: &str) -> Result<()> {
+        self.apply_untrusted_bundle_with_auth_user(bundle, Some(user))
+    }
+
+    fn apply_untrusted_bundle_with_auth_user(
+        &mut self,
+        bundle: &Bundle,
+        bundle_auth_user: Option<&str>,
+    ) -> Result<()> {
         let stale_exclusive_tx_ids =
             read_set::stale_exclusive_tx_ids_in_bundle(&self.conn, bundle)?;
-        let forwarded_auth_principals = bundle
+        let forwarded_auth_users = bundle
             .txs
             .iter()
             .filter(|tx| tx.conflict_mode == tx::MODE_EXCLUSIVE)
             .filter_map(|tx| {
-                tx.auth_principal
+                tx.auth_user
                     .as_deref()
-                    .map(|principal| (tx.tx_id.as_str(), principal))
+                    .map(|user| (tx.tx_id.as_str(), user))
             })
             .collect::<BTreeMap<_, _>>();
         self.apply_bundle_inner(bundle, false)?;
@@ -666,30 +811,56 @@ impl Runtime {
             if tx_outcome(&self.conn, tx_num)? != tx::OUTCOME_PENDING {
                 continue;
             }
-            if tx_conflict_mode(&self.conn, tx_num)? == tx::MODE_EXCLUSIVE
-                && read_set::tx_read_set_is_stale(&self.conn, tx_num, &record.branch_id)?
-            {
+            let conflict_mode = tx_conflict_mode(&self.conn, tx_num)?;
+            if conflict_mode == tx::MODE_EXCLUSIVE {
+                if !forwarded_auth_users.contains_key(record.tx_id.as_str()) {
+                    self.reject_transaction_with_detail(
+                        &record.tx_id,
+                        "policy_denied",
+                        json!({
+                            "reason": "missing_auth_user",
+                        }),
+                    )?;
+                    rejected.insert(record.tx_id.clone());
+                    continue;
+                }
+                if read_set::tx_read_set_is_stale(&self.conn, tx_num, &record.branch_id)? {
+                    self.reject_transaction_with_detail(
+                        &record.tx_id,
+                        "stale_read_set",
+                        json!({
+                            "reason": "exclusive_read_dependency_changed",
+                        }),
+                    )?;
+                    rejected.insert(record.tx_id.clone());
+                    continue;
+                }
+            }
+            let table = self.schema.table_def(&record.table)?;
+            let row_num = ensure_row_id(&self.conn, &record.table, &record.row_id)?;
+            let auth_user = if conflict_mode == tx::MODE_EXCLUSIVE {
+                forwarded_auth_users.get(record.tx_id.as_str()).copied()
+            } else {
+                bundle_auth_user
+            };
+            if auth_user.is_none() {
                 self.reject_transaction_with_detail(
                     &record.tx_id,
-                    "stale_read_set",
+                    "policy_denied",
                     json!({
-                        "reason": "exclusive_read_dependency_changed",
+                        "reason": "missing_auth_user",
                     }),
                 )?;
                 rejected.insert(record.tx_id.clone());
                 continue;
             }
-            let table = self.schema.table_def(&record.table)?;
-            let row_num = ensure_row_id(&self.conn, &record.table, &record.row_id)?;
             let allowed = write_allowed_for_history_record(
                 &self.conn,
                 &self.schema,
                 table,
                 row_num,
                 record,
-                forwarded_auth_principals
-                    .get(record.tx_id.as_str())
-                    .copied(),
+                auth_user,
             )?;
             if !allowed {
                 let detail =
@@ -1431,8 +1602,13 @@ impl Runtime {
         Ok(branches)
     }
 
-    pub fn principal_for_test(&mut self, principal: &str) {
-        self.principal = principal.to_owned();
+    pub fn session_user_for_test(&mut self, user: &str) {
+        match &mut self.auth {
+            RuntimeAuth::Client(User(current)) => *current = user.to_owned(),
+            RuntimeAuth::TrustedPeer { session } => {
+                *session = TrustedSession::AsUser(User(user.to_owned()));
+            }
+        }
     }
 
     pub fn transaction(&mut self) -> TransactionBuilder<'_> {
@@ -1450,6 +1626,8 @@ impl Runtime {
             .into_iter()
             .find(|row| row.id == id)
             .ok_or_else(|| crate::Error::new(format!("row {id} is not visible")))?;
+        let user = self.attribution_user().to_owned();
+        let bypass_policy = self.bypasses_policy();
         let db = self.conn.transaction()?;
         let now = now_ms();
         let (tx_num, tx_id) = tx::create_tx(&db, self.node_num, &self.node_id, now)?;
@@ -1463,7 +1641,7 @@ impl Runtime {
             self.branch_num,
             tx_num,
         )?;
-        let allowed = self.trusted
+        let allowed = bypass_policy
             || local_write_allowed(LocalWriteCheck {
                 db: &db,
                 schema: &self.schema,
@@ -1471,7 +1649,7 @@ impl Runtime {
                 row_num,
                 branch_num: self.branch_num,
                 values: &visible_row.values,
-                principal: &self.principal,
+                user: &user,
                 op: 3,
             })?;
 
@@ -1517,7 +1695,7 @@ impl Runtime {
                 select_columns.join(", "),
                 crate::schema::current_table(&table.name),
             ),
-            params![tx_num, now, self.principal, row_num, self.branch_num],
+            params![tx_num, now, user, row_num, self.branch_num],
         )?;
         if inserted == 0 {
             let mut values = vec![
@@ -1540,8 +1718,8 @@ impl Runtime {
             values.extend([
                 rusqlite::types::Value::Integer(now),
                 rusqlite::types::Value::Integer(now),
-                rusqlite::types::Value::Text(self.principal.clone()),
-                rusqlite::types::Value::Text(self.principal.clone()),
+                rusqlite::types::Value::Text(user.to_owned()),
+                rusqlite::types::Value::Text(user.to_owned()),
             ]);
             insert_dynamic(
                 &db,
@@ -1591,8 +1769,8 @@ impl Runtime {
             current_values.extend([
                 rusqlite::types::Value::Integer(now),
                 rusqlite::types::Value::Integer(now),
-                rusqlite::types::Value::Text(self.principal.clone()),
-                rusqlite::types::Value::Text(self.principal.clone()),
+                rusqlite::types::Value::Text(user.to_owned()),
+                rusqlite::types::Value::Text(user.to_owned()),
             ]);
             insert_dynamic(
                 &db,
@@ -1891,6 +2069,8 @@ impl Runtime {
         ref_include_fields: &[&str],
     ) -> Result<Bundle> {
         let table = self.schema.table_def(table_name)?;
+        let user = self.policy_user();
+        let bypass_policy = self.bypasses_policy();
         let mut row_nums = rows
             .iter()
             .map(|row| row_num(&self.conn, &row.id))
@@ -1906,8 +2086,8 @@ impl Runtime {
             &self.conn,
             &self.schema,
             table_name,
-            &self.principal,
-            self.trusted,
+            user,
+            bypass_policy,
             &branch_nums,
             Some(&row_nums),
         )?;
@@ -1924,8 +2104,8 @@ impl Runtime {
             PolicyDependencyExport {
                 table_name,
                 policy: &self.schema.table_def(table_name)?.read_policy,
-                principal: &self.principal,
-                trusted: self.trusted,
+                user,
+                bypass_policy,
                 branch_nums: &branch_nums,
                 child_row_nums: Some(&row_nums),
             },
@@ -1951,8 +2131,8 @@ impl Runtime {
                     &self.conn,
                     &self.schema,
                     table_name,
-                    &self.principal,
-                    self.trusted,
+                    user,
+                    bypass_policy,
                     base_epoch,
                     Some(&row_nums),
                 )?);
@@ -1986,6 +2166,8 @@ impl Runtime {
         ref_field_name: &str,
         branch_nums: &[i64],
     ) -> Result<Vec<HistoryRecord>> {
+        let user = self.policy_user();
+        let bypass_policy = self.bypasses_policy();
         let field = table
             .fields
             .iter()
@@ -2014,8 +2196,8 @@ impl Runtime {
             &self.conn,
             &self.schema,
             ref_table_name,
-            &self.principal,
-            self.trusted,
+            user,
+            bypass_policy,
             branch_nums,
             Some(&ref_row_nums),
         )?;
@@ -2032,8 +2214,8 @@ impl Runtime {
             PolicyDependencyExport {
                 table_name: ref_table_name,
                 policy: &self.schema.table_def(ref_table_name)?.read_policy,
-                principal: &self.principal,
-                trusted: self.trusted,
+                user,
+                bypass_policy,
                 branch_nums,
                 child_row_nums: Some(&ref_row_nums),
             },
@@ -2360,8 +2542,8 @@ impl Runtime {
             conn: &self.conn,
             schema: &self.schema,
             branch_num: self.branch_num,
-            principal: &self.principal,
-            trusted: self.trusted,
+            user: self.policy_user(),
+            bypass_policy: self.bypasses_policy(),
         }
     }
 }
@@ -2375,8 +2557,8 @@ struct InsertRowInTx<'a> {
     tx_num: i64,
     branch_num: i64,
     now: i64,
-    principal: &'a str,
-    trusted: bool,
+    user: &'a str,
+    bypass_policy: bool,
     op: i64,
 }
 
@@ -2457,7 +2639,7 @@ fn insert_row_in_tx(args: InsertRowInTx<'_>) -> Result<bool> {
         args.branch_num,
         args.tx_num,
     )?;
-    let allowed = args.trusted
+    let allowed = args.bypass_policy
         || local_write_allowed(LocalWriteCheck {
             db: args.db,
             schema: args.schema,
@@ -2465,7 +2647,7 @@ fn insert_row_in_tx(args: InsertRowInTx<'_>) -> Result<bool> {
             row_num,
             branch_num: args.branch_num,
             values: &effective_values,
-            principal: args.principal,
+            user: args.user,
             op: args.op,
         })?;
 
@@ -2502,16 +2684,16 @@ fn insert_row_in_tx(args: InsertRowInTx<'_>) -> Result<bool> {
         "j_updated_by".to_owned(),
     ]);
     let (created_at, created_by) = if args.op == 1 {
-        (args.now, args.principal.to_owned())
+        (args.now, args.user.to_owned())
     } else {
         current_creation_metadata(args.db, &table.name, row_num, args.branch_num)?
-            .unwrap_or((args.now, args.principal.to_owned()))
+            .unwrap_or((args.now, args.user.to_owned()))
     };
     sql_values.extend([
         rusqlite::types::Value::Integer(created_at),
         rusqlite::types::Value::Integer(args.now),
         rusqlite::types::Value::Text(created_by),
-        rusqlite::types::Value::Text(args.principal.to_owned()),
+        rusqlite::types::Value::Text(args.user.to_owned()),
     ]);
     insert_dynamic(
         args.db,
@@ -2573,12 +2755,12 @@ struct LocalWriteCheck<'a> {
     row_num: i64,
     branch_num: i64,
     values: &'a BTreeMap<String, JsonValue>,
-    principal: &'a str,
+    user: &'a str,
     op: i64,
 }
 
 fn local_write_allowed(check: LocalWriteCheck<'_>) -> Result<bool> {
-    if check.op == 1 && matches!(check.table.write_policy, PolicyDef::CreatedByPrincipal) {
+    if check.op == 1 && matches!(check.table.write_policy, PolicyDef::CreatedByUser) {
         return Ok(true);
     }
     policy::write_allowed(policy::WriteCheck {
@@ -2588,7 +2770,7 @@ fn local_write_allowed(check: LocalWriteCheck<'_>) -> Result<bool> {
         row_num: check.row_num,
         branch_num: check.branch_num,
         values: check.values,
-        principal: check.principal,
+        user: check.user,
     })
 }
 
@@ -3065,6 +3247,8 @@ impl<'a> TransactionBuilder<'a> {
 
     pub fn commit(self) -> Result<String> {
         let mutations = self.mutations;
+        let user = self.runtime.attribution_user().to_owned();
+        let bypass_policy = self.runtime.bypasses_policy();
         let mut delete_snapshots = BTreeMap::new();
         for mutation in &mutations {
             let Mutation::DeleteRow { table, id } = mutation else {
@@ -3131,8 +3315,8 @@ impl<'a> TransactionBuilder<'a> {
                         tx_num,
                         branch_num: self.runtime.branch_num,
                         now,
-                        principal: &self.runtime.principal,
-                        trusted: self.runtime.trusted,
+                        user: &user,
+                        bypass_policy,
                         op,
                     })?;
                 }
@@ -3161,7 +3345,7 @@ impl<'a> TransactionBuilder<'a> {
                         self.runtime.branch_num,
                         tx_num,
                     )?;
-                    allowed &= self.runtime.trusted
+                    allowed &= bypass_policy
                         || local_write_allowed(LocalWriteCheck {
                             db: &db,
                             schema: &self.runtime.schema,
@@ -3169,7 +3353,7 @@ impl<'a> TransactionBuilder<'a> {
                             row_num,
                             branch_num: self.runtime.branch_num,
                             values: &visible_row.values,
-                            principal: &self.runtime.principal,
+                            user: &user,
                             op: 3,
                         })?;
                     let field_columns = table_def
@@ -3216,13 +3400,7 @@ impl<'a> TransactionBuilder<'a> {
                             select_columns.join(", "),
                             crate::schema::current_table(&table),
                         ),
-                        params![
-                            tx_num,
-                            now,
-                            self.runtime.principal,
-                            row_num,
-                            self.runtime.branch_num
-                        ],
+                        params![tx_num, now, user, row_num, self.runtime.branch_num],
                     )?;
                     if inserted == 0 {
                         let mut values = vec![
@@ -3244,8 +3422,8 @@ impl<'a> TransactionBuilder<'a> {
                         values.extend([
                             rusqlite::types::Value::Integer(now),
                             rusqlite::types::Value::Integer(now),
-                            rusqlite::types::Value::Text(self.runtime.principal.clone()),
-                            rusqlite::types::Value::Text(self.runtime.principal.clone()),
+                            rusqlite::types::Value::Text(user.to_owned()),
+                            rusqlite::types::Value::Text(user.to_owned()),
                         ]);
                         insert_dynamic(
                             &db,
@@ -3294,8 +3472,8 @@ impl<'a> TransactionBuilder<'a> {
                         current_values.extend([
                             rusqlite::types::Value::Integer(now),
                             rusqlite::types::Value::Integer(now),
-                            rusqlite::types::Value::Text(self.runtime.principal.clone()),
-                            rusqlite::types::Value::Text(self.runtime.principal.clone()),
+                            rusqlite::types::Value::Text(user.to_owned()),
+                            rusqlite::types::Value::Text(user.to_owned()),
                         ]);
                         insert_dynamic(
                             &db,
@@ -3376,17 +3554,13 @@ fn write_allowed_for_history_record(
     table: &crate::schema::TableDef,
     row_num: i64,
     record: &HistoryRecord,
-    forwarded_auth_principal: Option<&str>,
+    auth_user: Option<&str>,
 ) -> Result<bool> {
-    let record_principal = if record.op == 1 {
-        &record.created_by
-    } else {
-        &record.updated_by
-    };
-    let principal = forwarded_auth_principal.unwrap_or(record_principal);
+    let user = auth_user
+        .ok_or_else(|| crate::Error::new("untrusted policy validation requires auth user"))?;
     let branch_num = branch::ensure(conn, &record.branch_id, None, now_ms())?;
-    if record.op == 3 && matches!(table.write_policy, PolicyDef::CreatedByPrincipal) {
-        return Ok(record.created_by == principal);
+    if record.op == 3 && matches!(table.write_policy, PolicyDef::CreatedByUser) {
+        return Ok(record.created_by == user);
     }
     policy::write_allowed(policy::WriteCheck {
         db: conn,
@@ -3395,7 +3569,7 @@ fn write_allowed_for_history_record(
         row_num,
         branch_num,
         values: &record.values,
-        principal,
+        user,
     })
 }
 
@@ -3458,7 +3632,7 @@ fn export_txs(conn: &Connection) -> Result<Vec<TxRecord>> {
             global_epoch: row.get(3)?,
             conflict_mode: row.get(4)?,
             outcome: row.get(5)?,
-            auth_principal: parse_tx_auth_principal_for_sqlite(&row.get::<_, String>(9)?, 9)?,
+            auth_user: parse_tx_auth_user_for_sqlite(&row.get::<_, String>(9)?, 9)?,
             rejection_code: row.get(6)?,
             rejection_detail: row
                 .get::<_, Option<String>>(7)?
@@ -3484,15 +3658,15 @@ fn parse_rejection_detail(detail_json: &str) -> Result<Option<JsonValue>> {
     }
 }
 
-fn tx_metadata_json(auth_principal: Option<&str>) -> Result<String> {
-    let metadata = match auth_principal {
-        Some(principal) => json!({ "auth_principal": principal }),
+fn tx_metadata_json(auth_user: Option<&str>) -> Result<String> {
+    let metadata = match auth_user {
+        Some(user) => json!({ "auth_user": user }),
         None => json!({}),
     };
     serde_json::to_string(&metadata).map_err(|err| crate::Error::new(err.to_string()))
 }
 
-fn parse_tx_auth_principal_for_sqlite(
+fn parse_tx_auth_user_for_sqlite(
     metadata_json: &str,
     column: usize,
 ) -> rusqlite::Result<Option<String>> {
@@ -3504,7 +3678,7 @@ fn parse_tx_auth_principal_for_sqlite(
         )
     })?;
     Ok(metadata
-        .get("auth_principal")
+        .get("auth_user")
         .and_then(JsonValue::as_str)
         .map(str::to_owned))
 }
@@ -3689,8 +3863,8 @@ fn export_table_history(
     conn: &Connection,
     schema: &SchemaDef,
     table_name: &str,
-    principal: &str,
-    trusted: bool,
+    user: &str,
+    bypass_policy: bool,
     branch_num: i64,
 ) -> Result<Vec<HistoryRecord>> {
     let branch_nums = branch::scope_nums(conn, branch_num)?;
@@ -3698,8 +3872,8 @@ fn export_table_history(
         conn,
         schema,
         table_name,
-        principal,
-        trusted,
+        user,
+        bypass_policy,
         &branch_nums,
         None,
     )?;
@@ -3715,8 +3889,8 @@ fn export_table_history(
         PolicyDependencyExport {
             table_name,
             policy: &schema.table_def(table_name)?.read_policy,
-            principal,
-            trusted,
+            user,
+            bypass_policy,
             branch_nums: &branch_nums,
             child_row_nums: None,
         },
@@ -3727,8 +3901,8 @@ fn export_table_history(
         PolicyDependencyExport {
             table_name,
             policy: &schema.table_def(table_name)?.write_policy,
-            principal,
-            trusted,
+            user,
+            bypass_policy,
             branch_nums: &branch_nums,
             child_row_nums: None,
         },
@@ -3736,7 +3910,12 @@ fn export_table_history(
     if branch_num != 1 {
         if let Some(base_epoch) = branch::base_global_epoch(conn, branch_num)? {
             records.extend(export_main_base_snapshot_history(
-                conn, schema, table_name, base_epoch, principal, trusted,
+                conn,
+                schema,
+                table_name,
+                base_epoch,
+                user,
+                bypass_policy,
             )?);
         }
     }
@@ -3748,14 +3927,14 @@ fn export_main_base_snapshot_history(
     schema: &SchemaDef,
     table_name: &str,
     base_epoch: i64,
-    principal: &str,
-    trusted: bool,
+    user: &str,
+    bypass_policy: bool,
 ) -> Result<Vec<HistoryRecord>> {
     let table = schema.table_def(table_name)?;
-    let policy_sql = if trusted {
+    let policy_sql = if bypass_policy {
         "1 = 1".to_owned()
     } else {
-        policy::snapshot_read_policy_sql_for_alias(schema, table, "h", principal, base_epoch)?
+        policy::snapshot_read_policy_sql_for_alias(schema, table, "h", user, base_epoch)?
     };
     let sql = format!(
         "SELECT h.row_num
@@ -3804,8 +3983,8 @@ fn export_main_base_snapshot_history(
         conn,
         schema,
         table_name,
-        principal,
-        trusted,
+        user,
+        bypass_policy,
         base_epoch,
         Some(&row_nums),
     )?);
@@ -3816,8 +3995,8 @@ fn export_snapshot_policy_dependency_history(
     conn: &Connection,
     schema: &SchemaDef,
     table_name: &str,
-    principal: &str,
-    trusted: bool,
+    user: &str,
+    bypass_policy: bool,
     base_epoch: i64,
     child_row_nums: Option<&[i64]>,
 ) -> Result<Vec<HistoryRecord>> {
@@ -3839,10 +4018,10 @@ fn export_snapshot_policy_dependency_history(
             field.name
         )));
     };
-    let policy_sql = if trusted {
+    let policy_sql = if bypass_policy {
         "1 = 1".to_owned()
     } else {
-        policy::snapshot_read_policy_sql_for_alias(schema, table, "h", principal, base_epoch)?
+        policy::snapshot_read_policy_sql_for_alias(schema, table, "h", user, base_epoch)?
     };
     let ref_column = crate::schema::quote_ident(&crate::schema::storage_column(field));
     let sql = format!(
@@ -3888,8 +4067,8 @@ fn export_snapshot_policy_dependency_history(
         conn,
         schema,
         parent_table,
-        principal,
-        trusted,
+        user,
+        bypass_policy,
         base_epoch,
         Some(&row_nums),
     )?);
@@ -3899,8 +4078,8 @@ fn export_snapshot_policy_dependency_history(
 struct PolicyDependencyExport<'a> {
     table_name: &'a str,
     policy: &'a PolicyDef,
-    principal: &'a str,
-    trusted: bool,
+    user: &'a str,
+    bypass_policy: bool,
     branch_nums: &'a [i64],
     child_row_nums: Option<&'a [i64]>,
 }
@@ -3928,7 +4107,7 @@ fn export_policy_dependency_history(
             field.name
         )));
     };
-    let policy_sql = export_read_policy_sql(schema, table, args.principal, args.trusted)?;
+    let policy_sql = export_read_policy_sql(schema, table, args.user, args.bypass_policy)?;
     let ref_column = crate::schema::quote_ident(&crate::schema::storage_column(field));
     let sql = format!(
         "SELECT DISTINCT current.{ref_column}
@@ -3952,8 +4131,8 @@ fn export_policy_dependency_history(
         conn,
         schema,
         parent_table,
-        args.principal,
-        args.trusted,
+        args.user,
+        args.bypass_policy,
         args.branch_nums,
         Some(&row_nums),
     )?;
@@ -3963,8 +4142,8 @@ fn export_policy_dependency_history(
         PolicyDependencyExport {
             table_name: parent_table,
             policy: &schema.table_def(parent_table)?.read_policy,
-            principal: args.principal,
-            trusted: args.trusted,
+            user: args.user,
+            bypass_policy: args.bypass_policy,
             branch_nums: args.branch_nums,
             child_row_nums: Some(&row_nums),
         },
@@ -4274,13 +4453,13 @@ fn export_visible_table_history(
     conn: &Connection,
     schema: &SchemaDef,
     table_name: &str,
-    principal: &str,
-    trusted: bool,
+    user: &str,
+    bypass_policy: bool,
     branch_nums: &[i64],
     row_nums: Option<&[i64]>,
 ) -> Result<Vec<HistoryRecord>> {
     let table = schema.table_def(table_name)?;
-    let policy_sql = export_read_policy_sql(schema, table, principal, trusted)?;
+    let policy_sql = export_read_policy_sql(schema, table, user, bypass_policy)?;
     let field_columns = table
         .fields
         .iter()
@@ -4503,13 +4682,13 @@ fn branch_filter_sql(alias: &str, branch_nums: &[i64]) -> String {
 fn export_read_policy_sql(
     schema: &SchemaDef,
     table: &crate::schema::TableDef,
-    principal: &str,
-    trusted: bool,
+    user: &str,
+    bypass_policy: bool,
 ) -> Result<String> {
-    if trusted {
+    if bypass_policy {
         Ok("1 = 1".to_owned())
     } else {
-        policy::read_policy_sql(schema, table, principal)
+        policy::read_policy_sql(schema, table, user)
     }
 }
 

--- a/crates/mini-jazz-sqlite/src/schema.rs
+++ b/crates/mini-jazz-sqlite/src/schema.rs
@@ -134,7 +134,7 @@ pub(crate) struct IndexDef {
 pub(crate) enum PolicyDef {
     #[default]
     AllowAll,
-    CreatedByPrincipal,
+    CreatedByUser,
     RefReadable {
         field: String,
     },
@@ -144,7 +144,7 @@ impl PolicyDef {
     fn fingerprint_for_table(&self, table: &TableDef) -> String {
         match self {
             PolicyDef::AllowAll => "allow_all".to_owned(),
-            PolicyDef::CreatedByPrincipal => "created_by_principal".to_owned(),
+            PolicyDef::CreatedByUser => "created_by_user".to_owned(),
             PolicyDef::RefReadable { field } => {
                 let storage_field = table
                     .fields
@@ -278,12 +278,12 @@ impl TableBuilder {
         });
     }
 
-    pub fn read_if_created_by_principal(&mut self) {
-        self.table.read_policy = PolicyDef::CreatedByPrincipal;
+    pub fn read_if_created_by_user(&mut self) {
+        self.table.read_policy = PolicyDef::CreatedByUser;
     }
 
-    pub fn write_if_created_by_principal(&mut self) {
-        self.table.write_policy = PolicyDef::CreatedByPrincipal;
+    pub fn write_if_created_by_user(&mut self) {
+        self.table.write_policy = PolicyDef::CreatedByUser;
     }
 
     pub fn write_if_ref_readable(&mut self, field: &str) {

--- a/crates/mini-jazz-sqlite/src/sync.rs
+++ b/crates/mini-jazz-sqlite/src/sync.rs
@@ -51,7 +51,7 @@ pub struct TxRecord {
     pub conflict_mode: i64,
     pub outcome: i64,
     #[serde(default)]
-    pub auth_principal: Option<String>,
+    pub auth_user: Option<String>,
     pub rejection_code: Option<String>,
     #[serde(default)]
     pub rejection_detail: Option<JsonValue>,

--- a/crates/mini-jazz-sqlite/tests/support/mod.rs
+++ b/crates/mini-jazz-sqlite/tests/support/mod.rs
@@ -38,6 +38,75 @@ pub struct Harness {
     dir: TempDir,
 }
 
+#[derive(Clone, Copy)]
+pub enum NodeStorage {
+    Memory,
+    Durable(&'static str),
+}
+
+#[derive(Clone, Copy)]
+pub enum NodeKind {
+    Client { user: &'static str },
+    TrustedPeer,
+}
+
+#[derive(Clone, Copy)]
+pub struct NodeSpec {
+    pub node_id: &'static str,
+    pub kind: NodeKind,
+    pub storage: NodeStorage,
+}
+
+impl NodeSpec {
+    pub fn client_memory(node_id: &'static str, user: &'static str) -> Self {
+        Self {
+            node_id,
+            kind: NodeKind::Client { user },
+            storage: NodeStorage::Memory,
+        }
+    }
+
+    pub fn trusted_peer_memory(node_id: &'static str) -> Self {
+        Self {
+            node_id,
+            kind: NodeKind::TrustedPeer,
+            storage: NodeStorage::Memory,
+        }
+    }
+
+    pub fn trusted_peer_durable(file_name: &'static str, node_id: &'static str) -> Self {
+        Self {
+            node_id,
+            kind: NodeKind::TrustedPeer,
+            storage: NodeStorage::Durable(file_name),
+        }
+    }
+}
+
+pub struct Topology {
+    nodes: BTreeMap<&'static str, Runtime>,
+}
+
+impl Topology {
+    pub fn new(
+        harness: &Harness,
+        schema: SchemaDef,
+        specs: &[(&'static str, NodeSpec)],
+    ) -> Result<Self> {
+        let mut nodes = BTreeMap::new();
+        for (role, spec) in specs {
+            nodes.insert(*role, harness.node_with_schema(*spec, schema.clone())?);
+        }
+        Ok(Self { nodes })
+    }
+
+    pub fn take(&mut self, role: &'static str) -> Runtime {
+        self.nodes
+            .remove(role)
+            .unwrap_or_else(|| panic!("missing topology role {role}"))
+    }
+}
+
 impl Harness {
     pub fn new() -> Self {
         Self {
@@ -49,41 +118,119 @@ impl Harness {
         self.dir.path().join(file_name)
     }
 
-    pub fn memory(&self, node_id: &str, principal: &str) -> Result<Runtime> {
-        Runtime::open(Storage::Memory, node_id, principal)
+    pub fn memory(&self, node_id: &str, user: &str) -> Result<Runtime> {
+        Runtime::open(Storage::Memory, node_id, user)
     }
 
-    pub fn durable(&self, file_name: &str, node_id: &str, principal: &str) -> Result<Runtime> {
-        Runtime::open(Storage::File(self.path(file_name)), node_id, principal)
+    pub fn durable(&self, file_name: &str, node_id: &str, user: &str) -> Result<Runtime> {
+        Runtime::open(Storage::File(self.path(file_name)), node_id, user)
     }
 
     pub fn memory_with_schema(
         &self,
         node_id: &str,
-        principal: &str,
+        user: &str,
         schema: SchemaDef,
     ) -> Result<Runtime> {
-        Runtime::open_with_schema(Storage::Memory, node_id, principal, schema)
+        Runtime::open_with_schema(Storage::Memory, node_id, user, schema)
     }
 
     pub fn durable_with_schema(
         &self,
         file_name: &str,
         node_id: &str,
-        principal: &str,
+        user: &str,
         schema: SchemaDef,
     ) -> Result<Runtime> {
-        Runtime::open_with_schema(
-            Storage::File(self.path(file_name)),
-            node_id,
-            principal,
-            schema,
-        )
+        Runtime::open_with_schema(Storage::File(self.path(file_name)), node_id, user, schema)
     }
+
+    pub fn trusted_memory_with_schema(&self, node_id: &str, schema: SchemaDef) -> Result<Runtime> {
+        Runtime::open_trusted_with_schema(Storage::Memory, node_id, schema)
+    }
+
+    pub fn trusted_durable_with_schema(
+        &self,
+        file_name: &str,
+        node_id: &str,
+        schema: SchemaDef,
+    ) -> Result<Runtime> {
+        Runtime::open_trusted_with_schema(Storage::File(self.path(file_name)), node_id, schema)
+    }
+
+    pub fn node_with_schema(&self, spec: NodeSpec, schema: SchemaDef) -> Result<Runtime> {
+        let storage = match spec.storage {
+            NodeStorage::Memory => Storage::Memory,
+            NodeStorage::Durable(file_name) => Storage::File(self.path(file_name)),
+        };
+        match spec.kind {
+            NodeKind::Client { user } => {
+                Runtime::open_with_schema(storage, spec.node_id, user, schema)
+            }
+            NodeKind::TrustedPeer => {
+                Runtime::open_trusted_with_schema(storage, spec.node_id, schema)
+            }
+        }
+    }
+}
+
+pub fn run_as_user<T>(
+    trusted_peer: &mut Runtime,
+    user: &str,
+    f: impl FnOnce(&mut Runtime) -> T,
+) -> T {
+    trusted_peer.run_as_user(user, f)
+}
+
+pub fn run_attributing_to_user<T>(
+    trusted_peer: &mut Runtime,
+    user: &str,
+    f: impl FnOnce(&mut Runtime) -> T,
+) -> T {
+    trusted_peer.run_attributing_to_user(user, f)
 }
 
 pub fn apply(source_bundle: Bundle, target: &mut Runtime) -> Result<()> {
     target.apply_bundle(&source_bundle)
+}
+
+pub fn apply_untrusted(source_bundle: Bundle, target: &mut Runtime) -> Result<()> {
+    target.apply_untrusted_bundle(&source_bundle)
+}
+
+pub fn apply_untrusted_as_user(
+    source_bundle: Bundle,
+    target: &mut Runtime,
+    user: &str,
+) -> Result<()> {
+    target.apply_untrusted_bundle_as_user(&source_bundle, user)
+}
+
+pub fn sync_table(source: &Runtime, target: &mut Runtime, table_name: &str) -> Result<()> {
+    target.apply_bundle(&source.export_table_history(table_name)?)
+}
+
+pub fn sync_table_untrusted(
+    source: &Runtime,
+    target: &mut Runtime,
+    table_name: &str,
+) -> Result<()> {
+    target.apply_untrusted_bundle_as_user(
+        &source.export_table_history(table_name)?,
+        source.session_user(),
+    )
+}
+
+pub fn forward_exclusive(
+    source: &Runtime,
+    target: &mut Runtime,
+    table_name: &str,
+    tx_id: &str,
+    auth_user: &str,
+) -> Result<()> {
+    target.apply_untrusted_bundle(
+        &source.export_exclusive_transaction_forwarding(table_name, tx_id, auth_user)?,
+    )
 }
 
 pub fn refresh_observed_queries(source: &Runtime, target: &mut Runtime) -> Result<()> {
@@ -91,6 +238,88 @@ pub fn refresh_observed_queries(source: &Runtime, target: &mut Runtime) -> Resul
         target.apply_bundle(&refresh)?;
     }
     Ok(())
+}
+
+pub struct TrustedEdgeTopology {
+    pub alice: Runtime,
+    pub bob: Runtime,
+    pub edge: Runtime,
+}
+
+impl TrustedEdgeTopology {
+    pub fn memory(harness: &Harness, schema: SchemaDef) -> Result<Self> {
+        let mut topology = Topology::new(
+            harness,
+            schema,
+            &[
+                ("alice", NodeSpec::client_memory("alice-node", "alice")),
+                ("bob", NodeSpec::trusted_peer_memory("bob-node")),
+                ("edge", NodeSpec::trusted_peer_memory("edge")),
+            ],
+        )?;
+        Ok(Self {
+            alice: topology.take("alice"),
+            bob: topology.take("bob"),
+            edge: topology.take("edge"),
+        })
+    }
+
+    pub fn durable_edge(harness: &Harness, schema: SchemaDef) -> Result<Self> {
+        let mut topology = Topology::new(
+            harness,
+            schema,
+            &[
+                ("alice", NodeSpec::client_memory("alice-node", "alice")),
+                ("bob", NodeSpec::trusted_peer_memory("bob-node")),
+                (
+                    "edge",
+                    NodeSpec::trusted_peer_durable("edge.sqlite", "edge"),
+                ),
+            ],
+        )?;
+        Ok(Self {
+            alice: topology.take("alice"),
+            bob: topology.take("bob"),
+            edge: topology.take("edge"),
+        })
+    }
+}
+
+pub struct TrustedMeshTopology {
+    pub alice_tab: Runtime,
+    pub edge_a: Runtime,
+    pub core: Runtime,
+    pub edge_b: Runtime,
+    pub alice_laptop: Runtime,
+    pub bob_tab: Runtime,
+}
+
+impl TrustedMeshTopology {
+    pub fn memory(harness: &Harness, schema: SchemaDef) -> Result<Self> {
+        let mut topology = Topology::new(
+            harness,
+            schema,
+            &[
+                ("alice-tab", NodeSpec::client_memory("alice-tab", "alice")),
+                ("edge-a", NodeSpec::trusted_peer_memory("edge-a")),
+                ("core", NodeSpec::trusted_peer_memory("core")),
+                ("edge-b", NodeSpec::trusted_peer_memory("edge-b")),
+                (
+                    "alice-laptop",
+                    NodeSpec::client_memory("alice-laptop", "alice"),
+                ),
+                ("bob-tab", NodeSpec::client_memory("bob-tab", "bob")),
+            ],
+        )?;
+        Ok(Self {
+            alice_tab: topology.take("alice-tab"),
+            edge_a: topology.take("edge-a"),
+            core: topology.take("core"),
+            edge_b: topology.take("edge-b"),
+            alice_laptop: topology.take("alice-laptop"),
+            bob_tab: topology.take("bob-tab"),
+        })
+    }
 }
 
 impl FixtureRuntimeExt for Runtime {
@@ -274,6 +503,6 @@ pub fn folders_schema() -> SchemaDef {
     SchemaDef::new().table("folders", |table| {
         table.text("name");
         table.ref_("parent", "folders");
-        table.read_if_created_by_principal();
+        table.read_if_created_by_user();
     })
 }

--- a/crates/mini-jazz-sqlite/tests/whole_system/branches.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/branches.rs
@@ -876,7 +876,7 @@ fn branch_base_snapshot_applies_row_policy() {
     let schema = SchemaDef::new().table("tasks", |table| {
         table.text("title");
         table.bool("done");
-        table.read_if_created_by_principal();
+        table.read_if_created_by_user();
     });
     let mut alice =
         Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema.clone()).unwrap();
@@ -922,7 +922,7 @@ fn branch_base_snapshot_ref_policy_uses_parent_at_base_epoch() {
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
@@ -978,7 +978,7 @@ fn branch_ref_policy_uses_branch_local_parent_visibility() {
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
@@ -1011,7 +1011,7 @@ fn branch_ref_policy_uses_branch_local_parent_visibility() {
     alice.checkout_branch("draft").unwrap();
     assert_eq!(alice.read_rows("todos").unwrap().len(), 1);
 
-    alice.principal_for_test("bob");
+    alice.session_user_for_test("bob");
     alice
         .update_row(
             "projects",
@@ -1019,7 +1019,7 @@ fn branch_ref_policy_uses_branch_local_parent_visibility() {
             BTreeMap::from([("title".to_owned(), json!("Bob-owned branch project"))]),
         )
         .unwrap();
-    alice.principal_for_test("alice");
+    alice.session_user_for_test("alice");
 
     assert!(alice.read_rows("todos").unwrap().is_empty());
 }
@@ -1029,7 +1029,7 @@ fn branch_equality_query_uses_effective_branch_policy() {
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
@@ -1061,7 +1061,7 @@ fn branch_equality_query_uses_effective_branch_policy() {
     alice.create_branch("draft", Some(2)).unwrap();
     alice.checkout_branch("draft").unwrap();
 
-    alice.principal_for_test("bob");
+    alice.session_user_for_test("bob");
     alice
         .update_row(
             "projects",
@@ -1069,7 +1069,7 @@ fn branch_equality_query_uses_effective_branch_policy() {
             BTreeMap::from([("title".to_owned(), json!("Bob-owned branch project"))]),
         )
         .unwrap();
-    alice.principal_for_test("alice");
+    alice.session_user_for_test("alice");
 
     assert!(alice
         .read_rows_where_eq("todos", "title", json!("Find me"))
@@ -1082,7 +1082,7 @@ fn branch_base_export_preserves_ref_policy_at_base_epoch() {
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
@@ -2637,7 +2637,7 @@ fn branch_conflict_candidates_respect_effective_row_policy() {
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("tasks", |table| {
             table.text("title");
@@ -2669,7 +2669,7 @@ fn branch_conflict_candidates_respect_effective_row_policy() {
         )
         .unwrap();
 
-    alice.principal_for_test("bob");
+    alice.session_user_for_test("bob");
     alice.create_branch("right", None).unwrap();
     alice.checkout_branch("right").unwrap();
     alice
@@ -2691,7 +2691,7 @@ fn branch_conflict_candidates_respect_effective_row_policy() {
         )
         .unwrap();
 
-    alice.principal_for_test("alice");
+    alice.session_user_for_test("alice");
     alice
         .create_branch_from_branches("merge", &["left", "right"])
         .unwrap();

--- a/crates/mini-jazz-sqlite/tests/whole_system/generic_schema.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/generic_schema.rs
@@ -493,7 +493,7 @@ fn durable_in_query_read_refresh_repairs_row_that_left_value_set_after_restart()
 }
 
 #[test]
-fn created_by_magic_field_query_matches_creator_principal() {
+fn created_by_magic_field_query_matches_creator_user() {
     let schema = support::notes_schema();
     let mut alice =
         Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema.clone()).unwrap();
@@ -825,7 +825,7 @@ fn generic_equality_query_scope_exports_matching_rows_and_policy_dependencies() 
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("tasks", |table| {
             table.text("title");
@@ -904,7 +904,7 @@ fn query_scope_bundle_dedupes_shared_policy_dependency_history() {
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("tasks", |table| {
             table.text("title");
@@ -1854,7 +1854,7 @@ fn equality_query_scope_resync_removes_row_hidden_by_policy_dependency_change() 
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("tasks", |table| {
             table.text("title");
@@ -1941,7 +1941,7 @@ fn durable_query_read_refresh_repairs_policy_dependency_change_after_restart() {
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("tasks", |table| {
             table.text("title");
@@ -2381,7 +2381,7 @@ fn generic_required_ref_read_filters_parent_until_target_is_visible() {
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");

--- a/crates/mini-jazz-sqlite/tests/whole_system/policies.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/policies.rs
@@ -5,7 +5,7 @@ fn policy_filters_reads_through_required_parent_ref() {
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
@@ -68,7 +68,7 @@ fn required_ref_include_filters_parent_when_target_is_unauthorized() {
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
@@ -144,7 +144,7 @@ fn untrusted_acceptance_uses_authority_policy_not_sender_policy_fingerprint() {
     let edge_schema = SchemaDef::new().table("notes", |table| {
         table.text("body");
         table.bool("pinned");
-        table.write_if_created_by_principal();
+        table.write_if_created_by_user();
     });
     let mut writer =
         Runtime::open_with_schema(Storage::Memory, "writer", "alice", writer_schema).unwrap();
@@ -163,7 +163,8 @@ fn untrusted_acceptance_uses_authority_policy_not_sender_policy_fingerprint() {
     let bundle = writer.export_table_history("notes").unwrap();
     assert_ne!(bundle.policy_fingerprint, edge.local_policy_fingerprint());
 
-    edge.apply_untrusted_bundle(&bundle).unwrap();
+    edge.apply_untrusted_bundle_as_user(&bundle, writer.session_user())
+        .unwrap();
     assert_eq!(edge.read_rows("notes").unwrap().len(), 1);
 
     let mut rejecting_edge = Runtime::open_trusted_with_schema(
@@ -172,11 +173,13 @@ fn untrusted_acceptance_uses_authority_policy_not_sender_policy_fingerprint() {
         SchemaDef::new().table("notes", |table| {
             table.text("body");
             table.bool("pinned");
-            table.write_if_created_by_principal();
+            table.write_if_created_by_user();
         }),
     )
     .unwrap();
-    rejecting_edge.apply_untrusted_bundle(&bundle).unwrap();
+    rejecting_edge
+        .apply_untrusted_bundle_as_user(&bundle, writer.session_user())
+        .unwrap();
     assert_eq!(rejecting_edge.read_rows("notes").unwrap().len(), 1);
     assert_eq!(
         rejecting_edge.transaction_info(&tx).unwrap().rejection_code,
@@ -189,7 +192,7 @@ fn policy_scoped_sync_includes_required_parent_rows_only() {
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
@@ -238,11 +241,11 @@ fn policy_scoped_sync_includes_required_parent_rows_only() {
 }
 
 #[test]
-fn trusted_peer_can_read_applied_policy_scoped_facts_without_user_principal() {
+fn trusted_peer_can_read_applied_policy_scoped_facts_without_user() {
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
@@ -276,7 +279,7 @@ fn trusted_transport_history_still_filters_untrusted_current_reads() {
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
@@ -344,7 +347,7 @@ fn trusted_peer_generic_transaction_bypasses_user_write_policy() {
     let schema = SchemaDef::new()
         .table("docs", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("comments", |table| {
             table.text("body");
@@ -382,21 +385,24 @@ fn trusted_peer_generic_transaction_bypasses_user_write_policy() {
 
 #[test]
 fn trusted_edge_accepts_mergeable_tx_then_untrusted_peers_enforce_policy() {
-    let dir = tempdir().unwrap();
-    let edge_path = dir.path().join("edge.sqlite");
+    let harness = support::Harness::new();
     let schema = SchemaDef::new().table("notes", |table| {
         table.text("body");
         table.bool("pinned");
-        table.read_if_created_by_principal();
+        table.read_if_created_by_user();
     });
-    let mut alice =
-        Runtime::open_with_schema(Storage::Memory, "alice-tab", "alice", schema.clone()).unwrap();
-    let mut edge =
-        Runtime::open_trusted_with_schema(Storage::File(edge_path), "edge", schema.clone())
-            .unwrap();
-    let mut alice_phone =
-        Runtime::open_with_schema(Storage::Memory, "alice-phone", "alice", schema.clone()).unwrap();
-    let mut bob = Runtime::open_with_schema(Storage::Memory, "bob-tab", "bob", schema).unwrap();
+    let mut alice = harness
+        .memory_with_schema("alice-tab", "alice", schema.clone())
+        .unwrap();
+    let mut edge = harness
+        .trusted_durable_with_schema("edge.sqlite", "edge", schema.clone())
+        .unwrap();
+    let mut alice_phone = harness
+        .memory_with_schema("alice-phone", "alice", schema.clone())
+        .unwrap();
+    let mut bob = harness
+        .memory_with_schema("bob-tab", "bob", schema)
+        .unwrap();
 
     let tx = alice
         .insert_row(
@@ -408,13 +414,12 @@ fn trusted_edge_accepts_mergeable_tx_then_untrusted_peers_enforce_policy() {
             ]),
         )
         .unwrap();
-    edge.apply_bundle(&alice.export_table_history("notes").unwrap())
-        .unwrap();
+    support::sync_table(&alice, &mut edge, "notes").unwrap();
     edge.accept_transaction_at_global(&tx, 11).unwrap();
 
     let accepted_bundle = edge.export_table_history("notes").unwrap();
-    alice_phone.apply_bundle(&accepted_bundle).unwrap();
-    bob.apply_bundle(&accepted_bundle).unwrap();
+    support::apply(accepted_bundle.clone(), &mut alice_phone).unwrap();
+    support::apply(accepted_bundle, &mut bob).unwrap();
 
     assert_eq!(alice_phone.read_rows("notes").unwrap().len(), 1);
     assert_eq!(
@@ -426,16 +431,17 @@ fn trusted_edge_accepts_mergeable_tx_then_untrusted_peers_enforce_policy() {
 
 #[test]
 fn trusted_edge_acceptance_syncs_without_global_epoch() {
-    let dir = tempdir().unwrap();
-    let edge_path = dir.path().join("edge.sqlite");
+    let harness = support::Harness::new();
     let schema = support::notes_schema();
-    let mut alice =
-        Runtime::open_with_schema(Storage::Memory, "alice-tab", "alice", schema.clone()).unwrap();
-    let mut edge =
-        Runtime::open_trusted_with_schema(Storage::File(edge_path), "edge", schema.clone())
-            .unwrap();
-    let mut phone =
-        Runtime::open_with_schema(Storage::Memory, "alice-phone", "alice", schema).unwrap();
+    let mut alice = harness
+        .memory_with_schema("alice-tab", "alice", schema.clone())
+        .unwrap();
+    let mut edge = harness
+        .trusted_durable_with_schema("edge.sqlite", "edge", schema.clone())
+        .unwrap();
+    let mut phone = harness
+        .memory_with_schema("alice-phone", "alice", schema)
+        .unwrap();
 
     let tx = alice
         .insert_row(
@@ -447,13 +453,10 @@ fn trusted_edge_acceptance_syncs_without_global_epoch() {
             ]),
         )
         .unwrap();
-    edge.apply_bundle(&alice.export_table_history("notes").unwrap())
-        .unwrap();
+    support::sync_table(&alice, &mut edge, "notes").unwrap();
     edge.accept_transaction_at_edge(&tx).unwrap();
 
-    phone
-        .apply_bundle(&edge.export_table_history("notes").unwrap())
-        .unwrap();
+    support::sync_table(&edge, &mut phone, "notes").unwrap();
 
     let info = phone.transaction_info(&tx).unwrap();
     assert_eq!(info.global_epoch, None);
@@ -463,13 +466,17 @@ fn trusted_edge_acceptance_syncs_without_global_epoch() {
 
 #[test]
 fn edge_accepted_transaction_can_upgrade_to_global_epoch() {
+    let harness = support::Harness::new();
     let schema = support::notes_schema();
-    let mut alice =
-        Runtime::open_with_schema(Storage::Memory, "alice-tab", "alice", schema.clone()).unwrap();
-    let mut edge =
-        Runtime::open_trusted_with_schema(Storage::Memory, "edge", schema.clone()).unwrap();
-    let mut phone =
-        Runtime::open_with_schema(Storage::Memory, "alice-phone", "alice", schema).unwrap();
+    let mut alice = harness
+        .memory_with_schema("alice-tab", "alice", schema.clone())
+        .unwrap();
+    let mut edge = harness
+        .trusted_memory_with_schema("edge", schema.clone())
+        .unwrap();
+    let mut phone = harness
+        .memory_with_schema("alice-phone", "alice", schema)
+        .unwrap();
 
     let tx = alice
         .insert_row(
@@ -481,18 +488,13 @@ fn edge_accepted_transaction_can_upgrade_to_global_epoch() {
             ]),
         )
         .unwrap();
-    edge.apply_bundle(&alice.export_table_history("notes").unwrap())
-        .unwrap();
+    support::sync_table(&alice, &mut edge, "notes").unwrap();
     edge.accept_transaction_at_edge(&tx).unwrap();
-    phone
-        .apply_bundle(&edge.export_table_history("notes").unwrap())
-        .unwrap();
+    support::sync_table(&edge, &mut phone, "notes").unwrap();
     assert_eq!(phone.transaction_info(&tx).unwrap().global_epoch, None);
 
     edge.accept_transaction_at_global(&tx, 42).unwrap();
-    phone
-        .apply_bundle(&edge.export_table_history("notes").unwrap())
-        .unwrap();
+    support::sync_table(&edge, &mut phone, "notes").unwrap();
 
     let info = phone.transaction_info(&tx).unwrap();
     assert_eq!(info.global_epoch, Some(42));
@@ -502,25 +504,22 @@ fn edge_accepted_transaction_can_upgrade_to_global_epoch() {
 
 #[test]
 fn edge_core_peer_edge_round_trip_preserves_policy_and_receipts() {
+    let harness = support::Harness::new();
     let schema = SchemaDef::new().table("notes", |table| {
         table.text("body");
         table.bool("pinned");
-        table.read_if_created_by_principal();
+        table.read_if_created_by_user();
     });
-    let mut alice =
-        Runtime::open_with_schema(Storage::Memory, "alice-tab", "alice", schema.clone()).unwrap();
-    let mut edge_a =
-        Runtime::open_trusted_with_schema(Storage::Memory, "edge-a", schema.clone()).unwrap();
-    let mut core =
-        Runtime::open_trusted_with_schema(Storage::Memory, "core", schema.clone()).unwrap();
-    let mut edge_b =
-        Runtime::open_trusted_with_schema(Storage::Memory, "edge-b", schema.clone()).unwrap();
-    let mut alice_laptop =
-        Runtime::open_with_schema(Storage::Memory, "alice-laptop", "alice", schema.clone())
-            .unwrap();
-    let mut bob = Runtime::open_with_schema(Storage::Memory, "bob-tab", "bob", schema).unwrap();
+    let support::TrustedMeshTopology {
+        mut alice_tab,
+        mut edge_a,
+        mut core,
+        mut edge_b,
+        mut alice_laptop,
+        mut bob_tab,
+    } = support::TrustedMeshTopology::memory(&harness, schema).unwrap();
 
-    let tx = alice
+    let tx = alice_tab
         .insert_row(
             "notes",
             "note-1",
@@ -531,25 +530,20 @@ fn edge_core_peer_edge_round_trip_preserves_policy_and_receipts() {
         )
         .unwrap();
 
-    edge_a
-        .apply_untrusted_bundle(&alice.export_table_history("notes").unwrap())
-        .unwrap();
+    support::sync_table_untrusted(&alice_tab, &mut edge_a, "notes").unwrap();
     edge_a.accept_transaction_at_edge(&tx).unwrap();
-    core.apply_bundle(&edge_a.export_table_history("notes").unwrap())
-        .unwrap();
+    support::sync_table(&edge_a, &mut core, "notes").unwrap();
     core.accept_transaction_at_global(&tx, 99).unwrap();
-    edge_b
-        .apply_bundle(&core.export_table_history("notes").unwrap())
-        .unwrap();
+    support::sync_table(&core, &mut edge_b, "notes").unwrap();
 
     let global_bundle = edge_b.export_table_history("notes").unwrap();
-    alice_laptop.apply_bundle(&global_bundle).unwrap();
-    bob.apply_bundle(&global_bundle).unwrap();
+    support::apply(global_bundle.clone(), &mut alice_laptop).unwrap();
+    support::apply(global_bundle, &mut bob_tab).unwrap();
 
     let alice_rows = alice_laptop.read_rows("notes").unwrap();
     assert_eq!(alice_rows.len(), 1);
     assert_eq!(alice_rows[0].id, "note-1");
-    assert!(bob.read_rows("notes").unwrap().is_empty());
+    assert!(bob_tab.read_rows("notes").unwrap().is_empty());
 
     let info = alice_laptop.transaction_info(&tx).unwrap();
     assert_eq!(info.global_epoch, Some(99));
@@ -562,7 +556,7 @@ fn trusted_edge_rejects_policy_violating_tx_and_syncs_reason() {
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
@@ -614,22 +608,22 @@ fn trusted_edge_rejects_policy_violating_tx_and_syncs_reason() {
 
 #[test]
 fn trusted_edge_authoritatively_rejects_untrusted_policy_violation_on_apply() {
+    let harness = support::Harness::new();
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
             table.ref_("project", "projects");
             table.write_if_ref_readable("project");
         });
-    let mut alice =
-        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema.clone()).unwrap();
-    let mut bob =
-        Runtime::open_trusted_as_with_schema(Storage::Memory, "bob-node", "bob", schema.clone())
-            .unwrap();
-    let mut edge = Runtime::open_trusted_with_schema(Storage::Memory, "edge", schema).unwrap();
+    let support::TrustedEdgeTopology {
+        mut alice,
+        mut bob,
+        mut edge,
+    } = support::TrustedEdgeTopology::memory(&harness, schema).unwrap();
 
     alice
         .insert_row(
@@ -639,8 +633,8 @@ fn trusted_edge_authoritatively_rejects_untrusted_policy_violation_on_apply() {
         )
         .unwrap();
     let project_bundle = alice.export_table_history("projects").unwrap();
-    bob.apply_bundle(&project_bundle).unwrap();
-    edge.apply_bundle(&project_bundle).unwrap();
+    support::apply(project_bundle.clone(), &mut bob).unwrap();
+    support::apply(project_bundle, &mut edge).unwrap();
 
     let tx = bob
         .insert_row(
@@ -656,7 +650,7 @@ fn trusted_edge_authoritatively_rejects_untrusted_policy_violation_on_apply() {
         )
         .unwrap();
 
-    edge.apply_untrusted_bundle(&bob.export_table_history("todos").unwrap())
+    support::apply_untrusted_as_user(bob.export_table_history("todos").unwrap(), &mut edge, "bob")
         .unwrap();
 
     assert!(edge.read_rows("todos").unwrap().is_empty());
@@ -685,8 +679,7 @@ fn trusted_edge_authoritatively_rejects_untrusted_policy_violation_on_apply() {
         }]
     );
 
-    bob.apply_bundle(&edge.export_table_history("todos").unwrap())
-        .unwrap();
+    support::sync_table(&edge, &mut bob, "todos").unwrap();
     assert_eq!(
         bob.transaction_info(&tx).unwrap().rejection_detail,
         Some(json!({
@@ -710,26 +703,44 @@ fn trusted_edge_authoritatively_rejects_untrusted_policy_violation_on_apply() {
 }
 
 #[test]
-fn core_validates_forwarded_exclusive_transaction_with_session_principal() {
+fn core_validates_forwarded_exclusive_transaction_with_session_user() {
+    let harness = support::Harness::new();
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
             table.ref_("project", "projects");
             table.write_if_ref_readable("project");
         });
-    let mut alice =
-        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema.clone()).unwrap();
-    let mut edge =
-        Runtime::open_trusted_as_with_schema(Storage::Memory, "edge", "service", schema.clone())
-            .unwrap();
-    let mut core =
-        Runtime::open_trusted_with_schema(Storage::Memory, "core", schema.clone()).unwrap();
-    let mut core_without_forwarded_auth =
-        Runtime::open_trusted_with_schema(Storage::Memory, "core-no-auth", schema).unwrap();
+    let mut topology = support::Topology::new(
+        &harness,
+        schema,
+        &[
+            (
+                "alice",
+                support::NodeSpec::client_memory("alice-node", "alice"),
+            ),
+            ("edge", support::NodeSpec::trusted_peer_memory("edge")),
+            ("core", support::NodeSpec::trusted_peer_memory("core")),
+            (
+                "core-missing-auth",
+                support::NodeSpec::trusted_peer_memory("core-missing-auth"),
+            ),
+            (
+                "core-no-auth",
+                support::NodeSpec::trusted_peer_memory("core-no-auth"),
+            ),
+        ],
+    )
+    .unwrap();
+    let mut alice = topology.take("alice");
+    let mut edge = topology.take("edge");
+    let mut core = topology.take("core");
+    let mut core_missing_auth = topology.take("core-missing-auth");
+    let mut core_without_forwarded_auth = topology.take("core-no-auth");
 
     alice
         .insert_row(
@@ -739,14 +750,13 @@ fn core_validates_forwarded_exclusive_transaction_with_session_principal() {
         )
         .unwrap();
     let project_bundle = alice.export_table_history("projects").unwrap();
-    edge.apply_bundle(&project_bundle).unwrap();
-    core.apply_bundle(&project_bundle).unwrap();
-    core_without_forwarded_auth
-        .apply_bundle(&project_bundle)
-        .unwrap();
+    support::apply(project_bundle.clone(), &mut edge).unwrap();
+    support::apply(project_bundle.clone(), &mut core).unwrap();
+    support::apply(project_bundle.clone(), &mut core_missing_auth).unwrap();
+    support::apply(project_bundle, &mut core_without_forwarded_auth).unwrap();
 
-    let tx = edge
-        .insert_row(
+    let tx = support::run_attributing_to_user(&mut edge, "service", |edge| {
+        edge.insert_row(
             "todos",
             "todo-1",
             BTreeMap::from([
@@ -754,14 +764,42 @@ fn core_validates_forwarded_exclusive_transaction_with_session_principal() {
                 ("project".to_owned(), json!("project-1")),
             ]),
         )
+    })
+    .unwrap();
+    let mut missing_auth_bundle = edge
+        .export_exclusive_transaction_forwarding("todos", &tx, "alice")
         .unwrap();
-    let bundle_without_forwarded_auth = edge
-        .export_exclusive_transaction_forwarding("todos", &tx, "service")
-        .unwrap();
+    missing_auth_bundle
+        .txs
+        .iter_mut()
+        .find(|record| record.tx_id == tx)
+        .unwrap()
+        .auth_user = None;
+    support::apply_untrusted(missing_auth_bundle, &mut core_missing_auth).unwrap();
+    assert_eq!(
+        core_missing_auth
+            .transaction_info(&tx)
+            .unwrap()
+            .rejection_code,
+        Some("policy_denied".to_owned())
+    );
+    assert_eq!(
+        core_missing_auth
+            .transaction_info(&tx)
+            .unwrap()
+            .rejection_detail,
+        Some(json!({ "reason": "missing_auth_user" }))
+    );
+    assert!(core_missing_auth.read_rows("todos").unwrap().is_empty());
 
-    core_without_forwarded_auth
-        .apply_untrusted_bundle(&bundle_without_forwarded_auth)
-        .unwrap();
+    support::forward_exclusive(
+        &edge,
+        &mut core_without_forwarded_auth,
+        "todos",
+        &tx,
+        "service",
+    )
+    .unwrap();
     assert_eq!(
         core_without_forwarded_auth
             .transaction_info(&tx)
@@ -774,11 +812,7 @@ fn core_validates_forwarded_exclusive_transaction_with_session_principal() {
         .unwrap()
         .is_empty());
 
-    let bundle = edge
-        .export_exclusive_transaction_forwarding("todos", &tx, "alice")
-        .unwrap();
-
-    core.apply_untrusted_bundle(&bundle).unwrap();
+    support::forward_exclusive(&edge, &mut core, "todos", &tx, "alice").unwrap();
 
     let info = core.transaction_info(&tx).unwrap();
     assert_eq!(info.conflict_mode, "exclusive");
@@ -791,7 +825,7 @@ fn core_validates_forwarded_exclusive_transaction_with_session_principal() {
             .iter()
             .find(|record| record.tx_id == tx)
             .unwrap()
-            .auth_principal
+            .auth_user
             .as_deref(),
         Some("alice")
     );
@@ -799,29 +833,29 @@ fn core_validates_forwarded_exclusive_transaction_with_session_principal() {
 
 #[test]
 fn trusted_edge_rejects_untrusted_write_when_policy_dependency_is_missing() {
+    let harness = support::Harness::new();
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
             table.ref_("project", "projects");
             table.write_if_ref_readable("project");
         });
-    let mut bob =
-        Runtime::open_trusted_as_with_schema(Storage::Memory, "bob-node", "bob", schema.clone())
-            .unwrap();
-    let mut edge = Runtime::open_trusted_with_schema(Storage::Memory, "edge", schema).unwrap();
+    let mut bob = harness
+        .trusted_memory_with_schema("bob-node", schema.clone())
+        .unwrap();
+    let mut edge = harness.trusted_memory_with_schema("edge", schema).unwrap();
 
-    bob.insert_row(
-        "projects",
-        "project-bob",
-        BTreeMap::from([("title".to_owned(), json!("Bob project"))]),
-    )
-    .unwrap();
-    let tx = bob
-        .insert_row(
+    let tx = support::run_as_user(&mut bob, "bob", |bob| {
+        bob.insert_row(
+            "projects",
+            "project-bob",
+            BTreeMap::from([("title".to_owned(), json!("Bob project"))]),
+        )?;
+        bob.insert_row(
             "todos",
             "todo-1",
             BTreeMap::from([
@@ -829,14 +863,15 @@ fn trusted_edge_rejects_untrusted_write_when_policy_dependency_is_missing() {
                 ("project".to_owned(), json!("project-bob")),
             ]),
         )
-        .unwrap();
+    })
+    .unwrap();
 
     let mut incomplete_bundle = bob.export_table_history("todos").unwrap();
     incomplete_bundle
         .history
         .retain(|record| record.table != "projects");
 
-    edge.apply_untrusted_bundle(&incomplete_bundle).unwrap();
+    support::apply_untrusted_as_user(incomplete_bundle, &mut edge, bob.session_user()).unwrap();
     assert!(edge.read_rows("todos").unwrap().is_empty());
     assert_eq!(
         edge.transaction_info(&tx).unwrap().rejection_code,
@@ -853,11 +888,10 @@ fn trusted_edge_rejects_untrusted_write_when_policy_dependency_is_missing() {
         }))
     );
 
-    edge.apply_bundle(&bob.export_table_history("projects").unwrap())
-        .unwrap();
+    support::sync_table(&bob, &mut edge, "projects").unwrap();
     assert!(edge.read_rows("todos").unwrap().is_empty());
 
-    edge.apply_untrusted_bundle(&bob.export_table_history("todos").unwrap())
+    support::apply_untrusted_as_user(bob.export_table_history("todos").unwrap(), &mut edge, "bob")
         .unwrap();
     assert!(edge.read_rows("todos").unwrap().is_empty());
     assert_eq!(
@@ -874,29 +908,29 @@ fn trusted_edge_rejects_untrusted_write_when_policy_dependency_is_missing() {
 
 #[test]
 fn trusted_edge_accepts_untrusted_write_when_bundle_contains_policy_dependency() {
+    let harness = support::Harness::new();
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
             table.ref_("project", "projects");
             table.write_if_ref_readable("project");
         });
-    let mut bob =
-        Runtime::open_trusted_as_with_schema(Storage::Memory, "bob-node", "bob", schema.clone())
-            .unwrap();
-    let mut edge = Runtime::open_trusted_with_schema(Storage::Memory, "edge", schema).unwrap();
+    let mut bob = harness
+        .trusted_memory_with_schema("bob-node", schema.clone())
+        .unwrap();
+    let mut edge = harness.trusted_memory_with_schema("edge", schema).unwrap();
 
-    bob.insert_row(
-        "projects",
-        "project-bob",
-        BTreeMap::from([("title".to_owned(), json!("Bob project"))]),
-    )
-    .unwrap();
-    let tx = bob
-        .insert_row(
+    let tx = support::run_as_user(&mut bob, "bob", |bob| {
+        bob.insert_row(
+            "projects",
+            "project-bob",
+            BTreeMap::from([("title".to_owned(), json!("Bob project"))]),
+        )?;
+        bob.insert_row(
             "todos",
             "todo-1",
             BTreeMap::from([
@@ -904,9 +938,10 @@ fn trusted_edge_accepts_untrusted_write_when_bundle_contains_policy_dependency()
                 ("project".to_owned(), json!("project-bob")),
             ]),
         )
-        .unwrap();
+    })
+    .unwrap();
 
-    edge.apply_untrusted_bundle(&bob.export_table_history("todos").unwrap())
+    support::apply_untrusted_as_user(bob.export_table_history("todos").unwrap(), &mut edge, "bob")
         .unwrap();
 
     let rows = edge.read_rows("todos").unwrap();
@@ -916,23 +951,55 @@ fn trusted_edge_accepts_untrusted_write_when_bundle_contains_policy_dependency()
 }
 
 #[test]
+fn untrusted_policy_validation_uses_authenticated_user_not_forged_provenance() {
+    let schema = SchemaDef::new().table("docs", |table| {
+        table.text("title");
+        table.write_if_created_by_user();
+    });
+    let mut bob =
+        Runtime::open_with_schema(Storage::Memory, "bob-node", "bob", schema.clone()).unwrap();
+    let mut edge = Runtime::open_trusted_with_schema(Storage::Memory, "edge", schema).unwrap();
+
+    let tx = bob
+        .insert_row(
+            "docs",
+            "doc-forged",
+            BTreeMap::from([("title".to_owned(), json!("Forged owner"))]),
+        )
+        .unwrap();
+    let mut bundle = bob.export_table_history("docs").unwrap();
+    for record in &mut bundle.history {
+        record.created_by = "alice".to_owned();
+        record.updated_by = "alice".to_owned();
+    }
+
+    edge.apply_untrusted_bundle_as_user(&bundle, "bob").unwrap();
+
+    assert!(edge.read_rows("docs").unwrap().is_empty());
+    assert_eq!(
+        edge.transaction_info(&tx).unwrap().rejection_code,
+        Some("policy_denied".to_owned())
+    );
+}
+
+#[test]
 fn trusted_edge_rejects_untrusted_transaction_atomically() {
+    let harness = support::Harness::new();
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
             table.ref_("project", "projects");
             table.write_if_ref_readable("project");
         });
-    let mut alice =
-        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema.clone()).unwrap();
-    let mut bob =
-        Runtime::open_trusted_as_with_schema(Storage::Memory, "bob-node", "bob", schema.clone())
-            .unwrap();
-    let mut edge = Runtime::open_trusted_with_schema(Storage::Memory, "edge", schema).unwrap();
+    let support::TrustedEdgeTopology {
+        mut alice,
+        mut bob,
+        mut edge,
+    } = support::TrustedEdgeTopology::memory(&harness, schema).unwrap();
 
     alice
         .insert_row(
@@ -947,35 +1014,33 @@ fn trusted_edge_rejects_untrusted_transaction_atomically() {
         BTreeMap::from([("title".to_owned(), json!("Bob project"))]),
     )
     .unwrap();
-    bob.apply_bundle(&alice.export_table_history("projects").unwrap())
-        .unwrap();
-    edge.apply_bundle(&alice.export_table_history("projects").unwrap())
-        .unwrap();
-    edge.apply_bundle(&bob.export_table_history("projects").unwrap())
-        .unwrap();
+    support::sync_table(&alice, &mut bob, "projects").unwrap();
+    support::sync_table(&alice, &mut edge, "projects").unwrap();
+    support::sync_table(&bob, &mut edge, "projects").unwrap();
 
-    let tx = bob
-        .transaction()
-        .insert_row(
-            "todos",
-            "todo-allowed-sibling",
-            BTreeMap::from([
-                ("title".to_owned(), json!("Allowed sibling")),
-                ("project".to_owned(), json!("project-bob")),
-            ]),
-        )
-        .insert_row(
-            "todos",
-            "todo-denied-sibling",
-            BTreeMap::from([
-                ("title".to_owned(), json!("Denied sibling")),
-                ("project".to_owned(), json!("project-alice")),
-            ]),
-        )
-        .commit()
-        .unwrap();
+    let tx = support::run_as_user(&mut bob, "bob", |bob| {
+        bob.transaction()
+            .insert_row(
+                "todos",
+                "todo-allowed-sibling",
+                BTreeMap::from([
+                    ("title".to_owned(), json!("Allowed sibling")),
+                    ("project".to_owned(), json!("project-bob")),
+                ]),
+            )
+            .insert_row(
+                "todos",
+                "todo-denied-sibling",
+                BTreeMap::from([
+                    ("title".to_owned(), json!("Denied sibling")),
+                    ("project".to_owned(), json!("project-alice")),
+                ]),
+            )
+            .commit()
+    })
+    .unwrap();
 
-    edge.apply_untrusted_bundle(&bob.export_table_history("todos").unwrap())
+    support::apply_untrusted_as_user(bob.export_table_history("todos").unwrap(), &mut edge, "bob")
         .unwrap();
 
     assert!(edge.read_rows("todos").unwrap().is_empty());
@@ -987,22 +1052,22 @@ fn trusted_edge_rejects_untrusted_transaction_atomically() {
 
 #[test]
 fn trusted_edge_rejects_untrusted_update_to_unreadable_ref() {
+    let harness = support::Harness::new();
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
             table.ref_("project", "projects");
             table.write_if_ref_readable("project");
         });
-    let mut alice =
-        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema.clone()).unwrap();
-    let mut bob =
-        Runtime::open_trusted_as_with_schema(Storage::Memory, "bob-node", "bob", schema.clone())
-            .unwrap();
-    let mut edge = Runtime::open_trusted_with_schema(Storage::Memory, "edge", schema).unwrap();
+    let support::TrustedEdgeTopology {
+        mut alice,
+        mut bob,
+        mut edge,
+    } = support::TrustedEdgeTopology::memory(&harness, schema).unwrap();
 
     alice
         .insert_row(
@@ -1011,31 +1076,35 @@ fn trusted_edge_rejects_untrusted_update_to_unreadable_ref() {
             BTreeMap::from([("title".to_owned(), json!("Alice project"))]),
         )
         .unwrap();
-    bob.insert_row(
-        "projects",
-        "project-bob",
-        BTreeMap::from([("title".to_owned(), json!("Bob project"))]),
+    support::run_as_user(&mut bob, "bob", |bob| {
+        bob.insert_row(
+            "projects",
+            "project-bob",
+            BTreeMap::from([("title".to_owned(), json!("Bob project"))]),
+        )?;
+        bob.insert_row(
+            "todos",
+            "todo-1",
+            BTreeMap::from([
+                ("title".to_owned(), json!("Initially allowed")),
+                ("project".to_owned(), json!("project-bob")),
+            ]),
+        )
+    })
+    .unwrap();
+    support::sync_table(&alice, &mut edge, "projects").unwrap();
+    support::apply_untrusted_as_user(
+        bob.export_table_history("projects").unwrap(),
+        &mut edge,
+        "bob",
     )
     .unwrap();
-    bob.insert_row(
-        "todos",
-        "todo-1",
-        BTreeMap::from([
-            ("title".to_owned(), json!("Initially allowed")),
-            ("project".to_owned(), json!("project-bob")),
-        ]),
-    )
-    .unwrap();
-    edge.apply_bundle(&alice.export_table_history("projects").unwrap())
-        .unwrap();
-    edge.apply_untrusted_bundle(&bob.export_table_history("projects").unwrap())
-        .unwrap();
-    edge.apply_untrusted_bundle(&bob.export_table_history("todos").unwrap())
+    support::apply_untrusted_as_user(bob.export_table_history("todos").unwrap(), &mut edge, "bob")
         .unwrap();
     assert_eq!(edge.read_rows("todos").unwrap().len(), 1);
 
-    let tx = bob
-        .update_row(
+    let tx = support::run_as_user(&mut bob, "bob", |bob| {
+        bob.update_row(
             "todos",
             "todo-1",
             BTreeMap::from([
@@ -1043,8 +1112,9 @@ fn trusted_edge_rejects_untrusted_update_to_unreadable_ref() {
                 ("project".to_owned(), json!("project-alice")),
             ]),
         )
-        .unwrap();
-    edge.apply_untrusted_bundle(&bob.export_table_history("todos").unwrap())
+    })
+    .unwrap();
+    support::apply_untrusted_as_user(bob.export_table_history("todos").unwrap(), &mut edge, "bob")
         .unwrap();
 
     let rows = edge.read_rows("todos").unwrap();
@@ -1061,7 +1131,7 @@ fn branch_write_policy_does_not_use_parent_from_different_branch() {
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
@@ -1096,8 +1166,11 @@ fn branch_write_policy_does_not_use_parent_from_different_branch() {
         )
         .unwrap();
 
-    edge.apply_untrusted_bundle(&bob.export_table_history("todos").unwrap())
-        .unwrap();
+    edge.apply_untrusted_bundle_as_user(
+        &bob.export_table_history("todos").unwrap(),
+        bob.session_user(),
+    )
+    .unwrap();
     edge.checkout_branch("draft").unwrap();
 
     assert!(edge.read_rows("todos").unwrap().is_empty());
@@ -1112,7 +1185,7 @@ fn branch_write_policy_uses_parent_visible_from_pinned_base() {
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
@@ -1154,7 +1227,7 @@ fn branch_recursive_write_policy_uses_parent_state_from_pinned_base() {
     let schema = SchemaDef::new()
         .table("orgs", |table| {
             table.text("name");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("projects", |table| {
             table.text("title");
@@ -1242,7 +1315,7 @@ fn trusted_edge_validates_branch_recursive_write_policy_against_pinned_base() {
     let schema = SchemaDef::new()
         .table("orgs", |table| {
             table.text("name");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("projects", |table| {
             table.text("title");
@@ -1257,7 +1330,7 @@ fn trusted_edge_validates_branch_recursive_write_policy_against_pinned_base() {
     let mut alice =
         Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema.clone()).unwrap();
     let mut bob =
-        Runtime::open_trusted_as_with_schema(Storage::Memory, "bob-node", "bob", schema.clone())
+        Runtime::open_trusted_with_session_user(Storage::Memory, "bob-node", "bob", schema.clone())
             .unwrap();
     let mut edge = Runtime::open_trusted_with_schema(Storage::Memory, "edge", schema).unwrap();
 
@@ -1319,8 +1392,11 @@ fn trusted_edge_validates_branch_recursive_write_policy_against_pinned_base() {
         )
         .unwrap();
 
-    edge.apply_untrusted_bundle(&alice.export_table_history("todos").unwrap())
-        .unwrap();
+    edge.apply_untrusted_bundle_as_user(
+        &alice.export_table_history("todos").unwrap(),
+        alice.session_user(),
+    )
+    .unwrap();
     edge.checkout_branch("draft").unwrap();
     let rows = edge.read_rows("todos").unwrap();
     assert_eq!(rows.len(), 1);
@@ -1332,9 +1408,9 @@ fn trusted_edge_validates_branch_recursive_write_policy_against_pinned_base() {
 fn trusted_edge_rejects_untrusted_delete_policy_violation() {
     let schema = SchemaDef::new().table("docs", |table| {
         table.text("title");
-        table.write_if_created_by_principal();
+        table.write_if_created_by_user();
     });
-    let mut alice = Runtime::open_trusted_as_with_schema(
+    let mut alice = Runtime::open_trusted_with_session_user(
         Storage::Memory,
         "alice-node",
         "alice",
@@ -1342,7 +1418,7 @@ fn trusted_edge_rejects_untrusted_delete_policy_violation() {
     )
     .unwrap();
     let mut bob =
-        Runtime::open_trusted_as_with_schema(Storage::Memory, "bob-node", "bob", schema.clone())
+        Runtime::open_trusted_with_session_user(Storage::Memory, "bob-node", "bob", schema.clone())
             .unwrap();
     let mut edge = Runtime::open_trusted_with_schema(Storage::Memory, "edge", schema).unwrap();
 
@@ -1359,8 +1435,11 @@ fn trusted_edge_rejects_untrusted_delete_policy_violation() {
     edge.accept_transaction_at_edge(&alice_tx).unwrap();
 
     let delete_tx = bob.delete_row("docs", "doc-1").unwrap();
-    edge.apply_untrusted_bundle(&bob.export_table_history("docs").unwrap())
-        .unwrap();
+    edge.apply_untrusted_bundle_as_user(
+        &bob.export_table_history("docs").unwrap(),
+        bob.session_user(),
+    )
+    .unwrap();
 
     let edge_rows = edge.read_rows("docs").unwrap();
     assert_eq!(edge_rows.len(), 1);
@@ -1373,16 +1452,18 @@ fn trusted_edge_rejects_untrusted_delete_policy_violation() {
 
 #[test]
 fn created_by_write_policy_allows_self_create_but_rejects_other_writer() {
+    let harness = support::Harness::new();
     let schema = SchemaDef::new().table("docs", |table| {
         table.text("title");
-        table.write_if_created_by_principal();
+        table.write_if_created_by_user();
     });
-    let mut alice =
-        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema.clone()).unwrap();
-    let mut bob =
-        Runtime::open_trusted_as_with_schema(Storage::Memory, "bob-node", "bob", schema.clone())
-            .unwrap();
-    let mut edge = Runtime::open_trusted_with_schema(Storage::Memory, "edge", schema).unwrap();
+    let mut alice = harness
+        .memory_with_schema("alice-node", "alice", schema.clone())
+        .unwrap();
+    let mut bob = harness
+        .trusted_memory_with_schema("bob-node", schema.clone())
+        .unwrap();
+    let mut edge = harness.trusted_memory_with_schema("edge", schema).unwrap();
 
     let create_tx = alice
         .insert_row(
@@ -1394,19 +1475,19 @@ fn created_by_write_policy_allows_self_create_but_rejects_other_writer() {
     assert_eq!(alice.read_rows("docs").unwrap().len(), 1);
 
     let alice_bundle = alice.export_table_history("docs").unwrap();
-    bob.apply_bundle(&alice_bundle).unwrap();
-    edge.apply_untrusted_bundle(&alice_bundle).unwrap();
+    support::apply(alice_bundle.clone(), &mut bob).unwrap();
+    support::apply_untrusted_as_user(alice_bundle, &mut edge, alice.session_user()).unwrap();
     edge.accept_transaction_at_edge(&create_tx).unwrap();
 
-    let update_tx = bob
-        .update_row(
+    let update_tx = support::run_as_user(&mut bob, "bob", |bob| {
+        bob.update_row(
             "docs",
             "doc-1",
             BTreeMap::from([("title".to_owned(), json!("Bob rewrite"))]),
         )
-        .unwrap();
-    edge.apply_untrusted_bundle(&bob.export_table_history("docs").unwrap())
-        .unwrap();
+    })
+    .unwrap();
+    support::sync_table_untrusted(&bob, &mut edge, "docs").unwrap();
 
     assert_eq!(
         edge.read_rows("docs").unwrap()[0].values["title"],
@@ -1420,23 +1501,24 @@ fn created_by_write_policy_allows_self_create_but_rejects_other_writer() {
 
 #[test]
 fn untrusted_validation_error_does_not_leave_invalid_current_row_visible() {
+    let harness = support::Harness::new();
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
             table.ref_("project", "projects");
             table.write_if_ref_readable("project");
         });
-    let mut bob =
-        Runtime::open_trusted_as_with_schema(Storage::Memory, "bob-node", "bob", schema.clone())
-            .unwrap();
-    let mut edge = Runtime::open_trusted_with_schema(Storage::Memory, "edge", schema).unwrap();
+    let mut bob = harness
+        .trusted_memory_with_schema("bob-node", schema.clone())
+        .unwrap();
+    let mut edge = harness.trusted_memory_with_schema("edge", schema).unwrap();
 
-    let tx = bob
-        .insert_row(
+    let tx = support::run_as_user(&mut bob, "bob", |bob| {
+        bob.insert_row(
             "todos",
             "todo-1",
             BTreeMap::from([
@@ -1444,9 +1526,10 @@ fn untrusted_validation_error_does_not_leave_invalid_current_row_visible() {
                 ("project".to_owned(), json!("project-missing")),
             ]),
         )
-        .unwrap();
+    })
+    .unwrap();
 
-    edge.apply_untrusted_bundle(&bob.export_table_history("todos").unwrap())
+    support::apply_untrusted_as_user(bob.export_table_history("todos").unwrap(), &mut edge, "bob")
         .unwrap();
 
     assert!(edge.read_rows("todos").unwrap().is_empty());
@@ -1458,23 +1541,22 @@ fn untrusted_validation_error_does_not_leave_invalid_current_row_visible() {
 
 #[test]
 fn durable_edge_rejects_after_restart_and_repairs_memory_client() {
-    let dir = tempdir().unwrap();
-    let edge_path = dir.path().join("edge.sqlite");
+    let harness = support::Harness::new();
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
             table.ref_("project", "projects");
             table.write_if_ref_readable("project");
         });
-    let mut alice =
-        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema.clone()).unwrap();
-    let mut bob =
-        Runtime::open_trusted_as_with_schema(Storage::Memory, "bob-node", "bob", schema.clone())
-            .unwrap();
+    let support::TrustedEdgeTopology {
+        mut alice,
+        mut bob,
+        edge: _,
+    } = support::TrustedEdgeTopology::durable_edge(&harness, schema.clone()).unwrap();
 
     alice
         .insert_row(
@@ -1499,26 +1581,22 @@ fn durable_edge_rejects_after_restart_and_repairs_memory_client() {
     assert_eq!(bob.read_rows("todos").unwrap().len(), 1);
 
     {
-        let mut edge = Runtime::open_trusted_with_schema(
-            Storage::File(edge_path.clone()),
-            "edge",
-            schema.clone(),
-        )
-        .unwrap();
-        edge.apply_bundle(&project_bundle).unwrap();
-        edge.apply_bundle(&bob.export_table_history("todos").unwrap())
+        let mut edge = harness
+            .trusted_durable_with_schema("edge.sqlite", "edge", schema.clone())
             .unwrap();
+        support::apply(project_bundle.clone(), &mut edge).unwrap();
+        support::sync_table(&bob, &mut edge, "todos").unwrap();
         assert_eq!(edge.read_rows("todos").unwrap().len(), 1);
     }
 
-    let mut edge =
-        Runtime::open_trusted_with_schema(Storage::File(edge_path), "edge", schema).unwrap();
-    edge.apply_untrusted_bundle(&bob.export_table_history("todos").unwrap())
+    let mut edge = harness
+        .trusted_durable_with_schema("edge.sqlite", "edge", schema)
+        .unwrap();
+    support::apply_untrusted_as_user(bob.export_table_history("todos").unwrap(), &mut edge, "bob")
         .unwrap();
     assert!(edge.read_rows("todos").unwrap().is_empty());
 
-    bob.apply_bundle(&edge.export_table_history("todos").unwrap())
-        .unwrap();
+    support::sync_table(&edge, &mut bob, "todos").unwrap();
     assert!(bob.read_rows("todos").unwrap().is_empty());
     assert_eq!(
         bob.transaction_info(&tx).unwrap().rejection_code,
@@ -1531,7 +1609,7 @@ fn policy_denied_write_is_rejected_history_not_current_state() {
     let schema = SchemaDef::new()
         .table("docs", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("comments", |table| {
             table.text("body");
@@ -1568,7 +1646,7 @@ fn write_policy_parent_check_records_policy_read_set() {
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
@@ -1607,7 +1685,7 @@ fn patch_update_uses_preserved_ref_for_write_policy_validation() {
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
@@ -1657,7 +1735,7 @@ fn ref_retarget_update_validates_new_parent_policy() {
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
@@ -1717,7 +1795,7 @@ fn policy_denied_delete_restores_previous_visible_row_and_subscription() {
     let schema = SchemaDef::new()
         .table("docs", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("comments", |table| {
             table.text("body");
@@ -1772,7 +1850,7 @@ fn multi_row_transaction_rejects_atomically_when_one_policy_check_fails() {
     let schema = SchemaDef::new()
         .table("docs", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("comments", |table| {
             table.text("body");
@@ -1840,7 +1918,7 @@ fn trusted_admin_write_bypasses_policy_but_preserves_author_provenance() {
     let schema = SchemaDef::new()
         .table("docs", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("comments", |table| {
             table.text("body");
@@ -1850,7 +1928,7 @@ fn trusted_admin_write_bypasses_policy_but_preserves_author_provenance() {
     let mut alice =
         Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema.clone()).unwrap();
     let mut admin =
-        Runtime::open_trusted_as_with_schema(Storage::Memory, "admin-node", "service", schema)
+        Runtime::open_trusted_attributing_to_user(Storage::Memory, "admin-node", "service", schema)
             .unwrap();
 
     alice
@@ -1882,11 +1960,84 @@ fn trusted_admin_write_bypasses_policy_but_preserves_author_provenance() {
 }
 
 #[test]
+fn trusted_as_user_enforces_policy_while_attribution_mode_bypasses_it() {
+    let schema = SchemaDef::new().table("docs", |table| {
+        table.text("title");
+        table.write_if_created_by_user();
+    });
+    let mut alice =
+        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema.clone()).unwrap();
+    let mut worker =
+        Runtime::open_trusted_with_schema(Storage::Memory, "worker-node", schema).unwrap();
+
+    alice
+        .insert_row(
+            "docs",
+            "doc-alice",
+            BTreeMap::from([("title".to_owned(), json!("Alice doc"))]),
+        )
+        .unwrap();
+    worker
+        .apply_bundle(&alice.export_table_history("docs").unwrap())
+        .unwrap();
+
+    let denied_tx = support::run_as_user(&mut worker, "bob", |worker| {
+        worker.update_row(
+            "docs",
+            "doc-alice",
+            BTreeMap::from([("title".to_owned(), json!("Denied"))]),
+        )
+    })
+    .unwrap();
+    assert_eq!(
+        worker.transaction_info(&denied_tx).unwrap().rejection_code,
+        Some("policy_denied".to_owned())
+    );
+    assert_eq!(
+        worker
+            .read_rows_where_eq("docs", "id", json!("doc-alice"))
+            .unwrap()[0]
+            .values["title"],
+        json!("Alice doc")
+    );
+
+    let accepted_tx = support::run_attributing_to_user(&mut worker, "bob", |worker| {
+        worker.update_row(
+            "docs",
+            "doc-alice",
+            BTreeMap::from([("title".to_owned(), json!("Privileged edit"))]),
+        )
+    })
+    .unwrap();
+    let row = worker
+        .read_rows_where_eq("docs", "id", json!("doc-alice"))
+        .unwrap()
+        .pop()
+        .unwrap();
+    assert_eq!(row.values["title"], json!("Privileged edit"));
+    assert_eq!(row.created_by, "alice");
+    let history = worker.export_table_history("docs").unwrap();
+    let accepted_history = history
+        .history
+        .iter()
+        .find(|record| record.tx_id == accepted_tx)
+        .unwrap();
+    assert_eq!(accepted_history.updated_by, "bob");
+    assert_eq!(
+        worker
+            .transaction_info(&accepted_tx)
+            .unwrap()
+            .rejection_code,
+        None
+    );
+}
+
+#[test]
 fn recursive_write_policy_records_transitive_policy_read_set() {
     let schema = SchemaDef::new()
         .table("orgs", |table| {
             table.text("name");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("projects", |table| {
             table.text("title");
@@ -1944,7 +2095,7 @@ fn trusted_edge_accepts_untrusted_recursive_write_when_bundle_contains_transitiv
     let schema = SchemaDef::new()
         .table("orgs", |table| {
             table.text("name");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("projects", |table| {
             table.text("title");
@@ -1956,7 +2107,7 @@ fn trusted_edge_accepts_untrusted_recursive_write_when_bundle_contains_transitiv
             table.ref_("project", "projects");
             table.write_if_ref_readable("project");
         });
-    let mut alice = Runtime::open_trusted_as_with_schema(
+    let mut alice = Runtime::open_trusted_with_session_user(
         Storage::Memory,
         "alice-node",
         "alice",
@@ -2003,7 +2154,8 @@ fn trusted_edge_accepts_untrusted_recursive_write_when_bundle_contains_transitiv
     assert!(exported.contains(&("projects", "project-1")));
     assert!(exported.contains(&("orgs", "org-1")));
 
-    edge.apply_untrusted_bundle(&bundle).unwrap();
+    edge.apply_untrusted_bundle_as_user(&bundle, alice.session_user())
+        .unwrap();
 
     let rows = edge.read_rows("todos").unwrap();
     assert_eq!(rows.len(), 1);
@@ -2016,7 +2168,7 @@ fn trusted_edge_reports_missing_transitive_policy_dependency() {
     let schema = SchemaDef::new()
         .table("orgs", |table| {
             table.text("name");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("projects", |table| {
             table.text("title");
@@ -2028,7 +2180,7 @@ fn trusted_edge_reports_missing_transitive_policy_dependency() {
             table.ref_("project", "projects");
             table.write_if_ref_readable("project");
         });
-    let mut alice = Runtime::open_trusted_as_with_schema(
+    let mut alice = Runtime::open_trusted_with_session_user(
         Storage::Memory,
         "alice-node",
         "alice",
@@ -2069,7 +2221,8 @@ fn trusted_edge_reports_missing_transitive_policy_dependency() {
         .history
         .retain(|record| !(record.table == "orgs" && record.row_id == "org-1"));
 
-    edge.apply_untrusted_bundle(&bundle).unwrap();
+    edge.apply_untrusted_bundle_as_user(&bundle, alice.session_user())
+        .unwrap();
 
     assert!(edge.read_rows("todos").unwrap().is_empty());
     assert_eq!(
@@ -2089,7 +2242,7 @@ fn policy_read_set_survives_sync() {
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
@@ -2132,7 +2285,7 @@ fn bundle_read_sets_are_scoped_to_exported_history_transactions() {
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");

--- a/crates/mini-jazz-sqlite/tests/whole_system/recursive_queries.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/recursive_queries.rs
@@ -5,7 +5,7 @@ fn recursive_policy_filters_reads_through_grandparent_ref() {
     let schema = SchemaDef::new()
         .table("orgs", |table| {
             table.text("name");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("projects", |table| {
             table.text("title");
@@ -105,7 +105,7 @@ fn long_acyclic_ref_policy_chain_reads_visible_leaf() {
                 table.ref_("parent", &parent_name);
                 table.read_if_ref_readable("parent");
             } else {
-                table.read_if_created_by_principal();
+                table.read_if_created_by_user();
             }
         });
     }
@@ -175,7 +175,7 @@ fn long_acyclic_recursive_policy_chain_is_sql_lowerable() {
         schema = schema.table(&table_name, |table| {
             table.text("name");
             if idx == 19 {
-                table.read_if_created_by_principal();
+                table.read_if_created_by_user();
             } else {
                 table.ref_("parent", &parent_name);
                 table.read_if_ref_readable("parent");
@@ -183,7 +183,7 @@ fn long_acyclic_recursive_policy_chain_is_sql_lowerable() {
         });
     }
     let mut writer =
-        Runtime::open_trusted_as_with_schema(Storage::Memory, "writer", "alice", schema.clone())
+        Runtime::open_trusted_with_session_user(Storage::Memory, "writer", "alice", schema.clone())
             .unwrap();
     let mut reader =
         Runtime::open_with_schema(Storage::Memory, "reader", "alice", schema.clone()).unwrap();
@@ -227,7 +227,7 @@ fn recursive_policy_scoped_sync_includes_transitive_parent_rows() {
     let schema = SchemaDef::new()
         .table("orgs", |table| {
             table.text("name");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("projects", |table| {
             table.text("title");
@@ -591,7 +591,7 @@ fn recursive_observed_query_refresh_removes_policy_hidden_descendant_with_subscr
     let schema = SchemaDef::new()
         .table("orgs", |table| {
             table.text("name");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("folders", |table| {
             table.text("name");
@@ -915,7 +915,7 @@ fn recursive_query_scope_sync_includes_recursive_policy_ancestors() {
     let schema = SchemaDef::new()
         .table("orgs", |table| {
             table.text("name");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("folders", |table| {
             table.text("name");
@@ -1185,7 +1185,7 @@ fn recursive_branch_query_export_includes_snapshot_policy_ancestors() {
     let schema = SchemaDef::new()
         .table("orgs", |table| {
             table.text("name");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("folders", |table| {
             table.text("name");

--- a/crates/mini-jazz-sqlite/tests/whole_system/schema_lenses.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/schema_lenses.rs
@@ -352,7 +352,7 @@ fn renamed_ref_lens_participates_in_read_policy() {
     let old_schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
@@ -361,7 +361,7 @@ fn renamed_ref_lens_participates_in_read_policy() {
     let new_schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
@@ -435,7 +435,7 @@ fn renamed_ref_lens_participates_in_untrusted_write_policy_validation() {
     let old_schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
@@ -444,7 +444,7 @@ fn renamed_ref_lens_participates_in_untrusted_write_policy_validation() {
     let new_schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
@@ -455,7 +455,7 @@ fn renamed_ref_lens_participates_in_untrusted_write_policy_validation() {
         Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", old_schema.clone())
             .unwrap();
     let mut bob =
-        Runtime::open_trusted_as_with_schema(Storage::Memory, "bob-node", "bob", old_schema)
+        Runtime::open_trusted_with_session_user(Storage::Memory, "bob-node", "bob", old_schema)
             .unwrap();
     let mut edge = Runtime::open_trusted_with_schema(Storage::Memory, "edge", new_schema).unwrap();
 
@@ -481,8 +481,11 @@ fn renamed_ref_lens_participates_in_untrusted_write_policy_validation() {
         )
         .unwrap();
 
-    edge.apply_untrusted_bundle(&bob.export_table_history("todos").unwrap())
-        .unwrap();
+    edge.apply_untrusted_bundle_as_user(
+        &bob.export_table_history("todos").unwrap(),
+        bob.session_user(),
+    )
+    .unwrap();
 
     assert!(edge.read_rows("todos").unwrap().is_empty());
     assert_eq!(
@@ -496,7 +499,7 @@ fn lens_compatible_write_policy_allows_ordinary_peer_sync() {
     let old_schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
@@ -506,7 +509,7 @@ fn lens_compatible_write_policy_allows_ordinary_peer_sync() {
     let new_schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
@@ -552,7 +555,7 @@ fn renamed_ref_lens_exports_transitive_write_policy_dependencies_for_untrusted_e
     let old_schema = SchemaDef::new()
         .table("orgs", |table| {
             table.text("name");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("projects", |table| {
             table.text("title");
@@ -567,7 +570,7 @@ fn renamed_ref_lens_exports_transitive_write_policy_dependencies_for_untrusted_e
     let new_schema = SchemaDef::new()
         .table("orgs", |table| {
             table.text("name");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("projects", |table| {
             table.text("title");
@@ -580,7 +583,7 @@ fn renamed_ref_lens_exports_transitive_write_policy_dependencies_for_untrusted_e
             table.write_if_ref_readable("workspace");
         });
     let mut alice =
-        Runtime::open_trusted_as_with_schema(Storage::Memory, "alice-node", "alice", old_schema)
+        Runtime::open_trusted_with_session_user(Storage::Memory, "alice-node", "alice", old_schema)
             .unwrap();
     let mut edge = Runtime::open_trusted_with_schema(Storage::Memory, "edge", new_schema).unwrap();
 
@@ -622,7 +625,8 @@ fn renamed_ref_lens_exports_transitive_write_policy_dependencies_for_untrusted_e
     assert!(exported.contains(&("projects", "project-1")));
     assert!(exported.contains(&("orgs", "org-1")));
 
-    edge.apply_untrusted_bundle(&bundle).unwrap();
+    edge.apply_untrusted_bundle_as_user(&bundle, alice.session_user())
+        .unwrap();
 
     assert_eq!(edge.transaction_info(&tx).unwrap().rejection_code, None);
     let rows = edge.read_rows("todos").unwrap();

--- a/crates/mini-jazz-sqlite/tests/whole_system/subscriptions.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/subscriptions.rs
@@ -743,7 +743,7 @@ fn subscription_removes_child_when_parent_policy_dependency_changes() {
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");

--- a/crates/mini-jazz-sqlite/tests/whole_system/sync_fate.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/sync_fate.rs
@@ -685,7 +685,7 @@ fn permission_fingerprint_mismatch_fails_closed_without_partial_apply() {
     let receiver_schema = SchemaDef::new().table("notes", |table| {
         table.text("body");
         table.bool("pinned");
-        table.write_if_created_by_principal();
+        table.write_if_created_by_user();
     });
     let mut writer =
         Runtime::open_with_schema(Storage::Memory, "writer", "alice", writer_schema).unwrap();
@@ -789,7 +789,7 @@ fn replicas_may_use_different_physical_tx_nums_for_same_public_tx_id() {
 }
 
 #[test]
-fn same_principal_on_two_nodes_preserves_authorship_and_distinct_node_epochs() {
+fn same_user_on_two_nodes_preserves_authorship_and_distinct_node_epochs() {
     let schema = support::notes_schema();
     let mut alice_phone =
         Runtime::open_with_schema(Storage::Memory, "alice-phone", "alice", schema.clone()).unwrap();

--- a/crates/mini-jazz-sqlite/tests/whole_system/transactions.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/transactions.rs
@@ -357,7 +357,8 @@ fn exclusive_transaction_mode_survives_sync() {
 fn exclusive_forwarding_export_marks_only_selected_transaction() {
     let schema = support::notes_schema();
     let mut edge =
-        Runtime::open_trusted_as_with_schema(Storage::Memory, "edge", "service", schema).unwrap();
+        Runtime::open_trusted_with_session_user(Storage::Memory, "edge", "service", schema)
+            .unwrap();
 
     let first_tx = edge
         .insert_row(
@@ -392,7 +393,7 @@ fn exclusive_forwarding_export_marks_only_selected_transaction() {
     assert_eq!(forwarded.outcome, 1);
     assert_eq!(forwarded.global_epoch, None);
     assert_eq!(forwarded.receipt_tiers, Vec::<i64>::new());
-    assert_eq!(forwarded.auth_principal.as_deref(), Some("alice"));
+    assert_eq!(forwarded.auth_user.as_deref(), Some("alice"));
 
     let untouched = bundle
         .txs
@@ -400,7 +401,7 @@ fn exclusive_forwarding_export_marks_only_selected_transaction() {
         .find(|record| record.tx_id == second_tx)
         .unwrap();
     assert_eq!(untouched.conflict_mode, 1);
-    assert_eq!(untouched.auth_principal, None);
+    assert_eq!(untouched.auth_user, None);
 }
 
 #[test]
@@ -536,7 +537,7 @@ fn untrusted_exclusive_transaction_rejects_stale_policy_read_set() {
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
@@ -544,9 +545,13 @@ fn untrusted_exclusive_transaction_rejects_stale_policy_read_set() {
             table.ref_("project", "projects");
             table.write_if_ref_readable("project");
         });
-    let mut authority =
-        Runtime::open_trusted_as_with_schema(Storage::Memory, "authority", "alice", schema.clone())
-            .unwrap();
+    let mut authority = Runtime::open_trusted_with_session_user(
+        Storage::Memory,
+        "authority",
+        "alice",
+        schema.clone(),
+    )
+    .unwrap();
     let mut writer = Runtime::open_with_schema(Storage::Memory, "writer", "alice", schema).unwrap();
 
     let project_tx = authority
@@ -609,9 +614,13 @@ fn untrusted_exclusive_transaction_rejects_stale_policy_read_set() {
 #[test]
 fn untrusted_exclusive_transaction_rejects_stale_row_update_read_set() {
     let schema = support::notes_schema();
-    let mut authority =
-        Runtime::open_trusted_as_with_schema(Storage::Memory, "authority", "alice", schema.clone())
-            .unwrap();
+    let mut authority = Runtime::open_trusted_with_session_user(
+        Storage::Memory,
+        "authority",
+        "alice",
+        schema.clone(),
+    )
+    .unwrap();
     let mut writer = Runtime::open_with_schema(Storage::Memory, "writer", "alice", schema).unwrap();
 
     let original_tx = authority
@@ -673,9 +682,13 @@ fn untrusted_exclusive_transaction_rejects_stale_row_update_read_set() {
 #[test]
 fn untrusted_exclusive_transaction_rejects_stale_absent_row_read_set() {
     let schema = support::notes_schema();
-    let mut authority =
-        Runtime::open_trusted_as_with_schema(Storage::Memory, "authority", "alice", schema.clone())
-            .unwrap();
+    let mut authority = Runtime::open_trusted_with_session_user(
+        Storage::Memory,
+        "authority",
+        "alice",
+        schema.clone(),
+    )
+    .unwrap();
     let mut writer = Runtime::open_with_schema(Storage::Memory, "writer", "alice", schema).unwrap();
 
     let note_tx = writer
@@ -729,9 +742,13 @@ fn untrusted_exclusive_transaction_rejects_stale_absent_row_read_set() {
 #[test]
 fn untrusted_exclusive_transaction_rejects_stale_absent_row_from_new_source_branch() {
     let schema = support::notes_schema();
-    let mut authority =
-        Runtime::open_trusted_as_with_schema(Storage::Memory, "authority", "alice", schema.clone())
-            .unwrap();
+    let mut authority = Runtime::open_trusted_with_session_user(
+        Storage::Memory,
+        "authority",
+        "alice",
+        schema.clone(),
+    )
+    .unwrap();
     let mut writer = Runtime::open_with_schema(Storage::Memory, "writer", "alice", schema).unwrap();
 
     writer.create_branch("merge", None).unwrap();
@@ -786,9 +803,13 @@ fn untrusted_exclusive_transaction_rejects_stale_absent_row_from_new_source_bran
 #[test]
 fn untrusted_exclusive_transaction_rejects_stale_source_branch_row_read_set() {
     let schema = support::notes_schema();
-    let mut authority =
-        Runtime::open_trusted_as_with_schema(Storage::Memory, "authority", "alice", schema.clone())
-            .unwrap();
+    let mut authority = Runtime::open_trusted_with_session_user(
+        Storage::Memory,
+        "authority",
+        "alice",
+        schema.clone(),
+    )
+    .unwrap();
     let mut writer = Runtime::open_with_schema(Storage::Memory, "writer", "alice", schema).unwrap();
 
     authority.create_branch("left", None).unwrap();
@@ -852,9 +873,13 @@ fn untrusted_exclusive_transaction_rejects_stale_source_branch_row_read_set() {
 #[test]
 fn untrusted_exclusive_delete_rejects_stale_source_branch_row_read_set() {
     let schema = support::notes_schema();
-    let mut authority =
-        Runtime::open_trusted_as_with_schema(Storage::Memory, "authority", "alice", schema.clone())
-            .unwrap();
+    let mut authority = Runtime::open_trusted_with_session_user(
+        Storage::Memory,
+        "authority",
+        "alice",
+        schema.clone(),
+    )
+    .unwrap();
     let mut writer = Runtime::open_with_schema(Storage::Memory, "writer", "alice", schema).unwrap();
 
     authority.create_branch("left", None).unwrap();
@@ -916,7 +941,7 @@ fn branch_exclusive_transaction_observes_inherited_base_read_version() {
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
@@ -924,9 +949,13 @@ fn branch_exclusive_transaction_observes_inherited_base_read_version() {
             table.ref_("project", "projects");
             table.write_if_ref_readable("project");
         });
-    let mut authority =
-        Runtime::open_trusted_as_with_schema(Storage::Memory, "authority", "alice", schema.clone())
-            .unwrap();
+    let mut authority = Runtime::open_trusted_with_session_user(
+        Storage::Memory,
+        "authority",
+        "alice",
+        schema.clone(),
+    )
+    .unwrap();
     let mut writer = Runtime::open_with_schema(Storage::Memory, "writer", "alice", schema).unwrap();
 
     let project_tx = authority
@@ -972,7 +1001,7 @@ fn untrusted_exclusive_validation_handles_new_branch_records() {
     let schema = SchemaDef::new()
         .table("projects", |table| {
             table.text("title");
-            table.read_if_created_by_principal();
+            table.read_if_created_by_user();
         })
         .table("todos", |table| {
             table.text("title");
@@ -980,9 +1009,13 @@ fn untrusted_exclusive_validation_handles_new_branch_records() {
             table.ref_("project", "projects");
             table.write_if_ref_readable("project");
         });
-    let mut authority =
-        Runtime::open_trusted_as_with_schema(Storage::Memory, "authority", "alice", schema.clone())
-            .unwrap();
+    let mut authority = Runtime::open_trusted_with_session_user(
+        Storage::Memory,
+        "authority",
+        "alice",
+        schema.clone(),
+    )
+    .unwrap();
     let mut writer = Runtime::open_with_schema(Storage::Memory, "writer", "alice", schema).unwrap();
 
     let project_tx = authority
@@ -1014,13 +1047,9 @@ fn untrusted_exclusive_validation_handles_new_branch_records() {
         )
         .commit()
         .unwrap();
-    let mut bundle = writer.export_table_history("todos").unwrap();
-    bundle
-        .txs
-        .iter_mut()
-        .find(|tx| tx.tx_id == todo_tx)
-        .unwrap()
-        .conflict_mode = 2;
+    let bundle = writer
+        .export_exclusive_transaction_forwarding("todos", &todo_tx, "alice")
+        .unwrap();
 
     authority.apply_untrusted_bundle(&bundle).unwrap();
     authority.checkout_branch("draft").unwrap();

--- a/crates/mini-jazz-sqlite/vs-status-quo.md
+++ b/crates/mini-jazz-sqlite/vs-status-quo.md
@@ -105,7 +105,7 @@ Status-quo concepts that will eventually need a migration story include:
 | `DurabilityTier`                | delivery target and authority/edge/global observation tier  |
 | `QuerySettled`                  | query settled signal                                        |
 | `Db`                            | product API facade over query/write/sync plans              |
-| `Session`                       | principal plus role plus policy context                     |
+| `Session`                       | user/auth context plus separate policy and attribution mode |
 | `VisibleRowEntry`               | current projection row                                      |
 | `branch_name` / composed prefix | branch/source/schema context                                |
 | `row_format`                    | physical row codec                                          |


### PR DESCRIPTION
## Summary

- Add a small topology construction set for mini-jazz-sqlite tests: `NodeSpec`, `NodeKind`, `NodeStorage`, and `Topology` for role-based runtime creation.
- Model the product topology split directly: untrusted clients carry users, while trusted peers have no ambient user and execute work through explicit session helpers.
- Reflect that split in the runtime itself with `RuntimeAuth::{Client, TrustedPeer}` and `TrustedSession::{Admin, AsUser}` instead of a loose user + trusted pair.
- Adopt user language across mini-jazz-sqlite schema/policy/query/runtime abstractions; `principal` remains only in the spec note about external JWT principal/subject claims.
- Keep concrete fixtures (`TrustedEdgeTopology`, `TrustedMeshTopology`) as reusable setups built from the generic construction set.
- Add named sync helpers for trusted apply, untrusted apply, table sync, observed refresh, and exclusive forwarding.
- Migrate representative trusted edge/core policy tests to the construction set and fixtures, including exclusive forwarding, edge acceptance, durable edge restart, and atomic rejection paths.
- Clarify in the spec how users, admin execution, trusted peers, JWT claim mapping, and forwarded validation relate in typical topologies and runtime APIs.

## Test plan

- `cargo test -p mini-jazz-sqlite --test whole_system policies::`
- `cargo test -p mini-jazz-sqlite --test whole_system`
