### PR TITLE
Fix jazz-rn scheduler thread growth

### DIFF
--- a/.changeset/no-duplicate-tick-on-auto-commit.md
+++ b/.changeset/no-duplicate-tick-on-auto-commit.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Avoid firing a duplicate immediate tick for auto-committed direct writes. Insert, update, upsert, delete, and restore ticked both inside `commit_batch` and unconditionally afterwards; the follow-up tick now only fires when the write does not auto-seal, halving scheduler pressure during bursts of bare writes.

--- a/.changeset/rn-scheduler-persistent-worker.md
+++ b/.changeset/rn-scheduler-persistent-worker.md
@@ -1,0 +1,5 @@
+---
+"jazz-rn": patch
+---
+
+Stop the React Native scheduler from spawning a thread per tick. Every accepted tick or mutation-error delivery used to spawn a fresh thread that blocked until the JS thread serviced its callback, and because the debounce flag was released before the callback returned, a heavy burst of bare inserts minted roughly one blocked thread per millisecond. Jobs are now queued to a single lazily-spawned worker thread, so the scheduler's thread count stays constant and callbacks are serialized. Shutdown from `close()` drops the worker's channel instead of joining it (a worker blocked on a JS callback would deadlock the JS thread running `close()`), the tick callback is no longer invoked while holding the mutex that `close()` needs, a failed worker spawn no longer poisons the scheduler, and a panicking mutation-error callback can no longer kill the worker.

