### PR TITLE
Branch: permissions and query APIs

### DIFF
--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -34,6 +34,7 @@ export declare class NapiRuntime {
   executeSubscription(handle: number, onUpdate: (...args: any[]) => any): void
   getSchema(): any
   getSchemaHash(): string
+  composeBranchName(userBranch: string): string
   flush(): void
   /** Flush and close the underlying storage, releasing filesystem locks. */
   close(): void

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -826,6 +826,19 @@ impl NapiRuntime {
         Ok(SchemaHash::compute(schema).to_string())
     }
 
+    #[napi(js_name = "composeBranchName")]
+    pub fn compose_branch_name(&self, user_branch: String) -> napi::Result<String> {
+        let core = self
+            .core
+            .lock()
+            .map_err(|_| napi::Error::from_reason("lock"))?;
+        Ok(core
+            .schema_manager()
+            .compose_branch_name(&user_branch)
+            .as_str()
+            .to_string())
+    }
+
     #[napi]
     pub fn flush(&self) -> napi::Result<()> {
         let core = self

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -398,6 +398,7 @@ fn build_napi_runtime(
     let schema_manager = SchemaManager::new_with_policy_mode(
         sync_manager,
         schema,
+        runtime_schema.branch_policies,
         AppId::from_string(&app_id).unwrap_or_else(|_| AppId::from_name(&app_id)),
         &jazz_env,
         &user_branch,

--- a/crates/jazz-tools/src/client.rs
+++ b/crates/jazz-tools/src/client.rs
@@ -140,6 +140,7 @@ fn build_client_schema_manager_with_policy_mode<S: Storage + ?Sized>(
     let mut schema_manager = SchemaManager::new_with_policy_mode(
         sync_manager,
         context.schema.clone(),
+        crate::query_manager::types::BranchPolicies::default(),
         context.app_id,
         "client",
         "main",

--- a/crates/jazz-tools/src/query_manager/bindings.rs
+++ b/crates/jazz-tools/src/query_manager/bindings.rs
@@ -13,7 +13,7 @@ use crate::query_manager::manager::LocalUpdates;
 use crate::query_manager::parse_query_json;
 use crate::query_manager::query::Query;
 use crate::query_manager::session::{Session, WriteContext};
-use crate::query_manager::types::Schema;
+use crate::query_manager::types::{BranchPolicies, Schema};
 use crate::row_format::decode_row;
 use crate::row_histories::BatchId;
 use crate::runtime_core::{MutationErrorEvent, ReadDurabilityOptions, SubscriptionDelta};
@@ -30,6 +30,7 @@ struct QueryExecutionOptionsWire {
 pub struct RuntimeSchemaInput {
     pub schema: Schema,
     pub loaded_policy_bundle: bool,
+    pub branch_policies: BranchPolicies,
 }
 
 #[derive(Debug, Deserialize)]
@@ -37,16 +38,11 @@ pub struct RuntimeSchemaInput {
 struct RuntimeSchemaEnvelopeWire {
     #[serde(rename = "__jazzRuntimeSchema")]
     version: u8,
-    schema: Schema,
+    schema: JsonValue,
     #[serde(default)]
     loaded_policy_bundle: bool,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(untagged)]
-enum RuntimeSchemaWire {
-    Envelope(RuntimeSchemaEnvelopeWire),
-    Schema(Schema),
+    #[serde(default)]
+    branch_policies: BranchPolicies,
 }
 
 pub fn parse_query_input(query_json: &str) -> Result<Query, String> {
@@ -54,24 +50,40 @@ pub fn parse_query_input(query_json: &str) -> Result<Query, String> {
 }
 
 pub fn parse_runtime_schema_input(schema_json: &str) -> Result<RuntimeSchemaInput, String> {
-    match serde_json::from_str::<RuntimeSchemaWire>(schema_json).map_err(|err| err.to_string())? {
-        RuntimeSchemaWire::Envelope(envelope) => {
-            if envelope.version != 1 {
-                return Err(format!(
-                    "unsupported runtime schema envelope version {}",
-                    envelope.version
-                ));
-            }
-            Ok(RuntimeSchemaInput {
-                schema: envelope.schema,
-                loaded_policy_bundle: envelope.loaded_policy_bundle,
-            })
+    let value = serde_json::from_str::<JsonValue>(schema_json).map_err(|err| err.to_string())?;
+
+    if value
+        .as_object()
+        .and_then(|object| object.get("__jazzRuntimeSchema"))
+        .is_some()
+    {
+        let envelope = serde_json::from_value::<RuntimeSchemaEnvelopeWire>(value)
+            .map_err(|err| err.to_string())?;
+        if envelope.version != 1 {
+            return Err(format!(
+                "unsupported runtime schema envelope version {}",
+                envelope.version
+            ));
         }
-        RuntimeSchemaWire::Schema(schema) => Ok(RuntimeSchemaInput {
-            schema,
-            loaded_policy_bundle: false,
-        }),
+        return Ok(RuntimeSchemaInput {
+            schema: parse_schema_value(envelope.schema)?,
+            loaded_policy_bundle: envelope.loaded_policy_bundle,
+            branch_policies: envelope.branch_policies,
+        });
     }
+
+    Ok(RuntimeSchemaInput {
+        schema: parse_schema_value(value)?,
+        loaded_policy_bundle: false,
+        branch_policies: BranchPolicies::default(),
+    })
+}
+
+fn parse_schema_value(mut schema: JsonValue) -> Result<Schema, String> {
+    if let JsonValue::Object(object) = &mut schema {
+        object.remove("branch_policies");
+    }
+    serde_json::from_value(schema).map_err(|err| err.to_string())
 }
 
 pub fn parse_session_input(session_json: Option<&str>) -> Result<Option<Session>, String> {
@@ -444,6 +456,50 @@ mod tests {
 
         assert!(input.loaded_policy_bundle);
         assert!(input.schema.contains_key(&TableName::new("todos")));
+    }
+
+    #[test]
+    fn runtime_schema_envelope_reads_branch_policies() {
+        let schema_json = r#"{
+            "__jazzRuntimeSchema": 1,
+            "schema": {
+                "todos": {
+                    "columns": [
+                        {
+                            "name": "title",
+                            "column_type": { "type": "Text" },
+                            "nullable": false
+                        }
+                    ]
+                },
+                "branch_policies": {
+                    "branches": {
+                        "todos": {}
+                    }
+                }
+            },
+            "branchPolicies": {
+                "branches": {
+                    "todos": {}
+                }
+            }
+        }"#;
+
+        let input = parse_runtime_schema_input(schema_json).expect("parse runtime schema");
+
+        assert_eq!(input.branch_policies.len(), 1);
+        assert!(
+            !input
+                .schema
+                .contains_key(&TableName::new("branch_policies"))
+        );
+        assert!(
+            input
+                .branch_policies
+                .get(&TableName::new("branches"))
+                .expect("branch table policies")
+                .contains_key(&TableName::new("todos"))
+        );
     }
 
     #[test]

--- a/crates/jazz-tools/src/query_manager/graph/compile.rs
+++ b/crates/jazz-tools/src/query_manager/graph/compile.rs
@@ -3,8 +3,8 @@ use std::{cmp::Ordering, ops::Bound};
 
 use crate::object::{BranchName, ObjectId};
 use crate::query_manager::types::{
-    ColumnDescriptor, ColumnName, ColumnType, ComposedBranchName, RowDescriptor, RowPolicyMode,
-    Schema, SchemaHash, TableName, TupleDescriptor, Value,
+    BranchPolicies, ColumnDescriptor, ColumnName, ColumnType, ComposedBranchName, RowDescriptor,
+    RowPolicyMode, Schema, SchemaHash, TableName, TupleDescriptor, Value,
 };
 use crate::schema_manager::{
     SchemaContext, translate_column_for_index, translate_table_name_to_schema,
@@ -460,6 +460,7 @@ impl QueryGraph {
             session,
             schema_context,
             row_policy_mode,
+            &BranchPolicies::default(),
         )
     }
 
@@ -535,6 +536,7 @@ impl QueryGraph {
         session: Option<Session>,
         schema_context: &SchemaContext,
         row_policy_mode: RowPolicyMode,
+        branch_policies: &BranchPolicies,
     ) -> Option<Self> {
         // Build branch -> schema hash map for column translation.
         // Use full hashes from SchemaContext (do not re-parse branch strings, which only encode
@@ -692,14 +694,17 @@ impl QueryGraph {
                 .first()
                 .cloned()
                 .unwrap_or_else(|| "main".to_string());
-            let policy_node = PolicyFilterNode::new_with_branch_and_policy_mode(
+            let policy_node = PolicyFilterNode::new_with_options(
                 current_descriptor.clone(),
                 policy,
                 session.clone(),
                 schema.clone(),
                 plan.table.as_str(),
-                branch_for_policy,
-                row_policy_mode,
+                crate::query_manager::graph_nodes::policy_filter::PolicyFilterOptions::for_branch(
+                    branch_for_policy,
+                )
+                .with_row_policy_mode(row_policy_mode)
+                .with_branch_policies(branch_policies.clone()),
             );
             let inherits_tables: Vec<TableName> = policy_node
                 .inherits_tables()
@@ -962,6 +967,24 @@ impl QueryGraph {
         schema_context: &SchemaContext,
         row_policy_mode: RowPolicyMode,
     ) -> Result<Self, QueryCompileError> {
+        Self::try_compile_with_schema_context_and_branch_policies(
+            query,
+            schema,
+            session,
+            schema_context,
+            row_policy_mode,
+            &BranchPolicies::default(),
+        )
+    }
+
+    pub fn try_compile_with_schema_context_and_branch_policies(
+        query: &Query,
+        schema: &Schema,
+        session: Option<Session>,
+        schema_context: &SchemaContext,
+        row_policy_mode: RowPolicyMode,
+        branch_policies: &BranchPolicies,
+    ) -> Result<Self, QueryCompileError> {
         let branches: Vec<String> = if query.branches.is_empty() {
             schema_context
                 .all_branch_names()
@@ -994,6 +1017,7 @@ impl QueryGraph {
             session,
             schema_context,
             row_policy_mode,
+            branch_policies,
         )
         .ok_or_else(|| {
             QueryCompileError::InvalidPlan(

--- a/crates/jazz-tools/src/query_manager/graph/execute.rs
+++ b/crates/jazz-tools/src/query_manager/graph/execute.rs
@@ -692,8 +692,8 @@ impl QueryGraph {
                         .unwrap_or_default();
 
                     if let Some(GraphNode::PolicyFilter(policy_node)) = self.get_node_mut(node_id) {
-                        // Use process_with_context if the policy has INHERITS clauses
-                        let delta = if policy_node.has_inherits() {
+                        // Use process_with_context if the policy needs storage-backed context.
+                        let delta = if policy_node.needs_context() {
                             policy_node.process_with_context(
                                 input_delta,
                                 storage,

--- a/crates/jazz-tools/src/query_manager/graph_nodes/policy_filter.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/policy_filter.rs
@@ -11,13 +11,16 @@ use crate::query_manager::encoding::column_is_null;
 use crate::query_manager::graph_nodes::policy_eval::{
     PolicyContextEvaluator, collect_policy_dependency_tables,
 };
+use crate::query_manager::permission_routing::{
+    PermissionRoute, bind_branch_refs, policy_for_operation, resolve_branch_route_with_policies,
+};
 use crate::query_manager::policy::{
     Operation, PolicyExpr, evaluate_expr_recursive_with_row_id, normalize_recursive_max_depth,
 };
 use crate::query_manager::session::Session;
 use crate::query_manager::types::{
-    LoadedRow, Row, RowDescriptor, RowPolicyMode, Schema, TableName, Tuple, TupleDelta,
-    TupleElement,
+    BranchPolicies, LoadedRow, Row, RowDescriptor, RowPolicyMode, Schema, TableName, Tuple,
+    TupleDelta, TupleElement,
 };
 
 use crate::storage::Storage;
@@ -41,6 +44,7 @@ pub struct PolicyFilterNode {
     /// Branch name for index lookups.
     branch: String,
     row_policy_mode: RowPolicyMode,
+    branch_policies: BranchPolicies,
     /// Initial recursion depth used for policy evaluation.
     initial_depth: usize,
     /// Current tuples that pass the policy.
@@ -62,6 +66,7 @@ pub(crate) struct PolicyFilterOptions {
     initial_depth: usize,
     row_policy_mode: RowPolicyMode,
     policy_operation: Operation,
+    branch_policies: BranchPolicies,
 }
 
 impl PolicyFilterOptions {
@@ -95,7 +100,15 @@ impl Default for PolicyFilterOptions {
             initial_depth: 0,
             row_policy_mode: RowPolicyMode::PermissiveLocal,
             policy_operation: Operation::Select,
+            branch_policies: BranchPolicies::default(),
         }
+    }
+}
+
+impl PolicyFilterOptions {
+    pub(crate) fn with_branch_policies(mut self, branch_policies: BranchPolicies) -> Self {
+        self.branch_policies = branch_policies;
+        self
     }
 }
 
@@ -219,6 +232,7 @@ impl PolicyFilterNode {
             table_name,
             branch: options.branch,
             row_policy_mode: options.row_policy_mode,
+            branch_policies: options.branch_policies,
             initial_depth: options.initial_depth,
             current_tuples: AHashSet::new(),
             input_tuples: AHashSet::new(),
@@ -232,6 +246,10 @@ impl PolicyFilterNode {
     /// Returns true if this policy contains clauses requiring context evaluation.
     pub fn has_inherits(&self) -> bool {
         self.has_inherits
+    }
+
+    pub fn needs_context(&self) -> bool {
+        self.has_inherits || (!self.branch_policies.is_empty() && self.branch != "main")
     }
 
     /// Returns tables that can affect policy outcome for this node.
@@ -368,6 +386,25 @@ impl PolicyFilterNode {
         io: &dyn Storage,
         row_loader: &mut dyn FnMut(ObjectId, Option<TableName>) -> Option<LoadedRow>,
     ) -> bool {
+        let policy = match resolve_branch_route_with_policies(
+            &self.schema,
+            &self.branch_policies,
+            &TableName::new(&self.table_name),
+            &self.branch,
+            self.policy_operation,
+            io,
+            Some(&self.session),
+        ) {
+            PermissionRoute::Normal => self.policy.clone(),
+            PermissionRoute::Branch { policy, context } => {
+                let Some(operation_policy) = policy_for_operation(policy, self.policy_operation)
+                else {
+                    return false;
+                };
+                bind_branch_refs(operation_policy, &context)
+            }
+            PermissionRoute::NoBranchPolicy | PermissionRoute::Deny => return false,
+        };
         let mut evaluator = PolicyContextEvaluator::new(
             &self.schema,
             &self.session,
@@ -380,7 +417,7 @@ impl PolicyFilterNode {
             row,
             &self.descriptor,
             &self.table_name,
-            Some(&self.policy),
+            Some(&policy),
             io,
             row_loader,
             self.initial_depth,

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -29,9 +29,9 @@ use super::query::Query;
 use super::session::Session;
 use super::settlement_eval_cache::SettlementEvalCache;
 use super::types::{
-    ColumnName, ComposedBranchName, LoadedRow, OrderedAdded, OrderedRowDelta, Row, RowDelta,
-    RowDescriptor, RowPolicyMode, Schema, SchemaHash, TableName, TablePolicies, Tuple, Value,
-    build_ordered_delta_with_post_ids,
+    BranchPolicies, ColumnName, ComposedBranchName, LoadedRow, OrderedAdded, OrderedRowDelta, Row,
+    RowDelta, RowDescriptor, RowPolicyMode, Schema, SchemaHash, TableName, TablePolicies, Tuple,
+    Value, build_ordered_delta_with_post_ids,
 };
 
 /// Error types for QueryManager operations.
@@ -491,6 +491,7 @@ pub struct QueryManager {
     pub(super) schema: Arc<Schema>,
     pub(super) row_policy_mode: RowPolicyMode,
     pub(super) authorization_schema: Option<Arc<Schema>>,
+    pub(super) authorization_branch_policies: BranchPolicies,
     pub(super) authorization_schema_required: bool,
     pub(super) authorization_context_cache: HashMap<(String, String), Arc<SchemaContext>>,
 
@@ -644,6 +645,7 @@ impl QueryManager {
             schema: Arc::new(Schema::new()),
             row_policy_mode: RowPolicyMode::PermissiveLocal,
             authorization_schema: None,
+            authorization_branch_policies: BranchPolicies::default(),
             authorization_schema_required: false,
             authorization_context_cache: HashMap::new(),
             pending_catalogue_updates: Vec::new(),
@@ -702,6 +704,7 @@ impl QueryManager {
         } else {
             None
         };
+        self.authorization_branch_policies = BranchPolicies::default();
         self.authorization_context_cache.clear();
         self.authorization_schema_required = false;
         self.write_table_cache.clear();
@@ -717,7 +720,16 @@ impl QueryManager {
     }
 
     pub fn set_authorization_schema(&mut self, schema: Schema) {
+        self.set_authorization_schema_with_branch_policies(schema, BranchPolicies::default());
+    }
+
+    pub fn set_authorization_schema_with_branch_policies(
+        &mut self,
+        schema: Schema,
+        branch_policies: BranchPolicies,
+    ) {
         self.authorization_schema = Some(Arc::new(schema));
+        self.authorization_branch_policies = branch_policies;
         self.authorization_context_cache.clear();
         self.row_policy_mode = RowPolicyMode::Enforcing;
         self.authorization_schema_required = true;
@@ -799,13 +811,15 @@ impl QueryManager {
         session: Option<Session>,
         schema_context: &SchemaContext,
         row_policy_mode: RowPolicyMode,
+        branch_policies: &BranchPolicies,
     ) -> Result<QueryGraph, QueryCompileError> {
-        QueryGraph::try_compile_with_schema_context(
+        QueryGraph::try_compile_with_schema_context_and_branch_policies(
             query,
             schema,
             session,
             schema_context,
             row_policy_mode,
+            branch_policies,
         )
     }
 
@@ -930,6 +944,7 @@ impl QueryManager {
         let current_schema = self.schema.clone();
         let current_schema_context = self.schema_context.clone();
         let authorization_schema = self.authorization_schema.clone();
+        let authorization_branch_policies = self.authorization_branch_policies.clone();
 
         // Recompile local subscriptions
         for (sub_id, sub) in &mut self.subscriptions {
@@ -970,6 +985,7 @@ impl QueryManager {
                     sub.session.clone(),
                     &current_schema_context,
                     compile_row_policy_mode,
+                    &authorization_branch_policies,
                 ) {
                     Ok(new_graph) => {
                         let policy_context_tables =
@@ -1069,6 +1085,7 @@ impl QueryManager {
                 session,
                 &subscription_context,
                 RowPolicyMode::PermissiveLocal,
+                &self.authorization_branch_policies,
             ) {
                 Ok(new_graph) => {
                     let branches = Self::resolved_server_query_branches(

--- a/crates/jazz-tools/src/query_manager/mod.rs
+++ b/crates/jazz-tools/src/query_manager/mod.rs
@@ -6,6 +6,7 @@ pub mod index;
 pub mod indices;
 pub mod magic_columns;
 pub mod manager;
+pub mod permission_routing;
 pub mod policy;
 pub mod policy_counters;
 pub mod policy_graph;

--- a/crates/jazz-tools/src/query_manager/permission_routing.rs
+++ b/crates/jazz-tools/src/query_manager/permission_routing.rs
@@ -1,19 +1,23 @@
 use crate::object::{BranchName, ObjectId};
+use crate::query_manager::graph_nodes::policy_eval::PolicyContextEvaluator;
 use crate::query_manager::manager::QueryManager;
 use crate::query_manager::policy::{Operation, PolicyExpr, PolicyValue};
 use crate::query_manager::relation_ir::{PredicateExpr, RelExpr, ValueRef};
+use crate::query_manager::session::Session;
 use crate::query_manager::types::{
-    ComposedBranchName, RowDescriptor, TableName, TablePolicies, Value,
+    BranchPolicies, ComposedBranchName, Row, RowDescriptor, RowPolicyMode, Schema, TableName,
+    TablePolicies, Value,
 };
 use crate::row_format::decode_row;
 use crate::storage::Storage;
+use std::collections::HashSet;
 
 #[derive(Debug)]
 pub struct ResolvedBranchRow<'a> {
     pub table_name: &'a TableName,
     pub row_id: ObjectId,
     pub descriptor: &'a RowDescriptor,
-    pub content: &'a [u8],
+    pub content: Vec<u8>,
 }
 
 impl ResolvedBranchRow<'_> {
@@ -23,7 +27,7 @@ impl ResolvedBranchRow<'_> {
             .columns
             .iter()
             .position(|descriptor| descriptor.name.as_str() == column)?;
-        decode_row(self.descriptor, self.content)
+        decode_row(self.descriptor, &self.content)
             .ok()?
             .get(index)
             .cloned()
@@ -281,31 +285,140 @@ impl QueryManager {
         target_table: &TableName,
         branch: &str,
         op: Operation,
-        storage: &'a impl Storage,
+        storage: &'a dyn Storage,
+        session: Option<&'a Session>,
     ) -> PermissionRoute<'a> {
-        if branch == "main" || branch == self.current_branch() {
-            return PermissionRoute::Normal;
+        resolve_branch_route_with_policies(
+            self.authorization_schema
+                .as_deref()
+                .unwrap_or(self.schema.as_ref()),
+            &self.authorization_branch_policies,
+            target_table,
+            branch,
+            op,
+            storage,
+            session,
+        )
+    }
+}
+
+pub(crate) fn resolve_branch_route_with_policies<'a>(
+    schema: &'a Schema,
+    branch_policies: &'a BranchPolicies,
+    target_table: &TableName,
+    branch: &str,
+    op: Operation,
+    storage: &dyn Storage,
+    session: Option<&'a Session>,
+) -> PermissionRoute<'a> {
+    if branch == "main" {
+        return PermissionRoute::Normal;
+    }
+
+    let Some(composed) = ComposedBranchName::parse(&BranchName::new(branch)) else {
+        return PermissionRoute::Deny;
+    };
+
+    if composed.user_branch == "main" {
+        return PermissionRoute::Normal;
+    }
+
+    let Ok(row_uuid) = uuid::Uuid::parse_str(&composed.user_branch) else {
+        return PermissionRoute::Deny;
+    };
+    let row_id = ObjectId::from_uuid(row_uuid);
+    let Some(session) = session else {
+        return PermissionRoute::Deny;
+    };
+    let main_branch = ComposedBranchName::new(&composed.env, composed.schema_hash, "main")
+        .to_branch_name()
+        .as_str()
+        .to_string();
+
+    for (backing_table, policies_by_target) in branch_policies {
+        let Some(target_policy) = policies_by_target.get(target_table) else {
+            continue;
+        };
+        let Some(backing_schema) = schema.get(backing_table) else {
+            continue;
+        };
+        let Ok(Some(backing_row)) =
+            storage.load_visible_region_row(backing_table.as_str(), &main_branch, row_id)
+        else {
+            continue;
+        };
+        if backing_row.is_hard_deleted() {
+            continue;
         }
 
-        let Some(composed) = ComposedBranchName::parse(&BranchName::new(branch)) else {
+        let Some(backing_read_policy) = backing_schema.policies.select_policy() else {
             return PermissionRoute::Deny;
         };
+        let row = Row::new(
+            row_id,
+            backing_row.data.to_vec(),
+            backing_row.batch_id(),
+            backing_row.row_provenance(),
+        );
+        let mut evaluator =
+            PolicyContextEvaluator::new(schema, session, &main_branch, RowPolicyMode::Enforcing);
+        let mut visited_referencing = HashSet::new();
+        let mut row_loader = |related_id: ObjectId, table_hint: Option<TableName>| {
+            let table = table_hint?;
+            let row = storage
+                .load_visible_region_row(table.as_str(), &main_branch, related_id)
+                .ok()??;
+            Some(crate::query_manager::types::LoadedRow::new(
+                row.data.clone(),
+                row.row_provenance(),
+                [(related_id, BranchName::new(&main_branch))]
+                    .into_iter()
+                    .collect(),
+                row.batch_id(),
+            ))
+        };
 
-        if composed.user_branch == "main" {
-            return PermissionRoute::Normal;
+        if !evaluator.evaluate_row_access(
+            Operation::Select,
+            &row,
+            &backing_schema.columns,
+            backing_table.as_str(),
+            Some(backing_read_policy),
+            storage,
+            &mut row_loader,
+            0,
+            &mut visited_referencing,
+        ) {
+            return PermissionRoute::Deny;
         }
 
-        let Ok(_row_uuid) = uuid::Uuid::parse_str(&composed.user_branch) else {
-            return PermissionRoute::Deny;
-        };
+        if policy_for_operation(target_policy, op).is_none() {
+            return PermissionRoute::NoBranchPolicy;
+        }
 
-        let _ = (target_table, op, storage);
-        // TODO(task5): QueryManager currently does not retain the decoded
-        // CurrentPermissionsSummary.branch_policies map. Once the call sites pass
-        // or expose that summary, resolve the backing row id from user_branch,
-        // load the backing row, gate it on normal readability, and return
-        // PermissionRoute::Branch or NoBranchPolicy.
-        PermissionRoute::Deny
+        return PermissionRoute::Branch {
+            policy: target_policy,
+            context: ResolvedBranchRow {
+                table_name: backing_table,
+                row_id,
+                descriptor: &backing_schema.columns,
+                content: row.data.to_vec(),
+            },
+        };
+    }
+
+    PermissionRoute::Deny
+}
+
+pub(crate) fn policy_for_operation(
+    policies: &TablePolicies,
+    operation: Operation,
+) -> Option<&PolicyExpr> {
+    match operation {
+        Operation::Select => policies.select_policy(),
+        Operation::Insert => policies.insert_policy(),
+        Operation::Update => policies.update_using_policy(),
+        Operation::Delete => policies.effective_delete_using(),
     }
 }
 
@@ -338,7 +451,7 @@ mod tests {
             table_name: &table_name,
             row_id,
             descriptor: &descriptor,
-            content: &content,
+            content,
         };
         let expr = PolicyExpr::And(vec![
             PolicyExpr::Cmp {

--- a/crates/jazz-tools/src/query_manager/permission_routing.rs
+++ b/crates/jazz-tools/src/query_manager/permission_routing.rs
@@ -1,0 +1,374 @@
+use crate::object::{BranchName, ObjectId};
+use crate::query_manager::manager::QueryManager;
+use crate::query_manager::policy::{Operation, PolicyExpr, PolicyValue};
+use crate::query_manager::relation_ir::{PredicateExpr, RelExpr, ValueRef};
+use crate::query_manager::types::{
+    ComposedBranchName, RowDescriptor, TableName, TablePolicies, Value,
+};
+use crate::row_format::decode_row;
+use crate::storage::Storage;
+
+#[derive(Debug)]
+pub struct ResolvedBranchRow<'a> {
+    pub table_name: &'a TableName,
+    pub row_id: ObjectId,
+    pub descriptor: &'a RowDescriptor,
+    pub content: &'a [u8],
+}
+
+impl ResolvedBranchRow<'_> {
+    pub fn column_value(&self, column: &str) -> Option<Value> {
+        let index = self
+            .descriptor
+            .columns
+            .iter()
+            .position(|descriptor| descriptor.name.as_str() == column)?;
+        decode_row(self.descriptor, self.content)
+            .ok()?
+            .get(index)
+            .cloned()
+    }
+}
+
+pub type BranchPolicyContext<'a> = ResolvedBranchRow<'a>;
+
+pub enum PermissionRoute<'a> {
+    Normal,
+    Branch {
+        policy: &'a TablePolicies,
+        context: ResolvedBranchRow<'a>,
+    },
+    NoBranchPolicy,
+    Deny,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct PolicyEvalRefs<'a> {
+    pub row_id: Option<ObjectId>,
+    pub branch_context: Option<&'a BranchPolicyContext<'a>>,
+}
+
+impl<'a> PolicyEvalRefs<'a> {
+    pub fn with_branch_context(mut self, ctx: &'a BranchPolicyContext<'a>) -> Self {
+        self.branch_context = Some(ctx);
+        self
+    }
+}
+
+pub fn bind_branch_refs(expr: &PolicyExpr, ctx: &ResolvedBranchRow<'_>) -> PolicyExpr {
+    fn bind_policy_value(value: &PolicyValue, ctx: &ResolvedBranchRow<'_>) -> PolicyValue {
+        match value {
+            PolicyValue::BranchRef(column) => {
+                PolicyValue::Literal(ctx.column_value(column).unwrap_or(Value::Null))
+            }
+            PolicyValue::Literal(value) => PolicyValue::Literal(value.clone()),
+            PolicyValue::SessionRef(path) => PolicyValue::SessionRef(path.clone()),
+        }
+    }
+
+    match expr {
+        PolicyExpr::Cmp { column, op, value } => PolicyExpr::Cmp {
+            column: column.clone(),
+            op: op.clone(),
+            value: bind_policy_value(value, ctx),
+        },
+        PolicyExpr::SessionCmp { path, op, value } => PolicyExpr::SessionCmp {
+            path: path.clone(),
+            op: op.clone(),
+            value: value.clone(),
+        },
+        PolicyExpr::IsNull { column } => PolicyExpr::IsNull {
+            column: column.clone(),
+        },
+        PolicyExpr::SessionIsNull { path } => PolicyExpr::SessionIsNull { path: path.clone() },
+        PolicyExpr::IsNotNull { column } => PolicyExpr::IsNotNull {
+            column: column.clone(),
+        },
+        PolicyExpr::SessionIsNotNull { path } => {
+            PolicyExpr::SessionIsNotNull { path: path.clone() }
+        }
+        PolicyExpr::Contains { column, value } => PolicyExpr::Contains {
+            column: column.clone(),
+            value: bind_policy_value(value, ctx),
+        },
+        PolicyExpr::SessionContains { path, value } => PolicyExpr::SessionContains {
+            path: path.clone(),
+            value: value.clone(),
+        },
+        PolicyExpr::In {
+            column,
+            session_path,
+        } => PolicyExpr::In {
+            column: column.clone(),
+            session_path: session_path.clone(),
+        },
+        PolicyExpr::InList { column, values } => PolicyExpr::InList {
+            column: column.clone(),
+            values: values
+                .iter()
+                .map(|value| bind_policy_value(value, ctx))
+                .collect(),
+        },
+        PolicyExpr::SessionInList { path, values } => PolicyExpr::SessionInList {
+            path: path.clone(),
+            values: values.clone(),
+        },
+        PolicyExpr::Exists { table, condition } => PolicyExpr::Exists {
+            table: table.clone(),
+            condition: Box::new(bind_branch_refs(condition, ctx)),
+        },
+        PolicyExpr::ExistsRel { rel } => PolicyExpr::ExistsRel {
+            rel: bind_relation_branch_refs(rel, ctx),
+        },
+        PolicyExpr::Inherits {
+            operation,
+            via_column,
+            max_depth,
+        } => PolicyExpr::Inherits {
+            operation: *operation,
+            via_column: via_column.clone(),
+            max_depth: *max_depth,
+        },
+        PolicyExpr::InheritsReferencing {
+            operation,
+            source_table,
+            via_column,
+            max_depth,
+        } => PolicyExpr::InheritsReferencing {
+            operation: *operation,
+            source_table: source_table.clone(),
+            via_column: via_column.clone(),
+            max_depth: *max_depth,
+        },
+        PolicyExpr::And(exprs) => PolicyExpr::And(
+            exprs
+                .iter()
+                .map(|expr| bind_branch_refs(expr, ctx))
+                .collect(),
+        ),
+        PolicyExpr::Or(exprs) => PolicyExpr::Or(
+            exprs
+                .iter()
+                .map(|expr| bind_branch_refs(expr, ctx))
+                .collect(),
+        ),
+        PolicyExpr::Not(expr) => PolicyExpr::Not(Box::new(bind_branch_refs(expr, ctx))),
+        PolicyExpr::True => PolicyExpr::True,
+        PolicyExpr::False => PolicyExpr::False,
+    }
+}
+
+pub fn bind_relation_branch_refs(rel: &RelExpr, ctx: &ResolvedBranchRow<'_>) -> RelExpr {
+    fn bind_value_ref(value_ref: &ValueRef, ctx: &ResolvedBranchRow<'_>) -> ValueRef {
+        match value_ref {
+            ValueRef::BranchRef(column) => {
+                ValueRef::Literal(ctx.column_value(column).unwrap_or(Value::Null))
+            }
+            ValueRef::Literal(value) => ValueRef::Literal(value.clone()),
+            ValueRef::SessionRef(path) => ValueRef::SessionRef(path.clone()),
+            ValueRef::OuterColumn(column) => ValueRef::OuterColumn(column.clone()),
+            ValueRef::FrontierColumn(column) => ValueRef::FrontierColumn(column.clone()),
+            ValueRef::RowId(row_id) => ValueRef::RowId(*row_id),
+        }
+    }
+
+    fn bind_predicate(predicate: &PredicateExpr, ctx: &ResolvedBranchRow<'_>) -> PredicateExpr {
+        match predicate {
+            PredicateExpr::Cmp { left, op, right } => PredicateExpr::Cmp {
+                left: left.clone(),
+                op: *op,
+                right: bind_value_ref(right, ctx),
+            },
+            PredicateExpr::Contains { left, right } => PredicateExpr::Contains {
+                left: left.clone(),
+                right: bind_value_ref(right, ctx),
+            },
+            PredicateExpr::IsNull { column } => PredicateExpr::IsNull {
+                column: column.clone(),
+            },
+            PredicateExpr::IsNotNull { column } => PredicateExpr::IsNotNull {
+                column: column.clone(),
+            },
+            PredicateExpr::In { left, values } => PredicateExpr::In {
+                left: left.clone(),
+                values: values
+                    .iter()
+                    .map(|value| bind_value_ref(value, ctx))
+                    .collect(),
+            },
+            PredicateExpr::And(predicates) => PredicateExpr::And(
+                predicates
+                    .iter()
+                    .map(|predicate| bind_predicate(predicate, ctx))
+                    .collect(),
+            ),
+            PredicateExpr::Or(predicates) => PredicateExpr::Or(
+                predicates
+                    .iter()
+                    .map(|predicate| bind_predicate(predicate, ctx))
+                    .collect(),
+            ),
+            PredicateExpr::Not(predicate) => {
+                PredicateExpr::Not(Box::new(bind_predicate(predicate, ctx)))
+            }
+            PredicateExpr::True => PredicateExpr::True,
+            PredicateExpr::False => PredicateExpr::False,
+        }
+    }
+
+    match rel {
+        RelExpr::TableScan { table } => RelExpr::TableScan { table: *table },
+        RelExpr::Union { inputs } => RelExpr::Union {
+            inputs: inputs
+                .iter()
+                .map(|input| bind_relation_branch_refs(input, ctx))
+                .collect(),
+        },
+        RelExpr::Filter { input, predicate } => RelExpr::Filter {
+            input: Box::new(bind_relation_branch_refs(input, ctx)),
+            predicate: bind_predicate(predicate, ctx),
+        },
+        RelExpr::Join {
+            left,
+            right,
+            on,
+            join_kind,
+        } => RelExpr::Join {
+            left: Box::new(bind_relation_branch_refs(left, ctx)),
+            right: Box::new(bind_relation_branch_refs(right, ctx)),
+            on: on.clone(),
+            join_kind: *join_kind,
+        },
+        RelExpr::Project { input, columns } => RelExpr::Project {
+            input: Box::new(bind_relation_branch_refs(input, ctx)),
+            columns: columns.clone(),
+        },
+        RelExpr::Gather {
+            seed,
+            step,
+            frontier_key,
+            max_depth,
+            dedupe_key,
+        } => RelExpr::Gather {
+            seed: Box::new(bind_relation_branch_refs(seed, ctx)),
+            step: Box::new(bind_relation_branch_refs(step, ctx)),
+            frontier_key: frontier_key.clone(),
+            max_depth: *max_depth,
+            dedupe_key: dedupe_key.clone(),
+        },
+        RelExpr::Distinct { input, key } => RelExpr::Distinct {
+            input: Box::new(bind_relation_branch_refs(input, ctx)),
+            key: key.clone(),
+        },
+        RelExpr::OrderBy { input, terms } => RelExpr::OrderBy {
+            input: Box::new(bind_relation_branch_refs(input, ctx)),
+            terms: terms.clone(),
+        },
+        RelExpr::Offset { input, offset } => RelExpr::Offset {
+            input: Box::new(bind_relation_branch_refs(input, ctx)),
+            offset: *offset,
+        },
+        RelExpr::Limit { input, limit } => RelExpr::Limit {
+            input: Box::new(bind_relation_branch_refs(input, ctx)),
+            limit: *limit,
+        },
+    }
+}
+
+impl QueryManager {
+    pub fn resolve_branch_route<'a>(
+        &'a self,
+        target_table: &TableName,
+        branch: &str,
+        op: Operation,
+        storage: &'a impl Storage,
+    ) -> PermissionRoute<'a> {
+        if branch == "main" || branch == self.current_branch() {
+            return PermissionRoute::Normal;
+        }
+
+        let Some(composed) = ComposedBranchName::parse(&BranchName::new(branch)) else {
+            return PermissionRoute::Deny;
+        };
+
+        if composed.user_branch == "main" {
+            return PermissionRoute::Normal;
+        }
+
+        let Ok(_row_uuid) = uuid::Uuid::parse_str(&composed.user_branch) else {
+            return PermissionRoute::Deny;
+        };
+
+        let _ = (target_table, op, storage);
+        // TODO(task5): QueryManager currently does not retain the decoded
+        // CurrentPermissionsSummary.branch_policies map. Once the call sites pass
+        // or expose that summary, resolve the backing row id from user_branch,
+        // load the backing row, gate it on normal readability, and return
+        // PermissionRoute::Branch or NoBranchPolicy.
+        PermissionRoute::Deny
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query_manager::policy::CmpOp;
+    use crate::query_manager::types::{ColumnDescriptor, ColumnType};
+    use crate::row_format::encode_row;
+
+    #[test]
+    fn bind_branch_refs_rewrites_branch_ref_operands() {
+        // This helper is tested directly because branch-reference binding is not
+        // user-observable until route enforcement is wired in the next tasks.
+        let table_name = TableName::new("projects");
+        let row_id = ObjectId::new();
+        let descriptor = RowDescriptor::new(vec![
+            ColumnDescriptor::new("projectId", ColumnType::Text),
+            ColumnDescriptor::new("name", ColumnType::Text),
+        ]);
+        let content = encode_row(
+            &descriptor,
+            &[
+                Value::Text("p1".to_string()),
+                Value::Text("Project".to_string()),
+            ],
+        )
+        .expect("encode backing row");
+        let backing_row = ResolvedBranchRow {
+            table_name: &table_name,
+            row_id,
+            descriptor: &descriptor,
+            content: &content,
+        };
+        let expr = PolicyExpr::And(vec![
+            PolicyExpr::Cmp {
+                column: "projectId".to_string(),
+                op: CmpOp::Eq,
+                value: PolicyValue::BranchRef("projectId".to_string()),
+            },
+            PolicyExpr::Cmp {
+                column: "status".to_string(),
+                op: CmpOp::Eq,
+                value: PolicyValue::Literal(Value::Text("active".to_string())),
+            },
+        ]);
+
+        let bound = bind_branch_refs(&expr, &backing_row);
+
+        assert_eq!(
+            bound,
+            PolicyExpr::And(vec![
+                PolicyExpr::Cmp {
+                    column: "projectId".to_string(),
+                    op: CmpOp::Eq,
+                    value: PolicyValue::Literal(Value::Text("p1".to_string())),
+                },
+                PolicyExpr::Cmp {
+                    column: "status".to_string(),
+                    op: CmpOp::Eq,
+                    value: PolicyValue::Literal(Value::Text("active".to_string())),
+                },
+            ])
+        );
+    }
+}

--- a/crates/jazz-tools/src/query_manager/permission_routing.rs
+++ b/crates/jazz-tools/src/query_manager/permission_routing.rs
@@ -46,6 +46,52 @@ pub enum PermissionRoute<'a> {
     Deny,
 }
 
+pub(crate) struct RoutedWritePolicies {
+    pub using: Option<PolicyExpr>,
+    pub with_check: Option<PolicyExpr>,
+}
+
+pub(crate) fn branch_write_policies_from_route(
+    route: PermissionRoute<'_>,
+    operation: Operation,
+) -> Result<Option<RoutedWritePolicies>, ()> {
+    match route {
+        PermissionRoute::Normal => Ok(None),
+        PermissionRoute::NoBranchPolicy | PermissionRoute::Deny => Err(()),
+        PermissionRoute::Branch { policy, context } => {
+            let policies = match operation {
+                Operation::Insert => RoutedWritePolicies {
+                    using: None,
+                    with_check: policy
+                        .insert_policy()
+                        .map(|expr| bind_branch_refs(expr, &context)),
+                },
+                Operation::Update => RoutedWritePolicies {
+                    using: policy
+                        .update_using_policy()
+                        .map(|expr| bind_branch_refs(expr, &context)),
+                    with_check: policy
+                        .update_check_policy()
+                        .map(|expr| bind_branch_refs(expr, &context)),
+                },
+                Operation::Delete => RoutedWritePolicies {
+                    using: policy
+                        .effective_delete_using()
+                        .map(|expr| bind_branch_refs(expr, &context)),
+                    with_check: None,
+                },
+                Operation::Select => return Ok(None),
+            };
+
+            if policies.using.is_none() && policies.with_check.is_none() {
+                Err(())
+            } else {
+                Ok(Some(policies))
+            }
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default)]
 pub struct PolicyEvalRefs<'a> {
     pub row_id: Option<ObjectId>,

--- a/crates/jazz-tools/src/query_manager/policy.rs
+++ b/crates/jazz-tools/src/query_manager/policy.rs
@@ -23,7 +23,7 @@ pub enum CmpOp {
     Ge,
 }
 
-/// A value in a policy expression - either a literal or a session reference.
+/// A value in a policy expression - either a literal, session reference, or branch reference.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(from = "PolicyValueSerde", into = "PolicyValueSerde")]
 pub enum PolicyValue {
@@ -31,6 +31,8 @@ pub enum PolicyValue {
     Literal(Value),
     /// Reference to a session variable, e.g., ["user_id"] or ["claims", "teams"].
     SessionRef(Vec<String>),
+    /// Reference to a backing branch row column, e.g. `$branch.projectId`.
+    BranchRef(String),
 }
 
 /// Reserved session path prefix used to encode outer-row references in correlated EXISTS clauses.
@@ -197,6 +199,7 @@ pub enum PolicyExpr {
 enum PolicyValueSerde {
     Literal { value: Value },
     SessionRef { path: Vec<String> },
+    BranchRef { column: String },
 }
 
 impl From<PolicyValueSerde> for PolicyValue {
@@ -204,6 +207,7 @@ impl From<PolicyValueSerde> for PolicyValue {
         match value {
             PolicyValueSerde::Literal { value } => PolicyValue::Literal(value),
             PolicyValueSerde::SessionRef { path } => PolicyValue::SessionRef(path),
+            PolicyValueSerde::BranchRef { column } => PolicyValue::BranchRef(column),
         }
     }
 }
@@ -213,6 +217,7 @@ impl From<PolicyValue> for PolicyValueSerde {
         match value {
             PolicyValue::Literal(value) => PolicyValueSerde::Literal { value },
             PolicyValue::SessionRef(path) => PolicyValueSerde::SessionRef { path },
+            PolicyValue::BranchRef(column) => PolicyValueSerde::BranchRef { column },
         }
     }
 }
@@ -1059,6 +1064,8 @@ fn resolve_policy_value(value: &PolicyValue, session: &Session) -> Option<Value>
     match value {
         PolicyValue::Literal(v) => Some(v.clone()),
         PolicyValue::SessionRef(path) => resolve_session_value(path, session),
+        // resolved later by permission_routing::bind_branch_refs
+        PolicyValue::BranchRef(_) => None,
     }
 }
 
@@ -1113,6 +1120,8 @@ pub fn bind_outer_row_refs(
                         PolicyValue::SessionRef(path.clone())
                     }
                 }
+                // resolved later by permission_routing::bind_branch_refs
+                PolicyValue::BranchRef(column) => PolicyValue::BranchRef(column.clone()),
             };
 
             Some(PolicyExpr::Cmp {
@@ -1154,6 +1163,8 @@ pub fn bind_outer_row_refs(
                         PolicyValue::SessionRef(path.clone())
                     }
                 }
+                // resolved later by permission_routing::bind_branch_refs
+                PolicyValue::BranchRef(column) => PolicyValue::BranchRef(column.clone()),
             };
             Some(PolicyExpr::Contains {
                 column: column.clone(),
@@ -1194,6 +1205,8 @@ pub fn bind_outer_row_refs(
                             Some(PolicyValue::SessionRef(path.clone()))
                         }
                     }
+                    // resolved later by permission_routing::bind_branch_refs
+                    PolicyValue::BranchRef(column) => Some(PolicyValue::BranchRef(column.clone())),
                 })
                 .collect::<Option<Vec<_>>>()?;
             Some(PolicyExpr::InList {
@@ -1297,6 +1310,8 @@ pub fn bind_relation_refs(
                 let resolved = resolve_session_value(path, session)?;
                 Some(ValueRef::Literal(resolved))
             }
+            // resolved later by permission_routing::bind_branch_refs
+            ValueRef::BranchRef(column) => Some(ValueRef::BranchRef(column.clone())),
             ValueRef::OuterColumn(column) => {
                 let resolved = resolve_outer_col(
                     &column.column,
@@ -2133,6 +2148,17 @@ mod tests {
             session,
             Some(row_id),
         )
+    }
+
+    #[test]
+    fn branch_ref_policy_value_roundtrips_through_serde() {
+        // INTERNAL TEST (justified): BranchRef has no public API surface until
+        // permission_routing enforcement lands (Tasks 4-6). This pins the serde shape.
+        let value = PolicyValue::BranchRef("projectId".to_string());
+        let serialized = serde_json::to_value(&value).unwrap();
+        let back: PolicyValue = serde_json::from_value(serialized).unwrap();
+
+        assert_eq!(value, back);
     }
 
     #[test]

--- a/crates/jazz-tools/src/query_manager/rebac_tests.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests.rs
@@ -467,6 +467,7 @@ fn enqueue_inherited_insert(
 /// Test that valid INHERITS chains (no cycles) pass validation.
 
 /// Test that bounded self-referential INHERITS is accepted by cycle validation.
+mod branch_policies;
 mod inheritance_validation;
 mod inherited_policies;
 mod insert_policies;

--- a/crates/jazz-tools/src/query_manager/rebac_tests.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests.rs
@@ -25,7 +25,7 @@ use crate::query_manager::encoding::encode_row;
 use crate::query_manager::manager::QueryError;
 use crate::query_manager::manager::QueryManager;
 use crate::query_manager::policy::Operation;
-use crate::query_manager::session::Session;
+use crate::query_manager::session::{Session, WriteContext};
 use crate::query_manager::types::{
     ColumnDescriptor, ColumnType, ComposedBranchName, RowDescriptor, Schema, SchemaBuilder,
     SchemaHash, TableName, TableSchema, Value, permissions, policy_expr as pe,

--- a/crates/jazz-tools/src/query_manager/rebac_tests/branch_policies.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests/branch_policies.rs
@@ -47,6 +47,14 @@ fn branch_policy_map() -> crate::query_manager::types::BranchPolicies {
             permissions(|p| {
                 p.allow_read()
                     .where_(pe::eq("projectId", pe::branch("projectId")));
+                p.allow_insert().where_(pe::all_of([
+                    pe::eq("projectId", pe::branch("projectId")),
+                    pe::eq("ownerId", pe::session("user_id")),
+                ]));
+                p.allow_update()
+                    .where_(pe::eq("projectId", pe::branch("projectId")));
+                p.allow_delete()
+                    .where_(pe::eq("projectId", pe::branch("projectId")));
             }),
         )]),
     )])
@@ -99,6 +107,101 @@ fn setup_branch_permissions() -> (QueryManager, MemoryStorage, ObjectId, ObjectI
     let branch = get_branch_for_user_branch(&qm, &branch_row.row_id.to_string());
 
     (qm, storage, project.row_id, branch_row.row_id, branch)
+}
+
+fn visible_todos_on_branch(
+    qm: &mut QueryManager,
+    storage: &mut MemoryStorage,
+    branch: &str,
+    session: &str,
+) -> Vec<(ObjectId, Vec<Value>)> {
+    let query = qm.query("todos").branch(branch).build();
+    execute_query_with_session(qm, storage, query, Session::new(session)).expect("query todos")
+}
+
+fn insert_todo_on_branch_as(
+    qm: &mut QueryManager,
+    storage: &mut MemoryStorage,
+    branch: &str,
+    project_id: ObjectId,
+    title: &str,
+    owner_id: &str,
+    session: &str,
+) -> Result<crate::query_manager::manager::InsertResult, QueryError> {
+    let write_context = WriteContext::from_session(Session::new(session));
+    qm.insert_on_branch(
+        storage,
+        "todos",
+        branch,
+        &[
+            Value::Uuid(project_id),
+            Value::Text(title.into()),
+            Value::Text(owner_id.into()),
+        ],
+        Some(&write_context),
+    )
+}
+
+fn update_todo_on_branch_as(
+    qm: &mut QueryManager,
+    storage: &mut MemoryStorage,
+    branch: &str,
+    row_id: ObjectId,
+    project_id: ObjectId,
+    title: &str,
+    owner_id: &str,
+    session: &str,
+) -> Result<BatchId, QueryError> {
+    let current_row = storage
+        .load_visible_region_row("todos", branch, row_id)
+        .expect("load row")
+        .expect("row exists");
+    let write_context = WriteContext::from_session(Session::new(session));
+    qm.write_existing_row_on_branch_with_schema_and_write_context(
+        storage,
+        crate::query_manager::writes::RowBranchWrite {
+            table: "todos",
+            branch,
+            id: row_id,
+            values: &[
+                Value::Uuid(project_id),
+                Value::Text(title.into()),
+                Value::Text(owner_id.into()),
+            ],
+            old_data_for_policy: &current_row.data,
+            old_provenance_for_policy: &current_row.row_provenance(),
+        },
+        qm.schema.clone().as_ref(),
+        Some(&write_context),
+        true,
+    )
+}
+
+fn delete_todo_on_branch_as(
+    qm: &mut QueryManager,
+    storage: &mut MemoryStorage,
+    branch: &str,
+    row_id: ObjectId,
+    session: &str,
+) -> Result<crate::query_manager::manager::DeleteHandle, QueryError> {
+    let current_row = storage
+        .load_visible_region_row("todos", branch, row_id)
+        .expect("load row")
+        .expect("row exists");
+    let write_context = WriteContext::from_session(Session::new(session));
+    qm.delete_existing_row_on_branch_with_schema_and_write_context(
+        storage,
+        crate::query_manager::writes::RowBranchDelete {
+            table: "todos",
+            branch,
+            id: row_id,
+            old_data_for_policy: &current_row.data,
+            old_provenance_for_policy: &current_row.row_provenance(),
+        },
+        qm.schema.clone().as_ref(),
+        Some(&write_context),
+        true,
+    )
 }
 
 #[test]
@@ -190,4 +293,168 @@ fn branch_reads_are_isolated_from_main_reads() {
     assert_eq!(main_rows[0].1[1], Value::Text("Main todo".into()));
     assert_eq!(branch_rows.len(), 1);
     assert_eq!(branch_rows[0].1[1], Value::Text("Branch todo".into()));
+}
+
+#[test]
+fn branch_insert_policy_allows_owner_matching_branch_project_and_owner() {
+    let (mut qm, mut storage, project_id, _branch_row_id, branch) = setup_branch_permissions();
+
+    let inserted = insert_todo_on_branch_as(
+        &mut qm,
+        &mut storage,
+        &branch,
+        project_id,
+        "Write API docs",
+        "alice",
+        "alice",
+    )
+    .expect("branch insert should be accepted");
+
+    let rows = visible_todos_on_branch(&mut qm, &mut storage, &branch, "alice");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].0, inserted.row_id);
+    assert_eq!(rows[0].1[1], Value::Text("Write API docs".into()));
+}
+
+#[test]
+fn branch_insert_policy_denies_when_backing_row_is_not_readable() {
+    let (mut qm, mut storage, project_id, _branch_row_id, branch) = setup_branch_permissions();
+
+    let denied = insert_todo_on_branch_as(
+        &mut qm,
+        &mut storage,
+        &branch,
+        project_id,
+        "Hidden draft",
+        "bob",
+        "bob",
+    )
+    .expect_err("branch insert should be rejected");
+
+    assert!(matches!(
+        denied,
+        QueryError::PolicyDenied {
+            operation: Operation::Insert,
+            ..
+        }
+    ));
+    assert!(visible_todos_on_branch(&mut qm, &mut storage, &branch, "alice").is_empty());
+}
+
+#[test]
+fn branch_update_policy_allows_owner_when_row_matches_branch_project() {
+    let (mut qm, mut storage, project_id, _branch_row_id, branch) = setup_branch_permissions();
+    let inserted = insert_todo_on_branch_as(
+        &mut qm,
+        &mut storage,
+        &branch,
+        project_id,
+        "Draft",
+        "alice",
+        "alice",
+    )
+    .expect("branch insert should be accepted");
+
+    update_todo_on_branch_as(
+        &mut qm,
+        &mut storage,
+        &branch,
+        inserted.row_id,
+        project_id,
+        "Updated draft",
+        "alice",
+        "alice",
+    )
+    .expect("branch update should be accepted");
+
+    let rows = visible_todos_on_branch(&mut qm, &mut storage, &branch, "alice");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].1[1], Value::Text("Updated draft".into()));
+}
+
+#[test]
+fn branch_update_policy_denies_when_backing_row_is_not_readable() {
+    let (mut qm, mut storage, project_id, _branch_row_id, branch) = setup_branch_permissions();
+    let inserted = insert_todo_on_branch_as(
+        &mut qm,
+        &mut storage,
+        &branch,
+        project_id,
+        "Draft",
+        "alice",
+        "alice",
+    )
+    .expect("branch insert should be accepted");
+
+    let denied = update_todo_on_branch_as(
+        &mut qm,
+        &mut storage,
+        &branch,
+        inserted.row_id,
+        project_id,
+        "Bob edit",
+        "alice",
+        "bob",
+    )
+    .expect_err("branch update should be rejected");
+
+    assert!(matches!(
+        denied,
+        QueryError::PolicyDenied {
+            operation: Operation::Update,
+            ..
+        }
+    ));
+    let rows = visible_todos_on_branch(&mut qm, &mut storage, &branch, "alice");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].1[1], Value::Text("Draft".into()));
+}
+
+#[test]
+fn branch_delete_policy_allows_owner_when_row_matches_branch_project() {
+    let (mut qm, mut storage, project_id, _branch_row_id, branch) = setup_branch_permissions();
+    let inserted = insert_todo_on_branch_as(
+        &mut qm,
+        &mut storage,
+        &branch,
+        project_id,
+        "Draft",
+        "alice",
+        "alice",
+    )
+    .expect("branch insert should be accepted");
+
+    delete_todo_on_branch_as(&mut qm, &mut storage, &branch, inserted.row_id, "alice")
+        .expect("branch delete should be accepted");
+
+    assert!(visible_todos_on_branch(&mut qm, &mut storage, &branch, "alice").is_empty());
+}
+
+#[test]
+fn branch_delete_policy_denies_when_backing_row_is_not_readable() {
+    let (mut qm, mut storage, project_id, _branch_row_id, branch) = setup_branch_permissions();
+    let inserted = insert_todo_on_branch_as(
+        &mut qm,
+        &mut storage,
+        &branch,
+        project_id,
+        "Draft",
+        "alice",
+        "alice",
+    )
+    .expect("branch insert should be accepted");
+
+    let denied = delete_todo_on_branch_as(&mut qm, &mut storage, &branch, inserted.row_id, "bob")
+        .expect_err("branch delete should be rejected");
+
+    assert!(matches!(
+        denied,
+        QueryError::PolicyDenied {
+            operation: Operation::Delete,
+            ..
+        }
+    ));
+    let rows = visible_todos_on_branch(&mut qm, &mut storage, &branch, "alice");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].1[1], Value::Text("Draft".into()));
 }

--- a/crates/jazz-tools/src/query_manager/rebac_tests/branch_policies.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests/branch_policies.rs
@@ -1,0 +1,193 @@
+use super::*;
+use crate::query_manager::query::Query;
+
+fn branch_permissions_schema() -> Schema {
+    let project_policies = permissions(|p| {
+        p.allow_read().always();
+        p.allow_insert().always();
+    });
+    let branch_policies = permissions(|p| {
+        p.allow_read()
+            .where_(pe::eq("ownerId", pe::session("user_id")));
+        p.allow_insert().always();
+    });
+    let todo_policies = permissions(|p| {
+        p.allow_read().always();
+        p.allow_insert().always();
+    });
+
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("projects")
+                .column("name", ColumnType::Text)
+                .column("ownerId", ColumnType::Text)
+                .policies(project_policies),
+        )
+        .table(
+            TableSchema::builder("branches")
+                .fk_column("projectId", "projects")
+                .column("ownerId", ColumnType::Text)
+                .policies(branch_policies),
+        )
+        .table(
+            TableSchema::builder("todos")
+                .fk_column("projectId", "projects")
+                .column("title", ColumnType::Text)
+                .column("ownerId", ColumnType::Text)
+                .policies(todo_policies),
+        )
+        .build()
+}
+
+fn branch_policy_map() -> crate::query_manager::types::BranchPolicies {
+    HashMap::from([(
+        TableName::new("branches"),
+        HashMap::from([(
+            TableName::new("todos"),
+            permissions(|p| {
+                p.allow_read()
+                    .where_(pe::eq("projectId", pe::branch("projectId")));
+            }),
+        )]),
+    )])
+}
+
+fn get_branch_for_user_branch(qm: &QueryManager, user_branch: &str) -> String {
+    ComposedBranchName::new(
+        &qm.schema_context().env,
+        qm.schema_context().current_hash,
+        user_branch,
+    )
+    .to_branch_name()
+    .as_str()
+    .to_string()
+}
+
+fn execute_query_with_session<H: Storage>(
+    qm: &mut QueryManager,
+    storage: &mut H,
+    query: Query,
+    session: Session,
+) -> Result<Vec<(ObjectId, Vec<Value>)>, QueryError> {
+    let sub_id = qm.subscribe_with_session(query, Some(session), None)?;
+    qm.process(storage);
+    let results = qm.get_subscription_results(sub_id);
+    qm.unsubscribe_with_sync(sub_id);
+    Ok(results)
+}
+
+fn setup_branch_permissions() -> (QueryManager, MemoryStorage, ObjectId, ObjectId, String) {
+    let schema = branch_permissions_schema();
+    let mut qm = create_query_manager(SyncManager::new(), schema.clone());
+    qm.set_authorization_schema_with_branch_policies(schema, branch_policy_map());
+    let mut storage = MemoryStorage::new();
+
+    let project = qm
+        .insert(
+            &mut storage,
+            "projects",
+            &[Value::Text("Project".into()), Value::Text("alice".into())],
+        )
+        .expect("insert project");
+    let branch_row = qm
+        .insert(
+            &mut storage,
+            "branches",
+            &[Value::Uuid(project.row_id), Value::Text("alice".into())],
+        )
+        .expect("insert branch row");
+    let branch = get_branch_for_user_branch(&qm, &branch_row.row_id.to_string());
+
+    (qm, storage, project.row_id, branch_row.row_id, branch)
+}
+
+#[test]
+fn branch_read_policy_allows_owner_to_read_matching_rows() {
+    let (mut qm, mut storage, project_id, _branch_row_id, branch) = setup_branch_permissions();
+    qm.insert_on_branch(
+        &mut storage,
+        "todos",
+        &branch,
+        &[
+            Value::Uuid(project_id),
+            Value::Text("Write API docs".into()),
+            Value::Text("alice".into()),
+        ],
+        None,
+    )
+    .expect("insert branch todo");
+
+    let query = qm.query("todos").branch(&branch).build();
+    let rows = execute_query_with_session(&mut qm, &mut storage, query, Session::new("alice"))
+        .expect("query todos");
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].1[1], Value::Text("Write API docs".into()));
+}
+
+#[test]
+fn branch_read_policy_denies_when_backing_row_is_not_readable() {
+    let (mut qm, mut storage, project_id, _branch_row_id, branch) = setup_branch_permissions();
+    qm.insert_on_branch(
+        &mut storage,
+        "todos",
+        &branch,
+        &[
+            Value::Uuid(project_id),
+            Value::Text("Hidden draft".into()),
+            Value::Text("alice".into()),
+        ],
+        None,
+    )
+    .expect("insert branch todo");
+
+    let query = qm.query("todos").branch(&branch).build();
+    let rows = execute_query_with_session(&mut qm, &mut storage, query, Session::new("bob"))
+        .expect("query todos");
+
+    assert!(
+        rows.is_empty(),
+        "branch reads must not fall back to normal todos allowRead"
+    );
+}
+
+#[test]
+fn branch_reads_are_isolated_from_main_reads() {
+    let (mut qm, mut storage, project_id, _branch_row_id, branch) = setup_branch_permissions();
+    qm.insert_on_branch(
+        &mut storage,
+        "todos",
+        &branch,
+        &[
+            Value::Uuid(project_id),
+            Value::Text("Branch todo".into()),
+            Value::Text("alice".into()),
+        ],
+        None,
+    )
+    .expect("insert branch todo");
+    qm.insert(
+        &mut storage,
+        "todos",
+        &[
+            Value::Uuid(project_id),
+            Value::Text("Main todo".into()),
+            Value::Text("alice".into()),
+        ],
+    )
+    .expect("insert main todo");
+
+    let main_query = qm.query("todos").build();
+    let main_rows =
+        execute_query_with_session(&mut qm, &mut storage, main_query, Session::new("alice"))
+            .expect("query main todos");
+    let branch_query = qm.query("todos").branch(&branch).build();
+    let branch_rows =
+        execute_query_with_session(&mut qm, &mut storage, branch_query, Session::new("alice"))
+            .expect("query branch todos");
+
+    assert_eq!(main_rows.len(), 1);
+    assert_eq!(main_rows[0].1[1], Value::Text("Main todo".into()));
+    assert_eq!(branch_rows.len(), 1);
+    assert_eq!(branch_rows[0].1[1], Value::Text("Branch todo".into()));
+}

--- a/crates/jazz-tools/src/query_manager/relation_ir.rs
+++ b/crates/jazz-tools/src/query_manager/relation_ir.rs
@@ -43,6 +43,7 @@ pub enum RowIdRef {
 pub enum ValueRef {
     Literal(Value),
     SessionRef(Vec<String>),
+    BranchRef(String),
     OuterColumn(ColumnRef),
     FrontierColumn(ColumnRef),
     RowId(RowIdRef),

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -14,6 +14,7 @@ use crate::sync_manager::{
 };
 
 use super::manager::{QueryManager, SchemaWarningAccumulator, ServerQuerySubscription};
+use super::permission_routing::{PermissionRoute, bind_branch_refs, policy_for_operation};
 use super::policy::{ComplexClause, Operation, PolicyExpr};
 use super::policy_graph::{PolicyGraph, PolicyGraphBuildOptions};
 use super::session::Session;
@@ -537,10 +538,28 @@ impl QueryManager {
         let tip_provenance = row.row_provenance();
 
         let table_name = TableName::new(&table);
-        let Some(select_policy) = auth_schema
-            .get(&table_name)
-            .and_then(|table_schema| table_schema.policies.select_policy())
-        else {
+        let branch_select_policy = match self.resolve_branch_route(
+            &table_name,
+            branch_name.as_str(),
+            Operation::Select,
+            storage,
+            session,
+        ) {
+            PermissionRoute::Normal => None,
+            PermissionRoute::Branch { policy, context } => {
+                let Some(select_policy) = policy_for_operation(policy, Operation::Select) else {
+                    return false;
+                };
+                Some(bind_branch_refs(select_policy, &context))
+            }
+            PermissionRoute::NoBranchPolicy | PermissionRoute::Deny => return false,
+        };
+
+        let Some(select_policy) = branch_select_policy.as_ref().or_else(|| {
+            auth_schema
+                .get(&table_name)
+                .and_then(|table_schema| table_schema.policies.select_policy())
+        }) else {
             return !self.row_policy_mode.denies_missing_explicit_policy()
                 && auth_schema.contains_key(&table_name);
         };
@@ -985,6 +1004,7 @@ impl QueryManager {
                 session_for_policy.clone(),
                 &subscription_context,
                 compile_row_policy_mode,
+                &self.authorization_branch_policies,
             );
 
             let Ok(mut graph) = graph else {

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -1697,30 +1697,71 @@ impl QueryManager {
             return;
         }
 
-        let policy = match check.operation {
-            Operation::Insert => auth_table_schema.policies.insert_policy(),
-            Operation::Update => unreachable!(),
-            Operation::Delete => auth_table_schema.policies.effective_delete_using(),
-            Operation::Select => {
-                self.sync_manager.approve_permission_check(storage, check);
+        let branch_write_policies = match self.branch_write_policies_for_operation(
+            storage,
+            auth_table_name,
+            branch_name.as_str(),
+            &check.session,
+            check.operation,
+        ) {
+            Ok(policies) => policies,
+            Err(_) => {
+                let reason = format!(
+                    "{:?} denied by branch policy on table {}",
+                    check.operation, write_table_name.0
+                );
+                self.sync_manager
+                    .reject_permission_check(storage, check, reason);
                 return;
             }
         };
 
-        let policy = match policy {
-            Some(p) => p,
-            None => {
-                if self.row_policy_mode.denies_missing_explicit_policy() {
-                    let reason = format!(
-                        "{:?} denied on table {} - missing explicit policy",
-                        check.operation, write_table_name.0
-                    );
-                    self.sync_manager
-                        .reject_permission_check(storage, check, reason);
-                } else {
+        let policy = if let Some(branch_write_policies) = branch_write_policies {
+            let policy = match check.operation {
+                Operation::Insert => branch_write_policies.with_check,
+                Operation::Update => unreachable!(),
+                Operation::Delete => branch_write_policies.using,
+                Operation::Select => {
                     self.sync_manager.approve_permission_check(storage, check);
+                    return;
                 }
+            };
+            let Some(policy) = policy else {
+                let reason = format!(
+                    "{:?} denied on table {} - missing explicit branch policy",
+                    check.operation, write_table_name.0
+                );
+                self.sync_manager
+                    .reject_permission_check(storage, check, reason);
                 return;
+            };
+            Cow::Owned(policy)
+        } else {
+            let policy = match check.operation {
+                Operation::Insert => auth_table_schema.policies.insert_policy(),
+                Operation::Update => unreachable!(),
+                Operation::Delete => auth_table_schema.policies.effective_delete_using(),
+                Operation::Select => {
+                    self.sync_manager.approve_permission_check(storage, check);
+                    return;
+                }
+            };
+
+            match policy {
+                Some(p) => Cow::Borrowed(p),
+                None => {
+                    if self.row_policy_mode.denies_missing_explicit_policy() {
+                        let reason = format!(
+                            "{:?} denied on table {} - missing explicit policy",
+                            check.operation, write_table_name.0
+                        );
+                        self.sync_manager
+                            .reject_permission_check(storage, check, reason);
+                    } else {
+                        self.sync_manager.approve_permission_check(storage, check);
+                    }
+                    return;
+                }
             }
         };
 
@@ -1781,7 +1822,7 @@ impl QueryManager {
                 object_id,
                 branch_name,
                 table_name: auth_table_name,
-                policy,
+                policy: policy.as_ref(),
                 content,
                 provenance: &provenance,
                 session: &check.session,
@@ -1849,6 +1890,137 @@ impl QueryManager {
             check.old_content = Some(previous_row.data.to_vec());
         }
 
+        let source_branch_schema_map = self.branch_schema_map.clone();
+        let old_provenance =
+            self.current_row_provenance(storage, object_id, branch_name, Some(&write_table_name));
+        let new_provenance = Self::payload_row_provenance(&check.payload);
+
+        let branch_write_policies = match self.branch_write_policies_for_operation(
+            storage,
+            auth_table_name,
+            branch_name.as_str(),
+            &check.session,
+            Operation::Update,
+        ) {
+            Ok(policies) => policies,
+            Err(_) => {
+                let reason = format!(
+                    "Update denied by branch policy on table {}",
+                    write_table_name.0
+                );
+                self.sync_manager
+                    .reject_permission_check(storage, check, reason);
+                return;
+            }
+        };
+
+        if let Some(branch_write_policies) = branch_write_policies {
+            if let Some(using) = branch_write_policies.using.as_ref() {
+                let old_content = match check.old_content.as_ref() {
+                    Some(c) if !c.is_empty() => c,
+                    _ => {
+                        let reason = format!(
+                            "Update denied by branch USING policy on table {} - no old content",
+                            write_table_name.0
+                        );
+                        self.sync_manager
+                            .reject_permission_check(storage, check, reason);
+                        return;
+                    }
+                };
+                let Some(old_provenance) = old_provenance.as_ref() else {
+                    let reason = format!(
+                        "Update denied by branch USING policy on table {} - missing old provenance",
+                        write_table_name.0
+                    );
+                    self.sync_manager
+                        .reject_permission_check(storage, check, reason);
+                    return;
+                };
+
+                if !self.evaluate_authorization_policy(
+                    storage,
+                    AuthorizationPolicyRequest {
+                        object_id,
+                        branch_name,
+                        table_name: auth_table_name,
+                        policy: using,
+                        content: old_content,
+                        provenance: old_provenance,
+                        session: &check.session,
+                        auth_schema,
+                        auth_context,
+                        source_branch_schema_map: &source_branch_schema_map,
+                        operation: Operation::Update,
+                        settlement_eval_cache: None,
+                    },
+                ) {
+                    let reason = format!(
+                        "Update denied by branch USING policy on table {}",
+                        write_table_name.0
+                    );
+                    self.sync_manager
+                        .reject_permission_check(storage, check, reason);
+                    return;
+                }
+            }
+
+            if let Some(with_check) = branch_write_policies.with_check.as_ref() {
+                let new_content = match check.new_content.as_ref() {
+                    Some(c) => c,
+                    None => {
+                        self.sync_manager.reject_permission_check(
+                            storage,
+                            check,
+                            format!(
+                                "Update denied by branch WITH CHECK policy on table {} - missing new content",
+                                write_table_name.0
+                            ),
+                        );
+                        return;
+                    }
+                };
+                let Some(new_provenance) = new_provenance.as_ref() else {
+                    let reason = format!(
+                        "Update denied by branch WITH CHECK policy on table {} - missing new provenance",
+                        write_table_name.0
+                    );
+                    self.sync_manager
+                        .reject_permission_check(storage, check, reason);
+                    return;
+                };
+
+                if !self.evaluate_authorization_policy(
+                    storage,
+                    AuthorizationPolicyRequest {
+                        object_id,
+                        branch_name,
+                        table_name: auth_table_name,
+                        policy: with_check,
+                        content: new_content,
+                        provenance: new_provenance,
+                        session: &check.session,
+                        auth_schema,
+                        auth_context,
+                        source_branch_schema_map: &source_branch_schema_map,
+                        operation: Operation::Update,
+                        settlement_eval_cache: None,
+                    },
+                ) {
+                    let reason = format!(
+                        "Update denied by branch WITH CHECK policy on table {}",
+                        write_table_name.0
+                    );
+                    self.sync_manager
+                        .reject_permission_check(storage, check, reason);
+                    return;
+                }
+            }
+
+            self.sync_manager.approve_permission_check(storage, check);
+            return;
+        }
+
         let Some(table_schema) = auth_schema.get(&auth_table_name) else {
             self.sync_manager.reject_permission_check(
                 storage,
@@ -1862,10 +2034,6 @@ impl QueryManager {
         };
         let using_policy = table_schema.policies.update_using_policy();
         let check_policy = table_schema.policies.update_check_policy();
-        let source_branch_schema_map = self.branch_schema_map.clone();
-        let old_provenance =
-            self.current_row_provenance(storage, object_id, branch_name, Some(&write_table_name));
-        let new_provenance = Self::payload_row_provenance(&check.payload);
 
         if using_policy.is_none() && check_policy.is_none() {
             if self.row_policy_mode.denies_missing_explicit_policy() {

--- a/crates/jazz-tools/src/query_manager/subscriptions.rs
+++ b/crates/jazz-tools/src/query_manager/subscriptions.rs
@@ -151,6 +151,7 @@ impl QueryManager {
             session.clone(),
             &self.schema_context,
             compile_row_policy_mode,
+            &self.authorization_branch_policies,
         )
         .map_err(|err| QueryError::QueryCompilationError(err.to_string()))?;
         let policy_context_tables = Self::policy_context_tables_for_graph(&graph);

--- a/crates/jazz-tools/src/query_manager/types/policy.rs
+++ b/crates/jazz-tools/src/query_manager/types/policy.rs
@@ -5,6 +5,7 @@ use crate::query_manager::relation_ir::{
     ColumnRef, PredicateCmpOp, PredicateExpr, RelExpr, ValueRef,
 };
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum RowPolicyMode {
@@ -68,6 +69,8 @@ pub struct TablePolicies {
     pub update: OperationPolicy,
     pub delete: OperationPolicy,
 }
+
+pub type BranchPolicies = HashMap<TableName, HashMap<TableName, TablePolicies>>;
 
 impl TablePolicies {
     /// Create empty policies.
@@ -326,6 +329,7 @@ pub mod policy_expr {
     pub enum PolicyValueInput {
         Literal(Value),
         Session(Vec<String>),
+        Branch(String),
     }
 
     impl From<PolicyValueInput> for PolicyValue {
@@ -333,6 +337,7 @@ pub mod policy_expr {
             match value {
                 PolicyValueInput::Literal(value) => PolicyValue::Literal(value),
                 PolicyValueInput::Session(path) => PolicyValue::SessionRef(path),
+                PolicyValueInput::Branch(column) => PolicyValue::BranchRef(column),
             }
         }
     }
@@ -342,6 +347,7 @@ pub mod policy_expr {
             match value {
                 PolicyValue::Literal(value) => PolicyValueInput::Literal(value),
                 PolicyValue::SessionRef(path) => PolicyValueInput::Session(path),
+                PolicyValue::BranchRef(column) => PolicyValueInput::Branch(column),
             }
         }
     }
@@ -396,6 +402,10 @@ pub mod policy_expr {
 
     pub fn session(path: impl IntoSessionPath) -> PolicyValueInput {
         PolicyValueInput::Session(path.into_session_path())
+    }
+
+    pub fn branch(column: impl Into<String>) -> PolicyValueInput {
+        PolicyValueInput::Branch(column.into())
     }
 
     pub fn literal(value: impl Into<Value>) -> PolicyValueInput {

--- a/crates/jazz-tools/src/query_manager/writes.rs
+++ b/crates/jazz-tools/src/query_manager/writes.rs
@@ -21,6 +21,7 @@ use super::manager::{
     DeleteHandle, InsertResult, QueryError, QueryManager, SchemaWarningAccumulator,
     WriteTableCacheEntry,
 };
+use super::permission_routing::{RoutedWritePolicies, branch_write_policies_from_route};
 use super::policy::{ComplexClause, Operation, evaluate_simple_parts_with_row_id};
 use super::server_queries::{AuthorizationPolicyRequest, RowTransformContext};
 use super::session::{AuthMode, Session, WriteContext};
@@ -28,6 +29,12 @@ use super::types::{
     ColumnName, ColumnType, ComposedBranchName, LoadedRow, RowDescriptor, Schema, SchemaHash,
     TableName, Value,
 };
+
+type BranchWriteAuthorizationContext = (
+    std::sync::Arc<Schema>,
+    std::sync::Arc<crate::schema_manager::SchemaContext>,
+    RoutedWritePolicies,
+);
 
 pub struct RowBranchWrite<'a> {
     pub table: &'a str,
@@ -718,7 +725,57 @@ impl QueryManager {
             encode_row(descriptor, values).map_err(|e| QueryError::EncodingError(e.to_string()))?;
 
         if let Some(session) = write_context.and_then(WriteContext::session) {
-            if let Some((auth_schema, auth_context)) =
+            if let Some((auth_schema, auth_context, branch_policies)) = self
+                .branch_write_authorization_context(
+                    storage,
+                    table_name,
+                    branch,
+                    session,
+                    Operation::Update,
+                )?
+            {
+                if let Some(policy) = branch_policies.using.as_ref()
+                    && !self.evaluate_current_authorization_policy_for_content(
+                        storage,
+                        id,
+                        branch,
+                        table_name,
+                        policy,
+                        old_data_for_policy,
+                        old_provenance_for_policy,
+                        session,
+                        Operation::Update,
+                        &auth_schema,
+                        &auth_context,
+                    )
+                {
+                    return Err(QueryError::PolicyDenied {
+                        table: table_name,
+                        operation: Operation::Update,
+                    });
+                }
+
+                if let Some(policy) = branch_policies.with_check.as_ref()
+                    && !self.evaluate_current_authorization_policy_for_content(
+                        storage,
+                        id,
+                        branch,
+                        table_name,
+                        policy,
+                        &new_data,
+                        new_provenance,
+                        session,
+                        Operation::Update,
+                        &auth_schema,
+                        &auth_context,
+                    )
+                {
+                    return Err(QueryError::PolicyDenied {
+                        table: table_name,
+                        operation: Operation::Update,
+                    });
+                }
+            } else if let Some((auth_schema, auth_context)) =
                 self.local_write_authorization_context(branch, Some(session))
             {
                 let Some(auth_table_schema) = auth_schema.get(&table_name) else {
@@ -1097,7 +1154,40 @@ impl QueryManager {
         }
 
         if let Some(session) = write_context.and_then(WriteContext::session) {
-            if let Some((auth_schema, auth_context)) =
+            if let Some((auth_schema, auth_context, branch_policies)) = self
+                .branch_write_authorization_context(
+                    storage,
+                    table_name,
+                    branch,
+                    session,
+                    Operation::Insert,
+                )?
+            {
+                let Some(policy) = branch_policies.with_check.as_ref() else {
+                    return Err(QueryError::PolicyDenied {
+                        table: table_name,
+                        operation: Operation::Insert,
+                    });
+                };
+                if !self.evaluate_current_authorization_policy_for_content(
+                    storage,
+                    object_id,
+                    branch,
+                    table_name,
+                    policy,
+                    &data,
+                    &provenance,
+                    session,
+                    Operation::Insert,
+                    &auth_schema,
+                    &auth_context,
+                ) {
+                    return Err(QueryError::PolicyDenied {
+                        table: table_name,
+                        operation: Operation::Insert,
+                    });
+                }
+            } else if let Some((auth_schema, auth_context)) =
                 self.local_write_authorization_context(branch, Some(session))
             {
                 let allowed = auth_schema
@@ -1328,6 +1418,50 @@ impl QueryManager {
         self.local_subscription_uses_explicit_authorization(session)
             .then(|| self.authorization_schema_for_branch(&BranchName::new(branch)))
             .flatten()
+    }
+
+    pub(super) fn branch_write_policies_for_operation(
+        &self,
+        storage: &dyn Storage,
+        table_name: TableName,
+        branch: &str,
+        session: &Session,
+        operation: Operation,
+    ) -> Result<Option<RoutedWritePolicies>, QueryError> {
+        if self.authorization_branch_policies.is_empty() {
+            return Ok(None);
+        }
+
+        branch_write_policies_from_route(
+            self.resolve_branch_route(&table_name, branch, operation, storage, Some(session)),
+            operation,
+        )
+        .map_err(|_| QueryError::PolicyDenied {
+            table: table_name,
+            operation,
+        })
+    }
+
+    fn branch_write_authorization_context(
+        &mut self,
+        storage: &dyn Storage,
+        table_name: TableName,
+        branch: &str,
+        session: &Session,
+        operation: Operation,
+    ) -> Result<Option<BranchWriteAuthorizationContext>, QueryError> {
+        let Some((auth_schema, auth_context)) =
+            self.authorization_schema_for_branch(&BranchName::new(branch))
+        else {
+            return Ok(None);
+        };
+        let Some(policies) = self
+            .branch_write_policies_for_operation(storage, table_name, branch, session, operation)?
+        else {
+            return Ok(None);
+        };
+
+        Ok(Some((auth_schema, auth_context, policies)))
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -2046,7 +2180,40 @@ impl QueryManager {
         let using_policy = table_write.delete_using_policy.as_deref();
 
         if let Some(session) = write_context.and_then(WriteContext::session) {
-            if let Some((auth_schema, auth_context)) =
+            if let Some((auth_schema, auth_context, branch_policies)) = self
+                .branch_write_authorization_context(
+                    storage,
+                    table_name,
+                    branch,
+                    session,
+                    Operation::Delete,
+                )?
+            {
+                let Some(policy) = branch_policies.using.as_ref() else {
+                    return Err(QueryError::PolicyDenied {
+                        table: table_name,
+                        operation: Operation::Delete,
+                    });
+                };
+                if !self.evaluate_current_authorization_policy_for_content(
+                    storage,
+                    id,
+                    branch,
+                    table_name,
+                    policy,
+                    old_data_for_policy,
+                    old_provenance_for_policy,
+                    session,
+                    Operation::Delete,
+                    &auth_schema,
+                    &auth_context,
+                ) {
+                    return Err(QueryError::PolicyDenied {
+                        table: table_name,
+                        operation: Operation::Delete,
+                    });
+                }
+            } else if let Some((auth_schema, auth_context)) =
                 self.local_write_authorization_context(branch, Some(session))
             {
                 let Some(auth_table_schema) = auth_schema.get(&table_name) else {

--- a/crates/jazz-tools/src/runtime_core/mod.rs
+++ b/crates/jazz-tools/src/runtime_core/mod.rs
@@ -707,12 +707,30 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         permissions: HashMap<TableName, TablePolicies>,
         expected_parent_bundle_object_id: Option<ObjectId>,
     ) -> Result<Option<ObjectId>, crate::schema_manager::SchemaError> {
-        let id = self.schema_manager.publish_permissions_bundle(
-            &mut self.storage,
+        self.publish_permissions_bundle_with_branch_policies(
             schema_hash,
             permissions,
+            crate::query_manager::types::BranchPolicies::default(),
             expected_parent_bundle_object_id,
-        )?;
+        )
+    }
+
+    pub fn publish_permissions_bundle_with_branch_policies(
+        &mut self,
+        schema_hash: SchemaHash,
+        permissions: HashMap<TableName, TablePolicies>,
+        branch_policies: crate::query_manager::types::BranchPolicies,
+        expected_parent_bundle_object_id: Option<ObjectId>,
+    ) -> Result<Option<ObjectId>, crate::schema_manager::SchemaError> {
+        let id = self
+            .schema_manager
+            .publish_permissions_bundle_with_branch_policies(
+                &mut self.storage,
+                schema_hash,
+                permissions,
+                branch_policies,
+                expected_parent_bundle_object_id,
+            )?;
         if id.is_some() {
             self.mark_storage_write_pending_flush();
             self.refresh_transport_catalogue_state_hash();

--- a/crates/jazz-tools/src/runtime_tokio.rs
+++ b/crates/jazz-tools/src/runtime_tokio.rs
@@ -315,6 +315,26 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
             .map_err(|error| RuntimeError::WriteError(error.to_string()))
     }
 
+    pub fn publish_permissions_bundle_with_branch_policies(
+        &self,
+        schema_hash: crate::query_manager::types::SchemaHash,
+        permissions: std::collections::HashMap<
+            crate::query_manager::types::TableName,
+            crate::query_manager::types::TablePolicies,
+        >,
+        branch_policies: crate::query_manager::types::BranchPolicies,
+        expected_parent_bundle_object_id: Option<ObjectId>,
+    ) -> Result<Option<ObjectId>, RuntimeError> {
+        let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
+        core.publish_permissions_bundle_with_branch_policies(
+            schema_hash,
+            permissions,
+            branch_policies,
+            expected_parent_bundle_object_id,
+        )
+        .map_err(|error| RuntimeError::WriteError(error.to_string()))
+    }
+
     pub fn current_permissions_head(&self) -> Result<Option<PermissionsHeadSummary>, RuntimeError> {
         let core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
         Ok(core.schema_manager().current_permissions_head())

--- a/crates/jazz-tools/src/schema_manager/encoding.rs
+++ b/crates/jazz-tools/src/schema_manager/encoding.rs
@@ -20,7 +20,7 @@ use super::lens::{LensOp, LensTransform};
 const SCHEMA_VERSION: u8 = SchemaEncodingVersion::V6 as u8;
 const LENS_VERSION: u8 = 2;
 const PERMISSIONS_VERSION: u8 = 1;
-const PERMISSIONS_BUNDLE_VERSION: u8 = 2;
+const PERMISSIONS_BUNDLE_VERSION: u8 = 3;
 const PERMISSIONS_HEAD_VERSION: u8 = 2;
 
 #[derive(Copy, Clone, PartialEq, Eq)]
@@ -1009,6 +1009,7 @@ const POLICY_EXPR_SESSION_IN_LIST: u8 = 21;
 
 const POLICY_VALUE_LITERAL: u8 = 1;
 const POLICY_VALUE_SESSION_REF: u8 = 2;
+const POLICY_VALUE_BRANCH_REF: u8 = 3;
 
 fn encode_table_policies(buf: &mut Vec<u8>, policies: &TablePolicies) {
     encode_operation_policy(buf, &policies.select);
@@ -1076,14 +1077,94 @@ pub fn decode_permissions(
     Ok(permissions)
 }
 
+pub fn encode_branch_policies(
+    branch_policies: &crate::query_manager::types::BranchPolicies,
+) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.push(PERMISSIONS_VERSION);
+
+    let mut backing_entries: Vec<_> = branch_policies.iter().collect();
+    backing_entries.sort_by_key(|(name, _)| name.as_str());
+    write_u32(&mut buf, backing_entries.len() as u32);
+
+    for (backing_table, table_policies) in backing_entries {
+        write_string(&mut buf, backing_table.as_str());
+        let mut table_entries: Vec<_> = table_policies.iter().collect();
+        table_entries.sort_by_key(|(name, _)| name.as_str());
+        write_u32(&mut buf, table_entries.len() as u32);
+        for (table_name, policies) in table_entries {
+            write_string(&mut buf, table_name.as_str());
+            encode_table_policies(&mut buf, policies);
+        }
+    }
+
+    buf
+}
+
+pub fn decode_branch_policies(
+    data: &[u8],
+) -> Result<crate::query_manager::types::BranchPolicies, CatalogueEncodingError> {
+    if data.is_empty() {
+        return Err(CatalogueEncodingError::TruncatedData {
+            expected: 1,
+            actual: 0,
+        });
+    }
+
+    let version = data[0];
+    if version != PERMISSIONS_VERSION {
+        return Err(CatalogueEncodingError::UnsupportedVersion {
+            found: version,
+            expected: PERMISSIONS_VERSION,
+        });
+    }
+
+    let mut offset = 1;
+    let backing_count = read_u32(data, &mut offset)?;
+    let mut branch_policies = HashMap::new();
+
+    for _ in 0..backing_count {
+        let backing_table = TableName::new(read_string(data, &mut offset, "backing_table")?);
+        let table_count = read_u32(data, &mut offset)?;
+        let mut table_policies = HashMap::new();
+        for _ in 0..table_count {
+            let table_name = TableName::new(read_string(data, &mut offset, "table_name")?);
+            let policies = decode_table_policies(data, &mut offset)?;
+            table_policies.insert(table_name, policies);
+        }
+        branch_policies.insert(backing_table, table_policies);
+    }
+
+    Ok(branch_policies)
+}
+
 pub fn encode_permissions_bundle(
     schema_hash: SchemaHash,
     version: u64,
     parent_bundle_object_id: Option<ObjectId>,
     permissions: &HashMap<TableName, TablePolicies>,
 ) -> Vec<u8> {
+    encode_permissions_bundle_with_branch_policies(
+        schema_hash,
+        version,
+        parent_bundle_object_id,
+        permissions,
+        &crate::query_manager::types::BranchPolicies::default(),
+    )
+}
+
+pub fn encode_permissions_bundle_with_branch_policies(
+    schema_hash: SchemaHash,
+    version: u64,
+    parent_bundle_object_id: Option<ObjectId>,
+    permissions: &HashMap<TableName, TablePolicies>,
+    branch_policies: &crate::query_manager::types::BranchPolicies,
+) -> Vec<u8> {
     let encoded_permissions = encode_permissions(permissions);
-    let mut buf = Vec::with_capacity(1 + 32 + 8 + 1 + 16 + 4 + encoded_permissions.len());
+    let encoded_branch_policies = encode_branch_policies(branch_policies);
+    let mut buf = Vec::with_capacity(
+        1 + 32 + 8 + 1 + 16 + 4 + encoded_permissions.len() + 4 + encoded_branch_policies.len(),
+    );
     buf.push(PERMISSIONS_BUNDLE_VERSION);
     buf.extend_from_slice(schema_hash.as_bytes());
     write_u64(&mut buf, version);
@@ -1096,6 +1177,8 @@ pub fn encode_permissions_bundle(
     }
     write_u32(&mut buf, encoded_permissions.len() as u32);
     buf.extend_from_slice(&encoded_permissions);
+    write_u32(&mut buf, encoded_branch_policies.len() as u32);
+    buf.extend_from_slice(&encoded_branch_policies);
     buf
 }
 
@@ -1104,6 +1187,7 @@ type DecodedPermissionsBundle = (
     u64,
     Option<ObjectId>,
     HashMap<TableName, TablePolicies>,
+    crate::query_manager::types::BranchPolicies,
 );
 
 pub fn decode_permissions_bundle(
@@ -1119,7 +1203,8 @@ pub fn decode_permissions_bundle(
     let version = data[0];
     match version {
         1 => decode_permissions_bundle_v1(data),
-        PERMISSIONS_BUNDLE_VERSION => decode_permissions_bundle_v2(data),
+        2 => decode_permissions_bundle_v2(data),
+        PERMISSIONS_BUNDLE_VERSION => decode_permissions_bundle_v3(data),
         _ => Err(CatalogueEncodingError::UnsupportedVersion {
             found: version,
             expected: PERMISSIONS_BUNDLE_VERSION,
@@ -1139,7 +1224,13 @@ fn decode_permissions_bundle_v1(
     let payload_len = read_u32(data, &mut offset)? as usize;
     let payload = read_bytes(data, &mut offset, payload_len)?;
     let permissions = decode_permissions(payload)?;
-    Ok((schema_hash, 1, None, permissions))
+    Ok((
+        schema_hash,
+        1,
+        None,
+        permissions,
+        crate::query_manager::types::BranchPolicies::default(),
+    ))
 }
 
 fn decode_permissions_bundle_v2(
@@ -1167,7 +1258,50 @@ fn decode_permissions_bundle_v2(
     let payload_len = read_u32(data, &mut offset)? as usize;
     let payload = read_bytes(data, &mut offset, payload_len)?;
     let permissions = decode_permissions(payload)?;
-    Ok((schema_hash, version, parent_bundle_object_id, permissions))
+    Ok((
+        schema_hash,
+        version,
+        parent_bundle_object_id,
+        permissions,
+        crate::query_manager::types::BranchPolicies::default(),
+    ))
+}
+
+fn decode_permissions_bundle_v3(
+    data: &[u8],
+) -> Result<DecodedPermissionsBundle, CatalogueEncodingError> {
+    let mut offset = 1;
+    let schema_hash = SchemaHash::from_bytes(
+        read_bytes(data, &mut offset, 32)?
+            .try_into()
+            .expect("schema hash length should be exact"),
+    );
+    let version = read_u64(data, &mut offset)?;
+    let has_parent = read_u8(data, &mut offset)? != 0;
+    let parent_bundle_object_id = if has_parent {
+        let parent_uuid =
+            uuid::Uuid::from_slice(read_bytes(data, &mut offset, 16)?).map_err(|err| {
+                CatalogueEncodingError::DecodeError {
+                    message: format!("invalid parent permissions bundle object id: {err}"),
+                }
+            })?;
+        Some(ObjectId::from_uuid(parent_uuid))
+    } else {
+        None
+    };
+    let payload_len = read_u32(data, &mut offset)? as usize;
+    let payload = read_bytes(data, &mut offset, payload_len)?;
+    let permissions = decode_permissions(payload)?;
+    let branch_payload_len = read_u32(data, &mut offset)? as usize;
+    let branch_payload = read_bytes(data, &mut offset, branch_payload_len)?;
+    let branch_policies = decode_branch_policies(branch_payload)?;
+    Ok((
+        schema_hash,
+        version,
+        parent_bundle_object_id,
+        permissions,
+        branch_policies,
+    ))
 }
 
 pub fn encode_permissions_head(
@@ -1652,6 +1786,10 @@ fn encode_policy_value(buf: &mut Vec<u8>, value: &PolicyValue) {
                 write_string(buf, part);
             }
         }
+        PolicyValue::BranchRef(column) => {
+            buf.push(POLICY_VALUE_BRANCH_REF);
+            write_string(buf, column);
+        }
     }
 }
 
@@ -1669,6 +1807,10 @@ fn decode_policy_value(
                 path.push(read_string(data, offset, "policy_session_ref_path")?);
             }
             Ok(PolicyValue::SessionRef(path))
+        }
+        POLICY_VALUE_BRANCH_REF => {
+            let column = read_string(data, offset, "policy_branch_ref_column")?;
+            Ok(PolicyValue::BranchRef(column))
         }
         _ => Err(CatalogueEncodingError::InvalidTypeTag {
             tag,
@@ -2525,13 +2667,64 @@ mod tests {
 
         let encoded =
             encode_permissions_bundle(schema_hash, version, parent_bundle_object_id, &permissions);
-        let (decoded_hash, decoded_version, decoded_parent_bundle_object_id, decoded_permissions) =
-            decode_permissions_bundle(&encoded).expect("bundle should decode");
+        let (
+            decoded_hash,
+            decoded_version,
+            decoded_parent_bundle_object_id,
+            decoded_permissions,
+            decoded_branch_policies,
+        ) = decode_permissions_bundle(&encoded).expect("bundle should decode");
 
         assert_eq!(decoded_hash, schema_hash);
         assert_eq!(decoded_version, version);
         assert_eq!(decoded_parent_bundle_object_id, parent_bundle_object_id);
         assert_eq!(decoded_permissions, permissions);
+        assert_eq!(
+            decoded_branch_policies,
+            crate::query_manager::types::BranchPolicies::default()
+        );
+    }
+
+    #[test]
+    fn permissions_bundle_roundtrip_preserves_branch_policies() {
+        let schema_hash = SchemaHash::from_bytes([8; 32]);
+        let version = 8;
+        let permissions = HashMap::from([(
+            TableName::new("projects"),
+            TablePolicies::new().with_select(PolicyExpr::True),
+        )]);
+        let branch_policies = HashMap::from([(
+            TableName::new("project_branches"),
+            HashMap::from([(
+                TableName::new("tasks"),
+                TablePolicies::new().with_select(PolicyExpr::Cmp {
+                    column: "project_id".to_string(),
+                    op: CmpOp::Eq,
+                    value: PolicyValue::BranchRef("projectId".to_string()),
+                }),
+            )]),
+        )]);
+
+        let encoded = encode_permissions_bundle_with_branch_policies(
+            schema_hash,
+            version,
+            None,
+            &permissions,
+            &branch_policies,
+        );
+        let (
+            decoded_hash,
+            decoded_version,
+            decoded_parent_bundle_object_id,
+            decoded_permissions,
+            decoded_branch_policies,
+        ) = decode_permissions_bundle(&encoded).expect("bundle should decode");
+
+        assert_eq!(decoded_hash, schema_hash);
+        assert_eq!(decoded_version, version);
+        assert_eq!(decoded_parent_bundle_object_id, None);
+        assert_eq!(decoded_permissions, permissions);
+        assert_eq!(decoded_branch_policies, branch_policies);
     }
 
     #[test]

--- a/crates/jazz-tools/src/schema_manager/manager.rs
+++ b/crates/jazz-tools/src/schema_manager/manager.rs
@@ -1543,7 +1543,10 @@ impl SchemaManager {
 
         let authorization_schema = merge_permissions_into_schema(&schema, &bundle.permissions);
         self.query_manager
-            .set_authorization_schema(authorization_schema);
+            .set_authorization_schema_with_branch_policies(
+                authorization_schema,
+                bundle.branch_policies.clone(),
+            );
         true
     }
 

--- a/crates/jazz-tools/src/schema_manager/manager.rs
+++ b/crates/jazz-tools/src/schema_manager/manager.rs
@@ -174,6 +174,7 @@ impl SchemaManager {
         Self::new_with_policy_mode(
             sync_manager,
             schema,
+            BranchPolicies::default(),
             app_id,
             env,
             user_branch,
@@ -184,6 +185,7 @@ impl SchemaManager {
     pub fn new_with_policy_mode(
         sync_manager: SyncManager,
         schema: Schema,
+        branch_policies: BranchPolicies,
         app_id: AppId,
         env: &str,
         user_branch: &str,
@@ -203,6 +205,10 @@ impl SchemaManager {
             user_branch,
             row_policy_mode,
         );
+        if !branch_policies.is_empty() {
+            query_manager
+                .set_authorization_schema_with_branch_policies(schema.clone(), branch_policies);
+        }
 
         // Initialize known_schemas with current schema
         let mut known_schemas = HashMap::new();

--- a/crates/jazz-tools/src/schema_manager/manager.rs
+++ b/crates/jazz-tools/src/schema_manager/manager.rs
@@ -20,8 +20,8 @@ use crate::query_manager::manager::{DeleteHandle, InsertResult, QueryError, Quer
 use crate::query_manager::query::QueryBuilder;
 use crate::query_manager::session::WriteContext;
 use crate::query_manager::types::{
-    ComposedBranchName, RowDescriptor, RowPolicyMode, Schema, SchemaHash, TableName, TablePolicies,
-    Value,
+    BranchPolicies, ComposedBranchName, RowDescriptor, RowPolicyMode, Schema, SchemaHash,
+    TableName, TablePolicies, Value,
 };
 use crate::query_manager::writes::{RowBranchDelete, RowBranchWrite};
 use crate::row_format::decode_row;
@@ -34,8 +34,8 @@ use super::auto_lens::generate_lens;
 use super::context::{SchemaContext, SchemaError};
 use super::encoding::{
     decode_lens_transform, decode_permissions, decode_permissions_bundle, decode_permissions_head,
-    decode_schema, encode_lens_transform, encode_permissions, encode_permissions_bundle,
-    encode_permissions_head, encode_schema,
+    decode_schema, encode_lens_transform, encode_permissions,
+    encode_permissions_bundle_with_branch_policies, encode_permissions_head, encode_schema,
 };
 use super::lens::Lens;
 use super::types::AppId;
@@ -46,6 +46,7 @@ struct PermissionsBundleState {
     version: u64,
     parent_bundle_object_id: Option<ObjectId>,
     permissions: HashMap<TableName, TablePolicies>,
+    branch_policies: BranchPolicies,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -68,6 +69,7 @@ pub struct PermissionsHeadSummary {
 pub struct CurrentPermissionsSummary {
     pub head: PermissionsHeadSummary,
     pub permissions: HashMap<TableName, TablePolicies>,
+    pub branch_policies: BranchPolicies,
 }
 
 #[derive(Clone, Debug)]
@@ -733,6 +735,7 @@ impl SchemaManager {
         Some(CurrentPermissionsSummary {
             head,
             permissions: bundle.permissions.clone(),
+            branch_policies: bundle.branch_policies.clone(),
         })
     }
 
@@ -1021,11 +1024,12 @@ impl SchemaManager {
         let bundle_metadata = self.permissions_bundle_metadata();
         let head_object_id = self.permissions_head_object_id();
         let head_metadata = self.permissions_head_metadata();
-        let bundle_content = encode_permissions_bundle(
+        let bundle_content = encode_permissions_bundle_with_branch_policies(
             bundle.schema_hash,
             bundle.version,
             bundle.parent_bundle_object_id,
             &bundle.permissions,
+            &bundle.branch_policies,
         );
         let bundle_timestamp = self.query_manager.sync_manager_mut().reserve_timestamp();
         self.catalogue_publish_timestamps
@@ -1064,6 +1068,23 @@ impl SchemaManager {
         permissions: HashMap<TableName, TablePolicies>,
         expected_parent_bundle_object_id: Option<ObjectId>,
     ) -> Result<Option<ObjectId>, SchemaError> {
+        self.publish_permissions_bundle_with_branch_policies(
+            storage,
+            schema_hash,
+            permissions,
+            BranchPolicies::default(),
+            expected_parent_bundle_object_id,
+        )
+    }
+
+    pub fn publish_permissions_bundle_with_branch_policies<H: Storage>(
+        &mut self,
+        storage: &mut H,
+        schema_hash: SchemaHash,
+        permissions: HashMap<TableName, TablePolicies>,
+        branch_policies: BranchPolicies,
+        expected_parent_bundle_object_id: Option<ObjectId>,
+    ) -> Result<Option<ObjectId>, SchemaError> {
         let current_parent_bundle_object_id = self
             .current_permissions_head
             .map(|head| head.bundle_object_id);
@@ -1078,6 +1099,7 @@ impl SchemaManager {
             && head.schema_hash == schema_hash
             && let Some(existing) = self.known_permissions_bundles.get(&head.bundle_object_id)
             && existing.permissions == permissions
+            && existing.branch_policies == branch_policies
         {
             return Ok(Some(self.permissions_head_object_id()));
         }
@@ -1091,6 +1113,7 @@ impl SchemaManager {
             version,
             parent_bundle_object_id: current_parent_bundle_object_id,
             permissions,
+            branch_policies,
         };
         let bundle_object_id = self.permissions_bundle_object_id(&bundle_state);
         self.known_permissions_bundles
@@ -1154,11 +1177,12 @@ impl SchemaManager {
     fn permissions_bundle_object_id(&self, bundle: &PermissionsBundleState) -> ObjectId {
         let mut identity =
             format!("jazz-catalogue-permissions-bundle:{}:", self.app_id.uuid()).into_bytes();
-        identity.extend_from_slice(&encode_permissions_bundle(
+        identity.extend_from_slice(&encode_permissions_bundle_with_branch_policies(
             bundle.schema_hash,
             bundle.version,
             bundle.parent_bundle_object_id,
             &bundle.permissions,
+            &bundle.branch_policies,
         ));
         ObjectId::from_uuid(Uuid::new_v5(&Uuid::NAMESPACE_DNS, &identity))
     }
@@ -1316,7 +1340,7 @@ impl SchemaManager {
             return Ok(());
         }
 
-        let (schema_hash, version, parent_bundle_object_id, permissions) =
+        let (schema_hash, version, parent_bundle_object_id, permissions, branch_policies) =
             decode_permissions_bundle(content)
                 .map_err(|_| SchemaError::SchemaNotFound(SchemaHash::from_bytes([0; 32])))?;
         self.known_permissions_bundles.insert(
@@ -1326,6 +1350,7 @@ impl SchemaManager {
                 version,
                 parent_bundle_object_id,
                 permissions,
+                branch_policies,
             },
         );
 
@@ -1402,6 +1427,7 @@ impl SchemaManager {
                 version: 1,
                 parent_bundle_object_id: None,
                 permissions,
+                branch_policies: BranchPolicies::default(),
             },
         );
         let head = PermissionsHeadState {
@@ -2537,6 +2563,7 @@ mod tests {
             version: 3,
             parent_bundle_object_id: Some(ObjectId::new()),
             permissions: permissions.clone(),
+            branch_policies: BranchPolicies::default(),
         };
         let bundle_object_id = manager.permissions_bundle_object_id(&bundle);
         let head = PermissionsHeadState {
@@ -2565,7 +2592,7 @@ mod tests {
             .process_catalogue_update(
                 bundle_object_id,
                 &manager.permissions_bundle_metadata(),
-                &encode_permissions_bundle(
+                &crate::schema_manager::encoding::encode_permissions_bundle(
                     schema_hash,
                     bundle.version,
                     bundle.parent_bundle_object_id,
@@ -2608,6 +2635,7 @@ mod tests {
             version: 1,
             parent_bundle_object_id: None,
             permissions: permissions.clone(),
+            branch_policies: BranchPolicies::default(),
         };
         let bundle_object_id = manager.permissions_bundle_object_id(&bundle);
 
@@ -2652,7 +2680,7 @@ mod tests {
             .process_catalogue_update(
                 bundle_object_id,
                 &manager.permissions_bundle_metadata(),
-                &encode_permissions_bundle(
+                &crate::schema_manager::encoding::encode_permissions_bundle(
                     schema_hash,
                     bundle.version,
                     bundle.parent_bundle_object_id,

--- a/crates/jazz-tools/src/schema_manager/manager.rs
+++ b/crates/jazz-tools/src/schema_manager/manager.rs
@@ -329,6 +329,12 @@ impl SchemaManager {
         self.context.branch_name()
     }
 
+    /// Compose a branch name for the current environment and schema.
+    pub fn compose_branch_name(&self, user_branch: &str) -> BranchName {
+        ComposedBranchName::new(&self.context.env, self.context.current_hash, user_branch)
+            .to_branch_name()
+    }
+
     /// Get branch names for all live schemas (current + live).
     pub fn all_branches(&self) -> Vec<BranchName> {
         self.context.all_branch_names()
@@ -361,12 +367,16 @@ impl SchemaManager {
     fn resolve_target_branch(
         &self,
         write_context: Option<&WriteContext>,
-    ) -> Result<(String, SchemaHash), QueryError> {
+    ) -> Result<(String, SchemaHash, String), QueryError> {
         let current_branch = self.context.branch_name().as_str().to_string();
         let current_hash = self.context.current_hash;
         let Some(target_branch_name) = write_context.and_then(WriteContext::target_branch_name)
         else {
-            return Ok((current_branch, current_hash));
+            return Ok((
+                current_branch,
+                current_hash,
+                self.context.user_branch.clone(),
+            ));
         };
 
         let parsed =
@@ -376,46 +386,51 @@ impl SchemaManager {
                 ))
             })?;
 
-        if !parsed.matches_env_and_branch(&self.context.env, &self.context.user_branch) {
+        // A runtime is not pinned to a single data branch: a write may target any
+        // user branch within the same env (this is how `db.branch(...)` routes
+        // writes through one runtime). Only the env must match; the schema hash is
+        // resolved against the current/live schemas below.
+        if parsed.env != self.context.env {
             return Err(QueryError::EncodingError(format!(
-                "target_branch_name `{target_branch_name}` is outside the current schema family {}/*/{}",
-                self.context.env, self.context.user_branch
+                "target_branch_name `{target_branch_name}` is outside the current schema family {}/*/*",
+                self.context.env
             )));
         }
 
-        if parsed.schema_hash.short() == current_hash.short() {
-            return Ok((current_branch, current_hash));
-        }
-
-        if let Some(hash) = self
+        let resolved_hash = if parsed.schema_hash.short() == current_hash.short() {
+            current_hash
+        } else if let Some(hash) = self
             .context
             .live_schemas
             .keys()
             .copied()
             .find(|hash| hash.short() == parsed.schema_hash.short())
         {
-            let canonical =
-                ComposedBranchName::new(&self.context.env, hash, &self.context.user_branch)
-                    .to_branch_name();
-            return Ok((canonical.as_str().to_string(), hash));
-        }
+            hash
+        } else {
+            return Err(QueryError::UnknownSchema(parsed.schema_hash));
+        };
 
-        Err(QueryError::UnknownSchema(parsed.schema_hash))
+        let target = ComposedBranchName::new(&self.context.env, resolved_hash, &parsed.user_branch)
+            .to_branch_name();
+        Ok((
+            target.as_str().to_string(),
+            resolved_hash,
+            parsed.user_branch,
+        ))
     }
 
     fn schema_context_for_hash(
         &self,
         schema_hash: SchemaHash,
+        user_branch: &str,
     ) -> Result<SchemaContext, QueryError> {
         let target_schema = self
             .schema_for_hash(schema_hash)
             .ok_or(QueryError::UnknownSchema(schema_hash))?
             .clone();
-        let mut temp_context = SchemaContext::new(
-            target_schema.clone(),
-            &self.context.env,
-            &self.context.user_branch,
-        );
+        let mut temp_context =
+            SchemaContext::new(target_schema.clone(), &self.context.env, user_branch);
 
         for lens in self.context.lenses.values() {
             temp_context.register_lens(lens.clone());
@@ -1613,7 +1628,7 @@ impl SchemaManager {
         write_context: Option<&WriteContext>,
     ) -> Result<InsertResult, QueryError> {
         let _ = self.ensure_current_schema_persisted(storage);
-        let (target_branch, target_hash) = self.resolve_target_branch(write_context)?;
+        let (target_branch, target_hash, _) = self.resolve_target_branch(write_context)?;
         let table_name = TableName::new(table);
 
         let context = &self.context;
@@ -1653,8 +1668,9 @@ impl SchemaManager {
         write_context: Option<&WriteContext>,
     ) -> Result<crate::row_histories::BatchId, QueryError> {
         let _ = self.ensure_current_schema_persisted(storage);
-        let (target_branch, target_hash) = self.resolve_target_branch(write_context)?;
-        let target_context = self.schema_context_for_hash(target_hash)?;
+        let (target_branch, target_hash, target_user_branch) =
+            self.resolve_target_branch(write_context)?;
+        let target_context = self.schema_context_for_hash(target_hash, &target_user_branch)?;
         let branches = target_context
             .all_branch_names()
             .into_iter()
@@ -1708,12 +1724,13 @@ impl SchemaManager {
         write_context: Option<&WriteContext>,
     ) -> Result<crate::row_histories::BatchId, QueryError> {
         let _ = self.ensure_current_schema_persisted(storage);
-        let (target_branch, target_hash) = self.resolve_target_branch(write_context)?;
+        let (target_branch, target_hash, target_user_branch) =
+            self.resolve_target_branch(write_context)?;
         let target_schema = self
             .schema_for_hash(target_hash)
             .ok_or(QueryError::UnknownSchema(target_hash))?
             .clone();
-        let target_context = self.schema_context_for_hash(target_hash)?;
+        let target_context = self.schema_context_for_hash(target_hash, &target_user_branch)?;
         let branches = target_context
             .all_branch_names()
             .into_iter()
@@ -1821,12 +1838,13 @@ impl SchemaManager {
         write_context: Option<&WriteContext>,
     ) -> Result<DeleteHandle, QueryError> {
         let _ = self.ensure_current_schema_persisted(storage);
-        let (target_branch, target_hash) = self.resolve_target_branch(write_context)?;
+        let (target_branch, target_hash, target_user_branch) =
+            self.resolve_target_branch(write_context)?;
         let target_schema = self
             .schema_for_hash(target_hash)
             .ok_or(QueryError::UnknownSchema(target_hash))?
             .clone();
-        let target_context = self.schema_context_for_hash(target_hash)?;
+        let target_context = self.schema_context_for_hash(target_hash, &target_user_branch)?;
         let branches = target_context
             .all_branch_names()
             .into_iter()
@@ -1892,7 +1910,7 @@ impl SchemaManager {
         write_context: Option<&WriteContext>,
     ) -> Result<InsertResult, QueryError> {
         let _ = self.ensure_current_schema_persisted(storage);
-        let (target_branch, target_hash) = self.resolve_target_branch(write_context)?;
+        let (target_branch, target_hash, _) = self.resolve_target_branch(write_context)?;
         let actual_table = self
             .query_manager
             .load_row_table_name(storage, object_id)
@@ -2107,6 +2125,25 @@ mod tests {
         assert_eq!(manager.env(), "dev");
         assert_eq!(manager.user_branch(), "main");
         assert_eq!(manager.app_id(), test_app_id());
+    }
+
+    #[test]
+    fn compose_branch_name_uses_current_env_and_schema_hash() {
+        let schema = make_schema_v1();
+        let hash_short = SchemaHash::compute(&schema).short();
+        let manager =
+            SchemaManager::new(SyncManager::new(), schema, test_app_id(), "dev", "main").unwrap();
+
+        assert_eq!(
+            manager.compose_branch_name("main").as_str(),
+            format!("dev-{hash_short}-main")
+        );
+        assert_eq!(
+            manager
+                .compose_branch_name("0197a60f-6eba-7500-b968-a4ab7af76e39")
+                .as_str(),
+            format!("dev-{hash_short}-0197a60f-6eba-7500-b968-a4ab7af76e39")
+        );
     }
 
     #[test]

--- a/crates/jazz-tools/src/server/routes/http.rs
+++ b/crates/jazz-tools/src/server/routes/http.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use crate::jazz_transport::ErrorResponse;
 use crate::middleware::auth::validate_admin_secret;
 use crate::query_manager::types::{
-    ColumnType, Schema, SchemaHash, TableName, TablePolicies, Value,
+    BranchPolicies, ColumnType, Schema, SchemaHash, TableName, TablePolicies, Value,
 };
 use crate::schema_manager::{Lens, LensOp, LensTransform};
 use crate::server::{ServerState, ShutdownPhase};
@@ -116,6 +116,8 @@ pub(super) struct PublishSchemaRequest {
 pub(super) struct PublishPermissionsRequest {
     schema_hash: String,
     permissions: std::collections::HashMap<String, TablePolicies>,
+    #[serde(default, alias = "branch_policies")]
+    branch_policies: BranchPolicies,
     expected_parent_bundle_object_id: Option<String>,
 }
 
@@ -784,17 +786,21 @@ pub(super) async fn publish_permissions_handler(
         }
     }
 
+    let branch_policies = request.branch_policies;
     let permissions = request
         .permissions
         .into_iter()
         .map(|(table_name, policies)| (TableName::new(table_name), policies))
         .collect();
 
-    match state.runtime.publish_permissions_bundle(
-        schema_hash,
-        permissions,
-        expected_parent_bundle_object_id,
-    ) {
+    match state
+        .runtime
+        .publish_permissions_bundle_with_branch_policies(
+            schema_hash,
+            permissions,
+            branch_policies,
+            expected_parent_bundle_object_id,
+        ) {
         Ok(_) => match state.runtime.with_schema_manager(|schema_manager| {
             schema_manager
                 .current_permissions_head()

--- a/crates/jazz-wasm/src/runtime.rs
+++ b/crates/jazz-wasm/src/runtime.rs
@@ -337,6 +337,7 @@ fn build_schema_manager(
     SchemaManager::new_with_policy_mode(
         sync_manager,
         runtime_schema.schema,
+        runtime_schema.branch_policies,
         app_id,
         env,
         user_branch,
@@ -1469,7 +1470,6 @@ impl WasmRuntime {
         // Parse schema
         let runtime_schema = jazz_tools::binding_support::parse_runtime_schema_input(schema_json)
             .map_err(|e| JsError::new(&format!("Invalid schema JSON: {}", e)))?;
-        let schema = runtime_schema.schema;
         // Parse optional tier
         let node_tiers = parse_node_durability_tiers(tier.as_deref())?;
 
@@ -1484,7 +1484,8 @@ impl WasmRuntime {
         // Create schema manager
         let schema_manager = SchemaManager::new_with_policy_mode(
             sync_manager,
-            schema,
+            runtime_schema.schema,
+            runtime_schema.branch_policies,
             app_id,
             env,
             user_branch,

--- a/crates/jazz-wasm/src/runtime.rs
+++ b/crates/jazz-wasm/src/runtime.rs
@@ -1983,6 +1983,16 @@ impl WasmRuntime {
         SchemaHash::compute(schema).to_string()
     }
 
+    /// Compose a raw user branch name for the current environment and schema.
+    #[wasm_bindgen(js_name = composeBranchName)]
+    pub fn compose_branch_name(&self, user_branch: &str) -> String {
+        let core = self.core.borrow();
+        core.schema_manager()
+            .compose_branch_name(user_branch)
+            .as_str()
+            .to_string()
+    }
+
     /// Debug helper: expose schema/lens state currently loaded in SchemaManager.
     #[wasm_bindgen(js_name = __debugSchemaState)]
     pub fn debug_schema_state(&self) -> Result<JsValue, JsError> {

--- a/docs/superpowers/plans/2026-06-23-branch-permissions.md
+++ b/docs/superpowers/plans/2026-06-23-branch-permissions.md
@@ -1,0 +1,548 @@
+# Branch Permissions & Query APIs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Each Task is sized for one subagent.
+
+**Goal:** Add branch-scoped access control to jazz2's public API: define full-CRUD branch policies with `policy.forBranch`, read/write branch-scoped rows through a `db.branch(branchId)` view (incl. framework adapters), enforced deny-by-default in the Rust core.
+
+**Architecture:** A branch is a normal application row; its id is the public branch id. The TS DSL collects branch rules (tagged with a `branchBackingTable`) alongside normal rules and compiles them into a branch-scoped permission structure carried through the IR to the Rust core. A new Rust `permission_routing` module resolves the backing branch row (`$branch`), gates access on its readability, and dispatches to branch policies; `$branch.<col>` refs bind to literal backing-row values exactly as `SessionRef` does today. jazz2's existing storage-branch routing is reused unchanged.
+
+**Tech Stack:** Rust (`crates/jazz-tools`), TypeScript (`packages/jazz-tools`), vitest, `cargo test`, turbo.
+
+**Reference:** garden-co/jazz PR #917. Executors SHOULD pull the reference diff for the corresponding hunks (it is a _guide_, not a copy source — jazz2 has diverged):
+
+```bash
+gh pr diff 917 --repo garden-co/jazz > /tmp/pr917.diff
+```
+
+**Spec:** `docs/superpowers/specs/2026-06-23-branch-permissions-design.md` — read it before starting.
+
+**Global rules for every task:**
+
+- Black-box integration tests via the public API per `crates/jazz-tools/TESTING_GUIDELINES.md` (read it before writing Rust tests). No JSON-like schema/permission/query literals — build them with the public DSL / `SchemaBuilder`.
+- Do NOT rewrite existing passing tests to match new behavior without surfacing it. New behavior gets new tests.
+- Commit after each task with a `feat:`/`test:` message. No AI/Claude attribution in commits.
+- Build commands: `pnpm build:core`, `pnpm test` (turbo). Per-package commands are given inline per task.
+
+---
+
+## File Structure
+
+**TypeScript (`packages/jazz-tools/src/`)**
+
+- `permissions/index.ts` — add `forBranch`, table-keyed `branchPolicy` builder, `$branch` proxy; extend `Rule` with `branchBackingTable`; compile branch rules into the compiled-permissions structure.
+- `schema-permissions.ts` — carry/normalize branch policies for WASM.
+- `ir.ts` — branch-ref operand + branch-policy fields in the IR.
+- `runtime/db.ts` — `db.branch(branchId)` returning a branch-scoped `Db` view.
+- `react-core/use-all.ts`, `react-native/use-all.ts`, `svelte/use-all.svelte.ts`, `vue/use-all.ts` — accept a branch-scoped Db/query.
+
+**Rust (`crates/jazz-tools/src/query_manager/`)**
+
+- `policy.rs` — `PolicyValue::BranchRef(String)` + serde + binding.
+- `permission_routing.rs` — **new**: `PermissionRoute`, `ResolvedBranchRow`, `PolicyEvalRefs`, `bind_branch_refs`.
+- `mod.rs` — register `permission_routing` module.
+- `types/policy.rs` — branch-ref policy-value input variant; branch policy carrier on schema/permissions types.
+- `graph_nodes/policy_filter.rs`, `graph_nodes/policy_eval.rs` — route reads through `permission_routing`.
+- `writes.rs` — route insert/update/delete through `permission_routing`.
+- `schema_manager/encoding.rs` — encode/decode branch policies + branch-ref values.
+- `rebac_tests/branch_policies.rs` — **new**: Rust integration tests.
+
+**TS tests**
+
+- `packages/jazz-tools/src/permissions/index.test.ts`, `dsl.test.ts` — DSL unit coverage.
+- `packages/jazz-tools/src/schema-permissions.test.ts` — compile/normalize coverage.
+- `packages/jazz-tools/src/runtime/db.branch.test.ts` — **new**: `db.branch()` view.
+- `packages/jazz-tools/tests/branch-permissions.integration.test.ts` — **new**: end-to-end CRUD matrix.
+- `packages/jazz-tools/src/vue/use-all.test.ts` — adapter smoke.
+
+---
+
+## Task 1: TS DSL — `forBranch`, `branchPolicy`, `$branch`
+
+**Files:**
+
+- Modify: `packages/jazz-tools/src/permissions/index.ts` (`Rule` at ~423; `definePermissions`/`buildPolicyContext` at ~619-700; `compileRules` at ~2055)
+- Test: `packages/jazz-tools/src/dsl.test.ts`
+
+- [ ] **Step 1: Write the failing test** in `dsl.test.ts`. Build a real app + permissions through the public DSL and assert the compiled output carries branch policies keyed by the backing table.
+
+```ts
+import { describe, it, expect } from "vitest";
+import * as s from "./index.js"; // match how dsl.test.ts already imports the schema/permissions DSL
+
+describe("forBranch DSL", () => {
+  it("collects table-keyed branch policies tagged with the backing table", () => {
+    const app = s.defineApp({
+      projects: s.table({ name: s.string(), ownerId: s.string() }),
+      branches: s.table({ projectId: s.ref("projects"), ownerId: s.string() }),
+      todos: s.table({ projectId: s.ref("projects"), title: s.string(), ownerId: s.string() }),
+    });
+
+    const permissions = s.definePermissions(app, ({ policy, session }) => {
+      policy.branches.allowRead.where({ ownerId: session.user_id });
+      policy.forBranch(policy.branches, ({ $branch, branchPolicy }) => {
+        branchPolicy.todos.allowRead.where({ projectId: $branch.projectId });
+        branchPolicy.todos.allowInsert.where({
+          projectId: $branch.projectId,
+          ownerId: session.user_id,
+        });
+      });
+    });
+
+    // The compiled permissions expose a branch-scoped section for `todos`
+    // backed by `branches`, with read + insert operations present.
+    const branchPolicies = (permissions as any).branchPolicies;
+    expect(branchPolicies).toBeDefined();
+    expect(branchPolicies.branches.todos.select.using).toBeDefined();
+    expect(branchPolicies.branches.todos.insert.with_check).toBeDefined();
+  });
+});
+```
+
+> Note: confirm the exact public import surface (`s.defineApp`/`s.definePermissions`) against the top of the existing `dsl.test.ts` and match it. The assertion shape (`branchPolicies[backingTable][table]`) is the contract this task establishes — keep it stable for Task 2.
+
+- [ ] **Step 2: Run the test, verify it fails.**
+      Run: `pnpm --filter jazz-tools exec vitest run src/dsl.test.ts -t "forBranch"`
+      Expected: FAIL — `policy.forBranch is not a function` (or `branchPolicies` undefined).
+
+- [ ] **Step 3: Implement the DSL.** In `permissions/index.ts`:
+  1. Extend `Rule`: `interface Rule { table: string; action: PolicyAction; using?: Condition; withCheck?: Condition; branchBackingTable?: string; }`.
+  2. Add a branch-ref value kind. Near the other `__jazzPermissionKind` value types, add `interface BranchRefValue { readonly __jazzPermissionKind: "branch-ref"; readonly column: string; }` and a `isBranchRefCondition`-style guard. Ensure `resolveWhereInput`/`compileCondition` accept it and lower it to a branch-ref operand (see Task 2 for the IR operand).
+  3. Add `createBranchContext()` returning a `Proxy` whose `get(_t, prop)` yields `{ __jazzPermissionKind: "branch-ref", column: prop }` for string props.
+  4. Add `buildBranchPolicyBuilder(backingTable, relationsByTable, collectRule)` mirroring `buildTablePolicyBuilder` but table-keyed: for each app table it returns an object with `allowRead/allowInsert/allowDelete` and `get allowUpdate()` whose `.where(...)` calls `collectRule({ table, action, using|withCheck, branchBackingTable: backingTable })`. Update actions use the existing `UpdateRuleBuilder`; pass the backing table so its emitted rule carries `branchBackingTable` (extend `UpdateRuleBuilder` constructor with an optional `branchBackingTable` and include it in `toRule()`).
+  5. In `buildPolicyContext`, add `context.forBranch = (backingTableBuilder, factory) => { const backingTable = backingTableBuilder.__jazzPermissionTable; factory({ $branch: createBranchContext(), branchPolicy: buildBranchPolicyBuilder(backingTable, relationsByTable, collectRule) }); }`.
+  6. In `compileRules`, branch the switch: when `rule.branchBackingTable` is set, write into a separate `branchPolicies[backingTable][table]` `TablePolicies` structure (reuse `emptyTablePolicies`/`mergeOperationPolicy`/`compileCondition`) instead of the normal `compiled[table]`. Return `{ ...compiled-as-today, branchPolicies }` — but keep the existing `CompiledPermissions` return shape additive (attach `branchPolicies` as a non-enumerable or extra field so existing consumers are unaffected). Update `CompiledPermissions` type accordingly.
+
+- [ ] **Step 4: Run the test, verify it passes.**
+      Run: `pnpm --filter jazz-tools exec vitest run src/dsl.test.ts -t "forBranch"`
+      Expected: PASS.
+
+- [ ] **Step 5: Typecheck + existing permission tests still green.**
+      Run: `pnpm --filter jazz-tools exec tsc --noEmit --pretty false`
+      Run: `pnpm --filter jazz-tools exec vitest run src/permissions/index.test.ts`
+      Expected: PASS (no regressions).
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add packages/jazz-tools/src/permissions/index.ts packages/jazz-tools/src/dsl.test.ts
+git commit -m "feat(permissions): add forBranch/branchPolicy/\$branch DSL"
+```
+
+---
+
+## Task 2: TS IR + schema-permissions — carry branch policies to WASM
+
+**Files:**
+
+- Modify: `packages/jazz-tools/src/ir.ts`
+- Modify: `packages/jazz-tools/src/schema-permissions.ts`
+- Test: `packages/jazz-tools/src/schema-permissions.test.ts`
+
+- [ ] **Step 1: Write the failing test** in `schema-permissions.test.ts`. Compile permissions with a `forBranch` block (as in Task 1), normalize for WASM, and assert the normalized schema carries a branch-policy section with a branch-ref operand.
+
+```ts
+it("normalizes branch policies with branch-ref operands for wasm", () => {
+  const app = s.defineApp({
+    branches: s.table({ projectId: s.ref("projects"), ownerId: s.string() }),
+    projects: s.table({ name: s.string(), ownerId: s.string() }),
+    todos: s.table({ projectId: s.ref("projects"), title: s.string(), ownerId: s.string() }),
+  });
+  const permissions = s.definePermissions(app, ({ policy, session }) => {
+    policy.branches.allowRead.where({ ownerId: session.user_id });
+    policy.forBranch(policy.branches, ({ $branch, branchPolicy }) => {
+      branchPolicy.todos.allowRead.where({ projectId: $branch.projectId });
+    });
+  });
+
+  const normalized = normalizePermissionsForWasm(permissions);
+  // The wasm-facing payload exposes branch policies and a branch-ref operand
+  // pointing at the backing row column `projectId`.
+  const json = JSON.stringify(normalized);
+  expect(json).toContain("branch_policies");
+  expect(json).toContain("branch_ref");
+  expect(json).toContain("projectId");
+});
+```
+
+> Match the actual exported name (`normalizePermissionsForWasm` exists at `schema-permissions.ts:490`). Confirm whether the wasm field naming is snake_case (`branch_policies`/`branch_ref`) by checking how existing policies are normalized in `normalizePolicyExprForWasm`; keep naming consistent with that convention and update the assertion to match.
+
+- [ ] **Step 2: Run, verify fail.**
+      Run: `pnpm --filter jazz-tools exec vitest run src/schema-permissions.test.ts -t "branch policies"`
+      Expected: FAIL — no `branch_policies` in output.
+
+- [ ] **Step 3: Implement.**
+  1. In `ir.ts`: add a branch-ref operand to the policy-expr IR union (parallel to the session-ref operand) carrying `{ kind: "branch_ref" | "branch-ref", column: string }`. Add an optional `branchPolicies` field to the compiled-permissions IR type: `Record<backingTable, Record<table, TablePolicies>>`.
+  2. In `schema-permissions.ts`: in `normalizePermissionsForWasm` (and `mergePermissionsIntoWasmSchema`), read the `branchPolicies` from the compiled permissions, run each operation policy through `normalizePolicyExprForWasm`, and attach under the wasm field name the Rust side expects (see `schema_manager/encoding.rs`; align with Task 3's decoder). Ensure branch-ref operands survive `normalizePolicyExprForWasm` (add a passthrough case).
+
+- [ ] **Step 4: Run, verify pass.**
+      Run: `pnpm --filter jazz-tools exec vitest run src/schema-permissions.test.ts -t "branch policies"`
+      Expected: PASS.
+
+- [ ] **Step 5: Typecheck + existing schema-permission tests green.**
+      Run: `pnpm --filter jazz-tools exec tsc --noEmit --pretty false`
+      Run: `pnpm --filter jazz-tools exec vitest run src/schema-permissions.test.ts`
+      Expected: PASS.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add packages/jazz-tools/src/ir.ts packages/jazz-tools/src/schema-permissions.ts packages/jazz-tools/src/schema-permissions.test.ts
+git commit -m "feat(permissions): carry branch policies + branch-ref operands to wasm IR"
+```
+
+---
+
+## Task 3: Rust — `PolicyValue::BranchRef` + decode branch policies
+
+**Files:**
+
+- Modify: `crates/jazz-tools/src/query_manager/policy.rs` (`PolicyValue` at :29, `PolicyValueSerde` at :197, binding at :1275-1296)
+- Modify: `crates/jazz-tools/src/query_manager/types/policy.rs` (`PolicyValueInput` at :326)
+- Modify: `crates/jazz-tools/src/schema_manager/encoding.rs`
+- Test: in `policy.rs` (justified internal unit test — decode shape is not observable via public API yet) and `schema_manager/integration_tests/tests/writes.rs`
+
+- [ ] **Step 1: Write the failing test.** In `policy.rs` `#[cfg(test)]`, add a unit test that a `BranchRef` policy value binds to a literal from a backing row (mirrors the existing `SessionRef` binding test). State explicitly in a comment why this is an internal test: branch-ref binding has no public surface until enforcement (Task 5/6) lands.
+
+```rust
+#[test]
+fn branch_ref_binds_to_backing_row_literal() {
+    // INTERNAL TEST (justified): branch-ref value binding has no public API
+    // surface until permission_routing enforcement lands in later tasks.
+    let value = PolicyValue::BranchRef("projectId".to_string());
+    // resolve_branch_row_value returns the backing row's `projectId` literal.
+    let bound = bind_branch_value_for_test(&value, &/* backing row exposing projectId = "p1" */);
+    assert_eq!(bound, PolicyValue::Literal(Value::Text("p1".into())));
+}
+```
+
+> Construct the backing row using existing `RowDescriptor`/`encode_row` test helpers (see `rebac_tests.rs` imports). If `bind_branch_value_for_test` doesn't exist yet, this is the seam you create in Task 4; for Task 3 assert only that `PolicyValue::BranchRef` round-trips through serde (`PolicyValueSerde`).
+
+- [ ] **Step 2: Run, verify fail.**
+      Run: `cargo test -p jazz-tools query_manager::policy::tests::branch_ref --lib`
+      Expected: FAIL — `BranchRef` variant does not exist.
+
+- [ ] **Step 3: Implement.**
+  1. `policy.rs`: add `BranchRef(String)` to `PolicyValue` and a matching `PolicyValueSerde::BranchRef { column: String }` with `From` conversions (mirror `SessionRef`).
+  2. `types/policy.rs`: add `PolicyValueInput::Branch(String)` and its `From`/`Into` mappings to `PolicyValue::BranchRef`.
+  3. `schema_manager/encoding.rs`: decode the wasm `branch_ref` operand (from Task 2) into `PolicyValue::BranchRef`, and decode the `branch_policies` map into the schema/permissions structure (add a `branch_policies` carrier on the relevant schema-permissions type in `types/policy.rs`, keyed `backing_table -> table -> TablePolicies`).
+
+- [ ] **Step 4: Run, verify pass.**
+      Run: `cargo test -p jazz-tools query_manager::policy::tests::branch_ref --lib`
+      Expected: PASS.
+
+- [ ] **Step 5: Format + check.**
+      Run: `cargo fmt -p jazz-tools && cargo check -p jazz-tools`
+      Expected: clean.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add crates/jazz-tools/src/query_manager/policy.rs crates/jazz-tools/src/query_manager/types/policy.rs crates/jazz-tools/src/schema_manager/encoding.rs
+git commit -m "feat(core): add BranchRef policy value and decode branch policies"
+```
+
+---
+
+## Task 4: Rust — `permission_routing` module
+
+**Files:**
+
+- Create: `crates/jazz-tools/src/query_manager/permission_routing.rs`
+- Modify: `crates/jazz-tools/src/query_manager/mod.rs` (register module)
+- Test: unit tests inside `permission_routing.rs`
+
+- [ ] **Step 1: Write the failing test** in the new module: `bind_branch_refs` rewrites `BranchRef(col)` operands to `Literal(backing_row[col])` and leaves other operands untouched.
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bind_branch_refs_replaces_branch_ref_with_backing_row_literal() {
+        // Build a ResolvedBranchRow exposing projectId = "p1" using existing
+        // RowDescriptor/encode_row helpers, then bind an expr that references
+        // $branch.projectId and assert it becomes a literal.
+        // (See rebac_tests.rs for row-construction helpers.)
+    }
+}
+```
+
+> Fill in the row construction with the same helpers `rebac_tests.rs` uses (`RowDescriptor`, `encode_row`, `Value`). Keep the test black-box at the module's public function boundary (`bind_branch_refs`).
+
+- [ ] **Step 2: Run, verify fail.**
+      Run: `cargo test -p jazz-tools query_manager::permission_routing --lib`
+      Expected: FAIL — module/file does not exist.
+
+- [ ] **Step 3: Implement** the module. Define:
+  - `pub struct ResolvedBranchRow<'a> { pub table_name: &'a TableName, pub row_id: ObjectId, pub descriptor: &'a RowDescriptor, pub content: &'a [u8] }` with a method to read a column value by name (`fn column_value(&self, column: &str) -> Option<Value>`), using existing row-decoding helpers.
+  - `pub type BranchPolicyContext<'a> = ResolvedBranchRow<'a>;`
+  - `pub enum PermissionRoute<'a> { Normal, Branch { policy: &'a TablePolicies, context: ResolvedBranchRow<'a> }, NoBranchPolicy, Deny }` — a composed non-main branch never yields `Normal`.
+  - `pub struct PolicyEvalRefs<'a> { pub row_id: Option<ObjectId>, pub branch_context: Option<&'a BranchPolicyContext<'a>> }` with `fn with_branch_context(self, ctx) -> Self`.
+  - `pub fn bind_branch_refs(expr: &PolicyExpr, ctx: &ResolvedBranchRow) -> PolicyExpr` — walk the expr; map `PolicyValue::BranchRef(col) => PolicyValue::Literal(ctx.column_value(col).unwrap_or(Value::Null))`; recurse like the existing `bind_*`/`resolve_*` walkers in `policy.rs` (`policy.rs:1275` is the `SessionRef` analog — follow its structure).
+  - A `QueryManager` method (in this module's `impl QueryManager`) `resolve_branch_route(&self, table, branch, op) -> PermissionRoute` that: detects whether `branch` is the composed main branch (reuse the existing branch-composition utilities used by `query.rs`/`types/branch.rs`); if main → `Normal`; otherwise resolves the backing row by branch-id from the `forBranch` backing table; if not found/unreadable → `Deny`; if found but no branch policy for `(table, op)` → `NoBranchPolicy`; else `Branch { policy, context }`.
+  - Register `pub mod permission_routing;` in `query_manager/mod.rs`.
+
+  Consult PR #917's `permission_routing.rs` hunk for the exact route resolution and error-categorization shape; re-derive against jazz2's current `QueryManager` API rather than copying verbatim.
+
+- [ ] **Step 4: Run, verify pass.**
+      Run: `cargo test -p jazz-tools query_manager::permission_routing --lib`
+      Expected: PASS.
+
+- [ ] **Step 5: Format + check.**
+      Run: `cargo fmt -p jazz-tools && cargo check -p jazz-tools`
+      Expected: clean.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add crates/jazz-tools/src/query_manager/permission_routing.rs crates/jazz-tools/src/query_manager/mod.rs
+git commit -m "feat(core): add permission_routing module for branch policies"
+```
+
+---
+
+## Task 5: Rust — enforce branch policies on reads
+
+**Files:**
+
+- Modify: `crates/jazz-tools/src/query_manager/graph_nodes/policy_filter.rs` (branch param already at :160)
+- Modify: `crates/jazz-tools/src/query_manager/graph_nodes/policy_eval.rs` (branch at :20)
+- Create: `crates/jazz-tools/src/query_manager/rebac_tests/branch_policies.rs`
+- Modify: `crates/jazz-tools/src/query_manager/rebac_tests.rs` (add `mod branch_policies;`)
+- Test: `rebac_tests/branch_policies.rs`
+
+- [ ] **Step 1: Write the failing tests** (read-path) in `rebac_tests/branch_policies.rs`, following the existing `rebac_tests` harness (`create_query_manager`, `SchemaBuilder`, `permissions`, `pe`, `execute_query`, `get_branch_for_user_branch`). Cover three cases:
+
+```rust
+// 1. allowed: owner reads todos inside their branch (projectId matches $branch.projectId).
+// 2. denied: a session that cannot read the backing branch row sees zero branch todos
+//    (deny-by-default), even though a normal todos read policy would have matched.
+// 3. isolation: a todo inserted on the branch does NOT appear when querying `main`,
+//    and a `main` todo does NOT appear when querying the branch.
+```
+
+Build the schema (projects/branches/todos) and permissions (`policy.branches.allowRead`, `forBranch(branches){ branchPolicy.todos.allowRead.where(projectId == $branch.projectId) }`) with the public Rust builders. Seed a `branches` row, derive the branch via `get_branch_for_user_branch(&qm, &branch_row_id)`, insert todos on that branch, then assert visible rows per session.
+
+- [ ] **Step 2: Run, verify fail.**
+      Run: `cargo test -p jazz-tools query_manager::rebac_tests::branch_policies --lib`
+      Expected: FAIL — branch reads not yet routed (todos either all-visible or all-denied incorrectly).
+
+- [ ] **Step 3: Implement.** In `policy_filter.rs`/`policy_eval.rs`, when evaluating a non-main branch:
+  1. Call `QueryManager::resolve_branch_route(table, branch, Operation::Read)`.
+  2. `Deny` → emit no rows. `NoBranchPolicy` → apply missing-policy rule (deny-by-default for reads). `Branch { policy, context }` → bind the `select.using` expr via `bind_branch_refs(.., context)`, then evaluate as a normal read filter (still applying session refs). `Normal` only occurs for main.
+  3. Thread the `ResolvedBranchRow` through `PolicyEvalRefs::with_branch_context` so `$branch` literals are available during evaluation.
+     Reuse the existing policy evaluation path — only the policy _selection_ and the `bind_branch_refs` pre-pass are new.
+
+- [ ] **Step 4: Run, verify pass.**
+      Run: `cargo test -p jazz-tools query_manager::rebac_tests::branch_policies --lib`
+      Expected: PASS (all three read cases).
+
+- [ ] **Step 5: No regressions + format.**
+      Run: `cargo fmt -p jazz-tools && cargo test -p jazz-tools query_manager::rebac_tests --lib`
+      Expected: PASS.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add crates/jazz-tools/src/query_manager/graph_nodes/policy_filter.rs crates/jazz-tools/src/query_manager/graph_nodes/policy_eval.rs crates/jazz-tools/src/query_manager/rebac_tests/branch_policies.rs crates/jazz-tools/src/query_manager/rebac_tests.rs
+git commit -m "feat(core): enforce branch read policies with deny-by-default"
+```
+
+---
+
+## Task 6: Rust — enforce branch policies on insert/update/delete
+
+**Files:**
+
+- Modify: `crates/jazz-tools/src/query_manager/writes.rs`
+- Modify: `crates/jazz-tools/src/query_manager/rebac_tests/branch_policies.rs` (add write tests)
+- Test: `rebac_tests/branch_policies.rs`
+
+- [ ] **Step 1: Write the failing tests** (write-path), extending `branch_policies.rs`. For each of insert / update / delete:
+
+```rust
+// insert allowed: owner inserts a todo on their branch (withCheck projectId == $branch.projectId
+//   AND ownerId == session.user_id) -> settles accepted, visible on the branch.
+// insert denied: a session that cannot read the backing branch row -> write rejected; row not visible.
+// update allowed/denied: owner updates a branch todo (using projectId == $branch.projectId);
+//   non-owner update rejected.
+// delete allowed/denied: same pattern with allowDelete.
+```
+
+Use the public write API used elsewhere in `rebac_tests` (insert via `qm.insert(...)` on the derived branch; updates/deletes via the same public mutation path the other rebac tests use) and assert accepted/rejected settlement + visible state.
+
+- [ ] **Step 2: Run, verify fail.**
+      Run: `cargo test -p jazz-tools query_manager::rebac_tests::branch_policies --lib`
+      Expected: FAIL — branch writes not routed.
+
+- [ ] **Step 3: Implement.** In `writes.rs`, before applying an insert/update/delete on a non-main branch:
+  1. `resolve_branch_route(table, branch, op)`.
+  2. `Deny`/`NoBranchPolicy` → reject the write (deny-by-default). `Branch { policy, context }` → `bind_branch_refs` on the relevant expr (`insert.with_check`, `update.using`+`update.with_check`, `delete.using`) then evaluate against the row (post-image for `with_check`, current row for `using`), combined with session refs.
+  3. Reject on policy failure; accept otherwise. Reuse the existing write-policy evaluation; only selection + branch binding are new.
+
+- [ ] **Step 4: Run, verify pass.**
+      Run: `cargo test -p jazz-tools query_manager::rebac_tests::branch_policies --lib`
+      Expected: PASS (all CRUD cases).
+
+- [ ] **Step 5: Full crate tests + format.**
+      Run: `cargo fmt -p jazz-tools && cargo test -p jazz-tools --lib`
+      Expected: PASS.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add crates/jazz-tools/src/query_manager/writes.rs crates/jazz-tools/src/query_manager/rebac_tests/branch_policies.rs
+git commit -m "feat(core): enforce branch insert/update/delete policies"
+```
+
+---
+
+## Task 7: TS runtime — `db.branch(branchId)` view
+
+**Files:**
+
+- Modify: `packages/jazz-tools/src/runtime/db.ts` (`DbConfig.userBranch` at ~143; `class Db` at ~869)
+- Modify: `packages/jazz-tools/src/runtime/client.ts` (branch threading already partly present)
+- Test: `packages/jazz-tools/src/runtime/db.branch.test.ts` (new)
+
+- [ ] **Step 1: Write the failing test** in `db.branch.test.ts`. Using the existing in-process test harness for `Db` (mirror `db.dev-mode.test.ts` setup), assert `db.branch(branchId)` returns a Db-like view whose reads/writes carry the branch.
+
+```ts
+it("db.branch(id) routes reads and writes to the branch", async () => {
+  // set up Db with the projects/branches/todos app + forBranch permissions (Task 1 DSL)
+  // insert a project + a branch row on main
+  // const branchDb = db.branch(branch.id);
+  // await branchDb.insert(app.todos, { projectId, title: "draft", ownerId }).wait({ tier: "local" });
+  // branch todo is visible through branchDb.all(...) but NOT through db.all(...) on main
+  const onMain = await db.all(app.todos.where({ projectId }));
+  const onBranch = await branchDb.all(app.todos.where({ projectId }));
+  expect(onMain).toHaveLength(0);
+  expect(onBranch).toHaveLength(1);
+});
+```
+
+> Follow the exact harness/import pattern in `db.dev-mode.test.ts` (it already imports `branch`-related config). Keep the test in-process (`tier: "local"`).
+
+- [ ] **Step 2: Run, verify fail.**
+      Run: `pnpm --filter jazz-tools exec vitest run src/runtime/db.branch.test.ts`
+      Expected: FAIL — `db.branch is not a function`.
+
+- [ ] **Step 3: Implement** `Db.branch(branchId: string)`: return a lightweight branch-scoped view exposing `all`, `insert`, `update`, `delete` (and `wait`) that delegate to the same underlying client(s) but set the query/write `userBranch`/`branches` to `branchId`. The existing query path already serializes `branches` (db.ts ~2789-2837) and `DbConfig.userBranch` already exists — the view just overrides the branch per call rather than per Db config. Prefer a thin wrapper object over duplicating Db; do not fork connection/broker state.
+
+- [ ] **Step 4: Run, verify pass.**
+      Run: `pnpm --filter jazz-tools exec vitest run src/runtime/db.branch.test.ts`
+      Expected: PASS.
+
+- [ ] **Step 5: Typecheck + runtime tests green.**
+      Run: `pnpm --filter jazz-tools exec tsc --noEmit --pretty false`
+      Run: `pnpm --filter jazz-tools exec vitest run src/runtime`
+      Expected: PASS.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add packages/jazz-tools/src/runtime/db.ts packages/jazz-tools/src/runtime/client.ts packages/jazz-tools/src/runtime/db.branch.test.ts
+git commit -m "feat(runtime): add db.branch() branch-scoped view"
+```
+
+---
+
+## Task 8: Framework adapters — branch-scoped `useAll`
+
+**Files:**
+
+- Modify: `packages/jazz-tools/src/react-core/use-all.ts`, `react-core/index.ts`
+- Modify: `packages/jazz-tools/src/react-native/use-all.ts`, `react-native/index.ts`
+- Modify: `packages/jazz-tools/src/svelte/use-all.svelte.ts`, `svelte/index.ts`
+- Modify: `packages/jazz-tools/src/vue/use-all.ts`, `vue/index.ts`
+- Test: `packages/jazz-tools/src/vue/use-all.test.ts`
+
+- [ ] **Step 1: Write the failing test** in `vue/use-all.test.ts` (vue has an existing `use-all.test.ts` harness — extend it): a `useAll` driven by a branch-scoped Db/query reads branch-scoped rows.
+
+```ts
+it("useAll reads from a branch-scoped db", async () => {
+  // build app + forBranch permissions + Db; insert a project + branch + a branch todo
+  // const branchDb = db.branch(branch.id);
+  // const result = useAll(branchDb, app.todos.where({ projectId }));
+  // await flush; expect result to contain the branch todo and not main rows
+});
+```
+
+> Match the existing `vue/use-all.test.ts` setup exactly (it already exercises `useAll`). If `useAll` takes a `Db` as first arg in this package, pass `branchDb`; if it takes a query, pass a branch-scoped query produced by the branch view.
+
+- [ ] **Step 2: Run, verify fail.**
+      Run: `pnpm --filter jazz-tools exec vitest run src/vue/use-all.test.ts -t "branch-scoped"`
+      Expected: FAIL — branch rows not read (adapter ignores branch).
+
+- [ ] **Step 3: Implement.** Thread the branch through each `use-all` so a branch-scoped `Db` view (Task 7) produces branch-scoped subscriptions/queries. The PR's per-adapter changes are small (a few lines each) — they pass the branch from the Db/query down into the subscription the hook opens. Apply the same minimal threading to all four adapters and keep their public signatures source-compatible (additive only). Update the `index.ts` re-exports only if a new type is exported.
+
+- [ ] **Step 4: Run, verify pass.**
+      Run: `pnpm --filter jazz-tools exec vitest run src/vue/use-all.test.ts`
+      Expected: PASS.
+
+- [ ] **Step 5: Typecheck all adapters.**
+      Run: `pnpm --filter jazz-tools exec tsc --noEmit --pretty false`
+      Expected: PASS.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add packages/jazz-tools/src/react-core packages/jazz-tools/src/react-native packages/jazz-tools/src/svelte packages/jazz-tools/src/vue
+git commit -m "feat(adapters): branch-scoped useAll across react/react-native/svelte/vue"
+```
+
+---
+
+## Task 9: End-to-end integration test — full CRUD matrix
+
+**Files:**
+
+- Create: `packages/jazz-tools/tests/branch-permissions.integration.test.ts`
+
+- [ ] **Step 1: Write the integration test** exercising the public API end-to-end (mirror the harness in existing `packages/jazz-tools/tests/` integration tests). One coherent file with the matrix:
+
+```ts
+// Setup: app { projects, branches, todos }; forBranch(branches) policies for
+// read/insert/update/delete on todos keyed by $branch.projectId (+ ownerId for writes).
+//
+// allowed path (branch owner):
+//   - insert a todo via db.branch(id).insert(...).wait()
+//   - read it back via db.branch(id).all(...)
+//   - update it via db.branch(id).update(...)
+//   - delete it via db.branch(id).delete(...)
+// denied path (a second user who cannot read the backing branch row):
+//   - all four operations are denied / yield no rows
+// isolation:
+//   - branch todos never appear on db.all(...) for main, and vice versa
+```
+
+Use two sessions/users (the integration harness supports untrusted clients; see existing integration tests). Assert accepted/rejected settlement and visible state.
+
+- [ ] **Step 2: Run, verify fail (or pass).**
+      Run: `pnpm --filter jazz-tools exec vitest run tests/branch-permissions.integration.test.ts`
+      Expected: All assertions PASS if Tasks 1-8 are correct. If anything fails, fix the relevant layer (do not weaken the test).
+
+- [ ] **Step 3: Full build + test sweep.**
+      Run: `pnpm build:core`
+      Run: `pnpm --filter jazz-tools test`
+      Expected: PASS.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add packages/jazz-tools/tests/branch-permissions.integration.test.ts
+git commit -m "test: end-to-end branch permissions CRUD matrix"
+```
+
+---
+
+## Final verification
+
+- [ ] `cargo fmt --check -p jazz-tools` — clean
+- [ ] `cargo test -p jazz-tools query_manager::rebac_tests::branch_policies --lib` — PASS
+- [ ] `cargo test -p jazz-tools --lib` — PASS (no regressions)
+- [ ] `pnpm --filter jazz-tools exec tsc --noEmit --pretty false` — clean
+- [ ] `pnpm --filter jazz-tools test` — PASS
+- [ ] `pnpm build:core` — PASS
+- [ ] Spec coverage: forBranch/branchPolicy/$branch (T1), IR (T2), BranchRef + decode (T3), permission_routing (T4), read enforcement (T5), write enforcement (T6), db.branch (T7), adapters (T8), e2e (T9). All scope items covered; deferred items (query-level `.branch()`, include/union branch targeting) intentionally excluded.

--- a/docs/superpowers/specs/2026-06-23-branch-permissions-design.md
+++ b/docs/superpowers/specs/2026-06-23-branch-permissions-design.md
@@ -1,0 +1,172 @@
+# Branch Permissions & Query APIs — Design
+
+**Date:** 2026-06-23
+**Status:** Approved design (pending spec review)
+**Reference:** garden-co/jazz PR #917 ("Branch: permissions and query APIs") — used as a behavioral/API reference. This is a _re-derivation_ in jazz2, not a port of the PR diff.
+
+## Goal
+
+Add branch-scoped access control to jazz2's public API as a complete, useful vertical slice: define branch policies, then write and read branch-scoped rows through a branch `Db` view, with deny-by-default enforcement, across all four CRUD actions and all framework adapters.
+
+A "branch" here is a _data branch_ (a git-like branch of rows), backed by a normal application row. This is distinct from jazz2's lower-level storage-branch string; that machinery already exists and is reused, not rebuilt.
+
+## Scope
+
+### In scope
+
+- **TS permissions DSL** (`packages/jazz-tools/src/permissions/index.ts`):
+  - Top-level `policy.forBranch(backingTable, ({ $branch, branchPolicy }) => { ... })`.
+  - A **table-keyed** `branchPolicy` builder: `branchPolicy.<table>.allowRead / allowInsert / allowUpdate / allowDelete`.
+  - A `$branch` proxy exposing backing-row columns as branch refs.
+  - **Full CRUD** branch policies (read, insert, update, delete), including the existing `UpdateRuleBuilder` `using` / `withCheck` split.
+- **TS runtime** (`packages/jazz-tools/src/runtime/db.ts`): `db.branch(branchId)` returning a branch-scoped `Db` view supporting `.all()`, `.insert()`, `.update()`, `.delete()`.
+- **Framework adapters**: `react-core`, `react-native`, `svelte`, `vue` — `useAll` (and re-exports) work against a branch-scoped `Db` view / query so branch reads are reactive.
+- **IR / schema-permissions** (`ir.ts`, `schema-permissions.ts`): serialize branch rules (with `branchBackingTable` and branch-ref operands) through to the Rust core.
+- **Rust core**: a new `permission_routing` module that resolves the backing branch row, gates access, and dispatches to branch policies; a `BranchRef` policy value; deny-by-default enforcement wired into reads (`policy_filter`), inserts, updates, and deletes (`writes.rs`).
+- **Tests**: black-box integration tests (Rust + TS) covering all four actions for the allowed path, the denied path, and branch isolation.
+
+### Out of scope (deferred to later specs)
+
+- Query-level `.branch(branchId)` modifier on query builders (e.g. `db.all(app.todos.where(...).branch(id))`). The slice ships only `db.branch()`.
+- `include` / `union` inputs that target a branch.
+- Subscriptions semantics specific to branches beyond what `useAll` needs for branch reads.
+
+## Authoritative API
+
+Taken from the PR description (this is the API contract; the stale `.test-tmp` generated fixture, which shows a single-table `branchPolicy` and a table-builder-level `forBranch`, is **superseded** by this shape).
+
+```ts
+const app = s.defineApp({
+  projects: s.table({ name: s.string(), ownerId: s.string() }),
+  branches: s.table({
+    projectId: s.ref("projects"),
+    name: s.string(),
+    ownerId: s.string(),
+  }),
+  todos: s.table({
+    projectId: s.ref("projects"),
+    title: s.string(),
+    ownerId: s.string(),
+  }),
+});
+
+const permissions = s.definePermissions(app, ({ policy, session }) => {
+  policy.projects.allowRead.where({ ownerId: session.user_id });
+  policy.projects.allowInsert.where({ ownerId: session.user_id });
+
+  policy.branches.allowRead.where({ ownerId: session.user_id });
+  policy.branches.allowInsert.where({ ownerId: session.user_id });
+
+  policy.forBranch(policy.branches, ({ $branch, branchPolicy }) => {
+    branchPolicy.todos.allowRead.where({ projectId: $branch.projectId });
+    branchPolicy.todos.allowInsert.where({
+      projectId: $branch.projectId,
+      ownerId: session.user_id,
+    });
+    branchPolicy.todos.allowUpdate.where({ projectId: $branch.projectId });
+    branchPolicy.todos.allowDelete.where({ projectId: $branch.projectId });
+  });
+});
+
+// usage
+const branch = await db
+  .insert(app.branches, { projectId: project.id, name: "Alice's draft", ownerId: userId })
+  .wait({ tier: "local" });
+
+const branchDb = db.branch(branch.id);
+
+await branchDb
+  .insert(app.todos, { projectId: branch.projectId, title: "Write API docs", ownerId: userId })
+  .wait({ tier: "edge" });
+
+const draftTodos = await branchDb.all(app.todos.where({ projectId: branch.projectId }));
+```
+
+Key API decisions:
+
+- `forBranch` is **top-level on `policy`**, taking the backing table as its first argument.
+- `branchPolicy` is **table-keyed** (`branchPolicy.<table>.allow*`), parallel to the top-level `policy` object.
+- `$branch.<column>` references resolve to the backing branch row's column values.
+
+## Branch identity & composition
+
+- A branch is a normal row in a backing table (e.g. `branches`). Its `branch.id` (`ObjectId`) **is** the public branch id passed to `db.branch(...)`.
+- `db.branch(branchId)` produces a `Db` view with `userBranch = branchId`. The existing Rust routing composes the logical branch (`<env>/<schemaHash>/<branchId>`) and isolates storage per branch — **this already works** and is unchanged.
+- The same `branchId` segment also identifies the backing row on the composed main branch. That row is loaded as the `$branch` context for branch-policy evaluation.
+
+## Data flow
+
+### Insert through a branch view
+
+1. `branchDb.insert(app.todos, {...})` issues a write tagged with the branch.
+2. The Rust write path builds a `PermissionRoute` for `(table = todos, branch = branchId, op = insert)`.
+3. The route resolves the backing branch row by `branchId` from the registered `forBranch` backing table → `ResolvedBranchRow` (`$branch`).
+4. The `todos` branch `insert` policy is evaluated with `$branch.*` refs bound to literals from the backing row. Deny-by-default if the row is missing/unreadable or no matching branch policy exists.
+
+### Read through a branch view
+
+1. `branchDb.all(app.todos.where(...))` issues a query carrying the branch.
+2. `policy_filter` selects the branch policy set via `permission_routing`, resolves `$branch`, and gates on the backing row being readable.
+3. Rows are filtered by the branch `read` policy `using` expression with `$branch.*` bound to literals.
+
+### Update / delete through a branch view
+
+- Same routing. For updates, `$branch.*` is bindable in **both** the `using` (which rows may change) and `withCheck` (post-image constraint) expressions of `UpdateRuleBuilder`.
+
+## Components
+
+### 1. TS permissions DSL (`permissions/index.ts`)
+
+- Add top-level `forBranch(backingTable, factory)` to the object returned by `definePermissions`.
+- Add a table-keyed `branchPolicy` builder producing branch rules of shape `{ table, action, using | withCheck, branchBackingTable }`.
+- Add a `$branch` proxy emitting `{ __jazzPermissionKind: "branch-ref", column }`.
+- Branch rules flow through the existing `collectRule` channel, tagged so they serialize distinctly from normal rules.
+
+### 2. IR / schema-permissions (`ir.ts`, `schema-permissions.ts`)
+
+- Carry the new `branchBackingTable` field and `branch-ref` operands through serialization into the Rust-facing schema/permissions payload.
+
+### 3. Rust `permission_routing.rs` (new module)
+
+- `PermissionRoute` enum: `Normal` (table policies), `Branch { policy }` (resolved `forBranch` policy), `NoBranchPolicy` (missing-policy rules apply), `Deny` (hard deny). A composed non-main branch never falls back to `Normal`.
+- `ResolvedBranchRow<'a>` (aka `BranchPolicyContext`): the backing row exposed as `$branch`.
+- `PolicyEvalRefs` with `.with_branch_context(...)`, threading `row_id` + branch context into evaluation.
+- `bind_branch_refs`: `BranchRef(column) => Literal(resolve_branch_row_value(column))`, mirroring the existing `SessionRef => Literal` binding at `policy.rs:1275`.
+
+### 4. Rust policy value (`policy.rs`)
+
+- Extend `PolicyValue` (currently `Literal`, `SessionRef(Vec<String>)`) with `BranchRef(String)` (column name), plus its serde variant. Resolution mirrors `resolve_session_value`.
+
+### 5. Rust enforcement wiring
+
+- Reads: `graph_nodes/policy_filter.rs` / `policy_eval.rs` already accept a branch; route through `permission_routing` to pick the branch policy set and bind `$branch`.
+- Writes: `writes.rs` consults the route for insert/update/delete before applying.
+
+### 6. TS runtime (`db.ts`) + framework adapters
+
+- `db.branch(branchId)`: returns a `Db` view with `userBranch = branchId` threaded into queries and writes.
+- `react-core` / `react-native` / `svelte` / `vue` `use-all`: accept a branch-scoped `Db`/query so branch reads are reactive, matching the small per-adapter threading the PR performs.
+
+## Deny-by-default semantics
+
+On a non-main branch, normal table policies never apply. Access to a branch-scoped row requires **both**:
+
+1. the backing branch row is resolvable **and** readable by the session, **and**
+2. a matching branch policy allows the operation, with `$branch` bound.
+
+Any of {no backing row, unreadable backing row, no matching branch policy} → **deny**.
+
+## Testing
+
+Black-box integration tests using the public API only, per `crates/jazz-tools/TESTING_GUIDELINES.md` (read in full before writing Rust tests). No JSON-like schema/permission definitions — build them with the public DSL.
+
+- **Rust** (`query_manager/rebac_tests/`): for each of read / insert / update / delete —
+  - _allowed_: the branch owner operates on `todos` inside their branch.
+  - _denied_: a session that cannot read the backing branch row gets no rows / a rejected write.
+  - _isolation_: branch `todos` do not appear on `main`, and vice versa.
+- **TS** (`packages/jazz-tools/tests/` integration): the same matrix through `db.branch(...)`, plus one framework-adapter smoke test that a branch `useAll` reads branch-scoped rows reactively.
+
+## Open questions / risks
+
+- **Backing-row resolution cost**: resolving and read-gating the backing branch row on every branch operation. For the slice, resolve once per query/write; optimization (caching the resolved `$branch`) is deferred.
+- **Multiple `forBranch` backing tables**: the PR's router tries each registered backing table (`NotFound` vs `Denied`). The slice targets a single backing table; the router structure should not preclude multiple, but multi-backing-table resolution is not a slice deliverable.

--- a/examples/todo-client-localfirst-react/permissions.ts
+++ b/examples/todo-client-localfirst-react/permissions.ts
@@ -8,4 +8,18 @@ export default s.definePermissions(app, ({ policy, session }) => {
     .whereOld({ owner_id: session.user_id })
     .whereNew({ owner_id: session.user_id });
   policy.todos.allowDelete.where({ owner_id: session.user_id });
+
+  // Branches are normal rows: you can see/create your own.
+  policy.branches.allowRead.where({ owner_id: session.user_id });
+  policy.branches.allowInsert.where({ owner_id: session.user_id });
+
+  // Data written inside a branch is governed by these rules. `$branch` exposes
+  // the backing branch row, and access is deny-by-default: a session can only
+  // touch branch data if it can read the backing branch row AND a rule matches.
+  policy.forBranch(policy.branches, ({ $branch, branchPolicy }) => {
+    branchPolicy.todos.allowRead.where({ owner_id: $branch.owner_id });
+    branchPolicy.todos.allowInsert.where({ owner_id: session.user_id });
+    branchPolicy.todos.allowUpdate.where({ owner_id: session.user_id });
+    branchPolicy.todos.allowDelete.where({ owner_id: session.user_id });
+  });
 });

--- a/examples/todo-client-localfirst-react/schema.ts
+++ b/examples/todo-client-localfirst-react/schema.ts
@@ -4,6 +4,12 @@ const schema = {
   projects: s.table({
     name: s.string(),
   }),
+  // A branch is a normal app row. Its id is the branch id passed to
+  // db.branch(...) and useAll(..., { branch }).
+  branches: s.table({
+    name: s.string(),
+    owner_id: s.string(),
+  }),
   todos: s.table({
     title: s.string(),
     done: s.boolean(),
@@ -18,3 +24,4 @@ type AppSchema = s.Schema<typeof schema>;
 export const app: s.App<AppSchema> = s.defineApp(schema);
 
 export type Todo = s.RowOf<typeof app.todos>;
+export type Branch = s.RowOf<typeof app.branches>;

--- a/examples/todo-client-localfirst-react/src/TodoList.tsx
+++ b/examples/todo-client-localfirst-react/src/TodoList.tsx
@@ -6,6 +6,10 @@ import { app } from "../schema.js";
 export function TodoList() {
   const [filterTitle, setFilterTitle] = useState("");
   const [showDoneOnly, setShowDoneOnly] = useState(false);
+  // null = the "main" branch; otherwise the id of a `branches` row.
+  const [currentBranchId, setCurrentBranchId] = useState<string | null>(null);
+  const [newBranchName, setNewBranchName] = useState("");
+
   const trimmedFilterTitle = filterTitle.trim();
   let todosQuery = app.todos;
   if (trimmedFilterTitle) {
@@ -16,32 +20,90 @@ export function TodoList() {
   }
 
   const db = useDb();
-  // #region reading-reactive-hooks-react
-  const todos = useAll(todosQuery) ?? [];
-  // #endregion reading-reactive-hooks-react
   const session = useSession();
   const sessionUserId = session?.user_id ?? null;
+
+  // Branches live on main; list the ones this session owns.
+  const branches = useAll(app.branches) ?? [];
+
+  // #region reading-reactive-hooks-react
+  // Reactive read scoped to the selected branch (or main when undefined).
+  const todos = useAll(todosQuery, currentBranchId ? { branch: currentBranchId } : undefined) ?? [];
+  // #endregion reading-reactive-hooks-react
+
+  // Writes go through a branch-scoped view when a branch is selected.
+  const writer = currentBranchId ? db.branch(currentBranchId) : db;
+  const currentBranchName = branches.find((b) => b.id === currentBranchId)?.name ?? null;
+
   const [title, setTitle] = useState("");
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!title.trim() || !sessionUserId) return;
-    db.insert(app.todos, { title: title.trim(), done: false, owner_id: sessionUserId });
+    writer.insert(app.todos, { title: title.trim(), done: false, owner_id: sessionUserId });
     setTitle("");
+  };
+
+  const handleCreateBranch = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newBranchName.trim() || !sessionUserId) return;
+    const { value } = db.insert(app.branches, {
+      name: newBranchName.trim(),
+      owner_id: sessionUserId,
+    });
+    setNewBranchName("");
+    setCurrentBranchId(value.id); // jump onto the freshly created branch
   };
 
   return (
     <>
+      <section
+        aria-label="Branch"
+        style={{ marginBottom: "1rem", padding: "0.5rem", border: "1px solid #ccc" }}
+      >
+        <strong>Branch:</strong>{" "}
+        <select
+          aria-label="Current branch"
+          value={currentBranchId ?? "main"}
+          onChange={(e) => setCurrentBranchId(e.target.value === "main" ? null : e.target.value)}
+        >
+          <option value="main">main</option>
+          {branches.map((b) => (
+            <option key={b.id} value={b.id}>
+              {b.name}
+            </option>
+          ))}
+        </select>{" "}
+        <span data-testid="current-branch">
+          (viewing <em>{currentBranchName ?? "main"}</em>)
+        </span>
+      </section>
+
       <form onSubmit={handleSubmit}>
         <input
           type="text"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
-          placeholder="What needs to be done?"
+          placeholder={
+            currentBranchName ? `Add a todo on "${currentBranchName}"` : "What needs to be done?"
+          }
           required
         />
         <button type="submit" disabled={!sessionUserId}>
           Add
+        </button>
+      </form>
+
+      <form onSubmit={handleCreateBranch}>
+        <input
+          type="text"
+          value={newBranchName}
+          onChange={(e) => setNewBranchName(e.target.value)}
+          placeholder="New branch name"
+          aria-label="New branch name"
+        />
+        <button type="submit" disabled={!sessionUserId}>
+          Create branch
         </button>
       </form>
       <div>
@@ -69,7 +131,7 @@ export function TodoList() {
               checked={todo.done}
               onChange={() => {
                 try {
-                  db.update(app.todos, todo.id, { done: !todo.done });
+                  writer.update(app.todos, todo.id, { done: !todo.done });
                 } catch {
                   toast.error("You don't have permission to update this task");
                 }
@@ -82,7 +144,7 @@ export function TodoList() {
               className="delete-btn"
               onClick={() => {
                 try {
-                  db.delete(app.todos, todo.id);
+                  writer.delete(app.todos, todo.id);
                 } catch {
                   toast.error("You don't have permission to delete this task");
                 }

--- a/examples/todo-client-localfirst-react/tests/browser/todo-app.test.tsx
+++ b/examples/todo-client-localfirst-react/tests/browser/todo-app.test.tsx
@@ -36,6 +36,13 @@ function typeInto(input: HTMLInputElement, value: string) {
   input.dispatchEvent(new Event("input", { bubbles: true }));
 }
 
+/** Set the value of a React-controlled <select> (triggers React's onChange). */
+function setSelectValue(select: HTMLSelectElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLSelectElement.prototype, "value")!.set!;
+  setter.call(select, value);
+  select.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
 function todoTitles(el: HTMLDivElement): Array<string | null> {
   return [...el.querySelectorAll("#todo-list li span")].map((span) => span.textContent);
 }
@@ -368,6 +375,55 @@ describe("React Todo App E2E", () => {
         ),
       20000,
       "Todo should sync to app 2 through the server",
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Branch: create a branch, add a branch-scoped todo, verify isolation
+  // -------------------------------------------------------------------------
+
+  it("adds a todo on a branch and isolates it from main", async () => {
+    const el = await mountApp({ driver: { type: "persistent", dbName: uniqueDbName("branch") } });
+
+    // Create a branch (the app auto-switches onto it).
+    const branchNameInput = el.querySelector<HTMLInputElement>(
+      'input[aria-label="New branch name"]',
+    )!;
+    const branchForm = branchNameInput.closest("form")!;
+    await act(async () => {
+      typeInto(branchNameInput, "feature-x");
+      branchForm.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    });
+    await waitFor(
+      () =>
+        el.querySelector('[data-testid="current-branch"]')!.textContent?.includes("feature-x") ??
+        false,
+      5000,
+      "App should switch onto the new branch",
+    );
+
+    // Add a todo while on the branch (first text input is the todo title).
+    const todoInput = el.querySelector<HTMLInputElement>("input[type='text']")!;
+    const todoForm = todoInput.closest("form")!;
+    await act(async () => {
+      typeInto(todoInput, "Branch todo");
+      todoForm.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    });
+    await waitFor(
+      () => hasTodoTitle(el, "Branch todo"),
+      5000,
+      "Branch todo should appear in the list while on the branch",
+    );
+
+    // Switch back to main: the branch todo must not be visible there.
+    const select = el.querySelector<HTMLSelectElement>('select[aria-label="Current branch"]')!;
+    await act(async () => {
+      setSelectValue(select, "main");
+    });
+    await waitFor(
+      () => !hasTodoTitle(el, "Branch todo"),
+      5000,
+      "Branch todo should be isolated from main",
     );
   });
 });

--- a/packages/jazz-tools/src/codegen/schema-reader.ts
+++ b/packages/jazz-tools/src/codegen/schema-reader.ts
@@ -102,6 +102,9 @@ function clonePolicyValue(value: DslPolicyValue): PolicyValue {
   if (value.type === "SessionRef") {
     return { type: "SessionRef", path: [...value.path] };
   }
+  if (value.type === "BranchRef") {
+    return { type: "BranchRef", column: value.column };
+  }
   return { type: "Literal", value: literalToWasmValue(value.value) };
 }
 

--- a/packages/jazz-tools/src/drivers/schema-wire.ts
+++ b/packages/jazz-tools/src/drivers/schema-wire.ts
@@ -12,6 +12,7 @@ interface RuntimeSchemaEnvelope {
   __jazzRuntimeSchema: 1;
   schema: WasmSchema;
   loadedPolicyBundle: boolean;
+  branchPolicies?: unknown;
 }
 
 interface SerializeRuntimeSchemaOptions {
@@ -55,11 +56,15 @@ export function serializeRuntimeSchema(
   schema: WasmSchema,
   options?: SerializeRuntimeSchemaOptions,
 ): string {
+  const branchPolicies = (schema as { branch_policies?: unknown }).branch_policies;
   const envelope: RuntimeSchemaEnvelope = {
     __jazzRuntimeSchema: 1,
     schema,
     loadedPolicyBundle: options?.loadedPolicyBundle ?? false,
   };
+  if (branchPolicies !== undefined) {
+    envelope.branchPolicies = branchPolicies;
+  }
   return JSON.stringify(envelope, runtimeSchemaJsonReplacer);
 }
 

--- a/packages/jazz-tools/src/drivers/types.ts
+++ b/packages/jazz-tools/src/drivers/types.ts
@@ -102,7 +102,8 @@ export type PolicyCmpOp = "Eq" | "Ne" | "Lt" | "Le" | "Gt" | "Ge";
 
 export type PolicyValue =
   | { type: "Literal"; value: Value }
-  | { type: "SessionRef"; path: string[] };
+  | { type: "SessionRef"; path: string[] }
+  | { type: "BranchRef"; column: string };
 
 export type PolicyLiteralValue = Value;
 
@@ -151,6 +152,8 @@ export interface TableSchema {
   indexed_columns?: string[];
   policies?: TablePolicies;
 }
+
+export type BranchPolicies = Record<string, Record<string, TablePolicies>>;
 
 export type Schema = Record<string, TableSchema>;
 

--- a/packages/jazz-tools/src/drivers/types.ts
+++ b/packages/jazz-tools/src/drivers/types.ts
@@ -31,6 +31,10 @@ export interface WasmRow {
 
 export type FFIRow = WasmRow;
 
+export interface RuntimeBranchComposer {
+  composeBranchName(userBranch: string): string;
+}
+
 export type RowAdded = 0;
 export type RowRemoved = 1;
 export type RowUpdated = 2;

--- a/packages/jazz-tools/src/dsl.test.ts
+++ b/packages/jazz-tools/src/dsl.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { StandardJSONSchemaV1 } from "@standard-schema/spec";
+import { schema as s } from "./index.js";
 import {
   col,
   getCollectedMigration,
@@ -10,6 +11,32 @@ import {
 } from "./dsl.js";
 import { schemaToWasm } from "./codegen/schema-reader.js";
 import type { AddOp } from "./schema.js";
+
+describe("forBranch DSL", () => {
+  it("collects table-keyed branch policies tagged with the backing table", () => {
+    const app = s.defineApp({
+      projects: s.table({ name: s.string(), ownerId: s.string() }),
+      branches: s.table({ projectId: s.ref("projects"), ownerId: s.string() }),
+      todos: s.table({ projectId: s.ref("projects"), title: s.string(), ownerId: s.string() }),
+    });
+
+    const permissions = s.definePermissions(app, ({ policy, session }) => {
+      policy.branches.allowRead.where({ ownerId: session.user_id });
+      policy.forBranch(policy.branches, ({ $branch, branchPolicy }) => {
+        branchPolicy.todos.allowRead.where({ projectId: $branch.projectId });
+        branchPolicy.todos.allowInsert.where({
+          projectId: $branch.projectId,
+          ownerId: session.user_id,
+        });
+      });
+    });
+
+    const branchPolicies = (permissions as any).branchPolicies;
+    expect(branchPolicies).toBeDefined();
+    expect(branchPolicies.branches.todos.select.using).toBeDefined();
+    expect(branchPolicies.branches.todos.insert.with_check).toBeDefined();
+  });
+});
 
 describe("enum DSL invariants", () => {
   it("rejects empty variant list", () => {

--- a/packages/jazz-tools/src/ir.ts
+++ b/packages/jazz-tools/src/ir.ts
@@ -8,6 +8,7 @@ export type RelRowIdRef = "Current" | "Outer" | "Frontier";
 export type RelValueRef =
   | { Literal: unknown }
   | { SessionRef: string[] }
+  | { BranchRef: string }
   | { OuterColumn: RelColumnRef }
   | { FrontierColumn: RelColumnRef }
   | { RowId: RelRowIdRef };
@@ -92,3 +93,9 @@ export type PolicyExprV2 =
   | { Not: PolicyExprV2 }
   | "True"
   | "False";
+
+export type BranchPolicies<TablePolicies> = Record<string, Record<string, TablePolicies>>;
+
+export type CompiledPermissionsIr<TablePolicies> = Record<string, TablePolicies> & {
+  branchPolicies?: BranchPolicies<TablePolicies>;
+};

--- a/packages/jazz-tools/src/permissions/index.ts
+++ b/packages/jazz-tools/src/permissions/index.ts
@@ -2080,7 +2080,7 @@ function toPolicyValue(value: unknown, options: { allowRowRefs: boolean }): Poli
     return {
       type: "BranchRef",
       column: value.column,
-    } as unknown as PolicyValue;
+    };
   }
   return { type: "Literal", value };
 }

--- a/packages/jazz-tools/src/permissions/index.ts
+++ b/packages/jazz-tools/src/permissions/index.ts
@@ -83,6 +83,11 @@ export interface RowRefValue {
   readonly column: string;
 }
 
+export interface BranchRefValue {
+  readonly __jazzPermissionKind: "branch-ref";
+  readonly column: string;
+}
+
 interface ExistsCondition {
   readonly __jazzPermissionKind: "exists";
   readonly table: string;
@@ -425,12 +430,17 @@ interface Rule {
   action: PolicyAction;
   using?: Condition;
   withCheck?: Condition;
+  branchBackingTable?: string;
 }
 
 type RuleLike = Rule | UpdateRuleBuilder<unknown, unknown>;
 
 export type RowContext<Row> = {
   [K in keyof Row & string]: RowRefValue;
+};
+
+export type BranchContext<Row> = {
+  [K in keyof Row & string]: BranchRefValue;
 };
 
 export type WhereInputOrCallback<WhereInput, Row> =
@@ -503,6 +513,18 @@ interface TablePolicyBuilder<WhereInput, Row> extends TableRelationBuilder<Where
   exists: ExistsBuilder<WhereInput>;
 }
 
+type BranchPolicyBuilder<TApp extends AppLike> = {
+  [K in TableKey<TApp>]: TablePolicyBuilder<
+    WhereFor<QueryBuilderFor<TApp, K>>,
+    RowFor<QueryBuilderFor<TApp, K>>
+  >;
+};
+
+interface BranchPolicyFactoryContext<TApp extends AppLike, BackingRow> {
+  $branch: BranchContext<BackingRow>;
+  branchPolicy: BranchPolicyBuilder<TApp>;
+}
+
 export type PolicyContext<TApp extends AppLike> = {
   policy: {
     [K in TableKey<TApp>]: TablePolicyBuilder<
@@ -510,6 +532,10 @@ export type PolicyContext<TApp extends AppLike> = {
       RowFor<QueryBuilderFor<TApp, K>>
     >;
   } & {
+    forBranch(
+      backingTableBuilder: TablePolicyBuilder<unknown, unknown>,
+      factory: (ctx: BranchPolicyFactoryContext<TApp, Record<string, unknown>>) => void,
+    ): void;
     exists(relation: PermissionRelation): ExistsRelationCondition;
     union(relations: readonly PermissionRelation[]): PermissionRelation;
   };
@@ -520,20 +546,33 @@ export type PolicyContext<TApp extends AppLike> = {
   session: SessionContext;
 };
 
-export type CompiledPermissions = Record<string, TablePolicies>;
+export type CompiledPermissions = Record<string, TablePolicies> & {
+  branchPolicies?: Record<string, Record<string, TablePolicies>>;
+};
 
-type PermissionWhereLeaf<T> = T | SessionRefValue | RowRefValue | RecursiveCurrentValue;
+type PermissionWhereLeaf<T> =
+  | T
+  | SessionRefValue
+  | RowRefValue
+  | BranchRefValue
+  | RecursiveCurrentValue;
 
 type PermissionWhereObjectBase<T> = {
   [K in keyof T]?:
     | PermissionWhereInput<T[K]>
     | SessionRefValue
     | RowRefValue
+    | BranchRefValue
     | RecursiveCurrentValue;
 };
 
 type QualifiedPermissionWhereEntries = {
-  [K in `${string}.${string}`]?: unknown | SessionRefValue | RowRefValue | RecursiveCurrentValue;
+  [K in `${string}.${string}`]?:
+    | unknown
+    | SessionRefValue
+    | RowRefValue
+    | BranchRefValue
+    | RecursiveCurrentValue;
 };
 
 type PermissionWhereObject<T> =
@@ -555,6 +594,7 @@ class UpdateRuleBuilder<WhereInput, Row> {
   constructor(
     private readonly table: string,
     private readonly registerRule?: (ruleLike: RuleLike) => void,
+    private readonly branchBackingTable?: string,
   ) {}
 
   where(
@@ -566,6 +606,7 @@ class UpdateRuleBuilder<WhereInput, Row> {
       action: "update",
       using: condition,
       withCheck: condition,
+      branchBackingTable: this.branchBackingTable,
     };
     this.registerRule?.(rule);
     return rule;
@@ -612,6 +653,7 @@ class UpdateRuleBuilder<WhereInput, Row> {
       action: "update",
       using: this.oldCondition ?? this.newCondition,
       withCheck: this.newCondition ?? this.oldCondition,
+      branchBackingTable: this.branchBackingTable,
     };
   }
 }
@@ -699,6 +741,42 @@ function buildPolicyContext(
   });
   context.union = (relations: readonly PermissionRelation[]): PermissionRelation =>
     createUnionRelation(relations, relationsByTable);
+  context.forBranch = (
+    backingTableBuilder: { __jazzPermissionTable?: unknown },
+    factory: (ctx: {
+      $branch: BranchContext<Record<string, unknown>>;
+      branchPolicy: unknown;
+    }) => void,
+  ): void => {
+    if (typeof backingTableBuilder.__jazzPermissionTable !== "string") {
+      throw new Error(
+        "policy.forBranch(...) expects a table policy builder as its first argument.",
+      );
+    }
+    const backingTable = backingTableBuilder.__jazzPermissionTable;
+    factory({
+      $branch: createBranchContext(),
+      branchPolicy: buildBranchPolicyBuilder(
+        tableNames,
+        backingTable,
+        relationsByTable,
+        collectRule,
+      ),
+    });
+  };
+  return context;
+}
+
+function buildBranchPolicyBuilder(
+  tableNames: string[],
+  backingTable: string,
+  relationsByTable: Map<string, Relation[]>,
+  collectRule: (ruleLike: RuleLike) => void,
+): Record<string, unknown> {
+  const context: Record<string, unknown> = {};
+  for (const table of tableNames) {
+    context[table] = buildTablePolicyBuilder(table, relationsByTable, collectRule, backingTable);
+  }
   return context;
 }
 
@@ -706,29 +784,42 @@ function buildTablePolicyBuilder(
   table: string,
   relationsByTable: Map<string, Relation[]>,
   collectRule: (ruleLike: RuleLike) => void,
+  branchBackingTable?: string,
 ): Record<string, unknown> {
   const registerRule = (rule: Rule): Rule => {
     collectRule(rule);
     return rule;
   };
   const read: ActionBuilder<unknown, unknown> = {
-    where: (input) => registerRule({ table, action: "read", using: resolveWhereInput(input) }),
+    where: (input) =>
+      registerRule({ table, action: "read", using: resolveWhereInput(input), branchBackingTable }),
     always: () => read.where(alwaysCondition()),
     never: () => read.where(neverCondition()),
   };
   const insert: ActionBuilder<unknown, unknown> = {
     where: (input) =>
-      registerRule({ table, action: "insert", withCheck: resolveWhereInput(input) }),
+      registerRule({
+        table,
+        action: "insert",
+        withCheck: resolveWhereInput(input),
+        branchBackingTable,
+      }),
     always: () => insert.where(alwaysCondition()),
     never: () => insert.where(neverCondition()),
   };
   const del: ActionBuilder<unknown, unknown> = {
-    where: (input) => registerRule({ table, action: "delete", using: resolveWhereInput(input) }),
+    where: (input) =>
+      registerRule({
+        table,
+        action: "delete",
+        using: resolveWhereInput(input),
+        branchBackingTable,
+      }),
     always: () => del.where(alwaysCondition()),
     never: () => del.where(neverCondition()),
   };
   const updateFactory = (): UpdateRuleBuilder<unknown, unknown> =>
-    new UpdateRuleBuilder(table, collectRule);
+    new UpdateRuleBuilder(table, collectRule, branchBackingTable);
   const managedByCreator = (): void => {
     read.where(CREATOR_CONDITION);
     insert.where(CREATOR_CONDITION);
@@ -1582,6 +1673,20 @@ function createRowContext(): RowContext<Record<string, unknown>> {
   });
 }
 
+function createBranchContext(): BranchContext<Record<string, unknown>> {
+  return new Proxy({} as BranchContext<Record<string, unknown>>, {
+    get(_target, prop) {
+      if (typeof prop === "string") {
+        return {
+          __jazzPermissionKind: "branch-ref",
+          column: prop,
+        } satisfies BranchRefValue;
+      }
+      return undefined;
+    },
+  });
+}
+
 function normalizeWhereObject(input: unknown): Record<string, unknown> {
   if (!isPlainObject(input)) {
     throw new Error("Expected a where-object condition.");
@@ -1748,6 +1853,9 @@ function columnFilterToExprs(
   if (isSessionRefValue(raw)) {
     return [cmpExpr(column, "Eq", raw, options)];
   }
+  if (isBranchRefValue(raw)) {
+    return [cmpExpr(column, "Eq", raw, options)];
+  }
   if (isRowRefValue(raw)) {
     if (!options.allowRowRefs) {
       throw new Error("Row references are only valid inside exists() clauses.");
@@ -1844,6 +1952,7 @@ function sessionPathFilterToExprs(path: string, raw: unknown): PolicyExpr[] {
     !isPlainObject(raw) ||
     isSessionRefValue(raw) ||
     isRowRefValue(raw) ||
+    isBranchRefValue(raw) ||
     isRecursiveCurrentValue(raw) ||
     isExistsCondition(raw) ||
     isExistsRelationCondition(raw) ||
@@ -1967,6 +2076,12 @@ function toPolicyValue(value: unknown, options: { allowRowRefs: boolean }): Poli
       path: [OUTER_ROW_SESSION_PREFIX, value.column],
     };
   }
+  if (isBranchRefValue(value)) {
+    return {
+      type: "BranchRef",
+      column: value.column,
+    } as unknown as PolicyValue;
+  }
   return { type: "Literal", value };
 }
 
@@ -1983,6 +2098,9 @@ function assertSessionWhereLiteralValue(value: unknown, context: string): void {
   }
   if (isRowRefValue(value)) {
     throw new Error(`${context} only accepts literal values; row references are not supported.`);
+  }
+  if (isBranchRefValue(value)) {
+    throw new Error(`${context} only accepts literal values; branch references are not supported.`);
   }
   if (isRecursiveCurrentValue(value)) {
     throw new Error(
@@ -2057,13 +2175,10 @@ function compileRules(
   fkReferencesByTable: Map<string, Map<string, string>>,
   relationsByTable: Map<string, Relation[]>,
 ): CompiledPermissions {
-  const compiled: CompiledPermissions = {};
+  const compiled = {} as CompiledPermissions;
   for (const ruleLike of rules) {
     const rule = isUpdateRuleBuilder(ruleLike) ? ruleLike.toRule() : ruleLike;
-    if (!compiled[rule.table]) {
-      compiled[rule.table] = emptyTablePolicies();
-    }
-    const tablePolicies = compiled[rule.table]!;
+    const tablePolicies = getTablePoliciesForRule(compiled, rule);
     switch (rule.action) {
       case "read":
         tablePolicies.select = mergeOperationPolicy(tablePolicies.select, {
@@ -2101,6 +2216,23 @@ function compileRules(
     }
   }
   return compiled;
+}
+
+function getTablePoliciesForRule(compiled: CompiledPermissions, rule: Rule): TablePolicies {
+  if (!rule.branchBackingTable) {
+    if (!compiled[rule.table]) {
+      compiled[rule.table] = emptyTablePolicies();
+    }
+    return compiled[rule.table]!;
+  }
+
+  const compiledWithBranches = compiled as CompiledPermissions & {
+    branchPolicies?: Record<string, Record<string, TablePolicies>>;
+  };
+  compiledWithBranches.branchPolicies ??= {};
+  compiledWithBranches.branchPolicies[rule.branchBackingTable] ??= {};
+  compiledWithBranches.branchPolicies[rule.branchBackingTable][rule.table] ??= emptyTablePolicies();
+  return compiledWithBranches.branchPolicies[rule.branchBackingTable][rule.table]!;
 }
 
 function emptyOperationPolicy(): OperationPolicy {
@@ -2337,6 +2469,14 @@ function isRowRefValue(input: unknown): input is RowRefValue {
   return (
     isPlainObject(input) &&
     input.__jazzPermissionKind === "row-ref" &&
+    typeof input.column === "string"
+  );
+}
+
+function isBranchRefValue(input: unknown): input is BranchRefValue {
+  return (
+    isPlainObject(input) &&
+    input.__jazzPermissionKind === "branch-ref" &&
     typeof input.column === "string"
   );
 }

--- a/packages/jazz-tools/src/react-core/use-all.test.tsx
+++ b/packages/jazz-tools/src/react-core/use-all.test.tsx
@@ -3,7 +3,7 @@ import { Component, Suspense, useState, type ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { act, cleanup, render } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
-import type { QueryBuilder } from "../runtime/db.js";
+import type { QueryBuilder, QueryOptions } from "../runtime/db.js";
 import type { SubscriptionDelta } from "../runtime/subscription-manager.js";
 import { SubscriptionsOrchestrator } from "../subscriptions-orchestrator.js";
 import { JazzClientProvider } from "./provider.js";
@@ -27,6 +27,7 @@ function delta(all: Todo[]): SubscriptionDelta<Todo> {
 function makeHarness(appId: string, options?: { throwOnSubscribe?: Error }) {
   const subscribeCalls: Array<{
     callback: (d: SubscriptionDelta<Todo>) => void;
+    options: QueryOptions | undefined;
     unsubscribe: ReturnType<typeof vi.fn>;
   }> = [];
 
@@ -34,13 +35,18 @@ function makeHarness(appId: string, options?: { throwOnSubscribe?: Error }) {
     getAuthState: () => ({ authMode: "local-first", session: null }),
     onAuthChanged: () => () => {},
     updateAuthToken: () => {},
-    subscribeAll: (_query: any, callback: (d: SubscriptionDelta<any>) => void) => {
+    subscribeAll: (
+      _query: any,
+      callback: (d: SubscriptionDelta<any>) => void,
+      queryOptions?: QueryOptions,
+    ) => {
       if (options?.throwOnSubscribe) {
         throw options.throwOnSubscribe;
       }
       const unsubscribe = vi.fn();
       subscribeCalls.push({
         callback: callback as (d: SubscriptionDelta<Todo>) => void,
+        options: queryOptions,
         unsubscribe,
       });
       return unsubscribe;
@@ -91,6 +97,24 @@ describe("react-core/useAll", () => {
     act(() => force(2));
 
     expect(subscribeCalls).toHaveLength(1);
+  });
+
+  it("forwards branch QueryOptions into the subscription entry", () => {
+    const { client, subscribeCalls } = makeHarness("rc-all-branch-option");
+
+    function Probe() {
+      useAll(makeQuery(), { branch: "branch-row-id" });
+      return null;
+    }
+
+    render(
+      <JazzClientProvider client={client}>
+        <Probe />
+      </JazzClientProvider>,
+    );
+
+    expect(subscribeCalls).toHaveLength(1);
+    expect(subscribeCalls[0]!.options).toEqual({ branch: "branch-row-id" });
   });
 
   it("renders rows and reflects later deltas", () => {

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.test.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.test.ts
@@ -18,6 +18,7 @@ function createBinding(overrides: Partial<JazzRnRuntimeBinding> = {}): JazzRnRun
     ),
     executeSubscription: vi.fn(),
     getSchemaHash: vi.fn(() => "schema-hash"),
+    composeBranchName: vi.fn((userBranch: string) => `dev-schema-${userBranch}`),
     waitForBatch: vi.fn(async () => undefined),
     beginBatch: vi.fn((batchMode) => `batch-${batchMode}`),
     rollbackBatch: vi.fn(() => true),

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
@@ -28,6 +28,7 @@ export interface JazzRnRuntimeBinding {
   disconnect(): void;
   updateAuth(authJson: string): void;
   onAuthFailure(callback: { onFailure(reason: string): void }): void;
+  composeBranchName?(userBranch: string): string;
   delete_(objectId: string, writeContextJson: string | undefined): string;
   getSchemaHash(): string;
   insert(
@@ -382,6 +383,13 @@ export class JazzRnRuntimeAdapter implements Runtime {
 
   getSchemaHash(): string {
     return this.binding.getSchemaHash();
+  }
+
+  composeBranchName(userBranch: string): string {
+    if (!this.binding.composeBranchName) {
+      throw new Error("Branch composition is not available in this React Native runtime");
+    }
+    return this.binding.composeBranchName(userBranch);
   }
 
   close(): void {

--- a/packages/jazz-tools/src/runtime/branch-permissions.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/branch-permissions.integration.test.ts
@@ -1,0 +1,166 @@
+import { randomUUID } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, onTestFinished } from "vitest";
+import { schema as s } from "../index.js";
+
+const app = s.defineApp({
+  projects: s.table({ name: s.string(), ownerId: s.string() }),
+  branches: s.table({ projectId: s.ref("projects"), ownerId: s.string() }),
+  todos: s.table({
+    projectId: s.ref("projects"),
+    title: s.string(),
+    ownerId: s.string(),
+  }),
+});
+
+const permissions = s.definePermissions(app, ({ policy, session }) => {
+  policy.projects.allowRead.where({ ownerId: session.user_id });
+  policy.projects.allowInsert.where({ ownerId: session.user_id });
+  policy.branches.allowRead.where({ ownerId: session.user_id });
+  policy.branches.allowInsert.where({ ownerId: session.user_id });
+
+  // Normal todo policy is intentionally permissive so branch deny-by-default is observable.
+  policy.todos.allowRead.where({ ownerId: session.user_id });
+  policy.todos.allowInsert.where({ ownerId: session.user_id });
+
+  policy.forBranch(policy.branches, ({ $branch, branchPolicy }) => {
+    branchPolicy.todos.allowRead.where({ projectId: $branch.projectId });
+    branchPolicy.todos.allowInsert.where({
+      projectId: $branch.projectId,
+      ownerId: session.user_id,
+    });
+    branchPolicy.todos.allowUpdate.where({ projectId: $branch.projectId });
+    branchPolicy.todos.allowDelete.where({ projectId: $branch.projectId });
+  });
+});
+
+type JazzContext = import("../backend/create-jazz-context.js").JazzContext;
+
+async function createBranchPermissionsContext(): Promise<JazzContext> {
+  const appId = randomUUID();
+  const dataRoot = await mkdtemp(join(tmpdir(), "jazz-branch-permissions-"));
+  const dataPath = join(dataRoot, "runtime.db");
+  const { createJazzContext } = await import("../backend/create-jazz-context.js");
+  const context = createJazzContext({
+    appId,
+    app,
+    permissions,
+    driver: { type: "persistent", dataPath },
+    env: "test",
+    userBranch: "main",
+    tier: "edge",
+  });
+
+  onTestFinished(async () => {
+    context.flush();
+    await context.shutdown();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await rm(dataRoot, { recursive: true, force: true });
+  });
+
+  return context;
+}
+
+function titles(rows: Array<{ title: string }>): string[] {
+  return rows.map((row) => row.title).sort();
+}
+
+async function expectDeniedWrite(write: () => Promise<unknown>): Promise<void> {
+  // A branch the session cannot access is denied deny-by-default. For inserts this
+  // surfaces as a policy-denied error; for update/delete of a row that is invisible
+  // to the session (because the backing branch row is unreadable) the targeted row
+  // is not found — both are valid denials. The denial is corroborated separately by
+  // the session's branch reads returning [] and the owner's row remaining intact.
+  await expect(write()).rejects.toThrow(/policy denied|denied|object not found|not found/i);
+}
+
+describe("branch permissions integration", () => {
+  it("enforces branch-scoped CRUD permissions and isolation end to end", async () => {
+    const context = await createBranchPermissionsContext();
+    const aliceDb = context.forSession({ user_id: "alice", claims: {}, authMode: "external" }, app);
+    const bobDb = context.forSession({ user_id: "bob", claims: {}, authMode: "external" }, app);
+
+    const project = await aliceDb
+      .insert(app.projects, { name: "Website", ownerId: "alice" })
+      .wait({ tier: "edge" });
+    const branch = await aliceDb
+      .insert(app.branches, { projectId: project.id, ownerId: "alice" })
+      .wait({ tier: "edge" });
+
+    const aDraft = aliceDb.branch(branch.id);
+    const bDraft = bobDb.branch(branch.id);
+
+    const draftTodo = await aDraft
+      .insert(app.todos, {
+        projectId: project.id,
+        title: "Draft branch todo",
+        ownerId: "alice",
+      })
+      .wait({ tier: "edge" });
+
+    await expect(
+      aDraft.all(app.todos.where({ projectId: project.id }), { tier: "edge" }),
+    ).resolves.toEqual([expect.objectContaining({ id: draftTodo.id, title: "Draft branch todo" })]);
+
+    await expect(
+      aliceDb.all(app.todos.where({ projectId: project.id }), { tier: "edge" }),
+    ).resolves.toEqual([]);
+
+    const mainTodo = await aliceDb
+      .insert(app.todos, {
+        projectId: project.id,
+        title: "Main todo",
+        ownerId: "alice",
+      })
+      .wait({ tier: "edge" });
+
+    await expect(
+      aDraft.all(app.todos.where({ projectId: project.id }), { tier: "edge" }),
+    ).resolves.toEqual([expect.objectContaining({ id: draftTodo.id, title: "Draft branch todo" })]);
+    await expect(
+      aliceDb.all(app.todos.where({ projectId: project.id }), { tier: "edge" }),
+    ).resolves.toEqual([expect.objectContaining({ id: mainTodo.id, title: "Main todo" })]);
+
+    await expect(
+      bDraft.all(app.todos.where({ projectId: project.id }), { tier: "edge" }),
+    ).resolves.toEqual([]);
+
+    await expectDeniedWrite(async () => {
+      await bDraft
+        .insert(app.todos, {
+          projectId: project.id,
+          title: "Bob branch todo",
+          ownerId: "bob",
+        })
+        .wait({ tier: "edge" });
+    });
+    await expectDeniedWrite(async () => {
+      await bDraft
+        .update(app.todos, draftTodo.id, { title: "Bob branch update" })
+        .wait({ tier: "edge" });
+    });
+    await expectDeniedWrite(async () => {
+      await bDraft.delete(app.todos, draftTodo.id).wait({ tier: "edge" });
+    });
+    await expect(
+      bDraft.all(app.todos.where({ projectId: project.id }), { tier: "edge" }),
+    ).resolves.toEqual([]);
+
+    await aDraft
+      .update(app.todos, draftTodo.id, { title: "Updated branch todo" })
+      .wait({ tier: "edge" });
+    expect(
+      titles(await aDraft.all(app.todos.where({ projectId: project.id }), { tier: "edge" })),
+    ).toEqual(["Updated branch todo"]);
+
+    await aDraft.delete(app.todos, draftTodo.id).wait({ tier: "edge" });
+    await expect(
+      aDraft.all(app.todos.where({ projectId: project.id }), { tier: "edge" }),
+    ).resolves.toEqual([]);
+    await expect(
+      aliceDb.all(app.todos.where({ projectId: project.id }), { tier: "edge" }),
+    ).resolves.toEqual([expect.objectContaining({ id: mainTodo.id, title: "Main todo" })]);
+  });
+});

--- a/packages/jazz-tools/src/runtime/client-tests/for-request.test.ts
+++ b/packages/jazz-tools/src/runtime/client-tests/for-request.test.ts
@@ -205,6 +205,7 @@ describe("JazzClient runtime helpers", () => {
       unsubscribe: () => {},
       getSchema: () => ({}),
       getSchemaHash: () => "schema-hash",
+      composeBranchName: (userBranch: string) => `dev-schema-${userBranch}`,
     };
 
     const JazzClientCtor = JazzClient as unknown as {

--- a/packages/jazz-tools/src/runtime/client-tests/for-request.test.ts
+++ b/packages/jazz-tools/src/runtime/client-tests/for-request.test.ts
@@ -77,6 +77,16 @@ describe("JazzClient runtime helpers", () => {
     expect(parsed).toHaveProperty("relation_ir");
   });
 
+  it("injects the composed target branch into subscribe queries", () => {
+    const { client, createSubscriptionCalls } = makeClient();
+
+    client.subscribe('{"table":"todos"}', () => {}, undefined, undefined, "branch-row-id");
+
+    expect(createSubscriptionCalls).toHaveLength(1);
+    const parsed = JSON.parse(createSubscriptionCalls[0]![0]) as { branches?: string[] };
+    expect(parsed.branches).toEqual(["dev-schema-branch-row-id"]);
+  });
+
   it("forwards structured RN delta payloads to subscription callbacks", async () => {
     const { client, executeSubscriptionCalls } = makeClient();
     const callback = vi.fn();

--- a/packages/jazz-tools/src/runtime/client-tests/support.ts
+++ b/packages/jazz-tools/src/runtime/client-tests/support.ts
@@ -120,6 +120,7 @@ export function makeClient() {
     },
     getSchema: () => ({}),
     getSchemaHash: () => "schema-hash",
+    composeBranchName: (userBranch: string) => `dev-schema-${userBranch}`,
   };
 
   const context: AppContext = {
@@ -171,6 +172,7 @@ export function makeClientWithContext(context: AppContext): JazzClient {
     unsubscribe: () => {},
     getSchema: () => ({}),
     getSchemaHash: () => "schema-hash",
+    composeBranchName: (userBranch: string) => `dev-schema-${userBranch}`,
   };
 
   const JazzClientCtor = JazzClient as unknown as {

--- a/packages/jazz-tools/src/runtime/client.mutations.test.ts
+++ b/packages/jazz-tools/src/runtime/client.mutations.test.ts
@@ -74,6 +74,7 @@ function makeClient(runtimeOverrides: Partial<Runtime> = {}) {
     rollbackBatch: () => false,
     getSchema: () => ({}),
     getSchemaHash: () => "schema-hash",
+    composeBranchName: (userBranch: string) => `dev-schema-${userBranch}`,
   };
   const runtime: Runtime = { ...runtimeBase, ...runtimeOverrides };
 

--- a/packages/jazz-tools/src/runtime/client.test.ts
+++ b/packages/jazz-tools/src/runtime/client.test.ts
@@ -90,6 +90,7 @@ function makeFakeRuntime() {
     rollbackBatch: vi.fn<Runtime["rollbackBatch"]>(() => false),
     getSchema: vi.fn().mockReturnValue({}),
     getSchemaHash: vi.fn().mockReturnValue("hash"),
+    composeBranchName: vi.fn((userBranch: string) => `dev-hash-${userBranch}`),
     close: vi.fn(),
   } satisfies Runtime;
 

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -1114,11 +1114,12 @@ export class JazzClient {
     callback: SubscriptionCallback,
     options?: QueryExecutionOptions,
     session?: Session,
+    targetBranch?: string,
   ): number {
     const normalizedOptions = this.normalizeQueryExecutionOptions(options);
     const effectiveSession = session ?? this.resolvedSession;
     const sessionJson = effectiveSession ? JSON.stringify(effectiveSession) : undefined;
-    const queryJson = resolveQueryJson(query);
+    const queryJson = this.resolveQueryJsonForBranch(query, targetBranch);
     const optionsJson = encodeQueryExecutionOptions(normalizedOptions);
 
     // Uses the runtime's 2-phase subscribe API: `createSubscription` allocates

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -87,6 +87,7 @@ export interface Runtime {
   createWorkerBridge?(worker: Worker, options: object): unknown;
   getSchema(): any;
   getSchemaHash(): string;
+  composeBranchName(userBranch: string): string;
   close?(): void | Promise<void>;
   /** Connect to a Jazz server over WebSocket (Rust transport). */
   connect(url: string, auth_json: string): void;
@@ -771,11 +772,24 @@ export class JazzClient {
     attribution?: string,
     batchId?: BatchId,
     updatedAt?: number,
+    targetBranchName?: string,
   ): string | undefined {
-    if (!session && attribution === undefined && !batchId && updatedAt === undefined) {
+    if (
+      !session &&
+      attribution === undefined &&
+      !batchId &&
+      updatedAt === undefined &&
+      targetBranchName === undefined
+    ) {
       return undefined;
     }
-    if (attribution === undefined && session && !batchId && updatedAt === undefined) {
+    if (
+      attribution === undefined &&
+      session &&
+      !batchId &&
+      updatedAt === undefined &&
+      targetBranchName === undefined
+    ) {
       return JSON.stringify(session);
     }
 
@@ -792,6 +806,9 @@ export class JazzClient {
     if (batchId) {
       payload.batch_id = batchId;
     }
+    if (targetBranchName !== undefined) {
+      payload.target_branch_name = targetBranchName;
+    }
     return JSON.stringify(payload);
   }
 
@@ -805,6 +822,21 @@ export class JazzClient {
     return this.resolvedSession ?? undefined;
   }
 
+  composeBranch(userBranch: string): string {
+    return this.runtime.composeBranchName(userBranch);
+  }
+
+  private resolveQueryJsonForBranch(query: string | QueryInput, targetBranch?: string): string {
+    const queryJson = resolveQueryJson(query);
+    if (targetBranch === undefined) {
+      return queryJson;
+    }
+
+    const queryPayload = JSON.parse(queryJson) as Record<string, unknown>;
+    queryPayload.branches = [this.composeBranch(targetBranch)];
+    return JSON.stringify(queryPayload);
+  }
+
   /**
    * Insert a new row into a table without waiting for durability.
    */
@@ -814,8 +846,17 @@ export class JazzClient {
     options?: CreateOptions,
     session?: Session,
     attribution?: string,
+    targetBranch?: string,
   ): WriteResult<Row> {
-    const row = this.insertInternal(table, values, options, session, attribution);
+    const row = this.insertInternal(
+      table,
+      values,
+      options,
+      session,
+      attribution,
+      undefined,
+      targetBranch,
+    );
     return new WriteResult(row, row.batchId, this);
   }
 
@@ -829,13 +870,17 @@ export class JazzClient {
     session?: Session,
     attribution?: string,
     batchId?: BatchId,
+    targetBranch?: string,
   ): DirectInsertResult {
     const effectiveSession = this.resolveWriteSession(session, attribution);
+    const targetBranchName =
+      targetBranch === undefined ? undefined : this.composeBranch(targetBranch);
     const writeContext = this.encodeWriteContext(
       effectiveSession,
       attribution,
       batchId,
       options?.updatedAt,
+      targetBranchName,
     );
     const row = this.runtime.insert(table, values, writeContext, options?.id);
     return {
@@ -854,8 +899,18 @@ export class JazzClient {
     options?: RestoreOptions,
     session?: Session,
     attribution?: string,
+    targetBranch?: string,
   ): WriteResult<Row> {
-    const row = this.restoreInternal(table, objectId, values, options, session, attribution);
+    const row = this.restoreInternal(
+      table,
+      objectId,
+      values,
+      options,
+      session,
+      attribution,
+      undefined,
+      targetBranch,
+    );
     return new WriteResult(row, row.batchId, this);
   }
 
@@ -870,13 +925,17 @@ export class JazzClient {
     session?: Session,
     attribution?: string,
     batchId?: BatchId,
+    targetBranch?: string,
   ): DirectInsertResult {
     const effectiveSession = this.resolveWriteSession(session, attribution);
+    const targetBranchName =
+      targetBranch === undefined ? undefined : this.composeBranch(targetBranch);
     const writeContext = this.encodeWriteContext(
       effectiveSession,
       attribution,
       batchId,
       options?.updatedAt,
+      targetBranchName,
     );
     const row = this.runtime.restore(table, objectId, values, writeContext);
     return {
@@ -931,9 +990,10 @@ export class JazzClient {
     query: string | QueryInput,
     options?: InternalQueryExecutionOptions,
     session?: Session,
+    targetBranch?: string,
   ): Promise<Row[]> {
     const normalizedOptions = this.normalizeQueryExecutionOptions(options);
-    const queryJson = resolveQueryJson(query);
+    const queryJson = this.resolveQueryJsonForBranch(query, targetBranch);
     const effectiveSession = session ?? this.resolvedSession;
     const sessionJson = effectiveSession ? JSON.stringify(effectiveSession) : undefined;
     const optionsJson = encodeQueryExecutionOptions(normalizedOptions);
@@ -957,6 +1017,7 @@ export class JazzClient {
     options?: UpdateOptions,
     session?: Session,
     attribution?: string,
+    targetBranch?: string,
   ): WriteHandle {
     const result = this.updateInternal(
       objectId,
@@ -965,6 +1026,7 @@ export class JazzClient {
       session,
       attribution,
       undefined,
+      targetBranch,
     );
     return new WriteHandle(result.batchId, this);
   }
@@ -979,9 +1041,18 @@ export class JazzClient {
     session?: Session,
     attribution?: string,
     batchId?: BatchId,
+    targetBranch?: string,
   ): DirectMutationResult {
     const effectiveSession = this.resolveWriteSession(session, attribution);
-    const writeContext = this.encodeWriteContext(effectiveSession, attribution, batchId, updatedAt);
+    const targetBranchName =
+      targetBranch === undefined ? undefined : this.composeBranch(targetBranch);
+    const writeContext = this.encodeWriteContext(
+      effectiveSession,
+      attribution,
+      batchId,
+      updatedAt,
+      targetBranchName,
+    );
     return this.runtime.update(objectId, updates, writeContext);
   }
 
@@ -993,8 +1064,16 @@ export class JazzClient {
     options?: DeleteOptions,
     session?: Session,
     attribution?: string,
+    targetBranch?: string,
   ): WriteHandle {
-    const result = this.deleteInternal(objectId, options?.updatedAt, session, attribution);
+    const result = this.deleteInternal(
+      objectId,
+      options?.updatedAt,
+      session,
+      attribution,
+      undefined,
+      targetBranch,
+    );
     return new WriteHandle(result.batchId, this);
   }
 
@@ -1007,9 +1086,18 @@ export class JazzClient {
     session?: Session,
     attribution?: string,
     batchId?: BatchId,
+    targetBranch?: string,
   ): DirectMutationResult {
     const effectiveSession = this.resolveWriteSession(session, attribution);
-    const writeContext = this.encodeWriteContext(effectiveSession, attribution, batchId, updatedAt);
+    const targetBranchName =
+      targetBranch === undefined ? undefined : this.composeBranch(targetBranch);
+    const writeContext = this.encodeWriteContext(
+      effectiveSession,
+      attribution,
+      batchId,
+      updatedAt,
+      targetBranchName,
+    );
     return this.runtime.delete(objectId, writeContext);
   }
 

--- a/packages/jazz-tools/src/runtime/db.branch.subscribe.test.ts
+++ b/packages/jazz-tools/src/runtime/db.branch.subscribe.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { schema as s } from "../index.js";
+import { createDb, type Db } from "./db.js";
+import type { SubscriptionDelta } from "../shared/index.js";
+
+const app = s.defineApp({
+  projects: s.table({ name: s.string(), ownerId: s.string() }),
+  branches: s.table({ projectId: s.ref("projects"), ownerId: s.string() }),
+  todos: s.table({ projectId: s.ref("projects"), title: s.string(), ownerId: s.string() }),
+});
+
+const dbs: Db[] = [];
+afterEach(async () => {
+  while (dbs.length > 0) {
+    const db = dbs.pop();
+    if (db) await db.shutdown();
+  }
+});
+
+async function makeDb(): Promise<Db> {
+  const appId = `db-branch-sub-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const db = await createDb({
+    appId,
+    driver: { type: "persistent", dbName: appId },
+    cookieSession: { user_id: "alice", claims: {}, authMode: "external" },
+    userBranch: "main",
+  });
+  dbs.push(db);
+  return db;
+}
+
+describe("branch subscription (useAll path) repro", () => {
+  it("a branch-scoped subscription receives an optimistic branch insert", async () => {
+    const db = await makeDb();
+    const project = await db
+      .insert(app.projects, { name: "P", ownerId: "alice" })
+      .wait({ tier: "local" });
+    const branch = await db
+      .insert(app.branches, { projectId: project.id, ownerId: "alice" })
+      .wait({ tier: "local" });
+
+    let branchRows: string[] = [];
+    let mainRows: string[] = [];
+    const q = app.todos.where({ projectId: project.id });
+    const unsubBranch = db.subscribeAll(
+      q,
+      (d: SubscriptionDelta<{ id: string; title: string }>) => {
+        branchRows = d.all.map((t) => t.title);
+      },
+      { branch: branch.id },
+    );
+    const unsubMain = db.subscribeAll(q, (d: SubscriptionDelta<{ id: string; title: string }>) => {
+      mainRows = d.all.map((t) => t.title);
+    });
+
+    // Optimistic insert on the branch, mirroring the example app (no .wait()).
+    db.branch(branch.id).insert(app.todos, {
+      projectId: project.id,
+      title: "Branch todo",
+      ownerId: "alice",
+    });
+
+    await new Promise((r) => setTimeout(r, 500));
+
+    expect(branchRows).toContain("Branch todo");
+    expect(mainRows).not.toContain("Branch todo");
+    unsubBranch();
+    unsubMain();
+  });
+});

--- a/packages/jazz-tools/src/runtime/db.branch.test.ts
+++ b/packages/jazz-tools/src/runtime/db.branch.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { schema as s } from "../index.js";
+import { createDb, type Db } from "./db.js";
+
+const app = s.defineApp({
+  projects: s.table({ name: s.string(), ownerId: s.string() }),
+  branches: s.table({ projectId: s.ref("projects"), ownerId: s.string() }),
+  todos: s.table({
+    projectId: s.ref("projects"),
+    title: s.string(),
+    ownerId: s.string(),
+  }),
+});
+
+const permissions = s.definePermissions(app, ({ policy, session }) => {
+  policy.projects.allowRead.where({ ownerId: session.user_id });
+  policy.projects.allowInsert.where({ ownerId: session.user_id });
+  policy.branches.allowRead.where({ ownerId: session.user_id });
+  policy.branches.allowInsert.where({ ownerId: session.user_id });
+  policy.forBranch(policy.branches, ({ $branch, branchPolicy }) => {
+    branchPolicy.todos.allowRead.where({ projectId: $branch.projectId });
+    branchPolicy.todos.allowInsert.where({
+      projectId: $branch.projectId,
+      ownerId: session.user_id,
+    });
+  });
+});
+
+const dbs: Db[] = [];
+
+afterEach(async () => {
+  while (dbs.length > 0) {
+    const db = dbs.pop();
+    if (db) {
+      await db.shutdown();
+    }
+  }
+});
+
+async function makeDb(): Promise<Db> {
+  void permissions;
+  const appId = `db-branch-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const db = await createDb({
+    appId,
+    driver: { type: "persistent", dbName: appId },
+    cookieSession: { user_id: "alice", claims: {}, authMode: "external" },
+    userBranch: "main",
+  });
+  dbs.push(db);
+  return db;
+}
+
+describe("Db branch view", () => {
+  it("routes reads and writes through the selected branch", async () => {
+    const db = await makeDb();
+
+    const projectInsert = db.insert(app.projects, {
+      name: "Website",
+      ownerId: "alice",
+    });
+    await projectInsert.wait({ tier: "local" });
+    const project = projectInsert.value;
+
+    const branchInsert = db.insert(app.branches, {
+      projectId: project.id,
+      ownerId: "alice",
+    });
+    await branchInsert.wait({ tier: "local" });
+    const branch = branchInsert.value;
+
+    const branchDb = db.branch(branch.id);
+    const todoInsert = branchDb.insert(app.todos, {
+      projectId: project.id,
+      title: "Draft landing page",
+      ownerId: "alice",
+    });
+    await todoInsert.wait({ tier: "local" });
+    const todo = todoInsert.value;
+
+    await expect(branchDb.all(app.todos.where({ projectId: project.id }))).resolves.toEqual([
+      expect.objectContaining({ id: todo.id, title: "Draft landing page" }),
+    ]);
+    await expect(db.all(app.todos.where({ projectId: project.id }))).resolves.toEqual([]);
+  });
+});

--- a/packages/jazz-tools/src/runtime/db.persisted.test.ts
+++ b/packages/jazz-tools/src/runtime/db.persisted.test.ts
@@ -112,6 +112,7 @@ describe("Db write handles", () => {
       undefined,
       undefined,
       undefined,
+      undefined,
     );
     expect(pending.batchId).toBe("batch-insert");
     expect(pending.value).toEqual({
@@ -151,8 +152,9 @@ describe("Db write handles", () => {
       undefined,
       undefined,
       undefined,
+      undefined,
     );
-    expect(remove).toHaveBeenCalledWith("todo-1", undefined, undefined, undefined);
+    expect(remove).toHaveBeenCalledWith("todo-1", undefined, undefined, undefined, undefined);
     await expect(updated.wait({ tier: "edge" })).resolves.toBeUndefined();
     await expect(deleted.wait({ tier: "global" })).resolves.toBeUndefined();
     expect(updateClient.waitForBatch).toHaveBeenCalledWith("batch-update", "edge");
@@ -208,6 +210,7 @@ describe("Db write handles", () => {
       undefined,
       session,
       "alice@writer",
+      undefined,
     );
     expect(update).toHaveBeenCalledWith(
       "todo-2",
@@ -217,8 +220,9 @@ describe("Db write handles", () => {
       undefined,
       session,
       "alice@writer",
+      undefined,
     );
-    expect(deleteRow).toHaveBeenCalledWith("todo-2", undefined, session, "alice@writer");
+    expect(deleteRow).toHaveBeenCalledWith("todo-2", undefined, session, "alice@writer", undefined);
     expect(inserted.value).toEqual({
       id: "todo-2",
       title: "With session",

--- a/packages/jazz-tools/src/runtime/db.schema-order.test.ts
+++ b/packages/jazz-tools/src/runtime/db.schema-order.test.ts
@@ -81,6 +81,7 @@ describe("Db runtime schema order", () => {
       undefined,
       undefined,
       undefined,
+      undefined,
     );
     expect(row).toEqual({
       id: "todo-1",
@@ -189,6 +190,7 @@ describe("Db runtime schema order", () => {
       undefined,
       undefined,
       undefined,
+      undefined,
     );
     expect(row).toEqual({
       id: "todo-1",
@@ -243,6 +245,7 @@ describe("Db runtime schema order", () => {
         done: { type: "Boolean", value: false },
       },
       { id: externalId },
+      undefined,
       undefined,
       undefined,
     );
@@ -355,6 +358,7 @@ describe("Db runtime schema order", () => {
       { updatedAt },
       undefined,
       undefined,
+      undefined,
     );
     expect(update).toHaveBeenCalledWith(
       "todo-1",
@@ -362,6 +366,7 @@ describe("Db runtime schema order", () => {
         done: { type: "Boolean", value: true },
       },
       { updatedAt },
+      undefined,
       undefined,
       undefined,
     );
@@ -428,6 +433,7 @@ describe("Db runtime schema order", () => {
       { updatedAt },
       undefined,
       undefined,
+      undefined,
     );
     expect(update).toHaveBeenCalledWith(
       "todo-1",
@@ -435,6 +441,7 @@ describe("Db runtime schema order", () => {
         done: { type: "Boolean", value: true },
       },
       { updatedAt },
+      undefined,
       undefined,
       undefined,
     );

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -246,6 +246,7 @@ export interface QueryBuilder<T> {
 }
 
 export type QueryOptions = QueryExecutionOptions;
+export type DbBranchView = Pick<Db, "all" | "insert" | "update" | "delete">;
 
 type DbRuntimeOperationContext = {
   session?: Session;
@@ -1153,7 +1154,7 @@ export class Db {
    * In worker mode, the first call per schema also initializes the
    * WorkerBridge (async). Subsequent calls are sync.
    */
-  protected getClient(schema: WasmSchema): JazzClient {
+  protected getClient(schema: WasmSchema, userBranch?: string): JazzClient {
     if (!this.runtimeModule) {
       throw new Error("Db runtime module is not initialized for this Db implementation");
     }
@@ -1165,15 +1166,20 @@ export class Db {
 
     // Use the canonical schema JSON as the client cache key, but memoize it by
     // schema identity so write-heavy paths don't stringify the same schema per row.
-    const key = getRuntimeSchemaCacheKey(runtimeSchema);
-    this.reportBrokerSchemaReady(key);
+    const schemaKey = getRuntimeSchemaCacheKey(runtimeSchema);
+    const effectiveUserBranch = userBranch ?? this.config.userBranch ?? "main";
+    const key =
+      effectiveUserBranch === (this.config.userBranch ?? "main")
+        ? schemaKey
+        : `${schemaKey}::branch:${encodeURIComponent(effectiveUserBranch)}`;
+    this.reportBrokerSchemaReady(schemaKey);
 
     if (!this.clients.has(key)) {
       this.installMainThreadWasmTelemetry();
       const usesDurablePeer = this.worker !== null || this.brokerClient !== null;
 
       const client = this.runtimeModule.createClient({
-        config: { ...this.config },
+        config: { ...this.config, userBranch: effectiveUserBranch },
         schema: runtimeSchema,
         hasWorker: usesDurablePeer,
         useBinaryEncoding: usesDurablePeer,
@@ -2208,6 +2214,23 @@ export class Db {
     };
   }
 
+  branch(branchId: string): DbBranchView {
+    return {
+      all: <T>(query: QueryBuilder<T>, options?: QueryOptions) =>
+        this.allOnBranch(branchId, query, options),
+      insert: <T, Init>(table: TableProxy<T, Init>, data: Init, options?: CreateOptions) =>
+        this.insertOnBranch(branchId, table, data, options),
+      update: <T, Init>(
+        table: TableProxy<T, Init>,
+        id: string,
+        data: Partial<Init>,
+        options?: UpdateOptions,
+      ) => this.updateOnBranch(branchId, table, id, data, options),
+      delete: <T, Init>(table: TableProxy<T, Init>, id: string, options?: DeleteOptions) =>
+        this.deleteOnBranch(branchId, table, id, options),
+    };
+  }
+
   /**
    * Insert a new row into a table without waiting for durability.
    *
@@ -2218,7 +2241,16 @@ export class Db {
    * @returns Write result containing the inserted row
    */
   insert<T, Init>(table: TableProxy<T, Init>, data: Init, options?: CreateOptions): WriteResult<T> {
-    const client = this.getClient(table._schema);
+    return this.insertOnBranch(undefined, table, data, options);
+  }
+
+  private insertOnBranch<T, Init>(
+    branchId: string | undefined,
+    table: TableProxy<T, Init>,
+    data: Init,
+    options?: CreateOptions,
+  ): WriteResult<T> {
+    const client = this.getClient(table._schema, branchId);
     // Don't wait for bridge to be ready in worker mode. Inserts will be propagated once the bridge is ready.
     // If the bridge fails to initialize, the insert will be lost on restart.
     const transformedData = transformInputColumns(table, data);
@@ -2298,7 +2330,17 @@ export class Db {
     data: Partial<Init>,
     options?: UpdateOptions,
   ): WriteHandle {
-    const client = this.getClient(table._schema);
+    return this.updateOnBranch(undefined, table, id, data, options);
+  }
+
+  private updateOnBranch<T, Init>(
+    branchId: string | undefined,
+    table: TableProxy<T, Init>,
+    id: string,
+    data: Partial<Init>,
+    options?: UpdateOptions,
+  ): WriteHandle {
+    const client = this.getClient(table._schema, branchId);
     const transformedData = transformInputColumns(table, data);
     const updates = toWriteRecord(transformedData, table._schema, table._table);
     const context = this.getRuntimeOperationContext();
@@ -2313,7 +2355,16 @@ export class Db {
    * Use {@link WriteHandle.wait} to wait for durable confirmation.
    */
   delete<T, Init>(table: TableProxy<T, Init>, id: string, options?: DeleteOptions): WriteHandle {
-    const client = this.getClient(table._schema);
+    return this.deleteOnBranch(undefined, table, id, options);
+  }
+
+  private deleteOnBranch<T, Init>(
+    branchId: string | undefined,
+    table: TableProxy<T, Init>,
+    id: string,
+    options?: DeleteOptions,
+  ): WriteHandle {
+    const client = this.getClient(table._schema, branchId);
     const context = this.getRuntimeOperationContext();
     return this.wrapWriteWait(client.delete(id, options, context?.session, context?.attribution));
   }
@@ -2461,19 +2512,32 @@ export class Db {
    * @returns Array of typed objects matching the query
    */
   async all<T>(query: QueryBuilder<T>, options?: QueryOptions): Promise<T[]> {
-    const client = this.getClient(query._schema);
+    return this.allOnBranch(undefined, query, options);
+  }
+
+  private async allOnBranch<T>(
+    branchId: string | undefined,
+    query: QueryBuilder<T>,
+    options?: QueryOptions,
+  ): Promise<T[]> {
+    const client = this.getClient(query._schema, branchId);
+    const scopedQuery = query;
     const runtimeSchema = createRuntimeSchemaResolver(() =>
       normalizeRuntimeSchema(client.getSchema()),
     );
-    const builderJson = query._build();
-    const builtQuery = normalizeBuiltQuery(JSON.parse(builderJson), query._table);
+    const builderJson = scopedQuery._build();
+    const builtQuery = normalizeBuiltQuery(JSON.parse(builderJson), scopedQuery._table);
     const planningSchema = resolveSchemaWithTable(
-      query._schema,
+      scopedQuery._schema,
       runtimeSchema.get,
       builtQuery.table,
     );
     const outputTable = resolveBuiltQueryOutputTable(planningSchema, builtQuery);
-    const outputSchema = resolveSchemaWithTable(query._schema, runtimeSchema.get, outputTable);
+    const outputSchema = resolveSchemaWithTable(
+      scopedQuery._schema,
+      runtimeSchema.get,
+      outputTable,
+    );
     const queryOptions = ordinaryDbQueryOptions(options);
     await this.ensureQueryReady(queryOptions);
     const wasmQuery = translateQuery(builderJson, planningSchema);

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -245,7 +245,7 @@ export interface QueryBuilder<T> {
   readonly _rowType: T;
 }
 
-export type QueryOptions = QueryExecutionOptions;
+export type QueryOptions = QueryExecutionOptions & { branch?: string };
 export type DbBranchView = Pick<Db, "all" | "insert" | "update" | "delete">;
 
 type DbRuntimeOperationContext = {
@@ -2666,7 +2666,8 @@ export class Db {
     session?: Session,
   ): () => void {
     const manager = new SubscriptionManager<T>();
-    const client = this.getClient(query._schema);
+    const { branch, ...executionOptions } = options ?? {};
+    const client = this.getClient(query._schema, branch);
     const runtimeSchema = createRuntimeSchemaResolver(() =>
       normalizeRuntimeSchema(client.getSchema()),
     );
@@ -2709,7 +2710,7 @@ export class Db {
       callback(typedDelta);
     };
 
-    const queryOptions = ordinaryDbQueryOptions(options);
+    const queryOptions = ordinaryDbQueryOptions(executionOptions);
     const context = this.getRuntimeOperationContext();
     let unsubscribed = false;
     let subId: number | null = null;
@@ -2717,7 +2718,13 @@ export class Db {
 
     const startSubscription = () => {
       if (unsubscribed) return;
-      subId = client.subscribe(wasmQuery, handleDelta, queryOptions, context?.session ?? session);
+      subId = client.subscribe(
+        wasmQuery,
+        handleDelta,
+        queryOptions,
+        context?.session ?? session,
+        branch,
+      );
       traceId = this.registerActiveQuerySubscriptionTrace(
         wasmQuery,
         builtQuery.table,

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -2262,6 +2262,7 @@ export class Db {
       options,
       context?.session,
       context?.attribution,
+      branchId,
     );
     return this.wrapWriteWait(
       inserted.mapValue((row) =>
@@ -2345,7 +2346,7 @@ export class Db {
     const updates = toWriteRecord(transformedData, table._schema, table._table);
     const context = this.getRuntimeOperationContext();
     return this.wrapWriteWait(
-      client.update(id, updates, options, context?.session, context?.attribution),
+      client.update(id, updates, options, context?.session, context?.attribution, branchId),
     );
   }
 
@@ -2366,7 +2367,9 @@ export class Db {
   ): WriteHandle {
     const client = this.getClient(table._schema, branchId);
     const context = this.getRuntimeOperationContext();
-    return this.wrapWriteWait(client.delete(id, options, context?.session, context?.attribution));
+    return this.wrapWriteWait(
+      client.delete(id, options, context?.session, context?.attribution, branchId),
+    );
   }
 
   /**
@@ -2548,8 +2551,8 @@ export class Db {
     const context = this.getRuntimeOperationContext();
     const rows =
       context || usesRelationTraversal
-        ? await client.query(wasmQuery, runtimeQueryOptions, context?.session)
-        : await client.query(wasmQuery, queryOptions);
+        ? await client.query(wasmQuery, runtimeQueryOptions, context?.session, branchId)
+        : await client.query(wasmQuery, queryOptions, undefined, branchId);
     const outputIncludes = outputTable !== builtQuery.table ? {} : builtQuery.includes;
     const transformedRows = transformRows(
       rows,

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -2250,7 +2250,7 @@ export class Db {
     data: Init,
     options?: CreateOptions,
   ): WriteResult<T> {
-    const client = this.getClient(table._schema, branchId);
+    const client = this.getClient(table._schema);
     // Don't wait for bridge to be ready in worker mode. Inserts will be propagated once the bridge is ready.
     // If the bridge fails to initialize, the insert will be lost on restart.
     const transformedData = transformInputColumns(table, data);
@@ -2341,7 +2341,7 @@ export class Db {
     data: Partial<Init>,
     options?: UpdateOptions,
   ): WriteHandle {
-    const client = this.getClient(table._schema, branchId);
+    const client = this.getClient(table._schema);
     const transformedData = transformInputColumns(table, data);
     const updates = toWriteRecord(transformedData, table._schema, table._table);
     const context = this.getRuntimeOperationContext();
@@ -2365,7 +2365,7 @@ export class Db {
     id: string,
     options?: DeleteOptions,
   ): WriteHandle {
-    const client = this.getClient(table._schema, branchId);
+    const client = this.getClient(table._schema);
     const context = this.getRuntimeOperationContext();
     return this.wrapWriteWait(
       client.delete(id, options, context?.session, context?.attribution, branchId),
@@ -2523,7 +2523,7 @@ export class Db {
     query: QueryBuilder<T>,
     options?: QueryOptions,
   ): Promise<T[]> {
-    const client = this.getClient(query._schema, branchId);
+    const client = this.getClient(query._schema);
     const scopedQuery = query;
     const runtimeSchema = createRuntimeSchemaResolver(() =>
       normalizeRuntimeSchema(client.getSchema()),
@@ -2667,7 +2667,7 @@ export class Db {
   ): () => void {
     const manager = new SubscriptionManager<T>();
     const { branch, ...executionOptions } = options ?? {};
-    const client = this.getClient(query._schema, branch);
+    const client = this.getClient(query._schema);
     const runtimeSchema = createRuntimeSchemaResolver(() =>
       normalizeRuntimeSchema(client.getSchema()),
     );

--- a/packages/jazz-tools/src/schema-loader.ts
+++ b/packages/jazz-tools/src/schema-loader.ts
@@ -241,7 +241,11 @@ function isPermissionsMap(input: unknown): input is Record<string, TablePolicies
   if (typeof input !== "object" || input === null) {
     return false;
   }
-  return Object.values(input).every((value) => isTablePoliciesLike(value));
+  // `branchPolicies` (from policy.forBranch(...)) is a nested map keyed by
+  // backing table, not a TablePolicies — it is not a table entry.
+  return Object.entries(input).every(
+    ([key, value]) => key === "branchPolicies" || isTablePoliciesLike(value),
+  );
 }
 
 async function loadPermissionsModule(filePath: string): Promise<Record<string, TablePolicies>> {

--- a/packages/jazz-tools/src/schema-permissions.test.ts
+++ b/packages/jazz-tools/src/schema-permissions.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { schema as s } from "./index.js";
 import type { CompiledPermissionsMap } from "./schema-permissions.js";
 import { normalizePermissionsForWasm } from "./schema-permissions.js";
 
@@ -146,5 +147,29 @@ describe("normalizePermissionsForWasm", () => {
         delete: undefined,
       },
     });
+  });
+
+  it("normalizes branch policies with branch-ref operands for wasm", () => {
+    const app = s.defineApp({
+      projects: s.table({ name: s.string(), ownerId: s.string() }),
+      branches: s.table({ projectId: s.ref("projects"), ownerId: s.string() }),
+      todos: s.table({
+        projectId: s.ref("projects"),
+        title: s.string(),
+        ownerId: s.string(),
+      }),
+    });
+    const permissions = s.definePermissions(app, ({ policy, session }) => {
+      policy.branches.allowRead.where({ ownerId: session.user_id });
+      policy.forBranch(policy.branches, ({ $branch, branchPolicy }) => {
+        branchPolicy.todos.allowRead.where({ projectId: $branch.projectId });
+      });
+    });
+
+    const normalized = normalizePermissionsForWasm(permissions);
+    const json = JSON.stringify(normalized);
+    expect(json).toContain("branch_policies");
+    expect(json).toContain("BranchRef");
+    expect(json).toContain("projectId");
   });
 });

--- a/packages/jazz-tools/src/schema-permissions.ts
+++ b/packages/jazz-tools/src/schema-permissions.ts
@@ -1,4 +1,5 @@
 import type {
+  BranchPolicies as WasmBranchPolicies,
   OperationPolicy as WasmOperationPolicy,
   PolicyExpr as WasmPolicyExpr,
   PolicyValue as WasmPolicyValue,
@@ -16,7 +17,16 @@ import type {
   TablePolicies,
 } from "./schema.js";
 
-export type CompiledPermissionsMap = Record<string, TablePolicies>;
+export type BranchPoliciesMap = Record<string, Record<string, TablePolicies>>;
+export type CompiledPermissionsMap = Record<string, TablePolicies> & {
+  branchPolicies?: BranchPoliciesMap;
+};
+export type WasmPermissionsMap = Record<string, WasmTablePolicies> & {
+  branch_policies?: WasmBranchPolicies;
+};
+export type WasmSchemaWithBranchPolicies = WasmSchema & {
+  branch_policies?: WasmBranchPolicies;
+};
 export type ExplicitPolicyOperation = "read" | "insert" | "update" | "delete";
 
 export interface MissingExplicitPolicyDiagnostic {
@@ -146,7 +156,7 @@ function normalizeWasmLiteral(value: unknown): WasmValue {
 }
 
 function normalizePolicyValueForWasm(value: PolicyValue): WasmPolicyValue {
-  if (value.type === "SessionRef") {
+  if (value.type === "SessionRef" || value.type === "BranchRef") {
     return value;
   }
   return {
@@ -410,18 +420,69 @@ function normalizeOperationPolicyForWasm(
   return normalized;
 }
 
+function normalizeBranchPoliciesForWasm(
+  branchPolicies?: BranchPoliciesMap,
+): WasmBranchPolicies | undefined {
+  if (!branchPolicies) {
+    return undefined;
+  }
+
+  const normalized: WasmBranchPolicies = {};
+  for (const [backingTable, policiesByTable] of Object.entries(branchPolicies)) {
+    normalized[backingTable] = {};
+    for (const [tableName, tablePolicies] of Object.entries(policiesByTable)) {
+      normalized[backingTable]![tableName] = {
+        select: normalizeOperationPolicyForWasm(tablePolicies.select),
+        insert: normalizeOperationPolicyForWasm(tablePolicies.insert),
+        update: normalizeOperationPolicyForWasm(tablePolicies.update),
+        delete: normalizeOperationPolicyForWasm(tablePolicies.delete),
+      };
+    }
+  }
+
+  return normalized;
+}
+
 function validatePermissionTables(
   schemaTableNames: readonly string[],
   compiledPermissions: CompiledPermissionsMap,
 ): void {
   const knownTables = new Set(schemaTableNames);
-  const unknownTables = Object.keys(compiledPermissions).filter(
-    (tableName) => !knownTables.has(tableName),
-  );
+  const unknownTables = Object.keys(compiledPermissions).filter((tableName) => {
+    if (tableName === "branchPolicies") {
+      return false;
+    }
+    return !knownTables.has(tableName);
+  });
 
   if (unknownTables.length > 0) {
     throw new Error(
       `permissions.ts defines permissions for unknown table(s): ${unknownTables.join(", ")}.`,
+    );
+  }
+
+  const branchPolicies = compiledPermissions.branchPolicies;
+  if (!branchPolicies) {
+    return;
+  }
+
+  const unknownBranchTables = new Set<string>();
+  for (const [backingTable, policiesByTable] of Object.entries(branchPolicies)) {
+    if (!knownTables.has(backingTable)) {
+      unknownBranchTables.add(backingTable);
+    }
+    for (const tableName of Object.keys(policiesByTable)) {
+      if (!knownTables.has(tableName)) {
+        unknownBranchTables.add(tableName);
+      }
+    }
+  }
+
+  if (unknownBranchTables.size > 0) {
+    throw new Error(
+      `permissions.ts defines branch permissions for unknown table(s): ${[
+        ...unknownBranchTables,
+      ].join(", ")}.`,
     );
   }
 }
@@ -489,15 +550,22 @@ export function collectMissingExplicitPolicyDiagnostics(
 
 export function normalizePermissionsForWasm(
   compiledPermissions: CompiledPermissionsMap,
-): Record<string, WasmTablePolicies> {
-  const normalized: Record<string, WasmTablePolicies> = {};
+): WasmPermissionsMap {
+  const normalized: WasmPermissionsMap = {};
   for (const [tableName, tablePolicies] of Object.entries(compiledPermissions)) {
+    if (tableName === "branchPolicies") {
+      continue;
+    }
     normalized[tableName] = {
       select: normalizeOperationPolicyForWasm(tablePolicies.select),
       insert: normalizeOperationPolicyForWasm(tablePolicies.insert),
       update: normalizeOperationPolicyForWasm(tablePolicies.update),
       delete: normalizeOperationPolicyForWasm(tablePolicies.delete),
     };
+  }
+  const branchPolicies = normalizeBranchPoliciesForWasm(compiledPermissions.branchPolicies);
+  if (branchPolicies) {
+    normalized.branch_policies = branchPolicies;
   }
   return normalized;
 }
@@ -529,16 +597,22 @@ export function mergePermissionsIntoSchema(
 export function mergePermissionsIntoWasmSchema(
   schema: WasmSchema,
   compiledPermissions: CompiledPermissionsMap,
-): WasmSchema {
+): WasmSchemaWithBranchPolicies {
   validatePermissionTables(Object.keys(schema), compiledPermissions);
   const normalizedPermissions = normalizePermissionsForWasm(compiledPermissions);
 
-  const merged: WasmSchema = {};
+  const merged: WasmSchemaWithBranchPolicies = {};
   for (const [tableName, table] of Object.entries(schema)) {
+    if (tableName === "branch_policies") {
+      continue;
+    }
     merged[tableName] = {
       ...table,
       policies: normalizedPermissions[tableName] ?? table.policies,
     };
+  }
+  if (normalizedPermissions.branch_policies) {
+    merged.branch_policies = normalizedPermissions.branch_policies;
   }
   return merged;
 }

--- a/packages/jazz-tools/src/schema.ts
+++ b/packages/jazz-tools/src/schema.ts
@@ -100,6 +100,10 @@ export type PolicyValue =
   | {
       type: "SessionRef";
       path: string[];
+    }
+  | {
+      type: "BranchRef";
+      column: string;
     };
 
 export type PolicyLiteralValue = Extract<PolicyValue, { type: "Literal" }>;

--- a/packages/jazz-tools/src/subscriptions-orchestrator.integration.test.ts
+++ b/packages/jazz-tools/src/subscriptions-orchestrator.integration.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { WasmSchema } from "./drivers/types.js";
+import { schema as s } from "./index.js";
 import { createDb, type Db, type QueryBuilder, type TableProxy } from "./runtime/db.js";
 import { SubscriptionsOrchestrator } from "./subscriptions-orchestrator.js";
 
@@ -44,6 +45,16 @@ const allTodosQuery: QueryBuilder<Todo> = {
   },
 };
 
+const branchApp = s.defineApp({
+  projects: s.table({ name: s.string(), ownerId: s.string() }),
+  branches: s.table({ projectId: s.ref("projects"), ownerId: s.string() }),
+  todos: s.table({
+    projectId: s.ref("projects"),
+    title: s.string(),
+    ownerId: s.string(),
+  }),
+});
+
 async function waitForCondition(
   condition: () => boolean,
   timeoutMs: number,
@@ -76,6 +87,87 @@ async function withRealManager<T>(
 }
 
 describe("SubscriptionsOrchestrator integration coverage", () => {
+  it("SO-I00 branch QueryOptions isolate useAll-style subscriptions", async () => {
+    const appId = `orchestrator-int-branch-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const db = await createDb({
+      appId,
+      driver: { type: "persistent", dbName: appId },
+      cookieSession: { user_id: "alice", claims: {}, authMode: "external" },
+      userBranch: "main",
+    });
+    const manager = new SubscriptionsOrchestrator({ appId }, db);
+
+    try {
+      const projectInsert = db.insert(branchApp.projects, {
+        name: "Website",
+        ownerId: "alice",
+      });
+      await projectInsert.wait({ tier: "local" });
+      const project = projectInsert.value;
+
+      const branchInsert = db.insert(branchApp.branches, {
+        projectId: project.id,
+        ownerId: "alice",
+      });
+      await branchInsert.wait({ tier: "local" });
+      const branch = branchInsert.value;
+
+      const query = branchApp.todos.where({ projectId: project.id });
+      const mainKey = manager.makeQueryKey(query);
+      const branchKey = manager.makeQueryKey(query, { branch: branch.id });
+      const mainEntry = manager.getCacheEntry(mainKey);
+      const branchEntry = manager.getCacheEntry(branchKey);
+      const mainSnapshots: string[][] = [];
+      const branchSnapshots: string[][] = [];
+
+      const unsubscribeMain = mainEntry.subscribe({
+        onfulfilled(data) {
+          mainSnapshots.push(data.map((row) => row.id));
+        },
+        onDelta(delta) {
+          mainSnapshots.push(delta.all.map((row) => row.id));
+        },
+      });
+      const unsubscribeBranch = branchEntry.subscribe({
+        onfulfilled(data) {
+          branchSnapshots.push(data.map((row) => row.id));
+        },
+        onDelta(delta) {
+          branchSnapshots.push(delta.all.map((row) => row.id));
+        },
+      });
+
+      const todoInsert = db.branch(branch.id).insert(branchApp.todos, {
+        projectId: project.id,
+        title: "Draft landing page",
+        ownerId: "alice",
+      });
+      await todoInsert.wait({ tier: "local" });
+      const todo = todoInsert.value;
+      await expect(db.branch(branch.id).all(query)).resolves.toEqual([
+        expect.objectContaining({ id: todo.id }),
+      ]);
+
+      await waitForCondition(
+        () => branchSnapshots.some((snapshot) => snapshot.includes(todo.id)),
+        5_000,
+        "SO-I00 expected branch-scoped subscription to include branch todo",
+      );
+
+      expect(branchSnapshots[branchSnapshots.length - 1]).toContain(todo.id);
+      expect(mainSnapshots.every((snapshot) => !snapshot.includes(todo.id))).toBe(true);
+      if (mainEntry.state.status === "fulfilled") {
+        expect(mainEntry.state.data.some((row) => row.id === todo.id)).toBe(false);
+      }
+
+      unsubscribeMain();
+      unsubscribeBranch();
+    } finally {
+      await manager.shutdown();
+      await db.shutdown();
+    }
+  }, 10_000);
+
   it("SO-I01 first mutation causes first fulfilled cache snapshot", async () => {
     await withRealManager("i01", async ({ manager, db }) => {
       const key = manager.makeQueryKey(allTodosQuery);

--- a/packages/jazz-tools/src/types/jazz-wasm.d.ts
+++ b/packages/jazz-tools/src/types/jazz-wasm.d.ts
@@ -155,6 +155,7 @@ declare module "jazz-wasm" {
     createWorkerBridge(worker: Worker, options: unknown): WasmWorkerBridge;
     getSchema(): unknown;
     getSchemaHash(): string;
+    composeBranchName(userBranch: string): string;
     close?(): void;
 
     /** Derive a deterministic user ID (UUIDv5) from a base64url-encoded seed. */


### PR DESCRIPTION
## Summary

Adds branch-scoped access control to the public Jazz APIs.

- Branches are normal app rows, so apps create and permission them with the existing table APIs.
- `policy.forBranch(policy.branches, ...)` defines the read/write rules for data stored inside each branch.
- `$branch` exposes the backing branch row inside branch policy rules, so branch data can be tied back to fields like `projectId` or `ownerId`.
- `db.branch(branchId)` returns a branch-targeted view for reads and mutations.
- `useAll(query, { branch })` makes reactive reads branch-scoped across React, React Native, Svelte, and Vue.
- Branch access is **deny-by-default**: a session may only touch branch data if it can read the backing branch row *and* a matching branch policy allows the operation.

## API

```ts
const app = s.defineApp({
  projects: s.table({ name: s.string(), ownerId: s.string() }),
  branches: s.table({ projectId: s.ref("projects"), name: s.string(), ownerId: s.string() }),
  todos: s.table({ projectId: s.ref("projects"), title: s.string(), ownerId: s.string() }),
});

const permissions = s.definePermissions(app, ({ policy, session }) => {
  policy.branches.allowRead.where({ ownerId: session.user_id });
  policy.branches.allowInsert.where({ ownerId: session.user_id });

  policy.forBranch(policy.branches, ({ $branch, branchPolicy }) => {
    branchPolicy.todos.allowRead.where({ projectId: $branch.projectId });
    branchPolicy.todos.allowInsert.where({ projectId: $branch.projectId, ownerId: session.user_id });
    branchPolicy.todos.allowUpdate.where({ projectId: $branch.projectId });
    branchPolicy.todos.allowDelete.where({ projectId: $branch.projectId });
  });
});

// Imperative CRUD through a branch view
const branchDb = db.branch(branch.id);
await branchDb.insert(app.todos, { projectId, title, ownerId }).wait({ tier: "edge" });
const draftTodos = await branchDb.all(app.todos.where({ projectId }));

// Reactive reads
const todos = useAll(app.todos.where({ projectId }), { branch: branch.id });
```

## How it works

- **TS DSL** (`permissions/index.ts`): `forBranch` / table-keyed `branchPolicy` / `$branch` proxy; branch rules compile into a `branchPolicies` map carried through the IR and normalized into the WASM permissions payload.
- **Rust core**: a `BranchRef` policy value, a `permission_routing` module that resolves and read-gates the backing branch row (exposed as `$branch`) and dispatches to branch policies, and deny-by-default enforcement wired into reads (`policy_filter`) and writes (`writes.rs`/`server_queries.rs`).
- **Runtime ingestion**: branch policies flow through the schema envelope into the enforcing runtime (NAPI + WASM).
- **Per-operation branch routing**: a runtime is no longer pinned to a single data branch at load. Writes carry their target branch (composed from the runtime's env + schema), the write-path schema-family guard allows any user branch within the env, and `update`/`delete` resolve the row in the target branch's context. This lets one runtime serve all branches for reads, writes, and subscriptions.

## Validation

- `cargo test -p jazz-tools --features test-utils --lib query_manager::rebac_tests::branch_policies` (read + full CRUD, deny-by-default, isolation)
- `cargo test -p jazz-tools --features test-utils --lib query_manager schema_manager` (no regressions)
- `cargo clippy --workspace`, `cargo fmt --check`
- `pnpm --filter jazz-tools exec vitest run src/runtime` (incl. `branch-permissions.integration.test.ts`, `db.branch.test.ts`)
- React / Vue / Svelte `useAll` suites + `subscriptions-orchestrator` branch coverage
- `pnpm --filter jazz-tools exec tsc --noEmit`

## Notes

- The per-operation branch routing is a breaking change to the runtime's internal branch model (branch is no longer chosen at load). It is isolated in its own commit.
- Deferred to follow-ups: query-level `.branch()` modifier and `include` / `union` inputs targeting branches.
