### PR TITLE
Use SQL scopes for mini-sqlite built query exports

### DIFF
--- a/crates/mini-jazz-sqlite/Cargo.toml
+++ b/crates/mini-jazz-sqlite/Cargo.toml
@@ -11,7 +11,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-rusqlite = { version = "0.40", features = ["bundled"] }
+rusqlite = { version = "0.40", features = ["bundled", "limits"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3"

--- a/crates/mini-jazz-sqlite/src/lib.rs
+++ b/crates/mini-jazz-sqlite/src/lib.rs
@@ -20,8 +20,6 @@ mod tx;
 mod types;
 mod users;
 
-pub(crate) const SQL_VARIABLE_CHUNK_SIZE: usize = 100;
-
 pub use error::{Error, Result};
 pub use query_api::{BuiltQuery, QueryCondition, QueryConditionOp, QueryDirection, QueryOrderBy};
 pub use runtime::Runtime;

--- a/crates/mini-jazz-sqlite/src/query.rs
+++ b/crates/mini-jazz-sqlite/src/query.rs
@@ -25,6 +25,20 @@ struct LoweredCondition {
     params: Vec<SqlValue>,
 }
 
+pub(crate) struct LoweredQueryRowScope {
+    pub(crate) ctes: Vec<String>,
+    pub(crate) select_sql: String,
+    pub(crate) params: Vec<SqlValue>,
+}
+
+impl LoweredQueryRowScope {
+    pub(crate) fn with_scope_cte(&self, scope_name: &str) -> String {
+        let mut ctes = self.ctes.clone();
+        ctes.push(format!("{scope_name}(row_num) AS ({})", self.select_sql));
+        format!("WITH {}", ctes.join(",\n"))
+    }
+}
+
 enum QueryColumn<'a> {
     Id,
     CreatedBy,
@@ -127,6 +141,73 @@ impl QueryContext<'_> {
         row_nums.sort();
         row_nums.dedup();
         Ok(row_nums)
+    }
+
+    pub(crate) fn lower_built_query_row_scope(
+        &self,
+        query: &BuiltQuery,
+    ) -> Result<Option<LoweredQueryRowScope>> {
+        let table = self.schema.table_def(&query.table)?;
+        let scope_nums = branch::scope_nums(self.conn, self.branch_num)?;
+        let base_epoch = branch::base_global_epoch(self.conn, self.branch_num)?;
+        if self.defer_query_window_until_effective_branch_policy(table, query, base_epoch) {
+            return Ok(None);
+        }
+
+        if self.branch_num == 1 && scope_nums == [self.branch_num] && base_epoch.is_none() {
+            let (condition_sql, mut condition_params) =
+                self.lower_query_conditions(table, &query.conditions, "current", "ids")?;
+            let order_sql =
+                self.lower_source_query_order(table, &query.order_by, "current", "ids")?;
+            let mut select_sql = format!(
+                "SELECT current.row_num AS row_num
+                 FROM {} current
+                 JOIN jazz_row_id ids ON ids.row_num = current.row_num
+                 JOIN jazz_tx tx ON tx.tx_num = current.visible_tx_num
+                 WHERE current.j_branch_num = ?
+                   AND current.is_deleted = 0
+                   AND tx.outcome != ?
+                   AND {condition_sql}
+                   AND {policy_sql}
+                 ORDER BY {order_sql}",
+                crate::schema::current_table(&query.table),
+                policy_sql = self.read_policy_sql(table)?,
+            );
+            let mut params = vec![
+                SqlValue::Integer(self.branch_num),
+                SqlValue::Integer(tx::OUTCOME_REJECTED),
+            ];
+            params.append(&mut condition_params);
+            append_query_window_sql(&mut select_sql, &mut params, query.limit, query.offset)?;
+            return Ok(Some(LoweredQueryRowScope {
+                ctes: Vec::new(),
+                select_sql,
+                params,
+            }));
+        }
+
+        let (candidates_sql, mut params) = self.lower_query_candidates(query, table)?;
+        let order_sql = self.lower_query_order(table, &query.order_by)?;
+        let mut select_sql = format!(
+            "SELECT j_query_row_num AS row_num
+             FROM j_query_ranked
+             WHERE j_query_branch_depth = j_query_min_branch_depth
+             ORDER BY {order_sql}",
+        );
+        append_query_window_sql(&mut select_sql, &mut params, query.limit, query.offset)?;
+        Ok(Some(LoweredQueryRowScope {
+            ctes: vec![
+                format!("j_query_candidates AS ({candidates_sql})"),
+                "j_query_ranked AS (
+                   SELECT *,
+                          MIN(j_query_branch_depth) OVER (PARTITION BY j_query_row_id) AS j_query_min_branch_depth
+                   FROM j_query_candidates
+                 )"
+                .to_owned(),
+            ],
+            select_sql,
+            params,
+        }))
     }
 
     fn repair_current_row_nums_for_built_query(

--- a/crates/mini-jazz-sqlite/src/read_visibility.rs
+++ b/crates/mini-jazz-sqlite/src/read_visibility.rs
@@ -55,21 +55,6 @@ impl ReadVisibility<'_> {
         if matches!(row_nums, Some([])) {
             return Ok(Vec::new());
         }
-        if let Some(row_nums) = row_nums {
-            if row_nums.len() > crate::SQL_VARIABLE_CHUNK_SIZE {
-                let mut visible_row_nums = Vec::new();
-                for chunk in row_nums.chunks(crate::SQL_VARIABLE_CHUNK_SIZE) {
-                    visible_row_nums.extend(self.base_snapshot_row_nums_visible_in_branch(
-                        table_name,
-                        base_epoch,
-                        Some(chunk),
-                    )?);
-                }
-                visible_row_nums.sort();
-                visible_row_nums.dedup();
-                return Ok(visible_row_nums);
-            }
-        }
         let table = self.schema.table_def(table_name)?;
         let snapshot_policy_sql = self.snapshot_policy_sql(table, "h", base_epoch)?;
         let effective_branch_policy_sql =
@@ -109,12 +94,7 @@ impl ReadVisibility<'_> {
             history_table = crate::schema::history_table(table_name),
             current_table = crate::schema::current_table(table_name),
         );