--- a/crates/jazz-rn/rust/src/lib.rs
+++ b/crates/jazz-rn/rust/src/lib.rs
@@ -264,12 +264,54 @@ pub trait MutationErrorCallback: Send + Sync {
 // RnScheduler
 // ============================================================================
 
+#[derive(Clone, Copy)]
+enum SchedulerJob {
+    Tick,
+    DeliverMutationErrors,
+}
+
+struct SchedulerWorker {
+    sender: Option<std::sync::mpsc::Sender<SchedulerJob>>,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl SchedulerWorker {
+    fn send(&self, job: SchedulerJob) -> Result<(), std::sync::mpsc::SendError<SchedulerJob>> {
+        let Some(sender) = self.sender.as_ref() else {
+            return Err(std::sync::mpsc::SendError(job));
+        };
+        sender.send(job)
+    }
+
+    fn shutdown(&mut self) {
+        drop(self.sender.take());
+
+        let Some(handle) = self.handle.take() else {
+            return;
+        };
+
+        if handle.thread().id() == std::thread::current().id() {
+            return;
+        }
+
+        let _ = handle.join();
+    }
+}
+
+impl Drop for SchedulerWorker {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
 #[derive(Clone, Default)]
 struct RnScheduler {
     scheduled: Arc<AtomicBool>,
     mutation_error_delivery_scheduled: Arc<AtomicBool>,
     core_ref: Arc<Mutex<Option<Weak<Mutex<RnCoreType>>>>>,
     callback: Arc<Mutex<Option<Box<dyn BatchedTickCallback>>>>,
+    worker: Arc<Mutex<Option<SchedulerWorker>>>,
+    shutdown: Arc<AtomicBool>,
 }
 
 impl RnScheduler {
@@ -288,6 +330,118 @@ impl RnScheduler {
     fn clear_scheduled(&self) {
         self.scheduled.store(false, Ordering::SeqCst);
     }
+
+    fn send_job(&self, job: SchedulerJob) {
+        if self.shutdown.load(Ordering::SeqCst) {
+            self.clear_job_scheduled(job);
+            return;
+        }
+
+        let mut slot = match self.worker.lock() {
+            Ok(slot) => slot,
+            Err(_) => {
+                self.clear_job_scheduled(job);
+                return;
+            }
+        };
+
+        if self.shutdown.load(Ordering::SeqCst) {
+            self.clear_job_scheduled(job);
+            return;
+        }
+
+        if slot.is_none() {
+            *slot = Some(Self::spawn_worker(
+                Arc::clone(&self.scheduled),
+                Arc::clone(&self.mutation_error_delivery_scheduled),
+                Arc::clone(&self.core_ref),
+                Arc::clone(&self.callback),
+            ));
+        }
+
+        let send_failed = slot
+            .as_ref()
+            .is_some_and(|worker| worker.send(job).is_err());
+
+        if send_failed {
+            self.clear_job_scheduled(job);
+            let _ = slot.take();
+        }
+    }
+
+    fn clear_job_scheduled(&self, job: SchedulerJob) {
+        match job {
+            SchedulerJob::Tick => self.scheduled.store(false, Ordering::SeqCst),
+            SchedulerJob::DeliverMutationErrors => self
+                .mutation_error_delivery_scheduled
+                .store(false, Ordering::SeqCst),
+        }
+    }
+
+    fn spawn_worker(
+        scheduled: Arc<AtomicBool>,
+        mutation_error_delivery_scheduled: Arc<AtomicBool>,
+        core_ref: Arc<Mutex<Option<Weak<Mutex<RnCoreType>>>>>,
+        callback: Arc<Mutex<Option<Box<dyn BatchedTickCallback>>>>,
+    ) -> SchedulerWorker {
+        let (sender, receiver) = std::sync::mpsc::channel::<SchedulerJob>();
+        let handle = std::thread::Builder::new()
+            .name("jazz-rn-scheduler".into())
+            .spawn(move || {
+                while let Ok(job) = receiver.recv() {
+                    std::thread::sleep(Duration::from_millis(1));
+                    match job {
+                        SchedulerJob::Tick => {
+                            scheduled.store(false, Ordering::SeqCst);
+                            Self::request_batched_tick(&callback);
+                        }
+                        SchedulerJob::DeliverMutationErrors => {
+                            mutation_error_delivery_scheduled.store(false, Ordering::SeqCst);
+                            Self::deliver_mutation_errors(&core_ref);
+                        }
+                    }
+                }
+            })
+            .expect("spawn jazz-rn scheduler thread");
+
+        SchedulerWorker {
+            sender: Some(sender),
+            handle: Some(handle),
+        }
+    }
+
+    fn request_batched_tick(callback: &Arc<Mutex<Option<Box<dyn BatchedTickCallback>>>>) {
+        if let Ok(guard) = callback.lock() {
+            if let Some(cb) = guard.as_ref() {
+                let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    cb.request_batched_tick();
+                }));
+            }
+        }
+    }
+
+    fn deliver_mutation_errors(core_ref: &Arc<Mutex<Option<Weak<Mutex<RnCoreType>>>>>) {
+        let core_ref = core_ref.lock().ok().and_then(|slot| slot.clone());
+
+        if let Some(core) = core_ref.and_then(|core_ref| core_ref.upgrade()) {
+            if let Err(error) = deliver_pending_mutation_errors(&core) {
+                eprintln!("jazz-rn: deliver pending mutation errors: {error:?}");
+            }
+        }
+    }
+
+    fn shutdown(&self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+        self.scheduled.store(false, Ordering::SeqCst);
+        self.mutation_error_delivery_scheduled
+            .store(false, Ordering::SeqCst);
+
+        if let Ok(mut slot) = self.worker.lock() {
+            if let Some(mut worker) = slot.take() {
+                worker.shutdown();
+            }
+        }
+    }
 }
 
 impl Scheduler for RnScheduler {
@@ -297,7 +451,7 @@ impl Scheduler for RnScheduler {
             return;
         }
 
-        // Defer firing the JS callback through a background thread so we do
+        // Defer firing the JS callback through the scheduler worker so we do
         // not synchronously re-enter `RnRuntime::batched_tick` from inside
         // `core.batched_tick()`. Without this delay,
         // `cb.request_batched_tick()` enqueues a JS microtask that runs
@@ -306,19 +460,7 @@ impl Scheduler for RnScheduler {
         // of schedule calls within a tick into a single follow-up callback.
         // This mirrors `schedule_mutation_error_delivery` below and
         // `NapiScheduler::schedule_batched_tick` in `jazz-napi`.
-        let scheduled = Arc::clone(&self.scheduled);
-        let callback = Arc::clone(&self.callback);
-        std::thread::spawn(move || {
-            std::thread::sleep(Duration::from_millis(1));
-            scheduled.store(false, Ordering::SeqCst);
-            if let Ok(guard) = callback.lock() {
-                if let Some(cb) = guard.as_ref() {
-                    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        cb.request_batched_tick();
-                    }));
-                }
-            }
-        });
+        self.send_job(SchedulerJob::Tick);
     }
 
     fn schedule_mutation_error_delivery(&self) {
@@ -329,22 +471,7 @@ impl Scheduler for RnScheduler {
             return;
         }
 
-        let scheduled = Arc::clone(&self.mutation_error_delivery_scheduled);
-        let core_ref = self.core_ref.lock().ok().and_then(|slot| slot.clone());
-        let Some(core_ref) = core_ref else {
-            scheduled.store(false, Ordering::SeqCst);
-            return;
-        };
-
-        std::thread::spawn(move || {
-            std::thread::sleep(Duration::from_millis(1));
-            scheduled.store(false, Ordering::SeqCst);
-            if let Some(core) = core_ref.upgrade() {
-                if let Err(error) = deliver_pending_mutation_errors(&core) {
-                    eprintln!("jazz-rn: deliver pending mutation errors: {error:?}");
-                }
-            }
-        });
+        self.send_job(SchedulerJob::DeliverMutationErrors);
     }
 }
 
