### PR TITLE
fix: permissions that reference row IDs in `exists` policies

### DIFF
--- a/.changeset/fix-policy-row-id-exists-updates.md
+++ b/.changeset/fix-policy-row-id-exists-updates.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix update permission policies that compare `id` inside `EXISTS` checks.

--- a/crates/jazz-tools/src/query_manager/graph_nodes/policy_filter.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/policy_filter.rs
@@ -12,7 +12,7 @@ use crate::query_manager::graph_nodes::policy_eval::{
     PolicyContextEvaluator, collect_policy_dependency_tables,
 };
 use crate::query_manager::policy::{
-    Operation, PolicyExpr, evaluate_expr_recursive, normalize_recursive_max_depth,
+    Operation, PolicyExpr, evaluate_expr_recursive_with_row_id, normalize_recursive_max_depth,
 };
 use crate::query_manager::session::Session;
 use crate::query_manager::types::{
@@ -420,12 +420,13 @@ impl PolicyFilterNode {
             PolicyExpr::Not(inner) => !self.evaluate_expr(inner, row, depth),
 
             // All other expressions delegate to shared evaluation
-            _ => evaluate_expr_recursive(
+            _ => evaluate_expr_recursive_with_row_id(
                 expr,
                 &row.data,
                 &row.provenance,
                 &self.descriptor,
                 &self.session,
+                Some(row.id),
                 depth,
             ),
         }
@@ -587,6 +588,7 @@ mod tests {
     use super::*;
     use crate::object::ObjectId;
     use crate::query_manager::encoding::encode_row;
+    use crate::query_manager::policy::{CmpOp, PolicyValue};
     use crate::query_manager::relation_ir::RelExpr;
     use crate::query_manager::types::{ColumnDescriptor, ColumnType, TableName, Value};
     use serde_json::json;
@@ -655,6 +657,44 @@ mod tests {
 
         let row = make_row("user1", "eng", "Doc 1");
         assert!(!node.evaluate(&row));
+    }
+
+    #[test]
+    fn test_policy_id_column_resolves_to_row_object_id() {
+        let row_id = ObjectId::from_uuid(uuid::Uuid::from_u128(
+            0xdead_beef_cafe_0000_0000_0000_0000_0003,
+        ));
+        let session = Session::new("user1");
+        let node = PolicyFilterNode::new(
+            test_descriptor(),
+            PolicyExpr::Cmp {
+                column: "id".into(),
+                op: CmpOp::Eq,
+                value: PolicyValue::Literal(Value::Uuid(row_id)),
+            },
+            session,
+            test_schema(),
+            "documents",
+        );
+
+        let desc = test_descriptor();
+        let data = encode_row(
+            &desc,
+            &[
+                Value::Text("user1".into()),
+                Value::Text("eng".into()),
+                Value::Text("Doc 1".into()),
+            ],
+        )
+        .unwrap();
+        let row = Row::new(
+            row_id,
+            data,
+            crate::row_histories::BatchId([0; 16]),
+            crate::metadata::RowProvenance::for_insert("jazz:test", 0),
+        );
+
+        assert!(node.evaluate(&row));
     }
 
     #[test]

--- a/crates/jazz-tools/src/query_manager/policy.rs
+++ b/crates/jazz-tools/src/query_manager/policy.rs
@@ -2071,7 +2071,7 @@ fn evaluate_simple_recursive(
         }),
 
         PolicyExpr::Exists { table, condition } => {
-            let bound = match bind_outer_row_refs(condition, content, descriptor, None) {
+            let bound = match bind_outer_row_refs(condition, content, descriptor, row_id) {
                 Some(expr) => expr,
                 None => return SimpleEvalResult::fail(),
             };
@@ -2082,7 +2082,7 @@ fn evaluate_simple_recursive(
             })
         }
         PolicyExpr::ExistsRel { rel } => {
-            let bound = match bind_relation_refs(rel, content, descriptor, session, None) {
+            let bound = match bind_relation_refs(rel, content, descriptor, session, row_id) {
                 Some(expr) => expr,
                 None => return SimpleEvalResult::fail(),
             };
@@ -2317,6 +2317,39 @@ mod tests {
             "expected @session.__jazz_outer_row.id to resolve to Value::Uuid(row_id), got {:?}",
             bound
         );
+    }
+
+    #[test]
+    fn test_exists_outer_row_id_binds_to_row_object_id_when_evaluating_for_row() {
+        let descriptor = RowDescriptor::new(vec![ColumnDescriptor::new("title", ColumnType::Text)]);
+        let content = encode_row(&descriptor, &[Value::Text("Members only".into())]).unwrap();
+        let row_id = ObjectId::from_uuid(uuid::Uuid::from_u128(
+            0xdead_beef_cafe_0000_0000_0000_0000_0002,
+        ));
+        let session = Session::new("alice");
+
+        let expr = PolicyExpr::Exists {
+            table: "chat_members".into(),
+            condition: Box::new(PolicyExpr::Cmp {
+                column: "chat_id".into(),
+                op: CmpOp::Eq,
+                value: PolicyValue::SessionRef(vec![OUTER_ROW_SESSION_PREFIX.into(), "id".into()]),
+            }),
+        };
+
+        let result = evaluate_simple_parts_for_row(&expr, &content, &descriptor, &session, row_id);
+        assert!(result.passed);
+        let ComplexClause::Exists { condition, .. } = &result.complex_clauses[0] else {
+            panic!("expected EXISTS complex clause");
+        };
+        assert!(matches!(
+            condition.as_ref(),
+            PolicyExpr::Cmp {
+                column,
+                op: CmpOp::Eq,
+                value: PolicyValue::Literal(Value::Uuid(id)),
+            } if column == "chat_id" && *id == row_id
+        ));
     }
 
     #[test]

--- a/crates/jazz-tools/tests/policies_integration/complex_policies.rs
+++ b/crates/jazz-tools/tests/policies_integration/complex_policies.rs
@@ -35,6 +35,10 @@ fn title_document_values(title: &str) -> Vec<Value> {
     vec![title.into()]
 }
 
+fn chat_values(name: &str, created_by: &str, is_public: bool) -> Vec<Value> {
+    vec![name.into(), created_by.into(), is_public.into()]
+}
+
 fn complex_document_values(
     team_slug: &str,
     published: bool,
@@ -99,6 +103,35 @@ fn editor_document_update_policy() -> PolicyExpr {
                 value: outer_row_id_ref(),
             },
             PolicyExpr::eq_session("user_id", vec!["user_id".into()]),
+        ])),
+    }
+}
+
+fn immutable_chat_metadata_update_check_policy() -> PolicyExpr {
+    PolicyExpr::Exists {
+        table: "chats".into(),
+        condition: Box::new(PolicyExpr::and(vec![
+            PolicyExpr::Cmp {
+                column: "id".into(),
+                op: CmpOp::Eq,
+                value: outer_row_id_ref(),
+            },
+            PolicyExpr::Cmp {
+                column: "created_by".into(),
+                op: CmpOp::Eq,
+                value: PolicyValue::SessionRef(vec![
+                    OUTER_ROW_SESSION_PREFIX.into(),
+                    "created_by".into(),
+                ]),
+            },
+            PolicyExpr::Cmp {
+                column: "is_public".into(),
+                op: CmpOp::Eq,
+                value: PolicyValue::SessionRef(vec![
+                    OUTER_ROW_SESSION_PREFIX.into(),
+                    "is_public".into(),
+                ]),
+            },
         ])),
     }
 }
