### PR TITLE
fix(inspector): cannot edit field in table grid

### DIFF
--- a/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
@@ -1902,6 +1902,18 @@ function PlainTableView({
       );
     }
   };
+  const selectOnlyRow = (rowId: string): void => {
+    onSelectedRowIdsChange((currentSelectedRowIds) => {
+      // Avoid changing selection if selected row didn't actually change.
+      // This prevents unnecessary re-renders that sometimes prevented cells
+      // from entering edit mode on double-click
+      if (currentSelectedRowIds.size === 1 && currentSelectedRowIds.has(rowId)) {
+        return currentSelectedRowIds;
+      }
+
+      return new Set([rowId]);
+    });
+  };
   const selectRowRange = (
     row: EditableGridRow,
     rowIndex: number,
@@ -1911,7 +1923,7 @@ function PlainTableView({
 
     if (!isRangeSelection) {
       selectionAnchorRowIdRef.current = rowId;
-      onSelectedRowIdsChange(new Set([rowId]));
+      selectOnlyRow(rowId);
       return;
     }
 
@@ -1921,7 +1933,7 @@ function PlainTableView({
     );
     if (anchorRowIndex === -1) {
       selectionAnchorRowIdRef.current = rowId;
-      onSelectedRowIdsChange(new Set([rowId]));
+      selectOnlyRow(rowId);
       return;
     }
 

--- a/packages/inspector/tests/browser/standalone-inspector.spec.ts
+++ b/packages/inspector/tests/browser/standalone-inspector.spec.ts
@@ -152,6 +152,15 @@ test.describe("data explorer page", () => {
     await expect(page.getByText('"delete"')).toBeVisible();
   });
 
+  test("opens inline text editor in selected row", async ({ page }) => {
+    const title = "First seeded todo";
+    const titleCell = page.getByRole("gridcell", { name: title, exact: true });
+
+    await titleCell.dblclick();
+
+    await expect(page.getByLabel("Edit title")).toBeVisible();
+  });
+
   test("discards queued inline text edits without persisting them", async ({ page }) => {
     const originalTitle = "Seeded todo 000003";
     const updatedTitle = `Discarded inline edit ${Date.now()}`;


### PR DESCRIPTION
## Description

Fixes a bug that sometimes prevented rows from being edited in the inspector. Before this PR, clicking a row always created a fresh `Set([rowId])` to keep track of the selected rows, even when that row was already the only selected row. During a double-click, the second click therefore triggered an unnecessary grid re-render right before `react-data-grid` entered edit mode. In tables with lots of rows, this could interrupt the edit transition, so the cell was selected but the editor never rendered.

## Validation

#### Before

https://github.com/user-attachments/assets/a6c66d26-cf01-4af7-b3f3-27988cccd857

#### After

https://github.com/user-attachments/assets/405b3b8f-c956-461d-9b73-26283b850481