### PR TITLE
feat: add db.disconnect() and db.reconnect()

### DIFF
--- a/.changeset/db-disconnect-reconnect.md
+++ b/.changeset/db-disconnect-reconnect.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Add `Db.disconnect()` and `Db.reconnect()` for temporarily pausing and resuming sync without shutting down local storage.

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -1085,6 +1085,16 @@ export class JazzClient {
   }
 
   /**
+   * Disconnect from the Jazz server without shutting down the local runtime.
+   *
+   * Local reads and writes can continue. Call {@link connectTransport} to
+   * reconnect the same runtime to a server later.
+   */
+  disconnectTransport(): void {
+    this.runtime.disconnect();
+  }
+
+  /**
    * Get the current schema.
    */
   getSchema(): WasmSchema {

--- a/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.ts
@@ -168,6 +168,32 @@ export class BrowserConnectionManager extends ConnectionManager {
     await this.activeRoleBridge?.ensureReady(tier);
   }
 
+  async disconnect(): Promise<void> {
+    if (!this.host.config.serverUrl) {
+      throw new Error("Db.disconnect() requires a configured serverUrl.");
+    }
+
+    await this.ensureBridgeReady();
+    const roleBridge = this.activeRoleBridge;
+    if (!roleBridge) {
+      throw new Error("Db.disconnect() requires an active browser connection.");
+    }
+    await roleBridge.disconnect();
+  }
+
+  async reconnect(): Promise<void> {
+    if (!this.host.config.serverUrl) {
+      throw new Error("Db.reconnect() requires a configured serverUrl.");
+    }
+
+    await this.ensureBridgeReady();
+    const roleBridge = this.activeRoleBridge;
+    if (!roleBridge) {
+      throw new Error("Db.reconnect() requires an active browser connection.");
+    }
+    await roleBridge.reconnect();
+  }
+
   override updateAuth(auth: { jwtToken?: string; cookieSession?: Session }): void {
     super.updateAuth(auth);
     if ("jwtToken" in auth) {

--- a/packages/jazz-tools/src/runtime/connection-manager/connection-roles/connection-role.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/connection-roles/connection-role.ts
@@ -5,6 +5,8 @@ import type { ConnectionManagerClientInput } from "../types.js";
 export interface BrowserConnectionRole {
   onClientCreated(input: ConnectionManagerClientInput): void;
   ensureReady(tier?: DurabilityTier): Promise<void>;
+  disconnect(): Promise<void>;
+  reconnect(): Promise<void>;
   updateAuth(auth: { jwtToken?: string }): void;
   sendLifecycleHint(event: WorkerLifecycleEvent): void;
   shutdown(): Promise<void> | void;

--- a/packages/jazz-tools/src/runtime/connection-manager/connection-roles/follower-port-connection-role.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/connection-roles/follower-port-connection-role.ts
@@ -54,6 +54,14 @@ export class FollowerPortConnectionRole implements BrowserConnectionRole {
 
   async ensureReady(): Promise<void> {}
 
+  async disconnect(): Promise<void> {
+    throw new Error("Db.disconnect() is only supported on the browser leader tab.");
+  }
+
+  async reconnect(): Promise<void> {
+    throw new Error("Db.reconnect() is only supported on the browser leader tab.");
+  }
+
   updateAuth(auth: { jwtToken?: string }): void {
     this.followerPortBridge?.updateAuth(auth);
   }

--- a/packages/jazz-tools/src/runtime/connection-manager/connection-roles/leader-worker-connection-role.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/connection-roles/leader-worker-connection-role.ts
@@ -17,6 +17,7 @@ interface LeaderWorkerBridgeCallbacks {
 export class LeaderWorkerConnectionRole implements BrowserConnectionRole {
   private workerBridge: WorkerBridge | null = null;
   private bridgeReady: Promise<void> | null = null;
+  private shouldBeConnected = true;
   private readonly pendingFollowerPorts = new Map<
     string,
     { followerTabId: string; leadershipId: number; port: MessagePort }
@@ -61,6 +62,9 @@ export class LeaderWorkerConnectionRole implements BrowserConnectionRole {
       .init(this.buildWorkerBridgeOptions(schemaJson))
       .then(() => {
         if (this.workerBridge !== bridge) return;
+        if (!this.shouldBeConnected) {
+          bridge.disconnectUpstream();
+        }
         this.flushPendingFollowerPorts();
         this.callbacks.onReady(this.leadershipId);
       })
@@ -116,6 +120,28 @@ export class LeaderWorkerConnectionRole implements BrowserConnectionRole {
     await this.bridgeReady;
     if (!this.workerBridge || !this.host.config.serverUrl) return;
     if (!tier || tier === "local") return;
+    await this.workerBridge.waitForUpstreamServerConnection();
+  }
+
+  async disconnect(): Promise<void> {
+    if (!this.host.config.serverUrl) {
+      throw new Error("Db.disconnect() requires a configured serverUrl.");
+    }
+
+    this.shouldBeConnected = false;
+    await this.bridgeReady;
+    this.workerBridge?.disconnectUpstream();
+  }
+
+  async reconnect(): Promise<void> {
+    if (!this.host.config.serverUrl) {
+      throw new Error("Db.reconnect() requires a configured serverUrl.");
+    }
+
+    this.shouldBeConnected = true;
+    await this.bridgeReady;
+    if (!this.workerBridge) return;
+    this.workerBridge.reconnectUpstream();
     await this.workerBridge.waitForUpstreamServerConnection();
   }
 

--- a/packages/jazz-tools/src/runtime/connection-manager/direct-connection-manager.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/direct-connection-manager.ts
@@ -9,6 +9,8 @@ import {
  */
 export class DirectConnectionManager extends ConnectionManager {
   protected readonly hasDurablePeer = false;
+  private isDisconnected = false;
+  private reconnectWaiters: Array<() => void> = [];
 
   constructor(host: DbForConnection) {
     super(host);
@@ -17,6 +19,11 @@ export class DirectConnectionManager extends ConnectionManager {
   async start(): Promise<void> {}
 
   protected override onClientCreated({ client }: ConnectionManagerClientInput): void {
+    if (this.isDisconnected) return;
+    this.connectClient(client);
+  }
+
+  private connectClient(client: ConnectionManagerClientInput["client"]): void {
     const { config } = this.host;
     if (!config.serverUrl) return;
     client.connectTransport(config.serverUrl, {
@@ -25,7 +32,36 @@ export class DirectConnectionManager extends ConnectionManager {
     });
   }
 
-  async ensureReady(): Promise<void> {}
+  async ensureReady(): Promise<void> {
+    if (!this.isDisconnected) return;
+    await new Promise<void>((resolve) => {
+      this.reconnectWaiters.push(resolve);
+    });
+  }
+
+  async disconnect(): Promise<void> {
+    if (!this.host.config.serverUrl) {
+      throw new Error("Db.disconnect() requires a configured serverUrl.");
+    }
+
+    this.isDisconnected = true;
+    this.clientEntry?.client.disconnectTransport();
+  }
+
+  async reconnect(): Promise<void> {
+    if (!this.host.config.serverUrl) {
+      throw new Error("Db.reconnect() requires a configured serverUrl.");
+    }
+
+    this.isDisconnected = false;
+    const client = this.clientEntry?.client;
+    if (client) {
+      this.connectClient(client);
+    }
+    for (const resolve of this.reconnectWaiters.splice(0)) {
+      resolve();
+    }
+  }
 
   sendLifecycleHint(): void {}
 

--- a/packages/jazz-tools/src/runtime/connection-manager/types.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/types.ts
@@ -130,6 +130,10 @@ export abstract class ConnectionManager {
 
   abstract ensureReady(tier?: DurabilityTier): Promise<void>;
 
+  abstract disconnect(): Promise<void>;
+
+  abstract reconnect(): Promise<void>;
+
   updateAuth(auth: { jwtToken?: string; cookieSession?: Session }): void {
     if ("jwtToken" in auth) {
       this.client?.updateAuthToken(auth.jwtToken);

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -960,6 +960,32 @@ export class Db {
     await this.connection.ensureReady(tier);
   }
 
+  /**
+   * Temporarily disconnect this Db from its configured Jazz sync server.
+   *
+   * Local reads and writes can continue while disconnected. Call
+   * {@link reconnect} to resume sync using the same Db instance.
+   */
+  async disconnect(): Promise<void> {
+    if (this.isShuttingDown || this.shutdownPromise) {
+      throw new Error("Cannot disconnect a Db that is shutting down.");
+    }
+
+    await this.connection.disconnect();
+  }
+
+  /**
+   * Reconnect this Db to its configured Jazz sync server after
+   * {@link disconnect}.
+   */
+  async reconnect(): Promise<void> {
+    if (this.isShuttingDown || this.shutdownPromise) {
+      throw new Error("Cannot reconnect a Db that is shutting down.");
+    }
+
+    await this.connection.reconnect();
+  }
+
   private wrapWriteWait<THandle extends WriteHandle<unknown>>(handle: THandle): THandle {
     const wait = handle.wait.bind(handle);
     handle.wait = (async (options: { tier: DurabilityTier }) => {
@@ -1682,6 +1708,14 @@ class ClientBackedDb extends Db {
       session: this.session,
       attribution: this.attribution,
     };
+  }
+
+  override async disconnect(): Promise<void> {
+    throw new Error("Db.disconnect() is not supported on scoped Db handles.");
+  }
+
+  override async reconnect(): Promise<void> {
+    throw new Error("Db.reconnect() is not supported on scoped Db handles.");
   }
 
   override async shutdown(): Promise<void> {

--- a/packages/jazz-tools/tests/browser/db.disconnect.test.ts
+++ b/packages/jazz-tools/tests/browser/db.disconnect.test.ts
@@ -1,0 +1,493 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { CompiledPermissions, schema as s } from "../../src/";
+import { createDb, Db, type QueryBuilder } from "../../src/runtime/db.js";
+import { generateAuthSecret } from "../../src/runtime/auth-secret-store.js";
+import {
+  fetchPermissionsHead,
+  publishStoredPermissions,
+  publishStoredSchema,
+} from "../../src/runtime/schema-fetch.js";
+import { TestCleanup, sleep, uniqueDbName, waitForQuery, withTimeout } from "./support.js";
+import { getJazzServerInfo, type JazzServerInfo } from "./testing-server.js";
+
+const schema = {
+  todos: s.table({
+    title: s.string(),
+    done: s.boolean(),
+  }),
+};
+
+type AppSchema = s.Schema<typeof schema>;
+const app: s.App<AppSchema> = s.defineApp(schema);
+const { todos } = app;
+type Todo = s.RowOf<typeof todos>;
+
+const allowAllPermissions = s.definePermissions(app, ({ policy }) => [
+  policy.todos.allowRead.always(),
+  policy.todos.allowInsert.always(),
+  policy.todos.allowUpdate.always(),
+  policy.todos.allowDelete.always(),
+]);
+
+const PENDING_ASSERTION_MS = 750;
+const LOCAL_OPERATION_TIMEOUT_MS = 2_000;
+const SYNC_OPERATION_TIMEOUT_MS = 10_000;
+
+type DbFactory = (
+  ctx: TestCleanup,
+  label: string,
+  secret: string,
+  server: JazzServerInfo,
+) => Promise<Db>;
+
+interface ConnectedPair {
+  readonly db: Db;
+  readonly peer: Db;
+}
+
+describe("Db disconnect/reconnect", () => {
+  const ctx = new TestCleanup();
+
+  afterEach(async () => {
+    await ctx.cleanup();
+  });
+
+  describe("direct server connection", () => {
+    it("syncs writes made while disconnected after reconnect", async () => {
+      const { db, peer } = await createDbPair(ctx, createDirectDb);
+
+      await db.disconnect();
+
+      const offlineTitle = "offline write";
+      db.insert(todos, { title: offlineTitle, done: true });
+
+      const localRead = db.all(todoByTitle(offlineTitle), {
+        tier: "local",
+        localUpdates: "immediate",
+        propagation: "local-only",
+      });
+      await expectStillPending(
+        localRead,
+        PENDING_ASSERTION_MS,
+        "direct server connection: local read while disconnected",
+      );
+
+      const peerRowsBeforeReconnect = await withTimeout(
+        peer.all(todoByTitle(offlineTitle), {
+          tier: "local",
+          localUpdates: "immediate",
+          propagation: "local-only",
+        }),
+        LOCAL_OPERATION_TIMEOUT_MS,
+        "direct server connection: peer local read before reconnect did not resolve",
+      );
+      expect(peerRowsBeforeReconnect).toEqual([]);
+
+      await db.reconnect();
+
+      const localRows = await withTimeout(
+        localRead,
+        SYNC_OPERATION_TIMEOUT_MS,
+        "direct server connection: local read did not resolve after reconnect",
+      );
+      expect(localRows.some((row) => row.title === offlineTitle)).toBe(true);
+
+      await waitForTodos(
+        peer,
+        (rows) => rows.some((row) => row.title === offlineTitle),
+        "direct server connection: peer sees disconnected write after reconnect",
+        SYNC_OPERATION_TIMEOUT_MS,
+        "edge",
+      );
+    }, 60_000);
+
+    it("receives server updates missed while disconnected after reconnect", async () => {
+      const { db, peer } = await createDbPair(ctx, createDirectDb);
+
+      await db.disconnect();
+
+      const serverOnlyTitle = "server only";
+      await withTimeout(
+        peer.insert(todos, { title: serverOnlyTitle, done: true }).wait({ tier: "edge" }),
+        SYNC_OPERATION_TIMEOUT_MS,
+        "direct server connection: peer write did not reach edge while db was disconnected",
+      );
+
+      await expectStillPending(
+        db.all(todoByTitle(serverOnlyTitle), {
+          tier: "local",
+          localUpdates: "immediate",
+          propagation: "local-only",
+        }),
+        PENDING_ASSERTION_MS,
+        "direct server connection: local-only read while disconnected",
+      );
+
+      await db.reconnect();
+
+      await waitForTodos(
+        db,
+        (rows) => rows.some((row) => row.title === serverOnlyTitle),
+        "direct server connection: disconnected client receives server update after reconnect",
+        SYNC_OPERATION_TIMEOUT_MS,
+        "edge",
+      );
+    }, 60_000);
+
+    it("keeps all wait tiers pending while disconnected", async () => {
+      const { db } = await createDbPair(ctx, createDirectDb);
+
+      await db.disconnect();
+
+      const localWait = db
+        .insert(todos, { title: "local wait", done: false })
+        .wait({ tier: "local" });
+      await expectStillPending(
+        localWait,
+        PENDING_ASSERTION_MS,
+        "direct server connection: local wait while disconnected",
+      );
+
+      const edgeWait = db.insert(todos, { title: "edge wait", done: false }).wait({ tier: "edge" });
+      await expectStillPending(
+        edgeWait,
+        PENDING_ASSERTION_MS,
+        "direct server connection: edge wait while disconnected",
+      );
+
+      const globalWait = db
+        .insert(todos, { title: "global wait", done: false })
+        .wait({ tier: "global" });
+      await expectStillPending(
+        globalWait,
+        PENDING_ASSERTION_MS,
+        "direct server connection: global wait while disconnected",
+      );
+
+      await db.reconnect();
+
+      await withTimeout(
+        localWait,
+        SYNC_OPERATION_TIMEOUT_MS,
+        "direct server connection: local wait did not settle after reconnect",
+      );
+      await withTimeout(
+        edgeWait,
+        SYNC_OPERATION_TIMEOUT_MS,
+        "direct server connection: edge wait did not settle after reconnect",
+      );
+      await withTimeout(
+        globalWait,
+        SYNC_OPERATION_TIMEOUT_MS,
+        "direct server connection: global wait did not settle after reconnect",
+      );
+    }, 60_000);
+
+    it("keeps disconnected reads pending until reconnect", async () => {
+      const { db } = await createDbPair(ctx, createDirectDb);
+
+      await db.disconnect();
+
+      const localRead = db.all(app.todos, {
+        tier: "local",
+        localUpdates: "immediate",
+        propagation: "local-only",
+      });
+      await expectStillPending(
+        localRead,
+        PENDING_ASSERTION_MS,
+        "direct server connection: immediate local read while disconnected",
+      );
+
+      const deferredRead = db.all(app.todos, {
+        tier: "edge",
+        localUpdates: "deferred",
+      });
+      await expectStillPending(
+        deferredRead,
+        PENDING_ASSERTION_MS,
+        "direct server connection: deferred read while disconnected",
+      );
+
+      await db.reconnect();
+
+      const localRows = await withTimeout(
+        localRead,
+        SYNC_OPERATION_TIMEOUT_MS,
+        "direct server connection: local read did not resolve after reconnect",
+      );
+      expect(localRows).toEqual([]);
+
+      const deferredRows = await withTimeout(
+        deferredRead,
+        SYNC_OPERATION_TIMEOUT_MS,
+        "direct server connection: deferred read did not resolve after reconnect",
+      );
+      expect(deferredRows).toEqual([]);
+    }, 60_000);
+  });
+
+  describe("worker mode", () => {
+    it("syncs writes made while disconnected after reconnect", async () => {
+      const { db, peer } = await createDbPair(ctx, createWorkerDb);
+
+      await db.disconnect();
+
+      const offlineTitle = "offline write";
+      db.insert(todos, { title: offlineTitle, done: true });
+
+      const localRows = await withTimeout(
+        db.all(todoByTitle(offlineTitle), {
+          tier: "local",
+          localUpdates: "immediate",
+          propagation: "local-only",
+        }),
+        LOCAL_OPERATION_TIMEOUT_MS,
+        "worker mode: local read for disconnected write did not resolve",
+      );
+      expect(localRows.some((row) => row.title === offlineTitle)).toBe(true);
+
+      const peerRowsBeforeReconnect = await withTimeout(
+        peer.all(todoByTitle(offlineTitle), {
+          tier: "local",
+          localUpdates: "immediate",
+          propagation: "local-only",
+        }),
+        LOCAL_OPERATION_TIMEOUT_MS,
+        "worker mode: peer local read before reconnect did not resolve",
+      );
+      expect(peerRowsBeforeReconnect).toEqual([]);
+
+      await db.reconnect();
+
+      await waitForTodos(
+        peer,
+        (rows) => rows.some((row) => row.title === offlineTitle),
+        "worker mode: peer sees disconnected write after reconnect",
+        SYNC_OPERATION_TIMEOUT_MS,
+        "edge",
+      );
+    }, 60_000);
+
+    it("receives server updates missed while disconnected after reconnect", async () => {
+      const { db, peer } = await createDbPair(ctx, createWorkerDb);
+
+      await db.disconnect();
+
+      const serverOnlyTitle = "server only";
+      await withTimeout(
+        peer.insert(todos, { title: serverOnlyTitle, done: true }).wait({ tier: "edge" }),
+        SYNC_OPERATION_TIMEOUT_MS,
+        "worker mode: peer write did not reach edge while db was disconnected",
+      );
+
+      const disconnectedLocalRows = await withTimeout(
+        db.all(todoByTitle(serverOnlyTitle), {
+          tier: "local",
+          localUpdates: "immediate",
+          propagation: "local-only",
+        }),
+        LOCAL_OPERATION_TIMEOUT_MS,
+        "worker mode: local-only read while disconnected did not resolve",
+      );
+      expect(disconnectedLocalRows).toEqual([]);
+
+      await db.reconnect();
+
+      await waitForTodos(
+        db,
+        (rows) => rows.some((row) => row.title === serverOnlyTitle),
+        "worker mode: disconnected client receives server update after reconnect",
+        SYNC_OPERATION_TIMEOUT_MS,
+        "edge",
+      );
+    }, 60_000);
+
+    it("resolves local waits and keeps edge/global waits pending while disconnected", async () => {
+      const { db } = await createDbPair(ctx, createWorkerDb);
+
+      await db.disconnect();
+
+      const localWait = db
+        .insert(todos, { title: "local wait", done: false })
+        .wait({ tier: "local" });
+      await withTimeout(
+        localWait,
+        LOCAL_OPERATION_TIMEOUT_MS,
+        "worker mode: local wait should resolve while disconnected",
+      );
+
+      const edgeWait = db.insert(todos, { title: "edge wait", done: false }).wait({ tier: "edge" });
+      await expectStillPending(
+        edgeWait,
+        PENDING_ASSERTION_MS,
+        "worker mode: edge wait while disconnected",
+      );
+
+      const globalWait = db
+        .insert(todos, { title: "global wait", done: false })
+        .wait({ tier: "global" });
+      await expectStillPending(
+        globalWait,
+        PENDING_ASSERTION_MS,
+        "worker mode: global wait while disconnected",
+      );
+
+      await db.reconnect();
+
+      await withTimeout(
+        edgeWait,
+        SYNC_OPERATION_TIMEOUT_MS,
+        "worker mode: edge wait did not settle after reconnect",
+      );
+      await withTimeout(
+        globalWait,
+        SYNC_OPERATION_TIMEOUT_MS,
+        "worker mode: global wait did not settle after reconnect",
+      );
+    }, 60_000);
+
+    it("resolves local reads and defers edge reads while disconnected", async () => {
+      const { db } = await createDbPair(ctx, createWorkerDb);
+
+      await db.disconnect();
+
+      const title = "read mode";
+      db.insert(todos, { title, done: true });
+
+      const localRows = await withTimeout(
+        db.all(todoByTitle(title), {
+          tier: "local",
+          localUpdates: "immediate",
+          propagation: "local-only",
+        }),
+        LOCAL_OPERATION_TIMEOUT_MS,
+        "worker mode: immediate local read while disconnected did not resolve",
+      );
+      expect(localRows.some((row) => row.title === title)).toBe(true);
+
+      const deferredRead = db.all(todoByTitle(title), {
+        tier: "edge",
+        localUpdates: "deferred",
+      });
+      await expectStillPending(
+        deferredRead,
+        PENDING_ASSERTION_MS,
+        "worker mode: deferred read while disconnected",
+      );
+
+      await db.reconnect();
+
+      await withTimeout(
+        deferredRead,
+        SYNC_OPERATION_TIMEOUT_MS,
+        "worker mode: deferred read did not resolve after reconnect",
+      );
+    }, 60_000);
+  });
+});
+
+async function createDirectDb(
+  ctx: TestCleanup,
+  _label: string,
+  secret: string,
+  server: JazzServerInfo,
+): Promise<Db> {
+  return ctx.track(
+    await createDb({
+      appId: server.appId,
+      driver: { type: "memory" },
+      serverUrl: server.serverUrl,
+      secret,
+    }),
+  );
+}
+
+async function createWorkerDb(
+  ctx: TestCleanup,
+  label: string,
+  secret: string,
+  server: JazzServerInfo,
+): Promise<Db> {
+  return ctx.track(
+    await createDb({
+      appId: server.appId,
+      driver: { type: "persistent", dbName: uniqueDbName(label) },
+      serverUrl: server.serverUrl,
+      secret,
+    }),
+  );
+}
+
+async function createDbPair(ctx: TestCleanup, createDbForMode: DbFactory): Promise<ConnectedPair> {
+  const label = uniqueDbName("db-disconnect-pair");
+  const server = await publishSyncServerSchemaAndPermissions(label);
+  const sharedSecret = generateAuthSecret();
+  const db = await createDbForMode(ctx, `${label}-a`, sharedSecret, server);
+  const peer = await createDbForMode(ctx, `${label}-peer`, sharedSecret, server);
+
+  return { db, peer };
+}
+
+function todoByTitle(title: string): QueryBuilder<Todo> {
+  return app.todos.where({ title: { eq: title } });
+}
+
+async function waitForTodos(
+  db: Db,
+  predicate: (rows: Todo[]) => boolean,
+  label: string,
+  timeoutMs = SYNC_OPERATION_TIMEOUT_MS,
+  tier?: "local" | "edge",
+): Promise<Todo[]> {
+  return waitForQuery(db, app.todos, predicate, label, timeoutMs, tier);
+}
+
+async function expectStillPending<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  label: string,
+): Promise<void> {
+  const result = await Promise.race([
+    promise.then(
+      () => ({ state: "fulfilled" as const }),
+      (error) => ({ state: "rejected" as const, error }),
+    ),
+    sleep(timeoutMs).then(() => ({ state: "pending" as const })),
+  ]);
+
+  if (result.state === "pending") return;
+
+  const reason =
+    result.state === "rejected" && result.error instanceof Error ? `: ${result.error.message}` : "";
+  throw new Error(`${label} ${result.state}${reason}`);
+}
+
+async function publishSyncServerSchemaAndPermissions(appId: string): Promise<JazzServerInfo> {
+  const testingServer = await getJazzServerInfo(appId);
+  await publishPermissionsForServer(testingServer, allowAllPermissions);
+  return testingServer;
+}
+
+async function publishPermissionsForServer(
+  testingServer: JazzServerInfo,
+  permissions: CompiledPermissions,
+): Promise<void> {
+  const { appId, serverUrl, adminSecret } = testingServer;
+  const { hash: schemaHash } = await publishStoredSchema(serverUrl, {
+    appId,
+    adminSecret,
+    schema: app.wasmSchema,
+  });
+  const { head } = await fetchPermissionsHead(serverUrl, {
+    appId,
+    adminSecret,
+  });
+  await publishStoredPermissions(serverUrl, {
+    appId,
+    adminSecret,
+    schemaHash,
+    permissions,
+    expectedParentBundleObjectId: head?.bundleObjectId ?? null,
+  });
+}

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -2069,7 +2069,7 @@ describe("Worker Bridge with OPFS", () => {
     // Disconnect the WS transport so the block takes effect immediately.
     // Playwright route blocking only intercepts new connections; the existing
     // WebSocket must be closed explicitly for the offline simulation to hold.
-    getActiveRoleBridge(dbA)?.disconnectUpstream?.();
+    await dbA.disconnect();
     await sleep(250);
 
     const offlineTitle = `offline-worker-row-${Date.now()}`;
@@ -2098,7 +2098,7 @@ describe("Worker Bridge with OPFS", () => {
 
     await unblockJazzServerNetwork(serverUrl);
     // Re-establish the worker's upstream WebSocket now that the network is live again.
-    getActiveRoleBridge(dbA)?.reconnectUpstream?.();
+    await dbA.reconnect();
     await sleep(250);
 
     getBrowserConnection(dbA)?.sendLifecycleHint?.("freeze");


### PR DESCRIPTION
## Description

Adds `db.disconnect()` and `db.reconnect()` utilities to modify a Db's connection state. The primary motivation is to simulate offline state in tests, but decided to add it as an actual Db method instead of a test util as there may be use cases where disabling and enable network access is useful (other libraries like Firebase also [offer this option](https://firebase.google.com/docs/firestore/manage-data/enable-offline)).

Stack: PR 3 of 5. Depends on #1063.