### PR TITLE
fix: make persisted batch recovery complete and retryable

### DIFF
--- a/.changeset/recover-incomplete-batch-settlement.md
+++ b/.changeset/recover-incomplete-batch-settlement.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Make persisted batch-fate recovery complete and retryable after restarts, missing batch members, or row materialisation failures.

--- a/crates/jazz-tools/src/client.rs
+++ b/crates/jazz-tools/src/client.rs
@@ -563,6 +563,18 @@ impl JazzClient {
         self.runtime.transport_client_id()
     }
 
+    pub fn fail_prepared_row_mutation_for_batch_for_test(&self, batch_id: BatchId) -> Result<()> {
+        self.runtime
+            .fail_prepared_row_mutation_for_batch_for_test(batch_id)
+            .map_err(|error| JazzError::Storage(error.to_string()))
+    }
+
+    pub fn prepared_row_mutation_failure_is_armed_for_test(&self) -> Result<bool> {
+        self.runtime
+            .prepared_row_mutation_failure_is_armed_for_test()
+            .map_err(|error| JazzError::Storage(error.to_string()))
+    }
+
     pub async fn test_client(schema: Schema) -> crate::JazzClient {
         let context = crate::AppContext::test(schema);
         crate::JazzClient::connect(context)

--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/rejection_recovery.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/rejection_recovery.rs
@@ -114,6 +114,75 @@ fn rc_direct_insert_persisted_reconnect_reconciles_rejected_batch_from_server() 
 }
 
 #[test]
+fn rc_rejected_fate_falls_back_from_partial_sealed_membership() {
+    let mut core =
+        create_runtime_with_schema(test_schema(), "rejected-partial-sealed-membership-test");
+    attach_server_and_drain(&mut core);
+    let batch_id = core.begin_batch(crate::batch_fate::BatchMode::Direct);
+    let write_context = WriteContext::default().with_batch_id(batch_id);
+
+    let ((first_row_id, _), _) = core
+        .insert(
+            "users",
+            user_insert_values(ObjectId::new(), "Alice"),
+            Some(&write_context),
+        )
+        .unwrap();
+    let ((second_row_id, _), _) = core
+        .insert(
+            "users",
+            user_insert_values(ObjectId::new(), "Bob"),
+            Some(&write_context),
+        )
+        .unwrap();
+    core.commit_batch(batch_id).unwrap();
+
+    assert_eq!(
+        core.storage()
+            .load_local_batch_record(batch_id)
+            .unwrap()
+            .expect("unsettled direct batch should retain its local record")
+            .members
+            .len(),
+        2,
+        "the lower-priority local record must retain complete membership"
+    );
+    core.storage_mut()
+        .put_row_locator(second_row_id, None)
+        .unwrap();
+    assert_eq!(
+        core.local_batch_rows(batch_id).len(),
+        2,
+        "partial sealed membership must fall back to the complete local record"
+    );
+
+    core.replay_batch_rejection(batch_id, "permission_denied", "writer lacks publish rights")
+        .unwrap();
+
+    let branch_name = core.schema_manager().branch_name();
+    for row_id in [first_row_id, second_row_id] {
+        assert_eq!(
+            core.storage()
+                .load_visible_region_row("users", branch_name.as_str(), row_id)
+                .unwrap(),
+            None,
+            "an authoritative rejection must retract every sealed batch member"
+        );
+        assert_eq!(
+            core.storage()
+                .scan_history_row_batches("users", row_id)
+                .unwrap()
+                .into_iter()
+                .find(|row| row.batch_id == batch_id)
+                .expect("batch member history should remain available")
+                .state,
+            crate::row_histories::RowState::Rejected,
+            "an authoritative rejection must mark every sealed batch member rejected"
+        );
+    }
+}
+
+#[test]
 fn rc_direct_update_rejection_restores_previous_visible_row() {
     let mut core = create_runtime_with_schema(test_schema(), "direct-update-reject-restore-test");
 

--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/transactional.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/transactional.rs
@@ -159,6 +159,81 @@ fn rc_transactional_insert_persisted_tracks_local_batch_record_and_settlement() 
 }
 
 #[test]
