### PR TITLE
feat: add Rust permissions DSL

### DIFF
--- a/crates/jazz-tools/src/query_manager/rebac_tests.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests.rs
@@ -36,7 +36,7 @@ use crate::query_manager::relation_ir::{
 use crate::query_manager::session::{Session, WriteContext};
 use crate::query_manager::types::{
     ColumnDescriptor, ColumnType, ComposedBranchName, RowDescriptor, RowPolicyMode, Schema,
-    SchemaHash, TableName, TablePolicies, TableSchema, Value,
+    SchemaBuilder, SchemaHash, TableName, TablePolicies, TableSchema, Value,
 };
 use crate::row_histories::{RowState, StoredRowBatch};
 
@@ -244,57 +244,32 @@ fn test_row_tip_ids(
 
 /// Schema for ReBAC tests: documents with owner_id policy + folders for INHERITS
 fn rebac_test_schema() -> Schema {
-    let mut schema = Schema::new();
-
-    // Folders table (parent for documents)
-    let folders_descriptor = RowDescriptor::new(vec![
-        ColumnDescriptor::new("owner_id", ColumnType::Text),
-        ColumnDescriptor::new("name", ColumnType::Text),
-    ]);
     let folders_policies = TablePolicies::new()
         .with_select(PolicyExpr::eq_session("owner_id", vec!["user_id".into()]))
         .with_insert(PolicyExpr::eq_session("owner_id", vec!["user_id".into()]));
 
-    schema.insert(
-        TableName::new("folders"),
-        TableSchema::with_policies(folders_descriptor, folders_policies),
-    );
-
-    // Documents table with owner_id policy
-    let docs_descriptor = RowDescriptor::new(vec![
-        ColumnDescriptor::new("owner_id", ColumnType::Text),
-        ColumnDescriptor::new("title", ColumnType::Text),
-        ColumnDescriptor::new("folder_id", ColumnType::Uuid)
-            .nullable()
-            .references("folders"),
-    ]);
     let docs_policies = TablePolicies::new()
         .with_select(PolicyExpr::eq_session("owner_id", vec!["user_id".into()]))
         .with_insert(PolicyExpr::eq_session("owner_id", vec!["user_id".into()]));
 
-    schema.insert(
-        TableName::new("documents"),
-        TableSchema::with_policies(docs_descriptor, docs_policies),
-    );
-
-    schema
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("folders")
+                .column("owner_id", ColumnType::Text)
+                .column("name", ColumnType::Text)
+                .policies(folders_policies),
+        )
+        .table(
+            TableSchema::builder("documents")
+                .column("owner_id", ColumnType::Text)
+                .column("title", ColumnType::Text)
+                .nullable_fk_column("folder_id", "folders")
+                .policies(docs_policies),
+        )
+        .build()
 }
 
 fn magic_introspection_schema() -> Schema {
-    let mut schema = Schema::new();
-
-    let admins_descriptor =
-        RowDescriptor::new(vec![ColumnDescriptor::new("user_id", ColumnType::Text)]);
-    schema.insert(
-        TableName::new("admins"),
-        TableSchema::with_policies(
-            admins_descriptor,
-            TablePolicies::new().with_select(PolicyExpr::True),
-        ),
-    );
-
-    let protected_descriptor =
-        RowDescriptor::new(vec![ColumnDescriptor::new("data", ColumnType::Text)]);
     let protected_policies = TablePolicies::new()
         .with_select(PolicyExpr::True)
         .with_update(
@@ -316,29 +291,28 @@ fn magic_introspection_schema() -> Schema {
                 },
             },
         });
-    schema.insert(
-        TableName::new("protected"),
-        TableSchema::with_policies(protected_descriptor, protected_policies),
-    );
 
