### PR TITLE
ci(starters): end-to-end harness gating changesets release PR

### DIFF
--- a/.github/workflows/starters-e2e.yml
+++ b/.github/workflows/starters-e2e.yml
@@ -1,0 +1,92 @@
+name: Starters E2E
+
+# Runs the create-jazz-e2e harness against every starter as a matrix job,
+# blocking the changesets release PR if any starter fails to scaffold, install,
+# build, or pass its Playwright suite against the production build.
+#
+# Trigger: any push to the changesets-managed release branch
+# (`changeset-release/main`), plus manual dispatch for ad-hoc runs.
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      starter:
+        description: "Single starter to run (omit for all twelve)"
+        required: false
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    # On PR events, only fire on the changesets release PR. Manual dispatch is
+    # always allowed (handy for testing a starter in isolation).
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'changeset-release/') }}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
+    env:
+      JAZZ_SKIP_RN_DEPS: "1"
+    strategy:
+      fail-fast: false
+      matrix:
+        starter:
+          - next-betterauth
+          - next-localfirst
+          - next-hybrid
+          - sveltekit-betterauth
+          - sveltekit-localfirst
+          - sveltekit-hybrid
+          - react-betterauth
+          - react-localfirst
+          - react-hybrid
+          - ts-betterauth
+          - ts-localfirst
+          - ts-hybrid
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: 1.93.1
+          targets: wasm32-unknown-unknown
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: .nvmrc
+
+      - run: corepack enable
+      - run: pnpm install --frozen-lockfile
+
+      - name: Install Rust prerequisites
+        run: pnpm run ensure:rust-toolchain
+
+      - name: Build core workspace
+        run: pnpm run build:core
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install chromium --with-deps
+
+      - name: Skip if starter doesn't match dispatch filter
+        id: filter
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.starter != '' && github.event.inputs.starter != matrix.starter
+        run: echo "skip=1" >> "$GITHUB_OUTPUT"
+
+      - name: Run create-jazz-e2e harness
+        if: steps.filter.outputs.skip != '1'
+        # `--keep` retains the scaffolded project so the artifact-upload step
+        # below can grab Playwright traces on failure. The runner is torn down
+        # at end-of-job anyway, so there's no on-disk leak.
+        run: pnpm --filter create-jazz-e2e exec tsx src/cli.ts ${{ matrix.starter }} --verbose --keep
+
+      - name: Upload Playwright traces on failure
+        if: failure() && steps.filter.outputs.skip != '1'
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4
+        with:
+          name: playwright-traces-${{ matrix.starter }}
+          path: /tmp/cje2e-${{ matrix.starter }}-*/test-app/test-results/**
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/starters-e2e.yml
+++ b/.github/workflows/starters-e2e.yml
@@ -30,6 +30,9 @@ jobs:
     timeout-minutes: 30
     env:
       JAZZ_SKIP_RN_DEPS: "1"
+      # The scaffolded starter pins its own pnpm via `packageManager`; without
+      # this, Corepack prompts on first download and the non-TTY CI run aborts.
+      COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/starters-e2e.yml
+++ b/.github/workflows/starters-e2e.yml
@@ -11,9 +11,9 @@ name: Starters E2E
 # workspace tarballs (jazz-tools, jazz-napi, jazz-wasm) plus the runtime
 # artifacts the harness needs (jazz-tools/dist, jazz-napi index + .node).
 # The `e2e` matrix then downloads those and runs the harness per starter,
-# skipping the ~10-minute `build:core` step entirely. The prepare job adds
-# ~10 minutes of wall-clock but removes ~10 minutes from each of 12 matrix
-# jobs, dropping total runner-minutes by ~3x.
+# skipping the ~10-minute `build:core` step entirely. Playwright browsers
+# and the pnpm store are cached between jobs so the matrix doesn't repeat
+# the 280 MB chromium download or the lockfile resolution per runner.
 
 on:
   pull_request:
@@ -34,6 +34,10 @@ env:
   # The scaffolded starter pins its own pnpm via `packageManager`; without
   # this, Corepack prompts on first download and the non-TTY CI run aborts.
   COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
+  # actions/upload-artifact and friends still ship a Node 20 entrypoint;
+  # GitHub started warning about that. Force the runner to execute JS actions
+  # under Node 24 so the warning goes away without bumping every action SHA.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   prepare:
@@ -75,6 +79,22 @@ jobs:
             (cd "$dir" && pnpm pack --pack-destination "$GITHUB_WORKSPACE/_e2e-state/tarballs")
           done
           ls -la "$GITHUB_WORKSPACE/_e2e-state/tarballs"
+
+      - name: Cache Playwright browsers
+        # Same key in the matrix below — prepare populates, matrix restores.
+        # The cache is per-OS; we don't key on lockfile because the harness
+        # installs Playwright from inside the scaffolded folder anyway, which
+        # pins its own version. The install command below is idempotent on a
+        # cache hit (Playwright skips re-downloading already-present browsers).
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install chromium --with-deps
 
       - name: Upload prebuilt artifacts
         uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4
@@ -129,7 +149,18 @@ jobs:
           name: starters-e2e-build-state
           path: .
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+
       - name: Install Playwright browsers
+        # On a cache hit this is effectively just the apt step (~30s); the
+        # browser binaries are restored from cache. --with-deps still runs each
+        # job because the system libs aren't part of the cache.
         run: pnpm exec playwright install chromium --with-deps
 
       - name: Skip if starter doesn't match dispatch filter

--- a/.github/workflows/starters-e2e.yml
+++ b/.github/workflows/starters-e2e.yml
@@ -34,10 +34,6 @@ env:
   # The scaffolded starter pins its own pnpm via `packageManager`; without
   # this, Corepack prompts on first download and the non-TTY CI run aborts.
   COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
-  # actions/upload-artifact and friends still ship a Node 20 entrypoint;
-  # GitHub started warning about that. Force the runner to execute JS actions
-  # under Node 24 so the warning goes away without bumping every action SHA.
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   prepare:
@@ -97,7 +93,7 @@ jobs:
         run: pnpm exec playwright install chromium --with-deps
 
       - name: Upload prebuilt artifacts
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: starters-e2e-build-state
           # Tarballs feed `--tarball-dir`. jazz-tools/dist and jazz-napi's JS +
@@ -144,7 +140,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Restore prebuilt artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: starters-e2e-build-state
           path: .
@@ -178,7 +174,7 @@ jobs:
 
       - name: Upload Playwright traces on failure
         if: failure() && steps.filter.outputs.skip != '1'
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-traces-${{ matrix.starter }}
           path: /tmp/cje2e-${{ matrix.starter }}-*/test-app/test-results/**

--- a/.github/workflows/starters-e2e.yml
+++ b/.github/workflows/starters-e2e.yml
@@ -1,11 +1,19 @@
 name: Starters E2E
 
-# Runs the create-jazz-e2e harness against every starter as a matrix job,
-# blocking the changesets release PR if any starter fails to scaffold, install,
-# build, or pass its Playwright suite against the production build.
+# Runs the create-jazz-e2e harness against every starter, blocking the
+# changesets release PR if any starter fails to scaffold, install, build, or
+# pass its Playwright suite against the production build.
 #
 # Trigger: any push to the changesets-managed release branch
 # (`changeset-release/main`), plus manual dispatch for ad-hoc runs.
+#
+# Shape: the `prepare` job builds the workspace once and packs the three
+# workspace tarballs (jazz-tools, jazz-napi, jazz-wasm) plus the runtime
+# artifacts the harness needs (jazz-tools/dist, jazz-napi index + .node).
+# The `e2e` matrix then downloads those and runs the harness per starter,
+# skipping the ~10-minute `build:core` step entirely. The prepare job adds
+# ~10 minutes of wall-clock but removes ~10 minutes from each of 12 matrix
+# jobs, dropping total runner-minutes by ~3x.
 
 on:
   pull_request:
@@ -21,34 +29,19 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+env:
+  JAZZ_SKIP_RN_DEPS: "1"
+  # The scaffolded starter pins its own pnpm via `packageManager`; without
+  # this, Corepack prompts on first download and the non-TTY CI run aborts.
+  COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
+
 jobs:
-  e2e:
+  prepare:
     # On PR events, only fire on the changesets release PR. Manual dispatch is
     # always allowed (handy for testing a starter in isolation).
     if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'changeset-release/') }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 30
-    env:
-      JAZZ_SKIP_RN_DEPS: "1"
-      # The scaffolded starter pins its own pnpm via `packageManager`; without
-      # this, Corepack prompts on first download and the non-TTY CI run aborts.
-      COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
-    strategy:
-      fail-fast: false
-      matrix:
-        starter:
-          - next-betterauth
-          - next-localfirst
-          - next-hybrid
-          - sveltekit-betterauth
-          - sveltekit-localfirst
-          - sveltekit-hybrid
-          - react-betterauth
-          - react-localfirst
-          - react-hybrid
-          - ts-betterauth
-          - ts-localfirst
-          - ts-hybrid
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -70,6 +63,72 @@ jobs:
       - name: Build core workspace
         run: pnpm run build:core
 
+      - name: Pack workspace tarballs
+        # Mirrors PACKAGES_TO_PACK in run-starter.ts. The harness picks these up
+        # via `--tarball-dir` and pins them as `pnpm.overrides` in each
+        # scaffolded app, exactly the same as running `pnpm pack` in-process.
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/_e2e-state/tarballs"
+          for pkg in jazz-tools jazz-napi jazz-wasm; do
+            dir="packages/$pkg"
+            if [ ! -d "$dir" ]; then dir="crates/$pkg"; fi
+            (cd "$dir" && pnpm pack --pack-destination "$GITHUB_WORKSPACE/_e2e-state/tarballs")
+          done
+          ls -la "$GITHUB_WORKSPACE/_e2e-state/tarballs"
+
+      - name: Upload prebuilt artifacts
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4
+        with:
+          name: starters-e2e-build-state
+          # Tarballs feed `--tarball-dir`. jazz-tools/dist and jazz-napi's JS +
+          # native binary are needed at *harness* runtime (the harness imports
+          # `jazz-tools/dev`, which in turn requires jazz-napi).
+          path: |
+            _e2e-state/tarballs/**
+            packages/jazz-tools/dist/**
+            crates/jazz-napi/index.js
+            crates/jazz-napi/index.d.ts
+            crates/jazz-napi/*.node
+          if-no-files-found: error
+          retention-days: 1
+
+  e2e:
+    needs: prepare
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'changeset-release/') }}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        starter:
+          - next-betterauth
+          - next-localfirst
+          - next-hybrid
+          - sveltekit-betterauth
+          - sveltekit-localfirst
+          - sveltekit-hybrid
+          - react-betterauth
+          - react-localfirst
+          - react-hybrid
+          - ts-betterauth
+          - ts-localfirst
+          - ts-hybrid
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: .nvmrc
+
+      - run: corepack enable
+      - run: pnpm install --frozen-lockfile
+
+      - name: Restore prebuilt artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: starters-e2e-build-state
+          path: .
+
       - name: Install Playwright browsers
         run: pnpm exec playwright install chromium --with-deps
 
@@ -80,10 +139,11 @@ jobs:
 
       - name: Run create-jazz-e2e harness
         if: steps.filter.outputs.skip != '1'
-        # `--keep` retains the scaffolded project so the artifact-upload step
-        # below can grab Playwright traces on failure. The runner is torn down
-        # at end-of-job anyway, so there's no on-disk leak.
-        run: pnpm --filter create-jazz-e2e exec tsx src/cli.ts ${{ matrix.starter }} --verbose --keep
+        # `--tarball-dir` makes the harness reuse the prebuilt tarballs from
+        # `prepare` instead of running `pnpm pack` (which would need build:core
+        # to have run in this job). `--keep` retains the scaffolded project so
+        # the artifact-upload step below can grab Playwright traces on failure.
+        run: pnpm --filter create-jazz-e2e exec tsx src/cli.ts ${{ matrix.starter }} --tarball-dir "$GITHUB_WORKSPACE/_e2e-state/tarballs" --verbose --keep
 
       - name: Upload Playwright traces on failure
         if: failure() && steps.filter.outputs.skip != '1'

--- a/packages/create-jazz-e2e/README.md
+++ b/packages/create-jazz-e2e/README.md
@@ -1,0 +1,65 @@
+# create-jazz-e2e
+
+End-to-end harness that builds each `create-jazz` starter the way a real user
+would receive it, then runs the starter's Playwright suite against the
+production build.
+
+This catches a class of bugs that the per-starter Playwright suites miss —
+they run against `pnpm dev`, where the Vite/Turbopack pipelines mask build-time
+problems (e.g. duplicate React copies under Next's SSR worker, jazz-tools/jazz-napi
+resolution differences between dev and prod).
+
+## How it works
+
+For each starter, the harness:
+
+1. **Packs** the workspace packages a starter can transitively pull in
+   (`jazz-tools`, `jazz-napi`, `jazz-wasm`) into `.tgz` tarballs.
+2. **Scaffolds** via the `create-jazz` CLI itself, with `JAZZ_STARTER_PATH`
+   pointing at the local starter dir and `--hosting selfhosted` so it never
+   reaches Jazz Cloud.
+3. **Pins** the tarballs into the scaffolded `package.json` via
+   `pnpm.overrides`. This lets `pnpm install` work even when the alpha versions
+   the workspace bumps to aren't yet on npm (the normal case during a release PR).
+4. **Installs** with `pnpm install --ignore-workspace`.
+5. **Starts a local Jazz sync server** in-process (via `jazz-tools/dev`'s
+   `startLocalJazzServer`) and writes its app ID + URL + backend secret into
+   the scaffolded `.env`. No traffic leaves the runner.
+6. **Builds** the starter (`pnpm build`).
+7. **Runs Playwright** with `JAZZ_E2E_PROD=1` set. Each starter's
+   `playwright.config.ts` reads that flag and swaps its `webServer.command`
+   from `pnpm dev` to the framework-appropriate production start
+   (`next start`, `vite preview`, `node build`, `node server-dist/index.js`).
+
+## Running locally
+
+```bash
+# One starter.
+pnpm build:core
+pnpm --filter create-jazz-e2e exec tsx src/cli.ts next-localfirst
+
+# All twelve, sequentially.
+pnpm --filter create-jazz-e2e exec tsx src/cli.ts --all
+
+# Stream all child output (verbose).
+pnpm --filter create-jazz-e2e exec tsx src/cli.ts next-localfirst --verbose
+
+# Skip the playwright step (build-only smoke).
+pnpm --filter create-jazz-e2e exec tsx src/cli.ts --all --skip-e2e
+
+# Keep the scaffolded tempdir around after a failure for inspection.
+pnpm --filter create-jazz-e2e exec tsx src/cli.ts next-localfirst --keep
+```
+
+Browsers must be installed once per machine:
+
+```bash
+pnpm exec playwright install chromium --with-deps
+```
+
+## CI
+
+`.github/workflows/starters-e2e.yml` runs the harness as a matrix job (one
+runner per starter) on every push to a `changeset-release/*` branch — i.e. the
+release PR that the changesets action keeps updated against `main`. Failures
+block the release.

--- a/packages/create-jazz-e2e/README.md
+++ b/packages/create-jazz-e2e/README.md
@@ -49,6 +49,10 @@ pnpm --filter create-jazz-e2e exec tsx src/cli.ts --all --skip-e2e
 
 # Keep the scaffolded tempdir around after a failure for inspection.
 pnpm --filter create-jazz-e2e exec tsx src/cli.ts next-localfirst --keep
+
+# Skip the in-process `pnpm pack` step and consume prebuilt tarballs
+# (one *.tgz per package in PACKAGES_TO_PACK). Used by CI's prepare job.
+pnpm --filter create-jazz-e2e exec tsx src/cli.ts next-localfirst --tarball-dir ./_e2e-state/tarballs
 ```
 
 Browsers must be installed once per machine:
@@ -59,7 +63,17 @@ pnpm exec playwright install chromium --with-deps
 
 ## CI
 
-`.github/workflows/starters-e2e.yml` runs the harness as a matrix job (one
-runner per starter) on every push to a `changeset-release/*` branch — i.e. the
-release PR that the changesets action keeps updated against `main`. Failures
-block the release.
+`.github/workflows/starters-e2e.yml` is split into two jobs to avoid repeating
+the ~10-minute `build:core` across 12 matrix runners:
+
+1. `prepare` — builds the workspace once, packs the three workspace tarballs,
+   and uploads them alongside the runtime artifacts the harness needs
+   (`jazz-tools/dist`, jazz-napi's `index.js` + native `.node`) as a single
+   workflow artifact.
+2. `e2e` (matrix) — downloads that artifact, installs Playwright browsers, and
+   runs the harness with `--tarball-dir` so it skips the pack step.
+
+Fires on every push to a `changeset-release/*` branch (the release PR that the
+changesets action keeps updated against `main`). Failures block the release.
+`workflow_dispatch` is also available for ad-hoc runs and accepts a single
+`starter` input to run just one matrix slot.

--- a/packages/create-jazz-e2e/package.json
+++ b/packages/create-jazz-e2e/package.json
@@ -7,8 +7,8 @@
   "type": "module",
   "scripts": {
     "check": "tsc --noEmit",
-    "test": "tsx src/cli.ts",
-    "test:all": "tsx src/cli.ts --all"
+    "e2e": "tsx src/cli.ts",
+    "e2e:all": "tsx src/cli.ts --all"
   },
   "dependencies": {
     "create-jazz": "workspace:*",

--- a/packages/create-jazz-e2e/package.json
+++ b/packages/create-jazz-e2e/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "create-jazz-e2e",
+  "version": "0.0.0",
+  "private": true,
+  "description": "End-to-end harness that scaffolds each create-jazz starter, builds it against the local workspace, and runs its Playwright suite against the production build.",
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "check": "tsc --noEmit",
+    "test": "tsx src/cli.ts",
+    "test:all": "tsx src/cli.ts --all"
+  },
+  "dependencies": {
+    "create-jazz": "workspace:*",
+    "jazz-tools": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:default",
+    "picocolors": "^1.1.1",
+    "tsx": "^4.21.0",
+    "typescript": "catalog:default"
+  },
+  "engines": {
+    "node": ">=22.12"
+  }
+}

--- a/packages/create-jazz-e2e/src/cli.ts
+++ b/packages/create-jazz-e2e/src/cli.ts
@@ -1,0 +1,82 @@
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import pc from "picocolors";
+
+import { KNOWN_STARTERS, type StarterName } from "./starters.js";
+import { runStarter, type RunStarterResult } from "./run-starter.js";
+
+function findRepoRoot(): string {
+  // src/cli.ts → ../ is src/, ../../ is the package dir, ../../../ is packages/,
+  // ../../../../ is the repo root.
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(here, "../../..");
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function printResult(r: RunStarterResult): void {
+  const total = r.durations.reduce((acc, p) => acc + p.durationMs, 0);
+  const phaseLine = r.durations.map((p) => `${p.name}=${formatDuration(p.durationMs)}`).join(" ");
+  const tag = r.success ? pc.green("✔") : pc.red("✘");
+  console.log(`${tag} ${r.starter} ${pc.dim(`(${formatDuration(total)})`)}`);
+  console.log(`  ${pc.dim(phaseLine)}`);
+  if (!r.success && r.errorMessage) {
+    console.log(pc.red(r.errorMessage));
+  }
+}
+
+function usage(): never {
+  console.error("Usage: tsx src/cli.ts <starter> [<starter>...] [--verbose] [--skip-e2e] [--keep]");
+  console.error("       tsx src/cli.ts --all [--verbose] [--skip-e2e] [--keep]");
+  console.error(`\nKnown starters:\n  ${KNOWN_STARTERS.join("\n  ")}`);
+  process.exit(1);
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const all = args.includes("--all");
+  const verbose = args.includes("--verbose") || args.includes("-v");
+  const skipE2E = args.includes("--skip-e2e");
+  const keepTempDir = args.includes("--keep");
+  const positional = args.filter((a) => !a.startsWith("-"));
+
+  let targets: StarterName[];
+  if (all) {
+    targets = [...KNOWN_STARTERS];
+  } else if (positional.length === 0) {
+    usage();
+  } else {
+    targets = positional.map((p) => {
+      if (!(KNOWN_STARTERS as readonly string[]).includes(p)) {
+        console.error(pc.red(`Unknown starter: ${p}`));
+        usage();
+      }
+      return p as StarterName;
+    });
+  }
+
+  const repoRoot = findRepoRoot();
+  const results: RunStarterResult[] = [];
+
+  for (const starter of targets) {
+    console.log(pc.bold(`\n▶ ${starter}`));
+    const r = await runStarter({ starter, repoRoot, verbose, skipE2E, keepTempDir });
+    results.push(r);
+    printResult(r);
+  }
+
+  const failures = results.filter((r) => !r.success);
+  if (failures.length > 0) {
+    console.log(pc.red(`\n${failures.length}/${results.length} starter(s) failed.`));
+    process.exit(1);
+  }
+  console.log(pc.green(`\nAll ${results.length} starter(s) passed.`));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/create-jazz-e2e/src/cli.ts
+++ b/packages/create-jazz-e2e/src/cli.ts
@@ -29,14 +29,30 @@ function printResult(r: RunStarterResult): void {
 }
 
 function usage(): never {
-  console.error("Usage: tsx src/cli.ts <starter> [<starter>...] [--verbose] [--skip-e2e] [--keep]");
-  console.error("       tsx src/cli.ts --all [--verbose] [--skip-e2e] [--keep]");
+  console.error(
+    "Usage: tsx src/cli.ts <starter> [<starter>...] [--verbose] [--skip-e2e] [--keep] [--tarball-dir <dir>]",
+  );
+  console.error(
+    "       tsx src/cli.ts --all [--verbose] [--skip-e2e] [--keep] [--tarball-dir <dir>]",
+  );
   console.error(`\nKnown starters:\n  ${KNOWN_STARTERS.join("\n  ")}`);
   process.exit(1);
 }
 
+function takeFlagValue(args: string[], flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+  if (idx === -1) return undefined;
+  const value = args[idx + 1];
+  if (value === undefined || value.startsWith("-")) usage();
+  // Remove both the flag and its value from the array so the positional filter
+  // below doesn't pick the value up as a starter name.
+  args.splice(idx, 2);
+  return value;
+}
+
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
+  const tarballDir = takeFlagValue(args, "--tarball-dir");
   const all = args.includes("--all");
   const verbose = args.includes("--verbose") || args.includes("-v");
   const skipE2E = args.includes("--skip-e2e");
@@ -63,7 +79,7 @@ async function main(): Promise<void> {
 
   for (const starter of targets) {
     console.log(pc.bold(`\n▶ ${starter}`));
-    const r = await runStarter({ starter, repoRoot, verbose, skipE2E, keepTempDir });
+    const r = await runStarter({ starter, repoRoot, verbose, skipE2E, keepTempDir, tarballDir });
     results.push(r);
     printResult(r);
   }

--- a/packages/create-jazz-e2e/src/run-starter.ts
+++ b/packages/create-jazz-e2e/src/run-starter.ts
@@ -28,6 +28,13 @@ export interface RunStarterOptions {
   keepTempDir?: boolean;
   /** Stream child stdout/stderr instead of buffering. */
   verbose?: boolean;