@@ -850,12 +977,21 @@ impl RnRuntime {
     /// Flush and close the underlying storage, releasing filesystem locks.
     pub fn close(&self) -> Result<(), JazzRnError> {
         with_panic_boundary("close", || {
-            let mut core = self.core.lock().map_err(|_| JazzRnError::Internal {
-                message: "lock poisoned".into(),
-            })?;
-            let flush_result = core.flush_storage();
-            let flush_wal_result = core.flush_wal();
-            let close_result = core.storage().close();
+            let (scheduler, flush_result, flush_wal_result, close_result) = {
+                let mut core = self.core.lock().map_err(|_| JazzRnError::Internal {
+                    message: "lock poisoned".into(),
+                })?;
+                core.scheduler_mut().set_callback(None);
+                core.set_mutation_error_callback(None);
+                let scheduler = core.scheduler().clone();
+                let flush_result = core.flush_storage();
+                let flush_wal_result = core.flush_wal();
+                let close_result = core.storage().close();
+
+                (scheduler, flush_result, flush_wal_result, close_result)
+            };
+
+            scheduler.shutdown();
 
             flush_result.map_err(runtime_err)?;
             flush_wal_result.map_err(runtime_err)?;
@@ -965,6 +1101,83 @@ struct RnTickNotifier {
 impl jazz_tools::transport_manager::TickNotifier for RnTickNotifier {
     fn notify(&self) {
         self.scheduler.schedule_batched_tick();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::mpsc;
+    use std::thread::ThreadId;
+
+    struct BlockingTickCallback {
+        invocations: AtomicUsize,
+        entered_tx: mpsc::Sender<(usize, ThreadId)>,
+        unblock_first_rx: Mutex<mpsc::Receiver<()>>,
+    }
+
+    impl BatchedTickCallback for BlockingTickCallback {
+        fn request_batched_tick(&self) {
+            let invocation = self.invocations.fetch_add(1, Ordering::SeqCst) + 1;
+            self.entered_tx
+                .send((invocation, std::thread::current().id()))
+                .expect("test should receive tick callback");
+
+            if invocation == 1 {
+                self.unblock_first_rx
+                    .lock()
+                    .expect("test unblock receiver should not be poisoned")
+                    .recv_timeout(Duration::from_secs(1))
+                    .expect("test should unblock first tick callback");
+            }
+        }
+    }
+
+    #[test]
+    fn scheduler_coalesces_bursts_on_one_worker_for_follow_up_ticks() {
+        // This is intentionally an internal scheduler test: constant worker
+        // count and callback serialization are not observable through the
+        // public RN runtime API.
+        let scheduler = RnScheduler::default();
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let (unblock_first_tx, unblock_first_rx) = mpsc::channel();
+
+        scheduler.set_callback(Some(Box::new(BlockingTickCallback {
+            invocations: AtomicUsize::new(0),
+            entered_tx,
+            unblock_first_rx: Mutex::new(unblock_first_rx),
+        })));
+
+        scheduler.schedule_batched_tick();
+        let (first_invocation, first_thread_id) = entered_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("first tick callback should run");
+        assert_eq!(first_invocation, 1);
+
+        for _ in 0..5 {
+            scheduler.schedule_batched_tick();
+        }
+        assert!(
+            entered_rx.recv_timeout(Duration::from_millis(100)).is_err(),
+            "follow-up tick callback ran concurrently with the blocked callback"
+        );
+
+        unblock_first_tx
+            .send(())
+            .expect("first tick callback should still be waiting");
+        let (second_invocation, second_thread_id) = entered_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("follow-up tick callback should run after the first returns");
+        assert_eq!(second_invocation, 2);
+        assert_eq!(
+            second_thread_id, first_thread_id,
+            "follow-up tick ran on a freshly spawned scheduler thread"
+        );
+        assert!(
+            entered_rx.recv_timeout(Duration::from_millis(100)).is_err(),
+            "burst schedules produced more than one follow-up tick"
+        );
     }
 }
 

--- a/crates/jazz-rn/rust/src/lib.rs
+++ b/crates/jazz-rn/rust/src/lib.rs
@@ -270,47 +270,18 @@ enum SchedulerJob {
     DeliverMutationErrors,
 }
 
-struct SchedulerWorker {
-    sender: Option<std::sync::mpsc::Sender<SchedulerJob>>,
-    handle: Option<std::thread::JoinHandle<()>>,
-}
-
-impl SchedulerWorker {
-    fn send(&self, job: SchedulerJob) -> Result<(), std::sync::mpsc::SendError<SchedulerJob>> {
-        let Some(sender) = self.sender.as_ref() else {
-            return Err(std::sync::mpsc::SendError(job));
-        };
-        sender.send(job)
-    }
-
-    fn shutdown(&mut self) {
-        drop(self.sender.take());
-
-        let Some(handle) = self.handle.take() else {
-            return;
-        };
-
-        if handle.thread().id() == std::thread::current().id() {
-            return;
-        }
-
-        let _ = handle.join();
-    }
-}
-
-impl Drop for SchedulerWorker {
-    fn drop(&mut self) {
-        self.shutdown();
-    }
-}
+type SharedTickCallback = Arc<Mutex<Option<Arc<dyn BatchedTickCallback>>>>;
+type SharedCoreRef = Arc<Mutex<Option<Weak<Mutex<RnCoreType>>>>>;
 
 #[derive(Clone, Default)]
 struct RnScheduler {
     scheduled: Arc<AtomicBool>,
     mutation_error_delivery_scheduled: Arc<AtomicBool>,
-    core_ref: Arc<Mutex<Option<Weak<Mutex<RnCoreType>>>>>,
-    callback: Arc<Mutex<Option<Box<dyn BatchedTickCallback>>>>,
-    worker: Arc<Mutex<Option<SchedulerWorker>>>,
+    core_ref: SharedCoreRef,
+    callback: SharedTickCallback,
+    // The worker thread is detached: it exits once the sender is dropped and
+    // its queue drains. It must never be joined — see `shutdown` below.
+    worker: Arc<Mutex<Option<std::sync::mpsc::Sender<SchedulerJob>>>>,
     shutdown: Arc<AtomicBool>,
 }
 
@@ -323,7 +294,7 @@ impl RnScheduler {
 
     fn set_callback(&self, cb: Option<Box<dyn BatchedTickCallback>>) {
         if let Ok(mut slot) = self.callback.lock() {
-            *slot = cb;
+            *slot = cb.map(Arc::from);
         }
     }
 
@@ -351,21 +322,21 @@ impl RnScheduler {
         }
 
         if slot.is_none() {
-            *slot = Some(Self::spawn_worker(
+            *slot = Self::spawn_worker(
                 Arc::clone(&self.scheduled),
                 Arc::clone(&self.mutation_error_delivery_scheduled),
                 Arc::clone(&self.core_ref),
                 Arc::clone(&self.callback),
-            ));
+            );
         }
 
-        let send_failed = slot
-            .as_ref()
-            .is_some_and(|worker| worker.send(job).is_err());
+        let sent = slot.as_ref().is_some_and(|sender| sender.send(job).is_ok());
 
-        if send_failed {
+        if !sent {
+            // Spawn failed or the worker died; drop the job and reset both
+            // the slot and the debounce flag so the next schedule retries.
             self.clear_job_scheduled(job);
-            let _ = slot.take();
+            *slot = None;
         }
     }
 
@@ -381,11 +352,11 @@ impl RnScheduler {
     fn spawn_worker(
         scheduled: Arc<AtomicBool>,
         mutation_error_delivery_scheduled: Arc<AtomicBool>,
-        core_ref: Arc<Mutex<Option<Weak<Mutex<RnCoreType>>>>>,
-        callback: Arc<Mutex<Option<Box<dyn BatchedTickCallback>>>>,
-    ) -> SchedulerWorker {
+        core_ref: SharedCoreRef,
+        callback: SharedTickCallback,
+    ) -> Option<std::sync::mpsc::Sender<SchedulerJob>> {
         let (sender, receiver) = std::sync::mpsc::channel::<SchedulerJob>();
-        let handle = std::thread::Builder::new()
+        let spawned = std::thread::Builder::new()
             .name("jazz-rn-scheduler".into())
             .spawn(move || {
                 while let Ok(job) = receiver.recv() {
@@ -401,26 +372,33 @@ impl RnScheduler {
                         }
                     }
                 }
-            })
-            .expect("spawn jazz-rn scheduler thread");
+            });
 
-        SchedulerWorker {
-            sender: Some(sender),
-            handle: Some(handle),
-        }
-    }
-
-    fn request_batched_tick(callback: &Arc<Mutex<Option<Box<dyn BatchedTickCallback>>>>) {
-        if let Ok(guard) = callback.lock() {
-            if let Some(cb) = guard.as_ref() {
-                let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    cb.request_batched_tick();
-                }));
+        match spawned {
+            Ok(_) => Some(sender),
+            Err(error) => {
+                // Do not panic: this runs while `send_job` holds the worker
+                // mutex, and poisoning it would silently disable the
+                // scheduler for good.
+                eprintln!("jazz-rn: failed to spawn scheduler thread: {error}");
+                None
             }
         }
     }
 
-    fn deliver_mutation_errors(core_ref: &Arc<Mutex<Option<Weak<Mutex<RnCoreType>>>>>) {
+    fn request_batched_tick(callback: &SharedTickCallback) {
+        // Clone the callback out before invoking it: the call blocks until
+        // the JS thread services it, and `set_callback(None)` (run by
+        // `close()` on that same JS thread) must never wait on it.
+        let callback = callback.lock().ok().and_then(|slot| slot.clone());
+        if let Some(cb) = callback {
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                cb.request_batched_tick();
+            }));
+        }
+    }
+
+    fn deliver_mutation_errors(core_ref: &SharedCoreRef) {
         let core_ref = core_ref.lock().ok().and_then(|slot| slot.clone());
 
         if let Some(core) = core_ref.and_then(|core_ref| core_ref.upgrade()) {
@@ -436,10 +414,12 @@ impl RnScheduler {
         self.mutation_error_delivery_scheduled
             .store(false, Ordering::SeqCst);
 
+        // Dropping the sender lets the worker drain its queue (no-ops once
+        // the callbacks are cleared) and exit on its own. Never join it: JS
+        // callbacks run via a blocking hop to the JS thread, and `close()`
+        // runs on that same thread — joining here can deadlock the app.
         if let Ok(mut slot) = self.worker.lock() {
-            if let Some(mut worker) = slot.take() {
-                worker.shutdown();
-            }
+            *slot = None;
         }
     }
 }
@@ -494,7 +474,9 @@ fn deliver_pending_mutation_errors(core: &Arc<Mutex<RnCoreType>>) -> Result<(), 
     };
 
     for event in events {
-        callback(&event);
+        // The callback re-enters JS; a panic (e.g. a JS exception) must not
+        // kill the scheduler worker or skip the remaining events.
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| callback(&event)));
     }
 
     Ok(())
