### PR TITLE
Fix `in` filters in included relation queries

### DIFF
--- a/.changeset/quiet-filters-sync.md
+++ b/.changeset/quiet-filters-sync.md
@@ -1,0 +1,9 @@
+---
+"jazz-tools": patch
+"jazz-wasm": patch
+"jazz-napi": patch
+"jazz-rn": patch
+"create-jazz": patch
+---
+
+Fix `in` filters inside included relation queries, including empty lists returning no included rows. This bumps the sync protocol for the new `Condition` enum variants.

--- a/crates/jazz-tools/src/query_manager/graph/compile.rs
+++ b/crates/jazz-tools/src/query_manager/graph/compile.rs
@@ -1047,7 +1047,7 @@ impl QueryGraph {
             }
         }
         for condition in &spec.filters {
-            base_builder = apply_condition_to_builder(base_builder, condition);
+            base_builder = apply_condition_to_builder(base_builder, condition)?;
         }
         for (column, direction) in &spec.order_by {
             base_builder = match direction {
@@ -1210,7 +1210,7 @@ impl QueryGraph {
             }
         }
         for condition in &spec.filters {
-            step_builder = apply_condition_to_builder(step_builder, condition);
+            step_builder = apply_condition_to_builder(step_builder, condition)?;
         }
         if let Some(cols) = &spec.select_columns {
             let col_refs: Vec<&str> = cols.iter().map(String::as_str).collect();
@@ -2408,9 +2408,14 @@ fn compare_index_values(left: &Value, right: &Value) -> Option<Ordering> {
     }
 }
 
-fn apply_condition_to_builder(mut builder: QueryBuilder, condition: &Condition) -> QueryBuilder {
+fn apply_condition_to_builder(
+    mut builder: QueryBuilder,
+    condition: &Condition,
+) -> Option<QueryBuilder> {
     builder = match condition {
         Condition::Eq { column, value } => builder.filter_eq(column, value.clone()),
+        Condition::In { column, values } => builder.filter_in(column, values.clone()),
+        Condition::NotIn { .. } => return None,
         Condition::Ne { column, value } => builder.filter_ne(column, value.clone()),
         Condition::Lt { column, value } => builder.filter_lt(column, value.clone()),
         Condition::Le { column, value } => builder.filter_le(column, value.clone()),
@@ -2423,7 +2428,7 @@ fn apply_condition_to_builder(mut builder: QueryBuilder, condition: &Condition) 
         Condition::IsNull { column } => builder.filter_is_null(column),
         Condition::IsNotNull { column } => builder.filter_is_not_null(column),
     };
-    builder
+    Some(builder)
 }
 
 /// Convert a condition to a scan condition.

--- a/crates/jazz-tools/src/query_manager/graph_nodes/subgraph.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/subgraph.rs
@@ -105,6 +105,10 @@ impl SubgraphTemplate {
                     crate::query_manager::query::Condition::Eq { column, value } => {
                         query_builder.filter_eq(column, value.clone())
                     }
+                    crate::query_manager::query::Condition::In { column, values } => {
+                        query_builder.filter_in(column, values.clone())
+                    }
+                    crate::query_manager::query::Condition::NotIn { .. } => return None,
                     crate::query_manager::query::Condition::Ne { column, value } => {
                         query_builder.filter_ne(column, value.clone())
                     }

--- a/crates/jazz-tools/src/query_manager/query.rs
+++ b/crates/jazz-tools/src/query_manager/query.rs
@@ -1355,6 +1355,15 @@ impl RecursiveBuilder {
         self
     }
 
+    /// Add an in-list filter to each recursive step query.
+    pub fn filter_in(mut self, column: impl Into<String>, values: Vec<Value>) -> Self {
+        self.filters.push(Condition::In {
+            column: column.into(),
+            values,
+        });
+        self
+    }
+
     /// Join another table in each recursive step query.
     pub fn join(mut self, table: impl Into<TableName>) -> Self {
         self.joins.push(JoinSpec {

--- a/crates/jazz-tools/src/query_manager/query.rs
+++ b/crates/jazz-tools/src/query_manager/query.rs
@@ -159,6 +159,10 @@ pub enum Condition {
     IsNull { column: String },
     /// Column is not null.
     IsNotNull { column: String },
+    /// Column is one of the provided values.
+    In { column: String, values: Vec<Value> },
+    /// Reserved wire variant; not implemented yet.
+    NotIn { column: String, values: Vec<Value> },
 }
 
 impl Condition {
@@ -224,6 +228,17 @@ impl Condition {
                     value: encode(max),
                 },
             ]),
+            Condition::In { values, .. } => Predicate::Or(
+                values
+                    .iter()
+                    .map(|value| Predicate::RowIdEq {
+                        element_index,
+                        value: encode(value),
+                    })
+                    .collect(),
+            ),
+            // Reserved wire variant: fail closed until NOT IN is implemented.
+            Condition::NotIn { .. } => Predicate::Or(vec![]),
             Condition::Contains { .. } => Predicate::Or(vec![]),
             Condition::IsNull { .. } => Predicate::RowIdIsNull { element_index },
             Condition::IsNotNull { .. } => Predicate::RowIdIsNotNull { element_index },
@@ -234,6 +249,7 @@ impl Condition {
     pub fn raw_column(&self) -> &str {
         match self {
             Condition::Eq { column, .. } => column,
+            Condition::In { column, .. } => column,
             Condition::Ne { column, .. } => column,
             Condition::Lt { column, .. } => column,
             Condition::Le { column, .. } => column,
@@ -243,6 +259,7 @@ impl Condition {
             Condition::Contains { column, .. } => column,
             Condition::IsNull { column } => column,
             Condition::IsNotNull { column } => column,
+            Condition::NotIn { column, .. } => column,
         }
     }
 
@@ -292,6 +309,17 @@ impl Condition {
                     col_index,
                     value: encode_value_with_type(value, col_type),
                 },
+                Condition::In { values, .. } => Predicate::Or(
+                    values
+                        .iter()
+                        .map(|value| Predicate::Eq {
+                            col_index,
+                            value: encode_value_with_type(value, col_type),
+                        })
+                        .collect(),
+                ),
+                // Reserved wire variant: fail closed until NOT IN is implemented.
+                Condition::NotIn { .. } => Predicate::Or(vec![]),
                 Condition::Ne { value, .. } => Predicate::Ne {
                     col_index,
                     value: encode_value_with_type(value, col_type),
@@ -349,6 +377,17 @@ impl Condition {
                     col_index,
                     value: encode_value_with_type(value, col_type),
                 },
+                Condition::In { values, .. } => Predicate::Or(
+                    values
+                        .iter()
+                        .map(|value| Predicate::Eq {
+                            col_index,
+                            value: encode_value_with_type(value, col_type),
+                        })
+                        .collect(),
+                ),
+                // Reserved wire variant: fail closed until NOT IN is implemented.
+                Condition::NotIn { .. } => Predicate::Or(vec![]),
                 Condition::Ne { value, .. } => Predicate::Ne {
                     col_index,
                     value: encode_value_with_type(value, col_type),
@@ -815,6 +854,16 @@ impl QueryBuilder {
         current.add(Condition::Eq {
             column: column.into(),
             value,
+        });
+        self
+    }
+
+    /// Add an in-list filter condition.
+    pub fn filter_in(mut self, column: impl Into<String>, values: Vec<Value>) -> Self {
+        let current = self.query.disjuncts.last_mut().unwrap();
+        current.add(Condition::In {
+            column: column.into(),
+            values,
         });
         self
     }

--- a/crates/jazz-tools/src/query_manager/query_to_relation_ir.rs
+++ b/crates/jazz-tools/src/query_manager/query_to_relation_ir.rs
@@ -272,6 +272,12 @@ fn normalize_condition(condition: &Condition) -> Option<PredicateExpr> {
             op: PredicateCmpOp::Eq,
             right: ValueRef::Literal(value.clone()),
         }),
+        Condition::In { values, .. } => Some(PredicateExpr::In {
+            left: column_ref,
+            values: values.iter().cloned().map(ValueRef::Literal).collect(),
+        }),
+        // Reserved wire variant: reject until NOT IN is implemented.
+        Condition::NotIn { .. } => None,
         Condition::Ne { value, .. } => Some(PredicateExpr::Cmp {
             left: column_ref,
             op: PredicateCmpOp::Ne,

--- a/crates/jazz-tools/src/query_manager/relation_ir_query_plan.rs
+++ b/crates/jazz-tools/src/query_manager/relation_ir_query_plan.rs
@@ -959,6 +959,7 @@ pub(crate) fn lower_relation_to_execution_plan(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::query_manager::query::QueryBuilder;
     use crate::query_manager::relation_ir::{ColumnRef, JoinCondition, PredicateCmpOp};
     use crate::query_manager::types::Value;
 
@@ -1069,6 +1070,37 @@ mod tests {
                     column: "name".to_string(),
                 },
             ]
+        );
+    }
+
+    #[test]
+    fn lower_relation_to_execution_plan_lowers_recursive_in_filter() {
+        let query = QueryBuilder::new("teams")
+            .with_recursive(|r| {
+                r.from("team_edges")
+                    .correlate("child_team", "_id")
+                    .filter_in("kind", vec![Value::Text("target".to_string())])
+                    .max_depth(4)
+            })
+            .build();
+        let relation = crate::query_manager::query_to_relation_ir::normalize_query_to_rel_expr(&query)
+            .expect("recursive in filter should normalize to relation");
+
+        let plan = lower_relation_to_execution_plan(
+            &relation,
+            &["main".to_string()],
+            false,
+            Vec::new(),
+            None,
+        )
+        .expect("recursive in filter should lower to an execution plan");
+
+        assert_eq!(
+            plan.recursive.expect("expected recursive plan").filters,
+            vec![Condition::In {
+                column: "team_edges.kind".to_string(),
+                values: vec![Value::Text("target".to_string())],
+            }]
         );
     }
 

--- a/crates/jazz-tools/src/query_manager/relation_ir_query_plan.rs
+++ b/crates/jazz-tools/src/query_manager/relation_ir_query_plan.rs
@@ -170,6 +170,16 @@ fn predicate_term_to_condition(predicate: &PredicateExpr) -> Option<Condition> {
         PredicateExpr::IsNotNull { column } => Some(Condition::IsNotNull {
             column: to_scoped_runtime_column(column),
         }),
+        PredicateExpr::In { left, values } => Some(Condition::In {
+            column: to_scoped_runtime_column(left),
+            values: values
+                .iter()
+                .map(|value| match value {
+                    ValueRef::Literal(value) => Some(value.clone()),
+                    _ => None,
+                })
+                .collect::<Option<Vec<_>>>()?,
+        }),
         PredicateExpr::True => None,
         _ => None,
     }
@@ -1098,7 +1108,7 @@ mod tests {
         assert_eq!(
             plan.recursive.expect("expected recursive plan").filters,
             vec![Condition::In {
-                column: "team_edges.kind".to_string(),
+                column: "kind".to_string(),
                 values: vec![Value::Text("target".to_string())],
             }]
         );

--- a/crates/jazz-tools/src/query_manager/relation_ir_query_plan.rs
+++ b/crates/jazz-tools/src/query_manager/relation_ir_query_plan.rs
@@ -1093,8 +1093,9 @@ mod tests {
                     .max_depth(4)
             })
             .build();
-        let relation = crate::query_manager::query_to_relation_ir::normalize_query_to_rel_expr(&query)
-            .expect("recursive in filter should normalize to relation");
+        let relation =
+            crate::query_manager::query_to_relation_ir::normalize_query_to_rel_expr(&query)
+                .expect("recursive in filter should normalize to relation");
 
         let plan = lower_relation_to_execution_plan(
             &relation,

--- a/crates/jazz-tools/src/transport_manager.rs
+++ b/crates/jazz-tools/src/transport_manager.rs
@@ -8,7 +8,7 @@ use crate::sync_manager::types::{ClientId, InboxEntry, OutboxEntry, ServerId, Sy
 use futures::channel::mpsc;
 use std::time::Duration;
 
-pub const SYNC_PROTOCOL_VERSION: u32 = 3;
+pub const SYNC_PROTOCOL_VERSION: u32 = 4;
 const MAX_OUTBOUND_SYNC_PAYLOADS_PER_FRAME: usize = 256;
 
 pub trait TickNotifier: 'static {

--- a/crates/jazz-tools/src/transport_manager.rs
+++ b/crates/jazz-tools/src/transport_manager.rs
@@ -1419,6 +1419,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn handshake_rejects_fixed_v3_response() {
+        let controller = Arc::new(TestStreamController::default());
+        let response = ConnectedResponse {
+            sync_protocol_version: 3,
+            connection_id: "conn-1".into(),
+            client_id: "client-1".into(),
+            next_sync_seq: Some(0),
+            catalogue_state_hash: None,
+        };
+        *controller.handshake_response.lock().unwrap() = Some(frame_encode(
+            &serde_json::to_vec(&response).expect("encode handshake response"),
+        ));
+        let mut stream = TestStreamAdapter {
+            controller,
+            handshake_delivered: false,
+        };
+
+        let result =
+            TransportManager::<TestStreamAdapter, CountingTick>::do_handshake(&mut stream, vec![])
+                .await;
+
+        match result {
+            HandshakeResult::NetworkError(message) => {
+                assert!(message.contains("incompatible Jazz sync protocol"));
+                assert!(message.contains("server sent 3"));
+            }
+            HandshakeResult::Connected(_) => panic!("fixed v3 response must be rejected"),
+            HandshakeResult::AuthFailure(_) => panic!("protocol mismatch is not an auth failure"),
+        }
+    }
+
+    #[tokio::test]
     async fn shutdown_during_connect() {
         let controller = Arc::new(TestStreamController::default());
         controller.connect_pending.store(true, Ordering::SeqCst);

--- a/packages/jazz-tools/src/runtime/query-adapter.ts
+++ b/packages/jazz-tools/src/runtime/query-adapter.ts
@@ -240,6 +240,18 @@ function conditionToArraySubqueryFilter(
 
   const valueTypeForCondition =
     cond.op === "contains" && columnType.type === "Array" ? columnType.element : columnType;
+  if (cond.op === "in") {
+    if (!Array.isArray(cond.value)) {
+      throw new Error('"in" operator requires an array value');
+    }
+    return {
+      In: {
+        column,
+        values: cond.value.map((value) => toWasmValue(value, columnType, column)),
+      },
+    };
+  }
+
   const literalValue = toWasmValue(cond.value, valueTypeForCondition, column);
   const isNullValue = cond.value === undefined ? true : cond.value;
 

--- a/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
@@ -999,7 +999,18 @@ describe("TS Query API", () => {
       };
 
       await waitForSnapshot([]);
-      insertTodo(db, { title: "Other", projectId, assigneesIds: [] });
+      const { id: otherTodoId } = insertTodo(db, {
+        title: "Other",
+        projectId,
+        assigneesIds: [],
+      });
+
+      db.update(app.todos, otherTodoId, { title: "Target" });
+      await waitForSnapshot([otherTodoId]);
+
+      db.update(app.todos, otherTodoId, { title: "Other" });
+      await waitForSnapshot([]);
+
       const { id: targetTodoId } = insertTodo(db, {
         title: "Target",
         projectId,

--- a/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
@@ -929,6 +929,89 @@ describe("TS Query API", () => {
       );
     });
 
+    it("include builders filter reverse relations with in", async () => {
+      const { id: projectId } = insertProject(db, "Announcements");
+      const { id: matchingTodoId } = insertTodo(db, {
+        title: "Write tests",
+        projectId,
+        assigneesIds: [],
+      });
+      insertTodo(db, {
+        title: "Ship release",
+        projectId,
+        assigneesIds: [],
+      });
+
+      const result = await db.one(
+        app.projects.where({ id: { eq: projectId } }).include({
+          todosViaProject: app.todos.where({ id: { in: [matchingTodoId] } }),
+        }),
+      );
+
+      assert(result, "Result is not defined");
+      expect(result.todosViaProject.map((todo) => todo.id)).toEqual([matchingTodoId]);
+    });
+
+    it("include builders return no rows for an empty in list", async () => {
+      const { id: projectId } = insertProject(db, "Announcements");
+      insertTodo(db, {
+        title: "Write tests",
+        projectId,
+        assigneesIds: [],
+      });
+
+      const result = await db.one(
+        app.projects.where({ id: { eq: projectId } }).include({
+          todosViaProject: app.todos.where({ id: { in: [] } }),
+        }),
+      );
+
+      assert(result, "Result is not defined");
+      expect(result.todosViaProject).toEqual([]);
+    });
+
+    it("subscribeAll updates filtered included relations", async () => {
+      const { id: projectId } = insertProject(db, "Announcements");
+      const query = app.projects.where({ id: { eq: projectId } }).include({
+        todosViaProject: app.todos.where({ title: { in: ["Target"] } }),
+      });
+      const snapshots: string[][] = [];
+      let nextSnapshotIndex = 0;
+      const unsubscribe = db.subscribeAll(query, (delta) => {
+        const project = delta.all[0];
+        if (project) {
+          snapshots.push(project.todosViaProject.map((todo) => todo.id).sort());
+        }
+      });
+
+      const waitForSnapshot = async (expected: string[]) => {
+        const deadline = Date.now() + 4_000;
+        while (Date.now() < deadline) {
+          while (nextSnapshotIndex < snapshots.length) {
+            const actual = snapshots[nextSnapshotIndex++];
+            if (JSON.stringify(actual) === JSON.stringify(expected)) {
+              return;
+            }
+          }
+          await new Promise((resolve) => setTimeout(resolve, 20));
+        }
+        throw new Error(`Timed out waiting for included rows ${JSON.stringify(expected)}`);
+      };
+
+      await waitForSnapshot([]);
+      insertTodo(db, { title: "Other", projectId, assigneesIds: [] });
+      const { id: targetTodoId } = insertTodo(db, {
+        title: "Target",
+        projectId,
+        assigneesIds: [],
+      });
+      await waitForSnapshot([targetTodoId]);
+
+      db.delete(app.todos, targetTodoId);
+      await waitForSnapshot([]);
+      unsubscribe();
+    });
+
     it("include builders can project nested relation columns", async () => {
       const { id: projectId } = insertProject(db, "Announcements");
       const { id: ownerId } = insertUser(db);


### PR DESCRIPTION
## Summary
- Lower `in` filters inside included relation queries, including empty lists.
- Keep the new `Condition` variants append-only and reserve `NotIn`.

⚠️ This is a sync protocol version change because of the new Condition enum variants.

## Testing
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts tests/ts-dsl/query-api.test.ts` — passed
- Focused Rust query, array-subquery, relation-IR, and protocol tests — passed
