### PR TITLE
Avoid repeated retained batch row scans

### DIFF
--- a/crates/jazz-tools/src/runtime_core/sync.rs
+++ b/crates/jazz-tools/src/runtime_core/sync.rs
@@ -96,7 +96,9 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         }));
         batch_ids.sort();
         batch_ids.dedup();
-        batch_ids.retain(|batch_id| !self.local_batch_rows(*batch_id).is_empty());
+        let batch_id_set = batch_ids.iter().copied().collect();
+        let local_rows_by_batch = self.local_batch_rows_for_batch_ids(&batch_id_set);
+        batch_ids.retain(|batch_id| local_rows_by_batch.contains_key(batch_id));
         batch_ids
     }
 

--- a/crates/jazz-tools/src/runtime_core/ticks.rs
+++ b/crates/jazz-tools/src/runtime_core/ticks.rs
@@ -4,7 +4,39 @@ use crate::row_histories::{RowState, patch_row_batch_state};
 use crate::storage::metadata_from_row_locator;
 use crate::sync_manager::{RowMetadata, SyncPayload};
 
+pub(crate) type LocalBatchRow = (
+    LocalBatchMember,
+    crate::storage::RowLocator,
+    crate::row_histories::StoredRowBatch,
+);
+
 impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
+    fn sort_local_batch_rows(rows: &mut [LocalBatchRow]) {
+        rows.sort_by(
+            |(left_member, left_locator, left_row), (right_member, right_locator, right_row)| {
+                left_member
+                    .object_id
+                    .uuid()
+                    .as_bytes()
+                    .cmp(right_member.object_id.uuid().as_bytes())
+                    .then_with(|| {
+                        left_locator
+                            .table
+                            .as_str()
+                            .cmp(right_locator.table.as_str())
+                    })
+                    .then_with(|| left_row.branch.as_str().cmp(right_row.branch.as_str()))
+                    .then_with(|| {
+                        left_member
+                            .schema_hash
+                            .as_bytes()
+                            .cmp(right_member.schema_hash.as_bytes())
+                    })
+                    .then_with(|| left_row.batch_id.0.cmp(&right_row.batch_id.0))
+            },
+        );
+    }
+
     fn local_batch_row_was_insert(
         &self,
         table: &str,
@@ -24,14 +56,10 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         })
     }
 
