### PR TITLE
perf(opfs-btree): bitmap freelist allocator

### DIFF
--- a/crates/opfs-btree/src/db.rs
+++ b/crates/opfs-btree/src/db.rs
@@ -4,6 +4,7 @@ use std::collections::BinaryHeap;
 
 use crate::BTreeError;
 use crate::file::SyncFile;
+use crate::free_bitmap::FreeBitmap;
 use crate::leaf_hint::{LEAF_HINT_SLOTS, LeafHintCache};
 use crate::page::{
     OverflowRef, Page, PageId, PageKind, RawDescendStep, RawLeafDeleteResult, RawLeafUpsertResult,
@@ -115,8 +116,7 @@ pub struct OpfsBTree<F: SyncFile> {
     dirty_pages: OpfsSet<PageId>,
     wal_pages: OpfsSet<PageId>,
     freelist_dirty: bool,
-    free_pages: Vec<PageId>,
-    free_set: OpfsSet<PageId>,
+    free_bitmap: FreeBitmap,
     freelist_meta_pages: Vec<PageId>,
     leaf_hints: LeafHintCache,
 }
@@ -166,8 +166,7 @@ impl<F: SyncFile> OpfsBTree<F> {
             dirty_pages: OpfsSet::default(),
             wal_pages: OpfsSet::default(),
             freelist_dirty: false,
-            free_pages: Vec::new(),
-            free_set: OpfsSet::default(),
+            free_bitmap: FreeBitmap::default(),
             freelist_meta_pages: Vec::new(),
             leaf_hints: LeafHintCache::default(),
         };
@@ -1327,7 +1326,7 @@ impl<F: SyncFile> OpfsBTree<F> {
         if let Some(max_live) = self.pages.keys().max().copied() {
             max_page_id = max_page_id.max(max_live);
         }
-        if let Some(max_free) = self.free_set.iter().max().copied() {
+        if let Some(max_free) = self.free_bitmap.highest() {
             max_page_id = max_page_id.max(max_free);
         }
         if let Some(max_freelist) = freelist_pages.iter().map(|(id, _)| *id).max() {
@@ -1496,8 +1495,7 @@ impl<F: SyncFile> OpfsBTree<F> {
         }
         self.total_pages = header.total_pages;
         self.root_page_id = (header.root_page_id != 0).then_some(header.root_page_id);
-        self.free_pages.clear();
-        self.free_set.clear();
+        self.free_bitmap.clear();
         self.freelist_meta_pages.clear();
 
         for frame in frames {
@@ -1631,11 +1629,9 @@ impl<F: SyncFile> OpfsBTree<F> {
 
         self.sanitize_free_pages();
 
-        let mut free_ids: Vec<PageId> = self.free_set.iter().copied().collect();
-        free_ids.sort_unstable();
-
+        let total_free = self.free_bitmap.len();
         let capacity = freelist_ids_per_page(self.options.page_size)?;
-        if capacity == 0 && !free_ids.is_empty() {
+        if capacity == 0 && total_free != 0 {
             return Err(BTreeError::InvalidOptions(
                 "page size too small for freelist pages".to_string(),
             ));
@@ -1645,27 +1641,25 @@ impl<F: SyncFile> OpfsBTree<F> {
         while meta_count
             .checked_mul(capacity)
             .ok_or_else(|| BTreeError::Io("freelist capacity overflow".to_string()))?
-            < free_ids.len().saturating_sub(meta_count)
+            < total_free.saturating_sub(meta_count)
         {
             meta_count += 1;
         }
 
+        // The meta pages that host the freelist come off the top of the free
+        // set; taking them in place leaves the remaining (lower) ids still free
+        // in the bitmap, so no clear-and-reinsert is needed.
         let mut meta_page_ids = Vec::with_capacity(meta_count);
         for _ in 0..meta_count {
-            let page_id = free_ids.pop().ok_or_else(|| {
+            let page_id = self.free_bitmap.take_highest().ok_or_else(|| {
                 BTreeError::Corrupt("freelist meta page allocation underflow".to_string())
             })?;
             meta_page_ids.push(page_id);
         }
         meta_page_ids.sort_unstable();
 
-        let remaining_free = free_ids;
-        self.free_set.clear();
-        self.free_pages.clear();
-        for page_id in &remaining_free {
-            self.free_set.insert(*page_id);
-            self.free_pages.push(*page_id);
-        }
+        // The bitmap already yields ids in ascending order, so no sort here.
+        let remaining_free: Vec<PageId> = self.free_bitmap.iter().collect();
 
         self.freelist_meta_pages = meta_page_ids.clone();
         let head_page_id = *meta_page_ids.first().unwrap_or(&0);
@@ -1692,22 +1686,31 @@ impl<F: SyncFile> OpfsBTree<F> {
     }
 
     fn sanitize_free_pages(&mut self) {
-        let live_page_ids: OpfsSet<PageId> = self.pages.keys().copied().collect();
-        self.free_set.retain(|page_id| {
-            *page_id >= 2 && *page_id < self.total_pages && !live_page_ids.contains(page_id)
-        });
-
-        self.free_pages.clear();
-        self.free_pages.extend(self.free_set.iter().copied());
-        self.free_pages.sort_unstable();
+        // Pages 0 and 1 are reserved; ids at or beyond total_pages do not exist
+        // yet; and a page currently resident in the cache is live, not free.
+        self.free_bitmap.remove(0);
+        self.free_bitmap.remove(1);
+        self.free_bitmap.retain_below(self.total_pages);
+        // Drop any free id that is actually live. Scan the free set (usually
+        // small, often empty on write-heavy workloads) rather than the page
+        // cache, which is frequently much larger.
+        let live_free: Vec<PageId> = self
+            .free_bitmap
+            .iter()
+            .filter(|page_id| self.pages.contains_key(page_id))
+            .collect();
+        for page_id in live_free {
+            self.free_bitmap.remove(page_id);
+        }
+        // Removing high live/out-of-range ids can leave empty trailing words.
+        self.free_bitmap.trim_trailing_empty_words();
     }
 
     fn alloc_page(&mut self) -> PageId {
-        while let Some(page_id) = self.free_pages.pop() {
-            if self.claim_free_page(page_id) {
-                tracing::trace!(page_id, reused = true, "alloc_page");
-                return page_id;
-            }
+        if let Some(page_id) = self.free_bitmap.take_highest() {
+            self.freelist_dirty = true;
+            tracing::trace!(page_id, reused = true, "alloc_page");
+            return page_id;
         }
 
         let page_id = self.total_pages;
@@ -1726,38 +1729,15 @@ impl<F: SyncFile> OpfsBTree<F> {
             return Ok(self.alloc_page());
         }
 
-        let mut free_ids: Vec<PageId> = self.free_set.iter().copied().collect();
-        free_ids.sort_unstable();
-        let mut run_start = 0u64;
-        let mut run_len = 0usize;
-        let mut prev = 0u64;
-        for id in free_ids {
-            if run_len == 0 {
-                run_start = id;
-                run_len = 1;
-            } else if id == prev.saturating_add(1) {
-                run_len = run_len.saturating_add(1);
-            } else {
-                run_start = id;
-                run_len = 1;
-            }
-            prev = id;
-
-            if run_len >= page_count {
-                for i in 0..page_count {
-                    let page_id = run_start.checked_add(i as u64).ok_or_else(|| {
-                        BTreeError::Corrupt("extent free-run page id overflow".to_string())
-                    })?;
-                    self.claim_free_page(page_id);
-                }
-                tracing::trace!(
-                    head_page_id = run_start,
-                    page_count,
-                    reused = true,
-                    "alloc_extent_pages"
-                );
-                return Ok(run_start);
-            }
+        if let Some(run_start) = self.free_bitmap.take_run(page_count) {
+            self.freelist_dirty = true;
+            tracing::trace!(
+                head_page_id = run_start,
+                page_count,
+                reused = true,
+                "alloc_extent_pages"
+            );
+            return Ok(run_start);
         }
 
         let start = self.total_pages;
@@ -1804,14 +1784,13 @@ impl<F: SyncFile> OpfsBTree<F> {
         if page_id < 2 {
             return;
         }
-        if self.free_set.insert(page_id) {
-            self.free_pages.push(page_id);
+        if self.free_bitmap.insert(page_id) {
             self.freelist_dirty = true;
         }
     }
 
     fn claim_free_page(&mut self, page_id: PageId) -> bool {
-        if self.free_set.remove(&page_id) {
+        if self.free_bitmap.remove(page_id) {
             self.freelist_dirty = true;
             true
         } else {
@@ -2542,7 +2521,7 @@ mod tests {
             "same-page-count overflow update should reuse existing extent pages"
         );
         assert!(
-            tree.free_set.is_empty(),
+            tree.free_bitmap.is_empty(),
             "reuse path should not free overflow pages when page count is unchanged"
         );
     }
@@ -2562,7 +2541,7 @@ mod tests {
         assert_eq!(tree.get(b"k").expect("get k"), Some(value_small));
         assert_eq!(tree.total_pages, total_pages_before);
         assert!(
-            !tree.free_set.is_empty(),
+            !tree.free_bitmap.is_empty(),
             "shrinking overflow value should return tail pages to free list"
         );
     }
@@ -3093,7 +3072,7 @@ mod tests {
 
         let allocated = tree.alloc_page_near(10);
         assert_eq!(allocated, 11, "expected +1 neighbor to be selected first");
-        assert!(!tree.free_set.contains(&11));
+        assert!(!tree.free_bitmap.contains(11));
     }
 
     #[test]

--- a/crates/opfs-btree/src/free_bitmap.rs
+++ b/crates/opfs-btree/src/free_bitmap.rs
@@ -134,13 +134,51 @@ impl FreeBitmap {
     /// long is free. `count` must be >= 1.
     pub(crate) fn take_run(&mut self, count: usize) -> Option<PageId> {
         let run_start = self.find_run(count)?;
-        // `find_run` just confirmed every bit in the run is set, so each
-        // `remove` succeeds and the count stays accurate.
-        for offset in 0..count as u64 {
-            self.remove(run_start + offset);
-        }
+        self.remove_run(run_start, count);
         self.trim_trailing_empty_words();
         Some(run_start)
+    }
+
+    /// Clears the `count` consecutive free bits starting at `start` using
+    /// word-level masking: at most one masked write per 64-page span the run
+    /// touches, instead of one `remove` (with its own `locate` + bounds check)
+    /// per page. Callers must have confirmed the whole range is free, as
+    /// `take_run` does via `find_run`; `free_count` is decremented by the
+    /// number of bits actually cleared.
+    fn remove_run(&mut self, start: PageId, count: usize) {
+        debug_assert!(count >= 1);
+        let last = start + count as u64 - 1;
+        let start_word = (start / BITS_PER_WORD) as usize;
+        let last_word = (last / BITS_PER_WORD) as usize;
+
+        // Bits at or above `start` within the first touched word.
+        let from_start = u64::MAX << (start % BITS_PER_WORD);
+        // Bits at or below `last` within the last touched word.
+        let last_bit = last % BITS_PER_WORD;
+        let through_last = if last_bit == BITS_PER_WORD - 1 {
+            u64::MAX
+        } else {
+            (1u64 << (last_bit + 1)) - 1
+        };
+
+        if start_word == last_word {
+            self.clear_masked(start_word, from_start & through_last);
+        } else {
+            self.clear_masked(start_word, from_start);
+            for word in start_word + 1..last_word {
+                self.clear_masked(word, u64::MAX);
+            }
+            self.clear_masked(last_word, through_last);
+        }
+    }
+
+    /// Clears the bits selected by `mask` in `words[word]`, keeping
+    /// `free_count` in sync with the bits actually removed.
+    #[inline]
+    fn clear_masked(&mut self, word: usize, mask: u64) {
+        let cleared = (self.words[word] & mask).count_ones() as usize;
+        self.words[word] &= !mask;
+        self.free_count -= cleared;
     }
 
     /// Clears every free bit for a page id `>= limit`.
@@ -275,6 +313,27 @@ mod tests {
         assert!(!bm.contains(10) && !bm.contains(11) && !bm.contains(12));
         assert_eq!(bm.iter().collect::<Vec<_>>(), vec![2, 3, 20]);
         assert_eq!(bm.take_run(3), None);
+    }
+
+    #[test]
+    fn take_run_clears_a_run_spanning_multiple_words() {
+        let mut bm = FreeBitmap::default();
+        // A 130-page run starting mid-word at 60, crossing two word
+        // boundaries (60..190 spans words 0, 1, and 2).
+        for id in 60u64..190 {
+            bm.insert(id);
+        }
+        // A couple of free pages on either side that must survive untouched.
+        bm.insert(2);
+        bm.insert(200);
+        assert_eq!(bm.len(), 132);
+
+        assert_eq!(bm.take_run(130), Some(60));
+        assert_eq!(bm.len(), 2);
+        assert_eq!(bm.iter().collect::<Vec<_>>(), vec![2, 200]);
+        for id in 60u64..190 {
+            assert!(!bm.contains(id), "page {id} should be allocated");
+        }
     }
 
     #[test]

--- a/crates/opfs-btree/src/free_bitmap.rs
+++ b/crates/opfs-btree/src/free_bitmap.rs
@@ -1,0 +1,297 @@
+//! In-memory free-page tracker backed by a bitmap.
+//!
+//! Replaces the previous sorted-`Vec` + `HashSet` pair. A set bit at index
+//! `page_id` means that page is free and available for reuse. Pages 0 and 1 are
+//! reserved for the superblock slots and are never tracked here.
+//!
+//! The on-disk freelist format (a linked list of id chunks; see
+//! `Page::Freelist`) is unchanged. This structure is the in-memory working set
+//! only: it is populated on load/WAL replay and serialized back on flush.
+//!
+//! Allocation policy is preserved from the previous implementation:
+//! single-page allocation reuses the highest free id, while extent allocation
+//! reuses the lowest contiguous run that is large enough.
+
+use crate::page::PageId;
+
+const BITS_PER_WORD: u64 = 64;
+
+#[derive(Debug, Default)]
+pub(crate) struct FreeBitmap {
+    /// Bit `i` of `words[i / 64]` is set when page `i` is free.
+    words: Vec<u64>,
+    /// Number of set bits, kept in sync with `words` so `len` stays O(1).
+    free_count: usize,
+}
+
+impl FreeBitmap {
+    #[inline]
+    fn locate(page_id: PageId) -> (usize, u64) {
+        let word = (page_id / BITS_PER_WORD) as usize;
+        let bit = 1u64 << (page_id % BITS_PER_WORD);
+        (word, bit)
+    }
+
+    /// Marks `page_id` free. Returns `true` if it was not already free.
+    pub(crate) fn insert(&mut self, page_id: PageId) -> bool {
+        let (word, bit) = Self::locate(page_id);
+        if word >= self.words.len() {
+            self.words.resize(word + 1, 0);
+        }
+        if self.words[word] & bit != 0 {
+            return false;
+        }
+        self.words[word] |= bit;
+        self.free_count += 1;
+        true
+    }
+
+    /// Marks `page_id` allocated. Returns `true` if it had been free.
+    pub(crate) fn remove(&mut self, page_id: PageId) -> bool {
+        let (word, bit) = Self::locate(page_id);
+        if word >= self.words.len() || self.words[word] & bit == 0 {
+            return false;
+        }
+        self.words[word] &= !bit;
+        self.free_count -= 1;
+        true
+    }
+
+    #[cfg(test)]
+    pub(crate) fn contains(&self, page_id: PageId) -> bool {
+        let (word, bit) = Self::locate(page_id);
+        word < self.words.len() && self.words[word] & bit != 0
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.free_count
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.free_count == 0
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.words.clear();
+        self.free_count = 0;
+    }
+
+    /// Highest free page id, or `None` when empty.
+    pub(crate) fn highest(&self) -> Option<PageId> {
+        for (idx, word) in self.words.iter().enumerate().rev() {
+            if *word != 0 {
+                let bit = BITS_PER_WORD - 1 - word.leading_zeros() as u64;
+                return Some(idx as u64 * BITS_PER_WORD + bit);
+            }
+        }
+        None
+    }
+
+    /// Removes and returns the highest free page id, or `None` when empty.
+    pub(crate) fn take_highest(&mut self) -> Option<PageId> {
+        let page_id = self.highest()?;
+        self.remove(page_id);
+        self.trim_trailing_empty_words();
+        Some(page_id)
+    }
+
+    /// Iterates free page ids in ascending order.
+    pub(crate) fn iter(&self) -> impl Iterator<Item = PageId> + '_ {
+        self.words
+            .iter()
+            .enumerate()
+            .flat_map(|(idx, &word)| WordBits {
+                word,
+                base: idx as u64 * BITS_PER_WORD,
+            })
+    }
+
+    /// Lowest start page of `count` consecutive free pages, or `None` if no
+    /// such run exists. `count` must be >= 1.
+    pub(crate) fn find_run(&self, count: usize) -> Option<PageId> {
+        debug_assert!(count >= 1);
+        let mut run_start = 0u64;
+        let mut run_len = 0usize;
+        let mut prev = 0u64;
+        for page_id in self.iter() {
+            if run_len != 0 && page_id == prev + 1 {
+                run_len += 1;
+            } else {
+                run_start = page_id;
+                run_len = 1;
+            }
+            prev = page_id;
+            if run_len >= count {
+                return Some(run_start);
+            }
+        }
+        None
+    }
+
+    /// Finds the lowest run of `count` consecutive free pages, marks them
+    /// allocated, and returns the start page. Returns `None` if no run that
+    /// long is free. `count` must be >= 1.
+    pub(crate) fn take_run(&mut self, count: usize) -> Option<PageId> {
+        let run_start = self.find_run(count)?;
+        // `find_run` just confirmed every bit in the run is set, so each
+        // `remove` succeeds and the count stays accurate.
+        for offset in 0..count as u64 {
+            self.remove(run_start + offset);
+        }
+        self.trim_trailing_empty_words();
+        Some(run_start)
+    }
+
+    /// Clears every free bit for a page id `>= limit`.
+    pub(crate) fn retain_below(&mut self, limit: PageId) {
+        let (limit_word, limit_bit) = Self::locate(limit);
+        // Mask off the high bits of the boundary word, then drop the words that
+        // sit entirely above `limit`.
+        if limit_word < self.words.len() {
+            let keep_mask = limit_bit - 1;
+            let word = &mut self.words[limit_word];
+            let dropped = (*word & !keep_mask).count_ones() as usize;
+            *word &= keep_mask;
+            self.free_count -= dropped;
+
+            for word in &mut self.words[limit_word + 1..] {
+                self.free_count -= word.count_ones() as usize;
+                *word = 0;
+            }
+            self.words.truncate(limit_word + 1);
+        }
+        self.trim_trailing_empty_words();
+    }
+
+    /// Drops trailing all-zero words so `highest`/`take_highest` never scan
+    /// dead space left behind after high pages are cleared.
+    pub(crate) fn trim_trailing_empty_words(&mut self) {
+        while matches!(self.words.last(), Some(0)) {
+            self.words.pop();
+        }
+    }
+}
+
+/// Iterator over the set bits of a single word, yielding absolute page ids.
+struct WordBits {
+    word: u64,
+    base: u64,
+}
+
+impl Iterator for WordBits {
+    type Item = PageId;
+
+    fn next(&mut self) -> Option<PageId> {
+        if self.word == 0 {
+            return None;
+        }
+        let bit = self.word.trailing_zeros() as u64;
+        self.word &= self.word - 1;
+        Some(self.base + bit)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insert_remove_and_membership() {
+        let mut bm = FreeBitmap::default();
+        assert!(bm.insert(5));
+        assert!(!bm.insert(5));
+        assert!(bm.contains(5));
+        assert_eq!(bm.len(), 1);
+        assert!(bm.remove(5));
+        assert!(!bm.remove(5));
+        assert!(!bm.contains(5));
+        assert!(bm.is_empty());
+    }
+
+    #[test]
+    fn highest_picks_largest_id() {
+        let mut bm = FreeBitmap::default();
+        for id in [3u64, 70, 64, 130] {
+            bm.insert(id);
+        }
+        assert_eq!(bm.highest(), Some(130));
+        assert_eq!(bm.take_highest(), Some(130));
+        assert_eq!(bm.highest(), Some(70));
+    }
+
+    #[test]
+    fn iter_is_ascending() {
+        let mut bm = FreeBitmap::default();
+        for id in [130u64, 3, 64, 70, 2] {
+            bm.insert(id);
+        }
+        let ids: Vec<PageId> = bm.iter().collect();
+        assert_eq!(ids, vec![2, 3, 64, 70, 130]);
+    }
+
+    #[test]
+    fn find_run_returns_lowest_contiguous_start() {
+        let mut bm = FreeBitmap::default();
+        // Runs: [2,3], [10,11,12], [20]
+        for id in [2u64, 3, 10, 11, 12, 20] {
+            bm.insert(id);
+        }
+        assert_eq!(bm.find_run(1), Some(2));
+        assert_eq!(bm.find_run(2), Some(2));
+        assert_eq!(bm.find_run(3), Some(10));
+        assert_eq!(bm.find_run(4), None);
+    }
+
+    #[test]
+    fn find_run_spans_word_boundary() {
+        let mut bm = FreeBitmap::default();
+        for id in [62u64, 63, 64, 65] {
+            bm.insert(id);
+        }
+        assert_eq!(bm.find_run(4), Some(62));
+        assert_eq!(bm.find_run(5), None);
+    }
+
+    #[test]
+    fn retain_below_clears_high_ids_and_recounts() {
+        let mut bm = FreeBitmap::default();
+        for id in [2u64, 63, 64, 65, 200] {
+            bm.insert(id);
+        }
+        bm.retain_below(64);
+        assert_eq!(bm.iter().collect::<Vec<_>>(), vec![2, 63]);
+        assert_eq!(bm.len(), 2);
+    }
+
+    #[test]
+    fn take_run_clears_lowest_run_and_updates_count() {
+        let mut bm = FreeBitmap::default();
+        for id in [2u64, 3, 10, 11, 12, 20] {
+            bm.insert(id);
+        }
+        assert_eq!(bm.take_run(3), Some(10));
+        assert_eq!(bm.len(), 3);
+        assert!(!bm.contains(10) && !bm.contains(11) && !bm.contains(12));
+        assert_eq!(bm.iter().collect::<Vec<_>>(), vec![2, 3, 20]);
+        assert_eq!(bm.take_run(3), None);
+    }
+
+    #[test]
+    fn trim_keeps_highest_scan_tight_after_high_pages_clear() {
+        let mut bm = FreeBitmap::default();
+        // 200 sits in a high word; 2 sits in word 0.
+        bm.insert(2);
+        bm.insert(200);
+        assert_eq!(bm.take_highest(), Some(200));
+        // After trimming, only word 0 remains backing the bitmap.
+        assert_eq!(bm.words.len(), 1);
+        assert_eq!(bm.highest(), Some(2));
+
+        // retain_below also trims the empty tail it leaves behind.
+        bm.insert(300);
+        bm.retain_below(64);
+        assert_eq!(bm.words.len(), 1);
+        assert_eq!(bm.iter().collect::<Vec<_>>(), vec![2]);
+    }
+}

--- a/crates/opfs-btree/src/lib.rs
+++ b/crates/opfs-btree/src/lib.rs
@@ -2,6 +2,7 @@ mod checksum;
 mod db;
 mod error;
 mod file;
+mod free_bitmap;
 mod leaf_hint;
 mod page;
 mod superblock;


### PR DESCRIPTION
## Summary

Replace the opfs-btree in-memory free-page list (a sorted `Vec` + `HashSet` pair) with a `FreeBitmap` (`Vec<u64>` + count):

- O(1) `insert`/`remove`
- word-scan `highest` / contiguous-run search
- ascending iteration with **no per-flush sort**

Every large/overflow allocation previously re-collected and sorted all free ids to find a contiguous run, and each flush re-sorted the whole set to serialize it. The on-disk freelist format (linked list of id chunks) is unchanged — this is purely the in-memory working set.

Stacked on #1037 (base: `guido/storage-benchmark`), rebased onto its **page-size-tuned SQLite baseline**.

## Benchmark difference

Median of 3 in-browser runs. The freelist change targets the **overflow / large-value write path** — `wikipedia`, whose values exceed the 4 KB overflow threshold, so updates churn multi-page extents and hit the contiguous-run allocator. That's where it moves the needle, and where opfs-btree's lead over SQLite widens:

| wikipedia phase | btree baseline | btree **+freelist** | freelist Δ | SQLite (tuned) | btree+freelist vs SQLite |
|---|---:|---:|---:|---:|---:|
| update_random | 21.0 | 13.0 | **−38%** | 170.7 | **13.1× faster** |
| mixed_70_20_10 | 14.2 | 12.3 | −13% | 80.2 | 6.5× faster |
| load | 8.4 | 7.1 | −15% | 57.9 | 8.2× faster |

`objects` (~900 B values, never overflow) doesn't exercise the extent allocator, so the freelist is **neutral** there (±2%, noise) — opfs-btree stays ~12–13× faster than SQLite on its update/mixed phases regardless. Read phases are a tie between the engines on both profiles.

Single-machine, median of 3 (±~20% per run); SQLite is the page-size-tuned baseline from #1037 (matching opfs-btree's 16 KB page).

All 73 opfs-btree tests pass with the bitmap allocator.
