### PR TITLE
Add awaiting dependency authority state

### DIFF
--- a/crates/mini-jazz-sqlite/SPEC.md
+++ b/crates/mini-jazz-sqlite/SPEC.md
@@ -508,11 +508,13 @@ trusted peer does not know the authenticated user for a pending mergeable
 transaction, it must reject or await auth context rather than infer authority
 from history rows.
 
-Exclusive transactions require final fate from the global authority. If an edge
-or other intermediary forwards an exclusive transaction instead of deciding it
-locally, it must forward enough authenticated session context for the global
-authority to evaluate the transaction under the same user, admin/trust role, and
-policy context as the initiating session.
+Exclusive transactions require final fate from the global authority. Edges and
+other intermediaries forward them upstream immediately instead of waiting for
+local policy dependencies. Until global fate returns, intermediaries may store
+the pending exclusive transaction and its history for retry, but ordinary reads
+must not show it as accepted state. The forwarded transaction must carry enough
+authenticated session context for the global authority to evaluate it under the
+same user, admin/trust role, and policy context as the initiating session.
 
 The Rust prototype currently carries only an optional forwarded authenticated
 user for this authority validation path. Forwarding rewrites only the selected
@@ -839,6 +841,12 @@ global
 For v0, the hot transaction row may store the current outcome and global epoch
 mutably. Rejection details should live in a side table keyed by transaction id
 or physical transaction id, not as a wide field on the hot transaction row.
+The Rust prototype currently represents `awaiting_deps` as a side-table marker
+while leaving the hot outcome `pending`; this keeps outcome ordering simple
+while still making dependency waits durable and queryable.
+That marker must persist the auth user context that the authority used for the
+original validation attempt. Dependency arrival must not require the client to
+resend the original write bundle.
 
 The local write path:
 
@@ -862,12 +870,29 @@ public transaction id.
 Authority rejection keeps the transaction and history rows. Visibility and
 projection repair make rejected versions disappear from ordinary reads.
 
-An edge that cannot validate a transaction because required policy-influencing
-facts are missing should mark it `awaiting_deps`, request or subscribe to the
-missing facts, and re-evaluate after they arrive. `awaiting_deps` is not
-acceptance and must not make an authority-accepted version visible. Globally
-consistent exclusive transactions must always receive final `accepted` or
-`rejected` fate from the global authority.
+An edge that cannot validate a mergeable transaction because required
+policy-influencing facts are missing should mark it `awaiting_deps`, request or
+subscribe to the missing facts, and re-evaluate after they arrive.
+`awaiting_deps` is not acceptance and must not make an authority-accepted
+version visible. Globally consistent exclusive transactions do not use
+`awaiting_deps` for ordinary policy-dependency cache misses; they are forwarded
+to the global authority and must always receive final `accepted` or `rejected`
+fate there.
+
+An `awaiting_deps` transaction keeps its public transaction id and history rows.
+It is not reported as rejected, and ordinary current projections must exclude
+its row versions. When the missing facts arrive, the same sealed transaction is
+re-evaluated. If validation succeeds, the edge clears the awaiting marker and
+accepts/receipts the original mergeable transaction. If validation fails for a
+reason other than missing dependencies, including a dependency row arriving but
+still not being readable by the transaction's auth user, the edge rejects the
+original mergeable transaction.
+
+When a previously missing policy dependency becomes visible, the authority
+should repair any stored observed-read facts that were recorded as missing so
+future sync exports describe the dependency version that allowed validation to
+complete. This repair enriches the read set for the same transaction; it does
+not create a replacement transaction.
 
 Edge acceptance of mergeable transactions sets the transaction outcome to
 accepted and records an edge receipt without a global epoch. Global acceptance
@@ -892,6 +917,10 @@ Open issues:
 - exact durability receipt layout
 - explicit fate partial order and merge rules for all incoming-sync cases
 - timeout/retry behavior for transactions that remain `awaiting_deps`
+- dependency request/subscription protocol for proactively fetching missing
+  policy facts
+- forwarded exclusive transaction retry, offline storage, auth-context
+  preservation, and global fate propagation
 - audit-grade append-only fate/receipt history
 
 ## 12. Row History And Current Projection
@@ -1991,10 +2020,20 @@ CREATE TABLE jazz_tx_rejection (
   code INTEGER NOT NULL,
   detail_blob BLOB NOT NULL
 );
