### PR TITLE
fix(ci): skip redundant Rust toolchain install when already present

### DIFF
--- a/dev/scripts/install-jazz-rn-deps.sh
+++ b/dev/scripts/install-jazz-rn-deps.sh
@@ -49,7 +49,11 @@ if ! command -v rustup >/dev/null 2>&1; then
   curl -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain "$RUST_TOOLCHAIN"
 fi
 
-rustup toolchain install "$RUST_TOOLCHAIN"
+if rustup toolchain list | grep -q "^${RUST_TOOLCHAIN}-"; then
+  echo "Rust toolchain ${RUST_TOOLCHAIN} already installed, skipping download."
+else
+  rustup toolchain install "$RUST_TOOLCHAIN"
+fi
 rustup default "$RUST_TOOLCHAIN"
 rustup target add wasm32-unknown-unknown --toolchain "$RUST_TOOLCHAIN"
 


### PR DESCRIPTION
The `ensure:rust-toolchain` script was re-installing the Rust toolchain on every CI run even though the `setup-build` action already installs it. This caused network timeout failures in CI when downloading Rust from static.rust-lang.org.

Now the script checks if the toolchain is already installed before trying to download it again.