+  /**
+   * If provided, skip the in-process `pnpm pack` step and resolve workspace
+   * tarballs from this directory (one `*.tgz` per package in PACKAGES_TO_PACK).
+   * The CI workflow uses this to build tarballs once in a prepare job and reuse
+   * them across the matrix without rebuilding the workspace each time.
+   */
+  tarballDir?: string;
 }
 
 export interface PhaseTiming {
@@ -143,6 +150,22 @@ function patchInstalledJazzNapi(appDir: string, repoRoot: string): void {
   }
 }
 
+function discoverPrebuiltTarballs(dir: string): Record<string, string> {
+  if (!fs.existsSync(dir)) {
+    throw new Error(`--tarball-dir ${dir} does not exist`);
+  }
+  const entries = fs.readdirSync(dir);
+  const tarballs: Record<string, string> = {};
+  for (const pkg of PACKAGES_TO_PACK) {
+    const matches = entries.filter((f) => f.startsWith(`${pkg}-`) && f.endsWith(".tgz")).sort();
+    if (matches.length === 0) {
+      throw new Error(`--tarball-dir ${dir} has no tarball for "${pkg}"`);
+    }
+    tarballs[pkg] = path.join(dir, matches[matches.length - 1]);
+  }
+  return tarballs;
+}
+
 async function packWorkspaceTarballs(
   repoRoot: string,
   destDir: string,
@@ -226,8 +249,10 @@ export async function runStarter(opts: RunStarterOptions): Promise<RunStarterRes
   };
 
   try {
-    const tarballs = await recordPhase("pack", () =>
-      packWorkspaceTarballs(opts.repoRoot, tarballDir, verbose),
+    const tarballs = await recordPhase("pack", async () =>
+      opts.tarballDir
+        ? discoverPrebuiltTarballs(opts.tarballDir)
+        : packWorkspaceTarballs(opts.repoRoot, tarballDir, verbose),
     );
 
     await recordPhase("scaffold", async () => {

--- a/packages/create-jazz-e2e/src/run-starter.ts
+++ b/packages/create-jazz-e2e/src/run-starter.ts
@@ -11,9 +11,10 @@ const APP_NAME = "test-app";
 
 /**
  * Workspace packages every starter's dependency closure can transitively pull
- * in. We pack each as a tarball and pin them via `pnpm.overrides` in the
- * scaffolded project, so `pnpm install` resolves against the local workspace
- * even when the alpha versions aren't on npm yet (e.g. during a release PR).
+ * in. We pack each as a tarball and pin them via `overrides` in the
+ * scaffolded project's `pnpm-workspace.yaml`, so `pnpm install` resolves
+ * against the local workspace even when the alpha versions aren't on npm
+ * yet (e.g. during a release PR).
  */
 const PACKAGES_TO_PACK = ["jazz-tools", "jazz-napi", "jazz-wasm"] as const;
 
@@ -203,16 +204,36 @@ async function packWorkspaceTarballs(
   return tarballs;
 }
 
-function patchManifestWithOverrides(manifestPath: string, tarballs: Record<string, string>): void {
-  const raw = JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as {
-    pnpm?: { overrides?: Record<string, string> };
-  } & Record<string, unknown>;
-  const overrides: Record<string, string> = { ...raw.pnpm?.overrides };
-  for (const [pkg, tgz] of Object.entries(tarballs)) {
-    overrides[pkg] = `file:${tgz}`;
-  }
-  raw.pnpm = { ...raw.pnpm, overrides };
-  fs.writeFileSync(manifestPath, JSON.stringify(raw, null, 2) + "\n", "utf-8");
+/**
+ * pnpm 10 stopped reading the `pnpm` field in package.json — it emits
+ * `[WARN] The "pnpm" field in package.json is no longer read by pnpm` and
+ * ignores anything underneath, including `overrides`. The canonical home is
+ * `pnpm-workspace.yaml` (yes, even in a non-workspace single-project setup).
+ *
+ * We also pre-approve build scripts for known native/postinstall-using deps;
+ * pnpm 10 exits non-zero from `pnpm install` if it sees a build script for a
+ * package that isn't on the allowlist (`ERR_PNPM_IGNORED_BUILDS`). Listing
+ * the common ones here keeps the harness's install reliable across starters.
+ */
+const ONLY_BUILT_DEPENDENCIES = [
+  "@swc/core",
+  "better-sqlite3",
+  "blake3",
+  "bufferutil",
+  "esbuild",
+  "lefthook",
+  "protobufjs",
+  "sharp",
+  "utf-8-validate",
+];
+
+function writeScaffoldedPnpmConfig(appDir: string, tarballs: Record<string, string>): void {
+  const overrideLines = Object.entries(tarballs)
+    .map(([pkg, tgz]) => `  "${pkg}": "file:${tgz}"`)
+    .join("\n");
+  const allowLines = ONLY_BUILT_DEPENDENCIES.map((p) => `  - "${p}"`).join("\n");
+  const yaml = `overrides:\n${overrideLines}\n\nonlyBuiltDependencies:\n${allowLines}\n`;
+  fs.writeFileSync(path.join(appDir, "pnpm-workspace.yaml"), yaml, "utf-8");
 }
 
 function writeEnvFile(
@@ -277,8 +298,8 @@ export async function runStarter(opts: RunStarterOptions): Promise<RunStarterRes
       };
       // create-jazz auto-installs if it can detect a package manager via
       // `npm_config_user_agent`. We unset it so the CLI exits after scaffolding;
-      // we run pnpm install ourselves below, after patching overrides into the
-      // manifest. Otherwise the install runs first and resolves against npm.
+      // we run pnpm install ourselves below, after writing the workspace
+      // overrides. Otherwise the install runs first and resolves against npm.
       delete env.npm_config_user_agent;
 
       await runChild(
@@ -288,18 +309,19 @@ export async function runStarter(opts: RunStarterOptions): Promise<RunStarterRes
       );
     });
 
-    patchManifestWithOverrides(path.join(appDir, "package.json"), tarballs);
+    writeScaffoldedPnpmConfig(appDir, tarballs);
 
     await recordPhase("install", () =>
-      runChild(
-        "pnpm",
-        ["install", "--ignore-workspace", "--no-frozen-lockfile", "--prefer-offline"],
-        {
-          cwd: appDir,
-          verbose,
-          description: `pnpm install ${opts.starter}`,
-        },
-      ),
+      // No `--ignore-workspace` here: that would make pnpm skip the
+      // pnpm-workspace.yaml we just wrote (which is where pnpm 10 reads
+      // `overrides` and `onlyBuiltDependencies` from). The scaffolded folder
+      // lives in $TMPDIR, so there's no risk of pnpm walking up into the
+      // jazz monorepo's workspace by accident.
+      runChild("pnpm", ["install", "--no-frozen-lockfile", "--prefer-offline"], {
+        cwd: appDir,
+        verbose,
+        description: `pnpm install ${opts.starter}`,
+      }),
     );
 
     patchInstalledJazzNapi(appDir, opts.repoRoot);

--- a/packages/create-jazz-e2e/src/run-starter.ts
+++ b/packages/create-jazz-e2e/src/run-starter.ts
@@ -55,6 +55,14 @@ async function runChild(
   args: string[],
   opts: {
     cwd: string;
+    /**
+     * If provided, this is the COMPLETE environment for the child — runChild
+     * does not merge in `process.env`. Callers that want to inherit the parent
+     * env should spread it themselves (`{ ...process.env, EXTRA: "..." }`).
+     * This is so callers can `delete` keys (e.g. `npm_config_user_agent` to
+     * stop create-jazz auto-detecting a package manager) without runChild
+     * re-introducing them via the spread.
+     */
     env?: NodeJS.ProcessEnv;
     verbose?: boolean;
     description: string;
@@ -65,7 +73,7 @@ async function runChild(
   return await new Promise((resolve, reject) => {
     const child = spawn(cmd, args, {
       cwd: opts.cwd,
-      env: { ...process.env, ...opts.env },
+      env: opts.env ?? process.env,
       stdio: opts.verbose ? "inherit" : ["ignore", "pipe", "pipe"],
     });
     const chunks: string[] = [];
@@ -322,7 +330,7 @@ export async function runStarter(opts: RunStarterOptions): Promise<RunStarterRes
       await recordPhase("e2e", () =>
         runChild("pnpm", ["exec", "playwright", "test", "--reporter=line"], {
           cwd: appDir,
-          env: { JAZZ_E2E_PROD: "1" },
+          env: { ...process.env, JAZZ_E2E_PROD: "1" },
           verbose,
           description: `playwright test ${opts.starter}`,
         }),

--- a/packages/create-jazz-e2e/src/run-starter.ts
+++ b/packages/create-jazz-e2e/src/run-starter.ts
@@ -1,0 +1,332 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { startLocalJazzServer, type LocalJazzServerHandle } from "jazz-tools/dev";
+
+import { getStarterConfig, type StarterName } from "./starters.js";
+
+const APP_NAME = "test-app";
+
+/**
+ * Workspace packages every starter's dependency closure can transitively pull
+ * in. We pack each as a tarball and pin them via `pnpm.overrides` in the
+ * scaffolded project, so `pnpm install` resolves against the local workspace
+ * even when the alpha versions aren't on npm yet (e.g. during a release PR).
+ */
+const PACKAGES_TO_PACK = ["jazz-tools", "jazz-napi", "jazz-wasm"] as const;
+
+export interface RunStarterOptions {
+  starter: StarterName;
+  repoRoot: string;
+  /** If provided, scaffold under here; else mkdtemp. */
+  workDir?: string;
+  /** Skip the playwright step (build-only). Useful for a fast smoke pass. */
+  skipE2E?: boolean;
+  /** Leave the scaffolded dir on disk so it can be inspected after a failure. */
+  keepTempDir?: boolean;
+  /** Stream child stdout/stderr instead of buffering. */
+  verbose?: boolean;
+}
+
+export interface PhaseTiming {
+  name: string;
+  durationMs: number;
+}
+
+export interface RunStarterResult {
+  starter: StarterName;
+  success: boolean;
+  durations: PhaseTiming[];
+  appDir: string;
+  errorMessage?: string;
+}
+
+async function runChild(
+  cmd: string,
+  args: string[],
+  opts: {
+    cwd: string;
+    env?: NodeJS.ProcessEnv;
+    verbose?: boolean;
+    description: string;
+    /** Soft timeout — kills the child and rejects after N ms. */
+    timeoutMs?: number;
+  },
+): Promise<void> {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      cwd: opts.cwd,
+      env: { ...process.env, ...opts.env },
+      stdio: opts.verbose ? "inherit" : ["ignore", "pipe", "pipe"],
+    });
+    const chunks: string[] = [];
+    if (!opts.verbose) {
+      child.stdout?.on("data", (d) => chunks.push(d.toString()));
+      child.stderr?.on("data", (d) => chunks.push(d.toString()));
+    }
+    let timer: NodeJS.Timeout | undefined;
+    if (opts.timeoutMs !== undefined) {
+      timer = setTimeout(() => {
+        child.kill("SIGKILL");
+        reject(new Error(`${opts.description} timed out after ${opts.timeoutMs}ms`));
+      }, opts.timeoutMs);
+    }
+    child.on("error", (err) => {
+      if (timer) clearTimeout(timer);
+      reject(err);
+    });
+    child.on("exit", (code, signal) => {
+      if (timer) clearTimeout(timer);
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      const tail = chunks.join("").split("\n").slice(-80).join("\n");
+      reject(
+        new Error(
+          `${opts.description} exited with code=${code} signal=${signal ?? "none"}\n${tail}`,
+        ),
+      );
+    });
+  });
+}
+
+/**
+ * jazz-napi's tarball intentionally excludes the per-platform `.node` files
+ * (napi-rs's standard publish layout puts them in sibling packages like
+ * `@garden-co/jazz-napi-darwin-arm64`). During an e2e run those siblings
+ * aren't published, so we'd have an empty install. After `pnpm install`, copy
+ * the locally-built `.node` files into every installed jazz-napi directory so
+ * the bundled `require('./jazz-napi.<platform>.node')` lookup succeeds.
+ *
+ * We deliberately don't use `NAPI_RS_NATIVE_LIBRARY_PATH` here — that env var
+ * is honoured by every napi-rs package (including rolldown, which vite 8
+ * uses), so setting it to jazz-napi's binary breaks the build.
+ */
+function patchInstalledJazzNapi(appDir: string, repoRoot: string): void {
+  const napiSourceDir = path.join(repoRoot, "crates/jazz-napi");
+  if (!fs.existsSync(napiSourceDir)) return;
+  const binaries = fs
+    .readdirSync(napiSourceDir)
+    .filter((f) => f.endsWith(".node"))
+    .map((f) => path.join(napiSourceDir, f));
+  if (binaries.length === 0) return;
+
+  const installedDirs: string[] = [];
+  const visited = new Set<string>();
+  function walk(dir: string, depth = 0): void {
+    if (depth > 8 || visited.has(dir) || !fs.existsSync(dir)) return;
+    visited.add(dir);
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      if (!e.isDirectory()) continue;
+      const child = path.join(dir, e.name);
+      if (e.name === "jazz-napi") {
+        installedDirs.push(child);
+      }
+      walk(child, depth + 1);
+    }
+  }
+  walk(path.join(appDir, "node_modules"));
+
+  for (const dir of installedDirs) {
+    for (const src of binaries) {
+      fs.copyFileSync(src, path.join(dir, path.basename(src)));
+    }
+  }
+}
+
+async function packWorkspaceTarballs(
+  repoRoot: string,
+  destDir: string,
+  verbose: boolean,
+): Promise<Record<string, string>> {
+  const tarballs: Record<string, string> = {};
+  for (const pkg of PACKAGES_TO_PACK) {
+    const candidates = [path.join(repoRoot, "packages", pkg), path.join(repoRoot, "crates", pkg)];
+    const pkgDir = candidates.find((d) => fs.existsSync(path.join(d, "package.json")));
+    if (!pkgDir) {
+      throw new Error(`Could not locate workspace package "${pkg}" under packages/ or crates/`);
+    }
+    await runChild("pnpm", ["pack", "--pack-destination", destDir], {
+      cwd: pkgDir,
+      verbose,
+      description: `pnpm pack ${pkg}`,
+    });
+    const entries = fs
+      .readdirSync(destDir)
+      .filter((f) => f.startsWith(`${pkg}-`) && f.endsWith(".tgz"));
+    if (entries.length === 0) {
+      throw new Error(`pnpm pack ${pkg} produced no tarball in ${destDir}`);
+    }
+    entries.sort();
+    tarballs[pkg] = path.join(destDir, entries[entries.length - 1]);
+  }
+  return tarballs;
+}
+
+function patchManifestWithOverrides(manifestPath: string, tarballs: Record<string, string>): void {
+  const raw = JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as {
+    pnpm?: { overrides?: Record<string, string> };
+  } & Record<string, unknown>;
+  const overrides: Record<string, string> = { ...raw.pnpm?.overrides };
+  for (const [pkg, tgz] of Object.entries(tarballs)) {
+    overrides[pkg] = `file:${tgz}`;
+  }
+  raw.pnpm = { ...raw.pnpm, overrides };
+  fs.writeFileSync(manifestPath, JSON.stringify(raw, null, 2) + "\n", "utf-8");
+}
+
+function writeEnvFile(
+  appDir: string,
+  starter: StarterName,
+  server: LocalJazzServerHandle,
+  config: ReturnType<typeof getStarterConfig>,
+): void {
+  const prefix = config.envPrefix;
+  const lines: string[] = [
+    `${prefix}_JAZZ_APP_ID=${server.appId}`,
+    `${prefix}_JAZZ_SERVER_URL=${server.url}`,
+    `APP_ORIGIN=${config.appOrigin}`,
+  ];
+  if (server.backendSecret) {
+    lines.push(`BACKEND_SECRET=${server.backendSecret}`);
+  }
+  if (starter.endsWith("-betterauth") || starter.endsWith("-hybrid")) {
+    lines.push(`BETTER_AUTH_SECRET=${randomBytes(32).toString("base64url")}`);
+  }
+  fs.writeFileSync(path.join(appDir, ".env"), lines.join("\n") + "\n", "utf-8");
+}
+
+export async function runStarter(opts: RunStarterOptions): Promise<RunStarterResult> {
+  const verbose = !!opts.verbose;
+  const config = getStarterConfig(opts.starter);
+  const durations: PhaseTiming[] = [];
+  let server: LocalJazzServerHandle | undefined;
+  const workDir = opts.workDir ?? fs.mkdtempSync(path.join(os.tmpdir(), `cje2e-${opts.starter}-`));
+  fs.mkdirSync(workDir, { recursive: true });
+  const tarballDir = path.join(workDir, "_tarballs");
+  fs.mkdirSync(tarballDir, { recursive: true });
+  const appDir = path.join(workDir, APP_NAME);
+
+  const recordPhase = async <T>(name: string, fn: () => Promise<T>): Promise<T> => {
+    const t0 = Date.now();
+    try {
+      return await fn();
+    } finally {
+      durations.push({ name, durationMs: Date.now() - t0 });
+    }
+  };
+
+  try {
+    const tarballs = await recordPhase("pack", () =>
+      packWorkspaceTarballs(opts.repoRoot, tarballDir, verbose),
+    );
+
+    await recordPhase("scaffold", async () => {
+      const cliEntry = path.join(opts.repoRoot, "packages/create-jazz/src/index.ts");
+      const tsxBin = path.join(opts.repoRoot, "packages/create-jazz/node_modules/.bin/tsx");
+      const starterPath = path.join(opts.repoRoot, "starters", opts.starter);
+      const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        JAZZ_STARTER_PATH: starterPath,
+        GIT_AUTHOR_NAME: "create-jazz-e2e",
+        GIT_AUTHOR_EMAIL: "tests@create-jazz.invalid",
+        GIT_COMMITTER_NAME: "create-jazz-e2e",
+        GIT_COMMITTER_EMAIL: "tests@create-jazz.invalid",
+      };
+      // create-jazz auto-installs if it can detect a package manager via
+      // `npm_config_user_agent`. We unset it so the CLI exits after scaffolding;
+      // we run pnpm install ourselves below, after patching overrides into the
+      // manifest. Otherwise the install runs first and resolves against npm.
+      delete env.npm_config_user_agent;
+
+      await runChild(
+        tsxBin,
+        [cliEntry, APP_NAME, "--starter", opts.starter, "--hosting", "selfhosted", "--no-git"],
+        { cwd: workDir, env, verbose, description: `create-jazz ${opts.starter}` },
+      );
+    });
+
+    patchManifestWithOverrides(path.join(appDir, "package.json"), tarballs);
+
+    await recordPhase("install", () =>
+      runChild(
+        "pnpm",
+        ["install", "--ignore-workspace", "--no-frozen-lockfile", "--prefer-offline"],
+        {
+          cwd: appDir,
+          verbose,
+          description: `pnpm install ${opts.starter}`,
+        },
+      ),
+    );
+
+    patchInstalledJazzNapi(appDir, opts.repoRoot);
+
+    // Start the sync server before we write .env, so we can write the real
+    // appId + serverUrl in one go and the build picks them up.
+    server = await startLocalJazzServer({ inMemory: true });
+    writeEnvFile(appDir, opts.starter, server, config);
+
+    await recordPhase("build", () =>
+      runChild("pnpm", ["build"], {
+        cwd: appDir,
+        verbose,
+        description: `pnpm build ${opts.starter}`,
+      }),
+    );
+
+    if (!opts.skipE2E) {
+      // Each scaffolded starter pins its own @playwright/test version, which
+      // can differ from whatever's installed globally. Run `playwright install`
+      // from inside the scaffolded dir so we fetch exactly the chromium build
+      // that version expects. Cheap no-op if it's already on disk.
+      await runChild("pnpm", ["exec", "playwright", "install", "chromium"], {
+        cwd: appDir,
+        verbose,
+        description: `playwright install chromium ${opts.starter}`,
+      });
+      await recordPhase("e2e", () =>
+        runChild("pnpm", ["exec", "playwright", "test", "--reporter=line"], {
+          cwd: appDir,
+          env: { JAZZ_E2E_PROD: "1" },
+          verbose,
+          description: `playwright test ${opts.starter}`,
+        }),
+      );
+    }
+
+    return { starter: opts.starter, success: true, durations, appDir };
+  } catch (err) {
+    return {
+      starter: opts.starter,
+      success: false,
+      durations,
+      appDir,
+      errorMessage: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    if (server) {
+      try {
+        await server.stop();
+      } catch {
+        // Best-effort.
+      }
+    }
+    if (!opts.keepTempDir) {
+      try {
+        fs.rmSync(workDir, { recursive: true, force: true });
+      } catch {
+        // Best-effort.
+      }
+    }
+  }
+}

--- a/packages/create-jazz-e2e/src/run-starter.ts
+++ b/packages/create-jazz-e2e/src/run-starter.ts
@@ -205,34 +205,22 @@ async function packWorkspaceTarballs(
 }
 
 /**
- * pnpm 10 stopped reading the `pnpm` field in package.json — it emits
+ * pnpm 10+ stopped reading the `pnpm` field in package.json — it emits
  * `[WARN] The "pnpm" field in package.json is no longer read by pnpm` and
  * ignores anything underneath, including `overrides`. The canonical home is
  * `pnpm-workspace.yaml` (yes, even in a non-workspace single-project setup).
  *
- * We also pre-approve build scripts for known native/postinstall-using deps;
- * pnpm 10 exits non-zero from `pnpm install` if it sees a build script for a
- * package that isn't on the allowlist (`ERR_PNPM_IGNORED_BUILDS`). Listing
- * the common ones here keeps the harness's install reliable across starters.
+ * Build-script approval is handled at install time via `--ignore-scripts`
+ * rather than `onlyBuiltDependencies` here, because the allowlist mechanism
+ * has shifted between pnpm 10 and 11 and skipping postinstalls is safe for
+ * the e2e harness — the few packages affected ship working binaries via
+ * optionalDependencies.
  */
-const ONLY_BUILT_DEPENDENCIES = [
-  "@swc/core",
-  "better-sqlite3",
-  "blake3",
-  "bufferutil",
-  "esbuild",
-  "lefthook",
-  "protobufjs",
-  "sharp",
-  "utf-8-validate",
-];
-
 function writeScaffoldedPnpmConfig(appDir: string, tarballs: Record<string, string>): void {
   const overrideLines = Object.entries(tarballs)
     .map(([pkg, tgz]) => `  "${pkg}": "file:${tgz}"`)
     .join("\n");
-  const allowLines = ONLY_BUILT_DEPENDENCIES.map((p) => `  - "${p}"`).join("\n");
-  const yaml = `overrides:\n${overrideLines}\n\nonlyBuiltDependencies:\n${allowLines}\n`;
+  const yaml = `overrides:\n${overrideLines}\n`;
   fs.writeFileSync(path.join(appDir, "pnpm-workspace.yaml"), yaml, "utf-8");
 }
 
@@ -313,15 +301,27 @@ export async function runStarter(opts: RunStarterOptions): Promise<RunStarterRes
 
     await recordPhase("install", () =>
       // No `--ignore-workspace` here: that would make pnpm skip the
-      // pnpm-workspace.yaml we just wrote (which is where pnpm 10 reads
-      // `overrides` and `onlyBuiltDependencies` from). The scaffolded folder
-      // lives in $TMPDIR, so there's no risk of pnpm walking up into the
-      // jazz monorepo's workspace by accident.
-      runChild("pnpm", ["install", "--no-frozen-lockfile", "--prefer-offline"], {
-        cwd: appDir,
-        verbose,
-        description: `pnpm install ${opts.starter}`,
-      }),
+      // pnpm-workspace.yaml we just wrote (which is where pnpm 10+ reads
+      // `overrides` from). The scaffolded folder lives in $TMPDIR, so there's
+      // no risk of pnpm walking up into the jazz monorepo's workspace by
+      // accident.
+      //
+      // `--ignore-scripts`: pnpm 10+ exits non-zero from `pnpm install` if it
+      // sees postinstall scripts for packages that aren't on the project's
+      // build allowlist (`ERR_PNPM_IGNORED_BUILDS`). The allowlist mechanism
+      // in pnpm-workspace.yaml isn't reliable across pnpm major versions —
+      // and the few build scripts we'd hit (esbuild, sharp, protobufjs) all
+      // ship their working binaries via optionalDependencies, so skipping
+      // their postinstalls is safe for the e2e purpose.
+      runChild(
+        "pnpm",
+        ["install", "--no-frozen-lockfile", "--prefer-offline", "--ignore-scripts"],
+        {
+          cwd: appDir,
+          verbose,
+          description: `pnpm install ${opts.starter}`,
+        },
+      ),
     );
 
     patchInstalledJazzNapi(appDir, opts.repoRoot);

--- a/packages/create-jazz-e2e/src/run-starter.ts
+++ b/packages/create-jazz-e2e/src/run-starter.ts
@@ -205,6 +205,23 @@ async function packWorkspaceTarballs(
 }
 
 /**
+ * Pinned upstream versions the harness needs to override regardless of what
+ * any individual starter's transitive resolution lands on.
+ *
+ * `kysely`: `@better-auth/kysely-adapter@1.6.12` declares
+ * `peerDependencies.kysely: "^0.28.17 || ^0.29.0"` but still imports
+ * `DEFAULT_MIGRATION_LOCK_TABLE` and `DEFAULT_MIGRATION_TABLE` from kysely —
+ * symbols kysely removed in 0.29.0 (a legitimate breaking change under
+ * pre-1.0 semver). The widened peer range opts the adapter into a kysely it
+ * doesn't actually work with, and the SSR-bundled starters (next-*,
+ * sveltekit-*) crash trying to resolve the missing exports. Pinning to the
+ * last 0.28.x keeps the e2e build green until upstream catches up.
+ */
+const UPSTREAM_PINS: Record<string, string> = {
+  kysely: "0.28.17",
+};
+
+/**
  * pnpm 10+ stopped reading the `pnpm` field in package.json — it emits
  * `[WARN] The "pnpm" field in package.json is no longer read by pnpm` and
  * ignores anything underneath, including `overrides`. The canonical home is
@@ -217,9 +234,10 @@ async function packWorkspaceTarballs(
  * optionalDependencies.
  */
 function writeScaffoldedPnpmConfig(appDir: string, tarballs: Record<string, string>): void {
-  const overrideLines = Object.entries(tarballs)
-    .map(([pkg, tgz]) => `  "${pkg}": "file:${tgz}"`)
-    .join("\n");
+  const overrideLines = [
+    ...Object.entries(tarballs).map(([pkg, tgz]) => `  "${pkg}": "file:${tgz}"`),
+    ...Object.entries(UPSTREAM_PINS).map(([pkg, v]) => `  "${pkg}": "${v}"`),
+  ].join("\n");
   const yaml = `overrides:\n${overrideLines}\n`;
   fs.writeFileSync(path.join(appDir, "pnpm-workspace.yaml"), yaml, "utf-8");
 }

--- a/packages/create-jazz-e2e/src/starters.ts
+++ b/packages/create-jazz-e2e/src/starters.ts
@@ -1,0 +1,52 @@
+/**
+ * Per-starter configuration for the E2E harness. Each entry tells the
+ * orchestrator (a) which env-var prefix the framework uses for `*_JAZZ_APP_ID`
+ * and `*_JAZZ_SERVER_URL`, and (b) which extra env vars the starter needs at
+ * build/run time (e.g. APP_ORIGIN for the Hono-server starters).
+ *
+ * Prod-start commands and ports live in each starter's playwright.config.ts,
+ * keyed off `process.env.JAZZ_E2E_PROD === "1"`. We keep them there so each
+ * starter's prod-serving choices stay co-located with its own config.
+ */
+
+export const KNOWN_STARTERS = [
+  "next-betterauth",
+  "next-localfirst",
+  "next-hybrid",
+  "sveltekit-betterauth",
+  "sveltekit-localfirst",
+  "sveltekit-hybrid",
+  "react-betterauth",
+  "react-localfirst",
+  "react-hybrid",
+  "ts-betterauth",
+  "ts-localfirst",
+  "ts-hybrid",
+] as const;
+
+export type StarterName = (typeof KNOWN_STARTERS)[number];
+
+type EnvPrefix = "NEXT_PUBLIC" | "PUBLIC" | "VITE";
+
+export interface StarterConfig {
+  name: StarterName;
+  envPrefix: EnvPrefix;
+  /**
+   * Origin the prod server will be reachable on (host + port). The orchestrator
+   * sets this as APP_ORIGIN so any auth/JWT issuance code aimed at "this app"
+   * targets the prod build, not the dev server's port.
+   */
+  appOrigin: string;
+}
+
+export function getStarterConfig(name: StarterName): StarterConfig {
+  if (name.startsWith("next-")) {
+    return { name, envPrefix: "NEXT_PUBLIC", appOrigin: "http://localhost:3000" };
+  }
+  if (name.startsWith("sveltekit-")) {
+    return { name, envPrefix: "PUBLIC", appOrigin: "http://localhost:5173" };
+  }
+  // react-* and ts-* both serve from Vite (preview) or a Hono server bound to
+  // 5173, matching their playwright BASE_URL.
+  return { name, envPrefix: "VITE", appOrigin: "http://localhost:5173" };
+}

--- a/packages/create-jazz-e2e/tsconfig.json
+++ b/packages/create-jazz-e2e/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -692,7 +692,7 @@ importers:
         version: 19.2.14
       babel-preset-expo:
         specifier: ~54.0.10
-        version: 54.0.10(@babel/core@7.29.0)(@babel/runtime@7.28.6)(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-refresh@0.14.2)
+        version: 54.0.10(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-refresh@0.17.0)
       typescript:
         specifier: catalog:default
         version: 6.0.2
@@ -1298,6 +1298,28 @@ importers:
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+
+  packages/create-jazz-e2e:
+    dependencies:
+      create-jazz:
+        specifier: workspace:*
+        version: link:../create-jazz
+      jazz-tools:
+        specifier: workspace:*
+        version: link:../jazz-tools
+    devDependencies:
+      '@types/node':
+        specifier: catalog:default
+        version: 22.19.13
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: catalog:default
+        version: 6.0.2
 
   packages/inspector:
     dependencies:
@@ -17527,7 +17549,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   '@vitest/utils@4.1.0':
     dependencies:

--- a/starters/next-betterauth/playwright.config.ts
+++ b/starters/next-betterauth/playwright.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
 
 const BASE_URL = "http://localhost:3000";
+const PROD = process.env.JAZZ_E2E_PROD === "1";
 
 export default defineConfig({
   testDir: "./e2e",
@@ -20,10 +21,10 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "pnpm dev",
-    env: { BETTER_AUTH_SECRET: "test-secret-do-not-use-in-production" },
+    command: PROD ? "pnpm exec next start" : "pnpm dev",
+    env: PROD ? {} : { BETTER_AUTH_SECRET: "test-secret-do-not-use-in-production" },
     url: BASE_URL,
     reuseExistingServer: false,
-    timeout: 60_000,
+    timeout: PROD ? 120_000 : 60_000,
   },
 });

--- a/starters/next-hybrid/playwright.config.ts
+++ b/starters/next-hybrid/playwright.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
 
 const BASE_URL = "http://localhost:3000";
+const PROD = process.env.JAZZ_E2E_PROD === "1";
 
 export default defineConfig({
   testDir: "./e2e",
@@ -20,10 +21,10 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "pnpm dev",
-    env: { BETTER_AUTH_SECRET: "test-secret-do-not-use-in-production" },
+    command: PROD ? "pnpm exec next start" : "pnpm dev",
+    env: PROD ? {} : { BETTER_AUTH_SECRET: "test-secret-do-not-use-in-production" },
     url: BASE_URL,
     reuseExistingServer: false,
-    timeout: 60_000,
+    timeout: PROD ? 120_000 : 60_000,
   },
 });

--- a/starters/next-localfirst/playwright.config.ts
+++ b/starters/next-localfirst/playwright.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
 
 const BASE_URL = "http://localhost:3000";
+const PROD = process.env.JAZZ_E2E_PROD === "1";
 
 export default defineConfig({
   testDir: "./e2e",
@@ -20,9 +21,9 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "pnpm dev",
+    command: PROD ? "pnpm exec next start" : "pnpm dev",
     url: BASE_URL,
     reuseExistingServer: false,
-    timeout: 60_000,
+    timeout: PROD ? 120_000 : 60_000,
   },
 });

--- a/starters/react-betterauth/playwright.config.ts
+++ b/starters/react-betterauth/playwright.config.ts
@@ -1,6 +1,22 @@
 import { defineConfig, devices } from "@playwright/test";
 
 const BASE_URL = "http://localhost:5173";
+const PROD = process.env.JAZZ_E2E_PROD === "1";
+
+const prodApiServer = {
+  command: "node --env-file=.env server-dist/index.js",
+  env: { PORT: "3001" },
+  url: "http://localhost:3001/health",
+  reuseExistingServer: false,
+  timeout: 60_000,
+};
+
+const prodFrontend = {
+  command: "pnpm exec vite preview --port 5173 --strictPort",
+  url: BASE_URL,
+  reuseExistingServer: false,
+  timeout: 60_000,
+};
 
 export default defineConfig({
   testDir: "./e2e",
@@ -19,11 +35,13 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
   ],
-  webServer: {
-    command: "pnpm dev",
-    env: { BETTER_AUTH_SECRET: "test-secret-do-not-use-in-production" },
-    url: BASE_URL,
-    reuseExistingServer: false,
-    timeout: 60_000,
-  },
+  webServer: PROD
+    ? [prodApiServer, prodFrontend]
+    : {
+        command: "pnpm dev",
+        env: { BETTER_AUTH_SECRET: "test-secret-do-not-use-in-production" },
+        url: BASE_URL,
+        reuseExistingServer: false,
+        timeout: 60_000,
+      },
 });

