### PR TITLE
feat(jazz-sqlite): align permissions with mainline Jazz

### DIFF
--- a/crates/jazz-tools/src/query_manager/graph_nodes/policy_filter.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/policy_filter.rs
@@ -12,7 +12,7 @@ use crate::query_manager::graph_nodes::policy_eval::{
     PolicyContextEvaluator, collect_policy_dependency_tables,
 };
 use crate::query_manager::policy::{
-    Operation, PolicyExpr, evaluate_expr_recursive, normalize_recursive_max_depth,
+    Operation, PolicyExpr, evaluate_expr_recursive_with_row_id, normalize_recursive_max_depth,
 };
 use crate::query_manager::session::Session;
 use crate::query_manager::types::{
@@ -420,12 +420,13 @@ impl PolicyFilterNode {
             PolicyExpr::Not(inner) => !self.evaluate_expr(inner, row, depth),
 
             // All other expressions delegate to shared evaluation
-            _ => evaluate_expr_recursive(
+            _ => evaluate_expr_recursive_with_row_id(
                 expr,
                 &row.data,
                 &row.provenance,
                 &self.descriptor,
                 &self.session,
+                Some(row.id),
                 depth,
             ),
         }
@@ -587,6 +588,7 @@ mod tests {
     use super::*;
     use crate::object::ObjectId;
     use crate::query_manager::encoding::encode_row;
+    use crate::query_manager::policy::{CmpOp, PolicyValue};
     use crate::query_manager::relation_ir::RelExpr;
     use crate::query_manager::types::{ColumnDescriptor, ColumnType, TableName, Value};
     use serde_json::json;
@@ -655,6 +657,44 @@ mod tests {
 
         let row = make_row("user1", "eng", "Doc 1");
         assert!(!node.evaluate(&row));
+    }
+
+    #[test]
+    fn test_policy_id_column_resolves_to_row_object_id() {
+        let row_id = ObjectId::from_uuid(uuid::Uuid::from_u128(
+            0xdead_beef_cafe_0000_0000_0000_0000_0003,
+        ));
+        let session = Session::new("user1");
+        let node = PolicyFilterNode::new(
+            test_descriptor(),
+            PolicyExpr::Cmp {
+                column: "id".into(),
+                op: CmpOp::Eq,
+                value: PolicyValue::Literal(Value::Uuid(row_id)),
+            },
+            session,
+            test_schema(),
+            "documents",
+        );
+
+        let desc = test_descriptor();
+        let data = encode_row(
+            &desc,
+            &[
+                Value::Text("user1".into()),
+                Value::Text("eng".into()),
+                Value::Text("Doc 1".into()),
+            ],
+        )
+        .unwrap();
+        let row = Row::new(
+            row_id,
+            data,
+            crate::row_histories::BatchId([0; 16]),
+            crate::metadata::RowProvenance::for_insert("jazz:test", 0),
+        );
+
+        assert!(node.evaluate(&row));
     }
 
     #[test]

--- a/crates/jazz-tools/src/query_manager/policy.rs
+++ b/crates/jazz-tools/src/query_manager/policy.rs
@@ -2071,7 +2071,7 @@ fn evaluate_simple_recursive(
         }),
 
         PolicyExpr::Exists { table, condition } => {
-            let bound = match bind_outer_row_refs(condition, content, descriptor, None) {
+            let bound = match bind_outer_row_refs(condition, content, descriptor, row_id) {
                 Some(expr) => expr,
                 None => return SimpleEvalResult::fail(),
             };
@@ -2082,7 +2082,7 @@ fn evaluate_simple_recursive(
             })
         }
         PolicyExpr::ExistsRel { rel } => {
-            let bound = match bind_relation_refs(rel, content, descriptor, session, None) {
+            let bound = match bind_relation_refs(rel, content, descriptor, session, row_id) {
                 Some(expr) => expr,
                 None => return SimpleEvalResult::fail(),
             };
@@ -2317,6 +2317,39 @@ mod tests {
             "expected @session.__jazz_outer_row.id to resolve to Value::Uuid(row_id), got {:?}",
             bound
         );
+    }
+
+    #[test]
+    fn test_exists_outer_row_id_binds_to_row_object_id_when_evaluating_for_row() {
+        let descriptor = RowDescriptor::new(vec![ColumnDescriptor::new("title", ColumnType::Text)]);
+        let content = encode_row(&descriptor, &[Value::Text("Members only".into())]).unwrap();
+        let row_id = ObjectId::from_uuid(uuid::Uuid::from_u128(
+            0xdead_beef_cafe_0000_0000_0000_0000_0002,
+        ));
+        let session = Session::new("alice");
+
+        let expr = PolicyExpr::Exists {
+            table: "chat_members".into(),
+            condition: Box::new(PolicyExpr::Cmp {
+                column: "chat_id".into(),
+                op: CmpOp::Eq,
+                value: PolicyValue::SessionRef(vec![OUTER_ROW_SESSION_PREFIX.into(), "id".into()]),
+            }),
+        };
+
+        let result = evaluate_simple_parts_for_row(&expr, &content, &descriptor, &session, row_id);
+        assert!(result.passed);
+        let ComplexClause::Exists { condition, .. } = &result.complex_clauses[0] else {
+            panic!("expected EXISTS complex clause");
+        };
+        assert!(matches!(
+            condition.as_ref(),
+            PolicyExpr::Cmp {
+                column,
+                op: CmpOp::Eq,
+                value: PolicyValue::Literal(Value::Uuid(id)),
+            } if column == "chat_id" && *id == row_id
+        ));
     }
 
     #[test]

--- a/crates/mini-jazz-sqlite-wasm/src/lib.rs
+++ b/crates/mini-jazz-sqlite-wasm/src/lib.rs
@@ -1,9 +1,10 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use mini_jazz_sqlite::{BuiltQuery, RowsSubscription, Runtime, Storage};
+use mini_jazz_sqlite::{BuiltQuery, RowsSubscription, Runtime, SchemaDef, Storage};
 use serde::Serialize;
 use serde_json::Value as JsonValue;
 use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
 
 #[wasm_bindgen(start)]
 pub fn install_panic_hook() {
@@ -55,6 +56,29 @@ impl MiniJazzRuntime {
             .map_err(to_js_error)
     }
 
+    #[wasm_bindgen(js_name = openTodoMemory)]
+    pub fn open_todo_memory(node_id: &str, user: &str) -> Result<MiniJazzRuntime, JsValue> {
+        Runtime::open_with_schema(
+            Storage::Memory,
+            node_id,
+            user,
+            SchemaDef::mini_sqlite_todo_fixture(),
+        )
+        .map(MiniJazzRuntime::new)
+        .map_err(to_js_error)
+    }
+
+    #[wasm_bindgen(js_name = openTrustedTodoMemory)]
+    pub fn open_trusted_todo_memory(node_id: &str) -> Result<MiniJazzRuntime, JsValue> {
+        Runtime::open_trusted_with_schema(
+            Storage::Memory,
+            node_id,
+            SchemaDef::mini_sqlite_todo_fixture(),
+        )
+        .map(MiniJazzRuntime::new)
+        .map_err(to_js_error)
+    }
+
     #[cfg(target_arch = "wasm32")]
     #[wasm_bindgen(js_name = openOpfs)]
     pub async fn open_opfs(
@@ -62,19 +86,47 @@ impl MiniJazzRuntime {
         node_id: &str,
         user: &str,
     ) -> Result<MiniJazzRuntime, JsValue> {
-        let pool_name = opfs_pool_name(db_name);
-        let pool_directory = format!(".{pool_name}");
-        let config = sqlite_wasm_vfs::sahpool::OpfsSAHPoolCfgBuilder::new()
-            .vfs_name(&pool_name)
-            .directory(&pool_directory)
-            .build();
-        sqlite_wasm_vfs::sahpool::install::<sqlite_wasm_rs::WasmOsCallback>(&config, true)
-            .await
-            .map_err(|error| JsValue::from_str(&format!("install OPFS SQLite VFS: {error}")))?;
+        install_opfs_vfs(db_name).await?;
 
         Runtime::open(Storage::File(db_name.into()), node_id, user)
             .map(MiniJazzRuntime::new)
             .map_err(to_js_error)
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen(js_name = openTodoOpfs)]
+    pub async fn open_todo_opfs(
+        db_name: &str,
+        node_id: &str,
+        user: &str,
+    ) -> Result<MiniJazzRuntime, JsValue> {
+        install_opfs_vfs(db_name).await?;
+
+        Runtime::open_with_schema(
+            Storage::File(db_name.into()),
+            node_id,
+            user,
+            SchemaDef::mini_sqlite_todo_fixture(),
+        )
+        .map(MiniJazzRuntime::new)
+        .map_err(to_js_error)
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen(js_name = openTrustedTodoOpfs)]
+    pub async fn open_trusted_todo_opfs(
+        db_name: &str,
+        node_id: &str,
+    ) -> Result<MiniJazzRuntime, JsValue> {
+        install_opfs_vfs(db_name).await?;
+
+        Runtime::open_trusted_with_schema(
+            Storage::File(db_name.into()),
+            node_id,
+            SchemaDef::mini_sqlite_todo_fixture(),
+        )
+        .map(MiniJazzRuntime::new)
+        .map_err(to_js_error)
     }
 
     #[wasm_bindgen(js_name = insertRow)]
@@ -119,20 +171,16 @@ impl MiniJazzRuntime {
 
     #[wasm_bindgen(js_name = query)]
     pub fn query(&self, query: JsValue) -> Result<JsValue, JsValue> {
-        to_js_value(
-            self.runtime
-                .query(parse_built_query(query)?)
-                .map_err(to_js_error)?,
-        )
+        let query = parse_built_query(query)?;
+        log_sqlite_query("query", self.runtime.debug_query_sql(&query).ok());
+        to_js_value(self.runtime.query(query).map_err(to_js_error)?)
     }
 
     #[wasm_bindgen(js_name = one)]
     pub fn one(&self, query: JsValue) -> Result<JsValue, JsValue> {
-        to_js_value(
-            self.runtime
-                .one(parse_built_query(query)?)
-                .map_err(to_js_error)?,
-        )
+        let query = parse_built_query(query)?;
+        log_sqlite_query("one", self.runtime.debug_query_sql(&query).ok());
+        to_js_value(self.runtime.one(query).map_err(to_js_error)?)
     }
 
     #[wasm_bindgen(js_name = subscribe)]
@@ -141,10 +189,9 @@ impl MiniJazzRuntime {
         query: JsValue,
         callback: js_sys::Function,
     ) -> Result<u32, JsValue> {
-        let subscription = self
-            .runtime
-            .subscribe_query(parse_built_query(query)?)
-            .map_err(to_js_error)?;
+        let query = parse_built_query(query)?;
+        log_sqlite_query("subscribe", self.runtime.debug_query_sql(&query).ok());
+        let subscription = self.runtime.subscribe_query(query).map_err(to_js_error)?;
         let initial = subscription.initial_delta();
         let initial = to_js_value(initial)?;
         let id = self.next_subscription_id;
@@ -292,6 +339,32 @@ impl MiniJazzRuntime {
             None => Ok(()),
         }
     }
+}
+
+fn log_sqlite_query(operation: &str, debug: Option<mini_jazz_sqlite::SqliteQueryDebug>) {
+    let Some(debug) = debug else {
+        return;
+    };
+    let Ok(value) = to_js_value(debug) else {
+        return;
+    };
+    let global = js_sys::global();
+    let Ok(console) = js_sys::Reflect::get(&global, &JsValue::from_str("console")) else {
+        return;
+    };
+    let method = js_sys::Reflect::get(&console, &JsValue::from_str("debug"))
+        .or_else(|_| js_sys::Reflect::get(&console, &JsValue::from_str("log")));
+    let Ok(method) = method else {
+        return;
+    };
+    let Ok(method) = method.dyn_into::<js_sys::Function>() else {
+        return;
+    };
+    let _ = method.call2(
+        &console,
+        &JsValue::from_str(&format!("[mini-jazz-sqlite] {operation} SQL")),
+        &value,
+    );
 }
 
 fn parse_values(value: JsValue) -> Result<BTreeMap<String, JsonValue>, JsValue> {
@@ -660,6 +733,20 @@ mod tests {
         let rows: js_sys::Array = runtime.read_rows("projects").unwrap().dyn_into().unwrap();
         assert_eq!(rows.length(), 2);
     }
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn install_opfs_vfs(db_name: &str) -> Result<(), JsValue> {
+    let pool_name = opfs_pool_name(db_name);
+    let pool_directory = format!(".{pool_name}");
+    let config = sqlite_wasm_vfs::sahpool::OpfsSAHPoolCfgBuilder::new()
+        .vfs_name(&pool_name)
+        .directory(&pool_directory)
+        .build();
+    sqlite_wasm_vfs::sahpool::install::<sqlite_wasm_rs::WasmOsCallback>(&config, true)
+        .await
+        .map_err(|error| JsValue::from_str(&format!("install OPFS SQLite VFS: {error}")))?;
+    Ok(())
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/mini-jazz-sqlite-wasm/src/lib.rs
+++ b/crates/mini-jazz-sqlite-wasm/src/lib.rs
@@ -8,7 +8,7 @@ use serde_json::Value as JsonValue;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 
-const SLOW_QUERY_LOG_THRESHOLD_MS: f64 = 1_000.0;
+const SLOW_QUERY_LOG_THRESHOLD_MS: f64 = 10.0;
 
 #[wasm_bindgen(start)]
 pub fn install_panic_hook() {

--- a/crates/mini-jazz-sqlite-wasm/src/lib.rs
+++ b/crates/mini-jazz-sqlite-wasm/src/lib.rs
@@ -1,10 +1,14 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use mini_jazz_sqlite::{BuiltQuery, RowsSubscription, Runtime, SchemaDef, Storage};
+use mini_jazz_sqlite::{
+    BuiltQuery, RowsSubscription, Runtime, SchemaDef, SqliteQueryPlan, SqliteQueryPlanRow, Storage,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
+
+const SLOW_QUERY_LOG_THRESHOLD_MS: f64 = 1_000.0;
 
 #[wasm_bindgen(start)]
 pub fn install_panic_hook() {
@@ -200,15 +204,109 @@ impl MiniJazzRuntime {
     #[wasm_bindgen(js_name = query)]
     pub fn query(&self, query: JsValue) -> Result<JsValue, JsValue> {
         let query = parse_built_query(query)?;
-        log_sqlite_query("query", self.runtime.debug_query_sql(&query).ok());
-        to_js_value(self.runtime.query(query).map_err(to_js_error)?)
+        let debug = self.runtime.debug_query_sql(&query).ok();
+        let table = query.table.clone();
+        let started_at = js_sys::Date::now();
+        match self.runtime.query(query.clone()) {
+            Ok(rows) => {
+                let duration_ms = js_sys::Date::now() - started_at;
+                let row_count = rows.len();
+                let value = to_js_value(rows)?;
+                if should_log_sqlite_timing(duration_ms, false) {
+                    let plan = explain_query_for_log(&self.runtime, &query);
+                    log_sqlite_query(
+                        "query",
+                        table,
+                        debug,
+                        plan,
+                        duration_ms,
+                        Some(row_count),
+                        None,
+                    );
+                }
+                Ok(value)
+            }
+            Err(error) => {
+                let duration_ms = js_sys::Date::now() - started_at;
+                let message = error.to_string();
+                if should_log_sqlite_timing(duration_ms, true) {
+                    let plan = explain_query_for_log(&self.runtime, &query);
+                    log_sqlite_query(
+                        "query",
+                        table,
+                        debug,
+                        plan,
+                        duration_ms,
+                        None,
+                        Some(message),
+                    );
+                }
+                Err(to_js_error(error))
+            }
+        }
     }
 
     #[wasm_bindgen(js_name = one)]
     pub fn one(&self, query: JsValue) -> Result<JsValue, JsValue> {
         let query = parse_built_query(query)?;
-        log_sqlite_query("one", self.runtime.debug_query_sql(&query).ok());
-        to_js_value(self.runtime.one(query).map_err(to_js_error)?)
+        let debug = self.runtime.debug_query_sql(&query).ok();
+        let table = query.table.clone();
+        let started_at = js_sys::Date::now();
+        match self.runtime.one(query.clone()) {
+            Ok(row) => {
+                let duration_ms = js_sys::Date::now() - started_at;
+                let row_count = usize::from(row.is_some());
+                let value = to_js_value(row)?;
+                if should_log_sqlite_timing(duration_ms, false) {
+                    let plan = explain_query_for_log(&self.runtime, &query);
+                    log_sqlite_query(
+                        "one",
+                        table,
+                        debug,
+                        plan,
+                        duration_ms,
+                        Some(row_count),
+                        None,
+                    );
+                }
+                Ok(value)
+            }
+            Err(error) => {
+                let duration_ms = js_sys::Date::now() - started_at;
+                let message = error.to_string();
+                if should_log_sqlite_timing(duration_ms, true) {
+                    let plan = explain_query_for_log(&self.runtime, &query);
+                    log_sqlite_query("one", table, debug, plan, duration_ms, None, Some(message));
+                }
+                Err(to_js_error(error))
+            }
+        }
+    }
+
+    #[wasm_bindgen(js_name = explainQuery)]
+    pub fn explain_query(&self, query: JsValue) -> Result<JsValue, JsValue> {
+        let query = parse_built_query(query)?;
+        let table = query.table.clone();
+        let started_at = js_sys::Date::now();
+        match self.runtime.explain_query_plan(&query) {
+            Ok(plan) => {
+                let duration_ms = js_sys::Date::now() - started_at;
+                let plan_rows = plan.plan.len();
+                let value = to_js_value(plan)?;
+                if should_log_sqlite_timing(duration_ms, false) {
+                    log_sqlite_operation("explainQuery", table, duration_ms, Some(plan_rows), None);
+                }
+                Ok(value)
+            }
+            Err(error) => {
+                let duration_ms = js_sys::Date::now() - started_at;
+                let message = error.to_string();
+                if should_log_sqlite_timing(duration_ms, true) {
+                    log_sqlite_operation("explainQuery", table, duration_ms, None, Some(message));
+                }
+                Err(to_js_error(error))
+            }
+        }
     }
 
     #[wasm_bindgen(js_name = subscribe)]
@@ -218,8 +316,42 @@ impl MiniJazzRuntime {
         callback: js_sys::Function,
     ) -> Result<u32, JsValue> {
         let query = parse_built_query(query)?;
-        log_sqlite_query("subscribe", self.runtime.debug_query_sql(&query).ok());
-        let subscription = self.runtime.subscribe_query(query).map_err(to_js_error)?;
+        let debug = self.runtime.debug_query_sql(&query).ok();
+        let table = query.table.clone();
+        let started_at = js_sys::Date::now();
+        let subscription = match self.runtime.subscribe_query(query.clone()) {
+            Ok(subscription) => subscription,
+            Err(error) => {
+                let duration_ms = js_sys::Date::now() - started_at;
+                let message = error.to_string();
+                if should_log_sqlite_timing(duration_ms, true) {
+                    let plan = explain_query_for_log(&self.runtime, &query);
+                    log_sqlite_query(
+                        "subscribe",
+                        table,
+                        debug,
+                        plan,
+                        duration_ms,
+                        None,
+                        Some(message),
+                    );
+                }
+                return Err(to_js_error(error));
+            }
+        };
+        let duration_ms = js_sys::Date::now() - started_at;
+        if should_log_sqlite_timing(duration_ms, false) {
+            let plan = explain_query_for_log(&self.runtime, &query);
+            log_sqlite_query(
+                "subscribe",
+                table,
+                debug,
+                plan,
+                duration_ms,
+                Some(subscription.initial_delta().all.len()),
+                None,
+            );
+        }
         let initial = subscription.initial_delta();
         let initial = to_js_value(initial)?;
         let id = self.next_subscription_id;
@@ -253,7 +385,38 @@ impl MiniJazzRuntime {
 
     #[wasm_bindgen(js_name = readRows)]
     pub fn read_rows(&self, table_name: &str) -> Result<JsValue, JsValue> {
-        to_js_value(self.runtime.read_rows(table_name).map_err(to_js_error)?)
+        let started_at = js_sys::Date::now();
+        match self.runtime.read_rows(table_name) {
+            Ok(rows) => {
+                let duration_ms = js_sys::Date::now() - started_at;
+                let row_count = rows.len();
+                let value = to_js_value(rows)?;
+                if should_log_sqlite_timing(duration_ms, false) {
+                    log_sqlite_operation(
+                        "readRows",
+                        table_name.to_owned(),
+                        duration_ms,
+                        Some(row_count),
+                        None,
+                    );
+                }
+                Ok(value)
+            }
+            Err(error) => {
+                let duration_ms = js_sys::Date::now() - started_at;
+                let message = error.to_string();
+                if should_log_sqlite_timing(duration_ms, true) {
+                    log_sqlite_operation(
+                        "readRows",
+                        table_name.to_owned(),
+                        duration_ms,
+                        None,
+                        Some(message),
+                    );
+                }
+                Err(to_js_error(error))
+            }
+        }
     }
 
     #[wasm_bindgen(js_name = storageStats)]
@@ -369,11 +532,107 @@ impl MiniJazzRuntime {
     }
 }
 
-fn log_sqlite_query(operation: &str, debug: Option<mini_jazz_sqlite::SqliteQueryDebug>) {
-    let Some(debug) = debug else {
-        return;
+#[derive(Serialize)]
+struct SqliteTimingLog {
+    table: String,
+    duration_ms: f64,
+    row_count: Option<usize>,
+    sql: Option<String>,
+    params: Option<Vec<JsonValue>>,
+    plan: Option<String>,
+    plan_rows: Option<Vec<SqliteQueryPlanRow>>,
+    error: Option<String>,
+}
+
+fn log_sqlite_query(
+    operation: &str,
+    table: String,
+    debug: Option<mini_jazz_sqlite::SqliteQueryDebug>,
+    plan: Option<SqliteQueryPlan>,
+    duration_ms: f64,
+    row_count: Option<usize>,
+    error: Option<String>,
+) {
+    let plan_text = plan
+        .as_ref()
+        .map(|plan| format_sqlite_query_plan(&plan.plan));
+    let log = SqliteTimingLog {
+        table,
+        duration_ms,
+        row_count,
+        sql: debug.as_ref().map(|debug| debug.sql.clone()),
+        params: debug.map(|debug| debug.params),
+        plan: plan_text,
+        plan_rows: plan.map(|plan| plan.plan),
+        error,
     };
-    let Ok(value) = to_js_value(debug) else {
+    log_to_console(&format!("[mini-jazz-sqlite] {operation}"), &log);
+}
+
+fn log_sqlite_operation(
+    operation: &str,
+    table: String,
+    duration_ms: f64,
+    row_count: Option<usize>,
+    error: Option<String>,
+) {
+    let log = SqliteTimingLog {
+        table,
+        duration_ms,
+        row_count,
+        sql: None,
+        params: None,
+        plan: None,
+        plan_rows: None,
+        error,
+    };
+    log_to_console(&format!("[mini-jazz-sqlite] {operation}"), &log);
+}
+
+fn explain_query_for_log(runtime: &Runtime, query: &BuiltQuery) -> Option<SqliteQueryPlan> {
+    runtime.explain_query_plan(query).ok()
+}
+
+fn should_log_sqlite_timing(duration_ms: f64, is_error: bool) -> bool {
+    is_error || duration_ms >= SLOW_QUERY_LOG_THRESHOLD_MS
+}
+
+fn format_sqlite_query_plan(rows: &[SqliteQueryPlanRow]) -> String {
+    let mut children_by_parent = BTreeMap::<i64, Vec<&SqliteQueryPlanRow>>::new();
+    let mut ids = BTreeSet::new();
+    for row in rows {
+        ids.insert(row.id);
+        children_by_parent.entry(row.parent).or_default().push(row);
+    }
+
+    let roots = rows
+        .iter()
+        .filter(|row| row.parent == 0 || !ids.contains(&row.parent))
+        .collect::<Vec<_>>();
+    let mut lines = vec!["QUERY PLAN".to_owned()];
+    append_plan_rows(&mut lines, &roots, &children_by_parent, "");
+    lines.join("\n")
+}
+
+fn append_plan_rows(
+    lines: &mut Vec<String>,
+    rows: &[&SqliteQueryPlanRow],
+    children_by_parent: &BTreeMap<i64, Vec<&SqliteQueryPlanRow>>,
+    prefix: &str,
+) {
+    for (idx, row) in rows.iter().enumerate() {
+        let is_last = idx + 1 == rows.len();
+        let connector = if is_last { "`--" } else { "|--" };
+        lines.push(format!("{prefix}{connector}{}", row.detail));
+        if let Some(children) = children_by_parent.get(&row.id) {
+            let next_prefix = format!("{}{}", prefix, if is_last { "   " } else { "|  " });
+            append_plan_rows(lines, children, children_by_parent, &next_prefix);
+        }
+    }
+}
+
+fn log_to_console(label: &str, payload: &impl Serialize) {
+    let Ok(value) = to_js_value(payload) else {
         return;
     };
     let global = js_sys::global();
@@ -388,11 +647,7 @@ fn log_sqlite_query(operation: &str, debug: Option<mini_jazz_sqlite::SqliteQuery
     let Ok(method) = method.dyn_into::<js_sys::Function>() else {
         return;
     };
-    let _ = method.call2(
-        &console,
-        &JsValue::from_str(&format!("[mini-jazz-sqlite] {operation} SQL")),
-        &value,
-    );
+    let _ = method.call2(&console, &JsValue::from_str(label), &value);
 }
 
 fn parse_values(value: JsValue) -> Result<BTreeMap<String, JsonValue>, JsValue> {

--- a/crates/mini-jazz-sqlite-wasm/src/lib.rs
+++ b/crates/mini-jazz-sqlite-wasm/src/lib.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use mini_jazz_sqlite::{BuiltQuery, RowsSubscription, Runtime, SchemaDef, Storage};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
@@ -36,6 +36,12 @@ struct PendingNotification {
 struct NotificationError {
     error: JsValue,
     failed_ids: Vec<u32>,
+}
+
+#[derive(Deserialize)]
+struct WasmRowMutation {
+    id: String,
+    values: BTreeMap<String, JsonValue>,
 }
 
 impl From<JsValue> for NotificationError {
@@ -139,6 +145,28 @@ impl MiniJazzRuntime {
         let tx_id = self
             .runtime
             .insert_row(table_name, id, parse_values(values)?)
+            .map_err(to_js_error)?;
+        self.notify_subscriptions()?;
+        Ok(tx_id)
+    }
+
+    #[wasm_bindgen(js_name = upsertRowsAsUser)]
+    pub fn upsert_rows_as_user(
+        &mut self,
+        user: &str,
+        table_name: &str,
+        rows: JsValue,
+    ) -> Result<String, JsValue> {
+        let rows = parse_row_mutations(rows)?;
+        let tx_id = self
+            .runtime
+            .run_attributing_to_user(user, |runtime| {
+                let mut tx = runtime.transaction();
+                for row in rows {
+                    tx = tx.upsert_row(table_name, &row.id, row.values);
+                }
+                tx.commit()
+            })
             .map_err(to_js_error)?;
         self.notify_subscriptions()?;
         Ok(tx_id)
@@ -370,6 +398,11 @@ fn log_sqlite_query(operation: &str, debug: Option<mini_jazz_sqlite::SqliteQuery
 fn parse_values(value: JsValue) -> Result<BTreeMap<String, JsonValue>, JsValue> {
     serde_wasm_bindgen::from_value(value)
         .map_err(|error| JsValue::from_str(&format!("invalid row values: {error}")))
+}
+
+fn parse_row_mutations(value: JsValue) -> Result<Vec<WasmRowMutation>, JsValue> {
+    serde_wasm_bindgen::from_value(value)
+        .map_err(|error| JsValue::from_str(&format!("invalid row mutations: {error}")))
 }
 
 fn parse_built_query(value: JsValue) -> Result<BuiltQuery, JsValue> {

--- a/crates/mini-jazz-sqlite-wasm/src/lib.rs
+++ b/crates/mini-jazz-sqlite-wasm/src/lib.rs
@@ -9,6 +9,7 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 
 const SLOW_QUERY_LOG_THRESHOLD_MS: f64 = 10.0;
+const SQLITE_TIMING_LOGS_FLAG: &str = "sqliteTimingLogs";
 
 #[wasm_bindgen(start)]
 pub fn install_panic_hook() {
@@ -18,10 +19,16 @@ pub fn install_panic_hook() {
 #[wasm_bindgen]
 pub struct MiniJazzRuntime {
     runtime: Runtime,
+    flags: MiniJazzFlags,
     subscriptions: BTreeMap<u32, WasmRowsSubscription>,
     next_subscription_id: u32,
     notifying_subscriptions: bool,
     notify_subscriptions_again: bool,
+}
+
+#[derive(Default)]
+struct MiniJazzFlags {
+    sqlite_timing_logs: bool,
 }
 
 struct WasmRowsSubscription {
@@ -201,10 +208,33 @@ impl MiniJazzRuntime {
         Ok(tx_id)
     }
 
+    #[wasm_bindgen(js_name = setMiniJazzFlag)]
+    pub fn set_mini_jazz_flag(&mut self, flag: &str, enabled: bool) -> Result<(), JsValue> {
+        match flag {
+            SQLITE_TIMING_LOGS_FLAG => {
+                self.flags.sqlite_timing_logs = enabled;
+                Ok(())
+            }
+            _ => Err(JsValue::from_str(&format!(
+                "unknown mini-jazz flag: {flag}"
+            ))),
+        }
+    }
+
+    #[wasm_bindgen(js_name = getMiniJazzFlag)]
+    pub fn get_mini_jazz_flag(&self, flag: &str) -> Result<bool, JsValue> {
+        match flag {
+            SQLITE_TIMING_LOGS_FLAG => Ok(self.flags.sqlite_timing_logs),
+            _ => Err(JsValue::from_str(&format!(
+                "unknown mini-jazz flag: {flag}"
+            ))),
+        }
+    }
+
     #[wasm_bindgen(js_name = query)]
     pub fn query(&self, query: JsValue) -> Result<JsValue, JsValue> {
         let query = parse_built_query(query)?;
-        let debug = self.runtime.debug_query_sql(&query).ok();
+        let debug = self.debug_query_sql_for_log(&query);
         let table = query.table.clone();
         let started_at = js_sys::Date::now();
         match self.runtime.query(query.clone()) {
@@ -212,7 +242,7 @@ impl MiniJazzRuntime {
                 let duration_ms = js_sys::Date::now() - started_at;
                 let row_count = rows.len();
                 let value = to_js_value(rows)?;
-                if should_log_sqlite_timing(duration_ms, false) {
+                if self.should_log_sqlite_timing(duration_ms, false) {
                     let plan = explain_query_for_log(&self.runtime, &query);
                     log_sqlite_query(
                         "query",
@@ -229,7 +259,7 @@ impl MiniJazzRuntime {
             Err(error) => {
                 let duration_ms = js_sys::Date::now() - started_at;
                 let message = error.to_string();
-                if should_log_sqlite_timing(duration_ms, true) {
+                if self.should_log_sqlite_timing(duration_ms, true) {
                     let plan = explain_query_for_log(&self.runtime, &query);
                     log_sqlite_query(
                         "query",
@@ -249,7 +279,7 @@ impl MiniJazzRuntime {
     #[wasm_bindgen(js_name = one)]
     pub fn one(&self, query: JsValue) -> Result<JsValue, JsValue> {
         let query = parse_built_query(query)?;
-        let debug = self.runtime.debug_query_sql(&query).ok();
+        let debug = self.debug_query_sql_for_log(&query);
         let table = query.table.clone();
         let started_at = js_sys::Date::now();
         match self.runtime.one(query.clone()) {
@@ -257,7 +287,7 @@ impl MiniJazzRuntime {
                 let duration_ms = js_sys::Date::now() - started_at;
                 let row_count = usize::from(row.is_some());
                 let value = to_js_value(row)?;
-                if should_log_sqlite_timing(duration_ms, false) {
+                if self.should_log_sqlite_timing(duration_ms, false) {
                     let plan = explain_query_for_log(&self.runtime, &query);
                     log_sqlite_query(
                         "one",
@@ -274,7 +304,7 @@ impl MiniJazzRuntime {
             Err(error) => {
                 let duration_ms = js_sys::Date::now() - started_at;
                 let message = error.to_string();
-                if should_log_sqlite_timing(duration_ms, true) {
+                if self.should_log_sqlite_timing(duration_ms, true) {
                     let plan = explain_query_for_log(&self.runtime, &query);
                     log_sqlite_query("one", table, debug, plan, duration_ms, None, Some(message));
                 }
@@ -293,7 +323,7 @@ impl MiniJazzRuntime {
                 let duration_ms = js_sys::Date::now() - started_at;
                 let plan_rows = plan.plan.len();
                 let value = to_js_value(plan)?;
-                if should_log_sqlite_timing(duration_ms, false) {
+                if self.should_log_sqlite_timing(duration_ms, false) {
                     log_sqlite_operation("explainQuery", table, duration_ms, Some(plan_rows), None);
                 }
                 Ok(value)
@@ -301,7 +331,7 @@ impl MiniJazzRuntime {
             Err(error) => {
                 let duration_ms = js_sys::Date::now() - started_at;
                 let message = error.to_string();
-                if should_log_sqlite_timing(duration_ms, true) {
+                if self.should_log_sqlite_timing(duration_ms, true) {
                     log_sqlite_operation("explainQuery", table, duration_ms, None, Some(message));
                 }
                 Err(to_js_error(error))
@@ -316,7 +346,7 @@ impl MiniJazzRuntime {
         callback: js_sys::Function,
     ) -> Result<u32, JsValue> {
         let query = parse_built_query(query)?;
-        let debug = self.runtime.debug_query_sql(&query).ok();
+        let debug = self.debug_query_sql_for_log(&query);
         let table = query.table.clone();
         let started_at = js_sys::Date::now();
         let subscription = match self.runtime.subscribe_query(query.clone()) {
@@ -324,7 +354,7 @@ impl MiniJazzRuntime {
             Err(error) => {
                 let duration_ms = js_sys::Date::now() - started_at;
                 let message = error.to_string();
-                if should_log_sqlite_timing(duration_ms, true) {
+                if self.should_log_sqlite_timing(duration_ms, true) {
                     let plan = explain_query_for_log(&self.runtime, &query);
                     log_sqlite_query(
                         "subscribe",
@@ -340,7 +370,7 @@ impl MiniJazzRuntime {
             }
         };
         let duration_ms = js_sys::Date::now() - started_at;
-        if should_log_sqlite_timing(duration_ms, false) {
+        if self.should_log_sqlite_timing(duration_ms, false) {
             let plan = explain_query_for_log(&self.runtime, &query);
             log_sqlite_query(
                 "subscribe",
@@ -391,7 +421,7 @@ impl MiniJazzRuntime {
                 let duration_ms = js_sys::Date::now() - started_at;
                 let row_count = rows.len();
                 let value = to_js_value(rows)?;
-                if should_log_sqlite_timing(duration_ms, false) {
+                if self.should_log_sqlite_timing(duration_ms, false) {
                     log_sqlite_operation(
                         "readRows",
                         table_name.to_owned(),
@@ -405,7 +435,7 @@ impl MiniJazzRuntime {
             Err(error) => {
                 let duration_ms = js_sys::Date::now() - started_at;
                 let message = error.to_string();
-                if should_log_sqlite_timing(duration_ms, true) {
+                if self.should_log_sqlite_timing(duration_ms, true) {
                     log_sqlite_operation(
                         "readRows",
                         table_name.to_owned(),
@@ -434,10 +464,26 @@ impl MiniJazzRuntime {
     fn new(runtime: Runtime) -> Self {
         Self {
             runtime,
+            flags: MiniJazzFlags::default(),
             subscriptions: BTreeMap::new(),
             next_subscription_id: 0,
             notifying_subscriptions: false,
             notify_subscriptions_again: false,
+        }
+    }
+
+    fn should_log_sqlite_timing(&self, duration_ms: f64, is_error: bool) -> bool {
+        self.flags.sqlite_timing_logs && (is_error || duration_ms >= SLOW_QUERY_LOG_THRESHOLD_MS)
+    }
+
+    fn debug_query_sql_for_log(
+        &self,
+        query: &BuiltQuery,
+    ) -> Option<mini_jazz_sqlite::SqliteQueryDebug> {
+        if self.flags.sqlite_timing_logs {
+            self.runtime.debug_query_sql(query).ok()
+        } else {
+            None
         }
     }
 
@@ -593,10 +639,6 @@ fn explain_query_for_log(runtime: &Runtime, query: &BuiltQuery) -> Option<Sqlite
     runtime.explain_query_plan(query).ok()
 }
 
-fn should_log_sqlite_timing(duration_ms: f64, is_error: bool) -> bool {
-    is_error || duration_ms >= SLOW_QUERY_LOG_THRESHOLD_MS
-}
-
 fn format_sqlite_query_plan(rows: &[SqliteQueryPlanRow]) -> String {
     let mut children_by_parent = BTreeMap::<i64, Vec<&SqliteQueryPlanRow>>::new();
     let mut ids = BTreeSet::new();
@@ -680,6 +722,30 @@ fn to_js_value<T: Serialize>(value: T) -> Result<JsValue, JsValue> {
 
 fn to_js_error(error: mini_jazz_sqlite::Error) -> JsValue {
     JsValue::from_str(&error.to_string())
+}
+
+#[cfg(test)]
+mod native_tests {
+    use super::*;
+
+    #[test]
+    fn sqlite_timing_logs_require_explicit_flag() {
+        let runtime = Runtime::open(Storage::Memory, "alice-node", "alice").unwrap();
+        let mut runtime = MiniJazzRuntime::new(runtime);
+
+        assert!(!runtime.should_log_sqlite_timing(SLOW_QUERY_LOG_THRESHOLD_MS, false));
+        assert!(!runtime.should_log_sqlite_timing(0.0, true));
+        assert!(!runtime.get_mini_jazz_flag(SQLITE_TIMING_LOGS_FLAG).unwrap());
+
+        runtime
+            .set_mini_jazz_flag(SQLITE_TIMING_LOGS_FLAG, true)
+            .unwrap();
+
+        assert!(runtime.get_mini_jazz_flag(SQLITE_TIMING_LOGS_FLAG).unwrap());
+        assert!(!runtime.should_log_sqlite_timing(SLOW_QUERY_LOG_THRESHOLD_MS - 1.0, false));
+        assert!(runtime.should_log_sqlite_timing(SLOW_QUERY_LOG_THRESHOLD_MS, false));
+        assert!(runtime.should_log_sqlite_timing(0.0, true));
+    }
 }
 
 #[cfg(all(test, target_arch = "wasm32"))]

--- a/crates/mini-jazz-sqlite/Cargo.toml
+++ b/crates/mini-jazz-sqlite/Cargo.toml
@@ -15,7 +15,10 @@ rusqlite = { version = "0.40", features = ["bundled", "limits"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3"
-rusqlite = { version = "0.40", default-features = false, features = ["ffi-sqlite-wasm-rs"] }
+rusqlite = { version = "0.40", default-features = false, features = [
+  "cache",
+  "ffi-sqlite-wasm-rs",
+] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/mini-jazz-sqlite/src/effective.rs
+++ b/crates/mini-jazz-sqlite/src/effective.rs
@@ -1,4 +1,5 @@
 use crate::schema::{current_table, history_table, quote_ident, storage_column, SchemaDef};
+use crate::sync::history_op;
 use crate::{branch, query, tx, Result};
 use rusqlite::{params, Connection};
 use serde_json::Value as JsonValue;
@@ -85,13 +86,14 @@ fn snapshot_row_values(
         .iter()
         .map(|field| format!("h.{}", quote_ident(&storage_column(field))))
         .collect::<Vec<_>>();
+    let delete_op = history_op::DELETE;
     let sql = format!(
         "SELECT {}
          FROM {} h
          JOIN jazz_tx tx ON tx.tx_num = h.tx_num
          WHERE h.row_num = ?
            AND h.j_branch_num = 1
-           AND h.op != 3
+           AND h.op != {delete_op}
            AND tx.outcome != ?
            AND tx.global_epoch IS NOT NULL
            AND tx.global_epoch <= ?

--- a/crates/mini-jazz-sqlite/src/lib.rs
+++ b/crates/mini-jazz-sqlite/src/lib.rs
@@ -24,6 +24,7 @@ mod types;
 mod users;
 
 pub use error::{Error, Result};
+pub use query::SqliteQueryDebug;
 pub use query_api::{BuiltQuery, QueryCondition, QueryConditionOp, QueryDirection, QueryOrderBy};
 pub use runtime::Runtime;
 pub use schema::SchemaDef;

--- a/crates/mini-jazz-sqlite/src/lib.rs
+++ b/crates/mini-jazz-sqlite/src/lib.rs
@@ -24,7 +24,7 @@ mod types;
 mod users;
 
 pub use error::{Error, Result};
-pub use query::SqliteQueryDebug;
+pub use query::{SqliteQueryDebug, SqliteQueryPlan, SqliteQueryPlanRow};
 pub use query_api::{BuiltQuery, QueryCondition, QueryConditionOp, QueryDirection, QueryOrderBy};
 pub use runtime::Runtime;
 pub use schema::SchemaDef;

--- a/crates/mini-jazz-sqlite/src/policy.rs
+++ b/crates/mini-jazz-sqlite/src/policy.rs
@@ -35,6 +35,138 @@ pub(crate) fn write_allowed(check: WriteCheck<'_>) -> Result<bool> {
             )?;
             Ok(count > 0)
         }
+        PolicyDef::RowIdEqualsUser => {
+            Ok(crate::rows::public_row_id(check.db, check.row_num)? == check.user)
+        }
+        PolicyDef::UserRefEqualsSession { field } => {
+            let field_def = check
+                .table
+                .fields
+                .iter()
+                .find(|candidate| candidate.name == *field)
+                .ok_or_else(|| crate::Error::new(format!("unknown policy ref {field}")))?;
+            let FieldKind::Ref { table } = &field_def.kind else {
+                return Err(crate::Error::new(format!(
+                    "policy field {} is not a ref",
+                    field_def.name
+                )));
+            };
+            if table != "users" {
+                return Err(crate::Error::new(format!(
+                    "policy field {} must reference users",
+                    field_def.name
+                )));
+            }
+            Ok(check
+                .values
+                .get(field)
+                .or_else(|| check.values.get(&field_def.storage_name))
+                .and_then(JsonValue::as_str)
+                == Some(check.user))
+        }
+        PolicyDef::GroupMember => {
+            let policy_sql = current_group_member_policy_sql(
+                "current.row_num",
+                check.user,
+                Some(check.branch_num),
+                0,
+            );
+            let count: i64 = check.db.query_row(
+                &format!(
+                    "SELECT COUNT(*)
+                     FROM {} current
+                     JOIN jazz_tx tx ON tx.tx_num = current.visible_tx_num
+                     WHERE current.row_num = ?
+                       AND {}
+                       AND current.is_deleted = 0
+                       AND tx.outcome != {}
+                       AND {policy_sql}",
+                    crate::schema::current_table(&check.table.name),
+                    effective_branch_sql("current", &check.table.name, check.branch_num),
+                    tx::OUTCOME_REJECTED,
+                ),
+                params![check.row_num],
+                |row| row.get(0),
+            )?;
+            Ok(count > 0)
+        }
+        PolicyDef::ProjectMember => {
+            let policy_sql = current_project_member_policy_sql(
+                "current.row_num",
+                check.user,
+                Some(check.branch_num),
+                0,
+            );
+            let count: i64 = check.db.query_row(
+                &format!(
+                    "SELECT COUNT(*)
+                     FROM {} current
+                     JOIN jazz_tx tx ON tx.tx_num = current.visible_tx_num
+                     WHERE current.row_num = ?
+                       AND {}
+                       AND current.is_deleted = 0
+                       AND tx.outcome != {}
+                       AND {policy_sql}",
+                    crate::schema::current_table(&check.table.name),
+                    effective_branch_sql("current", &check.table.name, check.branch_num),
+                    tx::OUTCOME_REJECTED,
+                ),
+                params![check.row_num],
+                |row| row.get(0),
+            )?;
+            Ok(count > 0)
+        }
+        PolicyDef::ProjectRefMember { field } => {
+            let field_def = check
+                .table
+                .fields
+                .iter()
+                .find(|candidate| candidate.name == *field)
+                .ok_or_else(|| crate::Error::new(format!("unknown policy ref {field}")))?;
+            let FieldKind::Ref { table } = &field_def.kind else {
+                return Err(crate::Error::new(format!(
+                    "policy field {} is not a ref",
+                    field_def.name
+                )));
+            };
+            if table != "projects" {
+                return Err(crate::Error::new(format!(
+                    "policy field {} must reference projects",
+                    field_def.name
+                )));
+            }
+            let project_id = check
+                .values
+                .get(field)
+                .or_else(|| check.values.get(&field_def.storage_name))
+                .and_then(JsonValue::as_str)
+                .ok_or_else(|| crate::Error::new(format!("expected ref id for {field}")))?;
+            let project_row_num = crate::rows::row_num(check.db, project_id)?;
+            let policy_sql = current_project_member_policy_sql(
+                "current.row_num",
+                check.user,
+                Some(check.branch_num),
+                0,
+            );
+            let count: i64 = check.db.query_row(
+                &format!(
+                    "SELECT COUNT(*)
+                     FROM {} current
+                     JOIN jazz_tx tx ON tx.tx_num = current.visible_tx_num
+                     WHERE current.row_num = ?
+                       AND {}
+                       AND current.is_deleted = 0
+                       AND tx.outcome != {}
+                       AND {policy_sql}",
+                    crate::schema::current_table("projects"),
+                    effective_branch_sql("current", "projects", check.branch_num),
+                    tx::OUTCOME_REJECTED,
+                ),
+                params![project_row_num],
+                |row| row.get(0),
+            )?;
+            Ok(count > 0)
+        }
         PolicyDef::RefReadable { field } => {
             let field_def = check
                 .table
@@ -192,6 +324,184 @@ fn effective_branch_sql(alias: &str, table_name: &str, branch_num: i64) -> Strin
     )
 }
 
+fn sql_literal(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+fn user_row_num_subquery(user: &str) -> String {
+    format!(
+        "SELECT row_num FROM jazz_row_id WHERE row_id = {}",
+        sql_literal(user)
+    )
+}
+
+fn row_id_equals_user_sql(alias: &str, user: &str) -> String {
+    format!("{alias}.row_num = ({})", user_row_num_subquery(user))
+}
+
+fn current_user_ref_equals_session_sql(
+    table: &TableDef,
+    alias: &str,
+    field_name: &str,
+    user: &str,
+) -> Result<String> {
+    let field = table
+        .fields
+        .iter()
+        .find(|candidate| candidate.name == field_name)
+        .ok_or_else(|| crate::Error::new(format!("unknown policy ref {field_name}")))?;
+    let FieldKind::Ref { table } = &field.kind else {
+        return Err(crate::Error::new(format!(
+            "policy field {} is not a ref",
+            field.name
+        )));
+    };
+    if table != "users" {
+        return Err(crate::Error::new(format!(
+            "policy field {} must reference users",
+            field.name
+        )));
+    }
+    Ok(format!(
+        "{alias}.{} = ({})",
+        crate::schema::quote_ident(&crate::schema::storage_column(field)),
+        user_row_num_subquery(user)
+    ))
+}
+
+fn current_project_ref_member_sql(
+    table: &TableDef,
+    alias: &str,
+    field_name: &str,
+    user: &str,
+    branch_num: Option<i64>,
+    depth: usize,
+) -> Result<String> {
+    let field = table
+        .fields
+        .iter()
+        .find(|candidate| candidate.name == field_name)
+        .ok_or_else(|| crate::Error::new(format!("unknown policy ref {field_name}")))?;
+    let FieldKind::Ref { table } = &field.kind else {
+        return Err(crate::Error::new(format!(
+            "policy field {} is not a ref",
+            field.name
+        )));
+    };
+    if table != "projects" {
+        return Err(crate::Error::new(format!(
+            "policy field {} must reference projects",
+            field.name
+        )));
+    }
+    Ok(current_project_member_policy_sql(
+        &format!(
+            "{alias}.{}",
+            crate::schema::quote_ident(&crate::schema::storage_column(field))
+        ),
+        user,
+        branch_num,
+        depth,
+    ))
+}
+
+fn current_group_member_policy_sql(
+    group_row_expr: &str,
+    user: &str,
+    branch_num: Option<i64>,
+    depth: usize,
+) -> String {
+    let member_alias = format!("policy_group_member_{depth}");
+    let member_tx_alias = format!("policy_group_member_tx_{depth}");
+    let branch_filter = branch_num
+        .map(|branch_num| {
+            format!(
+                "AND {}",
+                effective_branch_sql(&member_alias, "group_members", branch_num)
+            )
+        })
+        .unwrap_or_default();
+    format!(
+        "EXISTS (
+           SELECT 1
+           FROM {} {member_alias}
+           JOIN jazz_tx {member_tx_alias}
+             ON {member_tx_alias}.tx_num = {member_alias}.visible_tx_num
+           WHERE {member_alias}.group_row_num = {group_row_expr}
+             AND {member_alias}.user_row_num = ({})
+             {branch_filter}
+             AND {member_alias}.is_deleted = 0
+             AND {member_tx_alias}.outcome != {}
+         )",
+        crate::schema::current_table("group_members"),
+        user_row_num_subquery(user),
+        tx::OUTCOME_REJECTED,
+    )
+}
+
+fn current_project_member_policy_sql(
+    project_row_expr: &str,
+    user: &str,
+    branch_num: Option<i64>,
+    depth: usize,
+) -> String {
+    let project_member_alias = format!("policy_project_member_{depth}");
+    let project_member_tx_alias = format!("policy_project_member_tx_{depth}");
+    let group_member_alias = format!("policy_project_group_member_{depth}");
+    let group_member_tx_alias = format!("policy_project_group_member_tx_{depth}");
+    let group_ids_alias = format!("policy_project_group_ids_{depth}");
+    let project_member_branch_filter = branch_num
+        .map(|branch_num| {
+            format!(
+                "AND {}",
+                effective_branch_sql(&project_member_alias, "project_members", branch_num)
+            )
+        })
+        .unwrap_or_default();
+    let group_member_branch_filter = branch_num
+        .map(|branch_num| {
+            format!(
+                "AND {}",
+                effective_branch_sql(&group_member_alias, "group_members", branch_num)
+            )
+        })
+        .unwrap_or_default();
+    format!(
+        "EXISTS (
+           SELECT 1
+           FROM {} {project_member_alias}
+           JOIN jazz_tx {project_member_tx_alias}
+             ON {project_member_tx_alias}.tx_num = {project_member_alias}.visible_tx_num
+           WHERE {project_member_alias}.project_row_num = {project_row_expr}
+             {project_member_branch_filter}
+             AND {project_member_alias}.is_deleted = 0
+             AND {project_member_tx_alias}.outcome != {}
+             AND (
+               {project_member_alias}.member = {}
+               OR EXISTS (
+                 SELECT 1
+                 FROM {} {group_member_alias}
+                 JOIN jazz_tx {group_member_tx_alias}
+                   ON {group_member_tx_alias}.tx_num = {group_member_alias}.visible_tx_num
+                 JOIN jazz_row_id {group_ids_alias}
+                   ON {group_ids_alias}.row_num = {group_member_alias}.group_row_num
+                 WHERE {group_member_alias}.user_row_num = ({})
+                   {group_member_branch_filter}
+                   AND {group_member_alias}.is_deleted = 0
+                   AND {group_member_tx_alias}.outcome != {}
+                   AND {project_member_alias}.member = ('group:' || {group_ids_alias}.row_id)
+               )
+             )
+         )",
+        crate::schema::current_table("project_members"),
+        tx::OUTCOME_REJECTED,
+        sql_literal(&format!("user:{user}")),
+        crate::schema::current_table("group_members"),
+        user_row_num_subquery(user),
+        tx::OUTCOME_REJECTED,
+    )
+}
+
 pub(crate) fn branch_read_policy_sql_for_alias(
     schema: &SchemaDef,
     table: &TableDef,
@@ -246,6 +556,25 @@ fn lower_policy(
             "{alias}.j_created_by = (SELECT user_num FROM jazz_user WHERE user_id = '{}')",
             user.replace('\'', "''")
         )),
+        PolicyDef::RowIdEqualsUser => Ok(row_id_equals_user_sql(alias, user)),
+        PolicyDef::UserRefEqualsSession { field } => {
+            current_user_ref_equals_session_sql(table, alias, field, user)
+        }
+        PolicyDef::GroupMember => Ok(current_group_member_policy_sql(
+            &format!("{alias}.row_num"),
+            user,
+            branch_num,
+            depth,
+        )),
+        PolicyDef::ProjectMember => Ok(current_project_member_policy_sql(
+            &format!("{alias}.row_num"),
+            user,
+            branch_num,
+            depth,
+        )),
+        PolicyDef::ProjectRefMember { field } => {
+            current_project_ref_member_sql(table, alias, field, user, branch_num, depth)
+        }
         PolicyDef::RefReadable { field } => {
             let field = table
                 .fields
@@ -321,6 +650,25 @@ fn lower_snapshot_policy(
             "{alias}.j_created_by = (SELECT user_num FROM jazz_user WHERE user_id = '{}')",
             user.replace('\'', "''")
         )),
+        PolicyDef::RowIdEqualsUser => Ok(row_id_equals_user_sql(alias, user)),
+        PolicyDef::UserRefEqualsSession { field } => {
+            current_user_ref_equals_session_sql(table, alias, field, user)
+        }
+        PolicyDef::GroupMember => Ok(current_group_member_policy_sql(
+            &format!("{alias}.row_num"),
+            user,
+            None,
+            depth,
+        )),
+        PolicyDef::ProjectMember => Ok(current_project_member_policy_sql(
+            &format!("{alias}.row_num"),
+            user,
+            None,
+            depth,
+        )),
+        PolicyDef::ProjectRefMember { field } => {
+            current_project_ref_member_sql(table, alias, field, user, None, depth)
+        }
         PolicyDef::RefReadable { field } => {
             let field = table
                 .fields

--- a/crates/mini-jazz-sqlite/src/policy.rs
+++ b/crates/mini-jazz-sqlite/src/policy.rs
@@ -91,6 +91,34 @@ pub(crate) fn write_allowed(check: WriteCheck<'_>) -> Result<bool> {
             )?;
             Ok(count > 0)
         }
+        PolicyDef::GroupRefMember { field } => {
+            let policy_sql = current_group_ref_member_sql(
+                check.table,
+                "current",
+                field,
+                check.user,
+                Some(check.branch_num),
+                0,
+            )?;
+            let count: i64 = check.db.query_row(
+                &format!(
+                    "SELECT COUNT(*)
+                     FROM {} current
+                     JOIN jazz_tx tx ON tx.tx_num = current.visible_tx_num
+                     WHERE current.row_num = ?
+                       AND {}
+                       AND current.is_deleted = 0
+                       AND tx.outcome != {}
+                       AND {policy_sql}",
+                    crate::schema::current_table(&check.table.name),
+                    effective_branch_sql("current", &check.table.name, check.branch_num),
+                    tx::OUTCOME_REJECTED,
+                ),
+                params![check.row_num],
+                |row| row.get(0),
+            )?;
+            Ok(count > 0)
+        }
         PolicyDef::ProjectMember => {
             let policy_sql = current_project_member_policy_sql(
                 "current.row_num",
@@ -412,30 +440,110 @@ fn current_group_member_policy_sql(
     branch_num: Option<i64>,
     depth: usize,
 ) -> String {
-    let member_alias = format!("policy_group_member_{depth}");
-    let member_tx_alias = format!("policy_group_member_tx_{depth}");
-    let branch_filter = branch_num
+    let reachable_alias = format!("policy_reachable_group_{depth}");
+    let reachable_cte = current_reachable_group_rows_cte(&reachable_alias, user, branch_num, depth);
+    format!(
+        "EXISTS (
+           {reachable_cte}
+           SELECT 1
+           FROM {reachable_alias}
+           WHERE {reachable_alias}.row_num = {group_row_expr}
+         )",
+    )
+}
+
+fn current_group_ref_member_sql(
+    table: &TableDef,
+    alias: &str,
+    field_name: &str,
+    user: &str,
+    branch_num: Option<i64>,
+    depth: usize,
+) -> Result<String> {
+    let field = table
+        .fields
+        .iter()
+        .find(|candidate| candidate.name == field_name)
+        .ok_or_else(|| crate::Error::new(format!("unknown policy ref {field_name}")))?;
+    let FieldKind::Ref { table } = &field.kind else {
+        return Err(crate::Error::new(format!(
+            "policy field {} is not a ref",
+            field.name
+        )));
+    };
+    if table != "groups" {
+        return Err(crate::Error::new(format!(
+            "policy field {} must reference groups",
+            field.name
+        )));
+    }
+    Ok(current_group_member_policy_sql(
+        &format!(
+            "{alias}.{}",
+            crate::schema::quote_ident(&crate::schema::storage_column(field))
+        ),
+        user,
+        branch_num,
+        depth,
+    ))
+}
+
+fn current_reachable_group_rows_cte(
+    cte_alias: &str,
+    user: &str,
+    branch_num: Option<i64>,
+    depth: usize,
+) -> String {
+    let direct_alias = format!("{cte_alias}_direct_{depth}");
+    let direct_tx_alias = format!("{cte_alias}_direct_tx_{depth}");
+    let nested_alias = format!("{cte_alias}_nested_{depth}");
+    let nested_tx_alias = format!("{cte_alias}_nested_tx_{depth}");
+    let parent_alias = format!("{cte_alias}_parent_{depth}");
+    let parent_id_alias = format!("{cte_alias}_parent_id_{depth}");
+    let direct_branch_filter = branch_num
         .map(|branch_num| {
             format!(
                 "AND {}",
-                effective_branch_sql(&member_alias, "group_members", branch_num)
+                effective_branch_sql(&direct_alias, "group_members", branch_num)
+            )
+        })
+        .unwrap_or_default();
+    let nested_branch_filter = branch_num
+        .map(|branch_num| {
+            format!(
+                "AND {}",
+                effective_branch_sql(&nested_alias, "group_members", branch_num)
             )
         })
         .unwrap_or_default();
     format!(
-        "EXISTS (
-           SELECT 1
-           FROM {} {member_alias}
-           JOIN jazz_tx {member_tx_alias}
-             ON {member_tx_alias}.tx_num = {member_alias}.visible_tx_num
-           WHERE {member_alias}.group_row_num = {group_row_expr}
-             AND {member_alias}.user_row_num = ({})
-             {branch_filter}
-             AND {member_alias}.is_deleted = 0
-             AND {member_tx_alias}.outcome != {}
+        "WITH RECURSIVE {cte_alias}(row_num) AS (
+           SELECT {direct_alias}.group_row_num
+           FROM {} {direct_alias}
+           JOIN jazz_tx {direct_tx_alias}
+             ON {direct_tx_alias}.tx_num = {direct_alias}.visible_tx_num
+           WHERE {direct_alias}.member = {}
+             {direct_branch_filter}
+             AND {direct_alias}.is_deleted = 0
+             AND {direct_tx_alias}.outcome != {}
+           UNION
+           SELECT {nested_alias}.group_row_num
+           FROM {} {nested_alias}
+           JOIN jazz_tx {nested_tx_alias}
+             ON {nested_tx_alias}.tx_num = {nested_alias}.visible_tx_num
+           JOIN {cte_alias} {parent_alias}
+             ON 1 = 1
+           JOIN jazz_row_id {parent_id_alias}
+             ON {parent_id_alias}.row_num = {parent_alias}.row_num
+           WHERE {nested_alias}.member = ('group:' || {parent_id_alias}.row_id)
+             {nested_branch_filter}
+             AND {nested_alias}.is_deleted = 0
+             AND {nested_tx_alias}.outcome != {}
          )",
         crate::schema::current_table("group_members"),
-        user_row_num_subquery(user),
+        sql_literal(&format!("user:{user}")),
+        tx::OUTCOME_REJECTED,
+        crate::schema::current_table("group_members"),
         tx::OUTCOME_REJECTED,
     )
 }
@@ -448,22 +556,14 @@ fn current_project_member_policy_sql(
 ) -> String {
     let project_member_alias = format!("policy_project_member_{depth}");
     let project_member_tx_alias = format!("policy_project_member_tx_{depth}");
-    let group_member_alias = format!("policy_project_group_member_{depth}");
-    let group_member_tx_alias = format!("policy_project_group_member_tx_{depth}");
-    let group_ids_alias = format!("policy_project_group_ids_{depth}");
+    let reachable_alias = format!("policy_project_reachable_group_{depth}");
+    let reachable_ids_alias = format!("policy_project_reachable_group_ids_{depth}");
+    let reachable_cte = current_reachable_group_rows_cte(&reachable_alias, user, branch_num, depth);
     let project_member_branch_filter = branch_num
         .map(|branch_num| {
             format!(
                 "AND {}",
                 effective_branch_sql(&project_member_alias, "project_members", branch_num)
-            )
-        })
-        .unwrap_or_default();
-    let group_member_branch_filter = branch_num
-        .map(|branch_num| {
-            format!(
-                "AND {}",
-                effective_branch_sql(&group_member_alias, "group_members", branch_num)
             )
         })
         .unwrap_or_default();
@@ -480,26 +580,18 @@ fn current_project_member_policy_sql(
              AND (
                {project_member_alias}.member = {}
                OR EXISTS (
+                 {reachable_cte}
                  SELECT 1
-                 FROM {} {group_member_alias}
-                 JOIN jazz_tx {group_member_tx_alias}
-                   ON {group_member_tx_alias}.tx_num = {group_member_alias}.visible_tx_num
-                 JOIN jazz_row_id {group_ids_alias}
-                   ON {group_ids_alias}.row_num = {group_member_alias}.group_row_num
-                 WHERE {group_member_alias}.user_row_num = ({})
-                   {group_member_branch_filter}
-                   AND {group_member_alias}.is_deleted = 0
-                   AND {group_member_tx_alias}.outcome != {}
-                   AND {project_member_alias}.member = ('group:' || {group_ids_alias}.row_id)
+                 FROM {reachable_alias}
+                 JOIN jazz_row_id {reachable_ids_alias}
+                   ON {reachable_ids_alias}.row_num = {reachable_alias}.row_num
+                 WHERE {project_member_alias}.member = ('group:' || {reachable_ids_alias}.row_id)
                )
              )
          )",
         crate::schema::current_table("project_members"),
         tx::OUTCOME_REJECTED,
         sql_literal(&format!("user:{user}")),
-        crate::schema::current_table("group_members"),
-        user_row_num_subquery(user),
-        tx::OUTCOME_REJECTED,
     )
 }
 
@@ -567,6 +659,9 @@ fn lower_policy(
             branch_num,
             depth,
         )),
+        PolicyDef::GroupRefMember { field } => {
+            current_group_ref_member_sql(table, alias, field, user, branch_num, depth)
+        }
         PolicyDef::ProjectMember => Ok(current_project_member_policy_sql(
             &format!("{alias}.row_num"),
             user,
@@ -661,6 +756,9 @@ fn lower_snapshot_policy(
             None,
             depth,
         )),
+        PolicyDef::GroupRefMember { field } => {
+            current_group_ref_member_sql(table, alias, field, user, None, depth)
+        }
         PolicyDef::ProjectMember => Ok(current_project_member_policy_sql(
             &format!("{alias}.row_num"),
             user,

--- a/crates/mini-jazz-sqlite/src/policy.rs
+++ b/crates/mini-jazz-sqlite/src/policy.rs
@@ -10,6 +10,7 @@ pub(crate) struct WriteCheck<'a> {
     pub(crate) db: &'a Connection,
     pub(crate) schema: &'a SchemaDef,
     pub(crate) table: &'a TableDef,
+    pub(crate) policy: &'a PolicyDef,
     pub(crate) row_num: i64,
     pub(crate) branch_num: i64,
     pub(crate) values: &'a BTreeMap<String, JsonValue>,
@@ -17,7 +18,7 @@ pub(crate) struct WriteCheck<'a> {
 }
 
 pub(crate) fn write_allowed(check: WriteCheck<'_>) -> Result<bool> {
-    match &check.table.write_policy {
+    match check.policy {
         PolicyDef::AllowAll => Ok(true),
         PolicyDef::CreatedByUser => {
             let user_num = users::ensure_user(check.db, check.user)?;

--- a/crates/mini-jazz-sqlite/src/policy.rs
+++ b/crates/mini-jazz-sqlite/src/policy.rs
@@ -1,6 +1,6 @@
-use crate::schema::{FieldKind, PolicyDef, SchemaDef, TableDef};
-use crate::{branch, tx, users, Result};
-use rusqlite::{params, Connection};
+use crate::schema::{CmpOp, FieldKind, Operation, PolicyDef, PolicyValue, SchemaDef, TableDef};
+use crate::{branch, tx, Result};
+use rusqlite::{params, Connection, OptionalExtension};
 use serde_json::Value as JsonValue;
 use std::collections::BTreeMap;
 
@@ -15,258 +15,56 @@ pub(crate) struct WriteCheck<'a> {
     pub(crate) branch_num: i64,
     pub(crate) values: &'a BTreeMap<String, JsonValue>,
     pub(crate) user: &'a str,
+    pub(crate) created_by: Option<&'a str>,
 }
 
 pub(crate) fn write_allowed(check: WriteCheck<'_>) -> Result<bool> {
-    match check.policy {
-        PolicyDef::AllowAll => Ok(true),
-        PolicyDef::CreatedByUser => {
-            let user_num = users::ensure_user(check.db, check.user)?;
-            let count: i64 = check.db.query_row(
-                &format!(
-                    "SELECT COUNT(*)
-                     FROM {} current
-                     WHERE current.row_num = ?
-                       AND current.j_branch_num = ?
-                       AND current.j_created_by = ?",
-                    crate::schema::current_table(&check.table.name)
-                ),
-                params![check.row_num, check.branch_num, user_num],
-                |row| row.get(0),
-            )?;
-            Ok(count > 0)
+    write_allowed_for_policy(&check, check.policy)
+}
+
+fn write_allowed_for_policy(check: &WriteCheck<'_>, policy: &PolicyDef) -> Result<bool> {
+    match policy {
+        PolicyDef::True => Ok(true),
+        PolicyDef::False => Ok(false),
+        PolicyDef::Cmp { column, op, value } => cmp_write_allowed(check, column, op, value),
+        PolicyDef::SessionCmp { .. }
+        | PolicyDef::IsNull { .. }
+        | PolicyDef::SessionIsNull { .. }
+        | PolicyDef::IsNotNull { .. }
+        | PolicyDef::SessionIsNotNull { .. }
+        | PolicyDef::Contains { .. }
+        | PolicyDef::SessionContains { .. }
+        | PolicyDef::In { .. }
+        | PolicyDef::InList { .. }
+        | PolicyDef::SessionInList { .. }
+        | PolicyDef::Exists { .. }
+        | PolicyDef::ExistsRel { .. } => current_row_matches_policy(check, policy),
+        PolicyDef::Inherits {
+            operation,
+            via_column,
+            ..
+        } => {
+            ensure_select_operation(*operation)?;
+            ref_readable_write_allowed(check, via_column)
         }
-        PolicyDef::RowIdEqualsUser => {
-            Ok(crate::rows::public_row_id(check.db, check.row_num)? == check.user)
-        }
-        PolicyDef::UserRefEqualsSession { field } => {
-            let field_def = check
-                .table
-                .fields
-                .iter()
-                .find(|candidate| candidate.name == *field)
-                .ok_or_else(|| crate::Error::new(format!("unknown policy ref {field}")))?;
-            let FieldKind::Ref { table } = &field_def.kind else {
-                return Err(crate::Error::new(format!(
-                    "policy field {} is not a ref",
-                    field_def.name
-                )));
-            };
-            if table != "users" {
-                return Err(crate::Error::new(format!(
-                    "policy field {} must reference users",
-                    field_def.name
-                )));
-            }
-            Ok(check
-                .values
-                .get(field)
-                .or_else(|| check.values.get(&field_def.storage_name))
-                .and_then(JsonValue::as_str)
-                == Some(check.user))
-        }
-        PolicyDef::GroupMember => {
-            let policy_sql = current_group_member_policy_sql(
-                "current.row_num",
-                check.user,
-                Some(check.branch_num),
-                0,
-            );
-            let count: i64 = check.db.query_row(
-                &format!(
-                    "SELECT COUNT(*)
-                     FROM {} current
-                     JOIN jazz_tx tx ON tx.tx_num = current.visible_tx_num
-                     WHERE current.row_num = ?
-                       AND {}
-                       AND current.is_deleted = 0
-                       AND tx.outcome != {}
-                       AND {policy_sql}",
-                    crate::schema::current_table(&check.table.name),
-                    effective_branch_sql("current", &check.table.name, check.branch_num),
-                    tx::OUTCOME_REJECTED,
-                ),
-                params![check.row_num],
-                |row| row.get(0),
-            )?;
-            Ok(count > 0)
-        }
-        PolicyDef::GroupRefMember { field } => {
-            let policy_sql = current_group_ref_member_sql(
-                check.table,
-                "current",
-                field,
-                check.user,
-                Some(check.branch_num),
-                0,
-            )?;
-            let count: i64 = check.db.query_row(
-                &format!(
-                    "SELECT COUNT(*)
-                     FROM {} current
-                     JOIN jazz_tx tx ON tx.tx_num = current.visible_tx_num
-                     WHERE current.row_num = ?
-                       AND {}
-                       AND current.is_deleted = 0
-                       AND tx.outcome != {}
-                       AND {policy_sql}",
-                    crate::schema::current_table(&check.table.name),
-                    effective_branch_sql("current", &check.table.name, check.branch_num),
-                    tx::OUTCOME_REJECTED,
-                ),
-                params![check.row_num],
-                |row| row.get(0),
-            )?;
-            Ok(count > 0)
-        }
-        PolicyDef::ProjectMember => {
-            let policy_sql = current_project_member_policy_sql(
-                "current.row_num",
-                check.user,
-                Some(check.branch_num),
-                0,
-            );
-            let count: i64 = check.db.query_row(
-                &format!(
-                    "SELECT COUNT(*)
-                     FROM {} current
-                     JOIN jazz_tx tx ON tx.tx_num = current.visible_tx_num
-                     WHERE current.row_num = ?
-                       AND {}
-                       AND current.is_deleted = 0
-                       AND tx.outcome != {}
-                       AND {policy_sql}",
-                    crate::schema::current_table(&check.table.name),
-                    effective_branch_sql("current", &check.table.name, check.branch_num),
-                    tx::OUTCOME_REJECTED,
-                ),
-                params![check.row_num],
-                |row| row.get(0),
-            )?;
-            Ok(count > 0)
-        }
-        PolicyDef::ProjectRefMember { field } => {
-            let field_def = check
-                .table
-                .fields
-                .iter()
-                .find(|candidate| candidate.name == *field)
-                .ok_or_else(|| crate::Error::new(format!("unknown policy ref {field}")))?;
-            let FieldKind::Ref { table } = &field_def.kind else {
-                return Err(crate::Error::new(format!(
-                    "policy field {} is not a ref",
-                    field_def.name
-                )));
-            };
-            if table != "projects" {
-                return Err(crate::Error::new(format!(
-                    "policy field {} must reference projects",
-                    field_def.name
-                )));
-            }
-            let project_id = check
-                .values
-                .get(field)
-                .or_else(|| check.values.get(&field_def.storage_name))
-                .and_then(JsonValue::as_str)
-                .ok_or_else(|| crate::Error::new(format!("expected ref id for {field}")))?;
-            let project_row_num = crate::rows::row_num(check.db, project_id)?;
-            let policy_sql = current_project_member_policy_sql(
-                "current.row_num",
-                check.user,
-                Some(check.branch_num),
-                0,
-            );
-            let count: i64 = check.db.query_row(
-                &format!(
-                    "SELECT COUNT(*)
-                     FROM {} current
-                     JOIN jazz_tx tx ON tx.tx_num = current.visible_tx_num
-                     WHERE current.row_num = ?
-                       AND {}
-                       AND current.is_deleted = 0
-                       AND tx.outcome != {}
-                       AND {policy_sql}",
-                    crate::schema::current_table("projects"),
-                    effective_branch_sql("current", "projects", check.branch_num),
-                    tx::OUTCOME_REJECTED,
-                ),
-                params![project_row_num],
-                |row| row.get(0),
-            )?;
-            Ok(count > 0)
-        }
-        PolicyDef::RefReadable { field } => {
-            let field_def = check
-                .table
-                .fields
-                .iter()
-                .find(|candidate| candidate.name == *field)
-                .ok_or_else(|| crate::Error::new(format!("unknown policy ref {field}")))?;
-            let FieldKind::Ref {
-                table: ref_table_name,
-            } = &field_def.kind
-            else {
-                return Err(crate::Error::new(format!(
-                    "policy field {} is not a ref",
-                    field_def.name
-                )));
-            };
-            let ref_id = check
-                .values
-                .get(field)
-                .or_else(|| check.values.get(&field_def.storage_name))
-                .and_then(JsonValue::as_str)
-                .ok_or_else(|| crate::Error::new(format!("expected ref id for {field}")))?;
-            let ref_row_num = crate::rows::row_num(check.db, ref_id)?;
-            let ref_table = check.schema.table_def(ref_table_name)?;
-            if check.branch_num != 1 {
-                if let Some(base_epoch) = branch::base_global_epoch(check.db, check.branch_num)? {
-                    if !branch_current_row_exists(
-                        check.db,
-                        ref_table_name,
-                        ref_row_num,
-                        check.branch_num,
-                    )? {
-                        return snapshot_write_ref_allowed(
-                            check.db,
-                            check.schema,
-                            ref_table,
-                            ref_row_num,
-                            check.user,
-                            base_epoch,
-                        );
-                    }
+        PolicyDef::InheritsReferencing { .. } => current_row_matches_policy(check, policy),
+        PolicyDef::And(children) => {
+            for child in children {
+                if !write_allowed_for_policy(check, child)? {
+                    return Ok(false);
                 }
             }
-            let policy_sql = lower_policy(
-                check.schema,
-                ref_table,
-                "current",
-                &ref_table.read_policy,
-                check.user,
-                Some(check.branch_num),
-                0,
-            )?;
-            let count: i64 = check.db.query_row(
-                &format!(
-                    "SELECT COUNT(*)
-                     FROM {} current
-                     JOIN jazz_tx tx ON tx.tx_num = current.visible_tx_num
-                     WHERE current.row_num = ?
-                       AND {}
-                       AND current.is_deleted = 0
-                       AND tx.outcome != {}
-                       AND {policy_sql}",
-                    crate::schema::current_table(ref_table_name),
-                    effective_branch_sql("current", ref_table_name, check.branch_num),
-                    tx::OUTCOME_REJECTED,
-                ),
-                params![ref_row_num],
-                |row| row.get(0),
-            )?;
-            Ok(count > 0)
+            Ok(true)
         }
+        PolicyDef::Or(children) => {
+            for child in children {
+                if write_allowed_for_policy(check, child)? {
+                    return Ok(true);
+                }
+            }
+            Ok(false)
+        }
+        PolicyDef::Not(child) => Ok(!write_allowed_for_policy(check, child)?),
     }
 }
 
@@ -285,6 +83,232 @@ fn branch_current_row_exists(
             crate::schema::current_table(table_name)
         ),
         params![row_num, branch_num],
+        |row| row.get(0),
+    )?;
+    Ok(count > 0)
+}
+
+fn ensure_select_operation(operation: Operation) -> Result<()> {
+    if operation != Operation::Select {
+        return Err(crate::Error::new(
+            "mini-sqlite policies only lower SELECT inheritance today",
+        ));
+    }
+    Ok(())
+}
+
+fn cmp_write_allowed(
+    check: &WriteCheck<'_>,
+    column: &str,
+    op: &CmpOp,
+    value: &PolicyValue,
+) -> Result<bool> {
+    if column == "$id" {
+        let left = JsonValue::String(crate::rows::public_row_id(check.db, check.row_num)?);
+        let right = resolve_policy_value_for_json(check, value)?;
+        return Ok(compare_json_values(&left, op, &right));
+    }
+    if column == "$createdBy" {
+        let left = current_or_pending_created_by(check)?
+            .map(JsonValue::String)
+            .unwrap_or(JsonValue::Null);
+        let right = resolve_policy_value_for_json(check, value)?;
+        return Ok(compare_json_values(&left, op, &right));
+    }
+    let field = check
+        .table
+        .fields
+        .iter()
+        .find(|candidate| candidate.name == column)
+        .ok_or_else(|| crate::Error::new(format!("unknown policy column {column}")))?;
+    let left = check
+        .values
+        .get(column)
+        .or_else(|| check.values.get(&field.storage_name))
+        .cloned()
+        .unwrap_or(JsonValue::Null);
+    let right = match &field.kind {
+        FieldKind::Ref { table } => resolve_policy_value_for_ref(check, table, value)?,
+        FieldKind::Text | FieldKind::Bool => resolve_policy_value_for_json(check, value)?,
+    };
+    Ok(compare_json_values(&left, op, &right))
+}
+
+fn current_or_pending_created_by(check: &WriteCheck<'_>) -> Result<Option<String>> {
+    if let Some(created_by) = check.created_by {
+        return Ok(Some(created_by.to_owned()));
+    }
+    check
+        .db
+        .query_row(
+            &format!(
+                "SELECT user.user_id
+                 FROM {} current
+                 JOIN jazz_user user ON user.user_num = current.j_created_by
+                 WHERE current.row_num = ?
+                   AND current.j_branch_num = ?",
+                crate::schema::current_table(&check.table.name)
+            ),
+            params![check.row_num, check.branch_num],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(Into::into)
+}
+
+fn resolve_policy_value_for_ref(
+    check: &WriteCheck<'_>,
+    ref_table: &str,
+    value: &PolicyValue,
+) -> Result<JsonValue> {
+    match value {
+        PolicyValue::Literal(value) => Ok(value.clone()),
+        PolicyValue::SessionRef(path) if is_session_user_id(path) && ref_table == "users" => {
+            Ok(JsonValue::String(check.user.to_owned()))
+        }
+        PolicyValue::SessionRef(path) => Err(crate::Error::new(format!(
+            "unsupported policy session ref {}",
+            path.join(".")
+        ))),
+    }
+}
+
+fn resolve_policy_value_for_json(check: &WriteCheck<'_>, value: &PolicyValue) -> Result<JsonValue> {
+    match value {
+        PolicyValue::Literal(value) => Ok(value.clone()),
+        PolicyValue::SessionRef(path) if is_session_user_id(path) => {
+            Ok(JsonValue::String(check.user.to_owned()))
+        }
+        PolicyValue::SessionRef(path) => Err(crate::Error::new(format!(
+            "unsupported policy session ref {}",
+            path.join(".")
+        ))),
+    }
+}
+
+fn compare_json_values(left: &JsonValue, op: &CmpOp, right: &JsonValue) -> bool {
+    match op {
+        CmpOp::Eq => left == right,
+        CmpOp::Ne => left != right,
+        CmpOp::Lt => json_ord(left, right).is_some_and(|ord| ord.is_lt()),
+        CmpOp::Le => json_ord(left, right).is_some_and(|ord| ord.is_le()),
+        CmpOp::Gt => json_ord(left, right).is_some_and(|ord| ord.is_gt()),
+        CmpOp::Ge => json_ord(left, right).is_some_and(|ord| ord.is_ge()),
+    }
+}
+
+fn json_ord(left: &JsonValue, right: &JsonValue) -> Option<std::cmp::Ordering> {
+    match (left, right) {
+        (JsonValue::String(left), JsonValue::String(right)) => Some(left.cmp(right)),
+        (JsonValue::Number(left), JsonValue::Number(right)) => {
+            left.as_f64()?.partial_cmp(&right.as_f64()?)
+        }
+        (JsonValue::Bool(left), JsonValue::Bool(right)) => Some(left.cmp(right)),
+        _ => None,
+    }
+}
+
+fn ref_readable_write_allowed(check: &WriteCheck<'_>, field: &str) -> Result<bool> {
+    let field_def = check
+        .table
+        .fields
+        .iter()
+        .find(|candidate| candidate.name == field)
+        .ok_or_else(|| crate::Error::new(format!("unknown policy ref {field}")))?;
+    let FieldKind::Ref {
+        table: ref_table_name,
+    } = &field_def.kind
+    else {
+        return Err(crate::Error::new(format!(
+            "policy field {} is not a ref",
+            field_def.name
+        )));
+    };
+    let ref_id = check
+        .values
+        .get(field)
+        .or_else(|| check.values.get(&field_def.storage_name))
+        .and_then(JsonValue::as_str)
+        .ok_or_else(|| crate::Error::new(format!("expected ref id for {field}")))?;
+    ref_row_read_allowed(check, ref_table_name, ref_id)
+}
+
+fn ref_row_read_allowed(
+    check: &WriteCheck<'_>,
+    ref_table_name: &str,
+    ref_id: &str,
+) -> Result<bool> {
+    let ref_row_num = crate::rows::row_num(check.db, ref_id)?;
+    let ref_table = check.schema.table_def(ref_table_name)?;
+    if check.branch_num != 1 {
+        if let Some(base_epoch) = branch::base_global_epoch(check.db, check.branch_num)? {
+            if !branch_current_row_exists(check.db, ref_table_name, ref_row_num, check.branch_num)?
+            {
+                return snapshot_write_ref_allowed(
+                    check.db,
+                    check.schema,
+                    ref_table,
+                    ref_row_num,
+                    check.user,
+                    base_epoch,
+                );
+            }
+        }
+    }
+    let policy_sql = lower_policy(
+        check.schema,
+        ref_table,
+        "current",
+        &ref_table.read_policy,
+        check.user,
+        Some(check.branch_num),
+        0,
+    )?;
+    let count: i64 = check.db.query_row(
+        &format!(
+            "SELECT COUNT(*)
+             FROM {} current
+             JOIN jazz_tx tx ON tx.tx_num = current.visible_tx_num
+             WHERE current.row_num = ?
+               AND {}
+               AND current.is_deleted = 0
+               AND tx.outcome != {}
+               AND {policy_sql}",
+            crate::schema::current_table(ref_table_name),
+            effective_branch_sql("current", ref_table_name, check.branch_num),
+            tx::OUTCOME_REJECTED,
+        ),
+        params![ref_row_num],
+        |row| row.get(0),
+    )?;
+    Ok(count > 0)
+}
+
+fn current_row_matches_policy(check: &WriteCheck<'_>, policy: &PolicyDef) -> Result<bool> {
+    let policy_sql = lower_policy(
+        check.schema,
+        check.table,
+        "current",
+        policy,
+        check.user,
+        Some(check.branch_num),
+        0,
+    )?;
+    let count: i64 = check.db.query_row(
+        &format!(
+            "SELECT COUNT(*)
+             FROM {} current
+             JOIN jazz_tx tx ON tx.tx_num = current.visible_tx_num
+             WHERE current.row_num = ?
+               AND {}
+               AND current.is_deleted = 0
+               AND tx.outcome != {}
+               AND {policy_sql}",
+            crate::schema::current_table(&check.table.name),
+            effective_branch_sql("current", &check.table.name, check.branch_num),
+            tx::OUTCOME_REJECTED,
+        ),
+        params![check.row_num],
         |row| row.get(0),
     )?;
     Ok(count > 0)
@@ -353,7 +377,7 @@ fn effective_branch_sql(alias: &str, table_name: &str, branch_num: i64) -> Strin
     )
 }
 
-fn sql_literal(value: &str) -> String {
+pub(crate) fn sql_literal(value: &str) -> String {
     format!("'{}'", value.replace('\'', "''"))
 }
 
@@ -364,73 +388,158 @@ fn user_row_num_subquery(user: &str) -> String {
     )
 }
 
-fn row_id_equals_user_sql(alias: &str, user: &str) -> String {
-    format!("{alias}.row_num = ({})", user_row_num_subquery(user))
-}
-
-fn current_user_ref_equals_session_sql(
+fn current_cmp_sql(
     table: &TableDef,
     alias: &str,
-    field_name: &str,
+    column: &str,
+    op: &CmpOp,
+    value: &PolicyValue,
     user: &str,
 ) -> Result<String> {
+    let left = policy_column_sql(table, alias, column)?;
+    let right = policy_value_sql(table, column, value, user)?;
+    Ok(format!("{left} {} {right}", cmp_op_sql(op)))
+}
+
+fn policy_column_sql(table: &TableDef, alias: &str, column: &str) -> Result<String> {
+    if column == "$id" {
+        return Ok(format!(
+            "(SELECT row_id FROM jazz_row_id WHERE row_num = {alias}.row_num)"
+        ));
+    }
+    if column == "$createdBy" {
+        return Ok(format!(
+            "(SELECT user_id FROM jazz_user WHERE user_num = {alias}.j_created_by)"
+        ));
+    }
     let field = table
         .fields
         .iter()
-        .find(|candidate| candidate.name == field_name)
-        .ok_or_else(|| crate::Error::new(format!("unknown policy ref {field_name}")))?;
-    let FieldKind::Ref { table } = &field.kind else {
-        return Err(crate::Error::new(format!(
-            "policy field {} is not a ref",
-            field.name
-        )));
-    };
-    if table != "users" {
-        return Err(crate::Error::new(format!(
-            "policy field {} must reference users",
-            field.name
-        )));
-    }
+        .find(|candidate| candidate.name == column)
+        .ok_or_else(|| crate::Error::new(format!("unknown policy column {column}")))?;
     Ok(format!(
-        "{alias}.{} = ({})",
-        crate::schema::quote_ident(&crate::schema::storage_column(field)),
-        user_row_num_subquery(user)
+        "{alias}.{}",
+        crate::schema::quote_ident(&crate::schema::storage_column(field))
     ))
 }
 
-fn current_project_ref_member_sql(
+fn policy_value_sql(
     table: &TableDef,
-    alias: &str,
-    field_name: &str,
+    column: &str,
+    value: &PolicyValue,
+    user: &str,
+) -> Result<String> {
+    match value {
+        PolicyValue::Literal(value) => {
+            let Some(field) = table
+                .fields
+                .iter()
+                .find(|candidate| candidate.name == column)
+            else {
+                return Ok(json_literal_sql(value));
+            };
+            match (&field.kind, value) {
+                (FieldKind::Ref { .. }, JsonValue::String(row_id)) => Ok(format!(
+                    "(SELECT row_num FROM jazz_row_id WHERE row_id = {})",
+                    sql_literal(row_id)
+                )),
+                _ => Ok(json_literal_sql(value)),
+            }
+        }
+        PolicyValue::SessionRef(path) if is_session_user_id(path) => {
+            let Some(field) = table
+                .fields
+                .iter()
+                .find(|candidate| candidate.name == column)
+            else {
+                return Ok(sql_literal(user));
+            };
+            match &field.kind {
+                FieldKind::Ref { table } if table == "users" => {
+                    Ok(format!("({})", user_row_num_subquery(user)))
+                }
+                _ => Ok(sql_literal(user)),
+            }
+        }
+        PolicyValue::SessionRef(path) => Err(crate::Error::new(format!(
+            "unsupported policy session ref {}",
+            path.join(".")
+        ))),
+    }
+}
+
+fn is_session_user_id(path: &[String]) -> bool {
+    path.len() == 1 && path[0] == "user_id"
+}
+
+fn cmp_op_sql(op: &CmpOp) -> &'static str {
+    match op {
+        CmpOp::Eq => "=",
+        CmpOp::Ne => "!=",
+        CmpOp::Lt => "<",
+        CmpOp::Le => "<=",
+        CmpOp::Gt => ">",
+        CmpOp::Ge => ">=",
+    }
+}
+
+fn json_literal_sql(value: &JsonValue) -> String {
+    match value {
+        JsonValue::String(value) => sql_literal(value),
+        JsonValue::Bool(value) => {
+            if *value {
+                "1".to_owned()
+            } else {
+                "0".to_owned()
+            }
+        }
+        JsonValue::Number(value) => value.to_string(),
+        JsonValue::Null => "NULL".to_owned(),
+        JsonValue::Array(_) | JsonValue::Object(_) => sql_literal(&value.to_string()),
+    }
+}
+
+fn current_exists_policy_sql(
+    schema: &SchemaDef,
+    table_name: &str,
+    condition: &PolicyDef,
     user: &str,
     branch_num: Option<i64>,
     depth: usize,
 ) -> Result<String> {
-    let field = table
-        .fields
-        .iter()
-        .find(|candidate| candidate.name == field_name)
-        .ok_or_else(|| crate::Error::new(format!("unknown policy ref {field_name}")))?;
-    let FieldKind::Ref { table } = &field.kind else {
-        return Err(crate::Error::new(format!(
-            "policy field {} is not a ref",
-            field.name
-        )));
-    };
-    if table != "projects" {
-        return Err(crate::Error::new(format!(
-            "policy field {} must reference projects",
-            field.name
-        )));
-    }
-    Ok(current_project_member_policy_sql(
-        &format!(
-            "{alias}.{}",
-            crate::schema::quote_ident(&crate::schema::storage_column(field))
-        ),
+    let exists_table = schema.table_def(table_name)?;
+    let exists_alias = format!("policy_exists_{depth}");
+    let exists_tx_alias = format!("policy_exists_tx_{depth}");
+    let condition_sql = lower_policy(
+        schema,
+        exists_table,
+        &exists_alias,
+        condition,
         user,
         branch_num,
-        depth,
+        depth + 1,
+    )?;
+    let branch_filter = branch_num
+        .map(|branch_num| {
+            format!(
+                "AND {}",
+                effective_branch_sql(&exists_alias, table_name, branch_num)
+            )
+        })
+        .unwrap_or_default();
+    Ok(format!(
+        "EXISTS (
+           SELECT 1
+           FROM {} {exists_alias}
+           JOIN jazz_tx {exists_tx_alias}
+             ON {exists_tx_alias}.tx_num = {exists_alias}.visible_tx_num
+           WHERE {exists_alias}.is_deleted = 0
+             {branch_filter}
+             AND {exists_tx_alias}.outcome != {}
+             AND {condition_sql}
+         )",
+        crate::schema::current_table(table_name),
+        tx::OUTCOME_REJECTED,
     ))
 }
 
@@ -452,42 +561,6 @@ fn current_group_member_policy_sql(
     )
 }
 
-fn current_group_ref_member_sql(
-    table: &TableDef,
-    alias: &str,
-    field_name: &str,
-    user: &str,
-    branch_num: Option<i64>,
-    depth: usize,
-) -> Result<String> {
-    let field = table
-        .fields
-        .iter()
-        .find(|candidate| candidate.name == field_name)
-        .ok_or_else(|| crate::Error::new(format!("unknown policy ref {field_name}")))?;
-    let FieldKind::Ref { table } = &field.kind else {
-        return Err(crate::Error::new(format!(
-            "policy field {} is not a ref",
-            field.name
-        )));
-    };
-    if table != "groups" {
-        return Err(crate::Error::new(format!(
-            "policy field {} must reference groups",
-            field.name
-        )));
-    }
-    Ok(current_group_member_policy_sql(
-        &format!(
-            "{alias}.{}",
-            crate::schema::quote_ident(&crate::schema::storage_column(field))
-        ),
-        user,
-        branch_num,
-        depth,
-    ))
-}
-
 fn current_reachable_group_rows_cte(
     cte_alias: &str,
     user: &str,
@@ -499,7 +572,6 @@ fn current_reachable_group_rows_cte(
     let nested_alias = format!("{cte_alias}_nested_{depth}");
     let nested_tx_alias = format!("{cte_alias}_nested_tx_{depth}");
     let parent_alias = format!("{cte_alias}_parent_{depth}");
-    let parent_id_alias = format!("{cte_alias}_parent_id_{depth}");
     let direct_branch_filter = branch_num
         .map(|branch_num| {
             format!(
@@ -522,7 +594,7 @@ fn current_reachable_group_rows_cte(
            FROM {} {direct_alias}
            JOIN jazz_tx {direct_tx_alias}
              ON {direct_tx_alias}.tx_num = {direct_alias}.visible_tx_num
-           WHERE {direct_alias}.member = {}
+           WHERE {direct_alias}.user_row_num = ({})
              {direct_branch_filter}
              AND {direct_alias}.is_deleted = 0
              AND {direct_tx_alias}.outcome != {}
@@ -533,15 +605,13 @@ fn current_reachable_group_rows_cte(
              ON {nested_tx_alias}.tx_num = {nested_alias}.visible_tx_num
            JOIN {cte_alias} {parent_alias}
              ON 1 = 1
-           JOIN jazz_row_id {parent_id_alias}
-             ON {parent_id_alias}.row_num = {parent_alias}.row_num
-           WHERE {nested_alias}.member = ('group:' || {parent_id_alias}.row_id)
+           WHERE {nested_alias}.member_group_row_num = {parent_alias}.row_num
              {nested_branch_filter}
              AND {nested_alias}.is_deleted = 0
              AND {nested_tx_alias}.outcome != {}
          )",
         crate::schema::current_table("group_members"),
-        sql_literal(&format!("user:{user}")),
+        user_row_num_subquery(user),
         tx::OUTCOME_REJECTED,
         crate::schema::current_table("group_members"),
         tx::OUTCOME_REJECTED,
@@ -557,7 +627,6 @@ fn current_project_member_policy_sql(
     let project_member_alias = format!("policy_project_member_{depth}");
     let project_member_tx_alias = format!("policy_project_member_tx_{depth}");
     let reachable_alias = format!("policy_project_reachable_group_{depth}");
-    let reachable_ids_alias = format!("policy_project_reachable_group_ids_{depth}");
     let reachable_cte = current_reachable_group_rows_cte(&reachable_alias, user, branch_num, depth);
     let project_member_branch_filter = branch_num
         .map(|branch_num| {
@@ -578,21 +647,180 @@ fn current_project_member_policy_sql(
              AND {project_member_alias}.is_deleted = 0
              AND {project_member_tx_alias}.outcome != {}
              AND (
-               {project_member_alias}.member = {}
+               {project_member_alias}.user_row_num = ({})
                OR EXISTS (
                  {reachable_cte}
                  SELECT 1
                  FROM {reachable_alias}
-                 JOIN jazz_row_id {reachable_ids_alias}
-                   ON {reachable_ids_alias}.row_num = {reachable_alias}.row_num
-                 WHERE {project_member_alias}.member = ('group:' || {reachable_ids_alias}.row_id)
+                 WHERE {project_member_alias}.group_row_num = {reachable_alias}.row_num
                )
              )
          )",
         crate::schema::current_table("project_members"),
         tx::OUTCOME_REJECTED,
-        sql_literal(&format!("user:{user}")),
+        user_row_num_subquery(user),
     )
+}
+
+fn current_inherits_policy_sql(
+    schema: &SchemaDef,
+    table: &TableDef,
+    alias: &str,
+    field_name: &str,
+    user: &str,
+    branch_num: Option<i64>,
+    depth: usize,
+) -> Result<String> {
+    let field = table
+        .fields
+        .iter()
+        .find(|candidate| candidate.name == field_name)
+        .ok_or_else(|| crate::Error::new(format!("unknown policy ref {field_name}")))?;
+    let FieldKind::Ref {
+        table: ref_table_name,
+    } = &field.kind
+    else {
+        return Err(crate::Error::new(format!(
+            "policy field {} is not a ref",
+            field.name
+        )));
+    };
+    let ref_table = schema.table_def(ref_table_name)?;
+    let parent_alias = format!("policy_parent_{depth}");
+    let parent_tx_alias = format!("policy_parent_tx_{depth}");
+    let parent_policy = lower_policy(
+        schema,
+        ref_table,
+        &parent_alias,
+        &ref_table.read_policy,
+        user,
+        branch_num,
+        depth + 1,
+    )?;
+    let branch_filter = branch_num
+        .map(|branch_num| {
+            format!(
+                "AND {}",
+                effective_branch_sql(&parent_alias, &ref_table.name, branch_num)
+            )
+        })
+        .unwrap_or_default();
+    Ok(format!(
+        "EXISTS (
+           SELECT 1
+           FROM {} {parent_alias}
+           JOIN jazz_tx {parent_tx_alias}
+             ON {parent_tx_alias}.tx_num = {parent_alias}.visible_tx_num
+           WHERE {parent_alias}.row_num = {alias}.{}
+             {branch_filter}
+             AND {parent_alias}.is_deleted = 0
+             AND {parent_tx_alias}.outcome != {}
+             AND {parent_policy}
+         )",
+        crate::schema::current_table(&ref_table.name),
+        crate::schema::quote_ident(&crate::schema::storage_column(field)),
+        tx::OUTCOME_REJECTED,
+    ))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn current_inherits_referencing_policy_sql(
+    schema: &SchemaDef,
+    table: &TableDef,
+    alias: &str,
+    source_table_name: &str,
+    field_name: &str,
+    user: &str,
+    branch_num: Option<i64>,
+    depth: usize,
+) -> Result<String> {
+    let source_table = schema.table_def(source_table_name)?;
+    if source_table_name == "group_members"
+        && field_name == "group"
+        && source_table
+            .read_policy
+            .is_user_or_ref_readable("user", "member_group")
+    {
+        return Ok(current_group_member_policy_sql(
+            &format!("{alias}.row_num"),
+            user,
+            branch_num,
+            depth,
+        ));
+    }
+    if source_table_name == "project_members"
+        && field_name == "project"
+        && source_table
+            .read_policy
+            .is_user_or_ref_readable("user", "group")
+    {
+        return Ok(current_project_member_policy_sql(
+            &format!("{alias}.row_num"),
+            user,
+            branch_num,
+            depth,
+        ));
+    }
+
+    let field = source_table
+        .fields
+        .iter()
+        .find(|candidate| candidate.name == field_name)
+        .ok_or_else(|| {
+            crate::Error::new(format!(
+                "unknown policy ref {source_table_name}.{field_name}"
+            ))
+        })?;
+    let FieldKind::Ref {
+        table: ref_table_name,
+    } = &field.kind
+    else {
+        return Err(crate::Error::new(format!(
+            "policy field {}.{} is not a ref",
+            source_table_name, field.name
+        )));
+    };
+    if ref_table_name != &table.name {
+        return Err(crate::Error::new(format!(
+            "policy field {}.{} must reference {}",
+            source_table_name, field.name, table.name
+        )));
+    }
+    let source_alias = format!("policy_ref_source_{depth}");
+    let source_tx_alias = format!("policy_ref_source_tx_{depth}");
+    let source_policy = lower_policy(
+        schema,
+        source_table,
+        &source_alias,
+        &source_table.read_policy,
+        user,
+        branch_num,
+        depth + 1,
+    )?;
+    let branch_filter = branch_num
+        .map(|branch_num| {
+            format!(
+                "AND {}",
+                effective_branch_sql(&source_alias, source_table_name, branch_num)
+            )
+        })
+        .unwrap_or_default();
+    Ok(format!(
+        "EXISTS (
+           SELECT 1
+           FROM {} {source_alias}
+           JOIN jazz_tx {source_tx_alias}
+             ON {source_tx_alias}.tx_num = {source_alias}.visible_tx_num
+           WHERE {source_alias}.{} = {alias}.row_num
+             {branch_filter}
+             AND {source_alias}.is_deleted = 0
+             AND {source_tx_alias}.outcome != {}
+             AND {source_policy}
+         )",
+        crate::schema::current_table(source_table_name),
+        crate::schema::quote_ident(&crate::schema::storage_column(field)),
+        tx::OUTCOME_REJECTED,
+    ))
 }
 
 pub(crate) fn branch_read_policy_sql_for_alias(
@@ -644,85 +872,78 @@ fn lower_policy(
         return Err(crate::Error::new("policy recursion depth exceeded"));
     }
     match policy {
-        PolicyDef::AllowAll => Ok("1 = 1".to_owned()),
-        PolicyDef::CreatedByUser => Ok(format!(
-            "{alias}.j_created_by = (SELECT user_num FROM jazz_user WHERE user_id = '{}')",
-            user.replace('\'', "''")
-        )),
-        PolicyDef::RowIdEqualsUser => Ok(row_id_equals_user_sql(alias, user)),
-        PolicyDef::UserRefEqualsSession { field } => {
-            current_user_ref_equals_session_sql(table, alias, field, user)
+        PolicyDef::True => Ok("1 = 1".to_owned()),
+        PolicyDef::False => Ok("0 = 1".to_owned()),
+        PolicyDef::Cmp { column, op, value } => {
+            current_cmp_sql(table, alias, column, op, value, user)
         }
-        PolicyDef::GroupMember => Ok(current_group_member_policy_sql(
-            &format!("{alias}.row_num"),
-            user,
-            branch_num,
-            depth,
+        PolicyDef::SessionCmp { .. }
+        | PolicyDef::IsNull { .. }
+        | PolicyDef::SessionIsNull { .. }
+        | PolicyDef::IsNotNull { .. }
+        | PolicyDef::SessionIsNotNull { .. }
+        | PolicyDef::Contains { .. }
+        | PolicyDef::SessionContains { .. }
+        | PolicyDef::In { .. }
+        | PolicyDef::InList { .. }
+        | PolicyDef::SessionInList { .. }
+        | PolicyDef::ExistsRel { .. } => Err(crate::Error::new(
+            "policy expression is not lowerable by mini-sqlite yet",
         )),
-        PolicyDef::GroupRefMember { field } => {
-            current_group_ref_member_sql(table, alias, field, user, branch_num, depth)
+        PolicyDef::Exists {
+            table: exists_table,
+            condition,
+        } => current_exists_policy_sql(schema, exists_table, condition, user, branch_num, depth),
+        PolicyDef::Inherits {
+            operation,
+            via_column,
+            ..
+        } => {
+            ensure_select_operation(*operation)?;
+            current_inherits_policy_sql(schema, table, alias, via_column, user, branch_num, depth)
         }
-        PolicyDef::ProjectMember => Ok(current_project_member_policy_sql(
-            &format!("{alias}.row_num"),
-            user,
-            branch_num,
-            depth,
-        )),
-        PolicyDef::ProjectRefMember { field } => {
-            current_project_ref_member_sql(table, alias, field, user, branch_num, depth)
-        }
-        PolicyDef::RefReadable { field } => {
-            let field = table
-                .fields
-                .iter()
-                .find(|candidate| candidate.name == *field)
-                .ok_or_else(|| crate::Error::new(format!("unknown policy ref {field}")))?;
-            let FieldKind::Ref {
-                table: ref_table_name,
-            } = &field.kind
-            else {
-                return Err(crate::Error::new(format!(
-                    "policy field {} is not a ref",
-                    field.name
-                )));
-            };
-            let ref_table = schema.table_def(ref_table_name)?;
-            let parent_alias = format!("policy_parent_{depth}");
-            let parent_tx_alias = format!("policy_parent_tx_{depth}");
-            let parent_policy = lower_policy(
+        PolicyDef::InheritsReferencing {
+            operation,
+            source_table,
+            via_column,
+            ..
+        } => {
+            ensure_select_operation(*operation)?;
+            current_inherits_referencing_policy_sql(
                 schema,
-                ref_table,
-                &parent_alias,
-                &ref_table.read_policy,
+                table,
+                alias,
+                source_table,
+                via_column,
                 user,
                 branch_num,
-                depth + 1,
-            )?;
-            let branch_filter = branch_num
-                .map(|branch_num| {
-                    format!(
-                        "AND {}",
-                        effective_branch_sql(&parent_alias, &ref_table.name, branch_num)
-                    )
-                })
-                .unwrap_or_default();
-            Ok(format!(
-                "EXISTS (
-                   SELECT 1
-                   FROM {} {parent_alias}
-                   JOIN jazz_tx {parent_tx_alias}
-                     ON {parent_tx_alias}.tx_num = {parent_alias}.visible_tx_num
-                   WHERE {parent_alias}.row_num = {alias}.{}
-                     {branch_filter}
-                     AND {parent_alias}.is_deleted = 0
-                     AND {parent_tx_alias}.outcome != {}
-                     AND {parent_policy}
-                 )",
-                crate::schema::current_table(&ref_table.name),
-                crate::schema::quote_ident(&crate::schema::storage_column(field)),
-                tx::OUTCOME_REJECTED,
-            ))
+                depth,
+            )
         }
+        PolicyDef::And(children) => {
+            if children.is_empty() {
+                return Ok("1 = 1".to_owned());
+            }
+            let parts = children
+                .iter()
+                .map(|child| lower_policy(schema, table, alias, child, user, branch_num, depth + 1))
+                .collect::<Result<Vec<_>>>()?;
+            Ok(format!("({})", parts.join(" AND ")))
+        }
+        PolicyDef::Or(children) => {
+            if children.is_empty() {
+                return Ok("0 = 1".to_owned());
+            }
+            let parts = children
+                .iter()
+                .map(|child| lower_policy(schema, table, alias, child, user, branch_num, depth + 1))
+                .collect::<Result<Vec<_>>>()?;
+            Ok(format!("({})", parts.join(" OR ")))
+        }
+        PolicyDef::Not(child) => Ok(format!(
+            "NOT ({})",
+            lower_policy(schema, table, alias, child, user, branch_num, depth + 1)?
+        )),
     }
 }
 
@@ -741,34 +962,34 @@ fn lower_snapshot_policy(
         ));
     }
     match policy {
-        PolicyDef::AllowAll => Ok("1 = 1".to_owned()),
-        PolicyDef::CreatedByUser => Ok(format!(
-            "{alias}.j_created_by = (SELECT user_num FROM jazz_user WHERE user_id = '{}')",
-            user.replace('\'', "''")
-        )),
-        PolicyDef::RowIdEqualsUser => Ok(row_id_equals_user_sql(alias, user)),
-        PolicyDef::UserRefEqualsSession { field } => {
-            current_user_ref_equals_session_sql(table, alias, field, user)
+        PolicyDef::True => Ok("1 = 1".to_owned()),
+        PolicyDef::False => Ok("0 = 1".to_owned()),
+        PolicyDef::Cmp { column, op, value } => {
+            current_cmp_sql(table, alias, column, op, value, user)
         }
-        PolicyDef::GroupMember => Ok(current_group_member_policy_sql(
-            &format!("{alias}.row_num"),
-            user,
-            None,
-            depth,
+        PolicyDef::SessionCmp { .. }
+        | PolicyDef::IsNull { .. }
+        | PolicyDef::SessionIsNull { .. }
+        | PolicyDef::IsNotNull { .. }
+        | PolicyDef::SessionIsNotNull { .. }
+        | PolicyDef::Contains { .. }
+        | PolicyDef::SessionContains { .. }
+        | PolicyDef::In { .. }
+        | PolicyDef::InList { .. }
+        | PolicyDef::SessionInList { .. }
+        | PolicyDef::ExistsRel { .. } => Err(crate::Error::new(
+            "policy expression is not lowerable by mini-sqlite yet",
         )),
-        PolicyDef::GroupRefMember { field } => {
-            current_group_ref_member_sql(table, alias, field, user, None, depth)
-        }
-        PolicyDef::ProjectMember => Ok(current_project_member_policy_sql(
-            &format!("{alias}.row_num"),
-            user,
-            None,
-            depth,
-        )),
-        PolicyDef::ProjectRefMember { field } => {
-            current_project_ref_member_sql(table, alias, field, user, None, depth)
-        }
-        PolicyDef::RefReadable { field } => {
+        PolicyDef::Exists {
+            table: exists_table,
+            condition,
+        } => current_exists_policy_sql(schema, exists_table, condition, user, None, depth),
+        PolicyDef::Inherits {
+            operation,
+            via_column: field,
+            ..
+        } => {
+            ensure_select_operation(*operation)?;
             let field = table
                 .fields
                 .iter()
@@ -830,5 +1051,51 @@ fn lower_snapshot_policy(
                 tx::OUTCOME_REJECTED,
             ))
         }
+        PolicyDef::InheritsReferencing {
+            operation,
+            source_table,
+            via_column,
+            ..
+        } => {
+            ensure_select_operation(*operation)?;
+            current_inherits_referencing_policy_sql(
+                schema,
+                table,
+                alias,
+                source_table,
+                via_column,
+                user,
+                None,
+                depth,
+            )
+        }
+        PolicyDef::And(children) => {
+            if children.is_empty() {
+                return Ok("1 = 1".to_owned());
+            }
+            let parts = children
+                .iter()
+                .map(|child| {
+                    lower_snapshot_policy(schema, table, alias, child, user, base_epoch, depth + 1)
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok(format!("({})", parts.join(" AND ")))
+        }
+        PolicyDef::Or(children) => {
+            if children.is_empty() {
+                return Ok("0 = 1".to_owned());
+            }
+            let parts = children
+                .iter()
+                .map(|child| {
+                    lower_snapshot_policy(schema, table, alias, child, user, base_epoch, depth + 1)
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok(format!("({})", parts.join(" OR ")))
+        }
+        PolicyDef::Not(child) => Ok(format!(
+            "NOT ({})",
+            lower_snapshot_policy(schema, table, alias, child, user, base_epoch, depth + 1)?
+        )),
     }
 }

--- a/crates/mini-jazz-sqlite/src/policy.rs
+++ b/crates/mini-jazz-sqlite/src/policy.rs
@@ -1,4 +1,8 @@
-use crate::schema::{CmpOp, FieldKind, Operation, PolicyDef, PolicyValue, SchemaDef, TableDef};
+use crate::schema::{
+    CmpOp, FieldKind, Operation, PolicyDef, PolicyValue, SchemaDef, TableDef,
+    OUTER_ROW_SESSION_PREFIX,
+};
+use crate::sync::history_op;
 use crate::{branch, tx, Result};
 use rusqlite::{params, Connection, OptionalExtension};
 use serde_json::Value as JsonValue;
@@ -37,8 +41,8 @@ fn write_allowed_for_policy(check: &WriteCheck<'_>, policy: &PolicyDef) -> Resul
         | PolicyDef::In { .. }
         | PolicyDef::InList { .. }
         | PolicyDef::SessionInList { .. }
-        | PolicyDef::Exists { .. }
         | PolicyDef::ExistsRel { .. } => current_row_matches_policy(check, policy),
+        PolicyDef::Exists { table, condition } => exists_write_allowed(check, table, condition),
         PolicyDef::Inherits {
             operation,
             via_column,
@@ -163,6 +167,9 @@ fn resolve_policy_value_for_ref(
 ) -> Result<JsonValue> {
     match value {
         PolicyValue::Literal(value) => Ok(value.clone()),
+        PolicyValue::SessionRef(path) if outer_row_ref_column(path).is_some() => {
+            resolve_outer_policy_value_for_json(check, path)
+        }
         PolicyValue::SessionRef(path) if is_session_user_id(path) && ref_table == "users" => {
             Ok(JsonValue::String(check.user.to_owned()))
         }
@@ -176,6 +183,9 @@ fn resolve_policy_value_for_ref(
 fn resolve_policy_value_for_json(check: &WriteCheck<'_>, value: &PolicyValue) -> Result<JsonValue> {
     match value {
         PolicyValue::Literal(value) => Ok(value.clone()),
+        PolicyValue::SessionRef(path) if outer_row_ref_column(path).is_some() => {
+            resolve_outer_policy_value_for_json(check, path)
+        }
         PolicyValue::SessionRef(path) if is_session_user_id(path) => {
             Ok(JsonValue::String(check.user.to_owned()))
         }
@@ -184,6 +194,36 @@ fn resolve_policy_value_for_json(check: &WriteCheck<'_>, value: &PolicyValue) ->
             path.join(".")
         ))),
     }
+}
+
+fn resolve_outer_policy_value_for_json(
+    check: &WriteCheck<'_>,
+    path: &[String],
+) -> Result<JsonValue> {
+    let column = outer_row_ref_column(path).expect("outer row ref checked by caller");
+    if column == "$id" {
+        return Ok(JsonValue::String(crate::rows::public_row_id(
+            check.db,
+            check.row_num,
+        )?));
+    }
+    if column == "$createdBy" {
+        return Ok(current_or_pending_created_by(check)?
+            .map(JsonValue::String)
+            .unwrap_or(JsonValue::Null));
+    }
+    let field = check
+        .table
+        .fields
+        .iter()
+        .find(|candidate| candidate.name == column)
+        .ok_or_else(|| crate::Error::new(format!("unknown outer row policy column {column}")))?;
+    Ok(check
+        .values
+        .get(column)
+        .or_else(|| check.values.get(&field.storage_name))
+        .cloned()
+        .unwrap_or(JsonValue::Null))
 }
 
 fn compare_json_values(left: &JsonValue, op: &CmpOp, right: &JsonValue) -> bool {
@@ -263,6 +303,7 @@ fn ref_row_read_allowed(
         check.user,
         Some(check.branch_num),
         0,
+        None,
     )?;
     let count: i64 = check.db.query_row(
         &format!(
@@ -293,6 +334,7 @@ fn current_row_matches_policy(check: &WriteCheck<'_>, policy: &PolicyDef) -> Res
         check.user,
         Some(check.branch_num),
         0,
+        None,
     )?;
     let count: i64 = check.db.query_row(
         &format!(
@@ -314,6 +356,51 @@ fn current_row_matches_policy(check: &WriteCheck<'_>, policy: &PolicyDef) -> Res
     Ok(count > 0)
 }
 
+fn exists_write_allowed(
+    check: &WriteCheck<'_>,
+    table_name: &str,
+    condition: &PolicyDef,
+) -> Result<bool> {
+    let exists_table = check.schema.table_def(table_name)?;
+    let exists_alias = "policy_exists_write";
+    let exists_tx_alias = "policy_exists_write_tx";
+    let condition_sql = lower_policy(
+        check.schema,
+        exists_table,
+        exists_alias,
+        condition,
+        check.user,
+        Some(check.branch_num),
+        1,
+        Some(PolicyOuterRow::Values {
+            db: check.db,
+            table: check.table,
+            row_num: check.row_num,
+            branch_num: check.branch_num,
+            values: check.values,
+            created_by: check.created_by,
+        }),
+    )?;
+    let count: i64 = check.db.query_row(
+        &format!(
+            "SELECT COUNT(*)
+             FROM {} {exists_alias}
+             JOIN jazz_tx {exists_tx_alias}
+               ON {exists_tx_alias}.tx_num = {exists_alias}.visible_tx_num
+             WHERE {exists_alias}.is_deleted = 0
+               AND {}
+               AND {exists_tx_alias}.outcome != {}
+               AND {condition_sql}",
+            crate::schema::current_table(table_name),
+            effective_branch_sql(exists_alias, table_name, check.branch_num),
+            tx::OUTCOME_REJECTED,
+        ),
+        [],
+        |row| row.get(0),
+    )?;
+    Ok(count > 0)
+}
+
 fn snapshot_write_ref_allowed(
     conn: &Connection,
     schema: &SchemaDef,
@@ -323,6 +410,7 @@ fn snapshot_write_ref_allowed(
     base_epoch: i64,
 ) -> Result<bool> {
     let policy_sql = snapshot_read_policy_sql_for_alias(schema, ref_table, "h", user, base_epoch)?;
+    let delete_op = history_op::DELETE;
     let count: i64 = conn.query_row(
         &format!(
             "SELECT COUNT(*)
@@ -330,7 +418,7 @@ fn snapshot_write_ref_allowed(
              JOIN jazz_tx tx ON tx.tx_num = h.tx_num
              WHERE h.row_num = ?
                AND h.j_branch_num = 1
-               AND h.op != 3
+               AND h.op != {delete_op}
                AND tx.outcome != {}
                AND tx.global_epoch IS NOT NULL
                AND tx.global_epoch <= ?
@@ -377,8 +465,32 @@ fn effective_branch_sql(alias: &str, table_name: &str, branch_num: i64) -> Strin
     )
 }
 
+#[derive(Clone, Copy)]
+enum PolicyOuterRow<'a> {
+    Alias {
+        table: &'a TableDef,
+        alias: &'a str,
+    },
+    Values {
+        db: &'a Connection,
+        table: &'a TableDef,
+        row_num: i64,
+        branch_num: i64,
+        values: &'a BTreeMap<String, JsonValue>,
+        created_by: Option<&'a str>,
+    },
+}
+
 pub(crate) fn sql_literal(value: &str) -> String {
     format!("'{}'", value.replace('\'', "''"))
+}
+
+fn outer_row_ref_column(path: &[String]) -> Option<&str> {
+    if path.len() == 2 && path[0] == OUTER_ROW_SESSION_PREFIX {
+        Some(path[1].as_str())
+    } else {
+        None
+    }
 }
 
 fn user_row_num_subquery(user: &str) -> String {
@@ -395,9 +507,10 @@ fn current_cmp_sql(
     op: &CmpOp,
     value: &PolicyValue,
     user: &str,
+    outer_row: Option<PolicyOuterRow<'_>>,
 ) -> Result<String> {
     let left = policy_column_sql(table, alias, column)?;
-    let right = policy_value_sql(table, column, value, user)?;
+    let right = policy_value_sql(table, column, value, user, outer_row)?;
     Ok(format!("{left} {} {right}", cmp_op_sql(op)))
 }
 
@@ -428,6 +541,7 @@ fn policy_value_sql(
     column: &str,
     value: &PolicyValue,
     user: &str,
+    outer_row: Option<PolicyOuterRow<'_>>,
 ) -> Result<String> {
     match value {
         PolicyValue::Literal(value) => {
@@ -445,6 +559,16 @@ fn policy_value_sql(
                 )),
                 _ => Ok(json_literal_sql(value)),
             }
+        }
+        PolicyValue::SessionRef(path) if outer_row_ref_column(path).is_some() => {
+            let outer_column = outer_row_ref_column(path).expect("outer row ref checked by guard");
+            let Some(outer_row) = outer_row else {
+                return Err(crate::Error::new(format!(
+                    "outer row ref {} used without outer row context",
+                    path.join(".")
+                )));
+            };
+            outer_policy_value_sql(table, column, outer_row, outer_column)
         }
         PolicyValue::SessionRef(path) if is_session_user_id(path) => {
             let Some(field) = table
@@ -466,6 +590,102 @@ fn policy_value_sql(
             path.join(".")
         ))),
     }
+}
+
+fn outer_policy_value_sql(
+    table: &TableDef,
+    column: &str,
+    outer_row: PolicyOuterRow<'_>,
+    outer_column: &str,
+) -> Result<String> {
+    match outer_row {
+        PolicyOuterRow::Alias { table, alias } => policy_column_sql(table, alias, outer_column),
+        PolicyOuterRow::Values {
+            db,
+            table: outer_table,
+            row_num,
+            branch_num,
+            values,
+            created_by,
+        } => {
+            let value = outer_policy_value_from_values(
+                db,
+                outer_table,
+                row_num,
+                branch_num,
+                values,
+                created_by,
+                outer_column,
+            )?;
+            let Some(field) = table
+                .fields
+                .iter()
+                .find(|candidate| candidate.name == column)
+            else {
+                return Ok(json_literal_sql(&value));
+            };
+            match (&field.kind, value) {
+                (FieldKind::Ref { .. }, JsonValue::String(row_id)) => Ok(format!(
+                    "(SELECT row_num FROM jazz_row_id WHERE row_id = {})",
+                    sql_literal(&row_id)
+                )),
+                (_, value) => Ok(json_literal_sql(&value)),
+            }
+        }
+    }
+}
+
+fn outer_policy_value_from_values(
+    db: &Connection,
+    table: &TableDef,
+    row_num: i64,
+    branch_num: i64,
+    values: &BTreeMap<String, JsonValue>,
+    created_by: Option<&str>,
+    column: &str,
+) -> Result<JsonValue> {
+    if column == "$id" {
+        return Ok(JsonValue::String(crate::rows::public_row_id(db, row_num)?));
+    }
+    if column == "$createdBy" {
+        let created_by = match created_by {
+            Some(created_by) => Some(created_by.to_owned()),
+            None => current_created_by_for_row(db, table, row_num, branch_num)?,
+        };
+        return Ok(created_by.map(JsonValue::String).unwrap_or(JsonValue::Null));
+    }
+    let field = table
+        .fields
+        .iter()
+        .find(|candidate| candidate.name == column)
+        .ok_or_else(|| crate::Error::new(format!("unknown outer row policy column {column}")))?;
+    Ok(values
+        .get(column)
+        .or_else(|| values.get(&field.storage_name))
+        .cloned()
+        .unwrap_or(JsonValue::Null))
+}
+
+fn current_created_by_for_row(
+    db: &Connection,
+    table: &TableDef,
+    row_num: i64,
+    branch_num: i64,
+) -> Result<Option<String>> {
+    db.query_row(
+        &format!(
+            "SELECT user.user_id
+             FROM {} current
+             JOIN jazz_user user ON user.user_num = current.j_created_by
+             WHERE current.row_num = ?
+               AND current.j_branch_num = ?",
+            crate::schema::current_table(&table.name)
+        ),
+        params![row_num, branch_num],
+        |row| row.get::<_, String>(0),
+    )
+    .optional()
+    .map_err(Into::into)
 }
 
 fn is_session_user_id(path: &[String]) -> bool {
@@ -499,8 +719,11 @@ fn json_literal_sql(value: &JsonValue) -> String {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn current_exists_policy_sql(
     schema: &SchemaDef,
+    outer_table: &TableDef,
+    outer_alias: &str,
     table_name: &str,
     condition: &PolicyDef,
     user: &str,
@@ -518,6 +741,10 @@ fn current_exists_policy_sql(
         user,
         branch_num,
         depth + 1,
+        Some(PolicyOuterRow::Alias {
+            table: outer_table,
+            alias: outer_alias,
+        }),
     )?;
     let branch_filter = branch_num
         .map(|branch_num| {
@@ -696,6 +923,7 @@ fn current_inherits_policy_sql(
         user,
         branch_num,
         depth + 1,
+        None,
     )?;
     let branch_filter = branch_num
         .map(|branch_num| {
@@ -796,6 +1024,7 @@ fn current_inherits_referencing_policy_sql(
         user,
         branch_num,
         depth + 1,
+        None,
     )?;
     let branch_filter = branch_num
         .map(|branch_num| {
@@ -838,6 +1067,7 @@ pub(crate) fn branch_read_policy_sql_for_alias(
         user,
         Some(branch_num),
         0,
+        None,
     )
 }
 
@@ -859,6 +1089,7 @@ pub(crate) fn snapshot_read_policy_sql_for_alias(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn lower_policy(
     schema: &SchemaDef,
     table: &TableDef,
@@ -867,6 +1098,7 @@ fn lower_policy(
     user: &str,
     branch_num: Option<i64>,
     depth: usize,
+    outer_row: Option<PolicyOuterRow<'_>>,
 ) -> Result<String> {
     if depth > MAX_POLICY_RECURSION_DEPTH {
         return Err(crate::Error::new("policy recursion depth exceeded"));
@@ -875,7 +1107,7 @@ fn lower_policy(
         PolicyDef::True => Ok("1 = 1".to_owned()),
         PolicyDef::False => Ok("0 = 1".to_owned()),
         PolicyDef::Cmp { column, op, value } => {
-            current_cmp_sql(table, alias, column, op, value, user)
+            current_cmp_sql(table, alias, column, op, value, user, outer_row)
         }
         PolicyDef::SessionCmp { .. }
         | PolicyDef::IsNull { .. }
@@ -893,7 +1125,16 @@ fn lower_policy(
         PolicyDef::Exists {
             table: exists_table,
             condition,
-        } => current_exists_policy_sql(schema, exists_table, condition, user, branch_num, depth),
+        } => current_exists_policy_sql(
+            schema,
+            table,
+            alias,
+            exists_table,
+            condition,
+            user,
+            branch_num,
+            depth,
+        ),
         PolicyDef::Inherits {
             operation,
             via_column,
@@ -926,7 +1167,18 @@ fn lower_policy(
             }
             let parts = children
                 .iter()
-                .map(|child| lower_policy(schema, table, alias, child, user, branch_num, depth + 1))
+                .map(|child| {
+                    lower_policy(
+                        schema,
+                        table,
+                        alias,
+                        child,
+                        user,
+                        branch_num,
+                        depth + 1,
+                        outer_row,
+                    )
+                })
                 .collect::<Result<Vec<_>>>()?;
             Ok(format!("({})", parts.join(" AND ")))
         }
@@ -936,13 +1188,33 @@ fn lower_policy(
             }
             let parts = children
                 .iter()
-                .map(|child| lower_policy(schema, table, alias, child, user, branch_num, depth + 1))
+                .map(|child| {
+                    lower_policy(
+                        schema,
+                        table,
+                        alias,
+                        child,
+                        user,
+                        branch_num,
+                        depth + 1,
+                        outer_row,
+                    )
+                })
                 .collect::<Result<Vec<_>>>()?;
             Ok(format!("({})", parts.join(" OR ")))
         }
         PolicyDef::Not(child) => Ok(format!(
             "NOT ({})",
-            lower_policy(schema, table, alias, child, user, branch_num, depth + 1)?
+            lower_policy(
+                schema,
+                table,
+                alias,
+                child,
+                user,
+                branch_num,
+                depth + 1,
+                outer_row,
+            )?
         )),
     }
 }
@@ -965,7 +1237,7 @@ fn lower_snapshot_policy(
         PolicyDef::True => Ok("1 = 1".to_owned()),
         PolicyDef::False => Ok("0 = 1".to_owned()),
         PolicyDef::Cmp { column, op, value } => {
-            current_cmp_sql(table, alias, column, op, value, user)
+            current_cmp_sql(table, alias, column, op, value, user, None)
         }
         PolicyDef::SessionCmp { .. }
         | PolicyDef::IsNull { .. }
@@ -983,7 +1255,16 @@ fn lower_snapshot_policy(
         PolicyDef::Exists {
             table: exists_table,
             condition,
-        } => current_exists_policy_sql(schema, exists_table, condition, user, None, depth),
+        } => current_exists_policy_sql(
+            schema,
+            table,
+            alias,
+            exists_table,
+            condition,
+            user,
+            None,
+            depth,
+        ),
         PolicyDef::Inherits {
             operation,
             via_column: field,
@@ -1018,6 +1299,7 @@ fn lower_snapshot_policy(
                 base_epoch,
                 depth + 1,
             )?;
+            let delete_op = history_op::DELETE;
             Ok(format!(
                 "EXISTS (
                    SELECT 1
@@ -1026,7 +1308,7 @@ fn lower_snapshot_policy(
                      ON {parent_tx_alias}.tx_num = {parent_alias}.tx_num
                    WHERE {parent_alias}.row_num = {alias}.{}
                      AND {parent_alias}.j_branch_num = 1
-                     AND {parent_alias}.op != 3
+                     AND {parent_alias}.op != {delete_op}
                      AND {parent_tx_alias}.outcome != {}
                      AND {parent_tx_alias}.global_epoch IS NOT NULL
                      AND {parent_tx_alias}.global_epoch <= {base_epoch}

--- a/crates/mini-jazz-sqlite/src/projection.rs
+++ b/crates/mini-jazz-sqlite/src/projection.rs
@@ -1,4 +1,5 @@
 use crate::schema::{current_table, history_table, quote_ident, storage_column, SchemaDef};
+use crate::sync::history_op;
 use crate::{tx, Result};
 use rusqlite::{params, params_from_iter, Connection};
 
@@ -87,7 +88,7 @@ fn rebuild_table(
         let tx_num = integer_value(&values[1], "tx_num")?;
         let branch_num = integer_value(&values[2], "j_branch_num")?;
         let op = integer_value(&values[3], "op")?;
-        if op == 3 {
+        if op == history_op::DELETE {
             conn.execute(
                 &format!(
                     "DELETE FROM {} WHERE row_num = ? AND j_branch_num = ?",

--- a/crates/mini-jazz-sqlite/src/query.rs
+++ b/crates/mini-jazz-sqlite/src/query.rs
@@ -4,6 +4,7 @@ use crate::query_api::{
 use crate::read_visibility::ReadVisibility;
 use crate::rows::{public_row_id, row_num};
 use crate::schema::{FieldDef, FieldKind, Operation, PolicyDef, SchemaDef};
+use crate::sync::history_op;
 use crate::types::RowView;
 use crate::{branch, policy, tx, users, Result};
 use rusqlite::{params, params_from_iter, types::Value as SqlValue, Connection, OptionalExtension};
@@ -350,6 +351,7 @@ impl QueryContext<'_> {
             self.visibility()
                 .snapshot_policy_sql(table, "h", base_epoch)?
         };
+        let delete_op = history_op::DELETE;
         let sql = format!(
             "SELECT DISTINCT h.row_num
              FROM {} h
@@ -359,7 +361,7 @@ impl QueryContext<'_> {
                AND tx.outcome != ?
                AND tx.global_epoch IS NOT NULL
                AND tx.global_epoch <= ?
-               AND h.op != 3
+               AND h.op != {delete_op}
                AND {condition_sql}
                AND {policy_sql}
                AND NOT EXISTS (
@@ -623,6 +625,7 @@ impl QueryContext<'_> {
         };
         let select_columns =
             query_candidate_select_columns(table, "h", "ids", "tx", &(i64::MAX / 4).to_string());
+        let delete_op = history_op::DELETE;
         let sql = format!(
             "SELECT {}
              FROM {} h
@@ -632,7 +635,7 @@ impl QueryContext<'_> {
                AND tx.outcome != ?
                AND tx.global_epoch IS NOT NULL
                AND tx.global_epoch <= ?
-               AND h.op != 3
+               AND h.op != {delete_op}
                AND {policy_sql}
                AND NOT EXISTS (
                  SELECT 1
@@ -1413,6 +1416,7 @@ impl QueryContext<'_> {
             self.visibility()
                 .snapshot_policy_sql(table, "h", base_epoch)?
         };
+        let delete_op = history_op::DELETE;
         let sql = format!(
             "WITH
              overlay_rows AS (
@@ -1437,7 +1441,7 @@ impl QueryContext<'_> {
                  AND tx.outcome != ?
                  AND tx.global_epoch IS NOT NULL
                  AND tx.global_epoch <= ?
-                 AND h.op != 3
+                 AND h.op != {delete_op}
                  AND h.{predicate_column} = ?
                  AND NOT EXISTS (
                    SELECT 1
@@ -2762,6 +2766,7 @@ impl QueryContext<'_> {
             "{} AS j_created_by",
             users::user_id_expr("h", "j_created_by")
         ));
+        let delete_op = history_op::DELETE;
         let sql = format!(
             "SELECT {}
              FROM {} h
@@ -2771,7 +2776,7 @@ impl QueryContext<'_> {
                AND tx.outcome != ?
                AND tx.global_epoch IS NOT NULL
                AND tx.global_epoch <= ?
-               AND h.op != 3
+               AND h.op != {delete_op}
                AND {policy_sql}
                AND NOT EXISTS (
                  SELECT 1

--- a/crates/mini-jazz-sqlite/src/query.rs
+++ b/crates/mini-jazz-sqlite/src/query.rs
@@ -2006,6 +2006,7 @@ impl QueryContext<'_> {
                 Ok(row.values.get(field).and_then(JsonValue::as_str) == Some(self.user))
             }
             PolicyDef::GroupMember
+            | PolicyDef::GroupRefMember { .. }
             | PolicyDef::ProjectMember
             | PolicyDef::ProjectRefMember { .. } => {
                 let row_num = row_num(self.conn, &row.id)?;

--- a/crates/mini-jazz-sqlite/src/query.rs
+++ b/crates/mini-jazz-sqlite/src/query.rs
@@ -3,7 +3,7 @@ use crate::query_api::{
 };
 use crate::read_visibility::ReadVisibility;
 use crate::rows::{public_row_id, row_num};
-use crate::schema::{FieldDef, FieldKind, PolicyDef, SchemaDef};
+use crate::schema::{FieldDef, FieldKind, Operation, PolicyDef, SchemaDef};
 use crate::types::RowView;
 use crate::{branch, policy, tx, users, Result};
 use rusqlite::{params, params_from_iter, types::Value as SqlValue, Connection, OptionalExtension};
@@ -1987,7 +1987,12 @@ impl QueryContext<'_> {
             return Ok(rows);
         }
         let table = self.schema.table_def(table_name)?;
-        let PolicyDef::RefReadable { field } = &table.read_policy else {
+        let PolicyDef::Inherits {
+            operation: Operation::Select,
+            via_column: field,
+            ..
+        } = &table.read_policy
+        else {
             return Ok(rows);
         };
         let field = table
@@ -2027,7 +2032,7 @@ impl QueryContext<'_> {
             && self.branch_num != 1
             && base_epoch.is_some()
             && (query.limit.is_some() || query.offset.is_some())
-            && matches!(table.read_policy, PolicyDef::RefReadable { .. })
+            && matches!(table.read_policy, PolicyDef::Inherits { .. })
     }
 
     fn row_view_visible_in_branch(
@@ -2041,16 +2046,25 @@ impl QueryContext<'_> {
         }
         let table = self.schema.table_def(table_name)?;
         match &table.read_policy {
-            PolicyDef::AllowAll => Ok(true),
-            PolicyDef::CreatedByUser => Ok(row.created_by == self.user),
-            PolicyDef::RowIdEqualsUser => Ok(row.id == self.user),
-            PolicyDef::UserRefEqualsSession { field } => {
-                Ok(row.values.get(field).and_then(JsonValue::as_str) == Some(self.user))
-            }
-            PolicyDef::GroupMember
-            | PolicyDef::GroupRefMember { .. }
-            | PolicyDef::ProjectMember
-            | PolicyDef::ProjectRefMember { .. } => {
+            PolicyDef::True => Ok(true),
+            PolicyDef::False => Ok(false),
+            PolicyDef::Cmp { .. }
+            | PolicyDef::SessionCmp { .. }
+            | PolicyDef::IsNull { .. }
+            | PolicyDef::SessionIsNull { .. }
+            | PolicyDef::IsNotNull { .. }
+            | PolicyDef::SessionIsNotNull { .. }
+            | PolicyDef::Contains { .. }
+            | PolicyDef::SessionContains { .. }
+            | PolicyDef::In { .. }
+            | PolicyDef::InList { .. }
+            | PolicyDef::SessionInList { .. }
+            | PolicyDef::Exists { .. }
+            | PolicyDef::ExistsRel { .. }
+            | PolicyDef::InheritsReferencing { .. }
+            | PolicyDef::And(_)
+            | PolicyDef::Or(_)
+            | PolicyDef::Not(_) => {
                 let row_num = row_num(self.conn, &row.id)?;
                 let policy_sql = policy::branch_read_policy_sql_for_alias(
                     self.schema,
@@ -2077,7 +2091,11 @@ impl QueryContext<'_> {
                 )?;
                 Ok(count > 0)
             }
-            PolicyDef::RefReadable { field } => {
+            PolicyDef::Inherits {
+                operation: Operation::Select,
+                via_column: field,
+                ..
+            } => {
                 let field = table
                     .fields
                     .iter()
@@ -2102,6 +2120,7 @@ impl QueryContext<'_> {
                     None => Ok(false),
                 }
             }
+            PolicyDef::Inherits { .. } => Ok(false),
         }
     }
 

--- a/crates/mini-jazz-sqlite/src/query.rs
+++ b/crates/mini-jazz-sqlite/src/query.rs
@@ -33,6 +33,21 @@ pub struct SqliteQueryDebug {
     pub params: Vec<JsonValue>,
 }
 
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct SqliteQueryPlan {
+    pub sql: String,
+    pub params: Vec<JsonValue>,
+    pub plan: Vec<SqliteQueryPlanRow>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct SqliteQueryPlanRow {
+    pub id: i64,
+    pub parent: i64,
+    pub notused: i64,
+    pub detail: String,
+}
+
 pub(crate) struct LoweredQueryRowScope {
     pub(crate) ctes: Vec<String>,
     pub(crate) select_sql: String,
@@ -60,6 +75,27 @@ impl LoweredBuiltQuery {
             sql: self.sql.clone(),
             params: self.params.iter().map(sqlite_param_to_json).collect(),
         }
+    }
+
+    fn explain_query_plan(&self, conn: &Connection) -> Result<SqliteQueryPlan> {
+        let mut stmt = conn.prepare(&format!("EXPLAIN QUERY PLAN {}", self.sql))?;
+        let rows = stmt.query_map(params_from_iter(self.params.iter()), |row| {
+            Ok(SqliteQueryPlanRow {
+                id: row.get(0)?,
+                parent: row.get(1)?,
+                notused: row.get(2)?,
+                detail: row.get(3)?,
+            })
+        })?;
+        let plan = rows
+            .map(|row| row.map_err(crate::Error::from))
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(SqliteQueryPlan {
+            sql: self.sql.clone(),
+            params: self.params.iter().map(sqlite_param_to_json).collect(),
+            plan,
+        })
     }
 }
 
@@ -158,6 +194,12 @@ impl QueryContext<'_> {
     pub(crate) fn debug_sql_for_built_query(&self, query: &BuiltQuery) -> Result<SqliteQueryDebug> {
         let table = self.schema.table_def(&query.table)?;
         Ok(self.lower_built_query(query, table)?.debug())
+    }
+
+    pub(crate) fn explain_built_query(&self, query: &BuiltQuery) -> Result<SqliteQueryPlan> {
+        let table = self.schema.table_def(&query.table)?;
+        self.lower_built_query(query, table)?
+            .explain_query_plan(self.conn)
     }
 
     pub(crate) fn repair_row_nums_for_built_query(&self, query: &BuiltQuery) -> Result<Vec<i64>> {

--- a/crates/mini-jazz-sqlite/src/query.rs
+++ b/crates/mini-jazz-sqlite/src/query.rs
@@ -5,8 +5,9 @@ use crate::read_visibility::ReadVisibility;
 use crate::rows::{public_row_id, row_num};
 use crate::schema::{FieldDef, FieldKind, PolicyDef, SchemaDef};
 use crate::types::RowView;
-use crate::{branch, tx, users, Result};
+use crate::{branch, policy, tx, users, Result};
 use rusqlite::{params, params_from_iter, types::Value as SqlValue, Connection, OptionalExtension};
+use serde::Serialize;
 use serde_json::Value as JsonValue;
 use std::collections::BTreeMap;
 
@@ -26,6 +27,12 @@ struct LoweredCondition {
     params: Vec<SqlValue>,
 }
 
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct SqliteQueryDebug {
+    pub sql: String,
+    pub params: Vec<JsonValue>,
+}
+
 pub(crate) struct LoweredQueryRowScope {
     pub(crate) ctes: Vec<String>,
     pub(crate) select_sql: String,
@@ -37,6 +44,22 @@ impl LoweredQueryRowScope {
         let mut ctes = self.ctes.clone();
         ctes.push(format!("{scope_name}(row_num) AS ({})", self.select_sql));
         format!("WITH {}", ctes.join(",\n"))
+    }
+}
+
+struct LoweredBuiltQuery {
+    sql: String,
+    params: Vec<SqlValue>,
+    filter_effective_branch_policy: bool,
+    defer_window_until_effective_policy: bool,
+}
+
+impl LoweredBuiltQuery {
+    fn debug(&self) -> SqliteQueryDebug {
+        SqliteQueryDebug {
+            sql: self.sql.clone(),
+            params: self.params.iter().map(sqlite_param_to_json).collect(),
+        }
     }
 }
 
@@ -111,46 +134,11 @@ impl QueryContext<'_> {
 
     pub(crate) fn read_rows_for_built_query(&self, query: &BuiltQuery) -> Result<Vec<RowView>> {
         let table = self.schema.table_def(&query.table)?;
-        let scope_nums = branch::scope_nums(self.conn, self.branch_num)?;
-        let base_epoch = branch::base_global_epoch(self.conn, self.branch_num)?;
-        if self.branch_num == 1 && scope_nums == [self.branch_num] && base_epoch.is_none() {
-            return self.read_current_built_query(query, table);
-        }
-        let (candidates_sql, mut params) = self.lower_query_candidates(query, table)?;
-        let order_sql = self.lower_query_order(table, &query.order_by)?;
-        let defer_window_until_effective_policy =
-            self.defer_query_window_until_effective_branch_policy(table, query, base_epoch);
-        let field_columns = table
-            .fields
-            .iter()
-            .map(|field| crate::schema::quote_ident(&crate::schema::storage_column(field)))
-            .collect::<Vec<_>>();
-        let mut select_columns = vec!["j_query_row_id".to_owned(), "j_query_tx_id".to_owned()];
-        select_columns.extend(field_columns.iter().cloned());
-        select_columns.push("j_query_created_by".to_owned());
-        select_columns.push("j_query_created_at".to_owned());
-        let mut sql = format!(
-            "WITH candidates AS (
-               {candidates_sql}
-             ),
-             ranked AS (
-               SELECT *,
-                      MIN(j_query_branch_depth) OVER (PARTITION BY j_query_row_id) AS j_query_min_branch_depth
-               FROM candidates
-             )
-             SELECT {}
-             FROM ranked
-             WHERE j_query_branch_depth = j_query_min_branch_depth
-             ORDER BY {order_sql}",
-            select_columns.join(", "),
-        );
-        if !defer_window_until_effective_policy {
-            append_query_window_sql(&mut sql, &mut params, query.limit, query.offset)?;
-        }
+        let lowered = self.lower_built_query(query, table)?;
 
-        let mut stmt = self.conn.prepare(&sql)?;
+        let mut stmt = self.conn.prepare(&lowered.sql)?;
         let row_width = 2 + table.fields.len() + 2;
-        let rows = stmt.query_map(params_from_iter(params.iter()), |row| {
+        let rows = stmt.query_map(params_from_iter(lowered.params.iter()), |row| {
             (0..row_width)
                 .map(|idx| row.get::<_, SqlValue>(idx))
                 .collect::<rusqlite::Result<Vec<_>>>()
@@ -158,13 +146,18 @@ impl QueryContext<'_> {
         let mut rows = rows
             .map(|row| row_to_view(self.conn, &query.table, table, row?))
             .collect::<Result<Vec<_>>>()?;
-        if self.branch_num != 1 && base_epoch.is_some() {
+        if lowered.filter_effective_branch_policy {
             rows = self.filter_rows_by_effective_branch_policy(&query.table, rows)?;
         }
-        if defer_window_until_effective_policy {
+        if lowered.defer_window_until_effective_policy {
             rows = apply_query_window(rows, query.limit, query.offset);
         }
         Ok(rows)
+    }
+
+    pub(crate) fn debug_sql_for_built_query(&self, query: &BuiltQuery) -> Result<SqliteQueryDebug> {
+        let table = self.schema.table_def(&query.table)?;
+        Ok(self.lower_built_query(query, table)?.debug())
     }
 
     pub(crate) fn repair_row_nums_for_built_query(&self, query: &BuiltQuery) -> Result<Vec<i64>> {
@@ -359,11 +352,24 @@ impl QueryContext<'_> {
             .map_err(Into::into)
     }
 
-    fn read_current_built_query(
+    fn lower_built_query(
         &self,
         query: &BuiltQuery,
         table: &crate::schema::TableDef,
-    ) -> Result<Vec<RowView>> {
+    ) -> Result<LoweredBuiltQuery> {
+        let scope_nums = branch::scope_nums(self.conn, self.branch_num)?;
+        let base_epoch = branch::base_global_epoch(self.conn, self.branch_num)?;
+        if self.branch_num == 1 && scope_nums == [self.branch_num] && base_epoch.is_none() {
+            return self.lower_current_built_query(query, table);
+        }
+        self.lower_branch_aware_built_query(query, table, base_epoch)
+    }
+
+    fn lower_current_built_query(
+        &self,
+        query: &BuiltQuery,
+        table: &crate::schema::TableDef,
+    ) -> Result<LoweredBuiltQuery> {
         let (condition_sql, mut params) =
             self.lower_query_conditions(table, &query.conditions, "current", "ids")?;
         let order_sql = self.lower_source_query_order(table, &query.order_by, "current", "ids")?;
@@ -405,15 +411,58 @@ impl QueryContext<'_> {
         query_params.append(&mut params);
         append_query_window_sql(&mut sql, &mut query_params, query.limit, query.offset)?;
 
-        let mut stmt = self.conn.prepare(&sql)?;
-        let row_width = 2 + table.fields.len() + 2;
-        let rows = stmt.query_map(params_from_iter(query_params.iter()), |row| {
-            (0..row_width)
-                .map(|idx| row.get::<_, SqlValue>(idx))
-                .collect::<rusqlite::Result<Vec<_>>>()
-        })?;
-        rows.map(|row| row_to_view(self.conn, &query.table, table, row?))
-            .collect()
+        Ok(LoweredBuiltQuery {
+            sql,
+            params: query_params,
+            filter_effective_branch_policy: false,
+            defer_window_until_effective_policy: false,
+        })
+    }
+
+    fn lower_branch_aware_built_query(
+        &self,
+        query: &BuiltQuery,
+        table: &crate::schema::TableDef,
+        base_epoch: Option<i64>,
+    ) -> Result<LoweredBuiltQuery> {
+        let (candidates_sql, mut params) = self.lower_query_candidates(query, table)?;
+        let order_sql = self.lower_query_order(table, &query.order_by)?;
+        let defer_window_until_effective_policy =
+            self.defer_query_window_until_effective_branch_policy(table, query, base_epoch);
+        let field_columns = table
+            .fields
+            .iter()
+            .map(|field| crate::schema::quote_ident(&crate::schema::storage_column(field)))
+            .collect::<Vec<_>>();
+        let mut select_columns = vec!["j_query_row_id".to_owned(), "j_query_tx_id".to_owned()];
+        select_columns.extend(field_columns.iter().cloned());
+        select_columns.push("j_query_created_by".to_owned());
+        select_columns.push("j_query_created_at".to_owned());
+        let mut sql = format!(
+            "WITH candidates AS (
+               {candidates_sql}
+             ),
+             ranked AS (
+               SELECT *,
+                      MIN(j_query_branch_depth) OVER (PARTITION BY j_query_row_id) AS j_query_min_branch_depth
+               FROM candidates
+             )
+             SELECT {}
+             FROM ranked
+             WHERE j_query_branch_depth = j_query_min_branch_depth
+             ORDER BY {order_sql}",
+            select_columns.join(", "),
+        );
+        if !defer_window_until_effective_policy {
+            append_query_window_sql(&mut sql, &mut params, query.limit, query.offset)?;
+        }
+
+        Ok(LoweredBuiltQuery {
+            sql,
+            params,
+            filter_effective_branch_policy: self.branch_num != 1 && base_epoch.is_some(),
+            defer_window_until_effective_policy,
+        })
     }
 
     fn lower_query_candidates(
@@ -1952,6 +2001,39 @@ impl QueryContext<'_> {
         match &table.read_policy {
             PolicyDef::AllowAll => Ok(true),
             PolicyDef::CreatedByUser => Ok(row.created_by == self.user),
+            PolicyDef::RowIdEqualsUser => Ok(row.id == self.user),
+            PolicyDef::UserRefEqualsSession { field } => {
+                Ok(row.values.get(field).and_then(JsonValue::as_str) == Some(self.user))
+            }
+            PolicyDef::GroupMember
+            | PolicyDef::ProjectMember
+            | PolicyDef::ProjectRefMember { .. } => {
+                let row_num = row_num(self.conn, &row.id)?;
+                let policy_sql = policy::branch_read_policy_sql_for_alias(
+                    self.schema,
+                    table,
+                    "current",
+                    self.user,
+                    branch_num,
+                )?;
+                let count: i64 = self.conn.query_row(
+                    &format!(
+                        "SELECT COUNT(*)
+                         FROM {} current
+                         JOIN jazz_tx tx ON tx.tx_num = current.visible_tx_num
+                         WHERE current.row_num = ?
+                           AND current.j_branch_num = ?
+                           AND current.is_deleted = 0
+                           AND tx.outcome != {}
+                           AND {policy_sql}",
+                        crate::schema::current_table(table_name),
+                        tx::OUTCOME_REJECTED,
+                    ),
+                    params![row_num, branch_num],
+                    |row| row.get(0),
+                )?;
+                Ok(count > 0)
+            }
             PolicyDef::RefReadable { field } => {
                 let field = table
                     .fields
@@ -2927,6 +3009,18 @@ fn in_predicate_sql(predicate_expr: &str, value_count: usize, includes_null: boo
     format!("({})", clauses.join(" OR "))
 }
 
+fn sqlite_param_to_json(value: &rusqlite::types::Value) -> JsonValue {
+    match value {
+        rusqlite::types::Value::Null => JsonValue::Null,
+        rusqlite::types::Value::Integer(value) => JsonValue::from(*value),
+        rusqlite::types::Value::Real(value) => JsonValue::from(*value),
+        rusqlite::types::Value::Text(value) => JsonValue::String(value.clone()),
+        rusqlite::types::Value::Blob(value) => {
+            JsonValue::Array(value.iter().map(|byte| JsonValue::from(*byte)).collect())
+        }
+    }
+}
+
 pub(crate) fn sql_value_to_json(
     conn: &Connection,
     field: &FieldDef,
@@ -2997,6 +3091,38 @@ mod tests {
         assert_eq!(rows.len(), 10);
         assert_eq!(rows[0].id, "todo-100");
         assert_eq!(rows[9].id, "todo-91");
+        Ok(())
+    }
+
+    #[test]
+    fn debug_sql_for_built_query_returns_final_sql_and_params() -> Result<()> {
+        let schema = SchemaDef::attempt3_fixture();
+        let conn = storage::open(Storage::Memory)?;
+        schema::install(&conn, &schema)?;
+        seed_todos(&conn, 1)?;
+
+        let context = QueryContext {
+            conn: &conn,
+            schema: &schema,
+            branch_num: 1,
+            user: "alice",
+            bypass_policy: false,
+        };
+
+        let query = BuiltQuery::from_json_value(json!({
+            "table": "todos",
+            "conditions": [{"column": "done", "op": "eq", "value": false}],
+            "orderBy": [["$createdAt", "desc"]],
+            "limit": 10,
+        }))?;
+        let debug = context.debug_sql_for_built_query(&query)?;
+
+        assert!(debug
+            .sql
+            .contains("FROM \"todos__schema_v1_current\" current"));
+        assert!(debug.sql.contains("ORDER BY current.j_created_at DESC"));
+        assert!(debug.sql.contains("LIMIT ?"));
+        assert_eq!(debug.params.last(), Some(&json!(10)));
         Ok(())
     }
 

--- a/crates/mini-jazz-sqlite/src/query_api.rs
+++ b/crates/mini-jazz-sqlite/src/query_api.rs
@@ -157,6 +157,10 @@ impl Runtime {
         self.read_rows_for_built_query(&query)
     }
 
+    pub fn debug_query_sql(&self, query: &BuiltQuery) -> Result<crate::query::SqliteQueryDebug> {
+        self.debug_sql_for_built_query(query)
+    }
+
     pub fn one(&self, query: BuiltQuery) -> Result<Option<RowView>> {
         Ok(self.query(query)?.into_iter().next())
     }

--- a/crates/mini-jazz-sqlite/src/query_api.rs
+++ b/crates/mini-jazz-sqlite/src/query_api.rs
@@ -161,6 +161,10 @@ impl Runtime {
         self.debug_sql_for_built_query(query)
     }
 
+    pub fn explain_query_plan(&self, query: &BuiltQuery) -> Result<crate::query::SqliteQueryPlan> {
+        self.explain_built_query(query)
+    }
+
     pub fn one(&self, query: BuiltQuery) -> Result<Option<RowView>> {
         Ok(self.query(query)?.into_iter().next())
     }

--- a/crates/mini-jazz-sqlite/src/read_set.rs
+++ b/crates/mini-jazz-sqlite/src/read_set.rs
@@ -1,5 +1,5 @@
 use crate::rows::ensure_row_id;
-use crate::sync::Bundle;
+use crate::sync::{history_op, Bundle};
 use crate::time::now_ms;
 use crate::{branch, schema, tx, Result};
 use rusqlite::{params, Connection, OptionalExtension};
@@ -214,6 +214,7 @@ fn snapshot_visible_tx_num(
     row_num: i64,
     base_epoch: i64,
 ) -> Result<Option<i64>> {
+    let delete_op = history_op::DELETE;
     conn.query_row(
         &format!(
             "SELECT h.tx_num
@@ -221,7 +222,7 @@ fn snapshot_visible_tx_num(
              JOIN jazz_tx tx ON tx.tx_num = h.tx_num
              WHERE h.row_num = ?
                AND h.j_branch_num = 1
-               AND h.op != 3
+               AND h.op != {delete_op}
                AND tx.outcome != ?
                AND tx.global_epoch IS NOT NULL
                AND tx.global_epoch <= ?

--- a/crates/mini-jazz-sqlite/src/read_visibility.rs
+++ b/crates/mini-jazz-sqlite/src/read_visibility.rs
@@ -143,6 +143,7 @@ impl ReadVisibility<'_> {
             PolicyDef::RowIdEqualsUser
             | PolicyDef::UserRefEqualsSession { .. }
             | PolicyDef::GroupMember
+            | PolicyDef::GroupRefMember { .. }
             | PolicyDef::ProjectMember
             | PolicyDef::ProjectRefMember { .. } => policy::branch_read_policy_sql_for_alias(
                 self.schema,

--- a/crates/mini-jazz-sqlite/src/read_visibility.rs
+++ b/crates/mini-jazz-sqlite/src/read_visibility.rs
@@ -1,4 +1,5 @@
 use crate::schema::{FieldKind, Operation, PolicyDef, SchemaDef, TableDef};
+use crate::sync::history_op;
 use crate::{policy, tx, Result};
 use rusqlite::{params_from_iter, types::Value as SqlValue, Connection};
 
@@ -60,6 +61,7 @@ impl ReadVisibility<'_> {
         let effective_branch_policy_sql =
             self.base_snapshot_effective_policy_sql(table, "h", base_epoch)?;
         let row_filter = row_filter_sql("h", row_nums);
+        let delete_op = history_op::DELETE;
         let sql = format!(
             "SELECT h.row_num
              FROM {} h
@@ -69,7 +71,7 @@ impl ReadVisibility<'_> {
                AND tx.outcome != ?
                AND tx.global_epoch IS NOT NULL
                AND tx.global_epoch <= ?
-               AND h.op != 3
+               AND h.op != {delete_op}
                AND {snapshot_policy_sql}
                AND {effective_branch_policy_sql}
                AND NOT EXISTS (
@@ -238,6 +240,7 @@ impl ReadVisibility<'_> {
                     base_epoch,
                     depth + 1,
                 )?;
+                let delete_op = history_op::DELETE;
                 Ok(format!(
                     "(
                        EXISTS (
@@ -265,7 +268,7 @@ impl ReadVisibility<'_> {
                              ON {snapshot_tx_alias}.tx_num = {snapshot_alias}.tx_num
                            WHERE {snapshot_alias}.row_num = {alias}.{ref_column}
                              AND {snapshot_alias}.j_branch_num = 1
-                             AND {snapshot_alias}.op != 3
+                             AND {snapshot_alias}.op != {delete_op}
                              AND {snapshot_tx_alias}.outcome != {}
                              AND {snapshot_tx_alias}.global_epoch IS NOT NULL
                              AND {snapshot_tx_alias}.global_epoch <= {base_epoch}

--- a/crates/mini-jazz-sqlite/src/read_visibility.rs
+++ b/crates/mini-jazz-sqlite/src/read_visibility.rs
@@ -140,6 +140,17 @@ impl ReadVisibility<'_> {
                 "{alias}.j_created_by = (SELECT user_num FROM jazz_user WHERE user_id = '{}')",
                 self.user.replace('\'', "''")
             )),
+            PolicyDef::RowIdEqualsUser
+            | PolicyDef::UserRefEqualsSession { .. }
+            | PolicyDef::GroupMember
+            | PolicyDef::ProjectMember
+            | PolicyDef::ProjectRefMember { .. } => policy::branch_read_policy_sql_for_alias(
+                self.schema,
+                table,
+                alias,
+                self.user,
+                self.branch_num,
+            ),
             PolicyDef::RefReadable { field } => {
                 let field = table
                     .fields

--- a/crates/mini-jazz-sqlite/src/read_visibility.rs
+++ b/crates/mini-jazz-sqlite/src/read_visibility.rs
@@ -1,4 +1,4 @@
-use crate::schema::{FieldKind, PolicyDef, SchemaDef, TableDef};
+use crate::schema::{FieldKind, Operation, PolicyDef, SchemaDef, TableDef};
 use crate::{policy, tx, Result};
 use rusqlite::{params_from_iter, types::Value as SqlValue, Connection};
 
@@ -135,24 +135,73 @@ impl ReadVisibility<'_> {
             ));
         }
         match policy {
-            PolicyDef::AllowAll => Ok("1 = 1".to_owned()),
-            PolicyDef::CreatedByUser => Ok(format!(
-                "{alias}.j_created_by = (SELECT user_num FROM jazz_user WHERE user_id = '{}')",
-                self.user.replace('\'', "''")
-            )),
-            PolicyDef::RowIdEqualsUser
-            | PolicyDef::UserRefEqualsSession { .. }
-            | PolicyDef::GroupMember
-            | PolicyDef::GroupRefMember { .. }
-            | PolicyDef::ProjectMember
-            | PolicyDef::ProjectRefMember { .. } => policy::branch_read_policy_sql_for_alias(
+            PolicyDef::True => Ok("1 = 1".to_owned()),
+            PolicyDef::False => Ok("0 = 1".to_owned()),
+            PolicyDef::Cmp { .. }
+            | PolicyDef::SessionCmp { .. }
+            | PolicyDef::IsNull { .. }
+            | PolicyDef::SessionIsNull { .. }
+            | PolicyDef::IsNotNull { .. }
+            | PolicyDef::SessionIsNotNull { .. }
+            | PolicyDef::Contains { .. }
+            | PolicyDef::SessionContains { .. }
+            | PolicyDef::In { .. }
+            | PolicyDef::InList { .. }
+            | PolicyDef::SessionInList { .. }
+            | PolicyDef::Exists { .. }
+            | PolicyDef::ExistsRel { .. }
+            | PolicyDef::InheritsReferencing { .. } => policy::branch_read_policy_sql_for_alias(
                 self.schema,
                 table,
                 alias,
                 self.user,
                 self.branch_num,
             ),
-            PolicyDef::RefReadable { field } => {
+            PolicyDef::And(children) => {
+                if children.is_empty() {
+                    return Ok("1 = 1".to_owned());
+                }
+                let parts = children
+                    .iter()
+                    .map(|child| {
+                        self.lower_effective_branch_policy(
+                            table,
+                            alias,
+                            child,
+                            base_epoch,
+                            depth + 1,
+                        )
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                Ok(format!("({})", parts.join(" AND ")))
+            }
+            PolicyDef::Or(children) => {
+                if children.is_empty() {
+                    return Ok("0 = 1".to_owned());
+                }
+                let parts = children
+                    .iter()
+                    .map(|child| {
+                        self.lower_effective_branch_policy(
+                            table,
+                            alias,
+                            child,
+                            base_epoch,
+                            depth + 1,
+                        )
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                Ok(format!("({})", parts.join(" OR ")))
+            }
+            PolicyDef::Not(child) => Ok(format!(
+                "NOT ({})",
+                self.lower_effective_branch_policy(table, alias, child, base_epoch, depth + 1)?
+            )),
+            PolicyDef::Inherits {
+                operation: Operation::Select,
+                via_column: field,
+                ..
+            } => {
                 let field = table
                     .fields
                     .iter()
@@ -247,6 +296,9 @@ impl ReadVisibility<'_> {
                     tx::OUTCOME_REJECTED,
                 ))
             }
+            PolicyDef::Inherits { .. } => Err(crate::Error::new(
+                "mini-sqlite policies only lower SELECT inheritance today",
+            )),
         }
     }
 }

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -2778,6 +2778,13 @@ impl Runtime {
             .read_rows_where_eq(table_name, field_name, value)
     }
 
+    pub(crate) fn debug_sql_for_built_query(
+        &self,
+        query: &BuiltQuery,
+    ) -> Result<query::SqliteQueryDebug> {
+        self.query_context().debug_sql_for_built_query(query)
+    }
+
     pub fn read_rows_where_contains(
         &self,
         table_name: &str,
@@ -6482,71 +6489,280 @@ fn export_policy_dependency_history(
     let conn = visibility.conn;
     let schema = visibility.schema;
     let table = schema.table_def(args.table_name)?;
-    let PolicyDef::RefReadable { field } = args.policy else {
-        return Ok(Vec::new());
-    };
-    let field = table
-        .fields
-        .iter()
-        .find(|candidate| candidate.name == *field)
-        .ok_or_else(|| crate::Error::new(format!("unknown policy ref {field}")))?;
-    let FieldKind::Ref {
-        table: parent_table,
-    } = &field.kind
-    else {
-        return Err(crate::Error::new(format!(
-            "policy field {} is not a ref",
-            field.name
-        )));
-    };
-    let policy_sql = if args.child_row_nums.is_some() {
-        "1 = 1".to_owned()
-    } else {
-        visibility.current_policy_sql(table, "current")?
-    };
-    let ref_column = crate::schema::quote_ident(&crate::schema::storage_column(field));
-    let row_nums = if let Some(child_row_nums) = args.child_row_nums {
-        scoped_policy_parent_row_nums(
-            conn,
-            args.table_name,
-            &ref_column,
-            args.branch_nums,
-            child_row_nums,
-        )?
-    } else {
-        let sql = format!(
-            "SELECT DISTINCT current.{ref_column}
-             FROM {} current
-             JOIN jazz_tx current_tx ON current_tx.tx_num = current.visible_tx_num
-             WHERE current.is_deleted = 0
-               AND {}
-               AND current_tx.outcome != {}
-               AND {policy_sql}",
-            crate::schema::current_table(args.table_name),
-            branch_filter_sql("current", args.branch_nums),
-            tx::OUTCOME_REJECTED,
-        );
-        let mut stmt = conn.prepare(&sql)?;
-        let rows = stmt
-            .query_map([], |row| row.get::<_, i64>(0))?
-            .collect::<std::result::Result<Vec<_>, _>>()?;
-        rows
-    };
-    let mut records = if args.child_row_nums.is_some() {
-        export_history_versions_for_rows(conn, schema, parent_table, Some(&row_nums), None)?
-    } else {
-        export_visible_table_history(visibility, parent_table, args.branch_nums, Some(&row_nums))?
-    };
-    records.extend(export_policy_dependency_history(
+    match args.policy {
+        PolicyDef::AllowAll
+        | PolicyDef::CreatedByUser
+        | PolicyDef::RowIdEqualsUser
+        | PolicyDef::UserRefEqualsSession { .. } => Ok(Vec::new()),
+        PolicyDef::GroupMember => export_group_membership_policy_dependencies(visibility, args),
+        PolicyDef::ProjectMember => {
+            let project_row_nums = args.child_row_nums.map(|rows| rows.to_vec());
+            export_project_membership_policy_dependencies(visibility, args, project_row_nums)
+        }
+        PolicyDef::ProjectRefMember { field } => {
+            let field = table
+                .fields
+                .iter()
+                .find(|candidate| candidate.name == *field)
+                .ok_or_else(|| crate::Error::new(format!("unknown policy ref {field}")))?;
+            let FieldKind::Ref {
+                table: parent_table,
+            } = &field.kind
+            else {
+                return Err(crate::Error::new(format!(
+                    "policy field {} is not a ref",
+                    field.name
+                )));
+            };
+            if parent_table != "projects" {
+                return Err(crate::Error::new(format!(
+                    "policy field {} must reference projects",
+                    field.name
+                )));
+            }
+            let project_row_nums = current_ref_row_nums_for_children(
+                conn,
+                args.table_name,
+                field,
+                args.branch_nums,
+                args.child_row_nums,
+            )?;
+            export_project_membership_policy_dependencies(visibility, args, Some(project_row_nums))
+        }
+        PolicyDef::RefReadable { field } => {
+            let field = table
+                .fields
+                .iter()
+                .find(|candidate| candidate.name == *field)
+                .ok_or_else(|| crate::Error::new(format!("unknown policy ref {field}")))?;
+            let FieldKind::Ref {
+                table: parent_table,
+            } = &field.kind
+            else {
+                return Err(crate::Error::new(format!(
+                    "policy field {} is not a ref",
+                    field.name
+                )));
+            };
+            let ref_column = crate::schema::quote_ident(&crate::schema::storage_column(field));
+            let policy_sql = if args.child_row_nums.is_some() {
+                "1 = 1".to_owned()
+            } else {
+                visibility.current_policy_sql(table, "current")?
+            };
+            let row_nums = if let Some(child_row_nums) = args.child_row_nums {
+                scoped_policy_parent_row_nums(
+                    conn,
+                    args.table_name,
+                    &ref_column,
+                    args.branch_nums,
+                    child_row_nums,
+                )?
+            } else {
+                let sql = format!(
+                    "SELECT DISTINCT current.{ref_column}
+                     FROM {} current
+                     JOIN jazz_tx current_tx ON current_tx.tx_num = current.visible_tx_num
+                     WHERE current.is_deleted = 0
+                       AND {}
+                       AND current_tx.outcome != {}
+                       AND {policy_sql}",
+                    crate::schema::current_table(args.table_name),
+                    branch_filter_sql("current", args.branch_nums),
+                    tx::OUTCOME_REJECTED,
+                );
+                let mut stmt = conn.prepare(&sql)?;
+                let rows = stmt
+                    .query_map([], |row| row.get::<_, i64>(0))?
+                    .collect::<std::result::Result<Vec<_>, _>>()?;
+                rows
+            };
+            let mut records = if args.child_row_nums.is_some() {
+                export_history_versions_for_rows(conn, schema, parent_table, Some(&row_nums), None)?
+            } else {
+                export_visible_table_history(
+                    visibility,
+                    parent_table,
+                    args.branch_nums,
+                    Some(&row_nums),
+                )?
+            };
+            records.extend(export_policy_dependency_history(
+                visibility,
+                PolicyDependencyExport {
+                    table_name: parent_table,
+                    policy: &schema.table_def(parent_table)?.read_policy,
+                    branch_nums: args.branch_nums,
+                    child_row_nums: Some(&row_nums),
+                },
+            )?);
+            Ok(records)
+        }
+    }
+}
+
+fn export_group_membership_policy_dependencies(
+    visibility: &ReadVisibility<'_>,
+    args: PolicyDependencyExport<'_>,
+) -> Result<Vec<HistoryRecord>> {
+    let member_row_nums = current_group_member_row_nums_for_groups(
+        visibility.conn,
+        visibility.user,
+        args.branch_nums,
+        args.child_row_nums,
+    )?;
+    export_visible_table_history(
         visibility,
-        PolicyDependencyExport {
-            table_name: parent_table,
-            policy: &schema.table_def(parent_table)?.read_policy,
-            branch_nums: args.branch_nums,
-            child_row_nums: Some(&row_nums),
-        },
+        "group_members",
+        args.branch_nums,
+        Some(&member_row_nums),
+    )
+}
+
+fn export_project_membership_policy_dependencies(
+    visibility: &ReadVisibility<'_>,
+    args: PolicyDependencyExport<'_>,
+    project_row_nums: Option<Vec<i64>>,
+) -> Result<Vec<HistoryRecord>> {
+    let project_row_nums_ref = project_row_nums.as_deref();
+    let project_member_row_nums = current_project_member_row_nums_for_projects(
+        visibility.conn,
+        args.branch_nums,
+        project_row_nums_ref,
+    )?;
+    let mut records = export_visible_table_history(
+        visibility,
+        "project_members",
+        args.branch_nums,
+        Some(&project_member_row_nums),
+    )?;
+    let group_member_row_nums =
+        current_group_member_row_nums_for_user(visibility.conn, visibility.user, args.branch_nums)?;
+    records.extend(export_visible_table_history(
+        visibility,
+        "group_members",
+        args.branch_nums,
+        Some(&group_member_row_nums),
     )?);
     Ok(records)
+}
+
+fn current_ref_row_nums_for_children(
+    conn: &Connection,
+    table_name: &str,
+    field: &FieldDef,
+    branch_nums: &[i64],
+    child_row_nums: Option<&[i64]>,
+) -> Result<Vec<i64>> {
+    let ref_column = crate::schema::quote_ident(&crate::schema::storage_column(field));
+    let sql = format!(
+        "SELECT DISTINCT current.{ref_column}
+         FROM {} current
+         JOIN jazz_tx tx ON tx.tx_num = current.visible_tx_num
+         WHERE current.is_deleted = 0
+           AND {}
+           AND {}
+           AND tx.outcome != {}",
+        crate::schema::current_table(table_name),
+        branch_filter_sql("current", branch_nums),
+        row_num_filter_sql("current", child_row_nums),
+        tx::OUTCOME_REJECTED,
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let row_nums = stmt
+        .query_map([], |row| row.get::<_, i64>(0))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    Ok(row_nums)
+}
+
+fn current_group_member_row_nums_for_groups(
+    conn: &Connection,
+    user: &str,
+    branch_nums: &[i64],
+    group_row_nums: Option<&[i64]>,
+) -> Result<Vec<i64>> {
+    if matches!(group_row_nums, Some([])) {
+        return Ok(Vec::new());
+    }
+    let sql = format!(
+        "SELECT DISTINCT current.row_num
+         FROM {} current
+         JOIN jazz_tx tx ON tx.tx_num = current.visible_tx_num
+         WHERE current.is_deleted = 0
+           AND {}
+           AND {}
+           AND current.user_row_num = (
+             SELECT row_num FROM jazz_row_id WHERE row_id = ?
+           )
+           AND tx.outcome != {}",
+        crate::schema::current_table("group_members"),
+        branch_filter_sql("current", branch_nums),
+        group_row_nums
+            .map(|row_nums| {
+                format!(
+                    "current.group_row_num IN ({})",
+                    row_nums
+                        .iter()
+                        .map(i64::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            })
+            .unwrap_or_else(|| "1 = 1".to_owned()),
+        tx::OUTCOME_REJECTED,
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let row_nums = stmt
+        .query_map(params![user], |row| row.get::<_, i64>(0))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    Ok(row_nums)
+}
+
+fn current_group_member_row_nums_for_user(
+    conn: &Connection,
+    user: &str,
+    branch_nums: &[i64],
+) -> Result<Vec<i64>> {
+    current_group_member_row_nums_for_groups(conn, user, branch_nums, None)
+}
+
+fn current_project_member_row_nums_for_projects(
+    conn: &Connection,
+    branch_nums: &[i64],
+    project_row_nums: Option<&[i64]>,
+) -> Result<Vec<i64>> {
+    if matches!(project_row_nums, Some([])) {
+        return Ok(Vec::new());
+    }
+    let sql = format!(
+        "SELECT DISTINCT current.row_num
+         FROM {} current
+         JOIN jazz_tx tx ON tx.tx_num = current.visible_tx_num
+         WHERE current.is_deleted = 0
+           AND {}
+           AND {}
+           AND tx.outcome != {}",
+        crate::schema::current_table("project_members"),
+        branch_filter_sql("current", branch_nums),
+        project_row_nums
+            .map(|row_nums| {
+                format!(
+                    "current.project_row_num IN ({})",
+                    row_nums
+                        .iter()
+                        .map(i64::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            })
+            .unwrap_or_else(|| "1 = 1".to_owned()),
+        tx::OUTCOME_REJECTED,
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let row_nums = stmt
+        .query_map([], |row| row.get::<_, i64>(0))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    Ok(row_nums)
 }
 
 fn export_policy_dependency_history_for_query_scope(
@@ -7729,6 +7945,10 @@ fn history_row_filter_sql(alias: &str, row_nums: Option<&[i64]>) -> String {
         Some(row_nums) => format!("{alias}.row_num IN ({})", integer_list_sql(row_nums)),
         None => "1 = 1".to_owned(),
     }
+}
+
+fn row_num_filter_sql(alias: &str, row_nums: Option<&[i64]>) -> String {
+    history_row_filter_sql(alias, row_nums)
 }
 
 fn history_branch_filter_sql(alias: &str, branch_nums: Option<&[i64]>) -> String {

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -1,7 +1,7 @@
 use crate::query_api::{predicate_query, BuiltQuery, QueryCondition, QueryConditionOp};
 use crate::read_visibility::ReadVisibility;
 use crate::rows::{ensure_row_id, ensure_row_id_with_status, public_row_id, row_num};
-use crate::schema::{FieldDef, FieldKind, PolicyDef, SchemaDef};
+use crate::schema::{FieldDef, FieldKind, Operation, PolicyDef, SchemaDef};
 use crate::subscription::{RejectionSubscription, RowsSubscription, RowsSubscriptionQuery};
 use crate::sync::{
     BranchRecord, Bundle, HistoryRecord, QueryReadRecord, ReadRecord, TxRecord,
@@ -2517,6 +2517,7 @@ impl Runtime {
                 values: &visible_row.values,
                 user: &user,
                 op: 3,
+                created_by: Some(&visible_row.created_by),
             })?;
 
         let field_columns = table
@@ -4501,6 +4502,7 @@ fn insert_row_in_tx(args: InsertRowInTx<'_>) -> Result<bool> {
             values: &effective_values,
             user: args.user,
             op: args.op,
+            created_by: (args.op == 1).then_some(args.user),
         })?;
 
     let mut columns = vec![
@@ -4666,13 +4668,11 @@ struct LocalWriteCheck<'a> {
     values: &'a BTreeMap<String, JsonValue>,
     user: &'a str,
     op: i64,
+    created_by: Option<&'a str>,
 }
 
 fn local_write_allowed(check: LocalWriteCheck<'_>) -> Result<bool> {
     let policy = write_policy_for_op(check.table, check.op);
-    if check.op == 1 && matches!(policy, PolicyDef::CreatedByUser) {
-        return Ok(true);
-    }
     policy::write_allowed(policy::WriteCheck {
         db: check.db,
         schema: check.schema,
@@ -4682,6 +4682,7 @@ fn local_write_allowed(check: LocalWriteCheck<'_>) -> Result<bool> {
         branch_num: check.branch_num,
         values: check.values,
         user: check.user,
+        created_by: check.created_by,
     })
 }
 
@@ -4690,6 +4691,17 @@ fn write_policy_for_op(table: &crate::schema::TableDef, op: i64) -> &PolicyDef {
         table.delete_policy()
     } else {
         &table.write_policy
+    }
+}
+
+fn inherited_ref_policy_field(policy: &PolicyDef) -> Option<&str> {
+    match policy {
+        PolicyDef::Inherits {
+            operation: Operation::Select,
+            via_column,
+            ..
+        } => Some(via_column),
+        _ => None,
     }
 }
 
@@ -4710,7 +4722,7 @@ fn policy_denial_detail_for_history_record(
             "dependency_row_id": dependency.1,
         }));
     }
-    if let PolicyDef::RefReadable { field } = policy {
+    if let Some(field) = inherited_ref_policy_field(policy) {
         if let Some(dependency) = unavailable_policy_dependency(conn, table, record, tx_num, field)?
         {
             return Ok(json!({
@@ -5075,7 +5087,7 @@ fn record_policy_read_set_for_write(
     branch_num: i64,
     tx_num: i64,
 ) -> Result<()> {
-    let PolicyDef::RefReadable { field } = policy else {
+    let Some(field) = inherited_ref_policy_field(policy) else {
         return Ok(());
     };
     let field = table
@@ -5115,7 +5127,7 @@ fn record_policy_read_dependencies_for_row(
     branch_num: i64,
     tx_num: i64,
 ) -> Result<()> {
-    let PolicyDef::RefReadable { field } = policy else {
+    let Some(field) = inherited_ref_policy_field(policy) else {
         return Ok(());
     };
     let field = table
@@ -5546,6 +5558,7 @@ impl<'a> TransactionBuilder<'a> {
                             values: &visible_row.values,
                             user: &user,
                             op: 3,
+                            created_by: Some(&visible_row.created_by),
                         })?;
                     let field_columns = table_def
                         .fields
@@ -5785,9 +5798,6 @@ fn write_allowed_for_history_record(
         .ok_or_else(|| crate::Error::new("untrusted policy validation requires auth user"))?;
     let branch_num = branch::ensure(conn, &record.branch_id, None, now_ms())?;
     let policy = write_policy_for_op(table, record.op);
-    if record.op == 3 && matches!(policy, PolicyDef::CreatedByUser) {
-        return Ok(record.created_by == user);
-    }
     policy::write_allowed(policy::WriteCheck {
         db: conn,
         schema,
@@ -5797,6 +5807,7 @@ fn write_allowed_for_history_record(
         branch_num,
         values: &record.values,
         user,
+        created_by: Some(&record.created_by),
     })
 }
 
@@ -6323,7 +6334,7 @@ fn export_snapshot_policy_dependency_history(
     let conn = visibility.conn;
     let schema = visibility.schema;
     let table = schema.table_def(table_name)?;
-    let PolicyDef::RefReadable { field } = &table.read_policy else {
+    let Some(field) = inherited_ref_policy_field(&table.read_policy) else {
         return Ok(Vec::new());
     };
     let field = table
@@ -6415,7 +6426,7 @@ fn export_snapshot_policy_dependency_history_for_query_scope_at_depth(
     let conn = visibility.conn;
     let schema = visibility.schema;
     let table = schema.table_def(table_name)?;
-    let PolicyDef::RefReadable { field } = &table.read_policy else {
+    let Some(field) = inherited_ref_policy_field(&table.read_policy) else {
         return Ok(Vec::new());
     };
     let field = table
@@ -6516,54 +6527,91 @@ fn export_policy_dependency_history(
     let schema = visibility.schema;
     let table = schema.table_def(args.table_name)?;
     match args.policy {
-        PolicyDef::AllowAll
-        | PolicyDef::CreatedByUser
-        | PolicyDef::RowIdEqualsUser
-        | PolicyDef::UserRefEqualsSession { .. } => Ok(Vec::new()),
-        PolicyDef::GroupMember => export_group_membership_policy_dependencies(visibility, args),
-        PolicyDef::GroupRefMember { .. } => {
-            export_group_membership_policy_dependencies(visibility, args)
-        }
-        PolicyDef::ProjectMember => {
-            let project_row_nums = args.child_row_nums.map(|rows| rows.to_vec());
-            export_project_membership_policy_dependencies(visibility, args, project_row_nums)
-        }
-        PolicyDef::ProjectRefMember { field } => {
-            let field = table
-                .fields
-                .iter()
-                .find(|candidate| candidate.name == *field)
-                .ok_or_else(|| crate::Error::new(format!("unknown policy ref {field}")))?;
-            let FieldKind::Ref {
-                table: parent_table,
-            } = &field.kind
-            else {
-                return Err(crate::Error::new(format!(
-                    "policy field {} is not a ref",
-                    field.name
-                )));
-            };
-            if parent_table != "projects" {
-                return Err(crate::Error::new(format!(
-                    "policy field {} must reference projects",
-                    field.name
-                )));
+        PolicyDef::True
+        | PolicyDef::False
+        | PolicyDef::Cmp { .. }
+        | PolicyDef::SessionCmp { .. }
+        | PolicyDef::IsNull { .. }
+        | PolicyDef::SessionIsNull { .. }
+        | PolicyDef::IsNotNull { .. }
+        | PolicyDef::SessionIsNotNull { .. }
+        | PolicyDef::Contains { .. }
+        | PolicyDef::SessionContains { .. }
+        | PolicyDef::In { .. }
+        | PolicyDef::InList { .. }
+        | PolicyDef::SessionInList { .. }
+        | PolicyDef::Exists { .. }
+        | PolicyDef::ExistsRel { .. } => Ok(Vec::new()),
+        PolicyDef::InheritsReferencing {
+            operation,
+            source_table,
+            via_column,
+            ..
+        } => {
+            if *operation != Operation::Select {
+                return Err(crate::Error::new(
+                    "mini-sqlite policies only lower SELECT inheritance today",
+                ));
             }
-            let project_row_nums = current_ref_row_nums_for_children(
-                conn,
-                args.table_name,
-                field,
-                args.branch_nums,
-                args.child_row_nums,
-            )?;
-            export_project_membership_policy_dependencies(visibility, args, Some(project_row_nums))
+            let source_def = schema.table_def(source_table)?;
+            if source_table == "group_members"
+                && via_column == "group"
+                && source_def
+                    .read_policy
+                    .is_user_or_ref_readable("user", "member_group")
+            {
+                export_group_membership_policy_dependencies(visibility, args)
+            } else if source_table == "project_members"
+                && via_column == "project"
+                && source_def
+                    .read_policy
+                    .is_user_or_ref_readable("user", "group")
+            {
+                let project_row_nums = args.child_row_nums.map(|rows| rows.to_vec());
+                export_project_membership_policy_dependencies(visibility, args, project_row_nums)
+            } else {
+                Ok(Vec::new())
+            }
         }
-        PolicyDef::RefReadable { field } => {
+        PolicyDef::And(children) | PolicyDef::Or(children) => {
+            let mut records = Vec::new();
+            for child in children {
+                records.extend(export_policy_dependency_history(
+                    visibility,
+                    PolicyDependencyExport {
+                        table_name: args.table_name,
+                        policy: child,
+                        branch_nums: args.branch_nums,
+                        child_row_nums: args.child_row_nums,
+                    },
+                )?);
+            }
+            Ok(records)
+        }
+        PolicyDef::Not(child) => export_policy_dependency_history(
+            visibility,
+            PolicyDependencyExport {
+                table_name: args.table_name,
+                policy: child,
+                branch_nums: args.branch_nums,
+                child_row_nums: args.child_row_nums,
+            },
+        ),
+        PolicyDef::Inherits {
+            operation,
+            via_column,
+            ..
+        } => {
+            if *operation != Operation::Select {
+                return Err(crate::Error::new(
+                    "mini-sqlite policies only lower SELECT inheritance today",
+                ));
+            }
             let field = table
                 .fields
                 .iter()
-                .find(|candidate| candidate.name == *field)
-                .ok_or_else(|| crate::Error::new(format!("unknown policy ref {field}")))?;
+                .find(|candidate| candidate.name == *via_column)
+                .ok_or_else(|| crate::Error::new(format!("unknown policy ref {via_column}")))?;
             let FieldKind::Ref {
                 table: parent_table,
             } = &field.kind
@@ -6594,6 +6642,7 @@ fn export_policy_dependency_history(
                      JOIN jazz_tx current_tx ON current_tx.tx_num = current.visible_tx_num
                      WHERE current.is_deleted = 0
                        AND {}
+                       AND current.{ref_column} IS NOT NULL
                        AND current_tx.outcome != {}
                        AND {policy_sql}",
                     crate::schema::current_table(args.table_name),
@@ -6676,34 +6725,6 @@ fn export_project_membership_policy_dependencies(
     Ok(records)
 }
 
-fn current_ref_row_nums_for_children(
-    conn: &Connection,
-    table_name: &str,
-    field: &FieldDef,
-    branch_nums: &[i64],
-    child_row_nums: Option<&[i64]>,
-) -> Result<Vec<i64>> {
-    let ref_column = crate::schema::quote_ident(&crate::schema::storage_column(field));
-    let sql = format!(
-        "SELECT DISTINCT current.{ref_column}
-         FROM {} current
-         JOIN jazz_tx tx ON tx.tx_num = current.visible_tx_num
-         WHERE current.is_deleted = 0
-           AND {}
-           AND {}
-           AND tx.outcome != {}",
-        crate::schema::current_table(table_name),
-        branch_filter_sql("current", branch_nums),
-        row_num_filter_sql("current", child_row_nums),
-        tx::OUTCOME_REJECTED,
-    );
-    let mut stmt = conn.prepare(&sql)?;
-    let row_nums = stmt
-        .query_map([], |row| row.get::<_, i64>(0))?
-        .collect::<std::result::Result<Vec<_>, _>>()?;
-    Ok(row_nums)
-}
-
 fn current_group_member_row_nums_for_groups(
     conn: &Connection,
     user: &str,
@@ -6722,17 +6743,16 @@ fn current_group_member_row_nums_for_groups(
            JOIN jazz_tx direct_tx ON direct_tx.tx_num = direct.visible_tx_num
            WHERE direct.is_deleted = 0
              AND {direct_branch_filter}
-             AND direct.member = ?
+             AND direct.user_row_num = (SELECT row_num FROM jazz_row_id WHERE row_id = ?)
              AND direct_tx.outcome != {}
            UNION
            SELECT nested.group_row_num, nested.row_num
            FROM {} nested
            JOIN jazz_tx nested_tx ON nested_tx.tx_num = nested.visible_tx_num
            JOIN reachable parent ON 1 = 1
-           JOIN jazz_row_id parent_ids ON parent_ids.row_num = parent.group_row_num
            WHERE nested.is_deleted = 0
              AND {nested_branch_filter}
-             AND nested.member = ('group:' || parent_ids.row_id)
+             AND nested.member_group_row_num = parent.group_row_num
              AND nested_tx.outcome != {}
          )
          SELECT DISTINCT member_row_num
@@ -6744,7 +6764,7 @@ fn current_group_member_row_nums_for_groups(
     );
     let mut stmt = conn.prepare(&sql)?;
     let row_nums = stmt
-        .query_map(params![format!("user:{user}")], |row| row.get::<_, i64>(0))?
+        .query_map(params![user], |row| row.get::<_, i64>(0))?
         .collect::<std::result::Result<Vec<_>, _>>()?;
     Ok(row_nums)
 }
@@ -6811,7 +6831,7 @@ fn export_policy_dependency_history_for_query_scope_at_depth(
     let conn = visibility.conn;
     let schema = visibility.schema;
     let table = schema.table_def(args.table_name)?;
-    let PolicyDef::RefReadable { field } = args.policy else {
+    let Some(field) = inherited_ref_policy_field(args.policy) else {
         return Ok(Vec::new());
     };
     let field = table
@@ -6889,6 +6909,7 @@ fn scoped_policy_parent_row_nums(
          WHERE current.row_num IN ({child_row_nums})
            AND current.is_deleted = 0
            AND {}
+           AND current.{ref_column} IS NOT NULL
            AND current_tx.outcome != {}",
         crate::schema::current_table(table_name),
         branch_filter_sql("current", branch_nums),
@@ -7976,10 +7997,6 @@ fn history_row_filter_sql(alias: &str, row_nums: Option<&[i64]>) -> String {
         Some(row_nums) => format!("{alias}.row_num IN ({})", integer_list_sql(row_nums)),
         None => "1 = 1".to_owned(),
     }
-}
-
-fn row_num_filter_sql(alias: &str, row_nums: Option<&[i64]>) -> String {
-    history_row_filter_sql(alias, row_nums)
 }
 
 fn history_branch_filter_sql(alias: &str, branch_nums: Option<&[i64]>) -> String {

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -2502,7 +2502,7 @@ impl Runtime {
             &db,
             &self.schema,
             &table,
-            &table.write_policy,
+            table.delete_policy(),
             &visible_row.values,
             self.branch_num,
             tx_num,
@@ -4665,18 +4665,28 @@ struct LocalWriteCheck<'a> {
 }
 
 fn local_write_allowed(check: LocalWriteCheck<'_>) -> Result<bool> {
-    if check.op == 1 && matches!(check.table.write_policy, PolicyDef::CreatedByUser) {
+    let policy = write_policy_for_op(check.table, check.op);
+    if check.op == 1 && matches!(policy, PolicyDef::CreatedByUser) {
         return Ok(true);
     }
     policy::write_allowed(policy::WriteCheck {
         db: check.db,
         schema: check.schema,
         table: check.table,
+        policy,
         row_num: check.row_num,
         branch_num: check.branch_num,
         values: check.values,
         user: check.user,
     })
+}
+
+fn write_policy_for_op(table: &crate::schema::TableDef, op: i64) -> &PolicyDef {
+    if op == 3 {
+        table.delete_policy()
+    } else {
+        &table.write_policy
+    }
 }
 
 fn policy_denial_detail_for_history_record(
@@ -4686,6 +4696,7 @@ fn policy_denial_detail_for_history_record(
     tx_num: i64,
 ) -> Result<JsonValue> {
     let branch_num = branch::checkout(conn, &record.branch_id)?;
+    let policy = write_policy_for_op(table, record.op);
     if let Some(dependency) = unavailable_recorded_policy_dependency(conn, tx_num, branch_num)? {
         return Ok(json!({
             "reason": "policy_dependency_unavailable",
@@ -4695,7 +4706,7 @@ fn policy_denial_detail_for_history_record(
             "dependency_row_id": dependency.1,
         }));
     }
-    if let PolicyDef::RefReadable { field } = &table.write_policy {
+    if let PolicyDef::RefReadable { field } = policy {
         if let Some(dependency) = unavailable_policy_dependency(conn, table, record, tx_num, field)?
         {
             return Ok(json!({
@@ -5516,7 +5527,7 @@ impl<'a> TransactionBuilder<'a> {
                         &db,
                         &self.runtime.schema,
                         table_def,
-                        &table_def.write_policy,
+                        table_def.delete_policy(),
                         &visible_row.values,
                         self.runtime.branch_num,
                         tx_num,
@@ -5769,13 +5780,15 @@ fn write_allowed_for_history_record(
     let user = auth_user
         .ok_or_else(|| crate::Error::new("untrusted policy validation requires auth user"))?;
     let branch_num = branch::ensure(conn, &record.branch_id, None, now_ms())?;
-    if record.op == 3 && matches!(table.write_policy, PolicyDef::CreatedByUser) {
+    let policy = write_policy_for_op(table, record.op);
+    if record.op == 3 && matches!(policy, PolicyDef::CreatedByUser) {
         return Ok(record.created_by == user);
     }
     policy::write_allowed(policy::WriteCheck {
         db: conn,
         schema,
         table,
+        policy,
         row_num,
         branch_num,
         values: &record.values,
@@ -6247,6 +6260,15 @@ fn export_table_history(
         PolicyDependencyExport {
             table_name,
             policy: &schema.table_def(table_name)?.write_policy,
+            branch_nums: &branch_nums,
+            child_row_nums: None,
+        },
+    )?);
+    records.extend(export_policy_dependency_history(
+        &visibility,
+        PolicyDependencyExport {
+            table_name,
+            policy: schema.table_def(table_name)?.delete_policy(),
             branch_nums: &branch_nums,
             child_row_nums: None,
         },

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -2785,6 +2785,10 @@ impl Runtime {
         self.query_context().debug_sql_for_built_query(query)
     }
 
+    pub(crate) fn explain_built_query(&self, query: &BuiltQuery) -> Result<query::SqliteQueryPlan> {
+        self.query_context().explain_built_query(query)
+    }
+
     pub fn read_rows_where_contains(
         &self,
         table_name: &str,

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -6517,6 +6517,9 @@ fn export_policy_dependency_history(
         | PolicyDef::RowIdEqualsUser
         | PolicyDef::UserRefEqualsSession { .. } => Ok(Vec::new()),
         PolicyDef::GroupMember => export_group_membership_policy_dependencies(visibility, args),
+        PolicyDef::GroupRefMember { .. } => {
+            export_group_membership_policy_dependencies(visibility, args)
+        }
         PolicyDef::ProjectMember => {
             let project_row_nums = args.child_row_nums.map(|rows| rows.to_vec());
             export_project_membership_policy_dependencies(visibility, args, project_row_nums)
@@ -6706,36 +6709,38 @@ fn current_group_member_row_nums_for_groups(
     if matches!(group_row_nums, Some([])) {
         return Ok(Vec::new());
     }
+    let direct_branch_filter = branch_filter_sql("direct", branch_nums);
+    let nested_branch_filter = branch_filter_sql("nested", branch_nums);
     let sql = format!(
-        "SELECT DISTINCT current.row_num
-         FROM {} current
-         JOIN jazz_tx tx ON tx.tx_num = current.visible_tx_num
-         WHERE current.is_deleted = 0
-           AND {}
-           AND {}
-           AND current.user_row_num = (
-             SELECT row_num FROM jazz_row_id WHERE row_id = ?
-           )
-           AND tx.outcome != {}",
+        "WITH RECURSIVE reachable(group_row_num, member_row_num) AS (
+           SELECT direct.group_row_num, direct.row_num
+           FROM {} direct
+           JOIN jazz_tx direct_tx ON direct_tx.tx_num = direct.visible_tx_num
+           WHERE direct.is_deleted = 0
+             AND {direct_branch_filter}
+             AND direct.member = ?
+             AND direct_tx.outcome != {}
+           UNION
+           SELECT nested.group_row_num, nested.row_num
+           FROM {} nested
+           JOIN jazz_tx nested_tx ON nested_tx.tx_num = nested.visible_tx_num
+           JOIN reachable parent ON 1 = 1
+           JOIN jazz_row_id parent_ids ON parent_ids.row_num = parent.group_row_num
+           WHERE nested.is_deleted = 0
+             AND {nested_branch_filter}
+             AND nested.member = ('group:' || parent_ids.row_id)
+             AND nested_tx.outcome != {}
+         )
+         SELECT DISTINCT member_row_num
+         FROM reachable",
         crate::schema::current_table("group_members"),
-        branch_filter_sql("current", branch_nums),
-        group_row_nums
-            .map(|row_nums| {
-                format!(
-                    "current.group_row_num IN ({})",
-                    row_nums
-                        .iter()
-                        .map(i64::to_string)
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                )
-            })
-            .unwrap_or_else(|| "1 = 1".to_owned()),
+        tx::OUTCOME_REJECTED,
+        crate::schema::current_table("group_members"),
         tx::OUTCOME_REJECTED,
     );
     let mut stmt = conn.prepare(&sql)?;
     let row_nums = stmt
-        .query_map(params![user], |row| row.get::<_, i64>(0))?
+        .query_map(params![format!("user:{user}")], |row| row.get::<_, i64>(0))?
         .collect::<std::result::Result<Vec<_>, _>>()?;
     Ok(row_nums)
 }

--- a/crates/mini-jazz-sqlite/src/runtime.rs
+++ b/crates/mini-jazz-sqlite/src/runtime.rs
@@ -4,7 +4,7 @@ use crate::rows::{ensure_row_id, ensure_row_id_with_status, public_row_id, row_n
 use crate::schema::{FieldDef, FieldKind, Operation, PolicyDef, SchemaDef};
 use crate::subscription::{RejectionSubscription, RowsSubscription, RowsSubscriptionQuery};
 use crate::sync::{
-    BranchRecord, Bundle, HistoryRecord, QueryReadRecord, ReadRecord, TxRecord,
+    history_op, BranchRecord, Bundle, HistoryRecord, QueryReadRecord, ReadRecord, TxRecord,
     BUNDLE_PROTOCOL_VERSION,
 };
 use crate::time::now_ms;
@@ -314,7 +314,7 @@ impl Runtime {
         id: &str,
         values: BTreeMap<String, JsonValue>,
     ) -> Result<String> {
-        self.write_row(table_name, id, values, 1)
+        self.write_row(table_name, id, values, history_op::INSERT)
     }
 
     pub fn update_row(
@@ -324,7 +324,7 @@ impl Runtime {
         values: BTreeMap<String, JsonValue>,
     ) -> Result<String> {
         self.physical_row_num_for(id)?;
-        self.write_row(table_name, id, values, 2)
+        self.write_row(table_name, id, values, history_op::UPDATE)
     }
 
     pub fn upsert_row(
@@ -334,9 +334,9 @@ impl Runtime {
         values: BTreeMap<String, JsonValue>,
     ) -> Result<String> {
         let op = if self.row_has_current_branch_value(table_name, id)? {
-            2
+            history_op::UPDATE
         } else {
-            1
+            history_op::INSERT
         };
         self.write_row(table_name, id, values, op)
     }
@@ -348,9 +348,9 @@ impl Runtime {
         values: BTreeMap<String, JsonValue>,
     ) -> Result<String> {
         let op = if self.row_has_current_branch_value(table_name, id)? {
-            2
+            history_op::UPDATE
         } else {
-            1
+            history_op::INSERT
         };
         self.write_row(table_name, id, values, op)
     }
@@ -1296,6 +1296,7 @@ impl Runtime {
                 table,
                 row_num,
                 record,
+                tx_num,
                 Some(auth_user),
             )?;
             if !allowed {
@@ -1366,6 +1367,7 @@ impl Runtime {
                     table,
                     row_num,
                     &record,
+                    awaiting.tx_num,
                     Some(awaiting.auth_user.as_str()),
                 )?;
                 if !allowed {
@@ -1712,11 +1714,12 @@ impl Runtime {
                              JOIN jazz_tx tx ON tx.tx_num = h.tx_num
                              WHERE ids.row_id != ?
                                AND h.j_branch_num = ?
-                               AND h.op != 3
+                               AND h.op != {delete_op}
                                AND tx.outcome != ?
                            )",
                         current_table = crate::schema::current_table(&query_read.table),
                         history_table = crate::schema::history_table(&query_read.table),
+                        delete_op = history_op::DELETE,
                     ),
                     params![
                         branch_num,
@@ -1742,11 +1745,12 @@ impl Runtime {
                              JOIN jazz_tx tx ON tx.tx_num = h.tx_num
                              WHERE h.row_num = ?
                                AND h.j_branch_num = ?
-                               AND h.op != 3
+                               AND h.op != {delete_op}
                                AND tx.outcome != ?
                            )",
                         crate::schema::current_table(&query_read.table),
                         history_table = crate::schema::history_table(&query_read.table),
+                        delete_op = history_op::DELETE,
                     ),
                     params![
                         branch_num,
@@ -1792,11 +1796,12 @@ impl Runtime {
                          JOIN jazz_tx tx ON tx.tx_num = h.tx_num
                          WHERE h.j_branch_num = ?
                            AND {history_created_by_sql}
-                           AND h.op != 3
+                           AND h.op != {delete_op}
                            AND tx.outcome != ?
                        )",
                     crate::schema::current_table(&query_read.table),
                     history_table = crate::schema::history_table(&query_read.table),
+                    delete_op = history_op::DELETE,
                 ),
                 params![
                     branch_num,
@@ -1832,12 +1837,13 @@ impl Runtime {
                      JOIN {history_table} h ON h.row_num = ids.row_num
                      JOIN jazz_tx tx ON tx.tx_num = h.tx_num
                      WHERE h.j_branch_num = ?
-                       AND h.op != 3
+                       AND h.op != {delete_op}
                        AND tx.outcome != ?
                        AND {history_predicate_sql}
                    )",
                 crate::schema::current_table(&query_read.table),
                 history_table = crate::schema::history_table(&query_read.table),
+                delete_op = history_op::DELETE,
                 history_predicate_sql =
                     query_predicate::sql(field, &format!("h.{predicate_column}"), &query_read.op)?,
             ),
@@ -2099,7 +2105,7 @@ impl Runtime {
                 return Ok(());
             }
         }
-        if outcome != tx::OUTCOME_REJECTED && record.op == 3 {
+        if outcome != tx::OUTCOME_REJECTED && record.op == history_op::DELETE {
             context.db.execute(
                 &format!(
                     "DELETE FROM {} WHERE row_num = ? AND j_branch_num = ?",
@@ -2498,15 +2504,17 @@ impl Runtime {
         let now = now_ms();
         let (tx_num, tx_id) = tx::create_tx(&db, self.node_num, &self.node_id, now)?;
         let row_num = row_num(&db, id)?;
-        record_policy_read_set_for_write(
-            &db,
-            &self.schema,
-            &table,
-            table.delete_policy(),
-            &visible_row.values,
-            self.branch_num,
-            tx_num,
-        )?;
+        if let Some(policy) = table.effective_delete_using() {
+            record_policy_read_set_for_write(
+                &db,
+                &self.schema,
+                &table,
+                policy,
+                &visible_row.values,
+                self.branch_num,
+                tx_num,
+            )?;
+        }
         let allowed = bypass_policy
             || local_write_allowed(LocalWriteCheck {
                 db: &db,
@@ -2514,9 +2522,10 @@ impl Runtime {
                 table: &table,
                 row_num,
                 branch_num: self.branch_num,
-                values: &visible_row.values,
+                old_values: Some(&visible_row.values),
+                new_values: &visible_row.values,
                 user: &user,
-                op: 3,
+                op: history_op::DELETE,
                 created_by: Some(&visible_row.created_by),
             })?;
 
@@ -2542,7 +2551,7 @@ impl Runtime {
             "row_num".to_owned(),
             "?".to_owned(),
             "j_branch_num".to_owned(),
-            "3".to_owned(),
+            history_op::DELETE.to_string(),
         ];
         select_columns.extend(field_columns.iter().cloned());
         select_columns.extend([
@@ -2570,7 +2579,7 @@ impl Runtime {
                 rusqlite::types::Value::Integer(row_num),
                 rusqlite::types::Value::Integer(tx_num),
                 rusqlite::types::Value::Integer(self.branch_num),
-                rusqlite::types::Value::Integer(3),
+                rusqlite::types::Value::Integer(history_op::DELETE),
             ];
             for field in &table.fields {
                 let value = visible_row
@@ -2647,7 +2656,7 @@ impl Runtime {
                 &current_values,
             )?;
         }
-        record_tx_write(&db, tx_num, &table.name, row_num, 3)?;
+        record_tx_write(&db, tx_num, &table.name, row_num, history_op::DELETE)?;
         if !allowed {
             tx::reject(&db, &tx_id, "policy_denied")?;
             projection::rebuild(&db, &self.schema, self.node_num)?;
@@ -2675,12 +2684,13 @@ impl Runtime {
              JOIN jazz_tx tx ON tx.tx_num = h.tx_num
              WHERE h.row_num = ?
                AND h.j_branch_num = ?
-               AND h.op = 3
+               AND h.op = {delete_op}
                AND tx.outcome != ?
              ORDER BY tx.global_epoch DESC NULLS LAST, h.tx_num DESC
              LIMIT 1",
             field_columns.join(", "),
-            crate::schema::history_table(table_name)
+            crate::schema::history_table(table_name),
+            delete_op = history_op::DELETE,
         );
         let mut stmt = self.conn.prepare(&sql)?;
         let mut rows = stmt.query_map(
@@ -2704,7 +2714,7 @@ impl Runtime {
         }
         drop(rows);
         drop(stmt);
-        self.write_row(table_name, id, values, 1)
+        self.write_row(table_name, id, values, history_op::INSERT)
     }
 
     pub fn clear_current_projection_for_test(&mut self) -> Result<()> {
@@ -4410,7 +4420,7 @@ struct EffectiveWriteValues<'a> {
 
 fn effective_write_values(args: EffectiveWriteValues<'_>) -> Result<BTreeMap<String, JsonValue>> {
     let table = args.schema.table_def(args.table_name)?;
-    if args.op == 1 {
+    if args.op == history_op::INSERT {
         let mut values = args.patch_values.clone();
         for field in &table.fields {
             if !values.contains_key(&field.name) {
@@ -4437,7 +4447,7 @@ fn insert_row_in_tx(args: InsertRowInTx<'_>) -> Result<bool> {
     let table = args.schema.table_def(args.table_name)?;
     validate_write_fields(table, args.values)?;
     let (row_num, row_id_created) = ensure_row_id_with_status(args.db, args.id)?;
-    if args.op == 1 && !row_id_created {
+    if args.op == history_op::INSERT && !row_id_created {
         if row_id_used_by_other_table(args.db, args.schema, args.table_name, row_num)? {
             return Err(crate::Error::new(format!(
                 "row id {} is already used by another table",
@@ -4461,7 +4471,21 @@ fn insert_row_in_tx(args: InsertRowInTx<'_>) -> Result<bool> {
         patch_values: args.values,
         op: args.op,
     })?;
-    if args.op == 1 {
+    let previous_values = if args.op == history_op::UPDATE {
+        Some(
+            effective::row_values(
+                args.db,
+                args.schema,
+                args.table_name,
+                row_num,
+                args.branch_num,
+            )?
+            .ok_or_else(|| crate::Error::new(format!("row {} is not visible", args.id)))?,
+        )
+    } else {
+        None
+    };
+    if args.op == history_op::INSERT {
         if row_id_created {
             read_set::record_tx_absent_read(args.db, args.tx_num, args.table_name, row_num)?;
         } else {
@@ -4483,11 +4507,12 @@ fn insert_row_in_tx(args: InsertRowInTx<'_>) -> Result<bool> {
             2,
         )?;
     }
-    record_policy_read_set_for_write(
+    record_policy_read_sets_for_write(
         args.db,
         args.schema,
         table,
-        &table.write_policy,
+        args.op,
+        previous_values.as_ref(),
         &effective_values,
         args.branch_num,
         args.tx_num,
@@ -4499,10 +4524,11 @@ fn insert_row_in_tx(args: InsertRowInTx<'_>) -> Result<bool> {
             table,
             row_num,
             branch_num: args.branch_num,
-            values: &effective_values,
+            old_values: previous_values.as_ref(),
+            new_values: &effective_values,
             user: args.user,
             op: args.op,
-            created_by: (args.op == 1).then_some(args.user),
+            created_by: (args.op == history_op::INSERT).then_some(args.user),
         })?;
 
     let mut columns = vec![
@@ -4537,7 +4563,7 @@ fn insert_row_in_tx(args: InsertRowInTx<'_>) -> Result<bool> {
         "j_created_by".to_owned(),
         "j_updated_by".to_owned(),
     ]);
-    let (created_at, created_by) = if args.op == 1 {
+    let (created_at, created_by) = if args.op == history_op::INSERT {
         (args.now, args.user.to_owned())
     } else {
         current_creation_metadata(args.db, &table.name, row_num, args.branch_num)?
@@ -4665,19 +4691,119 @@ struct LocalWriteCheck<'a> {
     table: &'a crate::schema::TableDef,
     row_num: i64,
     branch_num: i64,
-    values: &'a BTreeMap<String, JsonValue>,
+    old_values: Option<&'a BTreeMap<String, JsonValue>>,
+    new_values: &'a BTreeMap<String, JsonValue>,
     user: &'a str,
     op: i64,
     created_by: Option<&'a str>,
 }
 
 fn local_write_allowed(check: LocalWriteCheck<'_>) -> Result<bool> {
-    let policy = write_policy_for_op(check.table, check.op);
+    operation_policy_allowed_for_op(&check)
+}
+
+fn operation_policy_allowed_for_op(check: &LocalWriteCheck<'_>) -> Result<bool> {
+    if check.op == history_op::DELETE {
+        let Some(policy) = check.table.effective_delete_using() else {
+            return Ok(true);
+        };
+        let Some(old_values) = check.old_values else {
+            return Ok(false);
+        };
+        return policy_allowed_for_values(PolicyValueCheck {
+            db: check.db,
+            schema: check.schema,
+            table: check.table,
+            policy,
+            row_num: check.row_num,
+            branch_num: check.branch_num,
+            values: old_values,
+            user: check.user,
+            created_by: check.created_by,
+        });
+    }
+    operation_policy_allowed(OperationPolicyCheck {
+        db: check.db,
+        schema: check.schema,
+        table: check.table,
+        row_num: check.row_num,
+        branch_num: check.branch_num,
+        policy: operation_policy_for_op(check.table, check.op),
+        old_values: check.old_values,
+        new_values: check.new_values,
+        user: check.user,
+        created_by: check.created_by,
+    })
+}
+
+struct OperationPolicyCheck<'a> {
+    db: &'a Connection,
+    schema: &'a SchemaDef,
+    table: &'a crate::schema::TableDef,
+    row_num: i64,
+    branch_num: i64,
+    policy: &'a crate::schema::OperationPolicy,
+    old_values: Option<&'a BTreeMap<String, JsonValue>>,
+    new_values: &'a BTreeMap<String, JsonValue>,
+    user: &'a str,
+    created_by: Option<&'a str>,
+}
+
+fn operation_policy_allowed(check: OperationPolicyCheck<'_>) -> Result<bool> {
+    if let Some(using) = &check.policy.using {
+        let Some(old_values) = check.old_values else {
+            return Ok(false);
+        };
+        if !policy_allowed_for_values(PolicyValueCheck {
+            db: check.db,
+            schema: check.schema,
+            table: check.table,
+            policy: using,
+            row_num: check.row_num,
+            branch_num: check.branch_num,
+            values: old_values,
+            user: check.user,
+            created_by: check.created_by,
+        })? {
+            return Ok(false);
+        }
+    }
+    if let Some(with_check) = &check.policy.with_check {
+        if !policy_allowed_for_values(PolicyValueCheck {
+            db: check.db,
+            schema: check.schema,
+            table: check.table,
+            policy: with_check,
+            row_num: check.row_num,
+            branch_num: check.branch_num,
+            values: check.new_values,
+            user: check.user,
+            created_by: check.created_by,
+        })? {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+struct PolicyValueCheck<'a> {
+    db: &'a Connection,
+    schema: &'a SchemaDef,
+    table: &'a crate::schema::TableDef,
+    policy: &'a PolicyDef,
+    row_num: i64,
+    branch_num: i64,
+    values: &'a BTreeMap<String, JsonValue>,
+    user: &'a str,
+    created_by: Option<&'a str>,
+}
+
+fn policy_allowed_for_values(check: PolicyValueCheck<'_>) -> Result<bool> {
     policy::write_allowed(policy::WriteCheck {
         db: check.db,
         schema: check.schema,
         table: check.table,
-        policy,
+        policy: check.policy,
         row_num: check.row_num,
         branch_num: check.branch_num,
         values: check.values,
@@ -4686,11 +4812,15 @@ fn local_write_allowed(check: LocalWriteCheck<'_>) -> Result<bool> {
     })
 }
 
-fn write_policy_for_op(table: &crate::schema::TableDef, op: i64) -> &PolicyDef {
-    if op == 3 {
-        table.delete_policy()
-    } else {
-        &table.write_policy
+fn operation_policy_for_op(
+    table: &crate::schema::TableDef,
+    op: i64,
+) -> &crate::schema::OperationPolicy {
+    match op {
+        history_op::INSERT => &table.insert_policy,
+        history_op::UPDATE => &table.update_policy,
+        history_op::DELETE => &table.delete_policy,
+        _ => &table.update_policy,
     }
 }
 
@@ -4705,6 +4835,23 @@ fn inherited_ref_policy_field(policy: &PolicyDef) -> Option<&str> {
     }
 }
 
+fn inherited_ref_policy_fields<'a>(policy: &'a PolicyDef, fields: &mut Vec<&'a str>) {
+    match policy {
+        PolicyDef::Inherits {
+            operation: Operation::Select,
+            via_column,
+            ..
+        } => fields.push(via_column),
+        PolicyDef::And(children) | PolicyDef::Or(children) => {
+            for child in children {
+                inherited_ref_policy_fields(child, fields);
+            }
+        }
+        PolicyDef::Not(child) => inherited_ref_policy_fields(child, fields),
+        _ => {}
+    }
+}
+
 fn policy_denial_detail_for_history_record(
     conn: &Connection,
     table: &crate::schema::TableDef,
@@ -4712,7 +4859,6 @@ fn policy_denial_detail_for_history_record(
     tx_num: i64,
 ) -> Result<JsonValue> {
     let branch_num = branch::checkout(conn, &record.branch_id)?;
-    let policy = write_policy_for_op(table, record.op);
     if let Some(dependency) = unavailable_recorded_policy_dependency(conn, tx_num, branch_num)? {
         return Ok(json!({
             "reason": "policy_dependency_unavailable",
@@ -4722,16 +4868,27 @@ fn policy_denial_detail_for_history_record(
             "dependency_row_id": dependency.1,
         }));
     }
-    if let Some(field) = inherited_ref_policy_field(policy) {
-        if let Some(dependency) = unavailable_policy_dependency(conn, table, record, tx_num, field)?
-        {
-            return Ok(json!({
-                "reason": "policy_dependency_unavailable",
-                "table": record.table,
-                "row_id": record.row_id,
-                "dependency_table": dependency.0,
-                "dependency_row_id": dependency.1,
-            }));
+    let policies = if record.op == history_op::DELETE {
+        vec![table.effective_delete_using()]
+    } else {
+        let policy = operation_policy_for_op(table, record.op);
+        vec![policy.using.as_ref(), policy.with_check.as_ref()]
+    };
+    for policy in policies.into_iter().flatten() {
+        let mut fields = Vec::new();
+        inherited_ref_policy_fields(policy, &mut fields);
+        for field in fields {
+            if let Some(dependency) =
+                unavailable_policy_dependency(conn, table, record, tx_num, field)?
+            {
+                return Ok(json!({
+                    "reason": "policy_dependency_unavailable",
+                    "table": record.table,
+                    "row_id": record.row_id,
+                    "dependency_table": dependency.0,
+                    "dependency_row_id": dependency.1,
+                }));
+            }
         }
     }
     Ok(json!({
@@ -5087,35 +5244,96 @@ fn record_policy_read_set_for_write(
     branch_num: i64,
     tx_num: i64,
 ) -> Result<()> {
-    let Some(field) = inherited_ref_policy_field(policy) else {
+    let mut fields = Vec::new();
+    inherited_ref_policy_fields(policy, &mut fields);
+    if fields.is_empty() {
         return Ok(());
     };
-    let field = table
-        .fields
-        .iter()
-        .find(|candidate| candidate.name == *field)
-        .ok_or_else(|| crate::Error::new(format!("unknown policy ref {field}")))?;
-    let FieldKind::Ref {
-        table: ref_table_name,
-    } = &field.kind
-    else {
+    for field in fields {
+        let field = table
+            .fields
+            .iter()
+            .find(|candidate| candidate.name == *field)
+            .ok_or_else(|| crate::Error::new(format!("unknown policy ref {field}")))?;
+        let FieldKind::Ref {
+            table: ref_table_name,
+        } = &field.kind
+        else {
+            continue;
+        };
+        let Some(row_id) = values.get(&field.name).and_then(JsonValue::as_str) else {
+            continue;
+        };
+        let row_num = ensure_row_id(conn, ref_table_name, row_id)?;
+        read_set::record_tx_read(conn, tx_num, ref_table_name, row_num, branch_num, 1)?;
+        let ref_table = schema.table_def(ref_table_name)?;
+        record_policy_read_dependencies_for_row(
+            conn,
+            schema,
+            ref_table,
+            &ref_table.read_policy,
+            row_num,
+            branch_num,
+            tx_num,
+        )?;
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn record_policy_read_sets_for_write(
+    conn: &Connection,
+    schema: &SchemaDef,
+    table: &crate::schema::TableDef,
+    op: i64,
+    old_values: Option<&BTreeMap<String, JsonValue>>,
+    new_values: &BTreeMap<String, JsonValue>,
+    branch_num: i64,
+    tx_num: i64,
+) -> Result<()> {
+    if op == history_op::DELETE {
+        if let (Some(policy), Some(old_values)) = (table.effective_delete_using(), old_values) {
+            record_policy_read_set_for_write(
+                conn, schema, table, policy, old_values, branch_num, tx_num,
+            )?;
+        }
         return Ok(());
-    };
-    let Some(row_id) = values.get(&field.name).and_then(JsonValue::as_str) else {
-        return Ok(());
-    };
-    let row_num = ensure_row_id(conn, ref_table_name, row_id)?;
-    read_set::record_tx_read(conn, tx_num, ref_table_name, row_num, branch_num, 1)?;
-    let ref_table = schema.table_def(ref_table_name)?;
-    record_policy_read_dependencies_for_row(
+    }
+    record_operation_policy_read_set_for_write(
         conn,
         schema,
-        ref_table,
-        &ref_table.read_policy,
-        row_num,
+        table,
+        operation_policy_for_op(table, op),
+        old_values,
+        new_values,
         branch_num,
         tx_num,
-    )
+    )?;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn record_operation_policy_read_set_for_write(
+    conn: &Connection,
+    schema: &SchemaDef,
+    table: &crate::schema::TableDef,
+    policy: &crate::schema::OperationPolicy,
+    old_values: Option<&BTreeMap<String, JsonValue>>,
+    new_values: &BTreeMap<String, JsonValue>,
+    branch_num: i64,
+    tx_num: i64,
+) -> Result<()> {
+    if let (Some(using), Some(old_values)) = (&policy.using, old_values) {
+        record_policy_read_set_for_write(
+            conn, schema, table, using, old_values, branch_num, tx_num,
+        )?;
+    }
+    if let Some(with_check) = &policy.with_check {
+        record_policy_read_set_for_write(
+            conn, schema, table, with_check, new_values, branch_num, tx_num,
+        )?;
+    }
+    Ok(())
 }
 
 fn record_policy_read_dependencies_for_row(
@@ -5127,36 +5345,41 @@ fn record_policy_read_dependencies_for_row(
     branch_num: i64,
     tx_num: i64,
 ) -> Result<()> {
-    let Some(field) = inherited_ref_policy_field(policy) else {
+    let mut fields = Vec::new();
+    inherited_ref_policy_fields(policy, &mut fields);
+    if fields.is_empty() {
         return Ok(());
     };
-    let field = table
-        .fields
-        .iter()
-        .find(|candidate| candidate.name == *field)
-        .ok_or_else(|| crate::Error::new(format!("unknown policy ref {field}")))?;
-    let FieldKind::Ref {
-        table: ref_table_name,
-    } = &field.kind
-    else {
-        return Ok(());
-    };
-    let Some(parent_row_num) =
-        current_ref_field_row_num(conn, &table.name, field, row_num, branch_num)?
-    else {
-        return Ok(());
-    };
-    read_set::record_tx_read(conn, tx_num, ref_table_name, parent_row_num, branch_num, 1)?;
-    let parent_table = schema.table_def(ref_table_name)?;
-    record_policy_read_dependencies_for_row(
-        conn,
-        schema,
-        parent_table,
-        &parent_table.read_policy,
-        parent_row_num,
-        branch_num,
-        tx_num,
-    )
+    for field in fields {
+        let field = table
+            .fields
+            .iter()
+            .find(|candidate| candidate.name == *field)
+            .ok_or_else(|| crate::Error::new(format!("unknown policy ref {field}")))?;
+        let FieldKind::Ref {
+            table: ref_table_name,
+        } = &field.kind
+        else {
+            continue;
+        };
+        let Some(parent_row_num) =
+            current_ref_field_row_num(conn, &table.name, field, row_num, branch_num)?
+        else {
+            continue;
+        };
+        read_set::record_tx_read(conn, tx_num, ref_table_name, parent_row_num, branch_num, 1)?;
+        let parent_table = schema.table_def(ref_table_name)?;
+        record_policy_read_dependencies_for_row(
+            conn,
+            schema,
+            parent_table,
+            &parent_table.read_policy,
+            parent_row_num,
+            branch_num,
+            tx_num,
+        )?;
+    }
+    Ok(())
 }
 
 fn current_ref_field_row_num(
@@ -5230,7 +5453,7 @@ fn snapshot_ref_field_row_num(
              JOIN jazz_tx tx ON tx.tx_num = h.tx_num
              WHERE h.row_num = ?
                AND h.j_branch_num = 1
-               AND h.op != 3
+               AND h.op != ?
                AND tx.outcome != ?
                AND tx.global_epoch IS NOT NULL
                AND tx.global_epoch <= ?
@@ -5251,6 +5474,7 @@ fn snapshot_ref_field_row_num(
         ),
         params![
             row_num,
+            history_op::DELETE,
             tx::OUTCOME_REJECTED,
             base_epoch,
             tx::OUTCOME_REJECTED,
@@ -5363,7 +5587,7 @@ fn normalize_mutations(mutations: Vec<Mutation>) -> Vec<Mutation> {
                 Mutation::Row { values, op, .. },
             ) => {
                 existing_values.extend(values);
-                if *existing_op != 1 {
+                if *existing_op != history_op::INSERT {
                     *existing_op = op;
                 }
             }
@@ -5398,7 +5622,7 @@ impl<'a> TransactionBuilder<'a> {
             table: table.to_owned(),
             id: id.to_owned(),
             values,
-            op: 1,
+            op: history_op::INSERT,
         });
         self
     }
@@ -5413,7 +5637,7 @@ impl<'a> TransactionBuilder<'a> {
             table: table.to_owned(),
             id: id.to_owned(),
             values,
-            op: 2,
+            op: history_op::UPDATE,
         });
         self
     }
@@ -5425,8 +5649,8 @@ impl<'a> TransactionBuilder<'a> {
         values: BTreeMap<String, JsonValue>,
     ) -> Self {
         let op = match self.runtime.row_has_current_branch_value(table, id) {
-            Ok(true) => 2,
-            Ok(false) | Err(_) => 1,
+            Ok(true) => history_op::UPDATE,
+            Ok(false) | Err(_) => history_op::INSERT,
         };
         self.mutations.push(Mutation::Row {
             table: table.to_owned(),
@@ -5539,15 +5763,17 @@ impl<'a> TransactionBuilder<'a> {
                         .ok_or_else(|| {
                             crate::Error::new(format!("missing delete snapshot {id}"))
                         })?;
-                    record_policy_read_set_for_write(
-                        &db,
-                        &self.runtime.schema,
-                        table_def,
-                        table_def.delete_policy(),
-                        &visible_row.values,
-                        self.runtime.branch_num,
-                        tx_num,
-                    )?;
+                    if let Some(policy) = table_def.effective_delete_using() {
+                        record_policy_read_set_for_write(
+                            &db,
+                            &self.runtime.schema,
+                            table_def,
+                            policy,
+                            &visible_row.values,
+                            self.runtime.branch_num,
+                            tx_num,
+                        )?;
+                    }
                     allowed &= bypass_policy
                         || local_write_allowed(LocalWriteCheck {
                             db: &db,
@@ -5555,9 +5781,10 @@ impl<'a> TransactionBuilder<'a> {
                             table: table_def,
                             row_num,
                             branch_num: self.runtime.branch_num,
-                            values: &visible_row.values,
+                            old_values: Some(&visible_row.values),
+                            new_values: &visible_row.values,
                             user: &user,
-                            op: 3,
+                            op: history_op::DELETE,
                             created_by: Some(&visible_row.created_by),
                         })?;
                     let field_columns = table_def
@@ -5584,7 +5811,7 @@ impl<'a> TransactionBuilder<'a> {
                         "row_num".to_owned(),
                         "?".to_owned(),
                         "j_branch_num".to_owned(),
-                        "3".to_owned(),
+                        history_op::DELETE.to_string(),
                     ];
                     select_columns.extend(field_columns.iter().cloned());
                     select_columns.extend([
@@ -5612,7 +5839,7 @@ impl<'a> TransactionBuilder<'a> {
                             rusqlite::types::Value::Integer(row_num),
                             rusqlite::types::Value::Integer(tx_num),
                             rusqlite::types::Value::Integer(self.runtime.branch_num),
-                            rusqlite::types::Value::Integer(3),
+                            rusqlite::types::Value::Integer(history_op::DELETE),
                         ];
                         for field in &table_def.fields {
                             let value = visible_row.values.get(&field.name).ok_or_else(|| {
@@ -5687,7 +5914,7 @@ impl<'a> TransactionBuilder<'a> {
                             &current_values,
                         )?;
                     }
-                    record_tx_write(&db, tx_num, &table, row_num, 3)?;
+                    record_tx_write(&db, tx_num, &table, row_num, history_op::DELETE)?;
                 }
             }
         }
@@ -5792,23 +6019,114 @@ fn write_allowed_for_history_record(
     table: &crate::schema::TableDef,
     row_num: i64,
     record: &HistoryRecord,
+    tx_num: i64,
     auth_user: Option<&str>,
 ) -> Result<bool> {
     let user = auth_user
         .ok_or_else(|| crate::Error::new("untrusted policy validation requires auth user"))?;
     let branch_num = branch::ensure(conn, &record.branch_id, None, now_ms())?;
-    let policy = write_policy_for_op(table, record.op);
-    policy::write_allowed(policy::WriteCheck {
-        db: conn,
-        schema,
-        table,
-        policy,
-        row_num,
-        branch_num,
-        values: &record.values,
-        user,
-        created_by: Some(&record.created_by),
-    })
+    let previous_values = match record.op {
+        history_op::UPDATE => {
+            previous_history_values_before_tx(conn, table, row_num, branch_num, tx_num)?
+        }
+        history_op::DELETE => Some(record.values.clone()),
+        _ => None,
+    };
+    let row_policy_allowed = if record.op == history_op::DELETE {
+        if let Some(policy) = table.effective_delete_using() {
+            let Some(old_values) = previous_values.as_ref() else {
+                return Ok(false);
+            };
+            policy_allowed_for_values(PolicyValueCheck {
+                db: conn,
+                schema,
+                table,
+                policy,
+                row_num,
+                branch_num,
+                values: old_values,
+                user,
+                created_by: Some(&record.created_by),
+            })?
+        } else {
+            true
+        }
+    } else {
+        operation_policy_allowed(OperationPolicyCheck {
+            db: conn,
+            schema,
+            table,
+            row_num,
+            branch_num,
+            policy: operation_policy_for_op(table, record.op),
+            old_values: previous_values.as_ref(),
+            new_values: &record.values,
+            user,
+            created_by: Some(&record.created_by),
+        })?
+    };
+    if !row_policy_allowed {
+        return Ok(false);
+    }
+    Ok(true)
+}
+
+fn previous_history_values_before_tx(
+    conn: &Connection,
+    table: &crate::schema::TableDef,
+    row_num: i64,
+    branch_num: i64,
+    tx_num: i64,
+) -> Result<Option<BTreeMap<String, JsonValue>>> {
+    let field_columns = table
+        .fields
+        .iter()
+        .map(|field| {
+            format!(
+                "h.{}",
+                crate::schema::quote_ident(&crate::schema::storage_column(field))
+            )
+        })
+        .collect::<Vec<_>>();
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {}
+         FROM {} h
+         JOIN jazz_tx tx ON tx.tx_num = h.tx_num
+         WHERE h.row_num = ?
+           AND h.j_branch_num = ?
+           AND h.tx_num < ?
+           AND h.op != ?
+           AND tx.outcome != ?
+         ORDER BY h.tx_num DESC
+         LIMIT 1",
+        field_columns.join(", "),
+        crate::schema::history_table(&table.name)
+    ))?;
+    let mut rows = stmt.query_map(
+        params![
+            row_num,
+            branch_num,
+            tx_num,
+            history_op::DELETE,
+            tx::OUTCOME_REJECTED
+        ],
+        |row| {
+            (0..table.fields.len())
+                .map(|idx| row.get::<_, rusqlite::types::Value>(idx))
+                .collect::<rusqlite::Result<Vec<_>>>()
+        },
+    )?;
+    let Some(row) = rows.next().transpose()? else {
+        return Ok(None);
+    };
+    let mut values = BTreeMap::new();
+    for (idx, field) in table.fields.iter().enumerate() {
+        values.insert(
+            field.name.clone(),
+            query::sql_value_to_json(conn, field, &row[idx])?,
+        );
+    }
+    Ok(Some(values))
 }
 
 fn is_newest_version_for_current(
@@ -6270,24 +6588,36 @@ fn export_table_history(
             child_row_nums: None,
         },
     )?);
-    records.extend(export_policy_dependency_history(
-        &visibility,
-        PolicyDependencyExport {
-            table_name,
-            policy: &schema.table_def(table_name)?.write_policy,
-            branch_nums: &branch_nums,
-            child_row_nums: None,
-        },
-    )?);
-    records.extend(export_policy_dependency_history(
-        &visibility,
-        PolicyDependencyExport {
-            table_name,
-            policy: schema.table_def(table_name)?.delete_policy(),
-            branch_nums: &branch_nums,
-            child_row_nums: None,
-        },
-    )?);
+    let table = schema.table_def(table_name)?;
+    for policy in [
+        table.insert_policy.with_check.as_ref(),
+        table.update_policy.using.as_ref(),
+        table.update_policy.with_check.as_ref(),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        records.extend(export_policy_dependency_history(
+            &visibility,
+            PolicyDependencyExport {
+                table_name,
+                policy,
+                branch_nums: &branch_nums,
+                child_row_nums: None,
+            },
+        )?);
+    }
+    if let Some(policy) = table.effective_delete_using() {
+        records.extend(export_policy_dependency_history(
+            &visibility,
+            PolicyDependencyExport {
+                table_name,
+                policy,
+                branch_nums: &branch_nums,
+                child_row_nums: None,
+            },
+        )?);
+    }
     if branch_num != 1 {
         if let Some(base_epoch) = branch::base_global_epoch(conn, branch_num)? {
             records.extend(export_main_base_snapshot_history(
@@ -6359,7 +6689,7 @@ fn export_snapshot_policy_dependency_history(
          JOIN jazz_tx tx ON tx.tx_num = h.tx_num
          WHERE {row_filter}
            AND h.j_branch_num = 1
-           AND h.op != 3
+           AND h.op != {delete_op}
            AND tx.outcome != {}
            AND tx.global_epoch IS NOT NULL
            AND tx.global_epoch <= {base_epoch}
@@ -6374,10 +6704,11 @@ fn export_snapshot_policy_dependency_history(
                AND newer_tx.global_epoch IS NOT NULL
                AND newer_tx.global_epoch <= {base_epoch}
                AND (newer_tx.global_epoch > tx.global_epoch OR (newer_tx.global_epoch = tx.global_epoch AND newer_tx.tx_num > tx.tx_num))
-           )",
+        )",
         crate::schema::history_table(table_name),
         tx::OUTCOME_REJECTED,
         tx::OUTCOME_REJECTED,
+        delete_op = history_op::DELETE,
         row_filter = history_row_filter_sql("h", child_row_nums),
         history_table = crate::schema::history_table(table_name),
     );
@@ -6459,7 +6790,7 @@ fn export_snapshot_policy_dependency_history_for_query_scope_at_depth(
            JOIN {child_scope_name} child_scope ON child_scope.row_num = h.row_num
            JOIN jazz_tx tx ON tx.tx_num = h.tx_num
            WHERE h.j_branch_num = 1
-             AND h.op != 3
+             AND h.op != {delete_op}
              AND tx.outcome != {}
              AND tx.global_epoch IS NOT NULL
              AND tx.global_epoch <= {base_epoch}
@@ -6475,10 +6806,11 @@ fn export_snapshot_policy_dependency_history_for_query_scope_at_depth(
                  AND newer_tx.global_epoch <= {base_epoch}
                  AND (newer_tx.global_epoch > tx.global_epoch OR (newer_tx.global_epoch = tx.global_epoch AND newer_tx.tx_num > tx.tx_num))
              )
-         )",
+        )",
         crate::schema::history_table(table_name),
         tx::OUTCOME_REJECTED,
         tx::OUTCOME_REJECTED,
+        delete_op = history_op::DELETE,
         history_table = crate::schema::history_table(table_name),
     ));
     let parent_scope = query::LoweredQueryRowScope {
@@ -6831,6 +7163,37 @@ fn export_policy_dependency_history_for_query_scope_at_depth(
     let conn = visibility.conn;
     let schema = visibility.schema;
     let table = schema.table_def(args.table_name)?;
+    match args.policy {
+        PolicyDef::And(children) | PolicyDef::Or(children) => {
+            let mut records = Vec::new();
+            for child in children {
+                records.extend(export_policy_dependency_history_for_query_scope_at_depth(
+                    visibility,
+                    PolicyDependencyQueryScopeExport {
+                        table_name: args.table_name,
+                        policy: child,
+                        branch_nums: args.branch_nums,
+                        child_scope: args.child_scope,
+                    },
+                    depth,
+                )?);
+            }
+            return Ok(records);
+        }
+        PolicyDef::Not(child) => {
+            return export_policy_dependency_history_for_query_scope_at_depth(
+                visibility,
+                PolicyDependencyQueryScopeExport {
+                    table_name: args.table_name,
+                    policy: child,
+                    branch_nums: args.branch_nums,
+                    child_scope: args.child_scope,
+                },
+                depth,
+            );
+        }
+        _ => {}
+    }
     let Some(field) = inherited_ref_policy_field(args.policy) else {
         return Ok(Vec::new());
     };
@@ -6933,7 +7296,7 @@ fn export_deleted_table_history(
         "SELECT h.row_num
          FROM {} h
          JOIN jazz_tx tx ON tx.tx_num = h.tx_num
-         WHERE h.op = 3
+         WHERE h.op = {delete_op}
            AND {}
            AND tx.outcome != {}
            AND NOT EXISTS (
@@ -6949,6 +7312,7 @@ fn export_deleted_table_history(
         branch_filter_sql("h", branch_nums),
         tx::OUTCOME_REJECTED,
         tx::OUTCOME_REJECTED,
+        delete_op = history_op::DELETE,
         history_table = crate::schema::history_table(table_name),
     );
     let mut stmt = conn.prepare(&sql)?;
@@ -6983,7 +7347,7 @@ fn export_deleted_recursive_descendant_history(
            SELECT h.row_num
            FROM {history_table} h
            JOIN jazz_tx tx ON tx.tx_num = h.tx_num
-           WHERE h.op = 3
+           WHERE h.op = {delete_op}
              AND {branch_filter}
              AND h.{parent_column} IN ({parent_row_nums})
              AND tx.outcome != {rejected}
@@ -7001,7 +7365,7 @@ fn export_deleted_recursive_descendant_history(
            FROM {history_table} child
            JOIN jazz_tx child_tx ON child_tx.tx_num = child.tx_num
            JOIN deleted_tree parent ON child.{parent_column} = parent.row_num
-           WHERE child.op = 3
+           WHERE child.op = {delete_op}
              AND {child_branch_filter}
              AND child_tx.outcome != {rejected}
              AND NOT EXISTS (
@@ -7019,6 +7383,7 @@ fn export_deleted_recursive_descendant_history(
         branch_filter = branch_filter_sql("h", branch_nums),
         child_branch_filter = branch_filter_sql("child", branch_nums),
         rejected = tx::OUTCOME_REJECTED,
+        delete_op = history_op::DELETE,
         parent_row_nums = integer_list_sql(&parent_row_nums),
     );
     let mut stmt = conn.prepare(&sql)?;

--- a/crates/mini-jazz-sqlite/src/schema.rs
+++ b/crates/mini-jazz-sqlite/src/schema.rs
@@ -66,24 +66,29 @@ impl SchemaDef {
             })
             .table("groups", |table| {
                 table.text("name");
-                table.read_if_group_member();
+                table.read_if_inherits_referencing("group_members", "group");
             })
             .table("group_members", |table| {
-                table.text("member");
+                table.optional_ref("user", "users");
+                table.optional_ref("member_group", "groups");
                 table.ref_("group", "groups");
-                table.index("by_member", ["member", "group"]);
-                table.read_if_group_ref_member("group");
+                table.index("by_user", ["user", "group"]);
+                table.index("by_member_group", ["member_group", "group"]);
+                table.read_if_user_or_ref_readable("user", "member_group");
             })
             .table("projects", |table| {
                 table.text("title");
-                table.read_if_project_member();
+                table.read_if_inherits_referencing("project_members", "project");
             })
             .table("project_members", |table| {
                 table.ref_("project", "projects");
-                table.text("member");
-                table.index("by_member", ["member", "project"]);
-                table.index("by_project_member", ["project", "member"]);
-                table.read_if_project_ref_member("project");
+                table.optional_ref("user", "users");
+                table.optional_ref("group", "groups");
+                table.index("by_user", ["user", "project"]);
+                table.index("by_group", ["group", "project"]);
+                table.index("by_project_user", ["project", "user"]);
+                table.index("by_project_group", ["project", "group"]);
+                table.read_if_user_or_ref_readable("user", "group");
             })
             .table("todos", |table| {
                 table.text("title");
@@ -93,7 +98,7 @@ impl SchemaDef {
                 table.index("created", ["$createdAt"]);
                 table.index("by_title", ["title"]);
                 table.index("open_visible", ["done", "project", "$createdAt"]);
-                table.read_if_ref_readable("project");
+                table.read_if_inherits("project");
                 table.delete_if_created_by_user();
             })
             .table("labels", |table| {
@@ -106,7 +111,7 @@ impl SchemaDef {
                 table.index("by_todo", ["todo"]);
                 table.index("by_todo_created", ["todo", "$createdAt"]);
                 table.index("by_label", ["label"]);
-                table.read_if_ref_readable("todo");
+                table.read_if_inherits("todo");
             })
     }
 
@@ -225,52 +230,258 @@ pub(crate) struct IndexDef {
     pub(crate) columns: Vec<String>,
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
-pub(crate) enum PolicyDef {
-    #[default]
-    AllowAll,
-    CreatedByUser,
-    RowIdEqualsUser,
-    UserRefEqualsSession {
-        field: String,
-    },
-    GroupMember,
-    GroupRefMember {
-        field: String,
-    },
-    ProjectMember,
-    ProjectRefMember {
-        field: String,
-    },
-    RefReadable {
-        field: String,
-    },
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum CmpOp {
+    Eq,
+    Ne,
+    Lt,
+    Le,
+    Gt,
+    Ge,
 }
 
-impl PolicyDef {
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub(crate) enum PolicyValue {
+    Literal(JsonValue),
+    SessionRef(Vec<String>),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum Operation {
+    Select,
+    Insert,
+    Update,
+    Delete,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub(crate) enum PolicyExpr {
+    Cmp {
+        column: String,
+        op: CmpOp,
+        value: PolicyValue,
+    },
+    SessionCmp {
+        path: Vec<String>,
+        op: CmpOp,
+        value: JsonValue,
+    },
+    IsNull {
+        column: String,
+    },
+    SessionIsNull {
+        path: Vec<String>,
+    },
+    IsNotNull {
+        column: String,
+    },
+    SessionIsNotNull {
+        path: Vec<String>,
+    },
+    Contains {
+        column: String,
+        value: PolicyValue,
+    },
+    SessionContains {
+        path: Vec<String>,
+        value: JsonValue,
+    },
+    In {
+        column: String,
+        session_path: Vec<String>,
+    },
+    InList {
+        column: String,
+        values: Vec<PolicyValue>,
+    },
+    SessionInList {
+        path: Vec<String>,
+        values: Vec<JsonValue>,
+    },
+    Exists {
+        table: String,
+        condition: Box<PolicyExpr>,
+    },
+    ExistsRel {
+        rel: JsonValue,
+    },
+    Inherits {
+        operation: Operation,
+        via_column: String,
+        max_depth: Option<usize>,
+    },
+    InheritsReferencing {
+        operation: Operation,
+        source_table: String,
+        via_column: String,
+        max_depth: Option<usize>,
+    },
+    And(Vec<PolicyExpr>),
+    Or(Vec<PolicyExpr>),
+    Not(Box<PolicyExpr>),
+    #[default]
+    True,
+    False,
+}
+
+pub(crate) type PolicyDef = PolicyExpr;
+
+impl PolicyExpr {
     fn fingerprint_for_table(&self, table: &TableDef) -> String {
         match self {
-            PolicyDef::AllowAll => "allow_all".to_owned(),
-            PolicyDef::CreatedByUser => "created_by_user".to_owned(),
-            PolicyDef::RowIdEqualsUser => "row_id_equals_user".to_owned(),
-            PolicyDef::UserRefEqualsSession { field } => {
+            PolicyDef::Cmp { column, op, value } => {
                 format!(
-                    "user_ref_equals_session:{}",
-                    storage_field_name(table, field)
+                    "cmp:{}:{op:?}:{}",
+                    policy_column_fingerprint(table, column),
+                    policy_value_fingerprint(value)
                 )
             }
-            PolicyDef::GroupMember => "group_member".to_owned(),
-            PolicyDef::GroupRefMember { field } => {
-                format!("group_ref_member:{}", storage_field_name(table, field))
+            PolicyDef::SessionCmp { path, op, value } => {
+                format!("session_cmp:{}:{op:?}:{value}", path.join("."))
             }
-            PolicyDef::ProjectMember => "project_member".to_owned(),
-            PolicyDef::ProjectRefMember { field } => {
-                format!("project_ref_member:{}", storage_field_name(table, field))
+            PolicyDef::IsNull { column } => {
+                format!("is_null:{}", policy_column_fingerprint(table, column))
             }
-            PolicyDef::RefReadable { field } => {
-                format!("ref_readable:{}", storage_field_name(table, field))
+            PolicyDef::SessionIsNull { path } => format!("session_is_null:{}", path.join(".")),
+            PolicyDef::IsNotNull { column } => {
+                format!("is_not_null:{}", policy_column_fingerprint(table, column))
             }
+            PolicyDef::SessionIsNotNull { path } => {
+                format!("session_is_not_null:{}", path.join("."))
+            }
+            PolicyDef::Contains { column, value } => {
+                format!(
+                    "contains:{}:{}",
+                    policy_column_fingerprint(table, column),
+                    policy_value_fingerprint(value)
+                )
+            }
+            PolicyDef::SessionContains { path, value } => {
+                format!("session_contains:{}:{value}", path.join("."))
+            }
+            PolicyDef::In {
+                column,
+                session_path,
+            } => format!(
+                "in:{}:{}",
+                policy_column_fingerprint(table, column),
+                session_path.join(".")
+            ),
+            PolicyDef::InList { column, values } => format!(
+                "in_list:{}:{}",
+                policy_column_fingerprint(table, column),
+                values
+                    .iter()
+                    .map(policy_value_fingerprint)
+                    .collect::<Vec<_>>()
+                    .join(",")
+            ),
+            PolicyDef::SessionInList { path, values } => format!(
+                "session_in_list:{}:{}",
+                path.join("."),
+                values
+                    .iter()
+                    .map(JsonValue::to_string)
+                    .collect::<Vec<_>>()
+                    .join(",")
+            ),
+            PolicyDef::Exists {
+                table: exists_table,
+                condition,
+            } => {
+                format!(
+                    "exists:{exists_table}:{}",
+                    condition.fingerprint_for_table(table)
+                )
+            }
+            PolicyDef::ExistsRel { rel } => format!("exists_rel:{rel}"),
+            PolicyDef::Inherits {
+                operation,
+                via_column,
+                max_depth,
+            } => {
+                format!(
+                    "inherits:{operation:?}:{}:{max_depth:?}",
+                    policy_column_fingerprint(table, via_column)
+                )
+            }
+            PolicyDef::InheritsReferencing {
+                operation,
+                source_table,
+                via_column,
+                max_depth,
+            } => {
+                format!(
+                    "inherits_referencing:{operation:?}:{source_table}:{via_column}:{max_depth:?}"
+                )
+            }
+            PolicyDef::And(children) => format!(
+                "and({})",
+                children
+                    .iter()
+                    .map(|policy| policy.fingerprint_for_table(table))
+                    .collect::<Vec<_>>()
+                    .join(",")
+            ),
+            PolicyDef::Or(children) => format!(
+                "or({})",
+                children
+                    .iter()
+                    .map(|policy| policy.fingerprint_for_table(table))
+                    .collect::<Vec<_>>()
+                    .join(",")
+            ),
+            PolicyDef::Not(child) => {
+                format!("not({})", child.fingerprint_for_table(table))
+            }
+            PolicyDef::True => "true".to_owned(),
+            PolicyDef::False => "false".to_owned(),
         }
+    }
+
+    pub(crate) fn is_user_or_ref_readable(&self, user_field: &str, ref_field: &str) -> bool {
+        let PolicyDef::Or(children) = self else {
+            return false;
+        };
+        if children.len() != 2 {
+            return false;
+        }
+        let has_session = children.iter().any(|child| {
+            matches!(
+                child,
+                PolicyDef::Cmp {
+                    column,
+                    op: CmpOp::Eq,
+                    value: PolicyValue::SessionRef(path),
+                } if column == user_field && path == &["user_id".to_owned()]
+            )
+        });
+        let has_ref = children.iter().any(|child| {
+            matches!(
+                child,
+                PolicyDef::Inherits {
+                    operation: Operation::Select,
+                    via_column,
+                    ..
+                } if via_column == ref_field
+            )
+        });
+        has_session && has_ref
+    }
+}
+
+fn policy_value_fingerprint(value: &PolicyValue) -> String {
+    match value {
+        PolicyValue::Literal(value) => format!("literal:{value}"),
+        PolicyValue::SessionRef(path) => format!("session:{}", path.join(".")),
+    }
+}
+
+fn policy_column_fingerprint(table: &TableDef, column: &str) -> String {
+    if column.starts_with('$') {
+        column.to_owned()
+    } else {
+        storage_field_name(table, column).to_owned()
     }
 }
 
@@ -294,8 +505,8 @@ impl TableBuilder {
                 name: name.to_owned(),
                 fields: Vec::new(),
                 indexes: Vec::new(),
-                read_policy: PolicyDef::AllowAll,
-                write_policy: PolicyDef::AllowAll,
+                read_policy: PolicyDef::True,
+                write_policy: PolicyDef::True,
                 delete_policy: None,
             },
         }
@@ -405,61 +616,99 @@ impl TableBuilder {
     }
 
     pub fn read_if_created_by_user(&mut self) {
-        self.table.read_policy = PolicyDef::CreatedByUser;
+        self.table.read_policy = created_by_user_policy();
     }
 
     pub fn read_if_row_id_equals_user(&mut self) {
-        self.table.read_policy = PolicyDef::RowIdEqualsUser;
+        self.table.read_policy = row_id_equals_user_policy();
     }
 
     pub fn read_if_user_ref_equals_session(&mut self, field: &str) {
-        self.table.read_policy = PolicyDef::UserRefEqualsSession {
-            field: field.to_owned(),
-        };
+        self.table.read_policy = user_ref_equals_session_policy(field);
     }
 
-    pub fn read_if_group_member(&mut self) {
-        self.table.read_policy = PolicyDef::GroupMember;
+    pub fn read_if_inherits(&mut self, field: &str) {
+        self.table.read_policy = inherits_policy(field);
     }
 
-    pub fn read_if_group_ref_member(&mut self, field: &str) {
-        self.table.read_policy = PolicyDef::GroupRefMember {
-            field: field.to_owned(),
-        };
+    pub fn read_if_inherits_referencing(&mut self, source_table: &str, field: &str) {
+        self.table.read_policy = inherits_referencing_policy(source_table, field);
     }
 
-    pub fn read_if_project_member(&mut self) {
-        self.table.read_policy = PolicyDef::ProjectMember;
-    }
-
-    pub fn read_if_project_ref_member(&mut self, field: &str) {
-        self.table.read_policy = PolicyDef::ProjectRefMember {
-            field: field.to_owned(),
-        };
+    pub fn read_if_user_or_ref_readable(&mut self, user_field: &str, ref_field: &str) {
+        self.table.read_policy = PolicyDef::Or(vec![
+            PolicyDef::Cmp {
+                column: user_field.to_owned(),
+                op: CmpOp::Eq,
+                value: PolicyValue::SessionRef(vec!["user_id".to_owned()]),
+            },
+            PolicyDef::Inherits {
+                operation: Operation::Select,
+                via_column: ref_field.to_owned(),
+                max_depth: None,
+            },
+        ]);
     }
 
     pub fn write_if_created_by_user(&mut self) {
-        self.table.write_policy = PolicyDef::CreatedByUser;
+        self.table.write_policy = created_by_user_policy();
     }
 
     pub fn write_if_ref_readable(&mut self, field: &str) {
-        self.table.write_policy = PolicyDef::RefReadable {
-            field: field.to_owned(),
-        };
+        self.table.write_policy = inherits_policy(field);
     }
 
     pub fn delete_if_created_by_user(&mut self) {
-        self.table.delete_policy = Some(PolicyDef::CreatedByUser);
+        self.table.delete_policy = Some(created_by_user_policy());
     }
 
     pub fn read_if_ref_readable(&mut self, field: &str) {
-        self.table.read_policy = PolicyDef::RefReadable {
-            field: field.to_owned(),
-        };
+        self.table.read_policy = inherits_policy(field);
     }
 
     fn finish(self) -> TableDef {
         self.table
+    }
+}
+
+fn created_by_user_policy() -> PolicyDef {
+    PolicyDef::Cmp {
+        column: "$createdBy".to_owned(),
+        op: CmpOp::Eq,
+        value: PolicyValue::SessionRef(vec!["user_id".to_owned()]),
+    }
+}
+
+fn row_id_equals_user_policy() -> PolicyDef {
+    PolicyDef::Cmp {
+        column: "$id".to_owned(),
+        op: CmpOp::Eq,
+        value: PolicyValue::SessionRef(vec!["user_id".to_owned()]),
+    }
+}
+
+fn user_ref_equals_session_policy(field: &str) -> PolicyDef {
+    PolicyDef::Cmp {
+        column: field.to_owned(),
+        op: CmpOp::Eq,
+        value: PolicyValue::SessionRef(vec!["user_id".to_owned()]),
+    }
+}
+
+fn inherits_policy(field: &str) -> PolicyDef {
+    PolicyDef::Inherits {
+        operation: Operation::Select,
+        via_column: field.to_owned(),
+        max_depth: None,
+    }
+}
+
+fn inherits_referencing_policy(source_table: &str, field: &str) -> PolicyDef {
+    PolicyDef::InheritsReferencing {
+        operation: Operation::Select,
+        source_table: source_table.to_owned(),
+        via_column: field.to_owned(),
+        max_depth: None,
     }
 }
 
@@ -648,24 +897,60 @@ fn validate_policy_cycle(
     seen: &mut BTreeSet<String>,
 ) -> Result<()> {
     let field = match policy {
-        PolicyDef::RefReadable { field } => field,
-        PolicyDef::UserRefEqualsSession { field } => {
-            validate_policy_ref_field(schema, table, field, Some("users"))?;
+        PolicyDef::Inherits {
+            operation,
+            via_column,
+            ..
+        } => {
+            validate_select_operation(*operation)?;
+            via_column
+        }
+        PolicyDef::InheritsReferencing {
+            source_table,
+            via_column,
+            operation,
+            ..
+        } => {
+            validate_select_operation(*operation)?;
+            validate_inherits_referencing_policy(schema, table, source_table, via_column)?;
             return Ok(());
         }
-        PolicyDef::ProjectRefMember { field } => {
-            validate_policy_ref_field(schema, table, field, Some("projects"))?;
+        PolicyDef::Cmp { column, .. }
+        | PolicyDef::IsNull { column }
+        | PolicyDef::IsNotNull { column }
+        | PolicyDef::Contains { column, .. }
+        | PolicyDef::In { column, .. }
+        | PolicyDef::InList { column, .. } => {
+            validate_policy_column(table, column)?;
             return Ok(());
         }
-        PolicyDef::GroupRefMember { field } => {
-            validate_policy_ref_field(schema, table, field, Some("groups"))?;
+        PolicyDef::SessionCmp { .. }
+        | PolicyDef::SessionIsNull { .. }
+        | PolicyDef::SessionIsNotNull { .. }
+        | PolicyDef::SessionContains { .. }
+        | PolicyDef::SessionInList { .. } => return Ok(()),
+        PolicyDef::Exists {
+            table: exists_table,
+            condition,
+        } => {
+            let exists_table = schema.table_def(exists_table)?;
+            validate_policy_cycle(schema, exists_table, condition, seen)?;
             return Ok(());
         }
-        PolicyDef::AllowAll
-        | PolicyDef::CreatedByUser
-        | PolicyDef::RowIdEqualsUser
-        | PolicyDef::GroupMember
-        | PolicyDef::ProjectMember => return Ok(()),
+        PolicyDef::ExistsRel { .. } => {
+            return Ok(());
+        }
+        PolicyDef::And(children) | PolicyDef::Or(children) => {
+            for child in children {
+                validate_policy_cycle(schema, table, child, seen)?;
+            }
+            return Ok(());
+        }
+        PolicyDef::Not(child) => {
+            validate_policy_cycle(schema, table, child, seen)?;
+            return Ok(());
+        }
+        PolicyDef::True | PolicyDef::False => return Ok(()),
     };
     if !seen.insert(table.name.clone()) {
         return Err(crate::Error::new(format!(
@@ -697,36 +982,56 @@ fn validate_policy_cycle(
     result
 }
 
-fn validate_policy_ref_field(
+fn validate_select_operation(operation: Operation) -> Result<()> {
+    if operation != Operation::Select {
+        return Err(crate::Error::new(
+            "mini-sqlite policies only lower SELECT inheritance today",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_policy_column(table: &TableDef, column: &str) -> Result<()> {
+    if matches!(column, "$id" | "$createdBy") {
+        return Ok(());
+    }
+    if table.fields.iter().any(|field| field.name == column) {
+        return Ok(());
+    }
+    Err(crate::Error::new(format!(
+        "policy on {} references unknown column {}",
+        table.name, column
+    )))
+}
+
+fn validate_inherits_referencing_policy(
     schema: &SchemaDef,
     table: &TableDef,
+    source_table_name: &str,
     field_name: &str,
-    expected_table: Option<&str>,
 ) -> Result<()> {
-    let Some(field) = table
+    let source_table = schema.table_def(source_table_name)?;
+    let Some(field) = source_table
         .fields
         .iter()
         .find(|candidate| candidate.name == field_name)
     else {
         return Err(crate::Error::new(format!(
-            "policy on {} references unknown field {}",
-            table.name, field_name
+            "policy on {} references unknown field {}.{}",
+            table.name, source_table_name, field_name
         )));
     };
     let FieldKind::Ref { table: parent } = &field.kind else {
         return Err(crate::Error::new(format!(
-            "policy on {} references non-ref field {}",
-            table.name, field.name
+            "policy on {} references non-ref field {}.{}",
+            table.name, source_table_name, field.name
         )));
     };
-    schema.table_def(parent)?;
-    if let Some(expected_table) = expected_table {
-        if parent != expected_table {
-            return Err(crate::Error::new(format!(
-                "policy on {} expected {} to reference {}",
-                table.name, field.name, expected_table
-            )));
-        }
+    if parent != &table.name {
+        return Err(crate::Error::new(format!(
+            "policy on {} expected {}.{} to reference {}",
+            table.name, source_table_name, field.name, table.name
+        )));
     }
     Ok(())
 }

--- a/crates/mini-jazz-sqlite/src/schema.rs
+++ b/crates/mini-jazz-sqlite/src/schema.rs
@@ -93,6 +93,7 @@ impl SchemaDef {
                 table.index("by_title", ["title"]);
                 table.index("open_visible", ["done", "project", "$createdAt"]);
                 table.read_if_ref_readable("project");
+                table.delete_if_created_by_user();
             })
             .table("labels", |table| {
                 table.text("name");
@@ -157,6 +158,11 @@ impl SchemaDef {
                 table.name,
                 table.write_policy.fingerprint_for_table(table)
             ));
+            parts.push(format!(
+                "{}:delete:{}",
+                table.name,
+                table.delete_policy().fingerprint_for_table(table)
+            ));
         }
         parts.join("|")
     }
@@ -175,6 +181,13 @@ pub(crate) struct TableDef {
     pub(crate) indexes: Vec<IndexDef>,
     pub(crate) read_policy: PolicyDef,
     pub(crate) write_policy: PolicyDef,
+    delete_policy: Option<PolicyDef>,
+}
+
+impl TableDef {
+    pub(crate) fn delete_policy(&self) -> &PolicyDef {
+        self.delete_policy.as_ref().unwrap_or(&self.write_policy)
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -275,6 +288,7 @@ impl TableBuilder {
                 indexes: Vec::new(),
                 read_policy: PolicyDef::AllowAll,
                 write_policy: PolicyDef::AllowAll,
+                delete_policy: None,
             },
         }
     }
@@ -418,6 +432,10 @@ impl TableBuilder {
         self.table.write_policy = PolicyDef::RefReadable {
             field: field.to_owned(),
         };
+    }
+
+    pub fn delete_if_created_by_user(&mut self) {
+        self.table.delete_policy = Some(PolicyDef::CreatedByUser);
     }
 
     pub fn read_if_ref_readable(&mut self, field: &str) {
@@ -602,6 +620,9 @@ fn validate_policy_cycles(schema: &SchemaDef) -> Result<()> {
     for table in schema.tables() {
         validate_policy_cycle(schema, table, &table.read_policy, &mut BTreeSet::new())?;
         validate_policy_cycle(schema, table, &table.write_policy, &mut BTreeSet::new())?;
+        if let Some(delete_policy) = &table.delete_policy {
+            validate_policy_cycle(schema, table, delete_policy, &mut BTreeSet::new())?;
+        }
     }
     Ok(())
 }

--- a/crates/mini-jazz-sqlite/src/schema.rs
+++ b/crates/mini-jazz-sqlite/src/schema.rs
@@ -25,9 +25,9 @@ impl SchemaDef {
                 table.text("name");
             })
             .table("group_members", |table| {
-                table.ref_("user", "users");
+                table.text("member");
                 table.ref_("group", "groups");
-                table.index("by_user", ["user", "group"]);
+                table.index("by_member", ["member", "group"]);
             })
             .table("projects", |table| {
                 table.text("title");
@@ -69,10 +69,10 @@ impl SchemaDef {
                 table.read_if_group_member();
             })
             .table("group_members", |table| {
-                table.ref_("user", "users");
+                table.text("member");
                 table.ref_("group", "groups");
-                table.index("by_user", ["user", "group"]);
-                table.read_if_user_ref_equals_session("user");
+                table.index("by_member", ["member", "group"]);
+                table.read_if_group_ref_member("group");
             })
             .table("projects", |table| {
                 table.text("title");
@@ -233,6 +233,9 @@ pub(crate) enum PolicyDef {
         field: String,
     },
     GroupMember,
+    GroupRefMember {
+        field: String,
+    },
     ProjectMember,
     ProjectRefMember {
         field: String,
@@ -255,6 +258,9 @@ impl PolicyDef {
                 )
             }
             PolicyDef::GroupMember => "group_member".to_owned(),
+            PolicyDef::GroupRefMember { field } => {
+                format!("group_ref_member:{}", storage_field_name(table, field))
+            }
             PolicyDef::ProjectMember => "project_member".to_owned(),
             PolicyDef::ProjectRefMember { field } => {
                 format!("project_ref_member:{}", storage_field_name(table, field))
@@ -412,6 +418,12 @@ impl TableBuilder {
 
     pub fn read_if_group_member(&mut self) {
         self.table.read_policy = PolicyDef::GroupMember;
+    }
+
+    pub fn read_if_group_ref_member(&mut self, field: &str) {
+        self.table.read_policy = PolicyDef::GroupRefMember {
+            field: field.to_owned(),
+        };
     }
 
     pub fn read_if_project_member(&mut self) {
@@ -641,6 +653,10 @@ fn validate_policy_cycle(
         }
         PolicyDef::ProjectRefMember { field } => {
             validate_policy_ref_field(schema, table, field, Some("projects"))?;
+            return Ok(());
+        }
+        PolicyDef::GroupRefMember { field } => {
+            validate_policy_ref_field(schema, table, field, Some("groups"))?;
             return Ok(());
         }
         PolicyDef::AllowAll

--- a/crates/mini-jazz-sqlite/src/schema.rs
+++ b/crates/mini-jazz-sqlite/src/schema.rs
@@ -99,6 +99,8 @@ impl SchemaDef {
                 table.index("by_title", ["title"]);
                 table.index("open_visible", ["done", "project", "$createdAt"]);
                 table.read_if_inherits("project");
+                table.write_if_ref_readable("project");
+                table.update_protected_fields_if_created_by_user(["title", "project"]);
                 table.delete_if_created_by_user();
             })
             .table("labels", |table| {
@@ -161,14 +163,19 @@ impl SchemaDef {
                 continue;
             };
             parts.push(format!(
-                "{}:write:{}",
+                "{}:insert:{}",
                 table.name,
-                table.write_policy.fingerprint_for_table(table)
+                table.insert_policy.fingerprint_for_table(table)
+            ));
+            parts.push(format!(
+                "{}:update:{}",
+                table.name,
+                table.update_policy.fingerprint_for_table(table)
             ));
             parts.push(format!(
                 "{}:delete:{}",
                 table.name,
-                table.delete_policy().fingerprint_for_table(table)
+                table.delete_policy.fingerprint_for_table(table)
             ));
         }
         parts.join("|")
@@ -187,13 +194,17 @@ pub(crate) struct TableDef {
     pub(crate) fields: Vec<FieldDef>,
     pub(crate) indexes: Vec<IndexDef>,
     pub(crate) read_policy: PolicyDef,
-    pub(crate) write_policy: PolicyDef,
-    delete_policy: Option<PolicyDef>,
+    pub(crate) insert_policy: OperationPolicy,
+    pub(crate) update_policy: OperationPolicy,
+    pub(crate) delete_policy: OperationPolicy,
 }
 
 impl TableDef {
-    pub(crate) fn delete_policy(&self) -> &PolicyDef {
-        self.delete_policy.as_ref().unwrap_or(&self.write_policy)
+    pub(crate) fn effective_delete_using(&self) -> Option<&PolicyDef> {
+        self.delete_policy
+            .using
+            .as_ref()
+            .or(self.update_policy.using.as_ref())
     }
 }
 
@@ -246,12 +257,58 @@ pub(crate) enum PolicyValue {
     SessionRef(Vec<String>),
 }
 
+pub(crate) const OUTER_ROW_SESSION_PREFIX: &str = "__jazz_outer_row";
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) enum Operation {
     Select,
     Insert,
     Update,
     Delete,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub(crate) struct OperationPolicy {
+    pub(crate) using: Option<PolicyDef>,
+    pub(crate) with_check: Option<PolicyDef>,
+}
+
+impl OperationPolicy {
+    fn using(policy: PolicyDef) -> Self {
+        Self {
+            using: Some(policy),
+            with_check: None,
+        }
+    }
+
+    fn with_check(policy: PolicyDef) -> Self {
+        Self {
+            using: None,
+            with_check: Some(policy),
+        }
+    }
+
+    fn using_and_check(using: PolicyDef, with_check: PolicyDef) -> Self {
+        Self {
+            using: Some(using),
+            with_check: Some(with_check),
+        }
+    }
+
+    fn fingerprint_for_table(&self, table: &TableDef) -> String {
+        format!(
+            "using:{}|check:{}",
+            self.using
+                .as_ref()
+                .map(|policy| policy.fingerprint_for_table(table))
+                .unwrap_or_else(|| "none".to_owned()),
+            self.with_check
+                .as_ref()
+                .map(|policy| policy.fingerprint_for_table(table))
+                .unwrap_or_else(|| "none".to_owned())
+        )
+    }
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -506,8 +563,9 @@ impl TableBuilder {
                 fields: Vec::new(),
                 indexes: Vec::new(),
                 read_policy: PolicyDef::True,
-                write_policy: PolicyDef::True,
-                delete_policy: None,
+                insert_policy: OperationPolicy::with_check(PolicyDef::True),
+                update_policy: OperationPolicy::using_and_check(PolicyDef::True, PolicyDef::True),
+                delete_policy: OperationPolicy::default(),
             },
         }
     }
@@ -651,15 +709,59 @@ impl TableBuilder {
     }
 
     pub fn write_if_created_by_user(&mut self) {
-        self.table.write_policy = created_by_user_policy();
+        self.insert_if_created_by_user();
+        self.update_if_created_by_user();
     }
 
     pub fn write_if_ref_readable(&mut self, field: &str) {
-        self.table.write_policy = inherits_policy(field);
+        self.insert_if_ref_readable(field);
+        self.update_if_ref_readable(field);
+    }
+
+    pub fn insert_if_created_by_user(&mut self) {
+        self.table.insert_policy = OperationPolicy::with_check(created_by_user_policy());
+    }
+
+    pub fn insert_if_ref_readable(&mut self, field: &str) {
+        self.table.insert_policy = OperationPolicy::with_check(inherits_policy(field));
+    }
+
+    pub fn update_if_created_by_user(&mut self) {
+        self.table.update_policy =
+            OperationPolicy::using_and_check(created_by_user_policy(), created_by_user_policy());
+    }
+
+    pub fn update_using_created_by_user(&mut self) {
+        self.table.update_policy.using = Some(created_by_user_policy());
+    }
+
+    pub fn update_check_created_by_user(&mut self) {
+        self.table.update_policy.with_check = Some(created_by_user_policy());
+    }
+
+    pub fn update_if_ref_readable(&mut self, field: &str) {
+        self.table.update_policy =
+            OperationPolicy::using_and_check(inherits_policy(field), inherits_policy(field));
+    }
+
+    pub fn update_using_ref_readable(&mut self, field: &str) {
+        self.table.update_policy.using = Some(inherits_policy(field));
+    }
+
+    pub fn update_check_ref_readable(&mut self, field: &str) {
+        self.table.update_policy.with_check = Some(inherits_policy(field));
+    }
+
+    pub fn update_protected_fields_if_created_by_user<const N: usize>(
+        &mut self,
+        fields: [&str; N],
+    ) {
+        let guard = protected_fields_unchanged_or_created_by_user_policy(&self.table.name, fields);
+        self.and_update_check(guard);
     }
 
     pub fn delete_if_created_by_user(&mut self) {
-        self.table.delete_policy = Some(created_by_user_policy());
+        self.table.delete_policy = OperationPolicy::using(created_by_user_policy());
     }
 
     pub fn read_if_ref_readable(&mut self, field: &str) {
@@ -668,6 +770,14 @@ impl TableBuilder {
 
     fn finish(self) -> TableDef {
         self.table
+    }
+
+    fn and_update_check(&mut self, guard: PolicyDef) {
+        self.table.update_policy.with_check =
+            Some(match self.table.update_policy.with_check.take() {
+                None | Some(PolicyDef::True) => guard,
+                Some(existing) => PolicyDef::And(vec![existing, guard]),
+            });
     }
 }
 
@@ -710,6 +820,33 @@ fn inherits_referencing_policy(source_table: &str, field: &str) -> PolicyDef {
         via_column: field.to_owned(),
         max_depth: None,
     }
+}
+
+fn protected_fields_unchanged_or_created_by_user_policy<const N: usize>(
+    table_name: &str,
+    fields: [&str; N],
+) -> PolicyDef {
+    let mut unchanged = vec![PolicyDef::Cmp {
+        column: "$id".to_owned(),
+        op: CmpOp::Eq,
+        value: outer_row_value("$id"),
+    }];
+    unchanged.extend(fields.into_iter().map(|field| PolicyDef::Cmp {
+        column: field.to_owned(),
+        op: CmpOp::Eq,
+        value: outer_row_value(field),
+    }));
+    PolicyDef::Or(vec![
+        created_by_user_policy(),
+        PolicyDef::Exists {
+            table: table_name.to_owned(),
+            condition: Box::new(PolicyDef::And(unchanged)),
+        },
+    ])
+}
+
+fn outer_row_value(column: &str) -> PolicyValue {
+    PolicyValue::SessionRef(vec![OUTER_ROW_SESSION_PREFIX.to_owned(), column.to_owned()])
 }
 
 pub(crate) fn install(conn: &Connection, schema: &SchemaDef) -> Result<()> {
@@ -882,8 +1019,16 @@ fn validate_schema_shape(schema: &SchemaDef) -> Result<()> {
 fn validate_policy_cycles(schema: &SchemaDef) -> Result<()> {
     for table in schema.tables() {
         validate_policy_cycle(schema, table, &table.read_policy, &mut BTreeSet::new())?;
-        validate_policy_cycle(schema, table, &table.write_policy, &mut BTreeSet::new())?;
-        if let Some(delete_policy) = &table.delete_policy {
+        if let Some(policy) = &table.insert_policy.with_check {
+            validate_policy_cycle(schema, table, policy, &mut BTreeSet::new())?;
+        }
+        if let Some(policy) = &table.update_policy.using {
+            validate_policy_cycle(schema, table, policy, &mut BTreeSet::new())?;
+        }
+        if let Some(policy) = &table.update_policy.with_check {
+            validate_policy_cycle(schema, table, policy, &mut BTreeSet::new())?;
+        }
+        if let Some(delete_policy) = &table.delete_policy.using {
             validate_policy_cycle(schema, table, delete_policy, &mut BTreeSet::new())?;
         }
     }

--- a/crates/mini-jazz-sqlite/src/schema.rs
+++ b/crates/mini-jazz-sqlite/src/schema.rs
@@ -18,8 +18,24 @@ impl SchemaDef {
 
     pub fn attempt3_fixture() -> Self {
         Self::new()
+            .table("users", |table| {
+                table.text("name");
+            })
+            .table("groups", |table| {
+                table.text("name");
+            })
+            .table("group_members", |table| {
+                table.ref_("user", "users");
+                table.ref_("group", "groups");
+                table.index("by_user", ["user", "group"]);
+            })
             .table("projects", |table| {
                 table.text("title");
+            })
+            .table("project_members", |table| {
+                table.ref_("project", "projects");
+                table.text("member");
+                table.index("by_member", ["member", "project"]);
             })
             .table("todos", |table| {
                 table.text("title");
@@ -28,6 +44,7 @@ impl SchemaDef {
                 table.index("open_created", ["done", "$createdAt"]);
                 table.index("created", ["$createdAt"]);
                 table.index("by_title", ["title"]);
+                table.index("open_visible", ["done", "project", "$createdAt"]);
             })
             .table("labels", |table| {
                 table.text("name");
@@ -38,6 +55,55 @@ impl SchemaDef {
                 table.ref_("label", "labels");
                 table.index("by_todo", ["todo"]);
                 table.index("by_label", ["label"]);
+            })
+    }
+
+    pub fn mini_sqlite_todo_fixture() -> Self {
+        Self::new()
+            .table("users", |table| {
+                table.text("name");
+                table.read_if_row_id_equals_user();
+            })
+            .table("groups", |table| {
+                table.text("name");
+                table.read_if_group_member();
+            })
+            .table("group_members", |table| {
+                table.ref_("user", "users");
+                table.ref_("group", "groups");
+                table.index("by_user", ["user", "group"]);
+                table.read_if_user_ref_equals_session("user");
+            })
+            .table("projects", |table| {
+                table.text("title");
+                table.read_if_project_member();
+            })
+            .table("project_members", |table| {
+                table.ref_("project", "projects");
+                table.text("member");
+                table.index("by_member", ["member", "project"]);
+                table.read_if_project_ref_member("project");
+            })
+            .table("todos", |table| {
+                table.text("title");
+                table.bool("done");
+                table.ref_("project", "projects");
+                table.index("open_created", ["done", "$createdAt"]);
+                table.index("created", ["$createdAt"]);
+                table.index("by_title", ["title"]);
+                table.index("open_visible", ["done", "project", "$createdAt"]);
+                table.read_if_ref_readable("project");
+            })
+            .table("labels", |table| {
+                table.text("name");
+                table.index("by_name", ["name"]);
+            })
+            .table("todo_labels", |table| {
+                table.ref_("todo", "todos");
+                table.ref_("label", "labels");
+                table.index("by_todo", ["todo"]);
+                table.index("by_label", ["label"]);
+                table.read_if_ref_readable("todo");
             })
     }
 
@@ -149,6 +215,15 @@ pub(crate) enum PolicyDef {
     #[default]
     AllowAll,
     CreatedByUser,
+    RowIdEqualsUser,
+    UserRefEqualsSession {
+        field: String,
+    },
+    GroupMember,
+    ProjectMember,
+    ProjectRefMember {
+        field: String,
+    },
     RefReadable {
         field: String,
     },
@@ -159,17 +234,32 @@ impl PolicyDef {
         match self {
             PolicyDef::AllowAll => "allow_all".to_owned(),
             PolicyDef::CreatedByUser => "created_by_user".to_owned(),
+            PolicyDef::RowIdEqualsUser => "row_id_equals_user".to_owned(),
+            PolicyDef::UserRefEqualsSession { field } => {
+                format!(
+                    "user_ref_equals_session:{}",
+                    storage_field_name(table, field)
+                )
+            }
+            PolicyDef::GroupMember => "group_member".to_owned(),
+            PolicyDef::ProjectMember => "project_member".to_owned(),
+            PolicyDef::ProjectRefMember { field } => {
+                format!("project_ref_member:{}", storage_field_name(table, field))
+            }
             PolicyDef::RefReadable { field } => {
-                let storage_field = table
-                    .fields
-                    .iter()
-                    .find(|candidate| candidate.name == *field)
-                    .map(|field| field.storage_name.as_str())
-                    .unwrap_or(field);
-                format!("ref_readable:{storage_field}")
+                format!("ref_readable:{}", storage_field_name(table, field))
             }
         }
     }
+}
+
+fn storage_field_name<'a>(table: &'a TableDef, field: &'a str) -> &'a str {
+    table
+        .fields
+        .iter()
+        .find(|candidate| candidate.name == field)
+        .map(|field| field.storage_name.as_str())
+        .unwrap_or(field)
 }
 
 pub struct TableBuilder {
@@ -294,6 +384,30 @@ impl TableBuilder {
 
     pub fn read_if_created_by_user(&mut self) {
         self.table.read_policy = PolicyDef::CreatedByUser;
+    }
+
+    pub fn read_if_row_id_equals_user(&mut self) {
+        self.table.read_policy = PolicyDef::RowIdEqualsUser;
+    }
+
+    pub fn read_if_user_ref_equals_session(&mut self, field: &str) {
+        self.table.read_policy = PolicyDef::UserRefEqualsSession {
+            field: field.to_owned(),
+        };
+    }
+
+    pub fn read_if_group_member(&mut self) {
+        self.table.read_policy = PolicyDef::GroupMember;
+    }
+
+    pub fn read_if_project_member(&mut self) {
+        self.table.read_policy = PolicyDef::ProjectMember;
+    }
+
+    pub fn read_if_project_ref_member(&mut self, field: &str) {
+        self.table.read_policy = PolicyDef::ProjectRefMember {
+            field: field.to_owned(),
+        };
     }
 
     pub fn write_if_created_by_user(&mut self) {
@@ -498,8 +612,21 @@ fn validate_policy_cycle(
     policy: &PolicyDef,
     seen: &mut BTreeSet<String>,
 ) -> Result<()> {
-    let PolicyDef::RefReadable { field } = policy else {
-        return Ok(());
+    let field = match policy {
+        PolicyDef::RefReadable { field } => field,
+        PolicyDef::UserRefEqualsSession { field } => {
+            validate_policy_ref_field(schema, table, field, Some("users"))?;
+            return Ok(());
+        }
+        PolicyDef::ProjectRefMember { field } => {
+            validate_policy_ref_field(schema, table, field, Some("projects"))?;
+            return Ok(());
+        }
+        PolicyDef::AllowAll
+        | PolicyDef::CreatedByUser
+        | PolicyDef::RowIdEqualsUser
+        | PolicyDef::GroupMember
+        | PolicyDef::ProjectMember => return Ok(()),
     };
     if !seen.insert(table.name.clone()) {
         return Err(crate::Error::new(format!(
@@ -529,6 +656,40 @@ fn validate_policy_cycle(
     let result = validate_policy_cycle(schema, parent_table, &parent_table.read_policy, seen);
     seen.remove(&table.name);
     result
+}
+
+fn validate_policy_ref_field(
+    schema: &SchemaDef,
+    table: &TableDef,
+    field_name: &str,
+    expected_table: Option<&str>,
+) -> Result<()> {
+    let Some(field) = table
+        .fields
+        .iter()
+        .find(|candidate| candidate.name == field_name)
+    else {
+        return Err(crate::Error::new(format!(
+            "policy on {} references unknown field {}",
+            table.name, field_name
+        )));
+    };
+    let FieldKind::Ref { table: parent } = &field.kind else {
+        return Err(crate::Error::new(format!(
+            "policy on {} references non-ref field {}",
+            table.name, field.name
+        )));
+    };
+    schema.table_def(parent)?;
+    if let Some(expected_table) = expected_table {
+        if parent != expected_table {
+            return Err(crate::Error::new(format!(
+                "policy on {} expected {} to reference {}",
+                table.name, field.name, expected_table
+            )));
+        }
+    }
+    Ok(())
 }
 
 fn install_table(conn: &Connection, table: &TableDef) -> Result<()> {

--- a/crates/mini-jazz-sqlite/src/schema.rs
+++ b/crates/mini-jazz-sqlite/src/schema.rs
@@ -82,6 +82,7 @@ impl SchemaDef {
                 table.ref_("project", "projects");
                 table.text("member");
                 table.index("by_member", ["member", "project"]);
+                table.index("by_project_member", ["project", "member"]);
                 table.read_if_project_ref_member("project");
             })
             .table("todos", |table| {
@@ -103,6 +104,7 @@ impl SchemaDef {
                 table.ref_("todo", "todos");
                 table.ref_("label", "labels");
                 table.index("by_todo", ["todo"]);
+                table.index("by_todo_created", ["todo", "$createdAt"]);
                 table.index("by_label", ["label"]);
                 table.read_if_ref_readable("todo");
             })
@@ -780,7 +782,7 @@ fn install_table(conn: &Connection, table: &TableDef) -> Result<()> {
             index
                 .columns
                 .iter()
-                .map(|column| index_storage_column_name(column)),
+                .map(|column| index_storage_column_name(table, column)),
         );
         columns.push("row_num".to_owned());
         conn.execute_batch(&format!(
@@ -869,10 +871,16 @@ pub(crate) fn storage_column_name(column: &str) -> String {
     quote_ident(&storage)
 }
 
-fn index_storage_column_name(column: &str) -> String {
+fn index_storage_column_name(table: &TableDef, column: &str) -> String {
     match column {
         "$createdAt" => format!("{} DESC", quote_ident("j_created_at")),
-        other => storage_column_name(other),
+        "$updatedAt" => quote_ident("j_updated_at"),
+        other => table
+            .fields
+            .iter()
+            .find(|field| field.name == other)
+            .map(|field| quote_ident(&storage_column(field)))
+            .unwrap_or_else(|| storage_column_name(other)),
     }
 }
 

--- a/crates/mini-jazz-sqlite/src/sync.rs
+++ b/crates/mini-jazz-sqlite/src/sync.rs
@@ -6,6 +6,16 @@ use std::collections::BTreeMap;
 
 pub const BUNDLE_PROTOCOL_VERSION: i64 = 1;
 
+/// Persisted integer codes used by `HistoryRecord::op` in bundles and history tables.
+pub mod history_op {
+    /// A row creation.
+    pub const INSERT: i64 = 1;
+    /// A row update.
+    pub const UPDATE: i64 = 2;
+    /// A row deletion tombstone.
+    pub const DELETE: i64 = 3;
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Bundle {
     #[serde(default = "default_bundle_protocol_version")]

--- a/crates/mini-jazz-sqlite/tests/whole_system.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system.rs
@@ -1,5 +1,6 @@
 use mini_jazz_sqlite::{
-    BuiltQuery, RejectionInfo, RowDiff, Runtime, SchemaDef, Storage, SubscriptionRowDelta,
+    sync::history_op, BuiltQuery, RejectionInfo, RowDiff, Runtime, SchemaDef, Storage,
+    SubscriptionRowDelta,
 };
 use serde_json::json;
 use std::collections::BTreeMap;

--- a/crates/mini-jazz-sqlite/tests/whole_system.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system.rs
@@ -14,6 +14,8 @@ mod branches;
 mod connection;
 #[path = "whole_system/generic_schema.rs"]
 mod generic_schema;
+#[path = "whole_system/group_visibility.rs"]
+mod group_visibility;
 #[path = "whole_system/invariant_coverage.rs"]
 mod invariant_coverage;
 #[path = "whole_system/policies.rs"]

--- a/crates/mini-jazz-sqlite/tests/whole_system/group_visibility.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/group_visibility.rs
@@ -15,23 +15,31 @@ fn mini_sqlite_todo_fixture_db_enforces_project_and_todo_visibility_by_user_or_g
     db.run_as_user("user-alice", |alice| {
         assert_eq!(
             visible_ids(alice.read_rows("projects").unwrap()),
-            vec!["project-alice", "project-engineering"]
+            vec!["project-alice", "project-company", "project-engineering"]
         );
         assert_eq!(
             visible_ids(open_todos_query(alice)),
-            vec!["todo-alice", "todo-engineering"]
+            vec!["todo-alice", "todo-company", "todo-engineering"]
         );
     });
 
     db.run_as_user("user-bob", |bob| {
         assert_eq!(
             visible_ids(bob.read_rows("projects").unwrap()),
-            vec!["project-bob", "project-engineering"]
+            vec!["project-bob", "project-company", "project-engineering"]
         );
         assert_eq!(
             visible_ids(open_todos_query(bob)),
-            vec!["todo-bob", "todo-engineering"]
+            vec!["todo-bob", "todo-company", "todo-engineering"]
         );
+    });
+
+    db.run_as_user("user-cara", |cara| {
+        assert_eq!(
+            visible_ids(cara.read_rows("projects").unwrap()),
+            vec!["project-company"]
+        );
+        assert_eq!(visible_ids(open_todos_query(cara)), vec!["todo-company"]);
     });
 }
 
@@ -49,7 +57,7 @@ fn mini_sqlite_todo_fixture_allows_group_reads_but_only_authors_can_delete_todos
     db.run_as_user("user-bob", |bob| {
         assert_eq!(
             visible_ids(open_todos_query(bob)),
-            vec!["todo-bob", "todo-engineering"]
+            vec!["todo-bob", "todo-company", "todo-engineering"]
         );
 
         let tx = bob.delete_row("todos", "todo-engineering").unwrap();
@@ -59,14 +67,17 @@ fn mini_sqlite_todo_fixture_allows_group_reads_but_only_authors_can_delete_todos
         );
         assert_eq!(
             visible_ids(open_todos_query(bob)),
-            vec!["todo-bob", "todo-engineering"]
+            vec!["todo-bob", "todo-company", "todo-engineering"]
         );
     });
 
     db.run_as_user("user-alice", |alice| {
         let tx = alice.delete_row("todos", "todo-engineering").unwrap();
         assert_eq!(alice.transaction_info(&tx).unwrap().rejection_code, None);
-        assert_eq!(visible_ids(open_todos_query(alice)), vec!["todo-alice"]);
+        assert_eq!(
+            visible_ids(open_todos_query(alice)),
+            vec!["todo-alice", "todo-company"]
+        );
     });
 }
 
@@ -86,7 +97,9 @@ fn seed_group_visibility_fixture(db: &mut Runtime) {
 
     for (id, name) in [
         ("group-engineering", "Engineering"),
+        ("group-company", "Company"),
         ("group-design", "Design"),
+        ("group-support", "Support"),
     ] {
         db.insert_row(
             "groups",
@@ -96,24 +109,44 @@ fn seed_group_visibility_fixture(db: &mut Runtime) {
         .unwrap();
     }
 
-    for (id, user, group) in [
+    for (id, member, group) in [
         (
             "group-member-alice-engineering",
-            "user-alice",
+            "user:user-alice",
             "group-engineering",
         ),
         (
             "group-member-bob-engineering",
-            "user-bob",
+            "user:user-bob",
             "group-engineering",
         ),
-        ("group-member-bob-design", "user-bob", "group-design"),
+        (
+            "group-member-engineering-company",
+            "group:group-engineering",
+            "group-company",
+        ),
+        (
+            "group-member-design-company",
+            "group:group-design",
+            "group-company",
+        ),
+        (
+            "group-member-support-company",
+            "group:group-support",
+            "group-company",
+        ),
+        ("group-member-bob-design", "user:user-bob", "group-design"),
+        (
+            "group-member-cara-support",
+            "user:user-cara",
+            "group-support",
+        ),
     ] {
         db.insert_row(
             "group_members",
             id,
             BTreeMap::from([
-                ("user".to_owned(), json!(user)),
+                ("member".to_owned(), json!(member)),
                 ("group".to_owned(), json!(group)),
             ]),
         )
@@ -122,6 +155,7 @@ fn seed_group_visibility_fixture(db: &mut Runtime) {
 
     for (id, title) in [
         ("project-engineering", "Engineering roadmap"),
+        ("project-company", "Company strategy"),
         ("project-alice", "Alice private"),
         ("project-bob", "Bob private"),
     ] {
@@ -148,6 +182,11 @@ fn seed_group_visibility_fixture(db: &mut Runtime) {
             "project-engineering",
             "group:group-engineering",
         ),
+        (
+            "project-member-company",
+            "project-company",
+            "group:group-company",
+        ),
         ("project-member-alice", "project-alice", "user:user-alice"),
         ("project-member-bob", "project-bob", "user:user-bob"),
     ] {
@@ -167,6 +206,12 @@ fn seed_group_visibility_fixture(db: &mut Runtime) {
             "todo-engineering",
             "Plan sync protocol",
             "project-engineering",
+            "user-alice",
+        ),
+        (
+            "todo-company",
+            "Review company plan",
+            "project-company",
             "user-alice",
         ),
         (

--- a/crates/mini-jazz-sqlite/tests/whole_system/group_visibility.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/group_visibility.rs
@@ -1,0 +1,166 @@
+use super::*;
+use mini_jazz_sqlite::RowView;
+
+#[test]
+fn mini_sqlite_todo_fixture_db_enforces_project_and_todo_visibility_by_user_or_group() {
+    let mut db = Runtime::open_trusted_with_schema(
+        Storage::Memory,
+        "seed-node",
+        SchemaDef::mini_sqlite_todo_fixture(),
+    )
+    .unwrap();
+
+    seed_group_visibility_fixture(&mut db);
+
+    db.run_as_user("user-alice", |alice| {
+        assert_eq!(
+            visible_ids(alice.read_rows("projects").unwrap()),
+            vec!["project-alice", "project-engineering"]
+        );
+        assert_eq!(
+            visible_ids(open_todos_query(alice)),
+            vec!["todo-alice", "todo-engineering"]
+        );
+    });
+
+    db.run_as_user("user-bob", |bob| {
+        assert_eq!(
+            visible_ids(bob.read_rows("projects").unwrap()),
+            vec!["project-bob"]
+        );
+        assert_eq!(visible_ids(open_todos_query(bob)), vec!["todo-bob"]);
+    });
+}
+
+fn seed_group_visibility_fixture(db: &mut Runtime) {
+    for (id, name) in [
+        ("user-alice", "Alice"),
+        ("user-bob", "Bob"),
+        ("user-cara", "Cara"),
+    ] {
+        db.insert_row(
+            "users",
+            id,
+            BTreeMap::from([("name".to_owned(), json!(name))]),
+        )
+        .unwrap();
+    }
+
+    for (id, name) in [
+        ("group-engineering", "Engineering"),
+        ("group-design", "Design"),
+    ] {
+        db.insert_row(
+            "groups",
+            id,
+            BTreeMap::from([("name".to_owned(), json!(name))]),
+        )
+        .unwrap();
+    }
+
+    for (id, user, group) in [
+        (
+            "group-member-alice-engineering",
+            "user-alice",
+            "group-engineering",
+        ),
+        ("group-member-bob-design", "user-bob", "group-design"),
+    ] {
+        db.insert_row(
+            "group_members",
+            id,
+            BTreeMap::from([
+                ("user".to_owned(), json!(user)),
+                ("group".to_owned(), json!(group)),
+            ]),
+        )
+        .unwrap();
+    }
+
+    for (id, title) in [
+        ("project-engineering", "Engineering roadmap"),
+        ("project-alice", "Alice private"),
+        ("project-bob", "Bob private"),
+    ] {
+        db.insert_row(
+            "projects",
+            id,
+            BTreeMap::from([("title".to_owned(), json!(title))]),
+        )
+        .unwrap();
+    }
+    db.run_attributing_to_user("user-alice", |alice| {
+        alice
+            .insert_row(
+                "projects",
+                "project-created-without-membership",
+                BTreeMap::from([("title".to_owned(), json!("Created without membership"))]),
+            )
+            .unwrap();
+    });
+
+    for (id, project, member) in [
+        (
+            "project-member-engineering",
+            "project-engineering",
+            "group:group-engineering",
+        ),
+        ("project-member-alice", "project-alice", "user:user-alice"),
+        ("project-member-bob", "project-bob", "user:user-bob"),
+    ] {
+        db.insert_row(
+            "project_members",
+            id,
+            BTreeMap::from([
+                ("project".to_owned(), json!(project)),
+                ("member".to_owned(), json!(member)),
+            ]),
+        )
+        .unwrap();
+    }
+
+    for (id, title, project) in [
+        (
+            "todo-engineering",
+            "Plan sync protocol",
+            "project-engineering",
+        ),
+        ("todo-alice", "Review launch notes", "project-alice"),
+        ("todo-bob", "Bob-only task", "project-bob"),
+        (
+            "todo-created-without-membership",
+            "Created by Alice without membership",
+            "project-created-without-membership",
+        ),
+    ] {
+        db.insert_row(
+            "todos",
+            id,
+            BTreeMap::from([
+                ("title".to_owned(), json!(title)),
+                ("done".to_owned(), json!(false)),
+                ("project".to_owned(), json!(project)),
+            ]),
+        )
+        .unwrap();
+    }
+}
+
+fn open_todos_query(db: &Runtime) -> Vec<RowView> {
+    db.query(
+        BuiltQuery::from_json_value(json!({
+            "table": "todos",
+            "conditions": [{"column": "done", "op": "eq", "value": false}],
+            "orderBy": [["$createdAt", "desc"]],
+            "limit": 10
+        }))
+        .unwrap(),
+    )
+    .unwrap()
+}
+
+fn visible_ids(rows: Vec<RowView>) -> Vec<String> {
+    let mut ids = rows.into_iter().map(|row| row.id).collect::<Vec<_>>();
+    ids.sort();
+    ids
+}

--- a/crates/mini-jazz-sqlite/tests/whole_system/group_visibility.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/group_visibility.rs
@@ -82,6 +82,73 @@ fn mini_sqlite_todo_fixture_allows_group_reads_but_only_authors_can_delete_todos
 }
 
 #[test]
+fn mini_sqlite_todo_fixture_allows_visible_done_updates_but_only_authors_can_rename_todos() {
+    let mut db = Runtime::open_trusted_with_schema(
+        Storage::Memory,
+        "seed-node",
+        SchemaDef::mini_sqlite_todo_fixture(),
+    )
+    .unwrap();
+
+    seed_group_visibility_fixture(&mut db);
+
+    db.run_as_user("user-bob", |bob| {
+        let tx = bob
+            .update_row(
+                "todos",
+                "todo-engineering",
+                BTreeMap::from([("done".to_owned(), json!(true))]),
+            )
+            .unwrap();
+        assert_eq!(bob.transaction_info(&tx).unwrap().rejection_code, None);
+        let todo = bob
+            .read_rows("todos")
+            .unwrap()
+            .into_iter()
+            .find(|row| row.id == "todo-engineering")
+            .unwrap();
+        assert_eq!(todo.values["done"], json!(true));
+
+        let tx = bob
+            .update_row(
+                "todos",
+                "todo-engineering",
+                BTreeMap::from([("title".to_owned(), json!("Bob renames Alice's task"))]),
+            )
+            .unwrap();
+        assert_eq!(
+            bob.transaction_info(&tx).unwrap().rejection_code,
+            Some("policy_denied".to_owned())
+        );
+        let todo = bob
+            .read_rows("todos")
+            .unwrap()
+            .into_iter()
+            .find(|row| row.id == "todo-engineering")
+            .unwrap();
+        assert_eq!(todo.values["title"], json!("Plan sync protocol"));
+    });
+
+    db.run_as_user("user-alice", |alice| {
+        let tx = alice
+            .update_row(
+                "todos",
+                "todo-engineering",
+                BTreeMap::from([("title".to_owned(), json!("Alice renames her task"))]),
+            )
+            .unwrap();
+        assert_eq!(alice.transaction_info(&tx).unwrap().rejection_code, None);
+        let todo = alice
+            .read_rows("todos")
+            .unwrap()
+            .into_iter()
+            .find(|row| row.id == "todo-engineering")
+            .unwrap();
+        assert_eq!(todo.values["title"], json!("Alice renames her task"));
+    });
+}
+
+#[test]
 fn mini_sqlite_todo_fixture_explains_project_visibility_query() {
     let mut db = Runtime::open_trusted_with_schema(
         Storage::Memory,
@@ -200,6 +267,8 @@ fn nested_group_policy_schema() -> SchemaDef {
             table.index("by_title", ["title"]);
             table.index("open_visible", ["done", "project", "$createdAt"]);
             table.read_if_inherits("project");
+            table.write_if_ref_readable("project");
+            table.update_protected_fields_if_created_by_user(["title", "project"]);
             table.delete_if_created_by_user();
         })
         .table("labels", |table| {

--- a/crates/mini-jazz-sqlite/tests/whole_system/group_visibility.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/group_visibility.rs
@@ -101,6 +101,121 @@ fn mini_sqlite_todo_fixture_explains_project_visibility_query() {
     });
 }
 
+#[test]
+fn generic_policy_expressions_model_nested_group_project_visibility() {
+    let mut db = Runtime::open_trusted_with_schema(
+        Storage::Memory,
+        "seed-node",
+        nested_group_policy_schema(),
+    )
+    .unwrap();
+
+    seed_group_visibility_fixture(&mut db);
+
+    db.run_as_user("user-alice", |alice| {
+        assert_eq!(
+            visible_ids(alice.read_rows("projects").unwrap()),
+            vec!["project-alice", "project-company", "project-engineering"]
+        );
+        assert_eq!(
+            visible_ids(open_todos_query(alice)),
+            vec!["todo-alice", "todo-company", "todo-engineering"]
+        );
+    });
+
+    db.run_as_user("user-cara", |cara| {
+        assert_eq!(
+            visible_ids(cara.read_rows("projects").unwrap()),
+            vec!["project-company"]
+        );
+        assert_eq!(visible_ids(open_todos_query(cara)), vec!["todo-company"]);
+    });
+}
+
+#[test]
+fn generic_policy_export_includes_group_dependencies() {
+    let schema = nested_group_policy_schema();
+    let mut source =
+        Runtime::open_trusted_with_schema(Storage::Memory, "source-node", schema.clone()).unwrap();
+    seed_group_visibility_fixture(&mut source);
+
+    let bundle = source
+        .run_as_user("user-alice", |alice| {
+            alice.export_table_history("project_members")
+        })
+        .unwrap();
+
+    let mut peer =
+        Runtime::open_with_schema(Storage::Memory, "peer-node", "user-alice", schema).unwrap();
+    peer.apply_bundle(&bundle).unwrap();
+
+    assert_eq!(
+        visible_ids(peer.read_rows("project_members").unwrap()),
+        vec![
+            "project-member-alice",
+            "project-member-company",
+            "project-member-engineering"
+        ]
+    );
+}
+
+fn nested_group_policy_schema() -> SchemaDef {
+    SchemaDef::new()
+        .table("users", |table| {
+            table.text("name");
+            table.read_if_row_id_equals_user();
+        })
+        .table("groups", |table| {
+            table.text("name");
+            table.read_if_inherits_referencing("group_members", "group");
+        })
+        .table("group_members", |table| {
+            table.optional_ref("user", "users");
+            table.optional_ref("member_group", "groups");
+            table.ref_("group", "groups");
+            table.index("by_user", ["user", "group"]);
+            table.index("by_member_group", ["member_group", "group"]);
+            table.read_if_user_or_ref_readable("user", "member_group");
+        })
+        .table("projects", |table| {
+            table.text("title");
+            table.read_if_inherits_referencing("project_members", "project");
+        })
+        .table("project_members", |table| {
+            table.ref_("project", "projects");
+            table.optional_ref("user", "users");
+            table.optional_ref("group", "groups");
+            table.index("by_user", ["user", "project"]);
+            table.index("by_group", ["group", "project"]);
+            table.index("by_project_user", ["project", "user"]);
+            table.index("by_project_group", ["project", "group"]);
+            table.read_if_user_or_ref_readable("user", "group");
+        })
+        .table("todos", |table| {
+            table.text("title");
+            table.bool("done");
+            table.ref_("project", "projects");
+            table.index("open_created", ["done", "$createdAt"]);
+            table.index("created", ["$createdAt"]);
+            table.index("by_title", ["title"]);
+            table.index("open_visible", ["done", "project", "$createdAt"]);
+            table.read_if_inherits("project");
+            table.delete_if_created_by_user();
+        })
+        .table("labels", |table| {
+            table.text("name");
+            table.index("by_name", ["name"]);
+        })
+        .table("todo_labels", |table| {
+            table.ref_("todo", "todos");
+            table.ref_("label", "labels");
+            table.index("by_todo", ["todo"]);
+            table.index("by_todo_created", ["todo", "$createdAt"]);
+            table.index("by_label", ["label"]);
+            table.read_if_inherits("todo");
+        })
+}
+
 fn seed_group_visibility_fixture(db: &mut Runtime) {
     for (id, name) in [
         ("user-alice", "Alice"),
@@ -162,15 +277,8 @@ fn seed_group_visibility_fixture(db: &mut Runtime) {
             "group-support",
         ),
     ] {
-        db.insert_row(
-            "group_members",
-            id,
-            BTreeMap::from([
-                ("member".to_owned(), json!(member)),
-                ("group".to_owned(), json!(group)),
-            ]),
-        )
-        .unwrap();
+        db.insert_row("group_members", id, group_member_values(member, group))
+            .unwrap();
     }
 
     for (id, title) in [
@@ -213,10 +321,7 @@ fn seed_group_visibility_fixture(db: &mut Runtime) {
         db.insert_row(
             "project_members",
             id,
-            BTreeMap::from([
-                ("project".to_owned(), json!(project)),
-                ("member".to_owned(), json!(member)),
-            ]),
+            project_member_values(project, member),
         )
         .unwrap();
     }
@@ -261,6 +366,34 @@ fn seed_group_visibility_fixture(db: &mut Runtime) {
                 )
                 .unwrap();
         });
+    }
+}
+
+fn group_member_values(member: &str, group: &str) -> BTreeMap<String, serde_json::Value> {
+    let (user, member_group) = split_member_ref(member);
+    BTreeMap::from([
+        ("user".to_owned(), user),
+        ("member_group".to_owned(), member_group),
+        ("group".to_owned(), json!(group)),
+    ])
+}
+
+fn project_member_values(project: &str, member: &str) -> BTreeMap<String, serde_json::Value> {
+    let (user, group) = split_member_ref(member);
+    BTreeMap::from([
+        ("project".to_owned(), json!(project)),
+        ("user".to_owned(), user),
+        ("group".to_owned(), group),
+    ])
+}
+
+fn split_member_ref(member: &str) -> (serde_json::Value, serde_json::Value) {
+    if let Some(user) = member.strip_prefix("user:") {
+        (json!(user), serde_json::Value::Null)
+    } else if let Some(group) = member.strip_prefix("group:") {
+        (serde_json::Value::Null, json!(group))
+    } else {
+        (serde_json::Value::Null, serde_json::Value::Null)
     }
 }
 

--- a/crates/mini-jazz-sqlite/tests/whole_system/group_visibility.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/group_visibility.rs
@@ -26,9 +26,47 @@ fn mini_sqlite_todo_fixture_db_enforces_project_and_todo_visibility_by_user_or_g
     db.run_as_user("user-bob", |bob| {
         assert_eq!(
             visible_ids(bob.read_rows("projects").unwrap()),
-            vec!["project-bob"]
+            vec!["project-bob", "project-engineering"]
         );
-        assert_eq!(visible_ids(open_todos_query(bob)), vec!["todo-bob"]);
+        assert_eq!(
+            visible_ids(open_todos_query(bob)),
+            vec!["todo-bob", "todo-engineering"]
+        );
+    });
+}
+
+#[test]
+fn mini_sqlite_todo_fixture_allows_group_reads_but_only_authors_can_delete_todos() {
+    let mut db = Runtime::open_trusted_with_schema(
+        Storage::Memory,
+        "seed-node",
+        SchemaDef::mini_sqlite_todo_fixture(),
+    )
+    .unwrap();
+
+    seed_group_visibility_fixture(&mut db);
+
+    db.run_as_user("user-bob", |bob| {
+        assert_eq!(
+            visible_ids(open_todos_query(bob)),
+            vec!["todo-bob", "todo-engineering"]
+        );
+
+        let tx = bob.delete_row("todos", "todo-engineering").unwrap();
+        assert_eq!(
+            bob.transaction_info(&tx).unwrap().rejection_code,
+            Some("policy_denied".to_owned())
+        );
+        assert_eq!(
+            visible_ids(open_todos_query(bob)),
+            vec!["todo-bob", "todo-engineering"]
+        );
+    });
+
+    db.run_as_user("user-alice", |alice| {
+        let tx = alice.delete_row("todos", "todo-engineering").unwrap();
+        assert_eq!(alice.transaction_info(&tx).unwrap().rejection_code, None);
+        assert_eq!(visible_ids(open_todos_query(alice)), vec!["todo-alice"]);
     });
 }
 
@@ -62,6 +100,11 @@ fn seed_group_visibility_fixture(db: &mut Runtime) {
         (
             "group-member-alice-engineering",
             "user-alice",
+            "group-engineering",
+        ),
+        (
+            "group-member-bob-engineering",
+            "user-bob",
             "group-engineering",
         ),
         ("group-member-bob-design", "user-bob", "group-design"),
@@ -119,30 +162,40 @@ fn seed_group_visibility_fixture(db: &mut Runtime) {
         .unwrap();
     }
 
-    for (id, title, project) in [
+    for (id, title, project, author) in [
         (
             "todo-engineering",
             "Plan sync protocol",
             "project-engineering",
+            "user-alice",
         ),
-        ("todo-alice", "Review launch notes", "project-alice"),
-        ("todo-bob", "Bob-only task", "project-bob"),
+        (
+            "todo-alice",
+            "Review launch notes",
+            "project-alice",
+            "user-alice",
+        ),
+        ("todo-bob", "Bob-only task", "project-bob", "user-bob"),
         (
             "todo-created-without-membership",
             "Created by Alice without membership",
             "project-created-without-membership",
+            "user-alice",
         ),
     ] {
-        db.insert_row(
-            "todos",
-            id,
-            BTreeMap::from([
-                ("title".to_owned(), json!(title)),
-                ("done".to_owned(), json!(false)),
-                ("project".to_owned(), json!(project)),
-            ]),
-        )
-        .unwrap();
+        db.run_attributing_to_user(author, |author_db| {
+            author_db
+                .insert_row(
+                    "todos",
+                    id,
+                    BTreeMap::from([
+                        ("title".to_owned(), json!(title)),
+                        ("done".to_owned(), json!(false)),
+                        ("project".to_owned(), json!(project)),
+                    ]),
+                )
+                .unwrap();
+        });
     }
 }
 

--- a/crates/mini-jazz-sqlite/tests/whole_system/group_visibility.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/group_visibility.rs
@@ -81,6 +81,26 @@ fn mini_sqlite_todo_fixture_allows_group_reads_but_only_authors_can_delete_todos
     });
 }
 
+#[test]
+fn mini_sqlite_todo_fixture_explains_project_visibility_query() {
+    let mut db = Runtime::open_trusted_with_schema(
+        Storage::Memory,
+        "seed-node",
+        SchemaDef::mini_sqlite_todo_fixture(),
+    )
+    .unwrap();
+
+    seed_group_visibility_fixture(&mut db);
+
+    db.run_as_user("user-alice", |alice| {
+        let plan = alice.explain_query_plan(&project_list_query()).unwrap();
+
+        assert!(plan.sql.contains("SELECT"));
+        assert!(!plan.plan.is_empty());
+        assert!(plan.plan.iter().any(|row| !row.detail.is_empty()));
+    });
+}
+
 fn seed_group_visibility_fixture(db: &mut Runtime) {
     for (id, name) in [
         ("user-alice", "Alice"),
@@ -254,6 +274,14 @@ fn open_todos_query(db: &Runtime) -> Vec<RowView> {
         }))
         .unwrap(),
     )
+    .unwrap()
+}
+
+fn project_list_query() -> BuiltQuery {
+    BuiltQuery::from_json_value(json!({
+        "table": "projects",
+        "orderBy": [["title", "asc"]]
+    }))
     .unwrap()
 }
 

--- a/crates/mini-jazz-sqlite/tests/whole_system/policies.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/policies.rs
@@ -1994,6 +1994,159 @@ fn patch_update_uses_preserved_ref_for_write_policy_validation() {
 }
 
 #[test]
+fn update_policy_uses_old_row_and_checks_new_row_separately() {
+    let schema = SchemaDef::new()
+        .table("projects", |table| {
+            table.text("title");
+            table.read_if_created_by_user();
+        })
+        .table("todos", |table| {
+            table.text("title");
+            table.ref_("project", "projects");
+            table.insert_if_ref_readable("project");
+            table.update_using_created_by_user();
+            table.update_check_ref_readable("project");
+        });
+    let mut alice =
+        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema.clone()).unwrap();
+    let mut bob =
+        Runtime::open_with_schema(Storage::Memory, "bob-node", "bob", schema.clone()).unwrap();
+    let mut edge = Runtime::open_trusted_with_schema(Storage::Memory, "edge", schema).unwrap();
+
+    alice
+        .insert_row(
+            "projects",
+            "project-alice",
+            BTreeMap::from([("title".to_owned(), json!("Alice project"))]),
+        )
+        .unwrap();
+    bob.insert_row(
+        "projects",
+        "project-bob",
+        BTreeMap::from([("title".to_owned(), json!("Bob project"))]),
+    )
+    .unwrap();
+    alice
+        .insert_row(
+            "todos",
+            "todo-alice",
+            BTreeMap::from([
+                ("title".to_owned(), json!("Alice task")),
+                ("project".to_owned(), json!("project-alice")),
+            ]),
+        )
+        .unwrap();
+
+    for bundle in [
+        alice.export_table_history("projects").unwrap(),
+        alice.export_table_history("todos").unwrap(),
+        bob.export_table_history("projects").unwrap(),
+    ] {
+        edge.apply_bundle(&bundle).unwrap();
+        bob.apply_bundle(&bundle).unwrap();
+        alice.apply_bundle(&bundle).unwrap();
+    }
+
+    let bob_tx = bob
+        .update_row(
+            "todos",
+            "todo-alice",
+            BTreeMap::from([("project".to_owned(), json!("project-bob"))]),
+        )
+        .unwrap();
+    assert_eq!(
+        bob.transaction_info(&bob_tx).unwrap().rejection_code,
+        Some("policy_denied".to_owned())
+    );
+
+    let alice_tx = alice
+        .update_row(
+            "todos",
+            "todo-alice",
+            BTreeMap::from([("project".to_owned(), json!("project-bob"))]),
+        )
+        .unwrap();
+    assert_eq!(
+        alice.transaction_info(&alice_tx).unwrap().rejection_code,
+        Some("policy_denied".to_owned())
+    );
+
+    let alice_tx = alice
+        .update_row(
+            "todos",
+            "todo-alice",
+            BTreeMap::from([("title".to_owned(), json!("Alice task renamed"))]),
+        )
+        .unwrap();
+    assert_eq!(
+        alice.transaction_info(&alice_tx).unwrap().rejection_code,
+        None
+    );
+}
+
+#[test]
+fn update_with_check_plus_exists_allows_preventing_updates_to_specific_columns() {
+    let schema = SchemaDef::new().table("todos", |table| {
+        table.text("title");
+        table.bool("done");
+        table.update_protected_fields_if_created_by_user(["title"]);
+    });
+    let mut alice =
+        Runtime::open_with_schema(Storage::Memory, "alice-node", "alice", schema.clone()).unwrap();
+    let mut bob =
+        Runtime::open_with_schema(Storage::Memory, "bob-node", "bob", schema.clone()).unwrap();
+    let mut edge = Runtime::open_trusted_with_schema(Storage::Memory, "edge", schema).unwrap();
+
+    alice
+        .insert_row(
+            "todos",
+            "todo-alice",
+            BTreeMap::from([
+                ("title".to_owned(), json!("Alice task")),
+                ("done".to_owned(), json!(false)),
+            ]),
+        )
+        .unwrap();
+
+    let bundle = alice.export_table_history("todos").unwrap();
+    edge.apply_bundle(&bundle).unwrap();
+    bob.apply_bundle(&bundle).unwrap();
+
+    let bob_tx = bob
+        .update_row(
+            "todos",
+            "todo-alice",
+            BTreeMap::from([("done".to_owned(), json!(true))]),
+        )
+        .unwrap();
+    assert_eq!(bob.transaction_info(&bob_tx).unwrap().rejection_code, None);
+
+    let bob_tx = bob
+        .update_row(
+            "todos",
+            "todo-alice",
+            BTreeMap::from([("title".to_owned(), json!("Bob rename"))]),
+        )
+        .unwrap();
+    assert_eq!(
+        bob.transaction_info(&bob_tx).unwrap().rejection_code,
+        Some("policy_denied".to_owned())
+    );
+
+    let alice_tx = alice
+        .update_row(
+            "todos",
+            "todo-alice",
+            BTreeMap::from([("title".to_owned(), json!("Alice rename"))]),
+        )
+        .unwrap();
+    assert_eq!(
+        alice.transaction_info(&alice_tx).unwrap().rejection_code,
+        None
+    );
+}
+
+#[test]
 fn ref_retarget_update_validates_new_parent_policy() {
     let schema = SchemaDef::new()
         .table("projects", |table| {

--- a/crates/mini-jazz-sqlite/tests/whole_system/recursive_queries.rs
+++ b/crates/mini-jazz-sqlite/tests/whole_system/recursive_queries.rs
@@ -808,7 +808,7 @@ fn recursive_query_scope_sync_exports_deleted_descendant_tombstone() {
     assert!(delete_bundle
         .history
         .iter()
-        .any(|record| record.row_id == "child" && record.op == 3));
+        .any(|record| record.row_id == "child" && record.op == history_op::DELETE));
 
     peer.apply_bundle(&delete_bundle).unwrap();
     let ids = peer
@@ -880,11 +880,11 @@ fn recursive_query_scope_sync_exports_deleted_descendant_subtree_tombstones() {
     assert!(delete_bundle
         .history
         .iter()
-        .any(|record| record.row_id == "child" && record.op == 3));
+        .any(|record| record.row_id == "child" && record.op == history_op::DELETE));
     assert!(delete_bundle
         .history
         .iter()
-        .any(|record| record.row_id == "grandchild" && record.op == 3));
+        .any(|record| record.row_id == "grandchild" && record.op == history_op::DELETE));
 
     peer.apply_bundle(&delete_bundle).unwrap();
     let ids = peer
@@ -1240,7 +1240,7 @@ fn recursive_branch_query_export_includes_tombstone_for_deleted_base_descendant(
         .iter()
         .any(|record| record.branch_id == "draft"
             && record.row_id == "base-child"
-            && record.op == 3));
+            && record.op == history_op::DELETE));
 
     peer.apply_bundle(&bundle).unwrap();
     let ids = peer

--- a/examples/mini-sqlite-todo/index.html
+++ b/examples/mini-sqlite-todo/index.html
@@ -55,7 +55,7 @@
       }
 
       #app {
-        width: min(720px, calc(100vw - 32px));
+        width: min(760px, calc(100vw - 32px));
         margin: 48px auto;
       }
 
@@ -90,6 +90,29 @@
         line-height: 1;
       }
 
+      .scope-controls {
+        display: grid;
+        grid-template-columns: minmax(120px, 0.7fr) minmax(180px, 1fr) minmax(180px, 1.2fr);
+        gap: 12px;
+        align-items: end;
+        margin-top: 22px;
+      }
+
+      .field,
+      .controls label {
+        display: grid;
+        gap: 6px;
+        min-width: 0;
+      }
+
+      .field span,
+      .controls label span {
+        color: #596760;
+        font-size: 0.82rem;
+        font-weight: 700;
+        text-transform: uppercase;
+      }
+
       .todo-form {
         display: grid;
         grid-template-columns: minmax(0, 1.3fr) minmax(180px, 0.7fr) auto;
@@ -99,7 +122,8 @@
 
       .todo-form input,
       .controls input,
-      .controls select {
+      .controls select,
+      .field select {
         width: 100%;
         min-height: 2.5rem;
         border: 1px solid #b7c1ba;
@@ -109,20 +133,44 @@
         padding: 0 0.85rem;
       }
 
+      .field select {
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .group-list {
+        display: flex;
+        gap: 6px;
+        flex-wrap: wrap;
+        min-width: 0;
+        min-height: 2.5rem;
+        align-content: end;
+      }
+
+      .group-chip,
+      .todo-tags span {
+        border: 1px solid #c5cdbf;
+        border-radius: 999px;
+        background: #ffffff;
+        color: #24352f;
+        font-size: 0.86rem;
+        line-height: 1.8rem;
+        max-width: 100%;
+        overflow: hidden;
+        padding: 0 0.7rem;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .group-chip.muted {
+        color: #6b756f;
+      }
+
       .controls {
         display: grid;
         grid-template-columns: minmax(0, 1fr) 142px 142px;
         gap: 10px;
         margin-top: 12px;
-      }
-
-      .controls label {
-        display: grid;
-        gap: 4px;
-        color: #596760;
-        font-size: 0.8rem;
-        font-weight: 700;
-        text-transform: uppercase;
       }
 
       .label-filters {
@@ -134,16 +182,13 @@
       }
 
       .chip {
-        border-radius: 999px;
-        font-size: 0.82rem;
-        line-height: 1;
-      }
-
-      .chip {
         min-height: 2rem;
         border-color: #b7c1ba;
+        border-radius: 999px;
         background: #ffffff;
         color: #24352f;
+        font-size: 0.82rem;
+        line-height: 1;
         padding: 0 0.75rem;
       }
 
@@ -191,7 +236,31 @@
       }
 
       .todo-label span {
+        display: grid;
+        gap: 2px;
         overflow-wrap: anywhere;
+      }
+
+      .todo-label strong {
+        font-weight: 700;
+      }
+
+      .todo-label small {
+        color: #687a40;
+        font-size: 0.82rem;
+      }
+
+      .todo-tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+        margin-top: 3px;
+      }
+
+      .todo-tags span {
+        font-size: 0.74rem;
+        line-height: 1.35rem;
+        padding: 0 0.55rem;
       }
 
       .todo-label input {
@@ -226,6 +295,7 @@
         }
 
         .app-header,
+        .scope-controls,
         .todo-form,
         .controls,
         .todo-item {

--- a/examples/mini-sqlite-todo/index.html
+++ b/examples/mini-sqlite-todo/index.html
@@ -173,7 +173,7 @@
         margin-top: 12px;
       }
 
-      .debug-toggle {
+      .table-stats-toggle {
         display: flex;
         align-items: center;
         gap: 8px;
@@ -185,7 +185,7 @@
         white-space: nowrap;
       }
 
-      .debug-toggle input {
+      .table-stats-toggle input {
         width: 18px;
         height: 18px;
         accent-color: #687a40;

--- a/examples/mini-sqlite-todo/index.html
+++ b/examples/mini-sqlite-todo/index.html
@@ -121,7 +121,7 @@
       }
 
       .todo-form input,
-      .controls input,
+      .controls input:not([type="checkbox"]),
       .controls select,
       .field select {
         width: 100%;
@@ -168,9 +168,27 @@
 
       .controls {
         display: grid;
-        grid-template-columns: minmax(0, 1fr) 142px 142px;
+        grid-template-columns: minmax(0, 1fr) 142px 142px auto;
         gap: 10px;
         margin-top: 12px;
+      }
+
+      .debug-toggle {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        min-height: 2.5rem;
+        color: #596760;
+        font-size: 0.82rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        white-space: nowrap;
+      }
+
+      .debug-toggle input {
+        width: 18px;
+        height: 18px;
+        accent-color: #687a40;
       }
 
       .label-filters {

--- a/examples/mini-sqlite-todo/index.html
+++ b/examples/mini-sqlite-todo/index.html
@@ -245,6 +245,20 @@
         font-weight: 700;
       }
 
+      .todo-title {
+        cursor: text;
+      }
+
+      .todo-title-editor {
+        width: min(100%, 28rem);
+        min-height: 2rem;
+        border: 1px solid #90a096;
+        border-radius: 6px;
+        background: #ffffff;
+        color: #18211f;
+        padding: 0 0.6rem;
+      }
+
       .todo-label small {
         color: #687a40;
         font-size: 0.82rem;
@@ -263,7 +277,7 @@
         padding: 0 0.55rem;
       }
 
-      .todo-label input {
+      .todo-label input[type="checkbox"] {
         width: 18px;
         height: 18px;
         accent-color: #687a40;

--- a/examples/mini-sqlite-todo/src/db-worker.js
+++ b/examples/mini-sqlite-todo/src/db-worker.js
@@ -191,7 +191,7 @@ async function seedDirectory() {
     insertMissing(
       "group_members",
       member.id,
-      { member: member.member, group: member.group },
+      groupMemberValues(member.member, member.group),
       groupMemberIds,
     );
   }
@@ -230,10 +230,38 @@ function ensureProjectMembers(project, projectMemberIds) {
     insertMissing(
       "project_members",
       `project-member-${project.id}-${slug(member)}`,
-      { project: project.id, member },
+      projectMemberValues(project.id, member),
       projectMemberIds,
     );
   }
+}
+
+function groupMemberValues(member, group) {
+  const ref = splitMemberRef(member);
+  return {
+    user: ref.user,
+    member_group: ref.group,
+    group,
+  };
+}
+
+function projectMemberValues(project, member) {
+  const ref = splitMemberRef(member);
+  return {
+    project,
+    user: ref.user,
+    group: ref.group,
+  };
+}
+
+function splitMemberRef(member) {
+  if (member.startsWith("user:")) {
+    return { user: member.slice("user:".length), group: null };
+  }
+  if (member.startsWith("group:")) {
+    return { user: null, group: member.slice("group:".length) };
+  }
+  return { user: null, group: null };
 }
 
 function insertMissing(table, id, values, ids) {

--- a/examples/mini-sqlite-todo/src/db-worker.js
+++ b/examples/mini-sqlite-todo/src/db-worker.js
@@ -1,7 +1,8 @@
 import init, { MiniJazzRuntime } from "./generated/mini-jazz-sqlite-wasm/mini_jazz_sqlite_wasm.js";
 
 const PAGE_SIZE = 10;
-const GENERATED_PROJECT_COUNT = 240;
+const GENERATED_PROJECT_COUNT = 100;
+const SEEDED_TODOS_PER_PROJECT = 10000;
 const GENERATED_LABELS = ["work", "home", "urgent", "later", "bug", "idea", "docs", "release"];
 const SORT_COLUMNS = {
   date: "$createdAt",
@@ -100,7 +101,7 @@ self.onmessage = async ({ data }) => {
       nodeId = data.nodeId;
       activeUserId = data.user ?? activeUserId;
       await openDbAs(SEED_USER_ID, { trusted: true });
-      seedDirectory();
+      await seedDirectory();
       await openDbAs(activeUserId);
       refreshLabelCache();
     } else if (data.type === "setUser") {
@@ -173,7 +174,7 @@ async function openDbAs(userId, { trusted = false } = {}) {
     : await MiniJazzRuntime.openTodoOpfs(dbName, nodeId, userId);
 }
 
-function seedDirectory() {
+async function seedDirectory() {
   refreshLabelCache();
   const userIds = rowIds("users");
   for (const user of USERS) {
@@ -197,12 +198,14 @@ function seedDirectory() {
 
   const projectIds = rowIds("projects");
   const projectMemberIds = rowIds("project_members");
-  for (const project of [...BASE_PROJECTS, ...generatedProjects()]) {
+  const projects = [...BASE_PROJECTS, ...generatedProjects()];
+  for (const project of projects) {
     insertMissing("projects", project.id, { title: project.title }, projectIds);
     ensureProjectMembers(project, projectMemberIds);
   }
 
   ensureLabels(GENERATED_LABELS);
+  await seedProjectTodos(projects);
 }
 
 function ensureGeneratedProjects() {
@@ -237,6 +240,80 @@ function insertMissing(table, id, values, ids) {
   if (ids.has(id)) return;
   db.insertRow(table, id, values);
   ids.add(id);
+}
+
+async function seedProjectTodos(projects) {
+  const total = projects.length * SEEDED_TODOS_PER_PROJECT;
+  let seen = 0;
+
+  for (const project of projects) {
+    const finalTodoId = seededTodoId(project.id, SEEDED_TODOS_PER_PROJECT);
+    if (db.one({ table: "todos", conditions: [{ column: "id", op: "eq", value: finalTodoId }] })) {
+      seen += SEEDED_TODOS_PER_PROJECT;
+      postMessage({ type: "progress", generated: seen, total });
+      continue;
+    }
+
+    const authors = authorsForProject(project);
+    const rowsByAuthor = new Map();
+    for (let i = 1; i <= SEEDED_TODOS_PER_PROJECT; i++) {
+      const author = authors[(i - 1) % authors.length];
+      const rows = rowsByAuthor.get(author) ?? [];
+      rows.push({
+        id: seededTodoId(project.id, i),
+        values: {
+          title: seededTodoTitle(project, i),
+          done: false,
+          project: project.id,
+        },
+      });
+      rowsByAuthor.set(author, rows);
+    }
+
+    for (const [author, rows] of rowsByAuthor) {
+      db.upsertRowsAsUser(author, "todos", rows);
+      seen += rows.length;
+      postMessage({ type: "progress", generated: seen, total });
+      await new Promise((resolve) => setTimeout(resolve));
+    }
+  }
+
+  postMessage({ type: "progress", generated: total, total });
+}
+
+function authorsForProject(project) {
+  const authors = [];
+  const seen = new Set();
+  for (const member of project.members) {
+    for (const userId of userIdsForMember(member)) {
+      if (seen.has(userId)) continue;
+      seen.add(userId);
+      authors.push(userId);
+    }
+  }
+  return authors.length ? authors : [USERS[0].id];
+}
+
+function userIdsForMember(member, seenGroups = new Set()) {
+  if (member.startsWith("user:")) return [member.slice("user:".length)];
+  if (!member.startsWith("group:")) return [];
+
+  const groupId = member.slice("group:".length);
+  if (seenGroups.has(groupId)) return [];
+  const nextSeenGroups = new Set(seenGroups);
+  nextSeenGroups.add(groupId);
+
+  return GROUP_MEMBERS.filter((row) => row.group === groupId).flatMap((row) =>
+    userIdsForMember(row.member, nextSeenGroups),
+  );
+}
+
+function seededTodoId(projectId, index) {
+  return `todo-seeded-${projectId}-${String(index).padStart(5, "0")}`;
+}
+
+function seededTodoTitle(project, index) {
+  return `${project.title} task ${String(index).padStart(5, "0")}`;
 }
 
 function rowIds(table) {

--- a/examples/mini-sqlite-todo/src/db-worker.js
+++ b/examples/mini-sqlite-todo/src/db-worker.js
@@ -86,6 +86,7 @@ let nodeId;
 let activeUserId = USERS[0].id;
 let selectedProjectId = null;
 let labelsById = new Map();
+let showDebugInfo = false;
 let filters = {
   search: "",
   labelIds: [],
@@ -112,6 +113,8 @@ self.onmessage = async ({ data }) => {
       filters = sanitizeFilters(filters);
     } else if (data.type === "setProject") {
       selectedProjectId = data.projectId;
+    } else if (data.type === "setDebugInfo") {
+      showDebugInfo = Boolean(data.enabled);
     } else if (data.type === "add") {
       const scope = visibleScope();
       const projectId = visibleProjectId(data.projectId ?? selectedProjectId, scope);
@@ -416,6 +419,13 @@ function postState(generateMs) {
     txId: row.tx_id,
   }));
   const queryMs = performance.now() - todoStartedAt;
+  const debugInfo = showDebugInfo
+    ? {
+        currentRows: db.storageStats().current_rows,
+        visibilityMs: scope.visibilityMs,
+        queryMs,
+      }
+    : null;
 
   postMessage({
     type: "state",
@@ -427,9 +437,8 @@ function postState(generateMs) {
     filters,
     labels: sortedLabels(),
     todos,
-    visibilityMs: scope.visibilityMs,
-    queryMs,
-    currentRows: db.storageStats().current_rows,
+    showDebugInfo,
+    debugInfo,
     generateMs,
   });
 }

--- a/examples/mini-sqlite-todo/src/db-worker.js
+++ b/examples/mini-sqlite-todo/src/db-worker.js
@@ -16,15 +16,23 @@ const USERS = [
 
 const GROUPS = [
   { id: "group-engineering", name: "Engineering" },
+  { id: "group-company", name: "Company" },
   { id: "group-design", name: "Design" },
   { id: "group-support", name: "Support" },
 ];
 
 const GROUP_MEMBERS = [
-  { id: "group-member-alice-engineering", user: "user-alice", group: "group-engineering" },
-  { id: "group-member-alice-design", user: "user-alice", group: "group-design" },
-  { id: "group-member-bob-engineering", user: "user-bob", group: "group-engineering" },
-  { id: "group-member-cara-support", user: "user-cara", group: "group-support" },
+  { id: "group-member-alice-engineering", member: "user:user-alice", group: "group-engineering" },
+  { id: "group-member-alice-design", member: "user:user-alice", group: "group-design" },
+  { id: "group-member-bob-engineering", member: "user:user-bob", group: "group-engineering" },
+  { id: "group-member-cara-support", member: "user:user-cara", group: "group-support" },
+  {
+    id: "group-member-engineering-company",
+    member: "group:group-engineering",
+    group: "group-company",
+  },
+  { id: "group-member-design-company", member: "group:group-design", group: "group-company" },
+  { id: "group-member-support-company", member: "group:group-support", group: "group-company" },
 ];
 
 const BASE_PROJECTS = [
@@ -37,6 +45,11 @@ const BASE_PROJECTS = [
     id: "project-launch-plan",
     title: "Launch plan",
     members: ["group:group-engineering"],
+  },
+  {
+    id: "project-company-strategy",
+    title: "Company strategy",
+    members: ["group:group-company"],
   },
   {
     id: "project-design-polish",
@@ -57,6 +70,7 @@ const BASE_PROJECTS = [
 
 const GENERATED_MEMBERS = [
   "group:group-engineering",
+  "group:group-company",
   "group:group-design",
   "group:group-support",
   "user:user-alice",
@@ -176,7 +190,7 @@ function seedDirectory() {
     insertMissing(
       "group_members",
       member.id,
-      { user: member.user, group: member.group },
+      { member: member.member, group: member.group },
       groupMemberIds,
     );
   }

--- a/examples/mini-sqlite-todo/src/db-worker.js
+++ b/examples/mini-sqlite-todo/src/db-worker.js
@@ -1,13 +1,75 @@
 import init, { MiniJazzRuntime } from "./generated/mini-jazz-sqlite-wasm/mini_jazz_sqlite_wasm.js";
 
-const PROJECT_ID = "todo-list";
 const PAGE_SIZE = 10;
+const GENERATED_PROJECT_COUNT = 240;
 const GENERATED_LABELS = ["work", "home", "urgent", "later", "bug", "idea", "docs", "release"];
 const SORT_COLUMNS = {
   date: "$createdAt",
   name: "title",
 };
+
+const USERS = [
+  { id: "user-alice", name: "Alice" },
+  { id: "user-bob", name: "Bob" },
+  { id: "user-cara", name: "Cara" },
+];
+
+const GROUPS = [
+  { id: "group-engineering", name: "Engineering" },
+  { id: "group-design", name: "Design" },
+  { id: "group-support", name: "Support" },
+];
+
+const GROUP_MEMBERS = [
+  { id: "group-member-alice-engineering", user: "user-alice", group: "group-engineering" },
+  { id: "group-member-alice-design", user: "user-alice", group: "group-design" },
+  { id: "group-member-bob-engineering", user: "user-bob", group: "group-engineering" },
+  { id: "group-member-cara-support", user: "user-cara", group: "group-support" },
+];
+
+const BASE_PROJECTS = [
+  {
+    id: "todo-list",
+    title: "Alice inbox",
+    members: ["user:user-alice"],
+  },
+  {
+    id: "project-launch-plan",
+    title: "Launch plan",
+    members: ["group:group-engineering"],
+  },
+  {
+    id: "project-design-polish",
+    title: "Design polish",
+    members: ["group:group-design"],
+  },
+  {
+    id: "project-bob-private",
+    title: "Bob private",
+    members: ["user:user-bob"],
+  },
+  {
+    id: "project-support-rotation",
+    title: "Support rotation",
+    members: ["group:group-support"],
+  },
+];
+
+const GENERATED_MEMBERS = [
+  "group:group-engineering",
+  "group:group-design",
+  "group:group-support",
+  "user:user-alice",
+  "user:user-bob",
+  "user:user-cara",
+];
+
+const SEED_USER_ID = "seed";
 let db;
+let dbName;
+let nodeId;
+let activeUserId = USERS[0].id;
+let selectedProjectId = null;
 let labelsById = new Map();
 let filters = {
   search: "",
@@ -20,17 +82,32 @@ self.onmessage = async ({ data }) => {
   try {
     if (data.type === "init") {
       await init();
-      db = await MiniJazzRuntime.openOpfs(data.dbName, data.nodeId, data.user);
-      if (!db.readRows("projects").some((row) => row.id === PROJECT_ID)) {
-        db.insertRow("projects", PROJECT_ID, { title: "Todo list" });
-      }
+      dbName = data.dbName;
+      nodeId = data.nodeId;
+      activeUserId = data.user ?? activeUserId;
+      await openDbAs(SEED_USER_ID, { trusted: true });
+      seedDirectory();
+      await openDbAs(activeUserId);
       refreshLabelCache();
+    } else if (data.type === "setUser") {
+      activeUserId = data.user;
+      selectedProjectId = null;
+      await openDbAs(activeUserId);
+      refreshLabelCache();
+      filters = sanitizeFilters(filters);
+    } else if (data.type === "setProject") {
+      selectedProjectId = data.projectId;
     } else if (data.type === "add") {
+      const scope = visibleScope();
+      const projectId = visibleProjectId(data.projectId ?? selectedProjectId, scope);
+      if (!projectId) {
+        throw new Error("No visible project selected");
+      }
       const id = `todo-${crypto.randomUUID()}`;
       db.insertRow("todos", id, {
         title: data.title,
         done: false,
-        project: PROJECT_ID,
+        project: projectId,
       });
       addTodoLabels(id, data.labels);
     } else if (data.type === "setFilters") {
@@ -38,13 +115,15 @@ self.onmessage = async ({ data }) => {
     } else if (data.type === "generate") {
       const startedAt = performance.now();
       ensureLabels(GENERATED_LABELS);
+      const projects = ensureGeneratedProjects();
       for (let i = 0; i < data.count; i++) {
-        const todoId = `todo-${crypto.randomUUID()}`;
+        const project = projects[i % projects.length];
+        const todoId = `todo-generated-${crypto.randomUUID()}`;
         const todoLabels = labelsForGeneratedTodo(i);
         db.insertRow("todos", todoId, {
           title: generatedTitle(i, todoLabels),
           done: false,
-          project: PROJECT_ID,
+          project: project.id,
         });
         addTodoLabels(todoId, todoLabels);
         if ((i + 1) % 1000 === 0) {
@@ -55,10 +134,14 @@ self.onmessage = async ({ data }) => {
       postState(performance.now() - startedAt);
       return;
     } else if (data.type === "toggle") {
-      db.updateRow("todos", data.id, { done: data.done });
+      if (visibleTodo(data.id)) {
+        db.updateRow("todos", data.id, { done: data.done });
+      }
     } else if (data.type === "delete") {
-      deleteTodoLabels(data.id);
-      db.deleteRow("todos", data.id);
+      if (visibleTodo(data.id)) {
+        deleteTodoLabels(data.id);
+        db.deleteRow("todos", data.id);
+      }
     }
     postState();
   } catch (error) {
@@ -66,28 +149,151 @@ self.onmessage = async ({ data }) => {
   }
 };
 
-function postState(generateMs) {
-  const startedAt = performance.now();
-  const todoIds = todoIdsForSelectedLabels(filters.labelIds);
-  let rows = [];
+async function openDbAs(userId, { trusted = false } = {}) {
+  db?.free?.();
+  db = trusted
+    ? await MiniJazzRuntime.openTrustedTodoOpfs(dbName, nodeId)
+    : await MiniJazzRuntime.openTodoOpfs(dbName, nodeId, userId);
+}
 
-  if (!todoIds || todoIds.length > 0) {
-    rows = db.query(buildTodoQuery(todoIds));
+function seedDirectory() {
+  refreshLabelCache();
+  const userIds = rowIds("users");
+  for (const user of USERS) {
+    insertMissing("users", user.id, { name: user.name }, userIds);
   }
-  const queryMs = performance.now() - startedAt;
 
+  const groupIds = rowIds("groups");
+  for (const group of GROUPS) {
+    insertMissing("groups", group.id, { name: group.name }, groupIds);
+  }
+
+  const groupMemberIds = rowIds("group_members");
+  for (const member of GROUP_MEMBERS) {
+    insertMissing(
+      "group_members",
+      member.id,
+      { user: member.user, group: member.group },
+      groupMemberIds,
+    );
+  }
+
+  const projectIds = rowIds("projects");
+  const projectMemberIds = rowIds("project_members");
+  for (const project of [...BASE_PROJECTS, ...generatedProjects()]) {
+    insertMissing("projects", project.id, { title: project.title }, projectIds);
+    ensureProjectMembers(project, projectMemberIds);
+  }
+
+  ensureLabels(GENERATED_LABELS);
+}
+
+function ensureGeneratedProjects() {
+  return generatedProjects();
+}
+
+function generatedProjects() {
+  const projects = [];
+  for (let i = 0; i < GENERATED_PROJECT_COUNT; i++) {
+    const member = GENERATED_MEMBERS[i % GENERATED_MEMBERS.length];
+    projects.push({
+      id: `project-generated-${String(i + 1).padStart(3, "0")}`,
+      title: `Generated ${String(i + 1).padStart(3, "0")}`,
+      members: [member],
+    });
+  }
+  return projects;
+}
+
+function ensureProjectMembers(project, projectMemberIds) {
+  for (const member of project.members) {
+    insertMissing(
+      "project_members",
+      `project-member-${project.id}-${slug(member)}`,
+      { project: project.id, member },
+      projectMemberIds,
+    );
+  }
+}
+
+function insertMissing(table, id, values, ids) {
+  if (ids.has(id)) return;
+  db.insertRow(table, id, values);
+  ids.add(id);
+}
+
+function rowIds(table) {
+  return new Set(db.readRows(table).map((row) => row.id));
+}
+
+function visibleScope() {
+  const startedAt = performance.now();
+  const projects = db
+    .query({
+      table: "projects",
+      orderBy: [["title", "asc"]],
+    })
+    .map((row) => ({ id: row.id, title: row.values.title }));
+  const groups = db
+    .query({
+      table: "groups",
+      orderBy: [["name", "asc"]],
+    })
+    .map((row) => ({ id: row.id, name: row.values.name }));
+  const projectIds = projects.map((project) => project.id);
+
+  return {
+    groups,
+    projects,
+    projectIds,
+    projectIdSet: new Set(projectIds),
+    visibilityMs: performance.now() - startedAt,
+  };
+}
+
+function visibleProjectId(candidate, scope) {
+  if (candidate && scope.projectIdSet.has(candidate)) return candidate;
+  return scope.projects[0]?.id ?? null;
+}
+
+function visibleTodo(id) {
+  return db.one({
+    table: "todos",
+    conditions: [{ column: "id", op: "eq", value: id }],
+  });
+}
+
+function postState(generateMs) {
+  const scope = visibleScope();
+  selectedProjectId = visibleProjectId(selectedProjectId, scope);
+
+  const todoStartedAt = performance.now();
+  const selectedTodoIds = todoIdsForSelectedLabels(filters.labelIds);
+  const rows = selectedTodoIds?.length === 0 ? [] : db.query(buildTodoQuery(selectedTodoIds));
+  const projectTitles = new Map(scope.projects.map((project) => [project.id, project.title]));
+  const todoLabels = labelsByTodoId(rows.map((row) => row.id));
   const todos = rows.map((row) => ({
     id: row.id,
     title: row.values.title,
     done: row.values.done,
+    projectId: row.values.project,
+    projectTitle: projectTitles.get(row.values.project) ?? row.values.project,
+    labels: todoLabels.get(row.id) ?? [],
     txId: row.tx_id,
   }));
+  const queryMs = performance.now() - todoStartedAt;
 
   postMessage({
     type: "state",
+    activeUserId,
+    users: USERS,
+    groups: scope.groups,
+    projects: scope.projects,
+    selectedProjectId,
     filters,
     labels: sortedLabels(),
     todos,
+    visibilityMs: scope.visibilityMs,
     queryMs,
     currentRows: db.storageStats().current_rows,
     generateMs,
@@ -95,7 +301,7 @@ function postState(generateMs) {
 }
 
 function buildTodoQuery(todoIds) {
-  const conditions = [];
+  const conditions = [{ column: "done", op: "eq", value: false }];
   const search = filters.search.trim();
 
   if (search) {
@@ -141,12 +347,10 @@ function ensureLabels(labelNames) {
   return labels;
 }
 
-function labelRow(row) {
-  return [row.id, { id: row.id, name: row.values.name }];
-}
-
 function refreshLabelCache() {
-  labelsById = new Map(db.readRows("labels").map(labelRow));
+  labelsById = new Map(
+    db.readRows("labels").map((row) => [row.id, { id: row.id, name: row.values.name }]),
+  );
 }
 
 function sortedLabels() {
@@ -161,6 +365,27 @@ function deleteTodoLabels(todoId) {
   })) {
     db.deleteRow("todo_labels", row.id);
   }
+}
+
+function labelsByTodoId(todoIds) {
+  const labels = new Map();
+  if (todoIds.length === 0) return labels;
+  const rows = db.query({
+    table: "todo_labels",
+    conditions: [{ column: "todo", op: "in", value: todoIds }],
+    includes: {},
+  });
+  for (const row of rows) {
+    const label = labelsById.get(row.values.label);
+    if (!label) continue;
+    const todoLabels = labels.get(row.values.todo) ?? [];
+    todoLabels.push(label);
+    labels.set(row.values.todo, todoLabels);
+  }
+  for (const todoLabels of labels.values()) {
+    todoLabels.sort((left, right) => left.name.localeCompare(right.name));
+  }
+  return labels;
 }
 
 function todoIdsForSelectedLabels(labelIds) {
@@ -226,4 +451,11 @@ function normalizeLabelName(value) {
 
 function labelIdForName(name) {
   return `label-${name}`;
+}
+
+function slug(value) {
+  return value
+    .replace(/[^a-z0-9]+/gi, "-")
+    .replace(/^-|-$/g, "")
+    .toLowerCase();
 }

--- a/examples/mini-sqlite-todo/src/db-worker.js
+++ b/examples/mini-sqlite-todo/src/db-worker.js
@@ -326,12 +326,11 @@ function userName(userId) {
 
 function visibleScope() {
   const startedAt = performance.now();
-  const projects = db
-    .query({
-      table: "projects",
-      orderBy: [["title", "asc"]],
-    })
-    .map((row) => ({ id: row.id, title: row.values.title }));
+  const projectQuery = {
+    table: "projects",
+    orderBy: [["title", "asc"]],
+  };
+  const projects = db.query(projectQuery).map((row) => ({ id: row.id, title: row.values.title }));
   const groups = db
     .query({
       table: "groups",

--- a/examples/mini-sqlite-todo/src/db-worker.js
+++ b/examples/mini-sqlite-todo/src/db-worker.js
@@ -152,6 +152,11 @@ self.onmessage = async ({ data }) => {
       if (visibleTodo(data.id)) {
         db.updateRow("todos", data.id, { done: data.done });
       }
+    } else if (data.type === "rename") {
+      const title = String(data.title ?? "").trim();
+      if (title && visibleTodo(data.id)) {
+        db.updateRow("todos", data.id, { title });
+      }
     } else if (data.type === "delete") {
       const todo = visibleTodo(data.id);
       if (todo?.created_by === activeUserId) {
@@ -405,6 +410,7 @@ function postState(generateMs) {
     projectTitle: projectTitles.get(row.values.project) ?? row.values.project,
     createdBy: row.created_by,
     createdByName: userName(row.created_by),
+    canRename: row.created_by === activeUserId,
     canDelete: row.created_by === activeUserId,
     labels: todoLabels.get(row.id) ?? [],
     txId: row.tx_id,

--- a/examples/mini-sqlite-todo/src/db-worker.js
+++ b/examples/mini-sqlite-todo/src/db-worker.js
@@ -86,7 +86,7 @@ let nodeId;
 let activeUserId = USERS[0].id;
 let selectedProjectId = null;
 let labelsById = new Map();
-let showDebugInfo = false;
+let showTableStats = false;
 let filters = {
   search: "",
   labelIds: [],
@@ -113,8 +113,8 @@ self.onmessage = async ({ data }) => {
       filters = sanitizeFilters(filters);
     } else if (data.type === "setProject") {
       selectedProjectId = data.projectId;
-    } else if (data.type === "setDebugInfo") {
-      showDebugInfo = Boolean(data.enabled);
+    } else if (data.type === "setTableStats") {
+      showTableStats = Boolean(data.enabled);
     } else if (data.type === "add") {
       const scope = visibleScope();
       const projectId = visibleProjectId(data.projectId ?? selectedProjectId, scope);
@@ -419,7 +419,7 @@ function postState(generateMs) {
     txId: row.tx_id,
   }));
   const queryMs = performance.now() - todoStartedAt;
-  const debugInfo = showDebugInfo
+  const tableStats = showTableStats
     ? {
         currentRows: db.storageStats().current_rows,
         visibilityMs: scope.visibilityMs,
@@ -437,8 +437,8 @@ function postState(generateMs) {
     filters,
     labels: sortedLabels(),
     todos,
-    showDebugInfo,
-    debugInfo,
+    showTableStats,
+    tableStats,
     generateMs,
   });
 }

--- a/examples/mini-sqlite-todo/src/db-worker.js
+++ b/examples/mini-sqlite-todo/src/db-worker.js
@@ -138,8 +138,11 @@ self.onmessage = async ({ data }) => {
         db.updateRow("todos", data.id, { done: data.done });
       }
     } else if (data.type === "delete") {
-      if (visibleTodo(data.id)) {
+      const todo = visibleTodo(data.id);
+      if (todo?.created_by === activeUserId) {
         deleteTodoLabels(data.id);
+        db.deleteRow("todos", data.id);
+      } else if (todo) {
         db.deleteRow("todos", data.id);
       }
     }
@@ -226,6 +229,10 @@ function rowIds(table) {
   return new Set(db.readRows(table).map((row) => row.id));
 }
 
+function userName(userId) {
+  return USERS.find((user) => user.id === userId)?.name ?? userId;
+}
+
 function visibleScope() {
   const startedAt = performance.now();
   const projects = db
@@ -278,6 +285,9 @@ function postState(generateMs) {
     done: row.values.done,
     projectId: row.values.project,
     projectTitle: projectTitles.get(row.values.project) ?? row.values.project,
+    createdBy: row.created_by,
+    createdByName: userName(row.created_by),
+    canDelete: row.created_by === activeUserId,
     labels: todoLabels.get(row.id) ?? [],
     txId: row.tx_id,
   }));

--- a/examples/mini-sqlite-todo/src/main.js
+++ b/examples/mini-sqlite-todo/src/main.js
@@ -20,8 +20,8 @@ const state = {
   generated: 0,
   totalToGenerate: 100000,
   generateMs: 0,
-  showDebugInfo: false,
-  debugInfo: null,
+  showTableStats: false,
+  tableStats: null,
 };
 let searchTimer = 0;
 let editingTodoId = null;
@@ -67,9 +67,9 @@ app.innerHTML = `
           <option value="asc">Asc</option>
         </select>
       </label>
-      <label class="debug-toggle">
-        <input id="debug-info" type="checkbox" />
-        <span>Debug</span>
+      <label class="table-stats-toggle">
+        <input id="table-stats" type="checkbox" />
+        <span>Table stats</span>
       </label>
     </div>
     <div id="label-filters" class="label-filters" aria-label="Label filters"></div>
@@ -87,7 +87,7 @@ const labelsInput = app.querySelector("#todo-labels");
 const searchInput = app.querySelector("#search");
 const sortField = app.querySelector("#sort-field");
 const sortDir = app.querySelector("#sort-dir");
-const debugInfo = app.querySelector("#debug-info");
+const tableStats = app.querySelector("#table-stats");
 const labelFilters = app.querySelector("#label-filters");
 const list = app.querySelector("#todo-list");
 const generate = app.querySelector("#generate");
@@ -132,10 +132,10 @@ sortDir.addEventListener("change", () => {
   setFilters({ sortDir: sortDir.value });
 });
 
-debugInfo.addEventListener("change", () => {
-  state.showDebugInfo = debugInfo.checked;
-  state.debugInfo = null;
-  worker.postMessage({ type: "setDebugInfo", enabled: state.showDebugInfo });
+tableStats.addEventListener("change", () => {
+  state.showTableStats = tableStats.checked;
+  state.tableStats = null;
+  worker.postMessage({ type: "setTableStats", enabled: state.showTableStats });
   render();
 });
 
@@ -211,8 +211,8 @@ worker.onmessage = ({ data }) => {
     state.todos = data.todos;
     state.labels = data.labels;
     state.filters = data.filters;
-    state.showDebugInfo = data.showDebugInfo;
-    state.debugInfo = data.debugInfo;
+    state.showTableStats = data.showTableStats;
+    state.tableStats = data.tableStats;
     state.generateMs = data.generateMs ?? state.generateMs;
     state.generating = false;
     state.error = "";
@@ -248,7 +248,7 @@ function render() {
   app.querySelector("#status").textContent =
     state.generating || state.ready ? statusText() : "Opening OPFS worker...";
 
-  for (const control of [titleInput, labelsInput, searchInput, sortField, sortDir, debugInfo]) {
+  for (const control of [titleInput, labelsInput, searchInput, sortField, sortDir, tableStats]) {
     control.disabled =
       !state.ready || state.generating || (control === titleInput && !state.selectedProjectId);
   }
@@ -269,7 +269,7 @@ function render() {
   searchInput.value = state.filters.search;
   sortField.value = state.filters.sortField;
   sortDir.value = state.filters.sortDir;
-  debugInfo.checked = state.showDebugInfo;
+  tableStats.checked = state.showTableStats;
 
   const error = app.querySelector("#error-message");
   error.hidden = !state.error;
@@ -291,7 +291,7 @@ function render() {
     `${state.todos.length} open todos shown.`,
     `${state.projects.length.toLocaleString()} visible projects.`,
     filterSummary(),
-    debugSummary(),
+    tableStatsSummary(),
   ]
     .filter(Boolean)
     .join(" ");
@@ -311,18 +311,18 @@ function filterSummary() {
   return `Filters: ${parts.join(", ")}.`;
 }
 
-function debugSummary() {
-  if (!state.showDebugInfo) return "";
-  if (!state.debugInfo) return "Debug: loading...";
+function tableStatsSummary() {
+  if (!state.showTableStats) return "";
+  if (!state.tableStats) return "Table stats: loading...";
   const parts = [
-    `${state.debugInfo.currentRows.toLocaleString()} current rows`,
-    `access ${state.debugInfo.visibilityMs.toFixed(2)} ms`,
-    `top-10 ${state.debugInfo.queryMs.toFixed(2)} ms`,
+    `${state.tableStats.currentRows.toLocaleString()} current rows`,
+    `access ${state.tableStats.visibilityMs.toFixed(2)} ms`,
+    `top-10 ${state.tableStats.queryMs.toFixed(2)} ms`,
   ];
   if (state.generateMs) {
     parts.push(`generate ${(state.generateMs / 1000).toFixed(2)} s`);
   }
-  return `Debug: ${parts.join(", ")}.`;
+  return `Table stats: ${parts.join(", ")}.`;
 }
 
 function userOptionHtml(user) {

--- a/examples/mini-sqlite-todo/src/main.js
+++ b/examples/mini-sqlite-todo/src/main.js
@@ -207,7 +207,8 @@ function setFilters(patch) {
 }
 
 function render() {
-  app.querySelector("#status").textContent = state.ready ? statusText() : "Opening OPFS worker...";
+  app.querySelector("#status").textContent =
+    state.generating || state.ready ? statusText() : "Opening OPFS worker...";
 
   for (const control of [titleInput, labelsInput, searchInput, sortField, sortDir]) {
     control.disabled =

--- a/examples/mini-sqlite-todo/src/main.js
+++ b/examples/mini-sqlite-todo/src/main.js
@@ -20,9 +20,8 @@ const state = {
   generated: 0,
   totalToGenerate: 100000,
   generateMs: 0,
-  queryMs: 0,
-  visibilityMs: 0,
-  currentRows: 0,
+  showDebugInfo: false,
+  debugInfo: null,
 };
 let searchTimer = 0;
 let editingTodoId = null;
@@ -68,6 +67,10 @@ app.innerHTML = `
           <option value="asc">Asc</option>
         </select>
       </label>
+      <label class="debug-toggle">
+        <input id="debug-info" type="checkbox" />
+        <span>Debug</span>
+      </label>
     </div>
     <div id="label-filters" class="label-filters" aria-label="Label filters"></div>
     <button id="generate" class="generate" type="button">Generate 100k todos</button>
@@ -84,6 +87,7 @@ const labelsInput = app.querySelector("#todo-labels");
 const searchInput = app.querySelector("#search");
 const sortField = app.querySelector("#sort-field");
 const sortDir = app.querySelector("#sort-dir");
+const debugInfo = app.querySelector("#debug-info");
 const labelFilters = app.querySelector("#label-filters");
 const list = app.querySelector("#todo-list");
 const generate = app.querySelector("#generate");
@@ -126,6 +130,13 @@ sortField.addEventListener("change", () => {
 
 sortDir.addEventListener("change", () => {
   setFilters({ sortDir: sortDir.value });
+});
+
+debugInfo.addEventListener("change", () => {
+  state.showDebugInfo = debugInfo.checked;
+  state.debugInfo = null;
+  worker.postMessage({ type: "setDebugInfo", enabled: state.showDebugInfo });
+  render();
 });
 
 labelFilters.addEventListener("click", (event) => {
@@ -200,9 +211,8 @@ worker.onmessage = ({ data }) => {
     state.todos = data.todos;
     state.labels = data.labels;
     state.filters = data.filters;
-    state.visibilityMs = data.visibilityMs;
-    state.queryMs = data.queryMs;
-    state.currentRows = data.currentRows;
+    state.showDebugInfo = data.showDebugInfo;
+    state.debugInfo = data.debugInfo;
     state.generateMs = data.generateMs ?? state.generateMs;
     state.generating = false;
     state.error = "";
@@ -238,7 +248,7 @@ function render() {
   app.querySelector("#status").textContent =
     state.generating || state.ready ? statusText() : "Opening OPFS worker...";
 
-  for (const control of [titleInput, labelsInput, searchInput, sortField, sortDir]) {
+  for (const control of [titleInput, labelsInput, searchInput, sortField, sortDir, debugInfo]) {
     control.disabled =
       !state.ready || state.generating || (control === titleInput && !state.selectedProjectId);
   }
@@ -259,6 +269,7 @@ function render() {
   searchInput.value = state.filters.search;
   sortField.value = state.filters.sortField;
   sortDir.value = state.filters.sortDir;
+  debugInfo.checked = state.showDebugInfo;
 
   const error = app.querySelector("#error-message");
   error.hidden = !state.error;
@@ -276,14 +287,14 @@ function render() {
   }
   app.querySelector("#empty-state").hidden = state.todos.length > 0;
 
-  app.querySelector("#summary").textContent =
-    `${state.todos.length} open todos shown. ` +
-    `${state.projects.length.toLocaleString()} visible projects. ` +
-    `${state.currentRows.toLocaleString()} current rows. ` +
-    `Access: ${state.visibilityMs.toFixed(2)} ms. ` +
-    `Top-10 query: ${state.queryMs.toFixed(2)} ms. ` +
-    `${filterSummary()}` +
-    (state.generateMs ? ` Generate: ${(state.generateMs / 1000).toFixed(2)} s.` : "");
+  app.querySelector("#summary").textContent = [
+    `${state.todos.length} open todos shown.`,
+    `${state.projects.length.toLocaleString()} visible projects.`,
+    filterSummary(),
+    debugSummary(),
+  ]
+    .filter(Boolean)
+    .join(" ");
 }
 
 function statusText() {
@@ -298,6 +309,20 @@ function filterSummary() {
   const sortName = state.filters.sortField === "name" ? "name" : "date";
   parts.push(`${sortName} ${state.filters.sortDir}`);
   return `Filters: ${parts.join(", ")}.`;
+}
+
+function debugSummary() {
+  if (!state.showDebugInfo) return "";
+  if (!state.debugInfo) return "Debug: loading...";
+  const parts = [
+    `${state.debugInfo.currentRows.toLocaleString()} current rows`,
+    `access ${state.debugInfo.visibilityMs.toFixed(2)} ms`,
+    `top-10 ${state.debugInfo.queryMs.toFixed(2)} ms`,
+  ];
+  if (state.generateMs) {
+    parts.push(`generate ${(state.generateMs / 1000).toFixed(2)} s`);
+  }
+  return `Debug: ${parts.join(", ")}.`;
 }
 
 function userOptionHtml(user) {

--- a/examples/mini-sqlite-todo/src/main.js
+++ b/examples/mini-sqlite-todo/src/main.js
@@ -297,11 +297,11 @@ function todoHtml(todo) {
         <input type="checkbox" data-role="toggle" data-id="${escapeAttr(todo.id)}" ${todo.done ? "checked" : ""}>
         <span>
           <strong>${escapeHtml(todo.title)}</strong>
-          <small>${escapeHtml(todo.projectTitle)}</small>
+          <small>${escapeHtml(todo.projectTitle)} - by ${escapeHtml(todo.createdByName)}</small>
           ${labelHtml}
         </span>
       </label>
-      <button type="button" data-role="delete" data-id="${escapeAttr(todo.id)}">Delete</button>
+      <button type="button" data-role="delete" data-id="${escapeAttr(todo.id)}" ${todo.canDelete ? "" : "disabled"}>Delete</button>
     </li>
   `;
 }

--- a/examples/mini-sqlite-todo/src/main.js
+++ b/examples/mini-sqlite-todo/src/main.js
@@ -25,13 +25,14 @@ const state = {
   currentRows: 0,
 };
 let searchTimer = 0;
+let editingTodoId = null;
 
 app.innerHTML = `
   <section class="todo-app">
     <header class="app-header">
       <div>
         <p class="eyebrow">mini-jazz-sqlite WASM</p>
-        <h1>Group-scoped todos</h1>
+        <h1>Todos</h1>
       </div>
       <p id="status" class="status" role="status"></p>
     </header>
@@ -69,7 +70,7 @@ app.innerHTML = `
       </label>
     </div>
     <div id="label-filters" class="label-filters" aria-label="Label filters"></div>
-    <button id="generate" class="generate" type="button">Generate 100k scoped todos</button>
+    <button id="generate" class="generate" type="button">Generate 100k todos</button>
     <p id="error-message" class="error-message" role="alert" hidden></p>
     <ul id="todo-list" class="todo-list"></ul>
     <p id="empty-state" class="empty-state">No visible open todos.</p>
@@ -161,6 +162,33 @@ list.addEventListener("click", (event) => {
   worker.postMessage({ type: "delete", id: target.dataset.id });
 });
 
+list.addEventListener("dblclick", (event) => {
+  const target = event.target.closest?.("[data-role='title']");
+  if (!target || !state.ready || state.generating) return;
+  const todo = state.todos.find((candidate) => candidate.id === target.dataset.id);
+  if (!todo?.canRename) return;
+  editingTodoId = todo.id;
+  render();
+});
+
+list.addEventListener("keydown", (event) => {
+  const target = event.target;
+  if (target.dataset.role !== "title-editor") return;
+  if (event.key === "Escape") {
+    editingTodoId = null;
+    render();
+    return;
+  }
+  if (event.key !== "Enter") return;
+  event.preventDefault();
+  const title = target.value.trim();
+  editingTodoId = null;
+  if (title) {
+    worker.postMessage({ type: "rename", id: target.dataset.id, title });
+  }
+  render();
+});
+
 worker.onmessage = ({ data }) => {
   if (data.type === "state") {
     state.ready = true;
@@ -237,7 +265,15 @@ function render() {
   error.textContent = state.error;
 
   labelFilters.innerHTML = state.labels.map(labelFilterHtml).join("");
+  if (editingTodoId && !state.todos.some((todo) => todo.id === editingTodoId && todo.canRename)) {
+    editingTodoId = null;
+  }
   list.innerHTML = state.todos.map(todoHtml).join("");
+  const editor = list.querySelector("[data-role='title-editor']");
+  if (editor) {
+    editor.focus();
+    editor.select();
+  }
   app.querySelector("#empty-state").hidden = state.todos.length > 0;
 
   app.querySelector("#summary").textContent =
@@ -292,16 +328,20 @@ function todoHtml(todo) {
   const labelHtml = todo.labels.length
     ? `<span class="todo-tags">${todo.labels.map((label) => `<span>${escapeHtml(label.name)}</span>`).join("")}</span>`
     : "";
+  const titleHtml =
+    editingTodoId === todo.id && todo.canRename
+      ? `<input class="todo-title-editor" data-role="title-editor" data-id="${escapeAttr(todo.id)}" type="text" autocomplete="off" value="${escapeAttr(todo.title)}">`
+      : `<strong class="todo-title" data-role="title" data-id="${escapeAttr(todo.id)}">${escapeHtml(todo.title)}</strong>`;
   return `
     <li class="todo-item ${todo.done ? "done" : ""}">
-      <label class="todo-label">
-        <input type="checkbox" data-role="toggle" data-id="${escapeAttr(todo.id)}" ${todo.done ? "checked" : ""}>
+      <div class="todo-label">
+        <input type="checkbox" data-role="toggle" data-id="${escapeAttr(todo.id)}" aria-label="${escapeAttr(todo.title)}" ${todo.done ? "checked" : ""}>
         <span>
-          <strong>${escapeHtml(todo.title)}</strong>
+          ${titleHtml}
           <small>${escapeHtml(todo.projectTitle)} - by ${escapeHtml(todo.createdByName)}</small>
           ${labelHtml}
         </span>
-      </label>
+      </div>
       <button type="button" data-role="delete" data-id="${escapeAttr(todo.id)}" ${todo.canDelete ? "" : "disabled"}>Delete</button>
     </li>
   `;

--- a/examples/mini-sqlite-todo/src/main.js
+++ b/examples/mini-sqlite-todo/src/main.js
@@ -3,6 +3,11 @@ const worker = new Worker(new URL("./db-worker.js", import.meta.url), { type: "m
 const state = {
   ready: false,
   generating: false,
+  users: [],
+  groups: [],
+  projects: [],
+  activeUserId: "user-alice",
+  selectedProjectId: null,
   todos: [],
   labels: [],
   filters: {
@@ -16,6 +21,7 @@ const state = {
   totalToGenerate: 100000,
   generateMs: 0,
   queryMs: 0,
+  visibilityMs: 0,
   currentRows: 0,
 };
 let searchTimer = 0;
@@ -25,10 +31,21 @@ app.innerHTML = `
     <header class="app-header">
       <div>
         <p class="eyebrow">mini-jazz-sqlite WASM</p>
-        <h1>Todos</h1>
+        <h1>Group-scoped todos</h1>
       </div>
       <p id="status" class="status" role="status"></p>
     </header>
+    <div class="scope-controls">
+      <label class="field">
+        <span>User</span>
+        <select id="user-select"></select>
+      </label>
+      <label class="field">
+        <span>Project</span>
+        <select id="project-select"></select>
+      </label>
+      <div id="group-list" class="group-list" aria-label="Groups"></div>
+    </div>
     <form id="todo-form" class="todo-form">
       <input id="todo-title" name="title" type="text" autocomplete="off" placeholder="Add a task" required />
       <input id="todo-labels" name="labels" type="text" autocomplete="off" placeholder="labels: work, urgent" />
@@ -52,10 +69,10 @@ app.innerHTML = `
       </label>
     </div>
     <div id="label-filters" class="label-filters" aria-label="Label filters"></div>
-    <button id="generate" class="generate" type="button">Generate 100k todos</button>
+    <button id="generate" class="generate" type="button">Generate 100k scoped todos</button>
     <p id="error-message" class="error-message" role="alert" hidden></p>
     <ul id="todo-list" class="todo-list"></ul>
-    <p id="empty-state" class="empty-state">No matching todos.</p>
+    <p id="empty-state" class="empty-state">No visible open todos.</p>
     <p id="summary" class="summary"></p>
   </section>
 `;
@@ -69,12 +86,19 @@ const sortDir = app.querySelector("#sort-dir");
 const labelFilters = app.querySelector("#label-filters");
 const list = app.querySelector("#todo-list");
 const generate = app.querySelector("#generate");
+const userSelect = app.querySelector("#user-select");
+const projectSelect = app.querySelector("#project-select");
 
 form.addEventListener("submit", (event) => {
   event.preventDefault();
   const title = titleInput.value.trim();
-  if (!title || !state.ready) return;
-  worker.postMessage({ type: "add", title, labels: parseLabels(labelsInput.value) });
+  if (!title || !state.ready || !state.selectedProjectId) return;
+  worker.postMessage({
+    type: "add",
+    title,
+    labels: parseLabels(labelsInput.value),
+    projectId: state.selectedProjectId,
+  });
   titleInput.value = "";
   labelsInput.value = "";
 });
@@ -115,6 +139,16 @@ labelFilters.addEventListener("click", (event) => {
   setFilters({ labelIds: [...labelIds] });
 });
 
+userSelect.addEventListener("change", () => {
+  if (!state.ready || state.generating) return;
+  worker.postMessage({ type: "setUser", user: userSelect.value });
+});
+
+projectSelect.addEventListener("change", () => {
+  if (!state.ready || state.generating) return;
+  worker.postMessage({ type: "setProject", projectId: projectSelect.value });
+});
+
 list.addEventListener("change", (event) => {
   const target = event.target;
   if (target.dataset.role !== "toggle") return;
@@ -130,9 +164,15 @@ list.addEventListener("click", (event) => {
 worker.onmessage = ({ data }) => {
   if (data.type === "state") {
     state.ready = true;
+    state.users = data.users;
+    state.groups = data.groups;
+    state.projects = data.projects;
+    state.activeUserId = data.activeUserId;
+    state.selectedProjectId = data.selectedProjectId;
     state.todos = data.todos;
     state.labels = data.labels;
     state.filters = data.filters;
+    state.visibilityMs = data.visibilityMs;
     state.queryMs = data.queryMs;
     state.currentRows = data.currentRows;
     state.generateMs = data.generateMs ?? state.generateMs;
@@ -153,9 +193,9 @@ addEventListener("pagehide", () => worker.terminate());
 
 worker.postMessage({
   type: "init",
-  dbName: "mini-jazz-sqlite-labeled-todos.sqlite3",
+  dbName: "mini-jazz-sqlite-group-label-todos.sqlite3",
   nodeId: "browser-worker",
-  user: "alice",
+  user: "user-alice",
 });
 render();
 
@@ -170,10 +210,23 @@ function render() {
   app.querySelector("#status").textContent = state.ready ? statusText() : "Opening OPFS worker...";
 
   for (const control of [titleInput, labelsInput, searchInput, sortField, sortDir]) {
-    control.disabled = !state.ready || state.generating;
+    control.disabled =
+      !state.ready || state.generating || (control === titleInput && !state.selectedProjectId);
   }
-  form.querySelector("button").disabled = !state.ready || state.generating;
+  labelsInput.disabled = !state.ready || state.generating || !state.selectedProjectId;
+  form.querySelector("button").disabled =
+    !state.ready || state.generating || !state.selectedProjectId;
   generate.disabled = !state.ready || state.generating;
+  userSelect.disabled = !state.ready || state.generating;
+  projectSelect.disabled = !state.ready || state.generating || state.projects.length === 0;
+
+  userSelect.innerHTML = state.users.map(userOptionHtml).join("");
+  userSelect.value = state.activeUserId;
+
+  projectSelect.innerHTML = state.projects.map(projectOptionHtml).join("");
+  projectSelect.value = state.selectedProjectId ?? "";
+
+  app.querySelector("#group-list").innerHTML = groupListHtml();
   searchInput.value = state.filters.search;
   sortField.value = state.filters.sortField;
   sortDir.value = state.filters.sortDir;
@@ -186,13 +239,13 @@ function render() {
   list.innerHTML = state.todos.map(todoHtml).join("");
   app.querySelector("#empty-state").hidden = state.todos.length > 0;
 
-  const done = state.todos.filter((todo) => todo.done).length;
-  const filters = filterSummary();
   app.querySelector("#summary").textContent =
-    `${state.todos.length - done} open / ${done} done shown. ` +
+    `${state.todos.length} open todos shown. ` +
+    `${state.projects.length.toLocaleString()} visible projects. ` +
     `${state.currentRows.toLocaleString()} current rows. ` +
+    `Access: ${state.visibilityMs.toFixed(2)} ms. ` +
     `Top-10 query: ${state.queryMs.toFixed(2)} ms. ` +
-    `${filters}` +
+    `${filterSummary()}` +
     (state.generateMs ? ` Generate: ${(state.generateMs / 1000).toFixed(2)} s.` : "");
 }
 
@@ -210,6 +263,21 @@ function filterSummary() {
   return `Filters: ${parts.join(", ")}.`;
 }
 
+function userOptionHtml(user) {
+  return `<option value="${escapeAttr(user.id)}">${escapeHtml(user.name)}</option>`;
+}
+
+function projectOptionHtml(project) {
+  return `<option value="${escapeAttr(project.id)}">${escapeHtml(project.title)}</option>`;
+}
+
+function groupListHtml() {
+  if (!state.groups.length) return `<span class="group-chip muted">No groups</span>`;
+  return state.groups
+    .map((group) => `<span class="group-chip">${escapeHtml(group.name)}</span>`)
+    .join("");
+}
+
 function labelFilterHtml(label) {
   const selected = state.filters.labelIds.includes(label.id);
   return `
@@ -220,11 +288,18 @@ function labelFilterHtml(label) {
 }
 
 function todoHtml(todo) {
+  const labelHtml = todo.labels.length
+    ? `<span class="todo-tags">${todo.labels.map((label) => `<span>${escapeHtml(label.name)}</span>`).join("")}</span>`
+    : "";
   return `
     <li class="todo-item ${todo.done ? "done" : ""}">
       <label class="todo-label">
         <input type="checkbox" data-role="toggle" data-id="${escapeAttr(todo.id)}" ${todo.done ? "checked" : ""}>
-        <span>${escapeHtml(todo.title)}</span>
+        <span>
+          <strong>${escapeHtml(todo.title)}</strong>
+          <small>${escapeHtml(todo.projectTitle)}</small>
+          ${labelHtml}
+        </span>
       </label>
       <button type="button" data-role="delete" data-id="${escapeAttr(todo.id)}">Delete</button>
     </li>

--- a/examples/mini-sqlite-todo/src/main.js
+++ b/examples/mini-sqlite-todo/src/main.js
@@ -193,7 +193,7 @@ addEventListener("pagehide", () => worker.terminate());
 
 worker.postMessage({
   type: "init",
-  dbName: "mini-jazz-sqlite-group-label-todos.sqlite3",
+  dbName: "mini-jazz-sqlite-nested-group-label-todos.sqlite3",
   nodeId: "browser-worker",
   user: "user-alice",
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -877,6 +877,14 @@ importers:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
+  examples/mini-sqlite-todo:
+    devDependencies:
+      vite:
+        specifier: catalog:default
+        version: 8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
+  examples/mini-sqlite-todo-yew: {}
+
   examples/moon-lander-react:
     dependencies:
       jazz-tools:
@@ -971,12 +979,6 @@ importers:
       typescript:
         specifier: catalog:default
         version: 6.0.2
-
-  examples/mini-sqlite-todo:
-    devDependencies:
-      vite:
-        specifier: catalog:default
-        version: 8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   examples/todo-client-localfirst-expo:
     dependencies:


### PR DESCRIPTION
## Description

Added a policy implementation that aligns more closely with Jazz's, and used it to add the concept of groups to the todo example.

Things I added:
- separate insert/update/delete policies (instead of a single write policy)
- separate using & with check policies
- some of the policies supported by Jazz: Cmp, And/Or/Not, Exists, Inherits

## Takeaways

Even in large tables (I tested a table with 1M todos) with recursive groups, queries completed in <10ms. There's probably room for improvement, but for a super naive implementation I'm pleasantly surprised with the results.

## Discussion

Permissions are only partially implemented. I focused on the policies that allowed testing recursive groups. I don't think we need to focus on until we decide whether we want to cleanup and "productize" the current POC or start from scratch.