### PR TITLE
Cover mini SQLite subscription tier invariants

### DIFF
--- a/crates/mini-jazz-sqlite/SPEC.md
+++ b/crates/mini-jazz-sqlite/SPEC.md
@@ -2855,6 +2855,14 @@ feature exists.
 - Subscription updates are semantic row diffs.
 - Dependency-only changes can update parent semantic rows.
 - Every subscription update is tier-gated.
+- Edge-tier subscriptions publish only row versions with an edge-or-global
+  durability receipt.
+- Global-tier subscriptions publish only row versions with a global durability
+  receipt; an edge receipt alone does not settle global delivery.
+- Tier-gated subscriptions preserve branch overlay and pinned-base snapshot
+  semantics while filtering by the requested durability tier.
+- A higher-tier subscription keeps its last tier-visible result and reports
+  unsettled while newer local state lacks the requested tier receipt.
 - Rows may arrive before query settlement without being published.
 - Missing sync/catalogue state leaves a query unsettled until timeout or
   irrecoverable failure.
@@ -3120,26 +3128,26 @@ Coverage labels:
 
 ### E.1 Coverage Summary By Invariant Group
 
-| Group                      | Current status        | Notes                                                                                                                                                                                                                                              |
-| -------------------------- | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| D.1 Identity               | covered for prototype | Public row ids, physical id locality, replica-local physical ids, and one principal writing from multiple nodes are tested.                                                                                                                        |
-| D.2 Transactions           | partial               | Sealing, explicit transactions, edge/global receipts, rejection, idempotence, non-unique global epochs, and monotonic fate are tested. Awaiting-dependencies semantics and audit-grade receipt history are not.                                    |
-| D.3 History/projection     | partial               | Append-only ordinary deletes, rebuild, rejection repair, global ordering, remote pending constraints, and broad repair are tested. Hard delete/truncate and full merge/conflict projection semantics remain partial.                               |
-| D.4 Visibility/snapshots   | partial               | Global epoch and pinned branch snapshot behavior is tested. Full vector snapshots are not implemented/tested.                                                                                                                                      |
-| D.5 Branches               | covered for prototype | Branch overlay/base reads, branch tombstones, rejected overlay fallback, provenance sync, multi-source conflict candidates, and branch policy contexts are tested. Full product branch backing rows and merge commits are not.                     |
-| D.6 Queries/observed facts | partial               | Equality, contains, IN, not-equal, null-present, selected system fields, ordered pages, absence facts, recursive query scopes, policy dependencies, query-scope repair, and predicate serialization are tested. Range and catalogue facts are not. |
-| D.7 Sync                   | partial               | Query-scoped sync, table-vs-query scope, idempotence, public id hydration, reordered fate, scope contraction, active query refresh, and reconnect-shaped repair are tested. Compact reconnect summaries are not.                                   |
-| D.8 Subscriptions          | partial               | Rerun-and-diff, policy dependency diffs, branch checkout diffs, pinned branch stability, pagination, and reconnect-shaped observed subscription recovery are tested. Tier gating and settled state are not.                                        |
-| D.9 Policies               | covered for prototype | Read/write policies, ref-readable policies, recursive acyclic policies, cycle rejection, branch/pinned-base contexts, trusted bypass, and transitive policy read sets are tested. Full policy language and diagnostics are not.                    |
-| D.10 Catalogue/lenses      | partial               | Narrow storage-name rename lenses, ref lenses, system prefix escaping, and index-only compatibility are tested. Catalogue revision graph, migrations directory semantics, inverse lenses, and copy-forward are not.                                |
-| D.11 Authority validation  | partial               | Untrusted bundle rejection, atomic rejection, delete/update validation, branch-context validation, stale row/absence/policy/source read-set checks, exclusive same-row conflict, and repair are tested. Predicate/range validation is not.         |
-| D.12 Conflicts             | partial               | Side APIs expose multi-base and pinned-base conflict candidates and policy-filtered candidates; conflict-aware row reads and resolution transactions are tested. Product metadata shape is not.                                                    |
-| D.13 Errors/diagnostics    | partial               | Rejection codes, transaction info, rejection lists, rejection subscriptions, and detail enrichment are tested. Public error object shape, redaction, and diagnostics are not.                                                                      |
-| D.14 Storage/lowering      | partial               | SQLite current/history tables, physical ids, system prefix escaping, integer-like enum behavior, and rebuild are exercised. `WITHOUT ROWID`, generated indexes, and query plans are not asserted.                                                  |
-| D.15 Files/blobs           | untested              | No file/blob implementation in the prototype.                                                                                                                                                                                                      |
-| D.16 Privacy/encryption    | untested              | No E2EE/encrypted-index implementation in the prototype.                                                                                                                                                                                           |
-| D.17 Harness               | partial               | In-memory SQLite, file-backed durable nodes, multi-runtime local/edge/global tests, duplicate/reordered bundles, and durable reopen are tested. Drop/delay/reconnect protocol and deterministic clock APIs are not.                                |
-| D.18 Tooling/admin         | untested              | Tooling, inspector, admin catalogue publication, and codegen workflows are not implemented in the prototype.                                                                                                                                       |
+| Group                      | Current status        | Notes                                                                                                                                                                                                                                                  |
+| -------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| D.1 Identity               | covered for prototype | Public row ids, physical id locality, replica-local physical ids, and one principal writing from multiple nodes are tested.                                                                                                                            |
+| D.2 Transactions           | partial               | Sealing, explicit transactions, edge/global receipts, rejection, idempotence, non-unique global epochs, and monotonic fate are tested. Awaiting-dependencies semantics and audit-grade receipt history are not.                                        |
+| D.3 History/projection     | partial               | Append-only ordinary deletes, rebuild, rejection repair, global ordering, remote pending constraints, and broad repair are tested. Hard delete/truncate and full merge/conflict projection semantics remain partial.                                   |
+| D.4 Visibility/snapshots   | partial               | Global epoch and pinned branch snapshot behavior is tested. Full vector snapshots are not implemented/tested.                                                                                                                                          |
+| D.5 Branches               | covered for prototype | Branch overlay/base reads, branch tombstones, rejected overlay fallback, provenance sync, multi-source conflict candidates, and branch policy contexts are tested. Full product branch backing rows and merge commits are not.                         |
+| D.6 Queries/observed facts | partial               | Equality, contains, IN, not-equal, null-present, selected system fields, ordered pages, absence facts, recursive query scopes, policy dependencies, query-scope repair, and predicate serialization are tested. Range and catalogue facts are not.     |
+| D.7 Sync                   | partial               | Query-scoped sync, table-vs-query scope, idempotence, public id hydration, reordered fate, scope contraction, active query refresh, and reconnect-shaped repair are tested. Compact reconnect summaries are not.                                       |
+| D.8 Subscriptions          | covered for prototype | Rerun-and-diff, predicate diffs, policy dependency diffs, rejection diffs, branch checkout diffs, pinned branch stability, pagination, reconnect-shaped observed subscription recovery, tier-gated edge/global delivery, and settled state are tested. |
+| D.9 Policies               | covered for prototype | Read/write policies, ref-readable policies, recursive acyclic policies, cycle rejection, branch/pinned-base contexts, trusted bypass, and transitive policy read sets are tested. Full policy language and diagnostics are not.                        |
+| D.10 Catalogue/lenses      | partial               | Narrow storage-name rename lenses, ref lenses, system prefix escaping, and index-only compatibility are tested. Catalogue revision graph, migrations directory semantics, inverse lenses, and copy-forward are not.                                    |
+| D.11 Authority validation  | partial               | Untrusted bundle rejection, atomic rejection, delete/update validation, branch-context validation, stale row/absence/policy/source read-set checks, exclusive same-row conflict, and repair are tested. Predicate/range validation is not.             |
+| D.12 Conflicts             | partial               | Side APIs expose multi-base and pinned-base conflict candidates and policy-filtered candidates; conflict-aware row reads and resolution transactions are tested. Product metadata shape is not.                                                        |
+| D.13 Errors/diagnostics    | partial               | Rejection codes, transaction info, rejection lists, rejection subscriptions, and detail enrichment are tested. Public error object shape, redaction, and diagnostics are not.                                                                          |
+| D.14 Storage/lowering      | partial               | SQLite current/history tables, physical ids, system prefix escaping, integer-like enum behavior, and rebuild are exercised. `WITHOUT ROWID`, generated indexes, and query plans are not asserted.                                                      |
+| D.15 Files/blobs           | untested              | No file/blob implementation in the prototype.                                                                                                                                                                                                          |
+| D.16 Privacy/encryption    | untested              | No E2EE/encrypted-index implementation in the prototype.                                                                                                                                                                                               |
+| D.17 Harness               | partial               | In-memory SQLite, file-backed durable nodes, multi-runtime local/edge/global tests, duplicate/reordered bundles, and durable reopen are tested. Drop/delay/reconnect protocol and deterministic clock APIs are not.                                    |
+| D.18 Tooling/admin         | untested              | Tooling, inspector, admin catalogue publication, and codegen workflows are not implemented in the prototype.                                                                                                                                           |
 
 ### E.2 Test Module Mapping
 