--- a/starters/react-betterauth/vite.config.ts
+++ b/starters/react-betterauth/vite.config.ts
@@ -2,15 +2,18 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { jazzPlugin } from "jazz-tools/dev/vite";
 
+// `/api` must reach the Hono server in both `vite` (dev) and `vite preview`
+// (prod-build smoke). The two configs mirror each other on purpose.
+const apiProxy = {
+  "/api": {
+    target: "http://localhost:3001",
+    changeOrigin: true,
+  },
+};
+
 export default defineConfig({
   plugins: [react(), jazzPlugin({ server: { jwksUrl: "http://localhost:3001/api/auth/jwks" } })],
   worker: { format: "es" },
-  server: {
-    proxy: {
-      "/api": {
-        target: "http://localhost:3001",
-        changeOrigin: true,
-      },
-    },
-  },
+  server: { proxy: apiProxy },
+  preview: { proxy: apiProxy },
 });

--- a/starters/react-hybrid/playwright.config.ts
+++ b/starters/react-hybrid/playwright.config.ts
@@ -1,6 +1,22 @@
 import { defineConfig, devices } from "@playwright/test";
 
 const BASE_URL = "http://localhost:5173";
+const PROD = process.env.JAZZ_E2E_PROD === "1";
+
+const prodApiServer = {
+  command: "node --env-file=.env server-dist/index.js",
+  env: { PORT: "3001" },
+  url: "http://localhost:3001/health",
+  reuseExistingServer: false,
+  timeout: 60_000,
+};
+
+const prodFrontend = {
+  command: "pnpm exec vite preview --port 5173 --strictPort",
+  url: BASE_URL,
+  reuseExistingServer: false,
+  timeout: 60_000,
+};
 
 export default defineConfig({
   testDir: "./e2e",
@@ -19,11 +35,13 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
   ],
-  webServer: {
-    command: "pnpm dev",
-    env: { BETTER_AUTH_SECRET: "test-secret-do-not-use-in-production" },
-    url: BASE_URL,
-    reuseExistingServer: false,
-    timeout: 60_000,
-  },
+  webServer: PROD
+    ? [prodApiServer, prodFrontend]
+    : {
+        command: "pnpm dev",
+        env: { BETTER_AUTH_SECRET: "test-secret-do-not-use-in-production" },
+        url: BASE_URL,
+        reuseExistingServer: false,
+        timeout: 60_000,
+      },
 });