@@ -292,6 +325,21 @@ fn exists_update_policy_schema() -> Schema {
                 .column("document_id", ColumnType::Uuid)
                 .column("user_id", ColumnType::Text),
         )
+        .table(
+            TableSchema::builder("chats")
+                .column("name", ColumnType::Text)
+                .column("created_by", ColumnType::Text)
+                .column("is_public", ColumnType::Boolean)
+                .policies(
+                    TablePolicies::new()
+                        .with_insert(PolicyExpr::True)
+                        .with_select(PolicyExpr::True)
+                        .with_update(
+                            Some(PolicyExpr::True),
+                            immutable_chat_metadata_update_check_policy(),
+                        ),
+                ),
+        )
         .build()
 }
 
@@ -300,6 +348,26 @@ async fn create_title_document(client: &JazzClient, title: &str) -> ObjectId {
         .create("documents", row_input!("title" => title.to_string()))
         .await
         .expect("create title document")
+        .0
+}
+
+async fn create_chat(
+    client: &JazzClient,
+    name: &str,
+    created_by: &str,
+    is_public: bool,
+) -> ObjectId {
+    client
+        .create(
+            "chats",
+            row_input!(
+                "name" => name.to_string(),
+                "created_by" => created_by.to_string(),
+                "is_public" => is_public,
+            ),
+        )
+        .await
+        .expect("create chat")
         .0
 }
 
