### PR TITLE
Add native sync server to Yew todo example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2530,13 +2530,16 @@ dependencies = [
 name = "mini-sqlite-todo-yew"
 version = "0.1.0"
 dependencies = [
+ "axum",
  "console_error_panic_hook",
+ "futures-util",
  "js-sys",
  "mini-jazz-sqlite",
  "serde",
  "serde_json",
  "sqlite-wasm-rs",
  "sqlite-wasm-vfs",
+ "tokio",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",

--- a/examples/mini-sqlite-todo-yew/.gitignore
+++ b/examples/mini-sqlite-todo-yew/.gitignore
@@ -1,0 +1,4 @@
+dist/
+*.sqlite3
+*.sqlite3-shm
+*.sqlite3-wal

--- a/examples/mini-sqlite-todo-yew/Cargo.toml
+++ b/examples/mini-sqlite-todo-yew/Cargo.toml
@@ -12,6 +12,10 @@ path = "src/main.rs"
 name = "worker"
 path = "src/bin/worker.rs"
 
+[[bin]]
+name = "mini-sqlite-todo-yew-server"
+path = "src/bin/server.rs"
+
 [dependencies]
 console_error_panic_hook = "0.1"
 mini-jazz-sqlite = { path = "../../crates/mini-jazz-sqlite" }
@@ -23,13 +27,16 @@ js-sys = "0.3"
 web-sys = { version = "0.3", features = [
   "console",
   "DedicatedWorkerGlobalScope",
+  "ErrorEvent",
   "Event",
   "HtmlInputElement",
   "HtmlSelectElement",
   "InputEvent",
   "MessageEvent",
   "SubmitEvent",
+  "CloseEvent",
   "Worker",
+  "WebSocket",
   "Window",
 ] }
 yew = { version = "0.23", features = ["csr"] }
@@ -37,3 +44,8 @@ yew = { version = "0.23", features = ["csr"] }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 sqlite-wasm-rs = "0.5"
 sqlite-wasm-vfs = "0.2"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+axum = { version = "0.7", features = ["ws"] }
+futures-util = "0.3"
+tokio = { version = "1", features = ["full"] }

--- a/examples/mini-sqlite-todo-yew/package.json
+++ b/examples/mini-sqlite-todo-yew/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "env -u NO_COLOR CC_wasm32_unknown_unknown=${CC_wasm32_unknown_unknown:-/opt/homebrew/opt/llvm@21/bin/clang} trunk serve --address 127.0.0.1",
+    "dev": "sh -c 'trap \"kill 0\" EXIT; cargo run --bin mini-sqlite-todo-yew-server & env -u NO_COLOR CC_wasm32_unknown_unknown=${CC_wasm32_unknown_unknown:-/opt/homebrew/opt/llvm@21/bin/clang} trunk serve --address 127.0.0.1'",
+    "dev:web": "env -u NO_COLOR CC_wasm32_unknown_unknown=${CC_wasm32_unknown_unknown:-/opt/homebrew/opt/llvm@21/bin/clang} trunk serve --address 127.0.0.1",
+    "dev:server": "cargo run --bin mini-sqlite-todo-yew-server",
     "build": "env -u NO_COLOR CC_wasm32_unknown_unknown=${CC_wasm32_unknown_unknown:-/opt/homebrew/opt/llvm@21/bin/clang} trunk build"
   }
 }

