### PR TITLE
fix: persist direct batch settlement before publishing rows

### DIFF
--- a/.changeset/persist-batch-settlement-before-visibility.md
+++ b/.changeset/persist-batch-settlement-before-visibility.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Persist batch settlement and recovery metadata before publishing rows, so failed commits cannot expose partially durable writes.

--- a/crates/jazz-tools/src/runtime_core/tests.rs
+++ b/crates/jazz-tools/src/runtime_core/tests.rs
@@ -36,6 +36,7 @@ struct RowRegionReadFailingStorage {
     inner: MemoryStorage,
     fail_visible_row_reads: bool,
     fail_row_locator_scans: bool,
+    fail_sealed_submission_upserts: Arc<Mutex<bool>>,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -70,6 +71,7 @@ impl RowRegionReadFailingStorage {
             inner: MemoryStorage::new(),
             fail_visible_row_reads: true,
             fail_row_locator_scans: false,
+            fail_sealed_submission_upserts: Arc::new(Mutex::new(false)),
         }
     }
 
@@ -78,6 +80,18 @@ impl RowRegionReadFailingStorage {
             inner: MemoryStorage::new(),
             fail_visible_row_reads: false,
             fail_row_locator_scans: true,
+            fail_sealed_submission_upserts: Arc::new(Mutex::new(false)),
+        }
+    }
+
+    fn with_sealed_submission_upsert_failure(
+        fail_sealed_submission_upserts: Arc<Mutex<bool>>,
+    ) -> Self {
+        Self {
+            inner: MemoryStorage::new(),
+            fail_visible_row_reads: false,
+            fail_row_locator_scans: false,
+            fail_sealed_submission_upserts,
         }
     }
 }
@@ -165,6 +179,18 @@ impl Storage for RowRegionReadFailingStorage {
         locator: Option<&crate::storage::RowLocator>,
     ) -> Result<(), StorageError> {
         self.inner.put_row_locator(id, locator)
+    }
+
+    fn upsert_sealed_batch_submission(
+        &mut self,
+        submission: &SealedBatchSubmission,
+    ) -> Result<(), StorageError> {
+        if *self.fail_sealed_submission_upserts.lock().unwrap() {
+            return Err(StorageError::IoError(
+                "sealed submission upserts deliberately disabled in this test".to_string(),
+            ));
+        }
+        self.inner.upsert_sealed_batch_submission(submission)
     }
 
     fn raw_table_put(&mut self, table: &str, key: &str, value: &[u8]) -> Result<(), StorageError> {

--- a/crates/jazz-tools/src/runtime_core/tests.rs
+++ b/crates/jazz-tools/src/runtime_core/tests.rs
@@ -37,6 +37,7 @@ struct RowRegionReadFailingStorage {
     fail_visible_row_reads: bool,
     fail_row_locator_scans: bool,
     fail_sealed_submission_upserts: Arc<Mutex<bool>>,
+    fail_prepared_row_mutations: Arc<Mutex<bool>>,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -72,6 +73,7 @@ impl RowRegionReadFailingStorage {
             fail_visible_row_reads: true,
             fail_row_locator_scans: false,
             fail_sealed_submission_upserts: Arc::new(Mutex::new(false)),
+            fail_prepared_row_mutations: Arc::new(Mutex::new(false)),
         }
     }
 
@@ -81,6 +83,7 @@ impl RowRegionReadFailingStorage {
             fail_visible_row_reads: false,
             fail_row_locator_scans: true,
             fail_sealed_submission_upserts: Arc::new(Mutex::new(false)),
+            fail_prepared_row_mutations: Arc::new(Mutex::new(false)),
         }
     }
 
@@ -92,6 +95,17 @@ impl RowRegionReadFailingStorage {
             fail_visible_row_reads: false,
             fail_row_locator_scans: false,
             fail_sealed_submission_upserts,
+            fail_prepared_row_mutations: Arc::new(Mutex::new(false)),
+        }
+    }
+
+    fn with_prepared_row_mutation_failure(fail_prepared_row_mutations: Arc<Mutex<bool>>) -> Self {
+        Self {
+            inner: MemoryStorage::new(),
+            fail_visible_row_reads: false,
+            fail_row_locator_scans: false,
+            fail_sealed_submission_upserts: Arc::new(Mutex::new(false)),
+            fail_prepared_row_mutations,
         }
     }
 }
