### PR TITLE
Cap pre-auth WebSocket handshake decompression

### DIFF
--- a/.changeset/cap-untrusted-length-allocations.md
+++ b/.changeset/cap-untrusted-length-allocations.md
@@ -1,0 +1,6 @@
+---
+"jazz-tools": patch
+"jazz-napi": patch
+---
+
+Reject an oversized LZ4 frame on the pre-authentication WebSocket handshake before decompressing it, closing an unauthenticated decompression-bomb that could exhaust server memory. The inbound WebSocket message-size limit is also pinned explicitly.

--- a/crates/jazz-tools/src/server/routes/websocket.rs
+++ b/crates/jazz-tools/src/server/routes/websocket.rs
@@ -21,6 +21,11 @@ use super::utils::connection_schema_diagnostics_from_handshake;
 
 const MAX_WS_SYNC_UPDATES_PER_FRAME: usize = 256;
 
+/// Generous ceiling on the decompressed size of the pre-auth handshake frame.
+/// An `AuthHandshake` is a few KB of JSON, so this only rejects an obvious LZ4
+/// decompression bomb sent by an unauthenticated peer before any auth runs.
+const MAX_HANDSHAKE_DECOMPRESSED_BYTES: usize = 1024 * 1024;
+
 pub(super) async fn ws_handler(
     ws: WebSocketUpgrade,
     State(state): State<Arc<ServerState>>,
@@ -326,7 +331,10 @@ async fn handle_ws_connection(
             return;
         }
     };