-    schema
-}
-
-fn provenance_notes_descriptor() -> RowDescriptor {
-    RowDescriptor::new(vec![ColumnDescriptor::new("title", ColumnType::Text)])
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("admins")
+                .column("user_id", ColumnType::Text)
+                .policies(TablePolicies::new().with_select(PolicyExpr::True)),
+        )
+        .table(
+            TableSchema::builder("protected")
+                .column("data", ColumnType::Text)
+                .policies(protected_policies),
+        )
+        .build()
 }
 
 fn provenance_notes_schema() -> Schema {
-    let mut schema = Schema::new();
-    schema.insert(
-        TableName::new("notes"),
-        TableSchema::new(provenance_notes_descriptor()),
-    );
-    schema
+    SchemaBuilder::new()
+        .table(TableSchema::builder("notes").column("title", ColumnType::Text))
+        .build()
 }
 
 fn authorship_permissions_schema() -> Schema {
-    let mut schema = Schema::new();
     let created_by_is_session = PolicyExpr::eq_session("$createdBy", vec!["user_id".into()]);
     let notes_policies = TablePolicies::new()
         .with_select(created_by_is_session.clone())
@@ -348,11 +322,14 @@ fn authorship_permissions_schema() -> Schema {
             created_by_is_session.clone(),
         )
         .with_delete(created_by_is_session);
-    schema.insert(
-        TableName::new("notes"),
-        TableSchema::with_policies(provenance_notes_descriptor(), notes_policies),
-    );
-    schema
+
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("notes")
+                .column("title", ColumnType::Text)
+                .policies(notes_policies),
+        )
+        .build()
 }
 
 fn query_rows(
@@ -375,16 +352,6 @@ fn query_rows(
 }
 
 fn recursive_folders_schema(max_depth: Option<usize>) -> Schema {
-    let mut schema = Schema::new();
-
-    let folders_descriptor = RowDescriptor::new(vec![
-        ColumnDescriptor::new("owner_id", ColumnType::Text),
-        ColumnDescriptor::new("name", ColumnType::Text),
-        ColumnDescriptor::new("parent_id", ColumnType::Uuid)
-            .nullable()
-            .references("folders"),
-    ]);
-
     let select_policy = PolicyExpr::Or(vec![
         PolicyExpr::eq_session("owner_id", vec!["user_id".into()]),
         PolicyExpr::Inherits {
@@ -407,12 +374,15 @@ fn recursive_folders_schema(max_depth: Option<usize>) -> Schema {
         .with_select(select_policy)
         .with_update(Some(update_using), PolicyExpr::True);
 
-    schema.insert(
-        TableName::new("folders"),
-        TableSchema::with_policies(folders_descriptor, folders_policies),
-    );
-
-    schema
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("folders")
+                .column("owner_id", ColumnType::Text)
+                .column("name", ColumnType::Text)
+                .nullable_fk_column("parent_id", "folders")
+                .policies(folders_policies),
+        )
+        .build()
 }
 
 /// Helper to encode a document row
@@ -462,26 +432,13 @@ fn folder_metadata() -> std::collections::HashMap<String, String> {
 }
 
 fn inherited_insert_schema() -> (Schema, RowDescriptor, SchemaHash) {
-    let mut schema = Schema::new();
-
-    let folders_descriptor = RowDescriptor::new(vec![
-        ColumnDescriptor::new("owner_id", ColumnType::Text),
-        ColumnDescriptor::new("name", ColumnType::Text),
-    ]);
+    let folders_table = TableSchema::builder("folders")
+        .column("owner_id", ColumnType::Text)
+        .column("name", ColumnType::Text);
+    let folders_descriptor = folders_table.clone().build().columns;
     let folders_policies = TablePolicies::new()
         .with_select(PolicyExpr::eq_session("owner_id", vec!["user_id".into()]));
-    schema.insert(
-        TableName::new("folders"),
-        TableSchema::with_policies(folders_descriptor.clone(), folders_policies),
-    );
 
-    let documents_descriptor = RowDescriptor::new(vec![
-        ColumnDescriptor::new("owner_id", ColumnType::Text),
-        ColumnDescriptor::new("title", ColumnType::Text),
-        ColumnDescriptor::new("folder_id", ColumnType::Uuid)
-            .nullable()
-            .references("folders"),
-    ]);
     let documents_policies = TablePolicies::new().with_insert(PolicyExpr::And(vec![
         PolicyExpr::eq_session("owner_id", vec!["user_id".into()]),
         PolicyExpr::Or(vec![
@@ -491,10 +448,17 @@ fn inherited_insert_schema() -> (Schema, RowDescriptor, SchemaHash) {
             PolicyExpr::inherits(Operation::Select, "folder_id"),
         ]),
     ]));
-    schema.insert(
-        TableName::new("documents"),
-        TableSchema::with_policies(documents_descriptor, documents_policies),
-    );
+
+    let schema = SchemaBuilder::new()
+        .table(folders_table.policies(folders_policies))
+        .table(
+            TableSchema::builder("documents")
+                .column("owner_id", ColumnType::Text)
+                .column("title", ColumnType::Text)
+                .nullable_fk_column("folder_id", "folders")
+                .policies(documents_policies),
+        )
+        .build();
 
     let schema_hash = SchemaHash::compute(&schema);
     (schema, folders_descriptor, schema_hash)
@@ -749,8 +713,6 @@ fn run_recursive_folder_update(max_depth: Option<usize>) -> (bool, bool) {
 /// Test that bounded self-referential INHERITS is accepted by cycle validation.
 
 fn declared_file_inheritance_schema(array_edge: bool) -> Schema {
-    let mut schema = Schema::new();
-
     let source_fk_column = if array_edge { "images" } else { "image" };
     let inherited_read = PolicyExpr::InheritsReferencing {
         operation: Operation::Select,
@@ -765,10 +727,6 @@ fn declared_file_inheritance_schema(array_edge: bool) -> Schema {
         max_depth: None,
     };
 
-    let files_descriptor = RowDescriptor::new(vec![
-        ColumnDescriptor::new("owner_id", ColumnType::Text),
-        ColumnDescriptor::new("name", ColumnType::Text),
-    ]);
     let files_policies = TablePolicies::new()
         .with_select(PolicyExpr::or(vec![
             PolicyExpr::eq_session("owner_id", vec!["user_id".into()]),
@@ -781,41 +739,34 @@ fn declared_file_inheritance_schema(array_edge: bool) -> Schema {
             ])),
             PolicyExpr::True,
         );
-    schema.insert(
-        TableName::new("files"),
-        TableSchema::with_policies(files_descriptor, files_policies),
-    );
 
-    let image_column = if array_edge {
-        ColumnDescriptor::new(
-            "images",
-            ColumnType::Array {
-                element: Box::new(ColumnType::Uuid),
-            },
-        )
-        .references("files")
+    let todos_table = if array_edge {
+        TableSchema::builder("todos")
+            .column("owner_id", ColumnType::Text)
+            .column("title", ColumnType::Text)
+            .array_fk_column("images", "files")
     } else {
-        ColumnDescriptor::new("image", ColumnType::Uuid)
-            .nullable()
-            .references("files")
+        TableSchema::builder("todos")
+            .column("owner_id", ColumnType::Text)
+            .column("title", ColumnType::Text)
+            .nullable_fk_column("image", "files")
     };
-    let todos_descriptor = RowDescriptor::new(vec![
-        ColumnDescriptor::new("owner_id", ColumnType::Text),
-        ColumnDescriptor::new("title", ColumnType::Text),
-        image_column,
-    ]);
     let todos_policies = TablePolicies::new()
         .with_select(PolicyExpr::eq_session("owner_id", vec!["user_id".into()]))
         .with_update(
             Some(PolicyExpr::eq_session("owner_id", vec!["user_id".into()])),
             PolicyExpr::True,
         );
-    schema.insert(
-        TableName::new("todos"),
-        TableSchema::with_policies(todos_descriptor, todos_policies),
-    );
 
-    schema
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("files")
+                .column("owner_id", ColumnType::Text)
+                .column("name", ColumnType::Text)
+                .policies(files_policies),
+        )
+        .table(todos_table.policies(todos_policies))
+        .build()
 }
 
 mod declared_fk_inheritance;

--- a/crates/jazz-tools/src/query_manager/rebac_tests.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests.rs
@@ -28,15 +28,11 @@ use crate::query_manager::encoding::{decode_row, encode_row};
 use crate::query_manager::manager::QueryError;
 use crate::query_manager::manager::QueryManager;
 use crate::query_manager::policy::Operation;
-use crate::query_manager::policy::PolicyExpr;
 use crate::query_manager::query::{Query, QueryBuilder};
-use crate::query_manager::relation_ir::{
-    ColumnRef, PredicateCmpOp, PredicateExpr, RelExpr, ValueRef,
-};
 use crate::query_manager::session::{Session, WriteContext};
 use crate::query_manager::types::{
     ColumnDescriptor, ColumnType, ComposedBranchName, RowDescriptor, RowPolicyMode, Schema,
-    SchemaBuilder, SchemaHash, TableName, TablePolicies, TableSchema, Value,
+    SchemaBuilder, SchemaHash, TableName, TableSchema, Value, permissions, policy_expr as pe,
 };
 use crate::row_histories::{RowState, StoredRowBatch};
 
@@ -244,13 +240,19 @@ fn test_row_tip_ids(
 
 /// Schema for ReBAC tests: documents with owner_id policy + folders for INHERITS
 fn rebac_test_schema() -> Schema {
-    let folders_policies = TablePolicies::new()
-        .with_select(PolicyExpr::eq_session("owner_id", vec!["user_id".into()]))
-        .with_insert(PolicyExpr::eq_session("owner_id", vec!["user_id".into()]));
+    let folders_policies = permissions(|p| {
+        p.allow_read()
+            .where_(pe::eq("owner_id", pe::session("user_id")));
+        p.allow_insert()
+            .where_(pe::eq("owner_id", pe::session("user_id")));
+    });
 
-    let docs_policies = TablePolicies::new()
-        .with_select(PolicyExpr::eq_session("owner_id", vec!["user_id".into()]))
-        .with_insert(PolicyExpr::eq_session("owner_id", vec!["user_id".into()]));
+    let docs_policies = permissions(|p| {
+        p.allow_read()
+            .where_(pe::eq("owner_id", pe::session("user_id")));
+        p.allow_insert()
+            .where_(pe::eq("owner_id", pe::session("user_id")));
+    });
 
     SchemaBuilder::new()
         .table(
@@ -270,33 +272,22 @@ fn rebac_test_schema() -> Schema {
 }
 
 fn magic_introspection_schema() -> Schema {
-    let protected_policies = TablePolicies::new()
-        .with_select(PolicyExpr::True)
-        .with_update(
-            Some(PolicyExpr::Exists {
-                table: "admins".into(),
-                condition: Box::new(PolicyExpr::eq_session("user_id", vec!["user_id".into()])),
-            }),
-            PolicyExpr::True,
-        )
-        .with_delete(PolicyExpr::ExistsRel {
-            rel: RelExpr::Filter {
-                input: Box::new(RelExpr::TableScan {
-                    table: TableName::new("admins"),
-                }),
-                predicate: PredicateExpr::Cmp {
-                    left: ColumnRef::unscoped("user_id"),
-                    op: PredicateCmpOp::Eq,
-                    right: ValueRef::SessionRef(vec!["user_id".into()]),
-                },
-            },
-        });
+    let is_admin = pe::eq("user_id", pe::session("user_id"));
+    let protected_policies = permissions(|p| {
+        p.allow_read().always();
+        p.allow_update()
+            .where_old(pe::exists(pe::table("admins").where_(is_admin.clone())))
+            .where_new(pe::always());
+        p.allow_delete().where_(pe::exists(
+            pe::table("admins").where_(pe::rel::eq_session("user_id", "user_id")),
+        ));
+    });
 
     SchemaBuilder::new()
         .table(
             TableSchema::builder("admins")
                 .column("user_id", ColumnType::Text)
-                .policies(TablePolicies::new().with_select(PolicyExpr::True)),
+                .policies(permissions(|p| p.allow_read().always())),
         )
         .table(
             TableSchema::builder("protected")
@@ -313,15 +304,13 @@ fn provenance_notes_schema() -> Schema {
 }
 
 fn authorship_permissions_schema() -> Schema {
-    let created_by_is_session = PolicyExpr::eq_session("$createdBy", vec!["user_id".into()]);
-    let notes_policies = TablePolicies::new()
-        .with_select(created_by_is_session.clone())
-        .with_insert(created_by_is_session.clone())
-        .with_update(
-            Some(created_by_is_session.clone()),
-            created_by_is_session.clone(),
-        )
-        .with_delete(created_by_is_session);
+    let created_by_is_session = pe::eq("$createdBy", pe::session("user_id"));
+    let notes_policies = permissions(|p| {
+        p.allow_read().where_(created_by_is_session.clone());
+        p.allow_insert().where_(created_by_is_session.clone());
+        p.allow_update().where_(created_by_is_session.clone());
+        p.allow_delete().where_(created_by_is_session);
+    });
 
     SchemaBuilder::new()
         .table(
@@ -352,27 +341,27 @@ fn query_rows(
 }
 
 fn recursive_folders_schema(max_depth: Option<usize>) -> Schema {
-    let select_policy = PolicyExpr::Or(vec![
-        PolicyExpr::eq_session("owner_id", vec!["user_id".into()]),
-        PolicyExpr::Inherits {
-            operation: Operation::Select,
-            via_column: "parent_id".into(),
-            max_depth,
-        },
-    ]);
+    let select_inherited = match max_depth {
+        Some(max_depth) => pe::allowed_to_read_with_depth("parent_id", max_depth),
+        None => pe::allowed_to_read("parent_id"),
+    };
+    let update_inherited = match max_depth {
+        Some(max_depth) => pe::allowed_to_update_with_depth("parent_id", max_depth),
+        None => pe::allowed_to_update("parent_id"),
+    };
 
-    let update_using = PolicyExpr::Or(vec![
-        PolicyExpr::eq_session("owner_id", vec!["user_id".into()]),
-        PolicyExpr::Inherits {
-            operation: Operation::Update,
-            via_column: "parent_id".into(),
-            max_depth,
-        },
-    ]);
-
-    let folders_policies = TablePolicies::new()
-        .with_select(select_policy)
-        .with_update(Some(update_using), PolicyExpr::True);
+    let folders_policies = permissions(|p| {
+        p.allow_read().where_(pe::any_of([
+            pe::eq("owner_id", pe::session("user_id")),
+            select_inherited,
+        ]));
+        p.allow_update()
+            .where_old(pe::any_of([
+                pe::eq("owner_id", pe::session("user_id")),
+                update_inherited,
+            ]))
+            .where_new(pe::always());
+    });
 
     SchemaBuilder::new()
         .table(
@@ -436,18 +425,17 @@ fn inherited_insert_schema() -> (Schema, RowDescriptor, SchemaHash) {
         .column("owner_id", ColumnType::Text)
         .column("name", ColumnType::Text);
     let folders_descriptor = folders_table.clone().build().columns;
-    let folders_policies = TablePolicies::new()
-        .with_select(PolicyExpr::eq_session("owner_id", vec!["user_id".into()]));
+    let folders_policies = permissions(|p| {
+        p.allow_read()
+            .where_(pe::eq("owner_id", pe::session("user_id")));
+    });
 
-    let documents_policies = TablePolicies::new().with_insert(PolicyExpr::And(vec![
-        PolicyExpr::eq_session("owner_id", vec!["user_id".into()]),
-        PolicyExpr::Or(vec![
-            PolicyExpr::IsNull {
-                column: "folder_id".into(),
-            },
-            PolicyExpr::inherits(Operation::Select, "folder_id"),
-        ]),
-    ]));
+    let documents_policies = permissions(|p| {
+        p.allow_insert().where_(pe::all_of([
+            pe::eq("owner_id", pe::session("user_id")),
+            pe::any_of([pe::is_null("folder_id"), pe::allowed_to_read("folder_id")]),
+        ]));
+    });
 
     let schema = SchemaBuilder::new()
         .table(folders_table.policies(folders_policies))
@@ -714,31 +702,18 @@ fn run_recursive_folder_update(max_depth: Option<usize>) -> (bool, bool) {
 
 fn declared_file_inheritance_schema(array_edge: bool) -> Schema {
     let source_fk_column = if array_edge { "images" } else { "image" };
-    let inherited_read = PolicyExpr::InheritsReferencing {
-        operation: Operation::Select,
-        source_table: "todos".into(),
-        via_column: source_fk_column.into(),
-        max_depth: None,
-    };
-    let inherited_update = PolicyExpr::InheritsReferencing {
-        operation: Operation::Update,
-        source_table: "todos".into(),
-        via_column: source_fk_column.into(),
-        max_depth: None,
-    };
-
-    let files_policies = TablePolicies::new()
-        .with_select(PolicyExpr::or(vec![
-            PolicyExpr::eq_session("owner_id", vec!["user_id".into()]),
-            inherited_read,
-        ]))
-        .with_update(
-            Some(PolicyExpr::or(vec![
-                PolicyExpr::eq_session("owner_id", vec!["user_id".into()]),
-                inherited_update,
-            ])),
-            PolicyExpr::True,
-        );
+    let files_policies = permissions(|p| {
+        p.allow_read().where_(pe::any_of([
+            pe::eq("owner_id", pe::session("user_id")),
+            pe::allowed_to_read_referencing("todos", source_fk_column),
+        ]));
+        p.allow_update()
+            .where_old(pe::any_of([
+                pe::eq("owner_id", pe::session("user_id")),
+                pe::allowed_to_update_referencing("todos", source_fk_column),
+            ]))
+            .where_new(pe::always());
+    });
 
     let todos_table = if array_edge {
         TableSchema::builder("todos")
@@ -751,12 +726,13 @@ fn declared_file_inheritance_schema(array_edge: bool) -> Schema {
             .column("title", ColumnType::Text)
             .nullable_fk_column("image", "files")
     };
-    let todos_policies = TablePolicies::new()
-        .with_select(PolicyExpr::eq_session("owner_id", vec!["user_id".into()]))
-        .with_update(
-            Some(PolicyExpr::eq_session("owner_id", vec!["user_id".into()])),
-            PolicyExpr::True,
-        );
+    let todos_policies = permissions(|p| {
+        p.allow_read()
+            .where_(pe::eq("owner_id", pe::session("user_id")));
+        p.allow_update()
+            .where_old(pe::eq("owner_id", pe::session("user_id")))
+            .where_new(pe::always());
+    });
 
     SchemaBuilder::new()
         .table(

--- a/crates/jazz-tools/src/query_manager/rebac_tests/declared_fk_inheritance.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests/declared_fk_inheritance.rs
@@ -153,24 +153,18 @@ fn rebac_declared_fk_inheritance_array_membership_grants_access() {
 fn rebac_declared_fk_inheritance_cycle_fails_closed() {
     use crate::query_manager::query::QueryBuilder;
 
-    let a_policies = TablePolicies::new().with_select(PolicyExpr::or(vec![
-        PolicyExpr::eq_session("owner_id", vec!["user_id".into()]),
-        PolicyExpr::InheritsReferencing {
-            operation: Operation::Select,
-            source_table: "table_b".into(),
-            via_column: "a_id".into(),
-            max_depth: None,
-        },
-    ]));
-    let b_policies = TablePolicies::new().with_select(PolicyExpr::or(vec![
-        PolicyExpr::eq_session("owner_id", vec!["user_id".into()]),
-        PolicyExpr::InheritsReferencing {
-            operation: Operation::Select,
-            source_table: "table_a".into(),
-            via_column: "b_id".into(),
-            max_depth: None,
-        },
-    ]));
+    let a_policies = permissions(|p| {
+        p.allow_read().where_(pe::any_of([
+            pe::eq("owner_id", pe::session("user_id")),
+            pe::allowed_to_read_referencing("table_b", "a_id"),
+        ]));
+    });
+    let b_policies = permissions(|p| {
+        p.allow_read().where_(pe::any_of([
+            pe::eq("owner_id", pe::session("user_id")),
+            pe::allowed_to_read_referencing("table_a", "b_id"),
+        ]));
+    });
     let schema = SchemaBuilder::new()
         .table(
             TableSchema::builder("table_a")

--- a/crates/jazz-tools/src/query_manager/rebac_tests/declared_fk_inheritance.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests/declared_fk_inheritance.rs
@@ -153,19 +153,6 @@ fn rebac_declared_fk_inheritance_array_membership_grants_access() {
 fn rebac_declared_fk_inheritance_cycle_fails_closed() {
     use crate::query_manager::query::QueryBuilder;
 
-    let mut schema = Schema::new();
-    let a_descriptor = RowDescriptor::new(vec![
-        ColumnDescriptor::new("owner_id", ColumnType::Text),
-        ColumnDescriptor::new("b_id", ColumnType::Uuid)
-            .nullable()
-            .references("table_b"),
-    ]);
-    let b_descriptor = RowDescriptor::new(vec![
-        ColumnDescriptor::new("owner_id", ColumnType::Text),
-        ColumnDescriptor::new("a_id", ColumnType::Uuid)
-            .nullable()
-            .references("table_a"),
-    ]);
     let a_policies = TablePolicies::new().with_select(PolicyExpr::or(vec![
         PolicyExpr::eq_session("owner_id", vec!["user_id".into()]),
         PolicyExpr::InheritsReferencing {
@@ -184,14 +171,20 @@ fn rebac_declared_fk_inheritance_cycle_fails_closed() {
             max_depth: None,
         },
     ]));
-    schema.insert(
-        TableName::new("table_a"),
-        TableSchema::with_policies(a_descriptor.clone(), a_policies),
-    );
-    schema.insert(
-        TableName::new("table_b"),
-        TableSchema::with_policies(b_descriptor.clone(), b_policies),
-    );
+    let schema = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("table_a")
+                .column("owner_id", ColumnType::Text)
+                .nullable_fk_column("b_id", "table_b")
+                .policies(a_policies),
+        )
+        .table(
+            TableSchema::builder("table_b")
+                .column("owner_id", ColumnType::Text)
+                .nullable_fk_column("a_id", "table_a")
+                .policies(b_policies),
+        )
+        .build();
 
     let sync_manager = SyncManager::new();
     let mut qm = create_query_manager(sync_manager, schema);

--- a/crates/jazz-tools/src/query_manager/rebac_tests/exists_policies.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests/exists_policies.rs
@@ -3,15 +3,16 @@ use super::*;
 #[test]
 fn rebac_exists_clause_denies_non_matching_insert() {
     // Schema with EXISTS policy: only admins can insert
-    let protected_policies = TablePolicies::new().with_insert(PolicyExpr::Exists {
-        table: "admins".into(),
-        condition: Box::new(PolicyExpr::eq_session("user_id", vec!["user_id".into()])),
+    let protected_policies = permissions(|p| {
+        p.allow_insert().where_(pe::exists(
+            pe::table("admins").where_(pe::eq("user_id", pe::session("user_id"))),
+        ));
     });
     let schema = SchemaBuilder::new()
         .table(
             TableSchema::builder("admins")
                 .column("user_id", ColumnType::Text)
-                .policies(TablePolicies::new().with_select(PolicyExpr::True)),
+                .policies(permissions(|p| p.allow_read().always())),
         )
         .table(
             TableSchema::builder("protected")
@@ -100,20 +101,20 @@ fn rebac_update_denied_by_using_exists_policy() {
     // Schema with EXISTS policy: only admins can update
     let protected_table = TableSchema::builder("protected").column("data", ColumnType::Text);
     let protected_descriptor = protected_table.clone().build().columns;
-    let protected_policies = TablePolicies::new().with_update(
+    let protected_policies = permissions(|p| {
         // USING: EXISTS (SELECT FROM admins WHERE user_id = @session.user_id)
-        Some(PolicyExpr::Exists {
-            table: "admins".into(),
-            condition: Box::new(PolicyExpr::eq_session("user_id", vec!["user_id".into()])),
-        }),
-        // WITH CHECK: no restriction on new row
-        PolicyExpr::True,
-    );
+        p.allow_update()
+            .where_old(pe::exists(
+                pe::table("admins").where_(pe::eq("user_id", pe::session("user_id"))),
+            ))
+            // WITH CHECK: no restriction on new row
+            .where_new(pe::always());
+    });
     let schema = SchemaBuilder::new()
         .table(
             TableSchema::builder("admins")
                 .column("user_id", ColumnType::Text)
-                .policies(TablePolicies::new().with_select(PolicyExpr::True)),
+                .policies(permissions(|p| p.allow_read().always())),
         )
         .table(protected_table.policies(protected_policies))
         .build();
@@ -284,18 +285,18 @@ fn rebac_update_denied_by_using_exists_policy() {
 
 #[test]
 fn local_update_using_exists_policy_allows_admin_and_denies_non_admin() {
-    let protected_policies = TablePolicies::new().with_update(
-        Some(PolicyExpr::Exists {
-            table: "admins".into(),
-            condition: Box::new(PolicyExpr::eq_session("user_id", vec!["user_id".into()])),
-        }),
-        PolicyExpr::True,
-    );
+    let protected_policies = permissions(|p| {
+        p.allow_update()
+            .where_old(pe::exists(
+                pe::table("admins").where_(pe::eq("user_id", pe::session("user_id"))),
+            ))
+            .where_new(pe::always());
+    });
     let schema = SchemaBuilder::new()
         .table(
             TableSchema::builder("admins")
                 .column("user_id", ColumnType::Text)
-                .policies(TablePolicies::new().with_select(PolicyExpr::True)),
+                .policies(permissions(|p| p.allow_read().always())),
         )
         .table(
             TableSchema::builder("protected")

--- a/crates/jazz-tools/src/query_manager/rebac_tests/exists_policies.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests/exists_policies.rs
@@ -3,30 +3,22 @@ use super::*;
 #[test]
 fn rebac_exists_clause_denies_non_matching_insert() {
     // Schema with EXISTS policy: only admins can insert
-    let mut schema = Schema::new();
-
-    // Admins table
-    let admins_descriptor =
-        RowDescriptor::new(vec![ColumnDescriptor::new("user_id", ColumnType::Text)]);
-    schema.insert(
-        TableName::new("admins"),
-        TableSchema::with_policies(
-            admins_descriptor,
-            TablePolicies::new().with_select(PolicyExpr::True),
-        ),
-    );
-
-    // Protected table: only admins can insert
-    let protected_descriptor =
-        RowDescriptor::new(vec![ColumnDescriptor::new("data", ColumnType::Text)]);
     let protected_policies = TablePolicies::new().with_insert(PolicyExpr::Exists {
         table: "admins".into(),
         condition: Box::new(PolicyExpr::eq_session("user_id", vec!["user_id".into()])),
     });
-    schema.insert(
-        TableName::new("protected"),
-        TableSchema::with_policies(protected_descriptor, protected_policies),
-    );
+    let schema = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("admins")
+                .column("user_id", ColumnType::Text)
+                .policies(TablePolicies::new().with_select(PolicyExpr::True)),
+        )
+        .table(
+            TableSchema::builder("protected")
+                .column("data", ColumnType::Text)
+                .policies(protected_policies),
+        )
+        .build();
 
     let sync_manager = SyncManager::new();
     let mut qm = create_query_manager(sync_manager, schema);
@@ -106,22 +98,8 @@ fn rebac_exists_clause_denies_non_matching_insert() {
 #[test]
 fn rebac_update_denied_by_using_exists_policy() {
     // Schema with EXISTS policy: only admins can update
-    let mut schema = Schema::new();
-
-    // Admins table
-    let admins_descriptor =
-        RowDescriptor::new(vec![ColumnDescriptor::new("user_id", ColumnType::Text)]);
-    schema.insert(
-        TableName::new("admins"),
-        TableSchema::with_policies(
-            admins_descriptor.clone(),
-            TablePolicies::new().with_select(PolicyExpr::True),
-        ),
-    );
-
-    // Protected table: only admins can update (via EXISTS in USING)
-    let protected_descriptor =
-        RowDescriptor::new(vec![ColumnDescriptor::new("data", ColumnType::Text)]);
+    let protected_table = TableSchema::builder("protected").column("data", ColumnType::Text);
+    let protected_descriptor = protected_table.clone().build().columns;
     let protected_policies = TablePolicies::new().with_update(
         // USING: EXISTS (SELECT FROM admins WHERE user_id = @session.user_id)
         Some(PolicyExpr::Exists {
@@ -131,10 +109,14 @@ fn rebac_update_denied_by_using_exists_policy() {
         // WITH CHECK: no restriction on new row
         PolicyExpr::True,
     );
-    schema.insert(
-        TableName::new("protected"),
-        TableSchema::with_policies(protected_descriptor.clone(), protected_policies),
-    );
+    let schema = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("admins")
+                .column("user_id", ColumnType::Text)
+                .policies(TablePolicies::new().with_select(PolicyExpr::True)),
+        )
+        .table(protected_table.policies(protected_policies))
+        .build();
 
     let sync_manager = SyncManager::new();
     let mut qm = create_query_manager(sync_manager, schema);
@@ -302,19 +284,6 @@ fn rebac_update_denied_by_using_exists_policy() {
 
 #[test]
 fn local_update_using_exists_policy_allows_admin_and_denies_non_admin() {
-    let mut schema = Schema::new();
-    let admins_descriptor =
-        RowDescriptor::new(vec![ColumnDescriptor::new("user_id", ColumnType::Text)]);
-    schema.insert(
-        TableName::new("admins"),
-        TableSchema::with_policies(
-            admins_descriptor.clone(),
-            TablePolicies::new().with_select(PolicyExpr::True),
-        ),
-    );
-
-    let protected_descriptor =
-        RowDescriptor::new(vec![ColumnDescriptor::new("data", ColumnType::Text)]);
     let protected_policies = TablePolicies::new().with_update(
         Some(PolicyExpr::Exists {
             table: "admins".into(),
@@ -322,10 +291,18 @@ fn local_update_using_exists_policy_allows_admin_and_denies_non_admin() {
         }),
         PolicyExpr::True,
     );
-    schema.insert(
-        TableName::new("protected"),
-        TableSchema::with_policies(protected_descriptor.clone(), protected_policies),
-    );
+    let schema = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("admins")
+                .column("user_id", ColumnType::Text)
+                .policies(TablePolicies::new().with_select(PolicyExpr::True)),
+        )
+        .table(
+            TableSchema::builder("protected")
+                .column("data", ColumnType::Text)
+                .policies(protected_policies),
+        )
+        .build();
 
     let sync_manager = SyncManager::new();
     let mut qm = create_query_manager(sync_manager, schema);

--- a/crates/jazz-tools/src/query_manager/rebac_tests/exists_rel_policies.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests/exists_rel_policies.rs
@@ -2,30 +2,15 @@ use super::*;
 
 #[test]
 fn local_insert_with_exists_policy_propagates_enforcing_mode_to_nested_exists_rel() {
-    let projects_policies = TablePolicies::new().with_insert(PolicyExpr::Exists {
-        table: "admins".into(),
-        condition: Box::new(PolicyExpr::And(vec![
-            PolicyExpr::eq_session("user_id", vec!["user_id".into()]),
-            PolicyExpr::ExistsRel {
-                rel: RelExpr::Filter {
-                    input: Box::new(RelExpr::TableScan {
-                        table: TableName::new("team_memberships"),
-                    }),
-                    predicate: PredicateExpr::And(vec![
-                        PredicateExpr::Cmp {
-                            left: ColumnRef::unscoped("team_id"),
-                            op: PredicateCmpOp::Eq,
-                            right: ValueRef::OuterColumn(ColumnRef::unscoped("team_id")),
-                        },
-                        PredicateExpr::Cmp {
-                            left: ColumnRef::unscoped("user_id"),
-                            op: PredicateCmpOp::Eq,
-                            right: ValueRef::SessionRef(vec!["user_id".into()]),
-                        },
-                    ]),
-                },
-            },
-        ])),
+    let projects_policies = permissions(|p| {
+        p.allow_insert()
+            .where_(pe::exists(pe::table("admins").where_(pe::all_of([
+                pe::eq("user_id", pe::session("user_id")),
+                pe::exists(pe::table("team_memberships").where_(pe::rel::all_of([
+                    pe::rel::eq_outer("team_id", "team_id"),
+                    pe::rel::eq_session("user_id", "user_id"),
+                ]))),
+            ]))));
     });
     let schema = SchemaBuilder::new()
         .table(
@@ -83,23 +68,16 @@ fn local_insert_with_exists_policy_propagates_enforcing_mode_to_nested_exists_re
 
 #[test]
 fn local_insert_with_exists_rel_policy_denies_non_admin() {
-    let projects_policies = TablePolicies::new().with_insert(PolicyExpr::ExistsRel {
-        rel: RelExpr::Filter {
-            input: Box::new(RelExpr::TableScan {
-                table: TableName::new("admins"),
-            }),
-            predicate: PredicateExpr::Cmp {
-                left: ColumnRef::unscoped("user_id"),
-                op: PredicateCmpOp::Eq,
-                right: ValueRef::SessionRef(vec!["user_id".into()]),
-            },
-        },
+    let projects_policies = permissions(|p| {
+        p.allow_insert().where_(pe::exists(
+            pe::table("admins").where_(pe::rel::eq_session("user_id", "user_id")),
+        ));
     });
     let schema = SchemaBuilder::new()
         .table(
             TableSchema::builder("admins")
                 .column("user_id", ColumnType::Text)
-                .policies(TablePolicies::new().with_select(PolicyExpr::True)),
+                .policies(permissions(|p| p.allow_read().always())),
         )
         .table(
             TableSchema::builder("projects")
@@ -142,17 +120,10 @@ fn local_insert_with_exists_rel_policy_denies_non_admin() {
 
 #[test]
 fn local_insert_with_exists_rel_policy_requires_explicit_select_on_scanned_table() {
-    let projects_policies = TablePolicies::new().with_insert(PolicyExpr::ExistsRel {
-        rel: RelExpr::Filter {
-            input: Box::new(RelExpr::TableScan {
-                table: TableName::new("admins"),
-            }),
-            predicate: PredicateExpr::Cmp {
-                left: ColumnRef::unscoped("user_id"),
-                op: PredicateCmpOp::Eq,
-                right: ValueRef::SessionRef(vec!["user_id".into()]),
-            },
-        },
+    let projects_policies = permissions(|p| {
+        p.allow_insert().where_(pe::exists(
+            pe::table("admins").where_(pe::rel::eq_session("user_id", "user_id")),
+        ));
     });
     let schema = SchemaBuilder::new()
         .table(TableSchema::builder("admins").column("user_id", ColumnType::Text))
@@ -191,31 +162,19 @@ fn local_insert_with_exists_rel_policy_requires_explicit_select_on_scanned_table
 
 #[test]
 fn local_insert_with_exists_rel_null_literal_predicate_matches_null_rows() {
-    let projects_policies = TablePolicies::new().with_insert(PolicyExpr::ExistsRel {
-        rel: RelExpr::Filter {
-            input: Box::new(RelExpr::TableScan {
-                table: TableName::new("admins"),
-            }),
-            predicate: PredicateExpr::And(vec![
-                PredicateExpr::Cmp {
-                    left: ColumnRef::unscoped("user_id"),
-                    op: PredicateCmpOp::Eq,
-                    right: ValueRef::SessionRef(vec!["user_id".into()]),
-                },
-                PredicateExpr::Cmp {
-                    left: ColumnRef::unscoped("revoked_at"),
-                    op: PredicateCmpOp::Eq,
-                    right: ValueRef::Literal(Value::Null),
-                },
-            ]),
-        },
+    let projects_policies = permissions(|p| {
+        p.allow_insert()
+            .where_(pe::exists(pe::table("admins").where_(pe::rel::all_of([
+                pe::rel::eq_session("user_id", "user_id"),
+                pe::rel::eq_literal("revoked_at", Value::Null),
+            ]))));
     });
     let schema = SchemaBuilder::new()
         .table(
             TableSchema::builder("admins")
                 .column("user_id", ColumnType::Text)
                 .nullable_column("revoked_at", ColumnType::Text)
-                .policies(TablePolicies::new().with_select(PolicyExpr::True)),
+                .policies(permissions(|p| p.allow_read().always())),
         )
         .table(
             TableSchema::builder("projects")
@@ -271,23 +230,16 @@ fn local_insert_with_exists_rel_null_literal_predicate_matches_null_rows() {
 
 #[test]
 fn local_delete_with_exists_rel_policy_allows_admin_and_denies_non_admin() {
-    let protected_policies = TablePolicies::new().with_delete(PolicyExpr::ExistsRel {
-        rel: RelExpr::Filter {
-            input: Box::new(RelExpr::TableScan {
-                table: TableName::new("admins"),
-            }),
-            predicate: PredicateExpr::Cmp {
-                left: ColumnRef::unscoped("user_id"),
-                op: PredicateCmpOp::Eq,
-                right: ValueRef::SessionRef(vec!["user_id".into()]),
-            },
-        },
+    let protected_policies = permissions(|p| {
+        p.allow_delete().where_(pe::exists(
+            pe::table("admins").where_(pe::rel::eq_session("user_id", "user_id")),
+        ));
     });
     let schema = SchemaBuilder::new()
         .table(
             TableSchema::builder("admins")
                 .column("user_id", ColumnType::Text)
-                .policies(TablePolicies::new().with_select(PolicyExpr::True)),
+                .policies(permissions(|p| p.allow_read().always())),
         )
         .table(
             TableSchema::builder("protected")

--- a/crates/jazz-tools/src/query_manager/rebac_tests/exists_rel_policies.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests/exists_rel_policies.rs
@@ -2,24 +2,6 @@ use super::*;
 
 #[test]
 fn local_insert_with_exists_policy_propagates_enforcing_mode_to_nested_exists_rel() {
-    let mut schema = Schema::new();
-    schema.insert(
-        TableName::new("admins"),
-        TableSchema::new(RowDescriptor::new(vec![
-            ColumnDescriptor::new("user_id", ColumnType::Text),
-            ColumnDescriptor::new("team_id", ColumnType::Text),
-        ])),
-    );
-    schema.insert(
-        TableName::new("team_memberships"),
-        TableSchema::new(RowDescriptor::new(vec![
-            ColumnDescriptor::new("team_id", ColumnType::Text),
-            ColumnDescriptor::new("user_id", ColumnType::Text),
-        ])),
-    );
-
-    let projects_descriptor =
-        RowDescriptor::new(vec![ColumnDescriptor::new("name", ColumnType::Text)]);
     let projects_policies = TablePolicies::new().with_insert(PolicyExpr::Exists {
         table: "admins".into(),
         condition: Box::new(PolicyExpr::And(vec![
@@ -45,10 +27,23 @@ fn local_insert_with_exists_policy_propagates_enforcing_mode_to_nested_exists_re
             },
         ])),
     });
-    schema.insert(
-        TableName::new("projects"),
-        TableSchema::with_policies(projects_descriptor, projects_policies),
-    );
+    let schema = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("admins")
+                .column("user_id", ColumnType::Text)
+                .column("team_id", ColumnType::Text),
+        )
+        .table(
+            TableSchema::builder("team_memberships")
+                .column("team_id", ColumnType::Text)
+                .column("user_id", ColumnType::Text),
+        )
+        .table(
+            TableSchema::builder("projects")
+                .column("name", ColumnType::Text)
+                .policies(projects_policies),
+        )
+        .build();
 
     let sync_manager = SyncManager::new();
     let mut qm = create_query_manager(sync_manager, schema);
@@ -88,19 +83,6 @@ fn local_insert_with_exists_policy_propagates_enforcing_mode_to_nested_exists_re
 
 #[test]
 fn local_insert_with_exists_rel_policy_denies_non_admin() {
-    let mut schema = Schema::new();
-    let admins_descriptor =
-        RowDescriptor::new(vec![ColumnDescriptor::new("user_id", ColumnType::Text)]);
-    schema.insert(
-        TableName::new("admins"),
-        TableSchema::with_policies(
-            admins_descriptor.clone(),
-            TablePolicies::new().with_select(PolicyExpr::True),
-        ),
-    );
-
-    let projects_descriptor =
-        RowDescriptor::new(vec![ColumnDescriptor::new("name", ColumnType::Text)]);
     let projects_policies = TablePolicies::new().with_insert(PolicyExpr::ExistsRel {
         rel: RelExpr::Filter {
             input: Box::new(RelExpr::TableScan {
@@ -113,10 +95,18 @@ fn local_insert_with_exists_rel_policy_denies_non_admin() {
             },
         },
     });
-    schema.insert(
-        TableName::new("projects"),
-        TableSchema::with_policies(projects_descriptor, projects_policies),
-    );
+    let schema = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("admins")
+                .column("user_id", ColumnType::Text)
+                .policies(TablePolicies::new().with_select(PolicyExpr::True)),
+        )
+        .table(
+            TableSchema::builder("projects")
+                .column("name", ColumnType::Text)
+                .policies(projects_policies),
+        )
+        .build();
 
     let sync_manager = SyncManager::new();
     let mut qm = create_query_manager(sync_manager, schema);
@@ -152,17 +142,6 @@ fn local_insert_with_exists_rel_policy_denies_non_admin() {
 
 #[test]
 fn local_insert_with_exists_rel_policy_requires_explicit_select_on_scanned_table() {
-    let mut schema = Schema::new();
-    schema.insert(
-        TableName::new("admins"),
-        TableSchema::new(RowDescriptor::new(vec![ColumnDescriptor::new(
-            "user_id",
-            ColumnType::Text,
-        )])),
-    );
-
-    let projects_descriptor =
-        RowDescriptor::new(vec![ColumnDescriptor::new("name", ColumnType::Text)]);
     let projects_policies = TablePolicies::new().with_insert(PolicyExpr::ExistsRel {
         rel: RelExpr::Filter {
             input: Box::new(RelExpr::TableScan {
@@ -175,10 +154,14 @@ fn local_insert_with_exists_rel_policy_requires_explicit_select_on_scanned_table
             },
         },
     });
-    schema.insert(
-        TableName::new("projects"),
-        TableSchema::with_policies(projects_descriptor, projects_policies),
-    );
+    let schema = SchemaBuilder::new()
+        .table(TableSchema::builder("admins").column("user_id", ColumnType::Text))
+        .table(
+            TableSchema::builder("projects")
+                .column("name", ColumnType::Text)
+                .policies(projects_policies),
+        )
+        .build();
 
     let sync_manager = SyncManager::new();
     let mut qm = create_query_manager(sync_manager, schema);
@@ -208,21 +191,6 @@ fn local_insert_with_exists_rel_policy_requires_explicit_select_on_scanned_table
 
 #[test]
 fn local_insert_with_exists_rel_null_literal_predicate_matches_null_rows() {
-    let mut schema = Schema::new();
-    let admins_descriptor = RowDescriptor::new(vec![
-        ColumnDescriptor::new("user_id", ColumnType::Text),
-        ColumnDescriptor::new("revoked_at", ColumnType::Text).nullable(),
-    ]);
-    schema.insert(
-        TableName::new("admins"),
-        TableSchema::with_policies(
-            admins_descriptor.clone(),
-            TablePolicies::new().with_select(PolicyExpr::True),
-        ),
-    );
-
-    let projects_descriptor =
-        RowDescriptor::new(vec![ColumnDescriptor::new("name", ColumnType::Text)]);
     let projects_policies = TablePolicies::new().with_insert(PolicyExpr::ExistsRel {
         rel: RelExpr::Filter {
             input: Box::new(RelExpr::TableScan {
@@ -242,10 +210,19 @@ fn local_insert_with_exists_rel_null_literal_predicate_matches_null_rows() {
             ]),
         },
     });
-    schema.insert(
-        TableName::new("projects"),
-        TableSchema::with_policies(projects_descriptor, projects_policies),
-    );
+    let schema = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("admins")
+                .column("user_id", ColumnType::Text)
+                .nullable_column("revoked_at", ColumnType::Text)
+                .policies(TablePolicies::new().with_select(PolicyExpr::True)),
+        )
+        .table(
+            TableSchema::builder("projects")
+                .column("name", ColumnType::Text)
+                .policies(projects_policies),
+        )
+        .build();
 
     let sync_manager = SyncManager::new();
     let mut qm = create_query_manager(sync_manager, schema);
@@ -294,19 +271,6 @@ fn local_insert_with_exists_rel_null_literal_predicate_matches_null_rows() {
 
 #[test]
 fn local_delete_with_exists_rel_policy_allows_admin_and_denies_non_admin() {
-    let mut schema = Schema::new();
-    let admins_descriptor =
-        RowDescriptor::new(vec![ColumnDescriptor::new("user_id", ColumnType::Text)]);
-    schema.insert(
-        TableName::new("admins"),
-        TableSchema::with_policies(
-            admins_descriptor.clone(),
-            TablePolicies::new().with_select(PolicyExpr::True),
-        ),
-    );
-
-    let protected_descriptor =
-        RowDescriptor::new(vec![ColumnDescriptor::new("data", ColumnType::Text)]);
     let protected_policies = TablePolicies::new().with_delete(PolicyExpr::ExistsRel {
         rel: RelExpr::Filter {
             input: Box::new(RelExpr::TableScan {
@@ -319,10 +283,18 @@ fn local_delete_with_exists_rel_policy_allows_admin_and_denies_non_admin() {
             },
         },
     });
-    schema.insert(
-        TableName::new("protected"),
-        TableSchema::with_policies(protected_descriptor.clone(), protected_policies),
-    );
+    let schema = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("admins")
+                .column("user_id", ColumnType::Text)
+                .policies(TablePolicies::new().with_select(PolicyExpr::True)),
+        )
+        .table(
+            TableSchema::builder("protected")
+                .column("data", ColumnType::Text)
+                .policies(protected_policies),
+        )
+        .build();
 
     let sync_manager = SyncManager::new();
     let mut qm = create_query_manager(sync_manager, schema);

--- a/crates/jazz-tools/src/query_manager/rebac_tests/inheritance_validation.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests/inheritance_validation.rs
@@ -75,39 +75,29 @@ fn rebac_recursive_inherits_cycle_does_not_overgrant() {
 fn rebac_inherits_cycle_detection() {
     use crate::query_manager::types::validate_no_inherits_cycles;
 
-    let mut schema = Schema::new();
-
-    // Table A references B via INHERITS
-    let a_desc = RowDescriptor::new(vec![
-        ColumnDescriptor::new("b_id", ColumnType::Uuid)
-            .nullable()
-            .references("table_b"),
-    ]);
     let a_policy = TablePolicies::new().with_select(PolicyExpr::Inherits {
         operation: Operation::Select,
         via_column: "b_id".into(),
         max_depth: None,
     });
-    schema.insert(
-        TableName::new("table_a"),
-        TableSchema::with_policies(a_desc, a_policy),
-    );
 
-    // Table B references A via INHERITS (creates cycle!)
-    let b_desc = RowDescriptor::new(vec![
-        ColumnDescriptor::new("a_id", ColumnType::Uuid)
-            .nullable()
-            .references("table_a"),
-    ]);
     let b_policy = TablePolicies::new().with_select(PolicyExpr::Inherits {
         operation: Operation::Select,
         via_column: "a_id".into(),
         max_depth: None,
     });
-    schema.insert(
-        TableName::new("table_b"),
-        TableSchema::with_policies(b_desc, b_policy),
-    );
+    let schema = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("table_a")
+                .nullable_fk_column("b_id", "table_b")
+                .policies(a_policy),
+        )
+        .table(
+            TableSchema::builder("table_b")
+                .nullable_fk_column("a_id", "table_a")
+                .policies(b_policy),
+        )
+        .build();
 
     // Should fail validation with cycle detected
     let result = validate_no_inherits_cycles(&schema);
@@ -124,24 +114,19 @@ fn rebac_inherits_cycle_detection() {
 fn rebac_inherits_self_reference_detection() {
     use crate::query_manager::types::validate_no_inherits_cycles;
 
-    let mut schema = Schema::new();
-
-    // Folder table with parent_id referencing itself
-    let folder_desc = RowDescriptor::new(vec![
-        ColumnDescriptor::new("name", ColumnType::Text),
-        ColumnDescriptor::new("parent_id", ColumnType::Uuid)
-            .nullable()
-            .references("folders"),
-    ]);
     let folder_policy = TablePolicies::new().with_select(PolicyExpr::Inherits {
         operation: Operation::Select,
         via_column: "parent_id".into(),
         max_depth: None,
     });
-    schema.insert(
-        TableName::new("folders"),
-        TableSchema::with_policies(folder_desc, folder_policy),
-    );
+    let schema = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("folders")
+                .column("name", ColumnType::Text)
+                .nullable_fk_column("parent_id", "folders")
+                .policies(folder_policy),
+        )
+        .build();
 
     // Should fail validation - self-reference is a cycle of length 1
     let result = validate_no_inherits_cycles(&schema);
@@ -161,23 +146,19 @@ fn rebac_inherits_self_reference_detection() {
 fn rebac_inherits_bounded_self_reference_passes_validation() {
     use crate::query_manager::types::validate_no_inherits_cycles;
 
-    let mut schema = Schema::new();
-
-    let folder_desc = RowDescriptor::new(vec![
-        ColumnDescriptor::new("name", ColumnType::Text),
-        ColumnDescriptor::new("parent_id", ColumnType::Uuid)
-            .nullable()
-            .references("folders"),
-    ]);
     let folder_policy = TablePolicies::new().with_select(PolicyExpr::Inherits {
         operation: Operation::Select,
         via_column: "parent_id".into(),
         max_depth: Some(10),
     });
-    schema.insert(
-        TableName::new("folders"),
-        TableSchema::with_policies(folder_desc, folder_policy),
-    );
+    let schema = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("folders")
+                .column("name", ColumnType::Text)
+                .nullable_fk_column("parent_id", "folders")
+                .policies(folder_policy),
+        )
+        .build();
 
     let result = validate_no_inherits_cycles(&schema);
     assert!(

--- a/crates/jazz-tools/src/query_manager/rebac_tests/inheritance_validation.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests/inheritance_validation.rs
@@ -75,16 +75,12 @@ fn rebac_recursive_inherits_cycle_does_not_overgrant() {
 fn rebac_inherits_cycle_detection() {
     use crate::query_manager::types::validate_no_inherits_cycles;
 
-    let a_policy = TablePolicies::new().with_select(PolicyExpr::Inherits {
-        operation: Operation::Select,
-        via_column: "b_id".into(),
-        max_depth: None,
+    let a_policy = permissions(|p| {
+        p.allow_read().where_(pe::allowed_to_read("b_id"));
     });
 
-    let b_policy = TablePolicies::new().with_select(PolicyExpr::Inherits {
-        operation: Operation::Select,
-        via_column: "a_id".into(),
-        max_depth: None,
+    let b_policy = permissions(|p| {
+        p.allow_read().where_(pe::allowed_to_read("a_id"));
     });
     let schema = SchemaBuilder::new()
         .table(
@@ -114,10 +110,8 @@ fn rebac_inherits_cycle_detection() {
 fn rebac_inherits_self_reference_detection() {
     use crate::query_manager::types::validate_no_inherits_cycles;
 
-    let folder_policy = TablePolicies::new().with_select(PolicyExpr::Inherits {
-        operation: Operation::Select,
-        via_column: "parent_id".into(),
-        max_depth: None,
+    let folder_policy = permissions(|p| {
+        p.allow_read().where_(pe::allowed_to_read("parent_id"));
     });
     let schema = SchemaBuilder::new()
         .table(
@@ -146,10 +140,9 @@ fn rebac_inherits_self_reference_detection() {
 fn rebac_inherits_bounded_self_reference_passes_validation() {
     use crate::query_manager::types::validate_no_inherits_cycles;
 
-    let folder_policy = TablePolicies::new().with_select(PolicyExpr::Inherits {
-        operation: Operation::Select,
-        via_column: "parent_id".into(),
-        max_depth: Some(10),
+    let folder_policy = permissions(|p| {
+        p.allow_read()
+            .where_(pe::allowed_to_read_with_depth("parent_id", 10));
     });
     let schema = SchemaBuilder::new()
         .table(

--- a/crates/jazz-tools/src/query_manager/rebac_tests/inherited_policies.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests/inherited_policies.rs
@@ -273,28 +273,18 @@ fn rebac_inherits_filters_select_query_results() {
     use crate::query_manager::query::QueryBuilder;
 
     // Schema with INHERITS policy
-    let mut schema = Schema::new();
-
-    // Folders table
-    let folders_descriptor = RowDescriptor::new(vec![
-        ColumnDescriptor::new("owner_id", ColumnType::Text),
-        ColumnDescriptor::new("name", ColumnType::Text),
-    ]);
+    let folders_table = TableSchema::builder("folders")
+        .column("owner_id", ColumnType::Text)
+        .column("name", ColumnType::Text);
+    let folders_descriptor = folders_table.clone().build().columns;
     let folders_policies = TablePolicies::new()
         .with_select(PolicyExpr::eq_session("owner_id", vec!["user_id".into()]));
-    schema.insert(
-        TableName::new("folders"),
-        TableSchema::with_policies(folders_descriptor.clone(), folders_policies),
-    );
 
-    // Documents table with INHERITS
-    let docs_descriptor = RowDescriptor::new(vec![
-        ColumnDescriptor::new("owner_id", ColumnType::Text),
-        ColumnDescriptor::new("title", ColumnType::Text),
-        ColumnDescriptor::new("folder_id", ColumnType::Uuid)
-            .nullable()
-            .references("folders"),
-    ]);
+    let docs_table = TableSchema::builder("documents")
+        .column("owner_id", ColumnType::Text)
+        .column("title", ColumnType::Text)
+        .nullable_fk_column("folder_id", "folders");
+    let docs_descriptor = docs_table.clone().build().columns;
 
     // SELECT policy: owner_id = @user_id OR INHERITS SELECT VIA folder_id
     let docs_policies = TablePolicies::new().with_select(PolicyExpr::Or(vec![
@@ -305,10 +295,10 @@ fn rebac_inherits_filters_select_query_results() {
             max_depth: None,
         },
     ]));
-    schema.insert(
-        TableName::new("documents"),
-        TableSchema::with_policies(docs_descriptor.clone(), docs_policies),
-    );
+    let schema = SchemaBuilder::new()
+        .table(folders_table.policies(folders_policies))
+        .table(docs_table.policies(docs_policies))
+        .build();
 
     let sync_manager = SyncManager::new();
     let mut qm = create_query_manager(sync_manager, schema);
@@ -395,32 +385,25 @@ fn rebac_inherits_filters_select_query_results() {
 fn inherits_select_denies_when_parent_operation_policy_is_missing() {
     use crate::query_manager::query::QueryBuilder;
 
-    let mut schema = Schema::new();
-    schema.insert(
-        TableName::new("folders"),
-        RowDescriptor::new(vec![
-            ColumnDescriptor::new("owner_id", ColumnType::Text),
-            ColumnDescriptor::new("name", ColumnType::Text),
-        ])
-        .into(),
-    );
-
-    let documents_descriptor = RowDescriptor::new(vec![
-        ColumnDescriptor::new("owner_id", ColumnType::Text),
-        ColumnDescriptor::new("title", ColumnType::Text),
-        ColumnDescriptor::new("folder_id", ColumnType::Uuid)
-            .nullable()
-            .references("folders"),
-    ]);
     let documents_policies = TablePolicies::new().with_select(PolicyExpr::Inherits {
         operation: Operation::Select,
         via_column: "folder_id".into(),
         max_depth: None,
     });
-    schema.insert(
-        TableName::new("documents"),
-        TableSchema::with_policies(documents_descriptor, documents_policies),
-    );
+    let schema = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("folders")
+                .column("owner_id", ColumnType::Text)
+                .column("name", ColumnType::Text),
+        )
+        .table(
+            TableSchema::builder("documents")
+                .column("owner_id", ColumnType::Text)
+                .column("title", ColumnType::Text)
+                .nullable_fk_column("folder_id", "folders")
+                .policies(documents_policies),
+        )
+        .build();
 
     let sync_manager = SyncManager::new();
     let mut qm = create_query_manager(sync_manager, schema);
@@ -459,29 +442,20 @@ fn inherits_select_denies_when_parent_operation_policy_is_missing() {
 
 #[test]
 fn local_insert_with_inherits_policy_allows_missing_parent_policy_in_permissive_local() {
-    let mut schema = Schema::new();
-    let folders_descriptor =
-        RowDescriptor::new(vec![ColumnDescriptor::new("title", ColumnType::Text)]);
-    schema.insert(
-        TableName::new("folders"),
-        TableSchema::new(folders_descriptor.clone()),
-    );
-
-    let documents_descriptor = RowDescriptor::new(vec![
-        ColumnDescriptor::new("title", ColumnType::Text),
-        ColumnDescriptor::new("folder_id", ColumnType::Uuid)
-            .nullable()
-            .references("folders"),
-    ]);
     let documents_policies = TablePolicies::new().with_insert(PolicyExpr::Inherits {
         operation: Operation::Insert,
         via_column: "folder_id".into(),
         max_depth: None,
     });
-    schema.insert(
-        TableName::new("documents"),
-        TableSchema::with_policies(documents_descriptor, documents_policies),
-    );
+    let schema = SchemaBuilder::new()
+        .table(TableSchema::builder("folders").column("title", ColumnType::Text))
+        .table(
+            TableSchema::builder("documents")
+                .column("title", ColumnType::Text)
+                .nullable_fk_column("folder_id", "folders")
+                .policies(documents_policies),
+        )
+        .build();
 
     let sync_manager = SyncManager::new();
     let mut qm =
@@ -509,11 +483,6 @@ fn local_insert_with_inherits_policy_allows_missing_parent_policy_in_permissive_
 
 #[test]
 fn local_update_with_inherits_referencing_allows_missing_source_policy_in_permissive_local() {
-    let mut schema = Schema::new();
-    let files_descriptor = RowDescriptor::new(vec![
-        ColumnDescriptor::new("owner_id", ColumnType::Text),
-        ColumnDescriptor::new("name", ColumnType::Text),
-    ]);
     let files_policies = TablePolicies::new().with_update(
         Some(PolicyExpr::InheritsReferencing {
             operation: Operation::Update,
@@ -523,19 +492,20 @@ fn local_update_with_inherits_referencing_allows_missing_source_policy_in_permis
         }),
         PolicyExpr::True,
     );
-    schema.insert(
-        TableName::new("files"),
-        TableSchema::with_policies(files_descriptor, files_policies),
-    );
-
-    let todos_descriptor = RowDescriptor::new(vec![
-        ColumnDescriptor::new("owner_id", ColumnType::Text),
-        ColumnDescriptor::new("title", ColumnType::Text),
-        ColumnDescriptor::new("file_id", ColumnType::Uuid)
-            .nullable()
-            .references("files"),
-    ]);
-    schema.insert(TableName::new("todos"), TableSchema::new(todos_descriptor));
+    let schema = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("files")
+                .column("owner_id", ColumnType::Text)
+                .column("name", ColumnType::Text)
+                .policies(files_policies),
+        )
+        .table(
+            TableSchema::builder("todos")
+                .column("owner_id", ColumnType::Text)
+                .column("title", ColumnType::Text)
+                .nullable_fk_column("file_id", "files"),
+        )
+        .build();
 
     let sync_manager = SyncManager::new();
     let mut qm =
@@ -576,14 +546,6 @@ fn local_update_with_inherits_referencing_allows_missing_source_policy_in_permis
 
 #[test]
 fn local_update_with_check_inherits_denies_when_parent_is_not_updateable() {
-    let mut schema = Schema::new();
-    let folders_descriptor = RowDescriptor::new(vec![
-        ColumnDescriptor::new("owner_id", ColumnType::Text),
-        ColumnDescriptor::new("name", ColumnType::Text),
-        ColumnDescriptor::new("parent_id", ColumnType::Uuid)
-            .nullable()
-            .references("folders"),
-    ]);
     let folders_policies = TablePolicies::new().with_update(
         Some(PolicyExpr::eq_session("owner_id", vec!["user_id".into()])),
         PolicyExpr::Inherits {
@@ -592,10 +554,15 @@ fn local_update_with_check_inherits_denies_when_parent_is_not_updateable() {
             max_depth: Some(10),
         },
     );
-    schema.insert(
-        TableName::new("folders"),
-        TableSchema::with_policies(folders_descriptor.clone(), folders_policies),
-    );
+    let schema = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("folders")
+                .column("owner_id", ColumnType::Text)
+                .column("name", ColumnType::Text)
+                .nullable_fk_column("parent_id", "folders")
+                .policies(folders_policies),
+        )
+        .build();
 
     let sync_manager = SyncManager::new();
     let mut qm = create_query_manager(sync_manager, schema);
@@ -648,14 +615,6 @@ fn local_update_with_check_inherits_denies_when_parent_is_not_updateable() {
 #[test]
 fn local_update_with_check_inherits_uses_visible_row_region_after_legacy_branch_history_is_removed()
 {
-    let mut schema = Schema::new();
-    let folders_descriptor = RowDescriptor::new(vec![
-        ColumnDescriptor::new("owner_id", ColumnType::Text),
-        ColumnDescriptor::new("name", ColumnType::Text),
-        ColumnDescriptor::new("parent_id", ColumnType::Uuid)
-            .nullable()
-            .references("folders"),
-    ]);
     let folders_policies = TablePolicies::new().with_update(
         Some(PolicyExpr::eq_session("owner_id", vec!["user_id".into()])),
         PolicyExpr::Inherits {
@@ -664,10 +623,15 @@ fn local_update_with_check_inherits_uses_visible_row_region_after_legacy_branch_
             max_depth: Some(10),
         },
     );
-    schema.insert(
-        TableName::new("folders"),
-        TableSchema::with_policies(folders_descriptor.clone(), folders_policies),
-    );
+    let schema = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("folders")
+                .column("owner_id", ColumnType::Text)
+                .column("name", ColumnType::Text)
+                .nullable_fk_column("parent_id", "folders")
+                .policies(folders_policies),
+        )
+        .build();
 
     let mut writer_qm = create_query_manager(SyncManager::new(), schema.clone());
     let _branch = get_branch(&writer_qm);
@@ -722,50 +686,39 @@ fn local_update_with_check_inherits_uses_visible_row_region_after_legacy_branch_
 fn rebac_inherits_no_cycle_passes() {
     use crate::query_manager::types::validate_no_inherits_cycles;
 
-    let mut schema = Schema::new();
-
-    // Organizations table (no INHERITS)
-    let org_desc = RowDescriptor::new(vec![ColumnDescriptor::new("name", ColumnType::Text)]);
     let org_policy =
         TablePolicies::new().with_select(PolicyExpr::eq_session("name", vec!["org".into()]));
-    schema.insert(
-        TableName::new("orgs"),
-        TableSchema::with_policies(org_desc, org_policy),
-    );
 
-    // Teams table - INHERITS from orgs
-    let team_desc = RowDescriptor::new(vec![
-        ColumnDescriptor::new("name", ColumnType::Text),
-        ColumnDescriptor::new("org_id", ColumnType::Uuid)
-            .nullable()
-            .references("orgs"),
-    ]);
     let team_policy = TablePolicies::new().with_select(PolicyExpr::Inherits {
         operation: Operation::Select,
         via_column: "org_id".into(),
         max_depth: None,
     });
-    schema.insert(
-        TableName::new("teams"),
-        TableSchema::with_policies(team_desc, team_policy),
-    );
 
-    // Projects table - INHERITS from teams
-    let project_desc = RowDescriptor::new(vec![
-        ColumnDescriptor::new("name", ColumnType::Text),
-        ColumnDescriptor::new("team_id", ColumnType::Uuid)
-            .nullable()
-            .references("teams"),
-    ]);
     let project_policy = TablePolicies::new().with_select(PolicyExpr::Inherits {
         operation: Operation::Select,
         via_column: "team_id".into(),
         max_depth: None,
     });
-    schema.insert(
-        TableName::new("projects"),
-        TableSchema::with_policies(project_desc, project_policy),
-    );
+    let schema = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("orgs")
+                .column("name", ColumnType::Text)
+                .policies(org_policy),
+        )
+        .table(
+            TableSchema::builder("teams")
+                .column("name", ColumnType::Text)
+                .nullable_fk_column("org_id", "orgs")
+                .policies(team_policy),
+        )
+        .table(
+            TableSchema::builder("projects")
+                .column("name", ColumnType::Text)
+                .nullable_fk_column("team_id", "teams")
+                .policies(project_policy),
+        )
+        .build();
 
     // Should pass - this is a valid chain: projects → teams → orgs
     let result = validate_no_inherits_cycles(&schema);

--- a/crates/jazz-tools/src/query_manager/rebac_tests/inherited_policies.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests/inherited_policies.rs
@@ -277,8 +277,10 @@ fn rebac_inherits_filters_select_query_results() {
         .column("owner_id", ColumnType::Text)
         .column("name", ColumnType::Text);
     let folders_descriptor = folders_table.clone().build().columns;
-    let folders_policies = TablePolicies::new()
-        .with_select(PolicyExpr::eq_session("owner_id", vec!["user_id".into()]));
+    let folders_policies = permissions(|p| {
+        p.allow_read()
+            .where_(pe::eq("owner_id", pe::session("user_id")));
+    });
 
     let docs_table = TableSchema::builder("documents")
         .column("owner_id", ColumnType::Text)
@@ -287,14 +289,12 @@ fn rebac_inherits_filters_select_query_results() {
     let docs_descriptor = docs_table.clone().build().columns;
 
     // SELECT policy: owner_id = @user_id OR INHERITS SELECT VIA folder_id
-    let docs_policies = TablePolicies::new().with_select(PolicyExpr::Or(vec![
-        PolicyExpr::eq_session("owner_id", vec!["user_id".into()]),
-        PolicyExpr::Inherits {
-            operation: Operation::Select,
-            via_column: "folder_id".into(),
-            max_depth: None,
-        },
-    ]));
+    let docs_policies = permissions(|p| {
+        p.allow_read().where_(pe::any_of([
+            pe::eq("owner_id", pe::session("user_id")),
+            pe::allowed_to_read("folder_id"),
+        ]));
+    });
     let schema = SchemaBuilder::new()
         .table(folders_table.policies(folders_policies))
         .table(docs_table.policies(docs_policies))
@@ -385,10 +385,8 @@ fn rebac_inherits_filters_select_query_results() {
 fn inherits_select_denies_when_parent_operation_policy_is_missing() {
     use crate::query_manager::query::QueryBuilder;
 
-    let documents_policies = TablePolicies::new().with_select(PolicyExpr::Inherits {
-        operation: Operation::Select,
-        via_column: "folder_id".into(),
-        max_depth: None,
+    let documents_policies = permissions(|p| {
+        p.allow_read().where_(pe::allowed_to_read("folder_id"));
     });
     let schema = SchemaBuilder::new()
         .table(
@@ -442,10 +440,8 @@ fn inherits_select_denies_when_parent_operation_policy_is_missing() {
 
 #[test]
 fn local_insert_with_inherits_policy_allows_missing_parent_policy_in_permissive_local() {
-    let documents_policies = TablePolicies::new().with_insert(PolicyExpr::Inherits {
-        operation: Operation::Insert,
-        via_column: "folder_id".into(),
-        max_depth: None,
+    let documents_policies = permissions(|p| {
+        p.allow_insert().where_(pe::allowed_to_insert("folder_id"));
     });
     let schema = SchemaBuilder::new()
         .table(TableSchema::builder("folders").column("title", ColumnType::Text))
@@ -483,15 +479,11 @@ fn local_insert_with_inherits_policy_allows_missing_parent_policy_in_permissive_
 
 #[test]
 fn local_update_with_inherits_referencing_allows_missing_source_policy_in_permissive_local() {
-    let files_policies = TablePolicies::new().with_update(
-        Some(PolicyExpr::InheritsReferencing {
-            operation: Operation::Update,
-            source_table: "todos".into(),
-            via_column: "file_id".into(),
-            max_depth: None,
-        }),
-        PolicyExpr::True,
-    );
+    let files_policies = permissions(|p| {
+        p.allow_update()
+            .where_old(pe::allowed_to_update_referencing("todos", "file_id"))
+            .where_new(pe::always());
+    });
     let schema = SchemaBuilder::new()
         .table(
             TableSchema::builder("files")
@@ -546,14 +538,11 @@ fn local_update_with_inherits_referencing_allows_missing_source_policy_in_permis
 
 #[test]
 fn local_update_with_check_inherits_denies_when_parent_is_not_updateable() {
-    let folders_policies = TablePolicies::new().with_update(
-        Some(PolicyExpr::eq_session("owner_id", vec!["user_id".into()])),
-        PolicyExpr::Inherits {
-            operation: Operation::Update,
-            via_column: "parent_id".into(),
-            max_depth: Some(10),
-        },
-    );
+    let folders_policies = permissions(|p| {
+        p.allow_update()
+            .where_old(pe::eq("owner_id", pe::session("user_id")))
+            .where_new(pe::allowed_to_update_with_depth("parent_id", 10));
+    });
     let schema = SchemaBuilder::new()
         .table(
             TableSchema::builder("folders")
@@ -615,14 +604,11 @@ fn local_update_with_check_inherits_denies_when_parent_is_not_updateable() {
 #[test]
 fn local_update_with_check_inherits_uses_visible_row_region_after_legacy_branch_history_is_removed()
 {
-    let folders_policies = TablePolicies::new().with_update(
-        Some(PolicyExpr::eq_session("owner_id", vec!["user_id".into()])),
-        PolicyExpr::Inherits {
-            operation: Operation::Update,
-            via_column: "parent_id".into(),
-            max_depth: Some(10),
-        },
-    );
+    let folders_policies = permissions(|p| {
+        p.allow_update()
+            .where_old(pe::eq("owner_id", pe::session("user_id")))
+            .where_new(pe::allowed_to_update_with_depth("parent_id", 10));
+    });
     let schema = SchemaBuilder::new()
         .table(
             TableSchema::builder("folders")
@@ -686,19 +672,16 @@ fn local_update_with_check_inherits_uses_visible_row_region_after_legacy_branch_
 fn rebac_inherits_no_cycle_passes() {
     use crate::query_manager::types::validate_no_inherits_cycles;
 
-    let org_policy =
-        TablePolicies::new().with_select(PolicyExpr::eq_session("name", vec!["org".into()]));
-
-    let team_policy = TablePolicies::new().with_select(PolicyExpr::Inherits {
-        operation: Operation::Select,
-        via_column: "org_id".into(),
-        max_depth: None,
+    let org_policy = permissions(|p| {
+        p.allow_read().where_(pe::eq("name", pe::session("org")));
     });
 
-    let project_policy = TablePolicies::new().with_select(PolicyExpr::Inherits {
-        operation: Operation::Select,
-        via_column: "team_id".into(),
-        max_depth: None,
+    let team_policy = permissions(|p| {
+        p.allow_read().where_(pe::allowed_to_read("org_id"));
+    });
+
+    let project_policy = permissions(|p| {
+        p.allow_read().where_(pe::allowed_to_read("team_id"));
     });
     let schema = SchemaBuilder::new()
         .table(

--- a/crates/jazz-tools/src/query_manager/rebac_tests/insert_policies.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests/insert_policies.rs
@@ -141,7 +141,7 @@ fn rebac_insert_denied_by_current_permissions_in_server_mode_known_schema() {
         .iter()
         .map(|(table_name, table_schema)| {
             let mut structural = table_schema.clone();
-            structural.policies = TablePolicies::default();
+            structural.policies = Default::default();
             (*table_name, structural)
         })
         .collect();
@@ -828,8 +828,9 @@ fn rebac_two_clients_different_sessions() {
 
 #[test]
 fn local_insert_policy_with_null_literal_allows_null_rows_and_denies_non_null_rows() {
-    let tasks_policies =
-        TablePolicies::new().with_insert(PolicyExpr::eq_literal("deleted_at", Value::Null));
+    let tasks_policies = permissions(|p| {
+        p.allow_insert().where_(pe::eq("deleted_at", pe::null()));
+    });
     let schema = SchemaBuilder::new()
         .table(
             TableSchema::builder("tasks")

--- a/crates/jazz-tools/src/query_manager/rebac_tests/insert_policies.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests/insert_policies.rs
@@ -526,16 +526,14 @@ fn rebac_insert_denied_when_stale_self_schema_would_otherwise_allow() {
 
     // Permissive local schema (no insert policy) that should NOT be used for server writes
     // on unrelated branches.
-    let mut permissive = Schema::new();
-    permissive.insert(
-        TableName::new("documents"),
-        RowDescriptor::new(vec![
-            ColumnDescriptor::new("owner_id", ColumnType::Text),
-            ColumnDescriptor::new("title", ColumnType::Text),
-            ColumnDescriptor::new("folder_id", ColumnType::Uuid).nullable(),
-        ])
-        .into(),
-    );
+    let permissive = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("documents")
+                .column("owner_id", ColumnType::Text)
+                .column("title", ColumnType::Text)
+                .nullable_column("folder_id", ColumnType::Uuid),
+        )
+        .build();
 
     let sync_manager = SyncManager::new();
     let mut qm = create_query_manager(sync_manager, permissive);
@@ -601,11 +599,9 @@ fn rebac_insert_denied_when_stale_self_schema_would_otherwise_allow() {
 #[test]
 fn permissive_local_runtime_without_loaded_policies_allows_sync_pending_write_without_policy() {
     // Schema with no policies
-    let mut schema = Schema::new();
-    schema.insert(
-        TableName::new("notes"),
-        RowDescriptor::new(vec![ColumnDescriptor::new("content", ColumnType::Text)]).into(),
-    );
+    let notes_table = TableSchema::builder("notes").column("content", ColumnType::Text);
+    let notes_desc = notes_table.clone().build().columns;
+    let schema = SchemaBuilder::new().table(notes_table).build();
 
     let sync_manager = SyncManager::new();
     let mut qm = create_query_manager(sync_manager, schema);
@@ -629,7 +625,6 @@ fn permissive_local_runtime_without_loaded_policies_allows_sync_pending_write_wi
     qm.sync_manager_mut().take_outbox();
 
     // Encode row content
-    let notes_desc = RowDescriptor::new(vec![ColumnDescriptor::new("content", ColumnType::Text)]);
     let content = encode_row(&notes_desc, &[Value::Text("A note".into())]).unwrap();
 
     // Client sends insert
@@ -667,11 +662,9 @@ fn permissive_local_runtime_without_loaded_policies_allows_sync_pending_write_wi
 
 #[test]
 fn loaded_empty_permissions_bundle_denies_sync_pending_write_without_explicit_policy() {
-    let mut schema = Schema::new();
-    schema.insert(
-        TableName::new("notes"),
-        RowDescriptor::new(vec![ColumnDescriptor::new("content", ColumnType::Text)]).into(),
-    );
+    let notes_table = TableSchema::builder("notes").column("content", ColumnType::Text);
+    let notes_desc = notes_table.clone().build().columns;
+    let schema = SchemaBuilder::new().table(notes_table).build();
 
     let sync_manager = SyncManager::new();
     let mut qm = create_query_manager(sync_manager, schema.clone());
@@ -693,7 +686,6 @@ fn loaded_empty_permissions_bundle_denies_sync_pending_write_without_explicit_po
     set_client_query_scope(&mut qm, &storage, client_id, QueryId(1), scope, None);
     qm.sync_manager_mut().take_outbox();
 
-    let notes_desc = RowDescriptor::new(vec![ColumnDescriptor::new("content", ColumnType::Text)]);
     let content = encode_row(&notes_desc, &[Value::Text("A note".into())]).unwrap();
     let commit = stored_row_commit(
         smallvec![],
@@ -836,17 +828,16 @@ fn rebac_two_clients_different_sessions() {
 
 #[test]
 fn local_insert_policy_with_null_literal_allows_null_rows_and_denies_non_null_rows() {
-    let mut schema = Schema::new();
-    let tasks_descriptor = RowDescriptor::new(vec![
-        ColumnDescriptor::new("title", ColumnType::Text),
-        ColumnDescriptor::new("deleted_at", ColumnType::Text).nullable(),
-    ]);
     let tasks_policies =
         TablePolicies::new().with_insert(PolicyExpr::eq_literal("deleted_at", Value::Null));
-    schema.insert(
-        TableName::new("tasks"),
-        TableSchema::with_policies(tasks_descriptor, tasks_policies),
-    );
+    let schema = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("tasks")
+                .column("title", ColumnType::Text)
+                .nullable_column("deleted_at", ColumnType::Text)
+                .policies(tasks_policies),
+        )
+        .build();
 
     let sync_manager = SyncManager::new();
     let mut qm = create_query_manager(sync_manager, schema);

--- a/crates/jazz-tools/src/query_manager/rebac_tests/mutations.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests/mutations.rs
@@ -3,12 +3,10 @@ use super::*;
 #[test]
 fn rebac_update_denied_by_using_policy() {
     // Schema with both USING and WITH CHECK for updates
-    let mut schema = Schema::new();
-
-    let docs_descriptor = RowDescriptor::new(vec![
-        ColumnDescriptor::new("owner_id", ColumnType::Text),
-        ColumnDescriptor::new("content", ColumnType::Text),
-    ]);
+    let docs_table = TableSchema::builder("documents")
+        .column("owner_id", ColumnType::Text)
+        .column("content", ColumnType::Text);
+    let docs_descriptor = docs_table.clone().build().columns;
 
     // UPDATE policy: USING (owner_id = @user_id) WITH CHECK (owner_id = @user_id)
     // This means: you can only update rows you own, and the result must still be owned by you
@@ -19,10 +17,9 @@ fn rebac_update_denied_by_using_policy() {
             PolicyExpr::eq_session("owner_id", vec!["user_id".into()]),       // WITH CHECK
         );
 
-    schema.insert(
-        TableName::new("documents"),
-        TableSchema::with_policies(docs_descriptor.clone(), docs_policies),
-    );
+    let schema = SchemaBuilder::new()
+        .table(docs_table.policies(docs_policies))
+        .build();
 
     let sync_manager = SyncManager::new();
     let mut qm = create_query_manager(sync_manager, schema);
@@ -120,19 +117,8 @@ fn rebac_update_denied_by_using_policy() {
 
 #[test]
 fn synced_soft_delete_should_use_delete_policy() {
-    let mut schema = Schema::new();
-    let admins_descriptor =
-        RowDescriptor::new(vec![ColumnDescriptor::new("user_id", ColumnType::Text)]);
-    schema.insert(
-        TableName::new("admins"),
-        TableSchema::with_policies(
-            admins_descriptor.clone(),
-            TablePolicies::new().with_select(PolicyExpr::True),
-        ),
-    );
-
-    let protected_descriptor =
-        RowDescriptor::new(vec![ColumnDescriptor::new("data", ColumnType::Text)]);
+    let protected_table = TableSchema::builder("protected").column("data", ColumnType::Text);
+    let protected_descriptor = protected_table.clone().build().columns;
     let protected_policies = TablePolicies::new().with_delete(PolicyExpr::ExistsRel {
         rel: RelExpr::Filter {
             input: Box::new(RelExpr::TableScan {
@@ -145,10 +131,14 @@ fn synced_soft_delete_should_use_delete_policy() {
             },
         },
     });
-    schema.insert(
-        TableName::new("protected"),
-        TableSchema::with_policies(protected_descriptor.clone(), protected_policies),
-    );
+    let schema = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("admins")
+                .column("user_id", ColumnType::Text)
+                .policies(TablePolicies::new().with_select(PolicyExpr::True)),
+        )
+        .table(protected_table.policies(protected_policies))
+        .build();
 
     let sync_manager = SyncManager::new();
     let mut qm = create_query_manager(sync_manager, schema);

--- a/crates/jazz-tools/src/query_manager/rebac_tests/mutations.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests/mutations.rs
@@ -10,12 +10,13 @@ fn rebac_update_denied_by_using_policy() {
 
     // UPDATE policy: USING (owner_id = @user_id) WITH CHECK (owner_id = @user_id)
     // This means: you can only update rows you own, and the result must still be owned by you
-    let docs_policies = TablePolicies::new()
-        .with_select(PolicyExpr::eq_session("owner_id", vec!["user_id".into()]))
-        .with_update(
-            Some(PolicyExpr::eq_session("owner_id", vec!["user_id".into()])), // USING
-            PolicyExpr::eq_session("owner_id", vec!["user_id".into()]),       // WITH CHECK
-        );
+    let owner_is_session = pe::eq("owner_id", pe::session("user_id"));
+    let docs_policies = permissions(|p| {
+        p.allow_read().where_(owner_is_session.clone());
+        p.allow_update()
+            .where_old(owner_is_session.clone()) // USING
+            .where_new(owner_is_session); // WITH CHECK
+    });
 
     let schema = SchemaBuilder::new()
         .table(docs_table.policies(docs_policies))
@@ -119,23 +120,16 @@ fn rebac_update_denied_by_using_policy() {
 fn synced_soft_delete_should_use_delete_policy() {
     let protected_table = TableSchema::builder("protected").column("data", ColumnType::Text);
     let protected_descriptor = protected_table.clone().build().columns;
-    let protected_policies = TablePolicies::new().with_delete(PolicyExpr::ExistsRel {
-        rel: RelExpr::Filter {
-            input: Box::new(RelExpr::TableScan {
-                table: TableName::new("admins"),
-            }),
-            predicate: PredicateExpr::Cmp {
-                left: ColumnRef::unscoped("user_id"),
-                op: PredicateCmpOp::Eq,
-                right: ValueRef::SessionRef(vec!["user_id".into()]),
-            },
-        },
+    let protected_policies = permissions(|p| {
+        p.allow_delete().where_(pe::exists(
+            pe::table("admins").where_(pe::rel::eq_session("user_id", "user_id")),
+        ));
     });
     let schema = SchemaBuilder::new()
         .table(
             TableSchema::builder("admins")
                 .column("user_id", ColumnType::Text)
-                .policies(TablePolicies::new().with_select(PolicyExpr::True)),
+                .policies(permissions(|p| p.allow_read().always())),
         )
         .table(protected_table.policies(protected_policies))
         .build();

--- a/crates/jazz-tools/src/query_manager/rebac_tests/select_policies.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests/select_policies.rs
@@ -4,8 +4,9 @@ use super::*;
 fn rebac_select_policy_with_null_literal_filters_query_results() {
     use crate::query_manager::query::QueryBuilder;
 
-    let documents_policies =
-        TablePolicies::new().with_select(PolicyExpr::eq_literal("deleted_at", Value::Null));
+    let documents_policies = permissions(|p| {
+        p.allow_read().where_(pe::eq("deleted_at", pe::null()));
+    });
     let schema = SchemaBuilder::new()
         .table(
             TableSchema::builder("documents")
@@ -70,8 +71,8 @@ fn rebac_select_policy_with_null_literal_filters_query_results() {
 fn rebac_select_policy_with_is_null_filters_query_results() {
     use crate::query_manager::query::QueryBuilder;
 
-    let documents_policies = TablePolicies::new().with_select(PolicyExpr::IsNull {
-        column: "deleted_at".into(),
+    let documents_policies = permissions(|p| {
+        p.allow_read().where_(pe::is_null("deleted_at"));
     });
     let schema = SchemaBuilder::new()
         .table(

--- a/crates/jazz-tools/src/query_manager/rebac_tests/select_policies.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests/select_policies.rs
@@ -4,17 +4,16 @@ use super::*;
 fn rebac_select_policy_with_null_literal_filters_query_results() {
     use crate::query_manager::query::QueryBuilder;
 
-    let mut schema = Schema::new();
-    let documents_descriptor = RowDescriptor::new(vec![
-        ColumnDescriptor::new("title", ColumnType::Text),
-        ColumnDescriptor::new("deleted_at", ColumnType::Text).nullable(),
-    ]);
     let documents_policies =
         TablePolicies::new().with_select(PolicyExpr::eq_literal("deleted_at", Value::Null));
-    schema.insert(
-        TableName::new("documents"),
-        TableSchema::with_policies(documents_descriptor, documents_policies),
-    );
+    let schema = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("documents")
+                .column("title", ColumnType::Text)
+                .nullable_column("deleted_at", ColumnType::Text)
+                .policies(documents_policies),
+        )
+        .build();
 
     let sync_manager = SyncManager::new();
     let mut qm = create_query_manager(sync_manager, schema);
@@ -71,18 +70,17 @@ fn rebac_select_policy_with_null_literal_filters_query_results() {
 fn rebac_select_policy_with_is_null_filters_query_results() {
     use crate::query_manager::query::QueryBuilder;
 
-    let mut schema = Schema::new();
-    let documents_descriptor = RowDescriptor::new(vec![
-        ColumnDescriptor::new("title", ColumnType::Text),
-        ColumnDescriptor::new("deleted_at", ColumnType::Text).nullable(),
-    ]);
     let documents_policies = TablePolicies::new().with_select(PolicyExpr::IsNull {
         column: "deleted_at".into(),
     });
-    schema.insert(
-        TableName::new("documents"),
-        TableSchema::with_policies(documents_descriptor, documents_policies),
-    );
+    let schema = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("documents")
+                .column("title", ColumnType::Text)
+                .nullable_column("deleted_at", ColumnType::Text)
+                .policies(documents_policies),
+        )
+        .build();
 
     let sync_manager = SyncManager::new();
     let mut qm = create_query_manager(sync_manager, schema);

--- a/crates/jazz-tools/src/query_manager/types/policy.rs
+++ b/crates/jazz-tools/src/query_manager/types/policy.rs
@@ -1,4 +1,9 @@
 use super::*;
+use crate::object::ObjectId;
+use crate::query_manager::policy::{CmpOp, Operation, PolicyValue};
+use crate::query_manager::relation_ir::{
+    ColumnRef, PredicateCmpOp, PredicateExpr, RelExpr, ValueRef,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -133,5 +138,593 @@ impl TablePolicies {
 
     pub fn has_explicit_update_policy(&self) -> bool {
         self.update.using.is_some() || self.update.with_check.is_some()
+    }
+}
+
+/// Build table permissions with a TypeScript-DSL-like API.
+///
+/// ```
+/// # use jazz_tools::query_manager::types::{permissions, policy_expr as expr};
+/// let policies = permissions(|p| {
+///     p.allow_read()
+///         .where_(expr::eq("owner_id", expr::session("user_id")));
+///     p.allow_update()
+///         .where_old(expr::eq("owner_id", expr::session("user_id")))
+///         .where_new(expr::eq("owner_id", expr::session("user_id")));
+/// });
+/// ```
+pub fn permissions(build: impl FnOnce(&mut TablePolicyBuilder)) -> TablePolicies {
+    let mut builder = TablePolicyBuilder::default();
+    build(&mut builder);
+    builder.build()
+}
+
+#[derive(Debug, Default)]
+pub struct TablePolicyBuilder {
+    policies: TablePolicies,
+}
+
+impl TablePolicyBuilder {
+    pub fn allow_read(&mut self) -> ActionPolicyBuilder<'_> {
+        ActionPolicyBuilder::new(&mut self.policies, PolicyAction::Read)
+    }
+
+    pub fn allow_insert(&mut self) -> ActionPolicyBuilder<'_> {
+        ActionPolicyBuilder::new(&mut self.policies, PolicyAction::Insert)
+    }
+
+    pub fn allow_delete(&mut self) -> ActionPolicyBuilder<'_> {
+        ActionPolicyBuilder::new(&mut self.policies, PolicyAction::Delete)
+    }
+
+    pub fn allow_update(&mut self) -> UpdatePolicyBuilder<'_> {
+        UpdatePolicyBuilder::new(&mut self.policies)
+    }
+
+    pub fn build(self) -> TablePolicies {
+        self.policies
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum PolicyAction {
+    Read,
+    Insert,
+    Delete,
+}
+
+#[derive(Debug)]
+pub struct ActionPolicyBuilder<'a> {
+    policies: &'a mut TablePolicies,
+    action: PolicyAction,
+}
+
+impl<'a> ActionPolicyBuilder<'a> {
+    fn new(policies: &'a mut TablePolicies, action: PolicyAction) -> Self {
+        Self { policies, action }
+    }
+
+    pub fn where_(self, expr: PolicyExpr) {
+        match self.action {
+            PolicyAction::Read => merge_expr(&mut self.policies.select.using, expr),
+            PolicyAction::Insert => merge_expr(&mut self.policies.insert.with_check, expr),
+            PolicyAction::Delete => merge_expr(&mut self.policies.delete.using, expr),
+        }
+    }
+
+    pub fn always(self) {
+        self.where_(PolicyExpr::True);
+    }
+
+    pub fn never(self) {
+        self.where_(PolicyExpr::False);
+    }
+}
+
+#[derive(Debug)]
+pub struct UpdatePolicyBuilder<'a> {
+    policies: &'a mut TablePolicies,
+    using: Option<PolicyExpr>,
+    with_check: Option<PolicyExpr>,
+}
+
+impl<'a> UpdatePolicyBuilder<'a> {
+    fn new(policies: &'a mut TablePolicies) -> Self {
+        Self {
+            policies,
+            using: None,
+            with_check: None,
+        }
+    }
+
+    pub fn where_(mut self, expr: PolicyExpr) {
+        self.using = Some(expr.clone());
+        self.with_check = Some(expr);
+    }
+
+    pub fn always(self) {
+        self.where_(PolicyExpr::True);
+    }
+
+    pub fn never(self) {
+        self.where_(PolicyExpr::False);
+    }
+
+    pub fn where_old(mut self, expr: PolicyExpr) -> Self {
+        self.using = Some(expr);
+        self
+    }
+
+    pub fn where_new(mut self, expr: PolicyExpr) -> Self {
+        self.with_check = Some(expr);
+        self
+    }
+}
+
+impl Drop for UpdatePolicyBuilder<'_> {
+    fn drop(&mut self) {
+        let using = self
+            .using
+            .take()
+            .or_else(|| self.with_check.as_ref().cloned());
+        let with_check = self.with_check.take().or_else(|| using.as_ref().cloned());
+
+        if let Some(expr) = using {
+            merge_expr(&mut self.policies.update.using, expr);
+        }
+        if let Some(expr) = with_check {
+            merge_expr(&mut self.policies.update.with_check, expr);
+        }
+    }
+}
+
+fn merge_expr(target: &mut Option<PolicyExpr>, expr: PolicyExpr) {
+    *target = Some(match target.take() {
+        Some(existing) => PolicyExpr::or(vec![existing, expr]),
+        None => expr,
+    });
+}
+
+pub mod policy_expr {
+    use super::*;
+
+    pub trait IntoSessionPath {
+        fn into_session_path(self) -> Vec<String>;
+    }
+
+    impl IntoSessionPath for &str {
+        fn into_session_path(self) -> Vec<String> {
+            self.split('.').map(str::to_string).collect()
+        }
+    }
+
+    impl IntoSessionPath for String {
+        fn into_session_path(self) -> Vec<String> {
+            self.split('.').map(str::to_string).collect()
+        }
+    }
+
+    impl IntoSessionPath for Vec<String> {
+        fn into_session_path(self) -> Vec<String> {
+            self
+        }
+    }
+
+    impl IntoSessionPath for Vec<&str> {
+        fn into_session_path(self) -> Vec<String> {
+            self.into_iter().map(str::to_string).collect()
+        }
+    }
+
+    impl IntoSessionPath for &[&str] {
+        fn into_session_path(self) -> Vec<String> {
+            self.iter().map(|part| (*part).to_string()).collect()
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum PolicyValueInput {
+        Literal(Value),
+        Session(Vec<String>),
+    }
+
+    impl From<PolicyValueInput> for PolicyValue {
+        fn from(value: PolicyValueInput) -> Self {
+            match value {
+                PolicyValueInput::Literal(value) => PolicyValue::Literal(value),
+                PolicyValueInput::Session(path) => PolicyValue::SessionRef(path),
+            }
+        }
+    }
+
+    impl From<PolicyValue> for PolicyValueInput {
+        fn from(value: PolicyValue) -> Self {
+            match value {
+                PolicyValue::Literal(value) => PolicyValueInput::Literal(value),
+                PolicyValue::SessionRef(path) => PolicyValueInput::Session(path),
+            }
+        }
+    }
+
+    impl From<Value> for PolicyValueInput {
+        fn from(value: Value) -> Self {
+            PolicyValueInput::Literal(value)
+        }
+    }
+
+    impl From<&str> for PolicyValueInput {
+        fn from(value: &str) -> Self {
+            PolicyValueInput::Literal(value.into())
+        }
+    }
+
+    impl From<String> for PolicyValueInput {
+        fn from(value: String) -> Self {
+            PolicyValueInput::Literal(value.into())
+        }
+    }
+
+    impl From<bool> for PolicyValueInput {
+        fn from(value: bool) -> Self {
+            PolicyValueInput::Literal(value.into())
+        }
+    }
+
+    impl From<i32> for PolicyValueInput {
+        fn from(value: i32) -> Self {
+            PolicyValueInput::Literal(value.into())
+        }
+    }
+
+    impl From<i64> for PolicyValueInput {
+        fn from(value: i64) -> Self {
+            PolicyValueInput::Literal(value.into())
+        }
+    }
+
+    impl From<f64> for PolicyValueInput {
+        fn from(value: f64) -> Self {
+            PolicyValueInput::Literal(value.into())
+        }
+    }
+
+    impl From<ObjectId> for PolicyValueInput {
+        fn from(value: ObjectId) -> Self {
+            PolicyValueInput::Literal(value.into())
+        }
+    }
+
+    pub fn session(path: impl IntoSessionPath) -> PolicyValueInput {
+        PolicyValueInput::Session(path.into_session_path())
+    }
+
+    pub fn literal(value: impl Into<Value>) -> PolicyValueInput {
+        PolicyValueInput::Literal(value.into())
+    }
+
+    pub fn null() -> PolicyValueInput {
+        PolicyValueInput::Literal(Value::Null)
+    }
+
+    pub fn always() -> PolicyExpr {
+        PolicyExpr::True
+    }
+
+    pub fn never() -> PolicyExpr {
+        PolicyExpr::False
+    }
+
+    pub fn eq(column: impl Into<String>, value: impl Into<PolicyValueInput>) -> PolicyExpr {
+        cmp(column, CmpOp::Eq, value)
+    }
+
+    pub fn ne(column: impl Into<String>, value: impl Into<PolicyValueInput>) -> PolicyExpr {
+        cmp(column, CmpOp::Ne, value)
+    }
+
+    pub fn cmp(
+        column: impl Into<String>,
+        op: CmpOp,
+        value: impl Into<PolicyValueInput>,
+    ) -> PolicyExpr {
+        PolicyExpr::Cmp {
+            column: column.into(),
+            op,
+            value: value.into().into(),
+        }
+    }
+
+    pub fn is_null(column: impl Into<String>) -> PolicyExpr {
+        PolicyExpr::IsNull {
+            column: column.into(),
+        }
+    }
+
+    pub fn is_not_null(column: impl Into<String>) -> PolicyExpr {
+        PolicyExpr::IsNotNull {
+            column: column.into(),
+        }
+    }
+
+    pub fn contains(column: impl Into<String>, value: impl Into<PolicyValueInput>) -> PolicyExpr {
+        PolicyExpr::Contains {
+            column: column.into(),
+            value: value.into().into(),
+        }
+    }
+
+    pub fn in_session(column: impl Into<String>, path: impl IntoSessionPath) -> PolicyExpr {
+        PolicyExpr::In {
+            column: column.into(),
+            session_path: path.into_session_path(),
+        }
+    }
+
+    pub fn all_of(exprs: impl IntoIterator<Item = PolicyExpr>) -> PolicyExpr {
+        PolicyExpr::and(exprs.into_iter().collect())
+    }
+
+    pub fn any_of(exprs: impl IntoIterator<Item = PolicyExpr>) -> PolicyExpr {
+        PolicyExpr::or(exprs.into_iter().collect())
+    }
+
+    pub fn not(expr: PolicyExpr) -> PolicyExpr {
+        PolicyExpr::not(expr)
+    }
+
+    /// Start a relation expression for `exists(table(...).where_(...))` policies.
+    ///
+    /// This mirrors the TypeScript `policy.exists(policy.some_table.where(...))`.
+    /// Passing a normal policy expression to `where_` builds a plain table
+    /// `EXISTS`; passing a relation predicate builds relation-backed `EXISTS`.
+    pub fn table(table: impl Into<TableName>) -> Table {
+        Table {
+            table: table.into(),
+        }
+    }
+
+    /// Build an `EXISTS` policy expression.
+    pub fn exists(exists: impl IntoExistsExpr) -> PolicyExpr {
+        exists.into_exists_expr()
+    }
+
+    pub trait IntoExistsExpr {
+        fn into_exists_expr(self) -> PolicyExpr;
+    }
+
+    pub trait IntoTableWhere {
+        type Output;
+
+        fn into_table_where(self, table: TableName) -> Self::Output;
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct Table {
+        table: TableName,
+    }
+
+    impl Table {
+        pub fn where_<W: IntoTableWhere>(self, condition: W) -> W::Output {
+            condition.into_table_where(self.table)
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct TableExists {
+        table: TableName,
+        condition: PolicyExpr,
+    }
+
+    impl IntoTableWhere for PolicyExpr {
+        type Output = TableExists;
+
+        fn into_table_where(self, table: TableName) -> Self::Output {
+            TableExists {
+                table,
+                condition: self,
+            }
+        }
+    }
+
+    impl IntoExistsExpr for TableExists {
+        fn into_exists_expr(self) -> PolicyExpr {
+            PolicyExpr::Exists {
+                table: self.table.as_str().to_string(),
+                condition: Box::new(self.condition),
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct Relation {
+        rel: RelExpr,
+    }
+
+    impl Relation {
+        fn new(rel: RelExpr) -> Self {
+            Self { rel }
+        }
+
+        pub fn where_(self, predicate: PredicateExpr) -> Self {
+            Self::new(RelExpr::Filter {
+                input: Box::new(self.rel),
+                predicate,
+            })
+        }
+
+        pub fn into_rel_expr(self) -> RelExpr {
+            self.rel
+        }
+    }
+
+    impl IntoTableWhere for PredicateExpr {
+        type Output = Relation;
+
+        fn into_table_where(self, table: TableName) -> Self::Output {
+            Relation::new(RelExpr::Filter {
+                input: Box::new(RelExpr::TableScan { table }),
+                predicate: self,
+            })
+        }
+    }
+
+    impl From<RelExpr> for Relation {
+        fn from(rel: RelExpr) -> Self {
+            Self::new(rel)
+        }
+    }
+
+    impl IntoExistsExpr for Relation {
+        fn into_exists_expr(self) -> PolicyExpr {
+            PolicyExpr::ExistsRel {
+                rel: self.into_rel_expr(),
+            }
+        }
+    }
+
+    impl IntoExistsExpr for RelExpr {
+        fn into_exists_expr(self) -> PolicyExpr {
+            PolicyExpr::ExistsRel { rel: self }
+        }
+    }
+
+    pub fn allowed_to_read(via_column: impl Into<String>) -> PolicyExpr {
+        allowed_to(Operation::Select, via_column)
+    }
+
+    pub fn allowed_to_insert(via_column: impl Into<String>) -> PolicyExpr {
+        allowed_to(Operation::Insert, via_column)
+    }
+
+    pub fn allowed_to_update(via_column: impl Into<String>) -> PolicyExpr {
+        allowed_to(Operation::Update, via_column)
+    }
+
+    pub fn allowed_to_delete(via_column: impl Into<String>) -> PolicyExpr {
+        allowed_to(Operation::Delete, via_column)
+    }
+
+    pub fn allowed_to_read_with_depth(
+        via_column: impl Into<String>,
+        max_depth: usize,
+    ) -> PolicyExpr {
+        allowed_to_with_depth(Operation::Select, via_column, max_depth)
+    }
+
+    pub fn allowed_to_update_with_depth(
+        via_column: impl Into<String>,
+        max_depth: usize,
+    ) -> PolicyExpr {
+        allowed_to_with_depth(Operation::Update, via_column, max_depth)
+    }
+
+    pub fn allowed_to(operation: Operation, via_column: impl Into<String>) -> PolicyExpr {
+        PolicyExpr::Inherits {
+            operation,
+            via_column: via_column.into(),
+            max_depth: None,
+        }
+    }
+
+    pub fn allowed_to_with_depth(
+        operation: Operation,
+        via_column: impl Into<String>,
+        max_depth: usize,
+    ) -> PolicyExpr {
+        PolicyExpr::Inherits {
+            operation,
+            via_column: via_column.into(),
+            max_depth: Some(max_depth),
+        }
+    }
+
+    pub fn allowed_to_read_referencing(
+        source_table: impl Into<String>,
+        via_column: impl Into<String>,
+    ) -> PolicyExpr {
+        allowed_to_referencing(Operation::Select, source_table, via_column)
+    }
+
+    pub fn allowed_to_update_referencing(
+        source_table: impl Into<String>,
+        via_column: impl Into<String>,
+    ) -> PolicyExpr {
+        allowed_to_referencing(Operation::Update, source_table, via_column)
+    }
+
+    pub fn allowed_to_referencing(
+        operation: Operation,
+        source_table: impl Into<String>,
+        via_column: impl Into<String>,
+    ) -> PolicyExpr {
+        PolicyExpr::InheritsReferencing {
+            operation,
+            source_table: source_table.into(),
+            via_column: via_column.into(),
+            max_depth: None,
+        }
+    }
+
+    pub mod rel {
+        use super::*;
+
+        pub fn eq_session(column: impl Into<String>, path: impl IntoSessionPath) -> PredicateExpr {
+            cmp(
+                column,
+                PredicateCmpOp::Eq,
+                ValueRef::SessionRef(path.into_session_path()),
+            )
+        }
+
+        pub fn eq_outer(
+            column: impl Into<String>,
+            outer_column: impl Into<String>,
+        ) -> PredicateExpr {
+            cmp(
+                column,
+                PredicateCmpOp::Eq,
+                ValueRef::OuterColumn(ColumnRef::unscoped(outer_column)),
+            )
+        }
+
+        pub fn eq_literal(column: impl Into<String>, value: impl Into<Value>) -> PredicateExpr {
+            cmp(column, PredicateCmpOp::Eq, ValueRef::Literal(value.into()))
+        }
+
+        pub fn is_null(column: impl Into<String>) -> PredicateExpr {
+            PredicateExpr::IsNull {
+                column: ColumnRef::unscoped(column),
+            }
+        }
+
+        pub fn all_of(exprs: impl IntoIterator<Item = PredicateExpr>) -> PredicateExpr {
+            let exprs = exprs.into_iter().collect::<Vec<_>>();
+            match exprs.len() {
+                0 => PredicateExpr::True,
+                1 => exprs.into_iter().next().unwrap(),
+                _ => PredicateExpr::And(exprs),
+            }
+        }
+
+        pub fn any_of(exprs: impl IntoIterator<Item = PredicateExpr>) -> PredicateExpr {
+            let exprs = exprs.into_iter().collect::<Vec<_>>();
+            match exprs.len() {
+                0 => PredicateExpr::False,
+                1 => exprs.into_iter().next().unwrap(),
+                _ => PredicateExpr::Or(exprs),
+            }
+        }
+
+        pub fn cmp(
+            column: impl Into<String>,
+            op: PredicateCmpOp,
+            right: ValueRef,
+        ) -> PredicateExpr {
+            PredicateExpr::Cmp {
+                left: ColumnRef::unscoped(column),
+                op,
+                right,
+            }
+        }
     }
 }

--- a/crates/jazz-tools/src/query_manager/types/schema.rs
+++ b/crates/jazz-tools/src/query_manager/types/schema.rs
@@ -504,6 +504,20 @@ impl TableSchemaBuilder {
         self
     }
 
+    /// Add an array foreign key column.
+    pub fn array_fk_column(mut self, name: &str, references: &str) -> Self {
+        self.columns.push(
+            ColumnDescriptor::new(
+                name,
+                ColumnType::Array {
+                    element: Box::new(ColumnType::Uuid),
+                },
+            )
+            .references(references),
+        );
+        self
+    }
+
     /// Set policies for the table.
     pub fn policies(mut self, policies: TablePolicies) -> Self {
         self.policies = policies;


### PR DESCRIPTION
## Description

This PR adds a permissions DSL to Rust that mirrors the TS DSL as closely as possible. For now, it's not meant to be a user-facing API, but rather just a utility for writing more readable tests. It's not as feature-complete as the Typescript DSL, the goal is to add the remaining parts as we need them.

To test the new DSL, I migrated all ReBAC permission tests to use the new permission DSL along with the existing schema/table builders, making them way easier to follow.

My goal is to migrate important Rust tests to use just schema/table builders, the permission DSL and the Rust JazzClient (instead of internals).