### PR TITLE
Add mini-sqlite WASM runtime, query API, and todo benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2311,6 +2311,7 @@ dependencies = [
  "sqlite-wasm-vfs",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-bindgen-test",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2302,6 +2302,7 @@ name = "mini-jazz-sqlite-wasm"
 version = "0.1.0"
 dependencies = [
  "console_error_panic_hook",
+ "js-sys",
  "mini-jazz-sqlite",
  "serde",
  "serde-wasm-bindgen 0.6.5",

--- a/crates/mini-jazz-sqlite-wasm/Cargo.toml
+++ b/crates/mini-jazz-sqlite-wasm/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 console_error_panic_hook = "0.1"
 mini-jazz-sqlite = { path = "../mini-jazz-sqlite" }
+js-sys = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
 serde_json = "1"

--- a/crates/mini-jazz-sqlite-wasm/Cargo.toml
+++ b/crates/mini-jazz-sqlite-wasm/Cargo.toml
@@ -19,3 +19,6 @@ wasm-bindgen-futures = "0.4"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 sqlite-wasm-rs = "0.5"
 sqlite-wasm-vfs = "0.2"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"

--- a/crates/mini-jazz-sqlite-wasm/src/lib.rs
+++ b/crates/mini-jazz-sqlite-wasm/src/lib.rs
@@ -165,22 +165,6 @@ impl MiniJazzRuntime {
         )
     }
 
-    #[wasm_bindgen(js_name = readRowsWhereEqTopCreatedAtDesc)]
-    pub fn read_rows_where_eq_top_created_at_desc(
-        &self,
-        table_name: &str,
-        field_name: &str,
-        value: JsValue,
-        limit: usize,
-    ) -> Result<JsValue, JsValue> {
-        let value = parse_json_value(value)?;
-        to_js_value(
-            self.runtime
-                .read_rows_where_eq_top_created_at_desc(table_name, field_name, value, limit)
-                .map_err(to_js_error)?,
-        )
-    }
-
     #[wasm_bindgen(js_name = exportTableHistory)]
     pub fn export_table_history(&self, table_name: &str) -> Result<JsValue, JsValue> {
         to_js_value(

--- a/crates/mini-jazz-sqlite-wasm/src/lib.rs
+++ b/crates/mini-jazz-sqlite-wasm/src/lib.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use mini_jazz_sqlite::{BuiltQuery, RowsSubscription, Runtime, Storage, SubscriptionDelta};
+use mini_jazz_sqlite::{BuiltQuery, RowsSubscription, Runtime, Storage};
 use serde::Serialize;
 use serde_json::Value as JsonValue;
 use wasm_bindgen::prelude::*;
@@ -171,20 +171,18 @@ impl MiniJazzRuntime {
 
     fn notify_subscriptions(&mut self) -> Result<(), JsValue> {
         let runtime = &self.runtime;
-        let mut notifications: Vec<(js_sys::Function, SubscriptionDelta)> = Vec::new();
 
         for entry in self.subscriptions.values_mut() {
+            let mut next_subscription = entry.subscription.clone();
             let delta = runtime
-                .subscription_delta(&mut entry.subscription)
+                .subscription_delta(&mut next_subscription)
                 .map_err(to_js_error)?;
             if !delta.delta.is_empty() {
-                notifications.push((entry.callback.clone(), delta));
+                let value = to_js_value(delta)?;
+                entry.callback.call1(&JsValue::UNDEFINED, &value)?;
             }
-        }
 
-        for (callback, delta) in notifications {
-            let value = to_js_value(delta)?;
-            let _ = callback.call1(&JsValue::UNDEFINED, &value);
+            entry.subscription = next_subscription;
         }
 
         Ok(())
@@ -216,6 +214,105 @@ fn to_js_value<T: Serialize>(value: T) -> Result<JsValue, JsValue> {
 
 fn to_js_error(error: mini_jazz_sqlite::Error) -> JsValue {
     JsValue::from_str(&error.to_string())
+}
+
+#[cfg(all(test, target_arch = "wasm32"))]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::collections::BTreeMap;
+    use wasm_bindgen::JsCast;
+    use wasm_bindgen_test::*;
+
+    fn reset_test_globals() {
+        let global = js_sys::global();
+        js_sys::Reflect::set(
+            &global,
+            &JsValue::from_str("__miniJazzDeltas"),
+            &js_sys::Array::new(),
+        )
+        .unwrap();
+        js_sys::Reflect::set(
+            &global,
+            &JsValue::from_str("__miniJazzThrowNext"),
+            &JsValue::FALSE,
+        )
+        .unwrap();
+    }
+
+    fn observed_deltas() -> js_sys::Array {
+        js_sys::Reflect::get(&js_sys::global(), &JsValue::from_str("__miniJazzDeltas"))
+            .unwrap()
+            .dyn_into()
+            .unwrap()
+    }
+
+    fn set_throw_next() {
+        js_sys::Reflect::set(
+            &js_sys::global(),
+            &JsValue::from_str("__miniJazzThrowNext"),
+            &JsValue::TRUE,
+        )
+        .unwrap();
+    }
+
+    fn project_values(title: &str) -> JsValue {
+        to_js_value(BTreeMap::from([("title".to_owned(), json!(title))])).unwrap()
+    }
+
+    #[wasm_bindgen_test]
+    fn subscription_callback_error_is_returned_and_delta_retried() {
+        reset_test_globals();
+        let mut runtime = MiniJazzRuntime::open_memory("alice-node", "alice").unwrap();
+        let callback = js_sys::Function::new_with_args(
+            "delta",
+            r#"
+            if (globalThis.__miniJazzThrowNext) {
+                globalThis.__miniJazzThrowNext = false;
+                throw new Error("callback failed");
+            }
+            globalThis.__miniJazzDeltas.push({
+                all: delta.all.map((row) => row.id),
+                kinds: delta.delta.map((change) => change.kind),
+                titles: delta.all.map((row) => row.values.title),
+            });
+            "#,
+        );
+
+        runtime
+            .subscribe(JsValue::from_str(r#"{"table":"projects"}"#), callback)
+            .unwrap();
+        assert_eq!(observed_deltas().length(), 1);
+
+        set_throw_next();
+        let err = runtime
+            .insert_row("projects", "project-1", project_values("First"))
+            .unwrap_err();
+        let message = js_sys::Reflect::get(&err, &JsValue::from_str("message"))
+            .unwrap()
+            .as_string()
+            .unwrap();
+        assert_eq!(message, "callback failed");
+        assert_eq!(observed_deltas().length(), 1);
+
+        runtime
+            .update_row("projects", "project-1", project_values("Retried"))
+            .unwrap();
+        let deltas = observed_deltas();
+        assert_eq!(deltas.length(), 2);
+        let retried = deltas.get(1);
+        let kinds: js_sys::Array = js_sys::Reflect::get(&retried, &JsValue::from_str("kinds"))
+            .unwrap()
+            .dyn_into()
+            .unwrap();
+        let titles: js_sys::Array = js_sys::Reflect::get(&retried, &JsValue::from_str("titles"))
+            .unwrap()
+            .dyn_into()
+            .unwrap();
+
+        assert_eq!(kinds.get(0).as_f64(), Some(0.0));
+        assert_eq!(titles.get(0).as_string().as_deref(), Some("Retried"));
+    }
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/mini-jazz-sqlite-wasm/src/lib.rs
+++ b/crates/mini-jazz-sqlite-wasm/src/lib.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use mini_jazz_sqlite::sync::Bundle;
-use mini_jazz_sqlite::{Runtime, Storage};
+use mini_jazz_sqlite::{BuiltQuery, RowsSubscription, Runtime, Storage, SubscriptionDelta};
 use serde::Serialize;
 use serde_json::Value as JsonValue;
 use wasm_bindgen::prelude::*;
@@ -14,6 +14,13 @@ pub fn install_panic_hook() {
 #[wasm_bindgen]
 pub struct MiniJazzRuntime {
     runtime: Runtime,
+    subscriptions: BTreeMap<u32, WasmRowsSubscription>,
+    next_subscription_id: u32,
+}
+
+struct WasmRowsSubscription {
+    subscription: RowsSubscription,
+    callback: js_sys::Function,
 }
 
 #[wasm_bindgen]
@@ -21,7 +28,7 @@ impl MiniJazzRuntime {
     #[wasm_bindgen(js_name = openMemory)]
     pub fn open_memory(node_id: &str, user: &str) -> Result<MiniJazzRuntime, JsValue> {
         Runtime::open(Storage::Memory, node_id, user)
-            .map(|runtime| MiniJazzRuntime { runtime })
+            .map(MiniJazzRuntime::new)
             .map_err(to_js_error)
     }
 
@@ -43,7 +50,7 @@ impl MiniJazzRuntime {
             .map_err(|error| JsValue::from_str(&format!("install OPFS SQLite VFS: {error}")))?;
 
         Runtime::open(Storage::File(db_name.into()), node_id, user)
-            .map(|runtime| MiniJazzRuntime { runtime })
+            .map(MiniJazzRuntime::new)
             .map_err(to_js_error)
     }
 
@@ -54,9 +61,12 @@ impl MiniJazzRuntime {
         id: &str,
         values: JsValue,
     ) -> Result<String, JsValue> {
-        self.runtime
+        let tx_id = self
+            .runtime
             .insert_row(table_name, id, parse_values(values)?)
-            .map_err(to_js_error)
+            .map_err(to_js_error)?;
+        self.notify_subscriptions()?;
+        Ok(tx_id)
     }
 
     #[wasm_bindgen(js_name = updateRow)]
@@ -66,14 +76,73 @@ impl MiniJazzRuntime {
         id: &str,
         values: JsValue,
     ) -> Result<String, JsValue> {
-        self.runtime
+        let tx_id = self
+            .runtime
             .update_row(table_name, id, parse_values(values)?)
-            .map_err(to_js_error)
+            .map_err(to_js_error)?;
+        self.notify_subscriptions()?;
+        Ok(tx_id)
     }
 
     #[wasm_bindgen(js_name = deleteRow)]
     pub fn delete_row(&mut self, table_name: &str, id: &str) -> Result<String, JsValue> {
-        self.runtime.delete_row(table_name, id).map_err(to_js_error)
+        let tx_id = self
+            .runtime
+            .delete_row(table_name, id)
+            .map_err(to_js_error)?;
+        self.notify_subscriptions()?;
+        Ok(tx_id)
+    }
+
+    #[wasm_bindgen(js_name = query)]
+    pub fn query(&self, query: JsValue) -> Result<JsValue, JsValue> {
+        to_js_value(
+            self.runtime
+                .query(parse_built_query(query)?)
+                .map_err(to_js_error)?,
+        )
+    }
+
+    #[wasm_bindgen(js_name = one)]
+    pub fn one(&self, query: JsValue) -> Result<JsValue, JsValue> {
+        to_js_value(
+            self.runtime
+                .one(parse_built_query(query)?)
+                .map_err(to_js_error)?,
+        )
+    }
+
+    #[wasm_bindgen(js_name = subscribe)]
+    pub fn subscribe(
+        &mut self,
+        query: JsValue,
+        callback: js_sys::Function,
+    ) -> Result<u32, JsValue> {
+        let subscription = self
+            .runtime
+            .subscribe_query(parse_built_query(query)?)
+            .map_err(to_js_error)?;
+        let initial = subscription.initial_delta();
+        callback.call1(&JsValue::UNDEFINED, &to_js_value(initial)?)?;
+
+        let id = self.next_subscription_id;
+        self.next_subscription_id = self
+            .next_subscription_id
+            .checked_add(1)
+            .ok_or_else(|| JsValue::from_str("subscription id overflow"))?;
+        self.subscriptions.insert(
+            id,
+            WasmRowsSubscription {
+                subscription,
+                callback,
+            },
+        );
+        Ok(id)
+    }
+
+    #[wasm_bindgen(js_name = unsubscribe)]
+    pub fn unsubscribe(&mut self, handle: u32) {
+        self.subscriptions.remove(&handle);
     }
 
     #[wasm_bindgen(js_name = readRows)]
@@ -125,7 +194,8 @@ impl MiniJazzRuntime {
     pub fn apply_bundle(&mut self, bundle: JsValue) -> Result<(), JsValue> {
         let bundle: Bundle = serde_wasm_bindgen::from_value(bundle)
             .map_err(|error| JsValue::from_str(&format!("invalid bundle: {error}")))?;
-        self.runtime.apply_bundle(&bundle).map_err(to_js_error)
+        self.runtime.apply_bundle(&bundle).map_err(to_js_error)?;
+        self.notify_subscriptions()
     }
 
     #[wasm_bindgen(js_name = storageStats)]
@@ -139,9 +209,47 @@ impl MiniJazzRuntime {
     }
 }
 
+impl MiniJazzRuntime {
+    fn new(runtime: Runtime) -> Self {
+        Self {
+            runtime,
+            subscriptions: BTreeMap::new(),
+            next_subscription_id: 0,
+        }
+    }
+
+    fn notify_subscriptions(&mut self) -> Result<(), JsValue> {
+        let runtime = &self.runtime;
+        let mut notifications: Vec<(js_sys::Function, SubscriptionDelta)> = Vec::new();
+
+        for entry in self.subscriptions.values_mut() {
+            let delta = runtime
+                .subscription_delta(&mut entry.subscription)
+                .map_err(to_js_error)?;
+            if !delta.delta.is_empty() {
+                notifications.push((entry.callback.clone(), delta));
+            }
+        }
+
+        for (callback, delta) in notifications {
+            let value = to_js_value(delta)?;
+            let _ = callback.call1(&JsValue::UNDEFINED, &value);
+        }
+
+        Ok(())
+    }
+}
+
 fn parse_values(value: JsValue) -> Result<BTreeMap<String, JsonValue>, JsValue> {
     serde_wasm_bindgen::from_value(value)
         .map_err(|error| JsValue::from_str(&format!("invalid row values: {error}")))
+}
+
+fn parse_built_query(value: JsValue) -> Result<BuiltQuery, JsValue> {
+    if let Some(query) = value.as_string() {
+        return BuiltQuery::from_json_str(&query).map_err(to_js_error);
+    }
+    BuiltQuery::from_json_value(parse_json_value(value)?).map_err(to_js_error)
 }
 
 fn parse_json_value(value: JsValue) -> Result<JsonValue, JsValue> {

--- a/crates/mini-jazz-sqlite-wasm/src/lib.rs
+++ b/crates/mini-jazz-sqlite-wasm/src/lib.rs
@@ -15,11 +15,21 @@ pub struct MiniJazzRuntime {
     runtime: Runtime,
     subscriptions: BTreeMap<u32, WasmRowsSubscription>,
     next_subscription_id: u32,
+    notifying_subscriptions: bool,
+    notify_subscriptions_again: bool,
 }
 
 struct WasmRowsSubscription {
     subscription: RowsSubscription,
     callback: js_sys::Function,
+}
+
+struct PendingNotification {
+    id: u32,
+    previous_subscription: RowsSubscription,
+    next_subscription: RowsSubscription,
+    callback: js_sys::Function,
+    value: JsValue,
 }
 
 #[wasm_bindgen]
@@ -166,23 +176,76 @@ impl MiniJazzRuntime {
             runtime,
             subscriptions: BTreeMap::new(),
             next_subscription_id: 0,
+            notifying_subscriptions: false,
+            notify_subscriptions_again: false,
         }
     }
 
     fn notify_subscriptions(&mut self) -> Result<(), JsValue> {
-        let runtime = &self.runtime;
+        if self.notifying_subscriptions {
+            self.notify_subscriptions_again = true;
+            return Ok(());
+        }
 
-        for entry in self.subscriptions.values_mut() {
+        self.notifying_subscriptions = true;
+        loop {
+            self.notify_subscriptions_again = false;
+            if let Err(error) = self.notify_subscriptions_once() {
+                self.notifying_subscriptions = false;
+                self.notify_subscriptions_again = false;
+                return Err(error);
+            }
+            if !self.notify_subscriptions_again {
+                break;
+            }
+        }
+        self.notifying_subscriptions = false;
+        Ok(())
+    }
+
+    fn notify_subscriptions_once(&mut self) -> Result<(), JsValue> {
+        let runtime = &self.runtime;
+        let ids = self.subscriptions.keys().copied().collect::<Vec<_>>();
+        let mut pending = Vec::new();
+
+        for id in ids {
+            let Some(entry) = self.subscriptions.get(&id) else {
+                continue;
+            };
+            let previous_subscription = entry.subscription.clone();
             let mut next_subscription = entry.subscription.clone();
             let delta = runtime
                 .subscription_delta(&mut next_subscription)
                 .map_err(to_js_error)?;
             if !delta.delta.is_empty() {
-                let value = to_js_value(delta)?;
-                entry.callback.call1(&JsValue::UNDEFINED, &value)?;
+                pending.push(PendingNotification {
+                    id,
+                    previous_subscription,
+                    next_subscription,
+                    callback: entry.callback.clone(),
+                    value: to_js_value(delta)?,
+                });
+            } else if let Some(entry) = self.subscriptions.get_mut(&id) {
+                entry.subscription = next_subscription;
+            }
+        }
+
+        for notification in pending {
+            if let Some(entry) = self.subscriptions.get_mut(&notification.id) {
+                entry.subscription = notification.next_subscription.clone();
+            } else {
+                continue;
             }
 
-            entry.subscription = next_subscription;
+            if let Err(error) = notification
+                .callback
+                .call1(&JsValue::UNDEFINED, &notification.value)
+            {
+                if let Some(entry) = self.subscriptions.get_mut(&notification.id) {
+                    entry.subscription = notification.previous_subscription;
+                }
+                return Err(error);
+            }
         }
 
         Ok(())
@@ -220,7 +283,9 @@ fn to_js_error(error: mini_jazz_sqlite::Error) -> JsValue {
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::cell::Cell;
     use std::collections::BTreeMap;
+    use std::rc::Rc;
     use wasm_bindgen::JsCast;
     use wasm_bindgen_test::*;
 
@@ -312,6 +377,88 @@ mod tests {
 
         assert_eq!(kinds.get(0).as_f64(), Some(0.0));
         assert_eq!(titles.get(0).as_string().as_deref(), Some("Retried"));
+    }
+
+    #[wasm_bindgen_test]
+    fn subscription_callback_can_unsubscribe_current_handle() {
+        let mut runtime = MiniJazzRuntime::open_memory("alice-node", "alice").unwrap();
+        let handle = Rc::new(Cell::new(None::<u32>));
+        let seen_initial = Rc::new(Cell::new(false));
+        let callback_count = Rc::new(Cell::new(0));
+        let runtime_ptr = &mut runtime as *mut MiniJazzRuntime;
+        let callback_closure = Closure::<dyn FnMut(JsValue)>::new({
+            let handle = Rc::clone(&handle);
+            let seen_initial = Rc::clone(&seen_initial);
+            let callback_count = Rc::clone(&callback_count);
+            move |_| {
+                callback_count.set(callback_count.get() + 1);
+                if seen_initial.replace(true) {
+                    unsafe {
+                        (*runtime_ptr).unsubscribe(handle.get().expect("handle is set"));
+                    }
+                }
+            }
+        });
+        let callback = callback_closure
+            .as_ref()
+            .unchecked_ref::<js_sys::Function>()
+            .clone();
+
+        let subscription_handle = runtime
+            .subscribe(JsValue::from_str(r#"{"table":"projects"}"#), callback)
+            .unwrap();
+        handle.set(Some(subscription_handle));
+        assert_eq!(callback_count.get(), 1);
+
+        runtime
+            .insert_row("projects", "project-1", project_values("First"))
+            .unwrap();
+        assert_eq!(callback_count.get(), 2);
+
+        runtime
+            .update_row("projects", "project-1", project_values("Second"))
+            .unwrap();
+        assert_eq!(callback_count.get(), 2);
+    }
+
+    #[wasm_bindgen_test]
+    fn subscription_callback_can_write_another_row() {
+        let mut runtime = MiniJazzRuntime::open_memory("alice-node", "alice").unwrap();
+        let seen_initial = Rc::new(Cell::new(false));
+        let wrote_nested_row = Rc::new(Cell::new(false));
+        let callback_count = Rc::new(Cell::new(0));
+        let runtime_ptr = &mut runtime as *mut MiniJazzRuntime;
+        let callback_closure = Closure::<dyn FnMut(JsValue)>::new({
+            let seen_initial = Rc::clone(&seen_initial);
+            let wrote_nested_row = Rc::clone(&wrote_nested_row);
+            let callback_count = Rc::clone(&callback_count);
+            move |_| {
+                callback_count.set(callback_count.get() + 1);
+                if seen_initial.replace(true) && !wrote_nested_row.replace(true) {
+                    unsafe {
+                        (*runtime_ptr)
+                            .insert_row("projects", "project-2", project_values("Nested"))
+                            .unwrap();
+                    }
+                }
+            }
+        });
+        let callback = callback_closure
+            .as_ref()
+            .unchecked_ref::<js_sys::Function>()
+            .clone();
+
+        runtime
+            .subscribe(JsValue::from_str(r#"{"table":"projects"}"#), callback)
+            .unwrap();
+        assert_eq!(callback_count.get(), 1);
+
+        runtime
+            .insert_row("projects", "project-1", project_values("First"))
+            .unwrap();
+        assert_eq!(callback_count.get(), 3);
+        let rows: js_sys::Array = runtime.read_rows("projects").unwrap().dyn_into().unwrap();
+        assert_eq!(rows.length(), 2);
     }
 }
 

--- a/crates/mini-jazz-sqlite-wasm/src/lib.rs
+++ b/crates/mini-jazz-sqlite-wasm/src/lib.rs
@@ -1,6 +1,5 @@
 use std::collections::BTreeMap;
 
-use mini_jazz_sqlite::sync::Bundle;
 use mini_jazz_sqlite::{BuiltQuery, RowsSubscription, Runtime, Storage, SubscriptionDelta};
 use serde::Serialize;
 use serde_json::Value as JsonValue;
@@ -163,23 +162,6 @@ impl MiniJazzRuntime {
                 .read_rows_where_eq(table_name, field_name, value)
                 .map_err(to_js_error)?,
         )
-    }
-
-    #[wasm_bindgen(js_name = exportTableHistory)]
-    pub fn export_table_history(&self, table_name: &str) -> Result<JsValue, JsValue> {
-        to_js_value(
-            self.runtime
-                .export_table_history(table_name)
-                .map_err(to_js_error)?,
-        )
-    }
-
-    #[wasm_bindgen(js_name = applyBundle)]
-    pub fn apply_bundle(&mut self, bundle: JsValue) -> Result<(), JsValue> {
-        let bundle: Bundle = serde_wasm_bindgen::from_value(bundle)
-            .map_err(|error| JsValue::from_str(&format!("invalid bundle: {error}")))?;
-        self.runtime.apply_bundle(&bundle).map_err(to_js_error)?;
-        self.notify_subscriptions()
     }
 
     #[wasm_bindgen(js_name = storageStats)]

--- a/crates/mini-jazz-sqlite-wasm/src/lib.rs
+++ b/crates/mini-jazz-sqlite-wasm/src/lib.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use mini_jazz_sqlite::{BuiltQuery, RowsSubscription, Runtime, Storage};
 use serde::Serialize;
@@ -30,6 +30,20 @@ struct PendingNotification {
     next_subscription: RowsSubscription,
     callback: js_sys::Function,
     value: JsValue,
+}
+
+struct NotificationError {
+    error: JsValue,
+    failed_ids: Vec<u32>,
+}
+
+impl From<JsValue> for NotificationError {
+    fn from(error: JsValue) -> Self {
+        Self {
+            error,
+            failed_ids: Vec::new(),
+        }
+    }
 }
 
 #[wasm_bindgen]
@@ -132,8 +146,7 @@ impl MiniJazzRuntime {
             .subscribe_query(parse_built_query(query)?)
             .map_err(to_js_error)?;
         let initial = subscription.initial_delta();
-        callback.call1(&JsValue::UNDEFINED, &to_js_value(initial)?)?;
-
+        let initial = to_js_value(initial)?;
         let id = self.next_subscription_id;
         self.next_subscription_id = self
             .next_subscription_id
@@ -146,6 +159,15 @@ impl MiniJazzRuntime {
                 callback,
             },
         );
+        let initial_callback = self
+            .subscriptions
+            .get(&id)
+            .map(|entry| entry.callback.clone())
+            .ok_or_else(|| JsValue::from_str("subscription disappeared before initial callback"))?;
+        if let Err(error) = initial_callback.call1(&JsValue::UNDEFINED, &initial) {
+            self.subscriptions.remove(&id);
+            return Err(error);
+        }
         Ok(id)
     }
 
@@ -188,27 +210,39 @@ impl MiniJazzRuntime {
         }
 
         self.notifying_subscriptions = true;
+        let mut first_error = None;
+        let mut skip_retry_ids = BTreeSet::new();
         loop {
             self.notify_subscriptions_again = false;
-            if let Err(error) = self.notify_subscriptions_once() {
-                self.notifying_subscriptions = false;
-                self.notify_subscriptions_again = false;
-                return Err(error);
+            if let Err(error) = self.notify_subscriptions_once(&skip_retry_ids) {
+                skip_retry_ids.extend(error.failed_ids);
+                if first_error.is_none() {
+                    first_error = Some(error.error);
+                }
             }
             if !self.notify_subscriptions_again {
                 break;
             }
         }
         self.notifying_subscriptions = false;
-        Ok(())
+        match first_error {
+            Some(error) => Err(error),
+            None => Ok(()),
+        }
     }
 
-    fn notify_subscriptions_once(&mut self) -> Result<(), JsValue> {
+    fn notify_subscriptions_once(
+        &mut self,
+        skip_retry_ids: &BTreeSet<u32>,
+    ) -> Result<(), NotificationError> {
         let runtime = &self.runtime;
         let ids = self.subscriptions.keys().copied().collect::<Vec<_>>();
         let mut pending = Vec::new();
 
         for id in ids {
+            if skip_retry_ids.contains(&id) {
+                continue;
+            }
             let Some(entry) = self.subscriptions.get(&id) else {
                 continue;
             };
@@ -231,6 +265,7 @@ impl MiniJazzRuntime {
         }
 
         let mut first_error = None;
+        let mut failed_ids = Vec::new();
         for notification in pending {
             if let Some(entry) = self.subscriptions.get_mut(&notification.id) {
                 entry.subscription = notification.next_subscription.clone();
@@ -245,6 +280,7 @@ impl MiniJazzRuntime {
                 if let Some(entry) = self.subscriptions.get_mut(&notification.id) {
                     entry.subscription = notification.previous_subscription;
                 }
+                failed_ids.push(notification.id);
                 if first_error.is_none() {
                     first_error = Some(error);
                 }
@@ -252,7 +288,7 @@ impl MiniJazzRuntime {
         }
 
         match first_error {
-            Some(error) => Err(error),
+            Some(error) => Err(NotificationError { error, failed_ids }),
             None => Ok(()),
         }
     }
@@ -306,6 +342,12 @@ mod tests {
         js_sys::Reflect::set(
             &global,
             &JsValue::from_str("__miniJazzThrowNext"),
+            &JsValue::FALSE,
+        )
+        .unwrap();
+        js_sys::Reflect::set(
+            &global,
+            &JsValue::from_str("__miniJazzSeenInitial"),
             &JsValue::FALSE,
         )
         .unwrap();
@@ -434,6 +476,107 @@ mod tests {
             .dyn_into()
             .unwrap();
         assert_eq!(all.get(0).as_string().as_deref(), Some("project-1"));
+    }
+
+    #[wasm_bindgen_test]
+    fn subscription_initial_callback_write_is_reported_to_new_subscription() {
+        reset_test_globals();
+        let mut runtime = MiniJazzRuntime::open_memory("alice-node", "alice").unwrap();
+        let runtime_ptr = &mut runtime as *mut MiniJazzRuntime;
+        let write_closure = Closure::<dyn FnMut()>::new(move || unsafe {
+            (*runtime_ptr)
+                .insert_row("projects", "project-1", project_values("Initial write"))
+                .unwrap();
+        });
+        js_sys::Reflect::set(
+            &js_sys::global(),
+            &JsValue::from_str("__miniJazzInitialWrite"),
+            write_closure.as_ref(),
+        )
+        .unwrap();
+        let callback = js_sys::Function::new_with_args(
+            "delta",
+            r#"
+            globalThis.__miniJazzDeltas.push({
+                allLength: delta.all.length,
+            });
+            if (!globalThis.__miniJazzSeenInitial) {
+                globalThis.__miniJazzSeenInitial = true;
+                globalThis.__miniJazzInitialWrite();
+            }
+            "#,
+        );
+
+        runtime
+            .subscribe(JsValue::from_str(r#"{"table":"projects"}"#), callback)
+            .unwrap();
+
+        let deltas = observed_deltas();
+        assert_eq!(deltas.length(), 2);
+        let refreshed = deltas.get(1);
+        assert_eq!(
+            js_sys::Reflect::get(&refreshed, &JsValue::from_str("allLength"))
+                .unwrap()
+                .as_f64(),
+            Some(1.0)
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn subscription_nested_write_still_notifies_when_later_callback_throws() {
+        reset_test_globals();
+        let mut runtime = MiniJazzRuntime::open_memory("alice-node", "alice").unwrap();
+        let seen_initial = Rc::new(Cell::new(false));
+        let wrote_nested_row = Rc::new(Cell::new(false));
+        let writer_callback_count = Rc::new(Cell::new(0));
+        let runtime_ptr = &mut runtime as *mut MiniJazzRuntime;
+        let writer_closure = Closure::<dyn FnMut(JsValue)>::new({
+            let seen_initial = Rc::clone(&seen_initial);
+            let wrote_nested_row = Rc::clone(&wrote_nested_row);
+            let writer_callback_count = Rc::clone(&writer_callback_count);
+            move |_| {
+                writer_callback_count.set(writer_callback_count.get() + 1);
+                if seen_initial.replace(true) && !wrote_nested_row.replace(true) {
+                    unsafe {
+                        (*runtime_ptr)
+                            .insert_row("projects", "project-2", project_values("Nested"))
+                            .unwrap();
+                    }
+                }
+            }
+        });
+        let writer = writer_closure
+            .as_ref()
+            .unchecked_ref::<js_sys::Function>()
+            .clone();
+        let throwing = js_sys::Function::new_with_args(
+            "delta",
+            r#"
+            if (globalThis.__miniJazzThrowNext) {
+                globalThis.__miniJazzThrowNext = false;
+                throw new Error("callback failed");
+            }
+            "#,
+        );
+
+        runtime
+            .subscribe(JsValue::from_str(r#"{"table":"projects"}"#), writer)
+            .unwrap();
+        runtime
+            .subscribe(JsValue::from_str(r#"{"table":"projects"}"#), throwing)
+            .unwrap();
+        assert_eq!(writer_callback_count.get(), 1);
+
+        set_throw_next();
+        let err = runtime
+            .insert_row("projects", "project-1", project_values("First"))
+            .unwrap_err();
+        let message = js_sys::Reflect::get(&err, &JsValue::from_str("message"))
+            .unwrap()
+            .as_string()
+            .unwrap();
+        assert_eq!(message, "callback failed");
+        assert_eq!(writer_callback_count.get(), 3);
     }
 
     #[wasm_bindgen_test]

--- a/crates/mini-jazz-sqlite-wasm/src/lib.rs
+++ b/crates/mini-jazz-sqlite-wasm/src/lib.rs
@@ -149,21 +149,6 @@ impl MiniJazzRuntime {
         to_js_value(self.runtime.read_rows(table_name).map_err(to_js_error)?)
     }
 
-    #[wasm_bindgen(js_name = readRowsWhereEq)]
-    pub fn read_rows_where_eq(
-        &self,
-        table_name: &str,
-        field_name: &str,
-        value: JsValue,
-    ) -> Result<JsValue, JsValue> {
-        let value = parse_json_value(value)?;
-        to_js_value(
-            self.runtime
-                .read_rows_where_eq(table_name, field_name, value)
-                .map_err(to_js_error)?,
-        )
-    }
-
     #[wasm_bindgen(js_name = storageStats)]
     pub fn storage_stats(&self) -> Result<JsValue, JsValue> {
         to_js_value(self.runtime.storage_stats().map_err(to_js_error)?)

--- a/crates/mini-jazz-sqlite-wasm/src/lib.rs
+++ b/crates/mini-jazz-sqlite-wasm/src/lib.rs
@@ -230,6 +230,7 @@ impl MiniJazzRuntime {
             }
         }
 
+        let mut first_error = None;
         for notification in pending {
             if let Some(entry) = self.subscriptions.get_mut(&notification.id) {
                 entry.subscription = notification.next_subscription.clone();
@@ -244,11 +245,16 @@ impl MiniJazzRuntime {
                 if let Some(entry) = self.subscriptions.get_mut(&notification.id) {
                     entry.subscription = notification.previous_subscription;
                 }
-                return Err(error);
+                if first_error.is_none() {
+                    first_error = Some(error);
+                }
             }
         }
 
-        Ok(())
+        match first_error {
+            Some(error) => Err(error),
+            None => Ok(()),
+        }
     }
 }
 
@@ -377,6 +383,57 @@ mod tests {
 
         assert_eq!(kinds.get(0).as_f64(), Some(0.0));
         assert_eq!(titles.get(0).as_string().as_deref(), Some("Retried"));
+    }
+
+    #[wasm_bindgen_test]
+    fn throwing_subscription_callback_does_not_block_later_callbacks() {
+        reset_test_globals();
+        let mut runtime = MiniJazzRuntime::open_memory("alice-node", "alice").unwrap();
+        let throwing = js_sys::Function::new_with_args(
+            "delta",
+            r#"
+            if (globalThis.__miniJazzThrowNext) {
+                globalThis.__miniJazzThrowNext = false;
+                throw new Error("callback failed");
+            }
+            "#,
+        );
+        let observer = js_sys::Function::new_with_args(
+            "delta",
+            r#"
+            globalThis.__miniJazzDeltas.push({
+                all: delta.all.map((row) => row.id),
+                kinds: delta.delta.map((change) => change.kind),
+            });
+            "#,
+        );
+
+        runtime
+            .subscribe(JsValue::from_str(r#"{"table":"projects"}"#), throwing)
+            .unwrap();
+        runtime
+            .subscribe(JsValue::from_str(r#"{"table":"projects"}"#), observer)
+            .unwrap();
+        assert_eq!(observed_deltas().length(), 1);
+
+        set_throw_next();
+        let err = runtime
+            .insert_row("projects", "project-1", project_values("First"))
+            .unwrap_err();
+        let message = js_sys::Reflect::get(&err, &JsValue::from_str("message"))
+            .unwrap()
+            .as_string()
+            .unwrap();
+        assert_eq!(message, "callback failed");
+
+        let deltas = observed_deltas();
+        assert_eq!(deltas.length(), 2);
+        let delivered = deltas.get(1);
+        let all: js_sys::Array = js_sys::Reflect::get(&delivered, &JsValue::from_str("all"))
+            .unwrap()
+            .dyn_into()
+            .unwrap();
+        assert_eq!(all.get(0).as_string().as_deref(), Some("project-1"));
     }
 
     #[wasm_bindgen_test]

--- a/crates/mini-jazz-sqlite/SPEC.md
+++ b/crates/mini-jazz-sqlite/SPEC.md
@@ -21,10 +21,10 @@ The full spec is split across focused files.
 - [Transactions](spec/08-transactions.md): Transaction modes, outcomes, read/write sets, and local/global behavior.
 - [History And Projection](spec/09-history-projection.md): Append-only row history and rebuildable current projections.
 - [Visibility, Snapshots, And Branches](spec/10-visibility-branches.md): Visibility relations, historical snapshots, and branch source provenance.
-- [Queries And Observed Facts](spec/11-queries-observed-facts.md): Query semantics, generic query descriptors, observed facts, aggregates, and sync-scope basis.
-- [Sync And Subscriptions](spec/12-sync-subscriptions.md): Sync bundles, query settlement, push subscriptions, and incoming sync application.
+- [Queries And Observed Facts](spec/11-queries-observed-facts.md): Query semantics, observed facts, aggregates, and sync-scope basis.
+- [Sync And Subscriptions](spec/12-sync-subscriptions.md): Sync bundles, query settlement, subscriptions, and incoming sync application.
 - [Authority And Conflicts](spec/13-authority-conflicts.md): Authority validation, dependency handling, conflict candidates, and resolution.
-- [Runtime And Public Boundary](spec/14-runtime-boundary.md): Semantic system fields, runtime topology, browser/WASM boundaries, files, errors, and wire/public boundaries.
+- [Runtime And Public Boundary](spec/14-runtime-boundary.md): Semantic system fields, runtime topology, files, errors, and wire/public boundaries.
 - [Embedded Database Lowering](spec/15-embedded-database-lowering.md): SQLite-oriented physical lowering details and indexes.
 - [Operations, Platform, And Tooling](spec/16-operations-platform-tooling.md): Security, export/backup, bindings, packaging, developer tooling, and admin workflows.
 - [Open Areas, Strategy, And Rationale](spec/17-open-areas-strategy-rationale.md): Known undefined areas, research discipline, optimization recommendations, implementation strategy, rationale, and future revisits.

--- a/crates/mini-jazz-sqlite/SPEC.md
+++ b/crates/mini-jazz-sqlite/SPEC.md
@@ -21,10 +21,10 @@ The full spec is split across focused files.
 - [Transactions](spec/08-transactions.md): Transaction modes, outcomes, read/write sets, and local/global behavior.
 - [History And Projection](spec/09-history-projection.md): Append-only row history and rebuildable current projections.
 - [Visibility, Snapshots, And Branches](spec/10-visibility-branches.md): Visibility relations, historical snapshots, and branch source provenance.
-- [Queries And Observed Facts](spec/11-queries-observed-facts.md): Query semantics, observed facts, aggregates, and sync-scope basis.
-- [Sync And Subscriptions](spec/12-sync-subscriptions.md): Sync bundles, query settlement, subscriptions, and incoming sync application.
+- [Queries And Observed Facts](spec/11-queries-observed-facts.md): Query semantics, generic query descriptors, observed facts, aggregates, and sync-scope basis.
+- [Sync And Subscriptions](spec/12-sync-subscriptions.md): Sync bundles, query settlement, push subscriptions, and incoming sync application.
 - [Authority And Conflicts](spec/13-authority-conflicts.md): Authority validation, dependency handling, conflict candidates, and resolution.
-- [Runtime And Public Boundary](spec/14-runtime-boundary.md): Semantic system fields, runtime topology, files, errors, and wire/public boundaries.
+- [Runtime And Public Boundary](spec/14-runtime-boundary.md): Semantic system fields, runtime topology, browser/WASM boundaries, files, errors, and wire/public boundaries.
 - [Embedded Database Lowering](spec/15-embedded-database-lowering.md): SQLite-oriented physical lowering details and indexes.
 - [Operations, Platform, And Tooling](spec/16-operations-platform-tooling.md): Security, export/backup, bindings, packaging, developer tooling, and admin workflows.
 - [Open Areas, Strategy, And Rationale](spec/17-open-areas-strategy-rationale.md): Known undefined areas, research discipline, optimization recommendations, implementation strategy, rationale, and future revisits.

--- a/crates/mini-jazz-sqlite/spec/07-policies.md
+++ b/crates/mini-jazz-sqlite/spec/07-policies.md
@@ -70,6 +70,14 @@ history exported for them must stay branch-scoped. A repair scan may consider
 history to find rows that left a predicate or page, but it must not use that as
 permission to send unrelated branch history or rows the requester cannot read.
 
+Read visibility planning is centralized for read surfaces. Query execution,
+sync export, query-scope repair, and policy dependency export must derive their
+current-row, snapshot-row, and effective-branch policy SQL from the same
+read-visibility context: requester, bypass mode, branch, branch sources, base
+snapshot epoch, and schema. Read paths must not call raw policy lowering
+directly, because that makes it too easy for query and export to disagree about
+which rows are visible. Write permission validation remains a separate flow.
+
 Policies may depend on rows other than the result row. In the running example,
 a todo read may depend on the referenced project row and the project membership
 rows that authorize Alice.

--- a/crates/mini-jazz-sqlite/spec/07-policies.md
+++ b/crates/mini-jazz-sqlite/spec/07-policies.md
@@ -29,6 +29,47 @@ Policy operations:
   influence downstream row visibility in that branch view
 - catalogue publication is admin/core-controlled rather than ordinary row policy
 
+## Server Permission Validation Flow
+
+Permission enforcement follows the current Jazz Tools server flow:
+
+1. Untrusted client writes enter the sync layer as pending permission checks
+   with client id, session, operation, branch, table metadata, old content when
+   known, new content when present, and row provenance.
+2. The query/runtime layer drains pending checks and resolves the structural
+   schema for the target branch. If the schema is temporarily unavailable, the
+   check is requeued; if it stays unavailable past the wait budget, the write is
+   rejected.
+3. The runtime resolves the current authorization schema from the published
+   permissions head for the target branch context. Dynamic servers are
+   fail-closed before the permissions head is available. A loaded empty
+   permissions bundle is still enforcing and grants nothing implicitly.
+4. Missing tables, malformed row content, missing required old/new content, and
+   missing provenance fail closed.
+5. Insert checks evaluate the table insert `WITH CHECK` policy against the
+   proposed row and payload provenance.
+6. Update checks evaluate `USING` against the old visible row/provenance and
+   `WITH CHECK` against the proposed row/provenance. If both clauses are
+   present, both must pass. If neither clause exists in enforcing mode, the
+   update is rejected.
+7. Delete checks evaluate explicit delete `USING` when present, otherwise the
+   effective update `USING` fallback. Missing explicit policy in enforcing mode
+   rejects.
+8. Approval applies the pending payload and may settle the sealed batch.
+   Rejection records a replayable rejected fate or emits a permission-denied
+   error for non-row payloads.
+
+Read/query permission validation is the same authority boundary, not a client
+cleanup pass. A server answering a user-scoped query must compile the read
+policy into the query plan, evaluate it in the same session, branch, schema,
+lens, and snapshot context as the query itself, and export only rows and policy
+dependency rows visible in that context. Query-scope repair rows are part of the
+same user-facing delivery surface: they must be collected with the checked-out
+branch view and requester read policy, never with admin/system bypass, and the
+history exported for them must stay branch-scoped. A repair scan may consider
+history to find rows that left a predicate or page, but it must not use that as
+permission to send unrelated branch history or rows the requester cannot read.
+
 Policies may depend on rows other than the result row. In the running example,
 a todo read may depend on the referenced project row and the project membership
 rows that authorize Alice.

--- a/crates/mini-jazz-sqlite/spec/11-queries-observed-facts.md
+++ b/crates/mini-jazz-sqlite/spec/11-queries-observed-facts.md
@@ -89,6 +89,14 @@ fallback paths for historical pinned-base branch snapshots, arbitrary historical
 snapshots, and other query-time visibility cases where no derived projection has
 been promoted yet.
 
+For the same logical dataset, branch scope, visibility policy, and query,
+result membership and ordering must not depend on storage-local identifiers such
+as row numbers, transaction row numbers, insertion order, or SQLite allocation
+order. Query ordering uses semantic values and public ids. For example, ordering
+by a ref field sorts by the public referenced row id, not by the local numeric
+row id used to store the ref. Pagination uses the same logical ordering, with a
+stable public tie-breaker.
+
 Query-scoped sync must include enough repair information for a receiver that
 previously synced the same scope to remove stale rows. Exporting only the
 current result rows is insufficient. If a row previously matched `done = false`

--- a/crates/mini-jazz-sqlite/spec/11-queries-observed-facts.md
+++ b/crates/mini-jazz-sqlite/spec/11-queries-observed-facts.md
@@ -15,6 +15,18 @@ A query plan contains:
 - observed-fact collector
 - expected index information when relevant
 
+The public query boundary should be a semantic query descriptor or relational
+IR, not a growing set of per-feature helper methods. TypeScript and framework
+packages may provide rich DSLs, but they lower to this descriptor before
+crossing into the Rust runtime or platform bindings. Native, WASM, and future
+language bindings pass the same semantic shape to the core query engine.
+
+The descriptor is allowed to be smaller than the eventual Jazz query model in
+early prototypes. Supported operators and graph features define the portable
+contract. Unsupported semantic features are outside that contract until they
+have a generic lowering, and should not be exposed through binding-specific
+shortcuts.
+
 Includes follow ordinary relational semantics:
 
 - required includes lower to inner joins

--- a/crates/mini-jazz-sqlite/spec/11-queries-observed-facts.md
+++ b/crates/mini-jazz-sqlite/spec/11-queries-observed-facts.md
@@ -27,11 +27,12 @@ contract. Unsupported semantic features are outside that contract until they
 have a generic lowering, and should not be exposed through binding-specific
 shortcuts.
 
-Supported descriptors should lower into the embedded database query engine.
-Predicate evaluation, ordering, limit, and offset belong in compiled SQL or an
-equivalent backend relational plan. The runtime may decode semantic rows after
-the backend returns candidates, but it should not fetch broad row sets and
-reimplement query filtering, sorting, or pagination in host-language code.
+Supported indexable query forms should lower to the embedded database on current
+projections. Falling back to full visible-row scans is optimization debt and
+should be named as such. The correctness baseline allows slower fallback paths
+for historical pinned-base branch snapshots, arbitrary historical snapshots, and
+other query-time visibility cases where no derived projection has been promoted
+yet.
 
 Includes follow ordinary relational semantics:
 

--- a/crates/mini-jazz-sqlite/spec/11-queries-observed-facts.md
+++ b/crates/mini-jazz-sqlite/spec/11-queries-observed-facts.md
@@ -27,6 +27,12 @@ contract. Unsupported semantic features are outside that contract until they
 have a generic lowering, and should not be exposed through binding-specific
 shortcuts.
 
+Supported descriptors should lower into the embedded database query engine.
+Predicate evaluation, ordering, limit, and offset belong in compiled SQL or an
+equivalent backend relational plan. The runtime may decode semantic rows after
+the backend returns candidates, but it should not fetch broad row sets and
+reimplement query filtering, sorting, or pagination in host-language code.
+
 Includes follow ordinary relational semantics:
 
 - required includes lower to inner joins

--- a/crates/mini-jazz-sqlite/spec/11-queries-observed-facts.md
+++ b/crates/mini-jazz-sqlite/spec/11-queries-observed-facts.md
@@ -15,25 +15,6 @@ A query plan contains:
 - observed-fact collector
 - expected index information when relevant
 
-The public query boundary should be a semantic query descriptor or relational
-IR, not a growing set of per-feature helper methods. TypeScript and framework
-packages may provide rich DSLs, but they lower to this descriptor before
-crossing into the Rust runtime or platform bindings. Native, WASM, and future
-language bindings pass the same semantic shape to the core query engine.
-
-The descriptor is allowed to be smaller than the eventual Jazz query model in
-early prototypes. Supported operators and graph features define the portable
-contract. Unsupported semantic features are outside that contract until they
-have a generic lowering, and should not be exposed through binding-specific
-shortcuts.
-
-Supported indexable query forms should lower to the embedded database on current
-projections. Falling back to full visible-row scans is optimization debt and
-should be named as such. The correctness baseline allows slower fallback paths
-for historical pinned-base branch snapshots, arbitrary historical snapshots, and
-other query-time visibility cases where no derived projection has been promoted
-yet.
-
 Includes follow ordinary relational semantics:
 
 - required includes lower to inner joins

--- a/crates/mini-jazz-sqlite/spec/12-sync-subscriptions.md
+++ b/crates/mini-jazz-sqlite/spec/12-sync-subscriptions.md
@@ -98,16 +98,6 @@ One-shot queries and live subscriptions share query semantics.
 A subscription is a long-lived query interest that keeps previous semantic rows
 and observed facts so later changes can be delivered as semantic diffs.
 
-Public subscriptions are push/callback APIs. Rerun queues, dirty flags, and
-projection-diff effects may exist inside the runtime, but they are scheduling
-mechanisms rather than the product-facing subscription contract.
-
-The first delivery of a subscription is the current semantic result for the same
-query and tier as a one-shot query. Later deliveries publish the current
-semantic result plus a deterministic diff from the previous delivered result.
-This keeps simple consumers able to replace their full local view while letting
-incremental consumers apply row-level changes.
-
 The baseline implementation reruns the query and diffs full semantic rows.
 Projection-diff effects may be used as an internal scheduling/invalidation
 artifact, but subscription callbacks expose semantic row diffs.

--- a/crates/mini-jazz-sqlite/spec/12-sync-subscriptions.md
+++ b/crates/mini-jazz-sqlite/spec/12-sync-subscriptions.md
@@ -136,8 +136,10 @@ not only the set of rows.
 Row diffs identify the semantic row by public id, describe the change kind, and
 carry the row's deterministic position in the newly delivered result for added
 or updated rows, or in the previous delivered result for removed rows. Added and
-updated diffs carry the new semantic item. Removed diffs do not need to carry
-the old item unless a higher-level binding chooses to retain it for ergonomics.
+updated diffs carry the new semantic item when the semantic row changed. An
+updated diff may omit the item when only the row position changed and the
+semantic row payload is unchanged. Removed diffs do not need to carry the old
+item unless a higher-level binding chooses to retain it for ergonomics.
 
 Tiered delivery:
 

--- a/crates/mini-jazz-sqlite/spec/12-sync-subscriptions.md
+++ b/crates/mini-jazz-sqlite/spec/12-sync-subscriptions.md
@@ -124,12 +124,12 @@ for ordered pages and subscriptions whose user-visible state is the sequence,
 not only the set of rows.
 
 Row diffs identify the semantic row by public id, describe the change kind, and
-carry the row's deterministic position in the newly delivered result for added
-or updated rows, or in the previous delivered result for removed rows. Added and
-updated diffs carry the new semantic item when the semantic row changed. An
-updated diff may omit the item when only the row position changed and the
-semantic row payload is unchanged. Removed diffs do not need to carry the old
-item unless a higher-level binding chooses to retain it for ergonomics.
+carry the row's deterministic position in the newly delivered result for added,
+updated, and moved rows, or in the previous delivered result for removed rows.
+Moved diffs also carry the previous result position. Added and updated diffs
+carry the new semantic row. Moved diffs do not carry a row payload because the
+semantic row is unchanged. Removed diffs do not need to carry the old row unless
+a higher-level binding chooses to retain it for ergonomics.
 
 Tiered delivery:
 

--- a/crates/mini-jazz-sqlite/spec/12-sync-subscriptions.md
+++ b/crates/mini-jazz-sqlite/spec/12-sync-subscriptions.md
@@ -126,10 +126,12 @@ not only the set of rows.
 Row diffs identify the semantic row by public id, describe the change kind, and
 carry the row's deterministic position in the newly delivered result for added,
 updated, and moved rows, or in the previous delivered result for removed rows.
-Moved diffs also carry the previous result position. Added and updated diffs
-carry the new semantic row. Moved diffs do not carry a row payload because the
-semantic row is unchanged. Removed diffs do not need to carry the old row unless
-a higher-level binding chooses to retain it for ergonomics.
+Added and updated diffs carry the new semantic row. Moved diffs do not carry a
+row payload because the semantic row is unchanged. At the JavaScript wire
+boundary, moved diffs use the existing `updated` row-change kind without a row
+payload (`kind: 2`, `id`, `index`) so existing subscription managers can reorder
+without learning a fourth wire kind. Removed diffs do not need to carry the old
+row unless a higher-level binding chooses to retain it for ergonomics.
 
 Tiered delivery:
 

--- a/crates/mini-jazz-sqlite/spec/12-sync-subscriptions.md
+++ b/crates/mini-jazz-sqlite/spec/12-sync-subscriptions.md
@@ -98,6 +98,16 @@ One-shot queries and live subscriptions share query semantics.
 A subscription is a long-lived query interest that keeps previous semantic rows
 and observed facts so later changes can be delivered as semantic diffs.
 
+Public subscriptions are push/callback APIs. Rerun queues, dirty flags, and
+projection-diff effects may exist inside the runtime, but they are scheduling
+mechanisms rather than the product-facing subscription contract.
+
+The first delivery of a subscription is the current semantic result for the same
+query and tier as a one-shot query. Later deliveries publish the current
+semantic result plus a deterministic diff from the previous delivered result.
+This keeps simple consumers able to replace their full local view while letting
+incremental consumers apply row-level changes.
+
 The baseline implementation reruns the query and diffs full semantic rows.
 Projection-diff effects may be used as an internal scheduling/invalidation
 artifact, but subscription callbacks expose semantic row diffs.
@@ -122,6 +132,12 @@ Diff categories:
 the same semantic value but changes position in the ordered result. This matters
 for ordered pages and subscriptions whose user-visible state is the sequence,
 not only the set of rows.
+
+Row diffs identify the semantic row by public id, describe the change kind, and
+carry the row's deterministic position in the newly delivered result for added
+or updated rows, or in the previous delivered result for removed rows. Added and
+updated diffs carry the new semantic item. Removed diffs do not need to carry
+the old item unless a higher-level binding chooses to retain it for ergonomics.
 
 Tiered delivery:
 

--- a/crates/mini-jazz-sqlite/spec/14-runtime-boundary.md
+++ b/crates/mini-jazz-sqlite/spec/14-runtime-boundary.md
@@ -40,11 +40,22 @@ The semantic runtime roles are:
 Runtime topology changes where storage lives and where queries settle. It must
 not change query, write, policy, branch, or sync meaning.
 
+The Rust runtime is the semantic boundary for one-shot query execution and live
+subscriptions. Platform bindings should expose generic query/subscription entry
+points over the runtime's semantic descriptor shape instead of duplicating query
+semantics in each host language.
+
 Browser durable mode may use:
 
 - main-thread in-memory runtime
 - durable worker runtime
 - SharedWorker or tab broker
+
+Browser WASM is a binding and storage topology, not a separate product model.
+It may run against memory-only SQLite or browser-durable storage such as OPFS,
+and it may live on the main thread or inside a worker. Those choices affect
+latency, persistence, and crash behavior, but not row semantics, query results,
+subscription diffs, transaction outcomes, or sync facts.
 
 The main thread may run queries directly against an in-memory core. In durable
 browser topology, each tab may have its own in-memory SQLite node connected to a

--- a/crates/mini-jazz-sqlite/spec/14-runtime-boundary.md
+++ b/crates/mini-jazz-sqlite/spec/14-runtime-boundary.md
@@ -45,6 +45,17 @@ subscriptions. Platform bindings should expose generic query/subscription entry
 points over the runtime's semantic descriptor shape instead of duplicating query
 semantics in each host language.
 
+The default browser/app binding surface should stay at the semantic API level:
+writes, `query`, `one`, `subscribe`, and storage/runtime administration. Lower
+level peer-transport hooks belong behind an explicit sync topology API rather
+than appearing as ordinary application methods.
+
+Query descriptor values crossing JS/WASM boundaries must be parsed as bounded
+values before execution. Numeric window fields such as limit and offset must be
+finite, non-negative integers representable by the runtime and SQLite execution
+types. Invalid or oversized values fail at the boundary instead of wrapping,
+truncating, or changing the requested page.
+
 Browser durable mode may use:
 
 - main-thread in-memory runtime

--- a/crates/mini-jazz-sqlite/spec/15-embedded-database-lowering.md
+++ b/crates/mini-jazz-sqlite/spec/15-embedded-database-lowering.md
@@ -130,12 +130,6 @@ query plans. Generated or side indexes over history payloads should be added
 only when measurements show a hot historical query, conflict lookup, or
 authority-validation path needs them.
 
-Ordered pagination over current projections is a storage-planning requirement,
-not a host-language filtering problem. Hot top-N queries should compile to
-`ORDER BY ... LIMIT/OFFSET` plans backed by indexes matching the predicate and
-order key. A large current table should not require materializing the full
-matching set in Rust just to return the first or last page.
-
 Storage compression should target whole SQLite pages or larger ordered ranges,
 not individual row payloads. Per-row history payload compression has too little
 compression window for the expected complexity. History table ordering and

--- a/crates/mini-jazz-sqlite/spec/15-embedded-database-lowering.md
+++ b/crates/mini-jazz-sqlite/spec/15-embedded-database-lowering.md
@@ -130,6 +130,12 @@ query plans. Generated or side indexes over history payloads should be added
 only when measurements show a hot historical query, conflict lookup, or
 authority-validation path needs them.
 
+Ordered pagination over current projections is a storage-planning requirement,
+not a host-language filtering problem. Hot top-N queries should compile to
+`ORDER BY ... LIMIT/OFFSET` plans backed by indexes matching the predicate and
+order key. A large current table should not require materializing the full
+matching set in Rust just to return the first or last page.
+
 Storage compression should target whole SQLite pages or larger ordered ranges,
 not individual row payloads. Per-row history payload compression has too little
 compression window for the expected complexity. History table ordering and

--- a/crates/mini-jazz-sqlite/spec/16-operations-platform-tooling.md
+++ b/crates/mini-jazz-sqlite/spec/16-operations-platform-tooling.md
@@ -96,6 +96,13 @@ Bindings must agree on:
 - conflict metadata shape
 - error/rejection shape
 
+Binding APIs may be idiomatic, but they must remain thin over the core semantic
+operations. A binding can wrap query descriptors in a fluent DSL, generated
+types, callbacks, promises, or framework hooks; it should not introduce
+host-specific query helpers that cannot be expressed as the same core query
+descriptor. The cross-binding contract is limited to descriptors supported by
+the core query language.
+
 Higher-level language bindings should expose idiomatic values while preserving
 the same database semantics. TypeScript/JavaScript bindings are the concrete
 compatibility example: `BYTEA` values become `Uint8Array`, timestamps become

--- a/crates/mini-jazz-sqlite/spec/17-open-areas-strategy-rationale.md
+++ b/crates/mini-jazz-sqlite/spec/17-open-areas-strategy-rationale.md
@@ -381,7 +381,7 @@ Core verbs:
 - `apply_bundle`
 - `validate_at_authority`
 - `repair_projection`
-- `deliver_subscription_update`
+- `poll_subscription`
 
 Suggested slices:
 

--- a/crates/mini-jazz-sqlite/spec/17-open-areas-strategy-rationale.md
+++ b/crates/mini-jazz-sqlite/spec/17-open-areas-strategy-rationale.md
@@ -381,7 +381,7 @@ Core verbs:
 - `apply_bundle`
 - `validate_at_authority`
 - `repair_projection`
-- `poll_subscription`
+- `deliver_subscription_update`
 
 Suggested slices:
 

--- a/crates/mini-jazz-sqlite/spec/18-invariants.md
+++ b/crates/mini-jazz-sqlite/spec/18-invariants.md
@@ -165,11 +165,13 @@ feature exists.
 - Bundle locators dedupe concrete rows/transactions even when facts repeat.
 - Normalized predicates/ranges compare deterministically for supported planner
   forms.
-- Query-scope refresh repairs rows that leave a predicate through an update.
-- Query-scope refresh repairs rows that leave a predicate through a delete by
-  sending tombstone history.
-- Query-scope export includes predicate observed facts with table, field, value,
-  and branch context for supported predicates.
+- Query-scope refresh repairs rows that leave a supported query condition set
+  through an update, including multi-filter built queries and queries with
+  ordering/windowing.
+- Query-scope refresh repairs rows that leave a supported query condition set
+  through a delete by sending tombstone history.
+- Query-scope export includes observed facts with table, condition descriptor,
+  and branch context for supported predicate reads and built-query descriptors.
 - Query-scope repair rows may be included even when they are no longer semantic
   result rows.
 - Query-scope export dedupes concrete history records included for several

--- a/crates/mini-jazz-sqlite/spec/18-invariants.md
+++ b/crates/mini-jazz-sqlite/spec/18-invariants.md
@@ -176,6 +176,11 @@ feature exists.
   reasons.
 - Recursive query-scope export includes deleted descendant subtrees, not only
   direct deleted children.
+- Public query APIs expose generic semantic descriptors rather than
+  app-specific query helper methods.
+- Native, WASM, and higher-level bindings execute the same supported query
+  descriptor with the same semantic result.
+- Cross-binding query semantics cover supported query descriptor features.
 
 ### D.7 Sync Invariants
 
@@ -202,10 +207,16 @@ feature exists.
 
 - Subscription first delivery equals the corresponding one-shot query at the
   same tier.
+- Public subscriptions are push/callback APIs; rerun scheduling is internal,
+  not the application-facing contract.
+- Subscription deliveries include the current semantic result and deterministic
+  row-level changes from the previous delivered result.
 - Subscription updates are semantic row diffs.
 - Ordered subscriptions emit deterministic moved diffs for order-only changes.
 - Subscription diff ordering is deterministic and follows the same effective
   ordering as the corresponding query result.
+- Subscription row changes identify public row ids, change kind, and stable
+  result positions; added and updated changes carry the new semantic item.
 - Dependency-only changes can update parent semantic rows.
 - Every subscription update is tier-gated.
 - Rows may arrive before query settlement without being published.
@@ -379,6 +390,10 @@ feature exists.
   columns according to stable JS boundary rules.
 - Generated row/result layout follows declared schema order plus requested
   includes and subscription deltas.
+- Browser WASM exposes the same supported query and subscription semantics as
+  the native runtime.
+- Browser storage and worker topology affect persistence and latency, not row,
+  query, subscription, transaction, or sync meaning.
 
 ### D.15 File/Blob Invariants
 

--- a/crates/mini-jazz-sqlite/spec/18-invariants.md
+++ b/crates/mini-jazz-sqlite/spec/18-invariants.md
@@ -221,7 +221,9 @@ feature exists.
 - Subscription diff ordering is deterministic and follows the same effective
   ordering as the corresponding query result.
 - Subscription row changes identify public row ids, change kind, and stable
-  result positions; added and updated changes carry the new semantic item.
+  result positions; added changes carry the new semantic item. Updated changes
+  carry the new semantic item when the semantic row changed, and may omit it
+  when only the result position changed.
 - Dependency-only changes can update parent semantic rows.
 - Every subscription update is tier-gated.
 - Rows may arrive before query settlement without being published.

--- a/crates/mini-jazz-sqlite/spec/18-invariants.md
+++ b/crates/mini-jazz-sqlite/spec/18-invariants.md
@@ -165,30 +165,17 @@ feature exists.
 - Bundle locators dedupe concrete rows/transactions even when facts repeat.
 - Normalized predicates/ranges compare deterministically for supported planner
   forms.
-- Query-scope refresh repairs rows that leave a supported query condition set
-  through an update, including multi-filter built queries and queries with
-  ordering/windowing.
-- Query-scope refresh repairs rows that leave a supported query condition set
-  through a delete by sending tombstone history.
-- Query-scope export includes observed facts with table, condition descriptor,
-  and branch context for supported predicate reads and built-query descriptors.
+- Query-scope refresh repairs rows that leave a predicate through an update.
+- Query-scope refresh repairs rows that leave a predicate through a delete by
+  sending tombstone history.
+- Query-scope export includes predicate observed facts with table, field, value,
+  and branch context for supported predicates.
 - Query-scope repair rows may be included even when they are no longer semantic
   result rows.
 - Query-scope export dedupes concrete history records included for several
   reasons.
 - Recursive query-scope export includes deleted descendant subtrees, not only
   direct deleted children.
-- Public query APIs expose generic semantic descriptors rather than
-  app-specific query helper methods.
-- Native, WASM, and higher-level bindings execute the same supported query
-  descriptor with the same semantic result.
-- Cross-binding query semantics cover supported query descriptor features.
-- Supported indexable predicates, ordering, limit, and offset on current
-  projections are executed by the storage query plan. Full visible-row scans are
-  optimization debt reserved for historical or unpromoted visibility cases.
-- Query window values crossing platform boundaries fail on invalid or oversized
-  values instead of wrapping, truncating, or silently changing the requested
-  page.
 
 ### D.7 Sync Invariants
 
@@ -215,18 +202,10 @@ feature exists.
 
 - Subscription first delivery equals the corresponding one-shot query at the
   same tier.
-- Public subscriptions are push/callback APIs; rerun scheduling is internal,
-  not the application-facing contract.
-- Subscription deliveries include the current semantic result and deterministic
-  row-level changes from the previous delivered result.
 - Subscription updates are semantic row diffs.
 - Ordered subscriptions emit deterministic moved diffs for order-only changes.
 - Subscription diff ordering is deterministic and follows the same effective
   ordering as the corresponding query result.
-- Subscription row changes identify public row ids, change kind, and stable
-  result positions; added changes carry the new semantic item. Updated changes
-  carry the new semantic item when the semantic row changed, and may omit it
-  when only the result position changed.
 - Dependency-only changes can update parent semantic rows.
 - Every subscription update is tier-gated.
 - Rows may arrive before query settlement without being published.
@@ -400,10 +379,6 @@ feature exists.
   columns according to stable JS boundary rules.
 - Generated row/result layout follows declared schema order plus requested
   includes and subscription deltas.
-- Browser WASM exposes the same supported query and subscription semantics as
-  the native runtime.
-- Browser storage and worker topology affect persistence and latency, not row,
-  query, subscription, transaction, or sync meaning.
 
 ### D.15 File/Blob Invariants
 

--- a/crates/mini-jazz-sqlite/spec/18-invariants.md
+++ b/crates/mini-jazz-sqlite/spec/18-invariants.md
@@ -143,6 +143,11 @@ feature exists.
 
 - One-shot queries and subscriptions share query semantics.
 - Query results are deterministic even without explicit user ordering.
+- Query results and pagination are independent of storage-local identifiers
+  such as row numbers, transaction row numbers, insertion order, or SQLite
+  allocation order.
+- Ordering by a ref field uses the public referenced row id, not the local
+  numeric row id used to store the ref.
 - Queries return semantic rows and observed facts.
 - Required includes filter out the parent when missing or unauthorized.
 - Optional includes preserve the parent and return null/absent when missing or

--- a/crates/mini-jazz-sqlite/spec/18-invariants.md
+++ b/crates/mini-jazz-sqlite/spec/18-invariants.md
@@ -181,6 +181,11 @@ feature exists.
 - Native, WASM, and higher-level bindings execute the same supported query
   descriptor with the same semantic result.
 - Cross-binding query semantics cover supported query descriptor features.
+- Supported predicates, ordering, limit, and offset are executed by the storage
+  query plan, not by broad host-language post-processing.
+- Query window values crossing platform boundaries fail on invalid or oversized
+  values instead of wrapping, truncating, or silently changing the requested
+  page.
 
 ### D.7 Sync Invariants
 

--- a/crates/mini-jazz-sqlite/spec/18-invariants.md
+++ b/crates/mini-jazz-sqlite/spec/18-invariants.md
@@ -183,8 +183,9 @@ feature exists.
 - Native, WASM, and higher-level bindings execute the same supported query
   descriptor with the same semantic result.
 - Cross-binding query semantics cover supported query descriptor features.
-- Supported predicates, ordering, limit, and offset are executed by the storage
-  query plan, not by broad host-language post-processing.
+- Supported indexable predicates, ordering, limit, and offset on current
+  projections are executed by the storage query plan. Full visible-row scans are
+  optimization debt reserved for historical or unpromoted visibility cases.
 - Query window values crossing platform boundaries fail on invalid or oversized
   values instead of wrapping, truncating, or silently changing the requested
   page.

--- a/crates/mini-jazz-sqlite/spec/19-prototype-test-traceability.md
+++ b/crates/mini-jazz-sqlite/spec/19-prototype-test-traceability.md
@@ -131,6 +131,8 @@ Coverage labels:
 - `query_predicate_reads_survive_bundle_serialization`: D.6, D.7
 - `generic_equality_query_lowers_public_ref_ids_to_physical_row_ids`: D.1,
   D.6, D.14
+- `generic_ref_field_order_uses_public_ref_ids`: D.1, D.6
+- `branch_ref_field_order_uses_public_ref_ids`: D.1, D.5, D.6
 - `generic_update_records_update_op_and_syncs_current_value`: D.2, D.3, D.7
 
 #### `policies.rs`

--- a/crates/mini-jazz-sqlite/src/lib.rs
+++ b/crates/mini-jazz-sqlite/src/lib.rs
@@ -7,6 +7,7 @@ mod query;
 mod query_api;
 mod query_predicate;
 mod read_set;
+mod read_visibility;
 mod rows;
 mod runtime;
 mod schema;

--- a/crates/mini-jazz-sqlite/src/lib.rs
+++ b/crates/mini-jazz-sqlite/src/lib.rs
@@ -4,6 +4,7 @@ mod error;
 mod policy;
 mod projection;
 mod query;
+mod query_api;
 mod query_predicate;
 mod read_set;
 mod rows;
@@ -19,11 +20,12 @@ mod types;
 mod users;
 
 pub use error::{Error, Result};
+pub use query_api::{BuiltQuery, QueryCondition, QueryConditionOp, QueryDirection, QueryOrderBy};
 pub use runtime::Runtime;
 pub use schema::SchemaDef;
 pub use storage::Storage;
 pub use subscription::RowsSubscription;
 pub use types::{
     ApplyBundleProfile, QueryExportProfile, RejectionInfo, RowDiff, RowView, StorageStats,
-    TransactionInfo,
+    SubscriptionDelta, SubscriptionRowDelta, TransactionInfo,
 };

--- a/crates/mini-jazz-sqlite/src/policy.rs
+++ b/crates/mini-jazz-sqlite/src/policy.rs
@@ -192,10 +192,6 @@ fn effective_branch_sql(alias: &str, table_name: &str, branch_num: i64) -> Strin
     )
 }
 
-pub(crate) fn read_policy_sql(schema: &SchemaDef, table: &TableDef, user: &str) -> Result<String> {
-    lower_policy(schema, table, "current", &table.read_policy, user, None, 0)
-}
-
 pub(crate) fn branch_read_policy_sql_for_alias(
     schema: &SchemaDef,
     table: &TableDef,

--- a/crates/mini-jazz-sqlite/src/query.rs
+++ b/crates/mini-jazz-sqlite/src/query.rs
@@ -42,6 +42,20 @@ pub(crate) fn storage_plan(query: &BuiltQuery) -> Option<QueryStoragePlan<'_>> {
     }
 }
 
+pub(crate) fn query_scope_predicate(query: &BuiltQuery) -> Result<Option<&QueryCondition>> {
+    if query.conditions.len() != 1
+        || !query.order_by.is_empty()
+        || query.limit.is_some()
+        || query.offset.unwrap_or(0) != 0
+    {
+        return Err(crate::Error::new(
+            "export_query supports one predicate, or one eq predicate ordered by $createdAt desc with a limit",
+        ));
+    }
+
+    Ok(query.conditions.first())
+}
+
 impl QueryContext<'_> {
     pub(crate) fn read_rows(&self, table_name: &str) -> Result<Vec<RowView>> {
         if self.branch_num != 1 {

--- a/crates/mini-jazz-sqlite/src/query.rs
+++ b/crates/mini-jazz-sqlite/src/query.rs
@@ -53,6 +53,8 @@ impl QueryContext<'_> {
         }
         let (candidates_sql, mut params) = self.lower_query_candidates(query, table)?;
         let order_sql = self.lower_query_order(table, &query.order_by)?;
+        let defer_window_until_effective_policy =
+            self.defer_query_window_until_effective_branch_policy(table, query, base_epoch);
         let field_columns = table
             .fields
             .iter()
@@ -76,15 +78,8 @@ impl QueryContext<'_> {
              ORDER BY {order_sql}",
             select_columns.join(", "),
         );
-        if let Some(limit) = query.limit {
-            sql.push_str(" LIMIT ?");
-            params.push(SqlValue::Integer(window_value_to_i64(limit, "limit")?));
-        } else if query.offset.is_some() {
-            sql.push_str(" LIMIT -1");
-        }
-        if let Some(offset) = query.offset {
-            sql.push_str(" OFFSET ?");
-            params.push(SqlValue::Integer(window_value_to_i64(offset, "offset")?));
+        if !defer_window_until_effective_policy {
+            append_query_window_sql(&mut sql, &mut params, query.limit, query.offset)?;
         }
 
         let mut stmt = self.conn.prepare(&sql)?;
@@ -94,11 +89,14 @@ impl QueryContext<'_> {
                 .map(|idx| row.get::<_, SqlValue>(idx))
                 .collect::<rusqlite::Result<Vec<_>>>()
         })?;
-        let rows = rows
+        let mut rows = rows
             .map(|row| row_to_view(self.conn, &query.table, table, row?))
             .collect::<Result<Vec<_>>>()?;
         if self.branch_num != 1 && base_epoch.is_some() {
-            return self.filter_rows_by_effective_branch_policy(&query.table, rows);
+            rows = self.filter_rows_by_effective_branch_policy(&query.table, rows)?;
+        }
+        if defer_window_until_effective_policy {
+            rows = apply_query_window(rows, query.limit, query.offset);
         }
         Ok(rows)
     }
@@ -146,16 +144,7 @@ impl QueryContext<'_> {
             SqlValue::Integer(tx::OUTCOME_REJECTED),
         ];
         query_params.append(&mut params);
-        if let Some(limit) = query.limit {
-            sql.push_str(" LIMIT ?");
-            query_params.push(SqlValue::Integer(window_value_to_i64(limit, "limit")?));
-        } else if query.offset.is_some() {
-            sql.push_str(" LIMIT -1");
-        }
-        if let Some(offset) = query.offset {
-            sql.push_str(" OFFSET ?");
-            query_params.push(SqlValue::Integer(window_value_to_i64(offset, "offset")?));
-        }
+        append_query_window_sql(&mut sql, &mut query_params, query.limit, query.offset)?;
 
         let mut stmt = self.conn.prepare(&sql)?;
         let row_width = 2 + table.fields.len() + 1;
@@ -1394,6 +1383,19 @@ impl QueryContext<'_> {
             .collect())
     }
 
+    fn defer_query_window_until_effective_branch_policy(
+        &self,
+        table: &crate::schema::TableDef,
+        query: &BuiltQuery,
+        base_epoch: Option<i64>,
+    ) -> bool {
+        !self.bypass_policy
+            && self.branch_num != 1
+            && base_epoch.is_some()
+            && (query.limit.is_some() || query.offset.is_some())
+            && matches!(table.read_policy, PolicyDef::RefReadable { .. })
+    }
+
     fn row_view_visible_in_branch(
         &self,
         table_name: &str,
@@ -2091,6 +2093,40 @@ fn query_column_is_text(column: &QueryColumn<'_>) -> bool {
 
 fn window_value_to_i64(value: usize, field: &str) -> Result<i64> {
     i64::try_from(value).map_err(|_| crate::Error::new(format!("query {field} is too large")))
+}
+
+fn append_query_window_sql(
+    sql: &mut String,
+    params: &mut Vec<SqlValue>,
+    limit: Option<usize>,
+    offset: Option<usize>,
+) -> Result<()> {
+    if let Some(limit) = limit {
+        sql.push_str(" LIMIT ?");
+        params.push(SqlValue::Integer(window_value_to_i64(limit, "limit")?));
+    } else if offset.is_some() {
+        sql.push_str(" LIMIT -1");
+    }
+    if let Some(offset) = offset {
+        sql.push_str(" OFFSET ?");
+        params.push(SqlValue::Integer(window_value_to_i64(offset, "offset")?));
+    }
+    Ok(())
+}
+
+fn apply_query_window(
+    rows: Vec<RowView>,
+    limit: Option<usize>,
+    offset: Option<usize>,
+) -> Vec<RowView> {
+    let mut rows = rows
+        .into_iter()
+        .skip(offset.unwrap_or(0))
+        .collect::<Vec<_>>();
+    if let Some(limit) = limit {
+        rows.truncate(limit);
+    }
+    rows
 }
 
 fn row_to_view(

--- a/crates/mini-jazz-sqlite/src/query.rs
+++ b/crates/mini-jazz-sqlite/src/query.rs
@@ -19,45 +19,6 @@ pub(crate) struct QueryContext<'a> {
     pub(crate) bypass_policy: bool,
 }
 
-pub(crate) enum QueryStoragePlan<'a> {
-    EqCreatedAtDescPage {
-        condition: &'a QueryCondition,
-        limit: usize,
-    },
-}
-
-pub(crate) fn storage_plan(query: &BuiltQuery) -> Option<QueryStoragePlan<'_>> {
-    if query.offset.unwrap_or(0) != 0 || query.conditions.len() != 1 || query.order_by.len() != 1 {
-        return None;
-    }
-    let condition = query.conditions.first()?;
-    if condition.op != QueryConditionOp::Eq {
-        return None;
-    }
-    let order = query.order_by.first()?;
-    if order.column == "$createdAt" && order.direction == QueryDirection::Desc {
-        query
-            .limit
-            .map(|limit| QueryStoragePlan::EqCreatedAtDescPage { condition, limit })
-    } else {
-        None
-    }
-}
-
-pub(crate) fn query_scope_predicate(query: &BuiltQuery) -> Result<Option<&QueryCondition>> {
-    if query.conditions.len() != 1
-        || !query.order_by.is_empty()
-        || query.limit.is_some()
-        || query.offset.unwrap_or(0) != 0
-    {
-        return Err(crate::Error::new(
-            "export_query supports one predicate, or one eq predicate ordered by $createdAt desc with a limit",
-        ));
-    }
-
-    Ok(query.conditions.first())
-}
-
 struct LoweredCondition {
     sql: String,
     params: Vec<SqlValue>,

--- a/crates/mini-jazz-sqlite/src/query.rs
+++ b/crates/mini-jazz-sqlite/src/query.rs
@@ -1,5 +1,5 @@
 use crate::query_api::{
-    BuiltQuery, QueryCondition, QueryConditionOp, QueryDirection, QueryOrderBy,
+    predicate_query, BuiltQuery, QueryCondition, QueryConditionOp, QueryDirection, QueryOrderBy,
 };
 use crate::rows::{public_row_id, row_num};
 use crate::schema::{FieldDef, FieldKind, PolicyDef, SchemaDef};
@@ -83,61 +83,11 @@ impl QueryContext<'_> {
         self.read_rows_from_current(table_name, true)
     }
 
-    pub(crate) fn read_rows_where_eq(
-        &self,
-        table_name: &str,
-        field_name: &str,
-        value: JsonValue,
-    ) -> Result<Vec<RowView>> {
-        if field_name == "id" {
-            let Some(id) = value.as_str() else {
-                return Err(crate::Error::new("id equality expects a string value"));
-            };
-            return Ok(self
-                .read_rows(table_name)?
-                .into_iter()
-                .filter(|row| row.id == id)
-                .collect());
-        }
-        if field_name == "$createdBy" {
-            let Some(created_by) = value.as_str() else {
-                return Err(crate::Error::new(
-                    "$createdBy equality expects a string value",
-                ));
-            };
-            return Ok(self
-                .read_rows(table_name)?
-                .into_iter()
-                .filter(|row| row.created_by == created_by)
-                .collect());
-        }
-        let table = self.schema.table_def(table_name)?;
-        let field = table
-            .fields
-            .iter()
-            .find(|field| field.name == field_name)
-            .ok_or_else(|| crate::Error::new(format!("unknown field {table_name}.{field_name}")))?;
-        if self.branch_num != 1 {
-            if let Some(base_epoch) = branch::base_global_epoch(self.conn, self.branch_num)? {
-                let mut rows =
-                    self.read_rows_from_current_where_eq(table_name, field, &value, false)?;
-                rows.extend(
-                    self.read_main_snapshot_rows(table_name, base_epoch)?
-                        .into_iter()
-                        .filter(|row| row.values.get(field_name) == Some(&value)),
-                );
-                return self.filter_rows_by_effective_branch_policy(table_name, rows);
-            }
-        }
-        self.read_rows_from_current_where_eq(table_name, field, &value, true)
-    }
-
     pub(crate) fn read_rows_for_built_query(&self, query: &BuiltQuery) -> Result<Vec<RowView>> {
         let table = self.schema.table_def(&query.table)?;
         let scope_nums = branch::scope_nums(self.conn, self.branch_num)?;
-        if scope_nums == [self.branch_num]
-            && branch::base_global_epoch(self.conn, self.branch_num)?.is_none()
-        {
+        let base_epoch = branch::base_global_epoch(self.conn, self.branch_num)?;
+        if self.branch_num == 1 && scope_nums == [self.branch_num] && base_epoch.is_none() {
             return self.read_current_built_query(query, table);
         }
         let (candidates_sql, mut params) = self.lower_query_candidates(query, table)?;
@@ -183,8 +133,13 @@ impl QueryContext<'_> {
                 .map(|idx| row.get::<_, SqlValue>(idx))
                 .collect::<rusqlite::Result<Vec<_>>>()
         })?;
-        rows.map(|row| row_to_view(self.conn, &query.table, table, row?))
-            .collect()
+        let rows = rows
+            .map(|row| row_to_view(self.conn, &query.table, table, row?))
+            .collect::<Result<Vec<_>>>()?;
+        if self.branch_num != 1 && base_epoch.is_some() {
+            return self.filter_rows_by_effective_branch_policy(&query.table, rows);
+        }
+        Ok(rows)
     }
 
     fn read_current_built_query(
@@ -708,7 +663,8 @@ impl QueryContext<'_> {
             )? {
                 return Ok(rows);
             }
-            let mut rows = self.read_rows_where_eq(table_name, field_name, value)?;
+            let query = predicate_query(table_name, field_name, QueryConditionOp::Eq, value);
+            let mut rows = self.read_rows_for_built_query(&query)?;
             rows.sort_by(|left, right| {
                 json_sort_key(right.values.get(order_field_name))
                     .cmp(&json_sort_key(left.values.get(order_field_name)))
@@ -1647,138 +1603,6 @@ impl QueryContext<'_> {
             rusqlite::types::Value::Integer(self.branch_num),
             rusqlite::types::Value::Integer(self.branch_num),
         ]);
-        let mut stmt = self.conn.prepare(&sql)?;
-        let row_width = 3 + table.fields.len() + 1;
-        let rows = stmt.query_map(params_from_iter(params.iter()), |row| {
-            (0..row_width)
-                .map(|idx| row.get::<_, rusqlite::types::Value>(idx))
-                .collect::<rusqlite::Result<Vec<_>>>()
-        })?;
-        let rows = rows
-            .map(|row| {
-                let mut row = row?;
-                let branch_num = branch_num_from_row(&mut row)?;
-                Ok((branch_num, row_to_view(self.conn, table_name, table, row)?))
-            })
-            .collect::<Result<Vec<_>>>()?;
-        self.collapse_shadowed_current_rows(rows)
-    }
-
-    fn read_rows_from_current_where_eq(
-        &self,
-        table_name: &str,
-        field: &FieldDef,
-        value: &JsonValue,
-        overlay_main: bool,
-    ) -> Result<Vec<RowView>> {
-        let table = self.schema.table_def(table_name)?;
-        let field_columns = table
-            .fields
-            .iter()
-            .map(|field| crate::schema::quote_ident(&crate::schema::storage_column(field)))
-            .collect::<Vec<_>>();
-        let mut select_columns = vec![
-            "current.j_branch_num".to_owned(),
-            "ids.row_id".to_owned(),
-            "tx.tx_id".to_owned(),
-        ];
-        select_columns.extend(
-            field_columns
-                .iter()
-                .map(|column| format!("current.{column}")),
-        );
-        select_columns.push(format!(
-            "{} AS j_created_by",
-            users::user_id_expr("current", "j_created_by")
-        ));
-        let predicate_column = crate::schema::quote_ident(&crate::schema::storage_column(field));
-        let (predicate_sql, predicate_value) = if value.is_null() {
-            if !field.nullable {
-                return Err(crate::Error::new(format!(
-                    "expected non-null for {}",
-                    field.name
-                )));
-            }
-            ("IS NULL".to_owned(), None)
-        } else {
-            (
-                "= ?".to_owned(),
-                Some(crate::schema::field_sql_value(
-                    field,
-                    value,
-                    |ref_table, row_id| {
-                        row_num(self.conn, row_id).map_err(|err| {
-                            crate::Error::new(format!(
-                                "failed to resolve ref {ref_table}.{row_id} for equality predicate: {err}"
-                            ))
-                        })
-                    },
-                )?),
-            )
-        };
-        let scope_nums = branch::scope_nums(self.conn, self.branch_num)?;
-        let scope_placeholders = placeholders(scope_nums.len());
-        let sql = format!(
-            "SELECT {}
-             FROM {} current
-             JOIN jazz_row_id ids ON ids.row_num = current.row_num
-             JOIN jazz_tx tx ON tx.tx_num = current.visible_tx_num
-            WHERE current.is_deleted = 0
-               AND (
-                 current.j_branch_num IN ({scope_placeholders})
-                 OR (
-                   ? = 1
-                   AND ? != 1
-                   AND current.j_branch_num = 1
-                   AND NOT EXISTS (
-                     SELECT 1
-                     FROM {current_table} branch_current
-                     WHERE branch_current.row_num = current.row_num
-                       AND branch_current.j_branch_num IN ({scope_placeholders})
-                   )
-                 )
-               )
-               AND tx.outcome != ?
-               AND NOT (
-                 current.j_branch_num != ?
-                 AND EXISTS (
-                   SELECT 1
-                   FROM {current_table} active_current
-                   WHERE active_current.row_num = current.row_num
-                     AND active_current.j_branch_num = ?
-                 )
-               )
-               AND current.{predicate_column} {predicate_sql}
-               AND {policy_sql}
-             ORDER BY current.j_created_at DESC, current.row_num",
-            select_columns.join(", "),
-            crate::schema::current_table(table_name),
-            current_table = crate::schema::current_table(table_name),
-            policy_sql = self.read_policy_sql(table)?,
-        );
-        let mut params = scope_nums
-            .iter()
-            .copied()
-            .map(rusqlite::types::Value::Integer)
-            .collect::<Vec<_>>();
-        params.extend([
-            rusqlite::types::Value::Integer(if overlay_main { 1 } else { 0 }),
-            rusqlite::types::Value::Integer(self.branch_num),
-        ]);
-        params.extend(
-            scope_nums
-                .iter()
-                .copied()
-                .map(rusqlite::types::Value::Integer),
-        );
-        params.extend([
-            rusqlite::types::Value::Integer(tx::OUTCOME_REJECTED),
-            rusqlite::types::Value::Integer(self.branch_num),
-            rusqlite::types::Value::Integer(self.branch_num),
-        ]);
-        if let Some(predicate_value) = predicate_value {
-            params.push(predicate_value);
-        }
         let mut stmt = self.conn.prepare(&sql)?;
         let row_width = 3 + table.fields.len() + 1;
         let rows = stmt.query_map(params_from_iter(params.iter()), |row| {

--- a/crates/mini-jazz-sqlite/src/query.rs
+++ b/crates/mini-jazz-sqlite/src/query.rs
@@ -1,10 +1,11 @@
 use crate::query_api::{
     predicate_query, BuiltQuery, QueryCondition, QueryConditionOp, QueryDirection, QueryOrderBy,
 };
+use crate::read_visibility::ReadVisibility;
 use crate::rows::{public_row_id, row_num};
 use crate::schema::{FieldDef, FieldKind, PolicyDef, SchemaDef};
 use crate::types::RowView;
-use crate::{branch, policy, tx, users, Result};
+use crate::{branch, tx, users, Result};
 use rusqlite::{params, params_from_iter, types::Value as SqlValue, Connection, OptionalExtension};
 use serde_json::Value as JsonValue;
 use std::collections::BTreeMap;
@@ -138,13 +139,7 @@ impl QueryContext<'_> {
         let policy_sql = if self.bypass_policy {
             "1 = 1".to_owned()
         } else {
-            policy::branch_read_policy_sql_for_alias(
-                self.schema,
-                table,
-                "h",
-                self.user,
-                self.branch_num,
-            )?
+            self.visibility().current_policy_sql(table, "h")?
         };
         let branch_placeholders = placeholders(branch_nums.len());
         let sql = format!(
@@ -185,13 +180,8 @@ impl QueryContext<'_> {
         let policy_sql = if self.bypass_policy {
             "1 = 1".to_owned()
         } else {
-            policy::snapshot_read_policy_sql_for_alias(
-                self.schema,
-                table,
-                "h",
-                self.user,
-                base_epoch,
-            )?
+            self.visibility()
+                .snapshot_policy_sql(table, "h", base_epoch)?
         };
         let sql = format!(
             "SELECT DISTINCT h.row_num
@@ -404,13 +394,8 @@ impl QueryContext<'_> {
         let policy_sql = if self.bypass_policy {
             "1 = 1".to_owned()
         } else {
-            policy::snapshot_read_policy_sql_for_alias(
-                self.schema,
-                table,
-                "h",
-                self.user,
-                base_epoch,
-            )?
+            self.visibility()
+                .snapshot_policy_sql(table, "h", base_epoch)?
         };
         let select_columns =
             query_candidate_select_columns(table, "h", "ids", "tx", &(i64::MAX / 4).to_string());
@@ -609,7 +594,10 @@ impl QueryContext<'_> {
                 QueryDirection::Asc => "ASC",
                 QueryDirection::Desc => "DESC",
             };
-            parts.push(format!("{} {direction}", final_query_column_sql(&column)));
+            parts.push(format!(
+                "{} {direction}",
+                final_query_order_column_sql(&column)
+            ));
         }
         parts.push("j_query_row_num".to_owned());
         Ok(parts.join(", "))
@@ -636,7 +624,7 @@ impl QueryContext<'_> {
             };
             parts.push(format!(
                 "{} {direction}",
-                source_query_column_sql(&column, row_alias, ids_alias)
+                source_query_order_column_sql(&column, row_alias, ids_alias)
             ));
         }
         parts.push(format!("{row_alias}.row_num"));
@@ -901,13 +889,8 @@ impl QueryContext<'_> {
         let snapshot_policy_sql = if self.bypass_policy {
             "1 = 1".to_owned()
         } else {
-            policy::snapshot_read_policy_sql_for_alias(
-                self.schema,
-                table,
-                "h",
-                self.user,
-                base_epoch,
-            )?
+            self.visibility()
+                .snapshot_policy_sql(table, "h", base_epoch)?
         };
         let sql = format!(
             "WITH
@@ -1352,13 +1335,7 @@ impl QueryContext<'_> {
             current_table = crate::schema::current_table(table_name),
             parent_column = parent_column,
             policy_sql = policy_sql,
-            child_policy_sql = policy::branch_read_policy_sql_for_alias(
-                self.schema,
-                table,
-                "child",
-                self.user,
-                self.branch_num
-            )?,
+            child_policy_sql = self.visibility().current_policy_sql(table, "child")?,
         );
         let mut stmt = self.conn.prepare(&sql)?;
         let row_width = 2 + table.fields.len() + 1;
@@ -1467,16 +1444,16 @@ impl QueryContext<'_> {
     }
 
     fn read_policy_sql(&self, table: &crate::schema::TableDef) -> Result<String> {
-        if self.bypass_policy {
-            Ok("1 = 1".to_owned())
-        } else {
-            policy::branch_read_policy_sql_for_alias(
-                self.schema,
-                table,
-                "current",
-                self.user,
-                self.branch_num,
-            )
+        self.visibility().current_policy_sql(table, "current")
+    }
+
+    fn visibility(&self) -> ReadVisibility<'_> {
+        ReadVisibility {
+            conn: self.conn,
+            schema: self.schema,
+            branch_num: self.branch_num,
+            user: self.user,
+            bypass_policy: self.bypass_policy,
         }
     }
 
@@ -2065,13 +2042,8 @@ impl QueryContext<'_> {
         let policy_sql = if self.bypass_policy {
             "1 = 1".to_owned()
         } else {
-            policy::snapshot_read_policy_sql_for_alias(
-                self.schema,
-                table,
-                "h",
-                self.user,
-                base_epoch,
-            )?
+            self.visibility()
+                .snapshot_policy_sql(table, "h", base_epoch)?
         };
         let field_columns = table
             .fields
@@ -2219,6 +2191,34 @@ fn final_query_column_sql(column: &QueryColumn<'_>) -> String {
         QueryColumn::Field(field) => {
             crate::schema::quote_ident(&crate::schema::storage_column(field))
         }
+    }
+}
+
+fn source_query_order_column_sql(
+    column: &QueryColumn<'_>,
+    row_alias: &str,
+    ids_alias: &str,
+) -> String {
+    match column {
+        QueryColumn::Field(field) if matches!(field.kind, FieldKind::Ref { .. }) => {
+            let ref_column = crate::schema::quote_ident(&crate::schema::storage_column(field));
+            format!(
+                "(SELECT ref_order_ids.row_id FROM jazz_row_id ref_order_ids WHERE ref_order_ids.row_num = {row_alias}.{ref_column})"
+            )
+        }
+        _ => source_query_column_sql(column, row_alias, ids_alias),
+    }
+}
+
+fn final_query_order_column_sql(column: &QueryColumn<'_>) -> String {
+    match column {
+        QueryColumn::Field(field) if matches!(field.kind, FieldKind::Ref { .. }) => {
+            let ref_column = crate::schema::quote_ident(&crate::schema::storage_column(field));
+            format!(
+                "(SELECT ref_order_ids.row_id FROM jazz_row_id ref_order_ids WHERE ref_order_ids.row_num = {ref_column})"
+            )
+        }
+        _ => final_query_column_sql(column),
     }
 }
 

--- a/crates/mini-jazz-sqlite/src/query.rs
+++ b/crates/mini-jazz-sqlite/src/query.rs
@@ -77,6 +77,32 @@ impl QueryContext<'_> {
         self.read_rows_from_current_where_eq(table_name, field, &value, true)
     }
 
+    pub(crate) fn read_rows_where_eq_top_created_at_desc(
+        &self,
+        table_name: &str,
+        field_name: &str,
+        value: JsonValue,
+        limit: usize,
+    ) -> Result<Vec<RowView>> {
+        if field_name == "id" || field_name == "$createdBy" {
+            return self
+                .read_rows_where_eq_top_created_at_desc_slow(table_name, field_name, value, limit);
+        }
+        let table = self.schema.table_def(table_name)?;
+        let field = table
+            .fields
+            .iter()
+            .find(|field| field.name == field_name)
+            .ok_or_else(|| crate::Error::new(format!("unknown field {table_name}.{field_name}")))?;
+        if self.branch_num != 1 {
+            return self
+                .read_rows_where_eq_top_created_at_desc_slow(table_name, field_name, value, limit);
+        }
+        self.read_main_rows_from_current_where_eq_top_created_at_desc(
+            table_name, field, &value, limit,
+        )
+    }
+
     pub(crate) fn read_rows_where_in(
         &self,
         table_name: &str,
@@ -1474,6 +1500,110 @@ impl QueryContext<'_> {
             .collect()
     }
 
+    fn read_main_rows_from_current_where_eq_top_created_at_desc(
+        &self,
+        table_name: &str,
+        field: &FieldDef,
+        value: &JsonValue,
+        limit: usize,
+    ) -> Result<Vec<RowView>> {
+        let table = self.schema.table_def(table_name)?;
+        let field_columns = table
+            .fields
+            .iter()
+            .map(|field| crate::schema::quote_ident(&crate::schema::storage_column(field)))
+            .collect::<Vec<_>>();
+        let mut select_columns = vec!["ids.row_id".to_owned(), "tx.tx_id".to_owned()];
+        select_columns.extend(
+            field_columns
+                .iter()
+                .map(|column| format!("current.{column}")),
+        );
+        select_columns.push(format!(
+            "{} AS j_created_by",
+            users::user_id_expr("current", "j_created_by")
+        ));
+        let predicate_column = crate::schema::quote_ident(&crate::schema::storage_column(field));
+        let (predicate_sql, predicate_value) = if value.is_null() {
+            if !field.nullable {
+                return Err(crate::Error::new(format!(
+                    "expected non-null for {}",
+                    field.name
+                )));
+            }
+            ("IS NULL".to_owned(), None)
+        } else {
+            (
+                "= ?".to_owned(),
+                Some(crate::schema::field_sql_value(
+                    field,
+                    value,
+                    |ref_table, row_id| {
+                        row_num(self.conn, row_id).map_err(|err| {
+                            crate::Error::new(format!(
+                                "failed to resolve ref {ref_table}.{row_id} for equality predicate: {err}"
+                            ))
+                        })
+                    },
+                )?),
+            )
+        };
+        let sql = format!(
+            "SELECT {}
+             FROM {} current
+             JOIN jazz_row_id ids ON ids.row_num = current.row_num
+             JOIN jazz_tx tx ON tx.tx_num = current.visible_tx_num
+             WHERE current.j_branch_num = ?
+               AND current.is_deleted = 0
+               AND tx.outcome != ?
+               AND current.{predicate_column} {predicate_sql}
+               AND {policy_sql}
+             ORDER BY current.j_created_at DESC, current.row_num
+             LIMIT ?",
+            select_columns.join(", "),
+            crate::schema::current_table(table_name),
+            policy_sql = self.read_policy_sql(table)?,
+        );
+        let mut params = vec![
+            rusqlite::types::Value::Integer(self.branch_num),
+            rusqlite::types::Value::Integer(tx::OUTCOME_REJECTED),
+        ];
+        if let Some(predicate_value) = predicate_value {
+            params.push(predicate_value);
+        }
+        let limit = i64::try_from(limit)
+            .map_err(|_| crate::Error::new("top created query limit is too large"))?;
+        params.push(rusqlite::types::Value::Integer(limit));
+        let mut stmt = self.conn.prepare(&sql)?;
+        let row_width = 2 + table.fields.len() + 1;
+        let rows = stmt.query_map(params_from_iter(params.iter()), |row| {
+            (0..row_width)
+                .map(|idx| row.get::<_, rusqlite::types::Value>(idx))
+                .collect::<rusqlite::Result<Vec<_>>>()
+        })?;
+        rows.map(|row| row_to_view(self.conn, table_name, table, row?))
+            .collect()
+    }
+
+    fn read_rows_where_eq_top_created_at_desc_slow(
+        &self,
+        table_name: &str,
+        field_name: &str,
+        value: JsonValue,
+        limit: usize,
+    ) -> Result<Vec<RowView>> {
+        let mut rows = self.read_rows_where_eq(table_name, field_name, value)?;
+        let created_at_by_id = current_created_at_by_row_id(self.conn, table_name)?;
+        rows.sort_by(|left, right| {
+            created_at_by_id
+                .get(&right.id)
+                .cmp(&created_at_by_id.get(&left.id))
+                .then_with(|| left.id.cmp(&right.id))
+        });
+        rows.truncate(limit);
+        Ok(rows)
+    }
+
     fn read_rows_from_current_where_contains(
         &self,
         table_name: &str,
@@ -1731,6 +1861,23 @@ fn json_sort_key(value: Option<&JsonValue>) -> String {
         Some(value) => format!("j:{value}"),
         None => String::new(),
     }
+}
+
+fn current_created_at_by_row_id(
+    conn: &Connection,
+    table_name: &str,
+) -> Result<BTreeMap<String, i64>> {
+    let mut stmt = conn.prepare(&format!(
+        "SELECT ids.row_id, current.j_created_at
+         FROM {} current
+         JOIN jazz_row_id ids ON ids.row_num = current.row_num",
+        crate::schema::current_table(table_name)
+    ))?;
+    let rows = stmt.query_map([], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+    })?;
+    rows.collect::<std::result::Result<BTreeMap<_, _>, _>>()
+        .map_err(Into::into)
 }
 
 fn placeholders(count: usize) -> String {

--- a/crates/mini-jazz-sqlite/src/query.rs
+++ b/crates/mini-jazz-sqlite/src/query.rs
@@ -1,3 +1,4 @@
+use crate::query_api::BuiltQuery;
 use crate::rows::{public_row_id, row_num};
 use crate::schema::{FieldDef, FieldKind, PolicyDef, SchemaDef};
 use crate::types::RowView;
@@ -77,30 +78,38 @@ impl QueryContext<'_> {
         self.read_rows_from_current_where_eq(table_name, field, &value, true)
     }
 
-    pub(crate) fn read_rows_where_eq_top_created_at_desc(
+    pub(crate) fn read_rows_for_built_query(
         &self,
-        table_name: &str,
-        field_name: &str,
-        value: JsonValue,
-        limit: usize,
-    ) -> Result<Vec<RowView>> {
-        if field_name == "id" || field_name == "$createdBy" {
-            return self
-                .read_rows_where_eq_top_created_at_desc_slow(table_name, field_name, value, limit);
+        query: &BuiltQuery,
+    ) -> Result<Option<Vec<RowView>>> {
+        let Some((condition, limit)) = query.ordered_page() else {
+            return Ok(None);
+        };
+        if condition.column == "id" || condition.column == "$createdBy" || self.branch_num != 1 {
+            return Ok(Some(self.read_ordered_page_slow(
+                &query.table,
+                &condition.column,
+                condition.value.clone(),
+                limit,
+            )?));
         }
-        let table = self.schema.table_def(table_name)?;
+        let table = self.schema.table_def(&query.table)?;
         let field = table
             .fields
             .iter()
-            .find(|field| field.name == field_name)
-            .ok_or_else(|| crate::Error::new(format!("unknown field {table_name}.{field_name}")))?;
-        if self.branch_num != 1 {
-            return self
-                .read_rows_where_eq_top_created_at_desc_slow(table_name, field_name, value, limit);
-        }
-        self.read_main_rows_from_current_where_eq_top_created_at_desc(
-            table_name, field, &value, limit,
-        )
+            .find(|field| field.name == condition.column)
+            .ok_or_else(|| {
+                crate::Error::new(format!(
+                    "unknown field {}.{}",
+                    query.table, condition.column
+                ))
+            })?;
+        Ok(Some(self.read_main_ordered_page_where_eq(
+            &query.table,
+            field,
+            &condition.value,
+            limit,
+        )?))
     }
 
     pub(crate) fn read_rows_where_in(
@@ -1500,7 +1509,7 @@ impl QueryContext<'_> {
             .collect()
     }
 
-    fn read_main_rows_from_current_where_eq_top_created_at_desc(
+    fn read_main_ordered_page_where_eq(
         &self,
         table_name: &str,
         field: &FieldDef,
@@ -1572,7 +1581,7 @@ impl QueryContext<'_> {
             params.push(predicate_value);
         }
         let limit = i64::try_from(limit)
-            .map_err(|_| crate::Error::new("top created query limit is too large"))?;
+            .map_err(|_| crate::Error::new("ordered query limit is too large"))?;
         params.push(rusqlite::types::Value::Integer(limit));
         let mut stmt = self.conn.prepare(&sql)?;
         let row_width = 2 + table.fields.len() + 1;
@@ -1585,7 +1594,7 @@ impl QueryContext<'_> {
             .collect()
     }
 
-    fn read_rows_where_eq_top_created_at_desc_slow(
+    fn read_ordered_page_slow(
         &self,
         table_name: &str,
         field_name: &str,
@@ -1925,5 +1934,83 @@ pub(crate) fn text_value(value: &rusqlite::types::Value, name: &str) -> Result<S
     match value {
         rusqlite::types::Value::Text(value) => Ok(value.clone()),
         _ => Err(crate::Error::new(format!("expected text {name}"))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{schema, storage, tx, Storage};
+    use rusqlite::params;
+    use serde_json::json;
+
+    #[test]
+    fn top_created_at_query_returns_only_latest_page() -> Result<()> {
+        let schema = SchemaDef::attempt3_fixture();
+        let conn = storage::open(Storage::Memory)?;
+        schema::install(&conn, &schema)?;
+        seed_todos(&conn, 100)?;
+
+        let context = QueryContext {
+            conn: &conn,
+            schema: &schema,
+            branch_num: 1,
+            user: "alice",
+            bypass_policy: false,
+        };
+
+        let query = BuiltQuery::from_json_value(json!({
+            "table": "todos",
+            "conditions": [{"column": "done", "op": "eq", "value": false}],
+            "orderBy": [["$createdAt", "desc"]],
+            "limit": 10,
+        }))?;
+        let rows = context.read_rows_for_built_query(&query)?.unwrap();
+
+        assert_eq!(rows.len(), 10);
+        assert_eq!(rows[0].id, "todo-100");
+        assert_eq!(rows[9].id, "todo-91");
+        Ok(())
+    }
+
+    fn seed_todos(conn: &Connection, count: i64) -> Result<()> {
+        users::ensure_user(conn, "alice")?;
+        conn.execute(
+            "INSERT INTO jazz_node (node_num, node_id) VALUES (1, 'node-a')",
+            [],
+        )?;
+        conn.execute(
+            "INSERT INTO jazz_tx
+              (tx_num, tx_id, node_num, local_epoch, global_epoch, kind, conflict_mode, outcome, created_at, metadata_json)
+             VALUES (1, 'tx-1', 1, 1, NULL, ?, ?, ?, 1, '{}')",
+            params![tx::KIND_DATA, tx::MODE_MERGEABLE, tx::OUTCOME_ACCEPTED],
+        )?;
+        conn.execute(
+            "INSERT INTO jazz_row_id (row_num, table_name, row_id)
+             VALUES (1, 'projects', 'project-1')",
+            [],
+        )?;
+        conn.execute(
+            "INSERT INTO projects__schema_v1_current
+              (row_num, j_branch_num, visible_tx_num, is_deleted, title, j_created_at, j_updated_at, j_created_by, j_updated_by)
+             VALUES (1, 1, 1, 0, 'Project', 1, 1, 1, 1)",
+            [],
+        )?;
+        for index in 1..=count {
+            let row_num = index + 1;
+            let row_id = format!("todo-{index}");
+            conn.execute(
+                "INSERT INTO jazz_row_id (row_num, table_name, row_id)
+                 VALUES (?, 'todos', ?)",
+                params![row_num, row_id],
+            )?;
+            conn.execute(
+                "INSERT INTO todos__schema_v1_current
+                  (row_num, j_branch_num, visible_tx_num, is_deleted, title, done, project_row_num, j_created_at, j_updated_at, j_created_by, j_updated_by)
+                 VALUES (?, 1, 1, 0, ?, 0, 1, ?, ?, 1, 1)",
+                params![row_num, format!("Todo {index}"), index, index],
+            )?;
+        }
+        Ok(())
     }
 }

--- a/crates/mini-jazz-sqlite/src/query.rs
+++ b/crates/mini-jazz-sqlite/src/query.rs
@@ -105,18 +105,14 @@ impl QueryContext<'_> {
         let table = self.schema.table_def(&query.table)?;
         let (condition_sql, mut params) =
             self.lower_query_conditions(table, &query.conditions, "h", "ids")?;
-        let mut query_params = vec![
-            SqlValue::Text(table.name.clone()),
-            SqlValue::Integer(tx::OUTCOME_REJECTED),
-        ];
+        let mut query_params = vec![SqlValue::Integer(tx::OUTCOME_REJECTED)];
         query_params.append(&mut params);
         let sql = format!(
             "SELECT DISTINCT h.row_num
              FROM {} h
              JOIN jazz_row_id ids ON ids.row_num = h.row_num
              JOIN jazz_tx tx ON tx.tx_num = h.tx_num
-             WHERE ids.table_name = ?
-               AND tx.outcome != ?
+             WHERE tx.outcome != ?
                AND {condition_sql}
              ORDER BY h.row_num",
             crate::schema::history_table(&query.table),
@@ -2293,8 +2289,8 @@ mod tests {
             params![tx::KIND_DATA, tx::MODE_MERGEABLE, tx::OUTCOME_ACCEPTED],
         )?;
         conn.execute(
-            "INSERT INTO jazz_row_id (row_num, table_name, row_id)
-             VALUES (1, 'projects', 'project-1')",
+            "INSERT INTO jazz_row_id (row_num, row_id)
+             VALUES (1, 'project-1')",
             [],
         )?;
         conn.execute(
@@ -2307,8 +2303,8 @@ mod tests {
             let row_num = index + 1;
             let row_id = format!("todo-{index}");
             conn.execute(
-                "INSERT INTO jazz_row_id (row_num, table_name, row_id)
-                 VALUES (?, 'todos', ?)",
+                "INSERT INTO jazz_row_id (row_num, row_id)
+                 VALUES (?, ?)",
                 params![row_num, row_id],
             )?;
             conn.execute(

--- a/crates/mini-jazz-sqlite/src/query.rs
+++ b/crates/mini-jazz-sqlite/src/query.rs
@@ -1,9 +1,11 @@
-use crate::query_api::{BuiltQuery, QueryCondition, QueryConditionOp, QueryDirection};
+use crate::query_api::{
+    BuiltQuery, QueryCondition, QueryConditionOp, QueryDirection, QueryOrderBy,
+};
 use crate::rows::{public_row_id, row_num};
 use crate::schema::{FieldDef, FieldKind, PolicyDef, SchemaDef};
 use crate::types::RowView;
 use crate::{branch, policy, tx, users, Result};
-use rusqlite::{params, params_from_iter, Connection, OptionalExtension};
+use rusqlite::{params, params_from_iter, types::Value as SqlValue, Connection, OptionalExtension};
 use serde_json::Value as JsonValue;
 use std::collections::BTreeMap;
 
@@ -54,6 +56,19 @@ pub(crate) fn query_scope_predicate(query: &BuiltQuery) -> Result<Option<&QueryC
     }
 
     Ok(query.conditions.first())
+}
+
+struct LoweredCondition {
+    sql: String,
+    params: Vec<SqlValue>,
+}
+
+enum QueryColumn<'a> {
+    Id,
+    CreatedBy,
+    CreatedAt,
+    UpdatedAt,
+    Field(&'a FieldDef),
 }
 
 impl QueryContext<'_> {
@@ -117,39 +132,474 @@ impl QueryContext<'_> {
         self.read_rows_from_current_where_eq(table_name, field, &value, true)
     }
 
-    pub(crate) fn read_rows_for_built_query(
-        &self,
-        query: &BuiltQuery,
-    ) -> Result<Option<Vec<RowView>>> {
-        let Some(QueryStoragePlan::EqCreatedAtDescPage { condition, limit }) = storage_plan(query)
-        else {
-            return Ok(None);
-        };
-        if condition.column == "id" || condition.column == "$createdBy" || self.branch_num != 1 {
-            return Ok(Some(self.read_created_at_desc_page_slow(
-                &query.table,
-                &condition.column,
-                condition.value.clone(),
-                limit,
-            )?));
-        }
+    pub(crate) fn read_rows_for_built_query(&self, query: &BuiltQuery) -> Result<Vec<RowView>> {
         let table = self.schema.table_def(&query.table)?;
-        let field = table
+        let scope_nums = branch::scope_nums(self.conn, self.branch_num)?;
+        if scope_nums == [self.branch_num]
+            && branch::base_global_epoch(self.conn, self.branch_num)?.is_none()
+        {
+            return self.read_current_built_query(query, table);
+        }
+        let (candidates_sql, mut params) = self.lower_query_candidates(query, table)?;
+        let order_sql = self.lower_query_order(table, &query.order_by)?;
+        let field_columns = table
             .fields
             .iter()
-            .find(|field| field.name == condition.column)
-            .ok_or_else(|| {
-                crate::Error::new(format!(
-                    "unknown field {}.{}",
-                    query.table, condition.column
-                ))
-            })?;
-        Ok(Some(self.read_main_created_at_desc_page_where_eq(
-            &query.table,
-            field,
-            &condition.value,
-            limit,
-        )?))
+            .map(|field| crate::schema::quote_ident(&crate::schema::storage_column(field)))
+            .collect::<Vec<_>>();
+        let mut select_columns = vec!["j_query_row_id".to_owned(), "j_query_tx_id".to_owned()];
+        select_columns.extend(field_columns.iter().cloned());
+        select_columns.push("j_query_created_by".to_owned());
+        let mut sql = format!(
+            "WITH candidates AS (
+               {candidates_sql}
+             ),
+             ranked AS (
+               SELECT *,
+                      MIN(j_query_branch_depth) OVER (PARTITION BY j_query_row_id) AS j_query_min_branch_depth
+               FROM candidates
+             )
+             SELECT {}
+             FROM ranked
+             WHERE j_query_branch_depth = j_query_min_branch_depth
+             ORDER BY {order_sql}",
+            select_columns.join(", "),
+        );
+        if let Some(limit) = query.limit {
+            sql.push_str(" LIMIT ?");
+            params.push(SqlValue::Integer(window_value_to_i64(limit, "limit")?));
+        } else if query.offset.is_some() {
+            sql.push_str(" LIMIT -1");
+        }
+        if let Some(offset) = query.offset {
+            sql.push_str(" OFFSET ?");
+            params.push(SqlValue::Integer(window_value_to_i64(offset, "offset")?));
+        }
+
+        let mut stmt = self.conn.prepare(&sql)?;
+        let row_width = 2 + table.fields.len() + 1;
+        let rows = stmt.query_map(params_from_iter(params.iter()), |row| {
+            (0..row_width)
+                .map(|idx| row.get::<_, SqlValue>(idx))
+                .collect::<rusqlite::Result<Vec<_>>>()
+        })?;
+        rows.map(|row| row_to_view(self.conn, &query.table, table, row?))
+            .collect()
+    }
+
+    fn read_current_built_query(
+        &self,
+        query: &BuiltQuery,
+        table: &crate::schema::TableDef,
+    ) -> Result<Vec<RowView>> {
+        let (condition_sql, mut params) =
+            self.lower_query_conditions(table, &query.conditions, "current", "ids")?;
+        let order_sql = self.lower_source_query_order(table, &query.order_by, "current", "ids")?;
+        let field_columns = table
+            .fields
+            .iter()
+            .map(|field| crate::schema::quote_ident(&crate::schema::storage_column(field)))
+            .collect::<Vec<_>>();
+        let mut select_columns = vec!["ids.row_id".to_owned(), "tx.tx_id".to_owned()];
+        select_columns.extend(
+            field_columns
+                .iter()
+                .map(|column| format!("current.{column}")),
+        );
+        select_columns.push(format!(
+            "{} AS j_created_by",
+            users::user_id_expr("current", "j_created_by")
+        ));
+        let mut sql = format!(
+            "SELECT {}
+             FROM {} current
+             JOIN jazz_row_id ids ON ids.row_num = current.row_num
+             JOIN jazz_tx tx ON tx.tx_num = current.visible_tx_num
+             WHERE current.j_branch_num = ?
+               AND current.is_deleted = 0
+               AND tx.outcome != ?
+               AND {condition_sql}
+               AND {policy_sql}
+             ORDER BY {order_sql}",
+            select_columns.join(", "),
+            crate::schema::current_table(&query.table),
+            policy_sql = self.read_policy_sql(table)?,
+        );
+        let mut query_params = vec![
+            SqlValue::Integer(self.branch_num),
+            SqlValue::Integer(tx::OUTCOME_REJECTED),
+        ];
+        query_params.append(&mut params);
+        if let Some(limit) = query.limit {
+            sql.push_str(" LIMIT ?");
+            query_params.push(SqlValue::Integer(window_value_to_i64(limit, "limit")?));
+        } else if query.offset.is_some() {
+            sql.push_str(" LIMIT -1");
+        }
+        if let Some(offset) = query.offset {
+            sql.push_str(" OFFSET ?");
+            query_params.push(SqlValue::Integer(window_value_to_i64(offset, "offset")?));
+        }
+
+        let mut stmt = self.conn.prepare(&sql)?;
+        let row_width = 2 + table.fields.len() + 1;
+        let rows = stmt.query_map(params_from_iter(query_params.iter()), |row| {
+            (0..row_width)
+                .map(|idx| row.get::<_, SqlValue>(idx))
+                .collect::<rusqlite::Result<Vec<_>>>()
+        })?;
+        rows.map(|row| row_to_view(self.conn, &query.table, table, row?))
+            .collect()
+    }
+
+    fn lower_query_candidates(
+        &self,
+        query: &BuiltQuery,
+        table: &crate::schema::TableDef,
+    ) -> Result<(String, Vec<SqlValue>)> {
+        let mut parts = Vec::new();
+        let mut params = Vec::new();
+        let base_epoch = if self.branch_num != 1 {
+            branch::base_global_epoch(self.conn, self.branch_num)?
+        } else {
+            None
+        };
+        let (current_sql, current_params) =
+            self.lower_current_query_candidate(query, table, base_epoch.is_none())?;
+        parts.push(current_sql);
+        params.extend(current_params);
+        if let Some(base_epoch) = base_epoch {
+            let (snapshot_sql, snapshot_params) =
+                self.lower_main_snapshot_query_candidate(query, table, base_epoch)?;
+            parts.push(snapshot_sql);
+            params.extend(snapshot_params);
+        }
+        Ok((parts.join("\nUNION ALL\n"), params))
+    }
+
+    fn lower_current_query_candidate(
+        &self,
+        query: &BuiltQuery,
+        table: &crate::schema::TableDef,
+        overlay_main: bool,
+    ) -> Result<(String, Vec<SqlValue>)> {
+        let scope_nums = branch::scope_nums(self.conn, self.branch_num)?;
+        let scope_placeholders = placeholders(scope_nums.len());
+        let (condition_sql, condition_params) =
+            self.lower_query_conditions(table, &query.conditions, "current", "ids")?;
+        let select_columns = query_candidate_select_columns(
+            table,
+            "current",
+            "ids",
+            "tx",
+            &branch_depth_case_sql(self.conn, self.branch_num, "current")?,
+        );
+        let sql = format!(
+            "SELECT {}
+             FROM {} current
+             JOIN jazz_row_id ids ON ids.row_num = current.row_num
+             JOIN jazz_tx tx ON tx.tx_num = current.visible_tx_num
+             WHERE current.is_deleted = 0
+               AND (
+                 current.j_branch_num IN ({scope_placeholders})
+                 OR (
+                   ? = 1
+                   AND ? != 1
+                   AND current.j_branch_num = 1
+                   AND NOT EXISTS (
+                     SELECT 1
+                     FROM {current_table} branch_current
+                     WHERE branch_current.row_num = current.row_num
+                       AND branch_current.j_branch_num IN ({scope_placeholders})
+                   )
+                 )
+               )
+               AND tx.outcome != ?
+               AND NOT (
+                 current.j_branch_num != ?
+                 AND EXISTS (
+                   SELECT 1
+                   FROM {current_table} active_current
+                   WHERE active_current.row_num = current.row_num
+                     AND active_current.j_branch_num = ?
+                 )
+               )
+               AND {condition_sql}
+               AND {policy_sql}",
+            select_columns.join(", "),
+            crate::schema::current_table(&query.table),
+            current_table = crate::schema::current_table(&query.table),
+            policy_sql = self.read_policy_sql(table)?,
+        );
+        let mut params = scope_nums
+            .iter()
+            .copied()
+            .map(SqlValue::Integer)
+            .collect::<Vec<_>>();
+        params.extend([
+            SqlValue::Integer(i64::from(overlay_main)),
+            SqlValue::Integer(self.branch_num),
+        ]);
+        params.extend(scope_nums.iter().copied().map(SqlValue::Integer));
+        params.extend([
+            SqlValue::Integer(tx::OUTCOME_REJECTED),
+            SqlValue::Integer(self.branch_num),
+            SqlValue::Integer(self.branch_num),
+        ]);
+        params.extend(condition_params);
+        Ok((sql, params))
+    }
+
+    fn lower_main_snapshot_query_candidate(
+        &self,
+        query: &BuiltQuery,
+        table: &crate::schema::TableDef,
+        base_epoch: i64,
+    ) -> Result<(String, Vec<SqlValue>)> {
+        let scope_nums = branch::scope_nums(self.conn, self.branch_num)?;
+        let scope_placeholders = placeholders(scope_nums.len());
+        let (condition_sql, condition_params) =
+            self.lower_query_conditions(table, &query.conditions, "h", "ids")?;
+        let policy_sql = if self.bypass_policy {
+            "1 = 1".to_owned()
+        } else {
+            policy::snapshot_read_policy_sql_for_alias(
+                self.schema,
+                table,
+                "h",
+                self.user,
+                base_epoch,
+            )?
+        };
+        let select_columns =
+            query_candidate_select_columns(table, "h", "ids", "tx", &(i64::MAX / 4).to_string());
+        let sql = format!(
+            "SELECT {}
+             FROM {} h
+             JOIN jazz_row_id ids ON ids.row_num = h.row_num
+             JOIN jazz_tx tx ON tx.tx_num = h.tx_num
+             WHERE h.j_branch_num = 1
+               AND tx.outcome != ?
+               AND tx.global_epoch IS NOT NULL
+               AND tx.global_epoch <= ?
+               AND h.op != 3
+               AND {policy_sql}
+               AND NOT EXISTS (
+                 SELECT 1
+                 FROM {history_table} newer
+                 JOIN jazz_tx newer_tx ON newer_tx.tx_num = newer.tx_num
+                 WHERE newer.row_num = h.row_num
+                   AND newer.j_branch_num = 1
+                   AND newer_tx.outcome != ?
+                   AND newer_tx.global_epoch IS NOT NULL
+                   AND newer_tx.global_epoch <= ?
+                   AND (newer_tx.global_epoch > tx.global_epoch OR (newer_tx.global_epoch = tx.global_epoch AND newer_tx.tx_num > tx.tx_num))
+               )
+               AND NOT EXISTS (
+                 SELECT 1
+                 FROM {current_table} branch_current
+                 WHERE branch_current.row_num = h.row_num
+                   AND branch_current.j_branch_num IN ({scope_placeholders})
+               )
+               AND {condition_sql}",
+            select_columns.join(", "),
+            crate::schema::history_table(&query.table),
+            history_table = crate::schema::history_table(&query.table),
+            current_table = crate::schema::current_table(&query.table),
+            policy_sql = policy_sql,
+        );
+        let mut params = vec![
+            SqlValue::Integer(tx::OUTCOME_REJECTED),
+            SqlValue::Integer(base_epoch),
+            SqlValue::Integer(tx::OUTCOME_REJECTED),
+            SqlValue::Integer(base_epoch),
+        ];
+        params.extend(scope_nums.iter().copied().map(SqlValue::Integer));
+        params.extend(condition_params);
+        Ok((sql, params))
+    }
+
+    fn lower_query_conditions(
+        &self,
+        table: &crate::schema::TableDef,
+        conditions: &[QueryCondition],
+        row_alias: &str,
+        ids_alias: &str,
+    ) -> Result<(String, Vec<SqlValue>)> {
+        if conditions.is_empty() {
+            return Ok(("1 = 1".to_owned(), Vec::new()));
+        }
+        let mut sql = Vec::new();
+        let mut params = Vec::new();
+        for condition in conditions {
+            let lowered = self.lower_query_condition(table, condition, row_alias, ids_alias)?;
+            sql.push(lowered.sql);
+            params.extend(lowered.params);
+        }
+        Ok((sql.join(" AND "), params))
+    }
+
+    fn lower_query_condition(
+        &self,
+        table: &crate::schema::TableDef,
+        condition: &QueryCondition,
+        row_alias: &str,
+        ids_alias: &str,
+    ) -> Result<LoweredCondition> {
+        let column = query_column(table, &condition.column)?;
+        let column_sql = source_query_column_sql(&column, row_alias, ids_alias);
+        match condition.op {
+            QueryConditionOp::Eq if condition.value.is_null() => Ok(LoweredCondition {
+                sql: format!("{column_sql} IS NULL"),
+                params: Vec::new(),
+            }),
+            QueryConditionOp::Eq => Ok(LoweredCondition {
+                sql: format!("{column_sql} = ?"),
+                params: vec![self.query_condition_value(&column, &condition.value)?],
+            }),
+            QueryConditionOp::Ne if condition.value.is_null() => Ok(LoweredCondition {
+                sql: format!("{column_sql} IS NOT NULL"),
+                params: Vec::new(),
+            }),
+            QueryConditionOp::Ne => Ok(LoweredCondition {
+                sql: format!("{column_sql} IS NOT ?"),
+                params: vec![self.query_condition_value(&column, &condition.value)?],
+            }),
+            QueryConditionOp::Contains => {
+                if !query_column_is_text(&column) {
+                    return Err(crate::Error::new(format!(
+                        "contains only supports text fields, got {}",
+                        condition.column
+                    )));
+                }
+                let Some(needle) = condition.value.as_str() else {
+                    return Err(crate::Error::new(
+                        "contains condition expects a string value",
+                    ));
+                };
+                Ok(LoweredCondition {
+                    sql: format!("instr({column_sql}, ?) > 0"),
+                    params: vec![SqlValue::Text(needle.to_owned())],
+                })
+            }
+            QueryConditionOp::In => {
+                let Some(values) = condition.value.as_array() else {
+                    return Err(crate::Error::new("in condition expects an array value"));
+                };
+                self.lower_in_condition(&column, &column_sql, values)
+            }
+        }
+    }
+
+    fn lower_in_condition(
+        &self,
+        column: &QueryColumn<'_>,
+        column_sql: &str,
+        values: &[JsonValue],
+    ) -> Result<LoweredCondition> {
+        if values.is_empty() {
+            return Ok(LoweredCondition {
+                sql: "0 = 1".to_owned(),
+                params: Vec::new(),
+            });
+        }
+        let mut has_null = false;
+        let mut params = Vec::new();
+        for value in values {
+            if value.is_null() {
+                has_null = true;
+            } else {
+                params.push(self.query_condition_value(column, value)?);
+            }
+        }
+        let sql = match (params.is_empty(), has_null) {
+            (true, true) => format!("{column_sql} IS NULL"),
+            (false, true) => format!(
+                "({column_sql} IN ({}) OR {column_sql} IS NULL)",
+                placeholders(params.len())
+            ),
+            (false, false) => format!("{column_sql} IN ({})", placeholders(params.len())),
+            (true, false) => "0 = 1".to_owned(),
+        };
+        Ok(LoweredCondition { sql, params })
+    }
+
+    fn query_condition_value(
+        &self,
+        column: &QueryColumn<'_>,
+        value: &JsonValue,
+    ) -> Result<SqlValue> {
+        match column {
+            QueryColumn::Id | QueryColumn::CreatedBy => Ok(SqlValue::Text(
+                value
+                    .as_str()
+                    .ok_or_else(|| crate::Error::new("query system field expects a string"))?
+                    .to_owned(),
+            )),
+            QueryColumn::CreatedAt | QueryColumn::UpdatedAt => {
+                Ok(SqlValue::Integer(value.as_i64().ok_or_else(|| {
+                    crate::Error::new("query timestamp field expects an integer")
+                })?))
+            }
+            QueryColumn::Field(field) => {
+                crate::schema::field_sql_value(field, value, |ref_table, row_id| {
+                    row_num(self.conn, row_id).map_err(|err| {
+                        crate::Error::new(format!(
+                            "failed to resolve ref {ref_table}.{row_id} for query predicate: {err}"
+                        ))
+                    })
+                })
+            }
+        }
+    }
+
+    fn lower_query_order(
+        &self,
+        table: &crate::schema::TableDef,
+        order_by: &[QueryOrderBy],
+    ) -> Result<String> {
+        if order_by.is_empty() {
+            return Ok("j_query_created_at DESC, j_query_row_num".to_owned());
+        }
+        let mut parts = Vec::new();
+        for order in order_by {
+            let column = query_column(table, &order.column)?;
+            let direction = match order.direction {
+                QueryDirection::Asc => "ASC",
+                QueryDirection::Desc => "DESC",
+            };
+            parts.push(format!("{} {direction}", final_query_column_sql(&column)));
+        }
+        parts.push("j_query_row_num".to_owned());
+        Ok(parts.join(", "))
+    }
+
+    fn lower_source_query_order(
+        &self,
+        table: &crate::schema::TableDef,
+        order_by: &[QueryOrderBy],
+        row_alias: &str,
+        ids_alias: &str,
+    ) -> Result<String> {
+        if order_by.is_empty() {
+            return Ok(format!(
+                "{row_alias}.j_created_at DESC, {row_alias}.row_num"
+            ));
+        }
+        let mut parts = Vec::new();
+        for order in order_by {
+            let column = query_column(table, &order.column)?;
+            let direction = match order.direction {
+                QueryDirection::Asc => "ASC",
+                QueryDirection::Desc => "DESC",
+            };
+            parts.push(format!(
+                "{} {direction}",
+                source_query_column_sql(&column, row_alias, ids_alias)
+            ));
+        }
+        parts.push(format!("{row_alias}.row_num"));
+        Ok(parts.join(", "))
     }
 
     pub(crate) fn read_rows_where_in(
@@ -1548,111 +1998,6 @@ impl QueryContext<'_> {
             .filter_map(|result| result.transpose())
             .collect()
     }
-
-    fn read_main_created_at_desc_page_where_eq(
-        &self,
-        table_name: &str,
-        field: &FieldDef,
-        value: &JsonValue,
-        limit: usize,
-    ) -> Result<Vec<RowView>> {
-        let table = self.schema.table_def(table_name)?;
-        let field_columns = table
-            .fields
-            .iter()
-            .map(|field| crate::schema::quote_ident(&crate::schema::storage_column(field)))
-            .collect::<Vec<_>>();
-        let mut select_columns = vec!["ids.row_id".to_owned(), "tx.tx_id".to_owned()];
-        select_columns.extend(
-            field_columns
-                .iter()
-                .map(|column| format!("current.{column}")),
-        );
-        select_columns.push(format!(
-            "{} AS j_created_by",
-            users::user_id_expr("current", "j_created_by")
-        ));
-        let predicate_column = crate::schema::quote_ident(&crate::schema::storage_column(field));
-        let (predicate_sql, predicate_value) = if value.is_null() {
-            if !field.nullable {
-                return Err(crate::Error::new(format!(
-                    "expected non-null for {}",
-                    field.name
-                )));
-            }
-            ("IS NULL".to_owned(), None)
-        } else {
-            (
-                "= ?".to_owned(),
-                Some(crate::schema::field_sql_value(
-                    field,
-                    value,
-                    |ref_table, row_id| {
-                        row_num(self.conn, row_id).map_err(|err| {
-                            crate::Error::new(format!(
-                                "failed to resolve ref {ref_table}.{row_id} for equality predicate: {err}"
-                            ))
-                        })
-                    },
-                )?),
-            )
-        };
-        let sql = format!(
-            "SELECT {}
-             FROM {} current
-             JOIN jazz_row_id ids ON ids.row_num = current.row_num
-             JOIN jazz_tx tx ON tx.tx_num = current.visible_tx_num
-             WHERE current.j_branch_num = ?
-               AND current.is_deleted = 0
-               AND tx.outcome != ?
-               AND current.{predicate_column} {predicate_sql}
-               AND {policy_sql}
-             ORDER BY current.j_created_at DESC, current.row_num
-             LIMIT ?",
-            select_columns.join(", "),
-            crate::schema::current_table(table_name),
-            policy_sql = self.read_policy_sql(table)?,
-        );
-        let mut params = vec![
-            rusqlite::types::Value::Integer(self.branch_num),
-            rusqlite::types::Value::Integer(tx::OUTCOME_REJECTED),
-        ];
-        if let Some(predicate_value) = predicate_value {
-            params.push(predicate_value);
-        }
-        let limit = i64::try_from(limit)
-            .map_err(|_| crate::Error::new("ordered query limit is too large"))?;
-        params.push(rusqlite::types::Value::Integer(limit));
-        let mut stmt = self.conn.prepare(&sql)?;
-        let row_width = 2 + table.fields.len() + 1;
-        let rows = stmt.query_map(params_from_iter(params.iter()), |row| {
-            (0..row_width)
-                .map(|idx| row.get::<_, rusqlite::types::Value>(idx))
-                .collect::<rusqlite::Result<Vec<_>>>()
-        })?;
-        rows.map(|row| row_to_view(self.conn, table_name, table, row?))
-            .collect()
-    }
-
-    fn read_created_at_desc_page_slow(
-        &self,
-        table_name: &str,
-        field_name: &str,
-        value: JsonValue,
-        limit: usize,
-    ) -> Result<Vec<RowView>> {
-        let mut rows = self.read_rows_where_eq(table_name, field_name, value)?;
-        let created_at_by_id = current_created_at_by_row_id(self.conn, table_name)?;
-        rows.sort_by(|left, right| {
-            created_at_by_id
-                .get(&right.id)
-                .cmp(&created_at_by_id.get(&left.id))
-                .then_with(|| left.id.cmp(&right.id))
-        });
-        rows.truncate(limit);
-        Ok(rows)
-    }
-
     fn read_rows_from_current_where_contains(
         &self,
         table_name: &str,
@@ -1872,6 +2217,97 @@ impl QueryContext<'_> {
     }
 }
 
+fn query_candidate_select_columns(
+    table: &crate::schema::TableDef,
+    row_alias: &str,
+    ids_alias: &str,
+    tx_alias: &str,
+    branch_depth_sql: &str,
+) -> Vec<String> {
+    let mut select_columns = vec![
+        format!("{branch_depth_sql} AS j_query_branch_depth"),
+        format!("{ids_alias}.row_id AS j_query_row_id"),
+        format!("{tx_alias}.tx_id AS j_query_tx_id"),
+    ];
+    select_columns.extend(table.fields.iter().map(|field| {
+        let column = crate::schema::quote_ident(&crate::schema::storage_column(field));
+        format!("{row_alias}.{column} AS {column}")
+    }));
+    select_columns.extend([
+        format!(
+            "{} AS j_query_created_by",
+            users::user_id_expr(row_alias, "j_created_by")
+        ),
+        format!("{row_alias}.j_created_at AS j_query_created_at"),
+        format!("{row_alias}.j_updated_at AS j_query_updated_at"),
+        format!("{row_alias}.row_num AS j_query_row_num"),
+    ]);
+    select_columns
+}
+
+fn branch_depth_case_sql(conn: &Connection, branch_num: i64, row_alias: &str) -> Result<String> {
+    let arms = branch::scope_depths(conn, branch_num)?
+        .into_iter()
+        .map(|(branch_num, depth)| format!("WHEN {branch_num} THEN {depth}"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    Ok(format!(
+        "CASE {row_alias}.j_branch_num {arms} ELSE {} END",
+        i64::MAX / 2
+    ))
+}
+
+fn query_column<'a>(table: &'a crate::schema::TableDef, column: &str) -> Result<QueryColumn<'a>> {
+    match column {
+        "id" => Ok(QueryColumn::Id),
+        "$createdBy" => Ok(QueryColumn::CreatedBy),
+        "$createdAt" => Ok(QueryColumn::CreatedAt),
+        "$updatedAt" => Ok(QueryColumn::UpdatedAt),
+        column => table
+            .fields
+            .iter()
+            .find(|field| field.name == column)
+            .map(QueryColumn::Field)
+            .ok_or_else(|| crate::Error::new(format!("unknown field {}.{column}", table.name))),
+    }
+}
+
+fn source_query_column_sql(column: &QueryColumn<'_>, row_alias: &str, ids_alias: &str) -> String {
+    match column {
+        QueryColumn::Id => format!("{ids_alias}.row_id"),
+        QueryColumn::CreatedBy => users::user_id_expr(row_alias, "j_created_by"),
+        QueryColumn::CreatedAt => format!("{row_alias}.j_created_at"),
+        QueryColumn::UpdatedAt => format!("{row_alias}.j_updated_at"),
+        QueryColumn::Field(field) => {
+            format!(
+                "{row_alias}.{}",
+                crate::schema::quote_ident(&crate::schema::storage_column(field))
+            )
+        }
+    }
+}
+
+fn final_query_column_sql(column: &QueryColumn<'_>) -> String {
+    match column {
+        QueryColumn::Id => "j_query_row_id".to_owned(),
+        QueryColumn::CreatedBy => "j_query_created_by".to_owned(),
+        QueryColumn::CreatedAt => "j_query_created_at".to_owned(),
+        QueryColumn::UpdatedAt => "j_query_updated_at".to_owned(),
+        QueryColumn::Field(field) => {
+            crate::schema::quote_ident(&crate::schema::storage_column(field))
+        }
+    }
+}
+
+fn query_column_is_text(column: &QueryColumn<'_>) -> bool {
+    matches!(column, QueryColumn::Id | QueryColumn::CreatedBy)
+        || matches!(column, QueryColumn::Field(field) if matches!(field.kind, FieldKind::Text))
+}
+
+fn window_value_to_i64(value: usize, field: &str) -> Result<i64> {
+    i64::try_from(value).map_err(|_| crate::Error::new(format!("query {field} is too large")))
+}
+
 fn row_to_view(
     conn: &Connection,
     table_name: &str,
@@ -1911,24 +2347,6 @@ fn json_sort_key(value: Option<&JsonValue>) -> String {
         None => String::new(),
     }
 }
-
-fn current_created_at_by_row_id(
-    conn: &Connection,
-    table_name: &str,
-) -> Result<BTreeMap<String, i64>> {
-    let mut stmt = conn.prepare(&format!(
-        "SELECT ids.row_id, current.j_created_at
-         FROM {} current
-         JOIN jazz_row_id ids ON ids.row_num = current.row_num",
-        crate::schema::current_table(table_name)
-    ))?;
-    let rows = stmt.query_map([], |row| {
-        Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
-    })?;
-    rows.collect::<std::result::Result<BTreeMap<_, _>, _>>()
-        .map_err(Into::into)
-}
-
 fn placeholders(count: usize) -> String {
     (0..count).map(|_| "?").collect::<Vec<_>>().join(", ")
 }
@@ -2005,7 +2423,7 @@ mod tests {
             "orderBy": [["$createdAt", "desc"]],
             "limit": 10,
         }))?;
-        let rows = context.read_rows_for_built_query(&query)?.unwrap();
+        let rows = context.read_rows_for_built_query(&query)?;
 
         assert_eq!(rows.len(), 10);
         assert_eq!(rows[0].id, "todo-100");

--- a/crates/mini-jazz-sqlite/src/query.rs
+++ b/crates/mini-jazz-sqlite/src/query.rs
@@ -1,4 +1,4 @@
-use crate::query_api::BuiltQuery;
+use crate::query_api::{BuiltQuery, QueryCondition, QueryConditionOp, QueryDirection};
 use crate::rows::{public_row_id, row_num};
 use crate::schema::{FieldDef, FieldKind, PolicyDef, SchemaDef};
 use crate::types::RowView;
@@ -15,6 +15,31 @@ pub(crate) struct QueryContext<'a> {
     pub(crate) branch_num: i64,
     pub(crate) user: &'a str,
     pub(crate) bypass_policy: bool,
+}
+
+pub(crate) enum QueryStoragePlan<'a> {
+    EqCreatedAtDescPage {
+        condition: &'a QueryCondition,
+        limit: usize,
+    },
+}
+
+pub(crate) fn storage_plan(query: &BuiltQuery) -> Option<QueryStoragePlan<'_>> {
+    if query.offset.unwrap_or(0) != 0 || query.conditions.len() != 1 || query.order_by.len() != 1 {
+        return None;
+    }
+    let condition = query.conditions.first()?;
+    if condition.op != QueryConditionOp::Eq {
+        return None;
+    }
+    let order = query.order_by.first()?;
+    if order.column == "$createdAt" && order.direction == QueryDirection::Desc {
+        query
+            .limit
+            .map(|limit| QueryStoragePlan::EqCreatedAtDescPage { condition, limit })
+    } else {
+        None
+    }
 }
 
 impl QueryContext<'_> {
@@ -82,11 +107,12 @@ impl QueryContext<'_> {
         &self,
         query: &BuiltQuery,
     ) -> Result<Option<Vec<RowView>>> {
-        let Some((condition, limit)) = query.ordered_page() else {
+        let Some(QueryStoragePlan::EqCreatedAtDescPage { condition, limit }) = storage_plan(query)
+        else {
             return Ok(None);
         };
         if condition.column == "id" || condition.column == "$createdBy" || self.branch_num != 1 {
-            return Ok(Some(self.read_ordered_page_slow(
+            return Ok(Some(self.read_created_at_desc_page_slow(
                 &query.table,
                 &condition.column,
                 condition.value.clone(),
@@ -104,7 +130,7 @@ impl QueryContext<'_> {
                     query.table, condition.column
                 ))
             })?;
-        Ok(Some(self.read_main_ordered_page_where_eq(
+        Ok(Some(self.read_main_created_at_desc_page_where_eq(
             &query.table,
             field,
             &condition.value,
@@ -1509,7 +1535,7 @@ impl QueryContext<'_> {
             .collect()
     }
 
-    fn read_main_ordered_page_where_eq(
+    fn read_main_created_at_desc_page_where_eq(
         &self,
         table_name: &str,
         field: &FieldDef,
@@ -1594,7 +1620,7 @@ impl QueryContext<'_> {
             .collect()
     }
 
-    fn read_ordered_page_slow(
+    fn read_created_at_desc_page_slow(
         &self,
         table_name: &str,
         field_name: &str,

--- a/crates/mini-jazz-sqlite/src/query.rs
+++ b/crates/mini-jazz-sqlite/src/query.rs
@@ -101,6 +101,34 @@ impl QueryContext<'_> {
         Ok(rows)
     }
 
+    pub(crate) fn repair_row_nums_for_built_query(&self, query: &BuiltQuery) -> Result<Vec<i64>> {
+        let table = self.schema.table_def(&query.table)?;
+        let (condition_sql, mut params) =
+            self.lower_query_conditions(table, &query.conditions, "h", "ids")?;
+        let mut query_params = vec![
+            SqlValue::Text(table.name.clone()),
+            SqlValue::Integer(tx::OUTCOME_REJECTED),
+        ];
+        query_params.append(&mut params);
+        let sql = format!(
+            "SELECT DISTINCT h.row_num
+             FROM {} h
+             JOIN jazz_row_id ids ON ids.row_num = h.row_num
+             JOIN jazz_tx tx ON tx.tx_num = h.tx_num
+             WHERE ids.table_name = ?
+               AND tx.outcome != ?
+               AND {condition_sql}
+             ORDER BY h.row_num",
+            crate::schema::history_table(&query.table),
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt.query_map(params_from_iter(query_params.iter()), |row| {
+            row.get::<_, i64>(0)
+        })?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(Into::into)
+    }
+
     fn read_current_built_query(
         &self,
         query: &BuiltQuery,

--- a/crates/mini-jazz-sqlite/src/query.rs
+++ b/crates/mini-jazz-sqlite/src/query.rs
@@ -102,21 +102,133 @@ impl QueryContext<'_> {
     }
 
     pub(crate) fn repair_row_nums_for_built_query(&self, query: &BuiltQuery) -> Result<Vec<i64>> {
+        if query.limit.is_some() || query.offset.is_some() {
+            let support_query = repair_support_query(query)?;
+            return self
+                .read_rows_for_built_query(&support_query)?
+                .into_iter()
+                .map(|row| row_num(self.conn, &row.id))
+                .collect();
+        }
+
         let table = self.schema.table_def(&query.table)?;
-        let (condition_sql, mut params) =
+        let branch_nums = branch::scope_nums(self.conn, self.branch_num)?;
+        let mut row_nums =
+            self.repair_current_row_nums_for_built_query(query, table, &branch_nums)?;
+        if self.branch_num != 1 {
+            if let Some(base_epoch) = branch::base_global_epoch(self.conn, self.branch_num)? {
+                row_nums.extend(
+                    self.repair_main_snapshot_row_nums_for_built_query(query, table, base_epoch)?,
+                );
+            }
+        }
+        row_nums.sort();
+        row_nums.dedup();
+        Ok(row_nums)
+    }
+
+    fn repair_current_row_nums_for_built_query(
+        &self,
+        query: &BuiltQuery,
+        table: &crate::schema::TableDef,
+        branch_nums: &[i64],
+    ) -> Result<Vec<i64>> {
+        let (condition_sql, condition_params) =
             self.lower_query_conditions(table, &query.conditions, "h", "ids")?;
-        let mut query_params = vec![SqlValue::Integer(tx::OUTCOME_REJECTED)];
-        query_params.append(&mut params);
+        let policy_sql = if self.bypass_policy {
+            "1 = 1".to_owned()
+        } else {
+            policy::branch_read_policy_sql_for_alias(
+                self.schema,
+                table,
+                "h",
+                self.user,
+                self.branch_num,
+            )?
+        };
+        let branch_placeholders = placeholders(branch_nums.len());
         let sql = format!(
             "SELECT DISTINCT h.row_num
              FROM {} h
              JOIN jazz_row_id ids ON ids.row_num = h.row_num
              JOIN jazz_tx tx ON tx.tx_num = h.tx_num
-             WHERE tx.outcome != ?
+             WHERE h.j_branch_num IN ({branch_placeholders})
+               AND tx.outcome != ?
                AND {condition_sql}
+               AND {policy_sql}
              ORDER BY h.row_num",
             crate::schema::history_table(&query.table),
         );
+        let mut query_params = branch_nums
+            .iter()
+            .copied()
+            .map(SqlValue::Integer)
+            .collect::<Vec<_>>();
+        query_params.push(SqlValue::Integer(tx::OUTCOME_REJECTED));
+        query_params.extend(condition_params);
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt.query_map(params_from_iter(query_params.iter()), |row| {
+            row.get::<_, i64>(0)
+        })?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(Into::into)
+    }
+
+    fn repair_main_snapshot_row_nums_for_built_query(
+        &self,
+        query: &BuiltQuery,
+        table: &crate::schema::TableDef,
+        base_epoch: i64,
+    ) -> Result<Vec<i64>> {
+        let (condition_sql, condition_params) =
+            self.lower_query_conditions(table, &query.conditions, "h", "ids")?;
+        let policy_sql = if self.bypass_policy {
+            "1 = 1".to_owned()
+        } else {
+            policy::snapshot_read_policy_sql_for_alias(
+                self.schema,
+                table,
+                "h",
+                self.user,
+                base_epoch,
+            )?
+        };
+        let sql = format!(
+            "SELECT DISTINCT h.row_num
+             FROM {} h
+             JOIN jazz_row_id ids ON ids.row_num = h.row_num
+             JOIN jazz_tx tx ON tx.tx_num = h.tx_num
+             WHERE h.j_branch_num = 1
+               AND tx.outcome != ?
+               AND tx.global_epoch IS NOT NULL
+               AND tx.global_epoch <= ?
+               AND h.op != 3
+               AND {condition_sql}
+               AND {policy_sql}
+               AND NOT EXISTS (
+                 SELECT 1
+                 FROM {history_table} newer
+                 JOIN jazz_tx newer_tx ON newer_tx.tx_num = newer.tx_num
+                 WHERE newer.row_num = h.row_num
+                   AND newer.j_branch_num = 1
+                   AND newer_tx.outcome != ?
+                   AND newer_tx.global_epoch IS NOT NULL
+                   AND newer_tx.global_epoch <= ?
+                   AND (newer_tx.global_epoch > tx.global_epoch OR (newer_tx.global_epoch = tx.global_epoch AND newer_tx.tx_num > tx.tx_num))
+               )
+             ORDER BY h.row_num",
+            crate::schema::history_table(&query.table),
+            history_table = crate::schema::history_table(&query.table),
+        );
+        let mut query_params = vec![
+            SqlValue::Integer(tx::OUTCOME_REJECTED),
+            SqlValue::Integer(base_epoch),
+        ];
+        query_params.extend(condition_params);
+        query_params.extend([
+            SqlValue::Integer(tx::OUTCOME_REJECTED),
+            SqlValue::Integer(base_epoch),
+        ]);
         let mut stmt = self.conn.prepare(&sql)?;
         let rows = stmt.query_map(params_from_iter(query_params.iter()), |row| {
             row.get::<_, i64>(0)
@@ -2151,6 +2263,25 @@ fn apply_query_window(
         rows.truncate(limit);
     }
     rows
+}
+
+fn repair_support_query(query: &BuiltQuery) -> Result<BuiltQuery> {
+    let offset = query.offset.unwrap_or(0);
+    if offset == 0 {
+        return Ok(query.clone());
+    }
+
+    let mut support_query = query.clone();
+    support_query.offset = None;
+    support_query.limit = query
+        .limit
+        .map(|limit| {
+            offset
+                .checked_add(limit)
+                .ok_or_else(|| crate::Error::new("query limit plus offset is too large"))
+        })
+        .transpose()?;
+    Ok(support_query)
 }
 
 fn row_to_view(

--- a/crates/mini-jazz-sqlite/src/query_api.rs
+++ b/crates/mini-jazz-sqlite/src/query_api.rs
@@ -132,6 +132,25 @@ impl QueryDirection {
     }
 }
 
+pub(crate) fn predicate_query(
+    table: &str,
+    column: &str,
+    op: QueryConditionOp,
+    value: JsonValue,
+) -> BuiltQuery {
+    BuiltQuery {
+        table: table.to_owned(),
+        conditions: vec![QueryCondition {
+            column: column.to_owned(),
+            op,
+            value,
+        }],
+        order_by: Vec::new(),
+        limit: None,
+        offset: None,
+    }
+}
+
 impl Runtime {
     pub fn query(&self, query: BuiltQuery) -> Result<Vec<RowView>> {
         self.read_rows_for_built_query(&query)
@@ -165,7 +184,12 @@ impl Runtime {
         let rows = match &subscription.query {
             RowsSubscriptionQuery::Table { table } => self.read_rows(table)?,
             RowsSubscriptionQuery::Predicate(query) if query.op == "eq" => {
-                self.read_rows_where_eq(&query.table, &query.field, query.value.clone())?
+                self.query(predicate_query(
+                    &query.table,
+                    &query.field,
+                    QueryConditionOp::Eq,
+                    query.value.clone(),
+                ))?
             }
             RowsSubscriptionQuery::Predicate(query) if query.op == "ne" => {
                 self.read_rows_where_ne(&query.table, &query.field, query.value.clone())?

--- a/crates/mini-jazz-sqlite/src/query_api.rs
+++ b/crates/mini-jazz-sqlite/src/query_api.rs
@@ -385,6 +385,8 @@ fn parse_order_by(value: Option<&JsonValue>) -> Result<Vec<QueryOrderBy>> {
 }
 
 fn parse_usize_field(object: &JsonMap<String, JsonValue>, field: &str) -> Result<Option<usize>> {
+    const MAX_PORTABLE_USIZE: u64 = u32::MAX as u64;
+
     let Some(value) = object.get(field) else {
         return Ok(None);
     };
@@ -396,7 +398,14 @@ fn parse_usize_field(object: &JsonMap<String, JsonValue>, field: &str) -> Result
             "query {field} must be a non-negative integer"
         )));
     };
-    Ok(Some(value as usize))
+    if value > MAX_PORTABLE_USIZE {
+        return Err(Error::new(format!(
+            "query {field} is too large; maximum is {MAX_PORTABLE_USIZE}"
+        )));
+    }
+    usize::try_from(value)
+        .map(Some)
+        .map_err(|_| Error::new(format!("query {field} is too large")))
 }
 
 fn condition_matches(row: &RowView, condition: &QueryCondition) -> Result<bool> {
@@ -503,5 +512,29 @@ fn apply_window(rows: Vec<RowView>, offset: Option<usize>, limit: Option<usize>)
     match limit {
         Some(limit) => rows.into_iter().skip(offset).take(limit).collect(),
         None => rows.into_iter().skip(offset).collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn built_query_rejects_window_values_too_large_for_wasm_usize() {
+        for field in ["limit", "offset"] {
+            let err = BuiltQuery::from_json_value(json!({
+                "table": "todos",
+                "conditions": [],
+                field: u64::from(u32::MAX) + 1,
+            }))
+            .unwrap_err();
+
+            assert!(
+                err.to_string()
+                    .contains(&format!("query {field} is too large")),
+                "{err}"
+            );
+        }
     }
 }

--- a/crates/mini-jazz-sqlite/src/query_api.rs
+++ b/crates/mini-jazz-sqlite/src/query_api.rs
@@ -225,6 +225,31 @@ impl Runtime {
 }
 
 fn reject_unsupported_fields(object: &JsonMap<String, JsonValue>) -> Result<()> {
+    if object.get("branch").is_some_and(|value| !value.is_null()) {
+        return Err(Error::new("mini-sqlite query does not support branch"));
+    }
+    if object
+        .get("branches")
+        .is_some_and(|value| !is_empty_array(value))
+    {
+        return Err(Error::new("mini-sqlite query does not support branches"));
+    }
+    if object
+        .get("include_deleted")
+        .is_some_and(|value| value.as_bool().unwrap_or(true))
+    {
+        return Err(Error::new(
+            "mini-sqlite query does not support include_deleted",
+        ));
+    }
+    if object
+        .get("includeDeleted")
+        .is_some_and(|value| value.as_bool().unwrap_or(true))
+    {
+        return Err(Error::new(
+            "mini-sqlite query does not support includeDeleted",
+        ));
+    }
     if object
         .get("includes")
         .is_some_and(|value| !is_empty_object(value))
@@ -411,6 +436,29 @@ mod tests {
                 err.to_string()
                     .contains(&format!("query {field} is too large")),
                 "{err}"
+            );
+        }
+    }
+
+    #[test]
+    fn built_query_rejects_branch_and_include_deleted_options_it_cannot_honor() {
+        for (field, value) in [
+            ("branch", json!("draft")),
+            ("branches", json!(["draft"])),
+            ("include_deleted", json!(true)),
+            ("includeDeleted", json!(true)),
+        ] {
+            let err = BuiltQuery::from_json_value(json!({
+                "table": "todos",
+                "conditions": [],
+                field: value,
+            }))
+            .unwrap_err();
+
+            assert!(
+                err.to_string()
+                    .contains("mini-sqlite query does not support"),
+                "{field}: {err}"
             );
         }
     }

--- a/crates/mini-jazz-sqlite/src/query_api.rs
+++ b/crates/mini-jazz-sqlite/src/query_api.rs
@@ -4,7 +4,6 @@ use crate::sync::Bundle;
 use crate::types::{RowView, SubscriptionDelta};
 use crate::{Error, Result};
 use serde_json::{Map as JsonMap, Value as JsonValue};
-use std::cmp::Ordering;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BuiltQuery {
@@ -135,13 +134,7 @@ impl QueryDirection {
 
 impl Runtime {
     pub fn query(&self, query: BuiltQuery) -> Result<Vec<RowView>> {
-        if let Some(rows) = self.read_rows_for_built_query(&query)? {
-            return Ok(rows);
-        }
-
-        let mut rows = self.rows_for_conditions(&query.table, &query.conditions)?;
-        apply_ordering(&mut rows, &query.order_by)?;
-        Ok(apply_window(rows, query.offset, query.limit))
+        self.read_rows_for_built_query(&query)
     }
 
     pub fn one(&self, query: BuiltQuery) -> Result<Option<RowView>> {
@@ -204,57 +197,6 @@ impl Runtime {
             RowsSubscriptionQuery::Built(query) => self.query(query.clone())?,
         };
         Ok(subscription.replace_with_subscription_delta(rows))
-    }
-
-    fn rows_for_conditions(
-        &self,
-        table: &str,
-        conditions: &[QueryCondition],
-    ) -> Result<Vec<RowView>> {
-        let mut rows = match conditions.first() {
-            Some(condition) => self.rows_for_condition(table, condition)?,
-            None => self.read_rows(table)?,
-        };
-        if conditions.len() > 1 {
-            let mut filtered = Vec::new();
-            for row in rows {
-                let mut matches = true;
-                for condition in conditions {
-                    if !condition_matches(&row, condition)? {
-                        matches = false;
-                        break;
-                    }
-                }
-                if matches {
-                    filtered.push(row);
-                }
-            }
-            rows = filtered;
-        }
-        Ok(rows)
-    }
-
-    fn rows_for_condition(&self, table: &str, condition: &QueryCondition) -> Result<Vec<RowView>> {
-        match condition.op {
-            QueryConditionOp::Eq => {
-                self.read_rows_where_eq(table, &condition.column, condition.value.clone())
-            }
-            QueryConditionOp::Ne => {
-                self.read_rows_where_ne(table, &condition.column, condition.value.clone())
-            }
-            QueryConditionOp::In => {
-                let Some(values) = condition.value.as_array() else {
-                    return Err(Error::new("in condition expects an array value"));
-                };
-                self.read_rows_where_in(table, &condition.column, values.clone())
-            }
-            QueryConditionOp::Contains => {
-                let Some(needle) = condition.value.as_str() else {
-                    return Err(Error::new("contains condition expects a string value"));
-                };
-                self.read_rows_where_contains(table, &condition.column, needle)
-            }
-        }
     }
 }
 
@@ -406,113 +348,6 @@ fn parse_usize_field(object: &JsonMap<String, JsonValue>, field: &str) -> Result
     usize::try_from(value)
         .map(Some)
         .map_err(|_| Error::new(format!("query {field} is too large")))
-}
-
-fn condition_matches(row: &RowView, condition: &QueryCondition) -> Result<bool> {
-    match condition.op {
-        QueryConditionOp::Eq => {
-            Ok(row_query_value(row, &condition.column).as_ref() == Some(&condition.value))
-        }
-        QueryConditionOp::Ne => {
-            if condition.column == "id" || condition.column == "$createdBy" {
-                return Ok(
-                    row_query_value(row, &condition.column).as_ref() != Some(&condition.value)
-                );
-            }
-            Ok(row
-                .values
-                .get(&condition.column)
-                .is_some_and(|value| value != &condition.value))
-        }
-        QueryConditionOp::In => {
-            let Some(values) = condition.value.as_array() else {
-                return Err(Error::new("in condition expects an array value"));
-            };
-            Ok(row_query_value(row, &condition.column)
-                .as_ref()
-                .is_some_and(|value| values.contains(value)))
-        }
-        QueryConditionOp::Contains => {
-            let Some(needle) = condition.value.as_str() else {
-                return Err(Error::new("contains condition expects a string value"));
-            };
-            Ok(row_query_value(row, &condition.column)
-                .and_then(|value| value.as_str().map(str::to_owned))
-                .is_some_and(|value| value.contains(needle)))
-        }
-    }
-}
-
-fn row_query_value(row: &RowView, column: &str) -> Option<JsonValue> {
-    match column {
-        "id" => Some(JsonValue::String(row.id.clone())),
-        "$createdBy" => Some(JsonValue::String(row.created_by.clone())),
-        column => row.values.get(column).cloned(),
-    }
-}
-
-fn apply_ordering(rows: &mut [RowView], order_by: &[QueryOrderBy]) -> Result<()> {
-    if order_by.is_empty() {
-        return Ok(());
-    }
-    if order_by.iter().any(|order| order.column == "$createdAt") {
-        return Err(Error::new(
-            "$createdAt orderBy requires one eq condition, desc direction, limit, and no offset",
-        ));
-    }
-    rows.sort_by(|left, right| {
-        for order in order_by {
-            let ordering = compare_json_values(
-                row_query_value(left, &order.column).as_ref(),
-                row_query_value(right, &order.column).as_ref(),
-            );
-            let ordering = match order.direction {
-                QueryDirection::Asc => ordering,
-                QueryDirection::Desc => ordering.reverse(),
-            };
-            if ordering != Ordering::Equal {
-                return ordering;
-            }
-        }
-        left.id.cmp(&right.id)
-    });
-    Ok(())
-}
-
-fn compare_json_values(left: Option<&JsonValue>, right: Option<&JsonValue>) -> Ordering {
-    let left_rank = json_value_rank(left);
-    let right_rank = json_value_rank(right);
-    left_rank
-        .cmp(&right_rank)
-        .then_with(|| match (left, right) {
-            (Some(JsonValue::Bool(left)), Some(JsonValue::Bool(right))) => left.cmp(right),
-            (Some(JsonValue::Number(left)), Some(JsonValue::Number(right))) => left
-                .as_f64()
-                .partial_cmp(&right.as_f64())
-                .unwrap_or(Ordering::Equal),
-            (Some(JsonValue::String(left)), Some(JsonValue::String(right))) => left.cmp(right),
-            (Some(left), Some(right)) => left.to_string().cmp(&right.to_string()),
-            _ => Ordering::Equal,
-        })
-}
-
-fn json_value_rank(value: Option<&JsonValue>) -> u8 {
-    match value {
-        None | Some(JsonValue::Null) => 0,
-        Some(JsonValue::Bool(_)) => 1,
-        Some(JsonValue::Number(_)) => 2,
-        Some(JsonValue::String(_)) => 3,
-        Some(JsonValue::Array(_)) => 4,
-        Some(JsonValue::Object(_)) => 5,
-    }
-}
-
-fn apply_window(rows: Vec<RowView>, offset: Option<usize>, limit: Option<usize>) -> Vec<RowView> {
-    let offset = offset.unwrap_or(0);
-    match limit {
-        Some(limit) => rows.into_iter().skip(offset).take(limit).collect(),
-        None => rows.into_iter().skip(offset).collect(),
-    }
 }
 
 #[cfg(test)]

--- a/crates/mini-jazz-sqlite/src/query_api.rs
+++ b/crates/mini-jazz-sqlite/src/query_api.rs
@@ -71,7 +71,7 @@ impl BuiltQuery {
         })
     }
 
-    fn top_created_at_desc_fast_path(&self) -> Option<(&QueryCondition, usize)> {
+    pub(crate) fn ordered_page(&self) -> Option<(&QueryCondition, usize)> {
         if self.offset.unwrap_or(0) != 0 || self.conditions.len() != 1 || self.order_by.len() != 1 {
             return None;
         }
@@ -87,19 +87,7 @@ impl BuiltQuery {
         }
     }
 
-    fn export_scope(&self) -> Result<QueryExportScope> {
-        if let Some((condition, limit)) = self.top_created_at_desc_fast_path() {
-            return Ok(QueryExportScope {
-                table: self.table.clone(),
-                field: condition.column.clone(),
-                op: "eq_top_created_at_desc",
-                value: serde_json::json!({
-                    "eq": condition.value.clone(),
-                    "limit": limit,
-                }),
-            });
-        }
-
+    pub(crate) fn single_predicate_export_condition(&self) -> Result<Option<&QueryCondition>> {
         if self.conditions.len() != 1
             || !self.order_by.is_empty()
             || self.limit.is_some()
@@ -110,18 +98,53 @@ impl BuiltQuery {
             ));
         }
 
-        let condition = &self.conditions[0];
-        Ok(QueryExportScope {
-            table: self.table.clone(),
-            field: condition.column.clone(),
-            op: condition.op.query_read_op(),
-            value: condition.value.clone(),
-        })
+        Ok(self.conditions.first())
+    }
+
+    pub(crate) fn to_json_value(&self) -> JsonValue {
+        let mut object = JsonMap::new();
+        object.insert("table".to_owned(), JsonValue::String(self.table.clone()));
+        object.insert(
+            "conditions".to_owned(),
+            JsonValue::Array(
+                self.conditions
+                    .iter()
+                    .map(|condition| {
+                        serde_json::json!({
+                            "column": condition.column.clone(),
+                            "op": condition.op.as_str(),
+                            "value": condition.value.clone(),
+                        })
+                    })
+                    .collect(),
+            ),
+        );
+        object.insert(
+            "orderBy".to_owned(),
+            JsonValue::Array(
+                self.order_by
+                    .iter()
+                    .map(|order| {
+                        JsonValue::Array(vec![
+                            JsonValue::String(order.column.clone()),
+                            JsonValue::String(order.direction.as_str().to_owned()),
+                        ])
+                    })
+                    .collect(),
+            ),
+        );
+        if let Some(limit) = self.limit {
+            object.insert("limit".to_owned(), serde_json::json!(limit));
+        }
+        if let Some(offset) = self.offset {
+            object.insert("offset".to_owned(), serde_json::json!(offset));
+        }
+        JsonValue::Object(object)
     }
 }
 
 impl QueryConditionOp {
-    fn query_read_op(&self) -> &'static str {
+    pub(crate) fn as_str(&self) -> &'static str {
         match self {
             QueryConditionOp::Eq => "eq",
             QueryConditionOp::Ne => "ne",
@@ -131,22 +154,19 @@ impl QueryConditionOp {
     }
 }
 
-struct QueryExportScope {
-    table: String,
-    field: String,
-    op: &'static str,
-    value: JsonValue,
+impl QueryDirection {
+    fn as_str(&self) -> &'static str {
+        match self {
+            QueryDirection::Asc => "asc",
+            QueryDirection::Desc => "desc",
+        }
+    }
 }
 
 impl Runtime {
     pub fn query(&self, query: BuiltQuery) -> Result<Vec<RowView>> {
-        if let Some((condition, limit)) = query.top_created_at_desc_fast_path() {
-            return self.read_rows_where_eq_top_created_at_desc(
-                &query.table,
-                &condition.column,
-                condition.value.clone(),
-                limit,
-            );
+        if let Some(rows) = self.read_rows_for_built_query(&query)? {
+            return Ok(rows);
         }
 
         let mut rows = self.rows_for_conditions(&query.table, &query.conditions)?;
@@ -171,16 +191,8 @@ impl Runtime {
         query: BuiltQuery,
         ref_include_fields: &[&str],
     ) -> Result<Bundle> {
-        let scope = query.export_scope()?;
-        let rows = self.query(query)?;
-        self.export_query_scope(
-            &scope.table,
-            &scope.field,
-            scope.op,
-            scope.value,
-            rows,
-            ref_include_fields,
-        )
+        let rows = self.query(query.clone())?;
+        self.export_built_query_scope(query, rows, ref_include_fields)
     }
 
     pub fn subscription_delta(
@@ -212,23 +224,6 @@ impl Runtime {
                     return Err(Error::new("recursive refs expects root id string"));
                 };
                 self.read_recursive_refs(&query.table, root_id, &query.field)?
-            }
-            RowsSubscriptionQuery::Predicate(query) if query.op == "eq_top_created_at_desc" => {
-                let value = query
-                    .value
-                    .get("eq")
-                    .ok_or_else(|| Error::new("top created query expects eq value"))?;
-                let limit = query
-                    .value
-                    .get("limit")
-                    .and_then(JsonValue::as_u64)
-                    .ok_or_else(|| Error::new("top created query expects numeric limit"))?;
-                self.read_rows_where_eq_top_created_at_desc(
-                    &query.table,
-                    &query.field,
-                    value.clone(),
-                    limit as usize,
-                )?
             }
             RowsSubscriptionQuery::Predicate(query) => {
                 return Err(Error::new(format!(

--- a/crates/mini-jazz-sqlite/src/query_api.rs
+++ b/crates/mini-jazz-sqlite/src/query_api.rs
@@ -71,20 +71,6 @@ impl BuiltQuery {
         })
     }
 
-    pub(crate) fn single_predicate_export_condition(&self) -> Result<Option<&QueryCondition>> {
-        if self.conditions.len() != 1
-            || !self.order_by.is_empty()
-            || self.limit.is_some()
-            || self.offset.unwrap_or(0) != 0
-        {
-            return Err(Error::new(
-                "export_query supports one predicate, or one eq predicate ordered by $createdAt desc with a limit",
-            ));
-        }
-
-        Ok(self.conditions.first())
-    }
-
     pub(crate) fn to_json_value(&self) -> JsonValue {
         let mut object = JsonMap::new();
         object.insert("table".to_owned(), JsonValue::String(self.table.clone()));

--- a/crates/mini-jazz-sqlite/src/query_api.rs
+++ b/crates/mini-jazz-sqlite/src/query_api.rs
@@ -212,6 +212,29 @@ impl Runtime {
                 };
                 self.read_recursive_refs(&query.table, root_id, &query.field)?
             }
+            RowsSubscriptionQuery::Predicate(query) if query.op == "eq_top_field_desc" => {
+                let value = query
+                    .value
+                    .get("eq")
+                    .ok_or_else(|| Error::new("top field query expects eq value"))?;
+                let order_field = query
+                    .value
+                    .get("order_field")
+                    .and_then(JsonValue::as_str)
+                    .ok_or_else(|| Error::new("top field query expects order_field"))?;
+                let limit = query
+                    .value
+                    .get("limit")
+                    .and_then(JsonValue::as_u64)
+                    .ok_or_else(|| Error::new("top field query expects numeric limit"))?;
+                self.read_rows_where_eq_top_field_desc(
+                    &query.table,
+                    &query.field,
+                    value.clone(),
+                    order_field,
+                    limit as usize,
+                )?
+            }
             RowsSubscriptionQuery::Predicate(query) => {
                 return Err(Error::new(format!(
                     "unsupported subscription query {}",

--- a/crates/mini-jazz-sqlite/src/query_api.rs
+++ b/crates/mini-jazz-sqlite/src/query_api.rs
@@ -173,7 +173,7 @@ impl Runtime {
         query: BuiltQuery,
         ref_include_fields: &[&str],
     ) -> Result<Bundle> {
-        let rows = self.query(query.clone())?;
+        let rows = self.query(export_support_query(&query)?)?;
         self.export_built_query_scope(query, rows, ref_include_fields)
     }
 
@@ -267,6 +267,24 @@ fn is_empty_object(value: &JsonValue) -> bool {
 
 fn is_empty_array(value: &JsonValue) -> bool {
     value.as_array().is_some_and(Vec::is_empty)
+}
+
+fn export_support_query(query: &BuiltQuery) -> Result<BuiltQuery> {
+    let offset = query.offset.unwrap_or(0);
+    if offset == 0 {
+        return Ok(query.clone());
+    }
+
+    let mut support_query = query.clone();
+    support_query.offset = None;
+    if let Some(limit) = query.limit {
+        support_query.limit = Some(
+            offset
+                .checked_add(limit)
+                .ok_or_else(|| Error::new("query limit plus offset is too large"))?,
+        );
+    }
+    Ok(support_query)
 }
 
 fn parse_conditions(value: Option<&JsonValue>) -> Result<Vec<QueryCondition>> {

--- a/crates/mini-jazz-sqlite/src/query_api.rs
+++ b/crates/mini-jazz-sqlite/src/query_api.rs
@@ -1,0 +1,470 @@
+use crate::runtime::Runtime;
+use crate::subscription::{RowsSubscription, RowsSubscriptionQuery};
+use crate::types::{RowView, SubscriptionDelta};
+use crate::{Error, Result};
+use serde_json::{Map as JsonMap, Value as JsonValue};
+use std::cmp::Ordering;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BuiltQuery {
+    pub table: String,
+    pub conditions: Vec<QueryCondition>,
+    pub order_by: Vec<QueryOrderBy>,
+    pub limit: Option<usize>,
+    pub offset: Option<usize>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct QueryCondition {
+    pub column: String,
+    pub op: QueryConditionOp,
+    pub value: JsonValue,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum QueryConditionOp {
+    Eq,
+    Ne,
+    In,
+    Contains,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct QueryOrderBy {
+    pub column: String,
+    pub direction: QueryDirection,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum QueryDirection {
+    Asc,
+    Desc,
+}
+
+impl BuiltQuery {
+    pub fn from_json_str(query: &str) -> Result<Self> {
+        let value = serde_json::from_str(query)
+            .map_err(|error| Error::new(format!("invalid query JSON: {error}")))?;
+        Self::from_json_value(value)
+    }
+
+    pub fn from_json_value(value: JsonValue) -> Result<Self> {
+        let object = value
+            .as_object()
+            .ok_or_else(|| Error::new("query must be a JSON object"))?;
+        reject_unsupported_fields(object)?;
+
+        let table = object
+            .get("table")
+            .and_then(JsonValue::as_str)
+            .filter(|table| !table.is_empty())
+            .ok_or_else(|| Error::new("query table must be a non-empty string"))?
+            .to_owned();
+
+        Ok(Self {
+            table,
+            conditions: parse_conditions(object.get("conditions"))?,
+            order_by: parse_order_by(object.get("orderBy"))?,
+            limit: parse_usize_field(object, "limit")?,
+            offset: parse_usize_field(object, "offset")?,
+        })
+    }
+
+    fn top_created_at_desc_fast_path(&self) -> Option<(&QueryCondition, usize)> {
+        if self.offset.unwrap_or(0) != 0 || self.conditions.len() != 1 || self.order_by.len() != 1 {
+            return None;
+        }
+        let condition = self.conditions.first()?;
+        if condition.op != QueryConditionOp::Eq {
+            return None;
+        }
+        let order = self.order_by.first()?;
+        if order.column == "$createdAt" && order.direction == QueryDirection::Desc {
+            self.limit.map(|limit| (condition, limit))
+        } else {
+            None
+        }
+    }
+}
+
+impl Runtime {
+    pub fn query(&self, query: BuiltQuery) -> Result<Vec<RowView>> {
+        if let Some((condition, limit)) = query.top_created_at_desc_fast_path() {
+            return self.read_rows_where_eq_top_created_at_desc(
+                &query.table,
+                &condition.column,
+                condition.value.clone(),
+                limit,
+            );
+        }
+
+        let mut rows = self.rows_for_conditions(&query.table, &query.conditions)?;
+        apply_ordering(&mut rows, &query.order_by)?;
+        Ok(apply_window(rows, query.offset, query.limit))
+    }
+
+    pub fn one(&self, query: BuiltQuery) -> Result<Option<RowView>> {
+        Ok(self.query(query)?.into_iter().next())
+    }
+
+    pub fn subscribe_query(&self, query: BuiltQuery) -> Result<RowsSubscription> {
+        Ok(RowsSubscription::query(query.clone(), self.query(query)?))
+    }
+
+    pub fn subscription_delta(
+        &self,
+        subscription: &mut RowsSubscription,
+    ) -> Result<SubscriptionDelta> {
+        let rows = match &subscription.query {
+            RowsSubscriptionQuery::Table { table } => self.read_rows(table)?,
+            RowsSubscriptionQuery::Predicate(query) if query.op == "eq" => {
+                self.read_rows_where_eq(&query.table, &query.field, query.value.clone())?
+            }
+            RowsSubscriptionQuery::Predicate(query) if query.op == "ne" => {
+                self.read_rows_where_ne(&query.table, &query.field, query.value.clone())?
+            }
+            RowsSubscriptionQuery::Predicate(query) if query.op == "contains" => {
+                let Some(needle) = query.value.as_str() else {
+                    return Err(Error::new("contains expects a string value"));
+                };
+                self.read_rows_where_contains(&query.table, &query.field, needle)?
+            }
+            RowsSubscriptionQuery::Predicate(query) if query.op == "in" => {
+                let Some(values) = query.value.as_array() else {
+                    return Err(Error::new("in predicate expects an array value"));
+                };
+                self.read_rows_where_in(&query.table, &query.field, values.clone())?
+            }
+            RowsSubscriptionQuery::Predicate(query) if query.op == "recursive_refs" => {
+                let Some(root_id) = query.value.as_str() else {
+                    return Err(Error::new("recursive refs expects root id string"));
+                };
+                self.read_recursive_refs(&query.table, root_id, &query.field)?
+            }
+            RowsSubscriptionQuery::Predicate(query) if query.op == "eq_top_created_at_desc" => {
+                let value = query
+                    .value
+                    .get("eq")
+                    .ok_or_else(|| Error::new("top created query expects eq value"))?;
+                let limit = query
+                    .value
+                    .get("limit")
+                    .and_then(JsonValue::as_u64)
+                    .ok_or_else(|| Error::new("top created query expects numeric limit"))?;
+                self.read_rows_where_eq_top_created_at_desc(
+                    &query.table,
+                    &query.field,
+                    value.clone(),
+                    limit as usize,
+                )?
+            }
+            RowsSubscriptionQuery::Predicate(query) => {
+                return Err(Error::new(format!(
+                    "unsupported subscription query {}",
+                    query.op
+                )));
+            }
+            RowsSubscriptionQuery::Built(query) => self.query(query.clone())?,
+        };
+        Ok(subscription.replace_with_subscription_delta(rows))
+    }
+
+    fn rows_for_conditions(
+        &self,
+        table: &str,
+        conditions: &[QueryCondition],
+    ) -> Result<Vec<RowView>> {
+        let mut rows = match conditions.first() {
+            Some(condition) => self.rows_for_condition(table, condition)?,
+            None => self.read_rows(table)?,
+        };
+        if conditions.len() > 1 {
+            let mut filtered = Vec::new();
+            for row in rows {
+                let mut matches = true;
+                for condition in conditions {
+                    if !condition_matches(&row, condition)? {
+                        matches = false;
+                        break;
+                    }
+                }
+                if matches {
+                    filtered.push(row);
+                }
+            }
+            rows = filtered;
+        }
+        Ok(rows)
+    }
+
+    fn rows_for_condition(&self, table: &str, condition: &QueryCondition) -> Result<Vec<RowView>> {
+        match condition.op {
+            QueryConditionOp::Eq => {
+                self.read_rows_where_eq(table, &condition.column, condition.value.clone())
+            }
+            QueryConditionOp::Ne => {
+                self.read_rows_where_ne(table, &condition.column, condition.value.clone())
+            }
+            QueryConditionOp::In => {
+                let Some(values) = condition.value.as_array() else {
+                    return Err(Error::new("in condition expects an array value"));
+                };
+                self.read_rows_where_in(table, &condition.column, values.clone())
+            }
+            QueryConditionOp::Contains => {
+                let Some(needle) = condition.value.as_str() else {
+                    return Err(Error::new("contains condition expects a string value"));
+                };
+                self.read_rows_where_contains(table, &condition.column, needle)
+            }
+        }
+    }
+}
+
+fn reject_unsupported_fields(object: &JsonMap<String, JsonValue>) -> Result<()> {
+    if object
+        .get("includes")
+        .is_some_and(|value| !is_empty_object(value))
+    {
+        return Err(Error::new("mini-sqlite query does not support includes"));
+    }
+    if object
+        .get("__jazz_requireIncludes")
+        .and_then(JsonValue::as_bool)
+        .unwrap_or(false)
+    {
+        return Err(Error::new(
+            "mini-sqlite query does not support requireIncludes",
+        ));
+    }
+    if object
+        .get("select")
+        .is_some_and(|value| !is_empty_array(value))
+    {
+        return Err(Error::new("mini-sqlite query does not support select"));
+    }
+    if object
+        .get("hops")
+        .is_some_and(|value| !is_empty_array(value))
+    {
+        return Err(Error::new("mini-sqlite query does not support hopTo"));
+    }
+    if object.get("gather").is_some_and(|value| !value.is_null()) {
+        return Err(Error::new("mini-sqlite query does not support gather"));
+    }
+    if object.get("union").is_some_and(|value| !value.is_null()) {
+        return Err(Error::new("mini-sqlite query does not support union"));
+    }
+    Ok(())
+}
+
+fn is_empty_object(value: &JsonValue) -> bool {
+    value.as_object().is_some_and(JsonMap::is_empty)
+}
+
+fn is_empty_array(value: &JsonValue) -> bool {
+    value.as_array().is_some_and(Vec::is_empty)
+}
+
+fn parse_conditions(value: Option<&JsonValue>) -> Result<Vec<QueryCondition>> {
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+    let Some(conditions) = value.as_array() else {
+        return Err(Error::new("query conditions must be an array"));
+    };
+    conditions
+        .iter()
+        .map(|condition| {
+            let object = condition
+                .as_object()
+                .ok_or_else(|| Error::new("query condition must be an object"))?;
+            let column = object
+                .get("column")
+                .and_then(JsonValue::as_str)
+                .filter(|column| !column.is_empty())
+                .ok_or_else(|| Error::new("query condition column must be a non-empty string"))?
+                .to_owned();
+            let op = object
+                .get("op")
+                .and_then(JsonValue::as_str)
+                .ok_or_else(|| Error::new("query condition op must be a string"))
+                .and_then(parse_condition_op)?;
+            let value = object
+                .get("value")
+                .cloned()
+                .ok_or_else(|| Error::new("query condition value is required"))?;
+            Ok(QueryCondition { column, op, value })
+        })
+        .collect()
+}
+
+fn parse_condition_op(op: &str) -> Result<QueryConditionOp> {
+    match op {
+        "eq" => Ok(QueryConditionOp::Eq),
+        "ne" => Ok(QueryConditionOp::Ne),
+        "in" => Ok(QueryConditionOp::In),
+        "contains" => Ok(QueryConditionOp::Contains),
+        _ => Err(Error::new(format!("unsupported query condition op {op}"))),
+    }
+}
+
+fn parse_order_by(value: Option<&JsonValue>) -> Result<Vec<QueryOrderBy>> {
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+    let Some(entries) = value.as_array() else {
+        return Err(Error::new("query orderBy must be an array"));
+    };
+    entries
+        .iter()
+        .map(|entry| {
+            let Some(pair) = entry.as_array() else {
+                return Err(Error::new("query orderBy entry must be an array"));
+            };
+            if pair.len() != 2 {
+                return Err(Error::new("query orderBy entry must have two items"));
+            }
+            let column = pair[0]
+                .as_str()
+                .filter(|column| !column.is_empty())
+                .ok_or_else(|| Error::new("query orderBy column must be a non-empty string"))?
+                .to_owned();
+            let direction = match pair[1]
+                .as_str()
+                .ok_or_else(|| Error::new("query orderBy direction must be a string"))?
+            {
+                "asc" => QueryDirection::Asc,
+                "desc" => QueryDirection::Desc,
+                direction => {
+                    return Err(Error::new(format!(
+                        "unsupported query orderBy direction {direction}"
+                    )));
+                }
+            };
+            Ok(QueryOrderBy { column, direction })
+        })
+        .collect()
+}
+
+fn parse_usize_field(object: &JsonMap<String, JsonValue>, field: &str) -> Result<Option<usize>> {
+    let Some(value) = object.get(field) else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let Some(value) = value.as_u64() else {
+        return Err(Error::new(format!(
+            "query {field} must be a non-negative integer"
+        )));
+    };
+    Ok(Some(value as usize))
+}
+
+fn condition_matches(row: &RowView, condition: &QueryCondition) -> Result<bool> {
+    match condition.op {
+        QueryConditionOp::Eq => {
+            Ok(row_query_value(row, &condition.column).as_ref() == Some(&condition.value))
+        }
+        QueryConditionOp::Ne => {
+            if condition.column == "id" || condition.column == "$createdBy" {
+                return Ok(
+                    row_query_value(row, &condition.column).as_ref() != Some(&condition.value)
+                );
+            }
+            Ok(row
+                .values
+                .get(&condition.column)
+                .is_some_and(|value| value != &condition.value))
+        }
+        QueryConditionOp::In => {
+            let Some(values) = condition.value.as_array() else {
+                return Err(Error::new("in condition expects an array value"));
+            };
+            Ok(row_query_value(row, &condition.column)
+                .as_ref()
+                .is_some_and(|value| values.contains(value)))
+        }
+        QueryConditionOp::Contains => {
+            let Some(needle) = condition.value.as_str() else {
+                return Err(Error::new("contains condition expects a string value"));
+            };
+            Ok(row_query_value(row, &condition.column)
+                .and_then(|value| value.as_str().map(str::to_owned))
+                .is_some_and(|value| value.contains(needle)))
+        }
+    }
+}
+
+fn row_query_value(row: &RowView, column: &str) -> Option<JsonValue> {
+    match column {
+        "id" => Some(JsonValue::String(row.id.clone())),
+        "$createdBy" => Some(JsonValue::String(row.created_by.clone())),
+        column => row.values.get(column).cloned(),
+    }
+}
+
+fn apply_ordering(rows: &mut [RowView], order_by: &[QueryOrderBy]) -> Result<()> {
+    if order_by.is_empty() {
+        return Ok(());
+    }
+    if order_by.iter().any(|order| order.column == "$createdAt") {
+        return Err(Error::new(
+            "$createdAt orderBy requires one eq condition, desc direction, limit, and no offset",
+        ));
+    }
+    rows.sort_by(|left, right| {
+        for order in order_by {
+            let ordering = compare_json_values(
+                row_query_value(left, &order.column).as_ref(),
+                row_query_value(right, &order.column).as_ref(),
+            );
+            let ordering = match order.direction {
+                QueryDirection::Asc => ordering,
+                QueryDirection::Desc => ordering.reverse(),
+            };
+            if ordering != Ordering::Equal {
+                return ordering;
+            }
+        }
+        left.id.cmp(&right.id)
+    });
+    Ok(())
+}
+
+fn compare_json_values(left: Option<&JsonValue>, right: Option<&JsonValue>) -> Ordering {
+    let left_rank = json_value_rank(left);
+    let right_rank = json_value_rank(right);
+    left_rank
+        .cmp(&right_rank)
+        .then_with(|| match (left, right) {
+            (Some(JsonValue::Bool(left)), Some(JsonValue::Bool(right))) => left.cmp(right),
+            (Some(JsonValue::Number(left)), Some(JsonValue::Number(right))) => left
+                .as_f64()
+                .partial_cmp(&right.as_f64())
+                .unwrap_or(Ordering::Equal),
+            (Some(JsonValue::String(left)), Some(JsonValue::String(right))) => left.cmp(right),
+            (Some(left), Some(right)) => left.to_string().cmp(&right.to_string()),
+            _ => Ordering::Equal,
+        })
+}
+
+fn json_value_rank(value: Option<&JsonValue>) -> u8 {
+    match value {
+        None | Some(JsonValue::Null) => 0,
+        Some(JsonValue::Bool(_)) => 1,
+        Some(JsonValue::Number(_)) => 2,
+        Some(JsonValue::String(_)) => 3,
+        Some(JsonValue::Array(_)) => 4,
+        Some(JsonValue::Object(_)) => 5,
+    }
+}
+
+fn apply_window(rows: Vec<RowView>, offset: Option<usize>, limit: Option<usize>) -> Vec<RowView> {
+    let offset = offset.unwrap_or(0);
+    match limit {
+        Some(limit) => rows.into_iter().skip(offset).take(limit).collect(),
+        None => rows.into_iter().skip(offset).collect(),
+    }
+}

--- a/crates/mini-jazz-sqlite/src/query_api.rs
+++ b/crates/mini-jazz-sqlite/src/query_api.rs
@@ -71,22 +71,6 @@ impl BuiltQuery {
         })
     }
 
-    pub(crate) fn ordered_page(&self) -> Option<(&QueryCondition, usize)> {
-        if self.offset.unwrap_or(0) != 0 || self.conditions.len() != 1 || self.order_by.len() != 1 {
-            return None;
-        }
-        let condition = self.conditions.first()?;
-        if condition.op != QueryConditionOp::Eq {
-            return None;
-        }
-        let order = self.order_by.first()?;
-        if order.column == "$createdAt" && order.direction == QueryDirection::Desc {
-            self.limit.map(|limit| (condition, limit))
-        } else {
-            None
-        }
-    }
-
     pub(crate) fn single_predicate_export_condition(&self) -> Result<Option<&QueryCondition>> {
         if self.conditions.len() != 1
             || !self.order_by.is_empty()

--- a/crates/mini-jazz-sqlite/src/query_api.rs
+++ b/crates/mini-jazz-sqlite/src/query_api.rs
@@ -1,5 +1,6 @@
 use crate::runtime::Runtime;
 use crate::subscription::{RowsSubscription, RowsSubscriptionQuery};
+use crate::sync::Bundle;
 use crate::types::{RowView, SubscriptionDelta};
 use crate::{Error, Result};
 use serde_json::{Map as JsonMap, Value as JsonValue};
@@ -85,6 +86,56 @@ impl BuiltQuery {
             None
         }
     }
+
+    fn export_scope(&self) -> Result<QueryExportScope> {
+        if let Some((condition, limit)) = self.top_created_at_desc_fast_path() {
+            return Ok(QueryExportScope {
+                table: self.table.clone(),
+                field: condition.column.clone(),
+                op: "eq_top_created_at_desc",
+                value: serde_json::json!({
+                    "eq": condition.value.clone(),
+                    "limit": limit,
+                }),
+            });
+        }
+
+        if self.conditions.len() != 1
+            || !self.order_by.is_empty()
+            || self.limit.is_some()
+            || self.offset.unwrap_or(0) != 0
+        {
+            return Err(Error::new(
+                "export_query supports one predicate, or one eq predicate ordered by $createdAt desc with a limit",
+            ));
+        }
+
+        let condition = &self.conditions[0];
+        Ok(QueryExportScope {
+            table: self.table.clone(),
+            field: condition.column.clone(),
+            op: condition.op.query_read_op(),
+            value: condition.value.clone(),
+        })
+    }
+}
+
+impl QueryConditionOp {
+    fn query_read_op(&self) -> &'static str {
+        match self {
+            QueryConditionOp::Eq => "eq",
+            QueryConditionOp::Ne => "ne",
+            QueryConditionOp::In => "in",
+            QueryConditionOp::Contains => "contains",
+        }
+    }
+}
+
+struct QueryExportScope {
+    table: String,
+    field: String,
+    op: &'static str,
+    value: JsonValue,
 }
 
 impl Runtime {
@@ -109,6 +160,27 @@ impl Runtime {
 
     pub fn subscribe_query(&self, query: BuiltQuery) -> Result<RowsSubscription> {
         Ok(RowsSubscription::query(query.clone(), self.query(query)?))
+    }
+
+    pub fn export_query(&self, query: BuiltQuery) -> Result<Bundle> {
+        self.export_query_with_ref_includes(query, &[])
+    }
+
+    pub fn export_query_with_ref_includes(
+        &self,
+        query: BuiltQuery,
+        ref_include_fields: &[&str],
+    ) -> Result<Bundle> {
+        let scope = query.export_scope()?;
+        let rows = self.query(query)?;
+        self.export_query_scope(
+            &scope.table,
+            &scope.field,
+            scope.op,
+            scope.value,
+            rows,
+            ref_include_fields,
+        )
     }
 
     pub fn subscription_delta(

--- a/crates/mini-jazz-sqlite/src/read_set.rs
+++ b/crates/mini-jazz-sqlite/src/read_set.rs
@@ -64,7 +64,7 @@ pub(crate) fn record_tx_read_num_with_observed(
     reason: i64,
     observed_tx_num: Option<i64>,
 ) -> Result<()> {
-    let mut stmt = conn.prepare_cached(
+    let mut stmt = conn.prepare(
         "INSERT OR REPLACE INTO jazz_tx_read
          (tx_num, table_num, row_num, reason, observed_tx_num)
          VALUES (?, ?, ?, ?, ?)",

--- a/crates/mini-jazz-sqlite/src/read_visibility.rs
+++ b/crates/mini-jazz-sqlite/src/read_visibility.rs
@@ -1,0 +1,259 @@
+use crate::schema::{FieldKind, PolicyDef, SchemaDef, TableDef};
+use crate::{policy, tx, Result};
+use rusqlite::{params_from_iter, types::Value as SqlValue, Connection};
+
+const MAX_EFFECTIVE_POLICY_RECURSION_DEPTH: usize = 64;
+
+pub(crate) struct ReadVisibility<'a> {
+    pub(crate) conn: &'a Connection,
+    pub(crate) schema: &'a SchemaDef,
+    pub(crate) branch_num: i64,
+    pub(crate) user: &'a str,
+    pub(crate) bypass_policy: bool,
+}
+
+impl ReadVisibility<'_> {
+    pub(crate) fn current_policy_sql(&self, table: &TableDef, alias: &str) -> Result<String> {
+        if self.bypass_policy {
+            Ok("1 = 1".to_owned())
+        } else {
+            policy::branch_read_policy_sql_for_alias(
+                self.schema,
+                table,
+                alias,
+                self.user,
+                self.branch_num,
+            )
+        }
+    }
+
+    pub(crate) fn snapshot_policy_sql(
+        &self,
+        table: &TableDef,
+        alias: &str,
+        base_epoch: i64,
+    ) -> Result<String> {
+        if self.bypass_policy {
+            Ok("1 = 1".to_owned())
+        } else {
+            policy::snapshot_read_policy_sql_for_alias(
+                self.schema,
+                table,
+                alias,
+                self.user,
+                base_epoch,
+            )
+        }
+    }
+
+    pub(crate) fn base_snapshot_row_nums_visible_in_branch(
+        &self,
+        table_name: &str,
+        base_epoch: i64,
+        row_nums: Option<&[i64]>,
+    ) -> Result<Vec<i64>> {
+        if matches!(row_nums, Some([])) {
+            return Ok(Vec::new());
+        }
+        let table = self.schema.table_def(table_name)?;
+        let snapshot_policy_sql = self.snapshot_policy_sql(table, "h", base_epoch)?;
+        let effective_branch_policy_sql =
+            self.base_snapshot_effective_policy_sql(table, "h", base_epoch)?;
+        let row_filter = row_filter_sql("h", row_nums);
+        let sql = format!(
+            "SELECT h.row_num
+             FROM {} h
+             JOIN jazz_tx tx ON tx.tx_num = h.tx_num
+             WHERE {row_filter}
+               AND h.j_branch_num = 1
+               AND tx.outcome != ?
+               AND tx.global_epoch IS NOT NULL
+               AND tx.global_epoch <= ?
+               AND h.op != 3
+               AND {snapshot_policy_sql}
+               AND {effective_branch_policy_sql}
+               AND NOT EXISTS (
+                 SELECT 1
+                 FROM {history_table} newer
+                 JOIN jazz_tx newer_tx ON newer_tx.tx_num = newer.tx_num
+                 WHERE newer.row_num = h.row_num
+                   AND newer.j_branch_num = 1
+                   AND newer_tx.outcome != ?
+                   AND newer_tx.global_epoch IS NOT NULL
+                   AND newer_tx.global_epoch <= ?
+                   AND (newer_tx.global_epoch > tx.global_epoch OR (newer_tx.global_epoch = tx.global_epoch AND newer_tx.tx_num > tx.tx_num))
+               )
+               AND NOT EXISTS (
+                 SELECT 1
+                 FROM {current_table} branch_current
+                 WHERE branch_current.row_num = h.row_num
+                   AND branch_current.j_branch_num = ?
+               )
+             ORDER BY h.row_num",
+            crate::schema::history_table(table_name),
+            history_table = crate::schema::history_table(table_name),
+            current_table = crate::schema::current_table(table_name),
+        );
+        let mut params = row_nums
+            .unwrap_or(&[])
+            .iter()
+            .copied()
+            .map(SqlValue::Integer)
+            .collect::<Vec<_>>();
+        params.extend([
+            SqlValue::Integer(tx::OUTCOME_REJECTED),
+            SqlValue::Integer(base_epoch),
+            SqlValue::Integer(tx::OUTCOME_REJECTED),
+            SqlValue::Integer(base_epoch),
+            SqlValue::Integer(self.branch_num),
+        ]);
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt.query_map(params_from_iter(params.iter()), |row| row.get::<_, i64>(0))?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(Into::into)
+    }
+
+    fn base_snapshot_effective_policy_sql(
+        &self,
+        table: &TableDef,
+        alias: &str,
+        base_epoch: i64,
+    ) -> Result<String> {
+        if self.bypass_policy {
+            Ok("1 = 1".to_owned())
+        } else {
+            self.lower_effective_branch_policy(table, alias, &table.read_policy, base_epoch, 0)
+        }
+    }
+
+    fn lower_effective_branch_policy(
+        &self,
+        table: &TableDef,
+        alias: &str,
+        policy: &PolicyDef,
+        base_epoch: i64,
+        depth: usize,
+    ) -> Result<String> {
+        if depth > MAX_EFFECTIVE_POLICY_RECURSION_DEPTH {
+            return Err(crate::Error::new(
+                "effective branch policy recursion depth exceeded",
+            ));
+        }
+        match policy {
+            PolicyDef::AllowAll => Ok("1 = 1".to_owned()),
+            PolicyDef::CreatedByUser => Ok(format!(
+                "{alias}.j_created_by = (SELECT user_num FROM jazz_user WHERE user_id = '{}')",
+                self.user.replace('\'', "''")
+            )),
+            PolicyDef::RefReadable { field } => {
+                let field = table
+                    .fields
+                    .iter()
+                    .find(|candidate| candidate.name == *field)
+                    .ok_or_else(|| crate::Error::new(format!("unknown policy ref {field}")))?;
+                let FieldKind::Ref {
+                    table: ref_table_name,
+                } = &field.kind
+                else {
+                    return Err(crate::Error::new(format!(
+                        "policy field {} is not a ref",
+                        field.name
+                    )));
+                };
+                let ref_table = self.schema.table_def(ref_table_name)?;
+                let ref_column = crate::schema::quote_ident(&crate::schema::storage_column(field));
+                let current_alias = format!("effective_policy_current_{depth}");
+                let current_tx_alias = format!("effective_policy_current_tx_{depth}");
+                let snapshot_alias = format!("effective_policy_snapshot_{depth}");
+                let snapshot_tx_alias = format!("effective_policy_snapshot_tx_{depth}");
+                let newer_alias = format!("effective_policy_newer_{depth}");
+                let newer_tx_alias = format!("effective_policy_newer_tx_{depth}");
+                let current_policy = self.lower_effective_branch_policy(
+                    ref_table,
+                    &current_alias,
+                    &ref_table.read_policy,
+                    base_epoch,
+                    depth + 1,
+                )?;
+                let snapshot_policy = self.lower_effective_branch_policy(
+                    ref_table,
+                    &snapshot_alias,
+                    &ref_table.read_policy,
+                    base_epoch,
+                    depth + 1,
+                )?;
+                Ok(format!(
+                    "(
+                       EXISTS (
+                         SELECT 1
+                         FROM {} {current_alias}
+                         JOIN jazz_tx {current_tx_alias}
+                           ON {current_tx_alias}.tx_num = {current_alias}.visible_tx_num
+                         WHERE {current_alias}.row_num = {alias}.{ref_column}
+                           AND {current_alias}.j_branch_num = {}
+                           AND {current_alias}.is_deleted = 0
+                           AND {current_tx_alias}.outcome != {}
+                           AND {current_policy}
+                       )
+                       OR (
+                         NOT EXISTS (
+                           SELECT 1
+                           FROM {} shadow
+                           WHERE shadow.row_num = {alias}.{ref_column}
+                             AND shadow.j_branch_num = {}
+                         )
+                         AND EXISTS (
+                           SELECT 1
+                           FROM {} {snapshot_alias}
+                           JOIN jazz_tx {snapshot_tx_alias}
+                             ON {snapshot_tx_alias}.tx_num = {snapshot_alias}.tx_num
+                           WHERE {snapshot_alias}.row_num = {alias}.{ref_column}
+                             AND {snapshot_alias}.j_branch_num = 1
+                             AND {snapshot_alias}.op != 3
+                             AND {snapshot_tx_alias}.outcome != {}
+                             AND {snapshot_tx_alias}.global_epoch IS NOT NULL
+                             AND {snapshot_tx_alias}.global_epoch <= {base_epoch}
+                             AND NOT EXISTS (
+                               SELECT 1
+                               FROM {} {newer_alias}
+                               JOIN jazz_tx {newer_tx_alias}
+                                 ON {newer_tx_alias}.tx_num = {newer_alias}.tx_num
+                               WHERE {newer_alias}.row_num = {snapshot_alias}.row_num
+                                 AND {newer_alias}.j_branch_num = 1
+                                 AND {newer_tx_alias}.outcome != {}
+                                 AND {newer_tx_alias}.global_epoch IS NOT NULL
+                                 AND {newer_tx_alias}.global_epoch <= {base_epoch}
+                                 AND ({newer_tx_alias}.global_epoch > {snapshot_tx_alias}.global_epoch OR ({newer_tx_alias}.global_epoch = {snapshot_tx_alias}.global_epoch AND {newer_tx_alias}.tx_num > {snapshot_tx_alias}.tx_num))
+                             )
+                             AND {snapshot_policy}
+                         )
+                       )
+                     )",
+                    crate::schema::current_table(ref_table_name),
+                    self.branch_num,
+                    tx::OUTCOME_REJECTED,
+                    crate::schema::current_table(ref_table_name),
+                    self.branch_num,
+                    crate::schema::history_table(ref_table_name),
+                    tx::OUTCOME_REJECTED,
+                    crate::schema::history_table(ref_table_name),
+                    tx::OUTCOME_REJECTED,
+                ))
+            }
+        }
+    }
+}
+
+fn row_filter_sql(alias: &str, row_nums: Option<&[i64]>) -> String {
+    match row_nums {
+        Some([]) => "0 = 1".to_owned(),
+        Some(row_nums) => format!(
+            "{alias}.row_num IN ({})",
+            (0..row_nums.len())
+                .map(|_| "?")
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        None => "1 = 1".to_owned(),
+    }
+}

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -1,6 +1,4 @@
-use crate::query_api::{
-    predicate_query, BuiltQuery, QueryCondition, QueryConditionOp, QueryDirection,
-};
+use crate::query_api::{predicate_query, BuiltQuery, QueryCondition, QueryConditionOp};
 use crate::rows::{ensure_row_id, ensure_row_id_with_status, public_row_id, row_num};
 use crate::schema::{FieldDef, FieldKind, PolicyDef, SchemaDef};
 use crate::subscription::{RejectionSubscription, RowsSubscription, RowsSubscriptionQuery};
@@ -1555,9 +1553,9 @@ impl Runtime {
         //   jazz_query_read
         //   field="$query", op="query", value=<BuiltQuery JSON>
         //
-        // Repair keeps the old narrow fast paths for simple predicates and the
-        // original createdAt page shape, then falls back to a generic
-        // SQL-lowered pass for the wider built-query language:
+        // Repair keeps the old narrow fast path for simple predicates, then
+        // falls back to a generic SQL-lowered pass for the wider built-query
+        // language:
         //
         //   +-----------------------------+
         //   | BuiltQuery descriptor       |
@@ -1568,21 +1566,12 @@ impl Runtime {
         //   | QueryReadRecord predicate   | ---> | apply_query_scope_repair |
         //   +-----------------------------+      +--------------------------+
         //
-        //        | eq predicate + $createdAt DESC + limit
-        //        v
-        //   +-----------------------------+
-        //   | page-boundary repair        |
-        //   +-----------------------------+
-        //
         //        | every other SQL-lowered shape
         //        v
         //   +-----------------------------+
         //   | generic SQL-lowered repair  |
         //   +-----------------------------+
         match built_query_repair_scope(built_query)? {
-            BuiltQueryRepairScope::CreatedAtDescPage { condition, limit } => {
-                Self::apply_created_at_desc_page_repair(schema, db, query_read, condition, limit)
-            }
             BuiltQueryRepairScope::Predicate(condition) => {
                 let predicate_read = QueryReadRecord {
                     branch_id: query_read.branch_id.clone(),
@@ -1649,70 +1638,6 @@ impl Runtime {
             &scope_row_nums,
             &keep_row_nums,
         )
-    }
-
-    fn apply_created_at_desc_page_repair(
-        schema: &SchemaDef,
-        db: &Connection,
-        query_read: &QueryReadRecord,
-        condition: &QueryCondition,
-        limit: usize,
-    ) -> Result<()> {
-        // Ordered-page repair handles the sync case where a row is still in the
-        // predicate set but has fallen out of the materialized page.
-        //
-        // Example: top 2 open todos ordered by createdAt desc
-        //
-        //   before refresh: [C, B]        after refresh: [D, C]
-        //                         stale boundary row: B
-        //
-        // The DELETE below says:
-        //
-        //   delete local current rows that:
-        //     1. are in the observed branch
-        //     2. still match the page predicate
-        //     3. are not in SQLite's current top-N result for that predicate
-        //
-        // This is page-boundary contraction, not authorization. The refreshed
-        // top-N rows themselves arrive through normal history application.
-        let table = schema.table_def(&query_read.table)?;
-        let branch_num = branch::checkout(db, &query_read.branch_id)?;
-        let predicate = ordered_page_eq_predicate(table, condition, db)?;
-        let limit = i64::try_from(limit)
-            .map_err(|_| crate::Error::new("ordered query limit is too large"))?;
-        db.execute(
-            &format!(
-                "DELETE FROM {}
-                 WHERE j_branch_num = ?
-                   AND is_deleted = 0
-                   AND {predicate_sql}
-                   AND row_num NOT IN (
-                     SELECT current.row_num
-                     FROM {current_table} current
-                     JOIN jazz_row_id current_ids ON current_ids.row_num = current.row_num
-                     JOIN jazz_tx tx ON tx.tx_num = current.visible_tx_num
-                     WHERE current.j_branch_num = ?
-                       AND current.is_deleted = 0
-                       AND tx.outcome != ?
-                       AND {current_predicate_sql}
-                     ORDER BY current.j_created_at DESC, current.row_num
-                     LIMIT ?
-                   )",
-                crate::schema::current_table(&query_read.table),
-                current_table = crate::schema::current_table(&query_read.table),
-                predicate_sql = &predicate.outer_sql,
-                current_predicate_sql = &predicate.inner_sql,
-            ),
-            params![
-                branch_num,
-                predicate.value.clone(),
-                branch_num,
-                tx::OUTCOME_REJECTED,
-                predicate.value,
-                limit,
-            ],
-        )?;
-        Ok(())
     }
 
     fn apply_history_record(
@@ -2841,12 +2766,13 @@ impl Runtime {
         rejected_tx_ids.sort();
         rejected_tx_ids.dedup();
 
-        let mut history = export_history_versions_for_rows(
+        let mut history = export_history_versions_for_rows_in_branches(
             &self.conn,
             &self.schema,
             table_name,
             Some(&visible_row_nums),
             None,
+            &branch_nums,
         )?;
         if !repair_row_nums.is_empty() {
             history.extend(export_visible_table_history(
@@ -2858,12 +2784,13 @@ impl Runtime {
                 &branch_nums,
                 Some(&repair_row_nums),
             )?);
-            history.extend(export_history_versions_for_rows(
+            history.extend(export_history_versions_for_rows_in_branches(
                 &self.conn,
                 &self.schema,
                 table_name,
                 Some(&repair_row_nums),
                 None,
+                &branch_nums,
             )?);
         }
         history.extend(export_policy_dependency_history(
@@ -2970,6 +2897,9 @@ impl Runtime {
             &self.schema,
             table,
             &query_read,
+            self.branch_num,
+            user,
+            bypass_policy,
         )?);
         let visible_row_num_set = visible_row_nums.iter().copied().collect::<BTreeSet<_>>();
         repair_row_nums.retain(|row_num| !visible_row_num_set.contains(row_num));
@@ -2980,12 +2910,13 @@ impl Runtime {
         row_nums.sort();
         row_nums.dedup();
         let branch_nums = branch::scope_nums(&self.conn, self.branch_num)?;
-        let mut history = export_history_versions_for_rows(
+        let mut history = export_history_versions_for_rows_in_branches(
             &self.conn,
             &self.schema,
             table_name,
             Some(&visible_row_nums),
             None,
+            &branch_nums,
         )?;
         if !repair_row_nums.is_empty() {
             history.extend(export_visible_table_history(
@@ -2997,12 +2928,13 @@ impl Runtime {
                 &branch_nums,
                 Some(&repair_row_nums),
             )?);
-            history.extend(export_history_versions_for_rows(
+            history.extend(export_history_versions_for_rows_in_branches(
                 &self.conn,
                 &self.schema,
                 table_name,
                 Some(&repair_row_nums),
                 None,
+                &branch_nums,
             )?);
         }
         history.extend(export_policy_dependency_history(
@@ -3027,12 +2959,13 @@ impl Runtime {
         }
         if self.branch_num != 1 {
             if let Some(base_epoch) = branch::base_global_epoch(&self.conn, self.branch_num)? {
-                history.extend(export_history_versions_for_rows(
+                history.extend(export_history_versions_for_rows_in_branches(
                     &self.conn,
                     &self.schema,
                     table_name,
                     Some(&row_nums),
                     Some(base_epoch),
+                    &[1],
                 )?);
                 history.extend(export_snapshot_policy_dependency_history(
                     &self.conn,
@@ -3047,8 +2980,15 @@ impl Runtime {
         }
         dedupe_history_records(&mut history);
         let reads = export_reads_for_history(&self.conn, &history)?;
-        let rejected_tx_ids =
-            query_scope_rejected_tx_ids_for_read(&self.conn, &self.schema, table, &query_read)?;
+        let rejected_tx_ids = query_scope_rejected_tx_ids_for_read(
+            &self.conn,
+            &self.schema,
+            table,
+            &query_read,
+            self.branch_num,
+            user,
+            bypass_policy,
+        )?;
         let txs =
             export_txs_for_query_scope(&self.conn, table_name, &history, &reads, &rejected_tx_ids)?;
         let mut branches = export_branch_records_for_history(&self.conn, &history)?;
@@ -3155,12 +3095,13 @@ impl Runtime {
         let branch_nums = branch::scope_nums(&self.conn, self.branch_num)?;
 
         let visible_history_started = Instant::now();
-        let mut history = export_history_versions_for_rows(
+        let mut history = export_history_versions_for_rows_in_branches(
             &self.conn,
             &self.schema,
             table_name,
             Some(&visible_row_nums),
             None,
+            &branch_nums,
         )?;
         let visible_history_ms = duration_ms(visible_history_started.elapsed());
 
@@ -3180,12 +3121,13 @@ impl Runtime {
 
         let repair_all_started = Instant::now();
         if !repair_row_nums.is_empty() {
-            history.extend(export_history_versions_for_rows(
+            history.extend(export_history_versions_for_rows_in_branches(
                 &self.conn,
                 &self.schema,
                 table_name,
                 Some(&repair_row_nums),
                 None,
+                &branch_nums,
             )?);
         }
         let repair_all_history_ms = duration_ms(repair_all_started.elapsed());
@@ -3208,12 +3150,13 @@ impl Runtime {
         let snapshot_started = Instant::now();
         if self.branch_num != 1 {
             if let Some(base_epoch) = branch::base_global_epoch(&self.conn, self.branch_num)? {
-                history.extend(export_history_versions_for_rows(
+                history.extend(export_history_versions_for_rows_in_branches(
                     &self.conn,
                     &self.schema,
                     table_name,
                     Some(&row_nums),
                     Some(base_epoch),
+                    &[1],
                 )?);
                 history.extend(export_snapshot_policy_dependency_history(
                     &self.conn,
@@ -3352,12 +3295,13 @@ impl Runtime {
             branch_nums,
             Some(&ref_row_nums),
         )?;
-        history.extend(export_history_versions_for_rows(
+        history.extend(export_history_versions_for_rows_in_branches(
             &self.conn,
             &self.schema,
             ref_table_name,
             Some(&ref_row_nums),
             None,
+            branch_nums,
         )?);
         history.extend(export_policy_dependency_history(
             &self.conn,
@@ -6010,56 +5954,6 @@ fn export_recursive_scope_repair_history(
     export_history_versions_for_rows(conn, schema, table_name, Some(&row_nums), None)
 }
 
-struct OrderedPageEqPredicate {
-    outer_sql: String,
-    inner_sql: String,
-    value: rusqlite::types::Value,
-}
-
-fn ordered_page_eq_predicate(
-    table: &crate::schema::TableDef,
-    condition: &QueryCondition,
-    db: &Connection,
-) -> Result<OrderedPageEqPredicate> {
-    if condition.column == "id" {
-        let row_id = condition
-            .value
-            .as_str()
-            .ok_or_else(|| crate::Error::new("id equality expects a string value"))?;
-        return Ok(OrderedPageEqPredicate {
-            outer_sql: "row_num IN (SELECT ids.row_num FROM jazz_row_id ids WHERE ids.row_id = ?)"
-                .to_owned(),
-            inner_sql: "current_ids.row_id = ?".to_owned(),
-            value: rusqlite::types::Value::Text(row_id.to_owned()),
-        });
-    }
-
-    if condition.column == "$createdBy" {
-        let created_by = condition
-            .value
-            .as_str()
-            .ok_or_else(|| crate::Error::new("$createdBy equality expects a string value"))?;
-        let created_by_num = users::user_num(db, created_by).unwrap_or(-1);
-        return Ok(OrderedPageEqPredicate {
-            outer_sql: "j_created_by = ?".to_owned(),
-            inner_sql: "current.j_created_by = ?".to_owned(),
-            value: rusqlite::types::Value::Integer(created_by_num),
-        });
-    }
-
-    let field = table
-        .fields
-        .iter()
-        .find(|candidate| candidate.name == condition.column)
-        .ok_or_else(|| crate::Error::new(format!("unknown query field {}", condition.column)))?;
-    let predicate_column = crate::schema::quote_ident(&crate::schema::storage_column(field));
-    Ok(OrderedPageEqPredicate {
-        outer_sql: query_predicate::sql(field, &predicate_column, "eq")?,
-        inner_sql: query_predicate::sql(field, &format!("current.{predicate_column}"), "eq")?,
-        value: query_predicate::value(field, "eq", &condition.value, db)?,
-    })
-}
-
 fn query_scope_repair_row_nums(
     conn: &Connection,
     table: &crate::schema::TableDef,
@@ -6348,13 +6242,24 @@ fn query_scope_repair_row_nums_for_read(
     schema: &SchemaDef,
     table: &crate::schema::TableDef,
     query_read: &QueryReadRecord,
+    branch_num: i64,
+    user: &str,
+    bypass_policy: bool,
 ) -> Result<Vec<i64>> {
     // Dispatch from the serialized query-read shape used in bundles to the row
     // collection shape used by export. Built queries are stored opaquely, so
     // they need a small adapter before repair candidates can be collected.
     if query_read.op == "query" {
         let query = built_query_from_read(query_read)?;
-        return query_scope_repair_row_nums_for_built_query(conn, schema, table, &query);
+        return query_scope_repair_row_nums_for_built_query(
+            conn,
+            schema,
+            table,
+            &query,
+            branch_num,
+            user,
+            bypass_policy,
+        );
     }
     query_scope_repair_row_nums(
         conn,
@@ -6370,6 +6275,9 @@ fn query_scope_repair_row_nums_for_built_query(
     schema: &SchemaDef,
     table: &crate::schema::TableDef,
     built_query: &BuiltQuery,
+    branch_num: i64,
+    user: &str,
+    bypass_policy: bool,
 ) -> Result<Vec<i64>> {
     // Built-query repair row collection mirrors `apply_built_query_scope_repair`:
     //
@@ -6389,30 +6297,14 @@ fn query_scope_repair_row_nums_for_built_query(
             "query read table does not match descriptor",
         ));
     }
-    let condition = match built_query_repair_scope(built_query)? {
-        BuiltQueryRepairScope::CreatedAtDescPage {
-            condition,
-            limit: _,
-        }
-        | BuiltQueryRepairScope::Predicate(condition) => condition,
-        BuiltQueryRepairScope::Generic => {
-            let context = query::QueryContext {
-                conn,
-                schema,
-                branch_num: 1,
-                user: ADMIN_SYSTEM_USER,
-                bypass_policy: true,
-            };
-            return context.repair_row_nums_for_built_query(built_query);
-        }
-    };
-    query_scope_repair_row_nums(
+    let context = query::QueryContext {
         conn,
-        table,
-        &condition.column,
-        condition.op.as_str(),
-        &condition.value,
-    )
+        schema,
+        branch_num,
+        user,
+        bypass_policy,
+    };
+    context.repair_row_nums_for_built_query(built_query)
 }
 
 fn query_scope_rejected_tx_ids_for_read(
@@ -6420,10 +6312,21 @@ fn query_scope_rejected_tx_ids_for_read(
     schema: &SchemaDef,
     table: &crate::schema::TableDef,
     query_read: &QueryReadRecord,
+    branch_num: i64,
+    user: &str,
+    bypass_policy: bool,
 ) -> Result<Vec<String>> {
     if query_read.op == "query" {
         let query = built_query_from_read(query_read)?;
-        return query_scope_rejected_tx_ids_for_built_query(conn, schema, table, &query);
+        return query_scope_rejected_tx_ids_for_built_query(
+            conn,
+            schema,
+            table,
+            &query,
+            branch_num,
+            user,
+            bypass_policy,
+        );
     }
     query_scope_rejected_tx_ids(
         conn,
@@ -6439,45 +6342,28 @@ fn query_scope_rejected_tx_ids_for_built_query(
     schema: &SchemaDef,
     table: &crate::schema::TableDef,
     built_query: &BuiltQuery,
+    branch_num: i64,
+    user: &str,
+    bypass_policy: bool,
 ) -> Result<Vec<String>> {
     if built_query.table != table.name {
         return Err(crate::Error::new(
             "query read table does not match descriptor",
         ));
     }
-    let condition = match built_query_repair_scope(built_query)? {
-        BuiltQueryRepairScope::CreatedAtDescPage {
-            condition,
-            limit: _,
-        }
-        | BuiltQueryRepairScope::Predicate(condition) => condition,
-        BuiltQueryRepairScope::Generic => {
-            let context = query::QueryContext {
-                conn,
-                schema,
-                branch_num: 1,
-                user: ADMIN_SYSTEM_USER,
-                bypass_policy: true,
-            };
-            let row_nums = context.repair_row_nums_for_built_query(built_query)?;
-            return rejected_tx_ids_for_row_nums(conn, &built_query.table, &row_nums);
-        }
-    };
-    query_scope_rejected_tx_ids(
+    let context = query::QueryContext {
         conn,
-        table,
-        &condition.column,
-        condition.op.as_str(),
-        &condition.value,
-    )
+        schema,
+        branch_num,
+        user,
+        bypass_policy,
+    };
+    let row_nums = context.repair_row_nums_for_built_query(built_query)?;
+    rejected_tx_ids_for_row_nums(conn, &built_query.table, &row_nums)
 }
 
 enum BuiltQueryRepairScope<'a> {
     Predicate(&'a QueryCondition),
-    CreatedAtDescPage {
-        condition: &'a QueryCondition,
-        limit: usize,
-    },
     Generic,
 }
 
@@ -6487,14 +6373,6 @@ fn built_query_repair_scope(query: &BuiltQuery) -> Result<BuiltQueryRepairScope<
         match (query.order_by.as_slice(), query.limit) {
             ([], None) if legacy_predicate_repair_supports(condition) => {
                 return Ok(BuiltQueryRepairScope::Predicate(condition));
-            }
-            ([order], Some(limit))
-                if condition.op == QueryConditionOp::Eq
-                    && legacy_predicate_repair_supports(condition)
-                    && order.column == "$createdAt"
-                    && order.direction == QueryDirection::Desc =>
-            {
-                return Ok(BuiltQueryRepairScope::CreatedAtDescPage { condition, limit });
             }
             _ => {}
         }
@@ -6746,6 +6624,42 @@ fn export_history_versions_for_rows(
     row_nums: Option<&[i64]>,
     max_global_epoch: Option<i64>,
 ) -> Result<Vec<HistoryRecord>> {
+    export_history_versions_for_rows_with_branch_filter(
+        conn,
+        schema,
+        table_name,
+        row_nums,
+        max_global_epoch,
+        None,
+    )
+}
+
+fn export_history_versions_for_rows_in_branches(
+    conn: &Connection,
+    schema: &SchemaDef,
+    table_name: &str,
+    row_nums: Option<&[i64]>,
+    max_global_epoch: Option<i64>,
+    branch_nums: &[i64],
+) -> Result<Vec<HistoryRecord>> {
+    export_history_versions_for_rows_with_branch_filter(
+        conn,
+        schema,
+        table_name,
+        row_nums,
+        max_global_epoch,
+        Some(branch_nums),
+    )
+}
+
+fn export_history_versions_for_rows_with_branch_filter(
+    conn: &Connection,
+    schema: &SchemaDef,
+    table_name: &str,
+    row_nums: Option<&[i64]>,
+    max_global_epoch: Option<i64>,
+    branch_nums: Option<&[i64]>,
+) -> Result<Vec<HistoryRecord>> {
     let table = schema.table_def(table_name)?;
     let field_columns = table
         .fields
@@ -6778,11 +6692,13 @@ fn export_history_versions_for_rows(
          JOIN jazz_tx tx ON tx.tx_num = h.tx_num
          JOIN jazz_branch branch ON branch.branch_num = h.j_branch_num
          WHERE {row_filter}
+           AND {branch_filter}
            AND {epoch_filter}
          ORDER BY h.row_num, h.tx_num",
         select_columns.join(", "),
         crate::schema::history_table(table_name),
         row_filter = row_filter_sql(row_nums),
+        branch_filter = history_branch_filter_sql("h", branch_nums),
         epoch_filter = history_epoch_filter_sql(max_global_epoch),
     );
     let mut stmt = conn.prepare(&sql)?;
@@ -6842,6 +6758,21 @@ fn history_row_filter_sql(alias: &str, row_nums: Option<&[i64]>) -> String {
         Some(row_nums) => format!(
             "{alias}.row_num IN ({})",
             row_nums
+                .iter()
+                .map(i64::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        None => "1 = 1".to_owned(),
+    }
+}
+
+fn history_branch_filter_sql(alias: &str, branch_nums: Option<&[i64]>) -> String {
+    match branch_nums {
+        Some([]) => "0 = 1".to_owned(),
+        Some(branch_nums) => format!(
+            "{alias}.j_branch_num IN ({})",
+            branch_nums
                 .iter()
                 .map(i64::to_string)
                 .collect::<Vec<_>>()

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -312,16 +312,8 @@ impl Runtime {
         value: JsonValue,
         limit: usize,
     ) -> Result<Vec<RowView>> {
-        let mut rows = self.read_rows_where_eq(table_name, field_name, value)?;
-        let created_at_by_id = current_created_at_by_row_id(&self.conn, table_name)?;
-        rows.sort_by(|left, right| {
-            created_at_by_id
-                .get(&right.id)
-                .cmp(&created_at_by_id.get(&left.id))
-                .then_with(|| left.id.cmp(&right.id))
-        });
-        rows.truncate(limit);
-        Ok(rows)
+        self.query_context()
+            .read_rows_where_eq_top_created_at_desc(table_name, field_name, value, limit)
     }
 
     pub fn read_rows_where_eq_top_field_desc(
@@ -5476,23 +5468,6 @@ fn branch_id_for_num(conn: &Connection, branch_num: i64) -> Result<String> {
         |row| row.get(0),
     )
     .map_err(Into::into)
-}
-
-fn current_created_at_by_row_id(
-    conn: &Connection,
-    table_name: &str,
-) -> Result<BTreeMap<String, i64>> {
-    let mut stmt = conn.prepare(&format!(
-        "SELECT ids.row_id, current.j_created_at
-         FROM {} current
-         JOIN jazz_row_id ids ON ids.row_num = current.row_num",
-        crate::schema::current_table(table_name)
-    ))?;
-    let rows = stmt.query_map([], |row| {
-        Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
-    })?;
-    rows.collect::<std::result::Result<BTreeMap<_, _>, _>>()
-        .map_err(Into::into)
 }
 
 fn export_table_history(

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -1536,9 +1536,9 @@ impl Runtime {
         //   jazz_query_read
         //   field="$query", op="query", value=<BuiltQuery JSON>
         //
-        // Repair does not currently understand every SQL-lowered descriptor.
-        // It maps the supported sync-repair shapes back to the smaller repair
-        // primitives used below:
+        // Repair keeps the old narrow fast paths for simple predicates and the
+        // original createdAt page shape, then falls back to a generic
+        // SQL-lowered pass for the wider built-query language:
         //
         //   +-----------------------------+
         //   | BuiltQuery descriptor       |
@@ -1558,7 +1558,7 @@ impl Runtime {
         //        | every other SQL-lowered shape
         //        v
         //   +-----------------------------+
-        //   | no contraction repair yet   |
+        //   | generic SQL-lowered repair  |
         //   +-----------------------------+
         match built_query_repair_scope(built_query)? {
             BuiltQueryRepairScope::CreatedAtDescPage { condition, limit } => {
@@ -1574,8 +1574,55 @@ impl Runtime {
                 };
                 Self::apply_query_scope_repair(schema, db, &predicate_read)
             }
-            BuiltQueryRepairScope::Unsupported => Ok(()),
+            BuiltQueryRepairScope::Generic => {
+                Self::apply_generic_built_query_scope_repair(schema, db, query_read, built_query)
+            }
         }
+    }
+
+    fn apply_generic_built_query_scope_repair(
+        schema: &SchemaDef,
+        db: &Connection,
+        query_read: &QueryReadRecord,
+        built_query: &BuiltQuery,
+    ) -> Result<()> {
+        if built_query.limit.is_none() && built_query.offset.unwrap_or(0) == 0 {
+            return Ok(());
+        }
+
+        let branch_num = branch::checkout(db, &query_read.branch_id)?;
+        let context = query::QueryContext {
+            conn: db,
+            schema,
+            branch_num,
+            user: ADMIN_SYSTEM_USER,
+            bypass_policy: true,
+        };
+        let mut scope_query = built_query.clone();
+        scope_query.limit = None;
+        scope_query.offset = None;
+        let scope_row_nums = context
+            .read_rows_for_built_query(&scope_query)?
+            .iter()
+            .map(|row| row_num(db, &row.id))
+            .collect::<Result<Vec<_>>>()?;
+        if scope_row_nums.is_empty() {
+            return Ok(());
+        }
+
+        let keep_query = built_query_repair_keep_query(built_query)?;
+        let keep_row_nums = context
+            .read_rows_for_built_query(&keep_query)?
+            .iter()
+            .map(|row| row_num(db, &row.id))
+            .collect::<Result<Vec<_>>>()?;
+        delete_current_rows_outside_keep_set(
+            db,
+            &built_query.table,
+            branch_num,
+            &scope_row_nums,
+            &keep_row_nums,
+        )
     }
 
     fn apply_created_at_desc_page_repair(
@@ -2894,6 +2941,7 @@ impl Runtime {
         }
         repair_row_nums.extend(query_scope_repair_row_nums_for_read(
             &self.conn,
+            &self.schema,
             table,
             &query_read,
         )?);
@@ -2973,7 +3021,8 @@ impl Runtime {
         }
         dedupe_history_records(&mut history);
         let reads = export_reads_for_history(&self.conn, &history)?;
-        let rejected_tx_ids = query_scope_rejected_tx_ids_for_read(&self.conn, table, &query_read)?;
+        let rejected_tx_ids =
+            query_scope_rejected_tx_ids_for_read(&self.conn, &self.schema, table, &query_read)?;
         let txs =
             export_txs_for_query_scope(&self.conn, table_name, &history, &reads, &rejected_tx_ids)?;
         let mut branches = export_branch_records_for_history(&self.conn, &history)?;
@@ -6269,6 +6318,7 @@ fn rejected_tx_ids_for_row_nums(
 
 fn query_scope_repair_row_nums_for_read(
     conn: &Connection,
+    schema: &SchemaDef,
     table: &crate::schema::TableDef,
     query_read: &QueryReadRecord,
 ) -> Result<Vec<i64>> {
@@ -6277,7 +6327,7 @@ fn query_scope_repair_row_nums_for_read(
     // they need a small adapter before repair candidates can be collected.
     if query_read.op == "query" {
         let query = built_query_from_read(query_read)?;
-        return query_scope_repair_row_nums_for_built_query(conn, table, &query);
+        return query_scope_repair_row_nums_for_built_query(conn, schema, table, &query);
     }
     query_scope_repair_row_nums(
         conn,
@@ -6290,6 +6340,7 @@ fn query_scope_repair_row_nums_for_read(
 
 fn query_scope_repair_row_nums_for_built_query(
     conn: &Connection,
+    schema: &SchemaDef,
     table: &crate::schema::TableDef,
     built_query: &BuiltQuery,
 ) -> Result<Vec<i64>> {
@@ -6301,11 +6352,11 @@ fn query_scope_repair_row_nums_for_built_query(
     //       |                                         v
     //       +-- eq + createdAt desc + limit --> predicate repair rows
     //       |
-    //       +-- other SQL-lowered shape ------> exported result/support rows only
+    //       +-- other SQL-lowered shape ------> SQL-lowered history scope
     //
-    // The ordered-page case exports rows that ever matched the predicate. The
-    // receiver then recomputes the actual page boundary locally and deletes any
-    // stale rows outside that boundary.
+    // Generic built-query repair asks SQLite for rows whose history matched the
+    // query conditions. Export then sends those row histories so peers learn
+    // about rows that left a multi-filter or custom-ordered query.
     if built_query.table != table.name {
         return Err(crate::Error::new(
             "query read table does not match descriptor",
@@ -6317,7 +6368,16 @@ fn query_scope_repair_row_nums_for_built_query(
             limit: _,
         }
         | BuiltQueryRepairScope::Predicate(condition) => condition,
-        BuiltQueryRepairScope::Unsupported => return Ok(Vec::new()),
+        BuiltQueryRepairScope::Generic => {
+            let context = query::QueryContext {
+                conn,
+                schema,
+                branch_num: 1,
+                user: ADMIN_SYSTEM_USER,
+                bypass_policy: true,
+            };
+            return context.repair_row_nums_for_built_query(built_query);
+        }
     };
     query_scope_repair_row_nums(
         conn,
@@ -6330,12 +6390,13 @@ fn query_scope_repair_row_nums_for_built_query(
 
 fn query_scope_rejected_tx_ids_for_read(
     conn: &Connection,
+    schema: &SchemaDef,
     table: &crate::schema::TableDef,
     query_read: &QueryReadRecord,
 ) -> Result<Vec<String>> {
     if query_read.op == "query" {
         let query = built_query_from_read(query_read)?;
-        return query_scope_rejected_tx_ids_for_built_query(conn, table, &query);
+        return query_scope_rejected_tx_ids_for_built_query(conn, schema, table, &query);
     }
     query_scope_rejected_tx_ids(
         conn,
@@ -6348,6 +6409,7 @@ fn query_scope_rejected_tx_ids_for_read(
 
 fn query_scope_rejected_tx_ids_for_built_query(
     conn: &Connection,
+    schema: &SchemaDef,
     table: &crate::schema::TableDef,
     built_query: &BuiltQuery,
 ) -> Result<Vec<String>> {
@@ -6362,6 +6424,17 @@ fn query_scope_rejected_tx_ids_for_built_query(
             limit: _,
         }
         | BuiltQueryRepairScope::Predicate(condition) => condition,
+        BuiltQueryRepairScope::Generic => {
+            let context = query::QueryContext {
+                conn,
+                schema,
+                branch_num: 1,
+                user: ADMIN_SYSTEM_USER,
+                bypass_policy: true,
+            };
+            let row_nums = context.repair_row_nums_for_built_query(built_query)?;
+            return rejected_tx_ids_for_row_nums(conn, &built_query.table, &row_nums);
+        }
     };
     query_scope_rejected_tx_ids(
         conn,
@@ -6378,29 +6451,102 @@ enum BuiltQueryRepairScope<'a> {
         condition: &'a QueryCondition,
         limit: usize,
     },
-    Unsupported,
+    Generic,
 }
 
 fn built_query_repair_scope(query: &BuiltQuery) -> Result<BuiltQueryRepairScope<'_>> {
-    if query.conditions.len() != 1 || query.offset.unwrap_or(0) != 0 {
-        return Ok(BuiltQueryRepairScope::Unsupported);
-    }
-
-    let Some(condition) = query.conditions.first() else {
-        return Ok(BuiltQueryRepairScope::Unsupported);
-    };
-
-    match (query.order_by.as_slice(), query.limit) {
-        ([], None) => Ok(BuiltQueryRepairScope::Predicate(condition)),
-        ([order], Some(limit))
-            if condition.op == QueryConditionOp::Eq
-                && order.column == "$createdAt"
-                && order.direction == QueryDirection::Desc =>
-        {
-            Ok(BuiltQueryRepairScope::CreatedAtDescPage { condition, limit })
+    if query.conditions.len() == 1 && query.offset.unwrap_or(0) == 0 {
+        let condition = &query.conditions[0];
+        match (query.order_by.as_slice(), query.limit) {
+            ([], None) => return Ok(BuiltQueryRepairScope::Predicate(condition)),
+            ([order], Some(limit))
+                if condition.op == QueryConditionOp::Eq
+                    && order.column == "$createdAt"
+                    && order.direction == QueryDirection::Desc =>
+            {
+                return Ok(BuiltQueryRepairScope::CreatedAtDescPage { condition, limit });
+            }
+            _ => {}
         }
-        _ => Ok(BuiltQueryRepairScope::Unsupported),
     }
+    Ok(BuiltQueryRepairScope::Generic)
+}
+
+fn built_query_repair_keep_query(query: &BuiltQuery) -> Result<BuiltQuery> {
+    let offset = query.offset.unwrap_or(0);
+    if offset == 0 {
+        return Ok(query.clone());
+    }
+
+    let mut keep_query = query.clone();
+    keep_query.offset = None;
+    keep_query.limit = query
+        .limit
+        .map(|limit| {
+            offset
+                .checked_add(limit)
+                .ok_or_else(|| crate::Error::new("query limit plus offset is too large"))
+        })
+        .transpose()?;
+    Ok(keep_query)
+}
+
+fn delete_current_rows_outside_keep_set(
+    db: &Connection,
+    table_name: &str,
+    branch_num: i64,
+    scope_row_nums: &[i64],
+    keep_row_nums: &[i64],
+) -> Result<()> {
+    if scope_row_nums.is_empty() {
+        return Ok(());
+    }
+
+    // Generic window repair is a contraction pass:
+    //
+    //   rows matching query filters, without LIMIT/OFFSET
+    //             |
+    //             v
+    //   +------------------+        +----------------------+
+    //   | scope row nums   |  minus | rows to keep locally |
+    //   +------------------+        +----------------------+
+    //             |
+    //             v
+    //   DELETE stale current rows from the observed branch
+    //
+    // For offset queries, "keep" is the exported support window
+    // [0, offset + limit). Those prefix rows must stay local so SQLite can
+    // still evaluate the original OFFSET query correctly after the refresh.
+    let mut sql = format!(
+        "DELETE FROM {}
+         WHERE j_branch_num = ?
+           AND is_deleted = 0
+           AND row_num IN ({})",
+        crate::schema::current_table(table_name),
+        sql_placeholders(scope_row_nums.len()),
+    );
+    let mut params = Vec::with_capacity(1 + scope_row_nums.len() + keep_row_nums.len());
+    params.push(rusqlite::types::Value::Integer(branch_num));
+    params.extend(
+        scope_row_nums
+            .iter()
+            .copied()
+            .map(rusqlite::types::Value::Integer),
+    );
+    if !keep_row_nums.is_empty() {
+        sql.push_str(&format!(
+            " AND row_num NOT IN ({})",
+            sql_placeholders(keep_row_nums.len())
+        ));
+        params.extend(
+            keep_row_nums
+                .iter()
+                .copied()
+                .map(rusqlite::types::Value::Integer),
+        );
+    }
+    db.execute(&sql, params_from_iter(params.iter()))?;
+    Ok(())
 }
 
 fn built_query_from_read(read: &QueryReadRecord) -> Result<BuiltQuery> {
@@ -6636,13 +6782,7 @@ fn history_epoch_filter_sql(max_global_epoch: Option<i64>) -> String {
 fn row_filter_sql(row_nums: Option<&[i64]>) -> String {
     match row_nums {
         Some([]) => "0 = 1".to_owned(),
-        Some(row_nums) => format!(
-            "h.row_num IN ({})",
-            (0..row_nums.len())
-                .map(|_| "?")
-                .collect::<Vec<_>>()
-                .join(", ")
-        ),
+        Some(row_nums) => format!("h.row_num IN ({})", sql_placeholders(row_nums.len())),
         None => "1 = 1".to_owned(),
     }
 }

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -305,7 +305,7 @@ impl Runtime {
         Ok(tx_id)
     }
 
-    pub fn read_rows_where_eq_top_created_at_desc(
+    pub(crate) fn read_rows_where_eq_top_created_at_desc(
         &self,
         table_name: &str,
         field_name: &str,
@@ -1526,38 +1526,6 @@ impl Runtime {
             )?;
             return Ok(());
         }
-        if query_read.table == "todos"
-            && query_read.field == "done"
-            && query_read.op == "top_created_at_desc"
-        {
-            let Some(limit) = query_read.value.as_u64() else {
-                return Err(crate::Error::new(
-                    "top_created_at_desc expects numeric limit",
-                ));
-            };
-            let branch_num = branch::checkout(db, &query_read.branch_id)?;
-            db.execute(
-                &format!(
-                    "DELETE FROM {}
-                     WHERE j_branch_num = ?
-                       AND row_num NOT IN (
-                         SELECT todo.row_num
-                         FROM {current_table} todo
-                         JOIN jazz_tx todo_tx ON todo_tx.tx_num = todo.visible_tx_num
-                         WHERE todo.j_branch_num = ?
-                           AND todo.is_deleted = 0
-                           AND todo.done = 0
-                           AND todo_tx.outcome != ?
-                         ORDER BY todo.j_created_at DESC, todo.row_num
-                         LIMIT ?
-                       )",
-                    crate::schema::current_table("todos"),
-                    current_table = crate::schema::current_table("todos"),
-                ),
-                params![branch_num, branch_num, tx::OUTCOME_REJECTED, limit as i64],
-            )?;
-            return Ok(());
-        }
         let table = schema.table_def(&query_read.table)?;
         let field = table
             .fields
@@ -2531,7 +2499,7 @@ impl Runtime {
         )
     }
 
-    pub fn export_query_where_eq_top_created_at_desc(
+    pub(crate) fn export_query_where_eq_top_created_at_desc(
         &self,
         table_name: &str,
         field_name: &str,
@@ -2574,37 +2542,6 @@ impl Runtime {
             QueryScopeOptions {
                 ref_include_fields: &[],
                 extra_row_ids: &previous_observed_ids,
-            },
-        )
-    }
-
-    pub fn export_query_where_eq_top_created_at_desc_with_ref_include(
-        &self,
-        table_name: &str,
-        field_name: &str,
-        value: JsonValue,
-        limit: usize,
-        ref_field_name: &str,
-    ) -> Result<Bundle> {
-        let rows = self.read_rows_where_eq_top_created_at_desc(
-            table_name,
-            field_name,
-            value.clone(),
-            limit,
-        )?;
-        self.export_query_scope(
-            table_name,
-            field_name,
-            "eq_top_created_at_desc",
-            json!({
-                "eq": value.clone(),
-                "limit": limit,
-                "observed_ids": observed_row_ids(&rows),
-            }),
-            rows,
-            QueryScopeOptions {
-                ref_include_fields: &[ref_field_name],
-                extra_row_ids: &[],
             },
         )
     }
@@ -3088,7 +3025,7 @@ impl Runtime {
         Ok((bundle, profile))
     }
 
-    fn export_query_scope(
+    pub(crate) fn export_query_scope(
         &self,
         table_name: &str,
         field_name: &str,
@@ -3353,7 +3290,7 @@ impl Runtime {
         ))
     }
 
-    pub fn subscribe_rows_where_eq_top_created_at_desc(
+    pub(crate) fn subscribe_rows_where_eq_top_created_at_desc(
         &self,
         table_name: &str,
         field_name: &str,

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -533,6 +533,8 @@ impl Runtime {
         }
         let validation_ms = duration_ms(validation_started.elapsed());
         let schema = self.schema.clone();
+        let repair_user = self.policy_user().to_owned();
+        let repair_bypass_policy = self.bypasses_policy();
         let begin_tx_started = Instant::now();
         let db = self.conn.transaction()?;
         let begin_tx_ms = duration_ms(begin_tx_started.elapsed());
@@ -721,7 +723,13 @@ impl Runtime {
 
         let query_scope_repair_started = Instant::now();
         for query_read in &bundle.query_reads {
-            Self::apply_query_scope_repair(&schema, &db, query_read)?;
+            Self::apply_query_scope_repair(
+                &schema,
+                &db,
+                query_read,
+                &repair_user,
+                repair_bypass_policy,
+            )?;
         }
         let query_scope_repair_ms = duration_ms(query_scope_repair_started.elapsed());
 
@@ -1208,6 +1216,8 @@ impl Runtime {
         schema: &SchemaDef,
         db: &Connection,
         query_read: &QueryReadRecord,
+        user: &str,
+        bypass_policy: bool,
     ) -> Result<()> {
         // Query-scope repair keeps a receiver's current projection from retaining
         // rows that used to satisfy an observed query but are no longer covered by
@@ -1276,7 +1286,14 @@ impl Runtime {
         }
         if query_read.op == "query" {
             let query = built_query_from_read(query_read)?;
-            return Self::apply_built_query_scope_repair(schema, db, query_read, &query);
+            return Self::apply_built_query_scope_repair(
+                schema,
+                db,
+                query_read,
+                &query,
+                user,
+                bypass_policy,
+            );
         }
         if query_read.op == "eq_top_field_desc" {
             let value = query_read
@@ -1361,7 +1378,7 @@ impl Runtime {
                     op: "eq".to_owned(),
                     value: value.clone(),
                 };
-                Self::apply_query_scope_repair(schema, db, &eq_read)?;
+                Self::apply_query_scope_repair(schema, db, &eq_read, user, bypass_policy)?;
             }
             return Ok(());
         }
@@ -1529,6 +1546,8 @@ impl Runtime {
         db: &Connection,
         query_read: &QueryReadRecord,
         built_query: &BuiltQuery,
+        user: &str,
+        bypass_policy: bool,
     ) -> Result<()> {
         // Built queries are recorded as one opaque query-read value so they can
         // be replayed exactly after reconnect:
@@ -1572,11 +1591,16 @@ impl Runtime {
                     op: condition.op.as_str().to_owned(),
                     value: condition.value.clone(),
                 };
-                Self::apply_query_scope_repair(schema, db, &predicate_read)
+                Self::apply_query_scope_repair(schema, db, &predicate_read, user, bypass_policy)
             }
-            BuiltQueryRepairScope::Generic => {
-                Self::apply_generic_built_query_scope_repair(schema, db, query_read, built_query)
-            }
+            BuiltQueryRepairScope::Generic => Self::apply_generic_built_query_scope_repair(
+                schema,
+                db,
+                query_read,
+                built_query,
+                user,
+                bypass_policy,
+            ),
         }
     }
 
@@ -1585,6 +1609,8 @@ impl Runtime {
         db: &Connection,
         query_read: &QueryReadRecord,
         built_query: &BuiltQuery,
+        user: &str,
+        bypass_policy: bool,
     ) -> Result<()> {
         if built_query.limit.is_none() && built_query.offset.unwrap_or(0) == 0 {
             return Ok(());
@@ -1595,8 +1621,8 @@ impl Runtime {
             conn: db,
             schema,
             branch_num,
-            user: ADMIN_SYSTEM_USER,
-            bypass_policy: true,
+            user,
+            bypass_policy,
         };
         let mut scope_query = built_query.clone();
         scope_query.limit = None;
@@ -6459,9 +6485,12 @@ fn built_query_repair_scope(query: &BuiltQuery) -> Result<BuiltQueryRepairScope<
     if query.conditions.len() == 1 && query.offset.unwrap_or(0) == 0 {
         let condition = &query.conditions[0];
         match (query.order_by.as_slice(), query.limit) {
-            ([], None) => return Ok(BuiltQueryRepairScope::Predicate(condition)),
+            ([], None) if legacy_predicate_repair_supports(condition) => {
+                return Ok(BuiltQueryRepairScope::Predicate(condition));
+            }
             ([order], Some(limit))
                 if condition.op == QueryConditionOp::Eq
+                    && legacy_predicate_repair_supports(condition)
                     && order.column == "$createdAt"
                     && order.direction == QueryDirection::Desc =>
             {
@@ -6471,6 +6500,25 @@ fn built_query_repair_scope(query: &BuiltQuery) -> Result<BuiltQueryRepairScope<
         }
     }
     Ok(BuiltQueryRepairScope::Generic)
+}
+
+fn legacy_predicate_repair_supports(condition: &QueryCondition) -> bool {
+    match condition.column.as_str() {
+        "id" => matches!(
+            condition.op,
+            QueryConditionOp::Eq | QueryConditionOp::Ne | QueryConditionOp::In
+        ),
+        "$createdBy" => matches!(condition.op, QueryConditionOp::Eq | QueryConditionOp::Ne),
+        "$createdAt" | "$updatedAt" => false,
+        _ => !query_condition_value_contains_null(&condition.value),
+    }
+}
+
+fn query_condition_value_contains_null(value: &JsonValue) -> bool {
+    value.is_null()
+        || value
+            .as_array()
+            .is_some_and(|values| values.iter().any(JsonValue::is_null))
 }
 
 fn built_query_repair_keep_query(query: &BuiltQuery) -> Result<BuiltQuery> {

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -35,7 +35,7 @@ struct AwaitingDependencyTx {
     auth_user: String,
 }
 
-struct QueryScopeOptions<'a> {
+pub(crate) struct QueryScopeOptions<'a> {
     ref_include_fields: &'a [&'a str],
     extra_row_ids: &'a [String],
 }
@@ -2389,10 +2389,7 @@ impl Runtime {
             .read_rows_where_eq(table_name, field_name, value)
     }
 
-    pub(crate) fn read_rows_for_built_query(
-        &self,
-        query: &BuiltQuery,
-    ) -> Result<Option<Vec<RowView>>> {
+    pub(crate) fn read_rows_for_built_query(&self, query: &BuiltQuery) -> Result<Vec<RowView>> {
         self.query_context().read_rows_for_built_query(query)
     }
 
@@ -2632,39 +2629,6 @@ impl Runtime {
         limit: usize,
         ref_include_fields: &[&str],
     ) -> Result<Bundle> {
-        let query_read = QueryReadRecord {
-            branch_id: branch_id_for_num(&self.conn, self.branch_num)?,
-            table: table_name.to_owned(),
-            field: field_name.to_owned(),
-            op: op.to_owned(),
-            value,
-        };
-        self.export_query_read_scope(query_read, rows, ref_include_fields)
-    }
-
-    pub(crate) fn export_built_query_scope(
-        &self,
-        query: BuiltQuery,
-        rows: Vec<RowView>,
-        ref_include_fields: &[&str],
-    ) -> Result<Bundle> {
-        let query_read = QueryReadRecord {
-            branch_id: branch_id_for_num(&self.conn, self.branch_num)?,
-            table: query.table.clone(),
-            field: "$query".to_owned(),
-            op: "query".to_owned(),
-            value: query.to_json_value(),
-        };
-        self.export_query_read_scope(query_read, rows, ref_include_fields)
-    }
-
-    fn export_query_read_scope(
-        &self,
-        query_read: QueryReadRecord,
-        rows: Vec<RowView>,
-        ref_include_fields: &[&str],
-    ) -> Result<Bundle> {
-        let table_name = &query_read.table;
         let table = self.schema.table_def(table_name)?;
         let user = self.policy_user();
         let bypass_policy = self.bypasses_policy();
@@ -2785,6 +2749,144 @@ impl Runtime {
             export_txs_for_query_scope(&self.conn, table_name, &history, &reads, &rejected_tx_ids)?;
         let mut branches = export_branch_records_for_history(&self.conn, &history)?;
         include_branch_record(&self.conn, &mut branches, self.branch_num)?;
+        Ok(make_bundle(
+            &self.schema,
+            branches,
+            txs,
+            reads,
+            query_reads,
+            history,
+        ))
+    }
+
+    pub(crate) fn export_built_query_scope(
+        &self,
+        query: BuiltQuery,
+        rows: Vec<RowView>,
+        ref_include_fields: &[&str],
+    ) -> Result<Bundle> {
+        let query_read = QueryReadRecord {
+            branch_id: branch_id_for_num(&self.conn, self.branch_num)?,
+            table: query.table.clone(),
+            field: "$query".to_owned(),
+            op: "query".to_owned(),
+            value: query.to_json_value(),
+        };
+        self.export_query_read_scope(
+            query_read,
+            rows,
+            QueryScopeOptions {
+                ref_include_fields,
+                extra_row_ids: &[],
+            },
+        )
+    }
+
+    fn export_query_read_scope(
+        &self,
+        query_read: QueryReadRecord,
+        rows: Vec<RowView>,
+        options: QueryScopeOptions<'_>,
+    ) -> Result<Bundle> {
+        let table_name = &query_read.table;
+        let table = self.schema.table_def(table_name)?;
+        let user = self.policy_user();
+        let bypass_policy = self.bypasses_policy();
+        let visible_row_nums = rows
+            .iter()
+            .map(|row| row_num(&self.conn, &row.id))
+            .collect::<Result<Vec<_>>>()?;
+        let mut repair_row_nums = Vec::new();
+        for row_id in options.extra_row_ids {
+            repair_row_nums.push(row_num(&self.conn, row_id)?);
+        }
+        repair_row_nums.extend(query_scope_repair_row_nums_for_read(
+            &self.conn,
+            table,
+            &query_read,
+        )?);
+        let visible_row_num_set = visible_row_nums.iter().copied().collect::<BTreeSet<_>>();
+        repair_row_nums.retain(|row_num| !visible_row_num_set.contains(row_num));
+        repair_row_nums.sort();
+        repair_row_nums.dedup();
+        let mut row_nums = visible_row_nums.clone();
+        row_nums.extend(repair_row_nums.iter());
+        row_nums.sort();
+        row_nums.dedup();
+        let branch_nums = branch::scope_nums(&self.conn, self.branch_num)?;
+        let mut history = export_history_versions_for_rows(
+            &self.conn,
+            &self.schema,
+            table_name,
+            Some(&visible_row_nums),
+            None,
+        )?;
+        if !repair_row_nums.is_empty() {
+            history.extend(export_visible_table_history(
+                &self.conn,
+                &self.schema,
+                table_name,
+                user,
+                bypass_policy,
+                &branch_nums,
+                Some(&repair_row_nums),
+            )?);
+            history.extend(export_history_versions_for_rows(
+                &self.conn,
+                &self.schema,
+                table_name,
+                Some(&repair_row_nums),
+                None,
+            )?);
+        }
+        history.extend(export_policy_dependency_history(
+            &self.conn,
+            &self.schema,
+            PolicyDependencyExport {
+                table_name,
+                policy: &table.read_policy,
+                user,
+                bypass_policy,
+                branch_nums: &branch_nums,
+                child_row_nums: Some(&row_nums),
+            },
+        )?);
+        for ref_field_name in options.ref_include_fields {
+            history.extend(self.export_ref_include_history(
+                table,
+                &rows,
+                ref_field_name,
+                &branch_nums,
+            )?);
+        }
+        if self.branch_num != 1 {
+            if let Some(base_epoch) = branch::base_global_epoch(&self.conn, self.branch_num)? {
+                history.extend(export_history_versions_for_rows(
+                    &self.conn,
+                    &self.schema,
+                    table_name,
+                    Some(&row_nums),
+                    Some(base_epoch),
+                )?);
+                history.extend(export_snapshot_policy_dependency_history(
+                    &self.conn,
+                    &self.schema,
+                    table_name,
+                    user,
+                    bypass_policy,
+                    base_epoch,
+                    Some(&row_nums),
+                )?);
+            }
+        }
+        dedupe_history_records(&mut history);
+        let reads = export_reads_for_history(&self.conn, &history)?;
+        let rejected_tx_ids = query_scope_rejected_tx_ids_for_read(&self.conn, table, &query_read)?;
+        let txs =
+            export_txs_for_query_scope(&self.conn, table_name, &history, &reads, &rejected_tx_ids)?;
+        let mut branches = export_branch_records_for_history(&self.conn, &history)?;
+        include_branch_record(&self.conn, &mut branches, self.branch_num)?;
+        let query_reads = vec![query_read];
         Ok(make_bundle(
             &self.schema,
             branches,
@@ -3031,113 +3133,14 @@ impl Runtime {
         rows: Vec<RowView>,
         options: QueryScopeOptions<'_>,
     ) -> Result<Bundle> {
-        let table = self.schema.table_def(table_name)?;
-        let user = self.policy_user();
-        let bypass_policy = self.bypasses_policy();
-        let visible_row_nums = rows
-            .iter()
-            .map(|row| row_num(&self.conn, &row.id))
-            .collect::<Result<Vec<_>>>()?;
-        let mut repair_row_nums = Vec::new();
-        for row_id in options.extra_row_ids {
-            repair_row_nums.push(row_num(&self.conn, row_id)?);
-        }
-        repair_row_nums.extend(query_scope_repair_row_nums(
-            &self.conn, table, field_name, op, &value,
-        )?);
-        let visible_row_num_set = visible_row_nums.iter().copied().collect::<BTreeSet<_>>();
-        repair_row_nums.retain(|row_num| !visible_row_num_set.contains(row_num));
-        repair_row_nums.sort();
-        repair_row_nums.dedup();
-        let mut row_nums = visible_row_nums.clone();
-        row_nums.extend(repair_row_nums.iter());
-        row_nums.sort();
-        row_nums.dedup();
-        let branch_nums = branch::scope_nums(&self.conn, self.branch_num)?;
-        let mut history = export_history_versions_for_rows(
-            &self.conn,
-            &self.schema,
-            table_name,
-            Some(&visible_row_nums),
-            None,
-        )?;
-        if !repair_row_nums.is_empty() {
-            history.extend(export_visible_table_history(
-                &self.conn,
-                &self.schema,
-                table_name,
-                user,
-                bypass_policy,
-                &branch_nums,
-                Some(&repair_row_nums),
-            )?);
-        }
-        if !repair_row_nums.is_empty() {
-            history.extend(export_history_versions_for_rows(
-                &self.conn,
-                &self.schema,
-                table_name,
-                Some(&repair_row_nums),
-                None,
-            )?);
-        }
-        history.extend(export_policy_dependency_history(
-            &self.conn,
-            &self.schema,
-            PolicyDependencyExport {
-                table_name,
-                policy: &self.schema.table_def(table_name)?.read_policy,
-                user,
-                bypass_policy,
-                branch_nums: &branch_nums,
-                child_row_nums: Some(&row_nums),
-            },
-        )?);
-        for ref_field_name in options.ref_include_fields {
-            history.extend(self.export_ref_include_history(
-                table,
-                &rows,
-                ref_field_name,
-                &branch_nums,
-            )?);
-        }
-        if self.branch_num != 1 {
-            if let Some(base_epoch) = branch::base_global_epoch(&self.conn, self.branch_num)? {
-                history.extend(export_history_versions_for_rows(
-                    &self.conn,
-                    &self.schema,
-                    table_name,
-                    Some(&row_nums),
-                    Some(base_epoch),
-                )?);
-                history.extend(export_snapshot_policy_dependency_history(
-                    &self.conn,
-                    &self.schema,
-                    table_name,
-                    user,
-                    bypass_policy,
-                    base_epoch,
-                    Some(&row_nums),
-                )?);
-            }
-        }
-        dedupe_history_records(&mut history);
-        let reads = export_reads_for_history(&self.conn, &history)?;
-        let rejected_tx_ids =
-            query_scope_rejected_tx_ids(&self.conn, table, field_name, op, &value)?;
-        let txs =
-            export_txs_for_query_scope(&self.conn, table_name, &history, &reads, &rejected_tx_ids)?;
-        let mut branches = export_branch_records_for_history(&self.conn, &history)?;
-        include_branch_record(&self.conn, &mut branches, self.branch_num)?;
-        let query_reads = vec![query_read];
-        Ok(make_bundle(
-            &self.schema,
-            branches,
-            txs,
-            reads,
-            query_reads,
-            history,
-        ))
+        let query_read = QueryReadRecord {
+            branch_id: branch_id_for_num(&self.conn, self.branch_num)?,
+            table: table_name.to_owned(),
+            field: field_name.to_owned(),
+            op: op.to_owned(),
+            value,
+        };
+        self.export_query_read_scope(query_read, rows, options)
     }
 
     fn export_ref_include_history(
@@ -6170,6 +6173,61 @@ fn query_scope_repair_row_nums_for_built_query(
         ));
     };
     query_scope_repair_row_nums(
+        conn,
+        table,
+        &condition.column,
+        condition.op.as_str(),
+        &condition.value,
+    )
+}
+
+fn query_scope_rejected_tx_ids_for_read(
+    conn: &Connection,
+    table: &crate::schema::TableDef,
+    query_read: &QueryReadRecord,
+) -> Result<Vec<String>> {
+    if query_read.op == "query" {
+        let query = built_query_from_read(query_read)?;
+        return query_scope_rejected_tx_ids_for_built_query(conn, table, &query);
+    }
+    query_scope_rejected_tx_ids(
+        conn,
+        table,
+        &query_read.field,
+        &query_read.op,
+        &query_read.value,
+    )
+}
+
+fn query_scope_rejected_tx_ids_for_built_query(
+    conn: &Connection,
+    table: &crate::schema::TableDef,
+    built_query: &BuiltQuery,
+) -> Result<Vec<String>> {
+    if built_query.table != table.name {
+        return Err(crate::Error::new(
+            "query read table does not match descriptor",
+        ));
+    }
+    if let Some(query::QueryStoragePlan::EqCreatedAtDescPage {
+        condition,
+        limit: _,
+    }) = query::storage_plan(built_query)
+    {
+        return query_scope_rejected_tx_ids(
+            conn,
+            table,
+            &condition.column,
+            condition.op.as_str(),
+            &condition.value,
+        );
+    }
+    let Some(condition) = query::query_scope_predicate(built_query)? else {
+        return Err(crate::Error::new(
+            "query read rejection tracking supports one predicate, or one eq predicate ordered by $createdAt desc with a limit",
+        ));
+    };
+    query_scope_rejected_tx_ids(
         conn,
         table,
         &condition.column,

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -1,4 +1,4 @@
-use crate::query_api::{BuiltQuery, QueryCondition};
+use crate::query_api::{predicate_query, BuiltQuery, QueryCondition, QueryConditionOp};
 use crate::rows::{ensure_row_id, ensure_row_id_with_status, public_row_id, row_num};
 use crate::schema::{FieldDef, FieldKind, PolicyDef, SchemaDef};
 use crate::subscription::{RejectionSubscription, RowsSubscription, RowsSubscriptionQuery};
@@ -911,11 +911,12 @@ impl Runtime {
                         return Err(crate::Error::new("absent id expects string value"));
                     };
                     if self
-                        .read_rows_where_eq(
+                        .query(predicate_query(
                             &read.table,
                             &read.field,
+                            QueryConditionOp::Eq,
                             JsonValue::String(row_id.to_owned()),
-                        )?
+                        ))?
                         .is_empty()
                     {
                         let mut branches = Vec::new();
@@ -2450,16 +2451,6 @@ impl Runtime {
             .collect())
     }
 
-    pub fn read_rows_where_eq(
-        &self,
-        table_name: &str,
-        field_name: &str,
-        value: JsonValue,
-    ) -> Result<Vec<RowView>> {
-        self.query_context()
-            .read_rows_where_eq(table_name, field_name, value)
-    }
-
     pub(crate) fn read_rows_for_built_query(&self, query: &BuiltQuery) -> Result<Vec<RowView>> {
         self.query_context().read_rows_for_built_query(query)
     }
@@ -2500,12 +2491,18 @@ impl Runtime {
         field_name: &str,
         value: JsonValue,
     ) -> Result<Bundle> {
+        let rows = self.query(predicate_query(
+            table_name,
+            field_name,
+            QueryConditionOp::Eq,
+            value.clone(),
+        ))?;
         self.export_query_scope(
             table_name,
             field_name,
             "eq",
-            value.clone(),
-            self.read_rows_where_eq(table_name, field_name, value)?,
+            value,
+            rows,
             QueryScopeOptions::empty(),
         )
     }
@@ -2517,12 +2514,18 @@ impl Runtime {
         value: JsonValue,
         ref_field_name: &str,
     ) -> Result<Bundle> {
+        let rows = self.query(predicate_query(
+            table_name,
+            field_name,
+            QueryConditionOp::Eq,
+            value.clone(),
+        ))?;
         self.export_query_scope(
             table_name,
             field_name,
             "eq",
-            value.clone(),
-            self.read_rows_where_eq(table_name, field_name, value)?,
+            value,
+            rows,
             QueryScopeOptions {
                 ref_include_fields: &[ref_field_name],
                 extra_row_ids: &[],
@@ -3327,11 +3330,14 @@ impl Runtime {
         field_name: &str,
         value: JsonValue,
     ) -> Result<RowsSubscription> {
-        Ok(RowsSubscription::where_eq(
+        let rows = self.query(predicate_query(
             table_name,
             field_name,
+            QueryConditionOp::Eq,
             value.clone(),
-            self.read_rows_where_eq(table_name, field_name, value)?,
+        ))?;
+        Ok(RowsSubscription::where_eq(
+            table_name, field_name, value, rows,
         ))
     }
 
@@ -3492,30 +3498,6 @@ impl Runtime {
         Ok(rows)
     }
 
-    pub fn read_rows_where_eq_with_conflict_meta(
-        &self,
-        table_name: &str,
-        field_name: &str,
-        value: JsonValue,
-    ) -> Result<Vec<RowView>> {
-        if field_name == "id" {
-            let Some(id) = value.as_str() else {
-                return Err(crate::Error::new("id equality expects a string"));
-            };
-            return Ok(self
-                .read_rows_with_conflict_meta(table_name)?
-                .into_iter()
-                .filter(|row| row.id == id)
-                .collect());
-        }
-        self.schema.table_def(table_name)?;
-        Ok(self
-            .read_rows_with_conflict_meta(table_name)?
-            .into_iter()
-            .filter(|row| row.values.get(field_name) == Some(&value))
-            .collect())
-    }
-
     fn row_has_current_branch_value(&self, table_name: &str, id: &str) -> Result<bool> {
         self.schema.table_def(table_name)?;
         let row_num = row_num(&self.conn, id)?;
@@ -3560,7 +3542,12 @@ impl Runtime {
         let next_rows = match &subscription.query {
             RowsSubscriptionQuery::Table { table } => self.read_rows(table)?,
             RowsSubscriptionQuery::Predicate(query) if query.op == "eq" => {
-                self.read_rows_where_eq(&query.table, &query.field, query.value.clone())?
+                self.query(predicate_query(
+                    &query.table,
+                    &query.field,
+                    QueryConditionOp::Eq,
+                    query.value.clone(),
+                ))?
             }
             RowsSubscriptionQuery::Predicate(query) if query.op == "ne" => {
                 self.read_rows_where_ne(&query.table, &query.field, query.value.clone())?

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -632,7 +632,7 @@ impl Runtime {
         let mut row_nums_by_id = BTreeMap::new();
         let mut row_nums_created_in_apply = BTreeSet::new();
         let mut user_nums_by_id = BTreeMap::new();
-        let mut insert_read_stmt = db.prepare_cached(
+        let mut insert_read_stmt = db.prepare(
             "INSERT OR REPLACE INTO jazz_tx_read
              (tx_num, table_num, row_num, reason, observed_tx_num)
              VALUES (?, ?, ?, ?, ?)",
@@ -4504,7 +4504,7 @@ fn record_tx_write_num(
     row_num: i64,
     op: i64,
 ) -> Result<()> {
-    let mut stmt = conn.prepare_cached(
+    let mut stmt = conn.prepare(
         "INSERT OR REPLACE INTO jazz_tx_write (tx_num, table_num, row_num, op)
          VALUES (?, ?, ?, ?)",
     )?;
@@ -4987,7 +4987,7 @@ fn current_visible_tx_num(
     row_num: i64,
     branch_num: i64,
 ) -> Result<Option<i64>> {
-    let mut stmt = conn.prepare_cached(&format!(
+    let mut stmt = conn.prepare(&format!(
         "SELECT visible_tx_num
          FROM {}
          WHERE row_num = ?
@@ -5007,7 +5007,7 @@ fn history_record_exists(
     row_num: i64,
     tx_num: i64,
 ) -> Result<bool> {
-    let mut stmt = conn.prepare_cached(&format!(
+    let mut stmt = conn.prepare(&format!(
         "SELECT 1
          FROM {}
          WHERE row_num = ?
@@ -5345,8 +5345,8 @@ fn export_reads_for_history_with_temp_scope(
     )?;
     {
         let mut tx_stmt =
-            conn.prepare_cached("INSERT OR IGNORE INTO jazz_export_tx_scope (tx_id) VALUES (?)")?;
-        let mut scope_stmt = conn.prepare_cached(
+            conn.prepare("INSERT OR IGNORE INTO jazz_export_tx_scope (tx_id) VALUES (?)")?;
+        let mut scope_stmt = conn.prepare(
             "INSERT OR IGNORE INTO jazz_export_history_scope (tx_id, table_name, row_id)
              VALUES (?, ?, ?)",
         )?;
@@ -6013,10 +6013,11 @@ fn ordered_page_eq_predicate(
             .value
             .as_str()
             .ok_or_else(|| crate::Error::new("$createdBy equality expects a string value"))?;
+        let created_by_num = users::user_num(db, created_by).unwrap_or(-1);
         return Ok(OrderedPageEqPredicate {
             outer_sql: "j_created_by = ?".to_owned(),
             inner_sql: "current.j_created_by = ?".to_owned(),
-            value: rusqlite::types::Value::Text(created_by.to_owned()),
+            value: rusqlite::types::Value::Integer(created_by_num),
         });
     }
 
@@ -7053,7 +7054,7 @@ fn insert_dynamic(
         .map(|_| "?")
         .collect::<Vec<_>>()
         .join(", ");
-    let mut stmt = conn.prepare_cached(&format!(
+    let mut stmt = conn.prepare(&format!(
         "INSERT OR REPLACE INTO {table} ({}) VALUES ({placeholders})",
         columns.join(", ")
     ))?;

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -1206,6 +1206,36 @@ impl Runtime {
         db: &Connection,
         query_read: &QueryReadRecord,
     ) -> Result<()> {
+        // Query-scope repair keeps a receiver's current projection from retaining
+        // rows that used to satisfy an observed query but are no longer covered by
+        // the refresh bundle.
+        //
+        // Export side:
+        //
+        //   +------------------+      +---------------------+
+        //   | current results  | ---> | visible row history |
+        //   +------------------+      +---------------------+
+        //            |                         ^
+        //            v                         |
+        //   +------------------+      +---------------------+
+        //   | repair row nums  | ---> | old matching rows   |
+        //   +------------------+      +---------------------+
+        //
+        // Apply side:
+        //
+        //   +-------------------+      +----------------------+
+        //   | local current row | ---> | still has matching   |
+        //   | matches read      |      | history in bundle?   |
+        //   +-------------------+      +----------------------+
+        //             | yes                     | no
+        //             v                         v
+        //        keep current             delete current
+        //
+        // `apply_bundle` runs this both before and after applying incoming
+        // history. The first pass can remove stale rows using repair history
+        // already present locally; the second pass observes repair history that
+        // arrived in the bundle and catches page-boundary changes after current
+        // projection updates.
         if query_read.op == "absent" {
             let table = schema.table_def(&query_read.table)?;
             if query_read.field != "id"
@@ -1497,6 +1527,30 @@ impl Runtime {
         query_read: &QueryReadRecord,
         built_query: &BuiltQuery,
     ) -> Result<()> {
+        // Built queries are recorded as one opaque query-read value so they can
+        // be replayed exactly after reconnect:
+        //
+        //   jazz_query_read
+        //   field="$query", op="query", value=<BuiltQuery JSON>
+        //
+        // Repair does not currently understand every SQL-lowered descriptor.
+        // It maps the supported sync-repair shapes back to the smaller repair
+        // primitives used below:
+        //
+        //   +-----------------------------+
+        //   | BuiltQuery descriptor       |
+        //   +-----------------------------+
+        //        | one predicate only
+        //        v
+        //   +-----------------------------+      +--------------------------+
+        //   | QueryReadRecord predicate   | ---> | apply_query_scope_repair |
+        //   +-----------------------------+      +--------------------------+
+        //
+        //        | eq predicate + $createdAt DESC + limit
+        //        v
+        //   +-----------------------------+
+        //   | page-boundary repair        |
+        //   +-----------------------------+
         if let Some(query::QueryStoragePlan::EqCreatedAtDescPage { condition, limit }) =
             query::storage_plan(built_query)
         {
@@ -1526,6 +1580,23 @@ impl Runtime {
         condition: &QueryCondition,
         limit: usize,
     ) -> Result<()> {
+        // Ordered-page repair handles the sync case where a row is still in the
+        // predicate set but has fallen out of the materialized page.
+        //
+        // Example: top 2 open todos ordered by createdAt desc
+        //
+        //   before refresh: [C, B]        after refresh: [D, C]
+        //                         stale boundary row: B
+        //
+        // The DELETE below says:
+        //
+        //   delete local current rows that:
+        //     1. are in the observed branch
+        //     2. still match the page predicate
+        //     3. are not in SQLite's current top-N result for that predicate
+        //
+        // This is page-boundary contraction, not authorization. The refreshed
+        // top-N rows themselves arrive through normal history application.
         let table = schema.table_def(&query_read.table)?;
         let field = table
             .fields
@@ -2788,6 +2859,28 @@ impl Runtime {
         rows: Vec<RowView>,
         options: QueryScopeOptions<'_>,
     ) -> Result<Bundle> {
+        // Query-scope exports carry more than the rows currently visible in the
+        // query result. They also carry repair candidates: rows whose history
+        // previously satisfied the same query scope and may need to be removed
+        // or updated on a receiver.
+        //
+        //   +---------------------+
+        //   | query result rows   |
+        //   +---------------------+
+        //             |
+        //             v
+        //   +---------------------+      +---------------------+
+        //   | result row nums     | ---> | exported history    |
+        //   +---------------------+      +---------------------+
+        //             ^
+        //             |
+        //   +---------------------+
+        //   | repair row nums     |
+        //   +---------------------+
+        //
+        // Without the repair rows, query-scoped sync would only add or update
+        // rows that are still in the result. A receiver would not learn that a
+        // previously synced row left the predicate or page boundary.
         let table_name = &query_read.table;
         let table = self.schema.table_def(table_name)?;
         let user = self.policy_user();
@@ -5866,6 +5959,22 @@ fn query_scope_repair_row_nums(
     op: &str,
     value: &JsonValue,
 ) -> Result<Vec<i64>> {
+    // Return the physical rows whose history can affect a query-scope refresh.
+    // These are not necessarily current result rows.
+    //
+    // Predicate repair:
+    //
+    //   history rows ever matching predicate
+    //        |
+    //        v
+    //   exported repair history
+    //        |
+    //        v
+    //   receiver deletes stale current rows no longer justified by history
+    //
+    // `id` is special because the row id lives in `jazz_row_id`, not the user
+    // table history. `$createdBy` is special because it is a system column on
+    // history/current tables. User fields lower through `query_predicate`.
     if op == "eq_top_field_desc" {
         let observed_ids = observed_ids_from_query_value(value)?;
         if observed_ids.is_empty() {
@@ -6131,6 +6240,9 @@ fn query_scope_repair_row_nums_for_read(
     table: &crate::schema::TableDef,
     query_read: &QueryReadRecord,
 ) -> Result<Vec<i64>> {
+    // Dispatch from the serialized query-read shape used in bundles to the row
+    // collection shape used by export. Built queries are stored opaquely, so
+    // they need a small adapter before repair candidates can be collected.
     if query_read.op == "query" {
         let query = built_query_from_read(query_read)?;
         return query_scope_repair_row_nums_for_built_query(conn, table, &query);
@@ -6149,6 +6261,17 @@ fn query_scope_repair_row_nums_for_built_query(
     table: &crate::schema::TableDef,
     built_query: &BuiltQuery,
 ) -> Result<Vec<i64>> {
+    // Built-query repair row collection mirrors `apply_built_query_scope_repair`:
+    //
+    //   built query
+    //       |
+    //       +-- one predicate ------------------------+
+    //       |                                         v
+    //       +-- eq + createdAt desc + limit --> predicate repair rows
+    //
+    // The ordered-page case exports rows that ever matched the predicate. The
+    // receiver then recomputes the actual page boundary locally and deletes any
+    // stale rows outside that boundary.
     if built_query.table != table.name {
         return Err(crate::Error::new(
             "query read table does not match descriptor",

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -1495,19 +1495,23 @@ impl Runtime {
         schema: &SchemaDef,
         db: &Connection,
         query_read: &QueryReadRecord,
-        query: &BuiltQuery,
+        built_query: &BuiltQuery,
     ) -> Result<()> {
-        if let Some((condition, limit)) = query.ordered_page() {
-            return Self::apply_ordered_page_repair(schema, db, query_read, condition, limit);
+        if let Some(query::QueryStoragePlan::EqCreatedAtDescPage { condition, limit }) =
+            query::storage_plan(built_query)
+        {
+            return Self::apply_created_at_desc_page_repair(
+                schema, db, query_read, condition, limit,
+            );
         }
-        let Some(condition) = query.single_predicate_export_condition()? else {
+        let Some(condition) = built_query.single_predicate_export_condition()? else {
             return Err(crate::Error::new(
                 "query read repair supports one predicate, or one eq predicate ordered by $createdAt desc with a limit",
             ));
         };
         let predicate_read = QueryReadRecord {
             branch_id: query_read.branch_id.clone(),
-            table: query.table.clone(),
+            table: built_query.table.clone(),
             field: condition.column.clone(),
             op: condition.op.as_str().to_owned(),
             value: condition.value.clone(),
@@ -1515,7 +1519,7 @@ impl Runtime {
         Self::apply_query_scope_repair(schema, db, &predicate_read)
     }
 
-    fn apply_ordered_page_repair(
+    fn apply_created_at_desc_page_repair(
         schema: &SchemaDef,
         db: &Connection,
         query_read: &QueryReadRecord,
@@ -6140,14 +6144,18 @@ fn query_scope_repair_row_nums_for_read(
 fn query_scope_repair_row_nums_for_built_query(
     conn: &Connection,
     table: &crate::schema::TableDef,
-    query: &BuiltQuery,
+    built_query: &BuiltQuery,
 ) -> Result<Vec<i64>> {
-    if query.table != table.name {
+    if built_query.table != table.name {
         return Err(crate::Error::new(
             "query read table does not match descriptor",
         ));
     }
-    if let Some((condition, _limit)) = query.ordered_page() {
+    if let Some(query::QueryStoragePlan::EqCreatedAtDescPage {
+        condition,
+        limit: _,
+    }) = query::storage_plan(built_query)
+    {
         return query_scope_repair_row_nums(
             conn,
             table,
@@ -6156,7 +6164,7 @@ fn query_scope_repair_row_nums_for_built_query(
             &condition.value,
         );
     }
-    let Some(condition) = query.single_predicate_export_condition()? else {
+    let Some(condition) = built_query.single_predicate_export_condition()? else {
         return Err(crate::Error::new(
             "query read repair supports one predicate, or one eq predicate ordered by $createdAt desc with a limit",
         ));

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -1,3 +1,4 @@
+use crate::query_api::{BuiltQuery, QueryCondition};
 use crate::rows::{ensure_row_id, ensure_row_id_with_status, public_row_id, row_num};
 use crate::schema::{FieldDef, FieldKind, PolicyDef, SchemaDef};
 use crate::subscription::{RejectionSubscription, RowsSubscription, RowsSubscriptionQuery};
@@ -303,17 +304,6 @@ impl Runtime {
         }
         db.commit()?;
         Ok(tx_id)
-    }
-
-    pub(crate) fn read_rows_where_eq_top_created_at_desc(
-        &self,
-        table_name: &str,
-        field_name: &str,
-        value: JsonValue,
-        limit: usize,
-    ) -> Result<Vec<RowView>> {
-        self.query_context()
-            .read_rows_where_eq_top_created_at_desc(table_name, field_name, value, limit)
     }
 
     pub fn read_rows_where_eq_top_field_desc(
@@ -890,24 +880,6 @@ impl Runtime {
                 };
                 self.export_recursive_refs(&read.table, root_id, &read.field)
             }
-            "eq_top_created_at_desc" => {
-                let value = read
-                    .value
-                    .get("eq")
-                    .ok_or_else(|| crate::Error::new("top created query expects eq value"))?;
-                let limit = read
-                    .value
-                    .get("limit")
-                    .and_then(JsonValue::as_u64)
-                    .ok_or_else(|| crate::Error::new("top created query expects numeric limit"))?;
-                self.export_query_where_eq_top_created_at_desc_with_previous_observed(
-                    &read.table,
-                    &read.field,
-                    value.clone(),
-                    limit as usize,
-                    observed_ids_from_query_value(&read.value)?,
-                )
-            }
             "eq_top_field_desc" => {
                 let value = read
                     .value
@@ -932,6 +904,7 @@ impl Runtime {
                     observed_ids_from_query_value(&read.value)?,
                 )
             }
+            "query" => self.export_query(built_query_from_read(read)?),
             "absent" => {
                 if read.field == "id" {
                     let Some(row_id) = read.value.as_str() else {
@@ -1268,61 +1241,9 @@ impl Runtime {
             }
             return Ok(());
         }
-        if query_read.op == "eq_top_created_at_desc" {
-            let value = query_read
-                .value
-                .get("eq")
-                .ok_or_else(|| crate::Error::new("top created query expects eq value"))?;
-            let limit = query_read
-                .value
-                .get("limit")
-                .and_then(JsonValue::as_u64)
-                .ok_or_else(|| crate::Error::new("top created query expects numeric limit"))?;
-            let table = schema.table_def(&query_read.table)?;
-            let field = table
-                .fields
-                .iter()
-                .find(|candidate| candidate.name == query_read.field)
-                .ok_or_else(|| {
-                    crate::Error::new(format!("unknown query field {}", query_read.field))
-                })?;
-            let branch_num = branch::checkout(db, &query_read.branch_id)?;
-            let predicate_column =
-                crate::schema::quote_ident(&crate::schema::storage_column(field));
-            let predicate_sql = query_predicate::sql(field, &predicate_column, "eq")?;
-            let predicate_value = query_predicate::value(field, "eq", value, db)?;
-            db.execute(
-                &format!(
-                    "DELETE FROM {}
-                     WHERE j_branch_num = ?
-                       AND is_deleted = 0
-                       AND {predicate_sql}
-                       AND row_num NOT IN (
-                         SELECT current.row_num
-                         FROM {current_table} current
-                         JOIN jazz_tx tx ON tx.tx_num = current.visible_tx_num
-                         WHERE current.j_branch_num = ?
-                           AND current.is_deleted = 0
-                           AND tx.outcome != ?
-                           AND {current_predicate_sql}
-                         ORDER BY current.j_created_at DESC, current.row_num
-                         LIMIT ?
-                       )",
-                    crate::schema::current_table(&query_read.table),
-                    current_table = crate::schema::current_table(&query_read.table),
-                    current_predicate_sql =
-                        query_predicate::sql(field, &format!("current.{predicate_column}"), "eq")?,
-                ),
-                params![
-                    branch_num,
-                    predicate_value.clone(),
-                    branch_num,
-                    tx::OUTCOME_REJECTED,
-                    predicate_value,
-                    limit as i64
-                ],
-            )?;
-            return Ok(());
+        if query_read.op == "query" {
+            let query = built_query_from_read(query_read)?;
+            return Self::apply_built_query_scope_repair(schema, db, query_read, &query);
         }
         if query_read.op == "eq_top_field_desc" {
             let value = query_read
@@ -1565,6 +1486,85 @@ impl Runtime {
                 branch_num,
                 tx::OUTCOME_REJECTED,
                 predicate_value
+            ],
+        )?;
+        Ok(())
+    }
+
+    fn apply_built_query_scope_repair(
+        schema: &SchemaDef,
+        db: &Connection,
+        query_read: &QueryReadRecord,
+        query: &BuiltQuery,
+    ) -> Result<()> {
+        if let Some((condition, limit)) = query.ordered_page() {
+            return Self::apply_ordered_page_repair(schema, db, query_read, condition, limit);
+        }
+        let Some(condition) = query.single_predicate_export_condition()? else {
+            return Err(crate::Error::new(
+                "query read repair supports one predicate, or one eq predicate ordered by $createdAt desc with a limit",
+            ));
+        };
+        let predicate_read = QueryReadRecord {
+            branch_id: query_read.branch_id.clone(),
+            table: query.table.clone(),
+            field: condition.column.clone(),
+            op: condition.op.as_str().to_owned(),
+            value: condition.value.clone(),
+        };
+        Self::apply_query_scope_repair(schema, db, &predicate_read)
+    }
+
+    fn apply_ordered_page_repair(
+        schema: &SchemaDef,
+        db: &Connection,
+        query_read: &QueryReadRecord,
+        condition: &QueryCondition,
+        limit: usize,
+    ) -> Result<()> {
+        let table = schema.table_def(&query_read.table)?;
+        let field = table
+            .fields
+            .iter()
+            .find(|candidate| candidate.name == condition.column)
+            .ok_or_else(|| {
+                crate::Error::new(format!("unknown query field {}", condition.column))
+            })?;
+        let branch_num = branch::checkout(db, &query_read.branch_id)?;
+        let predicate_column = crate::schema::quote_ident(&crate::schema::storage_column(field));
+        let predicate_sql = query_predicate::sql(field, &predicate_column, "eq")?;
+        let predicate_value = query_predicate::value(field, "eq", &condition.value, db)?;
+        let limit = i64::try_from(limit)
+            .map_err(|_| crate::Error::new("ordered query limit is too large"))?;
+        db.execute(
+            &format!(
+                "DELETE FROM {}
+                 WHERE j_branch_num = ?
+                   AND is_deleted = 0
+                   AND {predicate_sql}
+                   AND row_num NOT IN (
+                     SELECT current.row_num
+                     FROM {current_table} current
+                     JOIN jazz_tx tx ON tx.tx_num = current.visible_tx_num
+                     WHERE current.j_branch_num = ?
+                       AND current.is_deleted = 0
+                       AND tx.outcome != ?
+                       AND {current_predicate_sql}
+                     ORDER BY current.j_created_at DESC, current.row_num
+                     LIMIT ?
+                   )",
+                crate::schema::current_table(&query_read.table),
+                current_table = crate::schema::current_table(&query_read.table),
+                current_predicate_sql =
+                    query_predicate::sql(field, &format!("current.{predicate_column}"), "eq")?,
+            ),
+            params![
+                branch_num,
+                predicate_value.clone(),
+                branch_num,
+                tx::OUTCOME_REJECTED,
+                predicate_value,
+                limit,
             ],
         )?;
         Ok(())
@@ -2385,6 +2385,13 @@ impl Runtime {
             .read_rows_where_eq(table_name, field_name, value)
     }
 
+    pub(crate) fn read_rows_for_built_query(
+        &self,
+        query: &BuiltQuery,
+    ) -> Result<Option<Vec<RowView>>> {
+        self.query_context().read_rows_for_built_query(query)
+    }
+
     pub fn read_rows_where_contains(
         &self,
         table_name: &str,
@@ -2496,53 +2503,6 @@ impl Runtime {
             value.clone(),
             self.read_rows_where_ne(table_name, field_name, value)?,
             QueryScopeOptions::empty(),
-        )
-    }
-
-    pub(crate) fn export_query_where_eq_top_created_at_desc(
-        &self,
-        table_name: &str,
-        field_name: &str,
-        value: JsonValue,
-        limit: usize,
-    ) -> Result<Bundle> {
-        self.export_query_where_eq_top_created_at_desc_with_previous_observed(
-            table_name,
-            field_name,
-            value,
-            limit,
-            Vec::new(),
-        )
-    }
-
-    fn export_query_where_eq_top_created_at_desc_with_previous_observed(
-        &self,
-        table_name: &str,
-        field_name: &str,
-        value: JsonValue,
-        limit: usize,
-        previous_observed_ids: Vec<String>,
-    ) -> Result<Bundle> {
-        let rows = self.read_rows_where_eq_top_created_at_desc(
-            table_name,
-            field_name,
-            value.clone(),
-            limit,
-        )?;
-        self.export_query_scope(
-            table_name,
-            field_name,
-            "eq_top_created_at_desc",
-            json!({
-                "eq": value.clone(),
-                "limit": limit,
-                "observed_ids": observed_row_ids(&rows),
-            }),
-            rows,
-            QueryScopeOptions {
-                ref_include_fields: &[],
-                extra_row_ids: &previous_observed_ids,
-            },
         )
     }
 
@@ -2668,6 +2628,39 @@ impl Runtime {
         limit: usize,
         ref_include_fields: &[&str],
     ) -> Result<Bundle> {
+        let query_read = QueryReadRecord {
+            branch_id: branch_id_for_num(&self.conn, self.branch_num)?,
+            table: table_name.to_owned(),
+            field: field_name.to_owned(),
+            op: op.to_owned(),
+            value,
+        };
+        self.export_query_read_scope(query_read, rows, ref_include_fields)
+    }
+
+    pub(crate) fn export_built_query_scope(
+        &self,
+        query: BuiltQuery,
+        rows: Vec<RowView>,
+        ref_include_fields: &[&str],
+    ) -> Result<Bundle> {
+        let query_read = QueryReadRecord {
+            branch_id: branch_id_for_num(&self.conn, self.branch_num)?,
+            table: query.table.clone(),
+            field: "$query".to_owned(),
+            op: "query".to_owned(),
+            value: query.to_json_value(),
+        };
+        self.export_query_read_scope(query_read, rows, ref_include_fields)
+    }
+
+    fn export_query_read_scope(
+        &self,
+        query_read: QueryReadRecord,
+        rows: Vec<RowView>,
+        ref_include_fields: &[&str],
+    ) -> Result<Bundle> {
+        let table_name = &query_read.table;
         let table = self.schema.table_def(table_name)?;
         let user = self.policy_user();
         let bypass_policy = self.bypasses_policy();
@@ -3132,13 +3125,7 @@ impl Runtime {
             export_txs_for_query_scope(&self.conn, table_name, &history, &reads, &rejected_tx_ids)?;
         let mut branches = export_branch_records_for_history(&self.conn, &history)?;
         include_branch_record(&self.conn, &mut branches, self.branch_num)?;
-        let query_reads = vec![QueryReadRecord {
-            branch_id: branch_id_for_num(&self.conn, self.branch_num)?,
-            table: table_name.to_owned(),
-            field: field_name.to_owned(),
-            op: op.to_owned(),
-            value,
-        }];
+        let query_reads = vec![query_read];
         Ok(make_bundle(
             &self.schema,
             branches,
@@ -3290,22 +3277,6 @@ impl Runtime {
         ))
     }
 
-    pub(crate) fn subscribe_rows_where_eq_top_created_at_desc(
-        &self,
-        table_name: &str,
-        field_name: &str,
-        value: JsonValue,
-        limit: usize,
-    ) -> Result<RowsSubscription> {
-        Ok(RowsSubscription::where_eq_top_created_at_desc(
-            table_name,
-            field_name,
-            value.clone(),
-            limit,
-            self.read_rows_where_eq_top_created_at_desc(table_name, field_name, value, limit)?,
-        ))
-    }
-
     pub fn subscribe_rows_where_eq_top_field_desc(
         &self,
         table_name: &str,
@@ -3362,23 +3333,6 @@ impl Runtime {
                     self.read_recursive_refs(&read.table, root_id, &read.field)?,
                 ))
             }
-            "eq_top_created_at_desc" => {
-                let value = read
-                    .value
-                    .get("eq")
-                    .ok_or_else(|| crate::Error::new("top created query expects eq value"))?;
-                let limit = read
-                    .value
-                    .get("limit")
-                    .and_then(JsonValue::as_u64)
-                    .ok_or_else(|| crate::Error::new("top created query expects numeric limit"))?;
-                self.subscribe_rows_where_eq_top_created_at_desc(
-                    &read.table,
-                    &read.field,
-                    value.clone(),
-                    limit as usize,
-                )
-            }
             "eq_top_field_desc" => {
                 let value = read
                     .value
@@ -3402,6 +3356,7 @@ impl Runtime {
                     limit as usize,
                 )
             }
+            "query" => self.subscribe_query(built_query_from_read(read)?),
             op => Err(crate::Error::new(format!(
                 "unsupported observed subscription query {op}"
             ))),
@@ -3527,23 +3482,6 @@ impl Runtime {
                     return Err(crate::Error::new("recursive refs expects root id string"));
                 };
                 self.read_recursive_refs(&query.table, root_id, &query.field)?
-            }
-            RowsSubscriptionQuery::Predicate(query) if query.op == "eq_top_created_at_desc" => {
-                let value = query
-                    .value
-                    .get("eq")
-                    .ok_or_else(|| crate::Error::new("top created query expects eq value"))?;
-                let limit = query
-                    .value
-                    .get("limit")
-                    .and_then(JsonValue::as_u64)
-                    .ok_or_else(|| crate::Error::new("top created query expects numeric limit"))?;
-                self.read_rows_where_eq_top_created_at_desc(
-                    &query.table,
-                    &query.field,
-                    value.clone(),
-                    limit as usize,
-                )?
             }
             RowsSubscriptionQuery::Predicate(query) if query.op == "eq_top_field_desc" => {
                 let value = query
@@ -5921,7 +5859,7 @@ fn query_scope_repair_row_nums(
     op: &str,
     value: &JsonValue,
 ) -> Result<Vec<i64>> {
-    if op == "eq_top_created_at_desc" || op == "eq_top_field_desc" {
+    if op == "eq_top_field_desc" {
         let observed_ids = observed_ids_from_query_value(value)?;
         if observed_ids.is_empty() {
             let value = value
@@ -6038,7 +5976,7 @@ fn query_scope_rejected_tx_ids(
     op: &str,
     value: &JsonValue,
 ) -> Result<Vec<String>> {
-    if op == "eq_top_created_at_desc" || op == "eq_top_field_desc" {
+    if op == "eq_top_field_desc" {
         let observed_ids = observed_ids_from_query_value(value)?;
         if observed_ids.is_empty() {
             let value = value
@@ -6179,6 +6117,67 @@ fn rejected_tx_ids_for_row_nums(
     tx_ids
         .collect::<std::result::Result<Vec<_>, _>>()
         .map_err(Into::into)
+}
+
+fn query_scope_repair_row_nums_for_read(
+    conn: &Connection,
+    table: &crate::schema::TableDef,
+    query_read: &QueryReadRecord,
+) -> Result<Vec<i64>> {
+    if query_read.op == "query" {
+        let query = built_query_from_read(query_read)?;
+        return query_scope_repair_row_nums_for_built_query(conn, table, &query);
+    }
+    query_scope_repair_row_nums(
+        conn,
+        table,
+        &query_read.field,
+        &query_read.op,
+        &query_read.value,
+    )
+}
+
+fn query_scope_repair_row_nums_for_built_query(
+    conn: &Connection,
+    table: &crate::schema::TableDef,
+    query: &BuiltQuery,
+) -> Result<Vec<i64>> {
+    if query.table != table.name {
+        return Err(crate::Error::new(
+            "query read table does not match descriptor",
+        ));
+    }
+    if let Some((condition, _limit)) = query.ordered_page() {
+        return query_scope_repair_row_nums(
+            conn,
+            table,
+            &condition.column,
+            condition.op.as_str(),
+            &condition.value,
+        );
+    }
+    let Some(condition) = query.single_predicate_export_condition()? else {
+        return Err(crate::Error::new(
+            "query read repair supports one predicate, or one eq predicate ordered by $createdAt desc with a limit",
+        ));
+    };
+    query_scope_repair_row_nums(
+        conn,
+        table,
+        &condition.column,
+        condition.op.as_str(),
+        &condition.value,
+    )
+}
+
+fn built_query_from_read(read: &QueryReadRecord) -> Result<BuiltQuery> {
+    let query = BuiltQuery::from_json_value(read.value.clone())?;
+    if read.table != query.table {
+        return Err(crate::Error::new(
+            "query read table does not match descriptor",
+        ));
+    }
+    Ok(query)
 }
 
 fn id_predicate_values(op: &str, value: &JsonValue) -> Result<Vec<String>> {

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -3637,6 +3637,7 @@ impl Runtime {
                     query.op
                 )));
             }
+            RowsSubscriptionQuery::Built(query) => self.query(query.clone())?,
         };
         Ok(subscription.replace_with_diff(next_rows))
     }

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -1,4 +1,5 @@
 use crate::query_api::{predicate_query, BuiltQuery, QueryCondition, QueryConditionOp};
+use crate::read_visibility::ReadVisibility;
 use crate::rows::{ensure_row_id, ensure_row_id_with_status, public_row_id, row_num};
 use crate::schema::{FieldDef, FieldKind, PolicyDef, SchemaDef};
 use crate::subscription::{RejectionSubscription, RowsSubscription, RowsSubscriptionQuery};
@@ -399,23 +400,15 @@ impl Runtime {
         parent_field: &str,
     ) -> Result<Bundle> {
         self.schema.table_def(table_name)?;
-        let user = self.policy_user();
-        let bypass_policy = self.bypasses_policy();
         let rows = self.read_recursive_refs(table_name, root_id, parent_field)?;
         let row_nums = rows
             .iter()
             .map(|row| row_num(&self.conn, &row.id))
             .collect::<Result<Vec<_>>>()?;
         let branch_nums = branch::scope_nums(&self.conn, self.branch_num)?;
-        let mut history = export_visible_table_history(
-            &self.conn,
-            &self.schema,
-            table_name,
-            user,
-            bypass_policy,
-            &branch_nums,
-            Some(&row_nums),
-        )?;
+        let visibility = self.read_visibility();
+        let mut history =
+            export_visible_table_history(&visibility, table_name, &branch_nums, Some(&row_nums))?;
         history.extend(export_deleted_recursive_descendant_history(
             &self.conn,
             &self.schema,
@@ -433,13 +426,10 @@ impl Runtime {
             &row_nums,
         )?);
         history.extend(export_policy_dependency_history(
-            &self.conn,
-            &self.schema,
+            &visibility,
             PolicyDependencyExport {
                 table_name,
                 policy: &self.schema.table_def(table_name)?.read_policy,
-                user,
-                bypass_policy,
                 branch_nums: &branch_nums,
                 child_row_nums: Some(&row_nums),
             },
@@ -454,11 +444,8 @@ impl Runtime {
                     Some(base_epoch),
                 )?);
                 history.extend(export_snapshot_policy_dependency_history(
-                    &self.conn,
-                    &self.schema,
+                    &visibility,
                     table_name,
-                    user,
-                    bypass_policy,
                     base_epoch,
                     Some(&row_nums),
                 )?);
@@ -2698,9 +2685,8 @@ impl Runtime {
         ref_include_fields: &[&str],
     ) -> Result<Bundle> {
         let table = self.schema.table_def(table_name)?;
-        let user = self.policy_user();
-        let bypass_policy = self.bypasses_policy();
         let branch_nums = branch::scope_nums(&self.conn, self.branch_num)?;
+        let visibility = self.read_visibility();
         let mut all_rows = Vec::new();
         let mut visible_row_nums = Vec::new();
         let mut repair_row_nums = Vec::new();
@@ -2776,11 +2762,8 @@ impl Runtime {
         )?;
         if !repair_row_nums.is_empty() {
             history.extend(export_visible_table_history(
-                &self.conn,
-                &self.schema,
+                &visibility,
                 table_name,
-                user,
-                bypass_policy,
                 &branch_nums,
                 Some(&repair_row_nums),
             )?);
@@ -2794,13 +2777,10 @@ impl Runtime {
             )?);
         }
         history.extend(export_policy_dependency_history(
-            &self.conn,
-            &self.schema,
+            &visibility,
             PolicyDependencyExport {
                 table_name,
                 policy: &table.read_policy,
-                user,
-                bypass_policy,
                 branch_nums: &branch_nums,
                 child_row_nums: Some(&row_nums),
             },
@@ -2910,6 +2890,7 @@ impl Runtime {
         row_nums.sort();
         row_nums.dedup();
         let branch_nums = branch::scope_nums(&self.conn, self.branch_num)?;
+        let visibility = self.read_visibility();
         let mut history = export_history_versions_for_rows_in_branches(
             &self.conn,
             &self.schema,
@@ -2920,11 +2901,8 @@ impl Runtime {
         )?;
         if !repair_row_nums.is_empty() {
             history.extend(export_visible_table_history(
-                &self.conn,
-                &self.schema,
+                &visibility,
                 table_name,
-                user,
-                bypass_policy,
                 &branch_nums,
                 Some(&repair_row_nums),
             )?);
@@ -2938,13 +2916,10 @@ impl Runtime {
             )?);
         }
         history.extend(export_policy_dependency_history(
-            &self.conn,
-            &self.schema,
+            &visibility,
             PolicyDependencyExport {
                 table_name,
                 policy: &table.read_policy,
-                user,
-                bypass_policy,
                 branch_nums: &branch_nums,
                 child_row_nums: Some(&row_nums),
             },
@@ -2968,11 +2943,8 @@ impl Runtime {
                     &[1],
                 )?);
                 history.extend(export_snapshot_policy_dependency_history(
-                    &self.conn,
-                    &self.schema,
+                    &visibility,
                     table_name,
-                    user,
-                    bypass_policy,
                     base_epoch,
                     Some(&row_nums),
                 )?);
@@ -3058,8 +3030,6 @@ impl Runtime {
         let read_rows_ms = duration_ms(read_started.elapsed());
 
         let table = self.schema.table_def(table_name)?;
-        let user = self.policy_user();
-        let bypass_policy = self.bypasses_policy();
 
         let resolve_started = Instant::now();
         let visible_row_nums = rows
@@ -3093,6 +3063,7 @@ impl Runtime {
         row_nums.sort();
         row_nums.dedup();
         let branch_nums = branch::scope_nums(&self.conn, self.branch_num)?;
+        let visibility = self.read_visibility();
 
         let visible_history_started = Instant::now();
         let mut history = export_history_versions_for_rows_in_branches(
@@ -3108,11 +3079,8 @@ impl Runtime {
         let repair_visible_started = Instant::now();
         if !repair_row_nums.is_empty() {
             history.extend(export_visible_table_history(
-                &self.conn,
-                &self.schema,
+                &visibility,
                 table_name,
-                user,
-                bypass_policy,
                 &branch_nums,
                 Some(&repair_row_nums),
             )?);
@@ -3134,13 +3102,10 @@ impl Runtime {
 
         let policy_started = Instant::now();
         history.extend(export_policy_dependency_history(
-            &self.conn,
-            &self.schema,
+            &visibility,
             PolicyDependencyExport {
                 table_name,
                 policy: &self.schema.table_def(table_name)?.read_policy,
-                user,
-                bypass_policy,
                 branch_nums: &branch_nums,
                 child_row_nums: Some(&row_nums),
             },
@@ -3159,11 +3124,8 @@ impl Runtime {
                     &[1],
                 )?);
                 history.extend(export_snapshot_policy_dependency_history(
-                    &self.conn,
-                    &self.schema,
+                    &visibility,
                     table_name,
-                    user,
-                    bypass_policy,
                     base_epoch,
                     Some(&row_nums),
                 )?);
@@ -3260,8 +3222,6 @@ impl Runtime {
         ref_field_name: &str,
         branch_nums: &[i64],
     ) -> Result<Vec<HistoryRecord>> {
-        let user = self.policy_user();
-        let bypass_policy = self.bypasses_policy();
         let field = table
             .fields
             .iter()
@@ -3286,12 +3246,10 @@ impl Runtime {
         if ref_row_nums.is_empty() {
             return Ok(Vec::new());
         }
+        let visibility = self.read_visibility();
         let mut history = export_visible_table_history(
-            &self.conn,
-            &self.schema,
+            &visibility,
             ref_table_name,
-            user,
-            bypass_policy,
             branch_nums,
             Some(&ref_row_nums),
         )?;
@@ -3304,13 +3262,10 @@ impl Runtime {
             branch_nums,
         )?);
         history.extend(export_policy_dependency_history(
-            &self.conn,
-            &self.schema,
+            &visibility,
             PolicyDependencyExport {
                 table_name: ref_table_name,
                 policy: &self.schema.table_def(ref_table_name)?.read_policy,
-                user,
-                bypass_policy,
                 branch_nums,
                 child_row_nums: Some(&ref_row_nums),
             },
@@ -3640,6 +3595,16 @@ impl Runtime {
 
     fn query_context(&self) -> query::QueryContext<'_> {
         query::QueryContext {
+            conn: &self.conn,
+            schema: &self.schema,
+            branch_num: self.branch_num,
+            user: self.policy_user(),
+            bypass_policy: self.bypasses_policy(),
+        }
+    }
+
+    fn read_visibility(&self) -> ReadVisibility<'_> {
+        ReadVisibility {
             conn: &self.conn,
             schema: &self.schema,
             branch_num: self.branch_num,
@@ -5457,15 +5422,14 @@ fn export_table_history(
     branch_num: i64,
 ) -> Result<Vec<HistoryRecord>> {
     let branch_nums = branch::scope_nums(conn, branch_num)?;
-    let mut records = export_visible_table_history(
+    let visibility = ReadVisibility {
         conn,
         schema,
-        table_name,
+        branch_num,
         user,
         bypass_policy,
-        &branch_nums,
-        None,
-    )?;
+    };
+    let mut records = export_visible_table_history(&visibility, table_name, &branch_nums, None)?;
     records.extend(export_deleted_table_history(
         conn,
         schema,
@@ -5473,25 +5437,19 @@ fn export_table_history(
         &branch_nums,
     )?);
     records.extend(export_policy_dependency_history(
-        conn,
-        schema,
+        &visibility,
         PolicyDependencyExport {
             table_name,
             policy: &schema.table_def(table_name)?.read_policy,
-            user,
-            bypass_policy,
             branch_nums: &branch_nums,
             child_row_nums: None,
         },
     )?);
     records.extend(export_policy_dependency_history(
-        conn,
-        schema,
+        &visibility,
         PolicyDependencyExport {
             table_name,
             policy: &schema.table_def(table_name)?.write_policy,
-            user,
-            bypass_policy,
             branch_nums: &branch_nums,
             child_row_nums: None,
         },
@@ -5499,12 +5457,9 @@ fn export_table_history(
     if branch_num != 1 {
         if let Some(base_epoch) = branch::base_global_epoch(conn, branch_num)? {
             records.extend(export_main_base_snapshot_history(
-                conn,
-                schema,
+                &visibility,
                 table_name,
                 base_epoch,
-                user,
-                bypass_policy,
             )?);
         }
     }
@@ -5512,55 +5467,14 @@ fn export_table_history(
 }
 
 fn export_main_base_snapshot_history(
-    conn: &Connection,
-    schema: &SchemaDef,
+    visibility: &ReadVisibility<'_>,
     table_name: &str,
     base_epoch: i64,
-    user: &str,
-    bypass_policy: bool,
 ) -> Result<Vec<HistoryRecord>> {
-    let table = schema.table_def(table_name)?;
-    let policy_sql = if bypass_policy {
-        "1 = 1".to_owned()
-    } else {
-        policy::snapshot_read_policy_sql_for_alias(schema, table, "h", user, base_epoch)?
-    };
-    let sql = format!(
-        "SELECT h.row_num
-         FROM {} h
-         JOIN jazz_tx tx ON tx.tx_num = h.tx_num
-         WHERE h.j_branch_num = 1
-           AND tx.outcome != ?
-           AND tx.global_epoch IS NOT NULL
-           AND tx.global_epoch <= ?
-           AND h.op != 3
-           AND {policy_sql}
-           AND NOT EXISTS (
-             SELECT 1
-             FROM {history_table} newer
-             JOIN jazz_tx newer_tx ON newer_tx.tx_num = newer.tx_num
-             WHERE newer.row_num = h.row_num
-               AND newer.j_branch_num = 1
-               AND newer_tx.outcome != ?
-               AND newer_tx.global_epoch IS NOT NULL
-               AND newer_tx.global_epoch <= ?
-               AND (newer_tx.global_epoch > tx.global_epoch OR (newer_tx.global_epoch = tx.global_epoch AND newer_tx.tx_num > tx.tx_num))
-           )",
-        crate::schema::history_table(table_name),
-        history_table = crate::schema::history_table(table_name),
-    );
-    let mut stmt = conn.prepare(&sql)?;
-    let row_nums = stmt
-        .query_map(
-            params![
-                tx::OUTCOME_REJECTED,
-                base_epoch,
-                tx::OUTCOME_REJECTED,
-                base_epoch
-            ],
-            |row| row.get::<_, i64>(0),
-        )?
-        .collect::<std::result::Result<Vec<_>, _>>()?;
+    let conn = visibility.conn;
+    let schema = visibility.schema;
+    let row_nums =
+        visibility.base_snapshot_row_nums_visible_in_branch(table_name, base_epoch, None)?;
     let mut records = export_history_versions_for_rows(
         conn,
         schema,
@@ -5569,11 +5483,8 @@ fn export_main_base_snapshot_history(
         Some(base_epoch),
     )?;
     records.extend(export_snapshot_policy_dependency_history(
-        conn,
-        schema,
+        visibility,
         table_name,
-        user,
-        bypass_policy,
         base_epoch,
         Some(&row_nums),
     )?);
@@ -5581,14 +5492,13 @@ fn export_main_base_snapshot_history(
 }
 
 fn export_snapshot_policy_dependency_history(
-    conn: &Connection,
-    schema: &SchemaDef,
+    visibility: &ReadVisibility<'_>,
     table_name: &str,
-    user: &str,
-    bypass_policy: bool,
     base_epoch: i64,
     child_row_nums: Option<&[i64]>,
 ) -> Result<Vec<HistoryRecord>> {
+    let conn = visibility.conn;
+    let schema = visibility.schema;
     let table = schema.table_def(table_name)?;
     let PolicyDef::RefReadable { field } = &table.read_policy else {
         return Ok(Vec::new());
@@ -5607,11 +5517,7 @@ fn export_snapshot_policy_dependency_history(
             field.name
         )));
     };
-    let policy_sql = if bypass_policy {
-        "1 = 1".to_owned()
-    } else {
-        policy::snapshot_read_policy_sql_for_alias(schema, table, "h", user, base_epoch)?
-    };
+    let policy_sql = visibility.snapshot_policy_sql(table, "h", base_epoch)?;
     let ref_column = crate::schema::quote_ident(&crate::schema::storage_column(field));
     let sql = format!(
         "SELECT DISTINCT h.{ref_column}
@@ -5653,11 +5559,8 @@ fn export_snapshot_policy_dependency_history(
         Some(base_epoch),
     )?;
     records.extend(export_snapshot_policy_dependency_history(
-        conn,
-        schema,
+        visibility,
         parent_table,
-        user,
-        bypass_policy,
         base_epoch,
         Some(&row_nums),
     )?);
@@ -5667,17 +5570,16 @@ fn export_snapshot_policy_dependency_history(
 struct PolicyDependencyExport<'a> {
     table_name: &'a str,
     policy: &'a PolicyDef,
-    user: &'a str,
-    bypass_policy: bool,
     branch_nums: &'a [i64],
     child_row_nums: Option<&'a [i64]>,
 }
 
 fn export_policy_dependency_history(
-    conn: &Connection,
-    schema: &SchemaDef,
+    visibility: &ReadVisibility<'_>,
     args: PolicyDependencyExport<'_>,
 ) -> Result<Vec<HistoryRecord>> {
+    let conn = visibility.conn;
+    let schema = visibility.schema;
     let table = schema.table_def(args.table_name)?;
     let PolicyDef::RefReadable { field } = args.policy else {
         return Ok(Vec::new());
@@ -5699,7 +5601,7 @@ fn export_policy_dependency_history(
     let policy_sql = if args.child_row_nums.is_some() {
         "1 = 1".to_owned()
     } else {
-        export_read_policy_sql(schema, table, args.user, args.bypass_policy)?
+        visibility.current_policy_sql(table, "current")?
     };
     let ref_column = crate::schema::quote_ident(&crate::schema::storage_column(field));
     let row_nums = if let Some(child_row_nums) = args.child_row_nums {
@@ -5732,24 +5634,13 @@ fn export_policy_dependency_history(
     let mut records = if args.child_row_nums.is_some() {
         export_history_versions_for_rows(conn, schema, parent_table, Some(&row_nums), None)?
     } else {
-        export_visible_table_history(
-            conn,
-            schema,
-            parent_table,
-            args.user,
-            args.bypass_policy,
-            args.branch_nums,
-            Some(&row_nums),
-        )?
+        export_visible_table_history(visibility, parent_table, args.branch_nums, Some(&row_nums))?
     };
     records.extend(export_policy_dependency_history(
-        conn,
-        schema,
+        visibility,
         PolicyDependencyExport {
             table_name: parent_table,
             policy: &schema.table_def(parent_table)?.read_policy,
-            user: args.user,
-            bypass_policy: args.bypass_policy,
             branch_nums: args.branch_nums,
             child_row_nums: Some(&row_nums),
         },
@@ -6521,16 +6412,15 @@ fn dedupe_history_records(records: &mut Vec<HistoryRecord>) {
 }
 
 fn export_visible_table_history(
-    conn: &Connection,
-    schema: &SchemaDef,
+    visibility: &ReadVisibility<'_>,
     table_name: &str,
-    user: &str,
-    bypass_policy: bool,
     branch_nums: &[i64],
     row_nums: Option<&[i64]>,
 ) -> Result<Vec<HistoryRecord>> {
+    let conn = visibility.conn;
+    let schema = visibility.schema;
     let table = schema.table_def(table_name)?;
-    let policy_sql = export_read_policy_sql(schema, table, user, bypass_policy)?;
+    let policy_sql = visibility.current_policy_sql(table, "current")?;
     let field_columns = table
         .fields
         .iter()
@@ -6798,19 +6688,6 @@ fn branch_filter_sql(alias: &str, branch_nums: &[i64]) -> String {
 
 fn sql_placeholders(count: usize) -> String {
     (0..count).map(|_| "?").collect::<Vec<_>>().join(", ")
-}
-
-fn export_read_policy_sql(
-    schema: &SchemaDef,
-    table: &crate::schema::TableDef,
-    user: &str,
-    bypass_policy: bool,
-) -> Result<String> {
-    if bypass_policy {
-        Ok("1 = 1".to_owned())
-    } else {
-        policy::read_policy_sql(schema, table, user)
-    }
 }
 
 fn sql_value_to_json(

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -1554,6 +1554,12 @@ impl Runtime {
         //   +-----------------------------+
         //   | page-boundary repair        |
         //   +-----------------------------+
+        //
+        //        | every other SQL-lowered shape
+        //        v
+        //   +-----------------------------+
+        //   | no contraction repair yet   |
+        //   +-----------------------------+
         match built_query_repair_scope(built_query)? {
             BuiltQueryRepairScope::CreatedAtDescPage { condition, limit } => {
                 Self::apply_created_at_desc_page_repair(schema, db, query_read, condition, limit)
@@ -1568,6 +1574,7 @@ impl Runtime {
                 };
                 Self::apply_query_scope_repair(schema, db, &predicate_read)
             }
+            BuiltQueryRepairScope::Unsupported => Ok(()),
         }
     }
 
@@ -1596,17 +1603,8 @@ impl Runtime {
         // This is page-boundary contraction, not authorization. The refreshed
         // top-N rows themselves arrive through normal history application.
         let table = schema.table_def(&query_read.table)?;
-        let field = table
-            .fields
-            .iter()
-            .find(|candidate| candidate.name == condition.column)
-            .ok_or_else(|| {
-                crate::Error::new(format!("unknown query field {}", condition.column))
-            })?;
         let branch_num = branch::checkout(db, &query_read.branch_id)?;
-        let predicate_column = crate::schema::quote_ident(&crate::schema::storage_column(field));
-        let predicate_sql = query_predicate::sql(field, &predicate_column, "eq")?;
-        let predicate_value = query_predicate::value(field, "eq", &condition.value, db)?;
+        let predicate = ordered_page_eq_predicate(table, condition, db)?;
         let limit = i64::try_from(limit)
             .map_err(|_| crate::Error::new("ordered query limit is too large"))?;
         db.execute(
@@ -1618,6 +1616,7 @@ impl Runtime {
                    AND row_num NOT IN (
                      SELECT current.row_num
                      FROM {current_table} current
+                     JOIN jazz_row_id current_ids ON current_ids.row_num = current.row_num
                      JOIN jazz_tx tx ON tx.tx_num = current.visible_tx_num
                      WHERE current.j_branch_num = ?
                        AND current.is_deleted = 0
@@ -1628,15 +1627,15 @@ impl Runtime {
                    )",
                 crate::schema::current_table(&query_read.table),
                 current_table = crate::schema::current_table(&query_read.table),
-                current_predicate_sql =
-                    query_predicate::sql(field, &format!("current.{predicate_column}"), "eq")?,
+                predicate_sql = &predicate.outer_sql,
+                current_predicate_sql = &predicate.inner_sql,
             ),
             params![
                 branch_num,
-                predicate_value.clone(),
+                predicate.value.clone(),
                 branch_num,
                 tx::OUTCOME_REJECTED,
-                predicate_value,
+                predicate.value,
                 limit,
             ],
         )?;
@@ -5936,6 +5935,55 @@ fn export_recursive_scope_repair_history(
     export_history_versions_for_rows(conn, schema, table_name, Some(&row_nums), None)
 }
 
+struct OrderedPageEqPredicate {
+    outer_sql: String,
+    inner_sql: String,
+    value: rusqlite::types::Value,
+}
+
+fn ordered_page_eq_predicate(
+    table: &crate::schema::TableDef,
+    condition: &QueryCondition,
+    db: &Connection,
+) -> Result<OrderedPageEqPredicate> {
+    if condition.column == "id" {
+        let row_id = condition
+            .value
+            .as_str()
+            .ok_or_else(|| crate::Error::new("id equality expects a string value"))?;
+        return Ok(OrderedPageEqPredicate {
+            outer_sql: "row_num IN (SELECT ids.row_num FROM jazz_row_id ids WHERE ids.row_id = ?)"
+                .to_owned(),
+            inner_sql: "current_ids.row_id = ?".to_owned(),
+            value: rusqlite::types::Value::Text(row_id.to_owned()),
+        });
+    }
+
+    if condition.column == "$createdBy" {
+        let created_by = condition
+            .value
+            .as_str()
+            .ok_or_else(|| crate::Error::new("$createdBy equality expects a string value"))?;
+        return Ok(OrderedPageEqPredicate {
+            outer_sql: "j_created_by = ?".to_owned(),
+            inner_sql: "current.j_created_by = ?".to_owned(),
+            value: rusqlite::types::Value::Text(created_by.to_owned()),
+        });
+    }
+
+    let field = table
+        .fields
+        .iter()
+        .find(|candidate| candidate.name == condition.column)
+        .ok_or_else(|| crate::Error::new(format!("unknown query field {}", condition.column)))?;
+    let predicate_column = crate::schema::quote_ident(&crate::schema::storage_column(field));
+    Ok(OrderedPageEqPredicate {
+        outer_sql: query_predicate::sql(field, &predicate_column, "eq")?,
+        inner_sql: query_predicate::sql(field, &format!("current.{predicate_column}"), "eq")?,
+        value: query_predicate::value(field, "eq", &condition.value, db)?,
+    })
+}
+
 fn query_scope_repair_row_nums(
     conn: &Connection,
     table: &crate::schema::TableDef,
@@ -6252,6 +6300,8 @@ fn query_scope_repair_row_nums_for_built_query(
     //       +-- one predicate ------------------------+
     //       |                                         v
     //       +-- eq + createdAt desc + limit --> predicate repair rows
+    //       |
+    //       +-- other SQL-lowered shape ------> exported result/support rows only
     //
     // The ordered-page case exports rows that ever matched the predicate. The
     // receiver then recomputes the actual page boundary locally and deletes any
@@ -6267,6 +6317,7 @@ fn query_scope_repair_row_nums_for_built_query(
             limit: _,
         }
         | BuiltQueryRepairScope::Predicate(condition) => condition,
+        BuiltQueryRepairScope::Unsupported => return Ok(Vec::new()),
     };
     query_scope_repair_row_nums(
         conn,
@@ -6327,17 +6378,17 @@ enum BuiltQueryRepairScope<'a> {
         condition: &'a QueryCondition,
         limit: usize,
     },
+    Unsupported,
 }
 
 fn built_query_repair_scope(query: &BuiltQuery) -> Result<BuiltQueryRepairScope<'_>> {
     if query.conditions.len() != 1 || query.offset.unwrap_or(0) != 0 {
-        return Err(unsupported_built_query_repair_scope());
+        return Ok(BuiltQueryRepairScope::Unsupported);
     }
 
-    let condition = query
-        .conditions
-        .first()
-        .ok_or_else(unsupported_built_query_repair_scope)?;
+    let Some(condition) = query.conditions.first() else {
+        return Ok(BuiltQueryRepairScope::Unsupported);
+    };
 
     match (query.order_by.as_slice(), query.limit) {
         ([], None) => Ok(BuiltQueryRepairScope::Predicate(condition)),
@@ -6348,14 +6399,8 @@ fn built_query_repair_scope(query: &BuiltQuery) -> Result<BuiltQueryRepairScope<
         {
             Ok(BuiltQueryRepairScope::CreatedAtDescPage { condition, limit })
         }
-        _ => Err(unsupported_built_query_repair_scope()),
+        _ => Ok(BuiltQueryRepairScope::Unsupported),
     }
-}
-
-fn unsupported_built_query_repair_scope() -> crate::Error {
-    crate::Error::new(
-        "query read repair supports one predicate, or one eq predicate ordered by $createdAt desc with a limit",
-    )
 }
 
 fn built_query_from_read(read: &QueryReadRecord) -> Result<BuiltQuery> {

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -1,4 +1,6 @@
-use crate::query_api::{predicate_query, BuiltQuery, QueryCondition, QueryConditionOp};
+use crate::query_api::{
+    predicate_query, BuiltQuery, QueryCondition, QueryConditionOp, QueryDirection,
+};
 use crate::rows::{ensure_row_id, ensure_row_id_with_status, public_row_id, row_num};
 use crate::schema::{FieldDef, FieldKind, PolicyDef, SchemaDef};
 use crate::subscription::{RejectionSubscription, RowsSubscription, RowsSubscriptionQuery};
@@ -1552,26 +1554,21 @@ impl Runtime {
         //   +-----------------------------+
         //   | page-boundary repair        |
         //   +-----------------------------+
-        if let Some(query::QueryStoragePlan::EqCreatedAtDescPage { condition, limit }) =
-            query::storage_plan(built_query)
-        {
-            return Self::apply_created_at_desc_page_repair(
-                schema, db, query_read, condition, limit,
-            );
+        match built_query_repair_scope(built_query)? {
+            BuiltQueryRepairScope::CreatedAtDescPage { condition, limit } => {
+                Self::apply_created_at_desc_page_repair(schema, db, query_read, condition, limit)
+            }
+            BuiltQueryRepairScope::Predicate(condition) => {
+                let predicate_read = QueryReadRecord {
+                    branch_id: query_read.branch_id.clone(),
+                    table: built_query.table.clone(),
+                    field: condition.column.clone(),
+                    op: condition.op.as_str().to_owned(),
+                    value: condition.value.clone(),
+                };
+                Self::apply_query_scope_repair(schema, db, &predicate_read)
+            }
         }
-        let Some(condition) = query::query_scope_predicate(built_query)? else {
-            return Err(crate::Error::new(
-                "query read repair supports one predicate, or one eq predicate ordered by $createdAt desc with a limit",
-            ));
-        };
-        let predicate_read = QueryReadRecord {
-            branch_id: query_read.branch_id.clone(),
-            table: built_query.table.clone(),
-            field: condition.column.clone(),
-            op: condition.op.as_str().to_owned(),
-            value: condition.value.clone(),
-        };
-        Self::apply_query_scope_repair(schema, db, &predicate_read)
     }
 
     fn apply_created_at_desc_page_repair(
@@ -6264,23 +6261,12 @@ fn query_scope_repair_row_nums_for_built_query(
             "query read table does not match descriptor",
         ));
     }
-    if let Some(query::QueryStoragePlan::EqCreatedAtDescPage {
-        condition,
-        limit: _,
-    }) = query::storage_plan(built_query)
-    {
-        return query_scope_repair_row_nums(
-            conn,
-            table,
-            &condition.column,
-            condition.op.as_str(),
-            &condition.value,
-        );
-    }
-    let Some(condition) = query::query_scope_predicate(built_query)? else {
-        return Err(crate::Error::new(
-            "query read repair supports one predicate, or one eq predicate ordered by $createdAt desc with a limit",
-        ));
+    let condition = match built_query_repair_scope(built_query)? {
+        BuiltQueryRepairScope::CreatedAtDescPage {
+            condition,
+            limit: _,
+        }
+        | BuiltQueryRepairScope::Predicate(condition) => condition,
     };
     query_scope_repair_row_nums(
         conn,
@@ -6319,23 +6305,12 @@ fn query_scope_rejected_tx_ids_for_built_query(
             "query read table does not match descriptor",
         ));
     }
-    if let Some(query::QueryStoragePlan::EqCreatedAtDescPage {
-        condition,
-        limit: _,
-    }) = query::storage_plan(built_query)
-    {
-        return query_scope_rejected_tx_ids(
-            conn,
-            table,
-            &condition.column,
-            condition.op.as_str(),
-            &condition.value,
-        );
-    }
-    let Some(condition) = query::query_scope_predicate(built_query)? else {
-        return Err(crate::Error::new(
-            "query read rejection tracking supports one predicate, or one eq predicate ordered by $createdAt desc with a limit",
-        ));
+    let condition = match built_query_repair_scope(built_query)? {
+        BuiltQueryRepairScope::CreatedAtDescPage {
+            condition,
+            limit: _,
+        }
+        | BuiltQueryRepairScope::Predicate(condition) => condition,
     };
     query_scope_rejected_tx_ids(
         conn,
@@ -6343,6 +6318,43 @@ fn query_scope_rejected_tx_ids_for_built_query(
         &condition.column,
         condition.op.as_str(),
         &condition.value,
+    )
+}
+
+enum BuiltQueryRepairScope<'a> {
+    Predicate(&'a QueryCondition),
+    CreatedAtDescPage {
+        condition: &'a QueryCondition,
+        limit: usize,
+    },
+}
+
+fn built_query_repair_scope(query: &BuiltQuery) -> Result<BuiltQueryRepairScope<'_>> {
+    if query.conditions.len() != 1 || query.offset.unwrap_or(0) != 0 {
+        return Err(unsupported_built_query_repair_scope());
+    }
+
+    let condition = query
+        .conditions
+        .first()
+        .ok_or_else(unsupported_built_query_repair_scope)?;
+
+    match (query.order_by.as_slice(), query.limit) {
+        ([], None) => Ok(BuiltQueryRepairScope::Predicate(condition)),
+        ([order], Some(limit))
+            if condition.op == QueryConditionOp::Eq
+                && order.column == "$createdAt"
+                && order.direction == QueryDirection::Desc =>
+        {
+            Ok(BuiltQueryRepairScope::CreatedAtDescPage { condition, limit })
+        }
+        _ => Err(unsupported_built_query_repair_scope()),
+    }
+}
+
+fn unsupported_built_query_repair_scope() -> crate::Error {
+    crate::Error::new(
+        "query read repair supports one predicate, or one eq predicate ordered by $createdAt desc with a limit",
     )
 }
 

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -1504,7 +1504,7 @@ impl Runtime {
                 schema, db, query_read, condition, limit,
             );
         }
-        let Some(condition) = built_query.single_predicate_export_condition()? else {
+        let Some(condition) = query::query_scope_predicate(built_query)? else {
             return Err(crate::Error::new(
                 "query read repair supports one predicate, or one eq predicate ordered by $createdAt desc with a limit",
             ));
@@ -6164,7 +6164,7 @@ fn query_scope_repair_row_nums_for_built_query(
             &condition.value,
         );
     }
-    let Some(condition) = built_query.single_predicate_export_condition()? else {
+    let Some(condition) = query::query_scope_predicate(built_query)? else {
         return Err(crate::Error::new(
             "query read repair supports one predicate, or one eq predicate ordered by $createdAt desc with a limit",
         ));

--- a/crates/mini-jazz-sqlite/src/schema.rs
+++ b/crates/mini-jazz-sqlite/src/schema.rs
@@ -563,17 +563,19 @@ fn install_table(conn: &Connection, table: &TableDef) -> Result<()> {
     ))?;
 
     for index in &table.indexes {
-        let columns = index
-            .columns
-            .iter()
-            .map(|column| storage_column_name(column))
-            .collect::<Vec<_>>()
-            .join(", ");
+        let mut columns = vec!["j_branch_num".to_owned(), "is_deleted".to_owned()];
+        columns.extend(
+            index
+                .columns
+                .iter()
+                .map(|column| index_storage_column_name(column)),
+        );
+        columns.push("row_num".to_owned());
         conn.execute_batch(&format!(
-            "CREATE INDEX IF NOT EXISTS {} ON {}(is_deleted, {});",
-            quote_ident(&format!("{}_current_{}", table.name, index.name)),
+            "CREATE INDEX IF NOT EXISTS {} ON {}({});",
+            quote_ident(&format!("{}_current_{}_v2", table.name, index.name)),
             current_table(&table.name),
-            columns
+            columns.join(", ")
         ))?;
     }
     Ok(())
@@ -655,6 +657,13 @@ pub(crate) fn storage_column_name(column: &str) -> String {
     quote_ident(&storage)
 }
 
+fn index_storage_column_name(column: &str) -> String {
+    match column {
+        "$createdAt" => format!("{} DESC", quote_ident("j_created_at")),
+        other => storage_column_name(other),
+    }
+}
+
 fn user_storage_name(name: &str) -> String {
     if name.starts_with("j_") {
         format!("u_{name}")
@@ -676,4 +685,29 @@ fn sql_type(kind: &FieldKind) -> &'static str {
 
 pub(crate) fn quote_ident(ident: &str) -> String {
     format!("\"{}\"", ident.replace('"', "\"\""))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{storage, Storage};
+
+    #[test]
+    fn current_index_for_created_at_page_queries_matches_query_order() -> Result<()> {
+        let schema = SchemaDef::attempt3_fixture();
+        let conn = storage::open(Storage::Memory)?;
+        install(&conn, &schema)?;
+
+        let sql: String = conn.query_row(
+            "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'todos_current_open_created_v2'",
+            [],
+            |row| row.get(0),
+        )?;
+
+        assert_eq!(
+            sql,
+            "CREATE INDEX \"todos_current_open_created_v2\" ON \"todos__schema_v1_current\"(j_branch_num, is_deleted, \"done\", \"j_created_at\" DESC, row_num)"
+        );
+        Ok(())
+    }
 }

--- a/crates/mini-jazz-sqlite/src/schema.rs
+++ b/crates/mini-jazz-sqlite/src/schema.rs
@@ -25,6 +25,8 @@ impl SchemaDef {
                 table.bool("done");
                 table.ref_("project", "projects");
                 table.index("open_created", ["done", "$createdAt"]);
+                table.index("created", ["$createdAt"]);
+                table.index("by_title", ["title"]);
             })
             .table("labels", |table| {
                 table.text("name");
@@ -708,15 +710,33 @@ mod tests {
         let conn = storage::open(Storage::Memory)?;
         install(&conn, &schema)?;
 
-        let sql: String = conn.query_row(
+        let open_created_sql: String = conn.query_row(
             "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'todos_current_open_created_v2'",
+            [],
+            |row| row.get(0),
+        )?;
+        let created_sql: String = conn.query_row(
+            "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'todos_current_created_v2'",
+            [],
+            |row| row.get(0),
+        )?;
+        let title_sql: String = conn.query_row(
+            "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'todos_current_by_title_v2'",
             [],
             |row| row.get(0),
         )?;
 
         assert_eq!(
-            sql,
+            open_created_sql,
             "CREATE INDEX \"todos_current_open_created_v2\" ON \"todos__schema_v1_current\"(j_branch_num, is_deleted, \"done\", \"j_created_at\" DESC, row_num)"
+        );
+        assert_eq!(
+            created_sql,
+            "CREATE INDEX \"todos_current_created_v2\" ON \"todos__schema_v1_current\"(j_branch_num, is_deleted, \"j_created_at\" DESC, row_num)"
+        );
+        assert_eq!(
+            title_sql,
+            "CREATE INDEX \"todos_current_by_title_v2\" ON \"todos__schema_v1_current\"(j_branch_num, is_deleted, \"title\", row_num)"
         );
         Ok(())
     }

--- a/crates/mini-jazz-sqlite/src/schema.rs
+++ b/crates/mini-jazz-sqlite/src/schema.rs
@@ -26,6 +26,16 @@ impl SchemaDef {
                 table.ref_("project", "projects");
                 table.index("open_created", ["done", "$createdAt"]);
             })
+            .table("labels", |table| {
+                table.text("name");
+                table.index("by_name", ["name"]);
+            })
+            .table("todo_labels", |table| {
+                table.ref_("todo", "todos");
+                table.ref_("label", "labels");
+                table.index("by_todo", ["todo"]);
+                table.index("by_label", ["label"]);
+            })
     }
 
     pub fn table(mut self, name: &str, build: impl FnOnce(&mut TableBuilder)) -> Self {

--- a/crates/mini-jazz-sqlite/src/subscription.rs
+++ b/crates/mini-jazz-sqlite/src/subscription.rs
@@ -264,11 +264,17 @@ fn indexed_delta(before: &[RowView], after: &[RowView]) -> Vec<SubscriptionRowDe
     for (id, (before_index, before_row)) in &before {
         match after.get(id) {
             Some((after_index, after_row)) => {
-                if before_index != after_index || before_row != after_row {
+                if before_row != after_row {
                     delta.push(SubscriptionRowDelta::Updated {
                         id: (*id).to_owned(),
                         index: *after_index,
-                        item: (before_row != after_row).then(|| (*after_row).clone()),
+                        item: Some((*after_row).clone()),
+                    });
+                } else if before_index != after_index {
+                    delta.push(SubscriptionRowDelta::Moved {
+                        id: (*id).to_owned(),
+                        previous_index: *before_index,
+                        index: *after_index,
                     });
                 }
             }
@@ -334,6 +340,43 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["second", "first"]
         );
+    }
+
+    #[test]
+    fn subscription_delta_serializes_added_and_updated_payloads_as_row() {
+        let first = row("first");
+        let mut subscription = RowsSubscription::new("items", vec![first.clone()]);
+
+        let initial = serde_json::to_value(subscription.initial_delta()).unwrap();
+        assert_eq!(initial["delta"][0]["row"], json!(first));
+        assert!(initial["delta"][0].get("item").is_none());
+
+        let mut changed = first.clone();
+        changed.values.insert("name".to_owned(), json!("updated"));
+        let update = serde_json::to_value(
+            subscription.replace_with_subscription_delta(vec![changed.clone()]),
+        )
+        .unwrap();
+        assert_eq!(update["delta"][0]["row"], json!(changed));
+        assert!(update["delta"][0].get("item").is_none());
+    }
+
+    #[test]
+    fn subscription_delta_serializes_order_only_changes_as_moved() {
+        let first = row("first");
+        let second = row("second");
+        let mut subscription = RowsSubscription::new("items", vec![first, second]);
+
+        let delta = serde_json::to_value(
+            subscription.replace_with_subscription_delta(vec![row("second"), row("first")]),
+        )
+        .unwrap();
+
+        assert_eq!(delta["delta"][0]["kind"], json!(3));
+        assert_eq!(delta["delta"][0]["id"], json!("second"));
+        assert_eq!(delta["delta"][0]["index"], json!(0));
+        assert_eq!(delta["delta"][0]["previousIndex"], json!(1));
+        assert!(delta["delta"][0].get("row").is_none());
     }
 
     fn row(id: &str) -> RowView {

--- a/crates/mini-jazz-sqlite/src/subscription.rs
+++ b/crates/mini-jazz-sqlite/src/subscription.rs
@@ -101,27 +101,6 @@ impl RowsSubscription {
         }
     }
 
-    pub(crate) fn where_eq_top_created_at_desc(
-        table: &str,
-        field: &str,
-        value: JsonValue,
-        limit: usize,
-        rows: Vec<RowView>,
-    ) -> Self {
-        Self {
-            query: RowsSubscriptionQuery::Predicate(QueryPredicateRecord::new(
-                table,
-                field,
-                "eq_top_created_at_desc",
-                serde_json::json!({
-                    "eq": value,
-                    "limit": limit,
-                }),
-            )),
-            last_rows: rows,
-        }
-    }
-
     pub(crate) fn where_eq_top_field_desc(
         table: &str,
         field: &str,

--- a/crates/mini-jazz-sqlite/src/subscription.rs
+++ b/crates/mini-jazz-sqlite/src/subscription.rs
@@ -1,5 +1,6 @@
+use crate::query_api::BuiltQuery;
 use crate::sync::QueryPredicateRecord;
-use crate::types::{RejectionInfo, RowDiff, RowView};
+use crate::types::{RejectionInfo, RowDiff, RowView, SubscriptionDelta, SubscriptionRowDelta};
 use serde_json::Value as JsonValue;
 use std::collections::BTreeMap;
 
@@ -18,6 +19,7 @@ pub struct RejectionSubscription {
 pub(crate) enum RowsSubscriptionQuery {
     Table { table: String },
     Predicate(QueryPredicateRecord),
+    Built(BuiltQuery),
 }
 
 impl RowsSubscription {
@@ -143,8 +145,19 @@ impl RowsSubscription {
         }
     }
 
+    pub(crate) fn query(query: BuiltQuery, rows: Vec<RowView>) -> Self {
+        Self {
+            query: RowsSubscriptionQuery::Built(query),
+            last_rows: rows,
+        }
+    }
+
     pub fn initial_rows(&self) -> &[RowView] {
         &self.last_rows
+    }
+
+    pub fn initial_delta(&self) -> SubscriptionDelta {
+        SubscriptionDelta::initial(self.last_rows.clone())
     }
 
     pub(crate) fn replace_with_diff(&mut self, next_rows: Vec<RowView>) -> Vec<RowDiff> {
@@ -197,6 +210,18 @@ impl RowsSubscription {
         self.last_rows = next_rows;
         diffs
     }
+
+    pub(crate) fn replace_with_subscription_delta(
+        &mut self,
+        next_rows: Vec<RowView>,
+    ) -> SubscriptionDelta {
+        let delta = indexed_delta(&self.last_rows, &next_rows);
+        self.last_rows = next_rows;
+        SubscriptionDelta {
+            all: self.last_rows.clone(),
+            delta,
+        }
+    }
 }
 
 impl RejectionSubscription {
@@ -242,6 +267,56 @@ fn positions_by_id(rows: &[RowView]) -> BTreeMap<String, usize> {
         .enumerate()
         .map(|(index, row)| (row.id.clone(), index))
         .collect()
+}
+
+fn indexed_delta(before: &[RowView], after: &[RowView]) -> Vec<SubscriptionRowDelta> {
+    let before = before
+        .iter()
+        .enumerate()
+        .map(|(index, row)| (row.id.as_str(), (index, row)))
+        .collect::<BTreeMap<_, _>>();
+    let after = after
+        .iter()
+        .enumerate()
+        .map(|(index, row)| (row.id.as_str(), (index, row)))
+        .collect::<BTreeMap<_, _>>();
+    let mut delta = Vec::new();
+
+    for (id, (before_index, before_row)) in &before {
+        match after.get(id) {
+            Some((after_index, after_row)) => {
+                if before_index != after_index || before_row != after_row {
+                    delta.push(SubscriptionRowDelta::Updated {
+                        id: (*id).to_owned(),
+                        index: *after_index,
+                        item: (before_row != after_row).then(|| (*after_row).clone()),
+                    });
+                }
+            }
+            None => delta.push(SubscriptionRowDelta::Removed {
+                id: (*id).to_owned(),
+                index: *before_index,
+            }),
+        }
+    }
+
+    for (id, (after_index, after_row)) in &after {
+        if !before.contains_key(id) {
+            delta.push(SubscriptionRowDelta::Added {
+                id: (*id).to_owned(),
+                index: *after_index,
+                item: (*after_row).clone(),
+            });
+        }
+    }
+
+    delta.sort_by(|left, right| {
+        left.index()
+            .cmp(&right.index())
+            .then(left.kind().cmp(&right.kind()))
+            .then(left.id().cmp(right.id()))
+    });
+    delta
 }
 
 #[cfg(test)]

--- a/crates/mini-jazz-sqlite/src/subscription.rs
+++ b/crates/mini-jazz-sqlite/src/subscription.rs
@@ -362,7 +362,7 @@ mod tests {
     }
 
     #[test]
-    fn subscription_delta_serializes_order_only_changes_as_moved() {
+    fn subscription_delta_serializes_order_only_changes_as_update_without_row() {
         let first = row("first");
         let second = row("second");
         let mut subscription = RowsSubscription::new("items", vec![first, second]);
@@ -372,11 +372,11 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(delta["delta"][0]["kind"], json!(3));
+        assert_eq!(delta["delta"][0]["kind"], json!(2));
         assert_eq!(delta["delta"][0]["id"], json!("second"));
         assert_eq!(delta["delta"][0]["index"], json!(0));
-        assert_eq!(delta["delta"][0]["previousIndex"], json!(1));
         assert!(delta["delta"][0].get("row").is_none());
+        assert!(delta["delta"][0].get("previousIndex").is_none());
     }
 
     fn row(id: &str) -> RowView {

--- a/crates/mini-jazz-sqlite/src/types.rs
+++ b/crates/mini-jazz-sqlite/src/types.rs
@@ -78,8 +78,7 @@ impl SubscriptionRowDelta {
         match self {
             Self::Added { .. } => 0,
             Self::Removed { .. } => 1,
-            Self::Updated { .. } => 2,
-            Self::Moved { .. } => 3,
+            Self::Updated { .. } | Self::Moved { .. } => 2,
         }
     }
 
@@ -136,13 +135,12 @@ impl Serialize for SubscriptionRowDelta {
             }
             SubscriptionRowDelta::Moved {
                 id,
-                previous_index,
                 index,
+                previous_index: _,
             } => {
-                let mut state = serializer.serialize_struct("SubscriptionRowDelta", 4)?;
-                state.serialize_field("kind", &3_u8)?;
+                let mut state = serializer.serialize_struct("SubscriptionRowDelta", 3)?;
+                state.serialize_field("kind", &2_u8)?;
                 state.serialize_field("id", id)?;
-                state.serialize_field("previousIndex", previous_index)?;
                 state.serialize_field("index", index)?;
                 state.end()
             }

--- a/crates/mini-jazz-sqlite/src/types.rs
+++ b/crates/mini-jazz-sqlite/src/types.rs
@@ -51,6 +51,11 @@ pub enum SubscriptionRowDelta {
         index: usize,
         item: Option<RowView>,
     },
+    Moved {
+        id: String,
+        previous_index: usize,
+        index: usize,
+    },
 }
 
 impl SubscriptionDelta {
@@ -74,12 +79,16 @@ impl SubscriptionRowDelta {
             Self::Added { .. } => 0,
             Self::Removed { .. } => 1,
             Self::Updated { .. } => 2,
+            Self::Moved { .. } => 3,
         }
     }
 
     pub fn id(&self) -> &str {
         match self {
-            Self::Added { id, .. } | Self::Removed { id, .. } | Self::Updated { id, .. } => id,
+            Self::Added { id, .. }
+            | Self::Removed { id, .. }
+            | Self::Updated { id, .. }
+            | Self::Moved { id, .. } => id,
         }
     }
 
@@ -87,7 +96,8 @@ impl SubscriptionRowDelta {
         match self {
             Self::Added { index, .. }
             | Self::Removed { index, .. }
-            | Self::Updated { index, .. } => *index,
+            | Self::Updated { index, .. }
+            | Self::Moved { index, .. } => *index,
         }
     }
 }
@@ -103,7 +113,7 @@ impl Serialize for SubscriptionRowDelta {
                 state.serialize_field("kind", &0_u8)?;
                 state.serialize_field("id", id)?;
                 state.serialize_field("index", index)?;
-                state.serialize_field("item", item)?;
+                state.serialize_field("row", item)?;
                 state.end()
             }
             SubscriptionRowDelta::Removed { id, index } => {
@@ -120,8 +130,20 @@ impl Serialize for SubscriptionRowDelta {
                 state.serialize_field("id", id)?;
                 state.serialize_field("index", index)?;
                 if let Some(item) = item {
-                    state.serialize_field("item", item)?;
+                    state.serialize_field("row", item)?;
                 }
+                state.end()
+            }
+            SubscriptionRowDelta::Moved {
+                id,
+                previous_index,
+                index,
+            } => {
+                let mut state = serializer.serialize_struct("SubscriptionRowDelta", 4)?;
+                state.serialize_field("kind", &3_u8)?;
+                state.serialize_field("id", id)?;
+                state.serialize_field("previousIndex", previous_index)?;
+                state.serialize_field("index", index)?;
                 state.end()
             }
         }

--- a/crates/mini-jazz-sqlite/src/types.rs
+++ b/crates/mini-jazz-sqlite/src/types.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
-use serde::Serialize;
+use serde::ser::SerializeStruct;
+use serde::{Serialize, Serializer};
 use serde_json::Value as JsonValue;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
@@ -26,6 +27,105 @@ pub enum RowDiff {
         after_index: usize,
     },
     Removed(RowView),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct SubscriptionDelta {
+    pub all: Vec<RowView>,
+    pub delta: Vec<SubscriptionRowDelta>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SubscriptionRowDelta {
+    Added {
+        id: String,
+        index: usize,
+        item: RowView,
+    },
+    Removed {
+        id: String,
+        index: usize,
+    },
+    Updated {
+        id: String,
+        index: usize,
+        item: Option<RowView>,
+    },
+}
+
+impl SubscriptionDelta {
+    pub fn initial(all: Vec<RowView>) -> Self {
+        let delta = all
+            .iter()
+            .enumerate()
+            .map(|(index, row)| SubscriptionRowDelta::Added {
+                id: row.id.clone(),
+                index,
+                item: row.clone(),
+            })
+            .collect();
+        Self { all, delta }
+    }
+}
+
+impl SubscriptionRowDelta {
+    pub fn kind(&self) -> u8 {
+        match self {
+            Self::Added { .. } => 0,
+            Self::Removed { .. } => 1,
+            Self::Updated { .. } => 2,
+        }
+    }
+
+    pub fn id(&self) -> &str {
+        match self {
+            Self::Added { id, .. } | Self::Removed { id, .. } | Self::Updated { id, .. } => id,
+        }
+    }
+
+    pub fn index(&self) -> usize {
+        match self {
+            Self::Added { index, .. }
+            | Self::Removed { index, .. }
+            | Self::Updated { index, .. } => *index,
+        }
+    }
+}
+
+impl Serialize for SubscriptionRowDelta {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            SubscriptionRowDelta::Added { id, index, item } => {
+                let mut state = serializer.serialize_struct("SubscriptionRowDelta", 4)?;
+                state.serialize_field("kind", &0_u8)?;
+                state.serialize_field("id", id)?;
+                state.serialize_field("index", index)?;
+                state.serialize_field("item", item)?;
+                state.end()
+            }
+            SubscriptionRowDelta::Removed { id, index } => {
+                let mut state = serializer.serialize_struct("SubscriptionRowDelta", 3)?;
+                state.serialize_field("kind", &1_u8)?;
+                state.serialize_field("id", id)?;
+                state.serialize_field("index", index)?;
+                state.end()
+            }
+            SubscriptionRowDelta::Updated { id, index, item } => {
+                let field_count = if item.is_some() { 4 } else { 3 };
+                let mut state = serializer.serialize_struct("SubscriptionRowDelta", field_count)?;
+                state.serialize_field("kind", &2_u8)?;
+                state.serialize_field("id", id)?;
+                state.serialize_field("index", index)?;
+                if let Some(item) = item {
+                    state.serialize_field("item", item)?;
+                }
+                state.end()
+            }
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]

--- a/crates/mini-jazz-sqlite/tests/support/mod.rs
+++ b/crates/mini-jazz-sqlite/tests/support/mod.rs
@@ -496,6 +496,14 @@ pub fn notes_schema() -> SchemaDef {
     })
 }
 
+pub fn eq_query(table: &str, field: &str, value: JsonValue) -> BuiltQuery {
+    BuiltQuery::from_json_value(json!({
+        "table": table,
+        "conditions": [{"column": field, "op": "eq", "value": value}],
+    }))
+    .unwrap()
+}
+
 pub fn top_created_query(table: &str, field: &str, value: JsonValue, limit: usize) -> BuiltQuery {
     BuiltQuery::from_json_value(json!({
         "table": table,

--- a/crates/mini-jazz-sqlite/tests/support/mod.rs
+++ b/crates/mini-jazz-sqlite/tests/support/mod.rs
@@ -1,5 +1,5 @@
 use mini_jazz_sqlite::sync::{Bundle, QueryReadRecord};
-use mini_jazz_sqlite::{Result, RowView, Runtime, SchemaDef, Storage};
+use mini_jazz_sqlite::{BuiltQuery, Result, RowView, Runtime, SchemaDef, Storage};
 use serde_json::json;
 use serde_json::Value as JsonValue;
 use std::collections::BTreeMap;
@@ -366,12 +366,12 @@ impl FixtureRuntimeExt for Runtime {
     }
 
     fn newest_open_todos(&self, limit: usize) -> Result<Vec<TodoView>> {
-        let todos = self.read_rows_where_eq_top_created_at_desc(
+        let todos = self.query(top_created_query(
             "todos",
             "done",
             JsonValue::Bool(false),
             limit,
-        )?;
+        ))?;
         open_todo_rows_with_sort(todos, self.read_rows("projects")?, false)
     }
 
@@ -389,12 +389,9 @@ impl FixtureRuntimeExt for Runtime {
 
     fn export_query_scope_newest_open_todos(&self, limit: usize) -> Result<Bundle> {
         let todos = self.newest_open_todos(limit)?;
-        let mut bundle = self.export_query_where_eq_top_created_at_desc_with_ref_include(
-            "todos",
-            "done",
-            JsonValue::Bool(false),
-            limit,
-            "project",
+        let mut bundle = self.export_query_with_ref_includes(
+            top_created_query("todos", "done", JsonValue::Bool(false), limit),
+            &["project"],
         )?;
         extend_with_project_scope(self, &mut bundle, &todos)?;
         Ok(bundle)
@@ -497,6 +494,16 @@ pub fn notes_schema() -> SchemaDef {
         table.text("body");
         table.bool("pinned");
     })
+}
+
+pub fn top_created_query(table: &str, field: &str, value: JsonValue, limit: usize) -> BuiltQuery {
+    BuiltQuery::from_json_value(json!({
+        "table": table,
+        "conditions": [{"column": field, "op": "eq", "value": value}],
+        "orderBy": [["$createdAt", "desc"]],
+        "limit": limit,
+    }))
+    .unwrap()
 }
 
 pub fn folders_schema() -> SchemaDef {

--- a/crates/mini-jazz-sqlite/tests/whole_system.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system.rs
@@ -14,6 +14,8 @@ mod branches;
 mod generic_schema;
 #[path = "whole_system/policies.rs"]
 mod policies;
+#[path = "whole_system/query_matrix.rs"]
+mod query_matrix;
 #[path = "whole_system/recursive_queries.rs"]
 mod recursive_queries;
 #[path = "whole_system/schema_lenses.rs"]

--- a/crates/mini-jazz-sqlite/tests/whole_system.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system.rs
@@ -1,4 +1,6 @@
-use mini_jazz_sqlite::{RejectionInfo, RowDiff, Runtime, SchemaDef, Storage};
+use mini_jazz_sqlite::{
+    BuiltQuery, RejectionInfo, RowDiff, Runtime, SchemaDef, Storage, SubscriptionRowDelta,
+};
 use serde_json::json;
 use std::collections::BTreeMap;
 use tempfile::tempdir;

--- a/crates/mini-jazz-sqlite/tests/whole_system/branches.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/branches.rs
@@ -303,7 +303,7 @@ fn branch_query_scope_refresh_removes_base_row_shadowed_by_branch_overlay() {
     .unwrap();
     peer.checkout_branch("draft").unwrap();
     assert_eq!(
-        peer.read_rows_where_eq("tasks", "done", json!(false))
+        peer.query(support::eq_query("tasks", "done", json!(false)))
             .unwrap()
             .len(),
         1
@@ -327,7 +327,7 @@ fn branch_query_scope_refresh_removes_base_row_shadowed_by_branch_overlay() {
     .unwrap();
 
     assert!(peer
-        .read_rows_where_eq("tasks", "done", json!(false))
+        .query(support::eq_query("tasks", "done", json!(false)))
         .unwrap()
         .is_empty());
 }
@@ -372,7 +372,7 @@ fn durable_branch_query_read_refreshes_after_restart() {
         worker.checkout_branch("draft").unwrap();
         assert_eq!(
             worker
-                .read_rows_where_eq("tasks", "done", json!(false))
+                .query(support::eq_query("tasks", "done", json!(false)))
                 .unwrap()
                 .len(),
             1
@@ -407,7 +407,7 @@ fn durable_branch_query_read_refreshes_after_restart() {
     }
 
     assert!(reopened
-        .read_rows_where_eq("tasks", "done", json!(false))
+        .query(support::eq_query("tasks", "done", json!(false)))
         .unwrap()
         .is_empty());
 }
@@ -1134,7 +1134,7 @@ fn branch_equality_query_uses_effective_branch_policy() {
     alice.session_user_for_test("alice");
 
     assert!(alice
-        .read_rows_where_eq("todos", "title", json!("Find me"))
+        .query(support::eq_query("todos", "title", json!("Find me")))
         .unwrap()
         .is_empty());
 }
@@ -1302,8 +1302,11 @@ fn branch_conflict_metadata_surfaces_through_filtered_query() {
     alice.checkout_branch("merge").unwrap();
 
     let rows = alice
-        .read_rows_where_eq_with_conflict_meta("tasks", "title", json!("Shared title"))
-        .unwrap();
+        .read_rows_with_conflict_meta("tasks")
+        .unwrap()
+        .into_iter()
+        .filter(|row| row.values.get("title") == Some(&json!("Shared title")))
+        .collect::<Vec<_>>();
     assert_eq!(rows.len(), 2);
     assert!(rows.iter().all(|row| row.id == "task-1"));
     assert!(rows.iter().all(|row| row.conflict_count == 2));
@@ -1871,7 +1874,7 @@ fn branch_observed_query_refresh_includes_later_source_branch_rows() {
     peer.apply_bundle(&initial).unwrap();
     peer.checkout_branch("merge").unwrap();
     assert!(peer
-        .read_rows_where_eq("tasks", "done", json!(false))
+        .query(support::eq_query("tasks", "done", json!(false)))
         .unwrap()
         .is_empty());
 
@@ -1896,7 +1899,7 @@ fn branch_observed_query_refresh_includes_later_source_branch_rows() {
     }
 
     let rows = peer
-        .read_rows_where_eq("tasks", "done", json!(false))
+        .query(support::eq_query("tasks", "done", json!(false)))
         .unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].id, "task-left");
@@ -1947,7 +1950,7 @@ fn branch_observed_query_refresh_includes_newly_added_source_branch() {
     .unwrap();
     peer.checkout_branch("merge").unwrap();
     assert!(peer
-        .read_rows_where_eq("tasks", "done", json!(false))
+        .query(support::eq_query("tasks", "done", json!(false)))
         .unwrap()
         .is_empty());
 
@@ -1960,7 +1963,7 @@ fn branch_observed_query_refresh_includes_newly_added_source_branch() {
     }
 
     let rows = peer
-        .read_rows_where_eq("tasks", "done", json!(false))
+        .query(support::eq_query("tasks", "done", json!(false)))
         .unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].id, "task-left");
@@ -2009,7 +2012,7 @@ fn branch_observed_query_refresh_removes_detached_source_branch_rows() {
     .unwrap();
     peer.checkout_branch("merge").unwrap();
     assert_eq!(
-        peer.read_rows_where_eq("tasks", "done", json!(false))
+        peer.query(support::eq_query("tasks", "done", json!(false)))
             .unwrap()
             .len(),
         1
@@ -2024,7 +2027,7 @@ fn branch_observed_query_refresh_removes_detached_source_branch_rows() {
     }
 
     assert!(peer
-        .read_rows_where_eq("tasks", "done", json!(false))
+        .query(support::eq_query("tasks", "done", json!(false)))
         .unwrap()
         .is_empty());
     let merge = peer
@@ -2144,7 +2147,7 @@ fn durable_branch_source_removal_survives_reopen() {
         worker.checkout_branch("merge").unwrap();
         assert_eq!(
             worker
-                .read_rows_where_eq("tasks", "done", json!(false))
+                .query(support::eq_query("tasks", "done", json!(false)))
                 .unwrap()
                 .len(),
             1
@@ -2163,7 +2166,7 @@ fn durable_branch_source_removal_survives_reopen() {
     }
 
     assert!(reopened
-        .read_rows_where_eq("tasks", "done", json!(false))
+        .query(support::eq_query("tasks", "done", json!(false)))
         .unwrap()
         .is_empty());
     let merge = reopened
@@ -2555,7 +2558,7 @@ fn durable_merge_branch_refresh_preserves_pinned_source_branch_bases_after_resta
             .unwrap();
         worker.checkout_branch("merge").unwrap();
         assert!(worker
-            .read_rows_where_eq("tasks", "done", json!(false))
+            .query(support::eq_query("tasks", "done", json!(false)))
             .unwrap()
             .is_empty());
     }
@@ -2587,7 +2590,7 @@ fn durable_merge_branch_refresh_preserves_pinned_source_branch_bases_after_resta
     reopened.checkout_branch("merge").unwrap();
 
     let rows = reopened
-        .read_rows_where_eq("tasks", "done", json!(false))
+        .query(support::eq_query("tasks", "done", json!(false)))
         .unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].id, "task-left");

--- a/crates/mini-jazz-sqlite/tests/whole_system/branches.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/branches.rs
@@ -460,6 +460,131 @@ fn branch_scoped_export_excludes_unrelated_branch_rows() {
 }
 
 #[test]
+fn branch_scoped_built_query_export_excludes_unrelated_branch_repair_rows() {
+    let schema = SchemaDef::new().table("tasks", |table| {
+        table.text("title");
+        table.bool("done");
+    });
+    let mut alice =
+        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema).unwrap();
+
+    alice.create_branch("draft", None).unwrap();
+    alice.checkout_branch("draft").unwrap();
+    alice
+        .insert_row(
+            "tasks",
+            "task-draft",
+            BTreeMap::from([
+                ("title".to_owned(), json!("Draft")),
+                ("done".to_owned(), json!(false)),
+            ]),
+        )
+        .unwrap();
+
+    alice.create_branch("other", None).unwrap();
+    alice.checkout_branch("other").unwrap();
+    alice
+        .insert_row(
+            "tasks",
+            "task-other",
+            BTreeMap::from([
+                ("title".to_owned(), json!("Other")),
+                ("done".to_owned(), json!(false)),
+            ]),
+        )
+        .unwrap();
+
+    alice.checkout_branch("draft").unwrap();
+    let query = BuiltQuery::from_json_value(json!({
+        "table": "tasks",
+        "conditions": [{"column": "done", "op": "eq", "value": false}],
+        "orderBy": [["title", "asc"]],
+        "limit": 10,
+    }))
+    .unwrap();
+    let rows = alice
+        .export_query(query)
+        .unwrap()
+        .history
+        .into_iter()
+        .filter(|record| record.table == "tasks")
+        .map(|record| record.row_id)
+        .collect::<Vec<_>>();
+
+    assert_eq!(rows, vec!["task-draft"]);
+}
+
+#[test]
+fn branch_scoped_built_query_export_excludes_unrelated_versions_of_same_row() {
+    let schema = SchemaDef::new().table("tasks", |table| {
+        table.text("title");
+        table.bool("done");
+    });
+    let mut alice =
+        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema).unwrap();
+
+    alice
+        .insert_row(
+            "tasks",
+            "task-shared",
+            BTreeMap::from([
+                ("title".to_owned(), json!("Main")),
+                ("done".to_owned(), json!(false)),
+            ]),
+        )
+        .unwrap();
+
+    alice
+        .create_branch_from_branches("draft", &["main"])
+        .unwrap();
+    alice.checkout_branch("draft").unwrap();
+    alice
+        .update_row(
+            "tasks",
+            "task-shared",
+            BTreeMap::from([
+                ("title".to_owned(), json!("Draft")),
+                ("done".to_owned(), json!(false)),
+            ]),
+        )
+        .unwrap();
+
+    alice
+        .create_branch_from_branches("other", &["main"])
+        .unwrap();
+    alice.checkout_branch("other").unwrap();
+    alice
+        .update_row(
+            "tasks",
+            "task-shared",
+            BTreeMap::from([
+                ("title".to_owned(), json!("Other")),
+                ("done".to_owned(), json!(false)),
+            ]),
+        )
+        .unwrap();
+
+    alice.checkout_branch("draft").unwrap();
+    let query = BuiltQuery::from_json_value(json!({
+        "table": "tasks",
+        "conditions": [{"column": "done", "op": "eq", "value": false}],
+        "orderBy": [["title", "asc"]],
+        "limit": 10,
+    }))
+    .unwrap();
+    let titles = alice
+        .export_query(query)
+        .unwrap()
+        .history
+        .into_iter()
+        .filter(|record| record.table == "tasks" && record.row_id == "task-shared")
+        .map(|record| record.values["title"].clone())
+        .collect::<Vec<_>>();
+
+    assert_eq!(titles, vec![json!("Main"), json!("Draft")]);
+}
+
+#[test]
 fn branch_scoped_export_excludes_unrelated_deleted_rows() {
     let schema = SchemaDef::new().table("tasks", |table| {
         table.text("title");
@@ -2007,6 +2132,76 @@ fn branch_observed_query_refresh_includes_later_source_branch_rows() {
 }
 
 #[test]
+fn branch_created_at_page_refresh_contracts_against_source_branch_window() {
+    let schema = SchemaDef::new().table("tasks", |table| {
+        table.text("title");
+        table.bool("done");
+    });
+    let mut upstream =
+        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema.clone()).unwrap();
+    let mut peer =
+        Runtime::open_with_schema(Storage::Memory, "alice-peer-node", "alice", schema).unwrap();
+
+    upstream.create_branch("left", None).unwrap();
+    upstream.create_branch("merge", None).unwrap();
+    upstream.checkout_branch("merge").unwrap();
+    upstream
+        .insert_row(
+            "tasks",
+            "task-merge-old",
+            BTreeMap::from([
+                ("title".to_owned(), json!("Merge old")),
+                ("done".to_owned(), json!(false)),
+            ]),
+        )
+        .unwrap();
+
+    let page_query = BuiltQuery::from_json_value(json!({
+        "table": "tasks",
+        "conditions": [{"column": "done", "op": "eq", "value": false}],
+        "orderBy": [["$createdAt", "desc"]],
+        "limit": 1,
+    }))
+    .unwrap();
+    let all_matching = BuiltQuery::from_json_value(json!({
+        "table": "tasks",
+        "conditions": [{"column": "done", "op": "eq", "value": false}],
+        "orderBy": [["$createdAt", "desc"]]
+    }))
+    .unwrap();
+
+    peer.apply_bundle(&upstream.export_query(page_query.clone()).unwrap())
+        .unwrap();
+    peer.checkout_branch("merge").unwrap();
+    assert_eq!(query_ids(&peer, page_query.clone()), vec!["task-merge-old"]);
+
+    upstream.checkout_branch("left").unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    upstream
+        .insert_row(
+            "tasks",
+            "task-left-new",
+            BTreeMap::from([
+                ("title".to_owned(), json!("Left new")),
+                ("done".to_owned(), json!(false)),
+            ]),
+        )
+        .unwrap();
+    upstream.add_branch_source("merge", "left").unwrap();
+    upstream.checkout_branch("merge").unwrap();
+
+    for refresh in upstream
+        .export_query_read_refreshes(&peer.observed_query_reads().unwrap())
+        .unwrap()
+    {
+        peer.apply_bundle(&refresh).unwrap();
+    }
+
+    assert_eq!(query_ids(&peer, page_query), vec!["task-left-new"]);
+    assert_eq!(query_ids(&peer, all_matching), vec!["task-left-new"]);
+}
+
+#[test]
 fn branch_observed_query_refresh_includes_newly_added_source_branch() {
     let schema = SchemaDef::new().table("tasks", |table| {
         table.text("title");
@@ -3010,4 +3205,13 @@ fn durable_reopen_preserves_branch_sync_and_dedupes_replay() {
     reopened.checkout_branch("draft").unwrap();
     assert_eq!(reopened.read_rows("tasks").unwrap()[0].id, "task-draft");
     assert_eq!(reopened.storage_stats().unwrap().history_rows, 1);
+}
+
+fn query_ids(runtime: &Runtime, query: BuiltQuery) -> Vec<String> {
+    runtime
+        .query(query)
+        .unwrap()
+        .into_iter()
+        .map(|row| row.id)
+        .collect()
 }

--- a/crates/mini-jazz-sqlite/tests/whole_system/branches.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/branches.rs
@@ -1212,6 +1212,62 @@ fn branch_ref_policy_uses_branch_local_parent_visibility() {
 }
 
 #[test]
+fn branch_table_export_uses_effective_branch_policy_for_base_rows() {
+    let schema = SchemaDef::new()
+        .table("projects", |table| {
+            table.text("title");
+            table.read_if_created_by_user();
+        })
+        .table("todos", |table| {
+            table.text("title");
+            table.ref_("project", "projects");
+            table.read_if_ref_readable("project");
+        });
+    let mut alice =
+        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema).unwrap();
+
+    let project_tx = alice
+        .insert_row(
+            "projects",
+            "project-1",
+            BTreeMap::from([("title".to_owned(), json!("Alice project"))]),
+        )
+        .unwrap();
+    alice.accept_transaction_at_global(&project_tx, 1).unwrap();
+    let todo_tx = alice
+        .insert_row(
+            "todos",
+            "todo-1",
+            BTreeMap::from([
+                ("title".to_owned(), json!("Hidden in branch")),
+                ("project".to_owned(), json!("project-1")),
+            ]),
+        )
+        .unwrap();
+    alice.accept_transaction_at_global(&todo_tx, 2).unwrap();
+    alice.create_branch("draft", Some(2)).unwrap();
+    alice.checkout_branch("draft").unwrap();
+
+    alice.session_user_for_test("bob");
+    alice
+        .update_row(
+            "projects",
+            "project-1",
+            BTreeMap::from([("title".to_owned(), json!("Bob-owned branch project"))]),
+        )
+        .unwrap();
+    alice.session_user_for_test("alice");
+
+    assert!(alice.read_rows("todos").unwrap().is_empty());
+
+    let bundle = alice.export_table_history("todos").unwrap();
+    assert!(!bundle
+        .history
+        .iter()
+        .any(|record| record.table == "todos" && record.row_id == "todo-1"));
+}
+
+#[test]
 fn branch_equality_query_uses_effective_branch_policy() {
     let schema = SchemaDef::new()
         .table("projects", |table| {

--- a/crates/mini-jazz-sqlite/tests/whole_system/branches.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/branches.rs
@@ -1140,6 +1140,96 @@ fn branch_equality_query_uses_effective_branch_policy() {
 }
 
 #[test]
+fn branch_ordered_query_applies_effective_policy_before_pagination() {
+    let schema = SchemaDef::new()
+        .table("projects", |table| {
+            table.text("title");
+            table.read_if_created_by_user();
+        })
+        .table("todos", |table| {
+            table.text("title");
+            table.ref_("project", "projects");
+            table.read_if_ref_readable("project");
+        });
+    let mut alice =
+        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema).unwrap();
+
+    let visible_project_tx = alice
+        .insert_row(
+            "projects",
+            "project-visible",
+            BTreeMap::from([("title".to_owned(), json!("Visible project"))]),
+        )
+        .unwrap();
+    alice
+        .accept_transaction_at_global(&visible_project_tx, 1)
+        .unwrap();
+    let hidden_project_tx = alice
+        .insert_row(
+            "projects",
+            "project-hidden",
+            BTreeMap::from([("title".to_owned(), json!("Hidden later"))]),
+        )
+        .unwrap();
+    alice
+        .accept_transaction_at_global(&hidden_project_tx, 2)
+        .unwrap();
+    let visible_todo_tx = alice
+        .insert_row(
+            "todos",
+            "todo-visible",
+            BTreeMap::from([
+                ("title".to_owned(), json!("Older visible todo")),
+                ("project".to_owned(), json!("project-visible")),
+            ]),
+        )
+        .unwrap();
+    alice
+        .accept_transaction_at_global(&visible_todo_tx, 3)
+        .unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    let hidden_todo_tx = alice
+        .insert_row(
+            "todos",
+            "todo-hidden",
+            BTreeMap::from([
+                ("title".to_owned(), json!("Newer hidden todo")),
+                ("project".to_owned(), json!("project-hidden")),
+            ]),
+        )
+        .unwrap();
+    alice
+        .accept_transaction_at_global(&hidden_todo_tx, 4)
+        .unwrap();
+
+    alice.create_branch("draft", Some(4)).unwrap();
+    alice.checkout_branch("draft").unwrap();
+    alice.session_user_for_test("bob");
+    alice
+        .update_row(
+            "projects",
+            "project-hidden",
+            BTreeMap::from([("title".to_owned(), json!("Bob branch project"))]),
+        )
+        .unwrap();
+    alice.session_user_for_test("alice");
+
+    let rows = alice
+        .query(
+            BuiltQuery::from_json_value(json!({
+                "table": "todos",
+                "orderBy": [["$createdAt", "desc"]],
+                "limit": 1,
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].id, "todo-visible");
+}
+
+#[test]
 fn branch_base_export_preserves_ref_policy_at_base_epoch() {
     let schema = SchemaDef::new()
         .table("projects", |table| {

--- a/crates/mini-jazz-sqlite/tests/whole_system/generic_schema.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/generic_schema.rs
@@ -732,16 +732,26 @@ fn generic_top_created_at_query_scope_refresh_replaces_displaced_boundary_row() 
 
     peer.apply_bundle(
         &alice
-            .export_query_where_eq_top_created_at_desc("notes", "pinned", json!(true), 2)
+            .export_query(support::top_created_query(
+                "notes",
+                "pinned",
+                json!(true),
+                2,
+            ))
             .unwrap(),
     )
     .unwrap();
     assert_eq!(
-        peer.read_rows_where_eq_top_created_at_desc("notes", "pinned", json!(true), 2)
-            .unwrap()
-            .iter()
-            .map(|row| row.id.as_str())
-            .collect::<Vec<_>>(),
+        peer.query(support::top_created_query(
+            "notes",
+            "pinned",
+            json!(true),
+            2,
+        ))
+        .unwrap()
+        .iter()
+        .map(|row| row.id.as_str())
+        .collect::<Vec<_>>(),
         vec!["note-middle", "note-old"]
     );
 
@@ -758,17 +768,27 @@ fn generic_top_created_at_query_scope_refresh_replaces_displaced_boundary_row() 
         .unwrap();
     peer.apply_bundle(
         &alice
-            .export_query_where_eq_top_created_at_desc("notes", "pinned", json!(true), 2)
+            .export_query(support::top_created_query(
+                "notes",
+                "pinned",
+                json!(true),
+                2,
+            ))
             .unwrap(),
     )
     .unwrap();
 
     assert_eq!(
-        peer.read_rows_where_eq_top_created_at_desc("notes", "pinned", json!(true), 3)
-            .unwrap()
-            .iter()
-            .map(|row| row.id.as_str())
-            .collect::<Vec<_>>(),
+        peer.query(support::top_created_query(
+            "notes",
+            "pinned",
+            json!(true),
+            3,
+        ))
+        .unwrap()
+        .iter()
+        .map(|row| row.id.as_str())
+        .collect::<Vec<_>>(),
         vec!["note-new", "note-middle"]
     );
 }

--- a/crates/mini-jazz-sqlite/tests/whole_system/generic_schema.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/generic_schema.rs
@@ -2593,6 +2593,142 @@ fn generic_equality_query_lowers_public_ref_ids_to_physical_row_ids() {
 }
 
 #[test]
+fn generic_ref_field_order_uses_public_ref_ids() {
+    let schema = SchemaDef::new()
+        .table("projects", |table| {
+            table.text("title");
+        })
+        .table("tasks", |table| {
+            table.text("title");
+            table.ref_("project", "projects");
+        });
+    let mut alice =
+        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema).unwrap();
+
+    alice
+        .insert_row(
+            "projects",
+            "project-z",
+            BTreeMap::from([("title".to_owned(), json!("Z project"))]),
+        )
+        .unwrap();
+    alice
+        .insert_row(
+            "projects",
+            "project-a",
+            BTreeMap::from([("title".to_owned(), json!("A project"))]),
+        )
+        .unwrap();
+    alice
+        .insert_row(
+            "tasks",
+            "task-z",
+            BTreeMap::from([
+                ("title".to_owned(), json!("Z task")),
+                ("project".to_owned(), json!("project-z")),
+            ]),
+        )
+        .unwrap();
+    alice
+        .insert_row(
+            "tasks",
+            "task-a",
+            BTreeMap::from([
+                ("title".to_owned(), json!("A task")),
+                ("project".to_owned(), json!("project-a")),
+            ]),
+        )
+        .unwrap();
+
+    let query = BuiltQuery::from_json_value(json!({
+        "table": "tasks",
+        "orderBy": [["project", "asc"]],
+    }))
+    .unwrap();
+    let ids = alice
+        .query(query)
+        .unwrap()
+        .into_iter()
+        .map(|row| row.id)
+        .collect::<Vec<_>>();
+
+    assert_eq!(ids, vec!["task-a", "task-z"]);
+}
+
+#[test]
+fn branch_ref_field_order_uses_public_ref_ids() {
+    let schema = SchemaDef::new()
+        .table("projects", |table| {
+            table.text("title");
+        })
+        .table("tasks", |table| {
+            table.text("title");
+            table.ref_("project", "projects");
+        });
+    let mut alice =
+        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema).unwrap();
+
+    let project_z_tx = alice
+        .insert_row(
+            "projects",
+            "project-z",
+            BTreeMap::from([("title".to_owned(), json!("Z project"))]),
+        )
+        .unwrap();
+    alice
+        .accept_transaction_at_global(&project_z_tx, 1)
+        .unwrap();
+    let project_a_tx = alice
+        .insert_row(
+            "projects",
+            "project-a",
+            BTreeMap::from([("title".to_owned(), json!("A project"))]),
+        )
+        .unwrap();
+    alice
+        .accept_transaction_at_global(&project_a_tx, 2)
+        .unwrap();
+    let task_z_tx = alice
+        .insert_row(
+            "tasks",
+            "task-z",
+            BTreeMap::from([
+                ("title".to_owned(), json!("Z task")),
+                ("project".to_owned(), json!("project-z")),
+            ]),
+        )
+        .unwrap();
+    alice.accept_transaction_at_global(&task_z_tx, 3).unwrap();
+    let task_a_tx = alice
+        .insert_row(
+            "tasks",
+            "task-a",
+            BTreeMap::from([
+                ("title".to_owned(), json!("A task")),
+                ("project".to_owned(), json!("project-a")),
+            ]),
+        )
+        .unwrap();
+    alice.accept_transaction_at_global(&task_a_tx, 4).unwrap();
+    alice.create_branch("draft", Some(4)).unwrap();
+    alice.checkout_branch("draft").unwrap();
+
+    let query = BuiltQuery::from_json_value(json!({
+        "table": "tasks",
+        "orderBy": [["project", "asc"]],
+    }))
+    .unwrap();
+    let ids = alice
+        .query(query)
+        .unwrap()
+        .into_iter()
+        .map(|row| row.id)
+        .collect::<Vec<_>>();
+
+    assert_eq!(ids, vec!["task-a", "task-z"]);
+}
+
+#[test]
 fn generic_required_ref_read_filters_parent_until_target_is_visible() {
     let schema = SchemaDef::new()
         .table("projects", |table| {

--- a/crates/mini-jazz-sqlite/tests/whole_system/generic_schema.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/generic_schema.rs
@@ -794,6 +794,135 @@ fn generic_top_created_at_query_scope_refresh_replaces_displaced_boundary_row() 
 }
 
 #[test]
+fn built_query_scope_export_accepts_multiple_filters() {
+    let schema = support::notes_schema();
+    let mut alice =
+        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema.clone()).unwrap();
+    let mut peer =
+        Runtime::open_with_schema(Storage::Memory, "peer-node", "alice", schema).unwrap();
+
+    alice
+        .insert_row(
+            "notes",
+            "note-match",
+            BTreeMap::from([
+                ("body".to_owned(), json!("ship the small thing")),
+                ("pinned".to_owned(), json!(true)),
+            ]),
+        )
+        .unwrap();
+    alice
+        .insert_row(
+            "notes",
+            "note-filtered",
+            BTreeMap::from([
+                ("body".to_owned(), json!("ship something later")),
+                ("pinned".to_owned(), json!(false)),
+            ]),
+        )
+        .unwrap();
+
+    let query = BuiltQuery::from_json_value(json!({
+        "table": "notes",
+        "conditions": [
+            {"column": "pinned", "op": "eq", "value": true},
+            {"column": "body", "op": "contains", "value": "ship"}
+        ],
+    }))
+    .unwrap();
+    assert_eq!(alice.query(query.clone()).unwrap()[0].id, "note-match");
+
+    peer.apply_bundle(&alice.export_query(query.clone()).unwrap())
+        .unwrap();
+
+    let rows = peer.query(query).unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].id, "note-match");
+}
+
+#[test]
+fn built_query_scope_export_includes_offset_support_rows() {
+    let schema = support::notes_schema();
+    let mut alice =
+        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema.clone()).unwrap();
+    let mut peer =
+        Runtime::open_with_schema(Storage::Memory, "peer-node", "alice", schema).unwrap();
+
+    alice
+        .insert_row(
+            "notes",
+            "note-older",
+            BTreeMap::from([
+                ("body".to_owned(), json!("older")),
+                ("pinned".to_owned(), json!(true)),
+            ]),
+        )
+        .unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    alice
+        .insert_row(
+            "notes",
+            "note-newer",
+            BTreeMap::from([
+                ("body".to_owned(), json!("newer")),
+                ("pinned".to_owned(), json!(true)),
+            ]),
+        )
+        .unwrap();
+
+    let query = BuiltQuery::from_json_value(json!({
+        "table": "notes",
+        "conditions": [{"column": "pinned", "op": "eq", "value": true}],
+        "orderBy": [["$createdAt", "desc"]],
+        "limit": 1,
+        "offset": 1,
+    }))
+    .unwrap();
+    assert_eq!(alice.query(query.clone()).unwrap()[0].id, "note-older");
+
+    peer.apply_bundle(&alice.export_query(query.clone()).unwrap())
+        .unwrap();
+
+    let rows = peer.query(query).unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].id, "note-older");
+}
+
+#[test]
+fn generic_top_created_at_query_scope_repairs_system_predicates() {
+    let schema = support::notes_schema();
+    let mut alice =
+        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema.clone()).unwrap();
+
+    alice
+        .insert_row(
+            "notes",
+            "note-target",
+            BTreeMap::from([
+                ("body".to_owned(), json!("target")),
+                ("pinned".to_owned(), json!(true)),
+            ]),
+        )
+        .unwrap();
+
+    for query in [
+        support::top_created_query("notes", "id", json!("note-target"), 1),
+        support::top_created_query("notes", "$createdBy", json!("alice"), 1),
+    ] {
+        let mut peer =
+            Runtime::open_with_schema(Storage::Memory, "peer-node", "alice", schema.clone())
+                .unwrap();
+
+        peer.apply_bundle(&alice.export_query(query.clone()).unwrap())
+            .unwrap();
+
+        let rows = peer.query(query).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].id, "note-target");
+    }
+}
+
+#[test]
 fn generic_schema_rows_rebuild_and_sync_by_public_ids() {
     let schema = SchemaDef::new()
         .table("docs", |table| {

--- a/crates/mini-jazz-sqlite/tests/whole_system/generic_schema.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/generic_schema.rs
@@ -153,15 +153,15 @@ fn id_magic_field_query_matches_public_row_id() {
         .unwrap();
 
     let rows = alice
-        .read_rows_where_eq("notes", "id", json!("note-public-id"))
+        .query(support::eq_query("notes", "id", json!("note-public-id")))
         .unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].id, "note-public-id");
     assert!(alice
-        .read_rows_where_eq("notes", "id", json!(7))
+        .query(support::eq_query("notes", "id", json!(7)))
         .unwrap_err()
         .to_string()
-        .contains("id equality expects a string"));
+        .contains("query system field expects a string"));
 }
 
 #[test]
@@ -189,7 +189,7 @@ fn id_magic_field_query_scope_syncs_and_repairs_delete() {
     )
     .unwrap();
     assert_eq!(
-        peer.read_rows_where_eq("notes", "id", json!("note-public-id"))
+        peer.query(support::eq_query("notes", "id", json!("note-public-id")))
             .unwrap()
             .len(),
         1
@@ -203,7 +203,7 @@ fn id_magic_field_query_scope_syncs_and_repairs_delete() {
     )
     .unwrap();
     assert!(peer
-        .read_rows_where_eq("notes", "id", json!("note-public-id"))
+        .query(support::eq_query("notes", "id", json!("note-public-id")))
         .unwrap()
         .is_empty());
 }
@@ -523,15 +523,15 @@ fn created_by_magic_field_query_matches_creator_user() {
         .unwrap();
 
     let rows = alice
-        .read_rows_where_eq("notes", "$createdBy", json!("bob"))
+        .query(support::eq_query("notes", "$createdBy", json!("bob")))
         .unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].id, "note-bob");
     assert!(alice
-        .read_rows_where_eq("notes", "$createdBy", json!(true))
+        .query(support::eq_query("notes", "$createdBy", json!(true)))
         .unwrap_err()
         .to_string()
-        .contains("$createdBy equality expects a string"));
+        .contains("query system field expects a string"));
 }
 
 #[test]
@@ -559,7 +559,7 @@ fn created_by_magic_field_query_scope_syncs_and_repairs_delete() {
     )
     .unwrap();
     assert_eq!(
-        peer.read_rows_where_eq("notes", "$createdBy", json!("alice"))
+        peer.query(support::eq_query("notes", "$createdBy", json!("alice")))
             .unwrap()
             .len(),
         1
@@ -573,7 +573,7 @@ fn created_by_magic_field_query_scope_syncs_and_repairs_delete() {
     )
     .unwrap();
     assert!(peer
-        .read_rows_where_eq("notes", "$createdBy", json!("alice"))
+        .query(support::eq_query("notes", "$createdBy", json!("alice")))
         .unwrap()
         .is_empty());
 }
@@ -889,7 +889,7 @@ fn generic_equality_query_scope_exports_matching_rows_and_policy_dependencies() 
         .unwrap();
 
     let rows = alice
-        .read_rows_where_eq("tasks", "done", json!(false))
+        .query(support::eq_query("tasks", "done", json!(false)))
         .unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].id, "task-open");
@@ -913,7 +913,7 @@ fn generic_equality_query_scope_exports_matching_rows_and_policy_dependencies() 
 
     peer.apply_bundle(&bundle).unwrap();
     let peer_rows = peer
-        .read_rows_where_eq("tasks", "done", json!(false))
+        .query(support::eq_query("tasks", "done", json!(false)))
         .unwrap();
     assert_eq!(peer_rows.len(), 1);
     assert_eq!(peer_rows[0].id, "task-open");
@@ -980,7 +980,7 @@ fn query_scope_bundle_dedupes_shared_policy_dependency_history() {
 
     peer.apply_bundle(&bundle).unwrap();
     let peer_rows = peer
-        .read_rows_where_eq("tasks", "done", json!(false))
+        .query(support::eq_query("tasks", "done", json!(false)))
         .unwrap();
     assert_eq!(peer_rows.len(), 2);
     assert!(peer_rows
@@ -1016,7 +1016,7 @@ fn equality_query_scope_resync_removes_row_that_left_predicate() {
     )
     .unwrap();
     assert_eq!(
-        peer.read_rows_where_eq("tasks", "done", json!(false))
+        peer.query(support::eq_query("tasks", "done", json!(false)))
             .unwrap()
             .len(),
         1
@@ -1040,7 +1040,7 @@ fn equality_query_scope_resync_removes_row_that_left_predicate() {
     .unwrap();
 
     assert!(peer
-        .read_rows_where_eq("tasks", "done", json!(false))
+        .query(support::eq_query("tasks", "done", json!(false)))
         .unwrap()
         .is_empty());
 }
@@ -1073,7 +1073,7 @@ fn equality_query_scope_resync_removes_deleted_matching_row() {
     )
     .unwrap();
     assert_eq!(
-        peer.read_rows_where_eq("tasks", "done", json!(false))
+        peer.query(support::eq_query("tasks", "done", json!(false)))
             .unwrap()
             .len(),
         1
@@ -1088,7 +1088,7 @@ fn equality_query_scope_resync_removes_deleted_matching_row() {
     .unwrap();
 
     assert!(peer
-        .read_rows_where_eq("tasks", "done", json!(false))
+        .query(support::eq_query("tasks", "done", json!(false)))
         .unwrap()
         .is_empty());
 }
@@ -1124,7 +1124,7 @@ fn nullable_text_round_trips_and_filters_with_is_null_semantics() {
         .unwrap();
 
     let rows = alice
-        .read_rows_where_eq("notes", "tag", json!(null))
+        .query(support::eq_query("notes", "tag", json!(null)))
         .unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].id, "note-2");
@@ -1176,7 +1176,7 @@ fn nullable_ref_round_trips_filters_and_is_skipped_by_require_ref() {
         .unwrap();
 
     let floating = alice
-        .read_rows_where_eq("todos", "project", json!(null))
+        .query(support::eq_query("todos", "project", json!(null)))
         .unwrap();
     assert_eq!(floating.len(), 1);
     assert_eq!(floating[0].id, "todo-floating");
@@ -1778,7 +1778,7 @@ fn query_scope_refresh_does_not_leak_unrelated_tombstones_while_repairing_delete
     )
     .unwrap();
     assert_eq!(
-        peer.read_rows_where_eq("tasks", "done", json!(false))
+        peer.query(support::eq_query("tasks", "done", json!(false)))
             .unwrap()
             .len(),
         1
@@ -1799,7 +1799,7 @@ fn query_scope_refresh_does_not_leak_unrelated_tombstones_while_repairing_delete
 
     peer.apply_bundle(&bundle).unwrap();
     assert!(peer
-        .read_rows_where_eq("tasks", "done", json!(false))
+        .query(support::eq_query("tasks", "done", json!(false)))
         .unwrap()
         .is_empty());
 }
@@ -1832,7 +1832,7 @@ fn empty_equality_query_scope_later_delivers_inserted_match_without_table_replic
     assert_eq!(initial.query_reads.len(), 1);
     peer.apply_bundle(&initial).unwrap();
     assert!(peer
-        .read_rows_where_eq("tasks", "done", json!(false))
+        .query(support::eq_query("tasks", "done", json!(false)))
         .unwrap()
         .is_empty());
     assert_eq!(peer.observed_query_reads().unwrap(), initial.query_reads);
@@ -1863,7 +1863,7 @@ fn empty_equality_query_scope_later_delivers_inserted_match_without_table_replic
     }
 
     let rows = peer
-        .read_rows_where_eq("tasks", "done", json!(false))
+        .query(support::eq_query("tasks", "done", json!(false)))
         .unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].id, "task-open");
@@ -1914,7 +1914,7 @@ fn equality_query_scope_resync_removes_row_hidden_by_policy_dependency_change() 
     )
     .unwrap();
     assert_eq!(
-        peer.read_rows_where_eq("tasks", "done", json!(false))
+        peer.query(support::eq_query("tasks", "done", json!(false)))
             .unwrap()
             .len(),
         1
@@ -1937,7 +1937,7 @@ fn equality_query_scope_resync_removes_row_hidden_by_policy_dependency_change() 
         )
         .unwrap();
     assert!(alice
-        .read_rows_where_eq("tasks", "done", json!(false))
+        .query(support::eq_query("tasks", "done", json!(false)))
         .unwrap()
         .is_empty());
 
@@ -1949,7 +1949,7 @@ fn equality_query_scope_resync_removes_row_hidden_by_policy_dependency_change() 
     .unwrap();
 
     assert!(peer
-        .read_rows_where_eq("tasks", "done", json!(false))
+        .query(support::eq_query("tasks", "done", json!(false)))
         .unwrap()
         .is_empty());
 }
@@ -2010,7 +2010,7 @@ fn durable_query_read_refresh_repairs_policy_dependency_change_after_restart() {
             .unwrap();
         assert_eq!(
             worker
-                .read_rows_where_eq("tasks", "done", json!(false))
+                .query(support::eq_query("tasks", "done", json!(false)))
                 .unwrap()
                 .len(),
             1
@@ -2050,7 +2050,7 @@ fn durable_query_read_refresh_repairs_policy_dependency_change_after_restart() {
     }
 
     assert!(reopened
-        .read_rows_where_eq("tasks", "done", json!(false))
+        .query(support::eq_query("tasks", "done", json!(false)))
         .unwrap()
         .is_empty());
 }
@@ -2120,7 +2120,7 @@ fn branch_equality_query_scope_resync_repairs_row_that_left_predicate() {
     .unwrap();
     peer.checkout_branch("draft").unwrap();
     let draft_rows = peer
-        .read_rows_where_eq("tasks", "done", json!(false))
+        .query(support::eq_query("tasks", "done", json!(false)))
         .unwrap();
     assert_eq!(draft_rows.len(), 1);
     assert_eq!(draft_rows[0].id, "task-1");
@@ -2143,7 +2143,7 @@ fn branch_equality_query_scope_resync_repairs_row_that_left_predicate() {
     .unwrap();
 
     assert!(peer
-        .read_rows_where_eq("tasks", "done", json!(false))
+        .query(support::eq_query("tasks", "done", json!(false)))
         .unwrap()
         .is_empty());
 }
@@ -2233,7 +2233,7 @@ fn branch_query_scope_repair_does_not_delete_same_predicate_row_on_main() {
     )
     .unwrap();
     assert_eq!(
-        peer.read_rows_where_eq("tasks", "done", json!(false))
+        peer.query(support::eq_query("tasks", "done", json!(false)))
             .unwrap()
             .len(),
         1
@@ -2259,7 +2259,7 @@ fn branch_query_scope_repair_does_not_delete_same_predicate_row_on_main() {
     .unwrap();
     peer.checkout_branch("draft").unwrap();
     let draft_rows = peer
-        .read_rows_where_eq("tasks", "done", json!(false))
+        .query(support::eq_query("tasks", "done", json!(false)))
         .unwrap();
     assert_eq!(draft_rows.len(), 2);
     assert!(draft_rows.iter().any(|row| row.id == "task-main"));
@@ -2280,13 +2280,13 @@ fn branch_query_scope_repair_does_not_delete_same_predicate_row_on_main() {
     .unwrap();
 
     let draft_rows = peer
-        .read_rows_where_eq("tasks", "done", json!(false))
+        .query(support::eq_query("tasks", "done", json!(false)))
         .unwrap();
     assert_eq!(draft_rows.len(), 1);
     assert_eq!(draft_rows[0].id, "task-main");
     peer.checkout_branch("main").unwrap();
     let main_rows = peer
-        .read_rows_where_eq("tasks", "done", json!(false))
+        .query(support::eq_query("tasks", "done", json!(false)))
         .unwrap();
     assert_eq!(main_rows.len(), 1);
     assert_eq!(main_rows[0].id, "task-main");
@@ -2389,7 +2389,7 @@ fn generic_equality_query_lowers_public_ref_ids_to_physical_row_ids() {
         .unwrap();
 
     let rows = alice
-        .read_rows_where_eq("tasks", "project", json!("project-2"))
+        .query(support::eq_query("tasks", "project", json!("project-2")))
         .unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].id, "task-2");

--- a/crates/mini-jazz-sqlite/tests/whole_system/generic_schema.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/generic_schema.rs
@@ -835,42 +835,9 @@ fn built_query_scope_export_accepts_multiple_filters() {
     peer.apply_bundle(&alice.export_query(query.clone()).unwrap())
         .unwrap();
 
-    let rows = peer.query(query).unwrap();
+    let rows = peer.query(query.clone()).unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].id, "note-match");
-}
-
-#[test]
-fn built_query_scope_refresh_removes_row_that_left_multiple_filters() {
-    let schema = support::notes_schema();
-    let mut alice =
-        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema.clone()).unwrap();
-    let mut peer =
-        Runtime::open_with_schema(Storage::Memory, "peer-node", "alice", schema).unwrap();
-
-    alice
-        .insert_row(
-            "notes",
-            "note-match",
-            BTreeMap::from([
-                ("body".to_owned(), json!("ship the small thing")),
-                ("pinned".to_owned(), json!(true)),
-            ]),
-        )
-        .unwrap();
-
-    let query = BuiltQuery::from_json_value(json!({
-        "table": "notes",
-        "conditions": [
-            {"column": "pinned", "op": "eq", "value": true},
-            {"column": "body", "op": "contains", "value": "ship"}
-        ],
-    }))
-    .unwrap();
-
-    peer.apply_bundle(&alice.export_query(query.clone()).unwrap())
-        .unwrap();
-    assert_eq!(peer.query(query.clone()).unwrap()[0].id, "note-match");
 
     alice
         .update_row(

--- a/crates/mini-jazz-sqlite/tests/whole_system/generic_schema.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/generic_schema.rs
@@ -841,6 +841,106 @@ fn built_query_scope_export_accepts_multiple_filters() {
 }
 
 #[test]
+fn built_query_scope_refresh_removes_row_that_left_multiple_filters() {
+    let schema = support::notes_schema();
+    let mut alice =
+        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema.clone()).unwrap();
+    let mut peer =
+        Runtime::open_with_schema(Storage::Memory, "peer-node", "alice", schema).unwrap();
+
+    alice
+        .insert_row(
+            "notes",
+            "note-match",
+            BTreeMap::from([
+                ("body".to_owned(), json!("ship the small thing")),
+                ("pinned".to_owned(), json!(true)),
+            ]),
+        )
+        .unwrap();
+
+    let query = BuiltQuery::from_json_value(json!({
+        "table": "notes",
+        "conditions": [
+            {"column": "pinned", "op": "eq", "value": true},
+            {"column": "body", "op": "contains", "value": "ship"}
+        ],
+    }))
+    .unwrap();
+
+    peer.apply_bundle(&alice.export_query(query.clone()).unwrap())
+        .unwrap();
+    assert_eq!(peer.query(query.clone()).unwrap()[0].id, "note-match");
+
+    alice
+        .update_row(
+            "notes",
+            "note-match",
+            BTreeMap::from([("pinned".to_owned(), json!(false))]),
+        )
+        .unwrap();
+
+    for refresh in alice
+        .export_query_read_refreshes(&peer.observed_query_reads().unwrap())
+        .unwrap()
+    {
+        peer.apply_bundle(&refresh).unwrap();
+    }
+
+    assert!(peer.query(query).unwrap().is_empty());
+}
+
+#[test]
+fn built_query_scope_refresh_removes_row_that_left_custom_order() {
+    let schema = support::notes_schema();
+    let mut alice =
+        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema.clone()).unwrap();
+    let mut peer =
+        Runtime::open_with_schema(Storage::Memory, "peer-node", "alice", schema).unwrap();
+
+    alice
+        .insert_row(
+            "notes",
+            "note-match",
+            BTreeMap::from([
+                ("body".to_owned(), json!("alpha")),
+                ("pinned".to_owned(), json!(true)),
+            ]),
+        )
+        .unwrap();
+
+    let query = BuiltQuery::from_json_value(json!({
+        "table": "notes",
+        "conditions": [
+            {"column": "pinned", "op": "eq", "value": true}
+        ],
+        "orderBy": [["body", "asc"]],
+    }))
+    .unwrap();
+
+    peer.apply_bundle(&alice.export_query(query.clone()).unwrap())
+        .unwrap();
+    assert_eq!(peer.query(query.clone()).unwrap()[0].id, "note-match");
+
+    alice
+        .update_row(
+            "notes",
+            "note-match",
+            BTreeMap::from([("pinned".to_owned(), json!(false))]),
+        )
+        .unwrap();
+
+    for refresh in alice
+        .export_query_read_refreshes(&peer.observed_query_reads().unwrap())
+        .unwrap()
+    {
+        peer.apply_bundle(&refresh).unwrap();
+    }
+
+    assert!(peer.query(query).unwrap().is_empty());
+}
+
+#[test]
 fn built_query_scope_export_includes_offset_support_rows() {
     let schema = support::notes_schema();
     let mut alice =

--- a/crates/mini-jazz-sqlite/tests/whole_system/policies.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/policies.rs
@@ -2258,7 +2258,7 @@ fn trusted_as_user_enforces_policy_while_attribution_mode_bypasses_it() {
     );
     assert_eq!(
         worker
-            .read_rows_where_eq("docs", "id", json!("doc-alice"))
+            .query(support::eq_query("docs", "id", json!("doc-alice")))
             .unwrap()[0]
             .values["title"],
         json!("Alice doc")
@@ -2273,7 +2273,7 @@ fn trusted_as_user_enforces_policy_while_attribution_mode_bypasses_it() {
     })
     .unwrap();
     let row = worker
-        .read_rows_where_eq("docs", "id", json!("doc-alice"))
+        .query(support::eq_query("docs", "id", json!("doc-alice")))
         .unwrap()
         .pop()
         .unwrap();

--- a/crates/mini-jazz-sqlite/tests/whole_system/query_matrix.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/query_matrix.rs
@@ -844,11 +844,7 @@ fn row_matches(row: &MatrixRow, condition: &JsonValue) -> bool {
     match op {
         "eq" => actual == *expected,
         "ne" => actual != *expected,
-        "in" => expected
-            .as_array()
-            .unwrap()
-            .iter()
-            .any(|candidate| *candidate == actual),
+        "in" => expected.as_array().unwrap().contains(&actual),
         "contains" => actual
             .as_str()
             .unwrap()

--- a/crates/mini-jazz-sqlite/tests/whole_system/query_matrix.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/query_matrix.rs
@@ -1,0 +1,837 @@
+use super::*;
+use serde_json::Value as JsonValue;
+use std::cmp::Ordering;
+
+#[derive(Clone)]
+struct MatrixRow {
+    id: &'static str,
+    title: &'static str,
+    category: &'static str,
+    body: &'static str,
+    tag: Option<&'static str>,
+    active: bool,
+    project: Option<&'static str>,
+    created_by: &'static str,
+    created_rank: i64,
+    updated_rank: i64,
+}
+
+#[derive(Clone)]
+struct ConditionCase {
+    label: &'static str,
+    conditions: Vec<JsonValue>,
+}
+
+#[derive(Clone)]
+struct OrderCase {
+    label: &'static str,
+    order_by: Vec<(&'static str, &'static str)>,
+}
+
+#[derive(Clone)]
+struct WindowCase {
+    label: &'static str,
+    limit: Option<usize>,
+    offset: Option<usize>,
+}
+
+#[test]
+fn built_query_matrix_matches_expected_rows_for_supported_operations() {
+    let mut runtime =
+        Runtime::open_trusted_with_schema(Storage::Memory, "matrix-node", query_matrix_schema())
+            .unwrap();
+    let model_rows = seed_query_matrix_rows(&mut runtime);
+    let condition_cases = query_condition_cases();
+    let order_cases = query_order_cases();
+    let window_cases = query_window_cases();
+
+    for condition_case in &condition_cases {
+        for order_case in &order_cases {
+            for window_case in &window_cases {
+                let query = built_query(
+                    "query_items",
+                    condition_case.conditions.clone(),
+                    &order_case.order_by,
+                    window_case.limit,
+                    window_case.offset,
+                );
+                let actual = runtime
+                    .query(query)
+                    .unwrap_or_else(|err| {
+                        panic!(
+                            "query failed for conditions={} order={} window={}: {err}",
+                            condition_case.label, order_case.label, window_case.label
+                        )
+                    })
+                    .into_iter()
+                    .map(|row| row.id)
+                    .collect::<Vec<_>>();
+                let expected = expected_matrix_ids(
+                    &model_rows,
+                    &condition_case.conditions,
+                    &order_case.order_by,
+                    window_case.limit,
+                    window_case.offset,
+                );
+
+                assert_eq!(
+                    actual, expected,
+                    "conditions={} order={} window={}",
+                    condition_case.label, order_case.label, window_case.label
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn policy_filtered_built_query_subscription_tracks_rows_entering_and_leaving() {
+    let mut runtime = Runtime::open_trusted_with_schema(
+        Storage::Memory,
+        "policy-query-node",
+        policy_query_schema(),
+    )
+    .unwrap();
+    seed_policy_query_rows(&mut runtime);
+    let query = active_tasks_by_title_query(3);
+
+    let mut subscription = support::run_as_user(&mut runtime, "alice", |runtime| {
+        runtime.subscribe_query(query).unwrap()
+    });
+    assert_eq!(
+        subscription_ids(subscription.initial_rows()),
+        vec!["task-beta", "task-delta"]
+    );
+
+    support::run_attributing_to_user(&mut runtime, "alice", |runtime| {
+        runtime
+            .update_row(
+                "tasks",
+                "task-alpha",
+                BTreeMap::from([("project".to_owned(), json!("project-alice"))]),
+            )
+            .unwrap();
+    });
+    let entered = support::run_as_user(&mut runtime, "alice", |runtime| {
+        runtime.subscription_delta(&mut subscription).unwrap()
+    });
+    assert_eq!(
+        entered
+            .all
+            .iter()
+            .map(|row| row.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["task-alpha", "task-beta", "task-delta"]
+    );
+    assert!(entered.delta.iter().any(
+        |delta| matches!(delta, SubscriptionRowDelta::Added { id, .. } if id == "task-alpha")
+    ));
+
+    support::run_attributing_to_user(&mut runtime, "alice", |runtime| {
+        runtime
+            .update_row(
+                "tasks",
+                "task-beta",
+                BTreeMap::from([("project".to_owned(), json!("project-bob"))]),
+            )
+            .unwrap();
+    });
+    let left = support::run_as_user(&mut runtime, "alice", |runtime| {
+        runtime.subscription_delta(&mut subscription).unwrap()
+    });
+    assert_eq!(
+        left.all
+            .iter()
+            .map(|row| row.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["task-alpha", "task-delta"]
+    );
+    assert!(left.delta.iter().any(
+        |delta| matches!(delta, SubscriptionRowDelta::Removed { id, .. } if id == "task-beta")
+    ));
+}
+
+#[test]
+fn policy_filtered_query_refresh_replaces_ordered_page_boundary_after_incremental_update() {
+    let schema = policy_query_schema();
+    let mut upstream =
+        Runtime::open_trusted_with_schema(Storage::Memory, "upstream", schema.clone()).unwrap();
+    let mut peer = Runtime::open_with_schema(Storage::Memory, "peer", "alice", schema).unwrap();
+    seed_policy_query_rows(&mut upstream);
+    let query = active_tasks_by_title_query(2);
+
+    let initial = support::run_as_user(&mut upstream, "alice", |runtime| {
+        runtime.export_query(query.clone()).unwrap()
+    });
+    peer.apply_bundle(&initial).unwrap();
+    assert_eq!(
+        query_ids(&peer, query.clone()),
+        vec!["task-beta", "task-delta"]
+    );
+
+    let mut subscription = peer.subscribe_query(query.clone()).unwrap();
+    support::run_attributing_to_user(&mut upstream, "alice", |runtime| {
+        runtime
+            .update_row(
+                "tasks",
+                "task-alpha",
+                BTreeMap::from([("project".to_owned(), json!("project-alice"))]),
+            )
+            .unwrap();
+    });
+
+    let observed = peer.observed_query_reads().unwrap();
+    let refreshes = support::run_as_user(&mut upstream, "alice", |runtime| {
+        runtime.export_query_read_refreshes(&observed).unwrap()
+    });
+    for refresh in refreshes {
+        peer.apply_bundle(&refresh).unwrap();
+    }
+
+    let update = peer.subscription_delta(&mut subscription).unwrap();
+    assert_eq!(
+        update
+            .all
+            .iter()
+            .map(|row| row.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["task-alpha", "task-beta"]
+    );
+    assert!(update.delta.iter().any(
+        |delta| matches!(delta, SubscriptionRowDelta::Added { id, .. } if id == "task-alpha")
+    ));
+    assert!(update.delta.iter().any(
+        |delta| matches!(delta, SubscriptionRowDelta::Removed { id, .. } if id == "task-delta")
+    ));
+}
+
+#[test]
+fn built_query_scope_export_refreshes_system_timestamp_and_system_text_conditions() {
+    let schema = support::notes_schema();
+    let mut alice =
+        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema.clone()).unwrap();
+    let mut peer =
+        Runtime::open_with_schema(Storage::Memory, "peer-node", "alice", schema).unwrap();
+
+    alice
+        .insert_row(
+            "notes",
+            "note-visible",
+            BTreeMap::from([
+                ("body".to_owned(), json!("system query")),
+                ("pinned".to_owned(), json!(true)),
+            ]),
+        )
+        .unwrap();
+    alice
+        .update_row(
+            "notes",
+            "note-visible",
+            BTreeMap::from([("body".to_owned(), json!("system query updated"))]),
+        )
+        .unwrap();
+
+    for query in [
+        built_query(
+            "notes",
+            vec![condition("$createdAt", "ne", json!(0))],
+            &[],
+            None,
+            None,
+        ),
+        built_query(
+            "notes",
+            vec![condition("$updatedAt", "ne", json!(0))],
+            &[],
+            None,
+            None,
+        ),
+        built_query(
+            "notes",
+            vec![condition("id", "contains", json!("note-"))],
+            &[],
+            None,
+            None,
+        ),
+        built_query(
+            "notes",
+            vec![condition("$createdBy", "contains", json!("ali"))],
+            &[],
+            None,
+            None,
+        ),
+    ] {
+        peer.apply_bundle(&alice.export_query(query.clone()).unwrap())
+            .unwrap();
+        assert_eq!(query_ids(&peer, query), vec!["note-visible"]);
+    }
+}
+
+fn query_matrix_schema() -> SchemaDef {
+    SchemaDef::new()
+        .table("projects", |table| {
+            table.text("name");
+        })
+        .table("query_items", |table| {
+            table.text("title");
+            table.text("category");
+            table.text("body");
+            table.optional_text("tag");
+            table.bool("active");
+            table.optional_ref("project", "projects");
+            table.index("active_title", ["active", "title"]);
+            table.index("category_title", ["category", "title"]);
+        })
+}
+
+fn seed_query_matrix_rows(runtime: &mut Runtime) -> Vec<MatrixRow> {
+    runtime
+        .insert_row(
+            "projects",
+            "project-a",
+            BTreeMap::from([("name".to_owned(), json!("Alpha project"))]),
+        )
+        .unwrap();
+    runtime
+        .insert_row(
+            "projects",
+            "project-b",
+            BTreeMap::from([("name".to_owned(), json!("Beta project"))]),
+        )
+        .unwrap();
+
+    let mut rows = vec![
+        MatrixRow {
+            id: "item-1",
+            title: "Alpha",
+            category: "work",
+            body: "ship alpha",
+            tag: Some("red"),
+            active: true,
+            project: Some("project-a"),
+            created_by: "alice",
+            created_rank: 1,
+            updated_rank: 1,
+        },
+        MatrixRow {
+            id: "item-2",
+            title: "Bravo",
+            category: "work",
+            body: "ship beta",
+            tag: Some("blue"),
+            active: true,
+            project: Some("project-a"),
+            created_by: "bob",
+            created_rank: 2,
+            updated_rank: 2,
+        },
+        MatrixRow {
+            id: "item-3",
+            title: "Charlie",
+            category: "home",
+            body: "cook dinner",
+            tag: None,
+            active: false,
+            project: None,
+            created_by: "alice",
+            created_rank: 3,
+            updated_rank: 3,
+        },
+        MatrixRow {
+            id: "item-4",
+            title: "Delta",
+            category: "home",
+            body: "ship delta",
+            tag: Some("red"),
+            active: true,
+            project: Some("project-b"),
+            created_by: "carol",
+            created_rank: 4,
+            updated_rank: 4,
+        },
+        MatrixRow {
+            id: "item-5",
+            title: "Echo",
+            category: "ops",
+            body: "review docs",
+            tag: None,
+            active: false,
+            project: Some("project-b"),
+            created_by: "bob",
+            created_rank: 5,
+            updated_rank: 5,
+        },
+        MatrixRow {
+            id: "item-6",
+            title: "Foxtrot",
+            category: "ops",
+            body: "ship foxtrot",
+            tag: Some("green"),
+            active: true,
+            project: None,
+            created_by: "alice",
+            created_rank: 6,
+            updated_rank: 6,
+        },
+        MatrixRow {
+            id: "item-7",
+            title: "Golf",
+            category: "work",
+            body: "plan launch",
+            tag: Some("blue"),
+            active: false,
+            project: Some("project-a"),
+            created_by: "carol",
+            created_rank: 7,
+            updated_rank: 7,
+        },
+        MatrixRow {
+            id: "item-8",
+            title: "Hotel",
+            category: "home",
+            body: "ship hotel",
+            tag: Some("yellow"),
+            active: true,
+            project: Some("project-b"),
+            created_by: "bob",
+            created_rank: 8,
+            updated_rank: 8,
+        },
+    ];
+
+    for row in &rows {
+        support::run_attributing_to_user(runtime, row.created_by, |runtime| {
+            runtime
+                .insert_row(
+                    "query_items",
+                    row.id,
+                    BTreeMap::from([
+                        ("title".to_owned(), json!(row.title)),
+                        ("category".to_owned(), json!(row.category)),
+                        ("body".to_owned(), json!(row.body)),
+                        ("tag".to_owned(), option_json(row.tag)),
+                        ("active".to_owned(), json!(row.active)),
+                        ("project".to_owned(), option_json(row.project)),
+                    ]),
+                )
+                .unwrap();
+        });
+        std::thread::sleep(std::time::Duration::from_millis(2));
+    }
+
+    support::run_attributing_to_user(runtime, "bob", |runtime| {
+        runtime
+            .update_row(
+                "query_items",
+                "item-2",
+                BTreeMap::from([("body".to_owned(), json!("ship beta updated"))]),
+            )
+            .unwrap();
+    });
+    rows[1].body = "ship beta updated";
+    rows[1].updated_rank = 9;
+    std::thread::sleep(std::time::Duration::from_millis(2));
+
+    support::run_attributing_to_user(runtime, "alice", |runtime| {
+        runtime
+            .update_row(
+                "query_items",
+                "item-6",
+                BTreeMap::from([("body".to_owned(), json!("ship foxtrot updated"))]),
+            )
+            .unwrap();
+    });
+    rows[5].body = "ship foxtrot updated";
+    rows[5].updated_rank = 10;
+
+    rows
+}
+
+fn query_condition_cases() -> Vec<ConditionCase> {
+    vec![
+        condition_case("all rows", vec![]),
+        condition_case(
+            "active eq true",
+            vec![condition("active", "eq", json!(true))],
+        ),
+        condition_case(
+            "active ne false",
+            vec![condition("active", "ne", json!(false))],
+        ),
+        condition_case(
+            "category in work/home",
+            vec![condition("category", "in", json!(["work", "home"]))],
+        ),
+        condition_case(
+            "body contains ship",
+            vec![condition("body", "contains", json!("ship"))],
+        ),
+        condition_case("tag eq null", vec![condition("tag", "eq", JsonValue::Null)]),
+        condition_case("tag ne null", vec![condition("tag", "ne", JsonValue::Null)]),
+        condition_case(
+            "tag in red/null",
+            vec![condition("tag", "in", json!(["red", null]))],
+        ),
+        condition_case(
+            "project eq project-a",
+            vec![condition("project", "eq", json!("project-a"))],
+        ),
+        condition_case(
+            "project in project-a/null",
+            vec![condition("project", "in", json!(["project-a", null]))],
+        ),
+        condition_case(
+            "id in selected",
+            vec![condition(
+                "id",
+                "in",
+                json!(["item-2", "item-5", "missing"]),
+            )],
+        ),
+        condition_case(
+            "id contains item",
+            vec![condition("id", "contains", json!("item-"))],
+        ),
+        condition_case(
+            "createdBy eq alice",
+            vec![condition("$createdBy", "eq", json!("alice"))],
+        ),
+        condition_case(
+            "createdBy ne bob",
+            vec![condition("$createdBy", "ne", json!("bob"))],
+        ),
+        condition_case(
+            "createdBy in alice/carol",
+            vec![condition("$createdBy", "in", json!(["alice", "carol"]))],
+        ),
+        condition_case(
+            "title eq Bravo",
+            vec![condition("title", "eq", json!("Bravo"))],
+        ),
+        condition_case(
+            "title ne Delta",
+            vec![condition("title", "ne", json!("Delta"))],
+        ),
+        condition_case(
+            "createdAt ne zero",
+            vec![condition("$createdAt", "ne", json!(0))],
+        ),
+        condition_case(
+            "updatedAt ne zero",
+            vec![condition("$updatedAt", "ne", json!(0))],
+        ),
+        condition_case(
+            "eq in contains",
+            vec![
+                condition("active", "eq", json!(true)),
+                condition("category", "in", json!(["work", "ops"])),
+                condition("body", "contains", json!("ship")),
+            ],
+        ),
+        condition_case(
+            "ne ne in",
+            vec![
+                condition("tag", "ne", JsonValue::Null),
+                condition("project", "ne", JsonValue::Null),
+                condition("active", "in", json!([true])),
+            ],
+        ),
+        condition_case(
+            "system text and field ops",
+            vec![
+                condition("active", "eq", json!(true)),
+                condition("$createdBy", "ne", json!("bob")),
+                condition("id", "contains", json!("item")),
+            ],
+        ),
+    ]
+}
+
+fn query_order_cases() -> Vec<OrderCase> {
+    vec![
+        order_case("default", vec![]),
+        order_case("title asc", vec![("title", "asc")]),
+        order_case("title desc", vec![("title", "desc")]),
+        order_case(
+            "active asc title asc",
+            vec![("active", "asc"), ("title", "asc")],
+        ),
+        order_case("tag asc id asc", vec![("tag", "asc"), ("id", "asc")]),
+        order_case(
+            "project desc title asc",
+            vec![("project", "desc"), ("title", "asc")],
+        ),
+        order_case("id asc", vec![("id", "asc")]),
+        order_case(
+            "createdBy asc title asc",
+            vec![("$createdBy", "asc"), ("title", "asc")],
+        ),
+        order_case("createdAt asc", vec![("$createdAt", "asc")]),
+        order_case("createdAt desc", vec![("$createdAt", "desc")]),
+        order_case(
+            "updatedAt desc id asc",
+            vec![("$updatedAt", "desc"), ("id", "asc")],
+        ),
+        order_case(
+            "category asc title desc",
+            vec![("category", "asc"), ("title", "desc")],
+        ),
+    ]
+}
+
+fn query_window_cases() -> Vec<WindowCase> {
+    vec![
+        window_case("all", None, None),
+        window_case("limit 1", Some(1), None),
+        window_case("limit 3", Some(3), None),
+        window_case("offset 1", None, Some(1)),
+        window_case("limit 2 offset 1", Some(2), Some(1)),
+        window_case("limit 5 offset 2", Some(5), Some(2)),
+    ]
+}
+
+fn condition_case(label: &'static str, conditions: Vec<JsonValue>) -> ConditionCase {
+    ConditionCase { label, conditions }
+}
+
+fn order_case(label: &'static str, order_by: Vec<(&'static str, &'static str)>) -> OrderCase {
+    OrderCase { label, order_by }
+}
+
+fn window_case(label: &'static str, limit: Option<usize>, offset: Option<usize>) -> WindowCase {
+    WindowCase {
+        label,
+        limit,
+        offset,
+    }
+}
+
+fn condition(column: &'static str, op: &'static str, value: JsonValue) -> JsonValue {
+    json!({"column": column, "op": op, "value": value})
+}
+
+fn built_query(
+    table: &str,
+    conditions: Vec<JsonValue>,
+    order_by: &[(&str, &str)],
+    limit: Option<usize>,
+    offset: Option<usize>,
+) -> BuiltQuery {
+    let mut query = json!({
+        "table": table,
+        "conditions": conditions,
+        "orderBy": order_by
+            .iter()
+            .map(|(column, direction)| json!([column, direction]))
+            .collect::<Vec<_>>(),
+    });
+    if let Some(limit) = limit {
+        query["limit"] = json!(limit);
+    }
+    if let Some(offset) = offset {
+        query["offset"] = json!(offset);
+    }
+    BuiltQuery::from_json_value(query).unwrap()
+}
+
+fn expected_matrix_ids(
+    rows: &[MatrixRow],
+    conditions: &[JsonValue],
+    order_by: &[(&str, &str)],
+    limit: Option<usize>,
+    offset: Option<usize>,
+) -> Vec<String> {
+    let mut rows = rows
+        .iter()
+        .filter(|row| {
+            conditions
+                .iter()
+                .all(|condition| row_matches(row, condition))
+        })
+        .collect::<Vec<_>>();
+    rows.sort_by(|left, right| compare_matrix_rows(left, right, order_by));
+    rows.into_iter()
+        .skip(offset.unwrap_or(0))
+        .take(limit.unwrap_or(usize::MAX))
+        .map(|row| row.id.to_owned())
+        .collect()
+}
+
+fn row_matches(row: &MatrixRow, condition: &JsonValue) -> bool {
+    let column = condition["column"].as_str().unwrap();
+    let op = condition["op"].as_str().unwrap();
+    let expected = &condition["value"];
+    let actual = matrix_value(row, column);
+    match op {
+        "eq" => actual == *expected,
+        "ne" => actual != *expected,
+        "in" => expected
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|candidate| *candidate == actual),
+        "contains" => actual
+            .as_str()
+            .unwrap()
+            .contains(expected.as_str().unwrap()),
+        _ => unreachable!("unsupported test op {op}"),
+    }
+}
+
+fn compare_matrix_rows(left: &MatrixRow, right: &MatrixRow, order_by: &[(&str, &str)]) -> Ordering {
+    if order_by.is_empty() {
+        return right
+            .created_rank
+            .cmp(&left.created_rank)
+            .then_with(|| left.created_rank.cmp(&right.created_rank));
+    }
+    for (column, direction) in order_by {
+        let ordering = sqlite_value_cmp(&matrix_value(left, column), &matrix_value(right, column));
+        let ordering = match *direction {
+            "asc" => ordering,
+            "desc" => ordering.reverse(),
+            _ => unreachable!("unsupported test order direction {direction}"),
+        };
+        if ordering != Ordering::Equal {
+            return ordering;
+        }
+    }
+    left.created_rank.cmp(&right.created_rank)
+}
+
+fn sqlite_value_cmp(left: &JsonValue, right: &JsonValue) -> Ordering {
+    match (left, right) {
+        (JsonValue::Null, JsonValue::Null) => Ordering::Equal,
+        (JsonValue::Null, _) => Ordering::Less,
+        (_, JsonValue::Null) => Ordering::Greater,
+        (JsonValue::Bool(left), JsonValue::Bool(right)) => left.cmp(right),
+        (JsonValue::Number(left), JsonValue::Number(right)) => {
+            left.as_i64().unwrap().cmp(&right.as_i64().unwrap())
+        }
+        (JsonValue::String(left), JsonValue::String(right)) => left.cmp(right),
+        _ => panic!("mixed test value types: {left:?} {right:?}"),
+    }
+}
+
+fn matrix_value(row: &MatrixRow, column: &str) -> JsonValue {
+    match column {
+        "id" => json!(row.id),
+        "$createdBy" => json!(row.created_by),
+        "$createdAt" => json!(row.created_rank),
+        "$updatedAt" => json!(row.updated_rank),
+        "title" => json!(row.title),
+        "category" => json!(row.category),
+        "body" => json!(row.body),
+        "tag" => option_json(row.tag),
+        "active" => json!(row.active),
+        "project" => option_json(row.project),
+        _ => unreachable!("unknown test column {column}"),
+    }
+}
+
+fn option_json(value: Option<&str>) -> JsonValue {
+    value.map_or(JsonValue::Null, |value| json!(value))
+}
+
+fn policy_query_schema() -> SchemaDef {
+    SchemaDef::new()
+        .table("projects", |table| {
+            table.text("title");
+            table.read_if_created_by_user();
+        })
+        .table("tasks", |table| {
+            table.text("title");
+            table.bool("active");
+            table.ref_("project", "projects");
+            table.read_if_ref_readable("project");
+            table.index("active_title", ["active", "title"]);
+        })
+}
+
+fn seed_policy_query_rows(runtime: &mut Runtime) {
+    support::run_attributing_to_user(runtime, "alice", |runtime| {
+        runtime
+            .insert_row(
+                "projects",
+                "project-alice",
+                BTreeMap::from([("title".to_owned(), json!("Alice project"))]),
+            )
+            .unwrap();
+        runtime
+            .insert_row(
+                "tasks",
+                "task-beta",
+                BTreeMap::from([
+                    ("title".to_owned(), json!("Beta")),
+                    ("active".to_owned(), json!(true)),
+                    ("project".to_owned(), json!("project-alice")),
+                ]),
+            )
+            .unwrap();
+        runtime
+            .insert_row(
+                "tasks",
+                "task-delta",
+                BTreeMap::from([
+                    ("title".to_owned(), json!("Delta")),
+                    ("active".to_owned(), json!(true)),
+                    ("project".to_owned(), json!("project-alice")),
+                ]),
+            )
+            .unwrap();
+        runtime
+            .insert_row(
+                "tasks",
+                "task-closed",
+                BTreeMap::from([
+                    ("title".to_owned(), json!("Closed")),
+                    ("active".to_owned(), json!(false)),
+                    ("project".to_owned(), json!("project-alice")),
+                ]),
+            )
+            .unwrap();
+    });
+    support::run_attributing_to_user(runtime, "bob", |runtime| {
+        runtime
+            .insert_row(
+                "projects",
+                "project-bob",
+                BTreeMap::from([("title".to_owned(), json!("Bob project"))]),
+            )
+            .unwrap();
+        runtime
+            .insert_row(
+                "tasks",
+                "task-alpha",
+                BTreeMap::from([
+                    ("title".to_owned(), json!("Alpha")),
+                    ("active".to_owned(), json!(true)),
+                    ("project".to_owned(), json!("project-bob")),
+                ]),
+            )
+            .unwrap();
+    });
+}
+
+fn active_tasks_by_title_query(limit: usize) -> BuiltQuery {
+    BuiltQuery::from_json_value(json!({
+        "table": "tasks",
+        "conditions": [{"column": "active", "op": "eq", "value": true}],
+        "orderBy": [["title", "asc"]],
+        "limit": limit,
+    }))
+    .unwrap()
+}
+
+fn subscription_ids(rows: &[mini_jazz_sqlite::RowView]) -> Vec<&str> {
+    rows.iter().map(|row| row.id.as_str()).collect()
+}
+
+fn query_ids(runtime: &Runtime, query: BuiltQuery) -> Vec<String> {
+    runtime
+        .query(query)
+        .unwrap()
+        .into_iter()
+        .map(|row| row.id)
+        .collect()
+}

--- a/crates/mini-jazz-sqlite/tests/whole_system/query_matrix.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/query_matrix.rs
@@ -1,6 +1,7 @@
 use super::*;
 use serde_json::Value as JsonValue;
 use std::cmp::Ordering;
+use std::collections::BTreeSet;
 
 #[derive(Clone)]
 struct MatrixRow {
@@ -206,12 +207,186 @@ fn policy_filtered_query_refresh_replaces_ordered_page_boundary_after_incrementa
 }
 
 #[test]
+fn policy_filtered_created_at_page_refresh_keeps_visible_rows_ahead_of_hidden_storage() {
+    let schema = policy_query_schema();
+    let mut upstream =
+        Runtime::open_trusted_with_schema(Storage::Memory, "upstream", schema.clone()).unwrap();
+    let mut peer = Runtime::open_with_schema(Storage::Memory, "peer", "alice", schema).unwrap();
+
+    support::run_attributing_to_user(&mut upstream, "alice", |runtime| {
+        runtime
+            .insert_row(
+                "projects",
+                "project-alice",
+                BTreeMap::from([("title".to_owned(), json!("Alice project"))]),
+            )
+            .unwrap();
+        runtime
+            .insert_row(
+                "tasks",
+                "task-visible-old",
+                BTreeMap::from([
+                    ("title".to_owned(), json!("Visible old")),
+                    ("active".to_owned(), json!(true)),
+                    ("project".to_owned(), json!("project-alice")),
+                ]),
+            )
+            .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        runtime
+            .insert_row(
+                "tasks",
+                "task-visible-new",
+                BTreeMap::from([
+                    ("title".to_owned(), json!("Visible new")),
+                    ("active".to_owned(), json!(true)),
+                    ("project".to_owned(), json!("project-alice")),
+                ]),
+            )
+            .unwrap();
+    });
+    support::run_attributing_to_user(&mut upstream, "bob", |runtime| {
+        runtime
+            .insert_row(
+                "projects",
+                "project-bob",
+                BTreeMap::from([("title".to_owned(), json!("Bob project"))]),
+            )
+            .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        runtime
+            .insert_row(
+                "tasks",
+                "task-hidden-newer",
+                BTreeMap::from([
+                    ("title".to_owned(), json!("Hidden newer")),
+                    ("active".to_owned(), json!(true)),
+                    ("project".to_owned(), json!("project-bob")),
+                ]),
+            )
+            .unwrap();
+    });
+
+    peer.apply_bundle(&upstream.export_table_history("projects").unwrap())
+        .unwrap();
+    peer.apply_bundle(&upstream.export_table_history("tasks").unwrap())
+        .unwrap();
+    let query = BuiltQuery::from_json_value(json!({
+        "table": "tasks",
+        "conditions": [{"column": "active", "op": "eq", "value": true}],
+        "orderBy": [["$createdAt", "desc"]],
+        "limit": 2,
+    }))
+    .unwrap();
+    let initial = support::run_as_user(&mut upstream, "alice", |runtime| {
+        runtime.export_query(query.clone()).unwrap()
+    });
+    peer.apply_bundle(&initial).unwrap();
+    assert_eq!(
+        query_ids(&peer, query.clone()),
+        vec!["task-visible-new", "task-visible-old"]
+    );
+
+    support::run_attributing_to_user(&mut upstream, "alice", |runtime| {
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        runtime
+            .insert_row(
+                "tasks",
+                "task-visible-newest",
+                BTreeMap::from([
+                    ("title".to_owned(), json!("Visible newest")),
+                    ("active".to_owned(), json!(true)),
+                    ("project".to_owned(), json!("project-alice")),
+                ]),
+            )
+            .unwrap();
+    });
+    let observed = peer.observed_query_reads().unwrap();
+    let refreshes = support::run_as_user(&mut upstream, "alice", |runtime| {
+        runtime.export_query_read_refreshes(&observed).unwrap()
+    });
+    for refresh in refreshes {
+        peer.apply_bundle(&refresh).unwrap();
+    }
+
+    assert_eq!(
+        query_ids(&peer, query),
+        vec!["task-visible-newest", "task-visible-new"]
+    );
+}
+
+#[test]
+fn built_query_page_export_does_not_collect_every_matching_row_as_repair_data() {
+    let schema = SchemaDef::new().table("tasks", |table| {
+        table.text("title");
+        table.bool("done");
+    });
+    let mut upstream =
+        Runtime::open_with_schema(Storage::Memory, "upstream", "alice", schema).unwrap();
+
+    for (id, title) in [
+        ("task-alpha", "Alpha"),
+        ("task-beta", "Beta"),
+        ("task-gamma", "Gamma"),
+    ] {
+        upstream
+            .insert_row(
+                "tasks",
+                id,
+                BTreeMap::from([
+                    ("title".to_owned(), json!(title)),
+                    ("done".to_owned(), json!(false)),
+                ]),
+            )
+            .unwrap();
+    }
+
+    let query = BuiltQuery::from_json_value(json!({
+        "table": "tasks",
+        "conditions": [{"column": "done", "op": "eq", "value": false}],
+        "orderBy": [["title", "asc"]],
+        "limit": 2,
+    }))
+    .unwrap();
+    let task_ids = upstream
+        .export_query(query)
+        .unwrap()
+        .history
+        .into_iter()
+        .filter(|record| record.table == "tasks")
+        .map(|record| record.row_id)
+        .collect::<Vec<_>>();
+
+    assert_eq!(task_ids, vec!["task-alpha", "task-beta"]);
+}
+
+#[test]
+fn policy_filtered_built_query_export_does_not_include_hidden_repair_rows() {
+    let schema = policy_query_schema();
+    let mut upstream =
+        Runtime::open_trusted_with_schema(Storage::Memory, "upstream", schema).unwrap();
+    seed_policy_query_rows(&mut upstream);
+
+    let bundle = support::run_as_user(&mut upstream, "alice", |runtime| {
+        runtime
+            .export_query(active_tasks_by_title_query(2))
+            .unwrap()
+    });
+    let task_ids = bundle
+        .history
+        .iter()
+        .filter(|record| record.table == "tasks")
+        .map(|record| record.row_id.as_str())
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(task_ids, BTreeSet::from(["task-beta", "task-delta"]));
+}
+
+#[test]
 fn built_query_scope_export_refreshes_system_timestamp_and_system_text_conditions() {
     let schema = support::notes_schema();
     let mut alice =
         Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema.clone()).unwrap();
-    let mut peer =
-        Runtime::open_with_schema(Storage::Memory, "peer-node", "alice", schema).unwrap();
 
     alice
         .insert_row(
@@ -261,6 +436,10 @@ fn built_query_scope_export_refreshes_system_timestamp_and_system_text_condition
             None,
         ),
     ] {
+        let mut peer =
+            Runtime::open_with_schema(Storage::Memory, "peer-node", "alice", schema.clone())
+                .unwrap();
+
         peer.apply_bundle(&alice.export_query(query.clone()).unwrap())
             .unwrap();
         assert_eq!(query_ids(&peer, query), vec!["note-visible"]);

--- a/crates/mini-jazz-sqlite/tests/whole_system/schema_lenses.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/schema_lenses.rs
@@ -255,7 +255,7 @@ fn renamed_field_lens_query_scope_syncs_and_repairs_rows() {
     )
     .unwrap();
     let rows = peer
-        .read_rows_where_eq("tasks", "name", json!("Important"))
+        .query(support::eq_query("tasks", "name", json!("Important")))
         .unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].id, "task-1");
@@ -277,7 +277,7 @@ fn renamed_field_lens_query_scope_syncs_and_repairs_rows() {
     .unwrap();
 
     assert!(peer
-        .read_rows_where_eq("tasks", "name", json!("Important"))
+        .query(support::eq_query("tasks", "name", json!("Important")))
         .unwrap()
         .is_empty());
 }
@@ -342,7 +342,7 @@ fn renamed_field_lens_observed_query_refresh_emits_semantic_removal() {
     let diffs = peer.poll_subscription(&mut subscription).unwrap();
     assert!(matches!(&diffs[..], [RowDiff::Removed(row)] if row.id == "task-1"));
     assert!(peer
-        .read_rows_where_eq("tasks", "name", json!("Important"))
+        .query(support::eq_query("tasks", "name", json!("Important")))
         .unwrap()
         .is_empty());
 }
@@ -659,7 +659,11 @@ fn user_columns_with_system_prefix_are_escaped_physically() {
         .unwrap();
 
     let rows = alice
-        .read_rows_where_eq("records", "j_title", json!("Looks like system"))
+        .query(support::eq_query(
+            "records",
+            "j_title",
+            json!("Looks like system"),
+        ))
         .unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].values["j_pinned"], json!(true));
@@ -741,7 +745,7 @@ fn index_only_schema_changes_are_semantically_compatible() {
         .unwrap();
 
     let rows = peer
-        .read_rows_where_eq("tasks", "done", json!(false))
+        .query(support::eq_query("tasks", "done", json!(false)))
         .unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].values["title"], json!("Compatible"));

--- a/crates/mini-jazz-sqlite/tests/whole_system/schema_lenses.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/schema_lenses.rs
@@ -748,7 +748,7 @@ fn index_only_schema_changes_are_semantically_compatible() {
 
     peer.apply_bundle(
         &alice
-            .export_query_where_eq_top_created_at_desc("tasks", "done", json!(false), 1)
+            .export_query(support::top_created_query("tasks", "done", json!(false), 1))
             .unwrap(),
     )
     .unwrap();

--- a/crates/mini-jazz-sqlite/tests/whole_system/subscriptions.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/subscriptions.rs
@@ -123,7 +123,9 @@ fn built_query_reads_newest_matching_rows_from_jazz_tools_json_shape() {
 fn built_query_lowers_predicates_ordering_and_window_to_sqlite() {
     let schema = support::notes_schema();
     let mut alice =
-        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema).unwrap();
+        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema.clone()).unwrap();
+    let mut peer =
+        Runtime::open_with_schema(Storage::Memory, "peer-node", "alice", schema).unwrap();
 
     for (id, body, pinned) in [
         ("note-old", "keep old", true),
@@ -156,10 +158,48 @@ fn built_query_lowers_predicates_ordering_and_window_to_sqlite() {
     }))
     .unwrap();
 
-    let rows = alice.query(query).unwrap();
+    let rows = alice.query(query.clone()).unwrap();
     assert_eq!(
         rows.iter().map(|row| row.id.as_str()).collect::<Vec<_>>(),
         vec!["note-middle", "note-old"]
+    );
+
+    peer.apply_bundle(&alice.export_query(query.clone()).unwrap())
+        .unwrap();
+    assert_eq!(
+        peer.query(query.clone())
+            .unwrap()
+            .iter()
+            .map(|row| row.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["note-middle", "note-old"]
+    );
+
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    alice
+        .insert_row(
+            "notes",
+            "note-newest",
+            BTreeMap::from([
+                ("body".to_owned(), json!("keep newest")),
+                ("pinned".to_owned(), json!(true)),
+            ]),
+        )
+        .unwrap();
+
+    for refresh in alice
+        .export_query_read_refreshes(&peer.observed_query_reads().unwrap())
+        .unwrap()
+    {
+        peer.apply_bundle(&refresh).unwrap();
+    }
+    assert_eq!(
+        peer.query(query)
+            .unwrap()
+            .iter()
+            .map(|row| row.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["note-new", "note-middle"]
     );
 }
 

--- a/crates/mini-jazz-sqlite/tests/whole_system/subscriptions.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/subscriptions.rs
@@ -120,6 +120,50 @@ fn built_query_reads_newest_matching_rows_from_jazz_tools_json_shape() {
 }
 
 #[test]
+fn built_query_lowers_predicates_ordering_and_window_to_sqlite() {
+    let schema = support::notes_schema();
+    let mut alice =
+        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema).unwrap();
+
+    for (id, body, pinned) in [
+        ("note-old", "keep old", true),
+        ("note-middle", "keep middle", true),
+        ("note-hidden", "keep hidden", false),
+        ("note-new", "keep new", true),
+    ] {
+        alice
+            .insert_row(
+                "notes",
+                id,
+                BTreeMap::from([
+                    ("body".to_owned(), json!(body)),
+                    ("pinned".to_owned(), json!(pinned)),
+                ]),
+            )
+            .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(2));
+    }
+
+    let query = BuiltQuery::from_json_value(json!({
+        "table": "notes",
+        "conditions": [
+            {"column": "pinned", "op": "eq", "value": true},
+            {"column": "body", "op": "contains", "value": "keep"}
+        ],
+        "orderBy": [["$createdAt", "desc"]],
+        "limit": 2,
+        "offset": 1
+    }))
+    .unwrap();
+
+    let rows = alice.query(query).unwrap();
+    assert_eq!(
+        rows.iter().map(|row| row.id.as_str()).collect::<Vec<_>>(),
+        vec!["note-middle", "note-old"]
+    );
+}
+
+#[test]
 fn built_query_rejects_graph_only_jazz_tools_fields() {
     let query = BuiltQuery::from_json_value(json!({
         "table": "notes",

--- a/crates/mini-jazz-sqlite/tests/whole_system/subscriptions.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/subscriptions.rs
@@ -54,6 +54,190 @@ fn rejection_subscription_reports_new_sync_rejections_with_detail_once() {
 }
 
 #[test]
+fn built_query_reads_newest_matching_rows_from_jazz_tools_json_shape() {
+    let schema = support::notes_schema();
+    let mut alice =
+        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema).unwrap();
+
+    alice
+        .insert_row(
+            "notes",
+            "note-old",
+            BTreeMap::from([
+                ("body".to_owned(), json!("old")),
+                ("pinned".to_owned(), json!(true)),
+            ]),
+        )
+        .unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    alice
+        .insert_row(
+            "notes",
+            "note-middle",
+            BTreeMap::from([
+                ("body".to_owned(), json!("middle")),
+                ("pinned".to_owned(), json!(true)),
+            ]),
+        )
+        .unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    alice
+        .insert_row(
+            "notes",
+            "note-new",
+            BTreeMap::from([
+                ("body".to_owned(), json!("new")),
+                ("pinned".to_owned(), json!(true)),
+            ]),
+        )
+        .unwrap();
+    alice
+        .insert_row(
+            "notes",
+            "note-hidden",
+            BTreeMap::from([
+                ("body".to_owned(), json!("hidden")),
+                ("pinned".to_owned(), json!(false)),
+            ]),
+        )
+        .unwrap();
+
+    let query = BuiltQuery::from_json_value(json!({
+        "table": "notes",
+        "conditions": [{"column": "pinned", "op": "eq", "value": true}],
+        "includes": {},
+        "orderBy": [["$createdAt", "desc"]],
+        "limit": 2
+    }))
+    .unwrap();
+
+    let rows = alice.query(query.clone()).unwrap();
+    assert_eq!(
+        rows.iter().map(|row| row.id.as_str()).collect::<Vec<_>>(),
+        vec!["note-new", "note-middle"]
+    );
+    assert_eq!(alice.one(query).unwrap().unwrap().id, "note-new");
+}
+
+#[test]
+fn built_query_rejects_graph_only_jazz_tools_fields() {
+    let query = BuiltQuery::from_json_value(json!({
+        "table": "notes",
+        "conditions": [],
+        "includes": {"author": true}
+    }))
+    .unwrap_err();
+
+    assert!(query
+        .to_string()
+        .contains("mini-sqlite query does not support includes"));
+}
+
+#[test]
+fn query_subscription_delta_matches_jazz_tools_subscribe_all_shape() {
+    let schema = support::notes_schema();
+    let mut alice =
+        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema).unwrap();
+
+    alice
+        .insert_row(
+            "notes",
+            "note-old",
+            BTreeMap::from([
+                ("body".to_owned(), json!("old")),
+                ("pinned".to_owned(), json!(true)),
+            ]),
+        )
+        .unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    alice
+        .insert_row(
+            "notes",
+            "note-middle",
+            BTreeMap::from([
+                ("body".to_owned(), json!("middle")),
+                ("pinned".to_owned(), json!(true)),
+            ]),
+        )
+        .unwrap();
+
+    let query = BuiltQuery::from_json_value(json!({
+        "table": "notes",
+        "conditions": [{"column": "pinned", "op": "eq", "value": true}],
+        "orderBy": [["$createdAt", "desc"]],
+        "limit": 2
+    }))
+    .unwrap();
+    let mut subscription = alice.subscribe_query(query).unwrap();
+
+    let initial = subscription.initial_delta();
+    assert_eq!(
+        initial
+            .all
+            .iter()
+            .map(|row| row.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["note-middle", "note-old"]
+    );
+    assert_eq!(
+        initial.delta,
+        vec![
+            SubscriptionRowDelta::Added {
+                id: "note-middle".to_owned(),
+                index: 0,
+                item: initial.all[0].clone(),
+            },
+            SubscriptionRowDelta::Added {
+                id: "note-old".to_owned(),
+                index: 1,
+                item: initial.all[1].clone(),
+            },
+        ]
+    );
+
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    alice
+        .insert_row(
+            "notes",
+            "note-new",
+            BTreeMap::from([
+                ("body".to_owned(), json!("new")),
+                ("pinned".to_owned(), json!(true)),
+            ]),
+        )
+        .unwrap();
+
+    let update = alice.subscription_delta(&mut subscription).unwrap();
+    assert_eq!(
+        update
+            .all
+            .iter()
+            .map(|row| row.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["note-new", "note-middle"]
+    );
+    assert_eq!(
+        update.delta,
+        vec![
+            SubscriptionRowDelta::Added {
+                id: "note-new".to_owned(),
+                index: 0,
+                item: update.all[0].clone(),
+            },
+            SubscriptionRowDelta::Removed {
+                id: "note-old".to_owned(),
+                index: 1,
+            },
+            SubscriptionRowDelta::Updated {
+                id: "note-middle".to_owned(),
+                index: 1,
+                item: None,
+            },
+        ]
+    );
+}
+
+#[test]
 fn restarted_rejection_subscription_baselines_old_rejections_and_reports_later_ones() {
     let dir = tempdir().unwrap();
     let worker_path = dir.path().join("worker.sqlite");

--- a/crates/mini-jazz-sqlite/tests/whole_system/subscriptions.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/subscriptions.rs
@@ -157,6 +157,15 @@ fn built_query_lowers_predicates_ordering_and_window_to_sqlite() {
         "offset": 1
     }))
     .unwrap();
+    let all_synced_matching = BuiltQuery::from_json_value(json!({
+        "table": "notes",
+        "conditions": [
+            {"column": "pinned", "op": "eq", "value": true},
+            {"column": "body", "op": "contains", "value": "keep"}
+        ],
+        "orderBy": [["$createdAt", "desc"]]
+    }))
+    .unwrap();
 
     let rows = alice.query(query.clone()).unwrap();
     assert_eq!(
@@ -200,6 +209,14 @@ fn built_query_lowers_predicates_ordering_and_window_to_sqlite() {
             .map(|row| row.id.as_str())
             .collect::<Vec<_>>(),
         vec!["note-new", "note-middle"]
+    );
+    assert_eq!(
+        peer.query(all_synced_matching)
+            .unwrap()
+            .iter()
+            .map(|row| row.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["note-newest", "note-new", "note-middle"]
     );
 }
 
@@ -1078,6 +1095,71 @@ fn ordered_field_page_subscription_replaces_displaced_boundary_row() {
     assert!(diffs
         .iter()
         .any(|diff| matches!(diff, RowDiff::Removed(row) if row.id == "doc-old")));
+}
+
+#[test]
+fn ordered_field_page_subscription_delta_replaces_displaced_boundary_row() {
+    let schema = SchemaDef::new().table("documents", |table| {
+        table.text("owner_id");
+        table.text("updated_at");
+        table.text("title");
+        table.index("owner_updated", ["owner_id", "updated_at"]);
+    });
+    let mut alice =
+        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema).unwrap();
+
+    for (id, updated_at) in [("doc-old", "0001"), ("doc-middle", "0002")] {
+        alice
+            .insert_row(
+                "documents",
+                id,
+                BTreeMap::from([
+                    ("owner_id".to_owned(), json!("alice")),
+                    ("updated_at".to_owned(), json!(updated_at)),
+                    ("title".to_owned(), json!(id)),
+                ]),
+            )
+            .unwrap();
+    }
+
+    let mut subscription = alice
+        .subscribe_rows_where_eq_top_field_desc(
+            "documents",
+            "owner_id",
+            json!("alice"),
+            "updated_at",
+            2,
+        )
+        .unwrap();
+
+    alice
+        .insert_row(
+            "documents",
+            "doc-new",
+            BTreeMap::from([
+                ("owner_id".to_owned(), json!("alice")),
+                ("updated_at".to_owned(), json!("0003")),
+                ("title".to_owned(), json!("newest")),
+            ]),
+        )
+        .unwrap();
+    let delta = alice.subscription_delta(&mut subscription).unwrap();
+
+    assert_eq!(
+        delta
+            .all
+            .iter()
+            .map(|row| row.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["doc-new", "doc-middle"]
+    );
+    assert!(delta
+        .delta
+        .iter()
+        .any(|change| matches!(change, SubscriptionRowDelta::Added { id, .. } if id == "doc-new")));
+    assert!(delta.delta.iter().any(
+        |change| matches!(change, SubscriptionRowDelta::Removed { id, .. } if id == "doc-old")
+    ));
 }
 
 #[test]

--- a/crates/mini-jazz-sqlite/tests/whole_system/subscriptions.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/subscriptions.rs
@@ -710,7 +710,12 @@ fn restarted_ordered_page_subscription_emits_boundary_refresh_diff() {
         worker
             .apply_bundle(
                 &upstream
-                    .export_query_where_eq_top_created_at_desc("notes", "pinned", json!(true), 2)
+                    .export_query(support::top_created_query(
+                        "notes",
+                        "pinned",
+                        json!(true),
+                        2,
+                    ))
                     .unwrap(),
             )
             .unwrap();
@@ -882,7 +887,12 @@ fn ordered_page_subscription_replaces_displaced_boundary_row() {
         .unwrap();
 
     let mut subscription = alice
-        .subscribe_rows_where_eq_top_created_at_desc("notes", "pinned", json!(true), 2)
+        .subscribe_query(support::top_created_query(
+            "notes",
+            "pinned",
+            json!(true),
+            2,
+        ))
         .unwrap();
     assert_eq!(
         subscription

--- a/crates/mini-jazz-sqlite/tests/whole_system/subscriptions.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/subscriptions.rs
@@ -312,10 +312,10 @@ fn query_subscription_delta_matches_jazz_tools_subscribe_all_shape() {
                 id: "note-old".to_owned(),
                 index: 1,
             },
-            SubscriptionRowDelta::Updated {
+            SubscriptionRowDelta::Moved {
                 id: "note-middle".to_owned(),
+                previous_index: 0,
                 index: 1,
-                item: None,
             },
         ]
     );

--- a/crates/mini-jazz-sqlite/tests/whole_system/sync_fate.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/sync_fate.rs
@@ -1276,6 +1276,102 @@ fn top_created_at_query_scope_refresh_replaces_displaced_page_boundary_row() {
 }
 
 #[test]
+fn top_created_at_query_scope_refresh_repairs_system_predicates() {
+    let schema = support::notes_schema();
+    let mut alice =
+        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema.clone()).unwrap();
+    let mut peer =
+        Runtime::open_with_schema(Storage::Memory, "peer-node", "alice", schema.clone()).unwrap();
+
+    alice
+        .insert_row(
+            "notes",
+            "note-old",
+            BTreeMap::from([
+                ("body".to_owned(), json!("old boundary")),
+                ("pinned".to_owned(), json!(true)),
+            ]),
+        )
+        .unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    alice
+        .insert_row(
+            "notes",
+            "note-middle",
+            BTreeMap::from([
+                ("body".to_owned(), json!("middle")),
+                ("pinned".to_owned(), json!(true)),
+            ]),
+        )
+        .unwrap();
+
+    let created_by_query = support::top_created_query("notes", "$createdBy", json!("alice"), 2);
+    peer.apply_bundle(&alice.export_query(created_by_query.clone()).unwrap())
+        .unwrap();
+    assert_eq!(
+        peer.query(created_by_query.clone())
+            .unwrap()
+            .iter()
+            .map(|row| row.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["note-middle", "note-old"]
+    );
+
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    alice
+        .insert_row(
+            "notes",
+            "note-new",
+            BTreeMap::from([
+                ("body".to_owned(), json!("newest")),
+                ("pinned".to_owned(), json!(true)),
+            ]),
+        )
+        .unwrap();
+    for refresh in alice
+        .export_query_read_refreshes(&peer.observed_query_reads().unwrap())
+        .unwrap()
+    {
+        peer.apply_bundle(&refresh).unwrap();
+    }
+
+    assert_eq!(
+        peer.query(support::top_created_query(
+            "notes",
+            "$createdBy",
+            json!("alice"),
+            3,
+        ))
+        .unwrap()
+        .iter()
+        .map(|row| row.id.as_str())
+        .collect::<Vec<_>>(),
+        vec!["note-new", "note-middle"]
+    );
+
+    let mut id_source =
+        Runtime::open_with_schema(Storage::Memory, "id-source", "alice", schema.clone()).unwrap();
+    let mut id_peer =
+        Runtime::open_with_schema(Storage::Memory, "id-peer", "alice", schema).unwrap();
+    id_source
+        .insert_row(
+            "notes",
+            "note-target",
+            BTreeMap::from([
+                ("body".to_owned(), json!("target")),
+                ("pinned".to_owned(), json!(true)),
+            ]),
+        )
+        .unwrap();
+
+    let id_query = support::top_created_query("notes", "id", json!("note-target"), 1);
+    id_peer
+        .apply_bundle(&id_source.export_query(id_query.clone()).unwrap())
+        .unwrap();
+    assert_eq!(id_peer.query(id_query).unwrap()[0].id, "note-target");
+}
+
+#[test]
 fn accepted_global_fate_update_reaches_peer_transaction_info() {
     let mut alice = Runtime::open(Storage::Memory, "alice-node", "alice").unwrap();
     let mut peer = Runtime::open(Storage::Memory, "alice-peer-node", "alice").unwrap();

--- a/crates/mini-jazz-sqlite/tests/whole_system/sync_fate.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/sync_fate.rs
@@ -138,14 +138,24 @@ fn durable_ordered_query_read_refreshes_page_boundary_after_restart() {
             .unwrap();
         support::apply(
             upstream
-                .export_query_where_eq_top_created_at_desc("notes", "pinned", json!(true), 2)
+                .export_query(support::top_created_query(
+                    "notes",
+                    "pinned",
+                    json!(true),
+                    2,
+                ))
                 .unwrap(),
             &mut worker,
         )
         .unwrap();
         assert_eq!(
             worker
-                .read_rows_where_eq_top_created_at_desc("notes", "pinned", json!(true), 2)
+                .query(support::top_created_query(
+                    "notes",
+                    "pinned",
+                    json!(true),
+                    2,
+                ))
                 .unwrap()
                 .iter()
                 .map(|row| row.id.as_str())
@@ -173,7 +183,12 @@ fn durable_ordered_query_read_refreshes_page_boundary_after_restart() {
 
     assert_eq!(
         reopened
-            .read_rows_where_eq_top_created_at_desc("notes", "pinned", json!(true), 3)
+            .query(support::top_created_query(
+                "notes",
+                "pinned",
+                json!(true),
+                3,
+            ))
             .unwrap()
             .iter()
             .map(|row| row.id.as_str())

--- a/crates/mini-jazz-sqlite/tests/whole_system/sync_fate.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/sync_fate.rs
@@ -1242,10 +1242,13 @@ fn top_created_at_query_scope_refresh_replaces_displaced_page_boundary_row() {
 
     peer.apply_bundle(&alice.export_query_scope_newest_open_todos(2).unwrap())
         .unwrap();
+    let observed_query = peer.observed_query_reads().unwrap()[0].clone();
+    assert_eq!(observed_query.op, "query");
     assert_eq!(
-        peer.observed_query_reads().unwrap()[0].op,
-        "eq_top_created_at_desc"
+        observed_query.value["orderBy"],
+        json!([["$createdAt", "desc"]])
     );
+    assert_eq!(observed_query.value["limit"], json!(2));
     assert_eq!(
         peer.newest_open_todos(2)
             .unwrap()

--- a/examples/mini-sqlite-todo/index.html
+++ b/examples/mini-sqlite-todo/index.html
@@ -28,7 +28,8 @@
       }
 
       button,
-      input {
+      input,
+      select {
         font: inherit;
       }
 
@@ -47,7 +48,8 @@
       }
 
       button:disabled,
-      input:disabled {
+      input:disabled,
+      select:disabled {
         cursor: wait;
         opacity: 0.6;
       }
@@ -90,12 +92,14 @@
 
       .todo-form {
         display: grid;
-        grid-template-columns: minmax(0, 1fr) auto;
+        grid-template-columns: minmax(0, 1.3fr) minmax(180px, 0.7fr) auto;
         gap: 10px;
         margin-top: 22px;
       }
 
-      .todo-form input {
+      .todo-form input,
+      .controls input,
+      .controls select {
         width: 100%;
         min-height: 2.5rem;
         border: 1px solid #b7c1ba;
@@ -103,6 +107,56 @@
         background: #ffffff;
         color: #18211f;
         padding: 0 0.85rem;
+      }
+
+      .controls {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) 142px 142px;
+        gap: 10px;
+        margin-top: 12px;
+      }
+
+      .controls label {
+        display: grid;
+        gap: 4px;
+        color: #596760;
+        font-size: 0.8rem;
+        font-weight: 700;
+        text-transform: uppercase;
+      }
+
+      .label-filters {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        min-height: 34px;
+        margin-top: 14px;
+      }
+
+      .chip,
+      .label-chip {
+        border-radius: 999px;
+        font-size: 0.82rem;
+        line-height: 1;
+      }
+
+      .chip {
+        min-height: 2rem;
+        border-color: #b7c1ba;
+        background: #ffffff;
+        color: #24352f;
+        padding: 0 0.75rem;
+      }
+
+      .chip:hover:not(:disabled),
+      .chip.selected {
+        border-color: #2f66c3;
+        background: #e9f0ff;
+        color: #163d82;
+      }
+
+      .generate {
+        margin-top: 12px;
       }
 
       .error-message {
@@ -121,7 +175,7 @@
 
       .todo-item {
         display: grid;
-        grid-template-columns: minmax(0, 1fr) auto;
+        grid-template-columns: minmax(0, 1fr) minmax(160px, auto) auto;
         align-items: center;
         gap: 10px;
         min-height: 48px;
@@ -152,6 +206,20 @@
         text-decoration: line-through;
       }
 
+      .todo-meta {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        gap: 6px;
+        min-width: 0;
+      }
+
+      .label-chip {
+        background: #f4ead5;
+        color: #5f4418;
+        padding: 0.34rem 0.48rem;
+      }
+
       .todo-item button {
         background: transparent;
         border-color: #b7c1ba;
@@ -174,6 +242,7 @@
 
         .app-header,
         .todo-form,
+        .controls,
         .todo-item {
           grid-template-columns: 1fr;
         }
@@ -182,6 +251,10 @@
           display: grid;
           align-items: start;
           gap: 10px;
+        }
+
+        .todo-meta {
+          justify-content: flex-start;
         }
 
         .todo-item button {

--- a/examples/mini-sqlite-todo/index.html
+++ b/examples/mini-sqlite-todo/index.html
@@ -133,8 +133,7 @@
         margin-top: 14px;
       }
 
-      .chip,
-      .label-chip {
+      .chip {
         border-radius: 999px;
         font-size: 0.82rem;
         line-height: 1;
@@ -175,7 +174,7 @@
 
       .todo-item {
         display: grid;
-        grid-template-columns: minmax(0, 1fr) minmax(160px, auto) auto;
+        grid-template-columns: minmax(0, 1fr) auto;
         align-items: center;
         gap: 10px;
         min-height: 48px;
@@ -204,20 +203,6 @@
       .todo-item.done span {
         color: #6b756f;
         text-decoration: line-through;
-      }
-
-      .todo-meta {
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: flex-end;
-        gap: 6px;
-        min-width: 0;
-      }
-
-      .label-chip {
-        background: #f4ead5;
-        color: #5f4418;
-        padding: 0.34rem 0.48rem;
       }
 
       .todo-item button {
@@ -251,10 +236,6 @@
           display: grid;
           align-items: start;
           gap: 10px;
-        }
-
-        .todo-meta {
-          justify-content: flex-start;
         }
 
         .todo-item button {

--- a/examples/mini-sqlite-todo/src/db-worker.js
+++ b/examples/mini-sqlite-todo/src/db-worker.js
@@ -7,16 +7,8 @@ const SORT_COLUMNS = {
   date: "$createdAt",
   name: "title",
 };
-const LABELS_QUERY = {
-  table: "labels",
-  conditions: [],
-  includes: {},
-  orderBy: [["name", "asc"]],
-};
 let db;
 let labelsById = new Map();
-let labelsSubscription;
-let suppressLabelSubscriptionState = false;
 let filters = {
   search: "",
   labelIds: [],
@@ -32,7 +24,7 @@ self.onmessage = async ({ data }) => {
       if (!db.readRows("projects").some((row) => row.id === PROJECT_ID)) {
         db.insertRow("projects", PROJECT_ID, { title: "Todo list" });
       }
-      withSuppressedLabelState(() => subscribeToLabels());
+      refreshLabelCache();
     } else if (data.type === "add") {
       const id = `todo-${crypto.randomUUID()}`;
       db.insertRow("todos", id, {
@@ -40,12 +32,12 @@ self.onmessage = async ({ data }) => {
         done: false,
         project: PROJECT_ID,
       });
-      withSuppressedLabelState(() => addTodoLabels(id, data.labels));
+      addTodoLabels(id, data.labels);
     } else if (data.type === "setFilters") {
       filters = sanitizeFilters(data.filters);
     } else if (data.type === "generate") {
       const startedAt = performance.now();
-      withSuppressedLabelState(() => ensureLabels(GENERATED_LABELS));
+      ensureLabels(GENERATED_LABELS);
       for (let i = 0; i < data.count; i++) {
         const todoId = `todo-${crypto.randomUUID()}`;
         const todoLabels = labelsForGeneratedTodo(i);
@@ -132,25 +124,6 @@ function addTodoLabels(todoId, labelNames) {
   }
 }
 
-function subscribeToLabels() {
-  if (labelsSubscription !== undefined) return;
-  labelsSubscription = db.subscribe(LABELS_QUERY, ({ all }) => {
-    labelsById = new Map(all.map(labelRow));
-    if (!suppressLabelSubscriptionState) {
-      postState();
-    }
-  });
-}
-
-function withSuppressedLabelState(fn) {
-  suppressLabelSubscriptionState = true;
-  try {
-    return fn();
-  } finally {
-    suppressLabelSubscriptionState = false;
-  }
-}
-
 function ensureLabels(labelNames) {
   const labels = [];
   const seen = new Set();
@@ -170,6 +143,10 @@ function ensureLabels(labelNames) {
 
 function labelRow(row) {
   return [row.id, { id: row.id, name: row.values.name }];
+}
+
+function refreshLabelCache() {
+  labelsById = new Map(db.readRows("labels").map(labelRow));
 }
 
 function sortedLabels() {

--- a/examples/mini-sqlite-todo/src/db-worker.js
+++ b/examples/mini-sqlite-todo/src/db-worker.js
@@ -2,14 +2,19 @@ import init, { MiniJazzRuntime } from "./generated/mini-jazz-sqlite-wasm/mini_ja
 
 const PROJECT_ID = "todo-list";
 const PAGE_SIZE = 10;
-const PAGE_QUERY = {
-  table: "todos",
-  conditions: [{ column: "done", op: "eq", value: false }],
-  includes: {},
-  orderBy: [["$createdAt", "desc"]],
-  limit: PAGE_SIZE,
+const GENERATED_LABELS = ["work", "home", "urgent", "later", "bug", "idea", "docs", "release"];
+const SORT_COLUMNS = {
+  date: "$createdAt",
+  name: "title",
 };
 let db;
+let labelsById = new Map();
+let filters = {
+  search: "",
+  labelIds: [],
+  sortField: "date",
+  sortDir: "desc",
+};
 
 self.onmessage = async ({ data }) => {
   try {
@@ -19,20 +24,29 @@ self.onmessage = async ({ data }) => {
       if (!db.readRows("projects").some((row) => row.id === PROJECT_ID)) {
         db.insertRow("projects", PROJECT_ID, { title: "Todo list" });
       }
+      refreshLabelCache();
     } else if (data.type === "add") {
-      db.insertRow("todos", `todo-${crypto.randomUUID()}`, {
+      const id = `todo-${crypto.randomUUID()}`;
+      db.insertRow("todos", id, {
         title: data.title,
         done: false,
         project: PROJECT_ID,
       });
+      addTodoLabels(id, data.labels);
+    } else if (data.type === "setFilters") {
+      filters = sanitizeFilters(data.filters);
     } else if (data.type === "generate") {
       const startedAt = performance.now();
+      ensureLabels(GENERATED_LABELS);
       for (let i = 0; i < data.count; i++) {
-        db.insertRow("todos", `todo-${crypto.randomUUID()}`, {
-          title: `Todo ${i + 1}`,
+        const todoId = `todo-${crypto.randomUUID()}`;
+        const todoLabels = labelsForGeneratedTodo(i);
+        db.insertRow("todos", todoId, {
+          title: generatedTitle(i, todoLabels),
           done: false,
           project: PROJECT_ID,
         });
+        addTodoLabels(todoId, todoLabels);
         if ((i + 1) % 1000 === 0) {
           postMessage({ type: "progress", generated: i + 1, total: data.count });
           await new Promise((resolve) => setTimeout(resolve));
@@ -43,6 +57,7 @@ self.onmessage = async ({ data }) => {
     } else if (data.type === "toggle") {
       db.updateRow("todos", data.id, { done: data.done });
     } else if (data.type === "delete") {
+      deleteTodoLabels(data.id);
       db.deleteRow("todos", data.id);
     }
     postState();
@@ -52,18 +67,184 @@ self.onmessage = async ({ data }) => {
 };
 
 function postState(generateMs) {
+  refreshLabelCache();
   const startedAt = performance.now();
-  const todos = db.query(PAGE_QUERY).map((row) => ({
-    id: row.id,
-    title: row.values.title,
-    done: row.values.done,
-    txId: row.tx_id,
-  }));
+  const todoIds = todoIdsForSelectedLabels(filters.labelIds);
+  let rows = [];
+
+  if (!todoIds || todoIds.length > 0) {
+    rows = db.query(buildTodoQuery(todoIds));
+  }
+
+  const todos = attachLabels(
+    rows.map((row) => ({
+      id: row.id,
+      title: row.values.title,
+      done: row.values.done,
+      txId: row.tx_id,
+    })),
+  );
+
   postMessage({
     type: "state",
+    filters,
+    labels: sortedLabels(),
     todos,
     queryMs: performance.now() - startedAt,
     currentRows: db.storageStats().current_rows,
     generateMs,
   });
+}
+
+function buildTodoQuery(todoIds) {
+  const conditions = [{ column: "done", op: "eq", value: false }];
+  const search = filters.search.trim();
+
+  if (search) {
+    conditions.push({ column: "title", op: "contains", value: search });
+  }
+  if (todoIds) {
+    conditions.push({ column: "id", op: "in", value: todoIds });
+  }
+
+  return {
+    table: "todos",
+    conditions,
+    includes: {},
+    orderBy: [[SORT_COLUMNS[filters.sortField], filters.sortDir]],
+    limit: PAGE_SIZE,
+  };
+}
+
+function addTodoLabels(todoId, labelNames) {
+  const labels = ensureLabels(labelNames);
+  for (const label of labels) {
+    db.insertRow("todo_labels", `${todoId}-${label.id}`, {
+      todo: todoId,
+      label: label.id,
+    });
+  }
+}
+
+function ensureLabels(labelNames) {
+  const labels = [];
+  const seen = new Set();
+  for (const rawName of labelNames ?? []) {
+    const name = normalizeLabelName(rawName);
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    const id = labelIdForName(name);
+    if (!labelsById.has(id)) {
+      db.insertRow("labels", id, { name });
+      labelsById.set(id, { id, name });
+    }
+    labels.push(labelsById.get(id));
+  }
+  return labels;
+}
+
+function refreshLabelCache() {
+  labelsById = new Map(
+    db.readRows("labels").map((row) => [row.id, { id: row.id, name: row.values.name }]),
+  );
+}
+
+function sortedLabels() {
+  return Array.from(labelsById.values()).sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function deleteTodoLabels(todoId) {
+  for (const row of db.query({
+    table: "todo_labels",
+    conditions: [{ column: "todo", op: "eq", value: todoId }],
+    includes: {},
+  })) {
+    db.deleteRow("todo_labels", row.id);
+  }
+}
+
+function todoIdsForSelectedLabels(labelIds) {
+  if (!labelIds.length) return null;
+
+  let intersection;
+  for (const labelId of labelIds) {
+    const ids = new Set(
+      db
+        .query({
+          table: "todo_labels",
+          conditions: [{ column: "label", op: "eq", value: labelId }],
+          includes: {},
+        })
+        .map((row) => row.values.todo),
+    );
+
+    if (!intersection) {
+      intersection = ids;
+    } else {
+      intersection = new Set([...intersection].filter((id) => ids.has(id)));
+    }
+
+    if (intersection.size === 0) return [];
+  }
+
+  return [...intersection];
+}
+
+function attachLabels(todos) {
+  if (!todos.length) return todos;
+
+  const byTodo = new Map(todos.map((todo) => [todo.id, []]));
+  for (const todo of todos) {
+    for (const row of db.query({
+      table: "todo_labels",
+      conditions: [{ column: "todo", op: "eq", value: todo.id }],
+      includes: {},
+    })) {
+      const label = labelsById.get(row.values.label);
+      if (label) byTodo.get(todo.id).push(label);
+    }
+  }
+
+  return todos.map((todo) => ({
+    ...todo,
+    labels: byTodo.get(todo.id).sort((left, right) => left.name.localeCompare(right.name)),
+  }));
+}
+
+function sanitizeFilters(nextFilters = {}) {
+  const labelIds = Array.isArray(nextFilters.labelIds)
+    ? nextFilters.labelIds.filter((id) => labelsById.has(id))
+    : [];
+  const sortField = nextFilters.sortField === "name" ? "name" : "date";
+  const sortDir = nextFilters.sortDir === "asc" ? "asc" : "desc";
+  return {
+    search: String(nextFilters.search ?? "").slice(0, 80),
+    labelIds,
+    sortField,
+    sortDir,
+  };
+}
+
+function labelsForGeneratedTodo(index) {
+  const labels = [GENERATED_LABELS[index % GENERATED_LABELS.length]];
+  if (index % 3 === 0) labels.push(GENERATED_LABELS[(index + 3) % GENERATED_LABELS.length]);
+  return labels;
+}
+
+function generatedTitle(index, labels) {
+  const topic = index % 5 === 0 ? "ship" : index % 5 === 1 ? "review" : "note";
+  return `Todo ${String(index + 1).padStart(6, "0")} ${topic} ${labels.join(" ")}`;
+}
+
+function normalizeLabelName(value) {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replaceAll(/\s+/g, "-")
+    .replaceAll(/[^a-z0-9_-]/g, "")
+    .slice(0, 32);
+}
+
+function labelIdForName(name) {
+  return `label-${name}`;
 }

--- a/examples/mini-sqlite-todo/src/db-worker.js
+++ b/examples/mini-sqlite-todo/src/db-worker.js
@@ -7,8 +7,16 @@ const SORT_COLUMNS = {
   date: "$createdAt",
   name: "title",
 };
+const LABELS_QUERY = {
+  table: "labels",
+  conditions: [],
+  includes: {},
+  orderBy: [["name", "asc"]],
+};
 let db;
 let labelsById = new Map();
+let labelsSubscription;
+let suppressLabelSubscriptionState = false;
 let filters = {
   search: "",
   labelIds: [],
@@ -24,7 +32,7 @@ self.onmessage = async ({ data }) => {
       if (!db.readRows("projects").some((row) => row.id === PROJECT_ID)) {
         db.insertRow("projects", PROJECT_ID, { title: "Todo list" });
       }
-      refreshLabelCache();
+      withSuppressedLabelState(() => subscribeToLabels());
     } else if (data.type === "add") {
       const id = `todo-${crypto.randomUUID()}`;
       db.insertRow("todos", id, {
@@ -32,12 +40,12 @@ self.onmessage = async ({ data }) => {
         done: false,
         project: PROJECT_ID,
       });
-      addTodoLabels(id, data.labels);
+      withSuppressedLabelState(() => addTodoLabels(id, data.labels));
     } else if (data.type === "setFilters") {
       filters = sanitizeFilters(data.filters);
     } else if (data.type === "generate") {
       const startedAt = performance.now();
-      ensureLabels(GENERATED_LABELS);
+      withSuppressedLabelState(() => ensureLabels(GENERATED_LABELS));
       for (let i = 0; i < data.count; i++) {
         const todoId = `todo-${crypto.randomUUID()}`;
         const todoLabels = labelsForGeneratedTodo(i);
@@ -67,7 +75,6 @@ self.onmessage = async ({ data }) => {
 };
 
 function postState(generateMs) {
-  refreshLabelCache();
   const startedAt = performance.now();
   const todoIds = todoIdsForSelectedLabels(filters.labelIds);
   let rows = [];
@@ -75,29 +82,28 @@ function postState(generateMs) {
   if (!todoIds || todoIds.length > 0) {
     rows = db.query(buildTodoQuery(todoIds));
   }
+  const queryMs = performance.now() - startedAt;
 
-  const todos = attachLabels(
-    rows.map((row) => ({
-      id: row.id,
-      title: row.values.title,
-      done: row.values.done,
-      txId: row.tx_id,
-    })),
-  );
+  const todos = rows.map((row) => ({
+    id: row.id,
+    title: row.values.title,
+    done: row.values.done,
+    txId: row.tx_id,
+  }));
 
   postMessage({
     type: "state",
     filters,
     labels: sortedLabels(),
     todos,
-    queryMs: performance.now() - startedAt,
+    queryMs,
     currentRows: db.storageStats().current_rows,
     generateMs,
   });
 }
 
 function buildTodoQuery(todoIds) {
-  const conditions = [{ column: "done", op: "eq", value: false }];
+  const conditions = [];
   const search = filters.search.trim();
 
   if (search) {
@@ -126,6 +132,25 @@ function addTodoLabels(todoId, labelNames) {
   }
 }
 
+function subscribeToLabels() {
+  if (labelsSubscription !== undefined) return;
+  labelsSubscription = db.subscribe(LABELS_QUERY, ({ all }) => {
+    labelsById = new Map(all.map(labelRow));
+    if (!suppressLabelSubscriptionState) {
+      postState();
+    }
+  });
+}
+
+function withSuppressedLabelState(fn) {
+  suppressLabelSubscriptionState = true;
+  try {
+    return fn();
+  } finally {
+    suppressLabelSubscriptionState = false;
+  }
+}
+
 function ensureLabels(labelNames) {
   const labels = [];
   const seen = new Set();
@@ -143,10 +168,8 @@ function ensureLabels(labelNames) {
   return labels;
 }
 
-function refreshLabelCache() {
-  labelsById = new Map(
-    db.readRows("labels").map((row) => [row.id, { id: row.id, name: row.values.name }]),
-  );
+function labelRow(row) {
+  return [row.id, { id: row.id, name: row.values.name }];
 }
 
 function sortedLabels() {
@@ -188,27 +211,6 @@ function todoIdsForSelectedLabels(labelIds) {
   }
 
   return [...intersection];
-}
-
-function attachLabels(todos) {
-  if (!todos.length) return todos;
-
-  const byTodo = new Map(todos.map((todo) => [todo.id, []]));
-  for (const todo of todos) {
-    for (const row of db.query({
-      table: "todo_labels",
-      conditions: [{ column: "todo", op: "eq", value: todo.id }],
-      includes: {},
-    })) {
-      const label = labelsById.get(row.values.label);
-      if (label) byTodo.get(todo.id).push(label);
-    }
-  }
-
-  return todos.map((todo) => ({
-    ...todo,
-    labels: byTodo.get(todo.id).sort((left, right) => left.name.localeCompare(right.name)),
-  }));
 }
 
 function sanitizeFilters(nextFilters = {}) {

--- a/examples/mini-sqlite-todo/src/db-worker.js
+++ b/examples/mini-sqlite-todo/src/db-worker.js
@@ -2,6 +2,13 @@ import init, { MiniJazzRuntime } from "./generated/mini-jazz-sqlite-wasm/mini_ja
 
 const PROJECT_ID = "todo-list";
 const PAGE_SIZE = 10;
+const PAGE_QUERY = {
+  table: "todos",
+  conditions: [{ column: "done", op: "eq", value: false }],
+  includes: {},
+  orderBy: [["$createdAt", "desc"]],
+  limit: PAGE_SIZE,
+};
 let db;
 
 self.onmessage = async ({ data }) => {
@@ -46,14 +53,12 @@ self.onmessage = async ({ data }) => {
 
 function postState(generateMs) {
   const startedAt = performance.now();
-  const todos = db
-    .readRowsWhereEqTopCreatedAtDesc("todos", "done", false, PAGE_SIZE)
-    .map((row) => ({
-      id: row.id,
-      title: row.values.title,
-      done: row.values.done,
-      txId: row.tx_id,
-    }));
+  const todos = db.query(PAGE_QUERY).map((row) => ({
+    id: row.id,
+    title: row.values.title,
+    done: row.values.done,
+    txId: row.tx_id,
+  }));
   postMessage({
     type: "state",
     todos,

--- a/examples/mini-sqlite-todo/src/main.js
+++ b/examples/mini-sqlite-todo/src/main.js
@@ -4,6 +4,13 @@ const state = {
   ready: false,
   generating: false,
   todos: [],
+  labels: [],
+  filters: {
+    search: "",
+    labelIds: [],
+    sortField: "date",
+    sortDir: "desc",
+  },
   error: "",
   generated: 0,
   totalToGenerate: 100000,
@@ -11,6 +18,7 @@ const state = {
   queryMs: 0,
   currentRows: 0,
 };
+let searchTimer = 0;
 
 app.innerHTML = `
   <section class="todo-app">
@@ -23,27 +31,52 @@ app.innerHTML = `
     </header>
     <form id="todo-form" class="todo-form">
       <input id="todo-title" name="title" type="text" autocomplete="off" placeholder="Add a task" required />
+      <input id="todo-labels" name="labels" type="text" autocomplete="off" placeholder="labels: work, urgent" />
       <button type="submit">Add</button>
     </form>
+    <div class="controls">
+      <input id="search" type="search" autocomplete="off" placeholder="Search titles" />
+      <label>
+        <span>Sort</span>
+        <select id="sort-field">
+          <option value="date">Date</option>
+          <option value="name">Name</option>
+        </select>
+      </label>
+      <label>
+        <span>Order</span>
+        <select id="sort-dir">
+          <option value="desc">Desc</option>
+          <option value="asc">Asc</option>
+        </select>
+      </label>
+    </div>
+    <div id="label-filters" class="label-filters" aria-label="Label filters"></div>
     <button id="generate" class="generate" type="button">Generate 100k todos</button>
     <p id="error-message" class="error-message" role="alert" hidden></p>
     <ul id="todo-list" class="todo-list"></ul>
-    <p id="empty-state" class="empty-state">No todos yet.</p>
+    <p id="empty-state" class="empty-state">No matching todos.</p>
     <p id="summary" class="summary"></p>
   </section>
 `;
 
 const form = app.querySelector("#todo-form");
-const input = app.querySelector("#todo-title");
+const titleInput = app.querySelector("#todo-title");
+const labelsInput = app.querySelector("#todo-labels");
+const searchInput = app.querySelector("#search");
+const sortField = app.querySelector("#sort-field");
+const sortDir = app.querySelector("#sort-dir");
+const labelFilters = app.querySelector("#label-filters");
 const list = app.querySelector("#todo-list");
 const generate = app.querySelector("#generate");
 
 form.addEventListener("submit", (event) => {
   event.preventDefault();
-  const title = input.value.trim();
+  const title = titleInput.value.trim();
   if (!title || !state.ready) return;
-  worker.postMessage({ type: "add", title });
-  input.value = "";
+  worker.postMessage({ type: "add", title, labels: parseLabels(labelsInput.value) });
+  titleInput.value = "";
+  labelsInput.value = "";
 });
 
 generate.addEventListener("click", () => {
@@ -53,6 +86,33 @@ generate.addEventListener("click", () => {
   state.generateMs = 0;
   worker.postMessage({ type: "generate", count: state.totalToGenerate });
   render();
+});
+
+searchInput.addEventListener("input", () => {
+  clearTimeout(searchTimer);
+  searchTimer = setTimeout(() => {
+    setFilters({ search: searchInput.value });
+  }, 120);
+});
+
+sortField.addEventListener("change", () => {
+  setFilters({ sortField: sortField.value });
+});
+
+sortDir.addEventListener("change", () => {
+  setFilters({ sortDir: sortDir.value });
+});
+
+labelFilters.addEventListener("click", (event) => {
+  const target = event.target;
+  if (target.dataset.role !== "label-filter") return;
+  const labelIds = new Set(state.filters.labelIds);
+  if (labelIds.has(target.dataset.id)) {
+    labelIds.delete(target.dataset.id);
+  } else {
+    labelIds.add(target.dataset.id);
+  }
+  setFilters({ labelIds: [...labelIds] });
 });
 
 list.addEventListener("change", (event) => {
@@ -71,6 +131,8 @@ worker.onmessage = ({ data }) => {
   if (data.type === "state") {
     state.ready = true;
     state.todos = data.todos;
+    state.labels = data.labels;
+    state.filters = data.filters;
     state.queryMs = data.queryMs;
     state.currentRows = data.currentRows;
     state.generateMs = data.generateMs ?? state.generateMs;
@@ -91,31 +153,47 @@ addEventListener("pagehide", () => worker.terminate());
 
 worker.postMessage({
   type: "init",
-  dbName: "mini-jazz-sqlite-lean-todos.sqlite3",
+  dbName: "mini-jazz-sqlite-labeled-todos.sqlite3",
   nodeId: "browser-worker",
   user: "alice",
 });
 render();
 
+function setFilters(patch) {
+  if (!state.ready || state.generating) return;
+  state.filters = { ...state.filters, ...patch };
+  worker.postMessage({ type: "setFilters", filters: state.filters });
+  render();
+}
+
 function render() {
   app.querySelector("#status").textContent = state.ready ? statusText() : "Opening OPFS worker...";
-  input.disabled = !state.ready || state.generating;
+
+  for (const control of [titleInput, labelsInput, searchInput, sortField, sortDir]) {
+    control.disabled = !state.ready || state.generating;
+  }
   form.querySelector("button").disabled = !state.ready || state.generating;
   generate.disabled = !state.ready || state.generating;
+  searchInput.value = state.filters.search;
+  sortField.value = state.filters.sortField;
+  sortDir.value = state.filters.sortDir;
 
   const error = app.querySelector("#error-message");
   error.hidden = !state.error;
   error.textContent = state.error;
 
+  labelFilters.innerHTML = state.labels.map(labelFilterHtml).join("");
   list.innerHTML = state.todos.map(todoHtml).join("");
   app.querySelector("#empty-state").hidden = state.todos.length > 0;
 
   const done = state.todos.filter((todo) => todo.done).length;
+  const filters = filterSummary();
   app.querySelector("#summary").textContent =
     `${state.todos.length - done} open / ${done} done shown. ` +
     `${state.currentRows.toLocaleString()} current rows. ` +
     `Top-10 query: ${state.queryMs.toFixed(2)} ms. ` +
-    (state.generateMs ? `Generate: ${(state.generateMs / 1000).toFixed(2)} s.` : "");
+    `${filters}` +
+    (state.generateMs ? ` Generate: ${(state.generateMs / 1000).toFixed(2)} s.` : "");
 }
 
 function statusText() {
@@ -123,18 +201,50 @@ function statusText() {
   return `Generating ${state.generated.toLocaleString()} / ${state.totalToGenerate.toLocaleString()} todos...`;
 }
 
+function filterSummary() {
+  const parts = [];
+  if (state.filters.search) parts.push(`search "${state.filters.search}"`);
+  if (state.filters.labelIds.length) parts.push(`${state.filters.labelIds.length} label filter`);
+  const sortName = state.filters.sortField === "name" ? "name" : "date";
+  parts.push(`${sortName} ${state.filters.sortDir}`);
+  return `Filters: ${parts.join(", ")}.`;
+}
+
+function labelFilterHtml(label) {
+  const selected = state.filters.labelIds.includes(label.id);
+  return `
+    <button type="button" class="chip ${selected ? "selected" : ""}" data-role="label-filter" data-id="${escapeAttr(label.id)}">
+      ${escapeHtml(label.name)}
+    </button>
+  `;
+}
+
 function todoHtml(todo) {
   return `
     <li class="todo-item ${todo.done ? "done" : ""}">
       <label class="todo-label">
-        <input type="checkbox" data-role="toggle" data-id="${todo.id}" ${todo.done ? "checked" : ""}>
+        <input type="checkbox" data-role="toggle" data-id="${escapeAttr(todo.id)}" ${todo.done ? "checked" : ""}>
         <span>${escapeHtml(todo.title)}</span>
       </label>
-      <button type="button" data-role="delete" data-id="${todo.id}">Delete</button>
+      <div class="todo-meta">
+        ${todo.labels.map((label) => `<span class="label-chip">${escapeHtml(label.name)}</span>`).join("")}
+      </div>
+      <button type="button" data-role="delete" data-id="${escapeAttr(todo.id)}">Delete</button>
     </li>
   `;
 }
 
+function parseLabels(value) {
+  return value
+    .split(",")
+    .map((label) => label.trim())
+    .filter(Boolean);
+}
+
 function escapeHtml(value) {
-  return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+  return String(value).replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+}
+
+function escapeAttr(value) {
+  return escapeHtml(value).replaceAll('"', "&quot;");
 }

--- a/examples/mini-sqlite-todo/src/main.js
+++ b/examples/mini-sqlite-todo/src/main.js
@@ -226,9 +226,6 @@ function todoHtml(todo) {
         <input type="checkbox" data-role="toggle" data-id="${escapeAttr(todo.id)}" ${todo.done ? "checked" : ""}>
         <span>${escapeHtml(todo.title)}</span>
       </label>
-      <div class="todo-meta">
-        ${todo.labels.map((label) => `<span class="label-chip">${escapeHtml(label.name)}</span>`).join("")}
-      </div>
       <button type="button" data-role="delete" data-id="${escapeAttr(todo.id)}">Delete</button>
     </li>
   `;


### PR DESCRIPTION
## Summary

This PR makes `mini-jazz-sqlite` usable from a browser, exposes a Rust/WASM query surface based on `BuiltQuery`, and adds a browser todo benchmark that exercises paginated query speed over a large local dataset with realistic query controls.

The main direction is:

```text
specialized runtime helpers     BuiltQuery JSON
read_rows_where_*          ->   query / one / subscribe
ad-hoc browser smoke       ->   examples/mini-sqlite-todo
runtime-side page scans    ->   SQL-lowered predicates/order/window
```

## Browser/WASM Runtime

The WASM wrapper exposes the embedded Rust runtime through `wasm-bindgen`, with both memory and OPFS-backed storage:

```text
browser UI
   |
   v
examples/mini-sqlite-todo/src/db-worker.js
   |
   v
wasm-bindgen MiniJazzRuntime
   |
   +-- openMemory(nodeId, user)
   +-- openOpfs(dbName, nodeId, user)
   +-- insertRow(table, id, values)
   +-- updateRow(table, id, values)
   +-- deleteRow(table, id)
   +-- query(builtQuery)
   +-- one(builtQuery)
   +-- subscribe(builtQuery, callback)
   +-- unsubscribe(handle)
   v
mini_jazz_sqlite::Runtime
   |
   v
SQLite WASM VFS / OPFS
```

Example browser usage:

```js
import init, { MiniJazzRuntime } from "./generated/mini-jazz-sqlite-wasm/mini_jazz_sqlite_wasm.js";

await init();

const db = await MiniJazzRuntime.openOpfs(
  "mini-sqlite-todo",
  "browser-tab-1",
  "alice",
);

db.insertRow("todos", `todo-${crypto.randomUUID()}`, {
  title: "Measure pagination",
  done: false,
  project: "todo-list",
});

const rows = db.query({
  table: "todos",
  conditions: [{ column: "done", op: "eq", value: false }],
  orderBy: [["$createdAt", "desc"]],
  limit: 10,
});
```

## Query Pipeline

The Rust query API accepts the same JSON-shaped query descriptor at the WASM boundary and lowers supported operations into SQLite instead of routing through prebuilt runtime methods.

```text
BuiltQuery JSON
   |
   v
parse + validate bounded fields
   |
   v
resolve schema fields and system fields
   |
   v
compile predicates / order / limit / offset
   |
   v
SQLite over current projections
   |
   v
semantic RowView values
```

Supported query operations now go through one path:

```js
const PAGE_QUERY = {
  table: "todos",
  conditions: [
    { column: "done", op: "eq", value: false },
  ],
  orderBy: [["$createdAt", "desc"]],
  limit: 10,
};

const latestOpenTodos = db.query(PAGE_QUERY);
const firstOpenTodo = db.one(PAGE_QUERY);
```

The intended SQL shape is now the ordinary database shape:

```sql
SELECT current.*
FROM current_todos AS current
WHERE current.done = ?
  AND <branch visibility>
  AND <read policy visibility>
ORDER BY current.j_created_at DESC, <stable tie breaker>
LIMIT 10 OFFSET 0;
```

That matters for the 100k todo benchmark: pagination should be an indexed query over the current projection, not a runtime scan followed by in-memory filtering and slicing.

## Query-Scoped Sync And Repair

Query exports remain history-based, not authoritative result snapshots. A receiver applies history and observed facts, then reruns its local query.

```text
upstream query export
   |
   +-- current result rows
   +-- repair rows for rows that left the scope
   +-- predicate / page / policy observed facts
   +-- branch and snapshot context when needed
   v
sync bundle
   |
   v
receiver applies history
   |
   v
receiver reruns query locally
```

This PR tightens the built-query refresh path so SQL-lowered queries can repair rows that enter or leave the visible result set through:

```text
field update
row delete
timestamp/order change
policy dependency change
branch/source change
page boundary displacement
```

The generic query repair tests cover combinations of supported operators, ordering, pagination, policy filtering, and incremental updates.

## Subscriptions

Subscriptions now use `BuiltQuery` for the query-shaped API and emit callback deltas from the WASM wrapper.

```js
const handle = db.subscribe(PAGE_QUERY, ({ all, delta }) => {
  for (const change of delta) {
    if (change.kind === 0) {
      // added: change.row is present
    } else if (change.kind === 1) {
      // removed: change.id and change.index identify the removal
    } else if (change.kind === 2) {
      // updated or moved: change.row is present for value updates
    }
  }

  render(all);
});

db.unsubscribe(handle);
```

The WASM notification loop keeps subscription state consistent when callbacks write rows or throw. One failing callback no longer prevents later callbacks from seeing the write that already happened.

## Removed Specialized Surface

The public direction is query language first. This PR removes or avoids public APIs that bypass that path:

```text
read_rows_where_eq_top_created_at_desc   removed from the public browser path
read_rows_where_eq_top_field_desc        replaced by BuiltQuery orderBy + limit
export_table_history                     not exposed on the WASM API
apply_bundle                             not exposed on the WASM API
```

The remaining browser-facing shape is smaller:

```text
writes:        insertRow / updateRow / deleteRow
reads:         readRows / query / one
live reads:    subscribe / unsubscribe
storage info:  storageStats / storageFormatVersion
```

## Todo Benchmark Example

The example is intentionally small and named `mini-sqlite-todo`, but now exercises a more realistic local app shape:

```text
examples/mini-sqlite-todo
   |
   +-- browser app
   +-- db worker
   +-- generated WASM package
```

The worker stores todos plus a many-to-many label model:

```text
todos
labels
todo_labels
```

Labels are maintained as an aggregate app-level subscription rather than hydrated row-by-row for each visible todo:

```text
subscribe({ table: "labels", orderBy: [["name", "asc"]] })
   |
   v
labelsById cache
   |
   +-- global label filter chips
   +-- filter validation
```

The paged todo benchmark path is kept separate from that aggregate label catalogue:

```text
generate 100000 todos with deterministic labels
   |
   v
store todos and label edges through MiniJazzRuntime.openOpfs(...)
   |
   v
keep labels available through the labels subscription
   |
   v
compose BuiltQuery JSON from UI controls
   |
   +-- title contains search text
   +-- optional label filter using todo_labels to find matching todo ids
   +-- order by title or $createdAt
   +-- asc or desc direction
   v
return only the first 10 matching todos
```

The UI supports:

```text
manual todo creation with comma-separated labels
full text-style title search through the query API contains operator
global label filter chips backed by the labels subscription
ordering controls for name/date in both directions
top-10 todo query timing
100k row generation timing
```

The worker reports:

```js
{
  type: "state",
  todos,
  labels,
  filters,
  queryMs,
  currentRows,
  generateMs,
}
```

Per-row label chips were removed from the visible todo list. That keeps the unfiltered timing focused on the paged todo query instead of including N extra `todo_labels` queries to decorate the 10 visible rows.

This keeps the example focused on the performance question while making the benchmark closer to an actual app query: how fast can the browser runtime answer a paged query after a large local seed, once search, label filters, and user-controlled ordering are involved?

## Correctness Notes

The query implementation is meant to preserve these contracts:

```text
same logical data + same branch + same policy + same query
   => same semantic result rows
   => same semantic order
   => same page window
```

Local storage ids are implementation details. Query results, ordering, and pagination should be based on semantic values and public ids rather than SQLite allocation order or internal row numbers.

Read visibility is also part of query planning, not a post-filter. Query, export, and repair paths need to use the same branch and policy visibility rules before selecting result rows or page windows.

## Validation

```text
cargo fmt --check
cargo test -p mini-jazz-sqlite
cargo clippy -p mini-jazz-sqlite --all-targets -- -D warnings
CC_wasm32_unknown_unknown=/opt/homebrew/Cellar/llvm@21/21.1.8/bin/clang cargo check -p mini-jazz-sqlite-wasm --target wasm32-unknown-unknown
pnpm --filter mini-sqlite-todo build
pnpm --dir examples/mini-sqlite-todo build
```

Browser smoke covered:

```text
memory runtime: generate 100k todos, query latest 10
OPFS runtime:   generate todos through real worker path, query latest 10
subscriptions: query, subscribe, callback delta, unsubscribe
API surface:    removed specialized helpers are absent from the browser path
todo example:   labels aggregate through subscription, add labeled todo, filter by label, search title text, change name/date sort order
```