### PR TITLE
feat(react): add useOne / useOneSuspense hooks

### DIFF
--- a/.changeset/use-one-and-react-result-shape.md
+++ b/.changeset/use-one-and-react-result-shape.md
@@ -1,0 +1,7 @@
+---
+"jazz-tools": minor
+---
+
+Add `useOne`/`useOneSuspense` single-row query bindings across the framework layers (React, Expo, Vue, Solid `useOne`; Svelte `SingleRowSubscription`). Each runs the query with `limit 1` (mirroring `db.one`) and exposes the first matching row: `undefined` while loading, `null` once resolved with no match, the row otherwise.
+
+**Breaking (React/Expo):** the non-suspense `useAll` and `useOne` now return `{ data, isLoading, error }` instead of a bare value, aligning React with Solid's binding shape. Read rows from `.data` (e.g. `const { data: todos } = useAll(query)`). The Suspense variants `useAllSuspense`/`useOneSuspense` are unchanged and still return the bare value.

--- a/docs/content/docs/faq.mdx
+++ b/docs/content/docs/faq.mdx
@@ -38,7 +38,7 @@ This is useful when iterating on your schema during development.
 
 <Accordion id="undefined-vs-empty-array" title="Why does useAll return undefined?">
 
-`useAll` and `QuerySubscription` return `undefined` until the first response arrives from the requested tier. After that, the value is an array&hairsp;—&hairsp;empty (`[]`) if no rows match, or populated. See [The undefined loading state](/docs/reading/queries#the-undefined-loading-state) for details.
+A query binding's `data` (`.current` in Svelte) is `undefined` until the first response arrives from the requested tier. After that, it's an array&hairsp;—&hairsp;empty (`[]`) if no rows match, or populated. React and Solid also expose an `isLoading` flag (Vue and Svelte a `loading` one) that is `true` over the same window. See [The undefined loading state](/docs/reading/queries#the-undefined-loading-state) for details.
 
 </Accordion>
 

--- a/docs/content/docs/reading/queries.mdx
+++ b/docs/content/docs/reading/queries.mdx
@@ -141,14 +141,14 @@ Each framework has a reactive binding that re-renders when query results change.
 
 | Framework  | API                            | Notes                                               |
 | ---------- | ------------------------------ | --------------------------------------------------- |
-| React/Expo | `useAll(query)`                | Returns `T[] \| undefined`                          |
+| React/Expo | `useAll(query)`                | Returns `{ data, isLoading, error }`                |
 | Vue        | `useAll(query)`                | Returns `{ data, error, loading }` refs             |
 | Svelte     | `new QuerySubscription(query)` | Exposes reactive `.current` / `.loading` / `.error` |
 | Solid      | `useAll(() => ({ query }))`    | Returns `{ data, isLoading, error }`                |
 
 ### The `undefined` loading state
 
-`useAll` (its `data` ref in Vue) and `QuerySubscription` return `undefined` until the first server response arrives. After that, the value is an array&hairsp;—&hairsp;empty (`[]`) if no rows match, or populated with the requested data.
+`useAll`'s `data` (a ref in Vue) and `QuerySubscription`'s `.current` are `undefined` until the first server response arrives; React and Solid also expose an `isLoading` flag for the same window. After that, `data` is an array&hairsp;—&hairsp;empty (`[]`) if no rows match, or populated with the requested data.
 
 <Tabs groupId="jazz-framework" items={["React", "Vue", "Svelte", "Solid"]} persist updateAnchor>
   <Tab value="React">
@@ -181,19 +181,19 @@ Each framework has a reactive binding that re-renders when query results change.
 
 ### Reading a single row
 
-When a component renders one row — a detail view fetched by id, or the first match of a query — React's `useOne` subscribes to just that row, the hook counterpart of [`db.one`](#one-shot-queries). It runs the query with `limit 1` and returns the first match, re-rendering if a closer match appears or the current row is removed.
+When a component renders one row — a detail view fetched by id, or the first match of a query — React's `useOne` subscribes to just that row, the hook counterpart of [`db.one`](#one-shot-queries). It runs the query with `limit 1` and returns the first row under the query's order, re-rendering if a different row takes that spot or the current one is removed.
 
 ```tsx
 function TodoItem({ id }: { id: string }) {
-  // `undefined` while loading, `null` if no row matches, otherwise the row.
-  const todo = useOne(app.todos.where({ id }));
-  if (todo === undefined) return <Spinner />;
+  // data: `undefined` while loading, `null` if no row matches, otherwise the row.
+  const { data: todo, isLoading } = useOne(app.todos.where({ id }));
+  if (isLoading) return <Spinner />;
   if (todo === null) return <NotFound />;
   return <span>{todo.title}</span>;
 }
 ```
 
-Unlike `useAll`, the empty result is `null` rather than `[]`, so it stays distinct from the `undefined` loading state. A `useOneSuspense` variant mirrors `useAllSuspense`, suspending until the query resolves and then returning the row or `null`.
+`useOne` returns `{ data, isLoading, error }` like `useAll`, but `data` is a single row instead of an array: it is `undefined` while loading, `null` once the query resolves with no match (distinct from the empty array `useAll` returns), or the matching row. A `useOneSuspense` variant mirrors `useAllSuspense`, suspending until the query resolves and then returning the row or `null` directly.
 
 ### Fine-grained updates
 

--- a/docs/content/docs/reading/queries.mdx
+++ b/docs/content/docs/reading/queries.mdx
@@ -179,6 +179,22 @@ Each framework has a reactive binding that re-renders when query results change.
   data exists yet.
 </Callout>
 
+### Reading a single row
+
+When a component renders one row — a detail view fetched by id, or the first match of a query — React's `useOne` subscribes to just that row, the hook counterpart of [`db.one`](#one-shot-queries). It runs the query with `limit 1` and returns the first match, re-rendering if a closer match appears or the current row is removed.
+
+```tsx
+function TodoItem({ id }: { id: string }) {
+  // `undefined` while loading, `null` if no row matches, otherwise the row.
+  const todo = useOne(app.todos.where({ id }));
+  if (todo === undefined) return <Spinner />;
+  if (todo === null) return <NotFound />;
+  return <span>{todo.title}</span>;
+}
+```
+
+Unlike `useAll`, the empty result is `null` rather than `[]`, so it stays distinct from the `undefined` loading state. A `useOneSuspense` variant mirrors `useAllSuspense`, suspending until the query resolves and then returning the row or `null`.
+
 ### Fine-grained updates
 
 Vue's `useAll`, Svelte's `QuerySubscription`, and Solid's `useAll` reconcile new query results into the existing reactive array in place rather than swapping the reference. When an upstream change touches a single row, only that row's affected fields write into the reactive proxy, so `$effect` (Svelte), Solid computations/effects, and `watch` / template bindings (Vue) only re-fire for components that depend on the fields that actually changed.

--- a/docs/content/docs/reference/framework-patterns.mdx
+++ b/docs/content/docs/reference/framework-patterns.mdx
@@ -11,13 +11,14 @@ full details.
 
 ## API equivalents
 
-| Concept            | React / Expo                     | Vue                               | Svelte                          | Solid                         |
-| ------------------ | -------------------------------- | --------------------------------- | ------------------------------- | ----------------------------- |
-| Provider           | `<JazzProvider config={config}>` | `<JazzProvider :client="client">` | `<JazzSvelteProvider {client}>` | `<JazzProvider client={...}>` |
-| Query subscription | `useAll(query)`                  | `useAll(query)`                   | `new QuerySubscription(query)`  | `useAll(() => ({ query }))`   |
-| DB access          | `useDb()`                        | `useDb()`                         | `getDb()`                       | `useDb()`                     |
-| Session            | `useSession()`                   | `useSession()`                    | `getSession()`                  | `useSession()`                |
-| Client creation    | `createJazzClient(config)`       | `createJazzClient(config)`        | `createJazzClient(config)`      | `createSolidJazzClient(...)`  |
+| Concept            | React / Expo                     | Vue                               | Svelte                             | Solid                         |
+| ------------------ | -------------------------------- | --------------------------------- | ---------------------------------- | ----------------------------- |
+| Provider           | `<JazzProvider config={config}>` | `<JazzProvider :client="client">` | `<JazzSvelteProvider {client}>`    | `<JazzProvider client={...}>` |
+| Query subscription | `useAll(query)`                  | `useAll(query)`                   | `new QuerySubscription(query)`     | `useAll(() => ({ query }))`   |
+| Single-row query   | `useOne(query)`                  | `useOne(query)`                   | `new SingleRowSubscription(query)` | `useOne(() => ({ query }))`   |
+| DB access          | `useDb()`                        | `useDb()`                         | `getDb()`                          | `useDb()`                     |
+| Session            | `useSession()`                   | `useSession()`                    | `getSession()`                     | `useSession()`                |
+| Client creation    | `createJazzClient(config)`       | `createJazzClient(config)`        | `createJazzClient(config)`         | `createSolidJazzClient(...)`  |
 
 ## Provider setup
 
@@ -73,7 +74,7 @@ Subscribe to query results reactively. See [Reading Data](/docs/reading/queries)
   </Tab>
 </Tabs>
 
-The `?? []` guard handles the `undefined` (not yet connected) case. See
+Each binding surfaces the same loading signal a little differently: React and Solid's `useAll` return `{ data, isLoading, error }`, Vue returns the same fields as refs (with `loading` rather than `isLoading`), and Svelte's `QuerySubscription` exposes `.current` / `.loading` / `.error`. In every case `data` (or `.current`) is `undefined` until the first response, then an array&hairsp;—&hairsp;empty (`[]`) if no rows match. See
 [Reading Data: The undefined loading state](/docs/reading/queries#the-undefined-loading-state) for patterns that depend on this signal.
 
 In Vue, Svelte, and Solid, the binding reconciles updates into the existing reactive array in place, so only fields that actually changed trigger re-renders. See [Fine-grained updates](/docs/reading/queries#fine-grained-updates) for the full behaviour.

--- a/examples/auth-betterauth-chat/src/ChatPanel.tsx
+++ b/examples/auth-betterauth-chat/src/ChatPanel.tsx
@@ -36,7 +36,7 @@ export function ChatPanel({
         .where({ chat_id: chatId })
         .select("id", "author_name", "text", "sent_at", "$canDelete")
         .orderBy("sent_at", "asc"),
-    ) ?? [];
+    ).data ?? [];
 
   const [messageText, setMessageText] = React.useState("");
   const [messagePending, setMessagePending] = React.useState(false);

--- a/examples/auth-simple-chat/src/ChatPanel.tsx
+++ b/examples/auth-simple-chat/src/ChatPanel.tsx
@@ -36,7 +36,7 @@ export function ChatPanel({
         .where({ chat_id: chatId })
         .select("id", "author_name", "text", "sent_at", "$canDelete")
         .orderBy("sent_at", "asc"),
-    ) ?? [];
+    ).data ?? [];
 
   const [messageText, setMessageText] = React.useState("");
   const [messagePending, setMessagePending] = React.useState(false);

--- a/examples/auth-workos-chat/src/ChatPanel.tsx
+++ b/examples/auth-workos-chat/src/ChatPanel.tsx
@@ -36,7 +36,7 @@ export function ChatPanel({
         .where({ chat_id: chatId })
         .select("id", "author_name", "text", "sent_at", "$canDelete")
         .orderBy("sent_at", "asc"),
-    ) ?? [];
+    ).data ?? [];
 
   const [messageText, setMessageText] = React.useState("");
   const [messagePending, setMessagePending] = React.useState(false);

--- a/examples/chat-react/src/components/canvas/Canvas.tsx
+++ b/examples/chat-react/src/components/canvas/Canvas.tsx
@@ -39,10 +39,10 @@ export function CollaborativeCanvas({
   const myColor = userId ? colorFromUserId(userId) : "#000000";
 
   // Subscribe to the canvas row so it's present in the local runtime for FK checks
-  const canvasRows = useAll(app.canvases.where({ id: canvasId })) ?? [];
+  const canvasRows = useAll(app.canvases.where({ id: canvasId })).data ?? [];
   const canvasReady = canvasRows.length > 0;
 
-  const profiles = useAll(app.profiles) ?? [];
+  const profiles = useAll(app.profiles).data ?? [];
   const profileNameByUserId = useMemo(() => {
     const map = new Map<string, string>();
     const sorted = [...profiles].sort((a, b) => a.id.localeCompare(b.id));
@@ -55,7 +55,7 @@ export function CollaborativeCanvas({
   }, [profiles]);
 
   // Fetch all strokes for this canvas
-  const allStrokes = useAll(app.strokes.where({ canvasId })) ?? [];
+  const allStrokes = useAll(app.strokes.where({ canvasId })).data ?? [];
 
   // Group strokes by ownerId
   const strokesByOwner: Record<string, StrokeData[]> = {};

--- a/examples/chat-react/src/components/chat-list/ChatList.tsx
+++ b/examples/chat-react/src/components/chat-list/ChatList.tsx
@@ -18,7 +18,8 @@ export const ChatList = () => {
   const myProfile = useMyProfile();
 
   const memberships =
-    useAll(app.chatMembers.where({ userId: userId ?? "__none__" }).include({ chat: true })) ?? [];
+    useAll(app.chatMembers.where({ userId: userId ?? "__none__" }).include({ chat: true })).data ??
+    [];
 
   const createPublicChat = async () => {
     if (!userId || !myProfile) return;

--- a/examples/chat-react/src/components/chat-view/ChatHeader.tsx
+++ b/examples/chat-react/src/components/chat-view/ChatHeader.tsx
@@ -24,7 +24,7 @@ export function ChatHeader({ chatId }: ChatHeaderProps) {
 function ChatHeaderContent({ chatId }: ChatHeaderProps) {
   const [settingsOpen, setSettingsOpen] = useState(false);
 
-  const chatRows = useAll(app.chats.where({ id: chatId })) ?? [];
+  const chatRows = useAll(app.chats.where({ id: chatId })).data ?? [];
   const chat = chatRows[0];
 
   const displayName = useChatDisplayName(chatId, chat?.name ?? undefined);

--- a/examples/chat-react/src/components/chat-view/ChatSettings.tsx
+++ b/examples/chat-react/src/components/chat-view/ChatSettings.tsx
@@ -62,7 +62,7 @@ function ChatSettingsContent({
   const userId = session?.user_id ?? null;
   const [willShare, setWillShare] = useState(false);
 
-  const chatRows = useAll(app.chats.where({ id: chatId })) ?? [];
+  const chatRows = useAll(app.chats.where({ id: chatId })).data ?? [];
   const chat = chatRows[0];
   const [draftName, setDraftName] = useState("");
 
@@ -70,8 +70,8 @@ function ChatSettingsContent({
     setDraftName(chat?.name ?? "");
   }, [chatId, chat?.name]);
 
-  const members = useAll(app.chatMembers.where({ chatId })) ?? [];
-  const allProfiles = useAll(app.profiles) ?? [];
+  const members = useAll(app.chatMembers.where({ chatId })).data ?? [];
+  const allProfiles = useAll(app.profiles).data ?? [];
 
   const memberUserIds = new Set(members.map((m) => m.userId));
   const memberProfiles = allProfiles.filter((p) => memberUserIds.has(p.userId));

--- a/examples/chat-react/src/components/chat-view/ChatView.tsx
+++ b/examples/chat-react/src/components/chat-view/ChatView.tsx
@@ -27,14 +27,14 @@ export const ChatView = ({ chatId }: ChatViewProps) => {
 
   const [showNLastMessages, setShowNLastMessages] = useState(INITIAL_MESSAGES_TO_SHOW);
 
-  const chatRowsResult = useAll(app.chats.where({ id: chatId }));
+  const { data: chatRowsResult } = useAll(app.chats.where({ id: chatId }));
   const chatRows = chatRowsResult ?? [];
   const chatKnown = chatRows.length > 0;
 
   // Auto-join: if the user can see the chat but isn't a member yet, insert a
   // chatMember row so they appear in the member list and can send messages.
   const myMemberships =
-    useAll(app.chatMembers.where({ chatId, userId: userId ?? "__none__" })) ?? [];
+    useAll(app.chatMembers.where({ chatId, userId: userId ?? "__none__" })).data ?? [];
   const isMember = myMemberships.length > 0;
   // autoJoinPending: true while we've started the insert but haven't yet
   // received server acknowledgement.  Used to suppress the isMember shortcut
@@ -106,7 +106,7 @@ export const ChatView = ({ chatId }: ChatViewProps) => {
         .include({ sender: true })
         .orderBy("createdAt", "desc")
         .limit(showNLastMessages + 1),
-    ) ?? [];
+    ).data ?? [];
 
   const hasMore = messages.length > showNLastMessages;
 

--- a/examples/chat-react/src/components/chat/ChatMessage.tsx
+++ b/examples/chat-react/src/components/chat/ChatMessage.tsx
@@ -41,10 +41,10 @@ export const ChatMessage = ({ message, sender, isMe, onDelete }: ChatMessageProp
   // Subscribe directly to the sender's profile so the name/avatar appears as
   // soon as the profile row syncs, even if the include in the parent query
   // fired before the profile was in the local store.
-  const senderProfiles = useAll(app.profiles.where({ id: message.senderId })) ?? [];
+  const senderProfiles = useAll(app.profiles.where({ id: message.senderId })).data ?? [];
   const resolvedSender = (senderProfiles[0] as unknown as Profile) ?? sender;
 
-  const attachments = useAll(app.attachments.where({ messageId: message.id })) ?? [];
+  const attachments = useAll(app.attachments.where({ messageId: message.id })).data ?? [];
 
   const canvasMatch = message.text?.match(/^\[Canvas: ([^\]]+)\]$/);
   const canvasId = canvasMatch?.[1] ?? null;

--- a/examples/chat-react/src/components/chat/ChatReactions.tsx
+++ b/examples/chat-react/src/components/chat/ChatReactions.tsx
@@ -5,7 +5,7 @@ import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/h
 import { app } from "../../../schema.js";
 
 function ReactorName({ userId, currentUserId }: { userId: string; currentUserId?: string }) {
-  const profiles = useAll(app.profiles.where({ userId })) ?? [];
+  const profiles = useAll(app.profiles.where({ userId })).data ?? [];
   const profile = profiles[0];
 
   if (userId === currentUserId) return <li>You</li>;
@@ -92,7 +92,7 @@ export const MessageReactions = ({ messageId, isMe }: MessageReactionsProps) => 
   const session = useSession();
   const userId = session?.user_id;
 
-  const reactions = useAll(app.reactions.where({ messageId })) ?? [];
+  const reactions = useAll(app.reactions.where({ messageId })).data ?? [];
 
   if (reactions.length === 0) return null;
 

--- a/examples/chat-react/src/hooks/useChatDisplayName.ts
+++ b/examples/chat-react/src/hooks/useChatDisplayName.ts
@@ -14,10 +14,10 @@ export function useChatDisplayName(chatId: string, chatName?: string): string {
   const session = useSession();
   const userId = session?.user_id ?? null;
 
-  const members = useAll(app.chatMembers.where({ chatId })) ?? [];
-  const allProfiles = useAll(app.profiles) ?? [];
+  const members = useAll(app.chatMembers.where({ chatId })).data ?? [];
+  const allProfiles = useAll(app.profiles).data ?? [];
   const messages =
-    useAll(app.messages.where({ chatId }).orderBy("createdAt", "asc").limit(1)) ?? [];
+    useAll(app.messages.where({ chatId }).orderBy("createdAt", "asc").limit(1)).data ?? [];
 
   if (chatName) return chatName;
 

--- a/examples/chat-react/src/hooks/useMyProfile.ts
+++ b/examples/chat-react/src/hooks/useMyProfile.ts
@@ -19,7 +19,7 @@ export function useMyProfile(): Profile | null {
   const userId = session?.user_id ?? null;
   const sharedWriteOptions = db.getConfig().serverUrl ? { tier: "edge" as const } : undefined;
 
-  const profiles = useAll(app.profiles.where({ userId: userId ?? "__none__" }));
+  const { data: profiles } = useAll(app.profiles.where({ userId: userId ?? "__none__" }));
 
   // Deterministic: always pick the first profile by ID
   const sorted = profiles ? [...profiles].sort((a, b) => a.id.localeCompare(b.id)) : [];

--- a/examples/docs/todo-client-localfirst-expo/src/ConditionalQueryExample.tsx
+++ b/examples/docs/todo-client-localfirst-expo/src/ConditionalQueryExample.tsx
@@ -6,7 +6,9 @@ import { app } from "../schema";
 // #region reading-conditional-query-expo
 export function FilteredTodos() {
   const [filter, setFilter] = useState<string | null>(null);
-  const filtered = useAll(filter ? app.todos.where({ title: { contains: filter } }) : undefined);
+  const { data: filtered } = useAll(
+    filter ? app.todos.where({ title: { contains: filter } }) : undefined,
+  );
 
   return (
     <View>

--- a/examples/docs/todo-client-localfirst-expo/src/LoadingStateExample.tsx
+++ b/examples/docs/todo-client-localfirst-expo/src/LoadingStateExample.tsx
@@ -4,13 +4,13 @@ import { app } from "../schema";
 
 // #region reading-loading-state-expo
 export function TodoList() {
-  const todos = useAll(app.todos);
+  const { data: todos, isLoading } = useAll(app.todos);
 
-  if (todos === undefined) {
+  if (isLoading) {
     return <Text>Connecting…</Text>;
   }
   // todos is now Todo[] — empty array means no rows, not "still loading"
 
-  return todos.map((todo) => <Text key={todo.id}>{todo.title}</Text>);
+  return todos?.map((todo) => <Text key={todo.id}>{todo.title}</Text>);
 }
 // #endregion reading-loading-state-expo

--- a/examples/docs/todo-client-localfirst-expo/src/TodoItem.tsx
+++ b/examples/docs/todo-client-localfirst-expo/src/TodoItem.tsx
@@ -4,7 +4,7 @@ import { app } from "../schema";
 
 export function TodoItem({ id }: { id: string }) {
   const db = useDb();
-  const [todo] = useAll(app.todos.where({ id }).limit(1)) ?? [];
+  const [todo] = useAll(app.todos.where({ id }).limit(1)).data ?? [];
 
   if (!todo) return null;
 

--- a/examples/docs/todo-client-localfirst-expo/src/TodoList.tsx
+++ b/examples/docs/todo-client-localfirst-expo/src/TodoList.tsx
@@ -31,7 +31,7 @@ export function TodoList() {
 
   // #region reading-reactive-hooks-expo
   const db = useDb();
-  const todos = useAll(todosQuery) ?? [];
+  const todos = useAll(todosQuery).data ?? [];
   const session = useSession();
   const sessionUserId = session?.user_id ?? null;
   // #endregion reading-reactive-hooks-expo

--- a/examples/docs/todo-client-localfirst-expo/src/quickstart-list.tsx
+++ b/examples/docs/todo-client-localfirst-expo/src/quickstart-list.tsx
@@ -5,7 +5,7 @@ import { TodoItem } from "./TodoItem";
 import { AddTodo } from "./AddTodo";
 
 export function TodoList() {
-  const todos = useAll(app.todos) ?? [];
+  const todos = useAll(app.todos).data ?? [];
 
   return (
     <View style={{ flex: 1, gap: 12 }}>

--- a/examples/docs/todo-client-localfirst-react/src/AuthSessionExamples.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/AuthSessionExamples.tsx
@@ -14,7 +14,7 @@ export function AuthSessionExamples() {
 
   // #region auth-session-react-query
   const ownedTodos =
-    useAll(sessionUserId ? app.todos.where({ owner_id: sessionUserId }) : undefined) ?? [];
+    useAll(sessionUserId ? app.todos.where({ owner_id: sessionUserId }) : undefined).data ?? [];
   // #endregion auth-session-react-query
 
   // #region auth-session-react-insert

--- a/examples/docs/todo-client-localfirst-react/src/TodoItem.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/TodoItem.tsx
@@ -3,7 +3,7 @@ import { app } from "../schema.js";
 
 export function TodoItem({ id }: { id: string }) {
   const db = useDb();
-  const [todo] = useAll(app.todos.where({ id }).limit(1)) ?? [];
+  const [todo] = useAll(app.todos.where({ id }).limit(1)).data ?? [];
 
   if (!todo) return null;
 

--- a/examples/docs/todo-client-localfirst-react/src/TodoList.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/TodoList.tsx
@@ -6,30 +6,32 @@ import { app } from "../schema.js";
 export function TodoList() {
   // #region read-write-react
   const db = useDb();
-  const todos = useAll(app.todos) ?? [];
+  const todos = useAll(app.todos).data ?? [];
   // #endregion reading-reactive-hooks-react
   // #region reading-filtering-react
-  const incompleteTodos = useAll(
+  const { data: incompleteTodos } = useAll(
     app.todos.where({ done: false }).orderBy("title", "asc").limit(50),
   );
   // #endregion reading-filtering-react
 
   // #region where-subscription-react
-  const pending = useAll(app.todos.where({ done: false }));
+  const { data: pending } = useAll(app.todos.where({ done: false }));
   // #endregion where-subscription-react
 
   // #region reading-tier-react
-  const todosAtEdgeDurability = useAll(app.todos, { tier: "edge" });
+  const { data: todosAtEdgeDurability } = useAll(app.todos, { tier: "edge" });
   // #endregion reading-tier-react
 
   // #region reading-loading-state-react
-  const allTodos = useAll(app.todos);
-  // allTodos is undefined while connecting, [] when loaded but empty
+  const { data: allTodos, isLoading } = useAll(app.todos);
+  // isLoading is true while connecting; allTodos is [] when loaded but empty
   // #endregion reading-loading-state-react
 
   // #region reading-conditional-query-react
   const [filter, setFilter] = useState<string | null>(null);
-  const filtered = useAll(filter ? app.todos.where({ title: { contains: filter } }) : undefined);
+  const { data: filtered } = useAll(
+    filter ? app.todos.where({ title: { contains: filter } }) : undefined,
+  );
   // #endregion reading-conditional-query-react
 
   // #region writing-use-db-react
@@ -56,7 +58,7 @@ export function TodoList() {
     setTitle("");
   };
 
-  if (allTodos === undefined) {
+  if (isLoading) {
     return <p>Connecting…</p>;
   }
 

--- a/examples/docs/todo-client-localfirst-react/src/collab-list-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/collab-list-snippets.tsx
@@ -64,7 +64,9 @@ s.definePermissions(app, ({ policy, anyOf, allowedTo, session }) => {
 // #region collab-subscribe
 export function ProjectTasks({ projectId }: { projectId: string }) {
   const db = useDb();
-  const tasks = useAll(app.tasks.where({ projectId, done: false }).orderBy("$createdAt", "desc"));
+  const { data: tasks } = useAll(
+    app.tasks.where({ projectId, done: false }).orderBy("$createdAt", "desc"),
+  );
 
   function addTask(title: string) {
     db.insert(app.tasks, { title, done: false, projectId });

--- a/examples/docs/todo-client-localfirst-react/src/framework-pattern-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/framework-pattern-snippets.tsx
@@ -22,7 +22,7 @@ export function ProviderExample() {
 
 // #region live-query-react
 export function LiveQueryExample() {
-  const todos = useAll(app.todos.where({ done: false }));
+  const { data: todos } = useAll(app.todos.where({ done: false }));
 
   // undefined = not yet connected; [] = connected, no rows; [...] = rows present
   if (todos === undefined) return <p>Loading...</p>;

--- a/examples/docs/todo-client-localfirst-react/src/group-permissions-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/group-permissions-snippets.tsx
@@ -122,7 +122,7 @@ export function addMember(
 
 // #region group-query-docs
 export function WorkspaceDocuments({ workspaceId }: { workspaceId: string }) {
-  const docs = useAll(app.documents.where({ workspaceId }));
+  const { data: docs } = useAll(app.documents.where({ workspaceId }));
 
   if (!docs) return <p>Loading…</p>;
 
@@ -138,7 +138,7 @@ export function WorkspaceDocuments({ workspaceId }: { workspaceId: string }) {
 
 // #region group-members-list
 export function WorkspaceMembers({ workspaceId }: { workspaceId: string }) {
-  const members = useAll(app.workspaceMembers.where({ workspaceId }));
+  const { data: members } = useAll(app.workspaceMembers.where({ workspaceId }));
 
   if (!members) return <p>Loading…</p>;
 

--- a/examples/docs/todo-client-localfirst-react/src/nested-data-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/nested-data-snippets.tsx
@@ -45,7 +45,7 @@ s.definePermissions(app, ({ policy, allowedTo, session }) => {
 
 // #region nested-query
 export function ProjectTasks({ projectId }: { projectId: string }) {
-  const tasks = useAll(app.tasks.where({ projectId }).orderBy("$createdAt", "desc"));
+  const { data: tasks } = useAll(app.tasks.where({ projectId }).orderBy("$createdAt", "desc"));
 
   if (!tasks) return <p>Loading…</p>;
 

--- a/examples/docs/todo-client-localfirst-react/src/quickstart-list.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/quickstart-list.tsx
@@ -4,7 +4,7 @@ import { TodoItem } from "./TodoItem.js";
 import { AddTodo } from "./AddTodo.js";
 
 export function TodoList() {
-  const todos = useAll(app.todos) ?? [];
+  const todos = useAll(app.todos).data ?? [];
 
   return (
     <>

--- a/examples/docs/todo-client-localfirst-react/src/shared-access-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/shared-access-snippets.tsx
@@ -75,7 +75,7 @@ export function shareTodo(db: ReturnType<typeof useDb>, todoId: string, recipien
 // #region shared-query
 export function SharedWithMe() {
   const session = useSession();
-  const shares = useAll(
+  const { data: shares } = useAll(
     app.todoShares.where({ user_id: session!.user_id }).include({ todo: true }),
   );
 

--- a/examples/docs/todo-client-localfirst-react/src/user-owned-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/user-owned-snippets.tsx
@@ -24,7 +24,7 @@ s.definePermissions(app, ({ policy, session }) => {
 
 // #region owned-query
 export function MyTodos() {
-  const todos = useAll(app.todos.where({ done: false }));
+  const { data: todos } = useAll(app.todos.where({ done: false }));
 
   if (!todos) return <p>Loading…</p>;
 

--- a/examples/file-upload-react/src/App.tsx
+++ b/examples/file-upload-react/src/App.tsx
@@ -99,7 +99,7 @@ function FileUploadScreen() {
         .orderBy("lastModified", "desc")
         .limit(1)
         .requireIncludes(),
-    ) ?? [];
+    ).data ?? [];
   const latestUpload = uploads[0];
   const [objectUrl, setObjectUrl] = useState<string | null>(null);
 

--- a/examples/moon-lander-react/src/jazz/useSync.ts
+++ b/examples/moon-lander-react/src/jazz/useSync.ts
@@ -70,17 +70,17 @@ export function useSync(playerId: string): SyncResult {
   // ---------------------------------------------------------------------------
 
   // Other players (exclude self)
-  const allRemotePlayers = useAll(app.players.where({ playerId: { ne: playerId } })) ?? [];
+  const allRemotePlayers = useAll(app.players.where({ playerId: { ne: playerId } })).data ?? [];
   const remotePlayers = useMemo(
     () => allRemotePlayers.filter((p) => p.lastSeen > staleCutoff),
     [allRemotePlayers, staleCutoff],
   );
 
   // Chat messages (ordered oldest-first for rendering)
-  const allChatMessages = useAll(app.chat_messages.orderBy("createdAt", "asc")) ?? [];
+  const allChatMessages = useAll(app.chat_messages.orderBy("createdAt", "asc")).data ?? [];
 
   // Local player row — used to detect first join (no row yet) vs reconnect
-  const localPlayerRowsRaw = useAll(app.players.where({ playerId }));
+  const { data: localPlayerRowsRaw } = useAll(app.players.where({ playerId }));
   const localPlayerRows = localPlayerRowsRaw ?? [];
   const localFuelType = localPlayerRows[0]?.requiredFuelType ?? FUEL_TYPES[0];
 
@@ -100,11 +100,13 @@ export function useSync(playerId: string): SyncResult {
 
   // Uncollected deposits — what the game renders on the surface.
   // "edge" tier: undefined until the edge subscription connects, which drives settled detection.
-  const allUncollected = useAll(app.fuel_deposits.where({ collected: false }), { tier: "edge" });
+  const { data: allUncollected } = useAll(app.fuel_deposits.where({ collected: false }), {
+    tier: "edge",
+  });
 
   // This player's collected deposits (compound WHERE = precise local tracking).
   // WHERE ENTRY fires immediately when this player collects (both fields match).
-  const localCollectedDeposits = useAll(
+  const { data: localCollectedDeposits } = useAll(
     app.fuel_deposits.where({ collected: true, collectedBy: playerId }),
   );
 
@@ -112,7 +114,7 @@ export function useSync(playerId: string): SyncResult {
   // other players. When Player A shares with B, B already has the row here
   // (it entered when A collected it), so collectedBy updating to B propagates
   // as a plain row update without needing WHERE re-evaluation.
-  const allCollectedDeposits = useAll(app.fuel_deposits.where({ collected: true }));
+  const { data: allCollectedDeposits } = useAll(app.fuel_deposits.where({ collected: true }));
 
   const settled = allUncollected !== undefined;
   const uncollectedDeposits = allUncollected ?? [];

--- a/examples/nextjs-csr-ssr/app/ClientTodo.tsx
+++ b/examples/nextjs-csr-ssr/app/ClientTodo.tsx
@@ -30,7 +30,7 @@ export default function ClientTodo() {
 }
 
 function TodoList() {
-  const todos = useAll(app.todos) ?? [];
+  const todos = useAll(app.todos).data ?? [];
   return (
     <ul className="mt-4 space-y-1">
       {todos.length === 0 && <li className="text-sm text-foreground/30 italic">No todos yet.</li>}

--- a/examples/todo-client-localfirst-expo/src/TodoList.tsx
+++ b/examples/todo-client-localfirst-expo/src/TodoList.tsx
@@ -42,7 +42,7 @@ export function TodoList() {
   }
 
   const db = useDb();
-  const todos = useAll(todosQuery) ?? [];
+  const todos = useAll(todosQuery).data ?? [];
   const session = useSession();
   const sessionUserId = session?.user_id ?? null;
 

--- a/examples/todo-client-localfirst-react/src/TodoList.tsx
+++ b/examples/todo-client-localfirst-react/src/TodoList.tsx
@@ -17,7 +17,7 @@ export function TodoList() {
 
   const db = useDb();
   // #region reading-reactive-hooks-react
-  const todos = useAll(todosQuery) ?? [];
+  const todos = useAll(todosQuery).data ?? [];
   // #endregion reading-reactive-hooks-react
   const session = useSession();
   const sessionUserId = session?.user_id ?? null;

--- a/packages/jazz-tools/src/react-core/index.ts
+++ b/packages/jazz-tools/src/react-core/index.ts
@@ -8,8 +8,8 @@ export {
   type JazzClientProviderProps,
   type JazzProviderProps,
 } from "./provider.js";
-export { useAll, useAllSuspense } from "./use-all.js";
-export { useOne, useOneSuspense } from "./use-one.js";
+export { useAll, useAllSuspense, type UseAllResult } from "./use-all.js";
+export { useOne, useOneSuspense, type UseOneResult } from "./use-one.js";
 export { useAuthState, type AuthStateInfo } from "./use-auth-state.js";
 export { createUseLocalFirstAuth, type LocalFirstAuth } from "./use-local-first-auth.js";
 

--- a/packages/jazz-tools/src/react-core/index.ts
+++ b/packages/jazz-tools/src/react-core/index.ts
@@ -9,6 +9,7 @@ export {
   type JazzProviderProps,
 } from "./provider.js";
 export { useAll, useAllSuspense } from "./use-all.js";
+export { useOne, useOneSuspense } from "./use-one.js";
 export { useAuthState, type AuthStateInfo } from "./use-auth-state.js";
 export { createUseLocalFirstAuth, type LocalFirstAuth } from "./use-local-first-auth.js";
 

--- a/packages/jazz-tools/src/react-core/use-all.test.tsx
+++ b/packages/jazz-tools/src/react-core/use-all.test.tsx
@@ -97,7 +97,7 @@ describe("react-core/useAll", () => {
     const { client, subscribeCalls } = makeHarness("rc-all-02");
 
     function List() {
-      const todos = useAll(makeQuery());
+      const { data: todos } = useAll(makeQuery());
       return (
         <>
           {(todos ?? []).map((t) => (
@@ -133,7 +133,7 @@ describe("react-core/useAll", () => {
     const { client, subscribeCalls } = makeHarness("rc-all-03");
 
     function List() {
-      const todos = useAll(makeQuery());
+      const { data: todos } = useAll(makeQuery());
       return <span>{(todos ?? []).length}</span>;
     }
 
@@ -154,7 +154,7 @@ describe("react-core/useAll", () => {
     manager.makeQueryKey(query, undefined, [{ id: "1", title: "seeded" }]);
 
     function List() {
-      const todos = useAll(query);
+      const { data: todos } = useAll(query);
       return (
         <>
           {(todos ?? []).map((t) => (
@@ -174,14 +174,19 @@ describe("react-core/useAll", () => {
     expect(subscribeCalls).toHaveLength(0);
   });
 
-  it("a failed subscription leaves non-suspense useAll undefined and does not throw", () => {
+  it("a failed subscription surfaces the error and leaves data undefined without throwing", () => {
     const { client } = makeHarness("rc-all-05", {
       throwOnSubscribe: new Error("subscribe failed"),
     });
 
     function List() {
-      const todos = useAll(makeQuery());
-      return <span>{todos === undefined ? "no-data" : String(todos.length)}</span>;
+      const { data: todos, isLoading, error } = useAll(makeQuery());
+      return (
+        <span>
+          {todos === undefined ? "no-data" : String(todos.length)}/{String(isLoading)}/
+          {error?.message ?? "no-error"}
+        </span>
+      );
     }
 
     const { container } = render(
@@ -190,7 +195,7 @@ describe("react-core/useAll", () => {
       </JazzClientProvider>,
     );
 
-    expect(container.textContent).toBe("no-data");
+    expect(container.textContent).toBe("no-data/false/subscribe failed");
   });
 
   it("useAllSuspense throws a failed subscription to the error boundary", () => {

--- a/packages/jazz-tools/src/react-core/use-all.ts
+++ b/packages/jazz-tools/src/react-core/use-all.ts
@@ -12,7 +12,13 @@ type UseAllOptions = {
 // its entry promise — opened during render so a suspended effect can't strand it.
 const SUSPEND_FOREVER: Promise<never> = new Promise(() => {});
 
-function useAllBase<T extends { id: string }>(
+/**
+ * Shared implementation behind {@link useAll}/{@link useAllSuspense} and the
+ * `useOne` bindings. Not part of the public API.
+ *
+ * @internal
+ */
+export function useAllBase<T extends { id: string }>(
   query?: QueryBuilder<T>,
   queryOptions?: QueryOptions,
   options?: UseAllOptions,

--- a/packages/jazz-tools/src/react-core/use-all.ts
+++ b/packages/jazz-tools/src/react-core/use-all.ts
@@ -2,8 +2,16 @@ import { type Usable, use, useCallback, useRef, useSyncExternalStore } from "rea
 import type { QueryBuilder, QueryOptions, UseAllState } from "../shared/index.js";
 import { useJazzClient } from "./provider.js";
 
-type UseAllOptions = {
-  suspense?: boolean;
+/**
+ * Reactive result of {@link useAll}. `data` is the matching rows (`undefined`
+ * until the first result resolves, or on error), `isLoading` is `true` until the
+ * first result or error arrives, and `error` is the last subscription error (or
+ * `null`). Mirrors the shape Solid's `useAll` returns.
+ */
+export type UseAllResult<T extends { id: string }> = {
+  data: T[] | undefined;
+  isLoading: boolean;
+  error: Error | null;
 };
 
 // A query that never arrives has nothing to fetch, so the suspense variant
@@ -12,30 +20,39 @@ type UseAllOptions = {
 // its entry promise — opened during render so a suspended effect can't strand it.
 const SUSPEND_FOREVER: Promise<never> = new Promise(() => {});
 
+function toError(value: unknown): Error {
+  return value instanceof Error ? value : new Error(String(value));
+}
+
 /**
- * Shared implementation behind {@link useAll}/{@link useAllSuspense} and the
- * `useOne` bindings. Not part of the public API.
+ * Subscription wiring shared by every react-core query hook: it computes the
+ * pure cache key, keeps the latest query/options in refs, and drives a
+ * `useSyncExternalStore`, returning the raw cache state. Not part of the public
+ * API.
+ *
+ * `computeKey` neither registers the query nor opens a subscription, so the
+ * render phase stays side-effect free (concurrent/strict and SSR safe).
+ * Registration + subscription happen in the commit-phase `subscribe` callback.
+ *
+ * The refs let the keyed `subscribe`/`getSnapshot` callbacks read the latest
+ * query/options without depending on object identity — an inline
+ * `app.todos.where(...)` is a fresh object every render, but the string key is
+ * stable, so we must not resubscribe just because the object changed.
  *
  * @internal
  */
-export function useAllBase<T extends { id: string }>(
+function useQuerySubscription<T extends { id: string }>(
   query?: QueryBuilder<T>,
   queryOptions?: QueryOptions,
-  options?: UseAllOptions,
-): T[] | undefined {
-  const { suspense = false } = options ?? {};
+): {
+  manager: ReturnType<typeof useJazzClient>["manager"];
+  key: string | null;
+  state: UseAllState<T> | null;
+} {
   const { manager } = useJazzClient();
 
-  // Pure, render-safe key: computeKey neither registers the query nor opens a
-  // subscription, so the render phase stays side-effect free (concurrent/strict
-  // and SSR safe). Registration + subscription happen in the commit-phase
-  // `subscribe` callback below.
   const key = query ? manager.computeKey(query, queryOptions) : null;
 
-  // Keep the latest query/options in refs so the keyed `subscribe`/`getSnapshot`
-  // callbacks can read them without depending on object identity — an inline
-  // `app.todos.where(...)` is a fresh object every render, but the string key is
-  // stable, so we must not resubscribe just because the object changed.
   const queryRef = useRef(query);
   queryRef.current = query;
   const optionsRef = useRef(queryOptions);
@@ -66,56 +83,92 @@ export function useAllBase<T extends { id: string }>(
 
   const state = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 
-  if (suspense) {
-    if (!query || key === null) {
-      return use(SUSPEND_FOREVER as unknown as Usable<T[]>);
-    }
+  return { manager, key, state };
+}
 
-    if (state) {
-      if (state.status === "fulfilled") {
-        return state.data;
-      }
-      if (state.status === "rejected") {
-        throw state.error;
-      }
-    }
+/**
+ * Non-suspense engine behind {@link useAll} and the `useOne` bindings: returns
+ * the live `{ data, isLoading, error }` for a query. Not part of the public API.
+ *
+ * @internal
+ */
+export function useAllResultBase<T extends { id: string }>(
+  query?: QueryBuilder<T>,
+  queryOptions?: QueryOptions,
+): UseAllResult<T> {
+  const { state } = useQuerySubscription(query, queryOptions);
 
-    // Pending: a suspense data source must start fetching during render — the
-    // `subscribe` effect can't run while the boundary is suspended — so create
-    // the entry here and suspend on its real promise (which resolves on the
-    // first result), rather than a sentinel that never resolves.
-    manager.makeQueryKey(query, queryOptions);
-    const entry = manager.getCacheEntry<T>(key);
-    if (entry.state.status === "rejected") {
-      throw entry.state.error;
-    }
-    if (entry.state.status === "fulfilled") {
-      return entry.state.data;
-    }
-    return use(entry.promise as unknown as Usable<T[]>);
+  if (!query) {
+    return { data: undefined, isLoading: false, error: null };
+  }
+  if (!state || state.status === "pending") {
+    return { data: undefined, isLoading: true, error: null };
+  }
+  if (state.status === "rejected") {
+    return { data: undefined, isLoading: false, error: toError(state.error) };
+  }
+  return { data: state.data, isLoading: false, error: null };
+}
+
+/**
+ * Suspense engine behind {@link useAllSuspense} and {@link useOneSuspense}:
+ * returns the resolved rows, suspending until the query resolves and throwing
+ * its error to the nearest boundary. Not part of the public API.
+ *
+ * @internal
+ */
+export function useAllSuspenseBase<T extends { id: string }>(
+  query?: QueryBuilder<T>,
+  queryOptions?: QueryOptions,
+): T[] {
+  const { manager, key, state } = useQuerySubscription(query, queryOptions);
+
+  if (!query || key === null) {
+    return use(SUSPEND_FOREVER as unknown as Usable<T[]>);
   }
 
-  return state?.status === "fulfilled" ? state.data : undefined;
+  if (state) {
+    if (state.status === "fulfilled") {
+      return state.data;
+    }
+    if (state.status === "rejected") {
+      throw state.error;
+    }
+  }
+
+  // Pending: a suspense data source must start fetching during render — the
+  // `subscribe` effect can't run while the boundary is suspended — so create
+  // the entry here and suspend on its real promise (which resolves on the
+  // first result), rather than a sentinel that never resolves.
+  manager.makeQueryKey(query, queryOptions);
+  const entry = manager.getCacheEntry<T>(key);
+  if (entry.state.status === "rejected") {
+    throw entry.state.error;
+  }
+  if (entry.state.status === "fulfilled") {
+    return entry.state.data;
+  }
+  return use(entry.promise as unknown as Usable<T[]>);
 }
 
 /**
  * Read all matching rows and subscribe to changes that modify the query's results.
  *
- * Loading and error states are handled the React way: `undefined` means the
- * query has not resolved yet, and for error handling use {@link useAllSuspense}
- * with a Suspense + error boundary. (The Svelte and Vue bindings expose the same
- * capabilities idiomatically — Svelte's `QuerySubscription` via
- * `.current`/`.loading`/`.error`, Vue's `useAll` via `{ data, error, loading }`.)
- *
  * @param query - the database query (e.g. `app.todos.where({done: false})`)
  *
- * @returns the matching rows, or `undefined` if the query is not yet executed
+ * @returns reactive `{ data, isLoading, error }`. `data` is `undefined` until the
+ *   query resolves (and on error); `isLoading` is `true` until the first result
+ *   or error; `error` holds the subscription error, or `null`. For Suspense-based
+ *   loading/error handling use {@link useAllSuspense}. (The Svelte and Vue
+ *   bindings expose the same capabilities idiomatically — Svelte's
+ *   `QuerySubscription` via `.current`/`.loading`/`.error`, Vue's `useAll` via
+ *   `{ data, error, loading }`.)
  */
 export function useAll<T extends { id: string }>(
   query?: QueryBuilder<T>,
   options?: QueryOptions,
-): T[] | undefined {
-  return useAllBase(query, options, { suspense: false });
+): UseAllResult<T> {
+  return useAllResultBase(query, options);
 }
 
 /**
@@ -136,5 +189,5 @@ export function useAllSuspense<T extends { id: string }>(
   query?: QueryBuilder<T>,
   options?: QueryOptions,
 ): T[] {
-  return useAllBase(query, options, { suspense: true }) as T[];
+  return useAllSuspenseBase(query, options);
 }

--- a/packages/jazz-tools/src/react-core/use-one.test.tsx
+++ b/packages/jazz-tools/src/react-core/use-one.test.tsx
@@ -1,0 +1,227 @@
+import * as React from "react";
+import { Component, Suspense, useState, type ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render } from "@testing-library/react";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { QueryBuilder } from "../runtime/db.js";
+import { limitQueryToOne } from "../runtime/limit-query.js";
+import type { SubscriptionDelta } from "../runtime/subscription-manager.js";
+import { SubscriptionsOrchestrator } from "../subscriptions-orchestrator.js";
+import { JazzClientProvider } from "./provider.js";
+import { useOne, useOneSuspense } from "./use-one.js";
+
+type Todo = { id: string; title: string };
+
+function makeQuery(table = "todos"): QueryBuilder<Todo> {
+  return {
+    _table: table,
+    _schema: {},
+    _rowType: {} as Todo,
+    _build: () => JSON.stringify({ table, conditions: [], includes: {}, orderBy: [] }),
+  } as unknown as QueryBuilder<Todo>;
+}
+
+function delta(all: Todo[]): SubscriptionDelta<Todo> {
+  return { all, delta: [] };
+}
+
+function makeHarness(appId: string, options?: { throwOnSubscribe?: Error }) {
+  const subscribeCalls: Array<{
+    query: QueryBuilder<Todo>;
+    callback: (d: SubscriptionDelta<Todo>) => void;
+    unsubscribe: ReturnType<typeof vi.fn>;
+  }> = [];
+
+  const db = {
+    getAuthState: () => ({ authMode: "local-first", session: null }),
+    onAuthChanged: () => () => {},
+    updateAuthToken: () => {},
+    subscribeAll: (query: any, callback: (d: SubscriptionDelta<any>) => void) => {
+      if (options?.throwOnSubscribe) {
+        throw options.throwOnSubscribe;
+      }
+      const unsubscribe = vi.fn();
+      subscribeCalls.push({
+        query: query as QueryBuilder<Todo>,
+        callback: callback as (d: SubscriptionDelta<Todo>) => void,
+        unsubscribe,
+      });
+      return unsubscribe;
+    },
+  };
+
+  const manager = new SubscriptionsOrchestrator({ appId }, db as any);
+  const client = { db, manager, session: null, shutdown: async () => {} } as any;
+  return { client, manager, subscribeCalls };
+}
+
+class ErrorBoundary extends Component<
+  { fallback: ReactNode; children: ReactNode },
+  { error: Error | null }
+> {
+  state: { error: Error | null } = { error: null };
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+  render() {
+    return this.state.error ? this.props.fallback : this.props.children;
+  }
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("react-core/useOne", () => {
+  it("subscribes with the query limited to one row", () => {
+    const { client, subscribeCalls } = makeHarness("rc-one-00");
+
+    function Probe() {
+      useOne(makeQuery());
+      return null;
+    }
+
+    render(
+      <JazzClientProvider client={client}>
+        <Probe />
+      </JazzClientProvider>,
+    );
+
+    expect(subscribeCalls).toHaveLength(1);
+    const built = JSON.parse(subscribeCalls[0]!.query._build());
+    expect(built.limit).toBe(1);
+  });
+
+  it("an inline query does not resubscribe across re-renders", () => {
+    const { client, subscribeCalls } = makeHarness("rc-one-01");
+    let force!: (n: number) => void;
+
+    function Probe() {
+      const [, setN] = useState(0);
+      force = setN;
+      useOne(makeQuery());
+      return null;
+    }
+
+    render(
+      <JazzClientProvider client={client}>
+        <Probe />
+      </JazzClientProvider>,
+    );
+
+    act(() => force(1));
+    act(() => force(2));
+
+    expect(subscribeCalls).toHaveLength(1);
+  });
+
+  it("renders the row and reflects later deltas", () => {
+    const { client, subscribeCalls } = makeHarness("rc-one-02");
+
+    function Item() {
+      const todo = useOne(makeQuery());
+      return <span>{todo === undefined ? "pending" : (todo?.title ?? "none")}</span>;
+    }
+
+    const { container } = render(
+      <JazzClientProvider client={client}>
+        <Item />
+      </JazzClientProvider>,
+    );
+
+    expect(container.textContent).toBe("pending");
+
+    act(() => subscribeCalls[0]!.callback(delta([{ id: "1", title: "first" }])));
+    expect(container.textContent).toBe("first");
+
+    // A later delta with a different top row replaces the tracked row.
+    act(() => subscribeCalls[0]!.callback(delta([{ id: "2", title: "second" }])));
+    expect(container.textContent).toBe("second");
+
+    // Resolving to no rows yields null, distinct from the pending undefined.
+    act(() => subscribeCalls[0]!.callback(delta([])));
+    expect(container.textContent).toBe("none");
+  });
+
+  it("StrictMode does not open a duplicate subscription", () => {
+    const { client, subscribeCalls } = makeHarness("rc-one-03");
+
+    function Item() {
+      const todo = useOne(makeQuery());
+      return <span>{todo?.title ?? ""}</span>;
+    }
+
+    render(
+      <React.StrictMode>
+        <JazzClientProvider client={client}>
+          <Item />
+        </JazzClientProvider>
+      </React.StrictMode>,
+    );
+
+    expect(subscribeCalls).toHaveLength(1);
+  });
+
+  it("server render reads the seeded snapshot without subscribing", () => {
+    const { client, manager, subscribeCalls } = makeHarness("rc-one-04");
+    const query = makeQuery();
+    // The hook subscribes to the limited query, so the seed must key off it too.
+    manager.makeQueryKey(limitQueryToOne(query), undefined, [{ id: "1", title: "seeded" }]);
+
+    function Item() {
+      const todo = useOne(query);
+      return <span>{todo?.title ?? "none"}</span>;
+    }
+
+    const html = renderToStaticMarkup(
+      <JazzClientProvider client={client}>
+        <Item />
+      </JazzClientProvider>,
+    );
+
+    expect(html).toContain("seeded");
+    expect(subscribeCalls).toHaveLength(0);
+  });
+
+  it("a failed subscription leaves non-suspense useOne undefined and does not throw", () => {
+    const { client } = makeHarness("rc-one-05", {
+      throwOnSubscribe: new Error("subscribe failed"),
+    });
+
+    function Item() {
+      const todo = useOne(makeQuery());
+      return <span>{todo === undefined ? "no-data" : (todo?.title ?? "none")}</span>;
+    }
+
+    const { container } = render(
+      <JazzClientProvider client={client}>
+        <Item />
+      </JazzClientProvider>,
+    );
+
+    expect(container.textContent).toBe("no-data");
+  });
+
+  it("useOneSuspense throws a failed subscription to the error boundary", () => {
+    const { client } = makeHarness("rc-one-06", {
+      throwOnSubscribe: new Error("subscribe failed"),
+    });
+
+    function Item() {
+      const todo = useOneSuspense(makeQuery());
+      return <span>{todo?.title ?? "none"}</span>;
+    }
+
+    const { container } = render(
+      <JazzClientProvider client={client}>
+        <ErrorBoundary fallback={<span>caught</span>}>
+          <Suspense fallback={<span>loading</span>}>
+            <Item />
+          </Suspense>
+        </ErrorBoundary>
+      </JazzClientProvider>,
+    );
+
+    expect(container.textContent).toBe("caught");
+  });
+});

--- a/packages/jazz-tools/src/react-core/use-one.test.tsx
+++ b/packages/jazz-tools/src/react-core/use-one.test.tsx
@@ -119,7 +119,7 @@ describe("react-core/useOne", () => {
     const { client, subscribeCalls } = makeHarness("rc-one-02");
 
     function Item() {
-      const todo = useOne(makeQuery());
+      const { data: todo } = useOne(makeQuery());
       return <span>{todo === undefined ? "pending" : (todo?.title ?? "none")}</span>;
     }
 
@@ -147,7 +147,7 @@ describe("react-core/useOne", () => {
     const { client, subscribeCalls } = makeHarness("rc-one-03");
 
     function Item() {
-      const todo = useOne(makeQuery());
+      const { data: todo } = useOne(makeQuery());
       return <span>{todo?.title ?? ""}</span>;
     }
 
@@ -169,7 +169,7 @@ describe("react-core/useOne", () => {
     manager.makeQueryKey(limitQueryToOne(query), undefined, [{ id: "1", title: "seeded" }]);
 
     function Item() {
-      const todo = useOne(query);
+      const { data: todo } = useOne(query);
       return <span>{todo?.title ?? "none"}</span>;
     }
 
@@ -183,14 +183,19 @@ describe("react-core/useOne", () => {
     expect(subscribeCalls).toHaveLength(0);
   });
 
-  it("a failed subscription leaves non-suspense useOne undefined and does not throw", () => {
+  it("a failed subscription surfaces the error and leaves data undefined without throwing", () => {
     const { client } = makeHarness("rc-one-05", {
       throwOnSubscribe: new Error("subscribe failed"),
     });
 
     function Item() {
-      const todo = useOne(makeQuery());
-      return <span>{todo === undefined ? "no-data" : (todo?.title ?? "none")}</span>;
+      const { data: todo, isLoading, error } = useOne(makeQuery());
+      return (
+        <span>
+          {todo === undefined ? "no-data" : (todo?.title ?? "none")}/{String(isLoading)}/
+          {error?.message ?? "no-error"}
+        </span>
+      );
     }
 
     const { container } = render(
@@ -199,7 +204,7 @@ describe("react-core/useOne", () => {
       </JazzClientProvider>,
     );
 
-    expect(container.textContent).toBe("no-data");
+    expect(container.textContent).toBe("no-data/false/subscribe failed");
   });
 
   it("useOneSuspense throws a failed subscription to the error boundary", () => {
@@ -223,5 +228,56 @@ describe("react-core/useOne", () => {
     );
 
     expect(container.textContent).toBe("caught");
+  });
+
+  // Pre-resolve the entry for the limited query so the suspense reader returns
+  // synchronously on first render — exercising the success branch (`rows[0] ??
+  // null`) deterministically, without relying on async suspense-retry timing.
+  function resolveOne(manager: SubscriptionsOrchestrator, query: QueryBuilder<Todo>, rows: Todo[]) {
+    const limited = limitQueryToOne(query);
+    manager.makeQueryKey(limited, undefined, rows);
+    manager.getCacheEntry<Todo>(manager.computeKey(limited, undefined));
+  }
+
+  it("useOneSuspense returns the matching row once the query resolves", () => {
+    const { client, manager } = makeHarness("rc-one-07");
+    const query = makeQuery();
+    resolveOne(manager, query, [{ id: "1", title: "only" }]);
+
+    function Item() {
+      const todo = useOneSuspense(query);
+      return <span>{todo?.title ?? "none"}</span>;
+    }
+
+    const { container } = render(
+      <JazzClientProvider client={client}>
+        <Suspense fallback={<span>loading</span>}>
+          <Item />
+        </Suspense>
+      </JazzClientProvider>,
+    );
+
+    expect(container.textContent).toBe("only");
+  });
+
+  it("useOneSuspense returns null when the query resolves with no row", () => {
+    const { client, manager } = makeHarness("rc-one-08");
+    const query = makeQuery();
+    resolveOne(manager, query, []);
+
+    function Item() {
+      const todo = useOneSuspense(query);
+      return <span>{todo === null ? "null" : (todo?.title ?? "?")}</span>;
+    }
+
+    const { container } = render(
+      <JazzClientProvider client={client}>
+        <Suspense fallback={<span>loading</span>}>
+          <Item />
+        </Suspense>
+      </JazzClientProvider>,
+    );
+
+    expect(container.textContent).toBe("null");
   });
 });

--- a/packages/jazz-tools/src/react-core/use-one.ts
+++ b/packages/jazz-tools/src/react-core/use-one.ts
@@ -1,0 +1,53 @@
+import type { QueryBuilder, QueryOptions } from "../shared/index.js";
+import { limitQueryToOne } from "../runtime/limit-query.js";
+import { useAllBase } from "./use-all.js";
+
+// `useOne` is `useAll` narrowed to a single row: the query is executed with
+// `limit 1` (the same wrapper `db.one` uses, so the two stay in lockstep), and
+// the subscription tracks just that row — replacing it should a closer match
+// appear or the current one be removed.
+
+/**
+ * Read the first matching row and subscribe to changes that affect it.
+ *
+ * The query is run with `limit 1`, mirroring {@link Db.one}. Loading and error
+ * states are handled the React way: `undefined` means the query has not resolved
+ * yet, `null` means it resolved with no matching row, and for error handling use
+ * {@link useOneSuspense} with a Suspense + error boundary.
+ *
+ * @param query - the database query (e.g. `app.todos.where({ id })`)
+ *
+ * @returns the matching row, `null` if none matched, or `undefined` if the query
+ * is not yet executed
+ */
+export function useOne<T extends { id: string }>(
+  query?: QueryBuilder<T>,
+  options?: QueryOptions,
+): T | null | undefined {
+  const rows = useAllBase(query ? limitQueryToOne(query) : undefined, options, {
+    suspense: false,
+  });
+  return rows === undefined ? undefined : (rows[0] ?? null);
+}
+
+/**
+ * Read the first matching row and subscribe to changes that affect it.
+ * Suspends until the query is executed.
+ *
+ * The query is run with `limit 1`, mirroring {@link Db.one}. Once resolved,
+ * returns the matching row, or `null` if none matched. See {@link useAllSuspense}
+ * for the server-render and Suspense semantics, which this hook shares.
+ *
+ * @param query - the database query (e.g. `app.todos.where({ id })`)
+ *
+ * @returns the matching row, or `null` if none matched
+ */
+export function useOneSuspense<T extends { id: string }>(
+  query?: QueryBuilder<T>,
+  options?: QueryOptions,
+): T | null {
+  const rows = useAllBase(query ? limitQueryToOne(query) : undefined, options, {
+    suspense: true,
+  }) as T[];
+  return rows[0] ?? null;
+}

--- a/packages/jazz-tools/src/react-core/use-one.ts
+++ b/packages/jazz-tools/src/react-core/use-one.ts
@@ -1,6 +1,6 @@
 import type { QueryBuilder, QueryOptions } from "../shared/index.js";
 import { limitQueryToOne } from "../runtime/limit-query.js";
-import { useAllBase } from "./use-all.js";
+import { useAllResultBase, useAllSuspenseBase } from "./use-all.js";
 
 // `useOne` is `useAll` narrowed to a single row: the query is executed with
 // `limit 1` (the same wrapper `db.one` uses, so the two stay in lockstep), and
@@ -8,26 +8,40 @@ import { useAllBase } from "./use-all.js";
 // appear or the current one be removed.
 
 /**
+ * Reactive result of {@link useOne}. Like {@link UseAllResult} but for a single
+ * row: `data` is the matching row, `null` once the query resolves with no match,
+ * or `undefined` while loading (and on error); `isLoading` is `true` until the
+ * query resolves; `error` holds the subscription error, or `null`.
+ */
+export type UseOneResult<T extends { id: string }> = {
+  data: T | null | undefined;
+  isLoading: boolean;
+  error: Error | null;
+};
+
+/**
  * Read the first matching row and subscribe to changes that affect it.
  *
- * The query is run with `limit 1`, mirroring {@link Db.one}. Loading and error
- * states are handled the React way: `undefined` means the query has not resolved
- * yet, `null` means it resolved with no matching row, and for error handling use
- * {@link useOneSuspense} with a Suspense + error boundary.
+ * The query is run with `limit 1`, mirroring {@link Db.one}.
  *
  * @param query - the database query (e.g. `app.todos.where({ id })`)
  *
- * @returns the matching row, `null` if none matched, or `undefined` if the query
- * is not yet executed
+ * @returns reactive `{ data, isLoading, error }`. `data` is the matching row,
+ *   `null` once the query resolves with no match, or `undefined` while loading
+ *   (and on error); `isLoading` is `true` until the query resolves. For
+ *   Suspense-based loading/error handling use {@link useOneSuspense}.
  */
 export function useOne<T extends { id: string }>(
   query?: QueryBuilder<T>,
   options?: QueryOptions,
-): T | null | undefined {
-  const rows = useAllBase(query ? limitQueryToOne(query) : undefined, options, {
-    suspense: false,
-  });
-  return rows === undefined ? undefined : (rows[0] ?? null);
+): UseOneResult<T> {
+  const {
+    data: rows,
+    isLoading,
+    error,
+  } = useAllResultBase(query ? limitQueryToOne(query) : undefined, options);
+  const data = rows === undefined ? undefined : (rows[0] ?? null);
+  return { data, isLoading, error };
 }
 
 /**
@@ -46,8 +60,6 @@ export function useOneSuspense<T extends { id: string }>(
   query?: QueryBuilder<T>,
   options?: QueryOptions,
 ): T | null {
-  const rows = useAllBase(query ? limitQueryToOne(query) : undefined, options, {
-    suspense: true,
-  }) as T[];
+  const rows = useAllSuspenseBase(query ? limitQueryToOne(query) : undefined, options);
   return rows[0] ?? null;
 }

--- a/packages/jazz-tools/src/react-native/index.ts
+++ b/packages/jazz-tools/src/react-native/index.ts
@@ -3,6 +3,7 @@ export { createJazzClient, type JazzClient } from "./create-jazz-client.js";
 export { loadJazzRn } from "./jazz-rn-loader.js";
 export type { JazzRnRuntimeBinding } from "./jazz-rn-runtime-adapter.js";
 export { useAll, useAllSuspense } from "./use-all.js";
+export { useOne, useOneSuspense } from "./use-one.js";
 export {
   JazzProvider,
   type JazzProviderProps,

--- a/packages/jazz-tools/src/react-native/index.ts
+++ b/packages/jazz-tools/src/react-native/index.ts
@@ -4,6 +4,8 @@ export { loadJazzRn } from "./jazz-rn-loader.js";
 export type { JazzRnRuntimeBinding } from "./jazz-rn-runtime-adapter.js";
 export { useAll, useAllSuspense } from "./use-all.js";
 export { useOne, useOneSuspense } from "./use-one.js";
+export type { UseAllResult } from "../react-core/use-all.js";
+export type { UseOneResult } from "../react-core/use-one.js";
 export {
   JazzProvider,
   type JazzProviderProps,

--- a/packages/jazz-tools/src/react-native/use-one.ts
+++ b/packages/jazz-tools/src/react-native/use-one.ts
@@ -1,0 +1,1 @@
+export { useOne, useOneSuspense } from "../react-core/use-one.js";

--- a/packages/jazz-tools/src/react/index.ts
+++ b/packages/jazz-tools/src/react/index.ts
@@ -14,6 +14,7 @@ export {
   useSession,
 } from "./provider.js";
 export { useAll, useAllSuspense } from "./use-all.js";
+export { useOne, useOneSuspense } from "./use-one.js";
 export { useLocalFirstAuth, type LocalFirstAuth } from "./use-local-first-auth.js";
 export { useAuthState, type AuthStateInfo } from "../react-core/use-auth-state.js";
 export type { QueryOptions, RuntimeSourcesConfig } from "../runtime/index.js";

--- a/packages/jazz-tools/src/react/index.ts
+++ b/packages/jazz-tools/src/react/index.ts
@@ -15,6 +15,8 @@ export {
 } from "./provider.js";
 export { useAll, useAllSuspense } from "./use-all.js";
 export { useOne, useOneSuspense } from "./use-one.js";
+export type { UseAllResult } from "../react-core/use-all.js";
+export type { UseOneResult } from "../react-core/use-one.js";
 export { useLocalFirstAuth, type LocalFirstAuth } from "./use-local-first-auth.js";
 export { useAuthState, type AuthStateInfo } from "../react-core/use-auth-state.js";
 export type { QueryOptions, RuntimeSourcesConfig } from "../runtime/index.js";

--- a/packages/jazz-tools/src/react/use-one.ts
+++ b/packages/jazz-tools/src/react/use-one.ts
@@ -1,0 +1,1 @@
+export { useOne, useOneSuspense } from "../react-core/use-one.js";

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -51,6 +51,7 @@ import {
 } from "./browser-broker-errors.js";
 import type { AuthFailureReason } from "./sync-transport.js";
 import { translateQuery } from "./query-adapter.js";
+import { limitQueryToOne } from "./limit-query.js";
 import { transformRow, transformRows } from "./row-transformer.js";
 import { toWriteRecord } from "./value-converter.js";
 import { SubscriptionManager, type SubscriptionDelta } from "./subscription-manager.js";
@@ -254,28 +255,6 @@ type DbRuntimeOperationContext = {
 
 function ordinaryDbQueryOptions(options?: QueryOptions): QueryOptions {
   return { localUpdates: "deferred", ...options };
-}
-
-function limitQueryToOne<T>(query: QueryBuilder<T>): QueryBuilder<T> {
-  return {
-    get _table() {
-      return query._table;
-    },
-    get _schema() {
-      return query._schema;
-    },
-    get _columnTransforms() {
-      return query._columnTransforms;
-    },
-    get _rowType() {
-      return query._rowType;
-    },
-    _build() {
-      const builtQuery = JSON.parse(query._build()) as Record<string, unknown>;
-      builtQuery.limit = 1;
-      return JSON.stringify(builtQuery);
-    },
-  };
 }
 
 function queryUsesRelationTraversal(builtQuery: NormalizedBuiltQuery): boolean {

--- a/packages/jazz-tools/src/runtime/index.ts
+++ b/packages/jazz-tools/src/runtime/index.ts
@@ -41,6 +41,7 @@ export {
   type TableProxy,
 } from "./db.js";
 export { allRowsInTableQuery, type DynamicTableRow } from "./dynamic-query.js";
+export { limitQueryToOne } from "./limit-query.js";
 export { resolveClientSessionSync, resolveClientSessionStateSync } from "./client-session.js";
 export type { AuthFailureReason, AuthState } from "./auth-state.js";
 export {

--- a/packages/jazz-tools/src/runtime/limit-query.ts
+++ b/packages/jazz-tools/src/runtime/limit-query.ts
@@ -1,0 +1,31 @@
+import type { QueryBuilder } from "./db.js";
+
+/**
+ * Wrap a query so it executes with `limit 1`, returning at most one row. Used by
+ * `Db.one` and by the framework `useOne`-style bindings so both share the exact
+ * same single-row semantics.
+ *
+ * This lives in its own module (rather than alongside `Db`) so framework
+ * bindings can reuse it without pulling in the wasm runtime.
+ */
+export function limitQueryToOne<T>(query: QueryBuilder<T>): QueryBuilder<T> {
+  return {
+    get _table() {
+      return query._table;
+    },
+    get _schema() {
+      return query._schema;
+    },
+    get _columnTransforms() {
+      return query._columnTransforms;
+    },
+    get _rowType() {
+      return query._rowType;
+    },
+    _build() {
+      const builtQuery = JSON.parse(query._build()) as Record<string, unknown>;
+      builtQuery.limit = 1;
+      return JSON.stringify(builtQuery);
+    },
+  };
+}

--- a/packages/jazz-tools/src/shared/index.ts
+++ b/packages/jazz-tools/src/shared/index.ts
@@ -19,6 +19,7 @@
  */
 
 export { applyDelta, reconcileArray } from "../reconcile-array.js";
+export { limitQueryToOne } from "../runtime/limit-query.js";
 export { RowChangeKind } from "../runtime/subscription-manager.js";
 export type { RowDelta, SubscriptionDelta } from "../runtime/subscription-manager.js";
 export type {

--- a/packages/jazz-tools/src/solid/index.ts
+++ b/packages/jazz-tools/src/solid/index.ts
@@ -20,5 +20,6 @@ export {
 } from "./provider.js";
 
 export { useAll } from "./use-all.js";
+export { useOne, type UseOneResult } from "./use-one.js";
 export { useLocalFirstAuth, type UseLocalFirstAuth } from "./use-local-first-auth.js";
 export type { DurabilityTier, QueryOptions, RuntimeSourcesConfig } from "../runtime/index.js";

--- a/packages/jazz-tools/src/solid/use-one.test.ts
+++ b/packages/jazz-tools/src/solid/use-one.test.ts
@@ -1,0 +1,200 @@
+import { createRoot } from "solid-js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const unsubscribe = vi.fn();
+  const subscribe = vi.fn(() => unsubscribe);
+  const makeQueryKey = vi.fn(() => "test-key");
+  const getCacheEntry = vi.fn(() => ({
+    state: { status: "fulfilled", data: [] },
+    subscribe,
+  }));
+
+  return {
+    unsubscribe,
+    subscribe,
+    makeQueryKey,
+    getCacheEntry,
+    reset() {
+      unsubscribe.mockReset();
+      subscribe.mockReset().mockReturnValue(unsubscribe);
+      makeQueryKey.mockReset().mockReturnValue("test-key");
+      getCacheEntry.mockReset().mockReturnValue({
+        state: { status: "fulfilled", data: [] },
+        subscribe,
+      });
+    },
+  };
+});
+
+vi.mock("./provider.js", () => ({
+  useJazzClient: () => ({
+    manager: {
+      makeQueryKey: mocks.makeQueryKey,
+      getCacheEntry: mocks.getCacheEntry,
+    },
+  }),
+}));
+
+import { useOne } from "./use-one.js";
+
+function makeQuery(marker = "todos") {
+  return { _build: () => `{"table":"${marker}"}`, _table: marker } as any;
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+}
+
+describe("solid/useOne", () => {
+  beforeEach(() => {
+    mocks.reset();
+  });
+
+  it("SD-ONE-01: subscribes with the query limited to one row", async () => {
+    const query = makeQuery();
+
+    let dispose!: () => void;
+    try {
+      createRoot((rootDispose) => {
+        dispose = rootDispose;
+        useOne(() => ({ query }));
+        return undefined;
+      });
+      await flushMicrotasks();
+
+      expect(mocks.makeQueryKey).toHaveBeenCalledTimes(1);
+      const [builtQuery] = mocks.makeQueryKey.mock.calls[0] as unknown as [any, unknown];
+      expect(JSON.parse(builtQuery._build())).toEqual({
+        table: "todos",
+        limit: 1,
+      });
+      expect(mocks.subscribe).toHaveBeenCalledTimes(1);
+    } finally {
+      dispose?.();
+    }
+  });
+
+  it("SD-ONE-02: when query is undefined, stays idle and skips subscription", () => {
+    let dispose!: () => void;
+    let result!: ReturnType<typeof useOne<{ id: string }>>;
+
+    try {
+      createRoot((rootDispose) => {
+        dispose = rootDispose;
+        result = useOne(() => ({ query: undefined }));
+        return undefined;
+      });
+
+      expect(mocks.makeQueryKey).not.toHaveBeenCalled();
+      expect(mocks.subscribe).not.toHaveBeenCalled();
+      expect(result.data).toBeUndefined();
+      expect(result.isLoading).toBe(false);
+      expect(result.error).toBeNull();
+    } finally {
+      dispose?.();
+    }
+  });
+
+  it("SD-ONE-03: pending entry sets loading true and data undefined", async () => {
+    mocks.getCacheEntry.mockReturnValue({
+      state: { status: "pending" as const },
+      subscribe: mocks.subscribe,
+    } as any);
+
+    let dispose!: () => void;
+    let result!: ReturnType<typeof useOne<{ id: string }>>;
+
+    try {
+      createRoot((rootDispose) => {
+        dispose = rootDispose;
+        result = useOne(() => ({ query: makeQuery() }));
+        return undefined;
+      });
+      await flushMicrotasks();
+
+      expect(result.data).toBeUndefined();
+      expect(result.isLoading).toBe(true);
+      expect(result.error).toBeNull();
+    } finally {
+      dispose?.();
+    }
+  });
+
+  it("SD-ONE-04: fulfilled entry exposes the single matching row", async () => {
+    const alice = { id: "u1", name: "Alice" };
+    mocks.getCacheEntry.mockReturnValue({
+      state: { status: "fulfilled" as const, data: [alice] },
+      subscribe: mocks.subscribe,
+    } as any);
+
+    let dispose!: () => void;
+    let result!: ReturnType<typeof useOne<{ id: string; name: string }>>;
+
+    try {
+      createRoot((rootDispose) => {
+        dispose = rootDispose;
+        result = useOne(() => ({ query: makeQuery() }));
+        return undefined;
+      });
+      await flushMicrotasks();
+
+      expect(result.data).toEqual(alice);
+      expect(result.isLoading).toBe(false);
+      expect(result.error).toBeNull();
+    } finally {
+      dispose?.();
+    }
+  });
+
+  it("SD-ONE-05: empty fulfilled result yields null", async () => {
+    mocks.getCacheEntry.mockReturnValue({
+      state: { status: "fulfilled" as const, data: [] },
+      subscribe: mocks.subscribe,
+    } as any);
+
+    let dispose!: () => void;
+    let result!: ReturnType<typeof useOne<{ id: string }>>;
+
+    try {
+      createRoot((rootDispose) => {
+        dispose = rootDispose;
+        result = useOne(() => ({ query: makeQuery() }));
+        return undefined;
+      });
+      await flushMicrotasks();
+
+      expect(result.data).toBeNull();
+      expect(result.isLoading).toBe(false);
+      expect(result.error).toBeNull();
+    } finally {
+      dispose?.();
+    }
+  });
+
+  it("SD-ONE-06: rejected entry maps error and clears loading", async () => {
+    mocks.getCacheEntry.mockReturnValue({
+      state: { status: "rejected" as const, error: new Error("boom") },
+      subscribe: mocks.subscribe,
+    } as any);
+
+    let dispose!: () => void;
+    let result!: ReturnType<typeof useOne<{ id: string }>>;
+
+    try {
+      createRoot((rootDispose) => {
+        dispose = rootDispose;
+        result = useOne(() => ({ query: makeQuery() }));
+        return undefined;
+      });
+      await flushMicrotasks();
+
+      expect(result.data).toBeUndefined();
+      expect(result.isLoading).toBe(false);
+      expect(result.error).toBeInstanceOf(Error);
+      expect(result.error?.message).toBe("boom");
+    } finally {
+      dispose?.();
+    }
+  });
+});

--- a/packages/jazz-tools/src/solid/use-one.ts
+++ b/packages/jazz-tools/src/solid/use-one.ts
@@ -1,0 +1,50 @@
+import type { Accessor } from "solid-js";
+import type { QueryBuilder, QueryOptions } from "../runtime/db.js";
+import { limitQueryToOne } from "../runtime/limit-query.js";
+import { useAll } from "./use-all.js";
+
+/**
+ * Reactive result of {@link useOne}. Like {@link UseAllResult} but for a single
+ * row: `data` is the matching row, `null` once the query resolves with no match,
+ * or `undefined` while loading; `isLoading` is `true` until the query resolves;
+ * `error` holds the subscription error, or `null`.
+ */
+export type UseOneResult<T extends { id: string }> = {
+  data: T | null | undefined;
+  isLoading: boolean;
+  error: Error | null;
+};
+
+/**
+ * Read the first matching row and subscribe to changes that affect it.
+ *
+ * Narrows {@link useAll} to a single row: the query is executed with `limit 1`
+ * (via {@link limitQueryToOne}, the same wrapper `Db.one` uses, so the two stay
+ * in lockstep), and the subscription tracks just that row.
+ *
+ * `data` is `undefined` while loading, `null` once the query resolves with no
+ * match, or the matching row otherwise.
+ */
+export function useOne<T extends { id: string }>(
+  args: Accessor<{
+    query: QueryBuilder<T> | undefined;
+    options?: QueryOptions | undefined;
+  }>,
+): UseOneResult<T> {
+  const all = useAll<T>(() => {
+    const { query, options } = args();
+    return { query: query ? limitQueryToOne(query) : undefined, options };
+  });
+
+  return {
+    get data() {
+      return all.data === undefined ? undefined : (all.data[0] ?? null);
+    },
+    get isLoading() {
+      return all.isLoading;
+    },
+    get error() {
+      return all.error;
+    },
+  };
+}

--- a/packages/jazz-tools/src/svelte/index.ts
+++ b/packages/jazz-tools/src/svelte/index.ts
@@ -6,6 +6,7 @@ export {
 } from "./create-jazz-client.js";
 export { getDb, getSession, getJazzContext, type JazzContext } from "./context.svelte.js";
 export { QuerySubscription } from "./use-all.svelte.js";
+export { SingleRowSubscription } from "./use-one.svelte.js";
 export { LocalFirstAuth } from "./local-first-auth.svelte.js";
 export { attachDevTools, type DevToolsAttachment } from "../dev-tools/dev-tools.js";
 export type { DurabilityTier, QueryOptions, RuntimeSourcesConfig } from "../runtime/index.js";

--- a/packages/jazz-tools/src/svelte/use-one.svelte.test.ts
+++ b/packages/jazz-tools/src/svelte/use-one.svelte.test.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { flushSync } from "svelte";
+import "./test-helpers.svelte.js";
+
+type Row = { id: string; title?: string };
+
+const mocks = vi.hoisted(() => {
+  const unsubscribe = vi.fn();
+  const subscribe = vi.fn(() => unsubscribe);
+  // Derive the key from the built query so distinct queries get distinct keys
+  // even after `limitQueryToOne` strips the `_marker` field.
+  const makeQueryKey = vi.fn((q: any) => `key:${q?._build?.() ?? "?"}`);
+  const getCacheEntry = vi.fn(() => ({
+    state: { status: "fulfilled", data: [] as Row[] },
+    subscribe,
+  }));
+
+  return {
+    makeQueryKey,
+    getCacheEntry,
+    subscribe,
+    unsubscribe,
+    reset() {
+      unsubscribe.mockReset();
+      subscribe.mockReset().mockReturnValue(unsubscribe);
+      makeQueryKey.mockReset().mockImplementation((q: any) => `key:${q?._build?.() ?? "?"}`);
+      getCacheEntry.mockReset().mockReturnValue({
+        state: { status: "fulfilled", data: [] as Row[] },
+        subscribe,
+      });
+    },
+  };
+});
+
+vi.mock("./context.svelte.js", () => ({
+  getJazzContext: () => ({
+    db: null,
+    session: null,
+    manager: {
+      makeQueryKey: mocks.makeQueryKey,
+      getCacheEntry: mocks.getCacheEntry,
+    },
+  }),
+}));
+
+const { SingleRowSubscription } = await import("./use-one.svelte.js");
+
+function makeQuery(marker = "todos") {
+  return { _marker: marker, _build: () => JSON.stringify({ table: marker }) } as any;
+}
+
+async function settle() {
+  await Promise.resolve();
+  flushSync();
+}
+
+describe("svelte/SingleRowSubscription", () => {
+  beforeEach(() => {
+    mocks.reset();
+  });
+
+  it("subscribes with the query limited to one row", async () => {
+    const query = makeQuery("inbox");
+    const cleanup = $effect.root(() => {
+      new SingleRowSubscription(query);
+    });
+    await settle();
+
+    expect(mocks.subscribe).toHaveBeenCalledTimes(1);
+    expect(mocks.makeQueryKey).toHaveBeenCalledTimes(1);
+
+    const builtQuery = mocks.makeQueryKey.mock.calls[0]![0];
+    expect(JSON.parse(builtQuery._build())).toMatchObject({ limit: 1 });
+
+    cleanup();
+  });
+
+  it("accepts a getter and subscribes with the resolved query limited to one row", async () => {
+    const query = makeQuery("inbox");
+    const cleanup = $effect.root(() => {
+      new SingleRowSubscription(() => query);
+    });
+    await settle();
+
+    expect(mocks.subscribe).toHaveBeenCalledTimes(1);
+    const builtQuery = mocks.makeQueryKey.mock.calls[0]![0];
+    expect(JSON.parse(builtQuery._build())).toMatchObject({ limit: 1 });
+
+    cleanup();
+  });
+
+  it("does not subscribe when given undefined", async () => {
+    const cleanup = $effect.root(() => {
+      new SingleRowSubscription(undefined);
+    });
+    await settle();
+
+    expect(mocks.makeQueryKey).not.toHaveBeenCalled();
+    expect(mocks.subscribe).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it("reflects the row from the initial fulfilled cache", async () => {
+    const row: Row = { id: "t1", title: "first" };
+    mocks.getCacheEntry.mockReturnValue({
+      state: { status: "fulfilled" as const, data: [row] },
+      subscribe: mocks.subscribe,
+    } as any);
+
+    let ref!: InstanceType<typeof SingleRowSubscription<Row>>;
+    const cleanup = $effect.root(() => {
+      ref = new SingleRowSubscription(makeQuery());
+    });
+    await settle();
+
+    expect(ref.loading).toBe(false);
+    expect(ref.error).toBeNull();
+    expect(ref.current).toEqual({ id: "t1", title: "first" });
+
+    cleanup();
+  });
+
+  it("reflects later deltas to the single row", async () => {
+    const row: Row = { id: "t1", title: "first" };
+    let captured: any;
+    mocks.getCacheEntry.mockReturnValue({
+      state: { status: "fulfilled" as const, data: [row] },
+      subscribe: (callbacks: any) => {
+        captured = callbacks;
+        return mocks.unsubscribe;
+      },
+    } as any);
+
+    let ref!: InstanceType<typeof SingleRowSubscription<Row>>;
+    const cleanup = $effect.root(() => {
+      ref = new SingleRowSubscription(makeQuery());
+    });
+    await settle();
+
+    expect(ref.current).toMatchObject({ id: "t1", title: "first" });
+
+    captured.onDelta({
+      all: [{ id: "t1", title: "updated" }],
+      delta: [{ kind: 2, id: "t1" }],
+    });
+    await settle();
+
+    expect(ref.current).toMatchObject({ id: "t1", title: "updated" });
+
+    cleanup();
+  });
+
+  it("yields null (distinct from undefined) once resolved with no row", async () => {
+    let ref!: InstanceType<typeof SingleRowSubscription<Row>>;
+    const cleanup = $effect.root(() => {
+      ref = new SingleRowSubscription(makeQuery());
+    });
+    await settle();
+
+    // fulfilled cache with empty data → resolved with no match → null
+    expect(ref.loading).toBe(false);
+    expect(ref.current).toBeNull();
+    expect(ref.current).not.toBeUndefined();
+
+    cleanup();
+  });
+
+  it("current is undefined while loading (pending cache)", async () => {
+    mocks.getCacheEntry.mockReturnValue({
+      state: { status: "pending" as const },
+      subscribe: mocks.subscribe,
+    } as any);
+
+    let ref!: InstanceType<typeof SingleRowSubscription<Row>>;
+    const cleanup = $effect.root(() => {
+      ref = new SingleRowSubscription(makeQuery());
+    });
+    await settle();
+
+    expect(ref.loading).toBe(true);
+    expect(ref.current).toBeUndefined();
+
+    cleanup();
+  });
+
+  it("surfaces subscription errors", async () => {
+    let captured: any;
+    mocks.getCacheEntry.mockReturnValue({
+      state: { status: "fulfilled" as const, data: [] as Row[] },
+      subscribe: (callbacks: any) => {
+        captured = callbacks;
+        return mocks.unsubscribe;
+      },
+    } as any);
+
+    let ref!: InstanceType<typeof SingleRowSubscription<Row>>;
+    const cleanup = $effect.root(() => {
+      ref = new SingleRowSubscription(makeQuery());
+    });
+    await settle();
+
+    captured.onError(new Error("boom"));
+    await settle();
+
+    expect(ref.error).toBeInstanceOf(Error);
+    expect(ref.error?.message).toBe("boom");
+    expect(ref.current).toBeUndefined();
+
+    cleanup();
+  });
+});

--- a/packages/jazz-tools/src/svelte/use-one.svelte.ts
+++ b/packages/jazz-tools/src/svelte/use-one.svelte.ts
@@ -1,0 +1,67 @@
+import type { QueryBuilder, QueryOptions } from "../shared/index.js";
+import { limitQueryToOne } from "../shared/index.js";
+import { QuerySubscription } from "./use-all.svelte.js";
+
+type MaybeGetter<T> = T | (() => T);
+
+function resolve<T>(value: MaybeGetter<T>): T {
+  return typeof value === "function" ? (value as () => T)() : value;
+}
+
+/**
+ * Reactive single-row subscription. Like {@link QuerySubscription} but narrowed
+ * to one row: the query is executed with `limit 1` (the same wrapper `Db.one`
+ * uses, so the two stay in lockstep), and the subscription tracks just that row.
+ *
+ * Instantiate in a component script block, access the result via `.current`,
+ * which is the matching row, `null` once the query resolves with no match, or
+ * `undefined` while loading.
+ *
+ * @param query - the database query, or a getter for a dynamic query
+ *   (e.g. `() => id ? app.todos.where({ id }) : undefined`).
+ *   When a getter is passed, any reactive reads inside it are tracked, so the
+ *   subscription re-runs when its dependencies change.
+ * @param options - optional query execution options, or a getter for them
+ *
+ * ```svelte
+ * <script lang="ts">
+ *   const todo = new SingleRowSubscription(app.todos.where({ id }), { tier: "edge" });
+ * </script>
+ *
+ * {#if todo.loading}
+ *   <p>Loading...</p>
+ * {:else if todo.error}
+ *   <p>Error: {todo.error.message}</p>
+ * {:else if todo.current}
+ *   <p>{todo.current.title}</p>
+ * {:else}
+ *   <p>Not found</p>
+ * {/if}
+ * ```
+ */
+export class SingleRowSubscription<T extends { id: string }> {
+  #subscription: QuerySubscription<T>;
+
+  constructor(
+    query: MaybeGetter<QueryBuilder<T> | undefined>,
+    options?: MaybeGetter<QueryOptions | undefined>,
+  ) {
+    this.#subscription = new QuerySubscription<T>(() => {
+      const resolvedQuery = resolve(query);
+      return resolvedQuery ? limitQueryToOne(resolvedQuery) : undefined;
+    }, options);
+  }
+
+  get current(): T | null | undefined {
+    const rows = this.#subscription.current;
+    return rows === undefined ? undefined : (rows[0] ?? null);
+  }
+
+  get loading(): boolean {
+    return this.#subscription.loading;
+  }
+
+  get error(): Error | null {
+    return this.#subscription.error;
+  }
+}

--- a/packages/jazz-tools/src/vue/index.ts
+++ b/packages/jazz-tools/src/vue/index.ts
@@ -12,6 +12,7 @@ export {
   type JazzClientContextValue,
   type JazzProviderProps,
 } from "./provider.js";
-export { useAll } from "./use-all.js";
+export { useAll, type UseAllResult, type UseAllSuspenseResult } from "./use-all.js";
+export { useOne, useOneSuspense, type UseOneResult, type UseOneSuspenseResult } from "./use-one.js";
 export { useLocalFirstAuth, type UseLocalFirstAuth } from "./use-local-first-auth.js";
 export type { DurabilityTier, QueryOptions, RuntimeSourcesConfig } from "../runtime/index.js";

--- a/packages/jazz-tools/src/vue/use-one.test.ts
+++ b/packages/jazz-tools/src/vue/use-one.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { effectScope } from "vue";
+
+const mocks = vi.hoisted(() => {
+  const unsubscribe = vi.fn();
+  const subscribe = vi.fn(() => unsubscribe);
+  const makeQueryKey = vi.fn(() => "test-key");
+  const getCacheEntry = vi.fn(() => ({
+    state: { status: "fulfilled", data: [] },
+    subscribe,
+  }));
+
+  return {
+    makeQueryKey,
+    getCacheEntry,
+    subscribe,
+    unsubscribe,
+    reset() {
+      makeQueryKey.mockReset().mockReturnValue("test-key");
+      getCacheEntry.mockReset().mockReturnValue({
+        state: { status: "fulfilled", data: [] },
+        subscribe: subscribe.mockReset().mockReturnValue(unsubscribe.mockReset()),
+      });
+    },
+  };
+});
+
+vi.mock("./provider.js", () => ({
+  useJazzClient: () => ({
+    manager: {
+      makeQueryKey: mocks.makeQueryKey,
+      getCacheEntry: mocks.getCacheEntry,
+    },
+  }),
+}));
+
+import { useOne, useOneSuspense } from "./use-one.js";
+
+function makeQuery(marker = "todos") {
+  return { _build: () => `{"table":"${marker}"}`, _table: marker } as any;
+}
+
+describe("vue/useOne", () => {
+  beforeEach(() => {
+    mocks.reset();
+  });
+
+  it("subscribes with the query limited to one row", () => {
+    const scope = effectScope();
+    scope.run(() => useOne(makeQuery()));
+
+    expect(mocks.makeQueryKey).toHaveBeenCalledTimes(1);
+    const limitedQuery = (mocks.makeQueryKey.mock.calls[0] as any)[0];
+    expect(JSON.parse(limitedQuery._build())).toEqual({ table: "todos", limit: 1 });
+    expect(mocks.subscribe).toHaveBeenCalledTimes(1);
+
+    scope.stop();
+  });
+
+  it("forwards QueryOptions to makeQueryKey", () => {
+    const scope = effectScope();
+    scope.run(() => useOne(makeQuery(), { tier: "edge" }));
+    expect(mocks.makeQueryKey).toHaveBeenCalledWith(expect.anything(), { tier: "edge" });
+    scope.stop();
+  });
+
+  it("reflects the first matching row", () => {
+    const alice = { id: "1", name: "Alice" };
+    mocks.getCacheEntry.mockReturnValue({
+      state: { status: "fulfilled" as const, data: [alice] },
+      subscribe: mocks.subscribe,
+    } as any);
+
+    const scope = effectScope();
+    const result = scope.run(() => useOne(makeQuery()))!;
+    expect(result.data.value).toEqual(alice);
+    expect(result.loading.value).toBe(false);
+    scope.stop();
+  });
+
+  it("yields null once resolved with no match", () => {
+    mocks.getCacheEntry.mockReturnValue({
+      state: { status: "fulfilled" as const, data: [] },
+      subscribe: mocks.subscribe,
+    } as any);
+
+    const scope = effectScope();
+    const result = scope.run(() => useOne(makeQuery()))!;
+    expect(result.data.value).toBeNull();
+    scope.stop();
+  });
+
+  it("yields undefined while loading (distinct from null)", () => {
+    mocks.getCacheEntry.mockReturnValue({
+      state: { status: "pending" as const },
+      subscribe: mocks.subscribe,
+    } as any);
+
+    const scope = effectScope();
+    const result = scope.run(() => useOne(makeQuery()))!;
+    expect(result.data.value).toBeUndefined();
+    expect(result.loading.value).toBe(true);
+    scope.stop();
+  });
+
+  it("surfaces subscription errors via the error ref", () => {
+    let capturedOnError: ((err: unknown) => void) | undefined;
+    mocks.getCacheEntry.mockReturnValue({
+      state: { status: "pending" as const },
+      subscribe: (callbacks: any) => {
+        capturedOnError = callbacks.onError;
+        return mocks.unsubscribe;
+      },
+    } as any);
+
+    const scope = effectScope();
+    const result = scope.run(() => useOne(makeQuery()))!;
+
+    expect(result.error.value).toBeNull();
+
+    capturedOnError!(new Error("network down"));
+
+    expect(result.error.value).toBeInstanceOf(Error);
+    expect((result.error.value as Error).message).toBe("network down");
+    expect(result.data.value).toBeUndefined();
+    expect(result.loading.value).toBe(false);
+
+    scope.stop();
+  });
+
+  it("useOneSuspense resolves the single row and omits loading", async () => {
+    const alice = { id: "1", name: "Alice" };
+    mocks.getCacheEntry.mockReturnValue({
+      state: { status: "fulfilled" as const, data: [alice] },
+      promise: Promise.resolve([alice]),
+      subscribe: mocks.subscribe,
+    } as any);
+
+    const scope = effectScope();
+    const result = await scope.run(() => useOneSuspense(makeQuery()))!;
+
+    expect(result.data.value).toEqual(alice);
+    expect("loading" in result).toBe(false);
+
+    const limitedQuery = (mocks.makeQueryKey.mock.calls[0] as any)[0];
+    expect(JSON.parse(limitedQuery._build())).toEqual({ table: "todos", limit: 1 });
+
+    scope.stop();
+  });
+
+  it("useOneSuspense yields null when no row matches", async () => {
+    mocks.getCacheEntry.mockReturnValue({
+      state: { status: "fulfilled" as const, data: [] },
+      promise: Promise.resolve([]),
+      subscribe: mocks.subscribe,
+    } as any);
+
+    const scope = effectScope();
+    const result = await scope.run(() => useOneSuspense(makeQuery()))!;
+
+    expect(result.data.value).toBeNull();
+
+    scope.stop();
+  });
+});

--- a/packages/jazz-tools/src/vue/use-one.ts
+++ b/packages/jazz-tools/src/vue/use-one.ts
@@ -1,0 +1,93 @@
+import { computed, toValue, type MaybeRefOrGetter, type Ref } from "vue";
+import { limitQueryToOne } from "../shared/index.js";
+import type { QueryBuilder, QueryOptions } from "../shared/index.js";
+import { useAll, useAllSuspense } from "./use-all.js";
+
+// `useOne` is `useAll` narrowed to a single row: the query is executed with
+// `limit 1` (the same wrapper `db.one` uses, so the two stay in lockstep), and
+// the subscription tracks just that row — replacing it should a closer match
+// appear or the current one be removed.
+
+/**
+ * Reactive result of {@link useOne}. Like {@link UseAllResult} but for a single
+ * row: `data` is the matching row, `null` once the query resolves with no match,
+ * or `undefined` while loading (and on error); `error` is the last subscription
+ * error (or `null`), and `loading` is `true` until the first result or error.
+ */
+export interface UseOneResult<T extends { id: string }> {
+  data: Ref<T | null | undefined>;
+  error: Ref<Error | null>;
+  loading: Ref<boolean>;
+}
+
+/**
+ * Result of {@link useOneSuspense}. Like {@link UseOneResult} but without
+ * `loading`: the suspense variant only returns once the first result (or error)
+ * has resolved, so a `loading` flag would carry no information at the point of
+ * use.
+ */
+export interface UseOneSuspenseResult<T extends { id: string }> {
+  data: Ref<T | null | undefined>;
+  error: Ref<Error | null>;
+}
+
+function toSingle<T>(rows: T[] | undefined): T | null | undefined {
+  return rows === undefined ? undefined : (rows[0] ?? null);
+}
+
+/**
+ * Read the first matching row and subscribe to changes that affect it.
+ *
+ * The query is run with `limit 1`, mirroring {@link useAll} but narrowed to a
+ * single row.
+ *
+ * @param query - the database query (e.g. `app.todos.where({ id })`)
+ * @param options - optional query execution options
+ *
+ * @returns reactive `{ data, error, loading }`. `data` is `undefined` while
+ *   loading, `null` once the query resolves with no match, or the matching row;
+ *   `error` is set if the subscription fails.
+ */
+export function useOne<T extends { id: string }>(
+  query: MaybeRefOrGetter<QueryBuilder<T> | undefined>,
+  options?: MaybeRefOrGetter<QueryOptions | undefined>,
+): UseOneResult<T> {
+  const {
+    data: rows,
+    error,
+    loading,
+  } = useAll<T>(() => {
+    const q = toValue(query);
+    return q ? limitQueryToOne(q) : undefined;
+  }, options);
+
+  const data = computed(() => toSingle(rows.value));
+
+  return { data, error, loading };
+}
+
+/**
+ * Suspense-compatible variant of {@link useOne} for use in an `async setup()`
+ * under Vue `<Suspense>`. Resolves once the query's first result is available,
+ * and rejects (surfacing to the nearest error boundary) if it fails.
+ *
+ * The query is run with `limit 1`, mirroring {@link useOne}.
+ *
+ * @param query - the database query (e.g. `app.todos.where({ id })`)
+ * @param options - optional query execution options
+ *
+ * @returns reactive `{ data, error }`. Unlike {@link useOne}, there is no
+ *   `loading` flag: the promise only resolves once the first result is
+ *   available, so the query is never loading at the point of use. `data` is the
+ *   matching row, or `null` if none matched.
+ */
+export async function useOneSuspense<T extends { id: string }>(
+  query: QueryBuilder<T>,
+  options?: QueryOptions,
+): Promise<UseOneSuspenseResult<T>> {
+  const { data: rows, error } = await useAllSuspense<T>(limitQueryToOne(query), options);
+
+  const data = computed(() => toSingle(rows.value));
+
+  return { data, error };
+}


### PR DESCRIPTION
## Why

The React bindings expose `useAll` but have no single-row counterpart to `db.one`, even though one-row-per-component is a common pattern — e.g. a list fetches ids, then each row gets a detail component that fetches its data by id. (Came up from a user asking why there's `db.all()`/`db.one()` and `useAll()` but no `useOne()`.)

## What

Adds `useOne` and `useOneSuspense` to the React / Expo / React Native bindings.

`useOne` is `useAll` narrowed to a single row:
- Reuses the existing subscription plumbing via `useAllBase` (StrictMode / SSR / Suspense handling all come for free).
- Uses the **same `limitQueryToOne` wrapper that `db.one` uses**, so the query subscribes with `limit 1` and tracks just that row — replacing it if a closer match appears or the current row is removed.
- Returns `T | null | undefined`: `undefined` while loading, `null` when resolved with no matching row, the row otherwise. Keeping `null` distinct from `undefined` is what the by-id detail-component case needs (not-found vs. loading).
- `useOneSuspense` mirrors `useAllSuspense`, returning `T | null`.

```tsx
function TodoItem({ id }: { id: string }) {
  const todo = useOne(app.todos.where({ id }));
  if (todo === undefined) return <Spinner />;
  if (todo === null) return <NotFound />;
  return <span>{todo.title}</span>;
}
```

## Refactor

`limitQueryToOne` lived inside `db.ts`, which pulls in the wasm runtime — importing it from there dragged `jazz-wasm` into the React bundle. Since it's a pure JSON wrapper with no runtime deps, it's extracted to `runtime/limit-query.ts`. `db.one` imports it from there now, and it's surfaced on the `shared` / `runtime` barrels so the Vue/Svelte/Solid binding authors can build their own `one`-style bindings on it.

## Scope

React binding only, matching the original request. The shared `limitQueryToOne` export makes adding `one`-style bindings to the other frameworks straightforward later, but they have different idioms (`QuerySubscription`, `{ data, error, loading }`) and are untouched here.

## Tests

New `use-one.test.tsx` mirrors the `useAll` suite plus `useOne`-specific cases: subscribes with `limit: 1`, no resubscribe across re-renders, reflects deltas, `null` when resolved empty, StrictMode dedup, SSR seeded snapshot, failed-subscription handling, and the Suspense error boundary. Full react suite (26 tests) and the `db.one` suite pass; lint/format clean.

Docs: adds a "Reading a single row" subsection to the queries page.