### PR TITLE
Make db.one limit queries to one row

### DIFF
--- a/.changeset/db-one-limit-one.md
+++ b/.changeset/db-one-limit-one.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Make `db.one(...)` execute with a root query limit of one instead of fetching every matching row and discarding all but the first.

--- a/packages/jazz-tools/src/runtime/db.one.test.ts
+++ b/packages/jazz-tools/src/runtime/db.one.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import { schema as s } from "../index.js";
+import { createDbFromClient } from "./db.js";
+import type { JazzClient, Row } from "./client.js";
+
+const todoSchema = {
+  todos: s.table({
+    title: s.string(),
+    done: s.boolean(),
+  }),
+};
+type TodoSchema = s.Schema<typeof todoSchema>;
+const app: s.App<TodoSchema> = s.defineApp(todoSchema);
+
+const todoRow: Row = {
+  id: "todo-1",
+  values: [
+    { type: "Text", value: "Buy milk" },
+    { type: "Boolean", value: false },
+  ],
+};
+
+type QuerySpy = ReturnType<typeof vi.fn<(queryJson: string, options?: unknown) => Promise<Row[]>>>;
+
+function makeClient() {
+  const query = vi.fn(async (_queryJson: string, _options?: unknown) => [todoRow]);
+  const beginBatch = vi.fn(() => "batch-1");
+  const client = {
+    getSchema: () => new Map(Object.entries(app.wasmSchema)),
+    query,
+    beginBatch,
+  } as unknown as JazzClient;
+
+  return { client, query, beginBatch };
+}
+
+function firstQueryJson(query: QuerySpy): string {
+  const firstCall = query.mock.calls[0];
+  expect(firstCall).toBeDefined();
+  return firstCall![0] as string;
+}
+
+function rootLimit(queryJson: string): number | undefined {
+  const parsed = JSON.parse(queryJson) as {
+    relation_ir?: { Limit?: { limit?: unknown } };
+  };
+  const limit = parsed.relation_ir?.Limit?.limit;
+  return typeof limit === "number" ? limit : undefined;
+}
+
+describe("Db.one", () => {
+  it("adds limit 1 before executing an unbounded query", async () => {
+    const { client, query } = makeClient();
+    const db = createDbFromClient({ appId: "db-one-limit-test" }, client);
+
+    await db.one(app.todos.where({ done: false }));
+
+    expect(rootLimit(firstQueryJson(query))).toBe(1);
+  });
+
+  it("narrows explicit limits above one", async () => {
+    const { client, query } = makeClient();
+    const db = createDbFromClient({ appId: "db-one-limit-test" }, client);
+
+    await db.one(app.todos.limit(10));
+
+    expect(rootLimit(firstQueryJson(query))).toBe(1);
+  });
+
+  it("overrides explicit limit 0", async () => {
+    const { client, query } = makeClient();
+    const db = createDbFromClient({ appId: "db-one-limit-test" }, client);
+
+    await db.one(app.todos.limit(0));
+
+    expect(rootLimit(firstQueryJson(query))).toBe(1);
+  });
+
+  it("adds limit 1 before executing an explicit batch query", async () => {
+    const { client, query, beginBatch } = makeClient();
+    const db = createDbFromClient({ appId: "db-one-limit-test" }, client);
+    const batch = db.beginBatch();
+
+    await batch.one(app.todos.where({ done: false }));
+
+    expect(beginBatch).toHaveBeenCalledWith("direct");
+    expect(rootLimit(firstQueryJson(query))).toBe(1);
+    expect(query.mock.calls[0]?.[1]).toMatchObject({
+      transactionBatchId: "batch-1",
+    });
+  });
+});

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -218,6 +218,28 @@ function ordinaryDbQueryOptions(options?: QueryOptions): QueryOptions {
   return { localUpdates: "deferred", ...options };
 }
 
+function limitQueryToOne<T>(query: QueryBuilder<T>): QueryBuilder<T> {
+  return {
+    get _table() {
+      return query._table;
+    },
+    get _schema() {
+      return query._schema;
+    },
+    get _columnTransforms() {
+      return query._columnTransforms;
+    },
+    get _rowType() {
+      return query._rowType;
+    },
+    _build() {
+      const builtQuery = JSON.parse(query._build()) as Record<string, unknown>;
+      builtQuery.limit = 1;
+      return JSON.stringify(builtQuery);
+    },
+  };
+}
+
 function queryUsesRelationTraversal(builtQuery: NormalizedBuiltQuery): boolean {
   return builtQuery.hops.length > 0 || builtQuery.gather !== undefined;
 }
@@ -727,12 +749,12 @@ abstract class DbBatchHandleBase {
   }
 
   /**
-   * Execute a query and return the first matching row, or null.
+   * Execute a query with a limit of one and return the first matching row, or null.
    *
    * Read data is scoped to this batch.
    */
   async one<T>(query: QueryBuilder<T>, options?: QueryOptions): Promise<T | null> {
-    const results = await this.all(query, options);
+    const results = await this.all(limitQueryToOne(query), options);
     return results[0] ?? null;
   }
 }
@@ -1994,14 +2016,14 @@ export class Db {
   }
 
   /**
-   * Execute a query and return the first matching row, or null.
+   * Execute a query with a limit of one and return the first matching row, or null.
    *
    * @param query QueryBuilder instance
    * @param options Optional read durability options
    * @returns First matching typed object, or null if none found
    */
   async one<T>(query: QueryBuilder<T>, options?: QueryOptions): Promise<T | null> {
-    const results = await this.all(query, options);
+    const results = await this.all(limitQueryToOne(query), options);
     return results[0] ?? null;
   }
 

--- a/specs/status-quo/query_manager.md
+++ b/specs/status-quo/query_manager.md
@@ -79,7 +79,7 @@ Both APIs use the same graph engine.
 
 ### One-shot query
 
-`db.all(...)` and `db.one(...)` compile a query, settle it, return the first full snapshot, and tear the subscription back down.
+`db.all(...)` compiles the query as supplied, settles it, returns the first full snapshot, and tears the subscription back down. `db.one(...)` follows the same path after setting the root query limit to one, then returns the first row from that snapshot or `null`.
 
 ### Live subscription
 

--- a/specs/status-quo/ts_client.md
+++ b/specs/status-quo/ts_client.md
@@ -99,6 +99,8 @@ The current `Db` API centers around a small set of predictable operations:
 - `beginBatch()`
 - `beginTransaction()`
 
+`one(...)` sets the root query limit to one before sending the query to the runtime, regardless of any limit already present on the query builder.
+
 Simple write calls are one-member direct batches under the hood. They seal immediately and return
 handles that callers can wait on for a specific durability tier.
 


### PR DESCRIPTION
## Summary

- Make `db.one(...)` and explicit batch/transaction `one(...)` set the root query limit to `1` before runtime execution.
- Add regression coverage for unbounded queries, existing limits, `limit(0)`, and explicit batch reads.
- Update status-quo specs to document the `one(...)` query limit behavior.

## Why

`db.one(...)` should execute a one-row query instead of fetching every matching row and discarding all but the first result after the runtime returns.

## Validation

- `pnpm exec vitest run --config vitest.config.ts src/runtime/db.one.test.ts tests/ts-dsl/query-api.test.ts`
- `pnpm exec tsc --project tsconfig.tests.json`
- `pnpm exec oxfmt --check --ignore-path .oxfmtignore packages/jazz-tools/src/runtime/db.ts packages/jazz-tools/src/runtime/db.one.test.ts specs/status-quo/query_manager.md specs/status-quo/ts_client.md`
