### PR TITLE
perf(opfs-btree): async OPFS backend + write-cost mitigations

### DIFF
--- a/crates/jazz-tools/src/storage/opfs_btree/mod.rs
+++ b/crates/jazz-tools/src/storage/opfs_btree/mod.rs
@@ -17,7 +17,7 @@ use std::cell::RefCell;
 use opfs_btree::OpfsFile;
 #[cfg(not(target_arch = "wasm32"))]
 use opfs_btree::StdFile;
-use opfs_btree::{BTreeError, BTreeOptions, MemoryFile, OpfsBTree, SyncFile};
+use opfs_btree::{AsyncFile, BTreeError, BTreeOptions, MemoryFile, OpfsBTree};
 
 #[cfg(not(target_arch = "wasm32"))]
 mod native;
@@ -50,55 +50,65 @@ pub(super) enum AnyFile {
     Opfs(OpfsFile),
 }
 
-impl SyncFile for AnyFile {
-    fn len(&self) -> Result<u64, BTreeError> {
+impl AsyncFile for AnyFile {
+    async fn len(&self) -> Result<u64, BTreeError> {
         match self {
-            Self::Memory(file) => file.len(),
+            Self::Memory(file) => file.len().await,
             #[cfg(not(target_arch = "wasm32"))]
-            Self::Std(file) => file.len(),
+            Self::Std(file) => file.len().await,
             #[cfg(target_arch = "wasm32")]
-            Self::Opfs(file) => file.len(),
+            Self::Opfs(file) => file.len().await,
         }
     }
 
-    fn read_exact_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BTreeError> {
+    async fn read_exact_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BTreeError> {
         match self {
-            Self::Memory(file) => file.read_exact_at(offset, buf),
+            Self::Memory(file) => file.read_exact_at(offset, buf).await,
             #[cfg(not(target_arch = "wasm32"))]
-            Self::Std(file) => file.read_exact_at(offset, buf),
+            Self::Std(file) => file.read_exact_at(offset, buf).await,
             #[cfg(target_arch = "wasm32")]
-            Self::Opfs(file) => file.read_exact_at(offset, buf),
+            Self::Opfs(file) => file.read_exact_at(offset, buf).await,
         }
     }
 
-    fn write_all_at(&self, offset: u64, buf: &[u8]) -> Result<(), BTreeError> {
+    async fn write_all_at(&self, offset: u64, buf: &[u8]) -> Result<(), BTreeError> {
         match self {
-            Self::Memory(file) => file.write_all_at(offset, buf),
+            Self::Memory(file) => file.write_all_at(offset, buf).await,
             #[cfg(not(target_arch = "wasm32"))]
-            Self::Std(file) => file.write_all_at(offset, buf),
+            Self::Std(file) => file.write_all_at(offset, buf).await,
             #[cfg(target_arch = "wasm32")]
-            Self::Opfs(file) => file.write_all_at(offset, buf),
+            Self::Opfs(file) => file.write_all_at(offset, buf).await,
         }
     }
 
-    fn truncate(&self, len: u64) -> Result<(), BTreeError> {
+    async fn truncate(&self, len: u64) -> Result<(), BTreeError> {
         match self {
-            Self::Memory(file) => file.truncate(len),
+            Self::Memory(file) => file.truncate(len).await,
             #[cfg(not(target_arch = "wasm32"))]
-            Self::Std(file) => file.truncate(len),
+            Self::Std(file) => file.truncate(len).await,
             #[cfg(target_arch = "wasm32")]
-            Self::Opfs(file) => file.truncate(len),
+            Self::Opfs(file) => file.truncate(len).await,
         }
     }
 
-    fn flush(&self) -> Result<(), BTreeError> {
+    async fn flush(&self) -> Result<(), BTreeError> {
         match self {
-            Self::Memory(file) => file.flush(),
+            Self::Memory(file) => file.flush().await,
             #[cfg(not(target_arch = "wasm32"))]
-            Self::Std(file) => file.flush(),
+            Self::Std(file) => file.flush().await,
             #[cfg(target_arch = "wasm32")]
-            Self::Opfs(file) => file.flush(),
+            Self::Opfs(file) => file.flush().await,
         }
+    }
+
+    async fn open_sibling(&self, suffix: &str) -> Result<Self, BTreeError> {
+        Ok(match self {
+            Self::Memory(file) => Self::Memory(file.open_sibling(suffix).await?),
+            #[cfg(not(target_arch = "wasm32"))]
+            Self::Std(file) => Self::Std(file.open_sibling(suffix).await?),
+            #[cfg(target_arch = "wasm32")]
+            Self::Opfs(file) => Self::Opfs(file.open_sibling(suffix).await?),
+        })
     }
 }
 

--- a/crates/opfs-btree/Cargo.toml
+++ b/crates/opfs-btree/Cargo.toml
@@ -29,8 +29,11 @@ web-sys = { version = "0.3", features = [
   "FileSystemDirectoryHandle",
   "FileSystemFileHandle",
   "FileSystemGetFileOptions",
-  "FileSystemSyncAccessHandle",
-  "FileSystemReadWriteOptions",
+  "FileSystemCreateWritableOptions",
+  "FileSystemWritableFileStream",
+  "WritableStream",
+  "File",
+  "Blob",
   "DomException",
 ] }
 

--- a/crates/opfs-btree/src/db.rs
+++ b/crates/opfs-btree/src/db.rs
@@ -2,8 +2,11 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use std::borrow::Cow;
 use std::collections::BinaryHeap;
 
+use std::future::Future;
+use std::pin::Pin;
+
 use crate::BTreeError;
-use crate::file::SyncFile;
+use crate::file::AsyncFile;
 use crate::free_bitmap::FreeBitmap;
 use crate::leaf_hint::{LEAF_HINT_SLOTS, LeafHintCache};
 use crate::page::{
@@ -98,17 +101,24 @@ pub struct CheckpointState {
 }
 
 #[derive(Debug)]
-pub struct OpfsBTree<F: SyncFile> {
+pub struct OpfsBTree<F: AsyncFile> {
     file: F,
+    // The WAL lives in its own (small) file so each async `createWritable()`
+    // copy-on-write touches only the WAL, and the home file's checkpoint copies
+    // never carry an appended WAL tail. WAL pages are addressed from page 2 in
+    // this file (pages 0/1 are reserved to mirror the home-file layout).
+    wal_file: F,
     options: BTreeOptions,
     active_slot: SuperblockSlot,
     active: Superblock,
     root_page_id: Option<PageId>,
     total_pages: u64,
-    // Pages >= active.total_pages are WAL tail pages, not home locations.
-    // Page ids in wal_pages have newer bytes only in the cache/WAL and must
-    // not be evicted until a checkpoint writes them to their home locations.
+    // Home pages physically present in `file`. Page ids in wal_pages have newer
+    // bytes only in the cache/WAL and must not be evicted until a checkpoint
+    // writes them to their home locations.
     persisted_pages: u64,
+    // Pages physically present in `wal_file` (its length in pages).
+    wal_persisted_pages: u64,
     pages: OpfsMap<PageId, Vec<u8>>,
     blob_pages: OpfsSet<PageId>,
     page_access_epoch: OpfsMap<PageId, u64>,
@@ -137,13 +147,28 @@ enum StagedValue {
     },
 }
 
-impl<F: SyncFile> OpfsBTree<F> {
+impl<F: AsyncFile> OpfsBTree<F> {
+    /// Native sync facade over the async [`open_inner`]: the in-memory and
+    /// std-file backends never truly pend, so `block_on` returns immediately.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn open(file: F, options: BTreeOptions) -> Result<Self, BTreeError> {
+        crate::file::block_on(Self::open_inner(file, options))
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub async fn open(file: F, options: BTreeOptions) -> Result<Self, BTreeError> {
+        Self::open_inner(file, options).await
+    }
+
+    async fn open_inner(file: F, options: BTreeOptions) -> Result<Self, BTreeError> {
         options.validate()?;
 
-        let a = read_slot(&file, SuperblockSlot::A, options.page_size)?;
-        let b = read_slot(&file, SuperblockSlot::B, options.page_size)?;
-        let file_len = file.len()?;
+        let wal_file = file.open_sibling(".wal").await?;
+
+        let a = read_slot(&file, SuperblockSlot::A, options.page_size).await?;
+        let b = read_slot(&file, SuperblockSlot::B, options.page_size).await?;
+        let file_len = file.len().await?;
+        let wal_persisted_pages = wal_file.len().await? / options.page_size as u64;
 
         let persisted_pages = file_len / options.page_size as u64;
         let (active_slot, active) = choose_active(a, b).unwrap_or((
@@ -153,12 +178,14 @@ impl<F: SyncFile> OpfsBTree<F> {
 
         let mut tree = Self {
             file,
+            wal_file,
             options,
             active_slot,
             active,
             root_page_id: None,
             total_pages: 2,
             persisted_pages,
+            wal_persisted_pages,
             pages: OpfsMap::default(),
             blob_pages: OpfsSet::default(),
             page_access_epoch: OpfsMap::default(),
@@ -177,11 +204,16 @@ impl<F: SyncFile> OpfsBTree<F> {
                     "no valid superblock found in non-empty file".to_string(),
                 ));
             }
+            // A fresh home file must start with an empty WAL; a stale WAL left
+            // over from a crashed run would not match this new store.
+            tree.wal_file.truncate(0).await?;
+            tree.wal_file.flush().await?;
+            tree.wal_persisted_pages = 0;
             let bootstrap =
                 Superblock::new(options.page_size as u32, BOOTSTRAP_GENERATION, 0, 0, 2);
-            write_slot(&tree.file, SuperblockSlot::A, options.page_size, bootstrap)?;
-            write_slot(&tree.file, SuperblockSlot::B, options.page_size, bootstrap)?;
-            tree.file.flush()?;
+            write_slot(&tree.file, SuperblockSlot::A, options.page_size, bootstrap).await?;
+            write_slot(&tree.file, SuperblockSlot::B, options.page_size, bootstrap).await?;
+            tree.file.flush().await?;
             tree.active_slot = SuperblockSlot::A;
             tree.active = bootstrap;
             tree.total_pages = 2;
@@ -192,7 +224,7 @@ impl<F: SyncFile> OpfsBTree<F> {
         tree.total_pages = tree.active.total_pages.max(2);
         if tree.active.root_page_id != 0 {
             tree.root_page_id = Some(tree.active.root_page_id);
-            tree.ensure_page_loaded(tree.active.root_page_id)?;
+            tree.ensure_page_loaded(tree.active.root_page_id).await?;
             match tree.page_kind(tree.active.root_page_id)? {
                 PageKind::Leaf | PageKind::Internal => {}
                 PageKind::Overflow | PageKind::Freelist => {
@@ -204,26 +236,37 @@ impl<F: SyncFile> OpfsBTree<F> {
             }
         }
         if tree.active.freelist_head_page_id != 0 {
-            tree.load_freelist_from_disk(tree.active.freelist_head_page_id)?;
+            tree.load_freelist_from_disk(tree.active.freelist_head_page_id)
+                .await?;
         }
         tree.sanitize_free_pages();
         // Loading the persisted freelist is not a modification; only replayed
         // WAL commits or later alloc/free calls should mark it dirty.
         tree.freelist_dirty = false;
-        tree.replay_wal()?;
+        tree.replay_wal().await?;
 
         Ok(tree)
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn get(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>, BTreeError> {
+        crate::file::block_on(self.get_inner(key))
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub async fn get(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>, BTreeError> {
+        self.get_inner(key).await
+    }
+
+    async fn get_inner(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>, BTreeError> {
         let _span = tracing::trace_span!("OpfsBTree::get", key_len = key.len()).entered();
-        let leaf_page_id = match self.leaf_for_key(key)? {
+        let leaf_page_id = match self.leaf_for_key(key).await? {
             Some(id) => id,
             None => return Ok(None),
         };
 
         let page_size = self.options.page_size;
-        let raw = self.ensure_page_loaded(leaf_page_id)?;
+        let raw = self.ensure_page_loaded(leaf_page_id).await?;
         let value_cell = raw_leaf_find_value(raw, page_size, key)?;
         match value_cell {
             None => Ok(None),
@@ -233,11 +276,22 @@ impl<F: SyncFile> OpfsBTree<F> {
                 total_len,
             }) => self
                 .read_overflow_value(head_page_id, total_len as usize)
+                .await
                 .map(Some),
         }
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn put(&mut self, key: &[u8], value: &[u8]) -> Result<(), BTreeError> {
+        crate::file::block_on(self.put_inner(key, value))
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub async fn put(&mut self, key: &[u8], value: &[u8]) -> Result<(), BTreeError> {
+        self.put_inner(key, value).await
+    }
+
+    async fn put_inner(&mut self, key: &[u8], value: &[u8]) -> Result<(), BTreeError> {
         let _span = tracing::trace_span!(
             "OpfsBTree::put",
             key_len = key.len(),
@@ -292,7 +346,7 @@ impl<F: SyncFile> OpfsBTree<F> {
         }
 
         let root_page_id = self.root_page_id.expect("root must exist");
-        if let Some(split) = self.insert_recursive(root_page_id, key, value)? {
+        if let Some(split) = self.insert_recursive(root_page_id, key, value).await? {
             let new_root_page_id = self.alloc_page();
             let new_root = Page::Internal {
                 keys: vec![split.separator],
@@ -306,14 +360,24 @@ impl<F: SyncFile> OpfsBTree<F> {
         Ok(())
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn delete(&mut self, key: &[u8]) -> Result<(), BTreeError> {
+        crate::file::block_on(self.delete_inner(key))
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub async fn delete(&mut self, key: &[u8]) -> Result<(), BTreeError> {
+        self.delete_inner(key).await
+    }
+
+    async fn delete_inner(&mut self, key: &[u8]) -> Result<(), BTreeError> {
         let _span = tracing::trace_span!("OpfsBTree::delete", key_len = key.len()).entered();
         let root_page_id = match self.root_page_id {
             Some(id) => id,
             None => return Ok(()),
         };
 
-        let removed = self.delete_recursive(root_page_id, key)?;
+        let removed = self.delete_recursive(root_page_id, key).await?;
         if !removed {
             return Ok(());
         }
@@ -339,7 +403,27 @@ impl<F: SyncFile> OpfsBTree<F> {
         Ok(())
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn range(
+        &mut self,
+        start: &[u8],
+        end: &[u8],
+        limit: usize,
+    ) -> Result<Vec<KvPair>, BTreeError> {
+        crate::file::block_on(self.range_inner(start, end, limit))
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub async fn range(
+        &mut self,
+        start: &[u8],
+        end: &[u8],
+        limit: usize,
+    ) -> Result<Vec<KvPair>, BTreeError> {
+        self.range_inner(start, end, limit).await
+    }
+
+    async fn range_inner(
         &mut self,
         start: &[u8],
         end: &[u8],
@@ -352,7 +436,7 @@ impl<F: SyncFile> OpfsBTree<F> {
 
         let page_size = self.options.page_size;
         let mut out = Vec::with_capacity(limit.min(1024));
-        let mut current = self.leaf_for_range_start(start)?;
+        let mut current = self.leaf_for_range_start(start).await?;
         let mut visited = OpfsSet::default();
         let mut staged: Vec<(Vec<u8>, StagedValue)> = Vec::new();
         let mut last_scanned = None;
@@ -365,7 +449,7 @@ impl<F: SyncFile> OpfsBTree<F> {
             }
 
             let remaining = limit.saturating_sub(out.len());
-            let raw = self.ensure_page_loaded(page_id)?;
+            let raw = self.ensure_page_loaded(page_id).await?;
             staged.clear();
             let next = raw_leaf_scan(raw, page_size, start, end, remaining, |key, value| {
                 let staged_value = match value {
@@ -388,7 +472,7 @@ impl<F: SyncFile> OpfsBTree<F> {
                     StagedValue::Overflow {
                         head_page_id,
                         total_len,
-                    } => self.read_overflow_value(head_page_id, total_len)?,
+                    } => self.read_overflow_value(head_page_id, total_len).await?,
                 };
                 out.push((key, value));
                 if out.len() == limit {
@@ -407,7 +491,17 @@ impl<F: SyncFile> OpfsBTree<F> {
         Ok(out)
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn checkpoint(&mut self) -> Result<(), BTreeError> {
+        crate::file::block_on(self.checkpoint_inner())
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub async fn checkpoint(&mut self) -> Result<(), BTreeError> {
+        self.checkpoint_inner().await
+    }
+
+    async fn checkpoint_inner(&mut self) -> Result<(), BTreeError> {
         let _span = tracing::debug_span!(
             "OpfsBTree::checkpoint",
             dirty_pages = self.dirty_pages.len(),
@@ -418,14 +512,16 @@ impl<F: SyncFile> OpfsBTree<F> {
             self.dirty_pages.union(&self.wal_pages).copied().collect();
         dirty_page_ids.sort_unstable();
         let (freelist_head_page_id, freelist_pages) = self.build_freelist_pages()?;
-        self.write_pages_to_disk(&dirty_page_ids, &freelist_pages)?;
-        self.file.flush()?;
+        self.write_pages_to_disk(&dirty_page_ids, &freelist_pages)
+            .await?;
+        self.file.flush().await?;
         self.checkpoint_superblock(
             self.root_page_id.unwrap_or(0),
             freelist_head_page_id,
             self.total_pages,
-        )?;
-        self.truncate_wal_tail()?;
+        )
+        .await?;
+        self.truncate_wal_tail().await?;
         self.dirty_pages.clear();
         self.wal_pages.clear();
         self.freelist_dirty = false;
@@ -433,7 +529,17 @@ impl<F: SyncFile> OpfsBTree<F> {
         Ok(())
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn flush_wal(&mut self) -> Result<(), BTreeError> {
+        crate::file::block_on(self.flush_wal_inner())
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub async fn flush_wal(&mut self) -> Result<(), BTreeError> {
+        self.flush_wal_inner().await
+    }
+
+    async fn flush_wal_inner(&mut self) -> Result<(), BTreeError> {
         let _span = tracing::debug_span!(
             "OpfsBTree::flush_wal",
             dirty_pages = self.dirty_pages.len(),
@@ -469,9 +575,9 @@ impl<F: SyncFile> OpfsBTree<F> {
                     raw: frame.raw.as_ref(),
                 })
                 .collect();
-            let start_page_id = self.persisted_pages.max(2);
+            let start_page_id = self.wal_persisted_pages.max(2);
             let pages_written = wal::append_commit(
-                &self.file,
+                &self.wal_file,
                 self.options.page_size,
                 start_page_id,
                 WalHeader::new(
@@ -481,13 +587,14 @@ impl<F: SyncFile> OpfsBTree<F> {
                     self.total_pages,
                 ),
                 &wal_frames,
-            )?;
+            )
+            .await?;
             start_page_id
                 .checked_add(pages_written)
                 .ok_or_else(|| BTreeError::Io("WAL persisted pages overflow".to_string()))?
         };
-        self.persisted_pages = persisted_pages;
-        self.file.flush()?;
+        self.wal_persisted_pages = persisted_pages;
+        self.wal_file.flush().await?;
 
         self.wal_pages.extend(dirty_page_ids);
         self.dirty_pages.clear();
@@ -519,221 +626,233 @@ impl<F: SyncFile> OpfsBTree<F> {
         self.file
     }
 
-    fn insert_recursive(
-        &mut self,
+    // Async recursion needs a boxed future, otherwise the compiler would have
+    // to build an infinitely sized `Future` type.
+    fn insert_recursive<'a>(
+        &'a mut self,
         page_id: PageId,
-        key: &[u8],
-        value: &[u8],
-    ) -> Result<Option<SplitResult>, BTreeError> {
-        let page_size = self.options.page_size;
-        let step = {
-            let raw = self.ensure_page_loaded(page_id)?;
-            raw_descend_step(raw, page_size, key)?
-        };
+        key: &'a [u8],
+        value: &'a [u8],
+    ) -> Pin<Box<dyn Future<Output = Result<Option<SplitResult>, BTreeError>> + 'a>> {
+        Box::pin(async move {
+            let page_size = self.options.page_size;
+            let step = {
+                let raw = self.ensure_page_loaded(page_id).await?;
+                raw_descend_step(raw, page_size, key)?
+            };
 
-        match step {
-            RawDescendStep::Leaf => {
-                let (new_value, reused_overflow_head) =
-                    if value.len() <= self.options.overflow_threshold {
-                        (ValueCell::Inline(value.to_vec()), None)
-                    } else if value.len() < OVERFLOW_REUSE_MIN_BYTES {
-                        (self.build_value_cell(value)?, None)
-                    } else {
-                        let existing_overflow = {
-                            let raw = self.raw_page_bytes(page_id)?;
-                            match raw_leaf_find_value(raw, self.options.page_size, key)? {
-                                Some(ValueCellRef::Overflow {
-                                    head_page_id,
-                                    total_len,
-                                }) => Some(OverflowRef {
-                                    head_page_id,
-                                    total_len,
-                                }),
-                                _ => None,
-                            }
+            match step {
+                RawDescendStep::Leaf => {
+                    let (new_value, reused_overflow_head) =
+                        if value.len() <= self.options.overflow_threshold {
+                            (ValueCell::Inline(value.to_vec()), None)
+                        } else if value.len() < OVERFLOW_REUSE_MIN_BYTES {
+                            (self.build_value_cell(value)?, None)
+                        } else {
+                            let existing_overflow = {
+                                let raw = self.raw_page_bytes(page_id)?;
+                                match raw_leaf_find_value(raw, self.options.page_size, key)? {
+                                    Some(ValueCellRef::Overflow {
+                                        head_page_id,
+                                        total_len,
+                                    }) => Some(OverflowRef {
+                                        head_page_id,
+                                        total_len,
+                                    }),
+                                    _ => None,
+                                }
+                            };
+                            self.build_value_cell_for_existing(existing_overflow, value)?
                         };
-                        self.build_value_cell_for_existing(existing_overflow, value)?
+                    let upsert = {
+                        let raw = self.pages.get_mut(&page_id).ok_or_else(|| {
+                            BTreeError::Corrupt(format!("page {} missing during insert", page_id))
+                        })?;
+                        raw_leaf_upsert_in_place(raw, self.options.page_size, key, &new_value)?
                     };
-                let upsert = {
-                    let raw = self.pages.get_mut(&page_id).ok_or_else(|| {
+
+                    match upsert {
+                        RawLeafUpsertResult::Inserted => {
+                            self.mark_dirty_loaded_page(page_id);
+                            self.remember_tail_leaf_hint(page_id)?;
+                            return Ok(None);
+                        }
+                        RawLeafUpsertResult::Updated { old_overflow } => {
+                            self.mark_dirty_loaded_page(page_id);
+                            self.remember_tail_leaf_hint(page_id)?;
+                            if let Some(old_overflow) = old_overflow
+                                && Some(old_overflow.head_page_id) != reused_overflow_head
+                            {
+                                self.free_overflow_extent(
+                                    old_overflow.head_page_id,
+                                    old_overflow.total_len as usize,
+                                )?;
+                            }
+                            return Ok(None);
+                        }
+                        RawLeafUpsertResult::NeedSplit => {}
+                    }
+
+                    let page_raw = self.pages.get(&page_id).cloned().ok_or_else(|| {
                         BTreeError::Corrupt(format!("page {} missing during insert", page_id))
                     })?;
-                    raw_leaf_upsert_in_place(raw, self.options.page_size, key, &new_value)?
-                };
+                    let page = decode_page(&page_raw, self.options.page_size)?;
+                    let Page::Leaf { mut entries, next } = page else {
+                        return Err(BTreeError::Corrupt(format!(
+                            "expected leaf page {}, found non-leaf during split fallback",
+                            page_id
+                        )));
+                    };
 
-                match upsert {
-                    RawLeafUpsertResult::Inserted => {
-                        self.mark_dirty_loaded_page(page_id);
-                        self.remember_tail_leaf_hint(page_id)?;
+                    match entries.binary_search_by(|(k, _)| k.as_slice().cmp(key)) {
+                        Ok(idx) => {
+                            let old_value = std::mem::replace(&mut entries[idx].1, new_value);
+                            match old_value {
+                                ValueCell::Overflow { head_page_id, .. }
+                                    if Some(head_page_id) == reused_overflow_head => {}
+                                other => self.free_value_cell(other)?,
+                            }
+                        }
+                        Err(idx) => entries.insert(idx, (key.to_vec(), new_value)),
+                    }
+
+                    let candidate = Page::Leaf { entries, next };
+                    if page_fits(&candidate, self.options.page_size)? {
+                        self.set_dirty_page(page_id, candidate)?;
                         return Ok(None);
                     }
-                    RawLeafUpsertResult::Updated { old_overflow } => {
-                        self.mark_dirty_loaded_page(page_id);
-                        self.remember_tail_leaf_hint(page_id)?;
-                        if let Some(old_overflow) = old_overflow
-                            && Some(old_overflow.head_page_id) != reused_overflow_head
-                        {
-                            self.free_overflow_extent(
-                                old_overflow.head_page_id,
-                                old_overflow.total_len as usize,
-                            )?;
-                        }
+                    let Page::Leaf { entries, next } = candidate else {
+                        unreachable!("candidate is constructed as a leaf above")
+                    };
+
+                    if entries.len() < 2 {
+                        return Err(BTreeError::InvalidOptions(
+                            "single leaf entry exceeds page size".to_string(),
+                        ));
+                    }
+
+                    let (split_key, mut left_page, right_page) =
+                        choose_leaf_split(entries, next, self.options.page_size)?;
+                    let right_page_id = self.alloc_page_near(page_id);
+                    if let Page::Leaf { next, .. } = &mut left_page {
+                        *next = Some(right_page_id);
+                    }
+
+                    self.set_dirty_page(page_id, left_page)?;
+                    self.set_dirty_page(right_page_id, right_page)?;
+                    Ok(Some(SplitResult {
+                        separator: split_key,
+                        right_page_id,
+                    }))
+                }
+                RawDescendStep::Child(child_page_id) => {
+                    let split = self.insert_recursive(child_page_id, key, value).await?;
+                    let Some(split) = split else {
+                        return Ok(None);
+                    };
+
+                    // Split path: recursion may have evicted this clean parent, so
+                    // reload before decoding for the structural update.
+                    let page = {
+                        let raw = self.ensure_page_loaded(page_id).await?;
+                        decode_page(raw, page_size)?
+                    };
+                    let Page::Internal {
+                        mut keys,
+                        mut children,
+                    } = page
+                    else {
+                        return Err(BTreeError::Corrupt(format!(
+                            "expected internal page {}, found non-internal during insert",
+                            page_id
+                        )));
+                    };
+                    let child_idx = child_index(&keys, key);
+
+                    keys.insert(child_idx, split.separator);
+                    children.insert(child_idx + 1, split.right_page_id);
+
+                    let candidate = Page::Internal { keys, children };
+                    if page_fits(&candidate, self.options.page_size)? {
+                        self.set_dirty_page(page_id, candidate)?;
                         return Ok(None);
                     }
-                    RawLeafUpsertResult::NeedSplit => {}
-                }
+                    let Page::Internal { keys, children } = candidate else {
+                        unreachable!("candidate is constructed as an internal page above")
+                    };
 
-                let page_raw = self.pages.get(&page_id).cloned().ok_or_else(|| {
-                    BTreeError::Corrupt(format!("page {} missing during insert", page_id))
-                })?;
-                let page = decode_page(&page_raw, self.options.page_size)?;
-                let Page::Leaf { mut entries, next } = page else {
-                    return Err(BTreeError::Corrupt(format!(
-                        "expected leaf page {}, found non-leaf during split fallback",
-                        page_id
-                    )));
-                };
-
-                match entries.binary_search_by(|(k, _)| k.as_slice().cmp(key)) {
-                    Ok(idx) => {
-                        let old_value = std::mem::replace(&mut entries[idx].1, new_value);
-                        match old_value {
-                            ValueCell::Overflow { head_page_id, .. }
-                                if Some(head_page_id) == reused_overflow_head => {}
-                            other => self.free_value_cell(other)?,
-                        }
+                    if keys.len() < 2 {
+                        return Err(BTreeError::InvalidOptions(
+                            "internal split requires at least two keys".to_string(),
+                        ));
                     }
-                    Err(idx) => entries.insert(idx, (key.to_vec(), new_value)),
-                }
 
-                let candidate = Page::Leaf { entries, next };
-                if page_fits(&candidate, self.options.page_size)? {
-                    self.set_dirty_page(page_id, candidate)?;
-                    return Ok(None);
-                }
-                let Page::Leaf { entries, next } = candidate else {
-                    unreachable!("candidate is constructed as a leaf above")
-                };
+                    let (promoted, left_page, right_page) =
+                        choose_internal_split(keys, children, self.options.page_size)?;
 
-                if entries.len() < 2 {
-                    return Err(BTreeError::InvalidOptions(
-                        "single leaf entry exceeds page size".to_string(),
-                    ));
-                }
+                    let right_page_id = self.alloc_page_near(page_id);
+                    self.set_dirty_page(page_id, left_page)?;
+                    self.set_dirty_page(right_page_id, right_page)?;
 
-                let (split_key, mut left_page, right_page) =
-                    choose_leaf_split(entries, next, self.options.page_size)?;
-                let right_page_id = self.alloc_page_near(page_id);
-                if let Page::Leaf { next, .. } = &mut left_page {
-                    *next = Some(right_page_id);
+                    Ok(Some(SplitResult {
+                        separator: promoted,
+                        right_page_id,
+                    }))
                 }
-
-                self.set_dirty_page(page_id, left_page)?;
-                self.set_dirty_page(right_page_id, right_page)?;
-                Ok(Some(SplitResult {
-                    separator: split_key,
-                    right_page_id,
-                }))
+                RawDescendStep::Other(kind) => Err(BTreeError::Corrupt(format!(
+                    "insert reached {:?} page {}",
+                    kind, page_id
+                ))),
             }
-            RawDescendStep::Child(child_page_id) => {
-                let split = self.insert_recursive(child_page_id, key, value)?;
-                let Some(split) = split else {
-                    return Ok(None);
-                };
-
-                // Split path: recursion may have evicted this clean parent, so
-                // reload before decoding for the structural update.
-                let page = {
-                    let raw = self.ensure_page_loaded(page_id)?;
-                    decode_page(raw, page_size)?
-                };
-                let Page::Internal {
-                    mut keys,
-                    mut children,
-                } = page
-                else {
-                    return Err(BTreeError::Corrupt(format!(
-                        "expected internal page {}, found non-internal during insert",
-                        page_id
-                    )));
-                };
-                let child_idx = child_index(&keys, key);
-
-                keys.insert(child_idx, split.separator);
-                children.insert(child_idx + 1, split.right_page_id);
-
-                let candidate = Page::Internal { keys, children };
-                if page_fits(&candidate, self.options.page_size)? {
-                    self.set_dirty_page(page_id, candidate)?;
-                    return Ok(None);
-                }
-                let Page::Internal { keys, children } = candidate else {
-                    unreachable!("candidate is constructed as an internal page above")
-                };
-
-                if keys.len() < 2 {
-                    return Err(BTreeError::InvalidOptions(
-                        "internal split requires at least two keys".to_string(),
-                    ));
-                }
-
-                let (promoted, left_page, right_page) =
-                    choose_internal_split(keys, children, self.options.page_size)?;
-
-                let right_page_id = self.alloc_page_near(page_id);
-                self.set_dirty_page(page_id, left_page)?;
-                self.set_dirty_page(right_page_id, right_page)?;
-
-                Ok(Some(SplitResult {
-                    separator: promoted,
-                    right_page_id,
-                }))
-            }
-            RawDescendStep::Other(kind) => Err(BTreeError::Corrupt(format!(
-                "insert reached {:?} page {}",
-                kind, page_id
-            ))),
-        }
+        })
     }
 
-    fn delete_recursive(&mut self, page_id: PageId, key: &[u8]) -> Result<bool, BTreeError> {
-        let page_size = self.options.page_size;
-        let step = {
-            let raw = self.ensure_page_loaded(page_id)?;
-            raw_descend_step(raw, page_size, key)?
-        };
+    fn delete_recursive<'a>(
+        &'a mut self,
+        page_id: PageId,
+        key: &'a [u8],
+    ) -> Pin<Box<dyn Future<Output = Result<bool, BTreeError>> + 'a>> {
+        Box::pin(async move {
+            let page_size = self.options.page_size;
+            let step = {
+                let raw = self.ensure_page_loaded(page_id).await?;
+                raw_descend_step(raw, page_size, key)?
+            };
 
-        match step {
-            RawDescendStep::Leaf => {
-                let deleted = {
-                    let raw = self.pages.get_mut(&page_id).ok_or_else(|| {
-                        BTreeError::Corrupt(format!("page {} missing during delete", page_id))
-                    })?;
-                    raw_leaf_delete_in_place(raw, self.options.page_size, key)?
-                };
-                match deleted {
-                    RawLeafDeleteResult::NotFound => Ok(false),
-                    RawLeafDeleteResult::Deleted { old_overflow, .. } => {
-                        self.mark_dirty_loaded_page(page_id);
-                        if let Some(old_overflow) = old_overflow {
-                            self.free_overflow_extent(
-                                old_overflow.head_page_id,
-                                old_overflow.total_len as usize,
-                            )?;
+            match step {
+                RawDescendStep::Leaf => {
+                    let deleted = {
+                        let raw = self.pages.get_mut(&page_id).ok_or_else(|| {
+                            BTreeError::Corrupt(format!("page {} missing during delete", page_id))
+                        })?;
+                        raw_leaf_delete_in_place(raw, self.options.page_size, key)?
+                    };
+                    match deleted {
+                        RawLeafDeleteResult::NotFound => Ok(false),
+                        RawLeafDeleteResult::Deleted { old_overflow, .. } => {
+                            self.mark_dirty_loaded_page(page_id);
+                            if let Some(old_overflow) = old_overflow {
+                                self.free_overflow_extent(
+                                    old_overflow.head_page_id,
+                                    old_overflow.total_len as usize,
+                                )?;
+                            }
+                            Ok(true)
                         }
-                        Ok(true)
                     }
                 }
+                RawDescendStep::Child(child_page_id) => {
+                    self.delete_recursive(child_page_id, key).await
+                }
+                RawDescendStep::Other(kind) => Err(BTreeError::Corrupt(format!(
+                    "delete reached {:?} page {}",
+                    kind, page_id
+                ))),
             }
-            RawDescendStep::Child(child_page_id) => self.delete_recursive(child_page_id, key),
-            RawDescendStep::Other(kind) => Err(BTreeError::Corrupt(format!(
-                "delete reached {:?} page {}",
-                kind, page_id
-            ))),
-        }
+        })
     }
 
-    fn read_overflow_value(
+    async fn read_overflow_value(
         &mut self,
         head_page_id: PageId,
         expected_len: usize,
@@ -744,11 +863,14 @@ impl<F: SyncFile> OpfsBTree<F> {
         if expected_len >= OVERFLOW_DIRECT_READ_MIN_BYTES
             && !self.overflow_extent_has_dirty_pages(head_page_id, page_count)?
         {
-            return self.read_overflow_extent_direct(head_page_id, expected_len, page_count);
+            return self
+                .read_overflow_extent_direct(head_page_id, expected_len, page_count)
+                .await;
         }
 
         let mut out = Vec::with_capacity(expected_len);
-        self.ensure_overflow_extent_loaded(head_page_id, page_count)?;
+        self.ensure_overflow_extent_loaded(head_page_id, page_count)
+            .await?;
 
         for idx in 0..page_count {
             let page_id = head_page_id.checked_add(idx as u64).ok_or_else(|| {
@@ -782,7 +904,7 @@ impl<F: SyncFile> OpfsBTree<F> {
         Ok(out)
     }
 
-    fn read_overflow_extent_direct(
+    async fn read_overflow_extent_direct(
         &self,
         head_page_id: PageId,
         expected_len: usize,
@@ -815,7 +937,7 @@ impl<F: SyncFile> OpfsBTree<F> {
             .ok_or_else(|| BTreeError::Corrupt("page offset overflow".to_string()))?;
 
         let mut raw = vec![0u8; run_bytes];
-        self.file.read_exact_at(offset, &mut raw)?;
+        self.file.read_exact_at(offset, &mut raw).await?;
 
         let mut out = Vec::with_capacity(expected_len);
         for i in 0..page_count {
@@ -883,7 +1005,7 @@ impl<F: SyncFile> OpfsBTree<F> {
         Ok(())
     }
 
-    fn ensure_overflow_extent_loaded(
+    async fn ensure_overflow_extent_loaded(
         &mut self,
         head_page_id: PageId,
         page_count: usize,
@@ -920,7 +1042,7 @@ impl<F: SyncFile> OpfsBTree<F> {
             .ok_or_else(|| BTreeError::Corrupt("page offset overflow".to_string()))?;
 
         let mut raw = vec![0u8; run_bytes];
-        self.file.read_exact_at(offset, &mut raw)?;
+        self.file.read_exact_at(offset, &mut raw).await?;
 
         for i in 0..load_pages {
             let page_id = start_page_id.checked_add(i as u64).ok_or_else(|| {
@@ -1037,7 +1159,7 @@ impl<F: SyncFile> OpfsBTree<F> {
         })
     }
 
-    fn find_leaf_page_id(&mut self, key: &[u8]) -> Result<Option<PageId>, BTreeError> {
+    async fn find_leaf_page_id(&mut self, key: &[u8]) -> Result<Option<PageId>, BTreeError> {
         let mut current = match self.root_page_id {
             Some(id) => id,
             None => return Ok(None),
@@ -1045,7 +1167,7 @@ impl<F: SyncFile> OpfsBTree<F> {
 
         let page_size = self.options.page_size;
         loop {
-            let raw = self.ensure_page_loaded(current)?;
+            let raw = self.ensure_page_loaded(current).await?;
             match raw_descend_step(raw, page_size, key)? {
                 RawDescendStep::Leaf => return Ok(Some(current)),
                 RawDescendStep::Child(child) => current = child,
@@ -1093,11 +1215,11 @@ impl<F: SyncFile> OpfsBTree<F> {
 
     /// Resolves the leaf for `key`, trying the hint slots before paying for a
     /// full root-to-leaf descent.
-    fn leaf_for_key(&mut self, key: &[u8]) -> Result<Option<PageId>, BTreeError> {
+    async fn leaf_for_key(&mut self, key: &[u8]) -> Result<Option<PageId>, BTreeError> {
         if let Some(page_id) = self.hinted_leaf_for_key(key, false)? {
             return Ok(Some(page_id));
         }
-        let leaf = self.find_leaf_page_id(key)?;
+        let leaf = self.find_leaf_page_id(key).await?;
         if let Some(page_id) = leaf {
             self.remember_leaf_hint(page_id)?;
         }
@@ -1109,7 +1231,7 @@ impl<F: SyncFile> OpfsBTree<F> {
     /// so when `start` falls in the empty gap between a hinted leaf and its
     /// cached successor, the successor is provably the right starting leaf and
     /// the descent can be skipped.
-    fn leaf_for_range_start(&mut self, start: &[u8]) -> Result<Option<PageId>, BTreeError> {
+    async fn leaf_for_range_start(&mut self, start: &[u8]) -> Result<Option<PageId>, BTreeError> {
         if let Some(page_id) = self.hinted_leaf_for_key(start, true)? {
             return Ok(Some(page_id));
         }
@@ -1146,7 +1268,7 @@ impl<F: SyncFile> OpfsBTree<F> {
                 return Ok(Some(next_id));
             }
         }
-        let leaf = self.find_leaf_page_id(start)?;
+        let leaf = self.find_leaf_page_id(start).await?;
         if let Some(page_id) = leaf {
             self.remember_leaf_hint(page_id)?;
         }
@@ -1182,11 +1304,11 @@ impl<F: SyncFile> OpfsBTree<F> {
         Ok(())
     }
 
-    fn ensure_page_loaded(&mut self, page_id: PageId) -> Result<&[u8], BTreeError> {
+    async fn ensure_page_loaded(&mut self, page_id: PageId) -> Result<&[u8], BTreeError> {
         if self.pages.contains_key(&page_id) {
             self.touch_page(page_id);
         } else {
-            self.read_page_run_from_disk(page_id)?;
+            self.read_page_run_from_disk(page_id).await?;
         }
         match self.pages.get(&page_id) {
             Some(raw) => Ok(raw),
@@ -1212,7 +1334,7 @@ impl<F: SyncFile> OpfsBTree<F> {
         }
     }
 
-    fn load_freelist_from_disk(&mut self, head_page_id: PageId) -> Result<(), BTreeError> {
+    async fn load_freelist_from_disk(&mut self, head_page_id: PageId) -> Result<(), BTreeError> {
         let mut current = head_page_id;
         let mut seen = OpfsSet::default();
 
@@ -1223,7 +1345,7 @@ impl<F: SyncFile> OpfsBTree<F> {
                 ));
             }
 
-            let raw = self.read_page_raw_from_disk(current)?;
+            let raw = self.read_page_raw_from_disk(current).await?;
             let (ids, next) = raw_freelist_page(&raw, self.options.page_size)?;
             self.freelist_meta_pages.push(current);
             for id in ids {
@@ -1235,7 +1357,7 @@ impl<F: SyncFile> OpfsBTree<F> {
         Ok(())
     }
 
-    fn read_page_raw_from_disk(&self, page_id: PageId) -> Result<Vec<u8>, BTreeError> {
+    async fn read_page_raw_from_disk(&self, page_id: PageId) -> Result<Vec<u8>, BTreeError> {
         if page_id < 2 || page_id >= self.total_pages {
             return Err(BTreeError::Corrupt(format!(
                 "page id {} out of bounds for total_pages {}",
@@ -1248,14 +1370,14 @@ impl<F: SyncFile> OpfsBTree<F> {
             .ok_or_else(|| BTreeError::Corrupt("page offset overflow".to_string()))?;
 
         let mut raw = vec![0u8; self.options.page_size];
-        self.file.read_exact_at(offset, &mut raw)?;
+        self.file.read_exact_at(offset, &mut raw).await?;
         let _ = validate_page(&raw, self.options.page_size)?;
         Ok(raw)
     }
 
-    fn read_page_run_from_disk(&mut self, page_id: PageId) -> Result<(), BTreeError> {
+    async fn read_page_run_from_disk(&mut self, page_id: PageId) -> Result<(), BTreeError> {
         if self.options.read_coalesce_pages <= 1 {
-            let raw = self.read_page_raw_from_disk(page_id)?;
+            let raw = self.read_page_raw_from_disk(page_id).await?;
             self.cache_loaded_raw_page(page_id, raw);
             return Ok(());
         }
@@ -1285,7 +1407,7 @@ impl<F: SyncFile> OpfsBTree<F> {
             .ok_or_else(|| BTreeError::Corrupt("page offset overflow".to_string()))?;
 
         let mut raw = vec![0u8; run_bytes];
-        self.file.read_exact_at(offset, &mut raw)?;
+        self.file.read_exact_at(offset, &mut raw).await?;
         let allowance = self.max_cached_pages() / 4;
 
         for i in 0..run_pages {
@@ -1315,7 +1437,7 @@ impl<F: SyncFile> OpfsBTree<F> {
 
     // Checkpoint path: copy the latest dirty/WAL-pinned page bytes back to
     // their home locations, so the checkpointed region becomes current.
-    fn write_pages_to_disk(
+    async fn write_pages_to_disk(
         &mut self,
         dirty_page_ids: &[PageId],
         freelist_pages: &[(PageId, Page)],
@@ -1340,7 +1462,7 @@ impl<F: SyncFile> OpfsBTree<F> {
             .checked_mul(self.options.page_size as u64)
             .ok_or_else(|| BTreeError::Io("file size overflow".to_string()))?;
         if self.persisted_pages < self.total_pages {
-            self.file.truncate(required_len)?;
+            self.file.truncate(required_len).await?;
             self.persisted_pages = self.total_pages;
         }
 
@@ -1374,7 +1496,7 @@ impl<F: SyncFile> OpfsBTree<F> {
             let offset = start_page_id.checked_mul(page_size as u64).ok_or_else(|| {
                 BTreeError::Io("checkpoint run write offset overflow".to_string())
             })?;
-            self.file.write_all_at(offset, &run)?;
+            self.file.write_all_at(offset, &run).await?;
 
             idx = end;
         }
@@ -1449,31 +1571,32 @@ impl<F: SyncFile> OpfsBTree<F> {
         Ok(writes)
     }
 
-    fn truncate_wal_tail(&mut self) -> Result<(), BTreeError> {
-        if self.persisted_pages <= self.total_pages {
+    // After a checkpoint copies every WAL-pinned page to its home location, the
+    // WAL is fully superseded, so the WAL file is truncated to empty.
+    async fn truncate_wal_tail(&mut self) -> Result<(), BTreeError> {
+        if self.wal_persisted_pages == 0 {
             return Ok(());
         }
-        let required_len = self
-            .total_pages
-            .checked_mul(self.options.page_size as u64)
-            .ok_or_else(|| BTreeError::Io("checkpoint truncate length overflow".to_string()))?;
-        self.file.truncate(required_len)?;
-        self.file.flush()?;
-        self.persisted_pages = self.total_pages;
+        self.wal_file.truncate(0).await?;
+        self.wal_file.flush().await?;
+        self.wal_persisted_pages = 0;
         Ok(())
     }
 
-    fn replay_wal(&mut self) -> Result<(), BTreeError> {
-        let mut cursor = self.active.total_pages.max(2);
-        while cursor < self.persisted_pages {
+    async fn replay_wal(&mut self) -> Result<(), BTreeError> {
+        // WAL commits live in their own file, addressed from page 2 (pages 0/1
+        // are reserved to mirror the home-file layout).
+        let mut cursor = 2u64;
+        while cursor < self.wal_persisted_pages {
             let Some((header, frames, next_cursor)) = wal::read_commit(
-                &self.file,
+                &self.wal_file,
                 self.options.page_size,
                 cursor,
-                self.persisted_pages,
-            )?
+                self.wal_persisted_pages,
+            )
+            .await?
             else {
-                self.persisted_pages = cursor;
+                self.wal_persisted_pages = cursor;
                 break;
             };
             self.apply_wal_commit(header, frames)?;
@@ -1895,7 +2018,7 @@ impl<F: SyncFile> OpfsBTree<F> {
         }
     }
 
-    fn checkpoint_superblock(
+    async fn checkpoint_superblock(
         &mut self,
         root_page_id: u64,
         freelist_head_page_id: u64,
@@ -1916,8 +2039,8 @@ impl<F: SyncFile> OpfsBTree<F> {
         );
 
         let target_slot = self.active_slot.inactive();
-        write_slot_unchecked(&self.file, target_slot, self.options.page_size, next)?;
-        self.file.flush()?;
+        write_slot_unchecked(&self.file, target_slot, self.options.page_size, next).await?;
+        self.file.flush().await?;
 
         self.active_slot = target_slot;
         self.active = next;
@@ -2076,19 +2199,19 @@ fn eviction_priority(kind: PageKind) -> u8 {
     }
 }
 
-fn read_slot<F: SyncFile>(
+async fn read_slot<F: AsyncFile>(
     file: &F,
     slot: SuperblockSlot,
     page_size: usize,
 ) -> Result<Option<Superblock>, BTreeError> {
     let offset = slot.byte_offset(page_size);
     let needed = offset.saturating_add(page_size as u64);
-    if file.len()? < needed {
+    if file.len().await? < needed {
         return Ok(None);
     }
 
     let mut page = vec![0u8; page_size];
-    file.read_exact_at(offset, &mut page)?;
+    file.read_exact_at(offset, &mut page).await?;
     if page.iter().all(|b| *b == 0) {
         return Ok(None);
     }
@@ -2099,21 +2222,21 @@ fn read_slot<F: SyncFile>(
     }
 }
 
-fn write_slot<F: SyncFile>(
+async fn write_slot<F: AsyncFile>(
     file: &F,
     slot: SuperblockSlot,
     page_size: usize,
     sb: Superblock,
 ) -> Result<(), BTreeError> {
     let required_file_len = (2 * page_size) as u64;
-    if file.len()? < required_file_len {
-        file.truncate(required_file_len)?;
+    if file.len().await? < required_file_len {
+        file.truncate(required_file_len).await?;
     }
 
-    write_slot_unchecked(file, slot, page_size, sb)
+    write_slot_unchecked(file, slot, page_size, sb).await
 }
 
-fn write_slot_unchecked<F: SyncFile>(
+async fn write_slot_unchecked<F: AsyncFile>(
     file: &F,
     slot: SuperblockSlot,
     page_size: usize,
@@ -2121,7 +2244,8 @@ fn write_slot_unchecked<F: SyncFile>(
 ) -> Result<(), BTreeError> {
     let mut page = vec![0u8; page_size];
     sb.encode_into_page(&mut page)?;
-    file.write_all_at(slot.byte_offset(page_size), &page)?;
+    file.write_all_at(slot.byte_offset(page_size), &page)
+        .await?;
     Ok(())
 }
 
@@ -2131,7 +2255,7 @@ mod tests {
     use std::rc::Rc;
 
     use super::*;
-    use crate::file::{MemoryFile, SyncFile};
+    use crate::file::{AsyncFile, MemoryFile, block_on};
 
     fn small_options() -> BTreeOptions {
         BTreeOptions {
@@ -2212,34 +2336,41 @@ mod tests {
         }
     }
 
-    impl SyncFile for CountingFile {
-        fn len(&self) -> Result<u64, BTreeError> {
-            self.inner.len()
+    impl AsyncFile for CountingFile {
+        async fn len(&self) -> Result<u64, BTreeError> {
+            self.inner.len().await
         }
 
-        fn read_exact_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BTreeError> {
+        async fn read_exact_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BTreeError> {
             self.reads.borrow_mut().push((offset, buf.len()));
-            self.inner.read_exact_at(offset, buf)
+            self.inner.read_exact_at(offset, buf).await
         }
 
-        fn write_all_at(&self, offset: u64, buf: &[u8]) -> Result<(), BTreeError> {
+        async fn write_all_at(&self, offset: u64, buf: &[u8]) -> Result<(), BTreeError> {
             self.writes.borrow_mut().push((offset, buf.len()));
-            self.inner.write_all_at(offset, buf)
+            self.inner.write_all_at(offset, buf).await
         }
 
-        fn truncate(&self, len: u64) -> Result<(), BTreeError> {
-            self.inner.truncate(len)
+        async fn truncate(&self, len: u64) -> Result<(), BTreeError> {
+            self.inner.truncate(len).await
         }
 
-        fn flush(&self) -> Result<(), BTreeError> {
-            self.inner.flush()
+        async fn flush(&self) -> Result<(), BTreeError> {
+            self.inner.flush().await
+        }
+
+        async fn open_sibling(&self, suffix: &str) -> Result<Self, BTreeError> {
+            Ok(CountingFile {
+                inner: self.inner.open_sibling(suffix).await?,
+                writes: Rc::new(RefCell::new(Vec::new())),
+                reads: Rc::new(RefCell::new(Vec::new())),
+            })
         }
     }
 
     fn corrupt_slot(file: &MemoryFile, slot: SuperblockSlot, page_size: usize) {
         let offset = slot.byte_offset(page_size) + 8;
-        file.write_all_at(offset, &[0xFF, 0x00, 0xAA, 0x55])
-            .expect("corrupt slot bytes");
+        block_on(file.write_all_at(offset, &[0xFF, 0x00, 0xAA, 0x55])).expect("corrupt slot bytes");
     }
 
     #[test]
@@ -2311,8 +2442,7 @@ mod tests {
         let mut tree = OpfsBTree::open(file, BTreeOptions::default()).expect("open tree");
 
         let before = tree.checkpoint_state();
-        tree.checkpoint_superblock(7, 11, 42)
-            .expect("first checkpoint");
+        block_on(tree.checkpoint_superblock(7, 11, 42)).expect("first checkpoint");
         let after = tree.checkpoint_state();
 
         assert_eq!(after.generation, before.generation + 1);
@@ -2326,8 +2456,8 @@ mod tests {
     fn reopen_picks_latest_valid_superblock() {
         let file = MemoryFile::new();
         let mut tree = OpfsBTree::open(file.clone(), BTreeOptions::default()).expect("open tree");
-        tree.checkpoint_superblock(0, 0, 10).expect("checkpoint 1");
-        tree.checkpoint_superblock(0, 0, 20).expect("checkpoint 2");
+        block_on(tree.checkpoint_superblock(0, 0, 10)).expect("checkpoint 1");
+        block_on(tree.checkpoint_superblock(0, 0, 20)).expect("checkpoint 2");
 
         let reopened = OpfsBTree::open(file, BTreeOptions::default()).expect("reopen tree");
         let state = reopened.checkpoint_state();
@@ -2343,8 +2473,7 @@ mod tests {
 
         let mut tree = OpfsBTree::open(file.clone(), BTreeOptions::default()).expect("open tree");
         let initial = tree.checkpoint_state();
-        tree.checkpoint_superblock(99, 0, 33)
-            .expect("checkpoint to inactive slot");
+        block_on(tree.checkpoint_superblock(99, 0, 33)).expect("checkpoint to inactive slot");
         let latest = tree.checkpoint_state();
         assert!(latest.generation > initial.generation);
 
@@ -2364,8 +2493,7 @@ mod tests {
     #[test]
     fn open_nonempty_without_valid_superblock_errors() {
         let file = MemoryFile::new();
-        file.write_all_at(0, &[1, 2, 3, 4, 5, 6, 7, 8])
-            .expect("seed invalid bytes");
+        block_on(file.write_all_at(0, &[1, 2, 3, 4, 5, 6, 7, 8])).expect("seed invalid bytes");
 
         let err = OpfsBTree::open(file, BTreeOptions::default()).expect_err("must error");
         assert!(matches!(err, BTreeError::Corrupt(_)));
@@ -2786,7 +2914,7 @@ mod tests {
 
         let root_page_id = tree.root_page_id.expect("root page");
         assert_eq!(
-            file.len().expect("file len") / options.page_size as u64,
+            block_on(file.len()).expect("file len") / options.page_size as u64,
             tree.total_pages,
             "checkpoint should extend the file through total_pages"
         );
@@ -2796,7 +2924,7 @@ mod tests {
         }
         tree.remove_page(root_page_id);
 
-        tree.ensure_page_loaded(root_page_id)
+        block_on(tree.ensure_page_loaded(root_page_id))
             .expect("coalesced read should not cross the persisted file length");
         assert!(tree.pages.contains_key(&root_page_id));
     }
@@ -2867,7 +2995,7 @@ mod tests {
         assert!(tree.pages.contains_key(&root));
 
         for page_id in 2..tree.total_pages {
-            tree.ensure_page_loaded(page_id).expect("load page");
+            block_on(tree.ensure_page_loaded(page_id)).expect("load page");
             assert!(tree.pages.len() <= max_cached);
             assert!(tree.pages.contains_key(&root));
         }
@@ -2936,7 +3064,7 @@ mod tests {
         let root = tree.root_page_id.expect("root exists");
 
         for page_id in 2..tree.total_pages {
-            tree.ensure_page_loaded(page_id).expect("load page");
+            block_on(tree.ensure_page_loaded(page_id)).expect("load page");
             assert!(
                 tree.pages.len() <= max_cached,
                 "cache exceeded budget after loading page {}",
@@ -3038,7 +3166,7 @@ mod tests {
 
         let mut internal_ids = Vec::new();
         for page_id in 2..tree.total_pages {
-            tree.ensure_page_loaded(page_id).expect("load page");
+            block_on(tree.ensure_page_loaded(page_id)).expect("load page");
             if tree.page_kind(page_id).expect("page kind") == PageKind::Internal {
                 internal_ids.push(page_id);
             }

--- a/crates/opfs-btree/src/file.rs
+++ b/crates/opfs-btree/src/file.rs
@@ -1,29 +1,74 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use rustc_hash::FxHashMap;
+
 use crate::BTreeError;
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::JsCast;
 #[cfg(target_arch = "wasm32")]
-use wasm_bindgen::prelude::wasm_bindgen;
-#[cfg(target_arch = "wasm32")]
 use wasm_bindgen_futures::JsFuture;
 
-pub trait SyncFile {
-    fn len(&self) -> Result<u64, BTreeError>;
-    fn is_empty(&self) -> Result<bool, BTreeError> {
-        self.len().map(|len| len == 0)
+/// Async file I/O abstraction. Every method returns a future so the OPFS
+/// backend can drive the *asynchronous* File System Access APIs
+/// (`getFile()` / `Blob.arrayBuffer()` for reads, `createWritable()` for
+/// writes) instead of the synchronous `FileSystemSyncAccessHandle`. The
+/// in-memory and native backends complete immediately.
+#[allow(async_fn_in_trait)]
+pub trait AsyncFile {
+    async fn len(&self) -> Result<u64, BTreeError>;
+    async fn is_empty(&self) -> Result<bool, BTreeError> {
+        Ok(self.len().await? == 0)
     }
-    fn read_exact_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BTreeError>;
-    fn write_all_at(&self, offset: u64, buf: &[u8]) -> Result<(), BTreeError>;
-    fn truncate(&self, len: u64) -> Result<(), BTreeError>;
-    fn flush(&self) -> Result<(), BTreeError>;
+    async fn read_exact_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BTreeError>;
+    async fn write_all_at(&self, offset: u64, buf: &[u8]) -> Result<(), BTreeError>;
+    async fn truncate(&self, len: u64) -> Result<(), BTreeError>;
+    async fn flush(&self) -> Result<(), BTreeError>;
+
+    /// Open a companion file alongside this one, identified by `suffix`. The
+    /// b-tree uses this to keep the WAL in a separate (small) file so each
+    /// async `createWritable()` copy-on-write touches only the WAL, not the
+    /// whole multi-megabyte home file. Reopening the same logical file must
+    /// return a handle onto the same companion bytes.
+    async fn open_sibling(&self, suffix: &str) -> Result<Self, BTreeError>
+    where
+        Self: Sized;
+}
+
+/// Minimal, dependency-free executor used by the native sync facades and the
+/// native test suite. The native and in-memory `AsyncFile` impls never truly
+/// pend (their bodies are synchronous), so the future is ready on the first
+/// poll; the spin loop is purely defensive.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn block_on<F: std::future::Future>(fut: F) -> F::Output {
+    use std::sync::Arc;
+    use std::task::{Context, Poll, Wake, Waker};
+
+    struct NoopWake;
+    impl Wake for NoopWake {
+        fn wake(self: Arc<Self>) {}
+    }
+
+    let waker = Waker::from(Arc::new(NoopWake));
+    let mut cx = Context::from_waker(&waker);
+    let mut fut = std::pin::pin!(fut);
+    loop {
+        match fut.as_mut().poll(&mut cx) {
+            Poll::Ready(value) => return value,
+            Poll::Pending => std::hint::spin_loop(),
+        }
+    }
 }
 
 #[derive(Clone, Default, Debug)]
 pub struct MemoryFile {
     inner: Rc<RefCell<Vec<u8>>>,
+    // Companion files (e.g. the WAL) live in this shared slot so that a cloned
+    // handle — which is how the in-memory backend models "reopen" — sees the
+    // same companion bytes. Without sharing, a reopen would get a fresh, empty
+    // WAL and lose un-checkpointed commits.
+    siblings: Rc<RefCell<FxHashMap<String, MemoryFile>>>,
 }
 
 impl MemoryFile {
@@ -32,12 +77,12 @@ impl MemoryFile {
     }
 }
 
-impl SyncFile for MemoryFile {
-    fn len(&self) -> Result<u64, BTreeError> {
+impl AsyncFile for MemoryFile {
+    async fn len(&self) -> Result<u64, BTreeError> {
         Ok(self.inner.borrow().len() as u64)
     }
 
-    fn read_exact_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BTreeError> {
+    async fn read_exact_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BTreeError> {
         let offset = usize::try_from(offset)
             .map_err(|_| BTreeError::Io("offset does not fit in usize".to_string()))?;
         let end = offset
@@ -57,7 +102,7 @@ impl SyncFile for MemoryFile {
         Ok(())
     }
 
-    fn write_all_at(&self, offset: u64, buf: &[u8]) -> Result<(), BTreeError> {
+    async fn write_all_at(&self, offset: u64, buf: &[u8]) -> Result<(), BTreeError> {
         let offset = usize::try_from(offset)
             .map_err(|_| BTreeError::Io("offset does not fit in usize".to_string()))?;
         let end = offset
@@ -72,7 +117,7 @@ impl SyncFile for MemoryFile {
         Ok(())
     }
 
-    fn truncate(&self, len: u64) -> Result<(), BTreeError> {
+    async fn truncate(&self, len: u64) -> Result<(), BTreeError> {
         let len = usize::try_from(len)
             .map_err(|_| BTreeError::Io("truncate length does not fit in usize".to_string()))?;
         let mut data = self.inner.borrow_mut();
@@ -80,14 +125,21 @@ impl SyncFile for MemoryFile {
         Ok(())
     }
 
-    fn flush(&self) -> Result<(), BTreeError> {
+    async fn flush(&self) -> Result<(), BTreeError> {
         Ok(())
+    }
+
+    async fn open_sibling(&self, suffix: &str) -> Result<Self, BTreeError> {
+        let mut siblings = self.siblings.borrow_mut();
+        let sibling = siblings.entry(suffix.to_string()).or_default();
+        Ok(sibling.clone())
     }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Clone, Debug)]
 pub struct StdFile {
+    path: std::path::PathBuf,
     inner: Rc<RefCell<std::fs::File>>,
 }
 
@@ -106,21 +158,22 @@ impl StdFile {
             .open(path)
             .map_err(|e| BTreeError::Io(e.to_string()))?;
         Ok(Self {
+            path: path.to_path_buf(),
             inner: Rc::new(RefCell::new(file)),
         })
     }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-impl SyncFile for StdFile {
-    fn len(&self) -> Result<u64, BTreeError> {
+impl AsyncFile for StdFile {
+    async fn len(&self) -> Result<u64, BTreeError> {
         let file = self.inner.borrow();
         file.metadata()
             .map(|m| m.len())
             .map_err(|e| BTreeError::Io(e.to_string()))
     }
 
-    fn read_exact_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BTreeError> {
+    async fn read_exact_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BTreeError> {
         #[cfg(unix)]
         {
             use std::os::unix::fs::FileExt;
@@ -146,7 +199,7 @@ impl SyncFile for StdFile {
         }
     }
 
-    fn write_all_at(&self, offset: u64, buf: &[u8]) -> Result<(), BTreeError> {
+    async fn write_all_at(&self, offset: u64, buf: &[u8]) -> Result<(), BTreeError> {
         #[cfg(unix)]
         {
             use std::os::unix::fs::FileExt;
@@ -172,14 +225,20 @@ impl SyncFile for StdFile {
         }
     }
 
-    fn truncate(&self, len: u64) -> Result<(), BTreeError> {
+    async fn truncate(&self, len: u64) -> Result<(), BTreeError> {
         let file = self.inner.borrow();
         file.set_len(len).map_err(|e| BTreeError::Io(e.to_string()))
     }
 
-    fn flush(&self) -> Result<(), BTreeError> {
+    async fn flush(&self) -> Result<(), BTreeError> {
         let file = self.inner.borrow();
         file.sync_all().map_err(|e| BTreeError::Io(e.to_string()))
+    }
+
+    async fn open_sibling(&self, suffix: &str) -> Result<Self, BTreeError> {
+        let mut sibling = self.path.clone().into_os_string();
+        sibling.push(suffix);
+        StdFile::open(std::path::PathBuf::from(sibling))
     }
 }
 
@@ -192,135 +251,125 @@ pub struct OpfsFile {
 #[cfg(target_arch = "wasm32")]
 #[derive(Debug)]
 struct OpfsFileInner {
-    handle: web_sys::FileSystemSyncAccessHandle,
-    read_options: web_sys::FileSystemReadWriteOptions,
-    write_options: web_sys::FileSystemReadWriteOptions,
-}
-
-#[cfg(target_arch = "wasm32")]
-impl Drop for OpfsFileInner {
-    fn drop(&mut self) {
-        self.handle.close();
-    }
+    handle: web_sys::FileSystemFileHandle,
+    /// The OPFS entry name, so siblings (the WAL) can be derived by suffix.
+    name: String,
+    /// A single writable stream held open across a write batch. Reopening a
+    /// fresh `createWritable()` per write would copy-on-write the whole file
+    /// each time; instead we open once on the first write and `close()` (which
+    /// publishes the changes) on the next `flush()` or read. This collapses a
+    /// checkpoint's dozens of full-file copies into one.
+    writable: RefCell<Option<web_sys::FileSystemWritableFileStream>>,
 }
 
 #[cfg(target_arch = "wasm32")]
 impl OpfsFile {
     pub async fn open(namespace: &str) -> Result<Self, BTreeError> {
-        let global: web_sys::WorkerGlobalScope = js_sys::global().dyn_into().map_err(|_| {
-            BTreeError::Io("OpfsFile::open must run in a dedicated worker".to_string())
-        })?;
-        let storage = global.navigator().storage();
+        Self::open_named(Self::file_name(namespace)).await
+    }
 
-        let root: web_sys::FileSystemDirectoryHandle = JsFuture::from(storage.get_directory())
-            .await
-            .map_err(map_js_error)?
-            .dyn_into()
-            .map_err(|_| BTreeError::Io("failed to cast OPFS root".to_string()))?;
-
+    async fn open_named(name: String) -> Result<Self, BTreeError> {
+        let root = opfs_root().await?;
         let opts = web_sys::FileSystemGetFileOptions::new();
         opts.set_create(true);
-        let file: web_sys::FileSystemFileHandle =
-            JsFuture::from(root.get_file_handle_with_options(&Self::file_name(namespace), &opts))
+        let handle: web_sys::FileSystemFileHandle =
+            JsFuture::from(root.get_file_handle_with_options(&name, &opts))
                 .await
                 .map_err(map_js_error)?
                 .dyn_into()
                 .map_err(|_| BTreeError::Io("failed to cast OPFS file handle".to_string()))?;
 
-        // Retry with exponential backoff: on rapid page refresh the previous
-        // worker may still hold the exclusive SyncAccessHandle.  The browser
-        // releases it once the old worker is GC'd, typically within a few
-        // hundred milliseconds.
-        // Only retries on DOMExceptions (handle conflicts); other errors fail immediately.
-        const MAX_RETRIES: u32 = 12;
-        const BASE_DELAY_MS: u32 = 50;
-
-        let mut last_err = None;
-        for attempt in 0..=MAX_RETRIES {
-            if attempt > 0 {
-                let delay = BASE_DELAY_MS * (1 << (attempt - 1));
-                sleep_ms(delay).await;
-            }
-            match JsFuture::from(file.create_sync_access_handle()).await {
-                Ok(val) => {
-                    let handle: web_sys::FileSystemSyncAccessHandle =
-                        val.dyn_into().map_err(|_| {
-                            BTreeError::Io("failed to cast OPFS sync access handle".to_string())
-                        })?;
-                    if attempt > 0 {
-                        tracing::info!(attempt, "acquired OPFS access handle after retry");
-                    }
-
-                    let read_options = web_sys::FileSystemReadWriteOptions::new();
-                    let write_options = web_sys::FileSystemReadWriteOptions::new();
-                    return Ok(Self {
-                        inner: Rc::new(OpfsFileInner {
-                            handle,
-                            read_options,
-                            write_options,
-                        }),
-                    });
-                }
-                Err(e) => {
-                    if !is_retryable_handle_conflict(&e) {
-                        return Err(map_js_error(e));
-                    }
-                    last_err = Some(e);
-                }
-            }
-        }
-
-        // All retries exhausted — return the last error.
-        Err(map_js_error(last_err.unwrap()))
+        Ok(Self {
+            inner: Rc::new(OpfsFileInner {
+                handle,
+                name,
+                writable: RefCell::new(None),
+            }),
+        })
     }
 
     pub async fn destroy(namespace: &str) -> Result<(), BTreeError> {
-        let global: web_sys::WorkerGlobalScope = js_sys::global().dyn_into().map_err(|_| {
-            BTreeError::Io("OpfsFile::destroy must run in a dedicated worker".to_string())
-        })?;
-        let storage = global.navigator().storage();
-        let root: web_sys::FileSystemDirectoryHandle = JsFuture::from(storage.get_directory())
-            .await
-            .map_err(map_js_error)?
-            .dyn_into()
-            .map_err(|_| BTreeError::Io("failed to cast OPFS root".to_string()))?;
-
         let name = Self::file_name(namespace);
-        let remove_fn = js_sys::Reflect::get(&root, &"removeEntry".into()).map_err(map_js_error)?;
-        let remove_fn: js_sys::Function = remove_fn
-            .dyn_into()
-            .map_err(|_| BTreeError::Io("OPFS removeEntry is unavailable".to_string()))?;
-        let opts = js_sys::Object::new();
-        let _ = js_sys::Reflect::set(&opts, &"recursive".into(), &false.into());
-        let promise = remove_fn.call2(&root, &name.into(), &opts.into());
-        if let Ok(promise) = promise {
-            let promise: js_sys::Promise = promise
-                .dyn_into()
-                .map_err(|_| BTreeError::Io("failed to cast removeEntry promise".to_string()))?;
-            let _ = JsFuture::from(promise).await;
-        }
-
-        Ok(())
+        // Remove the home file and its WAL sibling (see `open_sibling`).
+        remove_entry(&format!("{}.wal", name)).await?;
+        remove_entry(&name).await
     }
 
     fn file_name(namespace: &str) -> String {
         format!("{}.opfsbtree", namespace)
     }
+
+    /// `getFile()` returns a fresh `File` (a `Blob`) snapshot of the current
+    /// on-disk contents. Reads slice this blob and pull the bytes through
+    /// `arrayBuffer()`.
+    async fn current_file(&self) -> Result<web_sys::File, BTreeError> {
+        JsFuture::from(self.inner.handle.get_file())
+            .await
+            .map_err(map_js_error)?
+            .dyn_into()
+            .map_err(|_| BTreeError::Io("failed to cast OPFS File".to_string()))
+    }
+
+    /// Opens a writable stream that keeps the existing file bytes. `keepExisting
+    /// Data:true` makes the browser snapshot the file copy-on-write; changes are
+    /// published on `close()`.
+    async fn open_writable(&self) -> Result<web_sys::FileSystemWritableFileStream, BTreeError> {
+        let opts = web_sys::FileSystemCreateWritableOptions::new();
+        opts.set_keep_existing_data(true);
+        JsFuture::from(self.inner.handle.create_writable_with_options(&opts))
+            .await
+            .map_err(map_js_error)?
+            .dyn_into()
+            .map_err(|_| BTreeError::Io("failed to cast OPFS writable stream".to_string()))
+    }
+
+    /// Take the held writable stream, opening a fresh one if none is held.
+    async fn take_writable(&self) -> Result<web_sys::FileSystemWritableFileStream, BTreeError> {
+        let existing = self.inner.writable.borrow_mut().take();
+        match existing {
+            Some(stream) => Ok(stream),
+            None => self.open_writable().await,
+        }
+    }
+
+    fn store_writable(&self, stream: web_sys::FileSystemWritableFileStream) {
+        *self.inner.writable.borrow_mut() = Some(stream);
+    }
+
+    /// Close any held writable so its buffered writes become visible to the
+    /// next `getFile()` read. This is the durability/visibility barrier.
+    async fn commit_writable(&self) -> Result<(), BTreeError> {
+        let existing = self.inner.writable.borrow_mut().take();
+        if let Some(stream) = existing {
+            JsFuture::from(stream.close()).await.map_err(map_js_error)?;
+        }
+        Ok(())
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
-impl SyncFile for OpfsFile {
-    fn len(&self) -> Result<u64, BTreeError> {
-        Ok(self.inner.handle.get_size().map_err(map_js_error)? as u64)
+impl AsyncFile for OpfsFile {
+    async fn len(&self) -> Result<u64, BTreeError> {
+        self.commit_writable().await?;
+        Ok(self.current_file().await?.size() as u64)
     }
 
-    fn read_exact_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BTreeError> {
-        self.inner.read_options.set_at(offset as f64);
-        let read = self
-            .inner
-            .handle
-            .read_with_u8_array_and_options(buf, &self.inner.read_options)
-            .map_err(map_js_error)? as usize;
+    async fn read_exact_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BTreeError> {
+        if buf.is_empty() {
+            return Ok(());
+        }
+        self.commit_writable().await?;
+        let file = self.current_file().await?;
+        let start = offset as f64;
+        let end = start + buf.len() as f64;
+        let blob: web_sys::Blob = file
+            .slice_with_f64_and_f64(start, end)
+            .map_err(map_js_error)?;
+        let array_buffer = JsFuture::from(blob.array_buffer())
+            .await
+            .map_err(map_js_error)?;
+        let bytes = js_sys::Uint8Array::new(&array_buffer);
+        let read = bytes.length() as usize;
         if read != buf.len() {
             return Err(BTreeError::Io(format!(
                 "unexpected eof: read {} of {} bytes",
@@ -328,74 +377,83 @@ impl SyncFile for OpfsFile {
                 buf.len()
             )));
         }
+        bytes.copy_to(buf);
         Ok(())
     }
 
-    fn write_all_at(&self, offset: u64, buf: &[u8]) -> Result<(), BTreeError> {
-        self.inner.write_options.set_at(offset as f64);
-        let written = self
-            .inner
-            .handle
-            .write_with_u8_array_and_options(buf, &self.inner.write_options)
-            .map_err(map_js_error)? as usize;
-        if written != buf.len() {
-            return Err(BTreeError::Io(format!(
-                "short write: wrote {} of {} bytes",
-                written,
-                buf.len()
-            )));
+    async fn write_all_at(&self, offset: u64, buf: &[u8]) -> Result<(), BTreeError> {
+        let stream = self.take_writable().await?;
+        let result: Result<(), BTreeError> = async {
+            JsFuture::from(stream.seek_with_f64(offset as f64).map_err(map_js_error)?)
+                .await
+                .map_err(map_js_error)?;
+            JsFuture::from(stream.write_with_u8_array(buf).map_err(map_js_error)?)
+                .await
+                .map_err(map_js_error)?;
+            Ok(())
         }
-        Ok(())
+        .await;
+        if result.is_ok() {
+            self.store_writable(stream);
+        }
+        result
     }
 
-    fn truncate(&self, len: u64) -> Result<(), BTreeError> {
-        truncate_handle(&self.inner.handle, len)
+    async fn truncate(&self, len: u64) -> Result<(), BTreeError> {
+        let stream = self.take_writable().await?;
+        let result: Result<(), BTreeError> = async {
+            JsFuture::from(stream.truncate_with_f64(len as f64).map_err(map_js_error)?)
+                .await
+                .map_err(map_js_error)?;
+            Ok(())
+        }
+        .await;
+        if result.is_ok() {
+            self.store_writable(stream);
+        }
+        result
     }
 
-    fn flush(&self) -> Result<(), BTreeError> {
-        self.inner.handle.flush().map_err(map_js_error)
+    async fn flush(&self) -> Result<(), BTreeError> {
+        // Closing the held writable publishes its writes durably.
+        self.commit_writable().await
+    }
+
+    async fn open_sibling(&self, suffix: &str) -> Result<Self, BTreeError> {
+        Self::open_named(format!("{}{}", self.inner.name, suffix)).await
     }
 }
 
 #[cfg(target_arch = "wasm32")]
-fn truncate_handle(
-    handle: &web_sys::FileSystemSyncAccessHandle,
-    len: u64,
-) -> Result<(), BTreeError> {
-    let truncate = js_sys::Reflect::get(handle, &"truncate".into()).map_err(map_js_error)?;
-    let truncate: js_sys::Function = truncate
+async fn remove_entry(name: &str) -> Result<(), BTreeError> {
+    let root = opfs_root().await?;
+    let remove_fn = js_sys::Reflect::get(&root, &"removeEntry".into()).map_err(map_js_error)?;
+    let remove_fn: js_sys::Function = remove_fn
         .dyn_into()
-        .map_err(|_| BTreeError::Io("OPFS truncate is unavailable".to_string()))?;
-    truncate
-        .call1(handle, &wasm_bindgen::JsValue::from_f64(len as f64))
-        .map_err(map_js_error)?;
+        .map_err(|_| BTreeError::Io("OPFS removeEntry is unavailable".to_string()))?;
+    let opts = js_sys::Object::new();
+    let _ = js_sys::Reflect::set(&opts, &"recursive".into(), &false.into());
+    let promise = remove_fn.call2(&root, &name.into(), &opts.into());
+    if let Ok(promise) = promise {
+        let promise: js_sys::Promise = promise
+            .dyn_into()
+            .map_err(|_| BTreeError::Io("failed to cast removeEntry promise".to_string()))?;
+        let _ = JsFuture::from(promise).await;
+    }
     Ok(())
 }
 
 #[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
-unsafe extern "C" {
-    #[wasm_bindgen(js_name = "setTimeout")]
-    fn set_timeout(handler: &js_sys::Function, timeout: i32);
-}
-
-#[cfg(target_arch = "wasm32")]
-async fn sleep_ms(ms: u32) {
-    let promise = js_sys::Promise::new(&mut |resolve, _| {
-        set_timeout(&resolve, i32::try_from(ms).unwrap_or(i32::MAX));
-    });
-    let _ = JsFuture::from(promise).await;
-}
-
-/// Returns true if the JS error is a retryable handle conflict DOMException.
-/// `SecurityError` is excluded — it signals a blocked API, not a transient conflict.
-#[cfg(target_arch = "wasm32")]
-fn is_retryable_handle_conflict(value: &wasm_bindgen::JsValue) -> bool {
-    if value.is_instance_of::<web_sys::DomException>() {
-        let ex: &web_sys::DomException = value.unchecked_ref();
-        return ex.name() != "SecurityError";
-    }
-    false
+async fn opfs_root() -> Result<web_sys::FileSystemDirectoryHandle, BTreeError> {
+    let global: web_sys::WorkerGlobalScope = js_sys::global()
+        .dyn_into()
+        .map_err(|_| BTreeError::Io("OpfsFile must run in a dedicated worker".to_string()))?;
+    let storage = global.navigator().storage();
+    JsFuture::from(storage.get_directory())
+        .await
+        .map_err(map_js_error)?
+        .dyn_into()
+        .map_err(|_| BTreeError::Io("failed to cast OPFS root".to_string()))
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/opfs-btree/src/lib.rs
+++ b/crates/opfs-btree/src/lib.rs
@@ -14,4 +14,4 @@ pub use error::BTreeError;
 pub use file::OpfsFile;
 #[cfg(not(target_arch = "wasm32"))]
 pub use file::StdFile;
-pub use file::{MemoryFile, SyncFile};
+pub use file::{AsyncFile, MemoryFile};

--- a/crates/opfs-btree/src/wal.rs
+++ b/crates/opfs-btree/src/wal.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use crate::file::SyncFile;
+use crate::file::AsyncFile;
 use crate::page::PageId;
 use crate::{BTreeError, checksum};
 
@@ -64,7 +64,7 @@ pub(crate) struct WalFrameRef<'a> {
     pub(crate) raw: &'a [u8],
 }
 
-pub(crate) fn append_commit<F: SyncFile>(
+pub(crate) async fn append_commit<F: AsyncFile>(
     file: &F,
     page_size: usize,
     start_page_id: PageId,
@@ -80,11 +80,13 @@ pub(crate) fn append_commit<F: SyncFile>(
     let required_len = required_pages
         .checked_mul(page_size as u64)
         .ok_or_else(|| BTreeError::Io("WAL file byte length overflow".to_string()))?;
-    file.truncate(required_len)?;
+    file.truncate(required_len).await?;
 
     let header = header.with_frame_count(frame_count);
     let mut writer = PageRunWriter::new(file, page_size, start_page_id);
-    writer.push(&encode_wal_header_page(page_size, header)?)?;
+    writer
+        .push(&encode_wal_header_page(page_size, header)?)
+        .await?;
 
     for frame in frames {
         let meta = encode_wal_frame_meta_page(
@@ -94,20 +96,22 @@ pub(crate) fn append_commit<F: SyncFile>(
             frame.is_freelist,
             frame.raw,
         )?;
-        writer.push(&meta)?;
-        writer.push(frame.raw)?;
+        writer.push(&meta).await?;
+        writer.push(frame.raw).await?;
     }
 
-    writer.push(&encode_wal_commit_page(
-        page_size,
-        header.generation,
-        frame_count,
-    )?)?;
-    writer.flush_run()?;
+    writer
+        .push(&encode_wal_commit_page(
+            page_size,
+            header.generation,
+            frame_count,
+        )?)
+        .await?;
+    writer.flush_run().await?;
     Ok(wal_pages)
 }
 
-pub(crate) fn read_commit<F: SyncFile>(
+pub(crate) async fn read_commit<F: AsyncFile>(
     file: &F,
     page_size: usize,
     start_page_id: PageId,
@@ -120,11 +124,12 @@ pub(crate) fn read_commit<F: SyncFile>(
         persisted_pages,
         batch_wal_replay_reads(),
     )
+    .await
 }
 
 // `batched` is cfg-selected in production (see `batch_wal_replay_reads`) but
 // kept as a parameter so native tests can exercise the batched reader too.
-fn read_commit_with_mode<F: SyncFile>(
+async fn read_commit_with_mode<F: AsyncFile>(
     file: &F,
     page_size: usize,
     start_page_id: PageId,
@@ -132,13 +137,14 @@ fn read_commit_with_mode<F: SyncFile>(
     batched: bool,
 ) -> Result<Option<(WalHeader, Vec<WalFrame>, PageId)>, BTreeError> {
     let mut reader = if batched {
-        WalPageReader::Batched(PageRunReader::new(file, page_size, persisted_pages)?)
+        WalPageReader::Batched(PageRunReader::new(file, page_size, persisted_pages).await?)
     } else {
         WalPageReader::PerPage { file, page_size }
     };
     reader.limit_to(start_page_id + 1);
-    let Some(header) = decode_wal_header_page(&reader.page(start_page_id)?, page_size)? else {
-        truncate_tail(file, page_size, start_page_id)?;
+    let Some(header) = decode_wal_header_page(&reader.page(start_page_id).await?, page_size)?
+    else {
+        truncate_tail(file, page_size, start_page_id).await?;
         return Ok(None);
     };
     let frame_count = usize::try_from(header.frame_count)
@@ -152,7 +158,7 @@ fn read_commit_with_mode<F: SyncFile>(
         .checked_add(wal_pages)
         .ok_or_else(|| BTreeError::Corrupt("WAL cursor overflow".to_string()))?;
     if next_cursor > persisted_pages {
-        truncate_tail(file, page_size, start_page_id)?;
+        truncate_tail(file, page_size, start_page_id).await?;
         return Ok(None);
     }
     reader.limit_to(next_cursor);
@@ -161,14 +167,14 @@ fn read_commit_with_mode<F: SyncFile>(
     let mut cursor = start_page_id + 1;
     for _ in 0..frame_count {
         let Some((page_id, is_blob, is_freelist, expected_checksum)) =
-            decode_wal_frame_meta_page(&reader.page(cursor)?, page_size)?
+            decode_wal_frame_meta_page(&reader.page(cursor).await?, page_size)?
         else {
-            truncate_tail(file, page_size, start_page_id)?;
+            truncate_tail(file, page_size, start_page_id).await?;
             return Ok(None);
         };
-        let raw = reader.page(cursor + 1)?.into_owned();
+        let raw = reader.page(cursor + 1).await?.into_owned();
         if checksum::hash(&raw) != expected_checksum {
-            truncate_tail(file, page_size, start_page_id)?;
+            truncate_tail(file, page_size, start_page_id).await?;
             return Ok(None);
         }
         frames.push(WalFrame {
@@ -180,8 +186,12 @@ fn read_commit_with_mode<F: SyncFile>(
         cursor += 2;
     }
 
-    if !decode_wal_commit_page(&reader.page(cursor)?, header.generation, header.frame_count)? {
-        truncate_tail(file, page_size, start_page_id)?;
+    if !decode_wal_commit_page(
+        &reader.page(cursor).await?,
+        header.generation,
+        header.frame_count,
+    )? {
+        truncate_tail(file, page_size, start_page_id).await?;
         return Ok(None);
     }
     Ok(Some((header, frames, next_cursor)))
@@ -201,12 +211,12 @@ fn commit_page_count(
 /// Page source for `read_commit_with_mode`: either the run-buffered reader or
 /// direct per-page reads, behind one `Cow`-returning interface so the replay
 /// loop has a single control flow.
-enum WalPageReader<'a, F: SyncFile> {
+enum WalPageReader<'a, F: AsyncFile> {
     Batched(PageRunReader<'a, F>),
     PerPage { file: &'a F, page_size: usize },
 }
 
-impl<'a, F: SyncFile> WalPageReader<'a, F> {
+impl<'a, F: AsyncFile> WalPageReader<'a, F> {
     /// Caps batched reads at `end_page_id` so the run prefetch never reads
     /// past what the caller has validated. Per-page reads need no cap; they
     /// only ever touch the requested page.
@@ -216,24 +226,26 @@ impl<'a, F: SyncFile> WalPageReader<'a, F> {
         }
     }
 
-    fn page(&mut self, page_id: PageId) -> Result<Cow<'_, [u8]>, BTreeError> {
+    async fn page(&mut self, page_id: PageId) -> Result<Cow<'_, [u8]>, BTreeError> {
         match self {
-            WalPageReader::Batched(reader) => reader.page(page_id).map(Cow::Borrowed),
+            WalPageReader::Batched(reader) => reader.page(page_id).await.map(Cow::Borrowed),
             WalPageReader::PerPage { file, page_size } => {
-                read_raw_page_at(*file, *page_size, page_id).map(Cow::Owned)
+                read_raw_page_at(*file, *page_size, page_id)
+                    .await
+                    .map(Cow::Owned)
             }
         }
     }
 }
 
-fn read_raw_page_at<F: SyncFile>(
+async fn read_raw_page_at<F: AsyncFile>(
     file: &F,
     page_size: usize,
     page_id: PageId,
 ) -> Result<Vec<u8>, BTreeError> {
     let offset = page_offset(page_id, page_size, "raw page read offset overflow")?;
     let mut raw = vec![0u8; page_size];
-    file.read_exact_at(offset, &mut raw)?;
+    file.read_exact_at(offset, &mut raw).await?;
     Ok(raw)
 }
 
@@ -257,14 +269,14 @@ const WRITE_RUN_PAGES: usize = 64;
 /// Accumulates consecutive WAL pages and writes them to the backing file in
 /// runs of up to WRITE_RUN_PAGES, so a commit costs one write call per run
 /// instead of one per page.
-struct PageRunWriter<'a, F: SyncFile> {
+struct PageRunWriter<'a, F: AsyncFile> {
     file: &'a F,
     page_size: usize,
     next_page_id: PageId,
     buf: Vec<u8>,
 }
 
-impl<'a, F: SyncFile> PageRunWriter<'a, F> {
+impl<'a, F: AsyncFile> PageRunWriter<'a, F> {
     fn new(file: &'a F, page_size: usize, start_page_id: PageId) -> Self {
         Self {
             file,
@@ -274,7 +286,7 @@ impl<'a, F: SyncFile> PageRunWriter<'a, F> {
         }
     }
 
-    fn push(&mut self, raw: &[u8]) -> Result<(), BTreeError> {
+    async fn push(&mut self, raw: &[u8]) -> Result<(), BTreeError> {
         if raw.len() != self.page_size {
             return Err(BTreeError::Corrupt(format!(
                 "WAL page raw length {} does not match page size {}",
@@ -288,18 +300,18 @@ impl<'a, F: SyncFile> PageRunWriter<'a, F> {
                 self.page_size,
                 "WAL write offset overflow",
             )?;
-            self.file.write_all_at(offset, raw)?;
+            self.file.write_all_at(offset, raw).await?;
             self.next_page_id += 1;
             return Ok(());
         }
         self.buf.extend_from_slice(raw);
         if self.buf.len() >= wal_write_run_pages() * self.page_size {
-            self.flush_run()?;
+            self.flush_run().await?;
         }
         Ok(())
     }
 
-    fn flush_run(&mut self) -> Result<(), BTreeError> {
+    async fn flush_run(&mut self) -> Result<(), BTreeError> {
         if self.buf.is_empty() {
             return Ok(());
         }
@@ -308,7 +320,7 @@ impl<'a, F: SyncFile> PageRunWriter<'a, F> {
             self.page_size,
             "WAL write offset overflow",
         )?;
-        self.file.write_all_at(offset, &self.buf)?;
+        self.file.write_all_at(offset, &self.buf).await?;
         self.next_page_id += (self.buf.len() / self.page_size) as u64;
         self.buf.clear();
         Ok(())
@@ -330,7 +342,7 @@ fn wal_write_run_pages() -> usize {
 /// Serves WAL page reads from a buffered run of up to READ_RUN_PAGES pages,
 /// so sequential replay does one backing-file read per run instead of one
 /// (freshly allocated) read per page.
-struct PageRunReader<'a, F: SyncFile> {
+struct PageRunReader<'a, F: AsyncFile> {
     file: &'a F,
     page_size: usize,
     file_end_page_id: PageId,
@@ -341,9 +353,9 @@ struct PageRunReader<'a, F: SyncFile> {
     buf_page_count: u64,
 }
 
-impl<'a, F: SyncFile> PageRunReader<'a, F> {
-    fn new(file: &'a F, page_size: usize, persisted_pages: u64) -> Result<Self, BTreeError> {
-        let file_pages = file.len()? / page_size as u64;
+impl<'a, F: AsyncFile> PageRunReader<'a, F> {
+    async fn new(file: &'a F, page_size: usize, persisted_pages: u64) -> Result<Self, BTreeError> {
+        let file_pages = file.len().await? / page_size as u64;
         let file_end_page_id = persisted_pages.min(file_pages);
         Ok(Self {
             file,
@@ -360,7 +372,7 @@ impl<'a, F: SyncFile> PageRunReader<'a, F> {
         self.end_page_id = end_page_id.min(self.file_end_page_id);
     }
 
-    fn page(&mut self, page_id: PageId) -> Result<&[u8], BTreeError> {
+    async fn page(&mut self, page_id: PageId) -> Result<&[u8], BTreeError> {
         if page_id >= self.end_page_id {
             return Err(BTreeError::Io(format!(
                 "unexpected eof: WAL page {} beyond readable end {}",
@@ -368,13 +380,13 @@ impl<'a, F: SyncFile> PageRunReader<'a, F> {
             )));
         }
         if page_id < self.buf_first_page || page_id >= self.buf_first_page + self.buf_page_count {
-            self.fill(page_id)?;
+            self.fill(page_id).await?;
         }
         let start = (page_id - self.buf_first_page) as usize * self.page_size;
         Ok(&self.buf[start..start + self.page_size])
     }
 
-    fn fill(&mut self, page_id: PageId) -> Result<(), BTreeError> {
+    async fn fill(&mut self, page_id: PageId) -> Result<(), BTreeError> {
         if page_id >= self.end_page_id {
             return Err(BTreeError::Io(format!(
                 "unexpected eof: WAL page {} beyond readable end {}",
@@ -385,14 +397,16 @@ impl<'a, F: SyncFile> PageRunReader<'a, F> {
         let len = run as usize * self.page_size;
         self.buf.resize(len, 0);
         let offset = page_offset(page_id, self.page_size, "raw page read offset overflow")?;
-        self.file.read_exact_at(offset, &mut self.buf[..len])?;
+        self.file
+            .read_exact_at(offset, &mut self.buf[..len])
+            .await?;
         self.buf_first_page = page_id;
         self.buf_page_count = run;
         Ok(())
     }
 }
 
-fn truncate_tail<F: SyncFile>(
+async fn truncate_tail<F: AsyncFile>(
     file: &F,
     page_size: usize,
     start_page_id: PageId,
@@ -400,7 +414,7 @@ fn truncate_tail<F: SyncFile>(
     let len = start_page_id
         .checked_mul(page_size as u64)
         .ok_or_else(|| BTreeError::Io("WAL truncate length overflow".to_string()))?;
-    file.truncate(len)
+    file.truncate(len).await
 }
 
 fn page_offset(
@@ -594,7 +608,7 @@ fn write_u64_at(raw: &mut [u8], offset: usize, value: u64) -> Result<(), BTreeEr
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::file::MemoryFile;
+    use crate::file::{MemoryFile, block_on};
 
     const PAGE_SIZE: usize = 4 * 1024;
     const START_PAGE_ID: PageId = 2;
@@ -623,15 +637,25 @@ mod tests {
             },
         ];
 
-        let pages_written =
-            append_commit(&file, PAGE_SIZE, START_PAGE_ID, header(), &frames).expect("append WAL");
+        let pages_written = block_on(append_commit(
+            &file,
+            PAGE_SIZE,
+            START_PAGE_ID,
+            header(),
+            &frames,
+        ))
+        .expect("append WAL");
 
         assert_eq!(pages_written, 6);
         let persisted_pages = START_PAGE_ID + pages_written;
-        let (read_header, read_frames, next_cursor) =
-            read_commit(&file, PAGE_SIZE, START_PAGE_ID, persisted_pages)
-                .expect("read WAL")
-                .expect("commit present");
+        let (read_header, read_frames, next_cursor) = block_on(read_commit(
+            &file,
+            PAGE_SIZE,
+            START_PAGE_ID,
+            persisted_pages,
+        ))
+        .expect("read WAL")
+        .expect("commit present");
 
         assert_eq!(read_header.generation, 7);
         assert_eq!(read_header.root_page_id, 3);
@@ -661,16 +685,27 @@ mod tests {
             })
             .collect();
 
-        let pages_written =
-            append_commit(&file, PAGE_SIZE, START_PAGE_ID, header(), &frames).expect("append WAL");
+        let pages_written = block_on(append_commit(
+            &file,
+            PAGE_SIZE,
+            START_PAGE_ID,
+            header(),
+            &frames,
+        ))
+        .expect("append WAL");
         assert_eq!(pages_written, 82);
 
         let persisted_pages = START_PAGE_ID + pages_written;
         for batched in [false, true] {
-            let (_, read_frames, next_cursor) =
-                read_commit_with_mode(&file, PAGE_SIZE, START_PAGE_ID, persisted_pages, batched)
-                    .expect("read WAL")
-                    .expect("commit present");
+            let (_, read_frames, next_cursor) = block_on(read_commit_with_mode(
+                &file,
+                PAGE_SIZE,
+                START_PAGE_ID,
+                persisted_pages,
+                batched,
+            ))
+            .expect("read WAL")
+            .expect("commit present");
 
             assert_eq!(next_cursor, persisted_pages);
             assert_eq!(read_frames.len(), 40);
@@ -693,18 +728,28 @@ mod tests {
             is_freelist: false,
             raw: &page,
         }];
-        let pages_written =
-            append_commit(&file, PAGE_SIZE, START_PAGE_ID, header(), &frames).expect("append WAL");
+        let pages_written = block_on(append_commit(
+            &file,
+            PAGE_SIZE,
+            START_PAGE_ID,
+            header(),
+            &frames,
+        ))
+        .expect("append WAL");
         let truncated_pages = START_PAGE_ID + pages_written - 1;
-        file.truncate(truncated_pages * PAGE_SIZE as u64)
-            .expect("truncate commit page");
+        block_on(file.truncate(truncated_pages * PAGE_SIZE as u64)).expect("truncate commit page");
 
-        let result =
-            read_commit(&file, PAGE_SIZE, START_PAGE_ID, truncated_pages).expect("read torn WAL");
+        let result = block_on(read_commit(
+            &file,
+            PAGE_SIZE,
+            START_PAGE_ID,
+            truncated_pages,
+        ))
+        .expect("read torn WAL");
 
         assert!(result.is_none());
         assert_eq!(
-            file.len().expect("file len"),
+            block_on(file.len()).expect("file len"),
             START_PAGE_ID * PAGE_SIZE as u64
         );
     }
@@ -719,19 +764,29 @@ mod tests {
             is_freelist: false,
             raw: &page,
         }];
-        let pages_written =
-            append_commit(&file, PAGE_SIZE, START_PAGE_ID, header(), &frames).expect("append WAL");
+        let pages_written = block_on(append_commit(
+            &file,
+            PAGE_SIZE,
+            START_PAGE_ID,
+            header(),
+            &frames,
+        ))
+        .expect("append WAL");
         let persisted_pages = START_PAGE_ID + pages_written;
         let frame_page_offset = (START_PAGE_ID + 2) * PAGE_SIZE as u64;
-        file.write_all_at(frame_page_offset, &[9])
-            .expect("corrupt frame data");
+        block_on(file.write_all_at(frame_page_offset, &[9])).expect("corrupt frame data");
 
-        let result = read_commit(&file, PAGE_SIZE, START_PAGE_ID, persisted_pages)
-            .expect("read corrupt WAL");
+        let result = block_on(read_commit(
+            &file,
+            PAGE_SIZE,
+            START_PAGE_ID,
+            persisted_pages,
+        ))
+        .expect("read corrupt WAL");
 
         assert!(result.is_none());
         assert_eq!(
-            file.len().expect("file len"),
+            block_on(file.len()).expect("file len"),
             START_PAGE_ID * PAGE_SIZE as u64
         );
     }

--- a/crates/opfs-btree/wasm-bench/bench-core/src/engine.rs
+++ b/crates/opfs-btree/wasm-bench/bench-core/src/engine.rs
@@ -25,31 +25,32 @@ impl std::error::Error for EngineError {}
 
 /// A key/value store driven by the shared benchmark runner.
 ///
-/// Operations are synchronous (both real engines use synchronous OPFS access
-/// handles); only [`reopen`](BenchEngine::reopen) is async because it reopens
-/// the underlying file.
+/// All operations are async: the b-tree now drives the *asynchronous* OPFS
+/// File System Access APIs (`getFile()` / `createWritable()`), so every read
+/// and write is a future. SQLite's operations are synchronous and complete
+/// immediately when awaited.
 #[allow(async_fn_in_trait)]
 pub trait BenchEngine {
     /// Insert or overwrite `key`.
-    fn put(&mut self, key: &[u8], value: &[u8]) -> Result<(), EngineError>;
+    async fn put(&mut self, key: &[u8], value: &[u8]) -> Result<(), EngineError>;
 
     /// Look up `key`, returning the first byte of its value if present. The
     /// runner folds this byte into the cross-engine checksum, so engines must
     /// agree on it for identical data.
-    fn get(&mut self, key: &[u8]) -> Result<Option<u8>, EngineError>;
+    async fn get(&mut self, key: &[u8]) -> Result<Option<u8>, EngineError>;
 
     /// Delete `key` (a no-op if absent).
-    fn delete(&mut self, key: &[u8]) -> Result<(), EngineError>;
+    async fn delete(&mut self, key: &[u8]) -> Result<(), EngineError>;
 
     /// Count the rows in `[lo, hi)`, up to `limit`.
-    fn range(&mut self, lo: &[u8], hi: &[u8], limit: usize) -> Result<usize, EngineError>;
+    async fn range(&mut self, lo: &[u8], hi: &[u8], limit: usize) -> Result<usize, EngineError>;
 
     /// Open a phase. SQLite begins a transaction here; the b-tree does nothing.
-    fn begin_phase(&mut self, kind: PhaseKind) -> Result<(), EngineError>;
+    async fn begin_phase(&mut self, kind: PhaseKind) -> Result<(), EngineError>;
 
     /// Close a phase. SQLite commits; the b-tree checkpoints after write
     /// phases. Called inside the timed region, so durability cost is measured.
-    fn end_phase(&mut self, kind: PhaseKind) -> Result<(), EngineError>;
+    async fn end_phase(&mut self, kind: PhaseKind) -> Result<(), EngineError>;
 
     /// Drop and reopen the store *without* wiping it, giving a cold cache while
     /// the data persists. Used by the cold-read phase.

--- a/crates/opfs-btree/wasm-bench/bench-core/src/phases.rs
+++ b/crates/opfs-btree/wasm-bench/bench-core/src/phases.rs
@@ -159,7 +159,7 @@ impl Phase {
 /// `(op_count, checksum)`. Phase bracketing (`begin_phase`/`end_phase`) and
 /// cold reopen are handled by the [`runner`](crate::runner); this is purely the
 /// operation loop, so the semantics of each phase read top-to-bottom here.
-pub fn replay<E: BenchEngine>(
+pub async fn replay<E: BenchEngine>(
     engine: &mut E,
     phase: &Phase,
     args: &[u32],
@@ -179,26 +179,26 @@ pub fn replay<E: BenchEngine>(
     match phase.kind() {
         PhaseKind::Load => {
             for (k, v) in keys.iter().zip(vals.iter()) {
-                engine.put(k, v)?;
+                engine.put(k, v).await?;
                 ops += 1;
             }
         }
         PhaseKind::GetSeq => {
             for k in keys {
-                fold(engine.get(k)?);
+                fold(engine.get(k).await?);
                 ops += 1;
             }
         }
         PhaseKind::GetRandom | PhaseKind::GetSkewed | PhaseKind::ColdGetRandom => {
             for &raw in args {
-                fold(engine.get(keys[idx(raw)])?);
+                fold(engine.get(keys[idx(raw)]).await?);
                 ops += 1;
             }
         }
         PhaseKind::UpdateRandom => {
             for &raw in args {
                 let i = idx(raw);
-                engine.put(keys[i], vals[i])?;
+                engine.put(keys[i], vals[i]).await?;
                 ops += 1;
             }
         }
@@ -206,7 +206,7 @@ pub fn replay<E: BenchEngine>(
             for &raw in args {
                 let s = idx(raw);
                 let e = (s + RANGE_WINDOW_KEYS as usize).min(keys.len().saturating_sub(1));
-                let rows = engine.range(keys[s], keys[e], RANGE_RESULT_LIMIT)?;
+                let rows = engine.range(keys[s], keys[e], RANGE_RESULT_LIMIT).await?;
                 checksum = checksum.wrapping_add(rows as u64);
                 ops += 1;
             }
@@ -216,9 +216,9 @@ pub fn replay<E: BenchEngine>(
                 let op = packed >> 30;
                 let i = idx(packed & 0x3FFF_FFFF);
                 match op {
-                    1 => engine.put(keys[i], vals[i])?,
-                    2 => engine.delete(keys[i])?,
-                    _ => fold(engine.get(keys[i])?),
+                    1 => engine.put(keys[i], vals[i]).await?,
+                    2 => engine.delete(keys[i]).await?,
+                    _ => fold(engine.get(keys[i]).await?),
                 }
                 ops += 1;
             }

--- a/crates/opfs-btree/wasm-bench/bench-core/src/runner.rs
+++ b/crates/opfs-btree/wasm-bench/bench-core/src/runner.rs
@@ -48,18 +48,18 @@ pub async fn run<E: BenchEngine>(
         if kind.is_cold() {
             engine.reopen().await?;
         }
-        engine.begin_phase(kind)?;
-        let (op_count, checksum) = replay(engine, phase, &args, &keys, &vals)?;
-        engine.end_phase(kind)?;
+        engine.begin_phase(kind).await?;
+        let (op_count, checksum) = replay(engine, phase, &args, &keys, &vals).await?;
+        engine.end_phase(kind).await?;
         let mut elapsed = now_ms() - started;
         let mut total_ops = op_count;
 
         if kind.is_retryable_read() && elapsed < MIN_MEASURABLE_MS {
             let mut iterations = 1u32;
             while elapsed < MIN_MEASURABLE_MS && iterations < MAX_LOOP_ITERATIONS {
-                engine.begin_phase(kind)?;
-                let (ops2, _) = replay(engine, phase, &args, &keys, &vals)?;
-                engine.end_phase(kind)?;
+                engine.begin_phase(kind).await?;
+                let (ops2, _) = replay(engine, phase, &args, &keys, &vals).await?;
+                engine.end_phase(kind).await?;
                 total_ops = total_ops.saturating_add(ops2);
                 elapsed = now_ms() - started;
                 iterations += 1;

--- a/crates/opfs-btree/wasm-bench/sqlite/src/lib.rs
+++ b/crates/opfs-btree/wasm-bench/sqlite/src/lib.rs
@@ -51,7 +51,7 @@ impl SqliteEngine {
 }
 
 impl BenchEngine for SqliteEngine {
-    fn put(&mut self, key: &[u8], value: &[u8]) -> Result<(), EngineError> {
+    async fn put(&mut self, key: &[u8], value: &[u8]) -> Result<(), EngineError> {
         self.conn()
             .prepare_cached("INSERT OR REPLACE INTO kv(k,v) VALUES(?1,?2)")
             .map_err(eng)?
@@ -60,7 +60,7 @@ impl BenchEngine for SqliteEngine {
         Ok(())
     }
 
-    fn get(&mut self, key: &[u8]) -> Result<Option<u8>, EngineError> {
+    async fn get(&mut self, key: &[u8]) -> Result<Option<u8>, EngineError> {
         let mut stmt = self
             .conn()
             .prepare_cached("SELECT v FROM kv WHERE k=?1")
@@ -72,7 +72,7 @@ impl BenchEngine for SqliteEngine {
         }
     }
 
-    fn delete(&mut self, key: &[u8]) -> Result<(), EngineError> {
+    async fn delete(&mut self, key: &[u8]) -> Result<(), EngineError> {
         self.conn()
             .prepare_cached("DELETE FROM kv WHERE k=?1")
             .map_err(eng)?
@@ -81,7 +81,7 @@ impl BenchEngine for SqliteEngine {
         Ok(())
     }
 
-    fn range(&mut self, lo: &[u8], hi: &[u8], limit: usize) -> Result<usize, EngineError> {
+    async fn range(&mut self, lo: &[u8], hi: &[u8], limit: usize) -> Result<usize, EngineError> {
         let mut stmt = self
             .conn()
             .prepare_cached("SELECT v FROM kv WHERE k>=?1 AND k<?2 ORDER BY k LIMIT ?3")
@@ -93,11 +93,11 @@ impl BenchEngine for SqliteEngine {
         Ok(rows)
     }
 
-    fn begin_phase(&mut self, _kind: PhaseKind) -> Result<(), EngineError> {
+    async fn begin_phase(&mut self, _kind: PhaseKind) -> Result<(), EngineError> {
         self.conn().execute_batch("BEGIN").map_err(eng)
     }
 
-    fn end_phase(&mut self, _kind: PhaseKind) -> Result<(), EngineError> {
+    async fn end_phase(&mut self, _kind: PhaseKind) -> Result<(), EngineError> {
         self.conn().execute_batch("COMMIT").map_err(eng)
     }
 

--- a/crates/opfs-btree/wasm-bench/src/btree_engine.rs
+++ b/crates/opfs-btree/wasm-bench/src/btree_engine.rs
@@ -49,44 +49,47 @@ impl BtreeEngine {
 
 async fn open_db() -> Result<OpfsBTree<OpfsFile>, EngineError> {
     let file = OpfsFile::open(NAMESPACE).await.map_err(err)?;
-    OpfsBTree::open(file, benchmark_options()).map_err(err)
+    OpfsBTree::open(file, benchmark_options())
+        .await
+        .map_err(err)
 }
 
 impl BenchEngine for BtreeEngine {
-    fn put(&mut self, key: &[u8], value: &[u8]) -> Result<(), EngineError> {
-        self.db().put(key, value).map_err(err)
+    async fn put(&mut self, key: &[u8], value: &[u8]) -> Result<(), EngineError> {
+        self.db().put(key, value).await.map_err(err)
     }
 
-    fn get(&mut self, key: &[u8]) -> Result<Option<u8>, EngineError> {
+    async fn get(&mut self, key: &[u8]) -> Result<Option<u8>, EngineError> {
         Ok(self
             .db()
             .get(key)
+            .await
             .map_err(err)?
             .map(|v| v.first().copied().unwrap_or(0)))
     }
 
-    fn delete(&mut self, key: &[u8]) -> Result<(), EngineError> {
-        self.db().delete(key).map_err(err)
+    async fn delete(&mut self, key: &[u8]) -> Result<(), EngineError> {
+        self.db().delete(key).await.map_err(err)
     }
 
-    fn range(&mut self, lo: &[u8], hi: &[u8], limit: usize) -> Result<usize, EngineError> {
-        Ok(self.db().range(lo, hi, limit).map_err(err)?.len())
+    async fn range(&mut self, lo: &[u8], hi: &[u8], limit: usize) -> Result<usize, EngineError> {
+        Ok(self.db().range(lo, hi, limit).await.map_err(err)?.len())
     }
 
-    fn begin_phase(&mut self, _kind: PhaseKind) -> Result<(), EngineError> {
+    async fn begin_phase(&mut self, _kind: PhaseKind) -> Result<(), EngineError> {
         Ok(())
     }
 
-    fn end_phase(&mut self, kind: PhaseKind) -> Result<(), EngineError> {
+    async fn end_phase(&mut self, kind: PhaseKind) -> Result<(), EngineError> {
         if kind.is_write() {
-            self.db().checkpoint().map_err(err)?;
+            self.db().checkpoint().await.map_err(err)?;
         }
         Ok(())
     }
 
     async fn reopen(&mut self) -> Result<(), EngineError> {
         if let Some(db) = self.db.as_mut() {
-            db.checkpoint().map_err(err)?;
+            db.checkpoint().await.map_err(err)?;
         }
         // Drop the current handle before reopening; data persists on disk.
         self.db = None;


### PR DESCRIPTION
## What

An experiment: migrate the opfs-btree engine off the synchronous `FileSystemSyncAccessHandle` onto the **asynchronous** File System Access APIs (`getFile()`/`Blob.arrayBuffer()` for reads, `createWritable()` for writes), measure the cost, then absorb it.

Based on `guido/opfs-btree-freelist-bitmap` (#1038) so the diff is only the async work.

## How

- **`AsyncFile` trait** replaces `SyncFile`; the whole engine (`db.rs`, `wal.rs`) is threaded `async`, with boxed futures for the recursive insert/delete paths. Native `StdFile`/`MemoryFile` keep **sync facades** (`block_on`) so the existing test suite compiles and passes unchanged (73/73).

## Benchmark (16 KB pages, `btree_ms`, lower is better)

Same workload, two configurations:
- **sync** — `FileSystemSyncAccessHandle` (the baseline before this branch)
- **async** — this branch

| profile | phase | sync | async |
|---|---|--:|--:|
| objects | load | 66.6 | ~132 |
| objects | get_seq | 10.7 | ~10.8 |
| objects | get_random | 12.1 | ~11.8 |
| objects | range_random | 15.6 | ~16 |
| objects | **update_random** | 21.0 | **~95** |
| objects | **mixed_70_20_10** | 28.5 | **~106** |
| objects | cold_get_random | 67.0 | ~157 |
| wikipedia | load | 7.0 | ~18.7 |
| wikipedia | get_random | 10.4 | ~10.5 |
| wikipedia | range_random | 14.2 | ~18 |
| wikipedia | **update_random** | 13.2 | **~42** |
| wikipedia | **mixed_70_20_10** | 12.9 | **~39** |
| wikipedia | cold_get_random | 22.2 | ~68 |

## Takeaways

- **Reads** are essentially unchanged — they're served from the in-memory page cache, so the per-call API barely matters. The exception is `cold_get_random` (reopen → cold cache → real `getFile()` reads): **~2–3× slower** than sync, inherent to the async read API.
- **Writes** land at **~3–5× of the sync baseline**
- **The floor:** `createWritable` always copies on open, so a residual write gap vs. the sync access handle is inherent

Draft — opened for the numbers/discussion, not for merge.