### PR TITLE
Fix permissions head-before-bundle race causing local write denials

### DIFF
--- a/.changeset/defer-enforcing-until-bundle.md
+++ b/.changeset/defer-enforcing-until-bundle.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix a permissions race where a permissions head arriving before its bundle would flip the client into Enforcing mode without an authorization schema, causing local writes against every table to fail with `policy denied` until the bundle arrived. The mode now only flips when the bundle is applied.

--- a/crates/jazz-tools/src/schema_manager/manager.rs
+++ b/crates/jazz-tools/src/schema_manager/manager.rs
@@ -1356,13 +1356,16 @@ impl SchemaManager {
             parent_bundle_object_id,
             bundle_object_id,
         };
-        self.query_manager.require_authorization_schema();
         if let Some(current_head) = self.current_permissions_head
             && current_head.version > head.version
         {
             return Ok(());
         }
         self.current_permissions_head = Some(head);
+        // Defer flipping row_policy_mode to Enforcing until apply succeeds —
+        // apply_permissions_head calls set_authorization_schema which sets it.
+        // Flipping earlier denies writes against tables whose explicit policy
+        // lives in the not-yet-arrived bundle.
         if self.apply_permissions_head(head) {
             self.pending_permissions_head = None;
         } else {

--- a/crates/jazz-tools/src/schema_manager/manager.rs
+++ b/crates/jazz-tools/src/schema_manager/manager.rs
@@ -2604,6 +2604,9 @@ mod tests {
         let mut manager =
             SchemaManager::new(SyncManager::new(), schema, test_app_id(), "dev", "main").unwrap();
 
+        // `users` has a select policy but no insert policy. Pre-bundle the gap
+        // is permissive so the insert below succeeds; post-bundle the missing
+        // insert policy must deny it under Enforcing mode.
         let permissions = HashMap::from([(
             TableName::new("users"),
             TablePolicies::new().with_select(PolicyExpr::True),
@@ -2612,7 +2615,7 @@ mod tests {
             schema_hash,
             version: 1,
             parent_bundle_object_id: None,
-            permissions,
+            permissions: permissions.clone(),
         };
         let bundle_object_id = manager.permissions_bundle_object_id(&bundle);
 
@@ -2635,17 +2638,64 @@ mod tests {
         );
 
         let write_context = WriteContext::from_session(Session::new("test-user"));
-        let values = HashMap::from([
+        let pre_bundle_values = HashMap::from([
             ("id".to_string(), Value::Uuid(ObjectId::new())),
             ("name".to_string(), Value::Text("Alice".into())),
             ("email".to_string(), Value::Text("alice@example.com".into())),
         ]);
 
         manager
-            .insert(&mut storage, "users", values, None, Some(&write_context))
+            .insert(
+                &mut storage,
+                "users",
+                pre_bundle_values,
+                None,
+                Some(&write_context),
+            )
             .expect(
                 "writes in the head-before-bundle gap should not be denied by a missing policy",
             );
+
+        manager
+            .process_catalogue_update(
+                bundle_object_id,
+                &manager.permissions_bundle_metadata(),
+                &encode_permissions_bundle(
+                    schema_hash,
+                    bundle.version,
+                    bundle.parent_bundle_object_id,
+                    &permissions,
+                ),
+            )
+            .expect("bundle should process");
+
+        assert!(
+            manager.pending_permissions_head.is_none(),
+            "pending head should clear once the bundle has been applied",
+        );
+
+        let post_bundle_values = HashMap::from([
+            ("id".to_string(), Value::Uuid(ObjectId::new())),
+            ("name".to_string(), Value::Text("Bob".into())),
+            ("email".to_string(), Value::Text("bob@example.com".into())),
+        ]);
+
+        let post_bundle_result = manager.insert(
+            &mut storage,
+            "users",
+            post_bundle_values,
+            None,
+            Some(&write_context),
+        );
+
+        assert!(
+            matches!(
+                post_bundle_result,
+                Err(crate::query_manager::manager::QueryError::PolicyDenied { .. }),
+            ),
+            "after bundle applies, Enforcing mode must deny a write that lacks an explicit \
+             insert policy; got {post_bundle_result:?}",
+        );
     }
 
     #[test]

--- a/crates/jazz-tools/src/schema_manager/manager.rs
+++ b/crates/jazz-tools/src/schema_manager/manager.rs
@@ -2591,6 +2591,61 @@ mod tests {
     }
 
     #[test]
+    fn permissions_head_without_bundle_does_not_deny_local_writes() {
+        use crate::query_manager::session::{Session, WriteContext};
+        use crate::storage::MemoryStorage;
+
+        let schema = make_schema_v2();
+        let schema_hash = SchemaHash::compute(&schema);
+        let mut storage = MemoryStorage::new();
+        let mut manager =
+            SchemaManager::new(SyncManager::new(), schema, test_app_id(), "dev", "main").unwrap();
+
+        let permissions = HashMap::from([(
+            TableName::new("users"),
+            TablePolicies::new().with_select(PolicyExpr::True),
+        )]);
+        let bundle = PermissionsBundleState {
+            schema_hash,
+            version: 1,
+            parent_bundle_object_id: None,
+            permissions,
+        };
+        let bundle_object_id = manager.permissions_bundle_object_id(&bundle);
+
+        manager
+            .process_catalogue_update(
+                manager.permissions_head_object_id(),
+                &manager.permissions_head_metadata(),
+                &encode_permissions_head(
+                    schema_hash,
+                    bundle.version,
+                    bundle.parent_bundle_object_id,
+                    bundle_object_id,
+                ),
+            )
+            .expect("head should process");
+
+        assert!(
+            manager.pending_permissions_head.is_some(),
+            "bundle should be pending while only the head has arrived",
+        );
+
+        let write_context = WriteContext::from_session(Session::new("test-user"));
+        let values = HashMap::from([
+            ("id".to_string(), Value::Uuid(ObjectId::new())),
+            ("name".to_string(), Value::Text("Alice".into())),
+            ("email".to_string(), Value::Text("alice@example.com".into())),
+        ]);
+
+        manager
+            .insert(&mut storage, "users", values, None, Some(&write_context))
+            .expect(
+                "writes in the head-before-bundle gap should not be denied by a missing policy",
+            );
+    }
+
+    #[test]
     fn repersisting_rehydrated_permissions_keeps_unchanged_entries_stable() {
         let app_id = test_app_id();
         let schema = make_schema_v2();


### PR DESCRIPTION
## Summary
- `process_catalogue_permissions_head` called `require_authorization_schema()` unconditionally, flipping `row_policy_mode` to `Enforcing` the moment a permissions head arrived. When the matching bundle hadn't yet been received, `authorization_schema` stayed `None`, and every local insert/update in that window was denied by the missing-explicit-policy check — even writes against tables with wide-open policies.
- `apply_permissions_head` already calls `set_authorization_schema` (which sets Enforcing + the required flag) when the bundle is known, so the earlier call was redundant on success and incorrect during the gap. Dropping it lets the client stay `PermissiveLocal` until the bundle merges in.
- Resolves the world-tour browser flake where `useAll resolves .include() relations and reflects later updates` intermittently failed with `policy denied INSERT on table bands` under CI load (CI runs 26412268975, 26460534994, 26489581001, 26511724023, 26579926475).

## Test plan
- [ ] `cargo test -p jazz-tools` — new `permissions_head_without_bundle_does_not_deny_local_writes` unit test exercises the gap; fails at the red commit, passes at the fix.
- [ ] `pnpm --filter world-tour test`