-        let mut params = row_nums
-            .unwrap_or(&[])
-            .iter()
-            .copied()
-            .map(SqlValue::Integer)
-            .collect::<Vec<_>>();
+        let mut params = Vec::new();
         params.extend([
             SqlValue::Integer(tx::OUTCOME_REJECTED),
             SqlValue::Integer(base_epoch),
@@ -264,8 +244,9 @@ fn row_filter_sql(alias: &str, row_nums: Option<&[i64]>) -> String {
         Some([]) => "0 = 1".to_owned(),
         Some(row_nums) => format!(
             "{alias}.row_num IN ({})",
-            (0..row_nums.len())
-                .map(|_| "?")
+            row_nums
+                .iter()
+                .map(i64::to_string)
                 .collect::<Vec<_>>()
                 .join(", ")
         ),

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -2861,6 +2861,22 @@ impl Runtime {
             op: "query".to_owned(),
             value: query.to_json_value(),
         };
+        let support_query = built_query_repair_keep_query(&query)?;
+        if let Some(row_scope) = self
+            .query_context()
+            .lower_built_query_row_scope(&support_query)?
+        {
+            return self.export_built_query_read_scope_sql(
+                query_read,
+                &query,
+                &row_scope,
+                rows,
+                QueryScopeOptions {
+                    ref_include_fields,
+                    extra_row_ids: &[],
+                },
+            );
+        }
         self.export_query_read_scope(
             query_read,
             rows,
@@ -3011,6 +3027,153 @@ impl Runtime {
             txs,
             reads,
             query_reads,
+            history,
+        ))
+    }
+
+    fn export_built_query_read_scope_sql(
+        &self,
+        query_read: QueryReadRecord,
+        built_query: &BuiltQuery,
+        visible_scope: &query::LoweredQueryRowScope,
+        rows: Vec<RowView>,
+        options: QueryScopeOptions<'_>,
+    ) -> Result<Bundle> {
+        let table_name = &query_read.table;
+        let table = self.schema.table_def(table_name)?;
+        let user = self.policy_user();
+        let bypass_policy = self.bypasses_policy();
+        let visible_row_nums = rows
+            .iter()
+            .map(|row| row_num(&self.conn, &row.id))
+            .collect::<Result<Vec<_>>>()?;
+        let mut repair_row_nums = Vec::new();
+        for row_id in options.extra_row_ids {
+            repair_row_nums.push(row_num(&self.conn, row_id)?);
+        }
+        repair_row_nums.extend(query_scope_repair_row_nums_for_read(
+            &self.conn,
+            &self.schema,
+            table,
+            &query_read,
+            self.branch_num,
+            user,
+            bypass_policy,
+        )?);
+        let visible_row_num_set = visible_row_nums.iter().copied().collect::<BTreeSet<_>>();
+        repair_row_nums.retain(|row_num| !visible_row_num_set.contains(row_num));
+        repair_row_nums.sort();
+        repair_row_nums.dedup();
+
+        let branch_nums = branch::scope_nums(&self.conn, self.branch_num)?;
+        let visibility = self.read_visibility();
+        let mut history = export_history_versions_for_query_scope_in_branches(
+            &self.conn,
+            &self.schema,
+            table_name,
+            visible_scope,
+            None,
+            &branch_nums,
+        )?;
+        if !repair_row_nums.is_empty() {
+            history.extend(export_visible_table_history(
+                &visibility,
+                table_name,
+                &branch_nums,
+                Some(&repair_row_nums),
+            )?);
+            history.extend(export_history_versions_for_rows_in_branches(
+                &self.conn,
+                &self.schema,
+                table_name,
+                Some(&repair_row_nums),
+                None,
+                &branch_nums,
+            )?);
+        }
+        history.extend(export_policy_dependency_history_for_query_scope(
+            &visibility,
+            PolicyDependencyQueryScopeExport {
+                table_name,
+                policy: &table.read_policy,
+                branch_nums: &branch_nums,
+                child_scope: visible_scope,
+            },
+        )?);
+        if !repair_row_nums.is_empty() {
+            history.extend(export_policy_dependency_history(
+                &visibility,
+                PolicyDependencyExport {
+                    table_name,
+                    policy: &table.read_policy,
+                    branch_nums: &branch_nums,
+                    child_row_nums: Some(&repair_row_nums),
+                },
+            )?);
+        }
+        for ref_field_name in options.ref_include_fields {
+            history.extend(self.export_ref_include_history(
+                table,
+                &rows,
+                ref_field_name,
+                &branch_nums,
+            )?);
+        }
+        if self.branch_num != 1 {
+            if let Some(base_epoch) = branch::base_global_epoch(&self.conn, self.branch_num)? {
+                history.extend(export_history_versions_for_query_scope_in_branches(
+                    &self.conn,
+                    &self.schema,
+                    table_name,
+                    visible_scope,
+                    Some(base_epoch),
+                    &[1],
+                )?);
+                history.extend(export_snapshot_policy_dependency_history_for_query_scope(
+                    &visibility,
+                    table_name,
+                    base_epoch,
+                    visible_scope,
+                )?);
+                if !repair_row_nums.is_empty() {
+                    history.extend(export_history_versions_for_rows_in_branches(
+                        &self.conn,
+                        &self.schema,
+                        table_name,
+                        Some(&repair_row_nums),
+                        Some(base_epoch),
+                        &[1],
+                    )?);
+                    history.extend(export_snapshot_policy_dependency_history(
+                        &visibility,
+                        table_name,
+                        base_epoch,
+                        Some(&repair_row_nums),
+                    )?);
+                }
+            }
+        }
+        dedupe_history_records(&mut history);
+        let reads = export_reads_for_history(&self.conn, &history)?;
+        let rejected_tx_ids = query_scope_rejected_tx_ids_for_built_query(
+            &self.conn,
+            &self.schema,
+            table,
+            built_query,
+            self.branch_num,
+            user,
+            bypass_policy,
+        )?;
+        let txs =
+            export_txs_for_query_scope(&self.conn, table_name, &history, &reads, &rejected_tx_ids)?;
+        let mut branches = export_branch_records_for_history(&self.conn, &history)?;
+        include_branch_record(&self.conn, &mut branches, self.branch_num)?;
+        Ok(make_bundle(
+            &self.schema,
+            branches,
+            txs,
+            reads,
+            vec![query_read],
             history,
         ))
     }
@@ -5677,11 +5840,122 @@ fn export_snapshot_policy_dependency_history(
     Ok(records)
 }
 
+fn export_snapshot_policy_dependency_history_for_query_scope(
+    visibility: &ReadVisibility<'_>,
+    table_name: &str,
+    base_epoch: i64,
+    child_scope: &query::LoweredQueryRowScope,
+) -> Result<Vec<HistoryRecord>> {
+    export_snapshot_policy_dependency_history_for_query_scope_at_depth(
+        visibility,
+        table_name,
+        base_epoch,
+        child_scope,
+        0,
+    )
+}
+
+fn export_snapshot_policy_dependency_history_for_query_scope_at_depth(
+    visibility: &ReadVisibility<'_>,
+    table_name: &str,
+    base_epoch: i64,
+    child_scope: &query::LoweredQueryRowScope,
+    depth: usize,
+) -> Result<Vec<HistoryRecord>> {
+    let conn = visibility.conn;
+    let schema = visibility.schema;
+    let table = schema.table_def(table_name)?;
+    let PolicyDef::RefReadable { field } = &table.read_policy else {
+        return Ok(Vec::new());
+    };
+    let field = table
+        .fields
+        .iter()
+        .find(|candidate| candidate.name == *field)
+        .ok_or_else(|| crate::Error::new(format!("unknown policy ref {field}")))?;
+    let FieldKind::Ref {
+        table: parent_table,
+    } = &field.kind
+    else {
+        return Err(crate::Error::new(format!(
+            "policy field {} is not a ref",
+            field.name
+        )));
+    };
+    let policy_sql = visibility.snapshot_policy_sql(table, "h", base_epoch)?;
+    let ref_column = crate::schema::quote_ident(&crate::schema::storage_column(field));
+    let child_scope_name = format!("snapshot_policy_child_scope_{depth}");
+    let parent_scope_name = format!("snapshot_policy_parent_scope_{depth}");
+    let mut ctes = child_scope.ctes.clone();
+    ctes.push(format!(
+        "{child_scope_name}(row_num) AS ({})",
+        child_scope.select_sql
+    ));
+    ctes.push(format!(
+        "{parent_scope_name}(row_num) AS (
+           SELECT DISTINCT h.{ref_column}
+           FROM {} h
+           JOIN {child_scope_name} child_scope ON child_scope.row_num = h.row_num
+           JOIN jazz_tx tx ON tx.tx_num = h.tx_num
+           WHERE h.j_branch_num = 1
+             AND h.op != 3
+             AND tx.outcome != {}
+             AND tx.global_epoch IS NOT NULL
+             AND tx.global_epoch <= {base_epoch}
+             AND {policy_sql}
+             AND NOT EXISTS (
+               SELECT 1
+               FROM {history_table} newer
+               JOIN jazz_tx newer_tx ON newer_tx.tx_num = newer.tx_num
+               WHERE newer.row_num = h.row_num
+                 AND newer.j_branch_num = 1
+                 AND newer_tx.outcome != {}
+                 AND newer_tx.global_epoch IS NOT NULL
+                 AND newer_tx.global_epoch <= {base_epoch}
+                 AND (newer_tx.global_epoch > tx.global_epoch OR (newer_tx.global_epoch = tx.global_epoch AND newer_tx.tx_num > tx.tx_num))
+             )
+         )",
+        crate::schema::history_table(table_name),
+        tx::OUTCOME_REJECTED,
+        tx::OUTCOME_REJECTED,
+        history_table = crate::schema::history_table(table_name),
+    ));
+    let parent_scope = query::LoweredQueryRowScope {
+        ctes,
+        select_sql: format!("SELECT row_num FROM {parent_scope_name} WHERE row_num IS NOT NULL"),
+        params: child_scope.params.clone(),
+    };
+    let mut records = export_history_versions_for_query_scope(
+        conn,
+        schema,
+        parent_table,
+        &parent_scope,
+        Some(base_epoch),
+    )?;
+    records.extend(
+        export_snapshot_policy_dependency_history_for_query_scope_at_depth(
+            visibility,
+            parent_table,
+            base_epoch,
+            &parent_scope,
+            depth + 1,
+        )?,
+    );
+    Ok(records)
+}
+
 struct PolicyDependencyExport<'a> {
     table_name: &'a str,
     policy: &'a PolicyDef,
     branch_nums: &'a [i64],
     child_row_nums: Option<&'a [i64]>,
+}
+
+struct PolicyDependencyQueryScopeExport<'a> {
+    table_name: &'a str,
+    policy: &'a PolicyDef,
+    branch_nums: &'a [i64],
+    child_scope: &'a query::LoweredQueryRowScope,
 }
 
 fn export_policy_dependency_history(
@@ -5754,6 +6028,80 @@ fn export_policy_dependency_history(
             branch_nums: args.branch_nums,
             child_row_nums: Some(&row_nums),
         },
+    )?);
+    Ok(records)
+}
+
+fn export_policy_dependency_history_for_query_scope(
+    visibility: &ReadVisibility<'_>,
+    args: PolicyDependencyQueryScopeExport<'_>,
+) -> Result<Vec<HistoryRecord>> {
+    export_policy_dependency_history_for_query_scope_at_depth(visibility, args, 0)
+}
+
+fn export_policy_dependency_history_for_query_scope_at_depth(
+    visibility: &ReadVisibility<'_>,
+    args: PolicyDependencyQueryScopeExport<'_>,
+    depth: usize,
+) -> Result<Vec<HistoryRecord>> {
+    let conn = visibility.conn;
+    let schema = visibility.schema;
+    let table = schema.table_def(args.table_name)?;
+    let PolicyDef::RefReadable { field } = args.policy else {
+        return Ok(Vec::new());
+    };
+    let field = table
+        .fields
+        .iter()
+        .find(|candidate| candidate.name == *field)
+        .ok_or_else(|| crate::Error::new(format!("unknown policy ref {field}")))?;
+    let FieldKind::Ref {
+        table: parent_table,
+    } = &field.kind
+    else {
+        return Err(crate::Error::new(format!(
+            "policy field {} is not a ref",
+            field.name
+        )));
+    };
+    let ref_column = crate::schema::quote_ident(&crate::schema::storage_column(field));
+    let child_scope_name = format!("policy_child_scope_{depth}");
+    let parent_scope_name = format!("policy_parent_scope_{depth}");
+    let mut ctes = args.child_scope.ctes.clone();
+    ctes.push(format!(
+        "{child_scope_name}(row_num) AS ({})",
+        args.child_scope.select_sql
+    ));
+    ctes.push(format!(
+        "{parent_scope_name}(row_num) AS (
+           SELECT DISTINCT current.{ref_column}
+           FROM {} current
+           JOIN {child_scope_name} child_scope ON child_scope.row_num = current.row_num
+           JOIN jazz_tx current_tx ON current_tx.tx_num = current.visible_tx_num
+           WHERE current.is_deleted = 0
+             AND {}
+             AND current_tx.outcome != {}
+         )",
+        crate::schema::current_table(args.table_name),
+        branch_filter_sql("current", args.branch_nums),
+        tx::OUTCOME_REJECTED,
+    ));
+    let parent_scope = query::LoweredQueryRowScope {
+        ctes,
+        select_sql: format!("SELECT row_num FROM {parent_scope_name} WHERE row_num IS NOT NULL"),
+        params: args.child_scope.params.clone(),
+    };
+    let mut records =
+        export_history_versions_for_query_scope(conn, schema, parent_table, &parent_scope, None)?;
+    records.extend(export_policy_dependency_history_for_query_scope_at_depth(
+        visibility,
+        PolicyDependencyQueryScopeExport {
+            table_name: parent_table,
+            policy: &schema.table_def(parent_table)?.read_policy,
+            branch_nums: args.branch_nums,
+            child_scope: &parent_scope,
+        },
+        depth + 1,
     )?);
     Ok(records)
 }