@@ -3314,9 +3322,32 @@ Coverage labels:
 
 #### `subscriptions.rs`
 
+- `rejection_subscription_reports_new_sync_rejections_with_detail_once`: D.8,
+  D.13
+- `restarted_rejection_subscription_baselines_old_rejections_and_reports_later_ones`:
+  D.8, D.13, D.17
+- `rejection_subscription_reports_later_detail_enrichment`: D.8, D.13
 - `subscription_initial_snapshot_matches_query_then_diffs_semantic_rows`: D.8
+- `tiered_subscription_waits_for_required_receipt`: D.8
+- `global_tier_subscription_updates_are_gated_after_initial_delivery`: D.8
+- `tiered_subscription_preserves_branch_inherited_rows`: D.5, D.8
+- `predicate_subscription_diffs_when_row_enters_and_leaves_query`: D.6, D.8
+- `not_equal_subscription_diffs_when_optional_value_appears_and_clears`: D.6,
+  D.8
+- `observed_created_by_not_equal_subscription_removes_deleted_remote_row`: D.6,
+  D.7, D.8
+- `observed_id_not_equal_subscription_removes_deleted_remote_row`: D.6, D.7,
+  D.8
+- `restarted_subscription_uses_persisted_query_read_and_emits_refresh_diff`:
+  D.7, D.8, D.17
+- `restarted_ordered_page_subscription_emits_boundary_refresh_diff`: D.6, D.7,
+  D.8, D.17
+- `contains_subscription_diffs_when_text_starts_and_stops_matching`: D.6, D.8
+- `in_subscription_diffs_when_row_enters_and_leaves_value_set`: D.6, D.8
+- `ordered_page_subscription_replaces_displaced_boundary_row`: D.6, D.8
 - `subscription_removes_child_when_parent_policy_dependency_changes`: D.8,
   D.9