+fn rc_restart_reapplies_persisted_accepted_fate_before_retiring_submission() {
+    let schema = test_schema();
+    let schema_hash = SchemaHash::compute(&schema);
+    let batch_id = BatchId::new();
+    let row_id = ObjectId::new();
+    let staged_row = staged_user_row(row_id, batch_id, 1_000, "Alice");
+
+    let mut old_runtime = create_runtime_with_schema_and_sync_manager(
+        schema.clone(),
+        "transactional-restart-existing-fate-recovery-test",
+        SyncManager::new().with_durability_tier(DurabilityTier::Local),
+    );
+    old_runtime
+        .storage_mut()
+        .put_row_locator(
+            row_id,
+            Some(&RowLocator {
+                table: "users".into(),
+                origin_schema_hash: Some(schema_hash),
+            }),
+        )
+        .unwrap();
+    old_runtime
+        .storage_mut()
+        .append_history_region_rows("users", std::slice::from_ref(&staged_row))
+        .unwrap();
+    old_runtime
+        .storage_mut()
+        .upsert_sealed_batch_submission(&SealedBatchSubmission::new(
+            batch_id,
+            crate::batch_fate::BatchMode::Transactional,
+            crate::object::BranchName::new("main"),
+            vec![SealedBatchMember {
+                object_id: row_id,
+                row_digest: staged_row.content_digest(),
+            }],
+            Vec::new(),
+        ))
+        .unwrap();
+    old_runtime
+        .storage_mut()
+        .upsert_authoritative_batch_fate(&crate::batch_fate::BatchFate::AcceptedTransaction {
+            batch_id,
+            confirmed_tier: DurabilityTier::Local,
+        })
+        .unwrap();
+
+    let storage = old_runtime.into_storage();
+    let restarted = create_runtime_with_storage_and_sync_manager(
+        schema,
+        "transactional-restart-existing-fate-recovery-test",
+        storage,
+        SyncManager::new().with_durability_tier(DurabilityTier::Local),
+    );
+
+    let visible = restarted
+        .storage()
+        .load_visible_region_row("users", "main", row_id)
+        .unwrap()
+        .expect("restart recovery should apply the persisted accepted fate");
+    assert_eq!(
+        visible.state,
+        crate::row_histories::RowState::VisibleTransactional
+    );
+    assert_eq!(
+        restarted
+            .storage()
+            .load_sealed_batch_submission(batch_id)
+            .unwrap(),
+        None,
+        "recovery should retire the submission only after applying its fate"
+    );
+}
+
+#[test]
 fn rc_transactional_insert_is_accepted_when_replayed_to_reconnected_upstream() {
     // alice stages one transactional row while disconnected
     //   reconnect alone is not enough

--- a/crates/jazz-tools/src/runtime_core/ticks.rs
+++ b/crates/jazz-tools/src/runtime_core/ticks.rs
@@ -48,7 +48,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         submission
             .members
             .into_iter()
-            .filter_map(|sealed_member| {
+            .map(|sealed_member| {
                 let row_locator = self
                     .storage
                     .load_row_locator(sealed_member.object_id)
@@ -69,7 +69,8 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                     row_digest: sealed_member.row_digest,
                 })
             })
-            .collect()
+            .collect::<Option<Vec<_>>>()
+            .unwrap_or_default()
     }
 
     fn cached_local_batch_members(&self, batch_id: BatchId) -> Vec<LocalBatchMember> {
@@ -201,10 +202,16 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
 
         let mut rows = Vec::new();
         for load_members in member_sources {
-            rows = self.local_batch_rows_from_members(batch_id, load_members(self, batch_id));
-            if !rows.is_empty() {
+            let members = load_members(self, batch_id);
+            if members.is_empty() {
+                continue;
+            }
+            let expected_rows = members.len();
+            rows = self.local_batch_rows_from_members(batch_id, members);
+            if rows.len() == expected_rows {
                 break;
             }
+            rows.clear();
         }
         if rows.is_empty() {
             // Last-resort fallback if the batchId->rows index is not found.

--- a/crates/jazz-tools/src/runtime_tokio.rs
+++ b/crates/jazz-tools/src/runtime_tokio.rs
@@ -798,6 +798,25 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
         Ok(f(core.storage()))
     }
 
+    #[cfg(feature = "test-utils")]
+    pub fn fail_prepared_row_mutation_for_batch_for_test(
+        &self,
+        batch_id: BatchId,
+    ) -> Result<(), RuntimeError> {
+        let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
+        core.storage_mut()
+            .fail_prepared_row_mutation_for_batch_for_test(batch_id);
+        Ok(())
+    }
+
+    #[cfg(feature = "test-utils")]
+    pub fn prepared_row_mutation_failure_is_armed_for_test(&self) -> Result<bool, RuntimeError> {
+        let core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
+        Ok(core
+            .storage()
+            .prepared_row_mutation_failure_is_armed_for_test())
+    }
+
     /// Run a closure with read access to the SyncManager (for testing/inspection).
     #[cfg(test)]
     pub(crate) fn with_sync_manager<R>(

--- a/crates/jazz-tools/src/server/mod.rs
+++ b/crates/jazz-tools/src/server/mod.rs
@@ -130,6 +130,19 @@ impl BlockedMessagesToClient {
         }
     }
 
+    pub fn release_matching(
+        &self,
+        predicate: impl Fn(&SyncPayload) -> bool,
+    ) -> Option<SyncPayload> {
+        self.hub
+            .release_message_matching(self.client_id, &predicate)
+    }
+
+    pub fn discard_matching(&self, predicate: impl Fn(&SyncPayload) -> bool) -> usize {
+        self.hub
+            .discard_messages_matching(self.client_id, &predicate)
+    }
+
     pub fn unblock(mut self) {
         if !self.unblocked {
             self.hub.unblock_messages_to(self.client_id);
@@ -345,6 +358,38 @@ impl ConnectionEventHub {
             let prepared = self.prepare_payload(client_id, payload);
             self.dispatch_prepared(prepared);
         }
+    }
+
+    #[cfg(feature = "test-utils")]
+    fn release_message_matching(
+        &self,
+        client_id: ClientId,
+        predicate: &impl Fn(&SyncPayload) -> bool,
+    ) -> Option<SyncPayload> {
+        let payload = {
+            let mut blocked_clients = self.blocked_clients.lock().unwrap();
+            let blocked = blocked_clients.get_mut(&client_id)?;
+            let index = blocked.queue.iter().position(predicate)?;
+            blocked.queue.remove(index)?
+        };
+        let prepared = self.prepare_payload(client_id, payload.clone());
+        self.dispatch_prepared(prepared);
+        Some(payload)
+    }
+
+    #[cfg(feature = "test-utils")]
+    fn discard_messages_matching(
+        &self,
+        client_id: ClientId,
+        predicate: &impl Fn(&SyncPayload) -> bool,
+    ) -> usize {
+        let mut blocked_clients = self.blocked_clients.lock().unwrap();
+        let Some(blocked) = blocked_clients.get_mut(&client_id) else {
+            return 0;
+        };
+        let original_len = blocked.queue.len();
+        blocked.queue.retain(|payload| !predicate(payload));
+        original_len - blocked.queue.len()
     }
 
     #[cfg(feature = "test-utils")]

--- a/crates/jazz-tools/src/storage/memory.rs
+++ b/crates/jazz-tools/src/storage/memory.rs
@@ -48,6 +48,8 @@ pub struct MemoryStorage {
     flush_wal_failures: std::cell::RefCell<Option<(StorageError, Option<usize>)>>,
     #[cfg(test)]
     flush_wal_call_count: std::cell::RefCell<usize>,
+    #[cfg(feature = "test-utils")]
+    prepared_row_mutation_failure_batch: Option<BatchId>,
     /// Ordered raw-table storage.
     raw_tables: HashMap<String, RawTableEntries>,
     authoritative_batch_fates: std::cell::RefCell<HashMap<BatchId, BatchFate>>,
@@ -135,6 +137,8 @@ impl Default for MemoryStorage {
             flush_wal_failures: std::cell::RefCell::new(None),
             #[cfg(test)]
             flush_wal_call_count: std::cell::RefCell::new(0),
+            #[cfg(feature = "test-utils")]
+            prepared_row_mutation_failure_batch: None,
             raw_tables: HashMap::new(),
             authoritative_batch_fates: std::cell::RefCell::new(HashMap::new()),
             ensured_raw_table_headers: HashSet::new(),
@@ -148,6 +152,16 @@ impl Default for MemoryStorage {
 impl Storage for MemoryStorage {
     fn storage_cache_namespace(&self) -> usize {
         self.cache_namespace
+    }
+
+    #[cfg(feature = "test-utils")]
+    fn fail_prepared_row_mutation_for_batch_for_test(&mut self, batch_id: BatchId) {
+        self.prepared_row_mutation_failure_batch = Some(batch_id);
+    }
+
+    #[cfg(feature = "test-utils")]
+    fn prepared_row_mutation_failure_is_armed_for_test(&self) -> bool {
+        self.prepared_row_mutation_failure_batch.is_some()
     }
 
     fn scan_row_locators(&self) -> Result<RowLocatorRows, StorageError> {
@@ -169,6 +183,16 @@ impl Storage for MemoryStorage {
         encoded_visible_rows: &[OwnedVisibleRowBytes],
         index_mutations: &[IndexMutation<'_>],
     ) -> Result<(), StorageError> {
+        #[cfg(feature = "test-utils")]
+        if self
+            .prepared_row_mutation_failure_batch
+            .is_some_and(|batch_id| history_rows.iter().any(|row| row.batch_id == batch_id))
+        {
+            self.prepared_row_mutation_failure_batch = None;
+            return Err(StorageError::IoError(
+                "simulated prepared row mutation failure".to_string(),
+            ));
+        }
         if history_rows.len() != encoded_history_rows.len() {
             return Err(StorageError::IoError(format!(
                 "prepared history row count mismatch: {} decoded vs {} encoded",

--- a/crates/jazz-tools/src/storage/storage_trait.rs
+++ b/crates/jazz-tools/src/storage/storage_trait.rs
@@ -27,6 +27,16 @@ pub trait Storage {
         std::ptr::from_ref(self).cast::<()>() as usize
     }
 
+    #[cfg(feature = "test-utils")]
+    fn fail_prepared_row_mutation_for_batch_for_test(&mut self, _batch_id: BatchId) {
+        panic!("storage does not support prepared-row fault injection");
+    }
+
+    #[cfg(feature = "test-utils")]
+    fn prepared_row_mutation_failure_is_armed_for_test(&self) -> bool {
+        false
+    }
+
     // ================================================================
     // Logical row locator storage (sync - returns immediately with result)
     // ================================================================
@@ -1761,6 +1771,16 @@ pub trait Storage {
 impl<T: Storage + ?Sized> Storage for Box<T> {
     fn storage_cache_namespace(&self) -> usize {
         (**self).storage_cache_namespace()
+    }
+
+    #[cfg(feature = "test-utils")]
+    fn fail_prepared_row_mutation_for_batch_for_test(&mut self, batch_id: BatchId) {
+        (**self).fail_prepared_row_mutation_for_batch_for_test(batch_id);
+    }
+
+    #[cfg(feature = "test-utils")]
+    fn prepared_row_mutation_failure_is_armed_for_test(&self) -> bool {
+        (**self).prepared_row_mutation_failure_is_armed_for_test()
     }
 
     fn scan_row_locators(&self) -> Result<RowLocatorRows, StorageError> {

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -946,6 +946,28 @@ impl SyncManager {
             return false;
         }
 
+        if matches!(fate, BatchFate::Rejected { .. }) {
+            let submission = match storage.load_sealed_batch_submission(fate.batch_id()) {
+                Ok(Some(submission)) => submission,
+                Ok(None) => return true,
+                Err(error) => {
+                    tracing::error!(
+                        batch_id = ?fate.batch_id(),
+                        %error,
+                        "failed to verify rejected batch membership; retaining sealed batch submission for recovery"
+                    );
+                    return false;
+                }
+            };
+            if !Self::sealed_submission_members_are_complete(&submission, batch_rows) {
+                tracing::error!(
+                    batch_id = ?fate.batch_id(),
+                    "authoritative rejection has not been applied to every declared member; retaining sealed batch submission for recovery"
+                );
+                return false;
+            }
+        }
+
         if self.batch_fate_is_settled(fate)
             && let Err(error) = storage.delete_sealed_batch_submission(fate.batch_id())
         {
@@ -1034,6 +1056,19 @@ impl SyncManager {
             declared_rows.push(matching_row.clone());
         }
         Some(declared_rows)
+    }
+
+    fn sealed_submission_members_are_complete(
+        submission: &SealedBatchSubmission,
+        batch_rows: &[(String, StoredRowBatch)],
+    ) -> bool {
+        submission.members.iter().all(|member| {
+            batch_rows.iter().any(|(_, row)| {
+                row.batch_id == submission.batch_id
+                    && row.row_id == member.object_id
+                    && row.branch.as_str() == submission.target_branch_name.as_str()
+            })
+        })
     }
 
     /// True when this authority's tier outranks an existing `DurableDirect`
@@ -1173,6 +1208,26 @@ impl SyncManager {
                     // Continue into seal validation so this authority can promote a
                     // previously local direct fate to its own durability tier.
                 } else {
+                    if matches!(fate, BatchFate::Rejected { .. }) {
+                        let batch_rows = self.transactional_batch_rows(
+                            storage,
+                            batch_id,
+                            Some(&submission.target_branch_name),
+                            &submission
+                                .members
+                                .iter()
+                                .map(|member| member.object_id)
+                                .collect::<Vec<_>>(),
+                        );
+                        let _ = self.apply_batch_fate_and_retire_sealed_submission(
+                            storage,
+                            Some(client_id),
+                            &fate,
+                            &batch_rows,
+                        );
+                        self.queue_batch_fate_to_client_unfiltered(client_id, fate);
+                        return;
+                    }
                     let should_prune_submission = self.batch_fate_is_settled(&fate);
                     let prune_result = if should_prune_submission {
                         storage.delete_sealed_batch_submission(batch_id)

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -1222,6 +1222,7 @@ impl SyncManager {
                         let _ = self.apply_batch_fate_and_retire_sealed_submission(
                             storage,
                             Some(client_id),
+                            None,
                             &fate,
                             &batch_rows,
                         );
@@ -1444,13 +1445,18 @@ impl SyncManager {
     /// Process a single inbox entry.
     pub(super) fn process_inbox_entry<H: Storage>(&mut self, storage: &mut H, entry: InboxEntry) {
         tracing::trace!(source = ?entry.source, payload = entry.payload.variant_name(), "processing inbox entry");
-        match entry.source {
+        let retry_entry = entry.clone();
+        let processed = match entry.source {
             Source::Server(server_id) => {
                 self.process_from_server(storage, server_id, entry.payload)
             }
             Source::Client(client_id) => {
-                self.process_from_client(storage, client_id, entry.payload)
+                self.process_from_client(storage, client_id, entry.payload);
+                true
             }
+        };
+        if !processed {
+            self.inbox.push(retry_entry);
         }
     }
 
@@ -1460,7 +1466,7 @@ impl SyncManager {
         storage: &mut H,
         server_id: ServerId,
         payload: SyncPayload,
-    ) {
+    ) -> bool {
         let _span = tracing::debug_span!("process_from_server", %server_id, payload = payload.variant_name()).entered();
         match payload {
             SyncPayload::CatalogueEntryUpdated { entry } => {
@@ -1483,32 +1489,28 @@ impl SyncManager {
                     %branch_name,
                     "server→row-batch payload"
                 );
-                if let Some(applied) = self.apply_row_updated(
+                let Some(applied) = self.apply_row_updated(
                     storage,
                     metadata,
                     row.clone(),
                     AuthoritativeFateRecording::AcceptedByLocalAuthority,
-                ) {
-                    self.apply_authoritative_transaction_fate_for_row(
-                        storage,
-                        server_id,
-                        &applied.row,
+                ) else {
+                    return matches!(
+                        storage.load_authoritative_batch_fate(row.batch_id),
+                        Ok(Some(BatchFate::Rejected { .. }))
                     );
+                };
+                self.apply_authoritative_transaction_fate_for_row(storage, server_id, &applied.row);
 
-                    if let Some(update) = applied.visibility_change {
-                        self.pending_row_visibility_changes.push(update);
-                        self.forward_update_to_clients_with_storage(
-                            storage,
-                            object_id,
-                            branch_name,
-                        );
-                    }
+                if let Some(update) = applied.visibility_change {
+                    self.pending_row_visibility_changes.push(update);
+                    self.forward_update_to_clients_with_storage(storage, object_id, branch_name);
                 }
             }
             SyncPayload::BatchFate { fate } => {
                 let fate = match self.persist_authoritative_batch_fate(storage, &fate) {
                     Ok((fate, _)) => fate,
-                    Err(_) => return,
+                    Err(_) => return true,
                 };
                 self.pending_batch_fates.push(fate.clone());
                 if let BatchFate::AcceptedTransaction { batch_id, .. } = fate {
@@ -1616,6 +1618,7 @@ impl SyncManager {
             | SyncPayload::QueryUnsubscription { .. }
             | SyncPayload::SealBatch { .. } => {}
         }
+        true
     }
 
     /// Process a payload from a client.

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -681,8 +681,22 @@ impl SyncManager {
         table: &str,
         row: StoredRowBatch,
     ) -> Option<crate::row_histories::ApplyRowBatchResult> {
-        let context =
-            crate::storage::resolve_history_row_write_context(storage, table, &row).ok()?;
+        let row_id = row.row_id;
+        let batch_id = row.batch_id;
+        let context = match crate::storage::resolve_history_row_write_context(storage, table, &row)
+        {
+            Ok(context) => context,
+            Err(error) => {
+                tracing::error!(
+                    ?row_id,
+                    ?batch_id,
+                    table,
+                    %error,
+                    "failed to resolve row write context while applying authoritative batch fate"
+                );
+                return None;
+            }
+        };
         let branch_name = BranchName::new(&row.branch);
         let row_locator = storage
             .load_row_locator(row.row_id)
@@ -693,10 +707,10 @@ impl SyncManager {
                 origin_schema_hash: Some(context.history_row_raw_table_id().schema_hash),
             });
 
-        apply_row_batch_with_context(
+        match apply_row_batch_with_context(
             storage,
             ApplyRowBatchWithContext {
-                object_id: row.row_id,
+                object_id: row_id,
                 branch_name: &branch_name,
                 row,
                 index_mutations: &[],
@@ -706,8 +720,19 @@ impl SyncManager {
                 context,
                 is_known_new_object: false,
             },
-        )
-        .ok()
+        ) {
+            Ok(applied) => Some(applied),
+            Err(error) => {
+                tracing::error!(
+                    ?row_id,
+                    ?batch_id,
+                    table,
+                    ?error,
+                    "failed to apply authoritative batch fate to row"
+                );
+                None
+            }
+        }
     }
 
     fn apply_transactional_batch_fate_to_rows<H: Storage>(
@@ -717,7 +742,8 @@ impl SyncManager {
         origin_server_id: Option<ServerId>,
         fate: &BatchFate,
         batch_rows: &[(String, StoredRowBatch)],
-    ) {
+    ) -> bool {
+        let mut applied_all = true;
         let server_ids: Vec<_> = self
             .servers
             .keys()
@@ -734,6 +760,7 @@ impl SyncManager {
                     direct_row.confirmed_tier = None;
                     let applied =
                         self.apply_row_batch_for_table(storage, table, direct_row.clone());
+                    applied_all &= applied.is_some();
 
                     let metadata = self.metadata_for_batch_row(storage, table, &direct_row);
 
@@ -787,6 +814,7 @@ impl SyncManager {
                     let accepted_row = row.accepted_transaction_output(*confirmed_tier);
                     let applied =
                         self.apply_row_batch_for_table(storage, table, accepted_row.clone());
+                    applied_all &= applied.is_some();
 
                     let metadata = self.metadata_for_batch_row(storage, table, &accepted_row);
 
@@ -839,16 +867,26 @@ impl SyncManager {
                     let branch_name = BranchName::new(&row.branch);
                     let row_batch_id = row.batch_id();
 
-                    let visibility_change = patch_row_batch_state(
+                    let visibility_change = match patch_row_batch_state(
                         storage,
                         row_id,
                         &branch_name,
                         row_batch_id,
                         Some(RowState::Rejected),
                         None,
-                    )
-                    .ok()
-                    .flatten();
+                    ) {
+                        Ok(visibility_change) => visibility_change,
+                        Err(error) => {
+                            tracing::error!(
+                                ?row_id,
+                                ?row_batch_id,
+                                ?error,
+                                "failed to apply authoritative rejection to row"
+                            );
+                            applied_all = false;
+                            continue;
+                        }
+                    };
 
                     if let Some(update) = visibility_change {
                         self.pending_row_visibility_changes.push(update);
@@ -869,11 +907,11 @@ impl SyncManager {
                     }
                 }
             }
-            BatchFate::Missing { .. } => return,
+            BatchFate::Missing { .. } => return false,
         }
 
         if matches!(fate, BatchFate::DurableDirect { .. }) {
-            return;
+            return applied_all;
         }
 
         if let Some(client_id) = origin_client_id {
@@ -882,6 +920,43 @@ impl SyncManager {
                 payload: SyncPayload::BatchFate { fate: fate.clone() },
             });
         }
+
+        applied_all
+    }
+
+    fn apply_batch_fate_and_retire_sealed_submission<H: Storage>(
+        &mut self,
+        storage: &mut H,
+        origin_client_id: Option<ClientId>,
+        origin_server_id: Option<ServerId>,
+        fate: &BatchFate,
+        batch_rows: &[(String, StoredRowBatch)],
+    ) -> bool {
+        if !self.apply_transactional_batch_fate_to_rows(
+            storage,
+            origin_client_id,
+            origin_server_id,
+            fate,
+            batch_rows,
+        ) {
+            tracing::error!(
+                batch_id = ?fate.batch_id(),
+                "failed to materialize authoritative batch fate; retaining sealed batch submission for recovery"
+            );
+            return false;
+        }
+
+        if self.batch_fate_is_settled(fate)
+            && let Err(error) = storage.delete_sealed_batch_submission(fate.batch_id())
+        {
+            tracing::warn!(
+                batch_id = ?fate.batch_id(),
+                %error,
+                "failed to delete sealed batch submission"
+            );
+        }
+
+        true
     }
 
     fn apply_authoritative_transaction_fate_for_row<H: Storage>(
@@ -912,7 +987,7 @@ impl SyncManager {
                 .unwrap_or_default(),
             row.clone(),
         )];
-        self.apply_transactional_batch_fate_to_rows(
+        let _ = self.apply_transactional_batch_fate_to_rows(
             storage,
             None,
             Some(origin_server_id),
@@ -936,14 +1011,7 @@ impl SyncManager {
             Ok((fate, false)) => fate,
             Err(_) => return,
         };
-        if let Err(error) = storage.delete_sealed_batch_submission(fate.batch_id()) {
-            tracing::warn!(
-                batch_id = ?fate.batch_id(),
-                %error,
-                "failed to delete rejected sealed batch submission"
-            );
-        }
-        self.apply_transactional_batch_fate_to_rows(
+        let _ = self.apply_batch_fate_and_retire_sealed_submission(
             storage,
             origin_client_id,
             None,
@@ -1054,11 +1122,6 @@ impl SyncManager {
             }
         };
 
-        if self.batch_fate_is_settled(&fate)
-            && let Err(error) = storage.delete_sealed_batch_submission(batch_id)
-        {
-            tracing::warn!(?batch_id, %error, "failed to delete sealed batch submission");
-        }
         let rows_to_patch: &[(String, StoredRowBatch)] = match fate {
             BatchFate::DurableDirect { .. } | BatchFate::AcceptedTransaction { .. } => {
                 &declared_rows
@@ -1066,13 +1129,17 @@ impl SyncManager {
             BatchFate::Rejected { .. } => &batch_rows,
             BatchFate::Missing { .. } => &[],
         };
-        self.apply_transactional_batch_fate_to_rows(
-            storage,
-            origin_client_id,
-            None,
-            &fate,
-            rows_to_patch,
-        );
+        if matches!(fate, BatchFate::Missing { .. })
+            || !self.apply_batch_fate_and_retire_sealed_submission(
+                storage,
+                origin_client_id,
+                None,
+                &fate,
+                rows_to_patch,
+            )
+        {
+            return;
+        }
 
         if matches!(fate, BatchFate::DurableDirect { .. }) {
             let mut interested_clients = self.interested_clients_for_batch_fate(&fate);
@@ -1216,13 +1283,14 @@ impl SyncManager {
 
         let mut recovered_any = false;
         for submission in submissions {
-            match storage.load_authoritative_batch_fate(submission.batch_id) {
+            let existing_fate = match storage.load_authoritative_batch_fate(submission.batch_id) {
                 Ok(Some(fate)) if self.can_promote_direct_fate(&fate) => {
                     // Continue into validation so this authority can promote a
                     // direct fate that was previously confirmed by a lower tier.
+                    None
                 }
-                Ok(Some(_)) => continue,
-                Ok(None) => {}
+                Ok(Some(fate)) => Some(fate),
+                Ok(None) => None,
                 Err(error) => {
                     tracing::warn!(
                         batch_id = ?submission.batch_id,
@@ -1231,7 +1299,7 @@ impl SyncManager {
                     );
                     continue;
                 }
-            }
+            };
 
             let batch_rows = self.transactional_batch_rows(
                 storage,
@@ -1243,6 +1311,38 @@ impl SyncManager {
                     .map(|member| member.object_id)
                     .collect::<Vec<_>>(),
             );
+            if let Some(fate) = existing_fate {
+                let declared_rows = match fate {
+                    BatchFate::DurableDirect { .. } | BatchFate::AcceptedTransaction { .. } => {
+                        let Some(declared_rows) =
+                            Self::declared_rows_for_submission(&submission, &batch_rows)
+                        else {
+                            tracing::error!(
+                                batch_id = ?submission.batch_id,
+                                "authoritative batch fate exists but its declared rows are incomplete; retaining sealed batch submission for recovery"
+                            );
+                            continue;
+                        };
+                        declared_rows
+                    }
+                    BatchFate::Rejected { .. } => Vec::new(),
+                    BatchFate::Missing { .. } => continue,
+                };
+                let mode = match submission.mode {
+                    BatchMode::Direct => SealedBatchMode::Direct,
+                    BatchMode::Transactional => SealedBatchMode::Transactional,
+                };
+                self.settle_sealed_batch(
+                    storage,
+                    None,
+                    submission,
+                    batch_rows,
+                    declared_rows,
+                    mode,
+                );
+                recovered_any = true;
+                continue;
+            }
             if let Err(rejection) = self.validate_sealed_batch_submission(&submission) {
                 self.reject_sealed_transactional_batch(storage, None, rejection, &batch_rows);
                 recovered_any = true;
@@ -1358,7 +1458,7 @@ impl SyncManager {
                 self.pending_batch_fates.push(fate.clone());
                 if let BatchFate::AcceptedTransaction { batch_id, .. } = fate {
                     let rows = self.known_transactional_batch_rows_for_fate(storage, batch_id);
-                    self.apply_transactional_batch_fate_to_rows(
+                    let _ = self.apply_transactional_batch_fate_to_rows(
                         storage,
                         None,
                         Some(server_id),

--- a/crates/jazz-tools/src/sync_manager/tests.rs
+++ b/crates/jazz-tools/src/sync_manager/tests.rs
@@ -138,6 +138,7 @@ fn persist_visible_row_settlement(
 struct FailingHistoryPatchStorage {
     inner: MemoryStorage,
     fail_history_load: bool,
+    fail_prepared_row_mutation: bool,
     fail_authoritative_fate_scan: bool,
     fail_authoritative_settlement_upsert: bool,
     fail_sealed_submission_upsert: bool,
@@ -148,6 +149,7 @@ impl FailingHistoryPatchStorage {
         Self {
             inner: MemoryStorage::new(),
             fail_history_load: false,
+            fail_prepared_row_mutation: false,
             fail_authoritative_fate_scan: false,
             fail_authoritative_settlement_upsert: false,
             fail_sealed_submission_upsert: false,
@@ -194,6 +196,11 @@ impl Storage for FailingHistoryPatchStorage {
         encoded_visible_rows: &[crate::storage::OwnedVisibleRowBytes],
         index_mutations: &[crate::storage::IndexMutation<'_>],
     ) -> Result<(), crate::storage::StorageError> {
+        if self.fail_prepared_row_mutation {
+            return Err(crate::storage::StorageError::IoError(format!(
+                "simulated prepared row mutation failure for {table}"
+            )));
+        }
         self.inner.apply_prepared_row_mutation(
             table,
             history_rows,

--- a/crates/jazz-tools/src/sync_manager/tests/settlements.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/settlements.rs
@@ -183,6 +183,76 @@ fn delayed_server_row_does_not_override_authoritative_rejection() {
 }
 
 #[test]
+fn server_row_is_retried_after_post_fate_materialisation_failure() {
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
+    let mut io = FailingHistoryPatchStorage::new();
+    io.fail_prepared_row_mutation = true;
+    let server_id = ServerId::new();
+    let row_id = ObjectId::new();
+    let batch_id = BatchId::new();
+    let accepted = BatchFate::AcceptedTransaction {
+        batch_id,
+        confirmed_tier: DurabilityTier::EdgeServer,
+    };
+    let row = row_with_batch_state(
+        visible_row(row_id, "main", Vec::new(), 1_000, b"alice"),
+        batch_id,
+        crate::row_histories::RowState::VisibleTransactional,
+        Some(DurabilityTier::EdgeServer),
+    );
+
+    seed_users_schema(io.inner_mut());
+    io.upsert_authoritative_batch_fate(&accepted).unwrap();
+    sm.add_server_with_storage(server_id, false, &io);
+    sm.take_outbox();
+    sm.push_inbox(InboxEntry {
+        source: Source::Server(server_id),
+        payload: SyncPayload::RowBatchCreated {
+            metadata: Some(RowMetadata {
+                id: row_id,
+                metadata: row_metadata("users"),
+            }),
+            row,
+        },
+    });
+
+    sm.process_inbox(&mut io);
+
+    assert_eq!(
+        io.load_authoritative_batch_fate(batch_id).unwrap(),
+        Some(accepted),
+        "the simulated row failure must preserve the authoritative accepted fate"
+    );
+    assert!(
+        io.load_history_row_batch("users", "main", row_id, batch_id)
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        sm.inbox.len(),
+        1,
+        "a server row must remain queued when materialisation fails after fate persistence"
+    );
+
+    io.fail_prepared_row_mutation = false;
+    sm.process_inbox(&mut io);
+
+    assert!(sm.inbox.is_empty());
+    assert_eq!(
+        io.load_history_row_batch("users", "main", row_id, batch_id)
+            .unwrap()
+            .unwrap()
+            .state,
+        crate::row_histories::RowState::VisibleTransactional
+    );
+    assert_eq!(
+        io.scan_history_row_batches("users", row_id).unwrap().len(),
+        1,
+        "retry must materialise the server row exactly once"
+    );
+}
+
+#[test]
 fn client_durability_ack_is_not_authoritative() {
     let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::EdgeServer);
     let mut io = MemoryStorage::new();

--- a/crates/jazz-tools/src/sync_manager/tests/settlements.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/settlements.rs
@@ -246,7 +246,10 @@ fn server_row_is_retried_after_post_fate_materialisation_failure() {
         crate::row_histories::RowState::VisibleTransactional
     );
     assert_eq!(
-        io.scan_history_row_batches("users", row_id).unwrap().len(),
+        io.inner
+            .scan_history_row_batches("users", row_id)
+            .unwrap()
+            .len(),
         1,
         "retry must materialise the server row exactly once"
     );

--- a/crates/jazz-tools/src/sync_manager/tests/transaction_sealing.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/transaction_sealing.rs
@@ -442,6 +442,111 @@ fn direct_client_settlement_before_row_keeps_sealed_submission_without_server() 
 }
 
 #[test]
+fn rejected_sealed_batch_retains_submission_until_all_members_are_handled() {
+    let mut sm = SyncManager::new().with_durability_tier(DurabilityTier::Local);
+    let mut io = MemoryStorage::new();
+    let client_id = ClientId::new();
+    let batch_id = BatchId::new();
+    let first_row_id = ObjectId::new();
+    let second_row_id = ObjectId::new();
+    seed_users_schema(&mut io);
+
+    add_client(&mut sm, &io, client_id);
+    sm.set_client_role(client_id, ClientRole::Peer);
+    sm.take_outbox();
+
+    let first_row = row_with_batch_state(
+        visible_row(first_row_id, "main", Vec::new(), 1_000, b"alice"),
+        batch_id,
+        crate::row_histories::RowState::StagingPending,
+        None,
+    );
+    let second_row = row_with_batch_state(
+        visible_row(second_row_id, "main", Vec::new(), 1_001, b"bob"),
+        batch_id,
+        crate::row_histories::RowState::StagingPending,
+        None,
+    );
+
+    sm.process_from_client(
+        &mut io,
+        client_id,
+        SyncPayload::RowBatchCreated {
+            metadata: Some(RowMetadata {
+                id: first_row_id,
+                metadata: row_metadata("users"),
+            }),
+            row: first_row.clone(),
+        },
+    );
+
+    let submission = transactional_sealed_submission(
+        batch_id,
+        "main",
+        vec![
+            SealedBatchMember {
+                object_id: first_row_id,
+                row_digest: first_row.content_digest(),
+            },
+            SealedBatchMember {
+                object_id: second_row_id,
+                row_digest: second_row.content_digest(),
+            },
+        ],
+        Vec::new(),
+    );
+    sm.process_from_client(
+        &mut io,
+        client_id,
+        SyncPayload::SealBatch {
+            submission: submission.clone(),
+        },
+    );
+
+    let rejected = BatchFate::Rejected {
+        batch_id,
+        code: "permission_denied".to_string(),
+        reason: "writer lacks publish rights".to_string(),
+    };
+    io.upsert_authoritative_batch_fate(&rejected).unwrap();
+
+    assert!(sm.recover_completed_sealed_batches_with_storage(&mut io));
+    assert!(
+        io.load_sealed_batch_submission(batch_id).unwrap().is_some(),
+        "a rejected batch must retain its recovery manifest while a declared member is missing"
+    );
+    assert_eq!(
+        io.load_history_row_batch("users", "main", first_row_id, batch_id)
+            .unwrap()
+            .unwrap()
+            .state,
+        crate::row_histories::RowState::Rejected
+    );
+
+    sm.process_from_client(
+        &mut io,
+        client_id,
+        SyncPayload::RowBatchCreated {
+            metadata: Some(RowMetadata {
+                id: second_row_id,
+                metadata: row_metadata("users"),
+            }),
+            row: second_row,
+        },
+    );
+    sm.recover_completed_sealed_batches_with_storage(&mut io);
+
+    assert_eq!(
+        io.load_history_row_batch("users", "main", second_row_id, batch_id)
+            .unwrap()
+            .unwrap()
+            .state,
+        crate::row_histories::RowState::Rejected
+    );
+    assert_eq!(io.load_sealed_batch_submission(batch_id).unwrap(), None);
+}
+
+#[test]
 fn seal_batch_to_servers_targets_pending_server_transport() {
     let mut sm = SyncManager::new();
     let server_id = ServerId::new();

--- a/crates/jazz-tools/tests/transactions.rs
+++ b/crates/jazz-tools/tests/transactions.rs
@@ -549,6 +549,117 @@ async fn multiple_writes_in_one_transaction_settle_as_one_batch() {
     server.shutdown().await;
 }
 
+#[tokio::test]
+async fn subscribed_client_retries_transaction_row_after_transient_storage_failure() {
+    let (server, alice, bob) = start_two_clients(todo_schema()).await;
+    let todo_id = insert_visible_todo(&alice, "before transaction", false).await;
+    wait_for_todos(
+        &bob,
+        Some(DurabilityTier::EdgeServer),
+        "bob sees the row before alice's transaction",
+        |rows| has_todo(rows, todo_id, "before transaction", false),
+    )
+    .await;
+
+    let blocked = server.block_messages_to(bob.client_id().expect("bob client id"));
+    let tx = alice
+        .begin_transaction()
+        .expect("begin transaction through client API");
+    let batch_id = tx
+        .update(
+            todo_id,
+            vec![(
+                "title".to_string(),
+                Value::Text("after transaction".to_string()),
+            )],
+        )
+        .expect("stage transaction update");
+    assert_eq!(tx.commit().expect("commit transaction"), batch_id);
+    alice
+        .wait_for_batch(batch_id, DurabilityTier::EdgeServer)
+        .await
+        .expect("alice's transaction should be accepted");
+
+    blocked
+        .wait_until_buffered(
+            |payload| {
+                matches!(
+                    payload,
+                    SyncPayload::RowBatchCreated { row, .. }
+                        | SyncPayload::RowBatchNeeded { row, .. }
+                        if row.batch_id == batch_id && row.row_id == todo_id
+                )
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("server should send the accepted transaction row to bob");
+    blocked
+        .wait_until_buffered(
+            |payload| {
+                matches!(
+                    payload,
+                    SyncPayload::BatchFate { fate } if fate.batch_id() == batch_id
+                )
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("server should send the accepted transaction fate to bob");
+    bob.fail_prepared_row_mutation_for_batch_for_test(batch_id)
+        .expect("arm one transient storage failure for the transaction row");
+    blocked
+        .release_matching(|payload| {
+            matches!(
+                payload,
+                SyncPayload::RowBatchCreated { row, .. }
+                    | SyncPayload::RowBatchNeeded { row, .. }
+                    if row.batch_id == batch_id && row.row_id == todo_id
+            )
+        })
+        .expect("release the transaction row into the transient failure");
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if !bob
+                .prepared_row_mutation_failure_is_armed_for_test()
+                .expect("inspect transient storage failure")
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("the released transaction row should trigger the storage failure");
+    blocked.discard_matching(|payload| {
+        matches!(
+            payload,
+            SyncPayload::RowBatchCreated { row, .. }
+                | SyncPayload::RowBatchNeeded { row, .. }
+                if row.batch_id == batch_id && row.row_id == todo_id
+        )
+    });
+    blocked
+        .release_matching(
+            |payload| matches!(payload, SyncPayload::BatchFate { fate } if fate.batch_id() == batch_id),
+        )
+        .expect("release the accepted transaction fate after the row failure");
+
+    let rows = wait_for_todos(
+        &bob,
+        None,
+        "bob sees the accepted row after the transient storage failure",
+        |rows| has_todo(rows, todo_id, "after transaction", false),
+    )
+    .await;
+    assert!(has_todo(&rows, todo_id, "after transaction", false));
+    blocked.unblock();
+
+    alice.shutdown().await.expect("shutdown alice");
+    bob.shutdown().await.expect("shutdown bob");
+    server.shutdown().await;
+}
+
 /// Two transactions modify the same object unaware of each other.
 /// The server accepts the first tx and rejects the second.
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Reapply persisted accepted fates during restart recovery before retiring sealed submissions.
- Use a batch-membership source only when every declared member resolves exactly.
- Retain rejected-batch recovery manifests until every declared member has been handled.
- Retry server rows when fate persistence succeeds but row materialisation fails, with loud failure logging.

## Testing

- Restart, partial-membership and materialisation-retry regressions
- Full Rust workspace suite on the combined integration branch