### PR TITLE
feat(jazz-tools): add `notIn` query filters

### DIFF
--- a/.changeset/smart-apples-exclude.md
+++ b/.changeset/smart-apples-exclude.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Add typed `notIn` filters to table queries for excluding rows whose column value matches any value in a list.

--- a/docs/content/partials/where-operators-table.mdx
+++ b/docs/content/partials/where-operators-table.mdx
@@ -1,15 +1,15 @@
 Operator support by column type (TypeScript):
 
-| Column kind                   | Operators / shape                          |
-| ----------------------------- | ------------------------------------------ |
-| `id`                          | `eq`, `ne`, `in`                           |
-| `s.string()`                  | `eq`, `ne`, `contains`, `in`               |
-| `s.boolean()`                 | `eq`, `ne`, `in`                           |
-| `s.int()` / `s.float()`       | `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in` |
-| `s.timestamp()`               | `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in` |
-| `s.bytes()`                   | `eq`, `ne`, `in`                           |
-| `s.ref("...")` (required)     | `eq`, `ne`, `in`                           |
-| `s.ref("...").optional()`     | `eq`, `ne`, `in`, `isNull`                 |
-| `s.enum(...)`                 | `eq`, `ne`, `in`                           |
-| `s.array(...)`                | `eq`, `contains`, `in`                     |
-| `s.json()` / `s.json(schema)` | `eq`, `ne`, `in`                           |
+| Column kind                   | Operators / shape                                   |
+| ----------------------------- | --------------------------------------------------- |
+| `id`                          | `eq`, `ne`, `in`, `notIn`                           |
+| `s.string()`                  | `eq`, `ne`, `contains`, `in`, `notIn`               |
+| `s.boolean()`                 | `eq`, `ne`, `in`, `notIn`                           |
+| `s.int()` / `s.float()`       | `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `notIn` |
+| `s.timestamp()`               | `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `notIn` |
+| `s.bytes()`                   | `eq`, `ne`, `in`, `notIn`                           |
+| `s.ref("...")` (required)     | `eq`, `ne`, `in`, `notIn`                           |
+| `s.ref("...").optional()`     | `eq`, `ne`, `in`, `notIn`, `isNull`                 |
+| `s.enum(...)`                 | `eq`, `ne`, `in`, `notIn`                           |
+| `s.array(...)`                | `eq`, `contains`, `in`, `notIn`                     |
+| `s.json()` / `s.json(schema)` | `eq`, `ne`, `in`, `notIn`                           |

