### PR TITLE
Implement transaction upload protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2506,6 +2506,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/mini-jazz-sqlite/Cargo.toml
+++ b/crates/mini-jazz-sqlite/Cargo.toml
@@ -9,6 +9,7 @@ test = []
 [dependencies]
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1"
+uuid = { version = "1", features = ["js", "v7"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rusqlite = { version = "0.40", features = ["bundled", "limits"] }

--- a/crates/mini-jazz-sqlite/SPEC.md
+++ b/crates/mini-jazz-sqlite/SPEC.md
@@ -1,8 +1,8 @@
 # Jazz Relational Core On An Embedded Database
 
-Status: Draft v2.
+Status: Draft v3.
 
-Date: 2026-05-25.
+Date: 2026-06-01.
 
 Audience: database engineers and systems engineers who do not know existing
 Jazz internals.
@@ -18,14 +18,14 @@ The full spec is split across focused files.
 - [Product Surface](spec/05-product-surface.md): High-level API preservation goals and product operation semantics.
 - [Schemas, Catalogue, And Lenses](spec/06-schemas-catalogue-lenses.md): Schema catalogue, migrations, lenses, and explicit index declarations.
 - [Policies](spec/07-policies.md): SQL-lowerable policy semantics, read/write validation, and recursive policy requirements.
-- [Transactions](spec/08-transactions.md): Transaction modes, outcomes, read/write sets, and local/global behavior.
+- [Transactions](spec/08-transactions.md): Transaction ids, modes, outcomes, read/write sets, and local/global behavior.
 - [History And Projection](spec/09-history-projection.md): Append-only row history and rebuildable current projections.
 - [Visibility, Snapshots, And Branches](spec/10-visibility-branches.md): Visibility relations, historical snapshots, and branch source provenance.
 - [Queries And Observed Facts](spec/11-queries-observed-facts.md): Query semantics, observed facts, aggregates, and sync-scope basis.
-- [Sync And Subscriptions](spec/12-sync-subscriptions.md): Sync bundles, query settlement, subscriptions, and incoming sync application.
+- [Sync And Subscriptions](spec/12-sync-subscriptions.md): Sync bundles, client transaction upload, query settlement, subscriptions, unsubscribe, and incoming sync application.
 - [Authority And Conflicts](spec/13-authority-conflicts.md): Authority validation, dependency handling, conflict candidates, and resolution.
 - [Runtime And Public Boundary](spec/14-runtime-boundary.md): Semantic system fields, runtime topology, files, errors, and wire/public boundaries.
-- [Embedded Database Lowering](spec/15-embedded-database-lowering.md): SQLite-oriented physical lowering details and indexes.
+- [Embedded Database Lowering](spec/15-embedded-database-lowering.md): SQLite-oriented physical lowering details, upload registry storage, and indexes.
 - [Operations, Platform, And Tooling](spec/16-operations-platform-tooling.md): Security, export/backup, bindings, packaging, developer tooling, and admin workflows.
 - [Open Areas, Strategy, And Rationale](spec/17-open-areas-strategy-rationale.md): Known undefined areas, research discipline, optimization recommendations, implementation strategy, rationale, and future revisits.
 - [Invariants To Test](spec/18-invariants.md): The exhaustive invariant catalogue for implementation and whole-system tests.

--- a/crates/mini-jazz-sqlite/spec/08-transactions.md
+++ b/crates/mini-jazz-sqlite/spec/08-transactions.md
@@ -16,6 +16,14 @@ Every transaction has:
 - creation time
 - typed metadata containing write facts and persisted observed facts
 
+Public transaction ids are opaque. They are stable across replicas and across
+authority acceptance, but callers and protocol peers must not infer writer,
+local epoch, ordering, or authority state from their text. The current Rust
+prototype generates local transaction ids as UUIDv7 strings. Earlier
+`tx-{node_id}-{local_epoch}` ids are no longer the local-generation format.
+`node_id` and `local_epoch` remain stored transaction facts for writer identity,
+debugging, and local uniqueness, but they are not the public id encoding.
+
 Transaction kinds include:
 
 - data
@@ -52,14 +60,24 @@ resend the original write bundle.
 
 The local write path:
 
-1. allocates transaction id and local epoch
+1. allocates an opaque public transaction id and node-local epoch
 2. begins an embedded database transaction
 3. records the transaction
 4. appends all history rows
 5. records write facts and persisted observed facts
 6. updates or invalidates current projections
-7. commits the embedded database transaction
-8. publishes local subscription diffs
+7. records client-upload retry metadata for ordinary local transactions
+8. commits the embedded database transaction
+9. publishes local subscription diffs
+
+The transaction is the unit of upload and reconciliation. One transaction may
+contain multiple row mutations across multiple tables, but retry, acceptance,
+rejection, receipts, and upload status are all tracked for the transaction as a
+whole. Registry insertion for an ordinary local transaction is part of the same
+embedded-database transaction as the history append; if the registry insert
+fails, the local write fails rather than creating a durable write that cannot be
+reconciled upstream. A future true local-only transaction mode must opt out of
+this explicitly rather than relying on accidental queue omission.
 
 Patch updates preserve omitted fields from the effective visible row. The
 effective base may be a current branch row, a row inherited from branch sources,

--- a/crates/mini-jazz-sqlite/spec/12-sync-subscriptions.md
+++ b/crates/mini-jazz-sqlite/spec/12-sync-subscriptions.md
@@ -137,7 +137,7 @@ write provenance from the authenticated connection/session. For trusted peer or
 server connections, the peer may be authoritative for author/provenance subject
 to the connection role.
 
-`ClientDataRecord` carries row deltas:
+`ClientDataRecord` carries row data:
 
 ```rust
 struct ClientDataRecord {
@@ -148,10 +148,10 @@ struct ClientDataRecord {
 }
 ```
 
-`values` is delta-shaped:
+`values` is row-image-shaped:
 
-- `Insert`: proposed fields for the new row
-- `Update`: changed fields only
+- `Insert`: effective fields for the new row
+- `Update`: effective fields after the update
 - `Delete`: empty values
 
 System fields such as `j_created_at`, `j_updated_at`, `j_created_by`, and

--- a/crates/mini-jazz-sqlite/spec/12-sync-subscriptions.md
+++ b/crates/mini-jazz-sqlite/spec/12-sync-subscriptions.md
@@ -91,7 +91,178 @@ Open issues:
 - cache eviction policy and authorization revalidation for retained
   out-of-scope data
 
-## 17. Subscriptions
+## 17. Client Transaction Upload
+
+Client upload is transaction-scoped. One `ClientMessage::UploadTx` carries one
+transaction:
+
+```rust
+ClientMessage::UploadTx {
+    tx: ClientTx,
+    data: Vec<ClientDataRecord>,
+    reads: Vec<ReadRecord>,
+}
+```
+
+That transaction may contain multiple row changes across multiple tables.
+Protocol-level batching may group many messages in one transport frame, but the
+message-level unit remains one transaction.
+
+Upload sends transaction data, not authoritative history. The receiver expands
+the client delta into local storage/history only after applying connection
+trust, auth, policy, conflict-mode, branch, and current-state validation. A
+client cannot forge receipts, global epochs, rejection state, catalogue state,
+or system fields.
+
+`ClientTx` carries:
+
+```rust
+struct ClientTx {
+  tx_id: String,
+  branch_id: Option<String>,
+  conflict_mode: TxConflictMode,
+  created_at: i64,
+  author: Option<String>,
+}
+```
+
+`tx_id` is opaque. Locally generated ids are UUIDv7 in the Rust prototype, but
+upload handling accepts opaque public ids and does not derive behavior from the
+text format. `branch_id = Some(id)` targets that branch. `branch_id = None`
+uses the authenticated session's default branch; if no default branch exists
+for that session, the upload is invalid for that session.
+
+For untrusted client connections, the receiver ignores `author` and derives
+write provenance from the authenticated connection/session. For trusted peer or
+server connections, the peer may be authoritative for author/provenance subject
+to the connection role.
+
+`ClientDataRecord` carries row deltas:
+
+```rust
+struct ClientDataRecord {
+  table: String,
+  row_id: String,
+  op: DataOp,
+  values: BTreeMap<String, JsonValue>,
+}
+```
+
+`values` is delta-shaped:
+
+- `Insert`: proposed fields for the new row
+- `Update`: changed fields only
+- `Delete`: empty values
+
+System fields such as `j_created_at`, `j_updated_at`, `j_created_by`, and
+`j_updated_by` are rejected from client data. They are derived by the receiver.
+One upload transaction must not contain duplicate `(table, row_id)` records;
+the client normalizes repeated same-row mutations before upload.
+
+Mergeable transactions may send `reads: []`. Exclusive or conflict-sensitive
+transactions send the read facts needed for validation. This spec keeps the
+existing `ReadRecord` shape for now; redesigning the read-set protocol is a
+separate change.
+
+The server sends a receipt ACK when it has received the upload message on this
+connection:
+
+```rust
+ServerMessage::UploadAck {
+    tx_id: String,
+}
+```
+
+`UploadAck` is flow control only. It frees one in-flight upload slot. It does
+not mean the transaction was durably accepted, edge-filed, globally accepted,
+or rejected, and it never completes the durable upload queue.
+
+Transaction fate is reported separately:
+
+```rust
+ServerMessage::TxStatus {
+    tx_id: String,
+    status: TxStatusKind,
+}
+
+enum TxStatusKind {
+    EdgeAccepted,
+    GlobalAccepted { global_epoch: i64 },
+    Rejected { code: String, detail: Option<JsonValue> },
+}
+```
+
+The server sends `TxStatus` only when the transaction reaches edge, reaches
+global, or is rejected. It does not send pending or awaiting-dependency
+statuses. `TxStatus` is non-cumulative: `EdgeAccepted` means edge acceptance
+happened, `GlobalAccepted` means global acceptance happened and satisfies
+edge-level retry/wait needs, and `Rejected` is terminal for upload retry.
+Clients ignore unknown statuses. Clients also ignore invalid downgrade-like
+statuses; for example, an exclusive transaction that sees only edge acceptance
+keeps waiting/replaying until global acceptance or rejection.
+
+The client durable upload queue is scanned after handshake and reconnect. It
+sends active rows ordered by:
+
+```sql
+ORDER BY created_at, sync_seq
+```
+
+`created_at` is the transaction timestamp. `sync_seq` is a local monotonic
+registry tie-breaker and is never sent over the wire. The client sends in this
+order, but it does not wait for `tx A` to be acked before sending `tx B`.
+WebSocket and `postMessage` provide ordered delivery for the intended
+transports; any future unordered transport must provide an ordered stream below
+this protocol.
+
+The default max in-flight upload count is `1000`. Negotiation may be added
+later if servers need to advertise lower capacity.
+
+Reconnect has no special upload replay message. Connection-local in-flight
+state is cleared, the durable upload queue is scanned again, and active
+transactions are replayed even when no subscription is active.
+
+Server handling is:
+
+```text
+UploadTx
+   |
+   v
+handshake + auth checks
+   |
+   +-- failed envelope/auth check ----> protocol error / close
+   |
+   v
+send UploadAck(tx_id)
+   |
+   v
+validate shape, branch, tx id, reads, policy, current rows
+   |
+   +-- invalid or denied ------------> TxStatus(tx_id, Rejected)
+   |
+   v
+expand client delta into authoritative local storage/history
+   |
+   v
+record edge/global/rejection fate when known
+   |
+   v
+TxStatus(tx_id, EdgeAccepted | GlobalAccepted | Rejected)
+```
+
+Duplicate upload of an already known transaction is idempotent. The server
+still sends `UploadAck`; if it already knows terminal or settled fate, it should
+also send the current `TxStatus` so the client can complete reconciliation.
+
+If the server lacks authoritative state needed to validate an update or delete,
+it should fetch or wait for trusted upstream state rather than trusting client
+history. Missing local state is not automatically proof that the transaction is
+invalid.
+
+Protocol version is `2` for this wire shape. `ProtocolCapabilities` includes
+`tx_upload`; clients reject a server hello that does not advertise it.
+
+## 18. Subscriptions
 
 One-shot queries and live subscriptions share query semantics.
 
@@ -185,7 +356,22 @@ Invalidation may start coarse but must be correct. Useful invalidation facts:
 Row-id cursors alone are insufficient for ordered-page invalidation because a
 row outside the page may move inside the page when its order key changes.
 
-## 18. Incoming Sync Application
+Unsubscribe is explicit:
+
+```rust
+ClientMessage::Unsubscribe {
+    subscription_id: SubscriptionId,
+}
+```
+
+The server removes exactly that active subscription, drops pending download
+messages and last acknowledged cursor state for that subscription, and sends no
+reply. Unsubscribe does not touch upload queue state and does not rely on
+replaying the remaining subscription set. `Replay` remains the reconnect/full
+subscription reconciliation message, not the single-subscription removal
+mechanism.
+
+## 19. Incoming Sync Application
 
 Incoming sync application is semantic, not insert-only.
 

--- a/crates/mini-jazz-sqlite/spec/14-runtime-boundary.md
+++ b/crates/mini-jazz-sqlite/spec/14-runtime-boundary.md
@@ -105,11 +105,21 @@ physical browser/native storage backend.
 Transport should stay thin. It carries typed sync and catalogue messages; it
 does not implement a second query engine.
 
+The sync protocol version is bumped when the message contract changes. The
+client transaction upload protocol is version `2` and requires the server to
+advertise `ProtocolCapabilities { tx_upload: true, ... }`. Clients that need
+upload reject a server hello without that capability instead of silently
+falling back to download-only behavior.
+
 Reconnect should use replay-window recovery first and full scope/frontier
 snapshot fallback when the replay window is insufficient. Active subscriptions
 are desired state and should be replayed on reconnect. Query descriptors are
 not durable disk state: after a tab or worker restart, downstream live
 subscriptions replay to the worker/broker, then trickle upstream from there.
+Local transaction upload state is different: ordinary committed local
+transactions are durable retry state, so reconnect scans the upload registry and
+replays active transaction uploads even when there are no active
+subscriptions.
 
 Open issues:
 

--- a/crates/mini-jazz-sqlite/spec/15-embedded-database-lowering.md
+++ b/crates/mini-jazz-sqlite/spec/15-embedded-database-lowering.md
@@ -102,20 +102,11 @@ CREATE INDEX IF NOT EXISTS jazz_tx_upload_queue_active_idx
 ON jazz_tx_upload_queue(status, created_at, sync_seq)
 WHERE status = 1;
 
-CREATE TABLE IF NOT EXISTS jazz_tx_upload_data (
-  tx_num INTEGER NOT NULL,
-  record_index INTEGER NOT NULL,
-  table_name TEXT NOT NULL,
-  row_id TEXT NOT NULL,
-  op INTEGER NOT NULL,
-  values_json TEXT NOT NULL,
-  PRIMARY KEY (tx_num, record_index)
-) WITHOUT ROWID;
 ```
 
 `jazz_tx_upload_queue` owns retry, in-flight bookkeeping, and completion
-metadata. `jazz_tx_upload_data` stores the transaction's row deltas in
-transaction-local order. The registry joins to `jazz_tx` through `tx_num`; the
+metadata. Upload data is reconstructed from transaction write metadata and
+committed history rows. The registry joins to `jazz_tx` through `tx_num`; the
 public `tx_id` is read from `jazz_tx` when constructing an upload message.
 
 Active upload scans use:
@@ -129,10 +120,10 @@ The partial index keeps this scan small even when many completed rows are
 retained for diagnostics or delayed cleanup. `sync_seq` is a local-only
 monotonic tie-breaker and never crosses the protocol boundary.
 
-Cleanup deletes completed rows from `jazz_tx_upload_queue` and
-`jazz_tx_upload_data` only. It must never delete `jazz_tx`, transaction
-receipts, rejection details, history, current projection, or row identity
-metadata. Active rows are never eligible for cleanup by age.
+Cleanup deletes completed rows from `jazz_tx_upload_queue` only. It must never
+delete `jazz_tx`, transaction receipts, rejection details, history, current
+projection, or row identity metadata. Active rows are never eligible for cleanup
+by age.
 
 ### 26.3 History And Current Tables
 

--- a/crates/mini-jazz-sqlite/spec/15-embedded-database-lowering.md
+++ b/crates/mini-jazz-sqlite/spec/15-embedded-database-lowering.md
@@ -75,7 +75,66 @@ to re-run authority policy validation after missing facts arrive.
 authority epoch. Indexes should support lookup/order by `(global_epoch, tx_num)`
 or equivalent stable tie-breaker.
 
-### 26.2 History And Current Tables
+### 26.2 Client Upload Registry
+
+The client upload registry is durable retry metadata for ordinary local
+transactions that still need upstream reconciliation. It is not authoritative
+transaction fate storage; transaction outcome, receipts, rejection detail,
+history, and row data live in their normal tables.
+
+Prototype schema:
+
+```sql
+CREATE TABLE IF NOT EXISTS jazz_tx_upload_queue (
+  sync_seq INTEGER PRIMARY KEY AUTOINCREMENT,
+  tx_num INTEGER NOT NULL UNIQUE,
+  status INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  branch_id TEXT,
+  author TEXT,
+  completed_at INTEGER,
+  last_upload_attempt_at INTEGER,
+  last_ack_at INTEGER,
+  attempt_count INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS jazz_tx_upload_queue_active_idx
+ON jazz_tx_upload_queue(status, created_at, sync_seq)
+WHERE status = 1;
+
+CREATE TABLE IF NOT EXISTS jazz_tx_upload_data (
+  tx_num INTEGER NOT NULL,
+  record_index INTEGER NOT NULL,
+  table_name TEXT NOT NULL,
+  row_id TEXT NOT NULL,
+  op INTEGER NOT NULL,
+  values_json TEXT NOT NULL,
+  PRIMARY KEY (tx_num, record_index)
+) WITHOUT ROWID;
+```
+
+`jazz_tx_upload_queue` owns retry, in-flight bookkeeping, and completion
+metadata. `jazz_tx_upload_data` stores the transaction's row deltas in
+transaction-local order. The registry joins to `jazz_tx` through `tx_num`; the
+public `tx_id` is read from `jazz_tx` when constructing an upload message.
+
+Active upload scans use:
+
+```sql
+WHERE status = 1
+ORDER BY created_at, sync_seq
+```
+
+The partial index keeps this scan small even when many completed rows are
+retained for diagnostics or delayed cleanup. `sync_seq` is a local-only
+monotonic tie-breaker and never crosses the protocol boundary.
+
+Cleanup deletes completed rows from `jazz_tx_upload_queue` and
+`jazz_tx_upload_data` only. It must never delete `jazz_tx`, transaction
+receipts, rejection details, history, current projection, or row identity
+metadata. Active rows are never eligible for cleanup by age.
+
+### 26.3 History And Current Tables
 
 Sketch:
 
@@ -139,7 +198,7 @@ redundant append-only history can compress well. Custom VFS/page compression is
 a serious storage research target despite portability cost across browser,
 native, and server runtimes.
 
-### 26.3 Branch View Tables
+### 26.4 Branch View Tables
 
 Sketch:
 
@@ -171,7 +230,7 @@ CREATE TABLE jazz_branch_source (
 ) WITHOUT ROWID;
 ```
 
-### 26.4 Identity Mapping
+### 26.5 Identity Mapping
 
 Logical mappings:
 
@@ -207,7 +266,7 @@ that can later hydrate the same public identity to two different physical
 identities or attach branch provenance to the wrong branch. SQLite transactions
 should be used as the atomicity boundary for all such mapping updates.
 
-### 26.5 Indexes
+### 26.6 Indexes
 
 Indexes are part of the lowering plan, not handwritten per feature.
 

--- a/crates/mini-jazz-sqlite/spec/17-open-areas-strategy-rationale.md
+++ b/crates/mini-jazz-sqlite/spec/17-open-areas-strategy-rationale.md
@@ -23,6 +23,13 @@ The following areas remain intentionally underspecified:
 - full schema lens semantics
 - reconnect summaries
 - subscription settlement and reconnection protocol
+- negotiated upload in-flight capacity below the initial `1000` default
+- server-durable uploaded-transaction inbox/interest state, if reconnect replay
+  from the client queue is not sufficient for a future topology
+- unordered transport recovery below the upload protocol; current intended
+  transports provide ordered delivery
+- final read-set wire shape for uploaded exclusive transactions
+- true local-only transaction mode that deliberately skips upstream upload
 - hot branch projection heuristics
 - audit-grade append-only receipt history
 - hard-delete/truncate authorization, sync, and retention semantics

--- a/crates/mini-jazz-sqlite/spec/18-invariants.md
+++ b/crates/mini-jazz-sqlite/spec/18-invariants.md
@@ -10,6 +10,11 @@ feature exists.
 
 - Public row ids are stable across replicas.
 - Public transaction ids are stable across local-to-global acceptance.
+- Public transaction ids are opaque. Protocol peers and application code must
+  not derive writer node, local epoch, ordering, or authority state from the id
+  string.
+- Locally generated public transaction ids are UUIDv7 strings in the Rust
+  prototype.
 - Physical ids never cross API or sync boundaries.
 - Rehydrating the same public id on one replica returns the same physical id.
 - Different replicas may assign different physical ids to the same public id.
@@ -27,6 +32,12 @@ feature exists.
 - One simple write creates one sealed transaction.
 - One explicit transaction may contain multiple row mutations and still seals as
   one transaction.
+- One upload message contains exactly one sealed transaction; that transaction
+  may contain multiple row mutations across multiple tables.
+- Ordinary committed local transactions enter the durable upload registry
+  atomically with the transaction commit.
+- Failure to insert ordinary local transaction upload registry metadata fails
+  the local commit.
 - An explicit transaction with no staged mutations is a no-op and creates no
   transaction record.
 - Multiple staged mutations to the same row in one explicit transaction
@@ -219,6 +230,47 @@ feature exists.
 - Rows that leave scope because of update, delete, policy change, branch source
   change, outcome change, or catalogue/lens change eventually disappear from
   local query results after relevant repair data arrives.
+- Client upload sends transaction data, not authoritative history. The receiver
+  derives authoritative history/system fields from connection trust, auth,
+  policy, branch, and storage state.
+- Client upload data cannot forge receipts, global epochs, rejection state,
+  catalogue state, or semantic system fields.
+- Upload uses one `UploadTx` message per transaction. Protocol batching may
+  carry many upload messages, but one message is still one transaction.
+- Uploaded row data is delta-shaped: inserts carry proposed fields, updates
+  carry changed fields, and deletes carry empty values.
+- Mergeable upload transactions may omit reads; exclusive upload transactions
+  require the read facts needed for validation.
+- Uploads are sent from the durable registry ordered by `(created_at,
+sync_seq)`, where `sync_seq` is a local-only monotonic tie-breaker.
+- The client sends uploads in registry order but does not wait for one
+  transaction's ACK before sending the next transaction.
+- Upload transport must preserve message order, or provide an ordered stream
+  abstraction below the sync protocol.
+- `UploadAck` is connection-local flow control only and never completes the
+  durable upload registry entry.
+- Upload registry completion is derived from local authoritative transaction
+  fate, not from the ACK path.
+- `TxStatus` is non-cumulative. `GlobalAccepted` satisfies edge-level retry and
+  wait needs, `EdgeAccepted` records edge acceptance, and `Rejected` is
+  terminal for upload retry.
+- Mergeable upload registry entries complete on edge acceptance, global
+  acceptance, or rejection.
+- Exclusive upload registry entries complete only on global acceptance or
+  rejection; edge-only or downgrade-like statuses are ignored for exclusive
+  retry completion.
+- Unknown upload transaction statuses are ignored by the client.
+- Reconnect clears connection-local in-flight upload state and replays active
+  durable upload registry entries, even when no subscription is active.
+- Duplicate upload of an already known transaction is idempotent and does not
+  rewrite accepted history for the same public transaction id.
+- A server that lacks authoritative state needed to validate an uploaded update
+  or delete waits/fetches trusted upstream state when possible; missing local
+  state is not automatically a rejection.
+- Authenticated untrusted uploads use the authenticated connection/session user
+  for validation and provenance, not client-supplied author fields.
+- Trusted peer uploads may preserve peer-supplied author/provenance only within
+  the connection's trusted role.
 
 ### D.8 Subscription Invariants
 
@@ -236,6 +288,10 @@ feature exists.
 - Rejections that change visible results produce semantic diffs.
 - Rejected unawaited writes surface through the global rejection/error callback.
 - Ordered-page invalidation considers old and new order keys, not only row ids.
+- Targeted unsubscribe removes exactly the named subscription and pending
+  download/cursor state for that subscription.
+- Targeted unsubscribe does not touch upload registry state and does not rely
+  on replaying the remaining subscription set.
 
 ### D.9 Policy Invariants
 
@@ -376,6 +432,9 @@ feature exists.
 - Errors carry stable machine codes plus human-readable messages.
 - Transport/quota/upload capacity failures are transport/API errors.
 - Semantic database failures are transaction/query errors or rejections.
+- Upload envelope/auth failures may close the protocol session; semantically
+  invalid upload transactions reject the transaction without closing a healthy
+  session.
 - Recoverable catalogue/sync gaps are unsettled state before timeout, not
   immediate errors.
 - Developer diagnostics can be richer and less stable than public errors.
@@ -384,6 +443,13 @@ feature exists.
 
 - Hot paths use local integer surrogates for repeated public ids.
 - Hot enum fields use integer discriminants.
+- The upload registry stores retry metadata and row deltas only; transaction
+  fate, receipts, rejection detail, row history, and current projection remain
+  in their normal storage tables.
+- Upload registry cleanup deletes only completed registry/data rows and never
+  deletes transaction records, history, receipts, rejection detail, row identity
+  mappings, or current projection.
+- Upload registry cleanup never deletes active rows, regardless of age.
 - Runtime can install and use schemas that are not the todo fixture; fixture
   helpers do not define core semantics.
 - Composite-key hot tables use `WITHOUT ROWID` unless benchmarks show a

--- a/crates/mini-jazz-sqlite/spec/18-invariants.md
+++ b/crates/mini-jazz-sqlite/spec/18-invariants.md
@@ -237,8 +237,8 @@ feature exists.
   catalogue state, or semantic system fields.
 - Upload uses one `UploadTx` message per transaction. Protocol batching may
   carry many upload messages, but one message is still one transaction.
-- Uploaded row data is delta-shaped: inserts carry proposed fields, updates
-  carry changed fields, and deletes carry empty values.
+- Uploaded row data is row-image-shaped: inserts and updates carry effective
+  field values, and deletes carry empty values.
 - Mergeable upload transactions may omit reads; exclusive upload transactions
   require the read facts needed for validation.
 - Uploads are sent from the durable registry ordered by `(created_at,
@@ -443,12 +443,12 @@ sync_seq)`, where `sync_seq` is a local-only monotonic tie-breaker.
 
 - Hot paths use local integer surrogates for repeated public ids.
 - Hot enum fields use integer discriminants.
-- The upload registry stores retry metadata and row deltas only; transaction
-  fate, receipts, rejection detail, row history, and current projection remain
+- The upload registry stores retry metadata only; transaction fate, receipts,
+  rejection detail, row history, current projection, and upload row data remain
   in their normal storage tables.
-- Upload registry cleanup deletes only completed registry/data rows and never
-  deletes transaction records, history, receipts, rejection detail, row identity
-  mappings, or current projection.
+- Upload registry cleanup deletes only completed registry rows and never deletes
+  transaction records, history, receipts, rejection detail, row identity mappings,
+  or current projection.
 - Upload registry cleanup never deletes active rows, regardless of age.
 - Runtime can install and use schemas that are not the todo fixture; fixture
   helpers do not define core semantics.

--- a/crates/mini-jazz-sqlite/spec/19-prototype-test-traceability.md
+++ b/crates/mini-jazz-sqlite/spec/19-prototype-test-traceability.md
@@ -16,28 +16,64 @@ Coverage labels:
 
 ### E.1 Coverage Summary By Invariant Group
 
-| Group                      | Current status        | Notes                                                                                                                                                                                                                                              |
-| -------------------------- | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| D.1 Identity               | covered for prototype | Public row ids, physical id locality, replica-local physical ids, and one user writing from multiple nodes are tested.                                                                                                                             |
-| D.2 Transactions           | partial               | Sealing, explicit transactions, edge/global receipts, rejection, idempotence, non-unique global epochs, and monotonic fate are tested. Awaiting-dependencies semantics and audit-grade receipt history are not.                                    |
-| D.3 History/projection     | partial               | Append-only ordinary deletes, rebuild, rejection repair, global ordering, remote pending constraints, and broad repair are tested. Hard delete/truncate and full merge/conflict projection semantics remain partial.                               |
-| D.4 Visibility/snapshots   | partial               | Global epoch and pinned branch snapshot behavior is tested. Full vector snapshots are not implemented/tested.                                                                                                                                      |
-| D.5 Branches               | covered for prototype | Branch overlay/base reads, branch tombstones, rejected overlay fallback, provenance sync, multi-source conflict candidates, and branch policy contexts are tested. Full product branch backing rows and merge commits are not.                     |
-| D.6 Queries/observed facts | partial               | Equality, contains, IN, not-equal, null-present, selected system fields, ordered pages, absence facts, recursive query scopes, policy dependencies, query-scope repair, and predicate serialization are tested. Range and catalogue facts are not. |
-| D.7 Sync                   | partial               | Query-scoped sync, table-vs-query scope, idempotence, public id hydration, reordered fate, scope contraction, active query refresh, and reconnect-shaped repair are tested. Compact reconnect summaries and ephemeral observed interests are not.  |
-| D.8 Subscriptions          | partial               | Rerun-and-diff, policy dependency diffs, branch checkout diffs, pinned branch stability, pagination, and reconnect-shaped observed subscription recovery are tested. Tier gating and settled state are not.                                        |
-| D.9 Policies               | covered for prototype | Read/write policies, ref-readable policies, recursive acyclic policies, cycle rejection, branch/pinned-base contexts, trusted bypass, and transitive policy read sets are tested. Full policy language and diagnostics are not.                    |
-| D.10 Catalogue/lenses      | partial               | Narrow storage-name rename lenses, ref lenses, system prefix escaping, and index-only compatibility are tested. Catalogue revision graph, migrations directory semantics, inverse lenses, and copy-forward are not.                                |
-| D.11 Authority validation  | partial               | Untrusted bundle rejection, atomic rejection, delete/update validation, branch-context validation, stale row/absence/policy/source read-set checks, exclusive same-row conflict, and repair are tested. Predicate/range validation is not.         |
-| D.12 Conflicts             | partial               | Side APIs expose multi-base and pinned-base conflict candidates and policy-filtered candidates; conflict-aware row reads and resolution transactions are tested. Product metadata shape is not.                                                    |
-| D.13 Errors/diagnostics    | partial               | Rejection codes, transaction info, rejection lists, rejection subscriptions, and detail enrichment are tested. Public error object shape, redaction, and diagnostics are not.                                                                      |
-| D.14 Storage/lowering      | partial               | SQLite current/history tables, physical ids, system prefix escaping, integer-like enum behavior, and rebuild are exercised. `WITHOUT ROWID`, generated indexes, and query plans are not asserted.                                                  |
-| D.15 Files/blobs           | untested              | No file/blob implementation in the prototype.                                                                                                                                                                                                      |
-| D.16 Privacy/encryption    | untested              | No E2EE/encrypted-index implementation in the prototype.                                                                                                                                                                                           |
-| D.17 Harness               | partial               | In-memory SQLite, file-backed durable nodes, multi-runtime local/edge/global tests, duplicate/reordered bundles, and durable reopen are tested. Drop/delay/reconnect protocol and deterministic clock APIs are not.                                |
-| D.18 Tooling/admin         | untested              | Tooling, inspector, admin catalogue publication, and codegen workflows are not implemented in the prototype.                                                                                                                                       |
+| Group                      | Current status        | Notes                                                                                                                                                                                                                                                                                                           |
+| -------------------------- | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D.1 Identity               | covered for prototype | Public row ids, physical id locality, replica-local physical ids, and one user writing from multiple nodes are tested.                                                                                                                                                                                          |
+| D.2 Transactions           | partial               | Sealing, explicit transactions, edge/global receipts, rejection, idempotence, non-unique global epochs, and monotonic fate are tested. Awaiting-dependencies semantics and audit-grade receipt history are not.                                                                                                 |
+| D.3 History/projection     | partial               | Append-only ordinary deletes, rebuild, rejection repair, global ordering, remote pending constraints, and broad repair are tested. Hard delete/truncate and full merge/conflict projection semantics remain partial.                                                                                            |
+| D.4 Visibility/snapshots   | partial               | Global epoch and pinned branch snapshot behavior is tested. Full vector snapshots are not implemented/tested.                                                                                                                                                                                                   |
+| D.5 Branches               | covered for prototype | Branch overlay/base reads, branch tombstones, rejected overlay fallback, provenance sync, multi-source conflict candidates, and branch policy contexts are tested. Full product branch backing rows and merge commits are not.                                                                                  |
+| D.6 Queries/observed facts | partial               | Equality, contains, IN, not-equal, null-present, selected system fields, ordered pages, absence facts, recursive query scopes, policy dependencies, query-scope repair, and predicate serialization are tested. Range and catalogue facts are not.                                                              |
+| D.7 Sync                   | partial               | Query-scoped sync, table-vs-query scope, idempotence, public id hydration, reordered fate, scope contraction, active query refresh, client upload, ACK/status split, reconnect upload replay, and targeted upload validation are tested. Compact reconnect summaries and server-durable upload inboxes are not. |
+| D.8 Subscriptions          | partial               | Rerun-and-diff, policy dependency diffs, branch checkout diffs, pinned branch stability, pagination, targeted unsubscribe, and reconnect-shaped observed subscription recovery are tested. Tier gating and settled state are not.                                                                               |
+| D.9 Policies               | covered for prototype | Read/write policies, ref-readable policies, recursive acyclic policies, cycle rejection, branch/pinned-base contexts, trusted bypass, and transitive policy read sets are tested. Full policy language and diagnostics are not.                                                                                 |
+| D.10 Catalogue/lenses      | partial               | Narrow storage-name rename lenses, ref lenses, system prefix escaping, and index-only compatibility are tested. Catalogue revision graph, migrations directory semantics, inverse lenses, and copy-forward are not.                                                                                             |
+| D.11 Authority validation  | partial               | Untrusted bundle rejection, atomic rejection, delete/update validation, branch-context validation, stale row/absence/policy/source read-set checks, exclusive same-row conflict, and repair are tested. Predicate/range validation is not.                                                                      |
+| D.12 Conflicts             | partial               | Side APIs expose multi-base and pinned-base conflict candidates and policy-filtered candidates; conflict-aware row reads and resolution transactions are tested. Product metadata shape is not.                                                                                                                 |
+| D.13 Errors/diagnostics    | partial               | Rejection codes, transaction info, rejection lists, rejection subscriptions, upload rejection status, and detail enrichment are tested. Public error object shape, redaction, and diagnostics are not.                                                                                                          |
+| D.14 Storage/lowering      | partial               | SQLite current/history tables, upload registry tables, physical ids, system prefix escaping, integer-like enum behavior, and rebuild are exercised. `WITHOUT ROWID`, generated indexes, and query plans are not broadly asserted.                                                                               |
+| D.15 Files/blobs           | untested              | No file/blob implementation in the prototype.                                                                                                                                                                                                                                                                   |
+| D.16 Privacy/encryption    | untested              | No E2EE/encrypted-index implementation in the prototype.                                                                                                                                                                                                                                                        |
+| D.17 Harness               | partial               | In-memory SQLite, file-backed durable nodes, multi-runtime local/edge/global tests, duplicate/reordered bundles, and durable reopen are tested. Drop/delay/reconnect protocol and deterministic clock APIs are not.                                                                                             |
+| D.18 Tooling/admin         | untested              | Tooling, inspector, admin catalogue publication, and codegen workflows are not implemented in the prototype.                                                                                                                                                                                                    |
 
 ### E.2 Test Module Mapping
+
+#### `connection.rs`
+
+- `downstream_rejects_server_without_tx_upload_capability`: D.7, D.13
+- `protocol_defaults_include_tx_upload_capability`: D.7
+- `connection_upstream_requires_auth_for_upload_tx_after_handshake`: D.7,
+  D.9, D.13
+- `connection_upstream_unsubscribe_removes_subscription_after_handshake`: D.8
+- `connection_manager_unsubscribe_sends_targeted_unsubscribe_upstream`: D.8
+- `connection_manager_flushes_uploads_after_handshake`: D.2, D.7, D.17
+- `connection_manager_flushes_new_local_upload_on_quiet_connection`: D.2,
+  D.7
+- `upstream_upload_tx_gets_ack_and_edge_status`: D.2, D.7
+- `upstream_upload_tx_accepts_opaque_tx_id`: D.1, D.7
+- `upstream_upload_update_waits_when_row_is_missing_then_applies_after_sync`:
+  D.7, D.11
+- `upstream_upload_delete_waits_when_row_is_missing_then_applies_after_sync`:
+  D.7, D.11
+- `upstream_upload_tx_dedupes_existing_tx_id_without_rewrite`: D.2, D.3,
+  D.7
+- `upstream_exclusive_upload_without_write_reads_is_rejected`: D.7, D.11,
+  D.13
+- `rejected_upload_tx_does_not_leave_branch_or_row_id_side_effects`: D.1,
+  D.5, D.7, D.13
+- `rejected_exclusive_upload_reads_do_not_leave_row_id_side_effects`: D.1,
+  D.7, D.11, D.13
+- `upload_delete_with_values_returns_rejection_status`: D.7, D.13
+- `upload_insert_missing_required_field_returns_rejection_status`: D.7,
+  D.13
+- `upload_system_field_returns_rejection_status`: D.7, D.9, D.13
+- `connection_manager_rejects_upload_ack_before_handshake_without_marking_ack`:
+  D.7, D.13
+- `connection_manager_ignores_upload_ack_for_not_in_flight_tx`: D.7
+- `connection_manager_ack_frees_slot_without_resending_acked_upload`: D.7
+- `connection_manager_replays_acked_incomplete_upload_after_reconnect`: D.7,
+  D.17
 
 #### `storage_projection.rs`
 
@@ -398,6 +434,34 @@ Coverage labels:
 The following behaviors are now represented in Appendix D because the tests made
 them concrete:
 
+- locally generated public transaction ids are opaque UUIDv7 strings rather
+  than `tx-{node_id}-{local_epoch}` strings
+- client upload is one protocol message per transaction, while the transaction
+  itself may carry multiple row mutations
+- ordinary committed local transactions enter a durable upload registry and are
+  flushed after handshake or on a quiet connection
+- upload ACK is connection-local flow control and does not complete retry state
+- ACKs before handshake or for non-in-flight transactions do not mark durable
+  upload state as accepted
+- upload in-flight slots are freed by ACKs without resending the acked
+  transaction on the same healthy connection
+- reconnect replays acked but incomplete active upload registry rows
+- upload status and ACK are distinct; edge/global/rejected transaction fate
+  drives registry completion
+- duplicate upload of an already accepted transaction id is idempotent and
+  cannot rewrite accepted history with forged data
+- upload updates and deletes wait for authoritative upstream state when the row
+  is locally missing but may exist upstream
+- untrusted upload validation uses the authenticated connection/session and
+  rejects unauthenticated uploads after handshake
+- system fields in uploaded data are rejected instead of being trusted from the
+  client
+- semantically invalid upload transactions return rejection status without
+  closing an otherwise healthy authenticated session
+- rejected upload attempts roll back branch, row-id, and read-side effects
+- `tx_upload` is an explicit protocol capability
+- unsubscribe is a targeted message that removes one subscription without
+  replaying the remaining subscription set
 - edge-accepted mergeables are accepted/visible without global epochs
 - global epochs are not unique per transaction
 - repeated global acceptance for one transaction cannot regress its global
@@ -529,6 +593,8 @@ The largest gaps between Appendix D and the current prototype tests are:
 - compact reconnect summaries and active query-descriptor replay protocol,
   including how to stop persisting observed descriptors without leaving stale
   local facts in current query results
+- negotiated upload capacity, unordered transport recovery, and any
+  server-durable uploaded-transaction inbox beyond client-side durable replay
 - union semantics for merging overlapping query bundles with different scoped
   metadata fingerprints
 - catalogue observed facts

--- a/crates/mini-jazz-sqlite/src/connection.rs
+++ b/crates/mini-jazz-sqlite/src/connection.rs
@@ -381,8 +381,24 @@ impl UpstreamConnectionManager {
         policy_fingerprint: impl Into<String>,
         connection_auth_user: impl Into<String>,
     ) -> Self {
+        Self::new_authenticated(
+            session_id,
+            node_id,
+            schema_fingerprint,
+            policy_fingerprint,
+            connection_auth_user,
+        )
+    }
+
+    pub fn new_authenticated(
+        session_id: impl Into<String>,
+        node_id: impl Into<String>,
+        schema_fingerprint: impl Into<String>,
+        policy_fingerprint: impl Into<String>,
+        connection_auth_user: impl Into<String>,
+    ) -> Self {
         Self {
-            session: UpstreamSession::new_authenticated_for_test(
+            session: UpstreamSession::new_authenticated(
                 session_id,
                 node_id,
                 schema_fingerprint,
@@ -399,6 +415,16 @@ impl UpstreamConnectionManager {
     ) -> Result<Vec<ServerMessage>> {
         let mut batch = UpstreamMessageBatch::new(client_messages);
         self.session.pump(runtime, &mut batch)?;
+        Ok(batch.into_server_messages())
+    }
+
+    pub fn refresh_active_subscriptions(
+        &mut self,
+        runtime: &Runtime,
+    ) -> Result<Vec<ServerMessage>> {
+        let mut batch = UpstreamMessageBatch::new(Vec::new());
+        self.session
+            .refresh_active_subscriptions(runtime, &mut batch)?;
         Ok(batch.into_server_messages())
     }
 

--- a/crates/mini-jazz-sqlite/src/connection.rs
+++ b/crates/mini-jazz-sqlite/src/connection.rs
@@ -177,6 +177,20 @@ impl DownstreamConnectionManager {
         Ok(batch.into_client_messages())
     }
 
+    pub fn flush(&mut self, runtime: &mut Runtime) -> Result<Vec<ClientMessage>> {
+        if self.session.is_closed() {
+            return Err(Error::new("session is closed"));
+        }
+        if !self.is_ready() {
+            return Ok(Vec::new());
+        }
+
+        let mut batch = DownstreamMessageBatch::empty();
+        self.flush_pending_subscriptions(&mut batch)?;
+        self.flush_uploads(runtime, &mut batch)?;
+        Ok(batch.into_client_messages())
+    }
+
     pub fn receive(
         &mut self,
         runtime: &mut Runtime,
@@ -206,8 +220,7 @@ impl DownstreamConnectionManager {
             )));
         }
         if self.is_ready() {
-            self.flush_pending_subscriptions(&mut batch)?;
-            self.flush_uploads(runtime, &mut batch)?;
+            batch.extend_client_messages(self.flush(runtime)?);
         }
         Ok(batch.into_client_messages())
     }
@@ -422,6 +435,10 @@ impl DownstreamMessageBatch {
 
     pub fn into_client_messages(self) -> Vec<ClientMessage> {
         self.client_messages
+    }
+
+    fn extend_client_messages(&mut self, messages: Vec<ClientMessage>) {
+        self.client_messages.extend(messages);
     }
 }
 

--- a/crates/mini-jazz-sqlite/src/connection.rs
+++ b/crates/mini-jazz-sqlite/src/connection.rs
@@ -84,6 +84,9 @@ pub struct DownstreamConnectionManager {
     session: DownstreamSession,
     pending_subscriptions: BTreeMap<SubscriptionId, PendingSubscription>,
     dropped_subscriptions: BTreeSet<SubscriptionId>,
+    in_flight_uploads: BTreeSet<String>,
+    sent_uploads: BTreeSet<String>,
+    max_in_flight_uploads: usize,
     next_subscription_id: u64,
 }
 
@@ -113,14 +116,23 @@ impl DownstreamConnectionManager {
             ),
             pending_subscriptions: BTreeMap::new(),
             dropped_subscriptions: BTreeSet::new(),
+            in_flight_uploads: BTreeSet::new(),
+            sent_uploads: BTreeSet::new(),
+            max_in_flight_uploads: 1000,
             next_subscription_id: 0,
         }
     }
 
     pub fn open(&mut self) -> Result<Vec<ClientMessage>> {
         let mut batch = DownstreamMessageBatch::empty();
+        self.in_flight_uploads.clear();
+        self.sent_uploads.clear();
         self.session.open(&mut batch)?;
         Ok(batch.into_client_messages())
+    }
+
+    pub fn set_max_in_flight_uploads_for_test(&mut self, max: usize) {
+        self.max_in_flight_uploads = max;
     }
 
     pub fn subscribe(
@@ -171,6 +183,16 @@ impl DownstreamConnectionManager {
         server_messages: Vec<ServerMessage>,
     ) -> Result<Vec<ClientMessage>> {
         let server_messages = self.filter_dropped_server_messages(server_messages);
+        let should_process_upload_acks = self.is_ready();
+        if should_process_upload_acks {
+            for message in &server_messages {
+                if let ServerMessage::UploadAck { tx_id } = message {
+                    if self.in_flight_uploads.remove(tx_id) {
+                        runtime.mark_upload_ack(tx_id)?;
+                    }
+                }
+            }
+        }
         let protocol_error = server_messages.iter().find_map(|message| match message {
             ServerMessage::Error(error) => Some(error.clone()),
             _ => None,
@@ -185,6 +207,7 @@ impl DownstreamConnectionManager {
         }
         if self.is_ready() {
             self.flush_pending_subscriptions(&mut batch)?;
+            self.flush_uploads(runtime, &mut batch)?;
         }
         Ok(batch.into_client_messages())
     }
@@ -202,7 +225,9 @@ impl DownstreamConnectionManager {
         }
 
         let mut batch = DownstreamMessageBatch::empty();
-        self.session.replay(&mut batch)?;
+        batch.send_client_message(ClientMessage::Unsubscribe {
+            subscription_id: subscription.id().clone(),
+        });
         Ok(batch.into_client_messages())
     }
 
@@ -229,6 +254,8 @@ impl DownstreamConnectionManager {
     pub fn close(&mut self, reason: CloseReason) -> Result<Vec<ClientMessage>> {
         let mut batch = DownstreamMessageBatch::empty();
         self.pending_subscriptions.clear();
+        self.in_flight_uploads.clear();
+        self.sent_uploads.clear();
         self.session.close(&mut batch, reason)?;
         Ok(batch.into_client_messages())
     }
@@ -253,6 +280,31 @@ impl DownstreamConnectionManager {
                 subscription.query,
                 subscription.requested_tier,
             )?;
+        }
+        Ok(())
+    }
+
+    fn flush_uploads(
+        &mut self,
+        runtime: &mut Runtime,
+        batch: &mut DownstreamMessageBatch,
+    ) -> Result<()> {
+        let available = self
+            .max_in_flight_uploads
+            .saturating_sub(self.in_flight_uploads.len());
+        if available == 0 {
+            return Ok(());
+        }
+        for upload in runtime.active_uploads(available, &self.sent_uploads)? {
+            let tx_id = upload.tx.tx_id.clone();
+            batch.send_client_message(ClientMessage::UploadTx {
+                tx: upload.tx,
+                data: upload.data,
+                reads: upload.reads,
+            });
+            runtime.mark_upload_attempt(&tx_id)?;
+            self.in_flight_uploads.insert(tx_id.clone());
+            self.sent_uploads.insert(tx_id);
         }
         Ok(())
     }
@@ -284,6 +336,8 @@ impl DownstreamConnectionManager {
                     subscription_id: None,
                     ..
                 }
+                | ServerMessage::UploadAck { .. }
+                | ServerMessage::TxStatus { .. }
                 | ServerMessage::Close(_) => true,
             })
             .collect()
@@ -303,6 +357,24 @@ impl UpstreamConnectionManager {
                 node_id,
                 schema_fingerprint,
                 policy_fingerprint,
+            ),
+        }
+    }
+
+    pub fn new_authenticated_for_test(
+        session_id: impl Into<String>,
+        node_id: impl Into<String>,
+        schema_fingerprint: impl Into<String>,
+        policy_fingerprint: impl Into<String>,
+        connection_auth_user: impl Into<String>,
+    ) -> Self {
+        Self {
+            session: UpstreamSession::new_authenticated_for_test(
+                session_id,
+                node_id,
+                schema_fingerprint,
+                policy_fingerprint,
+                connection_auth_user,
             ),
         }
     }

