### PR TITLE
Unclaimed app expiration message

### DIFF
--- a/docs/components/mdx/generate-app-id.tsx
+++ b/docs/components/mdx/generate-app-id.tsx
@@ -71,6 +71,10 @@ export function GenerateAppId() {
   if (!app) {
     return (
       <div className="space-y-3">
+        <Callout type="warn">
+          Apps generated here are unclaimed. Claim the app in the dashboard within 14 days.
+          Unclaimed apps are automatically deleted after 14 days.
+        </Callout>
         <button
           onClick={generate}
           disabled={loading}
@@ -106,7 +110,7 @@ export function GenerateAppId() {
         >
           dashboard
         </a>{" "}
-        later.
+        within 14 days. Unclaimed apps are automatically deleted after 14 days.
       </Callout>
 
       <CredentialsBlock app={app} />

--- a/docs/content/docs/getting-started/server-setup.mdx
+++ b/docs/content/docs/getting-started/server-setup.mdx
@@ -8,7 +8,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 ## Hosted database server
 
-Your app ID namespaces your data for storage and sync. Click below to generate one on the Jazz hosted cloud&hairsp;—&hairsp;you'll also get the secrets you need to deploy permissions later.
+Your app ID namespaces your data for storage and sync. Click below to generate one on the Jazz hosted cloud&hairsp;—&hairsp;you'll also get the secrets you need to deploy permissions later. Generated apps are unclaimed until you claim them in the dashboard, and unclaimed apps are automatically deleted after 14 days.
 
 <GenerateAppId />
 

--- a/docs/content/docs/install/client.mdx
+++ b/docs/content/docs/install/client.mdx
@@ -158,7 +158,7 @@ Start with a fresh app. If you already have one, skip to [Install](#install).
 
 ## Get an app ID
 
-Your app ID namespaces your data for storage and sync. Click below to generate one on [Jazz Cloud](https://v2.dashboard.jazz.tools) (sync URL: `https://v2.sync.jazz.tools/`)&hairsp;—&hairsp;you'll also get the secrets you need to deploy permissions later.
+Your app ID namespaces your data for storage and sync. Click below to generate one on [Jazz Cloud](https://v2.dashboard.jazz.tools) (sync URL: `https://v2.sync.jazz.tools/`)&hairsp;—&hairsp;you'll also get the secrets you need to deploy permissions later. Generated apps are unclaimed until you claim them in the dashboard, and unclaimed apps are automatically deleted after 14 days.
 
 <GenerateAppId />
 

--- a/packages/create-jazz/src/cloud-init.ts
+++ b/packages/create-jazz/src/cloud-init.ts
@@ -101,7 +101,8 @@ export async function runHostedInit(options: RunHostedInitOptions): Promise<void
         `  ${envKeys.adminSecret}=${adminSecret}`,
         `  ${envKeys.backendSecret}=${backendSecret}`,
         "",
-        "Visit https://v2.dashboard.jazz.tools to sign up and claim your app!",
+        "Claim this app in the dashboard within 14 days: https://v2.dashboard.jazz.tools",
+        "Unclaimed apps are automatically deleted after 14 days.",
       ].join("\n"),
     );
   } catch (err) {


### PR DESCRIPTION
## Summary
- Add warning copy to the app ID generator for unclaimed apps
- Update hosted setup and install docs to explain the 14-day claim window and deletion policy
- Revise `create-jazz` init output to point users to the dashboard and the same deadline

## Testing
- Not run (not requested)