--- a/packages/inspector/src/components/data-explorer/TableFilterBuilder.test.tsx
+++ b/packages/inspector/src/components/data-explorer/TableFilterBuilder.test.tsx
@@ -32,25 +32,25 @@ describe("TableFilterBuilder", () => {
     const booleanOperators = Array.from(operatorSelect.querySelectorAll("option")).map((option) =>
       option.getAttribute("value"),
     );
-    expect(booleanOperators).toEqual(["eq", "ne", "in"]);
+    expect(booleanOperators).toEqual(["eq", "ne", "in", "notIn"]);
 
     fireEvent.change(screen.getByLabelText("Column"), { target: { value: "count" } });
     const numericOperators = Array.from(operatorSelect.querySelectorAll("option")).map((option) =>
       option.getAttribute("value"),
     );
-    expect(numericOperators).toEqual(["eq", "ne", "gt", "gte", "lt", "lte", "in"]);
+    expect(numericOperators).toEqual(["eq", "ne", "gt", "gte", "lt", "lte", "in", "notIn"]);
 
     fireEvent.change(screen.getByLabelText("Column"), { target: { value: "bytes" } });
     const byteaOperators = Array.from(operatorSelect.querySelectorAll("option")).map((option) =>
       option.getAttribute("value"),
     );
-    expect(byteaOperators).toEqual(["eq", "ne", "in"]);
+    expect(byteaOperators).toEqual(["eq", "ne", "in", "notIn"]);
 
     fireEvent.change(screen.getByLabelText("Column"), { target: { value: "assignee_id" } });
     const refOperators = Array.from(operatorSelect.querySelectorAll("option")).map((option) =>
       option.getAttribute("value"),
     );
-    expect(refOperators).toEqual(["eq", "ne", "in", "isNull"]);
+    expect(refOperators).toEqual(["eq", "ne", "in", "notIn", "isNull"]);
   });
 
   it("does not show unsupported columns", () => {
@@ -91,6 +91,30 @@ describe("TableFilterBuilder", () => {
       column: "count",
       operator: "gt",
       value: 3,
+    });
+  });
+
+  it("parses notIn values as a membership array", () => {
+    const onClausesChange = vi.fn();
+    render(
+      <TableFilterBuilder
+        schemaColumns={[...schemaColumns]}
+        clauses={[]}
+        onClausesChange={onClausesChange}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Column"), { target: { value: "count" } });
+    fireEvent.change(screen.getByLabelText("Operator"), { target: { value: "notIn" } });
+    fireEvent.change(screen.getByLabelText("Value"), { target: { value: "3, 5" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add where clause" }));
+
+    expect(onClausesChange).toHaveBeenCalledTimes(1);
+    const clauses = onClausesChange.mock.calls[0]?.[0] as TableFilterClause[];
+    expect(clauses[0]).toMatchObject({
+      column: "count",
+      operator: "notIn",
+      value: [3, 5],
     });
   });
 

--- a/packages/inspector/src/components/data-explorer/TableFilterBuilder.tsx
+++ b/packages/inspector/src/components/data-explorer/TableFilterBuilder.tsx
@@ -120,13 +120,13 @@ function parseFilterValue(
     return parsed;
   }
 
-  if (operator === "in") {
+  if (operator === "in" || operator === "notIn") {
     const items = value
       .split(",")
       .map((item) => item.trim())
       .filter((item) => item.length > 0);
     if (items.length === 0) {
-      throw new Error('The "in" operator requires at least one value.');
+      throw new Error(`The "${operator}" operator requires at least one value.`);
     }
     return items.map((item) => parseScalarValue(column.columnType, item));
   }
@@ -287,7 +287,11 @@ export function TableFilterBuilder({
                   aria-label="Value"
                   className={styles.input}
                   value={draft.valueText}
-                  placeholder={draft.operator === "in" ? "value1,value2" : "value"}
+                  placeholder={
+                    draft.operator === "in" || draft.operator === "notIn"
+                      ? "value1,value2"
+                      : "value"
+                  }
                   onChange={handleValueChange}
                 />
               </div>

--- a/packages/jazz-tools/src/runtime/query-adapter.ts
+++ b/packages/jazz-tools/src/runtime/query-adapter.ts
@@ -217,6 +217,22 @@ function validateIncludeBuilderSpec(
   }
 }
 
+function lowerNotInConditions(conditions: BuiltCondition[]): BuiltCondition[] {
+  return conditions.flatMap((condition) => {
+    if (condition.op !== "notIn") {
+      return [condition];
+    }
+    if (!Array.isArray(condition.value)) {
+      throw new Error('"notIn" operator requires an array value');
+    }
+    return condition.value.map((value) => ({
+      column: condition.column,
+      op: "ne",
+      value,
+    }));
+  });
+}
+
 function conditionToArraySubqueryFilter(
   cond: BuiltCondition,
   schema: WasmSchema,
@@ -314,7 +330,7 @@ function toArraySubqueries(
     const includeProjectionColumns = hasExplicitSelect
       ? Object.keys(spec.includes).map((relationName) => hiddenIncludeColumnName(relationName))
       : [];
-    const filters = spec.conditions.map((condition) =>
+    const filters = lowerNotInConditions(spec.conditions).map((condition) =>
       conditionToArraySubqueryFilter(condition, schema, rel.toTable),
     );
     const orderBy = spec.orderBy.map(([column, direction]) => [
@@ -484,14 +500,18 @@ function conditionsToRelPredicate(
   table: string,
   scope?: string,
 ): RelPredicateExpr {
-  if (conditions.length === 0) {
+  const loweredConditions = lowerNotInConditions(conditions);
+
+  if (loweredConditions.length === 0) {
     return "True";
   }
-  if (conditions.length === 1) {
-    return conditionToRelPredicate(conditions[0]!, schema, table, scope);
+  if (loweredConditions.length === 1) {
+    return conditionToRelPredicate(loweredConditions[0]!, schema, table, scope);
   }
   return {
-    And: conditions.map((condition) => conditionToRelPredicate(condition, schema, table, scope)),
+    And: loweredConditions.map((condition) =>
+      conditionToRelPredicate(condition, schema, table, scope),
+    ),
   };
 }
 

--- a/packages/jazz-tools/src/typed-app.ts
+++ b/packages/jazz-tools/src/typed-app.ts
@@ -222,10 +222,11 @@ type WhereEqNe<T, TOptional extends boolean, TExtra extends object = {}> =
       eq?: MaybeNullableWhere<T, TOptional>;
       ne?: MaybeNullableWhere<T, TOptional>;
     } & TExtra);
+type WhereMembership<T> = { in?: T[]; notIn?: T[] };
 type NumberWhere<T extends number, TOptional extends boolean> = WhereEqNe<
   T,
   TOptional,
-  { gt?: T; gte?: T; lt?: T; lte?: T; in?: T[] }
+  { gt?: T; gte?: T; lt?: T; lte?: T } & WhereMembership<T>
 >;
 type TimestampWhere<TOptional extends boolean> = WhereEqNe<
   Date | number,
@@ -235,20 +236,23 @@ type TimestampWhere<TOptional extends boolean> = WhereEqNe<
     gte?: Date | number;
     lt?: Date | number;
     lte?: Date | number;
-    in?: (Date | number)[];
-  }
+  } & WhereMembership<Date | number>
 >;
 type UuidWhere<TOptional extends boolean> = WhereEqNe<
   string,
   TOptional,
-  TOptional extends true ? { in?: string[]; isNull?: boolean } : { in?: string[] }
+  TOptional extends true ? WhereMembership<string> & { isNull?: boolean } : WhereMembership<string>
 >;
 
 type WhereInputForBuilder<TBuilder extends AnyTypedColumnBuilder> =
   ColumnBuilderSqlType<TBuilder> extends "TEXT"
-    ? WhereEqNe<string, ColumnBuilderOptional<TBuilder>, { contains?: string; in?: string[] }>
+    ? WhereEqNe<
+        string,
+        ColumnBuilderOptional<TBuilder>,
+        { contains?: string } & WhereMembership<string>
+      >
     : ColumnBuilderSqlType<TBuilder> extends "BOOLEAN"
-      ? WhereEqNe<boolean, ColumnBuilderOptional<TBuilder>, { in?: boolean[] }>
+      ? WhereEqNe<boolean, ColumnBuilderOptional<TBuilder>, WhereMembership<boolean>>
       : ColumnBuilderSqlType<TBuilder> extends "INTEGER" | "REAL"
         ? NumberWhere<number, ColumnBuilderOptional<TBuilder>>
         : ColumnBuilderSqlType<TBuilder> extends "TIMESTAMP"
@@ -259,19 +263,19 @@ type WhereInputForBuilder<TBuilder extends AnyTypedColumnBuilder> =
               ? WhereEqNe<
                   Uint8Array,
                   ColumnBuilderOptional<TBuilder>,
-                  { in?: (Uint8Array | number[])[] }
+                  WhereMembership<Uint8Array | number[]>
                 >
               : ColumnBuilderSqlType<TBuilder> extends { kind: "JSON" }
                 ? WhereEqNe<
                     StoredColumnValue<TBuilder>,
                     ColumnBuilderOptional<TBuilder>,
-                    { in?: StoredColumnValue<TBuilder>[] }
+                    WhereMembership<StoredColumnValue<TBuilder>>
                   >
                 : ColumnBuilderSqlType<TBuilder> extends {
                       kind: "ENUM";
                       variants: readonly (infer TVariant extends string)[];
                     }
-                  ? WhereEqNe<TVariant, ColumnBuilderOptional<TBuilder>, { in?: TVariant[] }>
+                  ? WhereEqNe<TVariant, ColumnBuilderOptional<TBuilder>, WhereMembership<TVariant>>
                   : ColumnBuilderSqlType<TBuilder> extends {
                         kind: "ARRAY";
                         element: infer TElementSql extends SqlType;
@@ -279,10 +283,9 @@ type WhereInputForBuilder<TBuilder extends AnyTypedColumnBuilder> =
                     ? WhereEqNe<
                         StoredColumnValue<TBuilder>,
                         ColumnBuilderOptional<TBuilder>,
-                        {
-                          contains?: TSTypeFromSqlType<TElementSql>;
-                          in?: StoredColumnValue<TBuilder>[];
-                        }
+                        { contains?: TSTypeFromSqlType<TElementSql> } & WhereMembership<
+                          StoredColumnValue<TBuilder>
+                        >
                       >
                     : never;
 
@@ -291,7 +294,7 @@ export type TableWhereInput<
   TTable extends TableName<TSchema>,
 > = Simplify<
   {
-    id?: string | { eq?: string; ne?: string; in?: string[] };
+    id?: string | ({ eq?: string; ne?: string } & WhereMembership<string>);
   } & {
     [TColumn in ColumnName<TSchema, TTable>]?: WhereInputForBuilder<
       BuilderForColumn<TSchema, TTable, TColumn>

--- a/packages/jazz-tools/src/where-operators.test.ts
+++ b/packages/jazz-tools/src/where-operators.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  getSupportedWhereOperatorsForColumn,
+  type WhereOperatorColumn,
+} from "./where-operators.js";
+
+describe("getSupportedWhereOperatorsForColumn", () => {
+  it("supports notIn everywhere it supports in", () => {
+    const columns = [
+      { name: "id", columnType: { type: "Uuid" }, nullable: false },
+      { name: "reference", columnType: { type: "Uuid" }, nullable: true, references: "users" },
+      { name: "text", columnType: { type: "Text" }, nullable: false },
+      { name: "boolean", columnType: { type: "Boolean" }, nullable: false },
+      { name: "integer", columnType: { type: "Integer" }, nullable: false },
+      { name: "bigint", columnType: { type: "BigInt" }, nullable: false },
+      { name: "double", columnType: { type: "Double" }, nullable: false },
+      { name: "timestamp", columnType: { type: "Timestamp" }, nullable: false },
+      { name: "uuid", columnType: { type: "Uuid" }, nullable: false },
+      { name: "bytes", columnType: { type: "Bytea" }, nullable: false },
+      { name: "json", columnType: { type: "Json" }, nullable: false },
+      {
+        name: "enum",
+        columnType: { type: "Enum", variants: ["a", "b"] },
+        nullable: false,
+      },
+      {
+        name: "array",
+        columnType: { type: "Array", element: { type: "Text" } },
+        nullable: false,
+      },
+    ] satisfies WhereOperatorColumn[];
+
+    const missingNotIn = columns
+      .filter((column) => {
+        const operators = getSupportedWhereOperatorsForColumn(column);
+        return operators.includes("in") && !operators.includes("notIn");
+      })
+      .map((column) => column.name);
+
+    expect(missingNotIn).toEqual([]);
+  });
+});

--- a/packages/jazz-tools/src/where-operators.ts
+++ b/packages/jazz-tools/src/where-operators.ts
@@ -9,6 +9,7 @@ export type WhereOperator =
   | "lte"
   | "contains"
   | "in"
+  | "notIn"
   | "isNull";
 
 export interface WhereOperatorColumn {
@@ -25,30 +26,30 @@ function operatorsForColumn(
   references?: string,
 ): WhereOperator[] {
   if (references) {
-    return nullable ? ["eq", "ne", "in", "isNull"] : ["eq", "ne", "in"];
+    return nullable ? ["eq", "ne", "in", "notIn", "isNull"] : ["eq", "ne", "in", "notIn"];
   }
 
   switch (columnType.type) {
     case "Text":
-      return ["eq", "ne", "contains", "in"];
+      return ["eq", "ne", "contains", "in", "notIn"];
     case "Boolean":
-      return ["eq", "ne", "in"];
+      return ["eq", "ne", "in", "notIn"];
     case "Integer":
     case "BigInt":
     case "Double":
-      return ["eq", "ne", "gt", "gte", "lt", "lte", "in"];
+      return ["eq", "ne", "gt", "gte", "lt", "lte", "in", "notIn"];
     case "Timestamp":
-      return ["eq", "ne", "gt", "gte", "lt", "lte", "in"];
+      return ["eq", "ne", "gt", "gte", "lt", "lte", "in", "notIn"];
     case "Uuid":
-      return ["eq", "ne", "in"];
+      return ["eq", "ne", "in", "notIn"];
     case "Bytea":
-      return ["eq", "ne", "in"];
+      return ["eq", "ne", "in", "notIn"];
     case "Json":
-      return ["eq", "ne", "in"];
+      return ["eq", "ne", "in", "notIn"];
     case "Enum":
-      return ["eq", "ne", "in"];
+      return ["eq", "ne", "in", "notIn"];
     case "Array":
-      return ["eq", "contains", "in"];
+      return ["eq", "contains", "in", "notIn"];
     case "Row":
       return [];
   }
@@ -56,7 +57,7 @@ function operatorsForColumn(
 
 export function getSupportedWhereOperatorsForColumn(column: WhereOperatorColumn): WhereOperator[] {
   if (column.implicitId || column.name === "id") {
-    return ["eq", "ne", "in"];
+    return ["eq", "ne", "in", "notIn"];
   }
 
   return operatorsForColumn(column.columnType, column.nullable, column.references);
@@ -67,7 +68,7 @@ export function getSupportedWhereOperatorsForSchemaColumn(
   column: ColumnDescriptor | undefined,
 ): WhereOperator[] | undefined {
   if (fieldName === "id") {
-    return ["eq", "ne", "in"];
+    return ["eq", "ne", "in", "notIn"];
   }
 
   if (!column) {

--- a/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
@@ -1114,6 +1114,36 @@ describe("TS Query API", () => {
       expect(result.todosViaProject.map((todo) => todo.id)).toEqual([includedTodoId]);
     });
 
+    it("include builders apply every notIn exclusion to reverse relations", async () => {
+      const { id: projectId } = insertProject(db, "Announcements");
+      const { id: includedTodoId } = insertTodo(db, {
+        title: "Write tests",
+        projectId,
+        assigneesIds: [],
+      });
+      const { id: firstExcludedTodoId } = insertTodo(db, {
+        title: "Ship release",
+        projectId,
+        assigneesIds: [],
+      });
+      const { id: secondExcludedTodoId } = insertTodo(db, {
+        title: "Write docs",
+        projectId,
+        assigneesIds: [],
+      });
+
+      const result = await db.one(
+        app.projects.where({ id: { eq: projectId } }).include({
+          todosViaProject: app.todos.where({
+            id: { notIn: [firstExcludedTodoId, secondExcludedTodoId] },
+          }),
+        }),
+      );
+
+      assert(result, "Result is not defined");
+      expect(result.todosViaProject.map((todo) => todo.id)).toEqual([includedTodoId]);
+    });
+
     it("include builders return no rows for an empty in list", async () => {
       const { id: projectId } = insertProject(db, "Announcements");
       insertTodo(db, {

--- a/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
@@ -248,6 +248,145 @@ describe("TS Query API", () => {
       });
     });
 
+    describe("notIn operator", () => {
+      it("filters enum columns with multiple exclusions", async () => {
+        db.insert(app.table_with_defaults, { enum: "a" });
+        const { value: rowB } = db.insert(app.table_with_defaults, { enum: "b" });
+        db.insert(app.table_with_defaults, { enum: "c" });
+
+        const results = await db.all(
+          app.table_with_defaults.where({ enum: { notIn: ["a", "c"] } }),
+        );
+
+        expect(results.map((row) => row.id)).toEqual([rowB.id]);
+      });
+
+      it("ANDs membership filters across chained where calls", async () => {
+        db.insert(app.table_with_defaults, { enum: "a" });
+        const { value: rowB } = db.insert(app.table_with_defaults, { enum: "b" });
+        db.insert(app.table_with_defaults, { enum: "c" });
+
+        const results = await db.all(
+          app.table_with_defaults
+            .where({ enum: { in: ["a", "b"] } })
+            .where({ enum: { notIn: ["a"] } }),
+        );
+
+        expect(results.map((row) => row.id)).toEqual([rowB.id]);
+      });
+
+      it("applies the same exclusions to id and reference columns", async () => {
+        const projectA = insertProject(db, "Project A");
+        const projectB = insertProject(db, "Project B");
+        const projectC = insertProject(db, "Project C");
+        insertTodo(db, { title: "A", projectId: projectA.id });
+        const todoB = insertTodo(db, { title: "B", projectId: projectB.id });
+        insertTodo(db, { title: "C", projectId: projectC.id });
+
+        const projects = await db.all(
+          app.projects.where({ id: { notIn: [projectA.id, projectC.id] } }),
+        );
+        const todos = await db.all(
+          app.todos.where({ projectId: { notIn: [projectA.id, projectC.id] } }),
+        );
+
+        expect(projects.map((project) => project.id)).toEqual([projectB.id]);
+        expect(todos.map((todo) => todo.id)).toEqual([todoB.id]);
+      });
+
+      it("matches all rows for an empty list", async () => {
+        const { value: rowA } = db.insert(app.table_with_defaults, { enum: "a" });
+        const { value: rowB } = db.insert(app.table_with_defaults, { enum: "b" });
+
+        const results = await db.all(app.table_with_defaults.where({ enum: { notIn: [] } }));
+
+        expect(results.map((row) => row.id).sort()).toEqual([rowA.id, rowB.id].sort());
+      });
+
+      it("preserves ne semantics for nullable columns", async () => {
+        const { value: nullRow } = db.insert(app.table_with_defaults, { nullable: null });
+        const { value: keptRow } = db.insert(app.table_with_defaults, { nullable: "kept" });
+        db.insert(app.table_with_defaults, { nullable: "excluded" });
+
+        const results = await db.all(
+          app.table_with_defaults.where({ nullable: { notIn: ["excluded"] } }),
+        );
+
+        expect(results.map((row) => row.id).sort()).toEqual([nullRow.id, keptRow.id].sort());
+      });
+
+      it("serializes timestamp exclusions", async () => {
+        const excluded = new Date("2026-03-01T00:00:00.000Z");
+        const kept = new Date("2026-03-02T00:00:00.000Z");
+        db.insert(app.table_with_defaults, { timestampDate: excluded });
+        const { value: keptRow } = db.insert(app.table_with_defaults, { timestampDate: kept });
+
+        const results = await db.all(
+          app.table_with_defaults.where({ timestampDate: { notIn: [excluded] } }),
+        );
+
+        expect(results.map((row) => row.id)).toEqual([keptRow.id]);
+      });
+
+      it("serializes byte-array exclusions", async () => {
+        db.insert(app.table_with_defaults, { bytes: new Uint8Array([1, 2, 3]) });
+        const { value: keptRow } = db.insert(app.table_with_defaults, {
+          bytes: new Uint8Array([4, 5, 6]),
+        });
+
+        const results = await db.all(
+          app.table_with_defaults.where({
+            bytes: { notIn: [new Uint8Array([1, 2, 3])] },
+          }),
+        );
+
+        expect(results.map((row) => row.id)).toEqual([keptRow.id]);
+      });
+
+      it("serializes JSON exclusions", async () => {
+        db.insert(app.table_with_defaults, { json: { name: "excluded", age: 1 } });
+        const { value: keptRow } = db.insert(app.table_with_defaults, {
+          json: { name: "kept", age: 2 },
+        });
+
+        const results = await db.all(
+          app.table_with_defaults.where({
+            json: { notIn: [{ name: "excluded", age: 1 }] },
+          }),
+        );
+
+        expect(results.map((row) => row.id)).toEqual([keptRow.id]);
+      });
+
+      it("compares array exclusions by whole-array equality", async () => {
+        db.insert(app.table_with_defaults, { array: ["a", "b"] });
+        const { value: shorterRow } = db.insert(app.table_with_defaults, { array: ["a"] });
+        const { value: reorderedRow } = db.insert(app.table_with_defaults, {
+          array: ["b", "a"],
+        });
+
+        const results = await db.all(
+          app.table_with_defaults.where({ array: { notIn: [["a", "b"]] } }),
+        );
+
+        expect(results.map((row) => row.id).sort()).toEqual(
+          [shorterRow.id, reorderedRow.id].sort(),
+        );
+      });
+
+      it("composes with another predicate on the same column", async () => {
+        db.insert(app.table_with_defaults, { integer: 5 });
+        db.insert(app.table_with_defaults, { integer: 10 });
+        const { value: keptRow } = db.insert(app.table_with_defaults, { integer: 15 });
+
+        const results = await db.all(
+          app.table_with_defaults.where({ integer: { notIn: [10], gt: 5 } }),
+        );
+
+        expect(results.map((row) => row.id)).toEqual([keptRow.id]);
+      });
+    });
+
     it("filters int columns with multiple range operators on the same column", async () => {
       db.insert(app.table_with_defaults, { integer: 5 });
       const { value: aliceTask } = db.insert(app.table_with_defaults, { integer: 10 });
@@ -952,6 +1091,29 @@ describe("TS Query API", () => {
       expect(result.todosViaProject.map((todo) => todo.id)).toEqual([matchingTodoId]);
     });
 
+    it("include builders filter reverse relations with notIn", async () => {
+      const { id: projectId } = insertProject(db, "Announcements");
+      const { id: includedTodoId } = insertTodo(db, {
+        title: "Write tests",
+        projectId,
+        assigneesIds: [],
+      });
+      const { id: excludedTodoId } = insertTodo(db, {
+        title: "Ship release",
+        projectId,
+        assigneesIds: [],
+      });
+
+      const result = await db.one(
+        app.projects.where({ id: { eq: projectId } }).include({
+          todosViaProject: app.todos.where({ id: { notIn: [excludedTodoId] } }),
+        }),
+      );
+
+      assert(result, "Result is not defined");
+      expect(result.todosViaProject.map((todo) => todo.id)).toEqual([includedTodoId]);
+    });
+
     it("include builders return no rows for an empty in list", async () => {
       const { id: projectId } = insertProject(db, "Announcements");
       insertTodo(db, {
@@ -968,6 +1130,31 @@ describe("TS Query API", () => {
 
       assert(result, "Result is not defined");
       expect(result.todosViaProject).toEqual([]);
+    });
+
+    it("include builders return all rows for an empty notIn list", async () => {
+      const { id: projectId } = insertProject(db, "Announcements");
+      const { id: firstTodoId } = insertTodo(db, {
+        title: "Write tests",
+        projectId,
+        assigneesIds: [],
+      });
+      const { id: secondTodoId } = insertTodo(db, {
+        title: "Ship release",
+        projectId,
+        assigneesIds: [],
+      });
+
+      const result = await db.one(
+        app.projects.where({ id: { eq: projectId } }).include({
+          todosViaProject: app.todos.where({ id: { notIn: [] } }),
+        }),
+      );
+
+      assert(result, "Result is not defined");
+      expect(result.todosViaProject.map((todo) => todo.id).sort()).toEqual(
+        [firstTodoId, secondTodoId].sort(),
+      );
     });
 
     it("subscribeAll updates filtered included relations", async () => {

--- a/packages/jazz-tools/tests/ts-dsl/typed-app.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/typed-app.test.ts
@@ -283,20 +283,44 @@ describe("typed app prototype", () => {
     expectTypeOf(todoInsert.project).toEqualTypeOf<string>();
     expectTypeOf(todoInsert.owner).toEqualTypeOf<string | null | undefined>();
 
+    expectTypeOf<TodoWhere["id"]>().branded.toEqualTypeOf<
+      string | { eq?: string; ne?: string; in?: string[]; notIn?: string[] } | undefined
+    >();
     expectTypeOf<TodoWhere["project"]>().branded.toEqualTypeOf<
-      string | { eq?: string; ne?: string; in?: string[] } | undefined
+      string | { eq?: string; ne?: string; in?: string[]; notIn?: string[] } | undefined
     >();
     expectTypeOf<TodoWhere["owner"]>().branded.toEqualTypeOf<
       | string
       | null
-      | { eq?: string | null; ne?: string | null; in?: string[]; isNull?: boolean }
+      | {
+          eq?: string | null;
+          ne?: string | null;
+          in?: string[];
+          notIn?: string[];
+          isNull?: boolean;
+        }
       | undefined
     >();
     expectTypeOf<TodoWhere["tags"]>().branded.toEqualTypeOf<
-      string[] | { eq?: string[]; ne?: string[]; contains?: string; in?: string[][] } | undefined
+      | string[]
+      | {
+          eq?: string[];
+          ne?: string[];
+          contains?: string;
+          in?: string[][];
+          notIn?: string[][];
+        }
+      | undefined
     >();
     expectTypeOf<TodoWhere["attachment"]>().branded.toEqualTypeOf<
-      Uint8Array | { eq?: Uint8Array; ne?: Uint8Array; in?: (Uint8Array | number[])[] } | undefined
+      | Uint8Array
+      | {
+          eq?: Uint8Array;
+          ne?: Uint8Array;
+          in?: (Uint8Array | number[])[];
+          notIn?: (Uint8Array | number[])[];
+        }
+      | undefined
     >();
 
     const projectRecord: ProjectRecord | null = todoWithProject.project;
@@ -388,13 +412,22 @@ describe("typed app prototype", () => {
     }
   });
 
-  it("infers in filters for boolean, bytes, and array columns", () => {
+  it("infers membership filters for boolean, bytes, and array columns", () => {
+    const notInFilter: s.WhereOf<typeof app.todos> = { done: { notIn: [true] } };
+    void notInFilter;
+
+    if ((globalThis as { __typecheck_only__?: boolean }).__typecheck_only__) {
+      // @ts-expect-error notIn membership filters require an array
+      app.todos.where({ done: { notIn: true } });
+    }
+
     expectTypeOf<s.WhereOf<typeof app.todos>["done"]>().branded.toEqualTypeOf<
       | boolean
       | {
           eq?: boolean;
           ne?: boolean;
           in?: boolean[];
+          notIn?: boolean[];
         }
       | undefined
     >();
@@ -405,6 +438,7 @@ describe("typed app prototype", () => {
           ne?: string[];
           contains?: string;
           in?: string[][];
+          notIn?: string[][];
         }
       | undefined
     >();
@@ -414,6 +448,7 @@ describe("typed app prototype", () => {
           eq?: Uint8Array;
           ne?: Uint8Array;
           in?: (Uint8Array | number[])[];
+          notIn?: (Uint8Array | number[])[];
         }
       | undefined
     >();
@@ -439,6 +474,7 @@ describe("typed app prototype", () => {
           lt?: number;
           lte?: number;
           in?: number[];
+          notIn?: number[];
         }
       | undefined
     >();


### PR DESCRIPTION
## Summary

- add typed `notIn` membership filters across supported table column types
- lower `notIn` to conjunctive `ne` predicates for root and included relation queries
- expose `notIn` in Inspector filtering and document operator support

Closes #1082

Should probably land in the same release as #1087 for protocol change simplicity.

## Testing

- `pnpm lint`
- `pnpm build:core`
- affected Jazz Tools tests
- Better Auth adapter tests
- Inspector tests
- Jazz Tools and Inspector TypeScript checks
- Oxfmt and Cargo formatting checks