+
+CREATE TABLE jazz_tx_awaiting_dependency (
+  tx_num INTEGER PRIMARY KEY,
+  auth_user TEXT NOT NULL,
+  detail_blob BLOB NOT NULL,
+  updated_at INTEGER NOT NULL
+);
 ```
 
 This sketch encodes the v2 split between outcome, durability receipt, and
-rejection detail.
+rejection detail. `jazz_tx_awaiting_dependency` is the selected prototype
+lowering for `awaiting_deps`: the hot transaction outcome remains `pending`,
+while the side table records the durable wait reason and the user context needed
+to re-run authority policy validation after missing facts arrive.
 
 `global_epoch` is intentionally not unique. Multiple transactions may share one
 authority epoch. Indexes should support lookup/order by `(global_epoch, tx_num)`
@@ -2782,6 +2821,8 @@ feature exists.
 - Edge-accepted mergeable transactions produce replayable receipt state.
 - Edge-accepted mergeable transactions are accepted and visible without a
   global epoch.
+- Awaiting-dependency state is durable, not visible in ordinary current reads,
+  and clears on successful revalidation of the same public transaction id.
 - Later global acceptance enriches the same public transaction id.
 - Rejected outcome is terminal for ordinary visibility.
 - Stale incoming fate cannot downgrade accepted/global or rejected state.
@@ -3447,8 +3488,8 @@ The largest gaps between Appendix D and the current prototype tests are:
   rejection detail storage outside the hot transaction row
 - explicit wait behavior for exclusive transactions at local, edge, and global
   tiers
-- awaiting-dependencies state for edges that need missing policy facts before
-  deciding or forwarding transactions
+- forwarded exclusive transaction retry/offline transport and proactive
+  dependency request/subscription mechanics for mergeable `awaiting_deps`
 - compact reconnect summaries and active query-descriptor replay protocol
 - range and catalogue observed facts
 - cache eviction policy for retained out-of-scope rows

--- a/crates/mini-jazz-sqlite/src/projection.rs
+++ b/crates/mini-jazz-sqlite/src/projection.rs
@@ -45,6 +45,12 @@ fn rebuild_table(
          FROM {} h
          JOIN jazz_tx tx ON tx.tx_num = h.tx_num
          WHERE tx.outcome != ?
+           AND NOT (tx.outcome = ? AND tx.conflict_mode = ?)
+           AND NOT EXISTS (
+             SELECT 1
+             FROM jazz_tx_awaiting_dependency awaiting
+             WHERE awaiting.tx_num = tx.tx_num
+           )
          ORDER BY h.row_num,
                   h.j_branch_num,
                   CASE
@@ -62,6 +68,8 @@ fn rebuild_table(
     let rows = stmt.query_map(
         params![
             tx::OUTCOME_REJECTED,
+            tx::OUTCOME_PENDING,
+            tx::MODE_EXCLUSIVE,
             tx::OUTCOME_PENDING,
             local_node_num,
             tx::OUTCOME_ACCEPTED

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -24,6 +24,12 @@ pub struct Runtime {
     branch_num: i64,
 }
 
+struct AwaitingDependencyTx {
+    tx_num: i64,
+    tx_id: String,
+    auth_user: String,
+}
+
 pub const ADMIN_SYSTEM_USER: &str = "@system/admin";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -330,16 +336,34 @@ impl Runtime {
         auth_user: &str,
     ) -> Result<Bundle> {
         let mut bundle = self.export_table_history(table_name)?;
+        if !bundle.history.iter().any(|record| record.tx_id == tx_id) {
+            let tx_num = tx::tx_num(&self.conn, tx_id)?;
+            let history = history_records_for_tx(&self.conn, &self.schema, tx_num, tx_id)?
+                .into_iter()
+                .filter(|record| record.table == table_name)
+                .collect::<Vec<_>>();
+            if history.is_empty() {
+                return Err(crate::Error::new(format!(
+                    "transaction {tx_id} has no exported history"
+                )));
+            }
+            let reads = export_reads_for_history(&self.conn, &history)?;
+            let mut branches = export_branch_records_for_history(&self.conn, &history)?;
+            include_branch_record(&self.conn, &mut branches, self.branch_num)?;
+            bundle = make_bundle(
+                &self.schema,
+                branches,
+                export_txs(&self.conn)?,
+                reads,
+                Vec::new(),
+                history,
+            );
+        }
         let tx_record = bundle
             .txs
             .iter_mut()
             .find(|record| record.tx_id == tx_id)
             .ok_or_else(|| crate::Error::new(format!("transaction {tx_id} is not in bundle")))?;
-        if !bundle.history.iter().any(|record| record.tx_id == tx_id) {
-            return Err(crate::Error::new(format!(
-                "transaction {tx_id} has no exported history"
-            )));
-        }
         tx_record.conflict_mode = tx::MODE_EXCLUSIVE;
         tx_record.outcome = tx::OUTCOME_PENDING;
         tx_record.global_epoch = None;
@@ -597,6 +621,7 @@ impl Runtime {
             Self::apply_query_scope_repair(&schema, &db, query_read)?;
         }
         db.commit()?;
+        self.revalidate_awaiting_dependencies()?;
         Ok(())
     }
 
@@ -774,6 +799,23 @@ impl Runtime {
         self.apply_untrusted_bundle_with_auth_user(bundle, Some(user))
     }
 
+    pub fn stage_exclusive_bundle_for_forwarding(&mut self, bundle: &Bundle) -> Result<()> {
+        for tx_record in &bundle.txs {
+            if tx_record.conflict_mode == tx::MODE_EXCLUSIVE
+                && tx_record.outcome == tx::OUTCOME_PENDING
+                && tx_record.auth_user.is_none()
+            {
+                return Err(crate::Error::new(format!(
+                    "exclusive transaction {} is missing forwarded auth user",
+                    tx_record.tx_id
+                )));
+            }
+        }
+        self.apply_bundle_inner(bundle, false)?;
+        projection::rebuild(&self.conn, &self.schema, self.node_num)?;
+        Ok(())
+    }
+
     fn apply_untrusted_bundle_with_auth_user(
         &mut self,
         bundle: &Bundle,
@@ -793,6 +835,7 @@ impl Runtime {
             .collect::<BTreeMap<_, _>>();
         self.apply_bundle_inner(bundle, false)?;
         let mut rejected = BTreeSet::new();
+        let mut exclusive_to_accept = BTreeSet::new();
         for tx_id in stale_exclusive_tx_ids {
             self.reject_transaction_with_detail(
                 &tx_id,
@@ -854,22 +897,126 @@ impl Runtime {
                 rejected.insert(record.tx_id.clone());
                 continue;
             }
+            let auth_user = auth_user.expect("auth user checked above");
             let allowed = write_allowed_for_history_record(
                 &self.conn,
                 &self.schema,
                 table,
                 row_num,
                 record,
-                auth_user,
+                Some(auth_user),
             )?;
             if !allowed {
                 let detail =
                     policy_denial_detail_for_history_record(&self.conn, table, record, tx_num)?;
+                if is_policy_dependency_unavailable(&detail) {
+                    if conflict_mode == tx::MODE_EXCLUSIVE {
+                        self.reject_transaction_with_detail(
+                            &record.tx_id,
+                            "policy_denied",
+                            detail,
+                        )?;
+                        rejected.insert(record.tx_id.clone());
+                        continue;
+                    }
+                    mark_transaction_awaiting_dependency(&self.conn, tx_num, auth_user, &detail)?;
+                    remove_current_for_awaiting_dependency(&self.conn, record, row_num)?;
+                    rejected.insert(record.tx_id.clone());
+                    continue;
+                }
                 self.reject_transaction_with_detail(&record.tx_id, "policy_denied", detail)?;
                 rejected.insert(record.tx_id.clone());
+            } else {
+                clear_transaction_awaiting_dependency(&self.conn, tx_num)?;
+                if conflict_mode == tx::MODE_EXCLUSIVE {
+                    exclusive_to_accept.insert(record.tx_id.clone());
+                }
             }
         }
-        if !rejected.is_empty() {
+        let mut accepted_exclusive = false;
+        for tx_id in exclusive_to_accept {
+            let tx_num = tx::tx_num(&self.conn, &tx_id)?;
+            if !rejected.contains(&tx_id) && tx_outcome(&self.conn, tx_num)? == tx::OUTCOME_PENDING
+            {
+                tx::accept_global(&self.conn, &tx_id, next_global_epoch(&self.conn)?)?;
+                accepted_exclusive = true;
+            }
+        }
+        if !rejected.is_empty() || accepted_exclusive {
+            projection::rebuild(&self.conn, &self.schema, self.node_num)?;
+        }
+        self.revalidate_awaiting_dependencies()?;
+        Ok(())
+    }
+
+    fn revalidate_awaiting_dependencies(&mut self) -> Result<()> {
+        let awaiting = awaiting_dependency_transactions(&self.conn)?;
+        let mut changed = false;
+        for awaiting in awaiting {
+            if tx_outcome(&self.conn, awaiting.tx_num)? != tx::OUTCOME_PENDING {
+                clear_transaction_awaiting_dependency(&self.conn, awaiting.tx_num)?;
+                changed = true;
+                continue;
+            }
+            let records =
+                history_records_for_tx(&self.conn, &self.schema, awaiting.tx_num, &awaiting.tx_id)?;
+            if records.is_empty() {
+                continue;
+            }
+            let mut still_waiting = None;
+            let mut denied = None;
+            for record in records {
+                let table = self.schema.table_def(&record.table)?;
+                let row_num = row_num(&self.conn, &record.row_id)?;
+                let allowed = write_allowed_for_history_record(
+                    &self.conn,
+                    &self.schema,
+                    table,
+                    row_num,
+                    &record,
+                    Some(awaiting.auth_user.as_str()),
+                )?;
+                if !allowed {
+                    let detail = policy_denial_detail_for_history_record(
+                        &self.conn,
+                        table,
+                        &record,
+                        awaiting.tx_num,
+                    )?;
+                    if is_policy_dependency_unavailable(&detail) {
+                        still_waiting = Some(detail);
+                    } else {
+                        denied = Some(detail);
+                    }
+                    break;
+                }
+            }
+            if let Some(detail) = denied {
+                clear_transaction_awaiting_dependency(&self.conn, awaiting.tx_num)?;
+                tx::reject_with_detail_json(
+                    &self.conn,
+                    &awaiting.tx_id,
+                    "policy_denied",
+                    &serde_json::to_string(&detail)
+                        .map_err(|err| crate::Error::new(err.to_string()))?,
+                )?;
+                changed = true;
+            } else if let Some(detail) = still_waiting {
+                mark_transaction_awaiting_dependency(
+                    &self.conn,
+                    awaiting.tx_num,
+                    &awaiting.auth_user,
+                    &detail,
+                )?;
+            } else {
+                clear_transaction_awaiting_dependency(&self.conn, awaiting.tx_num)?;
+                if tx_conflict_mode(&self.conn, awaiting.tx_num)? == tx::MODE_MERGEABLE {
+                    tx::accept_edge(&self.conn, &awaiting.tx_id, now_ms())?;
+                }
+                changed = true;
+            }
+        }
+        if changed {
             projection::rebuild(&self.conn, &self.schema, self.node_num)?;
         }
         Ok(())
@@ -1245,6 +1392,9 @@ impl Runtime {
         record_tx_write(db, tx_num, &record.table, row_num, record.op)?;
 
         let outcome = tx_outcome(db, tx_num)?;
+        if outcome == tx::OUTCOME_PENDING && tx_conflict_mode(db, tx_num)? == tx::MODE_EXCLUSIVE {
+            return Ok(());
+        }
         if tx_is_remote_pending(db, tx_num, local_node_num)?
             && durable_version_exists_for_row(db, &record.table, row_num, branch_num)?
         {
@@ -1332,6 +1482,7 @@ impl Runtime {
         let detail_json = encode_optional_json(detail.as_ref())?;
         let db = self.conn.transaction()?;
         let tx_num = tx::reject_with_detail_json(&db, tx_id, code, &detail_json)?;
+        clear_transaction_awaiting_dependency(&db, tx_num)?;
         for table in self.schema.tables() {
             db.execute(
                 &format!(
@@ -1347,13 +1498,16 @@ impl Runtime {
     }
 
     pub fn accept_transaction_at_global(&mut self, tx_id: &str, global_epoch: i64) -> Result<()> {
-        tx::accept_global(&self.conn, tx_id, global_epoch)?;
+        let tx_num = tx::accept_global(&self.conn, tx_id, global_epoch)?;
+        clear_transaction_awaiting_dependency(&self.conn, tx_num)?;
         projection::rebuild(&self.conn, &self.schema, self.node_num)?;
         Ok(())
     }
 
     pub fn accept_transaction_at_edge(&mut self, tx_id: &str) -> Result<()> {
-        tx::accept_edge(&self.conn, tx_id, now_ms())?;
+        let tx_num = tx::accept_edge(&self.conn, tx_id, now_ms())?;
+        clear_transaction_awaiting_dependency(&self.conn, tx_num)?;
+        projection::rebuild(&self.conn, &self.schema, self.node_num)?;
         Ok(())
     }
 
@@ -1396,11 +1550,26 @@ impl Runtime {
             }
             None => (None, None),
         };
+        let awaiting_dependency = self
+            .conn
+            .query_row(
+                "SELECT awaiting.detail_json
+                 FROM jazz_tx_awaiting_dependency awaiting
+                 JOIN jazz_tx tx ON tx.tx_num = awaiting.tx_num
+                 WHERE tx.tx_id = ?",
+                params![tx_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?
+            .map(|detail_json| parse_rejection_detail(&detail_json))
+            .transpose()?
+            .flatten();
         Ok(TransactionInfo {
             tx_id,
             global_epoch,
             conflict_mode,
             receipt_tiers,
+            awaiting_dependency,
             rejection_code,
             rejection_detail,
         })
@@ -2809,6 +2978,136 @@ fn policy_denial_detail_for_history_record(
     }))
 }
 
+fn is_policy_dependency_unavailable(detail: &JsonValue) -> bool {
+    detail.get("reason").and_then(JsonValue::as_str) == Some("policy_dependency_unavailable")
+}
+
+fn mark_transaction_awaiting_dependency(
+    conn: &Connection,
+    tx_num: i64,
+    auth_user: &str,
+    detail: &JsonValue,
+) -> Result<()> {
+    let detail_json =
+        serde_json::to_string(detail).map_err(|err| crate::Error::new(err.to_string()))?;
+    conn.execute(
+        "INSERT OR REPLACE INTO jazz_tx_awaiting_dependency
+         (tx_num, auth_user, detail_json, updated_at)
+         VALUES (?, ?, ?, ?)",
+        params![tx_num, auth_user, detail_json, now_ms()],
+    )?;
+    Ok(())
+}
+
+fn remove_current_for_awaiting_dependency(
+    conn: &Connection,
+    record: &HistoryRecord,
+    row_num: i64,
+) -> Result<()> {
+    let branch_num = branch::ensure(conn, &record.branch_id, None, now_ms())?;
+    conn.execute(
+        &format!(
+            "DELETE FROM {} WHERE row_num = ? AND j_branch_num = ?",
+            crate::schema::current_table(&record.table)
+        ),
+        params![row_num, branch_num],
+    )?;
+    Ok(())
+}
+
+fn clear_transaction_awaiting_dependency(conn: &Connection, tx_num: i64) -> Result<()> {
+    conn.execute(
+        "DELETE FROM jazz_tx_awaiting_dependency WHERE tx_num = ?",
+        params![tx_num],
+    )?;
+    Ok(())
+}
+
+fn awaiting_dependency_transactions(conn: &Connection) -> Result<Vec<AwaitingDependencyTx>> {
+    let mut stmt = conn.prepare(
+        "SELECT tx.tx_num, tx.tx_id, awaiting.auth_user
+         FROM jazz_tx_awaiting_dependency awaiting
+         JOIN jazz_tx tx ON tx.tx_num = awaiting.tx_num
+         ORDER BY tx.tx_num",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok(AwaitingDependencyTx {
+            tx_num: row.get(0)?,
+            tx_id: row.get(1)?,
+            auth_user: row.get(2)?,
+        })
+    })?;
+    rows.collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(Into::into)
+}
+
+fn history_records_for_tx(
+    conn: &Connection,
+    schema: &SchemaDef,
+    tx_num: i64,
+    tx_id: &str,
+) -> Result<Vec<HistoryRecord>> {
+    let mut records = Vec::new();
+    for table in schema.tables() {
+        let field_columns = table
+            .fields
+            .iter()
+            .map(|field| crate::schema::quote_ident(&crate::schema::storage_column(field)))
+            .collect::<Vec<_>>();
+        let mut select_columns = vec![
+            "ids.row_id".to_owned(),
+            "branch.branch_id".to_owned(),
+            "h.op".to_owned(),
+        ];
+        select_columns.extend(field_columns.iter().map(|column| format!("h.{column}")));
+        select_columns.extend([
+            "h.j_created_at".to_owned(),
+            "h.j_updated_at".to_owned(),
+            "h.j_created_by".to_owned(),
+            "h.j_updated_by".to_owned(),
+        ]);
+        let sql = format!(
+            "SELECT {}
+             FROM {} h
+             JOIN jazz_row_id ids ON ids.row_num = h.row_num
+             JOIN jazz_branch branch ON branch.branch_num = h.j_branch_num
+             WHERE h.tx_num = ?
+             ORDER BY h.row_num",
+            select_columns.join(", "),
+            crate::schema::history_table(&table.name)
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let row_width = 3 + table.fields.len() + 4;
+        let mut rows = stmt.query(params![tx_num])?;
+        while let Some(row) = rows.next()? {
+            let raw = (0..row_width)
+                .map(|idx| row.get::<_, rusqlite::types::Value>(idx))
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            let mut values = BTreeMap::new();
+            for (idx, field) in table.fields.iter().enumerate() {
+                values.insert(
+                    field.name.clone(),
+                    sql_value_to_json(conn, field, &raw[idx + 3])?,
+                );
+            }
+            let sys = 3 + table.fields.len();
+            records.push(HistoryRecord {
+                table: table.name.clone(),
+                row_id: text_value(&raw[0], "row_id")?,
+                branch_id: text_value(&raw[1], "branch_id")?,
+                tx_id: tx_id.to_owned(),
+                op: integer_value(&raw[2], "op")?,
+                values,
+                created_at: integer_value(&raw[sys], "j_created_at")?,
+                updated_at: integer_value(&raw[sys + 1], "j_updated_at")?,
+                created_by: text_value(&raw[sys + 2], "j_created_by")?,
+                updated_by: text_value(&raw[sys + 3], "j_updated_by")?,
+            });
+        }
+    }
+    Ok(records)
+}
+
 fn unavailable_recorded_policy_dependency(
     conn: &Connection,
     tx_num: i64,
@@ -2844,8 +3143,11 @@ fn unavailable_recorded_policy_dependency(
             params![row_num, branch_num],
             |row| row.get(0),
         )?;
-        if visible_count == 0 || observed_tx_num.is_none() {
+        if visible_count == 0 {
             return Ok(Some((table_name, row_id)));
+        }
+        if observed_tx_num.is_none() {
+            repair_missing_observed_policy_read(conn, tx_num, &table_name, row_num, branch_num)?;
         }
     }
     Ok(None)
@@ -2902,10 +3204,50 @@ fn unavailable_policy_dependency(
         |row| row.get(0),
     )?;
     if missing_observed_read_count > 0 {
-        Ok(Some((ref_table_name.clone(), row_id.to_owned())))
-    } else {
-        Ok(None)
+        repair_missing_observed_policy_read(
+            conn,
+            tx_num,
+            ref_table_name,
+            dependency_row_num,
+            branch_num,
+        )?;
     }
+    Ok(None)
+}
+
+fn repair_missing_observed_policy_read(
+    conn: &Connection,
+    tx_num: i64,
+    table_name: &str,
+    row_num: i64,
+    branch_num: i64,
+) -> Result<()> {
+    let observed_tx_num: Option<i64> = conn
+        .query_row(
+            &format!(
+                "SELECT visible_tx_num
+                 FROM {}
+                 WHERE row_num = ?
+                   AND j_branch_num = ?
+                   AND is_deleted = 0",
+                crate::schema::current_table(table_name)
+            ),
+            params![row_num, branch_num],
+            |row| row.get(0),
+        )
+        .optional()?;
+    if let Some(observed_tx_num) = observed_tx_num {
+        conn.execute(
+            "UPDATE jazz_tx_read
+             SET observed_tx_num = ?
+             WHERE tx_num = ?
+               AND table_name = ?
+               AND row_num = ?
+               AND observed_tx_num IS NULL",
+            params![observed_tx_num, tx_num, table_name, row_num],
+        )?;
+    }
+    Ok(())
 }
 
 fn current_creation_metadata(
@@ -3507,6 +3849,14 @@ fn tx_conflict_mode(conn: &Connection, tx_num: i64) -> Result<i64> {
     Ok(conn.query_row(
         "SELECT conflict_mode FROM jazz_tx WHERE tx_num = ?",
         params![tx_num],
+        |row| row.get(0),
+    )?)
+}
+
+fn next_global_epoch(conn: &Connection) -> Result<i64> {
+    Ok(conn.query_row(
+        "SELECT COALESCE(MAX(global_epoch), 0) + 1 FROM jazz_tx",
+        [],
         |row| row.get(0),
     )?)
 }

--- a/crates/mini-jazz-sqlite/src/schema.rs
+++ b/crates/mini-jazz-sqlite/src/schema.rs
@@ -342,6 +342,13 @@ pub(crate) fn install(conn: &Connection, schema: &SchemaDef) -> Result<()> {
           detail_json TEXT NOT NULL
         );
 
+        CREATE TABLE IF NOT EXISTS jazz_tx_awaiting_dependency (
+          tx_num INTEGER PRIMARY KEY,
+          auth_user TEXT NOT NULL,
+          detail_json TEXT NOT NULL,
+          updated_at INTEGER NOT NULL
+        );
+
         CREATE TABLE IF NOT EXISTS jazz_tx_write (
           tx_num INTEGER NOT NULL,
           table_name TEXT NOT NULL,

--- a/crates/mini-jazz-sqlite/src/storage.rs
+++ b/crates/mini-jazz-sqlite/src/storage.rs
@@ -2,7 +2,7 @@ use crate::Result;
 use rusqlite::Connection;
 use std::path::PathBuf;
 
-pub const STORAGE_FORMAT_VERSION: i64 = 3;
+pub const STORAGE_FORMAT_VERSION: i64 = 4;
 
 #[derive(Clone, Debug)]
 pub enum Storage {

--- a/crates/mini-jazz-sqlite/src/types.rs
+++ b/crates/mini-jazz-sqlite/src/types.rs
@@ -43,6 +43,7 @@ pub struct TransactionInfo {
     pub global_epoch: Option<i64>,
     pub conflict_mode: String,
     pub receipt_tiers: Vec<String>,
+    pub awaiting_dependency: Option<JsonValue>,
     pub rejection_code: Option<String>,
     pub rejection_detail: Option<JsonValue>,
 }

--- a/crates/mini-jazz-sqlite/tests/whole_system/policies.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/policies.rs
@@ -817,6 +817,8 @@ fn core_validates_forwarded_exclusive_transaction_with_session_user() {
     let info = core.transaction_info(&tx).unwrap();
     assert_eq!(info.conflict_mode, "exclusive");
     assert_eq!(info.rejection_code, None);
+    assert_eq!(info.global_epoch, Some(1));
+    assert!(info.receipt_tiers.contains(&"global".to_owned()));
     assert_eq!(core.read_rows("todos").unwrap().len(), 1);
     assert_eq!(
         core.export_table_history("todos")
@@ -832,7 +834,78 @@ fn core_validates_forwarded_exclusive_transaction_with_session_user() {
 }
 
 #[test]
-fn trusted_edge_rejects_untrusted_write_when_policy_dependency_is_missing() {
+fn edge_forwards_exclusive_without_local_policy_dependency_and_core_accepts() {
+    let harness = support::Harness::new();
+    let schema = SchemaDef::new()
+        .table("projects", |table| {
+            table.text("title");
+            table.read_if_created_by_user();
+        })
+        .table("todos", |table| {
+            table.text("title");
+            table.ref_("project", "projects");
+            table.write_if_ref_readable("project");
+        });
+    let mut alice = harness
+        .memory_with_schema("alice-node", "alice", schema.clone())
+        .unwrap();
+    let mut edge = harness
+        .trusted_memory_with_schema("edge", schema.clone())
+        .unwrap();
+    let mut core = harness
+        .trusted_memory_with_schema("core", schema.clone())
+        .unwrap();
+
+    alice
+        .insert_row(
+            "projects",
+            "project-1",
+            BTreeMap::from([("title".to_owned(), json!("Alice project"))]),
+        )
+        .unwrap();
+    core.apply_bundle(&alice.export_table_history("projects").unwrap())
+        .unwrap();
+    let tx = alice
+        .insert_row(
+            "todos",
+            "todo-1",
+            BTreeMap::from([
+                ("title".to_owned(), json!("Forward through cold edge")),
+                ("project".to_owned(), json!("project-1")),
+            ]),
+        )
+        .unwrap();
+
+    let mut forwarded = alice
+        .export_exclusive_transaction_forwarding("todos", &tx, "alice")
+        .unwrap();
+    forwarded
+        .history
+        .retain(|record| record.table != "projects");
+
+    edge.stage_exclusive_bundle_for_forwarding(&forwarded)
+        .unwrap();
+    assert!(edge.read_rows("todos").unwrap().is_empty());
+    let edge_info = edge.transaction_info(&tx).unwrap();
+    assert_eq!(edge_info.conflict_mode, "exclusive");
+    assert_eq!(edge_info.global_epoch, None);
+    assert_eq!(edge_info.awaiting_dependency, None);
+    assert_eq!(edge_info.rejection_code, None);
+
+    support::forward_exclusive(&edge, &mut core, "todos", &tx, "alice").unwrap();
+
+    let info = core.transaction_info(&tx).unwrap();
+    assert_eq!(info.conflict_mode, "exclusive");
+    assert_eq!(info.rejection_code, None);
+    assert_eq!(info.global_epoch, Some(1));
+    assert!(info.receipt_tiers.contains(&"global".to_owned()));
+    let rows = core.read_rows("todos").unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].id, "todo-1");
+}
+
+#[test]
+fn trusted_edge_awaits_missing_policy_dependency_then_accepts_after_it_arrives() {
     let harness = support::Harness::new();
     let schema = SchemaDef::new()
         .table("projects", |table| {
@@ -871,14 +944,11 @@ fn trusted_edge_rejects_untrusted_write_when_policy_dependency_is_missing() {
         .history
         .retain(|record| record.table != "projects");
 
-    support::apply_untrusted_as_user(incomplete_bundle, &mut edge, bob.session_user()).unwrap();
+    support::apply_untrusted_as_user(incomplete_bundle, &mut edge, "bob").unwrap();
     assert!(edge.read_rows("todos").unwrap().is_empty());
+    assert_eq!(edge.transaction_info(&tx).unwrap().rejection_code, None);
     assert_eq!(
-        edge.transaction_info(&tx).unwrap().rejection_code,
-        Some("policy_denied".to_owned())
-    );
-    assert_eq!(
-        edge.transaction_info(&tx).unwrap().rejection_detail,
+        edge.transaction_info(&tx).unwrap().awaiting_dependency,
         Some(json!({
             "reason": "policy_dependency_unavailable",
             "table": "todos",
@@ -889,19 +959,212 @@ fn trusted_edge_rejects_untrusted_write_when_policy_dependency_is_missing() {
     );
 
     support::sync_table(&bob, &mut edge, "projects").unwrap();
-    assert!(edge.read_rows("todos").unwrap().is_empty());
 
-    support::apply_untrusted_as_user(bob.export_table_history("todos").unwrap(), &mut edge, "bob")
+    let rows = edge.read_rows("todos").unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].id, "todo-1");
+    let info = edge.transaction_info(&tx).unwrap();
+    assert_eq!(info.rejection_code, None);
+    assert_eq!(info.awaiting_dependency, None);
+    assert_eq!(info.receipt_tiers, vec!["edge".to_owned()]);
+}
+
+#[test]
+fn durable_edge_preserves_awaiting_dependency_across_restart() {
+    let harness = support::Harness::new();
+    let schema = SchemaDef::new()
+        .table("projects", |table| {
+            table.text("title");
+            table.read_if_created_by_user();
+        })
+        .table("todos", |table| {
+            table.text("title");
+            table.ref_("project", "projects");
+            table.write_if_ref_readable("project");
+        });
+    let mut bob = harness
+        .trusted_memory_with_schema("bob-node", schema.clone())
         .unwrap();
-    assert!(edge.read_rows("todos").unwrap().is_empty());
+    let mut edge = harness
+        .trusted_durable_with_schema("edge.sqlite", "edge", schema.clone())
+        .unwrap();
+
+    let tx = support::run_as_user(&mut bob, "bob", |bob| {
+        bob.insert_row(
+            "projects",
+            "project-bob",
+            BTreeMap::from([("title".to_owned(), json!("Bob project"))]),
+        )?;
+        bob.insert_row(
+            "todos",
+            "todo-1",
+            BTreeMap::from([
+                ("title".to_owned(), json!("Restart while awaiting")),
+                ("project".to_owned(), json!("project-bob")),
+            ]),
+        )
+    })
+    .unwrap();
+
+    let mut incomplete_bundle = bob.export_table_history("todos").unwrap();
+    incomplete_bundle
+        .history
+        .retain(|record| record.table != "projects");
+    support::apply_untrusted_as_user(incomplete_bundle, &mut edge, "bob").unwrap();
     assert_eq!(
-        edge.transaction_info(&tx).unwrap().rejection_detail,
+        edge.transaction_info(&tx).unwrap().awaiting_dependency,
         Some(json!({
             "reason": "policy_dependency_unavailable",
             "table": "todos",
             "row_id": "todo-1",
             "dependency_table": "projects",
             "dependency_row_id": "project-bob"
+        }))
+    );
+    drop(edge);
+
+    let mut edge = harness
+        .trusted_durable_with_schema("edge.sqlite", "edge", schema)
+        .unwrap();
+    assert!(edge.read_rows("todos").unwrap().is_empty());
+    assert!(edge
+        .transaction_info(&tx)
+        .unwrap()
+        .awaiting_dependency
+        .is_some());
+
+    support::sync_table(&bob, &mut edge, "projects").unwrap();
+
+    assert_eq!(edge.read_rows("todos").unwrap().len(), 1);
+    let info = edge.transaction_info(&tx).unwrap();
+    assert_eq!(info.awaiting_dependency, None);
+    assert_eq!(info.rejection_code, None);
+    assert_eq!(info.receipt_tiers, vec!["edge".to_owned()]);
+}
+
+#[test]
+fn direct_authority_fate_clears_awaiting_dependency_marker() {
+    let harness = support::Harness::new();
+    let schema = SchemaDef::new()
+        .table("projects", |table| {
+            table.text("title");
+            table.read_if_created_by_user();
+        })
+        .table("todos", |table| {
+            table.text("title");
+            table.ref_("project", "projects");
+            table.write_if_ref_readable("project");
+        });
+    let mut bob = harness
+        .trusted_memory_with_schema("bob-node", schema.clone())
+        .unwrap();
+    let mut edge = harness.trusted_memory_with_schema("edge", schema).unwrap();
+
+    let tx = support::run_as_user(&mut bob, "bob", |bob| {
+        bob.insert_row(
+            "projects",
+            "project-bob",
+            BTreeMap::from([("title".to_owned(), json!("Bob project"))]),
+        )?;
+        bob.insert_row(
+            "todos",
+            "todo-1",
+            BTreeMap::from([
+                ("title".to_owned(), json!("Direct fate while awaiting")),
+                ("project".to_owned(), json!("project-bob")),
+            ]),
+        )
+    })
+    .unwrap();
+
+    let mut incomplete_bundle = bob.export_table_history("todos").unwrap();
+    incomplete_bundle
+        .history
+        .retain(|record| record.table != "projects");
+    support::apply_untrusted_as_user(incomplete_bundle, &mut edge, "bob").unwrap();
+    assert!(edge
+        .transaction_info(&tx)
+        .unwrap()
+        .awaiting_dependency
+        .is_some());
+    assert!(edge.read_rows("todos").unwrap().is_empty());
+
+    edge.accept_transaction_at_global(&tx, 1).unwrap();
+
+    let info = edge.transaction_info(&tx).unwrap();
+    assert_eq!(info.awaiting_dependency, None);
+    assert_eq!(info.rejection_code, None);
+    assert_eq!(info.global_epoch, Some(1));
+    let rows = edge.read_rows("todos").unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].id, "todo-1");
+}
+
+#[test]
+fn edge_rejects_awaiting_transaction_when_arrived_dependency_is_not_readable() {
+    let schema = SchemaDef::new()
+        .table("projects", |table| {
+            table.text("title");
+            table.read_if_created_by_user();
+        })
+        .table("todos", |table| {
+            table.text("title");
+            table.ref_("project", "projects");
+            table.write_if_ref_readable("project");
+        });
+    let mut alice =
+        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema.clone()).unwrap();
+    let mut bob = Runtime::open_trusted_attributing_to_user(
+        Storage::Memory,
+        "bob-node",
+        "bob",
+        schema.clone(),
+    )
+    .unwrap();
+    let mut edge = Runtime::open_trusted_with_schema(Storage::Memory, "edge", schema).unwrap();
+
+    alice
+        .insert_row(
+            "projects",
+            "project-alice",
+            BTreeMap::from([("title".to_owned(), json!("Private Alice project"))]),
+        )
+        .unwrap();
+    let tx = bob
+        .insert_row(
+            "todos",
+            "todo-1",
+            BTreeMap::from([
+                (
+                    "title".to_owned(),
+                    json!("Should be denied after dependency arrives"),
+                ),
+                ("project".to_owned(), json!("project-alice")),
+            ]),
+        )
+        .unwrap();
+
+    edge.apply_untrusted_bundle_as_user(&bob.export_table_history("todos").unwrap(), "bob")
+        .unwrap();
+    assert!(edge
+        .transaction_info(&tx)
+        .unwrap()
+        .awaiting_dependency
+        .is_some());
+
+    edge.apply_bundle(&alice.export_table_history("projects").unwrap())
+        .unwrap();
+
+    assert!(edge.read_rows("todos").unwrap().is_empty());
+    let info = edge.transaction_info(&tx).unwrap();
+    assert_eq!(info.awaiting_dependency, None);
+    assert_eq!(info.rejection_code, Some("policy_denied".to_owned()));
+    assert_eq!(
+        info.rejection_detail,
+        Some(json!({
+            "reason": "write_policy_denied",
+            "table": "todos",
+            "row_id": "todo-1"
         }))
     );
 }
@@ -2226,7 +2489,7 @@ fn trusted_edge_reports_missing_transitive_policy_dependency() {
 
     assert!(edge.read_rows("todos").unwrap().is_empty());
     assert_eq!(
-        edge.transaction_info(&tx).unwrap().rejection_detail,
+        edge.transaction_info(&tx).unwrap().awaiting_dependency,
         Some(json!({
             "reason": "policy_dependency_unavailable",
             "table": "todos",
@@ -2235,6 +2498,17 @@ fn trusted_edge_reports_missing_transitive_policy_dependency() {
             "dependency_row_id": "org-1"
         }))
     );
+
+    edge.apply_bundle(&alice.export_table_history("orgs").unwrap())
+        .unwrap();
+
+    let rows = edge.read_rows("todos").unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].id, "todo-1");
+    let info = edge.transaction_info(&tx).unwrap();
+    assert_eq!(info.rejection_code, None);
+    assert_eq!(info.awaiting_dependency, None);
+    assert_eq!(info.receipt_tiers, vec!["edge".to_owned()]);
 }
 
 #[test]

--- a/crates/mini-jazz-sqlite/tests/whole_system/storage_projection.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/storage_projection.rs
@@ -4,7 +4,7 @@ use super::*;
 fn memory_runtime_writes_through_sqlite_current_projection() {
     let mut alice = Runtime::open(Storage::Memory, "alice-node", "alice").unwrap();
 
-    assert_eq!(alice.storage_format_version().unwrap(), 3);
+    assert_eq!(alice.storage_format_version().unwrap(), 4);
 
     alice.create_project("project-1", "Spec work").unwrap();
     let tx = alice
@@ -38,7 +38,7 @@ fn durable_storage_is_tagged_with_format_version() {
     let version: i64 = conn
         .pragma_query_value(None, "user_version", |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 3);
+    assert_eq!(version, 4);
 }
 
 #[test]
@@ -46,7 +46,7 @@ fn future_storage_format_versions_fail_before_opening_runtime() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("future.sqlite");
     let conn = rusqlite::Connection::open(&path).unwrap();
-    conn.pragma_update(None, "user_version", 4).unwrap();
+    conn.pragma_update(None, "user_version", 5).unwrap();
     drop(conn);
 
     let err = match Runtime::open(Storage::File(path), "worker", "alice") {
@@ -56,7 +56,7 @@ fn future_storage_format_versions_fail_before_opening_runtime() {
 
     assert!(err
         .to_string()
-        .contains("unsupported storage format version 4"));
+        .contains("unsupported storage format version 5"));
 }
 
 #[test]

--- a/crates/mini-jazz-sqlite/tests/whole_system/sync_fate.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/sync_fate.rs
@@ -1502,6 +1502,57 @@ fn accepted_remote_pending_update_repairs_peer_current_projection() {
 }
 
 #[test]
+fn edge_accepted_remote_pending_update_repairs_peer_current_projection() {
+    let schema = support::notes_schema();
+    let mut authority =
+        Runtime::open_with_schema(Storage::Memory, "authority", "alice", schema.clone()).unwrap();
+    let mut writer =
+        Runtime::open_with_schema(Storage::Memory, "writer", "alice", schema.clone()).unwrap();
+    let mut peer = Runtime::open_with_schema(Storage::Memory, "peer", "alice", schema).unwrap();
+
+    let base_tx = authority
+        .insert_row(
+            "notes",
+            "note-1",
+            BTreeMap::from([
+                ("body".to_owned(), json!("global")),
+                ("pinned".to_owned(), json!(false)),
+            ]),
+        )
+        .unwrap();
+    authority.accept_transaction_at_global(&base_tx, 1).unwrap();
+    let base_bundle = authority.export_table_history("notes").unwrap();
+    writer.apply_bundle(&base_bundle).unwrap();
+    peer.apply_bundle(&base_bundle).unwrap();
+
+    let pending_tx = writer
+        .update_row(
+            "notes",
+            "note-1",
+            BTreeMap::from([
+                ("body".to_owned(), json!("edge accepted later")),
+                ("pinned".to_owned(), json!(true)),
+            ]),
+        )
+        .unwrap();
+    let pending_bundle = writer.export_table_history("notes").unwrap();
+    authority.apply_bundle(&pending_bundle).unwrap();
+    peer.apply_bundle(&pending_bundle).unwrap();
+    assert_eq!(
+        peer.read_rows("notes").unwrap()[0].values["body"],
+        json!("global")
+    );
+
+    authority.accept_transaction_at_edge(&pending_tx).unwrap();
+    peer.apply_bundle(&authority.export_table_history("notes").unwrap())
+        .unwrap();
+    assert_eq!(
+        peer.read_rows("notes").unwrap()[0].values["body"],
+        json!("edge accepted later")
+    );
+}
+
+#[test]
 fn older_global_mergeable_update_cannot_override_newer_exclusive_current() {
     let schema = support::notes_schema();
     let mut authority =


### PR DESCRIPTION
## Summary
- Add durable awaiting-dependency state for authority-side policy validation when required policy facts are missing
- Keep awaiting transactions out of current projection while preserving their public tx id/history and exposing awaiting detail through transaction info
- Revalidate the same transaction after missing facts arrive, clear awaiting state, and edge-accept on success
- Update spec and whole-system policy tests, including durable edge restart while awaiting

## Tests
- cargo test -p mini-jazz-sqlite --test whole_system