### PR TITLE
experiment(opfs-btree): try readwrite-unsafe OPFS access mode

### DIFF
--- a/crates/opfs-btree/Cargo.toml
+++ b/crates/opfs-btree/Cargo.toml
@@ -30,7 +30,17 @@ web-sys = { version = "0.3", features = [
   "FileSystemFileHandle",
   "FileSystemGetFileOptions",
   "FileSystemSyncAccessHandle",
+  "FileSystemSyncAccessHandleOptions",
+  "FileSystemSyncAccessHandleMode",
   "FileSystemReadWriteOptions",
   "DomException",
+] }
+
+# `web_sys_unstable_apis` is an opt-in cfg (set via RUSTFLAGS) that exposes the
+# unstable OPFS access-mode APIs.  Declare it so referencing it in `file.rs`
+# doesn't trip the `unexpected_cfgs` lint on builds that don't set it.
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(web_sys_unstable_apis)',
 ] }
 

--- a/crates/opfs-btree/src/file.rs
+++ b/crates/opfs-btree/src/file.rs
@@ -235,13 +235,18 @@ impl OpfsFile {
         const MAX_RETRIES: u32 = 12;
         const BASE_DELAY_MS: u32 = 50;
 
+        // Prefer the `readwrite-unsafe` access mode when the build enables it
+        // (cfg `web_sys_unstable_apis`).  It drops the per-file exclusive lock,
+        // which can reduce per-I/O overhead.  If the browser rejects the mode
+        // we fall back to the default exclusive `readwrite` handle.
+        let mut prefer_unsafe = true;
         let mut last_err = None;
         for attempt in 0..=MAX_RETRIES {
             if attempt > 0 {
                 let delay = BASE_DELAY_MS * (1 << (attempt - 1));
                 sleep_ms(delay).await;
             }
-            match JsFuture::from(file.create_sync_access_handle()).await {
+            match JsFuture::from(request_handle(&file, prefer_unsafe)).await {
                 Ok(val) => {
                     let handle: web_sys::FileSystemSyncAccessHandle =
                         val.dyn_into().map_err(|_| {
@@ -262,10 +267,22 @@ impl OpfsFile {
                     });
                 }
                 Err(e) => {
-                    if !is_retryable_handle_conflict(&e) {
-                        return Err(map_js_error(e));
+                    if is_retryable_handle_conflict(&e) {
+                        last_err = Some(e);
+                        continue;
                     }
-                    last_err = Some(e);
+                    // A non-conflict error while requesting `readwrite-unsafe`
+                    // most likely means the browser doesn't support the mode —
+                    // retry once with the default exclusive handle.
+                    if prefer_unsafe {
+                        tracing::warn!(
+                            "readwrite-unsafe handle unavailable, falling back to default mode"
+                        );
+                        prefer_unsafe = false;
+                        last_err = Some(e);
+                        continue;
+                    }
+                    return Err(map_js_error(e));
                 }
             }
         }
@@ -355,6 +372,31 @@ impl SyncFile for OpfsFile {
     fn flush(&self) -> Result<(), BTreeError> {
         self.inner.handle.flush().map_err(map_js_error)
     }
+}
+
+/// Build the promise that requests a sync access handle.
+///
+/// When the crate is built with `--cfg=web_sys_unstable_apis` and
+/// `prefer_unsafe` is set, this asks for the `readwrite-unsafe` access mode
+/// (no exclusive lock).  Otherwise — including any build without the unstable
+/// web-sys APIs — it requests the default exclusive `readwrite` handle.
+#[cfg(all(target_arch = "wasm32", web_sys_unstable_apis))]
+fn request_handle(file: &web_sys::FileSystemFileHandle, prefer_unsafe: bool) -> js_sys::Promise {
+    if prefer_unsafe {
+        let opts = web_sys::FileSystemSyncAccessHandleOptions::new();
+        opts.set_mode(web_sys::FileSystemSyncAccessHandleMode::ReadwriteUnsafe);
+        // The typed `Promise<FileSystemSyncAccessHandle>` is cast to the plain
+        // promise; the resolved value is `dyn_into`'d at the call site anyway.
+        file.create_sync_access_handle_with_options(&opts)
+            .unchecked_into()
+    } else {
+        file.create_sync_access_handle()
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", not(web_sys_unstable_apis)))]
+fn request_handle(file: &web_sys::FileSystemFileHandle, _prefer_unsafe: bool) -> js_sys::Promise {
+    file.create_sync_access_handle()
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/opfs-btree/wasm-bench/.cargo/config.toml
+++ b/crates/opfs-btree/wasm-bench/.cargo/config.toml
@@ -1,0 +1,5 @@
+# Enable web-sys's unstable OPFS APIs so opfs-btree can request the
+# `readwrite-unsafe` sync-access-handle mode in this benchmark build.
+# Scoped to the wasm target the bench compiles for.
+[target.wasm32-unknown-unknown]
+rustflags = ["--cfg=web_sys_unstable_apis"]


### PR DESCRIPTION
## What

Experiment: does the OPFS [`readwrite-unsafe`](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemFileHandle/createSyncAccessHandle#mode) `createSyncAccessHandle` mode make `opfs-btree` faster when available?

`OpfsFile::open` now requests `readwrite-unsafe`, falling back to the default exclusive `readwrite` handle if the browser rejects it. The new path is gated on the `web_sys_unstable_apis` cfg (the web-sys APIs are still unstable), so the **default build is unchanged**; only the wasm-bench opts in, via its own `.cargo/config.toml`.

## Result: no measurable difference

5 `bench:compare` runs per config over both profiles (`objects`, `wikipedia`). Median per-phase deltas:

| phase | objects (base→unsafe) | wikipedia (base→unsafe) |
|---|---|---|
| load | 55.4 → 55.6 ms (+0.4%) | 7.0 → 7.2 ms (+2.9%) |
| get_seq | 11.8 → 11.8 ms (0%) | 10.3 → 10.2 ms (−1.0%) |
| get_random | 10.8 → 10.4 ms (−3.7%) | 10.2 → 10.4 ms (+2.0%) |
| update_random | 21.0 → 21.3 ms (+1.4%) | 12.8 → 12.9 ms (+0.8%) |
| mixed_70_20_10 | 27.3 → 26.7 ms (−2.2%) | 11.8 → 12.1 ms (+2.5%) |
| cold_get_random | 62.3 → 62.2 ms (−0.2%) | 20.2 → 20.0 ms (−1.0%) |

Every delta is within ±3.7%, the min/max ranges of the two configs fully overlap on every phase, and the signs go both ways — noise, no signal. Checksums matched on all runs.

## Why this is expected

`readwrite-unsafe` drops the per-file **exclusive lock** (a concurrency property that lets multiple sync access handles open the same file at once); it does not reduce per-I/O call overhead. `opfs-btree` uses a single sequential handle inside one worker, so there is nothing for the relaxed mode to win back.

## Not for merge

Draft, kept for the record. No speedup, and it weakens the exclusive-lock invariant the open-retry loop relies on. Where the mode *could* still matter (untested): multi-handle scenarios — the main-thread async OPFS path, or multiple tabs/workers on the same file.