--- a/examples/mini-sqlite-todo-yew/src/bin/server.rs
+++ b/examples/mini-sqlite-todo-yew/src/bin/server.rs
@@ -1,0 +1,135 @@
+#[cfg(not(target_arch = "wasm32"))]
+use axum::{
+    extract::{
+        ws::{Message, WebSocket, WebSocketUpgrade},
+        State,
+    },
+    response::IntoResponse,
+    routing::get,
+    Router,
+};
+#[cfg(not(target_arch = "wasm32"))]
+use futures_util::{SinkExt, StreamExt};
+#[cfg(not(target_arch = "wasm32"))]
+use mini_jazz_sqlite::{connection::UpstreamConnectionManager, Runtime, Storage};
+#[cfg(not(target_arch = "wasm32"))]
+use mini_sqlite_todo_yew::{
+    native_sync::{decode_client_frame, encode_server_frame},
+    todo_schema::todo_schema,
+};
+#[cfg(not(target_arch = "wasm32"))]
+use std::{
+    net::SocketAddr,
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Clone)]
+struct AppState {
+    runtime: Arc<Mutex<Runtime>>,
+    user: String,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let addr = std::env::var("MINI_SQLITE_TODO_SERVER_ADDR")
+        .unwrap_or_else(|_| "127.0.0.1:8787".to_owned())
+        .parse::<SocketAddr>()?;
+    let db_path = std::env::var("MINI_SQLITE_TODO_SERVER_DB")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("mini-sqlite-todo-yew-server.sqlite3"));
+    let user = std::env::var("MINI_SQLITE_TODO_USER").unwrap_or_else(|_| "alice".to_owned());
+    let runtime = Runtime::open_with_schema(
+        Storage::File(db_path.clone()),
+        "mini-sqlite-todo-yew-native",
+        &user,
+        todo_schema(),
+    )?;
+    let state = AppState {
+        runtime: Arc::new(Mutex::new(runtime)),
+        user,
+    };
+
+    let app = Router::new()
+        .route("/health", get(|| async { "ok" }))
+        .route("/sync", get(sync_websocket))
+        .with_state(state);
+
+    eprintln!("mini-sqlite-todo-yew sync server listening on ws://{addr}/sync");
+    eprintln!("database: {}", db_path.display());
+
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+async fn sync_websocket(ws: WebSocketUpgrade, State(state): State<AppState>) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| handle_socket(socket, state))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+async fn handle_socket(socket: WebSocket, state: AppState) {
+    let (schema_fingerprint, policy_fingerprint) = {
+        let Ok(runtime) = state.runtime.lock() else {
+            return;
+        };
+        (
+            runtime.local_schema_fingerprint(),
+            runtime.local_policy_fingerprint(),
+        )
+    };
+    let mut upstream = UpstreamConnectionManager::new_authenticated(
+        "mini-sqlite-todo-yew-native-session",
+        "mini-sqlite-todo-yew-native",
+        schema_fingerprint,
+        policy_fingerprint,
+        state.user.clone(),
+    );
+    let (mut sender, mut receiver) = socket.split();
+
+    while let Some(message) = receiver.next().await {
+        let Ok(message) = message else {
+            break;
+        };
+        let Message::Text(encoded) = message else {
+            if matches!(message, Message::Close(_)) {
+                break;
+            }
+            continue;
+        };
+        let frame = match decode_client_frame(&encoded) {
+            Ok(frame) => frame,
+            Err(error) => {
+                eprintln!("invalid native sync frame: {error}");
+                break;
+            }
+        };
+        let server_messages = {
+            let Ok(mut runtime) = state.runtime.lock() else {
+                break;
+            };
+            match upstream.receive(&mut runtime, frame.client_messages) {
+                Ok(server_messages) => server_messages,
+                Err(error) => {
+                    eprintln!("native sync protocol error: {error}");
+                    break;
+                }
+            }
+        };
+        if server_messages.is_empty() {
+            continue;
+        }
+        let Ok(encoded) = encode_server_frame(server_messages) else {
+            break;
+        };
+        if sender.send(Message::Text(encoded)).await.is_err() {
+            break;
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn main() {}

--- a/examples/mini-sqlite-todo-yew/src/browser_runtime.rs
+++ b/examples/mini-sqlite-todo-yew/src/browser_runtime.rs
@@ -26,6 +26,7 @@ pub struct BrowserRuntimeConfig {
     pub user: String,
     pub schema: SchemaDef,
     pub hydrate_queries: Vec<BuiltQuery>,
+    pub native_sync_url: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -117,6 +118,7 @@ impl BrowserRuntime {
                 schema: config.schema,
                 hydrate_queries: config.hydrate_queries,
                 client_messages: opening_client_messages,
+                native_sync_url: config.native_sync_url,
             })?;
             Ok(())
         })?;
@@ -296,6 +298,10 @@ impl BrowserRuntime {
                 server_messages,
                 storage_stats,
             } => self.apply_protocol(request_id, server_messages, storage_stats),
+            RuntimeWorkerOutput::Pushed {
+                server_messages,
+                storage_stats,
+            } => self.apply_pushed(server_messages, storage_stats),
             RuntimeWorkerOutput::Exported { request_id, bundle } => {
                 self.apply_hydrated(request_id, vec![bundle])
             }
@@ -385,6 +391,25 @@ impl BrowserRuntime {
         })
     }
 
