### PR TITLE
chat-react: scoped updates, sender deletes, idempotent reactions

### DIFF
--- a/examples/chat-react/README.md
+++ b/examples/chat-react/README.md
@@ -6,8 +6,12 @@ Real-time, permission-aware chat app. Public rooms, private chats with invite li
 
 ```bash
 pnpm install
-pnpm dev        # starts the Jazz server, pushes the schema, and opens Vite
+pnpm dev        # starts Vite — the app runs local-first by default
 ```
+
+The app is local-first: without configuration it persists everything in the browser. To
+sync across devices, point it at a Jazz server with `VITE_JAZZ_SERVER_URL` (and
+`VITE_JAZZ_APP_ID`). `pnpm dev` does not start a server or push the schema.
 
 To understand how the app uses Jazz, run the walkthrough:
 
@@ -50,3 +54,5 @@ Defined in `schema.ts` using the Jazz typed schema DSL. Running `pnpm build` val
 - **canvases** — chat (ref), createdAt
 - **strokes** — canvas (ref), ownerId, color, width, pointsJson, createdAt
 - **attachments** — message (ref), type, name, file (ref), size
+- **files** — name (nullable), mimeType, partIds (refs), partSizes
+- **file_parts** — data (bytes)

--- a/examples/chat-react/permissions.ts
+++ b/examples/chat-react/permissions.ts
@@ -42,11 +42,20 @@ export default definePermissions(app, ({ policy, session, allOf, anyOf, allowedT
   policy.messages.allowInsert.where((message) =>
     policy.chatMembers.exists.where({ chatId: message.chatId, userId: session.user_id }),
   );
-  policy.messages.allowDelete.where({ senderId: session.user_id });
+  // `senderId` references a profile row, so the message is the sender's iff a
+  // profile with that id belongs to the session user. (Comparing `senderId`
+  // directly to `session.user_id` never matched — a profile id is not a user id.)
+  policy.messages.allowDelete.where((message) =>
+    policy.profiles.exists.where({ id: message.senderId, userId: session.user_id }),
+  );
 
   policy.reactions.allowRead.where(allowedTo.read("messageId"));
   policy.reactions.allowInsert.where({ userId: session.user_id });
-  policy.reactions.allowDelete.where({ userId: session.user_id });
+  // The reactor may always remove their own reaction; the message's sender may
+  // also clear reactions when deleting the message they hang off.
+  policy.reactions.allowDelete.where(
+    anyOf([{ userId: session.user_id }, allowedTo.delete("messageId")]),
+  );
 
   policy.canvases.allowRead.where((canvas) =>
     anyOf([
@@ -64,6 +73,9 @@ export default definePermissions(app, ({ policy, session, allOf, anyOf, allowedT
 
   policy.attachments.allowRead.where(allowedTo.read("messageId"));
   policy.attachments.allowInsert.where(allowedTo.read("messageId"));
+  // An attachment is deletable by whoever may delete its message; files and
+  // file_parts then cascade via the deleteReferencing policies below.
+  policy.attachments.allowDelete.where(allowedTo.delete("messageId"));
 
   policy.files.allowInsert.where({});
   policy.file_parts.allowInsert.where({});

--- a/examples/chat-react/src/components/ErrorBoundary.tsx
+++ b/examples/chat-react/src/components/ErrorBoundary.tsx
@@ -1,18 +1,32 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
 
+type ErrorKind = "unauthorised" | "deleted" | "unavailable" | "unknown";
+
+function classifyError(error: Error): ErrorKind {
+  const message = error.message?.toLowerCase() ?? "";
+
+  if (
+    message.includes("unauthorized") ||
+    message.includes("unauthorised") ||
+    message.includes("permission") ||
+    message.includes("not allowed") ||
+    // The runtime surfaces policy failures as "policy denied <op> on table …".
+    message.includes("denied")
+  ) {
+    return "unauthorised";
+  }
+  if (message.includes("deleted")) return "deleted";
+  if (message.includes("unavailable") || message.includes("not found")) return "unavailable";
+  return "unknown";
+}
+
 function ErrorUI({ error }: { error: Error }) {
   console.error(error.stack);
 
-  const message = error.message?.toLowerCase() ?? "";
-  const isUnauthorised =
-    message.includes("unauthorized") ||
-    message.includes("permission") ||
-    message.includes("access");
-  const isDeleted = message.includes("deleted");
-  const isUnavailable = message.includes("unavailable") || message.includes("not found");
+  const kind = classifyError(error);
 
-  if (isUnauthorised) {
+  if (kind === "unauthorised") {
     return (
       <div className="flex flex-1 items-center justify-center p-8">
         <div className="max-w-2xl space-y-4">
@@ -31,7 +45,7 @@ function ErrorUI({ error }: { error: Error }) {
     );
   }
 
-  if (isDeleted) {
+  if (kind === "deleted") {
     return (
       <div className="flex min-h-screen items-center justify-center p-8">
         <div className="max-w-2xl space-y-4">
@@ -50,7 +64,7 @@ function ErrorUI({ error }: { error: Error }) {
     );
   }
 
-  if (isUnavailable) {
+  if (kind === "unavailable") {
     return (
       <div className="flex flex-1 items-center justify-center p-8">
         <div className="max-w-2xl space-y-4">

--- a/examples/chat-react/src/components/chat-view/ChatView.tsx
+++ b/examples/chat-react/src/components/chat-view/ChatView.tsx
@@ -99,6 +99,8 @@ export const ChatView = ({ chatId }: ChatViewProps) => {
     }
   }, []);
 
+  useEffect(() => () => observer.current?.disconnect(), []);
+
   const messages =
     useAll(
       app.messages
@@ -110,8 +112,26 @@ export const ChatView = ({ chatId }: ChatViewProps) => {
 
   const hasMore = messages.length > showNLastMessages;
 
-  const handleDelete = (messageId: string) => {
-    db.delete(app.messages, messageId);
+  const handleDelete = async (messageId: string) => {
+    // Deletes don't cascade, so remove the message's children first: its
+    // attachments (with the file + file_parts each points at) and its reactions.
+    const [attachments, reactions] = await Promise.all([
+      db.all(app.attachments.where({ messageId })),
+      db.all(app.reactions.where({ messageId })),
+    ]);
+    const files = (
+      await Promise.all(attachments.map((att) => db.all(app.files.where({ id: att.fileId }))))
+    ).flat();
+
+    db.batch((b) => {
+      for (const file of files) {
+        for (const partId of file.partIds) b.delete(app.file_parts, partId);
+        b.delete(app.files, file.id);
+      }
+      for (const att of attachments) b.delete(app.attachments, att.id);
+      for (const reaction of reactions) b.delete(app.reactions, reaction.id);
+      b.delete(app.messages, messageId);
+    });
   };
 
   if (chatRowsResult !== undefined && !chatKnown && userId) {
@@ -135,7 +155,11 @@ export const ChatView = ({ chatId }: ChatViewProps) => {
                 message={msg}
                 sender={msg.sender ?? undefined}
                 isMe={msg.senderId === myProfile?.id || msg.sender?.userId === userId}
-                onDelete={() => handleDelete(msg.id)}
+                onDelete={() =>
+                  handleDelete(msg.id).catch((error) =>
+                    console.error("failed to delete message", error),
+                  )
+                }
               />
             ))
         ) : (

--- a/examples/chat-react/src/components/chat/ChatFile.tsx
+++ b/examples/chat-react/src/components/chat/ChatFile.tsx
@@ -1,5 +1,6 @@
 import { useDb } from "jazz-tools/react";
 import { DownloadIcon } from "lucide-react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { downloadBlob, formatBytes } from "@/lib/utils";
 import { app, type Attachment } from "../../../schema.js";
@@ -13,8 +14,12 @@ export function ChatFile({ attachment }: ChatFileProps) {
   const fileReadOptions = db.getConfig().serverUrl ? { tier: "edge" as const } : undefined;
 
   const handleDownload = async () => {
-    const blob = await db.loadFileAsBlob(app, attachment.fileId, fileReadOptions);
-    downloadBlob(blob, attachment.name);
+    try {
+      const blob = await db.loadFileAsBlob(app, attachment.fileId, fileReadOptions);
+      downloadBlob(blob, attachment.name);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Download failed");
+    }
   };
 
   return (

--- a/examples/chat-react/src/components/chat/ChatImage.tsx
+++ b/examples/chat-react/src/components/chat/ChatImage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useDb } from "jazz-tools/react";
-import { DownloadIcon } from "lucide-react";
+import { DownloadIcon, ImageOffIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { downloadUrl } from "@/lib/utils";
 import { app, type Attachment } from "../../../schema.js";
@@ -12,6 +12,7 @@ interface ChatImageProps {
 export function ChatImage({ attachment }: ChatImageProps) {
   const db = useDb();
   const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [status, setStatus] = useState<"loading" | "loaded" | "error">("loading");
   const serverUrl = db.getConfig().serverUrl;
   const fileReadOptions = useMemo(
     () => (serverUrl ? ({ tier: "edge" as const } as const) : undefined),
@@ -21,6 +22,8 @@ export function ChatImage({ attachment }: ChatImageProps) {
   useEffect(() => {
     let isActive = true;
     let objectUrl: string | null = null;
+    setStatus("loading");
+    setImageUrl(null);
 
     async function loadImage() {
       let blob: Blob;
@@ -28,7 +31,7 @@ export function ChatImage({ attachment }: ChatImageProps) {
         blob = await db.loadFileAsBlob(app, attachment.fileId, fileReadOptions);
       } catch {
         if (isActive) {
-          setImageUrl(null);
+          setStatus("error");
         }
         return;
       }
@@ -36,6 +39,7 @@ export function ChatImage({ attachment }: ChatImageProps) {
 
       objectUrl = URL.createObjectURL(blob);
       setImageUrl(objectUrl);
+      setStatus("loaded");
     }
 
     loadImage();
@@ -53,26 +57,46 @@ export function ChatImage({ attachment }: ChatImageProps) {
     downloadUrl(imageUrl, attachment.name);
   };
 
+  if (status === "error") {
+    return (
+      <div
+        role="img"
+        aria-label={attachment.name}
+        className="mt-1 flex max-w-xs items-center gap-2 rounded-md border border-dashed p-3 text-muted-foreground"
+      >
+        <ImageOffIcon className="size-4 shrink-0" />
+        <span className="text-sm wrap-anywhere">{attachment.name}</span>
+      </div>
+    );
+  }
+
   return (
     <div className="group relative mt-1 max-w-xs">
       {imageUrl ? (
         <img src={imageUrl} alt={attachment.name} className="rounded-md max-h-64 object-contain" />
-      ) : null}
-      <Button
-        variant="secondary"
-        size="icon-xs"
-        className="absolute top-1 right-1 opacity-0 group-hover:opacity-100 transition-opacity"
-        onClick={(event) => {
-          event.stopPropagation();
-          handleDownload();
-        }}
-        onPointerDown={(event) => {
-          event.stopPropagation();
-        }}
-        title="Download"
-      >
-        <DownloadIcon />
-      </Button>
+      ) : (
+        <div
+          className="h-32 w-full animate-pulse rounded-md bg-muted"
+          aria-label={`Loading ${attachment.name}`}
+        />
+      )}
+      {status === "loaded" && (
+        <Button
+          variant="secondary"
+          size="icon-xs"
+          className="absolute top-1 right-1 opacity-0 group-hover:opacity-100 transition-opacity"
+          onClick={(event) => {
+            event.stopPropagation();
+            handleDownload();
+          }}
+          onPointerDown={(event) => {
+            event.stopPropagation();
+          }}
+          title="Download"
+        >
+          <DownloadIcon />
+        </Button>
+      )}
     </div>
   );
 }

--- a/examples/chat-react/src/components/chat/ChatMessage.tsx
+++ b/examples/chat-react/src/components/chat/ChatMessage.tsx
@@ -120,8 +120,8 @@ export const ChatMessage = ({ message, sender, isMe, onDelete }: ChatMessageProp
           <AlertDialogHeader>
             <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
             <AlertDialogDescription>
-              This action cannot be undone. This will permanently delete your message from our
-              servers.
+              This action cannot be undone. Your message will be permanently removed for everyone in
+              this chat.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/examples/chat-react/src/components/chat/ChatReactionPicker.tsx
+++ b/examples/chat-react/src/components/chat/ChatReactionPicker.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { SmilePlus } from "lucide-react";
-import { useDb, useSession } from "jazz-tools/react";
+import { useAll, useDb, useSession } from "jazz-tools/react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenuLabel,
@@ -25,13 +25,18 @@ export const ReactionPicker = ({ onPick, messageId }: ReactionPickerProps) => {
   const emojiRegex =
     /^(\p{Extended_Pictographic}|\p{Emoji_Component}|\p{Emoji_Presentation}|\s)+$/u;
 
+  const myReactions =
+    useAll(app.reactions.where({ messageId, userId: session?.user_id ?? "__none__" })) ?? [];
+
   const addReaction = (emoji: string) => {
     if (!session?.user_id) return;
-    db.insert(app.reactions, {
-      messageId,
-      userId: session.user_id,
-      emoji,
-    });
+    if (!myReactions.some((reaction) => reaction.emoji === emoji)) {
+      db.insert(app.reactions, {
+        messageId,
+        userId: session.user_id,
+        emoji,
+      });
+    }
     onPick(emoji);
   };
 

--- a/examples/chat-react/tests/browser/chat-app.test.tsx
+++ b/examples/chat-react/tests/browser/chat-app.test.tsx
@@ -305,6 +305,79 @@ describe("Chat App E2E", () => {
   });
 
   // -------------------------------------------------------------------------
+  // 3b. Reacting twice with the same preset must not duplicate the reaction
+  // -------------------------------------------------------------------------
+
+  it("does not duplicate a reaction when the same preset is picked twice", async () => {
+    const el = await mountApp({ dbName: uniqueDbName("react-dupe") });
+
+    await waitFor(
+      () => el.textContent?.includes("Hello world") ?? false,
+      10000,
+      "Seed message should be visible",
+    );
+
+    const messageBubble = () =>
+      [...el.querySelectorAll("article")].find((a) => a.textContent?.includes("Hello world"));
+
+    // Open the dropdown → React submenu → click the heart preset.
+    async function reactWithHeartViaPicker() {
+      const clickTarget = messageBubble()!.querySelector('[data-slot="dropdown-menu-trigger"]');
+      simulateClick(clickTarget as HTMLElement);
+
+      await waitFor(
+        () => document.querySelectorAll('[data-slot="dropdown-menu-sub-trigger"]').length > 0,
+        3000,
+        "React submenu trigger should appear",
+      );
+      simulateClick(
+        document.querySelector('[data-slot="dropdown-menu-sub-trigger"]') as HTMLElement,
+      );
+
+      await waitFor(
+        () =>
+          [...document.querySelectorAll('[data-slot="dropdown-menu-sub-content"] button')].some(
+            (b) => b.textContent?.includes("❤️"),
+          ),
+        3000,
+        "Heart preset should appear",
+      );
+      const heart = [
+        ...document.querySelectorAll('[data-slot="dropdown-menu-sub-content"] button'),
+      ].find((b) => b.textContent?.includes("❤️")) as HTMLElement;
+      simulateClick(heart);
+
+      // Picking closes the menu; wait for the portal content to tear down before
+      // re-opening so the second cycle clicks fresh elements.
+      await waitFor(
+        () => document.querySelectorAll('[data-slot="dropdown-menu-sub-content"]').length === 0,
+        3000,
+        "Dropdown should close after picking",
+      );
+    }
+
+    await reactWithHeartViaPicker();
+    await waitFor(
+      () => messageBubble()?.textContent?.includes("❤️") ?? false,
+      5000,
+      "Heart reaction pill should appear after the first pick",
+    );
+
+    await reactWithHeartViaPicker();
+    // Give any (buggy) duplicate insert time to land and re-render.
+    await new Promise((r) => setTimeout(r, 500));
+
+    // The reaction pill renders a count only when more than one row exists, so a
+    // duplicate would surface as "❤️ 2". Picking the same preset twice must stay
+    // at a single reaction.
+    const heartPill = [...messageBubble()!.querySelectorAll("button")].find((b) =>
+      b.textContent?.includes("❤️"),
+    );
+    expect(heartPill).toBeTruthy();
+    expect((heartPill!.textContent ?? "").replace(/\s+/g, "")).toBe("❤️");
+  });
+
+  // -------------------------------------------------------------------------
   // 4. Delete a message
   // -------------------------------------------------------------------------
 

--- a/examples/chat-react/tests/browser/chat-app.test.tsx
+++ b/examples/chat-react/tests/browser/chat-app.test.tsx
@@ -305,7 +305,7 @@ describe("Chat App E2E", () => {
   // -------------------------------------------------------------------------
 
   it("does not duplicate a reaction when the same preset is picked twice", async () => {
-    const el = await mountApp({ dbName: uniqueDbName("react-dupe") });
+    const el = await mountApp();
 
     await waitFor(
       () => el.textContent?.includes("Hello world") ?? false,

--- a/examples/chat-react/tests/browser/chat-app.test.tsx
+++ b/examples/chat-react/tests/browser/chat-app.test.tsx
@@ -301,6 +301,79 @@ describe("Chat App E2E", () => {
   });
 
   // -------------------------------------------------------------------------
+  // 3b. Reacting twice with the same preset must not duplicate the reaction
+  // -------------------------------------------------------------------------
+
+  it("does not duplicate a reaction when the same preset is picked twice", async () => {
+    const el = await mountApp({ dbName: uniqueDbName("react-dupe") });
+
+    await waitFor(
+      () => el.textContent?.includes("Hello world") ?? false,
+      10000,
+      "Seed message should be visible",
+    );
+
+    const messageBubble = () =>
+      [...el.querySelectorAll("article")].find((a) => a.textContent?.includes("Hello world"));
+
+    // Open the dropdown → React submenu → click the heart preset.
+    async function reactWithHeartViaPicker() {
+      const clickTarget = messageBubble()!.querySelector('[data-slot="dropdown-menu-trigger"]');
+      simulateClick(clickTarget as HTMLElement);
+
+      await waitFor(
+        () => document.querySelectorAll('[data-slot="dropdown-menu-sub-trigger"]').length > 0,
+        3000,
+        "React submenu trigger should appear",
+      );
+      simulateClick(
+        document.querySelector('[data-slot="dropdown-menu-sub-trigger"]') as HTMLElement,
+      );
+
+      await waitFor(
+        () =>
+          [...document.querySelectorAll('[data-slot="dropdown-menu-sub-content"] button')].some(
+            (b) => b.textContent?.includes("❤️"),
+          ),
+        3000,
+        "Heart preset should appear",
+      );
+      const heart = [
+        ...document.querySelectorAll('[data-slot="dropdown-menu-sub-content"] button'),
+      ].find((b) => b.textContent?.includes("❤️")) as HTMLElement;
+      simulateClick(heart);
+
+      // Picking closes the menu; wait for the portal content to tear down before
+      // re-opening so the second cycle clicks fresh elements.
+      await waitFor(
+        () => document.querySelectorAll('[data-slot="dropdown-menu-sub-content"]').length === 0,
+        3000,
+        "Dropdown should close after picking",
+      );
+    }
+
+    await reactWithHeartViaPicker();
+    await waitFor(
+      () => messageBubble()?.textContent?.includes("❤️") ?? false,
+      5000,
+      "Heart reaction pill should appear after the first pick",
+    );
+
+    await reactWithHeartViaPicker();
+    // Give any (buggy) duplicate insert time to land and re-render.
+    await new Promise((r) => setTimeout(r, 500));
+
+    // The reaction pill renders a count only when more than one row exists, so a
+    // duplicate would surface as "❤️ 2". Picking the same preset twice must stay
+    // at a single reaction.
+    const heartPill = [...messageBubble()!.querySelectorAll("button")].find((b) =>
+      b.textContent?.includes("❤️"),
+    );
+    expect(heartPill).toBeTruthy();
+    expect((heartPill!.textContent ?? "").replace(/\s+/g, "")).toBe("❤️");
+  });
+
+  // -------------------------------------------------------------------------
   // 4. Delete a message
   // -------------------------------------------------------------------------
 

--- a/examples/chat-react/tests/permissions/permissions.test.ts
+++ b/examples/chat-react/tests/permissions/permissions.test.ts
@@ -214,4 +214,94 @@ describe("chat permissions", () => {
     ]);
     await expect(carolDb.all(app.reactions.where({ id: reaction.id }))).resolves.toEqual([]);
   });
+
+  it("lets the sender delete their own message but no one else", async () => {
+    const message = testApp.seed((db) => {
+      const { value: aliceProfile } = db.insert(app.profiles, {
+        userId: "alice",
+        name: "Alice",
+      });
+      const { value: chat } = db.insert(app.chats, {
+        name: "Members only",
+        isPublic: false,
+        createdBy: "alice",
+        joinCode: "del-1",
+      });
+      db.insert(app.chatMembers, { chatId: chat.id, userId: "alice", joinCode: "del-1" });
+      db.insert(app.chatMembers, { chatId: chat.id, userId: "bob", joinCode: "del-1" });
+      const { value: message } = db.insert(app.messages, {
+        chatId: chat.id,
+        text: "alice's message",
+        senderId: aliceProfile.id,
+        createdAt: new Date("2026-01-01T00:00:04.000Z"),
+      });
+      return message;
+    });
+
+    const aliceDb = testApp.as({ user_id: "alice", claims: {}, authMode: "local-first" });
+    const bobDb = testApp.as({ user_id: "bob", claims: {}, authMode: "local-first" });
+
+    aliceDb.expectAllowed((db) => db.delete(app.messages, message.id));
+    bobDb.expectDenied((db) => db.delete(app.messages, message.id));
+  });
+
+  it("lets the sender cascade-delete a message's attachments, files and reactions", async () => {
+    const seeded = testApp.seed((db) => {
+      const { value: aliceProfile } = db.insert(app.profiles, {
+        userId: "alice",
+        name: "Alice",
+      });
+      const { value: chat } = db.insert(app.chats, {
+        name: "Uploads",
+        isPublic: false,
+        createdBy: "alice",
+        joinCode: "del-2",
+      });
+      db.insert(app.chatMembers, { chatId: chat.id, userId: "alice", joinCode: "del-2" });
+      db.insert(app.chatMembers, { chatId: chat.id, userId: "bob", joinCode: "del-2" });
+      const { value: message } = db.insert(app.messages, {
+        chatId: chat.id,
+        text: "see attachment",
+        senderId: aliceProfile.id,
+        createdAt: new Date("2026-01-01T00:00:05.000Z"),
+      });
+      const { value: filePart } = db.insert(app.file_parts, {
+        data: new Uint8Array([1, 2, 3]),
+      });
+      const { value: file } = db.insert(app.files, {
+        name: "note.txt",
+        mimeType: "text/plain",
+        partIds: [filePart.id],
+        partSizes: [3],
+      });
+      const { value: attachment } = db.insert(app.attachments, {
+        messageId: message.id,
+        type: "file",
+        name: "note.txt",
+        fileId: file.id,
+        size: 3,
+      });
+      // A reaction left by someone *other* than the sender must also be removable
+      // when the sender deletes the message it hangs off.
+      const { value: bobReaction } = db.insert(app.reactions, {
+        messageId: message.id,
+        userId: "bob",
+        emoji: "🔥",
+      });
+      return { message, filePart, file, attachment, bobReaction };
+    });
+
+    const aliceDb = testApp.as({ user_id: "alice", claims: {}, authMode: "local-first" });
+    const carolDb = testApp.as({ user_id: "carol", claims: {}, authMode: "local-first" });
+
+    aliceDb.expectAllowed((db) => {
+      db.delete(app.file_parts, seeded.filePart.id);
+      db.delete(app.files, seeded.file.id);
+      db.delete(app.attachments, seeded.attachment.id);
+      db.delete(app.reactions, seeded.bobReaction.id);
+      db.delete(app.messages, seeded.message.id);
+    });
+
+    carolDb.expectDenied((db) => db.delete(app.attachments, seeded.attachment.id));
+  });
 });

--- a/packages/jazz-tools/src/better-auth-adapter/index.test.ts
+++ b/packages/jazz-tools/src/better-auth-adapter/index.test.ts
@@ -874,7 +874,7 @@ describe("jazzAdapter", () => {
       await server.stop();
     });
 
-    test("Email and Password: signup + signin + logout", async () => {
+    test("Email and Password: signup + signin + logout", { timeout: 10_000 }, async () => {
       const signUpResponse = await auth.api.signUpEmail({
         body: {
           name: "test",

--- a/specs/todo/ideas/3_later/permission-unchanged-columns-helper.md
+++ b/specs/todo/ideas/3_later/permission-unchanged-columns-helper.md
@@ -1,0 +1,94 @@
+# `unchanged(...)` helper for column-immutability in update policies
+
+## What
+
+Update policies that forbid specific columns from changing currently rely on a
+cryptic `exists` self-join. From the chat example (`examples/chat-react/permissions.ts`):
+
+```ts
+policy.chats.allowUpdate.whereOld(userIsChatMember).whereNew((chat) =>
+  allOf([
+    userIsChatMember(chat),
+    // createdBy and isPublic must not change
+    policy.chats.exists.where({
+      id: chat.id,
+      createdBy: chat.createdBy,
+      isPublic: chat.isPublic,
+    }),
+  ]),
+);
+```
+
+It reads as "a chat with this id and these values exists", not "these columns are
+immutable" — the intent is buried in a self-correlated existence check. Propose a
+helper that states it directly:
+
+```ts
+policy.chats.allowUpdate
+  .whereOld(userIsChatMember)
+  .whereNew((chat) =>
+    allOf([userIsChatMember(chat), policy.chats.unchanged("createdBy", "isPublic")]),
+  );
+```
+
+## Why the current trick works (and why it's opaque)
+
+Inside `whereNew`, `chat.createdBy` is a row-ref marker that compiles to
+`@__jazz_outer_row.createdBy` — the submitted (new) value — while `exists` queries
+stored state. The row matches only when stored(old) == submitted(new), i.e. the
+column did not change; the `id` term self-correlates to the same row. Trail:
+`packages/jazz-tools/src/permissions/index.ts` (`createRowContext`, `compileCondition`
+→ `Exists`, `toPolicyValue` → `OUTER_ROW_SESSION_PREFIX`) and
+`crates/jazz-tools/src/query_manager/policy.rs` (`OUTER_ROW_SESSION_PREFIX`).
+
+## API shape
+
+Pure TypeScript sugar over the existing `Exists` IR node — no new `PolicyExpr`
+variant and no evaluator change. `policy.<table>.unchanged(...cols)` emits exactly
+what the manual pattern does:
+
+```ts
+{
+  __jazzPermissionKind: "exists",
+  table: "<table>",
+  where: { id: rowRef("id"), [col]: rowRef(col), ... },
+}
+```
+
+Because the row-refs are static column-name markers (values are injected at eval
+time via `__jazz_outer_row`), the helper does not need the runtime row object.
+
+Two call-site options:
+
+- **A (recommended) — method on the table builder:**
+  `policy.chats.unchanged("createdBy", "isPublic")`. The table is already in scope
+  via `policy.chats`; columns type as `keyof Row` (autocompleted, typo-caught). Sits
+  beside the existing `policy.<table>.exists`. Zero internal changes beyond the new
+  method.
+- **B — free function in the builder object:**
+  `unchanged(chat, ["createdBy", "isPublic"])`, exposed alongside `allOf`/`anyOf` in
+  the `definePermissions` context (constructed in `permissions/index.ts`). Reads
+  closest to a bare sketch and avoids repeating the table name, but requires tagging
+  the `RowContext` proxy with a hidden table symbol so the helper can resolve the
+  table.
+
+## Notes / caveats
+
+- **Update-only.** "Unchanged" is meaningful only in a `whereNew` context; it is
+  nonsensical for insert/read/delete. Constrain the type so it is offered only there
+  (or at minimum document it), otherwise it silently desugars to an `exists` that
+  behaves oddly outside updates.
+- **Semantics = "equal to the currently-stored value."** For a normal update that is
+  the pre-update value, which is the intent — but it is an `exists`-against-stored-state,
+  not a literal old/new diff. The doc comment should say so.
+- **Migration path.** There is no `OldEqualsNew` / `CompareRowColumns` primitive in the
+  IR (`exists` is the only old-vs-new mechanism today). If one is ever added, `unchanged`
+  can re-point to it with no user-code change.
+- **Out of scope: ownership-via-FK.** This does not tidy the separate pattern
+  `policy.profiles.exists.where({ id: message.senderId, userId: session.user_id })`
+  (message-delete ownership) — that is column-equality-to-a-ref, a different shape.
+  `allowedTo.update("<fk>")` already expresses it tersely; its natural sugar would be a
+  distinct `allowedTo.referencing("<fk>").matches({ ... })` helper.
+
+Surfaced while fixing the chat-react example delete policy, once PR #980 made
+`exists`-on-`id` evaluate correctly.


### PR DESCRIPTION
Follow-up to #980, which landed the permissions-engine fix for `id` comparisons inside `exists`. This builds the worked example, tests and polish on top of that fix.

## Summary
- Restrict chat updates to non-protected fields — `createdBy` and `isPublic` can no longer be changed — demonstrating granular field-level update permissions in the chat-react example.
- Let a message's sender delete it and cascade-delete its attachments, files and reactions (including reactions left by others); deny everyone else.
- Make the reaction picker idempotent: picking the same preset twice no longer creates a duplicate reaction.
- Polish the example's docs, error handling and copy (ErrorBoundary, ChatImage, ChatFile, ChatView).
- Add a spec note proposing an unchanged-columns permission helper to replace hand-rolled per-field `exists` checks.

## Test plan
- [ ] `cd examples/chat-react && pnpm run test:unit` — 7 permission tests pass (incl. sender delete + cascade)
- [ ] `cd examples/chat-react && pnpm run test:browser` — 25 browser tests pass (incl. reaction-picker idempotency)