@@ -977,21 +959,15 @@ impl RnRuntime {
     /// Flush and close the underlying storage, releasing filesystem locks.
     pub fn close(&self) -> Result<(), JazzRnError> {
         with_panic_boundary("close", || {
-            let (scheduler, flush_result, flush_wal_result, close_result) = {
-                let mut core = self.core.lock().map_err(|_| JazzRnError::Internal {
-                    message: "lock poisoned".into(),
-                })?;
-                core.scheduler_mut().set_callback(None);
-                core.set_mutation_error_callback(None);
-                let scheduler = core.scheduler().clone();
-                let flush_result = core.flush_storage();
-                let flush_wal_result = core.flush_wal();
-                let close_result = core.storage().close();
-
-                (scheduler, flush_result, flush_wal_result, close_result)
-            };
-
-            scheduler.shutdown();
+            let mut core = self.core.lock().map_err(|_| JazzRnError::Internal {
+                message: "lock poisoned".into(),
+            })?;
+            core.scheduler_mut().set_callback(None);
+            core.set_mutation_error_callback(None);
+            core.scheduler().shutdown();
+            let flush_result = core.flush_storage();
+            let flush_wal_result = core.flush_wal();
+            let close_result = core.storage().close();
 
             flush_result.map_err(runtime_err)?;
             flush_wal_result.map_err(runtime_err)?;
@@ -1177,6 +1153,37 @@ mod tests {
         assert!(
             entered_rx.recv_timeout(Duration::from_millis(100)).is_err(),
             "burst schedules produced more than one follow-up tick"
+        );
+    }
+
+    struct NotifyTickCallback {
+        entered_tx: mpsc::Sender<()>,
+    }
+
+    impl BatchedTickCallback for NotifyTickCallback {
+        fn request_batched_tick(&self) {
+            let _ = self.entered_tx.send(());
+        }
+    }
+
+    #[test]
+    fn shutdown_scheduler_drops_new_ticks_and_clears_the_debounce_flag() {
+        // Internal scheduler test: post-shutdown scheduling behavior is not
+        // observable through the public RN runtime API.
+        let scheduler = RnScheduler::default();
+        let (entered_tx, entered_rx) = mpsc::channel();
+        scheduler.set_callback(Some(Box::new(NotifyTickCallback { entered_tx })));
+
+        scheduler.shutdown();
+        scheduler.schedule_batched_tick();
+
+        assert!(
+            entered_rx.recv_timeout(Duration::from_millis(100)).is_err(),
+            "tick callback ran after shutdown"
+        );
+        assert!(
+            !scheduler.scheduled.load(Ordering::SeqCst),
+            "shutdown left the tick debounce flag wedged"
         );
     }
 }

--- a/crates/jazz-tools/src/runtime_core/writes.rs
+++ b/crates/jazz-tools/src/runtime_core/writes.rs
@@ -249,6 +249,26 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         batch_mode == BatchMode::Direct && write_context.and_then(WriteContext::batch_id).is_none()
     }
 
+    fn finish_local_write(
+        &mut self,
+        row_id: ObjectId,
+        batch_id: BatchId,
+        write_context: Option<&WriteContext>,
+    ) -> Result<(), RuntimeError> {
+        let batch_mode = write_context
+            .map(WriteContext::batch_mode)
+            .unwrap_or(BatchMode::Direct);
+        self.track_local_batch(row_id, batch_id, batch_mode)?;
+        if Self::should_auto_seal_direct_write(batch_mode, write_context) {
+            self.commit_batch(batch_id)?;
+        } else {
+            // commit_batch runs these operations internally, avoid firing two ticks
+            self.mark_storage_write_pending_flush();
+            self.immediate_tick();
+        }
+        Ok(())
+    }
+
     fn ensure_batch_is_writable(
         &mut self,
         write_context: Option<&WriteContext>,
@@ -588,16 +608,8 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         let row_id = result.row_id;
         let row_values = result.row_values;
         let batch_id = result.batch_id;
-        let batch_mode = write_context
-            .map(WriteContext::batch_mode)
-            .unwrap_or(BatchMode::Direct);
-        self.track_local_batch(row_id, batch_id, batch_mode)?;
-        if Self::should_auto_seal_direct_write(batch_mode, write_context) {
-            self.commit_batch(batch_id)?;
-        }
+        self.finish_local_write(row_id, batch_id, write_context)?;
         debug!(object_id = %row_id, "inserted");
-        self.mark_storage_write_pending_flush();
-        self.immediate_tick();
         Ok(((row_id, row_values), batch_id))
     }
 
@@ -616,16 +628,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             .schema_manager
             .update(&mut self.storage, object_id, &values, write_context)
             .map_err(crate::runtime_core::write_error_from_query)?;
-        let batch_mode = write_context
-            .map(WriteContext::batch_mode)
-            .unwrap_or(BatchMode::Direct);
-        self.track_local_batch(object_id, batch_id, batch_mode)?;
-        if Self::should_auto_seal_direct_write(batch_mode, write_context) {
-            self.commit_batch(batch_id)?;
-        }
-
-        self.mark_storage_write_pending_flush();
-        self.immediate_tick();
+        self.finish_local_write(object_id, batch_id, write_context)?;
         Ok(batch_id)
     }
 
@@ -644,17 +647,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             .schema_manager
             .upsert(&mut self.storage, table, object_id, values, write_context)
             .map_err(crate::runtime_core::write_error_from_query)?;
-        let batch_mode = write_context
-            .map(WriteContext::batch_mode)
-            .unwrap_or(BatchMode::Direct);
-        self.track_local_batch(object_id, batch_id, batch_mode)?;
-
-        if Self::should_auto_seal_direct_write(batch_mode, write_context) {
-            self.commit_batch(batch_id)?;
-        }
-
-        self.mark_storage_write_pending_flush();
-        self.immediate_tick();
+        self.finish_local_write(object_id, batch_id, write_context)?;
         Ok(batch_id)
     }
 
