### PR TITLE
refactor(wasm): expose static computeSchemaHash so hashing needs no runtime

### DIFF
--- a/.changeset/static-schema-hash-export.md
+++ b/.changeset/static-schema-hash-export.md
@@ -1,0 +1,6 @@
+---
+"jazz-wasm": patch
+"jazz-tools": patch
+---
+
+Expose `WasmRuntime.computeSchemaHash` as a static WASM export so schema hashes can be computed without constructing a throwaway runtime.

--- a/crates/jazz-wasm/src/runtime.rs
+++ b/crates/jazz-wasm/src/runtime.rs
@@ -2071,6 +2071,15 @@ impl WasmRuntime {
         Ok(user_id.to_string())
     }
 
+    /// Compute the canonical schema hash (64-char hex) for a JSON-encoded
+    /// schema without constructing a runtime.
+    #[wasm_bindgen(js_name = "computeSchemaHash")]
+    pub fn compute_schema_hash_static(schema_json: &str) -> Result<String, JsError> {
+        let runtime_schema = jazz_tools::binding_support::parse_runtime_schema_input(schema_json)
+            .map_err(|e| JsError::new(&format!("Invalid schema JSON: {}", e)))?;
+        Ok(SchemaHash::compute(&runtime_schema.schema).to_string())
+    }
+
     #[wasm_bindgen(js_name = "mintJazzSelfSignedToken")]
     pub fn mint_jazz_self_signed_token_static(
         seed_b64: &str,

--- a/packages/jazz-tools/src/schema-hash.ts
+++ b/packages/jazz-tools/src/schema-hash.ts
@@ -13,20 +13,5 @@ async function loadSchemaHashWasmModule(): Promise<any> {
 
 export async function computeSchemaHash(schema: WasmSchema): Promise<string> {
   const wasmModule = await loadSchemaHashWasmModule();
-  const runtime = new wasmModule.WasmRuntime(
-    JSON.stringify(schema),
-    "jazz-tools-cli",
-    "dev",
-    "main",
-    null,
-    null,
-  );
-
-  try {
-    return runtime.getSchemaHash();
-  } finally {
-    if (typeof runtime.free === "function") {
-      runtime.free();
-    }
-  }
+  return wasmModule.WasmRuntime.computeSchemaHash(JSON.stringify(schema));
 }


### PR DESCRIPTION
Stacked on #1065. Addresses https://github.com/garden-co/jazz/pull/1065#discussion_r3509164501.

`computeSchemaHash` in `jazz-tools` used to construct a full `WasmRuntime` (sync manager, schema manager, in-memory storage, scheduler, plus a `persist_schema()` into the in-memory catalogue) just to call `getSchemaHash()` and free it again.

This adds a static `WasmRuntime.computeSchemaHash(schema_json)` export — same pattern as the existing `deriveUserId` static — that parses the schema and runs `SchemaHash::compute` directly. The JS helper now calls the static instead of building and freeing a throwaway runtime.

Compared to replicating the hashing in JS, this keeps the algorithm in Rust as the single source of truth, so there's no risk of the two implementations drifting. No `Db` instance is needed. The helper remains `async` only because of the WASM module load, which is cached after the first call.

Verified that the static export returns the same hash as the previous runtime-based path for a representative schema (including `indexOnly` overrides), and that `typed-app` and `catalogue` tests pass.