### PR TITLE
Cap WS connections per client_id and time out idle handshakes

### DIFF
--- a/.changeset/reconnect-storm-connection-cap.md
+++ b/.changeset/reconnect-storm-connection-cap.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Bound the reconnect-storm amplification on the server's WebSocket path: enforce a per-`client_id` connection cap (4) with evict-oldest semantics so a single client_id cannot pin unbounded fan-out memory, and time out pre-handshake sockets after 10s so an unauthenticated peer cannot park resources without sending the `AuthHandshake` frame. Evicted clients receive a `RateLimited` error frame followed by a policy close.

--- a/crates/jazz-tools/src/server/mod.rs
+++ b/crates/jazz-tools/src/server/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -31,7 +32,12 @@ pub type DynStorage = Box<dyn Storage + Send>;
 /// connection would exceed this cap, the oldest connection(s) for the same
 /// `client_id` are evicted so a reconnecting client is never locked out by
 /// its own zombies. Bounds the fan-out memory described in jaz0-a803.
-const PER_CLIENT_CONNECTION_CAP: usize = 4;
+///
+/// Value of 4 gives headroom for the realistic legitimate case (a brief
+/// overlap between an old half-open socket and a new reconnect, plus a
+/// small amount of slack for unusual topologies) without giving an
+/// attacker meaningful amplification before the cap bites.
+pub(crate) const PER_CLIENT_CONNECTION_CAP: usize = 4;
 
 #[derive(Debug, Clone)]
 pub struct SequencedSyncUpdate {
@@ -49,6 +55,24 @@ struct ConnectionStreamState {
     client_id: ClientId,
     next_sync_seq: u64,
     sender: mpsc::UnboundedSender<SequencedSyncUpdate>,
+    /// Set to `true` by `register_connection` immediately before this
+    /// stream is removed during per-client cap eviction. The connection
+    /// task reads it after `sync_rx.recv()` returns `None` to distinguish
+    /// eviction from a normal disconnect and emit a `RateLimited` error
+    /// frame.
+    evicted: Arc<AtomicBool>,
+}
+
+/// Result of registering a connection with the hub.
+pub struct ConnectionRegistration {
+    /// First sequence number to use for outbound payloads.
+    pub next_sync_seq: u64,
+    /// Receives sequenced sync updates dispatched to this connection.
+    pub receiver: mpsc::UnboundedReceiver<SequencedSyncUpdate>,
+    /// Set to `true` when this connection has been evicted by the
+    /// per-client cap. The connection task observes it after the
+    /// receiver returns `None`.
+    pub evicted: Arc<AtomicBool>,
 }
 
 #[derive(Default)]
@@ -61,8 +85,9 @@ impl ConnectionEventHub {
         &self,
         connection_id: u64,
         client_id: ClientId,
-    ) -> (u64, mpsc::UnboundedReceiver<SequencedSyncUpdate>) {
+    ) -> ConnectionRegistration {
         let (sender, receiver) = mpsc::unbounded_channel();
+        let evicted = Arc::new(AtomicBool::new(false));
         let mut streams = self.streams.lock().unwrap();
         streams.insert(
             connection_id,
@@ -70,27 +95,45 @@ impl ConnectionEventHub {
                 client_id,
                 next_sync_seq: 1,
                 sender,
+                evicted: evicted.clone(),
             },
         );
 
-        // Evict oldest connection(s) for this client_id past the cap.
-        // Connection IDs come from a monotonic counter, so the smallest
-        // IDs are the oldest registrations. Dropping a stream entry drops
-        // its sender, which causes the connection task's `sync_rx.recv()`
-        // to return `None` on its next select tick; that task then breaks
-        // its loop and runs `ws_cleanup`, removing itself from
-        // `ServerState::connections`.
-        let mut ids_for_client: Vec<u64> = streams
-            .iter()
-            .filter_map(|(id, state)| (state.client_id == client_id).then_some(*id))
-            .collect();
-        if ids_for_client.len() > PER_CLIENT_CONNECTION_CAP {
+        // Fast path: no eviction needed. Count without allocating; only
+        // walk + sort if we're actually past the cap.
+        let same_client_count = streams
+            .values()
+            .filter(|state| state.client_id == client_id)
+            .count();
+        if same_client_count > PER_CLIENT_CONNECTION_CAP {
+            // Evict the oldest connection(s) for this client_id past
+            // the cap. Connection IDs are assigned by a monotonic
+            // `fetch_add` in `handle_ws_connection`, so the smallest
+            // IDs were assigned earliest. Two registrations can race
+            // between the fetch and the lock here, but ordering by ID
+            // is still a stable, well-defined oldest-first tiebreaker.
+            //
+            // Eviction marks the per-stream `evicted` flag, then drops
+            // the stream's sender. The connection task's
+            // `sync_rx.recv()` returns `None` on its next select tick;
+            // it reads the flag, emits a `RateLimited` error frame,
+            // and runs `ws_cleanup` — which removes itself from
+            // `ServerState::connections`.
+            let mut ids_for_client: Vec<u64> = streams
+                .iter()
+                .filter_map(|(id, state)| (state.client_id == client_id).then_some(*id))
+                .collect();
             ids_for_client.sort_unstable();
-            let evict_count = ids_for_client.len() - PER_CLIENT_CONNECTION_CAP;
-            for evicted in &ids_for_client[..evict_count] {
-                streams.remove(evicted);
+            let evict_count = same_client_count - PER_CLIENT_CONNECTION_CAP;
+            for evicted_id in &ids_for_client[..evict_count] {
+                if let Some(state) = streams.get(evicted_id) {
+                    state
+                        .evicted
+                        .store(true, std::sync::atomic::Ordering::SeqCst);
+                }
+                streams.remove(evicted_id);
             }
-            tracing::info!(
+            tracing::warn!(
                 %client_id,
                 cap = PER_CLIENT_CONNECTION_CAP,
                 evicted = evict_count,
@@ -98,7 +141,11 @@ impl ConnectionEventHub {
             );
         }
 
-        (1, receiver)
+        ConnectionRegistration {
+            next_sync_seq: 1,
+            receiver,
+            evicted,
+        }
     }
 
     pub fn unregister_connection(&self, connection_id: u64) {

--- a/crates/jazz-tools/src/server/mod.rs
+++ b/crates/jazz-tools/src/server/mod.rs
@@ -27,6 +27,12 @@ pub use testing::{TestingJwksServer, TestingServer, TestingServerBuilder};
 
 pub type DynStorage = Box<dyn Storage + Send>;
 
+/// Cap on concurrent connections sharing a single `client_id`. When a new
+/// connection would exceed this cap, the oldest connection(s) for the same
+/// `client_id` are evicted so a reconnecting client is never locked out by
+/// its own zombies. Bounds the fan-out memory described in jaz0-a803.
+const PER_CLIENT_CONNECTION_CAP: usize = 4;
+
 #[derive(Debug, Clone)]
 pub struct SequencedSyncUpdate {
     pub seq: u64,
@@ -66,6 +72,32 @@ impl ConnectionEventHub {
                 sender,
             },
         );
+
+        // Evict oldest connection(s) for this client_id past the cap.
+        // Connection IDs come from a monotonic counter, so the smallest
+        // IDs are the oldest registrations. Dropping a stream entry drops
+        // its sender, which causes the connection task's `sync_rx.recv()`
+        // to return `None` on its next select tick; that task then breaks
+        // its loop and runs `ws_cleanup`, removing itself from
+        // `ServerState::connections`.
+        let mut ids_for_client: Vec<u64> = streams
+            .iter()
+            .filter_map(|(id, state)| (state.client_id == client_id).then_some(*id))
+            .collect();
+        if ids_for_client.len() > PER_CLIENT_CONNECTION_CAP {
+            ids_for_client.sort_unstable();
+            let evict_count = ids_for_client.len() - PER_CLIENT_CONNECTION_CAP;
+            for evicted in &ids_for_client[..evict_count] {
+                streams.remove(evicted);
+            }
+            tracing::info!(
+                %client_id,
+                cap = PER_CLIENT_CONNECTION_CAP,
+                evicted = evict_count,
+                "evicting oldest ws connections past per-client cap"
+            );
+        }
+
         (1, receiver)
     }
 

--- a/crates/jazz-tools/src/server/routes/mod.rs
+++ b/crates/jazz-tools/src/server/routes/mod.rs
@@ -91,6 +91,9 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
 }
 
 #[cfg(test)]
+mod reconnect_storm_tests;
+
+#[cfg(test)]
 mod tests {
     use super::http::*;
     use super::utils::*;

--- a/crates/jazz-tools/src/server/routes/reconnect_storm_tests.rs
+++ b/crates/jazz-tools/src/server/routes/reconnect_storm_tests.rs
@@ -1,0 +1,291 @@
+//! Behavioural tests for jaz0-a803 (reconnect-storm amplification).
+//!
+//! These tests drive the wire-level behaviour of a misconfigured or
+//! malicious client and assert what the server must guarantee, without
+//! peeking at the structure of the mitigation. They cover the two
+//! mitigations selected for this branch:
+//!
+//! 1. **Per-`client_id` connection cap** with evict-oldest semantics:
+//!    a single `client_id` cannot pin unbounded server state by opening
+//!    many concurrent sockets, and a reconnecting client always wins
+//!    against its own stale sockets.
+//! 2. **Handshake-stage read timeout**: a WS upgrade that never sends
+//!    an `AuthHandshake` frame cannot tie up server resources indefinitely.
+//!
+//! ## What these tests prove (and what they don't)
+//!
+//! The first and third tests are **exploit-primitive demonstrations at
+//! sub-OOM scale**. They show that the server accepts the relevant input
+//! pattern (many concurrent sockets under one `client_id`; a parked WS
+//! upgrade that never handshakes) without applying any bound. They are
+//! intentionally small enough to run quickly in CI — they prove the
+//! primitive exists, not that it crashes a production host. Severity at
+//! scale comes from the analysis on the ticket, not from these tests.
+//!
+//! The second test is a **fix-shape contract**, not an exploit demo. It
+//! pins the eviction policy to "evict oldest, not reject newest" so a
+//! reconnecting client cannot be locked out by its own zombies — that's
+//! a UX correctness property of the chosen mitigation, not an attack.
+//!
+//! Each test observes the server only through the public WebSocket
+//! protocol and the live `ServerState::connections` map — never through
+//! internals of the cap itself — so it remains valid under any
+//! implementation that satisfies the behavioural contract.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::stream::FuturesUnordered;
+use futures::{SinkExt as _, StreamExt as _};
+use tokio::net::TcpStream;
+use tokio_tungstenite::{
+    MaybeTlsStream, WebSocketStream, connect_async, tungstenite::Message as WsMessage,
+};
+
+use crate::middleware::AuthConfig;
+use crate::schema_manager::AppId;
+use crate::server::{ServerBuilder, ServerState, StorageBackend};
+use crate::sync_manager::ClientId;
+
+type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
+
+/// Selected cap value for this branch (see ticket jaz0-a803).
+const PER_CLIENT_CONNECTION_CAP: usize = 4;
+
+/// Scale used by the exploit-primitive demonstrations. Big enough that the
+/// failure message ("the server allowed N connections under one client_id"
+/// / "the server kept N idle upgrades parked") reads as a real exploit
+/// demonstration; small enough to run quickly inside CI's `ulimit -n`.
+const STORM_SIZE: usize = 100;
+
+const BACKEND_SECRET: &str = "test-backend-secret";
+
+async fn make_test_state() -> Arc<ServerState> {
+    let auth_config = AuthConfig {
+        backend_secret: Some(BACKEND_SECRET.to_string()),
+        ..Default::default()
+    };
+    ServerBuilder::new(AppId::from_name("test-app"))
+        .with_auth_config(auth_config)
+        .with_storage(StorageBackend::InMemory)
+        .build()
+        .await
+        .expect("build test server state")
+        .state
+}
+
+async fn start_test_server(state: Arc<ServerState>) -> std::net::SocketAddr {
+    let app = super::create_router(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let addr = listener.local_addr().expect("test listener addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve test app");
+    });
+    addr
+}
+
+/// Open a WS connection, send the handshake using `client_id_str`, and
+/// wait for `ConnectedResponse`. The returned stream is fully registered
+/// server-side by the time this resolves.
+async fn open_authenticated_ws(
+    addr: std::net::SocketAddr,
+    state: &Arc<ServerState>,
+    client_id_str: &str,
+) -> Result<WsStream, String> {
+    let url = format!("ws://{addr}/apps/{}/ws", state.app_id);
+    let (mut ws, _) = connect_async(&url)
+        .await
+        .map_err(|e| format!("ws upgrade failed: {e}"))?;
+
+    let handshake = crate::transport_manager::AuthHandshake {
+        sync_protocol_version: crate::transport_manager::SYNC_PROTOCOL_VERSION,
+        client_id: client_id_str.to_string(),
+        auth: crate::transport_manager::AuthConfig {
+            backend_secret: Some(BACKEND_SECRET.to_string()),
+            ..Default::default()
+        },
+        catalogue_state_hash: None,
+        declared_schema_hash: None,
+    };
+    let payload = serde_json::to_vec(&handshake).expect("serialize handshake");
+    ws.send(WsMessage::Binary(
+        crate::transport_manager::frame_encode(&payload).into(),
+    ))
+    .await
+    .map_err(|e| format!("ws send handshake: {e}"))?;
+
+    let msg = tokio::time::timeout(Duration::from_secs(5), ws.next())
+        .await
+        .map_err(|_| "timed out waiting for ConnectedResponse".to_string())?
+        .ok_or_else(|| "ws stream ended before ConnectedResponse".to_string())?
+        .map_err(|e| format!("ws recv: {e}"))?;
+    let WsMessage::Binary(bytes) = msg else {
+        return Err(format!("unexpected pre-Connected message: {msg:?}"));
+    };
+    let inner = crate::transport_manager::frame_decode(&bytes)
+        .ok_or_else(|| "malformed pre-Connected frame".to_string())?;
+    let _: crate::transport_manager::ConnectedResponse = serde_json::from_slice(&inner)
+        .map_err(|e| format!("expected ConnectedResponse, got error: {e}"))?;
+    Ok(ws)
+}
+
+async fn live_connections_for(state: &Arc<ServerState>, client_id: ClientId) -> usize {
+    state
+        .connections
+        .read()
+        .await
+        .values()
+        .filter(|c| c.client_id == client_id)
+        .count()
+}
+
+/// EXPLOIT-PRIMITIVE: at sub-OOM scale, demonstrate that the server has no
+/// bound on concurrent connections per `client_id`. A single client_id
+/// can register `STORM_SIZE` fan-out targets in `ConnectionEventHub`,
+/// each with its own unbounded outbound channel — payload memory grows
+/// as `connections × per-channel backlog`, and the same primitive at
+/// larger scale OOMs the server (see ticket analysis).
+///
+/// Today: all `STORM_SIZE` sockets register. The cap must reduce the
+/// live count to at most `PER_CLIENT_CONNECTION_CAP`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn same_client_id_concurrent_connections_are_bounded() {
+    let state = make_test_state().await;
+    let addr = start_test_server(state.clone()).await;
+    let client_id_str = ClientId::new().to_string();
+    let client_id = ClientId::parse(&client_id_str).expect("parse client_id");
+
+    // Open many concurrent sockets under the same client_id. We use
+    // FuturesUnordered so the handshakes race — matching the real
+    // attack shape, where an attacker opens connections in parallel
+    // rather than strictly in series.
+    let mut pending = FuturesUnordered::new();
+    for _ in 0..STORM_SIZE {
+        let addr = addr;
+        let state = state.clone();
+        let client_id_str = client_id_str.clone();
+        pending.push(async move { open_authenticated_ws(addr, &state, &client_id_str).await });
+    }
+    let mut sockets: Vec<WsStream> = Vec::with_capacity(STORM_SIZE);
+    let mut handshake_failures = 0usize;
+    while let Some(result) = pending.next().await {
+        match result {
+            Ok(ws) => sockets.push(ws),
+            Err(_) => handshake_failures += 1,
+        }
+    }
+
+    // Brief settle so any eviction policy has a chance to fire.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let live = live_connections_for(&state, client_id).await;
+    assert!(
+        live <= PER_CLIENT_CONNECTION_CAP,
+        "server must bound live connections per client_id to {PER_CLIENT_CONNECTION_CAP}, \
+         but registered {live} live for one client_id after a {STORM_SIZE}-socket storm \
+         ({} handshakes succeeded, {handshake_failures} failed) — at scale, this primitive \
+         drives the server-side fan-out memory growth described in jaz0-a803",
+        sockets.len(),
+    );
+}
+
+/// FIX-CONTRACT: when the per-client cap is reached, eviction must drop
+/// the OLDEST socket, not reject the newest. This is a UX correctness
+/// requirement for the chosen mitigation — not an exploit on its own —
+/// so that a benign client reconnecting after a network blip is never
+/// locked out by its own stale sockets.
+///
+/// Today: no cap exists, so the test fails simply because no eviction
+/// happens. After the fix, the (cap + 1)-th handshake must succeed AND
+/// the first socket opened must be closed by the server.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn eviction_policy_drops_oldest_socket_not_newest() {
+    let state = make_test_state().await;
+    let addr = start_test_server(state.clone()).await;
+    let client_id_str = ClientId::new().to_string();
+
+    // Open cap-many sockets, strictly in order so server-side
+    // registration is ordered too.
+    let mut sockets = Vec::with_capacity(PER_CLIENT_CONNECTION_CAP);
+    for i in 0..PER_CLIENT_CONNECTION_CAP {
+        let ws = open_authenticated_ws(addr, &state, &client_id_str)
+            .await
+            .unwrap_or_else(|e| panic!("handshake {i} failed: {e}"));
+        sockets.push(ws);
+    }
+
+    // The (cap + 1)-th handshake represents a reconnect that comes in
+    // while the older sockets are still registered. It must succeed.
+    let _newest = open_authenticated_ws(addr, &state, &client_id_str)
+        .await
+        .expect("reconnect must succeed once the cap is reached (evict-oldest, not reject-newest)");
+
+    // The oldest socket must now be closed by the server. We tolerate
+    // either an explicit Close frame, an end-of-stream, or a transport
+    // error — any of those signals that the server severed it.
+    let oldest = &mut sockets[0];
+    let outcome = tokio::time::timeout(Duration::from_secs(3), oldest.next()).await;
+    let closed_by_server = matches!(
+        outcome,
+        Ok(Some(Ok(WsMessage::Close(_)))) | Ok(Some(Err(_))) | Ok(None)
+    );
+    assert!(
+        closed_by_server,
+        "oldest socket must be closed by the server when the per-client cap is exceeded; \
+         observed: {outcome:?}",
+    );
+}
+
+/// EXPLOIT-PRIMITIVE: at sub-OOM scale, demonstrate that the server
+/// holds pre-handshake sockets open indefinitely. Each parked upgrade
+/// pins a Tokio task awaiting `socket.recv()`, an fd, and a recv
+/// buffer. At larger scale this is the unauthenticated slowloris
+/// pattern described on the ticket.
+///
+/// Today: all `STORM_SIZE` upgrades stay parked past the test's outer
+/// deadline. The handshake timeout must cause all of them to be closed
+/// within a bounded window.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn idle_ws_upgrades_are_not_held_open_indefinitely() {
+    let state = make_test_state().await;
+    let addr = start_test_server(state.clone()).await;
+    let url = format!("ws://{addr}/apps/{}/ws", state.app_id);
+
+    // Open many concurrent WS upgrades. None send a handshake frame;
+    // each just parks on its socket waiting for the server to give up.
+    let mut sockets: Vec<WsStream> = Vec::with_capacity(STORM_SIZE);
+    for _ in 0..STORM_SIZE {
+        let (ws, _) = connect_async(&url).await.expect("ws upgrade");
+        sockets.push(ws);
+    }
+
+    // Wait long enough for a production handshake timeout (~10s) to
+    // fire on every socket, plus margin. Then poll each one in parallel:
+    // a closed-by-server socket returns a Close frame, end-of-stream,
+    // or a transport error within a short window. A parked socket pends.
+    tokio::time::sleep(Duration::from_secs(15)).await;
+
+    let mut polls = FuturesUnordered::new();
+    for mut ws in sockets {
+        polls.push(async move { tokio::time::timeout(Duration::from_secs(2), ws.next()).await });
+    }
+    let mut still_parked = 0usize;
+    while let Some(outcome) = polls.next().await {
+        let closed_by_server = matches!(
+            outcome,
+            Ok(Some(Ok(WsMessage::Close(_)))) | Ok(Some(Err(_))) | Ok(None)
+        );
+        if !closed_by_server {
+            still_parked += 1;
+        }
+    }
+
+    assert_eq!(
+        still_parked, 0,
+        "server must close pre-handshake sockets within the handshake timeout, \
+         but {still_parked}/{STORM_SIZE} idle upgrades were still parked after 15s \
+         — at scale, this primitive is the slowloris pattern described in jaz0-a803",
+    );
+}

--- a/crates/jazz-tools/src/server/routes/reconnect_storm_tests.rs
+++ b/crates/jazz-tools/src/server/routes/reconnect_storm_tests.rs
@@ -8,24 +8,28 @@
 //! 1. **Per-`client_id` connection cap** with evict-oldest semantics:
 //!    a single `client_id` cannot pin unbounded server state by opening
 //!    many concurrent sockets, and a reconnecting client always wins
-//!    against its own stale sockets.
+//!    against its own stale sockets. Evicted clients receive a
+//!    `RateLimited` error frame followed by a policy close so the
+//!    eviction is observable application-side, not just at the TCP layer.
 //! 2. **Handshake-stage read timeout**: a WS upgrade that never sends
 //!    an `AuthHandshake` frame cannot tie up server resources indefinitely.
 //!
 //! ## What these tests prove (and what they don't)
 //!
-//! The first and third tests are **exploit-primitive demonstrations at
-//! sub-OOM scale**. They show that the server accepts the relevant input
-//! pattern (many concurrent sockets under one `client_id`; a parked WS
-//! upgrade that never handshakes) without applying any bound. They are
+//! The "concurrent storm" and "idle upgrade" tests are
+//! **exploit-primitive demonstrations at sub-OOM scale**. They show that
+//! without the mitigations the server accepts the relevant input pattern
+//! (many concurrent sockets under one `client_id`; a parked WS upgrade
+//! that never handshakes) without applying any bound. They are
 //! intentionally small enough to run quickly in CI — they prove the
 //! primitive exists, not that it crashes a production host. Severity at
 //! scale comes from the analysis on the ticket, not from these tests.
 //!
-//! The second test is a **fix-shape contract**, not an exploit demo. It
-//! pins the eviction policy to "evict oldest, not reject newest" so a
-//! reconnecting client cannot be locked out by its own zombies — that's
-//! a UX correctness property of the chosen mitigation, not an attack.
+//! The remaining tests are **fix-shape contracts**. They pin properties
+//! the mitigation must satisfy: oldest is the eviction target; other
+//! `client_id`s are unaffected; repeated eviction keeps live count
+//! bounded; the evicted client gets a `RateLimited` signal; the handshake
+//! timeout interacts cleanly with shutdown.
 //!
 //! Each test observes the server only through the public WebSocket
 //! protocol and the live `ServerState::connections` map — never through
@@ -42,21 +46,25 @@ use tokio_tungstenite::{
     MaybeTlsStream, WebSocketStream, connect_async, tungstenite::Message as WsMessage,
 };
 
+use crate::jazz_transport::{ErrorCode, ServerEvent};
 use crate::middleware::AuthConfig;
 use crate::schema_manager::AppId;
-use crate::server::{ServerBuilder, ServerState, StorageBackend};
+use crate::server::routes::websocket::HANDSHAKE_READ_TIMEOUT;
+use crate::server::{PER_CLIENT_CONNECTION_CAP, ServerBuilder, ServerState, StorageBackend};
 use crate::sync_manager::ClientId;
 
 type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
-
-/// Selected cap value for this branch (see ticket jaz0-a803).
-const PER_CLIENT_CONNECTION_CAP: usize = 4;
 
 /// Scale used by the exploit-primitive demonstrations. Big enough that the
 /// failure message ("the server allowed N connections under one client_id"
 /// / "the server kept N idle upgrades parked") reads as a real exploit
 /// demonstration; small enough to run quickly inside CI's `ulimit -n`.
 const STORM_SIZE: usize = 100;
+
+/// Upper bound on how long a behaviour assertion polls before failing.
+/// Generous enough to absorb scheduler jitter on loaded CI runners,
+/// without making genuine failures slow.
+const SETTLE_DEADLINE: Duration = Duration::from_secs(5);
 
 const BACKEND_SECRET: &str = "test-backend-secret";
 
@@ -141,6 +149,35 @@ async fn live_connections_for(state: &Arc<ServerState>, client_id: ClientId) -> 
         .count()
 }
 