+    fn apply_pushed(
+        &self,
+        server_messages: Vec<ServerMessage>,
+        storage_stats: BrowserStorageStats,
+    ) -> Result<Vec<PendingSubscriptionNotification>, String> {
+        self.with_inner(|inner| {
+            if server_messages.is_empty() || !inner.connection_manager.is_ready() {
+                return Ok(Vec::new());
+            }
+            let client_messages = inner.apply_protocol_messages(server_messages)?;
+            inner.send_protocol_messages(client_messages)?;
+            let notifications = inner.refresh_subscriptions()?;
+            inner.status.worker_storage_stats = storage_stats;
+            inner.status.syncing = inner.has_pending_work();
+            inner.status.error.clear();
+            Ok(notifications)
+        })
+    }
+
     fn apply_hydrated(
         &self,
         request_id: RuntimeRequestId,
@@ -430,24 +455,21 @@ impl BrowserRuntime {
 }
 
 impl Inner {
-    fn sync_queries(&mut self, queries: Vec<BuiltQuery>) -> Result<(), String> {
+    fn sync_queries(&mut self, _queries: Vec<BuiltQuery>) -> Result<(), String> {
         self.ensure_ready()?;
-        if queries.is_empty() {
+        let client_messages = self
+            .connection_manager
+            .flush(&mut self.main)
+            .map_err(error_message)?;
+        if client_messages.is_empty() {
             return Ok(());
         }
 
-        let bundles = queries
-            .into_iter()
-            .map(|query| self.main.export_query(query).map_err(error_message))
-            .collect::<Result<Vec<_>, _>>()?;
-        let client_messages = self.replay_connection_subscriptions()?;
         let request_id = self.next_request_id()?;
-
-        self.pending_syncs.insert(request_id);
+        self.pending_protocols.insert(request_id);
         self.status.syncing = true;
-        self.worker.send(RuntimeWorkerInput::ApplyBundles {
+        self.worker.send(RuntimeWorkerInput::Protocol {
             request_id,
-            bundles,
             client_messages,
         })?;
         Ok(())
@@ -491,10 +513,6 @@ impl Inner {
         } else {
             Err("runtime is opening".to_owned())
         }
-    }
-
-    fn replay_connection_subscriptions(&mut self) -> Result<Vec<ClientMessage>, String> {
-        self.connection_manager.replay().map_err(error_message)
     }
 
     fn apply_protocol_messages(

--- a/examples/mini-sqlite-todo-yew/src/browser_worker.rs
+++ b/examples/mini-sqlite-todo-yew/src/browser_worker.rs
@@ -1,8 +1,12 @@
 #![cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
 
 #[cfg(target_arch = "wasm32")]
+use crate::native_sync::{decode_server_frame, encode_client_frame};
+#[cfg(target_arch = "wasm32")]
 use crate::worker_bridge::WorkerResponder;
 use mini_jazz_sqlite::connection::UpstreamConnectionManager;
+#[cfg(target_arch = "wasm32")]
+use mini_jazz_sqlite::protocol::{ClientHello, SessionId, SUPPORTED_PROTOCOL_VERSION};
 use mini_jazz_sqlite::protocol::{ClientMessage, ServerMessage};
 #[cfg(target_arch = "wasm32")]
 use mini_jazz_sqlite::Storage;
@@ -13,7 +17,11 @@ use std::collections::BTreeMap;
 #[cfg(target_arch = "wasm32")]
 use std::{cell::RefCell, rc::Rc};
 #[cfg(target_arch = "wasm32")]
+use wasm_bindgen::{closure::Closure, JsCast, JsValue};
+#[cfg(target_arch = "wasm32")]
 use wasm_bindgen_futures::spawn_local;
+#[cfg(target_arch = "wasm32")]
+use web_sys::{CloseEvent, ErrorEvent, Event, MessageEvent, WebSocket};
 
 pub type RuntimeRequestId = u64;
 
@@ -26,6 +34,7 @@ pub enum RuntimeWorkerInput {
         schema: SchemaDef,
         hydrate_queries: Vec<BuiltQuery>,
         client_messages: Vec<ClientMessage>,
+        native_sync_url: Option<String>,
     },
     ApplyBundles {
         request_id: RuntimeRequestId,
@@ -67,6 +76,10 @@ pub enum RuntimeWorkerOutput {
     },
     Protocol {
         request_id: RuntimeRequestId,
+        server_messages: Vec<ServerMessage>,
+        storage_stats: BrowserStorageStats,
+    },
+    Pushed {
         server_messages: Vec<ServerMessage>,
         storage_stats: BrowserStorageStats,
     },
@@ -153,6 +166,26 @@ impl From<RowView> for BrowserRowView {
 pub struct BrowserRuntimeWorker {
     runtime: Option<Runtime>,
     upstream_connection_manager: Option<UpstreamConnectionManager>,
+    native_sync: Option<NativeSync>,
+}
+
+struct NativeSync {
+    node_id: String,
+    schema_fingerprint: String,
+    policy_fingerprint: String,
+    ready: bool,
+    sent_hello: bool,
+    pending_client_messages: Vec<ClientMessage>,
+    #[cfg(target_arch = "wasm32")]
+    socket: WebSocket,
+    #[cfg(target_arch = "wasm32")]
+    _onopen: Closure<dyn FnMut(Event)>,
+    #[cfg(target_arch = "wasm32")]
+    _onmessage: Closure<dyn FnMut(MessageEvent)>,
+    #[cfg(target_arch = "wasm32")]
+    _onerror: Closure<dyn FnMut(ErrorEvent)>,
+    #[cfg(target_arch = "wasm32")]
+    _onclose: Closure<dyn FnMut(CloseEvent)>,
 }
 
 impl BrowserRuntimeWorker {
@@ -160,6 +193,7 @@ impl BrowserRuntimeWorker {
         Self {
             runtime: None,
             upstream_connection_manager: None,
+            native_sync: None,
         }
     }
 
@@ -177,8 +211,10 @@ impl BrowserRuntimeWorker {
                 schema,
                 hydrate_queries,
                 client_messages,
+                native_sync_url,
             } => {
                 spawn_local(async move {
+                    let native_node_id = node_id.clone();
                     let output = match open_and_hydrate(
                         db_name,
                         node_id,
@@ -196,6 +232,30 @@ impl BrowserRuntimeWorker {
                             server_messages,
                             storage_stats,
                         )) => {
+                            let native_sync =
+                                native_sync_url.and_then(|url| {
+                                    match NativeSync::open(
+                                        worker.clone(),
+                                        responder.clone(),
+                                        url,
+                                        native_node_id.clone(),
+                                        runtime.local_schema_fingerprint(),
+                                        runtime.local_policy_fingerprint(),
+                                    ) {
+                                        Ok(sync) => Some(sync),
+                                        Err(message) => {
+                                            responder.send(RuntimeWorkerOutput::Error {
+                                                request_id: None,
+                                                message,
+                                            });
+                                            None
+                                        }
+                                    }
+                                });
+                            if let Some(mut sync) = native_sync {
+                                let _ = sync.flush_pending();
+                                worker.borrow_mut().native_sync = Some(sync);
+                            }
                             worker.borrow_mut().runtime = Some(runtime);
                             worker.borrow_mut().upstream_connection_manager =
                                 Some(upstream_connection_manager);
@@ -235,13 +295,21 @@ impl BrowserRuntimeWorker {
                 else {
                     return runtime_not_ready(request_id);
                 };
-                apply_bundles(
+                let native_client_messages = relayable_native_client_messages(&client_messages);
+                let output = apply_bundles(
                     runtime,
                     upstream_connection_manager,
                     request_id,
                     bundles,
                     client_messages,
-                )
+                );
+                if let Err(message) = self.send_native_client_messages(native_client_messages) {
+                    return RuntimeWorkerOutput::Error {
+                        request_id: Some(request_id),
+                        message,
+                    };
+                }
+                output
             }
             RuntimeWorkerInput::Protocol {
                 request_id,
@@ -254,12 +322,20 @@ impl BrowserRuntimeWorker {
                 else {
                     return runtime_not_ready(request_id);
                 };
-                protocol_messages(
+                let native_client_messages = relayable_native_client_messages(&client_messages);
+                let output = protocol_messages(
                     runtime,
                     upstream_connection_manager,
                     request_id,
                     client_messages,
-                )
+                );
+                if let Err(message) = self.send_native_client_messages(native_client_messages) {
+                    return RuntimeWorkerOutput::Error {
+                        request_id: Some(request_id),
+                        message,
+                    };
+                }
+                output
             }
             RuntimeWorkerInput::ExportQuery { request_id, query } => {
                 let Some(runtime) = self.runtime.as_ref() else {
@@ -298,6 +374,21 @@ impl Default for BrowserRuntimeWorker {
     }
 }
 
+impl BrowserRuntimeWorker {
+    fn send_native_client_messages(
+        &mut self,
+        client_messages: Vec<ClientMessage>,
+    ) -> Result<(), String> {
+        if client_messages.is_empty() {
+            return Ok(());
+        }
+        let Some(sync) = self.native_sync.as_mut() else {
+            return Ok(());
+        };
+        sync.send_or_buffer(client_messages)
+    }
+}
+
 fn runtime_not_ready(request_id: RuntimeRequestId) -> RuntimeWorkerOutput {
     RuntimeWorkerOutput::Error {
         request_id: Some(request_id),
@@ -323,11 +414,12 @@ async fn open_and_hydrate(
     String,
 > {
     let mut runtime = open_opfs_runtime(&db_name, &node_id, &user, schema).await?;
-    let mut upstream_connection_manager = UpstreamConnectionManager::new(
+    let mut upstream_connection_manager = UpstreamConnectionManager::new_authenticated(
         format!("{node_id}-session"),
         node_id.clone(),
         runtime.local_schema_fingerprint(),
         runtime.local_policy_fingerprint(),
+        user,
     );
     let bundles = hydrate_queries
         .into_iter()
@@ -494,6 +586,231 @@ fn storage_stats(runtime: &Runtime, request_id: RuntimeRequestId) -> RuntimeWork
     }
 }
 
+fn relayable_native_client_messages(client_messages: &[ClientMessage]) -> Vec<ClientMessage> {
+    client_messages
+        .iter()
+        .filter_map(|message| match message {
+            ClientMessage::Subscribe { .. }
+            | ClientMessage::Replay { .. }
+            | ClientMessage::UploadTx { .. }
+            | ClientMessage::Unsubscribe { .. } => Some(message.clone()),
+            ClientMessage::Hello(_) | ClientMessage::Ack { .. } | ClientMessage::Close(_) => None,
+        })
+        .collect()
+}
+
+fn apply_native_server_messages(
+    runtime: &mut Runtime,
+    upstream_connection_manager: &mut UpstreamConnectionManager,
+    server_messages: Vec<ServerMessage>,
+) -> Result<(Vec<ClientMessage>, Vec<ServerMessage>, BrowserStorageStats), String> {
+    let mut client_messages = Vec::new();
+    for message in server_messages {
+        match message {
+            ServerMessage::Hello(_) => {}
+            ServerMessage::Data {
+                message_id,
+                cursor,
+                bundle,
+                ..
+            } => {
+                runtime.apply_bundle(&bundle).map_err(error_message)?;
+                client_messages.push(ClientMessage::Ack {
+                    message_id,
+                    cursor: Some(cursor),
+                });
+            }
+            ServerMessage::TxStatus { tx_id, status } => {
+                runtime
+                    .apply_tx_status_from_server(&tx_id, status)
+                    .map_err(error_message)?;
+            }
+            ServerMessage::UploadAck { .. } | ServerMessage::Settled { .. } => {}
+            ServerMessage::Error(error) => {
+                return Err(format!(
+                    "native sync error {}: {}",
+                    error.code, error.message
+                ));
+            }
+            ServerMessage::Close(reason) => {
+                return Err(format!("native sync closed: {reason:?}"));
+            }
+        }
+    }
+    let main_server_messages = upstream_connection_manager
+        .refresh_active_subscriptions(runtime)
+        .map_err(error_message)?;
+    let storage_stats = runtime.storage_stats().map_err(error_message)?.into();
+    Ok((client_messages, main_server_messages, storage_stats))
+}
+
+impl NativeSync {
+    #[cfg(target_arch = "wasm32")]
+    fn open(
+        worker: Rc<RefCell<BrowserRuntimeWorker>>,
+        responder: WorkerResponder<RuntimeWorkerOutput>,
+        url: String,
+        node_id: String,
+        schema_fingerprint: String,
+        policy_fingerprint: String,
+    ) -> Result<Self, String> {
+        let socket =
+            WebSocket::new(&url).map_err(|error| format!("open native sync: {error:?}"))?;
+
+        let onopen = Closure::wrap(Box::new({
+            let worker = worker.clone();
+            move |_event: Event| {
+                if let Some(sync) = worker.borrow_mut().native_sync.as_mut() {
+                    sync.ready = true;
+                    if let Err(message) = sync.flush_pending() {
+                        web_sys::console::error_1(&JsValue::from_str(&message));
+                    }
+                }
+            }
+        }) as Box<dyn FnMut(Event)>);
+
+        let onmessage = Closure::wrap(Box::new({
+            let worker = worker.clone();
+            let responder = responder.clone();
+            move |event: MessageEvent| {
+                let Some(encoded) = event.data().as_string() else {
+                    responder.send(RuntimeWorkerOutput::Error {
+                        request_id: None,
+                        message: "native sync sent a non-string frame".to_owned(),
+                    });
+                    return;
+                };
+                let frame = match decode_server_frame(&encoded) {
+                    Ok(frame) => frame,
+                    Err(message) => {
+                        responder.send(RuntimeWorkerOutput::Error {
+                            request_id: None,
+                            message,
+                        });
+                        return;
+                    }
+                };
+                let output = {
+                    let mut worker = worker.borrow_mut();
+                    let result = {
+                        let worker = &mut *worker;
+                        let (Some(runtime), Some(upstream_connection_manager)) = (
+                            worker.runtime.as_mut(),
+                            worker.upstream_connection_manager.as_mut(),
+                        ) else {
+                            return;
+                        };
+                        apply_native_server_messages(
+                            runtime,
+                            upstream_connection_manager,
+                            frame.server_messages,
+                        )
+                    };
+                    match result {
+                        Ok((client_messages, main_server_messages, storage_stats)) => {
+                            if let Some(sync) = worker.native_sync.as_mut() {
+                                if let Err(message) = sync.send_or_buffer(client_messages) {
+                                    return responder.send(RuntimeWorkerOutput::Error {
+                                        request_id: None,
+                                        message,
+                                    });
+                                }
+                            }
+                            if main_server_messages.is_empty() {
+                                return;
+                            }
+                            RuntimeWorkerOutput::Pushed {
+                                server_messages: main_server_messages,
+                                storage_stats,
+                            }
+                        }
+                        Err(message) => RuntimeWorkerOutput::Error {
+                            request_id: None,
+                            message,
+                        },
+                    }
+                };
+                responder.send(output);
+            }
+        }) as Box<dyn FnMut(MessageEvent)>);
+
+        let onerror = Closure::wrap(Box::new({
+            let responder = responder.clone();
+            move |_event: ErrorEvent| {
+                responder.send(RuntimeWorkerOutput::Error {
+                    request_id: None,
+                    message: "native sync websocket error".to_owned(),
+                });
+            }
+        }) as Box<dyn FnMut(ErrorEvent)>);
+
+        let onclose = Closure::wrap(Box::new({
+            let worker = worker.clone();
+            move |_event: CloseEvent| {
+                if let Some(sync) = worker.borrow_mut().native_sync.as_mut() {
+                    sync.ready = false;
+                }
+            }
+        }) as Box<dyn FnMut(CloseEvent)>);
+
+        socket.set_onopen(Some(onopen.as_ref().unchecked_ref()));
+        socket.set_onmessage(Some(onmessage.as_ref().unchecked_ref()));
+        socket.set_onerror(Some(onerror.as_ref().unchecked_ref()));
+        socket.set_onclose(Some(onclose.as_ref().unchecked_ref()));
+
+        Ok(Self {
+            node_id,
+            schema_fingerprint,
+            policy_fingerprint,
+            ready: false,
+            sent_hello: false,
+            pending_client_messages: Vec::new(),
+            socket,
+            _onopen: onopen,
+            _onmessage: onmessage,
+            _onerror: onerror,
+            _onclose: onclose,
+        })
+    }
+
+    fn send_or_buffer(&mut self, client_messages: Vec<ClientMessage>) -> Result<(), String> {
+        if client_messages.is_empty() {
+            return Ok(());
+        }
+        self.pending_client_messages.extend(client_messages);
+        self.flush_pending()
+    }
+
+    fn flush_pending(&mut self) -> Result<(), String> {
+        #[cfg(target_arch = "wasm32")]
+        {
+            if !self.ready {
+                return Ok(());
+            }
+            let mut client_messages = Vec::new();
+            if !self.sent_hello {
+                client_messages.push(ClientMessage::Hello(ClientHello {
+                    protocol_version: SUPPORTED_PROTOCOL_VERSION,
+                    session_id: SessionId::new(format!("{}-native-session", self.node_id)),
+                    node_id: self.node_id.clone(),
+                    schema_fingerprint: self.schema_fingerprint.clone(),
+                    policy_fingerprint: self.policy_fingerprint.clone(),
+                }));
+                self.sent_hello = true;
+            }
+            client_messages.append(&mut self.pending_client_messages);
+            if client_messages.is_empty() {
+                return Ok(());
+            }
+            let encoded = encode_client_frame(client_messages)?;
+            self.socket
+                .send_with_str(&encoded)
+                .map_err(|error| format!("send native sync frame: {error:?}"))?;
+        }
+        Ok(())
+    }
+}
+
 #[cfg(target_arch = "wasm32")]
 async fn open_opfs_runtime(
     db_name: &str,
@@ -569,6 +886,7 @@ mod tests {
                 offset: None,
             }],
             client_messages: Vec::new(),
+            native_sync_url: Some("ws://127.0.0.1:8787/sync".to_owned()),
         };
 
         let decoded: RuntimeWorkerInput = serde_round_trip(&message);
@@ -658,6 +976,73 @@ mod tests {
             serde_json::to_value(decoded).unwrap(),
             serde_json::to_value(output).unwrap()
         );
+
+        let output = RuntimeWorkerOutput::Pushed {
+            server_messages: vec![mini_jazz_sqlite::protocol::ServerMessage::Close(
+                mini_jazz_sqlite::protocol::CloseReason::ClientClosed,
+            )],
+            storage_stats: BrowserStorageStats::default(),
+        };
+        let decoded: RuntimeWorkerOutput = serde_round_trip(&output);
+
+        assert_eq!(
+            serde_json::to_value(decoded).unwrap(),
+            serde_json::to_value(output).unwrap()
+        );
+    }
+
+    #[test]
+    fn worker_relays_subscriptions_and_uploads_to_native_sync() {
+        use mini_jazz_sqlite::protocol::{
+            ClientMessage, ClientTx, DataOp, SettlementTier, SubscriptionId, TxConflictMode,
+        };
+
+        let messages = vec![
+            ClientMessage::Hello(mini_jazz_sqlite::protocol::ClientHello {
+                protocol_version: mini_jazz_sqlite::protocol::ProtocolVersion(2),
+                session_id: mini_jazz_sqlite::protocol::SessionId::new("browser-session"),
+                node_id: "browser".to_owned(),
+                schema_fingerprint: "schema".to_owned(),
+                policy_fingerprint: "policy".to_owned(),
+            }),
+            ClientMessage::Subscribe {
+                subscription_id: SubscriptionId::new("todos"),
+                query: BuiltQuery {
+                    table: "todos".to_owned(),
+                    conditions: Vec::new(),
+                    order_by: Vec::new(),
+                    limit: Some(10),
+                    offset: None,
+                },
+                requested_tier: SettlementTier::Local,
+            },
+            ClientMessage::UploadTx {
+                tx: ClientTx {
+                    tx_id: "018f56e2-6e2b-7d4d-9f66-4a59421e8a8f".to_owned(),
+                    branch_id: None,
+                    conflict_mode: TxConflictMode::Mergeable,
+                    created_at: 1,
+                    author: Some("alice".to_owned()),
+                },
+                data: vec![mini_jazz_sqlite::protocol::ClientDataRecord {
+                    table: "projects".to_owned(),
+                    row_id: "project-1".to_owned(),
+                    op: DataOp::Insert,
+                    values: BTreeMap::new(),
+                }],
+                reads: Vec::new(),
+            },
+            ClientMessage::Ack {
+                message_id: mini_jazz_sqlite::protocol::MessageId(1),
+                cursor: None,
+            },
+        ];
+
+        let relayed = relayable_native_client_messages(&messages);
+
+        assert_eq!(relayed.len(), 2);
+        assert!(matches!(relayed[0], ClientMessage::Subscribe { .. }));
+        assert!(matches!(relayed[1], ClientMessage::UploadTx { .. }));
     }
 
     #[test]
@@ -689,8 +1074,8 @@ mod tests {
     #[test]
     fn worker_protocol_subscribe_exports_query_data_and_settlement() {
         use mini_jazz_sqlite::protocol::{
-            ClientHello, ClientMessage, ProtocolVersion, ServerMessage, SessionId, SettlementTier,
-            SubscriptionId,
+            ClientHello, ClientMessage, ServerMessage, SessionId, SettlementTier, SubscriptionId,
+            SUPPORTED_PROTOCOL_VERSION,
         };
 
         let mut runtime =
@@ -735,13 +1120,14 @@ mod tests {
                 schema_fingerprint.clone(),
                 policy_fingerprint.clone(),
             )),
+            native_sync: None,
         };
 
         let output = worker.handle_sync(RuntimeWorkerInput::Protocol {
             request_id: 7,
             client_messages: vec![
                 ClientMessage::Hello(ClientHello {
-                    protocol_version: ProtocolVersion(1),
+                    protocol_version: SUPPORTED_PROTOCOL_VERSION,
                     session_id: SessionId::new("browser-session"),
                     node_id: "browser".to_owned(),
                     schema_fingerprint,

--- a/examples/mini-sqlite-todo-yew/src/lib.rs
+++ b/examples/mini-sqlite-todo-yew/src/lib.rs
@@ -1,6 +1,7 @@
 #[cfg(target_arch = "wasm32")]
 pub mod browser_runtime;
 pub mod browser_worker;
+pub mod native_sync;
 pub mod query_builder;
 pub mod todo_query {
     use crate::query_builder::QueryBuilder;

--- a/examples/mini-sqlite-todo-yew/src/native_sync.rs
+++ b/examples/mini-sqlite-todo-yew/src/native_sync.rs
@@ -1,0 +1,55 @@
+use mini_jazz_sqlite::protocol::{ClientMessage, ServerMessage};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NativeClientFrame {
+    pub client_messages: Vec<ClientMessage>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NativeServerFrame {
+    pub server_messages: Vec<ServerMessage>,
+}
+
+pub fn encode_client_frame(client_messages: Vec<ClientMessage>) -> Result<String, String> {
+    serde_json::to_string(&NativeClientFrame { client_messages }).map_err(|error| error.to_string())
+}
+
+pub fn decode_client_frame(encoded: &str) -> Result<NativeClientFrame, String> {
+    serde_json::from_str(encoded).map_err(|error| error.to_string())
+}
+
+pub fn encode_server_frame(server_messages: Vec<ServerMessage>) -> Result<String, String> {
+    serde_json::to_string(&NativeServerFrame { server_messages }).map_err(|error| error.to_string())
+}
+
+pub fn decode_server_frame(encoded: &str) -> Result<NativeServerFrame, String> {
+    serde_json::from_str(encoded).map_err(|error| error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mini_jazz_sqlite::protocol::{ClientMessage, CloseReason, ServerMessage};
+
+    #[test]
+    fn native_sync_frames_round_trip_through_json() {
+        let client_messages = vec![ClientMessage::Close(CloseReason::ClientClosed)];
+        let encoded = encode_client_frame(client_messages.clone()).unwrap();
+        let decoded = decode_client_frame(&encoded).unwrap();
+
+        assert!(matches!(
+            decoded.client_messages.as_slice(),
+            [ClientMessage::Close(CloseReason::ClientClosed)]
+        ));
+
+        let server_messages = vec![ServerMessage::Close(CloseReason::ClientClosed)];
+        let encoded = encode_server_frame(server_messages.clone()).unwrap();
+        let decoded = decode_server_frame(&encoded).unwrap();
+
+        assert!(matches!(
+            decoded.server_messages.as_slice(),
+            [ServerMessage::Close(CloseReason::ClientClosed)]
+        ));
+    }
+}

--- a/examples/mini-sqlite-todo-yew/src/todo_runtime.rs
+++ b/examples/mini-sqlite-todo-yew/src/todo_runtime.rs
@@ -95,6 +95,7 @@ impl TodoRuntime {
                     project_query(),
                     TodoQueryState::default().page_hydration_query(),
                 ],
+                native_sync_url: native_sync_url(),
             },
             Callback::from({
                 let runtime_slot = runtime_slot.clone();
@@ -469,6 +470,10 @@ impl Inner {
             .query(self.state.query.next_page_probe_query())?
             .is_empty())
     }
+}
+
+fn native_sync_url() -> Option<String> {
+    Some("ws://127.0.0.1:8787/sync".to_owned())
 }
 
 fn project_query() -> BuiltQuery {


### PR DESCRIPTION
## What

Adds a runnable native sync server to `examples/mini-sqlite-todo-yew` and wires the example into a three-hop sync path:

```text
Yew main runtime <-> browser worker runtime <-> native SQLite server
```

The example dev command now starts both the websocket sync server and Trunk. Local writes from the Yew main runtime flush as protocol `UploadTx` messages to the worker, and the worker forwards subscription/upload traffic to the native server over websocket JSON frames.

## Why

This gives the example a concrete native endpoint for testing the transaction upload protocol instead of only exercising main/worker bundle application.

## Notes

- The native server binds to `127.0.0.1:8787` by default.
- The Yew app still runs through Trunk, usually at `http://127.0.0.1:8080`.
- Local SQLite server files are ignored by the example `.gitignore`.

## Verification

- `cargo test -p mini-sqlite-todo-yew`
- `cargo clippy -p mini-jazz-sqlite -p mini-sqlite-todo-yew --all-targets -- -D warnings`
- `CC_wasm32_unknown_unknown=... cargo check -p mini-sqlite-todo-yew --target wasm32-unknown-unknown`
- `cargo fmt --check -p mini-jazz-sqlite -p mini-sqlite-todo-yew && git diff --check`
- Browser smoke against `pnpm dev`: added a todo in the Yew UI and verified it reached the native SQLite database.