@@ -147,6 +161,11 @@ impl Storage for RowRegionReadFailingStorage {
         encoded_visible_rows: &[crate::storage::OwnedVisibleRowBytes],
         index_mutations: &[crate::storage::IndexMutation<'_>],
     ) -> Result<(), StorageError> {
+        if *self.fail_prepared_row_mutations.lock().unwrap() {
+            return Err(StorageError::IoError(
+                "prepared row mutations deliberately disabled in this test".to_string(),
+            ));
+        }
         self.inner.apply_prepared_row_mutation(
             table,
             history_rows,

--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/direct.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/direct.rs
@@ -13,6 +13,78 @@ fn rc_auto_committed_direct_write_rejects_later_commit() {
 }
 
 #[test]
+fn rc_direct_commit_persistence_failure_keeps_rows_staged_and_retryable() {
+    let fail_sealed_submission_upserts = Arc::new(Mutex::new(true));
+    let mut core = create_runtime_with_boxed_storage(
+        test_schema(),
+        "direct-commit-persistence-failure-test",
+        Box::new(
+            RowRegionReadFailingStorage::with_sealed_submission_upsert_failure(
+                fail_sealed_submission_upserts.clone(),
+            ),
+        ),
+    );
+    let server_id = ServerId::new();
+    core.add_server(server_id);
+    core.batched_tick();
+    core.sync_sender().take();
+
+    let batch_id = core.begin_batch(crate::batch_fate::BatchMode::Direct);
+    let write_context = WriteContext::default()
+        .with_batch_mode(crate::batch_fate::BatchMode::Direct)
+        .with_batch_id(batch_id);
+    let ((first_row_id, _), _) = core
+        .insert(
+            "users",
+            user_insert_values(ObjectId::new(), "Alice"),
+            Some(&write_context),
+        )
+        .unwrap();
+    let ((second_row_id, _), _) = core
+        .insert(
+            "users",
+            user_insert_values(ObjectId::new(), "Bob"),
+            Some(&write_context),
+        )
+        .unwrap();
+
+    let error = core
+        .commit_batch(batch_id)
+        .expect_err("metadata persistence failure must fail the direct commit");
+    assert!(
+        error
+            .to_string()
+            .contains("persist sealed batch submission"),
+        "expected the injected sealed-submission failure, got {error}"
+    );
+
+    let branch_name = core.schema_manager().branch_name();
+    for row_id in [first_row_id, second_row_id] {
+        assert_eq!(
+            core.storage()
+                .load_visible_region_row("users", branch_name.as_str(), row_id)
+                .unwrap(),
+            None,
+            "a failed direct commit must not publish any batch member"
+        );
+    }
+
+    *fail_sealed_submission_upserts.lock().unwrap() = false;
+    core.commit_batch(batch_id)
+        .expect("the direct batch should remain retryable after persistence recovers");
+
+    for row_id in [first_row_id, second_row_id] {
+        let visible = core
+            .storage()
+            .load_visible_region_row("users", branch_name.as_str(), row_id)
+            .unwrap()
+            .expect("a successful retry should publish every direct batch member");
+        assert_eq!(visible.batch_id, batch_id);
+        assert_eq!(visible.state, crate::row_histories::RowState::VisibleDirect);
+    }
+}
+
+#[test]
 fn rc_insert_syncs_exact_row_batch_without_row_region_reads() {
     let mut core = create_runtime_with_boxed_storage(
         test_schema(),

--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/direct.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/direct.rs
@@ -57,6 +57,13 @@ fn rc_direct_commit_persistence_failure_keeps_rows_staged_and_retryable() {
             .contains("persist sealed batch submission"),
         "expected the injected sealed-submission failure, got {error}"
     );
+    assert_eq!(
+        core.storage()
+            .load_authoritative_batch_fate(batch_id)
+            .unwrap(),
+        None,
+        "a direct batch fate must not be durable before its seal"
+    );
 
     let branch_name = core.schema_manager().branch_name();
     for row_id in [first_row_id, second_row_id] {

--- a/crates/jazz-tools/src/runtime_core/tests/write_batch/direct.rs
+++ b/crates/jazz-tools/src/runtime_core/tests/write_batch/direct.rs
@@ -92,6 +92,53 @@ fn rc_direct_commit_persistence_failure_keeps_rows_staged_and_retryable() {
 }
 
 #[test]
+fn rc_direct_publication_failure_retains_frozen_recovery_state() {
+    let fail_prepared_row_mutations = Arc::new(Mutex::new(false));
+    let mut core = create_runtime_with_boxed_storage(
+        test_schema(),
+        "direct-publication-failure-test",
+        Box::new(
+            RowRegionReadFailingStorage::with_prepared_row_mutation_failure(
+                fail_prepared_row_mutations.clone(),
+            ),
+        ),
+    );
+    let batch_id = core.begin_batch(crate::batch_fate::BatchMode::Direct);
+    let write_context = WriteContext::default()
+        .with_batch_mode(crate::batch_fate::BatchMode::Direct)
+        .with_batch_id(batch_id);
+    core.insert(
+        "users",
+        user_insert_values(ObjectId::new(), "Alice"),
+        Some(&write_context),
+    )
+    .unwrap();
+
+    *fail_prepared_row_mutations.lock().unwrap() = true;
+    core.commit_batch(batch_id)
+        .expect_err("row publication failure must fail the direct commit");
+
+    assert!(
+        core.storage()
+            .load_sealed_batch_submission(batch_id)
+            .unwrap()
+            .is_some(),
+        "a publication failure must retain the durable seal for restart recovery"
+    );
+    assert!(
+        core.insert(
+            "users",
+            user_insert_values(ObjectId::new(), "Bob"),
+            Some(&write_context),
+        )
+        .unwrap_err()
+        .to_string()
+        .contains("already sealed"),
+        "a batch with durable recovery metadata must stay frozen"
+    );
+}
+
+#[test]
 fn rc_insert_syncs_exact_row_batch_without_row_region_reads() {
     let mut core = create_runtime_with_boxed_storage(
         test_schema(),

--- a/crates/jazz-tools/src/runtime_core/writes.rs
+++ b/crates/jazz-tools/src/runtime_core/writes.rs
@@ -1122,6 +1122,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             record.mark_sealed(submission.clone());
             let mut settled_at_commit = false;
             let mut confirmed_tier_at_commit = None;
+            let mut settlement_at_commit = None;
             if record.mode == BatchMode::Direct
                 && let Some(confirmed_tier) = self.local_write_confirmed_tier()
             {
@@ -1130,13 +1131,9 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                     confirmed_tier,
                 };
                 record.apply_fate(settlement.clone());
-                self.storage
-                    .upsert_authoritative_batch_fate(&settlement)
-                    .map_err(|err| {
-                        RuntimeError::WriteError(format!("persist batch fate: {err}"))
-                    })?;
                 settled_at_commit = !self.batch_needs_settlement(Some(&settlement));
                 confirmed_tier_at_commit = Some(confirmed_tier);
+                settlement_at_commit = Some(settlement);
             }
             if !settled_at_commit {
                 self.storage
@@ -1148,6 +1145,13 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                     .upsert_local_batch_record(&record)
                     .map_err(|err| {
                         RuntimeError::WriteError(format!("persist local batch record: {err}"))
+                    })?;
+            }
+            if let Some(settlement) = settlement_at_commit {
+                self.storage
+                    .upsert_authoritative_batch_fate(&settlement)
+                    .map_err(|err| {
+                        RuntimeError::WriteError(format!("persist batch fate: {err}"))
                     })?;
             }
             if record.mode == BatchMode::Direct {

--- a/crates/jazz-tools/src/runtime_core/writes.rs
+++ b/crates/jazz-tools/src/runtime_core/writes.rs
@@ -1115,12 +1115,16 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             return Ok(());
         }
 
-        let submission = self.sealed_batch_submission(&record)?;
+        let retry_record = record.clone();
+        let result = (|| {
+            let submission = self.sealed_batch_submission(&record)?;
 
-        record.mark_sealed(submission.clone());
-        let mut settled_at_commit = false;
-        if record.mode == BatchMode::Direct {
-            if let Some(confirmed_tier) = self.local_write_confirmed_tier() {
+            record.mark_sealed(submission.clone());
+            let mut settled_at_commit = false;
+            let mut confirmed_tier_at_commit = None;
+            if record.mode == BatchMode::Direct
+                && let Some(confirmed_tier) = self.local_write_confirmed_tier()
+            {
                 let settlement = BatchFate::DurableDirect {
                     batch_id,
                     confirmed_tier,
@@ -1132,23 +1136,37 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                         RuntimeError::WriteError(format!("persist batch fate: {err}"))
                     })?;
                 settled_at_commit = !self.batch_needs_settlement(Some(&settlement));
-                self.durability.record_batch_ack(batch_id, confirmed_tier);
+                confirmed_tier_at_commit = Some(confirmed_tier);
             }
-            self.publish_direct_batch_rows(&record)?;
-        }
-        if !settled_at_commit {
-            self.storage
-                .upsert_sealed_batch_submission(&submission)
-                .map_err(|err| {
-                    RuntimeError::WriteError(format!("persist sealed batch submission: {err}"))
-                })?;
-            self.storage
-                .upsert_local_batch_record(&record)
-                .map_err(|err| {
-                    RuntimeError::WriteError(format!("persist local batch record: {err}"))
-                })?;
-        }
+            if !settled_at_commit {
+                self.storage
+                    .upsert_sealed_batch_submission(&submission)
+                    .map_err(|err| {
+                        RuntimeError::WriteError(format!("persist sealed batch submission: {err}"))
+                    })?;
+                self.storage
+                    .upsert_local_batch_record(&record)
+                    .map_err(|err| {
+                        RuntimeError::WriteError(format!("persist local batch record: {err}"))
+                    })?;
+            }
+            if record.mode == BatchMode::Direct {
+                self.publish_direct_batch_rows(&record)?;
+            }
+            Ok((submission, confirmed_tier_at_commit))
+        })();
+        let (submission, confirmed_tier_at_commit) = match result {
+            Ok(result) => result,
+            Err(error) => {
+                self.local_batch_record_cache.insert(batch_id, retry_record);
+                return Err(error);
+            }
+        };
+
         self.local_batch_record_cache.insert(batch_id, record);
+        if let Some(confirmed_tier) = confirmed_tier_at_commit {
+            self.durability.record_batch_ack(batch_id, confirmed_tier);
+        }
         self.schema_manager
             .query_manager_mut()
             .sync_manager_mut()

--- a/crates/jazz-tools/src/runtime_core/writes.rs
+++ b/crates/jazz-tools/src/runtime_core/writes.rs
@@ -1116,6 +1116,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         }
 
         let retry_record = record.clone();
+        let mut seal_persisted = false;
         let result = (|| {
             let submission = self.sealed_batch_submission(&record)?;
 
@@ -1135,18 +1136,17 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                 confirmed_tier_at_commit = Some(confirmed_tier);
                 settlement_at_commit = Some(settlement);
             }
-            if !settled_at_commit {
-                self.storage
-                    .upsert_sealed_batch_submission(&submission)
-                    .map_err(|err| {
-                        RuntimeError::WriteError(format!("persist sealed batch submission: {err}"))
-                    })?;
-                self.storage
-                    .upsert_local_batch_record(&record)
-                    .map_err(|err| {
-                        RuntimeError::WriteError(format!("persist local batch record: {err}"))
-                    })?;
-            }
+            self.storage
+                .upsert_sealed_batch_submission(&submission)
+                .map_err(|err| {
+                    RuntimeError::WriteError(format!("persist sealed batch submission: {err}"))
+                })?;
+            seal_persisted = true;
+            self.storage
+                .upsert_local_batch_record(&record)
+                .map_err(|err| {
+                    RuntimeError::WriteError(format!("persist local batch record: {err}"))
+                })?;
             if let Some(settlement) = settlement_at_commit {
                 self.storage
                     .upsert_authoritative_batch_fate(&settlement)
@@ -1157,19 +1157,25 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             if record.mode == BatchMode::Direct {
                 self.publish_direct_batch_rows(&record)?;
             }
-            Ok((submission, confirmed_tier_at_commit))
+            Ok((submission, confirmed_tier_at_commit, settled_at_commit))
         })();
-        let (submission, confirmed_tier_at_commit) = match result {
+        let (submission, confirmed_tier_at_commit, settled_at_commit) = match result {
             Ok(result) => result,
             Err(error) => {
-                self.local_batch_record_cache.insert(batch_id, retry_record);
+                self.local_batch_record_cache
+                    .insert(batch_id, if seal_persisted { record } else { retry_record });
                 return Err(error);
             }
         };
 
-        self.local_batch_record_cache.insert(batch_id, record);
+        self.local_batch_record_cache
+            .insert(batch_id, record.clone());
         if let Some(confirmed_tier) = confirmed_tier_at_commit {
             self.durability.record_batch_ack(batch_id, confirmed_tier);
+            if settled_at_commit {
+                self.retire_settled_batch(batch_id, confirmed_tier);
+                self.local_batch_record_cache.insert(batch_id, record);
+            }
         }
         self.schema_manager
             .query_manager_mut()

--- a/crates/jazz-tools/src/runtime_core/writes.rs
+++ b/crates/jazz-tools/src/runtime_core/writes.rs
@@ -1122,7 +1122,6 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
 
             record.mark_sealed(submission.clone());
             let mut settled_at_commit = false;
-            let mut confirmed_tier_at_commit = None;
             let mut settlement_at_commit = None;
             if record.mode == BatchMode::Direct
                 && let Some(confirmed_tier) = self.local_write_confirmed_tier()
@@ -1133,7 +1132,6 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                 };
                 record.apply_fate(settlement.clone());
                 settled_at_commit = !self.batch_needs_settlement(Some(&settlement));
-                confirmed_tier_at_commit = Some(confirmed_tier);
                 settlement_at_commit = Some(settlement);
             }
             self.storage
@@ -1147,9 +1145,9 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                 .map_err(|err| {
                     RuntimeError::WriteError(format!("persist local batch record: {err}"))
                 })?;
-            if let Some(settlement) = settlement_at_commit {
+            if let Some(settlement) = settlement_at_commit.as_ref() {
                 self.storage
-                    .upsert_authoritative_batch_fate(&settlement)
+                    .upsert_authoritative_batch_fate(settlement)
                     .map_err(|err| {
                         RuntimeError::WriteError(format!("persist batch fate: {err}"))
                     })?;
@@ -1157,9 +1155,9 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             if record.mode == BatchMode::Direct {
                 self.publish_direct_batch_rows(&record)?;
             }
-            Ok((submission, confirmed_tier_at_commit, settled_at_commit))
+            Ok((submission, settlement_at_commit, settled_at_commit))
         })();
-        let (submission, confirmed_tier_at_commit, settled_at_commit) = match result {
+        let (submission, settlement_at_commit, settled_at_commit) = match result {
             Ok(result) => result,
             Err(error) => {
                 self.local_batch_record_cache
@@ -1170,7 +1168,7 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
 
         self.local_batch_record_cache
             .insert(batch_id, record.clone());
-        if let Some(confirmed_tier) = confirmed_tier_at_commit {
+        if let Some(BatchFate::DurableDirect { confirmed_tier, .. }) = settlement_at_commit {
             self.durability.record_batch_ack(batch_id, confirmed_tier);
             if settled_at_commit {
                 self.retire_settled_batch(batch_id, confirmed_tier);


### PR DESCRIPTION
## Summary

- Load every exact direct-batch member before settlement, so a failed load cannot publish a partial batch.
- Persist the sealed submission, local recovery record and authoritative fate before making direct rows visible.
- Retain sealed recovery state when publication fails so retry or restart can finish the batch safely.

## Testing

- Direct-batch regression suite
- Full Rust workspace suite on the combined integration branch