### PR TITLE
perf: avoid performance pitfalls with rows with deep histories

### DIFF
--- a/.changeset/fast-batches-rest.md
+++ b/.changeset/fast-batches-rest.md
@@ -1,0 +1,7 @@
+---
+"jazz-tools": patch
+---
+
+Improve write and sync performance by replacing full row-history scans with batch-indexed or exact row lookups across batch tracking, transaction validation, permission rejection, and common parent resolution.
+
+Disable automatic full-storage reconciliation when connecting to a server, avoiding a replay of all stored rows' history on every connection. This means rows that couldn't be synced to the server will not be sent on reconnection, instead needing to wait until a query loads them again. Also, the full client storage won't be automatically reconciled when connecting to a new server.

--- a/crates/jazz-tools/src/query_manager/writes.rs
+++ b/crates/jazz-tools/src/query_manager/writes.rs
@@ -599,11 +599,9 @@ impl QueryManager {
     ) -> Option<(String, StoredRowBatch)> {
         let table = self.load_row_table_name(storage, row_id)?;
         let row = storage
-            .scan_history_row_batches(&table, row_id)
-            .ok()?
-            .into_iter()
-            .filter(|row| row.batch_id == batch_id && row.branch.as_str() == branch_name)
-            .max_by_key(|row| (row.updated_at, row.batch_id()))?;
+            .load_history_row_batch(&table, branch_name, row_id, batch_id)
+            .ok()
+            .flatten()?;
         Some((table, row))
     }
 

--- a/crates/jazz-tools/src/runtime_core/writes.rs
+++ b/crates/jazz-tools/src/runtime_core/writes.rs
@@ -367,53 +367,18 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         row_id: ObjectId,
         batch_id: BatchId,
     ) -> Result<Vec<LocalBatchMember>, RuntimeError> {
-        let row_locator = self
+        let members = self
             .storage
-            .load_row_locator(row_id)
-            .map_err(|err| RuntimeError::WriteError(format!("load row locator: {err}")))?
+            .load_local_batch_row_index(batch_id)
+            .map_err(|err| RuntimeError::WriteError(format!("load local batch row index: {err}")))?
             .ok_or_else(|| {
                 RuntimeError::WriteError(format!(
-                    "missing row locator while tracking local batch {batch_id:?} for {row_id:?}"
+                    "missing local batch row index while tracking {batch_id:?}"
                 ))
-            })?;
-        let mut members = self
-            .storage
-            .scan_history_row_batches(row_locator.table.as_str(), row_id)
-            .map_err(|err| RuntimeError::WriteError(format!("scan history rows: {err}")))?
+            })?
             .into_iter()
