### PR TITLE
Port browser broker state machines to Rust WASM

### DIFF
--- a/crates/jazz-wasm/src/broker_client.rs
+++ b/crates/jazz-wasm/src/broker_client.rs
@@ -1,0 +1,1796 @@
+use std::collections::{BTreeMap, HashMap};
+
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+
+pub use crate::broker_defaults::BrokerVisibility;
+use crate::broker_defaults::{
+    DEFAULT_BROKER_HELLO_TIMEOUT_MS, DEFAULT_BROKER_PING_INTERVAL_MS,
+    DEFAULT_BROKER_PONG_TIMEOUT_MS, DEFAULT_INITIAL_LEADERSHIP_TIMEOUT_MS,
+    DEFAULT_STORAGE_RESET_TIMEOUT_MS, RESET_RECONNECT_ERROR,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BrokerRole {
+    Leader,
+    Follower,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConnectRequested {
+    pub app_id: String,
+    pub db_name: String,
+    pub tab_id: String,
+    pub fingerprint: String,
+    pub visibility: BrokerVisibility,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub force_takeover_timeout_ms: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub broker_ping_interval_ms: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub broker_pong_timeout_ms: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub storage_reset_timeout_ms: Option<u32>,
+    pub now_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    tag = "type",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum BrokerClientEvent {
+    ConnectRequested(ConnectRequested),
+    PublicCommand {
+        command: BrokerClientCommand,
+    },
+    BrokerMessageReceived {
+        message: BrokerControlMessage,
+        #[serde(default = "default_respond_to_broker_ping")]
+        respond_to_broker_ping: bool,
+        now_ms: u64,
+    },
+    TimerFired {
+        timer_id: u64,
+        kind: BrokerClientTimerKind,
+        now_ms: u64,
+    },
+    CallbackResolved {
+        callback_id: u64,
+        now_ms: u64,
+    },
+    CallbackRejected {
+        callback_id: u64,
+        error_message: String,
+        now_ms: u64,
+    },
+    WorkerError {
+        worker_id: u64,
+        error_message: String,
+        now_ms: u64,
+    },
+    PortMessageError {
+        port_id: u64,
+        now_ms: u64,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    tag = "type",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum BrokerClientCommand {
+    WaitForRole {
+        role: BrokerRole,
+        promise_id: u64,
+        timeout_ms: u32,
+    },
+    ReportLeaderReady {
+        leadership_id: u32,
+        tab_lock_name: String,
+        worker_lock_name: String,
+        bridgeless_storage_reset: bool,
+    },
+    ReportLeaderFailed {
+        leadership_id: u32,
+        reason: String,
+    },
+    ReportVisibility {
+        visibility: BrokerVisibility,
+    },
+    ReportFollowerPortAttached {
+        follower_tab_id: String,
+        leadership_id: u32,
+    },
+    ReportFollowerPortClosed {
+        follower_tab_id: String,
+        leadership_id: u32,
+    },
+    ReportSchemaReady {
+        schema_fingerprint: String,
+    },
+    RequestStorageReset {
+        request_id: String,
+        start_promise_id: u64,
+        completion_promise_id: u64,
+    },
+    ReportStorageResetReady {
+        request_id: String,
+        success: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error_message: Option<String>,
+    },
+    Shutdown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    tag = "type",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum BrokerClientTimerKind {
+    BrokerHello,
+    InitialLeadership,
+    BrokerLiveness,
+    RoleWaiter { promise_id: u64 },
+    StorageResetStart { request_id: String, promise_id: u64 },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    tag = "type",
+    rename_all = "kebab-case",
+    rename_all_fields = "camelCase"
+)]
+pub enum BrowserBrokerTabMessage {
+    Hello {
+        tab_id: String,
+        app_id: String,
+        db_name: String,
+        fingerprint: String,
+        visibility: BrokerVisibility,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        force_takeover_timeout_ms: Option<u32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        broker_ping_interval_ms: Option<u32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        broker_pong_timeout_ms: Option<u32>,
+    },
+    Visibility {
+        broker_instance_id: String,
+        visibility: BrokerVisibility,
+    },
+    LeaderReady {
+        broker_instance_id: String,
+        leadership_id: u32,
+        tab_lock_name: String,
+        worker_lock_name: String,
+        #[serde(skip_serializing_if = "is_false")]
+        bridgeless_storage_reset: bool,
+    },
+    LeaderFailed {
+        broker_instance_id: String,
+        leadership_id: u32,
+        reason: String,
+    },
+    FollowerPortAttached {
+        broker_instance_id: String,
+        follower_tab_id: String,
+        leadership_id: u32,
+    },
+    FollowerPortClosed {
+        broker_instance_id: String,
+        follower_tab_id: String,
+        leadership_id: u32,
+    },
+    SchemaReady {
+        broker_instance_id: String,
+        schema_fingerprint: String,
+    },
+    StorageResetRequest {
+        broker_instance_id: String,
+        request_id: String,
+    },
+    StorageResetReady {
+        broker_instance_id: String,
+        request_id: String,
+        success: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error_message: Option<String>,
+    },
+    Shutdown {
+        broker_instance_id: String,
+    },
+    BrokerPong {
+        broker_instance_id: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    tag = "type",
+    rename_all = "kebab-case",
+    rename_all_fields = "camelCase"
+)]
+pub enum BrokerControlMessage {
+    BrokerHello {
+        broker_instance_id: String,
+    },
+    Unsupported {
+        broker_instance_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        code: Option<String>,
+        reason: String,
+    },
+    BrokerPing {
+        broker_instance_id: String,
+    },
+    BecomeLeader {
+        broker_instance_id: String,
+        leadership_id: u32,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reset_request_id: Option<String>,
+    },
+    Demote {
+        broker_instance_id: String,
+        leadership_id: u32,
+    },
+    LeaderReady {
+        broker_instance_id: String,
+        leader_tab_id: String,
+        leadership_id: u32,
+    },
+    AttachFollowerPort {
+        broker_instance_id: String,
+        follower_tab_id: String,
+        leadership_id: u32,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        port_id: Option<u64>,
+    },
+    UseFollowerPort {
+        broker_instance_id: String,
+        leader_tab_id: String,
+        leadership_id: u32,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        port_id: Option<u64>,
+    },
+    FollowerReady {
+        broker_instance_id: String,
+        leader_tab_id: String,
+        leadership_id: u32,
+    },
+    CloseFollowerPort {
+        broker_instance_id: String,
+        leadership_id: u32,
+    },
+    DetachFollowerPort {
+        broker_instance_id: String,
+        follower_tab_id: String,
+        leadership_id: u32,
+    },
+    StorageResetBegin {
+        broker_instance_id: String,
+        request_id: String,
+        leadership_id: u32,
+    },
+    StorageResetStarted {
+        broker_instance_id: String,
+        request_id: String,
+    },
+    StorageResetFinished {
+        broker_instance_id: String,
+        request_id: String,
+        success: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error_message: Option<String>,
+    },
+    SchemaBlocked {
+        broker_instance_id: String,
+        reason: String,
+    },
+}
+
+impl BrokerControlMessage {
+    fn broker_instance_id(&self) -> &str {
+        match self {
+            BrokerControlMessage::BrokerHello { broker_instance_id }
+            | BrokerControlMessage::Unsupported {
+                broker_instance_id, ..
+            }
+            | BrokerControlMessage::BrokerPing { broker_instance_id }
+            | BrokerControlMessage::BecomeLeader {
+                broker_instance_id, ..
+            }
+            | BrokerControlMessage::Demote {
+                broker_instance_id, ..
+            }
+            | BrokerControlMessage::LeaderReady {
+                broker_instance_id, ..
+            }
+            | BrokerControlMessage::AttachFollowerPort {
+                broker_instance_id, ..
+            }
+            | BrokerControlMessage::UseFollowerPort {
+                broker_instance_id, ..
+            }
+            | BrokerControlMessage::FollowerReady {
+                broker_instance_id, ..
+            }
+            | BrokerControlMessage::CloseFollowerPort {
+                broker_instance_id, ..
+            }
+            | BrokerControlMessage::DetachFollowerPort {
+                broker_instance_id, ..
+            }
+            | BrokerControlMessage::StorageResetBegin {
+                broker_instance_id, ..
+            }
+            | BrokerControlMessage::StorageResetStarted {
+                broker_instance_id, ..
+            }
+            | BrokerControlMessage::StorageResetFinished {
+                broker_instance_id, ..
+            }
+            | BrokerControlMessage::SchemaBlocked {
+                broker_instance_id, ..
+            } => broker_instance_id,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    tag = "type",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum BrokerClientCallback {
+    BrokerPing,
+    BecomeLeader {
+        leadership_id: u32,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reset_request_id: Option<String>,
+    },
+    Demote {
+        leadership_id: u32,
+    },
+    AttachFollowerPort {
+        follower_tab_id: String,
+        leadership_id: u32,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        port_id: Option<u64>,
+    },
+    DetachFollowerPort {
+        follower_tab_id: String,
+        leadership_id: u32,
+    },
+    UseFollowerPort {
+        leader_tab_id: String,
+        leadership_id: u32,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        port_id: Option<u64>,
+    },
+    FollowerReady {
+        leader_tab_id: String,
+        leadership_id: u32,
+    },
+    CloseFollowerPort {
+        leadership_id: u32,
+    },
+    StorageResetBegin {
+        request_id: String,
+        leadership_id: u32,
+    },
+    SchemaBlocked {
+        reason: String,
+    },
+    Reconnected,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    tag = "type",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum BrokerClientEffect {
+    CreateSharedWorker {
+        worker_id: u64,
+        name: String,
+    },
+    AttachPortListeners {
+        port_id: u64,
+    },
+    DetachPort {
+        port_id: u64,
+        close: bool,
+    },
+    PostToBroker {
+        port_id: u64,
+        message: BrowserBrokerTabMessage,
+    },
+    ArmTimer {
+        timer_id: u64,
+        kind: BrokerClientTimerKind,
+        delay_ms: u32,
+    },
+    CancelTimer {
+        timer_id: u64,
+    },
+    ReleaseMessagePort {
+        port_id: u64,
+    },
+    InvokeCallback {
+        callback_id: u64,
+        callback: BrokerClientCallback,
+    },
+    ResolveConnect,
+    RejectConnect {
+        reason: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        code: Option<String>,
+    },
+    ResolvePublicPromise {
+        promise_id: u64,
+    },
+    RejectPublicPromise {
+        promise_id: u64,
+        reason: String,
+    },
+    CloseClient {
+        reason: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        code: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BrokerClientSnapshot {
+    pub broker_instance_id: Option<String>,
+    pub role: BrokerRole,
+    pub tab_id: String,
+    pub leader_tab_id: Option<String>,
+    pub leadership_id: u32,
+    pub visibility: BrokerVisibility,
+    pub closed: bool,
+    pub reconnecting: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct BrokerClientCore {
+    config: Option<ClientConfig>,
+    broker_instance_id: Option<String>,
+    role: BrokerRole,
+    leader_tab_id: Option<String>,
+    leadership_id: u32,
+    visibility: BrokerVisibility,
+    closed: bool,
+    reconnecting: bool,
+    connecting: Option<ConnectingState>,
+    current_port_id: Option<u64>,
+    current_worker_id: Option<u64>,
+    broker_liveness_timer_id: Option<u64>,
+    role_waiters: Vec<RoleWaiter>,
+    reset_start_waiters: BTreeMap<String, Vec<ResetStartWaiter>>,
+    reset_completion_waiters: BTreeMap<String, Vec<u64>>,
+    pending_reset_requests: Vec<PendingResetRequest>,
+    pending_callbacks: HashMap<u64, PendingCallback>,
+    next_worker_id: u64,
+    next_port_id: u64,
+    next_timer_id: u64,
+    next_callback_id: u64,
+}
+
+#[derive(Debug, Clone)]
+struct ClientConfig {
+    app_id: String,
+    db_name: String,
+    tab_id: String,
+    fingerprint: String,
+    force_takeover_timeout_ms: Option<u32>,
+    broker_ping_interval_ms: Option<u32>,
+    broker_pong_timeout_ms: Option<u32>,
+    storage_reset_timeout_ms: Option<u32>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConnectionPurpose {
+    Initial,
+    Reconnect,
+}
+
+#[derive(Debug, Clone)]
+struct ConnectingState {
+    purpose: ConnectionPurpose,
+    worker_id: u64,
+    hello_timer_id: u64,
+    initial_leadership_timer_id: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+struct RoleWaiter {
+    role: BrokerRole,
+    promise_id: u64,
+    timer_id: u64,
+}
+
+#[derive(Debug, Clone)]
+struct ResetStartWaiter {
+    promise_id: u64,
+    timer_id: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+struct PendingResetRequest {
+    request_id: String,
+    start_promise_id: u64,
+}
+
+#[derive(Debug, Clone)]
+enum PendingCallback {
+    BecomeLeaderFailed {
+        leadership_id: u32,
+    },
+    StorageResetReady {
+        request_id: String,
+    },
+    ReconnectDemote {
+        previous_role: BrokerRole,
+        previous_leadership_id: u32,
+    },
+}
+
+impl Default for BrokerClientCore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BrokerClientCore {
+    pub fn new() -> Self {
+        Self {
+            config: None,
+            broker_instance_id: None,
+            role: BrokerRole::Follower,
+            leader_tab_id: None,
+            leadership_id: 0,
+            visibility: BrokerVisibility::Visible,
+            closed: false,
+            reconnecting: false,
+            connecting: None,
+            current_port_id: None,
+            current_worker_id: None,
+            broker_liveness_timer_id: None,
+            role_waiters: Vec::new(),
+            reset_start_waiters: BTreeMap::new(),
+            reset_completion_waiters: BTreeMap::new(),
+            pending_reset_requests: Vec::new(),
+            pending_callbacks: HashMap::new(),
+            next_worker_id: 1,
+            next_port_id: 1,
+            next_timer_id: 1,
+            next_callback_id: 1,
+        }
+    }
+
+    pub fn handle(&mut self, event: BrokerClientEvent) -> Vec<BrokerClientEffect> {
+        match event {
+            BrokerClientEvent::ConnectRequested(event) => self.handle_connect_requested(event),
+            BrokerClientEvent::PublicCommand { command } => self.handle_public_command(command),
+            BrokerClientEvent::BrokerMessageReceived {
+                message,
+                respond_to_broker_ping,
+                now_ms,
+            } => self.handle_broker_message(message, respond_to_broker_ping, now_ms),
+            BrokerClientEvent::TimerFired {
+                timer_id,
+                kind,
+                now_ms,
+            } => self.handle_timer_fired(timer_id, kind, now_ms),
+            BrokerClientEvent::CallbackResolved {
+                callback_id,
+                now_ms,
+            } => self.handle_callback_resolved(callback_id, now_ms),
+            BrokerClientEvent::CallbackRejected {
+                callback_id,
+                error_message,
+                now_ms,
+            } => self.handle_callback_rejected(callback_id, error_message, now_ms),
+            BrokerClientEvent::WorkerError {
+                worker_id,
+                error_message,
+                now_ms,
+            } => self.handle_worker_error(worker_id, error_message, now_ms),
+            BrokerClientEvent::PortMessageError { port_id, now_ms } => {
+                if self.current_port_id == Some(port_id) {
+                    self.start_reconnect(
+                        format!("Browser broker port message error at {now_ms}"),
+                        now_ms,
+                    )
+                } else {
+                    Vec::new()
+                }
+            }
+        }
+    }
+
+    pub fn snapshot(&self) -> BrokerClientSnapshot {
+        BrokerClientSnapshot {
+            broker_instance_id: self.broker_instance_id.clone(),
+            role: self.role,
+            tab_id: self
+                .config
+                .as_ref()
+                .map(|config| config.tab_id.clone())
+                .unwrap_or_default(),
+            leader_tab_id: self.leader_tab_id.clone(),
+            leadership_id: self.leadership_id,
+            visibility: self.visibility,
+            closed: self.closed,
+            reconnecting: self.reconnecting,
+        }
+    }
+
+    fn handle_connect_requested(&mut self, event: ConnectRequested) -> Vec<BrokerClientEffect> {
+        if self.closed {
+            return Vec::new();
+        }
+
+        self.config = Some(ClientConfig {
+            app_id: event.app_id,
+            db_name: event.db_name,
+            tab_id: event.tab_id,
+            fingerprint: event.fingerprint,
+            force_takeover_timeout_ms: event.force_takeover_timeout_ms,
+            broker_ping_interval_ms: event.broker_ping_interval_ms,
+            broker_pong_timeout_ms: event.broker_pong_timeout_ms,
+            storage_reset_timeout_ms: event.storage_reset_timeout_ms,
+        });
+        self.visibility = event.visibility;
+        self.begin_connection(ConnectionPurpose::Initial)
+    }
+
+    fn handle_public_command(&mut self, command: BrokerClientCommand) -> Vec<BrokerClientEffect> {
+        match command {
+            BrokerClientCommand::WaitForRole {
+                role,
+                promise_id,
+                timeout_ms,
+            } => self.handle_wait_for_role(role, promise_id, timeout_ms),
+            BrokerClientCommand::ReportLeaderReady {
+                leadership_id,
+                tab_lock_name,
+                worker_lock_name,
+                bridgeless_storage_reset,
+            } => self.send_stamped(|broker_instance_id| BrowserBrokerTabMessage::LeaderReady {
+                broker_instance_id,
+                leadership_id,
+                tab_lock_name,
+                worker_lock_name,
+                bridgeless_storage_reset,
+            }),
+            BrokerClientCommand::ReportLeaderFailed {
+                leadership_id,
+                reason,
+            } => self.send_stamped(|broker_instance_id| BrowserBrokerTabMessage::LeaderFailed {
+                broker_instance_id,
+                leadership_id,
+                reason,
+            }),
+            BrokerClientCommand::ReportVisibility { visibility } => {
+                self.visibility = visibility;
+                self.send_stamped(|broker_instance_id| BrowserBrokerTabMessage::Visibility {
+                    broker_instance_id,
+                    visibility,
+                })
+            }
+            BrokerClientCommand::ReportFollowerPortAttached {
+                follower_tab_id,
+                leadership_id,
+            } => self.send_stamped(|broker_instance_id| {
+                BrowserBrokerTabMessage::FollowerPortAttached {
+                    broker_instance_id,
+                    follower_tab_id,
+                    leadership_id,
+                }
+            }),
+            BrokerClientCommand::ReportFollowerPortClosed {
+                follower_tab_id,
+                leadership_id,
+            } => self.send_stamped(|broker_instance_id| {
+                BrowserBrokerTabMessage::FollowerPortClosed {
+                    broker_instance_id,
+                    follower_tab_id,
+                    leadership_id,
+                }
+            }),
+            BrokerClientCommand::ReportSchemaReady { schema_fingerprint } => {
+                self.send_stamped(|broker_instance_id| BrowserBrokerTabMessage::SchemaReady {
+                    broker_instance_id,
+                    schema_fingerprint,
+                })
+            }
+            BrokerClientCommand::RequestStorageReset {
+                request_id,
+                start_promise_id,
+                completion_promise_id,
+            } => self.handle_storage_reset_request(
+                request_id,
+                start_promise_id,
+                completion_promise_id,
+            ),
+            BrokerClientCommand::ReportStorageResetReady {
+                request_id,
+                success,
+                error_message,
+            } => {
+                self.send_stamped(
+                    |broker_instance_id| BrowserBrokerTabMessage::StorageResetReady {
+                        broker_instance_id,
+                        request_id,
+                        success,
+                        error_message,
+                    },
+                )
+            }
+            BrokerClientCommand::Shutdown => self.handle_shutdown(),
+        }
+    }
+
+    fn handle_broker_message(
+        &mut self,
+        message: BrokerControlMessage,
+        respond_to_broker_ping: bool,
+        now_ms: u64,
+    ) -> Vec<BrokerClientEffect> {
+        if self.closed {
+            return Vec::new();
+        }
+
+        if let Some(current_instance_id) = self.broker_instance_id.as_deref() {
+            if message.broker_instance_id() != current_instance_id {
+                return self.start_reconnect(
+                    format!(
+                        "Browser broker instance changed from {current_instance_id} to {}",
+                        message.broker_instance_id()
+                    ),
+                    now_ms,
+                );
+            }
+        }
+
+        match message {
+            BrokerControlMessage::BrokerHello { broker_instance_id } => {
+                self.handle_broker_hello(broker_instance_id)
+            }
+            BrokerControlMessage::Unsupported { code, reason, .. } => {
+                self.handle_unsupported(reason, code)
+            }
+            BrokerControlMessage::BrokerPing { broker_instance_id } => {
+                let mut effects = self.refresh_broker_liveness_timer();
+                effects.push(self.invoke_callback(BrokerClientCallback::BrokerPing, None));
+                if respond_to_broker_ping {
+                    if let Some(port_id) = self.current_port_id {
+                        effects.push(BrokerClientEffect::PostToBroker {
+                            port_id,
+                            message: BrowserBrokerTabMessage::BrokerPong { broker_instance_id },
+                        });
+                    }
+                }
+                effects
+            }
+            BrokerControlMessage::BecomeLeader {
+                leadership_id,
+                reset_request_id,
+                ..
+            } => {
+                self.leadership_id = leadership_id;
+                let mut effects = vec![self.invoke_callback(
+                    BrokerClientCallback::BecomeLeader {
+                        leadership_id,
+                        reset_request_id,
+                    },
+                    Some(PendingCallback::BecomeLeaderFailed { leadership_id }),
+                )];
+                effects.extend(self.complete_connection_if_waiting_for_leadership());
+                effects
+            }
+            BrokerControlMessage::Demote { leadership_id, .. } => {
+                if leadership_id == self.leadership_id {
+                    self.role = BrokerRole::Follower;
+                    self.leader_tab_id = None;
+                }
+                let mut effects = vec![
+                    self.invoke_callback(BrokerClientCallback::Demote { leadership_id }, None)
+                ];
+                effects.extend(self.resolve_role_waiters());
+                effects
+            }
+            BrokerControlMessage::LeaderReady {
+                leader_tab_id,
+                leadership_id,
+                ..
+            } => {
+                self.leadership_id = leadership_id;
+                self.role = if Some(leader_tab_id.as_str()) == self.config_tab_id() {
+                    BrokerRole::Leader
+                } else {
+                    BrokerRole::Follower
+                };
+                self.leader_tab_id = Some(leader_tab_id);
+                let mut effects = self.resolve_role_waiters();
+                effects.extend(self.complete_connection_if_waiting_for_leadership());
+                effects
+            }
+            BrokerControlMessage::AttachFollowerPort {
+                follower_tab_id,
+                leadership_id,
+                port_id,
+                ..
+            } => {
+                if leadership_id != self.leadership_id {
+                    return release_message_port(port_id);
+                }
+                vec![self.invoke_callback(
+                    BrokerClientCallback::AttachFollowerPort {
+                        follower_tab_id,
+                        leadership_id,
+                        port_id,
+                    },
+                    None,
+                )]
+            }
+            BrokerControlMessage::UseFollowerPort {
+                leader_tab_id,
+                leadership_id,
+                port_id,
+                ..
+            } => {
+                if self.leadership_id > 0 && leadership_id < self.leadership_id {
+                    return release_message_port(port_id);
+                }
+                self.leadership_id = leadership_id;
+                self.leader_tab_id = Some(leader_tab_id.clone());
+                self.role = BrokerRole::Follower;
+                let mut effects = vec![self.invoke_callback(
+                    BrokerClientCallback::UseFollowerPort {
+                        leader_tab_id,
+                        leadership_id,
+                        port_id,
+                    },
+                    None,
+                )];
+                effects.extend(self.complete_connection_if_waiting_for_leadership());
+                effects
+            }
+            BrokerControlMessage::FollowerReady {
+                leader_tab_id,
+                leadership_id,
+                ..
+            } => {
+                self.leadership_id = leadership_id;
+                self.leader_tab_id = Some(leader_tab_id.clone());
+                self.role = BrokerRole::Follower;
+                let mut effects = vec![self.invoke_callback(
+                    BrokerClientCallback::FollowerReady {
+                        leader_tab_id,
+                        leadership_id,
+                    },
+                    None,
+                )];
+                effects.extend(self.resolve_role_waiters());
+                effects.extend(self.complete_connection_if_waiting_for_leadership());
+                effects
+            }
+            BrokerControlMessage::CloseFollowerPort { leadership_id, .. } => {
+                vec![self.invoke_callback(
+                    BrokerClientCallback::CloseFollowerPort { leadership_id },
+                    None,
+                )]
+            }
+            BrokerControlMessage::DetachFollowerPort {
+                follower_tab_id,
+                leadership_id,
+                ..
+            } => {
+                vec![self.invoke_callback(
+                    BrokerClientCallback::DetachFollowerPort {
+                        follower_tab_id,
+                        leadership_id,
+                    },
+                    None,
+                )]
+            }
+            BrokerControlMessage::StorageResetBegin {
+                request_id,
+                leadership_id,
+                ..
+            } => {
+                let mut effects = self.resolve_reset_start_waiters(&request_id);
+                effects.push(self.invoke_callback(
+                    BrokerClientCallback::StorageResetBegin {
+                        request_id: request_id.clone(),
+                        leadership_id,
+                    },
+                    Some(PendingCallback::StorageResetReady { request_id }),
+                ));
+                effects
+            }
+            BrokerControlMessage::StorageResetStarted { request_id, .. } => {
+                self.resolve_reset_start_waiters(&request_id)
+            }
+            BrokerControlMessage::StorageResetFinished {
+                request_id,
+                success,
+                error_message,
+                ..
+            } => {
+                let mut effects = self.resolve_reset_start_waiters(&request_id);
+                effects.extend(self.resolve_reset_completion_waiters(
+                    &request_id,
+                    success,
+                    error_message,
+                ));
+                effects
+            }
+            BrokerControlMessage::SchemaBlocked { reason, .. } => {
+                vec![self.invoke_callback(BrokerClientCallback::SchemaBlocked { reason }, None)]
+            }
+        }
+    }
+
+    fn handle_timer_fired(
+        &mut self,
+        timer_id: u64,
+        kind: BrokerClientTimerKind,
+        now_ms: u64,
+    ) -> Vec<BrokerClientEffect> {
+        match kind {
+            BrokerClientTimerKind::BrokerHello => {
+                if self
+                    .connecting
+                    .as_ref()
+                    .map(|connecting| connecting.hello_timer_id == timer_id)
+                    .unwrap_or(false)
+                {
+                    self.connection_failed(
+                        "Timed out waiting for browser broker hello".to_string(),
+                        None,
+                    )
+                } else {
+                    Vec::new()
+                }
+            }
+            BrokerClientTimerKind::InitialLeadership => {
+                if self
+                    .connecting
+                    .as_ref()
+                    .and_then(|connecting| connecting.initial_leadership_timer_id)
+                    == Some(timer_id)
+                {
+                    self.complete_connection()
+                } else {
+                    Vec::new()
+                }
+            }
+            BrokerClientTimerKind::BrokerLiveness => {
+                if self.broker_liveness_timer_id == Some(timer_id) {
+                    self.broker_liveness_timer_id = None;
+                    self.start_reconnect(
+                        "Browser broker liveness timed out waiting for broker ping".to_string(),
+                        now_ms,
+                    )
+                } else {
+                    Vec::new()
+                }
+            }
+            BrokerClientTimerKind::RoleWaiter { promise_id } => {
+                self.handle_role_waiter_timeout(timer_id, promise_id)
+            }
+            BrokerClientTimerKind::StorageResetStart {
+                request_id,
+                promise_id,
+            } => self.handle_storage_reset_start_timeout(timer_id, request_id, promise_id),
+        }
+    }
+
+    fn handle_callback_resolved(
+        &mut self,
+        callback_id: u64,
+        _now_ms: u64,
+    ) -> Vec<BrokerClientEffect> {
+        match self.pending_callbacks.remove(&callback_id) {
+            Some(PendingCallback::BecomeLeaderFailed { .. }) => Vec::new(),
+            Some(PendingCallback::StorageResetReady { request_id }) => self.send_stamped(
+                |broker_instance_id| BrowserBrokerTabMessage::StorageResetReady {
+                    broker_instance_id,
+                    request_id,
+                    success: true,
+                    error_message: None,
+                },
+            ),
+            Some(PendingCallback::ReconnectDemote {
+                previous_role,
+                previous_leadership_id,
+            }) => self.continue_reconnect_after_demote(previous_role, previous_leadership_id),
+            None => Vec::new(),
+        }
+    }
+
+    fn handle_callback_rejected(
+        &mut self,
+        callback_id: u64,
+        error_message: String,
+        _now_ms: u64,
+    ) -> Vec<BrokerClientEffect> {
+        match self.pending_callbacks.remove(&callback_id) {
+            Some(PendingCallback::BecomeLeaderFailed { leadership_id }) => {
+                self.send_stamped(|broker_instance_id| BrowserBrokerTabMessage::LeaderFailed {
+                    broker_instance_id,
+                    leadership_id,
+                    reason: error_message,
+                })
+            }
+            Some(PendingCallback::StorageResetReady { request_id }) => self.send_stamped(
+                |broker_instance_id| BrowserBrokerTabMessage::StorageResetReady {
+                    broker_instance_id,
+                    request_id,
+                    success: false,
+                    error_message: Some(error_message),
+                },
+            ),
+            Some(PendingCallback::ReconnectDemote { .. }) => {
+                self.close_with_error(error_message, None, true)
+            }
+            None => Vec::new(),
+        }
+    }
+
+    fn handle_worker_error(
+        &mut self,
+        worker_id: u64,
+        error_message: String,
+        _now_ms: u64,
+    ) -> Vec<BrokerClientEffect> {
+        if self
+            .connecting
+            .as_ref()
+            .map(|connecting| connecting.worker_id == worker_id)
+            .unwrap_or(false)
+        {
+            self.connection_failed(
+                format!("Browser broker SharedWorker failed to start: {error_message}"),
+                None,
+            )
+        } else {
+            Vec::new()
+        }
+    }
+
+    fn handle_broker_hello(&mut self, broker_instance_id: String) -> Vec<BrokerClientEffect> {
+        let Some(connecting) = self.connecting.as_ref() else {
+            self.broker_instance_id = Some(broker_instance_id);
+            return Vec::new();
+        };
+
+        let hello_timer_id = connecting.hello_timer_id;
+        self.broker_instance_id = Some(broker_instance_id);
+
+        let mut effects = vec![BrokerClientEffect::CancelTimer {
+            timer_id: hello_timer_id,
+        }];
+        let initial_timer_id = self.alloc_timer_id();
+        if let Some(connecting) = self.connecting.as_mut() {
+            connecting.initial_leadership_timer_id = Some(initial_timer_id);
+        }
+        effects.push(BrokerClientEffect::ArmTimer {
+            timer_id: initial_timer_id,
+            kind: BrokerClientTimerKind::InitialLeadership,
+            delay_ms: DEFAULT_INITIAL_LEADERSHIP_TIMEOUT_MS,
+        });
+        effects
+    }
+
+    fn handle_unsupported(
+        &mut self,
+        reason: String,
+        code: Option<String>,
+    ) -> Vec<BrokerClientEffect> {
+        if self.connecting.is_some() {
+            self.connection_failed(reason, code)
+        } else {
+            self.close_with_error(reason, code, true)
+        }
+    }
+
+    fn handle_wait_for_role(
+        &mut self,
+        role: BrokerRole,
+        promise_id: u64,
+        timeout_ms: u32,
+    ) -> Vec<BrokerClientEffect> {
+        if self.closed {
+            return vec![BrokerClientEffect::RejectPublicPromise {
+                promise_id,
+                reason: "Browser broker client closed".to_string(),
+            }];
+        }
+
+        if self.role_available(role) {
+            return vec![BrokerClientEffect::ResolvePublicPromise { promise_id }];
+        }
+
+        let timer_id = self.alloc_timer_id();
+        self.role_waiters.push(RoleWaiter {
+            role,
+            promise_id,
+            timer_id,
+        });
+        vec![BrokerClientEffect::ArmTimer {
+            timer_id,
+            kind: BrokerClientTimerKind::RoleWaiter { promise_id },
+            delay_ms: timeout_ms,
+        }]
+    }
+
+    fn handle_role_waiter_timeout(
+        &mut self,
+        timer_id: u64,
+        promise_id: u64,
+    ) -> Vec<BrokerClientEffect> {
+        let Some(index) = self
+            .role_waiters
+            .iter()
+            .position(|waiter| waiter.timer_id == timer_id && waiter.promise_id == promise_id)
+        else {
+            return Vec::new();
+        };
+        let waiter = self.role_waiters.remove(index);
+        vec![BrokerClientEffect::RejectPublicPromise {
+            promise_id,
+            reason: format!(
+                "Timed out waiting for broker role {}",
+                role_name(waiter.role)
+            ),
+        }]
+    }
+
+    fn handle_storage_reset_request(
+        &mut self,
+        request_id: String,
+        start_promise_id: u64,
+        completion_promise_id: u64,
+    ) -> Vec<BrokerClientEffect> {
+        if self.closed {
+            return vec![
+                BrokerClientEffect::RejectPublicPromise {
+                    promise_id: start_promise_id,
+                    reason: "Browser broker client closed".to_string(),
+                },
+                BrokerClientEffect::RejectPublicPromise {
+                    promise_id: completion_promise_id,
+                    reason: "Browser broker client closed".to_string(),
+                },
+            ];
+        }
+
+        self.reset_completion_waiters
+            .entry(request_id.clone())
+            .or_default()
+            .push(completion_promise_id);
+
+        if self.can_post_to_broker() {
+            let mut effects = self.post_storage_reset_request(&request_id);
+            effects.extend(self.arm_storage_reset_start_timer(&request_id, start_promise_id));
+            return effects;
+        }
+
+        self.pending_reset_requests.push(PendingResetRequest {
+            request_id,
+            start_promise_id,
+        });
+        Vec::new()
+    }
+
+    fn handle_storage_reset_start_timeout(
+        &mut self,
+        timer_id: u64,
+        request_id: String,
+        promise_id: u64,
+    ) -> Vec<BrokerClientEffect> {
+        let Some(waiters) = self.reset_start_waiters.get_mut(&request_id) else {
+            return Vec::new();
+        };
+        let Some(index) = waiters.iter().position(|waiter| {
+            waiter.timer_id == Some(timer_id) && waiter.promise_id == promise_id
+        }) else {
+            return Vec::new();
+        };
+        waiters.remove(index);
+        if waiters.is_empty() {
+            self.reset_start_waiters.remove(&request_id);
+        }
+        vec![BrokerClientEffect::RejectPublicPromise {
+            promise_id,
+            reason: format!("Timed out waiting for browser storage reset {request_id} to start"),
+        }]
+    }
+
+    fn handle_shutdown(&mut self) -> Vec<BrokerClientEffect> {
+        if self.closed {
+            return Vec::new();
+        }
+
+        self.closed = true;
+        self.reconnecting = false;
+        let mut effects = Vec::new();
+        if let (Some(port_id), Some(broker_instance_id)) =
+            (self.current_port_id, self.broker_instance_id.clone())
+        {
+            effects.push(BrokerClientEffect::PostToBroker {
+                port_id,
+                message: BrowserBrokerTabMessage::Shutdown { broker_instance_id },
+            });
+        }
+        effects.extend(self.cancel_connection_timers());
+        if let Some(timer_id) = self.broker_liveness_timer_id.take() {
+            effects.push(BrokerClientEffect::CancelTimer { timer_id });
+        }
+        if let Some(port_id) = self.current_port_id.take() {
+            effects.push(BrokerClientEffect::DetachPort {
+                port_id,
+                close: true,
+            });
+        }
+        effects.extend(self.reject_role_waiters("Browser broker client closed"));
+        effects.extend(self.reject_all_reset_waiters("Browser broker client closed"));
+        self.pending_reset_requests.clear();
+        effects
+    }
+
+    fn begin_connection(&mut self, purpose: ConnectionPurpose) -> Vec<BrokerClientEffect> {
+        let Some(config) = self.config.clone() else {
+            return Vec::new();
+        };
+
+        let worker_id = self.alloc_worker_id();
+        let port_id = self.alloc_port_id();
+        let hello_timer_id = self.alloc_timer_id();
+        self.current_worker_id = Some(worker_id);
+        self.current_port_id = Some(port_id);
+        self.connecting = Some(ConnectingState {
+            purpose,
+            worker_id,
+            hello_timer_id,
+            initial_leadership_timer_id: None,
+        });
+
+        vec![
+            BrokerClientEffect::CreateSharedWorker {
+                worker_id,
+                name: format!("jazz-broker:{}:{}", config.app_id, config.db_name),
+            },
+            BrokerClientEffect::AttachPortListeners { port_id },
+            BrokerClientEffect::PostToBroker {
+                port_id,
+                message: BrowserBrokerTabMessage::Hello {
+                    tab_id: config.tab_id,
+                    app_id: config.app_id,
+                    db_name: config.db_name,
+                    fingerprint: config.fingerprint,
+                    visibility: self.visibility,
+                    force_takeover_timeout_ms: config.force_takeover_timeout_ms,
+                    broker_ping_interval_ms: config.broker_ping_interval_ms,
+                    broker_pong_timeout_ms: config.broker_pong_timeout_ms,
+                },
+            },
+            BrokerClientEffect::ArmTimer {
+                timer_id: hello_timer_id,
+                kind: BrokerClientTimerKind::BrokerHello,
+                delay_ms: DEFAULT_BROKER_HELLO_TIMEOUT_MS,
+            },
+        ]
+    }
+
+    fn complete_connection_if_waiting_for_leadership(&mut self) -> Vec<BrokerClientEffect> {
+        if self
+            .connecting
+            .as_ref()
+            .and_then(|connecting| connecting.initial_leadership_timer_id)
+            .is_some()
+        {
+            self.complete_connection()
+        } else {
+            Vec::new()
+        }
+    }
+
+    fn complete_connection(&mut self) -> Vec<BrokerClientEffect> {
+        let Some(connecting) = self.connecting.take() else {
+            return Vec::new();
+        };
+
+        let mut effects = Vec::new();
+        if let Some(timer_id) = connecting.initial_leadership_timer_id {
+            effects.push(BrokerClientEffect::CancelTimer { timer_id });
+        }
+        effects.extend(self.refresh_broker_liveness_timer());
+
+        match connecting.purpose {
+            ConnectionPurpose::Initial => {
+                effects.push(BrokerClientEffect::ResolveConnect);
+            }
+            ConnectionPurpose::Reconnect => {
+                self.reconnecting = false;
+                effects.extend(self.replay_after_reconnect());
+                effects.push(self.invoke_callback(BrokerClientCallback::Reconnected, None));
+            }
+        }
+        effects
+    }
+
+    fn connection_failed(
+        &mut self,
+        reason: String,
+        code: Option<String>,
+    ) -> Vec<BrokerClientEffect> {
+        let purpose = self
+            .connecting
+            .as_ref()
+            .map(|connecting| connecting.purpose)
+            .unwrap_or(ConnectionPurpose::Initial);
+
+        let mut effects = self.cancel_connection_timers();
+        if let Some(port_id) = self.current_port_id.take() {
+            effects.push(BrokerClientEffect::DetachPort {
+                port_id,
+                close: true,
+            });
+        }
+        self.current_worker_id = None;
+        self.broker_instance_id = None;
+
+        match purpose {
+            ConnectionPurpose::Initial => {
+                self.closed = true;
+                effects.push(BrokerClientEffect::RejectConnect { reason, code });
+            }
+            ConnectionPurpose::Reconnect => {
+                effects.extend(self.close_with_error(reason, code, false));
+            }
+        }
+        effects
+    }
+
+    fn start_reconnect(&mut self, _reason: String, _now_ms: u64) -> Vec<BrokerClientEffect> {
+        if self.closed || self.reconnecting {
+            return Vec::new();
+        }
+
+        self.reconnecting = true;
+        let previous_role = self.role;
+        let previous_leadership_id = self.leadership_id;
+        self.broker_instance_id = None;
+        self.role = BrokerRole::Follower;
+        self.leader_tab_id = None;
+        self.leadership_id = 0;
+
+        let mut effects = self.cancel_connection_timers();
+        if let Some(timer_id) = self.broker_liveness_timer_id.take() {
+            effects.push(BrokerClientEffect::CancelTimer { timer_id });
+        }
+        effects.extend(self.reject_all_reset_waiters(RESET_RECONNECT_ERROR));
+        self.pending_reset_requests.clear();
+
+        if let Some(port_id) = self.current_port_id.take() {
+            effects.push(BrokerClientEffect::DetachPort {
+                port_id,
+                close: true,
+            });
+        }
+
+        if previous_leadership_id > 0 {
+            effects.push(self.invoke_callback(
+                BrokerClientCallback::Demote {
+                    leadership_id: previous_leadership_id,
+                },
+                Some(PendingCallback::ReconnectDemote {
+                    previous_role,
+                    previous_leadership_id,
+                }),
+            ));
+        } else {
+            effects.extend(self.begin_connection(ConnectionPurpose::Reconnect));
+        }
+
+        effects
+    }
+
+    fn continue_reconnect_after_demote(
+        &mut self,
+        previous_role: BrokerRole,
+        previous_leadership_id: u32,
+    ) -> Vec<BrokerClientEffect> {
+        if self.closed || !self.reconnecting {
+            return Vec::new();
+        }
+
+        let mut effects = Vec::new();
+        if previous_role == BrokerRole::Follower && previous_leadership_id > 0 {
+            effects.push(self.invoke_callback(
+                BrokerClientCallback::CloseFollowerPort {
+                    leadership_id: previous_leadership_id,
+                },
+                None,
+            ));
+        }
+        effects.extend(self.begin_connection(ConnectionPurpose::Reconnect));
+        effects
+    }
+
+    fn replay_after_reconnect(&mut self) -> Vec<BrokerClientEffect> {
+        let mut effects =
+            self.send_stamped(|broker_instance_id| BrowserBrokerTabMessage::Visibility {
+                broker_instance_id,
+                visibility: self.visibility,
+            });
+        let pending = std::mem::take(&mut self.pending_reset_requests);
+        for request in pending {
+            effects.extend(self.post_storage_reset_request(&request.request_id));
+            effects.extend(
+                self.arm_storage_reset_start_timer(&request.request_id, request.start_promise_id),
+            );
+        }
+        effects
+    }
+
+    fn refresh_broker_liveness_timer(&mut self) -> Vec<BrokerClientEffect> {
+        let mut effects = Vec::new();
+        if let Some(timer_id) = self.broker_liveness_timer_id.take() {
+            effects.push(BrokerClientEffect::CancelTimer { timer_id });
+        }
+        if self.closed {
+            return effects;
+        }
+        let timer_id = self.alloc_timer_id();
+        self.broker_liveness_timer_id = Some(timer_id);
+        effects.push(BrokerClientEffect::ArmTimer {
+            timer_id,
+            kind: BrokerClientTimerKind::BrokerLiveness,
+            delay_ms: self.broker_liveness_timeout_ms(),
+        });
+        effects
+    }
+
+    fn post_storage_reset_request(&self, request_id: &str) -> Vec<BrokerClientEffect> {
+        self.send_stamped(
+            |broker_instance_id| BrowserBrokerTabMessage::StorageResetRequest {
+                broker_instance_id,
+                request_id: request_id.to_string(),
+            },
+        )
+    }
+
+    fn arm_storage_reset_start_timer(
+        &mut self,
+        request_id: &str,
+        promise_id: u64,
+    ) -> Vec<BrokerClientEffect> {
+        let timer_id = self.alloc_timer_id();
+        self.reset_start_waiters
+            .entry(request_id.to_string())
+            .or_default()
+            .push(ResetStartWaiter {
+                promise_id,
+                timer_id: Some(timer_id),
+            });
+        vec![BrokerClientEffect::ArmTimer {
+            timer_id,
+            kind: BrokerClientTimerKind::StorageResetStart {
+                request_id: request_id.to_string(),
+                promise_id,
+            },
+            delay_ms: self.storage_reset_timeout_ms(),
+        }]
+    }
+
+    fn resolve_reset_start_waiters(&mut self, request_id: &str) -> Vec<BrokerClientEffect> {
+        let Some(waiters) = self.reset_start_waiters.remove(request_id) else {
+            return Vec::new();
+        };
+        let mut effects = Vec::new();
+        for waiter in waiters {
+            if let Some(timer_id) = waiter.timer_id {
+                effects.push(BrokerClientEffect::CancelTimer { timer_id });
+            }
+            effects.push(BrokerClientEffect::ResolvePublicPromise {
+                promise_id: waiter.promise_id,
+            });
+        }
+        effects
+    }
+
+    fn resolve_reset_completion_waiters(
+        &mut self,
+        request_id: &str,
+        success: bool,
+        error_message: Option<String>,
+    ) -> Vec<BrokerClientEffect> {
+        let Some(waiters) = self.reset_completion_waiters.remove(request_id) else {
+            return Vec::new();
+        };
+        waiters
+            .into_iter()
+            .map(|promise_id| {
+                if success {
+                    BrokerClientEffect::ResolvePublicPromise { promise_id }
+                } else {
+                    BrokerClientEffect::RejectPublicPromise {
+                        promise_id,
+                        reason: error_message
+                            .clone()
+                            .unwrap_or_else(|| "Browser storage reset failed".to_string()),
+                    }
+                }
+            })
+            .collect()
+    }
+
+    fn resolve_role_waiters(&mut self) -> Vec<BrokerClientEffect> {
+        let mut effects = Vec::new();
+        let mut index = 0;
+        while index < self.role_waiters.len() {
+            if self.role_available(self.role_waiters[index].role) {
+                let waiter = self.role_waiters.remove(index);
+                effects.push(BrokerClientEffect::CancelTimer {
+                    timer_id: waiter.timer_id,
+                });
+                effects.push(BrokerClientEffect::ResolvePublicPromise {
+                    promise_id: waiter.promise_id,
+                });
+            } else {
+                index += 1;
+            }
+        }
+        effects
+    }
+
+    fn reject_role_waiters(&mut self, reason: &str) -> Vec<BrokerClientEffect> {
+        self.role_waiters
+            .drain(..)
+            .flat_map(|waiter| {
+                [
+                    BrokerClientEffect::CancelTimer {
+                        timer_id: waiter.timer_id,
+                    },
+                    BrokerClientEffect::RejectPublicPromise {
+                        promise_id: waiter.promise_id,
+                        reason: reason.to_string(),
+                    },
+                ]
+            })
+            .collect()
+    }
+
+    fn reject_all_reset_waiters(&mut self, reason: &str) -> Vec<BrokerClientEffect> {
+        let mut effects = Vec::new();
+        let reset_start_waiters = std::mem::take(&mut self.reset_start_waiters);
+        for waiters in reset_start_waiters.into_values() {
+            for waiter in waiters {
+                if let Some(timer_id) = waiter.timer_id {
+                    effects.push(BrokerClientEffect::CancelTimer { timer_id });
+                }
+                effects.push(BrokerClientEffect::RejectPublicPromise {
+                    promise_id: waiter.promise_id,
+                    reason: reason.to_string(),
+                });
+            }
+        }
+        let reset_completion_waiters = std::mem::take(&mut self.reset_completion_waiters);
+        for promise_id in reset_completion_waiters.into_values().flatten() {
+            effects.push(BrokerClientEffect::RejectPublicPromise {
+                promise_id,
+                reason: reason.to_string(),
+            });
+        }
+        effects
+    }
+
+    fn send_stamped<F>(&self, make_message: F) -> Vec<BrokerClientEffect>
+    where
+        F: FnOnce(String) -> BrowserBrokerTabMessage,
+    {
+        if !self.can_post_to_broker() {
+            return Vec::new();
+        }
+        let broker_instance_id = self.broker_instance_id.clone().unwrap_or_default();
+        let port_id = self.current_port_id.unwrap_or_default();
+        vec![BrokerClientEffect::PostToBroker {
+            port_id,
+            message: make_message(broker_instance_id),
+        }]
+    }
+
+    fn can_post_to_broker(&self) -> bool {
+        !self.closed
+            && !self.reconnecting
+            && self.broker_instance_id.is_some()
+            && self.current_port_id.is_some()
+    }
+
+    fn invoke_callback(
+        &mut self,
+        callback: BrokerClientCallback,
+        pending: Option<PendingCallback>,
+    ) -> BrokerClientEffect {
+        let callback_id = self.alloc_callback_id();
+        if let Some(pending) = pending {
+            self.pending_callbacks.insert(callback_id, pending);
+        }
+        BrokerClientEffect::InvokeCallback {
+            callback_id,
+            callback,
+        }
+    }
+
+    fn close_with_error(
+        &mut self,
+        reason: String,
+        code: Option<String>,
+        include_detach: bool,
+    ) -> Vec<BrokerClientEffect> {
+        if self.closed {
+            return Vec::new();
+        }
+        self.closed = true;
+        self.reconnecting = false;
+
+        let mut effects = self.cancel_connection_timers();
+        if let Some(timer_id) = self.broker_liveness_timer_id.take() {
+            effects.push(BrokerClientEffect::CancelTimer { timer_id });
+        }
+        if include_detach {
+            if let Some(port_id) = self.current_port_id.take() {
+                effects.push(BrokerClientEffect::DetachPort {
+                    port_id,
+                    close: true,
+                });
+            }
+        }
+        effects.extend(self.reject_role_waiters(&reason));
+        effects.extend(self.reject_all_reset_waiters(&reason));
+        self.pending_reset_requests.clear();
+        self.broker_instance_id = None;
+        effects.push(BrokerClientEffect::CloseClient { reason, code });
+        effects
+    }
+
+    fn cancel_connection_timers(&mut self) -> Vec<BrokerClientEffect> {
+        let Some(connecting) = self.connecting.take() else {
+            return Vec::new();
+        };
+        let mut effects = vec![BrokerClientEffect::CancelTimer {
+            timer_id: connecting.hello_timer_id,
+        }];
+        if let Some(timer_id) = connecting.initial_leadership_timer_id {
+            effects.push(BrokerClientEffect::CancelTimer { timer_id });
+        }
+        effects
+    }
+
+    fn role_available(&self, role: BrokerRole) -> bool {
+        self.role == role && self.leader_tab_id.is_some()
+    }
+
+    fn config_tab_id(&self) -> Option<&str> {
+        self.config.as_ref().map(|config| config.tab_id.as_str())
+    }
+
+    fn broker_liveness_timeout_ms(&self) -> u32 {
+        let Some(config) = self.config.as_ref() else {
+            return DEFAULT_BROKER_PING_INTERVAL_MS + DEFAULT_BROKER_PONG_TIMEOUT_MS;
+        };
+        normalize_positive_timeout(
+            config.broker_ping_interval_ms,
+            DEFAULT_BROKER_PING_INTERVAL_MS,
+        ) + normalize_positive_timeout(
+            config.broker_pong_timeout_ms,
+            DEFAULT_BROKER_PONG_TIMEOUT_MS,
+        )
+    }
+
+    fn storage_reset_timeout_ms(&self) -> u32 {
+        normalize_positive_timeout(
+            self.config
+                .as_ref()
+                .and_then(|config| config.storage_reset_timeout_ms),
+            DEFAULT_STORAGE_RESET_TIMEOUT_MS,
+        )
+    }
+
+    fn alloc_worker_id(&mut self) -> u64 {
+        let id = self.next_worker_id;
+        self.next_worker_id += 1;
+        id
+    }
+
+    fn alloc_port_id(&mut self) -> u64 {
+        let id = self.next_port_id;
+        self.next_port_id += 1;
+        id
+    }
+
+    fn alloc_timer_id(&mut self) -> u64 {
+        let id = self.next_timer_id;
+        self.next_timer_id += 1;
+        id
+    }
+
+    fn alloc_callback_id(&mut self) -> u64 {
+        let id = self.next_callback_id;
+        self.next_callback_id += 1;
+        id
+    }
+}
+
+#[wasm_bindgen(js_name = BrokerClient)]
+pub struct BrokerClient {
+    core: BrokerClientCore,
+}
+
+#[wasm_bindgen(js_class = BrokerClient)]
+impl BrokerClient {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self {
+            core: BrokerClientCore::new(),
+        }
+    }
+
+    #[wasm_bindgen(js_name = handleEvent)]
+    pub fn handle_event(&mut self, event: JsValue) -> Result<JsValue, JsError> {
+        let event: BrokerClientEvent = serde_wasm_bindgen::from_value(event)
+            .map_err(|err| JsError::new(&format!("broker client event: {err}")))?;
+        let effects = self.core.handle(event);
+        serde_wasm_bindgen::to_value(&effects)
+            .map_err(|err| JsError::new(&format!("broker client effects: {err}")))
+    }
+
+    #[wasm_bindgen(js_name = snapshot)]
+    pub fn snapshot_js(&self) -> Result<JsValue, JsError> {
+        serde_wasm_bindgen::to_value(&self.core.snapshot())
+            .map_err(|err| JsError::new(&format!("broker client snapshot: {err}")))
+    }
+}
+
+fn default_respond_to_broker_ping() -> bool {
+    true
+}
+
+fn normalize_positive_timeout(value: Option<u32>, fallback: u32) -> u32 {
+    value.filter(|value| *value > 0).unwrap_or(fallback).max(1)
+}
+
+fn release_message_port(port_id: Option<u64>) -> Vec<BrokerClientEffect> {
+    port_id
+        .map(|port_id| vec![BrokerClientEffect::ReleaseMessagePort { port_id }])
+        .unwrap_or_default()
+}
+
+fn role_name(role: BrokerRole) -> &'static str {
+    match role {
+        BrokerRole::Leader => "leader",
+        BrokerRole::Follower => "follower",
+    }
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}

--- a/crates/jazz-wasm/src/broker_defaults.rs
+++ b/crates/jazz-wasm/src/broker_defaults.rs
@@ -1,0 +1,22 @@
+use serde::{Deserialize, Serialize};
+
+pub(crate) const DEFAULT_BROKER_PING_INTERVAL_MS: u32 = 1_000;
+pub(crate) const DEFAULT_BROKER_PONG_TIMEOUT_MS: u32 = 3_000;
+pub(crate) const DEFAULT_BROKER_HELLO_TIMEOUT_MS: u32 = 5_000;
+pub(crate) const DEFAULT_INITIAL_LEADERSHIP_TIMEOUT_MS: u32 = 100;
+pub(crate) const DEFAULT_STORAGE_RESET_TIMEOUT_MS: u32 = 5_000;
+pub(crate) const RESET_RECONNECT_ERROR: &str = "Browser broker restarted during storage reset";
+
+pub(crate) const DEFAULT_FORCE_TAKEOVER_TIMEOUT_MS: u32 = 1_000;
+pub(crate) const LEADER_FAILURE_RETRY_BACKOFF_MS: u64 = 1_000;
+pub(crate) const INITIAL_FOLLOWER_ATTACHMENT_TIMEOUT_MS: u32 = 1_000;
+pub(crate) const MAX_FOLLOWER_ATTACHMENT_TIMEOUT_MS: u32 = 30_000;
+pub(crate) const COMPLETED_STORAGE_RESET_OUTCOME_TTL_MS: u64 = 30_000;
+pub(crate) const MAX_COMPLETED_STORAGE_RESET_OUTCOMES: usize = 100;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BrokerVisibility {
+    Visible,
+    Hidden,
+}

--- a/crates/jazz-wasm/src/broker_election.rs
+++ b/crates/jazz-wasm/src/broker_election.rs
@@ -1,0 +1,2348 @@
+use std::collections::{HashMap, HashSet};
+
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+
+pub use crate::broker_defaults::BrokerVisibility;
+use crate::broker_defaults::{
+    COMPLETED_STORAGE_RESET_OUTCOME_TTL_MS, DEFAULT_BROKER_PING_INTERVAL_MS,
+    DEFAULT_BROKER_PONG_TIMEOUT_MS, DEFAULT_FORCE_TAKEOVER_TIMEOUT_MS,
+    INITIAL_FOLLOWER_ATTACHMENT_TIMEOUT_MS, LEADER_FAILURE_RETRY_BACKOFF_MS,
+    MAX_COMPLETED_STORAGE_RESET_OUTCOMES, MAX_FOLLOWER_ATTACHMENT_TIMEOUT_MS,
+};
+const INCOMPATIBLE_BROWSER_BROKER_CONFIGURATION_CODE: &str =
+    "incompatible-browser-broker-configuration";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ResetPhase {
+    Preparing,
+    Promoting,
+    Reconnecting,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(
+    tag = "type",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum BrokerTimerId {
+    BrokerPing,
+    LeaderFailureRetry,
+    FollowerAttachment {
+        follower_tab_id: String,
+        leadership_id: u32,
+    },
+    PreviousLeaderLocksForceTakeover {
+        election_id: u64,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TabConnected {
+    pub tab_id: String,
+    pub app_id: String,
+    pub db_name: String,
+    pub fingerprint: String,
+    pub visibility: BrokerVisibility,
+    pub now_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub force_takeover_timeout_ms: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub broker_ping_interval_ms: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub broker_pong_timeout_ms: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LeaderReady {
+    pub tab_id: String,
+    pub leadership_id: u32,
+    pub tab_lock_name: String,
+    pub worker_lock_name: String,
+    pub bridgeless_storage_reset: bool,
+    pub now_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageResetReady {
+    pub tab_id: String,
+    pub request_id: String,
+    pub success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+    pub now_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    tag = "type",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum BrokerEvent {
+    TabConnected(TabConnected),
+    VisibilityChanged {
+        tab_id: String,
+        visibility: BrokerVisibility,
+        now_ms: u64,
+    },
+    SchemaReported {
+        tab_id: String,
+        schema_fingerprint: String,
+    },
+    LeaderReady(LeaderReady),
+    LeaderFailed {
+        tab_id: String,
+        leadership_id: u32,
+        reason: String,
+        now_ms: u64,
+    },
+    FollowerPortAttached {
+        leader_tab_id: String,
+        follower_tab_id: String,
+        leadership_id: u32,
+        now_ms: u64,
+    },
+    FollowerPortClosed {
+        leader_tab_id: String,
+        follower_tab_id: String,
+        leadership_id: u32,
+        now_ms: u64,
+    },
+    StorageResetRequested {
+        tab_id: String,
+        request_id: String,
+        now_ms: u64,
+    },
+    StorageResetReady(StorageResetReady),
+    Shutdown {
+        tab_id: String,
+        now_ms: u64,
+    },
+    BrokerPong {
+        tab_id: String,
+        now_ms: u64,
+    },
+    TimerFired {
+        timer_id: BrokerTimerId,
+        now_ms: u64,
+    },
+    LeaderLockReleased {
+        leadership_id: u32,
+        now_ms: u64,
+    },
+    PreviousLeaderLocksReleased {
+        election_id: u64,
+        now_ms: u64,
+    },
+    ForceTakeoverComplete {
+        election_id: u64,
+        now_ms: u64,
+    },
+    ForceTakeoverFailed {
+        election_id: u64,
+        reason: String,
+        now_ms: u64,
+    },
+}
+
+impl BrokerEvent {
+    fn now_ms(&self) -> Option<u64> {
+        match self {
+            BrokerEvent::TabConnected(event) => Some(event.now_ms),
+            BrokerEvent::VisibilityChanged { now_ms, .. }
+            | BrokerEvent::LeaderFailed { now_ms, .. }
+            | BrokerEvent::FollowerPortAttached { now_ms, .. }
+            | BrokerEvent::FollowerPortClosed { now_ms, .. }
+            | BrokerEvent::StorageResetRequested { now_ms, .. }
+            | BrokerEvent::Shutdown { now_ms, .. }
+            | BrokerEvent::BrokerPong { now_ms, .. }
+            | BrokerEvent::TimerFired { now_ms, .. }
+            | BrokerEvent::LeaderLockReleased { now_ms, .. }
+            | BrokerEvent::PreviousLeaderLocksReleased { now_ms, .. }
+            | BrokerEvent::ForceTakeoverComplete { now_ms, .. }
+            | BrokerEvent::ForceTakeoverFailed { now_ms, .. } => Some(*now_ms),
+            BrokerEvent::LeaderReady(event) => Some(event.now_ms),
+            BrokerEvent::StorageResetReady(event) => Some(event.now_ms),
+            BrokerEvent::SchemaReported { .. } => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    tag = "type",
+    rename_all = "kebab-case",
+    rename_all_fields = "camelCase"
+)]
+pub enum BrokerControlMessage {
+    BrokerHello {
+        broker_instance_id: String,
+    },
+    Unsupported {
+        broker_instance_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        code: Option<String>,
+        reason: String,
+    },
+    BecomeLeader {
+        broker_instance_id: String,
+        leadership_id: u32,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reset_request_id: Option<String>,
+    },
+    Demote {
+        broker_instance_id: String,
+        leadership_id: u32,
+    },
+    LeaderReady {
+        broker_instance_id: String,
+        leader_tab_id: String,
+        leadership_id: u32,
+    },
+    SchemaBlocked {
+        broker_instance_id: String,
+        reason: String,
+    },
+    BrokerPing {
+        broker_instance_id: String,
+    },
+    AttachFollowerPort {
+        broker_instance_id: String,
+        follower_tab_id: String,
+        leadership_id: u32,
+    },
+    UseFollowerPort {
+        broker_instance_id: String,
+        leader_tab_id: String,
+        leadership_id: u32,
+    },
+    FollowerReady {
+        broker_instance_id: String,
+        leader_tab_id: String,
+        leadership_id: u32,
+    },
+    CloseFollowerPort {
+        broker_instance_id: String,
+        leadership_id: u32,
+    },
+    DetachFollowerPort {
+        broker_instance_id: String,
+        follower_tab_id: String,
+        leadership_id: u32,
+    },
+    StorageResetBegin {
+        broker_instance_id: String,
+        request_id: String,
+        leadership_id: u32,
+    },
+    StorageResetStarted {
+        broker_instance_id: String,
+        request_id: String,
+    },
+    StorageResetFinished {
+        broker_instance_id: String,
+        request_id: String,
+        success: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error_message: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    tag = "type",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum BrokerEffect {
+    SendToTab {
+        tab_id: String,
+        message: BrokerControlMessage,
+    },
+    CloseTabPort {
+        tab_id: String,
+    },
+    CloseReplacedTabPort {
+        tab_id: String,
+    },
+    Broadcast {
+        message: BrokerControlMessage,
+    },
+    ArmTimer {
+        timer_id: BrokerTimerId,
+        delay_ms: u32,
+    },
+    CancelTimer {
+        timer_id: BrokerTimerId,
+    },
+    StartLeaderLockMonitor {
+        leadership_id: u32,
+        tab_lock_name: String,
+        worker_lock_name: String,
+    },
+    CancelLeaderLockMonitor {
+        leadership_id: u32,
+    },
+    WaitForPreviousLeaderLocks {
+        election_id: u64,
+        tab_lock_name: String,
+        worker_lock_name: String,
+    },
+    StealPreviousLeaderLocks {
+        election_id: u64,
+        tab_lock_name: String,
+        worker_lock_name: String,
+    },
+    AssignFollowerPort {
+        leader_tab_id: String,
+        follower_tab_id: String,
+        leadership_id: u32,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BrokerSnapshot {
+    pub namespace_app_id: Option<String>,
+    pub namespace_db_name: Option<String>,
+    pub namespace_fingerprint: Option<String>,
+    pub schema_fingerprint: Option<String>,
+    pub force_takeover_timeout_ms: Option<u32>,
+    pub broker_pong_timeout_ms: Option<u32>,
+    pub connected_tab_count: usize,
+    pub leader_tab_id: Option<String>,
+    pub leader_ready: bool,
+    pub current_leadership_id: u32,
+    pub replacement_election_id: Option<u64>,
+    pub reset_phase: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BrokerElectionCore {
+    broker_instance_id: String,
+    namespace: Option<NamespaceState>,
+    tabs: HashMap<String, TabState>,
+    tab_order: Vec<String>,
+    leader: Option<LeaderState>,
+    current_leadership_id: u32,
+    broker_ping_timer_armed: bool,
+    leader_failure_retry_timer_armed: bool,
+    failed_leader_retry_after_by_tab_id: HashMap<String, u64>,
+    deferred_follower_attachments: HashSet<FollowerAttachmentKey>,
+    pending_follower_attachments: HashSet<FollowerAttachmentKey>,
+    attached_follower_ports: HashSet<FollowerAttachmentKey>,
+    follower_attachment_retry_counts: HashMap<FollowerAttachmentKey, u32>,
+    pending_lock_wait: Option<PendingLockWait>,
+    reset_state: Option<ResetState>,
+    completed_storage_reset_outcomes: Vec<StorageResetOutcome>,
+    next_election_id: u64,
+    last_now_ms: u64,
+}
+
+#[derive(Debug, Clone)]
+struct NamespaceState {
+    app_id: String,
+    db_name: String,
+    fingerprint: String,
+    force_takeover_timeout_ms: u32,
+    broker_ping_interval_ms: u32,
+    broker_pong_timeout_ms: u32,
+    schema_fingerprint: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct TabState {
+    tab_id: String,
+    visibility: BrokerVisibility,
+    last_visible_at: u64,
+    schema_fingerprint: Option<String>,
+    last_pong_at: u64,
+}
+
+#[derive(Debug, Clone)]
+struct LeaderState {
+    tab_id: String,
+    leadership_id: u32,
+    ready: bool,
+    tab_lock_name: Option<String>,
+    worker_lock_name: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ClearedLeaderState {
+    leadership_id: u32,
+    tab_lock_name: Option<String>,
+    worker_lock_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PendingLockWaitOwner {
+    ReplacementElection,
+    StorageReset,
+}
+
+#[derive(Debug, Clone)]
+struct PendingLockWait {
+    election_id: u64,
+    previous_leader: ClearedLeaderState,
+    owner: PendingLockWaitOwner,
+}
+
+#[derive(Debug, Clone)]
+struct ResetState {
+    request_id: String,
+    request_ids: Vec<String>,
+    participants: HashSet<String>,
+    prepared_tabs: HashSet<String>,
+    errors: Vec<String>,
+    previous_leader: Option<ClearedLeaderState>,
+    promoted_leadership_id: Option<u32>,
+    phase: ResetPhase,
+}
+
+#[derive(Debug, Clone)]
+struct StorageResetOutcome {
+    request_id: String,
+    success: bool,
+    error_message: Option<String>,
+    finished_at: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct FollowerAttachmentKey {
+    follower_tab_id: String,
+    leadership_id: u32,
+}
+
+impl BrokerElectionCore {
+    pub fn new(broker_instance_id: String) -> Self {
+        Self {
+            broker_instance_id,
+            namespace: None,
+            tabs: HashMap::new(),
+            tab_order: Vec::new(),
+            leader: None,
+            current_leadership_id: 0,
+            broker_ping_timer_armed: false,
+            leader_failure_retry_timer_armed: false,
+            failed_leader_retry_after_by_tab_id: HashMap::new(),
+            deferred_follower_attachments: HashSet::new(),
+            pending_follower_attachments: HashSet::new(),
+            attached_follower_ports: HashSet::new(),
+            follower_attachment_retry_counts: HashMap::new(),
+            pending_lock_wait: None,
+            reset_state: None,
+            completed_storage_reset_outcomes: Vec::new(),
+            next_election_id: 1,
+            last_now_ms: 0,
+        }
+    }
+
+    pub fn handle(&mut self, event: BrokerEvent) -> Vec<BrokerEffect> {
+        if let Some(now_ms) = event.now_ms() {
+            self.last_now_ms = now_ms;
+        }
+
+        match event {
+            BrokerEvent::TabConnected(event) => self.handle_tab_connected(event),
+            BrokerEvent::VisibilityChanged {
+                tab_id,
+                visibility,
+                now_ms,
+            } => self.handle_visibility_changed(tab_id, visibility, now_ms),
+            BrokerEvent::SchemaReported {
+                tab_id,
+                schema_fingerprint,
+            } => self.handle_schema_reported(tab_id, schema_fingerprint),
+            BrokerEvent::LeaderReady(event) => self.handle_leader_ready(event),
+            BrokerEvent::LeaderFailed {
+                tab_id,
+                leadership_id,
+                reason,
+                now_ms,
+            } => self.handle_leader_failed(tab_id, leadership_id, reason, now_ms),
+            BrokerEvent::FollowerPortAttached {
+                leader_tab_id,
+                follower_tab_id,
+                leadership_id,
+                now_ms,
+            } => self.handle_follower_port_attached(
+                leader_tab_id,
+                follower_tab_id,
+                leadership_id,
+                now_ms,
+            ),
+            BrokerEvent::FollowerPortClosed {
+                leader_tab_id,
+                follower_tab_id,
+                leadership_id,
+                now_ms: _,
+            } => self.handle_follower_port_closed(leader_tab_id, follower_tab_id, leadership_id),
+            BrokerEvent::StorageResetRequested {
+                tab_id,
+                request_id,
+                now_ms,
+            } => self.handle_storage_reset_requested(tab_id, request_id, now_ms),
+            BrokerEvent::StorageResetReady(event) => self.handle_storage_reset_ready(event),
+            BrokerEvent::Shutdown { tab_id, now_ms } => self.handle_shutdown(tab_id, now_ms),
+            BrokerEvent::BrokerPong { tab_id, now_ms } => {
+                if let Some(tab) = self.tabs.get_mut(&tab_id) {
+                    tab.last_pong_at = now_ms;
+                }
+                Vec::new()
+            }
+            BrokerEvent::TimerFired { timer_id, now_ms } => {
+                self.handle_timer_fired(timer_id, now_ms)
+            }
+            BrokerEvent::LeaderLockReleased {
+                leadership_id,
+                now_ms,
+            } => self.handle_leader_lock_released(leadership_id, now_ms),
+            BrokerEvent::PreviousLeaderLocksReleased {
+                election_id,
+                now_ms,
+            }
+            | BrokerEvent::ForceTakeoverComplete {
+                election_id,
+                now_ms,
+            } => self.complete_previous_leader_lock_wait(election_id, now_ms),
+            BrokerEvent::ForceTakeoverFailed {
+                election_id,
+                reason: _,
+                now_ms: _,
+            } => self.handle_force_takeover_failed(election_id),
+        }
+    }
+
+    pub fn snapshot(&self) -> BrokerSnapshot {
+        BrokerSnapshot {
+            namespace_app_id: self.namespace.as_ref().map(|ns| ns.app_id.clone()),
+            namespace_db_name: self.namespace.as_ref().map(|ns| ns.db_name.clone()),
+            namespace_fingerprint: self.namespace.as_ref().map(|ns| ns.fingerprint.clone()),
+            schema_fingerprint: self
+                .namespace
+                .as_ref()
+                .and_then(|ns| ns.schema_fingerprint.clone()),
+            force_takeover_timeout_ms: self
+                .namespace
+                .as_ref()
+                .map(|ns| ns.force_takeover_timeout_ms),
+            broker_pong_timeout_ms: self.namespace.as_ref().map(|ns| ns.broker_pong_timeout_ms),
+            connected_tab_count: self.tabs.len(),
+            leader_tab_id: self.leader.as_ref().map(|leader| leader.tab_id.clone()),
+            leader_ready: self
+                .leader
+                .as_ref()
+                .map(|leader| leader.ready)
+                .unwrap_or(false),
+            current_leadership_id: self.current_leadership_id,
+            replacement_election_id: self
+                .pending_lock_wait
+                .as_ref()
+                .filter(|wait| wait.owner == PendingLockWaitOwner::ReplacementElection)
+                .map(|wait| wait.election_id),
+            reset_phase: self.reset_state.as_ref().map(|reset| {
+                match reset.phase {
+                    ResetPhase::Preparing => "preparing",
+                    ResetPhase::Promoting => "promoting",
+                    ResetPhase::Reconnecting => "reconnecting",
+                }
+                .to_string()
+            }),
+        }
+    }
+
+    fn handle_tab_connected(&mut self, event: TabConnected) -> Vec<BrokerEffect> {
+        let mut effects = Vec::new();
+        self.prune_completed_storage_reset_outcomes(event.now_ms);
+
+        if self.namespace.is_none() {
+            self.namespace = Some(NamespaceState {
+                app_id: event.app_id.clone(),
+                db_name: event.db_name.clone(),
+                fingerprint: event.fingerprint.clone(),
+                force_takeover_timeout_ms: normalize_force_takeover_timeout(
+                    event.force_takeover_timeout_ms,
+                ),
+                broker_ping_interval_ms: normalize_positive_timeout(
+                    event.broker_ping_interval_ms,
+                    DEFAULT_BROKER_PING_INTERVAL_MS,
+                ),
+                broker_pong_timeout_ms: normalize_positive_timeout(
+                    event.broker_pong_timeout_ms,
+                    DEFAULT_BROKER_PONG_TIMEOUT_MS,
+                ),
+                schema_fingerprint: None,
+            });
+        }
+
+        if self.is_incompatible_namespace(&event) {
+            effects.push(BrokerEffect::SendToTab {
+                tab_id: event.tab_id.clone(),
+                message: self.unsupported_configuration_message(),
+            });
+            effects.push(BrokerEffect::CloseTabPort {
+                tab_id: event.tab_id,
+            });
+            return effects;
+        }
+
+        if self.tabs.contains_key(&event.tab_id) {
+            effects.push(BrokerEffect::CloseReplacedTabPort {
+                tab_id: event.tab_id.clone(),
+            });
+            effects.extend(self.clear_follower_attachment_state(&event.tab_id));
+        } else {
+            self.tab_order.push(event.tab_id.clone());
+        }
+
+        let last_visible_at = if event.visibility == BrokerVisibility::Visible {
+            event.now_ms
+        } else {
+            0
+        };
+        self.tabs.insert(
+            event.tab_id.clone(),
+            TabState {
+                tab_id: event.tab_id.clone(),
+                visibility: event.visibility,
+                last_visible_at,
+                schema_fingerprint: None,
+                last_pong_at: event.now_ms,
+            },
+        );
+
+        effects.extend(self.start_broker_ping_timer(event.now_ms));
+        effects.push(BrokerEffect::SendToTab {
+            tab_id: event.tab_id.clone(),
+            message: BrokerControlMessage::BrokerHello {
+                broker_instance_id: self.broker_instance_id.clone(),
+            },
+        });
+        effects.extend(self.redeliver_finished_storage_resets(&event.tab_id, event.now_ms));
+
+        if let Some(reset_phase) = self.reset_state.as_ref().map(|reset| reset.phase) {
+            effects.extend(self.add_tab_to_active_reset(&event.tab_id));
+            if reset_phase != ResetPhase::Preparing {
+                if let Some(leader) = self.leader.clone().filter(|leader| leader.ready) {
+                    effects.push(BrokerEffect::SendToTab {
+                        tab_id: event.tab_id.clone(),
+                        message: BrokerControlMessage::LeaderReady {
+                            broker_instance_id: self.broker_instance_id.clone(),
+                            leader_tab_id: leader.tab_id.clone(),
+                            leadership_id: leader.leadership_id,
+                        },
+                    });
+                    effects.extend(self.assign_follower_ports(&leader));
+                } else {
+                    effects.extend(self.defer_follower_attachment_for_tab(&event.tab_id));
+                }
+            }
+            return effects;
+        }
+
+        if self
+            .leader
+            .as_ref()
+            .map(|leader| leader.tab_id == event.tab_id)
+            .unwrap_or(false)
+        {
+            let leadership_id = self.leader.as_ref().map(|leader| leader.leadership_id);
+            if let Some(leadership_id) = leadership_id {
+                let (_cleared, clear_effects) = self.clear_leader(
+                    leadership_id,
+                    ClearLeaderOptions {
+                        demote_leader: false,
+                        remove_leader_tab: false,
+                    },
+                );
+                effects.extend(clear_effects);
+            }
+        }
+
+        if let Some(leader) = self.leader.clone().filter(|leader| leader.ready) {
+            effects.push(BrokerEffect::SendToTab {
+                tab_id: event.tab_id,
+                message: BrokerControlMessage::LeaderReady {
+                    broker_instance_id: self.broker_instance_id.clone(),
+                    leader_tab_id: leader.tab_id.clone(),
+                    leadership_id: leader.leadership_id,
+                },
+            });
+            effects.extend(self.assign_follower_ports(&leader));
+        } else {
+            effects.extend(self.elect_if_needed(event.now_ms));
+        }
+
+        effects
+    }
+
+    fn handle_visibility_changed(
+        &mut self,
+        tab_id: String,
+        visibility: BrokerVisibility,
+        now_ms: u64,
+    ) -> Vec<BrokerEffect> {
+        if let Some(tab) = self.tabs.get_mut(&tab_id) {
+            tab.visibility = visibility;
+            if visibility == BrokerVisibility::Visible {
+                tab.last_visible_at = now_ms;
+            }
+        }
+        self.evict_stale_tabs(now_ms)
+    }
+
+    fn handle_schema_reported(
+        &mut self,
+        tab_id: String,
+        schema_fingerprint: String,
+    ) -> Vec<BrokerEffect> {
+        if self.namespace.is_none() || !self.tabs.contains_key(&tab_id) {
+            return Vec::new();
+        }
+
+        if self
+            .namespace
+            .as_ref()
+            .and_then(|ns| ns.schema_fingerprint.as_ref())
+            .is_none()
+        {
+            if let Some(namespace) = self.namespace.as_mut() {
+                namespace.schema_fingerprint = Some(schema_fingerprint.clone());
+            }
+        }
+
+        if let Some(tab) = self.tabs.get_mut(&tab_id) {
+            tab.schema_fingerprint = Some(schema_fingerprint.clone());
+        }
+
+        let canonical = self
+            .namespace
+            .as_ref()
+            .and_then(|ns| ns.schema_fingerprint.as_ref());
+        if canonical != Some(&schema_fingerprint) {
+            return self.block_tab_for_schema_mismatch(&tab_id);
+        }
+
+        if let Some(leader) = self.leader.clone().filter(|leader| leader.ready) {
+            self.assign_follower_ports(&leader)
+        } else if self.reset_state.is_some() {
+            self.defer_follower_attachment_for_tab(&tab_id)
+        } else {
+            self.elect_if_needed(self.last_now_ms)
+        }
+    }
+
+    fn handle_leader_ready(&mut self, event: LeaderReady) -> Vec<BrokerEffect> {
+        let Some(current) = self.leader.as_mut() else {
+            return self.demote_if_connected(&event.tab_id, event.leadership_id);
+        };
+
+        if current.tab_id != event.tab_id || current.leadership_id != event.leadership_id {
+            return self.demote_if_connected(&event.tab_id, event.leadership_id);
+        }
+
+        if self
+            .reset_state
+            .as_ref()
+            .map(|reset| reset.promoted_leadership_id == Some(event.leadership_id))
+            .unwrap_or(false)
+            && event.bridgeless_storage_reset
+            && self
+                .tabs
+                .get(&event.tab_id)
+                .and_then(|tab| tab.schema_fingerprint.as_ref())
+                .is_none()
+        {
+            let (_cleared, mut effects) = self.clear_leader(
+                event.leadership_id,
+                ClearLeaderOptions {
+                    demote_leader: true,
+                    remove_leader_tab: false,
+                },
+            );
+            effects.extend(self.finish_storage_reset(true, None, event.now_ms));
+            return effects;
+        }
+
+        current.ready = true;
+        current.tab_lock_name = Some(event.tab_lock_name.clone());
+        current.worker_lock_name = Some(event.worker_lock_name.clone());
+        let leader = current.clone();
+        let is_reset_promoted_leader = self
+            .reset_state
+            .as_ref()
+            .map(|reset| reset.promoted_leadership_id == Some(event.leadership_id))
+            .unwrap_or(false);
+        if is_reset_promoted_leader {
+            if let Some(reset) = self.reset_state.as_mut() {
+                reset.phase = ResetPhase::Reconnecting;
+            }
+        }
+
+        let mut effects = vec![
+            BrokerEffect::Broadcast {
+                message: BrokerControlMessage::LeaderReady {
+                    broker_instance_id: self.broker_instance_id.clone(),
+                    leader_tab_id: leader.tab_id.clone(),
+                    leadership_id: leader.leadership_id,
+                },
+            },
+            BrokerEffect::StartLeaderLockMonitor {
+                leadership_id: leader.leadership_id,
+                tab_lock_name: event.tab_lock_name,
+                worker_lock_name: event.worker_lock_name,
+            },
+        ];
+        effects.extend(self.assign_follower_ports(&leader));
+
+        if is_reset_promoted_leader {
+            effects.extend(self.finish_storage_reset_if_reconnected(event.now_ms));
+        }
+
+        effects
+    }
+
+    fn handle_leader_failed(
+        &mut self,
+        tab_id: String,
+        leadership_id: u32,
+        reason: String,
+        now_ms: u64,
+    ) -> Vec<BrokerEffect> {
+        if self
+            .reset_state
+            .as_ref()
+            .map(|reset| reset.promoted_leadership_id == Some(leadership_id))
+            .unwrap_or(false)
+        {
+            if let Some(reset) = self.reset_state.as_mut() {
+                reset.errors.push(reason);
+            }
+            let mut effects = self.remove_tab(&tab_id, false, false, now_ms);
+            effects.extend(self.remove_tab_from_active_reset(&tab_id, now_ms));
+            self.leader = None;
+            if let Some(reset) = self.reset_state.as_mut() {
+                reset.promoted_leadership_id = None;
+            }
+            effects.extend(self.promote_reset_leader(now_ms));
+            return effects;
+        }
+
+        if self
+            .leader
+            .as_ref()
+            .map(|leader| leader.tab_id == tab_id && leader.leadership_id == leadership_id)
+            .unwrap_or(false)
+        {
+            self.failed_leader_retry_after_by_tab_id
+                .insert(tab_id, now_ms + LEADER_FAILURE_RETRY_BACKOFF_MS);
+            let (cleared, mut effects) = self.clear_leader(
+                leadership_id,
+                ClearLeaderOptions {
+                    demote_leader: true,
+                    remove_leader_tab: false,
+                },
+            );
+            effects.extend(self.schedule_replacement_election(cleared, now_ms));
+            return effects;
+        }
+
+        Vec::new()
+    }
+
+    fn handle_follower_port_attached(
+        &mut self,
+        leader_tab_id: String,
+        follower_tab_id: String,
+        leadership_id: u32,
+        now_ms: u64,
+    ) -> Vec<BrokerEffect> {
+        if !self
+            .leader
+            .as_ref()
+            .map(|leader| {
+                leader.tab_id == leader_tab_id
+                    && leader.leadership_id == leadership_id
+                    && leader.ready
+            })
+            .unwrap_or(false)
+        {
+            return Vec::new();
+        }
+
+        let key = FollowerAttachmentKey {
+            follower_tab_id: follower_tab_id.clone(),
+            leadership_id,
+        };
+        if !self.pending_follower_attachments.remove(&key) {
+            return Vec::new();
+        }
+        self.follower_attachment_retry_counts.remove(&key);
+
+        let Some(leader) = self.leader.as_ref() else {
+            return Vec::new();
+        };
+        if !self.tabs.contains_key(&follower_tab_id) {
+            return Vec::new();
+        }
+
+        self.attached_follower_ports.insert(key);
+        let mut effects = vec![
+            BrokerEffect::CancelTimer {
+                timer_id: BrokerTimerId::FollowerAttachment {
+                    follower_tab_id: follower_tab_id.clone(),
+                    leadership_id,
+                },
+            },
+            BrokerEffect::SendToTab {
+                tab_id: follower_tab_id,
+                message: BrokerControlMessage::FollowerReady {
+                    broker_instance_id: self.broker_instance_id.clone(),
+                    leader_tab_id: leader.tab_id.clone(),
+                    leadership_id,
+                },
+            },
+        ];
+        effects.extend(self.finish_storage_reset_if_reconnected(now_ms));
+        effects
+    }
+
+    fn handle_follower_port_closed(
+        &mut self,
+        leader_tab_id: String,
+        follower_tab_id: String,
+        leadership_id: u32,
+    ) -> Vec<BrokerEffect> {
+        if !self
+            .leader
+            .as_ref()
+            .map(|leader| leader.tab_id == leader_tab_id && leader.leadership_id == leadership_id)
+            .unwrap_or(false)
+        {
+            return Vec::new();
+        }
+
+        let mut effects = self.clear_follower_attachment_key(&follower_tab_id, leadership_id);
+        let Some(leader) = self.leader.clone().filter(|leader| leader.ready) else {
+            return effects;
+        };
+        effects.extend(self.assign_follower_ports(&leader));
+        effects
+    }
+
+    fn handle_storage_reset_requested(
+        &mut self,
+        tab_id: String,
+        request_id: String,
+        now_ms: u64,
+    ) -> Vec<BrokerEffect> {
+        if let Some(reset) = self.reset_state.as_mut() {
+            if !reset.request_ids.contains(&request_id) {
+                reset.request_ids.push(request_id.clone());
+            }
+            if self.tabs.contains_key(&tab_id) {
+                return vec![BrokerEffect::SendToTab {
+                    tab_id,
+                    message: BrokerControlMessage::StorageResetStarted {
+                        broker_instance_id: self.broker_instance_id.clone(),
+                        request_id,
+                    },
+                }];
+            }
+            return Vec::new();
+        }
+
+        let (previous_leader, mut effects) =
+            if let Some(leadership_id) = self.leader.as_ref().map(|leader| leader.leadership_id) {
+                self.clear_leader(
+                    leadership_id,
+                    ClearLeaderOptions {
+                        demote_leader: false,
+                        remove_leader_tab: false,
+                    },
+                )
+            } else {
+                (None, Vec::new())
+            };
+
+        let leadership_id = previous_leader
+            .as_ref()
+            .map(|leader| leader.leadership_id)
+            .unwrap_or(self.current_leadership_id);
+        let participants: HashSet<String> = self.all_tab_ids().into_iter().collect();
+        self.reset_state = Some(ResetState {
+            request_id: request_id.clone(),
+            request_ids: vec![request_id.clone()],
+            participants,
+            prepared_tabs: HashSet::new(),
+            errors: Vec::new(),
+            previous_leader,
+            promoted_leadership_id: None,
+            phase: ResetPhase::Preparing,
+        });
+
+        if self.tabs.contains_key(&tab_id) {
+            effects.push(BrokerEffect::SendToTab {
+                tab_id,
+                message: BrokerControlMessage::StorageResetStarted {
+                    broker_instance_id: self.broker_instance_id.clone(),
+                    request_id: request_id.clone(),
+                },
+            });
+        }
+
+        for participant in self.all_tab_ids() {
+            effects.push(BrokerEffect::SendToTab {
+                tab_id: participant,
+                message: BrokerControlMessage::StorageResetBegin {
+                    broker_instance_id: self.broker_instance_id.clone(),
+                    request_id: request_id.clone(),
+                    leadership_id,
+                },
+            });
+        }
+
+        effects.extend(self.continue_storage_reset_if_ready(now_ms));
+        effects
+    }
+
+    fn handle_storage_reset_ready(&mut self, event: StorageResetReady) -> Vec<BrokerEffect> {
+        let Some(reset) = self.reset_state.as_mut() else {
+            return Vec::new();
+        };
+        if reset.request_id != event.request_id || reset.phase != ResetPhase::Preparing {
+            return Vec::new();
+        }
+        if !reset.participants.contains(&event.tab_id) {
+            return Vec::new();
+        }
+        if !event.success {
+            reset.errors.push(event.error_message.unwrap_or_else(|| {
+                format!("Tab {} failed to prepare storage reset", event.tab_id)
+            }));
+        }
+        reset.prepared_tabs.insert(event.tab_id);
+        self.continue_storage_reset_if_ready(event.now_ms)
+    }
+
+    fn handle_shutdown(&mut self, tab_id: String, now_ms: u64) -> Vec<BrokerEffect> {
+        if self
+            .leader
+            .as_ref()
+            .map(|leader| leader.tab_id == tab_id)
+            .unwrap_or(false)
+        {
+            let leadership_id = self.leader.as_ref().unwrap().leadership_id;
+            let reset_promoted = self
+                .reset_state
+                .as_ref()
+                .map(|reset| {
+                    reset.promoted_leadership_id == Some(leadership_id)
+                        && reset.phase != ResetPhase::Preparing
+                })
+                .unwrap_or(false);
+            let mut effects = self.remove_tab(&tab_id, false, false, now_ms);
+            let (cleared, clear_effects) = self.clear_leader(
+                leadership_id,
+                ClearLeaderOptions {
+                    demote_leader: false,
+                    remove_leader_tab: false,
+                },
+            );
+            effects.extend(clear_effects);
+            effects.extend(self.remove_tab_from_active_reset(&tab_id, now_ms));
+            if reset_promoted {
+                if let Some(reset) = self.reset_state.as_mut() {
+                    reset.promoted_leadership_id = None;
+                }
+                effects.extend(self.promote_reset_leader(now_ms));
+                effects.extend(self.reset_if_idle());
+                return effects;
+            }
+            effects.extend(self.schedule_replacement_election(cleared, now_ms));
+            effects.extend(self.reset_if_idle());
+            return effects;
+        }
+
+        let mut effects = self.remove_tab(&tab_id, false, true, now_ms);
+        effects.extend(self.remove_tab_from_active_reset(&tab_id, now_ms));
+        effects.extend(self.reset_if_idle());
+        effects
+    }
+
+    fn handle_timer_fired(&mut self, timer_id: BrokerTimerId, now_ms: u64) -> Vec<BrokerEffect> {
+        match timer_id {
+            BrokerTimerId::BrokerPing => {
+                self.broker_ping_timer_armed = false;
+                let mut effects = self.send_broker_pings(now_ms);
+                if self.namespace.is_some() && !self.tabs.is_empty() {
+                    effects.extend(self.start_broker_ping_timer_without_immediate_ping());
+                }
+                effects
+            }
+            BrokerTimerId::LeaderFailureRetry => {
+                self.leader_failure_retry_timer_armed = false;
+                self.elect_if_needed(now_ms)
+            }
+            BrokerTimerId::FollowerAttachment {
+                follower_tab_id,
+                leadership_id,
+            } => self.handle_follower_attachment_timer(follower_tab_id, leadership_id),
+            BrokerTimerId::PreviousLeaderLocksForceTakeover { election_id } => {
+                self.handle_previous_leader_locks_force_timer(election_id)
+            }
+        }
+    }
+
+    fn handle_leader_lock_released(
+        &mut self,
+        leadership_id: u32,
+        now_ms: u64,
+    ) -> Vec<BrokerEffect> {
+        if !self
+            .leader
+            .as_ref()
+            .map(|leader| leader.leadership_id == leadership_id)
+            .unwrap_or(false)
+        {
+            return Vec::new();
+        }
+        let (cleared, mut effects) = self.clear_leader(
+            leadership_id,
+            ClearLeaderOptions {
+                demote_leader: true,
+                remove_leader_tab: true,
+            },
+        );
+        effects.extend(self.schedule_replacement_election(cleared, now_ms));
+        effects
+    }
+
+    fn handle_follower_attachment_timer(
+        &mut self,
+        follower_tab_id: String,
+        leadership_id: u32,
+    ) -> Vec<BrokerEffect> {
+        let key = FollowerAttachmentKey {
+            follower_tab_id: follower_tab_id.clone(),
+            leadership_id,
+        };
+        let was_pending = self.pending_follower_attachments.remove(&key);
+        let was_deferred = self.deferred_follower_attachments.remove(&key);
+        if !was_pending && !was_deferred {
+            return Vec::new();
+        }
+
+        if !self.tabs.contains_key(&follower_tab_id) {
+            return Vec::new();
+        };
+
+        let retry_count = self
+            .follower_attachment_retry_counts
+            .get(&key)
+            .copied()
+            .unwrap_or(0)
+            + 1;
+        self.follower_attachment_retry_counts
+            .insert(key, retry_count);
+
+        let Some(leader) = self
+            .leader
+            .clone()
+            .filter(|leader| leader.leadership_id == leadership_id)
+        else {
+            return Vec::new();
+        };
+
+        if leader.ready
+            && self
+                .reset_state
+                .as_ref()
+                .map(|reset| reset.phase == ResetPhase::Reconnecting)
+                .unwrap_or(true)
+        {
+            self.assign_follower_ports(&leader)
+        } else {
+            self.defer_follower_attachment_for_tab(&follower_tab_id)
+        }
+    }
+
+    fn handle_previous_leader_locks_force_timer(&self, election_id: u64) -> Vec<BrokerEffect> {
+        // Stale timers intentionally no-op after the natural lock release wins
+        // the race, or after a newer election replaces this wait.
+        self.pending_lock_wait
+            .as_ref()
+            .filter(|wait| wait.election_id == election_id)
+            .and_then(|wait| lock_names_from_cleared(&wait.previous_leader))
+            .map(|(tab_lock_name, worker_lock_name)| {
+                vec![BrokerEffect::StealPreviousLeaderLocks {
+                    election_id,
+                    tab_lock_name,
+                    worker_lock_name,
+                }]
+            })
+            .unwrap_or_default()
+    }
+
+    fn complete_previous_leader_lock_wait(
+        &mut self,
+        election_id: u64,
+        now_ms: u64,
+    ) -> Vec<BrokerEffect> {
+        let Some(wait) = self
+            .pending_lock_wait
+            .as_ref()
+            .filter(|wait| wait.election_id == election_id)
+            .cloned()
+        else {
+            return Vec::new();
+        };
+
+        self.pending_lock_wait = None;
+        let mut effects = vec![BrokerEffect::CancelTimer {
+            timer_id: BrokerTimerId::PreviousLeaderLocksForceTakeover { election_id },
+        }];
+        match wait.owner {
+            PendingLockWaitOwner::ReplacementElection => {
+                effects.extend(self.elect_if_needed(now_ms));
+            }
+            PendingLockWaitOwner::StorageReset => {
+                effects.extend(self.continue_storage_reset_after_previous_locks(now_ms));
+            }
+        }
+        effects
+    }
+
+    fn handle_force_takeover_failed(&self, election_id: u64) -> Vec<BrokerEffect> {
+        if !self
+            .pending_lock_wait
+            .as_ref()
+            .map(|wait| wait.election_id == election_id)
+            .unwrap_or(false)
+        {
+            return Vec::new();
+        }
+
+        let delay_ms = self
+            .namespace
+            .as_ref()
+            .map(|ns| ns.force_takeover_timeout_ms)
+            .unwrap_or(DEFAULT_FORCE_TAKEOVER_TIMEOUT_MS);
+        vec![BrokerEffect::ArmTimer {
+            timer_id: BrokerTimerId::PreviousLeaderLocksForceTakeover { election_id },
+            delay_ms,
+        }]
+    }
+
+    fn block_tab_for_schema_mismatch(&mut self, tab_id: &str) -> Vec<BrokerEffect> {
+        let mut effects = vec![BrokerEffect::SendToTab {
+            tab_id: tab_id.to_string(),
+            message: BrokerControlMessage::SchemaBlocked {
+                broker_instance_id: self.broker_instance_id.clone(),
+                reason: "incompatible persistent browser schema".to_string(),
+            },
+        }];
+
+        if let Some(leadership_id) = self
+            .leader
+            .as_ref()
+            .filter(|leader| leader.tab_id == tab_id)
+            .map(|leader| leader.leadership_id)
+        {
+            let (cleared, clear_effects) = self.clear_leader(
+                leadership_id,
+                ClearLeaderOptions {
+                    demote_leader: true,
+                    remove_leader_tab: false,
+                },
+            );
+            effects.extend(clear_effects);
+            effects.extend(self.schedule_replacement_election(cleared, self.last_now_ms));
+        }
+
+        effects
+    }
+
+    fn elect_if_needed(&mut self, now_ms: u64) -> Vec<BrokerEffect> {
+        if self.reset_state.is_some()
+            || self.pending_lock_wait.is_some()
+            || self
+                .leader
+                .as_ref()
+                .map(|leader| leader.ready)
+                .unwrap_or(false)
+            || self.tabs.is_empty()
+        {
+            return Vec::new();
+        }
+
+        if self.leader.is_some()
+            && self
+                .namespace
+                .as_ref()
+                .and_then(|ns| ns.schema_fingerprint.as_ref())
+                .is_none()
+        {
+            return Vec::new();
+        }
+
+        let Some(candidate) = self.select_leader_candidate(now_ms) else {
+            return self.schedule_leader_failure_retry_election(now_ms);
+        };
+
+        let mut effects = Vec::new();
+        if let Some(current) = self.leader.as_ref() {
+            let canonical = self
+                .namespace
+                .as_ref()
+                .and_then(|ns| ns.schema_fingerprint.as_ref());
+            let current_leader_is_canonical = self
+                .tabs
+                .get(&current.tab_id)
+                .and_then(|tab| tab.schema_fingerprint.as_ref())
+                == canonical;
+            if current_leader_is_canonical || candidate.tab_id == current.tab_id {
+                return Vec::new();
+            }
+            let (_cleared, clear_effects) = self.clear_leader(
+                current.leadership_id,
+                ClearLeaderOptions {
+                    demote_leader: true,
+                    remove_leader_tab: false,
+                },
+            );
+            effects.extend(clear_effects);
+        }
+
+        self.current_leadership_id += 1;
+        self.leader = Some(LeaderState {
+            tab_id: candidate.tab_id.clone(),
+            leadership_id: self.current_leadership_id,
+            ready: false,
+            tab_lock_name: self.current_leader_tab_lock_name(),
+            worker_lock_name: self.current_leader_worker_lock_name(),
+        });
+
+        effects.push(BrokerEffect::SendToTab {
+            tab_id: candidate.tab_id,
+            message: BrokerControlMessage::BecomeLeader {
+                broker_instance_id: self.broker_instance_id.clone(),
+                leadership_id: self.current_leadership_id,
+                reset_request_id: None,
+            },
+        });
+        effects
+    }
+
+    fn demote_if_connected(&self, tab_id: &str, leadership_id: u32) -> Vec<BrokerEffect> {
+        if !self.tabs.contains_key(tab_id) {
+            return Vec::new();
+        }
+        vec![BrokerEffect::SendToTab {
+            tab_id: tab_id.to_string(),
+            message: BrokerControlMessage::Demote {
+                broker_instance_id: self.broker_instance_id.clone(),
+                leadership_id,
+            },
+        }]
+    }
+
+    fn select_leader_candidate(&mut self, now_ms: u64) -> Option<TabState> {
+        let canonical_schema = self
+            .namespace
+            .as_ref()
+            .and_then(|ns| ns.schema_fingerprint.clone());
+        let mut candidates = Vec::new();
+        for tab_id in self.all_tab_ids() {
+            if self.is_leader_candidate_in_failure_backoff(&tab_id, now_ms) {
+                continue;
+            }
+            let Some(tab) = self.tabs.get(&tab_id).cloned() else {
+                continue;
+            };
+            if canonical_schema.is_some() && tab.schema_fingerprint != canonical_schema {
+                continue;
+            }
+            candidates.push(tab);
+        }
+
+        let visible: Vec<TabState> = candidates
+            .iter()
+            .filter(|tab| tab.visibility == BrokerVisibility::Visible)
+            .cloned()
+            .collect();
+        let pool = if visible.is_empty() {
+            candidates
+        } else {
+            visible
+        };
+
+        pool.into_iter().max_by(|left, right| {
+            left.last_visible_at
+                .cmp(&right.last_visible_at)
+                .then_with(|| left.tab_id.cmp(&right.tab_id))
+        })
+    }
+
+    fn assign_follower_ports(&mut self, leader: &LeaderState) -> Vec<BrokerEffect> {
+        if self
+            .reset_state
+            .as_ref()
+            .map(|reset| reset.phase != ResetPhase::Reconnecting)
+            .unwrap_or(false)
+        {
+            return Vec::new();
+        }
+
+        if !self.tabs.contains_key(&leader.tab_id) {
+            return Vec::new();
+        }
+
+        let canonical_schema = self
+            .namespace
+            .as_ref()
+            .and_then(|ns| ns.schema_fingerprint.clone());
+        let follower_ids: Vec<String> = self
+            .all_tab_ids()
+            .into_iter()
+            .filter_map(|tab_id| self.tabs.get(&tab_id).cloned())
+            .filter(|tab| tab.tab_id != leader.tab_id)
+            .filter(|tab| canonical_schema.is_none() || tab.schema_fingerprint == canonical_schema)
+            .map(|tab| tab.tab_id)
+            .collect();
+
+        let mut effects = Vec::new();
+        for follower_tab_id in follower_ids {
+            let key = FollowerAttachmentKey {
+                follower_tab_id: follower_tab_id.clone(),
+                leadership_id: leader.leadership_id,
+            };
+            if self.pending_follower_attachments.contains(&key)
+                || self.attached_follower_ports.contains(&key)
+            {
+                continue;
+            }
+            self.deferred_follower_attachments.remove(&key);
+            let delay_ms = self.follower_attachment_timeout_ms(&key);
+            self.pending_follower_attachments.insert(key);
+            effects.push(BrokerEffect::AssignFollowerPort {
+                leader_tab_id: leader.tab_id.clone(),
+                follower_tab_id: follower_tab_id.clone(),
+                leadership_id: leader.leadership_id,
+            });
+            effects.push(BrokerEffect::ArmTimer {
+                timer_id: BrokerTimerId::FollowerAttachment {
+                    follower_tab_id,
+                    leadership_id: leader.leadership_id,
+                },
+                delay_ms,
+            });
+        }
+        effects
+    }
+
+    fn defer_follower_attachment_for_tab(&mut self, follower_tab_id: &str) -> Vec<BrokerEffect> {
+        let Some(leader) = self.leader.clone() else {
+            return Vec::new();
+        };
+        let Some(tab) = self.tabs.get(follower_tab_id).cloned() else {
+            return Vec::new();
+        };
+        if !self.should_assign_follower_port(&tab, &leader) {
+            return Vec::new();
+        }
+
+        let key = FollowerAttachmentKey {
+            follower_tab_id: follower_tab_id.to_string(),
+            leadership_id: leader.leadership_id,
+        };
+        if self.pending_follower_attachments.contains(&key)
+            || self.deferred_follower_attachments.contains(&key)
+            || self.attached_follower_ports.contains(&key)
+        {
+            return Vec::new();
+        }
+
+        let delay_ms = self.follower_attachment_timeout_ms(&key);
+        self.deferred_follower_attachments.insert(key);
+        vec![BrokerEffect::ArmTimer {
+            timer_id: BrokerTimerId::FollowerAttachment {
+                follower_tab_id: follower_tab_id.to_string(),
+                leadership_id: leader.leadership_id,
+            },
+            delay_ms,
+        }]
+    }
+
+    fn defer_follower_attachments_for_leader(&mut self, leader: &LeaderState) -> Vec<BrokerEffect> {
+        let follower_ids: Vec<String> = self
+            .all_tab_ids()
+            .into_iter()
+            .filter_map(|tab_id| self.tabs.get(&tab_id).cloned())
+            .filter(|tab| self.should_assign_follower_port(tab, leader))
+            .map(|tab| tab.tab_id)
+            .collect();
+
+        let mut effects = Vec::new();
+        for follower_tab_id in follower_ids {
+            effects.extend(self.defer_follower_attachment_for_tab(&follower_tab_id));
+        }
+        effects
+    }
+
+    fn clear_leader(
+        &mut self,
+        leadership_id: u32,
+        options: ClearLeaderOptions,
+    ) -> (Option<ClearedLeaderState>, Vec<BrokerEffect>) {
+        let Some(current) = self.leader.clone() else {
+            return (None, Vec::new());
+        };
+        if current.leadership_id != leadership_id {
+            return (None, Vec::new());
+        }
+
+        let mut effects = vec![BrokerEffect::CancelLeaderLockMonitor { leadership_id }];
+        effects.extend(self.clear_all_follower_attachment_state());
+
+        if options.demote_leader && self.tabs.contains_key(&current.tab_id) {
+            effects.push(BrokerEffect::SendToTab {
+                tab_id: current.tab_id.clone(),
+                message: BrokerControlMessage::Demote {
+                    broker_instance_id: self.broker_instance_id.clone(),
+                    leadership_id,
+                },
+            });
+        }
+
+        for tab_id in self.all_tab_ids() {
+            if tab_id == current.tab_id {
+                continue;
+            }
+            effects.push(BrokerEffect::SendToTab {
+                tab_id,
+                message: BrokerControlMessage::CloseFollowerPort {
+                    broker_instance_id: self.broker_instance_id.clone(),
+                    leadership_id,
+                },
+            });
+        }
+
+        if options.remove_leader_tab {
+            effects.extend(self.remove_tab(&current.tab_id, false, false, self.last_now_ms));
+        }
+
+        self.leader = None;
+        (
+            Some(ClearedLeaderState {
+                leadership_id: current.leadership_id,
+                tab_lock_name: current.tab_lock_name,
+                worker_lock_name: current.worker_lock_name,
+            }),
+            effects,
+        )
+    }
+
+    fn remove_tab(
+        &mut self,
+        tab_id: &str,
+        close_port: bool,
+        notify_leader: bool,
+        now_ms: u64,
+    ) -> Vec<BrokerEffect> {
+        let Some(departed) = self.tabs.remove(tab_id) else {
+            return Vec::new();
+        };
+
+        self.tab_order
+            .retain(|ordered_tab_id| ordered_tab_id != tab_id);
+        self.failed_leader_retry_after_by_tab_id.remove(tab_id);
+        let mut effects = Vec::new();
+        if notify_leader {
+            if let Some(leader) = self
+                .leader
+                .as_ref()
+                .filter(|leader| leader.tab_id != tab_id)
+            {
+                if self.tabs.contains_key(&leader.tab_id) {
+                    effects.push(BrokerEffect::SendToTab {
+                        tab_id: leader.tab_id.clone(),
+                        message: BrokerControlMessage::DetachFollowerPort {
+                            broker_instance_id: self.broker_instance_id.clone(),
+                            follower_tab_id: tab_id.to_string(),
+                            leadership_id: leader.leadership_id,
+                        },
+                    });
+                }
+            }
+        }
+
+        effects.extend(self.clear_follower_attachment_state(tab_id));
+        effects.extend(self.reelect_schema_fingerprint_if_unheld(&departed, now_ms));
+        if close_port {
+            effects.push(BrokerEffect::CloseTabPort {
+                tab_id: tab_id.to_string(),
+            });
+        }
+        effects
+    }
+
+    fn remove_tab_from_active_reset(&mut self, tab_id: &str, now_ms: u64) -> Vec<BrokerEffect> {
+        let Some(reset) = self.reset_state.as_mut() else {
+            return Vec::new();
+        };
+        reset.participants.remove(tab_id);
+        reset.prepared_tabs.remove(tab_id);
+        self.continue_storage_reset_if_ready(now_ms)
+    }
+
+    fn reelect_schema_fingerprint_if_unheld(
+        &mut self,
+        departed: &TabState,
+        now_ms: u64,
+    ) -> Vec<BrokerEffect> {
+        let Some(canonical) = self
+            .namespace
+            .as_ref()
+            .and_then(|ns| ns.schema_fingerprint.clone())
+        else {
+            return Vec::new();
+        };
+        if departed.schema_fingerprint.as_deref() != Some(canonical.as_str()) {
+            return Vec::new();
+        }
+        if self
+            .tabs
+            .values()
+            .any(|tab| tab.schema_fingerprint.as_deref() == Some(canonical.as_str()))
+        {
+            return Vec::new();
+        }
+
+        let next = self
+            .all_tab_ids()
+            .into_iter()
+            .filter_map(|tab_id| self.tabs.get(&tab_id))
+            .find_map(|tab| tab.schema_fingerprint.clone());
+        if let Some(namespace) = self.namespace.as_mut() {
+            namespace.schema_fingerprint = next;
+        }
+
+        if self
+            .namespace
+            .as_ref()
+            .and_then(|ns| ns.schema_fingerprint.as_ref())
+            .is_none()
+        {
+            return Vec::new();
+        }
+
+        if let Some(leader) = self.leader.clone().filter(|leader| leader.ready) {
+            self.assign_follower_ports(&leader)
+        } else {
+            self.elect_if_needed(now_ms)
+        }
+    }
+
+    fn schedule_replacement_election(
+        &mut self,
+        previous_leader: Option<ClearedLeaderState>,
+        now_ms: u64,
+    ) -> Vec<BrokerEffect> {
+        if self.pending_lock_wait.is_some() {
+            return Vec::new();
+        }
+        let Some(previous_leader) = previous_leader else {
+            return self.elect_if_needed(now_ms);
+        };
+        let Some((tab_lock_name, worker_lock_name)) = lock_names_from_cleared(&previous_leader)
+        else {
+            return self.elect_if_needed(now_ms);
+        };
+
+        let election_id = self.next_election_id;
+        self.next_election_id += 1;
+        self.pending_lock_wait = Some(PendingLockWait {
+            election_id,
+            previous_leader,
+            owner: PendingLockWaitOwner::ReplacementElection,
+        });
+
+        vec![
+            BrokerEffect::WaitForPreviousLeaderLocks {
+                election_id,
+                tab_lock_name: tab_lock_name.clone(),
+                worker_lock_name: worker_lock_name.clone(),
+            },
+            BrokerEffect::ArmTimer {
+                timer_id: BrokerTimerId::PreviousLeaderLocksForceTakeover { election_id },
+                delay_ms: self.force_takeover_timeout_ms(),
+            },
+        ]
+    }
+
+    fn schedule_leader_failure_retry_election(&mut self, now_ms: u64) -> Vec<BrokerEffect> {
+        if self.leader_failure_retry_timer_armed
+            || self.reset_state.is_some()
+            || self.pending_lock_wait.is_some()
+            || self
+                .leader
+                .as_ref()
+                .map(|leader| leader.ready)
+                .unwrap_or(false)
+        {
+            return Vec::new();
+        }
+
+        let mut retry_at: Option<u64> = None;
+        let tab_ids: Vec<String> = self
+            .failed_leader_retry_after_by_tab_id
+            .keys()
+            .cloned()
+            .collect();
+        for tab_id in tab_ids {
+            if !self.tabs.contains_key(&tab_id) {
+                self.failed_leader_retry_after_by_tab_id.remove(&tab_id);
+                continue;
+            }
+            if let Some(candidate_retry_at) = self.failed_leader_retry_after_by_tab_id.get(&tab_id)
+            {
+                retry_at = Some(retry_at.map_or(*candidate_retry_at, |current| {
+                    current.min(*candidate_retry_at)
+                }));
+            }
+        }
+
+        let Some(retry_at) = retry_at else {
+            return Vec::new();
+        };
+        self.leader_failure_retry_timer_armed = true;
+        vec![BrokerEffect::ArmTimer {
+            timer_id: BrokerTimerId::LeaderFailureRetry,
+            delay_ms: retry_at.saturating_sub(now_ms) as u32,
+        }]
+    }
+
+    fn continue_storage_reset_if_ready(&mut self, now_ms: u64) -> Vec<BrokerEffect> {
+        let Some(reset) = self.reset_state.as_ref() else {
+            return Vec::new();
+        };
+        if reset.phase != ResetPhase::Preparing {
+            return Vec::new();
+        }
+        if reset
+            .participants
+            .iter()
+            .any(|participant| !reset.prepared_tabs.contains(participant))
+        {
+            return Vec::new();
+        }
+
+        if let Some(reset) = self.reset_state.as_mut() {
+            reset.phase = ResetPhase::Promoting;
+        }
+
+        let previous_leader = self
+            .reset_state
+            .as_ref()
+            .and_then(|reset| reset.previous_leader.clone());
+        let Some(previous_leader) = previous_leader else {
+            return self.continue_storage_reset_after_previous_locks(now_ms);
+        };
+        let Some((tab_lock_name, worker_lock_name)) = lock_names_from_cleared(&previous_leader)
+        else {
+            return self.continue_storage_reset_after_previous_locks(now_ms);
+        };
+
+        let election_id = self.next_election_id;
+        self.next_election_id += 1;
+        self.pending_lock_wait = Some(PendingLockWait {
+            election_id,
+            previous_leader,
+            owner: PendingLockWaitOwner::StorageReset,
+        });
+        vec![
+            BrokerEffect::WaitForPreviousLeaderLocks {
+                election_id,
+                tab_lock_name: tab_lock_name.clone(),
+                worker_lock_name: worker_lock_name.clone(),
+            },
+            BrokerEffect::ArmTimer {
+                timer_id: BrokerTimerId::PreviousLeaderLocksForceTakeover { election_id },
+                delay_ms: self.force_takeover_timeout_ms(),
+            },
+        ]
+    }
+
+    fn continue_storage_reset_after_previous_locks(&mut self, now_ms: u64) -> Vec<BrokerEffect> {
+        let Some(reset) = self.reset_state.as_ref() else {
+            return Vec::new();
+        };
+        if !reset.errors.is_empty() {
+            return self.finish_storage_reset(false, Some(reset.errors.join("; ")), now_ms);
+        }
+        self.promote_reset_leader(now_ms)
+    }
+
+    fn promote_reset_leader(&mut self, now_ms: u64) -> Vec<BrokerEffect> {
+        if self.reset_state.is_none() {
+            return Vec::new();
+        }
+
+        let Some(candidate) = self.select_leader_candidate(now_ms) else {
+            return self.finish_storage_reset(
+                false,
+                Some("No connected tab is available to reset storage".to_string()),
+                now_ms,
+            );
+        };
+
+        self.current_leadership_id += 1;
+        let reset_request_id = self
+            .reset_state
+            .as_ref()
+            .map(|reset| reset.request_id.clone());
+        if let Some(reset) = self.reset_state.as_mut() {
+            reset.promoted_leadership_id = Some(self.current_leadership_id);
+        }
+
+        let leader = LeaderState {
+            tab_id: candidate.tab_id.clone(),
+            leadership_id: self.current_leadership_id,
+            ready: false,
+            tab_lock_name: self.current_leader_tab_lock_name(),
+            worker_lock_name: self.current_leader_worker_lock_name(),
+        };
+        self.leader = Some(leader.clone());
+
+        let mut effects = vec![BrokerEffect::SendToTab {
+            tab_id: candidate.tab_id,
+            message: BrokerControlMessage::BecomeLeader {
+                broker_instance_id: self.broker_instance_id.clone(),
+                leadership_id: self.current_leadership_id,
+                reset_request_id,
+            },
+        }];
+        effects.extend(self.defer_follower_attachments_for_leader(&leader));
+        effects
+    }
+
+    fn finish_storage_reset(
+        &mut self,
+        success: bool,
+        error_message: Option<String>,
+        now_ms: u64,
+    ) -> Vec<BrokerEffect> {
+        let Some(reset) = self.reset_state.take() else {
+            return Vec::new();
+        };
+
+        let outcomes =
+            self.remember_storage_reset_outcomes(reset.request_ids, success, error_message, now_ms);
+        let mut effects = Vec::new();
+        for tab_id in self.all_tab_ids() {
+            for outcome in &outcomes {
+                effects.push(BrokerEffect::SendToTab {
+                    tab_id: tab_id.clone(),
+                    message: self.storage_reset_finished_message(outcome),
+                });
+            }
+        }
+        if !success {
+            effects.extend(self.elect_if_needed(now_ms));
+        }
+        effects
+    }
+
+    fn finish_storage_reset_if_reconnected(&mut self, now_ms: u64) -> Vec<BrokerEffect> {
+        let Some(reset) = self.reset_state.as_ref() else {
+            return Vec::new();
+        };
+        if reset.phase != ResetPhase::Reconnecting {
+            return Vec::new();
+        }
+        let Some(leader) = self.leader.as_ref().filter(|leader| {
+            leader.ready && Some(leader.leadership_id) == reset.promoted_leadership_id
+        }) else {
+            return Vec::new();
+        };
+
+        for participant in reset.participants.iter() {
+            let Some(tab) = self.tabs.get(participant) else {
+                continue;
+            };
+            if !self.should_assign_follower_port(tab, leader) {
+                continue;
+            }
+            if !self
+                .attached_follower_ports
+                .contains(&FollowerAttachmentKey {
+                    follower_tab_id: participant.clone(),
+                    leadership_id: leader.leadership_id,
+                })
+            {
+                return Vec::new();
+            }
+        }
+
+        self.finish_storage_reset(true, None, now_ms)
+    }
+
+    fn add_tab_to_active_reset(&mut self, tab_id: &str) -> Vec<BrokerEffect> {
+        let Some(reset) = self.reset_state.as_mut() else {
+            return Vec::new();
+        };
+        if reset.phase != ResetPhase::Preparing || !self.tabs.contains_key(tab_id) {
+            return Vec::new();
+        }
+        reset.participants.insert(tab_id.to_string());
+        let leadership_id = reset
+            .previous_leader
+            .as_ref()
+            .map(|leader| leader.leadership_id)
+            .unwrap_or(self.current_leadership_id);
+        vec![BrokerEffect::SendToTab {
+            tab_id: tab_id.to_string(),
+            message: BrokerControlMessage::StorageResetBegin {
+                broker_instance_id: self.broker_instance_id.clone(),
+                request_id: reset.request_id.clone(),
+                leadership_id,
+            },
+        }]
+    }
+
+    fn start_broker_ping_timer(&mut self, now_ms: u64) -> Vec<BrokerEffect> {
+        if self.broker_ping_timer_armed || self.namespace.is_none() {
+            return Vec::new();
+        }
+        let mut effects = self.send_broker_pings(now_ms);
+        effects.extend(self.start_broker_ping_timer_without_immediate_ping());
+        effects
+    }
+
+    fn start_broker_ping_timer_without_immediate_ping(&mut self) -> Vec<BrokerEffect> {
+        let Some(namespace) = self.namespace.as_ref() else {
+            return Vec::new();
+        };
+        if self.broker_ping_timer_armed {
+            return Vec::new();
+        }
+        self.broker_ping_timer_armed = true;
+        vec![BrokerEffect::ArmTimer {
+            timer_id: BrokerTimerId::BrokerPing,
+            delay_ms: namespace.broker_ping_interval_ms,
+        }]
+    }
+
+    fn stop_broker_ping_timer(&mut self) -> Vec<BrokerEffect> {
+        if !self.broker_ping_timer_armed {
+            return Vec::new();
+        }
+        self.broker_ping_timer_armed = false;
+        vec![BrokerEffect::CancelTimer {
+            timer_id: BrokerTimerId::BrokerPing,
+        }]
+    }
+
+    fn send_broker_pings(&mut self, now_ms: u64) -> Vec<BrokerEffect> {
+        if self.namespace.is_none() {
+            return Vec::new();
+        }
+        let mut effects = Vec::new();
+        for tab_id in self.all_tab_ids() {
+            if self.is_broker_pong_timed_out(&tab_id, now_ms) {
+                effects.extend(self.evict_tab(&tab_id, "missed broker pong", now_ms));
+                continue;
+            }
+            if self.tabs.contains_key(&tab_id) {
+                effects.push(BrokerEffect::SendToTab {
+                    tab_id,
+                    message: BrokerControlMessage::BrokerPing {
+                        broker_instance_id: self.broker_instance_id.clone(),
+                    },
+                });
+            }
+        }
+        effects
+    }
+
+    fn evict_stale_tabs(&mut self, now_ms: u64) -> Vec<BrokerEffect> {
+        let mut effects = Vec::new();
+        for tab_id in self.all_tab_ids() {
+            if self.is_broker_pong_timed_out(&tab_id, now_ms) {
+                effects.extend(self.evict_tab(&tab_id, "missed broker pong", now_ms));
+            }
+        }
+        effects
+    }
+
+    fn evict_tab(&mut self, tab_id: &str, _reason: &str, now_ms: u64) -> Vec<BrokerEffect> {
+        if !self.tabs.contains_key(tab_id) {
+            return Vec::new();
+        }
+
+        let was_leader = self
+            .leader
+            .as_ref()
+            .map(|leader| leader.tab_id == tab_id)
+            .unwrap_or(false);
+        let leadership_id = self.leader.as_ref().map(|leader| leader.leadership_id);
+        let reset_promoted = leadership_id
+            .and_then(|leadership_id| {
+                self.reset_state.as_ref().map(|reset| {
+                    reset.promoted_leadership_id == Some(leadership_id)
+                        && reset.phase != ResetPhase::Preparing
+                })
+            })
+            .unwrap_or(false);
+
+        let mut effects = self.remove_tab(tab_id, true, true, now_ms);
+        if was_leader {
+            if let Some(leadership_id) = leadership_id {
+                let (cleared, clear_effects) = self.clear_leader(
+                    leadership_id,
+                    ClearLeaderOptions {
+                        demote_leader: false,
+                        remove_leader_tab: false,
+                    },
+                );
+                effects.extend(clear_effects);
+                effects.extend(self.remove_tab_from_active_reset(tab_id, now_ms));
+                if reset_promoted {
+                    if let Some(reset) = self.reset_state.as_mut() {
+                        reset.promoted_leadership_id = None;
+                    }
+                    effects.extend(self.promote_reset_leader(now_ms));
+                    effects.extend(self.reset_if_idle());
+                    return effects;
+                }
+                effects.extend(self.schedule_replacement_election(cleared, now_ms));
+            }
+        } else {
+            effects.extend(self.remove_tab_from_active_reset(tab_id, now_ms));
+        }
+        effects.extend(self.reset_if_idle());
+        effects
+    }
+
+    fn reset_if_idle(&mut self) -> Vec<BrokerEffect> {
+        if !self.tabs.is_empty() {
+            return Vec::new();
+        }
+
+        let mut effects = Vec::new();
+        effects.extend(self.stop_broker_ping_timer());
+        if self.leader_failure_retry_timer_armed {
+            self.leader_failure_retry_timer_armed = false;
+            effects.push(BrokerEffect::CancelTimer {
+                timer_id: BrokerTimerId::LeaderFailureRetry,
+            });
+        }
+        if let Some(wait) = self.pending_lock_wait.take() {
+            effects.push(BrokerEffect::CancelTimer {
+                timer_id: BrokerTimerId::PreviousLeaderLocksForceTakeover {
+                    election_id: wait.election_id,
+                },
+            });
+        }
+        self.reset_state = None;
+        effects.extend(self.clear_all_follower_attachment_state());
+        self.namespace = None;
+        self.leader = None;
+        self.tab_order.clear();
+        self.failed_leader_retry_after_by_tab_id.clear();
+        effects
+    }
+
+    fn clear_all_follower_attachment_state(&mut self) -> Vec<BrokerEffect> {
+        let mut timers: Vec<FollowerAttachmentKey> = self
+            .pending_follower_attachments
+            .iter()
+            .chain(self.deferred_follower_attachments.iter())
+            .cloned()
+            .collect();
+        sort_and_dedup_follower_attachment_keys(&mut timers);
+        self.pending_follower_attachments.clear();
+        self.deferred_follower_attachments.clear();
+        self.attached_follower_ports.clear();
+        self.follower_attachment_retry_counts.clear();
+        timers
+            .into_iter()
+            .map(|key| BrokerEffect::CancelTimer {
+                timer_id: BrokerTimerId::FollowerAttachment {
+                    follower_tab_id: key.follower_tab_id,
+                    leadership_id: key.leadership_id,
+                },
+            })
+            .collect()
+    }
+
+    fn clear_follower_attachment_state(&mut self, follower_tab_id: &str) -> Vec<BrokerEffect> {
+        let mut timers: Vec<FollowerAttachmentKey> = self
+            .pending_follower_attachments
+            .iter()
+            .chain(self.deferred_follower_attachments.iter())
+            .filter(|key| key.follower_tab_id == follower_tab_id)
+            .cloned()
+            .collect();
+        sort_and_dedup_follower_attachment_keys(&mut timers);
+        for key in &timers {
+            self.pending_follower_attachments.remove(key);
+            self.deferred_follower_attachments.remove(key);
+            self.follower_attachment_retry_counts.remove(key);
+        }
+        self.attached_follower_ports
+            .retain(|key| key.follower_tab_id != follower_tab_id);
+        timers
+            .into_iter()
+            .map(|key| BrokerEffect::CancelTimer {
+                timer_id: BrokerTimerId::FollowerAttachment {
+                    follower_tab_id: key.follower_tab_id,
+                    leadership_id: key.leadership_id,
+                },
+            })
+            .collect()
+    }
+
+    fn clear_follower_attachment_key(
+        &mut self,
+        follower_tab_id: &str,
+        leadership_id: u32,
+    ) -> Vec<BrokerEffect> {
+        let key = FollowerAttachmentKey {
+            follower_tab_id: follower_tab_id.to_string(),
+            leadership_id,
+        };
+        let had_pending = self.pending_follower_attachments.remove(&key);
+        let had_deferred = self.deferred_follower_attachments.remove(&key);
+        self.attached_follower_ports.remove(&key);
+        self.follower_attachment_retry_counts.remove(&key);
+        if had_pending || had_deferred {
+            vec![BrokerEffect::CancelTimer {
+                timer_id: BrokerTimerId::FollowerAttachment {
+                    follower_tab_id: follower_tab_id.to_string(),
+                    leadership_id,
+                },
+            }]
+        } else {
+            Vec::new()
+        }
+    }
+
+    fn remember_storage_reset_outcomes(
+        &mut self,
+        request_ids: Vec<String>,
+        success: bool,
+        error_message: Option<String>,
+        now_ms: u64,
+    ) -> Vec<StorageResetOutcome> {
+        let mut outcomes = Vec::new();
+        for request_id in request_ids {
+            self.completed_storage_reset_outcomes
+                .retain(|outcome| outcome.request_id != request_id);
+            let outcome = StorageResetOutcome {
+                request_id,
+                success,
+                error_message: error_message.clone(),
+                finished_at: now_ms,
+            };
+            self.completed_storage_reset_outcomes.push(outcome.clone());
+            outcomes.push(outcome);
+        }
+        self.prune_completed_storage_reset_outcomes(now_ms);
+        outcomes
+    }
+
+    fn prune_completed_storage_reset_outcomes(&mut self, now_ms: u64) {
+        self.completed_storage_reset_outcomes.retain(|outcome| {
+            now_ms.saturating_sub(outcome.finished_at) <= COMPLETED_STORAGE_RESET_OUTCOME_TTL_MS
+        });
+        while self.completed_storage_reset_outcomes.len() > MAX_COMPLETED_STORAGE_RESET_OUTCOMES {
+            self.completed_storage_reset_outcomes.remove(0);
+        }
+    }
+
+    fn redeliver_finished_storage_resets(
+        &mut self,
+        tab_id: &str,
+        now_ms: u64,
+    ) -> Vec<BrokerEffect> {
+        self.prune_completed_storage_reset_outcomes(now_ms);
+        self.completed_storage_reset_outcomes
+            .iter()
+            .map(|outcome| BrokerEffect::SendToTab {
+                tab_id: tab_id.to_string(),
+                message: self.storage_reset_finished_message(outcome),
+            })
+            .collect()
+    }
+
+    fn is_broker_pong_timed_out(&self, tab_id: &str, now_ms: u64) -> bool {
+        let Some(namespace) = self.namespace.as_ref() else {
+            return false;
+        };
+        let Some(tab) = self.tabs.get(tab_id) else {
+            return false;
+        };
+        now_ms.saturating_sub(tab.last_pong_at) > namespace.broker_pong_timeout_ms as u64
+    }
+
+    fn is_leader_candidate_in_failure_backoff(&mut self, tab_id: &str, now_ms: u64) -> bool {
+        let Some(retry_after) = self
+            .failed_leader_retry_after_by_tab_id
+            .get(tab_id)
+            .copied()
+        else {
+            return false;
+        };
+        if retry_after <= now_ms {
+            self.failed_leader_retry_after_by_tab_id.remove(tab_id);
+            return false;
+        }
+        true
+    }
+
+    fn should_assign_follower_port(&self, tab: &TabState, leader: &LeaderState) -> bool {
+        if tab.tab_id == leader.tab_id {
+            return false;
+        }
+        let canonical = self
+            .namespace
+            .as_ref()
+            .and_then(|ns| ns.schema_fingerprint.as_ref());
+        canonical.is_none() || tab.schema_fingerprint.as_ref() == canonical
+    }
+
+    fn is_incompatible_namespace(&self, event: &TabConnected) -> bool {
+        let Some(namespace) = self.namespace.as_ref() else {
+            return false;
+        };
+        namespace.app_id != event.app_id
+            || namespace.db_name != event.db_name
+            || namespace.fingerprint != event.fingerprint
+    }
+
+    fn all_tab_ids(&self) -> Vec<String> {
+        self.tab_order
+            .iter()
+            .filter(|tab_id| self.tabs.contains_key(*tab_id))
+            .cloned()
+            .collect()
+    }
+
+    fn current_leader_tab_lock_name(&self) -> Option<String> {
+        self.namespace
+            .as_ref()
+            .map(|ns| format!("jazz-leader-tab:{}:{}", ns.app_id, ns.db_name))
+    }
+
+    fn current_leader_worker_lock_name(&self) -> Option<String> {
+        self.namespace
+            .as_ref()
+            .map(|ns| format!("jazz-leader-worker:{}:{}", ns.app_id, ns.db_name))
+    }
+
+    fn force_takeover_timeout_ms(&self) -> u32 {
+        self.namespace
+            .as_ref()
+            .map(|ns| ns.force_takeover_timeout_ms)
+            .unwrap_or(DEFAULT_FORCE_TAKEOVER_TIMEOUT_MS)
+    }
+
+    fn follower_attachment_timeout_ms(&self, key: &FollowerAttachmentKey) -> u32 {
+        let retry_count = self
+            .follower_attachment_retry_counts
+            .get(key)
+            .copied()
+            .unwrap_or(0);
+        INITIAL_FOLLOWER_ATTACHMENT_TIMEOUT_MS
+            .saturating_mul(2_u32.saturating_pow(retry_count))
+            .min(MAX_FOLLOWER_ATTACHMENT_TIMEOUT_MS)
+    }
+
+    fn unsupported_configuration_message(&self) -> BrokerControlMessage {
+        BrokerControlMessage::Unsupported {
+            broker_instance_id: self.broker_instance_id.clone(),
+            code: Some(INCOMPATIBLE_BROWSER_BROKER_CONFIGURATION_CODE.to_string()),
+            reason: "incompatible persistent browser configuration".to_string(),
+        }
+    }
+
+    fn storage_reset_finished_message(
+        &self,
+        outcome: &StorageResetOutcome,
+    ) -> BrokerControlMessage {
+        BrokerControlMessage::StorageResetFinished {
+            broker_instance_id: self.broker_instance_id.clone(),
+            request_id: outcome.request_id.clone(),
+            success: outcome.success,
+            error_message: outcome.error_message.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ClearLeaderOptions {
+    demote_leader: bool,
+    remove_leader_tab: bool,
+}
+
+fn lock_names_from_cleared(previous: &ClearedLeaderState) -> Option<(String, String)> {
+    Some((
+        previous.tab_lock_name.clone()?,
+        previous.worker_lock_name.clone()?,
+    ))
+}
+
+fn sort_and_dedup_follower_attachment_keys(keys: &mut Vec<FollowerAttachmentKey>) {
+    keys.sort_by(|left, right| {
+        left.leadership_id
+            .cmp(&right.leadership_id)
+            .then_with(|| left.follower_tab_id.cmp(&right.follower_tab_id))
+    });
+    keys.dedup();
+}
+
+#[wasm_bindgen(js_name = BrokerElection)]
+pub struct BrokerElection {
+    core: BrokerElectionCore,
+}
+
+#[wasm_bindgen(js_class = BrokerElection)]
+impl BrokerElection {
+    #[wasm_bindgen(constructor)]
+    pub fn new(broker_instance_id: String) -> Self {
+        Self {
+            core: BrokerElectionCore::new(broker_instance_id),
+        }
+    }
+
+    #[wasm_bindgen(js_name = handleEvent)]
+    pub fn handle_event(&mut self, event: JsValue) -> Result<JsValue, JsError> {
+        let event: BrokerEvent = serde_wasm_bindgen::from_value(event)
+            .map_err(|err| JsError::new(&format!("broker event: {err}")))?;
+        let effects = self.core.handle(event);
+        serde_wasm_bindgen::to_value(&effects)
+            .map_err(|err| JsError::new(&format!("broker effects: {err}")))
+    }
+
+    #[wasm_bindgen(js_name = snapshot)]
+    pub fn snapshot_js(&self) -> Result<JsValue, JsError> {
+        serde_wasm_bindgen::to_value(&self.core.snapshot())
+            .map_err(|err| JsError::new(&format!("broker snapshot: {err}")))
+    }
+}
+
+fn normalize_positive_timeout(value: Option<u32>, fallback: u32) -> u32 {
+    value.filter(|value| *value > 0).unwrap_or(fallback).max(1)
+}
+
+fn normalize_force_takeover_timeout(value: Option<u32>) -> u32 {
+    value.unwrap_or(DEFAULT_FORCE_TAKEOVER_TIMEOUT_MS)
+}

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -43,6 +43,9 @@
 
 #![allow(clippy::new_without_default)]
 
+pub mod broker_client;
+mod broker_defaults;
+pub mod broker_election;
 pub mod driver_bridge;
 pub mod query;
 pub mod runtime;
@@ -56,6 +59,8 @@ pub mod worker_protocol;
 pub mod ws_stream;
 
 // Re-export main types for JavaScript
+pub use broker_client::BrokerClient;
+pub use broker_election::BrokerElection;
 pub use driver_bridge::JsStorageDriver;
 pub use query::WasmQueryBuilder;
 pub use runtime::WasmRuntime;

--- a/crates/jazz-wasm/tests/broker_client.rs
+++ b/crates/jazz-wasm/tests/broker_client.rs
@@ -1,0 +1,757 @@
+use jazz_wasm::broker_client::{
+    BrokerClientCallback, BrokerClientCommand, BrokerClientCore, BrokerClientEffect,
+    BrokerClientEvent, BrokerClientTimerKind, BrokerControlMessage, BrokerRole, BrokerVisibility,
+    BrowserBrokerTabMessage, ConnectRequested,
+};
+
+fn connect_event() -> BrokerClientEvent {
+    BrokerClientEvent::ConnectRequested(ConnectRequested {
+        app_id: "app".to_string(),
+        db_name: "db".to_string(),
+        tab_id: "tab-a".to_string(),
+        fingerprint: "fingerprint".to_string(),
+        visibility: BrokerVisibility::Visible,
+        force_takeover_timeout_ms: None,
+        broker_ping_interval_ms: Some(10),
+        broker_pong_timeout_ms: Some(20),
+        storage_reset_timeout_ms: Some(30),
+        now_ms: 1,
+    })
+}
+
+fn broker_hello(now_ms: u64) -> BrokerClientEvent {
+    BrokerClientEvent::BrokerMessageReceived {
+        message: BrokerControlMessage::BrokerHello {
+            broker_instance_id: "instance-a".to_string(),
+        },
+        respond_to_broker_ping: true,
+        now_ms,
+    }
+}
+
+fn connected_client() -> BrokerClientCore {
+    let mut client = BrokerClientCore::new();
+    let _ = client.handle(connect_event());
+    let _ = client.handle(broker_hello(2));
+    let _ = client.handle(BrokerClientEvent::TimerFired {
+        timer_id: 2,
+        kind: BrokerClientTimerKind::InitialLeadership,
+        now_ms: 103,
+    });
+    client
+}
+
+#[test]
+fn broker_client_events_serialize_with_stable_js_field_names() {
+    let event = connect_event();
+
+    let json = serde_json::to_value(event).unwrap();
+    assert_eq!(json["type"], "connectRequested");
+    assert_eq!(json["tabId"], "tab-a");
+    assert_eq!(json["storageResetTimeoutMs"], 30);
+}
+
+#[test]
+fn broker_client_effects_serialize_with_stable_js_field_names() {
+    let effect = BrokerClientEffect::ArmTimer {
+        timer_id: 7,
+        kind: BrokerClientTimerKind::BrokerLiveness,
+        delay_ms: 30,
+    };
+
+    let json = serde_json::to_value(effect).unwrap();
+    assert_eq!(json["type"], "armTimer");
+    assert_eq!(json["timerId"], 7);
+    assert_eq!(json["kind"]["type"], "brokerLiveness");
+    assert_eq!(json["delayMs"], 30);
+}
+
+#[test]
+fn connect_requests_worker_and_posts_hello() {
+    let mut client = BrokerClientCore::new();
+    let effects = client.handle(connect_event());
+
+    assert_eq!(
+        effects,
+        vec![
+            BrokerClientEffect::CreateSharedWorker {
+                worker_id: 1,
+                name: "jazz-broker:app:db".to_string(),
+            },
+            BrokerClientEffect::AttachPortListeners { port_id: 1 },
+            BrokerClientEffect::PostToBroker {
+                port_id: 1,
+                message: BrowserBrokerTabMessage::Hello {
+                    tab_id: "tab-a".to_string(),
+                    app_id: "app".to_string(),
+                    db_name: "db".to_string(),
+                    fingerprint: "fingerprint".to_string(),
+                    visibility: BrokerVisibility::Visible,
+                    force_takeover_timeout_ms: None,
+                    broker_ping_interval_ms: Some(10),
+                    broker_pong_timeout_ms: Some(20),
+                },
+            },
+            BrokerClientEffect::ArmTimer {
+                timer_id: 1,
+                kind: BrokerClientTimerKind::BrokerHello,
+                delay_ms: 5_000,
+            },
+        ],
+    );
+}
+
+#[test]
+fn broker_hello_adopts_instance_and_arms_initial_leadership_timer() {
+    let mut client = BrokerClientCore::new();
+    let _ = client.handle(connect_event());
+
+    let effects = client.handle(broker_hello(2));
+
+    assert_eq!(
+        effects,
+        vec![
+            BrokerClientEffect::CancelTimer { timer_id: 1 },
+            BrokerClientEffect::ArmTimer {
+                timer_id: 2,
+                kind: BrokerClientTimerKind::InitialLeadership,
+                delay_ms: 100,
+            },
+        ],
+    );
+    assert_eq!(
+        client.snapshot().broker_instance_id.as_deref(),
+        Some("instance-a")
+    );
+}
+
+#[test]
+fn visibility_updates_are_stamped_with_active_broker_instance() {
+    let mut client = connected_client();
+
+    let effects = client.handle(BrokerClientEvent::PublicCommand {
+        command: BrokerClientCommand::ReportVisibility {
+            visibility: BrokerVisibility::Hidden,
+        },
+    });
+
+    assert_eq!(
+        effects,
+        vec![BrokerClientEffect::PostToBroker {
+            port_id: 1,
+            message: BrowserBrokerTabMessage::Visibility {
+                broker_instance_id: "instance-a".to_string(),
+                visibility: BrokerVisibility::Hidden,
+            },
+        }],
+    );
+    assert_eq!(client.snapshot().visibility, BrokerVisibility::Hidden);
+}
+
+#[test]
+fn messages_without_broker_instance_are_dropped() {
+    let mut client = BrokerClientCore::new();
+    let _ = client.handle(connect_event());
+
+    let effects = client.handle(BrokerClientEvent::PublicCommand {
+        command: BrokerClientCommand::ReportSchemaReady {
+            schema_fingerprint: "schema-a".to_string(),
+        },
+    });
+
+    assert!(effects.is_empty());
+}
+
+#[test]
+fn leader_ready_sets_leader_role_for_own_tab() {
+    let mut client = connected_client();
+
+    let effects = client.handle(BrokerClientEvent::BrokerMessageReceived {
+        message: BrokerControlMessage::LeaderReady {
+            broker_instance_id: "instance-a".to_string(),
+            leader_tab_id: "tab-a".to_string(),
+            leadership_id: 1,
+        },
+        respond_to_broker_ping: true,
+        now_ms: 3,
+    });
+
+    assert!(effects.is_empty());
+    assert_eq!(client.snapshot().role, BrokerRole::Leader);
+    assert_eq!(client.snapshot().leader_tab_id.as_deref(), Some("tab-a"));
+    assert_eq!(client.snapshot().leadership_id, 1);
+}
+
+#[test]
+fn become_leader_callback_failure_reports_leader_failed() {
+    let mut client = connected_client();
+
+    let effects = client.handle(BrokerClientEvent::BrokerMessageReceived {
+        message: BrokerControlMessage::BecomeLeader {
+            broker_instance_id: "instance-a".to_string(),
+            leadership_id: 2,
+            reset_request_id: None,
+        },
+        respond_to_broker_ping: true,
+        now_ms: 3,
+    });
+
+    assert_eq!(
+        effects,
+        vec![BrokerClientEffect::InvokeCallback {
+            callback_id: 1,
+            callback: BrokerClientCallback::BecomeLeader {
+                leadership_id: 2,
+                reset_request_id: None,
+            },
+        }],
+    );
+
+    let effects = client.handle(BrokerClientEvent::CallbackRejected {
+        callback_id: 1,
+        error_message: "boom".to_string(),
+        now_ms: 4,
+    });
+
+    assert_eq!(
+        effects,
+        vec![BrokerClientEffect::PostToBroker {
+            port_id: 1,
+            message: BrowserBrokerTabMessage::LeaderFailed {
+                broker_instance_id: "instance-a".to_string(),
+                leadership_id: 2,
+                reason: "boom".to_string(),
+            },
+        }],
+    );
+}
+
+#[test]
+fn future_demote_invokes_callback_without_clearing_current_role() {
+    let mut client = connected_client();
+    let _ = client.handle(BrokerClientEvent::BrokerMessageReceived {
+        message: BrokerControlMessage::LeaderReady {
+            broker_instance_id: "instance-a".to_string(),
+            leader_tab_id: "tab-a".to_string(),
+            leadership_id: 1,
+        },
+        respond_to_broker_ping: true,
+        now_ms: 3,
+    });
+
+    let effects = client.handle(BrokerClientEvent::BrokerMessageReceived {
+        message: BrokerControlMessage::Demote {
+            broker_instance_id: "instance-a".to_string(),
+            leadership_id: 2,
+        },
+        respond_to_broker_ping: true,
+        now_ms: 4,
+    });
+
+    assert_eq!(
+        effects,
+        vec![BrokerClientEffect::InvokeCallback {
+            callback_id: 1,
+            callback: BrokerClientCallback::Demote { leadership_id: 2 },
+        }],
+    );
+    assert_eq!(client.snapshot().role, BrokerRole::Leader);
+    assert_eq!(client.snapshot().leadership_id, 1);
+}
+
+#[test]
+fn wait_for_role_resolves_after_follower_ready() {
+    let mut client = connected_client();
+
+    let effects = client.handle(BrokerClientEvent::PublicCommand {
+        command: BrokerClientCommand::WaitForRole {
+            role: BrokerRole::Follower,
+            promise_id: 42,
+            timeout_ms: 5_000,
+        },
+    });
+
+    assert_eq!(
+        effects,
+        vec![BrokerClientEffect::ArmTimer {
+            timer_id: 4,
+            kind: BrokerClientTimerKind::RoleWaiter { promise_id: 42 },
+            delay_ms: 5_000,
+        }],
+    );
+
+    let effects = client.handle(BrokerClientEvent::BrokerMessageReceived {
+        message: BrokerControlMessage::FollowerReady {
+            broker_instance_id: "instance-a".to_string(),
+            leader_tab_id: "leader-a".to_string(),
+            leadership_id: 3,
+        },
+        respond_to_broker_ping: true,
+        now_ms: 4,
+    });
+
+    assert_eq!(
+        effects,
+        vec![
+            BrokerClientEffect::InvokeCallback {
+                callback_id: 1,
+                callback: BrokerClientCallback::FollowerReady {
+                    leader_tab_id: "leader-a".to_string(),
+                    leadership_id: 3,
+                },
+            },
+            BrokerClientEffect::CancelTimer { timer_id: 4 },
+            BrokerClientEffect::ResolvePublicPromise { promise_id: 42 },
+        ],
+    );
+}
+
+#[test]
+fn stale_follower_port_messages_release_transferred_ports() {
+    let mut client = connected_client();
+    let _ = client.handle(BrokerClientEvent::BrokerMessageReceived {
+        message: BrokerControlMessage::LeaderReady {
+            broker_instance_id: "instance-a".to_string(),
+            leader_tab_id: "tab-a".to_string(),
+            leadership_id: 5,
+        },
+        respond_to_broker_ping: true,
+        now_ms: 4,
+    });
+
+    let stale_attach_effects = client.handle(BrokerClientEvent::BrokerMessageReceived {
+        message: BrokerControlMessage::AttachFollowerPort {
+            broker_instance_id: "instance-a".to_string(),
+            follower_tab_id: "tab-b".to_string(),
+            leadership_id: 4,
+            port_id: Some(7),
+        },
+        respond_to_broker_ping: true,
+        now_ms: 5,
+    });
+    assert_eq!(
+        stale_attach_effects,
+        vec![BrokerClientEffect::ReleaseMessagePort { port_id: 7 }],
+    );
+
+    let stale_use_effects = client.handle(BrokerClientEvent::BrokerMessageReceived {
+        message: BrokerControlMessage::UseFollowerPort {
+            broker_instance_id: "instance-a".to_string(),
+            leader_tab_id: "tab-old".to_string(),
+            leadership_id: 4,
+            port_id: Some(8),
+        },
+        respond_to_broker_ping: true,
+        now_ms: 6,
+    });
+    assert_eq!(
+        stale_use_effects,
+        vec![BrokerClientEffect::ReleaseMessagePort { port_id: 8 }],
+    );
+    assert_eq!(client.snapshot().role, BrokerRole::Leader);
+    assert_eq!(client.snapshot().leadership_id, 5);
+}
+
+#[test]
+fn reconnect_replays_latest_visibility_and_pending_reset() {
+    let mut client = connected_client();
+    let _ = client.handle(BrokerClientEvent::PublicCommand {
+        command: BrokerClientCommand::ReportVisibility {
+            visibility: BrokerVisibility::Hidden,
+        },
+    });
+
+    let effects = client.handle(BrokerClientEvent::BrokerMessageReceived {
+        message: BrokerControlMessage::BrokerPing {
+            broker_instance_id: "instance-b".to_string(),
+        },
+        respond_to_broker_ping: true,
+        now_ms: 10,
+    });
+
+    assert_eq!(
+        effects,
+        vec![
+            BrokerClientEffect::CancelTimer { timer_id: 3 },
+            BrokerClientEffect::DetachPort {
+                port_id: 1,
+                close: true,
+            },
+            BrokerClientEffect::CreateSharedWorker {
+                worker_id: 2,
+                name: "jazz-broker:app:db".to_string(),
+            },
+            BrokerClientEffect::AttachPortListeners { port_id: 2 },
+            BrokerClientEffect::PostToBroker {
+                port_id: 2,
+                message: BrowserBrokerTabMessage::Hello {
+                    tab_id: "tab-a".to_string(),
+                    app_id: "app".to_string(),
+                    db_name: "db".to_string(),
+                    fingerprint: "fingerprint".to_string(),
+                    visibility: BrokerVisibility::Hidden,
+                    force_takeover_timeout_ms: None,
+                    broker_ping_interval_ms: Some(10),
+                    broker_pong_timeout_ms: Some(20),
+                },
+            },
+            BrokerClientEffect::ArmTimer {
+                timer_id: 4,
+                kind: BrokerClientTimerKind::BrokerHello,
+                delay_ms: 5_000,
+            },
+        ],
+    );
+
+    let effects = client.handle(BrokerClientEvent::PublicCommand {
+        command: BrokerClientCommand::RequestStorageReset {
+            request_id: "reset-a".to_string(),
+            start_promise_id: 10,
+            completion_promise_id: 11,
+        },
+    });
+    assert!(effects.is_empty());
+
+    let _ = client.handle(BrokerClientEvent::BrokerMessageReceived {
+        message: BrokerControlMessage::BrokerHello {
+            broker_instance_id: "instance-b".to_string(),
+        },
+        respond_to_broker_ping: true,
+        now_ms: 11,
+    });
+
+    let effects = client.handle(BrokerClientEvent::TimerFired {
+        timer_id: 5,
+        kind: BrokerClientTimerKind::InitialLeadership,
+        now_ms: 112,
+    });
+
+    assert_eq!(
+        effects,
+        vec![
+            BrokerClientEffect::CancelTimer { timer_id: 5 },
+            BrokerClientEffect::ArmTimer {
+                timer_id: 6,
+                kind: BrokerClientTimerKind::BrokerLiveness,
+                delay_ms: 30,
+            },
+            BrokerClientEffect::PostToBroker {
+                port_id: 2,
+                message: BrowserBrokerTabMessage::Visibility {
+                    broker_instance_id: "instance-b".to_string(),
+                    visibility: BrokerVisibility::Hidden,
+                },
+            },
+            BrokerClientEffect::PostToBroker {
+                port_id: 2,
+                message: BrowserBrokerTabMessage::StorageResetRequest {
+                    broker_instance_id: "instance-b".to_string(),
+                    request_id: "reset-a".to_string(),
+                },
+            },
+            BrokerClientEffect::ArmTimer {
+                timer_id: 7,
+                kind: BrokerClientTimerKind::StorageResetStart {
+                    request_id: "reset-a".to_string(),
+                    promise_id: 10,
+                },
+                delay_ms: 30,
+            },
+            BrokerClientEffect::InvokeCallback {
+                callback_id: 1,
+                callback: BrokerClientCallback::Reconnected,
+            },
+        ],
+    );
+}
+
+#[test]
+fn reconnect_replayed_storage_reset_resolves_start_waiter_once() {
+    let mut client = connected_client();
+    let _ = client.handle(BrokerClientEvent::BrokerMessageReceived {
+        message: BrokerControlMessage::BrokerPing {
+            broker_instance_id: "instance-b".to_string(),
+        },
+        respond_to_broker_ping: true,
+        now_ms: 10,
+    });
+    let _ = client.handle(BrokerClientEvent::PublicCommand {
+        command: BrokerClientCommand::RequestStorageReset {
+            request_id: "reset-a".to_string(),
+            start_promise_id: 10,
+            completion_promise_id: 11,
+        },
+    });
+    let _ = client.handle(BrokerClientEvent::BrokerMessageReceived {
+        message: BrokerControlMessage::BrokerHello {
+            broker_instance_id: "instance-b".to_string(),
+        },
+        respond_to_broker_ping: true,
+        now_ms: 11,
+    });
+    let _ = client.handle(BrokerClientEvent::TimerFired {
+        timer_id: 5,
+        kind: BrokerClientTimerKind::InitialLeadership,
+        now_ms: 112,
+    });
+
+    let effects = client.handle(BrokerClientEvent::BrokerMessageReceived {
+        message: BrokerControlMessage::StorageResetStarted {
+            broker_instance_id: "instance-b".to_string(),
+            request_id: "reset-a".to_string(),
+        },
+        respond_to_broker_ping: true,
+        now_ms: 113,
+    });
+
+    assert_eq!(
+        effects,
+        vec![
+            BrokerClientEffect::CancelTimer { timer_id: 7 },
+            BrokerClientEffect::ResolvePublicPromise { promise_id: 10 },
+        ],
+    );
+}
+
+#[test]
+fn storage_reset_start_timeout_rejects_only_start_waiter() {
+    let mut client = connected_client();
+    let _ = client.handle(BrokerClientEvent::PublicCommand {
+        command: BrokerClientCommand::RequestStorageReset {
+            request_id: "reset-a".to_string(),
+            start_promise_id: 10,
+            completion_promise_id: 11,
+        },
+    });
+
+    let effects = client.handle(BrokerClientEvent::TimerFired {
+        timer_id: 4,
+        kind: BrokerClientTimerKind::StorageResetStart {
+            request_id: "reset-a".to_string(),
+            promise_id: 10,
+        },
+        now_ms: 40,
+    });
+
+    assert_eq!(
+        effects,
+        vec![BrokerClientEffect::RejectPublicPromise {
+            promise_id: 10,
+            reason: "Timed out waiting for browser storage reset reset-a to start".to_string(),
+        }],
+    );
+
+    let effects = client.handle(BrokerClientEvent::BrokerMessageReceived {
+        message: BrokerControlMessage::StorageResetFinished {
+            broker_instance_id: "instance-a".to_string(),
+            request_id: "reset-a".to_string(),
+            success: true,
+            error_message: None,
+        },
+        respond_to_broker_ping: true,
+        now_ms: 41,
+    });
+
+    assert_eq!(
+        effects,
+        vec![BrokerClientEffect::ResolvePublicPromise { promise_id: 11 }],
+    );
+}
+
+#[test]
+fn broker_ping_callback_can_suppress_pong() {
+    let mut client = connected_client();
+
+    let effects = client.handle(BrokerClientEvent::BrokerMessageReceived {
+        message: BrokerControlMessage::BrokerPing {
+            broker_instance_id: "instance-a".to_string(),
+        },
+        respond_to_broker_ping: false,
+        now_ms: 10,
+    });
+
+    assert!(effects.iter().any(|effect| {
+        matches!(
+            effect,
+            BrokerClientEffect::InvokeCallback {
+                callback: BrokerClientCallback::BrokerPing,
+                ..
+            }
+        )
+    }));
+    assert!(
+        effects.iter().all(|effect| {
+            !matches!(
+                effect,
+                BrokerClientEffect::PostToBroker {
+                    message: BrowserBrokerTabMessage::BrokerPong { .. },
+                    ..
+                }
+            )
+        }),
+        "broker-pong should not be emitted when respond_to_broker_ping is false: {effects:#?}",
+    );
+}
+
+#[test]
+fn reconnect_during_storage_reset_rejects_active_waiters() {
+    let mut client = connected_client();
+    let _ = client.handle(BrokerClientEvent::PublicCommand {
+        command: BrokerClientCommand::RequestStorageReset {
+            request_id: "reset-a".to_string(),
+            start_promise_id: 10,
+            completion_promise_id: 11,
+        },
+    });
+
+    let effects = client.handle(BrokerClientEvent::BrokerMessageReceived {
+        message: BrokerControlMessage::BrokerPing {
+            broker_instance_id: "instance-b".to_string(),
+        },
+        respond_to_broker_ping: true,
+        now_ms: 10,
+    });
+
+    assert!(effects.contains(&BrokerClientEffect::RejectPublicPromise {
+        promise_id: 10,
+        reason: "Browser broker restarted during storage reset".to_string(),
+    }));
+    assert!(effects.contains(&BrokerClientEffect::RejectPublicPromise {
+        promise_id: 11,
+        reason: "Browser broker restarted during storage reset".to_string(),
+    }));
+}
+
+#[test]
+fn reconnect_rejects_reset_waiters_in_request_order() {
+    let mut client = connected_client();
+    let _ = client.handle(BrokerClientEvent::PublicCommand {
+        command: BrokerClientCommand::RequestStorageReset {
+            request_id: "reset-b".to_string(),
+            start_promise_id: 10,
+            completion_promise_id: 11,
+        },
+    });
+    let _ = client.handle(BrokerClientEvent::PublicCommand {
+        command: BrokerClientCommand::RequestStorageReset {
+            request_id: "reset-a".to_string(),
+            start_promise_id: 12,
+            completion_promise_id: 13,
+        },
+    });
+
+    let effects = client.handle(BrokerClientEvent::BrokerMessageReceived {
+        message: BrokerControlMessage::BrokerPing {
+            broker_instance_id: "instance-b".to_string(),
+        },
+        respond_to_broker_ping: true,
+        now_ms: 10,
+    });
+
+    let rejected_promise_ids: Vec<u64> = effects
+        .iter()
+        .filter_map(|effect| match effect {
+            BrokerClientEffect::RejectPublicPromise { promise_id, .. } => Some(*promise_id),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(rejected_promise_ids, vec![12, 10, 13, 11]);
+}
+
+#[test]
+fn storage_reset_begin_callback_success_posts_ready() {
+    let mut client = connected_client();
+
+    let effects = client.handle(BrokerClientEvent::BrokerMessageReceived {
+        message: BrokerControlMessage::StorageResetBegin {
+            broker_instance_id: "instance-a".to_string(),
+            request_id: "reset-a".to_string(),
+            leadership_id: 3,
+        },
+        respond_to_broker_ping: true,
+        now_ms: 10,
+    });
+
+    assert_eq!(
+        effects,
+        vec![BrokerClientEffect::InvokeCallback {
+            callback_id: 1,
+            callback: BrokerClientCallback::StorageResetBegin {
+                request_id: "reset-a".to_string(),
+                leadership_id: 3,
+            },
+        }],
+    );
+
+    let effects = client.handle(BrokerClientEvent::CallbackResolved {
+        callback_id: 1,
+        now_ms: 11,
+    });
+
+    assert_eq!(
+        effects,
+        vec![BrokerClientEffect::PostToBroker {
+            port_id: 1,
+            message: BrowserBrokerTabMessage::StorageResetReady {
+                broker_instance_id: "instance-a".to_string(),
+                request_id: "reset-a".to_string(),
+                success: true,
+                error_message: None,
+            },
+        }],
+    );
+}
+
+#[test]
+fn storage_reset_begin_callback_failure_posts_not_ready() {
+    let mut client = connected_client();
+
+    let effects = client.handle(BrokerClientEvent::BrokerMessageReceived {
+        message: BrokerControlMessage::StorageResetBegin {
+            broker_instance_id: "instance-a".to_string(),
+            request_id: "reset-a".to_string(),
+            leadership_id: 3,
+        },
+        respond_to_broker_ping: true,
+        now_ms: 10,
+    });
+
+    assert_eq!(
+        effects,
+        vec![BrokerClientEffect::InvokeCallback {
+            callback_id: 1,
+            callback: BrokerClientCallback::StorageResetBegin {
+                request_id: "reset-a".to_string(),
+                leadership_id: 3,
+            },
+        }],
+    );
+
+    let effects = client.handle(BrokerClientEvent::CallbackRejected {
+        callback_id: 1,
+        error_message: "reset failed".to_string(),
+        now_ms: 11,
+    });
+
+    assert_eq!(
+        effects,
+        vec![BrokerClientEffect::PostToBroker {
+            port_id: 1,
+            message: BrowserBrokerTabMessage::StorageResetReady {
+                broker_instance_id: "instance-a".to_string(),
+                request_id: "reset-a".to_string(),
+                success: false,
+                error_message: Some("reset failed".to_string()),
+            },
+        }],
+    );
+}
+
+#[test]
+fn broker_client_snapshot_serializes_for_js() {
+    let client = connected_client();
+    let value = serde_json::to_value(client.snapshot()).unwrap();
+    assert_eq!(value["brokerInstanceId"], "instance-a");
+    assert_eq!(value["role"], "follower");
+    assert_eq!(value["tabId"], "tab-a");
+}

--- a/crates/jazz-wasm/tests/broker_election.rs
+++ b/crates/jazz-wasm/tests/broker_election.rs
@@ -1,0 +1,1474 @@
+use jazz_wasm::broker_election::{
+    BrokerControlMessage, BrokerEffect, BrokerElectionCore, BrokerEvent, BrokerTimerId,
+    BrokerVisibility, LeaderReady, StorageResetReady, TabConnected,
+};
+
+const BROKER_ID: &str = "broker-test";
+const APP_ID: &str = "app";
+const DB_NAME: &str = "db";
+const FINGERPRINT: &str = "fingerprint-a";
+const SCHEMA_A: &str = "schema-a";
+const SCHEMA_B: &str = "schema-b";
+
+fn connect(tab_id: &str, now_ms: u64) -> BrokerEvent {
+    connect_with_options(tab_id, now_ms, None, None, None)
+}
+
+fn connect_with_options(
+    tab_id: &str,
+    now_ms: u64,
+    force_takeover_timeout_ms: Option<u32>,
+    broker_ping_interval_ms: Option<u32>,
+    broker_pong_timeout_ms: Option<u32>,
+) -> BrokerEvent {
+    BrokerEvent::TabConnected(TabConnected {
+        tab_id: tab_id.to_string(),
+        app_id: APP_ID.to_string(),
+        db_name: DB_NAME.to_string(),
+        fingerprint: FINGERPRINT.to_string(),
+        visibility: BrokerVisibility::Visible,
+        now_ms,
+        force_takeover_timeout_ms,
+        broker_ping_interval_ms,
+        broker_pong_timeout_ms,
+    })
+}
+
+fn schema(tab_id: &str, schema_fingerprint: &str) -> BrokerEvent {
+    BrokerEvent::SchemaReported {
+        tab_id: tab_id.to_string(),
+        schema_fingerprint: schema_fingerprint.to_string(),
+    }
+}
+
+fn tab_lock_name() -> String {
+    format!("jazz-leader-tab:{APP_ID}:{DB_NAME}")
+}
+
+fn worker_lock_name() -> String {
+    format!("jazz-leader-worker:{APP_ID}:{DB_NAME}")
+}
+
+fn leader_ready(tab_id: &str, leadership_id: u32, now_ms: u64) -> BrokerEvent {
+    BrokerEvent::LeaderReady(LeaderReady {
+        tab_id: tab_id.to_string(),
+        leadership_id,
+        tab_lock_name: tab_lock_name(),
+        worker_lock_name: worker_lock_name(),
+        bridgeless_storage_reset: false,
+        now_ms,
+    })
+}
+
+fn storage_ready(tab_id: &str, request_id: &str, success: bool, now_ms: u64) -> BrokerEvent {
+    BrokerEvent::StorageResetReady(StorageResetReady {
+        tab_id: tab_id.to_string(),
+        request_id: request_id.to_string(),
+        success,
+        error_message: if success {
+            None
+        } else {
+            Some("prepare exploded".to_string())
+        },
+        now_ms,
+    })
+}
+
+fn request_storage_reset(tab_id: &str, request_id: &str, now_ms: u64) -> BrokerEvent {
+    BrokerEvent::StorageResetRequested {
+        tab_id: tab_id.to_string(),
+        request_id: request_id.to_string(),
+        now_ms,
+    }
+}
+
+fn send_to(tab_id: &str, message: BrokerControlMessage) -> BrokerEffect {
+    BrokerEffect::SendToTab {
+        tab_id: tab_id.to_string(),
+        message,
+    }
+}
+
+fn message_become_leader(
+    leadership_id: u32,
+    reset_request_id: Option<&str>,
+) -> BrokerControlMessage {
+    BrokerControlMessage::BecomeLeader {
+        broker_instance_id: BROKER_ID.to_string(),
+        leadership_id,
+        reset_request_id: reset_request_id.map(str::to_string),
+    }
+}
+
+fn message_demote(leadership_id: u32) -> BrokerControlMessage {
+    BrokerControlMessage::Demote {
+        broker_instance_id: BROKER_ID.to_string(),
+        leadership_id,
+    }
+}
+
+fn message_storage_reset_finished(
+    request_id: &str,
+    success: bool,
+    error_message: Option<&str>,
+) -> BrokerControlMessage {
+    BrokerControlMessage::StorageResetFinished {
+        broker_instance_id: BROKER_ID.to_string(),
+        request_id: request_id.to_string(),
+        success,
+        error_message: error_message.map(str::to_string),
+    }
+}
+
+fn assert_contains_effect(effects: &[BrokerEffect], expected: BrokerEffect) {
+    assert!(
+        effects.contains(&expected),
+        "expected effect {expected:?} in {effects:#?}",
+    );
+}
+
+fn assert_not_contains_steal(effects: &[BrokerEffect]) {
+    assert!(
+        effects
+            .iter()
+            .all(|effect| !matches!(effect, BrokerEffect::StealPreviousLeaderLocks { .. })),
+        "expected no stale lock-steal effect, got {effects:#?}",
+    );
+}
+
+fn find_wait_election(effects: &[BrokerEffect]) -> u64 {
+    effects
+        .iter()
+        .find_map(|effect| match effect {
+            BrokerEffect::WaitForPreviousLeaderLocks { election_id, .. } => Some(*election_id),
+            _ => None,
+        })
+        .expect("expected a previous-lock wait effect")
+}
+
+fn complete_previous_locks(election_id: u64, now_ms: u64) -> BrokerEvent {
+    BrokerEvent::PreviousLeaderLocksReleased {
+        election_id,
+        now_ms,
+    }
+}
+
+fn force_takeover_timer(election_id: u64, now_ms: u64) -> BrokerEvent {
+    BrokerEvent::TimerFired {
+        timer_id: BrokerTimerId::PreviousLeaderLocksForceTakeover { election_id },
+        now_ms,
+    }
+}
+
+fn finish_force_takeover(election_id: u64, now_ms: u64) -> BrokerEvent {
+    BrokerEvent::ForceTakeoverComplete {
+        election_id,
+        now_ms,
+    }
+}
+
+fn fail_force_takeover(election_id: u64, now_ms: u64) -> BrokerEvent {
+    BrokerEvent::ForceTakeoverFailed {
+        election_id,
+        reason: "steal failed".to_string(),
+        now_ms,
+    }
+}
+
+fn follower_attached(
+    leader_tab_id: &str,
+    follower_tab_id: &str,
+    leadership_id: u32,
+) -> BrokerEvent {
+    BrokerEvent::FollowerPortAttached {
+        leader_tab_id: leader_tab_id.to_string(),
+        follower_tab_id: follower_tab_id.to_string(),
+        leadership_id,
+        now_ms: 100,
+    }
+}
+
+fn setup_ready_leader_with_follower() -> BrokerElectionCore {
+    let mut broker = BrokerElectionCore::new(BROKER_ID.to_string());
+    let _ = broker.handle(connect("tab-a", 10));
+    let _ = broker.handle(schema("tab-a", SCHEMA_A));
+    let _ = broker.handle(leader_ready("tab-a", 1, 20));
+    let _ = broker.handle(connect("tab-b", 30));
+    let _ = broker.handle(schema("tab-b", SCHEMA_A));
+    let _ = broker.handle(follower_attached("tab-a", "tab-b", 1));
+    broker
+}
+
+fn setup_ready_leader_with_two_followers() -> BrokerElectionCore {
+    let mut broker = setup_ready_leader_with_follower();
+    let _ = broker.handle(connect("tab-c", 40));
+    let _ = broker.handle(schema("tab-c", SCHEMA_A));
+    let _ = broker.handle(follower_attached("tab-a", "tab-c", 1));
+    broker
+}
+
+#[test]
+fn one_namespace_elects_one_leader() {
+    let mut broker = BrokerElectionCore::new("broker-test".to_string());
+
+    let effects = broker.handle(connect("tab-a", 10));
+
+    assert_eq!(
+        effects,
+        vec![
+            BrokerEffect::SendToTab {
+                tab_id: "tab-a".to_string(),
+                message: BrokerControlMessage::BrokerPing {
+                    broker_instance_id: "broker-test".to_string(),
+                },
+            },
+            BrokerEffect::ArmTimer {
+                timer_id: BrokerTimerId::BrokerPing,
+                delay_ms: 1_000,
+            },
+            BrokerEffect::SendToTab {
+                tab_id: "tab-a".to_string(),
+                message: BrokerControlMessage::BrokerHello {
+                    broker_instance_id: "broker-test".to_string(),
+                },
+            },
+            BrokerEffect::SendToTab {
+                tab_id: "tab-a".to_string(),
+                message: BrokerControlMessage::BecomeLeader {
+                    broker_instance_id: "broker-test".to_string(),
+                    leadership_id: 1,
+                    reset_request_id: None,
+                },
+            },
+        ],
+    );
+
+    let snapshot = broker.snapshot();
+    assert_eq!(snapshot.leader_tab_id.as_deref(), Some("tab-a"));
+    assert_eq!(snapshot.current_leadership_id, 1);
+    assert_eq!(snapshot.connected_tab_count, 1);
+}
+
+#[test]
+fn mismatched_configuration_is_rejected() {
+    let mut broker = BrokerElectionCore::new("broker-test".to_string());
+    let _ = broker.handle(connect("tab-a", 10));
+
+    let effects = broker.handle(BrokerEvent::TabConnected(TabConnected {
+        tab_id: "tab-b".to_string(),
+        app_id: "app".to_string(),
+        db_name: "db".to_string(),
+        fingerprint: "fingerprint-b".to_string(),
+        visibility: BrokerVisibility::Visible,
+        now_ms: 20,
+        force_takeover_timeout_ms: None,
+        broker_ping_interval_ms: None,
+        broker_pong_timeout_ms: None,
+    }));
+
+    assert_eq!(
+        effects,
+        vec![
+            BrokerEffect::SendToTab {
+                tab_id: "tab-b".to_string(),
+                message: BrokerControlMessage::Unsupported {
+                    broker_instance_id: "broker-test".to_string(),
+                    code: Some("incompatible-browser-broker-configuration".to_string()),
+                    reason: "incompatible persistent browser configuration".to_string(),
+                },
+            },
+            BrokerEffect::CloseTabPort {
+                tab_id: "tab-b".to_string(),
+            },
+        ],
+    );
+
+    assert_eq!(broker.snapshot().connected_tab_count, 1);
+}
+
+#[test]
+fn leader_ready_announces_and_assigns_followers() {
+    let mut broker = BrokerElectionCore::new("broker-test".to_string());
+    let _ = broker.handle(connect("tab-a", 10));
+    let _ = broker.handle(BrokerEvent::SchemaReported {
+        tab_id: "tab-a".to_string(),
+        schema_fingerprint: "schema-a".to_string(),
+    });
+    let _ = broker.handle(connect("tab-b", 20));
+    let _ = broker.handle(BrokerEvent::SchemaReported {
+        tab_id: "tab-b".to_string(),
+        schema_fingerprint: "schema-a".to_string(),
+    });
+
+    let effects = broker.handle(BrokerEvent::LeaderReady(LeaderReady {
+        tab_id: "tab-a".to_string(),
+        leadership_id: 1,
+        tab_lock_name: "tab-lock".to_string(),
+        worker_lock_name: "worker-lock".to_string(),
+        bridgeless_storage_reset: false,
+        now_ms: 30,
+    }));
+
+    assert_eq!(
+        effects,
+        vec![
+            BrokerEffect::Broadcast {
+                message: BrokerControlMessage::LeaderReady {
+                    broker_instance_id: "broker-test".to_string(),
+                    leader_tab_id: "tab-a".to_string(),
+                    leadership_id: 1,
+                },
+            },
+            BrokerEffect::StartLeaderLockMonitor {
+                leadership_id: 1,
+                tab_lock_name: "tab-lock".to_string(),
+                worker_lock_name: "worker-lock".to_string(),
+            },
+            BrokerEffect::AssignFollowerPort {
+                leader_tab_id: "tab-a".to_string(),
+                follower_tab_id: "tab-b".to_string(),
+                leadership_id: 1,
+            },
+            BrokerEffect::ArmTimer {
+                timer_id: BrokerTimerId::FollowerAttachment {
+                    follower_tab_id: "tab-b".to_string(),
+                    leadership_id: 1,
+                },
+                delay_ms: 1_000,
+            },
+        ],
+    );
+}
+
+#[test]
+fn follower_ports_retry_until_attached() {
+    let mut broker = BrokerElectionCore::new("broker-test".to_string());
+    let _ = broker.handle(connect("tab-a", 10));
+    let _ = broker.handle(BrokerEvent::SchemaReported {
+        tab_id: "tab-a".to_string(),
+        schema_fingerprint: "schema-a".to_string(),
+    });
+    let _ = broker.handle(connect("tab-b", 20));
+    let _ = broker.handle(BrokerEvent::SchemaReported {
+        tab_id: "tab-b".to_string(),
+        schema_fingerprint: "schema-a".to_string(),
+    });
+    let _ = broker.handle(BrokerEvent::LeaderReady(LeaderReady {
+        tab_id: "tab-a".to_string(),
+        leadership_id: 1,
+        tab_lock_name: "tab-lock".to_string(),
+        worker_lock_name: "worker-lock".to_string(),
+        bridgeless_storage_reset: false,
+        now_ms: 30,
+    }));
+
+    let retry_effects = broker.handle(BrokerEvent::TimerFired {
+        timer_id: BrokerTimerId::FollowerAttachment {
+            follower_tab_id: "tab-b".to_string(),
+            leadership_id: 1,
+        },
+        now_ms: 1_020,
+    });
+
+    assert_eq!(
+        retry_effects,
+        vec![
+            BrokerEffect::AssignFollowerPort {
+                leader_tab_id: "tab-a".to_string(),
+                follower_tab_id: "tab-b".to_string(),
+                leadership_id: 1,
+            },
+            BrokerEffect::ArmTimer {
+                timer_id: BrokerTimerId::FollowerAttachment {
+                    follower_tab_id: "tab-b".to_string(),
+                    leadership_id: 1,
+                },
+                delay_ms: 2_000,
+            },
+        ],
+    );
+
+    let attached_effects = broker.handle(BrokerEvent::FollowerPortAttached {
+        leader_tab_id: "tab-a".to_string(),
+        follower_tab_id: "tab-b".to_string(),
+        leadership_id: 1,
+        now_ms: 3_020,
+    });
+
+    assert_eq!(
+        attached_effects,
+        vec![
+            BrokerEffect::CancelTimer {
+                timer_id: BrokerTimerId::FollowerAttachment {
+                    follower_tab_id: "tab-b".to_string(),
+                    leadership_id: 1,
+                },
+            },
+            BrokerEffect::SendToTab {
+                tab_id: "tab-b".to_string(),
+                message: BrokerControlMessage::FollowerReady {
+                    broker_instance_id: "broker-test".to_string(),
+                    leader_tab_id: "tab-a".to_string(),
+                    leadership_id: 1,
+                },
+            },
+        ],
+    );
+
+    let stale_retry_effects = broker.handle(BrokerEvent::TimerFired {
+        timer_id: BrokerTimerId::FollowerAttachment {
+            follower_tab_id: "tab-b".to_string(),
+            leadership_id: 1,
+        },
+        now_ms: 3_020,
+    });
+    assert!(stale_retry_effects.is_empty());
+}
+
+#[test]
+fn schema_mismatch_blocks_tab() {
+    let mut broker = BrokerElectionCore::new("broker-test".to_string());
+    let _ = broker.handle(connect("tab-a", 10));
+    let _ = broker.handle(BrokerEvent::SchemaReported {
+        tab_id: "tab-a".to_string(),
+        schema_fingerprint: "schema-a".to_string(),
+    });
+    let _ = broker.handle(connect("tab-b", 20));
+
+    let effects = broker.handle(BrokerEvent::SchemaReported {
+        tab_id: "tab-b".to_string(),
+        schema_fingerprint: "schema-b".to_string(),
+    });
+
+    assert_eq!(
+        effects,
+        vec![BrokerEffect::SendToTab {
+            tab_id: "tab-b".to_string(),
+            message: BrokerControlMessage::SchemaBlocked {
+                broker_instance_id: "broker-test".to_string(),
+                reason: "incompatible persistent browser schema".to_string(),
+            },
+        },],
+    );
+}
+
+#[test]
+fn schema_mismatched_tab_is_adopted_when_canonical_holder_departs() {
+    let mut broker = BrokerElectionCore::new(BROKER_ID.to_string());
+    let _ = broker.handle(connect("tab-a", 10));
+    let _ = broker.handle(schema("tab-a", SCHEMA_A));
+    let _ = broker.handle(leader_ready("tab-a", 1, 20));
+    let _ = broker.handle(connect("tab-b", 30));
+    let blocked = broker.handle(schema("tab-b", SCHEMA_B));
+    assert_contains_effect(
+        &blocked,
+        send_to(
+            "tab-b",
+            BrokerControlMessage::SchemaBlocked {
+                broker_instance_id: BROKER_ID.to_string(),
+                reason: "incompatible persistent browser schema".to_string(),
+            },
+        ),
+    );
+
+    let shutdown_effects = broker.handle(BrokerEvent::Shutdown {
+        tab_id: "tab-a".to_string(),
+        now_ms: 40,
+    });
+    let election_id = find_wait_election(&shutdown_effects);
+
+    let promotion_effects = broker.handle(complete_previous_locks(election_id, 50));
+
+    assert_contains_effect(
+        &promotion_effects,
+        send_to("tab-b", message_become_leader(2, None)),
+    );
+    let snapshot = broker.snapshot();
+    assert_eq!(snapshot.schema_fingerprint.as_deref(), Some(SCHEMA_B));
+    assert_eq!(snapshot.leader_tab_id.as_deref(), Some("tab-b"));
+    assert_eq!(snapshot.current_leadership_id, 2);
+}
+
+#[test]
+fn replacement_leader_survives_non_ready_schema_leader_shutdown() {
+    let mut broker = BrokerElectionCore::new(BROKER_ID.to_string());
+    let _ = broker.handle(connect("tab-a", 10));
+    let _ = broker.handle(schema("tab-a", SCHEMA_A));
+    let _ = broker.handle(connect("tab-b", 20));
+    let _ = broker.handle(schema("tab-b", SCHEMA_B));
+
+    let effects = broker.handle(BrokerEvent::Shutdown {
+        tab_id: "tab-a".to_string(),
+        now_ms: 30,
+    });
+
+    assert_contains_effect(&effects, send_to("tab-b", message_become_leader(2, None)));
+    let snapshot = broker.snapshot();
+    assert_eq!(snapshot.schema_fingerprint.as_deref(), Some(SCHEMA_B));
+    assert_eq!(snapshot.leader_tab_id.as_deref(), Some("tab-b"));
+    assert!(!snapshot.leader_ready);
+}
+
+#[test]
+fn current_leader_lock_release_promotes_follower() {
+    let mut broker = setup_ready_leader_with_follower();
+
+    let release_effects = broker.handle(BrokerEvent::LeaderLockReleased {
+        leadership_id: 1,
+        now_ms: 40,
+    });
+    let election_id = find_wait_election(&release_effects);
+    assert_eq!(broker.snapshot().connected_tab_count, 1);
+
+    let promotion_effects = broker.handle(complete_previous_locks(election_id, 50));
+
+    assert_contains_effect(
+        &promotion_effects,
+        send_to("tab-b", message_become_leader(2, None)),
+    );
+    assert_eq!(broker.snapshot().leader_tab_id.as_deref(), Some("tab-b"));
+    assert_eq!(broker.snapshot().current_leadership_id, 2);
+}
+
+#[test]
+fn leadership_ids_stay_monotonic_after_idle_reset() {
+    let mut broker = BrokerElectionCore::new(BROKER_ID.to_string());
+    let _ = broker.handle(connect("tab-a", 10));
+    let shutdown_effects = broker.handle(BrokerEvent::Shutdown {
+        tab_id: "tab-a".to_string(),
+        now_ms: 20,
+    });
+
+    assert_contains_effect(
+        &shutdown_effects,
+        BrokerEffect::CancelTimer {
+            timer_id: BrokerTimerId::BrokerPing,
+        },
+    );
+    assert_eq!(broker.snapshot().connected_tab_count, 0);
+    assert_eq!(broker.snapshot().current_leadership_id, 1);
+
+    let reconnect_effects = broker.handle(connect("tab-b", 30));
+
+    assert_contains_effect(
+        &reconnect_effects,
+        send_to("tab-b", message_become_leader(2, None)),
+    );
+    assert_eq!(broker.snapshot().current_leadership_id, 2);
+}
+
+#[test]
+fn stuck_leader_locks_are_stolen_before_replacement_promotion() {
+    let mut broker = setup_ready_leader_with_follower();
+
+    let shutdown_effects = broker.handle(BrokerEvent::Shutdown {
+        tab_id: "tab-a".to_string(),
+        now_ms: 40,
+    });
+    let election_id = find_wait_election(&shutdown_effects);
+
+    let steal_effects = broker.handle(force_takeover_timer(election_id, 1_040));
+    assert_eq!(
+        steal_effects,
+        vec![BrokerEffect::StealPreviousLeaderLocks {
+            election_id,
+            tab_lock_name: tab_lock_name(),
+            worker_lock_name: worker_lock_name(),
+        }],
+    );
+
+    let promotion_effects = broker.handle(finish_force_takeover(election_id, 1_050));
+
+    assert_contains_effect(
+        &promotion_effects,
+        send_to("tab-b", message_become_leader(2, None)),
+    );
+    assert_eq!(broker.snapshot().leader_tab_id.as_deref(), Some("tab-b"));
+}
+
+#[test]
+fn failed_force_takeover_does_not_promote_replacement_leader() {
+    let mut broker = setup_ready_leader_with_follower();
+
+    let shutdown_effects = broker.handle(BrokerEvent::Shutdown {
+        tab_id: "tab-a".to_string(),
+        now_ms: 40,
+    });
+    let election_id = find_wait_election(&shutdown_effects);
+    let _ = broker.handle(force_takeover_timer(election_id, 1_040));
+
+    let failure_effects = broker.handle(fail_force_takeover(election_id, 1_050));
+
+    assert_eq!(
+        failure_effects,
+        vec![BrokerEffect::ArmTimer {
+            timer_id: BrokerTimerId::PreviousLeaderLocksForceTakeover { election_id },
+            delay_ms: 1_000,
+        }],
+    );
+    assert_eq!(broker.snapshot().leader_tab_id.as_deref(), None);
+    assert_eq!(broker.snapshot().replacement_election_id, Some(election_id));
+}
+
+#[test]
+fn failed_force_takeover_keeps_storage_reset_wait_pending() {
+    let mut broker = setup_ready_leader_with_two_followers();
+    let request_id = "reset-a";
+
+    let _ = broker.handle(request_storage_reset("tab-b", request_id, 50));
+    let _ = broker.handle(storage_ready("tab-a", request_id, true, 60));
+    let _ = broker.handle(storage_ready("tab-b", request_id, true, 61));
+    let ready_effects = broker.handle(storage_ready("tab-c", request_id, true, 62));
+    let election_id = find_wait_election(&ready_effects);
+    let _ = broker.handle(force_takeover_timer(election_id, 1_062));
+
+    let failure_effects = broker.handle(fail_force_takeover(election_id, 1_063));
+
+    assert_eq!(
+        failure_effects,
+        vec![BrokerEffect::ArmTimer {
+            timer_id: BrokerTimerId::PreviousLeaderLocksForceTakeover { election_id },
+            delay_ms: 1_000,
+        }],
+    );
+    assert_eq!(broker.snapshot().reset_phase.as_deref(), Some("promoting"));
+
+    let retry_effects = broker.handle(force_takeover_timer(election_id, 2_063));
+
+    assert_eq!(
+        retry_effects,
+        vec![BrokerEffect::StealPreviousLeaderLocks {
+            election_id,
+            tab_lock_name: tab_lock_name(),
+            worker_lock_name: worker_lock_name(),
+        }],
+    );
+}
+
+#[test]
+fn stale_replacement_election_does_not_steal_new_leader_reused_locks() {
+    let mut broker = setup_ready_leader_with_follower();
+    let shutdown_effects = broker.handle(BrokerEvent::Shutdown {
+        tab_id: "tab-a".to_string(),
+        now_ms: 40,
+    });
+    let election_id = find_wait_election(&shutdown_effects);
+    let _ = broker.handle(complete_previous_locks(election_id, 50));
+
+    let stale_timer_effects = broker.handle(force_takeover_timer(election_id, 1_040));
+    let stale_completion_effects = broker.handle(finish_force_takeover(election_id, 1_050));
+
+    assert_not_contains_steal(&stale_timer_effects);
+    assert!(stale_completion_effects.is_empty());
+    assert_eq!(broker.snapshot().leader_tab_id.as_deref(), Some("tab-b"));
+}
+
+#[test]
+fn promoted_tab_without_schema_is_replaced_before_ready() {
+    let mut broker = BrokerElectionCore::new(BROKER_ID.to_string());
+    let _ = broker.handle(connect("tab-a", 10));
+    let _ = broker.handle(connect("tab-b", 20));
+
+    let effects = broker.handle(schema("tab-b", SCHEMA_A));
+
+    assert_contains_effect(&effects, send_to("tab-a", message_demote(1)));
+    assert_contains_effect(&effects, send_to("tab-b", message_become_leader(2, None)));
+    assert_eq!(broker.snapshot().leader_tab_id.as_deref(), Some("tab-b"));
+}
+
+#[test]
+fn failed_candidate_is_demoted_without_closing_tab() {
+    let mut broker = BrokerElectionCore::new(BROKER_ID.to_string());
+    let _ = broker.handle(connect("tab-a", 10));
+
+    let effects = broker.handle(BrokerEvent::LeaderFailed {
+        tab_id: "tab-a".to_string(),
+        leadership_id: 1,
+        reason: "boom".to_string(),
+        now_ms: 20,
+    });
+
+    assert_contains_effect(&effects, send_to("tab-a", message_demote(1)));
+    assert!(
+        !effects.iter().any(
+            |effect| matches!(effect, BrokerEffect::CloseTabPort { tab_id } if tab_id == "tab-a")
+        ),
+        "failed candidate should remain connected: {effects:#?}",
+    );
+    assert_eq!(broker.snapshot().connected_tab_count, 1);
+}
+
+#[test]
+fn failed_candidate_that_never_reports_ready_does_not_block_future_promotion() {
+    let mut broker = BrokerElectionCore::new(BROKER_ID.to_string());
+    let _ = broker.handle(connect("tab-a", 10));
+    let failed_effects = broker.handle(BrokerEvent::LeaderFailed {
+        tab_id: "tab-a".to_string(),
+        leadership_id: 1,
+        reason: "worker bootstrap hung".to_string(),
+        now_ms: 20,
+    });
+    let election_id = find_wait_election(&failed_effects);
+    let _ = broker.handle(connect("tab-b", 30));
+
+    let promotion_effects = broker.handle(complete_previous_locks(election_id, 40));
+
+    assert_contains_effect(
+        &promotion_effects,
+        send_to("tab-b", message_become_leader(2, None)),
+    );
+    assert_eq!(broker.snapshot().leader_tab_id.as_deref(), Some("tab-b"));
+}
+
+#[test]
+fn stale_candidate_reporting_ready_after_replacement_is_demoted() {
+    let mut broker = BrokerElectionCore::new(BROKER_ID.to_string());
+    let _ = broker.handle(connect("tab-a", 10));
+    let _ = broker.handle(connect("tab-b", 20));
+    let _ = broker.handle(schema("tab-b", SCHEMA_A));
+
+    let effects = broker.handle(leader_ready("tab-a", 1, 30));
+
+    assert_eq!(effects, vec![send_to("tab-a", message_demote(1))]);
+    assert_eq!(broker.snapshot().leader_tab_id.as_deref(), Some("tab-b"));
+}
+
+#[test]
+fn missed_broker_pongs_evict_leader_and_promote_follower() {
+    let mut broker = BrokerElectionCore::new(BROKER_ID.to_string());
+    let _ = broker.handle(connect_with_options(
+        "tab-a",
+        0,
+        Some(50),
+        Some(50),
+        Some(100),
+    ));
+    let _ = broker.handle(schema("tab-a", SCHEMA_A));
+    let _ = broker.handle(leader_ready("tab-a", 1, 10));
+    let _ = broker.handle(connect("tab-b", 50));
+    let _ = broker.handle(schema("tab-b", SCHEMA_A));
+
+    let timeout_effects = broker.handle(BrokerEvent::TimerFired {
+        timer_id: BrokerTimerId::BrokerPing,
+        now_ms: 101,
+    });
+    let election_id = find_wait_election(&timeout_effects);
+    assert_contains_effect(
+        &timeout_effects,
+        BrokerEffect::CloseTabPort {
+            tab_id: "tab-a".to_string(),
+        },
+    );
+
+    let promotion_effects = broker.handle(complete_previous_locks(election_id, 110));
+
+    assert_contains_effect(
+        &promotion_effects,
+        send_to("tab-b", message_become_leader(2, None)),
+    );
+    assert_eq!(broker.snapshot().leader_tab_id.as_deref(), Some("tab-b"));
+}
+
+#[test]
+fn evicted_follower_reconnects_and_is_reattached() {
+    let mut broker = BrokerElectionCore::new(BROKER_ID.to_string());
+    let _ = broker.handle(connect_with_options(
+        "tab-a",
+        0,
+        Some(50),
+        Some(50),
+        Some(100),
+    ));
+    let _ = broker.handle(schema("tab-a", SCHEMA_A));
+    let _ = broker.handle(leader_ready("tab-a", 1, 10));
+    let _ = broker.handle(connect("tab-b", 50));
+    let _ = broker.handle(schema("tab-b", SCHEMA_A));
+    let _ = broker.handle(follower_attached("tab-a", "tab-b", 1));
+    let _ = broker.handle(BrokerEvent::BrokerPong {
+        tab_id: "tab-a".to_string(),
+        now_ms: 140,
+    });
+
+    let eviction_effects = broker.handle(BrokerEvent::TimerFired {
+        timer_id: BrokerTimerId::BrokerPing,
+        now_ms: 151,
+    });
+
+    assert_contains_effect(
+        &eviction_effects,
+        BrokerEffect::CloseTabPort {
+            tab_id: "tab-b".to_string(),
+        },
+    );
+    assert_contains_effect(
+        &eviction_effects,
+        send_to(
+            "tab-a",
+            BrokerControlMessage::DetachFollowerPort {
+                broker_instance_id: BROKER_ID.to_string(),
+                follower_tab_id: "tab-b".to_string(),
+                leadership_id: 1,
+            },
+        ),
+    );
+
+    let _ = broker.handle(connect("tab-b", 160));
+    let reattach_effects = broker.handle(schema("tab-b", SCHEMA_A));
+
+    assert_contains_effect(
+        &reattach_effects,
+        BrokerEffect::AssignFollowerPort {
+            leader_tab_id: "tab-a".to_string(),
+            follower_tab_id: "tab-b".to_string(),
+            leadership_id: 1,
+        },
+    );
+}
+
+#[test]
+fn evicted_tab_reconnect_does_not_duplicate_fanout() {
+    let mut broker = BrokerElectionCore::new(BROKER_ID.to_string());
+    let _ = broker.handle(connect_with_options(
+        "tab-a",
+        0,
+        Some(50),
+        Some(50),
+        Some(100),
+    ));
+    let _ = broker.handle(schema("tab-a", SCHEMA_A));
+    let _ = broker.handle(leader_ready("tab-a", 1, 10));
+    let _ = broker.handle(connect("tab-b", 50));
+    let _ = broker.handle(schema("tab-b", SCHEMA_A));
+    let _ = broker.handle(follower_attached("tab-a", "tab-b", 1));
+    let _ = broker.handle(BrokerEvent::BrokerPong {
+        tab_id: "tab-a".to_string(),
+        now_ms: 140,
+    });
+
+    let _ = broker.handle(BrokerEvent::TimerFired {
+        timer_id: BrokerTimerId::BrokerPing,
+        now_ms: 151,
+    });
+    let _ = broker.handle(connect("tab-b", 160));
+    let _ = broker.handle(BrokerEvent::BrokerPong {
+        tab_id: "tab-a".to_string(),
+        now_ms: 180,
+    });
+    let _ = broker.handle(BrokerEvent::BrokerPong {
+        tab_id: "tab-b".to_string(),
+        now_ms: 180,
+    });
+
+    let ping_effects = broker.handle(BrokerEvent::TimerFired {
+        timer_id: BrokerTimerId::BrokerPing,
+        now_ms: 190,
+    });
+
+    let tab_b_pings = ping_effects
+        .iter()
+        .filter(|effect| {
+            matches!(
+                effect,
+                BrokerEffect::SendToTab {
+                    tab_id,
+                    message: BrokerControlMessage::BrokerPing { .. },
+                } if tab_id == "tab-b"
+            )
+        })
+        .count();
+    assert_eq!(
+        tab_b_pings, 1,
+        "reconnected tab should receive one broker ping: {ping_effects:#?}",
+    );
+}
+
+#[test]
+fn replacement_election_prefers_visible_tab_after_visibility_change() {
+    let mut broker = BrokerElectionCore::new(BROKER_ID.to_string());
+    let _ = broker.handle(connect("tab-a", 10));
+    let _ = broker.handle(schema("tab-a", SCHEMA_A));
+    let _ = broker.handle(leader_ready("tab-a", 1, 20));
+    let _ = broker.handle(connect("tab-b", 30));
+    let _ = broker.handle(schema("tab-b", SCHEMA_A));
+    let _ = broker.handle(connect("tab-c", 40));
+    let _ = broker.handle(schema("tab-c", SCHEMA_A));
+    let _ = broker.handle(BrokerEvent::VisibilityChanged {
+        tab_id: "tab-b".to_string(),
+        visibility: BrokerVisibility::Visible,
+        now_ms: 50,
+    });
+    let _ = broker.handle(BrokerEvent::VisibilityChanged {
+        tab_id: "tab-b".to_string(),
+        visibility: BrokerVisibility::Hidden,
+        now_ms: 60,
+    });
+
+    let shutdown_effects = broker.handle(BrokerEvent::Shutdown {
+        tab_id: "tab-a".to_string(),
+        now_ms: 70,
+    });
+    let election_id = find_wait_election(&shutdown_effects);
+    let replacement_effects = broker.handle(complete_previous_locks(election_id, 80));
+
+    assert_contains_effect(
+        &replacement_effects,
+        send_to("tab-c", message_become_leader(2, None)),
+    );
+    assert_eq!(broker.snapshot().leader_tab_id.as_deref(), Some("tab-c"));
+}
+
+#[test]
+fn storage_reset_prepares_promotes_reconnects_and_finishes() {
+    let mut broker = setup_ready_leader_with_two_followers();
+    let request_id = "reset-a";
+
+    let begin_effects = broker.handle(request_storage_reset("tab-b", request_id, 50));
+
+    assert_contains_effect(
+        &begin_effects,
+        send_to(
+            "tab-b",
+            BrokerControlMessage::StorageResetStarted {
+                broker_instance_id: BROKER_ID.to_string(),
+                request_id: request_id.to_string(),
+            },
+        ),
+    );
+    for tab_id in ["tab-a", "tab-b", "tab-c"] {
+        assert_contains_effect(
+            &begin_effects,
+            send_to(
+                tab_id,
+                BrokerControlMessage::StorageResetBegin {
+                    broker_instance_id: BROKER_ID.to_string(),
+                    request_id: request_id.to_string(),
+                    leadership_id: 1,
+                },
+            ),
+        );
+    }
+    assert_eq!(broker.snapshot().reset_phase.as_deref(), Some("preparing"));
+
+    assert!(broker
+        .handle(storage_ready("tab-a", request_id, true, 60))
+        .is_empty());
+    assert!(broker
+        .handle(storage_ready("tab-b", request_id, true, 61))
+        .is_empty());
+    let ready_effects = broker.handle(storage_ready("tab-c", request_id, true, 62));
+    let election_id = find_wait_election(&ready_effects);
+    assert_eq!(broker.snapshot().reset_phase.as_deref(), Some("promoting"));
+
+    let promote_effects = broker.handle(complete_previous_locks(election_id, 70));
+    assert_contains_effect(
+        &promote_effects,
+        send_to("tab-c", message_become_leader(2, Some(request_id))),
+    );
+
+    let leader_ready_effects = broker.handle(leader_ready("tab-c", 2, 80));
+    assert_eq!(
+        broker.snapshot().reset_phase.as_deref(),
+        Some("reconnecting")
+    );
+    assert_contains_effect(
+        &leader_ready_effects,
+        BrokerEffect::AssignFollowerPort {
+            leader_tab_id: "tab-c".to_string(),
+            follower_tab_id: "tab-a".to_string(),
+            leadership_id: 2,
+        },
+    );
+    assert_contains_effect(
+        &leader_ready_effects,
+        BrokerEffect::AssignFollowerPort {
+            leader_tab_id: "tab-c".to_string(),
+            follower_tab_id: "tab-b".to_string(),
+            leadership_id: 2,
+        },
+    );
+
+    assert!(broker
+        .handle(follower_attached("tab-c", "tab-a", 2))
+        .iter()
+        .all(|effect| !matches!(
+            effect,
+            BrokerEffect::SendToTab {
+                message: BrokerControlMessage::StorageResetFinished { .. },
+                ..
+            }
+        )));
+    let finished_effects = broker.handle(follower_attached("tab-c", "tab-b", 2));
+    for tab_id in ["tab-a", "tab-b", "tab-c"] {
+        assert_contains_effect(
+            &finished_effects,
+            send_to(
+                tab_id,
+                message_storage_reset_finished(request_id, true, None),
+            ),
+        );
+    }
+    assert_eq!(broker.snapshot().reset_phase, None);
+    assert!(broker.snapshot().leader_ready);
+}
+
+#[test]
+fn storage_reset_ignores_ready_messages_from_departed_participants() {
+    let mut broker = setup_ready_leader_with_follower();
+    let request_id = "reset-late";
+    let _ = broker.handle(request_storage_reset("tab-b", request_id, 40));
+
+    let shutdown_effects = broker.handle(BrokerEvent::Shutdown {
+        tab_id: "tab-a".to_string(),
+        now_ms: 41,
+    });
+    assert!(
+        !shutdown_effects.iter().any(|effect| matches!(
+            effect,
+            BrokerEffect::SendToTab {
+                message: BrokerControlMessage::BecomeLeader { .. },
+                ..
+            }
+        )),
+        "departing participant should not trigger promotion before remaining tabs are ready: {shutdown_effects:#?}",
+    );
+
+    let departed_ready = broker.handle(storage_ready("tab-a", request_id, true, 42));
+    assert!(departed_ready.is_empty());
+
+    let remaining_ready = broker.handle(storage_ready("tab-b", request_id, true, 43));
+    let election_id = find_wait_election(&remaining_ready);
+    let promotion_effects = broker.handle(complete_previous_locks(election_id, 50));
+
+    assert_contains_effect(
+        &promotion_effects,
+        send_to("tab-b", message_become_leader(2, Some(request_id))),
+    );
+}
+
+#[test]
+fn follower_connecting_during_reset_promotion_gets_deferred_attachment_retry() {
+    let mut broker = setup_ready_leader_with_follower();
+    let request_id = "reset-mid-connect";
+    let _ = broker.handle(request_storage_reset("tab-a", request_id, 40));
+    assert!(broker
+        .handle(storage_ready("tab-a", request_id, true, 41))
+        .is_empty());
+    let ready_effects = broker.handle(storage_ready("tab-b", request_id, true, 42));
+    let election_id = find_wait_election(&ready_effects);
+    let promote_effects = broker.handle(complete_previous_locks(election_id, 50));
+    assert_contains_effect(
+        &promote_effects,
+        send_to("tab-b", message_become_leader(2, Some(request_id))),
+    );
+    assert_eq!(broker.snapshot().reset_phase.as_deref(), Some("promoting"));
+
+    let _ = broker.handle(connect("tab-c", 55));
+    let schema_effects = broker.handle(schema("tab-c", SCHEMA_A));
+
+    assert_contains_effect(
+        &schema_effects,
+        BrokerEffect::ArmTimer {
+            timer_id: BrokerTimerId::FollowerAttachment {
+                follower_tab_id: "tab-c".to_string(),
+                leadership_id: 2,
+            },
+            delay_ms: 1_000,
+        },
+    );
+    assert!(
+        schema_effects
+            .iter()
+            .all(|effect| !matches!(effect, BrokerEffect::AssignFollowerPort { .. })),
+        "deferred attachment should not transfer a port while reset promotion is still blocked: {schema_effects:#?}",
+    );
+
+    let retry_effects = broker.handle(BrokerEvent::TimerFired {
+        timer_id: BrokerTimerId::FollowerAttachment {
+            follower_tab_id: "tab-c".to_string(),
+            leadership_id: 2,
+        },
+        now_ms: 1_055,
+    });
+    assert_contains_effect(
+        &retry_effects,
+        BrokerEffect::ArmTimer {
+            timer_id: BrokerTimerId::FollowerAttachment {
+                follower_tab_id: "tab-c".to_string(),
+                leadership_id: 2,
+            },
+            delay_ms: 2_000,
+        },
+    );
+    assert!(
+        retry_effects
+            .iter()
+            .all(|effect| !matches!(effect, BrokerEffect::AssignFollowerPort { .. })),
+        "retry should stay deferred until the promoted leader is ready: {retry_effects:#?}",
+    );
+
+    let leader_ready_effects = broker.handle(leader_ready("tab-b", 2, 2_000));
+    assert_contains_effect(
+        &leader_ready_effects,
+        BrokerEffect::AssignFollowerPort {
+            leader_tab_id: "tab-b".to_string(),
+            follower_tab_id: "tab-c".to_string(),
+            leadership_id: 2,
+        },
+    );
+}
+
+#[test]
+fn active_storage_reset_settles_every_requester() {
+    let mut broker = setup_ready_leader_with_follower();
+    let first_request_id = "reset-a";
+    let second_request_id = "reset-b";
+
+    let _ = broker.handle(request_storage_reset("tab-a", first_request_id, 40));
+    let joined_effects = broker.handle(request_storage_reset("tab-b", second_request_id, 41));
+    assert_eq!(
+        joined_effects,
+        vec![send_to(
+            "tab-b",
+            BrokerControlMessage::StorageResetStarted {
+                broker_instance_id: BROKER_ID.to_string(),
+                request_id: second_request_id.to_string(),
+            },
+        )],
+    );
+
+    assert!(broker
+        .handle(storage_ready("tab-a", first_request_id, true, 42))
+        .is_empty());
+    let ready_effects = broker.handle(storage_ready("tab-b", first_request_id, true, 43));
+    let election_id = find_wait_election(&ready_effects);
+    let promote_effects = broker.handle(complete_previous_locks(election_id, 50));
+    assert_contains_effect(
+        &promote_effects,
+        send_to("tab-b", message_become_leader(2, Some(first_request_id))),
+    );
+    let _ = broker.handle(leader_ready("tab-b", 2, 60));
+    let finished_effects = broker.handle(follower_attached("tab-b", "tab-a", 2));
+
+    for request_id in [first_request_id, second_request_id] {
+        for tab_id in ["tab-a", "tab-b"] {
+            assert_contains_effect(
+                &finished_effects,
+                send_to(
+                    tab_id,
+                    message_storage_reset_finished(request_id, true, None),
+                ),
+            );
+        }
+    }
+}
+
+#[test]
+fn completed_storage_reset_outcomes_are_redelivered_to_reconnecting_tabs() {
+    let mut broker = setup_ready_leader_with_follower();
+    let request_id = "reset-redeliver";
+    let _ = broker.handle(request_storage_reset("tab-a", request_id, 40));
+    let _ = broker.handle(storage_ready("tab-a", request_id, true, 41));
+    let ready_effects = broker.handle(storage_ready("tab-b", request_id, true, 42));
+    let election_id = find_wait_election(&ready_effects);
+    let _ = broker.handle(complete_previous_locks(election_id, 50));
+    let _ = broker.handle(leader_ready("tab-b", 2, 60));
+    let _ = broker.handle(follower_attached("tab-b", "tab-a", 2));
+
+    let reconnect_effects = broker.handle(connect("tab-a", 70));
+
+    assert_contains_effect(
+        &reconnect_effects,
+        send_to(
+            "tab-a",
+            message_storage_reset_finished(request_id, true, None),
+        ),
+    );
+}
+
+#[test]
+fn same_tab_follower_reconnects_with_fresh_follower_port() {
+    let mut broker = setup_ready_leader_with_follower();
+
+    let shutdown_effects = broker.handle(BrokerEvent::Shutdown {
+        tab_id: "tab-b".to_string(),
+        now_ms: 110,
+    });
+    assert_contains_effect(
+        &shutdown_effects,
+        send_to(
+            "tab-a",
+            BrokerControlMessage::DetachFollowerPort {
+                broker_instance_id: BROKER_ID.to_string(),
+                follower_tab_id: "tab-b".to_string(),
+                leadership_id: 1,
+            },
+        ),
+    );
+
+    let reconnect_effects = broker.handle(connect("tab-b", 120));
+    assert_contains_effect(
+        &reconnect_effects,
+        send_to(
+            "tab-b",
+            BrokerControlMessage::LeaderReady {
+                broker_instance_id: BROKER_ID.to_string(),
+                leader_tab_id: "tab-a".to_string(),
+                leadership_id: 1,
+            },
+        ),
+    );
+    let schema_effects = broker.handle(schema("tab-b", SCHEMA_A));
+    assert_contains_effect(
+        &schema_effects,
+        BrokerEffect::AssignFollowerPort {
+            leader_tab_id: "tab-a".to_string(),
+            follower_tab_id: "tab-b".to_string(),
+            leadership_id: 1,
+        },
+    );
+}
+
+#[test]
+fn same_tab_follower_rehello_without_eviction_gets_fresh_follower_port() {
+    let mut broker = setup_ready_leader_with_follower();
+
+    let rehello_effects = broker.handle(connect("tab-b", 120));
+    assert_contains_effect(
+        &rehello_effects,
+        BrokerEffect::CloseReplacedTabPort {
+            tab_id: "tab-b".to_string(),
+        },
+    );
+    let schema_effects = broker.handle(schema("tab-b", SCHEMA_A));
+
+    assert_contains_effect(
+        &schema_effects,
+        BrokerEffect::AssignFollowerPort {
+            leader_tab_id: "tab-a".to_string(),
+            follower_tab_id: "tab-b".to_string(),
+            leadership_id: 1,
+        },
+    );
+}
+
+#[test]
+fn same_tab_ready_leader_reconnects_to_live_broker_and_is_repromoted_after_schema() {
+    let mut broker = BrokerElectionCore::new(BROKER_ID.to_string());
+    let _ = broker.handle(connect("tab-a", 10));
+    let _ = broker.handle(schema("tab-a", SCHEMA_A));
+    let _ = broker.handle(leader_ready("tab-a", 1, 20));
+
+    let rehello_effects = broker.handle(connect("tab-a", 30));
+    assert_contains_effect(
+        &rehello_effects,
+        BrokerEffect::CloseReplacedTabPort {
+            tab_id: "tab-a".to_string(),
+        },
+    );
+    assert!(
+        rehello_effects.iter().all(|effect| !matches!(
+            effect,
+            BrokerEffect::SendToTab {
+                message: BrokerControlMessage::BecomeLeader { .. },
+                ..
+            }
+        )),
+        "leader should wait for cached schema to be re-reported after reconnect: {rehello_effects:#?}",
+    );
+
+    let schema_effects = broker.handle(schema("tab-a", SCHEMA_A));
+
+    assert_contains_effect(
+        &schema_effects,
+        send_to("tab-a", message_become_leader(2, None)),
+    );
+    assert_eq!(broker.snapshot().leader_tab_id.as_deref(), Some("tab-a"));
+}
+
+#[test]
+fn same_tab_non_ready_leader_reconnects_to_live_broker_and_is_repromoted() {
+    let mut broker = BrokerElectionCore::new(BROKER_ID.to_string());
+    let _ = broker.handle(connect("tab-a", 10));
+
+    let rehello_effects = broker.handle(connect("tab-a", 20));
+
+    assert_contains_effect(
+        &rehello_effects,
+        BrokerEffect::CloseReplacedTabPort {
+            tab_id: "tab-a".to_string(),
+        },
+    );
+    assert_contains_effect(
+        &rehello_effects,
+        send_to("tab-a", message_become_leader(2, None)),
+    );
+    assert_eq!(broker.snapshot().leader_tab_id.as_deref(), Some("tab-a"));
+}
+
+#[test]
+fn follower_port_closed_is_reattached() {
+    let mut broker = setup_ready_leader_with_follower();
+
+    let effects = broker.handle(BrokerEvent::FollowerPortClosed {
+        leader_tab_id: "tab-a".to_string(),
+        follower_tab_id: "tab-b".to_string(),
+        leadership_id: 1,
+        now_ms: 120,
+    });
+
+    assert_contains_effect(
+        &effects,
+        BrokerEffect::AssignFollowerPort {
+            leader_tab_id: "tab-a".to_string(),
+            follower_tab_id: "tab-b".to_string(),
+            leadership_id: 1,
+        },
+    );
+    assert_contains_effect(
+        &effects,
+        BrokerEffect::ArmTimer {
+            timer_id: BrokerTimerId::FollowerAttachment {
+                follower_tab_id: "tab-b".to_string(),
+                leadership_id: 1,
+            },
+            delay_ms: 1_000,
+        },
+    );
+}
+
+#[test]
+fn failed_storage_reset_still_allows_normal_election_afterwards() {
+    let mut broker = setup_ready_leader_with_follower();
+    let request_id = "reset-failed";
+    let _ = broker.handle(request_storage_reset("tab-a", request_id, 40));
+    assert!(broker
+        .handle(storage_ready("tab-a", request_id, true, 41))
+        .is_empty());
+    let ready_effects = broker.handle(storage_ready("tab-b", request_id, false, 42));
+    let election_id = find_wait_election(&ready_effects);
+
+    let failed_effects = broker.handle(complete_previous_locks(election_id, 50));
+
+    for tab_id in ["tab-a", "tab-b"] {
+        assert_contains_effect(
+            &failed_effects,
+            send_to(
+                tab_id,
+                message_storage_reset_finished(request_id, false, Some("prepare exploded")),
+            ),
+        );
+    }
+    assert_contains_effect(
+        &failed_effects,
+        send_to("tab-b", message_become_leader(2, None)),
+    );
+    assert_eq!(broker.snapshot().reset_phase, None);
+}
+
+#[test]
+fn promoted_reset_leader_eviction_continues_reset_with_another_tab() {
+    let mut broker = BrokerElectionCore::new(BROKER_ID.to_string());
+    let _ = broker.handle(connect_with_options(
+        "tab-a",
+        0,
+        Some(50),
+        Some(20),
+        Some(60),
+    ));
+    let _ = broker.handle(schema("tab-a", SCHEMA_A));
+    let _ = broker.handle(leader_ready("tab-a", 1, 10));
+    let _ = broker.handle(connect("tab-b", 20));
+    let _ = broker.handle(schema("tab-b", SCHEMA_A));
+    let _ = broker.handle(follower_attached("tab-a", "tab-b", 1));
+
+    let request_id = "reset-evict";
+    let _ = broker.handle(request_storage_reset("tab-a", request_id, 30));
+    assert!(broker
+        .handle(storage_ready("tab-a", request_id, true, 31))
+        .is_empty());
+    let ready_effects = broker.handle(storage_ready("tab-b", request_id, true, 32));
+    let election_id = find_wait_election(&ready_effects);
+    let promote_effects = broker.handle(complete_previous_locks(election_id, 40));
+    assert_contains_effect(
+        &promote_effects,
+        send_to("tab-b", message_become_leader(2, Some(request_id))),
+    );
+
+    let _ = broker.handle(BrokerEvent::BrokerPong {
+        tab_id: "tab-a".to_string(),
+        now_ms: 70,
+    });
+    let eviction_effects = broker.handle(BrokerEvent::TimerFired {
+        timer_id: BrokerTimerId::BrokerPing,
+        now_ms: 81,
+    });
+
+    assert_contains_effect(
+        &eviction_effects,
+        BrokerEffect::CloseTabPort {
+            tab_id: "tab-b".to_string(),
+        },
+    );
+    assert_contains_effect(
+        &eviction_effects,
+        send_to("tab-a", message_become_leader(3, Some(request_id))),
+    );
+
+    let finished_effects = broker.handle(leader_ready("tab-a", 3, 90));
+    assert_contains_effect(
+        &finished_effects,
+        send_to(
+            "tab-a",
+            message_storage_reset_finished(request_id, true, None),
+        ),
+    );
+    assert_eq!(broker.snapshot().leader_tab_id.as_deref(), Some("tab-a"));
+    assert_eq!(broker.snapshot().reset_phase, None);
+}
+
+#[test]
+fn effects_serialize_with_stable_js_field_names() {
+    let effect = BrokerEffect::SendToTab {
+        tab_id: "tab-a".to_string(),
+        message: BrokerControlMessage::BecomeLeader {
+            broker_instance_id: "broker-test".to_string(),
+            leadership_id: 7,
+            reset_request_id: None,
+        },
+    };
+
+    let json = serde_json::to_value(&effect).expect("effect should serialize");
+
+    assert_eq!(
+        json,
+        serde_json::json!({
+            "type": "sendToTab",
+            "tabId": "tab-a",
+            "message": {
+                "type": "become-leader",
+                "brokerInstanceId": "broker-test",
+                "leadershipId": 7
+            }
+        }),
+    );
+}
+
+#[test]
+fn events_serialize_with_stable_js_field_names() {
+    let event = connect("tab-a", 10);
+
+    let json = serde_json::to_value(&event).expect("event should serialize");
+
+    assert_eq!(
+        json,
+        serde_json::json!({
+            "type": "tabConnected",
+            "tabId": "tab-a",
+            "appId": "app",
+            "dbName": "db",
+            "fingerprint": "fingerprint-a",
+            "visibility": "visible",
+            "nowMs": 10
+        }),
+    );
+}

--- a/crates/jazz-wasm/tests/wasm.rs
+++ b/crates/jazz-wasm/tests/wasm.rs
@@ -9,7 +9,10 @@ use wasm_bindgen_test::*;
 wasm_bindgen_test_configure!(run_in_browser);
 
 use jazz_wasm::types::Value;
-use jazz_wasm::{current_timestamp, generate_id, parse_schema, WasmQueryBuilder};
+use jazz_wasm::{
+    current_timestamp, generate_id, parse_schema, BrokerClient, BrokerElection, WasmQueryBuilder,
+};
+use serde_json::json;
 
 #[wasm_bindgen_test]
 fn test_generate_id() {
@@ -55,6 +58,57 @@ fn test_parse_schema() {
 fn test_parse_schema_invalid() {
     let result = parse_schema("not valid json");
     assert!(result.is_err());
+}
+
+#[wasm_bindgen_test]
+fn broker_election_wrapper_handles_js_events_and_returns_js_effects() {
+    let mut broker = BrokerElection::new("broker-test".to_string());
+    let event = serde_wasm_bindgen::to_value(&json!({
+        "type": "tabConnected",
+        "tabId": "tab-a",
+        "appId": "app",
+        "dbName": "db",
+        "fingerprint": "fingerprint",
+        "visibility": "visible",
+        "nowMs": 1
+    }))
+    .unwrap();
+
+    let effects_js = broker.handle_event(event).unwrap();
+    let effects: serde_json::Value = serde_wasm_bindgen::from_value(effects_js).unwrap();
+
+    assert_eq!(effects[0]["type"], "sendToTab");
+    assert_eq!(effects[0]["tabId"], "tab-a");
+    assert_eq!(effects[0]["message"]["type"], "broker-ping");
+    assert_eq!(effects[1]["type"], "armTimer");
+    assert_eq!(effects[1]["timerId"]["type"], "brokerPing");
+}
+
+#[wasm_bindgen_test]
+fn broker_client_wrapper_handles_js_events_and_returns_js_effects() {
+    let mut client = BrokerClient::new();
+    let event = serde_wasm_bindgen::to_value(&json!({
+        "type": "connectRequested",
+        "appId": "app",
+        "dbName": "db",
+        "tabId": "tab-a",
+        "fingerprint": "fingerprint",
+        "visibility": "visible",
+        "nowMs": 1
+    }))
+    .unwrap();
+
+    let effects_js = client.handle_event(event).unwrap();
+    let effects: serde_json::Value = serde_wasm_bindgen::from_value(effects_js).unwrap();
+
+    assert_eq!(effects[0]["type"], "createSharedWorker");
+    assert_eq!(effects[0]["workerId"], 1);
+    assert_eq!(effects[1]["type"], "attachPortListeners");
+    assert_eq!(effects[1]["portId"], 1);
+    assert_eq!(effects[2]["type"], "postToBroker");
+    assert_eq!(effects[2]["message"]["type"], "hello");
+    assert_eq!(effects[3]["type"], "armTimer");
+    assert_eq!(effects[3]["kind"]["type"], "brokerHello");
 }
 
 #[wasm_bindgen_test]

--- a/crates/jazz-wasm/tests/worker_bridge.rs
+++ b/crates/jazz-wasm/tests/worker_bridge.rs
@@ -155,7 +155,7 @@ fn insert_todo(runtime: &WasmRuntime, title: &str) {
     Reflect::set(&values, &"title".into(), &title.into()).unwrap();
     Reflect::set(&values, &"completed".into(), &JsValue::FALSE).unwrap();
     runtime
-        .insert("todos", values.into(), None)
+        .insert("todos", values.into(), None, None)
         .expect("insert todo");
 }
 

--- a/packages/jazz-tools/src/runtime/browser-broker-client.test.ts
+++ b/packages/jazz-tools/src/runtime/browser-broker-client.test.ts
@@ -84,8 +84,40 @@ function createFakeWorkerEnv(options: FakeWorkerEnvOptions = {}) {
   return { workers, workerUrls, FakeSharedWorker };
 }
 
+type TestableBrowserBrokerClient = {
+  shutdown(): Promise<void>;
+  connectToBroker(wasmModulePromise: Promise<unknown>): Promise<void>;
+  closeWithError(error: Error): void;
+};
+
+function createTestClient(
+  options: Partial<Parameters<typeof BrowserBrokerClient.connect>[0]> = {},
+): TestableBrowserBrokerClient {
+  const Constructor = BrowserBrokerClient as unknown as {
+    new (options: Parameters<typeof BrowserBrokerClient.connect>[0]): TestableBrowserBrokerClient;
+  };
+  return new Constructor({
+    appId: "app",
+    dbName: "db",
+    tabId: "tab-a",
+    fingerprint: "fingerprint",
+    visibility: "visible",
+    globalLike: {
+      SharedWorker: class {
+        readonly port = new EventTarget() as MessagePort;
+      },
+      MessageChannel,
+      navigator: {
+        locks: { request() {} },
+      },
+    },
+    ...options,
+  } as Parameters<typeof BrowserBrokerClient.connect>[0]);
+}
+
 describe("BrowserBrokerClient", () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.useRealTimers();
   });
 
@@ -335,6 +367,85 @@ describe("BrowserBrokerClient", () => {
     await client.shutdown();
   });
 
+  it("sanitizes invalid numeric broker options before posting hello", async () => {
+    const env = createFakeWorkerEnv();
+
+    const client = await BrowserBrokerClient.connect({
+      appId: "app",
+      dbName: "db",
+      tabId: "tab-a",
+      fingerprint: "fingerprint",
+      visibility: "visible",
+      forceTakeoverTimeoutMs: Number.NaN,
+      brokerPingIntervalMs: -1,
+      brokerPongTimeoutMs: 1.5,
+      globalLike: {
+        SharedWorker: env.FakeSharedWorker,
+        MessageChannel,
+        navigator: {
+          locks: { request() {} },
+        },
+      },
+    });
+
+    expect(env.workers[0]!.port.postedMessages[0]).toMatchObject({
+      type: "hello",
+      forceTakeoverTimeoutMs: undefined,
+      brokerPingIntervalMs: undefined,
+      brokerPongTimeoutMs: 1,
+    });
+
+    await client.shutdown();
+  });
+
+  it("closes transferred follower ports when no callback is registered", async () => {
+    const env = createFakeWorkerEnv();
+    const attachPort = { close: vi.fn() } as unknown as MessagePort;
+    const usePort = { close: vi.fn() } as unknown as MessagePort;
+
+    const client = await BrowserBrokerClient.connect({
+      appId: "app",
+      dbName: "db",
+      tabId: "tab-a",
+      fingerprint: "fingerprint",
+      visibility: "visible",
+      globalLike: {
+        SharedWorker: env.FakeSharedWorker,
+        MessageChannel,
+        navigator: {
+          locks: { request() {} },
+        },
+      },
+    });
+
+    dispatchPortMessage(env.workers[0]!.port, {
+      type: "become-leader",
+      brokerInstanceId: "instance-a",
+      leadershipId: 1,
+    } satisfies BrowserBrokerControlMessage);
+
+    dispatchPortMessage(env.workers[0]!.port, {
+      type: "attach-follower-port",
+      brokerInstanceId: "instance-a",
+      followerTabId: "tab-b",
+      leadershipId: 1,
+      port: attachPort,
+    } satisfies BrowserBrokerControlMessage);
+
+    dispatchPortMessage(env.workers[0]!.port, {
+      type: "use-follower-port",
+      brokerInstanceId: "instance-a",
+      leaderTabId: "tab-b",
+      leadershipId: 1,
+      port: usePort,
+    } satisfies BrowserBrokerControlMessage);
+
+    expect(attachPort.close).toHaveBeenCalledTimes(1);
+    expect(usePort.close).toHaveBeenCalledTimes(1);
+
+    await client.shutdown();
+  });
+
   it("uses an explicit broker worker URL override", async () => {
     const env = createFakeWorkerEnv();
 
@@ -420,6 +531,151 @@ describe("BrowserBrokerClient", () => {
       "Browser broker SharedWorker failed to start: script URL mismatch",
     );
   }, 10_000);
+
+  it("retries loading the wasm module after a transient init failure", async () => {
+    await vi.resetModules();
+    let initAttempts = 0;
+
+    vi.doMock("jazz-wasm", () => ({
+      initSync: undefined,
+      default: async () => {
+        initAttempts += 1;
+        if (initAttempts === 1) {
+          throw new Error("temporary wasm init failure");
+        }
+      },
+      BrokerClient: class {
+        handleEvent(event: { type: string; message?: { type?: string } }) {
+          if (event.type === "connectRequested") {
+            return [
+              { type: "createSharedWorker", workerId: 1, name: "jazz-broker:app:db" },
+              { type: "attachPortListeners", portId: 1 },
+              {
+                type: "postToBroker",
+                portId: 1,
+                message: {
+                  type: "hello",
+                  tabId: "tab-a",
+                  appId: "app",
+                  dbName: "db",
+                  fingerprint: "fingerprint",
+                  visibility: "visible",
+                },
+              },
+            ];
+          }
+          if (event.type === "brokerMessageReceived" && event.message?.type === "broker-hello") {
+            return [{ type: "resolveConnect" }];
+          }
+          return [];
+        }
+
+        snapshot() {
+          return {
+            brokerInstanceId: "instance-a",
+            role: "follower",
+            tabId: "tab-a",
+            leaderTabId: null,
+            leadershipId: 0,
+          };
+        }
+      },
+    }));
+
+    try {
+      const { BrowserBrokerClient: IsolatedClient } = await import("./browser-broker-client.js");
+      const firstEnv = createFakeWorkerEnv();
+      await expect(
+        IsolatedClient.connect({
+          appId: "app",
+          dbName: "db",
+          tabId: "tab-a",
+          fingerprint: "fingerprint",
+          visibility: "visible",
+          globalLike: {
+            SharedWorker: firstEnv.FakeSharedWorker,
+            MessageChannel,
+            navigator: {
+              locks: { request() {} },
+            },
+          },
+        }),
+      ).rejects.toThrow("temporary wasm init failure");
+
+      const secondEnv = createFakeWorkerEnv();
+      const client = await IsolatedClient.connect({
+        appId: "app",
+        dbName: "db",
+        tabId: "tab-a",
+        fingerprint: "fingerprint",
+        visibility: "visible",
+        globalLike: {
+          SharedWorker: secondEnv.FakeSharedWorker,
+          MessageChannel,
+          navigator: {
+            locks: { request() {} },
+          },
+        },
+      });
+
+      expect(initAttempts).toBe(2);
+      await client.shutdown();
+    } finally {
+      vi.doUnmock("jazz-wasm");
+      await vi.resetModules();
+    }
+  });
+
+  it("rejects pending connect and closes the preconnected port on shutdown", async () => {
+    class FakePort extends EventTarget {
+      closed = false;
+      readonly postedMessages: unknown[] = [];
+
+      postMessage(message: unknown): void {
+        this.postedMessages.push(message);
+      }
+
+      start(): void {}
+
+      close(): void {
+        this.closed = true;
+      }
+    }
+
+    const workers: Array<{ port: FakePort & MessagePort }> = [];
+    class FakeSharedWorker {
+      readonly port = new FakePort() as FakePort & MessagePort;
+
+      constructor() {
+        workers.push(this);
+      }
+    }
+
+    const client = createTestClient({
+      globalLike: {
+        SharedWorker: FakeSharedWorker,
+        MessageChannel,
+        navigator: {
+          locks: { request() {} },
+        },
+      },
+    });
+    const connecting = client.connectToBroker(new Promise(() => {}));
+    connecting.catch(() => undefined);
+    await waitFor(() => workers.length === 1, 100, "preconnected worker should be created");
+
+    await client.shutdown();
+
+    const outcome = await Promise.race([
+      connecting.then(
+        () => "resolved",
+        (error: unknown) => (error instanceof Error ? error.message : String(error)),
+      ),
+      new Promise<string>((resolve) => setTimeout(() => resolve("pending"), 0)),
+    ]);
+    expect(outcome).toBe("Browser broker client closed");
+    expect(workers[0]!.port.closed).toBe(true);
+  });
 
   it("cleans up the port and handlers when broker hello times out", async () => {
     vi.useFakeTimers();
@@ -568,6 +824,43 @@ describe("BrowserBrokerClient", () => {
     await client.shutdown();
   });
 
+  it("does not post broker-pong when ping responses are disabled", async () => {
+    const env = createFakeWorkerEnv();
+    const respondToBrokerPings = vi.fn(() => false);
+
+    const client = await BrowserBrokerClient.connect({
+      appId: "app",
+      dbName: "db",
+      tabId: "tab-a",
+      fingerprint: "fingerprint",
+      visibility: "visible",
+      respondToBrokerPings,
+      globalLike: {
+        SharedWorker: env.FakeSharedWorker,
+        MessageChannel,
+        navigator: {
+          locks: { request() {} },
+        },
+      },
+    });
+
+    dispatchPortMessage(env.workers[0]!.port, {
+      type: "broker-ping",
+      brokerInstanceId: "instance-a",
+    } satisfies BrowserBrokerControlMessage);
+
+    expect(respondToBrokerPings).toHaveBeenCalled();
+    expect(env.workers[0]!.port.postedMessages).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "broker-pong",
+        }),
+      ]),
+    );
+
+    await client.shutdown();
+  });
+
   it("closes with the reconnect failure as the error cause", async () => {
     const env = createFakeWorkerEnv({ brokerInstanceIds: ["instance-a"] });
     const constructionError = new Error("second construction failed");
@@ -681,6 +974,17 @@ describe("BrowserBrokerClient", () => {
     await expect(client.waitForRole("leader", 10)).rejects.toThrow(
       "incompatible persistent browser configuration",
     );
+  });
+
+  it("notifies onClosed once when close is repeated with a different error", () => {
+    const onClosed = vi.fn();
+    const client = createTestClient({ onClosed });
+
+    client.closeWithError(new Error("first close"));
+    client.closeWithError(new Error("second close"));
+
+    expect(onClosed).toHaveBeenCalledTimes(1);
+    expect(onClosed.mock.calls[0]![0].message).toBe("first close");
   });
 
   it("forwards future demote messages so in-flight promotions can be cancelled", async () => {

--- a/packages/jazz-tools/src/runtime/browser-broker-client.ts
+++ b/packages/jazz-tools/src/runtime/browser-broker-client.ts
@@ -1,22 +1,23 @@
 import {
-  DEFAULT_BROKER_PING_INTERVAL_MS,
-  DEFAULT_BROKER_PONG_TIMEOUT_MS,
   detectBrowserBrokerMissingCapabilities,
   formatUnsupportedBrowserBrokerError,
-  normalizePositiveTimeout,
   stringifyError,
   type BrowserBrokerCapabilityGlobal,
   type BrowserBrokerControlMessage,
   type BrowserBrokerRole,
   type BrowserBrokerTabMessage,
-  type BrowserBrokerTabMessageInput,
   type BrowserBrokerVisibility,
 } from "./browser-broker-protocol.js";
-import { createBrowserBrokerUnsupportedError } from "./browser-broker-errors.js";
+import {
+  createBrowserBrokerUnsupportedError,
+  type BrowserBrokerUnsupportedCode,
+} from "./browser-broker-errors.js";
 import type { RuntimeSourcesConfig } from "./context.js";
-import { resolveRuntimeConfigBrokerWorkerUrl } from "./runtime-config.js";
-
-const DEFAULT_STORAGE_RESET_TIMEOUT_MS = 5_000;
+import {
+  resolveRuntimeConfigBrokerWorkerUrl,
+  resolveRuntimeConfigSyncInitInput,
+  resolveRuntimeConfigWasmUrl,
+} from "./runtime-config.js";
 
 export interface BrowserBrokerClientSnapshot {
   brokerInstanceId: string | null;
@@ -64,24 +65,6 @@ export interface BrowserBrokerClientOptions {
   storageResetTimeoutMs?: number;
 }
 
-type RoleWaiter = {
-  role: BrowserBrokerRole;
-  resolve: () => void;
-  reject: (error: Error) => void;
-  timeout: ReturnType<typeof setTimeout>;
-};
-
-type ResetWaiter = {
-  resolve: () => void;
-  reject: (error: Error) => void;
-};
-
-type ResetStartWaiter = {
-  resolve: () => void;
-  reject: (error: Error) => void;
-  timeout: ReturnType<typeof setTimeout>;
-};
-
 type SharedWorkerConstructor = new (
   scriptURL: string | URL,
   options?: string | BrowserBrokerSharedWorkerOptions,
@@ -93,29 +76,169 @@ interface BrowserBrokerSharedWorkerOptions {
   credentials?: RequestCredentials;
 }
 
+type BrokerClientBinding = {
+  handleEvent(event: BrokerClientEvent): BrokerClientEffect[];
+  snapshot(): BrowserBrokerClientSnapshot & { closed?: boolean; reconnecting?: boolean };
+};
+
+type BrokerClientModule = {
+  BrokerClient: new () => BrokerClientBinding;
+  default?: (input?: unknown) => Promise<unknown>;
+  initSync?: (input?: unknown) => unknown;
+};
+
+type BrokerClientEvent =
+  | ({ type: "connectRequested" } & ConnectRequestedEvent)
+  | { type: "publicCommand"; command: BrokerClientCommand }
+  | {
+      type: "brokerMessageReceived";
+      message: BrokerControlMessageForCore;
+      respondToBrokerPing: boolean;
+      nowMs: number;
+    }
+  | { type: "timerFired"; timerId: number; kind: BrokerClientTimerKind; nowMs: number }
+  | { type: "callbackResolved"; callbackId: number; nowMs: number }
+  | { type: "callbackRejected"; callbackId: number; errorMessage: string; nowMs: number }
+  | { type: "workerError"; workerId: number; errorMessage: string; nowMs: number }
+  | { type: "portMessageError"; portId: number; nowMs: number };
+
+interface ConnectRequestedEvent {
+  appId: string;
+  dbName: string;
+  tabId: string;
+  fingerprint: string;
+  visibility: BrowserBrokerVisibility;
+  forceTakeoverTimeoutMs?: number;
+  brokerPingIntervalMs?: number;
+  brokerPongTimeoutMs?: number;
+  storageResetTimeoutMs?: number;
+  nowMs: number;
+}
+
+type BrokerClientCommand =
+  | { type: "waitForRole"; role: BrowserBrokerRole; promiseId: number; timeoutMs: number }
+  | {
+      type: "reportLeaderReady";
+      leadershipId: number;
+      tabLockName: string;
+      workerLockName: string;
+      bridgelessStorageReset: boolean;
+    }
+  | { type: "reportLeaderFailed"; leadershipId: number; reason: string }
+  | { type: "reportVisibility"; visibility: BrowserBrokerVisibility }
+  | { type: "reportFollowerPortAttached"; followerTabId: string; leadershipId: number }
+  | { type: "reportFollowerPortClosed"; followerTabId: string; leadershipId: number }
+  | { type: "reportSchemaReady"; schemaFingerprint: string }
+  | {
+      type: "requestStorageReset";
+      requestId: string;
+      startPromiseId: number;
+      completionPromiseId: number;
+    }
+  | {
+      type: "reportStorageResetReady";
+      requestId: string;
+      success: boolean;
+      errorMessage?: string;
+    }
+  | { type: "shutdown" };
+
+type BrokerClientTimerKind =
+  | { type: "brokerHello" }
+  | { type: "initialLeadership" }
+  | { type: "brokerLiveness" }
+  | { type: "roleWaiter"; promiseId: number }
+  | { type: "storageResetStart"; requestId: string; promiseId: number };
+
+// Mirrors the serde-wasm-bindgen event/effect/callback shapes in
+// crates/jazz-wasm/src/broker_client.rs. Keep the Rust serialization tests and
+// these unions in sync until the protocol declarations are generated.
+type BrokerClientCallback =
+  | { type: "brokerPing" }
+  | { type: "becomeLeader"; leadershipId: number; resetRequestId?: string }
+  | { type: "demote"; leadershipId: number }
+  | {
+      type: "attachFollowerPort";
+      followerTabId: string;
+      leadershipId: number;
+      portId?: number;
+    }
+  | { type: "detachFollowerPort"; followerTabId: string; leadershipId: number }
+  | { type: "useFollowerPort"; leaderTabId: string; leadershipId: number; portId?: number }
+  | { type: "followerReady"; leaderTabId: string; leadershipId: number }
+  | { type: "closeFollowerPort"; leadershipId: number }
+  | { type: "storageResetBegin"; requestId: string; leadershipId: number }
+  | { type: "schemaBlocked"; reason: string }
+  | { type: "reconnected" };
+
+type BrokerClientEffect =
+  | { type: "createSharedWorker"; workerId: number; name: string }
+  | { type: "attachPortListeners"; portId: number }
+  | { type: "detachPort"; portId: number; close: boolean }
+  | { type: "postToBroker"; portId: number; message: BrowserBrokerTabMessage }
+  | { type: "armTimer"; timerId: number; kind: BrokerClientTimerKind; delayMs: number }
+  | { type: "cancelTimer"; timerId: number }
+  | { type: "releaseMessagePort"; portId: number }
+  | { type: "invokeCallback"; callbackId: number; callback: BrokerClientCallback }
+  | { type: "resolveConnect" }
+  | { type: "rejectConnect"; reason: string; code?: BrowserBrokerUnsupportedCode }
+  | { type: "resolvePublicPromise"; promiseId: number }
+  | { type: "rejectPublicPromise"; promiseId: number; reason: string }
+  | { type: "closeClient"; reason: string; code?: BrowserBrokerUnsupportedCode };
+
+type BrokerControlMessageForCore =
+  | Exclude<
+      BrowserBrokerControlMessage,
+      { type: "attach-follower-port" } | { type: "use-follower-port" }
+    >
+  | (Omit<Extract<BrowserBrokerControlMessage, { type: "attach-follower-port" }>, "port"> & {
+      portId?: number;
+    })
+  | (Omit<Extract<BrowserBrokerControlMessage, { type: "use-follower-port" }>, "port"> & {
+      portId?: number;
+    });
+
+type PublicPromise = {
+  resolve: () => void;
+  reject: (error: Error) => void;
+};
+
+type ConnectWaiter = PublicPromise;
+
+type PreconnectedWorker = {
+  workerId: number;
+  portId: number;
+  worker: SharedWorker;
+  port: MessagePort;
+  queuedMessages: BrowserBrokerControlMessage[];
+  cleanup: () => void;
+  helloPosted: boolean;
+};
+
 export class BrowserBrokerClient {
   private readonly options: BrowserBrokerClientOptions;
+  private core: BrokerClientBinding | null = null;
   private worker: SharedWorker | null = null;
   private port: MessagePort | null = null;
-  private brokerInstanceId: string | null = null;
-  private role: BrowserBrokerRole = "follower";
-  private leaderTabId: string | null = null;
-  private leadershipId = 0;
-  private visibility: BrowserBrokerVisibility;
+  private preconnectedWorker: PreconnectedWorker | null = null;
+  private pendingWorker: { workerId: number; worker: SharedWorker } | null = null;
+  private readonly workers = new Map<number, SharedWorker>();
+  private readonly workerCleanups = new Map<number, () => void>();
+  private readonly ports = new Map<number, MessagePort>();
+  private readonly portCleanups = new Map<number, () => void>();
+  private readonly portToWorker = new Map<number, number>();
+  private readonly timers = new Map<number, ReturnType<typeof setTimeout>>();
+  private readonly publicPromises = new Map<number, PublicPromise>();
+  private readonly messagePorts = new Map<number, MessagePort>();
+  private readonly suppressHelloPortIds = new Set<number>();
+  private nextPromiseId = 1;
+  private nextMessagePortId = 1;
+  private connectWaiter: ConnectWaiter | null = null;
   private closed = false;
   private closedError: Error | null = null;
-  private reconnecting = false;
-  private reconnectDone: Promise<void> | null = null;
-  private resolveReconnectDone: (() => void) | null = null;
-  private readonly roleWaiters = new Set<RoleWaiter>();
-  private readonly resetWaiters = new Map<string, ResetWaiter[]>();
-  private readonly resetStartWaiters = new Map<string, ResetStartWaiter[]>();
-  private readonly queuedMessages: BrowserBrokerTabMessage[] = [];
-  private brokerLivenessTimer: ReturnType<typeof setTimeout> | null = null;
 
   private constructor(options: BrowserBrokerClientOptions) {
     this.options = options;
-    this.visibility = options.visibility;
   }
 
   static async connect(options: BrowserBrokerClientOptions): Promise<BrowserBrokerClient> {
@@ -125,18 +248,20 @@ export class BrowserBrokerClient {
       throw new Error(formatUnsupportedBrowserBrokerError(missing));
     }
 
+    const wasmModule = loadBrokerClientWasmModule(options.runtimeSources);
     const client = new BrowserBrokerClient(options);
-    await client.connectToBroker();
+    await client.connectToBroker(wasmModule);
     return client;
   }
 
   snapshot(): BrowserBrokerClientSnapshot {
+    const snapshot = this.core?.snapshot();
     return {
-      brokerInstanceId: this.brokerInstanceId,
-      role: this.role,
-      tabId: this.options.tabId,
-      leaderTabId: this.leaderTabId,
-      leadershipId: this.leadershipId,
+      brokerInstanceId: snapshot?.brokerInstanceId ?? null,
+      role: snapshot?.role ?? "follower",
+      tabId: snapshot?.tabId ?? this.options.tabId,
+      leaderTabId: snapshot?.leaderTabId ?? null,
+      leadershipId: snapshot?.leadershipId ?? 0,
     };
   }
 
@@ -144,67 +269,66 @@ export class BrowserBrokerClient {
     if (this.closed) {
       throw this.closedError ?? new Error("Browser broker client closed");
     }
-    if (this.role === role && this.leaderTabId !== null) {
-      return;
-    }
 
-    await new Promise<void>((resolve, reject) => {
-      const waiter: RoleWaiter = {
+    const promiseId = this.nextPublicPromiseId();
+    const promise = this.createPublicPromise(promiseId);
+    this.runCoreEvent({
+      type: "publicCommand",
+      command: {
+        type: "waitForRole",
         role,
-        resolve,
-        reject,
-        timeout: setTimeout(() => {
-          this.roleWaiters.delete(waiter);
-          reject(new Error(`Timed out waiting for broker role ${role}`));
-        }, timeoutMs),
-      };
-      this.roleWaiters.add(waiter);
+        promiseId,
+        timeoutMs: sanitizeOptionalTimeoutMs(timeoutMs) ?? 5_000,
+      },
     });
+    return await promise;
   }
 
   reportLeaderReady(input: BrowserBrokerLeaderReadyInput): void {
-    this.send({
-      type: "leader-ready",
-      leadershipId: input.leadershipId,
-      tabLockName: input.tabLockName,
-      workerLockName: input.workerLockName,
-      ...(input.bridgelessStorageReset ? { bridgelessStorageReset: true } : {}),
+    this.runCoreEvent({
+      type: "publicCommand",
+      command: {
+        type: "reportLeaderReady",
+        leadershipId: input.leadershipId,
+        tabLockName: input.tabLockName,
+        workerLockName: input.workerLockName,
+        bridgelessStorageReset: input.bridgelessStorageReset === true,
+      },
     });
   }
 
   reportLeaderFailed(leadershipId: number, reason: string): void {
-    this.send({
-      type: "leader-failed",
-      leadershipId,
-      reason,
+    this.runCoreEvent({
+      type: "publicCommand",
+      command: { type: "reportLeaderFailed", leadershipId, reason },
     });
   }
 
   reportVisibility(visibility: BrowserBrokerVisibility): void {
-    this.visibility = visibility;
-    this.send({ type: "visibility", visibility });
+    this.runCoreEvent({
+      type: "publicCommand",
+      command: { type: "reportVisibility", visibility },
+    });
   }
 
   reportFollowerPortAttached(followerTabId: string, leadershipId: number): void {
-    this.send({
-      type: "follower-port-attached",
-      followerTabId,
-      leadershipId,
+    this.runCoreEvent({
+      type: "publicCommand",
+      command: { type: "reportFollowerPortAttached", followerTabId, leadershipId },
     });
   }
 
   reportFollowerPortClosed(followerTabId: string, leadershipId: number): void {
-    this.send({
-      type: "follower-port-closed",
-      followerTabId,
-      leadershipId,
+    this.runCoreEvent({
+      type: "publicCommand",
+      command: { type: "reportFollowerPortClosed", followerTabId, leadershipId },
     });
   }
 
   reportSchemaReady(schemaFingerprint: string): void {
-    this.send({
-      type: "schema-ready",
-      schemaFingerprint,
+    this.runCoreEvent({
+      type: "publicCommand",
+      command: { type: "reportSchemaReady", schemaFingerprint },
     });
   }
 
@@ -212,170 +336,242 @@ export class BrowserBrokerClient {
     if (this.closed) {
       throw this.closedError ?? new Error("Browser broker client closed");
     }
-    // A reconnect drops in-flight sends; wait for it to settle so the
-    // reset request reaches the new broker instance instead of vanishing.
-    while (this.reconnecting && this.reconnectDone) {
-      await this.reconnectDone;
-      if (this.closed) {
-        throw this.closedError ?? new Error("Browser broker client closed");
-      }
-    }
-    let startWaiter!: ResetStartWaiter;
-    let waiter!: ResetWaiter;
-    const started = new Promise<void>((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        this.removeResetStartWaiter(requestId, startWaiter);
-        reject(new Error(`Timed out waiting for browser storage reset ${requestId} to start`));
-      }, this.storageResetTimeoutMs());
-      startWaiter = { resolve, reject, timeout };
-      const waiters = this.resetStartWaiters.get(requestId) ?? [];
-      waiters.push(startWaiter);
-      this.resetStartWaiters.set(requestId, waiters);
+
+    const startPromiseId = this.nextPublicPromiseId();
+    const completionPromiseId = this.nextPublicPromiseId();
+    const started = this.createPublicPromise(startPromiseId);
+    const completion = this.createPublicPromise(completionPromiseId);
+
+    this.runCoreEvent({
+      type: "publicCommand",
+      command: {
+        type: "requestStorageReset",
+        requestId,
+        startPromiseId,
+        completionPromiseId,
+      },
     });
-    const completion = new Promise<void>((resolve, reject) => {
-      waiter = { resolve, reject };
-      const waiters = this.resetWaiters.get(requestId) ?? [];
-      waiters.push(waiter);
-      this.resetWaiters.set(requestId, waiters);
-    });
-    this.send({
-      type: "storage-reset-request",
-      requestId,
-    });
+
     try {
       await started;
       await completion;
     } catch (error) {
-      this.removeResetWaiter(requestId, waiter);
+      this.publicPromises.delete(completionPromiseId);
       throw error;
     }
   }
 
   async shutdown(): Promise<void> {
     if (this.closed) return;
-    const shutdownMessage = this.stampTabMessage({ type: "shutdown" });
+    this.runCoreEvent({ type: "publicCommand", command: { type: "shutdown" } });
     this.closed = true;
-    this.closedError = new Error("Browser broker client closed");
-    this.stopBrokerLivenessTimer();
-    this.queuedMessages.length = 0;
-    if (shutdownMessage) {
-      this.port?.postMessage(shutdownMessage);
-    }
-    if (this.port) {
-      this.detachBrokerPort(this.port);
-    }
-    for (const waiter of this.roleWaiters) {
-      clearTimeout(waiter.timeout);
-      waiter.reject(new Error("Browser broker client closed"));
-    }
-    this.roleWaiters.clear();
-    this.rejectResetStartWaiters(new Error("Browser broker client closed"));
-    this.rejectResetWaiters(new Error("Browser broker client closed"));
+    const error = new Error("Browser broker client closed");
+    this.closedError = error;
+    this.preconnectedWorker?.cleanup();
+    this.preconnectedWorker?.port.close();
+    this.preconnectedWorker = null;
+    this.connectWaiter?.reject(error);
+    this.connectWaiter = null;
+    this.rejectAllPublicPromises(this.closedError);
   }
 
-  private async connectToBroker(): Promise<void> {
-    const worker = this.createSharedWorker();
+  private connectToBroker(wasmModulePromise: Promise<BrokerClientModule>): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      this.connectWaiter = { resolve, reject };
+      let preconnected: PreconnectedWorker;
+      try {
+        preconnected = this.startPreconnectedWorker();
+        this.preconnectedWorker = preconnected;
+      } catch (error) {
+        this.failConnect(wrapUnknownError(error));
+        return;
+      }
+
+      void wasmModulePromise.then(
+        (wasmModule) => {
+          if (this.closed) {
+            preconnected.cleanup();
+            preconnected.port.close();
+            return;
+          }
+          this.core = new wasmModule.BrokerClient();
+          this.runCoreEvent(this.connectRequestedEvent());
+          this.replayPreconnectedMessages(preconnected);
+        },
+        (error) => {
+          if (this.closed) return;
+          this.failConnect(wrapUnknownError(error));
+        },
+      );
+    });
+  }
+
+  private connectRequestedEvent(): BrokerClientEvent {
+    return {
+      type: "connectRequested",
+      appId: this.options.appId,
+      dbName: this.options.dbName,
+      tabId: this.options.tabId,
+      fingerprint: this.options.fingerprint,
+      visibility: this.options.visibility,
+      forceTakeoverTimeoutMs: sanitizeOptionalTimeoutMs(this.options.forceTakeoverTimeoutMs),
+      brokerPingIntervalMs: sanitizeOptionalTimeoutMs(this.options.brokerPingIntervalMs),
+      brokerPongTimeoutMs: sanitizeOptionalTimeoutMs(this.options.brokerPongTimeoutMs),
+      storageResetTimeoutMs: sanitizeOptionalTimeoutMs(this.options.storageResetTimeoutMs),
+      nowMs: Date.now(),
+    };
+  }
+
+  private startPreconnectedWorker(): PreconnectedWorker {
+    const workerId = 1;
+    const portId = 1;
+    const worker = this.createSharedWorker(this.brokerWorkerName());
     const port = worker.port;
+    const queuedMessages: BrowserBrokerControlMessage[] = [];
+
     this.worker = worker;
     this.port = port;
+    this.suppressHelloPortIds.add(portId);
 
-    port.addEventListener("message", this.onMessage);
-    port.addEventListener("messageerror", this.onPortMessageError);
+    const onMessage = (event: MessageEvent) => {
+      queuedMessages.push(event.data as BrowserBrokerControlMessage);
+    };
+    const onPortMessageError = () => {
+      this.failConnect(new Error("Browser broker port message error"));
+    };
+    port.addEventListener("message", onMessage);
+    port.addEventListener("messageerror", onPortMessageError);
     port.start();
 
-    const hello = new Promise<void>((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        cleanup();
-        reject(new Error("Timed out waiting for browser broker hello"));
-      }, 5_000);
-
+    let workerCleanup = () => {};
+    if (typeof (worker as Partial<EventTarget>).addEventListener === "function") {
+      const workerEvents = worker as unknown as EventTarget;
       const onWorkerError = (event: Event) => {
-        cleanup();
         const detail =
           (event as ErrorEvent).message ||
           "worker error event (possible script URL or version mismatch)";
-        reject(new Error(`Browser broker SharedWorker failed to start: ${detail}`));
+        this.failConnect(new Error(`Browser broker SharedWorker failed to start: ${detail}`));
       };
+      workerEvents.addEventListener("error", onWorkerError);
+      workerCleanup = () => workerEvents.removeEventListener("error", onWorkerError);
+    }
 
-      const cleanup = () => {
-        clearTimeout(timeout);
-        port.removeEventListener("message", onHello);
-        workerEvents?.removeEventListener("error", onWorkerError);
-      };
+    port.postMessage(this.helloMessage());
 
-      const onHello = (event: MessageEvent) => {
-        const message = event.data as BrowserBrokerControlMessage;
-        if (message?.type === "broker-hello") {
-          cleanup();
-          resolve();
-          return;
-        }
-        if (message?.type === "unsupported") {
-          cleanup();
-          reject(createBrowserBrokerUnsupportedError(message.reason, message.code));
-        }
-      };
+    return {
+      workerId,
+      portId,
+      worker,
+      port,
+      queuedMessages,
+      helloPosted: true,
+      cleanup: () => {
+        port.removeEventListener("message", onMessage);
+        port.removeEventListener("messageerror", onPortMessageError);
+        workerCleanup();
+      },
+    };
+  }
 
-      // Fakes in unit tests (and exotic SharedWorker shims) may not be
-      // EventTargets, so the listener is best-effort.
-      const workerEvents =
-        typeof (worker as Partial<EventTarget>).addEventListener === "function"
-          ? (worker as unknown as EventTarget)
-          : null;
-      workerEvents?.addEventListener("error", onWorkerError);
-      port.addEventListener("message", onHello);
-    });
-
-    port.postMessage({
-      type: "hello",
-      tabId: this.options.tabId,
-      appId: this.options.appId,
-      dbName: this.options.dbName,
-      fingerprint: this.options.fingerprint,
-      visibility: this.visibility,
-      forceTakeoverTimeoutMs: this.options.forceTakeoverTimeoutMs,
-      brokerPingIntervalMs: this.options.brokerPingIntervalMs,
-      brokerPongTimeoutMs: this.options.brokerPongTimeoutMs,
-    });
-
-    try {
-      await hello;
-      await this.waitForInitialLeadershipMessage(port);
-      this.refreshBrokerLivenessTimer();
-      this.flushQueuedMessages();
-    } catch (error) {
-      if (this.port === port) {
-        this.detachBrokerPort(port);
-        this.port = null;
-      }
-      if (this.worker === worker) {
-        this.worker = null;
-      }
-      throw error;
+  private replayPreconnectedMessages(preconnected: PreconnectedWorker): void {
+    for (const message of preconnected.queuedMessages.splice(0)) {
+      this.handleControlMessage(preconnected.portId, message);
     }
   }
 
-  private async waitForInitialLeadershipMessage(port: MessagePort): Promise<void> {
-    if (this.leadershipId > 0 || this.closed || this.port !== port) return;
+  private runCoreEvent(event: BrokerClientEvent): void {
+    if (this.closed && event.type !== "callbackResolved" && event.type !== "callbackRejected") {
+      return;
+    }
 
-    await new Promise<void>((resolve) => {
-      let timeout: ReturnType<typeof setTimeout>;
-      const cleanup = () => {
-        clearTimeout(timeout);
-        port.removeEventListener("message", onMessage);
-        resolve();
-      };
-      const onMessage = () => {
-        if (this.leadershipId > 0 || this.closed || this.port !== port) {
-          cleanup();
-        }
-      };
-      timeout = setTimeout(cleanup, 100);
-      port.addEventListener("message", onMessage);
-    });
+    let effects: BrokerClientEffect[];
+    try {
+      if (!this.core) return;
+      effects = this.core.handleEvent(event);
+    } catch (error) {
+      this.handleEffectExecutionError(error);
+      return;
+    }
+    this.executeEffects(effects);
   }
 
-  private createSharedWorker(): SharedWorker {
+  private executeEffects(effects: BrokerClientEffect[]): void {
+    for (const effect of effects) {
+      try {
+        this.executeEffect(effect);
+      } catch (error) {
+        this.handleEffectExecutionError(error);
+        return;
+      }
+    }
+  }
+
+  private executeEffect(effect: BrokerClientEffect): void {
+    switch (effect.type) {
+      case "createSharedWorker": {
+        const worker =
+          this.preconnectedWorker?.workerId === effect.workerId
+            ? this.preconnectedWorker.worker
+            : this.createSharedWorker(effect.name);
+        this.worker = worker;
+        this.workers.set(effect.workerId, worker);
+        this.pendingWorker = { workerId: effect.workerId, worker };
+        if (this.preconnectedWorker?.workerId !== effect.workerId) {
+          this.attachWorkerErrorListener(effect.workerId, worker);
+        }
+        return;
+      }
+      case "attachPortListeners":
+        this.attachPort(effect.portId);
+        return;
+      case "detachPort":
+        this.detachPort(effect.portId, effect.close);
+        return;
+      case "postToBroker": {
+        if (effect.message.type === "hello" && this.suppressHelloPortIds.delete(effect.portId)) {
+          return;
+        }
+        this.ports.get(effect.portId)?.postMessage(effect.message);
+        return;
+      }
+      case "armTimer":
+        this.armTimer(effect.timerId, effect.kind, effect.delayMs);
+        return;
+      case "cancelTimer":
+        this.cancelTimer(effect.timerId);
+        return;
+      case "releaseMessagePort":
+        this.releaseMessagePort(effect.portId);
+        return;
+      case "invokeCallback":
+        this.invokeCallback(effect.callbackId, effect.callback);
+        return;
+      case "resolveConnect":
+        this.connectWaiter?.resolve();
+        this.connectWaiter = null;
+        return;
+      case "rejectConnect":
+        this.failConnect(errorFromBroker(effect.reason, effect.code));
+        return;
+      case "resolvePublicPromise": {
+        const promise = this.publicPromises.get(effect.promiseId);
+        this.publicPromises.delete(effect.promiseId);
+        promise?.resolve();
+        return;
+      }
+      case "rejectPublicPromise": {
+        const promise = this.publicPromises.get(effect.promiseId);
+        this.publicPromises.delete(effect.promiseId);
+        promise?.reject(new Error(effect.reason));
+        return;
+      }
+      case "closeClient":
+        this.closeWithError(errorFromBroker(effect.reason, effect.code));
+        return;
+    }
+  }
+
+  private createSharedWorker(name: string): SharedWorker {
     const globalLike = this.options.globalLike ?? (globalThis as BrowserBrokerCapabilityGlobal);
     const SharedWorkerCtor = globalLike.SharedWorker as SharedWorkerConstructor;
     const workerUrl =
@@ -386,284 +582,223 @@ export class BrowserBrokerClient {
             this.options.runtimeSources,
           )
         : new URL("../worker/jazz-broker-worker.js", import.meta.url);
-    return new SharedWorkerCtor(workerUrl, {
-      type: "module",
-      name: `jazz-broker:${this.options.appId}:${this.options.dbName}`,
+    return new SharedWorkerCtor(workerUrl, { type: "module", name });
+  }
+
+  private brokerWorkerName(): string {
+    return `jazz-broker:${this.options.appId}:${this.options.dbName}`;
+  }
+
+  private helloMessage(): BrowserBrokerTabMessage {
+    return {
+      type: "hello",
+      tabId: this.options.tabId,
+      appId: this.options.appId,
+      dbName: this.options.dbName,
+      fingerprint: this.options.fingerprint,
+      visibility: this.options.visibility,
+      forceTakeoverTimeoutMs: sanitizeOptionalTimeoutMs(this.options.forceTakeoverTimeoutMs),
+      brokerPingIntervalMs: sanitizeOptionalTimeoutMs(this.options.brokerPingIntervalMs),
+      brokerPongTimeoutMs: sanitizeOptionalTimeoutMs(this.options.brokerPongTimeoutMs),
+    };
+  }
+
+  private attachWorkerErrorListener(workerId: number, worker: SharedWorker): void {
+    if (typeof (worker as Partial<EventTarget>).addEventListener !== "function") return;
+
+    const workerEvents = worker as unknown as EventTarget;
+    const onWorkerError = (event: Event) => {
+      const detail =
+        (event as ErrorEvent).message ||
+        "worker error event (possible script URL or version mismatch)";
+      this.runCoreEvent({
+        type: "workerError",
+        workerId,
+        errorMessage: detail,
+        nowMs: Date.now(),
+      });
+    };
+    workerEvents.addEventListener("error", onWorkerError);
+    this.workerCleanups.set(workerId, () => {
+      workerEvents.removeEventListener("error", onWorkerError);
     });
   }
 
-  private readonly onMessage = (event: MessageEvent): void => {
-    this.handleControlMessage(event.data as BrowserBrokerControlMessage);
-  };
+  private attachPort(portId: number): void {
+    const pending = this.pendingWorker;
+    if (!pending) return;
 
-  private readonly onPortMessageError = (): void => {
-    void this.reconnectAfterBrokerPortFailure(new Error("Browser broker port message error"));
-  };
+    const port = pending.worker.port;
+    if (this.preconnectedWorker?.portId === portId) {
+      this.preconnectedWorker.cleanup();
+      this.preconnectedWorker = null;
+    }
+    this.port = port;
+    this.pendingWorker = null;
+    this.ports.set(portId, port);
+    this.portToWorker.set(portId, pending.workerId);
 
-  private handleControlMessage(message: BrowserBrokerControlMessage): void {
-    if (!message || typeof message !== "object") return;
-    if (this.brokerInstanceId && message.brokerInstanceId !== this.brokerInstanceId) {
-      void this.reconnectAfterBrokerInstanceChange(message.brokerInstanceId);
-      return;
+    const onMessage = (event: MessageEvent) => {
+      this.handleControlMessage(portId, event.data as BrowserBrokerControlMessage);
+    };
+    const onPortMessageError = () => {
+      this.runCoreEvent({ type: "portMessageError", portId, nowMs: Date.now() });
+    };
+    port.addEventListener("message", onMessage);
+    port.addEventListener("messageerror", onPortMessageError);
+    port.start();
+
+    this.portCleanups.set(portId, () => {
+      port.removeEventListener("message", onMessage);
+      port.removeEventListener("messageerror", onPortMessageError);
+    });
+  }
+
+  private detachPort(portId: number, close: boolean): void {
+    const port = this.ports.get(portId);
+    this.portCleanups.get(portId)?.();
+    this.portCleanups.delete(portId);
+    this.ports.delete(portId);
+
+    const workerId = this.portToWorker.get(portId);
+    this.portToWorker.delete(portId);
+    if (workerId !== undefined) {
+      this.workerCleanups.get(workerId)?.();
+      this.workerCleanups.delete(workerId);
+      this.workers.delete(workerId);
     }
 
-    switch (message.type) {
-      case "broker-hello":
-        this.brokerInstanceId = message.brokerInstanceId;
-        return;
-      case "broker-ping":
-        this.refreshBrokerLivenessTimer();
-        this.options.onBrokerPing?.();
-        if (this.shouldRespondToBrokerPing()) {
-          this.port?.postMessage({
-            type: "broker-pong",
-            brokerInstanceId: message.brokerInstanceId,
-          });
-        }
-        return;
-      case "become-leader":
-        this.leadershipId = message.leadershipId;
-        void Promise.resolve(
-          this.options.onBecomeLeader?.(this, message.leadershipId, message.resetRequestId),
-        ).catch((error) => {
-          this.reportLeaderFailed(message.leadershipId, stringifyError(error));
-        });
-        return;
-      case "demote":
-        if (message.leadershipId === this.leadershipId) {
-          this.role = "follower";
-          this.leaderTabId = null;
-          this.resolveRoleWaiters();
-        }
-        void this.options.onDemote?.(message.leadershipId);
-        return;
-      case "leader-ready":
-        this.leadershipId = message.leadershipId;
-        this.leaderTabId = message.leaderTabId;
-        this.role = message.leaderTabId === this.options.tabId ? "leader" : "follower";
-        this.resolveRoleWaiters();
-        return;
-      case "attach-follower-port":
-        if (message.leadershipId !== this.leadershipId) return;
-        this.options.onAttachFollowerPort?.(
-          message.followerTabId,
-          message.leadershipId,
-          message.port,
-        );
-        return;
-      case "use-follower-port":
-        this.leadershipId = message.leadershipId;
-        this.leaderTabId = message.leaderTabId;
-        this.role = "follower";
-        this.options.onUseFollowerPort?.(message.leaderTabId, message.leadershipId, message.port);
-        return;
-      case "follower-ready":
-        this.leadershipId = message.leadershipId;
-        this.leaderTabId = message.leaderTabId;
-        this.role = "follower";
-        this.options.onFollowerReady?.(message.leaderTabId, message.leadershipId);
-        this.resolveRoleWaiters();
-        return;
-      case "close-follower-port":
-        this.options.onCloseFollowerPort?.(message.leadershipId);
-        return;
-      case "detach-follower-port":
-        this.options.onDetachFollowerPort?.(message.followerTabId, message.leadershipId);
-        return;
-      case "storage-reset-begin":
-        this.resolveResetStartWaiters(message.requestId);
-        void Promise.resolve(
-          this.options.onStorageResetBegin?.(message.requestId, message.leadershipId),
-        )
-          .then(() => {
-            this.reportStorageResetReady(message.requestId, true);
-          })
-          .catch((error) => {
-            this.reportStorageResetReady(message.requestId, false, stringifyError(error));
-          });
-        return;
-      case "storage-reset-started":
-        this.resolveResetStartWaiters(message.requestId);
-        return;
-      case "storage-reset-finished":
-        this.resolveResetStartWaiters(message.requestId);
-        this.resolveResetWaiters(message.requestId, message.success, message.errorMessage);
-        return;
-      case "schema-blocked":
-        this.options.onSchemaBlocked?.(message.reason);
-        return;
-      case "unsupported":
-        this.closeWithError(createBrowserBrokerUnsupportedError(message.reason, message.code));
-        return;
+    if (close) {
+      port?.close();
+    }
+    if (this.port === port) {
+      this.port = null;
     }
   }
 
-  private async reconnectAfterBrokerInstanceChange(nextBrokerInstanceId: string): Promise<void> {
-    await this.reconnectAfterBrokerPortFailure(
-      new Error(
-        `Browser broker instance changed from ${this.brokerInstanceId} to ${nextBrokerInstanceId}`,
-      ),
+  private handleControlMessage(_portId: number, rawMessage: BrowserBrokerControlMessage): void {
+    if (!rawMessage || typeof rawMessage !== "object") return;
+    const message = this.prepareControlMessage(rawMessage);
+    this.runCoreEvent({
+      type: "brokerMessageReceived",
+      message,
+      respondToBrokerPing: this.shouldRespondToBrokerPing(),
+      nowMs: Date.now(),
+    });
+  }
+
+  private prepareControlMessage(message: BrowserBrokerControlMessage): BrokerControlMessageForCore {
+    if (message.type === "attach-follower-port" || message.type === "use-follower-port") {
+      const portId = this.nextMessagePortId++;
+      this.messagePorts.set(portId, message.port);
+      const { port: _port, ...rest } = message;
+      return { ...rest, portId } as BrokerControlMessageForCore;
+    }
+    return message;
+  }
+
+  private armTimer(timerId: number, kind: BrokerClientTimerKind, delayMs: number): void {
+    this.cancelTimer(timerId);
+    const timeout = setTimeout(() => {
+      this.timers.delete(timerId);
+      this.runCoreEvent({ type: "timerFired", timerId, kind, nowMs: Date.now() });
+    }, delayMs);
+    this.timers.set(timerId, timeout);
+  }
+
+  private cancelTimer(timerId: number): void {
+    const timer = this.timers.get(timerId);
+    if (!timer) return;
+    clearTimeout(timer);
+    this.timers.delete(timerId);
+  }
+
+  private invokeCallback(callbackId: number, callback: BrokerClientCallback): void {
+    let result: void | Promise<void>;
+    try {
+      result = this.callCallback(callback);
+    } catch (error) {
+      this.runCoreEvent({
+        type: "callbackRejected",
+        callbackId,
+        errorMessage: stringifyError(error),
+        nowMs: Date.now(),
+      });
+      return;
+    }
+
+    void Promise.resolve(result).then(
+      () => {
+        this.runCoreEvent({ type: "callbackResolved", callbackId, nowMs: Date.now() });
+      },
+      (error) => {
+        this.runCoreEvent({
+          type: "callbackRejected",
+          callbackId,
+          errorMessage: stringifyError(error),
+          nowMs: Date.now(),
+        });
+      },
     );
   }
 
-  private async reconnectAfterBrokerPortFailure(_error: Error): Promise<void> {
-    if (this.closed || this.reconnecting) return;
-    this.reconnecting = true;
-    this.reconnectDone = new Promise((resolve) => {
-      this.resolveReconnectDone = resolve;
-    });
-
-    const previousRole = this.role;
-    const previousLeadershipId = this.leadershipId;
-    const previousPort = this.port;
-
-    this.stopBrokerLivenessTimer();
-    this.brokerInstanceId = null;
-    this.role = "follower";
-    this.leaderTabId = null;
-    this.leadershipId = 0;
-    this.queuedMessages.length = 0;
-    const resetError = new Error("Browser broker restarted during storage reset");
-    this.rejectResetStartWaiters(resetError);
-    this.rejectResetWaiters(resetError);
-
-    if (previousPort) {
-      this.detachBrokerPort(previousPort);
-      if (this.port === previousPort) {
-        this.port = null;
+  private callCallback(callback: BrokerClientCallback): void | Promise<void> {
+    switch (callback.type) {
+      case "brokerPing":
+        return this.options.onBrokerPing?.();
+      case "becomeLeader":
+        return this.options.onBecomeLeader?.(this, callback.leadershipId, callback.resetRequestId);
+      case "demote":
+        return this.options.onDemote?.(callback.leadershipId);
+      case "attachFollowerPort": {
+        if (!this.options.onAttachFollowerPort) {
+          this.releaseMessagePort(callback.portId);
+          return;
+        }
+        const port = this.takeMessagePort(callback.portId);
+        if (!port) return;
+        return this.options.onAttachFollowerPort(
+          callback.followerTabId,
+          callback.leadershipId,
+          port,
+        );
       }
-    }
-
-    let reconnectError: unknown;
-    try {
-      if (previousLeadershipId > 0) {
-        await this.options.onDemote?.(previousLeadershipId);
+      case "detachFollowerPort":
+        return this.options.onDetachFollowerPort?.(callback.followerTabId, callback.leadershipId);
+      case "useFollowerPort": {
+        if (!this.options.onUseFollowerPort) {
+          this.releaseMessagePort(callback.portId);
+          return;
+        }
+        const port = this.takeMessagePort(callback.portId);
+        if (!port) return;
+        return this.options.onUseFollowerPort(callback.leaderTabId, callback.leadershipId, port);
       }
-      if (previousRole === "follower" && previousLeadershipId > 0) {
-        this.options.onCloseFollowerPort?.(previousLeadershipId);
-      }
-
-      if (!this.closed) {
-        await this.connectToBroker();
-      }
-    } catch (error) {
-      reconnectError = error;
-    }
-
-    this.reconnecting = false;
-    this.resolveReconnectDone?.();
-    this.resolveReconnectDone = null;
-    this.reconnectDone = null;
-    if (reconnectError) {
-      this.closeWithError(new Error(stringifyError(reconnectError), { cause: reconnectError }));
-      return;
-    }
-    if (!this.closed) {
-      this.send({ type: "visibility", visibility: this.visibility });
-      this.options.onReconnected?.(this);
-      this.flushQueuedMessages();
+      case "followerReady":
+        return this.options.onFollowerReady?.(callback.leaderTabId, callback.leadershipId);
+      case "closeFollowerPort":
+        return this.options.onCloseFollowerPort?.(callback.leadershipId);
+      case "storageResetBegin":
+        return this.options.onStorageResetBegin?.(callback.requestId, callback.leadershipId);
+      case "schemaBlocked":
+        return this.options.onSchemaBlocked?.(callback.reason);
+      case "reconnected":
+        return this.options.onReconnected?.(this);
     }
   }
 
-  private resolveRoleWaiters(): void {
-    for (const waiter of this.roleWaiters) {
-      if (this.role !== waiter.role || this.leaderTabId === null) {
-        continue;
-      }
-      clearTimeout(waiter.timeout);
-      this.roleWaiters.delete(waiter);
-      waiter.resolve();
-    }
+  private takeMessagePort(portId: number | undefined): MessagePort | null {
+    if (portId === undefined) return null;
+    const port = this.messagePorts.get(portId) ?? null;
+    this.messagePorts.delete(portId);
+    return port;
   }
 
-  private rejectRoleWaiters(error: Error): void {
-    for (const waiter of this.roleWaiters) {
-      clearTimeout(waiter.timeout);
-      waiter.reject(error);
-    }
-    this.roleWaiters.clear();
-  }
-
-  private reportStorageResetReady(
-    requestId: string,
-    success: boolean,
-    errorMessage?: string,
-  ): void {
-    this.send({
-      type: "storage-reset-ready",
-      requestId,
-      success,
-      ...(errorMessage ? { errorMessage } : {}),
-    });
-  }
-
-  private resolveResetWaiters(
-    requestId: string,
-    success: boolean,
-    errorMessage: string | undefined,
-  ): void {
-    const waiters = this.resetWaiters.get(requestId);
-    if (!waiters) return;
-    this.resetWaiters.delete(requestId);
-    const error = success ? null : new Error(errorMessage ?? "Browser storage reset failed");
-    for (const waiter of waiters) {
-      if (error) {
-        waiter.reject(error);
-      } else {
-        waiter.resolve();
-      }
-    }
-  }
-
-  private resolveResetStartWaiters(requestId: string): void {
-    const waiters = this.resetStartWaiters.get(requestId);
-    if (!waiters) return;
-    this.resetStartWaiters.delete(requestId);
-    for (const waiter of waiters) {
-      clearTimeout(waiter.timeout);
-      waiter.resolve();
-    }
-  }
-
-  private removeResetStartWaiter(requestId: string, waiter: ResetStartWaiter): void {
-    const waiters = this.resetStartWaiters.get(requestId);
-    if (!waiters) return;
-    const next = waiters.filter((candidate) => candidate !== waiter);
-    if (next.length === 0) {
-      this.resetStartWaiters.delete(requestId);
-    } else {
-      this.resetStartWaiters.set(requestId, next);
-    }
-  }
-
-  private removeResetWaiter(requestId: string, waiter: ResetWaiter): void {
-    const waiters = this.resetWaiters.get(requestId);
-    if (!waiters) return;
-    const next = waiters.filter((candidate) => candidate !== waiter);
-    if (next.length === 0) {
-      this.resetWaiters.delete(requestId);
-    } else {
-      this.resetWaiters.set(requestId, next);
-    }
-  }
-
-  private rejectResetStartWaiters(error: Error): void {
-    for (const waiters of this.resetStartWaiters.values()) {
-      for (const waiter of waiters) {
-        clearTimeout(waiter.timeout);
-        waiter.reject(error);
-      }
-    }
-    this.resetStartWaiters.clear();
-  }
-
-  private rejectResetWaiters(error: Error): void {
-    for (const waiters of this.resetWaiters.values()) {
-      for (const waiter of waiters) {
-        waiter.reject(error);
-      }
-    }
-    this.resetWaiters.clear();
+  private releaseMessagePort(portId: number | undefined): void {
+    if (portId === undefined) return;
+    const port = this.messagePorts.get(portId);
+    this.messagePorts.delete(portId);
+    port?.close();
   }
 
   private shouldRespondToBrokerPing(): boolean {
@@ -674,82 +809,164 @@ export class BrowserBrokerClient {
     return respond !== false;
   }
 
-  private refreshBrokerLivenessTimer(): void {
-    this.stopBrokerLivenessTimer();
-    if (this.closed) return;
-    this.brokerLivenessTimer = setTimeout(() => {
-      this.brokerLivenessTimer = null;
-      void this.reconnectAfterBrokerPortFailure(
-        new Error("Browser broker liveness timed out waiting for broker ping"),
-      );
-    }, this.brokerLivenessTimeoutMs());
+  private nextPublicPromiseId(): number {
+    return this.nextPromiseId++;
   }
 
-  private stopBrokerLivenessTimer(): void {
-    if (!this.brokerLivenessTimer) return;
-    clearTimeout(this.brokerLivenessTimer);
-    this.brokerLivenessTimer = null;
+  private createPublicPromise(promiseId: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.publicPromises.set(promiseId, { resolve, reject });
+    });
   }
 
-  private brokerLivenessTimeoutMs(): number {
-    return (
-      normalizePositiveTimeout(this.options.brokerPingIntervalMs, DEFAULT_BROKER_PING_INTERVAL_MS) +
-      normalizePositiveTimeout(this.options.brokerPongTimeoutMs, DEFAULT_BROKER_PONG_TIMEOUT_MS)
-    );
-  }
-
-  private storageResetTimeoutMs(): number {
-    return normalizePositiveTimeout(
-      this.options.storageResetTimeoutMs,
-      DEFAULT_STORAGE_RESET_TIMEOUT_MS,
-    );
-  }
-
-  private send(message: BrowserBrokerTabMessageInput): void {
-    if (this.closed) return;
-    const stampedMessage = this.stampTabMessage(message);
-    if (!stampedMessage) return;
-    if (this.reconnecting) return;
-    if (!this.port) {
-      this.queuedMessages.push(stampedMessage);
-      return;
-    }
-    this.port.postMessage(stampedMessage);
-  }
-
-  private stampTabMessage(message: BrowserBrokerTabMessageInput): BrowserBrokerTabMessage | null {
-    if (message.type === "hello") return message;
-    if (!this.brokerInstanceId) return null;
-    return { ...message, brokerInstanceId: this.brokerInstanceId };
-  }
-
-  private flushQueuedMessages(): void {
-    if (this.closed || this.reconnecting || !this.port) return;
-    const messages = this.queuedMessages.splice(0);
-    for (const message of messages) {
-      this.port.postMessage(message);
-    }
-  }
-
-  private detachBrokerPort(port: MessagePort): void {
-    port.removeEventListener("message", this.onMessage);
-    port.removeEventListener("messageerror", this.onPortMessageError);
-    port.close();
+  private failConnect(error: Error): void {
+    this.closed = true;
+    this.closedError = error;
+    this.preconnectedWorker?.cleanup();
+    this.preconnectedWorker?.port.close();
+    this.preconnectedWorker = null;
+    this.connectWaiter?.reject(error);
+    this.connectWaiter = null;
+    this.rejectAllPublicPromises(error);
   }
 
   private closeWithError(error: Error): void {
-    if (this.closed && this.closedError === error) return;
+    if (this.closed) return;
     this.closed = true;
     this.closedError = error;
-    this.stopBrokerLivenessTimer();
-    this.queuedMessages.length = 0;
-    if (this.port) {
-      this.detachBrokerPort(this.port);
-      this.port = null;
+    this.clearAllTimers();
+    for (const portId of [...this.ports.keys()]) {
+      this.detachPort(portId, true);
     }
-    this.rejectRoleWaiters(error);
-    this.rejectResetStartWaiters(error);
-    this.rejectResetWaiters(error);
+    this.preconnectedWorker?.cleanup();
+    this.preconnectedWorker?.port.close();
+    this.preconnectedWorker = null;
+    this.rejectAllPublicPromises(error);
+    this.connectWaiter?.reject(error);
+    this.connectWaiter = null;
     this.options.onClosed?.(error);
   }
+
+  private handleEffectExecutionError(error: unknown): void {
+    const cause = error instanceof Error ? error : undefined;
+    const wrapped = new Error(stringifyError(error), cause ? { cause } : undefined);
+    if (this.connectWaiter) {
+      this.failConnect(wrapped);
+      for (const portId of [...this.ports.keys()]) {
+        this.detachPort(portId, true);
+      }
+      return;
+    }
+    this.closeWithError(wrapped);
+  }
+
+  private rejectAllPublicPromises(error: Error): void {
+    for (const promise of this.publicPromises.values()) {
+      promise.reject(error);
+    }
+    this.publicPromises.clear();
+  }
+
+  private clearAllTimers(): void {
+    for (const timer of this.timers.values()) {
+      clearTimeout(timer);
+    }
+    this.timers.clear();
+  }
+}
+
+let brokerClientWasmInitPromise: Promise<BrokerClientModule> | null = null;
+
+async function loadBrokerClientWasmModule(
+  runtime?: RuntimeSourcesConfig,
+): Promise<BrokerClientModule> {
+  if (brokerClientWasmInitPromise) {
+    return brokerClientWasmInitPromise;
+  }
+
+  brokerClientWasmInitPromise = loadAndInitializeBrokerClientWasmModule(runtime).catch((error) => {
+    brokerClientWasmInitPromise = null;
+    throw error;
+  });
+  return brokerClientWasmInitPromise;
+}
+
+async function loadAndInitializeBrokerClientWasmModule(
+  runtime?: RuntimeSourcesConfig,
+): Promise<BrokerClientModule> {
+  const wasmModule = (await import("jazz-wasm")) as unknown as BrokerClientModule;
+  const syncInitInput = resolveRuntimeConfigSyncInitInput(runtime);
+
+  if (syncInitInput && wasmModule.initSync) {
+    wasmModule.initSync(syncInitInput);
+    return wasmModule;
+  }
+
+  if (typeof process !== "undefined" && process.versions?.node && wasmModule.initSync) {
+    try {
+      const wasmBinary = tryLoadNodePackagedWasmBinarySync();
+      if (wasmBinary) {
+        wasmModule.initSync({ module: wasmBinary });
+        return wasmModule;
+      }
+    } catch {
+      // Browser-like runtimes may expose a partial process object.
+    }
+  }
+
+  if (typeof wasmModule.default === "function") {
+    const wasmUrl =
+      typeof location !== "undefined"
+        ? resolveRuntimeConfigWasmUrl(import.meta.url, location.href, runtime)
+        : null;
+    if (wasmUrl) {
+      await wasmModule.default({ module_or_path: wasmUrl });
+    } else {
+      await wasmModule.default();
+    }
+  }
+
+  return wasmModule;
+}
+
+function tryLoadNodePackagedWasmBinarySync(): Uint8Array | null {
+  const moduleBuiltin = process.getBuiltinModule?.("module");
+  const fsBuiltin = process.getBuiltinModule?.("fs");
+  const pathBuiltin = process.getBuiltinModule?.("path");
+
+  if (!moduleBuiltin || !fsBuiltin || !pathBuiltin) {
+    return null;
+  }
+
+  const { createRequire } = moduleBuiltin;
+  const { existsSync, readFileSync } = fsBuiltin;
+  const { dirname, resolve } = pathBuiltin;
+
+  const require = createRequire(import.meta.url);
+  const packageJsonPath = require.resolve("jazz-wasm/package.json");
+  const packageDir = dirname(packageJsonPath);
+  const wasmPath = resolve(packageDir, "pkg/jazz_wasm_bg.wasm");
+
+  if (!existsSync(wasmPath)) {
+    return null;
+  }
+
+  return readFileSync(wasmPath);
+}
+
+function errorFromBroker(reason: string, code?: BrowserBrokerUnsupportedCode): Error {
+  return code ? createBrowserBrokerUnsupportedError(reason, code) : new Error(reason);
+}
+
+function sanitizeOptionalTimeoutMs(value: number | undefined): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+  const normalized = Math.max(0, Math.floor(value));
+  return normalized > 0 ? normalized : undefined;
+}
+
+function wrapUnknownError(error: unknown): Error {
+  const cause = error instanceof Error ? error : undefined;
+  return new Error(stringifyError(error), cause ? { cause } : undefined);
 }

--- a/packages/jazz-tools/src/runtime/browser-broker-protocol.test.ts
+++ b/packages/jazz-tools/src/runtime/browser-broker-protocol.test.ts
@@ -5,7 +5,6 @@ import {
   createRuntimeSourceIdentity,
   detectBrowserBrokerMissingCapabilities,
   formatUnsupportedBrowserBrokerError,
-  selectLeaderCandidate,
   type BrowserBrokerFingerprintInput,
 } from "./browser-broker-protocol.js";
 
@@ -35,25 +34,6 @@ describe("browser broker protocol", () => {
         navigator: {},
       }),
     ).toEqual(["MessageChannel", "Web Locks"]);
-  });
-
-  it("chooses the newest visible tab as leader candidate", () => {
-    expect(
-      selectLeaderCandidate([
-        { tabId: "a", visibility: "visible", lastVisibleAt: 10 },
-        { tabId: "b", visibility: "visible", lastVisibleAt: 20 },
-        { tabId: "c", visibility: "hidden", lastVisibleAt: 30 },
-      ])?.tabId,
-    ).toBe("b");
-  });
-
-  it("chooses the newest last-visible tab when all candidates are hidden", () => {
-    expect(
-      selectLeaderCandidate([
-        { tabId: "a", visibility: "hidden", lastVisibleAt: 10 },
-        { tabId: "b", visibility: "hidden", lastVisibleAt: 20 },
-      ])?.tabId,
-    ).toBe("b");
   });
 
   it("creates a deterministic fingerprint from stable compatibility fields", () => {

--- a/packages/jazz-tools/src/runtime/browser-broker-protocol.ts
+++ b/packages/jazz-tools/src/runtime/browser-broker-protocol.ts
@@ -11,11 +11,6 @@ import type { BrowserBrokerUnsupportedCode } from "./browser-broker-errors.js";
 export const BROKER_CONTROL_PROTOCOL_VERSION = "jazz-browser-broker-v3";
 export const BROWSER_STORAGE_FORMAT_VERSION = "opfs-btree-v1";
 
-// Liveness defaults shared by the broker worker and the tab client — a drift
-// between the two desynchronizes ping cadence from eviction timing.
-export const DEFAULT_BROKER_PING_INTERVAL_MS = 1_000;
-export const DEFAULT_BROKER_PONG_TIMEOUT_MS = 3_000;
-
 export function normalizePositiveTimeout(value: unknown, fallback: number): number {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
     return fallback;
@@ -49,12 +44,6 @@ export type BrowserBrokerRole = "leader" | "follower";
 
 export interface BrokerInstanceMessage {
   brokerInstanceId: string;
-}
-
-export interface BrowserBrokerCandidate {
-  tabId: string;
-  visibility: BrowserBrokerVisibility;
-  lastVisibleAt: number;
 }
 
 export interface BrowserBrokerFingerprintInput {
@@ -296,32 +285,6 @@ export function detectBrowserBrokerMissingCapabilities(
   }
 
   return missing;
-}
-
-export function selectLeaderCandidate(
-  candidates: readonly BrowserBrokerCandidate[],
-): BrowserBrokerCandidate | null {
-  const visible = candidates.filter((candidate) => candidate.visibility === "visible");
-  const pool = visible.length > 0 ? visible : candidates;
-  let selected: BrowserBrokerCandidate | null = null;
-
-  for (const candidate of pool) {
-    if (!selected) {
-      selected = candidate;
-      continue;
-    }
-
-    if (candidate.lastVisibleAt > selected.lastVisibleAt) {
-      selected = candidate;
-      continue;
-    }
-
-    if (candidate.lastVisibleAt === selected.lastVisibleAt && candidate.tabId > selected.tabId) {
-      selected = candidate;
-    }
-  }
-
-  return selected;
 }
 
 // Leadership ids increase monotonically per namespace. "Stale" means the

--- a/packages/jazz-tools/src/worker/jazz-broker-worker.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker.ts
@@ -1,16 +1,12 @@
-import {
-  createRandomId,
-  DEFAULT_BROKER_PING_INTERVAL_MS,
-  DEFAULT_BROKER_PONG_TIMEOUT_MS,
-  normalizePositiveTimeout,
-  selectLeaderCandidate,
-  stringifyError,
-  type BrowserBrokerCandidate,
-  type BrowserBrokerControlMessage,
-  type BrowserBrokerTabMessage,
-  type BrowserBrokerVisibility,
+import type {
+  BrowserBrokerControlMessage,
+  BrowserBrokerTabMessage,
 } from "../runtime/browser-broker-protocol.js";
-import { INCOMPATIBLE_BROWSER_BROKER_CONFIGURATION_CODE } from "../runtime/browser-broker-errors.js";
+import { createRandomId, stringifyError } from "../runtime/browser-broker-protocol.js";
+import {
+  readWorkerRuntimeWasmUrl,
+  resolveRuntimeConfigWasmUrl,
+} from "../runtime/runtime-config.js";
 import {
   monitorWebLockRelease,
   stealAndReleaseWebLock,
@@ -18,85 +14,146 @@ import {
   type WebLockMonitor,
 } from "../runtime/leader-lock.js";
 
-const DEFAULT_FORCE_TAKEOVER_TIMEOUT_MS = 1_000;
-const LEADER_FAILURE_RETRY_BACKOFF_MS = 1_000;
-const INITIAL_FOLLOWER_ATTACHMENT_TIMEOUT_MS = 1_000;
-const MAX_FOLLOWER_ATTACHMENT_TIMEOUT_MS = 30_000;
-const COMPLETED_STORAGE_RESET_OUTCOME_TTL_MS = 30_000;
-const MAX_COMPLETED_STORAGE_RESET_OUTCOMES = 100;
-
 type SharedWorkerGlobal = typeof globalThis & {
   onconnect: ((event: MessageEvent & { ports: MessagePort[] }) => void) | null;
+  location?: { href?: string };
 };
 
-type TabState = BrowserBrokerCandidate & {
-  appId: string;
-  dbName: string;
-  fingerprint: string;
-  schemaFingerprint: string | null;
-  port: MessagePort;
-  lastPongAt: number;
+type BrokerElectionModule = {
+  default?: (input?: unknown) => Promise<unknown>;
+  initSync?: (input?: unknown) => unknown;
+  BrokerElection: new (brokerInstanceId: string) => BrokerElectionBinding;
 };
 
-type LeaderState = {
-  tabId: string;
-  leadershipId: number;
-  ready: boolean;
-  tabLockName: string | null;
-  workerLockName: string | null;
-  tabLockMonitor: WebLockMonitor | null;
-  workerLockMonitor: WebLockMonitor | null;
+type BrokerElectionBinding = {
+  handleEvent(event: BrokerEvent): BrokerEffect[];
+  snapshot(): unknown;
 };
 
-type ClearedLeaderState = Pick<
-  LeaderState,
-  "tabId" | "leadershipId" | "tabLockName" | "workerLockName"
->;
-
-type ResetState = {
-  requestId: string;
-  requestIds: Set<string>;
-  participants: Set<string>;
-  preparedTabs: Set<string>;
-  errors: string[];
-  previousLeader: ClearedLeaderState | null;
-  promotedLeadershipId: number | null;
-  phase: "preparing" | "promoting" | "reconnecting";
+type VitestBrowserRunner = {
+  wrapDynamicImport<T>(loader: () => Promise<T>): Promise<T>;
 };
 
-type StorageResetOutcome = {
-  requestId: string;
-  success: boolean;
-  errorMessage?: string;
-  finishedAt: number;
-};
+type BrokerVisibility = "visible" | "hidden";
+
+// Mirrors the serde-wasm-bindgen event/effect shapes in
+// crates/jazz-wasm/src/broker_election.rs. Keep the Rust serialization tests
+// and these unions in sync until the protocol declarations are generated.
+type BrokerTimerId =
+  | { type: "brokerPing" }
+  | { type: "leaderFailureRetry" }
+  | { type: "followerAttachment"; followerTabId: string; leadershipId: number }
+  | { type: "previousLeaderLocksForceTakeover"; electionId: number };
+
+type BrokerEvent =
+  | {
+      type: "tabConnected";
+      tabId: string;
+      appId: string;
+      dbName: string;
+      fingerprint: string;
+      visibility: BrokerVisibility;
+      nowMs: number;
+      forceTakeoverTimeoutMs?: number;
+      brokerPingIntervalMs?: number;
+      brokerPongTimeoutMs?: number;
+    }
+  | { type: "visibilityChanged"; tabId: string; visibility: BrokerVisibility; nowMs: number }
+  | { type: "schemaReported"; tabId: string; schemaFingerprint: string }
+  | {
+      type: "leaderReady";
+      tabId: string;
+      leadershipId: number;
+      tabLockName: string;
+      workerLockName: string;
+      bridgelessStorageReset: boolean;
+      nowMs: number;
+    }
+  | { type: "leaderFailed"; tabId: string; leadershipId: number; reason: string; nowMs: number }
+  | {
+      type: "followerPortAttached";
+      leaderTabId: string;
+      followerTabId: string;
+      leadershipId: number;
+      nowMs: number;
+    }
+  | {
+      type: "followerPortClosed";
+      leaderTabId: string;
+      followerTabId: string;
+      leadershipId: number;
+      nowMs: number;
+    }
+  | { type: "storageResetRequested"; tabId: string; requestId: string; nowMs: number }
+  | {
+      type: "storageResetReady";
+      tabId: string;
+      requestId: string;
+      success: boolean;
+      errorMessage?: string;
+      nowMs: number;
+    }
+  | { type: "shutdown"; tabId: string; nowMs: number }
+  | { type: "brokerPong"; tabId: string; nowMs: number }
+  | { type: "timerFired"; timerId: BrokerTimerId; nowMs: number }
+  | { type: "leaderLockReleased"; leadershipId: number; nowMs: number }
+  | { type: "previousLeaderLocksReleased"; electionId: number; nowMs: number }
+  | { type: "forceTakeoverComplete"; electionId: number; nowMs: number }
+  | { type: "forceTakeoverFailed"; electionId: number; reason: string; nowMs: number };
+
+type BrokerEffect =
+  | { type: "sendToTab"; tabId: string; message: BrowserBrokerControlMessage }
+  | { type: "closeTabPort"; tabId: string }
+  | { type: "closeReplacedTabPort"; tabId: string }
+  | { type: "broadcast"; message: BrowserBrokerControlMessage }
+  | { type: "armTimer"; timerId: BrokerTimerId; delayMs: number }
+  | { type: "cancelTimer"; timerId: BrokerTimerId }
+  | {
+      type: "startLeaderLockMonitor";
+      leadershipId: number;
+      tabLockName: string;
+      workerLockName: string;
+    }
+  | { type: "cancelLeaderLockMonitor"; leadershipId: number }
+  | {
+      type: "waitForPreviousLeaderLocks";
+      electionId: number;
+      tabLockName: string;
+      workerLockName: string;
+    }
+  | {
+      type: "stealPreviousLeaderLocks";
+      electionId: number;
+      tabLockName: string;
+      workerLockName: string;
+    }
+  | {
+      type: "assignFollowerPort";
+      leaderTabId: string;
+      followerTabId: string;
+      leadershipId: number;
+    };
 
 const workerGlobal = globalThis as SharedWorkerGlobal;
 const brokerInstanceId = createRandomId("broker");
-const tabs = new Map<string, TabState>();
-let namespace: {
-  appId: string;
-  dbName: string;
-  fingerprint: string;
-  forceTakeoverTimeoutMs: number;
-  brokerPingIntervalMs: number;
-  brokerPongTimeoutMs: number;
-  schemaFingerprint: string | null;
-} | null = null;
-let leader: LeaderState | null = null;
-let currentLeadershipId = 0;
-const pendingFollowerAttachments = new Set<string>();
-const pendingFollowerAttachmentTimers = new Map<string, ReturnType<typeof setTimeout>>();
-const followerAttachmentRetryCounts = new Map<string, number>();
-const attachedFollowerPorts = new Set<string>();
+const ports = new Map<string, MessagePort>();
+const pendingConnects: Array<{
+  port: MessagePort;
+  message: Extract<BrowserBrokerTabMessage, { type: "hello" }>;
+}> = [];
+const timers = new Map<string, ReturnType<typeof setTimeout>>();
+const leaderLockMonitors = new Map<number, WebLockMonitor[]>();
+const replacedPorts = new Map<string, MessagePort>();
+let election: BrokerElectionBinding | null = null;
+let startupError: Error | null = null;
+let startup: Promise<void> | null = null;
 let warnedStaleInstanceDrop = false;
-let replacementElectionInFlight = false;
-let replacementElectionGeneration = 0;
-let brokerPingTimer: ReturnType<typeof setTimeout> | null = null;
-let leaderFailureRetryTimer: ReturnType<typeof setTimeout> | null = null;
-let resetState: ResetState | null = null;
-const completedStorageResetOutcomes = new Map<string, StorageResetOutcome>();
-const failedLeaderRetryAfterByTabId = new Map<string, number>();
+
+// Vite's browser test transform may wrap dynamic imports in worker bundles.
+// Production workers never read this property, but defining the no-op keeps the
+// same worker entry usable in Vitest without a test-only bundle.
+ensureVitestWorkerImportShim();
+void ensureStartup();
 
 workerGlobal.onconnect = (event) => {
   const port = event.ports[0];
@@ -109,7 +166,8 @@ workerGlobal.onconnect = (event) => {
     if (!message || typeof message !== "object") return;
 
     if (message.type === "hello") {
-      tabId = handleHello(port, message);
+      tabId = message.tabId;
+      void handleHello(port, message);
       return;
     }
 
@@ -119,89 +177,52 @@ workerGlobal.onconnect = (event) => {
   port.start();
 };
 
-function handleHello(port: MessagePort, message: BrowserBrokerTabMessage): string | null {
-  if (message.type !== "hello") return null;
+async function bootstrapElection(): Promise<void> {
+  const startedAt = performanceNow();
+  try {
+    const wasmModule = (await import("jazz-wasm")) as unknown as BrokerElectionModule;
+    await ensureWasmInitialized(wasmModule);
+    election = new wasmModule.BrokerElection(brokerInstanceId);
+    markBrokerTiming("wasm-init", startedAt);
 
-  if (!namespace) {
-    namespace = {
-      appId: message.appId,
-      dbName: message.dbName,
-      fingerprint: message.fingerprint,
-      forceTakeoverTimeoutMs: normalizeForceTakeoverTimeout(message.forceTakeoverTimeoutMs),
-      brokerPingIntervalMs: normalizePositiveTimeout(
-        message.brokerPingIntervalMs,
-        DEFAULT_BROKER_PING_INTERVAL_MS,
-      ),
-      brokerPongTimeoutMs: normalizePositiveTimeout(
-        message.brokerPongTimeoutMs,
-        DEFAULT_BROKER_PONG_TIMEOUT_MS,
-      ),
-      schemaFingerprint: null,
-    };
+    for (const pending of pendingConnects.splice(0)) {
+      runEvent(tabConnectedEvent(pending.message), {
+        currentPort: pending.port,
+        tabId: pending.message.tabId,
+      });
+    }
+  } catch (error) {
+    startupError = error instanceof Error ? error : new Error(String(error));
+    for (const pending of pendingConnects.splice(0)) {
+      post(pending.port, {
+        type: "unsupported",
+        brokerInstanceId,
+        reason: `browser broker startup failed: ${startupError.message}`,
+      });
+      pending.port.close();
+    }
+  }
+}
+
+function ensureStartup(): Promise<void> {
+  if (!startup || startupError) {
+    startupError = null;
+    startup = bootstrapElection();
+  }
+  return startup;
+}
+
+async function handleHello(
+  port: MessagePort,
+  message: Extract<BrowserBrokerTabMessage, { type: "hello" }>,
+): Promise<void> {
+  if (!election) {
+    pendingConnects.push({ port, message });
+    await ensureStartup();
+    return;
   }
 
-  if (
-    namespace.appId !== message.appId ||
-    namespace.dbName !== message.dbName ||
-    namespace.fingerprint !== message.fingerprint
-  ) {
-    post(port, {
-      type: "unsupported",
-      brokerInstanceId,
-      code: INCOMPATIBLE_BROWSER_BROKER_CONFIGURATION_CODE,
-      reason: "incompatible persistent browser configuration",
-    });
-    port.close();
-    return null;
-  }
-
-  const now = Date.now();
-  const previousTab = tabs.get(message.tabId);
-  if (previousTab && previousTab.port !== port) {
-    previousTab.port.close();
-  }
-  clearFollowerAttachmentState(message.tabId);
-
-  tabs.set(message.tabId, {
-    tabId: message.tabId,
-    appId: message.appId,
-    dbName: message.dbName,
-    fingerprint: message.fingerprint,
-    schemaFingerprint: null,
-    visibility: message.visibility,
-    lastVisibleAt: message.visibility === "visible" ? now : 0,
-    port,
-    lastPongAt: now,
-  });
-
-  startBrokerPingTimer();
-  post(port, { type: "broker-hello", brokerInstanceId });
-  // Redeliver on every hello, including mid-reset rejoins: a requester that
-  // reconnects after its reset finished must not wait out the client timeout.
-  redeliverFinishedStorageResets(port);
-  if (resetState) {
-    addTabToActiveReset(message.tabId);
-    return message.tabId;
-  }
-  if (leader && leader.tabId === message.tabId) {
-    clearLeader(leader.leadershipId, {
-      demoteLeader: false,
-      removeLeaderTab: false,
-    });
-  }
-  if (leader?.ready) {
-    post(port, {
-      type: "leader-ready",
-      brokerInstanceId,
-      leaderTabId: leader.tabId,
-      leadershipId: leader.leadershipId,
-    });
-    assignFollowerPorts(leader);
-  } else {
-    electIfNeeded();
-  }
-
-  return message.tabId;
+  runEvent(tabConnectedEvent(message), { currentPort: port, tabId: message.tabId });
 }
 
 function handleTabMessage(tabId: string, message: BrowserBrokerTabMessage): void {
@@ -211,8 +232,7 @@ function handleTabMessage(tabId: string, message: BrowserBrokerTabMessage): void
       warnedStaleInstanceDrop = true;
       console.warn(
         `[jazz-broker] dropping "${message.type}" from tab ${tabId}: stamped for broker ` +
-          `instance ${String(message.brokerInstanceId)}, current is ${brokerInstanceId}. ` +
-          "This usually means tabs are running different jazz-tools versions against one broker.",
+          `instance ${String(message.brokerInstanceId)}, current is ${brokerInstanceId}.`,
       );
     }
     return;
@@ -220,785 +240,277 @@ function handleTabMessage(tabId: string, message: BrowserBrokerTabMessage): void
 
   switch (message.type) {
     case "visibility":
-      updateVisibility(tabId, message.visibility);
-      evictStaleTabs();
+      runEvent({
+        type: "visibilityChanged",
+        tabId,
+        visibility: message.visibility,
+        nowMs: Date.now(),
+      });
       return;
-    case "leader-ready": {
-      if (!leader || leader.tabId !== tabId || leader.leadershipId !== message.leadershipId) {
-        const tab = tabs.get(tabId);
-        if (tab) {
-          post(tab.port, {
-            type: "demote",
-            brokerInstanceId,
-            leadershipId: message.leadershipId,
-          });
-        }
-        return;
-      }
-      const activeReset = resetState;
-      const leaderTab = tabs.get(tabId);
-      if (
-        activeReset?.promotedLeadershipId === message.leadershipId &&
-        message.bridgelessStorageReset &&
-        !leaderTab?.schemaFingerprint
-      ) {
-        // Fresh namespace: the promoted leader declared it has no client to
-        // rebuild a worker bridge from. The wipe is already done before the
-        // tab reports ready, so step the placeholder leader down before
-        // reporting reset completion.
-        clearLeader(message.leadershipId, { demoteLeader: true, removeLeaderTab: false });
-        finishStorageReset(activeReset, true);
-        return;
-      }
-      leader.ready = true;
-      leader.tabLockName = message.tabLockName;
-      leader.workerLockName = message.workerLockName;
-      announceLeaderReady(leader);
-      startLeaderLockMonitors(leader);
-      if (resetState?.promotedLeadershipId === message.leadershipId) {
-        resetState.phase = "reconnecting";
-        assignFollowerPorts(leader);
-        finishStorageResetIfReconnected(resetState);
-        return;
-      }
-      assignFollowerPorts(leader);
+    case "leader-ready":
+      runEvent({
+        type: "leaderReady",
+        tabId,
+        leadershipId: message.leadershipId,
+        tabLockName: message.tabLockName,
+        workerLockName: message.workerLockName,
+        bridgelessStorageReset: message.bridgelessStorageReset === true,
+        nowMs: Date.now(),
+      });
       return;
-    }
     case "follower-port-attached":
-      if (!leader || leader.tabId !== tabId || leader.leadershipId !== message.leadershipId) return;
-      markFollowerPortAttached(message.followerTabId, message.leadershipId);
+      runEvent({
+        type: "followerPortAttached",
+        leaderTabId: tabId,
+        followerTabId: message.followerTabId,
+        leadershipId: message.leadershipId,
+        nowMs: Date.now(),
+      });
       return;
     case "follower-port-closed":
-      if (!leader || leader.tabId !== tabId || leader.leadershipId !== message.leadershipId) return;
-      clearFollowerAttachmentKey(message.followerTabId, message.leadershipId);
-      assignFollowerPorts(leader);
+      runEvent({
+        type: "followerPortClosed",
+        leaderTabId: tabId,
+        followerTabId: message.followerTabId,
+        leadershipId: message.leadershipId,
+        nowMs: Date.now(),
+      });
       return;
     case "schema-ready":
-      handleSchemaReady(tabId, message.schemaFingerprint);
+      runEvent({ type: "schemaReported", tabId, schemaFingerprint: message.schemaFingerprint });
       return;
     case "leader-failed":
-      if (resetState?.promotedLeadershipId === message.leadershipId) {
-        resetState.errors.push(message.reason);
-        removeTab(tabId, { closePort: false, notifyLeader: false });
-        removeTabFromActiveReset(tabId);
-        leader = null;
-        resetState.promotedLeadershipId = null;
-        void promoteResetLeader(resetState);
-        return;
-      }
-      if (leader?.tabId === tabId && leader.leadershipId === message.leadershipId) {
-        markLeaderCandidateFailed(tabId);
-        const cleared = clearLeader(message.leadershipId, {
-          demoteLeader: true,
-          removeLeaderTab: false,
-        });
-        scheduleReplacementElection(cleared);
-      }
+      runEvent({
+        type: "leaderFailed",
+        tabId,
+        leadershipId: message.leadershipId,
+        reason: message.reason,
+        nowMs: Date.now(),
+      });
       return;
     case "storage-reset-request":
-      startStorageReset(tabId, message.requestId);
+      runEvent({
+        type: "storageResetRequested",
+        tabId,
+        requestId: message.requestId,
+        nowMs: Date.now(),
+      });
       return;
     case "storage-reset-ready":
-      handleStorageResetReady(tabId, message.requestId, message.success, message.errorMessage);
+      runEvent({
+        type: "storageResetReady",
+        tabId,
+        requestId: message.requestId,
+        success: message.success,
+        ...(message.errorMessage ? { errorMessage: message.errorMessage } : {}),
+        nowMs: Date.now(),
+      });
       return;
     case "shutdown":
-      if (leader?.tabId === tabId) {
-        const leadershipId = leader.leadershipId;
-        const activeReset = resetState;
-        removeTab(tabId, { closePort: false, notifyLeader: false });
-        const cleared = clearLeader(leadershipId, {
-          demoteLeader: false,
-          removeLeaderTab: false,
-        });
-        removeTabFromActiveReset(tabId);
-        if (
-          activeReset &&
-          activeReset.promotedLeadershipId === leadershipId &&
-          activeReset.phase !== "preparing"
-        ) {
-          activeReset.promotedLeadershipId = null;
-          void promoteResetLeader(activeReset);
-          resetIfIdle();
-          return;
-        }
-        scheduleReplacementElection(cleared);
-      } else {
-        removeTab(tabId, { closePort: false, notifyLeader: true });
-        removeTabFromActiveReset(tabId);
-      }
-      resetIfIdle();
+      runEvent({ type: "shutdown", tabId, nowMs: Date.now() });
+      ports.delete(tabId);
       return;
     case "broker-pong":
-      {
-        const tab = tabs.get(tabId);
-        if (!tab) return;
-        tab.lastPongAt = Date.now();
-      }
+      runEvent({ type: "brokerPong", tabId, nowMs: Date.now() });
       return;
   }
 }
 
-function updateVisibility(tabId: string, visibility: BrowserBrokerVisibility): void {
-  const tab = tabs.get(tabId);
-  if (!tab) return;
-
-  tab.visibility = visibility;
-  if (visibility === "visible") {
-    tab.lastVisibleAt = Date.now();
-  }
-}
-
-function electIfNeeded(): void {
-  if (resetState) return;
-  if (replacementElectionInFlight) return;
-  if (leader?.ready || tabs.size === 0) return;
-  if (leader && !namespace?.schemaFingerprint) return;
-
-  const candidate = selectLeaderCandidate(eligibleLeaderCandidates());
-  if (!candidate) {
-    scheduleLeaderFailureRetryElection();
-    return;
-  }
-
-  if (leader) {
-    const currentLeaderTab = tabs.get(leader.tabId);
-    if (currentLeaderTab?.schemaFingerprint === namespace?.schemaFingerprint) {
-      return;
-    }
-    if (candidate.tabId === leader.tabId) {
-      return;
-    }
-    clearLeader(leader.leadershipId, {
-      demoteLeader: true,
-      removeLeaderTab: false,
-    });
-  }
-
-  const tab = tabs.get(candidate.tabId);
-  if (!tab) return;
-  const lockNames = currentLeaderLockNames();
-  if (!lockNames) return;
-
-  currentLeadershipId += 1;
-  leader = {
-    tabId: tab.tabId,
-    leadershipId: currentLeadershipId,
-    ready: false,
-    tabLockName: lockNames.tabLockName,
-    workerLockName: lockNames.workerLockName,
-    tabLockMonitor: null,
-    workerLockMonitor: null,
-  };
-
-  post(tab.port, {
-    type: "become-leader",
-    brokerInstanceId,
-    leadershipId: currentLeadershipId,
-  });
-}
-
-function resetIfIdle(): void {
-  if (tabs.size > 0) return;
-  namespace = null;
-  leader = null;
-  clearAllFollowerAttachmentState();
-  resetState = null;
-  replacementElectionGeneration += 1;
-  replacementElectionInFlight = false;
-  failedLeaderRetryAfterByTabId.clear();
-  stopLeaderFailureRetryTimer();
-  stopBrokerPingTimer();
-}
-
-function removeTab(
-  tabId: string,
-  options: { closePort: boolean; notifyLeader: boolean },
-): TabState | null {
-  const tab = tabs.get(tabId);
-  if (!tab) return null;
-
-  if (options.notifyLeader && leader && leader.tabId !== tabId) {
-    notifyLeaderToDetachFollower(tabId, leader.leadershipId);
-  }
-
-  tabs.delete(tabId);
-  failedLeaderRetryAfterByTabId.delete(tabId);
-  clearFollowerAttachmentState(tabId);
-  reelectSchemaFingerprintIfUnheld(tab);
-  if (options.closePort) {
-    tab.port.close();
-  }
-  return tab;
-}
-
-function notifyLeaderToDetachFollower(followerTabId: string, leadershipId: number): void {
-  const leaderTab = leader ? tabs.get(leader.tabId) : null;
-  if (!leaderTab) return;
-  post(leaderTab.port, {
-    type: "detach-follower-port",
-    brokerInstanceId,
-    followerTabId,
-    leadershipId,
-  });
-}
-
-function clearFollowerAttachmentState(followerTabId: string): void {
-  for (const key of pendingFollowerAttachments) {
-    if (key.endsWith(`:${followerTabId}`)) {
-      clearPendingFollowerAttachment(key);
-    }
-  }
-  for (const key of attachedFollowerPorts) {
-    if (key.endsWith(`:${followerTabId}`)) {
-      attachedFollowerPorts.delete(key);
-    }
-  }
-}
-
-function clearFollowerAttachmentKey(followerTabId: string, leadershipId: number): void {
-  const key = followerAttachmentKey(followerTabId, leadershipId);
-  clearPendingFollowerAttachment(key);
-  attachedFollowerPorts.delete(key);
-}
-
-function clearAllFollowerAttachmentState(): void {
-  for (const timer of pendingFollowerAttachmentTimers.values()) {
-    clearTimeout(timer);
-  }
-  pendingFollowerAttachmentTimers.clear();
-  pendingFollowerAttachments.clear();
-  followerAttachmentRetryCounts.clear();
-  attachedFollowerPorts.clear();
-}
-
-function clearPendingFollowerAttachment(key: string): void {
-  pendingFollowerAttachments.delete(key);
-  followerAttachmentRetryCounts.delete(key);
-  const timer = pendingFollowerAttachmentTimers.get(key);
-  if (timer) {
-    clearTimeout(timer);
-    pendingFollowerAttachmentTimers.delete(key);
-  }
-}
-
-function handleSchemaReady(tabId: string, schemaFingerprint: string): void {
-  if (!namespace) return;
-  const tab = tabs.get(tabId);
-  if (!tab) return;
-
-  if (!namespace.schemaFingerprint) {
-    namespace.schemaFingerprint = schemaFingerprint;
-  }
-
-  tab.schemaFingerprint = schemaFingerprint;
-
-  if (namespace.schemaFingerprint !== schemaFingerprint) {
-    blockTabForSchemaMismatch(tab);
-    return;
-  }
-
-  if (leader?.ready) {
-    assignFollowerPorts(leader);
-    return;
-  }
-  electIfNeeded();
-}
-
-// A mismatching tab stays connected (and keeps answering pings) so it can be
-// adopted once the canonical fingerprint is re-elected; it is excluded from
-// leadership and follower ports purely by its non-canonical fingerprint.
-function blockTabForSchemaMismatch(tab: TabState): void {
-  post(tab.port, {
-    type: "schema-blocked",
-    brokerInstanceId,
-    reason: "incompatible persistent browser schema",
-  });
-
-  if (leader?.tabId === tab.tabId) {
-    const cleared = clearLeader(leader.leadershipId, {
-      demoteLeader: true,
-      removeLeaderTab: false,
-    });
-    scheduleReplacementElection(cleared);
-  }
-}
-
-// The canonical fingerprint is held by the tabs that reported it. When the
-// last holder departs, the namespace re-elects the earliest-connected
-// remaining fingerprint so schema-blocked tabs can recover without reloading.
-function reelectSchemaFingerprintIfUnheld(departed: TabState): void {
-  if (!namespace?.schemaFingerprint) return;
-  if (departed.schemaFingerprint !== namespace.schemaFingerprint) return;
-  for (const tab of tabs.values()) {
-    if (tab.schemaFingerprint === namespace.schemaFingerprint) return;
-  }
-
-  let next: string | null = null;
-  for (const tab of tabs.values()) {
-    if (tab.schemaFingerprint) {
-      next = tab.schemaFingerprint;
-      break;
-    }
-  }
-  namespace.schemaFingerprint = next;
-  if (!next) return;
-
-  if (leader?.ready) {
-    assignFollowerPorts(leader);
-  } else {
-    electIfNeeded();
-  }
-}
-
-function announceLeaderReady(nextLeader: LeaderState): void {
-  for (const tab of tabs.values()) {
-    post(tab.port, {
-      type: "leader-ready",
-      brokerInstanceId,
-      leaderTabId: nextLeader.tabId,
-      leadershipId: nextLeader.leadershipId,
-    });
-  }
-}
-
-function startLeaderLockMonitors(nextLeader: LeaderState): void {
-  cancelLeaderMonitors(nextLeader);
-  if (!nextLeader.tabLockName || !nextLeader.workerLockName) return;
-
-  nextLeader.tabLockMonitor = monitorWebLockRelease(nextLeader.tabLockName, {
-    onGranted: () => {
-      handleLeaderLockReleased(nextLeader.leadershipId);
-    },
-    onError: () => {
-      handleLeaderLockReleased(nextLeader.leadershipId);
-    },
-  });
-  nextLeader.workerLockMonitor = monitorWebLockRelease(nextLeader.workerLockName, {
-    onGranted: () => {
-      handleLeaderLockReleased(nextLeader.leadershipId);
-    },
-    onError: () => {
-      handleLeaderLockReleased(nextLeader.leadershipId);
-    },
-  });
-}
-
-function handleLeaderLockReleased(leadershipId: number): void {
-  if (!leader || leader.leadershipId !== leadershipId) return;
-  const cleared = clearLeader(leadershipId, { demoteLeader: true, removeLeaderTab: true });
-  scheduleReplacementElection(cleared);
-}
-
-function clearLeader(
-  leadershipId: number,
-  options: { demoteLeader: boolean; removeLeaderTab: boolean },
-): ClearedLeaderState | null {
-  const current = leader;
-  if (!current || current.leadershipId !== leadershipId) return null;
-  cancelLeaderMonitors(current);
-  clearAllFollowerAttachmentState();
-
-  const leaderTab = tabs.get(current.tabId);
-  if (options.demoteLeader && leaderTab) {
-    post(leaderTab.port, {
-      type: "demote",
-      brokerInstanceId,
-      leadershipId,
-    });
-  }
-
-  for (const tab of tabs.values()) {
-    if (tab.tabId === current.tabId) continue;
-    post(tab.port, {
-      type: "close-follower-port",
-      brokerInstanceId,
-      leadershipId,
-    });
-  }
-
-  if (options.removeLeaderTab) {
-    removeTab(current.tabId, { closePort: false, notifyLeader: false });
-  }
-  leader = null;
+function tabConnectedEvent(
+  message: Extract<BrowserBrokerTabMessage, { type: "hello" }>,
+): BrokerEvent {
   return {
-    tabId: current.tabId,
-    leadershipId: current.leadershipId,
-    tabLockName: current.tabLockName,
-    workerLockName: current.workerLockName,
+    type: "tabConnected",
+    tabId: message.tabId,
+    appId: message.appId,
+    dbName: message.dbName,
+    fingerprint: message.fingerprint,
+    visibility: message.visibility,
+    nowMs: Date.now(),
+    forceTakeoverTimeoutMs: sanitizeOptionalTimeoutMs(message.forceTakeoverTimeoutMs),
+    brokerPingIntervalMs: sanitizeOptionalTimeoutMs(message.brokerPingIntervalMs),
+    brokerPongTimeoutMs: sanitizeOptionalTimeoutMs(message.brokerPongTimeoutMs),
   };
 }
 
-function cancelLeaderMonitors(current: LeaderState): void {
-  current.tabLockMonitor?.cancel();
-  current.tabLockMonitor = null;
-  current.workerLockMonitor?.cancel();
-  current.workerLockMonitor = null;
-}
+function runEvent(
+  event: BrokerEvent,
+  options: { currentPort?: MessagePort; tabId?: string } = {},
+): void {
+  if (!election) return;
 
-function startStorageReset(requestingTabId: string, requestId: string): void {
-  if (resetState) {
-    resetState.requestIds.add(requestId);
-    const tab = tabs.get(requestingTabId);
-    if (tab) {
-      post(tab.port, {
-        type: "storage-reset-started",
+  if (event.type === "tabConnected" && options.currentPort && options.tabId) {
+    const previous = ports.get(options.tabId);
+    if (previous && previous !== options.currentPort) {
+      replacedPorts.set(options.tabId, previous);
+    }
+    ports.set(options.tabId, options.currentPort);
+  }
+
+  let effects: BrokerEffect[];
+  try {
+    effects = election.handleEvent(event);
+  } catch (error) {
+    console.error("[jazz-broker] Rust broker event failed", error);
+    if (event.type === "tabConnected" && options.currentPort) {
+      post(options.currentPort, {
+        type: "unsupported",
         brokerInstanceId,
-        requestId,
+        reason: `browser broker event failed: ${stringifyError(error)}`,
       });
+      options.currentPort.close();
     }
     return;
   }
 
-  const previousLeader = leader
-    ? clearLeader(leader.leadershipId, {
-        demoteLeader: false,
-        removeLeaderTab: false,
-      })
-    : null;
-
-  const leadershipId = previousLeader?.leadershipId ?? currentLeadershipId;
-  resetState = {
-    requestId,
-    requestIds: new Set([requestId]),
-    participants: new Set(tabs.keys()),
-    preparedTabs: new Set(),
-    errors: [],
-    previousLeader,
-    promotedLeadershipId: null,
-    phase: "preparing",
-  };
-
-  const requestingTab = tabs.get(requestingTabId);
-  if (requestingTab) {
-    post(requestingTab.port, {
-      type: "storage-reset-started",
-      brokerInstanceId,
-      requestId,
-    });
-  }
-
-  for (const tab of tabs.values()) {
-    post(tab.port, {
-      type: "storage-reset-begin",
-      brokerInstanceId,
-      requestId,
-      leadershipId,
-    });
-  }
-
-  continueStorageResetIfReady(resetState);
+  executeEffects(effects);
 }
 
-function addTabToActiveReset(tabId: string): void {
-  const activeReset = resetState;
-  const tab = tabs.get(tabId);
-  if (!activeReset || !tab) return;
-  if (activeReset.phase !== "preparing") return;
-
-  activeReset.participants.add(tabId);
-  post(tab.port, {
-    type: "storage-reset-begin",
-    brokerInstanceId,
-    requestId: activeReset.requestId,
-    leadershipId: activeReset.previousLeader?.leadershipId ?? currentLeadershipId,
-  });
-}
-
-function handleStorageResetReady(
-  tabId: string,
-  requestId: string,
-  success: boolean,
-  errorMessage: string | undefined,
-): void {
-  const activeReset = resetState;
-  if (!activeReset || activeReset.requestId !== requestId || activeReset.phase !== "preparing") {
-    return;
-  }
-
-  if (!activeReset.participants.has(tabId)) {
-    return;
-  }
-  if (!success) {
-    activeReset.errors.push(errorMessage ?? `Tab ${tabId} failed to prepare storage reset`);
-  }
-  activeReset.preparedTabs.add(tabId);
-  continueStorageResetIfReady(activeReset);
-}
-
-function continueStorageResetIfReady(activeReset: ResetState): void {
-  if (resetState !== activeReset || activeReset.phase !== "preparing") return;
-  for (const participant of activeReset.participants) {
-    if (!activeReset.preparedTabs.has(participant)) return;
-  }
-
-  activeReset.phase = "promoting";
-  void (async () => {
-    await waitForPreviousLeaderLocks(activeReset.previousLeader, () => resetState === activeReset);
-    if (activeReset.errors.length > 0) {
-      finishStorageReset(activeReset, false, activeReset.errors.join("; "));
-      return;
-    }
-    await promoteResetLeader(activeReset);
-  })();
-}
-
-async function promoteResetLeader(activeReset: ResetState): Promise<void> {
-  if (resetState !== activeReset) return;
-  const candidate = selectLeaderCandidate(eligibleLeaderCandidates());
-  if (!candidate) {
-    finishStorageReset(activeReset, false, "No connected tab is available to reset storage");
-    return;
-  }
-
-  const tab = tabs.get(candidate.tabId);
-  if (!tab) {
-    finishStorageReset(activeReset, false, "No connected tab is available to reset storage");
-    return;
-  }
-  const lockNames = currentLeaderLockNames();
-  if (!lockNames) {
-    finishStorageReset(activeReset, false, "No connected tab is available to reset storage");
-    return;
-  }
-
-  currentLeadershipId += 1;
-  activeReset.promotedLeadershipId = currentLeadershipId;
-  leader = {
-    tabId: tab.tabId,
-    leadershipId: currentLeadershipId,
-    ready: false,
-    tabLockName: lockNames.tabLockName,
-    workerLockName: lockNames.workerLockName,
-    tabLockMonitor: null,
-    workerLockMonitor: null,
-  };
-
-  post(tab.port, {
-    type: "become-leader",
-    brokerInstanceId,
-    leadershipId: currentLeadershipId,
-    resetRequestId: activeReset.requestId,
-  });
-}
-
-function finishStorageReset(
-  completedReset: ResetState,
-  success: boolean,
-  errorMessage?: string,
-): void {
-  if (resetState === completedReset) {
-    resetState = null;
-  }
-
-  const outcomes = rememberStorageResetOutcomes(completedReset.requestIds, success, errorMessage);
-  for (const tab of tabs.values()) {
-    for (const outcome of outcomes) {
-      postStorageResetOutcome(tab.port, outcome);
-    }
-  }
-
-  if (!success) {
-    electIfNeeded();
-  }
-}
-
-function rememberStorageResetOutcomes(
-  requestIds: Iterable<string>,
-  success: boolean,
-  errorMessage?: string,
-): StorageResetOutcome[] {
-  const now = Date.now();
-  const outcomes: StorageResetOutcome[] = [];
-  for (const requestId of requestIds) {
-    const outcome: StorageResetOutcome = {
-      requestId,
-      success,
-      ...(errorMessage ? { errorMessage } : {}),
-      finishedAt: now,
-    };
-    // Delete first: re-setting an existing key keeps its Map position, which
-    // would make the size eviction below treat a re-finished id as oldest.
-    completedStorageResetOutcomes.delete(requestId);
-    completedStorageResetOutcomes.set(requestId, outcome);
-    outcomes.push(outcome);
-  }
-  pruneCompletedStorageResetOutcomes(now);
-  return outcomes;
-}
-
-function redeliverFinishedStorageResets(port: MessagePort): void {
-  pruneCompletedStorageResetOutcomes();
-  for (const outcome of completedStorageResetOutcomes.values()) {
-    postStorageResetOutcome(port, outcome);
-  }
-}
-
-function postStorageResetOutcome(port: MessagePort, outcome: StorageResetOutcome): void {
-  post(port, {
-    type: "storage-reset-finished",
-    brokerInstanceId,
-    requestId: outcome.requestId,
-    success: outcome.success,
-    ...(outcome.errorMessage ? { errorMessage: outcome.errorMessage } : {}),
-  });
-}
-
-function pruneCompletedStorageResetOutcomes(now = Date.now()): void {
-  for (const [requestId, outcome] of completedStorageResetOutcomes) {
-    if (now - outcome.finishedAt > COMPLETED_STORAGE_RESET_OUTCOME_TTL_MS) {
-      completedStorageResetOutcomes.delete(requestId);
-    }
-  }
-
-  while (completedStorageResetOutcomes.size > MAX_COMPLETED_STORAGE_RESET_OUTCOMES) {
-    const oldestRequestId = completedStorageResetOutcomes.keys().next().value;
-    if (!oldestRequestId) return;
-    completedStorageResetOutcomes.delete(oldestRequestId);
-  }
-}
-
-function finishStorageResetIfReconnected(activeReset: ResetState): void {
-  if (resetState !== activeReset || activeReset.phase !== "reconnecting") return;
-  if (!leader || !leader.ready || activeReset.promotedLeadershipId !== leader.leadershipId) return;
-
-  for (const tabId of activeReset.participants) {
-    const tab = tabs.get(tabId);
-    if (!tab || !shouldAssignFollowerPort(tab, leader)) continue;
-    if (!attachedFollowerPorts.has(followerAttachmentKey(tabId, leader.leadershipId))) {
-      return;
-    }
-  }
-
-  finishStorageReset(activeReset, true);
-}
-
-function scheduleReplacementElection(previousLeader: ClearedLeaderState | null): void {
-  if (replacementElectionInFlight) return;
-  replacementElectionInFlight = true;
-  const electionGeneration = ++replacementElectionGeneration;
-
-  void (async () => {
-    try {
-      await waitForPreviousLeaderLocks(
-        previousLeader,
-        () =>
-          replacementElectionInFlight &&
-          replacementElectionGeneration === electionGeneration &&
-          leader === null,
-      );
-    } finally {
-      if (replacementElectionGeneration === electionGeneration) {
-        replacementElectionInFlight = false;
+function executeEffects(effects: BrokerEffect[]): void {
+  for (const effect of effects) {
+    switch (effect.type) {
+      case "sendToTab": {
+        const port = ports.get(effect.tabId);
+        if (port) post(port, effect.message);
+        break;
       }
+      case "closeTabPort":
+        closeTabPort(effect.tabId);
+        break;
+      case "closeReplacedTabPort":
+        closeReplacedTabPort(effect.tabId);
+        break;
+      case "broadcast":
+        for (const port of ports.values()) {
+          post(port, effect.message);
+        }
+        break;
+      case "armTimer":
+        armTimer(effect.timerId, effect.delayMs);
+        break;
+      case "cancelTimer":
+        cancelTimer(effect.timerId);
+        break;
+      case "startLeaderLockMonitor":
+        startLeaderLockMonitor(effect);
+        break;
+      case "cancelLeaderLockMonitor":
+        cancelLeaderLockMonitor(effect.leadershipId);
+        break;
+      case "waitForPreviousLeaderLocks":
+        void waitForPreviousLeaderLocks(effect);
+        break;
+      case "stealPreviousLeaderLocks":
+        void stealPreviousLeaderLocks(effect);
+        break;
+      case "assignFollowerPort":
+        assignFollowerPort(effect);
+        break;
     }
-    if (replacementElectionGeneration !== electionGeneration) return;
-    electIfNeeded();
-  })();
+  }
 }
 
-function startBrokerPingTimer(): void {
-  if (brokerPingTimer || !namespace) return;
-  sendBrokerPings();
-  brokerPingTimer = setTimeout(() => {
-    brokerPingTimer = null;
-    sendBrokerPings();
-    if (namespace && tabs.size > 0) {
-      startBrokerPingTimer();
-    }
-  }, namespace.brokerPingIntervalMs);
+function closeTabPort(tabId: string): void {
+  const port = ports.get(tabId);
+  const replaced = replacedPorts.get(tabId);
+  if (replaced && port) {
+    replacedPorts.delete(tabId);
+    ports.set(tabId, replaced);
+    port.close();
+    return;
+  }
+
+  ports.delete(tabId);
+  port?.close();
 }
 
-function stopBrokerPingTimer(): void {
-  if (!brokerPingTimer) return;
-  clearTimeout(brokerPingTimer);
-  brokerPingTimer = null;
+function closeReplacedTabPort(tabId: string): void {
+  const replaced = replacedPorts.get(tabId);
+  if (!replaced) return;
+  replacedPorts.delete(tabId);
+  replaced.close();
 }
 
-function sendBrokerPings(): void {
-  if (!namespace) return;
-  const now = Date.now();
+function armTimer(timerId: BrokerTimerId, delayMs: number): void {
+  const key = timerKey(timerId);
+  cancelTimer(timerId);
+  timers.set(
+    key,
+    setTimeout(() => {
+      timers.delete(key);
+      runEvent({ type: "timerFired", timerId, nowMs: Date.now() });
+    }, delayMs),
+  );
+}
 
-  const tabSnapshot = Array.from(tabs.values());
-  for (const tab of tabSnapshot) {
-    if (isBrokerPongTimedOut(tab, now)) {
-      evictTab(tab.tabId, "missed broker pong");
-      continue;
-    }
-    post(tab.port, {
-      type: "broker-ping",
-      brokerInstanceId,
+function cancelTimer(timerId: BrokerTimerId): void {
+  const key = timerKey(timerId);
+  const timer = timers.get(key);
+  if (!timer) return;
+  clearTimeout(timer);
+  timers.delete(key);
+}
+
+function startLeaderLockMonitor(effect: Extract<BrokerEffect, { type: "startLeaderLockMonitor" }>) {
+  cancelLeaderLockMonitor(effect.leadershipId);
+  const onReleased = () => {
+    runEvent({
+      type: "leaderLockReleased",
+      leadershipId: effect.leadershipId,
+      nowMs: Date.now(),
     });
-  }
+  };
+  leaderLockMonitors.set(effect.leadershipId, [
+    monitorWebLockRelease(effect.tabLockName, { onGranted: onReleased, onError: onReleased }),
+    monitorWebLockRelease(effect.workerLockName, { onGranted: onReleased, onError: onReleased }),
+  ]);
 }
 
-function evictStaleTabs(now = Date.now()): void {
-  if (!namespace) return;
-
-  const tabSnapshot = Array.from(tabs.values());
-  for (const tab of tabSnapshot) {
-    if (isBrokerPongTimedOut(tab, now)) {
-      evictTab(tab.tabId, "missed broker pong");
-    }
+function cancelLeaderLockMonitor(leadershipId: number): void {
+  const monitors = leaderLockMonitors.get(leadershipId);
+  if (!monitors) return;
+  leaderLockMonitors.delete(leadershipId);
+  for (const monitor of monitors) {
+    monitor.cancel();
   }
-}
-
-function isBrokerPongTimedOut(tab: TabState, now: number): boolean {
-  return namespace !== null && now - tab.lastPongAt > namespace.brokerPongTimeoutMs;
-}
-
-function evictTab(tabId: string, reason: string): void {
-  const tab = tabs.get(tabId);
-  if (!tab) return;
-  removeTab(tabId, { closePort: true, notifyLeader: true });
-
-  if (leader?.tabId === tabId) {
-    const leadershipId = leader.leadershipId;
-    const activeReset = resetState;
-    const cleared = clearLeader(leadershipId, {
-      demoteLeader: false,
-      removeLeaderTab: false,
-    });
-    removeTabFromActiveReset(tabId);
-    if (
-      activeReset &&
-      activeReset.promotedLeadershipId === leadershipId &&
-      activeReset.phase !== "preparing"
-    ) {
-      activeReset.promotedLeadershipId = null;
-      void promoteResetLeader(activeReset);
-      resetIfIdle();
-      return;
-    }
-    scheduleReplacementElection(cleared);
-  } else {
-    removeTabFromActiveReset(tabId);
-  }
-  resetIfIdle();
 }
 
 async function waitForPreviousLeaderLocks(
-  previousLeader: ClearedLeaderState | null,
-  shouldForceTakeover: () => boolean = () => true,
+  effect: Extract<BrokerEffect, { type: "waitForPreviousLeaderLocks" }>,
 ): Promise<void> {
-  if (!previousLeader?.tabLockName || !previousLeader.workerLockName) {
+  if (await acquireAndReleaseLocks([effect.tabLockName, effect.workerLockName])) {
+    runEvent({
+      type: "previousLeaderLocksReleased",
+      electionId: effect.electionId,
+      nowMs: Date.now(),
+    });
+  }
+  // If the probe could not acquire both locks, Rust already has a force-takeover
+  // timer armed for this election id. The timer drives the next explicit event.
+}
+
+async function stealPreviousLeaderLocks(
+  effect: Extract<BrokerEffect, { type: "stealPreviousLeaderLocks" }>,
+): Promise<void> {
+  const results = await Promise.allSettled([
+    stealAndReleaseWebLock(effect.tabLockName),
+    stealAndReleaseWebLock(effect.workerLockName),
+  ]);
+  const failed = results.find((result) => result.status === "rejected");
+  if (failed) {
+    runEvent({
+      type: "forceTakeoverFailed",
+      electionId: effect.electionId,
+      reason: stringifyError(failed.reason),
+      nowMs: Date.now(),
+    });
     return;
   }
-
-  if (!shouldForceTakeover()) return;
-
-  const takeoverLockNames = [previousLeader.tabLockName, previousLeader.workerLockName].filter(
-    (lockName): lockName is string => lockName !== null,
-  );
-
-  if (await acquireAndReleaseLocks(takeoverLockNames)) {
-    return;
-  }
-
-  await sleep(namespace?.forceTakeoverTimeoutMs ?? DEFAULT_FORCE_TAKEOVER_TIMEOUT_MS);
-  if (!shouldForceTakeover()) return;
-  for (const lockName of takeoverLockNames) {
-    await stealAndReleaseWebLock(lockName).catch(() => undefined);
-  }
+  runEvent({
+    type: "forceTakeoverComplete",
+    electionId: effect.electionId,
+    nowMs: Date.now(),
+  });
 }
 
 async function acquireAndReleaseLocks(lockNames: readonly string[]): Promise<boolean> {
@@ -1009,160 +521,83 @@ async function acquireAndReleaseLocks(lockNames: readonly string[]): Promise<boo
   return leases.every((lease) => lease !== null);
 }
 
-function assignFollowerPorts(nextLeader: LeaderState): void {
-  if (resetState && resetState.phase !== "reconnecting") return;
-  const leaderTab = tabs.get(nextLeader.tabId);
-  if (!leaderTab) return;
-
-  for (const follower of tabs.values()) {
-    if (!shouldAssignFollowerPort(follower, nextLeader)) continue;
-    const key = followerAttachmentKey(follower.tabId, nextLeader.leadershipId);
-    if (pendingFollowerAttachments.has(key)) continue;
-    if (attachedFollowerPorts.has(key)) continue;
-
-    const channel = new MessageChannel();
-    markFollowerPortPending(follower.tabId, nextLeader.leadershipId);
-    post(
-      leaderTab.port,
-      {
-        type: "attach-follower-port",
-        brokerInstanceId,
-        followerTabId: follower.tabId,
-        leadershipId: nextLeader.leadershipId,
-        port: channel.port1,
-      },
-      [channel.port1],
-    );
-    post(
-      follower.port,
-      {
-        type: "use-follower-port",
-        brokerInstanceId,
-        leaderTabId: nextLeader.tabId,
-        leadershipId: nextLeader.leadershipId,
-        port: channel.port2,
-      },
-      [channel.port2],
-    );
+function sanitizeOptionalTimeoutMs(value: number | undefined): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
   }
+  const normalized = Math.max(0, Math.floor(value));
+  return normalized > 0 ? normalized : undefined;
 }
 
-function markFollowerPortPending(followerTabId: string, leadershipId: number): void {
-  const key = followerAttachmentKey(followerTabId, leadershipId);
-  pendingFollowerAttachments.add(key);
-  const retryCount = followerAttachmentRetryCounts.get(key) ?? 0;
-  const timeoutMs = Math.min(
-    INITIAL_FOLLOWER_ATTACHMENT_TIMEOUT_MS * 2 ** retryCount,
-    MAX_FOLLOWER_ATTACHMENT_TIMEOUT_MS,
-  );
-  const timer = setTimeout(() => {
-    pendingFollowerAttachmentTimers.delete(key);
-    if (!pendingFollowerAttachments.delete(key)) return;
-    if (!leader || !leader.ready || leader.leadershipId !== leadershipId) return;
-    if (!tabs.has(followerTabId)) return;
-    followerAttachmentRetryCounts.set(key, retryCount + 1);
-    assignFollowerPorts(leader);
-  }, timeoutMs);
-  pendingFollowerAttachmentTimers.set(key, timer);
-}
+function assignFollowerPort(effect: Extract<BrokerEffect, { type: "assignFollowerPort" }>): void {
+  const leaderPort = ports.get(effect.leaderTabId);
+  const followerPort = ports.get(effect.followerTabId);
+  if (!leaderPort || !followerPort) return;
 
-function eligibleLeaderCandidates(): BrowserBrokerCandidate[] {
-  const schemaFingerprint = namespace?.schemaFingerprint;
-  return [...tabs.values()].filter((tab) => {
-    if (isLeaderCandidateInFailureBackoff(tab.tabId)) {
-      return false;
-    }
-    return !schemaFingerprint || tab.schemaFingerprint === schemaFingerprint;
-  });
-}
-
-function markLeaderCandidateFailed(tabId: string): void {
-  failedLeaderRetryAfterByTabId.set(tabId, Date.now() + LEADER_FAILURE_RETRY_BACKOFF_MS);
-}
-
-function isLeaderCandidateInFailureBackoff(tabId: string, now = Date.now()): boolean {
-  const retryAfter = failedLeaderRetryAfterByTabId.get(tabId);
-  if (retryAfter === undefined) return false;
-  if (retryAfter <= now) {
-    failedLeaderRetryAfterByTabId.delete(tabId);
-    return false;
-  }
-  return true;
-}
-
-function scheduleLeaderFailureRetryElection(now = Date.now()): void {
-  if (leaderFailureRetryTimer || resetState || replacementElectionInFlight || leader?.ready) return;
-
-  let retryAt: number | null = null;
-  for (const [tabId, candidateRetryAt] of failedLeaderRetryAfterByTabId) {
-    if (!tabs.has(tabId)) {
-      failedLeaderRetryAfterByTabId.delete(tabId);
-      continue;
-    }
-    retryAt = retryAt === null ? candidateRetryAt : Math.min(retryAt, candidateRetryAt);
-  }
-  if (retryAt === null) return;
-
-  leaderFailureRetryTimer = setTimeout(
-    () => {
-      leaderFailureRetryTimer = null;
-      electIfNeeded();
+  const channel = new MessageChannel();
+  post(
+    leaderPort,
+    {
+      type: "attach-follower-port",
+      brokerInstanceId,
+      followerTabId: effect.followerTabId,
+      leadershipId: effect.leadershipId,
+      port: channel.port1,
     },
-    Math.max(0, retryAt - now),
+    [channel.port1],
+  );
+  post(
+    followerPort,
+    {
+      type: "use-follower-port",
+      brokerInstanceId,
+      leaderTabId: effect.leaderTabId,
+      leadershipId: effect.leadershipId,
+      port: channel.port2,
+    },
+    [channel.port2],
   );
 }
 
-function stopLeaderFailureRetryTimer(): void {
-  if (!leaderFailureRetryTimer) return;
-  clearTimeout(leaderFailureRetryTimer);
-  leaderFailureRetryTimer = null;
+async function ensureWasmInitialized(wasmModule: BrokerElectionModule): Promise<void> {
+  if (typeof wasmModule.default !== "function") return;
+
+  const locationHref = workerGlobal.location?.href;
+  const wasmUrl =
+    resolveRuntimeConfigWasmUrl(import.meta.url, locationHref, undefined) ??
+    readWorkerRuntimeWasmUrl(locationHref);
+
+  if (wasmUrl) {
+    await wasmModule.default({ module_or_path: wasmUrl });
+    return;
+  }
+
+  await runWithRootRelativeFetchSupport(() => wasmModule.default?.());
 }
 
-function currentLeaderLockNames(): { tabLockName: string; workerLockName: string } | null {
-  if (!namespace) return null;
-  return {
-    tabLockName: `jazz-leader-tab:${namespace.appId}:${namespace.dbName}`,
-    workerLockName: `jazz-leader-worker:${namespace.appId}:${namespace.dbName}`,
-  };
-}
+async function runWithRootRelativeFetchSupport<T>(operation: () => Promise<T> | T): Promise<T> {
+  const globalRef = globalThis as typeof globalThis & { fetch?: typeof fetch };
+  const originalFetch = globalRef.fetch;
+  const origin = workerGlobal.location?.href ? new URL(workerGlobal.location.href).origin : null;
+  if (typeof originalFetch !== "function" || !origin) return await operation();
 
-function shouldAssignFollowerPort(tab: TabState, nextLeader: LeaderState): boolean {
-  if (tab.tabId === nextLeader.tabId) return false;
-  return !namespace?.schemaFingerprint || tab.schemaFingerprint === namespace.schemaFingerprint;
-}
-
-function removeTabFromActiveReset(tabId: string): void {
-  const activeReset = resetState;
-  if (!activeReset) return;
-
-  activeReset.participants.delete(tabId);
-  activeReset.preparedTabs.delete(tabId);
-  continueStorageResetIfReady(activeReset);
-}
-
-function markFollowerPortAttached(followerTabId: string, leadershipId: number): void {
-  const key = followerAttachmentKey(followerTabId, leadershipId);
-  if (!pendingFollowerAttachments.has(key)) return;
-  clearPendingFollowerAttachment(key);
-
-  if (!leader || leader.leadershipId !== leadershipId) return;
-  const follower = tabs.get(followerTabId);
-  if (!follower) return;
-  attachedFollowerPorts.add(key);
-
-  post(follower.port, {
-    type: "follower-ready",
-    brokerInstanceId,
-    leaderTabId: leader.tabId,
-    leadershipId,
-  });
-  if (resetState?.phase === "reconnecting" && resetState.promotedLeadershipId === leadershipId) {
-    finishStorageResetIfReconnected(resetState);
+  const patchedFetch: typeof fetch = (input, init) =>
+    originalFetch(
+      typeof input === "string" && input.startsWith("/")
+        ? new URL(input, origin).toString()
+        : input,
+      init,
+    );
+  globalRef.fetch = patchedFetch;
+  try {
+    return await operation();
+  } finally {
+    globalRef.fetch = originalFetch;
   }
 }
 
-function followerAttachmentKey(followerTabId: string, leadershipId: number): string {
-  return `${leadershipId}:${followerTabId}`;
+function timerKey(timerId: BrokerTimerId): string {
+  return JSON.stringify(timerId);
 }
 
 function post(
@@ -1177,13 +612,44 @@ function post(
   port.postMessage(message);
 }
 
-function normalizeForceTakeoverTimeout(value: unknown): number {
-  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
-    return DEFAULT_FORCE_TAKEOVER_TIMEOUT_MS;
-  }
-  return Math.max(0, Math.floor(value));
+function performanceNow(): number {
+  return typeof performance !== "undefined" && typeof performance.now === "function"
+    ? performance.now()
+    : Date.now();
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function ensureVitestWorkerImportShim(): void {
+  if (!isVitestEnvironment()) return;
+
+  const globalRef = globalThis as typeof globalThis & {
+    __vitest_browser_runner__?: VitestBrowserRunner;
+  };
+  if (globalRef.__vitest_browser_runner__) return;
+  globalRef.__vitest_browser_runner__ = {
+    wrapDynamicImport<T>(loader: () => Promise<T>): Promise<T> {
+      return loader();
+    },
+  };
+}
+
+function isVitestEnvironment(): boolean {
+  const processLike =
+    typeof process !== "undefined" ? (process as { env?: { VITEST?: string } }) : undefined;
+  if (processLike?.env?.VITEST) return true;
+
+  const importMeta = import.meta as ImportMeta & {
+    env?: { MODE?: string; VITEST?: boolean | string };
+  };
+  return importMeta.env?.MODE === "test" || Boolean(importMeta.env?.VITEST);
+}
+
+function markBrokerTiming(label: string, startedAt: number): void {
+  const durationMs = performanceNow() - startedAt;
+  (globalThis as typeof globalThis & { performance?: Performance }).performance?.measure?.(
+    `jazz-broker:${label}`,
+    {
+      start: startedAt,
+      duration: durationMs,
+    },
+  );
 }

--- a/packages/jazz-tools/tests/browser/shared-worker-broker.test.ts
+++ b/packages/jazz-tools/tests/browser/shared-worker-broker.test.ts
@@ -189,6 +189,39 @@ describe("SharedWorker browser broker", () => {
     ).rejects.toThrow("incompatible persistent browser configuration");
   });
 
+  it("keeps an accepted same-tab client connected after rejecting an incompatible reconnect", async () => {
+    const dbName = uniqueName("broker-same-tab-reject");
+    const reconnects: string[] = [];
+    const first = await BrowserBrokerClient.connect({
+      ...createLockingOptions(dbName, "tab-a", "fingerprint-a", {
+        brokerPingIntervalMs: 50,
+        brokerPongTimeoutMs: 100,
+      }),
+      onReconnected: () => {
+        reconnects.push("tab-a");
+      },
+    });
+    clients.push(first);
+    await first.waitForRole("leader", 2000);
+
+    await expect(
+      BrowserBrokerClient.connect({
+        ...createOptions(dbName, "tab-a", "fingerprint-b"),
+        brokerPingIntervalMs: 50,
+        brokerPongTimeoutMs: 100,
+      }),
+    ).rejects.toThrow("incompatible persistent browser configuration");
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    expect(reconnects).toEqual([]);
+    expect(first.snapshot()).toMatchObject({
+      role: "leader",
+      tabId: "tab-a",
+      leaderTabId: "tab-a",
+      leadershipId: 1,
+    });
+  });
+
   it("blocks a schema-mismatched tab and promotes it after the pinning tab departs", async () => {
     const dbName = uniqueName("broker-schema-blocked");
     const blockedReasons: string[] = [];


### PR DESCRIPTION
## Summary

Ports the browser broker client and shared-worker election state machines into Rust/WASM sans-I/O cores, with TypeScript reduced to executing browser effects returned by the cores.

This also addresses the review findings from the Rust/WASM broker port:

- Prunes and clears election `tab_order` to avoid duplicate fan-out and long-lived worker memory growth.
- Rejects and cleans up an in-flight browser broker `connect()` when `shutdown()` happens before WASM initialization completes.
- Makes `closeWithError` idempotent once closed.
- Allows browser client WASM initialization to retry after a transient failure.
- Allows worker election startup to retry after startup failure.
- Moves shared broker defaults and visibility typing into `broker_defaults.rs`.
- Removes the dead `send_stamped_ref` wrapper.
- Fixes duplicate storage-reset start waiters and makes reset waiter rejection deterministic.
- Gates the Vitest worker import shim to test environments.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p jazz-wasm`
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/runtime/browser-broker-client.test.ts`
- `pnpm --filter jazz-tools build:runtime`
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.browser.ts tests/browser/shared-worker-broker.test.ts`
- `wasm-pack test --headless --chrome --test wasm`
- `pnpm build:core`
- `pnpm --filter jazz-tools test`

Note: the full `wasm-pack test --headless --chrome` still fails in existing OPFS browser tests (`tests/opfs.rs`) with `invalid type: unit value, expected a string`; the targeted broker wasm wrapper suite passes.