-    pub(crate) fn local_batch_rows(
+    fn local_batch_rows_without_locator_scan(
         &self,
         batch_id: crate::row_histories::BatchId,
-    ) -> Vec<(
-        LocalBatchMember,
-        crate::storage::RowLocator,
-        crate::row_histories::StoredRowBatch,
-    )> {
+    ) -> Vec<LocalBatchRow> {
         let mut rows = Vec::new();
         if let Ok(Some(submission)) = self.storage.load_sealed_batch_submission(batch_id) {
             for sealed_member in submission.members {
@@ -135,6 +163,16 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                 rows.push((member, row_locator, row));
             }
         }
+
+        Self::sort_local_batch_rows(&mut rows);
+        rows
+    }
+
+    pub(crate) fn local_batch_rows(
+        &self,
+        batch_id: crate::row_histories::BatchId,
+    ) -> Vec<LocalBatchRow> {
+        let mut rows = self.local_batch_rows_without_locator_scan(batch_id);
         if rows.is_empty()
             && let Ok(row_locators) = self.storage.scan_row_locators()
         {
@@ -167,39 +205,71 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             }
         }
 
-        rows.sort_by(
-            |(left_member, left_locator, left_row), (right_member, right_locator, right_row)| {
-                left_member
-                    .object_id
-                    .uuid()
-                    .as_bytes()
-                    .cmp(right_member.object_id.uuid().as_bytes())
-                    .then_with(|| {
-                        left_locator
-                            .table
-                            .as_str()
-                            .cmp(right_locator.table.as_str())
-                    })
-                    .then_with(|| left_row.branch.as_str().cmp(right_row.branch.as_str()))
-                    .then_with(|| {
-                        left_member
-                            .schema_hash
-                            .as_bytes()
-                            .cmp(right_member.schema_hash.as_bytes())
-                    })
-                    .then_with(|| left_row.batch_id.0.cmp(&right_row.batch_id.0))
-            },
-        );
+        Self::sort_local_batch_rows(&mut rows);
         rows
+    }
+
+    pub(crate) fn local_batch_rows_for_batch_ids(
+        &self,
+        batch_ids: &std::collections::HashSet<crate::row_histories::BatchId>,
+    ) -> std::collections::HashMap<crate::row_histories::BatchId, Vec<LocalBatchRow>> {
+        let mut rows_by_batch = std::collections::HashMap::new();
+        let mut missing_rows = std::collections::HashSet::new();
+
+        for batch_id in batch_ids {
+            let rows = self.local_batch_rows_without_locator_scan(*batch_id);
+            if rows.is_empty() {
+                missing_rows.insert(*batch_id);
+            } else {
+                rows_by_batch.insert(*batch_id, rows);
+            }
+        }
+
+        if !missing_rows.is_empty()
+            && let Ok(row_locators) = self.storage.scan_row_locators()
+        {
+            for (object_id, row_locator) in row_locators {
+                let Ok(history_rows) = self
+                    .storage
+                    .scan_history_row_batches(row_locator.table.as_str(), object_id)
+                else {
+                    continue;
+                };
+                for row in history_rows
+                    .into_iter()
+                    .filter(|row| missing_rows.contains(&row.batch_id))
+                {
+                    let batch_id = row.batch_id;
+                    let branch_name = BranchName::new(row.branch.as_str());
+                    let Ok(schema_hash) =
+                        self.local_batch_member_schema_hash(branch_name, object_id, batch_id)
+                    else {
+                        continue;
+                    };
+                    let member = LocalBatchMember {
+                        object_id,
+                        table_name: row_locator.table.to_string(),
+                        branch_name,
+                        schema_hash,
+                        row_digest: row.content_digest(),
+                    };
+                    rows_by_batch
+                        .entry(batch_id)
+                        .or_insert_with(Vec::new)
+                        .push((member, row_locator.clone(), row));
+                }
+            }
+        }
+
+        for rows in rows_by_batch.values_mut() {
+            Self::sort_local_batch_rows(rows);
+        }
+        rows_by_batch
     }
 
     pub(crate) fn direct_sealed_submission_from_local_batch_rows(
         batch_id: crate::row_histories::BatchId,
-        rows: &[(
-            LocalBatchMember,
-            crate::storage::RowLocator,
-            crate::row_histories::StoredRowBatch,
-        )],
+        rows: &[LocalBatchRow],
     ) -> Option<SealedBatchSubmission> {
         let first_branch = rows.first()?.0.branch_name;
         if rows

--- a/crates/jazz-tools/src/runtime_core/writes.rs
+++ b/crates/jazz-tools/src/runtime_core/writes.rs
@@ -854,6 +854,15 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             .map_err(|err| {
                 RuntimeError::WriteError(format!("scan authoritative batch fates: {err}"))
             })?;
+        let fate_batch_ids: std::collections::HashSet<_> = fates
+            .iter()
+            .filter(|fate| {
+                !retained_batch_ids.contains(&fate.batch_id())
+                    && Self::sealed_batch_still_needs_edge_reconciliation(Some(fate))
+            })
+            .map(|fate| fate.batch_id())
+            .collect();
+        let local_rows_by_batch = self.local_batch_rows_for_batch_ids(&fate_batch_ids);
         for fate in fates {
             if retained_batch_ids.contains(&fate.batch_id()) {
                 continue;
@@ -861,9 +870,12 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             if !Self::sealed_batch_still_needs_edge_reconciliation(Some(&fate)) {
                 continue;
             }
-            let local_rows = self.local_batch_rows(fate.batch_id());
+            let local_rows = local_rows_by_batch
+                .get(&fate.batch_id())
+                .map(Vec::as_slice)
+                .unwrap_or(&[]);
             if let Some(submission) =
-                Self::direct_sealed_submission_from_local_batch_rows(fate.batch_id(), &local_rows)
+                Self::direct_sealed_submission_from_local_batch_rows(fate.batch_id(), local_rows)
                 && let Some(record) =
                     self.local_batch_record_from_sealed_submission(submission, Some(fate.clone()))?
             {

--- a/crates/jazz-wasm/src/worker_host.rs
+++ b/crates/jazz-wasm/src/worker_host.rs
@@ -347,10 +347,12 @@ async fn run_init(init: InitPayload) -> Result<(), String> {
         perform_upstream_connect(&runtime_rc, &ws_url, &auth_json);
     }
 
-    // 7. Sync retained local batch records to main. Rejected-batch error
-    //    replay already happened in step 4b; live rejections are handled by
-    //    normal sync payloads reaching the main runtime.
-    sync_retained_local_batch_records(&runtime_rc);
+    // 7. Sync retained local batch records to main only when an upstream can
+    //    promote local fates. Rejected-batch error replay already happened in
+    //    step 4b; live rejections are handled by normal sync payloads.
+    if init.fields.server_url.is_some() {
+        sync_retained_local_batch_records(&runtime_rc);
+    }
 
     // 8. Flip state to Ready before draining (so message handlers process
     //    directly via the dispatch path rather than re-buffering).

--- a/crates/jazz-wasm/src/worker_host.rs
+++ b/crates/jazz-wasm/src/worker_host.rs
@@ -347,12 +347,10 @@ async fn run_init(init: InitPayload) -> Result<(), String> {
         perform_upstream_connect(&runtime_rc, &ws_url, &auth_json);
     }
 
-    // 7. Sync retained local batch records to main only when an upstream can
-    //    promote local fates. Rejected-batch error replay already happened in
-    //    step 4b; live rejections are handled by normal sync payloads.
-    if init.fields.server_url.is_some() {
-        sync_retained_local_batch_records(&runtime_rc);
-    }
+    // 7. Sync retained local batch records to main. Rejected-batch error
+    //    replay already happened in step 4b; live rejections are handled by
+    //    normal sync payloads reaching the main runtime.
+    sync_retained_local_batch_records(&runtime_rc);
 
     // 8. Flip state to Ready before draining (so message handlers process
     //    directly via the dispatch path rather than re-buffering).


### PR DESCRIPTION
Summary:
- keep worker init retained local batch replay intact
- batch local batch row lookups for retained-record sync and pending reconciliation
- preserve existing empty fate marker behavior while avoiding repeated full row locator/history scans

Root cause:
- the regression came from the retained fate replay paths added for worker restart recovery
- when many pending fates had no direct local batch record, each call to local_batch_rows could fall back to scan_row_locators plus scan_history_row_batches
- reload then repeated the same full storage walk once per fate during init/reconciliation

Verification:
- cargo fmt -p jazz-tools -p jazz-wasm
- cargo check -p jazz-tools
- cargo test -p jazz-tools runtime_core::tests::write_batch::rejection_recovery --lib
- cargo check -p jazz-wasm
- git diff --check
- pnpm --filter jazz-wasm build
- browser reload of http://localhost:5477/#list after rebuilding WASM: list rendered immediately; this browser profile still showed zero todos even with replay enabled, so that separate visibility issue was not used as proof of the scan fix

Notes:
- dev/stress-tests/todo-react/vite.config.ts is still an unstaged local workspace change and is not part of this PR
- specs/status-quo/browser_worker_init_flows.md remains an unstaged doc draft and is not part of this PR