### PR TITLE
fix(ci): add --scope to vercel promote and make deploy branch configurable

### DIFF
--- a/.github/workflows/promote-inspector-production.yml
+++ b/.github/workflows/promote-inspector-production.yml
@@ -2,7 +2,18 @@ name: Promote inspector production
 
 on:
   workflow_dispatch:
+    inputs:
+      deploy-branch:
+        description: "Vercel deployment branch to promote"
+        required: false
+        default: "main"
+        type: string
   workflow_call:
+    inputs:
+      deploy-branch:
+        required: false
+        default: "main"
+        type: string
 
 jobs:
   promote-inspector-production:
@@ -17,6 +28,7 @@ jobs:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_INSPECTOR_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_INSPECTOR_PROJECT_ID }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_INSPECTOR_TOKEN }}
+      VERCEL_DEPLOY_BRANCH: ${{ inputs.deploy-branch }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -44,7 +56,7 @@ jobs:
 
       - name: Promote staged inspector deployment
         if: steps.inspector-deployment.outputs.already_promoted != 'true'
-        run: pnpm dlx vercel@latest promote "${{ steps.inspector-deployment.outputs.deployment_url }}" --yes --timeout=5m --token="${VERCEL_TOKEN}"
+        run: pnpm dlx vercel@latest promote "${{ steps.inspector-deployment.outputs.deployment_url }}" --yes --timeout=5m --token="${VERCEL_TOKEN}" --scope="${VERCEL_ORG_ID}"
 
       - name: Skip already promoted inspector deployment
         if: steps.inspector-deployment.outputs.already_promoted == 'true'

--- a/dev/scripts/resolve-inspector-deployment.mjs
+++ b/dev/scripts/resolve-inspector-deployment.mjs
@@ -16,11 +16,12 @@ function requireEnv(env) {
 }
 
 export function buildDeploymentsUrl(env) {
+  const branch = env.VERCEL_DEPLOY_BRANCH || "main";
   const params = new URLSearchParams({
     projectId: env.VERCEL_PROJECT_ID,
     target: "production",
     state: "READY",
-    branch: "main",
+    branch,
     limit: "20",
     teamId: env.VERCEL_ORG_ID,
   });
@@ -112,7 +113,9 @@ export async function resolveInspectorDeployment({
       return result;
     }
 
-    log(`No staged inspector production deployment on main yet (${attempt}/${attempts}).`);
+    log(
+      `No staged inspector production deployment on ${env.VERCEL_DEPLOY_BRANCH || "main"} yet (${attempt}/${attempts}).`,
+    );
 
     if (lastDeployments.length > 0) {
       log("Matching READY production deployments:");
@@ -126,10 +129,11 @@ export async function resolveInspectorDeployment({
     }
   }
 
+  const branch = env.VERCEL_DEPLOY_BRANCH || "main";
   throw new Error(
     [
-      "No staged inspector production deployment found on main.",
-      "Make sure the inspector Vercel project has a ready production deployment from main and has auto-assign custom production domains disabled.",
+      `No staged inspector production deployment found on ${branch}.`,
+      "Make sure the inspector Vercel project has a ready production deployment from the target branch and has auto-assign custom production domains disabled.",
       lastDeployments.length > 0
         ? `Last matching deployments:\n${lastDeployments
             .map((deployment) => `- ${describeDeployment(deployment)}`)

--- a/dev/scripts/resolve-inspector-deployment.test.mjs
+++ b/dev/scripts/resolve-inspector-deployment.test.mjs
@@ -182,6 +182,58 @@ test("resolveInspectorDeployment reports the last matching deployments when none
   assert.equal(fs.existsSync(outputFile), false);
 });
 
+test("resolveInspectorDeployment uses VERCEL_DEPLOY_BRANCH to query deployments from a custom branch", async () => {
+  const outputFile = makeOutputFile();
+  const requests = [];
+
+  const result = await resolveInspectorDeployment({
+    env: { ...requiredEnv, GITHUB_OUTPUT: outputFile, VERCEL_DEPLOY_BRANCH: "feature/foo" },
+    fetchImpl: async (url, init) => {
+      requests.push({ url: String(url), authorization: init.headers.Authorization });
+      return jsonResponse({
+        deployments: [
+          {
+            url: "jazz-inspector-git-feature-foo.vercel.app",
+            readyState: "READY",
+            target: "production",
+            readySubstate: "STAGED",
+          },
+        ],
+      });
+    },
+    log: () => {},
+  });
+
+  assert.deepEqual(result, {
+    deploymentUrl: "https://jazz-inspector-git-feature-foo.vercel.app",
+    alreadyPromoted: false,
+  });
+  assert.equal(requests.length, 1);
+  const requestUrl = new URL(requests[0].url);
+  assert.equal(requestUrl.searchParams.get("branch"), "feature/foo");
+});
+
+test("resolveInspectorDeployment error message mentions the custom branch", async () => {
+  const outputFile = makeOutputFile();
+
+  await assert.rejects(
+    resolveInspectorDeployment({
+      env: {
+        ...requiredEnv,
+        GITHUB_OUTPUT: outputFile,
+        VERCEL_DEPLOY_BRANCH: "staging",
+      },
+      fetchImpl: async () =>
+        jsonResponse({
+          deployments: [],
+        }),
+      attempts: 1,
+      log: () => {},
+    }),
+    /No staged inspector production deployment found on staging/,
+  );
+});
+
 test("resolveInspectorDeployment requires all CI environment variables", async () => {
   const env = { ...requiredEnv };
   delete env.VERCEL_TOKEN;


### PR DESCRIPTION
## Summary
- Adds `--scope="${VERCEL_ORG_ID}"` to `vercel promote` so it targets the Garden team instead of defaulting to the user's personal team
- Makes the Vercel deployment branch configurable via `VERCEL_DEPLOY_BRANCH` env var (defaults to `"main"`)
- Exposes `deploy-branch` as a workflow input on both `workflow_dispatch` and `workflow_call` triggers

## Test Plan
- [x] All existing tests pass (7/7)
- [x] Added tests for custom branch query parameter and error messages