### PR TITLE
feat: make useLocalFirstAuth localStorage key configurable

### DIFF
--- a/.changeset/configurable-local-first-auth-key.md
+++ b/.changeset/configurable-local-first-auth-key.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+feat: the localStorage key used by React's `useLocalFirstAuth` helper is now configurable, to support multiple Jazz apps on the same origin

--- a/examples/chat-react/src/App.tsx
+++ b/examples/chat-react/src/App.tsx
@@ -14,6 +14,10 @@ import Router from "@/components/Router";
 const appId = import.meta.env.VITE_JAZZ_APP_ID;
 const serverUrl = import.meta.env.VITE_JAZZ_SERVER_URL;
 
+type AppConfig = Partial<DbConfig> & {
+  authSecretStorageKey?: string;
+};
+
 function defaultConfig(secret: string, overrides: Partial<DbConfig> = {}): DbConfig {
   return {
     appId,
@@ -25,12 +29,11 @@ function defaultConfig(secret: string, overrides: Partial<DbConfig> = {}): DbCon
   };
 }
 
-export function App({ config }: { config?: Partial<DbConfig> } = {}) {
-  return <AppInner config={config} />;
-}
-
-function AppInner({ config }: { config?: Partial<DbConfig> }) {
-  const { secret, isLoading } = useLocalFirstAuth();
+export function App({ config }: { config?: AppConfig } = {}) {
+  const { authSecretStorageKey, ...dbConfig } = config ?? {};
+  const { secret, isLoading } = useLocalFirstAuth(
+    authSecretStorageKey ? { authSecretStorageKey: authSecretStorageKey } : undefined,
+  );
 
   if (isLoading || !secret) {
     return <p id="joining-chat">Loading...</p>;
@@ -38,7 +41,7 @@ function AppInner({ config }: { config?: Partial<DbConfig> }) {
 
   return (
     <JazzProvider
-      config={defaultConfig(secret, config)}
+      config={defaultConfig(secret, dbConfig)}
       fallback={<p id="joining-chat">Loading...</p>}
     >
       <AppContent />

--- a/examples/chat-react/tests/browser/auto-join-race.test.tsx
+++ b/examples/chat-react/tests/browser/auto-join-race.test.tsx
@@ -24,7 +24,7 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { createRoot, type Root } from "react-dom/client";
 import { App } from "../../src/App.js";
-import { TEST_PORT, APP_ID, testSecret } from "./test-constants.js";
+import { TEST_PORT, APP_ID } from "./test-constants.js";
 import { resetProfileGuard } from "../../src/hooks/useMyProfile.js";
 
 // ---------------------------------------------------------------------------
@@ -111,7 +111,6 @@ describe("auto-join race on first message send", () => {
             appId: APP_ID,
             dbName: uniqueDbName("autojoin-alice"),
             serverUrl,
-            secret: await testSecret(`autojoin-alice-${runId}`),
           }}
         />,
       );
@@ -178,7 +177,6 @@ describe("auto-join race on first message send", () => {
             appId: APP_ID,
             dbName: uniqueDbName("autojoin-bob"),
             serverUrl,
-            secret: await testSecret(`autojoin-bob-${runId}`),
           }}
         />,
       );

--- a/examples/chat-react/tests/browser/canvas.test.tsx
+++ b/examples/chat-react/tests/browser/canvas.test.tsx
@@ -8,7 +8,7 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { createRoot, type Root } from "react-dom/client";
 import { App } from "../../src/App.js";
-import { TEST_PORT, APP_ID, testSecret } from "./test-constants.js";
+import { TEST_PORT, APP_ID } from "./test-constants.js";
 import { resetProfileGuard } from "../../src/hooks/useMyProfile.js";
 
 // ---------------------------------------------------------------------------
@@ -208,7 +208,6 @@ describe("Canvas E2E", () => {
       appId: APP_ID,
       dbName: uniqueDbName("collab-canvas-a"),
       serverUrl,
-      secret: await testSecret(`canvas-user-a-${Date.now()}`),
     });
 
     await waitFor(
@@ -265,7 +264,6 @@ describe("Canvas E2E", () => {
       appId: APP_ID,
       dbName: uniqueDbName("collab-canvas-b"),
       serverUrl,
-      secret: await testSecret(`canvas-user-b-${Date.now()}`),
     });
 
     // User B should see the canvas

--- a/examples/chat-react/tests/browser/chat-app.test.tsx
+++ b/examples/chat-react/tests/browser/chat-app.test.tsx
@@ -7,7 +7,7 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { createRoot, type Root } from "react-dom/client";
 import { App } from "../../src/App.js";
-import { TEST_PORT, APP_ID, testSecret } from "./test-constants.js";
+import { TEST_PORT, APP_ID } from "./test-constants.js";
 import { resetProfileGuard } from "../../src/hooks/useMyProfile.js";
 
 // ---------------------------------------------------------------------------
@@ -458,7 +458,6 @@ describe("Chat App E2E", () => {
       appId: APP_ID,
       dbName: uniqueDbName("access-a"),
       serverUrl,
-      secret: await testSecret(`chat-access-user-a-${Date.now()}`),
     });
 
     await waitFor(
@@ -544,7 +543,6 @@ describe("Chat App E2E", () => {
       appId: APP_ID,
       dbName: uniqueDbName("access-b"),
       serverUrl,
-      secret: await testSecret(`chat-access-user-b-${Date.now()}`),
     });
 
     // Wait for sync to settle so Bob has whatever data the server delivers

--- a/examples/chat-react/tests/browser/chat-app.test.tsx
+++ b/examples/chat-react/tests/browser/chat-app.test.tsx
@@ -136,6 +136,7 @@ describe("Chat App E2E", () => {
       dbName?: string;
       serverUrl?: string;
       secret?: string;
+      authSecretStorageKey?: string;
     } = {},
   ): Promise<HTMLDivElement> {
     const el = document.createElement("div");
@@ -452,11 +453,14 @@ describe("Chat App E2E", () => {
     bobContainer: HTMLDivElement;
   }> {
     const serverUrl = `http://127.0.0.1:${TEST_PORT}`;
+    const aliceAuthKey = uniqueDbName("access-a-auth");
+    const bobAuthKey = uniqueDbName("access-b-auth");
 
     // --- User A: create a private chat with a secret message ----------------
     const aliceContainer = await mountApp({
       appId: APP_ID,
       dbName: uniqueDbName("access-a"),
+      authSecretStorageKey: aliceAuthKey,
       serverUrl,
     });
 
@@ -542,6 +546,7 @@ describe("Chat App E2E", () => {
     const bobContainer = await mountApp({
       appId: APP_ID,
       dbName: uniqueDbName("access-b"),
+      authSecretStorageKey: bobAuthKey,
       serverUrl,
     });
 

--- a/examples/chat-react/tests/browser/chat-settings.test.tsx
+++ b/examples/chat-react/tests/browser/chat-settings.test.tsx
@@ -7,7 +7,7 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { createRoot, type Root } from "react-dom/client";
 import { App } from "../../src/App.js";
-import { TEST_PORT, APP_ID, testSecret } from "./test-constants.js";
+import { TEST_PORT, APP_ID } from "./test-constants.js";
 import { resetProfileGuard } from "../../src/hooks/useMyProfile.js";
 
 // ---------------------------------------------------------------------------
@@ -296,7 +296,6 @@ describe("ChatHeader + ChatSettings E2E", () => {
       appId: APP_ID,
       dbName: uniqueDbName("members-alice"),
       serverUrl,
-      secret: await testSecret(`settings-alice-${Date.now()}`),
     });
 
     await waitFor(
@@ -319,7 +318,6 @@ describe("ChatHeader + ChatSettings E2E", () => {
       appId: APP_ID,
       dbName: uniqueDbName("members-bob"),
       serverUrl,
-      secret: await testSecret(`settings-bob-${Date.now()}`),
     });
 
     // Wait for Bob to see the chat

--- a/examples/chat-react/tests/browser/invite.test.tsx
+++ b/examples/chat-react/tests/browser/invite.test.tsx
@@ -8,7 +8,7 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { createRoot, type Root } from "react-dom/client";
 import { App } from "../../src/App.js";
-import { TEST_PORT, APP_ID, testSecret } from "./test-constants.js";
+import { TEST_PORT, APP_ID } from "./test-constants.js";
 import { resetProfileGuard } from "../../src/hooks/useMyProfile.js";
 
 // ---------------------------------------------------------------------------
@@ -118,7 +118,6 @@ describe("Invite Flow E2E", () => {
       appId: APP_ID,
       dbName: uniqueDbName("invite-a"),
       serverUrl,
-      secret: await testSecret(`invite-user-a-${Date.now()}`),
     });
 
     await waitFor(
@@ -266,7 +265,6 @@ describe("Invite Flow E2E", () => {
       appId: APP_ID,
       dbName: uniqueDbName("invite-b"),
       serverUrl,
-      secret: await testSecret(`invite-user-b-${Date.now()}`),
     });
 
     // User B should see the secret message after joining via invite

--- a/examples/chat-react/tests/browser/send-permission.test.tsx
+++ b/examples/chat-react/tests/browser/send-permission.test.tsx
@@ -32,7 +32,7 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { createRoot, type Root } from "react-dom/client";
 import { App } from "../../src/App.js";
-import { TEST_PORT, APP_ID, testSecret } from "./test-constants.js";
+import { TEST_PORT, APP_ID } from "./test-constants.js";
 import { resetProfileGuard } from "../../src/hooks/useMyProfile.js";
 
 // ---------------------------------------------------------------------------
@@ -182,7 +182,6 @@ describe("Send permission — private chat INSERT policy", () => {
     const aliceContainer = await mountApp({
       dbName: uniqueDbName("alice-a"),
       serverUrl,
-      secret: await testSecret(`send-perm-alice-a-${Date.now()}`),
     });
 
     // Alice's app auto-creates a public chat first; navigate to a private one
@@ -232,7 +231,6 @@ describe("Send permission — private chat INSERT policy", () => {
     const aliceContainer = await mountApp({
       dbName: uniqueDbName("alice-b"),
       serverUrl,
-      secret: await testSecret(`send-perm-alice-b-${Date.now()}`),
     });
 
     await waitFor(
@@ -293,7 +291,6 @@ describe("Send permission — private chat INSERT policy", () => {
     const bobContainer = await mountApp({
       dbName: uniqueDbName("bob-b"),
       serverUrl,
-      secret: await testSecret(`send-perm-bob-b-${Date.now()}`),
     });
 
     // InviteHandler should redirect Bob to the chat after inserting chatMember

--- a/examples/chat-react/tests/browser/test-constants.ts
+++ b/examples/chat-react/tests/browser/test-constants.ts
@@ -3,19 +3,3 @@ export const TEST_PORT = 19880;
 export const JWT_SECRET = "test-jwt-secret-for-chat-react-tests";
 export const ADMIN_SECRET = "test-admin-secret-for-chat-react-tests";
 export const APP_ID = "019d4349-24f1-7053-a5ae-b5fb5600f7a7";
-
-/**
- * Derive a valid base64url-encoded 32-byte secret from a human-readable label.
- * Uses SHA-256 so the result is deterministic and always the right format
- * for `mintLocalFirstToken`.
- */
-export async function testSecret(label: string): Promise<string> {
-  const data = new TextEncoder().encode(label);
-  const hash = await crypto.subtle.digest("SHA-256", data);
-  const bytes = new Uint8Array(hash);
-  let binary = "";
-  for (const b of bytes) {
-    binary += String.fromCharCode(b);
-  }
-  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-}

--- a/examples/moon-lander-react/tests/browser/global-setup.ts
+++ b/examples/moon-lander-react/tests/browser/global-setup.ts
@@ -11,7 +11,6 @@ import { startLocalJazzServer, deploy, type LocalJazzServerHandle } from "jazz-t
 const TEST_PORT = parseInt(process.env.TEST_PORT!, 10);
 const ADMIN_SECRET = "test-admin-secret-for-moon-lander-tests";
 const APP_ID = "00000000-0000-0000-0000-000000000003";
-const APP_ID_MULTI = "00000000-0000-0000-0000-000000000004";
 
 let server: Promise<LocalJazzServerHandle> | null = null;
 
@@ -33,14 +32,6 @@ export async function setup(): Promise<void> {
   await deploy({
     serverUrl: handle.url,
     appId: APP_ID,
-    adminSecret: ADMIN_SECRET,
-    schemaDir,
-  });
-  // Register schema for the isolated multi-player namespace so test 837
-  // starts with an empty event history (no stream connect timeout).
-  await deploy({
-    serverUrl: handle.url,
-    appId: APP_ID_MULTI,
     adminSecret: ADMIN_SECRET,
     schemaDir,
   });

--- a/examples/moon-lander-react/tests/browser/multiplayer.test.tsx
+++ b/examples/moon-lander-react/tests/browser/multiplayer.test.tsx
@@ -23,7 +23,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { commands } from "vitest/browser";
 import { App } from "../../src/App";
 import { FUEL_TYPES } from "../../src/game/constants";
-import { ADMIN_SECRET, APP_ID, APP_ID_MULTI, TEST_PORT, testSecret } from "./test-constants";
+import { ADMIN_SECRET, APP_ID, APP_ID_MULTI, TEST_PORT } from "./test-constants";
 import {
   type MountEntry,
   pressKey,
@@ -369,16 +369,12 @@ describe("Moon Lander — Cross-Client Sync", () => {
      * within SYNC_TIMEOUT.
      */
     const serverUrl = await commands.startFreshTestServer("full-phase2");
-    const sharedToken = await testSecret(
-      `full-token-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-    );
 
     try {
       const elA = await mountApp({
         appId: APP_ID_MULTI,
         dbName: uniqueDbName("full-a"),
         serverUrl,
-        localFirstSecret: sharedToken,
         adminSecret: ADMIN_SECRET,
         physicsSpeed: 10,
       });
@@ -387,7 +383,6 @@ describe("Moon Lander — Cross-Client Sync", () => {
         appId: APP_ID_MULTI,
         dbName: uniqueDbName("full-b"),
         serverUrl,
-        localFirstSecret: sharedToken,
         adminSecret: ADMIN_SECRET,
         physicsSpeed: 10,
       });

--- a/examples/moon-lander-react/tests/browser/test-constants.ts
+++ b/examples/moon-lander-react/tests/browser/test-constants.ts
@@ -10,17 +10,3 @@ export const APP_ID = "00000000-0000-0000-0000-000000000003";
  *  event history — preventing stream connect timeouts in the isolated
  *  BrowserContext caused by accumulated events from earlier tests. */
 export const APP_ID_MULTI = "00000000-0000-0000-0000-000000000004";
-
-/**
- * Derive a valid base64url-encoded 32-byte secret from a human-readable label.
- */
-export async function testSecret(label: string): Promise<string> {
-  const data = new TextEncoder().encode(label);
-  const hash = await crypto.subtle.digest("SHA-256", data);
-  const bytes = new Uint8Array(hash);
-  let binary = "";
-  for (const b of bytes) {
-    binary += String.fromCharCode(b);
-  }
-  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-}

--- a/packages/jazz-tools/src/expo/use-local-first-auth.ts
+++ b/packages/jazz-tools/src/expo/use-local-first-auth.ts
@@ -1,5 +1,9 @@
-import { createUseLocalFirstAuth } from "../react-core/use-local-first-auth.js";
+import { useLocalFirstAuthWithStore } from "../react-core/use-local-first-auth.js";
+import type { LocalFirstAuth } from "../react-core/use-local-first-auth.js";
 import { expoAuthSecretStore } from "./auth-secret-store.js";
 
-export const useLocalFirstAuth = createUseLocalFirstAuth(expoAuthSecretStore);
+export function useLocalFirstAuth(): LocalFirstAuth {
+  return useLocalFirstAuthWithStore(expoAuthSecretStore);
+}
+
 export type { LocalFirstAuth } from "../react-core/use-local-first-auth.js";

--- a/packages/jazz-tools/src/react-core/index.ts
+++ b/packages/jazz-tools/src/react-core/index.ts
@@ -10,7 +10,7 @@ export {
 } from "./provider.js";
 export { useAll, useAllSuspense } from "./use-all.js";
 export { useAuthState, type AuthStateInfo } from "./use-auth-state.js";
-export { createUseLocalFirstAuth, type LocalFirstAuth } from "./use-local-first-auth.js";
+export { useLocalFirstAuthWithStore, type LocalFirstAuth } from "./use-local-first-auth.js";
 
 export type {
   DurabilityTier,

--- a/packages/jazz-tools/src/react-core/use-local-first-auth.test.tsx
+++ b/packages/jazz-tools/src/react-core/use-local-first-auth.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
-import { createUseLocalFirstAuth } from "./use-local-first-auth.js";
+import { useLocalFirstAuthWithStore } from "./use-local-first-auth.js";
 import type { AuthSecretStore } from "../runtime/auth-secret-store.js";
 
 function makeInMemoryStore(): AuthSecretStore {
@@ -28,17 +28,15 @@ function makeInMemoryStore(): AuthSecretStore {
   };
 }
 
-describe("createUseLocalFirstAuth", () => {
+describe("useLocalFirstAuthWithStore", () => {
   let store: AuthSecretStore;
-  let useLocalFirstAuth: ReturnType<typeof createUseLocalFirstAuth>;
 
   beforeEach(() => {
     store = makeInMemoryStore();
-    useLocalFirstAuth = createUseLocalFirstAuth(store);
   });
 
   it("starts with isLoading=true and secret=null, then resolves", async () => {
-    const { result } = renderHook(() => useLocalFirstAuth());
+    const { result } = renderHook(() => useLocalFirstAuthWithStore(store));
     expect(result.current.isLoading).toBe(true);
     expect(result.current.secret).toBeNull();
 
@@ -47,7 +45,7 @@ describe("createUseLocalFirstAuth", () => {
   });
 
   it("login writes the store and updates secret", async () => {
-    const { result } = renderHook(() => useLocalFirstAuth());
+    const { result } = renderHook(() => useLocalFirstAuthWithStore(store));
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     await act(async () => {
@@ -60,7 +58,7 @@ describe("createUseLocalFirstAuth", () => {
   });
 
   it("signOut clears the store and rotates the secret on re-resolve", async () => {
-    const { result } = renderHook(() => useLocalFirstAuth());
+    const { result } = renderHook(() => useLocalFirstAuthWithStore(store));
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     const before = result.current.secret;
 
@@ -74,13 +72,11 @@ describe("createUseLocalFirstAuth", () => {
     });
   });
 
-  it("two factory invocations have independent version scopes", async () => {
+  it("useLocalFirstAuthWithStore isolates different stores", async () => {
     const storeA = makeInMemoryStore();
     const storeB = makeInMemoryStore();
-    const useA = createUseLocalFirstAuth(storeA);
-    const useB = createUseLocalFirstAuth(storeB);
-    const { result: a } = renderHook(() => useA());
-    const { result: b } = renderHook(() => useB());
+    const { result: a } = renderHook(() => useLocalFirstAuthWithStore(storeA));
+    const { result: b } = renderHook(() => useLocalFirstAuthWithStore(storeB));
 
     await waitFor(() => expect(a.current.isLoading).toBe(false));
     await waitFor(() => expect(b.current.isLoading).toBe(false));

--- a/packages/jazz-tools/src/react-core/use-local-first-auth.ts
+++ b/packages/jazz-tools/src/react-core/use-local-first-auth.ts
@@ -8,7 +8,22 @@ export interface LocalFirstAuth {
   signOut(): Promise<void>;
 }
 
-export function createUseLocalFirstAuth(store: AuthSecretStore): () => LocalFirstAuth {
+interface LocalFirstAuthStoreState {
+  subscribe(onChange: () => void): () => void;
+  getSnapshot(): number;
+  login(secret: string): Promise<void>;
+  signOut(): Promise<void>;
+}
+
+const storeStates = new WeakMap<AuthSecretStore, LocalFirstAuthStoreState>();
+const getServerSnapshot = (): number => 0;
+
+function getStoreState(store: AuthSecretStore): LocalFirstAuthStoreState {
+  const existing = storeStates.get(store);
+  if (existing) {
+    return existing;
+  }
+
   let version = 0;
   const listeners = new Set<() => void>();
 
@@ -25,7 +40,6 @@ export function createUseLocalFirstAuth(store: AuthSecretStore): () => LocalFirs
   };
 
   const getSnapshot = (): number => version;
-  const getServerSnapshot = (): number => 0;
 
   async function login(secret: string): Promise<void> {
     await store.saveSecret(secret);
@@ -37,31 +51,40 @@ export function createUseLocalFirstAuth(store: AuthSecretStore): () => LocalFirs
     notify();
   }
 
-  return function useLocalFirstAuth(): LocalFirstAuth {
-    const currentVersion = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
-    const [secret, setSecret] = useState<string | null>(null);
-    const [isLoading, setIsLoading] = useState(true);
+  const state = { subscribe, getSnapshot, login, signOut };
+  storeStates.set(store, state);
+  return state;
+}
 
-    useEffect(() => {
-      let cancelled = false;
-      setIsLoading(true);
-      store
-        .getOrCreateSecret()
-        .then((resolved) => {
-          if (cancelled) return;
-          setSecret(resolved);
-          setIsLoading(false);
-        })
-        .catch(() => {
-          if (cancelled) return;
-          setSecret(null);
-          setIsLoading(false);
-        });
-      return () => {
-        cancelled = true;
-      };
-    }, [currentVersion]);
+export function useLocalFirstAuthWithStore(store: AuthSecretStore): LocalFirstAuth {
+  const storeState = getStoreState(store);
+  const currentVersion = useSyncExternalStore(
+    storeState.subscribe,
+    storeState.getSnapshot,
+    getServerSnapshot,
+  );
+  const [secret, setSecret] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
 
-    return { secret, isLoading, login, signOut };
-  };
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    store
+      .getOrCreateSecret()
+      .then((resolved) => {
+        if (cancelled) return;
+        setSecret(resolved);
+        setIsLoading(false);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setSecret(null);
+        setIsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [currentVersion, store]);
+
+  return { secret, isLoading, login: storeState.login, signOut: storeState.signOut };
 }

--- a/packages/jazz-tools/src/react/index.ts
+++ b/packages/jazz-tools/src/react/index.ts
@@ -14,6 +14,10 @@ export {
   useSession,
 } from "./provider.js";
 export { useAll, useAllSuspense } from "./use-all.js";
-export { useLocalFirstAuth, type LocalFirstAuth } from "./use-local-first-auth.js";
+export {
+  useLocalFirstAuth,
+  type LocalFirstAuth,
+  type UseLocalFirstAuthOptions,
+} from "./use-local-first-auth.js";
 export { useAuthState, type AuthStateInfo } from "../react-core/use-auth-state.js";
 export type { QueryOptions, RuntimeSourcesConfig } from "../runtime/index.js";

--- a/packages/jazz-tools/src/react/use-local-first-auth.test.tsx
+++ b/packages/jazz-tools/src/react/use-local-first-auth.test.tsx
@@ -1,0 +1,28 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useLocalFirstAuth } from "./use-local-first-auth.js";
+
+describe("react/useLocalFirstAuth", () => {
+  it("accepts browser secret-store options to isolate storage keys", async () => {
+    const aliceKey = `auth:alice`;
+    const bobKey = `auth:bob`;
+    const { result: alice } = renderHook(() =>
+      useLocalFirstAuth({ authSecretStorageKey: aliceKey }),
+    );
+    const { result: bob } = renderHook(() => useLocalFirstAuth({ authSecretStorageKey: bobKey }));
+
+    await waitFor(() => {
+      expect(alice.current.isLoading).toBe(false);
+      expect(bob.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await alice.current.login("secret-A-aaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    });
+
+    await waitFor(() => expect(alice.current.secret).toBe("secret-A-aaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+    expect(localStorage.getItem(aliceKey)).toBe("secret-A-aaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    expect(localStorage.getItem(bobKey)).not.toBe("secret-A-aaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    expect(bob.current.secret).not.toBe("secret-A-aaaaaaaaaaaaaaaaaaaaaaaaaaa");
+  });
+});

--- a/packages/jazz-tools/src/react/use-local-first-auth.ts
+++ b/packages/jazz-tools/src/react/use-local-first-auth.ts
@@ -1,5 +1,18 @@
-import { createUseLocalFirstAuth } from "../react-core/use-local-first-auth.js";
-import { browserAuthSecretStore } from "../runtime/auth-secret-store.js";
+import { useLocalFirstAuthWithStore } from "../react-core/use-local-first-auth.js";
+import {
+  BrowserAuthSecretStore,
+  browserAuthSecretStore,
+  type BrowserAuthSecretStoreOptions,
+} from "../runtime/auth-secret-store.js";
+import type { LocalFirstAuth } from "../react-core/use-local-first-auth.js";
 
-export const useLocalFirstAuth = createUseLocalFirstAuth(browserAuthSecretStore);
+export type UseLocalFirstAuthOptions = Pick<BrowserAuthSecretStoreOptions, "authSecretStorageKey">;
+
+export function useLocalFirstAuth(options?: UseLocalFirstAuthOptions): LocalFirstAuth {
+  const store = options?.authSecretStorageKey
+    ? BrowserAuthSecretStore.getDefault({ authSecretStorageKey: options.authSecretStorageKey })
+    : browserAuthSecretStore;
+  return useLocalFirstAuthWithStore(store);
+}
+
 export type { LocalFirstAuth } from "../react-core/use-local-first-auth.js";

--- a/packages/jazz-tools/src/runtime/auth-secret-store.test.ts
+++ b/packages/jazz-tools/src/runtime/auth-secret-store.test.ts
@@ -78,7 +78,10 @@ describe("BrowserAuthSecretStore", () => {
   });
 
   it("uses custom key name", async () => {
-    const customStore = new BrowserAuthSecretStore({ storage, key: "my-custom-key" });
+    const customStore = new BrowserAuthSecretStore({
+      storage,
+      authSecretStorageKey: "my-custom-key",
+    });
     await customStore.saveSecret("test-secret");
     expect(storage.getItem("my-custom-key")).toBe("test-secret");
   });

--- a/packages/jazz-tools/src/runtime/auth-secret-store.ts
+++ b/packages/jazz-tools/src/runtime/auth-secret-store.ts
@@ -30,7 +30,7 @@ function uint8ArrayToBase64url(bytes: Uint8Array): string {
 
 export interface BrowserAuthSecretStoreOptions {
   /** localStorage key name (default: "jazz-auth-secret") */
-  key?: string;
+  authSecretStorageKey?: string;
   /** Optional app identifier to namespace the default key. */
   appId?: string;
   /** Optional principal identifier to isolate secrets per user. */
@@ -55,8 +55,8 @@ function normalizeScopeSegment(value?: string | null): string | null {
 }
 
 function resolveBrowserAuthSecretKey(options: BrowserAuthSecretStoreOptions = {}): string {
-  if (options.key) {
-    return options.key;
+  if (options.authSecretStorageKey) {
+    return options.authSecretStorageKey;
   }
 
   const scopeSegments = [

--- a/packages/jazz-tools/src/solid/use-local-first-auth.ts
+++ b/packages/jazz-tools/src/solid/use-local-first-auth.ts
@@ -22,6 +22,7 @@ export function useLocalFirstAuth(store: Accessor<AuthSecretStore> = () => brows
   const [error, setError] = createSignal<Error | null>(null);
 
   createEffect(() => {
+    const currentStore = store();
     let disposed = false;
     onCleanup(() => {
       disposed = true;
@@ -36,7 +37,7 @@ export function useLocalFirstAuth(store: Accessor<AuthSecretStore> = () => brows
       setIsLoading(true);
 
       try {
-        const resolved = await store().getOrCreateSecret();
+        const resolved = await currentStore.getOrCreateSecret();
         if (stale()) {
           return;
         }
@@ -53,7 +54,7 @@ export function useLocalFirstAuth(store: Accessor<AuthSecretStore> = () => brows
       }
     };
 
-    const listeners = getListeners(store());
+    const listeners = getListeners(currentStore);
 
     refetch();
     listeners.add(refetch);


### PR DESCRIPTION
# Description

The localStorage key used by React's `useLocalFirstAuth` helper is now configurable, to support multiple Jazz apps on the same origin. The other UI library bindings already support this.  

Stack: PR 2 of 5. Depends on #1062.