### PR TITLE
Fix mini-sqlite query exports over SQLite variable limits

### DIFF
--- a/crates/mini-jazz-sqlite/src/lib.rs
+++ b/crates/mini-jazz-sqlite/src/lib.rs
@@ -20,6 +20,8 @@ mod tx;
 mod types;
 mod users;
 
+pub(crate) const SQL_VARIABLE_CHUNK_SIZE: usize = 100;
+
 pub use error::{Error, Result};
 pub use query_api::{BuiltQuery, QueryCondition, QueryConditionOp, QueryDirection, QueryOrderBy};
 pub use runtime::Runtime;

--- a/crates/mini-jazz-sqlite/src/read_visibility.rs
+++ b/crates/mini-jazz-sqlite/src/read_visibility.rs
@@ -55,6 +55,21 @@ impl ReadVisibility<'_> {
         if matches!(row_nums, Some([])) {
             return Ok(Vec::new());
         }
+        if let Some(row_nums) = row_nums {
+            if row_nums.len() > crate::SQL_VARIABLE_CHUNK_SIZE {
+                let mut visible_row_nums = Vec::new();
+                for chunk in row_nums.chunks(crate::SQL_VARIABLE_CHUNK_SIZE) {
+                    visible_row_nums.extend(self.base_snapshot_row_nums_visible_in_branch(
+                        table_name,
+                        base_epoch,
+                        Some(chunk),
+                    )?);
+                }
+                visible_row_nums.sort();
+                visible_row_nums.dedup();
+                return Ok(visible_row_nums);
+            }
+        }
         let table = self.schema.table_def(table_name)?;
         let snapshot_policy_sql = self.snapshot_policy_sql(table, "h", base_epoch)?;
         let effective_branch_policy_sql =

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -5087,6 +5087,9 @@ fn export_txs_by_ids(conn: &Connection, tx_ids: BTreeSet<&str>) -> Result<Vec<Tx
         return Ok(Vec::new());
     }
     let tx_ids = tx_ids.into_iter().collect::<Vec<_>>();