@@ -723,6 +791,120 @@ async fn mixed_predicates_claims_exists_and_inherits_fail_closed() {
     admin.shutdown().await.expect("shutdown admin");
     alice_eng.shutdown().await.expect("shutdown alice eng");
     alice_sales.shutdown().await.expect("shutdown alice sales");
+    server.shutdown().await;
+}
+
+/// Verifies an update's `WITH CHECK` permission evaluates `EXISTS` policies
+/// before writing the update, thus allowing to implement per-field update policies.
+///
+/// Actors: admin creates the chat, alice submits the allowed and rejected
+/// updates, and observer reads the server-authoritative state.
+///
+/// ```text
+/// admin ──create chat(created_by=alice,is_public=false)──► server
+/// alice ──update name────────────────────────────────────► server ──✓ stored metadata still matches
+/// alice ──update is_public=true──────────────────────────► server ──✗ no stored row matches new metadata
+/// observer ──EdgeServer query────────────────────────────► sees renamed chat, protected fields unchanged
+/// ```
+#[tokio::test]
+async fn update_with_check_exists_allows_chat_name_updates_and_rejects_protected_field_changes() {
+    let schema = exists_update_policy_schema();
+    let server = TestingServer::builder()
+        .with_schema(schema.clone())
+        .start()
+        .await;
+    let admin = connect_ready_client(&server, &schema, "admin", "chats", READY_TIMEOUT).await;
+    let alice = connect_ready_user(&server, &schema, "alice", "chats", READY_TIMEOUT).await;
+    let observer = connect_ready_user(&server, &schema, "observer", "chats", READY_TIMEOUT).await;
+
+    let query = QueryBuilder::new("chats").build();
+    let chat_id = create_chat(&admin, "General", "alice", false).await;
+
+    wait_for_rows(
+        &alice,
+        query.clone(),
+        "alice sees the chat before updating it",
+        |rows| {
+            rows.iter()
+                .find(|(id, values)| {
+                    *id == chat_id && *values == chat_values("General", "alice", false)
+                })
+                .map(|_| ())
+        },
+    )
+    .await;
+    wait_for_rows(
+        &observer,
+        query.clone(),
+        "observer sees the initial chat",
+        |rows| {
+            rows.iter()
+                .find(|(id, values)| {
+                    *id == chat_id && *values == chat_values("General", "alice", false)
+                })
+                .map(|_| ())
+        },
+    )
+    .await;
+
+    alice
+        .update_persisted(
+            chat_id,
+            row_changes([("name", "Project Room".into())]),
+            DurabilityTier::EdgeServer,
+        )
+        .await
+        .expect("chat name update should satisfy same-table EXISTS with_check");
+
+    wait_for_rows(
+        &observer,
+        query.clone(),
+        "observer sees the accepted chat name update",
+        |rows| {
+            rows.iter()
+                .find(|(id, values)| {
+                    *id == chat_id && *values == chat_values("Project Room", "alice", false)
+                })
+                .map(|_| ())
+        },
+    )
+    .await;
+
+    let protected_update = alice
+        .update_persisted(
+            chat_id,
+            row_changes([("is_public", true.into())]),
+            DurabilityTier::EdgeServer,
+        )
+        .await;
+    assert!(
+        protected_update.is_err(),
+        "is_public change should be rejected by same-table EXISTS with_check"
+    );
+
+    let rows_after_rejection = wait_for_query(
+        &observer,
+        query,
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(3),
+        "observer sees unchanged protected fields after rejected update",
+        |rows| {
+            let protected_fields_unchanged = rows.iter().any(|(id, values)| {
+                *id == chat_id && *values == chat_values("Project Room", "alice", false)
+            });
+            let rejected_values_absent = rows.iter().all(|(id, values)| {
+                *id != chat_id || *values != chat_values("Project Room", "alice", true)
+            });
+
+            (protected_fields_unchanged && rejected_values_absent).then_some(rows)
+        },
+    )
+    .await;
+    assert_eq!(rows_after_rejection.len(), 1);
+
+    admin.shutdown().await.expect("shutdown admin");
+    alice.shutdown().await.expect("shutdown alice");
+    observer.shutdown().await.expect("shutdown observer");
     server.shutdown().await;
 }
 

