### PR TITLE
perf: add persistent batchId->rows index to speed up batch rows lookup

### DIFF
--- a/crates/jazz-tools/src/runtime_core/sync.rs
+++ b/crates/jazz-tools/src/runtime_core/sync.rs
@@ -102,6 +102,12 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                 .load_local_batch_record(batch_id)
                 .ok()
                 .flatten()
+                .is_some()
+            || self
+                .storage
+                .load_local_batch_row_index(batch_id)
+                .ok()
+                .flatten()
                 .is_some();
         if !has_stored_bookkeeping {
             return;
@@ -111,6 +117,9 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         }
         if let Err(error) = self.storage.delete_local_batch_record(batch_id) {
             tracing::warn!(?batch_id, %error, "failed to retire local batch record");
+        }
+        if let Err(error) = self.storage.delete_local_batch_row_index(batch_id) {
+            tracing::warn!(?batch_id, %error, "failed to retire local batch row index");
         }
         self.mark_storage_write_pending_flush();
     }

--- a/crates/jazz-tools/src/runtime_core/sync.rs
+++ b/crates/jazz-tools/src/runtime_core/sync.rs
@@ -83,13 +83,18 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
     /// Retire a batch's pending bookkeeping once its fate reaches the
     /// settlement target. The terminal fate row stays behind as the tombstone;
     /// row history is untouched.