+/// Poll the live connection count for `client_id` until it satisfies
+/// `predicate`, with a `SETTLE_DEADLINE` upper bound. Returns the last
+/// observed count. Used so tests don't need to guess a fixed settle
+/// window — flaky on loaded CI runners, especially under storms where
+/// evicted tasks may still be in `ensure_client_*` or mid-`socket.send`
+/// when a fixed-sleep test wakes.
+async fn wait_for_live_count(
+    state: &Arc<ServerState>,
+    client_id: ClientId,
+    predicate: impl Fn(usize) -> bool,
+) -> usize {
+    let start = tokio::time::Instant::now();
+    let mut live = live_connections_for(state, client_id).await;
+    while !predicate(live) && start.elapsed() < SETTLE_DEADLINE {
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        live = live_connections_for(state, client_id).await;
+    }
+    live
+}
+
+/// Decode a post-handshake `ServerEvent` from a binary WS message.
+/// Returns `None` if the message isn't a decodable event.
+fn decode_post_handshake_event(msg: &WsMessage) -> Option<ServerEvent> {
+    let WsMessage::Binary(bytes) = msg else {
+        return None;
+    };
+    ServerEvent::decode_frame(bytes)
+}
+
 /// EXPLOIT-PRIMITIVE: at sub-OOM scale, demonstrate that the server has no
 /// bound on concurrent connections per `client_id`. A single client_id
 /// can register `STORM_SIZE` fan-out targets in `ConnectionEventHub`,
