### PR TITLE
Export request session helper

### DIFF
--- a/.changeset/export-request-session-helper.md
+++ b/.changeset/export-request-session-helper.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Export `resolveRequestSession` from `jazz-tools/backend` so RPC handlers can derive Jazz sessions from request bearer JWTs without manual decoding.

--- a/packages/jazz-tools/src/backend/index.ts
+++ b/packages/jazz-tools/src/backend/index.ts
@@ -7,6 +7,7 @@ export {
   type BackendSchemaInput,
   type BackendSchemaSource,
 } from "./create-jazz-context.js";
+export { resolveRequestSession, type BackendRequestAuthConfig } from "./request-auth.js";
 export type { WasmSchema } from "../drivers/types.js";
 export type { Session } from "../runtime/context.js";
 export { Db, type QueryBuilder, type QueryOptions, type TableProxy } from "../runtime/db.js";


### PR DESCRIPTION
## Summary

- Export `resolveRequestSession` from `jazz-tools/backend`
- Re-export `BackendRequestAuthConfig` for typed callers
- Add a patch changeset for `jazz-tools`

## Validation

- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/backend/request-auth.test.ts src/backend/create-jazz-context.test.ts`
- `pnpm exec tsc --noEmit -p /private/tmp/jazz-backend-export-tsconfig.json`