--- a/starters/react-hybrid/vite.config.ts
+++ b/starters/react-hybrid/vite.config.ts
@@ -2,15 +2,18 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { jazzPlugin } from "jazz-tools/dev/vite";
 
+// `/api` must reach the Hono server in both `vite` (dev) and `vite preview`
+// (prod-build smoke). The two configs mirror each other on purpose.
+const apiProxy = {
+  "/api": {
+    target: "http://localhost:3001",
+    changeOrigin: true,
+  },
+};
+
 export default defineConfig({
   plugins: [react(), jazzPlugin({ server: { jwksUrl: "http://localhost:3001/api/auth/jwks" } })],
   worker: { format: "es" },
-  server: {
-    proxy: {
-      "/api": {
-        target: "http://localhost:3001",
-        changeOrigin: true,
-      },
-    },
-  },
+  server: { proxy: apiProxy },
+  preview: { proxy: apiProxy },
 });

--- a/starters/react-localfirst/playwright.config.ts
+++ b/starters/react-localfirst/playwright.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
 
 const BASE_URL = "http://localhost:5173";
+const PROD = process.env.JAZZ_E2E_PROD === "1";
 
 export default defineConfig({
   testDir: "./e2e",
@@ -20,9 +21,9 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "pnpm dev",
+    command: PROD ? "pnpm exec vite preview --port 5173 --strictPort" : "pnpm dev",
     url: BASE_URL,
     reuseExistingServer: false,
-    timeout: 60_000,
+    timeout: PROD ? 120_000 : 60_000,
   },
 });

