### PR TITLE
fix(inspector): Data Explorer cannot connect to leader DB

### DIFF
--- a/packages/jazz-tools/src/drivers/schema-wire.test.ts
+++ b/packages/jazz-tools/src/drivers/schema-wire.test.ts
@@ -49,6 +49,28 @@ describe("serializeRuntimeSchema", () => {
     });
   });
 
+  it("canonicalizes table order while preserving column order", () => {
+    const projects = {
+      columns: [{ name: "name", column_type: { type: "Text" as const }, nullable: false }],
+    };
+    const todos = {
+      columns: [
+        { name: "title", column_type: { type: "Text" as const }, nullable: false },
+        { name: "done", column_type: { type: "Boolean" as const }, nullable: false },
+      ],
+    };
+
+    const projectsFirst = serializeRuntimeSchema({ projects, todos });
+    const todosFirst = serializeRuntimeSchema({ todos, projects });
+    const reorderedColumns = serializeRuntimeSchema({
+      projects,
+      todos: { columns: [...todos.columns].reverse() },
+    });
+
+    expect(todosFirst).toBe(projectsFirst);
+    expect(reorderedColumns).not.toBe(projectsFirst);
+  });
+
   it("memoizes cache keys by runtime schema identity", () => {
     const schema: WasmSchema = {
       todos: {

--- a/packages/jazz-tools/src/drivers/schema-wire.ts
+++ b/packages/jazz-tools/src/drivers/schema-wire.ts
@@ -51,13 +51,21 @@ function runtimeSchemaJsonReplacer(_key: string, value: unknown): unknown {
   return value;
 }
 
+function sortSchemaTables(schema: WasmSchema): WasmSchema {
+  return Object.fromEntries(
+    Object.keys(schema)
+      .sort()
+      .map((tableName) => [tableName, schema[tableName]]),
+  ) as WasmSchema;
+}
+
 export function serializeRuntimeSchema(
   schema: WasmSchema,
   options?: SerializeRuntimeSchemaOptions,
 ): string {
   const envelope: RuntimeSchemaEnvelope = {
     __jazzRuntimeSchema: 1,
-    schema,
+    schema: sortSchemaTables(schema),
     loadedPolicyBundle: options?.loadedPolicyBundle ?? false,
   };
   return JSON.stringify(envelope, runtimeSchemaJsonReplacer);

--- a/packages/jazz-tools/src/runtime/connection-manager/types.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/types.ts
@@ -124,7 +124,7 @@ export abstract class ConnectionManager {
    * private fields.
    */
   getRuntimeSchema(): WasmSchema | null {
-    return this.client ? this.client.getSchema() : null;
+    return this.client?.getSchema() ?? null;
   }
 
   protected get clientEntry(): ConnectionManagerClientInput | null {


### PR DESCRIPTION
## Description

There was a regression on the inspector's Data Explorer that prevented connecting to the tab leader's DB.

The error occurred because the inspector and the tab leader could generate different schema keys for the same schema (because table ordering changed after the schema passed through the runtime). This caused the browser broker to incorrectly reject the inspector as incompatible.

The fix is to ignore table ordering when serializing schemas, while preserving meaningful column ordering. Equivalent schemas now generate the same key, and genuinely incompatible schemas remain rejected.