### PR TITLE
transport: in-band server→client Redirect (edge-fallback)

### DIFF
--- a/.changeset/edge-fallback-redirect.md
+++ b/.changeset/edge-fallback-redirect.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": minor
+---
+
+Add an opt-in, in-band server→client `Redirect` message: a sync server can tell a client to reconnect to a different public URL without dropping the connection. It is gated by the new `--public-url` / `JAZZ_PUBLIC_URL` server option and an `x-jazz-forwarded` request header — the server keeps serving, and older clients that don't recognize the message simply ignore it (no capability handshake). On receipt, the client re-points its transport to the advertised origin (keeping its `/apps/<id>/ws` path) and reconnects, preserving in-memory state. Enables edge-fallback routing, where a client proxied to the region its app actually lives in is handed a direct URL so the long-lived session bypasses the proxy.

--- a/crates/jazz-tools/src/commands/server.rs
+++ b/crates/jazz-tools/src/commands/server.rs
@@ -18,6 +18,7 @@ pub async fn run(
     in_memory: bool,
     auth_config: AuthConfig,
     upstream_url: Option<String>,
+    public_url: Option<String>,
     bound_port_file: Option<String>,
     shutdown_timeout: Duration,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -37,6 +38,10 @@ pub async fn run(
         .with_shutdown_timeout(shutdown_timeout);
     let builder = match upstream_url {
         Some(upstream_url) => builder.with_upstream_url(upstream_url),
+        None => builder,
+    };
+    let builder = match public_url {
+        Some(public_url) => builder.with_public_url(public_url),
         None => builder,
     };
     let built = if in_memory {

--- a/crates/jazz-tools/src/main.rs
+++ b/crates/jazz-tools/src/main.rs
@@ -146,6 +146,13 @@ enum Commands {
         #[arg(long, env = "JAZZ_UPSTREAM_URL")]
         upstream_url: Option<String>,
 
+        /// Public base URL this region advertises to forwarded clients, so they
+        /// reconnect directly instead of being proxied (edge-fallback redirect).
+        /// When set, a connection carrying `x-jazz-forwarded` is told to
+        /// reconnect here. Unset → redirect disabled.
+        #[arg(long, env = "JAZZ_PUBLIC_URL")]
+        public_url: Option<String>,
+
         /// Graceful shutdown network-drain timeout in seconds.
         #[arg(
             long,
@@ -201,6 +208,7 @@ async fn main() {
             backend_secret,
             admin_secret,
             upstream_url,
+            public_url,
             shutdown_timeout_secs,
             bound_port_file,
         } => {
@@ -245,6 +253,7 @@ async fn main() {
                 in_memory,
                 auth_config,
                 upstream_url,
+                public_url,
                 bound_port_file,
                 std::time::Duration::from_secs(shutdown_timeout_secs),
             )

--- a/crates/jazz-tools/src/server/builder.rs
+++ b/crates/jazz-tools/src/server/builder.rs
@@ -70,6 +70,7 @@ pub struct ServerBuilder {
     storage_backend: StorageBackend,
     sync_tracer: Option<crate::sync_tracer::SyncTracer>,
     upstream_url: Option<String>,
+    public_url: Option<String>,
     shutdown_timeout: Duration,
 }
 
@@ -87,6 +88,7 @@ impl ServerBuilder {
             },
             sync_tracer: None,
             upstream_url: None,
+            public_url: None,
             shutdown_timeout: DEFAULT_SHUTDOWN_TIMEOUT,
         }
     }
@@ -108,6 +110,13 @@ impl ServerBuilder {
 
     pub fn with_upstream_url(mut self, upstream_url: impl Into<String>) -> Self {
         self.upstream_url = Some(upstream_url.into());
+        self
+    }
+
+    /// Public base URL advertised to forwarded clients for the edge-fallback
+    /// redirect (env `JAZZ_PUBLIC_URL`). Unset → redirect disabled.
+    pub fn with_public_url(mut self, public_url: impl Into<String>) -> Self {
+        self.public_url = Some(public_url.into());
         self
     }
 
@@ -162,6 +171,7 @@ impl ServerBuilder {
             connection_event_hub,
             auth_config,
             upstream_http_url,
+            public_url: self.public_url.clone(),
             topology,
             jwt_verifier,
             http_client,

--- a/crates/jazz-tools/src/server/mod.rs
+++ b/crates/jazz-tools/src/server/mod.rs
@@ -250,6 +250,10 @@ pub struct ServerState {
     pub auth_config: AuthConfig,
     /// Upstream HTTP base URL used by edge servers to forward catalogue HTTP requests.
     pub upstream_http_url: Option<String>,
+    /// Public base URL this region advertises to forwarded clients so they can
+    /// reconnect directly (edge-fallback redirect). `None` disables the redirect.
+    /// Topology comes entirely from deployment config — never hardcoded.
+    pub public_url: Option<String>,
     /// Whether this process is the core/global node or an edge syncing upstream.
     pub topology: ServerTopology,
     /// Shared HTTP client for forwarding admin requests to a remote authority.
@@ -574,6 +578,7 @@ mod tests {
             connection_event_hub: Arc::new(ConnectionEventHub::default()),
             auth_config: AuthConfig::default(),
             upstream_http_url: None,
+            public_url: None,
             topology: ServerTopology::Core,
             http_client: reqwest::Client::builder()
                 .build()

--- a/crates/jazz-tools/src/server/routes/websocket.rs
+++ b/crates/jazz-tools/src/server/routes/websocket.rs
@@ -333,6 +333,17 @@ async fn close_ws_for_shutdown(socket: &mut WebSocket) {
         .await;
 }
 
+/// Decide the edge-fallback redirect target for a freshly-accepted connection:
+/// `Some(url)` when the connection was forwarded here (the landing gateway set
+/// `x-jazz-forwarded`) **and** a public URL is configured to advertise; `None`
+/// otherwise (serve normally). Pure so the gating is unit-testable.
+fn forwarded_redirect_target(public_url: Option<&str>, headers: &HeaderMap) -> Option<String> {
+    let public_url = public_url?;
+    headers
+        .contains_key("x-jazz-forwarded")
+        .then(|| public_url.to_string())
+}
+
 async fn handle_ws_connection(
     mut socket: WebSocket,
     state: Arc<ServerState>,
@@ -525,6 +536,25 @@ async fn handle_ws_connection(
     }
     tracing::info!(connection_id, %client_id, role, "ws client connected");
 
+    // 6b. Edge-fallback redirect. If this connection was proxied here from a
+    //     region where the tenant isn't present — the landing gateway stamps
+    //     `x-jazz-forwarded` — and we have a public URL to advertise, offer the
+    //     client a direct reconnect URL in-band and keep serving. The client
+    //     migrates at its own pace and closes its own old socket; older clients
+    //     that don't recognize the frame ignore it and stay on the proxy. The
+    //     URL is pure deployment config (JAZZ_PUBLIC_URL) — no topology here.
+    if let Some(url) = forwarded_redirect_target(state.public_url.as_deref(), &request_headers) {
+        let event = crate::jazz_transport::ServerEvent::Redirect { url: url.clone() };
+        if let Ok(bytes) = event.encode_payload() {
+            let frame = crate::transport_manager::frame_encode(&bytes);
+            if socket.send(Message::Binary(frame)).await.is_err() {
+                ws_cleanup(&state, connection_id, client_id).await;
+                return;
+            }
+            tracing::info!(connection_id, %client_id, public_url = %url, "offered edge-fallback redirect");
+        }
+    }
+
     // 7. Bidirectional loop: inbound frames from client + outbound updates from hub.
     //    Also fires a periodic heartbeat so idle connections don't look half-open.
     let mut heartbeat = tokio::time::interval(std::time::Duration::from_secs(30));
@@ -630,4 +660,40 @@ async fn ws_cleanup(state: &Arc<ServerState>, connection_id: u64, client_id: Cli
         .connection_event_hub
         .unregister_connection(connection_id);
     state.on_connection_closed(client_id).await;
+}
+
+#[cfg(test)]
+mod redirect_tests {
+    use super::forwarded_redirect_target;
+    use axum::http::HeaderMap;
+
+    fn headers_with(forwarded: bool) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        if forwarded {
+            h.insert("x-jazz-forwarded", "1".parse().unwrap());
+        }
+        h
+    }
+
+    #[test]
+    fn redirects_when_forwarded_and_public_url_set() {
+        assert_eq!(
+            forwarded_redirect_target(Some("https://us-east-2.example"), &headers_with(true))
+                .as_deref(),
+            Some("https://us-east-2.example"),
+        );
+    }
+
+    #[test]
+    fn no_redirect_without_forwarded_marker() {
+        assert!(
+            forwarded_redirect_target(Some("https://us-east-2.example"), &headers_with(false))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn no_redirect_without_public_url() {
+        assert!(forwarded_redirect_target(None, &headers_with(true)).is_none());
+    }
 }

--- a/crates/jazz-tools/src/transport_manager.rs
+++ b/crates/jazz-tools/src/transport_manager.rs
@@ -452,6 +452,13 @@ pub struct TransportManager<W: StreamAdapter, T: TickNotifier> {
     /// Shared with `TransportHandle::declared_schema_hash`. Read at each
     /// handshake attempt so the server sees the client's structural schema.
     declared_schema_hash: std::sync::Arc<std::sync::Mutex<Option<String>>>,
+    /// Edge-fallback redirect state. `redirect_requested` is a transient signal
+    /// set by `dispatch_server_event` when a `Redirect` event should be honored;
+    /// the connected loop observes it and returns `ConnectedExit::Redirect`, so
+    /// the next connect targets the (already-updated) `url`. `redirect_count`
+    /// caps consecutive redirects and resets on real sync traffic.
+    redirect_requested: bool,
+    redirect_count: u32,
     _stream: std::marker::PhantomData<W>,
 }
 
@@ -507,9 +514,34 @@ pub fn create_with_retry_config<W: StreamAdapter, T: TickNotifier>(
         control_rx,
         catalogue_state_hash,
         declared_schema_hash,
+        redirect_requested: false,
+        redirect_count: 0,
         _stream: std::marker::PhantomData,
     };
     (handle, manager)
+}
+
+/// Rebase a redirect onto the live transport URL: keep the path + query from
+/// `current` (so `/apps/<id>/ws` and any query survive), take the authority
+/// (host[:port]) from `target`, and normalize the scheme to `ws`/`wss`. The
+/// server advertises only a base origin (`JAZZ_PUBLIC_URL`), so its path, if
+/// any, is intentionally ignored. Returns `None` if either URL lacks a scheme
+/// separator or the target scheme isn't http(s)/ws(s). String-based on purpose
+/// — this runs in the wasm transport, which has no URL crate.
+fn rebase_ws_url(current: &str, target: &str) -> Option<String> {
+    let current_rest = current.split_once("://")?.1; // host[:port]/path?query
+    let current_path = match current_rest.find('/') {
+        Some(i) => &current_rest[i..],
+        None => "/",
+    };
+    let (target_scheme, target_rest) = target.split_once("://")?;
+    let target_authority = target_rest.split('/').next().filter(|a| !a.is_empty())?;
+    let scheme = match target_scheme {
+        "https" | "wss" => "wss",
+        "http" | "ws" => "ws",
+        _ => return None,
+    };
+    Some(format!("{scheme}://{target_authority}{current_path}"))
 }
 
 pub(crate) fn frame_encode(payload: &[u8]) -> Vec<u8> {
@@ -718,25 +750,55 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
     fn dispatch_server_event(&mut self, event: crate::transport_protocol::ServerEvent) {
         match event {
             crate::transport_protocol::ServerEvent::SyncUpdate { seq, payload } => {
+                // Real sync traffic from the current endpoint: it is serving us,
+                // so clear the consecutive-redirect guard.
+                self.redirect_count = 0;
                 self.dispatch_sync_update(seq, *payload);
             }
             crate::transport_protocol::ServerEvent::SyncUpdateBatch { updates } => {
+                self.redirect_count = 0;
                 self.dispatch_sync_update_batch(updates);
             }
             crate::transport_protocol::ServerEvent::Heartbeat => {}
+            crate::transport_protocol::ServerEvent::Subscribed { .. } => {
+                tracing::debug!("received Subscribed ServerEvent; skipping");
+            }
             crate::transport_protocol::ServerEvent::Connected { .. } => {
                 tracing::warn!("unexpected Connected frame mid-stream; ignoring");
             }
             crate::transport_protocol::ServerEvent::Error { message, code } => {
                 tracing::warn!(message, ?code, "server reported error");
             }
-            other => {
-                tracing::debug!(
-                    variant = other.variant_name(),
-                    "received non-sync ServerEvent; skipping"
-                );
+            crate::transport_protocol::ServerEvent::Redirect { url } => {
+                self.handle_redirect(url);
             }
         }
+    }
+
+    /// Honor a server `Redirect`: re-point the transport's target URL to the
+    /// advertised origin (keeping our existing `/apps/<id>/ws` path + query) and
+    /// signal the connected loop to reconnect there. Capped at
+    /// `MAX_CONSECUTIVE_REDIRECTS` bounces with no intervening sync traffic, as a
+    /// loop guard; the cap resets whenever the current endpoint actually serves
+    /// us (see the `SyncUpdate` arms above).
+    fn handle_redirect(&mut self, target: String) {
+        const MAX_CONSECUTIVE_REDIRECTS: u32 = 2;
+        if self.redirect_count >= MAX_CONSECUTIVE_REDIRECTS {
+            tracing::warn!(target, "ignoring redirect: consecutive redirect cap reached");
+            return;
+        }
+        let Some(new_url) = rebase_ws_url(&self.url, &target) else {
+            tracing::warn!(target, "ignoring redirect: could not parse target URL");
+            return;
+        };
+        if new_url == self.url {
+            // Already pointed here — don't churn the connection.
+            return;
+        }
+        tracing::info!(from = %self.url, to = %new_url, "honoring server redirect");
+        self.url = new_url;
+        self.redirect_count += 1;
+        self.redirect_requested = true;
     }
 
     fn trace_sync_payload(
@@ -824,6 +886,8 @@ enum ConnectedExit {
     NetworkError,
     Shutdown,
     UpdateAuth(AuthConfig),
+    /// Server asked us to reconnect elsewhere; `self.url` already points there.
+    Redirect,
 }
 
 enum ControlOrPhase<T> {
@@ -990,6 +1054,18 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
                             self.reconnect.reset();
                             continue;
                         }
+                        ConnectedExit::Redirect => {
+                            // `self.url` already points at the redirect target.
+                            // Close, signal a disconnect, and reconnect promptly
+                            // (no backoff) so the session lands on the new origin.
+                            let _ = self
+                                .inbound_tx
+                                .unbounded_send(TransportInbound::Disconnected);
+                            self.tick.notify();
+                            ws.close().await;
+                            self.reconnect.reset();
+                            continue;
+                        }
                     }
                 }
                 ControlOrPhase::Phase(HandshakeResult::AuthFailure(reason)) => {
@@ -1055,6 +1131,10 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
                             let Some(payload) = frame_decode(&data) else { continue; };
                             let Ok(event) = crate::transport_protocol::ServerEvent::decode_payload(&payload) else { continue; };
                             self.dispatch_server_event(event);
+                            if self.redirect_requested {
+                                self.redirect_requested = false;
+                                return ConnectedExit::Redirect;
+                            }
                         }
                         Ok(None) | Err(_) => return ConnectedExit::NetworkError,
                     }
@@ -1077,6 +1157,8 @@ enum WasmConnectedExit {
     NetworkError,
     Shutdown,
     UpdateAuth(AuthConfig),
+    /// Server asked us to reconnect elsewhere; `self.url` already points there.
+    Redirect,
 }
 
 #[cfg(not(feature = "runtime-tokio"))]
@@ -1178,6 +1260,16 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
                             self.reconnect.reset();
                             continue;
                         }
+                        WasmConnectedExit::Redirect => {
+                            // `self.url` already points at the redirect target.
+                            let _ = self
+                                .inbound_tx
+                                .unbounded_send(TransportInbound::Disconnected);
+                            self.tick.notify();
+                            ws.close().await;
+                            self.reconnect.reset();
+                            continue;
+                        }
                     }
                 }
                 ControlOrPhase::Phase(HandshakeResult::AuthFailure(reason)) => {
@@ -1243,6 +1335,10 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
                             let Some(payload) = frame_decode(&data) else { continue; };
                             let Ok(event) = crate::transport_protocol::ServerEvent::decode_payload(&payload) else { continue; };
                             self.dispatch_server_event(event);
+                            if self.redirect_requested {
+                                self.redirect_requested = false;
+                                return WasmConnectedExit::Redirect;
+                            }
                         }
                         Ok(None) | Err(_) => return WasmConnectedExit::NetworkError,
                     }
@@ -1284,6 +1380,38 @@ mod tests {
             frame_decode_capped(&ok, cap).as_deref(),
             Some(&b"handshake"[..])
         );
+    }
+
+    #[test]
+    fn rebase_ws_url_keeps_app_path_swaps_origin() {
+        // https origin → wss, keep /apps/<id>/ws path
+        assert_eq!(
+            rebase_ws_url(
+                "wss://internal.eu-central-1.preprod.v2.aws.cloud.jazz.tools/apps/abc/ws",
+                "https://us-east-2.preprod.v2.aws.cloud.jazz.tools",
+            )
+            .as_deref(),
+            Some("wss://us-east-2.preprod.v2.aws.cloud.jazz.tools/apps/abc/ws"),
+        );
+    }
+
+    #[test]
+    fn rebase_ws_url_preserves_query_and_port() {
+        assert_eq!(
+            rebase_ws_url("ws://old.host:1625/apps/x/ws?foo=1", "http://new.host:8080")
+                .as_deref(),
+            Some("ws://new.host:8080/apps/x/ws?foo=1"),
+        );
+    }
+
+    #[test]
+    fn rebase_ws_url_rejects_bad_input() {
+        // No scheme separator on target.
+        assert!(rebase_ws_url("wss://h/apps/x/ws", "us-east-2.example").is_none());
+        // Unsupported scheme.
+        assert!(rebase_ws_url("wss://h/apps/x/ws", "ftp://h").is_none());
+        // Empty target authority.
+        assert!(rebase_ws_url("wss://h/apps/x/ws", "https:///path").is_none());
     }
 
     struct MockStream {

--- a/crates/jazz-tools/src/transport_protocol.rs
+++ b/crates/jazz-tools/src/transport_protocol.rs
@@ -102,6 +102,13 @@ pub enum ServerEvent {
 
     /// Heartbeat to keep connection alive.
     Heartbeat,
+
+    /// Server offers the client a direct URL to reconnect to (edge-fallback
+    /// redirect). Sent only on a forwarded, redirect-capable connection; the
+    /// server keeps serving normally, and the client reconnects to `url` and
+    /// closes its own old socket. The URL comes entirely from deployment config
+    /// (JAZZ_PUBLIC_URL) — the protocol carries no topology of its own.
+    Redirect { url: String },
 }
 
 impl ServerEvent {
@@ -114,6 +121,7 @@ impl ServerEvent {
             ServerEvent::SyncUpdateBatch { .. } => "SyncUpdateBatch",
             ServerEvent::Error { .. } => "Error",
             ServerEvent::Heartbeat => "Heartbeat",
+            ServerEvent::Redirect { .. } => "Redirect",
         }
     }
 }
@@ -266,6 +274,7 @@ const SERVER_SYNC_UPDATE: u8 = 2;
 const SERVER_SYNC_UPDATE_BATCH: u8 = 3;
 const SERVER_ERROR: u8 = 4;
 const SERVER_HEARTBEAT: u8 = 5;
+const SERVER_REDIRECT: u8 = 6;
 
 const CLIENT_OUTBOX_ENTRY: u8 = 1;
 const CLIENT_SYNC_BATCH_REQUEST: u8 = 2;
@@ -504,6 +513,10 @@ impl ServerEvent {
             ServerEvent::Heartbeat => {
                 push_u8(&mut out, SERVER_HEARTBEAT);
             }
+            ServerEvent::Redirect { url } => {
+                push_u8(&mut out, SERVER_REDIRECT);
+                push_string(&mut out, url)?;
+            }
         }
         Ok(out)
     }
@@ -541,6 +554,9 @@ impl ServerEvent {
                 message: reader.read_string()?,
             },
             SERVER_HEARTBEAT => ServerEvent::Heartbeat,
+            SERVER_REDIRECT => ServerEvent::Redirect {
+                url: reader.read_string()?,
+            },
             tag => return Err(DecodeError::InvalidTag(tag)),
         };
         reader.finish()?;
@@ -672,6 +688,33 @@ mod tests {
 
         let decoded = ServerEvent::decode_frame(&frame).unwrap();
         assert!(matches!(decoded, ServerEvent::Heartbeat));
+    }
+
+    #[test]
+    fn test_redirect_frame_roundtrip() {
+        let event = ServerEvent::Redirect {
+            url: "https://us-east-2.preprod.v2.aws.cloud.jazz.tools".to_string(),
+        };
+        let frame = event.encode_frame();
+        match ServerEvent::decode_frame(&frame).unwrap() {
+            ServerEvent::Redirect { url } => {
+                assert_eq!(url, "https://us-east-2.preprod.v2.aws.cloud.jazz.tools");
+            }
+            other => panic!("Expected Redirect event, got {:?}", other.variant_name()),
+        }
+    }
+
+    #[test]
+    fn test_redirect_json_roundtrip() {
+        // The handshake path uses JSON; ensure the variant serdes there too.
+        let event = ServerEvent::Redirect {
+            url: "https://host.example".to_string(),
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        match serde_json::from_str::<ServerEvent>(&json).unwrap() {
+            ServerEvent::Redirect { url } => assert_eq!(url, "https://host.example"),
+            other => panic!("Expected Redirect, got {:?}", other.variant_name()),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Adds an opt-in, in-band redirect so a sync server can tell a client to reconnect to a different public URL — without dropping the connection. This is the protocol half of edge-fallback routing: when a client is proxied to the region where its app actually lives, that region can hand the client a direct URL so the long-lived session stops traversing the proxy.

## Protocol (J1)

- New `ServerEvent::Redirect { url }` variant — binary tag 6 + JSON form, with encode/decode and round-trip tests.
- Client honors it in the shared transport (`transport_manager`): re-points its target by swapping the advertised origin onto the existing `/apps/<id>/ws` path (`rebase_ws_url`), then reconnects. In-memory CoValues live in `RuntimeCore`, so the reconnect resyncs via `catalogue_state_hash` — no state loss.
- Consecutive redirects are capped (reset on real sync traffic) as a loop guard. Honored on both the tokio and wasm connected loops.
- **Backward compatible with no capability handshake:** an older client that receives the unknown tag skips the undecodable frame (`decode_payload(...) else { continue; }`) and stays put — it does not drop. Behavior-neutral until a server emits `Redirect`.

## Server (J2)

- New `--public-url` / `JAZZ_PUBLIC_URL`, plumbed `main` → `commands::server::run` → `ServerBuilder` → `ServerState` (mirrors `--upstream-url`).
- On WS accept, after the `Connected` frame, if the request carries `x-jazz-forwarded` **and** a public URL is configured, the server sends `ServerEvent::Redirect { url }` and keeps serving. Gating is a pure, unit-tested `forwarded_redirect_target()` helper. Unset URL or non-forwarded request → unchanged behavior.

Topology stays out of jazz: the server only advertises the URL it's given via config and only acts on a header set upstream — no region/hostname is hardcoded.

## Tests

Protocol round-trip (binary + JSON), `rebase_ws_url` cases, server gating helper, plus 14/14 `edge_server_sync` integration. Builds native + wasm + napi.

## Deferral

The **forced/early close** (server proactively dropping a forwarded connection) is intentionally out of scope — the server only offers the redirect and keeps serving; the client migrates at its own pace and closes its own old socket.

The infra/deployment wiring that sets `x-jazz-forwarded` and `JAZZ_PUBLIC_URL` lives in a separate (private) gitops repo.