--- a/starters/sveltekit-betterauth/playwright.config.ts
+++ b/starters/sveltekit-betterauth/playwright.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
 
 const BASE_URL = "http://localhost:5173";
+const PROD = process.env.JAZZ_E2E_PROD === "1";
 
 export default defineConfig({
   testDir: "./e2e",
@@ -20,10 +21,12 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "pnpm dev",
-    env: { BETTER_AUTH_SECRET: "test-secret-do-not-use-in-production" },
+    command: PROD ? "node --env-file=.env build" : "pnpm dev",
+    env: PROD
+      ? { PORT: "5173", ORIGIN: BASE_URL }
+      : { BETTER_AUTH_SECRET: "test-secret-do-not-use-in-production" },
     url: BASE_URL,
     reuseExistingServer: !process.env.CI,
-    timeout: 60_000,
+    timeout: PROD ? 120_000 : 60_000,
   },
 });

--- a/starters/sveltekit-hybrid/playwright.config.ts
+++ b/starters/sveltekit-hybrid/playwright.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
 
 const BASE_URL = "http://localhost:5173";
+const PROD = process.env.JAZZ_E2E_PROD === "1";
 
 export default defineConfig({
   testDir: "./e2e",
@@ -20,10 +21,12 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "pnpm dev",
-    env: { BETTER_AUTH_SECRET: "test-secret-do-not-use-in-production" },
+    command: PROD ? "node --env-file=.env build" : "pnpm dev",
+    env: PROD
+      ? { PORT: "5173", ORIGIN: BASE_URL }
+      : { BETTER_AUTH_SECRET: "test-secret-do-not-use-in-production" },
     url: BASE_URL,
     reuseExistingServer: false,
-    timeout: 60_000,
+    timeout: PROD ? 120_000 : 60_000,
   },
 });