@@ -673,16 +666,8 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             .delete(&mut self.storage, object_id, write_context)
             .map_err(crate::runtime_core::write_error_from_query)?;
         let batch_id = handle.batch_id;
-        let batch_mode = write_context
-            .map(WriteContext::batch_mode)
-            .unwrap_or(BatchMode::Direct);
-        self.track_local_batch(object_id, batch_id, batch_mode)?;
-        if Self::should_auto_seal_direct_write(batch_mode, write_context) {
-            self.commit_batch(batch_id)?;
-        }
+        self.finish_local_write(object_id, batch_id, write_context)?;
         debug!("deleted");
-        self.mark_storage_write_pending_flush();
-        self.immediate_tick();
         Ok(batch_id)
     }
 
@@ -705,16 +690,8 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         let row_id = result.row_id;
         let row_values = result.row_values;
         let batch_id = result.batch_id;
-        let batch_mode = write_context
-            .map(WriteContext::batch_mode)
-            .unwrap_or(BatchMode::Direct);
-        self.track_local_batch(row_id, batch_id, batch_mode)?;
-        if Self::should_auto_seal_direct_write(batch_mode, write_context) {
-            self.commit_batch(batch_id)?;
-        }
+        self.finish_local_write(row_id, batch_id, write_context)?;
         debug!(object_id = %row_id, "restored");
