### PR TITLE
feat(svelte, vue): reactive session handles for getSession and useSession

### DIFF
--- a/.changeset/reactive-session-handles.md
+++ b/.changeset/reactive-session-handles.md
@@ -1,0 +1,8 @@
+---
+"jazz-tools": patch
+---
+
+`getSession()` (Svelte) and `useSession()` (Vue) now return reactive handles that track auth changes without destroying the provider.
+
+- **Svelte**: `getSession()` returns `{ current: Session | null }` — read `.current` in templates, `$derived`, or `$effect` and it updates automatically on login/logout.
+- **Vue**: `useSession()` returns `ComputedRef<Session | null>` — bind `.value` in templates or computed properties and it stays in sync via `triggerRef`.

--- a/examples/docs/todo-client-localfirst-svelte/src/AuthSessionExamples.svelte
+++ b/examples/docs/todo-client-localfirst-svelte/src/AuthSessionExamples.svelte
@@ -9,7 +9,7 @@
   // #endregion auth-session-svelte-hook
 
   // #region auth-session-svelte-user-id
-  const sessionUserId = $derived(session?.user_id ?? null);
+  const sessionUserId = $derived(session.current?.user_id ?? null);
   // #endregion auth-session-svelte-user-id
 
   // #region auth-session-svelte-query

--- a/examples/docs/todo-client-localfirst-svelte/src/DbSessionExamples.svelte
+++ b/examples/docs/todo-client-localfirst-svelte/src/DbSessionExamples.svelte
@@ -12,7 +12,7 @@
   // #endregion db-access-svelte
 
   // #region session-svelte
-  const session = getSession(); // { user_id: string } | null
+  const session = getSession(); // { current: Session | null }
   // #endregion session-svelte
 
   void addTodo;

--- a/examples/docs/todo-client-localfirst-vue/src/AuthSessionExamples.vue
+++ b/examples/docs/todo-client-localfirst-vue/src/AuthSessionExamples.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from "vue";
 import { useAll, useDb, useSession } from "jazz-tools/vue";
 import { app } from "../session-app.js";
 
@@ -9,21 +10,25 @@ const session = useSession();
 // #endregion auth-session-vue-hook
 
 // #region auth-session-vue-user-id
-const sessionUserId = session?.user_id ?? null;
+const sessionUserId = computed(() => session.value?.user_id ?? null);
 // #endregion auth-session-vue-user-id
 
 // #region auth-session-vue-query
-const ownedTodos = useAll(sessionUserId ? app.todos.where({ owner_id: sessionUserId }) : undefined);
+const ownedTodos = useAll(
+  computed(() =>
+    sessionUserId.value ? app.todos.where({ owner_id: sessionUserId.value }) : undefined,
+  ),
+);
 // #endregion auth-session-vue-query
 
 // #region auth-session-vue-insert
 function addOwnedTodo(title: string) {
-  if (!sessionUserId) return;
+  if (!sessionUserId.value) return;
 
   db.insert(app.todos, {
     title,
     done: false,
-    owner_id: sessionUserId,
+    owner_id: sessionUserId.value,
   });
 }
 // #endregion auth-session-vue-insert