--- a/starters/sveltekit-localfirst/playwright.config.ts
+++ b/starters/sveltekit-localfirst/playwright.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
 
 const BASE_URL = "http://localhost:5173";
+const PROD = process.env.JAZZ_E2E_PROD === "1";
 
 export default defineConfig({
   testDir: "./e2e",
@@ -20,9 +21,10 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "pnpm dev",
+    command: PROD ? "node --env-file=.env build" : "pnpm dev",
+    env: PROD ? { PORT: "5173", ORIGIN: BASE_URL } : {},
     url: BASE_URL,
     reuseExistingServer: false,
-    timeout: 60_000,
+    timeout: PROD ? 120_000 : 60_000,
   },
 });

--- a/starters/ts-betterauth/playwright.config.ts
+++ b/starters/ts-betterauth/playwright.config.ts
@@ -1,6 +1,26 @@
 import { defineConfig, devices } from "@playwright/test";
 
 const BASE_URL = "http://localhost:5173";
+const PROD = process.env.JAZZ_E2E_PROD === "1";
+
+// In dev, `pnpm dev` runs the API + vite under concurrently. In prod, we wire
+// the equivalent through playwright's two-server form: the Hono server on
+// 3001 and `vite preview` on 5173 (which proxies /api back to 3001 via the
+// `preview.proxy` config in vite.config.ts).
+const prodApiServer = {
+  command: "node --env-file=.env server-dist/index.js",
+  env: { PORT: "3001" },
+  url: "http://localhost:3001/health",
+  reuseExistingServer: false,
+  timeout: 60_000,
+};
+
+const prodFrontend = {
+  command: "pnpm exec vite preview --port 5173 --strictPort",
+  url: BASE_URL,
+  reuseExistingServer: false,
+  timeout: 60_000,
+};
 
 export default defineConfig({
   testDir: "./e2e",
@@ -19,11 +39,13 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
   ],
-  webServer: {
-    command: "pnpm dev",
-    env: { BETTER_AUTH_SECRET: "test-secret-do-not-use-in-production" },
-    url: BASE_URL,
-    reuseExistingServer: false,
-    timeout: 60_000,
-  },
+  webServer: PROD
+    ? [prodApiServer, prodFrontend]
+    : {
+        command: "pnpm dev",
+        env: { BETTER_AUTH_SECRET: "test-secret-do-not-use-in-production" },
+        url: BASE_URL,
+        reuseExistingServer: false,
+        timeout: 60_000,
+      },
 });