+- `subscription_removes_row_when_visible_transaction_is_rejected`: D.3, D.8
 - `subscription_diffs_when_active_branch_changes`: D.5, D.8
 - `subscription_on_pinned_branch_ignores_later_main_updates_until_overlay_changes`:
   D.5, D.8

--- a/crates/mini-jazz-sqlite/src/lib.rs
+++ b/crates/mini-jazz-sqlite/src/lib.rs
@@ -20,5 +20,5 @@ pub use error::{Error, Result};
 pub use runtime::Runtime;
 pub use schema::SchemaDef;
 pub use storage::Storage;
-pub use subscription::RowsSubscription;
+pub use subscription::{RowsSubscription, SubscriptionTier};
 pub use types::{RejectionInfo, RowDiff, RowView, StorageStats, TransactionInfo};

--- a/crates/mini-jazz-sqlite/src/query.rs
+++ b/crates/mini-jazz-sqlite/src/query.rs
@@ -1,10 +1,11 @@
 use crate::rows::{public_row_id, row_num};
 use crate::schema::{FieldDef, FieldKind, PolicyDef, SchemaDef};
+use crate::subscription::SubscriptionTier;
 use crate::types::RowView;
 use crate::{branch, policy, tx, Result};
 use rusqlite::{params, params_from_iter, Connection};
 use serde_json::Value as JsonValue;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 pub(crate) struct QueryContext<'a> {
     pub(crate) conn: &'a Connection,
@@ -12,6 +13,11 @@ pub(crate) struct QueryContext<'a> {
     pub(crate) branch_num: i64,
     pub(crate) principal: &'a str,
     pub(crate) trusted: bool,
+}
+
+pub(crate) struct TieredRows {
+    pub(crate) rows: Vec<RowView>,
+    pub(crate) settled: bool,
 }
 
 impl QueryContext<'_> {
@@ -24,6 +30,26 @@ impl QueryContext<'_> {
             }
         }
         self.read_rows_from_current(table_name, true)
+    }
+
+    pub(crate) fn read_rows_at_tier(
+        &self,
+        table_name: &str,
+        tier: SubscriptionTier,
+    ) -> Result<TieredRows> {
+        if tier == SubscriptionTier::Local {
+            return Ok(TieredRows {
+                rows: self.read_rows(table_name)?,
+                settled: true,
+            });
+        }
+        let rows = self.read_rows_from_history_at_tier(table_name, tier)?;
+        let rows = self.filter_rows_by_effective_tier_policy(table_name, rows, tier)?;
+        let local_rows = self.read_rows(table_name)?;
+        Ok(TieredRows {
+            settled: rows == local_rows,
+            rows,
+        })
     }
 
     pub(crate) fn read_rows_where_eq(
@@ -849,6 +875,198 @@ impl QueryContext<'_> {
         self.collapse_shadowed_current_rows(rows)
     }
 
