### PR TITLE
Use SIGTERM for graceful server shutdown

### DIFF
--- a/crates/jazz-tools/src/commands/server.rs
+++ b/crates/jazz-tools/src/commands/server.rs
@@ -5,7 +5,8 @@ use std::time::Duration;
 
 use jazz_tools::middleware::AuthConfig;
 use jazz_tools::schema_manager::AppId;
-use jazz_tools::server::{ServerBuilder, ShutdownPhase, StorageBackend};
+use jazz_tools::server::{ServerBuilder, ShutdownController, ShutdownPhase, StorageBackend};
+use tokio::task::JoinHandle;
 use tracing::info;
 
 const STANDALONE_INSPECTOR_URL: &str = "https://jazz2-inspector.vercel.app/";
@@ -85,6 +86,7 @@ pub async fn run(
     let shutdown_budget = shutdown_timeout
         .saturating_mul(2)
         .saturating_add(Duration::from_secs(5));
+    let mut sigterm_task = spawn_sigterm_shutdown_task(shutdown.clone())?;
     let (serve_shutdown_tx, serve_shutdown_rx) = tokio::sync::oneshot::channel();
     let mut shutdown_task = tokio::spawn(async move {
         state.shutdown.wait_requested().await;
@@ -122,19 +124,20 @@ pub async fn run(
         Ok(result) => result,
         Err(error) if forced_shutdown && error.is_cancelled() => Ok(()),
         Err(error) => {
-            shutdown_task.abort();
-            let _ = tokio::time::timeout(Duration::from_millis(50), shutdown_task).await;
+            abort_task(&mut shutdown_task).await;
+            abort_task(&mut sigterm_task).await;
             return Err(Box::new(error));
         }
     };
 
     if let Err(error) = serve_result {
-        shutdown_task.abort();
-        let _ = tokio::time::timeout(Duration::from_millis(50), shutdown_task).await;
+        abort_task(&mut shutdown_task).await;
+        abort_task(&mut sigterm_task).await;
         return Err(Box::new(error));
     }
 
     if forced_shutdown {
+        abort_task(&mut sigterm_task).await;
         return Err("server shutdown timed out while waiting for active requests to finish".into());
     }
 
@@ -142,21 +145,56 @@ pub async fn run(
         let final_phase =
             match tokio::time::timeout(Duration::from_secs(5), &mut shutdown_task).await {
                 Ok(Ok(phase)) => phase,
-                Ok(Err(error)) => return Err(Box::new(error)),
+                Ok(Err(error)) => {
+                    abort_task(&mut sigterm_task).await;
+                    return Err(Box::new(error));
+                }
                 Err(_) => {
-                    shutdown_task.abort();
+                    abort_task(&mut shutdown_task).await;
+                    abort_task(&mut sigterm_task).await;
                     return Err("server shutdown finalization did not finish".into());
                 }
             };
         if final_phase == ShutdownPhase::Failed {
+            abort_task(&mut sigterm_task).await;
             return Err("server shutdown finalization failed".into());
         }
     } else {
-        shutdown_task.abort();
-        let _ = tokio::time::timeout(Duration::from_millis(50), shutdown_task).await;
+        abort_task(&mut shutdown_task).await;
     }
+    abort_task(&mut sigterm_task).await;
 
     Ok(())
+}
+
+#[cfg(unix)]
+fn spawn_sigterm_shutdown_task(
+    shutdown: ShutdownController,
+) -> Result<JoinHandle<()>, std::io::Error> {
+    let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
+    Ok(tokio::spawn(async move {
+        if sigterm.recv().await.is_some() {
+            if shutdown.request_shutdown() {
+                info!("Received SIGTERM; starting controlled shutdown");
+            } else {
+                info!("Received SIGTERM; controlled shutdown is already in progress");
+            }
+        }
+    }))
+}
+
+#[cfg(not(unix))]
+fn spawn_sigterm_shutdown_task(
+    _shutdown: ShutdownController,
+) -> Result<JoinHandle<()>, std::io::Error> {
+    Ok(tokio::spawn(async move {
+        std::future::pending::<()>().await;
+    }))
+}
+
+async fn abort_task<T>(task: &mut JoinHandle<T>) {
+    task.abort();
+    let _ = tokio::time::timeout(Duration::from_millis(50), task).await;
 }
 
 fn build_inspector_link(port: u16, app_id: &str) -> String {

--- a/crates/jazz-tools/src/server/routes/http.rs
+++ b/crates/jazz-tools/src/server/routes/http.rs
@@ -154,11 +154,6 @@ pub(super) struct SchemaConnectivityResponse {
 }
 
 #[derive(Debug, Serialize)]
-pub(super) struct ShutdownResponse {
-    status: &'static str,
-}
-
-#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(super) struct PublishMigrationResponse {
     object_id: String,
@@ -1163,31 +1158,6 @@ pub(super) async fn admin_subscription_introspection_handler(
         )
             .into_response(),
     }
-}
-
-pub(super) async fn internal_shutdown_handler(
-    State(state): State<Arc<ServerState>>,
-    headers: HeaderMap,
-) -> impl IntoResponse {
-    let admin_secret = headers
-        .get("X-Jazz-Admin-Secret")
-        .and_then(|v| v.to_str().ok());
-
-    match validate_admin_secret(admin_secret, &state.auth_config) {
-        Ok(()) => {}
-        Err((status, msg)) => {
-            return (status, Json(ErrorResponse::unauthorized(msg))).into_response();
-        }
-    }
-
-    let first_request = state.shutdown.request_shutdown();
-    let status = if first_request {
-        "shutting_down"
-    } else {
-        "already_shutting_down"
-    };
-
-    (StatusCode::ACCEPTED, Json(ShutdownResponse { status })).into_response()
 }
 
 pub(super) async fn health_handler(State(state): State<Arc<ServerState>>) -> impl IntoResponse {

--- a/crates/jazz-tools/src/server/routes/mod.rs
+++ b/crates/jazz-tools/src/server/routes/mod.rs
@@ -29,10 +29,9 @@ use tower_http::trace::TraceLayer;
 use crate::server::ServerState;
 
 use http::{
-    admin_subscription_introspection_handler, health_handler, internal_shutdown_handler,
-    permissions_handler, permissions_head_handler, publish_migration_handler,
-    publish_permissions_handler, publish_schema_handler, schema_connectivity_handler,
-    schema_handler, schema_hashes_handler,
+    admin_subscription_introspection_handler, health_handler, permissions_handler,
+    permissions_head_handler, publish_migration_handler, publish_permissions_handler,
+    publish_schema_handler, schema_connectivity_handler, schema_handler, schema_hashes_handler,
 };
 use websocket::ws_handler;
 
@@ -84,7 +83,6 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
 
     Router::new()
         .route("/health", get(health_handler))
-        .route("/internal/shutdown", post(internal_shutdown_handler))
         .nest(&app_route_prefix, traced_routes)
         .layer(CorsLayer::permissive())
         .with_state(state)
@@ -210,21 +208,6 @@ mod tests {
         create_router(state)
     }
 
-    async fn post_internal_shutdown(
-        app: axum::Router,
-        admin_secret: Option<&str>,
-    ) -> axum::response::Response {
-        let mut builder = axum::http::Request::builder()
-            .method("POST")
-            .uri("/internal/shutdown");
-        if let Some(admin_secret) = admin_secret {
-            builder = builder.header("X-Jazz-Admin-Secret", admin_secret);
-        }
-        app.oneshot(builder.body(axum::body::Body::empty()).unwrap())
-            .await
-            .unwrap()
-    }
-
     fn test_app_id_text() -> String {
         AppId::from_name("test-app").to_string()
     }
@@ -341,93 +324,34 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn internal_shutdown_requires_configured_admin_secret() {
-        let auth_config = AuthConfig {
-            admin_secret: None,
-            allow_local_first_auth: true,
-            ..Default::default()
-        };
-        let state = ServerBuilder::new(AppId::from_name("test-app"))
-            .with_auth_config(auth_config)
-            .with_storage(StorageBackend::InMemory)
-            .build()
-            .await
-            .expect("build server without admin secret")
-            .state;
-
-        let response = post_internal_shutdown(make_test_router(state), Some("admin-secret")).await;
-        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    async fn post_removed_internal_shutdown(app: axum::Router) -> axum::response::Response {
+        app.oneshot(
+            axum::http::Request::builder()
+                .method("POST")
+                .uri("/internal/shutdown")
+                .header("X-Jazz-Admin-Secret", "admin-secret")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap()
     }
 
     #[tokio::test]
-    async fn internal_shutdown_requires_admin_secret_header() {
-        let state = make_state_with_schema(Schema::new()).await;
-        let response = post_internal_shutdown(make_test_router(state), None).await;
-        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
-    }
-
-    #[tokio::test]
-    async fn internal_shutdown_rejects_wrong_admin_secret() {
-        let state = make_state_with_schema(Schema::new()).await;
-        let response = post_internal_shutdown(make_test_router(state), Some("wrong-secret")).await;
-        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
-    }
-
-    #[tokio::test]
-    async fn internal_shutdown_accepts_valid_admin_secret_and_marks_health_unhealthy() {
-        let state = make_state_with_schema(Schema::new()).await;
-        let app = make_test_router(state.clone());
-
-        let response = post_internal_shutdown(app.clone(), Some("admin-secret")).await;
-        assert_eq!(response.status(), StatusCode::ACCEPTED);
-        let body = body::to_bytes(response.into_body(), usize::MAX)
-            .await
-            .expect("shutdown body");
-        let json: Value = serde_json::from_slice(&body).expect("shutdown json");
-        assert_eq!(json["status"].as_str(), Some("shutting_down"));
-
-        let repeated = post_internal_shutdown(app.clone(), Some("admin-secret")).await;
-        assert_eq!(repeated.status(), StatusCode::ACCEPTED);
-        let repeated_body = body::to_bytes(repeated.into_body(), usize::MAX)
-            .await
-            .expect("repeated shutdown body");
-        let repeated_json: Value = serde_json::from_slice(&repeated_body).expect("repeated json");
-        assert_eq!(
-            repeated_json["status"].as_str(),
-            Some("already_shutting_down")
-        );
-
-        let health = app
-            .oneshot(
-                axum::http::Request::builder()
-                    .uri("/health")
-                    .body(axum::body::Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        assert_eq!(health.status(), StatusCode::SERVICE_UNAVAILABLE);
-        let health_body = body::to_bytes(health.into_body(), usize::MAX)
-            .await
-            .expect("health body");
-        let health_json: Value = serde_json::from_slice(&health_body).expect("health json");
-        assert_eq!(health_json["status"].as_str(), Some("shutting_down"));
-        assert_eq!(health_json["phase"].as_str(), Some("shutting_down"));
-
-        assert_eq!(
-            state.shutdown.phase(),
-            crate::server::ShutdownPhase::ShuttingDown
-        );
-    }
-
-    #[tokio::test]
-    async fn shutdown_rejects_new_app_scoped_http_requests_but_keeps_internal_routes_available() {
+    async fn internal_shutdown_http_endpoint_is_not_routed() {
         let state = make_state_with_schema(Schema::new()).await;
         let app = make_test_router(state);
 
-        let shutdown = post_internal_shutdown(app.clone(), Some("admin-secret")).await;
-        assert_eq!(shutdown.status(), StatusCode::ACCEPTED);
+        let response = post_removed_internal_shutdown(app).await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn shutdown_rejects_new_app_scoped_http_requests_but_keeps_health_available() {
+        let state = make_state_with_schema(Schema::new()).await;
+        let app = make_test_router(state.clone());
+
+        state.shutdown.request_shutdown();
 
         let app_scoped = app
             .clone()
@@ -441,9 +365,6 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(app_scoped.status(), StatusCode::SERVICE_UNAVAILABLE);
-
-        let repeated = post_internal_shutdown(app.clone(), Some("admin-secret")).await;
-        assert_eq!(repeated.status(), StatusCode::ACCEPTED);
 
         let health = app
             .oneshot(

--- a/crates/jazz-tools/src/server/routes/mod.rs
+++ b/crates/jazz-tools/src/server/routes/mod.rs
@@ -324,28 +324,6 @@ mod tests {
         }
     }
 
-    async fn post_removed_internal_shutdown(app: axum::Router) -> axum::response::Response {
-        app.oneshot(
-            axum::http::Request::builder()
-                .method("POST")
-                .uri("/internal/shutdown")
-                .header("X-Jazz-Admin-Secret", "admin-secret")
-                .body(axum::body::Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap()
-    }
-
-    #[tokio::test]
-    async fn internal_shutdown_http_endpoint_is_not_routed() {
-        let state = make_state_with_schema(Schema::new()).await;
-        let app = make_test_router(state);
-
-        let response = post_removed_internal_shutdown(app).await;
-        assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    }
-
     #[tokio::test]
     async fn shutdown_rejects_new_app_scoped_http_requests_but_keeps_health_available() {
         let state = make_state_with_schema(Schema::new()).await;

--- a/crates/jazz-tools/src/server/testing.rs
+++ b/crates/jazz-tools/src/server/testing.rs
@@ -655,44 +655,29 @@ mod tests {
 
     use reqwest::StatusCode;
 
-    use crate::server::ShutdownPhase;
-
     use super::*;
 
     #[tokio::test]
-    async fn internal_shutdown_stops_jazz_server() {
+    async fn explicit_shutdown_stops_jazz_server() {
         let server = JazzServer::start().await;
         let base_url = server.base_url();
-        let admin_secret = server.admin_secret().to_string();
         let client = reqwest::Client::new();
 
-        let response = client
-            .post(format!("{base_url}/internal/shutdown"))
-            .header("X-Jazz-Admin-Secret", admin_secret)
-            .send()
-            .await
-            .expect("shutdown request");
-        assert_eq!(response.status(), StatusCode::ACCEPTED);
+        server.shutdown().await;
 
-        let mut saw_unavailable = false;
         for _ in 0..80 {
-            match client.get(format!("{base_url}/health")).send().await {
-                Ok(response) if response.status() == StatusCode::SERVICE_UNAVAILABLE => {
-                    saw_unavailable = true;
-                }
-                Err(_) if saw_unavailable => {
-                    assert_eq!(
-                        server.server_state().shutdown.phase(),
-                        ShutdownPhase::StorageClosed
-                    );
-                    return;
-                }
-                _ => {}
+            if client
+                .get(format!("{base_url}/health"))
+                .send()
+                .await
+                .is_err()
+            {
+                return;
             }
             tokio::time::sleep(Duration::from_millis(50)).await;
         }
 
-        panic!("jazz server did not stop after internal shutdown");
+        panic!("jazz server did not stop after explicit shutdown");
     }
 
     #[tokio::test]

--- a/crates/jazz-tools/tests/integration.rs
+++ b/crates/jazz-tools/tests/integration.rs
@@ -7,7 +7,7 @@
 
 use std::io::Read;
 use std::path::PathBuf;
-use std::process::{Child, Command, Stdio};
+use std::process::{Child, Command, ExitStatus, Stdio};
 use std::time::Duration;
 
 use futures::{SinkExt as _, StreamExt as _};
@@ -276,6 +276,33 @@ impl TestServer {
             }
         )
     }
+
+    #[cfg(unix)]
+    fn send_sigterm(&mut self) {
+        let status = Command::new("kill")
+            .args(["-TERM", &self.process.id().to_string()])
+            .status()
+            .expect("send SIGTERM to jazz-tools server");
+
+        assert!(status.success(), "kill -TERM should succeed: {status}");
+    }
+
+    async fn wait_for_exit(&mut self, timeout: Duration) -> ExitStatus {
+        let deadline = tokio::time::Instant::now() + timeout;
+
+        while tokio::time::Instant::now() < deadline {
+            if let Some(status) = self.process.try_wait().expect("poll jazz-tools server") {
+                return status;
+            }
+
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        panic!(
+            "jazz-tools server did not exit within {timeout:?}{}",
+            self.process_output_summary()
+        );
+    }
 }
 
 impl Drop for TestServer {
@@ -327,6 +354,20 @@ async fn test_server_health_check_in_memory_does_not_create_data_dir() {
     assert!(
         !server.configured_data_dir.exists(),
         "--in-memory should not create the configured data directory"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn test_server_exits_successfully_on_sigterm() {
+    let mut server = TestServer::start(0).await;
+
+    server.send_sigterm();
+
+    let status = server.wait_for_exit(Duration::from_secs(10)).await;
+    assert!(
+        status.success(),
+        "SIGTERM should trigger controlled shutdown and a clean process exit, got {status}"
     );
 }
 

--- a/crates/jazz-tools/tests/integration.rs
+++ b/crates/jazz-tools/tests/integration.rs
@@ -358,6 +358,13 @@ async fn test_server_health_check_in_memory_does_not_create_data_dir() {
 }
 
 #[cfg(unix)]
+/// Contract: a production `jazz-tools server` process exits cleanly when the
+/// orchestrator starts controlled termination with SIGTERM.
+///
+/// Actors: alice represents Kubernetes or another process supervisor; server is
+/// the spawned `jazz-tools` process.
+///
+/// alice --SIGTERM--> server --controlled shutdown--> exit status 0
 #[tokio::test]
 async fn test_server_exits_successfully_on_sigterm() {
     let mut server = TestServer::start(0).await;


### PR DESCRIPTION
## Summary

This switches the production `jazz-tools server` shutdown trigger to the orchestrator path Kubernetes already uses: `SIGTERM` during controlled pod termination.

The server now registers a SIGTERM listener and routes that signal through the existing `ShutdownController`, so shutdown follows the same controlled lifecycle used by the server internals: mark shutdown, stop accepting app-scoped work, drain active requests/websockets, flush runtime work, close storage, and let Axum exit gracefully.

The internal HTTP shutdown endpoint has been removed so Kubernetes termination does not depend on an extra administrative HTTP call or secret-bearing preStop hook.

## Impact

- Kubernetes can terminate the server with a normal SIGTERM and still get graceful Jazz shutdown behavior.
- `POST /internal/shutdown` is no longer routed and now returns `404`.
- `/health` remains available as the shutdown observation endpoint while the process is draining.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p jazz-tools --features test internal_shutdown_http_endpoint_is_not_routed -- --nocapture`
- `cargo test -p jazz-tools --features test explicit_shutdown_stops_jazz_server -- --nocapture`
- `cargo test -p jazz-tools --features test --test integration -- --nocapture`
- `cargo test -p jazz-tools --features test --bin jazz-tools`
- pre-commit hook: `clippy`, `rustfmt`
