### PR TITLE
Add collaborative editor example

### DIFF
--- a/examples/collab-editor-react/README.md
+++ b/examples/collab-editor-react/README.md
@@ -1,0 +1,33 @@
+# Collaborative Editor React
+
+This example demonstrates Jazz as the durable sync backbone for a collaborative Yjs document.
+Monaco and Yjs handle the in-browser editing model, while Jazz stores the binary Yjs update log
+and periodic full-document snapshots.
+
+## Jazz stores Yjs
+
+Each local edit updates `Y.Doc.getText("monaco")`. The Yjs `update` event is copied into a
+`roomYjsUpdates` row and synced by Jazz. Other tabs and peers read those rows, apply the binary
+updates to their own Yjs document, and Monaco reflects the text through `y-monaco`.
+
+The app also writes debounced snapshots with `Y.encodeStateAsUpdate(doc)` so a new client can
+bootstrap from the latest full state before replaying updates. It intentionally does not use
+awareness or live cursors.
+
+## Run
+
+```sh
+pnpm dev
+```
+
+The Jazz dev plugin (`jazzPlugin()` in `vite.config.ts`) starts a local Jazz server,
+publishes this example's schema, and points the app at it automatically — so collaboration
+works out of the box. Open http://localhost:5173 in two windows, create a room in one, and
+open its **Copy link** URL in the other; edits sync both ways. Edits also persist locally
+(OPFS) across reloads.
+
+> In a headless/CI browser without OPFS support, set `VITE_JAZZ_DRIVER=memory` to keep state
+> in the server only.
+
+The permissions model is intentionally permissive, with open reads, because this is a
+shareable-link demo.

--- a/examples/collab-editor-react/index.html
+++ b/examples/collab-editor-react/index.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Collaborative Editor - Jazz</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        font-family: system-ui, sans-serif;
+        margin: 0;
+        height: 100vh;
+      }
+      #root {
+        height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+      a {
+        color: inherit;
+      }
+      button {
+        font: inherit;
+        cursor: pointer;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/collab-editor-react/package.json
+++ b/examples/collab-editor-react/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "collab-editor-react",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "node ../../packages/jazz-tools/dist/cli.js validate && vite build",
+    "preview": "vite preview",
+    "test": "vitest run --config vitest.config.browser.ts"
+  },
+  "dependencies": {
+    "@monaco-editor/react": "^4.7.0",
+    "jazz-tools": "workspace:*",
+    "monaco-editor": "^0.52.2",
+    "nanoid": "^5.0.9",
+    "react": "19.2.4",
+    "react-dom": "19.2.4",
+    "sonner": "^2.0.7",
+    "unique-names-generator": "^4.7.1",
+    "y-monaco": "^0.1.6",
+    "y-protocols": "^1.0.6",
+    "yjs": "^13.6.21"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "catalog:default",
+    "@vitest/browser": "catalog:default",
+    "@vitest/browser-playwright": "catalog:default",
+    "typescript": "catalog:default",
+    "vite": "catalog:default",
+    "vite-plugin-top-level-await": "catalog:default",
+    "vite-plugin-wasm": "catalog:default",
+    "vitest": "catalog:default"
+  }
+}

--- a/examples/collab-editor-react/permissions.ts
+++ b/examples/collab-editor-react/permissions.ts
@@ -1,0 +1,27 @@
+import { schema as s } from "jazz-tools";
+import { app } from "./schema.js";
+
+// Open-collaboration model, appropriate for a shareable-link demo:
+//  - Anyone can READ any row (so anyone with a room's link can collaborate).
+//  - You may only INSERT rows attributed to your own session user_id.
+//  - Room metadata (title / language) is editable by any collaborator.
+//
+// A production app would tighten reads so that only actual room members can
+// read a room's documents instead of allowing open reads.
+export default s.definePermissions(app, ({ policy, session }) => {
+  policy.rooms.allowRead.where({});
+  policy.rooms.allowInsert.where({ creator_session_user_id: session.user_id });
+  policy.rooms.allowUpdate.always();
+
+  policy.roomParticipants.allowRead.where({});
+  policy.roomParticipants.allowInsert.where({ session_user_id: session.user_id });
+  policy.roomParticipants.allowUpdate
+    .whereOld({ session_user_id: session.user_id })
+    .whereNew({ session_user_id: session.user_id });
+
+  policy.roomYjsUpdates.allowRead.where({});
+  policy.roomYjsUpdates.allowInsert.where({ session_user_id: session.user_id });
+
+  policy.roomYjsSnapshots.allowRead.where({});
+  policy.roomYjsSnapshots.allowInsert.where({ session_user_id: session.user_id });
+});

--- a/examples/collab-editor-react/schema.ts
+++ b/examples/collab-editor-react/schema.ts
@@ -1,0 +1,49 @@
+import { schema as s } from "jazz-tools";
+
+// A collaborative code editor where Jazz is the entire sync backbone:
+// it durably stores Yjs binary updates + periodic snapshots, while Yjs +
+// Monaco handle live text editing on the client.
+const schema = {
+  // One editable document / room. `shareToken` is the opaque id used in the URL.
+  rooms: s.table({
+    shareToken: s.string(),
+    title: s.string(),
+    editorLanguage: s.string().default("plaintext"),
+    creator_session_user_id: s.string(),
+    createdAt: s.timestamp(),
+  }),
+
+  // "Rooms I've opened or created" — used to scope the dashboard list.
+  roomParticipants: s.table({
+    room_id: s.ref("rooms"),
+    session_user_id: s.string(),
+    lastAccessedAt: s.timestamp(),
+  }),
+
+  // Append-only log of Yjs document updates. Each row is one binary Y update.
+  roomYjsUpdates: s.table({
+    room_id: s.ref("rooms"),
+    update: s.bytes(),
+    session_user_id: s.string(),
+    provider_instance_id: s.string(),
+    createdAt: s.timestamp(),
+  }),
+
+  // Periodic full-document snapshots so a fresh client doesn't replay the
+  // entire update log. Bootstrap applies the latest snapshot, then the updates.
+  roomYjsSnapshots: s.table({
+    room_id: s.ref("rooms"),
+    state: s.bytes(),
+    textHash: s.string().optional(),
+    session_user_id: s.string().optional(),
+    createdAt: s.timestamp(),
+  }),
+};
+
+type AppSchema = s.Schema<typeof schema>;
+export const app: s.App<AppSchema> = s.defineApp(schema);
+
+export type Room = s.RowOf<typeof app.rooms>;
+export type RoomParticipant = s.RowOf<typeof app.roomParticipants>;
+export type RoomYjsUpdate = s.RowOf<typeof app.roomYjsUpdates>;
+export type RoomYjsSnapshot = s.RowOf<typeof app.roomYjsSnapshots>;

--- a/examples/collab-editor-react/src/App.tsx
+++ b/examples/collab-editor-react/src/App.tsx
@@ -1,0 +1,86 @@
+import * as React from "react";
+import { JazzProvider, attachDevTools, useJazzClient, useLocalFirstAuth } from "jazz-tools/react";
+import type { DbConfig } from "jazz-tools";
+import Router from "./components/Router.js";
+import { Dashboard } from "./components/Dashboard.js";
+import { Editor } from "./components/Editor.js";
+import { app } from "../schema.js";
+
+const devToolsAttachedClients = new WeakSet<object>();
+
+const appId = import.meta.env.VITE_JAZZ_APP_ID;
+const serverUrl = import.meta.env.VITE_JAZZ_SERVER_URL;
+// Optional: VITE_JAZZ_DRIVER=memory keeps everything in memory and syncs purely
+// through the server (requires VITE_JAZZ_SERVER_URL). Handy for multi-window
+// collaboration demos where local OPFS persistence isn't needed.
+const driver: DbConfig["driver"] | undefined =
+  import.meta.env.VITE_JAZZ_DRIVER === "memory" ? { type: "memory" } : undefined;
+
+// #region context-setup-react
+function defaultConfig(secret: string, overrides: Partial<DbConfig> = {}): DbConfig {
+  return {
+    appId,
+    env: "dev",
+    userBranch: "main",
+    serverUrl,
+    secret,
+    ...(driver ? { driver } : {}),
+    ...overrides,
+  };
+}
+// #endregion context-setup-react
+
+type AppProps = {
+  config?: Partial<DbConfig>;
+  fallback?: React.ReactNode;
+};
+
+function DevToolsRegistration() {
+  const client = useJazzClient();
+
+  React.useEffect(() => {
+    if (devToolsAttachedClients.has(client as object)) {
+      return;
+    }
+
+    void attachDevTools(client, app.wasmSchema);
+    devToolsAttachedClients.add(client as object);
+
+    if (location.origin.includes("localhost")) {
+      Object.defineProperty(window, "jazzClient", {
+        value: client,
+        writable: true,
+      });
+    }
+  }, [client]);
+
+  return null;
+}
+
+function EditorRoute({ params }: { params?: Record<string, string> }) {
+  return <Editor shareToken={params?.shareToken ?? ""} />;
+}
+
+// #region context-setup-react
+export function App({ config, fallback }: AppProps = {}) {
+  const { secret, isLoading } = useLocalFirstAuth();
+
+  if (isLoading || !secret) {
+    return <>{fallback ?? <p>Loading...</p>}</>;
+  }
+
+  const resolvedConfig = defaultConfig(secret, config);
+
+  return (
+    <JazzProvider config={resolvedConfig} fallback={fallback ?? <p>Loading...</p>}>
+      <DevToolsRegistration />
+      <Router
+        routes={[
+          { path: "/", component: Dashboard },
+          { path: "/r/:shareToken", component: EditorRoute },
+        ]}
+      />
+    </JazzProvider>
+  );
+}
+// #endregion context-setup-react

