### PR TITLE
Fix worker retained overlay replay

### DIFF
--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -2307,6 +2307,73 @@ impl QueryManager {
         self.mark_local_row_updated_in_subscriptions(table, id);
     }
 
+    pub(crate) fn hydrate_retained_local_overlay_row(&mut self, table: &str, row_key: RowBatchKey) {
+        self.pending_local_row_batches
+            .insert(row_key.row_id, row_key);
+        self.visible_rows_by_batch
+            .entry(row_key.batch_id)
+            .or_default()
+            .insert((table.to_string(), row_key.row_id));
+        self.mark_subscriptions_dirty_local(table);
+        self.mark_local_row_updated_in_subscriptions(table, row_key.row_id);
+    }
+
+    pub(crate) fn pending_local_overlay_rows_for_batch(
+        &self,
+        batch_id: BatchId,
+    ) -> Vec<(String, ObjectId)> {
+        self.pending_local_overlay_row_keys_for_batch(batch_id)
+            .into_iter()
+            .map(|(table_name, row_key)| (table_name, row_key.row_id))
+            .collect()
+    }
+
+    pub(crate) fn pending_local_overlay_row_keys_for_batch(
+        &self,
+        batch_id: BatchId,
+    ) -> Vec<(String, RowBatchKey)> {
+        let Some(rows) = self.visible_rows_by_batch.get(&batch_id) else {
+            return Vec::new();
+        };
+
+        let mut pending_rows = rows
+            .iter()
+            .filter_map(|(table_name, row_id)| {
+                self.pending_local_row_batches
+                    .get(row_id)
+                    .copied()
+                    .filter(|row_key| row_key.batch_id == batch_id)
+                    .map(|row_key| (table_name.clone(), row_key))
+            })
+            .collect::<Vec<_>>();
+        pending_rows.sort_by(|left, right| {
+            left.0
+                .cmp(&right.0)
+                .then_with(|| left.1.row_id.cmp(&right.1.row_id))
+                .then_with(|| {
+                    left.1
+                        .branch_name
+                        .as_str()
+                        .cmp(right.1.branch_name.as_str())
+                })
+                .then_with(|| left.1.batch_id.cmp(&right.1.batch_id))
+        });
+        pending_rows
+    }
+
+    pub(crate) fn clear_pending_local_overlay_rows_for_batch(
+        &mut self,
+        batch_id: BatchId,
+    ) -> Vec<(String, ObjectId)> {
+        let rows = self.pending_local_overlay_rows_for_batch(batch_id);
+        for (table, row_id) in &rows {
+            self.pending_local_row_batches.remove(row_id);
+            self.mark_subscriptions_dirty_local(table);
+            self.mark_local_row_updated_in_subscriptions(table, *row_id);
+        }
+        rows
+    }
+
     fn load_row_locator(storage: &dyn Storage, row_id: ObjectId) -> Option<RowLocator> {
         storage.load_row_locator(row_id).ok().flatten()
     }

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -2367,9 +2367,7 @@ impl QueryManager {
     ) -> Vec<(String, ObjectId)> {
         let rows = self.pending_local_overlay_rows_for_batch(batch_id);
         for (table, row_id) in &rows {
-            self.pending_local_row_batches.remove(row_id);
-            self.mark_subscriptions_dirty_local(table);
-            self.mark_local_row_updated_in_subscriptions(table, *row_id);
+            self.clear_local_pending_row_overlay(table, *row_id);
         }
         rows
     }

--- a/crates/jazz-tools/src/runtime_core/mod.rs
+++ b/crates/jazz-tools/src/runtime_core/mod.rs
@@ -49,7 +49,9 @@ use crate::row_format::decode_row;
 use crate::row_histories::BatchId;
 use crate::schema_manager::{Lens, SchemaManager};
 use crate::storage::{Storage, StorageError};