+    fn read_rows_from_history_at_tier(
+        &self,
+        table_name: &str,
+        tier: SubscriptionTier,
+    ) -> Result<Vec<RowView>> {
+        let scope_nums = branch::scope_nums(self.conn, self.branch_num)?;
+        let shadowed_main_ids =
+            self.tier_visible_row_ids_for_branches(table_name, tier, &scope_nums)?;
+        let mut rows = self.read_history_rows_at_tier(table_name, tier, &scope_nums, None)?;
+
+        if self.branch_num != 1 && !scope_nums.contains(&1) {
+            let main_epoch_ceiling = branch::base_global_epoch(self.conn, self.branch_num)?;
+            rows.extend(
+                self.read_history_rows_at_tier(table_name, tier, &[1], main_epoch_ceiling)?
+                    .into_iter()
+                    .filter(|(_, row)| !shadowed_main_ids.contains(&row.id)),
+            );
+        }
+
+        self.collapse_shadowed_current_rows(rows)
+    }
+
+    fn read_history_rows_at_tier(
+        &self,
+        table_name: &str,
+        tier: SubscriptionTier,
+        branch_nums: &[i64],
+        max_global_epoch: Option<i64>,
+    ) -> Result<Vec<(i64, RowView)>> {
+        let table = self.schema.table_def(table_name)?;
+        let field_columns = table
+            .fields
+            .iter()
+            .map(|field| crate::schema::quote_ident(&crate::schema::storage_column(field)))
+            .collect::<Vec<_>>();
+        let mut select_columns = vec![
+            "h.j_branch_num".to_owned(),
+            "ids.row_id".to_owned(),
+            "tx.tx_id".to_owned(),
+        ];
+        select_columns.extend(field_columns.iter().map(|column| format!("h.{column}")));
+        select_columns.push("h.j_created_by".to_owned());
+        let branch_placeholders = placeholders(branch_nums.len());
+        let tx_receipt_sql = tier_receipt_sql("tx", tier);
+        let newer_receipt_sql = tier_receipt_sql("newer_tx", tier);
+        let newer_order_sql = tier_newer_order_sql("newer_tx", "tx", tier);
+        let tx_epoch_sql = if max_global_epoch.is_some() {
+            "AND tx.global_epoch IS NOT NULL
+               AND tx.global_epoch <= ?"
+        } else {
+            ""
+        };
+        let newer_epoch_sql = if max_global_epoch.is_some() {
+            "AND newer_tx.global_epoch IS NOT NULL
+                   AND newer_tx.global_epoch <= ?"
+        } else {
+            ""
+        };
+        let sql = format!(
+            "SELECT {}
+             FROM {} h
+             JOIN jazz_row_id ids ON ids.row_num = h.row_num
+             JOIN jazz_tx tx ON tx.tx_num = h.tx_num
+             WHERE h.j_branch_num IN ({branch_placeholders})
+               AND tx.outcome != ?
+               {tx_epoch_sql}
+               AND {tx_receipt_sql}
+               AND h.op != 3
+               AND NOT EXISTS (
+                 SELECT 1
+                 FROM {history_table} newer
+                 JOIN jazz_tx newer_tx ON newer_tx.tx_num = newer.tx_num
+                 WHERE newer.row_num = h.row_num
+                   AND newer.j_branch_num = h.j_branch_num
+                   AND newer_tx.outcome != ?
+                   {newer_epoch_sql}
+                   AND {newer_receipt_sql}
+                   AND {newer_order_sql}
+               )
+             ORDER BY h.j_created_at DESC, h.row_num",
+            select_columns.join(", "),
+            crate::schema::history_table(table_name),
+            history_table = crate::schema::history_table(table_name),
+        );
+        let mut params = branch_nums
+            .iter()
+            .copied()
+            .map(rusqlite::types::Value::Integer)
+            .collect::<Vec<_>>();
+        params.push(rusqlite::types::Value::Integer(tx::OUTCOME_REJECTED));
+        if let Some(max_global_epoch) = max_global_epoch {
+            params.push(rusqlite::types::Value::Integer(max_global_epoch));
+        }
+        params.push(rusqlite::types::Value::Integer(tx::OUTCOME_REJECTED));
+        if let Some(max_global_epoch) = max_global_epoch {
+            params.push(rusqlite::types::Value::Integer(max_global_epoch));
+        }
+        let mut stmt = self.conn.prepare(&sql)?;
+        let row_width = 3 + table.fields.len() + 1;
+        let rows = stmt.query_map(params_from_iter(params.iter()), |row| {
+            (0..row_width)
+                .map(|idx| row.get::<_, rusqlite::types::Value>(idx))
+                .collect::<rusqlite::Result<Vec<_>>>()
+        })?;
+        rows.map(|row| {
+            let mut row = row?;
+            let branch_num = branch_num_from_row(&mut row)?;
+            Ok((branch_num, row_to_view(self.conn, table_name, table, row)?))
+        })
+        .collect()
+    }
+
+    fn tier_visible_row_ids_for_branches(
+        &self,
+        table_name: &str,
+        tier: SubscriptionTier,
+        branch_nums: &[i64],
+    ) -> Result<BTreeSet<String>> {
+        let branch_placeholders = placeholders(branch_nums.len());
+        let tx_receipt_sql = tier_receipt_sql("tx", tier);
+        let sql = format!(
+            "SELECT DISTINCT ids.row_id
+             FROM {} h
+             JOIN jazz_row_id ids ON ids.row_num = h.row_num
+             JOIN jazz_tx tx ON tx.tx_num = h.tx_num
+             WHERE h.j_branch_num IN ({branch_placeholders})
+               AND tx.outcome != ?
+               AND {tx_receipt_sql}
+             ORDER BY ids.row_id",
+            crate::schema::history_table(table_name),
+        );
+        let mut params = branch_nums
+            .iter()
+            .copied()
+            .map(rusqlite::types::Value::Integer)
+            .collect::<Vec<_>>();
+        params.push(rusqlite::types::Value::Integer(tx::OUTCOME_REJECTED));
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt.query_map(params_from_iter(params.iter()), |row| {
+            row.get::<_, String>(0)
+        })?;
+        rows.collect::<std::result::Result<BTreeSet<_>, _>>()
+            .map_err(Into::into)
+    }
+
+    fn filter_rows_by_effective_tier_policy(
+        &self,
+        table_name: &str,
+        rows: Vec<RowView>,
+        tier: SubscriptionTier,
+    ) -> Result<Vec<RowView>> {
+        if self.trusted {
+            return Ok(rows);
+        }
+        let table = self.schema.table_def(table_name)?;
+        match &table.read_policy {
+            PolicyDef::AllowAll => Ok(rows),
+            PolicyDef::CreatedByPrincipal => Ok(rows
+                .into_iter()
+                .filter(|row| row.created_by == self.principal)
+                .collect()),
+            PolicyDef::RefReadable { field } => {
+                let field = table
+                    .fields
+                    .iter()
+                    .find(|candidate| candidate.name == *field)
+                    .ok_or_else(|| crate::Error::new(format!("unknown policy ref {field}")))?;
+                let FieldKind::Ref {
+                    table: parent_table,
+                } = &field.kind
+                else {
+                    return Ok(Vec::new());
+                };
+                let visible_parent_ids = self
+                    .read_rows_at_tier(parent_table, tier)?
+                    .rows
+                    .into_iter()
+                    .map(|row| row.id)
+                    .collect::<std::collections::BTreeSet<_>>();
+                Ok(rows
+                    .into_iter()
+                    .filter(|row| {
+                        row.values
+                            .get(&field.name)
+                            .and_then(JsonValue::as_str)
+                            .is_some_and(|parent_id| visible_parent_ids.contains(parent_id))
+                    })
+                    .collect())
+            }
+        }
+    }
+
     fn collapse_shadowed_current_rows(&self, rows: Vec<(i64, RowView)>) -> Result<Vec<RowView>> {
         let depths = branch::scope_depths(self.conn, self.branch_num)?;
         let mut min_depth_by_row: BTreeMap<String, i64> = BTreeMap::new();
@@ -991,6 +1209,41 @@ fn branch_num_from_row(raw: &mut Vec<rusqlite::types::Value>) -> Result<i64> {
 
 fn placeholders(count: usize) -> String {
     (0..count).map(|_| "?").collect::<Vec<_>>().join(", ")
+}
+
+fn tier_receipt_sql(tx_alias: &str, tier: SubscriptionTier) -> String {
+    let Some(min_tier) = (match tier {
+        SubscriptionTier::Local => None,
+        SubscriptionTier::Edge => Some(tx::TIER_EDGE),
+        SubscriptionTier::Global => Some(tx::TIER_GLOBAL),
+    }) else {
+        return "1 = 1".to_owned();
+    };
+    format!(
+        "EXISTS (
+           SELECT 1
+           FROM jazz_tx_receipt receipt
+           WHERE receipt.tx_num = {tx_alias}.tx_num
+             AND receipt.tier >= {min_tier}
+         )"
+    )
+}
+
+fn tier_newer_order_sql(
+    newer_tx_alias: &str,
+    current_tx_alias: &str,
+    tier: SubscriptionTier,
+) -> String {
+    match tier {
+        SubscriptionTier::Global => format!(
+            "({newer_tx_alias}.global_epoch > {current_tx_alias}.global_epoch
+              OR ({newer_tx_alias}.global_epoch = {current_tx_alias}.global_epoch
+                  AND {newer_tx_alias}.tx_num > {current_tx_alias}.tx_num))"
+        ),
+        SubscriptionTier::Local | SubscriptionTier::Edge => {
+            format!("{newer_tx_alias}.tx_num > {current_tx_alias}.tx_num")
+        }
+    }
 }
 
 pub(crate) fn sql_value_to_json(

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -1,6 +1,8 @@
 use crate::rows::{ensure_row_id, public_row_id, row_num};
 use crate::schema::{FieldDef, FieldKind, PolicyDef, SchemaDef};
-use crate::subscription::{RejectionSubscription, RowsSubscription, RowsSubscriptionQuery};
+use crate::subscription::{
+    RejectionSubscription, RowsSubscription, RowsSubscriptionQuery, SubscriptionTier,
+};
 use crate::sync::{
     BranchRecord, Bundle, HistoryRecord, QueryReadRecord, ReadRecord, TxRecord,
     BUNDLE_PROTOCOL_VERSION,
@@ -1677,6 +1679,17 @@ impl Runtime {
         self.query_context().read_rows(table_name)
     }
 
+    pub fn read_rows_at_tier(
+        &self,
+        table_name: &str,
+        tier: SubscriptionTier,
+    ) -> Result<Vec<RowView>> {
+        Ok(self
+            .query_context()
+            .read_rows_at_tier(table_name, tier)?
+            .rows)
+    }
+
     pub fn read_rows_require_ref(
         &self,
         table_name: &str,
@@ -2058,6 +2071,20 @@ impl Runtime {
         ))
     }
 
+    pub fn subscribe_rows_at_tier(
+        &self,
+        table_name: &str,
+        tier: SubscriptionTier,
+    ) -> Result<RowsSubscription> {
+        let tiered = self.query_context().read_rows_at_tier(table_name, tier)?;
+        Ok(RowsSubscription::new_at_tier(
+            table_name,
+            tier,
+            tiered.settled,
+            tiered.rows,
+        ))
+    }
+
     pub fn subscribe_rejections(&self) -> Result<RejectionSubscription> {
         Ok(RejectionSubscription::new(self.rejected_transactions()?))
     }
@@ -2283,8 +2310,15 @@ impl Runtime {
         &self,
         subscription: &mut RowsSubscription,
     ) -> Result<Vec<crate::types::RowDiff>> {
+        let mut settled = true;
         let next_rows = match &subscription.query {
-            RowsSubscriptionQuery::Table { table } => self.read_rows(table)?,
+            RowsSubscriptionQuery::Table { table } => {
+                let tiered = self
+                    .query_context()
+                    .read_rows_at_tier(table, subscription.tier)?;
+                settled = tiered.settled;
+                tiered.rows
+            }
             RowsSubscriptionQuery::Predicate(query) if query.op == "eq" => {
                 self.read_rows_where_eq(&query.table, &query.field, query.value.clone())?
             }
@@ -2333,6 +2367,7 @@ impl Runtime {
                 )));
             }
         };