+    if tx_ids.len() > crate::SQL_VARIABLE_CHUNK_SIZE {
+        return export_txs_by_ids_with_temp_scope(conn, &tx_ids);
+    }
     let mut receipt_stmt = conn.prepare(&format!(
         "SELECT tx.tx_id, receipt.tier
          FROM jazz_tx tx
@@ -5120,6 +5123,71 @@ fn export_txs_by_ids(conn: &Connection, tx_ids: BTreeSet<&str>) -> Result<Vec<Tx
             .join(", "),
     ))?;
     let records = stmt.query_map(params_from_iter(tx_ids.iter()), |row| {
+        let tx_id = row.get::<_, String>(0)?;
+        let receipt_tiers = receipt_tiers_by_tx.get(&tx_id).cloned().unwrap_or_default();
+        Ok(TxRecord {
+            tx_id,
+            node_id: row.get(1)?,
+            local_epoch: row.get(2)?,
+            global_epoch: row.get(3)?,
+            conflict_mode: row.get(4)?,
+            outcome: row.get(5)?,
+            auth_user: parse_tx_auth_user_for_sqlite(&row.get::<_, String>(9)?, 9)?,
+            rejection_code: row.get(6)?,
+            rejection_detail: row
+                .get::<_, Option<String>>(7)?
+                .map(|detail_json| parse_rejection_detail_for_sqlite(&detail_json, 7))
+                .transpose()?
+                .flatten(),
+            receipt_tiers,
+            created_at: row.get(8)?,
+        })
+    })?;
+    records
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(Into::into)
+}
+
+fn export_txs_by_ids_with_temp_scope(conn: &Connection, tx_ids: &[&str]) -> Result<Vec<TxRecord>> {
+    conn.execute_batch(
+        "CREATE TEMP TABLE IF NOT EXISTS jazz_export_tx_record_scope (
+           tx_id TEXT PRIMARY KEY
+         ) WITHOUT ROWID;
+         DELETE FROM jazz_export_tx_record_scope;",
+    )?;
+    {
+        let mut stmt =
+            conn.prepare("INSERT OR IGNORE INTO jazz_export_tx_record_scope (tx_id) VALUES (?)")?;
+        for tx_id in tx_ids {
+            stmt.execute(params![tx_id])?;
+        }
+    }
+
+    let mut receipt_stmt = conn.prepare(
+        "SELECT tx.tx_id, receipt.tier
+         FROM jazz_export_tx_record_scope tx_scope
+         JOIN jazz_tx tx ON tx.tx_id = tx_scope.tx_id
+         JOIN jazz_tx_receipt receipt ON receipt.tx_num = tx.tx_num
+         ORDER BY tx.tx_num, receipt.tier",
+    )?;
+    let receipt_rows = receipt_stmt.query_map([], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+    })?;
+    let mut receipt_tiers_by_tx = BTreeMap::<String, Vec<i64>>::new();
+    for receipt_row in receipt_rows {
+        let (tx_id, tier) = receipt_row?;
+        receipt_tiers_by_tx.entry(tx_id).or_default().push(tier);
+    }
+
+    let mut stmt = conn.prepare(
+        "SELECT tx.tx_id, node.node_id, tx.local_epoch, tx.global_epoch, tx.conflict_mode, tx.outcome, rejection.code, rejection.detail_json, tx.created_at, tx.metadata_json
+         FROM jazz_export_tx_record_scope tx_scope
+         JOIN jazz_tx tx ON tx.tx_id = tx_scope.tx_id
+         JOIN jazz_node node ON node.node_num = tx.node_num
+         LEFT JOIN jazz_tx_rejection rejection ON rejection.tx_num = tx.tx_num
+         ORDER BY tx.tx_num",
+    )?;
+    let records = stmt.query_map([], |row| {
         let tx_id = row.get::<_, String>(0)?;
         let receipt_tiers = receipt_tiers_by_tx.get(&tx_id).cloned().unwrap_or_default();
         Ok(TxRecord {
@@ -5218,6 +5286,9 @@ fn export_reads_for_history(
     tx_ids.dedup();
     if tx_ids.is_empty() {
         return Ok(Vec::new());
+    }
+    if tx_ids.len() > crate::SQL_VARIABLE_CHUNK_SIZE {
+        return export_reads_for_history_with_temp_scope(conn, history);
     }
     let candidate_read_count = count_read_rows_for_tx_ids(conn, &tx_ids)?;
     if candidate_read_count <= (history.len() * 4).max(256) {
@@ -5697,28 +5768,31 @@ fn scoped_policy_parent_row_nums(
     if child_row_nums.is_empty() {
         return Ok(Vec::new());
     }
-    let child_placeholders = sql_placeholders(child_row_nums.len());
-    let mut stmt = conn.prepare(&format!(
-        "SELECT current.{ref_column}
-         FROM {} current
-         JOIN jazz_tx current_tx ON current_tx.tx_num = current.visible_tx_num
-         WHERE current.row_num IN ({child_placeholders})
-           AND current.is_deleted = 0
-           AND {}
-           AND current_tx.outcome != ?",
-        crate::schema::current_table(table_name),
-        branch_filter_sql("current", branch_nums),
-    ))?;
-    let mut params = child_row_nums
-        .iter()
-        .copied()
-        .map(rusqlite::types::Value::Integer)
-        .collect::<Vec<_>>();
-    params.push(rusqlite::types::Value::Integer(tx::OUTCOME_REJECTED));
     let mut parent_row_nums = BTreeSet::new();
-    let rows = stmt.query_map(params_from_iter(params.iter()), |row| row.get::<_, i64>(0))?;
-    for row in rows {
-        parent_row_nums.insert(row?);
+    let child_row_nums = sorted_unique_row_nums(child_row_nums);
+    for child_chunk in child_row_nums.chunks(crate::SQL_VARIABLE_CHUNK_SIZE) {
+        let child_placeholders = sql_placeholders(child_chunk.len());
+        let mut stmt = conn.prepare(&format!(
+            "SELECT current.{ref_column}
+             FROM {} current
+             JOIN jazz_tx current_tx ON current_tx.tx_num = current.visible_tx_num
+             WHERE current.row_num IN ({child_placeholders})
+               AND current.is_deleted = 0
+               AND {}
+               AND current_tx.outcome != ?",
+            crate::schema::current_table(table_name),
+            branch_filter_sql("current", branch_nums),
+        ))?;
+        let mut params = child_chunk
+            .iter()
+            .copied()
+            .map(rusqlite::types::Value::Integer)
+            .collect::<Vec<_>>();
+        params.push(rusqlite::types::Value::Integer(tx::OUTCOME_REJECTED));
+        let rows = stmt.query_map(params_from_iter(params.iter()), |row| row.get::<_, i64>(0))?;
+        for row in rows {
+            parent_row_nums.insert(row?);
+        }
     }
     Ok(parent_row_nums.into_iter().collect())
 }
@@ -5769,6 +5843,7 @@ fn export_deleted_recursive_descendant_history(
     if parent_row_nums.is_empty() {
         return Ok(Vec::new());
     }
+    let parent_row_nums = sorted_unique_row_nums(parent_row_nums);
     let table = schema.table_def(table_name)?;
     let field = table
         .fields
@@ -5776,58 +5851,60 @@ fn export_deleted_recursive_descendant_history(
         .find(|field| field.name == parent_field)
         .ok_or_else(|| crate::Error::new(format!("unknown ref field {parent_field}")))?;
     let parent_column = crate::schema::quote_ident(&crate::schema::storage_column(field));
-    let sql = format!(
-        "WITH RECURSIVE deleted_tree(row_num) AS (
-           SELECT h.row_num
-           FROM {history_table} h
-           JOIN jazz_tx tx ON tx.tx_num = h.tx_num
-           WHERE h.op = 3
-             AND {branch_filter}
-             AND h.{parent_column} IN ({parent_placeholders})
-             AND tx.outcome != {rejected}
-             AND NOT EXISTS (
-               SELECT 1
-               FROM {history_table} newer
-               JOIN jazz_tx newer_tx ON newer_tx.tx_num = newer.tx_num
-               WHERE newer.row_num = h.row_num
-                 AND newer.j_branch_num = h.j_branch_num
-                 AND newer_tx.outcome != {rejected}
-                 AND newer.tx_num > h.tx_num
+    let mut row_nums = BTreeSet::new();
+    for parent_chunk in parent_row_nums.chunks(crate::SQL_VARIABLE_CHUNK_SIZE) {
+        let sql = format!(
+            "WITH RECURSIVE deleted_tree(row_num) AS (
+               SELECT h.row_num
+               FROM {history_table} h
+               JOIN jazz_tx tx ON tx.tx_num = h.tx_num
+               WHERE h.op = 3
+                 AND {branch_filter}
+                 AND h.{parent_column} IN ({parent_placeholders})
+                 AND tx.outcome != {rejected}
+                 AND NOT EXISTS (
+                   SELECT 1
+                   FROM {history_table} newer
+                   JOIN jazz_tx newer_tx ON newer_tx.tx_num = newer.tx_num
+                   WHERE newer.row_num = h.row_num
+                     AND newer.j_branch_num = h.j_branch_num
+                     AND newer_tx.outcome != {rejected}
+                     AND newer.tx_num > h.tx_num
+                 )
+               UNION
+               SELECT child.row_num
+               FROM {history_table} child
+               JOIN jazz_tx child_tx ON child_tx.tx_num = child.tx_num
+               JOIN deleted_tree parent ON child.{parent_column} = parent.row_num
+               WHERE child.op = 3
+                 AND {child_branch_filter}
+                 AND child_tx.outcome != {rejected}
+                 AND NOT EXISTS (
+                   SELECT 1
+                   FROM {history_table} newer
+                   JOIN jazz_tx newer_tx ON newer_tx.tx_num = newer.tx_num
+                   WHERE newer.row_num = child.row_num
+                     AND newer.j_branch_num = child.j_branch_num
+                     AND newer_tx.outcome != {rejected}
+                     AND newer.tx_num > child.tx_num
+                 )
              )
-           UNION
-           SELECT child.row_num
-           FROM {history_table} child
-           JOIN jazz_tx child_tx ON child_tx.tx_num = child.tx_num
-           JOIN deleted_tree parent ON child.{parent_column} = parent.row_num
-           WHERE child.op = 3
-             AND {child_branch_filter}
-             AND child_tx.outcome != {rejected}
-             AND NOT EXISTS (
-               SELECT 1
-               FROM {history_table} newer
-               JOIN jazz_tx newer_tx ON newer_tx.tx_num = newer.tx_num
-               WHERE newer.row_num = child.row_num
-                 AND newer.j_branch_num = child.j_branch_num
-                 AND newer_tx.outcome != {rejected}
-                 AND newer.tx_num > child.tx_num
-             )
-         )
-         SELECT row_num FROM deleted_tree",
-        history_table = crate::schema::history_table(table_name),
-        branch_filter = branch_filter_sql("h", branch_nums),
-        child_branch_filter = branch_filter_sql("child", branch_nums),
-        rejected = tx::OUTCOME_REJECTED,
-        parent_placeholders = (0..parent_row_nums.len())
-            .map(|_| "?")
-            .collect::<Vec<_>>()
-            .join(", "),
-    );
-    let mut stmt = conn.prepare(&sql)?;
-    let row_nums = stmt
-        .query_map(params_from_iter(parent_row_nums.iter()), |row| {
+             SELECT row_num FROM deleted_tree",
+            history_table = crate::schema::history_table(table_name),
+            branch_filter = branch_filter_sql("h", branch_nums),
+            child_branch_filter = branch_filter_sql("child", branch_nums),
+            rejected = tx::OUTCOME_REJECTED,
+            parent_placeholders = sql_placeholders(parent_chunk.len()),
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(params_from_iter(parent_chunk.iter()), |row| {
             row.get::<_, i64>(0)
-        })?
-        .collect::<std::result::Result<Vec<_>, _>>()?;
+        })?;
+        for row in rows {
+            row_nums.insert(row?);
+        }
+    }
+    let row_nums = row_nums.into_iter().collect::<Vec<_>>();
     export_history_versions_for_rows(conn, schema, table_name, Some(&row_nums), None)
 }
 
@@ -5842,6 +5919,7 @@ fn export_recursive_scope_repair_history(
     if parent_row_nums.is_empty() {
         return Ok(Vec::new());
     }
+    let parent_row_nums = sorted_unique_row_nums(parent_row_nums);
     let table = schema.table_def(table_name)?;
     let field = table
         .fields
@@ -5849,38 +5927,40 @@ fn export_recursive_scope_repair_history(
         .find(|field| field.name == parent_field)
         .ok_or_else(|| crate::Error::new(format!("unknown ref field {parent_field}")))?;
     let parent_column = crate::schema::quote_ident(&crate::schema::storage_column(field));
-    let sql = format!(
-        "WITH RECURSIVE historical_tree(row_num) AS (
-           SELECT h.row_num
-           FROM {history_table} h
-           JOIN jazz_tx tx ON tx.tx_num = h.tx_num
-           WHERE {branch_filter}
-             AND h.{parent_column} IN ({parent_placeholders})
-             AND tx.outcome != {rejected}
-           UNION
-           SELECT child.row_num
-           FROM {history_table} child
-           JOIN jazz_tx child_tx ON child_tx.tx_num = child.tx_num
-           JOIN historical_tree parent ON child.{parent_column} = parent.row_num
-           WHERE {child_branch_filter}
-             AND child_tx.outcome != {rejected}
-         )
-         SELECT DISTINCT row_num FROM historical_tree",
-        history_table = crate::schema::history_table(table_name),
-        branch_filter = branch_filter_sql("h", branch_nums),
-        child_branch_filter = branch_filter_sql("child", branch_nums),
-        rejected = tx::OUTCOME_REJECTED,
-        parent_placeholders = (0..parent_row_nums.len())
-            .map(|_| "?")
-            .collect::<Vec<_>>()
-            .join(", "),
-    );
-    let mut stmt = conn.prepare(&sql)?;
-    let row_nums = stmt
-        .query_map(params_from_iter(parent_row_nums.iter()), |row| {
+    let mut row_nums = BTreeSet::new();
+    for parent_chunk in parent_row_nums.chunks(crate::SQL_VARIABLE_CHUNK_SIZE) {
+        let sql = format!(
+            "WITH RECURSIVE historical_tree(row_num) AS (
+               SELECT h.row_num
+               FROM {history_table} h
+               JOIN jazz_tx tx ON tx.tx_num = h.tx_num
+               WHERE {branch_filter}
+                 AND h.{parent_column} IN ({parent_placeholders})
+                 AND tx.outcome != {rejected}
+               UNION
+               SELECT child.row_num
+               FROM {history_table} child
+               JOIN jazz_tx child_tx ON child_tx.tx_num = child.tx_num
+               JOIN historical_tree parent ON child.{parent_column} = parent.row_num
+               WHERE {child_branch_filter}
+                 AND child_tx.outcome != {rejected}
+             )
+             SELECT DISTINCT row_num FROM historical_tree",
+            history_table = crate::schema::history_table(table_name),
+            branch_filter = branch_filter_sql("h", branch_nums),
+            child_branch_filter = branch_filter_sql("child", branch_nums),
+            rejected = tx::OUTCOME_REJECTED,
+            parent_placeholders = sql_placeholders(parent_chunk.len()),
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(params_from_iter(parent_chunk.iter()), |row| {
             row.get::<_, i64>(0)
-        })?
-        .collect::<std::result::Result<Vec<_>, _>>()?;
+        })?;
+        for row in rows {
+            row_nums.insert(row?);
+        }
+    }
+    let row_nums = row_nums.into_iter().collect::<Vec<_>>();
     export_history_versions_for_rows(conn, schema, table_name, Some(&row_nums), None)
 }
 
@@ -6374,35 +6454,33 @@ fn delete_current_rows_outside_keep_set(
     // For offset queries, "keep" is the exported support window
     // [0, offset + limit). Those prefix rows must stay local so SQLite can
     // still evaluate the original OFFSET query correctly after the refresh.
-    let mut sql = format!(
-        "DELETE FROM {}
-         WHERE j_branch_num = ?
-           AND is_deleted = 0
-           AND row_num IN ({})",
-        crate::schema::current_table(table_name),
-        sql_placeholders(scope_row_nums.len()),
-    );
-    let mut params = Vec::with_capacity(1 + scope_row_nums.len() + keep_row_nums.len());
-    params.push(rusqlite::types::Value::Integer(branch_num));
-    params.extend(
-        scope_row_nums
-            .iter()
-            .copied()
-            .map(rusqlite::types::Value::Integer),
-    );
-    if !keep_row_nums.is_empty() {
-        sql.push_str(&format!(
-            " AND row_num NOT IN ({})",
-            sql_placeholders(keep_row_nums.len())
-        ));
+    let keep_row_nums = keep_row_nums.iter().copied().collect::<BTreeSet<_>>();
+    let delete_row_nums = scope_row_nums
+        .iter()
+        .copied()
+        .filter(|row_num| !keep_row_nums.contains(row_num))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    for delete_chunk in delete_row_nums.chunks(crate::SQL_VARIABLE_CHUNK_SIZE) {
+        let sql = format!(
+            "DELETE FROM {}
+             WHERE j_branch_num = ?
+               AND is_deleted = 0
+               AND row_num IN ({})",
+            crate::schema::current_table(table_name),
+            sql_placeholders(delete_chunk.len()),
+        );
+        let mut params = Vec::with_capacity(1 + delete_chunk.len());
+        params.push(rusqlite::types::Value::Integer(branch_num));
         params.extend(
-            keep_row_nums
+            delete_chunk
                 .iter()
                 .copied()
                 .map(rusqlite::types::Value::Integer),
         );
+        db.execute(&sql, params_from_iter(params.iter()))?;
     }
-    db.execute(&sql, params_from_iter(params.iter()))?;
     Ok(())
 }
 
@@ -6456,6 +6534,24 @@ fn export_visible_table_history(
     branch_nums: &[i64],
     row_nums: Option<&[i64]>,
 ) -> Result<Vec<HistoryRecord>> {
+    if let Some(row_nums) = row_nums {
+        if row_nums.is_empty() {
+            return Ok(Vec::new());
+        }
+        if row_nums.len() > crate::SQL_VARIABLE_CHUNK_SIZE {
+            let row_nums = sorted_unique_row_nums(row_nums);
+            let mut records = Vec::new();
+            for row_chunk in row_nums.chunks(crate::SQL_VARIABLE_CHUNK_SIZE) {
+                records.extend(export_visible_table_history(
+                    visibility,
+                    table_name,
+                    branch_nums,
+                    Some(row_chunk),
+                )?);
+            }
+            return Ok(records);
+        }
+    }
     let conn = visibility.conn;
     let schema = visibility.schema;
     let table = schema.table_def(table_name)?;
@@ -6589,6 +6685,26 @@ fn export_history_versions_for_rows_with_branch_filter(
     max_global_epoch: Option<i64>,
     branch_nums: Option<&[i64]>,
 ) -> Result<Vec<HistoryRecord>> {
+    if let Some(row_nums) = row_nums {
+        if row_nums.is_empty() {
+            return Ok(Vec::new());
+        }
+        if row_nums.len() > crate::SQL_VARIABLE_CHUNK_SIZE {
+            let row_nums = sorted_unique_row_nums(row_nums);
+            let mut records = Vec::new();
+            for row_chunk in row_nums.chunks(crate::SQL_VARIABLE_CHUNK_SIZE) {
+                records.extend(export_history_versions_for_rows_with_branch_filter(
+                    conn,
+                    schema,
+                    table_name,
+                    Some(row_chunk),
+                    max_global_epoch,
+                    branch_nums,
+                )?);
+            }
+            return Ok(records);
+        }
+    }
     let table = schema.table_def(table_name)?;
     let field_columns = table
         .fields
@@ -6723,6 +6839,13 @@ fn branch_filter_sql(alias: &str, branch_nums: &[i64]) -> String {
             .collect::<Vec<_>>()
             .join(", ")
     )
+}
+
+fn sorted_unique_row_nums(row_nums: &[i64]) -> Vec<i64> {
+    let mut row_nums = row_nums.to_vec();
+    row_nums.sort();
+    row_nums.dedup();
+    row_nums
 }
 
 fn sql_placeholders(count: usize) -> String {

--- a/crates/mini-jazz-sqlite/tests/whole_system/query_matrix.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/query_matrix.rs
@@ -86,6 +86,43 @@ fn built_query_matrix_matches_expected_rows_for_supported_operations() {
 }
 
 #[test]
+fn large_built_query_export_does_not_exceed_sqlite_variable_limit() {
+    const ROW_COUNT: usize = 40_000;
+
+    let schema = support::tasks_schema();
+    let mut upstream =
+        Runtime::open_trusted_with_schema(Storage::Memory, "large-query-upstream", schema.clone())
+            .unwrap();
+    let mut peer =
+        Runtime::open_with_schema(Storage::Memory, "large-query-peer", "alice", schema).unwrap();
+
+    for index in 0..ROW_COUNT {
+        upstream
+            .insert_row(
+                "tasks",
+                &format!("task-{index:05}"),
+                BTreeMap::from([
+                    ("title".to_owned(), json!(format!("Task {index:05}"))),
+                    ("done".to_owned(), json!(false)),
+                ]),
+            )
+            .unwrap();
+    }
+
+    let query = BuiltQuery::from_json_value(json!({
+        "table": "tasks",
+        "conditions": [{"column": "done", "op": "eq", "value": false}],
+        "orderBy": [["$createdAt", "desc"]]
+    }))
+    .unwrap();
+
+    peer.apply_bundle(&upstream.export_query(query.clone()).unwrap())
+        .unwrap();
+
+    assert_eq!(peer.query(query).unwrap().len(), ROW_COUNT);
+}
+
+#[test]
 fn policy_filtered_built_query_subscription_tracks_rows_entering_and_leaving() {
     let mut runtime = Runtime::open_trusted_with_schema(
         Storage::Memory,


### PR DESCRIPTION
## Summary

Fix large mini-sqlite query-scope exports that can exceed SQLite's host-parameter limit.

This introduces a shared SQL variable chunk size and applies it to the large `IN (...)` query paths used by query export, policy dependency repair, recursive repair, branch snapshot visibility, and current-row cleanup. Very large transaction id sets now use a temporary scope table instead of emitting one giant `IN` list.

## Why

Large filtered query exports can touch tens of thousands of rows. Several repair/export paths built SQL with one bind parameter per candidate row or transaction, which can fail with `too many SQL variables` before the bundle is exported.

## Validation

- `cargo test -p mini-jazz-sqlite --test whole_system`
- pre-commit hook: clippy and rustfmt

## Notes

This is stacked on `guido/generic-browser-runtime-yew` because the affected query/export code exists there.