--- a/starters/ts-betterauth/vite.config.ts
+++ b/starters/ts-betterauth/vite.config.ts
@@ -1,15 +1,18 @@
 import { defineConfig } from "vite";
 import { jazzPlugin } from "jazz-tools/dev/vite";
 
+// `/api` must reach the Hono server in both `vite` (dev) and `vite preview`
+// (prod-build smoke). The two configs mirror each other on purpose.
+const apiProxy = {
+  "/api": {
+    target: "http://localhost:3001",
+    changeOrigin: true,
+  },
+};
+
 export default defineConfig({
   plugins: [jazzPlugin({ server: { jwksUrl: "http://localhost:3001/api/auth/jwks" } })],
   worker: { format: "es" },
-  server: {
-    proxy: {
-      "/api": {
-        target: "http://localhost:3001",
-        changeOrigin: true,
-      },
-    },
-  },
+  server: { proxy: apiProxy },
+  preview: { proxy: apiProxy },
 });

--- a/starters/ts-hybrid/playwright.config.ts
+++ b/starters/ts-hybrid/playwright.config.ts
@@ -1,6 +1,22 @@
 import { defineConfig, devices } from "@playwright/test";
 
 const BASE_URL = "http://localhost:5173";
+const PROD = process.env.JAZZ_E2E_PROD === "1";
+
+const prodApiServer = {
+  command: "node --env-file=.env server-dist/index.js",
+  env: { PORT: "3001" },
+  url: "http://localhost:3001/health",
+  reuseExistingServer: false,
+  timeout: 60_000,
+};
+
+const prodFrontend = {
+  command: "pnpm exec vite preview --port 5173 --strictPort",
+  url: BASE_URL,
+  reuseExistingServer: false,
+  timeout: 60_000,
+};
 
 export default defineConfig({
   testDir: "./e2e",
@@ -19,11 +35,13 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
   ],
-  webServer: {
-    command: "pnpm dev",
-    env: { BETTER_AUTH_SECRET: "test-secret-do-not-use-in-production" },
-    url: BASE_URL,
-    reuseExistingServer: false,
-    timeout: 60_000,
-  },
+  webServer: PROD
+    ? [prodApiServer, prodFrontend]
+    : {
+        command: "pnpm dev",
+        env: { BETTER_AUTH_SECRET: "test-secret-do-not-use-in-production" },
+        url: BASE_URL,
+        reuseExistingServer: false,
+        timeout: 60_000,
+      },
 });

