### PR TITLE
feat: allow creating a standalone in-memory DB

### DIFF
--- a/.changeset/standalone-in-memory-db.md
+++ b/.changeset/standalone-in-memory-db.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Allow `createDb({ driver: { type: "memory" } })` to create a standalone in-memory database without connecting to a sync server.

--- a/packages/jazz-tools/src/runtime/db.browser-mode.test.ts
+++ b/packages/jazz-tools/src/runtime/db.browser-mode.test.ts
@@ -48,16 +48,7 @@ afterEach(() => {
   }
 });
 
-describe("runtime/createDb driver mode", () => {
-  it("throws when memory driver is used without serverUrl", async () => {
-    await expect(
-      createDb({
-        appId: "driver-mode-no-server",
-        driver: { type: "memory" },
-      }),
-    ).rejects.toThrow("driver.type='memory' requires serverUrl.");
-  });
-
+describe("createDb browser mode", () => {
   it("uses worker-backed path in browser when driver is persistent", async () => {
     (globalThis as Record<string, unknown>).window = {};
     (globalThis as Record<string, unknown>).Worker = class {};
@@ -87,7 +78,6 @@ describe("runtime/createDb driver mode", () => {
     const result = await createDb({
       appId: "driver-mode-memory",
       driver: { type: "memory" },
-      serverUrl: "http://localhost:1625",
     });
 
     expect(result).toBe(directDb);

--- a/packages/jazz-tools/src/runtime/db.in-memory.test.ts
+++ b/packages/jazz-tools/src/runtime/db.in-memory.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { schema as s } from "../index.js";
+import { createDb, type Db } from "./db.js";
+
+const schema = {
+  notes: s.table({
+    title: s.string(),
+    done: s.boolean(),
+  }),
+};
+
+type AppSchema = s.Schema<typeof schema>;
+const app: s.App<AppSchema> = s.defineApp(schema);
+type Note = s.RowOf<typeof app.notes>;
+
+describe("createDb in-memory driver", () => {
+  let db: Db | undefined;
+
+  afterEach(async () => {
+    await db?.shutdown();
+    db = undefined;
+  });
+
+  it("can read and write data without connecting to a server", async () => {
+    db = await createDb({
+      appId: "in-memory-db-test",
+      driver: { type: "memory" },
+    });
+
+    const { value: inserted } = db.insert(app.notes, {
+      title: "Draft test",
+      done: false,
+    });
+
+    await db.update(app.notes, inserted.id, { done: true }).wait({ tier: "local" });
+
+    const updated = await db.one<Note>(app.notes.where({ id: { eq: inserted.id } }));
+    expect(updated).toEqual({
+      id: inserted.id,
+      title: "Draft test",
+      done: true,
+    });
+
+    const rows = await db.all<Note>(app.notes.where({ done: true }));
+    expect(rows).toEqual([updated]);
+  });
+});

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -903,7 +903,7 @@ export class Db {
 
   /**
    * Create a Db instance with a loaded runtime module.
-   * @internal Use createDb() instead.
+   * @internal Use {@link createDb()} instead.
    */
   static create(config: DbConfig, runtimeModule: AnyDbRuntimeModule): Db {
     return new Db(config, runtimeModule);
@@ -1806,10 +1806,6 @@ export async function createDbWithRuntimeModule<RuntimeConfig extends DbConfig>(
   }
 
   const driver = resolveStorageDriver(resolvedConfig.driver);
-
-  if (driver.type === "memory" && !resolvedConfig.serverUrl) {
-    throw new Error("driver.type='memory' requires serverUrl.");
-  }
 
   let db: Db;
   if (


### PR DESCRIPTION
## Description

Allows creating a standalone in-memory database for tests.

We originally added this to guard to protect users from data loss mistakes from the unwanted combination of in-memory/no-server, but this setup can have useful use cases (most notably for testing), and it should be pretty easy for developers to catch a missing server connection before deploying their apps anyway (as data won't be persisted across app restarts).

Stack: PR 1 of 5