-    let payload = match crate::transport_manager::frame_decode(&first) {
+    let payload = match crate::transport_manager::frame_decode_capped(
+        &first,
+        MAX_HANDSHAKE_DECOMPRESSED_BYTES,
+    ) {
         Some(payload) => payload,
         None => {
             let _ = socket.close().await;

--- a/crates/jazz-tools/src/server/routes/websocket.rs
+++ b/crates/jazz-tools/src/server/routes/websocket.rs
@@ -26,6 +26,13 @@ const MAX_WS_SYNC_UPDATES_PER_FRAME: usize = 256;
 /// decompression bomb sent by an unauthenticated peer before any auth runs.
 const MAX_HANDSHAKE_DECOMPRESSED_BYTES: usize = 1024 * 1024;
 
+/// Maximum size of an inbound WebSocket message (the compressed bytes on the
+/// wire). This is axum's existing default, set explicitly so the limit is
+/// visible and can later be made configurable. It is *not* a bound on the
+/// decompressed payload — see `MAX_HANDSHAKE_DECOMPRESSED_BYTES` and the
+/// follow-up on bounded framing for that.
+const MAX_WS_MESSAGE_BYTES: usize = 64 * 1024 * 1024;
+
 pub(super) async fn ws_handler(
     ws: WebSocketUpgrade,
     State(state): State<Arc<ServerState>>,
@@ -41,7 +48,8 @@ pub(super) async fn ws_handler(
             .into_response();
     }
 
-    ws.on_upgrade(move |socket| handle_ws_connection(socket, state, headers))
+    ws.max_message_size(MAX_WS_MESSAGE_BYTES)
+        .on_upgrade(move |socket| handle_ws_connection(socket, state, headers))
 }
 
 /// Outcome of authenticating a WS handshake.

--- a/crates/jazz-tools/src/transport_manager.rs
+++ b/crates/jazz-tools/src/transport_manager.rs
@@ -508,6 +508,14 @@ pub(crate) fn frame_encode(payload: &[u8]) -> Vec<u8> {
 }
 
 pub(crate) fn frame_decode(data: &[u8]) -> Option<Vec<u8>> {
+    frame_decode_capped(data, usize::MAX)
+}
+
+/// Decode a frame, rejecting one whose LZ4 header declares an uncompressed size
+/// larger than `max_decompressed` — used on the pre-auth handshake path so a
+/// decompression bomb can't be expanded before the peer is authenticated.
+pub(crate) fn frame_decode_capped(data: &[u8], max_decompressed: usize) -> Option<Vec<u8>> {
+    let _ = max_decompressed; // TODO(green): enforce the declared-size cap
     if data.len() < 4 {
         return None;
     }
@@ -1180,6 +1188,24 @@ mod tests {
     use std::sync::Arc;
     use std::sync::Mutex;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    #[test]
+    fn handshake_decode_rejects_oversized_frame() {
+        // A handshake frame is a few KB of JSON; one declaring megabytes is a
+        // decompression bomb arriving before the peer is authenticated.
+        let cap = 1024 * 1024;
+        let bomb = frame_encode(&vec![0u8; 2 * 1024 * 1024]);
+        assert!(
+            frame_decode_capped(&bomb, cap).is_none(),
+            "oversized handshake frame must be rejected before decompression"
+        );
+        // A normal small handshake-sized frame still decodes through the cap.
+        let ok = frame_encode(b"handshake");
+        assert_eq!(
+            frame_decode_capped(&ok, cap).as_deref(),
+            Some(&b"handshake"[..])
+        );
+    }
 
     struct MockStream {
         sent: Vec<Vec<u8>>,

--- a/crates/jazz-tools/src/transport_manager.rs
+++ b/crates/jazz-tools/src/transport_manager.rs
@@ -515,7 +515,6 @@ pub(crate) fn frame_decode(data: &[u8]) -> Option<Vec<u8>> {
 /// larger than `max_decompressed` — used on the pre-auth handshake path so a
 /// decompression bomb can't be expanded before the peer is authenticated.
 pub(crate) fn frame_decode_capped(data: &[u8], max_decompressed: usize) -> Option<Vec<u8>> {
-    let _ = max_decompressed; // TODO(green): enforce the declared-size cap
     if data.len() < 4 {
         return None;
     }
@@ -523,7 +522,17 @@ pub(crate) fn frame_decode_capped(data: &[u8], max_decompressed: usize) -> Optio
     if data.len() < 4 + len {
         return None;
     }
-    lz4_flex::decompress_size_prepended(&data[4..4 + len]).ok()
+    let compressed = &data[4..4 + len];
+    if compressed.len() < 4 {
+        return None;
+    }
+    // lz4_flex prepends the uncompressed size as a little-endian u32. Reject an
+    // oversized declaration before it can size the output buffer.
+    let declared = u32::from_le_bytes(compressed[0..4].try_into().unwrap()) as usize;
+    if declared > max_decompressed {
+        return None;
+    }
+    lz4_flex::decompress_size_prepended(compressed).ok()
 }
 
 /// Outcome of the auth handshake.

--- a/specs/todo/issues/unbounded-payload-sizes.md
+++ b/specs/todo/issues/unbounded-payload-sizes.md
@@ -1,0 +1,26 @@
+# Sync accepts unbounded payload sizes
+
+## What
+
+The sync protocol imposes no byte budget on a frame, a row batch, or a row. A frame batches up to 256 payloads (`MAX_OUTBOUND_SYNC_PAYLOADS_PER_FRAME` / `MAX_WS_SYNC_UPDATES_PER_FRAME`) by **count only**, and a row batch carries a **full-row** snapshot (`StoredRowBatch.data`) whose `text` / array / column-count values are uncapped (only `bytea` *scalars* are bounded, at `BYTEA_MAX_BYTES` = 1 MiB). So a single legitimate frame is effectively unbounded — e.g. 256 rows × a 1 MiB `bytea` each ≈ 256 MiB — and post-handshake `frame_decode` will LZ4-decompress whatever an authenticated peer sends, with no ceiling on the decompressed output.
+
+This means an authenticated peer can drive a large (potentially multi-GB on a constrained host, or a WASM-client trap) allocation via the post-handshake sync path, and there is no principled value at which to cap inbound frames without risking silent rejection of legitimate traffic.
+
+The unauthenticated vector is closed separately: the pre-auth handshake frame is now decompress-capped at 1 MiB (`frame_decode_capped` + `MAX_HANDSHAKE_DECOMPRESSED_BYTES`). This issue is about the **post-handshake, authenticated** path and the absence of any frame/row size discipline.
+
+## Priority
+
+medium
+
+## Notes
+
+- On a 64-bit overcommit host an oversized count/length usually surfaces as a clean decode error rather than an OOM (lazy reservation + a fast read failure). The genuinely memory-*committing* path is LZ4 decompression (it writes the output), so the real exposure is: a constrained / no-overcommit server, or a 32-bit **WASM client** (linear-memory growth traps → the client bricks irrecoverably).
+- Failure mode today is poor: an over-cap or malformed frame on the steady-state loops is **silently dropped** (`frame_decode` → `None` → `continue` in `websocket.rs` and `transport_manager.rs`), with no error or ack to the sender. For a legitimate over-cap frame that means silent data loss / a stalled sync, not a recoverable error.
+- Because legitimate frames are unbounded, a hardcoded receiver cap is the wrong shape — it is an invented policy that either rejects valid traffic (too low) or barely helps (too high). A fixed post-auth cap was deliberately **not** added for this reason.
+- Desired direction (the real fix): **byte-budgeted framing**.
+  - Add a byte budget `B` to the sender-side batchers (`transport_manager.rs` outbound, `websocket.rs` outbound — both currently count-only) so a batch is split across multiple frames to fit `B`. A 256 × 2 MiB batch becomes ⌈512 MiB / B⌉ frames automatically.
+  - Receiver cap then = `B` + LZ4 framing margin — tight and safe, because frames are bounded *by construction* rather than by guesswork.
+  - Splitting is only possible down to **one row** (a batch is atomic full-row data; sub-row chunking would be a deep CRDT/wire-format change). So `B` doubles as an effective max-row size, and a row larger than `B` should fail with a **loud, recoverable** send-side error (e.g. `RowExceedsFrameBudget { size, max }`) — never a panic or a silent drop.
+  - Make `B` configurable (e.g. `JAZZ_MAX_FRAME_BYTES`, matching the existing `JAZZ_*` / `NODE_ENV` config pattern) so constrained deployments can tighten it and bulk-binary workloads can raise it.
+- Row history does not bloat a single payload: replacing a 1 MiB value N times produces N separate ~1 MiB batches linked by parent IDs, not one N MiB payload — so the parent closure splits cleanly across frames. The oversized-single-row case only arises when one *version* is itself huge.
+- Constraint for any solution: a bad/oversized payload must surface as a clean, recoverable error and must never crash a client irrecoverably (no WASM trap, no panic, no silent loss).

--- a/specs/todo/issues/unbounded-payload-sizes.md
+++ b/specs/todo/issues/unbounded-payload-sizes.md
@@ -2,7 +2,7 @@
 
 ## What
 
-The sync protocol imposes no byte budget on a frame, a row batch, or a row. A frame batches up to 256 payloads (`MAX_OUTBOUND_SYNC_PAYLOADS_PER_FRAME` / `MAX_WS_SYNC_UPDATES_PER_FRAME`) by **count only**, and a row batch carries a **full-row** snapshot (`StoredRowBatch.data`) whose `text` / array / column-count values are uncapped (only `bytea` *scalars* are bounded, at `BYTEA_MAX_BYTES` = 1 MiB). So a single legitimate frame is effectively unbounded — e.g. 256 rows × a 1 MiB `bytea` each ≈ 256 MiB — and post-handshake `frame_decode` will LZ4-decompress whatever an authenticated peer sends, with no ceiling on the decompressed output.
+The sync protocol imposes no byte budget on a frame, a row batch, or a row. A frame batches up to 256 payloads (`MAX_OUTBOUND_SYNC_PAYLOADS_PER_FRAME` / `MAX_WS_SYNC_UPDATES_PER_FRAME`) by **count only**, and a row batch carries a **full-row** snapshot (`StoredRowBatch.data`) whose `text` / array / column-count values are uncapped (only `bytea` _scalars_ are bounded, at `BYTEA_MAX_BYTES` = 1 MiB). So a single legitimate frame is effectively unbounded — e.g. 256 rows × a 1 MiB `bytea` each ≈ 256 MiB — and post-handshake `frame_decode` will LZ4-decompress whatever an authenticated peer sends, with no ceiling on the decompressed output.
 
 This means an authenticated peer can drive a large (potentially multi-GB on a constrained host, or a WASM-client trap) allocation via the post-handshake sync path, and there is no principled value at which to cap inbound frames without risking silent rejection of legitimate traffic.
 
@@ -14,13 +14,13 @@ medium
 
 ## Notes
 
-- On a 64-bit overcommit host an oversized count/length usually surfaces as a clean decode error rather than an OOM (lazy reservation + a fast read failure). The genuinely memory-*committing* path is LZ4 decompression (it writes the output), so the real exposure is: a constrained / no-overcommit server, or a 32-bit **WASM client** (linear-memory growth traps → the client bricks irrecoverably).
+- On a 64-bit overcommit host an oversized count/length usually surfaces as a clean decode error rather than an OOM (lazy reservation + a fast read failure). The genuinely memory-_committing_ path is LZ4 decompression (it writes the output), so the real exposure is: a constrained / no-overcommit server, or a 32-bit **WASM client** (linear-memory growth traps → the client bricks irrecoverably).
 - Failure mode today is poor: an over-cap or malformed frame on the steady-state loops is **silently dropped** (`frame_decode` → `None` → `continue` in `websocket.rs` and `transport_manager.rs`), with no error or ack to the sender. For a legitimate over-cap frame that means silent data loss / a stalled sync, not a recoverable error.
 - Because legitimate frames are unbounded, a hardcoded receiver cap is the wrong shape — it is an invented policy that either rejects valid traffic (too low) or barely helps (too high). A fixed post-auth cap was deliberately **not** added for this reason.
 - Desired direction (the real fix): **byte-budgeted framing**.
   - Add a byte budget `B` to the sender-side batchers (`transport_manager.rs` outbound, `websocket.rs` outbound — both currently count-only) so a batch is split across multiple frames to fit `B`. A 256 × 2 MiB batch becomes ⌈512 MiB / B⌉ frames automatically.
-  - Receiver cap then = `B` + LZ4 framing margin — tight and safe, because frames are bounded *by construction* rather than by guesswork.
+  - Receiver cap then = `B` + LZ4 framing margin — tight and safe, because frames are bounded _by construction_ rather than by guesswork.
   - Splitting is only possible down to **one row** (a batch is atomic full-row data; sub-row chunking would be a deep CRDT/wire-format change). So `B` doubles as an effective max-row size, and a row larger than `B` should fail with a **loud, recoverable** send-side error (e.g. `RowExceedsFrameBudget { size, max }`) — never a panic or a silent drop.
   - Make `B` configurable (e.g. `JAZZ_MAX_FRAME_BYTES`, matching the existing `JAZZ_*` / `NODE_ENV` config pattern) so constrained deployments can tighten it and bulk-binary workloads can raise it.
-- Row history does not bloat a single payload: replacing a 1 MiB value N times produces N separate ~1 MiB batches linked by parent IDs, not one N MiB payload — so the parent closure splits cleanly across frames. The oversized-single-row case only arises when one *version* is itself huge.
+- Row history does not bloat a single payload: replacing a 1 MiB value N times produces N separate ~1 MiB batches linked by parent IDs, not one N MiB payload — so the parent closure splits cleanly across frames. The oversized-single-row case only arises when one _version_ is itself huge.
 - Constraint for any solution: a bad/oversized payload must surface as a clean, recoverable error and must never crash a client irrecoverably (no WASM trap, no panic, no silent loss).


### PR DESCRIPTION
## Summary
- The pre-auth WebSocket handshake frame is LZ4-decompressed before the peer is authenticated, so a tiny frame declaring a huge uncompressed size is an unauthenticated OOM vector. `frame_decode_capped` now reads the declared little-endian uncompressed size and rejects a handshake frame declaring more than 1 MiB (a handshake is a few KB of JSON) before decompressing.
- Pins the WebSocket `max_message_size` explicitly to axum's existing 64 MiB default — makes the inbound wire-size limit visible and ready to make configurable; behaviourally a no-op today.
- Logs the broader accepted limitation (the post-handshake sync path imposes no frame/row byte budget) under `specs/todo/issues/`, with the byte-budgeted-framing direction noted for a follow-up.

## Test plan
- [ ] `cargo test -p jazz-tools --lib --features transport-websocket handshake_decode_rejects_oversized_frame`
- [ ] `cargo test -p jazz-tools --features test --test integration test_ws_connection` — handshake still connects