### PR TITLE
Expose framework-agnostic binding utilities via jazz-tools/shared

### DIFF
--- a/.changeset/shared-binding-utilities.md
+++ b/.changeset/shared-binding-utilities.md
@@ -1,0 +1,7 @@
+---
+"jazz-tools": patch
+---
+
+Add a `jazz-tools/shared` entry point exposing the framework-agnostic utilities the React, Svelte and Vue bindings use to turn a live query into a reactive, in-place-updated result set: `applyDelta`, `reconcileArray`, `RowChangeKind`, and the supporting types (`SubscriptionDelta`, `RowDelta`, `QueryBuilder`, `QueryOptions`, and the orchestrator's `SubscriptionsOrchestrator` / `CacheEntryHandle` / `UseAllState` shapes). The in-repo bindings now consume this shared surface so an external author can build their own binding (e.g. a signals-based `useAllSignal`) on the same utilities.
+
+This is an advanced, use-at-your-own-risk surface — the internals our framework bindings are built on, surfaced for reuse. It is not covered by semver; the orchestrator/cache-entry/delta shapes may change between releases, so pin a version if you depend on it.

--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -40,6 +40,10 @@
       "react-native": "./dist/react-native/react-core.js",
       "default": "./dist/react-core/index.js"
     },
+    "./shared": {
+      "types": "./dist/shared/index.d.ts",
+      "default": "./dist/shared/index.js"
+    },
     "./permissions": {
       "types": "./dist/permissions/index.d.ts",
       "default": "./dist/permissions/index.js"

--- a/packages/jazz-tools/src/react-core/use-all.ts
+++ b/packages/jazz-tools/src/react-core/use-all.ts
@@ -1,6 +1,5 @@
 import { type Usable, use, useCallback, useRef, useSyncExternalStore } from "react";
-import type { QueryBuilder, QueryOptions } from "../runtime/db.js";
-import type { UseAllState } from "../subscriptions-orchestrator.js";
+import type { QueryBuilder, QueryOptions, UseAllState } from "../shared/index.js";
 import { useJazzClient } from "./provider.js";
 
 type UseAllOptions = {

--- a/packages/jazz-tools/src/shared/index.test.ts
+++ b/packages/jazz-tools/src/shared/index.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { schema as s } from "../index.js";
+import { createDb } from "../runtime/db.js";
+import { SubscriptionsOrchestrator } from "../subscriptions-orchestrator.js";
+// The public surface under test. The vanilla binding below imports Jazz from
+// here and nowhere else — if any symbol it needs were missing, this file would
+// not compile, which is the proof the surface is complete.
+import { applyDelta, reconcileArray, RowChangeKind } from "./index.js";
+import type {
+  CacheEntryHandle,
+  QueryBuilder,
+  QueryOptions,
+  RowDelta,
+  SubscriptionDelta,
+  SubscriptionsOrchestrator as Orchestrator,
+  UseAllState,
+} from "./index.js";
+
+// ---------------------------------------------------------------------------
+// A minimal framework-agnostic binding — the same job the React/Svelte/Vue
+// `useAll` bindings do, with no framework — built ONLY on `jazz-tools/shared`.
+// ---------------------------------------------------------------------------
+
+interface VanillaResult<T extends { id: string }> {
+  /** The live result set, reconciled in place across deltas. */
+  readonly current: T[];
+  /** Count of `Updated` row-changes seen, to exercise the delta-kind surface. */
+  updatedRowCount: number;
+  stop(): void;
+}
+
+function useAllVanilla<T extends { id: string }>(
+  manager: Orchestrator,
+  query: QueryBuilder<T>,
+  options?: QueryOptions,
+): VanillaResult<T> {
+  const current: T[] = [];
+  const result: VanillaResult<T> = { current, updatedRowCount: 0, stop: () => {} };
+
+  // Render-safe peek: seed from cache without registering or subscribing.
+  const initial: UseAllState<T> = manager.peekState<T>(manager.computeKey(query, options));
+  if (initial.status === "fulfilled") {
+    reconcileArray(current, initial.data);
+  }
+
+  const key = manager.makeQueryKey(query, options);
+  const entry: CacheEntryHandle<T> = manager.getCacheEntry<T>(key);
+
+  result.stop = entry.subscribe({
+    onfulfilled: (data: T[]) => {
+      reconcileArray(current, data);
+    },
+    onDelta: (delta: SubscriptionDelta<T>) => {
+      result.updatedRowCount += delta.delta.filter(
+        (change: RowDelta<T>) => change.kind === RowChangeKind.Updated,
+      ).length;
+      applyDelta(current, delta);
+    },
+    onError: () => {},
+    onReset: () => {
+      current.length = 0;
+    },
+  });
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 5_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(message);
+}
+
+describe("jazz-tools/shared", () => {
+  it("a binding built only on the public surface tracks a live query and reconciles in place", async () => {
+    const appId = `shared-surface-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const db = await createDb({ appId });
+    const manager = new SubscriptionsOrchestrator({ appId }, db);
+
+    // Schema + query via the real builder API (no JSON-shaped literals).
+    const app = s.defineApp({
+      todos: s.table({ title: s.string(), done: s.boolean() }),
+    });
+    const query = app.todos.where({ done: { eq: false } });
+
+    const binding = useAllVanilla(manager, query);
+
+    try {
+      const { value: first } = await db.insert(app.todos, { title: "first", done: false });
+      await waitFor(
+        () => binding.current.some((row) => row.id === first.id),
+        "expected the first inserted row to reach the binding",
+      );
+
+      // Capture the live object so we can assert it is mutated in place, not replaced.
+      const firstRef = binding.current.find((row) => row.id === first.id)!;
+
+      const { value: second } = await db.insert(app.todos, { title: "second", done: false });
+      await waitFor(
+        () => binding.current.length === 2,
+        "expected the second inserted row to reach the binding",
+      );
+      // The first row's identity survived the delta — proof of in-place reconciliation.
+      expect(binding.current.find((row) => row.id === first.id)).toBe(firstRef);
+
+      await db.update(app.todos, first.id, { title: "first-edited" });
+      await waitFor(
+        () => binding.current.find((row) => row.id === first.id)?.title === "first-edited",
+        "expected the update to merge into the binding",
+      );
+
+      // Same object reference, field merged in place; the update was seen as `Updated`.
+      expect(binding.current.find((row) => row.id === first.id)).toBe(firstRef);
+      expect(firstRef.title).toBe("first-edited");
+      expect(binding.updatedRowCount).toBeGreaterThan(0);
+      expect(binding.current.map((row) => row.id).sort()).toEqual([first.id, second.id].sort());
+    } finally {
+      binding.stop();
+      await manager.shutdown();
+      await db.shutdown();
+    }
+  });
+});

--- a/packages/jazz-tools/src/shared/index.ts
+++ b/packages/jazz-tools/src/shared/index.ts
@@ -1,0 +1,29 @@
+/**
+ * `jazz-tools/shared` — framework-agnostic utilities for building a reactive,
+ * in-place-updated `useAll`-style binding.
+ *
+ * This is the shared surface the in-repo React, Svelte and Vue bindings consume
+ * to turn a live query into a reactive result set. It is exposed so binding
+ * authors (e.g. a signals-based `useAllSignal`) can reuse it instead of
+ * reimplementing it.
+ *
+ * **Support level: advanced — use at your own risk.** These are the internals
+ * our own framework bindings are built on, surfaced for reuse. They are not
+ * covered by semver: the orchestrator/cache-entry/delta shapes may change
+ * between releases. If you depend on them, pin a version.
+ *
+ * The orchestrator *instance* is reached via the existing framework client
+ * (`useJazzClient().manager`, the Svelte/Vue context equivalents, …) — this
+ * entry point exposes the framework-agnostic types and functions, not a new way
+ * to construct a client.
+ */
+
+export { applyDelta, reconcileArray } from "../reconcile-array.js";
+export { RowChangeKind } from "../runtime/subscription-manager.js";
+export type { RowDelta, SubscriptionDelta } from "../runtime/subscription-manager.js";
+export type {
+  CacheEntryHandle,
+  SubscriptionsOrchestrator,
+  UseAllState,
+} from "../subscriptions-orchestrator.js";
+export type { QueryBuilder, QueryOptions } from "../runtime/db.js";

--- a/packages/jazz-tools/src/svelte/use-all.svelte.ts
+++ b/packages/jazz-tools/src/svelte/use-all.svelte.ts
@@ -1,6 +1,5 @@
-import type { QueryBuilder, QueryOptions } from "../runtime/db.js";
-import type { SubscriptionDelta } from "../runtime/subscription-manager.js";
-import { applyDelta } from "../reconcile-array.js";
+import { applyDelta } from "../shared/index.js";
+import type { QueryBuilder, QueryOptions, SubscriptionDelta } from "../shared/index.js";
 import { getJazzContext } from "./context.svelte.js";
 
 type MaybeGetter<T> = T | (() => T);

--- a/packages/jazz-tools/src/vue/use-all.ts
+++ b/packages/jazz-tools/src/vue/use-all.ts
@@ -1,8 +1,12 @@
 import { ref, toValue, watchEffect, type MaybeRefOrGetter, type Ref } from "vue";
-import type { QueryBuilder, QueryOptions } from "../runtime/db.js";
-import type { SubscriptionDelta } from "../runtime/subscription-manager.js";
-import { applyDelta } from "../reconcile-array.js";
-import type { CacheEntryHandle, UseAllState } from "../subscriptions-orchestrator.js";
+import { applyDelta } from "../shared/index.js";
+import type {
+  CacheEntryHandle,
+  QueryBuilder,
+  QueryOptions,
+  SubscriptionDelta,
+  UseAllState,
+} from "../shared/index.js";
 import { useJazzClient } from "./provider.js";
 
 /**


### PR DESCRIPTION
## Summary
- Add a `jazz-tools/shared` entry point re-exporting the framework-agnostic utilities
  the React/Svelte/Vue bindings use to turn a live query into a reactive,
  in-place-updated result set: `applyDelta`, `reconcileArray`, `RowChangeKind`, plus the
  `SubscriptionDelta` / `RowDelta` / `QueryBuilder` / `QueryOptions` types and the
  orchestrator's `SubscriptionsOrchestrator` / `CacheEntryHandle` / `UseAllState` shapes.
- Refactor the React, Svelte and Vue `useAll` bindings to consume that public surface
  instead of deep relative imports — a pure import swap, no behaviour change. Dogfooding
  is the proof the surface is complete.
- Surfaced so an external author can build their own binding (e.g. a signals-based
  `useAllSignal`) on the same utilities. Documented as an advanced, use-at-your-own-risk
  surface — not semver-covered.
- Wired through the package `exports` map only; `tsc` already emits `dist/shared` JS + `.d.ts`.

## Test plan
- [ ] `pnpm --filter jazz-tools test` — react/svelte/vue `useAll` suites stay green
- [ ] `pnpm --filter jazz-tools test:browser` — covers react-core/`useAll` in a real browser
- [ ] New black-box test: a binding built only on `jazz-tools/shared` tracks a live query and reconciles in place
- [ ] `import('jazz-tools/shared')` resolves; the `./shared` exports map points at real JS + `.d.ts`