### PR TITLE
Add on-device integration test runner for React Native (Maestro)

### DIFF
--- a/.changeset/expo-crypto-random-values.md
+++ b/.changeset/expo-crypto-random-values.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+`jazz-tools/expo/polyfills` now installs `globalThis.crypto.getRandomValues` from `expo-crypto` when React Native/Hermes does not provide `globalThis.crypto`, fixing anonymous/local-first `createDb({ appId })` startup in Expo apps.

--- a/.changeset/rn-batched-tick-macrotask.md
+++ b/.changeset/rn-batched-tick-macrotask.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Schedule React Native `batchedTick` callbacks on a macrotask so repeated native tick requests do not starve timers, React rendering, or runner timeouts.

--- a/.github/workflows/expo-android-integration-e2e.yml
+++ b/.github/workflows/expo-android-integration-e2e.yml
@@ -1,0 +1,133 @@
+name: Expo Android Integration Tests (Maestro Cloud)
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - changeset-release/*
+  pull_request:
+    branches: [main]
+    paths:
+      - crates/jazz-rn/**
+      - packages/jazz-tools/src/react-native/**
+      - dev/integration-tests-expo/**
+      - dev/maestro/integration-tests/**
+      - .github/workflows/expo-android-integration-e2e.yml
+
+concurrency:
+  group: expo-android-integration-e2e-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CACHE_SCOPE_REPOSITORY_ID: ${{ github.event.pull_request.head.repo.id || github.repository_id }}
+
+jobs:
+  build-rn:
+    name: Build jazz-rn (Android) artifacts
+    uses: ./.github/workflows/rn-build-reusable.yml
+    with:
+      concurrency: e2e-integration-rn
+      disableAndroid: false
+      disableIOS: true
+
+  expo-android-integration-e2e:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs:
+      - build-rn
+    timeout-minutes: 60
+    env:
+      COREPACK_HOME: /home/runner/.local/share/corepack
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Source Code
+        uses: ./.github/actions/source-code/
+
+      - name: Download React Native Android artifact
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: jazz-rn-android
+          path: crates/jazz-rn
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: 1.93.1
+          targets: wasm32-unknown-unknown
+
+      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
+        with:
+          tool: wasm-pack@0.13.1
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-on-failure: true
+          key: repo-${{ env.CACHE_SCOPE_REPOSITORY_ID }}
+
+      - name: Build Expo E2E JS dependencies
+        run: |
+          pnpm --filter jazz-wasm run build
+          pnpm --filter jazz-tools run build:runtime
+
+      - name: Typecheck the integration-tests app
+        working-directory: dev/integration-tests-expo
+        run: pnpm exec tsc --noEmit
+
+      - name: Expo prebuild (Android)
+        run: pnpm --filter integration-tests-expo run verify:expo:android
+
+      - name: Write Gradle cache scope
+        run: echo "${{ env.CACHE_SCOPE_REPOSITORY_ID }}" > .github-cache-scope
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+          cache-dependency-path: |
+            .github-cache-scope
+            dev/integration-tests-expo/android/**/*.gradle*
+            dev/integration-tests-expo/android/gradle/wrapper/gradle-wrapper.properties
+            crates/jazz-rn/android/**/*.gradle*
+            crates/jazz-rn/android/gradle.properties
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+
+      - name: Install Android NDK
+        run: |
+          set -euo pipefail
+
+          SDK_ROOT="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-}}"
+          if [ -z "$SDK_ROOT" ]; then
+            echo "::error::ANDROID_SDK_ROOT and ANDROID_HOME are both unset"
+            exit 1
+          fi
+
+          export ANDROID_SDK_ROOT="$SDK_ROOT"
+
+          rm -rf "${SDK_ROOT}/ndk/27.1.12297006"
+          rm -rf "${SDK_ROOT}/.temp"
+          rm -rf "${HOME}/.android/cache"
+
+          set +o pipefail
+          yes | sdkmanager --licenses >/dev/null
+          set -o pipefail
+          sdkmanager --install "ndk;27.1.12297006"
+
+      - name: Build release APK
+        working-directory: dev/integration-tests-expo/android
+        run: chmod +x gradlew && ./gradlew :app:assembleRelease --build-cache --no-daemon
+
+      - name: Run Maestro Cloud flows
+        id: maestro
+        uses: mobile-dev-inc/action-maestro-cloud@34906065ba3e85fd57ed533b178187eefb042aed # v2
+        with:
+          api-key: ${{ secrets.MAESTRO_KEY }}
+          project-id: ${{ secrets.MAESTRO_PROJECT_ID }}
+          app-file: dev/integration-tests-expo/android/app/build/outputs/apk/release/app-release.apk
+          workspace: dev/maestro/integration-tests

--- a/dev/integration-tests-expo/.gitignore
+++ b/dev/integration-tests-expo/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+.expo/
+dist/
+/android
+/ios
+*.log

--- a/dev/integration-tests-expo/App.tsx
+++ b/dev/integration-tests-expo/App.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import { SafeAreaView, StatusBar, StyleSheet } from "react-native";
+import { TestRunnerScreen } from "./ui/TestRunnerScreen";
+import { suites } from "./tests/_registry";
+
+// No JazzProvider: the runner creates a fresh local `Db` per test via
+// `createDb` directly. Runtime polyfills are installed in index.js.
+export default function App() {
+  return (
+    <SafeAreaView style={styles.container}>
+      <StatusBar barStyle="dark-content" />
+      <TestRunnerScreen suites={suites} />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: "#f4f4f4" },
+});

--- a/dev/integration-tests-expo/README.md
+++ b/dev/integration-tests-expo/README.md
@@ -1,0 +1,67 @@
+# integration-tests-expo
+
+An Expo app that **is** an on-device integration-test runner for the Jazz React
+Native client (`jazz-rn`). It mirrors the browser integration tests
+(`packages/jazz-tools/tests/browser/**`) so the same kinds of behaviours — bulk
+writes, queries, subscriptions, relations, durability — are exercised against the
+real native runtime.
+
+It lives under `dev/` (not `examples/`) because it is internal QA tooling, not a
+user-facing showcase.
+
+## How it works
+
+- On launch the app runs every suite in `tests/_registry.ts` **sequentially** and
+  renders each test as a row that flips `pending → running → PASS/FAIL`.
+- Each test gets a fresh, **local-only** `Db` (`createDb({ appId })`, no server) and
+  has it shut down afterwards. Default-allow permissions mean no server or policy
+  setup is needed.
+- When every test passes, a `suite-passed` element renders. If any test fails (or the
+  app freezes), it never appears.
+
+## Maestro / CI
+
+`dev/maestro/integration-tests/integration_tests.yaml` launches the app and waits for
+`suite-passed`; a red test or a hang makes the wait time out and the flow throw. The
+GitHub workflow `expo-android-integration-e2e.yml` builds a release APK and runs that
+flow on Maestro Cloud (Android). No server, sandbox, or secrets beyond the Maestro
+key.
+
+## Run locally
+
+```bash
+pnpm --filter integration-tests-expo ios      # or: android
+```
+
+The runner starts automatically; watch the rows turn green.
+
+## Unit tests (the runner itself, in Node)
+
+The pure-TS runner modules (`runner/expect.ts`, `runner/support.ts`,
+`runner/harness.ts`) are unit-tested in Node — they have no RN imports:
+
+```bash
+pnpm --filter integration-tests-expo test
+```
+
+## Add a test
+
+1. Create `tests/<name>.suite.ts`:
+
+   ```ts
+   import { defineSuite } from "../runner/harness";
+   import { app } from "../schema";
+
+   export default defineSuite("<name>", ({ test }) => {
+     test("does a thing", async ({ db, expect, waitForQuery }) => {
+       db.insert(app.todos, { title: "x", done: false });
+       const rows = await waitForQuery(db, app.todos, (r) => r.length === 1, "one lands");
+       expect(rows).toHaveLength(1);
+     });
+   });
+   ```
+
+2. Register it in `tests/_registry.ts`.
+
+Add tables to `schema.ts` (public DSL) as needed. Assertions use the bundled
+Jest-style `expect` shim in `runner/expect.ts`.

--- a/dev/integration-tests-expo/app.json
+++ b/dev/integration-tests-expo/app.json
@@ -1,0 +1,16 @@
+{
+  "expo": {
+    "name": "integration-tests-expo",
+    "slug": "integration-tests-expo",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "jsEngine": "hermes",
+    "newArchEnabled": true,
+    "android": {
+      "package": "dev.jazz.integrationtests"
+    },
+    "ios": {
+      "bundleIdentifier": "dev.jazz.integrationtests"
+    }
+  }
+}

--- a/dev/integration-tests-expo/babel.config.js
+++ b/dev/integration-tests-expo/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: [["babel-preset-expo", { unstable_transformImportMeta: true }]],
+  };
+};

--- a/dev/integration-tests-expo/index.js
+++ b/dev/integration-tests-expo/index.js
@@ -1,0 +1,4 @@
+import "jazz-tools/expo/polyfills";
+import registerRootComponent from "expo/src/launch/registerRootComponent";
+import App from "./App";
+registerRootComponent(App);

--- a/dev/integration-tests-expo/metro.config.mjs
+++ b/dev/integration-tests-expo/metro.config.mjs
@@ -1,0 +1,17 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { getDefaultConfig } = require("expo/metro-config");
+
+const projectRoot = path.dirname(fileURLToPath(import.meta.url));
+
+const config = getDefaultConfig(projectRoot);
+
+// pnpm uses symlinks for hoisted packages.
+config.resolver.unstable_enableSymlinks = true;
+
+// No Jazz dev server: these integration tests run fully local (no serverUrl),
+// so we deliberately omit `withJazz` from the Metro config.
+export default config;

--- a/dev/integration-tests-expo/package.json
+++ b/dev/integration-tests-expo/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "integration-tests-expo",
+  "version": "0.1.0",
+  "private": true,
+  "main": "./index.js",
+  "scripts": {
+    "start": "expo start --clear",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "build": "tsc --noEmit",
+    "test": "vitest run --config vitest.config.ts",
+    "prebuild": "expo prebuild --clean",
+    "verify:expo:android": "CI=1 expo prebuild --platform android --clean --no-install"
+  },
+  "dependencies": {
+    "expo": "^54.0.0",
+    "expo-crypto": "~14.0.0",
+    "expo-secure-store": "~14.0.0",
+    "jazz-rn": "workspace:*",
+    "jazz-tools": "workspace:*",
+    "metro-runtime": "0.83.3",
+    "react": "19.2.4",
+    "react-native": "0.81.5"
+  },
+  "devDependencies": {
+    "@babel/plugin-transform-flow-strip-types": "^7.27.1",
+    "@types/react": "^19.0.0",
+    "babel-preset-expo": "~54.0.10",
+    "typescript": "catalog:default",
+    "vitest": "catalog:default"
+  }
+}

--- a/dev/integration-tests-expo/runner/expect.test.ts
+++ b/dev/integration-tests-expo/runner/expect.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect as v } from "vitest";
+import { expect } from "./expect";
+
+describe("expect shim", () => {
+  it("toBe / not.toBe", () => {
+    expect(2).toBe(2);
+    expect(2).not.toBe(3);
+    v(() => expect(2).toBe(3)).toThrow();
+    v(() => expect(2).not.toBe(2)).toThrow();
+  });
+
+  it("toEqual deep", () => {
+    expect({ a: [1, { b: 2 }] }).toEqual({ a: [1, { b: 2 }] });
+    expect([1, 2, 3]).toEqual([1, 2, 3]);
+    v(() => expect({ a: 1 }).toEqual({ a: 2 })).toThrow();
+    v(() => expect({ a: 1 }).toEqual({ a: 1, b: 2 })).toThrow();
+  });
+
+  it("toMatchObject subset", () => {
+    expect({ id: "x", title: "t", done: false }).toMatchObject({ title: "t", done: false });
+    expect({ nested: { a: 1, b: 2 } }).toMatchObject({ nested: { a: 1 } });
+    v(() => expect({ title: "t" }).toMatchObject({ title: "z" })).toThrow();
+  });
+
+  it("toHaveLength / toContain", () => {
+    expect([1, 2, 3]).toHaveLength(3);
+    expect([1, 2, 3]).toContain(2);
+    expect("hello").toContain("ell");
+    expect([{ id: "a" }]).toContain({ id: "a" });
+    v(() => expect([1]).toHaveLength(2)).toThrow();
+    v(() => expect([1, 2]).toContain(9)).toThrow();
+  });
+
+  it("comparisons and nullish", () => {
+    expect(5).toBeGreaterThan(4);
+    expect(5).toBeGreaterThanOrEqual(5);
+    expect(null).toBeNull();
+    expect(1).toBeDefined();
+    expect(undefined).toBeUndefined();
+    expect(0).toBeFalsy();
+    expect("x").toBeTruthy();
+    v(() => expect(3).toBeGreaterThan(4)).toThrow();
+  });
+});

