### PR TITLE
fix: make authoritative rejections terminal during replay

### DIFF
--- a/.changeset/terminal-rejected-batch-replays.md
+++ b/.changeset/terminal-rejected-batch-replays.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Treat authoritative rejected batch fates as terminal during reconnect and parent-closure replay.

--- a/.changeset/terminal-rejected-batch-replays.md
+++ b/.changeset/terminal-rejected-batch-replays.md
@@ -2,4 +2,4 @@
 "jazz-tools": patch
 ---
 
-Treat authoritative rejected batch fates as terminal during reconnect and parent-closure replay.
+Prevent replay from resubmitting terminally rejected batches or echoing accepted rows back to the authoritative server that delivered them.

--- a/crates/jazz-tools/src/batch_fate.rs
+++ b/crates/jazz-tools/src/batch_fate.rs
@@ -76,6 +76,10 @@ impl BatchFate {
         }
     }
 
+    pub fn is_rejected(&self) -> bool {
+        matches!(self, Self::Rejected { .. })
+    }
+
     pub fn confirmed_tier(&self) -> Option<DurabilityTier> {
         match self {
             Self::DurableDirect { confirmed_tier, .. }

--- a/crates/jazz-tools/src/batch_fate.rs
+++ b/crates/jazz-tools/src/batch_fate.rs
@@ -90,6 +90,7 @@ impl BatchFate {
 
     pub fn merged_with(&self, incoming: &BatchFate) -> BatchFate {
         match (self, incoming) {
+            (Self::Rejected { .. }, _) => self.clone(),
             (
                 Self::DurableDirect {
                     batch_id,

--- a/crates/jazz-tools/src/runtime_core/tests/accepted_batch_downgrade.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/accepted_batch_downgrade.rs
@@ -61,11 +61,22 @@ fn pump<S: Storage, Sch: Scheduler>(
     server_id: ServerId,
     client: &mut RuntimeCore<S, Sch>,
     client_id: ClientId,
-) {
+) -> Vec<(ServerId, &'static str)> {
+    let mut upstream_row_writes = Vec::new();
     for _ in 0..12 {
         let mut any = false;
         client.batched_tick();
         for entry in client.sync_sender().take() {
+            if let Destination::Server(destination_server_id) = &entry.destination
+                && matches!(
+                    &entry.payload,
+                    SyncPayload::RowBatchCreated { .. }
+                        | SyncPayload::RowBatchNeeded { .. }
+                        | SyncPayload::SealBatch { .. }
+                )
+            {
+                upstream_row_writes.push((*destination_server_id, entry.payload.variant_name()));
+            }
             if entry.destination == Destination::Server(server_id) {
                 any = true;
                 server.park_sync_message(InboxEntry {
@@ -92,6 +103,7 @@ fn pump<S: Storage, Sch: Scheduler>(
             break;
         }
     }
+    upstream_row_writes
 }
 
 /// Bidirectional pump for `C_backend ↔ S ↔ C_owner`, routing each server output
@@ -170,8 +182,17 @@ fn new_server<S: Storage>(
     schema: Schema,
     app_name: &str,
 ) -> RuntimeCore<S, NoopScheduler> {
+    new_server_at_tier(storage, schema, app_name, DurabilityTier::EdgeServer)
+}
+
+fn new_server_at_tier<S: Storage>(
+    storage: S,
+    schema: Schema,
+    app_name: &str,
+    tier: DurabilityTier,
+) -> RuntimeCore<S, NoopScheduler> {
     let schema_manager = SchemaManager::new(
-        SyncManager::new().with_durability_tier(DurabilityTier::EdgeServer),
+        SyncManager::new().with_durability_tier(tier),
         schema.clone(),
         AppId::from_name(app_name),
         "dev",
@@ -309,6 +330,129 @@ fn owner_update_of_backend_created_row_is_not_destroyed() {
             .unwrap()
             .is_some(),
         "the row must also survive on the client"
+    );
+}
+
+#[cfg(feature = "sqlite")]
+#[test]
+fn subscribing_to_a_backend_transaction_does_not_replay_it_after_reload() {
+    use crate::storage::SqliteStorage;
+
+    let schema = profiles_schema();
+    let server_dir = tempfile::TempDir::new().unwrap();
+    let client_dir = tempfile::TempDir::new().unwrap();
+    let client_path = client_dir.path().join("jazz.sqlite");
+    let app_name = "accepted-transaction-subscription";
+
+    let mut server = new_server_at_tier(
+        SqliteStorage::open(server_dir.path().join("jazz.sqlite")).unwrap(),
+        schema.clone(),
+        app_name,
+        DurabilityTier::GlobalServer,
+    );
+
+    let batch_id = crate::row_histories::BatchId::new();
+    let write_context = WriteContext {
+        session: None,
+        attribution: None,
+        updated_at: None,
+        batch_mode: Some(crate::batch_fate::BatchMode::Transactional),
+        batch_id: Some(batch_id),
+        target_branch_name: None,
+    };
+    let ((profile_id, _), _) = server
+        .insert(
+            "profiles",
+            profiles_values("Ada", "Lovelace"),
+            Some(&write_context),
+        )
+        .unwrap();
+    server.commit_batch(batch_id).unwrap();
+    server.immediate_tick();
+
+    assert!(matches!(
+        server
+            .storage()
+            .load_authoritative_batch_fate(batch_id)
+            .unwrap(),
+        Some(BatchFate::AcceptedTransaction { .. })
+    ));
+
+    let first_client_id = ClientId::new();
+    let first_server_id = ServerId::new();
+    let first_forward_server_id = ServerId::new();
+    server.add_client(first_client_id, Some(Session::new("owner-1")));
+    let mut client = new_client(
+        SqliteStorage::open(&client_path).unwrap(),
+        schema.clone(),
+        app_name,
+    );
+    client.add_server(first_server_id);
+    client.add_server(first_forward_server_id);
+    let _first_handle = client
+        .subscribe(
+            QueryBuilder::new("profiles").build(),
+            |_delta| {},
+            Some(Session::new("owner-1")),
+        )
+        .unwrap();
+
+    let first_upstream_writes = pump(&mut server, first_server_id, &mut client, first_client_id);
+    assert!(
+        client
+            .storage()
+            .load_visible_region_row(
+                "profiles",
+                client.schema_manager().branch_name().as_str(),
+                profile_id,
+            )
+            .unwrap()
+            .is_some(),
+        "the subscribed profile should be visible before reload"
+    );
+
+    drop(client);
+    server.remove_client(first_client_id);
+
+    let second_client_id = ClientId::new();
+    let second_server_id = ServerId::new();
+    let second_forward_server_id = ServerId::new();
+    server.add_client(second_client_id, Some(Session::new("owner-1")));
+    let mut reloaded_client =
+        new_client(SqliteStorage::open(&client_path).unwrap(), schema, app_name);
+    reloaded_client.add_server(second_server_id);
+    reloaded_client.add_server(second_forward_server_id);
+    let _second_handle = reloaded_client
+        .subscribe(
+            QueryBuilder::new("profiles").build(),
+            |_delta| {},
+            Some(Session::new("owner-1")),
+        )
+        .unwrap();
+
+    let reloaded_upstream_writes = pump(
+        &mut server,
+        second_server_id,
+        &mut reloaded_client,
+        second_client_id,
+    );
+    assert!(
+        first_upstream_writes
+            .iter()
+            .all(|(destination, _)| *destination != first_server_id)
+            && reloaded_upstream_writes
+                .iter()
+                .all(|(destination, _)| *destination != second_server_id),
+        "subscription delivery and reload must not replay the accepted profile to its source server: first={first_upstream_writes:?}, reloaded={reloaded_upstream_writes:?}"
+    );
+    assert!(
+        first_upstream_writes
+            .iter()
+            .any(|(destination, _)| *destination == first_forward_server_id)
+            && reloaded_upstream_writes
+                .iter()
+                .any(|(destination, _)| *destination == second_forward_server_id),
+        "the accepted profile must still be forwarded to a distinct upstream: first={first_upstream_writes:?}, reloaded={reloaded_upstream_writes:?}"
     );
 }
 

--- a/crates/jazz-tools/src/runtime_core/tests/accepted_batch_downgrade.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/accepted_batch_downgrade.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use crate::batch_fate::BatchFate;
+use crate::batch_fate::{BatchFate, BatchMode};
 use crate::metadata::{MetadataKey, RowProvenance};
 use crate::row_format::decode_row;
 use crate::row_histories::{RowState, StoredRowBatch};
@@ -351,15 +351,8 @@ fn subscribing_to_a_backend_transaction_does_not_replay_it_after_reload() {
         DurabilityTier::GlobalServer,
     );
 
-    let batch_id = crate::row_histories::BatchId::new();
-    let write_context = WriteContext {
-        session: None,
-        attribution: None,
-        updated_at: None,
-        batch_mode: Some(crate::batch_fate::BatchMode::Transactional),
-        batch_id: Some(batch_id),
-        target_branch_name: None,
-    };
+    let batch_id = server.begin_batch(BatchMode::Transactional);
+    let write_context = WriteContext::default().with_batch_id(batch_id);
     let ((profile_id, _), _) = server
         .insert(
             "profiles",

--- a/crates/jazz-tools/src/sync_manager/forwarding.rs
+++ b/crates/jazz-tools/src/sync_manager/forwarding.rs
@@ -199,14 +199,13 @@ impl SyncManager {
         }
 
         for server_id in server_ids {
-            let mut visited = HashSet::new();
             self.queue_row_to_server_with_missing_parents(
                 storage,
                 table,
                 server_id,
                 &metadata,
                 row.clone(),
-                &mut visited,
+                None,
             );
         }
     }
@@ -218,10 +217,11 @@ impl SyncManager {
         server_id: ServerId,
         metadata: &HashMap<String, String>,
         row: StoredRowBatch,
-        visited: &mut HashSet<BatchId>,
+        authoritative_fates: Option<&HashMap<BatchId, BatchFate>>,
     ) {
         let object_id = row.row_id;
         let branch_name = BranchName::new(&row.branch);
+        let mut visited = HashSet::new();
 
         // Iterative post-order walk, not recursion: a deep history chain would
         // otherwise put one frame per ancestor on the stack and overflow it.
@@ -240,6 +240,19 @@ impl SyncManager {
                         .and_then(|server| server.sent_batch_ids.get(&(object_id, branch_name)))
                         .is_some_and(|sent| sent.contains(&parent_batch_id))
                     {
+                        continue;
+                    }
+                    let parent_is_rejected = match authoritative_fates {
+                        Some(fates) => fates
+                            .get(&parent_batch_id)
+                            .is_some_and(BatchFate::is_rejected),
+                        None => storage
+                            .load_authoritative_batch_fate(parent_batch_id)
+                            .ok()
+                            .flatten()
+                            .is_some_and(|fate| fate.is_rejected()),
+                    };
+                    if parent_is_rejected {
                         continue;
                     }
                     if !visited.insert(parent_batch_id) {

--- a/crates/jazz-tools/src/sync_manager/forwarding.rs
+++ b/crates/jazz-tools/src/sync_manager/forwarding.rs
@@ -253,7 +253,7 @@ impl SyncManager {
                             .is_some_and(|fate| fate.is_rejected()),
                     };
                     if parent_is_rejected {
-                        continue;
+                        return;
                     }
                     if !visited.insert(parent_batch_id) {
                         continue;

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -376,7 +376,21 @@ impl SyncManager {
             storage.load_authoritative_batch_fate(row.batch_id),
             Ok(Some(BatchFate::Rejected { .. }))
         ) {
-            return None;
+            let is_declared_member = storage
+                .load_sealed_batch_submission(row.batch_id)
+                .ok()
+                .flatten()
+                .is_some_and(|submission| {
+                    submission.target_branch_name.as_str() == row.branch.as_str()
+                        && submission.members.iter().any(|member| {
+                            member.object_id == row.row_id
+                                && member.row_digest == row.content_digest()
+                        })
+                });
+            if !is_declared_member {
+                return None;
+            }
+            row.state = RowState::Rejected;
         }
         let (is_newly_located_object, needs_exact_locator) =
             self.ensure_object_metadata(storage, row.row_id, metadata.clone());

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -700,10 +700,16 @@ impl SyncManager {
         &mut self,
         storage: &mut H,
         origin_client_id: Option<ClientId>,
+        origin_server_id: Option<ServerId>,
         fate: &BatchFate,
         batch_rows: &[(String, StoredRowBatch)],
     ) {
-        let server_ids: Vec<_> = self.servers.keys().copied().collect();
+        let server_ids: Vec<_> = self
+            .servers
+            .keys()
+            .copied()
+            .filter(|server_id| Some(*server_id) != origin_server_id)
+            .collect();
         match fate {
             BatchFate::DurableDirect { .. } => {
                 for (table, row) in batch_rows {
@@ -867,6 +873,7 @@ impl SyncManager {
     fn apply_authoritative_transaction_fate_for_row<H: Storage>(
         &mut self,
         storage: &mut H,
+        origin_server_id: ServerId,
         row: &StoredRowBatch,
     ) {
         let fate = match storage.load_authoritative_batch_fate(row.batch_id) {
@@ -891,7 +898,13 @@ impl SyncManager {
                 .unwrap_or_default(),
             row.clone(),
         )];
-        self.apply_transactional_batch_fate_to_rows(storage, None, &fate, &rows);
+        self.apply_transactional_batch_fate_to_rows(
+            storage,
+            None,
+            Some(origin_server_id),
+            &fate,
+            &rows,
+        );
     }
 
     fn reject_sealed_transactional_batch<H: Storage>(
@@ -916,7 +929,13 @@ impl SyncManager {
                 "failed to delete rejected sealed batch submission"
             );
         }
-        self.apply_transactional_batch_fate_to_rows(storage, origin_client_id, &fate, batch_rows);
+        self.apply_transactional_batch_fate_to_rows(
+            storage,
+            origin_client_id,
+            None,
+            &fate,
+            batch_rows,
+        );
     }
 
     fn declared_rows_for_submission(
@@ -1036,6 +1055,7 @@ impl SyncManager {
         self.apply_transactional_batch_fate_to_rows(
             storage,
             origin_client_id,
+            None,
             &fate,
             rows_to_patch,
         );
@@ -1300,7 +1320,11 @@ impl SyncManager {
                     row.clone(),
                     AuthoritativeFateRecording::AcceptedByLocalAuthority,
                 ) {
-                    self.apply_authoritative_transaction_fate_for_row(storage, &applied.row);
+                    self.apply_authoritative_transaction_fate_for_row(
+                        storage,
+                        server_id,
+                        &applied.row,
+                    );
 
                     if let Some(update) = applied.visibility_change {
                         self.pending_row_visibility_changes.push(update);
@@ -1320,7 +1344,13 @@ impl SyncManager {
                 self.pending_batch_fates.push(fate.clone());
                 if let BatchFate::AcceptedTransaction { batch_id, .. } = fate {
                     let rows = self.known_transactional_batch_rows_for_fate(storage, batch_id);
-                    self.apply_transactional_batch_fate_to_rows(storage, None, &fate, &rows);
+                    self.apply_transactional_batch_fate_to_rows(
+                        storage,
+                        None,
+                        Some(server_id),
+                        &fate,
+                        &rows,
+                    );
                 }
                 let interested = self.interested_clients_for_batch_fate(&fate);
                 for cid in interested {

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -182,14 +182,14 @@ impl SyncManager {
         &self,
         storage: &mut H,
         fate: &BatchFate,
-    ) -> Result<bool, crate::storage::StorageError> {
+    ) -> Result<(BatchFate, bool), crate::storage::StorageError> {
         let previous = storage.load_authoritative_batch_fate(fate.batch_id())?;
         let merged = match previous.as_ref() {
             Some(existing) => existing.merged_with(fate),
             None => fate.clone(),
         };
         if previous.as_ref() == Some(&merged) {
-            return Ok(false);
+            return Ok((merged, false));
         }
         storage
             .upsert_authoritative_batch_fate(&merged)
@@ -201,7 +201,7 @@ impl SyncManager {
                 );
                 error
             })?;
-        Ok(true)
+        Ok((merged, true))
     }
 
     fn persist_sealed_batch_submission<H: Storage>(
@@ -372,6 +372,12 @@ impl SyncManager {
         row.confirmed_tier = None;
 
         let metadata = self.row_metadata_from_payload(storage, &row, metadata.as_ref())?;
+        if matches!(
+            storage.load_authoritative_batch_fate(row.batch_id),
+            Ok(Some(BatchFate::Rejected { .. }))
+        ) {
+            return None;
+        }
         let (is_newly_located_object, needs_exact_locator) =
             self.ensure_object_metadata(storage, row.row_id, metadata.clone());
         let branch_name = BranchName::new(&row.branch);
@@ -438,11 +444,8 @@ impl SyncManager {
                     unreachable!("row.state.is_visible() guarded non-visible states")
                 }
             };
-            if matches!(
-                self.persist_authoritative_batch_fate(storage, &fate),
-                Ok(true)
-            ) {
-                self.pending_batch_fates.push(fate.clone());
+            if let Ok((fate, true)) = self.persist_authoritative_batch_fate(storage, &fate) {
+                self.pending_batch_fates.push(fate);
             }
         }
 
@@ -898,11 +901,14 @@ impl SyncManager {
         fate: BatchFate,
         batch_rows: &[(String, StoredRowBatch)],
     ) {
-        match self.persist_authoritative_batch_fate(storage, &fate) {
-            Ok(true) => self.pending_batch_fates.push(fate.clone()),
-            Ok(false) => {}
+        let fate = match self.persist_authoritative_batch_fate(storage, &fate) {
+            Ok((fate, true)) => {
+                self.pending_batch_fates.push(fate.clone());
+                fate
+            }
+            Ok((fate, false)) => fate,
             Err(_) => return,
-        }
+        };
         if let Err(error) = storage.delete_sealed_batch_submission(fate.batch_id()) {
             tracing::warn!(
                 batch_id = ?fate.batch_id(),
@@ -966,8 +972,8 @@ impl SyncManager {
                     batch_id,
                     confirmed_tier,
                 };
-                let changed = match self.persist_authoritative_batch_fate(storage, &fate) {
-                    Ok(changed) => changed,
+                let (fate, changed) = match self.persist_authoritative_batch_fate(storage, &fate) {
+                    Ok(result) => result,
                     Err(_) => return,
                 };
                 if changed {
@@ -998,10 +1004,11 @@ impl SyncManager {
                             confirmed_tier,
                         },
                     };
-                    let changed = match self.persist_authoritative_batch_fate(storage, &fate) {
-                        Ok(changed) => changed,
-                        Err(_) => return,
-                    };
+                    let (fate, changed) =
+                        match self.persist_authoritative_batch_fate(storage, &fate) {
+                            Ok(result) => result,
+                            Err(_) => return,
+                        };
                     if changed {
                         self.pending_batch_fates.push(fate.clone());
                     }
@@ -1306,10 +1313,11 @@ impl SyncManager {
                 }
             }
             SyncPayload::BatchFate { fate } => {
-                match self.persist_authoritative_batch_fate(storage, &fate) {
-                    Ok(_) => self.pending_batch_fates.push(fate.clone()),
+                let fate = match self.persist_authoritative_batch_fate(storage, &fate) {
+                    Ok((fate, _)) => fate,
                     Err(_) => return,
-                }
+                };
+                self.pending_batch_fates.push(fate.clone());
                 if let BatchFate::AcceptedTransaction { batch_id, .. } = fate {
                     let rows = self.known_transactional_batch_rows_for_fate(storage, batch_id);
                     self.apply_transactional_batch_fate_to_rows(storage, None, &fate, &rows);

--- a/crates/jazz-tools/src/sync_manager/sync_logic.rs
+++ b/crates/jazz-tools/src/sync_manager/sync_logic.rs
@@ -67,10 +67,18 @@ impl SyncManager {
         let Ok(row_locators) = storage.scan_row_locators() else {
             return;
         };
-        let authoritative_fates: HashMap<BatchId, BatchFate> = storage
-            .scan_authoritative_batch_fates()
-            .ok()
-            .unwrap_or_default()
+        let authoritative_fates = match storage.scan_authoritative_batch_fates() {
+            Ok(fates) => fates,
+            Err(error) => {
+                tracing::error!(
+                    %server_id,
+                    %error,
+                    "failed to load authoritative batch fates; aborting full server replay"
+                );
+                return;
+            }
+        };
+        let authoritative_fates: HashMap<BatchId, BatchFate> = authoritative_fates
             .into_iter()
             .map(|fate| (fate.batch_id(), fate))
             .collect();

--- a/crates/jazz-tools/src/sync_manager/sync_logic.rs
+++ b/crates/jazz-tools/src/sync_manager/sync_logic.rs
@@ -78,18 +78,25 @@ impl SyncManager {
         let my_max_tier = self.max_local_durability_tier();
 
         for row in rows.into_iter() {
+            let authoritative_fate = storage
+                .load_authoritative_batch_fate(row.batch_id)
+                .ok()
+                .flatten();
+            if matches!(
+                authoritative_fate.as_ref(),
+                Some(BatchFate::Rejected { .. })
+            ) {
+                continue;
+            }
+
             // Skip rows already confirmed above our own tier — an upstream
             // server has them. Without this, a user-role client replays every
             // stored row (including ones authored by other users that it only
             // observed via subscription) on every reconnect, which the server
             // rejects under row-level update policies.
-            let effective_confirmed_tier = row.confirmed_tier.or_else(|| {
-                storage
-                    .load_authoritative_batch_fate(row.batch_id)
-                    .ok()
-                    .flatten()
-                    .and_then(|fate| fate.confirmed_tier())
-            });
+            let effective_confirmed_tier = row
+                .confirmed_tier
+                .or_else(|| authoritative_fate.and_then(|fate| fate.confirmed_tier()));
             let already_upstream = match (effective_confirmed_tier, my_max_tier) {
                 (None, _) => false,
                 (Some(_), None) => true,

--- a/crates/jazz-tools/src/sync_manager/sync_logic.rs
+++ b/crates/jazz-tools/src/sync_manager/sync_logic.rs
@@ -67,22 +67,34 @@ impl SyncManager {
         let Ok(row_locators) = storage.scan_row_locators() else {
             return;
         };
+        let authoritative_fates: HashMap<BatchId, BatchFate> = storage
+            .scan_authoritative_batch_fates()
+            .ok()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|fate| (fate.batch_id(), fate))
+            .collect();
 
         let mut row_sync: Vec<RowSyncData> = Vec::new();
 
         for (object_id, row_locator) in row_locators {
-            self.collect_row_sync_versions(storage, object_id, &row_locator, &mut row_sync);
+            self.collect_row_sync_versions(
+                storage,
+                object_id,
+                &row_locator,
+                &authoritative_fates,
+                &mut row_sync,
+            );
         }
 
         for (table, metadata, row) in row_sync {
-            let mut visiting = std::collections::HashSet::new();
             self.queue_row_to_server_with_missing_parents(
                 storage,
                 table.as_str(),
                 server_id,
                 &metadata,
                 row,
-                &mut visiting,
+                Some(&authoritative_fates),
             );
         }
     }
@@ -92,6 +104,7 @@ impl SyncManager {
         storage: &H,
         object_id: ObjectId,
         row_locator: &RowLocator,
+        authoritative_fates: &HashMap<BatchId, BatchFate>,
         row_sync: &mut Vec<RowSyncData>,
     ) {
         let metadata = metadata_from_row_locator(row_locator);
@@ -102,11 +115,11 @@ impl SyncManager {
         let my_max_tier = self.max_local_durability_tier();
 
         for row in rows.into_iter() {
-            let authoritative_fate = storage
-                .load_authoritative_batch_fate(row.batch_id)
-                .ok()
-                .flatten();
-            if !should_replay_row_to_server(&row, authoritative_fate.as_ref(), my_max_tier) {
+            if !should_replay_row_to_server(
+                &row,
+                authoritative_fates.get(&row.batch_id),
+                my_max_tier,
+            ) {
                 continue;
             }
             row_sync.push((row_locator.table.clone(), metadata.clone(), row));

--- a/crates/jazz-tools/src/sync_manager/sync_logic.rs
+++ b/crates/jazz-tools/src/sync_manager/sync_logic.rs
@@ -8,6 +8,30 @@ use std::collections::HashMap;
 
 type RowSyncData = (SharedString, HashMap<String, String>, StoredRowBatch);
 
+/// Decide whether a stored row is still eligible for upstream row replay.
+///
+/// A rejected fate is terminal for the row submission, while a missing fate
+/// remains replayable. Rows already confirmed above this node's tier are also
+/// skipped because an upstream server already has them.
+fn should_replay_row_to_server(
+    row: &StoredRowBatch,
+    authoritative_fate: Option<&BatchFate>,
+    my_max_tier: Option<DurabilityTier>,
+) -> bool {
+    if authoritative_fate.is_some_and(BatchFate::is_rejected) {
+        return false;
+    }
+
+    let effective_confirmed_tier = row
+        .confirmed_tier
+        .or_else(|| authoritative_fate.and_then(BatchFate::confirmed_tier));
+    match (effective_confirmed_tier, my_max_tier) {
+        (None, _) => true,
+        (Some(_), None) => false,
+        (Some(row_tier), Some(local_tier)) => row_tier <= local_tier,
+    }
+}
+
 impl SyncManager {
     fn scope_delivery_row(mut row: StoredRowBatch) -> StoredRowBatch {
         if row.state.is_visible() {
@@ -82,27 +106,7 @@ impl SyncManager {
                 .load_authoritative_batch_fate(row.batch_id)
                 .ok()
                 .flatten();
-            if matches!(
-                authoritative_fate.as_ref(),
-                Some(BatchFate::Rejected { .. })
-            ) {
-                continue;
-            }
-
-            // Skip rows already confirmed above our own tier — an upstream
-            // server has them. Without this, a user-role client replays every
-            // stored row (including ones authored by other users that it only
-            // observed via subscription) on every reconnect, which the server
-            // rejects under row-level update policies.
-            let effective_confirmed_tier = row
-                .confirmed_tier
-                .or_else(|| authoritative_fate.and_then(|fate| fate.confirmed_tier()));
-            let already_upstream = match (effective_confirmed_tier, my_max_tier) {
-                (None, _) => false,
-                (Some(_), None) => true,
-                (Some(row_tier), Some(local_tier)) => row_tier > local_tier,
-            };
-            if already_upstream {
+            if !should_replay_row_to_server(&row, authoritative_fate.as_ref(), my_max_tier) {
                 continue;
             }
             row_sync.push((row_locator.table.clone(), metadata.clone(), row));

--- a/crates/jazz-tools/src/sync_manager/tests.rs
+++ b/crates/jazz-tools/src/sync_manager/tests.rs
@@ -138,6 +138,7 @@ fn persist_visible_row_settlement(
 struct FailingHistoryPatchStorage {
     inner: MemoryStorage,
     fail_history_load: bool,
+    fail_authoritative_fate_scan: bool,
     fail_authoritative_settlement_upsert: bool,
     fail_sealed_submission_upsert: bool,
 }
@@ -147,6 +148,7 @@ impl FailingHistoryPatchStorage {
         Self {
             inner: MemoryStorage::new(),
             fail_history_load: false,
+            fail_authoritative_fate_scan: false,
             fail_authoritative_settlement_upsert: false,
             fail_sealed_submission_upsert: false,
         }
@@ -158,6 +160,20 @@ impl FailingHistoryPatchStorage {
 }
 
 impl Storage for FailingHistoryPatchStorage {
+    fn scan_row_locators(
+        &self,
+    ) -> Result<crate::storage::RowLocatorRows, crate::storage::StorageError> {
+        self.inner.scan_row_locators()
+    }
+
+    fn scan_history_row_batches(
+        &self,
+        table: &str,
+        row_id: ObjectId,
+    ) -> Result<Vec<StoredRowBatch>, crate::storage::StorageError> {
+        self.inner.scan_history_row_batches(table, row_id)
+    }
+
     fn apply_encoded_row_mutation(
         &mut self,
         table: &str,
@@ -257,6 +273,17 @@ impl Storage for FailingHistoryPatchStorage {
             )));
         }
         self.inner.upsert_authoritative_batch_fate(settlement)
+    }
+
+    fn scan_authoritative_batch_fates(
+        &self,
+    ) -> Result<Vec<BatchFate>, crate::storage::StorageError> {
+        if self.fail_authoritative_fate_scan {
+            return Err(crate::storage::StorageError::IoError(
+                "simulated authoritative fate scan failure".to_string(),
+            ));
+        }
+        self.inner.scan_authoritative_batch_fates()
     }
 
     fn upsert_sealed_batch_submission(

--- a/crates/jazz-tools/src/sync_manager/tests/server_sync.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/server_sync.rs
@@ -279,6 +279,68 @@ fn add_server_with_storage_skips_rows_with_rejected_batch_fate() {
 }
 
 #[test]
+fn add_server_with_storage_skips_rejected_parent_before_local_child() {
+    let mut io = MemoryStorage::new();
+    let row_id = ObjectId::new();
+    let rejected_parent = row_with_state(
+        visible_row(row_id, "main", Vec::new(), 1_000, b"rejected-parent"),
+        crate::row_histories::RowState::VisibleDirect,
+        None,
+    );
+    let local_child = visible_row(
+        row_id,
+        "main",
+        vec![rejected_parent.batch_id()],
+        2_000,
+        b"local-child",
+    );
+
+    seed_users_schema(&mut io);
+    io.put_row_locator(
+        row_id,
+        Some(
+            &crate::storage::row_locator_from_metadata(&row_metadata("users"))
+                .expect("row metadata should produce a row locator"),
+        ),
+    )
+    .unwrap();
+    io.append_history_region_rows("users", &[rejected_parent.clone(), local_child.clone()])
+        .unwrap();
+    io.upsert_visible_region_rows(
+        "users",
+        std::slice::from_ref(&VisibleRowEntry::rebuild(
+            local_child.clone(),
+            &[rejected_parent.clone(), local_child.clone()],
+        )),
+    )
+    .unwrap();
+    io.upsert_authoritative_batch_fate(&BatchFate::Rejected {
+        batch_id: rejected_parent.batch_id(),
+        code: "permission_denied".to_string(),
+        reason: "writer lacks publish rights".to_string(),
+    })
+    .unwrap();
+
+    let mut sm = SyncManager::new();
+    let server_id = ServerId::new();
+    sm.add_server_with_storage(server_id, false, &io);
+
+    let pushed_batch_ids: Vec<_> = sm
+        .take_outbox()
+        .into_iter()
+        .filter_map(|entry| match entry {
+            OutboxEntry {
+                destination: Destination::Server(id),
+                payload: SyncPayload::RowBatchCreated { row, .. },
+            } if id == server_id => Some(row.batch_id()),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(pushed_batch_ids, vec![local_child.batch_id()]);
+}
+
+#[test]
 fn add_server_with_storage_sends_skipped_parent_before_child() {
     let mut io = MemoryStorage::new();
     let row_id = ObjectId::new();

--- a/crates/jazz-tools/src/sync_manager/tests/server_sync.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/server_sync.rs
@@ -228,6 +228,57 @@ fn add_server_with_storage_skips_rows_confirmed_by_authoritative_batch_fate() {
 }
 
 #[test]
+fn add_server_with_storage_skips_rows_with_rejected_batch_fate() {
+    let mut io = MemoryStorage::new();
+    seed_users_schema(&mut io);
+
+    let row_id = ObjectId::new();
+    let row = row_with_state(
+        visible_row(row_id, "main", Vec::new(), 1_000, b"rejected"),
+        crate::row_histories::RowState::VisibleDirect,
+        None,
+    );
+    io.put_row_locator(
+        row_id,
+        Some(
+            &crate::storage::row_locator_from_metadata(&row_metadata("users"))
+                .expect("row metadata should produce a row locator"),
+        ),
+    )
+    .unwrap();
+    io.append_history_region_rows("users", std::slice::from_ref(&row))
+        .unwrap();
+    io.upsert_authoritative_batch_fate(&BatchFate::Rejected {
+        batch_id: row.batch_id(),
+        code: "permission_denied".to_string(),
+        reason: "writer lacks publish rights".to_string(),
+    })
+    .unwrap();
+
+    let mut sm = SyncManager::new();
+    let server_id = ServerId::new();
+    sm.add_server_with_storage(server_id, false, &io);
+
+    let row_syncs = sm
+        .take_outbox()
+        .into_iter()
+        .filter(|entry| {
+            matches!(
+                entry,
+                OutboxEntry {
+                    destination: Destination::Server(id),
+                    payload: SyncPayload::RowBatchCreated { row: sent, .. },
+                } if *id == server_id && sent.batch_id() == row.batch_id()
+            )
+        })
+        .count();
+    assert_eq!(
+        row_syncs, 0,
+        "a terminally rejected row must not be replayed as a client write"
+    );
+}
+
+#[test]
 fn add_server_with_storage_sends_skipped_parent_before_child() {
     let mut io = MemoryStorage::new();
     let row_id = ObjectId::new();

--- a/crates/jazz-tools/src/sync_manager/tests/server_sync.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/server_sync.rs
@@ -279,7 +279,7 @@ fn add_server_with_storage_skips_rows_with_rejected_batch_fate() {
 }
 
 #[test]
-fn add_server_with_storage_skips_rejected_parent_before_local_child() {
+fn add_server_with_storage_withholds_local_child_of_rejected_parent() {
     let mut io = MemoryStorage::new();
     let row_id = ObjectId::new();
     let rejected_parent = row_with_state(
@@ -337,7 +337,10 @@ fn add_server_with_storage_skips_rejected_parent_before_local_child() {
         })
         .collect();
 
-    assert_eq!(pushed_batch_ids, vec![local_child.batch_id()]);
+    assert!(
+        pushed_batch_ids.is_empty(),
+        "a row whose parent was terminally rejected cannot be applied by a fresh upstream"
+    );
 }
 
 #[test]

--- a/crates/jazz-tools/src/sync_manager/tests/server_sync.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/server_sync.rs
@@ -279,6 +279,56 @@ fn add_server_with_storage_skips_rows_with_rejected_batch_fate() {
 }
 
 #[test]
+fn add_server_with_storage_fails_closed_when_authoritative_fate_scan_fails() {
+    let mut io = FailingHistoryPatchStorage::new();
+    let row_id = ObjectId::new();
+    let row = row_with_state(
+        visible_row(row_id, "main", Vec::new(), 1_000, b"local"),
+        crate::row_histories::RowState::VisibleDirect,
+        None,
+    );
+
+    seed_users_schema(io.inner_mut());
+    io.inner_mut()
+        .put_row_locator(
+            row_id,
+            Some(
+                &crate::storage::row_locator_from_metadata(&row_metadata("users"))
+                    .expect("row metadata should produce a row locator"),
+            ),
+        )
+        .unwrap();
+    io.inner_mut()
+        .append_history_region_rows("users", std::slice::from_ref(&row))
+        .unwrap();
+    io.inner_mut()
+        .upsert_visible_region_rows(
+            "users",
+            std::slice::from_ref(&VisibleRowEntry::rebuild(
+                row.clone(),
+                std::slice::from_ref(&row),
+            )),
+        )
+        .unwrap();
+    io.fail_authoritative_fate_scan = true;
+
+    let mut sm = SyncManager::new();
+    let server_id = ServerId::new();
+    sm.add_server_with_storage(server_id, false, &io);
+
+    assert!(
+        sm.take_outbox().into_iter().all(|entry| !matches!(
+            entry,
+            OutboxEntry {
+                destination: Destination::Server(id),
+                payload: SyncPayload::RowBatchCreated { .. },
+            } if id == server_id
+        )),
+        "full replay must not send rows when authoritative fates cannot be loaded"
+    );
+}
+
+#[test]
 fn add_server_with_storage_withholds_local_child_of_rejected_parent() {
     let mut io = MemoryStorage::new();
     let row_id = ObjectId::new();

--- a/crates/jazz-tools/src/sync_manager/tests/settlements.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/settlements.rs
@@ -134,6 +134,55 @@ fn server_replay_does_not_send_local_durability_ack_upstream() {
 }
 
 #[test]
+fn delayed_server_row_does_not_override_authoritative_rejection() {
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
+    let mut io = MemoryStorage::new();
+    let server_id = ServerId::new();
+    let row_id = ObjectId::new();
+    let batch_id = BatchId::new();
+    let rejected = BatchFate::Rejected {
+        batch_id,
+        code: "permission_denied".to_string(),
+        reason: "writer lacks publish rights".to_string(),
+    };
+    let row = row_with_batch_state(
+        visible_row(row_id, "main", Vec::new(), 1_000, b"alice"),
+        batch_id,
+        crate::row_histories::RowState::VisibleTransactional,
+        Some(DurabilityTier::EdgeServer),
+    );
+
+    seed_users_schema(&mut io);
+    io.upsert_authoritative_batch_fate(&rejected).unwrap();
+    add_server(&mut sm, &io, server_id);
+    sm.take_outbox();
+
+    sm.process_from_server(
+        &mut io,
+        server_id,
+        SyncPayload::RowBatchCreated {
+            metadata: Some(RowMetadata {
+                id: row_id,
+                metadata: row_metadata("users"),
+            }),
+            row,
+        },
+    );
+
+    assert_eq!(
+        io.load_authoritative_batch_fate(batch_id).unwrap(),
+        Some(rejected),
+        "a delayed accepted row must not replace an authoritative rejection"
+    );
+    assert!(
+        io.load_history_row_batch("users", "main", row_id, batch_id)
+            .unwrap()
+            .is_none(),
+        "a delayed row from a rejected batch must remain invisible"
+    );
+}
+
+#[test]
 fn client_durability_ack_is_not_authoritative() {
     let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::EdgeServer);
     let mut io = MemoryStorage::new();

--- a/crates/jazz-tools/src/sync_manager/tests/transaction_sealing.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/transaction_sealing.rs
@@ -322,6 +322,73 @@ fn direct_client_settlement_before_row_is_not_authoritative_after_row() {
 }
 
 #[test]
+fn rejected_sealed_batch_records_late_declared_member_as_rejected() {
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
+    let mut io = MemoryStorage::new();
+    let client_id = ClientId::new();
+    let batch_id = BatchId::new();
+    let row_id = ObjectId::new();
+    seed_users_schema(&mut io);
+
+    add_client(&mut sm, &io, client_id);
+    sm.set_client_role(client_id, ClientRole::Peer);
+    sm.take_outbox();
+
+    let row = row_with_batch_state(
+        visible_row(row_id, "main", Vec::new(), 1_000, b"alice"),
+        batch_id,
+        crate::row_histories::RowState::StagingPending,
+        None,
+    );
+    sm.process_from_client(
+        &mut io,
+        client_id,
+        SyncPayload::SealBatch {
+            submission: transactional_sealed_submission(
+                batch_id,
+                "main",
+                vec![SealedBatchMember {
+                    object_id: row_id,
+                    row_digest: row.content_digest(),
+                }],
+                Vec::new(),
+            ),
+        },
+    );
+    let rejected = BatchFate::Rejected {
+        batch_id,
+        code: "permission_denied".to_string(),
+        reason: "writer lacks publish rights".to_string(),
+    };
+    io.upsert_authoritative_batch_fate(&rejected).unwrap();
+
+    sm.process_from_client(
+        &mut io,
+        client_id,
+        SyncPayload::RowBatchCreated {
+            metadata: Some(RowMetadata {
+                id: row_id,
+                metadata: row_metadata("users"),
+            }),
+            row,
+        },
+    );
+
+    assert_eq!(
+        io.load_history_row_batch("users", "main", row_id, batch_id)
+            .unwrap()
+            .unwrap()
+            .state,
+        crate::row_histories::RowState::Rejected,
+        "a late declared member must be accounted for without becoming visible"
+    );
+    assert_eq!(
+        io.load_authoritative_batch_fate(batch_id).unwrap(),
+        Some(rejected)
+    );
+}
+
+#[test]
 fn direct_client_settlement_before_row_keeps_sealed_submission_without_server() {
     let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
     let mut io = MemoryStorage::new();


### PR DESCRIPTION
## Summary

- Treat authoritative rejected fates as terminal during reconnect and history replay, failing closed if the fate scan fails.
- Withhold children whose parents have terminal rejected fates and preserve rejection when a delayed row arrives.
- Avoid echoing accepted transaction rows back to the authoritative server that supplied them while still forwarding them elsewhere.
- Record exact late members of a retained rejected seal as rejected, without making them visible.

## Trade-off

A terminally rejected write will not be retried automatically if permissions later change; the application must initiate the write again.

## Testing

- Reconnect, rejected-parent, delayed-row and source-suppression regressions
- Full Rust workspace suite on the combined integration branch