### PR TITLE
Fix jazz-tools MCP startup on Windows

### DIFF
--- a/packages/jazz-tools/bin/jazz-tools.js
+++ b/packages/jazz-tools/bin/jazz-tools.js
@@ -3,7 +3,7 @@
 import { spawnSync } from "node:child_process";
 import { accessSync, chmodSync, constants, existsSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const BINARIES = {
   "darwin-arm64": "jazz-tools-darwin-arm64",
@@ -128,7 +128,7 @@ if (!command || command === "--help" || command === "-h") {
   printWrapperHelp();
 } else if (command === "mcp") {
   const mcpPath = join(here, "..", "dist", "mcp", "server.js");
-  const { runServer } = await import(mcpPath);
+  const { runServer } = await import(pathToFileURL(mcpPath).href);
   await runServer();
   // runServer resolves when stdin closes; process exits naturally.
 } else if (command === "build") {


### PR DESCRIPTION
## Summary

Fix `jazz-tools mcp` on Windows by converting the local MCP server path to a `file://` URL before passing it to dynamic `import()`.

Raw Windows absolute paths like `C:\...` are parsed by Node's ESM loader as an unsupported `c:` URL scheme.

## Test

- `node --check packages\jazz-tools\bin\jazz-tools.js`
- `pnpm --filter jazz-tools exec vitest run src/mcp/integration.test.ts --config vitest.config.ts`