+        subscription.settled = settled;
         Ok(subscription.replace_with_diff(next_rows))
     }
 

--- a/crates/mini-jazz-sqlite/src/subscription.rs
+++ b/crates/mini-jazz-sqlite/src/subscription.rs
@@ -3,9 +3,18 @@ use crate::types::{RejectionInfo, RowDiff, RowView};
 use serde_json::Value as JsonValue;
 use std::collections::BTreeMap;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SubscriptionTier {
+    Local,
+    Edge,
+    Global,
+}
+
 #[derive(Clone, Debug)]
 pub struct RowsSubscription {
     pub(crate) query: RowsSubscriptionQuery,
+    pub(crate) tier: SubscriptionTier,
+    pub(crate) settled: bool,
     pub(crate) last_rows: Vec<RowView>,
 }
 
@@ -22,21 +31,44 @@ pub(crate) enum RowsSubscriptionQuery {
 
 impl RowsSubscription {
     pub(crate) fn new(table: &str, rows: Vec<RowView>) -> Self {
+        Self::new_query(
+            RowsSubscriptionQuery::Table {
+                table: table.to_owned(),
+            },
+            rows,
+        )
+    }
+
+    pub(crate) fn new_at_tier(
+        table: &str,
+        tier: SubscriptionTier,
+        settled: bool,
+        rows: Vec<RowView>,
+    ) -> Self {
         Self {
             query: RowsSubscriptionQuery::Table {
                 table: table.to_owned(),
             },
+            tier,
+            settled,
+            last_rows: rows,
+        }
+    }
+
+    fn new_query(query: RowsSubscriptionQuery, rows: Vec<RowView>) -> Self {
+        Self {
+            query,
+            tier: SubscriptionTier::Local,
+            settled: true,
             last_rows: rows,
         }
     }
 
     pub(crate) fn where_eq(table: &str, field: &str, value: JsonValue, rows: Vec<RowView>) -> Self {
-        Self {
-            query: RowsSubscriptionQuery::Predicate(QueryPredicateRecord::new(
-                table, field, "eq", value,
-            )),
-            last_rows: rows,
-        }
+        Self::new_query(
+            RowsSubscriptionQuery::Predicate(QueryPredicateRecord::new(table, field, "eq", value)),
+            rows,
+        )
     }
 
     pub(crate) fn where_contains(
@@ -45,15 +77,15 @@ impl RowsSubscription {
         needle: &str,
         rows: Vec<RowView>,
     ) -> Self {
-        Self {
-            query: RowsSubscriptionQuery::Predicate(QueryPredicateRecord::new(
+        Self::new_query(
+            RowsSubscriptionQuery::Predicate(QueryPredicateRecord::new(
                 table,
                 field,
                 "contains",
                 JsonValue::String(needle.to_owned()),
             )),
-            last_rows: rows,
-        }
+            rows,
+        )
     }
 
     pub(crate) fn where_in(
@@ -62,24 +94,22 @@ impl RowsSubscription {
         values: Vec<JsonValue>,
         rows: Vec<RowView>,
     ) -> Self {
-        Self {
-            query: RowsSubscriptionQuery::Predicate(QueryPredicateRecord::new(
+        Self::new_query(
+            RowsSubscriptionQuery::Predicate(QueryPredicateRecord::new(
                 table,
                 field,
                 "in",
                 JsonValue::Array(values),
             )),
-            last_rows: rows,
-        }
+            rows,
+        )
     }
 
     pub(crate) fn where_ne(table: &str, field: &str, value: JsonValue, rows: Vec<RowView>) -> Self {
-        Self {
-            query: RowsSubscriptionQuery::Predicate(QueryPredicateRecord::new(
-                table, field, "ne", value,
-            )),
-            last_rows: rows,
-        }
+        Self::new_query(
+            RowsSubscriptionQuery::Predicate(QueryPredicateRecord::new(table, field, "ne", value)),
+            rows,
+        )
     }
 
     pub(crate) fn where_recursive_refs(
@@ -88,15 +118,15 @@ impl RowsSubscription {
         parent_field: &str,
         rows: Vec<RowView>,
     ) -> Self {
-        Self {
-            query: RowsSubscriptionQuery::Predicate(QueryPredicateRecord::new(
+        Self::new_query(
+            RowsSubscriptionQuery::Predicate(QueryPredicateRecord::new(
                 table,
                 parent_field,
                 "recursive_refs",
                 JsonValue::String(root_id.to_owned()),
             )),
-            last_rows: rows,
-        }
+            rows,
+        )
     }
 
     pub(crate) fn where_eq_top_created_at_desc(
@@ -106,8 +136,8 @@ impl RowsSubscription {
         limit: usize,
         rows: Vec<RowView>,
     ) -> Self {
-        Self {
-            query: RowsSubscriptionQuery::Predicate(QueryPredicateRecord::new(
+        Self::new_query(
+            RowsSubscriptionQuery::Predicate(QueryPredicateRecord::new(
                 table,
                 field,
                 "eq_top_created_at_desc",
@@ -116,12 +146,20 @@ impl RowsSubscription {
                     "limit": limit,
                 }),
             )),
-            last_rows: rows,
-        }
+            rows,
+        )
     }
 
     pub fn initial_rows(&self) -> &[RowView] {
         &self.last_rows
+    }
+
+    pub fn tier(&self) -> SubscriptionTier {
+        self.tier
+    }
+
+    pub fn is_settled(&self) -> bool {
+        self.settled
     }
 
     pub(crate) fn replace_with_diff(&mut self, next_rows: Vec<RowView>) -> Vec<RowDiff> {

--- a/crates/mini-jazz-sqlite/tests/whole_system.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system.rs
@@ -1,4 +1,6 @@
-use mini_jazz_sqlite::{RejectionInfo, RowDiff, Runtime, SchemaDef, Storage};
+use mini_jazz_sqlite::{
+    RejectionInfo, RowDiff, RowsSubscription, Runtime, SchemaDef, Storage, SubscriptionTier,
+};
 use serde_json::json;
 use std::collections::BTreeMap;
 use tempfile::tempdir;

--- a/crates/mini-jazz-sqlite/tests/whole_system/subscriptions.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/subscriptions.rs
@@ -165,6 +165,45 @@ fn rejection_subscription_reports_later_detail_enrichment() {
     );
 }
 
+fn open_tasks_runtime(node_id: &str) -> Runtime {
+    Runtime::open_with_schema(Storage::Memory, node_id, "alice", support::tasks_schema()).unwrap()
+}
+
+fn insert_task(runtime: &mut Runtime, id: &str, title: &str) -> String {
+    runtime
+        .insert_row(
+            "tasks",
+            id,
+            BTreeMap::from([
+                ("title".to_owned(), json!(title)),
+                ("done".to_owned(), json!(false)),
+            ]),
+        )
+        .unwrap()
+}
+
+fn update_task_title(runtime: &mut Runtime, id: &str, title: &str) -> String {
+    runtime
+        .update_row(
+            "tasks",
+            id,
+            BTreeMap::from([("title".to_owned(), json!(title))]),
+        )
+        .unwrap()
+}
+
+fn assert_no_diff_and_unsettled(runtime: &Runtime, subscription: &mut RowsSubscription) {
+    assert!(runtime.poll_subscription(subscription).unwrap().is_empty());
+    assert!(!subscription.is_settled());
+}
+
+fn assert_added_task(diffs: &[RowDiff], id: &str) {
+    assert!(
+        matches!(diffs, [RowDiff::Added(row)] if row.id == id),
+        "expected one added diff for {id}, got {diffs:?}"
+    );
+}
+
 #[test]
 fn subscription_initial_snapshot_matches_query_then_diffs_semantic_rows() {
     let schema = SchemaDef::new().table("tasks", |table| {
@@ -212,6 +251,155 @@ fn subscription_initial_snapshot_matches_query_then_diffs_semantic_rows() {
     );
     let diffs = alice.poll_subscription(&mut subscription).unwrap();
     assert!(matches!(&diffs[..], [RowDiff::Removed(row)] if row.id == "task-2"));
+}
+
+#[test]
+fn tiered_subscription_waits_for_required_receipt() {
+    let mut edge = open_tasks_runtime("edge-node");
+    let edge_tx = insert_task(&mut edge, "task-edge", "Edge settled");
+
+    assert_eq!(edge.read_rows("tasks").unwrap().len(), 1);
+    assert!(edge
+        .read_rows_at_tier("tasks", SubscriptionTier::Edge)
+        .unwrap()
+        .is_empty());
+
+    let mut edge_subscription = edge
+        .subscribe_rows_at_tier("tasks", SubscriptionTier::Edge)
+        .unwrap();
+    assert_eq!(edge_subscription.tier(), SubscriptionTier::Edge);
+    assert!(edge_subscription.initial_rows().is_empty());
+    assert!(!edge_subscription.is_settled());
+    assert_no_diff_and_unsettled(&edge, &mut edge_subscription);
+
+    edge.accept_transaction_at_edge(&edge_tx).unwrap();
+    let diffs = edge.poll_subscription(&mut edge_subscription).unwrap();
+
+    assert_added_task(&diffs, "task-edge");
+    assert!(edge_subscription.is_settled());
+    let info = edge.transaction_info(&edge_tx).unwrap();
+    assert_eq!(info.receipt_tiers, vec!["edge".to_owned()]);
+
+    let mut global = open_tasks_runtime("global-node");
+    let global_tx = insert_task(&mut global, "task-global", "Global settled");
+    let global_snapshot = global
+        .read_rows_at_tier("tasks", SubscriptionTier::Global)
+        .unwrap();
+    let mut global_subscription = global
+        .subscribe_rows_at_tier("tasks", SubscriptionTier::Global)
+        .unwrap();
+
+    assert_eq!(global_subscription.initial_rows(), global_snapshot);
+    assert!(global_subscription.initial_rows().is_empty());
+    assert!(!global_subscription.is_settled());
+
+    global.accept_transaction_at_edge(&global_tx).unwrap();
+    assert_no_diff_and_unsettled(&global, &mut global_subscription);
+    assert!(global
+        .read_rows_at_tier("tasks", SubscriptionTier::Global)
+        .unwrap()
+        .is_empty());
+
+    global.accept_transaction_at_global(&global_tx, 1).unwrap();
+    let diffs = global.poll_subscription(&mut global_subscription).unwrap();
+
+    assert_added_task(&diffs, "task-global");
+    assert!(global_subscription.is_settled());
+    assert_eq!(
+        global_subscription.initial_rows(),
+        global
+            .read_rows_at_tier("tasks", SubscriptionTier::Global)
+            .unwrap()
+    );
+}
+
+#[test]
+fn global_tier_subscription_updates_are_gated_after_initial_delivery() {
+    let mut alice = open_tasks_runtime("alice-node");
+
+    let insert_tx = insert_task(&mut alice, "task-1", "Base");
+    alice.accept_transaction_at_global(&insert_tx, 1).unwrap();
+    let mut subscription = alice
+        .subscribe_rows_at_tier("tasks", SubscriptionTier::Global)
+        .unwrap();
+    assert_eq!(subscription.initial_rows().len(), 1);
+    assert_eq!(
+        subscription.initial_rows()[0].values["title"],
+        json!("Base")
+    );
+    assert!(subscription.is_settled());
+
+    let update_tx = update_task_title(&mut alice, "task-1", "Pending global");
+    assert_eq!(
+        alice.read_rows("tasks").unwrap()[0].values["title"],
+        json!("Pending global")
+    );
+    assert_eq!(
+        alice
+            .read_rows_at_tier("tasks", SubscriptionTier::Global)
+            .unwrap()[0]
+            .values["title"],
+        json!("Base")
+    );
+    assert_no_diff_and_unsettled(&alice, &mut subscription);
+    assert_eq!(
+        subscription.initial_rows()[0].values["title"],
+        json!("Base")
+    );
+
+    alice.accept_transaction_at_edge(&update_tx).unwrap();
+    assert_no_diff_and_unsettled(&alice, &mut subscription);
+
+    alice.accept_transaction_at_global(&update_tx, 2).unwrap();
+    let diffs = alice.poll_subscription(&mut subscription).unwrap();
+
+    assert!(matches!(
+        &diffs[..],
+        [RowDiff::Updated { before, after }]
+            if before.values["title"] == json!("Base")
+                && after.values["title"] == json!("Pending global")
+    ));
+    assert!(subscription.is_settled());
+}
+
+#[test]
+fn tiered_subscription_preserves_branch_inherited_rows() {
+    let mut alice = open_tasks_runtime("alice-node");
+
+    let main_tx = insert_task(&mut alice, "task-main", "Main");
+    alice.accept_transaction_at_global(&main_tx, 1).unwrap();
+    alice.create_branch("draft", None).unwrap();
+    alice.checkout_branch("draft").unwrap();
+
+    let mut inherited_subscription = alice
+        .subscribe_rows_at_tier("tasks", SubscriptionTier::Global)
+        .unwrap();
+    assert_eq!(inherited_subscription.initial_rows().len(), 1);
+    assert_eq!(inherited_subscription.initial_rows()[0].id, "task-main");
+    assert!(inherited_subscription.is_settled());
+    assert!(alice
+        .poll_subscription(&mut inherited_subscription)
+        .unwrap()
+        .is_empty());
+
+    alice.checkout_branch("main").unwrap();
+    let base_tx = insert_task(&mut alice, "task-base", "Pinned base");
+    alice.accept_transaction_at_global(&base_tx, 2).unwrap();
+    alice.create_branch("pinned", Some(2)).unwrap();
+    alice.checkout_branch("pinned").unwrap();
+
+    let pinned_subscription = alice
+        .subscribe_rows_at_tier("tasks", SubscriptionTier::Global)
+        .unwrap();
+    assert_eq!(
+        pinned_subscription
+            .initial_rows()
+            .iter()
+            .map(|row| row.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["task-base", "task-main"]
+    );
+    assert!(pinned_subscription.is_settled());
 }
 
 #[test]


### PR DESCRIPTION
## What

Adds prototype coverage for the D.8 subscription tier invariants in the mini SQLite runtime:

- introduce `SubscriptionTier` and tier-aware row reads/subscriptions
- gate edge/global subscription delivery on the required durability receipts
- expose subscription settled state while higher-tier views lag newer local state
- add whole-system coverage for initial tier delivery and post-initial update gating
- update `SPEC.md` invariants and subscription traceability entries

## Validation

- `cargo test -p mini-jazz-sqlite`
- `git diff --check HEAD~1..HEAD`
- pre-commit hook: clippy, oxfmt, rustfmt