### PR TITLE
test: update rollback error expectations

### DIFF
--- a/packages/jazz-tools/src/runtime/db.transaction.test.ts
+++ b/packages/jazz-tools/src/runtime/db.transaction.test.ts
@@ -97,9 +97,9 @@ describe("Db transactions", () => {
 
     tx.rollback();
 
-    const coreError = `transaction ${batchId} has already been rolled back`;
-    expect(() => tx.commit()).toThrow(`Write error: ${coreError}`);
-    expect(() => tx.rollback()).toThrow(`Write error: ${coreError}`);
+    const coreError = `batch ${batchId} has already been completed or was never opened`;
+    expect(() => tx.commit()).toThrow(`Commit batch failed: Write error: ${coreError}`);
+    expect(() => tx.rollback()).toThrow(`Rollback batch failed: Write error: ${coreError}`);
     expect(() => tx.insert(app.todos, { title: "Nope", done: false })).toThrow(
       `Insert failed: WriteError("${coreError}")`,
     );
@@ -152,9 +152,9 @@ describe("Db batches", () => {
 
     batch.rollback();
 
-    const coreError = `batch ${batchId} has already been rolled back`;
-    expect(() => batch.commit()).toThrow(`Write error: ${coreError}`);
-    expect(() => batch.rollback()).toThrow(`Write error: ${coreError}`);
+    const coreError = `batch ${batchId} has already been completed or was never opened`;
+    expect(() => batch.commit()).toThrow(`Commit batch failed: Write error: ${coreError}`);
+    expect(() => batch.rollback()).toThrow(`Rollback batch failed: Write error: ${coreError}`);
     expect(() => batch.insert(app.todos, { title: "Nope", done: false })).toThrow(
       `Insert failed: WriteError("${coreError}")`,
     );


### PR DESCRIPTION
## Summary
- Update rollback error assertions in db transaction tests to match current batch lifecycle errors.
- Keep implementation unchanged.

## Verification
- pnpm --dir packages/jazz-tools exec vitest run --config vitest.config.ts src/runtime/db.transaction.test.ts
- pnpm --filter jazz-tools test