--- a/examples/docs/todo-client-localfirst-vue/src/DbSessionExamples.vue
+++ b/examples/docs/todo-client-localfirst-vue/src/DbSessionExamples.vue
@@ -12,7 +12,7 @@ async function addTodo(title: string) {
 // #endregion db-access-vue
 
 // #region session-vue
-const session = useSession(); // ShallowRef<{ user_id: string } | null>
+const session = useSession(); // ComputedRef<Session | null>
 // #endregion session-vue
 
 void addTodo;

--- a/examples/todo-client-localfirst-svelte/src/TodoList.svelte
+++ b/examples/todo-client-localfirst-svelte/src/TodoList.svelte
@@ -8,7 +8,7 @@
 	const todos = new QuerySubscription(app.todos);
 	// #endregion reading-reactive-svelte
 	const session = getSession();
-	const sessionUserId = $derived(session?.user_id ?? null);
+	const sessionUserId = $derived(session.current?.user_id ?? null);
 	let title = $state('');
 
 	function handleSubmit(e: SubmitEvent) {

--- a/examples/todo-client-localfirst-vue/src/TodoList.vue
+++ b/examples/todo-client-localfirst-vue/src/TodoList.vue
@@ -9,7 +9,7 @@ const db = useDb();
 const todos = useAll(app.todos);
 // #endregion reading-reactive-vue
 const session = useSession();
-const sessionUserId = computed(() => session?.user_id ?? null);
+const sessionUserId = computed(() => session.value?.user_id ?? null);
 const title = ref("");
 
 function handleSubmit(e: Event) {

--- a/examples/wequencer/src/AudioProvider.svelte
+++ b/examples/wequencer/src/AudioProvider.svelte
@@ -287,11 +287,11 @@
 
 	// Join the jam as a participant (only after the jam row exists locally)
 	$effect(() => {
-		if (!session) return;
+		if (!session.current) return;
 		const jamRows = jam.current ?? [];
 		if (jamRows.length === 0) return;
 
-		db.all(app.participants.where({ jamId: jamId, $createdBy: session.user_id })).then((existing) => {
+		db.all(app.participants.where({ jamId: jamId, $createdBy: session.current.user_id })).then((existing) => {
 			if (existing.length === 0) {
 				const name = localStorage.getItem('wequencer-name') ?? getRandomName();
 				localStorage.setItem('wequencer-name', name);

--- a/examples/wequencer/src/InstrumentRow.svelte
+++ b/examples/wequencer/src/InstrumentRow.svelte
@@ -36,7 +36,7 @@
         jamId: jamId,
         instrumentId: instrument.id,
         beat_index: index,
-        placed_by: session?.user_id ?? "unknown",
+        placed_by: session.current?.user_id ?? "unknown",
       });
     }
   }

--- a/examples/wequencer/src/Participants.svelte
+++ b/examples/wequencer/src/Participants.svelte
@@ -41,7 +41,7 @@
   <h2>The Band</h2>
 
   {#each participants.current ?? [] as participant (participant.id)}
-    {@const isMe = participant.$createdBy === session?.user_id}
+    {@const isMe = participant.$createdBy === session.current?.user_id}
     <div class="participant" class:is-me={isMe}>
       <div
         class="avatar"

--- a/examples/wequencer/walkthrough/jazz-wequencer.md
+++ b/examples/wequencer/walkthrough/jazz-wequencer.md
@@ -137,7 +137,7 @@ Any component inside `JazzSvelteProvider` can reach the database and the current
 import { getDb, getSession } from "jazz-tools/svelte";
 
 const db = getDb(); // full query + write API
-const session = getSession(); // { user_id, ... } | null
+const session = getSession(); // { current: Session | null }
 ```
 
 Used in `InstrumentRow`, `InstrumentManager`, and `Participants` — each just calls `getDb()` directly.
@@ -200,7 +200,7 @@ function toggleBeat(index: number) {
       jam: jamId,
       instrument: instrument.id,
       beat_index: index,
-      placed_by: session?.user_id ?? "anonymous", // tag the author
+      placed_by: session.current?.user_id ?? "anonymous", // tag the author
     });
   }
 }
@@ -276,7 +276,7 @@ const allParticipants = new QuerySubscription(app.participants);
 db.update(app.participants, editingId, { display_name: name });
 ```
 
-Identity flows through `session.user_id` — the same ID that colours your beats in the grid.
+Identity flows through `session.current?.user_id` — the same ID that colours your beats in the grid.
 
 ---
 

--- a/examples/world-tour/src/App.vue
+++ b/examples/world-tour/src/App.vue
@@ -134,24 +134,36 @@ import GeolocateFab from "./components/GeolocateFab.vue";
 
 const db = useDb();
 const session = useSession();
-const canEdit = !!session && !isPublicMode;
+const canEdit = computed(() => !!session.value && !isPublicMode);
 
 function switchView() {
-  if (canEdit) {
+  if (canEdit.value) {
     window.location.href = window.location.pathname + "?public";
   } else {
     window.location.href = window.location.pathname;
   }
 }
 
-ensureData(db, session?.user_id, canEdit).catch((err) =>
+ensureData(db, session.value?.user_id, canEdit.value).catch((err) =>
   console.error("Failed to ensure data:", err),
 );
 
 const selectedStop = ref<StopWithVenue | null>(null);
 const posterStop = ref<StopWithVenue | null>(null);
-const showLandingPoster = ref(!canEdit);
-const showSplash = ref(canEdit);
+const showLandingPoster = ref(!canEdit.value);
+const showSplash = ref(canEdit.value);
+
+// Session resolves async — update splash state once auth is confirmed.
+watch(
+  canEdit,
+  (val) => {
+    if (val) {
+      showLandingPoster.value = false;
+      showSplash.value = true;
+    }
+  },
+  { once: true },
+);
 const sheetOpen = ref(false);
 const sheetMode = ref<"detail" | "create">("detail");
 
@@ -191,7 +203,7 @@ const stopsQuery = computed(() => {
     .include({ venue: true })
     .orderBy("date", "asc")
     .limit(12);
-  return canEdit ? base : confirmed;
+  return canEdit.value ? base : confirmed;
 });
 const stopsData = useAll(stopsQuery);
 
@@ -258,7 +270,7 @@ function onStopButtonClick(stopId: string) {
 }
 
 function selectStop(stop: StopWithVenue) {
-  if (!canEdit) {
+  if (!canEdit.value) {
     posterStop.value = stop;
   } else {
     selectedStop.value = stop;
@@ -368,7 +380,7 @@ onMounted(async () => {
     // Reject clicks outside valid Earth coordinates
     if (e.lat < -90 || e.lat > 90 || e.lng < -180 || e.lng > 180) return;
 
-    if (canEdit) {
+    if (canEdit.value) {
       popoverX.value = e.x;
       popoverY.value = e.y;
       popoverLat.value = e.lat;

--- a/examples/world-tour/src/components/BandLogo.vue
+++ b/examples/world-tour/src/components/BandLogo.vue
@@ -31,7 +31,7 @@ const props = defineProps<{
 
 const db = useDb();
 const session = useSession();
-const canEdit = !!session;
+const canEdit = !!session.value;
 
 const bandsWithLogo = useAll(app.bands.include({ logoFile: { parts: true } }).limit(1));
 const logoUrl = ref<string | null>(null);

--- a/examples/world-tour/src/components/StopDetail.vue
+++ b/examples/world-tour/src/components/StopDetail.vue
@@ -81,7 +81,7 @@ const emit = defineEmits<{
 
 const db = useDb();
 const session = useSession();
-const canEdit = !!session;
+const canEdit = !!session.value;
 
 const venue = computed(() => props.stop.venue);
 

--- a/examples/world-tour/src/components/TourCalendar.vue
+++ b/examples/world-tour/src/components/TourCalendar.vue
@@ -63,7 +63,7 @@ const emit = defineEmits<{
 
 const db = useDb();
 const session = useSession();
-const canEdit = !!session;
+const canEdit = !!session.value;
 
 const dayHeaders = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 

--- a/examples/world-tour/tests/browser/jazz-vue.test.ts
+++ b/examples/world-tour/tests/browser/jazz-vue.test.ts
@@ -242,7 +242,8 @@ describe("world-tour Jazz + Vue integration", () => {
     const SessionProbe = defineComponent({
       setup() {
         const session = useSession();
-        return () => h("p", { id: "session" }, session ? `id:${session.user_id}` : "anonymous");
+        return () =>
+          h("p", { id: "session" }, session.value ? `id:${session.value.user_id}` : "anonymous");
       },
     });
 

--- a/packages/jazz-tools/src/svelte/context.svelte.test.ts
+++ b/packages/jazz-tools/src/svelte/context.svelte.test.ts
@@ -42,14 +42,30 @@ describe("context with real $state", () => {
     expect(() => getDb()).toThrow("Jazz database is not yet initialised");
   });
 
-  it("getSession returns null initially, then reflects updates", () => {
+  it("getSession returns a live handle whose .current tracks the current session", () => {
     const ctx = initJazzContext();
-    expect(getSession()).toBe(null);
+    const handle = getSession();
+
+    expect(handle.current).toBe(null);
 
     const session = { user_id: "alice", claims: { role: "admin" } };
     ctx.session = session;
 
-    expect(getSession()).toStrictEqual(session);
+    expect(handle.current).toStrictEqual(session);
+  });
+
+  it("getSession handle tracks repeated auth changes without re-calling getSession", () => {
+    const ctx = initJazzContext();
+    const handle = getSession();
+
+    expect(handle.current).toBeNull();
+
+    const alice = { user_id: "alice", claims: { role: "admin" } };
+    ctx.session = alice;
+    expect(handle.current).toStrictEqual(alice);
+
+    ctx.session = null;
+    expect(handle.current).toBeNull();
   });
 
   it("reading back a set value returns the proxy-wrapped equivalent", () => {

--- a/packages/jazz-tools/src/svelte/context.svelte.ts
+++ b/packages/jazz-tools/src/svelte/context.svelte.ts
@@ -45,8 +45,15 @@ export function getDb(): Db {
 }
 
 /**
- * Get the current Jazz {@link Session}, including the user's id, claims and auth mode.
+ * Subscribe to the current Jazz {@link Session}.
+ * The returned handle's `.current` property always reflects the latest session,
+ * updating automatically as the user logs in or out.
  */
-export function getSession(): Session | null {
-  return getJazzContext().session;
+export function getSession(): { readonly current: Session | null } {
+  const ctx = getJazzContext();
+  return {
+    get current() {
+      return ctx.session;
+    },
+  };
 }

--- a/packages/jazz-tools/src/svelte/create-jazz-client.test.ts
+++ b/packages/jazz-tools/src/svelte/create-jazz-client.test.ts
@@ -166,7 +166,7 @@ describe("svelte/createExtensionJazzClient", () => {
     mocks.trackPromise.mockImplementation((promise) => promise);
   });
 
-  it("SV-EXT-01: creates client from inspected page", async () => {
+  it("creates client from inspected page", async () => {
     const db = createMockDb("devtools-app");
     mocks.createDbFromInspectedPage.mockResolvedValue(db);
 
@@ -181,7 +181,7 @@ describe("svelte/createExtensionJazzClient", () => {
     expect(client.manager).toBe(mocks.orchestratorInstances[0]!);
   });
 
-  it("SV-EXT-02: rejects when config is missing", async () => {
+  it("rejects when config is missing", async () => {
     const db = { shutdown: vi.fn(), getConfig: vi.fn(() => null) };
     mocks.createDbFromInspectedPage.mockResolvedValue(db);
 
@@ -190,7 +190,7 @@ describe("svelte/createExtensionJazzClient", () => {
     );
   });
 
-  it("SV-EXT-03: wraps with trackPromise", async () => {
+  it("wraps with trackPromise", async () => {
     const db = createMockDb();
     mocks.createDbFromInspectedPage.mockResolvedValue(db);
 

--- a/packages/jazz-tools/src/vue/provider.test.ts
+++ b/packages/jazz-tools/src/vue/provider.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { isRef, shallowRef, triggerRef } from "vue";
+import type { Session } from "../runtime/context.js";
+
+// Override inject so tests can control what the provider key resolves to without
+// mounting a real Vue component tree.  computed/shallowRef/triggerRef are kept real.
+const mockClientRef = shallowRef<any>(null);
+
+vi.mock("vue", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("vue")>();
+  return {
+    ...actual,
+    inject: (_key: unknown, defaultValue: unknown) =>
+      mockClientRef.value !== null ? mockClientRef : (defaultValue ?? null),
+  };
+});
+
+import { useSession } from "./provider.js";
+
+function makeSession(userId: string): Session {
+  return { user_id: userId, claims: {}, authMode: "local-first" };
+}
+
+describe("vue/useSession", () => {
+  beforeEach(() => {
+    mockClientRef.value = null;
+  });
+
+  it("VU-SES-01: throws when no JazzProvider context is present", () => {
+    expect(() => useSession()).toThrow("Jazz Vue composables must be used within <JazzProvider>");
+  });
+
+  it("VU-SES-02: returns a reactive ComputedRef", () => {
+    mockClientRef.value = { session: null };
+
+    const result = useSession();
+
+    expect(isRef(result)).toBe(true);
+  });
+
+  it("VU-SES-03: .value reflects the current session", () => {
+    const session = makeSession("alice");
+    mockClientRef.value = { session };
+
+    const sessionRef = useSession();
+
+    expect(sessionRef.value).toEqual(session);
+  });
+
+  it("VU-SES-04: .value is null when the client has no session", () => {
+    mockClientRef.value = { session: null };
+
+    const sessionRef = useSession();
+
+    expect(sessionRef.value).toBeNull();
+  });
+
+  it("VU-SES-05: .value updates when triggerRef is called after the session getter changes", () => {
+    // Model the real JazzClient: session is exposed via a getter over a mutable local variable.
+    // onAuthChanged updates the variable and calls triggerRef(clientRef).
+    let currentSession: Session | null = makeSession("alice");
+    const client = {
+      get session() {
+        return currentSession;
+      },
+    };
+    mockClientRef.value = client;
+
+    const sessionRef = useSession();
+    expect(sessionRef.value).toEqual(makeSession("alice"));
+
+    currentSession = makeSession("bob");
+    triggerRef(mockClientRef);
+
+    expect(sessionRef.value).toEqual(makeSession("bob"));
+  });
+
+  it("VU-SES-06: .value goes null when session is cleared and triggerRef fires", () => {
+    let currentSession: Session | null = makeSession("alice");
+    const client = {
+      get session() {
+        return currentSession;
+      },
+    };
+    mockClientRef.value = client;
+
+    const sessionRef = useSession();
+    expect(sessionRef.value).toEqual(makeSession("alice"));
+
+    currentSession = null;
+    triggerRef(mockClientRef);
+
+    expect(sessionRef.value).toBeNull();
+  });
+});

--- a/packages/jazz-tools/src/vue/provider.test.ts
+++ b/packages/jazz-tools/src/vue/provider.test.ts
@@ -26,11 +26,11 @@ describe("vue/useSession", () => {
     mockClientRef.value = null;
   });
 
-  it("VU-SES-01: throws when no JazzProvider context is present", () => {
+  it("throws when no JazzProvider context is present", () => {
     expect(() => useSession()).toThrow("Jazz Vue composables must be used within <JazzProvider>");
   });
 
-  it("VU-SES-02: returns a reactive ComputedRef", () => {
+  it("returns a reactive ComputedRef", () => {
     mockClientRef.value = { session: null };
 
     const result = useSession();
@@ -38,7 +38,7 @@ describe("vue/useSession", () => {
     expect(isRef(result)).toBe(true);
   });
 
-  it("VU-SES-03: .value reflects the current session", () => {
+  it(".value reflects the current session", () => {
     const session = makeSession("alice");
     mockClientRef.value = { session };
 
@@ -47,7 +47,7 @@ describe("vue/useSession", () => {
     expect(sessionRef.value).toEqual(session);
   });
 
-  it("VU-SES-04: .value is null when the client has no session", () => {
+  it(".value is null when the client has no session", () => {
     mockClientRef.value = { session: null };
 
     const sessionRef = useSession();
@@ -55,7 +55,7 @@ describe("vue/useSession", () => {
     expect(sessionRef.value).toBeNull();
   });
 
-  it("VU-SES-05: .value updates when triggerRef is called after the session getter changes", () => {
+  it(".value updates when triggerRef is called after the session getter changes", () => {
     // Model the real JazzClient: session is exposed via a getter over a mutable local variable.
     // onAuthChanged updates the variable and calls triggerRef(clientRef).
     let currentSession: Session | null = makeSession("alice");
@@ -75,7 +75,7 @@ describe("vue/useSession", () => {
     expect(sessionRef.value).toEqual(makeSession("bob"));
   });
 
-  it("VU-SES-06: .value goes null when session is cleared and triggerRef fires", () => {
+  it(".value goes null when session is cleared and triggerRef fires", () => {
     let currentSession: Session | null = makeSession("alice");
     const client = {
       get session() {

--- a/packages/jazz-tools/src/vue/provider.ts
+++ b/packages/jazz-tools/src/vue/provider.ts
@@ -1,4 +1,5 @@
 import {
+  computed,
   defineComponent,
   inject,
   onUnmounted,
@@ -6,6 +7,7 @@ import {
   shallowRef,
   triggerRef,
   watch,
+  type ComputedRef,
   type InjectionKey,
   type PropType,
   type ShallowRef,
@@ -135,8 +137,14 @@ export function useDb(): Db {
 }
 
 /**
- * Get the current Jazz {@link Session}, including the user's id, claims and auth mode.
+ * Subscribe to the current Jazz {@link Session}.
+ * Returns a {@link ComputedRef} whose `.value` updates automatically as the user
+ * logs in or out — use it in templates or computed properties.
  */
-export function useSession(): Session | null {
-  return useJazzClient().session ?? null;
+export function useSession(): ComputedRef<Session | null> {
+  const ctx = inject(JazzContextKey, null);
+  if (!ctx) {
+    throw new Error("Jazz Vue composables must be used within <JazzProvider>");
+  }
+  return computed(() => ctx.value?.session ?? null);
 }

--- a/packages/jazz-tools/src/vue/use-all.test.ts
+++ b/packages/jazz-tools/src/vue/use-all.test.ts
@@ -45,7 +45,7 @@ describe("vue/useAll", () => {
     mocks.reset();
   });
 
-  it("VU-ALL-01: calls makeQueryKey without options when none provided", () => {
+  it("calls makeQueryKey without options when none provided", () => {
     const query = makeQuery();
     const scope = effectScope();
     scope.run(() => useAll(query));
@@ -53,7 +53,7 @@ describe("vue/useAll", () => {
     scope.stop();
   });
 
-  it("VU-ALL-02: forwards QueryOptions with tier to makeQueryKey", () => {
+  it("forwards QueryOptions with tier to makeQueryKey", () => {
     const query = makeQuery();
     const scope = effectScope();
     scope.run(() => useAll(query, { tier: "edge" }));
@@ -61,7 +61,7 @@ describe("vue/useAll", () => {
     scope.stop();
   });
 
-  it("VU-ALL-03: forwards full QueryOptions to makeQueryKey", () => {
+  it("forwards full QueryOptions to makeQueryKey", () => {
     const query = makeQuery();
     const options = {
       tier: "local" as const,
@@ -74,7 +74,7 @@ describe("vue/useAll", () => {
     scope.stop();
   });
 
-  it("VU-ALL-04: reactive options trigger re-subscription on change", async () => {
+  it("reactive options trigger re-subscription on change", async () => {
     const query = makeQuery();
     const options = ref<any>({ tier: "local" });
 
@@ -100,7 +100,7 @@ describe("vue/useAll", () => {
     scope.stop();
   });
 
-  it("VU-ALL-05: returns data from cache entry state", () => {
+  it("returns data from cache entry state", () => {
     const alice = { id: "1", name: "Alice" };
     mocks.getCacheEntry.mockReturnValue({
       state: { status: "fulfilled" as const, data: [alice] },
@@ -113,7 +113,7 @@ describe("vue/useAll", () => {
     scope.stop();
   });
 
-  it("VU-ALL-06: returns undefined when entry state is pending", () => {
+  it("returns undefined when entry state is pending", () => {
     mocks.getCacheEntry.mockReturnValue({
       state: { status: "pending" as const },
       subscribe: mocks.subscribe,
@@ -125,7 +125,7 @@ describe("vue/useAll", () => {
     scope.stop();
   });
 
-  it("VU-ALL-07: onDelta reconciles in-place, preserving object identity", () => {
+  it("onDelta reconciles in-place, preserving object identity", () => {
     const alice = { id: "u1", name: "Alice", role: "admin" };
     let capturedOnDelta: ((delta: any) => void) | undefined;
 
@@ -158,7 +158,7 @@ describe("vue/useAll", () => {
     scope.stop();
   });
 
-  it("VU-ALL-08: batch delta with remove + add preserves correct items", () => {
+  it("batch delta with remove + add preserves correct items", () => {
     //  Before:  [alice, bob, carol]
     //  Delta:   remove alice (index 0), add dave (index 2)
     //  After:   [bob, carol, dave]
@@ -203,7 +203,7 @@ describe("vue/useAll", () => {
     scope.stop();
   });
 
-  it("VU-ALL-09: batch delta with two removes preserves survivors", () => {
+  it("batch delta with two removes preserves survivors", () => {
     //  Before:  [alice, bob, carol, dave]
     //  Delta:   remove alice (index 0), remove carol (index 2)
     //  After:   [bob, dave]
@@ -247,7 +247,7 @@ describe("vue/useAll", () => {
     scope.stop();
   });
 
-  it("VU-ALL-10: updated item changes position, array reorders correctly", () => {
+  it("updated item changes position, array reorders correctly", () => {
     //  Before: [alice, bob, carol]
     //  Delta:  alice updated and moved to end (e.g. sort order changed)
     //  After:  [bob, carol, alice']


### PR DESCRIPTION
## Summary
- `getSession()` (Svelte) now returns `{ current: Session | null }` — a getter handle that always reads from the underlying `$state`, so session changes propagate to any consumer holding the handle without destroying the provider.
- `useSession()` (Vue) now returns `ComputedRef<Session | null>` derived from the injected `clientRef` shallowRef, so `triggerRef()` calls from `onAuthChanged` update all template and computed consumers automatically.

## Test plan
- [ ] Run `pnpm exec vitest run --config vitest.config.svelte.ts` — all Svelte tests pass
- [ ] Run `pnpm exec vitest run --config vitest.config.ts src/vue/` — all Vue tests pass