### PR TITLE
Fix Next.js dual-React-copy SSR crash in withJazz

### DIFF
--- a/.changeset/next-jazz-tools-not-external.md
+++ b/.changeset/next-jazz-tools-not-external.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+`withJazz` no longer adds `jazz-tools` to Next.js `serverExternalPackages`. Externalising it caused the SSR worker and the user's "use client" components to load separate React instances, so the SSR dispatcher was missing on jazz-tools' copy and `useSyncExternalStore` failed with `Cannot read properties of null` when prerendering pages like `/_not-found`. `jazz-napi` stays external (native binary); jazz-tools is now bundled.

--- a/packages/jazz-tools/src/dev/next.test.ts
+++ b/packages/jazz-tools/src/dev/next.test.ts
@@ -93,8 +93,9 @@ describe("withJazz", () => {
 
     expect(resolved.poweredByHeader).toBe(false);
     expect(resolved.serverExternalPackages).toEqual(
-      expect.arrayContaining(["better-sqlite3", "jazz-tools", "jazz-napi"]),
+      expect.arrayContaining(["better-sqlite3", "jazz-napi"]),
     );
+    expect(resolved.serverExternalPackages).not.toContain("jazz-tools");
   });
 
   it("does not inject Jazz env vars outside the development phase", async () => {

--- a/packages/jazz-tools/src/dev/next.ts
+++ b/packages/jazz-tools/src/dev/next.ts
@@ -72,7 +72,7 @@ async function copyWasmToPublic(appRoot: string): Promise<void> {
 }
 
 function mergeServerExternalPackages(existing: string[] | undefined): string[] {
-  return Array.from(new Set([...(existing ?? []), "jazz-tools", "jazz-napi"]));
+  return Array.from(new Set([...(existing ?? []), "jazz-napi"]));
 }
 
 async function resolveConfig(


### PR DESCRIPTION
## Summary
- `withJazz` was adding `jazz-tools` to Next.js `serverExternalPackages`, causing the SSR worker and the user's "use client" components to load separate React instances. Hooks that read `ReactSharedInternals` (e.g. `useSyncExternalStore`) then hit a null dispatcher when prerendering.
- Now only `jazz-napi` (the native binary) stays external; jazz-tools is bundled with the SSR graph, so there's a single React instance again.
- SvelteKit was never affected — its plugin already externalises only `jazz-napi`.

Fixes https://github.com/garden-co/jazz/issues/960

## Test plan
- [ ] `pnpm build` in `starters/next-localfirst`, `starters/next-hybrid`, `starters/next-betterauth` with `NEXT_PUBLIC_JAZZ_APP_ID` / `NEXT_PUBLIC_JAZZ_SERVER_URL` set (and `BETTER_AUTH_SECRET` / `BACKEND_SECRET` for the auth starters)
- [ ] `pnpm test:e2e` in each of the three Next.js starters — all Playwright suites should pass.
- [ ] `pnpm dev` in each starter and `curl /` and `/api/auth/get-session` (where present) — confirm 200s and that the managed dev server still publishes the schema.