### PR TITLE
feat: migrate React `useAll` to return `{ data, isLoading, error }`

### DIFF
--- a/.changeset/react-useall-result.md
+++ b/.changeset/react-useall-result.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Align React and React Native `useAll` with the other framework bindings by returning `{ data, isLoading, error }` instead of a bare `T[] | undefined`. `useAllSuspense` still returns `T[]`.

--- a/.changeset/react-useall-result.md
+++ b/.changeset/react-useall-result.md
@@ -2,4 +2,4 @@
 "jazz-tools": patch
 ---
 
-Align React and React Native `useAll` with the other framework bindings by returning `{ data, isLoading, error }` instead of a bare `T[] | undefined`. `useAllSuspense` still returns `T[]`.
+BREAKING CHANGE: Align React and React Native `useAll` with the other framework bindings by returning `{ data, isLoading, error }` instead of a bare `T[] | undefined`. `useAllSuspense` still returns `T[]`.

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -302,6 +302,9 @@ impl SyncManager {
             && existing.metadata == incoming.metadata
     }
 
+    /// Returns the row's visible content immediately before the incoming batch
+    /// This "old" content is used to permission-check the change as an operation
+    /// from old content to new content
     fn pre_batch_visible_row<H: Storage>(
         &self,
         storage: &H,

--- a/dev/stress-tests/stress-test-expo/src/StressTest.tsx
+++ b/dev/stress-tests/stress-test-expo/src/StressTest.tsx
@@ -120,7 +120,7 @@ export function StressTest() {
   const session = useSession();
   const sessionUserId = session?.user_id ?? null;
   const [subscribed, setSubscribed] = useState(false);
-  const todos = useAll(subscribed ? app.todos : undefined) ?? [];
+  const { data: todos = [] } = useAll(subscribed ? app.todos : undefined);
 
   const [count, setCount] = useState("15000");
   const [isRunning, setIsRunning] = useState(false);

--- a/dev/stress-tests/stress-test-expo/src/TodoList.tsx
+++ b/dev/stress-tests/stress-test-expo/src/TodoList.tsx
@@ -88,7 +88,7 @@ export function TodoList() {
     setQueryTimeMs(null);
   }, [queryMode, filterTitle, showDoneOnly]);
 
-  const results = useAll(query) ?? [];
+  const { data: results = [] } = useAll(query);
 
   // Measure time when results first arrive after a query change
   useEffect(() => {

--- a/dev/stress-tests/todo-react/src/TodoList.tsx
+++ b/dev/stress-tests/todo-react/src/TodoList.tsx
@@ -16,7 +16,7 @@ export function TodoList() {
 
   const db = useDb();
   // #region reading-reactive-hooks-react
-  const todos = useAll(todosQuery) ?? [];
+  const { data: todos = [] } = useAll(todosQuery);
   // #endregion reading-reactive-hooks-react
   const session = useSession();
   const sessionUserId = session?.user_id ?? null;

--- a/docs/content/docs/reading/queries.mdx
+++ b/docs/content/docs/reading/queries.mdx
@@ -141,14 +141,14 @@ Each framework has a reactive binding that re-renders when query results change.
 
 | Framework  | API                            | Notes                                               |
 | ---------- | ------------------------------ | --------------------------------------------------- |
-| React/Expo | `useAll(query)`                | Returns `T[] \| undefined`                          |
+| React/Expo | `useAll(query)`                | Returns `{ data, isLoading, error }`                |
 | Vue        | `useAll(query)`                | Returns `{ data, error, loading }` refs             |
 | Svelte     | `new QuerySubscription(query)` | Exposes reactive `.current` / `.loading` / `.error` |
 | Solid      | `useAll(() => ({ query }))`    | Returns `{ data, isLoading, error }`                |
 
-### The `undefined` loading state
+### The loading state
 
-`useAll` (its `data` ref in Vue) and `QuerySubscription` return `undefined` until the first server response arrives. After that, the value is an array&hairsp;—&hairsp;empty (`[]`) if no rows match, or populated with the requested data.
+`useAll`'s `data` field (or Vue's `data` ref) and `QuerySubscription.current` are `undefined` until the first server response arrives. After that, the value is an array&hairsp;—&hairsp;empty (`[]`) if no rows match, or populated with the requested data.
 
 <Tabs groupId="jazz-framework" items={["React", "Vue", "Svelte", "Solid"]} persist updateAnchor>
   <Tab value="React">
@@ -174,7 +174,7 @@ Each framework has a reactive binding that re-renders when query results change.
 </Tabs>
 
 <Callout type="info">
-  You're unlikely to see `undefined` in practice unless you're awaiting a more [durable
+  You're unlikely to see `data: undefined` in practice unless you're awaiting a more [durable
   tier](#read-durability). Local storage reads are effectively instant and resolve to `[]` if no
   data exists yet.
 </Callout>
@@ -188,9 +188,9 @@ In practice this means:
 - Adding, removing, or reordering rows updates the array structure only — untouched row objects keep their identity, so `{#each items as item (item.id)}` and `<TransitionGroup>` keyed renders are stable.
 - Editing a single field on one row writes only that field — sibling rows do not re-render, and per-row components that read other fields stay quiet.
 - Vue's `useAll` returns `{ data, error, loading }`, where `data` is a deep `Ref` (not a `shallowRef`), so per-field reactivity composes with the rest of your component tree without manual unwrapping.
-- Solid's `useAll` returns a store, so Solid's fine-grained dependency tracking only re-runs computations that read changed fields.
+- React and Solid return `{ data, isLoading, error }`; React returns a fresh `data` array each tick, while Solid's store keeps fine-grained dependency tracking for fields that changed.
 
-React's `useAll` follows React's own re-render model and returns a fresh array each tick; the granularity benefit there comes from React's diffing, not from in-place reconciliation.
+React's granularity benefit comes from React's diffing, not from in-place reconciliation.
 
 ### Conditional queries
 
@@ -221,7 +221,7 @@ Pass `undefined` instead of a query to skip evaluation. This is useful when buil
 
 ### React Suspense and Transitions
 
-`useAllSuspense` is a React-specific variant that suspends instead of returning `undefined`, keeping the previous result visible while the next one loads.
+`useAllSuspense` is a React-specific variant that suspends instead of returning a loading state, keeping the previous result visible while the next one loads.
 
 <include cwd lang="tsx" meta='title="App.tsx"'>
   ../examples/docs/todo-client-localfirst-react/src/ConcurrentTodoList.tsx#reading-concurrent-rendering-react

--- a/docs/content/docs/reading/queries.mdx
+++ b/docs/content/docs/reading/queries.mdx
@@ -148,7 +148,7 @@ Each framework has a reactive binding that re-renders when query results change.
 
 ### The loading state
 
-`useAll`'s `data` field (or Vue's `data` ref) and `QuerySubscription.current` are `undefined` until the first server response arrives. After that, the value is an array&hairsp;—&hairsp;empty (`[]`) if no rows match, or populated with the requested data.
+`useAll`'s `data` field (or Vue's `data` ref and Svelte's `QuerySubscription.current`) are `undefined` until the first server response arrives. After that, the value is an array&hairsp;—&hairsp;empty (`[]`) if no rows match, or populated with the requested data.
 
 <Tabs groupId="jazz-framework" items={["React", "Vue", "Svelte", "Solid"]} persist updateAnchor>
   <Tab value="React">

--- a/docs/content/presentations/all-things-sync.mdx
+++ b/docs/content/presentations/all-things-sync.mdx
@@ -1161,8 +1161,10 @@ export const app = s.defineApp(schema);
 
 ```tsx
 function Canvas({ canvasId }) {
-  const letters = useAll(app.letters.where({ canvasId }));
-  const cursors = useAll(app.cursors.where({ canvasId }).select("x", "y", "$createdBy"));
+  const { data: letters = [] } = useAll(app.letters.where({ canvasId }));
+  const { data: cursors = [] } = useAll(
+    app.cursors.where({ canvasId }).select("x", "y", "$createdBy"),
+  );
 
   return (
     <Stage>
@@ -1225,8 +1227,10 @@ export const app = s.defineApp(schema);
 
 ```tsx
 function Canvas({ canvasId }) {
-  const letters = useAll(app.letters.where({ canvasId }));
-  const cursors = useAll(app.cursors.where({ canvasId }).select("x", "y", "$createdBy"));
+  const { data: letters = [] } = useAll(app.letters.where({ canvasId }));
+  const { data: cursors = [] } = useAll(
+    app.cursors.where({ canvasId }).select("x", "y", "$createdBy"),
+  );
 
   return (
     <Stage>
@@ -1308,8 +1312,10 @@ export const app = s.defineApp(schema);
 
 ```tsx
 function Canvas({ canvasId }) {
-  const letters = useAll(app.letters.where({ canvasId }));
-  const cursors = useAll(app.cursors.where({ canvasId }).select("x", "y", "$createdBy"));
+  const { data: letters = [] } = useAll(app.letters.where({ canvasId }));
+  const { data: cursors = [] } = useAll(
+    app.cursors.where({ canvasId }).select("x", "y", "$createdBy"),
+  );
 
   return (
     <Stage>

--- a/docs/content/presentations/react-miami.mdx
+++ b/docs/content/presentations/react-miami.mdx
@@ -1461,8 +1461,10 @@ export const app = s.defineApp(schema);
 
 ```tsx
 function Canvas({ canvasId }) {
-  const letters = useAll(app.letters.where({ canvasId }));
-  const cursors = useAll(app.cursors.where({ canvasId }).select("x", "y", "$createdBy"));
+  const { data: letters = [] } = useAll(app.letters.where({ canvasId }));
+  const { data: cursors = [] } = useAll(
+    app.cursors.where({ canvasId }).select("x", "y", "$createdBy"),
+  );
 
   return (
     <Stage>
@@ -1525,8 +1527,10 @@ export const app = s.defineApp(schema);
 
 ```tsx
 function Canvas({ canvasId }) {
-  const letters = useAll(app.letters.where({ canvasId }));
-  const cursors = useAll(app.cursors.where({ canvasId }).select("x", "y", "$createdBy"));
+  const { data: letters = [] } = useAll(app.letters.where({ canvasId }));
+  const { data: cursors = [] } = useAll(
+    app.cursors.where({ canvasId }).select("x", "y", "$createdBy"),
+  );
 
   return (
     <Stage>
@@ -1608,8 +1612,10 @@ export const app = s.defineApp(schema);
 
 ```tsx
 function Canvas({ canvasId }) {
-  const letters = useAll(app.letters.where({ canvasId }));
-  const cursors = useAll(app.cursors.where({ canvasId }).select("x", "y", "$createdBy"));
+  const { data: letters = [] } = useAll(app.letters.where({ canvasId }));
+  const { data: cursors = [] } = useAll(
+    app.cursors.where({ canvasId }).select("x", "y", "$createdBy"),
+  );
 
   return (
     <Stage>

--- a/examples/auth-betterauth-chat/src/ChatPanel.tsx
+++ b/examples/auth-betterauth-chat/src/ChatPanel.tsx
@@ -30,13 +30,12 @@ export function ChatPanel({
   const session = useSession();
   const sessionUserId = session?.user_id ?? null;
 
-  const rows =
-    useAll(
-      app.messages
-        .where({ chat_id: chatId })
-        .select("id", "author_name", "text", "sent_at", "$canDelete")
-        .orderBy("sent_at", "asc"),
-    ) ?? [];
+  const { data: rows = [] } = useAll(
+    app.messages
+      .where({ chat_id: chatId })
+      .select("id", "author_name", "text", "sent_at", "$canDelete")
+      .orderBy("sent_at", "asc"),
+  );
 
   const [messageText, setMessageText] = React.useState("");
   const [messagePending, setMessagePending] = React.useState(false);

--- a/examples/auth-simple-chat/src/ChatPanel.tsx
+++ b/examples/auth-simple-chat/src/ChatPanel.tsx
@@ -30,13 +30,12 @@ export function ChatPanel({
   const session = useSession();
   const sessionUserId = session?.user_id ?? null;
 
-  const rows =
-    useAll(
-      app.messages
-        .where({ chat_id: chatId })
-        .select("id", "author_name", "text", "sent_at", "$canDelete")
-        .orderBy("sent_at", "asc"),
-    ) ?? [];
+  const { data: rows = [] } = useAll(
+    app.messages
+      .where({ chat_id: chatId })
+      .select("id", "author_name", "text", "sent_at", "$canDelete")
+      .orderBy("sent_at", "asc"),
+  );
 
   const [messageText, setMessageText] = React.useState("");
   const [messagePending, setMessagePending] = React.useState(false);

--- a/examples/auth-workos-chat/src/ChatPanel.tsx
+++ b/examples/auth-workos-chat/src/ChatPanel.tsx
@@ -30,13 +30,12 @@ export function ChatPanel({
   const session = useSession();
   const sessionUserId = session?.user_id ?? null;
 
-  const rows =
-    useAll(
-      app.messages
-        .where({ chat_id: chatId })
-        .select("id", "author_name", "text", "sent_at", "$canDelete")
-        .orderBy("sent_at", "asc"),
-    ) ?? [];
+  const { data: rows = [] } = useAll(
+    app.messages
+      .where({ chat_id: chatId })
+      .select("id", "author_name", "text", "sent_at", "$canDelete")
+      .orderBy("sent_at", "asc"),
+  );
 
   const [messageText, setMessageText] = React.useState("");
   const [messagePending, setMessagePending] = React.useState(false);

--- a/examples/chat-react/src/components/canvas/Canvas.tsx
+++ b/examples/chat-react/src/components/canvas/Canvas.tsx
@@ -39,10 +39,10 @@ export function CollaborativeCanvas({
   const myColor = userId ? colorFromUserId(userId) : "#000000";
 
   // Subscribe to the canvas row so it's present in the local runtime for FK checks
-  const canvasRows = useAll(app.canvases.where({ id: canvasId })) ?? [];
+  const { data: canvasRows = [] } = useAll(app.canvases.where({ id: canvasId }));
   const canvasReady = canvasRows.length > 0;
 
-  const profiles = useAll(app.profiles) ?? [];
+  const { data: profiles = [] } = useAll(app.profiles);
   const profileNameByUserId = useMemo(() => {
     const map = new Map<string, string>();
     const sorted = [...profiles].sort((a, b) => a.id.localeCompare(b.id));
@@ -55,7 +55,7 @@ export function CollaborativeCanvas({
   }, [profiles]);
 
   // Fetch all strokes for this canvas
-  const allStrokes = useAll(app.strokes.where({ canvasId })) ?? [];
+  const { data: allStrokes = [] } = useAll(app.strokes.where({ canvasId }));
 
   // Group strokes by ownerId
   const strokesByOwner: Record<string, StrokeData[]> = {};

--- a/examples/chat-react/src/components/chat-list/ChatList.tsx
+++ b/examples/chat-react/src/components/chat-list/ChatList.tsx
@@ -17,8 +17,9 @@ export const ChatList = () => {
 
   const myProfile = useMyProfile();
 
-  const memberships =
-    useAll(app.chatMembers.where({ userId: userId ?? "__none__" }).include({ chat: true })) ?? [];
+  const { data: memberships = [] } = useAll(
+    app.chatMembers.where({ userId: userId ?? "__none__" }).include({ chat: true }),
+  );
 
   const createPublicChat = async () => {
     if (!userId || !myProfile) return;

--- a/examples/chat-react/src/components/chat-view/ChatHeader.tsx
+++ b/examples/chat-react/src/components/chat-view/ChatHeader.tsx
@@ -24,7 +24,7 @@ export function ChatHeader({ chatId }: ChatHeaderProps) {
 function ChatHeaderContent({ chatId }: ChatHeaderProps) {
   const [settingsOpen, setSettingsOpen] = useState(false);
 
-  const chatRows = useAll(app.chats.where({ id: chatId })) ?? [];
+  const { data: chatRows = [] } = useAll(app.chats.where({ id: chatId }));
   const chat = chatRows[0];
 
   const displayName = useChatDisplayName(chatId, chat?.name ?? undefined);

--- a/examples/chat-react/src/components/chat-view/ChatSettings.tsx
+++ b/examples/chat-react/src/components/chat-view/ChatSettings.tsx
@@ -62,7 +62,7 @@ function ChatSettingsContent({
   const userId = session?.user_id ?? null;
   const [willShare, setWillShare] = useState(false);
 
-  const chatRows = useAll(app.chats.where({ id: chatId })) ?? [];
+  const { data: chatRows = [] } = useAll(app.chats.where({ id: chatId }));
   const chat = chatRows[0];
   const [draftName, setDraftName] = useState("");
 
@@ -70,8 +70,8 @@ function ChatSettingsContent({
     setDraftName(chat?.name ?? "");
   }, [chatId, chat?.name]);
 
-  const members = useAll(app.chatMembers.where({ chatId })) ?? [];
-  const allProfiles = useAll(app.profiles) ?? [];
+  const { data: members = [] } = useAll(app.chatMembers.where({ chatId }));
+  const { data: allProfiles = [] } = useAll(app.profiles);
 
   const memberUserIds = new Set(members.map((m) => m.userId));
   const memberProfiles = allProfiles.filter((p) => memberUserIds.has(p.userId));

--- a/examples/chat-react/src/components/chat-view/ChatView.tsx
+++ b/examples/chat-react/src/components/chat-view/ChatView.tsx
@@ -34,7 +34,7 @@ export const ChatView = ({ chatId }: ChatViewProps) => {
   // Auto-join: if the user can see the chat but isn't a member yet, insert a
   // chatMember row so they appear in the member list and can send messages.
   const { data: myMemberships = [] } = useAll(
-    app.chatMembers.where({ chatId, userId: userId ?? "__none__" }),
+    userId !== null ? app.chatMembers.where({ chatId, userId }) : undefined,
   );
   const isMember = myMemberships.length > 0;
   // autoJoinPending: true while we've started the insert but haven't yet

--- a/examples/chat-react/src/components/chat-view/ChatView.tsx
+++ b/examples/chat-react/src/components/chat-view/ChatView.tsx
@@ -28,13 +28,14 @@ export const ChatView = ({ chatId }: ChatViewProps) => {
   const [showNLastMessages, setShowNLastMessages] = useState(INITIAL_MESSAGES_TO_SHOW);
 
   const chatRowsResult = useAll(app.chats.where({ id: chatId }));
-  const chatRows = chatRowsResult ?? [];
+  const chatRows = chatRowsResult.data ?? [];
   const chatKnown = chatRows.length > 0;
 
   // Auto-join: if the user can see the chat but isn't a member yet, insert a
   // chatMember row so they appear in the member list and can send messages.
-  const myMemberships =
-    useAll(app.chatMembers.where({ chatId, userId: userId ?? "__none__" })) ?? [];
+  const { data: myMemberships = [] } = useAll(
+    app.chatMembers.where({ chatId, userId: userId ?? "__none__" }),
+  );
   const isMember = myMemberships.length > 0;
   // autoJoinPending: true while we've started the insert but haven't yet
   // received server acknowledgement.  Used to suppress the isMember shortcut
@@ -99,14 +100,13 @@ export const ChatView = ({ chatId }: ChatViewProps) => {
     }
   }, []);
 
-  const messages =
-    useAll(
-      app.messages
-        .where({ chatId })
-        .include({ sender: true })
-        .orderBy("createdAt", "desc")
-        .limit(showNLastMessages + 1),
-    ) ?? [];
+  const { data: messages = [] } = useAll(
+    app.messages
+      .where({ chatId })
+      .include({ sender: true })
+      .orderBy("createdAt", "desc")
+      .limit(showNLastMessages + 1),
+  );
 
   const hasMore = messages.length > showNLastMessages;
 
@@ -114,7 +114,7 @@ export const ChatView = ({ chatId }: ChatViewProps) => {
     db.delete(app.messages, messageId);
   };
 
-  if (chatRowsResult !== undefined && !chatKnown && userId) {
+  if (!chatRowsResult.isLoading && !chatKnown && userId) {
     return (
       <div className="flex-1 flex items-center justify-center p-8 text-center text-muted-foreground">
         <p>You don't have permission to access this chat.</p>

--- a/examples/chat-react/src/components/chat/ChatMessage.tsx
+++ b/examples/chat-react/src/components/chat/ChatMessage.tsx
@@ -41,10 +41,10 @@ export const ChatMessage = ({ message, sender, isMe, onDelete }: ChatMessageProp
   // Subscribe directly to the sender's profile so the name/avatar appears as
   // soon as the profile row syncs, even if the include in the parent query
   // fired before the profile was in the local store.
-  const senderProfiles = useAll(app.profiles.where({ id: message.senderId })) ?? [];
+  const { data: senderProfiles = [] } = useAll(app.profiles.where({ id: message.senderId }));
   const resolvedSender = (senderProfiles[0] as unknown as Profile) ?? sender;
 
-  const attachments = useAll(app.attachments.where({ messageId: message.id })) ?? [];
+  const { data: attachments = [] } = useAll(app.attachments.where({ messageId: message.id }));
 
   const canvasMatch = message.text?.match(/^\[Canvas: ([^\]]+)\]$/);
   const canvasId = canvasMatch?.[1] ?? null;

--- a/examples/chat-react/src/components/chat/ChatReactions.tsx
+++ b/examples/chat-react/src/components/chat/ChatReactions.tsx
@@ -5,7 +5,7 @@ import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/h
 import { app } from "../../../schema.js";
 
 function ReactorName({ userId, currentUserId }: { userId: string; currentUserId?: string }) {
-  const profiles = useAll(app.profiles.where({ userId })) ?? [];
+  const { data: profiles = [] } = useAll(app.profiles.where({ userId }));
   const profile = profiles[0];
 
   if (userId === currentUserId) return <li>You</li>;
@@ -92,7 +92,7 @@ export const MessageReactions = ({ messageId, isMe }: MessageReactionsProps) => 
   const session = useSession();
   const userId = session?.user_id;
 
-  const reactions = useAll(app.reactions.where({ messageId })) ?? [];
+  const { data: reactions = [] } = useAll(app.reactions.where({ messageId }));
 
   if (reactions.length === 0) return null;
 

--- a/examples/chat-react/src/hooks/useChatDisplayName.ts
+++ b/examples/chat-react/src/hooks/useChatDisplayName.ts
@@ -14,10 +14,11 @@ export function useChatDisplayName(chatId: string, chatName?: string): string {
   const session = useSession();
   const userId = session?.user_id ?? null;
 
-  const members = useAll(app.chatMembers.where({ chatId })) ?? [];
-  const allProfiles = useAll(app.profiles) ?? [];
-  const messages =
-    useAll(app.messages.where({ chatId }).orderBy("createdAt", "asc").limit(1)) ?? [];
+  const { data: members = [] } = useAll(app.chatMembers.where({ chatId }));
+  const { data: allProfiles = [] } = useAll(app.profiles);
+  const { data: messages = [] } = useAll(
+    app.messages.where({ chatId }).orderBy("createdAt", "asc").limit(1),
+  );
 
   if (chatName) return chatName;
 

--- a/examples/chat-react/src/hooks/useMyProfile.ts
+++ b/examples/chat-react/src/hooks/useMyProfile.ts
@@ -19,7 +19,7 @@ export function useMyProfile(): Profile | null {
   const userId = session?.user_id ?? null;
   const sharedWriteOptions = db.getConfig().serverUrl ? { tier: "edge" as const } : undefined;
 
-  const profiles = useAll(app.profiles.where({ userId: userId ?? "__none__" }));
+  const { data: profiles } = useAll(app.profiles.where({ userId: userId ?? "__none__" }));
 
   // Deterministic: always pick the first profile by ID
   const sorted = profiles ? [...profiles].sort((a, b) => a.id.localeCompare(b.id)) : [];

--- a/examples/chat-react/src/hooks/useMyProfile.ts
+++ b/examples/chat-react/src/hooks/useMyProfile.ts
@@ -19,14 +19,16 @@ export function useMyProfile(): Profile | null {
   const userId = session?.user_id ?? null;
   const sharedWriteOptions = db.getConfig().serverUrl ? { tier: "edge" as const } : undefined;
 
-  const { data: profiles } = useAll(app.profiles.where({ userId: userId ?? "__none__" }));
+  const { data: profiles = [] } = useAll(
+    userId !== null ? app.profiles.where({ userId }) : undefined,
+  );
 
   // Deterministic: always pick the first profile by ID
   const sorted = profiles ? [...profiles].sort((a, b) => a.id.localeCompare(b.id)) : [];
   const canonical = sorted[0] ?? null;
 
   useEffect(() => {
-    if (!userId || !profiles || profiles.length > 0 || createdForUser.has(userId)) return;
+    if (!userId || profiles.length > 0 || createdForUser.has(userId)) return;
     createdForUser.add(userId);
     const profile = { userId, name: getRandomUsername() };
     if (sharedWriteOptions) {

--- a/examples/chat-react/walkthrough/jazz-chat.md
+++ b/examples/chat-react/walkthrough/jazz-chat.md
@@ -293,7 +293,7 @@ Each reaction is a row. The query is live; toggling one is a synchronous insert 
 **[`src/components/chat/ChatReactions.tsx`](../src/components/chat/ChatReactions.tsx)**
 
 ```typescript
-const reactions = useAll(app.reactions.where({ messageId })) ?? [];
+const { data: reactions = [] } = useAll(app.reactions.where({ messageId }));
 
 const handleToggle = (emoji: string) => {
   const mine = reactions.find((r) => r.emoji === emoji && r.userId === userId);
@@ -341,7 +341,7 @@ Each chat can host shared drawing canvases. Strokes are rows synced in real time
 
 ```typescript
 // Live — re-renders whenever any stroke is added or removed
-const allStrokes = useAll(app.strokes.where({ canvasId })) ?? [];
+const { data: allStrokes = [] } = useAll(app.strokes.where({ canvasId }));
 
 // Clear your own strokes — policy enforces ownerId check server-side
 for (const s of allStrokes.filter((s) => s.ownerId === userId)) {

--- a/examples/docs/todo-client-localfirst-expo/src/ConditionalQueryExample.tsx
+++ b/examples/docs/todo-client-localfirst-expo/src/ConditionalQueryExample.tsx
@@ -6,7 +6,9 @@ import { app } from "../schema";
 // #region reading-conditional-query-expo
 export function FilteredTodos() {
   const [filter, setFilter] = useState<string | null>(null);
-  const filtered = useAll(filter ? app.todos.where({ title: { contains: filter } }) : undefined);
+  const { data: filtered } = useAll(
+    filter ? app.todos.where({ title: { contains: filter } }) : undefined,
+  );
 
   return (
     <View>

--- a/examples/docs/todo-client-localfirst-expo/src/LoadingStateExample.tsx
+++ b/examples/docs/todo-client-localfirst-expo/src/LoadingStateExample.tsx
@@ -4,10 +4,13 @@ import { app } from "../schema";
 
 // #region reading-loading-state-expo
 export function TodoList() {
-  const { data: todos = [], isLoading } = useAll(app.todos);
+  const { data: todos, isLoading, error } = useAll(app.todos);
 
   if (isLoading) {
     return <Text>Connecting…</Text>;
+  }
+  if (error) {
+    return <Text>Something went wrong!</Text>;
   }
   // todos is now Todo[]; empty array means no rows, not "still loading"
 

--- a/examples/docs/todo-client-localfirst-expo/src/LoadingStateExample.tsx
+++ b/examples/docs/todo-client-localfirst-expo/src/LoadingStateExample.tsx
@@ -4,12 +4,12 @@ import { app } from "../schema";
 
 // #region reading-loading-state-expo
 export function TodoList() {
-  const todos = useAll(app.todos);
+  const { data: todos = [], isLoading } = useAll(app.todos);
 
-  if (todos === undefined) {
+  if (isLoading) {
     return <Text>Connecting…</Text>;
   }
-  // todos is now Todo[] — empty array means no rows, not "still loading"
+  // todos is now Todo[]; empty array means no rows, not "still loading"
 
   return todos.map((todo) => <Text key={todo.id}>{todo.title}</Text>);
 }

--- a/examples/docs/todo-client-localfirst-expo/src/TodoItem.tsx
+++ b/examples/docs/todo-client-localfirst-expo/src/TodoItem.tsx
@@ -4,7 +4,8 @@ import { app } from "../schema";
 
 export function TodoItem({ id }: { id: string }) {
   const db = useDb();
-  const [todo] = useAll(app.todos.where({ id }).limit(1)) ?? [];
+  const { data: todos = [] } = useAll(app.todos.where({ id }).limit(1));
+  const [todo] = todos;
 
   if (!todo) return null;
 

--- a/examples/docs/todo-client-localfirst-expo/src/TodoList.tsx
+++ b/examples/docs/todo-client-localfirst-expo/src/TodoList.tsx
@@ -31,7 +31,7 @@ export function TodoList() {
 
   // #region reading-reactive-hooks-expo
   const db = useDb();
-  const todos = useAll(todosQuery) ?? [];
+  const { data: todos = [] } = useAll(todosQuery);
   const session = useSession();
   const sessionUserId = session?.user_id ?? null;
   // #endregion reading-reactive-hooks-expo

--- a/examples/docs/todo-client-localfirst-expo/src/quickstart-list.tsx
+++ b/examples/docs/todo-client-localfirst-expo/src/quickstart-list.tsx
@@ -5,7 +5,7 @@ import { TodoItem } from "./TodoItem";
 import { AddTodo } from "./AddTodo";
 
 export function TodoList() {
-  const todos = useAll(app.todos) ?? [];
+  const { data: todos = [] } = useAll(app.todos);
 
   return (
     <View style={{ flex: 1, gap: 12 }}>

--- a/examples/docs/todo-client-localfirst-react/src/AuthSessionExamples.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/AuthSessionExamples.tsx
@@ -13,8 +13,9 @@ export function AuthSessionExamples() {
   // #endregion auth-session-react-user-id
 
   // #region auth-session-react-query
-  const ownedTodos =
-    useAll(sessionUserId ? app.todos.where({ owner_id: sessionUserId }) : undefined) ?? [];
+  const { data: ownedTodos = [] } = useAll(
+    sessionUserId ? app.todos.where({ owner_id: sessionUserId }) : undefined,
+  );
   // #endregion auth-session-react-query
 
   // #region auth-session-react-insert

--- a/examples/docs/todo-client-localfirst-react/src/TodoItem.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/TodoItem.tsx
@@ -3,7 +3,8 @@ import { app } from "../schema.js";
 
 export function TodoItem({ id }: { id: string }) {
   const db = useDb();
-  const [todo] = useAll(app.todos.where({ id }).limit(1)) ?? [];
+  const { data: todos = [] } = useAll(app.todos.where({ id }).limit(1));
+  const [todo] = todos;
 
   if (!todo) return null;
 

--- a/examples/docs/todo-client-localfirst-react/src/TodoList.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/TodoList.tsx
@@ -24,7 +24,8 @@ export function TodoList() {
 
   // #region reading-loading-state-react
   const allTodos = useAll(app.todos);
-  // allTodos.isLoading is true while connecting; allTodos.data is [] when loaded but empty
+  // `allTodos.data` is `undefined` while loading the first result (and `allTodos.isLoading` is `true`).
+  // `allTodos.data` is `[]` when loaded but empty
   // #endregion reading-loading-state-react
 
   // #region reading-conditional-query-react

--- a/examples/docs/todo-client-localfirst-react/src/TodoList.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/TodoList.tsx
@@ -6,10 +6,10 @@ import { app } from "../schema.js";
 export function TodoList() {
   // #region read-write-react
   const db = useDb();
-  const todos = useAll(app.todos) ?? [];
+  const { data: todos = [] } = useAll(app.todos);
   // #endregion reading-reactive-hooks-react
   // #region reading-filtering-react
-  const incompleteTodos = useAll(
+  const { data: incompleteTodos } = useAll(
     app.todos.where({ done: false }).orderBy("title", "asc").limit(50),
   );
   // #endregion reading-filtering-react
@@ -24,12 +24,14 @@ export function TodoList() {
 
   // #region reading-loading-state-react
   const allTodos = useAll(app.todos);
-  // allTodos is undefined while connecting, [] when loaded but empty
+  // allTodos.isLoading is true while connecting; allTodos.data is [] when loaded but empty
   // #endregion reading-loading-state-react
 
   // #region reading-conditional-query-react
   const [filter, setFilter] = useState<string | null>(null);
-  const filtered = useAll(filter ? app.todos.where({ title: { contains: filter } }) : undefined);
+  const { data: filtered } = useAll(
+    filter ? app.todos.where({ title: { contains: filter } }) : undefined,
+  );
   // #endregion reading-conditional-query-react
 
   // #region writing-use-db-react
@@ -56,7 +58,7 @@ export function TodoList() {
     setTitle("");
   };
 
-  if (allTodos === undefined) {
+  if (allTodos.isLoading) {
     return <p>Connecting…</p>;
   }
 

--- a/examples/docs/todo-client-localfirst-react/src/collab-list-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/collab-list-snippets.tsx
@@ -64,9 +64,11 @@ s.definePermissions(app, ({ policy, anyOf, allowedTo, session }) => {
 // #region collab-subscribe
 export function ProjectTasks({ projectId }: { projectId: string }) {
   const db = useDb();
-  const { data: tasks = [], isLoading } = useAll(
-    app.tasks.where({ projectId, done: false }).orderBy("$createdAt", "desc"),
-  );
+  const {
+    data: tasks,
+    isLoading,
+    error,
+  } = useAll(app.tasks.where({ projectId, done: false }).orderBy("$createdAt", "desc"));
 
   function addTask(title: string) {
     db.insert(app.tasks, { title, done: false, projectId });
@@ -77,6 +79,7 @@ export function ProjectTasks({ projectId }: { projectId: string }) {
   }
 
   if (isLoading) return <p>Loading…</p>;
+  if (error) return <p>Something went wrong!</p>;
 
   return (
     <ul>

--- a/examples/docs/todo-client-localfirst-react/src/collab-list-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/collab-list-snippets.tsx
@@ -64,7 +64,9 @@ s.definePermissions(app, ({ policy, anyOf, allowedTo, session }) => {
 // #region collab-subscribe
 export function ProjectTasks({ projectId }: { projectId: string }) {
   const db = useDb();
-  const tasks = useAll(app.tasks.where({ projectId, done: false }).orderBy("$createdAt", "desc"));
+  const { data: tasks = [], isLoading } = useAll(
+    app.tasks.where({ projectId, done: false }).orderBy("$createdAt", "desc"),
+  );
 
   function addTask(title: string) {
     db.insert(app.tasks, { title, done: false, projectId });
@@ -74,7 +76,7 @@ export function ProjectTasks({ projectId }: { projectId: string }) {
     db.update(app.tasks, taskId, { done: true });
   }
 
-  if (!tasks) return <p>Loading…</p>;
+  if (isLoading) return <p>Loading…</p>;
 
   return (
     <ul>

--- a/examples/docs/todo-client-localfirst-react/src/framework-pattern-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/framework-pattern-snippets.tsx
@@ -22,10 +22,10 @@ export function ProviderExample() {
 
 // #region live-query-react
 export function LiveQueryExample() {
-  const todos = useAll(app.todos.where({ done: false }));
+  const { data: todos = [], isLoading } = useAll(app.todos.where({ done: false }));
 
-  // undefined = not yet connected; [] = connected, no rows; [...] = rows present
-  if (todos === undefined) return <p>Loading...</p>;
+  // isLoading = not yet connected; [] = connected, no rows; [...] = rows present
+  if (isLoading) return <p>Loading...</p>;
 
   return (
     <ul>

--- a/examples/docs/todo-client-localfirst-react/src/framework-pattern-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/framework-pattern-snippets.tsx
@@ -22,10 +22,10 @@ export function ProviderExample() {
 
 // #region live-query-react
 export function LiveQueryExample() {
-  const { data: todos = [], isLoading } = useAll(app.todos.where({ done: false }));
+  const { data: todos, isLoading, error } = useAll(app.todos.where({ done: false }));
 
-  // isLoading = not yet connected; [] = connected, no rows; [...] = rows present
   if (isLoading) return <p>Loading...</p>;
+  if (error) return <p>Something went wrong!</p>;
 
   return (
     <ul>

--- a/examples/docs/todo-client-localfirst-react/src/group-permissions-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/group-permissions-snippets.tsx
@@ -122,9 +122,9 @@ export function addMember(
 
 // #region group-query-docs
 export function WorkspaceDocuments({ workspaceId }: { workspaceId: string }) {
-  const docs = useAll(app.documents.where({ workspaceId }));
+  const { data: docs = [], isLoading } = useAll(app.documents.where({ workspaceId }));
 
-  if (!docs) return <p>Loading…</p>;
+  if (isLoading) return <p>Loading…</p>;
 
   return (
     <ul>
@@ -138,9 +138,9 @@ export function WorkspaceDocuments({ workspaceId }: { workspaceId: string }) {
 
 // #region group-members-list
 export function WorkspaceMembers({ workspaceId }: { workspaceId: string }) {
-  const members = useAll(app.workspaceMembers.where({ workspaceId }));
+  const { data: members = [], isLoading } = useAll(app.workspaceMembers.where({ workspaceId }));
 
-  if (!members) return <p>Loading…</p>;
+  if (isLoading) return <p>Loading…</p>;
 
   return (
     <ul>

--- a/examples/docs/todo-client-localfirst-react/src/group-permissions-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/group-permissions-snippets.tsx
@@ -122,9 +122,10 @@ export function addMember(
 
 // #region group-query-docs
 export function WorkspaceDocuments({ workspaceId }: { workspaceId: string }) {
-  const { data: docs = [], isLoading } = useAll(app.documents.where({ workspaceId }));
+  const { data: docs, isLoading, error } = useAll(app.documents.where({ workspaceId }));
 
   if (isLoading) return <p>Loading…</p>;
+  if (error) return <p>Something went wrong!</p>;
 
   return (
     <ul>

--- a/examples/docs/todo-client-localfirst-react/src/nested-data-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/nested-data-snippets.tsx
@@ -45,9 +45,11 @@ s.definePermissions(app, ({ policy, allowedTo, session }) => {
 
 // #region nested-query
 export function ProjectTasks({ projectId }: { projectId: string }) {
-  const tasks = useAll(app.tasks.where({ projectId }).orderBy("$createdAt", "desc"));
+  const { data: tasks = [], isLoading } = useAll(
+    app.tasks.where({ projectId }).orderBy("$createdAt", "desc"),
+  );
 
-  if (!tasks) return <p>Loading…</p>;
+  if (isLoading) return <p>Loading…</p>;
 
   return (
     <ul>

--- a/examples/docs/todo-client-localfirst-react/src/nested-data-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/nested-data-snippets.tsx
@@ -45,11 +45,14 @@ s.definePermissions(app, ({ policy, allowedTo, session }) => {
 
 // #region nested-query
 export function ProjectTasks({ projectId }: { projectId: string }) {
-  const { data: tasks = [], isLoading } = useAll(
-    app.tasks.where({ projectId }).orderBy("$createdAt", "desc"),
-  );
+  const {
+    data: tasks,
+    isLoading,
+    error,
+  } = useAll(app.tasks.where({ projectId }).orderBy("$createdAt", "desc"));
 
   if (isLoading) return <p>Loading…</p>;
+  if (error) return <p>Something went wrong!</p>;
 
   return (
     <ul>

--- a/examples/docs/todo-client-localfirst-react/src/quickstart-list.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/quickstart-list.tsx
@@ -4,7 +4,7 @@ import { TodoItem } from "./TodoItem.js";
 import { AddTodo } from "./AddTodo.js";
 
 export function TodoList() {
-  const todos = useAll(app.todos) ?? [];
+  const { data: todos = [] } = useAll(app.todos);
 
   return (
     <>

--- a/examples/docs/todo-client-localfirst-react/src/shared-access-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/shared-access-snippets.tsx
@@ -75,11 +75,14 @@ export function shareTodo(db: ReturnType<typeof useDb>, todoId: string, recipien
 // #region shared-query
 export function SharedWithMe() {
   const session = useSession();
-  const { data: shares = [], isLoading } = useAll(
-    app.todoShares.where({ user_id: session!.user_id }).include({ todo: true }),
-  );
+  const {
+    data: shares,
+    isLoading,
+    error,
+  } = useAll(app.todoShares.where({ user_id: session!.user_id }).include({ todo: true }));
 
   if (isLoading) return <p>Loading…</p>;
+  if (error) return <p>Something went wrong!</p>;
 
   return (
     <ul>

--- a/examples/docs/todo-client-localfirst-react/src/shared-access-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/shared-access-snippets.tsx
@@ -75,11 +75,11 @@ export function shareTodo(db: ReturnType<typeof useDb>, todoId: string, recipien
 // #region shared-query
 export function SharedWithMe() {
   const session = useSession();
-  const shares = useAll(
+  const { data: shares = [], isLoading } = useAll(
     app.todoShares.where({ user_id: session!.user_id }).include({ todo: true }),
   );
 
-  if (!shares) return <p>Loading…</p>;
+  if (isLoading) return <p>Loading…</p>;
 
   return (
     <ul>

--- a/examples/docs/todo-client-localfirst-react/src/user-owned-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/user-owned-snippets.tsx
@@ -24,9 +24,9 @@ s.definePermissions(app, ({ policy, session }) => {
 
 // #region owned-query
 export function MyTodos() {
-  const todos = useAll(app.todos.where({ done: false }));
+  const { data: todos = [], isLoading } = useAll(app.todos.where({ done: false }));
 
-  if (!todos) return <p>Loading…</p>;
+  if (isLoading) return <p>Loading…</p>;
 
   return (
     <ul>

--- a/examples/docs/todo-client-localfirst-react/src/user-owned-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/user-owned-snippets.tsx
@@ -24,9 +24,10 @@ s.definePermissions(app, ({ policy, session }) => {
 
 // #region owned-query
 export function MyTodos() {
-  const { data: todos = [], isLoading } = useAll(app.todos.where({ done: false }));
+  const { data: todos, isLoading, error } = useAll(app.todos.where({ done: false }));
 
   if (isLoading) return <p>Loading…</p>;
+  if (error) return <p>Something went wrong!</p>;
 
   return (
     <ul>

--- a/examples/file-upload-react/src/App.tsx
+++ b/examples/file-upload-react/src/App.tsx
@@ -57,18 +57,17 @@ function FileUploadScreen() {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const db = useDb();
   const session = useSession();
-  const uploads =
-    useAll(
-      app.uploads
-        .include({
-          file: {
-            parts: true,
-          },
-        })
-        .orderBy("lastModified", "desc")
-        .limit(1)
-        .requireIncludes(),
-    ) ?? [];
+  const { data: uploads = [] } = useAll(
+    app.uploads
+      .include({
+        file: {
+          parts: true,
+        },
+      })
+      .orderBy("lastModified", "desc")
+      .limit(1)
+      .requireIncludes(),
+  );
   const latestUpload = uploads[0];
   const [objectUrl, setObjectUrl] = useState<string | null>(null);
 

--- a/examples/moon-lander-react/src/jazz/useSync.ts
+++ b/examples/moon-lander-react/src/jazz/useSync.ts
@@ -66,7 +66,6 @@ export function useSync(playerId: string): SyncResult {
 
   // ---------------------------------------------------------------------------
   // Subscriptions — useAll streams live results from the server.
-  // isLoading = not yet settled (subscription hasn't received its first result).
   // ---------------------------------------------------------------------------
 
   // Other players (exclude self)

--- a/examples/moon-lander-react/src/jazz/useSync.ts
+++ b/examples/moon-lander-react/src/jazz/useSync.ts
@@ -66,22 +66,22 @@ export function useSync(playerId: string): SyncResult {
 
   // ---------------------------------------------------------------------------
   // Subscriptions — useAll streams live results from the server.
-  // undefined = not yet settled (subscription hasn't received its first result).
+  // isLoading = not yet settled (subscription hasn't received its first result).
   // ---------------------------------------------------------------------------
 
   // Other players (exclude self)
-  const allRemotePlayers = useAll(app.players.where({ playerId: { ne: playerId } })) ?? [];
+  const { data: allRemotePlayers = [] } = useAll(app.players.where({ playerId: { ne: playerId } }));
   const remotePlayers = useMemo(
     () => allRemotePlayers.filter((p) => p.lastSeen > staleCutoff),
     [allRemotePlayers, staleCutoff],
   );
 
   // Chat messages (ordered oldest-first for rendering)
-  const allChatMessages = useAll(app.chat_messages.orderBy("createdAt", "asc")) ?? [];
+  const { data: allChatMessages = [] } = useAll(app.chat_messages.orderBy("createdAt", "asc"));
 
   // Local player row — used to detect first join (no row yet) vs reconnect
-  const localPlayerRowsRaw = useAll(app.players.where({ playerId }));
-  const localPlayerRows = localPlayerRowsRaw ?? [];
+  const localPlayerRowsResult = useAll(app.players.where({ playerId }));
+  const localPlayerRows = localPlayerRowsResult.data ?? [];
   const localFuelType = localPlayerRows[0]?.requiredFuelType ?? FUEL_TYPES[0];
 
   // Per-type deposit limits: base + 1 extra for each player whose required type
@@ -99,12 +99,12 @@ export function useSync(playerId: string): SyncResult {
   }, [remotePlayers, localFuelType]);
 
   // Uncollected deposits — what the game renders on the surface.
-  // "edge" tier: undefined until the edge subscription connects, which drives settled detection.
+  // "edge" tier: loading until the edge subscription connects, which drives settled detection.
   const allUncollected = useAll(app.fuel_deposits.where({ collected: false }), { tier: "edge" });
 
   // This player's collected deposits (compound WHERE = precise local tracking).
   // WHERE ENTRY fires immediately when this player collects (both fields match).
-  const localCollectedDeposits = useAll(
+  const { data: localCollectedDeposits = [] } = useAll(
     app.fuel_deposits.where({ collected: true, collectedBy: playerId }),
   );
 
@@ -112,17 +112,17 @@ export function useSync(playerId: string): SyncResult {
   // other players. When Player A shares with B, B already has the row here
   // (it entered when A collected it), so collectedBy updating to B propagates
   // as a plain row update without needing WHERE re-evaluation.
-  const allCollectedDeposits = useAll(app.fuel_deposits.where({ collected: true }));
+  const { data: allCollectedDeposits = [] } = useAll(app.fuel_deposits.where({ collected: true }));
 
-  const settled = allUncollected !== undefined;
-  const uncollectedDeposits = allUncollected ?? [];
-  const myCollectedDeposits = localCollectedDeposits ?? [];
+  const settled = !allUncollected.isLoading;
+  const uncollectedDeposits = allUncollected.data ?? [];
+  const myCollectedDeposits = localCollectedDeposits;
 
   // Merge local + broad collected subscriptions so received shares show in inventory
   const effectiveMyCollected = useMemo(() => {
     const map = new Map<string, FuelDeposit>();
     for (const d of myCollectedDeposits) map.set(d.id, d);
-    for (const d of (allCollectedDeposits ?? []).filter((d) => d.collectedBy === playerId)) {
+    for (const d of allCollectedDeposits.filter((d) => d.collectedBy === playerId)) {
       map.set(d.id, d);
     }
     return [...map.values()] as FuelDeposit[];
@@ -174,7 +174,6 @@ export function useSync(playerId: string): SyncResult {
   );
 
   const chatMessages = useMemo(() => {
-    if (!allChatMessages) return [];
     const nowS = Math.floor(Date.now() / 1000);
     return allChatMessages.filter((m) => nowS - m.createdAt < 60);
   }, [allChatMessages]);
@@ -190,7 +189,7 @@ export function useSync(playerId: string): SyncResult {
 
   sync.setInputs({
     settled,
-    localPlayerSettled: localPlayerRowsRaw !== undefined,
+    localPlayerSettled: !localPlayerRowsResult.isLoading,
     uncollectedDeposits,
     myCollectedDeposits: effectiveMyCollected,
     allDepositsRaw,
@@ -216,7 +215,7 @@ export function useSync(playerId: string): SyncResult {
 
     syncInputs: sync.inputs,
     remotePlayerCount: remotePlayers.length,
-    chatMessageCount: allChatMessages?.length ?? 0,
+    chatMessageCount: allChatMessages.length,
     gameState: sync.latestState,
   };
 }

--- a/examples/moon-lander-react/walkthrough/jazz-moon-lander.md
+++ b/examples/moon-lander-react/walkthrough/jazz-moon-lander.md
@@ -154,17 +154,17 @@ import { useAll, useDb } from "jazz-tools/react";
 
 export function useSync(playerId: string): SyncResult {
   // Other players' positions, modes, fuel levels (live from the server)
-  const remotePlayers = useAll(
+  const { data: remotePlayers = [] } = useAll(
     app.players.where({ playerId: { ne: playerId } }),
   );
 
   // Deposits on the surface (drives the game's collectible objects)
-  const uncollectedDeposits = useAll(
+  const { data: uncollectedDeposits = [] } = useAll(
     app.fuel_deposits.where({ collected: false }),
   );
 
   // Chat messages, newest-last
-  const chatMessages = useAll(
+  const { data: chatMessages = [] } = useAll(
     app.chat_messages.orderBy("createdAt", "asc"),
   );
   ...
@@ -180,10 +180,11 @@ Results stream from the sync server. When any client writes, every subscriber re
 The first `useAll` result may arrive before all remote data has synced. Moon Lander uses a `settled` flag to delay game setup until the edge subscription has delivered its initial payload.
 
 ```typescript
-// "edge" tier: undefined = still connecting to server; [] or [...] = server has responded
-const allUncollected = useAll(app.fuel_deposits.where({ collected: false }), "edge");
+// "edge" tier: isLoading = still connecting to server; data = [] or [...] once the server responds
+const allUncollected = useAll(app.fuel_deposits.where({ collected: false }), { tier: "edge" });
 
-const settled = allUncollected !== undefined;
+const settled = !allUncollected.isLoading;
+const uncollectedDeposits = allUncollected.data ?? [];
 ```
 
 `settled` gates two things:
@@ -395,7 +396,7 @@ Every other client's `useAll(app.players.where({ playerId: { ne: myId } }))` sub
 | ---------------------------- | ---------------------------------------------------------------------------- |
 | `JazzProvider`               | Wrap the app; handles WASM worker + OPFS + sync internally                   |
 | `useDb()`                    | Access the db write API from any component                                   |
-| `useAll(query, tier?)`       | Live subscription; re-renders on every remote or local change                |
+| `useAll(query, options?)`    | Live subscription; re-renders on every remote or local change                |
 | `db.insert(table, data)`     | Eventually consistent insert. Instant local update, propagates in background |
 | `db.update(table, id, data)` | Eventually consistent update. Instant local update, propagates in background |
 | `db.delete(table, id)`       | Eventually consistent delete. Used before re-inserting a released deposit    |

--- a/examples/nextjs-csr-ssr/app/ClientTodo.tsx
+++ b/examples/nextjs-csr-ssr/app/ClientTodo.tsx
@@ -30,7 +30,7 @@ export default function ClientTodo() {
 }
 
 function TodoList() {
-  const todos = useAll(app.todos) ?? [];
+  const { data: todos = [] } = useAll(app.todos);
   return (
     <ul className="mt-4 space-y-1">
       {todos.length === 0 && <li className="text-sm text-foreground/30 italic">No todos yet.</li>}

--- a/examples/todo-client-localfirst-expo/src/TodoList.tsx
+++ b/examples/todo-client-localfirst-expo/src/TodoList.tsx
@@ -42,7 +42,7 @@ export function TodoList() {
   }
 
   const db = useDb();
-  const todos = useAll(todosQuery) ?? [];
+  const { data: todos = [] } = useAll(todosQuery);
   const session = useSession();
   const sessionUserId = session?.user_id ?? null;
 

--- a/examples/todo-client-localfirst-react/src/TodoList.tsx
+++ b/examples/todo-client-localfirst-react/src/TodoList.tsx
@@ -17,7 +17,7 @@ export function TodoList() {
 
   const db = useDb();
   // #region reading-reactive-hooks-react
-  const todos = useAll(todosQuery) ?? [];
+  const { data: todos = [] } = useAll(todosQuery);
   // #endregion reading-reactive-hooks-react
   const session = useSession();
   const sessionUserId = session?.user_id ?? null;

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
@@ -169,18 +169,24 @@ describe("TableDataGrid", () => {
           : null;
 
       if (!builtQuery || builtQuery.table === "todos") {
-        return currentRows;
+        return { data: currentRows, isLoading: false, error: null };
       }
 
       const tableRows = currentReferenceRowsByTable[builtQuery.table] ?? [];
-      return tableRows.filter((row) =>
-        builtQuery.conditions.every((condition: { column: string; op: string; value: unknown }) => {
-          if (condition.op !== "eq") {
-            return true;
-          }
-          return row[condition.column] === condition.value;
-        }),
-      );
+      return {
+        data: tableRows.filter((row) =>
+          builtQuery.conditions.every(
+            (condition: { column: string; op: string; value: unknown }) => {
+              if (condition.op !== "eq") {
+                return true;
+              }
+              return row[condition.column] === condition.value;
+            },
+          ),
+        ),
+        isLoading: false,
+        error: null,
+      };
     });
   });
 

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
@@ -1473,7 +1473,7 @@ function RelationCell({
     () => new GenericQueryBuilder(relationTable, schema).where({ id: relationId }).limit(1),
     [relationId, relationTable, schema],
   );
-  const relationRows = useAll<DynamicTableRow>(queryBuilder, queryOptions) ?? EMPTY_ROWS;
+  const { data: relationRows = EMPTY_ROWS } = useAll<DynamicTableRow>(queryBuilder, queryOptions);
   const relationRow = relationRows[0];
   const displayColumn = useMemo(
     () => getRelationDisplayColumn(schema, relationTable),

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
@@ -722,12 +722,10 @@ export function TableDataGrid() {
       }) as const,
     [runtime],
   );
-  // `undefined` means the live query hasn't resolved yet (loading); `[]` means
-  // it resolved and is genuinely empty. Keep them apart so the grid can
-  // show a skeleton while the first result is in flight.
   const queryResult = useAll<DynamicTableRow>(queryBuilder, queryOptions);
-  const isInitialLoading = queryResult === undefined;
-  const rows = queryResult ?? EMPTY_ROWS;
+  // show a grid skeleton while the first result is in flight.
+  const isInitialLoading = queryResult.isLoading;
+  const rows = queryResult.data ?? EMPTY_ROWS;
 
   const gridColumns = useMemo<GridColumn[]>(
     () => [

--- a/packages/jazz-tools/src/react-core/index.ts
+++ b/packages/jazz-tools/src/react-core/index.ts
@@ -8,7 +8,7 @@ export {
   type JazzClientProviderProps,
   type JazzProviderProps,
 } from "./provider.js";
-export { useAll, useAllSuspense } from "./use-all.js";
+export { useAll, useAllSuspense, type UseAllResult } from "./use-all.js";
 export { useAuthState, type AuthStateInfo } from "./use-auth-state.js";
 export { useLocalFirstAuthWithStore, type LocalFirstAuth } from "./use-local-first-auth.js";
 

--- a/packages/jazz-tools/src/react-core/use-all.test.tsx
+++ b/packages/jazz-tools/src/react-core/use-all.test.tsx
@@ -101,6 +101,44 @@ describe("react-core/useAll", () => {
     expect(subscribeCalls).toHaveLength(0);
   });
 
+  it("keeps result object identity stable while the state is unchanged", () => {
+    const { client, subscribeCalls } = makeHarness("rc-all-stable-identity");
+    const noQueryResults: NoQueryResult[] = [];
+    const queryResults: UseAllResult<Todo>[] = [];
+    let force!: (n: number) => void;
+
+    function Probe() {
+      const [, setN] = useState(0);
+      force = setN;
+      noQueryResults.push(useAll<Todo>());
+      queryResults.push(useAll(makeQuery()));
+      return null;
+    }
+
+    render(
+      <JazzClientProvider client={client}>
+        <Probe />
+      </JazzClientProvider>,
+    );
+
+    const initialNoQuery = noQueryResults[0]!;
+    const initialLoading = queryResults[0]!;
+
+    act(() => force(1));
+
+    expect(noQueryResults.at(-1)).toBe(initialNoQuery);
+    expect(queryResults.at(-1)).toBe(initialLoading);
+
+    act(() => subscribeCalls[0]!.callback(delta([{ id: "1", title: "first" }])));
+
+    const fulfilled = queryResults.at(-1)!;
+    expect(fulfilled.data).toEqual([{ id: "1", title: "first" }]);
+
+    act(() => force(2));
+
+    expect(queryResults.at(-1)).toBe(fulfilled);
+  });
+
   it("an inline query does not resubscribe across re-renders", () => {
     const { client, subscribeCalls } = makeHarness("rc-all-01");
     let force!: (n: number) => void;

--- a/packages/jazz-tools/src/react-core/use-all.test.tsx
+++ b/packages/jazz-tools/src/react-core/use-all.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Component, Suspense, useState, type ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { act, cleanup, render } from "@testing-library/react";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { QueryBuilder } from "../runtime/db.js";
 import type { SubscriptionDelta } from "../runtime/subscription-manager.js";
@@ -97,7 +97,7 @@ describe("react-core/useAll", () => {
     const { client, subscribeCalls } = makeHarness("rc-all-02");
 
     function List() {
-      const todos = useAll(makeQuery());
+      const { data: todos } = useAll(makeQuery());
       return (
         <>
           {(todos ?? []).map((t) => (
@@ -133,7 +133,7 @@ describe("react-core/useAll", () => {
     const { client, subscribeCalls } = makeHarness("rc-all-03");
 
     function List() {
-      const todos = useAll(makeQuery());
+      const { data: todos } = useAll(makeQuery());
       return <span>{(todos ?? []).length}</span>;
     }
 
@@ -154,7 +154,7 @@ describe("react-core/useAll", () => {
     manager.makeQueryKey(query, undefined, [{ id: "1", title: "seeded" }]);
 
     function List() {
-      const todos = useAll(query);
+      const { data: todos } = useAll(query);
       return (
         <>
           {(todos ?? []).map((t) => (
@@ -174,14 +174,18 @@ describe("react-core/useAll", () => {
     expect(subscribeCalls).toHaveLength(0);
   });
 
-  it("a failed subscription leaves non-suspense useAll undefined and does not throw", () => {
+  it("a failed subscription surfaces a non-suspense useAll error and does not throw", async () => {
     const { client } = makeHarness("rc-all-05", {
       throwOnSubscribe: new Error("subscribe failed"),
     });
 
     function List() {
-      const todos = useAll(makeQuery());
-      return <span>{todos === undefined ? "no-data" : String(todos.length)}</span>;
+      const result = useAll(makeQuery());
+      return (
+        <span>
+          {result.error?.message ?? (result.isLoading ? "loading" : String(result.data?.length))}
+        </span>
+      );
     }
 
     const { container } = render(
@@ -190,7 +194,7 @@ describe("react-core/useAll", () => {
       </JazzClientProvider>,
     );
 
-    expect(container.textContent).toBe("no-data");
+    await waitFor(() => expect(container.textContent).toBe("subscribe failed"));
   });
 
   it("useAllSuspense throws a failed subscription to the error boundary", () => {

--- a/packages/jazz-tools/src/react-core/use-all.test.tsx
+++ b/packages/jazz-tools/src/react-core/use-all.test.tsx
@@ -214,7 +214,11 @@ describe("react-core/useAll", () => {
       const result = useAll(makeQuery());
       return (
         <span>
-          {result.error?.message ?? (result.isLoading ? "loading" : String(result.data?.length))}
+          {result.error
+            ? result.error.message
+            : result.isLoading
+              ? "loading"
+              : String(result.data.length)}
         </span>
       );
     }

--- a/packages/jazz-tools/src/react-core/use-all.test.tsx
+++ b/packages/jazz-tools/src/react-core/use-all.test.tsx
@@ -1,15 +1,16 @@
 import * as React from "react";
 import { Component, Suspense, useState, type ReactNode } from "react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { QueryBuilder } from "../runtime/db.js";
 import type { SubscriptionDelta } from "../runtime/subscription-manager.js";
 import { SubscriptionsOrchestrator } from "../subscriptions-orchestrator.js";
 import { JazzClientProvider } from "./provider.js";
-import { useAll, useAllSuspense } from "./use-all.js";
+import { useAll, useAllSuspense, type UseAllResult } from "./use-all.js";
 
 type Todo = { id: string; title: string };
+type NoQueryResult = { data: undefined; isLoading: false; error: null };
 
 function makeQuery(table = "todos"): QueryBuilder<Todo> {
   return {
@@ -70,6 +71,36 @@ afterEach(() => {
 });
 
 describe("react-core/useAll", () => {
+  it("returns no result when no query is provided", () => {
+    if ((globalThis as { __typecheck_only__?: boolean }).__typecheck_only__) {
+      expectTypeOf(useAll<Todo>()).toEqualTypeOf<NoQueryResult>();
+      expectTypeOf(useAll<Todo>(undefined)).toEqualTypeOf<NoQueryResult>();
+
+      const maybeQuery = makeQuery() as QueryBuilder<Todo> | undefined;
+      expectTypeOf(useAll(maybeQuery)).toEqualTypeOf<UseAllResult<Todo> | NoQueryResult>();
+    }
+  });
+
+  it("returns no result without subscribing when no query is provided", () => {
+    const { client, subscribeCalls } = makeHarness("rc-all-00");
+    let result: NoQueryResult | undefined;
+
+    function Probe() {
+      result = useAll<Todo>();
+      return <span>{result.isLoading ? "loading" : "idle"}</span>;
+    }
+
+    const { container } = render(
+      <JazzClientProvider client={client}>
+        <Probe />
+      </JazzClientProvider>,
+    );
+
+    expect(container.textContent).toBe("idle");
+    expect(result).toEqual({ data: undefined, isLoading: false, error: null });
+    expect(subscribeCalls).toHaveLength(0);
+  });
+
   it("an inline query does not resubscribe across re-renders", () => {
     const { client, subscribeCalls } = makeHarness("rc-all-01");
     let force!: (n: number) => void;

--- a/packages/jazz-tools/src/react-core/use-all.ts
+++ b/packages/jazz-tools/src/react-core/use-all.ts
@@ -6,17 +6,27 @@ type UseAllOptions = {
   suspense?: boolean;
 };
 
+export type UseAllResult<T extends { id: string }> = {
+  data: T[] | undefined;
+  isLoading: boolean;
+  error: Error | null;
+};
+
 // A query that never arrives has nothing to fetch, so the suspense variant
 // suspends on this until one is supplied on a later render (the boundary shows
 // its fallback meanwhile). Distinct from a pending real query, which suspends on
 // its entry promise — opened during render so a suspended effect can't strand it.
 const SUSPEND_FOREVER: Promise<never> = new Promise(() => {});
 
+function toError(value: unknown): Error {
+  return value instanceof Error ? value : new Error(String(value));
+}
+
 function useAllBase<T extends { id: string }>(
   query?: QueryBuilder<T>,
   queryOptions?: QueryOptions,
   options?: UseAllOptions,
-): T[] | undefined {
+): T[] | UseAllResult<T> {
   const { suspense = false } = options ?? {};
   const { manager } = useJazzClient();
 
@@ -89,27 +99,38 @@ function useAllBase<T extends { id: string }>(
     return use(entry.promise as unknown as Usable<T[]>);
   }
 
-  return state?.status === "fulfilled" ? state.data : undefined;
+  if (!query || key === null) {
+    return { data: undefined, isLoading: false, error: null };
+  }
+
+  if (state?.status === "fulfilled") {
+    return { data: state.data, isLoading: false, error: null };
+  }
+
+  if (state?.status === "rejected") {
+    return { data: undefined, isLoading: false, error: toError(state.error) };
+  }
+
+  return { data: undefined, isLoading: true, error: null };
 }
 
 /**
  * Read all matching rows and subscribe to changes that modify the query's results.
  *
- * Loading and error states are handled the React way: `undefined` means the
- * query has not resolved yet, and for error handling use {@link useAllSuspense}
- * with a Suspense + error boundary. (The Svelte and Vue bindings expose the same
- * capabilities idiomatically — Svelte's `QuerySubscription` via
- * `.current`/`.loading`/`.error`, Vue's `useAll` via `{ data, error, loading }`.)
+ * Loading and error states are returned alongside the rows, matching the other
+ * framework bindings. Use {@link useAllSuspense} when you want loading and
+ * errors to flow through Suspense and an error boundary instead.
  *
  * @param query - the database query (e.g. `app.todos.where({done: false})`)
  *
- * @returns the matching rows, or `undefined` if the query is not yet executed
+ * @returns `{ data, isLoading, error }`. `data` is `undefined` until the query
+ *   resolves or if the query fails.
  */
 export function useAll<T extends { id: string }>(
   query?: QueryBuilder<T>,
   options?: QueryOptions,
-): T[] | undefined {
-  return useAllBase(query, options, { suspense: false });
+): UseAllResult<T> {
+  return useAllBase(query, options, { suspense: false }) as UseAllResult<T>;
 }
 
 /**

--- a/packages/jazz-tools/src/react-core/use-all.ts
+++ b/packages/jazz-tools/src/react-core/use-all.ts
@@ -6,10 +6,27 @@ type UseAllOptions = {
   suspense?: boolean;
 };
 
-export type UseAllResult<T extends { id: string }> = {
-  data: T[] | undefined;
-  isLoading: boolean;
-  error: Error | null;
+export type UseAllResult<T extends { id: string }> =
+  | {
+      data: undefined;
+      isLoading: true;
+      error: null;
+    }
+  | {
+      data: T[];
+      isLoading: false;
+      error: null;
+    }
+  | {
+      data: undefined;
+      isLoading: false;
+      error: Error;
+    };
+
+type UseAllNoQueryResult = {
+  data: undefined;
+  isLoading: false;
+  error: null;
 };
 
 // A query that never arrives has nothing to fetch, so the suspense variant
@@ -26,7 +43,7 @@ function useAllBase<T extends { id: string }>(
   query?: QueryBuilder<T>,
   queryOptions?: QueryOptions,
   options?: UseAllOptions,
-): T[] | UseAllResult<T> {
+): T[] | UseAllResult<T> | UseAllNoQueryResult {
   const { suspense = false } = options ?? {};
   const { manager } = useJazzClient();
 
@@ -126,11 +143,24 @@ function useAllBase<T extends { id: string }>(
  * @returns `{ data, isLoading, error }`. `data` is `undefined` until the query
  *   resolves or if the query fails.
  */
+export function useAll<T extends { id: string } = { id: string }>(): UseAllNoQueryResult;
+export function useAll<T extends { id: string } = { id: string }>(
+  query: undefined,
+  options?: QueryOptions,
+): UseAllNoQueryResult;
+export function useAll<T extends { id: string }>(
+  query: QueryBuilder<T>,
+  options?: QueryOptions,
+): UseAllResult<T>;
+export function useAll<T extends { id: string }>(
+  query: QueryBuilder<T> | undefined,
+  options?: QueryOptions,
+): UseAllResult<T> | UseAllNoQueryResult;
 export function useAll<T extends { id: string }>(
   query?: QueryBuilder<T>,
   options?: QueryOptions,
-): UseAllResult<T> {
-  return useAllBase(query, options, { suspense: false }) as UseAllResult<T>;
+): UseAllResult<T> | UseAllNoQueryResult {
+  return useAllBase(query, options, { suspense: false }) as UseAllResult<T> | UseAllNoQueryResult;
 }
 
 /**

--- a/packages/jazz-tools/src/react-core/use-all.ts
+++ b/packages/jazz-tools/src/react-core/use-all.ts
@@ -1,4 +1,4 @@
-import { type Usable, use, useCallback, useRef, useSyncExternalStore } from "react";
+import { type Usable, use, useCallback, useMemo, useRef, useSyncExternalStore } from "react";
 import type { QueryBuilder, QueryOptions, UseAllState } from "../shared/index.js";
 import { useJazzClient } from "./provider.js";
 
@@ -7,21 +7,27 @@ type UseAllOptions = {
 };
 
 export type UseAllResult<T extends { id: string }> =
-  | {
-      data: undefined;
-      isLoading: true;
-      error: null;
-    }
-  | {
-      data: T[];
-      isLoading: false;
-      error: null;
-    }
-  | {
-      data: undefined;
-      isLoading: false;
-      error: Error;
-    };
+  | UseAllLoadingResult
+  | UseAllFulfilledResult<T>
+  | UseAllErrorResult;
+
+type UseAllLoadingResult = {
+  data: undefined;
+  isLoading: true;
+  error: null;
+};
+
+type UseAllFulfilledResult<T extends { id: string }> = {
+  data: T[];
+  isLoading: false;
+  error: null;
+};
+
+type UseAllErrorResult = {
+  data: undefined;
+  isLoading: false;
+  error: Error;
+};
 
 type UseAllNoQueryResult = {
   data: undefined;
@@ -86,6 +92,25 @@ function useAllBase<T extends { id: string }>(
   );
 
   const state = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  const status = state?.status;
+  const data = state?.status === "fulfilled" ? state.data : undefined;
+  const stateError = state?.status === "rejected" ? state.error : null;
+
+  const result = useMemo<UseAllResult<T> | UseAllNoQueryResult>(() => {
+    if (key === null) {
+      return { data: undefined, isLoading: false, error: null };
+    }
+
+    if (status === "fulfilled") {
+      return { data: data!, isLoading: false, error: null };
+    }
+
+    if (status === "rejected") {
+      return { data: undefined, isLoading: false, error: toError(stateError) };
+    }
+
+    return { data: undefined, isLoading: true, error: null };
+  }, [data, key, stateError, status]);
 
   if (suspense) {
     if (!query || key === null) {
@@ -116,19 +141,7 @@ function useAllBase<T extends { id: string }>(
     return use(entry.promise as unknown as Usable<T[]>);
   }
 
-  if (!query || key === null) {
-    return { data: undefined, isLoading: false, error: null };
-  }
-
-  if (state?.status === "fulfilled") {
-    return { data: state.data, isLoading: false, error: null };
-  }
-
-  if (state?.status === "rejected") {
-    return { data: undefined, isLoading: false, error: toError(state.error) };
-  }
-
-  return { data: undefined, isLoading: true, error: null };
+  return result;
 }
 
 /**

--- a/packages/jazz-tools/src/react-core/use-all.ts
+++ b/packages/jazz-tools/src/react-core/use-all.ts
@@ -134,14 +134,16 @@ function useAllBase<T extends { id: string }>(
 /**
  * Read all matching rows and subscribe to changes that modify the query's results.
  *
- * Loading and error states are returned alongside the rows, matching the other
- * framework bindings. Use {@link useAllSuspense} when you want loading and
- * errors to flow through Suspense and an error boundary instead.
- *
  * @param query - the database query (e.g. `app.todos.where({done: false})`)
  *
- * @returns `{ data, isLoading, error }`. `data` is `undefined` until the query
- *   resolves or if the query fails.
+ * @returns `{ data, isLoading, error }`
+ * - `data` is `undefined` until the query resolves or if the query fails.
+ * - `isLoading` is `true` before the first result is available.
+ * - `error` is `null` unless there was a problem setting up the subscription
+ *   and no results could be loaded.
+ *
+ * Use {@link useAllSuspense} when you want loading and errors to flow through
+ * Suspense and an error boundary instead.
  */
 export function useAll<T extends { id: string } = { id: string }>(): UseAllNoQueryResult;
 export function useAll<T extends { id: string } = { id: string }>(

--- a/packages/jazz-tools/src/react-native/index.ts
+++ b/packages/jazz-tools/src/react-native/index.ts
@@ -2,7 +2,7 @@ export { createDb, Db, type DbConfig } from "./db.js";
 export { createJazzClient, type JazzClient } from "./create-jazz-client.js";
 export { loadJazzRn } from "./jazz-rn-loader.js";
 export type { JazzRnRuntimeBinding } from "./jazz-rn-runtime-adapter.js";
-export { useAll, useAllSuspense } from "./use-all.js";
+export { useAll, useAllSuspense, type UseAllResult } from "./use-all.js";
 export {
   JazzProvider,
   type JazzProviderProps,

--- a/packages/jazz-tools/src/react-native/use-all.ts
+++ b/packages/jazz-tools/src/react-native/use-all.ts
@@ -1,1 +1,1 @@
-export { useAll, useAllSuspense } from "../react-core/use-all.js";
+export { useAll, useAllSuspense, type UseAllResult } from "../react-core/use-all.js";

--- a/packages/jazz-tools/src/react/index.ts
+++ b/packages/jazz-tools/src/react/index.ts
@@ -8,7 +8,7 @@ export {
   useJazzClient,
   useSession,
 } from "./provider.js";
-export { useAll, useAllSuspense } from "./use-all.js";
+export { useAll, useAllSuspense, type UseAllResult } from "./use-all.js";
 export {
   useLocalFirstAuth,
   type LocalFirstAuth,

--- a/packages/jazz-tools/src/react/use-all.ts
+++ b/packages/jazz-tools/src/react/use-all.ts
@@ -1,1 +1,1 @@
-export { useAll, useAllSuspense } from "../react-core/use-all.js";
+export { useAll, useAllSuspense, type UseAllResult } from "../react-core/use-all.js";

--- a/packages/jazz-tools/tests/browser/react-core-provider.test.tsx
+++ b/packages/jazz-tools/tests/browser/react-core-provider.test.tsx
@@ -239,7 +239,7 @@ describe("react-core provider/hooks browser coverage", () => {
     await expectText("db-session", "bob");
   });
 
-  it("RCB-B05: useAll returns undefined during pending phase", async () => {
+  it("RCB-B05: useAll returns loading state during pending phase", async () => {
     const manager = new ControlledManager();
     const entry = createEntry<Todo>();
     manager.register(BASE_QUERY, entry);
@@ -251,7 +251,7 @@ describe("react-core provider/hooks browser coverage", () => {
       </JazzProvider>,
     );
 
-    await expectText("rows", "undefined");
+    await expectText("rows", "loading");
   });
 
   it("RCB-B06: useAll transitions to data after first fulfillment", async () => {
@@ -266,7 +266,7 @@ describe("react-core provider/hooks browser coverage", () => {
       </JazzProvider>,
     );
 
-    await expectText("rows", "undefined");
+    await expectText("rows", "loading");
 
     entry.emitFulfilled([
       { id: "a", title: "Alpha" },
@@ -527,9 +527,14 @@ function DbAuthStateView() {
 }
 
 function UseAllView({ query, options }: { query: QueryBuilder<Todo>; options?: QueryOptions }) {
-  const rows = useAll(query, options);
+  const result = useAll(query, options);
+  const rows = result.data;
   return (
-    <div data-testid="rows">{rows ? rows.map((row) => row.title).join("|") : "undefined"}</div>
+    <div data-testid="rows">
+      {rows
+        ? rows.map((row) => row.title).join("|")
+        : (result.error?.message ?? (result.isLoading ? "loading" : "undefined"))}
+    </div>
   );
 }
 

--- a/packages/jazz-tools/tests/browser/react-core-provider.test.tsx
+++ b/packages/jazz-tools/tests/browser/react-core-provider.test.tsx
@@ -533,7 +533,9 @@ function UseAllView({ query, options }: { query: QueryBuilder<Todo>; options?: Q
     <div data-testid="rows">
       {rows
         ? rows.map((row) => row.title).join("|")
-        : (result.error?.message ?? (result.isLoading ? "loading" : "undefined"))}
+        : result.isLoading
+          ? "loading"
+          : result.error.message}
     </div>
   );
 }

--- a/packages/jazz-tools/tests/browser/useAll.test.tsx
+++ b/packages/jazz-tools/tests/browser/useAll.test.tsx
@@ -184,8 +184,14 @@ function UseAllProbe<T extends { id: string }>({
   options?: QueryOptions;
   pick: (row: T) => string;
 }) {
-  const rows = useAll(query, options);
-  const text = rows ? rows.map(pick).join("|") : "pending";
+  const result = useAll(query, options);
+  const text = result.error
+    ? `error:${result.error.message}`
+    : result.data
+      ? result.data.map(pick).join("|")
+      : result.isLoading
+        ? "pending"
+        : "idle";
   return <div data-testid="rows">{text}</div>;
 }
 
@@ -653,7 +659,7 @@ describe("useAll browser integration", () => {
       const query = makeQuery<Todo>("todos", {
         conditions: [{ column: "done", op: "eq", value: showDone }],
       });
-      const rows = useAll(query);
+      const { data: rows } = useAll(query);
       return (
         <>
           <button data-testid="toggle-query" onClick={() => setShowDone((value) => !value)}>
@@ -687,7 +693,7 @@ describe("useAll browser integration", () => {
     );
   });
 
-  it("returns undefined when query is missing and a result when the query is provided later", async () => {
+  it("returns idle state when query is missing and a result when the query is provided later", async () => {
     const client = track(
       await createJazzClient({
         appId: uniqueId("missing-query"),
@@ -723,9 +729,9 @@ describe("useAll browser integration", () => {
     );
 
     await waitForCondition(
-      () => getText("rows") === "pending",
+      () => getText("rows") === "idle",
       5000,
-      "expected pending text when query is missing",
+      "expected idle text when query is missing",
     );
 
     const setQueryButton = container?.querySelector('[data-testid="set-query"]');

--- a/packages/jazz-tools/tests/browser/useAll.test.tsx
+++ b/packages/jazz-tools/tests/browser/useAll.test.tsx
@@ -191,7 +191,7 @@ function UseAllProbe<T extends { id: string }>({
       ? result.data.map(pick).join("|")
       : result.isLoading
         ? "pending"
-        : "idle";
+        : "no result";
   return <div data-testid="rows">{text}</div>;
 }
 
@@ -693,7 +693,7 @@ describe("useAll browser integration", () => {
     );
   });
 
-  it("returns idle state when query is missing and a result when the query is provided later", async () => {
+  it("returns no result when query is missing and a result when the query is provided later", async () => {
     const client = track(
       await createJazzClient({
         appId: uniqueId("missing-query"),
@@ -729,9 +729,9 @@ describe("useAll browser integration", () => {
     );
 
     await waitForCondition(
-      () => getText("rows") === "idle",
+      () => getText("rows") === "no result",
       5000,
-      "expected idle text when query is missing",
+      "expected no result text when query is missing",
     );
 
     const setQueryButton = container?.querySelector('[data-testid="set-query"]');

--- a/starters/next-betterauth/components/todo-widget.tsx
+++ b/starters/next-betterauth/components/todo-widget.tsx
@@ -5,7 +5,7 @@ import { app } from "@/schema";
 
 export function TodoWidget() {
   const db = useDb();
-  const todos = useAll(app.todos) ?? [];
+  const { data: todos = [] } = useAll(app.todos);
 
   function add(formData: FormData) {
     const title = formData.get("title") as string;

--- a/starters/next-hybrid/components/todo-widget.tsx
+++ b/starters/next-hybrid/components/todo-widget.tsx
@@ -5,7 +5,7 @@ import { app } from "@/schema";
 
 export function TodoWidget() {
   const db = useDb();
-  const todos = useAll(app.todos) ?? [];
+  const { data: todos = [] } = useAll(app.todos);
 
   function add(formData: FormData) {
     const title = formData.get("title") as string;

--- a/starters/next-localfirst/components/todo-widget.tsx
+++ b/starters/next-localfirst/components/todo-widget.tsx
@@ -5,7 +5,7 @@ import { app } from "@/schema";
 
 export function TodoWidget() {
   const db = useDb();
-  const todos = useAll(app.todos) ?? [];
+  const { data: todos = [] } = useAll(app.todos);
 
   function add(formData: FormData) {
     const title = formData.get("title") as string;

--- a/starters/react-betterauth/src/todo-widget.tsx
+++ b/starters/react-betterauth/src/todo-widget.tsx
@@ -3,7 +3,7 @@ import { app } from "../schema";
 
 export function TodoWidget() {
   const db = useDb();
-  const todos = useAll(app.todos) ?? [];
+  const { data: todos = [] } = useAll(app.todos);
 
   function add(formData: FormData) {
     const title = formData.get("title") as string;

--- a/starters/react-hybrid/src/todo-widget.tsx
+++ b/starters/react-hybrid/src/todo-widget.tsx
@@ -3,7 +3,7 @@ import { app } from "../schema";
 
 export function TodoWidget() {
   const db = useDb();
-  const todos = useAll(app.todos) ?? [];
+  const { data: todos = [] } = useAll(app.todos);
 
   function add(formData: FormData) {
     const title = formData.get("title") as string;

--- a/starters/react-localfirst/src/todo-widget.tsx
+++ b/starters/react-localfirst/src/todo-widget.tsx
@@ -3,7 +3,7 @@ import { app } from "../schema";
 
 export function TodoWidget() {
   const db = useDb();
-  const todos = useAll(app.todos) ?? [];
+  const { data: todos = [] } = useAll(app.todos);
 
   function add(formData: FormData) {
     const title = formData.get("title") as string;


### PR DESCRIPTION
## Description

Align React and React Native `useAll` with the other framework bindings by returning `{ data, isLoading, error }` instead of a bare `T[] | undefined`. `useAllSuspense` still returns `T[]`.

The return type allows proper type narrowing after validating the load is not pending/errored.