@@ -6677,6 +7025,124 @@ fn export_history_versions_for_rows_in_branches(
     )
 }
 
+fn export_history_versions_for_query_scope(
+    conn: &Connection,
+    schema: &SchemaDef,
+    table_name: &str,
+    row_scope: &query::LoweredQueryRowScope,
+    max_global_epoch: Option<i64>,
+) -> Result<Vec<HistoryRecord>> {
+    export_history_versions_for_query_scope_with_branch_filter(
+        conn,
+        schema,
+        table_name,
+        row_scope,
+        max_global_epoch,
+        None,
+    )
+}
+
+fn export_history_versions_for_query_scope_in_branches(
+    conn: &Connection,
+    schema: &SchemaDef,
+    table_name: &str,
+    row_scope: &query::LoweredQueryRowScope,
+    max_global_epoch: Option<i64>,
+    branch_nums: &[i64],
+) -> Result<Vec<HistoryRecord>> {
+    export_history_versions_for_query_scope_with_branch_filter(
+        conn,
+        schema,
+        table_name,
+        row_scope,
+        max_global_epoch,
+        Some(branch_nums),
+    )
+}
+
+fn export_history_versions_for_query_scope_with_branch_filter(
+    conn: &Connection,
+    schema: &SchemaDef,
+    table_name: &str,
+    row_scope: &query::LoweredQueryRowScope,
+    max_global_epoch: Option<i64>,
+    branch_nums: Option<&[i64]>,
+) -> Result<Vec<HistoryRecord>> {
+    let table = schema.table_def(table_name)?;
+    let field_columns = table
+        .fields
+        .iter()
+        .map(|field| crate::schema::quote_ident(&crate::schema::storage_column(field)))
+        .collect::<Vec<_>>();
+    let mut select_columns = vec![
+        "ids.row_id".to_owned(),
+        "branch.branch_id".to_owned(),
+        "tx.tx_id".to_owned(),
+        "h.op".to_owned(),
+    ];
+    select_columns.extend(field_columns.iter().map(|column| format!("h.{column}")));
+    select_columns.extend([
+        "h.j_created_at".to_owned(),
+        "h.j_updated_at".to_owned(),
+        format!(
+            "{} AS j_created_by",
+            users::user_id_expr("h", "j_created_by")
+        ),
+        format!(
+            "{} AS j_updated_by",
+            users::user_id_expr("h", "j_updated_by")
+        ),
+    ]);
+    let sql = format!(
+        "{}
+         SELECT {}
+         FROM {} h
+         JOIN query_scope scope ON scope.row_num = h.row_num
+         JOIN jazz_row_id ids ON ids.row_num = h.row_num
+         JOIN jazz_tx tx ON tx.tx_num = h.tx_num
+         JOIN jazz_branch branch ON branch.branch_num = h.j_branch_num
+         WHERE {branch_filter}
+           AND {epoch_filter}
+         ORDER BY h.row_num, h.tx_num",
+        row_scope.with_scope_cte("query_scope"),
+        select_columns.join(", "),
+        crate::schema::history_table(table_name),
+        branch_filter = history_branch_filter_sql("h", branch_nums),
+        epoch_filter = history_epoch_filter_sql(max_global_epoch),
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let row_width = 4 + table.fields.len() + 4;
+    let mut rows = stmt.query(params_from_iter(row_scope.params.iter()))?;
+    let mut records = Vec::new();
+    let mut public_row_id_cache = BTreeMap::new();
+    while let Some(row) = rows.next()? {
+        let row = (0..row_width)
+            .map(|idx| row.get::<_, rusqlite::types::Value>(idx))
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        let mut values = BTreeMap::new();
+        for (idx, field) in table.fields.iter().enumerate() {
+            values.insert(
+                field.name.clone(),
+                sql_value_to_json_cached(conn, field, &row[idx + 4], &mut public_row_id_cache)?,
+            );
+        }
+        let sys = 4 + table.fields.len();
+        records.push(HistoryRecord {
+            table: table_name.to_owned(),
+            row_id: text_value(&row[0], "row_id")?,
+            branch_id: text_value(&row[1], "branch_id")?,
+            tx_id: text_value(&row[2], "tx_id")?,
+            op: integer_value(&row[3], "op")?,
+            values,
+            created_at: integer_value(&row[sys], "j_created_at")?,
+            updated_at: integer_value(&row[sys + 1], "j_updated_at")?,
+            created_by: text_value(&row[sys + 2], "j_created_by")?,
+            updated_by: text_value(&row[sys + 3], "j_updated_by")?,
+        });
+    }
+    Ok(records)
+}
+
 fn export_history_versions_for_rows_with_branch_filter(
     conn: &Connection,
     schema: &SchemaDef,
@@ -7074,4 +7540,53 @@ fn insert_dynamic(
     ))?;
     stmt.execute(params_from_iter(values.iter()))?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::limits::Limit;
+
+    #[test]
+    fn generic_built_query_export_uses_sql_scope_under_low_variable_limit() -> Result<()> {
+        const ROW_COUNT: usize = 120;
+
+        let schema = SchemaDef::new().table("tasks", |table| {
+            table.text("title");
+            table.bool("done");
+        });
+        let mut upstream = Runtime::open_trusted_with_schema(
+            Storage::Memory,
+            "low-limit-upstream",
+            schema.clone(),
+        )?;
+        let mut peer =
+            Runtime::open_with_schema(Storage::Memory, "low-limit-peer", "alice", schema)?;
+
+        upstream
+            .conn
+            .set_limit(Limit::SQLITE_LIMIT_VARIABLE_NUMBER, 32)?;
+
+        for index in 0..ROW_COUNT {
+            upstream.insert_row(
+                "tasks",
+                &format!("task-{index:03}"),
+                BTreeMap::from([
+                    ("title".to_owned(), json!(format!("Task {index:03}"))),
+                    ("done".to_owned(), json!(false)),
+                ]),
+            )?;
+        }
+
+        let query = BuiltQuery::from_json_value(json!({
+            "table": "tasks",
+            "conditions": [{"column": "done", "op": "eq", "value": false}],
+            "orderBy": [["$createdAt", "desc"]]
+        }))?;
+
+        peer.apply_bundle(&upstream.export_query(query.clone())?)?;
+
+        assert_eq!(peer.query(query)?.len(), ROW_COUNT);
+        Ok(())
+    }
 }

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -5249,87 +5249,9 @@ fn export_txs_by_ids(conn: &Connection, tx_ids: BTreeSet<&str>) -> Result<Vec<Tx
     if tx_ids.is_empty() {
         return Ok(Vec::new());
     }