--- a/dev/integration-tests-expo/runner/expect.ts
+++ b/dev/integration-tests-expo/runner/expect.ts
@@ -1,0 +1,122 @@
+// A tiny, Hermes-safe, Jest-style assertion shim. Only the matchers our
+// integration tests use are implemented. No V8-only APIs (no
+// Error.captureStackTrace), so it runs identically on Node and Hermes.
+
+export interface Matchers {
+  toBe(expected: unknown): void;
+  toEqual(expected: unknown): void;
+  toMatchObject(expected: Record<string, unknown>): void;
+  toHaveLength(expected: number): void;
+  toContain(expected: unknown): void;
+  toBeGreaterThan(expected: number): void;
+  toBeGreaterThanOrEqual(expected: number): void;
+  toBeDefined(): void;
+  toBeUndefined(): void;
+  toBeNull(): void;
+  toBeTruthy(): void;
+  toBeFalsy(): void;
+  readonly not: Matchers;
+}
+
+export type Expect = (actual: unknown) => Matchers;
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v) && !(v instanceof Uint8Array);
+}
+
+export function deepEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (a instanceof Uint8Array || b instanceof Uint8Array) {
+    if (!(a instanceof Uint8Array) || !(b instanceof Uint8Array) || a.length !== b.length)
+      return false;
+    for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+    return true;
+  }
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+    return a.every((x, i) => deepEqual(x, b[i]));
+  }
+  if (isPlainObject(a) && isPlainObject(b)) {
+    const ak = Object.keys(a);
+    const bk = Object.keys(b);
+    if (ak.length !== bk.length) return false;
+    return ak.every((k) => Object.prototype.hasOwnProperty.call(b, k) && deepEqual(a[k], b[k]));
+  }
+  return false;
+}
+
+function subsetMatch(actual: unknown, expected: Record<string, unknown>): boolean {
+  if (!isPlainObject(actual)) return false;
+  return Object.keys(expected).every((k) => {
+    const ev = expected[k];
+    const av = actual[k];
+    if (isPlainObject(ev)) return subsetMatch(av, ev);
+    return deepEqual(av, ev);
+  });
+}
+
+function fmt(v: unknown): string {
+  try {
+    return JSON.stringify(v) ?? String(v);
+  } catch {
+    return String(v);
+  }
+}
+
+function makeMatchers(actual: unknown, negate: boolean): Matchers {
+  const assert = (pass: boolean, describe: string) => {
+    if (pass === negate) {
+      throw new Error(`expected ${fmt(actual)} ${negate ? "not " : ""}${describe}`);
+    }
+  };
+  return {
+    toBe(expected) {
+      assert(Object.is(actual, expected), `to be ${fmt(expected)}`);
+    },
+    toEqual(expected) {
+      assert(deepEqual(actual, expected), `to equal ${fmt(expected)}`);
+    },
+    toMatchObject(expected) {
+      assert(subsetMatch(actual, expected), `to match object ${fmt(expected)}`);
+    },
+    toHaveLength(expected) {
+      const len = (actual as { length?: number } | null | undefined)?.length;
+      assert(len === expected, `to have length ${expected} (got ${fmt(len)})`);
+    },
+    toContain(expected) {
+      let pass = false;
+      if (Array.isArray(actual)) pass = actual.some((x) => deepEqual(x, expected));
+      else if (typeof actual === "string") pass = actual.includes(String(expected));
+      assert(pass, `to contain ${fmt(expected)}`);
+    },
+    toBeGreaterThan(expected) {
+      assert(typeof actual === "number" && actual > expected, `to be greater than ${expected}`);
+    },
+    toBeGreaterThanOrEqual(expected) {
+      assert(
+        typeof actual === "number" && actual >= expected,
+        `to be greater than or equal to ${expected}`,
+      );
+    },
+    toBeDefined() {
+      assert(actual !== undefined, `to be defined`);
+    },
+    toBeUndefined() {
+      assert(actual === undefined, `to be undefined`);
+    },
+    toBeNull() {
+      assert(actual === null, `to be null`);
+    },
+    toBeTruthy() {
+      assert(Boolean(actual), `to be truthy`);
+    },
+    toBeFalsy() {
+      assert(!actual, `to be falsy`);
+    },
+    get not() {
+      return makeMatchers(actual, !negate);
+    },
+  };
+}
+
+export const expect: Expect = (actual) => makeMatchers(actual, false);

--- a/dev/integration-tests-expo/runner/harness.test.ts
+++ b/dev/integration-tests-expo/runner/harness.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { defineSuite, runSuites, slugify, summarize } from "./harness";
+import type { TestResult } from "./types";
+
+describe("slugify", () => {
+  it("normalizes names to stable testID segments", () => {
+    expect(slugify("Writes 100 todos!")).toBe("writes-100-todos");
+  });
+});
+
+describe("runSuites", () => {
+  it("runs sequentially; records pass/fail/timeout; isolates + shuts down a db per test", async () => {
+    const appIds: string[] = [];
+    let shutdowns = 0;
+
+    const createDb = async (config: { appId: string }) => {
+      appIds.push(config.appId);
+      return {
+        all: async () => [],
+        shutdown: async () => {
+          shutdowns += 1;
+        },
+      } as any;
+    };
+
+    const updates: TestResult[][] = [];
+    const onUpdate = (results: TestResult[]) => updates.push(results.map((r) => ({ ...r })));
+
+    const alpha = defineSuite("alpha", ({ test }) => {
+      test("passes", async ({ expect: e }) => {
+        e(1).toBe(1);
+      });
+      test("fails", async ({ expect: e }) => {
+        e(1).toBe(2);
+      });
+    });
+    const beta = defineSuite("beta", ({ test }) => {
+      test("hangs", async () => {
+        await new Promise(() => {});
+      });
+    });
+
+    const results = await runSuites([alpha, beta], { createDb, onUpdate, perTestTimeoutMs: 100 });
+
+    expect(results.map((r) => r.status)).toEqual(["passed", "failed", "failed"]);
+    expect(results.map((r) => r.slug)).toEqual(["alpha-passes", "alpha-fails", "beta-hangs"]);
+    expect(results[1]!.error).toBeTruthy();
+    expect(results[2]!.error).toMatch(/Timeout/i);
+
+    expect(new Set(appIds).size).toBe(3);
+    expect(shutdowns).toBe(3);
+    expect(results.every((r) => typeof r.durationMs === "number")).toBe(true);
+
+    expect(summarize(results)).toEqual({
+      total: 3,
+      passed: 1,
+      failed: 2,
+      done: true,
+      allPassed: false,
+    });
+
+    const sawRunningBeforeTerminal = updates.some((snapshot) =>
+      snapshot.some((r) => r.status === "running"),
+    );
+    expect(sawRunningBeforeTerminal).toBe(true);
+  });
+
+  it("summarize reports allPassed when everything passes", async () => {
+    const createDb = async () => ({ all: async () => [], shutdown: async () => {} }) as any;
+    const suite = defineSuite("s", ({ test }) => {
+      test("ok", async ({ expect: e }) => {
+        e(true).toBeTruthy();
+      });
+    });
+    const results = await runSuites([suite], { createDb, onUpdate: () => {} });
+    expect(summarize(results).allPassed).toBe(true);
+  });
+});

--- a/dev/integration-tests-expo/runner/harness.test.ts
+++ b/dev/integration-tests-expo/runner/harness.test.ts
@@ -85,6 +85,27 @@ describe("runSuites", () => {
     expect(createDbCalls).toBe(2);
   });
 