@@ -148,8 +185,9 @@ async fn live_connections_for(state: &Arc<ServerState>, client_id: ClientId) -> 
 /// as `connections × per-channel backlog`, and the same primitive at
 /// larger scale OOMs the server (see ticket analysis).
 ///
-/// Today: all `STORM_SIZE` sockets register. The cap must reduce the
-/// live count to at most `PER_CLIENT_CONNECTION_CAP`.
+/// Today's gap: without the cap, all `STORM_SIZE` sockets register. The
+/// cap must reduce the live count to at most `PER_CLIENT_CONNECTION_CAP`,
+/// AND it must do so via eviction — none of the handshakes are rejected.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn same_client_id_concurrent_connections_are_bounded() {
     let state = make_test_state().await;
@@ -177,17 +215,18 @@ async fn same_client_id_concurrent_connections_are_bounded() {
         }
     }
 
-    // Brief settle so any eviction policy has a chance to fire.
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    assert_eq!(
+        handshake_failures, 0,
+        "the cap must evict-not-reject: all {STORM_SIZE} handshakes should succeed",
+    );
 
-    let live = live_connections_for(&state, client_id).await;
+    let live = wait_for_live_count(&state, client_id, |c| c <= PER_CLIENT_CONNECTION_CAP).await;
     assert!(
         live <= PER_CLIENT_CONNECTION_CAP,
         "server must bound live connections per client_id to {PER_CLIENT_CONNECTION_CAP}, \
-         but registered {live} live for one client_id after a {STORM_SIZE}-socket storm \
-         ({} handshakes succeeded, {handshake_failures} failed) — at scale, this primitive \
-         drives the server-side fan-out memory growth described in jaz0-a803",
-        sockets.len(),
+         but {live} were still live for one client_id after a {STORM_SIZE}-socket storm \
+         and a {SETTLE_DEADLINE:?} settle window — at scale, this primitive drives the \
+         server-side fan-out memory growth described in jaz0-a803",
     );
 }
 