--- a/starters/ts-hybrid/vite.config.ts
+++ b/starters/ts-hybrid/vite.config.ts
@@ -1,15 +1,18 @@
 import { defineConfig } from "vite";
 import { jazzPlugin } from "jazz-tools/dev/vite";
 
+// `/api` must reach the Hono server in both `vite` (dev) and `vite preview`
+// (prod-build smoke). The two configs mirror each other on purpose.
+const apiProxy = {
+  "/api": {
+    target: "http://localhost:3001",
+    changeOrigin: true,
+  },
+};
+
 export default defineConfig({
   plugins: [jazzPlugin({ server: { jwksUrl: "http://localhost:3001/api/auth/jwks" } })],
   worker: { format: "es" },
-  server: {
-    proxy: {
-      "/api": {
-        target: "http://localhost:3001",
-        changeOrigin: true,
-      },
-    },
-  },
+  server: { proxy: apiProxy },
+  preview: { proxy: apiProxy },
 });

--- a/starters/ts-localfirst/playwright.config.ts
+++ b/starters/ts-localfirst/playwright.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
 
 const BASE_URL = "http://localhost:5173";
+const PROD = process.env.JAZZ_E2E_PROD === "1";
 
 export default defineConfig({
   testDir: "./e2e",
@@ -20,9 +21,9 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "pnpm dev",
+    command: PROD ? "pnpm exec vite preview --port 5173 --strictPort" : "pnpm dev",
     url: BASE_URL,
     reuseExistingServer: false,
-    timeout: 60_000,
+    timeout: PROD ? 120_000 : 60_000,
   },
 });


### PR DESCRIPTION
## Summary
- Adds `packages/create-jazz-e2e`: a private harness that scaffolds each starter via `create-jazz`, installs deps, builds, and runs Playwright against the production preview.
- Wires every starter's Playwright config to honour `JAZZ_E2E_PROD` so the harness can flip the test runner into prod-mode, and mirrors `server.proxy` to `preview.proxy` in vite-based starters so the prod preview matches the dev proxy.
- Adds `.github/workflows/starters-e2e.yml`: a matrix job (12 starters) that gates the changesets release PR (`changeset-release/main`) and can be manually dispatched for ad-hoc runs.

## Test plan
- [ ] Manual `workflow_dispatch` on this branch completes green across the matrix.
- [ ] Confirm wall-clock time and per-starter timing for the CI run.
- [ ] Once merged, the next `changeset-release/main` PR triggers the same matrix automatically.