### PR TITLE
Add mini-jazz-sqlite connection manager

### DIFF
--- a/crates/mini-jazz-sqlite/src/connection.rs
+++ b/crates/mini-jazz-sqlite/src/connection.rs
@@ -1,0 +1,378 @@
+use crate::protocol::{
+    ClientMessage, CloseReason, ProtocolError, ServerMessage, SettlementTier, SubscriptionId,
+};
+use crate::session::{DownstreamSession, UpstreamSession};
+use crate::{BuiltQuery, Error, Result, Runtime};
+use std::cell::RefCell;
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::rc::Rc;
+
+pub trait DownstreamEndpoint {
+    fn send_client_message(&mut self, message: ClientMessage);
+    fn receive_server_message(&mut self) -> Option<ServerMessage>;
+}
+
+pub trait UpstreamEndpoint {
+    fn send_server_message(&mut self, message: ServerMessage);
+    fn receive_client_message(&mut self) -> Option<ClientMessage>;
+}
+
+#[derive(Debug, Default)]
+struct Queues {
+    downstream_to_upstream: VecDeque<ClientMessage>,
+    upstream_to_downstream: VecDeque<ServerMessage>,
+}
+
+#[derive(Clone, Debug)]
+pub struct DownstreamConnection {
+    queues: Rc<RefCell<Queues>>,
+}
+
+#[derive(Clone, Debug)]
+pub struct UpstreamConnection {
+    queues: Rc<RefCell<Queues>>,
+}
+
+pub fn in_memory_connection_pair() -> (DownstreamConnection, UpstreamConnection) {
+    let queues = Rc::new(RefCell::new(Queues::default()));
+    (
+        DownstreamConnection {
+            queues: Rc::clone(&queues),
+        },
+        UpstreamConnection { queues },
+    )
+}
+
+impl DownstreamEndpoint for DownstreamConnection {
+    fn send_client_message(&mut self, message: ClientMessage) {
+        self.queues
+            .borrow_mut()
+            .downstream_to_upstream
+            .push_back(message);
+    }
+
+    fn receive_server_message(&mut self) -> Option<ServerMessage> {
+        self.queues.borrow_mut().upstream_to_downstream.pop_front()
+    }
+}
+
+impl UpstreamEndpoint for UpstreamConnection {
+    fn send_server_message(&mut self, message: ServerMessage) {
+        self.queues
+            .borrow_mut()
+            .upstream_to_downstream
+            .push_back(message);
+    }
+
+    fn receive_client_message(&mut self) -> Option<ClientMessage> {
+        self.queues.borrow_mut().downstream_to_upstream.pop_front()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct DownstreamConnectionSubscription {
+    id: SubscriptionId,
+}
+
+impl DownstreamConnectionSubscription {
+    pub fn id(&self) -> &SubscriptionId {
+        &self.id
+    }
+}
+
+pub struct DownstreamConnectionManager {
+    session: DownstreamSession,
+    pending_subscriptions: BTreeMap<SubscriptionId, PendingSubscription>,
+    dropped_subscriptions: BTreeSet<SubscriptionId>,
+    next_subscription_id: u64,
+}
+
+pub struct UpstreamConnectionManager {
+    session: UpstreamSession,
+}
+
+#[derive(Clone, Debug)]
+struct PendingSubscription {
+    query: BuiltQuery,
+    requested_tier: SettlementTier,
+}
+
+impl DownstreamConnectionManager {
+    pub fn new(
+        session_id: impl Into<String>,
+        node_id: impl Into<String>,
+        schema_fingerprint: impl Into<String>,
+        policy_fingerprint: impl Into<String>,
+    ) -> Self {
+        Self {
+            session: DownstreamSession::new(
+                session_id,
+                node_id,
+                schema_fingerprint,
+                policy_fingerprint,
+            ),
+            pending_subscriptions: BTreeMap::new(),
+            dropped_subscriptions: BTreeSet::new(),
+            next_subscription_id: 0,
+        }
+    }
+
+    pub fn open(&mut self) -> Result<Vec<ClientMessage>> {
+        let mut batch = DownstreamMessageBatch::empty();
+        self.session.open(&mut batch)?;
+        Ok(batch.into_client_messages())
+    }
+
+    pub fn subscribe(
+        &mut self,
+        query: BuiltQuery,
+        requested_tier: SettlementTier,
+    ) -> Result<(DownstreamConnectionSubscription, Vec<ClientMessage>)> {
+        if self.session.is_closed() {
+            return Err(Error::new("session is closed"));
+        }
+        let subscription = self.next_subscription()?;
+        let id = subscription.id.clone();
+        self.dropped_subscriptions.remove(&id);
+
+        if !self.is_ready() {
+            self.pending_subscriptions.insert(
+                id,
+                PendingSubscription {
+                    query,
+                    requested_tier,
+                },
+            );
+            return Ok((subscription, Vec::new()));
+        }
+
+        let mut batch = DownstreamMessageBatch::empty();
+        self.session
+            .subscribe(&mut batch, id, query, requested_tier)?;
+        Ok((subscription, batch.into_client_messages()))
+    }
+
+    pub fn replay(&mut self) -> Result<Vec<ClientMessage>> {
+        if self.session.is_closed() {
+            return Err(Error::new("session is closed"));
+        }
+        if !self.is_ready() {
+            return Ok(Vec::new());
+        }
+
+        let mut batch = DownstreamMessageBatch::empty();
+        self.session.replay(&mut batch)?;
+        Ok(batch.into_client_messages())
+    }
+
+    pub fn receive(
+        &mut self,
+        runtime: &mut Runtime,
+        server_messages: Vec<ServerMessage>,
+    ) -> Result<Vec<ClientMessage>> {
+        let server_messages = self.filter_dropped_server_messages(server_messages);
+        let protocol_error = server_messages.iter().find_map(|message| match message {
+            ServerMessage::Error(error) => Some(error.clone()),
+            _ => None,
+        });
+        let mut batch = DownstreamMessageBatch::with_server_messages(server_messages);
+        self.session.pump(runtime, &mut batch)?;
+        if let Some(error) = protocol_error {
+            return Err(Error::new(format!(
+                "protocol error {}: {}",
+                error.code, error.message
+            )));
+        }
+        if self.is_ready() {
+            self.flush_pending_subscriptions(&mut batch)?;
+        }
+        Ok(batch.into_client_messages())
+    }
+
+    pub fn unsubscribe(&mut self, subscription: &DownstreamConnectionSubscription) {
+        self.pending_subscriptions.remove(subscription.id());
+        self.session.drop_subscription(subscription.id());
+        self.dropped_subscriptions.insert(subscription.id().clone());
+    }
+
+    pub fn is_settled(
+        &self,
+        subscription: &DownstreamConnectionSubscription,
+        tier: SettlementTier,
+    ) -> bool {
+        self.session.is_settled(subscription.id(), tier)
+    }
+
+    pub fn is_ready(&self) -> bool {
+        self.session.is_handshake_established() && !self.session.is_closed()
+    }
+
+    pub fn is_closed(&self) -> bool {
+        self.session.is_closed()
+    }
+
+    pub fn last_error(&self) -> Option<&ProtocolError> {
+        self.session.last_error()
+    }
+
+    pub fn close(&mut self, reason: CloseReason) -> Result<Vec<ClientMessage>> {
+        let mut batch = DownstreamMessageBatch::empty();
+        self.pending_subscriptions.clear();
+        self.session.close(&mut batch, reason)?;
+        Ok(batch.into_client_messages())
+    }
+
+    fn next_subscription(&mut self) -> Result<DownstreamConnectionSubscription> {
+        let id = self.next_subscription_id;
+        self.next_subscription_id = self
+            .next_subscription_id
+            .checked_add(1)
+            .ok_or_else(|| Error::new("subscription id overflow"))?;
+        Ok(DownstreamConnectionSubscription {
+            id: SubscriptionId::new(format!("downstream-subscription-{id}")),
+        })
+    }
+
+    fn flush_pending_subscriptions(&mut self, batch: &mut DownstreamMessageBatch) -> Result<()> {
+        let pending = std::mem::take(&mut self.pending_subscriptions);
+        for (subscription_id, subscription) in pending {
+            self.session.subscribe(
+                batch,
+                subscription_id,
+                subscription.query,
+                subscription.requested_tier,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn filter_dropped_server_messages(
+        &self,
+        server_messages: Vec<ServerMessage>,
+    ) -> Vec<ServerMessage> {
+        server_messages
+            .into_iter()
+            .filter(|message| match message {
+                ServerMessage::Data {
+                    subscription_id: Some(subscription_id),
+                    ..
+                } => !self.dropped_subscriptions.contains(subscription_id),
+                ServerMessage::Settled {
+                    subscription_id, ..
+                } => !self.dropped_subscriptions.contains(subscription_id),
+                ServerMessage::Error(error) => {
+                    error
+                        .subscription_id
+                        .as_ref()
+                        .is_none_or(|subscription_id| {
+                            !self.dropped_subscriptions.contains(subscription_id)
+                        })
+                }
+                ServerMessage::Hello(_)
+                | ServerMessage::Data {
+                    subscription_id: None,
+                    ..
+                }
+                | ServerMessage::Close(_) => true,
+            })
+            .collect()
+    }
+}
+
+impl UpstreamConnectionManager {
+    pub fn new(
+        session_id: impl Into<String>,
+        node_id: impl Into<String>,
+        schema_fingerprint: impl Into<String>,
+        policy_fingerprint: impl Into<String>,
+    ) -> Self {
+        Self {
+            session: UpstreamSession::new(
+                session_id,
+                node_id,
+                schema_fingerprint,
+                policy_fingerprint,
+            ),
+        }
+    }
+
+    pub fn receive(
+        &mut self,
+        runtime: &mut Runtime,
+        client_messages: Vec<ClientMessage>,
+    ) -> Result<Vec<ServerMessage>> {
+        let mut batch = UpstreamMessageBatch::new(client_messages);
+        self.session.pump(runtime, &mut batch)?;
+        Ok(batch.into_server_messages())
+    }
+
+    pub fn is_closed(&self) -> bool {
+        self.session.is_closed()
+    }
+
+    pub fn last_error(&self) -> Option<&ProtocolError> {
+        self.session.last_error()
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct DownstreamMessageBatch {
+    client_messages: Vec<ClientMessage>,
+    server_messages: VecDeque<ServerMessage>,
+}
+
+impl DownstreamMessageBatch {
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub fn with_server_messages(server_messages: Vec<ServerMessage>) -> Self {
+        Self {
+            client_messages: Vec::new(),
+            server_messages: server_messages.into(),
+        }
+    }
+
+    pub fn into_client_messages(self) -> Vec<ClientMessage> {
+        self.client_messages
+    }
+}
+
+impl DownstreamEndpoint for DownstreamMessageBatch {
+    fn send_client_message(&mut self, message: ClientMessage) {
+        self.client_messages.push(message);
+    }
+
+    fn receive_server_message(&mut self) -> Option<ServerMessage> {
+        self.server_messages.pop_front()
+    }
+}
+
+#[derive(Debug)]
+pub struct UpstreamMessageBatch {
+    client_messages: VecDeque<ClientMessage>,
+    server_messages: Vec<ServerMessage>,
+}
+
+impl UpstreamMessageBatch {
+    pub fn new(client_messages: Vec<ClientMessage>) -> Self {
+        Self {
+            client_messages: client_messages.into(),
+            server_messages: Vec::new(),
+        }
+    }
+
+    pub fn into_server_messages(self) -> Vec<ServerMessage> {
+        self.server_messages
+    }
+}
+
+impl UpstreamEndpoint for UpstreamMessageBatch {
+    fn send_server_message(&mut self, message: ServerMessage) {
+        self.server_messages.push(message);
+    }
+
+    fn receive_client_message(&mut self) -> Option<ClientMessage> {
+        self.client_messages.pop_front()
+    }
+}

--- a/crates/mini-jazz-sqlite/src/connection.rs
+++ b/crates/mini-jazz-sqlite/src/connection.rs
@@ -189,10 +189,21 @@ impl DownstreamConnectionManager {
         Ok(batch.into_client_messages())
     }
 
-    pub fn unsubscribe(&mut self, subscription: &DownstreamConnectionSubscription) {
+    pub fn unsubscribe(
+        &mut self,
+        subscription: &DownstreamConnectionSubscription,
+    ) -> Result<Vec<ClientMessage>> {
         self.pending_subscriptions.remove(subscription.id());
+        let was_active = self.session.has_active_subscription(subscription.id());
         self.session.drop_subscription(subscription.id());
         self.dropped_subscriptions.insert(subscription.id().clone());
+        if !was_active || !self.is_ready() {
+            return Ok(Vec::new());
+        }
+
+        let mut batch = DownstreamMessageBatch::empty();
+        self.session.replay(&mut batch)?;
+        Ok(batch.into_client_messages())
     }
 
     pub fn is_settled(

--- a/crates/mini-jazz-sqlite/src/connection.rs
+++ b/crates/mini-jazz-sqlite/src/connection.rs
@@ -310,6 +310,10 @@ impl UpstreamConnectionManager {
         self.session.is_closed()
     }
 
+    pub fn has_active_subscription(&self, subscription_id: &SubscriptionId) -> bool {
+        self.session.has_active_subscription(subscription_id)
+    }
+
     pub fn last_error(&self) -> Option<&ProtocolError> {
         self.session.last_error()
     }

--- a/crates/mini-jazz-sqlite/src/lib.rs
+++ b/crates/mini-jazz-sqlite/src/lib.rs
@@ -1,8 +1,10 @@
 mod branch;
+pub mod connection;
 mod effective;
 mod error;
 mod policy;
 mod projection;
+pub mod protocol;
 mod query;
 mod query_api;
 mod query_predicate;
@@ -11,6 +13,7 @@ mod read_visibility;
 mod rows;
 mod runtime;
 mod schema;
+pub mod session;
 mod stats;
 mod storage;
 mod subscription;

--- a/crates/mini-jazz-sqlite/src/protocol.rs
+++ b/crates/mini-jazz-sqlite/src/protocol.rs
@@ -1,0 +1,152 @@
+use crate::sync::Bundle;
+use crate::BuiltQuery;
+use serde::{Deserialize, Serialize};
+
+pub const SUPPORTED_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion(1);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct ProtocolVersion(pub u32);
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct SessionId(String);
+
+impl SessionId {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct MessageId(pub u64);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct ReplayCursor(pub u64);
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct SubscriptionId(String);
+
+impl SubscriptionId {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum SettlementTier {
+    Local,
+    Edge,
+    Global,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClientHello {
+    pub protocol_version: ProtocolVersion,
+    pub session_id: SessionId,
+    pub node_id: String,
+    pub schema_fingerprint: String,
+    pub policy_fingerprint: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ServerHello {
+    pub protocol_version: ProtocolVersion,
+    pub session_id: SessionId,
+    pub node_id: String,
+    pub capabilities: ProtocolCapabilities,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProtocolCapabilities {
+    pub replay: bool,
+    pub acknowledgements: bool,
+    pub query_settlement: bool,
+}
+
+impl Default for ProtocolCapabilities {
+    fn default() -> Self {
+        Self {
+            replay: true,
+            acknowledgements: true,
+            query_settlement: true,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplaySubscription {
+    pub subscription_id: SubscriptionId,
+    pub query: BuiltQuery,
+    pub requested_tier: SettlementTier,
+    pub last_applied_cursor: Option<ReplayCursor>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProtocolError {
+    pub code: String,
+    pub message: String,
+    pub subscription_id: Option<SubscriptionId>,
+    pub message_id: Option<MessageId>,
+    pub retry_hint: RetryHint,
+}
+
+impl ProtocolError {
+    pub fn new(code: impl Into<String>, message: impl Into<String>, retry_hint: RetryHint) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+            subscription_id: None,
+            message_id: None,
+            retry_hint,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RetryHint {
+    Retryable,
+    ReplayRequired,
+    Fatal,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CloseReason {
+    ClientClosed,
+    ProtocolError,
+    TransportFailed,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum ClientMessage {
+    Hello(ClientHello),
+    Subscribe {
+        subscription_id: SubscriptionId,
+        query: BuiltQuery,
+        requested_tier: SettlementTier,
+    },
+    Replay {
+        subscriptions: Vec<ReplaySubscription>,
+    },
+    Ack {
+        message_id: MessageId,
+        cursor: Option<ReplayCursor>,
+    },
+    Close(CloseReason),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum ServerMessage {
+    Hello(ServerHello),
+    Data {
+        message_id: MessageId,
+        subscription_id: Option<SubscriptionId>,
+        cursor: ReplayCursor,
+        bundle: Bundle,
+    },
+    Settled {
+        subscription_id: SubscriptionId,
+        tier: SettlementTier,
+        cursor: ReplayCursor,
+    },
+    Error(ProtocolError),
+    Close(CloseReason),
+}

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -4346,6 +4346,10 @@ impl Runtime {
         self.schema.policy_fingerprint()
     }
 
+    pub fn local_schema_fingerprint(&self) -> String {
+        self.schema.compatibility_fingerprint()
+    }
+
     fn query_context(&self) -> query::QueryContext<'_> {
         query::QueryContext {
             conn: &self.conn,

--- a/crates/mini-jazz-sqlite/src/session.rs
+++ b/crates/mini-jazz-sqlite/src/session.rs
@@ -1,0 +1,644 @@
+use crate::connection::{DownstreamEndpoint, UpstreamEndpoint};
+use crate::protocol::{
+    ClientHello, ClientMessage, CloseReason, MessageId, ProtocolCapabilities, ProtocolError,
+    ProtocolVersion, ReplayCursor, ReplaySubscription, RetryHint, ServerHello, ServerMessage,
+    SessionId, SettlementTier, SubscriptionId, SUPPORTED_PROTOCOL_VERSION,
+};
+use crate::{BuiltQuery, Error, Result, Runtime};
+use std::collections::{BTreeMap, BTreeSet};
+
+#[derive(Clone, Debug)]
+struct ActiveSubscription {
+    query: BuiltQuery,
+    requested_tier: SettlementTier,
+    last_applied_cursor: Option<ReplayCursor>,
+}
+
+pub struct DownstreamSession {
+    hello: ClientHello,
+    awaiting_server_hello: bool,
+    upstream_hello: Option<ServerHello>,
+    active_subscriptions: BTreeMap<SubscriptionId, ActiveSubscription>,
+    settled: BTreeMap<(SubscriptionId, SettlementTier), ReplayCursor>,
+    closed: bool,
+    last_error: Option<ProtocolError>,
+}
+
+pub struct UpstreamSession {
+    hello: ServerHello,
+    schema_fingerprint: String,
+    policy_fingerprint: String,
+    peer_hello: Option<ClientHello>,
+    active_subscriptions: BTreeMap<SubscriptionId, ActiveSubscription>,
+    pending_messages: BTreeMap<MessageId, (SubscriptionId, ReplayCursor)>,
+    last_acknowledged: BTreeMap<SubscriptionId, ReplayCursor>,
+    last_error: Option<ProtocolError>,
+    next_message_id: u64,
+    next_cursor: u64,
+    closed: bool,
+}
+
+impl DownstreamSession {
+    pub fn new(
+        session_id: impl Into<String>,
+        node_id: impl Into<String>,
+        schema_fingerprint: impl Into<String>,
+        policy_fingerprint: impl Into<String>,
+    ) -> Self {
+        Self::new_with_protocol_version(
+            session_id,
+            node_id,
+            SUPPORTED_PROTOCOL_VERSION.0,
+            schema_fingerprint,
+            policy_fingerprint,
+        )
+    }
+
+    pub fn new_with_protocol_version(
+        session_id: impl Into<String>,
+        node_id: impl Into<String>,
+        protocol_version: u32,
+        schema_fingerprint: impl Into<String>,
+        policy_fingerprint: impl Into<String>,
+    ) -> Self {
+        Self {
+            hello: ClientHello {
+                protocol_version: ProtocolVersion(protocol_version),
+                session_id: SessionId::new(session_id),
+                node_id: node_id.into(),
+                schema_fingerprint: schema_fingerprint.into(),
+                policy_fingerprint: policy_fingerprint.into(),
+            },
+            awaiting_server_hello: false,
+            upstream_hello: None,
+            active_subscriptions: BTreeMap::new(),
+            settled: BTreeMap::new(),
+            closed: false,
+            last_error: None,
+        }
+    }
+
+    pub fn open(&mut self, conn: &mut impl DownstreamEndpoint) -> Result<()> {
+        ensure_open(self.closed)?;
+        self.upstream_hello = None;
+        self.awaiting_server_hello = true;
+        self.settled.clear();
+        self.last_error = None;
+        conn.send_client_message(ClientMessage::Hello(self.hello.clone()));
+        Ok(())
+    }
+
+    pub fn subscribe(
+        &mut self,
+        conn: &mut impl DownstreamEndpoint,
+        subscription_id: SubscriptionId,
+        query: BuiltQuery,
+        requested_tier: SettlementTier,
+    ) -> Result<()> {
+        ensure_open(self.closed)?;
+        ensure_handshake(self.upstream_hello.is_some())?;
+        if self.active_subscriptions.contains_key(&subscription_id) {
+            return Err(Error::new("subscription is already active"));
+        }
+        self.active_subscriptions.insert(
+            subscription_id.clone(),
+            ActiveSubscription {
+                query: query.clone(),
+                requested_tier,
+                last_applied_cursor: None,
+            },
+        );
+        self.settled
+            .remove(&(subscription_id.clone(), requested_tier));
+        conn.send_client_message(ClientMessage::Subscribe {
+            subscription_id,
+            query,
+            requested_tier,
+        });
+        Ok(())
+    }
+
+    pub fn replay(&mut self, conn: &mut impl DownstreamEndpoint) -> Result<()> {
+        ensure_open(self.closed)?;
+        ensure_handshake(self.upstream_hello.is_some())?;
+        let subscriptions = self
+            .active_subscriptions
+            .iter()
+            .map(|(subscription_id, subscription)| ReplaySubscription {
+                subscription_id: subscription_id.clone(),
+                query: subscription.query.clone(),
+                requested_tier: subscription.requested_tier,
+                last_applied_cursor: subscription.last_applied_cursor,
+            })
+            .collect();
+        conn.send_client_message(ClientMessage::Replay { subscriptions });
+        Ok(())
+    }
+
+    pub fn close(&mut self, conn: &mut impl DownstreamEndpoint, reason: CloseReason) -> Result<()> {
+        ensure_open(self.closed)?;
+        self.clear_session_state();
+        self.closed = true;
+        conn.send_client_message(ClientMessage::Close(reason));
+        Ok(())
+    }
+
+    pub fn pump(
+        &mut self,
+        runtime: &mut Runtime,
+        conn: &mut impl DownstreamEndpoint,
+    ) -> Result<()> {
+        while let Some(message) = conn.receive_server_message() {
+            if self.closed {
+                break;
+            }
+            match message {
+                ServerMessage::Hello(hello) => {
+                    self.receive_server_hello(hello, conn);
+                }
+                ServerMessage::Data {
+                    message_id,
+                    subscription_id,
+                    cursor,
+                    bundle,
+                } => {
+                    if self.upstream_hello.is_none() {
+                        self.close_with_error(
+                            conn,
+                            "protocol_error",
+                            "handshake is not established",
+                        );
+                        return Err(Error::new("handshake is not established"));
+                    }
+                    if subscription_id.as_ref().is_some_and(|subscription_id| {
+                        !self.active_subscriptions.contains_key(subscription_id)
+                    }) {
+                        self.close_with_error(conn, "unknown_subscription", "unknown subscription");
+                        return Err(Error::new("unknown subscription"));
+                    }
+                    if let Err(error) = runtime.apply_bundle(&bundle) {
+                        self.close_with_error(conn, "bundle_apply_failed", &error.to_string());
+                        return Err(error);
+                    }
+                    if let Some(subscription_id) = subscription_id {
+                        let advanced = {
+                            let subscription = self
+                                .active_subscriptions
+                                .get_mut(&subscription_id)
+                                .expect("validated active subscription before bundle apply");
+                            let previous_cursor = subscription.last_applied_cursor;
+                            let next_cursor = previous_cursor
+                                .map(|current| current.max(cursor))
+                                .unwrap_or(cursor);
+                            subscription.last_applied_cursor = Some(next_cursor);
+                            Some(next_cursor) != previous_cursor
+                        };
+                        if advanced {
+                            self.settled.retain(|(settled_subscription_id, _), _| {
+                                settled_subscription_id != &subscription_id
+                            });
+                        }
+                    }
+                    conn.send_client_message(ClientMessage::Ack {
+                        message_id,
+                        cursor: Some(cursor),
+                    });
+                }
+                ServerMessage::Settled {
+                    subscription_id,
+                    tier,
+                    cursor,
+                } => {
+                    if self.upstream_hello.is_none() {
+                        self.close_with_error(
+                            conn,
+                            "protocol_error",
+                            "handshake is not established",
+                        );
+                        return Err(Error::new("handshake is not established"));
+                    }
+                    if self
+                        .active_subscriptions
+                        .get(&subscription_id)
+                        .is_some_and(|subscription| {
+                            subscription.requested_tier == tier
+                                && subscription.last_applied_cursor == Some(cursor)
+                        })
+                    {
+                        self.settled.insert((subscription_id, tier), cursor);
+                    }
+                }
+                ServerMessage::Error(error) => {
+                    let fatal = error.retry_hint == RetryHint::Fatal;
+                    if !fatal {
+                        if let Some(subscription_id) = &error.subscription_id {
+                            self.active_subscriptions.remove(subscription_id);
+                            self.settled.retain(|(settled_subscription_id, _), _| {
+                                settled_subscription_id != subscription_id
+                            });
+                        }
+                    }
+                    self.last_error = Some(error);
+                    if fatal {
+                        self.clear_session_state();
+                        self.closed = true;
+                        break;
+                    }
+                }
+                ServerMessage::Close(_) => {
+                    self.clear_session_state();
+                    self.closed = true;
+                    break;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn is_settled(&self, subscription_id: &SubscriptionId, tier: SettlementTier) -> bool {
+        self.active_subscriptions
+            .get(subscription_id)
+            .is_some_and(|subscription| {
+                if subscription.requested_tier != tier {
+                    return false;
+                }
+                let Some(cursor) = subscription.last_applied_cursor else {
+                    return false;
+                };
+                self.settled.get(&(subscription_id.clone(), tier)).copied() == Some(cursor)
+            })
+    }
+
+    pub fn has_active_subscription(&self, subscription_id: &SubscriptionId) -> bool {
+        self.active_subscriptions.contains_key(subscription_id)
+    }
+
+    pub fn drop_subscription(&mut self, subscription_id: &SubscriptionId) {
+        self.active_subscriptions.remove(subscription_id);
+        self.settled
+            .retain(|(settled_subscription_id, _), _| settled_subscription_id != subscription_id);
+    }
+
+    pub fn is_handshake_established(&self) -> bool {
+        self.upstream_hello.is_some()
+    }
+
+    pub fn is_closed(&self) -> bool {
+        self.closed
+    }
+
+    pub fn last_error(&self) -> Option<&ProtocolError> {
+        self.last_error.as_ref()
+    }
+
+    fn receive_server_hello(&mut self, hello: ServerHello, conn: &mut impl DownstreamEndpoint) {
+        if !self.awaiting_server_hello {
+            self.close_with_error(conn, "protocol_error", "unexpected server hello");
+            return;
+        }
+        if hello.protocol_version != SUPPORTED_PROTOCOL_VERSION {
+            self.close_with_error(
+                conn,
+                "unsupported_protocol_version",
+                "unsupported protocol version",
+            );
+            return;
+        }
+        if !hello.capabilities.replay
+            || !hello.capabilities.acknowledgements
+            || !hello.capabilities.query_settlement
+        {
+            self.close_with_error(
+                conn,
+                "unsupported_capability",
+                "server is missing a required protocol capability",
+            );
+            return;
+        }
+        self.awaiting_server_hello = false;
+        self.upstream_hello = Some(hello);
+    }
+
+    fn close_with_error(&mut self, conn: &mut impl DownstreamEndpoint, code: &str, message: &str) {
+        self.last_error = Some(ProtocolError::new(code, message, RetryHint::Fatal));
+        self.clear_session_state();
+        self.closed = true;
+        conn.send_client_message(ClientMessage::Close(CloseReason::ProtocolError));
+    }
+
+    fn clear_session_state(&mut self) {
+        self.active_subscriptions.clear();
+        self.settled.clear();
+    }
+}
+
+impl UpstreamSession {
+    pub fn new(
+        session_id: impl Into<String>,
+        node_id: impl Into<String>,
+        schema_fingerprint: impl Into<String>,
+        policy_fingerprint: impl Into<String>,
+    ) -> Self {
+        Self {
+            hello: ServerHello {
+                protocol_version: SUPPORTED_PROTOCOL_VERSION,
+                session_id: SessionId::new(session_id),
+                node_id: node_id.into(),
+                capabilities: ProtocolCapabilities::default(),
+            },
+            schema_fingerprint: schema_fingerprint.into(),
+            policy_fingerprint: policy_fingerprint.into(),
+            peer_hello: None,
+            active_subscriptions: BTreeMap::new(),
+            pending_messages: BTreeMap::new(),
+            last_acknowledged: BTreeMap::new(),
+            last_error: None,
+            next_message_id: 1,
+            next_cursor: 1,
+            closed: false,
+        }
+    }
+
+    pub fn pump(&mut self, runtime: &mut Runtime, conn: &mut impl UpstreamEndpoint) -> Result<()> {
+        while let Some(message) = conn.receive_client_message() {
+            if self.closed {
+                break;
+            }
+            match message {
+                ClientMessage::Hello(hello) => self.receive_hello(hello, conn)?,
+                ClientMessage::Subscribe {
+                    subscription_id,
+                    query,
+                    requested_tier,
+                } => {
+                    ensure_open(self.closed)?;
+                    if self.peer_hello.is_none() {
+                        self.close_with_error(
+                            conn,
+                            "protocol_error",
+                            "handshake is not established",
+                        );
+                        continue;
+                    }
+                    if self.active_subscriptions.contains_key(&subscription_id) {
+                        self.send_protocol_error(
+                            conn,
+                            "duplicate_subscription",
+                            "subscription is already active",
+                            Some(subscription_id),
+                            None,
+                            RetryHint::Retryable,
+                        );
+                        continue;
+                    }
+                    if let Err(error) = self.send_subscription_data(
+                        runtime,
+                        conn,
+                        subscription_id.clone(),
+                        query,
+                        requested_tier,
+                    ) {
+                        self.send_scoped_error(conn, "query_rejected", error, subscription_id);
+                    }
+                }
+                ClientMessage::Replay { subscriptions } => {
+                    ensure_open(self.closed)?;
+                    if self.peer_hello.is_none() {
+                        self.close_with_error(
+                            conn,
+                            "protocol_error",
+                            "handshake is not established",
+                        );
+                        continue;
+                    }
+                    let replay_subscription_ids = subscriptions
+                        .iter()
+                        .map(|subscription| subscription.subscription_id.clone())
+                        .collect::<BTreeSet<_>>();
+                    self.active_subscriptions.retain(|subscription_id, _| {
+                        replay_subscription_ids.contains(subscription_id)
+                    });
+                    self.pending_messages.retain(|_, (subscription_id, _)| {
+                        replay_subscription_ids.contains(subscription_id)
+                    });
+                    self.last_acknowledged.retain(|subscription_id, _| {
+                        replay_subscription_ids.contains(subscription_id)
+                    });
+                    for subscription in subscriptions {
+                        if let Err(error) = self.send_subscription_data(
+                            runtime,
+                            conn,
+                            subscription.subscription_id.clone(),
+                            subscription.query,
+                            subscription.requested_tier,
+                        ) {
+                            self.send_scoped_error(
+                                conn,
+                                "query_rejected",
+                                error,
+                                subscription.subscription_id,
+                            );
+                        }
+                    }
+                }
+                ClientMessage::Ack {
+                    message_id,
+                    cursor: _,
+                } => {
+                    if self.peer_hello.is_none() {
+                        self.close_with_error(
+                            conn,
+                            "protocol_error",
+                            "handshake is not established",
+                        );
+                        continue;
+                    }
+                    if let Some((subscription_id, pending_cursor)) =
+                        self.pending_messages.remove(&message_id)
+                    {
+                        let acknowledged_cursor = self
+                            .last_acknowledged
+                            .get(&subscription_id)
+                            .copied()
+                            .map(|current| current.max(pending_cursor))
+                            .unwrap_or(pending_cursor);
+                        self.last_acknowledged
+                            .insert(subscription_id, acknowledged_cursor);
+                    }
+                }
+                ClientMessage::Close(_) => {
+                    self.clear_session_state();
+                    self.closed = true;
+                    break;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn last_acknowledged_cursor(
+        &self,
+        subscription_id: &SubscriptionId,
+    ) -> Option<ReplayCursor> {
+        self.last_acknowledged.get(subscription_id).copied()
+    }
+
+    pub fn last_error(&self) -> Option<&ProtocolError> {
+        self.last_error.as_ref()
+    }
+
+    pub fn is_closed(&self) -> bool {
+        self.closed
+    }
+
+    fn receive_hello(
+        &mut self,
+        hello: ClientHello,
+        conn: &mut impl UpstreamEndpoint,
+    ) -> Result<()> {
+        if hello.protocol_version != SUPPORTED_PROTOCOL_VERSION {
+            self.close_with_error(
+                conn,
+                "unsupported_protocol_version",
+                "unsupported protocol version",
+            );
+            return Ok(());
+        }
+        if hello.schema_fingerprint != self.schema_fingerprint {
+            self.close_with_error(
+                conn,
+                "incompatible_schema_fingerprint",
+                "incompatible schema fingerprint",
+            );
+            return Ok(());
+        }
+        if hello.policy_fingerprint != self.policy_fingerprint {
+            self.close_with_error(
+                conn,
+                "incompatible_policy_fingerprint",
+                "incompatible policy fingerprint",
+            );
+            return Ok(());
+        }
+        self.clear_session_state();
+        self.last_error = None;
+        self.peer_hello = Some(hello);
+        conn.send_server_message(ServerMessage::Hello(self.hello.clone()));
+        Ok(())
+    }
+
+    fn send_subscription_data(
+        &mut self,
+        runtime: &Runtime,
+        conn: &mut impl UpstreamEndpoint,
+        subscription_id: SubscriptionId,
+        query: BuiltQuery,
+        requested_tier: SettlementTier,
+    ) -> Result<()> {
+        let bundle = runtime.export_query(query.clone())?;
+        let cursor = self.next_cursor();
+        let message_id = self.next_message_id();
+        self.active_subscriptions.insert(
+            subscription_id.clone(),
+            ActiveSubscription {
+                query,
+                requested_tier,
+                last_applied_cursor: Some(cursor),
+            },
+        );
+        self.pending_messages
+            .insert(message_id, (subscription_id.clone(), cursor));
+        conn.send_server_message(ServerMessage::Data {
+            message_id,
+            subscription_id: Some(subscription_id.clone()),
+            cursor,
+            bundle,
+        });
+        if requested_tier == SettlementTier::Local {
+            conn.send_server_message(ServerMessage::Settled {
+                subscription_id,
+                tier: SettlementTier::Local,
+                cursor,
+            });
+        }
+        Ok(())
+    }
+
+    fn close_with_error(&mut self, conn: &mut impl UpstreamEndpoint, code: &str, message: &str) {
+        self.clear_session_state();
+        self.closed = true;
+        let error = ProtocolError::new(code, message, RetryHint::Fatal);
+        self.last_error = Some(error.clone());
+        conn.send_server_message(ServerMessage::Error(error));
+        conn.send_server_message(ServerMessage::Close(CloseReason::ProtocolError));
+    }
+
+    fn send_protocol_error(
+        &mut self,
+        conn: &mut impl UpstreamEndpoint,
+        code: &str,
+        message: impl Into<String>,
+        subscription_id: Option<SubscriptionId>,
+        message_id: Option<MessageId>,
+        retry_hint: RetryHint,
+    ) {
+        let protocol_error = ProtocolError {
+            code: code.to_owned(),
+            message: message.into(),
+            subscription_id,
+            message_id,
+            retry_hint,
+        };
+        self.last_error = Some(protocol_error.clone());
+        conn.send_server_message(ServerMessage::Error(protocol_error));
+    }
+
+    fn send_scoped_error(
+        &mut self,
+        conn: &mut impl UpstreamEndpoint,
+        code: &str,
+        error: Error,
+        subscription_id: SubscriptionId,
+    ) {
+        self.send_protocol_error(
+            conn,
+            code,
+            error.to_string(),
+            Some(subscription_id),
+            None,
+            RetryHint::Retryable,
+        );
+    }
+
+    fn next_message_id(&mut self) -> MessageId {
+        let id = self.next_message_id;
+        self.next_message_id += 1;
+        MessageId(id)
+    }
+
+    fn next_cursor(&mut self) -> ReplayCursor {
+        let cursor = self.next_cursor;
+        self.next_cursor += 1;
+        ReplayCursor(cursor)
+    }
+
+    fn clear_session_state(&mut self) {
+        self.active_subscriptions.clear();
+        self.pending_messages.clear();
+        self.last_acknowledged.clear();
+    }
+}
+
+fn ensure_open(closed: bool) -> Result<()> {
+    if closed {
+        return Err(Error::new("session is closed"));
+    }
+    Ok(())
+}
+
+fn ensure_handshake(established: bool) -> Result<()> {
+    if !established {
+        return Err(Error::new("handshake is not established"));
+    }
+    Ok(())
+}

--- a/crates/mini-jazz-sqlite/src/session.rs
+++ b/crates/mini-jazz-sqlite/src/session.rs
@@ -391,6 +391,17 @@ impl UpstreamSession {
                         );
                         continue;
                     }
+                    if requested_tier != SettlementTier::Local {
+                        self.send_protocol_error(
+                            conn,
+                            "unsupported_settlement_tier",
+                            "only local settlement is supported",
+                            Some(subscription_id),
+                            None,
+                            RetryHint::Retryable,
+                        );
+                        continue;
+                    }
                     if let Err(error) = self.send_subscription_data(
                         runtime,
                         conn,
@@ -425,6 +436,17 @@ impl UpstreamSession {
                         replay_subscription_ids.contains(subscription_id)
                     });
                     for subscription in subscriptions {
+                        if subscription.requested_tier != SettlementTier::Local {
+                            self.send_protocol_error(
+                                conn,
+                                "unsupported_settlement_tier",
+                                "only local settlement is supported",
+                                Some(subscription.subscription_id),
+                                None,
+                                RetryHint::Retryable,
+                            );
+                            continue;
+                        }
                         if let Err(error) = self.send_subscription_data(
                             runtime,
                             conn,
@@ -481,6 +503,10 @@ impl UpstreamSession {
         subscription_id: &SubscriptionId,
     ) -> Option<ReplayCursor> {
         self.last_acknowledged.get(subscription_id).copied()
+    }
+
+    pub fn has_active_subscription(&self, subscription_id: &SubscriptionId) -> bool {
+        self.active_subscriptions.contains_key(subscription_id)
     }
 
     pub fn last_error(&self) -> Option<&ProtocolError> {

--- a/crates/mini-jazz-sqlite/tests/whole_system.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system.rs
@@ -10,6 +10,8 @@ use support::FixtureRuntimeExt;
 
 #[path = "whole_system/branches.rs"]
 mod branches;
+#[path = "whole_system/connection.rs"]
+mod connection;
 #[path = "whole_system/generic_schema.rs"]
 mod generic_schema;
 #[path = "whole_system/invariant_coverage.rs"]

--- a/crates/mini-jazz-sqlite/tests/whole_system/connection.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/connection.rs
@@ -1,0 +1,1926 @@
+use super::support::{FixtureRuntimeExt, Harness};
+use mini_jazz_sqlite::connection::{
+    in_memory_connection_pair, DownstreamEndpoint, UpstreamEndpoint,
+};
+use mini_jazz_sqlite::connection::{DownstreamConnectionManager, UpstreamConnectionManager};
+use mini_jazz_sqlite::protocol::{
+    ClientHello, ClientMessage, CloseReason, MessageId, ProtocolCapabilities, ProtocolError,
+    ProtocolVersion, ReplayCursor, ReplaySubscription, RetryHint, ServerHello, ServerMessage,
+    SessionId, SettlementTier, SubscriptionId,
+};
+use mini_jazz_sqlite::session::{DownstreamSession, UpstreamSession};
+use mini_jazz_sqlite::{BuiltQuery, QueryCondition, QueryConditionOp};
+use serde_json::json;
+
+#[test]
+fn connection_subscribe_delivers_initial_query_and_settled() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    worker.create_project("project-1", "Launch notes").unwrap();
+    worker
+        .create_todo("todo-1", "Draft protocol", false, "project-1")
+        .unwrap();
+    worker
+        .create_todo("todo-2", "Archived thought", true, "project-1")
+        .unwrap();
+
+    let query = open_todos_query();
+    let subscription_id = SubscriptionId::new("open-todos");
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut downstream = DownstreamSession::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamSession::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    downstream.open(&mut downstream_conn).unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+
+    downstream
+        .subscribe(
+            &mut downstream_conn,
+            subscription_id.clone(),
+            query.clone(),
+            SettlementTier::Local,
+        )
+        .unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+
+    assert!(downstream.is_settled(&subscription_id, SettlementTier::Local));
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    assert_eq!(
+        upstream.last_acknowledged_cursor(&subscription_id),
+        Some(ReplayCursor(1))
+    );
+    assert_eq!(row_ids(tab.query(query).unwrap()), vec!["todo-1"]);
+}
+
+#[test]
+fn connection_edge_subscription_receives_rows_without_false_settlement() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    worker.create_project("project-1", "Launch notes").unwrap();
+    worker
+        .create_todo("todo-1", "Draft protocol", false, "project-1")
+        .unwrap();
+
+    let query = open_todos_query();
+    let subscription_id = SubscriptionId::new("open-todos");
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut downstream = DownstreamSession::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamSession::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    downstream.open(&mut downstream_conn).unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+    downstream
+        .subscribe(
+            &mut downstream_conn,
+            subscription_id.clone(),
+            query.clone(),
+            SettlementTier::Edge,
+        )
+        .unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+
+    assert_eq!(row_ids(tab.query(query).unwrap()), vec!["todo-1"]);
+    assert!(!downstream.is_settled(&subscription_id, SettlementTier::Local));
+    assert!(!downstream.is_settled(&subscription_id, SettlementTier::Edge));
+    assert!(!downstream.is_settled(&subscription_id, SettlementTier::Global));
+}
+
+#[test]
+fn connection_new_subscription_data_invalidates_previous_settlement() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    worker.create_project("project-1", "Launch notes").unwrap();
+    worker
+        .create_todo("todo-1", "Draft protocol", false, "project-1")
+        .unwrap();
+
+    let query = open_todos_query();
+    let subscription_id = SubscriptionId::new("open-todos");
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut downstream = DownstreamSession::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamSession::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    downstream.open(&mut downstream_conn).unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+    downstream
+        .subscribe(
+            &mut downstream_conn,
+            subscription_id.clone(),
+            query.clone(),
+            SettlementTier::Local,
+        )
+        .unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+    assert!(downstream.is_settled(&subscription_id, SettlementTier::Local));
+
+    worker
+        .create_todo("todo-2", "Invalidate settlement", false, "project-1")
+        .unwrap();
+    let bundle = worker.export_query(query.clone()).unwrap();
+    upstream_conn.send_server_message(ServerMessage::Data {
+        message_id: MessageId(2),
+        subscription_id: Some(subscription_id.clone()),
+        cursor: ReplayCursor(2),
+        bundle,
+    });
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+
+    assert_eq!(
+        sorted_row_ids(tab.query(query).unwrap()),
+        vec!["todo-1", "todo-2"]
+    );
+    assert!(!downstream.is_settled(&subscription_id, SettlementTier::Local));
+}
+
+#[test]
+fn connection_replay_restores_active_subscription_after_reconnect() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    worker.create_project("project-1", "Launch notes").unwrap();
+    worker
+        .create_todo("todo-1", "Draft protocol", false, "project-1")
+        .unwrap();
+
+    let query = open_todos_query();
+    let subscription_id = SubscriptionId::new("open-todos");
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut downstream = DownstreamSession::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamSession::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    downstream.open(&mut downstream_conn).unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+    downstream
+        .subscribe(
+            &mut downstream_conn,
+            subscription_id.clone(),
+            query.clone(),
+            SettlementTier::Local,
+        )
+        .unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+    assert_eq!(row_ids(tab.query(query.clone()).unwrap()), vec!["todo-1"]);
+
+    worker
+        .create_todo("todo-2", "Reconnect protocol", false, "project-1")
+        .unwrap();
+
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut upstream = UpstreamSession::new(
+        "worker-session-reconnected",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+    downstream.open(&mut downstream_conn).unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+    downstream.replay(&mut downstream_conn).unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+
+    assert!(downstream.is_settled(&subscription_id, SettlementTier::Local));
+    assert_eq!(
+        sorted_row_ids(tab.query(query).unwrap()),
+        vec!["todo-1", "todo-2"]
+    );
+}
+
+#[test]
+fn connection_close_drops_session_interest_without_deleting_cached_rows() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    worker.create_project("project-1", "Launch notes").unwrap();
+    worker
+        .create_todo("todo-1", "Draft protocol", false, "project-1")
+        .unwrap();
+
+    let query = open_todos_query();
+    let subscription_id = SubscriptionId::new("open-todos");
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut downstream = DownstreamSession::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamSession::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    downstream.open(&mut downstream_conn).unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+    downstream
+        .subscribe(
+            &mut downstream_conn,
+            subscription_id.clone(),
+            query.clone(),
+            SettlementTier::Local,
+        )
+        .unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+
+    downstream
+        .close(&mut downstream_conn, CloseReason::ClientClosed)
+        .unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+
+    assert!(!downstream.has_active_subscription(&subscription_id));
+    assert!(downstream.is_closed());
+    assert!(!downstream.is_settled(&subscription_id, SettlementTier::Local));
+    assert_eq!(row_ids(tab.query(query).unwrap()), vec!["todo-1"]);
+}
+
+#[test]
+fn connection_requires_handshake_before_subscribe() {
+    let harness = Harness::new();
+    let tab = harness.memory("alice-tab", "alice").unwrap();
+    let query = open_todos_query();
+    let subscription_id = SubscriptionId::new("open-todos");
+    let (mut downstream_conn, _) = in_memory_connection_pair();
+    let mut downstream = DownstreamSession::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+
+    let err = downstream
+        .subscribe(
+            &mut downstream_conn,
+            subscription_id,
+            query,
+            SettlementTier::Local,
+        )
+        .unwrap_err();
+
+    assert!(err.to_string().contains("handshake is not established"));
+}
+
+#[test]
+fn connection_rejects_duplicate_active_subscription_id() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    let query = open_todos_query();
+    let subscription_id = SubscriptionId::new("open-todos");
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut downstream = DownstreamSession::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamSession::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    downstream.open(&mut downstream_conn).unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+    downstream
+        .subscribe(
+            &mut downstream_conn,
+            subscription_id.clone(),
+            query.clone(),
+            SettlementTier::Local,
+        )
+        .unwrap();
+    let err = downstream
+        .subscribe(
+            &mut downstream_conn,
+            subscription_id,
+            query,
+            SettlementTier::Local,
+        )
+        .unwrap_err();
+
+    assert!(err.to_string().contains("subscription is already active"));
+    assert!(matches!(
+        upstream_conn.receive_client_message(),
+        Some(ClientMessage::Subscribe { .. })
+    ));
+    assert!(upstream_conn.receive_client_message().is_none());
+}
+
+#[test]
+fn connection_subscription_is_not_settled_before_data_arrives() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    let query = open_todos_query();
+    let subscription_id = SubscriptionId::new("open-todos");
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut downstream = DownstreamSession::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamSession::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    downstream.open(&mut downstream_conn).unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+    downstream
+        .subscribe(
+            &mut downstream_conn,
+            subscription_id.clone(),
+            query,
+            SettlementTier::Local,
+        )
+        .unwrap();
+
+    assert!(!downstream.is_settled(&subscription_id, SettlementTier::Local));
+}
+
+#[test]
+fn connection_upstream_rejects_duplicate_subscribe_id() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    worker.create_project("project-1", "Launch notes").unwrap();
+    worker
+        .create_todo("todo-1", "Draft protocol", false, "project-1")
+        .unwrap();
+
+    let query = open_todos_query();
+    let subscription_id = SubscriptionId::new("open-todos");
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut downstream = DownstreamSession::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamSession::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    downstream.open(&mut downstream_conn).unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+    downstream
+        .subscribe(
+            &mut downstream_conn,
+            subscription_id.clone(),
+            query.clone(),
+            SettlementTier::Local,
+        )
+        .unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    downstream_conn.send_client_message(ClientMessage::Subscribe {
+        subscription_id: subscription_id.clone(),
+        query,
+        requested_tier: SettlementTier::Local,
+    });
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+
+    let ServerMessage::Data {
+        message_id,
+        subscription_id: first_data_subscription_id,
+        ..
+    } = downstream_conn
+        .receive_server_message()
+        .expect("first data frame")
+    else {
+        panic!("expected first data frame");
+    };
+    assert_eq!(message_id, MessageId(1));
+    assert_eq!(first_data_subscription_id, Some(subscription_id.clone()));
+    let ServerMessage::Settled {
+        subscription_id: first_settled_subscription_id,
+        ..
+    } = downstream_conn
+        .receive_server_message()
+        .expect("first settled frame")
+    else {
+        panic!("expected first settled frame");
+    };
+    assert_eq!(first_settled_subscription_id, subscription_id.clone());
+    let ServerMessage::Error(error) = downstream_conn
+        .receive_server_message()
+        .expect("duplicate subscribe error")
+    else {
+        panic!("expected duplicate subscribe error");
+    };
+    assert_eq!(error.code, "duplicate_subscription");
+    assert_eq!(error.subscription_id, Some(subscription_id));
+    assert!(downstream_conn.receive_server_message().is_none());
+}
+
+#[test]
+fn connection_rejects_settled_before_handshake() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let subscription_id = SubscriptionId::new("open-todos");
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut downstream = DownstreamSession::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+
+    upstream_conn.send_server_message(ServerMessage::Settled {
+        subscription_id: subscription_id.clone(),
+        tier: SettlementTier::Local,
+        cursor: ReplayCursor(1),
+    });
+    let err = downstream.pump(&mut tab, &mut downstream_conn).unwrap_err();
+
+    assert!(err.to_string().contains("handshake is not established"));
+    assert!(downstream.is_closed());
+    assert!(!downstream.is_settled(&subscription_id, SettlementTier::Local));
+}
+
+#[test]
+fn connection_ignores_unrequested_settled_tier() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    worker.create_project("project-1", "Launch notes").unwrap();
+    worker
+        .create_todo("todo-1", "Draft protocol", false, "project-1")
+        .unwrap();
+
+    let query = open_todos_query();
+    let bundle = worker.export_query(query.clone()).unwrap();
+    let subscription_id = SubscriptionId::new("open-todos");
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut downstream = DownstreamSession::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+
+    downstream.open(&mut downstream_conn).unwrap();
+    upstream_conn.send_server_message(ServerMessage::Hello(ServerHello {
+        protocol_version: ProtocolVersion(1),
+        session_id: SessionId::new("worker-session"),
+        node_id: "alice-worker".to_owned(),
+        capabilities: ProtocolCapabilities::default(),
+    }));
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+    downstream
+        .subscribe(
+            &mut downstream_conn,
+            subscription_id.clone(),
+            query.clone(),
+            SettlementTier::Local,
+        )
+        .unwrap();
+
+    upstream_conn.send_server_message(ServerMessage::Data {
+        message_id: MessageId(1),
+        subscription_id: Some(subscription_id.clone()),
+        cursor: ReplayCursor(1),
+        bundle,
+    });
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+    upstream_conn.send_server_message(ServerMessage::Settled {
+        subscription_id: subscription_id.clone(),
+        tier: SettlementTier::Global,
+        cursor: ReplayCursor(1),
+    });
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+
+    assert_eq!(row_ids(tab.query(query).unwrap()), vec!["todo-1"]);
+    assert!(!downstream.is_settled(&subscription_id, SettlementTier::Local));
+    assert!(!downstream.is_settled(&subscription_id, SettlementTier::Global));
+}
+
+#[test]
+fn connection_rejects_unknown_subscription_data_without_partial_apply() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    worker.create_project("project-1", "Launch notes").unwrap();
+    worker
+        .create_todo("todo-1", "Draft protocol", false, "project-1")
+        .unwrap();
+
+    let query = open_todos_query();
+    let bundle = worker.export_query(query.clone()).unwrap();
+    let unknown_subscription_id = SubscriptionId::new("unknown-open-todos");
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut downstream = DownstreamSession::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamSession::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    downstream.open(&mut downstream_conn).unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+    upstream_conn.send_server_message(ServerMessage::Data {
+        message_id: MessageId(1),
+        subscription_id: Some(unknown_subscription_id),
+        cursor: ReplayCursor(1),
+        bundle,
+    });
+    let err = downstream.pump(&mut tab, &mut downstream_conn).unwrap_err();
+
+    assert!(err.to_string().contains("unknown subscription"));
+    assert!(downstream.is_closed());
+    assert!(tab.query(query).unwrap().is_empty());
+    assert!(matches!(
+        upstream_conn.receive_client_message(),
+        Some(ClientMessage::Close(CloseReason::ProtocolError))
+    ));
+    assert!(upstream_conn.receive_client_message().is_none());
+}
+
+#[test]
+fn connection_rejects_data_before_handshake_without_partial_apply() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    worker.create_project("project-1", "Launch notes").unwrap();
+    worker
+        .create_todo("todo-1", "Draft protocol", false, "project-1")
+        .unwrap();
+
+    let query = open_todos_query();
+    let bundle = worker.export_query(query.clone()).unwrap();
+    let subscription_id = SubscriptionId::new("open-todos");
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut downstream = DownstreamSession::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+
+    upstream_conn.send_server_message(ServerMessage::Data {
+        message_id: MessageId(1),
+        subscription_id: Some(subscription_id),
+        cursor: ReplayCursor(1),
+        bundle,
+    });
+    let err = downstream.pump(&mut tab, &mut downstream_conn).unwrap_err();
+
+    assert!(err.to_string().contains("handshake is not established"));
+    assert!(downstream.is_closed());
+    assert_eq!(
+        downstream.last_error().map(|error| error.code.as_str()),
+        Some("protocol_error")
+    );
+    assert!(tab.query(query).unwrap().is_empty());
+}
+
+#[test]
+fn connection_reconnect_requires_fresh_server_hello_before_replay() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    worker.create_project("project-1", "Launch notes").unwrap();
+    worker
+        .create_todo("todo-1", "Draft protocol", false, "project-1")
+        .unwrap();
+
+    let query = open_todos_query();
+    let subscription_id = SubscriptionId::new("open-todos");
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut downstream = DownstreamSession::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamSession::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    downstream.open(&mut downstream_conn).unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+    downstream
+        .subscribe(
+            &mut downstream_conn,
+            subscription_id,
+            query,
+            SettlementTier::Local,
+        )
+        .unwrap();
+
+    let (mut downstream_conn, _) = in_memory_connection_pair();
+    downstream.open(&mut downstream_conn).unwrap();
+    let err = downstream.replay(&mut downstream_conn).unwrap_err();
+
+    assert!(err.to_string().contains("handshake is not established"));
+}
+
+#[test]
+fn connection_rejects_data_after_incompatible_server_hello_without_partial_apply() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    worker.create_project("project-1", "Launch notes").unwrap();
+    worker
+        .create_todo("todo-1", "Draft protocol", false, "project-1")
+        .unwrap();
+
+    let query = open_todos_query();
+    let bundle = worker.export_query(query.clone()).unwrap();
+    let subscription_id = SubscriptionId::new("open-todos");
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut downstream = DownstreamSession::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+
+    downstream.open(&mut downstream_conn).unwrap();
+    upstream_conn.send_server_message(ServerMessage::Hello(ServerHello {
+        protocol_version: ProtocolVersion(2),
+        session_id: SessionId::new("worker-session"),
+        node_id: "alice-worker".to_owned(),
+        capabilities: ProtocolCapabilities::default(),
+    }));
+    upstream_conn.send_server_message(ServerMessage::Data {
+        message_id: MessageId(1),
+        subscription_id: Some(subscription_id),
+        cursor: ReplayCursor(1),
+        bundle,
+    });
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+
+    assert!(downstream.is_closed());
+    assert_eq!(
+        downstream.last_error().map(|error| error.code.as_str()),
+        Some("unsupported_protocol_version")
+    );
+    assert!(tab.query(query).unwrap().is_empty());
+}
+
+#[test]
+fn connection_rejects_unsolicited_server_hello() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut downstream = DownstreamSession::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+
+    upstream_conn.send_server_message(ServerMessage::Hello(ServerHello {
+        protocol_version: ProtocolVersion(1),
+        session_id: SessionId::new("worker-session"),
+        node_id: "alice-worker".to_owned(),
+        capabilities: ProtocolCapabilities::default(),
+    }));
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+
+    assert!(downstream.is_closed());
+    assert_eq!(
+        downstream.last_error().map(|error| error.code.as_str()),
+        Some("protocol_error")
+    );
+}
+
+#[test]
+fn connection_downstream_closes_on_fatal_error_frame() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut downstream = DownstreamSession::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+
+    upstream_conn.send_server_message(ServerMessage::Error(ProtocolError::new(
+        "transport_failed",
+        "transport failed",
+        RetryHint::Fatal,
+    )));
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+
+    assert!(downstream.is_closed());
+    assert_eq!(
+        downstream.last_error().map(|error| error.code.as_str()),
+        Some("transport_failed")
+    );
+}
+
+#[test]
+fn connection_upstream_closes_on_subscribe_before_handshake() {
+    let harness = Harness::new();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    let query = open_todos_query();
+    let subscription_id = SubscriptionId::new("open-todos");
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut upstream = UpstreamSession::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    downstream_conn.send_client_message(ClientMessage::Subscribe {
+        subscription_id,
+        query,
+        requested_tier: SettlementTier::Local,
+    });
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+
+    assert!(upstream.is_closed());
+    assert_eq!(
+        upstream.last_error().map(|error| error.code.as_str()),
+        Some("protocol_error")
+    );
+}
+
+#[test]
+fn connection_rejects_server_hello_without_ack_capability() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut downstream = DownstreamSession::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+
+    downstream.open(&mut downstream_conn).unwrap();
+    upstream_conn.send_server_message(ServerMessage::Hello(ServerHello {
+        protocol_version: ProtocolVersion(1),
+        session_id: SessionId::new("worker-session"),
+        node_id: "alice-worker".to_owned(),
+        capabilities: ProtocolCapabilities {
+            acknowledgements: false,
+            ..ProtocolCapabilities::default()
+        },
+    }));
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+
+    assert!(downstream.is_closed());
+    assert_eq!(
+        downstream.last_error().map(|error| error.code.as_str()),
+        Some("unsupported_capability")
+    );
+}
+
+#[test]
+fn connection_ignores_ack_after_close() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    worker.create_project("project-1", "Launch notes").unwrap();
+    worker
+        .create_todo("todo-1", "Draft protocol", false, "project-1")
+        .unwrap();
+
+    let query = open_todos_query();
+    let subscription_id = SubscriptionId::new("open-todos");
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut downstream = DownstreamSession::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamSession::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    downstream.open(&mut downstream_conn).unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+    downstream
+        .subscribe(
+            &mut downstream_conn,
+            subscription_id.clone(),
+            query,
+            SettlementTier::Local,
+        )
+        .unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    downstream
+        .close(&mut downstream_conn, CloseReason::ClientClosed)
+        .unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+
+    downstream_conn.send_client_message(ClientMessage::Ack {
+        message_id: MessageId(1),
+        cursor: Some(ReplayCursor(1)),
+    });
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+
+    assert_eq!(upstream.last_acknowledged_cursor(&subscription_id), None);
+}
+
+#[test]
+fn connection_upstream_closes_on_ack_before_handshake() {
+    let harness = Harness::new();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    let subscription_id = SubscriptionId::new("open-todos");
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut upstream = UpstreamSession::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    downstream_conn.send_client_message(ClientMessage::Ack {
+        message_id: MessageId(1),
+        cursor: Some(ReplayCursor(1)),
+    });
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+
+    assert!(upstream.is_closed());
+    assert_eq!(
+        upstream.last_error().map(|error| error.code.as_str()),
+        Some("protocol_error")
+    );
+    assert_eq!(upstream.last_acknowledged_cursor(&subscription_id), None);
+}
+
+#[test]
+fn connection_ack_tracking_never_moves_cursor_backwards() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    worker.create_project("project-1", "Launch notes").unwrap();
+    worker
+        .create_todo("todo-1", "Draft protocol", false, "project-1")
+        .unwrap();
+
+    let query = open_todos_query();
+    let subscription_id = SubscriptionId::new("open-todos");
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut downstream = DownstreamSession::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamSession::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    downstream.open(&mut downstream_conn).unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+    downstream
+        .subscribe(
+            &mut downstream_conn,
+            subscription_id.clone(),
+            query,
+            SettlementTier::Local,
+        )
+        .unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+
+    downstream_conn.send_client_message(ClientMessage::Ack {
+        message_id: MessageId(1),
+        cursor: Some(ReplayCursor(0)),
+    });
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+
+    assert_eq!(
+        upstream.last_acknowledged_cursor(&subscription_id),
+        Some(ReplayCursor(1))
+    );
+}
+
+#[test]
+fn connection_ack_tracking_does_not_trust_unsent_cursor() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    worker.create_project("project-1", "Launch notes").unwrap();
+    worker
+        .create_todo("todo-1", "Draft protocol", false, "project-1")
+        .unwrap();
+
+    let query = open_todos_query();
+    let subscription_id = SubscriptionId::new("open-todos");
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut downstream = DownstreamSession::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamSession::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    downstream.open(&mut downstream_conn).unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+    downstream
+        .subscribe(
+            &mut downstream_conn,
+            subscription_id.clone(),
+            query,
+            SettlementTier::Local,
+        )
+        .unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+
+    downstream_conn.send_client_message(ClientMessage::Ack {
+        message_id: MessageId(1),
+        cursor: Some(ReplayCursor(999)),
+    });
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+
+    assert_eq!(
+        upstream.last_acknowledged_cursor(&subscription_id),
+        Some(ReplayCursor(1))
+    );
+}
+
+#[test]
+fn connection_ack_tracking_keeps_highest_cursor_when_acks_arrive_out_of_order() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    worker.create_project("project-1", "Launch notes").unwrap();
+    worker
+        .create_todo("todo-1", "Draft protocol", false, "project-1")
+        .unwrap();
+
+    let query = open_todos_query();
+    let subscription_id = SubscriptionId::new("open-todos");
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut downstream = DownstreamSession::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamSession::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    downstream.open(&mut downstream_conn).unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+    downstream
+        .subscribe(
+            &mut downstream_conn,
+            subscription_id.clone(),
+            query.clone(),
+            SettlementTier::Local,
+        )
+        .unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    downstream.replay(&mut downstream_conn).unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+
+    downstream_conn.send_client_message(ClientMessage::Ack {
+        message_id: MessageId(2),
+        cursor: Some(ReplayCursor(2)),
+    });
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    downstream_conn.send_client_message(ClientMessage::Ack {
+        message_id: MessageId(1),
+        cursor: Some(ReplayCursor(1)),
+    });
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+
+    assert_eq!(
+        upstream.last_acknowledged_cursor(&subscription_id),
+        Some(ReplayCursor(2))
+    );
+}
+
+#[test]
+fn connection_downstream_replay_cursor_never_moves_backwards() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    worker.create_project("project-1", "Launch notes").unwrap();
+    worker
+        .create_todo("todo-1", "Draft protocol", false, "project-1")
+        .unwrap();
+
+    let query = open_todos_query();
+    let bundle = worker.export_query(query.clone()).unwrap();
+    let subscription_id = SubscriptionId::new("open-todos");
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut downstream = DownstreamSession::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+
+    downstream.open(&mut downstream_conn).unwrap();
+    upstream_conn.send_server_message(ServerMessage::Hello(ServerHello {
+        protocol_version: ProtocolVersion(1),
+        session_id: SessionId::new("worker-session"),
+        node_id: "alice-worker".to_owned(),
+        capabilities: ProtocolCapabilities::default(),
+    }));
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+    downstream
+        .subscribe(
+            &mut downstream_conn,
+            subscription_id.clone(),
+            query,
+            SettlementTier::Local,
+        )
+        .unwrap();
+
+    upstream_conn.send_server_message(ServerMessage::Data {
+        message_id: MessageId(2),
+        subscription_id: Some(subscription_id.clone()),
+        cursor: ReplayCursor(2),
+        bundle: bundle.clone(),
+    });
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+    upstream_conn.send_server_message(ServerMessage::Data {
+        message_id: MessageId(1),
+        subscription_id: Some(subscription_id.clone()),
+        cursor: ReplayCursor(1),
+        bundle,
+    });
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    downstream.open(&mut downstream_conn).unwrap();
+    upstream_conn.send_server_message(ServerMessage::Hello(ServerHello {
+        protocol_version: ProtocolVersion(1),
+        session_id: SessionId::new("worker-session-2"),
+        node_id: "alice-worker".to_owned(),
+        capabilities: ProtocolCapabilities::default(),
+    }));
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+    let _ = upstream_conn.receive_client_message();
+    downstream.replay(&mut downstream_conn).unwrap();
+
+    let replay = upstream_conn
+        .receive_client_message()
+        .expect("replay message after reconnect");
+    let ClientMessage::Replay { subscriptions } = replay else {
+        panic!("expected replay message");
+    };
+    assert_eq!(subscriptions[0].last_applied_cursor, Some(ReplayCursor(2)));
+}
+
+#[test]
+fn connection_upstream_new_hello_resets_session_state() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    worker.create_project("project-1", "Launch notes").unwrap();
+    worker
+        .create_todo("todo-1", "Draft protocol", false, "project-1")
+        .unwrap();
+
+    let query = open_todos_query();
+    let subscription_id = SubscriptionId::new("open-todos");
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut downstream = DownstreamSession::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamSession::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    downstream.open(&mut downstream_conn).unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+    downstream
+        .subscribe(
+            &mut downstream_conn,
+            subscription_id.clone(),
+            query,
+            SettlementTier::Local,
+        )
+        .unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    downstream_conn.send_client_message(ClientMessage::Ack {
+        message_id: MessageId(1),
+        cursor: Some(ReplayCursor(1)),
+    });
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    assert_eq!(
+        upstream.last_acknowledged_cursor(&subscription_id),
+        Some(ReplayCursor(1))
+    );
+
+    downstream_conn.send_client_message(ClientMessage::Hello(ClientHello {
+        protocol_version: ProtocolVersion(1),
+        session_id: SessionId::new("tab-session-2"),
+        node_id: "alice-tab".to_owned(),
+        schema_fingerprint: tab.local_schema_fingerprint(),
+        policy_fingerprint: tab.local_policy_fingerprint(),
+    }));
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+
+    assert_eq!(upstream.last_acknowledged_cursor(&subscription_id), None);
+    assert_eq!(upstream.last_error(), None);
+}
+
+#[test]
+fn connection_upstream_replay_prunes_omitted_subscription_state() {
+    let harness = Harness::new();
+    let tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    worker.create_project("project-1", "Launch notes").unwrap();
+    worker
+        .create_todo("todo-1", "Draft protocol", false, "project-1")
+        .unwrap();
+
+    let todos_query = open_todos_query();
+    let projects_query = BuiltQuery {
+        table: "projects".to_owned(),
+        conditions: Vec::new(),
+        order_by: Vec::new(),
+        limit: None,
+        offset: None,
+    };
+    let dropped_subscription_id = SubscriptionId::new("open-todos");
+    let kept_subscription_id = SubscriptionId::new("projects");
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut upstream = UpstreamSession::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    downstream_conn.send_client_message(ClientMessage::Hello(ClientHello {
+        protocol_version: ProtocolVersion(1),
+        session_id: SessionId::new("tab-session"),
+        node_id: "alice-tab".to_owned(),
+        schema_fingerprint: tab.local_schema_fingerprint(),
+        policy_fingerprint: tab.local_policy_fingerprint(),
+    }));
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    drain_server_messages(&mut downstream_conn);
+    downstream_conn.send_client_message(ClientMessage::Subscribe {
+        subscription_id: dropped_subscription_id.clone(),
+        query: todos_query.clone(),
+        requested_tier: SettlementTier::Local,
+    });
+    downstream_conn.send_client_message(ClientMessage::Subscribe {
+        subscription_id: kept_subscription_id.clone(),
+        query: projects_query.clone(),
+        requested_tier: SettlementTier::Local,
+    });
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    drain_server_messages(&mut downstream_conn);
+
+    downstream_conn.send_client_message(ClientMessage::Replay {
+        subscriptions: vec![ReplaySubscription {
+            subscription_id: kept_subscription_id.clone(),
+            query: projects_query,
+            requested_tier: SettlementTier::Local,
+            last_applied_cursor: None,
+        }],
+    });
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    drain_server_messages(&mut downstream_conn);
+    downstream_conn.send_client_message(ClientMessage::Ack {
+        message_id: MessageId(1),
+        cursor: Some(ReplayCursor(1)),
+    });
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    downstream_conn.send_client_message(ClientMessage::Subscribe {
+        subscription_id: dropped_subscription_id.clone(),
+        query: todos_query,
+        requested_tier: SettlementTier::Local,
+    });
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+
+    assert_eq!(
+        upstream.last_acknowledged_cursor(&dropped_subscription_id),
+        None
+    );
+    let server_messages = drain_server_messages(&mut downstream_conn);
+    assert!(server_messages.iter().any(|message| {
+        matches!(
+            message,
+            ServerMessage::Data {
+                subscription_id: Some(id),
+                ..
+            } if id == &dropped_subscription_id
+        )
+    }));
+    assert!(!server_messages.iter().any(|message| {
+        matches!(
+            message,
+            ServerMessage::Error(error)
+                if error.subscription_id.as_ref() == Some(&dropped_subscription_id)
+                    && error.code == "duplicate_subscription"
+        )
+    }));
+}
+
+#[test]
+fn connection_rejects_incompatible_protocol_without_partial_apply() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    worker.create_project("project-1", "Launch notes").unwrap();
+    worker
+        .create_todo("todo-1", "Draft protocol", false, "project-1")
+        .unwrap();
+
+    let query = open_todos_query();
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut downstream = DownstreamSession::new_with_protocol_version(
+        "tab-session",
+        "alice-tab",
+        2,
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamSession::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    downstream.open(&mut downstream_conn).unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    assert_eq!(
+        upstream.last_error().map(|error| error.code.as_str()),
+        Some("unsupported_protocol_version")
+    );
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+
+    assert!(downstream.is_closed());
+    assert_eq!(
+        downstream.last_error().map(|error| error.code.as_str()),
+        Some("unsupported_protocol_version")
+    );
+    assert!(tab.query(query).unwrap().is_empty());
+}
+
+#[test]
+fn connection_rejects_incompatible_schema_fingerprint_without_partial_apply() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    worker.create_project("project-1", "Launch notes").unwrap();
+    worker
+        .create_todo("todo-1", "Draft protocol", false, "project-1")
+        .unwrap();
+
+    let query = open_todos_query();
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut downstream = DownstreamSession::new(
+        "tab-session",
+        "alice-tab",
+        "wrong-schema",
+        tab.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamSession::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    downstream.open(&mut downstream_conn).unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    assert_eq!(
+        upstream.last_error().map(|error| error.code.as_str()),
+        Some("incompatible_schema_fingerprint")
+    );
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+
+    assert!(downstream.is_closed());
+    assert_eq!(
+        downstream.last_error().map(|error| error.code.as_str()),
+        Some("incompatible_schema_fingerprint")
+    );
+    assert!(tab.query(query).unwrap().is_empty());
+}
+
+#[test]
+fn connection_rejects_incompatible_policy_fingerprint_without_partial_apply() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    worker.create_project("project-1", "Launch notes").unwrap();
+    worker
+        .create_todo("todo-1", "Draft protocol", false, "project-1")
+        .unwrap();
+
+    let query = open_todos_query();
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut downstream = DownstreamSession::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        "wrong-policy",
+    );
+    let mut upstream = UpstreamSession::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    downstream.open(&mut downstream_conn).unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    assert_eq!(
+        upstream.last_error().map(|error| error.code.as_str()),
+        Some("incompatible_policy_fingerprint")
+    );
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+
+    assert!(downstream.is_closed());
+    assert_eq!(
+        downstream.last_error().map(|error| error.code.as_str()),
+        Some("incompatible_policy_fingerprint")
+    );
+    assert!(tab.query(query).unwrap().is_empty());
+}
+
+#[test]
+fn connection_subscribe_rejection_is_protocol_error_frame() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    let bad_query = BuiltQuery {
+        table: "missing_table".to_owned(),
+        conditions: Vec::new(),
+        order_by: Vec::new(),
+        limit: None,
+        offset: None,
+    };
+    let subscription_id = SubscriptionId::new("bad-query");
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut downstream = DownstreamSession::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamSession::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    downstream.open(&mut downstream_conn).unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+    downstream
+        .subscribe(
+            &mut downstream_conn,
+            subscription_id.clone(),
+            bad_query,
+            SettlementTier::Local,
+        )
+        .unwrap();
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    downstream.pump(&mut tab, &mut downstream_conn).unwrap();
+
+    let error = downstream.last_error().expect("protocol error frame");
+    assert_eq!(error.code, "query_rejected");
+    assert_eq!(error.subscription_id, Some(subscription_id.clone()));
+    assert!(!downstream.is_closed());
+    assert!(!downstream.has_active_subscription(&subscription_id));
+}
+
+#[test]
+fn connection_closes_when_data_bundle_apply_fails() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    worker.create_project("project-1", "Launch notes").unwrap();
+    worker
+        .create_todo("todo-1", "Draft protocol", false, "project-1")
+        .unwrap();
+
+    let query = open_todos_query();
+    let mut bundle = worker.export_query(query.clone()).unwrap();
+    bundle.protocol_version = mini_jazz_sqlite::sync::BUNDLE_PROTOCOL_VERSION + 1;
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut downstream = DownstreamSession::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+
+    downstream.open(&mut downstream_conn).unwrap();
+    upstream_conn.send_server_message(ServerMessage::Hello(ServerHello {
+        protocol_version: ProtocolVersion(1),
+        session_id: SessionId::new("worker-session"),
+        node_id: "alice-worker".to_owned(),
+        capabilities: ProtocolCapabilities::default(),
+    }));
+    upstream_conn.send_server_message(ServerMessage::Data {
+        message_id: MessageId(1),
+        subscription_id: None,
+        cursor: ReplayCursor(1),
+        bundle,
+    });
+    let err = downstream.pump(&mut tab, &mut downstream_conn).unwrap_err();
+
+    assert!(err
+        .to_string()
+        .contains("unsupported bundle protocol version"));
+    assert!(downstream.is_closed());
+    assert_eq!(
+        downstream.last_error().map(|error| error.code.as_str()),
+        Some("bundle_apply_failed")
+    );
+    assert!(tab.query(query).unwrap().is_empty());
+}
+
+#[test]
+fn connection_can_run_tab_to_worker_and_worker_to_authority_with_same_messages() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    let mut authority = harness.memory("authority", "alice").unwrap();
+    authority
+        .create_project("project-1", "Launch notes")
+        .unwrap();
+    authority
+        .create_todo("todo-1", "Draft protocol", false, "project-1")
+        .unwrap();
+
+    let query = open_todos_query();
+    let worker_subscription = SubscriptionId::new("worker-open-todos");
+    let (mut worker_downstream_conn, mut authority_upstream_conn) = in_memory_connection_pair();
+    let mut worker_downstream = DownstreamSession::new(
+        "worker-downstream-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+    let mut authority_upstream = UpstreamSession::new(
+        "authority-session",
+        "authority",
+        authority.local_schema_fingerprint(),
+        authority.local_policy_fingerprint(),
+    );
+
+    worker_downstream.open(&mut worker_downstream_conn).unwrap();
+    authority_upstream
+        .pump(&mut authority, &mut authority_upstream_conn)
+        .unwrap();
+    worker_downstream
+        .pump(&mut worker, &mut worker_downstream_conn)
+        .unwrap();
+    worker_downstream
+        .subscribe(
+            &mut worker_downstream_conn,
+            worker_subscription,
+            query.clone(),
+            SettlementTier::Local,
+        )
+        .unwrap();
+    authority_upstream
+        .pump(&mut authority, &mut authority_upstream_conn)
+        .unwrap();
+    worker_downstream
+        .pump(&mut worker, &mut worker_downstream_conn)
+        .unwrap();
+    assert_eq!(
+        row_ids(worker.query(query.clone()).unwrap()),
+        vec!["todo-1"]
+    );
+
+    let tab_subscription = SubscriptionId::new("tab-open-todos");
+    let (mut tab_downstream_conn, mut worker_upstream_conn) = in_memory_connection_pair();
+    let mut tab_downstream = DownstreamSession::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+    let mut worker_upstream = UpstreamSession::new(
+        "worker-upstream-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    tab_downstream.open(&mut tab_downstream_conn).unwrap();
+    worker_upstream
+        .pump(&mut worker, &mut worker_upstream_conn)
+        .unwrap();
+    tab_downstream
+        .pump(&mut tab, &mut tab_downstream_conn)
+        .unwrap();
+    tab_downstream
+        .subscribe(
+            &mut tab_downstream_conn,
+            tab_subscription,
+            query.clone(),
+            SettlementTier::Local,
+        )
+        .unwrap();
+    worker_upstream
+        .pump(&mut worker, &mut worker_upstream_conn)
+        .unwrap();
+    tab_downstream
+        .pump(&mut tab, &mut tab_downstream_conn)
+        .unwrap();
+
+    assert_eq!(row_ids(tab.query(query).unwrap()), vec!["todo-1"]);
+}
+
+#[test]
+fn connection_manager_open_subscribe_applies_data_and_emits_ack() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    worker.create_project("project-1", "Launch notes").unwrap();
+    worker
+        .create_todo("todo-1", "Connection manager protocol", false, "project-1")
+        .unwrap();
+
+    let query = open_todos_query();
+    let mut downstream = DownstreamConnectionManager::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamConnectionManager::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    let server_messages = upstream
+        .receive(&mut worker, downstream.open().unwrap())
+        .unwrap();
+    assert!(!downstream.is_ready());
+    let client_messages = downstream.receive(&mut tab, server_messages).unwrap();
+    assert!(client_messages.is_empty());
+    assert!(downstream.is_ready());
+
+    let (subscription, client_messages) = downstream
+        .subscribe(query.clone(), SettlementTier::Local)
+        .unwrap();
+    let server_messages = upstream.receive(&mut worker, client_messages).unwrap();
+    let client_messages = downstream.receive(&mut tab, server_messages).unwrap();
+
+    assert!(downstream.is_settled(&subscription, SettlementTier::Local));
+    assert!(matches!(
+        client_messages.as_slice(),
+        [ClientMessage::Ack {
+            message_id: MessageId(1),
+            cursor: Some(ReplayCursor(1))
+        }]
+    ));
+    upstream.receive(&mut worker, client_messages).unwrap();
+    assert_eq!(row_ids(tab.query(query).unwrap()), vec!["todo-1"]);
+}
+
+#[test]
+fn connection_manager_queues_subscribe_until_handshake_is_ready() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    let mut downstream = DownstreamConnectionManager::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamConnectionManager::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    let open_messages = downstream.open().unwrap();
+    let (subscription, queued_messages) = downstream
+        .subscribe(open_todos_query(), SettlementTier::Local)
+        .unwrap();
+    assert!(queued_messages.is_empty());
+    assert!(!downstream.is_ready());
+
+    let server_messages = upstream.receive(&mut worker, open_messages).unwrap();
+    let client_messages = downstream.receive(&mut tab, server_messages).unwrap();
+
+    let [ClientMessage::Subscribe {
+        subscription_id,
+        requested_tier,
+        ..
+    }] = client_messages.as_slice()
+    else {
+        panic!("expected queued subscribe to flush after handshake");
+    };
+    assert_eq!(subscription_id, subscription.id());
+    assert_eq!(*requested_tier, SettlementTier::Local);
+    assert!(downstream.is_ready());
+}
+
+#[test]
+fn connection_manager_ignores_late_frames_for_locally_dropped_subscription() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    worker.create_project("project-1", "Launch notes").unwrap();
+    worker
+        .create_todo("todo-1", "Late frame", false, "project-1")
+        .unwrap();
+
+    let query = open_todos_query();
+    let mut downstream = DownstreamConnectionManager::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamConnectionManager::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    let server_messages = upstream
+        .receive(&mut worker, downstream.open().unwrap())
+        .unwrap();
+    downstream.receive(&mut tab, server_messages).unwrap();
+    let (subscription, client_messages) = downstream
+        .subscribe(query.clone(), SettlementTier::Local)
+        .unwrap();
+    let server_messages = upstream.receive(&mut worker, client_messages).unwrap();
+
+    downstream.unsubscribe(&subscription);
+    let client_messages = downstream.receive(&mut tab, server_messages).unwrap();
+
+    assert!(client_messages.is_empty());
+    assert!(!downstream.is_closed());
+    assert!(tab.query(query).unwrap().is_empty());
+}
+
+#[test]
+fn connection_manager_replay_excludes_locally_dropped_subscription() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    let mut downstream = DownstreamConnectionManager::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamConnectionManager::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    let server_messages = upstream
+        .receive(&mut worker, downstream.open().unwrap())
+        .unwrap();
+    downstream.receive(&mut tab, server_messages).unwrap();
+    let (dropped_subscription, dropped_messages) = downstream
+        .subscribe(open_todos_query(), SettlementTier::Local)
+        .unwrap();
+    let (kept_subscription, kept_messages) = downstream
+        .subscribe(
+            BuiltQuery {
+                table: "projects".to_owned(),
+                conditions: Vec::new(),
+                order_by: Vec::new(),
+                limit: None,
+                offset: None,
+            },
+            SettlementTier::Local,
+        )
+        .unwrap();
+    upstream.receive(&mut worker, dropped_messages).unwrap();
+    upstream.receive(&mut worker, kept_messages).unwrap();
+
+    downstream.unsubscribe(&dropped_subscription);
+    let replay_messages = downstream.replay().unwrap();
+
+    let [ClientMessage::Replay { subscriptions }] = replay_messages.as_slice() else {
+        panic!("expected one replay message");
+    };
+    assert_eq!(subscriptions.len(), 1);
+    assert_eq!(subscriptions[0].subscription_id, *kept_subscription.id());
+}
+
+#[test]
+fn connection_manager_upstream_reports_scoped_query_errors() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    let mut downstream = DownstreamConnectionManager::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamConnectionManager::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+    let bad_query = BuiltQuery {
+        table: "missing_table".to_owned(),
+        conditions: Vec::new(),
+        order_by: Vec::new(),
+        limit: None,
+        offset: None,
+    };
+
+    let server_messages = upstream
+        .receive(&mut worker, downstream.open().unwrap())
+        .unwrap();
+    downstream.receive(&mut tab, server_messages).unwrap();
+    let (subscription, client_messages) = downstream
+        .subscribe(bad_query, SettlementTier::Local)
+        .unwrap();
+    let server_messages = upstream.receive(&mut worker, client_messages).unwrap();
+
+    let [ServerMessage::Error(error)] = server_messages.as_slice() else {
+        panic!("expected one scoped error");
+    };
+    assert_eq!(error.code, "query_rejected");
+    assert_eq!(error.subscription_id.as_ref(), Some(subscription.id()));
+}
+
+#[test]
+fn connection_manager_downstream_surfaces_scoped_query_errors() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    let mut downstream = DownstreamConnectionManager::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamConnectionManager::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+    let bad_query = BuiltQuery {
+        table: "missing_table".to_owned(),
+        conditions: Vec::new(),
+        order_by: Vec::new(),
+        limit: None,
+        offset: None,
+    };
+
+    let server_messages = upstream
+        .receive(&mut worker, downstream.open().unwrap())
+        .unwrap();
+    downstream.receive(&mut tab, server_messages).unwrap();
+    let (_, client_messages) = downstream
+        .subscribe(bad_query, SettlementTier::Local)
+        .unwrap();
+    let server_messages = upstream.receive(&mut worker, client_messages).unwrap();
+    let err = downstream.receive(&mut tab, server_messages).unwrap_err();
+
+    assert!(err.to_string().contains("query_rejected"));
+}
+
+fn open_todos_query() -> BuiltQuery {
+    BuiltQuery {
+        table: "todos".to_owned(),
+        conditions: vec![QueryCondition {
+            column: "done".to_owned(),
+            op: QueryConditionOp::Eq,
+            value: json!(false),
+        }],
+        order_by: Vec::new(),
+        limit: None,
+        offset: None,
+    }
+}
+
+fn row_ids(rows: Vec<mini_jazz_sqlite::RowView>) -> Vec<String> {
+    rows.into_iter().map(|row| row.id).collect()
+}
+
+fn sorted_row_ids(rows: Vec<mini_jazz_sqlite::RowView>) -> Vec<String> {
+    let mut ids = row_ids(rows);
+    ids.sort();
+    ids
+}
+
+fn drain_server_messages(
+    conn: &mut mini_jazz_sqlite::connection::DownstreamConnection,
+) -> Vec<ServerMessage> {
+    let mut messages = Vec::new();
+    while let Some(message) = conn.receive_server_message() {
+        messages.push(message);
+    }
+    messages
+}

--- a/crates/mini-jazz-sqlite/tests/whole_system/connection.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/connection.rs
@@ -66,7 +66,7 @@ fn connection_subscribe_delivers_initial_query_and_settled() {
 }
 
 #[test]
-fn connection_edge_subscription_receives_rows_without_false_settlement() {
+fn connection_rejects_unsupported_edge_subscription_tier() {
     let harness = Harness::new();
     let mut tab = harness.memory("alice-tab", "alice").unwrap();
     let mut worker = harness.memory("alice-worker", "alice").unwrap();
@@ -105,7 +105,12 @@ fn connection_edge_subscription_receives_rows_without_false_settlement() {
     upstream.pump(&mut worker, &mut upstream_conn).unwrap();
     downstream.pump(&mut tab, &mut downstream_conn).unwrap();
 
-    assert_eq!(row_ids(tab.query(query).unwrap()), vec!["todo-1"]);
+    let error = downstream.last_error().expect("subscription is rejected");
+    assert_eq!(error.code, "unsupported_settlement_tier");
+    assert_eq!(error.subscription_id.as_ref(), Some(&subscription_id));
+    assert_eq!(error.retry_hint, RetryHint::Retryable);
+    assert!(!downstream.has_active_subscription(&subscription_id));
+    assert!(row_ids(tab.query(query).unwrap()).is_empty());
     assert!(!downstream.is_settled(&subscription_id, SettlementTier::Local));
     assert!(!downstream.is_settled(&subscription_id, SettlementTier::Edge));
     assert!(!downstream.is_settled(&subscription_id, SettlementTier::Global));
@@ -1810,6 +1815,11 @@ fn connection_manager_replay_excludes_locally_dropped_subscription() {
     };
     assert_eq!(subscriptions.len(), 1);
     assert_eq!(subscriptions[0].subscription_id, *kept_subscription.id());
+
+    upstream.receive(&mut worker, replay_messages).unwrap();
+
+    assert!(!upstream.has_active_subscription(dropped_subscription.id()));
+    assert!(upstream.has_active_subscription(kept_subscription.id()));
 }
 
 #[test]

--- a/crates/mini-jazz-sqlite/tests/whole_system/connection.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/connection.rs
@@ -1759,16 +1759,22 @@ fn connection_manager_ignores_late_frames_for_locally_dropped_subscription() {
         .unwrap();
     let server_messages = upstream.receive(&mut worker, client_messages).unwrap();
 
-    downstream.unsubscribe(&subscription);
+    let unsubscribe_messages = downstream.unsubscribe(&subscription).unwrap();
     let client_messages = downstream.receive(&mut tab, server_messages).unwrap();
 
+    assert!(unsubscribe_messages.iter().any(|message| {
+        matches!(
+            message,
+            ClientMessage::Replay { subscriptions } if subscriptions.is_empty()
+        )
+    }));
     assert!(client_messages.is_empty());
     assert!(!downstream.is_closed());
     assert!(tab.query(query).unwrap().is_empty());
 }
 
 #[test]
-fn connection_manager_replay_excludes_locally_dropped_subscription() {
+fn connection_manager_unsubscribe_replays_remaining_interest_upstream() {
     let harness = Harness::new();
     let mut tab = harness.memory("alice-tab", "alice").unwrap();
     let mut worker = harness.memory("alice-worker", "alice").unwrap();
@@ -1807,8 +1813,7 @@ fn connection_manager_replay_excludes_locally_dropped_subscription() {
     upstream.receive(&mut worker, dropped_messages).unwrap();
     upstream.receive(&mut worker, kept_messages).unwrap();
 
-    downstream.unsubscribe(&dropped_subscription);
-    let replay_messages = downstream.replay().unwrap();
+    let replay_messages = downstream.unsubscribe(&dropped_subscription).unwrap();
 
     let [ClientMessage::Replay { subscriptions }] = replay_messages.as_slice() else {
         panic!("expected one replay message");

--- a/docs/superpowers/specs/2026-05-29-mini-jazz-sqlite-connection-design.md
+++ b/docs/superpowers/specs/2026-05-29-mini-jazz-sqlite-connection-design.md
@@ -1,0 +1,298 @@
+# mini-jazz-sqlite Connection Protocol Design
+
+## Context
+
+`mini-jazz-sqlite` currently syncs by directly exporting and applying
+`sync::Bundle` values between `Runtime` instances. Tests and harness helpers
+manually call export methods on one runtime and `apply_bundle` on another.
+
+The next step is a connection abstraction that lets the same sync protocol run
+over in-memory tests, browser Worker communication, and network transports. The
+first version should introduce protocol-level session semantics:
+subscribe, replay, settled, and close.
+
+The protocol is explicitly client-to-upstream. The same downstream/upstream
+contract can be composed for tab to worker, worker to edge, and edge to global
+authority.
+
+## Goals
+
+- Define a transport-neutral connection contract for sync sessions.
+- Keep `sync::Bundle` as the semantic data payload for the first version.
+- Add typed session messages for handshake, subscribe, replay, data, settled,
+  errors, acknowledgements, and close.
+- Keep Worker and network transport details outside the Rust core.
+- Make session behavior deterministic and testable with in-memory connections.
+- Preserve current bundle idempotence and fail-closed compatibility checks.
+
+## Non-Goals
+
+- Replacing the `Bundle` wire payload immediately.
+- Adding real Worker or WebSocket transports in the first implementation.
+- Moving async runtimes or transport dependencies into `mini-jazz-sqlite`.
+- Persisting active query descriptors as durable application data.
+- Designing final catalogue, blob, compression, or auth protocols.
+
+## Architecture
+
+Add a protocol layer inside `crates/mini-jazz-sqlite`, separate from
+`sync::Bundle` and `Runtime`.
+
+`sync::Bundle` remains the data frame. The protocol layer wraps it in session
+messages:
+
+- downstream to upstream: `Hello`, `Subscribe`, `Replay`, `Ack`, `Close`
+- upstream to downstream: `Hello`, `Data`, `Settled`, `Error`, `Close`
+
+A connection implementation is responsible for reliable ordered delivery of
+typed messages. It does not implement query semantics, policy, bundle assembly,
+or bundle application.
+
+`Runtime` remains the semantic executor. It exports query scopes, applies
+bundles, records observed query reads, and computes subscription deltas. The
+protocol layer coordinates when those runtime operations happen across a
+session.
+
+## Components
+
+### `protocol`
+
+Pure serializable types:
+
+- `ClientMessage`
+- `ServerMessage`
+- `SessionId`
+- `SubscriptionId`
+- `MessageId`
+- `ReplayCursor`
+- `SettlementTier`
+- `ProtocolVersion`
+- `ProtocolCapabilities`
+- `ProtocolError`
+- `CloseReason`
+
+These types should be simple Rust data structures with `serde` support so they
+can cross Rust tests, WASM bindings, Worker messages, and network framing.
+
+### `connection`
+
+A small driver-facing contract for moving typed messages. The core contract
+should stay synchronous and dependency-light so the crate does not need an async
+runtime. Worker, WebSocket, or native network adapters can translate their own
+async events into calls against this contract.
+
+The in-core implementation should include an in-memory connection pair for
+tests. It should prove message ordering, disconnect, reconnect, replay, and
+close behavior without requiring platform APIs.
+
+### `session`
+
+A deterministic client-to-upstream state machine. It tracks:
+
+- handshake status
+- active subscriptions
+- replay cursors
+- pending outbound messages
+- acknowledged inbound messages
+- settlement state by subscription and tier
+- close state
+
+The state machine should not know about Worker, WebSocket, or filesystem
+details.
+
+### Runtime Protocol Glue
+
+Small functions bridge session events to existing runtime operations:
+
+- `Subscribe` on upstream exports the requested query scope.
+- `Replay` on upstream exports refreshes for active downstream interest.
+- `Data` on downstream applies a `Bundle`.
+- `Settled` on downstream marks a query/tier delivery barrier.
+- `Close` drops session-local interest and settlement state.
+
+## Message Semantics
+
+### Handshake
+
+Downstream sends:
+
+```text
+Hello {
+  protocol_version,
+  node_id,
+  schema_fingerprint,
+  policy_fingerprint
+}
+```
+
+Upstream replies with accepted protocol version, upstream node id, and
+capabilities. If the protocol, schema, policy, or auth context is incompatible,
+upstream sends `Error` and then `Close`.
+
+### Subscribe
+
+Downstream sends:
+
+```text
+Subscribe {
+  subscription_id,
+  query,
+  requested_tier
+}
+```
+
+The query should use the existing `BuiltQuery` descriptor shape first. Upstream
+exports one or more `Data` frames carrying `Bundle` payloads. After all data
+needed for the requested delivery tier has been sent, upstream sends `Settled`.
+
+Downstream may publish a settled subscription result only after it has applied
+the matching data cursor and observed the corresponding `Settled` frame.
+
+### Replay
+
+After reconnect, downstream sends active subscriptions and the last applied
+cursor known for each subscription.
+
+Upstream may satisfy replay by sending missing data from a replay window. If the
+window is insufficient, upstream sends fresh query-scope bundles for those
+subscriptions. Existing bundle idempotence makes repeated or overlapping data
+safe to apply.
+
+### Data
+
+`Data` carries a `Bundle`, optional `subscription_id`, and cursor metadata. A
+data frame may represent subscription refresh data, write forwarding data, or
+authoritative outcome/receipt data.
+
+The first implementation can keep write forwarding as bundle data and reuse
+existing trusted or untrusted apply paths based on session role. A later design
+can introduce dedicated mutation frames if needed.
+
+### Acknowledgement
+
+`Ack` records the highest applied message or cursor. It gives upstream enough
+state to bound replay windows and lets tests prove reconnect behavior. Acking a
+message means the receiver has durably applied its semantic effects or has
+intentionally ignored an idempotent duplicate.
+
+### Settled
+
+`Settled` is a delivery barrier, not a row payload. It means the upstream has
+sent the data needed for a subscription at a requested tier and cursor.
+
+Settlement is tracked per subscription and tier. Rows may arrive before
+settlement, but the downstream must not publish them as the settled tier result
+until the barrier is observed.
+
+### Close
+
+Either side may send `Close`. After close, both sides stop accepting new
+subscribe, replay, data, and ack messages for that session. Runtime data remains
+cached; only session-local desired interest, replay state, and settlement state
+are dropped.
+
+## Error Handling
+
+Protocol errors are explicit frames:
+
+```text
+Error {
+  code,
+  message,
+  subscription_id?,
+  message_id?,
+  retry_hint
+}
+```
+
+Retry hints are:
+
+- `retryable`
+- `replay_required`
+- `fatal`
+
+Fatal errors close the session after the error frame. Examples:
+
+- incompatible protocol version
+- incompatible schema fingerprint
+- incompatible policy fingerprint
+- auth failure
+- malformed message
+- unsupported required capability
+
+Scoped errors may fail one subscription without closing the session. Examples:
+
+- unknown subscription id
+- rejected query descriptor
+- expired replay cursor
+- settlement timeout
+- bundle apply failure scoped to one subscription
+
+Transport failures are outside the core protocol. Adapters translate them into
+disconnect/reconnect events. The downstream session then reconnects with
+`Replay`.
+
+Bundle application remains fail-closed. Unsupported bundle protocol versions or
+incompatible fingerprints must not partially apply.
+
+## Testing
+
+Use high-level integration tests under `crates/mini-jazz-sqlite/tests/whole_system`.
+Prefer realistic tab, worker, edge, and authority roles over generic peers.
+
+Initial tests:
+
+1. `connection_subscribe_delivers_initial_query_and_settled`
+   - Alice creates rows upstream.
+   - A tab subscribes through an in-memory connection.
+   - The tab applies data, receives settled, and sees the expected query result.
+
+2. `connection_replay_restores_active_subscription_after_reconnect`
+   - A tab subscribes and settles.
+   - The connection disconnects.
+   - Upstream changes data.
+   - The tab reconnects with replay state and converges after missing or
+     refreshed data is sent.
+
+3. `connection_close_drops_session_interest_without_deleting_cached_rows`
+   - A tab receives data for a subscription.
+   - The session closes.
+   - Active interest is gone, but previously synced rows remain queryable from
+     local cache.
+
+4. `connection_rejects_incompatible_protocol_without_partial_apply`
+   - A future protocol version or incompatible fingerprint produces error and
+     close.
+   - The downstream runtime remains unchanged.
+
+5. `connection_can_run_tab_to_worker_and_worker_to_authority_with_same_messages`
+   - A two-hop in-memory topology uses the same message types for both hops.
+   - Data converges without any Worker-specific or network-specific code.
+
+## Implementation Shape
+
+The first implementation should be small and vertical:
+
+1. Add serializable protocol message types.
+2. Add in-memory connection test support.
+3. Add session state for handshake, subscribe, data, settled, replay, ack, and
+   close.
+4. Add runtime glue that maps subscribe/replay/data events onto existing
+   `Runtime` bundle export/apply methods.
+5. Add whole-system tests proving subscribe, replay, close, incompatibility,
+   and two-hop composition.
+
+The implementation should not change existing application-facing query/write
+APIs. New public surface should be protocol-oriented and clearly separate from
+ordinary app methods.
+
+## Open Follow-Up Work
+
+- Worker `postMessage` adapter in the WASM/JS layer.
+- WebSocket or other network adapter.
+- Dedicated mutation frames for write forwarding if bundle data frames are too
+  broad.
+- Replay window storage and eviction policy.
+- Capability negotiation for compression, binary framing, catalogue lanes, and
+  blob transfer.
+- Product-facing connection API once the protocol state machine is proven.

--- a/examples/mini-sqlite-todo-yew/src/browser_runtime.rs
+++ b/examples/mini-sqlite-todo-yew/src/browser_runtime.rs
@@ -196,14 +196,20 @@ impl BrowserRuntime {
     }
 
     pub fn unsubscribe(&self, id: SubscriptionId) {
-        let _ = self.with_inner(|inner| {
+        let result = self.with_inner(|inner| {
             if let Some(entry) = inner.subscriptions.remove(&id) {
-                inner
+                let client_messages = inner
                     .connection_manager
-                    .unsubscribe(&entry.connection_subscription);
+                    .unsubscribe(&entry.connection_subscription)
+                    .map_err(error_message)?;
+                inner.send_protocol_messages(client_messages)?;
             }
             Ok(())
         });
+        match result {
+            Ok(()) => self.emit_status(),
+            Err(error) => self.set_error(error),
+        }
     }
 
     pub fn sync_queries(&self, queries: Vec<BuiltQuery>) -> Result<(), String> {

--- a/examples/mini-sqlite-todo-yew/src/browser_runtime.rs
+++ b/examples/mini-sqlite-todo-yew/src/browser_runtime.rs
@@ -1,9 +1,10 @@
 use crate::browser_worker::{
     BrowserStorageStats, RuntimeRequestId, RuntimeWorkerInput, RuntimeWorkerOutput,
-    WorkerSyncProfile,
 };
 use crate::worker_bridge::WorkerClient;
-use js_sys::{Date, Function, Promise};
+use js_sys::{Function, Promise};
+use mini_jazz_sqlite::connection::{DownstreamConnectionManager, DownstreamConnectionSubscription};
+use mini_jazz_sqlite::protocol::{ClientMessage, ServerMessage, SettlementTier};
 use mini_jazz_sqlite::{
     sync::Bundle, BuiltQuery, RowView, RowsSubscription, Runtime, SchemaDef, Storage, StorageStats,
     SubscriptionDelta,
@@ -33,17 +34,6 @@ pub struct BrowserRuntimeStatus {
     pub syncing: bool,
     pub error: String,
     pub worker_storage_stats: BrowserStorageStats,
-    pub last_sync: BrowserSyncProfile,
-}
-
-#[derive(Clone, Debug, Default, PartialEq)]
-pub struct BrowserSyncProfile {
-    pub main_export_ms: f64,
-    pub main_subscription_ms: f64,
-    pub worker_apply_ms: f64,
-    pub worker_query_ms: f64,
-    pub worker_export_ms: f64,
-    pub round_trip_ms: f64,
 }
 
 #[derive(Clone)]
@@ -54,28 +44,21 @@ pub struct BrowserRuntime {
 struct Inner {
     main: Runtime,
     worker: WorkerClient<RuntimeWorkerInput, RuntimeWorkerOutput>,
+    connection_manager: DownstreamConnectionManager,
     subscriptions: BTreeMap<SubscriptionId, BrowserRowsSubscription>,
     next_subscription_id: SubscriptionId,
     next_request_id: RuntimeRequestId,
-    pending_syncs: BTreeMap<RuntimeRequestId, PendingSync>,
-    pending_hydrates: BTreeMap<RuntimeRequestId, PendingHydrate>,
+    pending_syncs: BTreeSet<RuntimeRequestId>,
+    pending_hydrates: BTreeSet<RuntimeRequestId>,
+    pending_protocols: BTreeSet<RuntimeRequestId>,
     status: BrowserRuntimeStatus,
     on_status: Callback<BrowserRuntimeStatus>,
 }
 
 struct BrowserRowsSubscription {
-    query: BuiltQuery,
+    connection_subscription: DownstreamConnectionSubscription,
     subscription: RowsSubscription,
     callback: Callback<SubscriptionDelta>,
-}
-
-struct PendingSync {
-    started_at_ms: f64,
-    main_export_ms: f64,
-}
-
-struct PendingHydrate {
-    started_at_ms: f64,
 }
 
 type PendingSubscriptionNotification = (Callback<SubscriptionDelta>, SubscriptionDelta);
@@ -92,6 +75,13 @@ impl BrowserRuntime {
             config.schema.clone(),
         )
         .map_err(error_message)?;
+        let mut connection_manager = DownstreamConnectionManager::new(
+            format!("{}-session", config.main_node_id),
+            config.main_node_id.clone(),
+            main.local_schema_fingerprint(),
+            main.local_policy_fingerprint(),
+        );
+        let opening_client_messages = connection_manager.open().map_err(error_message)?;
         let runtime_slot = Rc::new(RefCell::new(None::<BrowserRuntime>));
         let worker = WorkerClient::spawn("./worker_loader.js?v=generic-runtime", {
             let runtime_slot = runtime_slot.clone();
@@ -106,11 +96,13 @@ impl BrowserRuntime {
             inner: Rc::new(RefCell::new(Inner {
                 main,
                 worker,
+                connection_manager,
                 subscriptions: BTreeMap::new(),
                 next_subscription_id: 0,
                 next_request_id: 0,
-                pending_syncs: BTreeMap::new(),
-                pending_hydrates: BTreeMap::new(),
+                pending_syncs: BTreeSet::new(),
+                pending_hydrates: BTreeSet::new(),
+                pending_protocols: BTreeSet::new(),
                 status: BrowserRuntimeStatus::default(),
                 on_status,
             })),
@@ -124,6 +116,7 @@ impl BrowserRuntime {
                 user: config.user,
                 schema: config.schema,
                 hydrate_queries: config.hydrate_queries,
+                client_messages: opening_client_messages,
             })?;
             Ok(())
         })?;
@@ -183,14 +176,19 @@ impl BrowserRuntime {
                 .next_subscription_id
                 .checked_add(1)
                 .ok_or_else(|| "subscription id overflow".to_owned())?;
+            let (connection_subscription, client_messages) = inner
+                .connection_manager
+                .subscribe(query.clone(), SettlementTier::Local)
+                .map_err(error_message)?;
             inner.subscriptions.insert(
                 id,
                 BrowserRowsSubscription {
-                    query,
+                    connection_subscription,
                     subscription,
                     callback: callback.clone(),
                 },
             );
+            inner.send_protocol_messages(client_messages)?;
             Ok((id, initial, callback))
         })?;
         callback.emit(initial);
@@ -199,7 +197,11 @@ impl BrowserRuntime {
 
     pub fn unsubscribe(&self, id: SubscriptionId) {
         let _ = self.with_inner(|inner| {
-            inner.subscriptions.remove(&id);
+            if let Some(entry) = inner.subscriptions.remove(&id) {
+                inner
+                    .connection_manager
+                    .unsubscribe(&entry.connection_subscription);
+            }
             Ok(())
         });
     }
@@ -249,11 +251,7 @@ impl BrowserRuntime {
     }
 
     pub fn refresh_subscriptions(&self) -> Result<(), String> {
-        let result = self.with_inner(|inner| {
-            let (notifications, main_subscription_ms) = inner.refresh_subscriptions()?;
-            inner.status.last_sync.main_subscription_ms = main_subscription_ms;
-            Ok(notifications)
-        });
+        let result = self.with_inner(|inner| inner.refresh_subscriptions());
         match result {
             Ok(notifications) => {
                 self.emit_notifications(notifications);
@@ -279,14 +277,19 @@ impl BrowserRuntime {
         let result = match output {
             RuntimeWorkerOutput::Opened {
                 bundles,
+                server_messages,
                 storage_stats,
-            } => self.apply_opened(bundles, storage_stats),
+            } => self.apply_opened(bundles, server_messages, storage_stats),
             RuntimeWorkerOutput::Applied {
                 request_id,
-                bundles,
-                profile,
+                server_messages,
                 storage_stats,
-            } => self.apply_synced(request_id, bundles, profile, storage_stats),
+            } => self.apply_synced(request_id, server_messages, storage_stats),
+            RuntimeWorkerOutput::Protocol {
+                request_id,
+                server_messages,
+                storage_stats,
+            } => self.apply_protocol(request_id, server_messages, storage_stats),
             RuntimeWorkerOutput::Exported { request_id, bundle } => {
                 self.apply_hydrated(request_id, vec![bundle])
             }
@@ -318,18 +321,20 @@ impl BrowserRuntime {
     fn apply_opened(
         &self,
         bundles: Vec<Bundle>,
+        server_messages: Vec<ServerMessage>,
         storage_stats: BrowserStorageStats,
     ) -> Result<Vec<PendingSubscriptionNotification>, String> {
         self.with_inner(|inner| {
             for bundle in bundles {
                 inner.main.apply_bundle(&bundle).map_err(error_message)?;
             }
-            let (notifications, main_subscription_ms) = inner.refresh_subscriptions()?;
+            let client_messages = inner.apply_protocol_messages(server_messages)?;
+            inner.send_protocol_messages(client_messages)?;
+            let notifications = inner.refresh_subscriptions()?;
             inner.status.ready = true;
             inner.status.syncing = inner.has_pending_work();
             inner.status.error.clear();
             inner.status.worker_storage_stats = storage_stats;
-            inner.status.last_sync.main_subscription_ms = main_subscription_ms;
             Ok(notifications)
         })
     }
@@ -337,24 +342,36 @@ impl BrowserRuntime {
     fn apply_synced(
         &self,
         request_id: RuntimeRequestId,
-        bundles: Vec<Bundle>,
-        worker_profile: WorkerSyncProfile,
+        server_messages: Vec<ServerMessage>,
         storage_stats: BrowserStorageStats,
     ) -> Result<Vec<PendingSubscriptionNotification>, String> {
         self.with_inner(|inner| {
-            let pending = inner.pending_syncs.remove(&request_id);
-            for bundle in bundles {
-                inner.main.apply_bundle(&bundle).map_err(error_message)?;
+            if !inner.pending_syncs.remove(&request_id) {
+                return Ok(Vec::new());
             }
-            let (notifications, main_subscription_ms) = inner.refresh_subscriptions()?;
-            if let Some(pending) = pending {
-                inner.status.last_sync.main_export_ms = pending.main_export_ms;
-                inner.status.last_sync.round_trip_ms = Date::now() - pending.started_at_ms;
+            let client_messages = inner.apply_protocol_messages(server_messages)?;
+            inner.send_protocol_messages(client_messages)?;
+            let notifications = inner.refresh_subscriptions()?;
+            inner.status.worker_storage_stats = storage_stats;
+            inner.status.syncing = inner.has_pending_work();
+            inner.status.error.clear();
+            Ok(notifications)
+        })
+    }
+
+    fn apply_protocol(
+        &self,
+        request_id: RuntimeRequestId,
+        server_messages: Vec<ServerMessage>,
+        storage_stats: BrowserStorageStats,
+    ) -> Result<Vec<PendingSubscriptionNotification>, String> {
+        self.with_inner(|inner| {
+            if !inner.pending_protocols.remove(&request_id) {
+                return Ok(Vec::new());
             }
-            inner.status.last_sync.main_subscription_ms = main_subscription_ms;
-            inner.status.last_sync.worker_apply_ms = worker_profile.apply_ms;
-            inner.status.last_sync.worker_query_ms = worker_profile.refresh_query_ms;
-            inner.status.last_sync.worker_export_ms = worker_profile.refresh_export_ms;
+            let client_messages = inner.apply_protocol_messages(server_messages)?;
+            inner.send_protocol_messages(client_messages)?;
+            let notifications = inner.refresh_subscriptions()?;
             inner.status.worker_storage_stats = storage_stats;
             inner.status.syncing = inner.has_pending_work();
             inner.status.error.clear();
@@ -368,16 +385,13 @@ impl BrowserRuntime {
         bundles: Vec<Bundle>,
     ) -> Result<Vec<PendingSubscriptionNotification>, String> {
         self.with_inner(|inner| {
-            let pending = inner.pending_hydrates.remove(&request_id);
-            let Some(pending) = pending else {
+            if !inner.pending_hydrates.remove(&request_id) {
                 return Ok(Vec::new());
-            };
+            }
             for bundle in bundles {
                 inner.main.apply_bundle(&bundle).map_err(error_message)?;
             }
-            let (notifications, main_subscription_ms) = inner.refresh_subscriptions()?;
-            inner.status.last_sync.round_trip_ms = Date::now() - pending.started_at_ms;
-            inner.status.last_sync.main_subscription_ms = main_subscription_ms;
+            let notifications = inner.refresh_subscriptions()?;
             inner.status.syncing = inner.has_pending_work();
             inner.status.error.clear();
             Ok(notifications)
@@ -403,6 +417,7 @@ impl BrowserRuntime {
             inner.status.error = error;
             inner.pending_syncs.clear();
             inner.pending_hydrates.clear();
+            inner.pending_protocols.clear();
         }
         self.emit_status();
     }
@@ -410,48 +425,36 @@ impl BrowserRuntime {
 
 impl Inner {
     fn sync_queries(&mut self, queries: Vec<BuiltQuery>) -> Result<(), String> {
+        self.ensure_ready()?;
         if queries.is_empty() {
             return Ok(());
         }
 
-        let export_started_at = Date::now();
         let bundles = queries
             .into_iter()
             .map(|query| self.main.export_query(query).map_err(error_message))
             .collect::<Result<Vec<_>, _>>()?;
-        let main_export_ms = Date::now() - export_started_at;
-        let refresh_queries = self.subscription_queries();
+        let client_messages = self.replay_connection_subscriptions()?;
         let request_id = self.next_request_id()?;
 
-        self.pending_syncs.insert(
-            request_id,
-            PendingSync {
-                started_at_ms: Date::now(),
-                main_export_ms,
-            },
-        );
+        self.pending_syncs.insert(request_id);
         self.status.syncing = true;
-        self.status.last_sync.main_export_ms = main_export_ms;
         self.worker.send(RuntimeWorkerInput::ApplyBundles {
             request_id,
             bundles,
-            refresh_queries,
+            client_messages,
         })?;
         Ok(())
     }
 
     fn hydrate_queries(&mut self, queries: Vec<BuiltQuery>) -> Result<(), String> {
+        self.ensure_ready()?;
         if queries.is_empty() {
             return Ok(());
         }
 
         let request_id = self.next_request_id()?;
-        self.pending_hydrates.insert(
-            request_id,
-            PendingHydrate {
-                started_at_ms: Date::now(),
-            },
-        );
+        self.pending_hydrates.insert(request_id);
         self.status.syncing = true;
         if queries.len() == 1 {
             let mut queries = queries;
@@ -476,21 +479,51 @@ impl Inner {
         Ok(request_id)
     }
 
-    fn subscription_queries(&self) -> Vec<BuiltQuery> {
-        self.subscriptions
-            .values()
-            .map(|entry| entry.query.clone())
-            .collect()
+    fn ensure_ready(&self) -> Result<(), String> {
+        if self.status.ready {
+            Ok(())
+        } else {
+            Err("runtime is opening".to_owned())
+        }
+    }
+
+    fn replay_connection_subscriptions(&mut self) -> Result<Vec<ClientMessage>, String> {
+        self.connection_manager.replay().map_err(error_message)
+    }
+
+    fn apply_protocol_messages(
+        &mut self,
+        server_messages: Vec<ServerMessage>,
+    ) -> Result<Vec<ClientMessage>, String> {
+        self.connection_manager
+            .receive(&mut self.main, server_messages)
+            .map_err(error_message)
+    }
+
+    fn send_protocol_messages(
+        &mut self,
+        client_messages: Vec<ClientMessage>,
+    ) -> Result<(), String> {
+        if client_messages.is_empty() {
+            return Ok(());
+        }
+        let request_id = self.next_request_id()?;
+        self.pending_protocols.insert(request_id);
+        self.status.syncing = true;
+        self.worker.send(RuntimeWorkerInput::Protocol {
+            request_id,
+            client_messages,
+        })?;
+        Ok(())
     }
 
     fn has_pending_work(&self) -> bool {
-        !self.pending_syncs.is_empty() || !self.pending_hydrates.is_empty()
+        !self.pending_syncs.is_empty()
+            || !self.pending_hydrates.is_empty()
+            || !self.pending_protocols.is_empty()
     }
 
-    fn refresh_subscriptions(
-        &mut self,
-    ) -> Result<(Vec<PendingSubscriptionNotification>, f64), String> {
-        let started_at = Date::now();
+    fn refresh_subscriptions(&mut self) -> Result<Vec<PendingSubscriptionNotification>, String> {
         let ids = self
             .subscriptions
             .keys()
@@ -515,7 +548,7 @@ impl Inner {
             }
         }
 
-        Ok((notifications, Date::now() - started_at))
+        Ok(notifications)
     }
 }
 

--- a/examples/mini-sqlite-todo-yew/src/browser_worker.rs
+++ b/examples/mini-sqlite-todo-yew/src/browser_worker.rs
@@ -2,6 +2,8 @@
 
 #[cfg(target_arch = "wasm32")]
 use crate::worker_bridge::WorkerResponder;
+use mini_jazz_sqlite::connection::UpstreamConnectionManager;
+use mini_jazz_sqlite::protocol::{ClientMessage, ServerMessage};
 #[cfg(target_arch = "wasm32")]
 use mini_jazz_sqlite::Storage;
 use mini_jazz_sqlite::{sync::Bundle, BuiltQuery, RowView, Runtime, SchemaDef, StorageStats};
@@ -23,11 +25,16 @@ pub enum RuntimeWorkerInput {
         user: String,
         schema: SchemaDef,
         hydrate_queries: Vec<BuiltQuery>,
+        client_messages: Vec<ClientMessage>,
     },
     ApplyBundles {
         request_id: RuntimeRequestId,
         bundles: Vec<Bundle>,
-        refresh_queries: Vec<BuiltQuery>,
+        client_messages: Vec<ClientMessage>,
+    },
+    Protocol {
+        request_id: RuntimeRequestId,
+        client_messages: Vec<ClientMessage>,
     },
     ExportQuery {
         request_id: RuntimeRequestId,
@@ -50,12 +57,17 @@ pub enum RuntimeWorkerInput {
 pub enum RuntimeWorkerOutput {
     Opened {
         bundles: Vec<Bundle>,
+        server_messages: Vec<ServerMessage>,
         storage_stats: BrowserStorageStats,
     },
     Applied {
         request_id: RuntimeRequestId,
-        bundles: Vec<Bundle>,
-        profile: WorkerSyncProfile,
+        server_messages: Vec<ServerMessage>,
+        storage_stats: BrowserStorageStats,
+    },
+    Protocol {
+        request_id: RuntimeRequestId,
+        server_messages: Vec<ServerMessage>,
         storage_stats: BrowserStorageStats,
     },
     Exported {
@@ -78,13 +90,6 @@ pub enum RuntimeWorkerOutput {
         request_id: Option<RuntimeRequestId>,
         message: String,
     },
-}
-
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
-pub struct WorkerSyncProfile {
-    pub apply_ms: f64,
-    pub refresh_query_ms: f64,
-    pub refresh_export_ms: f64,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -147,11 +152,15 @@ impl From<RowView> for BrowserRowView {
 
 pub struct BrowserRuntimeWorker {
     runtime: Option<Runtime>,
+    upstream_connection_manager: Option<UpstreamConnectionManager>,
 }
 
 impl BrowserRuntimeWorker {
     pub fn new() -> Self {
-        Self { runtime: None }
+        Self {
+            runtime: None,
+            upstream_connection_manager: None,
+        }
     }
 
     #[cfg(target_arch = "wasm32")]
@@ -167,24 +176,40 @@ impl BrowserRuntimeWorker {
                 user,
                 schema,
                 hydrate_queries,
+                client_messages,
             } => {
                 spawn_local(async move {
-                    let output =
-                        match open_and_hydrate(db_name, node_id, user, schema, hydrate_queries)
-                            .await
-                        {
-                            Ok((runtime, bundles, storage_stats)) => {
-                                worker.borrow_mut().runtime = Some(runtime);
-                                RuntimeWorkerOutput::Opened {
-                                    bundles,
-                                    storage_stats,
-                                }
+                    let output = match open_and_hydrate(
+                        db_name,
+                        node_id,
+                        user,
+                        schema,
+                        hydrate_queries,
+                        client_messages,
+                    )
+                    .await
+                    {
+                        Ok((
+                            runtime,
+                            upstream_connection_manager,
+                            bundles,
+                            server_messages,
+                            storage_stats,
+                        )) => {
+                            worker.borrow_mut().runtime = Some(runtime);
+                            worker.borrow_mut().upstream_connection_manager =
+                                Some(upstream_connection_manager);
+                            RuntimeWorkerOutput::Opened {
+                                bundles,
+                                server_messages,
+                                storage_stats,
                             }
-                            Err(message) => RuntimeWorkerOutput::Error {
-                                request_id: None,
-                                message,
-                            },
-                        };
+                        }
+                        Err(message) => RuntimeWorkerOutput::Error {
+                            request_id: None,
+                            message,
+                        },
+                    };
                     responder.send(output);
                 });
             }
@@ -201,12 +226,40 @@ impl BrowserRuntimeWorker {
             RuntimeWorkerInput::ApplyBundles {
                 request_id,
                 bundles,
-                refresh_queries,
+                client_messages,
             } => {
                 let Some(runtime) = self.runtime.as_mut() else {
                     return runtime_not_ready(request_id);
                 };
-                apply_bundles(runtime, request_id, bundles, refresh_queries)
+                let Some(upstream_connection_manager) = self.upstream_connection_manager.as_mut()
+                else {
+                    return runtime_not_ready(request_id);
+                };
+                apply_bundles(
+                    runtime,
+                    upstream_connection_manager,
+                    request_id,
+                    bundles,
+                    client_messages,
+                )
+            }
+            RuntimeWorkerInput::Protocol {
+                request_id,
+                client_messages,
+            } => {
+                let Some(runtime) = self.runtime.as_mut() else {
+                    return runtime_not_ready(request_id);
+                };
+                let Some(upstream_connection_manager) = self.upstream_connection_manager.as_mut()
+                else {
+                    return runtime_not_ready(request_id);
+                };
+                protocol_messages(
+                    runtime,
+                    upstream_connection_manager,
+                    request_id,
+                    client_messages,
+                )
             }
             RuntimeWorkerInput::ExportQuery { request_id, query } => {
                 let Some(runtime) = self.runtime.as_ref() else {
@@ -258,27 +311,59 @@ async fn open_and_hydrate(
     user: String,
     schema: SchemaDef,
     hydrate_queries: Vec<BuiltQuery>,
-) -> Result<(Runtime, Vec<Bundle>, BrowserStorageStats), String> {
-    let runtime = open_opfs_runtime(&db_name, &node_id, &user, schema).await?;
+    client_messages: Vec<ClientMessage>,
+) -> Result<
+    (
+        Runtime,
+        UpstreamConnectionManager,
+        Vec<Bundle>,
+        Vec<ServerMessage>,
+        BrowserStorageStats,
+    ),
+    String,
+> {
+    let mut runtime = open_opfs_runtime(&db_name, &node_id, &user, schema).await?;
+    let mut upstream_connection_manager = UpstreamConnectionManager::new(
+        format!("{node_id}-session"),
+        node_id.clone(),
+        runtime.local_schema_fingerprint(),
+        runtime.local_policy_fingerprint(),
+    );
     let bundles = hydrate_queries
         .into_iter()
         .map(|query| runtime.export_query(query).map_err(error_message))
         .collect::<Result<Vec<_>, _>>()?;
+    let server_messages = pump_upstream_connection_manager(
+        &mut runtime,
+        &mut upstream_connection_manager,
+        client_messages,
+    )?;
     let storage_stats = runtime.storage_stats().map_err(error_message)?.into();
-    Ok((runtime, bundles, storage_stats))
+    Ok((
+        runtime,
+        upstream_connection_manager,
+        bundles,
+        server_messages,
+        storage_stats,
+    ))
 }
 
 fn apply_bundles(
     runtime: &mut Runtime,
+    upstream_connection_manager: &mut UpstreamConnectionManager,
     request_id: RuntimeRequestId,
     bundles: Vec<Bundle>,
-    refresh_queries: Vec<BuiltQuery>,
+    client_messages: Vec<ClientMessage>,
 ) -> RuntimeWorkerOutput {
-    match apply_and_refresh(runtime, bundles, refresh_queries) {
-        Ok((bundles, profile, storage_stats)) => RuntimeWorkerOutput::Applied {
+    match apply_and_refresh(
+        runtime,
+        upstream_connection_manager,
+        bundles,
+        client_messages,
+    ) {
+        Ok((server_messages, storage_stats)) => RuntimeWorkerOutput::Applied {
             request_id,
-            bundles,
-            profile,
+            server_messages,
             storage_stats,
         },
         Err(message) => RuntimeWorkerOutput::Error {
@@ -290,38 +375,58 @@ fn apply_bundles(
 
 fn apply_and_refresh(
     runtime: &mut Runtime,
+    upstream_connection_manager: &mut UpstreamConnectionManager,
     bundles: Vec<Bundle>,
-    refresh_queries: Vec<BuiltQuery>,
-) -> Result<(Vec<Bundle>, WorkerSyncProfile, BrowserStorageStats), String> {
-    let apply_started_at = now_ms();
+    client_messages: Vec<ClientMessage>,
+) -> Result<(Vec<ServerMessage>, BrowserStorageStats), String> {
     for bundle in bundles {
         runtime.apply_bundle(&bundle).map_err(error_message)?;
     }
-    let apply_ms = now_ms() - apply_started_at;
 
-    let query_started_at = now_ms();
-    for query in &refresh_queries {
-        runtime.query(query.clone()).map_err(error_message)?;
-    }
-    let refresh_query_ms = now_ms() - query_started_at;
-
-    let export_started_at = now_ms();
-    let bundles = refresh_queries
-        .into_iter()
-        .map(|query| runtime.export_query(query).map_err(error_message))
-        .collect::<Result<Vec<_>, _>>()?;
-    let refresh_export_ms = now_ms() - export_started_at;
-
+    let server_messages =
+        pump_upstream_connection_manager(runtime, upstream_connection_manager, client_messages)?;
     let storage_stats = runtime.storage_stats().map_err(error_message)?.into();
-    Ok((
-        bundles,
-        WorkerSyncProfile {
-            apply_ms,
-            refresh_query_ms,
-            refresh_export_ms,
+    Ok((server_messages, storage_stats))
+}
+
+fn protocol_messages(
+    runtime: &mut Runtime,
+    upstream_connection_manager: &mut UpstreamConnectionManager,
+    request_id: RuntimeRequestId,
+    client_messages: Vec<ClientMessage>,
+) -> RuntimeWorkerOutput {
+    match pump_upstream_connection_manager(runtime, upstream_connection_manager, client_messages) {
+        Ok(server_messages) => {
+            let storage_stats = match runtime.storage_stats().map_err(error_message) {
+                Ok(stats) => stats.into(),
+                Err(message) => {
+                    return RuntimeWorkerOutput::Error {
+                        request_id: Some(request_id),
+                        message,
+                    };
+                }
+            };
+            RuntimeWorkerOutput::Protocol {
+                request_id,
+                server_messages,
+                storage_stats,
+            }
+        }
+        Err(message) => RuntimeWorkerOutput::Error {
+            request_id: Some(request_id),
+            message,
         },
-        storage_stats,
-    ))
+    }
+}
+
+fn pump_upstream_connection_manager(
+    runtime: &mut Runtime,
+    upstream_connection_manager: &mut UpstreamConnectionManager,
+    client_messages: Vec<ClientMessage>,
+) -> Result<Vec<ServerMessage>, String> {
+    upstream_connection_manager
+        .receive(runtime, client_messages)
+        .map_err(error_message)
 }
 
 fn export_query(
@@ -421,16 +526,6 @@ async fn open_opfs_runtime(
 }
 
 #[cfg(target_arch = "wasm32")]
-fn now_ms() -> f64 {
-    js_sys::Date::now()
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-fn now_ms() -> f64 {
-    0.0
-}
-
-#[cfg(target_arch = "wasm32")]
 fn opfs_pool_name(db_name: &str) -> String {
     let mut name = String::from("mini-jazz-sqlite-");
     for ch in db_name.chars() {
@@ -473,6 +568,7 @@ mod tests {
                 limit: Some(10),
                 offset: None,
             }],
+            client_messages: Vec::new(),
         };
 
         let decoded: RuntimeWorkerInput = serde_round_trip(&message);
@@ -503,16 +599,25 @@ mod tests {
         let message = RuntimeWorkerInput::ApplyBundles {
             request_id: 42,
             bundles: vec![bundle],
-            refresh_queries: vec![BuiltQuery {
-                table: "todos".to_owned(),
-                conditions: vec![QueryCondition {
-                    column: "labels".to_owned(),
-                    op: QueryConditionOp::In,
-                    value: json!(["work", {"nested": true}]),
+            client_messages: vec![mini_jazz_sqlite::protocol::ClientMessage::Replay {
+                subscriptions: vec![mini_jazz_sqlite::protocol::ReplaySubscription {
+                    subscription_id: mini_jazz_sqlite::protocol::SubscriptionId::new(
+                        "browser-subscription-1",
+                    ),
+                    query: BuiltQuery {
+                        table: "todos".to_owned(),
+                        conditions: vec![QueryCondition {
+                            column: "labels".to_owned(),
+                            op: QueryConditionOp::In,
+                            value: json!(["work", {"nested": true}]),
+                        }],
+                        order_by: Vec::new(),
+                        limit: Some(10),
+                        offset: None,
+                    },
+                    requested_tier: mini_jazz_sqlite::protocol::SettlementTier::Local,
+                    last_applied_cursor: None,
                 }],
-                order_by: Vec::new(),
-                limit: Some(10),
-                offset: None,
             }],
         };
 
@@ -522,6 +627,159 @@ mod tests {
             serde_json::to_value(decoded).unwrap(),
             serde_json::to_value(message).unwrap()
         );
+    }
+
+    #[test]
+    fn worker_protocol_message_round_trips_through_serde_json() {
+        let message = RuntimeWorkerInput::Protocol {
+            request_id: 99,
+            client_messages: vec![mini_jazz_sqlite::protocol::ClientMessage::Close(
+                mini_jazz_sqlite::protocol::CloseReason::ClientClosed,
+            )],
+        };
+
+        let decoded: RuntimeWorkerInput = serde_round_trip(&message);
+
+        assert_eq!(
+            serde_json::to_value(decoded).unwrap(),
+            serde_json::to_value(message).unwrap()
+        );
+
+        let output = RuntimeWorkerOutput::Protocol {
+            request_id: 99,
+            server_messages: vec![mini_jazz_sqlite::protocol::ServerMessage::Close(
+                mini_jazz_sqlite::protocol::CloseReason::ClientClosed,
+            )],
+            storage_stats: BrowserStorageStats::default(),
+        };
+        let decoded: RuntimeWorkerOutput = serde_round_trip(&output);
+
+        assert_eq!(
+            serde_json::to_value(decoded).unwrap(),
+            serde_json::to_value(output).unwrap()
+        );
+    }
+
+    #[test]
+    fn worker_applied_output_deserializes_minimal_payload() {
+        let message = json!({
+            "Applied": {
+                "request_id": 7,
+                "server_messages": [],
+                "storage_stats": BrowserStorageStats::default()
+            }
+        });
+
+        let decoded: RuntimeWorkerOutput = serde_json::from_value(message).unwrap();
+
+        let RuntimeWorkerOutput::Applied {
+            request_id,
+            server_messages,
+            storage_stats,
+            ..
+        } = decoded
+        else {
+            panic!("expected applied output");
+        };
+        assert_eq!(request_id, 7);
+        assert!(server_messages.is_empty());
+        assert_eq!(storage_stats, BrowserStorageStats::default());
+    }
+
+    #[test]
+    fn worker_protocol_subscribe_exports_query_data_and_settlement() {
+        use mini_jazz_sqlite::protocol::{
+            ClientHello, ClientMessage, ProtocolVersion, ServerMessage, SessionId, SettlementTier,
+            SubscriptionId,
+        };
+
+        let mut runtime =
+            Runtime::open_with_schema(Storage::Memory, "worker", "alice", todo_schema()).unwrap();
+        runtime
+            .insert_row(
+                "projects",
+                "project-1",
+                BTreeMap::from([("title".to_owned(), json!("Launch"))]),
+            )
+            .unwrap();
+        runtime
+            .insert_row(
+                "todos",
+                "todo-1",
+                BTreeMap::from([
+                    ("title".to_owned(), json!("Use protocol")),
+                    ("done".to_owned(), json!(false)),
+                    ("project".to_owned(), json!("project-1")),
+                ]),
+            )
+            .unwrap();
+        let schema_fingerprint = runtime.local_schema_fingerprint();
+        let policy_fingerprint = runtime.local_policy_fingerprint();
+        let query = BuiltQuery {
+            table: "todos".to_owned(),
+            conditions: vec![QueryCondition {
+                column: "done".to_owned(),
+                op: QueryConditionOp::Eq,
+                value: json!(false),
+            }],
+            order_by: Vec::new(),
+            limit: Some(10),
+            offset: None,
+        };
+        let subscription_id = SubscriptionId::new("browser-subscription-1");
+        let mut worker = BrowserRuntimeWorker {
+            runtime: Some(runtime),
+            upstream_connection_manager: Some(UpstreamConnectionManager::new(
+                "worker-session",
+                "worker",
+                schema_fingerprint.clone(),
+                policy_fingerprint.clone(),
+            )),
+        };
+
+        let output = worker.handle_sync(RuntimeWorkerInput::Protocol {
+            request_id: 7,
+            client_messages: vec![
+                ClientMessage::Hello(ClientHello {
+                    protocol_version: ProtocolVersion(1),
+                    session_id: SessionId::new("browser-session"),
+                    node_id: "browser".to_owned(),
+                    schema_fingerprint,
+                    policy_fingerprint,
+                }),
+                ClientMessage::Subscribe {
+                    subscription_id: subscription_id.clone(),
+                    query,
+                    requested_tier: SettlementTier::Local,
+                },
+            ],
+        });
+
+        let RuntimeWorkerOutput::Protocol {
+            request_id,
+            server_messages,
+            ..
+        } = output
+        else {
+            panic!("expected protocol output");
+        };
+        assert_eq!(request_id, 7);
+        assert!(matches!(server_messages[0], ServerMessage::Hello(_)));
+        assert!(matches!(
+            &server_messages[1],
+            ServerMessage::Data {
+                subscription_id: Some(id),
+                ..
+            } if id == &subscription_id
+        ));
+        assert!(matches!(
+            &server_messages[2],
+            ServerMessage::Settled {
+                subscription_id: id,
+                tier: SettlementTier::Local,
+                ..
+            } if id == &subscription_id
+        ));
     }
 
     #[test]

--- a/examples/mini-sqlite-todo-yew/src/main.rs
+++ b/examples/mini-sqlite-todo-yew/src/main.rs
@@ -257,18 +257,10 @@ mod app {
     }
 
     fn summary_text(state: &TodoState) -> String {
-        let mut parts = vec![
+        let parts = vec![
             format!("{} OPFS current rows", format_count(state.current_rows)),
             format!("page {}", state.query.page + 1),
-            format!("main query {:.2} ms", state.main_query_ms),
-            format!("export {:.2} ms", state.export_ms),
-            format!("OPFS apply {:.2} ms", state.worker_apply_ms),
-            format!("OPFS query {:.2} ms", state.worker_query_ms),
-            format!("round trip {:.2} ms", state.worker_round_trip_ms),
         ];
-        if state.generate_ms > 0.0 {
-            parts.push(format!("generate {:.2} s", state.generate_ms / 1000.0));
-        }
         format!("{}.", parts.join(". "))
     }
 

--- a/examples/mini-sqlite-todo-yew/src/todo_runtime.rs
+++ b/examples/mini-sqlite-todo-yew/src/todo_runtime.rs
@@ -38,12 +38,6 @@ pub struct TodoState {
     pub error: String,
     pub generated: u64,
     pub total_to_generate: u64,
-    pub generate_ms: f64,
-    pub main_query_ms: f64,
-    pub export_ms: f64,
-    pub worker_apply_ms: f64,
-    pub worker_query_ms: f64,
-    pub worker_round_trip_ms: f64,
     pub current_rows: u64,
 }
 
@@ -59,12 +53,6 @@ impl Default for TodoState {
             error: String::new(),
             generated: 0,
             total_to_generate: TOTAL_TO_GENERATE,
-            generate_ms: 0.0,
-            main_query_ms: 0.0,
-            export_ms: 0.0,
-            worker_apply_ms: 0.0,
-            worker_query_ms: 0.0,
-            worker_round_trip_ms: 0.0,
             current_rows: 0,
         }
     }
@@ -196,7 +184,6 @@ impl TodoRuntime {
         self.run_mut(|inner| {
             inner.state.generating = true;
             inner.state.generated = 0;
-            inner.state.generate_ms = 0.0;
             inner.emit();
             Ok(())
         });
@@ -256,11 +243,11 @@ impl TodoRuntime {
     }
 
     async fn generate_100k_inner(&self) -> Result<(), String> {
-        let started_at = Date::now();
+        let id_seed = Date::now() as u64;
         let mut batch_ids = Vec::new();
         let browser = self.browser();
         for index in 0..TOTAL_TO_GENERATE {
-            let id = format!("todo-{}-{}", started_at as u64, index);
+            let id = format!("todo-{id_seed}-{index}");
             browser.insert_row(
                 "todos",
                 &id,
@@ -293,7 +280,6 @@ impl TodoRuntime {
         browser.refresh_subscriptions()?;
 
         self.with_inner(|inner| {
-            inner.state.generate_ms = Date::now() - started_at;
             inner.state.generating = false;
             inner.emit();
             Ok(())
@@ -307,11 +293,6 @@ impl TodoRuntime {
                 inner.state.syncing = status.syncing;
                 inner.state.error = status.error;
                 inner.state.current_rows = status.worker_storage_stats.current_rows.max(0) as u64;
-                inner.state.main_query_ms = status.last_sync.main_subscription_ms;
-                inner.state.export_ms = status.last_sync.main_export_ms;
-                inner.state.worker_apply_ms = status.last_sync.worker_apply_ms;
-                inner.state.worker_query_ms = status.last_sync.worker_query_ms;
-                inner.state.worker_round_trip_ms = status.last_sync.round_trip_ms;
                 let should_ensure_project = status.ready && !inner.project_ensured;
                 if should_ensure_project {
                     inner.project_ensured = true;


### PR DESCRIPTION
This PR generalizes the connection & session management in order to make it possible to reuse the same connection flow over network and postMessage.

Keeping the protocol as-is because I'm going to redesign it completely as next step.

## Summary

- Add protocol, session, and connection-manager building blocks for client-to-upstream subscribe/replay/settled/close flows.
- Route the Yew browser and worker example through typed protocol message batches instead of local protocol lifecycle state.
- Remove sync profiling/timing state from the Yew worker messages, browser runtime status, and visible summary UI.
- Add whole-system coverage for connection manager handshake, replay, settlement, ack, close, local unsubscribe interest, and scoped query errors.