-    let tx_ids = tx_ids.into_iter().collect::<Vec<_>>();
-    if tx_ids.len() > crate::SQL_VARIABLE_CHUNK_SIZE {
-        return export_txs_by_ids_with_temp_scope(conn, &tx_ids);
-    }
-    let mut receipt_stmt = conn.prepare(&format!(
-        "SELECT tx.tx_id, receipt.tier
-         FROM jazz_tx tx
-         JOIN jazz_tx_receipt receipt ON receipt.tx_num = tx.tx_num
-         WHERE tx.tx_id IN ({placeholders})
-         ORDER BY tx.tx_num, receipt.tier",
-        placeholders = (0..tx_ids.len())
-            .map(|_| "?")
-            .collect::<Vec<_>>()
-            .join(", "),
-    ))?;
-    let receipt_rows = receipt_stmt.query_map(params_from_iter(tx_ids.iter()), |row| {
-        Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
-    })?;
-    let mut receipt_tiers_by_tx = BTreeMap::<String, Vec<i64>>::new();
-    for receipt_row in receipt_rows {
-        let (tx_id, tier) = receipt_row?;
-        receipt_tiers_by_tx.entry(tx_id).or_default().push(tier);
-    }
-
-    let mut stmt = conn.prepare(&format!(
-        "SELECT tx.tx_id, node.node_id, tx.local_epoch, tx.global_epoch, tx.conflict_mode, tx.outcome, rejection.code, rejection.detail_json, tx.created_at, tx.metadata_json
-         FROM jazz_tx tx
-         JOIN jazz_node node ON node.node_num = tx.node_num
-         LEFT JOIN jazz_tx_rejection rejection ON rejection.tx_num = tx.tx_num
-         WHERE tx.tx_id IN ({placeholders})
-         ORDER BY tx.tx_num",
-        placeholders = (0..tx_ids.len())
-            .map(|_| "?")
-            .collect::<Vec<_>>()
-            .join(", "),
-    ))?;
-    let records = stmt.query_map(params_from_iter(tx_ids.iter()), |row| {
-        let tx_id = row.get::<_, String>(0)?;
-        let receipt_tiers = receipt_tiers_by_tx.get(&tx_id).cloned().unwrap_or_default();
-        Ok(TxRecord {
-            tx_id,
-            node_id: row.get(1)?,
-            local_epoch: row.get(2)?,
-            global_epoch: row.get(3)?,
-            conflict_mode: row.get(4)?,
-            outcome: row.get(5)?,
-            auth_user: parse_tx_auth_user_for_sqlite(&row.get::<_, String>(9)?, 9)?,
-            rejection_code: row.get(6)?,
-            rejection_detail: row
-                .get::<_, Option<String>>(7)?
-                .map(|detail_json| parse_rejection_detail_for_sqlite(&detail_json, 7))
-                .transpose()?
-                .flatten(),
-            receipt_tiers,
-            created_at: row.get(8)?,
-        })
-    })?;
-    records
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .map_err(Into::into)
-}
-
-fn export_txs_by_ids_with_temp_scope(conn: &Connection, tx_ids: &[&str]) -> Result<Vec<TxRecord>> {
-    conn.execute_batch(
-        "CREATE TEMP TABLE IF NOT EXISTS jazz_export_tx_record_scope (
-           tx_id TEXT PRIMARY KEY
-         ) WITHOUT ROWID;
-         DELETE FROM jazz_export_tx_record_scope;",
-    )?;
-    {
-        let mut stmt =
-            conn.prepare("INSERT OR IGNORE INTO jazz_export_tx_record_scope (tx_id) VALUES (?)")?;
-        for tx_id in tx_ids {
-            stmt.execute(params![tx_id])?;
-        }
-    }
-
     let mut receipt_stmt = conn.prepare(
         "SELECT tx.tx_id, receipt.tier
-         FROM jazz_export_tx_record_scope tx_scope
-         JOIN jazz_tx tx ON tx.tx_id = tx_scope.tx_id
+         FROM jazz_tx tx
          JOIN jazz_tx_receipt receipt ON receipt.tx_num = tx.tx_num
          ORDER BY tx.tx_num, receipt.tier",
     )?;
@@ -5339,13 +5261,14 @@ fn export_txs_by_ids_with_temp_scope(conn: &Connection, tx_ids: &[&str]) -> Resu
     let mut receipt_tiers_by_tx = BTreeMap::<String, Vec<i64>>::new();
     for receipt_row in receipt_rows {
         let (tx_id, tier) = receipt_row?;
-        receipt_tiers_by_tx.entry(tx_id).or_default().push(tier);
+        if tx_ids.contains(tx_id.as_str()) {
+            receipt_tiers_by_tx.entry(tx_id).or_default().push(tier);
+        }
     }
 
     let mut stmt = conn.prepare(
         "SELECT tx.tx_id, node.node_id, tx.local_epoch, tx.global_epoch, tx.conflict_mode, tx.outcome, rejection.code, rejection.detail_json, tx.created_at, tx.metadata_json
-         FROM jazz_export_tx_record_scope tx_scope
-         JOIN jazz_tx tx ON tx.tx_id = tx_scope.tx_id
+         FROM jazz_tx tx
          JOIN jazz_node node ON node.node_num = tx.node_num
          LEFT JOIN jazz_tx_rejection rejection ON rejection.tx_num = tx.tx_num
          ORDER BY tx.tx_num",
@@ -5371,9 +5294,14 @@ fn export_txs_by_ids_with_temp_scope(conn: &Connection, tx_ids: &[&str]) -> Resu
             created_at: row.get(8)?,
         })
     })?;