+  it("publishes progress steps around db creation and test body execution", async () => {
+    const updates: TestResult[][] = [];
+    const suite = defineSuite("alpha", ({ test }) => {
+      test("reports progress", async ({ expect: e }) => {
+        e(true).toBe(true);
+      });
+    });
+
+    await runSuites([suite], {
+      createDb: async () => ({ all: async () => [], shutdown: async () => {} }) as any,
+      onUpdate: (next) => updates.push(next.map((r) => ({ ...r }))),
+    });
+
+    const progressSteps = updates
+      .flatMap((snapshot) => snapshot.map((result) => result.currentStep))
+      .filter((step): step is string => !!step);
+
+    expect(progressSteps).toContain("creating db");
+    expect(progressSteps).toContain("running test body");
+  });
+
   it("runs sequentially; records pass/fail/timeout; isolates + shuts down a db per test", async () => {
     const appIds: string[] = [];
     let shutdowns = 0;

--- a/dev/integration-tests-expo/runner/harness.test.ts
+++ b/dev/integration-tests-expo/runner/harness.test.ts
@@ -57,6 +57,34 @@ describe("runSuites", () => {
     expect(updates.at(-1)).toEqual(results);
   });
 
+  it("times out a hung db creation and continues to later tests", async () => {
+    let createDbCalls = 0;
+    const suite = defineSuite("alpha", ({ test }) => {
+      test("db hangs", async ({ expect: e }) => {
+        e(true).toBe(true);
+      });
+      test("runs after timeout", async ({ expect: e }) => {
+        e(true).toBe(true);
+      });
+    });
+
+    const results = await runSuites([suite], {
+      createDb: async () => {
+        createDbCalls += 1;
+        if (createDbCalls === 1) {
+          await new Promise(() => {});
+        }
+        return { all: async () => [], shutdown: async () => {} } as any;
+      },
+      onUpdate: () => {},
+      perTestTimeoutMs: 100,
+    });
+
+    expect(results.map((r) => r.status)).toEqual(["failed", "passed"]);
+    expect(results[0]!.error).toMatch(/Timeout/i);
+    expect(createDbCalls).toBe(2);
+  });
+
   it("runs sequentially; records pass/fail/timeout; isolates + shuts down a db per test", async () => {
     const appIds: string[] = [];
     let shutdowns = 0;

--- a/dev/integration-tests-expo/runner/harness.test.ts
+++ b/dev/integration-tests-expo/runner/harness.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { defineSuite, runSuites, slugify, summarize } from "./harness";
+import { initialResultsForSuites, defineSuite, runSuites, slugify, summarize } from "./harness";
 import type { TestResult } from "./types";
 
 describe("slugify", () => {
@@ -9,6 +9,54 @@ describe("slugify", () => {
 });
 
 describe("runSuites", () => {
+  it("initialResultsForSuites exposes pending rows before the runner effect starts", () => {
+    const suite = defineSuite("alpha", ({ test }) => {
+      test("first", async () => {});
+      test("second", async () => {});
+    });
+
+    expect(initialResultsForSuites([suite])).toEqual([
+      {
+        suite: "alpha",
+        name: "first",
+        slug: "alpha-first",
+        status: "pending",
+      },
+      {
+        suite: "alpha",
+        name: "second",
+        slug: "alpha-second",
+        status: "pending",
+      },
+    ]);
+  });
+
+  it("reports a terminal failure when no tests are registered", async () => {
+    let createDbCalls = 0;
+    const updates: TestResult[][] = [];
+
+    const results = await runSuites([], {
+      createDb: async () => {
+        createDbCalls += 1;
+        return { all: async () => [], shutdown: async () => {} } as any;
+      },
+      onUpdate: (next) => updates.push(next.map((r) => ({ ...r }))),
+    });
+
+    expect(createDbCalls).toBe(0);
+    expect(results).toHaveLength(1);
+    expect(results[0]!.status).toBe("failed");
+    expect(results[0]!.error).toMatch(/No tests registered/);
+    expect(summarize(results)).toEqual({
+      total: 1,
+      passed: 0,
+      failed: 1,
+      done: true,
+      allPassed: false,
+    });
+    expect(updates.at(-1)).toEqual(results);
+  });
+
   it("runs sequentially; records pass/fail/timeout; isolates + shuts down a db per test", async () => {
     const appIds: string[] = [];
     let shutdowns = 0;

--- a/dev/integration-tests-expo/runner/harness.ts
+++ b/dev/integration-tests-expo/runner/harness.ts
@@ -11,6 +11,7 @@ export interface TestCtx {
   withTimeout: typeof support.withTimeout;
   sleep: typeof support.sleep;
   uniqueAppId: typeof support.uniqueAppId;
+  step: (message: string) => Promise<void>;
 }
 
 export type TestBody = (ctx: TestCtx) => Promise<void>;
@@ -102,14 +103,22 @@ export async function runSuites(suites: Suite[], deps: RunnerDeps): Promise<Test
 
   for (const { body, result } of items) {
     result.status = "running";
+    result.currentStep = "starting";
     deps.onUpdate([...results]);
 
     const started = Date.now();
     let db: Db | undefined;
+    const step = async (message: string) => {
+      result.currentStep = message;
+      deps.onUpdate([...results]);
+      await support.sleep(0);
+    };
     try {
       await support.withTimeout(
         (async () => {
+          await step("creating db");
           db = await deps.createDb({ appId: support.uniqueAppId(result.slug) });
+          await step("running test body");
           const ctx: TestCtx = {
             db,
             expect,
@@ -118,6 +127,7 @@ export async function runSuites(suites: Suite[], deps: RunnerDeps): Promise<Test
             withTimeout: support.withTimeout,
             sleep: support.sleep,
             uniqueAppId: support.uniqueAppId,
+            step,
           };
           await body(ctx);
         })(),
@@ -125,6 +135,7 @@ export async function runSuites(suites: Suite[], deps: RunnerDeps): Promise<Test
         `${result.suite} › ${result.name}`,
       );
       result.status = "passed";
+      result.currentStep = undefined;
     } catch (error) {
       result.status = "failed";
       result.error = error instanceof Error ? error.message : String(error);

--- a/dev/integration-tests-expo/runner/harness.ts
+++ b/dev/integration-tests-expo/runner/harness.ts
@@ -1,0 +1,109 @@
+import type { Db } from "jazz-tools/react-native";
+import { expect, type Expect } from "./expect";
+import * as support from "./support";
+import type { SuiteSummary, TestResult } from "./types";
+
+export interface TestCtx {
+  db: Db;
+  expect: Expect;
+  waitForQuery: typeof support.waitForQuery;
+  waitForCondition: typeof support.waitForCondition;
+  withTimeout: typeof support.withTimeout;
+  sleep: typeof support.sleep;
+  uniqueAppId: typeof support.uniqueAppId;
+}
+
+export type TestBody = (ctx: TestCtx) => Promise<void>;
+
+export interface Suite {
+  name: string;
+  tests: { name: string; body: TestBody }[];
+}
+
+export interface RunnerDeps {
+  /** Injected so the runner stays free of RN imports (Node-unit-testable). */
+  createDb: (config: { appId: string }) => Promise<Db>;
+  onUpdate: (results: TestResult[]) => void;
+  perTestTimeoutMs?: number;
+}
+
+export function slugify(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function defineSuite(
+  name: string,
+  register: (api: { test: (name: string, body: TestBody) => void }) => void,
+): Suite {
+  const tests: { name: string; body: TestBody }[] = [];
+  register({ test: (testName, body) => tests.push({ name: testName, body }) });
+  return { name, tests };
+}
+
+export function summarize(results: TestResult[]): SuiteSummary {
+  const total = results.length;
+  const passed = results.filter((r) => r.status === "passed").length;
+  const failed = results.filter((r) => r.status === "failed").length;
+  const done =
+    results.length > 0 && results.every((r) => r.status === "passed" || r.status === "failed");
+  return { total, passed, failed, done, allPassed: done && failed === 0 };
+}
+
+export async function runSuites(suites: Suite[], deps: RunnerDeps): Promise<TestResult[]> {
+  const perTestTimeoutMs = deps.perTestTimeoutMs ?? 30_000;
+
+  const items = suites.flatMap((suite) =>
+    suite.tests.map((t) => ({
+      body: t.body,
+      result: {
+        suite: suite.name,
+        name: t.name,
+        slug: `${slugify(suite.name)}-${slugify(t.name)}`,
+        status: "pending" as const,
+      } as TestResult,
+    })),
+  );
+  const results = items.map((i) => i.result);
+  deps.onUpdate([...results]);
+
+  for (const { body, result } of items) {
+    result.status = "running";
+    deps.onUpdate([...results]);
+
+    const started = Date.now();
+    let db: Db | undefined;
+    try {
+      db = await deps.createDb({ appId: support.uniqueAppId(result.slug) });
+      const ctx: TestCtx = {
+        db,
+        expect,
+        waitForQuery: support.waitForQuery,
+        waitForCondition: support.waitForCondition,
+        withTimeout: support.withTimeout,
+        sleep: support.sleep,
+        uniqueAppId: support.uniqueAppId,
+      };
+      await support.withTimeout(body(ctx), perTestTimeoutMs, `${result.suite} › ${result.name}`);
+      result.status = "passed";
+    } catch (error) {
+      result.status = "failed";
+      result.error = error instanceof Error ? error.message : String(error);
+    } finally {
+      if (db) {
+        try {
+          await db.shutdown();
+        } catch {
+          // best effort — a failing test should still report its own error
+        }
+      }
+      result.durationMs = Date.now() - started;
+      deps.onUpdate([...results]);
+    }
+  }
+
+  return results;
+}

--- a/dev/integration-tests-expo/runner/harness.ts
+++ b/dev/integration-tests-expo/runner/harness.ts
@@ -107,17 +107,23 @@ export async function runSuites(suites: Suite[], deps: RunnerDeps): Promise<Test
     const started = Date.now();
     let db: Db | undefined;
     try {
-      db = await deps.createDb({ appId: support.uniqueAppId(result.slug) });
-      const ctx: TestCtx = {
-        db,
-        expect,
-        waitForQuery: support.waitForQuery,
-        waitForCondition: support.waitForCondition,
-        withTimeout: support.withTimeout,
-        sleep: support.sleep,
-        uniqueAppId: support.uniqueAppId,
-      };
-      await support.withTimeout(body(ctx), perTestTimeoutMs, `${result.suite} › ${result.name}`);
+      await support.withTimeout(
+        (async () => {
+          db = await deps.createDb({ appId: support.uniqueAppId(result.slug) });
+          const ctx: TestCtx = {
+            db,
+            expect,
+            waitForQuery: support.waitForQuery,
+            waitForCondition: support.waitForCondition,
+            withTimeout: support.withTimeout,
+            sleep: support.sleep,
+            uniqueAppId: support.uniqueAppId,
+          };
+          await body(ctx);
+        })(),
+        perTestTimeoutMs,
+        `${result.suite} › ${result.name}`,
+      );
       result.status = "passed";
     } catch (error) {
       result.status = "failed";

--- a/dev/integration-tests-expo/runner/harness.ts
+++ b/dev/integration-tests-expo/runner/harness.ts
@@ -53,20 +53,50 @@ export function summarize(results: TestResult[]): SuiteSummary {
   return { total, passed, failed, done, allPassed: done && failed === 0 };
 }
 
+function startupFailure(message: string): TestResult {
+  return {
+    suite: "runner",
+    name: "startup",
+    slug: "runner-startup",
+    status: "failed",
+    error: message,
+    durationMs: 0,
+  };
+}
+
+function collectItems(suites: Suite[]) {
+  const items: { body: TestBody; result: TestResult }[] = [];
+  for (const suite of suites) {
+    for (const t of suite.tests) {
+      items.push({
+        body: t.body,
+        result: {
+          suite: suite.name,
+          name: t.name,
+          slug: `${slugify(suite.name)}-${slugify(t.name)}`,
+          status: "pending" as const,
+        } as TestResult,
+      });
+    }
+  }
+  return items;
+}
+
+export function initialResultsForSuites(suites: Suite[]): TestResult[] {
+  const results = collectItems(suites).map((i) => i.result);
+  return results.length > 0 ? results : [startupFailure("No tests registered")];
+}
+
 export async function runSuites(suites: Suite[], deps: RunnerDeps): Promise<TestResult[]> {
   const perTestTimeoutMs = deps.perTestTimeoutMs ?? 30_000;
 
-  const items = suites.flatMap((suite) =>
-    suite.tests.map((t) => ({
-      body: t.body,
-      result: {
-        suite: suite.name,
-        name: t.name,
-        slug: `${slugify(suite.name)}-${slugify(t.name)}`,
-        status: "pending" as const,
-      } as TestResult,
-    })),
-  );
+  const items = collectItems(suites);
+  if (items.length === 0) {
+    const results = [startupFailure("No tests registered")];
+    deps.onUpdate([...results]);
+    return results;
+  }
+
   const results = items.map((i) => i.result);
   deps.onUpdate([...results]);
 

--- a/dev/integration-tests-expo/runner/support.test.ts
+++ b/dev/integration-tests-expo/runner/support.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { sleep, uniqueAppId, waitForCondition, withTimeout, waitForQuery } from "./support";
+
+describe("support", () => {
+  it("uniqueAppId returns distinct, labelled ids", () => {
+    const a = uniqueAppId("x");
+    const b = uniqueAppId("x");
+    expect(a).not.toBe(b);
+    expect(a.startsWith("itest-x-")).toBe(true);
+  });
+
+  it("sleep resolves", async () => {
+    await sleep(10);
+  });
+
+  it("waitForCondition resolves when predicate flips true", async () => {
+    let flag = false;
+    setTimeout(() => {
+      flag = true;
+    }, 60);
+    await waitForCondition(() => flag, 1000, "flag");
+  });
+
+  it("waitForCondition rejects with the message on timeout", async () => {
+    await expect(waitForCondition(() => false, 120, "never-true")).rejects.toThrow(/never-true/);
+  });
+
+  it("withTimeout rejects after the deadline", async () => {
+    await expect(withTimeout(new Promise(() => {}), 80, "hang")).rejects.toThrow(/hang/);
+  });
+
+  it("withTimeout passes through a resolved value", async () => {
+    await expect(withTimeout(Promise.resolve(42), 1000, "ok")).resolves.toBe(42);
+  });
+
+  it("waitForQuery polls until the predicate is satisfied", async () => {
+    let n = 0;
+    const db = {
+      all: async <T>() => {
+        n += 1;
+        return Array.from({ length: n }, (_, i) => ({ id: String(i) })) as T[];
+      },
+    };
+    const rows = await waitForQuery<{ id: string }>(db, null, (r) => r.length >= 3, "three", 2000);
+    expect(rows.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("waitForQuery times out with the row count in the message", async () => {
+    const db = { all: async <T>() => [] as T[] };
+    await expect(waitForQuery(db, null, () => false, "empty", 120)).rejects.toThrow(
+      /lastRowsCount=0/,
+    );
+  });
+});

--- a/dev/integration-tests-expo/runner/support.ts
+++ b/dev/integration-tests-expo/runner/support.ts
@@ -1,0 +1,83 @@
+// Async polling/timeout helpers, mirrored from the browser test support layer
+// (packages/jazz-tools/tests/browser/support.ts). Pure JS — runs on Node and
+// Hermes. No RN imports here so it can be unit-tested in Node.
+
+export interface Queryable {
+  all<T>(query: unknown): Promise<T[]>;
+}
+
+export const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+let __seq = 0;
+export function uniqueAppId(label: string): string {
+  __seq += 1;
+  return `itest-${label}-${Date.now().toString(36)}-${__seq.toString(36)}`;
+}
+
+export async function waitForCondition(
+  check: () => boolean | Promise<boolean>,
+  timeoutMs: number,
+  message: string,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      if (await check()) return;
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(50);
+  }
+  const suffix = lastError ? `; lastError=${errMsg(lastError)}` : "";
+  throw new Error(`Timeout after ${timeoutMs}ms: ${message}${suffix}`);
+}
+
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  label: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`Timeout after ${timeoutMs}ms: ${label}`)),
+      timeoutMs,
+    );
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+export async function waitForQuery<T>(
+  db: Queryable,
+  query: unknown,
+  predicate: (rows: T[]) => boolean,
+  label: string,
+  timeoutMs = 10_000,
+): Promise<T[]> {
+  const deadline = Date.now() + timeoutMs;
+  let lastRows: T[] = [];
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      lastRows = await db.all<T>(query);
+      if (predicate(lastRows)) return lastRows;
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(100);
+  }
+  const suffix = lastError ? `; lastError=${errMsg(lastError)}` : "";
+  throw new Error(
+    `Timeout after ${timeoutMs}ms: ${label}; lastRowsCount=${lastRows.length}${suffix}`,
+  );
+}
+
+function errMsg(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/dev/integration-tests-expo/runner/types.ts
+++ b/dev/integration-tests-expo/runner/types.ts
@@ -1,0 +1,20 @@
+export type TestStatus = "pending" | "running" | "passed" | "failed";
+
+export interface TestResult {
+  suite: string;
+  name: string;
+  slug: string;
+  status: TestStatus;
+  error?: string;
+  durationMs?: number;
+}
+
+export interface SuiteSummary {
+  total: number;
+  passed: number;
+  failed: number;
+  /** Every test has reached a terminal (passed/failed) status. */
+  done: boolean;
+  /** done && no failures. This is what Maestro keys off of. */
+  allPassed: boolean;
+}

--- a/dev/integration-tests-expo/runner/types.ts
+++ b/dev/integration-tests-expo/runner/types.ts
@@ -6,6 +6,7 @@ export interface TestResult {
   slug: string;
   status: TestStatus;
   error?: string;
+  currentStep?: string;
   durationMs?: number;
 }
 

--- a/dev/integration-tests-expo/schema.ts
+++ b/dev/integration-tests-expo/schema.ts
@@ -1,0 +1,21 @@
+import { schema as s } from "jazz-tools";
+
+// Test tables built with the public DSL (no JSON-like definitions).
+const schema = {
+  projects: s.table({
+    name: s.string(),
+  }),
+  todos: s.table({
+    title: s.string(),
+    done: s.boolean().default(false),
+    priority: s.string().optional(),
+    projectId: s.ref("projects").optional(),
+  }),
+};
+
+type AppSchema = s.Schema<typeof schema>;
+
+export const app: s.App<AppSchema> = s.defineApp(schema);
+
+export type Todo = s.RowOf<typeof app.todos>;
+export type Project = s.RowOf<typeof app.projects>;

--- a/dev/integration-tests-expo/tests/_registry.ts
+++ b/dev/integration-tests-expo/tests/_registry.ts
@@ -1,0 +1,11 @@
+import type { Suite } from "../runner/harness";
+import bulkWrites from "./bulk-writes.suite";
+import crud from "./crud.suite";
+import queries from "./queries.suite";
+import subscriptions from "./subscriptions.suite";
+import relations from "./relations.suite";
+import durability from "./durability.suite";
+
+// Explicit, ordered list of suites. Add a new file + one line here to grow the
+// suite. Order is the order tests render and run on screen.
+export const suites: Suite[] = [bulkWrites, crud, queries, subscriptions, relations, durability];

--- a/dev/integration-tests-expo/tests/bulk-writes.suite.ts
+++ b/dev/integration-tests-expo/tests/bulk-writes.suite.ts
@@ -2,10 +2,14 @@ import { defineSuite } from "../runner/harness";
 import { app, type Todo } from "../schema";
 
 export default defineSuite("bulk writes", ({ test }) => {
-  test("writes 100 todos and reads them all back", async ({ db, expect, waitForQuery }) => {
+  test("writes 100 todos and reads them all back", async ({ db, expect, waitForQuery, step }) => {
     for (let i = 0; i < 100; i++) {
+      if (i === 0 || (i + 1) % 10 === 0) {
+        await step(`insert ${i + 1}/100`);
+      }
       db.insert(app.todos, { title: `t-${i}`, done: false });
     }
+    await step("query 100 todos");
     const rows = await waitForQuery<Todo>(
       db,
       app.todos,

--- a/dev/integration-tests-expo/tests/bulk-writes.suite.ts
+++ b/dev/integration-tests-expo/tests/bulk-writes.suite.ts
@@ -1,0 +1,18 @@
+import { defineSuite } from "../runner/harness";
+import { app, type Todo } from "../schema";
+
+export default defineSuite("bulk writes", ({ test }) => {
+  test("writes 100 todos and reads them all back", async ({ db, expect, waitForQuery }) => {
+    for (let i = 0; i < 100; i++) {
+      db.insert(app.todos, { title: `t-${i}`, done: false });
+    }
+    const rows = await waitForQuery<Todo>(
+      db,
+      app.todos,
+      (r) => r.length >= 100,
+      "100 todos land",
+      15_000,
+    );
+    expect(rows).toHaveLength(100);
+  });
+});

--- a/dev/integration-tests-expo/tests/crud.suite.ts
+++ b/dev/integration-tests-expo/tests/crud.suite.ts
@@ -1,0 +1,26 @@
+import { defineSuite } from "../runner/harness";
+import { app, type Todo } from "../schema";
+
+export default defineSuite("crud", ({ test }) => {
+  test("insert, update and delete round-trip", async ({ db, expect, waitForQuery }) => {
+    const { value: created } = db.insert(app.todos, { title: "original", done: false });
+    expect(created.id).toBeDefined();
+
+    db.update(app.todos, created.id, { done: true });
+    const updated = await waitForQuery<Todo>(
+      db,
+      app.todos.where({ id: { eq: created.id } }),
+      (r) => r.length === 1 && r[0]!.done === true,
+      "todo marked done",
+    );
+    expect(updated[0]!.title).toBe("original");
+
+    db.delete(app.todos, created.id);
+    await waitForQuery<Todo>(
+      db,
+      app.todos.where({ id: { eq: created.id } }),
+      (r) => r.length === 0,
+      "todo deleted",
+    );
+  });
+});

--- a/dev/integration-tests-expo/tests/durability.suite.ts
+++ b/dev/integration-tests-expo/tests/durability.suite.ts
@@ -1,0 +1,15 @@
+import { defineSuite } from "../runner/harness";
+import { app } from "../schema";
+
+export default defineSuite("durability", ({ test }) => {
+  test("insert resolves at the local tier and is queryable", async ({ db, expect }) => {
+    const row = await db
+      .insert(app.todos, { title: "durable", done: false })
+      .wait({ tier: "local" });
+    expect(row.id).toBeDefined();
+
+    const found = await db.one(app.todos.where({ id: { eq: row.id } }));
+    expect(found).not.toBeNull();
+    expect(found?.title).toBe("durable");
+  });
+});

--- a/dev/integration-tests-expo/tests/queries.suite.ts
+++ b/dev/integration-tests-expo/tests/queries.suite.ts
@@ -1,0 +1,31 @@
+import { defineSuite } from "../runner/harness";
+import { app, type Todo } from "../schema";
+
+export default defineSuite("queries", ({ test }) => {
+  test("filters by a condition", async ({ db, expect, waitForQuery }) => {
+    db.insert(app.todos, { title: "a", done: false });
+    db.insert(app.todos, { title: "b", done: true });
+    db.insert(app.todos, { title: "c", done: false });
+
+    const open = await waitForQuery<Todo>(
+      db,
+      app.todos.where({ done: false }),
+      (r) => r.length === 2,
+      "two open todos",
+    );
+    expect(open.every((t) => t.done === false)).toBe(true);
+  });
+
+  test("orders and limits", async ({ db, expect, waitForQuery }) => {
+    db.insert(app.todos, { title: "zeta", done: false });
+    db.insert(app.todos, { title: "alpha", done: false });
+    db.insert(app.todos, { title: "mike", done: false });
+
+    // Wait until all three have landed, then assert deterministic order + limit.
+    await waitForQuery<Todo>(db, app.todos, (r) => r.length === 3, "all three land");
+    const rows = await db.all(app.todos.orderBy("title", "asc").limit(2));
+    expect(rows).toHaveLength(2);
+    expect(rows[0]!.title).toBe("alpha");
+    expect(rows[1]!.title).toBe("mike");
+  });
+});

--- a/dev/integration-tests-expo/tests/relations.suite.ts
+++ b/dev/integration-tests-expo/tests/relations.suite.ts
@@ -1,0 +1,23 @@
+import { defineSuite } from "../runner/harness";
+import { app } from "../schema";
+
+type TodoWithProject = { id: string; title: string; project: { name: string } | null };
+
+export default defineSuite("relations", ({ test }) => {
+  test("includes a forward ref relation", async ({ db, expect, waitForQuery }) => {
+    const { value: project } = db.insert(app.projects, { name: "Acme" });
+    const { value: todo } = db.insert(app.todos, {
+      title: "ship it",
+      done: false,
+      projectId: project.id,
+    });
+
+    const rows = await waitForQuery<TodoWithProject>(
+      db,
+      app.todos.where({ id: { eq: todo.id } }).include({ project: true }),
+      (r) => r.length === 1 && r[0]!.project != null,
+      "todo with project included",
+    );
+    expect(rows[0]!.project?.name).toBe("Acme");
+  });
+});

--- a/dev/integration-tests-expo/tests/subscriptions.suite.ts
+++ b/dev/integration-tests-expo/tests/subscriptions.suite.ts
@@ -1,0 +1,32 @@
+import { defineSuite } from "../runner/harness";
+import { app } from "../schema";
+
+type Delta = { all: Array<{ id: string }>; delta: Array<{ kind: number; id: string }> };
+
+export default defineSuite("subscriptions", ({ test }) => {
+  test("emits add and update deltas", async ({ db, expect, waitForCondition }) => {
+    const deltas: Delta[] = [];
+    const unsubscribe = db.subscribeAll(app.todos, (d) => deltas.push(d as unknown as Delta));
+    try {
+      const { value: created } = db.insert(app.todos, { title: "watch me", done: false });
+
+      await waitForCondition(
+        () => deltas.some((d) => d.delta.some((c) => c.kind === 0 && c.id === created.id)),
+        5000,
+        "add delta",
+      );
+
+      db.update(app.todos, created.id, { done: true });
+      await waitForCondition(
+        () => deltas.some((d) => d.delta.some((c) => c.kind === 2 && c.id === created.id)),
+        5000,
+        "update delta",
+      );
+
+      const latest = deltas[deltas.length - 1]!;
+      expect(latest.all.some((t) => t.id === created.id)).toBe(true);
+    } finally {
+      unsubscribe();
+    }
+  });
+});

--- a/dev/integration-tests-expo/tsconfig.json
+++ b/dev/integration-tests-expo/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "jsx": "react-jsx",
+    "typeRoots": ["./node_modules/@types"]
+  },
+  "include": ["App.tsx", "runner/**/*", "tests/**/*", "ui/**/*", "schema.ts"],
+  "extends": "expo/tsconfig.base"
+}

--- a/dev/integration-tests-expo/ui/TestRunnerScreen.tsx
+++ b/dev/integration-tests-expo/ui/TestRunnerScreen.tsx
@@ -1,0 +1,128 @@
+import * as React from "react";
+import { ScrollView, StyleSheet, Text, View } from "react-native";
+import { createDb } from "jazz-tools/react-native";
+import { runSuites, summarize, type Suite } from "../runner/harness";
+import type { TestResult, TestStatus } from "../runner/types";
+
+export function TestRunnerScreen({ suites }: { suites: Suite[] }) {
+  const [results, setResults] = React.useState<TestResult[]>([]);
+  const started = React.useRef(false);
+
+  React.useEffect(() => {
+    if (started.current) return;
+    started.current = true;
+    void runSuites(suites, {
+      createDb: (config) => createDb({ appId: config.appId }),
+      onUpdate: (next) => setResults([...next]),
+    });
+  }, [suites]);
+
+  const summary = summarize(results);
+  const status = summary.done ? (summary.allPassed ? "PASSED" : "FAILED") : "RUNNING";
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Jazz RN integration tests</Text>
+      <Text testID="suite-status" style={[styles.status, statusColor(status)]}>
+        {status} · {summary.passed}/{summary.total}
+      </Text>
+
+      <ScrollView style={styles.list} contentContainerStyle={styles.listContent}>
+        {results.map((r) => (
+          <View key={r.slug} testID={`test-row-${r.slug}`} style={styles.row}>
+            <Text style={[styles.badge, badgeColor(r.status)]}>{badgeText(r.status)}</Text>
+            <View style={styles.rowBody}>
+              <Text style={styles.rowName}>
+                {r.suite} › {r.name}
+              </Text>
+              {r.status === "failed" && r.error ? (
+                <Text testID={`test-error-${r.slug}`} style={styles.error}>
+                  {r.error}
+                </Text>
+              ) : null}
+            </View>
+          </View>
+        ))}
+      </ScrollView>
+
+      {summary.done && summary.allPassed ? (
+        <View testID="suite-passed" style={styles.bannerPass}>
+          <Text style={styles.bannerText}>ALL {summary.total} PASSED</Text>
+        </View>
+      ) : null}
+
+      {summary.done && !summary.allPassed ? (
+        <View testID="suite-failed" style={styles.bannerFail}>
+          <Text style={styles.bannerText}>
+            {summary.failed} FAILED: {failedNames(results)}
+          </Text>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+function failedNames(results: TestResult[]): string {
+  return results
+    .filter((r) => r.status === "failed")
+    .map((r) => r.name)
+    .join(", ");
+}
+
+function badgeText(status: TestStatus): string {
+  switch (status) {
+    case "passed":
+      return "PASS";
+    case "failed":
+      return "FAIL";
+    case "running":
+      return "RUN";
+    default:
+      return "…";
+  }
+}
+
+function statusColor(status: string) {
+  if (status === "PASSED") return { color: "#15803d" };
+  if (status === "FAILED") return { color: "#b91c1c" };
+  return { color: "#1d4ed8" };
+}
+
+function badgeColor(status: TestStatus) {
+  switch (status) {
+    case "passed":
+      return { backgroundColor: "#15803d" };
+    case "failed":
+      return { backgroundColor: "#b91c1c" };
+    case "running":
+      return { backgroundColor: "#1d4ed8" };
+    default:
+      return { backgroundColor: "#9ca3af" };
+  }
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, paddingHorizontal: 16, paddingTop: 12, gap: 8 },
+  title: { fontSize: 20, fontWeight: "700", color: "#111827" },
+  status: { fontSize: 18, fontWeight: "700" },
+  list: { flex: 1 },
+  listContent: { gap: 6, paddingVertical: 8 },
+  row: { flexDirection: "row", alignItems: "flex-start", gap: 8 },
+  rowBody: { flex: 1 },
+  rowName: { fontSize: 14, color: "#111827" },
+  badge: {
+    color: "#fff",
+    fontSize: 11,
+    fontWeight: "700",
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 4,
+    overflow: "hidden",
+    minWidth: 44,
+    textAlign: "center",
+  },
+  error: { fontSize: 12, color: "#b91c1c", marginTop: 2 },
+  bannerPass: { backgroundColor: "#dcfce7", padding: 12, borderRadius: 8 },
+  bannerFail: { backgroundColor: "#fee2e2", padding: 12, borderRadius: 8 },
+  bannerText: { fontSize: 16, fontWeight: "700", color: "#111827" },
+});

--- a/dev/integration-tests-expo/ui/TestRunnerScreen.tsx
+++ b/dev/integration-tests-expo/ui/TestRunnerScreen.tsx
@@ -51,6 +51,11 @@ export function TestRunnerScreen({ suites }: { suites: Suite[] }) {
                   {r.error}
                 </Text>
               ) : null}
+              {r.status === "running" && r.currentStep ? (
+                <Text testID={`test-progress-${r.slug}`} style={styles.progress}>
+                  {r.currentStep}
+                </Text>
+              ) : null}
             </View>
           </View>
         ))}
@@ -133,6 +138,7 @@ const styles = StyleSheet.create({
     textAlign: "center",
   },
   error: { fontSize: 12, color: "#b91c1c", marginTop: 2 },
+  progress: { fontSize: 12, color: "#4b5563", marginTop: 2 },
   bannerPass: { backgroundColor: "#dcfce7", padding: 12, borderRadius: 8 },
   bannerFail: { backgroundColor: "#fee2e2", padding: 12, borderRadius: 8 },
   bannerText: { fontSize: 16, fontWeight: "700", color: "#111827" },

--- a/dev/integration-tests-expo/ui/TestRunnerScreen.tsx
+++ b/dev/integration-tests-expo/ui/TestRunnerScreen.tsx
@@ -1,19 +1,30 @@
 import * as React from "react";
 import { ScrollView, StyleSheet, Text, View } from "react-native";
 import { createDb } from "jazz-tools/react-native";
-import { runSuites, summarize, type Suite } from "../runner/harness";
+import { initialResultsForSuites, runSuites, summarize, type Suite } from "../runner/harness";
 import type { TestResult, TestStatus } from "../runner/types";
 
 export function TestRunnerScreen({ suites }: { suites: Suite[] }) {
-  const [results, setResults] = React.useState<TestResult[]>([]);
+  const [results, setResults] = React.useState<TestResult[]>(() => initialResultsForSuites(suites));
   const started = React.useRef(false);
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     if (started.current) return;
     started.current = true;
     void runSuites(suites, {
       createDb: (config) => createDb({ appId: config.appId }),
       onUpdate: (next) => setResults([...next]),
+    }).catch((error) => {
+      setResults([
+        {
+          suite: "runner",
+          name: "startup",
+          slug: "runner-startup",
+          status: "failed",
+          error: error instanceof Error ? error.message : String(error),
+          durationMs: 0,
+        },
+      ]);
     });
   }, [suites]);
 

--- a/dev/integration-tests-expo/vitest.config.ts
+++ b/dev/integration-tests-expo/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+// Node-only unit tests for the pure-TS runner modules (expect shim, support
+// helpers, sequential runner). RN test bodies, UI and App are NOT run here —
+// they are validated by `tsc --noEmit` and on-device in CI.
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["runner/**/*.test.ts"],
+  },
+});

--- a/dev/maestro/integration-tests/integration_tests.yaml
+++ b/dev/maestro/integration-tests/integration_tests.yaml
@@ -1,0 +1,14 @@
+appId: dev.jazz.integrationtests
+---
+- launchApp
+
+# The app auto-runs the suite on launch. `suite-passed` renders only when every
+# test passed; a red test or a freeze means it never appears and this wait times
+# out, failing the flow. The failure screenshot shows which test died.
+- extendedWaitUntil:
+    visible:
+      id: "suite-passed"
+    timeout: 120000
+
+- assertNotVisible:
+    id: "suite-failed"

--- a/packages/jazz-tools/src/expo/polyfills.test.ts
+++ b/packages/jazz-tools/src/expo/polyfills.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+const originalCryptoDescriptor = Object.getOwnPropertyDescriptor(globalThis, "crypto");
+
+function restoreCrypto() {
+  if (originalCryptoDescriptor) {
+    Object.defineProperty(globalThis, "crypto", originalCryptoDescriptor);
+  } else {
+    Reflect.deleteProperty(globalThis, "crypto");
+  }
+}
+
+describe("expo polyfills", () => {
+  afterEach(() => {
+    restoreCrypto();
+  });
+
+  it("installs crypto.getRandomValues when React Native does not provide crypto", async () => {
+    Reflect.deleteProperty(globalThis, "crypto");
+
+    await import("./polyfills.js");
+
+    const bytes = new Uint8Array(8);
+    const result = globalThis.crypto.getRandomValues(bytes);
+
+    expect(result).toBe(bytes);
+    expect(bytes.some((byte) => byte !== 0)).toBe(true);
+  });
+});

--- a/packages/jazz-tools/src/expo/polyfills.ts
+++ b/packages/jazz-tools/src/expo/polyfills.ts
@@ -2,8 +2,22 @@
 
 import { polyfillGlobal } from "react-native/Libraries/Utilities/PolyfillFunctions";
 
+import { getRandomValues } from "expo-crypto";
 import { ReadableStream as PonyfillReadableStream } from "web-streams-polyfill";
 
 const readableStreamCtor = globalThis.ReadableStream ?? PonyfillReadableStream;
+const cryptoObject = globalThis.crypto;
 
 polyfillGlobal("ReadableStream", () => readableStreamCtor);
+
+if (cryptoObject) {
+  if (typeof cryptoObject.getRandomValues !== "function") {
+    Object.defineProperty(cryptoObject, "getRandomValues", {
+      configurable: true,
+      value: getRandomValues,
+      writable: true,
+    });
+  }
+} else {
+  polyfillGlobal("crypto", () => ({ getRandomValues }));
+}

--- a/packages/jazz-tools/src/expo/vendor.d.ts
+++ b/packages/jazz-tools/src/expo/vendor.d.ts
@@ -11,6 +11,7 @@ declare module "web-streams-polyfill" {
 
 declare module "expo-crypto" {
   export function getRandomBytes(byteCount: number): Uint8Array;
+  export function getRandomValues<T extends ArrayBufferView>(typedArray: T): T;
 }
 
 declare module "expo-secure-store" {

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.test.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.test.ts
@@ -50,7 +50,7 @@ function createBinding(overrides: Partial<JazzRnRuntimeBinding> = {}): JazzRnRun
 }
 
 describe("JazzRnRuntimeAdapter", () => {
-  it("defers batched tick execution to avoid re-entrancy", async () => {
+  it("schedules batched tick on a macrotask so timers and rendering can run", async () => {
     const binding = createBinding();
     new JazzRnRuntimeAdapter(binding, {});
 
@@ -61,6 +61,9 @@ describe("JazzRnRuntimeAdapter", () => {
     expect(binding.batchedTick).not.toHaveBeenCalled();
 
     await Promise.resolve();
+    expect(binding.batchedTick).not.toHaveBeenCalled();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(binding.batchedTick).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.test.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.test.ts
@@ -67,6 +67,28 @@ describe("JazzRnRuntimeAdapter", () => {
     expect(binding.batchedTick).toHaveBeenCalledTimes(1);
   });
 
+  it("swallows errors thrown by deferred batched ticks", () => {
+    vi.useFakeTimers();
+    try {
+      const binding = createBinding({
+        batchedTick: vi.fn(() => {
+          throw new Error("tick failed");
+        }),
+      });
+      new JazzRnRuntimeAdapter(binding, {});
+
+      const onBatchedTickNeeded = binding.onBatchedTickNeeded as ReturnType<typeof vi.fn>;
+      const callbackObject = onBatchedTickNeeded.mock.calls[0]![0];
+
+      callbackObject.requestBatchedTick();
+
+      expect(() => vi.runOnlyPendingTimers()).not.toThrow();
+      expect(binding.batchedTick).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("serializes mutation payloads and parses query responses", async () => {
     const binding = createBinding();
     const adapter = new JazzRnRuntimeAdapter(binding, {});

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
@@ -157,16 +157,13 @@ export class JazzRnRuntimeAdapter implements Runtime {
   ) {
     this.binding.onBatchedTickNeeded({
       requestBatchedTick: () => {
-        // Avoid re-entering Rust while the originating call still holds its mutex.
-        Promise.resolve()
-          .then(() => {
-            if (!this.closed) {
-              this.binding.batchedTick();
-            }
-          })
-          .catch(() => {
-            // Ignore callback failures from deferred ticks.
-          });
+        // Avoid re-entering Rust while the originating call still holds its mutex,
+        // and give timers/rendering a turn between repeated tick requests.
+        setTimeout(() => {
+          if (!this.closed) {
+            this.binding.batchedTick();
+          }
+        }, 0);
       },
     });
   }

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
@@ -160,8 +160,12 @@ export class JazzRnRuntimeAdapter implements Runtime {
         // Avoid re-entering Rust while the originating call still holds its mutex,
         // and give timers/rendering a turn between repeated tick requests.
         setTimeout(() => {
-          if (!this.closed) {
-            this.binding.batchedTick();
+          try {
+            if (!this.closed) {
+              this.binding.batchedTick();
+            }
+          } catch {
+            // Ignore callback failures from deferred ticks.
           }
         }, 0);
       },

--- a/packages/jazz-tools/test-support/expo-crypto-stub.ts
+++ b/packages/jazz-tools/test-support/expo-crypto-stub.ts
@@ -3,3 +3,8 @@ import { randomBytes } from "node:crypto";
 export function getRandomBytes(byteCount: number): Uint8Array {
   return new Uint8Array(randomBytes(byteCount));
 }
+
+export function getRandomValues<T extends Uint8Array>(typedArray: T): T {
+  typedArray.set(randomBytes(typedArray.byteLength));
+  return typedArray;
+}

--- a/packages/jazz-tools/test-support/react-native-polyfill-functions-stub.ts
+++ b/packages/jazz-tools/test-support/react-native-polyfill-functions-stub.ts
@@ -1,0 +1,7 @@
+export function polyfillGlobal<T>(name: string, getValue: () => T): void {
+  Object.defineProperty(globalThis, name, {
+    configurable: true,
+    enumerable: true,
+    get: getValue,
+  });
+}

--- a/packages/jazz-tools/vitest.config.ts
+++ b/packages/jazz-tools/vitest.config.ts
@@ -48,6 +48,9 @@ export default defineConfig({
       "expo-secure-store": fileURLToPath(
         new URL("./test-support/expo-secure-store-stub.ts", import.meta.url),
       ),
+      "react-native/Libraries/Utilities/PolyfillFunctions": fileURLToPath(
+        new URL("./test-support/react-native-polyfill-functions-stub.ts", import.meta.url),
+      ),
     },
   },
   test: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,49 @@ importers:
 
   crates/jazz-wasm: {}
 
+  dev/integration-tests-expo:
+    dependencies:
+      expo:
+        specifier: ^54.0.0
+        version: 54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
+      expo-crypto:
+        specifier: ~14.0.0
+        version: 14.0.2(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))
+      expo-secure-store:
+        specifier: ~14.0.0
+        version: 14.0.1(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))
+      jazz-rn:
+        specifier: workspace:*
+        version: link:../../crates/jazz-rn
+      jazz-tools:
+        specifier: workspace:*
+        version: link:../../packages/jazz-tools
+      metro-runtime:
+        specifier: 0.83.3
+        version: 0.83.3
+      react:
+        specifier: 19.2.4
+        version: 19.2.4
+      react-native:
+        specifier: 0.81.5
+        version: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4)
+    devDependencies:
+      '@babel/plugin-transform-flow-strip-types':
+        specifier: ^7.27.1
+        version: 7.27.1(@babel/core@7.29.0)
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      babel-preset-expo:
+        specifier: ~54.0.10
+        version: 54.0.10(@babel/core@7.29.0)(@babel/runtime@7.29.7)(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-refresh@0.14.2)
+      typescript:
+        specifier: catalog:default
+        version: 6.0.2
+      vitest:
+        specifier: catalog:default
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+
   dev/local-telemetry/web:
     dependencies:
       '@tanstack/react-query':
@@ -701,7 +744,7 @@ importers:
         version: 19.2.14
       babel-preset-expo:
         specifier: ~54.0.10
-        version: 54.0.10(@babel/core@7.29.0)(@babel/runtime@7.28.6)(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-refresh@0.14.2)
+        version: 54.0.10(@babel/core@7.29.0)(@babel/runtime@7.29.7)(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-refresh@0.17.0)
       typescript:
         specifier: catalog:default
         version: 6.0.2
@@ -2049,10 +2092,6 @@ packages:
       '@babel/core': ^7.11.0
       eslint: ^7.5.0 || ^8.0.0 || ^9.0.0
 
-  '@babel/generator@7.29.1':
-    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/generator@7.29.7':
     resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
     engines: {node: '>=6.9.0'}
@@ -2128,16 +2167,8 @@ packages:
     resolution: {integrity: sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.29.7':
@@ -2159,11 +2190,6 @@ packages:
   '@babel/highlight@7.25.9':
     resolution: {integrity: sha512-llL88JShoCsth8fF8R4SJnIn+WLvR6ccFxu1H3FlMhDontdcmZWf2HgIZ7AIqV3Xcck1idlohrN4EUBQz6klbw==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.29.0':
-    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
@@ -2759,10 +2785,6 @@ packages:
 
   '@babel/traverse@7.29.7':
     resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
@@ -12678,7 +12700,7 @@ snapshots:
 
   '@babel/code-frame@7.29.0':
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
@@ -12692,15 +12714,15 @@ snapshots:
 
   '@babel/core@7.29.0':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helpers': 7.28.6
-      '@babel/parser': 7.29.0
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
@@ -12718,14 +12740,6 @@ snapshots:
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
 
-  '@babel/generator@7.29.1':
-    dependencies:
-      '@babel/parser': 7.29.0
-      '@babel/types': 7.29.0
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      jsesc: 3.1.0
-
   '@babel/generator@7.29.7':
     dependencies:
       '@babel/parser': 7.29.7
@@ -12736,7 +12750,7 @@ snapshots:
 
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/helper-compilation-targets@7.28.6':
     dependencies:
@@ -12783,8 +12797,8 @@ snapshots:
 
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -12799,14 +12813,14 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-optimise-call-expression@7.27.1':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
@@ -12815,7 +12829,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-wrap-function': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -12824,22 +12838,18 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-string-parser@7.27.1': {}
-
   '@babel/helper-string-parser@7.29.7': {}
-
-  '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
@@ -12847,27 +12857,23 @@ snapshots:
 
   '@babel/helper-wrap-function@7.28.6':
     dependencies:
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helpers@7.28.6':
     dependencies:
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/highlight@7.25.9':
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       chalk: 2.4.2
       js-tokens: 4.0.0
       picocolors: 1.1.1
-
-  '@babel/parser@7.29.0':
-    dependencies:
-      '@babel/types': 7.29.0
 
   '@babel/parser@7.29.7':
     dependencies:
@@ -12877,7 +12883,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -12904,7 +12910,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -13052,7 +13058,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -13099,7 +13105,7 @@ snapshots:
       '@babel/helper-globals': 7.28.0
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -13107,13 +13113,13 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/template': 7.28.6
+      '@babel/template': 7.29.7
 
   '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -13176,7 +13182,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -13221,8 +13227,8 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -13262,7 +13268,7 @@ snapshots:
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
       '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -13343,7 +13349,7 @@ snapshots:
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -13528,7 +13534,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       esutils: 2.0.3
 
   '@babel/preset-react@7.28.5(@babel/core@7.29.0)':
@@ -13562,9 +13568,9 @@ snapshots:
 
   '@babel/template@7.28.6':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/template@7.29.7':
     dependencies:
@@ -13574,12 +13580,12 @@ snapshots:
 
   '@babel/traverse@7.29.0':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.0
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -13595,11 +13601,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.29.0':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.29.7':
     dependencies:
@@ -14412,14 +14413,14 @@ snapshots:
 
   '@expo/json-file@10.0.12':
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       json5: 2.2.3
 
   '@expo/metro-config@54.0.14(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))':
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       '@babel/core': 7.29.0
-      '@babel/generator': 7.29.1
+      '@babel/generator': 7.29.7
       '@expo/config': 12.0.13
       '@expo/env': 2.0.11
       '@expo/json-file': 10.0.12
@@ -14521,7 +14522,7 @@ snapshots:
 
   '@expo/xcpretty@4.4.1':
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       chalk: 4.1.2
       js-yaml: 4.1.1
 
@@ -15156,14 +15157,14 @@ snapshots:
 
   '@manypkg/find-root@1.1.0':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
 
   '@manypkg/get-packages@1.1.3':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@changesets/types': 4.1.0
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
@@ -16401,7 +16402,7 @@ snapshots:
 
   '@react-native/babel-plugin-codegen@0.81.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.7
       '@react-native/codegen': 0.81.6(@babel/core@7.29.0)
     transitivePeerDependencies:
       - '@babel/core'
@@ -16510,7 +16511,7 @@ snapshots:
   '@react-native/codegen@0.81.5(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.7
       glob: 7.2.3
       hermes-parser: 0.29.1
       invariant: 2.2.4
@@ -16520,7 +16521,7 @@ snapshots:
   '@react-native/codegen@0.81.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.7
       glob: 7.2.3
       hermes-parser: 0.29.1
       invariant: 2.2.4
@@ -17197,24 +17198,24 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.28.0
 
   '@types/babel__generator@7.27.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
   '@types/babel__traverse@7.28.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@types/body-parser@1.19.6':
     dependencies:
@@ -17682,7 +17683,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.29':
     dependencies:
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.7
       '@vue/shared': 3.5.29
       entities: 7.0.1
       estree-walker: 2.0.2
@@ -17695,7 +17696,7 @@ snapshots:
 
   '@vue/compiler-sfc@3.5.29':
     dependencies:
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.7
       '@vue/compiler-core': 3.5.29
       '@vue/compiler-dom': 3.5.29
       '@vue/compiler-ssr': 3.5.29
@@ -17971,7 +17972,7 @@ snapshots:
 
   automation-events@7.1.15:
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       tslib: 2.8.1
 
   available-typed-arrays@1.0.7:
@@ -18013,8 +18014,8 @@ snapshots:
 
   babel-plugin-jest-hoist@29.6.3:
     dependencies:
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.28.0
 
@@ -18089,7 +18090,7 @@ snapshots:
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.0)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.0)
 
-  babel-preset-expo@54.0.10(@babel/core@7.29.0)(@babel/runtime@7.28.6)(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-refresh@0.14.2):
+  babel-preset-expo@54.0.10(@babel/core@7.29.0)(@babel/runtime@7.29.7)(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-refresh@0.14.2):
     dependencies:
       '@babel/helper-module-imports': 7.28.6
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
@@ -18115,7 +18116,7 @@ snapshots:
       react-refresh: 0.14.2
       resolve-from: 5.0.0
     optionalDependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       expo: 54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
       - '@babel/core'
@@ -19579,7 +19580,7 @@ snapshots:
 
   expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@expo/cli': 54.0.23(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))
       '@expo/config': 12.0.13
       '@expo/config-plugins': 54.0.4
@@ -19589,7 +19590,7 @@ snapshots:
       '@expo/metro-config': 54.0.14(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))
       '@expo/vector-icons': 15.1.1(expo-font@14.0.11(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
       '@ungap/structured-clone': 1.3.0
-      babel-preset-expo: 54.0.10(@babel/core@7.29.0)(@babel/runtime@7.28.6)(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-refresh@0.14.2)
+      babel-preset-expo: 54.0.10(@babel/core@7.29.0)(@babel/runtime@7.29.7)(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-refresh@0.14.2)
       expo-asset: 12.0.12(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
       expo-constants: 18.0.13(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))
       expo-file-system: 19.0.21(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))
@@ -20676,7 +20677,7 @@ snapshots:
   istanbul-lib-instrument@5.2.1:
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.7
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -20686,7 +20687,7 @@ snapshots:
   istanbul-lib-instrument@6.0.3:
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.7
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 7.7.4
@@ -20965,10 +20966,10 @@ snapshots:
   jest-snapshot@29.7.0:
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/generator': 7.29.1
+      '@babel/generator': 7.29.7
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       '@jest/expect-utils': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
@@ -21773,19 +21774,19 @@ snapshots:
 
   metro-runtime@0.83.3:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       flow-enums-runtime: 0.0.6
 
   metro-runtime@0.83.5:
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       flow-enums-runtime: 0.0.6
 
   metro-source-map@0.83.3:
     dependencies:
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.7
       '@babel/traverse--for-generate-function-map': '@babel/traverse@7.29.7'
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
       metro-symbolicate: 0.83.3
@@ -21798,8 +21799,8 @@ snapshots:
 
   metro-source-map@0.83.5:
     dependencies:
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
       metro-symbolicate: 0.83.5
@@ -21835,9 +21836,9 @@ snapshots:
   metro-transform-plugins@0.83.3:
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/generator': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
       flow-enums-runtime: 0.0.6
       nullthrows: 1.1.1
     transitivePeerDependencies:
@@ -21846,9 +21847,9 @@ snapshots:
   metro-transform-plugins@0.83.5:
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/generator': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
       flow-enums-runtime: 0.0.6
       nullthrows: 1.1.1
     transitivePeerDependencies:
@@ -21857,9 +21858,9 @@ snapshots:
   metro-transform-worker@0.83.3:
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/generator': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       flow-enums-runtime: 0.0.6
       metro: 0.83.3
       metro-babel-transformer: 0.83.3
@@ -21877,9 +21878,9 @@ snapshots:
   metro-transform-worker@0.83.5:
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/generator': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       flow-enums-runtime: 0.0.6
       metro: 0.83.5
       metro-babel-transformer: 0.83.5
@@ -21896,13 +21897,13 @@ snapshots:
 
   metro@0.83.3:
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       '@babel/core': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.0
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/generator': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
       accepts: 1.3.8
       chalk: 4.1.2
       ci-info: 2.0.0
@@ -21943,13 +21944,13 @@ snapshots:
 
   metro@0.83.5:
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       '@babel/core': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.0
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/generator': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
       accepts: 2.0.0
       chalk: 4.1.2
       ci-info: 2.0.0
@@ -22782,7 +22783,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ packages:
   - examples/docs/*
   - dev/stress-tests/*
   - dev/local-telemetry/web
+  - dev/integration-tests-expo
   - crates
   - crates/jazz-wasm
   - crates/jazz-napi

--- a/specs/rn-integration-test-runner-design.md
+++ b/specs/rn-integration-test-runner-design.md
@@ -1,0 +1,222 @@
+# RN Integration Test Runner — Design Spec
+
+Date: 2026-06-03
+Status: Approved (brainstormed), pending implementation
+Branch: `feat/rn-integration-test-runner`
+
+## Problem
+
+CI exercises the React Native / Expo stack with a single Maestro flow that drives
+the `todo-client-localfirst-expo` example app (`dev/maestro/flows/todo_crud.yaml`).
+That is one happy-path UI walkthrough. Meanwhile the browser/JS client has a rich
+integration suite (`packages/jazz-tools/tests/browser/**`, `tests/ts-dsl/**`) that
+exercises real DB behaviour: bulk writes, queries, subscriptions, relations,
+convergence. **RN has no equivalent.** Regressions in the `jazz-rn` runtime that
+don't break the narrow todo flow can ship unnoticed.
+
+## Goal
+
+A reusable, on-device integration **test suite for RN**, authored with DX that
+mirrors the existing browser tests. It is delivered as a standalone Expo app that
+_is_ a test runner: it runs a list of integration tests sequentially, renders each
+result, and exposes a deterministic pass/fail signal that Maestro asserts in CI. A
+red test — or a freeze/hang — makes the Maestro flow throw.
+
+It is explicitly a growing harness: PR #956-style regression scenarios are the kind
+of thing it should host over time. #956 itself is **not** in Phase 1 (it needs
+multi-peer sync; see Phasing).
+
+## Non-goals
+
+- Not a user-facing tutorial/example (lives outside the `examples/` showcase path).
+- Not sharing test _files_ with the browser suite (chosen Option ②: mirror the
+  style, separate files). No dynamic cross-runtime import abstraction.
+- Phase 1 does **not** cover multi-peer sync, a server, or the in-process relay.
+- iOS is out of scope for Phase 1 (Android-only, matching existing Maestro CI).
+
+## Key decisions
+
+1. **Option ② — mirrored RN suite.** RN-only test files written in the same
+   ergonomic style as the browser tests, using ported helpers. Not literally shared
+   with the browser suite.
+2. **Placement (c) — out of the showcase path.** App lives at
+   `dev/integration-tests-expo/` (co-located with the existing `dev/maestro/`
+   infra), added as a one-line entry to `pnpm-workspace.yaml`. The Maestro flow lives
+   in its **own** workspace dir `dev/maestro/integration-tests/` (not the shared
+   `dev/maestro/flows/`, which holds the todo flow) so the new CI job runs only this
+   flow.
+3. **Local-only Phase 1.** Tests use `createDb` from `jazz-tools/react-native` with
+   no `serverUrl`. No Vercel Sandbox, no jazz-tools server, no deploy, no secrets —
+   which also sidesteps the known WS-upgrade flakiness
+   (`specs/todo/issues/expo-android-maestro-e2e-ws-unverified.md`).
+4. **Hand-rolled `expect`.** A small Jest-style assertion module (Hermes-safe,
+   unit-tested in Node), behind a single `runner/expect.ts`. `@vitest/expect` (already
+   in the tree, browser-proven) can be swapped in later if a CI spike confirms it
+   runs on Hermes. Decision driven by: the on-device assertion path cannot be
+   verified locally, and a controlled shim removes that risk with no DX cost for the
+   matchers used.
+5. **Auto-run on launch + deterministic terminal signal** for Maestro (below).
+
+## Architecture
+
+A normal Expo app (mirrors `todo-client-localfirst-expo`'s scaffold: `app.json`
+Hermes + new arch, `index.js`, `metro.config.mjs` with `withJazz`, `babel.config.js`,
+`tsconfig.json`, prebuild → `android/`). Its single screen is the test runner.
+
+```
+dev/integration-tests-expo/
+├── App.tsx                     # runtime/schema bootstrap (local-only) → TestRunnerScreen
+├── app.json                    # bundleId/package: dev.jazz.integrationtests, Hermes
+├── index.js, metro.config.mjs, babel.config.js, tsconfig.json
+├── schema.ts                   # test tables (todos, projects, orgs, teams, users) via public DSL
+├── runner/
+│   ├── harness.ts              # defineSuite/test, TestCtx, sequential runner + state machine
+│   ├── expect.ts               # hand-rolled Jest-style matchers
+│   ├── support.ts              # ported waitForQuery/waitForCondition/withTimeout/sleep/uniqueAppId/cleanup
+│   └── types.ts                # TestStatus, SuiteResult, etc.
+├── tests/
+│   ├── _registry.ts            # explicit list of suites (deterministic order)
+│   ├── bulk-writes.test.ts
+│   ├── crud.test.ts
+│   ├── queries.test.ts
+│   ├── subscriptions.test.ts
+│   ├── relations.test.ts
+│   └── durability.test.ts
+└── ui/
+    └── TestRunnerScreen.tsx    # renders rows + summary + Maestro testIDs
+```
+
+### Runtime/runner flow
+
+1. App mounts → native `jazz-rn` module + schema are bootstrapped local-only
+   (mirroring the todo app's `withJazz`/metro wiring; `JazzProvider` only if the
+   bootstrap needs it — otherwise the runner calls `createDb` directly). Each test
+   creates its **own** `Db` via `createDb` so tests are isolated. Exact schema wiring
+   is pinned during implementation.
+2. `TestRunnerScreen` mounts → kicks off the runner over `_registry` suites,
+   **sequentially**, updating observable state per test: `pending → running →
+passed | failed(error)` with a duration.
+3. Each test runs inside a per-test timeout (default ~30s) with auto-cleanup of any
+   `Db`/subscriptions it created. A thrown assertion or timeout → `failed` with the
+   message; the runner continues to the next test (so the UI shows the full picture)
+   then settles into a terminal suite state.
+
+### Test authoring DX (the priority)
+
+```ts
+// tests/bulk-writes.test.ts
+import { defineSuite } from "../runner/harness";
+import { todos, allTodos } from "../schema";
+
+export default defineSuite("bulk writes", ({ test }) => {
+  test("writes 100 todos and reads them all back", async ({ db, expect, waitForQuery }) => {
+    for (let i = 0; i < 100; i++)
+      db.insert(todos, { title: `t-${i}`, done: false, owner_id: "me" });
+    await waitForQuery(db, allTodos, (r) => r.length === 100, "100 land", 10_000);
+    expect((await db.all(allTodos)).length).toBe(100);
+  });
+});
+```
+
+`TestCtx` handed to each test:
+
+```ts
+type TestCtx = {
+  db: Db; // fresh local Db, auto-created (unique appId) + auto-shutdown
+  expect: Expect; // hand-rolled matchers
+  waitForQuery;
+  waitForCondition;
+  withTimeout;
+  sleep;
+  uniqueAppId;
+};
+```
+
+Adding a test = drop a `*.test.ts` in `tests/`, `export default defineSuite(...)`,
+add one line to `_registry.ts`. (Explicit registry over `require.context` for
+deterministic ordering.)
+
+## Maestro pass/fail contract
+
+UI state machine with stable testIDs:
+
+| testID                          | meaning                                                                          |
+| ------------------------------- | -------------------------------------------------------------------------------- |
+| `test-row-<slug>` + status text | per-test row: pending → running → `PASS`/`FAIL` (the "one after another" visual) |
+| `suite-status`                  | text = `RUNNING` → `PASSED` \| `FAILED`                                          |
+| `suite-passed`                  | rendered **only** when every test passed                                         |
+| `suite-failed`                  | rendered if any test failed; lists failing names + error messages                |
+
+Flow `dev/maestro/integration-tests/integration_tests.yaml`:
+
+```yaml
+appId: dev.jazz.integrationtests
+---
+- launchApp
+- extendedWaitUntil:
+    visible: { id: "suite-passed" }
+    timeout: 120000
+- assertNotVisible: { id: "suite-failed" }
+```
+
+A red test → `suite-passed` never renders → `extendedWaitUntil` times out → Maestro
+throws. A freeze/hang → identical outcome. One wait covers both failure and deadlock;
+the failure screenshot captures the failing test name + message.
+
+## CI
+
+New workflow `.github/workflows/expo-android-integration-e2e.yml`, modeled on
+`expo-android-maestro-e2e.yml` but **stripped of the server**:
+
+- Reuse `rn-build-reusable.yml` for jazz-rn Android artifacts.
+- `validate` (schema + `tsc --noEmit`) → `expo prebuild --platform android` → JDK/Gradle/SDK/NDK setup → `gradlew :app:assembleRelease`.
+- **No** Vercel Sandbox, jazz-tools server, deploy, or secrets (local-only; `appId` baked in, no `serverUrl`).
+- `mobile-dev-inc/action-maestro-cloud` runs the `dev/maestro/integration-tests/` workspace against the APK; upload screenshots/logs on failure.
+- Triggers: push to `main`; PRs touching `crates/jazz-rn/**`,
+  `packages/jazz-tools/src/react-native/**`, `dev/integration-tests-expo/**`,
+  `dev/maestro/integration-tests/**`, and the workflow file.
+
+## Phase-1 test list (local, no server)
+
+1. **bulk writes** — insert 100 rows, read back all 100, assert count + sample shape.
+2. **CRUD round-trip** — insert → update field → assert → delete → assert gone.
+3. **query conditions** — mixed rows; `db.all` with `eq`/filter + ordering/limit.
+4. **subscribeAll deltas** — assert add/update/remove deltas + final `all`.
+5. **include relations** — orgs→teams→users→todos; nested query result.
+6. **local durability** — `insert(...).wait({ tier: "local" })` resolves + queryable.
+
+## Phasing
+
+- **Phase 1 (this spec):** the app, runner, hand-rolled `expect`, support helpers,
+  the 6 local tests, Maestro flow, CI workflow, workspace wiring.
+- **Phase 2 (later):** multi-peer sync tests — either point at a server, or build the
+  in-process `addClient`/`addServer`/`batchedTick` relay. Designed-for (registry +
+  ctx accommodate a second `Db`), not built yet. PR #956-style deferred-subscription
+  regression belongs here.
+
+## Verification strategy
+
+- **Locally (Node):** unit-test `runner/expect.ts` (matchers incl. deep `toEqual`),
+  `runner/support.ts`, and the runner state machine; exercise the actual **test
+  bodies** against Node `createDb` (`jazz-tools`) to prove the assertions are correct
+  independent of RN. `tsc --noEmit` for the whole app.
+- **CI (device):** `expo prebuild` + release APK build + Maestro flow are validated
+  by the new workflow. The on-device Hermes assertion path and the end-to-end
+  pass/fail gate are confirmed there.
+
+## Risks / open implementation details
+
+- **Schema/metro wiring:** how `withJazz` injects/compiles the schema for the RN
+  runtime (todo app relies on it). Must be mirrored exactly; confirm local-only mode
+  (no `serverUrl`) is happy with `withJazz`. Pin during implementation.
+- **`expect` surface creep:** keep matchers minimal (what the 6 tests use); grow
+  deliberately. Deep `toEqual` + a couple asymmetric matchers are the only non-trivial
+  bits.
+- **batched_tick / timing:** local writes are fast, but waiters (`waitForQuery`) must
+  poll, not assume synchronous convergence. Generous per-test + Maestro timeouts.
+- **Maestro workspace scoping:** ensure the new flow runs in a way that doesn't pull
+  in the todo flow (separate workspace dir or appId filtering).
+
+```
+
+```

--- a/specs/rn-integration-test-runner-plan.md
+++ b/specs/rn-integration-test-runner-plan.md
@@ -1,0 +1,391 @@
+# RN Integration Test Runner — Implementation Plan
+
+> **For agentic workers:** Use superpowers:executing-plans / subagent-driven-development to implement task-by-task. Steps use `- [ ]` checkboxes.
+
+**Goal:** A standalone Expo app at `dev/integration-tests-expo/` that runs Jazz integration tests on-device, renders pass/fail per test, and exposes a deterministic signal Maestro asserts in CI.
+
+**Architecture:** Local-only `createDb` (no server/permissions). Pure-TS runner (`expect` shim + support helpers + sequential runner) decoupled from the RN test registry so it is Node-unit-testable. RN test bodies use the public DSL. A UI renders rows + a terminal `suite-passed`/`suite-failed` element. New CI workflow builds the APK and runs a dedicated Maestro flow.
+
+**Tech Stack:** Expo 54, React Native 0.81, Hermes, `jazz-tools`/`jazz-rn` (workspace), vitest (Node unit tests only), Maestro Cloud, GitHub Actions.
+
+**Verification split:** pure-TS modules → vitest in Node (local). RN bodies/UI/App → `tsc --noEmit` (local). APK build + Maestro pass/fail → CI only.
+
+---
+
+## Pinned API facts (verified, verbatim sources)
+
+- RN `createDb(config: DbConfig): Promise<Db>` from `jazz-tools/react-native`. `appId` required; `serverUrl` optional → omit for local-only (`packages/jazz-tools/src/runtime/db.ts:92`, `react-native/db.ts:8`).
+- Schema rides on queries: `app = s.defineApp(schema)`; `db.all(query)` reads `query._schema` (`typed-app.ts:1321`, `runtime/db.ts:1932`). No metro/`withJazz`/env needed for schema.
+- Empty/absent permissions = default allow locally (`napi.integration.test.ts:763`, `schema-permissions.ts:529`). No permissions file required.
+- No `secret` → runtime mints an anonymous session automatically (`react-native/db.test.ts:99`). `createDb({ appId })` alone is enough.
+- Db API: `insert(table, data) → WriteResult` with `.value` and `.wait({tier})`; `update(table,id,data)`; `delete(table,id)`; `all(query)`; `one(query)`; `subscribeAll(query, cb) → () => void`; `shutdown()` (`runtime/db.ts:1674..2145`, `client.ts:657..686`). `DurabilityTier = "local"|"edge"|"global"`.
+- Query DSL (public, NO JSON): `app.todos` (all), `.where({ col: { eq|gt|lt|... : v } })`, `.orderBy("col","asc"|"desc")`, `.limit(n)`, `.select(...)`, `.include({ rel: true })`. Forward ref `projectId: s.ref("projects")` → include key `project`.
+- `subscribeAll` delta: `{ all: T[]; delta: RowDelta[] }`, kinds `Added=0, Removed=1, Updated=2` (`subscription-manager.ts:17`). Query type requires `T extends { id: string }`.
+- Schema DSL: `s.table`, `s.string`, `s.boolean().default(false)`, `s.array(s.string()).default([])`, `s.ref("t")`, `.optional()`, `s.defineApp`, `s.RowOf<typeof app.todos>`.
+
+---
+
+## File structure
+
+```
+dev/integration-tests-expo/
+├── package.json            # mirrors todo app deps
+├── app.json                # bundleId/package dev.jazz.integrationtests, Hermes, newArch
+├── babel.config.js         # babel-preset-expo + unstable_transformImportMeta
+├── tsconfig.json           # extends expo/tsconfig.base
+├── index.js                # imports jazz-tools/expo/polyfills + registerRootComponent
+├── metro.config.mjs        # default expo config + symlinks (NO withJazz)
+├── vitest.config.ts        # Node, includes runner/**/*.test.ts only
+├── schema.ts               # test tables via public DSL
+├── runner/
+│   ├── types.ts            # TestStatus/TestResult/SuiteSummary
+│   ├── expect.ts           # hand-rolled Jest-style matchers (+ expect.test.ts)
+│   ├── support.ts          # sleep/uniqueAppId/waitForCondition/withTimeout/waitForQuery (+ support.test.ts)
+│   └── harness.ts          # defineSuite/runSuites + summarize (+ harness.test.ts)
+├── tests/
+│   ├── _registry.ts        # suites: Suite[] (RN imports; not unit-tested)
+│   ├── bulk-writes.test.ts
+│   ├── crud.test.ts
+│   ├── queries.test.ts
+│   ├── subscriptions.test.ts
+│   ├── relations.test.ts
+│   └── durability.test.ts
+└── ui/TestRunnerScreen.tsx # rows + summary + Maestro testIDs
+App wiring: App.tsx
+Maestro: dev/maestro/integration-tests/integration_tests.yaml
+CI: .github/workflows/expo-android-integration-e2e.yml
+Workspace: pnpm-workspace.yaml (+ one line)
+```
+
+---
+
+## Task 1 — Scaffold app + workspace
+
+**Files (create):** `dev/integration-tests-expo/{package.json,app.json,babel.config.js,tsconfig.json,index.js,metro.config.mjs}`; **modify:** `pnpm-workspace.yaml`.
+
+- [ ] `package.json` (mirror todo app; drop server-only `expo-secure-store` is risky → keep to match proven app):
+
+```json
+{
+  "name": "integration-tests-expo",
+  "version": "0.1.0",
+  "private": true,
+  "main": "./index.js",
+  "scripts": {
+    "start": "expo start --clear",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "build": "tsc --noEmit",
+    "test": "vitest run --config vitest.config.ts",
+    "prebuild": "expo prebuild --clean",
+    "verify:expo:android": "CI=1 expo prebuild --platform android --clean --no-install"
+  },
+  "dependencies": {
+    "expo": "^54.0.0",
+    "expo-crypto": "~14.0.0",
+    "expo-secure-store": "~14.0.0",
+    "jazz-rn": "workspace:*",
+    "jazz-tools": "workspace:*",
+    "metro-runtime": "0.83.3",
+    "react": "19.2.4",
+    "react-native": "0.81.5"
+  },
+  "devDependencies": {
+    "@babel/plugin-transform-flow-strip-types": "^7.27.1",
+    "@types/react": "^19.0.0",
+    "babel-preset-expo": "~54.0.10",
+    "typescript": "catalog:default",
+    "vitest": "catalog:default"
+  }
+}
+```
+
+- [ ] `app.json`:
+
+```json
+{
+  "expo": {
+    "name": "integration-tests-expo",
+    "slug": "integration-tests-expo",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "jsEngine": "hermes",
+    "newArchEnabled": true,
+    "android": { "package": "dev.jazz.integrationtests" },
+    "ios": { "bundleIdentifier": "dev.jazz.integrationtests" }
+  }
+}
+```
+
+- [ ] `babel.config.js` (exact copy of todo app); `tsconfig.json` (todo app's, with `include: ["App.tsx","runner/**/*","tests/**/*","ui/**/*","schema.ts"]`); `index.js` (exact copy: import `jazz-tools/expo/polyfills`, register `App`).
+- [ ] `metro.config.mjs` — default expo config + symlinks, **no** `withJazz`:
+
+```js
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
+const { getDefaultConfig } = require("expo/metro-config");
+const projectRoot = path.dirname(fileURLToPath(import.meta.url));
+const config = getDefaultConfig(projectRoot);
+config.resolver.unstable_enableSymlinks = true;
+export default config;
+```
+
+- [ ] `pnpm-workspace.yaml`: add `  - dev/integration-tests-expo` under `packages:`.
+- [ ] **Verify:** `pnpm install` (root) succeeds and links the package. Commit.
+
+## Task 2 — schema.ts + vitest config
+
+- [ ] `schema.ts`:
+
+```ts
+import { schema as s } from "jazz-tools";
+
+const schema = {
+  projects: s.table({ name: s.string() }),
+  todos: s.table({
+    title: s.string(),
+    done: s.boolean().default(false),
+    priority: s.string().optional(),
+    projectId: s.ref("projects").optional(),
+  }),
+};
+type AppSchema = s.Schema<typeof schema>;
+export const app: s.App<AppSchema> = s.defineApp(schema);
+export type Todo = s.RowOf<typeof app.todos>;
+export type Project = s.RowOf<typeof app.projects>;
+```
+
+- [ ] `vitest.config.ts`:
+
+```ts
+import { defineConfig } from "vitest/config";
+export default defineConfig({
+  test: { environment: "node", include: ["runner/**/*.test.ts"] },
+});
+```
+
+- [ ] **Verify:** `pnpm --filter integration-tests-expo exec tsc --noEmit` typechecks `schema.ts`. Commit.
+
+## Task 3 — runner/types.ts + runner/expect.ts (TDD)
+
+- [ ] `runner/types.ts`:
+
+```ts
+export type TestStatus = "pending" | "running" | "passed" | "failed";
+export interface TestResult {
+  suite: string;
+  name: string;
+  slug: string;
+  status: TestStatus;
+  error?: string;
+  durationMs?: number;
+}
+export interface SuiteSummary {
+  total: number;
+  passed: number;
+  failed: number;
+  done: boolean;
+  allPassed: boolean;
+}
+```
+
+- [ ] **Step 1 — failing test** `runner/expect.test.ts`:
+
+```ts
+import { describe, it, expect as v } from "vitest";
+import { expect } from "./expect";
+describe("expect shim", () => {
+  it("toBe / not.toBe", () => {
+    expect(2).toBe(2);
+    expect(2).not.toBe(3);
+    v(() => expect(2).toBe(3)).toThrow();
+  });
+  it("toEqual deep", () => {
+    expect({ a: [1, { b: 2 }] }).toEqual({ a: [1, { b: 2 }] });
+    v(() => expect({ a: 1 }).toEqual({ a: 2 })).toThrow();
+  });
+  it("toMatchObject subset", () => {
+    expect({ id: "x", title: "t", done: false }).toMatchObject({ title: "t" });
+    v(() => expect({ title: "t" }).toMatchObject({ title: "z" })).toThrow();
+  });
+  it("toHaveLength / toContain / comparisons / nullish", () => {
+    expect([1, 2, 3]).toHaveLength(3);
+    expect([1, 2, 3]).toContain(2);
+    expect(5).toBeGreaterThan(4);
+    expect(5).toBeGreaterThanOrEqual(5);
+    expect(null).toBeNull();
+    expect(1).toBeDefined();
+    expect(0).toBeFalsy();
+    expect("x").toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2 — run, expect FAIL:** `pnpm --filter integration-tests-expo test` → fails (no `expect`).
+- [ ] **Step 3 — implement** `runner/expect.ts`: `deepEqual(a,b)`, `subsetMatch(actual,expected)`, a `Matchers` object with `not` negation, throwing `Error` with a readable message on mismatch. Matchers: `toBe,toEqual,toMatchObject,toHaveLength,toContain,toBeGreaterThan,toBeGreaterThanOrEqual,toBeDefined,toBeUndefined,toBeNull,toBeTruthy,toBeFalsy`. Export `expect` and types `Expect`/`Matchers`.
+- [ ] **Step 4 — run, expect PASS.** Commit.
+
+## Task 4 — runner/support.ts (TDD)
+
+Structural `Queryable` so the module has no RN import.
+
+- [ ] **Step 1 — failing test** `runner/support.test.ts`: test `waitForCondition` resolves when predicate flips true; rejects with the label on timeout; `withTimeout` rejects after ms; `waitForQuery` polls a fake `{ all: async () => rows }` until predicate true; `uniqueAppId("x")` returns distinct strings with the label prefix.
+- [ ] **Step 2 — run, expect FAIL.**
+- [ ] **Step 3 — implement** `runner/support.ts`:
+
+```ts
+export interface Queryable {
+  all<T>(query: unknown): Promise<T[]>;
+}
+export const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+let __seq = 0;
+export function uniqueAppId(label: string): string {
+  return `itest-${label}-${Date.now().toString(36)}-${(__seq++).toString(36)}`;
+}
+export async function waitForCondition(
+  check: () => boolean | Promise<boolean>,
+  timeoutMs: number,
+  message: string,
+): Promise<void> {
+  /* poll every 50ms until deadline; throw Error(`Timeout ${timeoutMs}ms: ${message}`) */
+}
+export async function withTimeout<T>(p: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  /* Promise.race with a timer that rejects */
+}
+export async function waitForQuery<T>(
+  db: Queryable,
+  query: unknown,
+  predicate: (rows: T[]) => boolean,
+  label: string,
+  timeoutMs = 10_000,
+): Promise<T[]> {
+  /* loop: rows = await db.all<T>(query); if predicate(rows) return rows; sleep(100); until deadline → throw with last count */
+}
+```
+
+- [ ] **Step 4 — run, expect PASS.** Commit.
+
+## Task 5 — runner/harness.ts (TDD)
+
+Runner is decoupled: takes `suites` + injected `createDb` + `onUpdate`. `Db` type imported type-only.
+
+- [ ] Types:
+
+```ts
+import type { Db } from "jazz-tools/react-native";
+import type { Expect } from "./expect";
+import type { TestResult, SuiteSummary } from "./types";
+import { expect } from "./expect";
+import * as support from "./support";
+export interface TestCtx {
+  db: Db;
+  expect: Expect;
+  waitForQuery: typeof support.waitForQuery;
+  waitForCondition: typeof support.waitForCondition;
+  withTimeout: typeof support.withTimeout;
+  sleep: typeof support.sleep;
+  uniqueAppId: typeof support.uniqueAppId;
+}
+export type TestBody = (ctx: TestCtx) => Promise<void>;
+export interface Suite {
+  name: string;
+  tests: { name: string; body: TestBody }[];
+}
+export interface RunnerDeps {
+  createDb: (config: { appId: string }) => Promise<Db>;
+  onUpdate: (results: TestResult[]) => void;
+  perTestTimeoutMs?: number; // default 30000
+}
+```
+
+- [ ] **Step 1 — failing test** `runner/harness.test.ts`: build two suites via `defineSuite`; one test passes, one throws, one hangs (use a never-resolving promise) with a short `perTestTimeoutMs`; inject a fake `createDb` returning `{ all: async()=>[], shutdown: async()=>{} }`; assert final `TestResult[]` has statuses `passed/failed/failed`, the hang one has a timeout error, `summarize()` reports `done:true, allPassed:false`, and `onUpdate` was called with a `running` status before each terminal status. Also assert each test got a **distinct** `db` (fake createDb records appIds) and `shutdown` was called per test.
+- [ ] **Step 2 — run, expect FAIL.**
+- [ ] **Step 3 — implement** `defineSuite`, `slugify(name)`, `summarize(results): SuiteSummary`, and `runSuites(suites, deps)`: flatten to pending `TestResult[]`; `onUpdate`; for each: set `running`+`onUpdate`; `db = await deps.createDb({ appId: uniqueAppId(slug) })`; build ctx; `await withTimeout(body(ctx), perTestTimeoutMs, name)`; success→`passed` else `failed`+message; `finally` best-effort `db.shutdown()`; set `durationMs`; `onUpdate`. Return results. (`slug = suiteSlug + "-" + testSlug`.)
+- [ ] **Step 4 — run, expect PASS.** Commit.
+
+## Task 6 — test suites + registry
+
+Each suite uses only the public DSL + ctx. Full bodies below; `_registry.ts` lists them in order.
+
+- [ ] `tests/bulk-writes.test.ts`:
+
+```ts
+import { defineSuite } from "../runner/harness";
+import { app } from "../schema";
+export default defineSuite("bulk writes", ({ test }) => {
+  test("writes 100 todos and reads them all back", async ({ db, expect, waitForQuery }) => {
+    for (let i = 0; i < 100; i++) db.insert(app.todos, { title: `t-${i}`, done: false });
+    const rows = await waitForQuery(db, app.todos, (r) => r.length >= 100, "100 land", 15_000);
+    expect(rows).toHaveLength(100);
+  });
+});
+```
+
+- [ ] `tests/crud.test.ts` — insert (capture `value.id`), `update(app.todos, id, { done: true })`, `waitForQuery` until that row `done===true`, assert; `delete(app.todos, id)`, `waitForQuery` until absent, assert length 0.
+- [ ] `tests/queries.test.ts` — insert 3 todos with mixed `done`; `db.all(app.todos.where({ done: { eq: false } }))`; assert only the not-done rows; then `.orderBy("title","asc").limit(2)` and assert length 2 + order.
+- [ ] `tests/subscriptions.test.ts` — `const deltas=[]; const unsub = db.subscribeAll(app.todos, d => deltas.push(d));` insert one; `waitForCondition(() => deltas.some(d => d.delta.some(x => x.kind === 0)), 5000, "add delta")`; update it; assert an `Updated`(2) delta; finally `unsub()`.
+- [ ] `tests/relations.test.ts` — insert a project (capture id); insert a todo with `projectId`; `db.all(app.todos.where({ id: { eq: todoId } }).include({ project: true }))`; assert `rows[0].project?.name` equals the project name.
+- [ ] `tests/durability.test.ts` — `const row = await db.insert(app.todos, { title: "d" }).wait({ tier: "local" });` assert `row.id` defined; `db.one(app.todos.where({ id: { eq: row.id } }))` is non-null.
+- [ ] `tests/_registry.ts`:
+
+```ts
+import type { Suite } from "../runner/harness";
+import bulk from "./bulk-writes.test";
+import crud from "./crud.test";
+import queries from "./queries.test";
+import subscriptions from "./subscriptions.test";
+import relations from "./relations.test";
+import durability from "./durability.test";
+export const suites: Suite[] = [bulk, crud, queries, subscriptions, relations, durability];
+```
+
+- [ ] **Verify:** `tsc --noEmit`. Commit.
+
+## Task 7 — UI + App wiring
+
+- [ ] `ui/TestRunnerScreen.tsx`: props `{ suites }`. `useState<TestResult[]>([])`; `useEffect(run-once)` calling `runSuites(suites, { createDb, onUpdate: setResults })` with `createDb` from `jazz-tools/react-native`. Render:
+  - `<Text testID="suite-status">{summary.done ? (summary.allPassed ? "PASSED" : "FAILED") : "RUNNING"}</Text>`
+  - a `ScrollView` of rows: `<View testID={`test-row-${r.slug}`}><Text>{r.name}</Text><Text>{r.status === "passed" ? "PASS" : r.status === "failed" ? "FAIL" : r.status.toUpperCase()}</Text></View>` (failed rows also render `r.error`).
+  - when `summary.done && summary.allPassed`: `<View testID="suite-passed"><Text>ALL {summary.total} PASSED</Text></View>`.
+  - when `summary.done && !summary.allPassed`: `<View testID="suite-failed"><Text>{failed names + errors}</Text></View>`.
+- [ ] `App.tsx`: `import { suites } from "./tests/_registry"; export default () => <SafeAreaView style={{flex:1}}><TestRunnerScreen suites={suites} /></SafeAreaView>;` (no JazzProvider needed — runner calls `createDb` directly).
+- [ ] **Verify:** `tsc --noEmit`. Commit.
+
+## Task 8 — Maestro flow
+
+- [ ] `dev/maestro/integration-tests/integration_tests.yaml`:
+
+```yaml
+appId: dev.jazz.integrationtests
+---
+- launchApp
+- extendedWaitUntil:
+    visible:
+      id: "suite-passed"
+    timeout: 120000
+- assertNotVisible:
+    id: "suite-failed"
+```
+
+- [ ] Commit.
+
+## Task 9 — CI workflow
+
+- [ ] `.github/workflows/expo-android-integration-e2e.yml` — copy `expo-android-maestro-e2e.yml`, then: drop `build-jazz-tools-sandbox` job and all Vercel-sandbox/`deploy`/server-URL steps; in the e2e job keep checkout, `source-code`, download `jazz-rn-android` artifact, the JS build (`pnpm --filter jazz-wasm run build`, `pnpm --filter jazz-tools run build:runtime`), `tsc --noEmit` (drop `jazz-tools validate` — no schema deploy), `verify:expo:android` (filter `integration-tests-expo`), Java/Gradle/SDK/NDK, `gradlew :app:assembleRelease` **without** `EXPO_PUBLIC_JAZZ_*` env, then Maestro Cloud with `app-file: dev/integration-tests-expo/android/app/build/outputs/apk/release/app-release.apk` and `workspace: dev/maestro/integration-tests`. Update all `working-directory`/cache paths from `examples/todo-client-localfirst-expo` → `dev/integration-tests-expo`. Triggers: push `main`; PR paths `crates/jazz-rn/**`, `packages/jazz-tools/src/react-native/**`, `dev/integration-tests-expo/**`, `dev/maestro/integration-tests/**`, the workflow file.
+- [ ] Commit.
+
+## Task 10 — Final verification
+
+- [ ] `pnpm --filter integration-tests-expo test` (vitest, Node) → all green.
+- [ ] `pnpm --filter integration-tests-expo exec tsc --noEmit` → clean.
+- [ ] `pnpm --filter integration-tests-expo run verify:expo:android` if the Android toolchain is available locally; otherwise note CI-pending.
+- [ ] Final commit. (Push/PR only when the user asks.)
+
+## Risks / CI-pending
+
+- On-device Hermes behavior, the APK build, and the Maestro gate are validated only in CI.
+- If RN unexpectedly denies a local write (shouldn't — default allow), add an allow-all `permissions.ts` and attach to `app`.
+- `expo prebuild` for a fresh app generates `android/`/`ios/`; confirm `.gitignore` covers them (mirror todo app) so generated native dirs aren't committed.
+- Maestro `workspace: dev/maestro/integration-tests` must contain only this flow.


### PR DESCRIPTION
## What

Adds a standalone Expo app — `dev/integration-tests-expo` — that is itself an on-device integration-test runner for the React Native client (`jazz-rn`), plus a dedicated Maestro flow and CI workflow.

Today CI exercises RN through a single happy-path Maestro walkthrough of the todo example. The browser/JS client has a rich integration suite (bulk writes, queries, subscriptions, relations, convergence) that RN has no equivalent of. This fills that gap, and gives us a place to host RN regression scenarios going forward.

## How it works

- On launch the app runs every suite in `tests/_registry.ts` sequentially and renders each test as a row (`pending → running → PASS/FAIL`).
- Each test gets a fresh, **local-only** `Db` (`createDb({ appId })`, no server) and shuts it down afterwards. Default-allow permissions mean no server or policy setup is needed.
- When every test passes, a `suite-passed` element renders. The Maestro flow waits for it; a red test **or a freeze** means it never appears, the wait times out, and the flow fails. The failure screenshot shows which test died.

## Covered (Phase 1, local-only)

bulk writes (100 rows), CRUD round-trip, query conditions, order + limit, `subscribeAll` add/update deltas, forward-ref `include`, local-tier `wait`. Adding a test = one `tests/*.suite.ts` file + one line in `_registry.ts`. Assertions use a small Hermes-safe Jest-style `expect` shim (`runner/expect.ts`).

<img width="545" height="1098" alt="image" src="https://github.com/user-attachments/assets/acff6eef-8af7-4b17-adbb-8b47ee784eaa" />


## CI

`expo-android-integration-e2e.yml` builds a release APK and runs the flow on Maestro Cloud (Android). It mirrors the existing todo e2e workflow but drops the Vercel-sandbox / jazz-tools-server / deploy steps — Phase 1 is local-only, so there are no secrets beyond the Maestro key, which also avoids the known WS-upgrade flakiness.

## Verification

- `tsc --noEmit` clean; runner unit tests 16/16 (Node); oxlint clean.
- The actual suite bodies were run through the runner against the Node/WASM `createDb` (same Rust core + `Db` API as native) — all green — to validate the DSL semantics before the on-device run.
- The APK build + on-device Hermes run + Maestro gate are validated by the new workflow.

## Notes

- The runner (`runner/`) is decoupled from the RN registry so its pure-TS logic is Node-unit-testable.
- Lives under `dev/` (not `examples/`) because it is internal QA tooling, not a user-facing showcase.
- Design + plan: `specs/rn-integration-test-runner-{design,plan}.md`.
- **Phase 2 (not in this PR):** multi-peer sync tests (server-backed or an in-process relay) — the registry/ctx are designed to accommodate a second `Db`.