--- a/docs/content/docs/auth/permissions.mdx
+++ b/docs/content/docs/auth/permissions.mdx
@@ -129,6 +129,12 @@ permission to modify the original row and that the result is also valid.
 If you only use `.whereOld(...)`, the same condition is applied to both the old and new row. The
 same applies if you only use `.whereNew(...)`. Use both when the old-row and new-row checks differ.
 
+`exists` runs before a write is applied, so it can be used to prevent some columns from being updated.
+
+<include cwd lang="ts" meta='title="permissions.ts"'>
+  ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-update-protected-columns
+</include>
+
 ## Policy enforcement and request context
 
 Every policy is evaluated against a session. On the frontend, this is the authenticated user's session. In a backend handler, create a scoped session per request so queries run with the right identity.

--- a/examples/chat-react/permissions.ts
+++ b/examples/chat-react/permissions.ts
@@ -1,21 +1,27 @@
-import { definePermissions } from "jazz-tools/permissions";
-import { app } from "./schema.js";
+import { definePermissions, RowContext } from "jazz-tools/permissions";
+import { app, Chat } from "./schema.js";
 
-export default definePermissions(app, ({ policy, session, anyOf, allowedTo }) => {
+export default definePermissions(app, ({ policy, session, allOf, anyOf, allowedTo }) => {
   policy.profiles.allowRead.where({});
   policy.profiles.allowInsert.where({ userId: session.user_id });
   policy.profiles.allowUpdate.where({ userId: session.user_id });
 
+  const userIsChatMember = (chat: RowContext<Chat>) =>
+    policy.chatMembers.exists.where({ chatId: chat.id, userId: session.user_id });
   policy.chats.allowRead.where((chat) =>
-    anyOf([
-      { isPublic: true },
-      policy.chatMembers.exists.where({ chatId: chat.id, userId: session.user_id }),
-      { joinCode: session["claims.join_code"] },
-    ]),
+    anyOf([{ isPublic: true }, userIsChatMember(chat), { joinCode: session["claims.join_code"] }]),
   );
   policy.chats.allowInsert.where({ createdBy: session.user_id });
-  policy.chats.allowUpdate.where((chat) =>
-    policy.chatMembers.exists.where({ chatId: chat.id, userId: session.user_id }),
+  policy.chats.allowUpdate.whereOld(userIsChatMember).whereNew((chat) =>
+    allOf([
+      userIsChatMember(chat),
+      // Users may update only non-protected fields. `createdBy` and `isPublic` cannot be updated.
+      policy.chats.exists.where({
+        id: chat.id,
+        createdBy: chat.createdBy,
+        isPublic: chat.isPublic,
+      }),
+    ]),
   );
 
   policy.chatMembers.allowRead.where((member) =>

--- a/examples/chat-react/schema.ts
+++ b/examples/chat-react/schema.ts
@@ -62,5 +62,6 @@ type AppSchema = s.Schema<typeof schema>;
 export const app: s.App<AppSchema> = s.defineApp(schema);
 
 export type Profile = s.RowOf<typeof app.profiles>;
+export type Chat = s.RowOf<typeof app.chats>;
 export type Message = s.RowOf<typeof app.messages>;
 export type Attachment = s.RowOf<typeof app.attachments>;

--- a/examples/chat-react/tests/permissions/permissions.test.ts
+++ b/examples/chat-react/tests/permissions/permissions.test.ts
@@ -43,6 +43,70 @@ describe("chat permissions", () => {
     ]);
   });
 
+  it("allows chat name updates", async () => {
+    const privateChat = testApp.seed((db) => {
+      db.insert(app.profiles, {
+        userId: "alice",
+        name: "Alice",
+      });
+      const { value: privateChat } = db.insert(app.chats, {
+        name: "Members only",
+        isPublic: false,
+        createdBy: "alice",
+        joinCode: "invite-456",
+      });
+      db.insert(app.chatMembers, {
+        chatId: privateChat.id,
+        userId: "alice",
+        joinCode: "invite-456",
+      });
+      return privateChat;
+    });
+
+    const aliceDb = testApp.as({ user_id: "alice", claims: {}, authMode: "local-first" });
+
+    aliceDb.expectAllowed((db) =>
+      db.update(app.chats, privateChat.id, {
+        name: "New chat title",
+      }),
+    );
+  });
+
+  it("does not allow chat creator and isPublic updates", async () => {
+    const privateChat = testApp.seed((db) => {
+      db.insert(app.profiles, {
+        userId: "alice",
+        name: "Alice",
+      });
+      const { value: privateChat } = db.insert(app.chats, {
+        name: "Members only",
+        isPublic: false,
+        createdBy: "alice",
+        joinCode: "invite-456",
+      });
+      db.insert(app.chatMembers, {
+        chatId: privateChat.id,
+        userId: "alice",
+        joinCode: "invite-456",
+      });
+      return privateChat;
+    });
+
+    const aliceDb = testApp.as({ user_id: "alice", claims: {}, authMode: "local-first" });
+
+    aliceDb.expectDenied((db) =>
+      db.update(app.chats, privateChat.id, {
+        createdBy: "bob",
+      }),
+    );
+
+    aliceDb.expectDenied((db) =>
+      db.update(app.chats, privateChat.id, {
+        isPublic: true,
+      }),
+    );
+  });
+
   it("allows message inserts only for chat members", async () => {
     const { aliceProfile, bobProfile, privateChat } = testApp.seed((db) => {
       const { value: aliceProfile } = db.insert(app.profiles, {

--- a/examples/docs/todo-server-ts/src/permissions-snippets.ts
+++ b/examples/docs/todo-server-ts/src/permissions-snippets.ts
@@ -124,6 +124,22 @@ s.definePermissions(exampleApp, ({ policy, anyOf, session }) => {
 });
 // #endregion permissions-shares-ts
 
+// #region permissions-update-protected-columns
+s.definePermissions(exampleApp, ({ policy, allOf, session }) => {
+  policy.todos.allowUpdate.whereOld({ owner_id: session.user_id }).whereNew((updatedTodo) =>
+    allOf([
+      { owner_id: session.user_id },
+      // `parentId` and `projectId` cannot be updated.
+      policy.todos.exists.where({
+        id: updatedTodo.id,
+        parentId: updatedTodo.parentId,
+        projectId: updatedTodo.projectId,
+      }),
+    ]),
+  );
+});
+// #endregion permissions-update-protected-columns
+
 // #region permissions-whereold-wherenew-ts
 s.definePermissions(exampleApp, ({ policy, session }) => {
   // User can only update their own rows, and the result must still be owned by them

--- a/packages/jazz-tools/src/permissions/index.ts
+++ b/packages/jazz-tools/src/permissions/index.ts
@@ -429,7 +429,7 @@ interface Rule {
 
 type RuleLike = Rule | UpdateRuleBuilder<unknown, unknown>;
 
-type RowContext<Row> = {
+export type RowContext<Row> = {
   [K in keyof Row & string]: RowRefValue;
 };
 


### PR DESCRIPTION
## Description

Fixes update permission checks that reference `id` inside `exists` policies.

The policy evaluator now carries the current row object ID through these policies, so checks like `chatMembers.chatId == chat.id` and self-checks like `chats.id == chat.id` evaluate correctly.

Also added an example of how policies can be used to enforce only specific columns in a table can be updated. 