### PR TITLE
feat: add debug symbols for wasm profiling

### DIFF
--- a/crates/mini-jazz-sqlite-wasm/Cargo.toml
+++ b/crates/mini-jazz-sqlite-wasm/Cargo.toml
@@ -18,3 +18,11 @@ wasm-bindgen-futures = "0.4"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 sqlite-wasm-rs = "0.5"
 sqlite-wasm-vfs = "0.2"
+
+# `wasm-opt` here REPLACES wasm-pack's defaults, so include `-O` explicitly.
+# `-g` preserves the wasm `name` section so browser profilers show Rust symbols.
+[package.metadata.wasm-pack.profile.profiling]
+wasm-opt = ["-O", "-g"]
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-O", "-g"]

--- a/examples/mini-sqlite-todo/scripts/build-wasm.mjs
+++ b/examples/mini-sqlite-todo/scripts/build-wasm.mjs
@@ -21,11 +21,15 @@ if (!env.CC_wasm32_unknown_unknown) {
   }
 }
 
-const result = spawnSync("wasm-pack", ["build", crateDir, "--target", "web", "--out-dir", outDir], {
-  cwd: repoRoot,
-  env,
-  stdio: "inherit",
-});
+const result = spawnSync(
+  "wasm-pack",
+  ["build", crateDir, "--target", "web", "--out-dir", outDir, "--profiling"],
+  {
+    cwd: repoRoot,
+    env,
+    stdio: "inherit",
+  },
+);
 
 if (result.error) {
   console.error(result.error.message);


### PR DESCRIPTION
Using same config as in the jazz-tools crate.