-            .filter(|row| row.batch_id == batch_id)
-            .map(|row| {
-                let branch_name = BranchName::new(&row.branch);
-                Ok(LocalBatchMember {
-                    object_id: row_id,
-                    table_name: row_locator.table.to_string(),
-                    branch_name,
-                    schema_hash: self.local_batch_member_schema_hash(
-                        branch_name,
-                        row_id,
-                        row.batch_id(),
-                    )?,
-                    row_digest: row.content_digest(),
-                })
-            })
-            .collect::<Result<Vec<_>, RuntimeError>>()?;
-        if members.len() > 1 {
-            members.sort_by(|left, right| {
-                left.object_id
-                    .uuid()
-                    .as_bytes()
-                    .cmp(right.object_id.uuid().as_bytes())
-                    .then_with(|| left.table_name.cmp(&right.table_name))
-                    .then_with(|| left.branch_name.as_str().cmp(right.branch_name.as_str()))
-                    .then_with(|| {
-                        left.schema_hash
-                            .as_bytes()
-                            .cmp(right.schema_hash.as_bytes())
-                    })
-                    .then_with(|| left.row_digest.0.cmp(&right.row_digest.0))
-            });
-            members.dedup();
-        }
+            .filter(|member| member.object_id == row_id)
+            .collect::<Vec<_>>();
         if members.is_empty() {
             return Err(RuntimeError::WriteError(format!(
                 "missing local batch member rows for {batch_id:?} / {row_id:?}"

--- a/crates/jazz-tools/src/storage/storage_trait.rs
+++ b/crates/jazz-tools/src/storage/storage_trait.rs
@@ -1363,6 +1363,7 @@ pub trait Storage {
             .map(QueryRowBatch::from))
     }
 
+    #[cfg(test)]
     fn load_history_row_batch_any_branch(
         &self,
         table: &str,
@@ -1385,6 +1386,7 @@ pub trait Storage {
         Ok(Some(first_match))
     }
 
+    #[cfg(test)]
     fn load_history_query_row_batch_any_branch(
         &self,
         table: &str,
@@ -2189,6 +2191,7 @@ impl<T: Storage + ?Sized> Storage for Box<T> {
         )
     }
 
+    #[cfg(test)]
     fn load_history_row_batch_any_branch(
         &self,
         table: &str,
@@ -2198,6 +2201,7 @@ impl<T: Storage + ?Sized> Storage for Box<T> {
         (**self).load_history_row_batch_any_branch(table, row_id, batch_id)
     }
 
+    #[cfg(test)]
     fn load_history_query_row_batch_any_branch(
         &self,
         table: &str,

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -556,46 +556,28 @@ impl SyncManager {
         &self,
         storage: &H,
         batch_id: crate::row_histories::BatchId,
-        target_branch_name: Option<&BranchName>,
         object_ids: &[ObjectId],
     ) -> Vec<(String, StoredRowBatch)> {
-        let mut rows = Vec::new();
-        for row_id in object_ids {
-            if let Some(target_branch_name) = target_branch_name
-                && let Ok(Some(locator)) = storage.load_history_row_batch_table_locator(
-                    target_branch_name.as_str(),
-                    *row_id,
+        let object_ids = object_ids.iter().copied().collect::<HashSet<_>>();
+        let Ok(Some(batch_rows)) = storage.load_local_batch_row_index(batch_id) else {
+            return Vec::new();
+        };
+        let mut rows = batch_rows
+            .into_iter()
+            .filter(|member| object_ids.contains(&member.object_id))
+            .filter_map(|member| {
+                let Ok(Some(row)) = storage.load_history_row_batch_for_schema_hash(
+                    member.table_name.as_str(),
+                    member.schema_hash,
+                    member.branch_name.as_str(),
+                    member.object_id,
                     batch_id,
-                )
-            {
-                let table = locator.table_name.to_string();
-                if let Ok(Some(row)) = storage.load_history_row_batch_for_schema_hash(
-                    &table,
-                    locator.schema_hash,
-                    target_branch_name.as_str(),
-                    *row_id,
-                    batch_id,
-                ) {
-                    rows.push((table, row));
-                    continue;
-                }
-            }
-
-            let Ok(Some(row_locator)) = storage.load_row_locator(*row_id) else {
-                continue;
-            };
-            let Ok(history_rows) =
-                storage.scan_history_row_batches(row_locator.table.as_str(), *row_id)
-            else {
-                continue;
-            };
-
-            for row in history_rows {
-                if row.batch_id == batch_id {
-                    rows.push((row_locator.table.to_string(), row));
-                }
-            }
-        }
+                ) else {
+                    return None;
+                };
+                (row.content_digest() == member.row_digest).then_some((member.table_name, row))
+            })
+            .collect::<Vec<_>>();
 
         rows.sort_by(|(_, left), (_, right)| {
             left.row_id
@@ -627,14 +609,12 @@ impl SyncManager {
             return self.transactional_batch_rows(
                 storage,
                 batch_id,
-                Some(&submission.target_branch_name),
                 &object_ids.into_iter().collect::<Vec<_>>(),
             );
         }
         self.transactional_batch_rows(
             storage,
             batch_id,
-            None,
             &object_ids.into_iter().collect::<Vec<_>>(),
         )
     }
@@ -1133,7 +1113,6 @@ impl SyncManager {
         let batch_rows = self.transactional_batch_rows(
             storage,
             batch_id,
-            Some(&submission.target_branch_name),
             &submission
                 .members
                 .iter()
@@ -1236,7 +1215,6 @@ impl SyncManager {
             let batch_rows = self.transactional_batch_rows(
                 storage,
                 submission.batch_id,
-                Some(&submission.target_branch_name),
                 &submission
                     .members
                     .iter()
@@ -1913,7 +1891,6 @@ impl SyncManager {
                     let batch_rows = self.transactional_batch_rows(
                         storage,
                         submission.batch_id,
-                        Some(&submission.target_branch_name),
                         &submission
                             .members
                             .iter()

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -314,6 +314,15 @@ impl SyncManager {
         if row.parents.is_empty() {
             return None;
         }
+        // If the row has a single parent, we don't need any conflict resolution
+        if let [parent_batch_id] = row.parents.as_slice() {
+            let parent_row = storage
+                .load_history_row_batch(table, row.branch.as_str(), row.row_id, *parent_batch_id)
+                .ok()
+                .flatten()?;
+            return (parent_row.batch_id != row.batch_id && parent_row.state.is_visible())
+                .then_some(parent_row);
+        }
 
         let context =
             crate::storage::resolve_history_row_write_context(storage, table, row).ok()?;

--- a/crates/jazz-tools/src/sync_manager/mod.rs
+++ b/crates/jazz-tools/src/sync_manager/mod.rs
@@ -477,7 +477,9 @@ impl SyncManager {
     ) {
         self.pending_servers.remove(&server_id);
         self.servers.insert(server_id, ServerState::default());
-        self.queue_full_sync_to_server_from_storage(server_id, storage);
+        // TODO: this proved to be too resource intensive, replace with a more robust
+        // full-storage reconciliation strategy
+        // self.queue_full_sync_to_server_from_storage(server_id, storage);
         if !skip_catalogue_sync {
             self.queue_catalogue_sync_to_server_from_storage(server_id, storage);
         }

--- a/crates/jazz-tools/src/sync_manager/permissions.rs
+++ b/crates/jazz-tools/src/sync_manager/permissions.rs
@@ -7,7 +7,7 @@ use crate::row_histories::{
     BatchId, RowState, RowVisibilityChange, StoredRowBatch, VisibleRowEntry, patch_row_batch_state,
 };
 use crate::storage::Storage;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 impl SyncManager {
     /// Take all pending permission checks for policy evaluation.
@@ -160,63 +160,26 @@ impl SyncManager {
         batch_id: BatchId,
         fallback_row: StoredRowBatch,
     ) -> Vec<StoredRowBatch> {
-        let mut row_ids = HashSet::new();
-        for key in self.row_batch_interest.keys() {
-            if key.batch_id == batch_id {
-                row_ids.insert(key.row_id);
-            }
-        }
-        for pending in &self.pending_permission_checks {
-            if let SyncPayload::RowBatchCreated { row, .. }
-            | SyncPayload::RowBatchNeeded { row, .. } = &pending.payload
-                && row.batch_id == batch_id
-            {
-                row_ids.insert(row.row_id);
-            }
-        }
-
-        let mut rows = row_ids
+        let mut rows = storage
+            .load_local_batch_row_index(batch_id)
+            .ok()
+            .flatten()
+            .unwrap_or_default()
             .into_iter()
-            .filter_map(|row_id| {
-                let table = storage.load_row_locator(row_id).ok().flatten()?.table;
-                storage
-                    .scan_history_row_batches(table.as_str(), row_id)
-                    .ok()?
-                    .into_iter()
-                    .find(|row| row.batch_id == batch_id)
+            .filter_map(|member| {
+                let row = storage
+                    .load_history_row_batch_for_schema_hash(
+                        member.table_name.as_str(),
+                        member.schema_hash,
+                        member.branch_name.as_str(),
+                        member.object_id,
+                        batch_id,
+                    )
+                    .ok()
+                    .flatten()?;
+                (row.content_digest() == member.row_digest).then_some(row)
             })
             .collect::<Vec<_>>();
-
-        rows.extend(
-            storage
-                .load_sealed_batch_submission(batch_id)
-                .ok()
-                .flatten()
-                .map(|submission| {
-                    submission
-                        .members
-                        .into_iter()
-                        .filter_map(|member| {
-                            let table = storage
-                                .load_row_locator(member.object_id)
-                                .ok()
-                                .flatten()?
-                                .table;
-                            storage
-                                .scan_history_row_batches(table.as_str(), member.object_id)
-                                .ok()?
-                                .into_iter()
-                                .find(|row| {
-                                    row.batch_id == batch_id
-                                        && row.branch.as_str()
-                                            == submission.target_branch_name.as_str()
-                                        && row.content_digest() == member.row_digest
-                                })
-                        })
-                        .collect::<Vec<_>>()
-                })
-                .unwrap_or_default(),
-        );
 
         if !rows.iter().any(|row| {
             row.row_id == fallback_row.row_id

--- a/crates/jazz-tools/src/sync_manager/sync_logic.rs
+++ b/crates/jazz-tools/src/sync_manager/sync_logic.rs
@@ -57,6 +57,7 @@ impl SyncManager {
 
     /// Queue all existing objects to sync to a new server using storage as the
     /// source of truth for row history and current state.
+    #[allow(dead_code)]
     pub(super) fn queue_full_sync_to_server_from_storage<H: Storage>(
         &mut self,
         server_id: ServerId,

--- a/crates/jazz-tools/src/sync_manager/tests/server_sync.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/server_sync.rs
@@ -26,6 +26,7 @@ fn forward_update_to_servers_with_storage_replays_row_history_without_visible_re
     )));
 }
 
+#[ignore = "ignored until SyncManager.add_server_with_storage supports full-storage reconciliation"]
 #[test]
 fn add_server_with_storage_syncs_full_row_history_to_server() {
     let mut io = MemoryStorage::new();
@@ -101,6 +102,7 @@ fn add_server_with_storage_syncs_full_row_history_to_server() {
     ));
 }
 
+#[ignore = "ignored until SyncManager.add_server_with_storage supports full-storage reconciliation"]
 #[test]
 fn add_server_with_storage_skips_rows_already_confirmed_upstream() {
     let mut io = MemoryStorage::new();
@@ -393,6 +395,7 @@ fn add_server_with_storage_withholds_local_child_of_rejected_parent() {
     );
 }
 
+#[ignore = "ignored until SyncManager.add_server_with_storage supports full-storage reconciliation"]
 #[test]
 fn add_server_with_storage_sends_skipped_parent_before_child() {
     let mut io = MemoryStorage::new();


### PR DESCRIPTION
## Description

Fixes https://github.com/garden-co/jazz/issues/1081.

- Use the batch-> rows index introduced in https://github.com/garden-co/jazz/pull/1073 to avoid full history scans:
	- avoid scanning a row's full history on every write
	- avoid full-history scan to get batch members when receiving remote tx sealed/accepted payloads
- ⚠️ Temporarily disable full-storage reconciliation when connecting to a server, as the current mechanism is too resource intensive
	- This means rows that couldn't be synced to the server will not be sent on reconnection, instead needing to wait until a query loads them again. Also, the full client storage won't be automatically reconciled when connecting to a new server