-        self.mark_storage_write_pending_flush();
-        self.immediate_tick();
         Ok(((row_id, row_values), batch_id))
     }
 

--- a/crates/jazz-tools/src/runtime_core/writes.rs
+++ b/crates/jazz-tools/src/runtime_core/writes.rs
@@ -260,9 +260,12 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             .unwrap_or(BatchMode::Direct);
         self.track_local_batch(row_id, batch_id, batch_mode)?;
         if Self::should_auto_seal_direct_write(batch_mode, write_context) {
+            // commit_batch marks the pending flush and fires the tick itself:
+            // the batch was just tracked, so it reaches the sealing tail
+            // rather than the missing/empty/already-sealed early returns
+            // (which do not tick).
             self.commit_batch(batch_id)?;
         } else {
-            // commit_batch runs these operations internally, avoid firing two ticks
             self.mark_storage_write_pending_flush();
             self.immediate_tick();
         }


### PR DESCRIPTION
## Summary
- Replace jazz-rn's per-schedule thread spawning with one lazy scheduler worker fed by an mpsc channel.
- Preserve tick and mutation-error debounce behavior while keeping scheduler thread count constant.
- Harden shutdown: `RnRuntime::close()` clears the callbacks and drops the worker's channel sender instead of joining the thread.
- Avoid firing a duplicate immediate tick for auto-committed direct writes in jazz-tools.
- Add changesets for `jazz-rn` and `jazz-tools`.

