### PR TITLE
fix: improve server startup logging around sensitive config

### DIFF
--- a/.changeset/inspector-link-no-admin-secret.md
+++ b/.changeset/inspector-link-no-admin-secret.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+The inspector link logged on server startup no longer embeds the admin secret in the URL. If an admin secret is configured, a follow-up log line prompts you to enter it manually in the inspector.

--- a/.changeset/local-first-auth-auto-enable-warning.md
+++ b/.changeset/local-first-auth-auto-enable-warning.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+The server now logs a prominent warning when local-first auth is silently auto-enabled because `NODE_ENV` is not set to `"production"`. Deployments that forget to set `NODE_ENV=production` will see the warning rather than running wide open with no indication.

--- a/crates/jazz-tools/src/commands/server.rs
+++ b/crates/jazz-tools/src/commands/server.rs
@@ -54,8 +54,7 @@ pub async fn run(
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
     let listener = tokio::net::TcpListener::bind(addr).await?;
     let bound_addr = listener.local_addr()?;
-    let inspector_link =
-        build_inspector_link(bound_addr.port(), &app_id_string, admin_secret.as_deref());
+    let inspector_link = build_inspector_link(bound_addr.port(), &app_id_string);
 
     if let Some(path) = bound_port_file {
         std::fs::write(&path, bound_addr.port().to_string())
@@ -64,6 +63,9 @@ pub async fn run(
 
     info!("Listening on http://{}", bound_addr);
     info!("Open the inspector: {}", inspector_link);
+    if admin_secret.is_some() {
+        info!("Enter your admin secret in the inspector to publish schemas and policies.");
+    }
 
     let state = built.state.clone();
     let shutdown = state.shutdown.clone();
@@ -144,14 +146,12 @@ pub async fn run(
     Ok(())
 }
 
-fn build_inspector_link(port: u16, app_id: &str, admin_secret: Option<&str>) -> String {
+fn build_inspector_link(port: u16, app_id: &str) -> String {
     let server_url = format!("http://localhost:{port}");
-    let admin_secret_value = admin_secret.unwrap_or("");
     format!(
-        "{STANDALONE_INSPECTOR_URL}#serverUrl={}&appId={}&adminSecret={}",
+        "{STANDALONE_INSPECTOR_URL}#serverUrl={}&appId={}",
         percent_encode_fragment_value(&server_url),
         percent_encode_fragment_value(app_id),
-        percent_encode_fragment_value(admin_secret_value),
     )
 }
 
@@ -176,11 +176,21 @@ mod tests {
 
     #[test]
     fn inspector_link_percent_encodes_fragment_values() {
-        let link = build_inspector_link(4200, "app:one/two", Some("secret with spaces"));
+        let link = build_inspector_link(4200, "app:one/two");
 
         assert_eq!(
             link,
-            "https://jazz2-inspector.vercel.app/#serverUrl=http%3A%2F%2Flocalhost%3A4200&appId=app%3Aone%2Ftwo&adminSecret=secret%20with%20spaces"
+            "https://jazz2-inspector.vercel.app/#serverUrl=http%3A%2F%2Flocalhost%3A4200&appId=app%3Aone%2Ftwo"
+        );
+    }
+
+    #[test]
+    fn inspector_link_does_not_include_admin_secret() {
+        let link = build_inspector_link(4200, "my-app");
+
+        assert!(
+            !link.contains("adminSecret"),
+            "admin secret must not appear in logged link"
         );
     }
 }

--- a/crates/jazz-tools/src/main.rs
+++ b/crates/jazz-tools/src/main.rs
@@ -205,8 +205,18 @@ async fn main() {
             bound_port_file,
         } => {
             let node_env_mode = resolve_node_env_mode();
+            let explicitly_allowed = allow_local_first_auth;
             let allow_local_first_auth =
                 resolve_dev_default_flag(node_env_mode, allow_local_first_auth);
+            if allow_local_first_auth && !explicitly_allowed {
+                tracing::warn!(
+                    "Local-first auth is enabled automatically because NODE_ENV is not \
+                     set to \"production\". Any self-signed Jazz token will be accepted \
+                     with no additional configuration. Set NODE_ENV=production or pass \
+                     --allow-local-first-auth / JAZZ_ALLOW_LOCAL_FIRST_AUTH=true to \
+                     acknowledge this explicitly."
+                );
+            }
             let jwt_public_key = match jwt_public_key {
                 Some(value) => match resolve_jwt_public_key_input(value) {
                     Ok(value) => Some(value),


### PR DESCRIPTION
## Summary
- The server was embedding the real `--admin-secret` value in the inspector
  URL fragment and logging it at `info` level on every startup, exposing it
  to log aggregators and shoulder-surfable terminals. The logged link now
  omits `adminSecret` entirely; a follow-up line tells users to enter it
  manually in the inspector.
- Add a prominent `warn!` when local-first auth is silently auto-enabled
  because `NODE_ENV` is not set to `"production"`. Deployments that forget
  `NODE_ENV=production` now get a clear signal rather than running wide open
  with no indication. Passing `--allow-local-first-auth` /
  `JAZZ_ALLOW_LOCAL_FIRST_AUTH=true` suppresses the warning.

## Test plan
- [ ] Start the server with `--admin-secret my-secret` and confirm the logged
  inspector link contains no trace of `my-secret`.
- [ ] Start the server without `NODE_ENV=production` and without
  `--allow-local-first-auth`; confirm the warning appears in the logs.
- [ ] Run `cargo test -p jazz-tools --bin jazz-tools --features cli -- inspector_link`
  and confirm both tests pass.