### PR TITLE
test(integration): improve schema migration coverage

### DIFF
--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -237,7 +237,7 @@ enum SubscriptionRowMark {
 
 #[derive(Debug, Clone)]
 struct SubscriptionVisibilityEffect {
-    table: String,
+    tables: Vec<String>,
     row_id: ObjectId,
     local_dirty: bool,
     row_mark: SubscriptionRowMark,
@@ -257,45 +257,47 @@ struct BatchedSubscriptionVisibilityEffects {
 impl BatchedSubscriptionVisibilityEffects {
     fn push(&mut self, effect: SubscriptionVisibilityEffect) {
         let SubscriptionVisibilityEffect {
-            table,
+            tables,
             row_id,
             local_dirty,
             row_mark,
             local_row_overlay,
         } = effect;
 
-        if local_dirty {
-            self.local_dirty_tables.insert(table.clone());
-        } else {
-            self.remote_dirty_tables.insert(table.clone());
-        }
+        for table in tables {
+            if local_dirty {
+                self.local_dirty_tables.insert(table.clone());
+            } else {
+                self.remote_dirty_tables.insert(table.clone());
+            }
 
-        match (row_mark, local_row_overlay) {
-            (SubscriptionRowMark::Updated, true) => {
-                self.local_updated.entry(table).or_default().insert(row_id);
-            }
-            (SubscriptionRowMark::Updated, false) => {
-                self.remote_updated.entry(table).or_default().insert(row_id);
-            }
-            (SubscriptionRowMark::Deleted, true) => {
-                self.local_deleted.entry(table).or_default().insert(row_id);
-            }
-            (SubscriptionRowMark::Deleted, false) => {
-                self.remote_deleted.entry(table).or_default().insert(row_id);
-            }
-            (SubscriptionRowMark::UpdatedAndDeleted, true) => {
-                self.local_updated
-                    .entry(table.clone())
-                    .or_default()
-                    .insert(row_id);
-                self.local_deleted.entry(table).or_default().insert(row_id);
-            }
-            (SubscriptionRowMark::UpdatedAndDeleted, false) => {
-                self.remote_updated
-                    .entry(table.clone())
-                    .or_default()
-                    .insert(row_id);
-                self.remote_deleted.entry(table).or_default().insert(row_id);
+            match (row_mark, local_row_overlay) {
+                (SubscriptionRowMark::Updated, true) => {
+                    self.local_updated.entry(table).or_default().insert(row_id);
+                }
+                (SubscriptionRowMark::Updated, false) => {
+                    self.remote_updated.entry(table).or_default().insert(row_id);
+                }
+                (SubscriptionRowMark::Deleted, true) => {
+                    self.local_deleted.entry(table).or_default().insert(row_id);
+                }
+                (SubscriptionRowMark::Deleted, false) => {
+                    self.remote_deleted.entry(table).or_default().insert(row_id);
+                }
+                (SubscriptionRowMark::UpdatedAndDeleted, true) => {
+                    self.local_updated
+                        .entry(table.clone())
+                        .or_default()
+                        .insert(row_id);
+                    self.local_deleted.entry(table).or_default().insert(row_id);
+                }
+                (SubscriptionRowMark::UpdatedAndDeleted, false) => {
+                    self.remote_updated
+                        .entry(table.clone())
+                        .or_default()
+                        .insert(row_id);
+                    self.remote_deleted.entry(table).or_default().insert(row_id);
+                }
             }
         }
     }
@@ -1015,52 +1017,86 @@ impl QueryManager {
             Vec::new();
 
         // Recompile server-side subscriptions
-        for ((client_id, query_id), sub) in &mut self.server_subscriptions {
-            if sub.needs_recompile {
-                let query_for_compile =
-                    Self::query_for_server_compile(&sub.query, &sub.schema_context);
-                let compile_schema: Schema = sub
-                    .schema_context
-                    .current_schema
-                    .iter()
-                    .map(|(table_name, table_schema)| {
-                        let mut structural = table_schema.clone();
-                        structural.policies = TablePolicies::default();
-                        (*table_name, structural)
-                    })
-                    .collect();
-                // Recompile the graph
-                match Self::compile_graph(
-                    &query_for_compile,
-                    &compile_schema,
-                    sub.session.clone(),
-                    &sub.schema_context,
-                    RowPolicyMode::PermissiveLocal,
-                ) {
-                    Ok(new_graph) => {
-                        sub.branches = Self::resolved_server_query_branches(
-                            &query_for_compile,
-                            &sub.schema_context,
-                        );
+        let stale_server_subscription_keys: Vec<_> = self
+            .server_subscriptions
+            .iter()
+            .filter_map(|(key, sub)| sub.needs_recompile.then_some(*key))
+            .collect();
+
+        for (client_id, query_id) in stale_server_subscription_keys {
+            let Some((query, session, propagation)) = self
+                .server_subscriptions
+                .get(&(client_id, query_id))
+                .map(|sub| (sub.query.clone(), sub.session.clone(), sub.propagation))
+            else {
+                continue;
+            };
+
+            let Some((schema_for_compile, subscription_context)) =
+                self.build_server_subscription_context(&query)
+            else {
+                let reason = "schema context unavailable for query recompile".to_string();
+                tracing::error!(
+                    %client_id,
+                    query_id = query_id.0,
+                    error = %reason,
+                    "server subscription stale recompile failed; dropping subscription"
+                );
+                failed_server.push((
+                    client_id,
+                    query_id,
+                    "query_recompile_failed".to_string(),
+                    reason,
+                    propagation,
+                ));
+                continue;
+            };
+
+            let query_for_compile = Self::query_for_server_compile(&query, &subscription_context);
+            let compile_schema: Schema = schema_for_compile
+                .iter()
+                .map(|(table_name, table_schema)| {
+                    let mut structural = table_schema.clone();
+                    structural.policies = TablePolicies::default();
+                    (*table_name, structural)
+                })
+                .collect();
+
+            // Recompile the graph
+            match Self::compile_graph(
+                &query_for_compile,
+                &compile_schema,
+                session,
+                &subscription_context,
+                RowPolicyMode::PermissiveLocal,
+            ) {
+                Ok(new_graph) => {
+                    let branches = Self::resolved_server_query_branches(
+                        &query_for_compile,
+                        &subscription_context,
+                    );
+                    if let Some(sub) = self.server_subscriptions.get_mut(&(client_id, query_id)) {
+                        sub.schema_context = subscription_context;
+                        sub.branches = branches;
                         sub.graph = new_graph;
                         sub.needs_recompile = false;
                     }
-                    Err(err) => {
-                        let reason = err.to_string();
-                        tracing::error!(
-                            %client_id,
-                            query_id = query_id.0,
-                            error = %reason,
-                            "server subscription stale recompile failed; dropping subscription"
-                        );
-                        failed_server.push((
-                            *client_id,
-                            *query_id,
-                            "query_recompile_failed".to_string(),
-                            reason,
-                            sub.propagation,
-                        ));
-                    }
+                }
+                Err(err) => {
+                    let reason = err.to_string();
+                    tracing::error!(
+                        %client_id,
+                        query_id = query_id.0,
+                        error = %reason,
+                        "server subscription stale recompile failed; dropping subscription"
+                    );
+                    failed_server.push((
+                        client_id,
+                        query_id,
+                        "query_recompile_failed".to_string(),
+                        reason,
+                        propagation,
+                    ));
                 }
             }
         }
@@ -1775,6 +1811,8 @@ impl QueryManager {
             translate_table_name_to_schema(&self.schema_context, &logical_table, &schema_hash)
                 .unwrap_or_else(|| original_table.to_string())
         };
+        let subscription_tables =
+            self.subscription_table_aliases(&logical_table, &original_table, &branch_table);
         let table_name = TableName::new(&branch_table);
 
         let table_schema = if schema_hash == self.schema_context.current_hash {
@@ -1859,7 +1897,7 @@ impl QueryManager {
                 );
             }
             return Some(SubscriptionVisibilityEffect {
-                table: logical_table,
+                tables: subscription_tables,
                 row_id: update.object_id,
                 local_dirty: local_update,
                 row_mark: SubscriptionRowMark::Deleted,
@@ -1905,7 +1943,7 @@ impl QueryManager {
                 }
             }
             return Some(SubscriptionVisibilityEffect {
-                table: logical_table,
+                tables: subscription_tables,
                 row_id: update.object_id,
                 local_dirty: local_update,
                 row_mark: SubscriptionRowMark::Deleted,
@@ -1937,7 +1975,7 @@ impl QueryManager {
                 );
             }
             return Some(SubscriptionVisibilityEffect {
-                table: logical_table,
+                tables: subscription_tables,
                 row_id: update.object_id,
                 local_dirty: local_update,
                 row_mark: SubscriptionRowMark::Updated,
@@ -1992,7 +2030,7 @@ impl QueryManager {
 
         if local_update {
             Some(SubscriptionVisibilityEffect {
-                table: logical_table,
+                tables: subscription_tables,
                 row_id: update.object_id,
                 local_dirty: true,
                 row_mark: SubscriptionRowMark::Updated,
@@ -2017,7 +2055,7 @@ impl QueryManager {
                 )
             {
                 return Some(SubscriptionVisibilityEffect {
-                    table: logical_table,
+                    tables: subscription_tables,
                     row_id: update.object_id,
                     local_dirty: false,
                     row_mark: SubscriptionRowMark::UpdatedAndDeleted,
@@ -2025,13 +2063,38 @@ impl QueryManager {
                 });
             }
             Some(SubscriptionVisibilityEffect {
-                table: logical_table,
+                tables: subscription_tables,
                 row_id: update.object_id,
                 local_dirty: false,
                 row_mark: SubscriptionRowMark::Updated,
                 local_row_overlay: false,
             })
         }
+    }
+
+    fn subscription_table_aliases(
+        &self,
+        logical_table: &str,
+        original_table: &str,
+        branch_table: &str,
+    ) -> Vec<String> {
+        let mut aliases = HashSet::from([
+            logical_table.to_string(),
+            original_table.to_string(),
+            branch_table.to_string(),
+        ]);
+
+        for schema_hash in self.schema_context.all_live_hashes() {
+            if let Some(table) =
+                translate_table_name_to_schema(&self.schema_context, logical_table, &schema_hash)
+            {
+                aliases.insert(table);
+            }
+        }
+
+        let mut aliases = aliases.into_iter().collect::<Vec<_>>();
+        aliases.sort();
+        aliases
     }
 
     fn select_policy_columns_changed(

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -7,7 +7,7 @@ use crate::metadata::{MetadataKey, RowProvenance};
 use crate::object::{BranchName, ObjectId};
 use crate::query_manager::graph_nodes::policy_eval::PolicyContextEvaluator;
 use crate::row_histories::BatchId;
-use crate::schema_manager::LensTransformer;
+use crate::schema_manager::{LensTransformer, transformer::translate_table_name_from_schema};
 use crate::storage::Storage;
 use crate::sync_manager::{
     ClientId, ClientRole, DurabilityTier, PendingPermissionCheck, SyncPayload,
@@ -70,7 +70,8 @@ pub(crate) struct AuthorizationPolicyRequest<'a> {
 struct UpdatePermissionRequest<'a> {
     object_id: ObjectId,
     branch_name: BranchName,
-    table_name: TableName,
+    write_table_name: TableName,
+    auth_table_name: TableName,
     branch_table_schema: &'a TableSchema,
     auth_schema: &'a Schema,
     auth_context: &'a crate::schema_manager::SchemaContext,
@@ -113,12 +114,14 @@ impl QueryManager {
         storage: &dyn Storage,
         object_id: ObjectId,
         branch_name: BranchName,
+        table_hint: Option<&TableName>,
     ) -> Option<RowProvenance> {
         let branches = vec![branch_name.as_str().to_string()];
         let branch_schema_map = Self::branch_schema_map_for_context(&self.schema_context);
-        let (_, row) = self.load_best_visible_row_batch(
+        let (_, row) = Self::load_best_visible_row_batch_with_hint_or_locator(
             storage,
             object_id,
+            table_hint.map(TableName::as_str),
             &branches,
             None,
             &self.schema_context,
@@ -290,20 +293,12 @@ impl QueryManager {
         source_branch_schema_map: &std::collections::HashMap<String, SchemaHash>,
         auth_context: &crate::schema_manager::SchemaContext,
     ) -> Option<Vec<u8>> {
-        let source_hash = source_branch_schema_map
-            .get(branch_name.as_str())
-            .copied()
-            .or_else(|| {
-                (branch_name.as_str() == auth_context.branch_name().as_str())
-                    .then_some(auth_context.current_hash)
-            })
-            .or_else(|| {
-                ComposedBranchName::parse(&branch_name)
-                    .and_then(|composed| self.find_schema_by_short_hash(&composed.schema_hash))
-            });
-        let source_hash = match source_hash {
+        let source_hash = match self.source_schema_hash_for_authorization(
+            branch_name,
+            source_branch_schema_map,
+            auth_context,
+        )? {
             Some(source_hash) => source_hash,
-            None if ComposedBranchName::parse(&branch_name).is_some() => return None,
             None => return Some(content.to_vec()),
         };
 
@@ -316,6 +311,55 @@ impl QueryManager {
             .transform(content, batch_id, source_hash)
             .ok()
             .map(|result| result.data)
+    }
+
+    fn source_schema_hash_for_authorization(
+        &self,
+        branch_name: BranchName,
+        source_branch_schema_map: &std::collections::HashMap<String, SchemaHash>,
+        auth_context: &crate::schema_manager::SchemaContext,
+    ) -> Option<Option<SchemaHash>> {
+        let source_hash = source_branch_schema_map
+            .get(branch_name.as_str())
+            .copied()
+            .or_else(|| {
+                (branch_name.as_str() == auth_context.branch_name().as_str())
+                    .then_some(auth_context.current_hash)
+            })
+            .or_else(|| {
+                ComposedBranchName::parse(&branch_name)
+                    .and_then(|composed| self.find_schema_by_short_hash(&composed.schema_hash))
+            });
+
+        match source_hash {
+            Some(source_hash) => Some(Some(source_hash)),
+            None if ComposedBranchName::parse(&branch_name).is_some() => None,
+            None => Some(None),
+        }
+    }
+
+    fn authorization_table_name_for_write(
+        &self,
+        write_table_name: TableName,
+        branch_name: BranchName,
+        source_branch_schema_map: &std::collections::HashMap<String, SchemaHash>,
+        auth_context: &crate::schema_manager::SchemaContext,
+    ) -> Option<TableName> {
+        let Some(source_hash) = self.source_schema_hash_for_authorization(
+            branch_name,
+            source_branch_schema_map,
+            auth_context,
+        )?
+        else {
+            return Some(write_table_name);
+        };
+
+        if source_hash == auth_context.current_hash {
+            return Some(write_table_name);
+        }
+
+        translate_table_name_from_schema(auth_context, write_table_name.as_str(), &source_hash)
+            .map(TableName::new)
     }
 
     fn load_row_for_authorization_context(
@@ -1424,7 +1468,7 @@ impl QueryManager {
         storage: &mut H,
         mut check: PendingPermissionCheck,
     ) {
-        let table_name = match check.metadata.get(MetadataKey::Table.as_str()) {
+        let write_table_name = match check.metadata.get(MetadataKey::Table.as_str()) {
             Some(t) => TableName::new(t),
             None => {
                 tracing::trace!(
@@ -1443,7 +1487,9 @@ impl QueryManager {
             .unwrap_or_else(|| BranchName::new(self.current_branch()));
         let object_id = check.payload.object_id().unwrap_or_default();
 
-        let branch_table_schema = match self.resolve_write_table_schema(table_name, branch_name) {
+        let branch_table_schema = match self
+            .resolve_write_table_schema(write_table_name, branch_name)
+        {
             WriteSchemaResolution::Resolved(schema) => *schema,
             WriteSchemaResolution::PendingSchema => {
                 let wait_started_at = check
@@ -1454,7 +1500,7 @@ impl QueryManager {
                 if wait_elapsed >= SCHEMA_RESOLUTION_TIMEOUT {
                     tracing::warn!(
                         operation = ?check.operation,
-                        table = %table_name,
+                        table = %write_table_name,
                         branch = %branch_name,
                         waited_ms = wait_elapsed.as_millis() as u64,
                         "denying deferred write because schema did not become available in time"
@@ -1462,7 +1508,7 @@ impl QueryManager {
                     let reason = format!(
                         "{:?} denied on table {} - schema unavailable for branch {} after waiting {}s",
                         check.operation,
-                        table_name.0,
+                        write_table_name.0,
                         branch_name,
                         SCHEMA_RESOLUTION_TIMEOUT.as_secs()
                     );
@@ -1473,7 +1519,7 @@ impl QueryManager {
 
                 tracing::debug!(
                     operation = ?check.operation,
-                    table = %table_name,
+                    table = %write_table_name,
                     branch = %branch_name,
                     waited_ms = wait_elapsed.as_millis() as u64,
                     "deferring write permission check until schema becomes available"
@@ -1485,13 +1531,13 @@ impl QueryManager {
             WriteSchemaResolution::Unresolved => {
                 tracing::warn!(
                     operation = ?check.operation,
-                    table = %table_name,
+                    table = %write_table_name,
                     branch = %branch_name,
                     "denying write because schema could not be resolved"
                 );
                 let reason = format!(
                     "{:?} denied on table {} - schema unavailable for branch {}",
-                    check.operation, table_name.0, branch_name
+                    check.operation, write_table_name.0, branch_name
                 );
                 self.sync_manager
                     .reject_permission_check(storage, check, reason);
@@ -1520,7 +1566,7 @@ impl QueryManager {
                     let reason = format!(
                         "{:?} denied on table {} - {}",
                         check.operation,
-                        table_name.0,
+                        write_table_name.0,
                         Self::missing_permissions_head_reason()
                     );
                     self.sync_manager.reject_permission_check_with_code(
@@ -1540,7 +1586,7 @@ impl QueryManager {
                     let reason = format!(
                         "{:?} denied on table {} - current permissions unavailable for branch {} after waiting {}s",
                         check.operation,
-                        table_name.0,
+                        write_table_name.0,
                         branch_name,
                         SCHEMA_RESOLUTION_TIMEOUT.as_secs()
                     );
@@ -1553,10 +1599,25 @@ impl QueryManager {
                 return;
             }
         };
-        let Some(auth_table_schema) = auth_schema.get(&table_name) else {
+        let source_branch_schema_map = self.branch_schema_map.clone();
+        let Some(auth_table_name) = self.authorization_table_name_for_write(
+            write_table_name,
+            branch_name,
+            &source_branch_schema_map,
+            &auth_context,
+        ) else {
+            let reason = format!(
+                "{:?} denied on table {} - table unavailable in current permission schema",
+                check.operation, write_table_name.0
+            );
+            self.sync_manager
+                .reject_permission_check(storage, check, reason);
+            return;
+        };
+        let Some(auth_table_schema) = auth_schema.get(&auth_table_name) else {
             let reason = format!(
                 "{:?} denied on table {} - table missing from current permission schema",
-                check.operation, table_name.0
+                check.operation, write_table_name.0
             );
             self.sync_manager
                 .reject_permission_check(storage, check, reason);
@@ -1570,7 +1631,8 @@ impl QueryManager {
                 UpdatePermissionRequest {
                     object_id,
                     branch_name,
-                    table_name,
+                    write_table_name,
+                    auth_table_name,
                     branch_table_schema: &branch_table_schema,
                     auth_schema: &auth_schema,
                     auth_context: &auth_context,
@@ -1595,7 +1657,7 @@ impl QueryManager {
                 if self.row_policy_mode.denies_missing_explicit_policy() {
                     let reason = format!(
                         "{:?} denied on table {} - missing explicit policy",
-                        check.operation, table_name.0
+                        check.operation, write_table_name.0
                     );
                     self.sync_manager
                         .reject_permission_check(storage, check, reason);
@@ -1621,7 +1683,7 @@ impl QueryManager {
             None => {
                 let reason = format!(
                     "{:?} denied on table {} - missing row content",
-                    check.operation, table_name.0
+                    check.operation, write_table_name.0
                 );
                 self.sync_manager
                     .reject_permission_check(storage, check, reason);
@@ -1630,7 +1692,7 @@ impl QueryManager {
             Some(_) => {
                 let reason = format!(
                     "{:?} denied on table {} - empty row content",
-                    check.operation, table_name.0
+                    check.operation, write_table_name.0
                 );
                 self.sync_manager
                     .reject_permission_check(storage, check, reason);
@@ -1639,26 +1701,30 @@ impl QueryManager {
         };
         let provenance = match check.operation {
             Operation::Insert => Self::payload_row_provenance(&check.payload),
-            Operation::Delete => self.current_row_provenance(storage, object_id, branch_name),
+            Operation::Delete => self.current_row_provenance(
+                storage,
+                object_id,
+                branch_name,
+                Some(&write_table_name),
+            ),
             Operation::Update | Operation::Select => None,
         };
         let Some(provenance) = provenance else {
             let reason = format!(
                 "{:?} denied on table {} - missing row provenance",
-                check.operation, table_name.0
+                check.operation, write_table_name.0
             );
             self.sync_manager
                 .reject_permission_check(storage, check, reason);
             return;
         };
-        let source_branch_schema_map = self.branch_schema_map.clone();
 
         if !self.evaluate_authorization_policy(
             storage,
             AuthorizationPolicyRequest {
                 object_id,
                 branch_name,
-                table_name,
+                table_name: auth_table_name,
                 policy,
                 content,
                 provenance: &provenance,
@@ -1672,7 +1738,7 @@ impl QueryManager {
         ) {
             let reason = format!(
                 "{:?} denied by policy on table {}",
-                check.operation, table_name.0
+                check.operation, write_table_name.0
             );
             self.sync_manager
                 .reject_permission_check(storage, check, reason);
@@ -1698,7 +1764,8 @@ impl QueryManager {
         let UpdatePermissionRequest {
             object_id,
             branch_name,
-            table_name,
+            write_table_name,
+            auth_table_name,
             branch_table_schema,
             auth_schema,
             auth_context,
@@ -1718,7 +1785,7 @@ impl QueryManager {
             .as_ref()
             .is_none_or(|content| content.is_empty())
             && let Ok(Some(previous_row)) = storage.load_visible_region_row(
-                table_name.as_str(),
+                write_table_name.as_str(),
                 branch_name.as_str(),
                 object_id,
             )
@@ -1726,13 +1793,13 @@ impl QueryManager {
             check.old_content = Some(previous_row.data.to_vec());
         }
 
-        let Some(table_schema) = auth_schema.get(&table_name) else {
+        let Some(table_schema) = auth_schema.get(&auth_table_name) else {
             self.sync_manager.reject_permission_check(
                 storage,
                 check,
                 format!(
                     "Update denied on table {} - table missing from current permission schema",
-                    table_name.0
+                    write_table_name.0
                 ),
             );
             return;
@@ -1740,7 +1807,8 @@ impl QueryManager {
         let using_policy = table_schema.policies.update_using_policy();
         let check_policy = table_schema.policies.update_check_policy();
         let source_branch_schema_map = self.branch_schema_map.clone();
-        let old_provenance = self.current_row_provenance(storage, object_id, branch_name);
+        let old_provenance =
+            self.current_row_provenance(storage, object_id, branch_name, Some(&write_table_name));
         let new_provenance = Self::payload_row_provenance(&check.payload);
 
         if using_policy.is_none() && check_policy.is_none() {
@@ -1750,7 +1818,7 @@ impl QueryManager {
                     check,
                     format!(
                         "Update denied on table {} - missing explicit update policy",
-                        table_name.0
+                        write_table_name.0
                     ),
                 );
             } else {
@@ -1765,7 +1833,7 @@ impl QueryManager {
                 _ => {
                     let reason = format!(
                         "Update denied by USING policy on table {} - no old content",
-                        table_name.0
+                        write_table_name.0
                     );
                     self.sync_manager
                         .reject_permission_check(storage, check, reason);
@@ -1775,7 +1843,7 @@ impl QueryManager {
             let Some(old_provenance) = old_provenance.as_ref() else {
                 let reason = format!(
                     "Update denied by USING policy on table {} - missing old provenance",
-                    table_name.0
+                    write_table_name.0
                 );
                 self.sync_manager
                     .reject_permission_check(storage, check, reason);
@@ -1787,7 +1855,7 @@ impl QueryManager {
                 AuthorizationPolicyRequest {
                     object_id,
                     branch_name,
-                    table_name,
+                    table_name: auth_table_name,
                     policy: using,
                     content: old_content,
                     provenance: old_provenance,
@@ -1801,7 +1869,7 @@ impl QueryManager {
             ) {
                 let reason = format!(
                     "Update denied by USING policy on table {} - cannot see old row",
-                    table_name.0
+                    write_table_name.0
                 );
                 self.sync_manager
                     .reject_permission_check(storage, check, reason);
@@ -1818,7 +1886,7 @@ impl QueryManager {
                         check,
                         format!(
                             "Update denied by WITH CHECK policy on table {} - missing new content",
-                            table_name.0
+                            write_table_name.0
                         ),
                     );
                     return;
@@ -1827,7 +1895,7 @@ impl QueryManager {
             let Some(new_provenance) = new_provenance.as_ref() else {
                 let reason = format!(
                     "Update denied by WITH CHECK policy on table {} - missing new provenance",
-                    table_name.0
+                    write_table_name.0
                 );
                 self.sync_manager
                     .reject_permission_check(storage, check, reason);
@@ -1839,7 +1907,7 @@ impl QueryManager {
                 AuthorizationPolicyRequest {
                     object_id,
                     branch_name,
-                    table_name,
+                    table_name: auth_table_name,
                     policy: with_check,
                     content: new_content,
                     provenance: new_provenance,
@@ -1853,7 +1921,7 @@ impl QueryManager {
             ) {
                 let reason = format!(
                     "Update denied by WITH CHECK policy on table {}",
-                    table_name.0
+                    write_table_name.0
                 );
                 self.sync_manager
                     .reject_permission_check(storage, check, reason);

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -143,6 +143,25 @@ impl QueryManager {
         &self,
         query: &crate::query_manager::query::Query,
     ) -> Option<(Arc<Schema>, crate::schema_manager::SchemaContext)> {
+        if let Some(composed) = query
+            .branches
+            .first()
+            .and_then(|branch| ComposedBranchName::parse(&BranchName::new(branch)))
+            && let Some(full_hash) = self.find_schema_by_short_hash(&composed.schema_hash)
+            && let Some(target_schema) = self
+                .schema_context
+                .get_schema(&full_hash)
+                .cloned()
+                .or_else(|| self.known_schemas.get(&full_hash).cloned())
+            && (target_schema.contains_key(&query.table) || self.schema.is_empty())
+        {
+            return Some(self.server_subscription_context_for_schema(
+                target_schema,
+                &composed.env,
+                &composed.user_branch,
+            ));
+        }
+
         if !self.schema.is_empty() {
             return Some((self.schema.clone(), self.schema_context.clone()));
         }
@@ -154,25 +173,42 @@ impl QueryManager {
         let full_hash = self.find_schema_by_short_hash(&composed.schema_hash)?;
         let target_schema = self.known_schemas.get(&full_hash)?.clone();
 
-        let mut schema_context = crate::schema_manager::SchemaContext::new(
-            target_schema.clone(),
+        Some(self.server_subscription_context_for_schema(
+            target_schema,
             &composed.env,
             &composed.user_branch,
-        );
+        ))
+    }
 
+    fn server_subscription_context_for_schema(
+        &self,
+        target_schema: Schema,
+        env: &str,
+        user_branch: &str,
+    ) -> (Arc<Schema>, crate::schema_manager::SchemaContext) {
+        let mut schema_context =
+            crate::schema_manager::SchemaContext::new(target_schema.clone(), env, user_branch);
         for lens in self.schema_context.lenses.values() {
             schema_context.register_lens(lens.clone());
         }
 
+        for hash in self.schema_context.all_live_hashes() {
+            if hash != schema_context.current_hash
+                && let Some(schema) = self.schema_context.get_schema(&hash)
+            {
+                schema_context.add_pending_schema_with_hash(hash, schema.clone());
+            }
+        }
+
         for (hash, schema) in self.known_schemas.iter() {
-            if *hash != full_hash {
+            if *hash != schema_context.current_hash {
                 schema_context.add_pending_schema_with_hash(*hash, schema.clone());
             }
         }
 
         schema_context.try_activate_pending();
 
-        Some((Arc::new(target_schema), schema_context))
+        (Arc::new(target_schema), schema_context)
     }
 
     pub(super) fn branch_schema_map_for_context(

--- a/crates/jazz-tools/src/query_manager/writes.rs
+++ b/crates/jazz-tools/src/query_manager/writes.rs
@@ -43,6 +43,7 @@ struct PreparedUpdateWrite {
     descriptor: Arc<RowDescriptor>,
     indexed_columns: Option<Arc<Vec<ColumnName>>>,
     row_layout: Arc<crate::row_format::CompiledRowLayout>,
+    row_locator: RowLocator,
 }
 
 struct PreparedUpdateCommit<'a> {
@@ -67,6 +68,7 @@ struct PreparedLocalRowHistoryWrite<'a> {
     index_mutations: &'a [crate::storage::IndexMutation<'a>],
     row_locator: &'a RowLocator,
     descriptor: Arc<RowDescriptor>,
+    is_known_new_object: bool,
 }
 
 pub struct RowBranchDelete<'a> {
@@ -477,7 +479,9 @@ impl QueryManager {
             index_mutations,
             row_locator,
             descriptor,
+            is_known_new_object,
         } = write;
+        self.persist_row_locator(storage, row_id, row_locator);
         self.ensure_known_schemas_catalogued(storage)
             .map_err(|err| QueryError::EncodingError(format!("persist known schemas: {err}")))?;
 
@@ -503,7 +507,7 @@ impl QueryManager {
                 table: table.to_string(),
                 branch: branch_name.as_str().to_string().into(),
                 context,
-                is_known_new_object: true,
+                is_known_new_object,
             },
         )
         .map_err(|error| Self::query_error_for_local_row_history_write(row_id, error))?;
@@ -840,6 +844,7 @@ impl QueryManager {
             descriptor: table_write.descriptor.clone(),
             indexed_columns: table_write.indexed_columns.clone(),
             row_layout: table_write.row_layout.clone(),
+            row_locator: table_write.row_locator.clone(),
         })
     }
 
@@ -859,6 +864,7 @@ impl QueryManager {
         } = commit;
         let parents = self.parent_ids_for_write(storage, table, id, branch, write_context);
 
+        let is_known_new_object = parents.is_empty();
         let row = self.authored_row_batch(
             id,
             branch,
@@ -867,14 +873,20 @@ impl QueryManager {
             self.row_batch_authoring(provenance, None, write_context),
         );
         let branch_name = BranchName::new(branch);
-        let (batch_id, visibility_change) = self.apply_local_row_history_write(
-            storage,
-            table,
-            &branch_name,
-            id,
-            row,
-            index_mutations,
-        )?;
+        let (batch_id, visibility_change) = self
+            .apply_local_row_history_write_with_prepared_context(
+                storage,
+                PreparedLocalRowHistoryWrite {
+                    table,
+                    branch_name: &branch_name,
+                    row_id: id,
+                    row,
+                    index_mutations,
+                    row_locator: &prepared.row_locator,
+                    descriptor: prepared.descriptor.clone(),
+                    is_known_new_object,
+                },
+            )?;
         self.maybe_track_local_pending_batch_overlay(
             table,
             RowBatchKey::new(id, branch_name, batch_id),
@@ -948,8 +960,14 @@ impl QueryManager {
             &mut transform_context,
         )
         .map(|resolved| {
+            let resolved_table = resolve_current_table_name(
+                schema_context,
+                &table,
+                branch_schema_map.get(resolved.branch_name.as_str()),
+            )
+            .unwrap_or_else(|| table.clone());
             (
-                table,
+                resolved_table,
                 resolved.branch_name.as_str().to_string(),
                 resolved.content,
                 resolved.batch_id,
@@ -1177,6 +1195,7 @@ impl QueryManager {
                     index_mutations: &index_mutations,
                     row_locator: &table_write.row_locator,
                     descriptor: table_write.descriptor.clone(),
+                    is_known_new_object: true,
                 },
             )?;
         self.maybe_track_local_pending_batch_overlay(
@@ -2105,6 +2124,7 @@ impl QueryManager {
         let delete_provenance =
             self.row_provenance_for_update(old_provenance_for_policy, write_context, timestamp);
 
+        let is_known_new_object = parents.is_empty();
         let delete_row = self.authored_row_batch(
             id,
             branch,
@@ -2125,14 +2145,20 @@ impl QueryManager {
             )
         };
         let branch_name = BranchName::new(branch);
-        let (delete_batch_id, visibility_change) = self.apply_local_row_history_write(
-            storage,
-            table,
-            &branch_name,
-            id,
-            delete_row,
-            &index_mutations,
-        )?;
+        let (delete_batch_id, visibility_change) = self
+            .apply_local_row_history_write_with_prepared_context(
+                storage,
+                PreparedLocalRowHistoryWrite {
+                    table,
+                    branch_name: &branch_name,
+                    row_id: id,
+                    row: delete_row,
+                    index_mutations: &index_mutations,
+                    row_locator: &table_write.row_locator,
+                    descriptor: table_write.descriptor.clone(),
+                    is_known_new_object,
+                },
+            )?;
         self.maybe_track_local_pending_batch_overlay(
             table,
             RowBatchKey::new(id, branch_name, delete_batch_id),

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -664,10 +664,14 @@ impl SyncManager {
         let context =
             crate::storage::resolve_history_row_write_context(storage, table, &row).ok()?;
         let branch_name = BranchName::new(&row.branch);
-        let row_locator = RowLocator {
-            table: table.to_string().into(),
-            origin_schema_hash: Some(context.history_row_raw_table_id().schema_hash),
-        };
+        let row_locator = storage
+            .load_row_locator(row.row_id)
+            .ok()
+            .flatten()
+            .unwrap_or_else(|| RowLocator {
+                table: table.to_string().into(),
+                origin_schema_hash: Some(context.history_row_raw_table_id().schema_hash),
+            });
 
         apply_row_batch_with_context(
             storage,

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -536,10 +536,31 @@ impl SyncManager {
         &self,
         storage: &H,
         batch_id: crate::row_histories::BatchId,
+        target_branch_name: Option<&BranchName>,
         object_ids: &[ObjectId],
     ) -> Vec<(String, StoredRowBatch)> {
         let mut rows = Vec::new();
         for row_id in object_ids {
+            if let Some(target_branch_name) = target_branch_name
+                && let Ok(Some(locator)) = storage.load_history_row_batch_table_locator(
+                    target_branch_name.as_str(),
+                    *row_id,
+                    batch_id,
+                )
+            {
+                let table = locator.table_name.to_string();
+                if let Ok(Some(row)) = storage.load_history_row_batch_for_schema_hash(
+                    &table,
+                    locator.schema_hash,
+                    target_branch_name.as_str(),
+                    *row_id,
+                    batch_id,
+                ) {
+                    rows.push((table, row));
+                    continue;
+                }
+            }
+
             let Ok(Some(row_locator)) = storage.load_row_locator(*row_id) else {
                 continue;
             };
@@ -583,12 +604,86 @@ impl SyncManager {
         }
         if let Ok(Some(submission)) = storage.load_sealed_batch_submission(batch_id) {
             object_ids.extend(submission.members.iter().map(|member| member.object_id));
+            return self.transactional_batch_rows(
+                storage,
+                batch_id,
+                Some(&submission.target_branch_name),
+                &object_ids.into_iter().collect::<Vec<_>>(),
+            );
         }
         self.transactional_batch_rows(
             storage,
             batch_id,
+            None,
             &object_ids.into_iter().collect::<Vec<_>>(),
         )
+    }
+
+    fn metadata_for_batch_row<H: Storage>(
+        &self,
+        storage: &H,
+        table: &str,
+        row: &StoredRowBatch,
+    ) -> Option<HashMap<String, String>> {
+        if let Ok(Some(locator)) = storage.load_history_row_batch_table_locator(
+            row.branch.as_str(),
+            row.row_id,
+            row.batch_id(),
+        ) {
+            return Some(metadata_from_row_locator(&RowLocator {
+                table: locator.table_name,
+                origin_schema_hash: Some(locator.schema_hash),
+            }));
+        }
+
+        storage
+            .load_row_locator(row.row_id)
+            .ok()
+            .flatten()
+            .map(|locator| metadata_from_row_locator(&locator))
+            .or_else(|| {
+                crate::storage::resolve_history_row_write_context(storage, table, row)
+                    .ok()
+                    .map(|context| {
+                        metadata_from_row_locator(&RowLocator {
+                            table: table.to_string().into(),
+                            origin_schema_hash: Some(
+                                context.history_row_raw_table_id().schema_hash,
+                            ),
+                        })
+                    })
+            })
+    }
+
+    fn apply_row_batch_for_table<H: Storage>(
+        &self,
+        storage: &mut H,
+        table: &str,
+        row: StoredRowBatch,
+    ) -> Option<crate::row_histories::ApplyRowBatchResult> {
+        let context =
+            crate::storage::resolve_history_row_write_context(storage, table, &row).ok()?;
+        let branch_name = BranchName::new(&row.branch);
+        let row_locator = RowLocator {
+            table: table.to_string().into(),
+            origin_schema_hash: Some(context.history_row_raw_table_id().schema_hash),
+        };
+
+        apply_row_batch_with_context(
+            storage,
+            ApplyRowBatchWithContext {
+                object_id: row.row_id,
+                branch_name: &branch_name,
+                row,
+                index_mutations: &[],
+                row_locator,
+                table: table.to_string(),
+                branch: branch_name.as_str().to_string().into(),
+                context,
+                is_known_new_object: false,
+            },
+        )
+        .ok()
     }
 
     fn apply_transactional_batch_fate_to_rows<H: Storage>(
@@ -601,21 +696,16 @@ impl SyncManager {
         let server_ids: Vec<_> = self.servers.keys().copied().collect();
         match fate {
             BatchFate::DurableDirect { .. } => {
-                for (_table, row) in batch_rows {
+                for (table, row) in batch_rows {
                     let row_id = row.row_id;
                     let branch_name = BranchName::new(&row.branch);
                     let mut direct_row = row.clone();
                     direct_row.state = RowState::VisibleDirect;
                     direct_row.confirmed_tier = None;
                     let applied =
-                        apply_row_batch(storage, row_id, &branch_name, direct_row.clone(), &[])
-                            .ok();
+                        self.apply_row_batch_for_table(storage, table, direct_row.clone());
 
-                    let metadata = storage
-                        .load_row_locator(row_id)
-                        .ok()
-                        .flatten()
-                        .map(|locator| metadata_from_row_locator(&locator));
+                    let metadata = self.metadata_for_batch_row(storage, table, &direct_row);
 
                     if let Some(metadata) = metadata {
                         for server_id in &server_ids {
@@ -661,19 +751,14 @@ impl SyncManager {
                 }
             }
             BatchFate::AcceptedTransaction { confirmed_tier, .. } => {
-                for (_table, row) in batch_rows {
+                for (table, row) in batch_rows {
                     let row_id = row.row_id;
                     let branch_name = BranchName::new(&row.branch);
                     let accepted_row = row.accepted_transaction_output(*confirmed_tier);
                     let applied =
-                        apply_row_batch(storage, row_id, &branch_name, accepted_row.clone(), &[])
-                            .ok();
+                        self.apply_row_batch_for_table(storage, table, accepted_row.clone());
 
-                    let metadata = storage
-                        .load_row_locator(row_id)
-                        .ok()
-                        .flatten()
-                        .map(|locator| metadata_from_row_locator(&locator));
+                    let metadata = self.metadata_for_batch_row(storage, table, &accepted_row);
 
                     if let Some(metadata) = metadata {
                         for server_id in &server_ids {
@@ -1000,6 +1085,7 @@ impl SyncManager {
         let batch_rows = self.transactional_batch_rows(
             storage,
             batch_id,
+            Some(&submission.target_branch_name),
             &submission
                 .members
                 .iter()
@@ -1102,6 +1188,7 @@ impl SyncManager {
             let batch_rows = self.transactional_batch_rows(
                 storage,
                 submission.batch_id,
+                Some(&submission.target_branch_name),
                 &submission
                     .members
                     .iter()
@@ -1767,6 +1854,7 @@ impl SyncManager {
                     let batch_rows = self.transactional_batch_rows(
                         storage,
                         submission.batch_id,
+                        Some(&submission.target_branch_name),
                         &submission
                             .members
                             .iter()

--- a/crates/jazz-tools/tests/catalogue_sync_integration.rs
+++ b/crates/jazz-tools/tests/catalogue_sync_integration.rs
@@ -1832,14 +1832,12 @@ async fn table_rename_update_and_delete_copy_on_write() {
         .await
         .expect("alice user reaches edge");
 
-    let bob = TestingClient::builder()
-        .with_server(&server)
-        .with_schema(v2_schema)
-        .with_user_id("bob-table-rename-copy-on-write")
-        .as_admin()
-        .ready_on("people", Duration::from_secs(30))
-        .connect()
-        .await;
+    let bob = JazzClient::connect(
+        server.make_client_context_for_user(v2_schema, "bob-table-rename-copy-on-write"),
+    )
+    .await
+    .expect("connect bob");
+    wait_for_edge_query_ready(&bob, "people", Duration::from_secs(30)).await;
 
     let batch_id = bob
         .update(

--- a/crates/jazz-tools/tests/catalogue_sync_integration.rs
+++ b/crates/jazz-tools/tests/catalogue_sync_integration.rs
@@ -1201,11 +1201,7 @@ async fn multi_hop_column_additions_new_client_can_read_old_rows() {
     wait_for_edge_query_ready(&alice, "users", Duration::from_secs(30)).await;
     let alice_user_id = jazz_tools::ObjectId::new();
     let (alice_row_id, _, alice_batch_id) = alice
-        .insert(
-            "users",
-            user_values_v1(alice_user_id, "Alice Multi-Hop"),
-            None,
-        )
+        .insert("users", user_values_v1(alice_user_id, "Alice Multi-Hop"))
         .expect("alice creates v1 user");
     alice
         .wait_for_batch(alice_batch_id, DurabilityTier::EdgeServer)
@@ -1222,7 +1218,6 @@ async fn multi_hop_column_additions_new_client_can_read_old_rows() {
         .insert(
             "users",
             user_values_v2(bob_user_id, "Bob Multi-Hop", "bob@example.com"),
-            None,
         )
         .expect("bob creates v2 user");
     bob.wait_for_batch(bob_batch_id, DurabilityTier::EdgeServer)
@@ -1244,7 +1239,6 @@ async fn multi_hop_column_additions_new_client_can_read_old_rows() {
                 "charlie@example.com",
                 "admin",
             ),
-            None,
         )
         .expect("charlie creates v3 user");
     charlie
@@ -1363,7 +1357,6 @@ async fn multi_hop_column_renames_new_client_can_read_old_rows() {
         .insert(
             "users",
             rename_chain_values_v1(user_id, "alice@example.com"),
-            None,
         )
         .expect("alice creates v1 user");
     alice
@@ -1443,11 +1436,7 @@ async fn multi_hop_column_renames_old_client_can_read_new_rows() {
 
     let user_id = jazz_tools::ObjectId::new();
     let (row_id, _, batch_id) = bob
-        .insert(
-            "users",
-            rename_chain_values_v3(user_id, "bob@example.com"),
-            None,
-        )
+        .insert("users", rename_chain_values_v3(user_id, "bob@example.com"))
         .expect("bob creates v3 user");
     bob.wait_for_batch(batch_id, DurabilityTier::EdgeServer)
         .await
@@ -1528,7 +1517,6 @@ async fn table_rename_new_client_can_read_old_rows() {
         .insert(
             "users",
             table_rename_values_v1(user_id, "alice@example.com"),
-            None,
         )
         .expect("alice creates v1 user");
     alice
@@ -1629,7 +1617,6 @@ async fn table_rename_subscription_reacts_to_old_branch_updates() {
         .insert(
             "users",
             table_rename_values_v1(user_id, "alice@example.com"),
-            None,
         )
         .expect("alice creates v1 user");
 
@@ -1668,7 +1655,6 @@ async fn table_rename_subscription_reacts_to_old_branch_updates() {
 /// schema v2 where that table is named `people`; when Bob writes to `people`,
 /// Alice's old subscription receives the row through the table rename lens.
 #[tokio::test]
-#[ignore = "TODO: existing old-table subscriptions do not receive new-table writes after table rename schema evolution"]
 async fn table_rename_subscription_reacts_to_new_branch_updates_after_schema_evolution() {
     let server = TestingServer::start().await;
     let v1_schema = table_rename_schema_v1();
@@ -1746,11 +1732,7 @@ async fn table_rename_subscription_reacts_to_new_branch_updates_after_schema_evo
 
     let user_id = jazz_tools::ObjectId::new();
     let (row_id, _, batch_id) = bob
-        .insert(
-            "people",
-            table_rename_values_v2(user_id, "bob@example.com"),
-            None,
-        )
+        .insert("people", table_rename_values_v2(user_id, "bob@example.com"))
         .expect("bob creates v2 person");
     bob.wait_for_batch(batch_id, DurabilityTier::EdgeServer)
         .await
@@ -1824,7 +1806,6 @@ async fn table_rename_update_and_delete_copy_on_write() {
         .insert(
             "users",
             table_rename_values_v1(user_id, "alice@example.com"),
-            None,
         )
         .expect("alice creates v1 user");
     alice
@@ -1846,7 +1827,6 @@ async fn table_rename_update_and_delete_copy_on_write() {
                 "email".to_string(),
                 Value::Text("alice+updated@example.com".to_string()),
             )],
-            None,
         )
         .expect("bob updates renamed row");
     bob.wait_for_batch(batch_id, DurabilityTier::EdgeServer)
@@ -1875,7 +1855,7 @@ async fn table_rename_update_and_delete_copy_on_write() {
     .await;
     assert_eq!(rows_after_update.len(), 1);
 
-    let batch_id = bob.delete(row_id, None).expect("bob deletes renamed row");
+    let batch_id = bob.delete(row_id).expect("bob deletes renamed row");
     bob.wait_for_batch(batch_id, DurabilityTier::EdgeServer)
         .await
         .expect("bob delete reaches edge");
@@ -1929,11 +1909,7 @@ async fn table_rename_join_query_translates_join_target_on_old_branch() {
 
     let author_id = jazz_tools::ObjectId::new();
     let (_, _, batch_id) = alice
-        .insert(
-            "users",
-            table_rename_join_user_values(author_id, "Alice"),
-            None,
-        )
+        .insert("users", table_rename_join_user_values(author_id, "Alice"))
         .expect("alice creates v1 user");
     alice
         .wait_for_batch(batch_id, DurabilityTier::EdgeServer)
@@ -1945,7 +1921,6 @@ async fn table_rename_join_query_translates_join_target_on_old_branch() {
         .insert(
             "posts",
             table_rename_join_post_values(post_id, author_id, "Hello from v1"),
-            None,
         )
         .expect("alice creates v1 post");
     alice
@@ -2023,11 +1998,7 @@ async fn table_rename_fk_array_lookup_finds_related_rows_on_old_branch() {
 
     let author_id = jazz_tools::ObjectId::new();
     let (author_row_id, _, batch_id) = alice
-        .insert(
-            "users",
-            table_rename_join_user_values(author_id, "Alice"),
-            None,
-        )
+        .insert("users", table_rename_join_user_values(author_id, "Alice"))
         .expect("alice creates v1 user");
     alice
         .wait_for_batch(batch_id, DurabilityTier::EdgeServer)
@@ -2039,7 +2010,6 @@ async fn table_rename_fk_array_lookup_finds_related_rows_on_old_branch() {
         .insert(
             "posts",
             table_rename_join_post_values(post_id, author_id, "Alice post"),
-            None,
         )
         .expect("alice creates v1 post");
     alice
@@ -2126,7 +2096,6 @@ async fn multi_hop_table_renames_and_column_rename() {
         .insert(
             "users",
             multi_hop_table_rename_values_v1(alice_id, "alice@example.com"),
-            None,
         )
         .expect("alice creates v1 user");
     alice
@@ -2152,7 +2121,6 @@ async fn multi_hop_table_renames_and_column_rename() {
         .insert(
             "people",
             multi_hop_table_rename_values_v2(bob_id, "bob@example.com"),
-            None,
         )
         .expect("bob creates v2 person");
     bob.wait_for_batch(batch_id, DurabilityTier::EdgeServer)
@@ -2177,7 +2145,6 @@ async fn multi_hop_table_renames_and_column_rename() {
         .insert(
             "members",
             multi_hop_table_rename_values_v3(carol_id, "carol@example.com"),
-            None,
         )
         .expect("carol creates v3 member");
     carol

--- a/crates/jazz-tools/tests/catalogue_sync_integration.rs
+++ b/crates/jazz-tools/tests/catalogue_sync_integration.rs
@@ -1364,7 +1364,7 @@ async fn cannot_read_from_old_schema_until_lens_is_added() {
 }
 
 #[tokio::test]
-async fn draft_lens_does_make_rows_from_old_schema_visible() {
+async fn draft_lens_does_not_make_rows_from_old_schema_visible() {
     let server = TestingServer::start().await;
     let v1_schema = draft_lens_schema_v1();
     let v2_schema = draft_lens_schema_v2();

--- a/crates/jazz-tools/tests/catalogue_sync_integration.rs
+++ b/crates/jazz-tools/tests/catalogue_sync_integration.rs
@@ -43,6 +43,10 @@ fn user_values_v3(
     row_input!("id" => id, "name" => name, "email" => email, "role" => role)
 }
 
+fn draft_lens_values_v1(id: jazz_tools::ObjectId) -> HashMap<String, Value> {
+    row_input!("id" => id)
+}
+
 fn schema_v1() -> jazz_tools::Schema {
     SchemaBuilder::new()
         .table(
@@ -82,6 +86,26 @@ fn v1_to_v2_lens() -> Lens {
 
 fn v2_to_v3_lens() -> Lens {
     generate_lens(&schema_v2(), &schema_v3())
+}
+
+fn draft_lens_schema_v1() -> jazz_tools::Schema {
+    SchemaBuilder::new()
+        .table(TableSchema::builder("users").column("id", ColumnType::Uuid))
+        .build()
+}
+
+fn draft_lens_schema_v2() -> jazz_tools::Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("users")
+                .column("id", ColumnType::Uuid)
+                .column("org_id", ColumnType::Uuid),
+        )
+        .build()
+}
+
+fn draft_lens_v1_to_v2() -> Lens {
+    generate_lens(&draft_lens_schema_v1(), &draft_lens_schema_v2())
 }
 
 fn rename_chain_values_v1(id: jazz_tools::ObjectId, email: &str) -> HashMap<String, Value> {
@@ -320,6 +344,51 @@ fn multi_hop_table_rename_v2_to_v3_lens() -> Lens {
     )
 }
 
+fn removed_readded_values_v1(id: jazz_tools::ObjectId, name: &str) -> HashMap<String, Value> {
+    row_input!("id" => id, "name" => name)
+}
+
+fn removed_readded_values_v3(
+    id: jazz_tools::ObjectId,
+    name: &str,
+    email: &str,
+) -> HashMap<String, Value> {
+    row_input!("id" => id, "name" => name, "email" => email)
+}
+
+fn removed_readded_schema_v1() -> jazz_tools::Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("users")
+                .column("id", ColumnType::Uuid)
+                .column("name", ColumnType::Text),
+        )
+        .build()
+}
+
+fn removed_readded_schema_v2() -> jazz_tools::Schema {
+    SchemaBuilder::new().build()
+}
+
+fn removed_readded_schema_v3() -> jazz_tools::Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("users")
+                .column("id", ColumnType::Uuid)
+                .column("name", ColumnType::Text)
+                .nullable_column("email", ColumnType::Text),
+        )
+        .build()
+}
+
+fn removed_readded_v1_to_v2_lens() -> Lens {
+    generate_lens(&removed_readded_schema_v1(), &removed_readded_schema_v2())
+}
+
+fn removed_readded_v2_to_v3_lens() -> Lens {
+    generate_lens(&removed_readded_schema_v2(), &removed_readded_schema_v3())
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct PublishSchemaHttpResponse {
@@ -365,6 +434,36 @@ async fn seed_schema_catalogue(server: &TestingServer, schema: &jazz_tools::Sche
     )
     .await
     .expect("push schema catalogue");
+}
+
+async fn assert_edge_query_does_not_include_row(
+    client: &JazzClient,
+    query: jazz_tools::Query,
+    row_id: jazz_tools::ObjectId,
+    timeout: Duration,
+    description: &str,
+) {
+    let deadline = tokio::time::Instant::now() + timeout;
+
+    loop {
+        if let Ok(Ok(rows)) = tokio::time::timeout(
+            Duration::from_millis(500),
+            client.query(query.clone(), Some(DurabilityTier::EdgeServer)),
+        )
+        .await
+        {
+            assert!(
+                rows.iter().all(|(id, _)| *id != row_id),
+                "{description}: query unexpectedly included row {row_id}; rows: {rows:?}"
+            );
+        }
+
+        if tokio::time::Instant::now() >= deadline {
+            return;
+        }
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
 }
 
 // Test topology:
@@ -1150,6 +1249,194 @@ async fn column_addition_new_client_can_read_old_rows() {
         Value::Null,
         "email should be null (default from lens transform)"
     );
+
+    alice.shutdown().await.expect("shutdown alice");
+    bob.shutdown().await.expect("shutdown bob");
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn cannot_read_from_old_schema_until_lens_is_added() {
+    let server = TestingServer::start().await;
+    let v1_schema = schema_v1();
+    let v2_schema = schema_v2();
+
+    push_catalogue_in_memory(
+        server.server_state(),
+        server.app_id(),
+        "dev",
+        "main",
+        std::slice::from_ref(&v1_schema),
+        &[],
+    )
+    .await
+    .expect("push initial v1 catalogue");
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &v1_schema,
+    )
+    .await;
+
+    let alice = JazzClient::connect(
+        server.make_client_context_for_user(v1_schema.clone(), "alice-schema-before-lens"),
+    )
+    .await
+    .expect("connect alice");
+    wait_for_edge_query_ready(&alice, "users", Duration::from_secs(30)).await;
+
+    let user_id = jazz_tools::ObjectId::new();
+    let (row_id, _, batch_id) = alice
+        .insert("users", user_values_v1(user_id, "Alice Pending Lens"))
+        .expect("alice creates v1 user");
+    alice
+        .wait_for_batch(batch_id, DurabilityTier::EdgeServer)
+        .await
+        .expect("alice user reaches edge");
+
+    push_catalogue_in_memory(
+        server.server_state(),
+        server.app_id(),
+        "dev",
+        "main",
+        &[v1_schema.clone(), v2_schema.clone()],
+        &[],
+    )
+    .await
+    .expect("push v2 schema without lens");
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &v2_schema,
+    )
+    .await;
+
+    let bob = JazzClient::connect(
+        server.make_client_context_for_user(v2_schema.clone(), "bob-schema-before-lens"),
+    )
+    .await
+    .expect("connect bob");
+    let query = QueryBuilder::new("users").build();
+    assert_edge_query_does_not_include_row(
+        &bob,
+        query.clone(),
+        row_id,
+        Duration::from_secs(2),
+        "bob should not see v1 row before the lens arrives",
+    )
+    .await;
+
+    push_catalogue_in_memory(
+        server.server_state(),
+        server.app_id(),
+        "dev",
+        "main",
+        &[v1_schema, v2_schema],
+        &[v1_to_v2_lens()],
+    )
+    .await
+    .expect("push v1 to v2 lens");
+    wait_for_edge_query_ready(&bob, "users", Duration::from_secs(30)).await;
+
+    let rows = wait_for_query(
+        &bob,
+        query,
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "bob sees alice row after lens arrives",
+        |rows| (rows.len() == 1 && rows[0].0 == row_id).then_some(rows),
+    )
+    .await;
+    assert_eq!(
+        rows[0].1,
+        vec![
+            Value::Uuid(user_id),
+            Value::Text("Alice Pending Lens".to_string()),
+            Value::Null,
+        ]
+    );
+
+    alice.shutdown().await.expect("shutdown alice");
+    bob.shutdown().await.expect("shutdown bob");
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn draft_lens_does_make_rows_from_old_schema_visible() {
+    let server = TestingServer::start().await;
+    let v1_schema = draft_lens_schema_v1();
+    let v2_schema = draft_lens_schema_v2();
+    let draft_lens = draft_lens_v1_to_v2();
+    assert!(
+        draft_lens.is_draft(),
+        "test fixture should use a draft lens"
+    );
+
+    push_catalogue_in_memory(
+        server.server_state(),
+        server.app_id(),
+        "dev",
+        "main",
+        std::slice::from_ref(&v1_schema),
+        &[],
+    )
+    .await
+    .expect("push initial draft-lens v1 catalogue");
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &v1_schema,
+    )
+    .await;
+
+    let alice = JazzClient::connect(
+        server.make_client_context_for_user(v1_schema.clone(), "alice-draft-lens"),
+    )
+    .await
+    .expect("connect alice");
+    wait_for_edge_query_ready(&alice, "users", Duration::from_secs(30)).await;
+
+    let user_id = jazz_tools::ObjectId::new();
+    let (row_id, _, batch_id) = alice
+        .insert("users", draft_lens_values_v1(user_id))
+        .expect("alice creates v1 user");
+    alice
+        .wait_for_batch(batch_id, DurabilityTier::EdgeServer)
+        .await
+        .expect("alice user reaches edge");
+
+    push_catalogue_in_memory(
+        server.server_state(),
+        server.app_id(),
+        "dev",
+        "main",
+        &[v1_schema, v2_schema.clone()],
+        &[draft_lens],
+    )
+    .await
+    .expect("push v2 schema with draft lens");
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &v2_schema,
+    )
+    .await;
+
+    let bob = JazzClient::connect(server.make_client_context_for_user(v2_schema, "bob-draft-lens"))
+        .await
+        .expect("connect bob");
+    assert_edge_query_does_not_include_row(
+        &bob,
+        QueryBuilder::new("users").build(),
+        row_id,
+        Duration::from_secs(2),
+        "bob should not see v1 row through a draft lens",
+    )
+    .await;
 
     alice.shutdown().await.expect("shutdown alice");
     bob.shutdown().await.expect("shutdown bob");
@@ -2191,6 +2478,112 @@ async fn multi_hop_table_renames_and_column_rename() {
     alice.shutdown().await.expect("shutdown alice");
     bob.shutdown().await.expect("shutdown bob");
     carol.shutdown().await.expect("shutdown carol");
+    server.shutdown().await;
+}
+
+/// A table name reused after the table was removed is a new lineage. A v3
+/// `users` query must not resurface rows from the v1 `users` table that was
+/// removed in v2.
+#[tokio::test]
+async fn removed_table_then_readded_does_not_resurface_old_rows() {
+    let server = TestingServer::start().await;
+    let v1_schema = removed_readded_schema_v1();
+    let v2_schema = removed_readded_schema_v2();
+    let v3_schema = removed_readded_schema_v3();
+
+    push_catalogue_in_memory(
+        server.server_state(),
+        server.app_id(),
+        "dev",
+        "main",
+        &[v1_schema.clone(), v2_schema, v3_schema.clone()],
+        &[
+            removed_readded_v1_to_v2_lens(),
+            removed_readded_v2_to_v3_lens(),
+        ],
+    )
+    .await
+    .expect("push removed/re-added table catalogue");
+
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &v1_schema,
+    )
+    .await;
+
+    let alice = JazzClient::connect(
+        server.make_client_context_for_user(v1_schema, "alice-removed-readded-v1"),
+    )
+    .await
+    .expect("connect alice");
+    wait_for_edge_query_ready(&alice, "users", Duration::from_secs(30)).await;
+
+    let alice_id = jazz_tools::ObjectId::new();
+    let (alice_row_id, _, batch_id) = alice
+        .insert(
+            "users",
+            removed_readded_values_v1(alice_id, "Alice Old Lineage"),
+        )
+        .expect("alice creates v1 user");
+    alice
+        .wait_for_batch(batch_id, DurabilityTier::EdgeServer)
+        .await
+        .expect("alice row reaches edge");
+
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &v3_schema,
+    )
+    .await;
+
+    let bob = JazzClient::connect(
+        server.make_client_context_for_user(v3_schema, "bob-removed-readded-v3"),
+    )
+    .await
+    .expect("connect bob");
+    wait_for_edge_query_ready(&bob, "users", Duration::from_secs(30)).await;
+
+    let bob_id = jazz_tools::ObjectId::new();
+    let (bob_row_id, _, batch_id) = bob
+        .insert(
+            "users",
+            removed_readded_values_v3(bob_id, "Bob New Lineage", "bob@example.com"),
+        )
+        .expect("bob creates v3 user");
+    bob.wait_for_batch(batch_id, DurabilityTier::EdgeServer)
+        .await
+        .expect("bob row reaches edge");
+
+    let rows = wait_for_query(
+        &bob,
+        QueryBuilder::new("users").build(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "v3 users query only sees rows from the re-added table lineage",
+        |rows| {
+            (rows.len() == 1
+                && rows[0].0 == bob_row_id
+                && rows.iter().all(|(id, _)| *id != alice_row_id))
+            .then_some(rows)
+        },
+    )
+    .await;
+
+    assert_eq!(
+        rows[0].1,
+        vec![
+            Value::Uuid(bob_id),
+            Value::Text("Bob New Lineage".to_string()),
+            Value::Text("bob@example.com".to_string()),
+        ]
+    );
+
+    alice.shutdown().await.expect("shutdown alice");
+    bob.shutdown().await.expect("shutdown bob");
     server.shutdown().await;
 }
 

--- a/crates/jazz-tools/tests/catalogue_sync_integration.rs
+++ b/crates/jazz-tools/tests/catalogue_sync_integration.rs
@@ -11,7 +11,8 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use jazz_tools::query_manager::types::SchemaHash;
-use jazz_tools::schema_manager::{Lens, generate_lens};
+use jazz_tools::row_input;
+use jazz_tools::schema_manager::{Lens, LensOp, LensTransform, generate_lens};
 use jazz_tools::server::TestingServer;
 use jazz_tools::{
     ColumnType, DurabilityTier, JazzClient, QueryBuilder, SchemaBuilder, TableSchema, Value,
@@ -26,18 +27,20 @@ use support::{
 };
 
 fn user_values_v1(id: jazz_tools::ObjectId, name: &str) -> HashMap<String, Value> {
-    HashMap::from([
-        ("id".to_string(), Value::Uuid(id)),
-        ("name".to_string(), Value::Text(name.to_string())),
-    ])
+    row_input!("id" => id, "name" => name)
 }
 
 fn user_values_v2(id: jazz_tools::ObjectId, name: &str, email: &str) -> HashMap<String, Value> {
-    HashMap::from([
-        ("id".to_string(), Value::Uuid(id)),
-        ("name".to_string(), Value::Text(name.to_string())),
-        ("email".to_string(), Value::Text(email.to_string())),
-    ])
+    row_input!("id" => id, "name" => name, "email" => email)
+}
+
+fn user_values_v3(
+    id: jazz_tools::ObjectId,
+    name: &str,
+    email: &str,
+    role: &str,
+) -> HashMap<String, Value> {
+    row_input!("id" => id, "name" => name, "email" => email, "role" => role)
 }
 
 fn schema_v1() -> jazz_tools::Schema {
@@ -61,8 +64,260 @@ fn schema_v2() -> jazz_tools::Schema {
         .build()
 }
 
+fn schema_v3() -> jazz_tools::Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("users")
+                .column("id", ColumnType::Uuid)
+                .column("name", ColumnType::Text)
+                .nullable_column("email", ColumnType::Text)
+                .nullable_column("role", ColumnType::Text),
+        )
+        .build()
+}
+
 fn v1_to_v2_lens() -> Lens {
     generate_lens(&schema_v1(), &schema_v2())
+}
+
+fn v2_to_v3_lens() -> Lens {
+    generate_lens(&schema_v2(), &schema_v3())
+}
+
+fn rename_chain_values_v1(id: jazz_tools::ObjectId, email: &str) -> HashMap<String, Value> {
+    row_input!("id" => id, "email" => email)
+}
+
+fn rename_chain_values_v3(id: jazz_tools::ObjectId, contact_email: &str) -> HashMap<String, Value> {
+    row_input!("id" => id, "contact_email" => contact_email)
+}
+
+fn rename_chain_schema_v1() -> jazz_tools::Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("users")
+                .column("id", ColumnType::Uuid)
+                .column("email", ColumnType::Text),
+        )
+        .build()
+}
+
+fn rename_chain_schema_v2() -> jazz_tools::Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("users")
+                .column("id", ColumnType::Uuid)
+                .column("email_address", ColumnType::Text),
+        )
+        .build()
+}
+
+fn rename_chain_schema_v3() -> jazz_tools::Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("users")
+                .column("id", ColumnType::Uuid)
+                .column("contact_email", ColumnType::Text),
+        )
+        .build()
+}
+
+fn rename_chain_v1_to_v2_lens() -> Lens {
+    Lens::new(
+        SchemaHash::compute(&rename_chain_schema_v1()),
+        SchemaHash::compute(&rename_chain_schema_v2()),
+        LensTransform::with_ops(vec![LensOp::RenameColumn {
+            table: "users".to_string(),
+            old_name: "email".to_string(),
+            new_name: "email_address".to_string(),
+        }]),
+    )
+}
+
+fn rename_chain_v2_to_v3_lens() -> Lens {
+    Lens::new(
+        SchemaHash::compute(&rename_chain_schema_v2()),
+        SchemaHash::compute(&rename_chain_schema_v3()),
+        LensTransform::with_ops(vec![LensOp::RenameColumn {
+            table: "users".to_string(),
+            old_name: "email_address".to_string(),
+            new_name: "contact_email".to_string(),
+        }]),
+    )
+}
+
+fn table_rename_values_v1(id: jazz_tools::ObjectId, email: &str) -> HashMap<String, Value> {
+    row_input!("id" => id, "email" => email)
+}
+
+fn table_rename_values_v2(id: jazz_tools::ObjectId, email: &str) -> HashMap<String, Value> {
+    row_input!("id" => id, "email" => email)
+}
+
+fn table_rename_schema_v1() -> jazz_tools::Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("users")
+                .column("id", ColumnType::Uuid)
+                .column("email", ColumnType::Text),
+        )
+        .build()
+}
+
+fn table_rename_schema_v2() -> jazz_tools::Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("people")
+                .column("id", ColumnType::Uuid)
+                .column("email", ColumnType::Text),
+        )
+        .build()
+}
+
+fn table_rename_v1_to_v2_lens() -> Lens {
+    Lens::new(
+        SchemaHash::compute(&table_rename_schema_v1()),
+        SchemaHash::compute(&table_rename_schema_v2()),
+        LensTransform::with_ops(vec![LensOp::RenameTable {
+            old_name: "users".to_string(),
+            new_name: "people".to_string(),
+        }]),
+    )
+}
+
+fn table_rename_join_user_values(id: jazz_tools::ObjectId, name: &str) -> HashMap<String, Value> {
+    row_input!("id" => id, "name" => name)
+}
+
+fn table_rename_join_post_values(
+    id: jazz_tools::ObjectId,
+    author_id: jazz_tools::ObjectId,
+    title: &str,
+) -> HashMap<String, Value> {
+    row_input!("id" => id, "author_id" => author_id, "title" => title)
+}
+
+fn table_rename_join_schema_v1() -> jazz_tools::Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("users")
+                .column("id", ColumnType::Uuid)
+                .column("name", ColumnType::Text),
+        )
+        .table(
+            TableSchema::builder("posts")
+                .column("id", ColumnType::Uuid)
+                .fk_column("author_id", "users")
+                .column("title", ColumnType::Text),
+        )
+        .build()
+}
+
+fn table_rename_join_schema_v2() -> jazz_tools::Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("people")
+                .column("id", ColumnType::Uuid)
+                .column("name", ColumnType::Text),
+        )
+        .table(
+            TableSchema::builder("posts")
+                .column("id", ColumnType::Uuid)
+                .fk_column("author_id", "people")
+                .column("title", ColumnType::Text),
+        )
+        .build()
+}
+
+fn table_rename_join_v1_to_v2_lens() -> Lens {
+    Lens::new(
+        SchemaHash::compute(&table_rename_join_schema_v1()),
+        SchemaHash::compute(&table_rename_join_schema_v2()),
+        LensTransform::with_ops(vec![LensOp::RenameTable {
+            old_name: "users".to_string(),
+            new_name: "people".to_string(),
+        }]),
+    )
+}
+
+fn multi_hop_table_rename_values_v1(
+    id: jazz_tools::ObjectId,
+    email: &str,
+) -> HashMap<String, Value> {
+    row_input!("id" => id, "email" => email)
+}
+
+fn multi_hop_table_rename_values_v2(
+    id: jazz_tools::ObjectId,
+    email: &str,
+) -> HashMap<String, Value> {
+    row_input!("id" => id, "email" => email)
+}
+
+fn multi_hop_table_rename_values_v3(
+    id: jazz_tools::ObjectId,
+    email_address: &str,
+) -> HashMap<String, Value> {
+    row_input!("id" => id, "email_address" => email_address)
+}
+
+fn multi_hop_table_rename_schema_v1() -> jazz_tools::Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("users")
+                .column("id", ColumnType::Uuid)
+                .column("email", ColumnType::Text),
+        )
+        .build()
+}
+
+fn multi_hop_table_rename_schema_v2() -> jazz_tools::Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("people")
+                .column("id", ColumnType::Uuid)
+                .column("email", ColumnType::Text),
+        )
+        .build()
+}
+
+fn multi_hop_table_rename_schema_v3() -> jazz_tools::Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("members")
+                .column("id", ColumnType::Uuid)
+                .column("email_address", ColumnType::Text),
+        )
+        .build()
+}
+
+fn multi_hop_table_rename_v1_to_v2_lens() -> Lens {
+    Lens::new(
+        SchemaHash::compute(&multi_hop_table_rename_schema_v1()),
+        SchemaHash::compute(&multi_hop_table_rename_schema_v2()),
+        LensTransform::with_ops(vec![LensOp::RenameTable {
+            old_name: "users".to_string(),
+            new_name: "people".to_string(),
+        }]),
+    )
+}
+
+fn multi_hop_table_rename_v2_to_v3_lens() -> Lens {
+    Lens::new(
+        SchemaHash::compute(&multi_hop_table_rename_schema_v2()),
+        SchemaHash::compute(&multi_hop_table_rename_schema_v3()),
+        LensTransform::with_ops(vec![
+            LensOp::RenameTable {
+                old_name: "people".to_string(),
+                new_name: "members".to_string(),
+            },
+            LensOp::RenameColumn {
+                table: "members".to_string(),
+                old_name: "email".to_string(),
+                new_name: "email_address".to_string(),
+            },
+        ]),
+    )
 }
 
 #[derive(Debug, Deserialize)]
@@ -818,7 +1073,7 @@ async fn dynamic_server_live_subscription_replays_on_first_permissions_head_and_
 ///                                └──► user row with email: null
 /// ```
 #[tokio::test]
-async fn catalogue_sync_e2e_schema_evolution_through_sync_manager() {
+async fn column_addition_new_client_can_read_old_rows() {
     let server = TestingServer::start().await;
     let target_schema = schema_v2();
 
@@ -901,6 +1156,1079 @@ async fn catalogue_sync_e2e_schema_evolution_through_sync_manager() {
     server.shutdown().await;
 }
 
+/// Alice writes under schema v1, Bob writes under schema v2, and Charlie reads
+/// under schema v3 after the server has received both migration edges. Charlie
+/// must see every row projected into the v3 shape.
+///
+/// ```text
+/// push v1 + v2 + v3 schemas and v1→v2→v3 lenses ──► server
+///                                                       │
+/// alice (v1) ──create user─────────────────────────────►│
+/// bob   (v2) ──create user with email──────────────────►│
+/// charlie (v3) ──create user with email + role─────────►│
+///                                                       │
+/// charlie (v3) query ──► Alice(email=null, role=null)
+///                        Bob(email=value, role=null)
+///                        Charlie(email=value, role=value)
+/// ```
+#[tokio::test]
+async fn multi_hop_column_additions_new_client_can_read_old_rows() {
+    let server = TestingServer::start().await;
+    let v3_schema = schema_v3();
+
+    push_catalogue_in_memory(
+        server.server_state(),
+        server.app_id(),
+        "dev",
+        "main",
+        &[schema_v1(), schema_v2(), v3_schema.clone()],
+        &[v1_to_v2_lens(), v2_to_v3_lens()],
+    )
+    .await
+    .expect("push multi-hop catalogue");
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &v3_schema,
+    )
+    .await;
+
+    let alice =
+        JazzClient::connect(server.make_client_context_for_user(schema_v1(), "alice-multi-hop"))
+            .await
+            .expect("connect alice");
+    wait_for_edge_query_ready(&alice, "users", Duration::from_secs(30)).await;
+    let alice_user_id = jazz_tools::ObjectId::new();
+    let (alice_row_id, _, alice_batch_id) = alice
+        .insert(
+            "users",
+            user_values_v1(alice_user_id, "Alice Multi-Hop"),
+            None,
+        )
+        .expect("alice creates v1 user");
+    alice
+        .wait_for_batch(alice_batch_id, DurabilityTier::EdgeServer)
+        .await
+        .expect("alice user reaches edge");
+
+    let bob =
+        JazzClient::connect(server.make_client_context_for_user(schema_v2(), "bob-multi-hop"))
+            .await
+            .expect("connect bob");
+    wait_for_edge_query_ready(&bob, "users", Duration::from_secs(30)).await;
+    let bob_user_id = jazz_tools::ObjectId::new();
+    let (bob_row_id, _, bob_batch_id) = bob
+        .insert(
+            "users",
+            user_values_v2(bob_user_id, "Bob Multi-Hop", "bob@example.com"),
+            None,
+        )
+        .expect("bob creates v2 user");
+    bob.wait_for_batch(bob_batch_id, DurabilityTier::EdgeServer)
+        .await
+        .expect("bob user reaches edge");
+
+    let charlie =
+        JazzClient::connect(server.make_client_context_for_user(v3_schema, "charlie-multi-hop"))
+            .await
+            .expect("connect charlie");
+    wait_for_edge_query_ready(&charlie, "users", Duration::from_secs(30)).await;
+    let charlie_user_id = jazz_tools::ObjectId::new();
+    let (charlie_row_id, _, charlie_batch_id) = charlie
+        .insert(
+            "users",
+            user_values_v3(
+                charlie_user_id,
+                "Charlie Multi-Hop",
+                "charlie@example.com",
+                "admin",
+            ),
+            None,
+        )
+        .expect("charlie creates v3 user");
+    charlie
+        .wait_for_batch(charlie_batch_id, DurabilityTier::EdgeServer)
+        .await
+        .expect("charlie user reaches edge");
+
+    let rows = wait_for_query(
+        &charlie,
+        QueryBuilder::new("users").build(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "charlie sees all rows transformed to v3",
+        |rows| {
+            (rows.len() == 3
+                && rows.iter().any(|(id, _)| *id == alice_row_id)
+                && rows.iter().any(|(id, _)| *id == bob_row_id)
+                && rows.iter().any(|(id, _)| *id == charlie_row_id))
+            .then_some(rows)
+        },
+    )
+    .await;
+
+    let alice_row = rows
+        .iter()
+        .find(|(id, _)| *id == alice_row_id)
+        .expect("alice row should be present");
+    assert_eq!(
+        alice_row.1,
+        vec![
+            Value::Uuid(alice_user_id),
+            Value::Text("Alice Multi-Hop".to_string()),
+            Value::Null,
+            Value::Null,
+        ]
+    );
+
+    let bob_row = rows
+        .iter()
+        .find(|(id, _)| *id == bob_row_id)
+        .expect("bob row should be present");
+    assert_eq!(
+        bob_row.1,
+        vec![
+            Value::Uuid(bob_user_id),
+            Value::Text("Bob Multi-Hop".to_string()),
+            Value::Text("bob@example.com".to_string()),
+            Value::Null,
+        ]
+    );
+
+    let charlie_row = rows
+        .iter()
+        .find(|(id, _)| *id == charlie_row_id)
+        .expect("charlie row should be present");
+    assert_eq!(
+        charlie_row.1,
+        vec![
+            Value::Uuid(charlie_user_id),
+            Value::Text("Charlie Multi-Hop".to_string()),
+            Value::Text("charlie@example.com".to_string()),
+            Value::Text("admin".to_string()),
+        ]
+    );
+
+    alice.shutdown().await.expect("shutdown alice");
+    bob.shutdown().await.expect("shutdown bob");
+    charlie.shutdown().await.expect("shutdown charlie");
+    server.shutdown().await;
+}
+
+/// Alice writes under schema v1 with `email`. Bob reads under schema v3 where
+/// the column has been renamed twice: `email` -> `email_address` ->
+/// `contact_email`.
+///
+/// ```text
+/// push v1 + v2 + v3 schemas and rename lenses ──► server
+///                                                    │
+/// alice (v1) ──create user(email)───────────────────►│
+///                                                    │
+/// bob (v3) query ──► user row with contact_email value
+/// ```
+#[tokio::test]
+async fn multi_hop_column_renames_new_client_can_read_old_rows() {
+    let server = TestingServer::start().await;
+    let v1_schema = rename_chain_schema_v1();
+    let v2_schema = rename_chain_schema_v2();
+    let v3_schema = rename_chain_schema_v3();
+
+    push_catalogue_in_memory(
+        server.server_state(),
+        server.app_id(),
+        "dev",
+        "main",
+        &[v1_schema.clone(), v2_schema, v3_schema.clone()],
+        &[rename_chain_v1_to_v2_lens(), rename_chain_v2_to_v3_lens()],
+    )
+    .await
+    .expect("push rename-chain catalogue");
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &v3_schema,
+    )
+    .await;
+
+    let alice =
+        JazzClient::connect(server.make_client_context_for_user(v1_schema, "alice-rename-chain"))
+            .await
+            .expect("connect alice");
+    wait_for_edge_query_ready(&alice, "users", Duration::from_secs(30)).await;
+
+    let user_id = jazz_tools::ObjectId::new();
+    let (row_id, _, batch_id) = alice
+        .insert(
+            "users",
+            rename_chain_values_v1(user_id, "alice@example.com"),
+            None,
+        )
+        .expect("alice creates v1 user");
+    alice
+        .wait_for_batch(batch_id, DurabilityTier::EdgeServer)
+        .await
+        .expect("alice user reaches edge");
+
+    let bob =
+        JazzClient::connect(server.make_client_context_for_user(v3_schema, "bob-rename-chain"))
+            .await
+            .expect("connect bob");
+    wait_for_edge_query_ready(&bob, "users", Duration::from_secs(30)).await;
+
+    let rows = wait_for_query(
+        &bob,
+        QueryBuilder::new("users").build(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "bob sees alice row through chained column renames",
+        |rows| (rows.len() == 1 && rows[0].0 == row_id).then_some(rows),
+    )
+    .await;
+
+    assert_eq!(
+        rows[0].1,
+        vec![
+            Value::Uuid(user_id),
+            Value::Text("alice@example.com".to_string()),
+        ]
+    );
+
+    alice.shutdown().await.expect("shutdown alice");
+    bob.shutdown().await.expect("shutdown bob");
+    server.shutdown().await;
+}
+
+/// Bob writes under schema v3 with `contact_email`. Alice reads under schema
+/// v1 where the column was originally named `email`.
+///
+/// ```text
+/// push v1 + v2 + v3 schemas and rename lenses ──► server
+///                                                    │
+/// bob (v3) ──create user(contact_email)─────────────►│
+///                                                    │
+/// alice (v1) query ──► user row with email value
+/// ```
+#[tokio::test]
+async fn multi_hop_column_renames_old_client_can_read_new_rows() {
+    let server = TestingServer::start().await;
+    let v1_schema = rename_chain_schema_v1();
+    let v2_schema = rename_chain_schema_v2();
+    let v3_schema = rename_chain_schema_v3();
+
+    push_catalogue_in_memory(
+        server.server_state(),
+        server.app_id(),
+        "dev",
+        "main",
+        &[v1_schema.clone(), v2_schema, v3_schema.clone()],
+        &[rename_chain_v1_to_v2_lens(), rename_chain_v2_to_v3_lens()],
+    )
+    .await
+    .expect("push rename-chain catalogue");
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &v3_schema,
+    )
+    .await;
+
+    let bob =
+        JazzClient::connect(server.make_client_context_for_user(v3_schema, "bob-rename-chain-new"))
+            .await
+            .expect("connect bob");
+    wait_for_edge_query_ready(&bob, "users", Duration::from_secs(30)).await;
+
+    let user_id = jazz_tools::ObjectId::new();
+    let (row_id, _, batch_id) = bob
+        .insert(
+            "users",
+            rename_chain_values_v3(user_id, "bob@example.com"),
+            None,
+        )
+        .expect("bob creates v3 user");
+    bob.wait_for_batch(batch_id, DurabilityTier::EdgeServer)
+        .await
+        .expect("bob user reaches edge");
+
+    let alice = JazzClient::connect(
+        server.make_client_context_for_user(v1_schema, "alice-rename-chain-old"),
+    )
+    .await
+    .expect("connect alice");
+    wait_for_edge_query_ready(&alice, "users", Duration::from_secs(30)).await;
+
+    let rows = wait_for_query(
+        &alice,
+        QueryBuilder::new("users").build(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "alice sees bob row through chained column renames",
+        |rows| (rows.len() == 1 && rows[0].0 == row_id).then_some(rows),
+    )
+    .await;
+
+    assert_eq!(
+        rows[0].1,
+        vec![
+            Value::Uuid(user_id),
+            Value::Text("bob@example.com".to_string()),
+        ]
+    );
+
+    bob.shutdown().await.expect("shutdown bob");
+    alice.shutdown().await.expect("shutdown alice");
+    server.shutdown().await;
+}
+
+/// Alice writes under schema v1 to `users`. Bob reads under schema v2 where
+/// that table has been renamed to `people`.
+///
+/// ```text
+/// push v1 + v2 schemas and RenameTable users -> people ──► server
+///                                                          │
+/// alice (v1) ──create users row───────────────────────────►│
+///                                                          │
+/// bob (v2) query people ──► row from old users table
+/// ```
+#[tokio::test]
+async fn table_rename_new_client_can_read_old_rows() {
+    let server = TestingServer::start().await;
+    let v1_schema = table_rename_schema_v1();
+    let v2_schema = table_rename_schema_v2();
+
+    push_catalogue_in_memory(
+        server.server_state(),
+        server.app_id(),
+        "dev",
+        "main",
+        &[v1_schema.clone(), v2_schema.clone()],
+        &[table_rename_v1_to_v2_lens()],
+    )
+    .await
+    .expect("push table-rename catalogue");
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &v1_schema,
+    )
+    .await;
+
+    let alice =
+        JazzClient::connect(server.make_client_context_for_user(v1_schema, "alice-table-rename"))
+            .await
+            .expect("connect alice");
+    wait_for_edge_query_ready(&alice, "users", Duration::from_secs(30)).await;
+
+    let user_id = jazz_tools::ObjectId::new();
+    let (row_id, _, batch_id) = alice
+        .insert(
+            "users",
+            table_rename_values_v1(user_id, "alice@example.com"),
+            None,
+        )
+        .expect("alice creates v1 user");
+    alice
+        .wait_for_batch(batch_id, DurabilityTier::EdgeServer)
+        .await
+        .expect("alice user reaches edge");
+
+    let bob =
+        JazzClient::connect(server.make_client_context_for_user(v2_schema, "bob-table-rename"))
+            .await
+            .expect("connect bob");
+    wait_for_edge_query_ready(&bob, "people", Duration::from_secs(30)).await;
+
+    let rows = wait_for_query(
+        &bob,
+        QueryBuilder::new("people").build(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "bob sees alice row through table rename",
+        |rows| (rows.len() == 1 && rows[0].0 == row_id).then_some(rows),
+    )
+    .await;
+
+    assert_eq!(
+        rows[0].1,
+        vec![
+            Value::Uuid(user_id),
+            Value::Text("alice@example.com".to_string()),
+        ]
+    );
+
+    alice.shutdown().await.expect("shutdown alice");
+    bob.shutdown().await.expect("shutdown bob");
+    server.shutdown().await;
+}
+
+/// Bob subscribes under schema v2 to `people`. Alice then writes under schema
+/// v1 to `users`, and Bob's subscription receives the row through the table
+/// rename lens.
+#[tokio::test]
+async fn table_rename_subscription_reacts_to_old_branch_updates() {
+    let server = TestingServer::start().await;
+    let v1_schema = table_rename_schema_v1();
+    let v2_schema = table_rename_schema_v2();
+
+    push_catalogue_in_memory(
+        server.server_state(),
+        server.app_id(),
+        "dev",
+        "main",
+        &[v1_schema.clone(), v2_schema.clone()],
+        &[table_rename_v1_to_v2_lens()],
+    )
+    .await
+    .expect("push table-rename catalogue");
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &v1_schema,
+    )
+    .await;
+
+    let bob =
+        JazzClient::connect(server.make_client_context_for_user(v2_schema, "bob-table-rename-sub"))
+            .await
+            .expect("connect bob");
+    wait_for_edge_query_ready(&bob, "people", Duration::from_secs(30)).await;
+
+    let query = QueryBuilder::new("people").build();
+    let mut stream = bob
+        .subscribe(query.clone())
+        .await
+        .expect("bob subscribes to people");
+    let mut log = Vec::new();
+    wait_for_subscription_update(
+        &mut stream,
+        &mut log,
+        Duration::from_secs(10),
+        "initial empty people subscription",
+        |updates| !updates.is_empty(),
+    )
+    .await;
+    assert!(
+        log[0].is_empty(),
+        "subscription should start empty before old-table rows are written"
+    );
+
+    let alice = JazzClient::connect(
+        server.make_client_context_for_user(v1_schema, "alice-table-rename-sub"),
+    )
+    .await
+    .expect("connect alice");
+    wait_for_edge_query_ready(&alice, "users", Duration::from_secs(30)).await;
+
+    let user_id = jazz_tools::ObjectId::new();
+    let (row_id, _, _) = alice
+        .insert(
+            "users",
+            table_rename_values_v1(user_id, "alice@example.com"),
+            None,
+        )
+        .expect("alice creates v1 user");
+
+    wait_for_subscription_update(
+        &mut stream,
+        &mut log,
+        Duration::from_secs(25),
+        "bob subscription sees alice row through table rename",
+        |updates| has_added(updates, row_id),
+    )
+    .await;
+
+    let rows = wait_for_query(
+        &bob,
+        query,
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "bob query sees subscription row through table rename",
+        |rows| (rows.len() == 1 && rows[0].0 == row_id).then_some(rows),
+    )
+    .await;
+    assert_eq!(
+        rows[0].1,
+        vec![
+            Value::Uuid(user_id),
+            Value::Text("alice@example.com".to_string()),
+        ]
+    );
+
+    alice.shutdown().await.expect("shutdown alice");
+    bob.shutdown().await.expect("shutdown bob");
+    server.shutdown().await;
+}
+
+/// Alice subscribes under schema v1 to `users`. The catalogue then evolves to
+/// schema v2 where that table is named `people`; when Bob writes to `people`,
+/// Alice's old subscription receives the row through the table rename lens.
+#[tokio::test]
+#[ignore = "TODO: existing old-table subscriptions do not receive new-table writes after table rename schema evolution"]
+async fn table_rename_subscription_reacts_to_new_branch_updates_after_schema_evolution() {
+    let server = TestingServer::start().await;
+    let v1_schema = table_rename_schema_v1();
+    let v2_schema = table_rename_schema_v2();
+
+    push_catalogue_in_memory(
+        server.server_state(),
+        server.app_id(),
+        "dev",
+        "main",
+        std::slice::from_ref(&v1_schema),
+        &[],
+    )
+    .await
+    .expect("push initial v1 table-rename catalogue");
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &v1_schema,
+    )
+    .await;
+
+    let alice = JazzClient::connect(
+        server.make_client_context_for_user(v1_schema.clone(), "alice-table-rename-evolve-sub"),
+    )
+    .await
+    .expect("connect alice");
+    wait_for_edge_query_ready(&alice, "users", Duration::from_secs(30)).await;
+
+    let query = QueryBuilder::new("users").build();
+    let mut stream = alice
+        .subscribe(query.clone())
+        .await
+        .expect("alice subscribes to users");
+    let mut log = Vec::new();
+    wait_for_subscription_update(
+        &mut stream,
+        &mut log,
+        Duration::from_secs(10),
+        "initial empty users subscription",
+        |updates| !updates.is_empty(),
+    )
+    .await;
+    assert!(
+        log[0].is_empty(),
+        "subscription should start empty before new-table rows are written"
+    );
+
+    push_catalogue_in_memory(
+        server.server_state(),
+        server.app_id(),
+        "dev",
+        "main",
+        &[v1_schema.clone(), v2_schema.clone()],
+        &[table_rename_v1_to_v2_lens()],
+    )
+    .await
+    .expect("push evolved table-rename catalogue");
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &v2_schema,
+    )
+    .await;
+    wait_for_edge_query_ready(&alice, "users", Duration::from_secs(30)).await;
+
+    let bob = JazzClient::connect(
+        server.make_client_context_for_user(v2_schema, "bob-table-rename-evolve-sub"),
+    )
+    .await
+    .expect("connect bob");
+    wait_for_edge_query_ready(&bob, "people", Duration::from_secs(30)).await;
+
+    let user_id = jazz_tools::ObjectId::new();
+    let (row_id, _, batch_id) = bob
+        .insert(
+            "people",
+            table_rename_values_v2(user_id, "bob@example.com"),
+            None,
+        )
+        .expect("bob creates v2 person");
+    bob.wait_for_batch(batch_id, DurabilityTier::EdgeServer)
+        .await
+        .expect("bob person reaches edge");
+
+    wait_for_subscription_update(
+        &mut stream,
+        &mut log,
+        Duration::from_secs(25),
+        "alice subscription sees bob row through table rename",
+        |updates| has_added(updates, row_id),
+    )
+    .await;
+
+    let rows = wait_for_query(
+        &alice,
+        query,
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "alice query sees new-table row through table rename",
+        |rows| (rows.len() == 1 && rows[0].0 == row_id).then_some(rows),
+    )
+    .await;
+    assert_eq!(
+        rows[0].1,
+        vec![
+            Value::Uuid(user_id),
+            Value::Text("bob@example.com".to_string()),
+        ]
+    );
+
+    bob.shutdown().await.expect("shutdown bob");
+    alice.shutdown().await.expect("shutdown alice");
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn table_rename_update_and_delete_copy_on_write() {
+    let server = TestingServer::start().await;
+    let v1_schema = table_rename_schema_v1();
+    let v2_schema = table_rename_schema_v2();
+    let v2_branch = format!("client-{}-main", SchemaHash::compute(&v2_schema).short());
+
+    push_catalogue_in_memory(
+        server.server_state(),
+        server.app_id(),
+        "dev",
+        "main",
+        &[v1_schema.clone(), v2_schema.clone()],
+        &[table_rename_v1_to_v2_lens()],
+    )
+    .await
+    .expect("push table-rename catalogue");
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &v1_schema,
+    )
+    .await;
+
+    let alice = JazzClient::connect(
+        server.make_client_context_for_user(v1_schema.clone(), "alice-table-rename-copy-on-write"),
+    )
+    .await
+    .expect("connect alice");
+    wait_for_edge_query_ready(&alice, "users", Duration::from_secs(30)).await;
+
+    let user_id = jazz_tools::ObjectId::new();
+    let (row_id, _, batch_id) = alice
+        .insert(
+            "users",
+            table_rename_values_v1(user_id, "alice@example.com"),
+            None,
+        )
+        .expect("alice creates v1 user");
+    alice
+        .wait_for_batch(batch_id, DurabilityTier::EdgeServer)
+        .await
+        .expect("alice user reaches edge");
+
+    let bob = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(v2_schema)
+        .with_user_id("bob-table-rename-copy-on-write")
+        .as_admin()
+        .ready_on("people", Duration::from_secs(30))
+        .connect()
+        .await;
+
+    let batch_id = bob
+        .update(
+            row_id,
+            vec![(
+                "email".to_string(),
+                Value::Text("alice+updated@example.com".to_string()),
+            )],
+            None,
+        )
+        .expect("bob updates renamed row");
+    bob.wait_for_batch(batch_id, DurabilityTier::EdgeServer)
+        .await
+        .expect("bob update reaches edge");
+
+    let rows_after_update = wait_for_query(
+        &bob,
+        QueryBuilder::new("people")
+            .branch(v2_branch.clone())
+            .build(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "bob sees copied row on renamed table after update",
+        |rows| {
+            (rows.len() == 1
+                && rows[0].0 == row_id
+                && rows[0].1
+                    == vec![
+                        Value::Uuid(user_id),
+                        Value::Text("alice+updated@example.com".to_string()),
+                    ])
+            .then_some(rows)
+        },
+    )
+    .await;
+    assert_eq!(rows_after_update.len(), 1);
+
+    let batch_id = bob.delete(row_id, None).expect("bob deletes renamed row");
+    bob.wait_for_batch(batch_id, DurabilityTier::EdgeServer)
+        .await
+        .expect("bob delete reaches edge");
+
+    let rows_after_delete = wait_for_query(
+        &bob,
+        QueryBuilder::new("people").branch(v2_branch).build(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "bob sees renamed row deleted",
+        |rows| rows.is_empty().then_some(rows),
+    )
+    .await;
+    assert!(rows_after_delete.is_empty());
+
+    alice.shutdown().await.expect("shutdown alice");
+    bob.shutdown().await.expect("shutdown bob");
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn table_rename_join_query_translates_join_target_on_old_branch() {
+    let server = TestingServer::start().await;
+    let v1_schema = table_rename_join_schema_v1();
+    let v2_schema = table_rename_join_schema_v2();
+
+    push_catalogue_in_memory(
+        server.server_state(),
+        server.app_id(),
+        "dev",
+        "main",
+        &[v1_schema.clone(), v2_schema.clone()],
+        &[table_rename_join_v1_to_v2_lens()],
+    )
+    .await
+    .expect("push join table-rename catalogue");
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &v1_schema,
+    )
+    .await;
+
+    let alice =
+        JazzClient::connect(server.make_client_context_for_user(v1_schema, "alice-join-rename"))
+            .await
+            .expect("connect alice");
+    wait_for_edge_query_ready(&alice, "users", Duration::from_secs(30)).await;
+    wait_for_edge_query_ready(&alice, "posts", Duration::from_secs(30)).await;
+
+    let author_id = jazz_tools::ObjectId::new();
+    let (_, _, batch_id) = alice
+        .insert(
+            "users",
+            table_rename_join_user_values(author_id, "Alice"),
+            None,
+        )
+        .expect("alice creates v1 user");
+    alice
+        .wait_for_batch(batch_id, DurabilityTier::EdgeServer)
+        .await
+        .expect("alice user reaches edge");
+
+    let post_id = jazz_tools::ObjectId::new();
+    let (post_row_id, _, batch_id) = alice
+        .insert(
+            "posts",
+            table_rename_join_post_values(post_id, author_id, "Hello from v1"),
+            None,
+        )
+        .expect("alice creates v1 post");
+    alice
+        .wait_for_batch(batch_id, DurabilityTier::EdgeServer)
+        .await
+        .expect("alice post reaches edge");
+
+    let bob =
+        JazzClient::connect(server.make_client_context_for_user(v2_schema, "bob-join-rename"))
+            .await
+            .expect("connect bob");
+    wait_for_edge_query_ready(&bob, "people", Duration::from_secs(30)).await;
+    wait_for_edge_query_ready(&bob, "posts", Duration::from_secs(30)).await;
+
+    let query = QueryBuilder::new("posts")
+        .join("people")
+        .on("posts.author_id", "people.id")
+        .build();
+    let rows = wait_for_query(
+        &bob,
+        query,
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "bob join sees v1 post author through table rename",
+        |rows| (rows.len() == 1 && rows[0].0 == post_row_id).then_some(rows),
+    )
+    .await;
+
+    assert_eq!(
+        rows[0].1,
+        vec![
+            Value::Uuid(post_id),
+            Value::Uuid(author_id),
+            Value::Text("Hello from v1".to_string()),
+            Value::Uuid(author_id),
+            Value::Text("Alice".to_string()),
+        ]
+    );
+
+    alice.shutdown().await.expect("shutdown alice");
+    bob.shutdown().await.expect("shutdown bob");
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn table_rename_fk_array_lookup_finds_related_rows_on_old_branch() {
+    let server = TestingServer::start().await;
+    let v1_schema = table_rename_join_schema_v1();
+    let v2_schema = table_rename_join_schema_v2();
+
+    push_catalogue_in_memory(
+        server.server_state(),
+        server.app_id(),
+        "dev",
+        "main",
+        &[v1_schema.clone(), v2_schema.clone()],
+        &[table_rename_join_v1_to_v2_lens()],
+    )
+    .await
+    .expect("push array table-rename catalogue");
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &v1_schema,
+    )
+    .await;
+
+    let alice =
+        JazzClient::connect(server.make_client_context_for_user(v1_schema, "alice-array-rename"))
+            .await
+            .expect("connect alice");
+    wait_for_edge_query_ready(&alice, "users", Duration::from_secs(30)).await;
+    wait_for_edge_query_ready(&alice, "posts", Duration::from_secs(30)).await;
+
+    let author_id = jazz_tools::ObjectId::new();
+    let (author_row_id, _, batch_id) = alice
+        .insert(
+            "users",
+            table_rename_join_user_values(author_id, "Alice"),
+            None,
+        )
+        .expect("alice creates v1 user");
+    alice
+        .wait_for_batch(batch_id, DurabilityTier::EdgeServer)
+        .await
+        .expect("alice user reaches edge");
+
+    let post_id = jazz_tools::ObjectId::new();
+    let (_, _, batch_id) = alice
+        .insert(
+            "posts",
+            table_rename_join_post_values(post_id, author_id, "Alice post"),
+            None,
+        )
+        .expect("alice creates v1 post");
+    alice
+        .wait_for_batch(batch_id, DurabilityTier::EdgeServer)
+        .await
+        .expect("alice post reaches edge");
+
+    let bob =
+        JazzClient::connect(server.make_client_context_for_user(v2_schema, "bob-array-rename"))
+            .await
+            .expect("connect bob");
+    wait_for_edge_query_ready(&bob, "people", Duration::from_secs(30)).await;
+    wait_for_edge_query_ready(&bob, "posts", Duration::from_secs(30)).await;
+
+    let query = QueryBuilder::new("people")
+        .with_array("posts", |sub| {
+            sub.from("posts").correlate("author_id", "people.id")
+        })
+        .build();
+    let rows = wait_for_query(
+        &bob,
+        query,
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "bob array include sees v1 posts through table rename",
+        |rows| (rows.len() == 1 && rows[0].0 == author_row_id).then_some(rows),
+    )
+    .await;
+
+    assert_eq!(rows[0].1[0], Value::Uuid(author_id));
+    assert_eq!(rows[0].1[1], Value::Text("Alice".to_string()));
+    let posts = rows[0].1[2]
+        .as_array()
+        .expect("third column should be posts array");
+    assert_eq!(posts.len(), 1);
+    let first_post = posts[0]
+        .as_row()
+        .expect("post array element should be a row");
+    assert_eq!(first_post[0], Value::Uuid(post_id));
+    assert_eq!(first_post[1], Value::Uuid(author_id));
+    assert_eq!(first_post[2], Value::Text("Alice post".to_string()));
+
+    alice.shutdown().await.expect("shutdown alice");
+    bob.shutdown().await.expect("shutdown bob");
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn multi_hop_table_renames_and_column_rename() {
+    let server = TestingServer::start().await;
+    let v1_schema = multi_hop_table_rename_schema_v1();
+    let v2_schema = multi_hop_table_rename_schema_v2();
+    let v3_schema = multi_hop_table_rename_schema_v3();
+
+    push_catalogue_in_memory(
+        server.server_state(),
+        server.app_id(),
+        "dev",
+        "main",
+        &[v1_schema.clone(), v2_schema.clone(), v3_schema.clone()],
+        &[
+            multi_hop_table_rename_v1_to_v2_lens(),
+            multi_hop_table_rename_v2_to_v3_lens(),
+        ],
+    )
+    .await
+    .expect("push multi-hop table-rename catalogue");
+
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &v1_schema,
+    )
+    .await;
+    let alice = JazzClient::connect(
+        server.make_client_context_for_user(v1_schema, "alice-multi-table-rename"),
+    )
+    .await
+    .expect("connect alice");
+    wait_for_edge_query_ready(&alice, "users", Duration::from_secs(30)).await;
+    let alice_id = jazz_tools::ObjectId::new();
+    let (alice_row_id, _, batch_id) = alice
+        .insert(
+            "users",
+            multi_hop_table_rename_values_v1(alice_id, "alice@example.com"),
+            None,
+        )
+        .expect("alice creates v1 user");
+    alice
+        .wait_for_batch(batch_id, DurabilityTier::EdgeServer)
+        .await
+        .expect("alice row reaches edge");
+
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &v2_schema,
+    )
+    .await;
+    let bob = JazzClient::connect(
+        server.make_client_context_for_user(v2_schema, "bob-multi-table-rename"),
+    )
+    .await
+    .expect("connect bob");
+    wait_for_edge_query_ready(&bob, "people", Duration::from_secs(30)).await;
+    let bob_id = jazz_tools::ObjectId::new();
+    let (bob_row_id, _, batch_id) = bob
+        .insert(
+            "people",
+            multi_hop_table_rename_values_v2(bob_id, "bob@example.com"),
+            None,
+        )
+        .expect("bob creates v2 person");
+    bob.wait_for_batch(batch_id, DurabilityTier::EdgeServer)
+        .await
+        .expect("bob row reaches edge");
+
+    publish_allow_all_permissions(
+        &server.base_url(),
+        server.app_id(),
+        server.admin_secret(),
+        &v3_schema,
+    )
+    .await;
+    let carol = JazzClient::connect(
+        server.make_client_context_for_user(v3_schema.clone(), "carol-multi-table-rename"),
+    )
+    .await
+    .expect("connect carol");
+    wait_for_edge_query_ready(&carol, "members", Duration::from_secs(30)).await;
+    let carol_id = jazz_tools::ObjectId::new();
+    let (carol_row_id, _, batch_id) = carol
+        .insert(
+            "members",
+            multi_hop_table_rename_values_v3(carol_id, "carol@example.com"),
+            None,
+        )
+        .expect("carol creates v3 member");
+    carol
+        .wait_for_batch(batch_id, DurabilityTier::EdgeServer)
+        .await
+        .expect("carol row reaches edge");
+
+    let rows = wait_for_query(
+        &carol,
+        QueryBuilder::new("members").build(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "carol sees every schema version projected to members",
+        |rows| {
+            (rows.len() == 3
+                && rows.iter().any(|(id, _)| *id == alice_row_id)
+                && rows.iter().any(|(id, _)| *id == bob_row_id)
+                && rows.iter().any(|(id, _)| *id == carol_row_id))
+            .then_some(rows)
+        },
+    )
+    .await;
+
+    assert!(rows.iter().all(|(_, row)| row.len() == 2));
+    assert!(rows.iter().any(|(_, row)| {
+        row == &vec![
+            Value::Uuid(alice_id),
+            Value::Text("alice@example.com".to_string()),
+        ]
+    }));
+    assert!(rows.iter().any(|(_, row)| {
+        row == &vec![
+            Value::Uuid(bob_id),
+            Value::Text("bob@example.com".to_string()),
+        ]
+    }));
+    assert!(rows.iter().any(|(_, row)| {
+        row == &vec![
+            Value::Uuid(carol_id),
+            Value::Text("carol@example.com".to_string()),
+        ]
+    }));
+
+    alice.shutdown().await.expect("shutdown alice");
+    bob.shutdown().await.expect("shutdown bob");
+    carol.shutdown().await.expect("shutdown carol");
+    server.shutdown().await;
+}
+
 /// Bob writes under schema v2 after the server has received the v1/v2
 /// catalogue. Alice connects with schema v1 and sees Bob's data transformed
 /// through the backward lens.
@@ -915,7 +2243,7 @@ async fn catalogue_sync_e2e_schema_evolution_through_sync_manager() {
 ///                                        └──► user row without email column
 /// ```
 #[tokio::test]
-async fn catalogue_sync_e2e_backward_data_migration_through_sync_manager() {
+async fn column_addition_old_client_can_read_new_rows() {
     let server = TestingServer::start().await;
     let target_schema = schema_v2();
 
@@ -1008,7 +2336,7 @@ async fn catalogue_sync_e2e_backward_data_migration_through_sync_manager() {
 }
 
 #[tokio::test]
-async fn catalogue_sync_e2e_schema_evolution_keeps_authorization_through_v1_head() {
+async fn keeps_authorization_through_v1_head() {
     let server = TestingServer::start().await;
     let query = QueryBuilder::new("users").build();
     let v1_schema = schema_v1();

--- a/crates/jazz-tools/tests/subscribe_all_integration.rs
+++ b/crates/jazz-tools/tests/subscribe_all_integration.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 use jazz_tools::query_manager::encoding::decode_row;
 use jazz_tools::query_manager::types::RowDescriptor;
+use jazz_tools::row_input;
 use jazz_tools::server::TestingServer;
 use jazz_tools::{
     AppContext, AppId, ClientStorage, ColumnType, JazzClient, ObjectId, OrderedRowDelta, Query,
@@ -143,30 +144,22 @@ struct TodoSeed {
 
 impl TodoSeed {
     fn values(self) -> HashMap<String, Value> {
-        HashMap::from([
-            ("title".to_string(), Value::Text(self.title.to_string())),
-            ("done".to_string(), Value::Boolean(self.done)),
-            (
-                "priority".to_string(),
-                self.priority.map(Value::Integer).unwrap_or(Value::Null),
+        row_input!(
+            "title" => self.title,
+            "done" => self.done,
+            "priority" => self.priority.map(Value::Integer).unwrap_or(Value::Null),
+            "owner_id" => Value::Null,
+            "tags" => Value::Array(
+                self.tags
+                    .iter()
+                    .map(|tag| Value::Text((*tag).to_string()))
+                    .collect(),
             ),
-            ("owner_id".to_string(), Value::Null),
-            (
-                "tags".to_string(),
-                Value::Array(
-                    self.tags
-                        .iter()
-                        .map(|tag| Value::Text((*tag).to_string()))
-                        .collect(),
-                ),
-            ),
-            (
-                "payload".to_string(),
-                self.payload
-                    .map(|bytes| Value::Bytea(bytes.to_vec()))
-                    .unwrap_or(Value::Null),
-            ),
-        ])
+            "payload" => self
+                .payload
+                .map(|bytes| Value::Bytea(bytes.to_vec()))
+                .unwrap_or(Value::Null),
+        )
     }
 }
 


### PR DESCRIPTION
## Description

FUP to https://github.com/garden-co/jazz/pull/1019. Migrates unit tests on schema migration to integration tests that use the Rust JazzClient.

While adding these tests I found two issues, which I fixed:
- Permissions were not being enforced if a table was renamed while the permissions still referred to the old table name
- Writes on a newer schema didn't update subscriptions for the previous schema (even when there was a lens between both table versions)