-    pub(crate) fn retire_settled_batch(&mut self, batch_id: crate::row_histories::BatchId) {
+    pub(crate) fn retire_settled_batch(
+        &mut self,
+        batch_id: crate::row_histories::BatchId,
+        confirmed_tier: DurabilityTier,
+    ) {
         // Servers broadcast fates to every interested client and may
         // re-deliver them, so most settled fates arriving here describe
         // batches this node never tracked. Probe before deleting to avoid
         // dirtying storage (and forcing a flush) when there is nothing to
         // retire.
         let had_cached_record = self.local_batch_record_cache.remove(&batch_id).is_some();
+        let should_delete_row_index = confirmed_tier >= DurabilityTier::GlobalServer;
         let has_stored_bookkeeping = had_cached_record
             || self
                 .storage
@@ -102,13 +107,15 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                 .load_local_batch_record(batch_id)
                 .ok()
                 .flatten()
-                .is_some()
-            || self
+                .is_some();
+        let has_local_batch_row_index = should_delete_row_index
+            && self
                 .storage
                 .load_local_batch_row_index(batch_id)
                 .ok()
                 .flatten()
                 .is_some();
+        let has_stored_bookkeeping = has_stored_bookkeeping || has_local_batch_row_index;
         if !has_stored_bookkeeping {
             return;
         }
@@ -118,7 +125,9 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         if let Err(error) = self.storage.delete_local_batch_record(batch_id) {
             tracing::warn!(?batch_id, %error, "failed to retire local batch record");
         }
-        if let Err(error) = self.storage.delete_local_batch_row_index(batch_id) {
+        if should_delete_row_index
+            && let Err(error) = self.storage.delete_local_batch_row_index(batch_id)
+        {
             tracing::warn!(?batch_id, %error, "failed to retire local batch row index");
         }
         self.mark_storage_write_pending_flush();

--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/direct.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/direct.rs
@@ -301,7 +301,21 @@ fn rc_rolled_back_batch_rejects_later_operations() {
     )
     .unwrap();
 
+    // Internal storage bookkeeping: rolled-back batches should not retain the
+    // batch_id -> rows index after the batch is no longer replayable.
+    assert!(
+        core.storage()
+            .load_local_batch_row_index(batch_id)
+            .unwrap()
+            .is_some()
+    );
+
     core.rollback_batch(batch_id).unwrap();
+
+    assert_eq!(
+        core.storage().load_local_batch_row_index(batch_id).unwrap(),
+        None
+    );
 
     let expected_error =
         format!("Write error: batch {batch_id} has already been completed or was never opened");
@@ -805,6 +819,13 @@ fn rc_client_retires_batch_bookkeeping_when_fate_reaches_settlement_target() {
             .is_some(),
         "submission pends while below the target"
     );
+    assert!(
+        s.a.storage()
+            .load_local_batch_row_index(batch_id)
+            .unwrap()
+            .is_some(),
+        "internal batch row index should exist while the batch can be replayed"
+    );
 
     s.a.push_sync_inbox(InboxEntry {
         source: Source::Server(s.b_server_for_a),
@@ -830,6 +851,13 @@ fn rc_client_retires_batch_bookkeeping_when_fate_reaches_settlement_target() {
             .unwrap()
             .is_none(),
         "global fate retires the local batch record"
+    );
+    assert!(
+        s.a.storage()
+            .load_local_batch_row_index(batch_id)
+            .unwrap()
+            .is_none(),
+        "global fate retires the internal batch row index"
     );
     assert!(
         s.a.storage()

--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/rejection_recovery.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/rejection_recovery.rs
@@ -914,6 +914,14 @@ fn rc_acknowledge_rejected_batch_prunes_local_batch_record() {
         ),
         "rejected batch fate should be persisted before acknowledgement"
     );
+    assert!(
+        alice
+            .storage()
+            .load_local_batch_row_index(batch_id)
+            .unwrap()
+            .is_some(),
+        "internal batch row index should exist until the rejected batch is acknowledged"
+    );
 
     assert!(
         alice.acknowledge_rejected_batch(batch_id).unwrap(),
@@ -921,6 +929,13 @@ fn rc_acknowledge_rejected_batch_prunes_local_batch_record() {
     );
     assert_eq!(
         alice.storage().load_local_batch_record(batch_id).unwrap(),
+        None
+    );
+    assert_eq!(
+        alice
+            .storage()
+            .load_local_batch_row_index(batch_id)
+            .unwrap(),
         None
     );
     assert!(

--- a/crates/jazz-tools/src/runtime_core/ticks.rs
+++ b/crates/jazz-tools/src/runtime_core/ticks.rs
@@ -1,172 +1,116 @@
 use super::*;
 use crate::batch_fate::{LocalBatchMember, SealedBatchMember, SealedBatchSubmission};
-use crate::row_histories::{RowState, patch_row_batch_state};
+use crate::row_histories::{BatchId, RowState, StoredRowBatch, patch_row_batch_state};
 use crate::storage::metadata_from_row_locator;
 use crate::sync_manager::{RowMetadata, SyncPayload};
 
-impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
-    fn local_batch_row_was_insert(
-        &self,
-        table: &str,
-        row: &crate::row_histories::StoredRowBatch,
-    ) -> bool {
-        if !row.parents.is_empty() {
-            return false;
-        }
+type LocalBatchRow = (LocalBatchMember, crate::storage::RowLocator, StoredRowBatch);
 
-        let Ok(history_rows) = self.storage.scan_history_row_batches(table, row.row_id) else {
-            return true;
-        };
-        !history_rows.iter().any(|candidate| {
-            candidate.branch == row.branch
-                && candidate.batch_id != row.batch_id
-                && !matches!(candidate.state, RowState::Rejected)
-        })
+impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
+    fn local_batch_row_from_member(
+        &self,
+        batch_id: BatchId,
+        member: &LocalBatchMember,
+    ) -> Option<(crate::storage::RowLocator, StoredRowBatch)> {
+        let row_locator = self
+            .storage
+            .load_row_locator(member.object_id)
+            .ok()
+            .flatten()
+            .unwrap_or_else(|| crate::storage::RowLocator {
+                table: member.table_name.clone().into(),
+                origin_schema_hash: None,
+            });
+        let row = self
+            .storage
+            .load_history_row_batch_for_schema_hash(
+                member.table_name.as_str(),
+                member.schema_hash,
+                member.branch_name.as_str(),
+                member.object_id,
+                batch_id,
+            )
+            .ok()
+            .flatten()?;
+        (row.content_digest() == member.row_digest).then_some((row_locator, row))
     }
 
-    pub(crate) fn local_batch_rows(
-        &self,
-        batch_id: crate::row_histories::BatchId,
-    ) -> Vec<(
-        LocalBatchMember,
-        crate::storage::RowLocator,
-        crate::row_histories::StoredRowBatch,
-    )> {
-        let mut rows = Vec::new();
-        if let Ok(Some(submission)) = self.storage.load_sealed_batch_submission(batch_id) {
-            for sealed_member in submission.members {
-                let Ok(Some(row_locator)) = self.storage.load_row_locator(sealed_member.object_id)
-                else {
-                    continue;
-                };
-                let Some(row) = self
+    fn sealed_submission_batch_members(&self, batch_id: BatchId) -> Vec<LocalBatchMember> {
+        let Some(submission) = self
+            .storage
+            .load_sealed_batch_submission(batch_id)
+            .ok()
+            .flatten()
+        else {
+            return Vec::new();
+        };
+
+        submission
+            .members
+            .into_iter()
+            .filter_map(|sealed_member| {
+                let row_locator = self
                     .storage
-                    .scan_history_row_batches(row_locator.table.as_str(), sealed_member.object_id)
+                    .load_row_locator(sealed_member.object_id)
                     .ok()
-                    .and_then(|rows| {
-                        rows.into_iter().find(|row| {
-                            row.batch_id == batch_id
-                                && row.branch.as_str() == submission.target_branch_name.as_str()
-                                && row.content_digest() == sealed_member.row_digest
-                        })
-                    })
-                else {
-                    continue;
-                };
-                let Ok(schema_hash) = self.local_batch_member_schema_hash(
-                    submission.target_branch_name,
-                    sealed_member.object_id,
-                    batch_id,
-                ) else {
-                    continue;
-                };
-                let member = LocalBatchMember {
+                    .flatten()?;
+                let schema_hash = self
+                    .local_batch_member_schema_hash(
+                        submission.target_branch_name,
+                        sealed_member.object_id,
+                        batch_id,
+                    )
+                    .ok()?;
+                Some(LocalBatchMember {
                     object_id: sealed_member.object_id,
                     table_name: row_locator.table.to_string(),
                     branch_name: submission.target_branch_name,
                     schema_hash,
                     row_digest: sealed_member.row_digest,
-                };
-                rows.push((member, row_locator, row));
-            }
-        }
+                })
+            })
+            .collect()
+    }
 
-        if rows.is_empty()
-            && let Some(record) = self.local_batch_record_cache.get(&batch_id)
-        {
-            for member in record.members.clone() {
-                let row_locator = self
-                    .storage
-                    .load_row_locator(member.object_id)
-                    .ok()
-                    .flatten()
-                    .unwrap_or_else(|| crate::storage::RowLocator {
-                        table: member.table_name.clone().into(),
-                        origin_schema_hash: None,
-                    });
-                let Ok(Some(row)) = self.storage.load_history_row_batch_for_schema_hash(
-                    member.table_name.as_str(),
-                    member.schema_hash,
-                    member.branch_name.as_str(),
-                    member.object_id,
-                    batch_id,
-                ) else {
-                    let Some(row) = self
-                        .storage
-                        .scan_history_row_batches(member.table_name.as_str(), member.object_id)
-                        .ok()
-                        .and_then(|rows| {
-                            rows.into_iter().find(|row| {
-                                row.batch_id == batch_id
-                                    && row.branch.as_str() == member.branch_name.as_str()
-                            })
-                        })
-                    else {
-                        continue;
-                    };
-                    rows.push((member, row_locator, row));
-                    continue;
-                };
-                rows.push((member, row_locator, row));
-            }
-        }
-        if rows.is_empty()
-            && let Ok(Some(record)) = self.storage.load_local_batch_record(batch_id)
-        {
-            for member in record.members {
-                let row_locator = self
-                    .storage
-                    .load_row_locator(member.object_id)
-                    .ok()
-                    .flatten()
-                    .unwrap_or_else(|| crate::storage::RowLocator {
-                        table: member.table_name.clone().into(),
-                        origin_schema_hash: None,
-                    });
-                let Ok(Some(row)) = self.storage.load_history_row_batch_for_schema_hash(
-                    member.table_name.as_str(),
-                    member.schema_hash,
-                    member.branch_name.as_str(),
-                    member.object_id,
-                    batch_id,
-                ) else {
-                    continue;
-                };
-                rows.push((member, row_locator, row));
-            }
-        }
-        if rows.is_empty()
-            && let Ok(row_locators) = self.storage.scan_row_locators()
-        {
-            for (object_id, row_locator) in row_locators {
-                let Ok(history_rows) = self
-                    .storage
-                    .scan_history_row_batches(row_locator.table.as_str(), object_id)
-                else {
-                    continue;
-                };
-                for row in history_rows
-                    .into_iter()
-                    .filter(|row| row.batch_id == batch_id)
-                {
-                    let branch_name = BranchName::new(row.branch.as_str());
-                    let Ok(schema_hash) =
-                        self.local_batch_member_schema_hash(branch_name, object_id, batch_id)
-                    else {
-                        continue;
-                    };
-                    let member = LocalBatchMember {
-                        object_id,
-                        table_name: row_locator.table.to_string(),
-                        branch_name,
-                        schema_hash,
-                        row_digest: row.content_digest(),
-                    };
-                    rows.push((member, row_locator.clone(), row));
-                }
-            }
-        }
+    fn cached_local_batch_members(&self, batch_id: BatchId) -> Vec<LocalBatchMember> {
+        self.local_batch_record_cache
+            .get(&batch_id)
+            .map(|record| record.members.clone())
+            .unwrap_or_default()
+    }
 
+    fn persisted_local_batch_members(&self, batch_id: BatchId) -> Vec<LocalBatchMember> {
+        self.storage
+            .load_local_batch_record(batch_id)
+            .ok()
+            .flatten()
+            .map(|record| record.members)
+            .unwrap_or_default()
+    }
+
+    fn indexed_local_batch_members(&self, batch_id: BatchId) -> Vec<LocalBatchMember> {
+        self.storage
+            .load_local_batch_row_index(batch_id)
+            .ok()
+            .flatten()
+            .unwrap_or_default()
+    }
+
+    fn local_batch_rows_from_members(
+        &self,
+        batch_id: BatchId,
+        members: Vec<LocalBatchMember>,
+    ) -> Vec<LocalBatchRow> {
+        members
+            .into_iter()
+            .filter_map(|member| {
+                self.local_batch_row_from_member(batch_id, &member)
+                    .map(|(row_locator, row)| (member, row_locator, row))
+            })
+            .collect()
+    }
+
+    fn sort_local_batch_rows(rows: &mut [LocalBatchRow]) {
         rows.sort_by(
             |(left_member, left_locator, left_row), (right_member, right_locator, right_row)| {
                 left_member
@@ -190,6 +134,44 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                     .then_with(|| left_row.batch_id.0.cmp(&right_row.batch_id.0))
             },
         );
+    }
+
+    fn local_batch_row_was_insert(
+        &self,
+        table: &str,
+        row: &crate::row_histories::StoredRowBatch,
+    ) -> bool {
+        if !row.parents.is_empty() {
+            return false;
+        }
+
+        let Ok(history_rows) = self.storage.scan_history_row_batches(table, row.row_id) else {
+            return true;
+        };
+        !history_rows.iter().any(|candidate| {
+            candidate.branch == row.branch
+                && candidate.batch_id != row.batch_id
+                && !matches!(candidate.state, RowState::Rejected)
+        })
+    }
+
+    pub(crate) fn local_batch_rows(&self, batch_id: BatchId) -> Vec<LocalBatchRow> {
+        let member_sources: [fn(&Self, BatchId) -> Vec<LocalBatchMember>; 4] = [
+            Self::sealed_submission_batch_members,
+            Self::cached_local_batch_members,
+            Self::persisted_local_batch_members,
+            Self::indexed_local_batch_members,
+        ];
+
+        let mut rows = Vec::new();
+        for load_members in member_sources {
+            rows = self.local_batch_rows_from_members(batch_id, load_members(self, batch_id));
+            if !rows.is_empty() {
+                break;
+            }
+        }
+
+        Self::sort_local_batch_rows(&mut rows);
         rows
     }
 

--- a/crates/jazz-tools/src/runtime_core/ticks.rs
+++ b/crates/jazz-tools/src/runtime_core/ticks.rs
@@ -110,6 +110,42 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             .collect()
     }
 
+    fn scan_local_batch_rows(&self, batch_id: BatchId) -> Vec<LocalBatchRow> {
+        let Ok(row_locators) = self.storage.scan_row_locators() else {
+            return Vec::new();
+        };
+
+        let mut rows = Vec::new();
+        for (object_id, row_locator) in row_locators {
+            let Ok(history_rows) = self
+                .storage
+                .scan_history_row_batches(row_locator.table.as_str(), object_id)
+            else {
+                continue;
+            };
+            for row in history_rows
+                .into_iter()
+                .filter(|row| row.batch_id == batch_id)
+            {
+                let branch_name = BranchName::new(row.branch.as_str());
+                let Ok(schema_hash) =
+                    self.local_batch_member_schema_hash(branch_name, object_id, batch_id)
+                else {
+                    continue;
+                };
+                let member = LocalBatchMember {
+                    object_id,
+                    table_name: row_locator.table.to_string(),
+                    branch_name,
+                    schema_hash,
+                    row_digest: row.content_digest(),
+                };
+                rows.push((member, row_locator.clone(), row));
+            }
+        }
+        rows
+    }
+
     fn sort_local_batch_rows(rows: &mut [LocalBatchRow]) {
         rows.sort_by(
             |(left_member, left_locator, left_row), (right_member, right_locator, right_row)| {
@@ -169,6 +205,11 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             if !rows.is_empty() {
                 break;
             }
+        }
+        if rows.is_empty() {
+            // Last-resort fallback if the batchId->rows index is not found.
+            // This is extremely inefficient, as we're scanning across all tables' rows.
+            rows = self.scan_local_batch_rows(batch_id);
         }
 
         Self::sort_local_batch_rows(&mut rows);
@@ -275,7 +316,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             // its record for the mutation-error replay path and `Missing`
             // pends retransmission, and neither carries a confirmed tier.
             if acked_tier >= self.settlement_target() {
-                self.retire_settled_batch(batch_id);
+                self.retire_settled_batch(batch_id, acked_tier);
             }
         }
     }

--- a/crates/jazz-tools/src/runtime_core/writes.rs
+++ b/crates/jazz-tools/src/runtime_core/writes.rs
@@ -980,17 +980,33 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             .map_err(|err| RuntimeError::WriteError(format!("load rejected batch ack: {err}")))?
         {
             self.acknowledged_rejected_batches.insert(batch_id);
-            if self
+            let has_local_batch_record = self
                 .storage
                 .load_local_batch_record(batch_id)
                 .map_err(|err| RuntimeError::WriteError(format!("load local batch record: {err}")))?
-                .is_some()
-            {
+                .is_some();
+            let has_local_batch_row_index = self
+                .storage
+                .load_local_batch_row_index(batch_id)
+                .map_err(|err| {
+                    RuntimeError::WriteError(format!("load local batch row index: {err}"))
+                })?
+                .is_some();
+            if has_local_batch_record {
                 self.storage
                     .delete_local_batch_record(batch_id)
                     .map_err(|err| {
                         RuntimeError::WriteError(format!("delete local batch record: {err}"))
                     })?;
+            }
+            if has_local_batch_row_index {
+                self.storage
+                    .delete_local_batch_row_index(batch_id)
+                    .map_err(|err| {
+                        RuntimeError::WriteError(format!("delete local batch row index: {err}"))
+                    })?;
+            }
+            if has_local_batch_record || has_local_batch_row_index {
                 self.mark_storage_write_pending_flush();
             }
             return Ok(false);
@@ -1013,6 +1029,11 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         self.storage
             .delete_local_batch_record(batch_id)
             .map_err(|err| RuntimeError::WriteError(format!("delete local batch record: {err}")))?;
+        self.storage
+            .delete_local_batch_row_index(batch_id)
+            .map_err(|err| {
+                RuntimeError::WriteError(format!("delete local batch row index: {err}"))
+            })?;
         self.acknowledged_rejected_batches.insert(batch_id);
         self.mark_storage_write_pending_flush();
         Ok(true)
@@ -1040,6 +1061,11 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         self.storage
             .delete_local_batch_record(batch_id)
             .map_err(|err| RuntimeError::WriteError(format!("delete local batch record: {err}")))?;
+        self.storage
+            .delete_local_batch_row_index(batch_id)
+            .map_err(|err| {
+                RuntimeError::WriteError(format!("delete local batch row index: {err}"))
+            })?;
         self.durability.forget_batch(batch_id);
         self.finish_batch(batch_id);
         self.mark_storage_write_pending_flush();
@@ -1072,6 +1098,11 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                 .delete_local_batch_record(batch_id)
                 .map_err(|err| {
                     RuntimeError::WriteError(format!("delete empty local batch record: {err}"))
+                })?;
+            self.storage
+                .delete_local_batch_row_index(batch_id)
+                .map_err(|err| {
+                    RuntimeError::WriteError(format!("delete empty local batch row index: {err}"))
                 })?;
             self.mark_storage_write_pending_flush();
             self.finish_batch(batch_id);

--- a/crates/jazz-tools/src/storage/memory.rs
+++ b/crates/jazz-tools/src/storage/memory.rs
@@ -183,7 +183,6 @@ impl Storage for MemoryStorage {
                 encoded_visible_rows.len()
             )));
         }
-
         let table = table.to_string();
 
         for (row, encoded) in history_rows.iter().zip(encoded_history_rows) {
@@ -251,6 +250,7 @@ impl Storage for MemoryStorage {
         if !index_mutations.is_empty() {
             self.apply_index_mutations(index_mutations)?;
         }
+        self.index_local_batch_history_rows(&table, history_rows, encoded_history_rows)?;
         Ok(())
     }
 
@@ -262,6 +262,7 @@ impl Storage for MemoryStorage {
         index_mutations: &[IndexMutation<'_>],
     ) -> Result<(), StorageError> {
         let table = table.to_string();
+        let mut decoded_history_rows = Vec::with_capacity(history_rows.len());
 
         for row in history_rows {
             self.ensure_cached_row_raw_table_header(
@@ -292,6 +293,7 @@ impl Storage for MemoryStorage {
                 row.batch_id,
                 &row.bytes,
             )?;
+            decoded_history_rows.push(decoded.clone());
             self.row_histories
                 .entry(table.clone())
                 .or_default()
@@ -306,7 +308,6 @@ impl Storage for MemoryStorage {
                 .or_default()
                 .insert((row.branch.clone().into(), row.batch_id), row.bytes.clone());
         }
-
         for row in visible_rows {
             self.ensure_cached_row_raw_table_header(
                 row.row_raw_table.as_str(),
@@ -346,6 +347,7 @@ impl Storage for MemoryStorage {
         if !index_mutations.is_empty() {
             self.apply_index_mutations(index_mutations)?;
         }
+        self.index_local_batch_history_rows(&table, &decoded_history_rows, history_rows)?;
         Ok(())
     }
 
@@ -617,12 +619,13 @@ impl Storage for MemoryStorage {
             }
         }
         let raw_regions = self.row_history_bytes.entry(table.to_string()).or_default();
-        for row in encoded_rows {
+        for row in &encoded_rows {
             raw_regions
                 .entry(row.row_id)
                 .or_default()
-                .insert((row.branch.clone().into(), row.batch_id), row.bytes);
+                .insert((row.branch.clone().into(), row.batch_id), row.bytes.clone());
         }
+        self.index_local_batch_history_rows(table, rows, &encoded_rows)?;
         Ok(())
     }
 

--- a/crates/jazz-tools/src/storage/mod.rs
+++ b/crates/jazz-tools/src/storage/mod.rs
@@ -36,7 +36,7 @@ use serde::{Deserialize, Serialize};
 use smolset::SmolSet;
 
 use crate::batch_fate::{
-    BatchFate, CapturedFrontierMember, LocalBatchRecord, SealedBatchSubmission,
+    BatchFate, CapturedFrontierMember, LocalBatchMember, LocalBatchRecord, SealedBatchSubmission,
 };
 use crate::catalogue::CatalogueEntry;
 use crate::digest::Digest32;
@@ -155,6 +155,7 @@ const ROW_LOCATOR_TABLE: &str = "__row_locator";
 const VISIBLE_ROW_TABLE_LOCATOR_TABLE: &str = "__visible_row_table_locator";
 const HISTORY_ROW_BATCH_TABLE_LOCATOR_TABLE: &str = "__history_row_batch_table_locator";
 const LOCAL_BATCH_RECORD_TABLE: &str = "__local_batch_record";
+const LOCAL_BATCH_ROW_INDEX_TABLE: &str = "__local_batch_row_index";
 const AUTHORITATIVE_BATCH_SETTLEMENT_TABLE: &str = "__authoritative_batch_settlement";
 const ACKNOWLEDGED_REJECTED_BATCH_TABLE: &str = "__acknowledged_rejected_batch";
 const SEALED_BATCH_SUBMISSION_TABLE: &str = "__sealed_batch_submission";
@@ -177,6 +178,7 @@ const SEALED_BATCH_SUBMISSION_FORMAT_V2: i32 = 2;
 const AUTHORITATIVE_BATCH_SETTLEMENT_FORMAT_V2: i32 = 2;
 const ACKNOWLEDGED_REJECTED_BATCH_FORMAT_V1: i32 = 1;
 const LOCAL_BATCH_RECORD_FORMAT_V3: i32 = 3;
+const LOCAL_BATCH_ROW_INDEX_FORMAT_V1: i32 = 1;
 
 pub type BranchOrd = i32;
 
@@ -187,6 +189,7 @@ const STORAGE_KIND_BRANCH_ORD_BY_NAME: &str = "branch_ord_by_name";
 const STORAGE_KIND_BRANCH_NAME_BY_ORD: &str = "branch_name_by_ord";
 const STORAGE_KIND_BRANCH_ORD_META: &str = "branch_ord_meta";
 const STORAGE_KIND_LOCAL_BATCH_RECORD: &str = "local_batch_record";
+const STORAGE_KIND_LOCAL_BATCH_ROW_INDEX: &str = "local_batch_row_index";
 const STORAGE_KIND_AUTHORITATIVE_BATCH_SETTLEMENT: &str = "authoritative_batch_settlement";
 const STORAGE_KIND_ACKNOWLEDGED_REJECTED_BATCH: &str = "acknowledged_rejected_batch";
 const STORAGE_KIND_SEALED_BATCH_SUBMISSION: &str = "sealed_batch_submission";
@@ -1073,6 +1076,7 @@ fn supported_storage_format_version(storage_kind: &str) -> Result<i32, StorageEr
         STORAGE_KIND_BRANCH_NAME_BY_ORD => Ok(BRANCH_NAME_BY_ORD_FORMAT_V1),
         STORAGE_KIND_BRANCH_ORD_META => Ok(BRANCH_ORD_META_FORMAT_V1),
         STORAGE_KIND_LOCAL_BATCH_RECORD => Ok(LOCAL_BATCH_RECORD_FORMAT_V3),
+        STORAGE_KIND_LOCAL_BATCH_ROW_INDEX => Ok(LOCAL_BATCH_ROW_INDEX_FORMAT_V1),
         STORAGE_KIND_SEALED_BATCH_SUBMISSION => Ok(SEALED_BATCH_SUBMISSION_FORMAT_V2),
         STORAGE_KIND_AUTHORITATIVE_BATCH_SETTLEMENT => Ok(AUTHORITATIVE_BATCH_SETTLEMENT_FORMAT_V2),
         STORAGE_KIND_ACKNOWLEDGED_REJECTED_BATCH => Ok(ACKNOWLEDGED_REJECTED_BATCH_FORMAT_V1),
@@ -1668,6 +1672,26 @@ fn local_batch_record_storage_descriptor_with_branch_ords() -> RowDescriptor {
                         ColumnDescriptor::new("object_id", ColumnType::Bytea),
                         ColumnDescriptor::new("table_name", ColumnType::Text),
                         ColumnDescriptor::new("branch_ord", ColumnType::Integer),
+                        ColumnDescriptor::new("schema_hash", ColumnType::Bytea),
+                        ColumnDescriptor::new("row_digest", ColumnType::Bytea),
+                    ])),
+                }),
+            },
+        ),
+    ])
+}
+
+fn local_batch_row_index_storage_descriptor() -> RowDescriptor {
+    RowDescriptor::new(vec![
+        ColumnDescriptor::new("batch_id", ColumnType::BatchId),
+        ColumnDescriptor::new(
+            "members",
+            ColumnType::Array {
+                element: Box::new(ColumnType::Row {
+                    columns: Box::new(RowDescriptor::new(vec![
+                        ColumnDescriptor::new("object_id", ColumnType::Bytea),
+                        ColumnDescriptor::new("table_name", ColumnType::Text),
+                        ColumnDescriptor::new("branch_name", ColumnType::Text),
                         ColumnDescriptor::new("schema_hash", ColumnType::Bytea),
                         ColumnDescriptor::new("row_digest", ColumnType::Bytea),
                     ])),
@@ -2714,6 +2738,199 @@ fn encode_local_batch_record_with_branch_ords<H: Storage + ?Sized>(
         ],
     )
     .map_err(|err| StorageError::IoError(format!("encode local batch record: {err}")))
+}
+
+fn compare_local_batch_member_identity(
+    left: &LocalBatchMember,
+    right: &LocalBatchMember,
+) -> std::cmp::Ordering {
+    left.object_id
+        .uuid()
+        .as_bytes()
+        .cmp(right.object_id.uuid().as_bytes())
+        .then_with(|| left.table_name.cmp(&right.table_name))
+        .then_with(|| left.branch_name.as_str().cmp(right.branch_name.as_str()))
+}
+
+fn compare_local_batch_member_version(
+    left: &LocalBatchMember,
+    right: &LocalBatchMember,
+) -> std::cmp::Ordering {
+    left.schema_hash
+        .as_bytes()
+        .cmp(right.schema_hash.as_bytes())
+        .then_with(|| left.row_digest.0.cmp(&right.row_digest.0))
+}
+
+pub(crate) fn upsert_local_batch_member(
+    members: &mut Vec<LocalBatchMember>,
+    member: LocalBatchMember,
+) {
+    match members.binary_search_by(|existing| {
+        compare_local_batch_member_identity(existing, &member)
+            .then_with(|| compare_local_batch_member_version(existing, &member))
+    }) {
+        Ok(index) => {
+            members[index] = member;
+        }
+        Err(index) => {
+            if index > 0
+                && compare_local_batch_member_identity(&members[index - 1], &member)
+                    == std::cmp::Ordering::Equal
+            {
+                members[index - 1] = member;
+            } else if index < members.len()
+                && compare_local_batch_member_identity(&members[index], &member)
+                    == std::cmp::Ordering::Equal
+            {
+                members[index] = member;
+            } else {
+                members.insert(index, member);
+            }
+        }
+    }
+}
+
+fn encode_local_batch_members(members: &[LocalBatchMember]) -> Value {
+    Value::Array(
+        members
+            .iter()
+            .map(|member| Value::Row {
+                id: None,
+                values: vec![
+                    Value::Bytea(member.object_id.uuid().as_bytes().to_vec()),
+                    Value::Text(member.table_name.clone()),
+                    Value::Text(member.branch_name.to_string()),
+                    Value::Bytea(member.schema_hash.as_bytes().to_vec()),
+                    Value::Bytea(member.row_digest.0.to_vec()),
+                ],
+            })
+            .collect(),
+    )
+}
+
+fn encode_local_batch_row_index(
+    batch_id: BatchId,
+    members: &[LocalBatchMember],
+) -> Result<Vec<u8>, StorageError> {
+    encode_row(
+        &local_batch_row_index_storage_descriptor(),
+        &[
+            Value::BatchId(*batch_id.as_bytes()),
+            encode_local_batch_members(members),
+        ],
+    )
+    .map_err(|err| StorageError::IoError(format!("encode local batch row index: {err}")))
+}
+
+fn decode_local_batch_members(members: &Value) -> Result<Vec<LocalBatchMember>, StorageError> {
+    match members {
+        Value::Array(values) => values
+            .iter()
+            .map(|value| match value {
+                Value::Row { values, .. } => {
+                    let [object_id, table_name, branch_name, schema_hash, row_digest] =
+                        values.as_slice()
+                    else {
+                        return Err(StorageError::IoError(
+                            "expected local batch member row to have five values".to_string(),
+                        ));
+                    };
+                    let object_id = match object_id {
+                        Value::Bytea(bytes) => {
+                            let uuid = uuid::Uuid::from_slice(bytes).map_err(|err| {
+                                StorageError::IoError(format!(
+                                    "decode local batch member object id: expected uuid bytes: {err}"
+                                ))
+                            })?;
+                            ObjectId::from_uuid(uuid)
+                        }
+                        other => {
+                            return Err(StorageError::IoError(format!(
+                                "expected local batch member object id bytes, got {other:?}"
+                            )));
+                        }
+                    };
+                    let table_name = match table_name {
+                        Value::Text(raw) => raw.clone(),
+                        other => {
+                            return Err(StorageError::IoError(format!(
+                                "expected local batch member table name text, got {other:?}"
+                            )));
+                        }
+                    };
+                    let branch_name = match branch_name {
+                        Value::Text(raw) => BranchName::new(raw),
+                        other => {
+                            return Err(StorageError::IoError(format!(
+                                "expected local batch member branch name text, got {other:?}"
+                            )));
+                        }
+                    };
+                    let schema_hash = match schema_hash {
+                        Value::Bytea(bytes) => {
+                            let bytes: [u8; 32] = bytes.as_slice().try_into().map_err(|_| {
+                                StorageError::IoError(format!(
+                                    "expected local batch member schema hash to be 32 bytes, got {}",
+                                    bytes.len()
+                                ))
+                            })?;
+                            SchemaHash::from_bytes(bytes)
+                        }
+                        other => {
+                            return Err(StorageError::IoError(format!(
+                                "expected local batch member schema hash bytes, got {other:?}"
+                            )));
+                        }
+                    };
+                    let row_digest = match row_digest {
+                        Value::Bytea(bytes) => Digest32(bytes.as_slice().try_into().map_err(
+                            |_| {
+                                StorageError::IoError(format!(
+                                    "expected local batch member row digest to be 32 bytes, got {}",
+                                    bytes.len()
+                                ))
+                            },
+                        )?),
+                        other => {
+                            return Err(StorageError::IoError(format!(
+                                "expected local batch member row digest bytes, got {other:?}"
+                            )));
+                        }
+                    };
+                    Ok(LocalBatchMember {
+                        object_id,
+                        table_name,
+                        branch_name,
+                        schema_hash,
+                        row_digest,
+                    })
+                }
+                other => Err(StorageError::IoError(format!(
+                    "expected local batch member row, got {other:?}"
+                ))),
+            })
+            .collect::<Result<Vec<_>, StorageError>>(),
+        other => Err(StorageError::IoError(format!(
+            "expected local batch members array, got {other:?}"
+        ))),
+    }
+}
+
+fn decode_local_batch_row_index(
+    bytes: &[u8],
+) -> Result<(BatchId, Vec<LocalBatchMember>), StorageError> {
+    let values = decode_row(&local_batch_row_index_storage_descriptor(), bytes)
+        .map_err(|err| StorageError::IoError(format!("decode local batch row index: {err}")))?;
+    let [batch_id, members] = values.as_slice() else {
+        return Err(StorageError::IoError(
+            "unexpected local batch row index shape".to_string(),
+        ));
+    };
+
+    let batch_id =
+        decode_storage_batch_id_value(batch_id, "decode local batch row index batch id")?;
+    Ok((batch_id, decode_local_batch_members(members)?))
 }
 
 fn decode_local_batch_record_with_branch_ords<H: Storage + ?Sized>(

--- a/crates/jazz-tools/src/storage/storage_trait.rs
+++ b/crates/jazz-tools/src/storage/storage_trait.rs
@@ -530,6 +530,114 @@ pub trait Storage {
         Ok(records)
     }
 
+    fn upsert_local_batch_row_index(
+        &mut self,
+        batch_id: BatchId,
+        new_members: &[LocalBatchMember],
+    ) -> Result<(), StorageError> {
+        if new_members.is_empty() {
+            return Ok(());
+        }
+        let mut members = self
+            .load_local_batch_row_index(batch_id)?
+            .unwrap_or_default();
+        for member in new_members {
+            upsert_local_batch_member(&mut members, member.clone());
+        }
+
+        ensure_raw_table_header(
+            self,
+            LOCAL_BATCH_ROW_INDEX_TABLE,
+            &RawTableHeader::system(
+                STORAGE_KIND_LOCAL_BATCH_ROW_INDEX,
+                LOCAL_BATCH_ROW_INDEX_FORMAT_V1,
+            ),
+        )?;
+        let bytes = encode_local_batch_row_index(batch_id, &members)?;
+        self.raw_table_put(
+            LOCAL_BATCH_ROW_INDEX_TABLE,
+            &local_batch_record_key(batch_id),
+            &bytes,
+        )
+    }
+
+    fn load_local_batch_row_index(
+        &self,
+        batch_id: BatchId,
+    ) -> Result<Option<Vec<LocalBatchMember>>, StorageError> {
+        match self.raw_table_get(
+            LOCAL_BATCH_ROW_INDEX_TABLE,
+            &local_batch_record_key(batch_id),
+        )? {
+            Some(bytes) => {
+                ensure_system_raw_table_header_validated_once(
+                    self,
+                    LOCAL_BATCH_ROW_INDEX_TABLE,
+                    STORAGE_KIND_LOCAL_BATCH_ROW_INDEX,
+                    LOCAL_BATCH_ROW_INDEX_FORMAT_V1,
+                )?;
+                let (row_batch_id, members) = decode_local_batch_row_index(&bytes)?;
+                if row_batch_id != batch_id {
+                    return Err(StorageError::IoError(format!(
+                        "local batch row index key/row mismatch for {:?}",
+                        batch_id
+                    )));
+                }
+                Ok(Some(members))
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn index_local_batch_history_rows(
+        &mut self,
+        table: &str,
+        history_rows: &[StoredRowBatch],
+        encoded_history_rows: &[OwnedHistoryRowBytes],
+    ) -> Result<(), StorageError> {
+        if history_rows.len() != encoded_history_rows.len() {
+            return Err(StorageError::IoError(format!(
+                "history row index count mismatch: {} decoded vs {} encoded",
+                history_rows.len(),
+                encoded_history_rows.len()
+            )));
+        }
+
+        let mut members_by_batch = BTreeMap::<BatchId, Vec<LocalBatchMember>>::new();
+        for (row, encoded) in history_rows.iter().zip(encoded_history_rows) {
+            if row.row_id != encoded.row_id
+                || row.batch_id() != encoded.batch_id
+                || row.branch.as_str() != encoded.branch.as_str()
+            {
+                return Err(StorageError::IoError(format!(
+                    "history row index mismatch for table {table}: decoded ({}, {}, {:?}) vs encoded ({}, {}, {:?})",
+                    row.row_id,
+                    row.branch,
+                    row.batch_id(),
+                    encoded.row_id,
+                    encoded.branch,
+                    encoded.batch_id
+                )));
+            }
+
+            members_by_batch
+                .entry(row.batch_id())
+                .or_default()
+                .push(LocalBatchMember {
+                    object_id: row.row_id,
+                    table_name: table.to_string(),
+                    branch_name: BranchName::new(row.branch.as_str()),
+                    schema_hash: encoded.row_raw_table_id.schema_hash,
+                    row_digest: row.content_digest(),
+                });
+        }
+
+        for (batch_id, members) in members_by_batch {
+            self.upsert_local_batch_row_index(batch_id, &members)?;
+        }
+        Ok(())
+    }
+
     fn upsert_sealed_batch_submission(
         &mut self,
         submission: &SealedBatchSubmission,
@@ -775,7 +883,8 @@ pub trait Storage {
         rows: &[StoredRowBatch],
     ) -> Result<(), StorageError> {
         let encoded_rows = encode_history_row_bytes_for_storage(self, table, rows)?;
-        self.apply_encoded_row_mutation(table, &encoded_rows, &[], &[])
+        self.apply_encoded_row_mutation(table, &encoded_rows, &[], &[])?;
+        self.index_local_batch_history_rows(table, rows, &encoded_rows)
     }
 
     fn apply_encoded_row_mutation(
@@ -892,14 +1001,14 @@ pub trait Storage {
         encoded_visible_rows: &[OwnedVisibleRowBytes],
         index_mutations: &[IndexMutation<'_>],
     ) -> Result<(), StorageError> {
-        let _ = history_rows;
         let _ = visible_entries;
         self.apply_encoded_row_mutation(
             table,
             encoded_history_rows,
             encoded_visible_rows,
             index_mutations,
-        )
+        )?;
+        self.index_local_batch_history_rows(table, history_rows, encoded_history_rows)
     }
 
     fn upsert_visible_region_row_bytes(

--- a/crates/jazz-tools/src/storage/storage_trait.rs
+++ b/crates/jazz-tools/src/storage/storage_trait.rs
@@ -589,6 +589,13 @@ pub trait Storage {
         }
     }
 
+    fn delete_local_batch_row_index(&mut self, batch_id: BatchId) -> Result<(), StorageError> {
+        self.raw_table_delete(
+            LOCAL_BATCH_ROW_INDEX_TABLE,
+            &local_batch_record_key(batch_id),
+        )
+    }
+
     fn index_local_batch_history_rows(
         &mut self,
         table: &str,
@@ -1853,6 +1860,25 @@ impl<T: Storage + ?Sized> Storage for Box<T> {
 
     fn delete_local_batch_record(&mut self, batch_id: BatchId) -> Result<(), StorageError> {
         (**self).delete_local_batch_record(batch_id)
+    }
+
+    fn upsert_local_batch_row_index(
+        &mut self,
+        batch_id: BatchId,
+        new_members: &[LocalBatchMember],
+    ) -> Result<(), StorageError> {
+        (**self).upsert_local_batch_row_index(batch_id, new_members)
+    }
+
+    fn load_local_batch_row_index(
+        &self,
+        batch_id: BatchId,
+    ) -> Result<Option<Vec<LocalBatchMember>>, StorageError> {
+        (**self).load_local_batch_row_index(batch_id)
+    }
+
+    fn delete_local_batch_row_index(&mut self, batch_id: BatchId) -> Result<(), StorageError> {
+        (**self).delete_local_batch_row_index(batch_id)
     }
 
     fn scan_local_batch_records(&self) -> Result<Vec<LocalBatchRecord>, StorageError> {


### PR DESCRIPTION
## Description

Adds a persistent `batch_id -> local batch rows` index so `local_batch_rows` no longer needs to fall back to scanning every row locator and every row history.

The new index is stored as a system raw table and is populated whenever history rows are written through the normal storage mutation paths. `local_batch_rows` now uses only bounded lookup paths:

1. sealed batch submission
2. in-memory local batch record
3. persisted local batch record
4. persisted local batch row index

This removes the previous `scan_row_locators` fallback, which could become `O(rows × history_versions)` per batch fate lookup.