-use crate::sync_manager::{ClientId, DurabilityTier, InboxEntry, OutboxEntry, ServerId};
+use crate::sync_manager::{
+    ClientId, DurabilityTier, InboxEntry, OutboxEntry, RowBatchKey, ServerId,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MutationErrorEvent {
@@ -77,6 +79,14 @@ pub(crate) struct QueryLocalOverlay {
     pub(crate) batch_id: BatchId,
     pub(crate) branch_name: BranchName,
     pub(crate) row_ids: Vec<ObjectId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RetainedLocalOverlayRow {
+    pub table_name: String,
+    pub object_id: ObjectId,
+    pub branch_name: BranchName,
+    pub batch_id: BatchId,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -834,6 +844,14 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
     /// Attach a transport handle. Replaces any existing transport.
     pub fn set_transport(&mut self, handle: crate::transport_manager::TransportHandle) {
         self.transport = Some(handle);
+    }
+
+    pub fn hydrate_retained_local_overlay_row(&mut self, row: RetainedLocalOverlayRow) {
+        let row_key = RowBatchKey::new(row.object_id, row.branch_name, row.batch_id);
+        self.schema_manager
+            .query_manager_mut()
+            .hydrate_retained_local_overlay_row(&row.table_name, row_key);
+        self.immediate_tick();
     }
 
     pub(crate) fn mark_transport_catalogue_state_hash_dirty(&mut self) {

--- a/crates/jazz-tools/src/runtime_core/sync.rs
+++ b/crates/jazz-tools/src/runtime_core/sync.rs
@@ -165,24 +165,6 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         self.immediate_tick();
     }
 
-    pub fn reconcile_local_batch_with_server(&mut self, batch_id: crate::row_histories::BatchId) {
-        let Some(server_id) = self
-            .schema_manager
-            .query_manager()
-            .sync_manager()
-            .server_ids()
-            .next()
-        else {
-            return;
-        };
-        self.retransmit_local_batch_to_servers(batch_id);
-        self.schema_manager
-            .query_manager_mut()
-            .sync_manager_mut()
-            .request_batch_fates_from_server(server_id, vec![batch_id]);
-        self.immediate_tick();
-    }
-
     /// Remove a server connection.
     pub fn remove_server(&mut self, server_id: ServerId) {
         self.schema_manager

--- a/crates/jazz-tools/src/runtime_core/tests.rs
+++ b/crates/jazz-tools/src/runtime_core/tests.rs
@@ -36,6 +36,14 @@ struct RowRegionReadFailingStorage {
     inner: MemoryStorage,
     fail_visible_row_reads: bool,
     fail_row_locator_scans: bool,
+    calls: Arc<Mutex<RowRegionReadCallCounts>>,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct RowRegionReadCallCounts {
+    scan_row_locator_calls: usize,
+    load_row_locator_calls: usize,
+    scan_history_row_batches_calls: usize,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -70,6 +78,7 @@ impl RowRegionReadFailingStorage {
             inner: MemoryStorage::new(),
             fail_visible_row_reads: true,
             fail_row_locator_scans: false,
+            calls: Arc::new(Mutex::new(RowRegionReadCallCounts::default())),
         }
     }
 
@@ -78,7 +87,12 @@ impl RowRegionReadFailingStorage {
             inner: MemoryStorage::new(),
             fail_visible_row_reads: false,
             fail_row_locator_scans: true,
+            calls: Arc::new(Mutex::new(RowRegionReadCallCounts::default())),
         }
+    }
+
+    fn call_counts(&self) -> RowRegionReadCallCounts {
+        *self.calls.lock().unwrap()
     }
 }
 
@@ -144,6 +158,7 @@ impl Storage for RowRegionReadFailingStorage {
     }
 
     fn scan_row_locators(&self) -> Result<crate::storage::RowLocatorRows, StorageError> {
+        self.calls.lock().unwrap().scan_row_locator_calls += 1;
         if self.fail_row_locator_scans {
             return Err(StorageError::IoError(
                 "row-locator scans deliberately disabled in this test".to_string(),
@@ -156,6 +171,7 @@ impl Storage for RowRegionReadFailingStorage {
         &self,
         id: ObjectId,
     ) -> Result<Option<crate::storage::RowLocator>, StorageError> {
+        self.calls.lock().unwrap().load_row_locator_calls += 1;
         self.inner.load_row_locator(id)
     }
 
@@ -344,6 +360,7 @@ impl Storage for RowRegionReadFailingStorage {
         table: &str,
         row_id: ObjectId,
     ) -> Result<Vec<crate::row_histories::StoredRowBatch>, StorageError> {
+        self.calls.lock().unwrap().scan_history_row_batches_calls += 1;
         self.inner.scan_history_row_batches(table, row_id)
     }
 

--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/rejection_recovery.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/rejection_recovery.rs
@@ -1264,10 +1264,10 @@ fn rc_transactional_rejected_replay_record_keeps_sealed_submission_mode() {
 }
 
 #[test]
-fn rc_worker_sync_records_include_sealed_batches_pending_edge_reconciliation() {
+fn rc_worker_overlay_sync_includes_sealed_batches_pending_edge_reconciliation() {
     let mut core = create_runtime_with_schema(
         users_delete_denied_authorization_schema(),
-        "direct-pending-worker-sync-record-test",
+        "direct-pending-worker-overlay-test",
     );
 
     let ((row_id, _row_values), _receiver) = insert_and_wait_for_batch(
@@ -1291,25 +1291,19 @@ fn rc_worker_sync_records_include_sealed_batches_pending_edge_reconciliation() {
         .unwrap();
 
     assert_eq!(core.local_batch_record(batch_id).unwrap(), None);
-    let records = core.local_batch_records_for_worker_sync().unwrap();
-    assert_eq!(records.len(), 1);
-    assert_eq!(records[0].batch_id, batch_id);
-    assert!(matches!(
-        records[0].latest_fate,
-        Some(crate::batch_fate::BatchFate::DurableDirect {
-            confirmed_tier: DurabilityTier::Local,
-            ..
-        })
-    ));
-    assert_eq!(records[0].members.len(), 1);
-    assert_eq!(records[0].members[0].object_id, row_id);
+    let entries = core.retained_local_overlay_rows_for_worker_sync().unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].batch_id, batch_id);
+    assert_eq!(entries[0].object_id, row_id);
+    assert_eq!(entries[0].table_name, "users");
+    assert_eq!(entries[0].branch_name, branch_name);
 }
 
 #[test]
-fn rc_worker_sync_records_include_local_only_fates_as_pending_markers() {
+fn rc_worker_overlay_sync_excludes_local_only_fates_without_submissions() {
     let mut core = create_runtime_with_schema(
         users_delete_denied_authorization_schema(),
-        "direct-pending-fate-worker-sync-record-test",
+        "direct-pending-fate-worker-overlay-test",
     );
     let batch_id = BatchId::new();
 
@@ -1320,17 +1314,145 @@ fn rc_worker_sync_records_include_local_only_fates_as_pending_markers() {
         })
         .unwrap();
 
-    let records = core.local_batch_records_for_worker_sync().unwrap();
-    assert_eq!(records.len(), 1);
-    assert_eq!(records[0].batch_id, batch_id);
-    assert!(records[0].members.is_empty());
-    assert!(matches!(
-        records[0].latest_fate,
-        Some(crate::batch_fate::BatchFate::DurableDirect {
-            confirmed_tier: DurabilityTier::Local,
-            ..
-        })
-    ));
+    let entries = core.retained_local_overlay_rows_for_worker_sync().unwrap();
+    assert!(
+        entries.is_empty(),
+        "fate-only batches without retained submissions are not a startup overlay source"
+    );
+}
+
+#[test]
+fn rc_worker_overlay_sync_uses_point_locators_without_scans() {
+    let schema = users_delete_denied_authorization_schema();
+    let app_id = AppId::from_name("direct-pending-worker-overlay-no-scan-test");
+    let schema_manager =
+        SchemaManager::new(SyncManager::new(), schema, app_id, "dev", "main").unwrap();
+    let mut core = new_test_core(
+        schema_manager,
+        RowRegionReadFailingStorage::with_row_locator_scan_failure(),
+        NoopScheduler,
+    );
+    core.immediate_tick();
+
+    let ((retained_row_id, _row_values), _receiver) = insert_and_wait_for_batch(
+        &mut core,
+        "users",
+        user_insert_values(ObjectId::new(), "Retained"),
+        None,
+        DurabilityTier::Local,
+    )
+    .unwrap();
+    let branch_name = core.schema_manager().branch_name();
+    let retained_batch_id = core
+        .storage()
+        .load_visible_region_row("users", branch_name.as_str(), retained_row_id)
+        .unwrap()
+        .expect("persisted direct insert should materialize a visible row")
+        .batch_id;
+    core.storage_mut()
+        .delete_local_batch_record(retained_batch_id)
+        .unwrap();
+
+    for index in 0..5 {
+        let ((unrelated_row_id, _row_values), _receiver) = insert_and_wait_for_batch(
+            &mut core,
+            "users",
+            user_insert_values(ObjectId::new(), &format!("Unrelated {index}")),
+            None,
+            DurabilityTier::Local,
+        )
+        .unwrap();
+        let unrelated_batch_id = core
+            .storage()
+            .load_visible_region_row("users", branch_name.as_str(), unrelated_row_id)
+            .unwrap()
+            .expect("persisted unrelated row should materialize a visible row")
+            .batch_id;
+        core.storage_mut()
+            .delete_local_batch_record(unrelated_batch_id)
+            .unwrap();
+        core.storage_mut()
+            .delete_sealed_batch_submission(unrelated_batch_id)
+            .unwrap();
+    }
+
+    let before = core.storage().call_counts();
+    let entries = core.retained_local_overlay_rows_for_worker_sync().unwrap();
+    let after = core.storage().call_counts();
+
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].object_id, retained_row_id);
+    assert_eq!(entries[0].batch_id, retained_batch_id);
+    assert_eq!(
+        after.scan_row_locator_calls - before.scan_row_locator_calls,
+        0,
+        "retained overlay sync must not scan row locators"
+    );
+    assert_eq!(
+        after.scan_history_row_batches_calls - before.scan_history_row_batches_calls,
+        0,
+        "retained overlay sync must not scan history row batches"
+    );
+    assert_eq!(
+        after.load_row_locator_calls - before.load_row_locator_calls,
+        entries.len(),
+        "point locator lookups should scale with retained members, not total stored rows"
+    );
+}
+
+#[test]
+fn rc_overlay_only_global_fate_clears_without_local_batch_scans() {
+    let schema = users_delete_denied_authorization_schema();
+    let app_id = AppId::from_name("overlay-only-global-fate-no-scan-test");
+    let schema_manager =
+        SchemaManager::new(SyncManager::new(), schema, app_id, "dev", "main").unwrap();
+    let mut core = new_test_core(
+        schema_manager,
+        RowRegionReadFailingStorage::with_row_locator_scan_failure(),
+        NoopScheduler,
+    );
+    core.immediate_tick();
+
+    let batch_id = BatchId::new();
+    let row_id = ObjectId::new();
+    core.hydrate_retained_local_overlay_row(RetainedLocalOverlayRow {
+        table_name: "users".to_string(),
+        object_id: row_id,
+        branch_name: crate::object::BranchName::new("main"),
+        batch_id,
+    });
+
+    let before = core.storage().call_counts();
+    core.park_sync_message(InboxEntry {
+        source: Source::Server(ServerId::new()),
+        payload: SyncPayload::BatchFate {
+            fate: crate::batch_fate::BatchFate::DurableDirect {
+                batch_id,
+                confirmed_tier: DurabilityTier::GlobalServer,
+            },
+        },
+    });
+    core.batched_tick();
+    core.immediate_tick();
+    let after = core.storage().call_counts();
+
+    assert_eq!(
+        after.scan_row_locator_calls - before.scan_row_locator_calls,
+        0,
+        "overlay-only fate handling must not scan row locators"
+    );
+    assert_eq!(
+        after.scan_history_row_batches_calls - before.scan_history_row_batches_calls,
+        0,
+        "overlay-only fate handling must not scan history row batches"
+    );
+    assert!(
+        core.schema_manager()
+            .query_manager()
+            .pending_local_overlay_rows_for_batch(batch_id)
+            .is_empty(),
+        "global fate should clear the retained overlay"
+    );
 }
 
 #[test]
@@ -1367,12 +1489,12 @@ fn rc_worker_accepts_local_batch_replay_payloads_from_peer() {
     worker.batched_tick();
     worker.immediate_tick();
 
-    let records = worker.local_batch_records_for_worker_sync().unwrap();
+    let entries = worker
+        .retained_local_overlay_rows_for_worker_sync()
+        .unwrap();
     assert!(
-        records
-            .iter()
-            .any(|record| record.batch_id == batch_id && record.members.len() == 1),
-        "worker should retain memberful batch record after local replay; records={records:?}"
+        entries.is_empty(),
+        "worker startup overlay sync must not synthesize entries from replayed row history without a retained submission; entries={entries:?}"
     );
     assert!(
         worker

--- a/crates/jazz-tools/src/runtime_core/ticks.rs
+++ b/crates/jazz-tools/src/runtime_core/ticks.rs
@@ -5,6 +5,95 @@ use crate::storage::metadata_from_row_locator;
 use crate::sync_manager::{RowMetadata, SyncPayload};
 
 impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
+    fn pending_overlay_only_rows_for_batch(
+        &self,
+        batch_id: crate::row_histories::BatchId,
+    ) -> Vec<(String, crate::sync_manager::RowBatchKey)> {
+        let rows = self
+            .schema_manager
+            .query_manager()
+            .pending_local_overlay_row_keys_for_batch(batch_id);
+        if rows.is_empty() {
+            return rows;
+        }
+        if self
+            .storage
+            .load_local_batch_record(batch_id)
+            .ok()
+            .flatten()
+            .is_some()
+        {
+            return Vec::new();
+        }
+        rows
+    }
+
+    fn reject_pending_overlay_only_rows_for_batch(
+        &mut self,
+        batch_id: crate::row_histories::BatchId,
+    ) -> bool {
+        let rows = self.pending_overlay_only_rows_for_batch(batch_id);
+        if rows.is_empty() {
+            return false;
+        }
+
+        for (table, row_key) in rows {
+            let branch = row_key.branch_name.as_str().to_string();
+            let visible_row = self
+                .storage
+                .load_visible_region_row(&table, &branch, row_key.row_id)
+                .ok()
+                .flatten()
+                .filter(|row| row.batch_id() == batch_id);
+            if let Some(row) = visible_row.as_ref() {
+                let _ = self.storage.patch_row_region_rows_by_batch(
+                    &table,
+                    batch_id,
+                    Some(RowState::Rejected),
+                    None,
+                );
+                let _ = self.storage.patch_exact_row_batch(
+                    &table,
+                    &branch,
+                    row_key.row_id,
+                    batch_id,
+                    Some(RowState::Rejected),
+                    None,
+                );
+                let query_manager = self.schema_manager.query_manager_mut();
+                if row.delete_kind.is_some() {
+                    query_manager.restore_local_rejected_delete_row(
+                        &mut self.storage,
+                        &table,
+                        &branch,
+                        row_key.row_id,
+                        &row.data,
+                    );
+                } else if row.parents.is_empty() {
+                    let _ = self
+                        .storage
+                        .delete_visible_region_row(&table, &branch, row_key.row_id);
+                    query_manager.retract_local_rejected_row(
+                        &mut self.storage,
+                        &table,
+                        &branch,
+                        row_key.row_id,
+                        &row.data,
+                        true,
+                    );
+                } else {
+                    query_manager.clear_local_pending_row_overlay(&table, row_key.row_id);
+                }
+            } else {
+                self.schema_manager
+                    .query_manager_mut()
+                    .clear_local_pending_row_overlay(&table, row_key.row_id);
+            }
+        }
+
+        true
+    }
+
     fn local_batch_row_was_insert(
         &self,
         table: &str,
@@ -239,7 +328,9 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         }
 
         if let crate::batch_fate::BatchFate::Rejected { code, reason, .. } = &fate {
-            self.mark_local_batch_rows_rejected(batch_id);
+            if !self.reject_pending_overlay_only_rows_for_batch(batch_id) {
+                self.mark_local_batch_rows_rejected(batch_id);
+            }
             let acknowledged = self
                 .is_rejected_batch_acknowledged(batch_id)
                 .unwrap_or(false);
@@ -266,7 +357,12 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                 }
             }
         } else if matches!(fate, crate::batch_fate::BatchFate::Missing { .. }) {
-            self.retransmit_local_batch_to_servers(batch_id);
+            if self
+                .pending_overlay_only_rows_for_batch(batch_id)
+                .is_empty()
+            {
+                self.retransmit_local_batch_to_servers(batch_id);
+            }
         } else if matches!(
             fate,
             crate::batch_fate::BatchFate::AcceptedTransaction { .. }
@@ -280,13 +376,26 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             self.schema_manager
                 .query_manager_mut()
                 .mark_subscriptions_visibility_recompute_for_tier(acked_tier);
-            for (member, row_locator, _) in self.local_batch_rows(batch_id) {
+            let overlay_rows = self.pending_overlay_only_rows_for_batch(batch_id);
+            if overlay_rows.is_empty() {
+                for (member, row_locator, _) in self.local_batch_rows(batch_id) {
+                    self.schema_manager
+                        .query_manager_mut()
+                        .mark_local_row_updated_in_subscriptions(
+                            row_locator.table.as_str(),
+                            member.object_id,
+                        );
+                }
+            } else if acked_tier >= DurabilityTier::GlobalServer {
                 self.schema_manager
                     .query_manager_mut()
-                    .mark_local_row_updated_in_subscriptions(
-                        row_locator.table.as_str(),
-                        member.object_id,
-                    );
+                    .clear_pending_local_overlay_rows_for_batch(batch_id);
+            } else {
+                for (table_name, row_key) in overlay_rows {
+                    self.schema_manager
+                        .query_manager_mut()
+                        .mark_local_row_updated_in_subscriptions(&table_name, row_key.row_id);
+                }
             }
             self.durability.record_batch_ack(batch_id, acked_tier);
         }

--- a/crates/jazz-tools/src/runtime_core/writes.rs
+++ b/crates/jazz-tools/src/runtime_core/writes.rs
@@ -815,11 +815,13 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         &self,
     ) -> Result<Vec<RetainedLocalOverlayRow>, RuntimeError> {
         let mut rows = Vec::new();
+        let mut covered_batch_ids = std::collections::HashSet::new();
 
         for record in self.local_batch_records()? {
             if !Self::sealed_batch_still_needs_edge_reconciliation(record.latest_fate.as_ref()) {
                 continue;
             }
+            covered_batch_ids.insert(record.batch_id);
             for member in record.members {
                 rows.push(RetainedLocalOverlayRow {
                     table_name: member.table_name,
@@ -838,6 +840,12 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             })?;
 
         for submission in submissions {
+            // A batch already contributed by a retained local record carries the
+            // same members; skip the per-member locator lookups instead of
+            // re-deriving identical rows only to drop them in the final dedup.
+            if covered_batch_ids.contains(&submission.batch_id) {
+                continue;
+            }
             let fate = self
                 .storage
                 .load_authoritative_batch_fate(submission.batch_id)
@@ -925,21 +933,6 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
     /// Drain replayable mutation error events that should be surfaced by bindings.
     pub fn drain_mutation_error_events(&mut self) -> Vec<MutationErrorEvent> {
         self.durability.drain_mutation_error_events()
-    }
-
-    pub fn hydrate_local_batch_record(
-        &mut self,
-        record: LocalBatchRecord,
-    ) -> Result<(), RuntimeError> {
-        self.storage
-            .upsert_local_batch_record(&record)
-            .map_err(|err| {
-                RuntimeError::WriteError(format!("persist local batch record: {err}"))
-            })?;
-        self.local_batch_record_cache
-            .insert(record.batch_id, record);
-        self.mark_storage_write_pending_flush();
-        Ok(())
     }
 
     pub fn replay_batch_rejection(

--- a/crates/jazz-tools/src/runtime_core/writes.rs
+++ b/crates/jazz-tools/src/runtime_core/writes.rs
@@ -811,16 +811,25 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         }
     }
 
-    /// Load retained local batch records plus sealed submissions that still
-    /// need edge reconciliation. Browser workers send this set to the main
-    /// runtime during startup so local queries know when they must wait for the
-    /// upstream fate before rendering locally durable optimistic rows.
-    pub fn local_batch_records_for_worker_sync(
+    pub fn retained_local_overlay_rows_for_worker_sync(
         &self,
-    ) -> Result<Vec<LocalBatchRecord>, RuntimeError> {
-        let mut records = self.local_batch_records()?;
-        let retained_batch_ids: std::collections::HashSet<_> =
-            records.iter().map(|record| record.batch_id).collect();
+    ) -> Result<Vec<RetainedLocalOverlayRow>, RuntimeError> {
+        let mut rows = Vec::new();
+
+        for record in self.local_batch_records()? {
+            if !Self::sealed_batch_still_needs_edge_reconciliation(record.latest_fate.as_ref()) {
+                continue;
+            }
+            for member in record.members {
+                rows.push(RetainedLocalOverlayRow {
+                    table_name: member.table_name,
+                    object_id: member.object_id,
+                    branch_name: member.branch_name,
+                    batch_id: record.batch_id,
+                });
+            }
+        }
+
         let submissions = self
             .storage
             .scan_sealed_batch_submissions()
@@ -829,9 +838,6 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             })?;
 
         for submission in submissions {
-            if retained_batch_ids.contains(&submission.batch_id) {
-                continue;
-            }
             let fate = self
                 .storage
                 .load_authoritative_batch_fate(submission.batch_id)
@@ -839,47 +845,38 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             if !Self::sealed_batch_still_needs_edge_reconciliation(fate.as_ref()) {
                 continue;
             }
-            if let Some(record) =
-                self.local_batch_record_from_sealed_submission(submission, fate)?
-            {
-                records.push(record);
+
+            for member in submission.members {
+                let Some(row_locator) = self
+                    .storage
+                    .load_row_locator(member.object_id)
+                    .map_err(|err| RuntimeError::WriteError(format!("load row locator: {err}")))?
+                else {
+                    continue;
+                };
+                rows.push(RetainedLocalOverlayRow {
+                    table_name: row_locator.table.to_string(),
+                    object_id: member.object_id,
+                    branch_name: submission.target_branch_name,
+                    batch_id: submission.batch_id,
+                });
             }
         }
 
-        let retained_batch_ids: std::collections::HashSet<_> =
-            records.iter().map(|record| record.batch_id).collect();
-        let fates = self
-            .storage
-            .scan_authoritative_batch_fates()
-            .map_err(|err| {
-                RuntimeError::WriteError(format!("scan authoritative batch fates: {err}"))
-            })?;
-        for fate in fates {
-            if retained_batch_ids.contains(&fate.batch_id()) {
-                continue;
-            }
-            if !Self::sealed_batch_still_needs_edge_reconciliation(Some(&fate)) {
-                continue;
-            }
-            let local_rows = self.local_batch_rows(fate.batch_id());
-            if let Some(submission) =
-                Self::direct_sealed_submission_from_local_batch_rows(fate.batch_id(), &local_rows)
-                && let Some(record) =
-                    self.local_batch_record_from_sealed_submission(submission, Some(fate.clone()))?
-            {
-                records.push(record);
-                continue;
-            }
-            records.push(LocalBatchRecord::new(
-                fate.batch_id(),
-                BatchMode::Direct,
-                true,
-                Some(fate),
-            ));
-        }
-
-        records.sort_by_key(|record| record.batch_id);
-        Ok(records)
+        rows.sort_by(|left, right| {
+            left.table_name
+                .cmp(&right.table_name)
+                .then_with(|| left.object_id.cmp(&right.object_id))
+                .then_with(|| left.branch_name.as_str().cmp(right.branch_name.as_str()))
+                .then_with(|| left.batch_id.cmp(&right.batch_id))
+        });
+        rows.dedup_by(|left, right| {
+            left.table_name == right.table_name
+                && left.object_id == right.object_id
+                && left.branch_name == right.branch_name
+                && left.batch_id == right.batch_id
+        });
+        Ok(rows)
     }
 
     /// Scan all replayable local batch records currently retained by this

--- a/crates/jazz-wasm/src/worker_bridge.rs
+++ b/crates/jazz-wasm/src/worker_bridge.rs
@@ -21,10 +21,9 @@ use std::rc::Rc;
 
 use futures::channel::oneshot;
 use futures::future::{select, Either};
-use jazz_tools::batch_fate::{BatchFate, LocalBatchRecord};
 use jazz_tools::binding_support::parse_batch_id_input;
 use jazz_tools::row_histories::BatchId;
-use jazz_tools::sync_manager::DurabilityTier;
+use jazz_tools::runtime_core::RetainedLocalOverlayRow;
 use js_sys::{Array, Function, Object, Reflect, Uint8Array};
 use serde::Deserialize;
 use wasm_bindgen::prelude::*;
@@ -59,17 +58,6 @@ fn post_wire(worker: &Worker, msg: &MainToWorkerWire) {
         return;
     };
     let _ = worker.post_message_with_transfer(&value, transfer.as_ref());
-}
-
-fn local_batch_record_needs_fate_reconciliation(record: &LocalBatchRecord) -> bool {
-    match record.latest_fate.as_ref() {
-        None => true,
-        Some(BatchFate::DurableDirect { confirmed_tier, .. })
-        | Some(BatchFate::AcceptedTransaction { confirmed_tier, .. }) => {
-            *confirmed_tier < DurabilityTier::EdgeServer
-        }
-        Some(BatchFate::Missing { .. } | BatchFate::Rejected { .. }) => false,
-    }
 }
 
 // =============================================================================
@@ -601,34 +589,18 @@ impl BridgeInner {
         );
     }
 
-    fn hydrate_worker_local_batch_records(&self, encoded_records: Vec<serde_bytes::ByteBuf>) {
-        for row in encoded_records {
-            match LocalBatchRecord::decode_storage_row(row.as_ref()) {
-                Ok(record) => self.hydrate_worker_local_batch_record(record),
-                Err(error) => tracing::warn!("decode worker local batch record: {error:?}"),
-            }
-        }
-    }
-
-    fn hydrate_worker_local_batch_record(&self, record: LocalBatchRecord) {
-        let should_reconcile = local_batch_record_needs_fate_reconciliation(&record);
-        let batch_id = record.batch_id;
+    fn hydrate_worker_local_overlay_entries(
+        &self,
+        entries: Vec<crate::worker_protocol::LocalOverlayEntryWire>,
+    ) {
         let mut core = self.runtime.core.borrow_mut();
-        if let Some(BatchFate::Rejected { code, reason, .. }) = record.latest_fate.clone() {
-            if let Err(error) = core.replay_batch_rejection(record.batch_id, &code, &reason) {
-                tracing::warn!(
-                    batch_id = ?record.batch_id,
-                    %error,
-                    "replay worker rejected batch during hydration failed"
-                );
-            }
-        }
-        if let Err(error) = core.hydrate_local_batch_record(record) {
-            tracing::warn!("hydrate worker local batch record: {error:?}");
-            return;
-        }
-        if should_reconcile {
-            core.reconcile_local_batch_with_server(batch_id);
+        for entry in entries {
+            core.hydrate_retained_local_overlay_row(RetainedLocalOverlayRow {
+                table_name: entry.table_name,
+                object_id: entry.object_id,
+                branch_name: entry.branch_name,
+                batch_id: entry.batch_id,
+            });
         }
     }
 
@@ -788,8 +760,8 @@ impl BridgeInner {
                     let _ = cb.call1(&JsValue::NULL, &JsValue::from_str(&reason));
                 }
             }
-            WorkerToMainWire::LocalBatchRecordsSync { encoded_records } => {
-                self.hydrate_worker_local_batch_records(encoded_records);
+            WorkerToMainWire::LocalOverlaySync { entries } => {
+                self.hydrate_worker_local_overlay_entries(entries);
             }
             WorkerToMainWire::MutationErrorReplay {
                 batch_id,

--- a/crates/jazz-wasm/src/worker_host.rs
+++ b/crates/jazz-wasm/src/worker_host.rs
@@ -15,7 +15,7 @@
 //!   3. bootstrap catalogue (internal server attach/detach while flag is set)
 //!   4. connect upstream (install Rust transport handle)
 //!   5. drain pending pre-init messages (sync, peer-sync, control)
-//!   6. sync retained local batch records + queue rejected-batch replay
+//!   6. sync retained local overlays + queue rejected-batch replay
 //!   7. flip state to `Ready`
 //!   8. post `init-ok`
 //!
@@ -46,15 +46,14 @@ use std::collections::{HashMap, VecDeque};
 use std::rc::Rc;
 
 use js_sys::{Array, Function, Object, Reflect, Uint8Array};
-use serde_bytes::ByteBuf;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use web_sys::{DedicatedWorkerGlobalScope, MessageEvent};
 
 use crate::runtime::{RustOutboxSender, WasmRuntime};
 use crate::worker_protocol::{
-    parse_main_to_worker, worker_to_main_post, InitPayload, MainToWorkerMessage, MainToWorkerWire,
-    WorkerLifecycleEvent, WorkerToMainWire,
+    parse_main_to_worker, worker_to_main_post, InitPayload, LocalOverlayEntryWire,
+    MainToWorkerMessage, MainToWorkerWire, WorkerLifecycleEvent, WorkerToMainWire,
 };
 
 // =============================================================================
@@ -347,10 +346,10 @@ async fn run_init(init: InitPayload) -> Result<(), String> {
         perform_upstream_connect(&runtime_rc, &ws_url, &auth_json);
     }
 
-    // 7. Sync retained local batch records to main. Rejected-batch error
+    // 7. Sync retained local overlays to main. Rejected-batch error
     //    replay already happened in step 4b; live rejections are handled by
     //    normal sync payloads reaching the main runtime.
-    sync_retained_local_batch_records(&runtime_rc);
+    sync_retained_local_overlay_rows(&runtime_rc);
 
     // 8. Flip state to Ready before draining (so message handlers process
     //    directly via the dispatch path rather than re-buffering).
@@ -469,29 +468,30 @@ fn make_peer_routing_lookup() -> Function {
 // Mutation-error replay
 // =============================================================================
 
-fn sync_retained_local_batch_records(runtime: &Rc<WasmRuntime>) {
-    match retained_local_batch_records_payload(runtime) {
-        Ok(encoded_records) => {
-            post_to_main(&WorkerToMainWire::LocalBatchRecordsSync { encoded_records })
-        }
-        Err(err) => tracing::warn!("load retained local batch records failed: {err:?}"),
+fn sync_retained_local_overlay_rows(runtime: &Rc<WasmRuntime>) {
+    match retained_local_overlay_entries_payload(runtime) {
+        Ok(entries) => post_to_main(&WorkerToMainWire::LocalOverlaySync { entries }),
+        Err(err) => tracing::warn!("load retained local overlay rows failed: {err:?}"),
     }
 }
 
-fn retained_local_batch_records_payload(runtime: &Rc<WasmRuntime>) -> Result<Vec<ByteBuf>, String> {
-    let records = runtime
+fn retained_local_overlay_entries_payload(
+    runtime: &Rc<WasmRuntime>,
+) -> Result<Vec<LocalOverlayEntryWire>, String> {
+    let rows = runtime
         .core
         .borrow()
-        .local_batch_records_for_worker_sync()
+        .retained_local_overlay_rows_for_worker_sync()
         .map_err(|err| format!("{err:?}"))?;
-    let mut encoded_records = Vec::with_capacity(records.len());
-    for record in &records {
-        match record.encode_storage_row() {
-            Ok(row) => encoded_records.push(ByteBuf::from(row)),
-            Err(err) => tracing::warn!("encode local batch record for sync: {err:?}"),
-        }
-    }
-    Ok(encoded_records)
+    Ok(rows
+        .into_iter()
+        .map(|row| LocalOverlayEntryWire {
+            table_name: row.table_name,
+            object_id: row.object_id,
+            branch_name: row.branch_name,
+            batch_id: row.batch_id,
+        })
+        .collect())
 }
 
 /// Drain mutation errors restored from persistent storage on startup and post

--- a/crates/jazz-wasm/src/worker_protocol.rs
+++ b/crates/jazz-wasm/src/worker_protocol.rs
@@ -9,13 +9,14 @@
 //!
 //! Variant fields use `serde_bytes::ByteBuf` for binary payloads so postcard
 //! serialises them as length-prefixed bytes rather than Vec<u8>'s default
-//! sequence-of-u8s. Worker-retained local batch records ride as encoded
-//! storage rows so the main-thread Rust runtime can hydrate them directly.
+//! sequence-of-u8s. Worker-retained local overlays ride as typed row entries.
 //! Debug-only JS-shaped fields still ride as JSON strings inside the binary
 //! envelope.
 
 #![allow(dead_code)]
 
+use jazz_tools::object::{BranchName, ObjectId};
+use jazz_tools::row_histories::BatchId;
 use js_sys::{Array, Reflect, Uint8Array};
 use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
@@ -122,6 +123,14 @@ pub enum MainToWorkerWire {
     },
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LocalOverlayEntryWire {
+    pub table_name: String,
+    pub object_id: ObjectId,
+    pub branch_name: BranchName,
+    pub batch_id: BatchId,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum WorkerToMainWire {
     InitOk {
@@ -137,10 +146,10 @@ pub enum WorkerToMainWire {
         term: u32,
         payloads: Vec<ByteBuf>,
     },
-    /// Encoded `LocalBatchRecord` storage rows for Rust-side main-runtime
+    /// Retained worker optimistic rows for Rust-side main-runtime overlay
     /// hydration.
-    LocalBatchRecordsSync {
-        encoded_records: Vec<ByteBuf>,
+    LocalOverlaySync {
+        entries: Vec<LocalOverlayEntryWire>,
     },
     /// Startup/restart replay for a rejected batch retained by the worker.
     MutationErrorReplay {
@@ -542,8 +551,8 @@ mod tests {
             term: 1,
             payloads: vec![ByteBuf::from(vec![0xff])],
         });
-        rt_worker(&WorkerToMainWire::LocalBatchRecordsSync {
-            encoded_records: Vec::new(),
+        rt_worker(&WorkerToMainWire::LocalOverlaySync {
+            entries: Vec::new(),
         });
         rt_worker(&WorkerToMainWire::MutationErrorReplay {
             batch_id: "b1".into(),

--- a/crates/jazz-wasm/tests/worker_bridge.rs
+++ b/crates/jazz-wasm/tests/worker_bridge.rs
@@ -27,11 +27,13 @@ use wasm_bindgen_futures::JsFuture;
 use wasm_bindgen_test::*;
 use web_sys::Worker;
 
-use jazz_tools::batch_fate::{BatchFate, BatchMode, LocalBatchRecord};
+use jazz_tools::batch_fate::BatchFate;
+use jazz_tools::object::{BranchName, ObjectId};
 use jazz_tools::row_histories::BatchId;
-use jazz_tools::sync_manager::DurabilityTier;
+use jazz_tools::sync_manager::{DurabilityTier, SyncPayload};
 use jazz_wasm::worker_protocol::{
-    encode_main_to_worker, encode_worker_to_main, MainToWorkerWire, WorkerToMainWire,
+    encode_main_to_worker, encode_worker_to_main, LocalOverlayEntryWire, MainToWorkerWire,
+    SyncEntry, WorkerToMainWire,
 };
 use jazz_wasm::WasmRuntime;
 
@@ -788,26 +790,32 @@ fn auth_failed_fires_listener() {
 }
 
 #[wasm_bindgen_test]
-async fn local_batch_records_sync_hydrates_main_runtime() {
+async fn local_overlay_sync_hydrates_main_runtime() {
     let fw = FakeWorker::new();
     let runtime = fresh_runtime();
     let _bridge = jazz_wasm::WasmWorkerBridge::attach(fw.worker(), &runtime, build_options(None))
         .expect("attach");
 
     let batch_id = BatchId::new();
-    let record = LocalBatchRecord::new(
-        batch_id,
-        BatchMode::Direct,
-        true,
-        Some(BatchFate::DurableDirect {
+    let object_id = ObjectId::new();
+    fw.emit_wire(&WorkerToMainWire::LocalOverlaySync {
+        entries: vec![LocalOverlayEntryWire {
+            table_name: "todos".to_string(),
+            object_id,
+            branch_name: BranchName::new("main"),
+            batch_id,
+        }],
+    });
+
+    let sync_payload = postcard::to_allocvec(&SyncPayload::BatchFate {
+        fate: BatchFate::DurableDirect {
             batch_id,
             confirmed_tier: DurabilityTier::GlobalServer,
-        }),
-    );
-    let encoded_record = record.encode_storage_row().expect("encode record");
-
-    fw.emit_wire(&WorkerToMainWire::LocalBatchRecordsSync {
-        encoded_records: vec![ByteBuf::from(encoded_record)],
+        },
+    })
+    .expect("encode sync payload");
+    fw.emit_wire(&WorkerToMainWire::Sync {
+        payloads: vec![SyncEntry::BareBytes(ByteBuf::from(sync_payload))],
     });
 
     JsFuture::from(

--- a/docs/superpowers/plans/2026-06-09-worker-local-overlay-replay.md
+++ b/docs/superpowers/plans/2026-06-09-worker-local-overlay-replay.md
@@ -1,0 +1,138 @@
+# Worker Local Overlay Replay Implementation Plan
+
+> **For Guido:** REQUIRED SUB-SKILL: Use executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace retained-batch replay/reconciliation between worker and main with direct row-level local overlay hydration, without startup scans on main and without the `LocalBatchRecord` hydration path.
+
+**Architecture:** The worker remains the owner of retained sealed submission metadata. During startup it sends only the row overlay entries needed by main. Main hydrates those entries into the existing query manager local overlay state (`pending_local_row_batches` plus `visible_rows_by_batch`) and lets normal row sync and fates clear them.
+
+**Correctness Invariant:** Every row that still needs optimistic local overlay on main also still has a retained `SealedBatchSubmission` on the worker. This is true because sealed submission pruning is gated on either rejection or `confirmed_tier >= GlobalServer`, so local-only batches retain their submissions and the worker submission list is a complete source for rows that matter. Fate-only retained batches without submissions are inconsistent metadata for this path and must not trigger a startup scan.
+
+## Preconditions
+
+- Work on branch `guido/worker-local-overlay-replay`.
+- Do not revert existing unrelated dirty workspace changes.
+- Keep the implementation narrow: no index, no metadata migration, no generalized replay protocol.
+- Preserve worker-side forensic helpers unless directly replaced by this path.
+
+## Task 1: Add Query Manager Overlay Hydration Helpers
+
+**Files:**
+
+- `crates/jazz-tools/src/query_manager/manager.rs`
+- `crates/jazz-tools/src/runtime_core/mod.rs`
+
+**Changes:**
+
+1. Add a query manager helper that hydrates one retained local overlay row by inserting a `RowBatchKey` into `pending_local_row_batches` and registering the table/row under `visible_rows_by_batch`.
+2. Mark local subscriptions dirty for the table and row when hydrating.
+3. Add a helper that returns pending overlay rows for a batch by intersecting `visible_rows_by_batch` with `pending_local_row_batches`.
+4. Add a helper that clears pending overlay rows for a batch when a terminal fate or globally confirmed row makes the overlay obsolete.
+5. Expose a `RuntimeCore` wrapper around overlay hydration using a small `RetainedLocalOverlayRow` struct.
+
+**Acceptance:**
+
+- No new parallel cache beyond existing query manager maps.
+- Main can represent retained worker overlays without persisting `LocalBatchRecord`.
+
+## Task 2: Replace Worker Retained Batch Payload With Overlay Entries
+
+**Files:**
+
+- `crates/jazz-tools/src/runtime_core/writes.rs`
+
+**Changes:**
+
+1. Add `retained_local_overlay_rows_for_worker_sync()`.
+2. Build entries from retained `LocalBatchRecord` members, when present.
+3. Build entries from retained sealed submissions by loading each member row locator with `load_row_locator`.
+4. Do not inspect fate-only batches and do not call `local_batch_rows()` for this startup payload.
+5. De-duplicate entries by `(table_name, object_id, branch_name, batch_id)` and sort deterministically.
+6. Remove or stop using `local_batch_records_for_worker_sync()` from the worker startup path.
+
+**Acceptance:**
+
+- `scan_row_locators` is not called.
+- `scan_history_row_batches` is not called.
+- `load_row_locator` calls scale with retained submission members, not unrelated stored rows.
+
+## Task 3: Switch The Worker Wire Protocol
+
+**Files:**
+
+- `crates/jazz-wasm/src/worker_protocol.rs`
+- `crates/jazz-wasm/src/worker_host.rs`
+- `crates/jazz-wasm/src/worker_bridge.rs`
+
+**Changes:**
+
+1. Replace `LocalBatchRecordsSync` with `LocalOverlaySync { entries }`.
+2. Define a wire entry carrying table name, object id, branch name, and batch id.
+3. Worker host sends `LocalOverlaySync` from `retained_local_overlay_rows_for_worker_sync()`.
+4. Worker bridge hydrates each entry through the `RuntimeCore` overlay helper.
+5. Remove bridge-side `LocalBatchRecord` decoding, hydration, rejection replay, and reconciliation from this retained startup path.
+
+**Acceptance:**
+
+- Main startup receives row overlays only.
+- Main does not persist retained worker `LocalBatchRecord` values.
+- Main does not call `reconcile_local_batch_with_server()` from worker retained startup sync.
+
+## Task 4: Make Fate Handling Respect Overlay-Only State
+
+**Files:**
+
+- `crates/jazz-tools/src/runtime_core/ticks.rs`
+- `crates/jazz-tools/src/query_manager/manager.rs`
+
+**Changes:**
+
+1. When a rejected fate arrives and pending overlay rows exist for that batch, clear those overlays directly instead of calling scan-backed local batch row lookup.
+2. When a missing fate arrives and pending overlay rows exist for that batch, do not retransmit from main; the worker is the owner of the submission.
+3. When a globally confirmed fate arrives and pending overlay rows exist for that batch, clear those overlays and dirty affected subscriptions.
+4. Preserve existing local-batch behavior when no overlay-only rows are present.
+
+**Acceptance:**
+
+- Main does not need retained batch records to remove worker overlays.
+- Existing worker/server reconciliation behavior remains available outside this startup overlay path.
+
+## Task 5: Update And Add Tests
+
+**Files:**
+
+- `crates/jazz-tools/src/runtime_core/tests/write_batch/rejection_recovery.rs`
+- `crates/jazz-tools/src/runtime_core/tests.rs`
+- `crates/jazz-wasm/tests/worker_bridge.rs`
+
+**Changes:**
+
+1. Replace retained local-batch sync assertions with retained overlay entry assertions.
+2. Add a no-scan test that fails if `scan_row_locators` or `scan_history_row_batches` are called.
+3. In the no-scan test, assert `load_row_locator` calls equal the retained member count and do not grow after unrelated rows are inserted.
+4. Add an assertion that fate-only batches without retained submissions do not produce overlay entries.
+5. Update worker bridge tests to send `LocalOverlaySync` and assert main gets the optimistic overlay without a persisted local batch record.
+
+**Acceptance:**
+
+- The no-scan test forbids both scan functions.
+- Point lookup counts scale with retained members, not total rows.
+- Existing retained local UX remains covered through black-box runtime or bridge behavior.
+
+## Task 6: Verification
+
+Run targeted checks:
+
+```bash
+cargo test -p jazz-tools retained_local_overlay
+cargo test -p jazz-tools rc_worker
+cargo test -p jazz-wasm local_overlay
+```
+
+If a filter matches no tests, run the nearest package-level focused test command that compiles the touched crate and exercises the changed path.
+
+Before finishing:
+
+- Inspect `git diff --stat`.
+- Inspect the touched-file diff.
+- Ensure no unrelated dirty files were staged or modified.

--- a/docs/superpowers/specs/2026-06-09-worker-local-overlay-replay-design.md
+++ b/docs/superpowers/specs/2026-06-09-worker-local-overlay-replay-design.md
@@ -1,0 +1,155 @@
+# Worker local overlay replay design
+
+## Purpose
+
+Browser reload currently rebuilds main-thread query visibility by replaying
+worker-retained `LocalBatchRecord` metadata into main. That makes main duplicate
+worker batch cache state and lets main trigger manual batch reconciliation. It
+also couples a query visibility concern to sync/storage recovery metadata.
+
+This design replaces retained batch-record replay with retained local overlay
+replay. The worker remains the owner of durable browser storage and batch
+reconciliation. Main receives only the volatile row-level facts its query manager
+needs to render locally visible rows after reload.
+
+## Scope
+
+In scope:
+
+- Replace worker-to-main `LocalBatchRecordsSync` startup replay with a row-level
+  local overlay replay.
+- Stop hydrating worker `LocalBatchRecord`s into the main runtime.
+- Stop main from calling batch reconciliation as a result of worker startup
+  replay.
+- Prove retained overlay replay does not use row-locator or row-history
+  forensic scans.
+
+Out of scope:
+
+- Adding a `batch_id -> rows` storage index.
+- Terminal retained-batch garbage collection.
+- Removing the main runtime entirely or serving all queries through worker RPC.
+- Reworking rejected mutation-error replay. That remains a separate path.
+
+## Architecture
+
+Worker remains the durable runtime. Main remains the UI-facing runtime for now,
+but it no longer mirrors worker batch metadata.
+
+The new boundary is:
+
+- Worker owns storage, sealed submissions, authoritative fates, retained local
+  batch records, and upstream reconciliation.
+- Main owns volatile query overlay state for rendering.
+- Worker sends main a startup snapshot of retained local overlay rows.
+- Main applies those rows to query overlay state only. It does not persist them
+  as local batch records and does not reconstruct sealed submissions or fates.
+
+This is intentionally smaller than a full one-runtime architecture rewrite while
+removing the duplicated batch cache and manual reconciliation responsibility from
+main.
+
+## Wire Shape
+
+Add a worker-to-main wire payload like:
+
+```rust
+pub struct LocalOverlayEntryWire {
+    pub table_name: String,
+    pub object_id: String,
+    pub branch_name: String,
+    pub batch_id: String,
+}
+
+pub enum WorkerToMainWire {
+    LocalOverlaySync {
+        entries: Vec<LocalOverlayEntryWire>,
+    },
+}
+```
+
+The exact Rust types can use existing binary encodings where convenient, but the
+semantic payload is row-level overlay state, not batch metadata.
+
+## Worker Data Flow
+
+On worker startup:
+
+1. Open durable storage as today.
+2. Build retained local overlay entries from trusted retained metadata:
+   persisted `LocalBatchRecord`s and memberful sealed submissions. Sealed
+   submission members may resolve table names with per-object `load_row_locator`
+   point lookups.
+3. Do not derive overlay entries by scanning all row locators or all row
+   histories.
+4. Post `LocalOverlaySync` before `InitOk`.
+5. Continue normal worker startup and drain buffered sync messages.
+
+Worker-side reconciliation stays in worker:
+
+- Worker asks upstream for batch fates.
+- Worker retransmits local rows/seals to upstream when needed.
+- Worker forwards normal row and fate sync messages to main through the existing
+  sync channel.
+
+## Main Data Flow
+
+On `LocalOverlaySync`:
+
+1. Decode each overlay entry.
+2. Insert or replace a volatile `RowBatchKey` for that row in main query overlay
+   state.
+3. Mark affected subscriptions dirty as local overlay updates.
+4. Do not call `hydrate_local_batch_record`.
+5. Do not persist a `LocalBatchRecord`.
+6. Do not call `reconcile_local_batch_with_server`.
+
+Later normal row and fate sync messages continue to update main storage and
+clear or supersede local overlay state through existing visibility processing.
+
+## Runtime API
+
+Add a narrow main-runtime API such as:
+
+```rust
+pub fn hydrate_retained_local_overlay_row(
+    &mut self,
+    table_name: &str,
+    object_id: ObjectId,
+    branch_name: BranchName,
+    batch_id: BatchId,
+) -> Result<(), RuntimeError>
+```
+
+This API should update query overlay state only. It should not touch local batch
+record storage and should not start sync reconciliation.
+
+## Error Handling
+
+- Worker logs and skips malformed or incomplete retained metadata.
+- Main logs and skips invalid overlay entries.
+- Overlay hydration is idempotent. Replaying the same row replaces the same
+  `RowBatchKey`.
+- Startup continues if overlay replay has partial failures.
+
+## Testing
+
+Add focused tests that prove the boundary:
+
+- Worker retained overlay payload includes entries for retained local records
+  and memberful sealed submissions.
+- Worker retained overlay payload generation does not call `scan_row_locators`.
+- Main bridge hydration updates query overlay state without persisting a
+  `LocalBatchRecord`.
+- Main bridge hydration does not call `reconcile_local_batch_with_server`.
+- Existing rejected mutation-error replay tests remain separate.
+
+## Non-Goals And Follow-Ups
+
+This design does not solve retained-batch accumulation. A later pass should add
+a lifecycle rule for pruning terminal batch envelopes once their retention
+boundary is satisfied.
+
+This design also does not collapse the two runtimes. If that becomes the goal,
+main should become an RPC client for worker-owned query execution. That is a
+larger architecture project and is not needed for this fix.

--- a/docs/superpowers/specs/2026-06-09-worker-local-overlay-replay-design.md
+++ b/docs/superpowers/specs/2026-06-09-worker-local-overlay-replay-design.md
@@ -179,7 +179,11 @@ Add focused tests that prove the boundary:
 
 - Worker retained overlay payload includes entries for retained local records
   and memberful sealed submissions.
-- Worker retained overlay payload generation does not call `scan_row_locators`.
+- Worker retained overlay payload generation calls neither `scan_row_locators`
+  nor `scan_history_row_batches`; per-member `load_row_locator` point lookups
+  are allowed.
+- Worker retained overlay payload generation has lookup counts that scale with
+  retained members, not total unrelated rows in storage.
 - Main bridge hydration updates query overlay state without persisting a
   `LocalBatchRecord`.
 - Main bridge hydration does not call `reconcile_local_batch_with_server`.

--- a/docs/superpowers/specs/2026-06-09-worker-local-overlay-replay-design.md
+++ b/docs/superpowers/specs/2026-06-09-worker-local-overlay-replay-design.md
@@ -102,12 +102,24 @@ Worker-side reconciliation stays in worker:
 - Worker forwards normal row and fate sync messages to main through the existing
   sync channel.
 
-Fate-only batches without a retained local batch record or sealed submission are
-not replayed as overlays. The assumption is that well-formed committed local
-batches retain a sealed submission even if their `LocalBatchRecord` is pruned.
-The existing commit path persists sealed submissions and does not delete them on
-ack. A fate-only retained batch therefore indicates incomplete or inconsistent
-metadata, not a normal startup overlay source.
+Correctness invariant for the no-scan claim:
+
+> Every row that still needs optimistic local overlay on main also still has a
+> retained `SealedBatchSubmission` on the worker.
+
+The design drops today's third retained-batch source: fate-only batches with no
+retained local batch record and no sealed submission, discovered by calling
+`local_batch_rows(fate.batch_id())` and falling into a full row-locator/history
+scan. Dropping that source is correct only because retained sealed submissions
+are the complete source for rows that still matter to main's optimistic overlay.
+
+That invariant follows from the current submission lifecycle: commit persists a
+sealed submission, and seal handling prunes submissions only for rejected batches
+or fates confirmed at `GlobalServer` or higher. A purely local batch keeps its
+sealed submission, so the worker can recover its overlay members from trusted
+retained metadata without scanning all rows. A fate-only retained batch therefore
+indicates incomplete or inconsistent metadata, not a normal startup overlay
+source.
 
 ## Main Data Flow
 

--- a/docs/superpowers/specs/2026-06-09-worker-local-overlay-replay-design.md
+++ b/docs/superpowers/specs/2026-06-09-worker-local-overlay-replay-design.md
@@ -21,6 +21,10 @@ In scope:
 - Stop hydrating worker `LocalBatchRecord`s into the main runtime.
 - Stop main from calling batch reconciliation as a result of worker startup
   replay.
+- Make main batch-fate processing tolerate overlay-only batch state without
+  falling back to full row-locator/history scans.
+- Clear hydrated overlay entries when durable row or fate processing makes them
+  obsolete.
 - Prove retained overlay replay does not use row-locator or row-history
   forensic scans.
 
@@ -48,6 +52,12 @@ The new boundary is:
 This is intentionally smaller than a full one-runtime architecture rewrite while
 removing the duplicated batch cache and manual reconciliation responsibility from
 main.
+
+The implementation should reuse the existing query overlay mechanism. Main's
+overlay hydration API is a thin runtime wrapper around
+`QueryManager::pending_local_row_batches` / `local_overlay_rows` behavior, using
+the same semantics as `maybe_track_local_pending_batch_overlay` or its exact
+equivalent. It must not introduce a parallel overlay state machine.
 
 ## Wire Shape
 
@@ -92,6 +102,13 @@ Worker-side reconciliation stays in worker:
 - Worker forwards normal row and fate sync messages to main through the existing
   sync channel.
 
+Fate-only batches without a retained local batch record or sealed submission are
+not replayed as overlays. The assumption is that well-formed committed local
+batches retain a sealed submission even if their `LocalBatchRecord` is pruned.
+The existing commit path persists sealed submissions and does not delete them on
+ack. A fate-only retained batch therefore indicates incomplete or inconsistent
+metadata, not a normal startup overlay source.
+
 ## Main Data Flow
 
 On `LocalOverlaySync`:
@@ -104,8 +121,16 @@ On `LocalOverlaySync`:
 5. Do not persist a `LocalBatchRecord`.
 6. Do not call `reconcile_local_batch_with_server`.
 
-Later normal row and fate sync messages continue to update main storage and
-clear or supersede local overlay state through existing visibility processing.
+Main batch-fate processing must handle overlay-only state. Before invoking any
+scan-enabled row reconstruction helper for a batch, fate handling should consult
+overlay entries for that batch. This covers fate-before-seal ordering and
+prevents one full database scan per fate after reload.
+
+Main sync processing must also clear stale overlay entries. When the
+corresponding row arrives through `RowBatchCreated`, or when a batch fate settles
+the row so the visible region can answer the subscription without local overlay,
+main removes the matching `RowBatchKey` and dirties affected subscriptions. This
+prevents replayed overlay state from shadowing durable rows indefinitely.
 
 ## Runtime API
 
@@ -123,6 +148,10 @@ pub fn hydrate_retained_local_overlay_row(
 
 This API should update query overlay state only. It should not touch local batch
 record storage and should not start sync reconciliation.
+
+Add a matching query-manager/runtime helper for clearing overlay rows by
+`RowBatchKey` or `(object_id, batch_id)` so row and fate sync processing can
+evict retained overlay entries once durable state supersedes them.
 
 ## Error Handling
 
@@ -142,6 +171,10 @@ Add focused tests that prove the boundary:
 - Main bridge hydration updates query overlay state without persisting a
   `LocalBatchRecord`.
 - Main bridge hydration does not call `reconcile_local_batch_with_server`.
+- Main fate processing with overlay-only state marks subscriptions dirty without
+  scanning row locators or requiring a local batch record.
+- Main clears a retained overlay entry when the same row arrives through normal
+  sync or when its batch fate makes the overlay obsolete.
 - Existing rejected mutation-error replay tests remain separate.
 
 ## Non-Goals And Follow-Ups
@@ -149,6 +182,13 @@ Add focused tests that prove the boundary:
 This design does not solve retained-batch accumulation. A later pass should add
 a lifecycle rule for pruning terminal batch envelopes once their retention
 boundary is satisfied.
+
+This design also does not fix worker-side
+`pending_batch_ids_needing_reconciliation`. The worker may still scan visible
+rows while discovering batches that need upstream reconciliation. That remaining
+cost delays sync/reconciliation rather than forcing main to hydrate duplicate
+batch metadata, and should be addressed as a separate worker reconciliation
+cleanup.
 
 This design also does not collapse the two runtimes. If that becomes the goal,
 main should become an RPC client for worker-owned query execution. That is a


### PR DESCRIPTION
## Summary
- Replace worker retained local batch startup sync with typed local overlay entries.
- Hydrate retained worker overlays into existing query manager overlay state on main.
- Remove startup fate-only scan fallback and add no-scan tests for row locator and history scans.

## Root Cause
Main was replaying worker-retained batch metadata through a second local batch runtime path. When retained metadata was incomplete, startup reconciliation could fall back to broad row scans even though rows that still need optimistic overlay should be covered by retained worker sealed submissions.

## Test Plan
- `cargo test -p jazz-tools rc_worker`
- `cargo test -p jazz-tools overlay_only_global`
- `cargo test -p jazz-wasm local_overlay`
- `RUSTFLAGS='--cfg=web_sys_unstable_apis --cfg getrandom_backend="wasm_js"' cargo check -p jazz-wasm --target wasm32-unknown-unknown`
- pre-commit `clippy` and `rustfmt`