### PR TITLE
feat(inspector): sort schemas by published_at in schema selector

### DIFF
--- a/crates/jazz-tools/src/server/routes/http.rs
+++ b/crates/jazz-tools/src/server/routes/http.rs
@@ -25,8 +25,17 @@ use super::utils::{
 };
 
 #[derive(Debug, Serialize)]
-pub(super) struct SchemaHashesResponse {
+#[serde(rename_all = "camelCase")]
+pub(super) struct SchemaSummary {
+    hash: String,
+    published_at: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct SchemaSummaryResponse {
+    #[deprecated(note = "Use `schemas` instead")]
     hashes: Vec<String>,
+    schemas: Vec<SchemaSummary>,
 }
 
 #[derive(Debug, Serialize)]
@@ -361,7 +370,7 @@ pub(super) async fn schema_handler(
 pub(super) async fn schema_hashes_handler(
     State(state): State<Arc<ServerState>>,
     headers: HeaderMap,
-) -> impl IntoResponse {
+) -> Result<Json<SchemaSummaryResponse>, Response> {
     let admin_secret = headers
         .get("X-Jazz-Admin-Secret")
         .and_then(|v| v.to_str().ok());
@@ -369,7 +378,7 @@ pub(super) async fn schema_hashes_handler(
     match validate_admin_secret(admin_secret, &state.auth_config) {
         Ok(()) => {}
         Err((status, msg)) => {
-            return (status, Json(ErrorResponse::unauthorized(msg))).into_response();
+            return Err((status, Json(ErrorResponse::unauthorized(msg))).into_response());
         }
     }
 
@@ -383,25 +392,46 @@ pub(super) async fn schema_hashes_handler(
         )
         .await
         {
-            Ok(response) => response,
-            Err(error) => error.into_response(),
+            Ok(response) => Err(response),
+            Err(error) => Err(error.into_response()),
         };
     }
 
     match state.runtime.known_schema_hashes() {
         Ok(hashes) => {
-            let body = SchemaHashesResponse {
+            let mut schemas = Vec::with_capacity(hashes.len());
+            for hash in &hashes {
+                let published_at = match state.runtime.schema_published_at(hash) {
+                    Ok(timestamp) => timestamp,
+                    Err(err) => {
+                        return Err((
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            Json(ErrorResponse::internal(format!(
+                                "failed to read schema publish timestamp: {err}"
+                            ))),
+                        )
+                            .into_response());
+                    }
+                };
+                schemas.push(SchemaSummary {
+                    hash: hash.to_string(),
+                    published_at,
+                });
+            }
+            #[allow(deprecated)]
+            let body = SchemaSummaryResponse {
                 hashes: hashes.iter().map(ToString::to_string).collect(),
+                schemas,
             };
-            Json(body).into_response()
+            Ok(Json(body))
         }
-        Err(err) => (
+        Err(err) => Err((
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse::internal(format!(
                 "failed to read schema hashes: {err}"
             ))),
         )
-            .into_response(),
+            .into_response()),
     }
 }
 

--- a/crates/jazz-tools/src/server/routes/mod.rs
+++ b/crates/jazz-tools/src/server/routes/mod.rs
@@ -820,6 +820,11 @@ mod tests {
             hashes_json["hashes"][0].as_str(),
             Some(expected_hash.as_str())
         );
+        assert_eq!(
+            hashes_json["schemas"][0]["hash"].as_str(),
+            Some(expected_hash.as_str())
+        );
+        assert!(hashes_json["schemas"][0].get("publishedAt").is_some());
 
         let schema_response = app
             .clone()

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -20,8 +20,7 @@
     "react-data-grid": "7.0.0-beta.59",
     "react-dom": "^19.2.0",
     "react-resizable-panels": "^4.9.0",
-    "react-router": "^7.13.0",
-    "swr": "^2.4.0"
+    "react-router": "^7.13.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/packages/inspector/src/App.tsx
+++ b/packages/inspector/src/App.tsx
@@ -7,6 +7,7 @@ import { DevtoolsProvider } from "./contexts/devtools-context.js";
 import { InspectorRoutes } from "./routes.js";
 import { DbConfigForm, SchemaHashSelect } from "./components/db-config-form/index.js";
 import type { DbConfigFormValues } from "./components/db-config-form/index.js";
+import { normalizeSchemaHashInfos, type SchemaHashInfo } from "./utility/schema-hash-display.js";
 import styles from "./App.module.css";
 
 interface StoredConnection {
@@ -33,6 +34,9 @@ const DEFAULT_SERVER_URL = "https://v2.sync.jazz.tools/";
 
 type AppScreen = "form" | "schema" | "connections" | null;
 type ConnectionFormMode = "connect" | "edit";
+type SchemaHashesResult = Awaited<ReturnType<typeof fetchSchemaHashes>> & {
+  schemas?: SchemaHashInfo[];
+};
 
 export default function App() {
   const [initialState] = useState(() => {
@@ -55,8 +59,8 @@ export default function App() {
   const [connectionFormMode, setConnectionFormMode] = useState<ConnectionFormMode>("connect");
   const [editingConnectionId, setEditingConnectionId] = useState<string | null>(null);
   const [formValues, setFormValues] = useState<DbConfigFormValues | null>(null);
-  const [schemaHashes, setSchemaHashes] = useState<string[]>([]);
-  const [availableSchemaHashes, setAvailableSchemaHashes] = useState<string[]>([]);
+  const [schemaHashes, setSchemaHashes] = useState<SchemaHashInfo[]>([]);
+  const [availableSchemaHashes, setAvailableSchemaHashes] = useState<SchemaHashInfo[]>([]);
   const [client, setClient] = useState<Awaited<ReturnType<typeof createJazzClient>> | null>(null);
   const [wasmSchema, setWasmSchema] = useState<import("jazz-tools").WasmSchema | null>(null);
   const [storedPermissions, setStoredPermissions] = useState<Awaited<
@@ -83,7 +87,7 @@ export default function App() {
     setConnectionStore(nextStore);
   };
 
-  const handleFormSubmit = (values: DbConfigFormValues, hashes: string[]) => {
+  const handleFormSubmit = (values: DbConfigFormValues, hashes: SchemaHashInfo[]) => {
     setFormValues(values);
     setSchemaHashes(hashes);
     setScreen("schema");
@@ -212,7 +216,7 @@ export default function App() {
 
     const run = async () => {
       try {
-        const [resolvedClient, { schema }, { hashes }, permissions] = await Promise.all([
+        const [resolvedClient, { schema }, schemaHashesResult, permissions] = await Promise.all([
           createJazzClient({
             appId: activeConnection.appId,
             serverUrl: activeConnection.serverUrl,
@@ -229,7 +233,7 @@ export default function App() {
           fetchSchemaHashes(activeConnection.serverUrl, {
             appId: activeConnection.appId,
             adminSecret: activeConnection.adminSecret,
-          }),
+          }) as Promise<SchemaHashesResult>,
           fetchStoredPermissions(activeConnection.serverUrl, {
             appId: activeConnection.appId,
             adminSecret: activeConnection.adminSecret,
@@ -249,7 +253,9 @@ export default function App() {
         });
         setWasmSchema(schema);
         setStoredPermissions(permissions);
-        setAvailableSchemaHashes(hashes);
+        setAvailableSchemaHashes(
+          normalizeSchemaHashInfos(schemaHashesResult.hashes, schemaHashesResult.schemas),
+        );
         setError(null);
         setIsSwitchingSchema(false);
       } catch (err) {
@@ -317,7 +323,7 @@ export default function App() {
   if (screen === "schema" && formValues) {
     return (
       <main className={styles.statePage}>
-        <SchemaHashSelect hashes={schemaHashes} onSelect={handleSchemaSelect} />
+        <SchemaHashSelect schemas={schemaHashes} onSelect={handleSchemaSelect} />
       </main>
     );
   }

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
@@ -165,12 +165,9 @@ describe("TableDataGrid", () => {
   it("renders schema-derived columns and reactive rows", () => {
     renderGrid();
 
-    expect(screen.getByRole("heading", { name: "todos" })).not.toBeNull();
     expect(screen.queryByText("6 columns · 2 rows on page · 0 filters")).toBeNull();
-    const header = screen.getByRole("heading", { name: "todos" }).closest("header");
-    expect(header).not.toBeNull();
-    expect(within(header as HTMLElement).getByRole("button", { name: "Filter" })).not.toBeNull();
-    expect(within(header as HTMLElement).getByRole("button", { name: "Insert" })).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Filter" })).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Insert" })).not.toBeNull();
     expect(screen.getByRole("columnheader", { name: /ID/ })).not.toBeNull();
     expect(screen.getByRole("columnheader", { name: "title" })).not.toBeNull();
     expect(screen.getByRole("columnheader", { name: "done" })).not.toBeNull();

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
@@ -803,7 +803,6 @@ export function TableDataGrid() {
   return (
     <section className={styles.container}>
       <header className={styles.header}>
-        <h2 className={styles.title}>{table}</h2>
         <div className={styles.headerActions}>
           <Link to={`/data-explorer/${table}/schema`} className={styles.secondaryButton}>
             Schema

--- a/packages/inspector/src/components/db-config-form/DbConfigForm.tsx
+++ b/packages/inspector/src/components/db-config-form/DbConfigForm.tsx
@@ -1,5 +1,9 @@
 import { fetchSchemaHashes } from "jazz-tools";
 import { useEffect, useState, type FormEvent } from "react";
+import {
+  normalizeSchemaHashInfos,
+  type SchemaHashInfo,
+} from "../../utility/schema-hash-display.js";
 import styles from "./DbConfigForm.module.css";
 
 export interface DbConfigFormValues {
@@ -11,8 +15,12 @@ export interface DbConfigFormValues {
   branch: string;
 }
 
+type SchemaHashesResult = Awaited<ReturnType<typeof fetchSchemaHashes>> & {
+  schemas?: SchemaHashInfo[];
+};
+
 interface DbConfigFormProps {
-  onSubmit: (values: DbConfigFormValues, hashes: string[]) => void;
+  onSubmit: (values: DbConfigFormValues, schemas: SchemaHashInfo[]) => void;
   initialValues?: Partial<DbConfigFormValues>;
   mode?: "connect" | "edit";
   title?: string;
@@ -61,11 +69,11 @@ export function DbConfigForm({
     };
 
     try {
-      const { hashes } = await fetchSchemaHashes(values.serverUrl, {
+      const { hashes, schemas } = (await fetchSchemaHashes(values.serverUrl, {
         appId: values.appId,
         adminSecret: values.adminSecret,
-      });
-      onSubmit(values, hashes);
+      })) as SchemaHashesResult;
+      onSubmit(values, normalizeSchemaHashInfos(hashes, schemas));
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       setErrorMessage(message);

--- a/packages/inspector/src/components/db-config-form/SchemaHashSelect.test.tsx
+++ b/packages/inspector/src/components/db-config-form/SchemaHashSelect.test.tsx
@@ -1,0 +1,28 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SchemaHashSelect } from "./SchemaHashSelect";
+
+describe("SchemaHashSelect", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows short schema hashes with upload time while submitting full hashes", () => {
+    const onSelect = vi.fn();
+    const hash = "aaaaaaaaaaaabbbbbbbbbbbbccccccccccccddddddddddddeeeeeeeeeeeeffff";
+
+    render(
+      <SchemaHashSelect
+        schemas={[{ hash, publishedAt: Date.UTC(2026, 5, 18, 19, 15) }]}
+        onSelect={onSelect}
+      />,
+    );
+
+    expect(screen.getByRole("option", { name: /aaaaaaaaaaaa - uploaded / })).not.toBeNull();
+
+    fireEvent.change(screen.getByLabelText("Schema hash"), { target: { value: hash } });
+    fireEvent.click(screen.getByRole("button", { name: "Use schema" }));
+
+    expect(onSelect).toHaveBeenCalledWith(hash);
+  });
+});

--- a/packages/inspector/src/components/db-config-form/SchemaHashSelect.tsx
+++ b/packages/inspector/src/components/db-config-form/SchemaHashSelect.tsx
@@ -1,12 +1,16 @@
 import type { SubmitEvent } from "react";
+import {
+  formatSchemaHashOptionLabel,
+  type SchemaHashInfo,
+} from "../../utility/schema-hash-display.js";
 import styles from "./SchemaHashSelect.module.css";
 
 interface SchemaHashSelectProps {
-  hashes: string[];
+  schemas: SchemaHashInfo[];
   onSelect: (hash: string) => void;
 }
 
-export function SchemaHashSelect({ hashes, onSelect }: SchemaHashSelectProps) {
+export function SchemaHashSelect({ schemas, onSelect }: SchemaHashSelectProps) {
   const handleSubmit = (event: SubmitEvent<HTMLFormElement>) => {
     event.preventDefault();
     const form = event.currentTarget;
@@ -17,7 +21,7 @@ export function SchemaHashSelect({ hashes, onSelect }: SchemaHashSelectProps) {
     }
   };
 
-  if (hashes.length === 0) {
+  if (schemas.length === 0) {
     return (
       <section className={styles.card}>
         <h2 className={styles.title}>No schemas available</h2>
@@ -33,9 +37,9 @@ export function SchemaHashSelect({ hashes, onSelect }: SchemaHashSelectProps) {
         Schema hash
         <select name="schema-hash" required className={styles.select}>
           <option value="">—</option>
-          {hashes.map((hash) => (
-            <option key={hash} value={hash}>
-              {hash}
+          {schemas.map((schema) => (
+            <option key={schema.hash} value={schema.hash} title={schema.hash}>
+              {formatSchemaHashOptionLabel(schema)}
             </option>
           ))}
         </select>

--- a/packages/inspector/src/components/inspector-layout/index.test.tsx
+++ b/packages/inspector/src/components/inspector-layout/index.test.tsx
@@ -32,7 +32,10 @@ describe("InspectorLayout", () => {
     mockUseStandaloneContext.mockReturnValue({
       onManageConnections,
       onReset: vi.fn(),
-      schemaHashes: ["hash-a", "hash-b"],
+      schemaHashes: [
+        { hash: "hash-a", publishedAt: null },
+        { hash: "hash-b", publishedAt: null },
+      ],
       selectedSchemaHash: "hash-a",
       onSelectSchema,
       isSwitchingSchema: false,
@@ -51,13 +54,37 @@ describe("InspectorLayout", () => {
     expect(screen.getByRole("link", { name: "Live Query" })).not.toBeNull();
   });
 
+  it("shortens schema hashes and includes upload time when available", () => {
+    mockUseStandaloneContext.mockReturnValue({
+      onManageConnections: vi.fn(),
+      onReset: vi.fn(),
+      schemaHashes: [
+        {
+          hash: "aaaaaaaaaaaabbbbbbbbbbbbccccccccccccddddddddddddeeeeeeeeeeeeffff",
+          publishedAt: Date.UTC(2026, 5, 18, 19, 15),
+        },
+      ],
+      selectedSchemaHash: "aaaaaaaaaaaabbbbbbbbbbbbccccccccccccddddddddddddeeeeeeeeeeeeffff",
+      onSelectSchema: vi.fn(),
+      isSwitchingSchema: false,
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/data-explorer"]}>
+        <InspectorLayout />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("option", { name: /aaaaaaaaaaaa - uploaded / })).not.toBeNull();
+  });
+
   it("calls manage handler when connections button is clicked", () => {
     const onManageConnections = vi.fn();
 
     mockUseStandaloneContext.mockReturnValue({
       onManageConnections,
       onReset: vi.fn(),
-      schemaHashes: ["hash-a"],
+      schemaHashes: [{ hash: "hash-a", publishedAt: null }],
       selectedSchemaHash: "hash-a",
       onSelectSchema: vi.fn(),
       isSwitchingSchema: false,
@@ -80,7 +107,10 @@ describe("InspectorLayout", () => {
     mockUseStandaloneContext.mockReturnValue({
       onManageConnections: vi.fn(),
       onReset: vi.fn(),
-      schemaHashes: ["hash-a", "hash-b"],
+      schemaHashes: [
+        { hash: "hash-a", publishedAt: null },
+        { hash: "hash-b", publishedAt: null },
+      ],
       selectedSchemaHash: "hash-a",
       onSelectSchema,
       isSwitchingSchema: false,
@@ -101,7 +131,7 @@ describe("InspectorLayout", () => {
     mockUseStandaloneContext.mockReturnValue({
       onManageConnections: vi.fn(),
       onReset: vi.fn(),
-      schemaHashes: ["hash-a"],
+      schemaHashes: [{ hash: "hash-a", publishedAt: null }],
       selectedSchemaHash: "hash-a",
       onSelectSchema: vi.fn(),
       isSwitchingSchema: true,

--- a/packages/inspector/src/components/inspector-layout/index.tsx
+++ b/packages/inspector/src/components/inspector-layout/index.tsx
@@ -1,6 +1,10 @@
 import { useState } from "react";
 import { NavLink, Outlet, useLocation } from "react-router";
 import { useStandaloneContext } from "../../contexts/standalone-context.js";
+import {
+  formatSchemaHashOptionLabel,
+  type SchemaHashInfo,
+} from "../../utility/schema-hash-display.js";
 import styles from "./index.module.css";
 
 interface TablesPanelIconProps {
@@ -98,7 +102,7 @@ export function InspectorLayout() {
 }
 
 interface SchemaHashesSelectProps {
-  schemaHashes: string[];
+  schemaHashes: SchemaHashInfo[];
   selectedSchemaHash: string | null;
   onSelectSchema: (schemaHash: string) => void;
   isSwitchingSchema: boolean;
@@ -119,9 +123,9 @@ export function SchemaHashesSelect({
         onChange={(event) => onSelectSchema(event.target.value)}
         disabled={isSwitchingSchema || schemaHashes.length === 0}
       >
-        {schemaHashes.map((schemaHash) => (
-          <option key={schemaHash} value={schemaHash}>
-            {schemaHash}
+        {schemaHashes.map((schema) => (
+          <option key={schema.hash} value={schema.hash} title={schema.hash}>
+            {formatSchemaHashOptionLabel(schema)}
           </option>
         ))}
       </select>

--- a/packages/inspector/src/contexts/standalone-context.tsx
+++ b/packages/inspector/src/contexts/standalone-context.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, type PropsWithChildren } from "react";
+import type { SchemaHashInfo } from "../utility/schema-hash-display.js";
 
 export interface StandaloneConnectionConfig {
   serverUrl: string;
@@ -8,7 +9,7 @@ export interface StandaloneConnectionConfig {
 
 interface StandaloneContextValue {
   onManageConnections: () => void;
-  schemaHashes: string[];
+  schemaHashes: SchemaHashInfo[];
   selectedSchemaHash: string | null;
   onSelectSchema: (schemaHash: string) => void;
   isSwitchingSchema: boolean;

--- a/packages/inspector/src/utility/schema-hash-display.test.ts
+++ b/packages/inspector/src/utility/schema-hash-display.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { normalizeSchemaHashInfos } from "./schema-hash-display";
+
+describe("schema hash display", () => {
+  it("sorts schema hashes by publishedAt descending with unknown times last", () => {
+    const sorted = normalizeSchemaHashInfos(
+      ["old", "unknown", "new"],
+      [
+        { hash: "old", publishedAt: 100 },
+        { hash: "new", publishedAt: 300 },
+      ],
+    );
+
+    expect(sorted).toEqual([
+      { hash: "new", publishedAt: 300 },
+      { hash: "old", publishedAt: 100 },
+      { hash: "unknown", publishedAt: null },
+    ]);
+  });
+});

--- a/packages/inspector/src/utility/schema-hash-display.ts
+++ b/packages/inspector/src/utility/schema-hash-display.ts
@@ -1,0 +1,46 @@
+export interface SchemaHashInfo {
+  hash: string;
+  publishedAt: number | null;
+}
+
+export function normalizeSchemaHashInfos(
+  hashes: string[],
+  schemas: readonly SchemaHashInfo[] = [],
+): SchemaHashInfo[] {
+  const schemaByHash = new Map(schemas.map((schema) => [schema.hash, schema]));
+  const hashOrder = new Map(hashes.map((hash, index) => [hash, index]));
+  return hashes
+    .map((hash) => schemaByHash.get(hash) ?? { hash, publishedAt: null })
+    .sort((left, right) => {
+      if (left.publishedAt === null && right.publishedAt === null) {
+        return (hashOrder.get(left.hash) ?? 0) - (hashOrder.get(right.hash) ?? 0);
+      }
+      if (left.publishedAt === null) return 1;
+      if (right.publishedAt === null) return -1;
+      return right.publishedAt - left.publishedAt;
+    });
+}
+
+export function shortSchemaHash(hash: string): string {
+  return hash.slice(0, 12);
+}
+
+export function formatSchemaPublishedAt(publishedAt: number | null): string | null {
+  if (publishedAt === null || !Number.isFinite(publishedAt)) {
+    return null;
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(publishedAt));
+}
+
+export function formatSchemaHashOptionLabel(schema: SchemaHashInfo): string {
+  const publishedAt = formatSchemaPublishedAt(schema.publishedAt);
+  if (!publishedAt) {
+    return shortSchemaHash(schema.hash);
+  }
+
+  return `${shortSchemaHash(schema.hash)} - uploaded ${publishedAt}`;
+}

--- a/packages/jazz-tools/src/runtime/index.ts
+++ b/packages/jazz-tools/src/runtime/index.ts
@@ -56,6 +56,7 @@ export {
   type PublishStoredPermissionsOptions,
   type FetchStoredPermissionsOptions,
   type FetchStoredWasmSchemaOptions,
+  type StoredSchemaHash,
   type StoredPermissionsResponse,
 } from "./schema-fetch.js";
 export {

--- a/packages/jazz-tools/src/runtime/schema-fetch.test.ts
+++ b/packages/jazz-tools/src/runtime/schema-fetch.test.ts
@@ -107,6 +107,7 @@ describe("schema-fetch", () => {
     expect(result.hashes).toEqual([
       "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     ]);
+    expect(result.schemas).toEqual([]);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0]![0]).toBe("http://localhost:1625/apps/app-123/schemas");
     expect(fetchMock.mock.calls[0]![1]).toMatchObject({
@@ -115,6 +116,39 @@ describe("schema-fetch", () => {
         "X-Jazz-Admin-Secret": "admin-secret",
       },
     });
+  });
+
+  it("fetches schema hash upload metadata when present", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({
+        hashes: ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"],
+        schemas: [
+          {
+            hash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            publishedAt: 1_744_011_200_000_000,
+          },
+        ],
+      }),
+    });
+    (globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await fetchSchemaHashes("http://localhost:1625/", {
+      appId: "app-123",
+      adminSecret: "admin-secret",
+    });
+
+    expect(result.hashes).toEqual([
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    ]);
+    expect(result.schemas).toEqual([
+      {
+        hash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        publishedAt: 1_744_011_200_000,
+      },
+    ]);
   });
 
   it("fetches the requested schema hash when provided", async () => {

--- a/packages/jazz-tools/src/runtime/schema-fetch.ts
+++ b/packages/jazz-tools/src/runtime/schema-fetch.ts
@@ -70,10 +70,55 @@ export interface FetchStoredSchemasOptions {
   adminSecret: string;
 }
 
+export interface StoredSchemaHash {
+  hash: string;
+  publishedAt: number | null;
+}
+
+interface SchemaHashesResponseBody {
+  hashes?: string[];
+  schemas?: Array<{
+    hash: string;
+    publishedAt?: number | null;
+  }>;
+}
+
+function isSchemaHashesResponseBody(value: unknown): value is SchemaHashesResponseBody {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const candidate = value as {
+    hashes?: unknown;
+    schemas?: unknown;
+  };
+
+  const hasValidHashes =
+    candidate.hashes === undefined ||
+    (Array.isArray(candidate.hashes) && candidate.hashes.every((hash) => typeof hash === "string"));
+  const hasValidSchemas =
+    candidate.schemas === undefined ||
+    (Array.isArray(candidate.schemas) &&
+      candidate.schemas.every((schema) => {
+        if (typeof schema !== "object" || schema === null) {
+          return false;
+        }
+        const entry = schema as { hash?: unknown; publishedAt?: unknown };
+        return (
+          typeof entry.hash === "string" &&
+          (entry.publishedAt === undefined ||
+            entry.publishedAt === null ||
+            (typeof entry.publishedAt === "number" && Number.isFinite(entry.publishedAt)))
+        );
+      }));
+
+  return hasValidHashes && hasValidSchemas;
+}
+
 export async function fetchSchemaHashes(
   serverUrl: string,
   options: FetchStoredSchemasOptions,
-): Promise<{ hashes: string[] }> {
+): Promise<{ hashes: string[]; schemas: StoredSchemaHash[] }> {
   const response = await fetch(appScopedUrl(serverUrl, options.appId, "schemas"), {
     method: "GET",
     headers: {
@@ -89,8 +134,20 @@ export async function fetchSchemaHashes(
     );
   }
 
-  const schemaHashesResponse = (await response.json()) as { hashes?: string[] };
-  return { hashes: schemaHashesResponse.hashes ?? [] };
+  const rawSchemaHashesResponse = (await response.json()) as unknown;
+  const schemaHashesResponse = isSchemaHashesResponseBody(rawSchemaHashesResponse)
+    ? rawSchemaHashesResponse
+    : {};
+  const schemas =
+    schemaHashesResponse.schemas?.map((schema) => ({
+      hash: schema.hash,
+      publishedAt: normalizePublishedAtEpochMilliseconds(schema.publishedAt),
+    })) ?? [];
+
+  return {
+    hashes: schemaHashesResponse.hashes ?? schemas.map((schema) => schema.hash),
+    schemas,
+  };
 }
 
 export interface PublishStoredSchemaOptions {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1421,9 +1421,6 @@ importers:
       react-router:
         specifier: ^7.13.0
         version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      swr:
-        specifier: ^2.4.0
-        version: 2.4.1(react@19.2.4)
     devDependencies:
       '@playwright/test':
         specifier: ^1.58.2
@@ -11844,11 +11841,6 @@ packages:
   svelte@5.53.6:
     resolution: {integrity: sha512-lP5DGF3oDDI9fhHcSpaBiJEkFLuS16h92DhM1L5K1lFm0WjOmUh1i2sNkBBk8rkxJRpob0dBE75jRfUzGZUOGA==}
     engines: {node: '>=18'}
-
-  swr@2.4.1:
-    resolution: {integrity: sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==}
-    peerDependencies:
-      react: 19.2.4
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -24308,12 +24300,6 @@ snapshots:
       locate-character: 3.0.0
       magic-string: 0.30.21
       zimmerframe: 1.1.4
-
-  swr@2.4.1(react@19.2.4):
-    dependencies:
-      dequal: 2.0.3
-      react: 19.2.4
-      use-sync-external-store: 1.6.0(react@19.2.4)
 
   symbol-tree@3.2.4: {}
 


### PR DESCRIPTION
## Description

Previously we only showed each schema's full hash. Now we show a short hash + the published at date and time, to make it easier to identify schemas. We also sort schemas by published timestamp.

https://github.com/user-attachments/assets/5012aa53-4c11-4941-8517-3b32c8a3282c