-    records
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .map_err(Into::into)
+    let mut tx_records = Vec::new();
+    for record in records {
+        let record = record?;
+        if tx_ids.contains(record.tx_id.as_str()) {
+            tx_records.push(record);
+        }
+    }
+    Ok(tx_records)
 }
 
 fn parse_rejection_detail(detail_json: &str) -> Result<Option<JsonValue>> {
@@ -5441,30 +5369,13 @@ fn export_reads_for_history(
     conn: &Connection,
     history: &[HistoryRecord],
 ) -> Result<Vec<ReadRecord>> {
-    let mut tx_ids = history
+    let tx_ids = history
         .iter()
-        .map(|record| record.tx_id.clone())
-        .collect::<Vec<_>>();
-    tx_ids.sort();
-    tx_ids.dedup();
+        .map(|record| record.tx_id.as_str())
+        .collect::<BTreeSet<_>>();
     if tx_ids.is_empty() {
         return Ok(Vec::new());
     }
-    if tx_ids.len() > crate::SQL_VARIABLE_CHUNK_SIZE {
-        return export_reads_for_history_with_temp_scope(conn, history);
-    }
-    let candidate_read_count = count_read_rows_for_tx_ids(conn, &tx_ids)?;
-    if candidate_read_count <= (history.len() * 4).max(256) {
-        return export_reads_for_history_simple(conn, history, &tx_ids);
-    }
-    export_reads_for_history_with_temp_scope(conn, history)
-}
-
-fn export_reads_for_history_simple(
-    conn: &Connection,
-    history: &[HistoryRecord],
-    tx_ids: &[String],
-) -> Result<Vec<ReadRecord>> {
     let history_keys = history
         .iter()
         .map(|record| {
@@ -5475,21 +5386,16 @@ fn export_reads_for_history_simple(
             )
         })
         .collect::<BTreeSet<_>>();
-    let mut stmt = conn.prepare(&format!(
+    let mut stmt = conn.prepare(
         "SELECT tx.tx_id, tables.table_name, ids.row_id, reads.reason, observed.tx_id
          FROM jazz_tx_read reads
          JOIN jazz_tx tx ON tx.tx_num = reads.tx_num
          JOIN jazz_table tables ON tables.table_num = reads.table_num
          LEFT JOIN jazz_tx observed ON observed.tx_num = reads.observed_tx_num
          JOIN jazz_row_id ids ON ids.row_num = reads.row_num
-         WHERE tx.tx_id IN ({placeholders})
          ORDER BY tx.tx_num, tables.table_name, ids.row_id, reads.reason",
-        placeholders = (0..tx_ids.len())
-            .map(|_| "?")
-            .collect::<Vec<_>>()
-            .join(", "),
-    ))?;
-    let records = stmt.query_map(params_from_iter(tx_ids.iter()), |row| {
+    )?;
+    let records = stmt.query_map([], |row| {
         Ok(ReadRecord {
             tx_id: row.get(0)?,
             table: row.get(1)?,
@@ -5502,95 +5408,16 @@ fn export_reads_for_history_simple(
         .collect::<std::result::Result<Vec<_>, _>>()?
         .into_iter()
         .filter(|record| {
-            record.reason != read_set::REASON_ABSENT
-                || history_keys.contains(&(
-                    record.tx_id.as_str(),
-                    record.table.as_str(),
-                    record.row_id.as_str(),
-                ))
+            tx_ids.contains(record.tx_id.as_str())
+                && (record.reason != read_set::REASON_ABSENT
+                    || history_keys.contains(&(
+                        record.tx_id.as_str(),
+                        record.table.as_str(),
+                        record.row_id.as_str(),
+                    )))
         })
         .collect();
     Ok(records)
-}
-
-fn count_read_rows_for_tx_ids(conn: &Connection, tx_ids: &[String]) -> Result<usize> {
-    let count: i64 = conn.query_row(
-        &format!(
-            "SELECT COUNT(*)
-             FROM jazz_tx_read reads
-             JOIN jazz_tx tx ON tx.tx_num = reads.tx_num
-             WHERE tx.tx_id IN ({placeholders})",
-            placeholders = (0..tx_ids.len())
-                .map(|_| "?")
-                .collect::<Vec<_>>()
-                .join(", "),
-        ),
-        params_from_iter(tx_ids.iter()),
-        |row| row.get(0),
-    )?;
-    Ok(count as usize)
-}
-
-fn export_reads_for_history_with_temp_scope(
-    conn: &Connection,
-    history: &[HistoryRecord],
-) -> Result<Vec<ReadRecord>> {
-    if history.is_empty() {
-        return Ok(Vec::new());
-    }
-    conn.execute_batch(
-        "CREATE TEMP TABLE IF NOT EXISTS jazz_export_tx_scope (
-           tx_id TEXT PRIMARY KEY
-         ) WITHOUT ROWID;
-         CREATE TEMP TABLE IF NOT EXISTS jazz_export_history_scope (
-           tx_id TEXT NOT NULL,
-           table_name TEXT NOT NULL,
-           row_id TEXT NOT NULL,
-           PRIMARY KEY (tx_id, table_name, row_id)
-         ) WITHOUT ROWID;
-         DELETE FROM jazz_export_tx_scope;
-         DELETE FROM jazz_export_history_scope;",
-    )?;
-    {
-        let mut tx_stmt =
-            conn.prepare("INSERT OR IGNORE INTO jazz_export_tx_scope (tx_id) VALUES (?)")?;
-        let mut scope_stmt = conn.prepare(
-            "INSERT OR IGNORE INTO jazz_export_history_scope (tx_id, table_name, row_id)
-             VALUES (?, ?, ?)",
-        )?;
-        for record in history {
-            tx_stmt.execute(params![record.tx_id])?;
-            scope_stmt.execute(params![record.tx_id, record.table, record.row_id])?;
-        }
-    }
-    let mut stmt = conn.prepare(
-        "SELECT tx.tx_id, tables.table_name, ids.row_id, reads.reason, observed.tx_id
-         FROM jazz_export_tx_scope tx_scope
-         JOIN jazz_tx tx ON tx.tx_id = tx_scope.tx_id
-         JOIN jazz_tx_read reads ON reads.tx_num = tx.tx_num
-         JOIN jazz_table tables ON tables.table_num = reads.table_num
-         LEFT JOIN jazz_tx observed ON observed.tx_num = reads.observed_tx_num
-         JOIN jazz_row_id ids ON ids.row_num = reads.row_num
-         LEFT JOIN jazz_export_history_scope history_scope
-           ON history_scope.tx_id = tx.tx_id
-          AND history_scope.table_name = tables.table_name
-          AND history_scope.row_id = ids.row_id
-         WHERE reads.reason != ?
-            OR history_scope.tx_id IS NOT NULL
-         ORDER BY tx.tx_num, tables.table_name, ids.row_id, reads.reason",
-    )?;
-    let records = stmt.query_map(params![read_set::REASON_ABSENT], |row| {
-        Ok(ReadRecord {
-            tx_id: row.get(0)?,
-            table: row.get(1)?,
-            row_id: row.get(2)?,
-            reason: row.get(3)?,
-            observed_tx_id: row.get(4)?,
-        })
-    })?;
-    records
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .map_err(Into::into)
 }
 
 fn export_branch_records_for_history(
@@ -6118,29 +5945,22 @@ fn scoped_policy_parent_row_nums(
     }
     let mut parent_row_nums = BTreeSet::new();
     let child_row_nums = sorted_unique_row_nums(child_row_nums);
-    for child_chunk in child_row_nums.chunks(crate::SQL_VARIABLE_CHUNK_SIZE) {
-        let child_placeholders = sql_placeholders(child_chunk.len());
-        let mut stmt = conn.prepare(&format!(
-            "SELECT current.{ref_column}
-             FROM {} current
-             JOIN jazz_tx current_tx ON current_tx.tx_num = current.visible_tx_num
-             WHERE current.row_num IN ({child_placeholders})
-               AND current.is_deleted = 0
-               AND {}
-               AND current_tx.outcome != ?",
-            crate::schema::current_table(table_name),
-            branch_filter_sql("current", branch_nums),
-        ))?;
-        let mut params = child_chunk
-            .iter()
-            .copied()
-            .map(rusqlite::types::Value::Integer)
-            .collect::<Vec<_>>();
-        params.push(rusqlite::types::Value::Integer(tx::OUTCOME_REJECTED));
-        let rows = stmt.query_map(params_from_iter(params.iter()), |row| row.get::<_, i64>(0))?;
-        for row in rows {
-            parent_row_nums.insert(row?);
-        }
+    let mut stmt = conn.prepare(&format!(
+        "SELECT current.{ref_column}
+         FROM {} current
+         JOIN jazz_tx current_tx ON current_tx.tx_num = current.visible_tx_num
+         WHERE current.row_num IN ({child_row_nums})
+           AND current.is_deleted = 0
+           AND {}
+           AND current_tx.outcome != {}",
+        crate::schema::current_table(table_name),
+        branch_filter_sql("current", branch_nums),
+        tx::OUTCOME_REJECTED,
+        child_row_nums = integer_list_sql(&child_row_nums),
+    ))?;
+    let rows = stmt.query_map([], |row| row.get::<_, i64>(0))?;
+    for row in rows {
+        parent_row_nums.insert(row?);
     }
     Ok(parent_row_nums.into_iter().collect())
 }
@@ -6200,57 +6020,53 @@ fn export_deleted_recursive_descendant_history(
         .ok_or_else(|| crate::Error::new(format!("unknown ref field {parent_field}")))?;
     let parent_column = crate::schema::quote_ident(&crate::schema::storage_column(field));
     let mut row_nums = BTreeSet::new();
-    for parent_chunk in parent_row_nums.chunks(crate::SQL_VARIABLE_CHUNK_SIZE) {
-        let sql = format!(
-            "WITH RECURSIVE deleted_tree(row_num) AS (
-               SELECT h.row_num
-               FROM {history_table} h
-               JOIN jazz_tx tx ON tx.tx_num = h.tx_num
-               WHERE h.op = 3
-                 AND {branch_filter}
-                 AND h.{parent_column} IN ({parent_placeholders})
-                 AND tx.outcome != {rejected}
-                 AND NOT EXISTS (
-                   SELECT 1
-                   FROM {history_table} newer
-                   JOIN jazz_tx newer_tx ON newer_tx.tx_num = newer.tx_num
-                   WHERE newer.row_num = h.row_num
-                     AND newer.j_branch_num = h.j_branch_num
-                     AND newer_tx.outcome != {rejected}
-                     AND newer.tx_num > h.tx_num
-                 )
-               UNION
-               SELECT child.row_num
-               FROM {history_table} child
-               JOIN jazz_tx child_tx ON child_tx.tx_num = child.tx_num
-               JOIN deleted_tree parent ON child.{parent_column} = parent.row_num
-               WHERE child.op = 3
-                 AND {child_branch_filter}
-                 AND child_tx.outcome != {rejected}
-                 AND NOT EXISTS (
-                   SELECT 1
-                   FROM {history_table} newer
-                   JOIN jazz_tx newer_tx ON newer_tx.tx_num = newer.tx_num
-                   WHERE newer.row_num = child.row_num
-                     AND newer.j_branch_num = child.j_branch_num
-                     AND newer_tx.outcome != {rejected}
-                     AND newer.tx_num > child.tx_num
-                 )
+    let sql = format!(
+        "WITH RECURSIVE deleted_tree(row_num) AS (
+           SELECT h.row_num
+           FROM {history_table} h
+           JOIN jazz_tx tx ON tx.tx_num = h.tx_num
+           WHERE h.op = 3
+             AND {branch_filter}
+             AND h.{parent_column} IN ({parent_row_nums})
+             AND tx.outcome != {rejected}
+             AND NOT EXISTS (
+               SELECT 1
+               FROM {history_table} newer
+               JOIN jazz_tx newer_tx ON newer_tx.tx_num = newer.tx_num
+               WHERE newer.row_num = h.row_num
+                 AND newer.j_branch_num = h.j_branch_num
+                 AND newer_tx.outcome != {rejected}
+                 AND newer.tx_num > h.tx_num
              )
-             SELECT row_num FROM deleted_tree",
-            history_table = crate::schema::history_table(table_name),
-            branch_filter = branch_filter_sql("h", branch_nums),
-            child_branch_filter = branch_filter_sql("child", branch_nums),
-            rejected = tx::OUTCOME_REJECTED,
-            parent_placeholders = sql_placeholders(parent_chunk.len()),
-        );
-        let mut stmt = conn.prepare(&sql)?;
-        let rows = stmt.query_map(params_from_iter(parent_chunk.iter()), |row| {
-            row.get::<_, i64>(0)
-        })?;
-        for row in rows {
-            row_nums.insert(row?);
-        }
+           UNION
+           SELECT child.row_num
+           FROM {history_table} child
+           JOIN jazz_tx child_tx ON child_tx.tx_num = child.tx_num
+           JOIN deleted_tree parent ON child.{parent_column} = parent.row_num
+           WHERE child.op = 3
+             AND {child_branch_filter}
+             AND child_tx.outcome != {rejected}
+             AND NOT EXISTS (
+               SELECT 1
+               FROM {history_table} newer
+               JOIN jazz_tx newer_tx ON newer_tx.tx_num = newer.tx_num
+               WHERE newer.row_num = child.row_num
+                 AND newer.j_branch_num = child.j_branch_num
+                 AND newer_tx.outcome != {rejected}
+                 AND newer.tx_num > child.tx_num
+             )
+         )
+         SELECT row_num FROM deleted_tree",
+        history_table = crate::schema::history_table(table_name),
+        branch_filter = branch_filter_sql("h", branch_nums),
+        child_branch_filter = branch_filter_sql("child", branch_nums),
+        rejected = tx::OUTCOME_REJECTED,
+        parent_row_nums = integer_list_sql(&parent_row_nums),
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map([], |row| row.get::<_, i64>(0))?;
+    for row in rows {
+        row_nums.insert(row?);
     }
     let row_nums = row_nums.into_iter().collect::<Vec<_>>();
     export_history_versions_for_rows(conn, schema, table_name, Some(&row_nums), None)
@@ -6276,37 +6092,33 @@ fn export_recursive_scope_repair_history(
         .ok_or_else(|| crate::Error::new(format!("unknown ref field {parent_field}")))?;
     let parent_column = crate::schema::quote_ident(&crate::schema::storage_column(field));
     let mut row_nums = BTreeSet::new();
-    for parent_chunk in parent_row_nums.chunks(crate::SQL_VARIABLE_CHUNK_SIZE) {
-        let sql = format!(
-            "WITH RECURSIVE historical_tree(row_num) AS (
-               SELECT h.row_num
-               FROM {history_table} h
-               JOIN jazz_tx tx ON tx.tx_num = h.tx_num
-               WHERE {branch_filter}
-                 AND h.{parent_column} IN ({parent_placeholders})
-                 AND tx.outcome != {rejected}
-               UNION
-               SELECT child.row_num
-               FROM {history_table} child
-               JOIN jazz_tx child_tx ON child_tx.tx_num = child.tx_num
-               JOIN historical_tree parent ON child.{parent_column} = parent.row_num
-               WHERE {child_branch_filter}
-                 AND child_tx.outcome != {rejected}
-             )
-             SELECT DISTINCT row_num FROM historical_tree",
-            history_table = crate::schema::history_table(table_name),
-            branch_filter = branch_filter_sql("h", branch_nums),
-            child_branch_filter = branch_filter_sql("child", branch_nums),
-            rejected = tx::OUTCOME_REJECTED,
-            parent_placeholders = sql_placeholders(parent_chunk.len()),
-        );
-        let mut stmt = conn.prepare(&sql)?;
-        let rows = stmt.query_map(params_from_iter(parent_chunk.iter()), |row| {
-            row.get::<_, i64>(0)
-        })?;
-        for row in rows {
-            row_nums.insert(row?);
-        }
+    let sql = format!(
+        "WITH RECURSIVE historical_tree(row_num) AS (
+           SELECT h.row_num
+           FROM {history_table} h
+           JOIN jazz_tx tx ON tx.tx_num = h.tx_num
+           WHERE {branch_filter}
+             AND h.{parent_column} IN ({parent_row_nums})
+             AND tx.outcome != {rejected}
+           UNION
+           SELECT child.row_num
+           FROM {history_table} child
+           JOIN jazz_tx child_tx ON child_tx.tx_num = child.tx_num
+           JOIN historical_tree parent ON child.{parent_column} = parent.row_num
+           WHERE {child_branch_filter}
+             AND child_tx.outcome != {rejected}
+         )
+         SELECT DISTINCT row_num FROM historical_tree",
+        history_table = crate::schema::history_table(table_name),
+        branch_filter = branch_filter_sql("h", branch_nums),
+        child_branch_filter = branch_filter_sql("child", branch_nums),
+        rejected = tx::OUTCOME_REJECTED,
+        parent_row_nums = integer_list_sql(&parent_row_nums),
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map([], |row| row.get::<_, i64>(0))?;
+    for row in rows {
+        row_nums.insert(row?);
     }
     let row_nums = row_nums.into_iter().collect::<Vec<_>>();
     export_history_versions_for_rows(conn, schema, table_name, Some(&row_nums), None)
@@ -6810,24 +6622,16 @@ fn delete_current_rows_outside_keep_set(
         .collect::<BTreeSet<_>>()
         .into_iter()
         .collect::<Vec<_>>();
-    for delete_chunk in delete_row_nums.chunks(crate::SQL_VARIABLE_CHUNK_SIZE) {
+    if !delete_row_nums.is_empty() {
         let sql = format!(
             "DELETE FROM {}
              WHERE j_branch_num = ?
                AND is_deleted = 0
                AND row_num IN ({})",
             crate::schema::current_table(table_name),
-            sql_placeholders(delete_chunk.len()),
+            integer_list_sql(&delete_row_nums),
         );
-        let mut params = Vec::with_capacity(1 + delete_chunk.len());
-        params.push(rusqlite::types::Value::Integer(branch_num));
-        params.extend(
-            delete_chunk
-                .iter()
-                .copied()
-                .map(rusqlite::types::Value::Integer),
-        );
-        db.execute(&sql, params_from_iter(params.iter()))?;
+        db.execute(&sql, params![branch_num])?;
     }
     Ok(())
 }
@@ -6885,19 +6689,6 @@ fn export_visible_table_history(
     if let Some(row_nums) = row_nums {
         if row_nums.is_empty() {
             return Ok(Vec::new());
-        }
-        if row_nums.len() > crate::SQL_VARIABLE_CHUNK_SIZE {
-            let row_nums = sorted_unique_row_nums(row_nums);
-            let mut records = Vec::new();
-            for row_chunk in row_nums.chunks(crate::SQL_VARIABLE_CHUNK_SIZE) {
-                records.extend(export_visible_table_history(
-                    visibility,
-                    table_name,
-                    branch_nums,
-                    Some(row_chunk),
-                )?);
-            }
-            return Ok(records);
         }
     }
     let conn = visibility.conn;
@@ -6957,10 +6748,7 @@ fn export_visible_table_history(
     let mut stmt = conn.prepare(&sql)?;
     let row_width = 4 + table.fields.len() + 4;
     let mut records = Vec::new();
-    let mut rows = match row_nums {
-        Some(row_nums) => stmt.query(params_from_iter(row_nums.iter()))?,
-        None => stmt.query([])?,
-    };
+    let mut rows = stmt.query([])?;
     let mut public_row_id_cache = BTreeMap::new();
     while let Some(row) = rows.next()? {
         let row = (0..row_width)
@@ -7155,21 +6943,6 @@ fn export_history_versions_for_rows_with_branch_filter(
         if row_nums.is_empty() {
             return Ok(Vec::new());
         }
-        if row_nums.len() > crate::SQL_VARIABLE_CHUNK_SIZE {
-            let row_nums = sorted_unique_row_nums(row_nums);
-            let mut records = Vec::new();
-            for row_chunk in row_nums.chunks(crate::SQL_VARIABLE_CHUNK_SIZE) {
-                records.extend(export_history_versions_for_rows_with_branch_filter(
-                    conn,
-                    schema,
-                    table_name,
-                    Some(row_chunk),
-                    max_global_epoch,
-                    branch_nums,
-                )?);
-            }
-            return Ok(records);
-        }
     }
     let table = schema.table_def(table_name)?;
     let field_columns = table
@@ -7214,10 +6987,7 @@ fn export_history_versions_for_rows_with_branch_filter(
     );
     let mut stmt = conn.prepare(&sql)?;
     let row_width = 4 + table.fields.len() + 4;
-    let mut rows = match row_nums {
-        Some(row_nums) => stmt.query(params_from_iter(row_nums.iter()))?,
-        None => stmt.query([])?,
-    };
+    let mut rows = stmt.query([])?;
     let mut records = Vec::new();
     let mut public_row_id_cache = BTreeMap::new();
     while let Some(row) = rows.next()? {
@@ -7258,7 +7028,7 @@ fn history_epoch_filter_sql(max_global_epoch: Option<i64>) -> String {
 fn row_filter_sql(row_nums: Option<&[i64]>) -> String {
     match row_nums {
         Some([]) => "0 = 1".to_owned(),
-        Some(row_nums) => format!("h.row_num IN ({})", sql_placeholders(row_nums.len())),
+        Some(row_nums) => format!("h.row_num IN ({})", integer_list_sql(row_nums)),
         None => "1 = 1".to_owned(),
     }
 }
@@ -7266,14 +7036,7 @@ fn row_filter_sql(row_nums: Option<&[i64]>) -> String {
 fn history_row_filter_sql(alias: &str, row_nums: Option<&[i64]>) -> String {
     match row_nums {
         Some([]) => "0 = 1".to_owned(),
-        Some(row_nums) => format!(
-            "{alias}.row_num IN ({})",
-            row_nums
-                .iter()
-                .map(i64::to_string)
-                .collect::<Vec<_>>()
-                .join(", ")
-        ),
+        Some(row_nums) => format!("{alias}.row_num IN ({})", integer_list_sql(row_nums)),
         None => "1 = 1".to_owned(),
     }
 }
@@ -7283,11 +7046,7 @@ fn history_branch_filter_sql(alias: &str, branch_nums: Option<&[i64]>) -> String
         Some([]) => "0 = 1".to_owned(),
         Some(branch_nums) => format!(
             "{alias}.j_branch_num IN ({})",
-            branch_nums
-                .iter()
-                .map(i64::to_string)
-                .collect::<Vec<_>>()
-                .join(", ")
+            integer_list_sql(branch_nums)
         ),
         None => "1 = 1".to_owned(),
     }
@@ -7299,12 +7058,16 @@ fn branch_filter_sql(alias: &str, branch_nums: &[i64]) -> String {
     }
     format!(
         "{alias}.j_branch_num IN ({})",
-        branch_nums
-            .iter()
-            .map(i64::to_string)
-            .collect::<Vec<_>>()
-            .join(", ")
+        integer_list_sql(branch_nums)
     )
+}
+
+fn integer_list_sql(values: &[i64]) -> String {
+    values
+        .iter()
+        .map(i64::to_string)
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 fn sorted_unique_row_nums(row_nums: &[i64]) -> Vec<i64> {
@@ -7312,10 +7075,6 @@ fn sorted_unique_row_nums(row_nums: &[i64]) -> Vec<i64> {
     row_nums.sort();
     row_nums.dedup();
     row_nums
-}
-
-fn sql_placeholders(count: usize) -> String {
-    (0..count).map(|_| "?").collect::<Vec<_>>().join(", ")
 }
 
 fn sql_value_to_json(

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -1700,7 +1700,7 @@ impl Runtime {
         let history_exists = history_record_exists(context.db, &record.table, row_num, tx_num)?;
         if history_exists
             && current_visible_tx_num(context.db, &record.table, row_num, branch_num)?
-                .is_none_or(|current_tx_num| current_tx_num == tx_num)
+                .is_some_and(|current_tx_num| current_tx_num == tx_num)
         {
             return Ok(());
         }

--- a/crates/mini-jazz-sqlite/tests/whole_system/query_matrix.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/query_matrix.rs
@@ -123,6 +123,121 @@ fn large_built_query_export_does_not_exceed_sqlite_variable_limit() {
 }
 
 #[test]
+fn built_query_offset_page_export_supports_peer_pagination() {
+    let schema = support::tasks_schema();
+    let mut upstream =
+        Runtime::open_trusted_with_schema(Storage::Memory, "page-upstream", schema.clone())
+            .unwrap();
+    let mut peer =
+        Runtime::open_with_schema(Storage::Memory, "page-peer", "alice", schema).unwrap();
+
+    for index in 0..40 {
+        upstream
+            .insert_row(
+                "tasks",
+                &format!("task-{index:02}"),
+                BTreeMap::from([
+                    ("title".to_owned(), json!(format!("Task {index:02}"))),
+                    ("done".to_owned(), json!(false)),
+                ]),
+            )
+            .unwrap();
+    }
+
+    let query = BuiltQuery::from_json_value(json!({
+        "table": "tasks",
+        "conditions": [{"column": "done", "op": "eq", "value": false}],
+        "orderBy": [["title", "asc"]],
+        "limit": 10,
+        "offset": 20,
+    }))
+    .unwrap();
+
+    peer.apply_bundle(&upstream.export_query(query.clone()).unwrap())
+        .unwrap();
+
+    assert_eq!(
+        query_ids(&peer, query),
+        (20..30)
+            .map(|index| format!("task-{index:02}"))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn built_query_page_refresh_removes_stale_rows_and_adds_new_boundary_rows() {
+    let schema = support::tasks_schema();
+    let mut upstream =
+        Runtime::open_trusted_with_schema(Storage::Memory, "refresh-upstream", schema.clone())
+            .unwrap();
+    let mut peer =
+        Runtime::open_with_schema(Storage::Memory, "refresh-peer", "alice", schema).unwrap();
+
+    for (id, title) in [
+        ("task-alpha", "Alpha"),
+        ("task-beta", "Beta"),
+        ("task-gamma", "Gamma"),
+    ] {
+        upstream
+            .insert_row(
+                "tasks",
+                id,
+                BTreeMap::from([
+                    ("title".to_owned(), json!(title)),
+                    ("done".to_owned(), json!(false)),
+                ]),
+            )
+            .unwrap();
+    }
+
+    let query = BuiltQuery::from_json_value(json!({
+        "table": "tasks",
+        "conditions": [{"column": "done", "op": "eq", "value": false}],
+        "orderBy": [["title", "asc"]],
+        "limit": 2,
+    }))
+    .unwrap();
+
+    peer.apply_bundle(&upstream.export_query(query.clone()).unwrap())
+        .unwrap();
+    assert_eq!(
+        query_ids(&peer, query.clone()),
+        vec!["task-alpha", "task-beta"]
+    );
+    let mut subscription = peer.subscribe_query(query.clone()).unwrap();
+
+    upstream
+        .update_row(
+            "tasks",
+            "task-gamma",
+            BTreeMap::from([("title".to_owned(), json!("Aardvark"))]),
+        )
+        .unwrap();
+    for refresh in upstream
+        .export_query_read_refreshes(&peer.observed_query_reads().unwrap())
+        .unwrap()
+    {
+        peer.apply_bundle(&refresh).unwrap();
+    }
+
+    let update = peer.subscription_delta(&mut subscription).unwrap();
+    assert_eq!(
+        update
+            .all
+            .iter()
+            .map(|row| row.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["task-gamma", "task-alpha"]
+    );
+    assert!(update.delta.iter().any(
+        |delta| matches!(delta, SubscriptionRowDelta::Added { id, .. } if id == "task-gamma")
+    ));
+    assert!(update.delta.iter().any(
+        |delta| matches!(delta, SubscriptionRowDelta::Removed { id, .. } if id == "task-beta")
+    ));
+}
+
+#[test]
 fn policy_filtered_built_query_subscription_tracks_rows_entering_and_leaving() {
     let mut runtime = Runtime::open_trusted_with_schema(
         Storage::Memory,

--- a/examples/mini-sqlite-todo-yew/src/lib.rs
+++ b/examples/mini-sqlite-todo-yew/src/lib.rs
@@ -739,6 +739,157 @@ mod tests {
     }
 
     #[test]
+    fn done_filter_survives_page_reload_and_filter_flips() {
+        let mut worker = Runtime::open_with_schema(
+            Storage::Memory,
+            "worker-filter-reload-flips",
+            "alice",
+            todo_schema(),
+        )
+        .unwrap();
+        let mut main = Runtime::open_with_schema(
+            Storage::Memory,
+            "main-filter-reload-flips",
+            "alice",
+            todo_schema(),
+        )
+        .unwrap();
+
+        let mut batch_ids = Vec::new();
+        for index in 0..5_000 {
+            let id = format!("todo-{index:04}");
+            main.insert_row(
+                "todos",
+                &id,
+                BTreeMap::from([
+                    ("title".to_owned(), json!(format!("Todo {index:04}"))),
+                    ("done".to_owned(), json!(false)),
+                    ("project".to_owned(), json!("todo-list")),
+                ]),
+            )
+            .unwrap();
+            batch_ids.push(id);
+            if batch_ids.len() == 100 {
+                let changed_ids = QueryBuilder::table("todos")
+                    .in_values("id", json!(std::mem::take(&mut batch_ids)))
+                    .build();
+                worker
+                    .apply_bundle(&main.export_query(changed_ids).unwrap())
+                    .unwrap();
+            }
+        }
+        if !batch_ids.is_empty() {
+            let changed_ids = QueryBuilder::table("todos")
+                .in_values("id", json!(batch_ids))
+                .build();
+            worker
+                .apply_bundle(&main.export_query(changed_ids).unwrap())
+                .unwrap();
+        }
+
+        let page_five = TodoQueryState {
+            page: 4,
+            ..TodoQueryState::default()
+        };
+        main.apply_bundle(
+            &worker
+                .export_query(page_five.page_hydration_query())
+                .unwrap(),
+        )
+        .unwrap();
+        let page_five_ids = main
+            .query(page_five.page_query())
+            .unwrap()
+            .into_iter()
+            .take(3)
+            .map(|row| row.id)
+            .collect::<Vec<_>>();
+        assert_eq!(page_five_ids.len(), 3);
+
+        for id in &page_five_ids {
+            main.update_row(
+                "todos",
+                id,
+                BTreeMap::from([("done".to_owned(), json!(true))]),
+            )
+            .unwrap();
+            let changed_id = QueryBuilder::table("todos")
+                .in_values("id", json!([id]))
+                .build();
+            worker
+                .apply_bundle(&main.export_query(changed_id).unwrap())
+                .unwrap();
+            for query in [page_five.page_query(), page_five.next_page_probe_query()] {
+                main.apply_bundle(&worker.export_query(query).unwrap())
+                    .unwrap();
+            }
+        }
+
+        let mut reloaded = Runtime::open_with_schema(
+            Storage::Memory,
+            "reloaded-main-filter-flips",
+            "alice",
+            todo_schema(),
+        )
+        .unwrap();
+        let default_page = TodoQueryState::default();
+        reloaded
+            .apply_bundle(
+                &worker
+                    .export_query(default_page.page_hydration_query())
+                    .unwrap(),
+            )
+            .unwrap();
+
+        let done_page = TodoQueryState {
+            done_filter: TodoDoneFilter::Done,
+            ..TodoQueryState::default()
+        };
+        let mut done_subscription = reloaded.subscribe_query(done_page.page_query()).unwrap();
+        assert!(done_subscription.initial_rows().is_empty());
+        reloaded
+            .apply_bundle(
+                &worker
+                    .export_query(done_page.page_hydration_query())
+                    .unwrap(),
+            )
+            .unwrap();
+        let done_delta = reloaded.subscription_delta(&mut done_subscription).unwrap();
+        assert_eq!(done_delta.all.len(), 3);
+
+        let open_page = TodoQueryState {
+            done_filter: TodoDoneFilter::Open,
+            ..TodoQueryState::default()
+        };
+        let mut open_subscription = reloaded.subscribe_query(open_page.page_query()).unwrap();
+        reloaded
+            .apply_bundle(
+                &worker
+                    .export_query(open_page.page_hydration_query())
+                    .unwrap(),
+            )
+            .unwrap();
+        let open_delta = reloaded.subscription_delta(&mut open_subscription).unwrap();
+        assert_eq!(open_delta.all.len(), TODO_PAGE_SIZE);
+
+        let mut done_subscription = reloaded.subscribe_query(done_page.page_query()).unwrap();
+        reloaded
+            .apply_bundle(
+                &worker
+                    .export_query(done_page.page_hydration_query())
+                    .unwrap(),
+            )
+            .unwrap();
+        let done_delta = reloaded
+            .subscription_delta(&mut done_subscription)
+            .unwrap()
+            .all;
+        let done_ids = done_delta.into_iter().map(|row| row.id).collect::<Vec<_>>();
+
+        assert_eq!(done_ids, page_five_ids);
+    }
+
+    #[test]
     fn todo_query_state_builds_search_done_and_page_query() {
         let state = TodoQueryState {
             title_search: "  needle  ".to_owned(),

--- a/examples/mini-sqlite-todo-yew/src/lib.rs
+++ b/examples/mini-sqlite-todo-yew/src/lib.rs
@@ -624,6 +624,121 @@ mod tests {
     }
 
     #[test]
+    fn synced_pagination_survives_filter_and_page_changes() {
+        let mut worker = Runtime::open_with_schema(
+            Storage::Memory,
+            "worker-filter-pagination-sync",
+            "alice",
+            todo_schema(),
+        )
+        .unwrap();
+        let mut main = Runtime::open_with_schema(
+            Storage::Memory,
+            "main-filter-pagination-sync",
+            "alice",
+            todo_schema(),
+        )
+        .unwrap();
+
+        let default_page = TodoQueryState::default();
+        for index in 0..12 {
+            let id = format!("todo-{index:02}");
+            main.insert_row(
+                "todos",
+                &id,
+                BTreeMap::from([
+                    ("title".to_owned(), json!(format!("sync page {index:02}"))),
+                    ("done".to_owned(), json!(false)),
+                    ("project".to_owned(), json!("todo-list")),
+                ]),
+            )
+            .unwrap();
+            let changed_id = QueryBuilder::table("todos")
+                .in_values("id", json!([id]))
+                .build();
+            worker
+                .apply_bundle(&main.export_query(changed_id).unwrap())
+                .unwrap();
+            for query in [
+                default_page.page_query(),
+                default_page.next_page_probe_query(),
+            ] {
+                main.apply_bundle(&worker.export_query(query).unwrap())
+                    .unwrap();
+            }
+        }
+
+        let filtered_page_one = TodoQueryState {
+            title_search: "sync page".to_owned(),
+            sort_field: TodoSortField::Title,
+            sort_direction: TodoSortDirection::Asc,
+            page: 0,
+            ..TodoQueryState::default()
+        };
+        let worker_all_ids = worker
+            .query(
+                QueryBuilder::table("todos")
+                    .contains("title", "sync page")
+                    .order_by("title", QueryDirection::Asc)
+                    .build(),
+            )
+            .unwrap()
+            .into_iter()
+            .map(|row| row.id)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            worker_all_ids,
+            (0..12)
+                .map(|index| format!("todo-{index:02}"))
+                .collect::<Vec<_>>()
+        );
+        main.apply_bundle(
+            &worker
+                .export_query(filtered_page_one.page_hydration_query())
+                .unwrap(),
+        )
+        .unwrap();
+
+        let page_one_ids = main
+            .query(filtered_page_one.page_query())
+            .unwrap()
+            .into_iter()
+            .map(|row| row.id)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            page_one_ids,
+            (0..10)
+                .map(|index| format!("todo-{index:02}"))
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            main.query(filtered_page_one.next_page_probe_query())
+                .unwrap()
+                .len(),
+            1
+        );
+
+        let filtered_page_two = TodoQueryState {
+            page: 1,
+            ..filtered_page_one
+        };
+        main.apply_bundle(
+            &worker
+                .export_query(filtered_page_two.page_hydration_query())
+                .unwrap(),
+        )
+        .unwrap();
+
+        let page_two_ids = main
+            .query(filtered_page_two.page_query())
+            .unwrap()
+            .into_iter()
+            .map(|row| row.id)
+            .collect::<Vec<_>>();
+        assert_eq!(page_two_ids, vec!["todo-10", "todo-11"]);
+    }
+
+    #[test]
     fn todo_query_state_builds_search_done_and_page_query() {
         let state = TodoQueryState {
             title_search: "  needle  ".to_owned(),

--- a/examples/mini-sqlite-todo-yew/src/todo_runtime.rs
+++ b/examples/mini-sqlite-todo-yew/src/todo_runtime.rs
@@ -155,7 +155,7 @@ impl TodoRuntime {
                 ]),
             )?;
             browser.refresh_subscriptions()?;
-            browser.sync_queries_after_render(vec![todo_ids_query(vec![id])]);
+            browser.sync_queries(vec![todo_ids_query(vec![id])])?;
             Ok(())
         })() {
             self.set_error(error);
@@ -167,7 +167,7 @@ impl TodoRuntime {
         if let Err(error) = (|| {
             browser.update_row("todos", &id, row_values([("done", json!(done))]))?;
             browser.refresh_subscriptions()?;
-            browser.sync_queries_after_render(vec![todo_ids_query(vec![id])]);
+            browser.sync_queries(vec![todo_ids_query(vec![id])])?;
             Ok(())
         })() {
             self.set_error(error);
@@ -179,7 +179,7 @@ impl TodoRuntime {
         if let Err(error) = (|| {
             browser.delete_row("todos", &id)?;
             browser.refresh_subscriptions()?;
-            browser.sync_queries_after_render(vec![todo_ids_query(vec![id])]);
+            browser.sync_queries(vec![todo_ids_query(vec![id])])?;
             Ok(())
         })() {
             self.set_error(error);


### PR DESCRIPTION
## Summary

- Replace generic `BuiltQuery` export history collection with SQL row-scope CTEs so large query result sets are joined inside SQLite instead of sent back as huge `IN (...)` parameter lists.
- Keep the existing materialized fallback for branch queries that must apply effective policy before windowing, and leave legacy prebuilt query export paths unchanged.
- Add regression coverage for low SQLite variable limits, offset page exports, and page refreshes that add/remove boundary rows.

## Validation

- `cargo test -p mini-jazz-sqlite`
- pre-commit hook: clippy and rustfmt