## Root Cause
The previous RN scheduler spawned a fresh thread for each accepted tick or mutation-error delivery. During heavy bare inserts, the debounce flag was cleared before the JS callback returned, so follow-up ticks kept spawning additional threads that all blocked on the busy JS thread — roughly one new thread per millisecond of write burst. Jobs are now queued to a single lazily-spawned worker, and the debounce interlock bounds the queue to at most one pending job per type, so thread count stays constant under any load.

## Shutdown hardening
uniffi-bindgen-react-native dispatches callback-interface calls through `invokeBlocking`: the worker blocks until the JS thread services the call, and `close()` runs on that same JS thread. Joining the worker from `close()` — or locking the callback mutex it held mid-call — could therefore deadlock the app. Instead:
- `shutdown()` drops the channel sender; the worker drains its queue (no-ops once callbacks are cleared) and exits on its own. It is never joined.
- The tick callback is stored as `Arc<dyn BatchedTickCallback>` and cloned out of the mutex before invocation, so `set_callback(None)` never waits on an in-flight callback.
- A failed worker spawn no longer panics while holding the worker mutex (which would have poisoned it and silently disabled the scheduler); the job is dropped and the next schedule retries.
- Mutation-error callbacks are wrapped in `catch_unwind` so a JS exception cannot kill the shared worker.

## Validation
- `cargo test -p jazz-rn` (includes new burst-coalescing and post-shutdown regression tests)
- `cargo test -p jazz-tools --features test`
- `cargo clippy --workspace -- -D warnings`
- `cargo fmt`, `git diff --check`
- The `close()` deadlock scenario requires a real JS thread and cannot be covered by unit tests; recommended on-device smoke test: heavy writes followed immediately by `close()`.