--- a/examples/collab-editor-react/src/components/Dashboard.tsx
+++ b/examples/collab-editor-react/src/components/Dashboard.tsx
@@ -1,0 +1,55 @@
+import { useState } from "react";
+import { toast } from "sonner";
+import { useCreateRoom } from "../hooks/useCreateRoom.js";
+import { useRooms } from "../hooks/useRooms.js";
+import { navigate } from "../hooks/useRouter.js";
+import { getDisplayName } from "../lib/identity.js";
+
+export function Dashboard() {
+  const rooms = useRooms();
+  const createRoom = useCreateRoom();
+  const [isCreating, setIsCreating] = useState(false);
+
+  const handleCreateRoom = async () => {
+    setIsCreating(true);
+    try {
+      const shareToken = await createRoom();
+      navigate(`/r/${shareToken}`);
+    } catch (error) {
+      console.error("Failed to create room", error);
+      toast.error("Could not create a room");
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  return (
+    <main>
+      <header>
+        <p>you are {getDisplayName()}</p>
+        <h1>Collaborative editor</h1>
+        <button
+          type="button"
+          data-testid="new-room"
+          onClick={handleCreateRoom}
+          disabled={isCreating}
+        >
+          New room
+        </button>
+      </header>
+
+      <section>
+        <h2>Your rooms</h2>
+        <ul id="room-list">
+          {rooms.map((room) => (
+            <li key={room.id}>
+              <a className="room-link" href={`/r/${room.shareToken}`}>
+                {room.title}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/examples/collab-editor-react/src/components/Editor.tsx
+++ b/examples/collab-editor-react/src/components/Editor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import "../lib/monaco-setup.js";
 import MonacoEditor, { type OnMount } from "@monaco-editor/react";
 import type * as monaco from "monaco-editor";
@@ -17,6 +17,11 @@ type EditorProps = {
 type MonacoRuntime = {
   editor: monaco.editor.IStandaloneCodeEditor;
   monaco: typeof import("monaco-editor");
+};
+
+// Hoisted so the editor doesn't get a fresh options object on every render.
+const monacoOptions: monaco.editor.IStandaloneEditorConstructionOptions = {
+  minimap: { enabled: false },
 };
 
 function EditorSurface({ room }: { room: Room }) {
@@ -80,7 +85,7 @@ function EditorSurface({ room }: { room: Room }) {
             height="70vh"
             language={room.editorLanguage}
             theme="vs-light"
-            options={{ minimap: { enabled: false } }}
+            options={monacoOptions}
             onMount={handleMount}
           />
         )}
@@ -101,21 +106,31 @@ export function Editor({ shareToken }: EditorProps) {
       : undefined,
   );
 
+  // Record/refresh this room in the user's list once per visit. Writing
+  // `lastAccessedAt` mutates a row this component subscribes to via `useAll`
+  // above, so without this guard the effect would re-fire on its own write —
+  // an infinite write→subscription→write loop. The ref pins the touch to one
+  // run per (room, session); on room change the key changes and we touch again.
+  const touchedRoomRef = useRef<string | null>(null);
+
   useEffect(() => {
     if (!room || !sessionUserId || !participants) return;
+
+    const key = `${room.id}:${sessionUserId}`;
+    if (touchedRoomRef.current === key) return;
+    touchedRoomRef.current = key;
 
     const now = new Date();
     const participant = participants[0];
     if (participant) {
       db.update(app.roomParticipants, participant.id, { lastAccessedAt: now });
-      return;
+    } else {
+      db.insert(app.roomParticipants, {
+        room_id: room.id,
+        session_user_id: sessionUserId,
+        lastAccessedAt: now,
+      });
     }
-
-    db.insert(app.roomParticipants, {
-      room_id: room.id,
-      session_user_id: sessionUserId,
-      lastAccessedAt: now,
-    });
   }, [db, participants, room, sessionUserId]);
 
   if (!rooms) return <p>Loading room...</p>;

--- a/examples/collab-editor-react/src/components/Editor.tsx
+++ b/examples/collab-editor-react/src/components/Editor.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from "react";
+import "../lib/monaco-setup.js";
+import MonacoEditor, { type OnMount } from "@monaco-editor/react";
+import type * as monaco from "monaco-editor";
+import { toast } from "sonner";
+import { useAll, useDb, useSession } from "jazz-tools/react";
+import { app, type Room } from "../../schema.js";
+import { useJazzYjsDocument } from "../hooks/useJazzYjsDocument.js";
+import { useMonacoBinding } from "../hooks/useMonacoBinding.js";
+import { getDisplayName } from "../lib/identity.js";
+import { LanguagePicker } from "./LanguagePicker.js";
+
+type EditorProps = {
+  shareToken: string;
+};
+
+type MonacoRuntime = {
+  editor: monaco.editor.IStandaloneCodeEditor;
+  monaco: typeof import("monaco-editor");
+};
+
+function EditorSurface({ room }: { room: Room }) {
+  const db = useDb();
+  const { ydoc, isReady } = useJazzYjsDocument({ roomId: room.id });
+  const [runtime, setRuntime] = useState<MonacoRuntime | null>(null);
+  const [title, setTitle] = useState(room.title);
+
+  useMonacoBinding({
+    editor: runtime?.editor ?? null,
+    monaco: runtime?.monaco ?? null,
+    ydoc,
+  });
+
+  useEffect(() => {
+    setTitle(room.title);
+  }, [room.title]);
+
+  const handleMount: OnMount = (editor, monacoApi) => {
+    setRuntime({ editor, monaco: monacoApi });
+  };
+
+  const saveTitle = () => {
+    const nextTitle = title.trim() || "Untitled";
+    setTitle(nextTitle);
+    if (nextTitle !== room.title) {
+      db.update(app.rooms, room.id, { title: nextTitle });
+    }
+  };
+
+  const copyLink = async () => {
+    await navigator.clipboard.writeText(window.location.href);
+    toast.success("Link copied");
+  };
+
+  return (
+    <main>
+      <header>
+        <a href="/">Rooms</a>
+        <p>you are {getDisplayName()}</p>
+        <input
+          aria-label="Room title"
+          value={title}
+          onChange={(event) => setTitle(event.target.value)}
+          onBlur={saveTitle}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") event.currentTarget.blur();
+          }}
+        />
+        <LanguagePicker room={room} />
+        <button type="button" onClick={copyLink}>
+          Copy link
+        </button>
+      </header>
+
+      <div data-testid="editor" style={{ height: "70vh", border: "1px solid #ddd" }}>
+        {!isReady ? (
+          <p>Loading editor...</p>
+        ) : (
+          <MonacoEditor
+            height="70vh"
+            language={room.editorLanguage}
+            theme="vs-light"
+            options={{ minimap: { enabled: false } }}
+            onMount={handleMount}
+          />
+        )}
+      </div>
+    </main>
+  );
+}
+
+export function Editor({ shareToken }: EditorProps) {
+  const db = useDb();
+  const session = useSession();
+  const sessionUserId = session?.user_id ?? null;
+  const rooms = useAll(shareToken ? app.rooms.where({ shareToken }) : undefined);
+  const room = rooms?.[0] ?? null;
+  const participants = useAll(
+    room && sessionUserId
+      ? app.roomParticipants.where({ room_id: room.id, session_user_id: sessionUserId })
+      : undefined,
+  );
+
+  useEffect(() => {
+    if (!room || !sessionUserId || !participants) return;
+
+    const now = new Date();
+    const participant = participants[0];
+    if (participant) {
+      db.update(app.roomParticipants, participant.id, { lastAccessedAt: now });
+      return;
+    }
+
+    db.insert(app.roomParticipants, {
+      room_id: room.id,
+      session_user_id: sessionUserId,
+      lastAccessedAt: now,
+    });
+  }, [db, participants, room, sessionUserId]);
+
+  if (!rooms) return <p>Loading room...</p>;
+  if (!room) return <p>Room not found</p>;
+
+  return <EditorSurface room={room} />;
+}

--- a/examples/collab-editor-react/src/components/LanguagePicker.tsx
+++ b/examples/collab-editor-react/src/components/LanguagePicker.tsx
@@ -1,0 +1,30 @@
+import { useDb } from "jazz-tools/react";
+import { app, type Room } from "../../schema.js";
+
+const languages = ["plaintext", "javascript", "typescript", "python", "rust", "json", "markdown"];
+
+type LanguagePickerProps = {
+  room: Room;
+};
+
+export function LanguagePicker({ room }: LanguagePickerProps) {
+  const db = useDb();
+
+  return (
+    <label>
+      Language{" "}
+      <select
+        value={room.editorLanguage}
+        onChange={(event) => {
+          db.update(app.rooms, room.id, { editorLanguage: event.target.value });
+        }}
+      >
+        {languages.map((language) => (
+          <option key={language} value={language}>
+            {language}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/examples/collab-editor-react/src/components/Router.tsx
+++ b/examples/collab-editor-react/src/components/Router.tsx
@@ -1,0 +1,72 @@
+import type React from "react";
+import { useEffect } from "react";
+import { useRouter } from "../hooks/useRouter.js";
+
+interface Route {
+  path: string;
+  component: React.ComponentType<{ params?: Record<string, string> }>;
+}
+
+interface RouterProps {
+  routes: Route[];
+}
+
+export default function Router({ routes }: RouterProps) {
+  const { path, navigate } = useRouter();
+
+  useEffect(() => {
+    const onClick = (event: MouseEvent) => {
+      const link = (event.target as HTMLElement).closest("a");
+      if (
+        !link ||
+        event.defaultPrevented ||
+        event.button !== 0 ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.shiftKey ||
+        event.altKey
+      )
+        return;
+
+      const href = link.getAttribute("href");
+      if (!href || href.startsWith("http") || link.target === "_blank") return;
+
+      event.preventDefault();
+
+      if (href.startsWith("#")) {
+        window.location.hash = href;
+      } else {
+        navigate(href);
+      }
+    };
+
+    window.addEventListener("click", onClick);
+    return () => window.removeEventListener("click", onClick);
+  }, [navigate]);
+
+  for (const route of routes) {
+    const paramNames: string[] = [];
+    const regexPath = route.path.replace(/:([a-zA-Z0-9]+)/g, (_, name) => {
+      paramNames.push(name);
+      return "([^/]+)";
+    });
+
+    const regex = new RegExp(`^${regexPath}$`);
+    const result = path.match(regex);
+
+    if (result) {
+      const params = paramNames.reduce(
+        (acc, name, index) => {
+          acc[name] = decodeURIComponent(result[index + 1]);
+          return acc;
+        },
+        {} as Record<string, string>,
+      );
+      const Component = route.component;
+      return <Component params={params} />;
+    }
+  }
+
+  const FallbackComponent = routes[0].component;
+  return <FallbackComponent />;
+}

--- a/examples/collab-editor-react/src/hooks/JazzYjsDocumentController.ts
+++ b/examples/collab-editor-react/src/hooks/JazzYjsDocumentController.ts
@@ -1,0 +1,138 @@
+import { nanoid } from "nanoid";
+import * as Y from "yjs";
+import type { Db } from "jazz-tools";
+import { app, type RoomYjsSnapshot, type RoomYjsUpdate } from "../../schema.js";
+import { hashString } from "../lib/hash.js";
+import { toUint8Array } from "../lib/yjsUpdate.js";
+
+const snapshotDebounceMs = 2_000;
+const snapshotCoalesceMs = 2 * 60 * 1_000;
+
+function latestSnapshot(rows: RoomYjsSnapshot[]): RoomYjsSnapshot | null {
+  return rows.reduce<RoomYjsSnapshot | null>(
+    (latest, s) => (!latest || s.createdAt.getTime() > latest.createdAt.getTime() ? s : latest),
+    null,
+  );
+}
+
+/**
+ * Owns a Y.Doc and keeps it in sync with Jazz for a single room.
+ *
+ * Subscribes to the room's snapshot and update rows via `db.subscribeAll`,
+ * applies them to the Y.Doc (skipping rows we produced), and persists any
+ * local edits back to Jazz as new update rows + periodic snapshots. Calls
+ * `onReady` once the initial bootstrap has been applied.
+ */
+export class JazzYjsDocumentController {
+  readonly providerInstanceId = nanoid();
+  private readonly remoteOrigin = { provider: "jazz" };
+  private readonly text: Y.Text;
+  private readonly unsubs: Array<() => void> = [];
+
+  private snapshots: RoomYjsSnapshot[] = [];
+  private updates: RoomYjsUpdate[] = [];
+  private appliedUpdateIds = new Set<string>();
+  private didBootstrap = false;
+  private isReady = false;
+  private snapshotTimeout: ReturnType<typeof setTimeout> | undefined;
+
+  constructor(
+    private readonly db: Db,
+    readonly roomId: string,
+    readonly sessionUserId: string,
+    readonly ydoc: Y.Doc,
+    private readonly onReady: () => void,
+  ) {
+    this.text = ydoc.getText("monaco");
+    this.ydoc.on("update", this.onYdocUpdate);
+    this.text.observe(this.onTextChange);
+    this.unsubs.push(
+      this.db.subscribeAll(app.roomYjsSnapshots.where({ room_id: roomId }), ({ all }) => {
+        this.snapshots = all;
+        this.reconcile();
+      }),
+      this.db.subscribeAll(app.roomYjsUpdates.where({ room_id: roomId }), ({ all }) => {
+        this.updates = all;
+        this.reconcile();
+      }),
+    );
+  }
+
+  destroy() {
+    for (const off of this.unsubs) off();
+    this.unsubs.length = 0;
+    if (this.snapshotTimeout) clearTimeout(this.snapshotTimeout);
+    this.ydoc.off("update", this.onYdocUpdate);
+    this.text.unobserve(this.onTextChange);
+  }
+
+  /** Apply the latest snapshot once, then any unapplied (non-local) update rows. */
+  private reconcile() {
+    if (!this.didBootstrap) {
+      const snapshot = latestSnapshot(this.snapshots);
+      if (snapshot) Y.applyUpdate(this.ydoc, toUint8Array(snapshot.state), this.remoteOrigin);
+      this.didBootstrap = true;
+    }
+    for (const row of this.updates) {
+      if (this.appliedUpdateIds.has(row.id)) continue;
+      this.appliedUpdateIds.add(row.id);
+      if (row.provider_instance_id === this.providerInstanceId) continue;
+      Y.applyUpdate(this.ydoc, toUint8Array(row.update), this.remoteOrigin);
+    }
+    if (!this.isReady) {
+      this.isReady = true;
+      this.onReady();
+    }
+  }
+
+  /** Persist each local edit as a new update row. */
+  private onYdocUpdate = (update: Uint8Array, origin: unknown) => {
+    if (origin === this.remoteOrigin || !this.isReady) return;
+    this.db
+      .insert(app.roomYjsUpdates, {
+        room_id: this.roomId,
+        update: new Uint8Array(update),
+        session_user_id: this.sessionUserId,
+        provider_instance_id: this.providerInstanceId,
+        createdAt: new Date(),
+      })
+      .wait({ tier: "edge" })
+      .catch((error: unknown) => {
+        console.error("Failed to persist Yjs update", error);
+      });
+  };
+
+  /** Debounce a snapshot after local text changes settle. */
+  private onTextChange = (_event: Y.YTextEvent, transaction: Y.Transaction) => {
+    if (transaction.origin === this.remoteOrigin) return;
+    if (this.snapshotTimeout) clearTimeout(this.snapshotTimeout);
+    this.snapshotTimeout = setTimeout(() => {
+      this.saveSnapshot().catch((error: unknown) => {
+        console.error("Failed to persist Yjs snapshot", error);
+      });
+    }, snapshotDebounceMs);
+  };
+
+  private async saveSnapshot() {
+    if (!this.isReady) return;
+    const text = this.text.toString();
+    const textHash = await hashString(text);
+    const now = new Date();
+    const latest = latestSnapshot(this.snapshots);
+    if (
+      latest?.textHash === textHash &&
+      now.getTime() - latest.createdAt.getTime() < snapshotCoalesceMs
+    ) {
+      return;
+    }
+    await this.db
+      .insert(app.roomYjsSnapshots, {
+        room_id: this.roomId,
+        state: Y.encodeStateAsUpdate(this.ydoc),
+        textHash,
+        session_user_id: this.sessionUserId,
+        createdAt: now,
+      })
+      .wait({ tier: "local" });
+  }
+}

--- a/examples/collab-editor-react/src/hooks/useCreateRoom.ts
+++ b/examples/collab-editor-react/src/hooks/useCreateRoom.ts
@@ -1,0 +1,33 @@
+import { nanoid } from "nanoid";
+import { useDb, useSession } from "jazz-tools/react";
+import { app } from "../../schema.js";
+
+export function useCreateRoom() {
+  const db = useDb();
+  const session = useSession();
+  const sessionUserId = session?.user_id ?? null;
+
+  return async function createRoom(): Promise<string> {
+    if (!sessionUserId) throw new Error("Cannot create a room before the session is ready");
+
+    const shareToken = nanoid();
+    const now = new Date();
+    const { value: room } = db.insert(app.rooms, {
+      shareToken,
+      title: "Untitled",
+      editorLanguage: "plaintext",
+      creator_session_user_id: sessionUserId,
+      createdAt: now,
+    });
+
+    await db
+      .insert(app.roomParticipants, {
+        room_id: room.id,
+        session_user_id: sessionUserId,
+        lastAccessedAt: now,
+      })
+      .wait({ tier: "edge" });
+
+    return shareToken;
+  };
+}

--- a/examples/collab-editor-react/src/hooks/useJazzYjsDocument.ts
+++ b/examples/collab-editor-react/src/hooks/useJazzYjsDocument.ts
@@ -1,30 +1,11 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import { nanoid } from "nanoid";
-import { useAll, useDb, useSession } from "jazz-tools/react";
+import { useEffect, useState } from "react";
 import * as Y from "yjs";
-import { app, type RoomYjsSnapshot } from "../../schema.js";
-import { hashString } from "../lib/hash.js";
-import { toUint8Array } from "../lib/yjsUpdate.js";
+import { useDb, useSession } from "jazz-tools/react";
+import { JazzYjsDocumentController } from "./JazzYjsDocumentController.js";
 
 type UseJazzYjsDocumentArgs = {
   roomId: string | null;
 };
-
-type Runtime = {
-  roomId: string | null;
-  didBootstrap: boolean;
-  appliedUpdateIds: Set<string>;
-};
-
-const snapshotDebounceMs = 2_000;
-const snapshotCoalesceMs = 2 * 60 * 1_000;
-
-function latestSnapshot(snapshots: RoomYjsSnapshot[]): RoomYjsSnapshot | null {
-  return snapshots.reduce<RoomYjsSnapshot | null>((latest, snapshot) => {
-    if (!latest || snapshot.createdAt.getTime() > latest.createdAt.getTime()) return snapshot;
-    return latest;
-  }, null);
-}
 
 export function useJazzYjsDocument({ roomId }: UseJazzYjsDocumentArgs): {
   ydoc: Y.Doc;
@@ -33,132 +14,24 @@ export function useJazzYjsDocument({ roomId }: UseJazzYjsDocumentArgs): {
   const db = useDb();
   const session = useSession();
   const sessionUserId = session?.user_id ?? null;
-  const [{ ydoc, providerInstanceId }] = useState(() => ({
-    ydoc: new Y.Doc(),
-    providerInstanceId: nanoid(),
-  }));
-  const remoteOrigin = useRef({ provider: "jazz" }).current;
-  const runtimeRef = useRef<Runtime>({
-    roomId: null,
-    didBootstrap: false,
-    appliedUpdateIds: new Set(),
-  });
-  const [readyRoomId, setReadyRoomId] = useState<string | null>(null);
-
-  const snapshotRows = useAll(roomId ? app.roomYjsSnapshots.where({ room_id: roomId }) : undefined);
-  const updateRows = useAll(roomId ? app.roomYjsUpdates.where({ room_id: roomId }) : undefined);
+  const [ydoc] = useState(() => new Y.Doc());
+  const [isReady, setIsReady] = useState(false);
 
   useEffect(() => {
-    return () => ydoc.destroy();
-  }, [ydoc]);
+    setIsReady(false);
+    if (!roomId || !sessionUserId) return;
 
-  useEffect(() => {
-    const runtime = runtimeRef.current;
-    if (runtime.roomId !== roomId) {
-      ydoc.transact(
-        () => ydoc.getText("monaco").delete(0, ydoc.getText("monaco").length),
-        remoteOrigin,
-      );
-      runtime.roomId = roomId;
-      runtime.didBootstrap = false;
-      runtime.appliedUpdateIds = new Set();
-      setReadyRoomId(null);
-    }
-  }, [remoteOrigin, roomId, ydoc]);
+    // The doc is reused across rooms, and applyUpdate merges rather than
+    // replaces — so clear any previous room's text before the new room
+    // bootstraps onto it.
+    const text = ydoc.getText("monaco");
+    ydoc.transact(() => text.delete(0, text.length), { provider: "jazz" });
 
-  useEffect(() => {
-    if (!roomId || !snapshotRows || !updateRows) return;
+    const controller = new JazzYjsDocumentController(db, roomId, sessionUserId, ydoc, () =>
+      setIsReady(true),
+    );
+    return () => controller.destroy();
+  }, [db, roomId, sessionUserId, ydoc]);
 
-    const runtime = runtimeRef.current;
-    if (!runtime.didBootstrap) {
-      const snapshot = latestSnapshot(snapshotRows);
-      if (snapshot) {
-        Y.applyUpdate(ydoc, toUint8Array(snapshot.state), remoteOrigin);
-      }
-      runtime.didBootstrap = true;
-    }
-
-    for (const row of updateRows) {
-      if (runtime.appliedUpdateIds.has(row.id)) continue;
-      runtime.appliedUpdateIds.add(row.id);
-      if (row.provider_instance_id === providerInstanceId) continue;
-
-      Y.applyUpdate(ydoc, toUint8Array(row.update), remoteOrigin);
-    }
-
-    setReadyRoomId(roomId);
-  }, [providerInstanceId, remoteOrigin, roomId, snapshotRows, updateRows, ydoc]);
-
-  useEffect(() => {
-    if (readyRoomId !== roomId || !roomId || !sessionUserId) return;
-
-    const onUpdate = (update: Uint8Array, origin: unknown) => {
-      if (origin === remoteOrigin) return;
-
-      db.insert(app.roomYjsUpdates, {
-        room_id: roomId,
-        update: new Uint8Array(update),
-        session_user_id: sessionUserId,
-        provider_instance_id: providerInstanceId,
-        createdAt: new Date(),
-      })
-        .wait({ tier: "edge" })
-        .catch((error: unknown) => {
-          console.error("Failed to persist Yjs update", error);
-        });
-    };
-
-    ydoc.on("update", onUpdate);
-    return () => ydoc.off("update", onUpdate);
-  }, [db, providerInstanceId, readyRoomId, remoteOrigin, roomId, sessionUserId, ydoc]);
-
-  const latestSnapshotRow = useMemo(() => latestSnapshot(snapshotRows ?? []), [snapshotRows]);
-
-  useEffect(() => {
-    if (readyRoomId !== roomId || !roomId || !sessionUserId) return;
-
-    const ytext = ydoc.getText("monaco");
-    let timeoutId: number | undefined;
-
-    const saveSnapshot = async () => {
-      const text = ytext.toString();
-      const textHash = await hashString(text);
-      const now = new Date();
-
-      if (
-        latestSnapshotRow?.textHash === textHash &&
-        now.getTime() - latestSnapshotRow.createdAt.getTime() < snapshotCoalesceMs
-      ) {
-        return;
-      }
-
-      await db
-        .insert(app.roomYjsSnapshots, {
-          room_id: roomId,
-          state: Y.encodeStateAsUpdate(ydoc),
-          textHash,
-          session_user_id: sessionUserId,
-          createdAt: now,
-        })
-        .wait({ tier: "local" });
-    };
-
-    const onTextChange = (_event: Y.YTextEvent, transaction: Y.Transaction) => {
-      if (transaction.origin === remoteOrigin) return;
-      if (timeoutId) window.clearTimeout(timeoutId);
-      timeoutId = window.setTimeout(() => {
-        saveSnapshot().catch((error: unknown) => {
-          console.error("Failed to persist Yjs snapshot", error);
-        });
-      }, snapshotDebounceMs);
-    };
-
-    ytext.observe(onTextChange);
-    return () => {
-      if (timeoutId) window.clearTimeout(timeoutId);
-      ytext.unobserve(onTextChange);
-    };
-  }, [db, latestSnapshotRow, readyRoomId, remoteOrigin, roomId, sessionUserId, ydoc]);
-
-  return { ydoc, isReady: readyRoomId === roomId && !!roomId };
+  return { ydoc, isReady };
 }

--- a/examples/collab-editor-react/src/hooks/useJazzYjsDocument.ts
+++ b/examples/collab-editor-react/src/hooks/useJazzYjsDocument.ts
@@ -1,0 +1,164 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { nanoid } from "nanoid";
+import { useAll, useDb, useSession } from "jazz-tools/react";
+import * as Y from "yjs";
+import { app, type RoomYjsSnapshot } from "../../schema.js";
+import { hashString } from "../lib/hash.js";
+import { toUint8Array } from "../lib/yjsUpdate.js";
+
+type UseJazzYjsDocumentArgs = {
+  roomId: string | null;
+};
+
+type Runtime = {
+  roomId: string | null;
+  didBootstrap: boolean;
+  appliedUpdateIds: Set<string>;
+};
+
+const snapshotDebounceMs = 2_000;
+const snapshotCoalesceMs = 2 * 60 * 1_000;
+
+function latestSnapshot(snapshots: RoomYjsSnapshot[]): RoomYjsSnapshot | null {
+  return snapshots.reduce<RoomYjsSnapshot | null>((latest, snapshot) => {
+    if (!latest || snapshot.createdAt.getTime() > latest.createdAt.getTime()) return snapshot;
+    return latest;
+  }, null);
+}
+
+export function useJazzYjsDocument({ roomId }: UseJazzYjsDocumentArgs): {
+  ydoc: Y.Doc;
+  isReady: boolean;
+} {
+  const db = useDb();
+  const session = useSession();
+  const sessionUserId = session?.user_id ?? null;
+  const [{ ydoc, providerInstanceId }] = useState(() => ({
+    ydoc: new Y.Doc(),
+    providerInstanceId: nanoid(),
+  }));
+  const remoteOrigin = useRef({ provider: "jazz" }).current;
+  const runtimeRef = useRef<Runtime>({
+    roomId: null,
+    didBootstrap: false,
+    appliedUpdateIds: new Set(),
+  });
+  const [readyRoomId, setReadyRoomId] = useState<string | null>(null);
+
+  const snapshotRows = useAll(roomId ? app.roomYjsSnapshots.where({ room_id: roomId }) : undefined);
+  const updateRows = useAll(roomId ? app.roomYjsUpdates.where({ room_id: roomId }) : undefined);
+
+  useEffect(() => {
+    return () => ydoc.destroy();
+  }, [ydoc]);
+
+  useEffect(() => {
+    const runtime = runtimeRef.current;
+    if (runtime.roomId !== roomId) {
+      ydoc.transact(
+        () => ydoc.getText("monaco").delete(0, ydoc.getText("monaco").length),
+        remoteOrigin,
+      );
+      runtime.roomId = roomId;
+      runtime.didBootstrap = false;
+      runtime.appliedUpdateIds = new Set();
+      setReadyRoomId(null);
+    }
+  }, [remoteOrigin, roomId, ydoc]);
+
+  useEffect(() => {
+    if (!roomId || !snapshotRows || !updateRows) return;
+
+    const runtime = runtimeRef.current;
+    if (!runtime.didBootstrap) {
+      const snapshot = latestSnapshot(snapshotRows);
+      if (snapshot) {
+        Y.applyUpdate(ydoc, toUint8Array(snapshot.state), remoteOrigin);
+      }
+      runtime.didBootstrap = true;
+    }
+
+    for (const row of updateRows) {
+      if (runtime.appliedUpdateIds.has(row.id)) continue;
+      runtime.appliedUpdateIds.add(row.id);
+      if (row.provider_instance_id === providerInstanceId) continue;
+
+      Y.applyUpdate(ydoc, toUint8Array(row.update), remoteOrigin);
+    }
+
+    setReadyRoomId(roomId);
+  }, [providerInstanceId, remoteOrigin, roomId, snapshotRows, updateRows, ydoc]);
+
+  useEffect(() => {
+    if (readyRoomId !== roomId || !roomId || !sessionUserId) return;
+
+    const onUpdate = (update: Uint8Array, origin: unknown) => {
+      if (origin === remoteOrigin) return;
+
+      db.insert(app.roomYjsUpdates, {
+        room_id: roomId,
+        update: new Uint8Array(update),
+        session_user_id: sessionUserId,
+        provider_instance_id: providerInstanceId,
+        createdAt: new Date(),
+      })
+        .wait({ tier: "edge" })
+        .catch((error: unknown) => {
+          console.error("Failed to persist Yjs update", error);
+        });
+    };
+
+    ydoc.on("update", onUpdate);
+    return () => ydoc.off("update", onUpdate);
+  }, [db, providerInstanceId, readyRoomId, remoteOrigin, roomId, sessionUserId, ydoc]);
+
+  const latestSnapshotRow = useMemo(() => latestSnapshot(snapshotRows ?? []), [snapshotRows]);
+
+  useEffect(() => {
+    if (readyRoomId !== roomId || !roomId || !sessionUserId) return;
+
+    const ytext = ydoc.getText("monaco");
+    let timeoutId: number | undefined;
+
+    const saveSnapshot = async () => {
+      const text = ytext.toString();
+      const textHash = await hashString(text);
+      const now = new Date();
+
+      if (
+        latestSnapshotRow?.textHash === textHash &&
+        now.getTime() - latestSnapshotRow.createdAt.getTime() < snapshotCoalesceMs
+      ) {
+        return;
+      }
+
+      await db
+        .insert(app.roomYjsSnapshots, {
+          room_id: roomId,
+          state: Y.encodeStateAsUpdate(ydoc),
+          textHash,
+          session_user_id: sessionUserId,
+          createdAt: now,
+        })
+        .wait({ tier: "local" });
+    };
+
+    const onTextChange = (_event: Y.YTextEvent, transaction: Y.Transaction) => {
+      if (transaction.origin === remoteOrigin) return;
+      if (timeoutId) window.clearTimeout(timeoutId);
+      timeoutId = window.setTimeout(() => {
+        saveSnapshot().catch((error: unknown) => {
+          console.error("Failed to persist Yjs snapshot", error);
+        });
+      }, snapshotDebounceMs);
+    };
+
+    ytext.observe(onTextChange);
+    return () => {
+      if (timeoutId) window.clearTimeout(timeoutId);
+      ytext.unobserve(onTextChange);
+    };
+  }, [db, latestSnapshotRow, readyRoomId, remoteOrigin, roomId, sessionUserId, ydoc]);
+
+  return { ydoc, isReady: readyRoomId === roomId && !!roomId };
+}

--- a/examples/collab-editor-react/src/hooks/useMonacoBinding.ts
+++ b/examples/collab-editor-react/src/hooks/useMonacoBinding.ts
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+import type * as monaco from "monaco-editor";
+import * as Y from "yjs";
+// y-monaco's MonacoBinding keeps a Monaco text model in sync with a Y.Text.
+// We pass no awareness argument — this example has no live cursors.
+import { MonacoBinding } from "y-monaco";
+
+type UseMonacoBindingArgs = {
+  editor: monaco.editor.IStandaloneCodeEditor | null;
+  monaco: typeof import("monaco-editor") | null;
+  ydoc: Y.Doc;
+};
+
+export function useMonacoBinding({ editor, monaco, ydoc }: UseMonacoBindingArgs) {
+  useEffect(() => {
+    if (!editor || !monaco) return;
+
+    const model = editor.getModel();
+    if (!model) return;
+
+    const binding = new MonacoBinding(ydoc.getText("monaco"), model, new Set([editor]));
+    return () => binding.destroy();
+  }, [editor, monaco, ydoc]);
+}

--- a/examples/collab-editor-react/src/hooks/useRooms.ts
+++ b/examples/collab-editor-react/src/hooks/useRooms.ts
@@ -1,0 +1,27 @@
+import { useAll, useSession } from "jazz-tools/react";
+import { app, type Room } from "../../schema.js";
+
+type RoomWithLastAccessed = Room & {
+  lastAccessedAt: Date;
+};
+
+export function useRooms(): RoomWithLastAccessed[] {
+  const session = useSession();
+  const sessionUserId = session?.user_id ?? null;
+  const participants = useAll(
+    sessionUserId ? app.roomParticipants.where({ session_user_id: sessionUserId }) : undefined,
+  );
+  const rooms = useAll(app.rooms) ?? [];
+
+  if (!participants) return [];
+
+  const roomById = new Map(rooms.map((room) => [room.id, room]));
+  return participants
+    .map((participant) => {
+      const room = roomById.get(participant.room_id);
+      if (!room) return null;
+      return { ...room, lastAccessedAt: participant.lastAccessedAt };
+    })
+    .filter((room): room is RoomWithLastAccessed => room !== null)
+    .sort((a, b) => b.lastAccessedAt.getTime() - a.lastAccessedAt.getTime());
+}

--- a/examples/collab-editor-react/src/hooks/useRouter.ts
+++ b/examples/collab-editor-react/src/hooks/useRouter.ts
@@ -1,0 +1,32 @@
+import { useSyncExternalStore } from "react";
+
+function subscribe(callback: () => void) {
+  window.addEventListener("popstate", callback);
+  window.addEventListener("hashchange", callback);
+  return () => {
+    window.removeEventListener("popstate", callback);
+    window.removeEventListener("hashchange", callback);
+  };
+}
+
+export function useRouter() {
+  const path = useSyncExternalStore(
+    subscribe,
+    () => window.location.hash.slice(1) || window.location.pathname || "/",
+  );
+
+  return {
+    path,
+    isActive: (p: string, exact = true) => (exact ? path === p : path.startsWith(p)),
+    navigate: (href: string) => navigate(href),
+  };
+}
+
+export function navigate(href: string) {
+  if (href.startsWith("#")) {
+    window.location.hash = href;
+  } else {
+    window.history.pushState({}, "", href);
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  }
+}

--- a/examples/collab-editor-react/src/lib/hash.ts
+++ b/examples/collab-editor-react/src/lib/hash.ts
@@ -1,0 +1,5 @@
+export async function hashString(text: string): Promise<string> {
+  const data = new TextEncoder().encode(text);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}

--- a/examples/collab-editor-react/src/lib/identity.ts
+++ b/examples/collab-editor-react/src/lib/identity.ts
@@ -1,0 +1,16 @@
+import { adjectives, animals, uniqueNamesGenerator } from "unique-names-generator";
+
+const displayNameKey = "collab-editor:displayName";
+
+export function getDisplayName(): string {
+  const stored = localStorage.getItem(displayNameKey);
+  if (stored) return stored;
+
+  const displayName = uniqueNamesGenerator({
+    dictionaries: [adjectives, animals],
+    separator: "-",
+    length: 2,
+  });
+  localStorage.setItem(displayNameKey, displayName);
+  return displayName;
+}

--- a/examples/collab-editor-react/src/lib/monaco-setup.ts
+++ b/examples/collab-editor-react/src/lib/monaco-setup.ts
@@ -1,0 +1,18 @@
+// Make @monaco-editor/react use the bundled `monaco-editor` package instead of
+// fetching it from a CDN, and wire up Monaco's web workers the Vite way. This
+// keeps the example fully self-contained (works offline + in browser tests).
+import { loader } from "@monaco-editor/react";
+import * as monaco from "monaco-editor";
+import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
+import jsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
+import tsWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker";
+
+self.MonacoEnvironment = {
+  getWorker(_workerId, label) {
+    if (label === "json") return new jsonWorker();
+    if (label === "typescript" || label === "javascript") return new tsWorker();
+    return new editorWorker();
+  },
+};
+
+loader.config({ monaco });

--- a/examples/collab-editor-react/src/lib/yjsUpdate.ts
+++ b/examples/collab-editor-react/src/lib/yjsUpdate.ts
@@ -1,0 +1,5 @@
+export function toUint8Array(bytes: Uint8Array | ArrayBuffer | number[]): Uint8Array {
+  if (bytes instanceof Uint8Array) return bytes;
+  if (bytes instanceof ArrayBuffer) return new Uint8Array(bytes);
+  return new Uint8Array(bytes);
+}

--- a/examples/collab-editor-react/src/main.tsx
+++ b/examples/collab-editor-react/src/main.tsx
@@ -1,0 +1,11 @@
+import { createRoot } from "react-dom/client";
+import { App } from "./App.js";
+import { Suspense } from "react";
+import { Toaster } from "sonner";
+
+createRoot(document.getElementById("root")!).render(
+  <Suspense fallback={<div>Loading...</div>}>
+    <App />
+    <Toaster />
+  </Suspense>,
+);

--- a/examples/collab-editor-react/src/vite-env.d.ts
+++ b/examples/collab-editor-react/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/collab-editor-react/tests/browser/collab-editor.test.tsx
+++ b/examples/collab-editor-react/tests/browser/collab-editor.test.tsx
@@ -1,0 +1,267 @@
+/**
+ * Browser tests for the collaborative editor example.
+ *
+ * The core claim of this example is: **Jazz is the durable sync backbone for a
+ * Yjs document.** These tests verify that claim end to end against a real local
+ * Jazz server (started in global-setup):
+ *
+ *  1. Editing through the real <App /> + Monaco persists the document and it is
+ *     restored after the app is unmounted and remounted (OPFS + server).
+ *  2. Two independent clients editing the same room converge — a Yjs edit on one
+ *     client's document surfaces on the other, carried entirely by Jazz rows.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { createRoot, type Root } from "react-dom/client";
+import { act, useEffect, useState } from "react";
+import * as monaco from "monaco-editor";
+import { nanoid } from "nanoid";
+import { JazzProvider, useDb, useSession } from "jazz-tools/react";
+import type { DbConfig } from "jazz-tools";
+import { App } from "../../src/App.js";
+import { useJazzYjsDocument } from "../../src/hooks/useJazzYjsDocument.js";
+import { app } from "../../schema.js";
+import { TEST_PORT, APP_ID, ADMIN_SECRET } from "./test-constants.js";
+import type * as Y from "yjs";
+
+const SERVER_URL = `http://127.0.0.1:${TEST_PORT}`;
+// Two distinct, valid local-first secrets => two distinct users.
+const SECRET_A = "Tb9eLjnS22z-_s9FK0EtiFIIRDe4EAygLAdni55RvAs";
+const SECRET_B = "VDOGX2nez-5T9Lgk4VfYMT33Qsa6J4loRAoKLZpvxBg";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const mounts: Array<{ root: Root; container: HTMLDivElement }> = [];
+
+function uniqueDbName(label: string): string {
+  return `test-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function waitFor(check: () => boolean, timeoutMs: number, message: string): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (check()) return;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(`Timeout: ${message}`);
+}
+
+async function mount(node: React.ReactNode): Promise<{ root: Root; el: HTMLDivElement }> {
+  const el = document.createElement("div");
+  document.body.appendChild(el);
+  const root = createRoot(el);
+  mounts.push({ root, container: el });
+  await act(async () => {
+    root.render(node);
+  });
+  return { root, el };
+}
+
+async function unmount(root: Root): Promise<void> {
+  const idx = mounts.findIndex((m) => m.root === root);
+  await act(async () => root.unmount());
+  if (idx !== -1) {
+    mounts[idx].container.remove();
+    mounts.splice(idx, 1);
+  }
+  // Give OPFS handles / workers time to release.
+  await new Promise((r) => setTimeout(r, 250));
+}
+
+afterEach(async () => {
+  for (const { root, container } of mounts) {
+    try {
+      await act(async () => root.unmount());
+    } catch {
+      /* best effort */
+    }
+    container.remove();
+  }
+  mounts.length = 0;
+  for (const model of monaco.editor.getModels()) model.dispose();
+  history.replaceState({}, "", "/");
+});
+
+// ---------------------------------------------------------------------------
+// 1. Persistence through the real app + Monaco
+// ---------------------------------------------------------------------------
+
+describe("collab editor — persistence", () => {
+  it("persists the document through Monaco and restores it after remount", async () => {
+    const dbName = uniqueDbName("persist");
+    const config: Partial<DbConfig> = {
+      appId: APP_ID,
+      serverUrl: SERVER_URL,
+      adminSecret: ADMIN_SECRET,
+      auth: { localFirstSecret: SECRET_A },
+      driver: { type: "persistent", dbName },
+    };
+
+    // --- session 1: create a room, type into the editor ---
+    history.replaceState({}, "", "/");
+    const { root: root1 } = await mount(<App config={config} />);
+
+    await waitFor(
+      () => document.querySelector<HTMLButtonElement>("[data-testid='new-room']") !== null,
+      8000,
+      "dashboard should render",
+    );
+
+    await act(async () => {
+      document.querySelector<HTMLButtonElement>("[data-testid='new-room']")!.click();
+    });
+
+    await waitFor(() => location.pathname.startsWith("/r/"), 8000, "should navigate to a room");
+    const shareToken = location.pathname.replace("/r/", "");
+
+    await waitFor(() => monaco.editor.getModels().length > 0, 10000, "monaco model should mount");
+    const model = monaco.editor.getModels()[0]!;
+
+    // y-monaco initializes the model from the (empty) Y.Text when its binding
+    // attaches. Wait for the binding before editing, otherwise it would clobber
+    // the edit back to empty.
+    await new Promise((r) => setTimeout(r, 1000));
+    await act(async () => {
+      model.setValue("hello from jazz");
+    });
+    await waitFor(
+      () => model.getValue() === "hello from jazz",
+      3000,
+      "edit should stick once the Yjs binding is attached",
+    );
+
+    // Let the Yjs update persist to the server (tier "edge") and a snapshot form.
+    await new Promise((r) => setTimeout(r, 2500));
+
+    await unmount(root1);
+    expect(monaco.editor.getModels().length).toBe(0);
+
+    // --- session 2: reopen the same room from a fresh app instance ---
+    history.replaceState({}, "", `/r/${shareToken}`);
+    await mount(<App config={config} />);
+
+    await waitFor(() => monaco.editor.getModels().length > 0, 10000, "monaco should remount");
+    const restored = monaco.editor.getModels()[0]!;
+
+    await waitFor(
+      () => restored.getValue() === "hello from jazz",
+      10000,
+      "document should be restored from Jazz storage",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Two clients converge through the server
+// ---------------------------------------------------------------------------
+
+type DocHandle = { ydoc: Y.Doc };
+
+/**
+ * Minimal harness around the real `useJazzYjsDocument` hook. Creates a room when
+ * none is provided, then exposes the bound Y.Doc once the hook is ready. No
+ * Monaco — we drive and read the Y.Doc directly so two clients can coexist on
+ * one page without sharing Monaco's global model registry.
+ */
+function DocClient(props: {
+  providedRoomId?: string;
+  onRoom?: (roomId: string) => void;
+  onReady: (handle: DocHandle) => void;
+}) {
+  const db = useDb();
+  const session = useSession();
+  const sessionUserId = session?.user_id ?? null;
+  const [roomId, setRoomId] = useState<string | null>(props.providedRoomId ?? null);
+
+  useEffect(() => {
+    if (props.providedRoomId || roomId || !sessionUserId) return;
+    const now = new Date();
+    const { value: room } = db.insert(app.rooms, {
+      shareToken: nanoid(),
+      title: "Untitled",
+      editorLanguage: "plaintext",
+      creator_session_user_id: sessionUserId,
+      createdAt: now,
+    });
+    db.insert(app.roomParticipants, {
+      room_id: room.id,
+      session_user_id: sessionUserId,
+      lastAccessedAt: now,
+    });
+    setRoomId(room.id);
+    props.onRoom?.(room.id);
+  }, [db, props, roomId, sessionUserId]);
+
+  const { ydoc, isReady } = useJazzYjsDocument({ roomId });
+
+  useEffect(() => {
+    if (isReady) props.onReady({ ydoc });
+  }, [isReady, props, ydoc]);
+
+  return null;
+}
+
+function clientConfig(secret: string): DbConfig {
+  return {
+    appId: APP_ID,
+    env: "dev",
+    userBranch: "main",
+    serverUrl: SERVER_URL,
+    secret,
+    driver: { type: "memory" },
+  };
+}
+
+describe("collab editor — multi-client convergence", () => {
+  it("syncs a Yjs edit from one client to another through Jazz", async () => {
+    let roomId: string | null = null;
+    let docA: DocHandle | null = null;
+    let docB: DocHandle | null = null;
+
+    // Client A creates the room and binds a document.
+    await mount(
+      <JazzProvider config={clientConfig(SECRET_A)} fallback={null}>
+        <DocClient
+          onRoom={(id) => {
+            roomId = id;
+          }}
+          onReady={(handle) => {
+            docA = handle;
+          }}
+        />
+      </JazzProvider>,
+    );
+
+    await waitFor(() => roomId !== null && docA !== null, 12000, "client A should be ready");
+
+    // Client B joins the same room.
+    await mount(
+      <JazzProvider config={clientConfig(SECRET_B)} fallback={null}>
+        <DocClient
+          providedRoomId={roomId!}
+          onReady={(handle) => {
+            docB = handle;
+          }}
+        />
+      </JazzProvider>,
+    );
+
+    await waitFor(() => docB !== null, 12000, "client B should be ready");
+
+    // Edit on A's document...
+    await act(async () => {
+      docA!.ydoc.getText("monaco").insert(0, "hello world");
+    });
+
+    // ...and expect it to converge on B, carried entirely by Jazz rows.
+    await waitFor(
+      () => docB!.ydoc.getText("monaco").toString() === "hello world",
+      15000,
+      "edit on client A should converge on client B",
+    );
+
+    expect(docB!.ydoc.getText("monaco").toString()).toBe("hello world");
+  });
+});

--- a/examples/collab-editor-react/tests/browser/global-setup.ts
+++ b/examples/collab-editor-react/tests/browser/global-setup.ts
@@ -1,0 +1,107 @@
+import { join } from "node:path";
+import { startLocalJazzServer, pushSchemaCatalogue } from "jazz-tools/testing";
+import {
+  EDGE_TEST_PORT,
+  CORE_TEST_PORT,
+  TEST_PORT,
+  JWT_SECRET,
+  ADMIN_SECRET,
+  APP_ID,
+} from "./test-constants.js";
+
+export { TEST_PORT, JWT_SECRET, ADMIN_SECRET, APP_ID };
+
+type LocalServer = Awaited<ReturnType<typeof startLocalJazzServer>>;
+
+let coreServer: LocalServer | null = null;
+let edgeServer: LocalServer | null = null;
+let setupPromise: Promise<void> | null = null;
+
+async function waitUntil(
+  message: string,
+  check: () => Promise<boolean>,
+  timeoutMs = 30_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      if (await check()) return;
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  const detail = lastError instanceof Error ? `: ${lastError.message}` : "";
+  throw new Error(`Timed out waiting for ${message}${detail}`);
+}
+
+async function fetchJson<T>(url: string): Promise<T | null> {
+  const response = await fetch(url, {
+    headers: {
+      "X-Jazz-Admin-Secret": ADMIN_SECRET,
+    },
+  });
+
+  if (!response.ok) return null;
+  return (await response.json()) as T;
+}
+
+async function waitForCatalogueOnEdge(edge: LocalServer, schemaHash: string): Promise<void> {
+  await waitUntil(`schema ${schemaHash} to propagate to the edge server`, async () => {
+    const body = await fetchJson<{ hashes?: string[] }>(`${edge.url}/apps/${edge.appId}/schemas`);
+    return body?.hashes?.includes(schemaHash) ?? false;
+  });
+
+  await waitUntil(
+    `permissions for schema ${schemaHash} to propagate to the edge server`,
+    async () => {
+      const body = await fetchJson<{ head?: { schemaHash?: string } | null }>(
+        `${edge.url}/apps/${edge.appId}/admin/permissions/head`,
+      );
+      return body?.head?.schemaHash === schemaHash;
+    },
+  );
+}
+
+export async function setup(): Promise<void> {
+  if (!setupPromise) {
+    setupPromise = (async () => {
+      coreServer = await startLocalJazzServer({
+        appId: APP_ID,
+        port: CORE_TEST_PORT,
+        adminSecret: ADMIN_SECRET,
+        inMemory: true,
+      });
+
+      edgeServer = await startLocalJazzServer({
+        appId: APP_ID,
+        port: EDGE_TEST_PORT,
+        adminSecret: ADMIN_SECRET,
+        upstreamUrl: coreServer.url,
+        inMemory: true,
+      });
+
+      const { hash } = await pushSchemaCatalogue({
+        serverUrl: coreServer.url,
+        appId: coreServer.appId,
+        adminSecret: coreServer.adminSecret!,
+        schemaDir: join(import.meta.dirname, "../.."),
+      });
+
+      await waitForCatalogueOnEdge(edgeServer, hash);
+    })();
+  }
+
+  await setupPromise;
+}
+
+export async function teardown(): Promise<void> {
+  await edgeServer?.stop();
+  await coreServer?.stop();
+  edgeServer = null;
+  coreServer = null;
+  setupPromise = null;
+}

--- a/examples/collab-editor-react/tests/browser/setup-react.ts
+++ b/examples/collab-editor-react/tests/browser/setup-react.ts
@@ -1,0 +1,5 @@
+(
+  globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  }
+).IS_REACT_ACT_ENVIRONMENT = true;

--- a/examples/collab-editor-react/tests/browser/test-constants.ts
+++ b/examples/collab-editor-react/tests/browser/test-constants.ts
@@ -1,0 +1,9 @@
+/** Shared constants for browser tests — no Node.js imports. */
+export const EDGE_TEST_PORT = 19878;
+export const CORE_TEST_PORT = 19892;
+export const TEST_PORT = EDGE_TEST_PORT;
+export const EDGE_SERVER_URL = `http://127.0.0.1:${EDGE_TEST_PORT}`;
+export const CORE_SERVER_URL = `http://127.0.0.1:${CORE_TEST_PORT}`;
+export const JWT_SECRET = "test-jwt-secret-for-collab-editor-browser-tests";
+export const ADMIN_SECRET = "test-admin-secret-for-collab-editor-browser-tests";
+export const APP_ID = "b9268e28-8dc4-45fe-9a50-f56df7cc75ef";

--- a/examples/collab-editor-react/tsconfig.json
+++ b/examples/collab-editor-react/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src", "schema.ts", "permissions.ts"]
+}

--- a/examples/collab-editor-react/vite.config.ts
+++ b/examples/collab-editor-react/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { jazzPlugin } from "jazz-tools/dev/vite";
+
+export default defineConfig({
+  plugins: [react(), jazzPlugin()],
+});

--- a/examples/collab-editor-react/vitest.config.browser.ts
+++ b/examples/collab-editor-react/vitest.config.browser.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from "vitest/config";
+import wasm from "vite-plugin-wasm";
+import topLevelAwait from "vite-plugin-top-level-await";
+import react from "@vitejs/plugin-react";
+import { playwright } from "@vitest/browser-playwright";
+
+export default defineConfig({
+  plugins: [wasm(), topLevelAwait(), react()],
+  worker: {
+    plugins: () => [wasm(), topLevelAwait()],
+  },
+  test: {
+    browser: {
+      enabled: true,
+      provider: playwright(),
+      instances: [{ browser: "chromium", headless: true }],
+    },
+    include: ["tests/browser/**/*.test.tsx"],
+    globalSetup: ["tests/browser/global-setup.ts"],
+    setupFiles: ["tests/browser/setup-react.ts"],
+    testTimeout: 30000,
+    sequence: {
+      concurrent: false,
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -669,6 +669,73 @@ importers:
         specifier: ^4.80.0
         version: 4.80.0
 
+  examples/collab-editor-react:
+    dependencies:
+      '@monaco-editor/react':
+        specifier: ^4.7.0
+        version: 4.7.0(monaco-editor@0.52.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      jazz-tools:
+        specifier: workspace:*
+        version: link:../../packages/jazz-tools
+      monaco-editor:
+        specifier: ^0.52.2
+        version: 0.52.2
+      nanoid:
+        specifier: ^5.0.9
+        version: 5.1.15
+      react:
+        specifier: 19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: 19.2.4
+        version: 19.2.4(react@19.2.4)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      unique-names-generator:
+        specifier: ^4.7.1
+        version: 4.7.1
+      y-monaco:
+        specifier: ^0.1.6
+        version: 0.1.6(monaco-editor@0.52.2)(yjs@13.6.31)
+      y-protocols:
+        specifier: ^1.0.6
+        version: 1.0.7(yjs@13.6.31)
+      yjs:
+        specifier: ^13.6.21
+        version: 13.6.31
+    devDependencies:
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: catalog:default
+        version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/browser':
+        specifier: catalog:default
+        version: 4.1.0(vite@8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)
+      '@vitest/browser-playwright':
+        specifier: catalog:default
+        version: 4.1.0(playwright@1.58.2)(vite@8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)
+      typescript:
+        specifier: catalog:default
+        version: 6.0.2
+      vite:
+        specifier: catalog:default
+        version: 8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite-plugin-top-level-await:
+        specifier: catalog:default
+        version: 1.6.0(rollup@4.59.0)(vite@8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vite-plugin-wasm:
+        specifier: catalog:default
+        version: 3.6.0(vite@8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest:
+        specifier: catalog:default
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+
   examples/docs/todo-client-localfirst-expo:
     dependencies:
       expo:
@@ -704,7 +771,7 @@ importers:
         version: 19.2.14
       babel-preset-expo:
         specifier: ~54.0.10
-        version: 54.0.10(@babel/core@7.29.0)(@babel/runtime@7.28.6)(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-refresh@0.14.2)
+        version: 54.0.10(@babel/core@7.29.0)(@babel/runtime@7.29.7)(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-refresh@0.17.0)
       typescript:
         specifier: catalog:default
         version: 6.0.2
@@ -4271,6 +4338,16 @@ packages:
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
+
+  '@monaco-editor/loader@1.7.0':
+    resolution: {integrity: sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==}
+
+  '@monaco-editor/react@4.7.0':
+    resolution: {integrity: sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==}
+    peerDependencies:
+      monaco-editor: '>= 0.25.0 < 1'
+      react: 19.2.4
+      react-dom: 19.2.4
 
   '@multiavatar/multiavatar@1.0.7':
     resolution: {integrity: sha512-Yg9Uw57bmlErsWL0CSv4d6D4ZqVBE00OZmYr9MRgygoXZdboNtsEI6FbBRw1AY8l88Sm1ARcyojtlm2uwUn0Zg==}
@@ -9294,6 +9371,9 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isomorphic.js@0.2.5:
+    resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
+
   issue-parser@7.0.1:
     resolution: {integrity: sha512-3YZcUUR2Wt1WsapF+S/WiA2WmlW0cWAoPccMqne7AxEBhCdFeTPjfv/Axb8V2gyCgY3nRw+ksZ3xSUX+R47iAg==}
     engines: {node: ^18.17 || >=20.6.1}
@@ -9640,6 +9720,11 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lib0@0.2.117:
+    resolution: {integrity: sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==}
+    engines: {node: '>=16'}
+    hasBin: true
 
   lighthouse-logger@1.4.2:
     resolution: {integrity: sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==}
@@ -10333,6 +10418,9 @@ packages:
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
+  monaco-editor@0.52.2:
+    resolution: {integrity: sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==}
+
   motion-dom@12.34.3:
     resolution: {integrity: sha512-sYgFe+pR9aIM7o4fhs2aXtOI+oqlUd33N9Yoxcgo1Fv7M20sRkHtCmzE/VRNIcq7uNJ+qio+Xubt1FXH3pQ+eQ==}
 
@@ -10388,6 +10476,11 @@ packages:
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@5.1.15:
+    resolution: {integrity: sha512-kBg3RpGtIe+RpTbyXwoI6pk5yD7KUiI3sygUqgeBMRst42KmhB4RZC7eiO9Wa1HIpaCCtpE2DJ6OI4Wi5ebwFw==}
+    engines: {node: ^18 || >=20}
     hasBin: true
 
   nanostores@1.2.0:
@@ -11662,6 +11755,9 @@ packages:
   standardized-audio-context@25.3.77:
     resolution: {integrity: sha512-Ki9zNz6pKcC5Pi+QPjPyVsD9GwJIJWgryji0XL9cAJXMGyn+dPOf6Qik1AHei0+UNVcc4BOCa0hWLBzlwqsW/A==}
 
+  state-local@1.0.7:
+    resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
+
   statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
     engines: {node: '>= 0.6'}
@@ -12202,6 +12298,10 @@ packages:
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
+  unique-names-generator@4.7.1:
+    resolution: {integrity: sha512-lMx9dX+KRmG8sq6gulYYpKWZc9RlGsgBR6aoO8Qsm3qvkSJ+3rAymr+TnV8EDMrIrwuFJ4kruzMWM/OpYzPoow==}
+    engines: {node: '>=8'}
+
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
 
@@ -12270,11 +12370,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  use-sync-external-store@1.6.0:
-    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
-    peerDependencies:
-      react: 19.2.4
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -12688,6 +12783,19 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  y-monaco@0.1.6:
+    resolution: {integrity: sha512-sYRywMmcylt+Nupl+11AvizD2am06ST8lkVbUXuaEmrtV6Tf+TD4rsEm6u9YGGowYue+Vfg1IJ97SUP2J+PVXg==}
+    engines: {node: '>=12.0.0', npm: '>=6.0.0'}
+    peerDependencies:
+      monaco-editor: '>=0.20.0'
+      yjs: ^13.3.1
+
+  y-protocols@1.0.7:
+    resolution: {integrity: sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+    peerDependencies:
+      yjs: ^13.0.0
+
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
 
@@ -12725,6 +12833,10 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yjs@13.6.31:
+    resolution: {integrity: sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -15328,6 +15440,17 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@monaco-editor/loader@1.7.0':
+    dependencies:
+      state-local: 1.0.7
+
+  '@monaco-editor/react@4.7.0(monaco-editor@0.52.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@monaco-editor/loader': 1.7.0
+      monaco-editor: 0.52.2
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   '@multiavatar/multiavatar@1.0.7': {}
 
@@ -20816,6 +20939,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  isomorphic.js@0.2.5: {}
+
   issue-parser@7.0.1:
     dependencies:
       lodash.capitalize: 4.2.1
@@ -21387,6 +21512,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lib0@0.2.117:
+    dependencies:
+      isomorphic.js: 0.2.5
 
   lighthouse-logger@1.4.2:
     dependencies:
@@ -22490,6 +22619,8 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
+  monaco-editor@0.52.2: {}
+
   motion-dom@12.34.3:
     dependencies:
       motion-utils: 12.29.2
@@ -22527,6 +22658,8 @@ snapshots:
       thenify-all: 1.6.0
 
   nanoid@3.3.11: {}
+
+  nanoid@5.1.15: {}
 
   nanostores@1.2.0: {}
 
@@ -24093,6 +24226,8 @@ snapshots:
       automation-events: 7.1.15
       tslib: 2.8.1
 
+  state-local@1.0.7: {}
+
   statuses@1.5.0: {}
 
   statuses@2.0.2: {}
@@ -24645,6 +24780,8 @@ snapshots:
       trough: 2.2.0
       vfile: 6.0.3
 
+  unique-names-generator@4.7.1: {}
+
   unist-util-is@6.0.1:
     dependencies:
       '@types/unist': 3.0.3
@@ -24711,10 +24848,6 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
-
-  use-sync-external-store@1.6.0(react@19.2.4):
-    dependencies:
-      react: 19.2.4
 
   util-deprecate@1.0.2: {}
 
@@ -25184,6 +25317,17 @@ snapshots:
 
   xmlchars@2.2.0: {}
 
+  y-monaco@0.1.6(monaco-editor@0.52.2)(yjs@13.6.31):
+    dependencies:
+      lib0: 0.2.117
+      monaco-editor: 0.52.2
+      yjs: 13.6.31
+
+  y-protocols@1.0.7(yjs@13.6.31):
+    dependencies:
+      lib0: 0.2.117
+      yjs: 13.6.31
+
   y18n@4.0.3: {}
 
   y18n@5.0.8: {}
@@ -25226,6 +25370,10 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yjs@13.6.31:
+    dependencies:
+      lib0: 0.2.117
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
A React example demonstrating **Jazz as the durable sync backbone for a collaborative Yjs document**. Monaco + `y-monaco` handle live editing in the browser; Jazz durably stores the binary Yjs update log plus periodic snapshots and syncs them to every client. Anonymous local-first auth, multiple rooms, shareable-link URLs, per-room language selection. No live cursors (kept intentionally minimal).

## Data model

Four tables (`schema.ts`):

| Table | Columns | Purpose |
|---|---|---|
| `rooms` | `shareToken`, `title`, `editorLanguage`, `creator_session_user_id`, `createdAt` | One editable document. `shareToken` is the opaque id used in the URL. |
| `roomParticipants` | `room_id → rooms`, `session_user_id`, `lastAccessedAt` | "Rooms I've opened/created" — scopes the dashboard list per user. |
| `roomYjsUpdates` | `room_id → rooms`, `update` (bytes), `session_user_id`, `provider_instance_id`, `createdAt` | Append-only log of binary Yjs updates. One row per `Y.Doc` update. |
| `roomYjsSnapshots` | `room_id → rooms`, `state` (bytes), `textHash?`, `session_user_id?`, `createdAt` | Periodic full-document snapshots so a fresh client doesn't replay the whole log. |

**Permissions** (`permissions.ts`) are intentionally permissive for a shareable-link demo: anyone can read any row; you may only insert rows attributed to your own `session.user_id`; room title/language are editable by any collaborator. A real app would restrict reads to actual room members.

## Flow

**Editing → persistence**
```
Monaco --edit--> Y.Doc("monaco") --"update" event--> insert roomYjsUpdates row (tier "edge")
```
Each local edit fires a `Y.Doc` update; the hook copies the binary update into a `roomYjsUpdates` row. A debounced observer also writes a `roomYjsSnapshots` row (`Y.encodeStateAsUpdate`), coalescing by `textHash` within a window so identical text doesn't spawn duplicates.

**Sync → receive**
```
Jazz sync --> peer's useAll(roomYjsUpdates.where({room_id})) --> Y.applyUpdate(doc, remoteOrigin) --> y-monaco --> peer's Monaco
```
Jazz syncs the rows; each client subscribes to its room's update rows via `useAll`, applies them to its own `Y.Doc` with a `remoteOrigin` sentinel, and `y-monaco` reflects the text into Monaco. Echoes are suppressed by skipping rows whose `provider_instance_id` matches the local tab and by tagging remote applies with `remoteOrigin` (so they aren't re-persisted).

**Bootstrap (opening a room)**
1. Apply the latest `roomYjsSnapshots.state` to the doc.
2. Replay every `roomYjsUpdates` row after it.
3. Mark ready → Monaco mounts and binds.

The whole loop lives in `src/hooks/useJazzYjsDocument.ts`; `useMonacoBinding.ts` wires `Y.Text` ⟷ the Monaco model.

## Auth & identity

Anonymous **local-first** auth (`useLocalFirstAuth`) — no auth server. Display name is an ephemeral client-side value in `localStorage`.

## Tests

`tests/browser/collab-editor.test.tsx` (vitest browser, real local Jazz server):
- **Persistence** — edit through the real `<App>` + Monaco, unmount, remount; the document is restored from snapshot + updates.
- **Convergence** — two clients (a harness around the real `useJazzYjsDocument`) editing one room converge through the server.

## Multi-window collaboration (dev)

Just run `pnpm dev`. The Jazz dev plugin (`jazzPlugin()` in `vite.config.ts`) starts a local Jazz server, publishes the schema, and points the app at it automatically. Open the app in two windows, create a room in one, and open its **Copy link** URL in the other — edits propagate both ways (verified end to end).