### PR TITLE
[codex] Fix broker browser test flakes

### DIFF
--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -92,7 +92,7 @@ import {
   type BrowserBrokerRole,
   type BrowserBrokerVisibility,
 } from "./browser-broker-protocol.js";
-import { tryAcquireWebLock, type LeaderLockLease } from "./leader-lock.js";
+import { acquireWebLockWithRetry, type LeaderLockLease } from "./leader-lock.js";
 
 type WasmLogLevel = "error" | "warn" | "info" | "debug" | "trace";
 type AnyDbRuntimeModule = DbRuntimeModule<any>;
@@ -1442,7 +1442,7 @@ export class Db {
 
     try {
       const tabLockName = this.brokerTabLockName();
-      const tabLockLease = await tryAcquireWebLock(tabLockName, {
+      const tabLockLease = await acquireWebLockWithRetry(tabLockName, {
         onLost: (reason) => {
           void this.handleBrokerLeaderLockLost(leadershipId, tabLockName, reason);
         },
@@ -1454,7 +1454,7 @@ export class Db {
       if (await this.finishCancelledBrokerPromotion(promotion)) return;
 
       const compatibilityLockName = this.brokerCompatibilityLockName();
-      const compatibilityLockLease = await tryAcquireWebLock(compatibilityLockName, {
+      const compatibilityLockLease = await acquireWebLockWithRetry(compatibilityLockName, {
         onLost: (reason) => {
           void this.handleBrokerLeaderLockLost(leadershipId, compatibilityLockName, reason);
         },

--- a/packages/jazz-tools/src/runtime/leader-lock.ts
+++ b/packages/jazz-tools/src/runtime/leader-lock.ts
@@ -11,6 +11,14 @@ export interface WebLockAcquireOptions {
   onLost?: (reason: unknown) => void;
 }
 
+export interface WebLockRetryOptions extends WebLockAcquireOptions {
+  timeoutMs?: number;
+  retryDelayMs?: number;
+}
+
+const DEFAULT_WEB_LOCK_RETRY_TIMEOUT_MS = 250;
+const DEFAULT_WEB_LOCK_RETRY_DELAY_MS = 20;
+
 interface LockManagerLike {
   request<T>(
     name: string,
@@ -142,6 +150,30 @@ export async function tryAcquireWebLock(
   return await acquiredPromise;
 }
 
+export async function acquireWebLockWithRetry(
+  lockName: string,
+  options: WebLockRetryOptions = {},
+): Promise<LeaderLockLease | null> {
+  const timeoutMs = normalizePositiveMilliseconds(
+    options.timeoutMs,
+    DEFAULT_WEB_LOCK_RETRY_TIMEOUT_MS,
+  );
+  const retryDelayMs = normalizePositiveMilliseconds(
+    options.retryDelayMs,
+    DEFAULT_WEB_LOCK_RETRY_DELAY_MS,
+  );
+  const deadline = Date.now() + timeoutMs;
+
+  while (true) {
+    const lease = await tryAcquireWebLock(lockName, options);
+    if (lease) return lease;
+
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) return null;
+    await sleep(Math.min(retryDelayMs, remainingMs));
+  }
+}
+
 function normalizeAcquireOptions(
   optionsOrLockManager: WebLockAcquireOptions | LockManagerLike | null | undefined,
 ): { lockManager: LockManagerLike | null; onLost?: (reason: unknown) => void } {
@@ -234,4 +266,15 @@ function isAbortError(error: unknown): boolean {
     error instanceof DOMException &&
     (error.name === "AbortError" || error.name === "InvalidStateError")
   );
+}
+
+function normalizePositiveMilliseconds(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return fallback;
+  }
+  return Math.max(1, Math.floor(value));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/packages/jazz-tools/src/runtime/leader-lock.ts
+++ b/packages/jazz-tools/src/runtime/leader-lock.ts
@@ -1,3 +1,5 @@
+import { normalizePositiveTimeout } from "./browser-broker-protocol.js";
+
 export interface LeaderLockLease {
   release(): void;
 }
@@ -154,11 +156,8 @@ export async function acquireWebLockWithRetry(
   lockName: string,
   options: WebLockRetryOptions = {},
 ): Promise<LeaderLockLease | null> {
-  const timeoutMs = normalizePositiveMilliseconds(
-    options.timeoutMs,
-    DEFAULT_WEB_LOCK_RETRY_TIMEOUT_MS,
-  );
-  const retryDelayMs = normalizePositiveMilliseconds(
+  const timeoutMs = normalizePositiveTimeout(options.timeoutMs, DEFAULT_WEB_LOCK_RETRY_TIMEOUT_MS);
+  const retryDelayMs = normalizePositiveTimeout(
     options.retryDelayMs,
     DEFAULT_WEB_LOCK_RETRY_DELAY_MS,
   );
@@ -266,13 +265,6 @@ function isAbortError(error: unknown): boolean {
     error instanceof DOMException &&
     (error.name === "AbortError" || error.name === "InvalidStateError")
   );
-}
-
-function normalizePositiveMilliseconds(value: unknown, fallback: number): number {
-  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
-    return fallback;
-  }
-  return Math.max(1, Math.floor(value));
 }
 
 function sleep(ms: number): Promise<void> {

--- a/packages/jazz-tools/src/worker/jazz-broker-worker.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker.ts
@@ -18,6 +18,8 @@ import {
 } from "../runtime/leader-lock.js";
 
 const DEFAULT_FORCE_TAKEOVER_TIMEOUT_MS = 1_000;
+const COMPLETED_STORAGE_RESET_OUTCOME_TTL_MS = 30_000;
+const MAX_COMPLETED_STORAGE_RESET_OUTCOMES = 100;
 
 type SharedWorkerGlobal = typeof globalThis & {
   onconnect: ((event: MessageEvent & { ports: MessagePort[] }) => void) | null;
@@ -60,6 +62,13 @@ type ResetState = {
   phase: "preparing" | "promoting" | "reconnecting";
 };
 
+type StorageResetOutcome = {
+  requestId: string;
+  success: boolean;
+  errorMessage?: string;
+  finishedAt: number;
+};
+
 const workerGlobal = globalThis as SharedWorkerGlobal;
 const brokerInstanceId = createRandomId("broker");
 const tabs = new Map<string, TabState>();
@@ -80,6 +89,7 @@ let replacementElectionInFlight = false;
 let replacementElectionGeneration = 0;
 let brokerPingTimer: ReturnType<typeof setTimeout> | null = null;
 let resetState: ResetState | null = null;
+const completedStorageResetOutcomes = new Map<string, StorageResetOutcome>();
 
 workerGlobal.onconnect = (event) => {
   const port = event.ports[0];
@@ -158,6 +168,7 @@ function handleHello(port: MessagePort, message: BrowserBrokerTabMessage): strin
   }
   if (leader?.ready) {
     post(port, { type: "broker-hello", brokerInstanceId });
+    redeliverFinishedStorageResets(port);
     post(port, {
       type: "leader-ready",
       brokerInstanceId,
@@ -168,6 +179,7 @@ function handleHello(port: MessagePort, message: BrowserBrokerTabMessage): strin
   } else {
     electIfNeeded();
     post(port, { type: "broker-hello", brokerInstanceId });
+    redeliverFinishedStorageResets(port);
   }
 
   return message.tabId;
@@ -695,20 +707,67 @@ function finishStorageReset(
     resetState = null;
   }
 
+  const outcomes = rememberStorageResetOutcomes(completedReset.requestIds, success, errorMessage);
   for (const tab of tabs.values()) {
-    for (const requestId of completedReset.requestIds) {
-      post(tab.port, {
-        type: "storage-reset-finished",
-        brokerInstanceId,
-        requestId,
-        success,
-        ...(errorMessage ? { errorMessage } : {}),
-      });
+    for (const outcome of outcomes) {
+      postStorageResetOutcome(tab.port, outcome);
     }
   }
 
   if (!success) {
     electIfNeeded();
+  }
+}
+
+function rememberStorageResetOutcomes(
+  requestIds: Iterable<string>,
+  success: boolean,
+  errorMessage?: string,
+): StorageResetOutcome[] {
+  const now = Date.now();
+  const outcomes: StorageResetOutcome[] = [];
+  for (const requestId of requestIds) {
+    const outcome: StorageResetOutcome = {
+      requestId,
+      success,
+      ...(errorMessage ? { errorMessage } : {}),
+      finishedAt: now,
+    };
+    completedStorageResetOutcomes.set(requestId, outcome);
+    outcomes.push(outcome);
+  }
+  pruneCompletedStorageResetOutcomes(now);
+  return outcomes;
+}
+
+function redeliverFinishedStorageResets(port: MessagePort): void {
+  pruneCompletedStorageResetOutcomes();
+  for (const outcome of completedStorageResetOutcomes.values()) {
+    postStorageResetOutcome(port, outcome);
+  }
+}
+
+function postStorageResetOutcome(port: MessagePort, outcome: StorageResetOutcome): void {
+  post(port, {
+    type: "storage-reset-finished",
+    brokerInstanceId,
+    requestId: outcome.requestId,
+    success: outcome.success,
+    ...(outcome.errorMessage ? { errorMessage: outcome.errorMessage } : {}),
+  });
+}
+
+function pruneCompletedStorageResetOutcomes(now = Date.now()): void {
+  for (const [requestId, outcome] of completedStorageResetOutcomes) {
+    if (now - outcome.finishedAt > COMPLETED_STORAGE_RESET_OUTCOME_TTL_MS) {
+      completedStorageResetOutcomes.delete(requestId);
+    }
+  }
+
+  while (completedStorageResetOutcomes.size > MAX_COMPLETED_STORAGE_RESET_OUTCOMES) {
+    const oldestRequestId = completedStorageResetOutcomes.keys().next().value;
+    if (!oldestRequestId) return;
+    completedStorageResetOutcomes.delete(oldestRequestId);
   }
 }
 

--- a/packages/jazz-tools/src/worker/jazz-broker-worker.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker.ts
@@ -161,14 +161,15 @@ function handleHello(port: MessagePort, message: BrowserBrokerTabMessage): strin
   });
 
   startBrokerPingTimer();
+  post(port, { type: "broker-hello", brokerInstanceId });
+  // Redeliver on every hello, including mid-reset rejoins: a requester that
+  // reconnects after its reset finished must not wait out the client timeout.
+  redeliverFinishedStorageResets(port);
   if (resetState) {
-    post(port, { type: "broker-hello", brokerInstanceId });
     addTabToActiveReset(message.tabId);
     return message.tabId;
   }
   if (leader?.ready) {
-    post(port, { type: "broker-hello", brokerInstanceId });
-    redeliverFinishedStorageResets(port);
     post(port, {
       type: "leader-ready",
       brokerInstanceId,
@@ -178,8 +179,6 @@ function handleHello(port: MessagePort, message: BrowserBrokerTabMessage): strin
     assignFollowerPorts(leader);
   } else {
     electIfNeeded();
-    post(port, { type: "broker-hello", brokerInstanceId });
-    redeliverFinishedStorageResets(port);
   }
 
   return message.tabId;
@@ -733,6 +732,9 @@ function rememberStorageResetOutcomes(
       ...(errorMessage ? { errorMessage } : {}),
       finishedAt: now,
     };
+    // Delete first: re-setting an existing key keeps its Map position, which
+    // would make the size eviction below treat a re-finished id as oldest.
+    completedStorageResetOutcomes.delete(requestId);
     completedStorageResetOutcomes.set(requestId, outcome);
     outcomes.push(outcome);
   }

--- a/packages/jazz-tools/tests/browser/leader-lock.test.ts
+++ b/packages/jazz-tools/tests/browser/leader-lock.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  acquireWebLockWithRetry,
   createNavigatorLocksLeaderLockStrategy,
   monitorWebLockRelease,
   stealAndReleaseWebLock,
@@ -55,6 +56,23 @@ describe("leader-lock browser integration", () => {
     leaseA!.release();
 
     const leaseAfterRelease = await waitForLease(() => tryAcquireWebLock(lockName), 1000);
+    expect(leaseAfterRelease).not.toBeNull();
+    leaseAfterRelease!.release();
+  });
+
+  it("retries acquisition until a released lock is observable", async () => {
+    const lockName = uniqueLockName("leader-lock-retry");
+    const leaseA = await tryAcquireWebLock(lockName);
+    expect(leaseA).not.toBeNull();
+
+    const retry = acquireWebLockWithRetry(lockName, {
+      timeoutMs: 1_000,
+      retryDelayMs: 20,
+    });
+
+    setTimeout(() => leaseA!.release(), 50);
+
+    const leaseAfterRelease = await retry;
     expect(leaseAfterRelease).not.toBeNull();
     leaseAfterRelease!.release();
   });

--- a/packages/jazz-tools/tests/browser/shared-worker-broker.test.ts
+++ b/packages/jazz-tools/tests/browser/shared-worker-broker.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { BrowserBrokerClient } from "../../src/runtime/browser-broker-client.js";
-import { tryAcquireWebLock, type LeaderLockLease } from "../../src/runtime/leader-lock.js";
+import {
+  acquireWebLockWithRetry,
+  tryAcquireWebLock,
+  type LeaderLockLease,
+} from "../../src/runtime/leader-lock.js";
 
 function uniqueName(prefix: string): string {
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -78,10 +82,10 @@ describe("SharedWorker browser broker", () => {
     const tabLockName = `jazz-leader-tab:broker-test-app:${dbName}`;
     const workerLockName = `jazz-leader-worker:broker-test-app:${dbName}`;
     const compatibilityLockName = `jazz-leader-lock:broker-test-app:${dbName}`;
-    const tabLease = await tryAcquireWebLock(tabLockName);
-    const workerLease = await tryAcquireWebLock(workerLockName);
+    const tabLease = await acquireWebLockWithRetry(tabLockName);
+    const workerLease = await acquireWebLockWithRetry(workerLockName);
     const compatibilityLease = options.compatibility
-      ? await tryAcquireWebLock(compatibilityLockName)
+      ? await acquireWebLockWithRetry(compatibilityLockName)
       : null;
     if (!tabLease || !workerLease || !compatibilityLease) {
       if (!options.compatibility && tabLease && workerLease) {
@@ -740,6 +744,84 @@ describe("SharedWorker browser broker", () => {
     expect(resetBegun).toContain(`tab-a:${firstRequestId}`);
     expect(resetBegun).toContain(`tab-b:${firstRequestId}`);
     expect(resetPromotions.some((entry) => entry.endsWith(`:${firstRequestId}`))).toBe(true);
+  });
+
+  it("redelivers storage reset completion after the requester reconnects", async () => {
+    const dbName = uniqueName("broker-storage-reset-redeliver");
+    const requestId = `reset-${dbName}`;
+    const resetBegun: string[] = [];
+    const reconnects: string[] = [];
+    const clientByTabId = new Map<string, BrowserBrokerClient>();
+    let releaseLeaderPreparation!: () => void;
+    const leaderPreparation = new Promise<void>((resolve) => {
+      releaseLeaderPreparation = resolve;
+    });
+
+    function createResetRedeliveryOptions(
+      tabId: string,
+    ): Parameters<typeof BrowserBrokerClient.connect>[0] {
+      return {
+        ...createOptions(dbName, tabId),
+        forceTakeoverTimeoutMs: 50,
+        brokerPingIntervalMs: 50,
+        brokerPongTimeoutMs: 100,
+        storageResetTimeoutMs: 2_500,
+        onStorageResetBegin: async (requestId) => {
+          resetBegun.push(`${tabId}:${requestId}`);
+          releaseHeldLock(`jazz-leader-tab:broker-test-app:${dbName}`);
+          releaseHeldLock(`jazz-leader-worker:broker-test-app:${dbName}`);
+          releaseHeldLock(`jazz-leader-lock:broker-test-app:${dbName}`);
+          if (tabId === "tab-a") {
+            await leaderPreparation;
+          }
+        },
+        onBecomeLeader: async (client, leadershipId) => {
+          const locks = await acquireLeaderLocks(dbName, { compatibility: false });
+          client.reportLeaderReady({
+            leadershipId,
+            ...locks,
+          });
+        },
+        onAttachFollowerPort: (followerTabId, leadershipId, port) => {
+          port.close();
+          clientByTabId.get(tabId)?.reportFollowerPortAttached(followerTabId, leadershipId);
+        },
+        onUseFollowerPort: (_leaderTabId, _leadershipId, port) => {
+          port.close();
+        },
+        onReconnected: (client) => {
+          reconnects.push(tabId);
+          client.reportSchemaReady("schema-a");
+        },
+      };
+    }
+
+    const first = await BrowserBrokerClient.connect(createResetRedeliveryOptions("tab-a"));
+    clientByTabId.set("tab-a", first);
+    clients.push(first);
+    const second = await BrowserBrokerClient.connect(createResetRedeliveryOptions("tab-b"));
+    clientByTabId.set("tab-b", second);
+    clients.push(second);
+
+    await first.waitForRole("leader", 2000);
+    first.reportSchemaReady("schema-a");
+    second.reportSchemaReady("schema-a");
+    await second.waitForRole("follower", 2000);
+
+    const reset = second.requestStorageReset(requestId);
+    reset.catch(() => undefined);
+
+    await waitFor(
+      () => resetBegun.includes(`tab-a:${requestId}`) && resetBegun.includes(`tab-b:${requestId}`),
+      2000,
+      "broker should ask both tabs to prepare storage reset",
+    );
+
+    (second as unknown as { port?: MessagePort | null }).port?.close();
+    releaseLeaderPreparation();
+
+    await withTimeout(reset, 3000, "reset requester should receive redelivered completion");
+    expect(reconnects).toContain("tab-b");
   });
 
   it("reattaches a same-tab follower after shutdown and reconnect", async () => {

--- a/packages/jazz-tools/tests/browser/testing-server-node.ts
+++ b/packages/jazz-tools/tests/browser/testing-server-node.ts
@@ -1,4 +1,4 @@
-import type { BrowserContext, Route } from "playwright";
+import type { BrowserContext, Route, WebSocketRoute } from "playwright";
 type JazzNapiTestingServer = import("jazz-napi").TestingServer;
 
 interface StartedTestingServer {
@@ -10,7 +10,15 @@ interface StartedTestingServer {
 
 const DEFAULT_TESTING_SERVER_KEY = "__default__";
 const testingServerPromises = new Map<string, Promise<StartedTestingServer>>();
-const blockedServerRoutes = new WeakMap<BrowserContext, Map<string, (route: Route) => void>>();
+interface TestingServerRouteBlock {
+  blocked: boolean;
+  httpHandler: (route: Route) => void;
+  webSocketHandler: (route: WebSocketRoute) => void | Promise<void>;
+  webSocketPattern: string;
+  webSocketRouted: boolean;
+}
+
+const blockedServerRoutes = new WeakMap<BrowserContext, Map<string, TestingServerRouteBlock>>();
 const browserContextIds = new WeakMap<BrowserContext, number>();
 let nextBrowserContextId = 1;
 
@@ -99,6 +107,12 @@ function testingServerUrlPattern(serverUrl: string): string {
   return `${serverUrl.replace(/\/+$/, "")}/**`;
 }
 
+function testingServerWebSocketUrlPattern(serverUrl: string): string {
+  const url = new URL(serverUrl);
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  return `${url.toString().replace(/\/+$/, "")}/**`;
+}
+
 function getBrowserContextId(context: BrowserContext): number {
   let id = browserContextIds.get(context);
   if (!id) {
@@ -124,8 +138,12 @@ export async function debugTestingServerNetwork(
   return {
     contextId: getBrowserContextId(context),
     pattern,
-    blocked: contextRoutes?.has(pattern) ?? false,
-    activePatterns: contextRoutes ? [...contextRoutes.keys()] : [],
+    blocked: contextRoutes?.get(pattern)?.blocked ?? false,
+    activePatterns: contextRoutes
+      ? [...contextRoutes.entries()]
+          .filter(([, routeBlock]) => routeBlock.blocked)
+          .map(([activePattern]) => activePattern)
+      : [],
   };
 }
 
@@ -140,26 +158,54 @@ export async function blockTestingServerNetwork(
     contextRoutes = new Map();
     blockedServerRoutes.set(context, contextRoutes);
   }
-  if (contextRoutes.has(pattern)) {
+  let routeBlock = contextRoutes.get(pattern);
+  if (routeBlock?.blocked) {
     console.info("[testing-server-network]", {
       action: "block-skip",
       contextId,
       pattern,
-      activePatterns: [...contextRoutes.keys()],
+      activePatterns: [...contextRoutes.entries()]
+        .filter(([, activeRouteBlock]) => activeRouteBlock.blocked)
+        .map(([activePattern]) => activePattern),
     });
     return;
   }
 
-  const handler = (route: Route) => {
-    void route.abort("internetdisconnected");
-  };
-  contextRoutes.set(pattern, handler);
-  await context.route(pattern, handler);
+  if (!routeBlock) {
+    const webSocketPattern = testingServerWebSocketUrlPattern(serverUrl);
+    routeBlock = {
+      blocked: false,
+      httpHandler: (route) => {
+        void route.abort("internetdisconnected");
+      },
+      webSocketHandler: async (webSocketRoute) => {
+        const currentRouteBlock = contextRoutes?.get(pattern);
+        if (!currentRouteBlock?.blocked) {
+          webSocketRoute.connectToServer();
+          return;
+        }
+        await webSocketRoute.close().catch(() => undefined);
+      },
+      webSocketPattern,
+      webSocketRouted: false,
+    };
+    contextRoutes.set(pattern, routeBlock);
+  }
+
+  routeBlock.blocked = true;
+  if (!routeBlock.webSocketRouted) {
+    await context.routeWebSocket(routeBlock.webSocketPattern, routeBlock.webSocketHandler);
+    routeBlock.webSocketRouted = true;
+  }
+  await context.route(pattern, routeBlock.httpHandler);
   console.info("[testing-server-network]", {
     action: "block",
     contextId,
     pattern,
-    activePatterns: [...contextRoutes.keys()],
+    webSocketPattern: routeBlock.webSocketPattern,
+    activePatterns: [...contextRoutes.entries()]
+      .filter(([, activeRouteBlock]) => activeRouteBlock.blocked)
+      .map(([activePattern]) => activePattern),
   });
 }
 
@@ -170,23 +216,32 @@ export async function unblockTestingServerNetwork(
   const pattern = testingServerUrlPattern(serverUrl);
   const contextId = getBrowserContextId(context);
   const contextRoutes = blockedServerRoutes.get(context);
-  const handler = contextRoutes?.get(pattern);
-  if (!handler) {
+  const routeBlock = contextRoutes?.get(pattern);
+  if (!routeBlock?.blocked) {
     console.info("[testing-server-network]", {
       action: "unblock-skip",
       contextId,
       pattern,
-      activePatterns: contextRoutes ? [...contextRoutes.keys()] : [],
+      activePatterns: contextRoutes
+        ? [...contextRoutes.entries()]
+            .filter(([, activeRouteBlock]) => activeRouteBlock.blocked)
+            .map(([activePattern]) => activePattern)
+        : [],
     });
     return;
   }
 
-  await context.unroute(pattern, handler);
-  contextRoutes?.delete(pattern);
+  await context.unroute(pattern, routeBlock.httpHandler);
+  routeBlock.blocked = false;
   console.info("[testing-server-network]", {
     action: "unblock",
     contextId,
     pattern,
-    activePatterns: contextRoutes ? [...contextRoutes.keys()] : [],
+    webSocketPattern: routeBlock.webSocketPattern,
+    activePatterns: contextRoutes
+      ? [...contextRoutes.entries()]
+          .filter(([, activeRouteBlock]) => activeRouteBlock.blocked)
+          .map(([activePattern]) => activePattern)
+      : [],
   });
 }

--- a/packages/jazz-tools/tests/browser/testing-server-node.ts
+++ b/packages/jazz-tools/tests/browser/testing-server-node.ts
@@ -122,6 +122,15 @@ function getBrowserContextId(context: BrowserContext): number {
   return id;
 }
 
+function activeBlockedPatterns(
+  contextRoutes: Map<string, TestingServerRouteBlock> | undefined,
+): string[] {
+  if (!contextRoutes) return [];
+  return [...contextRoutes.entries()]
+    .filter(([, routeBlock]) => routeBlock.blocked)
+    .map(([pattern]) => pattern);
+}
+
 export interface TestingServerNetworkDebugState {
   contextId: number;
   pattern: string;
@@ -139,11 +148,7 @@ export async function debugTestingServerNetwork(
     contextId: getBrowserContextId(context),
     pattern,
     blocked: contextRoutes?.get(pattern)?.blocked ?? false,
-    activePatterns: contextRoutes
-      ? [...contextRoutes.entries()]
-          .filter(([, routeBlock]) => routeBlock.blocked)
-          .map(([activePattern]) => activePattern)
-      : [],
+    activePatterns: activeBlockedPatterns(contextRoutes),
   };
 }
 
@@ -164,9 +169,7 @@ export async function blockTestingServerNetwork(
       action: "block-skip",
       contextId,
       pattern,
-      activePatterns: [...contextRoutes.entries()]
-        .filter(([, activeRouteBlock]) => activeRouteBlock.blocked)
-        .map(([activePattern]) => activePattern),
+      activePatterns: activeBlockedPatterns(contextRoutes),
     });
     return;
   }
@@ -203,9 +206,7 @@ export async function blockTestingServerNetwork(
     contextId,
     pattern,
     webSocketPattern: routeBlock.webSocketPattern,
-    activePatterns: [...contextRoutes.entries()]
-      .filter(([, activeRouteBlock]) => activeRouteBlock.blocked)
-      .map(([activePattern]) => activePattern),
+    activePatterns: activeBlockedPatterns(contextRoutes),
   });
 }
 
@@ -222,11 +223,7 @@ export async function unblockTestingServerNetwork(
       action: "unblock-skip",
       contextId,
       pattern,
-      activePatterns: contextRoutes
-        ? [...contextRoutes.entries()]
-            .filter(([, activeRouteBlock]) => activeRouteBlock.blocked)
-            .map(([activePattern]) => activePattern)
-        : [],
+      activePatterns: activeBlockedPatterns(contextRoutes),
     });
     return;
   }
@@ -238,10 +235,6 @@ export async function unblockTestingServerNetwork(
     contextId,
     pattern,
     webSocketPattern: routeBlock.webSocketPattern,
-    activePatterns: contextRoutes
-      ? [...contextRoutes.entries()]
-          .filter(([, activeRouteBlock]) => activeRouteBlock.blocked)
-          .map(([activePattern]) => activePattern)
-      : [],
+    activePatterns: activeBlockedPatterns(contextRoutes),
   });
 }


### PR DESCRIPTION
## Summary

Stacked on #998.

- make the browser testing-server network block cover WebSocket sync connections, not only HTTP requests
- add bounded Web Lock acquisition retry and use it during broker-backed leader promotion
- remember recent broker storage reset completions and redeliver them to reconnecting tabs
- add focused browser coverage for lock retry and reset completion redelivery

## Root Cause

The auth fan-out test depended on `blockTestingServerNetwork`, but that helper only installed `context.route()` HTTP interception. The Jazz sync transport uses WebSockets, so invalid-JWT handshakes reached the testing server during setup.

The rotating broker failures came from two lifecycle races: one-shot Web Lock acquisition could observe a just-released lock as unavailable, and storage reset completion could be posted while a requester was evicted or reconnecting, leaving its promise unresolved.

## Validation

- `pnpm --filter jazz-tools exec vitest run --config vitest.config.browser.ts tests/browser/leader-lock.test.ts tests/browser/shared-worker-broker.test.ts --reporter verbose`
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.browser.ts tests/browser/worker-bridge.test.ts --reporter verbose`
- `pnpm --filter jazz-tools build:runtime`
- `pnpm --filter jazz-tools build:test`
- `git diff --check`