--- a/crates/mini-jazz-sqlite/src/protocol.rs
+++ b/crates/mini-jazz-sqlite/src/protocol.rs
@@ -2,7 +2,7 @@ use crate::sync::Bundle;
 use crate::BuiltQuery;
 use serde::{Deserialize, Serialize};
 
-pub const SUPPORTED_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion(1);
+pub const SUPPORTED_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion(2);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct ProtocolVersion(pub u32);
@@ -60,6 +60,7 @@ pub struct ProtocolCapabilities {
     pub replay: bool,
     pub acknowledgements: bool,
     pub query_settlement: bool,
+    pub tx_upload: bool,
 }
 
 impl Default for ProtocolCapabilities {
@@ -68,8 +69,51 @@ impl Default for ProtocolCapabilities {
             replay: true,
             acknowledgements: true,
             query_settlement: true,
+            tx_upload: true,
         }
     }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TxConflictMode {
+    Mergeable,
+    Exclusive,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DataOp {
+    Insert,
+    Update,
+    Delete,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClientTx {
+    pub tx_id: String,
+    pub branch_id: Option<String>,
+    pub conflict_mode: TxConflictMode,
+    pub created_at: i64,
+    pub author: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClientDataRecord {
+    pub table: String,
+    pub row_id: String,
+    pub op: DataOp,
+    pub values: std::collections::BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TxStatusKind {
+    EdgeAccepted,
+    GlobalAccepted {
+        global_epoch: i64,
+    },
+    Rejected {
+        code: String,
+        detail: Option<serde_json::Value>,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -126,6 +170,14 @@ pub enum ClientMessage {
     Replay {
         subscriptions: Vec<ReplaySubscription>,
     },
+    UploadTx {
+        tx: ClientTx,
+        data: Vec<ClientDataRecord>,
+        reads: Vec<crate::sync::ReadRecord>,
+    },
+    Unsubscribe {
+        subscription_id: SubscriptionId,
+    },
     Ack {
         message_id: MessageId,
         cursor: Option<ReplayCursor>,
@@ -141,6 +193,13 @@ pub enum ServerMessage {
         subscription_id: Option<SubscriptionId>,
         cursor: ReplayCursor,
         bundle: Bundle,
+    },
+    UploadAck {
+        tx_id: String,
+    },
+    TxStatus {
+        tx_id: String,
+        status: TxStatusKind,
     },
     Settled {
         subscription_id: SubscriptionId,

--- a/crates/mini-jazz-sqlite/src/read_set.rs
+++ b/crates/mini-jazz-sqlite/src/read_set.rs
@@ -141,7 +141,7 @@ pub(crate) fn stale_exclusive_tx_ids_in_bundle(
             .find(|branch| branch.branch_id == *branch_id)
             .and_then(|branch| branch.base_global_epoch);
         let branch_num = branch::ensure(conn, branch_id, base_global_epoch, now_ms())?;
-        let current_tx_num = existing_row_num(conn, &read.row_id)?
+        let current_tx_num = crate::rows::existing_row_num(conn, &read.row_id)?
             .map(|row_num| current_visible_tx_num(conn, &read.table, row_num, branch_num))
             .transpose()?
             .flatten();
@@ -159,16 +159,6 @@ pub(crate) fn stale_exclusive_tx_ids_in_bundle(
         }
     }
     Ok(stale)
-}
-
-fn existing_row_num(conn: &Connection, row_id: &str) -> Result<Option<i64>> {
-    conn.query_row(
-        "SELECT row_num FROM jazz_row_id WHERE row_id = ?",
-        params![row_id],
-        |row| row.get(0),
-    )
-    .optional()
-    .map_err(Into::into)
 }
 
 fn current_visible_tx_num(

--- a/crates/mini-jazz-sqlite/src/read_set.rs
+++ b/crates/mini-jazz-sqlite/src/read_set.rs
@@ -1,4 +1,3 @@
-use crate::rows::ensure_row_id;
 use crate::sync::Bundle;
 use crate::time::now_ms;
 use crate::{branch, schema, tx, Result};
@@ -142,8 +141,10 @@ pub(crate) fn stale_exclusive_tx_ids_in_bundle(
             .find(|branch| branch.branch_id == *branch_id)
             .and_then(|branch| branch.base_global_epoch);
         let branch_num = branch::ensure(conn, branch_id, base_global_epoch, now_ms())?;
-        let row_num = ensure_row_id(conn, &read.table, &read.row_id)?;
-        let current_tx_num = current_visible_tx_num(conn, &read.table, row_num, branch_num)?;
+        let current_tx_num = existing_row_num(conn, &read.row_id)?
+            .map(|row_num| current_visible_tx_num(conn, &read.table, row_num, branch_num))
+            .transpose()?
+            .flatten();
         if read.reason == REASON_ABSENT {
             if current_tx_num.is_some() {
                 stale.insert(read.tx_id.clone());
@@ -158,6 +159,16 @@ pub(crate) fn stale_exclusive_tx_ids_in_bundle(
         }
     }
     Ok(stale)
+}
+
+fn existing_row_num(conn: &Connection, row_id: &str) -> Result<Option<i64>> {
+    conn.query_row(
+        "SELECT row_num FROM jazz_row_id WHERE row_id = ?",
+        params![row_id],
+        |row| row.get(0),
+    )
+    .optional()
+    .map_err(Into::into)
 }
 
 fn current_visible_tx_num(

--- a/crates/mini-jazz-sqlite/src/rows.rs
+++ b/crates/mini-jazz-sqlite/src/rows.rs
@@ -19,14 +19,19 @@ pub(crate) fn ensure_row_id_with_status(conn: &Connection, row_id: &str) -> Resu
     .map(|row_num| (row_num, created))
 }
 
-pub(crate) fn row_num(conn: &Connection, row_id: &str) -> Result<i64> {
+pub(crate) fn existing_row_num(conn: &Connection, row_id: &str) -> Result<Option<i64>> {
     conn.query_row(
         "SELECT row_num FROM jazz_row_id WHERE row_id = ?",
         params![row_id],
         |row| row.get(0),
     )
-    .optional()?
-    .ok_or_else(|| crate::Error::new(format!("unknown row {row_id}")))
+    .optional()
+    .map_err(Into::into)
+}
+
+pub(crate) fn row_num(conn: &Connection, row_id: &str) -> Result<i64> {
+    existing_row_num(conn, row_id)?
+        .ok_or_else(|| crate::Error::new(format!("unknown row {row_id}")))
 }
 
 pub(crate) fn public_row_id(conn: &Connection, row_num: i64) -> Result<String> {

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -1,3 +1,4 @@
+use crate::protocol::{ClientDataRecord, ClientTx, DataOp, TxConflictMode, TxStatusKind};
 use crate::query_api::{predicate_query, BuiltQuery, QueryCondition, QueryConditionOp};
 use crate::read_visibility::ReadVisibility;
 use crate::rows::{ensure_row_id, ensure_row_id_with_status, public_row_id, row_num};
@@ -29,6 +30,13 @@ pub struct Runtime {
     auth: RuntimeAuth,
     node_num: i64,
     branch_num: i64,
+}
+
+#[derive(Clone, Debug)]
+pub struct UploadQueueEntry {
+    pub tx: ClientTx,
+    pub data: Vec<ClientDataRecord>,
+    pub reads: Vec<ReadRecord>,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -129,6 +137,33 @@ impl QueryScopeOptions<'_> {
 }
 
 pub const ADMIN_SYSTEM_USER: &str = "@system/admin";
+const UPLOAD_STATUS_ACTIVE: i64 = 1;
+const UPLOAD_STATUS_COMPLETED: i64 = 2;
+
+#[derive(Clone, Copy)]
+enum UploadCompletion {
+    EdgeAccepted,
+    GlobalAccepted,
+    Rejected,
+}
+
+struct UploadCompletionFate {
+    tx_num: i64,
+    conflict_mode: i64,
+    rejected: bool,
+    has_edge_receipt: bool,
+    has_global_receipt: bool,
+}
+
+impl From<&crate::protocol::TxStatusKind> for UploadCompletion {
+    fn from(status: &crate::protocol::TxStatusKind) -> Self {
+        match status {
+            crate::protocol::TxStatusKind::EdgeAccepted => Self::EdgeAccepted,
+            crate::protocol::TxStatusKind::GlobalAccepted { .. } => Self::GlobalAccepted,
+            crate::protocol::TxStatusKind::Rejected { .. } => Self::Rejected,
+        }
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RuntimeAuth {
@@ -365,6 +400,12 @@ impl Runtime {
         let table = self.schema.table_def(table_name)?.clone();
         let user = self.attribution_user().to_owned();
         let bypass_policy = self.bypasses_policy();
+        let upload_records = vec![ClientDataRecord {
+            table: table_name.to_owned(),
+            row_id: id.to_owned(),
+            op: data_op_from_storage(op)?,
+            values: values.clone(),
+        }];
         let db = self.conn.transaction()?;
         let now = now_ms();
         let (tx_num, tx_id) = tx::create_tx(&db, self.node_num, &self.node_id, now)?;
@@ -390,6 +431,17 @@ impl Runtime {
                     crate::schema::current_table(&table.name)
                 ),
                 params![row_num, self.branch_num, tx_num],
+            )?;
+        }
+        if allowed {
+            let branch_id = branch_id_for_num(&db, self.branch_num)?;
+            enqueue_upload_tx(
+                &db,
+                tx_num,
+                now,
+                Some(&branch_id),
+                Some(&user),
+                &upload_records,
             )?;
         }
         db.commit()?;
@@ -1189,6 +1241,134 @@ impl Runtime {
 
     pub fn apply_untrusted_bundle_as_user(&mut self, bundle: &Bundle, user: &str) -> Result<()> {
         self.apply_untrusted_bundle_with_auth_user(bundle, Some(user))
+    }
+
+    pub(crate) fn apply_upload_tx_as_user(
+        &mut self,
+        upload_tx: &ClientTx,
+        data: &[ClientDataRecord],
+        reads: &[ReadRecord],
+        connection_node_id: &str,
+        connection_auth_user: &str,
+    ) -> Result<Option<TxStatusKind>> {
+        upload_tx_local_epoch(connection_node_id, &upload_tx.tx_id)?;
+        if tx::tx_num(&self.conn, &upload_tx.tx_id).is_ok() {
+            return self.upload_tx_status(&upload_tx.tx_id);
+        }
+
+        let bundle = self.upload_tx_bundle(
+            upload_tx,
+            data,
+            reads,
+            connection_node_id,
+            connection_auth_user,
+        )?;
+        self.apply_untrusted_bundle_as_user(&bundle, connection_auth_user)?;
+
+        if let Some(status) = self.upload_tx_status(&upload_tx.tx_id)? {
+            return Ok(Some(status));
+        }
+        if matches!(upload_tx.conflict_mode, TxConflictMode::Mergeable) {
+            if self
+                .transaction_info(&upload_tx.tx_id)?
+                .awaiting_dependency
+                .is_some()
+            {
+                return Ok(None);
+            }
+            self.accept_transaction_at_edge(&upload_tx.tx_id)?;
+            return Ok(Some(TxStatusKind::EdgeAccepted));
+        }
+        Ok(None)
+    }
+
+    fn upload_tx_bundle(
+        &self,
+        upload_tx: &ClientTx,
+        data: &[ClientDataRecord],
+        reads: &[ReadRecord],
+        connection_node_id: &str,
+        connection_auth_user: &str,
+    ) -> Result<Bundle> {
+        if data.is_empty() {
+            return Err(crate::Error::new("upload transaction contains no data"));
+        }
+        for read in reads {
+            if read.tx_id != upload_tx.tx_id {
+                return Err(crate::Error::new(
+                    "upload read references another transaction",
+                ));
+            }
+        }
+        if matches!(upload_tx.conflict_mode, TxConflictMode::Exclusive) {
+            validate_exclusive_upload_reads(data, reads)?;
+        }
+
+        let branch_id = upload_tx
+            .branch_id
+            .clone()
+            .unwrap_or_else(|| "main".to_owned());
+        let branch_num = branch::checkout(&self.conn, &branch_id)?;
+        let history = upload_history_records(
+            &self.conn,
+            &self.schema,
+            upload_tx,
+            data,
+            &branch_id,
+            branch_num,
+            connection_auth_user,
+        )?;
+        let mut branches = Vec::new();
+        include_branch_record(&self.conn, &mut branches, branch_num)?;
+
+        let mut referenced_tx_ids = reads
+            .iter()
+            .filter_map(|read| read.observed_tx_id.as_deref())
+            .collect::<BTreeSet<_>>();
+        referenced_tx_ids.remove(upload_tx.tx_id.as_str());
+        let mut txs = export_txs_by_ids(&self.conn, referenced_tx_ids)?;
+        txs.push(TxRecord {
+            tx_id: upload_tx.tx_id.clone(),
+            node_id: connection_node_id.to_owned(),
+            local_epoch: upload_tx_local_epoch(connection_node_id, &upload_tx.tx_id)?,
+            global_epoch: None,
+            conflict_mode: tx_conflict_mode_to_storage(&upload_tx.conflict_mode),
+            outcome: tx::OUTCOME_PENDING,
+            auth_user: matches!(upload_tx.conflict_mode, TxConflictMode::Exclusive)
+                .then(|| connection_auth_user.to_owned()),
+            rejection_code: None,
+            rejection_detail: None,
+            receipt_tiers: Vec::new(),
+            created_at: upload_tx.created_at,
+        });
+
+        Ok(make_bundle(
+            &self.schema,
+            branches,
+            txs,
+            reads.to_vec(),
+            Vec::new(),
+            history,
+        ))
+    }
+
+    fn upload_tx_status(&self, tx_id: &str) -> Result<Option<TxStatusKind>> {
+        let Ok(info) = self.transaction_info(tx_id) else {
+            return Ok(None);
+        };
+        if let Some(code) = info.rejection_code {
+            return Ok(Some(TxStatusKind::Rejected {
+                code,
+                detail: info.rejection_detail,
+            }));
+        }
+        if let Some(global_epoch) = info.global_epoch {
+            return Ok(Some(TxStatusKind::GlobalAccepted { global_epoch }));
+        }
+        if info.receipt_tiers.iter().any(|tier| tier == "edge") {
+            return Ok(Some(TxStatusKind::EdgeAccepted));
+        }
+        Ok(None)
     }
 
     pub fn stage_exclusive_bundle_for_forwarding(&mut self, bundle: &Bundle) -> Result<()> {
@@ -2199,9 +2379,49 @@ impl Runtime {
     }
 
     pub fn accept_transaction_at_edge(&mut self, tx_id: &str) -> Result<()> {
-        let tx_num = tx::accept_edge(&self.conn, tx_id, now_ms())?;
+        self.accept_transaction_at_edge_observed(tx_id, now_ms())
+    }
+
+    fn accept_transaction_at_edge_observed(&mut self, tx_id: &str, observed_at: i64) -> Result<()> {
+        let tx_num = tx::accept_edge(&self.conn, tx_id, observed_at)?;
         clear_transaction_awaiting_dependency(&self.conn, tx_num)?;
         projection::rebuild(&self.conn, &self.schema, self.node_num)?;
+        Ok(())
+    }
+
+    pub fn apply_tx_status_for_test(
+        &mut self,
+        tx_id: &str,
+        status: crate::protocol::TxStatusKind,
+    ) -> Result<()> {
+        self.apply_tx_status(tx_id, status)
+    }
+
+    pub(crate) fn apply_tx_status(
+        &mut self,
+        tx_id: &str,
+        status: crate::protocol::TxStatusKind,
+    ) -> Result<()> {
+        if tx::tx_num(&self.conn, tx_id).is_err() {
+            return Ok(());
+        }
+        let completion = UploadCompletion::from(&status);
+        match status {
+            crate::protocol::TxStatusKind::EdgeAccepted => {
+                self.accept_transaction_at_edge(tx_id)?;
+            }
+            crate::protocol::TxStatusKind::GlobalAccepted { global_epoch } => {
+                self.accept_transaction_at_global(tx_id, global_epoch)?;
+            }
+            crate::protocol::TxStatusKind::Rejected { code, detail } => {
+                if let Some(detail) = detail {
+                    self.reject_transaction_with_detail(tx_id, &code, detail)?;
+                } else {
+                    self.reject_transaction(tx_id, &code)?;
+                }
+            }
+        }
+        self.complete_upload_for_status(tx_id, completion)?;
         Ok(())
     }
 
@@ -2485,6 +2705,249 @@ impl Runtime {
         }
     }
 
+    pub fn active_uploads_for_test(&self, limit: usize) -> Result<Vec<UploadQueueEntry>> {
+        self.active_uploads(limit, &BTreeSet::new())
+    }
+
+    pub fn upload_queue_counts_for_test(&self) -> Result<(usize, usize)> {
+        let queue_count =
+            self.conn
+                .query_row("SELECT COUNT(*) FROM jazz_tx_upload_queue", [], |row| {
+                    row.get::<_, i64>(0)
+                })?;
+        let data_count =
+            self.conn
+                .query_row("SELECT COUNT(*) FROM jazz_tx_upload_data", [], |row| {
+                    row.get::<_, i64>(0)
+                })?;
+        Ok((queue_count as usize, data_count as usize))
+    }
+
+    pub fn upload_ack_count_for_test(&self) -> Result<usize> {
+        let ack_count = self.conn.query_row(
+            "SELECT COUNT(*) FROM jazz_tx_upload_queue WHERE last_ack_at IS NOT NULL",
+            [],
+            |row| row.get::<_, i64>(0),
+        )?;
+        Ok(ack_count as usize)
+    }
+
+    pub fn row_id_exists_for_test(&self, row_id: &str) -> Result<bool> {
+        Ok(self
+            .conn
+            .query_row(
+                "SELECT 1 FROM jazz_row_id WHERE row_id = ?",
+                params![row_id],
+                |_| Ok(()),
+            )
+            .optional()?
+            .is_some())
+    }
+
+    pub fn cleanup_completed_uploads_for_test(
+        &mut self,
+        retention_ms: i64,
+        batch_size: usize,
+    ) -> Result<()> {
+        if batch_size == 0 {
+            return Ok(());
+        }
+
+        let cutoff = now_ms().saturating_sub(retention_ms.max(0));
+        let tx_nums = {
+            let mut stmt = self.conn.prepare(
+                "SELECT tx_num
+                 FROM jazz_tx_upload_queue
+                 WHERE status = ?
+                   AND completed_at IS NOT NULL
+                   AND completed_at <= ?
+                 ORDER BY completed_at, sync_seq
+                 LIMIT ?",
+            )?;
+            let rows = stmt.query_map(
+                params![UPLOAD_STATUS_COMPLETED, cutoff, batch_size as i64],
+                |row| row.get::<_, i64>(0),
+            )?;
+            rows.collect::<std::result::Result<Vec<_>, _>>()?
+        };
+
+        let db = self.conn.transaction()?;
+        for tx_num in tx_nums {
+            db.execute(
+                "DELETE FROM jazz_tx_upload_data WHERE tx_num = ?",
+                params![tx_num],
+            )?;
+            db.execute(
+                "DELETE FROM jazz_tx_upload_queue
+                 WHERE tx_num = ?
+                   AND status = ?",
+                params![tx_num, UPLOAD_STATUS_COMPLETED],
+            )?;
+        }
+        db.commit()?;
+        Ok(())
+    }
+
+    pub(crate) fn mark_upload_attempt(&mut self, tx_id: &str) -> Result<()> {
+        self.conn.execute(
+            "UPDATE jazz_tx_upload_queue
+             SET last_upload_attempt_at = ?,
+                 attempt_count = attempt_count + 1
+             WHERE tx_num = (
+                 SELECT tx_num
+                 FROM jazz_tx
+                 WHERE tx_id = ?
+             )
+               AND status = ?",
+            params![now_ms(), tx_id, UPLOAD_STATUS_ACTIVE],
+        )?;
+        Ok(())
+    }
+
+    pub(crate) fn mark_upload_ack(&mut self, tx_id: &str) -> Result<()> {
+        self.conn.execute(
+            "UPDATE jazz_tx_upload_queue
+             SET last_ack_at = ?
+             WHERE tx_num = (
+                 SELECT tx_num
+                 FROM jazz_tx
+                 WHERE tx_id = ?
+             )
+               AND status = ?",
+            params![now_ms(), tx_id, UPLOAD_STATUS_ACTIVE],
+        )?;
+        Ok(())
+    }
+
+    fn complete_upload_for_status(
+        &mut self,
+        tx_id: &str,
+        completion: UploadCompletion,
+    ) -> Result<()> {
+        let Some(fate) = self.upload_completion_fate(tx_id)? else {
+            return Ok(());
+        };
+        let satisfied = match completion {
+            UploadCompletion::EdgeAccepted => {
+                fate.conflict_mode == tx::MODE_MERGEABLE
+                    && (fate.has_edge_receipt || fate.has_global_receipt)
+            }
+            UploadCompletion::GlobalAccepted => fate.has_global_receipt,
+            UploadCompletion::Rejected => fate.rejected,
+        };
+        if satisfied {
+            self.conn.execute(
+                "UPDATE jazz_tx_upload_queue
+                 SET status = ?,
+                     completed_at = ?
+                 WHERE tx_num = ?
+                   AND status = ?",
+                params![
+                    UPLOAD_STATUS_COMPLETED,
+                    now_ms(),
+                    fate.tx_num,
+                    UPLOAD_STATUS_ACTIVE,
+                ],
+            )?;
+        }
+        Ok(())
+    }
+
+    fn upload_completion_fate(&self, tx_id: &str) -> Result<Option<UploadCompletionFate>> {
+        self.conn
+            .query_row(
+                "SELECT tx.tx_num,
+                        tx.conflict_mode,
+                        rejection.tx_num IS NOT NULL,
+                        EXISTS (
+                            SELECT 1
+                            FROM jazz_tx_receipt receipt
+                            WHERE receipt.tx_num = tx.tx_num
+                              AND receipt.tier = ?
+                        ),
+                        EXISTS (
+                            SELECT 1
+                            FROM jazz_tx_receipt receipt
+                            WHERE receipt.tx_num = tx.tx_num
+                              AND receipt.tier = ?
+                        )
+                FROM jazz_tx tx
+                LEFT JOIN jazz_tx_rejection rejection ON rejection.tx_num = tx.tx_num
+                WHERE tx.tx_id = ?",
+                params![tx::TIER_EDGE, tx::TIER_GLOBAL, tx_id],
+                |row| {
+                    Ok(UploadCompletionFate {
+                        tx_num: row.get(0)?,
+                        conflict_mode: row.get(1)?,
+                        rejected: row.get(2)?,
+                        has_edge_receipt: row.get(3)?,
+                        has_global_receipt: row.get(4)?,
+                    })
+                },
+            )
+            .optional()
+            .map_err(Into::into)
+    }
+
+    pub(crate) fn active_uploads(
+        &self,
+        limit: usize,
+        excluded_tx_ids: &BTreeSet<String>,
+    ) -> Result<Vec<UploadQueueEntry>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+
+        let mut stmt = self.conn.prepare(
+            "SELECT queue.tx_num, tx.tx_id, tx.conflict_mode, tx.created_at, queue.branch_id, queue.author
+             FROM jazz_tx_upload_queue queue
+             JOIN jazz_tx tx ON tx.tx_num = queue.tx_num
+             WHERE queue.status = ?
+               AND tx.outcome != ?
+             ORDER BY queue.created_at, queue.sync_seq
+             LIMIT ?",
+        )?;
+        let scan_limit = limit.saturating_add(excluded_tx_ids.len()).max(limit) as i64;
+        let rows = stmt.query_map(
+            params![UPLOAD_STATUS_ACTIVE, tx::OUTCOME_REJECTED, scan_limit],
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, Option<String>>(4)?,
+                    row.get::<_, Option<String>>(5)?,
+                ))
+            },
+        )?;
+
+        let mut entries = Vec::new();
+        for row in rows {
+            let (tx_num, tx_id, conflict_mode, created_at, branch_id, author) = row?;
+            if excluded_tx_ids.contains(&tx_id) {
+                continue;
+            }
+            let data = upload_data_records(&self.conn, tx_num)?;
+            entries.push(UploadQueueEntry {
+                tx: ClientTx {
+                    tx_id,
+                    branch_id,
+                    conflict_mode: tx_conflict_mode_from_storage(conflict_mode)?,
+                    created_at,
+                    author,
+                },
+                data,
+                reads: upload_read_records(&self.conn, tx_num)?,
+            });
+            if entries.len() >= limit {
+                break;
+            }
+        }
+
+        Ok(entries)
+    }
+
     pub fn delete_row(&mut self, table_name: &str, id: &str) -> Result<String> {
         let table = self.schema.table_def(table_name)?.clone();
         let visible_row = self
@@ -2494,6 +2957,12 @@ impl Runtime {
             .ok_or_else(|| crate::Error::new(format!("row {id} is not visible")))?;
         let user = self.attribution_user().to_owned();
         let bypass_policy = self.bypasses_policy();
+        let upload_records = vec![ClientDataRecord {
+            table: table_name.to_owned(),
+            row_id: id.to_owned(),
+            op: DataOp::Delete,
+            values: BTreeMap::new(),
+        }];
         let db = self.conn.transaction()?;
         let now = now_ms();
         let (tx_num, tx_id) = tx::create_tx(&db, self.node_num, &self.node_id, now)?;
@@ -2650,6 +3119,17 @@ impl Runtime {
         if !allowed {
             tx::reject(&db, &tx_id, "policy_denied")?;
             projection::rebuild(&db, &self.schema, self.node_num)?;
+        }
+        if allowed {
+            let branch_id = branch_id_for_num(&db, self.branch_num)?;
+            enqueue_upload_tx(
+                &db,
+                tx_num,
+                now,
+                Some(&branch_id),
+                Some(&user),
+                &upload_records,
+            )?;
         }
         db.commit()?;
         Ok(tx_id)
@@ -5273,6 +5753,270 @@ fn record_tx_write_num(
     Ok(())
 }
 
+fn enqueue_upload_tx(
+    conn: &Connection,
+    tx_num: i64,
+    created_at: i64,
+    branch_id: Option<&str>,
+    author: Option<&str>,
+    records: &[ClientDataRecord],
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO jazz_tx_upload_queue
+         (tx_num, status, created_at, branch_id, author, completed_at, last_upload_attempt_at, last_ack_at, attempt_count)
+         VALUES (?, ?, ?, ?, ?, NULL, NULL, NULL, 0)",
+        params![tx_num, UPLOAD_STATUS_ACTIVE, created_at, branch_id, author],
+    )?;
+    for (record_index, record) in records.iter().enumerate() {
+        let values_json = serde_json::to_string(&record.values)
+            .map_err(|err| crate::Error::new(format!("invalid upload values JSON: {err}")))?;
+        conn.execute(
+            "INSERT INTO jazz_tx_upload_data
+             (tx_num, record_index, table_name, row_id, op, values_json)
+             VALUES (?, ?, ?, ?, ?, ?)",
+            params![
+                tx_num,
+                record_index as i64,
+                &record.table,
+                &record.row_id,
+                data_op_to_storage(&record.op),
+                values_json
+            ],
+        )?;
+    }
+    Ok(())
+}
+
+fn data_op_to_storage(op: &DataOp) -> i64 {
+    match op {
+        DataOp::Insert => 1,
+        DataOp::Update => 2,
+        DataOp::Delete => 3,
+    }
+}
+
+fn tx_conflict_mode_to_storage(mode: &TxConflictMode) -> i64 {
+    match mode {
+        TxConflictMode::Mergeable => tx::MODE_MERGEABLE,
+        TxConflictMode::Exclusive => tx::MODE_EXCLUSIVE,
+    }
+}
+
+fn data_op_from_storage(op: i64) -> Result<DataOp> {
+    match op {
+        1 => Ok(DataOp::Insert),
+        2 => Ok(DataOp::Update),
+        3 => Ok(DataOp::Delete),
+        other => Err(crate::Error::new(format!("unsupported upload op {other}"))),
+    }
+}
+
+fn tx_conflict_mode_from_storage(mode: i64) -> Result<TxConflictMode> {
+    match mode {
+        tx::MODE_MERGEABLE => Ok(TxConflictMode::Mergeable),
+        tx::MODE_EXCLUSIVE => Ok(TxConflictMode::Exclusive),
+        other => Err(crate::Error::new(format!(
+            "unsupported tx conflict mode {other}"
+        ))),
+    }
+}
+
+fn upload_data_records(conn: &Connection, tx_num: i64) -> Result<Vec<ClientDataRecord>> {
+    let mut stmt = conn.prepare(
+        "SELECT table_name, row_id, op, values_json
+         FROM jazz_tx_upload_data
+         WHERE tx_num = ?
+         ORDER BY record_index",
+    )?;
+    let rows = stmt.query_map(params![tx_num], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, i64>(2)?,
+            row.get::<_, String>(3)?,
+        ))
+    })?;
+
+    let mut records = Vec::new();
+    for row in rows {
+        let (table, row_id, op, values_json) = row?;
+        records.push(ClientDataRecord {
+            table,
+            row_id,
+            op: data_op_from_storage(op)?,
+            values: serde_json::from_str::<BTreeMap<String, JsonValue>>(&values_json)
+                .map_err(|err| crate::Error::new(format!("invalid upload values JSON: {err}")))?,
+        });
+    }
+    Ok(records)
+}
+
+fn upload_read_records(conn: &Connection, tx_num: i64) -> Result<Vec<ReadRecord>> {
+    let mut stmt = conn.prepare(
+        "SELECT tx.tx_id, tables.table_name, ids.row_id, reads.reason, observed.tx_id
+         FROM jazz_tx_read reads
+         JOIN jazz_tx tx ON tx.tx_num = reads.tx_num
+         JOIN jazz_table tables ON tables.table_num = reads.table_num
+         JOIN jazz_row_id ids ON ids.row_num = reads.row_num
+         LEFT JOIN jazz_tx observed ON observed.tx_num = reads.observed_tx_num
+         WHERE reads.tx_num = ?
+         ORDER BY tables.table_name, ids.row_id, reads.reason",
+    )?;
+    let rows = stmt.query_map(params![tx_num], |row| {
+        Ok(ReadRecord {
+            tx_id: row.get(0)?,
+            table: row.get(1)?,
+            row_id: row.get(2)?,
+            reason: row.get(3)?,
+            observed_tx_id: row.get(4)?,
+        })
+    })?;
+    rows.collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(Into::into)
+}
+
+fn upload_history_records(
+    conn: &Connection,
+    schema: &SchemaDef,
+    tx_record: &ClientTx,
+    data: &[ClientDataRecord],
+    branch_id: &str,
+    branch_num: i64,
+    connection_auth_user: &str,
+) -> Result<Vec<HistoryRecord>> {
+    let mut seen_rows = BTreeSet::new();
+    let mut records = Vec::new();
+    for record in data {
+        if !seen_rows.insert((record.table.as_str(), record.row_id.as_str())) {
+            return Err(crate::Error::new(format!(
+                "duplicate upload record {}:{}",
+                record.table, record.row_id
+            )));
+        }
+        let table = schema.table_def(&record.table)?;
+        if matches!(record.op, DataOp::Delete) && !record.values.is_empty() {
+            return Err(crate::Error::new("delete upload values must be empty"));
+        }
+        if record
+            .values
+            .keys()
+            .any(|field_name| field_name.starts_with("j_"))
+        {
+            return Err(crate::Error::new(
+                "upload data cannot include system fields",
+            ));
+        }
+        validate_write_fields(table, &record.values)?;
+        let row_num = if matches!(record.op, DataOp::Insert) {
+            let existing_row_num = existing_row_num(conn, &record.row_id)?;
+            if let Some(row_num) = existing_row_num {
+                if row_has_current_branch_value(conn, &record.table, row_num, branch_num)? {
+                    return Err(crate::Error::new(format!(
+                        "row id {} already exists in table {}",
+                        record.row_id, record.table
+                    )));
+                }
+            }
+            existing_row_num.unwrap_or(0)
+        } else {
+            row_num(conn, &record.row_id)?
+        };
+        let values = effective_write_values(EffectiveWriteValues {
+            db: conn,
+            schema,
+            table_name: &record.table,
+            id: &record.row_id,
+            row_num,
+            branch_num,
+            patch_values: &record.values,
+            op: data_op_to_storage(&record.op),
+        })?;
+        let (created_at, created_by) = if matches!(record.op, DataOp::Insert) {
+            (tx_record.created_at, connection_auth_user.to_owned())
+        } else {
+            current_creation_metadata(conn, &record.table, row_num, branch_num)?
+                .unwrap_or((tx_record.created_at, connection_auth_user.to_owned()))
+        };
+        records.push(HistoryRecord {
+            table: record.table.clone(),
+            row_id: record.row_id.clone(),
+            branch_id: branch_id.to_owned(),
+            tx_id: tx_record.tx_id.clone(),
+            op: data_op_to_storage(&record.op),
+            values,
+            created_at,
+            updated_at: tx_record.created_at,
+            created_by,
+            updated_by: connection_auth_user.to_owned(),
+        });
+    }
+    Ok(records)
+}
+
+fn existing_row_num(conn: &Connection, row_id: &str) -> Result<Option<i64>> {
+    conn.query_row(
+        "SELECT row_num FROM jazz_row_id WHERE row_id = ?",
+        params![row_id],
+        |row| row.get(0),
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+fn validate_exclusive_upload_reads(data: &[ClientDataRecord], reads: &[ReadRecord]) -> Result<()> {
+    if reads.is_empty() {
+        return Err(crate::Error::new("exclusive upload requires a read set"));
+    }
+    for record in data {
+        let Some(read) = reads
+            .iter()
+            .find(|read| read.table == record.table && read.row_id == record.row_id)
+        else {
+            return Err(crate::Error::new(format!(
+                "exclusive upload is missing write read for {}:{}",
+                record.table, record.row_id
+            )));
+        };
+        match record.op {
+            DataOp::Insert => {
+                if read.reason != read_set::REASON_ABSENT || read.observed_tx_id.is_some() {
+                    return Err(crate::Error::new(format!(
+                        "exclusive insert upload has invalid write read for {}:{}",
+                        record.table, record.row_id
+                    )));
+                }
+            }
+            DataOp::Update | DataOp::Delete => {
+                if read.reason == read_set::REASON_ABSENT || read.observed_tx_id.is_none() {
+                    return Err(crate::Error::new(format!(
+                        "exclusive update/delete upload has invalid write read for {}:{}",
+                        record.table, record.row_id
+                    )));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn upload_tx_local_epoch(node_id: &str, tx_id: &str) -> Result<i64> {
+    let prefix = format!("tx-{node_id}-");
+    let epoch_text = tx_id.strip_prefix(&prefix).ok_or_else(|| {
+        crate::Error::new(format!(
+            "upload transaction id {tx_id} does not belong to node {node_id}"
+        ))
+    })?;
+    let epoch = epoch_text
+        .parse::<i64>()
+        .map_err(|_| crate::Error::new(format!("invalid upload transaction id {tx_id}")))?;
+    if epoch <= 0 {
+        return Err(crate::Error::new(format!(
+            "invalid upload transaction id {tx_id}"
+        )));
+    }
+    Ok(epoch)
+}
+
 pub struct TransactionBuilder<'a> {
     runtime: &'a mut Runtime,
     mutations: Vec<Mutation>,
@@ -5416,6 +6160,28 @@ impl<'a> TransactionBuilder<'a> {
         if mutations.is_empty() {
             return Ok(String::new());
         }
+        let upload_records = mutations
+            .iter()
+            .map(|mutation| match mutation {
+                Mutation::Row {
+                    table,
+                    id,
+                    values,
+                    op,
+                } => Ok(ClientDataRecord {
+                    table: table.clone(),
+                    row_id: id.clone(),
+                    op: data_op_from_storage(*op)?,
+                    values: values.clone(),
+                }),
+                Mutation::DeleteRow { table, id } => Ok(ClientDataRecord {
+                    table: table.clone(),
+                    row_id: id.clone(),
+                    op: DataOp::Delete,
+                    values: BTreeMap::new(),
+                }),
+            })
+            .collect::<Result<Vec<_>>>()?;
         let user = self.runtime.attribution_user().to_owned();
         let bypass_policy = self.runtime.bypasses_policy();
         let mut delete_snapshots = BTreeMap::new();
@@ -5659,6 +6425,17 @@ impl<'a> TransactionBuilder<'a> {
         if !allowed {
             tx::reject(&db, &tx_id, "policy_denied")?;
             projection::rebuild(&db, &self.runtime.schema, self.runtime.node_num)?;
+        }
+        if allowed {
+            let branch_id = branch_id_for_num(&db, self.runtime.branch_num)?;
+            enqueue_upload_tx(
+                &db,
+                tx_num,
+                now,
+                Some(&branch_id),
+                Some(&user),
+                &upload_records,
+            )?;
         }
         db.commit()?;
         Ok(tx_id)

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -1,7 +1,9 @@
 use crate::protocol::{ClientDataRecord, ClientTx, DataOp, TxConflictMode, TxStatusKind};
 use crate::query_api::{predicate_query, BuiltQuery, QueryCondition, QueryConditionOp};
 use crate::read_visibility::ReadVisibility;
-use crate::rows::{ensure_row_id, ensure_row_id_with_status, public_row_id, row_num};
+use crate::rows::{
+    ensure_row_id, ensure_row_id_with_status, existing_row_num, public_row_id, row_num,
+};
 use crate::schema::{FieldDef, FieldKind, PolicyDef, SchemaDef};
 use crate::subscription::{RejectionSubscription, RowsSubscription, RowsSubscriptionQuery};
 use crate::sync::{
@@ -434,15 +436,7 @@ impl Runtime {
             )?;
         }
         if allowed {
-            let branch_id = branch_id_for_num(&db, self.branch_num)?;
-            enqueue_upload_tx(
-                &db,
-                tx_num,
-                now,
-                Some(&branch_id),
-                Some(&user),
-                &upload_records,
-            )?;
+            enqueue_upload_tx(&db, tx_num, now, self.branch_num, &user, &upload_records)?;
         }
         db.commit()?;
         Ok(tx_id)
@@ -969,6 +963,30 @@ impl Runtime {
         }
         let query_scope_repair_ms = query_scope_repair_started.elapsed_ms();
 
+        for tx_record in &bundle.txs {
+            if tx_record.outcome == tx::OUTCOME_REJECTED {
+                Self::complete_upload_for_status(
+                    &db,
+                    &tx_record.tx_id,
+                    UploadCompletion::Rejected,
+                )?;
+            } else if tx_record.global_epoch.is_some()
+                || tx_record.receipt_tiers.contains(&tx::TIER_GLOBAL)
+            {
+                Self::complete_upload_for_status(
+                    &db,
+                    &tx_record.tx_id,
+                    UploadCompletion::GlobalAccepted,
+                )?;
+            } else if tx_record.receipt_tiers.contains(&tx::TIER_EDGE) {
+                Self::complete_upload_for_status(
+                    &db,
+                    &tx_record.tx_id,
+                    UploadCompletion::EdgeAccepted,
+                )?;
+            }
+        }
+
         let commit_started = ProfileTimer::start();
         db.commit()?;
         let commit_ms = commit_started.elapsed_ms();
@@ -1256,13 +1274,16 @@ impl Runtime {
             return self.upload_tx_status(&upload_tx.tx_id);
         }
 
-        let bundle = self.upload_tx_bundle(
+        let Some(bundle) = self.upload_tx_bundle(
             upload_tx,
             data,
             reads,
             connection_node_id,
             connection_auth_user,
-        )?;
+        )?
+        else {
+            return Ok(None);
+        };
         self.apply_untrusted_bundle_as_user(&bundle, connection_auth_user)?;
 
         if let Some(status) = self.upload_tx_status(&upload_tx.tx_id)? {
@@ -1289,7 +1310,7 @@ impl Runtime {
         reads: &[ReadRecord],
         connection_node_id: &str,
         connection_auth_user: &str,
-    ) -> Result<Bundle> {
+    ) -> Result<Option<Bundle>> {
         if data.is_empty() {
             return Err(crate::Error::new("upload transaction contains no data"));
         }
@@ -1309,6 +1330,10 @@ impl Runtime {
             .clone()
             .unwrap_or_else(|| "main".to_owned());
         let branch_num = branch::checkout(&self.conn, &branch_id)?;
+        if upload_waits_for_missing_current_dependency(&self.conn, &self.schema, data, branch_num)?
+        {
+            return Ok(None);
+        }
         let history = upload_history_records(
             &self.conn,
             &self.schema,
@@ -1342,14 +1367,14 @@ impl Runtime {
             created_at: upload_tx.created_at,
         });
 
-        Ok(make_bundle(
+        Ok(Some(make_bundle(
             &self.schema,
             branches,
             txs,
             reads.to_vec(),
             Vec::new(),
             history,
-        ))
+        )))
     }
 
     fn upload_tx_status(&self, tx_id: &str) -> Result<Option<TxStatusKind>> {
@@ -1511,6 +1536,11 @@ impl Runtime {
             if !rejected.contains(&tx_id) && tx_outcome(&self.conn, tx_num)? == tx::OUTCOME_PENDING
             {
                 tx::accept_global(&self.conn, &tx_id, next_global_epoch(&self.conn)?)?;
+                Self::complete_upload_for_status(
+                    &self.conn,
+                    &tx_id,
+                    UploadCompletion::GlobalAccepted,
+                )?;
                 accepted_exclusive = true;
             }
         }
@@ -1572,6 +1602,11 @@ impl Runtime {
                     &serde_json::to_string(&detail)
                         .map_err(|err| crate::Error::new(err.to_string()))?,
                 )?;
+                Self::complete_upload_for_status(
+                    &self.conn,
+                    &awaiting.tx_id,
+                    UploadCompletion::Rejected,
+                )?;
                 changed = true;
             } else if let Some(detail) = still_waiting {
                 mark_transaction_awaiting_dependency(
@@ -1584,6 +1619,11 @@ impl Runtime {
                 clear_transaction_awaiting_dependency(&self.conn, awaiting.tx_num)?;
                 if tx_conflict_mode(&self.conn, awaiting.tx_num)? == tx::MODE_MERGEABLE {
                     tx::accept_edge(&self.conn, &awaiting.tx_id, now_ms())?;
+                    Self::complete_upload_for_status(
+                        &self.conn,
+                        &awaiting.tx_id,
+                        UploadCompletion::EdgeAccepted,
+                    )?;
                 }
                 changed = true;
             }
@@ -2357,6 +2397,7 @@ impl Runtime {
         let db = self.conn.transaction()?;
         let tx_num = tx::reject_with_detail_json(&db, tx_id, code, &detail_json)?;
         clear_transaction_awaiting_dependency(&db, tx_num)?;
+        Self::complete_upload_for_status(&db, tx_id, UploadCompletion::Rejected)?;
         for table in self.schema.tables() {
             db.execute(
                 &format!(
@@ -2374,6 +2415,7 @@ impl Runtime {
     pub fn accept_transaction_at_global(&mut self, tx_id: &str, global_epoch: i64) -> Result<()> {
         let tx_num = tx::accept_global(&self.conn, tx_id, global_epoch)?;
         clear_transaction_awaiting_dependency(&self.conn, tx_num)?;
+        Self::complete_upload_for_status(&self.conn, tx_id, UploadCompletion::GlobalAccepted)?;
         projection::rebuild(&self.conn, &self.schema, self.node_num)?;
         Ok(())
     }
@@ -2385,6 +2427,7 @@ impl Runtime {
     fn accept_transaction_at_edge_observed(&mut self, tx_id: &str, observed_at: i64) -> Result<()> {
         let tx_num = tx::accept_edge(&self.conn, tx_id, observed_at)?;
         clear_transaction_awaiting_dependency(&self.conn, tx_num)?;
+        Self::complete_upload_for_status(&self.conn, tx_id, UploadCompletion::EdgeAccepted)?;
         projection::rebuild(&self.conn, &self.schema, self.node_num)?;
         Ok(())
     }
@@ -2405,7 +2448,6 @@ impl Runtime {
         if tx::tx_num(&self.conn, tx_id).is_err() {
             return Ok(());
         }
-        let completion = UploadCompletion::from(&status);
         match status {
             crate::protocol::TxStatusKind::EdgeAccepted => {
                 self.accept_transaction_at_edge(tx_id)?;
@@ -2421,7 +2463,6 @@ impl Runtime {
                 }
             }
         }
-        self.complete_upload_for_status(tx_id, completion)?;
         Ok(())
     }
 
@@ -2820,11 +2861,11 @@ impl Runtime {
     }
 
     fn complete_upload_for_status(
-        &mut self,
+        conn: &Connection,
         tx_id: &str,
         completion: UploadCompletion,
     ) -> Result<()> {
-        let Some(fate) = self.upload_completion_fate(tx_id)? else {
+        let Some(fate) = Self::upload_completion_fate(conn, tx_id)? else {
             return Ok(());
         };
         let satisfied = match completion {
@@ -2836,7 +2877,7 @@ impl Runtime {
             UploadCompletion::Rejected => fate.rejected,
         };
         if satisfied {
-            self.conn.execute(
+            conn.execute(
                 "UPDATE jazz_tx_upload_queue
                  SET status = ?,
                      completed_at = ?
@@ -2853,10 +2894,12 @@ impl Runtime {
         Ok(())
     }
 
-    fn upload_completion_fate(&self, tx_id: &str) -> Result<Option<UploadCompletionFate>> {
-        self.conn
-            .query_row(
-                "SELECT tx.tx_num,
+    fn upload_completion_fate(
+        conn: &Connection,
+        tx_id: &str,
+    ) -> Result<Option<UploadCompletionFate>> {
+        conn.query_row(
+            "SELECT tx.tx_num,
                         tx.conflict_mode,
                         rejection.tx_num IS NOT NULL,
                         EXISTS (
@@ -2874,19 +2917,19 @@ impl Runtime {
                 FROM jazz_tx tx
                 LEFT JOIN jazz_tx_rejection rejection ON rejection.tx_num = tx.tx_num
                 WHERE tx.tx_id = ?",
-                params![tx::TIER_EDGE, tx::TIER_GLOBAL, tx_id],
-                |row| {
-                    Ok(UploadCompletionFate {
-                        tx_num: row.get(0)?,
-                        conflict_mode: row.get(1)?,
-                        rejected: row.get(2)?,
-                        has_edge_receipt: row.get(3)?,
-                        has_global_receipt: row.get(4)?,
-                    })
-                },
-            )
-            .optional()
-            .map_err(Into::into)
+            params![tx::TIER_EDGE, tx::TIER_GLOBAL, tx_id],
+            |row| {
+                Ok(UploadCompletionFate {
+                    tx_num: row.get(0)?,
+                    conflict_mode: row.get(1)?,
+                    rejected: row.get(2)?,
+                    has_edge_receipt: row.get(3)?,
+                    has_global_receipt: row.get(4)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(Into::into)
     }
 
     pub(crate) fn active_uploads(
@@ -2907,7 +2950,7 @@ impl Runtime {
              ORDER BY queue.created_at, queue.sync_seq
              LIMIT ?",
         )?;
-        let scan_limit = limit.saturating_add(excluded_tx_ids.len()).max(limit) as i64;
+        let scan_limit = limit.saturating_add(excluded_tx_ids.len()) as i64;
         let rows = stmt.query_map(
             params![UPLOAD_STATUS_ACTIVE, tx::OUTCOME_REJECTED, scan_limit],
             |row| {
@@ -3121,15 +3164,7 @@ impl Runtime {
             projection::rebuild(&db, &self.schema, self.node_num)?;
         }
         if allowed {
-            let branch_id = branch_id_for_num(&db, self.branch_num)?;
-            enqueue_upload_tx(
-                &db,
-                tx_num,
-                now,
-                Some(&branch_id),
-                Some(&user),
-                &upload_records,
-            )?;
+            enqueue_upload_tx(&db, tx_num, now, self.branch_num, &user, &upload_records)?;
         }
         db.commit()?;
         Ok(tx_id)
@@ -5757,14 +5792,15 @@ fn enqueue_upload_tx(
     conn: &Connection,
     tx_num: i64,
     created_at: i64,
-    branch_id: Option<&str>,
-    author: Option<&str>,
+    branch_num: i64,
+    author: &str,
     records: &[ClientDataRecord],
 ) -> Result<()> {
+    let branch_id = branch_id_for_num(conn, branch_num)?;
     conn.execute(
         "INSERT INTO jazz_tx_upload_queue
-         (tx_num, status, created_at, branch_id, author, completed_at, last_upload_attempt_at, last_ack_at, attempt_count)
-         VALUES (?, ?, ?, ?, ?, NULL, NULL, NULL, 0)",
+         (tx_num, status, created_at, branch_id, author)
+         VALUES (?, ?, ?, ?, ?)",
         params![tx_num, UPLOAD_STATUS_ACTIVE, created_at, branch_id, author],
     )?;
     for (record_index, record) in records.iter().enumerate() {
@@ -5875,6 +5911,46 @@ fn upload_read_records(conn: &Connection, tx_num: i64) -> Result<Vec<ReadRecord>
         .map_err(Into::into)
 }
 
+fn upload_waits_for_missing_current_dependency(
+    conn: &Connection,
+    schema: &SchemaDef,
+    data: &[ClientDataRecord],
+    branch_num: i64,
+) -> Result<bool> {
+    let mut seen_rows = BTreeSet::new();
+    for record in data {
+        if !seen_rows.insert((record.table.as_str(), record.row_id.as_str())) {
+            return Err(crate::Error::new(format!(
+                "duplicate upload record {}:{}",
+                record.table, record.row_id
+            )));
+        }
+        let table = schema.table_def(&record.table)?;
+        if matches!(record.op, DataOp::Delete) && !record.values.is_empty() {
+            return Err(crate::Error::new("delete upload values must be empty"));
+        }
+        if record
+            .values
+            .keys()
+            .any(|field_name| field_name.starts_with("j_"))
+        {
+            return Err(crate::Error::new(
+                "upload data cannot include system fields",
+            ));
+        }
+        validate_write_fields(table, &record.values)?;
+        if !matches!(record.op, DataOp::Insert) {
+            let Some(row_num) = existing_row_num(conn, &record.row_id)? else {
+                return Ok(true);
+            };
+            if effective::row_values(conn, schema, &record.table, row_num, branch_num)?.is_none() {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
+}
+
 fn upload_history_records(
     conn: &Connection,
     schema: &SchemaDef,
@@ -5951,16 +6027,6 @@ fn upload_history_records(
         });
     }
     Ok(records)
-}
-
-fn existing_row_num(conn: &Connection, row_id: &str) -> Result<Option<i64>> {
-    conn.query_row(
-        "SELECT row_num FROM jazz_row_id WHERE row_id = ?",
-        params![row_id],
-        |row| row.get(0),
-    )
-    .optional()
-    .map_err(Into::into)
 }
 
 fn validate_exclusive_upload_reads(data: &[ClientDataRecord], reads: &[ReadRecord]) -> Result<()> {
@@ -6427,13 +6493,12 @@ impl<'a> TransactionBuilder<'a> {
             projection::rebuild(&db, &self.runtime.schema, self.runtime.node_num)?;
         }
         if allowed {
-            let branch_id = branch_id_for_num(&db, self.runtime.branch_num)?;
             enqueue_upload_tx(
                 &db,
                 tx_num,
                 now,
-                Some(&branch_id),
-                Some(&user),
+                self.runtime.branch_num,
+                &user,
                 &upload_records,
             )?;
         }

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -788,7 +788,8 @@ impl Runtime {
         let mut tx_info_by_num = BTreeMap::new();
         for tx_record in &bundle.txs {
             let node_num = tx::ensure_node(&db, &tx_record.node_id)?;
-            let metadata_json = tx_metadata_json(tx_record.auth_user.as_deref())?;
+            let metadata_json =
+                tx_metadata_json(tx_record.auth_user.as_deref(), tx_record.server_ingested_at)?;
             db.execute(
                 "INSERT INTO jazz_tx
                  (tx_id, node_num, local_epoch, global_epoch, kind, conflict_mode, outcome, created_at, metadata_json)
@@ -1365,6 +1366,7 @@ impl Runtime {
             rejection_detail: None,
             receipt_tiers: Vec::new(),
             created_at: upload_tx.created_at,
+            server_ingested_at: Some(now_ms()),
         });
 
         Ok(Some(make_bundle(
@@ -6721,6 +6723,7 @@ fn export_txs(conn: &Connection) -> Result<Vec<TxRecord>> {
     )?;
     let records = stmt.query_map([], |row| {
         let tx_id = row.get::<_, String>(0)?;
+        let metadata_json = row.get::<_, String>(9)?;
         let mut receipt_stmt = conn.prepare(
             "SELECT receipt.tier
              FROM jazz_tx_receipt receipt
@@ -6738,7 +6741,7 @@ fn export_txs(conn: &Connection) -> Result<Vec<TxRecord>> {
             global_epoch: row.get(3)?,
             conflict_mode: row.get(4)?,
             outcome: row.get(5)?,
-            auth_user: parse_tx_auth_user_for_sqlite(&row.get::<_, String>(9)?, 9)?,
+            auth_user: parse_tx_auth_user_for_sqlite(&metadata_json, 9)?,
             rejection_code: row.get(6)?,
             rejection_detail: row
                 .get::<_, Option<String>>(7)?
@@ -6747,6 +6750,7 @@ fn export_txs(conn: &Connection) -> Result<Vec<TxRecord>> {
                 .flatten(),
             receipt_tiers,
             created_at: row.get(8)?,
+            server_ingested_at: parse_tx_server_ingested_at_for_sqlite(&metadata_json, 9)?,
         })
     })?;
     records
@@ -6807,6 +6811,7 @@ fn export_txs_by_ids(conn: &Connection, tx_ids: BTreeSet<&str>) -> Result<Vec<Tx
     )?;
     let records = stmt.query_map([], |row| {
         let tx_id = row.get::<_, String>(0)?;
+        let metadata_json = row.get::<_, String>(9)?;
         let receipt_tiers = receipt_tiers_by_tx.get(&tx_id).cloned().unwrap_or_default();
         Ok(TxRecord {
             tx_id,
@@ -6815,7 +6820,7 @@ fn export_txs_by_ids(conn: &Connection, tx_ids: BTreeSet<&str>) -> Result<Vec<Tx
             global_epoch: row.get(3)?,
             conflict_mode: row.get(4)?,
             outcome: row.get(5)?,
-            auth_user: parse_tx_auth_user_for_sqlite(&row.get::<_, String>(9)?, 9)?,
+            auth_user: parse_tx_auth_user_for_sqlite(&metadata_json, 9)?,
             rejection_code: row.get(6)?,
             rejection_detail: row
                 .get::<_, Option<String>>(7)?
@@ -6824,6 +6829,7 @@ fn export_txs_by_ids(conn: &Connection, tx_ids: BTreeSet<&str>) -> Result<Vec<Tx
                 .flatten(),
             receipt_tiers,
             created_at: row.get(8)?,
+            server_ingested_at: parse_tx_server_ingested_at_for_sqlite(&metadata_json, 9)?,
         })
     })?;
     let mut tx_records = Vec::new();
@@ -6846,11 +6852,14 @@ fn parse_rejection_detail(detail_json: &str) -> Result<Option<JsonValue>> {
     }
 }
 
-fn tx_metadata_json(auth_user: Option<&str>) -> Result<String> {
-    let metadata = match auth_user {
-        Some(user) => json!({ "auth_user": user }),
-        None => json!({}),
-    };
+fn tx_metadata_json(auth_user: Option<&str>, server_ingested_at: Option<i64>) -> Result<String> {
+    let mut metadata = serde_json::Map::new();
+    if let Some(user) = auth_user {
+        metadata.insert("auth_user".to_owned(), json!(user));
+    }
+    if let Some(server_ingested_at) = server_ingested_at {
+        metadata.insert("server_ingested_at".to_owned(), json!(server_ingested_at));
+    }
     serde_json::to_string(&metadata).map_err(|err| crate::Error::new(err.to_string()))
 }
 
@@ -6869,6 +6878,22 @@ fn parse_tx_auth_user_for_sqlite(
         .get("auth_user")
         .and_then(JsonValue::as_str)
         .map(str::to_owned))
+}
+
+fn parse_tx_server_ingested_at_for_sqlite(
+    metadata_json: &str,
+    column: usize,
+) -> rusqlite::Result<Option<i64>> {
+    let metadata = serde_json::from_str::<JsonValue>(metadata_json).map_err(|err| {
+        rusqlite::Error::FromSqlConversionFailure(
+            column,
+            rusqlite::types::Type::Text,
+            Box::new(err),
+        )
+    })?;
+    Ok(metadata
+        .get("server_ingested_at")
+        .and_then(JsonValue::as_i64))
 }
 
 fn parse_rejection_detail_for_sqlite(

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -788,8 +788,7 @@ impl Runtime {
         let mut tx_info_by_num = BTreeMap::new();
         for tx_record in &bundle.txs {
             let node_num = tx::ensure_node(&db, &tx_record.node_id)?;
-            let metadata_json =
-                tx_metadata_json(tx_record.auth_user.as_deref(), tx_record.server_ingested_at)?;
+            let metadata_json = tx_metadata_json(tx_record.auth_user.as_deref())?;
             db.execute(
                 "INSERT INTO jazz_tx
                  (tx_id, node_num, local_epoch, global_epoch, kind, conflict_mode, outcome, created_at, metadata_json)
@@ -1366,7 +1365,6 @@ impl Runtime {
             rejection_detail: None,
             receipt_tiers: Vec::new(),
             created_at: upload_tx.created_at,
-            server_ingested_at: Some(now_ms()),
         });
 
         Ok(Some(make_bundle(
@@ -6750,7 +6748,6 @@ fn export_txs(conn: &Connection) -> Result<Vec<TxRecord>> {
                 .flatten(),
             receipt_tiers,
             created_at: row.get(8)?,
-            server_ingested_at: parse_tx_server_ingested_at_for_sqlite(&metadata_json, 9)?,
         })
     })?;
     records
@@ -6829,7 +6826,6 @@ fn export_txs_by_ids(conn: &Connection, tx_ids: BTreeSet<&str>) -> Result<Vec<Tx
                 .flatten(),
             receipt_tiers,
             created_at: row.get(8)?,
-            server_ingested_at: parse_tx_server_ingested_at_for_sqlite(&metadata_json, 9)?,
         })
     })?;
     let mut tx_records = Vec::new();
@@ -6852,13 +6848,10 @@ fn parse_rejection_detail(detail_json: &str) -> Result<Option<JsonValue>> {
     }
 }
 
-fn tx_metadata_json(auth_user: Option<&str>, server_ingested_at: Option<i64>) -> Result<String> {
+fn tx_metadata_json(auth_user: Option<&str>) -> Result<String> {
     let mut metadata = serde_json::Map::new();
     if let Some(user) = auth_user {
         metadata.insert("auth_user".to_owned(), json!(user));
-    }
-    if let Some(server_ingested_at) = server_ingested_at {
-        metadata.insert("server_ingested_at".to_owned(), json!(server_ingested_at));
     }
     serde_json::to_string(&metadata).map_err(|err| crate::Error::new(err.to_string()))
 }
@@ -6878,22 +6871,6 @@ fn parse_tx_auth_user_for_sqlite(
         .get("auth_user")
         .and_then(JsonValue::as_str)
         .map(str::to_owned))
-}
-
-fn parse_tx_server_ingested_at_for_sqlite(
-    metadata_json: &str,
-    column: usize,
-) -> rusqlite::Result<Option<i64>> {
-    let metadata = serde_json::from_str::<JsonValue>(metadata_json).map_err(|err| {
-        rusqlite::Error::FromSqlConversionFailure(
-            column,
-            rusqlite::types::Type::Text,
-            Box::new(err),
-        )
-    })?;
-    Ok(metadata
-        .get("server_ingested_at")
-        .and_then(JsonValue::as_i64))
 }
 
 fn parse_rejection_detail_for_sqlite(

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -1269,7 +1269,6 @@ impl Runtime {
         connection_node_id: &str,
         connection_auth_user: &str,
     ) -> Result<Option<TxStatusKind>> {
-        upload_tx_local_epoch(connection_node_id, &upload_tx.tx_id)?;
         if tx::tx_num(&self.conn, &upload_tx.tx_id).is_ok() {
             return self.upload_tx_status(&upload_tx.tx_id);
         }
@@ -1355,7 +1354,7 @@ impl Runtime {
         txs.push(TxRecord {
             tx_id: upload_tx.tx_id.clone(),
             node_id: connection_node_id.to_owned(),
-            local_epoch: upload_tx_local_epoch(connection_node_id, &upload_tx.tx_id)?,
+            local_epoch: next_uploaded_tx_local_epoch(&self.conn, connection_node_id)?,
             global_epoch: None,
             conflict_mode: tx_conflict_mode_to_storage(&upload_tx.conflict_mode),
             outcome: tx::OUTCOME_PENDING,
@@ -2433,6 +2432,14 @@ impl Runtime {
     }
 
     pub fn apply_tx_status_for_test(
+        &mut self,
+        tx_id: &str,
+        status: crate::protocol::TxStatusKind,
+    ) -> Result<()> {
+        self.apply_tx_status(tx_id, status)
+    }
+
+    pub fn apply_tx_status_from_server(
         &mut self,
         tx_id: &str,
         status: crate::protocol::TxStatusKind,
@@ -6065,22 +6072,15 @@ fn validate_exclusive_upload_reads(data: &[ClientDataRecord], reads: &[ReadRecor
     Ok(())
 }
 
-fn upload_tx_local_epoch(node_id: &str, tx_id: &str) -> Result<i64> {
-    let prefix = format!("tx-{node_id}-");
-    let epoch_text = tx_id.strip_prefix(&prefix).ok_or_else(|| {
-        crate::Error::new(format!(
-            "upload transaction id {tx_id} does not belong to node {node_id}"
-        ))
-    })?;
-    let epoch = epoch_text
-        .parse::<i64>()
-        .map_err(|_| crate::Error::new(format!("invalid upload transaction id {tx_id}")))?;
-    if epoch <= 0 {
-        return Err(crate::Error::new(format!(
-            "invalid upload transaction id {tx_id}"
-        )));
-    }
-    Ok(epoch)
+fn next_uploaded_tx_local_epoch(conn: &Connection, node_id: &str) -> Result<i64> {
+    let node_num = tx::ensure_node(conn, node_id)?;
+    Ok(conn
+        .query_row(
+            "SELECT COALESCE(MAX(local_epoch), 0) + 1 FROM jazz_tx WHERE node_num = ?",
+            params![node_num],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap_or(1))
 }
 
 pub struct TransactionBuilder<'a> {

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -402,12 +402,6 @@ impl Runtime {
         let table = self.schema.table_def(table_name)?.clone();
         let user = self.attribution_user().to_owned();
         let bypass_policy = self.bypasses_policy();
-        let upload_records = vec![ClientDataRecord {
-            table: table_name.to_owned(),
-            row_id: id.to_owned(),
-            op: data_op_from_storage(op)?,
-            values: values.clone(),
-        }];
         let db = self.conn.transaction()?;
         let now = now_ms();
         let (tx_num, tx_id) = tx::create_tx(&db, self.node_num, &self.node_id, now)?;
@@ -436,7 +430,7 @@ impl Runtime {
             )?;
         }
         if allowed {
-            enqueue_upload_tx(&db, tx_num, now, self.branch_num, &user, &upload_records)?;
+            enqueue_upload_tx(&db, tx_num, now, self.branch_num, &user)?;
         }
         db.commit()?;
         Ok(tx_id)
@@ -2757,18 +2751,13 @@ impl Runtime {
         self.active_uploads(limit, &BTreeSet::new())
     }
 
-    pub fn upload_queue_counts_for_test(&self) -> Result<(usize, usize)> {
+    pub fn upload_queue_count_for_test(&self) -> Result<usize> {
         let queue_count =
             self.conn
                 .query_row("SELECT COUNT(*) FROM jazz_tx_upload_queue", [], |row| {
                     row.get::<_, i64>(0)
                 })?;
-        let data_count =
-            self.conn
-                .query_row("SELECT COUNT(*) FROM jazz_tx_upload_data", [], |row| {
-                    row.get::<_, i64>(0)
-                })?;
-        Ok((queue_count as usize, data_count as usize))
+        Ok(queue_count as usize)
     }
 
     pub fn upload_ack_count_for_test(&self) -> Result<usize> {
@@ -2821,10 +2810,6 @@ impl Runtime {
 
         let db = self.conn.transaction()?;
         for tx_num in tx_nums {
-            db.execute(
-                "DELETE FROM jazz_tx_upload_data WHERE tx_num = ?",
-                params![tx_num],
-            )?;
             db.execute(
                 "DELETE FROM jazz_tx_upload_queue
                  WHERE tx_num = ?
@@ -2978,7 +2963,7 @@ impl Runtime {
             if excluded_tx_ids.contains(&tx_id) {
                 continue;
             }
-            let data = upload_data_records(&self.conn, tx_num)?;
+            let data = upload_data_records(&self.conn, &self.schema, tx_num, &tx_id)?;
             entries.push(UploadQueueEntry {
                 tx: ClientTx {
                     tx_id,
@@ -3007,12 +2992,6 @@ impl Runtime {
             .ok_or_else(|| crate::Error::new(format!("row {id} is not visible")))?;
         let user = self.attribution_user().to_owned();
         let bypass_policy = self.bypasses_policy();
-        let upload_records = vec![ClientDataRecord {
-            table: table_name.to_owned(),
-            row_id: id.to_owned(),
-            op: DataOp::Delete,
-            values: BTreeMap::new(),
-        }];
         let db = self.conn.transaction()?;
         let now = now_ms();
         let (tx_num, tx_id) = tx::create_tx(&db, self.node_num, &self.node_id, now)?;
@@ -3171,7 +3150,7 @@ impl Runtime {
             projection::rebuild(&db, &self.schema, self.node_num)?;
         }
         if allowed {
-            enqueue_upload_tx(&db, tx_num, now, self.branch_num, &user, &upload_records)?;
+            enqueue_upload_tx(&db, tx_num, now, self.branch_num, &user)?;
         }
         db.commit()?;
         Ok(tx_id)
@@ -5801,7 +5780,6 @@ fn enqueue_upload_tx(
     created_at: i64,
     branch_num: i64,
     author: &str,
-    records: &[ClientDataRecord],
 ) -> Result<()> {
     let branch_id = branch_id_for_num(conn, branch_num)?;
     conn.execute(
@@ -5810,23 +5788,6 @@ fn enqueue_upload_tx(
          VALUES (?, ?, ?, ?, ?)",
         params![tx_num, UPLOAD_STATUS_ACTIVE, created_at, branch_id, author],
     )?;
-    for (record_index, record) in records.iter().enumerate() {
-        let values_json = serde_json::to_string(&record.values)
-            .map_err(|err| crate::Error::new(format!("invalid upload values JSON: {err}")))?;
-        conn.execute(
-            "INSERT INTO jazz_tx_upload_data
-             (tx_num, record_index, table_name, row_id, op, values_json)
-             VALUES (?, ?, ?, ?, ?, ?)",
-            params![
-                tx_num,
-                record_index as i64,
-                &record.table,
-                &record.row_id,
-                data_op_to_storage(&record.op),
-                values_json
-            ],
-        )?;
-    }
     Ok(())
 }
 
@@ -5864,34 +5825,28 @@ fn tx_conflict_mode_from_storage(mode: i64) -> Result<TxConflictMode> {
     }
 }
 
-fn upload_data_records(conn: &Connection, tx_num: i64) -> Result<Vec<ClientDataRecord>> {
-    let mut stmt = conn.prepare(
-        "SELECT table_name, row_id, op, values_json
-         FROM jazz_tx_upload_data
-         WHERE tx_num = ?
-         ORDER BY record_index",
-    )?;
-    let rows = stmt.query_map(params![tx_num], |row| {
-        Ok((
-            row.get::<_, String>(0)?,
-            row.get::<_, String>(1)?,
-            row.get::<_, i64>(2)?,
-            row.get::<_, String>(3)?,
-        ))
-    })?;
-
-    let mut records = Vec::new();
-    for row in rows {
-        let (table, row_id, op, values_json) = row?;
-        records.push(ClientDataRecord {
-            table,
-            row_id,
-            op: data_op_from_storage(op)?,
-            values: serde_json::from_str::<BTreeMap<String, JsonValue>>(&values_json)
-                .map_err(|err| crate::Error::new(format!("invalid upload values JSON: {err}")))?,
-        });
-    }
-    Ok(records)
+fn upload_data_records(
+    conn: &Connection,
+    schema: &SchemaDef,
+    tx_num: i64,
+    tx_id: &str,
+) -> Result<Vec<ClientDataRecord>> {
+    history_records_for_tx(conn, schema, tx_num, tx_id)?
+        .into_iter()
+        .map(|record| {
+            let op = data_op_from_storage(record.op)?;
+            Ok(ClientDataRecord {
+                table: record.table,
+                row_id: record.row_id,
+                values: if matches!(op, DataOp::Delete) {
+                    BTreeMap::new()
+                } else {
+                    record.values
+                },
+                op,
+            })
+        })
+        .collect()
 }
 
 fn upload_read_records(conn: &Connection, tx_num: i64) -> Result<Vec<ReadRecord>> {
@@ -6226,28 +6181,6 @@ impl<'a> TransactionBuilder<'a> {
         if mutations.is_empty() {
             return Ok(String::new());
         }
-        let upload_records = mutations
-            .iter()
-            .map(|mutation| match mutation {
-                Mutation::Row {
-                    table,
-                    id,
-                    values,
-                    op,
-                } => Ok(ClientDataRecord {
-                    table: table.clone(),
-                    row_id: id.clone(),
-                    op: data_op_from_storage(*op)?,
-                    values: values.clone(),
-                }),
-                Mutation::DeleteRow { table, id } => Ok(ClientDataRecord {
-                    table: table.clone(),
-                    row_id: id.clone(),
-                    op: DataOp::Delete,
-                    values: BTreeMap::new(),
-                }),
-            })
-            .collect::<Result<Vec<_>>>()?;
         let user = self.runtime.attribution_user().to_owned();
         let bypass_policy = self.runtime.bypasses_policy();
         let mut delete_snapshots = BTreeMap::new();
@@ -6493,14 +6426,7 @@ impl<'a> TransactionBuilder<'a> {
             projection::rebuild(&db, &self.runtime.schema, self.runtime.node_num)?;
         }
         if allowed {
-            enqueue_upload_tx(
-                &db,
-                tx_num,
-                now,
-                self.runtime.branch_num,
-                &user,
-                &upload_records,
-            )?;
+            enqueue_upload_tx(&db, tx_num, now, self.runtime.branch_num, &user)?;
         }
         db.commit()?;
         Ok(tx_id)

--- a/crates/mini-jazz-sqlite/src/schema.rs
+++ b/crates/mini-jazz-sqlite/src/schema.rs
@@ -390,6 +390,33 @@ pub(crate) fn install(conn: &Connection, schema: &SchemaDef) -> Result<()> {
           PRIMARY KEY (tx_num, table_num, row_num, reason)
         ) WITHOUT ROWID;
 
+        CREATE TABLE IF NOT EXISTS jazz_tx_upload_queue (
+          sync_seq INTEGER PRIMARY KEY AUTOINCREMENT,
+          tx_num INTEGER NOT NULL UNIQUE,
+          status INTEGER NOT NULL,
+          created_at INTEGER NOT NULL,
+          branch_id TEXT,
+          author TEXT,
+          completed_at INTEGER,
+          last_upload_attempt_at INTEGER,
+          last_ack_at INTEGER,
+          attempt_count INTEGER NOT NULL DEFAULT 0
+        );
+
+        CREATE INDEX IF NOT EXISTS jazz_tx_upload_queue_active_idx
+        ON jazz_tx_upload_queue(status, created_at, sync_seq)
+        WHERE status = 1;
+
+        CREATE TABLE IF NOT EXISTS jazz_tx_upload_data (
+          tx_num INTEGER NOT NULL,
+          record_index INTEGER NOT NULL,
+          table_name TEXT NOT NULL,
+          row_id TEXT NOT NULL,
+          op INTEGER NOT NULL,
+          values_json TEXT NOT NULL,
+          PRIMARY KEY (tx_num, record_index)
+        ) WITHOUT ROWID;
+
         CREATE TABLE IF NOT EXISTS jazz_query_read (
           branch_id TEXT NOT NULL,
           table_name TEXT NOT NULL,

--- a/crates/mini-jazz-sqlite/src/schema.rs
+++ b/crates/mini-jazz-sqlite/src/schema.rs
@@ -407,16 +407,6 @@ pub(crate) fn install(conn: &Connection, schema: &SchemaDef) -> Result<()> {
         ON jazz_tx_upload_queue(status, created_at, sync_seq)
         WHERE status = 1;
 
-        CREATE TABLE IF NOT EXISTS jazz_tx_upload_data (
-          tx_num INTEGER NOT NULL,
-          record_index INTEGER NOT NULL,
-          table_name TEXT NOT NULL,
-          row_id TEXT NOT NULL,
-          op INTEGER NOT NULL,
-          values_json TEXT NOT NULL,
-          PRIMARY KEY (tx_num, record_index)
-        ) WITHOUT ROWID;
-
         CREATE TABLE IF NOT EXISTS jazz_query_read (
           branch_id TEXT NOT NULL,
           table_name TEXT NOT NULL,

--- a/crates/mini-jazz-sqlite/src/session.rs
+++ b/crates/mini-jazz-sqlite/src/session.rs
@@ -2,9 +2,10 @@ use crate::connection::{DownstreamEndpoint, UpstreamEndpoint};
 use crate::protocol::{
     ClientHello, ClientMessage, CloseReason, MessageId, ProtocolCapabilities, ProtocolError,
     ProtocolVersion, ReplayCursor, ReplaySubscription, RetryHint, ServerHello, ServerMessage,
-    SessionId, SettlementTier, SubscriptionId, SUPPORTED_PROTOCOL_VERSION,
+    SessionId, SettlementTier, SubscriptionId, TxStatusKind, SUPPORTED_PROTOCOL_VERSION,
 };
 use crate::{BuiltQuery, Error, Result, Runtime};
+use serde_json::json;
 use std::collections::{BTreeMap, BTreeSet};
 
 #[derive(Clone, Debug)]
@@ -28,6 +29,7 @@ pub struct UpstreamSession {
     hello: ServerHello,
     schema_fingerprint: String,
     policy_fingerprint: String,
+    connection_auth_user: Option<String>,
     peer_hello: Option<ClientHello>,
     active_subscriptions: BTreeMap<SubscriptionId, ActiveSubscription>,
     pending_messages: BTreeMap<MessageId, (SubscriptionId, ReplayCursor)>,
@@ -228,6 +230,27 @@ impl DownstreamSession {
                         self.settled.insert((subscription_id, tier), cursor);
                     }
                 }
+                ServerMessage::UploadAck { .. } => {
+                    if self.upstream_hello.is_none() {
+                        self.close_with_error(
+                            conn,
+                            "protocol_error",
+                            "handshake is not established",
+                        );
+                        return Err(Error::new("handshake is not established"));
+                    }
+                }
+                ServerMessage::TxStatus { tx_id, status } => {
+                    if self.upstream_hello.is_none() {
+                        self.close_with_error(
+                            conn,
+                            "protocol_error",
+                            "handshake is not established",
+                        );
+                        return Err(Error::new("handshake is not established"));
+                    }
+                    runtime.apply_tx_status(&tx_id, status)?;
+                }
                 ServerMessage::Error(error) => {
                     let fatal = error.retry_hint == RetryHint::Fatal;
                     if !fatal {
@@ -307,6 +330,7 @@ impl DownstreamSession {
         if !hello.capabilities.replay
             || !hello.capabilities.acknowledgements
             || !hello.capabilities.query_settlement
+            || !hello.capabilities.tx_upload
         {
             self.close_with_error(
                 conn,
@@ -348,6 +372,7 @@ impl UpstreamSession {
             },
             schema_fingerprint: schema_fingerprint.into(),
             policy_fingerprint: policy_fingerprint.into(),
+            connection_auth_user: None,
             peer_hello: None,
             active_subscriptions: BTreeMap::new(),
             pending_messages: BTreeMap::new(),
@@ -357,6 +382,18 @@ impl UpstreamSession {
             next_cursor: 1,
             closed: false,
         }
+    }
+
+    pub fn new_authenticated_for_test(
+        session_id: impl Into<String>,
+        node_id: impl Into<String>,
+        schema_fingerprint: impl Into<String>,
+        policy_fingerprint: impl Into<String>,
+        connection_auth_user: impl Into<String>,
+    ) -> Self {
+        let mut session = Self::new(session_id, node_id, schema_fingerprint, policy_fingerprint);
+        session.connection_auth_user = Some(connection_auth_user.into());
+        session
     }
 
     pub fn pump(&mut self, runtime: &mut Runtime, conn: &mut impl UpstreamEndpoint) -> Result<()> {
@@ -487,6 +524,73 @@ impl UpstreamSession {
                         self.last_acknowledged
                             .insert(subscription_id, acknowledged_cursor);
                     }
+                }
+                ClientMessage::UploadTx { tx, data, reads } => {
+                    ensure_open(self.closed)?;
+                    if self.peer_hello.is_none() {
+                        self.close_with_error(
+                            conn,
+                            "protocol_error",
+                            "handshake is not established",
+                        );
+                        continue;
+                    }
+                    conn.send_server_message(ServerMessage::UploadAck {
+                        tx_id: tx.tx_id.clone(),
+                    });
+                    let Some(connection_auth_user) = self.connection_auth_user.as_deref() else {
+                        self.close_with_error(
+                            conn,
+                            "auth_required",
+                            "transaction upload requires authenticated connection",
+                        );
+                        continue;
+                    };
+                    let peer_node_id = self
+                        .peer_hello
+                        .as_ref()
+                        .expect("handshake checked before upload")
+                        .node_id
+                        .clone();
+                    match runtime.apply_upload_tx_as_user(
+                        &tx,
+                        &data,
+                        &reads,
+                        &peer_node_id,
+                        connection_auth_user,
+                    ) {
+                        Ok(Some(status)) => conn.send_server_message(ServerMessage::TxStatus {
+                            tx_id: tx.tx_id,
+                            status,
+                        }),
+                        Ok(None) => {}
+                        Err(error) => conn.send_server_message(ServerMessage::TxStatus {
+                            tx_id: tx.tx_id,
+                            status: TxStatusKind::Rejected {
+                                code: "upload_rejected".to_owned(),
+                                detail: Some(json!({
+                                    "message": error.to_string(),
+                                })),
+                            },
+                        }),
+                    }
+                }
+                ClientMessage::Unsubscribe { subscription_id } => {
+                    ensure_open(self.closed)?;
+                    if self.peer_hello.is_none() {
+                        self.close_with_error(
+                            conn,
+                            "protocol_error",
+                            "handshake is not established",
+                        );
+                        continue;
+                    }
+                    self.active_subscriptions.remove(&subscription_id);
+                    self.pending_messages
+                        .retain(|_, (pending_subscription_id, _)| {
+                            pending_subscription_id != &subscription_id
+                        });
+                    self.last_acknowledged.remove(&subscription_id);
                 }
                 ClientMessage::Close(_) => {
                     self.clear_session_state();

--- a/crates/mini-jazz-sqlite/src/session.rs
+++ b/crates/mini-jazz-sqlite/src/session.rs
@@ -535,9 +535,6 @@ impl UpstreamSession {
                         );
                         continue;
                     }
-                    conn.send_server_message(ServerMessage::UploadAck {
-                        tx_id: tx.tx_id.clone(),
-                    });
                     let Some(connection_auth_user) = self.connection_auth_user.as_deref() else {
                         self.close_with_error(
                             conn,
@@ -546,6 +543,9 @@ impl UpstreamSession {
                         );
                         continue;
                     };
+                    conn.send_server_message(ServerMessage::UploadAck {
+                        tx_id: tx.tx_id.clone(),
+                    });
                     let peer_node_id = self
                         .peer_hello
                         .as_ref()

--- a/crates/mini-jazz-sqlite/src/session.rs
+++ b/crates/mini-jazz-sqlite/src/session.rs
@@ -391,6 +391,22 @@ impl UpstreamSession {
         policy_fingerprint: impl Into<String>,
         connection_auth_user: impl Into<String>,
     ) -> Self {
+        Self::new_authenticated(
+            session_id,
+            node_id,
+            schema_fingerprint,
+            policy_fingerprint,
+            connection_auth_user,
+        )
+    }
+
+    pub fn new_authenticated(
+        session_id: impl Into<String>,
+        node_id: impl Into<String>,
+        schema_fingerprint: impl Into<String>,
+        policy_fingerprint: impl Into<String>,
+        connection_auth_user: impl Into<String>,
+    ) -> Self {
         let mut session = Self::new(session_id, node_id, schema_fingerprint, policy_fingerprint);
         session.connection_auth_user = Some(connection_auth_user.into());
         session
@@ -607,6 +623,34 @@ impl UpstreamSession {
         subscription_id: &SubscriptionId,
     ) -> Option<ReplayCursor> {
         self.last_acknowledged.get(subscription_id).copied()
+    }
+
+    pub fn refresh_active_subscriptions(
+        &mut self,
+        runtime: &Runtime,
+        conn: &mut impl UpstreamEndpoint,
+    ) -> Result<()> {
+        ensure_open(self.closed)?;
+        if self.peer_hello.is_none() {
+            return Err(Error::new("handshake is not established"));
+        }
+
+        let subscriptions = self
+            .active_subscriptions
+            .iter()
+            .map(|(subscription_id, subscription)| {
+                (
+                    subscription_id.clone(),
+                    subscription.query.clone(),
+                    subscription.requested_tier,
+                )
+            })
+            .collect::<Vec<_>>();
+
+        for (subscription_id, query, requested_tier) in subscriptions {
+            self.send_subscription_data(runtime, conn, subscription_id, query, requested_tier)?;
+        }
+        Ok(())
     }
 
     pub fn has_active_subscription(&self, subscription_id: &SubscriptionId) -> bool {

--- a/crates/mini-jazz-sqlite/src/sync.rs
+++ b/crates/mini-jazz-sqlite/src/sync.rs
@@ -114,6 +114,8 @@ pub struct TxRecord {
     pub rejection_detail: Option<JsonValue>,
     pub receipt_tiers: Vec<i64>,
     pub created_at: i64,
+    #[serde(default)]
+    pub server_ingested_at: Option<i64>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/mini-jazz-sqlite/src/sync.rs
+++ b/crates/mini-jazz-sqlite/src/sync.rs
@@ -114,8 +114,6 @@ pub struct TxRecord {
     pub rejection_detail: Option<JsonValue>,
     pub receipt_tiers: Vec<i64>,
     pub created_at: i64,
-    #[serde(default)]
-    pub server_ingested_at: Option<i64>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/mini-jazz-sqlite/src/tx.rs
+++ b/crates/mini-jazz-sqlite/src/tx.rs
@@ -42,7 +42,7 @@ pub(crate) fn create_tx(
 pub(crate) fn create_tx_with_options(
     conn: &Connection,
     node_num: i64,
-    node_id: &str,
+    _node_id: &str,
     now: i64,
     conflict_mode: i64,
     outcome: i64,
@@ -55,7 +55,7 @@ pub(crate) fn create_tx_with_options(
             |row| row.get::<_, i64>(0),
         )
         .unwrap_or(1);
-    let tx_id = format!("tx-{node_id}-{next_epoch}");
+    let tx_id = uuid::Uuid::now_v7().to_string();
     conn.execute(
         "INSERT INTO jazz_tx
           (tx_id, node_num, local_epoch, global_epoch, kind, conflict_mode, outcome, created_at, metadata_json)

--- a/crates/mini-jazz-sqlite/tests/whole_system/connection.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/connection.rs
@@ -1955,6 +1955,71 @@ fn upstream_upload_tx_gets_ack_and_edge_status() {
 }
 
 #[test]
+fn upstream_upload_tx_accepts_opaque_tx_id() {
+    let harness = Harness::new();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    let tx_id = "018f56e2-6e2b-7d4d-9f66-4a59421e8a8f".to_owned();
+
+    let mut downstream = DownstreamConnectionManager::new(
+        "tab-session",
+        "alice-tab",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamConnectionManager::new_authenticated_for_test(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+        "alice",
+    );
+
+    let server_messages = upstream
+        .receive(&mut worker, downstream.open().unwrap())
+        .unwrap();
+    downstream.receive(&mut worker, server_messages).unwrap();
+
+    let server_messages = upstream
+        .receive(
+            &mut worker,
+            vec![ClientMessage::UploadTx {
+                tx: ClientTx {
+                    tx_id: tx_id.clone(),
+                    branch_id: None,
+                    conflict_mode: TxConflictMode::Mergeable,
+                    created_at: 1,
+                    author: Some("alice".to_owned()),
+                },
+                data: vec![ClientDataRecord {
+                    table: "projects".to_owned(),
+                    row_id: "project-opaque-upload".to_owned(),
+                    op: DataOp::Insert,
+                    values: BTreeMap::from([("title".to_owned(), json!("Opaque upload"))]),
+                }],
+                reads: Vec::new(),
+            }],
+        )
+        .unwrap();
+
+    assert!(server_messages.iter().any(|message| {
+        matches!(message, ServerMessage::UploadAck { tx_id: acked } if acked == &tx_id)
+    }));
+    assert!(server_messages.iter().any(|message| {
+        matches!(
+            message,
+            ServerMessage::TxStatus {
+                tx_id: status_tx_id,
+                status: TxStatusKind::EdgeAccepted
+            } if status_tx_id == &tx_id
+        )
+    }));
+    assert_eq!(
+        row_ids(worker.read_rows("projects").unwrap()),
+        vec!["project-opaque-upload"]
+    );
+}
+
+#[test]
 fn upstream_upload_update_waits_when_row_is_missing_then_applies_after_sync() {
     let harness = Harness::new();
     let mut authority = harness.memory("authority", "alice").unwrap();
@@ -2135,12 +2200,13 @@ fn upstream_upload_delete_waits_when_row_is_missing_then_applies_after_sync() {
 }
 
 #[test]
-fn upstream_upload_tx_rejects_existing_tx_id_from_another_node() {
+fn upstream_upload_tx_dedupes_existing_tx_id_without_rewrite() {
     let harness = Harness::new();
     let mut worker = harness.memory("alice-worker", "alice").unwrap();
     let existing_tx = worker
         .create_project("project-existing", "Already here")
         .unwrap();
+    worker.accept_transaction_at_edge(&existing_tx).unwrap();
     let mut downstream = DownstreamConnectionManager::new(
         "tab-session",
         "alice-tab",
@@ -2190,10 +2256,14 @@ fn upstream_upload_tx_rejects_existing_tx_id_from_another_node() {
             message,
             ServerMessage::TxStatus {
                 tx_id,
-                status: TxStatusKind::Rejected { code, .. }
-            } if tx_id == &existing_tx && code == "upload_rejected"
+                status: TxStatusKind::EdgeAccepted
+            } if tx_id == &existing_tx
         )
     }));
+    assert_eq!(
+        row_ids(worker.read_rows("projects").unwrap()),
+        vec!["project-existing"]
+    );
 }
 
 #[test]
@@ -2744,6 +2814,64 @@ fn connection_manager_replays_acked_incomplete_upload_after_reconnect() {
     let replay_messages = downstream.receive(&mut tab, server_messages).unwrap();
 
     assert_eq!(upload_tx_ids(&replay_messages), vec![tx_id]);
+}
+
+#[test]
+fn upstream_connection_manager_can_refresh_active_subscriptions() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    worker.create_project("project-1", "Refresh data").unwrap();
+
+    let mut downstream = DownstreamConnectionManager::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamConnectionManager::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+    let query = open_todos_query();
+    let (subscription, subscribe_messages) = downstream
+        .subscribe(query.clone(), SettlementTier::Local)
+        .unwrap();
+
+    let server_messages = upstream
+        .receive(&mut worker, downstream.open().unwrap())
+        .unwrap();
+    let client_messages = downstream.receive(&mut tab, server_messages).unwrap();
+    let server_messages = upstream
+        .receive(&mut worker, [client_messages, subscribe_messages].concat())
+        .unwrap();
+    downstream.receive(&mut tab, server_messages).unwrap();
+
+    worker
+        .create_todo(
+            "todo-refresh",
+            "Refresh active subscription",
+            false,
+            "project-1",
+        )
+        .unwrap();
+
+    let server_messages = upstream.refresh_active_subscriptions(&worker).unwrap();
+    let client_messages = downstream.receive(&mut tab, server_messages).unwrap();
+
+    assert!(client_messages.iter().any(|message| {
+        matches!(
+            message,
+            ClientMessage::Ack {
+                cursor: Some(_),
+                ..
+            }
+        )
+    }));
+    assert!(downstream.is_settled(&subscription, SettlementTier::Local));
+    assert_eq!(row_ids(tab.query(query).unwrap()), vec!["todo-refresh"]);
 }
 
 #[test]

--- a/crates/mini-jazz-sqlite/tests/whole_system/connection.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/connection.rs
@@ -1952,14 +1952,6 @@ fn upstream_upload_tx_gets_ack_and_edge_status() {
         .unwrap()
         .iter()
         .any(|upload| upload.tx.tx_id == tx_id));
-    let uploaded_tx = worker
-        .export_table_history("todos")
-        .unwrap()
-        .txs
-        .into_iter()
-        .find(|tx| tx.tx_id == tx_id)
-        .unwrap();
-    assert!(uploaded_tx.server_ingested_at.is_some());
 }
 
 #[test]

--- a/crates/mini-jazz-sqlite/tests/whole_system/connection.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/connection.rs
@@ -1919,6 +1919,186 @@ fn upstream_upload_tx_gets_ack_and_edge_status() {
 }
 
 #[test]
+fn upstream_upload_update_waits_when_row_is_missing_then_applies_after_sync() {
+    let harness = Harness::new();
+    let mut authority = harness.memory("authority", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    authority
+        .create_project("project-1", "Upload plan")
+        .unwrap();
+    authority
+        .create_todo("todo-missing-update", "Original", false, "project-1")
+        .unwrap();
+
+    let mut downstream = DownstreamConnectionManager::new(
+        "tab-session",
+        "alice-tab",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamConnectionManager::new_authenticated_for_test(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+        "alice",
+    );
+
+    let server_messages = upstream
+        .receive(&mut worker, downstream.open().unwrap())
+        .unwrap();
+    downstream.receive(&mut worker, server_messages).unwrap();
+
+    let tx_id = "tx-alice-tab-9101".to_owned();
+    let upload = ClientMessage::UploadTx {
+        tx: ClientTx {
+            tx_id: tx_id.clone(),
+            branch_id: None,
+            conflict_mode: TxConflictMode::Mergeable,
+            created_at: 1,
+            author: Some("alice".to_owned()),
+        },
+        data: vec![ClientDataRecord {
+            table: "todos".to_owned(),
+            row_id: "todo-missing-update".to_owned(),
+            op: DataOp::Update,
+            values: BTreeMap::from([("title".to_owned(), json!("Updated after sync"))]),
+        }],
+        reads: Vec::new(),
+    };
+
+    let server_messages = upstream.receive(&mut worker, vec![upload.clone()]).unwrap();
+
+    assert!(server_messages.iter().any(
+        |message| matches!(message, ServerMessage::UploadAck { tx_id: acked } if acked == &tx_id)
+    ));
+    assert!(!server_messages.iter().any(|message| {
+        matches!(
+            message,
+            ServerMessage::TxStatus {
+                tx_id: status_tx_id,
+                status: TxStatusKind::Rejected { .. }
+            } if status_tx_id == &tx_id
+        )
+    }));
+    assert!(worker.transaction_info(&tx_id).is_err());
+
+    worker
+        .apply_bundle(&authority.export_table_history("projects").unwrap())
+        .unwrap();
+    worker
+        .apply_bundle(&authority.export_table_history("todos").unwrap())
+        .unwrap();
+
+    let server_messages = upstream.receive(&mut worker, vec![upload]).unwrap();
+
+    assert!(server_messages.iter().any(|message| {
+        matches!(
+            message,
+            ServerMessage::TxStatus {
+                tx_id: status_tx_id,
+                status: TxStatusKind::EdgeAccepted
+            } if status_tx_id == &tx_id
+        )
+    }));
+    let rows = worker.read_rows("todos").unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].id, "todo-missing-update");
+    assert_eq!(rows[0].values["title"], json!("Updated after sync"));
+}
+
+#[test]
+fn upstream_upload_delete_waits_when_row_is_missing_then_applies_after_sync() {
+    let harness = Harness::new();
+    let mut authority = harness.memory("authority", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    authority
+        .create_project("project-1", "Upload plan")
+        .unwrap();
+    authority
+        .create_todo(
+            "todo-missing-delete",
+            "Delete after sync",
+            false,
+            "project-1",
+        )
+        .unwrap();
+
+    let mut downstream = DownstreamConnectionManager::new(
+        "tab-session",
+        "alice-tab",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamConnectionManager::new_authenticated_for_test(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+        "alice",
+    );
+
+    let server_messages = upstream
+        .receive(&mut worker, downstream.open().unwrap())
+        .unwrap();
+    downstream.receive(&mut worker, server_messages).unwrap();
+
+    let tx_id = "tx-alice-tab-9102".to_owned();
+    let upload = ClientMessage::UploadTx {
+        tx: ClientTx {
+            tx_id: tx_id.clone(),
+            branch_id: None,
+            conflict_mode: TxConflictMode::Mergeable,
+            created_at: 1,
+            author: Some("alice".to_owned()),
+        },
+        data: vec![ClientDataRecord {
+            table: "todos".to_owned(),
+            row_id: "todo-missing-delete".to_owned(),
+            op: DataOp::Delete,
+            values: BTreeMap::new(),
+        }],
+        reads: Vec::new(),
+    };
+
+    let server_messages = upstream.receive(&mut worker, vec![upload.clone()]).unwrap();
+
+    assert!(server_messages.iter().any(
+        |message| matches!(message, ServerMessage::UploadAck { tx_id: acked } if acked == &tx_id)
+    ));
+    assert!(!server_messages.iter().any(|message| {
+        matches!(
+            message,
+            ServerMessage::TxStatus {
+                tx_id: status_tx_id,
+                status: TxStatusKind::Rejected { .. }
+            } if status_tx_id == &tx_id
+        )
+    }));
+    assert!(worker.transaction_info(&tx_id).is_err());
+
+    worker
+        .apply_bundle(&authority.export_table_history("projects").unwrap())
+        .unwrap();
+    worker
+        .apply_bundle(&authority.export_table_history("todos").unwrap())
+        .unwrap();
+
+    let server_messages = upstream.receive(&mut worker, vec![upload]).unwrap();
+
+    assert!(server_messages.iter().any(|message| {
+        matches!(
+            message,
+            ServerMessage::TxStatus {
+                tx_id: status_tx_id,
+                status: TxStatusKind::EdgeAccepted
+            } if status_tx_id == &tx_id
+        )
+    }));
+    assert!(worker.read_rows("todos").unwrap().is_empty());
+}
+
+#[test]
 fn upstream_upload_tx_rejects_existing_tx_id_from_another_node() {
     let harness = Harness::new();
     let mut worker = harness.memory("alice-worker", "alice").unwrap();

--- a/crates/mini-jazz-sqlite/tests/whole_system/connection.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/connection.rs
@@ -4,13 +4,16 @@ use mini_jazz_sqlite::connection::{
 };
 use mini_jazz_sqlite::connection::{DownstreamConnectionManager, UpstreamConnectionManager};
 use mini_jazz_sqlite::protocol::{
-    ClientHello, ClientMessage, CloseReason, MessageId, ProtocolCapabilities, ProtocolError,
-    ProtocolVersion, ReplayCursor, ReplaySubscription, RetryHint, ServerHello, ServerMessage,
-    SessionId, SettlementTier, SubscriptionId,
+    ClientDataRecord, ClientHello, ClientMessage, ClientTx, CloseReason, DataOp, MessageId,
+    ProtocolCapabilities, ProtocolError, ProtocolVersion, ReplayCursor, ReplaySubscription,
+    RetryHint, ServerHello, ServerMessage, SessionId, SettlementTier, SubscriptionId,
+    TxConflictMode, TxStatusKind,
 };
 use mini_jazz_sqlite::session::{DownstreamSession, UpstreamSession};
+use mini_jazz_sqlite::sync::ReadRecord;
 use mini_jazz_sqlite::{BuiltQuery, QueryCondition, QueryConditionOp};
 use serde_json::json;
+use std::collections::BTreeMap;
 
 #[test]
 fn connection_subscribe_delivers_initial_query_and_settled() {
@@ -530,7 +533,7 @@ fn connection_ignores_unrequested_settled_tier() {
 
     downstream.open(&mut downstream_conn).unwrap();
     upstream_conn.send_server_message(ServerMessage::Hello(ServerHello {
-        protocol_version: ProtocolVersion(1),
+        protocol_version: ProtocolVersion(2),
         session_id: SessionId::new("worker-session"),
         node_id: "alice-worker".to_owned(),
         capabilities: ProtocolCapabilities::default(),
@@ -718,7 +721,7 @@ fn connection_rejects_data_after_incompatible_server_hello_without_partial_apply
 
     downstream.open(&mut downstream_conn).unwrap();
     upstream_conn.send_server_message(ServerMessage::Hello(ServerHello {
-        protocol_version: ProtocolVersion(2),
+        protocol_version: ProtocolVersion(3),
         session_id: SessionId::new("worker-session"),
         node_id: "alice-worker".to_owned(),
         capabilities: ProtocolCapabilities::default(),
@@ -752,7 +755,7 @@ fn connection_rejects_unsolicited_server_hello() {
     );
 
     upstream_conn.send_server_message(ServerMessage::Hello(ServerHello {
-        protocol_version: ProtocolVersion(1),
+        protocol_version: ProtocolVersion(2),
         session_id: SessionId::new("worker-session"),
         node_id: "alice-worker".to_owned(),
         capabilities: ProtocolCapabilities::default(),
@@ -834,7 +837,7 @@ fn connection_rejects_server_hello_without_ack_capability() {
 
     downstream.open(&mut downstream_conn).unwrap();
     upstream_conn.send_server_message(ServerMessage::Hello(ServerHello {
-        protocol_version: ProtocolVersion(1),
+        protocol_version: ProtocolVersion(2),
         session_id: SessionId::new("worker-session"),
         node_id: "alice-worker".to_owned(),
         capabilities: ProtocolCapabilities {
@@ -849,6 +852,146 @@ fn connection_rejects_server_hello_without_ack_capability() {
         downstream.last_error().map(|error| error.code.as_str()),
         Some("unsupported_capability")
     );
+}
+
+#[test]
+fn downstream_rejects_server_without_tx_upload_capability() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut downstream = DownstreamConnectionManager::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+
+    let open_messages = downstream.open().unwrap();
+    assert!(matches!(
+        open_messages.as_slice(),
+        [ClientMessage::Hello(_)]
+    ));
+
+    let server_messages = vec![ServerMessage::Hello(ServerHello {
+        protocol_version: ProtocolVersion(2),
+        session_id: SessionId::new("server-session"),
+        node_id: "edge".to_owned(),
+        capabilities: ProtocolCapabilities {
+            tx_upload: false,
+            ..ProtocolCapabilities::default()
+        },
+    })];
+
+    let result = downstream.receive(&mut tab, server_messages);
+
+    assert!(result.is_ok());
+    assert!(downstream.is_closed());
+    assert_eq!(
+        downstream.last_error().map(|error| error.code.as_str()),
+        Some("unsupported_capability")
+    );
+}
+
+#[test]
+fn protocol_defaults_include_tx_upload_capability() {
+    assert!(ProtocolCapabilities::default().tx_upload);
+}
+
+#[test]
+fn connection_upstream_requires_auth_for_upload_tx_after_handshake() {
+    let harness = Harness::new();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut upstream = UpstreamSession::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    downstream_conn.send_client_message(ClientMessage::Hello(ClientHello {
+        protocol_version: ProtocolVersion(2),
+        session_id: SessionId::new("tab-session"),
+        node_id: "alice-tab".to_owned(),
+        schema_fingerprint: worker.local_schema_fingerprint(),
+        policy_fingerprint: worker.local_policy_fingerprint(),
+    }));
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    assert!(matches!(
+        downstream_conn.receive_server_message(),
+        Some(ServerMessage::Hello(_))
+    ));
+
+    downstream_conn.send_client_message(ClientMessage::UploadTx {
+        tx: ClientTx {
+            tx_id: "tx-1".to_owned(),
+            branch_id: None,
+            conflict_mode: TxConflictMode::Mergeable,
+            created_at: 1,
+            author: Some("alice".to_owned()),
+        },
+        data: Vec::new(),
+        reads: Vec::new(),
+    });
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+
+    assert!(upstream.is_closed());
+    assert_eq!(
+        upstream.last_error().map(|error| error.code.as_str()),
+        Some("auth_required")
+    );
+    assert!(matches!(
+        drain_server_messages(&mut downstream_conn).as_slice(),
+        [
+            ServerMessage::UploadAck { tx_id },
+            ServerMessage::Error(error),
+            ServerMessage::Close(CloseReason::ProtocolError)
+        ] if tx_id == "tx-1" && error.code == "auth_required"
+    ));
+}
+
+#[test]
+fn connection_upstream_unsubscribe_removes_subscription_after_handshake() {
+    let harness = Harness::new();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
+    let mut upstream = UpstreamSession::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    downstream_conn.send_client_message(ClientMessage::Hello(ClientHello {
+        protocol_version: ProtocolVersion(2),
+        session_id: SessionId::new("tab-session"),
+        node_id: "alice-tab".to_owned(),
+        schema_fingerprint: worker.local_schema_fingerprint(),
+        policy_fingerprint: worker.local_policy_fingerprint(),
+    }));
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    assert!(matches!(
+        downstream_conn.receive_server_message(),
+        Some(ServerMessage::Hello(_))
+    ));
+
+    let subscription_id = SubscriptionId::new("open-todos");
+    downstream_conn.send_client_message(ClientMessage::Subscribe {
+        subscription_id: subscription_id.clone(),
+        query: open_todos_query(),
+        requested_tier: SettlementTier::Local,
+    });
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+    assert!(upstream.has_active_subscription(&subscription_id));
+    drain_server_messages(&mut downstream_conn);
+
+    downstream_conn.send_client_message(ClientMessage::Unsubscribe {
+        subscription_id: subscription_id.clone(),
+    });
+    upstream.pump(&mut worker, &mut upstream_conn).unwrap();
+
+    assert!(!upstream.is_closed());
+    assert!(!upstream.has_active_subscription(&subscription_id));
+    assert!(drain_server_messages(&mut downstream_conn).is_empty());
 }
 
 #[test]
@@ -1113,7 +1256,7 @@ fn connection_downstream_replay_cursor_never_moves_backwards() {
 
     downstream.open(&mut downstream_conn).unwrap();
     upstream_conn.send_server_message(ServerMessage::Hello(ServerHello {
-        protocol_version: ProtocolVersion(1),
+        protocol_version: ProtocolVersion(2),
         session_id: SessionId::new("worker-session"),
         node_id: "alice-worker".to_owned(),
         capabilities: ProtocolCapabilities::default(),
@@ -1146,7 +1289,7 @@ fn connection_downstream_replay_cursor_never_moves_backwards() {
     let (mut downstream_conn, mut upstream_conn) = in_memory_connection_pair();
     downstream.open(&mut downstream_conn).unwrap();
     upstream_conn.send_server_message(ServerMessage::Hello(ServerHello {
-        protocol_version: ProtocolVersion(1),
+        protocol_version: ProtocolVersion(2),
         session_id: SessionId::new("worker-session-2"),
         node_id: "alice-worker".to_owned(),
         capabilities: ProtocolCapabilities::default(),
@@ -1213,7 +1356,7 @@ fn connection_upstream_new_hello_resets_session_state() {
     );
 
     downstream_conn.send_client_message(ClientMessage::Hello(ClientHello {
-        protocol_version: ProtocolVersion(1),
+        protocol_version: ProtocolVersion(2),
         session_id: SessionId::new("tab-session-2"),
         node_id: "alice-tab".to_owned(),
         schema_fingerprint: tab.local_schema_fingerprint(),
@@ -1254,7 +1397,7 @@ fn connection_upstream_replay_prunes_omitted_subscription_state() {
     );
 
     downstream_conn.send_client_message(ClientMessage::Hello(ClientHello {
-        protocol_version: ProtocolVersion(1),
+        protocol_version: ProtocolVersion(2),
         session_id: SessionId::new("tab-session"),
         node_id: "alice-tab".to_owned(),
         schema_fingerprint: tab.local_schema_fingerprint(),
@@ -1336,7 +1479,7 @@ fn connection_rejects_incompatible_protocol_without_partial_apply() {
     let mut downstream = DownstreamSession::new_with_protocol_version(
         "tab-session",
         "alice-tab",
-        2,
+        1,
         tab.local_schema_fingerprint(),
         tab.local_policy_fingerprint(),
     );
@@ -1516,7 +1659,7 @@ fn connection_closes_when_data_bundle_apply_fails() {
 
     downstream.open(&mut downstream_conn).unwrap();
     upstream_conn.send_server_message(ServerMessage::Hello(ServerHello {
-        protocol_version: ProtocolVersion(1),
+        protocol_version: ProtocolVersion(2),
         session_id: SessionId::new("worker-session"),
         node_id: "alice-worker".to_owned(),
         capabilities: ProtocolCapabilities::default(),
@@ -1686,6 +1829,708 @@ fn connection_manager_open_subscribe_applies_data_and_emits_ack() {
 }
 
 #[test]
+fn connection_manager_flushes_uploads_after_handshake() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    tab.create_project("project-1", "Upload plan").unwrap();
+    let tx_id = tab
+        .create_todo("todo-upload-loop", "Flush after hello", false, "project-1")
+        .unwrap();
+
+    let mut downstream = DownstreamConnectionManager::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamConnectionManager::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    let server_messages = upstream
+        .receive(&mut worker, downstream.open().unwrap())
+        .unwrap();
+    let client_messages = downstream.receive(&mut tab, server_messages).unwrap();
+
+    assert!(client_messages.iter().any(|message| {
+        matches!(message, ClientMessage::UploadTx { tx, .. } if tx.tx_id == tx_id)
+    }));
+}
+
+#[test]
+fn upstream_upload_tx_gets_ack_and_edge_status() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    tab.create_project("project-1", "Upload plan").unwrap();
+    let tx_id = tab
+        .create_todo("todo-upload-upstream", "Apply upload", false, "project-1")
+        .unwrap();
+
+    let mut downstream = DownstreamConnectionManager::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamConnectionManager::new_authenticated_for_test(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+        "alice",
+    );
+
+    let server_messages = upstream
+        .receive(&mut worker, downstream.open().unwrap())
+        .unwrap();
+    let upload_messages = downstream.receive(&mut tab, server_messages).unwrap();
+    assert!(upload_tx_ids(&upload_messages).contains(&tx_id));
+
+    let server_messages = upstream.receive(&mut worker, upload_messages).unwrap();
+
+    assert!(server_messages.iter().any(|message| {
+        matches!(message, ServerMessage::UploadAck { tx_id: acked } if acked == &tx_id)
+    }));
+    assert!(server_messages.iter().any(|message| {
+        matches!(
+            message,
+            ServerMessage::TxStatus {
+                tx_id: status_tx_id,
+                status: TxStatusKind::EdgeAccepted
+            } if status_tx_id == &tx_id
+        )
+    }));
+    assert_eq!(
+        row_ids(worker.read_rows("todos").unwrap()),
+        vec!["todo-upload-upstream"]
+    );
+
+    downstream.receive(&mut tab, server_messages).unwrap();
+    assert!(!tab
+        .active_uploads_for_test(10)
+        .unwrap()
+        .iter()
+        .any(|upload| upload.tx.tx_id == tx_id));
+}
+
+#[test]
+fn upstream_upload_tx_rejects_existing_tx_id_from_another_node() {
+    let harness = Harness::new();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    let existing_tx = worker
+        .create_project("project-existing", "Already here")
+        .unwrap();
+    let mut downstream = DownstreamConnectionManager::new(
+        "tab-session",
+        "alice-tab",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamConnectionManager::new_authenticated_for_test(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+        "alice",
+    );
+
+    let server_messages = upstream
+        .receive(&mut worker, downstream.open().unwrap())
+        .unwrap();
+    downstream.receive(&mut worker, server_messages).unwrap();
+
+    let server_messages = upstream
+        .receive(
+            &mut worker,
+            vec![ClientMessage::UploadTx {
+                tx: ClientTx {
+                    tx_id: existing_tx.clone(),
+                    branch_id: None,
+                    conflict_mode: TxConflictMode::Mergeable,
+                    created_at: 1,
+                    author: Some("alice".to_owned()),
+                },
+                data: vec![ClientDataRecord {
+                    table: "projects".to_owned(),
+                    row_id: "project-spoof".to_owned(),
+                    op: DataOp::Insert,
+                    values: BTreeMap::from([("title".to_owned(), json!("Spoof"))]),
+                }],
+                reads: Vec::new(),
+            }],
+        )
+        .unwrap();
+
+    assert!(server_messages.iter().any(|message| {
+        matches!(message, ServerMessage::UploadAck { tx_id } if tx_id == &existing_tx)
+    }));
+    assert!(server_messages.iter().any(|message| {
+        matches!(
+            message,
+            ServerMessage::TxStatus {
+                tx_id,
+                status: TxStatusKind::Rejected { code, .. }
+            } if tx_id == &existing_tx && code == "upload_rejected"
+        )
+    }));
+}
+
+#[test]
+fn upstream_exclusive_upload_without_write_reads_is_rejected() {
+    let harness = Harness::new();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    let mut downstream = DownstreamConnectionManager::new(
+        "tab-session",
+        "alice-tab",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamConnectionManager::new_authenticated_for_test(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+        "alice",
+    );
+
+    let server_messages = upstream
+        .receive(&mut worker, downstream.open().unwrap())
+        .unwrap();
+    downstream.receive(&mut worker, server_messages).unwrap();
+
+    let tx_id = "tx-alice-tab-9001".to_owned();
+    let server_messages = upstream
+        .receive(
+            &mut worker,
+            vec![ClientMessage::UploadTx {
+                tx: ClientTx {
+                    tx_id: tx_id.clone(),
+                    branch_id: None,
+                    conflict_mode: TxConflictMode::Exclusive,
+                    created_at: 1,
+                    author: Some("alice".to_owned()),
+                },
+                data: vec![ClientDataRecord {
+                    table: "projects".to_owned(),
+                    row_id: "project-exclusive-no-reads".to_owned(),
+                    op: DataOp::Insert,
+                    values: BTreeMap::from([("title".to_owned(), json!("No reads"))]),
+                }],
+                reads: Vec::new(),
+            }],
+        )
+        .unwrap();
+
+    assert!(server_messages.iter().any(|message| {
+        matches!(
+            message,
+            ServerMessage::TxStatus {
+                tx_id: status_tx_id,
+                status: TxStatusKind::Rejected { code, .. }
+            } if status_tx_id == &tx_id && code == "upload_rejected"
+        )
+    }));
+    assert!(worker.transaction_info(&tx_id).is_err());
+    assert!(worker.read_rows("projects").unwrap().is_empty());
+}
+
+#[test]
+fn rejected_upload_tx_does_not_leave_branch_or_row_id_side_effects() {
+    let harness = Harness::new();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    let branches_before = worker.branches().unwrap();
+    let mut downstream = DownstreamConnectionManager::new(
+        "tab-session",
+        "alice-tab",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamConnectionManager::new_authenticated_for_test(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+        "alice",
+    );
+
+    let server_messages = upstream
+        .receive(&mut worker, downstream.open().unwrap())
+        .unwrap();
+    downstream.receive(&mut worker, server_messages).unwrap();
+
+    let row_id = "project-duplicate-upload";
+    let tx_id = "tx-alice-tab-9002".to_owned();
+    let duplicate = ClientDataRecord {
+        table: "projects".to_owned(),
+        row_id: row_id.to_owned(),
+        op: DataOp::Insert,
+        values: BTreeMap::from([("title".to_owned(), json!("Duplicate"))]),
+    };
+    let server_messages = upstream
+        .receive(
+            &mut worker,
+            vec![ClientMessage::UploadTx {
+                tx: ClientTx {
+                    tx_id: tx_id.clone(),
+                    branch_id: Some("draft-side-effect".to_owned()),
+                    conflict_mode: TxConflictMode::Mergeable,
+                    created_at: 1,
+                    author: Some("alice".to_owned()),
+                },
+                data: vec![duplicate.clone(), duplicate],
+                reads: Vec::new(),
+            }],
+        )
+        .unwrap();
+
+    assert!(server_messages.iter().any(|message| {
+        matches!(
+            message,
+            ServerMessage::TxStatus {
+                tx_id: status_tx_id,
+                status: TxStatusKind::Rejected { code, .. }
+            } if status_tx_id == &tx_id && code == "upload_rejected"
+        )
+    }));
+    assert_eq!(worker.branches().unwrap(), branches_before);
+    assert!(!worker.row_id_exists_for_test(row_id).unwrap());
+}
+
+#[test]
+fn rejected_exclusive_upload_reads_do_not_leave_row_id_side_effects() {
+    let harness = Harness::new();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    let mut downstream = DownstreamConnectionManager::new(
+        "tab-session",
+        "alice-tab",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamConnectionManager::new_authenticated_for_test(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+        "alice",
+    );
+
+    let server_messages = upstream
+        .receive(&mut worker, downstream.open().unwrap())
+        .unwrap();
+    downstream.receive(&mut worker, server_messages).unwrap();
+
+    let tx_id = "tx-alice-tab-9003".to_owned();
+    let data_row_id = "project-exclusive-rollback";
+    let extra_read_row_id = "project-exclusive-extra-read";
+    let server_messages = upstream
+        .receive(
+            &mut worker,
+            vec![ClientMessage::UploadTx {
+                tx: ClientTx {
+                    tx_id: tx_id.clone(),
+                    branch_id: None,
+                    conflict_mode: TxConflictMode::Exclusive,
+                    created_at: 1,
+                    author: Some("alice".to_owned()),
+                },
+                data: vec![ClientDataRecord {
+                    table: "projects".to_owned(),
+                    row_id: data_row_id.to_owned(),
+                    op: DataOp::Insert,
+                    values: BTreeMap::from([("title".to_owned(), json!("Rollback"))]),
+                }],
+                reads: vec![
+                    ReadRecord {
+                        tx_id: tx_id.clone(),
+                        table: "projects".to_owned(),
+                        row_id: data_row_id.to_owned(),
+                        reason: 3,
+                        observed_tx_id: None,
+                    },
+                    ReadRecord {
+                        tx_id: tx_id.clone(),
+                        table: "projects".to_owned(),
+                        row_id: extra_read_row_id.to_owned(),
+                        reason: 2,
+                        observed_tx_id: Some("tx-missing-node-1".to_owned()),
+                    },
+                ],
+            }],
+        )
+        .unwrap();
+
+    assert!(server_messages.iter().any(|message| {
+        matches!(
+            message,
+            ServerMessage::TxStatus {
+                tx_id: status_tx_id,
+                status: TxStatusKind::Rejected { code, .. }
+            } if status_tx_id == &tx_id && code == "upload_rejected"
+        )
+    }));
+    assert!(!worker.row_id_exists_for_test(data_row_id).unwrap());
+    assert!(!worker.row_id_exists_for_test(extra_read_row_id).unwrap());
+}
+
+#[test]
+fn upload_delete_with_values_returns_rejection_status() {
+    let harness = Harness::new();
+    let mut edge = harness.memory("edge", "service").unwrap();
+    let mut upstream = UpstreamConnectionManager::new_authenticated_for_test(
+        "edge-session",
+        "edge",
+        edge.local_schema_fingerprint(),
+        edge.local_policy_fingerprint(),
+        "alice",
+    );
+    let schema_fingerprint = edge.local_schema_fingerprint();
+    let policy_fingerprint = edge.local_policy_fingerprint();
+    let tx_id = "tx-alice-tab-9010".to_owned();
+
+    let server_messages = upstream
+        .receive(
+            &mut edge,
+            vec![
+                ClientMessage::Hello(ClientHello {
+                    protocol_version: ProtocolVersion(2),
+                    session_id: SessionId::new("tab-session"),
+                    node_id: "alice-tab".to_owned(),
+                    schema_fingerprint,
+                    policy_fingerprint,
+                }),
+                ClientMessage::UploadTx {
+                    tx: ClientTx {
+                        tx_id: tx_id.clone(),
+                        branch_id: None,
+                        conflict_mode: TxConflictMode::Mergeable,
+                        created_at: 1,
+                        author: None,
+                    },
+                    data: vec![ClientDataRecord {
+                        table: "todos".to_owned(),
+                        row_id: "todo-delete-bad".to_owned(),
+                        op: DataOp::Delete,
+                        values: BTreeMap::from([("title".to_owned(), json!("bad"))]),
+                    }],
+                    reads: Vec::new(),
+                },
+            ],
+        )
+        .unwrap();
+
+    assert!(!upstream.is_closed());
+    assert!(server_messages.iter().any(|message| {
+        matches!(message, ServerMessage::UploadAck { tx_id: acked } if acked == &tx_id)
+    }));
+    assert!(server_messages.iter().any(|message| {
+        matches!(
+            message,
+            ServerMessage::TxStatus {
+                tx_id: status_tx_id,
+                status: TxStatusKind::Rejected { code, .. }
+            } if status_tx_id == &tx_id && code == "upload_rejected"
+        )
+    }));
+}
+
+#[test]
+fn upload_insert_missing_required_field_returns_rejection_status() {
+    let harness = Harness::new();
+    let mut edge = harness.memory("edge", "service").unwrap();
+    let mut upstream = UpstreamConnectionManager::new_authenticated_for_test(
+        "edge-session",
+        "edge",
+        edge.local_schema_fingerprint(),
+        edge.local_policy_fingerprint(),
+        "alice",
+    );
+    let schema_fingerprint = edge.local_schema_fingerprint();
+    let policy_fingerprint = edge.local_policy_fingerprint();
+    let tx_id = "tx-alice-tab-9011".to_owned();
+
+    let server_messages = upstream
+        .receive(
+            &mut edge,
+            vec![
+                ClientMessage::Hello(ClientHello {
+                    protocol_version: ProtocolVersion(2),
+                    session_id: SessionId::new("tab-session"),
+                    node_id: "alice-tab".to_owned(),
+                    schema_fingerprint,
+                    policy_fingerprint,
+                }),
+                ClientMessage::UploadTx {
+                    tx: ClientTx {
+                        tx_id: tx_id.clone(),
+                        branch_id: None,
+                        conflict_mode: TxConflictMode::Mergeable,
+                        created_at: 1,
+                        author: None,
+                    },
+                    data: vec![ClientDataRecord {
+                        table: "todos".to_owned(),
+                        row_id: "todo-missing-field".to_owned(),
+                        op: DataOp::Insert,
+                        values: BTreeMap::from([("title".to_owned(), json!("Missing project"))]),
+                    }],
+                    reads: Vec::new(),
+                },
+            ],
+        )
+        .unwrap();
+
+    assert!(!upstream.is_closed());
+    assert!(server_messages.iter().any(|message| {
+        matches!(
+            message,
+            ServerMessage::TxStatus {
+                tx_id: status_tx_id,
+                status: TxStatusKind::Rejected { code, .. }
+            } if status_tx_id == &tx_id && code == "upload_rejected"
+        )
+    }));
+}
+
+#[test]
+fn upload_system_field_returns_rejection_status() {
+    let harness = Harness::new();
+    let mut edge = harness.memory("edge", "service").unwrap();
+    let mut upstream = UpstreamConnectionManager::new_authenticated_for_test(
+        "edge-session",
+        "edge",
+        edge.local_schema_fingerprint(),
+        edge.local_policy_fingerprint(),
+        "alice",
+    );
+    let schema_fingerprint = edge.local_schema_fingerprint();
+    let policy_fingerprint = edge.local_policy_fingerprint();
+    let tx_id = "tx-alice-tab-9012".to_owned();
+
+    let server_messages = upstream
+        .receive(
+            &mut edge,
+            vec![
+                ClientMessage::Hello(ClientHello {
+                    protocol_version: ProtocolVersion(2),
+                    session_id: SessionId::new("tab-session"),
+                    node_id: "alice-tab".to_owned(),
+                    schema_fingerprint,
+                    policy_fingerprint,
+                }),
+                ClientMessage::UploadTx {
+                    tx: ClientTx {
+                        tx_id: tx_id.clone(),
+                        branch_id: None,
+                        conflict_mode: TxConflictMode::Mergeable,
+                        created_at: 1,
+                        author: None,
+                    },
+                    data: vec![ClientDataRecord {
+                        table: "projects".to_owned(),
+                        row_id: "project-system-field".to_owned(),
+                        op: DataOp::Insert,
+                        values: BTreeMap::from([
+                            ("title".to_owned(), json!("System field")),
+                            ("j_created_at".to_owned(), json!(1)),
+                        ]),
+                    }],
+                    reads: Vec::new(),
+                },
+            ],
+        )
+        .unwrap();
+
+    assert!(!upstream.is_closed());
+    assert!(server_messages.iter().any(|message| {
+        matches!(
+            message,
+            ServerMessage::TxStatus {
+                tx_id: status_tx_id,
+                status: TxStatusKind::Rejected {
+                    code,
+                    detail: Some(detail)
+                }
+            } if status_tx_id == &tx_id
+                && code == "upload_rejected"
+                && detail["message"].as_str().is_some_and(|message| {
+                    message.contains("system fields")
+                })
+        )
+    }));
+}
+
+#[test]
+fn connection_manager_rejects_upload_ack_before_handshake_without_marking_ack() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    tab.create_project("project-1", "Upload plan").unwrap();
+    let mut downstream = DownstreamConnectionManager::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+
+    let _open_messages = downstream.open().unwrap();
+    let result = downstream.receive(
+        &mut tab,
+        vec![ServerMessage::UploadAck {
+            tx_id: "tx-alice-tab-1".to_owned(),
+        }],
+    );
+
+    assert!(result.is_err());
+    assert!(downstream.is_closed());
+    assert_eq!(tab.upload_ack_count_for_test().unwrap(), 0);
+}
+
+#[test]
+fn connection_manager_ignores_upload_ack_for_not_in_flight_tx() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    tab.create_project("project-1", "Upload plan").unwrap();
+    tab.create_todo("todo-upload-loop", "Flush after hello", false, "project-1")
+        .unwrap();
+
+    let mut downstream = DownstreamConnectionManager::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamConnectionManager::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    let server_messages = upstream
+        .receive(&mut worker, downstream.open().unwrap())
+        .unwrap();
+    let upload_messages = downstream.receive(&mut tab, server_messages).unwrap();
+    assert!(upload_messages
+        .iter()
+        .any(|message| matches!(message, ClientMessage::UploadTx { .. })));
+
+    downstream
+        .receive(
+            &mut tab,
+            vec![ServerMessage::UploadAck {
+                tx_id: "unknown-upload-tx".to_owned(),
+            }],
+        )
+        .unwrap();
+
+    assert_eq!(tab.upload_ack_count_for_test().unwrap(), 0);
+}
+
+#[test]
+fn connection_manager_ack_frees_slot_without_resending_acked_upload() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    tab.create_project("project-1", "Upload plan").unwrap();
+    tab.create_todo("todo-upload-next", "Next after ack", false, "project-1")
+        .unwrap();
+
+    let mut downstream = DownstreamConnectionManager::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+    downstream.set_max_in_flight_uploads_for_test(1);
+    let mut upstream = UpstreamConnectionManager::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    let server_messages = upstream
+        .receive(&mut worker, downstream.open().unwrap())
+        .unwrap();
+    let first_messages = downstream.receive(&mut tab, server_messages).unwrap();
+    let first_uploads = upload_tx_ids(&first_messages);
+    assert_eq!(first_uploads.len(), 1);
+    let first_tx_id = first_uploads[0].clone();
+
+    let second_messages = downstream
+        .receive(
+            &mut tab,
+            vec![ServerMessage::UploadAck {
+                tx_id: first_tx_id.clone(),
+            }],
+        )
+        .unwrap();
+    let second_uploads = upload_tx_ids(&second_messages);
+
+    assert_eq!(tab.upload_ack_count_for_test().unwrap(), 1);
+    assert_eq!(second_uploads.len(), 1);
+    assert_ne!(second_uploads[0], first_tx_id);
+}
+
+#[test]
+fn connection_manager_replays_acked_incomplete_upload_after_reconnect() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+    let tx_id = tab
+        .create_project("project-reconnect", "Replay me")
+        .unwrap();
+
+    let mut downstream = DownstreamConnectionManager::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamConnectionManager::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    let server_messages = upstream
+        .receive(&mut worker, downstream.open().unwrap())
+        .unwrap();
+    let first_messages = downstream.receive(&mut tab, server_messages).unwrap();
+    assert_eq!(upload_tx_ids(&first_messages), vec![tx_id.clone()]);
+
+    let after_ack = downstream
+        .receive(
+            &mut tab,
+            vec![ServerMessage::UploadAck {
+                tx_id: tx_id.clone(),
+            }],
+        )
+        .unwrap();
+    assert!(upload_tx_ids(&after_ack).is_empty());
+    assert_eq!(tab.upload_ack_count_for_test().unwrap(), 1);
+
+    let mut reconnected_upstream = UpstreamConnectionManager::new(
+        "worker-session-reconnected",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+    let server_messages = reconnected_upstream
+        .receive(&mut worker, downstream.open().unwrap())
+        .unwrap();
+    let replay_messages = downstream.receive(&mut tab, server_messages).unwrap();
+
+    assert_eq!(upload_tx_ids(&replay_messages), vec![tx_id]);
+}
+
+#[test]
 fn connection_manager_queues_subscribe_until_handshake_is_ready() {
     let harness = Harness::new();
     let mut tab = harness.memory("alice-tab", "alice").unwrap();
@@ -1762,19 +2607,17 @@ fn connection_manager_ignores_late_frames_for_locally_dropped_subscription() {
     let unsubscribe_messages = downstream.unsubscribe(&subscription).unwrap();
     let client_messages = downstream.receive(&mut tab, server_messages).unwrap();
 
-    assert!(unsubscribe_messages.iter().any(|message| {
-        matches!(
-            message,
-            ClientMessage::Replay { subscriptions } if subscriptions.is_empty()
-        )
-    }));
+    let [ClientMessage::Unsubscribe { subscription_id }] = unsubscribe_messages.as_slice() else {
+        panic!("expected one unsubscribe message");
+    };
+    assert_eq!(subscription_id, subscription.id());
     assert!(client_messages.is_empty());
     assert!(!downstream.is_closed());
     assert!(tab.query(query).unwrap().is_empty());
 }
 
 #[test]
-fn connection_manager_unsubscribe_replays_remaining_interest_upstream() {
+fn connection_manager_unsubscribe_sends_targeted_unsubscribe_upstream() {
     let harness = Harness::new();
     let mut tab = harness.memory("alice-tab", "alice").unwrap();
     let mut worker = harness.memory("alice-worker", "alice").unwrap();
@@ -1813,15 +2656,14 @@ fn connection_manager_unsubscribe_replays_remaining_interest_upstream() {
     upstream.receive(&mut worker, dropped_messages).unwrap();
     upstream.receive(&mut worker, kept_messages).unwrap();
 
-    let replay_messages = downstream.unsubscribe(&dropped_subscription).unwrap();
+    let unsubscribe_messages = downstream.unsubscribe(&dropped_subscription).unwrap();
 
-    let [ClientMessage::Replay { subscriptions }] = replay_messages.as_slice() else {
-        panic!("expected one replay message");
+    let [ClientMessage::Unsubscribe { subscription_id }] = unsubscribe_messages.as_slice() else {
+        panic!("expected one unsubscribe message");
     };
-    assert_eq!(subscriptions.len(), 1);
-    assert_eq!(subscriptions[0].subscription_id, *kept_subscription.id());
+    assert_eq!(subscription_id, dropped_subscription.id());
 
-    upstream.receive(&mut worker, replay_messages).unwrap();
+    upstream.receive(&mut worker, unsubscribe_messages).unwrap();
 
     assert!(!upstream.has_active_subscription(dropped_subscription.id()));
     assert!(upstream.has_active_subscription(kept_subscription.id()));
@@ -1928,6 +2770,16 @@ fn sorted_row_ids(rows: Vec<mini_jazz_sqlite::RowView>) -> Vec<String> {
     let mut ids = row_ids(rows);
     ids.sort();
     ids
+}
+
+fn upload_tx_ids(messages: &[ClientMessage]) -> Vec<String> {
+    messages
+        .iter()
+        .filter_map(|message| match message {
+            ClientMessage::UploadTx { tx, .. } => Some(tx.tx_id.clone()),
+            _ => None,
+        })
+        .collect()
 }
 
 fn drain_server_messages(

--- a/crates/mini-jazz-sqlite/tests/whole_system/connection.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/connection.rs
@@ -942,10 +942,9 @@ fn connection_upstream_requires_auth_for_upload_tx_after_handshake() {
     assert!(matches!(
         drain_server_messages(&mut downstream_conn).as_slice(),
         [
-            ServerMessage::UploadAck { tx_id },
             ServerMessage::Error(error),
             ServerMessage::Close(CloseReason::ProtocolError)
-        ] if tx_id == "tx-1" && error.code == "auth_required"
+        ] if error.code == "auth_required"
     ));
 }
 
@@ -1862,6 +1861,43 @@ fn connection_manager_flushes_uploads_after_handshake() {
 }
 
 #[test]
+fn connection_manager_flushes_new_local_upload_on_quiet_connection() {
+    let harness = Harness::new();
+    let mut tab = harness.memory("alice-tab", "alice").unwrap();
+    let mut worker = harness.memory("alice-worker", "alice").unwrap();
+
+    let mut downstream = DownstreamConnectionManager::new(
+        "tab-session",
+        "alice-tab",
+        tab.local_schema_fingerprint(),
+        tab.local_policy_fingerprint(),
+    );
+    let mut upstream = UpstreamConnectionManager::new(
+        "worker-session",
+        "alice-worker",
+        worker.local_schema_fingerprint(),
+        worker.local_policy_fingerprint(),
+    );
+
+    let server_messages = upstream
+        .receive(&mut worker, downstream.open().unwrap())
+        .unwrap();
+    assert!(downstream
+        .receive(&mut tab, server_messages)
+        .unwrap()
+        .is_empty());
+
+    let tx_id = tab
+        .create_project("project-quiet-upload", "Quiet upload")
+        .unwrap();
+    let client_messages = downstream.flush(&mut tab).unwrap();
+
+    assert!(client_messages.iter().any(|message| {
+        matches!(message, ClientMessage::UploadTx { tx, .. } if tx.tx_id == tx_id)
+    }));
+}
+
+#[test]
 fn upstream_upload_tx_gets_ack_and_edge_status() {
     let harness = Harness::new();
     let mut tab = harness.memory("alice-tab", "alice").unwrap();
@@ -1916,6 +1952,14 @@ fn upstream_upload_tx_gets_ack_and_edge_status() {
         .unwrap()
         .iter()
         .any(|upload| upload.tx.tx_id == tx_id));
+    let uploaded_tx = worker
+        .export_table_history("todos")
+        .unwrap()
+        .txs
+        .into_iter()
+        .find(|tx| tx.tx_id == tx_id)
+        .unwrap();
+    assert!(uploaded_tx.server_ingested_at.is_some());
 }
 
 #[test]

--- a/crates/mini-jazz-sqlite/tests/whole_system/sync_fate.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/sync_fate.rs
@@ -1157,8 +1157,9 @@ fn same_user_on_two_nodes_preserves_authorship_and_distinct_node_epochs() {
         )
         .unwrap();
 
-    assert_eq!(phone_tx, "tx-alice-phone-1");
-    assert_eq!(laptop_tx, "tx-alice-laptop-1");
+    assert_ne!(phone_tx, laptop_tx);
+    assert_eq!(phone_tx.len(), 36);
+    assert_eq!(laptop_tx.len(), 36);
 
     peer.apply_bundle(&alice_phone.export_table_history("notes").unwrap())
         .unwrap();

--- a/crates/mini-jazz-sqlite/tests/whole_system/transactions.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/transactions.rs
@@ -393,6 +393,38 @@ fn upload_queue_completes_when_global_receipt_arrives_in_bundle() {
 }
 
 #[test]
+fn upload_queue_completes_when_rejection_arrives_in_bundle() {
+    let mut alice = Runtime::open(Storage::Memory, "alice-node", "alice").unwrap();
+    alice
+        .create_project("project-1", "Bundle rejection")
+        .unwrap();
+    let tx_id = alice
+        .create_todo(
+            "todo-bundle-rejected",
+            "Rejected from bundle",
+            false,
+            "project-1",
+        )
+        .unwrap();
+    let mut bundle = alice.export_table_history("todos").unwrap();
+    let tx = bundle.txs.iter_mut().find(|tx| tx.tx_id == tx_id).unwrap();
+    tx.outcome = 3;
+    tx.rejection_code = Some("server_rejected".to_owned());
+
+    alice.apply_bundle(&bundle).unwrap();
+
+    assert!(!alice
+        .active_uploads_for_test(10)
+        .unwrap()
+        .iter()
+        .any(|upload| upload.tx.tx_id == tx_id));
+    assert_eq!(
+        alice.transaction_info(&tx_id).unwrap().rejection_code,
+        Some("server_rejected".to_owned())
+    );
+}
+
+#[test]
 fn rejecting_multi_row_transaction_hides_all_written_rows_but_keeps_history() {
     let mut alice = Runtime::open(Storage::Memory, "alice-node", "alice").unwrap();
 

--- a/crates/mini-jazz-sqlite/tests/whole_system/transactions.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/transactions.rs
@@ -56,7 +56,7 @@ fn committed_transaction_uses_opaque_uuid_tx_id() {
 }
 
 #[test]
-fn committed_transaction_enters_upload_queue_with_delta_payload() {
+fn committed_transaction_enters_upload_queue_with_row_image_payload() {
     let mut alice = Runtime::open(Storage::Memory, "alice-node", "alice").unwrap();
     alice.create_project("project-1", "Upload plan").unwrap();
 
@@ -83,11 +83,18 @@ fn committed_transaction_enters_upload_queue_with_delta_payload() {
     assert_eq!(upload.data.len(), 1);
     assert_eq!(upload.data[0].table, "todos");
     assert_eq!(upload.data[0].row_id, "todo-upload-1");
-    assert_eq!(upload.data[0].values["title"], json!("Upload one tx"));
+    assert_eq!(
+        upload.data[0].values,
+        BTreeMap::from([
+            ("done".to_owned(), json!(false)),
+            ("project".to_owned(), json!("project-1")),
+            ("title".to_owned(), json!("Upload one tx")),
+        ])
+    );
 }
 
 #[test]
-fn update_upload_payload_keeps_only_delta_values() {
+fn update_upload_payload_contains_effective_row_image() {
     let mut alice = Runtime::open(Storage::Memory, "alice-node", "alice").unwrap();
     alice.create_project("project-1", "Upload plan").unwrap();
     alice
@@ -112,7 +119,11 @@ fn update_upload_payload_keeps_only_delta_values() {
         .expect("queued update");
     assert_eq!(
         upload.data[0].values,
-        BTreeMap::from([("title".to_owned(), json!("Changed"))])
+        BTreeMap::from([
+            ("done".to_owned(), json!(false)),
+            ("project".to_owned(), json!("project-1")),
+            ("title".to_owned(), json!("Changed")),
+        ])
     );
 }
 
@@ -332,9 +343,9 @@ fn upload_queue_cleanup_prunes_only_completed_rows() {
     alice
         .apply_tx_status_for_test(&completed, TxStatusKind::EdgeAccepted)
         .unwrap();
-    assert_eq!(alice.upload_queue_counts_for_test().unwrap(), (3, 3));
+    assert_eq!(alice.upload_queue_count_for_test().unwrap(), 3);
     alice.cleanup_completed_uploads_for_test(0, 10).unwrap();
-    assert_eq!(alice.upload_queue_counts_for_test().unwrap(), (2, 2));
+    assert_eq!(alice.upload_queue_count_for_test().unwrap(), 2);
 
     let active_uploads = alice.active_uploads_for_test(10).unwrap();
     assert!(!active_uploads

--- a/crates/mini-jazz-sqlite/tests/whole_system/transactions.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/transactions.rs
@@ -1,4 +1,5 @@
 use super::*;
+use mini_jazz_sqlite::protocol::{DataOp, TxStatusKind};
 
 #[test]
 fn explicit_transaction_seals_multiple_mutations_atomically() {
@@ -39,6 +40,327 @@ fn explicit_transaction_seals_multiple_mutations_atomically() {
     let stats = alice.storage_stats().unwrap();
     assert_eq!(stats.history_rows, 3);
     assert_eq!(stats.current_rows, 3);
+}
+
+#[test]
+fn committed_transaction_enters_upload_queue_with_delta_payload() {
+    let mut alice = Runtime::open(Storage::Memory, "alice-node", "alice").unwrap();
+    alice.create_project("project-1", "Upload plan").unwrap();
+
+    let tx_id = alice
+        .transaction()
+        .insert_row(
+            "todos",
+            "todo-upload-1",
+            BTreeMap::from([
+                ("title".to_owned(), json!("Upload one tx")),
+                ("done".to_owned(), json!(false)),
+                ("project".to_owned(), json!("project-1")),
+            ]),
+        )
+        .commit()
+        .unwrap();
+
+    let queued = alice.active_uploads_for_test(10).unwrap();
+    assert!(queued.iter().any(|upload| upload.tx.tx_id == tx_id));
+    let upload = queued
+        .iter()
+        .find(|upload| upload.tx.tx_id == tx_id)
+        .expect("queued upload");
+    assert_eq!(upload.data.len(), 1);
+    assert_eq!(upload.data[0].table, "todos");
+    assert_eq!(upload.data[0].row_id, "todo-upload-1");
+    assert_eq!(upload.data[0].values["title"], json!("Upload one tx"));
+}
+
+#[test]
+fn update_upload_payload_keeps_only_delta_values() {
+    let mut alice = Runtime::open(Storage::Memory, "alice-node", "alice").unwrap();
+    alice.create_project("project-1", "Upload plan").unwrap();
+    alice
+        .create_todo("todo-upload-2", "Original", false, "project-1")
+        .unwrap();
+
+    let tx_id = alice
+        .transaction()
+        .update_row(
+            "todos",
+            "todo-upload-2",
+            BTreeMap::from([("title".to_owned(), json!("Changed"))]),
+        )
+        .commit()
+        .unwrap();
+
+    let upload = alice
+        .active_uploads_for_test(10)
+        .unwrap()
+        .into_iter()
+        .find(|upload| upload.tx.tx_id == tx_id)
+        .expect("queued update");
+    assert_eq!(
+        upload.data[0].values,
+        BTreeMap::from([("title".to_owned(), json!("Changed"))])
+    );
+}
+
+#[test]
+fn delete_upload_payload_is_empty_tombstone() {
+    let mut alice = Runtime::open(Storage::Memory, "alice-node", "alice").unwrap();
+    alice.create_project("project-1", "Upload plan").unwrap();
+    alice
+        .create_todo("todo-upload-delete", "Delete upload", false, "project-1")
+        .unwrap();
+
+    let tx_id = alice.delete_row("todos", "todo-upload-delete").unwrap();
+
+    let upload = alice
+        .active_uploads_for_test(10)
+        .unwrap()
+        .into_iter()
+        .find(|upload| upload.tx.tx_id == tx_id)
+        .expect("queued delete");
+    assert_eq!(upload.data.len(), 1);
+    assert_eq!(upload.data[0].table, "todos");
+    assert_eq!(upload.data[0].row_id, "todo-upload-delete");
+    assert_eq!(upload.data[0].op, DataOp::Delete);
+    assert!(upload.data[0].values.is_empty());
+}
+
+#[test]
+fn branch_upload_payload_records_non_default_branch() {
+    let schema = support::notes_schema();
+    let mut alice =
+        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema).unwrap();
+    alice.create_branch("draft", None).unwrap();
+    alice.checkout_branch("draft").unwrap();
+
+    let tx_id = alice
+        .insert_row(
+            "notes",
+            "note-upload-branch",
+            BTreeMap::from([
+                ("body".to_owned(), json!("Branch upload")),
+                ("pinned".to_owned(), json!(false)),
+            ]),
+        )
+        .unwrap();
+
+    let upload = alice
+        .active_uploads_for_test(10)
+        .unwrap()
+        .into_iter()
+        .find(|upload| upload.tx.tx_id == tx_id)
+        .expect("queued branch upload");
+    assert_eq!(upload.tx.branch_id.as_deref(), Some("draft"));
+    assert_eq!(upload.data[0].table, "notes");
+    assert_eq!(upload.data[0].row_id, "note-upload-branch");
+}
+
+#[test]
+fn upload_author_comes_from_transaction_not_current_session() {
+    let mut alice = Runtime::open(Storage::Memory, "alice-node", "alice").unwrap();
+    alice.create_project("project-1", "Upload author").unwrap();
+
+    let tx_id = alice
+        .create_todo(
+            "todo-upload-author",
+            "Authored by Alice",
+            false,
+            "project-1",
+        )
+        .unwrap();
+    alice.session_user_for_test("bob");
+
+    let upload = alice
+        .active_uploads_for_test(10)
+        .unwrap()
+        .into_iter()
+        .find(|upload| upload.tx.tx_id == tx_id)
+        .expect("queued authored upload");
+    assert_eq!(upload.tx.author.as_deref(), Some("alice"));
+}
+
+#[test]
+fn locally_rejected_transaction_is_not_active_upload() {
+    let schema = SchemaDef::new().table("docs", |table| {
+        table.text("title");
+        table.write_if_created_by_user();
+    });
+    let mut alice =
+        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema).unwrap();
+    alice
+        .insert_row(
+            "docs",
+            "doc-rejected-upload",
+            BTreeMap::from([("title".to_owned(), json!("Alice draft"))]),
+        )
+        .unwrap();
+    alice.session_user_for_test("bob");
+
+    let rejected_tx = alice
+        .update_row(
+            "docs",
+            "doc-rejected-upload",
+            BTreeMap::from([("title".to_owned(), json!("Bob rewrite"))]),
+        )
+        .unwrap();
+
+    assert_eq!(
+        alice.transaction_info(&rejected_tx).unwrap().rejection_code,
+        Some("policy_denied".to_owned())
+    );
+    assert!(!alice
+        .active_uploads_for_test(10)
+        .unwrap()
+        .iter()
+        .any(|upload| upload.tx.tx_id == rejected_tx));
+}
+
+#[test]
+fn mergeable_upload_queue_completes_on_edge_status() {
+    let mut alice = Runtime::open(Storage::Memory, "alice-node", "alice").unwrap();
+    alice.create_project("project-1", "Upload plan").unwrap();
+    let tx_id = alice
+        .create_todo("todo-edge", "Edge completes", false, "project-1")
+        .unwrap();
+
+    alice
+        .apply_tx_status_for_test(&tx_id, TxStatusKind::EdgeAccepted)
+        .unwrap();
+
+    assert!(!alice
+        .active_uploads_for_test(10)
+        .unwrap()
+        .iter()
+        .any(|upload| upload.tx.tx_id == tx_id));
+    assert!(alice
+        .transaction_info(&tx_id)
+        .unwrap()
+        .receipt_tiers
+        .contains(&"edge".to_owned()));
+}
+
+#[test]
+fn exclusive_upload_queue_ignores_edge_status_for_completion() {
+    let mut alice = Runtime::open(Storage::Memory, "alice-node", "alice").unwrap();
+    alice.create_project("project-1", "Upload plan").unwrap();
+    let tx_id = alice
+        .transaction()
+        .exclusive_at_global(7)
+        .insert_row(
+            "todos",
+            "todo-exclusive",
+            BTreeMap::from([
+                ("title".to_owned(), json!("Exclusive")),
+                ("done".to_owned(), json!(false)),
+                ("project".to_owned(), json!("project-1")),
+            ]),
+        )
+        .commit()
+        .unwrap();
+
+    alice
+        .apply_tx_status_for_test(&tx_id, TxStatusKind::EdgeAccepted)
+        .unwrap();
+
+    assert!(alice
+        .transaction_info(&tx_id)
+        .unwrap()
+        .receipt_tiers
+        .contains(&"edge".to_owned()));
+    assert!(alice
+        .active_uploads_for_test(10)
+        .unwrap()
+        .iter()
+        .any(|upload| upload.tx.tx_id == tx_id));
+}
+
+#[test]
+fn exclusive_upload_queue_completes_on_global_status() {
+    let mut alice = Runtime::open(Storage::Memory, "alice-node", "alice").unwrap();
+    alice.create_project("project-1", "Upload plan").unwrap();
+    let tx_id = alice
+        .transaction()
+        .exclusive_at_global(7)
+        .insert_row(
+            "todos",
+            "todo-exclusive-global",
+            BTreeMap::from([
+                ("title".to_owned(), json!("Exclusive global")),
+                ("done".to_owned(), json!(false)),
+                ("project".to_owned(), json!("project-1")),
+            ]),
+        )
+        .commit()
+        .unwrap();
+
+    alice
+        .apply_tx_status_for_test(&tx_id, TxStatusKind::GlobalAccepted { global_epoch: 7 })
+        .unwrap();
+
+    assert!(!alice
+        .active_uploads_for_test(10)
+        .unwrap()
+        .iter()
+        .any(|upload| upload.tx.tx_id == tx_id));
+}
+
+#[test]
+fn upload_queue_cleanup_prunes_only_completed_rows() {
+    let mut alice = Runtime::open(Storage::Memory, "alice-node", "alice").unwrap();
+    alice.create_project("project-1", "Upload cleanup").unwrap();
+    let completed = alice
+        .create_todo("todo-clean-complete", "Complete", false, "project-1")
+        .unwrap();
+    let active = alice
+        .create_todo("todo-clean-active", "Active", false, "project-1")
+        .unwrap();
+
+    alice
+        .apply_tx_status_for_test(&completed, TxStatusKind::EdgeAccepted)
+        .unwrap();
+    assert_eq!(alice.upload_queue_counts_for_test().unwrap(), (3, 3));
+    alice.cleanup_completed_uploads_for_test(0, 10).unwrap();
+    assert_eq!(alice.upload_queue_counts_for_test().unwrap(), (2, 2));
+
+    let active_uploads = alice.active_uploads_for_test(10).unwrap();
+    assert!(!active_uploads
+        .iter()
+        .any(|upload| upload.tx.tx_id == completed));
+    assert!(active_uploads
+        .iter()
+        .any(|upload| upload.tx.tx_id == active));
+}
+
+#[test]
+fn rejected_upload_queue_completes_and_records_rejection_code() {
+    let mut alice = Runtime::open(Storage::Memory, "alice-node", "alice").unwrap();
+    alice
+        .create_project("project-1", "Upload rejection")
+        .unwrap();
+    let tx_id = alice
+        .create_todo("todo-rejected-upload", "Rejected", false, "project-1")
+        .unwrap();
+
+    alice
+        .apply_tx_status_for_test(
+            &tx_id,
+            TxStatusKind::Rejected {
+                code: "server_rejected".to_owned(),
+                detail: None,
+            },
+        )
+        .unwrap();
+
+    assert!(!alice
+        .active_uploads_for_test(10)
+        .unwrap()
+        .iter()
+        .any(|upload| upload.tx.tx_id == tx_id));
+    assert_eq!(
+        alice.transaction_info(&tx_id).unwrap().rejection_code,
+        Some("server_rejected".to_owned())
+    );
 }
 
 #[test]

--- a/crates/mini-jazz-sqlite/tests/whole_system/transactions.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/transactions.rs
@@ -364,6 +364,35 @@ fn rejected_upload_queue_completes_and_records_rejection_code() {
 }
 
 #[test]
+fn upload_queue_completes_when_global_receipt_arrives_in_bundle() {
+    let mut alice = Runtime::open(Storage::Memory, "alice-node", "alice").unwrap();
+    alice
+        .create_project("project-1", "Bundle completion")
+        .unwrap();
+    let tx_id = alice
+        .create_todo(
+            "todo-bundle-complete",
+            "Complete from bundle",
+            false,
+            "project-1",
+        )
+        .unwrap();
+    let mut bundle = alice.export_table_history("todos").unwrap();
+    let tx = bundle.txs.iter_mut().find(|tx| tx.tx_id == tx_id).unwrap();
+    tx.global_epoch = Some(9);
+    tx.outcome = 2;
+    tx.receipt_tiers.push(3);
+
+    alice.apply_bundle(&bundle).unwrap();
+
+    assert!(!alice
+        .active_uploads_for_test(10)
+        .unwrap()
+        .iter()
+        .any(|upload| upload.tx.tx_id == tx_id));
+}
+
+#[test]
 fn rejecting_multi_row_transaction_hides_all_written_rows_but_keeps_history() {
     let mut alice = Runtime::open(Storage::Memory, "alice-node", "alice").unwrap();
 

--- a/crates/mini-jazz-sqlite/tests/whole_system/transactions.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/transactions.rs
@@ -43,6 +43,19 @@ fn explicit_transaction_seals_multiple_mutations_atomically() {
 }
 
 #[test]
+fn committed_transaction_uses_opaque_uuid_tx_id() {
+    let mut alice = Runtime::open(Storage::Memory, "alice-node", "alice").unwrap();
+
+    let tx_id = alice
+        .create_project("project-opaque-tx-id", "Opaque tx id")
+        .unwrap();
+
+    assert_eq!(tx_id.len(), 36);
+    assert_eq!(tx_id.chars().filter(|ch| *ch == '-').count(), 4);
+    assert!(!tx_id.starts_with("tx-alice-node-"));
+}
+
+#[test]
 fn committed_transaction_enters_upload_queue_with_delta_payload() {
     let mut alice = Runtime::open(Storage::Memory, "alice-node", "alice").unwrap();
     alice.create_project("project-1", "Upload plan").unwrap();
@@ -579,7 +592,7 @@ fn generic_update_records_previous_row_read_set() {
     let mut alice =
         Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema).unwrap();
 
-    alice
+    let original_tx = alice
         .insert_row(
             "notes",
             "note-1",
@@ -606,11 +619,7 @@ fn generic_update_records_previous_row_read_set() {
     );
     assert_eq!(
         alice.transaction_observed_read_rows(&tx).unwrap(),
-        vec![(
-            "notes".to_owned(),
-            "note-1".to_owned(),
-            Some("tx-alice-node-1".to_owned())
-        )]
+        vec![("notes".to_owned(), "note-1".to_owned(), Some(original_tx))]
     );
 }
 

--- a/docs/superpowers/specs/2026-06-01-mini-jazz-sqlite-client-data-protocol.md
+++ b/docs/superpowers/specs/2026-06-01-mini-jazz-sqlite-client-data-protocol.md
@@ -1,0 +1,466 @@
+# mini-jazz-sqlite - Client Transaction Upload Protocol
+
+**Date:** 2026-06-01
+**Status:** Design checkpoint
+**Scope:** Defines the client-to-server data upload path, reconnect reconciliation
+from the client upload queue, upload acknowledgement semantics, transaction status
+messages, and targeted unsubscribe behavior.
+
+## Problem
+
+The current sync protocol is effectively download/subscription-oriented. Clients can
+subscribe, replay subscriptions, acknowledge server data, and close, but they do not
+have a clear protocol for asking an upstream peer to process local transactions.
+
+This creates three gaps:
+
+- clients have no dedicated message for sending local transaction data
+- reconnect has no client-to-server reconciliation path for locally committed
+  transactions that were not filed before shutdown
+- unsubscribe is modeled as `Replay` with a reduced subscription set, forcing the
+  server to diff interests and often resend remaining subscriptions unnecessarily
+
+## Design Summary
+
+Client upload is transaction-scoped.
+
+One `ClientMessage::UploadTx` uploads one transaction. A transaction may contain multiple
+row mutations across multiple tables. Transport-level batching may coalesce many
+protocol messages into one WebSocket frame or `postMessage` delivery, but the protocol
+message remains one transaction.
+
+The client keeps a durable upload queue. Every normal committed local transaction is
+inserted into that queue atomically with the transaction commit. After connection
+handshake, the client sends queued transactions ordered by `(created_at, sync_seq)`,
+with up to `max_in_flight_uploads` unacknowledged uploads. The initial default is
+`1000`; negotiation can be added later if servers need to advertise lower capacity.
+
+Upload ACK is flow control only:
+
+```text
+Server -> UploadAck { tx_id }
+```
+
+It means the server received the upload message on this connection. It does not mean
+the transaction was durably stored, accepted, edge-filed, globally accepted, or
+rejected.
+
+Transaction fate/progress is reported separately:
+
+```text
+Server -> TxStatus { tx_id, status }
+```
+
+`TxStatus` is non-cumulative. `GlobalAccepted` implies edge satisfaction for retry and
+wait checks, but storage does not need to materialize an edge receipt when only a global
+receipt exists.
+
+## Protocol Messages
+
+### Client Upload
+
+```rust
+ClientMessage::UploadTx {
+    tx: ClientTx,
+    data: Vec<ClientDataRecord>,
+    reads: Vec<ReadRecord>,
+}
+```
+
+`data` must be non-empty.
+
+`reads` uses the existing `ReadRecord` shape for now. The read-set model is expected to
+change soon, so this design does not introduce a new read-set protocol type.
+
+### Client Transaction Header
+
+```rust
+struct ClientTx {
+    tx_id: String,
+    branch_id: Option<String>,
+    conflict_mode: TxConflictMode,
+    created_at: i64,
+    author: Option<String>,
+}
+```
+
+`branch_id` semantics:
+
+- `Some(branch_id)` applies the transaction to that branch.
+- `None` applies the transaction to the connection/session default branch.
+- If no default branch exists, the message is malformed for that session.
+
+`author` semantics:
+
+- for untrusted client connections, the receiver ignores `author` and uses the
+  authenticated session user
+- for trusted peer connections, `author` is required and may be preserved as
+  authoritative provenance
+
+`created_at` is the transaction timestamp used for client-side upload ordering. The
+server processes messages in transport receive order. WebSocket and `postMessage`
+provide ordered delivery for the intended transports; unordered transports must provide
+an ordered stream abstraction below this protocol.
+
+There is no `target_tier` in the message. Upload retry completion is independent of a
+requested tier and is driven by authoritative local transaction fate.
+
+### Client Data Record
+
+```rust
+struct ClientDataRecord {
+    table: String,
+    row_id: String,
+    op: DataOp,
+    values: BTreeMap<String, JsonValue>,
+}
+```
+
+`values` is delta-shaped:
+
+- `Insert`: values contain the proposed fields for a new row
+- `Update`: values contain only changed fields
+- `Delete`: values must be empty
+
+System fields such as `j_created_at`, `j_updated_at`, `j_created_by`, and
+`j_updated_by` are not valid inside `values`. They are derived from `ClientTx` and the
+connection trust context.
+
+Row ids and reference field values use public ids on the wire. The receiver hydrates
+them into local physical ids before storage.
+
+One transaction must not contain multiple `ClientDataRecord`s for the same
+`(table, row_id)`. The client normalizes repeated mutations before upload.
+
+### Data Operations
+
+```rust
+enum DataOp {
+    Insert,
+    Update,
+    Delete,
+}
+```
+
+`Insert` against an existing row is a transaction rejection.
+
+`Update` against a row missing from the local server should fetch/wait for
+authoritative state when the row might exist upstream. It is rejected only after
+authoritative absence is known.
+
+`Delete` with non-empty `values` is malformed for MVP.
+
+### Conflict Mode
+
+```rust
+enum TxConflictMode {
+    Mergeable,
+    Exclusive,
+}
+```
+
+Mergeable transactions may omit reads by sending an empty `reads` vector.
+
+Exclusive or conflict-sensitive transactions require the read facts needed for
+validation. Missing or incomplete reads are a transaction rejection, not a fatal
+protocol error.
+
+### Server Upload ACK
+
+```rust
+ServerMessage::UploadAck {
+    tx_id: String,
+}
+```
+
+`UploadAck` means the server received the upload message on this connection and the
+client may free one in-flight upload slot.
+
+`UploadAck` is ignored if the client has no matching in-flight upload.
+
+`UploadAck` for an already completed transaction is also ignored except for in-flight
+bookkeeping.
+
+### Server Transaction Status
+
+```rust
+ServerMessage::TxStatus {
+    tx_id: String,
+    status: TxStatusKind,
+}
+
+enum TxStatusKind {
+    EdgeAccepted,
+    GlobalAccepted { global_epoch: i64 },
+    Rejected {
+        code: String,
+        detail: Option<JsonValue>,
+    },
+}
+```
+
+The server only sends `TxStatus` when the transaction reaches edge, reaches global, or
+is rejected. It does not send pending or awaiting-dependency statuses.
+
+`TxStatus` is non-cumulative:
+
+- `EdgeAccepted` means edge filing/acceptance happened
+- `GlobalAccepted` means global filing/acceptance happened and satisfies edge-level
+  retry/wait checks
+- `Rejected` is terminal for upload retry
+
+Unknown `TxStatus` messages are ignored by the client for MVP.
+
+Applying `TxStatus` updates normal local transaction fate tables first. Upload queue
+completion is then derived from local tx fate, not from the status message path itself.
+
+## Client Upload Queue
+
+Every normal committed local transaction enters the upload queue atomically with the
+transaction commit. Registry insertion failure fails the commit.
+
+True local-only writes, if needed later, should be an explicit transaction mode that
+skips upload queue insertion.
+
+MVP schema:
+
+```sql
+CREATE TABLE jazz_tx_upload_queue (
+  sync_seq INTEGER PRIMARY KEY AUTOINCREMENT,
+  tx_num INTEGER NOT NULL UNIQUE,
+  status INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  completed_at INTEGER,
+  last_upload_attempt_at INTEGER,
+  last_ack_at INTEGER,
+  attempt_count INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX jazz_tx_upload_queue_active_idx
+ON jazz_tx_upload_queue(status, created_at, sync_seq)
+WHERE status = 1;
+```
+
+Status values:
+
+```text
+1 = active
+2 = completed
+```
+
+`sync_seq` is a stable local queue sequence assigned atomically with commit. It is used
+as a tie-breaker for upload order:
+
+```sql
+ORDER BY created_at, sync_seq
+```
+
+`sync_seq` is local-only and is not sent to the server.
+
+Upload queue completion rule for mergeable transactions:
+
+```text
+complete when local tx fate has:
+  edge receipt
+  OR global receipt
+  OR rejected outcome
+```
+
+Upload queue completion rule for exclusive transactions:
+
+```text
+complete when local tx fate has:
+  global receipt
+  OR rejected outcome
+```
+
+Exclusive transactions require global final fate. If an edge-only status or receipt is
+observed for an exclusive transaction, the client ignores it for upload queue completion.
+
+For retry/completion purposes, global acceptance satisfies edge. Existing receipt APIs can
+keep reporting literal stored receipts; higher-level satisfaction checks should treat
+global as satisfying edge.
+
+The queue is not completed by `UploadAck`. `UploadAck` is only in-flight flow
+control.
+
+Queue completion can be triggered by any authoritative local tx fate update:
+
+- `TxStatus`
+- subscription/query sync that applies a receipt or rejection
+- any other trusted sync path that enriches the local transaction record
+
+## Client Send Loop
+
+After `ServerHello`, the client starts upload reconciliation.
+
+The client:
+
+1. scans active queue rows ordered by `(created_at, sync_seq)`
+2. sends `ClientMessage::UploadTx` while `in_flight_uploads < max_in_flight_uploads`
+3. records `last_upload_attempt_at` and increments `attempt_count`
+4. tracks in-flight uploads by `tx_id`
+5. removes an in-flight tx when `UploadAck { tx_id }` arrives
+6. sends more queued transactions as upload ACKs free slots
+
+The default `max_in_flight_uploads` is `1000`.
+
+The client does not retry upload-acked transactions on the same healthy connection. If
+the connection drops, in-flight state is cleared and reconnect reconciliation replays
+active queue rows that are still not completed.
+
+If a queued transaction completes before its upload ACK arrives, the queue row is marked
+completed and any matching in-flight entry may be dropped.
+
+## Server Handling
+
+On `ClientMessage::UploadTx`, the server:
+
+1. verifies handshake/session is established
+2. verifies the connection is authenticated
+3. validates protocol shape
+4. sends `UploadAck { tx_id }` after parsing/accepting the message into the connection flow
+5. validates/applies the proposed transaction according to trust role and conflict mode
+6. emits `TxStatus` only when the tx reaches edge, reaches global, or is rejected
+
+For untrusted client connections:
+
+- policy validation uses the authenticated session user
+- `ClientTx.author` is ignored
+- row provenance is derived from the authenticated session and transaction timestamp
+- the client cannot forge edge/global acceptance, rejection, receipt state, catalogue
+  publication, or system fields
+
+For trusted peer connections:
+
+- `ClientTx.author` is required
+- trusted provenance may be preserved
+- the receiver may treat peer-provided transaction data as coming from a trusted sync
+  role, subject to the connection's authority level
+
+The server processes upload messages in receive order. Ordering is a transport
+requirement, not an application-level buffering/reordering protocol.
+
+If the server receives duplicate `UploadTx` for a tx it already knows, it still sends
+`UploadAck { tx_id }`. If the tx is already edge-accepted, globally accepted, or
+rejected, the server should also send the current `TxStatus` so the client can complete
+its queue quickly after reconnect.
+
+## Validation And Rejection
+
+Malformed protocol shape is fatal and closes the session.
+
+Examples:
+
+- `UploadTx` before handshake
+- missing transaction header
+- invalid enum tag
+- `branch_id = None` when the session has no default branch
+- empty `data`
+- delete record with non-empty values
+- system fields in `values`
+- duplicate `(table, row_id)` records in one transaction
+
+Semantically invalid transactions produce `TxStatus::Rejected` and do not close the
+session.
+
+Examples:
+
+- insert missing required fields
+- insert row that already exists
+- policy denied
+- stale read set
+- exclusive transaction missing required reads
+
+If an edge/server lacks authoritative state needed to validate an update/delete, it
+should fetch or wait for trusted upstream state when possible. Missing local state is not
+automatically a rejection.
+
+## Reconnect Reconciliation
+
+Reconnect has no special upload replay message. After handshake, the normal send loop
+scans `jazz_tx_upload_queue` and sends active transactions.
+
+This means clients still upload local transactions even when no subscription is active.
+
+Server-side implicit interest in uploaded txs is live-session state only. On disconnect,
+the server may forget it. The client upload queue is the durable source of truth and
+rebuilds interest by replaying still-active transactions after reconnect.
+
+## Unsubscribe
+
+Unsubscribe is a dedicated client message:
+
+```rust
+ClientMessage::Unsubscribe {
+    subscription_id: SubscriptionId,
+}
+```
+
+It is fire-and-forget.
+
+Server handling:
+
+- remove `active_subscriptions[subscription_id]`
+- remove pending download messages for that subscription
+- remove last acknowledged cursor for that subscription
+- do not touch upload queue state or uploaded-tx implicit interest
+- send no reply
+
+`Replay` remains subscription-only and is used for reconnect/full subscription
+reconciliation, not single-subscription drops.
+
+## Capability And Versioning
+
+This is a protocol-breaking change. Bump `SUPPORTED_PROTOCOL_VERSION` from `1` to `2`.
+
+Add a required server capability:
+
+```rust
+ProtocolCapabilities {
+    replay: bool,
+    acknowledgements: bool,
+    query_settlement: bool,
+    tx_upload: bool,
+}
+```
+
+Default `tx_upload` is `true`.
+
+Clients reject `ServerHello` if `tx_upload` is false.
+
+## Cleanup
+
+Upload queue cleanup only removes completed retry metadata. It never deletes transaction
+records, row data, history, receipts, or rejection details.
+
+Cleanup never deletes active rows, regardless of age.
+
+Default MVP cleanup policy:
+
+```text
+retention_age = 7 days
+max_completed_rows = 10_000
+delete_batch_size = 500
+min_cleanup_interval = 60 seconds
+```
+
+Run cleanup:
+
+- on runtime open/startup
+- after marking transactions completed, rate-limited
+- through an explicit maintenance API for tests/tools
+
+Accepted and rejected completed upload queue rows use the same retention policy. Durable
+rejection detail lives in transaction fate tables, not in the upload queue.
+
+## Out Of Scope
+
+- negotiated `max_in_flight_uploads`
+- unordered transport recovery
+- compact/delta optimization for `TxStatus`
+- final read-set protocol shape
+- true local-only transaction mode
+- richer receipt metadata such as authority identity, receipt timestamp, signatures, or
+  audit payload
+- server-durable client interest/inbox for uploaded txs

--- a/docs/superpowers/specs/2026-06-01-mini-jazz-sqlite-client-data-protocol.md
+++ b/docs/superpowers/specs/2026-06-01-mini-jazz-sqlite-client-data-protocol.md
@@ -120,10 +120,10 @@ struct ClientDataRecord {
 }
 ```
 
-`values` is delta-shaped:
+`values` is row-image-shaped:
 
-- `Insert`: values contain the proposed fields for a new row
-- `Update`: values contain only changed fields
+- `Insert`: values contain the effective fields for the new row
+- `Update`: values contain the effective fields after the update
 - `Delete`: values must be empty
 
 System fields such as `j_created_at`, `j_updated_at`, `j_created_by`, and
@@ -246,15 +246,6 @@ CREATE INDEX jazz_tx_upload_queue_active_idx
 ON jazz_tx_upload_queue(status, created_at, sync_seq)
 WHERE status = 1;
 
-CREATE TABLE jazz_tx_upload_data (
-  tx_num INTEGER NOT NULL,
-  record_index INTEGER NOT NULL,
-  table_name TEXT NOT NULL,
-  row_id TEXT NOT NULL,
-  op INTEGER NOT NULL,
-  values_json TEXT NOT NULL,
-  PRIMARY KEY (tx_num, record_index)
-) WITHOUT ROWID;
 ```
 
 Status values:
@@ -273,8 +264,8 @@ ORDER BY created_at, sync_seq
 
 `sync_seq` is local-only and is not sent to the server.
 
-`jazz_tx_upload_data` stores the transaction's row deltas in transaction-local order.
-Cleanup removes completed queue/data rows only; it never deletes transaction records,
+Upload data is reconstructed from transaction write metadata and committed history
+rows. Cleanup removes completed queue rows only; it never deletes transaction records,
 history, receipts, or rejection details.
 
 Upload queue completion rule for mergeable transactions:

--- a/docs/superpowers/specs/2026-06-01-mini-jazz-sqlite-client-data-protocol.md
+++ b/docs/superpowers/specs/2026-06-01-mini-jazz-sqlite-client-data-protocol.md
@@ -29,6 +29,10 @@ row mutations across multiple tables. Transport-level batching may coalesce many
 protocol messages into one WebSocket frame or `postMessage` delivery, but the protocol
 message remains one transaction.
 
+The implementation also changes locally generated public `tx_id` values from
+`tx-{node_id}-{local_epoch}` strings to UUIDv7 strings. The protocol treats `tx_id` as
+opaque and must not derive writer, epoch, ordering, or authority state from the string.
+
 The client keeps a durable upload queue. Every normal committed local transaction is
 inserted into that queue atomically with the transaction commit. After connection
 handshake, the client sends queued transactions ordered by `(created_at, sync_seq)`,
@@ -88,7 +92,7 @@ struct ClientTx {
 
 - `Some(branch_id)` applies the transaction to that branch.
 - `None` applies the transaction to the connection/session default branch.
-- If no default branch exists, the message is malformed for that session.
+- If no default branch exists, the transaction is invalid for that session.
 
 `author` semantics:
 
@@ -148,7 +152,7 @@ enum DataOp {
 authoritative state when the row might exist upstream. It is rejected only after
 authoritative absence is known.
 
-`Delete` with non-empty `values` is malformed for MVP.
+`Delete` with non-empty `values` is rejected for MVP.
 
 ### Conflict Mode
 
@@ -230,6 +234,8 @@ CREATE TABLE jazz_tx_upload_queue (
   tx_num INTEGER NOT NULL UNIQUE,
   status INTEGER NOT NULL,
   created_at INTEGER NOT NULL,
+  branch_id TEXT,
+  author TEXT,
   completed_at INTEGER,
   last_upload_attempt_at INTEGER,
   last_ack_at INTEGER,
@@ -239,6 +245,16 @@ CREATE TABLE jazz_tx_upload_queue (
 CREATE INDEX jazz_tx_upload_queue_active_idx
 ON jazz_tx_upload_queue(status, created_at, sync_seq)
 WHERE status = 1;
+
+CREATE TABLE jazz_tx_upload_data (
+  tx_num INTEGER NOT NULL,
+  record_index INTEGER NOT NULL,
+  table_name TEXT NOT NULL,
+  row_id TEXT NOT NULL,
+  op INTEGER NOT NULL,
+  values_json TEXT NOT NULL,
+  PRIMARY KEY (tx_num, record_index)
+) WITHOUT ROWID;
 ```
 
 Status values:
@@ -256,6 +272,10 @@ ORDER BY created_at, sync_seq
 ```
 
 `sync_seq` is local-only and is not sent to the server.
+
+`jazz_tx_upload_data` stores the transaction's row deltas in transaction-local order.
+Cleanup removes completed queue/data rows only; it never deletes transaction records,
+history, receipts, or rejection details.
 
 Upload queue completion rule for mergeable transactions:
 
@@ -348,24 +368,25 @@ its queue quickly after reconnect.
 
 ## Validation And Rejection
 
-Malformed protocol shape is fatal and closes the session.
+Envelope, protocol-shape, and auth failures are fatal and close the session.
 
 Examples:
 
 - `UploadTx` before handshake
 - missing transaction header
 - invalid enum tag
-- `branch_id = None` when the session has no default branch
-- empty `data`
-- delete record with non-empty values
-- system fields in `values`
-- duplicate `(table, row_id)` records in one transaction
+- unauthenticated upload on a connection that requires auth
 
 Semantically invalid transactions produce `TxStatus::Rejected` and do not close the
 session.
 
 Examples:
 
+- `branch_id = None` when the session has no default branch
+- empty `data`
+- delete record with non-empty values
+- system fields in `values`
+- duplicate `(table, row_id)` data records
 - insert missing required fields
 - insert row that already exists
 - policy denied


### PR DESCRIPTION
This PR adds a client-to-server upload path to `mini-jazz-sqlite`.

It also changes locally generated `tx_id` values from `tx-{node_id}-{local_epoch}` strings to UUIDv7 strings. Upload handling still treats `tx_id` as an opaque transaction identifier, so the protocol does not derive behavior from the id format.

Upload row data is now row-image-shaped: inserts and updates carry the effective field values for the row, while deletes carry empty values. The durable upload registry only stores retry metadata; upload data is reconstructed from transaction write metadata and committed history rows.

## Client Transaction Upload Protocol

The unit of sync is one transaction. A transaction can contain multiple row changes across multiple tables, but it is uploaded as one protocol message. Batching is handled by the transport layer, not by stuffing multiple transactions into one upload message.

The client sends transaction data, not history. The receiving server reconstructs and validates authoritative storage/history from its local state, trust context, policies, and any upstream state it needs to fetch. A client cannot forge receipts, rejection state, system fields, or server history.

Updated the Rust example app to use a sync server: https://github.com/garden-co/jazz/pull/984

The client changes are uploaded correctly, but the subscription updates are not propagated currently.
The auth is also not implemented yet (going to be the next thing I'm going to do).

Full spec [here](https://github.com/garden-co/jazz/blob/guido/transaction-upload-proto/docs/superpowers/specs/2026-06-01-mini-jazz-sqlite-client-data-protocol.md)

## Goals

- Let clients send local committed transactions upstream.
- Reconcile unsynced local transactions on startup and reconnect, even with no active subscriptions.
- Keep upload retry state durable on the client.
- Separate message receipt from transaction acceptance.
- Replace unsubscribe-by-`Replay`-difference with an explicit unsubscribe message.

## Wire Messages

Client upload:

```rust
ClientMessage::UploadTx {
    tx: ClientTx,
    data: Vec<ClientDataRecord>,
    reads: Vec<ReadRecord>,
}
```

Server receipt ACK:

```rust
ServerMessage::UploadAck {
    tx_id: String,
}
```

Server transaction fate:

```rust
ServerMessage::TxStatus {
    tx_id: String,
    status: TxStatusKind,
}
```

Unsubscribe:

```rust
ClientMessage::Unsubscribe {
    subscription_id: SubscriptionId,
}
```

Protocol version is bumped to v2 and `ProtocolCapabilities` now includes `tx_upload`.

## Upload Flow

`UploadAck` is flow control only. It means the server received the upload message on this connection and the client can free one in-flight upload slot. It does not mean the transaction was accepted, persisted as authoritative history, edge-filed, globally accepted, or rejected.

Transaction outcome is reported separately with `TxStatus`.

```text
client durable upload queue                     server
---------------------------                     ------
active txs ordered by
(created_at, sync_seq)

[tx A] [tx B] [tx C]
   |      |      |
   |      |      +---- UploadTx(C) -----------> receive message
   |      +----------- UploadTx(B) -----------> receive message
   +------------------ UploadTx(A) -----------> receive message

<---------------------- UploadAck(A) --------- frees one in-flight slot
<---------------------- UploadAck(B) --------- frees one in-flight slot

...later, when fate is known...

<---------------------- TxStatus(A, EdgeAccepted | GlobalAccepted | Rejected)
                         completes or keeps the retry entry according to tx mode
```

The default max in-flight upload count is `1000`. The client sends transactions in order, but it does not wait for `tx A` to be acked before sending `tx B`. WebSocket and `postMessage` already provide ordered delivery for the intended transports.

On reconnect, connection-local in-flight state is cleared. The client scans the durable queue again and replays active transactions that have not completed.

## Transaction Shape

`ClientTx` carries the transaction header:

```rust
struct ClientTx {
    tx_id: String,
    branch_id: Option<String>,
    conflict_mode: TxConflictMode,
    created_at: i64,
    author: Option<String>,
}
```

`branch_id = Some(id)` applies to that branch. `branch_id = None` uses the authenticated session/default branch.

For untrusted client connections, the server derives the author/provenance from the authenticated session and ignores forged client authors. For trusted peer/server connections, the peer may be authoritative for author/provenance, subject to the connection role.

`ClientDataRecord` carries the actual transaction data:

```rust
struct ClientDataRecord {
    table: String,
    row_id: String,
    op: DataOp,
    values: BTreeMap<String, JsonValue>,
}
```

`values` is row-image-shaped:

- `Insert`: effective fields for the new row.
- `Update`: effective fields after the update.
- `Delete`: empty values.

System fields such as `j_created_at`, `j_updated_at`, `j_created_by`, and `j_updated_by` are not accepted from client data. The server derives them.

One upload message must contain exactly one transaction. That transaction may contain many row changes.

## Reads And Conflict Mode

Mergeable transactions may send `reads: []`.

Exclusive transactions need the read facts required for validation. Missing or stale reads reject the transaction rather than closing the connection.

This PR keeps the existing `ReadRecord` shape; read-set redesign is intentionally outside this change.

## Server Handling

The server receives upload messages in transport order and processes them in that order.

```text
UploadTx
   |
   v
handshake + auth checks
   |
   +-- failed envelope/auth check ----> protocol error / close
   |
   v
send UploadAck(tx_id)
   |
   v
validate shape, branch, tx id, reads, policy, current rows
   |
   +-- invalid or denied ------------> TxStatus(tx_id, Rejected)
   |
   v
expand client row data into authoritative local storage/history
   |
   v
record edge/global/rejection fate when known
   |
   v
TxStatus(tx_id, EdgeAccepted | GlobalAccepted | Rejected)
```

Duplicate upload of an already known transaction is idempotent. The server still sends `UploadAck`, and if the transaction already has terminal/known fate, it can send the current `TxStatus` so the client can finish reconciliation quickly.

If the server lacks authoritative state needed to validate an update/delete, it should fetch or wait for trusted upstream state instead of trusting client-provided history. Missing local state is not automatically proof that the transaction is invalid.

## Client Upload Queue

Every normal committed local transaction is inserted into a durable upload registry atomically with the transaction commit. Registry insertion failure fails the commit.

Registry schema:

```sql
CREATE TABLE IF NOT EXISTS jazz_tx_upload_queue (
  sync_seq INTEGER PRIMARY KEY AUTOINCREMENT,
  tx_num INTEGER NOT NULL UNIQUE,
  status INTEGER NOT NULL,
  created_at INTEGER NOT NULL,
  branch_id TEXT,
  author TEXT,
  completed_at INTEGER,
  last_upload_attempt_at INTEGER,
  last_ack_at INTEGER,
  attempt_count INTEGER NOT NULL DEFAULT 0
);

CREATE INDEX IF NOT EXISTS jazz_tx_upload_queue_active_idx
ON jazz_tx_upload_queue(status, created_at, sync_seq)
WHERE status = 1;
```

`jazz_tx_upload_queue` owns durable retry/completion state. Upload data is reconstructed from `jazz_tx_write` and the committed history rows for the transaction.

Queue rows are ordered by:

```sql
ORDER BY created_at, sync_seq
```

`created_at` is the transaction timestamp. `sync_seq` is a local monotonic tie-breaker and is never sent over the wire.

`TxStatus` is non-cumulative:

- `EdgeAccepted` means edge acceptance happened.
- `GlobalAccepted` means global acceptance happened and also satisfies edge-level waiting/retry needs.
- `Rejected` is terminal for upload retry.

Completion rules:

```text
mergeable tx:
  complete when local fate has edge receipt OR global receipt OR rejection

exclusive tx:
  complete when local fate has global receipt OR rejection
```

For registry/retry purposes, an edge receipt is enough to complete mergeable uploads. Exclusive uploads keep waiting/replaying until global acceptance or rejection. Unknown or downgrade-like status messages are ignored.

The queue is never completed by `UploadAck`; it is completed only from authoritative local transaction fate.

## Cleanup

Cleanup deletes completed upload registry metadata only. It never deletes transaction records, row data, history, receipts, or rejection detail.

Active rows are never deleted by cleanup, regardless of age.

MVP cleanup policy:

```text
retention_age = 7 days
max_completed_rows = 10_000
delete_batch_size = 500
min_cleanup_interval = 60 seconds
```

## Unsubscribe

`ClientMessage::Unsubscribe { subscription_id }` removes exactly that subscription. It also drops pending download messages and last acknowledged cursor state for that subscription.

It does not touch upload queue state and does not rely on replaying the remaining subscription set.

## Validation

- `cargo test -p mini-jazz-sqlite --test whole_system`
- `cargo test -p mini-jazz-sqlite`
- `cargo fmt --check -p mini-jazz-sqlite`
- `cargo clippy -p mini-jazz-sqlite -- -D warnings`
- `git diff --check`