@@ -196,10 +235,6 @@ async fn same_client_id_concurrent_connections_are_bounded() {
 /// requirement for the chosen mitigation — not an exploit on its own —
 /// so that a benign client reconnecting after a network blip is never
 /// locked out by its own stale sockets.
-///
-/// Today: no cap exists, so the test fails simply because no eviction
-/// happens. After the fix, the (cap + 1)-th handshake must succeed AND
-/// the first socket opened must be closed by the server.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn eviction_policy_drops_oldest_socket_not_newest() {
     let state = make_test_state().await;
@@ -224,9 +259,18 @@ async fn eviction_policy_drops_oldest_socket_not_newest() {
 
     // The oldest socket must now be closed by the server. We tolerate
     // either an explicit Close frame, an end-of-stream, or a transport
-    // error — any of those signals that the server severed it.
+    // error — any of those signals that the server severed it. The
+    // intervening RateLimited error frame is checked by a dedicated test.
     let oldest = &mut sockets[0];
-    let outcome = tokio::time::timeout(Duration::from_secs(3), oldest.next()).await;
+    let outcome = tokio::time::timeout(Duration::from_secs(3), async {
+        loop {
+            match oldest.next().await {
+                Some(Ok(WsMessage::Binary(_))) => continue, // skip the RateLimited error frame
+                other => break other,
+            }
+        }
+    })
+    .await;
     let closed_by_server = matches!(
         outcome,
         Ok(Some(Ok(WsMessage::Close(_)))) | Ok(Some(Err(_))) | Ok(None)
@@ -238,15 +282,170 @@ async fn eviction_policy_drops_oldest_socket_not_newest() {
     );
 }
 
+/// FIX-CONTRACT: an evicted connection must receive a programmatic signal
+/// before the close frame, so clients can distinguish cap eviction from
+/// a generic TCP-level disconnect. We assert the `RateLimited` error
+/// event arrives, followed by a policy close.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn evicted_connection_receives_rate_limited_error_then_close() {
+    let state = make_test_state().await;
+    let addr = start_test_server(state.clone()).await;
+    let client_id_str = ClientId::new().to_string();
+
+    let mut oldest = open_authenticated_ws(addr, &state, &client_id_str)
+        .await
+        .expect("open oldest handshake");
+    // Fill the cap with placeholder sockets we don't read from.
+    let mut _fillers = Vec::with_capacity(PER_CLIENT_CONNECTION_CAP);
+    for _ in 0..PER_CLIENT_CONNECTION_CAP {
+        _fillers.push(
+            open_authenticated_ws(addr, &state, &client_id_str)
+                .await
+                .expect("filler handshake"),
+        );
+    }
+
+    let mut saw_rate_limited = false;
+    let mut saw_close = false;
+    let mut close_code = None;
+    let _ = tokio::time::timeout(Duration::from_secs(3), async {
+        while let Some(msg) = oldest.next().await {
+            match msg {
+                Ok(msg) => {
+                    if let Some(event) = decode_post_handshake_event(&msg) {
+                        if let ServerEvent::Error { code, .. } = event
+                            && code == ErrorCode::RateLimited
+                        {
+                            saw_rate_limited = true;
+                        }
+                    }
+                    if let WsMessage::Close(frame) = msg {
+                        saw_close = true;
+                        close_code = frame.map(|f| f.code);
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    })
+    .await;
+
+    assert!(
+        saw_rate_limited,
+        "evicted socket must receive a ServerEvent::Error with code RateLimited before close",
+    );
+    assert!(
+        saw_close,
+        "evicted socket must receive an application-level Close frame"
+    );
+    assert_eq!(
+        close_code,
+        Some(tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode::Policy),
+        "close code must be Policy (1008) for cap-driven evictions",
+    );
+}
+
+/// FIX-CONTRACT: eviction is scoped to the offending `client_id`.
+/// A storm against client X must not touch client Y's connections.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn eviction_does_not_affect_other_client_ids() {
+    let state = make_test_state().await;
+    let addr = start_test_server(state.clone()).await;
+    let client_x_str = ClientId::new().to_string();
+    let client_y_str = ClientId::new().to_string();
+    let client_x = ClientId::parse(&client_x_str).expect("parse x");
+    let client_y = ClientId::parse(&client_y_str).expect("parse y");
+
+    // Open Y's connections first, well under the cap, and hold them.
+    let mut _y_sockets = Vec::with_capacity(PER_CLIENT_CONNECTION_CAP);
+    for _ in 0..PER_CLIENT_CONNECTION_CAP {
+        _y_sockets.push(
+            open_authenticated_ws(addr, &state, &client_y_str)
+                .await
+                .expect("open Y socket"),
+        );
+    }
+    let y_baseline = live_connections_for(&state, client_y).await;
+    assert_eq!(
+        y_baseline, PER_CLIENT_CONNECTION_CAP,
+        "Y should have exactly cap-many connections established",
+    );
+
+    // Storm X concurrently with Y already at the cap.
+    let mut pending = FuturesUnordered::new();
+    for _ in 0..STORM_SIZE {
+        let addr = addr;
+        let state = state.clone();
+        let client_x_str = client_x_str.clone();
+        pending.push(async move { open_authenticated_ws(addr, &state, &client_x_str).await });
+    }
+    let mut _x_sockets: Vec<WsStream> = Vec::with_capacity(STORM_SIZE);
+    while let Some(result) = pending.next().await {
+        if let Ok(ws) = result {
+            _x_sockets.push(ws);
+        }
+    }
+
+    let x_live = wait_for_live_count(&state, client_x, |c| c <= PER_CLIENT_CONNECTION_CAP).await;
+    assert!(
+        x_live <= PER_CLIENT_CONNECTION_CAP,
+        "X live count must be bounded by cap; got {x_live}",
+    );
+
+    let y_live = live_connections_for(&state, client_y).await;
+    assert_eq!(
+        y_live, PER_CLIENT_CONNECTION_CAP,
+        "Y connections must not be evicted by X's storm; expected {PER_CLIENT_CONNECTION_CAP}, got {y_live}",
+    );
+}
+
+/// FIX-CONTRACT: a steady stream of reconnects (each evicting the
+/// previous oldest) keeps the live count at the cap rather than letting
+/// it drift up over time. This guards against an off-by-one in the
+/// eviction count or a state-machine regression that only evicts on the
+/// first overflow.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn repeated_evictions_keep_live_count_at_cap() {
+    let state = make_test_state().await;
+    let addr = start_test_server(state.clone()).await;
+    let client_id_str = ClientId::new().to_string();
+    let client_id = ClientId::parse(&client_id_str).expect("parse client_id");
+
+    // Fill to the cap.
+    let mut sockets = Vec::with_capacity(PER_CLIENT_CONNECTION_CAP);
+    for _ in 0..PER_CLIENT_CONNECTION_CAP {
+        sockets.push(
+            open_authenticated_ws(addr, &state, &client_id_str)
+                .await
+                .expect("fill handshake"),
+        );
+    }
+    let initial = wait_for_live_count(&state, client_id, |c| c == PER_CLIENT_CONNECTION_CAP).await;
+    assert_eq!(initial, PER_CLIENT_CONNECTION_CAP);
+
+    // Cycle: open one new connection, then check the live count.
+    // Each new socket must evict exactly one old socket, keeping the
+    // total live count at the cap.
+    for cycle in 0..(PER_CLIENT_CONNECTION_CAP * 3) {
+        let _new = open_authenticated_ws(addr, &state, &client_id_str)
+            .await
+            .unwrap_or_else(|e| panic!("cycle {cycle} reconnect failed: {e}"));
+
+        let live = wait_for_live_count(&state, client_id, |c| c == PER_CLIENT_CONNECTION_CAP).await;
+        assert_eq!(
+            live, PER_CLIENT_CONNECTION_CAP,
+            "live count must stay at cap after cycle {cycle}; observed {live}",
+        );
+        sockets.push(_new);
+    }
+}
+
 /// EXPLOIT-PRIMITIVE: at sub-OOM scale, demonstrate that the server
 /// holds pre-handshake sockets open indefinitely. Each parked upgrade
 /// pins a Tokio task awaiting `socket.recv()`, an fd, and a recv
 /// buffer. At larger scale this is the unauthenticated slowloris
 /// pattern described on the ticket.
-///
-/// Today: all `STORM_SIZE` upgrades stay parked past the test's outer
-/// deadline. The handshake timeout must cause all of them to be closed
-/// within a bounded window.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn idle_ws_upgrades_are_not_held_open_indefinitely() {
     let state = make_test_state().await;
@@ -261,11 +460,9 @@ async fn idle_ws_upgrades_are_not_held_open_indefinitely() {
         sockets.push(ws);
     }
 
-    // Wait long enough for a production handshake timeout (~10s) to
-    // fire on every socket, plus margin. Then poll each one in parallel:
-    // a closed-by-server socket returns a Close frame, end-of-stream,
-    // or a transport error within a short window. A parked socket pends.
-    tokio::time::sleep(Duration::from_secs(15)).await;
+    // Wait `HANDSHAKE_READ_TIMEOUT` plus a margin for the timer to fire
+    // and the close frames to land. Then poll each one in parallel.
+    tokio::time::sleep(HANDSHAKE_READ_TIMEOUT + Duration::from_secs(2)).await;
 
     let mut polls = FuturesUnordered::new();
     for mut ws in sockets {
@@ -285,7 +482,35 @@ async fn idle_ws_upgrades_are_not_held_open_indefinitely() {
     assert_eq!(
         still_parked, 0,
         "server must close pre-handshake sockets within the handshake timeout, \
-         but {still_parked}/{STORM_SIZE} idle upgrades were still parked after 15s \
-         — at scale, this primitive is the slowloris pattern described in jaz0-a803",
+         but {still_parked}/{STORM_SIZE} idle upgrades were still parked after \
+         {HANDSHAKE_READ_TIMEOUT:?} + 2s — at scale, this primitive is the slowloris \
+         pattern described in jaz0-a803",
+    );
+}
+
+/// FIX-CONTRACT: a parked pre-handshake socket must close cleanly when
+/// the server is shutting down, with no panic and no resource leak,
+/// regardless of which branch of the handshake select wins the race.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn idle_ws_upgrade_during_shutdown_closes_cleanly() {
+    let state = make_test_state().await;
+    let addr = start_test_server(state.clone()).await;
+    let url = format!("ws://{addr}/apps/{}/ws", state.app_id);
+    let (mut ws, _) = connect_async(&url).await.expect("ws upgrade");
+
+    // Give the server a moment to enter the handshake-wait select,
+    // then request shutdown. Shutdown should win the race against the
+    // 10s handshake timer.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    state.shutdown.request_shutdown();
+
+    let outcome = tokio::time::timeout(Duration::from_secs(3), ws.next()).await;
+    let closed_by_server = matches!(
+        outcome,
+        Ok(Some(Ok(WsMessage::Close(_)))) | Ok(Some(Err(_))) | Ok(None)
+    );
+    assert!(
+        closed_by_server,
+        "parked pre-handshake socket must close cleanly under shutdown; observed: {outcome:?}",
     );
 }

--- a/crates/jazz-tools/src/server/routes/websocket.rs
+++ b/crates/jazz-tools/src/server/routes/websocket.rs
@@ -30,7 +30,7 @@ const MAX_HANDSHAKE_DECOMPRESSED_BYTES: usize = 1024 * 1024;
 /// frame after the WS upgrade completes. Closes the slowloris pattern
 /// where an attacker pins server-side state by opening upgrades and never
 /// sending the first frame. See jaz0-a803.
-const HANDSHAKE_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+pub(crate) const HANDSHAKE_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// Maximum size of an inbound WebSocket message (the compressed bytes on the
 /// wire). This is axum's existing default, set explicitly so the limit is
@@ -278,6 +278,9 @@ async fn send_ws_error(socket: &mut WebSocket, message: &str) {
 }
 
 /// Send a `ServerEvent::Error` frame on the socket, best-effort.
+///
+/// Uses JSON encoding so a not-yet-authenticated peer (which doesn't know
+/// the post-handshake binary wire format yet) can still decode the error.
 async fn send_ws_error_with_code(
     socket: &mut WebSocket,
     code: crate::jazz_transport::ErrorCode,
@@ -293,11 +296,40 @@ async fn send_ws_error_with_code(
     }
 }
 
+/// Send a `ServerEvent::Error` frame using the post-handshake binary
+/// wire format. Use this from any path that runs after the
+/// `ConnectedResponse` has been sent — clients post-handshake parse
+/// frames via `ServerEvent::decode_payload`, not JSON.
+async fn send_ws_error_binary(
+    socket: &mut WebSocket,
+    code: crate::jazz_transport::ErrorCode,
+    message: &str,
+) {
+    let event = crate::jazz_transport::ServerEvent::Error {
+        message: message.to_string(),
+        code,
+    };
+    if let Ok(bytes) = event.encode_payload() {
+        let frame = crate::transport_manager::frame_encode(&bytes);
+        let _ = socket.send(Message::Binary(frame)).await;
+    }
+}
+
 async fn close_ws_with_protocol_reason(socket: &mut WebSocket, reason: &str) {
     let reason = reason.chars().take(123).collect::<String>();
     let _ = socket
         .send(Message::Close(Some(CloseFrame {
             code: close_code::PROTOCOL,
+            reason: reason.into(),
+        })))
+        .await;
+}
+
+async fn close_ws_with_policy_reason(socket: &mut WebSocket, reason: &str) {
+    let reason = reason.chars().take(123).collect::<String>();
+    let _ = socket
+        .send(Message::Close(Some(CloseFrame {
+            code: close_code::POLICY,
             reason: reason.into(),
         })))
         .await;
@@ -347,7 +379,7 @@ async fn handle_ws_connection(
             return;
         }
         _ = tokio::time::sleep(HANDSHAKE_READ_TIMEOUT) => {
-            close_ws_with_protocol_reason(&mut socket, "handshake timeout").await;
+            close_ws_with_policy_reason(&mut socket, "handshake timeout").await;
             return;
         }
     };
@@ -430,7 +462,11 @@ async fn handle_ws_connection(
     let connection_id = state
         .next_connection_id
         .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-    let (next_sync_seq, mut sync_rx) = state
+    let crate::server::ConnectionRegistration {
+        next_sync_seq,
+        receiver: mut sync_rx,
+        evicted: evicted_flag,
+    } = state
         .connection_event_hub
         .register_connection(connection_id, client_id);
     {
@@ -537,7 +573,25 @@ async fn handle_ws_connection(
                 _ => continue,
             },
             update = sync_rx.recv() => {
-                let Some(u) = update else { break };
+                let Some(u) = update else {
+                    // Distinguish per-client-cap eviction from a normal
+                    // disconnect, so the evicted client gets a programmatic
+                    // signal instead of an unexplained TCP close.
+                    if evicted_flag.load(std::sync::atomic::Ordering::SeqCst) {
+                        send_ws_error_binary(
+                            &mut socket,
+                            crate::jazz_transport::ErrorCode::RateLimited,
+                            "per-client connection cap exceeded",
+                        )
+                        .await;
+                        close_ws_with_policy_reason(
+                            &mut socket,
+                            "per-client connection cap exceeded",
+                        )
+                        .await;
+                    }
+                    break;
+                };
                 let mut updates = Vec::with_capacity(MAX_WS_SYNC_UPDATES_PER_FRAME);
                 updates.push(crate::jazz_transport::SequencedSyncPayload {
                     seq: Some(u.seq),

--- a/crates/jazz-tools/src/server/routes/websocket.rs
+++ b/crates/jazz-tools/src/server/routes/websocket.rs
@@ -26,6 +26,12 @@ const MAX_WS_SYNC_UPDATES_PER_FRAME: usize = 256;
 /// decompression bomb sent by an unauthenticated peer before any auth runs.
 const MAX_HANDSHAKE_DECOMPRESSED_BYTES: usize = 1024 * 1024;
 
+/// Maximum time the server waits for a client to send its `AuthHandshake`
+/// frame after the WS upgrade completes. Closes the slowloris pattern
+/// where an attacker pins server-side state by opening upgrades and never
+/// sending the first frame. See jaz0-a803.
+const HANDSHAKE_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 /// Maximum size of an inbound WebSocket message (the compressed bytes on the
 /// wire). This is axum's existing default, set explicitly so the limit is
 /// visible and can later be made configurable. It is *not* a bound on the
@@ -322,6 +328,8 @@ async fn handle_ws_connection(
     }
 
     // 1. Read the first binary frame — expected to be AuthHandshake.
+    //    Bounded read so unauthenticated peers can't pin server-side
+    //    resources by opening upgrades without sending a handshake.
     let first = tokio::select! {
         msg = socket.recv() => match msg {
             Some(Ok(Message::Binary(b))) => b,
@@ -336,6 +344,10 @@ async fn handle_ws_connection(
             } else {
                 let _ = socket.close().await;
             }
+            return;
+        }
+        _ = tokio::time::sleep(HANDSHAKE_READ_TIMEOUT) => {
+            close_ws_with_protocol_reason(&mut socket, "handshake timeout").await;
             return;
         }
     };


### PR DESCRIPTION
## Summary
Closes the reconnect-storm amplification path on the Jazz server's WebSocket route described in ticket jaz0-a803. Two mitigations:

- **Per-`client_id` connection cap (4) with evict-oldest** in `ConnectionEventHub::register_connection`. A single `client_id` cannot pin unbounded server-side fan-out memory by opening many concurrent sockets, and a reconnecting client always wins against its own stale sockets. Evicted clients receive a `ServerEvent::Error { code: RateLimited }` followed by a close with code 1008 (Policy) so the eviction is observable application-side, not just at the TCP layer.
- **10s handshake-read timeout** on the initial `socket.recv()` in `handle_ws_connection`. A WS upgrade that never sends an `AuthHandshake` frame is closed with a policy close instead of pinning a Tokio task, an fd, and a recv buffer indefinitely.

The wire protocol's `ErrorCode::RateLimited` was previously defined but never emitted — it's now sent on the eviction path with the post-handshake binary encoding (the existing `send_ws_error_with_code` was JSON-only and only correct pre-handshake, so a separate `send_ws_error_binary` helper was added).

Out of scope for this PR (per ticket scoping discussion): bounded outbound channels, shorter heartbeats, global connection caps, per-IP rate limits, TCP keepalives. Each can be filed as a follow-up if telemetry justifies.

## Test plan
- [x] `cargo test -p jazz-tools --lib --features test reconnect_storm_tests` — 7 tests pass in ~12s
  - 2 exploit-primitive demonstrations at 100-socket scale (concurrent-storm + idle-upgrade slowloris)
  - 5 fix-shape contracts (evict-oldest; rate-limited error frame; cross-client_id isolation; steady-state eviction; handshake-timeout × shutdown race)
- [x] Full `cargo test -p jazz-tools --tests --features test` suite — 1461 lib + ~200 integration tests, no regressions
- [x] Tests observe the server only through the public WS protocol plus the live `ServerState::connections` map, so they remain valid under any implementation that satisfies the behavioural contract
- [x] Changeset added for jazz-tools patch bump