### PR TITLE
Fix counter merge replay over-counting

### DIFF
--- a/.changeset/counter-replay-ancestry.md
+++ b/.changeset/counter-replay-ancestry.md
@@ -1,0 +1,9 @@
+---
+"jazz-tools": patch
+---
+
+Fix counter merge replay over-counting after reconnect and scoped sync delivery.
+
+Scoped visible snapshots now preserve local raw ancestry and update only the
+materialised projection when replaying merged values, so concurrent and causal
+counter updates converge without double-counting.

--- a/crates/jazz-tools/src/metadata.rs
+++ b/crates/jazz-tools/src/metadata.rs
@@ -31,6 +31,8 @@ pub enum MetadataKey {
     TargetHash,
     /// Flag to suppress sync for an object.
     NoSync,
+    /// Visible row projection observed by the first write in a transaction.
+    TransactionBasis,
 }
 
 impl MetadataKey {
@@ -47,6 +49,7 @@ impl MetadataKey {
             Self::SourceHash => "source_hash",
             Self::TargetHash => "target_hash",
             Self::NoSync => "nosync",
+            Self::TransactionBasis => "transaction_basis_v1",
         }
     }
 }

--- a/crates/jazz-tools/src/query_manager/graph_nodes/index_scan.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/index_scan.rs
@@ -4,9 +4,11 @@ use std::ops::Bound;
 use crate::object::{BranchName, ObjectId};
 use crate::query_manager::index::ScanCondition;
 use crate::query_manager::types::{
-    ColumnName, RowDescriptor, TableName, Tuple, TupleDelta, TupleDescriptor, Value,
+    ColumnMergeStrategy, ColumnName, RowDescriptor, TableName, Tuple, TupleDelta, TupleDescriptor,
+    Value,
 };
 use crate::row_format::decode_row;
+use crate::row_histories::{RowState, rebase_counter_data};
 
 use super::{SourceContext, SourceNode};
 
@@ -97,6 +99,45 @@ impl IndexScanNode {
         values.get(column_index).cloned()
     }
 
+    fn rebased_staged_counter_data(
+        &self,
+        ctx: &SourceContext,
+        row_id: ObjectId,
+        batch_id: crate::row_histories::BatchId,
+    ) -> Option<Vec<u8>> {
+        if !matches!(
+            self.row_descriptor
+                .column(self.column.as_str())
+                .and_then(|column| column.merge_strategy),
+            Some(ColumnMergeStrategy::Counter)
+        ) {
+            return None;
+        }
+        let pending_row = ctx
+            .storage
+            .load_history_row_batch(self.table.as_str(), &self.branch, row_id, batch_id)
+            .ok()??;
+        let [parent] = pending_row.parents.as_slice() else {
+            return None;
+        };
+        let raw_parent = ctx
+            .storage
+            .load_history_row_batch(self.table.as_str(), &self.branch, row_id, *parent)
+            .ok()??;
+        let visible_row = ctx
+            .storage
+            .load_visible_query_row(self.table.as_str(), &self.branch, row_id)
+            .ok()??;
+
+        rebase_counter_data(
+            &self.row_descriptor,
+            &raw_parent.data,
+            &pending_row.data,
+            &visible_row.data,
+        )
+        .ok()?
+    }
+
     fn apply_local_overlay_rows(&self, ctx: &SourceContext, new_ids: &mut AHashSet<ObjectId>) {
         let Some(local_overlay_rows) = ctx.local_overlay_rows else {
             return;
@@ -118,10 +159,18 @@ impl IndexScanNode {
                 new_ids.insert(row_id);
             } else if row.is_soft_deleted() || row.is_hard_deleted() {
                 new_ids.remove(&row_id);
-            } else if self.overlay_value_matches_condition(row_id, &row.data) {
-                new_ids.insert(row_id);
             } else {
-                new_ids.remove(&row_id);
+                let rebased_data = matches!(row.state, RowState::StagingPending)
+                    .then(|| self.rebased_staged_counter_data(ctx, row_id, row.batch_id))
+                    .flatten();
+                if self.overlay_value_matches_condition(
+                    row_id,
+                    rebased_data.as_deref().unwrap_or(&row.data),
+                ) {
+                    new_ids.insert(row_id);
+                } else {
+                    new_ids.remove(&row_id);
+                }
             }
         }
     }

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -9,7 +9,10 @@ use crate::batch_fate::BatchFate;
 use crate::catalogue::CatalogueEntry;
 use crate::metadata::{MetadataKey, ObjectType};
 use crate::object::{BranchName, ObjectId};
-use crate::row_histories::{BatchId, QueryRowBatch, RowState, RowVisibilityChange, StoredRowBatch};
+use crate::row_histories::{
+    BatchId, QueryRowBatch, RowState, RowVisibilityChange, StoredRowBatch,
+    has_counter_merge_strategy, rebase_counter_data,
+};
 use crate::schema_manager::{
     LensTransformer, SchemaContext, encoding::encode_schema, resolve_current_table_name,
     translate_table_name_to_schema,
@@ -2513,6 +2516,67 @@ impl QueryManager {
         Some((current_table_name.to_string(), row))
     }
 
+    fn current_counter_descriptor_for_branch<'a>(
+        table: &str,
+        branch: &str,
+        schema_context: &'a SchemaContext,
+        branch_schema_map: &HashMap<String, SchemaHash>,
+    ) -> Option<&'a RowDescriptor> {
+        if branch_schema_map.get(branch).copied() != Some(schema_context.current_hash) {
+            return None;
+        }
+        let descriptor = schema_context
+            .current_schema
+            .get(&TableName::new(table))
+            .map(|table_schema| &table_schema.columns)?;
+        has_counter_merge_strategy(descriptor).then_some(descriptor)
+    }
+
+    fn rebase_pending_counter_projection(
+        storage: &dyn Storage,
+        table: &str,
+        row_id: ObjectId,
+        mut pending_row: QueryRowBatch,
+        visible_row: &QueryRowBatch,
+        descriptor: &RowDescriptor,
+    ) -> QueryRowBatch {
+        let branch = pending_row.branch.as_str();
+        if visible_row.branch.as_str() != branch {
+            return pending_row;
+        }
+        let Ok(Some(stored_pending_row)) =
+            storage.load_history_row_batch(table, branch, row_id, pending_row.batch_id)
+        else {
+            return pending_row;
+        };
+        let [parent] = stored_pending_row.parents.as_slice() else {
+            return pending_row;
+        };
+        let Ok(Some(raw_parent)) = storage.load_history_row_batch(table, branch, row_id, *parent)
+        else {
+            return pending_row;
+        };
+
+        match rebase_counter_data(
+            descriptor,
+            &raw_parent.data,
+            &pending_row.data,
+            &visible_row.data,
+        ) {
+            Ok(Some(data)) => pending_row.data = data.into(),
+            Ok(None) => {}
+            Err(error) => {
+                tracing::debug!(
+                    row_id = %row_id,
+                    batch_id = %pending_row.batch_id,
+                    error = %error,
+                    "failed to rebase pending counter projection"
+                );
+            }
+        }
+        pending_row
+    }
+
     fn load_best_visible_row_batch_from_storage_with_table_hint(
         storage: &dyn Storage,
         row_id: ObjectId,
@@ -2709,17 +2773,49 @@ impl QueryManager {
         };
         let pending_staged_row = || {
             let pending_version = local_pending_version?;
-            let resolved = Self::load_local_pending_query_row_with_hint_or_locator(
+            let (table, row) = Self::load_local_pending_query_row_with_hint_or_locator(
                 storage,
                 pending_version,
                 table_hint,
                 schema_context,
             )?;
-            let (_, row) = &resolved;
             (row.batch_id == pending_version.batch_id
                 && row.branch.as_str() == pending_version.branch_name.as_str()
                 && matches!(row.state, RowState::StagingPending))
-            .then_some(resolved)
+            .then(|| {
+                let descriptor = Self::current_counter_descriptor_for_branch(
+                    &table,
+                    row.branch.as_str(),
+                    schema_context,
+                    branch_schema_map,
+                );
+                let visible_row = descriptor.and_then(|descriptor| {
+                    Self::load_best_visible_row_batch_with_hint_or_locator(
+                        storage,
+                        row_id,
+                        table_hint,
+                        branches,
+                        durability_tier,
+                        schema_context,
+                        branch_schema_map,
+                    )
+                    .filter(|(visible_table, _)| visible_table == &table)
+                    .map(|(_, visible_row)| (descriptor, visible_row))
+                });
+                let row = if let Some((descriptor, visible_row)) = visible_row {
+                    Self::rebase_pending_counter_projection(
+                        storage,
+                        &table,
+                        row_id,
+                        row,
+                        &visible_row,
+                        descriptor,
+                    )
+                } else {
+                    row
+                };
+                (table, row)
+            })
         };
         let best_visible_row = || {
             Self::load_best_visible_row_batch_with_hint_or_locator(

--- a/crates/jazz-tools/src/query_manager/writes.rs
+++ b/crates/jazz-tools/src/query_manager/writes.rs
@@ -2,13 +2,16 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use crate::batch_fate::{BatchFate, BatchMode};
-use crate::metadata::{DeleteKind, RowProvenance, SYSTEM_PRINCIPAL_ID, row_provenance_metadata};
+use crate::metadata::{
+    DeleteKind, MetadataKey, RowProvenance, SYSTEM_PRINCIPAL_ID, row_provenance_metadata,
+};
 use crate::object::{BranchName, ObjectId};
 use crate::row_format::compiled_row_layout;
 use crate::row_histories::{
     ApplyRowBatchResult, ApplyRowBatchWithContext, BatchId, QueryRowBatch, RowHistoryError,
     RowState, RowVisibilityChange, StoredRowBatch, VisibleRowEntry, apply_row_batch,
-    apply_row_batch_with_context,
+    apply_row_batch_with_context, has_counter_merge_strategy, rebase_counter_data,
+    transaction_projection_basis, transaction_query_projection_basis,
 };
 use crate::schema_manager::{SchemaContext, resolve_current_table_name};
 use crate::storage::{
@@ -26,8 +29,8 @@ use super::policy::{ComplexClause, Operation, evaluate_simple_parts_with_row_id}
 use super::server_queries::{AuthorizationPolicyRequest, RowTransformContext};
 use super::session::{AuthMode, Session, WriteContext};
 use super::types::{
-    ColumnMergeStrategy, ColumnName, ColumnType, ComposedBranchName, LoadedRow, RowDescriptor,
-    Schema, SchemaHash, TableName, Value,
+    ColumnName, ColumnType, ComposedBranchName, LoadedRow, RowDescriptor, Schema, SchemaHash,
+    TableName, Value,
 };
 
 pub struct RowBranchWrite<'a> {
@@ -643,21 +646,48 @@ impl QueryManager {
         row_id: ObjectId,
         branch_name: &str,
         write_context: Option<&WriteContext>,
-    ) -> (Vec<BatchId>, Option<VisibleRowEntry>) {
+    ) -> (Vec<BatchId>, Option<VisibleRowEntry>, Option<String>) {
         if let Some(existing_batch_row) =
             self.batch_history_row_for_write(storage, row_id, branch_name, write_context)
         {
-            return (existing_batch_row.parents.iter().copied().collect(), None);
+            let transaction_basis = existing_batch_row
+                .metadata
+                .get(MetadataKey::TransactionBasis.as_str())
+                .cloned();
+            return (
+                existing_batch_row.parents.iter().copied().collect(),
+                None,
+                transaction_basis,
+            );
         }
-        if let Ok(Some(entry)) = storage.load_visible_region_entry(table, branch_name, row_id) {
-            return (entry.branch_frontier.clone(), Some(entry));
+        let visible_entry = storage.load_visible_region_entry(table, branch_name, row_id);
+        if let Ok(Some(entry)) = visible_entry {
+            let transaction_basis = matches!(
+                write_context.map(WriteContext::batch_mode),
+                Some(BatchMode::Transactional)
+            )
+            .then(|| transaction_projection_basis(&entry.current_row));
+            return (
+                entry.branch_frontier.clone(),
+                Some(entry),
+                transaction_basis,
+            );
         }
+
+        let transaction_basis = matches!(
+            write_context.map(WriteContext::batch_mode),
+            Some(BatchMode::Transactional)
+        )
+        .then(|| self.load_visible_row_on_branch(storage, row_id, branch_name))
+        .flatten()
+        .map(|(_, row)| transaction_query_projection_basis(row_id, &row));
 
         (
             storage
                 .scan_row_branch_tip_ids(table, branch_name, row_id)
                 .unwrap_or_default(),
             None,
+            transaction_basis,
         )
     }
 
@@ -699,11 +729,7 @@ impl QueryManager {
         descriptor: &RowDescriptor,
         requested_data: &[u8],
     ) -> Result<Option<Vec<u8>>, QueryError> {
-        if !descriptor
-            .columns
-            .iter()
-            .any(|column| matches!(column.merge_strategy, Some(ColumnMergeStrategy::Counter)))
-        {
+        if !has_counter_merge_strategy(descriptor) {
             return Ok(None);
         }
         let [parent] = parents else {
@@ -720,66 +746,13 @@ impl QueryManager {
         else {
             return Ok(None);
         };
-        if raw_parent.data == visible_entry.current_row.data {
-            return Ok(None);
-        }
-
-        let projected_values = decode_row(descriptor, &visible_entry.current_row.data)
-            .map_err(|error| QueryError::EncodingError(error.to_string()))?;
-        let requested_values = decode_row(descriptor, requested_data)
-            .map_err(|error| QueryError::EncodingError(error.to_string()))?;
-        let raw_values = decode_row(descriptor, &raw_parent.data)
-            .map_err(|error| QueryError::EncodingError(error.to_string()))?;
-        let mut authored_values = requested_values.clone();
-
-        for (index, column) in descriptor.columns.iter().enumerate() {
-            if !matches!(column.merge_strategy, Some(ColumnMergeStrategy::Counter)) {
-                continue;
-            }
-            let counter_value = |value: &Value| match value {
-                Value::Integer(value) => Some(*value),
-                Value::Null => Some(0),
-                _ => None,
-            };
-            let projected = counter_value(&projected_values[index]).ok_or_else(|| {
-                QueryError::EncodingError(format!(
-                    "counter projection for '{}' is not an integer",
-                    column.name_str()
-                ))
-            })?;
-            let requested = counter_value(&requested_values[index]).ok_or_else(|| {
-                QueryError::EncodingError(format!(
-                    "requested counter value for '{}' is not an integer",
-                    column.name_str()
-                ))
-            })?;
-            let raw = counter_value(&raw_values[index]).ok_or_else(|| {
-                QueryError::EncodingError(format!(
-                    "raw counter frontier for '{}' is not an integer",
-                    column.name_str()
-                ))
-            })?;
-            let delta = requested.checked_sub(projected).ok_or_else(|| {
-                QueryError::EncodingError(format!(
-                    "counter projection delta overflow for '{}'",
-                    column.name_str()
-                ))
-            })?;
-            let authored = raw.checked_add(delta).ok_or_else(|| {
-                QueryError::EncodingError(format!(
-                    "counter projection update overflow for '{}'",
-                    column.name_str()
-                ))
-            })?;
-            authored_values[index] = Value::Integer(authored);
-        }
-
-        if authored_values == requested_values {
-            return Ok(None);
-        }
-        encode_row(descriptor, &authored_values)
-            .map(Some)
-            .map_err(|error| QueryError::EncodingError(error.to_string()))
+        rebase_counter_data(
+            descriptor,
+            &visible_entry.current_row.data,
+            requested_data,
+            &raw_parent.data,
+        )
+        .map_err(|error| QueryError::EncodingError(error.to_string()))
     }
 
     fn prepare_update_write_for_schema<H: Storage>(
@@ -969,7 +942,7 @@ impl QueryManager {
             id,
             index_mutations,
         } = commit;
-        let (parents, visible_entry) =
+        let (parents, visible_entry, transaction_basis) =
             self.parent_ids_for_write(storage, table, id, branch, write_context);
 
         let authored_data = if Self::write_context_is_open_batch(write_context) {
@@ -991,13 +964,17 @@ impl QueryManager {
             (authored_data != prepared.new_data).then(|| prepared.new_data.clone());
 
         let is_known_new_object = parents.is_empty();
-        let row = self.authored_row_batch(
+        let mut row = self.authored_row_batch(
             id,
             branch,
             parents,
             authored_data,
             self.row_batch_authoring(provenance, None, write_context),
         );
+        if let Some(transaction_basis) = transaction_basis {
+            row.metadata
+                .insert(MetadataKey::TransactionBasis.as_str(), transaction_basis);
+        }
         let branch_name = BranchName::new(branch);
         let (batch_id, visibility_change) = self
             .apply_local_row_history_write_with_prepared_context(
@@ -2247,19 +2224,25 @@ impl QueryManager {
             }
         }
 
-        let (parents, _) = self.parent_ids_for_write(storage, table, id, branch, write_context);
+        let (parents, _, transaction_basis) =
+            self.parent_ids_for_write(storage, table, id, branch, write_context);
         let timestamp = self.resolve_update_timestamp(write_context);
         let delete_provenance =
             self.row_provenance_for_update(old_provenance_for_policy, write_context, timestamp);
 
         let is_known_new_object = parents.is_empty();
-        let delete_row = self.authored_row_batch(
+        let mut delete_row = self.authored_row_batch(
             id,
             branch,
             parents,
             old_data_for_policy.to_vec(),
             self.row_batch_authoring(&delete_provenance, Some(DeleteKind::Soft), write_context),
         );
+        if let Some(transaction_basis) = transaction_basis {
+            delete_row
+                .metadata
+                .insert(MetadataKey::TransactionBasis.as_str(), transaction_basis);
+        }
         let index_mutations = if Self::write_context_is_open_batch(write_context) {
             Vec::new()
         } else {

--- a/crates/jazz-tools/src/query_manager/writes.rs
+++ b/crates/jazz-tools/src/query_manager/writes.rs
@@ -9,9 +9,9 @@ use crate::object::{BranchName, ObjectId};
 use crate::row_format::compiled_row_layout;
 use crate::row_histories::{
     ApplyRowBatchResult, ApplyRowBatchWithContext, BatchId, QueryRowBatch, RowHistoryError,
-    RowState, RowVisibilityChange, StoredRowBatch, VisibleRowEntry, apply_row_batch,
-    apply_row_batch_with_context, has_counter_merge_strategy, rebase_counter_data,
-    transaction_projection_basis, transaction_query_projection_basis,
+    RowState, RowVisibilityChange, StoredRowBatch, apply_row_batch, apply_row_batch_with_context,
+    has_counter_merge_strategy, rebase_counter_data, transaction_projection_basis,
+    transaction_query_projection_basis,
 };
 use crate::schema_manager::{SchemaContext, resolve_current_table_name};
 use crate::storage::{
@@ -55,6 +55,12 @@ struct PreparedUpdateCommit<'a> {
     branch: &'a str,
     id: ObjectId,
     index_mutations: &'a [crate::storage::IndexMutation<'a>],
+}
+
+struct WriteAncestry {
+    parents: Vec<BatchId>,
+    visible_projection: Option<QueryRowBatch>,
+    transaction_basis: Option<String>,
 }
 
 struct RowBatchAuthoring<'a> {
@@ -639,14 +645,15 @@ impl QueryManager {
             .map(|(_, row)| row)
     }
 
-    fn parent_ids_for_write(
+    fn write_ancestry(
         &self,
         storage: &dyn Storage,
         table: &str,
         row_id: ObjectId,
         branch_name: &str,
         write_context: Option<&WriteContext>,
-    ) -> (Vec<BatchId>, Option<VisibleRowEntry>, Option<String>) {
+        load_visible_projection: bool,
+    ) -> WriteAncestry {
         if let Some(existing_batch_row) =
             self.batch_history_row_for_write(storage, row_id, branch_name, write_context)
         {
@@ -654,11 +661,15 @@ impl QueryManager {
                 .metadata
                 .get(MetadataKey::TransactionBasis.as_str())
                 .cloned();
-            return (
-                existing_batch_row.parents.iter().copied().collect(),
-                None,
+            let visible_projection = load_visible_projection
+                .then(|| self.load_visible_row_on_branch(storage, row_id, branch_name))
+                .flatten()
+                .map(|(_, row)| row);
+            return WriteAncestry {
+                parents: existing_batch_row.parents.iter().copied().collect(),
+                visible_projection,
                 transaction_basis,
-            );
+            };
         }
         let visible_entry = storage.load_visible_region_entry(table, branch_name, row_id);
         if let Ok(Some(entry)) = visible_entry {
@@ -667,28 +678,40 @@ impl QueryManager {
                 Some(BatchMode::Transactional)
             )
             .then(|| transaction_projection_basis(&entry.current_row));
-            return (
-                entry.branch_frontier.clone(),
-                Some(entry),
+            let visible_projection =
+                load_visible_projection.then(|| QueryRowBatch::from(&entry.current_row));
+            return WriteAncestry {
+                parents: entry.branch_frontier,
+                visible_projection,
                 transaction_basis,
-            );
+            };
         }
 
-        let transaction_basis = matches!(
+        let is_transactional = matches!(
             write_context.map(WriteContext::batch_mode),
             Some(BatchMode::Transactional)
-        )
-        .then(|| self.load_visible_row_on_branch(storage, row_id, branch_name))
-        .flatten()
-        .map(|(_, row)| transaction_query_projection_basis(row_id, &row));
+        );
+        let visible_projection = (is_transactional || load_visible_projection)
+            .then(|| self.load_visible_row_on_branch(storage, row_id, branch_name))
+            .flatten()
+            .map(|(_, row)| row);
+        let transaction_basis = is_transactional
+            .then(|| {
+                visible_projection
+                    .as_ref()
+                    .map(|row| transaction_query_projection_basis(row_id, row))
+            })
+            .flatten();
 
-        (
-            storage
+        WriteAncestry {
+            parents: storage
                 .scan_row_branch_tip_ids(table, branch_name, row_id)
                 .unwrap_or_default(),
-            None,
+            visible_projection: load_visible_projection
+                .then_some(visible_projection)
+                .flatten(),
             transaction_basis,
-        )
+        }
     }
 
     fn load_branch_tip_ids(
@@ -724,18 +747,17 @@ impl QueryManager {
         table: &str,
         branch: &str,
         row_id: ObjectId,
-        parents: &[BatchId],
-        visible_entry: Option<&VisibleRowEntry>,
+        ancestry: &WriteAncestry,
         descriptor: &RowDescriptor,
         requested_data: &[u8],
     ) -> Result<Option<Vec<u8>>, QueryError> {
         if !has_counter_merge_strategy(descriptor) {
             return Ok(None);
         }
-        let [parent] = parents else {
+        let [parent] = ancestry.parents.as_slice() else {
             return Ok(None);
         };
-        let Some(visible_entry) = visible_entry else {
+        let Some(visible_projection) = ancestry.visible_projection.as_ref() else {
             return Ok(None);
         };
         let Some(raw_parent) = storage
@@ -746,9 +768,10 @@ impl QueryManager {
         else {
             return Ok(None);
         };
+
         rebase_counter_data(
             descriptor,
-            &visible_entry.current_row.data,
+            &visible_projection.data,
             requested_data,
             &raw_parent.data,
         )
@@ -942,36 +965,37 @@ impl QueryManager {
             id,
             index_mutations,
         } = commit;
-        let (parents, visible_entry, transaction_basis) =
-            self.parent_ids_for_write(storage, table, id, branch, write_context);
+        let ancestry = self.write_ancestry(
+            storage,
+            table,
+            id,
+            branch,
+            write_context,
+            has_counter_merge_strategy(prepared.descriptor.as_ref()),
+        );
 
-        let authored_data = if Self::write_context_is_open_batch(write_context) {
-            prepared.new_data.clone()
-        } else {
-            Self::authored_counter_data_for_projection_overlay(
-                storage,
-                table,
-                branch,
-                id,
-                &parents,
-                visible_entry.as_ref(),
-                prepared.descriptor.as_ref(),
-                &prepared.new_data,
-            )?
-            .unwrap_or_else(|| prepared.new_data.clone())
-        };
+        let authored_data = Self::authored_counter_data_for_projection_overlay(
+            storage,
+            table,
+            branch,
+            id,
+            &ancestry,
+            prepared.descriptor.as_ref(),
+            &prepared.new_data,
+        )?
+        .unwrap_or_else(|| prepared.new_data.clone());
         let visible_data_override =
             (authored_data != prepared.new_data).then(|| prepared.new_data.clone());
 
-        let is_known_new_object = parents.is_empty();
+        let is_known_new_object = ancestry.parents.is_empty();
         let mut row = self.authored_row_batch(
             id,
             branch,
-            parents,
+            ancestry.parents,
             authored_data,
             self.row_batch_authoring(provenance, None, write_context),
         );
-        if let Some(transaction_basis) = transaction_basis {
+        if let Some(transaction_basis) = ancestry.transaction_basis {
             row.metadata
                 .insert(MetadataKey::TransactionBasis.as_str(), transaction_basis);
         }
@@ -2224,21 +2248,20 @@ impl QueryManager {
             }
         }
 
-        let (parents, _, transaction_basis) =
-            self.parent_ids_for_write(storage, table, id, branch, write_context);
+        let ancestry = self.write_ancestry(storage, table, id, branch, write_context, false);
         let timestamp = self.resolve_update_timestamp(write_context);
         let delete_provenance =
             self.row_provenance_for_update(old_provenance_for_policy, write_context, timestamp);
 
-        let is_known_new_object = parents.is_empty();
+        let is_known_new_object = ancestry.parents.is_empty();
         let mut delete_row = self.authored_row_batch(
             id,
             branch,
-            parents,
+            ancestry.parents,
             old_data_for_policy.to_vec(),
             self.row_batch_authoring(&delete_provenance, Some(DeleteKind::Soft), write_context),
         );
-        if let Some(transaction_basis) = transaction_basis {
+        if let Some(transaction_basis) = ancestry.transaction_basis {
             delete_row
                 .metadata
                 .insert(MetadataKey::TransactionBasis.as_str(), transaction_basis);

--- a/crates/jazz-tools/src/query_manager/writes.rs
+++ b/crates/jazz-tools/src/query_manager/writes.rs
@@ -7,7 +7,8 @@ use crate::object::{BranchName, ObjectId};
 use crate::row_format::compiled_row_layout;
 use crate::row_histories::{
     ApplyRowBatchResult, ApplyRowBatchWithContext, BatchId, QueryRowBatch, RowHistoryError,
-    RowState, RowVisibilityChange, StoredRowBatch, apply_row_batch, apply_row_batch_with_context,
+    RowState, RowVisibilityChange, StoredRowBatch, VisibleRowEntry, apply_row_batch,
+    apply_row_batch_with_context,
 };
 use crate::schema_manager::{SchemaContext, resolve_current_table_name};
 use crate::storage::{
@@ -642,25 +643,22 @@ impl QueryManager {
         row_id: ObjectId,
         branch_name: &str,
         write_context: Option<&WriteContext>,
-    ) -> Vec<BatchId> {
+    ) -> (Vec<BatchId>, Option<VisibleRowEntry>) {
         if let Some(existing_batch_row) =
             self.batch_history_row_for_write(storage, row_id, branch_name, write_context)
         {
-            return existing_batch_row.parents.iter().copied().collect();
+            return (existing_batch_row.parents.iter().copied().collect(), None);
         }
-        self.load_branch_tip_ids(storage, table, row_id, branch_name)
-    }
+        if let Ok(Some(entry)) = storage.load_visible_region_entry(table, branch_name, row_id) {
+            return (entry.branch_frontier.clone(), Some(entry));
+        }
 
-    fn staged_row_for_write(
-        &self,
-        storage: &dyn Storage,
-        row_id: ObjectId,
-        branch_name: &str,
-        write_context: Option<&WriteContext>,
-    ) -> Option<QueryRowBatch> {
-        let batch_id = write_context.and_then(WriteContext::batch_id)?;
-        self.load_latest_transactional_staged_row_on_branch(storage, row_id, branch_name, batch_id)
-            .map(|(_, row)| row)
+        (
+            storage
+                .scan_row_branch_tip_ids(table, branch_name, row_id)
+                .unwrap_or_default(),
+            None,
+        )
     }
 
     fn load_branch_tip_ids(
@@ -679,26 +677,39 @@ impl QueryManager {
             .unwrap_or_default()
     }
 
+    fn staged_row_for_write(
+        &self,
+        storage: &dyn Storage,
+        row_id: ObjectId,
+        branch_name: &str,
+        write_context: Option<&WriteContext>,
+    ) -> Option<QueryRowBatch> {
+        let batch_id = write_context.and_then(WriteContext::batch_id)?;
+        self.load_latest_transactional_staged_row_on_branch(storage, row_id, branch_name, batch_id)
+            .map(|(_, row)| row)
+    }
+
     fn authored_counter_data_for_projection_overlay<H: Storage>(
         storage: &H,
         table: &str,
         branch: &str,
         row_id: ObjectId,
         parents: &[BatchId],
+        visible_entry: Option<&VisibleRowEntry>,
         descriptor: &RowDescriptor,
         requested_data: &[u8],
     ) -> Result<Option<Vec<u8>>, QueryError> {
+        if !descriptor
+            .columns
+            .iter()
+            .any(|column| matches!(column.merge_strategy, Some(ColumnMergeStrategy::Counter)))
+        {
+            return Ok(None);
+        }
         let [parent] = parents else {
             return Ok(None);
         };
-        let Some(visible_entry) = storage
-            .load_visible_region_entry(table, branch, row_id)
-            .map_err(|error| {
-                QueryError::EncodingError(format!(
-                    "load visible projection for counter update: {error}"
-                ))
-            })?
-        else {
+        let Some(visible_entry) = visible_entry else {
             return Ok(None);
         };
         let Some(raw_parent) = storage
@@ -958,7 +969,8 @@ impl QueryManager {
             id,
             index_mutations,
         } = commit;
-        let parents = self.parent_ids_for_write(storage, table, id, branch, write_context);
+        let (parents, visible_entry) =
+            self.parent_ids_for_write(storage, table, id, branch, write_context);
 
         let authored_data = if Self::write_context_is_open_batch(write_context) {
             prepared.new_data.clone()
@@ -969,6 +981,7 @@ impl QueryManager {
                 branch,
                 id,
                 &parents,
+                visible_entry.as_ref(),
                 prepared.descriptor.as_ref(),
                 &prepared.new_data,
             )?
@@ -2234,7 +2247,7 @@ impl QueryManager {
             }
         }
 
-        let parents = self.parent_ids_for_write(storage, table, id, branch, write_context);
+        let (parents, _) = self.parent_ids_for_write(storage, table, id, branch, write_context);
         let timestamp = self.resolve_update_timestamp(write_context);
         let delete_provenance =
             self.row_provenance_for_update(old_provenance_for_policy, write_context, timestamp);

--- a/crates/jazz-tools/src/query_manager/writes.rs
+++ b/crates/jazz-tools/src/query_manager/writes.rs
@@ -508,6 +508,7 @@ impl QueryManager {
                 branch: branch_name.as_str().to_string().into(),
                 context,
                 is_known_new_object,
+                is_scoped_delivery: false,
             },
         )
         .map_err(|error| Self::query_error_for_local_row_history_write(row_id, error))?;

--- a/crates/jazz-tools/src/query_manager/writes.rs
+++ b/crates/jazz-tools/src/query_manager/writes.rs
@@ -25,8 +25,8 @@ use super::policy::{ComplexClause, Operation, evaluate_simple_parts_with_row_id}
 use super::server_queries::{AuthorizationPolicyRequest, RowTransformContext};
 use super::session::{AuthMode, Session, WriteContext};
 use super::types::{
-    ColumnName, ColumnType, ComposedBranchName, LoadedRow, RowDescriptor, Schema, SchemaHash,
-    TableName, Value,
+    ColumnMergeStrategy, ColumnName, ColumnType, ComposedBranchName, LoadedRow, RowDescriptor,
+    Schema, SchemaHash, TableName, Value,
 };
 
 pub struct RowBranchWrite<'a> {
@@ -69,6 +69,7 @@ struct PreparedLocalRowHistoryWrite<'a> {
     row_locator: &'a RowLocator,
     descriptor: Arc<RowDescriptor>,
     is_known_new_object: bool,
+    visible_data_override: Option<Vec<u8>>,
 }
 
 pub struct RowBranchDelete<'a> {
@@ -480,6 +481,7 @@ impl QueryManager {
             row_locator,
             descriptor,
             is_known_new_object,
+            visible_data_override,
         } = write;
         self.persist_row_locator(storage, row_id, row_locator);
         self.ensure_known_schemas_catalogued(storage)
@@ -509,6 +511,7 @@ impl QueryManager {
                 context,
                 is_known_new_object,
                 is_scoped_delivery: false,
+                visible_data_override,
             },
         )
         .map_err(|error| Self::query_error_for_local_row_history_write(row_id, error))?;
@@ -674,6 +677,98 @@ impl QueryManager {
         storage
             .scan_row_branch_tip_ids(table, branch, row_id)
             .unwrap_or_default()
+    }
+
+    fn authored_counter_data_for_projection_overlay<H: Storage>(
+        storage: &H,
+        table: &str,
+        branch: &str,
+        row_id: ObjectId,
+        parents: &[BatchId],
+        descriptor: &RowDescriptor,
+        requested_data: &[u8],
+    ) -> Result<Option<Vec<u8>>, QueryError> {
+        let [parent] = parents else {
+            return Ok(None);
+        };
+        let Some(visible_entry) = storage
+            .load_visible_region_entry(table, branch, row_id)
+            .map_err(|error| {
+                QueryError::EncodingError(format!(
+                    "load visible projection for counter update: {error}"
+                ))
+            })?
+        else {
+            return Ok(None);
+        };
+        let Some(raw_parent) = storage
+            .load_history_row_batch(table, branch, row_id, *parent)
+            .map_err(|error| {
+                QueryError::EncodingError(format!("load raw counter frontier for update: {error}"))
+            })?
+        else {
+            return Ok(None);
+        };
+        if raw_parent.data == visible_entry.current_row.data {
+            return Ok(None);
+        }
+
+        let projected_values = decode_row(descriptor, &visible_entry.current_row.data)
+            .map_err(|error| QueryError::EncodingError(error.to_string()))?;
+        let requested_values = decode_row(descriptor, requested_data)
+            .map_err(|error| QueryError::EncodingError(error.to_string()))?;
+        let raw_values = decode_row(descriptor, &raw_parent.data)
+            .map_err(|error| QueryError::EncodingError(error.to_string()))?;
+        let mut authored_values = requested_values.clone();
+
+        for (index, column) in descriptor.columns.iter().enumerate() {
+            if !matches!(column.merge_strategy, Some(ColumnMergeStrategy::Counter)) {
+                continue;
+            }
+            let counter_value = |value: &Value| match value {
+                Value::Integer(value) => Some(*value),
+                Value::Null => Some(0),
+                _ => None,
+            };
+            let projected = counter_value(&projected_values[index]).ok_or_else(|| {
+                QueryError::EncodingError(format!(
+                    "counter projection for '{}' is not an integer",
+                    column.name_str()
+                ))
+            })?;
+            let requested = counter_value(&requested_values[index]).ok_or_else(|| {
+                QueryError::EncodingError(format!(
+                    "requested counter value for '{}' is not an integer",
+                    column.name_str()
+                ))
+            })?;
+            let raw = counter_value(&raw_values[index]).ok_or_else(|| {
+                QueryError::EncodingError(format!(
+                    "raw counter frontier for '{}' is not an integer",
+                    column.name_str()
+                ))
+            })?;
+            let delta = requested.checked_sub(projected).ok_or_else(|| {
+                QueryError::EncodingError(format!(
+                    "counter projection delta overflow for '{}'",
+                    column.name_str()
+                ))
+            })?;
+            let authored = raw.checked_add(delta).ok_or_else(|| {
+                QueryError::EncodingError(format!(
+                    "counter projection update overflow for '{}'",
+                    column.name_str()
+                ))
+            })?;
+            authored_values[index] = Value::Integer(authored);
+        }
+
+        if authored_values == requested_values {
+            return Ok(None);
+        }
+        encode_row(descriptor, &authored_values)
+            .map(Some)
+            .map_err(|error| QueryError::EncodingError(error.to_string()))
     }
 
     fn prepare_update_write_for_schema<H: Storage>(
@@ -865,12 +960,29 @@ impl QueryManager {
         } = commit;
         let parents = self.parent_ids_for_write(storage, table, id, branch, write_context);
 
+        let authored_data = if Self::write_context_is_open_batch(write_context) {
+            prepared.new_data.clone()
+        } else {
+            Self::authored_counter_data_for_projection_overlay(
+                storage,
+                table,
+                branch,
+                id,
+                &parents,
+                prepared.descriptor.as_ref(),
+                &prepared.new_data,
+            )?
+            .unwrap_or_else(|| prepared.new_data.clone())
+        };
+        let visible_data_override =
+            (authored_data != prepared.new_data).then(|| prepared.new_data.clone());
+
         let is_known_new_object = parents.is_empty();
         let row = self.authored_row_batch(
             id,
             branch,
             parents,
-            prepared.new_data.clone(),
+            authored_data,
             self.row_batch_authoring(provenance, None, write_context),
         );
         let branch_name = BranchName::new(branch);
@@ -886,6 +998,7 @@ impl QueryManager {
                     row_locator: &prepared.row_locator,
                     descriptor: prepared.descriptor.clone(),
                     is_known_new_object,
+                    visible_data_override,
                 },
             )?;
         self.maybe_track_local_pending_batch_overlay(
@@ -1197,6 +1310,7 @@ impl QueryManager {
                     row_locator: &table_write.row_locator,
                     descriptor: table_write.descriptor.clone(),
                     is_known_new_object: true,
+                    visible_data_override: None,
                 },
             )?;
         self.maybe_track_local_pending_batch_overlay(
@@ -2158,6 +2272,7 @@ impl QueryManager {
                     row_locator: &table_write.row_locator,
                     descriptor: table_write.descriptor.clone(),
                     is_known_new_object,
+                    visible_data_override: None,
                 },
             )?;
         self.maybe_track_local_pending_batch_overlay(

--- a/crates/jazz-tools/src/row_histories/mod.rs
+++ b/crates/jazz-tools/src/row_histories/mod.rs
@@ -30,11 +30,14 @@ pub use codecs::{
 };
 pub(crate) use mutations::{ApplyRowBatchWithContext, apply_row_batch_with_context};
 pub use mutations::{apply_row_batch, patch_row_batch_state};
-pub(crate) use resolution::visible_row_preview_from_history_rows;
+pub(crate) use resolution::{
+    has_counter_merge_strategy, rebase_counter_data, visible_row_preview_from_history_rows,
+};
 pub use types::{
     ApplyRowBatchResult, BatchId, HistoryScan, QueryRowBatch, RowHistoryError, RowMetadata,
     RowState, RowVisibilityChange, StoredRowBatch, VisibleRowEntry,
 };
+pub(crate) use types::{transaction_projection_basis, transaction_query_projection_basis};
 
 #[cfg(test)]
 mod tests {

--- a/crates/jazz-tools/src/row_histories/mutations.rs
+++ b/crates/jazz-tools/src/row_histories/mutations.rs
@@ -190,7 +190,7 @@ pub(crate) fn apply_row_batch_with_context<H: Storage>(
     let ApplyRowBatchWithContext {
         object_id,
         branch_name,
-        row,
+        mut row,
         index_mutations,
         row_locator,
         table,
@@ -218,6 +218,68 @@ pub(crate) fn apply_row_batch_with_context<H: Storage>(
         .as_ref()
         .map(|entry| entry.current_row.clone());
 
+    let existing_history_row = if !is_known_new_object {
+        io.load_history_row_batch(&table, branch_name.as_str(), object_id, batch_id)
+            .map_err(RowHistoryError::StorageError)?
+    } else {
+        None
+    };
+
+    // Scoped deliveries intentionally omit parents. Reattach a new snapshot
+    // to the local frontier so a causal update does not become a new root.
+    // If the raw batch already exists, update only the visible projection:
+    // the merged snapshot must not replace the writer's raw history.
+    if row.state.is_visible() && row.parents.is_empty() && !is_known_new_object {
+        if let Some(existing_row) = existing_history_row.as_ref()
+            && !existing_row.parents.is_empty()
+        {
+            if existing_row == &row {
+                return Ok(ApplyRowBatchResult {
+                    batch_id,
+                    row_locator,
+                    visibility_change: None,
+                });
+            }
+
+            let current_entry = VisibleRowEntry::new(row.clone());
+            let current_visible = Some(row.clone());
+            let visible_changed = previous_visible != current_visible;
+            let encoded_visible =
+                crate::storage::encode_visible_row_bytes_with_context(&context, &current_entry)
+                    .map_err(RowHistoryError::StorageError)?;
+            <H as Storage>::apply_prepared_row_mutation(
+                io,
+                &table,
+                &[],
+                std::slice::from_ref(&current_entry),
+                &[],
+                std::slice::from_ref(&encoded_visible),
+                index_mutations,
+            )
+            .map_err(RowHistoryError::StorageError)?;
+
+            let applied = AppliedRowBatch {
+                row_locator: row_locator.clone(),
+                previous_visible,
+                current_visible,
+                is_new_object: false,
+                visible_changed,
+            };
+            return Ok(ApplyRowBatchResult {
+                batch_id,
+                row_locator,
+                visibility_change: visibility_change_from_applied(object_id, applied),
+            });
+        }
+
+        if let Some(previous_entry) = previous_entry.as_ref()
+            && !previous_entry.branch_frontier.is_empty()
+            && !previous_entry.branch_frontier.contains(&batch_id)
+        {
+            row.parents = previous_entry.branch_frontier.clone().into();
+        }
+    }
+
     if !is_known_new_object {
         for parent in &row.parents {
             if io
@@ -243,16 +305,14 @@ pub(crate) fn apply_row_batch_with_context<H: Storage>(
     } else {
         let mut patched_history = load_branch_history(io, &table, object_id, &branch)?;
 
-        if let Some(existing_row) = io
-            .load_history_row_batch(&table, branch_name.as_str(), object_id, batch_id)
-            .map_err(RowHistoryError::StorageError)?
-            && existing_row == row
-        {
-            return Ok(ApplyRowBatchResult {
-                batch_id,
-                row_locator,
-                visibility_change: None,
-            });
+        if let Some(existing_row) = existing_history_row {
+            if existing_row == row {
+                return Ok(ApplyRowBatchResult {
+                    batch_id,
+                    row_locator,
+                    visibility_change: None,
+                });
+            }
         }
         if let Some(existing) = patched_history
             .iter_mut()

--- a/crates/jazz-tools/src/row_histories/mutations.rs
+++ b/crates/jazz-tools/src/row_histories/mutations.rs
@@ -47,6 +47,9 @@ pub(crate) struct ApplyRowBatchWithContext<'a> {
     /// True only when a top-level client applies a parent-stripped row from
     /// its upstream server.
     pub(crate) is_scoped_delivery: bool,
+    /// Materialised data to expose while the raw row remains authoritative
+    /// for history and sync.
+    pub(crate) visible_data_override: Option<Vec<u8>>,
 }
 
 pub(super) fn row_locator_from_storage<H: Storage>(
@@ -183,6 +186,7 @@ pub fn apply_row_batch<H: Storage>(
             context,
             is_known_new_object: false,
             is_scoped_delivery: false,
+            visible_data_override: None,
         },
     )
 }
@@ -194,7 +198,7 @@ pub(crate) fn apply_row_batch_with_context<H: Storage>(
     let ApplyRowBatchWithContext {
         object_id,
         branch_name,
-        mut row,
+        row,
         index_mutations,
         row_locator,
         table,
@@ -202,6 +206,7 @@ pub(crate) fn apply_row_batch_with_context<H: Storage>(
         context,
         is_known_new_object,
         is_scoped_delivery,
+        visible_data_override,
     } = request;
     let batch_id = row.batch_id();
     debug_assert!(
@@ -227,17 +232,9 @@ pub(crate) fn apply_row_batch_with_context<H: Storage>(
         && row.state.is_visible()
         && row.parents.is_empty()
         && !is_known_new_object;
-    let existing_history_row = if is_scoped_visible_delivery {
-        io.load_history_row_batch(&table, branch_name.as_str(), object_id, batch_id)
-            .map_err(RowHistoryError::StorageError)?
-    } else {
-        None
-    };
-
-    // Scoped deliveries intentionally omit parents. Reattach a new snapshot
-    // to the local frontier so a causal update does not become a new root.
-    // If the raw batch already exists, update only the visible projection:
-    // the merged snapshot must not replace the writer's raw history.
+    // Scoped deliveries intentionally omit parents, so they cannot safely be
+    // added to raw history. Keep the local frontier intact and update only
+    // the server-derived materialised projection.
     if is_scoped_visible_delivery {
         if let Some(previous_entry) = previous_entry.as_ref()
             && (row.updated_at, row.batch_id())
@@ -253,55 +250,38 @@ pub(crate) fn apply_row_batch_with_context<H: Storage>(
             });
         }
 
-        if existing_history_row.is_some() {
-            // The raw row is authoritative for future merges. A scoped
-            // snapshot may contain contributions from history this client
-            // cannot see, so update only the materialised projection while
-            // preserving the frontier and tier sidecars used by later local
-            // writes and tiered reads.
-            let mut current_entry = previous_entry
-                .clone()
-                .unwrap_or_else(|| VisibleRowEntry::new(row.clone()));
-            current_entry.current_row = row.clone();
-            let current_visible = Some(row.clone());
-            let visible_changed = previous_visible != current_visible;
-            let encoded_visible =
-                crate::storage::encode_visible_row_bytes_with_context(&context, &current_entry)
-                    .map_err(RowHistoryError::StorageError)?;
-            <H as Storage>::apply_prepared_row_mutation(
-                io,
-                &table,
-                &[],
-                std::slice::from_ref(&current_entry),
-                &[],
-                std::slice::from_ref(&encoded_visible),
-                index_mutations,
-            )
-            .map_err(RowHistoryError::StorageError)?;
+        let mut current_entry = previous_entry
+            .clone()
+            .unwrap_or_else(|| VisibleRowEntry::new(row.clone()));
+        current_entry.current_row = row.clone();
+        let current_visible = Some(row.clone());
+        let visible_changed = previous_visible != current_visible;
+        let encoded_visible =
+            crate::storage::encode_visible_row_bytes_with_context(&context, &current_entry)
+                .map_err(RowHistoryError::StorageError)?;
+        <H as Storage>::apply_prepared_row_mutation(
+            io,
+            &table,
+            &[],
+            std::slice::from_ref(&current_entry),
+            &[],
+            std::slice::from_ref(&encoded_visible),
+            index_mutations,
+        )
+        .map_err(RowHistoryError::StorageError)?;
 
-            let applied = AppliedRowBatch {
-                row_locator: row_locator.clone(),
-                previous_visible,
-                current_visible,
-                is_new_object: false,
-                visible_changed,
-            };
-            return Ok(ApplyRowBatchResult {
-                batch_id,
-                row_locator,
-                visibility_change: visibility_change_from_applied(object_id, applied),
-            });
-        }
-
-        // A pruned ancestor may not appear in the local frontier. The
-        // monotonic check above rejects that stale delivery before it can be
-        // attached below one of its descendants.
-        if let Some(previous_entry) = previous_entry.as_ref()
-            && !previous_entry.branch_frontier.is_empty()
-            && !previous_entry.branch_frontier.contains(&batch_id)
-        {
-            row.parents = previous_entry.branch_frontier.clone().into();
-        }
+        let applied = AppliedRowBatch {
+            row_locator: row_locator.clone(),
+            previous_visible,
+            current_visible,
+            is_new_object: false,
+            visible_changed,
+        };
+        return Ok(ApplyRowBatchResult {
+            batch_id,
+            row_locator,
+            visibility_change: visibility_change_from_applied(object_id, applied),
+        });
     }
 
     if !is_known_new_object {
@@ -316,7 +296,7 @@ pub(crate) fn apply_row_batch_with_context<H: Storage>(
         }
     }
 
-    let current_entry = if is_known_new_object {
+    let mut current_entry = if is_known_new_object {
         visible_entry_from_history_rows(
             context.user_descriptor().as_ref(),
             std::slice::from_ref(&row),
@@ -329,12 +309,9 @@ pub(crate) fn apply_row_batch_with_context<H: Storage>(
     } else {
         let mut patched_history = load_branch_history(io, &table, object_id, &branch)?;
 
-        let existing_history_row = if let Some(existing_row) = existing_history_row {
-            Some(existing_row)
-        } else {
-            io.load_history_row_batch(&table, branch_name.as_str(), object_id, batch_id)
-                .map_err(RowHistoryError::StorageError)?
-        };
+        let existing_history_row = io
+            .load_history_row_batch(&table, branch_name.as_str(), object_id, batch_id)
+            .map_err(RowHistoryError::StorageError)?;
         if let Some(existing_row) = existing_history_row
             && existing_row == row
         {
@@ -359,6 +336,11 @@ pub(crate) fn apply_row_batch_with_context<H: Storage>(
                 )))
             })?
     };
+    if let Some(entry) = current_entry.as_mut()
+        && let Some(data) = visible_data_override
+    {
+        entry.current_row.data = data.into();
+    }
     let current_visible = current_entry
         .as_ref()
         .map(|entry| entry.current_row.clone());

--- a/crates/jazz-tools/src/row_histories/mutations.rs
+++ b/crates/jazz-tools/src/row_histories/mutations.rs
@@ -305,14 +305,14 @@ pub(crate) fn apply_row_batch_with_context<H: Storage>(
     } else {
         let mut patched_history = load_branch_history(io, &table, object_id, &branch)?;
 
-        if let Some(existing_row) = existing_history_row {
-            if existing_row == row {
-                return Ok(ApplyRowBatchResult {
-                    batch_id,
-                    row_locator,
-                    visibility_change: None,
-                });
-            }
+        if let Some(existing_row) = existing_history_row
+            && existing_row == row
+        {
+            return Ok(ApplyRowBatchResult {
+                batch_id,
+                row_locator,
+                visibility_change: None,
+            });
         }
         if let Some(existing) = patched_history
             .iter_mut()

--- a/crates/jazz-tools/src/row_histories/mutations.rs
+++ b/crates/jazz-tools/src/row_histories/mutations.rs
@@ -44,6 +44,9 @@ pub(crate) struct ApplyRowBatchWithContext<'a> {
     pub(crate) branch: SharedString,
     pub(crate) context: PreparedRowWriteContext,
     pub(crate) is_known_new_object: bool,
+    /// True only when a top-level client applies a parent-stripped row from
+    /// its upstream server.
+    pub(crate) is_scoped_delivery: bool,
 }
 
 pub(super) fn row_locator_from_storage<H: Storage>(
@@ -179,6 +182,7 @@ pub fn apply_row_batch<H: Storage>(
             branch,
             context,
             is_known_new_object: false,
+            is_scoped_delivery: false,
         },
     )
 }
@@ -197,6 +201,7 @@ pub(crate) fn apply_row_batch_with_context<H: Storage>(
         branch,
         context,
         is_known_new_object,
+        is_scoped_delivery,
     } = request;
     let batch_id = row.batch_id();
     debug_assert!(
@@ -218,8 +223,10 @@ pub(crate) fn apply_row_batch_with_context<H: Storage>(
         .as_ref()
         .map(|entry| entry.current_row.clone());
 
-    let is_scoped_visible_delivery =
-        row.state.is_visible() && row.parents.is_empty() && !is_known_new_object;
+    let is_scoped_visible_delivery = is_scoped_delivery
+        && row.state.is_visible()
+        && row.parents.is_empty()
+        && !is_known_new_object;
     let existing_history_row = if is_scoped_visible_delivery {
         io.load_history_row_batch(&table, branch_name.as_str(), object_id, batch_id)
             .map_err(RowHistoryError::StorageError)?

--- a/crates/jazz-tools/src/row_histories/mutations.rs
+++ b/crates/jazz-tools/src/row_histories/mutations.rs
@@ -218,7 +218,9 @@ pub(crate) fn apply_row_batch_with_context<H: Storage>(
         .as_ref()
         .map(|entry| entry.current_row.clone());
 
-    let existing_history_row = if !is_known_new_object {
+    let is_scoped_visible_delivery =
+        row.state.is_visible() && row.parents.is_empty() && !is_known_new_object;
+    let existing_history_row = if is_scoped_visible_delivery {
         io.load_history_row_batch(&table, branch_name.as_str(), object_id, batch_id)
             .map_err(RowHistoryError::StorageError)?
     } else {
@@ -229,19 +231,31 @@ pub(crate) fn apply_row_batch_with_context<H: Storage>(
     // to the local frontier so a causal update does not become a new root.
     // If the raw batch already exists, update only the visible projection:
     // the merged snapshot must not replace the writer's raw history.
-    if row.state.is_visible() && row.parents.is_empty() && !is_known_new_object {
-        if let Some(existing_row) = existing_history_row.as_ref()
-            && !existing_row.parents.is_empty()
+    if is_scoped_visible_delivery {
+        if let Some(previous_entry) = previous_entry.as_ref()
+            && (row.updated_at, row.batch_id())
+                < (
+                    previous_entry.current_row.updated_at,
+                    previous_entry.current_row.batch_id(),
+                )
         {
-            if existing_row == &row {
-                return Ok(ApplyRowBatchResult {
-                    batch_id,
-                    row_locator,
-                    visibility_change: None,
-                });
-            }
+            return Ok(ApplyRowBatchResult {
+                batch_id,
+                row_locator,
+                visibility_change: None,
+            });
+        }
 
-            let current_entry = VisibleRowEntry::new(row.clone());
+        if existing_history_row.is_some() {
+            // The raw row is authoritative for future merges. A scoped
+            // snapshot may contain contributions from history this client
+            // cannot see, so update only the materialised projection while
+            // preserving the frontier and tier sidecars used by later local
+            // writes and tiered reads.
+            let mut current_entry = previous_entry
+                .clone()
+                .unwrap_or_else(|| VisibleRowEntry::new(row.clone()));
+            current_entry.current_row = row.clone();
             let current_visible = Some(row.clone());
             let visible_changed = previous_visible != current_visible;
             let encoded_visible =
@@ -272,6 +286,9 @@ pub(crate) fn apply_row_batch_with_context<H: Storage>(
             });
         }
 
+        // A pruned ancestor may not appear in the local frontier. The
+        // monotonic check above rejects that stale delivery before it can be
+        // attached below one of its descendants.
         if let Some(previous_entry) = previous_entry.as_ref()
             && !previous_entry.branch_frontier.is_empty()
             && !previous_entry.branch_frontier.contains(&batch_id)
@@ -305,6 +322,12 @@ pub(crate) fn apply_row_batch_with_context<H: Storage>(
     } else {
         let mut patched_history = load_branch_history(io, &table, object_id, &branch)?;
 
+        let existing_history_row = if let Some(existing_row) = existing_history_row {
+            Some(existing_row)
+        } else {
+            io.load_history_row_batch(&table, branch_name.as_str(), object_id, batch_id)
+                .map_err(RowHistoryError::StorageError)?
+        };
         if let Some(existing_row) = existing_history_row
             && existing_row == row
         {

--- a/crates/jazz-tools/src/row_histories/resolution.rs
+++ b/crates/jazz-tools/src/row_histories/resolution.rs
@@ -27,7 +27,7 @@ use crate::metadata::DeleteKind;
 use crate::query_manager::types::{
     ColumnDescriptor, ColumnMergeStrategy, ColumnType, RowDescriptor, Value,
 };
-use crate::row_format::{EncodingError, encode_row, encode_value_with_type};
+use crate::row_format::{EncodingError, decode_row, encode_row, encode_value_with_type};
 use crate::sync_manager::DurabilityTier;
 
 use super::codecs::{flat_user_values, malformed, tier_satisfies};
@@ -119,6 +119,68 @@ pub(super) fn current_winner_batch_id(
     column_winner
         .map(StoredRowBatch::batch_id)
         .unwrap_or_else(|| fallback.batch_id())
+}
+
+pub(crate) fn has_counter_merge_strategy(descriptor: &RowDescriptor) -> bool {
+    descriptor
+        .columns
+        .iter()
+        .any(|column| matches!(column.merge_strategy, Some(ColumnMergeStrategy::Counter)))
+}
+
+pub(crate) fn rebase_counter_data(
+    descriptor: &RowDescriptor,
+    source_base_data: &[u8],
+    source_result_data: &[u8],
+    target_base_data: &[u8],
+) -> Result<Option<Vec<u8>>, EncodingError> {
+    if !has_counter_merge_strategy(descriptor) {
+        return Ok(None);
+    }
+
+    let source_base_values = decode_row(descriptor, source_base_data)?;
+    let source_result_values = decode_row(descriptor, source_result_data)?;
+    let target_base_values = decode_row(descriptor, target_base_data)?;
+    let mut rebased_values = source_result_values.clone();
+
+    let counter_value = |column: &ColumnDescriptor, value: &Value| match value {
+        Value::Integer(value) => Ok(*value),
+        Value::Null => Ok(0),
+        other => Err(malformed(format!(
+            "counter rebase expected INTEGER for column '{}', got {:?}",
+            column.name_str(),
+            other
+        ))),
+    };
+
+    for (index, column) in descriptor.columns.iter().enumerate() {
+        if !matches!(column.merge_strategy, Some(ColumnMergeStrategy::Counter)) {
+            continue;
+        }
+
+        let source_base = counter_value(column, &source_base_values[index])?;
+        let source_result = counter_value(column, &source_result_values[index])?;
+        let target_base = counter_value(column, &target_base_values[index])?;
+        let delta = source_result.checked_sub(source_base).ok_or_else(|| {
+            malformed(format!(
+                "counter rebase delta overflow for column '{}'",
+                column.name_str()
+            ))
+        })?;
+        let rebased = target_base.checked_add(delta).ok_or_else(|| {
+            malformed(format!(
+                "counter rebase overflow for column '{}'",
+                column.name_str()
+            ))
+        })?;
+        rebased_values[index] = Value::Integer(rebased);
+    }
+
+    if rebased_values == source_result_values {
+        return Ok(None);
+    }
+
+    encode_row(descriptor, &rebased_values).map(Some)
 }
 
 #[derive(Clone, Copy)]

--- a/crates/jazz-tools/src/row_histories/types.rs
+++ b/crates/jazz-tools/src/row_histories/types.rs
@@ -243,6 +243,22 @@ impl RowMetadata {
             .find_map(|(entry_key, value)| (entry_key == key).then_some(value))
     }
 
+    pub(crate) fn insert(&mut self, key: impl Into<String>, value: impl Into<String>) {
+        let key = key.into();
+        let value = value.into();
+        if let Some((_, existing_value)) = self
+            .0
+            .iter_mut()
+            .find(|(existing_key, _)| existing_key == &key)
+        {
+            *existing_value = value;
+            return;
+        }
+        self.0.push((key, value));
+        self.0
+            .sort_by(|(left_key, _), (right_key, _)| left_key.cmp(right_key));
+    }
+
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
@@ -374,6 +390,53 @@ impl StoredRowBatch {
     pub fn is_hard_deleted(&self) -> bool {
         self.delete_kind == Some(DeleteKind::Hard) || (self.is_deleted && self.data.is_empty())
     }
+}
+
+fn transaction_projection_basis_for_fields(
+    row_id: ObjectId,
+    batch_id: BatchId,
+    updated_at: u64,
+    data: &[u8],
+    is_soft_deleted: bool,
+    is_hard_deleted: bool,
+) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"jazz-transaction-projection-basis-v1");
+    hasher.update(row_id.uuid().as_bytes());
+    hasher.update(batch_id.as_bytes());
+    hasher.update(&updated_at.to_le_bytes());
+    hasher.update(&(data.len() as u64).to_le_bytes());
+    hasher.update(data);
+    hasher.update(&[if is_hard_deleted {
+        2
+    } else if is_soft_deleted {
+        1
+    } else {
+        0
+    }]);
+    hasher.finalize().to_hex().to_string()
+}
+
+pub(crate) fn transaction_projection_basis(row: &StoredRowBatch) -> String {
+    transaction_projection_basis_for_fields(
+        row.row_id,
+        row.batch_id,
+        row.updated_at,
+        &row.data,
+        row.is_soft_deleted(),
+        row.is_hard_deleted(),
+    )
+}
+
+pub(crate) fn transaction_query_projection_basis(row_id: ObjectId, row: &QueryRowBatch) -> String {
+    transaction_projection_basis_for_fields(
+        row_id,
+        row.batch_id,
+        row.updated_at,
+        &row.data,
+        row.is_soft_deleted(),
+        row.is_hard_deleted(),
+    )
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -362,6 +362,7 @@ impl SyncManager {
         metadata: Option<RowMetadata>,
         mut row: StoredRowBatch,
         fate_recording: AuthoritativeFateRecording,
+        is_scoped_delivery: bool,
     ) -> Option<AppliedRowBatch> {
         let authoritative_tier = match (row.confirmed_tier, self.max_local_durability_tier()) {
             (Some(incoming), Some(local)) => Some(incoming.max(local)),
@@ -412,6 +413,7 @@ impl SyncManager {
                             branch,
                             context,
                             is_known_new_object: is_newly_located_object && row.parents.is_empty(),
+                            is_scoped_delivery,
                         },
                     ) {
                         Ok(applied) => applied.visibility_change,
@@ -705,6 +707,7 @@ impl SyncManager {
                 branch: branch_name.as_str().to_string().into(),
                 context,
                 is_known_new_object: false,
+                is_scoped_delivery: !self.has_durability_identity(),
             },
         )
         .ok()
@@ -1323,6 +1326,7 @@ impl SyncManager {
             | SyncPayload::RowBatchNeeded { metadata, row } => {
                 let object_id = row.row_id;
                 let branch_name = BranchName::new(&row.branch);
+                let is_scoped_delivery = !self.has_durability_identity();
                 tracing::debug!(
                     %object_id,
                     %branch_name,
@@ -1333,6 +1337,7 @@ impl SyncManager {
                     metadata,
                     row.clone(),
                     AuthoritativeFateRecording::AcceptedByLocalAuthority,
+                    is_scoped_delivery,
                 ) {
                     self.apply_authoritative_transaction_fate_for_row(
                         storage,
@@ -1862,7 +1867,7 @@ impl SyncManager {
                     .insert(client_id);
 
                 if let Some(applied) =
-                    self.apply_row_updated(storage, metadata, row.clone(), fate_recording)
+                    self.apply_row_updated(storage, metadata, row.clone(), fate_recording, false)
                 {
                     self.forward_row_batch_to_servers(
                         storage,

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -414,6 +414,7 @@ impl SyncManager {
                             context,
                             is_known_new_object: is_newly_located_object && row.parents.is_empty(),
                             is_scoped_delivery,
+                            visible_data_override: None,
                         },
                     ) {
                         Ok(applied) => applied.visibility_change,
@@ -708,6 +709,7 @@ impl SyncManager {
                 context,
                 is_known_new_object: false,
                 is_scoped_delivery: !self.has_durability_identity(),
+                visible_data_override: None,
             },
         )
         .ok()

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -5,12 +5,13 @@ use crate::object::{BranchName, ObjectId};
 use crate::query_manager::policy::Operation;
 use crate::row_histories::{
     ApplyRowBatchWithContext, RowState, RowVisibilityChange, StoredRowBatch, apply_row_batch,
-    apply_row_batch_with_context, patch_row_batch_state,
+    apply_row_batch_with_context, patch_row_batch_state, transaction_projection_basis,
+    visible_row_preview_from_history_rows,
 };
 use crate::storage::{
     PreparedRowWriteContext, RowLocator, Storage, metadata_from_row_locator,
     prepared_row_table_context_for_schema_hash, prepared_row_write_context_from_table_context,
-    row_locator_from_metadata,
+    resolve_history_row_write_context, row_locator_from_metadata,
 };
 use std::collections::{HashMap, HashSet};
 
@@ -155,6 +156,45 @@ impl SyncManager {
         declared_rows: &[(String, StoredRowBatch)],
     ) -> Result<(), BatchFate> {
         for (table, row) in declared_rows {
+            if let Some(expected_basis) = row.metadata.get(MetadataKey::TransactionBasis.as_str()) {
+                let history_rows = storage
+                    .scan_history_row_batches(table, row.row_id)
+                    .map_err(|error| BatchFate::Rejected {
+                        batch_id: submission.batch_id,
+                        code: "invalid_batch_submission".to_string(),
+                        reason: format!("failed to load row history transaction basis: {error}"),
+                    })?;
+                let branch_history = history_rows
+                    .into_iter()
+                    .filter(|history_row| {
+                        history_row.branch.as_str() == submission.target_branch_name.as_str()
+                    })
+                    .collect::<Vec<_>>();
+                let context =
+                    resolve_history_row_write_context(storage, table, row).map_err(|error| {
+                        BatchFate::Rejected {
+                            batch_id: submission.batch_id,
+                            code: "invalid_batch_submission".to_string(),
+                            reason: format!("failed to resolve row transaction basis: {error}"),
+                        }
+                    })?;
+                let current_basis = visible_row_preview_from_history_rows(
+                    context.user_descriptor().as_ref(),
+                    &branch_history,
+                    None,
+                )
+                .map_err(|error| BatchFate::Rejected {
+                    batch_id: submission.batch_id,
+                    code: "invalid_batch_submission".to_string(),
+                    reason: format!("failed to rebuild row transaction basis: {error}"),
+                })?
+                .map(|visible_row| transaction_projection_basis(&visible_row));
+                if current_basis.as_ref() != Some(expected_basis) {
+                    return Err(self.parent_frontier_conflict_fate(submission.batch_id));
+                }
+                continue;
+            }
+
             let expected_frontier = Self::normalize_frontier(row.parents.iter().copied().collect());
             let current_frontier = storage
                 .load_visible_region_frontier(

--- a/crates/jazz-tools/tests/counter_merge.rs
+++ b/crates/jazz-tools/tests/counter_merge.rs
@@ -11,6 +11,7 @@ use jazz_tools::{
     RowDescriptor, Schema, TableName, TableSchema, Value,
 };
 use support::{TestingClient, wait_for_query};
+use uuid::Uuid;
 
 const READY_TIMEOUT: Duration = Duration::from_secs(30);
 const QUERY_TIMEOUT: Duration = Duration::from_secs(25);
@@ -320,6 +321,121 @@ async fn counter_merge_preserves_projection_when_scoped_snapshot_replays_local_b
         .expect("shutdown Bob after the offline follow-up");
     observer.shutdown().await.expect("shutdown observer");
     alice.shutdown().await.expect("shutdown Alice");
+    server.shutdown().await;
+}
+
+#[tokio::test]
+/// Keeps caller-supplied IDs from turning concurrent inserts into causal updates.
+///
+/// Alice and bob intentionally create the same deterministic ID while offline;
+/// this is not a random UUID collision.
+///
+/// ```text
+/// alice ── offline insert id=shared, value=2 ──► server
+/// bob   ── offline insert id=shared, value=3 ──► server
+/// observer ◄────────── concurrent-root merge 5 ────────── server
+/// ```
+async fn parentless_client_rows_with_the_same_id_remain_concurrent() {
+    let _suite_guard = COUNTER_SUITE_LOCK.lock().await;
+    let schema = counter_schema();
+    let server = JazzServer::start_with_schema(schema.clone()).await;
+
+    let (mut alice_context, alice) = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema.clone())
+        .with_user_id("alice-counter-shared-id")
+        .with_persistent_storage()
+        .ready_on("counters", READY_TIMEOUT)
+        .connect_with_context()
+        .await;
+    let (mut bob_context, bob) = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema.clone())
+        .with_user_id("bob-counter-shared-id")
+        .with_persistent_storage()
+        .ready_on("counters", READY_TIMEOUT)
+        .connect_with_context()
+        .await;
+
+    alice
+        .shutdown()
+        .await
+        .expect("alice shuts down before the offline insert");
+    bob.shutdown()
+        .await
+        .expect("bob shuts down before the offline insert");
+    alice_context.server_url = String::new();
+    bob_context.server_url = String::new();
+
+    let shared_id =
+        Uuid::parse_str("550e8400-e29b-41d4-a716-446655440010").expect("parse shared UUID");
+    let alice_offline = JazzClient::connect(alice_context.clone())
+        .await
+        .expect("alice opens her persistent storage offline");
+    let (_, _, _) = alice_offline
+        .insert_with_id("counters", shared_id, jazz_tools::row_input!("value" => 2))
+        .expect("alice inserts the shared ID offline");
+    alice_offline
+        .shutdown()
+        .await
+        .expect("alice shuts down after the offline insert");
+
+    let bob_offline = JazzClient::connect(bob_context.clone())
+        .await
+        .expect("bob opens his persistent storage offline");
+    let (counter_id, _, _) = bob_offline
+        .insert_with_id("counters", shared_id, jazz_tools::row_input!("value" => 3))
+        .expect("bob inserts the shared ID offline");
+    bob_offline
+        .shutdown()
+        .await
+        .expect("bob shuts down after the offline insert");
+
+    alice_context.server_url = server.base_url();
+    let alice_restarted = JazzClient::connect(alice_context)
+        .await
+        .expect("alice reconnects with her offline insert");
+    wait_for_query(
+        &alice_restarted,
+        QueryBuilder::new("counters").build(),
+        Some(DurabilityTier::EdgeServer),
+        QUERY_TIMEOUT,
+        "alice's root reaches the server first",
+        |rows| {
+            (rows.len() == 1 && rows[0].0 == counter_id && counter_value(&rows[0]) == Some(2))
+                .then_some(())
+        },
+    )
+    .await;
+
+    bob_context.server_url = server.base_url();
+    let bob_restarted = JazzClient::connect(bob_context)
+        .await
+        .expect("bob reconnects with his concurrent root");
+
+    let observer = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema)
+        .with_user_id("charlie-counter-shared-id")
+        .ready_on("counters", READY_TIMEOUT)
+        .connect()
+        .await;
+    wait_for_query(
+        &observer,
+        QueryBuilder::new("counters").build(),
+        Some(DurabilityTier::EdgeServer),
+        QUERY_TIMEOUT,
+        "observer sees both parentless inserts merged as concurrent roots",
+        |rows| {
+            (rows.len() == 1 && rows[0].0 == counter_id && counter_value(&rows[0]) == Some(5))
+                .then_some(())
+        },
+    )
+    .await;
+
+    observer.shutdown().await.expect("shutdown observer");
+    bob_restarted.shutdown().await.expect("shutdown bob");
+    alice_restarted.shutdown().await.expect("shutdown alice");
     server.shutdown().await;
 }
 

--- a/crates/jazz-tools/tests/counter_merge.rs
+++ b/crates/jazz-tools/tests/counter_merge.rs
@@ -501,6 +501,141 @@ async fn scoped_projection_rebases_an_open_counter_transaction() {
 }
 
 #[tokio::test]
+/// Authors a transaction's counter delta from the scoped projection Bob observed.
+///
+/// ```text
+/// alice ── +5 ──► server ── scoped 5 ──────────────► bob
+/// bob ── begin transaction ── set 6 ──► local 6
+/// bob ── commit +1 ──► server ── merged 6 ─────────► charlie
+/// ```
+async fn counter_transaction_staged_after_scoped_projection_commits_observed_value() {
+    let _suite_guard = COUNTER_SUITE_LOCK.lock().await;
+    let schema = counter_schema();
+    let server = JazzServer::start_with_schema(schema.clone()).await;
+
+    let alice = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema.clone())
+        .with_user_id("alice-counter-transaction-basis")
+        .ready_on("counters", READY_TIMEOUT)
+        .connect()
+        .await;
+    let bob = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema.clone())
+        .with_user_id("bob-counter-transaction-basis")
+        .ready_on("counters", READY_TIMEOUT)
+        .connect()
+        .await;
+
+    let (counter_id, _, _) = alice
+        .insert("counters", jazz_tools::row_input!("value" => 0))
+        .expect("alice creates counter");
+    let query = QueryBuilder::new("counters").build();
+    wait_for_query(
+        &bob,
+        query.clone(),
+        Some(DurabilityTier::EdgeServer),
+        QUERY_TIMEOUT,
+        "bob sees the counter base",
+        |rows| {
+            (rows.len() == 1 && rows[0].0 == counter_id && counter_value(&rows[0]) == Some(0))
+                .then_some(())
+        },
+    )
+    .await;
+
+    let alice_batch = alice
+        .update(counter_id, vec![("value".to_string(), Value::Integer(5))])
+        .expect("alice writes +5");
+    alice
+        .wait_for_batch(alice_batch, DurabilityTier::EdgeServer)
+        .await
+        .expect("alice's +5 settles");
+    wait_for_query(
+        &bob,
+        query.clone(),
+        Some(DurabilityTier::EdgeServer),
+        QUERY_TIMEOUT,
+        "bob receives Alice's scoped projection",
+        |rows| {
+            (rows.len() == 1 && rows[0].0 == counter_id && counter_value(&rows[0]) == Some(5))
+                .then_some(())
+        },
+    )
+    .await;
+
+    let bob_tx = bob
+        .begin_transaction()
+        .expect("bob begins a counter transaction");
+    let bob_batch = bob_tx
+        .update(counter_id, vec![("value".to_string(), Value::Integer(6))])
+        .expect("bob stages +1 from the observed 5");
+    assert_eq!(bob_batch, bob_tx.batch_id());
+    wait_for_query(
+        bob_tx.client(),
+        query.clone(),
+        None,
+        QUERY_TIMEOUT,
+        "bob's transaction sees the requested 6",
+        |rows| {
+            (rows.len() == 1 && rows[0].0 == counter_id && counter_value(&rows[0]) == Some(6))
+                .then_some(())
+        },
+    )
+    .await;
+    let repeated_batch = bob_tx
+        .update(counter_id, vec![("value".to_string(), Value::Integer(6))])
+        .expect("bob repeats the staged visible value");
+    assert_eq!(repeated_batch, bob_batch);
+    let filtered_query = QueryBuilder::new("counters")
+        .filter_eq("value", Value::Integer(6))
+        .build();
+    wait_for_query(
+        bob_tx.client(),
+        filtered_query,
+        None,
+        QUERY_TIMEOUT,
+        "bob's transaction filters against the requested 6",
+        |rows| {
+            (rows.len() == 1 && rows[0].0 == counter_id && counter_value(&rows[0]) == Some(6))
+                .then_some(())
+        },
+    )
+    .await;
+
+    assert_eq!(bob_tx.commit().expect("bob commits +1"), bob_batch);
+    bob.wait_for_batch(bob_batch, DurabilityTier::EdgeServer)
+        .await
+        .expect("bob's transaction settles");
+
+    let observer = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema)
+        .with_user_id("charlie-counter-transaction-basis")
+        .ready_on("counters", READY_TIMEOUT)
+        .connect()
+        .await;
+    wait_for_query(
+        &observer,
+        query,
+        Some(DurabilityTier::EdgeServer),
+        QUERY_TIMEOUT,
+        "fresh observer sees exactly 6",
+        |rows| {
+            (rows.len() == 1 && rows[0].0 == counter_id && counter_value(&rows[0]) == Some(6))
+                .then_some(())
+        },
+    )
+    .await;
+
+    observer.shutdown().await.expect("shutdown observer");
+    bob.shutdown().await.expect("shutdown Bob");
+    alice.shutdown().await.expect("shutdown Alice");
+    server.shutdown().await;
+}
+
+#[tokio::test]
 /// Keeps caller-supplied IDs from turning concurrent inserts into causal updates.
 ///
 /// Alice and bob intentionally create the same deterministic ID while offline;

--- a/crates/jazz-tools/tests/counter_merge.rs
+++ b/crates/jazz-tools/tests/counter_merge.rs
@@ -65,9 +65,7 @@ async fn counter_merge_does_not_recount_a_writer_after_restart_and_reconnect() {
         QUERY_TIMEOUT,
         "bob sees the counter base",
         |rows| {
-            (rows.len() == 1
-                && rows[0].0 == counter_id
-                && counter_value(&rows[0]) == Some(0))
+            (rows.len() == 1 && rows[0].0 == counter_id && counter_value(&rows[0]) == Some(0))
                 .then_some(())
         },
     )
@@ -76,32 +74,29 @@ async fn counter_merge_does_not_recount_a_writer_after_restart_and_reconnect() {
     // Bob keeps the shared base locally, then goes offline before writing.
     // Alice's +5 and Bob's offline +3 are concurrent absolute snapshots, so
     // the server must merge their MRCA-relative deltas to the canonical 8.
-    let alice_batch = alice
-        .update(
-            counter_id,
-            vec![("value".to_string(), Value::Integer(5))],
-        )
-        .expect("alice writes +5");
-    alice
-        .wait_for_batch(alice_batch, DurabilityTier::EdgeServer)
+    bob.shutdown()
         .await
-        .expect("alice's write settles at the server");
-    bob.shutdown().await.expect("bob shuts down before offline write");
+        .expect("bob shuts down before offline write");
     bob_context.server_url = String::new();
     let bob_offline = JazzClient::connect(bob_context.clone())
         .await
         .expect("bob opens his persistent storage offline");
     bob_offline
-        .update(
-            counter_id,
-            vec![("value".to_string(), Value::Integer(3))],
-        )
+        .update(counter_id, vec![("value".to_string(), Value::Integer(3))])
         .expect("bob writes +3");
     bob_offline
         .shutdown()
         .await
         .expect("bob shuts down after offline write");
     bob_context.server_url = server.base_url();
+
+    let alice_batch = alice
+        .update(counter_id, vec![("value".to_string(), Value::Integer(5))])
+        .expect("alice writes +5");
+    alice
+        .wait_for_batch(alice_batch, DurabilityTier::EdgeServer)
+        .await
+        .expect("alice's write settles at the server");
 
     let observer = TestingClient::builder()
         .with_server(&server)
@@ -115,35 +110,46 @@ async fn counter_merge_does_not_recount_a_writer_after_restart_and_reconnect() {
         .await
         .expect("bob reconnects with persistent storage");
     wait_for_query(
-        &bob_restarted,
+        &alice,
         query.clone(),
         Some(DurabilityTier::EdgeServer),
         QUERY_TIMEOUT,
-        "restarted Bob converges to the canonical counter",
+        "live Alice sees the canonical counter",
         |rows| {
-            (rows.len() == 1
-                && rows[0].0 == counter_id
-                && counter_value(&rows[0]) == Some(8))
+            (rows.len() == 1 && rows[0].0 == counter_id && counter_value(&rows[0]) == Some(8))
                 .then_some(())
         },
     )
     .await;
     wait_for_query(
         &observer,
-        query,
+        query.clone(),
         Some(DurabilityTier::EdgeServer),
         QUERY_TIMEOUT,
         "fresh observer sees the canonical counter",
         |rows| {
-            (rows.len() == 1
-                && rows[0].0 == counter_id
-                && counter_value(&rows[0]) == Some(8))
+            (rows.len() == 1 && rows[0].0 == counter_id && counter_value(&rows[0]) == Some(8))
+                .then_some(())
+        },
+    )
+    .await;
+    wait_for_query(
+        &bob_restarted,
+        query,
+        Some(DurabilityTier::EdgeServer),
+        QUERY_TIMEOUT,
+        "restarted Bob converges to the canonical counter",
+        |rows| {
+            (rows.len() == 1 && rows[0].0 == counter_id && counter_value(&rows[0]) == Some(8))
                 .then_some(())
         },
     )
     .await;
 
-    bob_restarted.shutdown().await.expect("shutdown restarted Bob");
+    bob_restarted
+        .shutdown()
+        .await
+        .expect("shutdown restarted Bob");
     observer.shutdown().await.expect("shutdown observer");
     alice.shutdown().await.expect("shutdown Alice");
     server.shutdown().await;
@@ -181,46 +187,36 @@ async fn counter_merge_does_not_recount_causal_updates_for_live_clients() {
         QUERY_TIMEOUT,
         "bob sees the causal counter base",
         |rows| {
-            (rows.len() == 1
-                && rows[0].0 == counter_id
-                && counter_value(&rows[0]) == Some(0))
+            (rows.len() == 1 && rows[0].0 == counter_id && counter_value(&rows[0]) == Some(0))
                 .then_some(())
         },
     )
     .await;
 
     let first_batch = alice
-        .update(
-            counter_id,
-            vec![("value".to_string(), Value::Integer(2))],
-        )
+        .update(counter_id, vec![("value".to_string(), Value::Integer(2))])
         .expect("alice writes the first causal snapshot");
     alice
         .wait_for_batch(first_batch, DurabilityTier::EdgeServer)
         .await
         .expect("first causal snapshot settles");
     let second_batch = alice
-        .update(
-            counter_id,
-            vec![("value".to_string(), Value::Integer(3))],
-        )
+        .update(counter_id, vec![("value".to_string(), Value::Integer(3))])
         .expect("alice writes the second causal snapshot");
     alice
         .wait_for_batch(second_batch, DurabilityTier::EdgeServer)
         .await
         .expect("second causal snapshot settles");
 
-    for client in [&alice, &bob] {
+    for (name, client) in [("Alice", &alice), ("Bob", &bob)] {
         wait_for_query(
             client,
             query.clone(),
             Some(DurabilityTier::EdgeServer),
             QUERY_TIMEOUT,
-            "live client sees the causal counter result",
+            &format!("{name} sees the causal counter result"),
             |rows| {
-                (rows.len() == 1
-                    && rows[0].0 == counter_id
-                    && counter_value(&rows[0]) == Some(3))
+                (rows.len() == 1 && rows[0].0 == counter_id && counter_value(&rows[0]) == Some(3))
                     .then_some(())
             },
         )
@@ -241,9 +237,7 @@ async fn counter_merge_does_not_recount_causal_updates_for_live_clients() {
         QUERY_TIMEOUT,
         "fresh observer sees the causal counter result",
         |rows| {
-            (rows.len() == 1
-                && rows[0].0 == counter_id
-                && counter_value(&rows[0]) == Some(3))
+            (rows.len() == 1 && rows[0].0 == counter_id && counter_value(&rows[0]) == Some(3))
                 .then_some(())
         },
     )

--- a/crates/jazz-tools/tests/counter_merge.rs
+++ b/crates/jazz-tools/tests/counter_merge.rs
@@ -185,6 +185,145 @@ async fn counter_merge_does_not_recount_a_writer_after_restart_and_reconnect() {
 }
 
 #[tokio::test]
+/// Preserves a merged counter projection when the receiving writer contributed to it.
+///
+/// ```text
+/// bob ── base ── offline +3 ────────────────► server
+/// alice ── +5 ──► server ── merged 8 ───────► bob
+/// bob ── offline follow-up 9 ───────────────► local view
+/// ```
+async fn counter_merge_preserves_projection_when_scoped_snapshot_replays_local_batch() {
+    let _suite_guard = COUNTER_SUITE_LOCK.lock().await;
+    let schema = counter_schema();
+    let server = JazzServer::start_with_schema(schema.clone()).await;
+
+    let alice = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema.clone())
+        .with_user_id("alice-counter-projection")
+        .ready_on("counters", READY_TIMEOUT)
+        .connect()
+        .await;
+    let (mut bob_context, bob) = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema.clone())
+        .with_user_id("bob-counter-projection")
+        .with_persistent_storage()
+        .ready_on("counters", READY_TIMEOUT)
+        .connect_with_context()
+        .await;
+
+    let (counter_id, _, _) = alice
+        .insert("counters", jazz_tools::row_input!("value" => 0))
+        .expect("alice creates counter");
+    let query = QueryBuilder::new("counters").build();
+    wait_for_query(
+        &bob,
+        query.clone(),
+        Some(DurabilityTier::EdgeServer),
+        QUERY_TIMEOUT,
+        "bob sees the counter base",
+        |rows| {
+            (rows.len() == 1 && rows[0].0 == counter_id && counter_value(&rows[0]) == Some(0))
+                .then_some(())
+        },
+    )
+    .await;
+
+    bob.shutdown()
+        .await
+        .expect("bob shuts down before offline write");
+    bob_context.server_url = String::new();
+    let bob_offline = JazzClient::connect(bob_context.clone())
+        .await
+        .expect("bob opens his persistent storage offline");
+    bob_offline
+        .update(counter_id, vec![("value".to_string(), Value::Integer(3))])
+        .expect("bob writes +3 offline");
+    bob_offline
+        .shutdown()
+        .await
+        .expect("bob shuts down after offline write");
+
+    let alice_batch = alice
+        .update(counter_id, vec![("value".to_string(), Value::Integer(5))])
+        .expect("alice writes +5 first");
+    alice
+        .wait_for_batch(alice_batch, DurabilityTier::EdgeServer)
+        .await
+        .expect("alice's write settles at the server");
+
+    bob_context.server_url = server.base_url();
+    let observer = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema.clone())
+        .with_user_id("charlie-counter-projection")
+        .ready_on("counters", READY_TIMEOUT)
+        .connect()
+        .await;
+    let bob_restarted = JazzClient::connect(bob_context.clone())
+        .await
+        .expect("bob reconnects with persistent storage");
+
+    wait_for_query(
+        &bob_restarted,
+        query.clone(),
+        Some(DurabilityTier::EdgeServer),
+        QUERY_TIMEOUT,
+        "bob sees the merged counter",
+        |rows| {
+            (rows.len() == 1 && rows[0].0 == counter_id && counter_value(&rows[0]) == Some(8))
+                .then_some(())
+        },
+    )
+    .await;
+    wait_for_query(
+        &observer,
+        query.clone(),
+        Some(DurabilityTier::EdgeServer),
+        QUERY_TIMEOUT,
+        "fresh observer sees the merged counter",
+        |rows| {
+            (rows.len() == 1 && rows[0].0 == counter_id && counter_value(&rows[0]) == Some(8))
+                .then_some(())
+        },
+    )
+    .await;
+
+    bob_restarted
+        .shutdown()
+        .await
+        .expect("shutdown restarted Bob");
+    bob_context.server_url = String::new();
+    let bob_follow_up = JazzClient::connect(bob_context)
+        .await
+        .expect("bob reopens his merged state offline");
+    bob_follow_up
+        .update(counter_id, vec![("value".to_string(), Value::Integer(9))])
+        .expect("bob writes the next counter value offline");
+    let local_rows = bob_follow_up
+        .query(QueryBuilder::new("counters").build(), None)
+        .await
+        .expect("query Bob's offline counter");
+    assert_eq!(
+        local_rows
+            .iter()
+            .find(|row| row.0 == counter_id)
+            .and_then(counter_value),
+        Some(9),
+        "a local write after a scoped merge must build on the merged visible value"
+    );
+
+    bob_follow_up
+        .shutdown()
+        .await
+        .expect("shutdown Bob after the offline follow-up");
+    observer.shutdown().await.expect("shutdown observer");
+    alice.shutdown().await.expect("shutdown Alice");
+    server.shutdown().await;
+}
+
+#[tokio::test]
 /// Keeps causal counter snapshots from being counted as independent roots.
 ///
 /// ```text

--- a/crates/jazz-tools/tests/counter_merge.rs
+++ b/crates/jazz-tools/tests/counter_merge.rs
@@ -348,6 +348,159 @@ async fn counter_merge_preserves_projection_when_scoped_snapshot_replays_local_b
 }
 
 #[tokio::test]
+/// Rebases Bob's staged counter intent over Alice's incoming scoped projection.
+///
+/// Ordinary reads exclude Bob's open transaction and therefore show Alice's
+/// server value. Bob's transaction-scoped read must retain his pending `+1`.
+///
+/// ```text
+/// bob ── stage +1 (open transaction) ───────────────► local only
+/// alice ── +5 ──► server ── scoped 5 ──────────────► bob
+/// bob ordinary read: 5    bob transaction read: 6
+/// bob ── commit +1 ──► server ── merged 6 ─────────► charlie
+/// ```
+async fn scoped_projection_rebases_an_open_counter_transaction() {
+    let _suite_guard = COUNTER_SUITE_LOCK.lock().await;
+    let schema = counter_schema();
+    let server = JazzServer::start_with_schema(schema.clone()).await;
+
+    let alice = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema.clone())
+        .with_user_id("alice-counter-pending")
+        .ready_on("counters", READY_TIMEOUT)
+        .connect()
+        .await;
+    let bob = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema.clone())
+        .with_user_id("bob-counter-pending")
+        .ready_on("counters", READY_TIMEOUT)
+        .connect()
+        .await;
+
+    let (counter_id, _, _) = alice
+        .insert("counters", jazz_tools::row_input!("value" => 0))
+        .expect("alice creates counter");
+    let query = QueryBuilder::new("counters").build();
+    wait_for_query(
+        &bob,
+        query.clone(),
+        Some(DurabilityTier::EdgeServer),
+        QUERY_TIMEOUT,
+        "bob sees the counter base",
+        |rows| {
+            (rows.len() == 1 && rows[0].0 == counter_id && counter_value(&rows[0]) == Some(0))
+                .then_some(())
+        },
+    )
+    .await;
+
+    let bob_tx = bob
+        .begin_transaction()
+        .expect("bob begins a counter transaction");
+    let bob_batch = bob_tx
+        .update(counter_id, vec![("value".to_string(), Value::Integer(1))])
+        .expect("bob stages +1");
+    assert_eq!(bob_batch, bob_tx.batch_id());
+    wait_for_query(
+        bob_tx.client(),
+        query.clone(),
+        None,
+        QUERY_TIMEOUT,
+        "bob's transaction sees its staged +1",
+        |rows| {
+            (rows.len() == 1 && rows[0].0 == counter_id && counter_value(&rows[0]) == Some(1))
+                .then_some(())
+        },
+    )
+    .await;
+
+    let alice_batch = alice
+        .update(counter_id, vec![("value".to_string(), Value::Integer(5))])
+        .expect("alice writes +5 while Bob's transaction is open");
+    alice
+        .wait_for_batch(alice_batch, DurabilityTier::EdgeServer)
+        .await
+        .expect("alice's +5 settles");
+    wait_for_query(
+        &bob,
+        query.clone(),
+        Some(DurabilityTier::EdgeServer),
+        QUERY_TIMEOUT,
+        "bob's ordinary read receives Alice's scoped projection",
+        |rows| {
+            (rows.len() == 1 && rows[0].0 == counter_id && counter_value(&rows[0]) == Some(5))
+                .then_some(())
+        },
+    )
+    .await;
+    wait_for_query(
+        bob_tx.client(),
+        query.clone(),
+        None,
+        QUERY_TIMEOUT,
+        "bob's transaction rebases its pending +1 over the scoped 5",
+        |rows| {
+            (rows.len() == 1 && rows[0].0 == counter_id && counter_value(&rows[0]) == Some(6))
+                .then_some(())
+        },
+    )
+    .await;
+    let rebased_query = QueryBuilder::new("counters")
+        .filter_eq("value", Value::Integer(6))
+        .build();
+    wait_for_query(
+        bob_tx.client(),
+        rebased_query,
+        None,
+        QUERY_TIMEOUT,
+        "bob's transaction filters against the rebased counter projection",
+        |rows| {
+            (rows.len() == 1 && rows[0].0 == counter_id && counter_value(&rows[0]) == Some(6))
+                .then_some(())
+        },
+    )
+    .await;
+
+    assert_eq!(bob_tx.commit().expect("bob commits +1"), bob_batch);
+    let rejection = bob
+        .wait_for_batch(bob_batch, DurabilityTier::EdgeServer)
+        .await
+        .expect_err("bob's stale transaction is rejected")
+        .to_string();
+    assert!(
+        rejection.contains("transaction_conflict"),
+        "unexpected rejection: {rejection}"
+    );
+
+    let observer = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema)
+        .with_user_id("charlie-counter-pending")
+        .ready_on("counters", READY_TIMEOUT)
+        .connect()
+        .await;
+    wait_for_query(
+        &observer,
+        query,
+        Some(DurabilityTier::EdgeServer),
+        QUERY_TIMEOUT,
+        "fresh observer sees Alice's durable +5",
+        |rows| {
+            (rows.len() == 1 && rows[0].0 == counter_id && counter_value(&rows[0]) == Some(5))
+                .then_some(())
+        },
+    )
+    .await;
+
+    observer.shutdown().await.expect("shutdown observer");
+    bob.shutdown().await.expect("shutdown Bob");
+    alice.shutdown().await.expect("shutdown Alice");
+    server.shutdown().await;
+}
+
+#[tokio::test]
 /// Keeps caller-supplied IDs from turning concurrent inserts into causal updates.
 ///
 /// Alice and bob intentionally create the same deterministic ID while offline;

--- a/crates/jazz-tools/tests/counter_merge.rs
+++ b/crates/jazz-tools/tests/counter_merge.rs
@@ -1,0 +1,256 @@
+#![cfg(feature = "test")]
+
+mod support;
+
+use std::sync::LazyLock;
+use std::time::Duration;
+
+use jazz_tools::server::JazzServer;
+use jazz_tools::{
+    ColumnDescriptor, ColumnMergeStrategy, ColumnType, DurabilityTier, JazzClient, QueryBuilder,
+    RowDescriptor, Schema, TableName, TableSchema, Value,
+};
+use support::{TestingClient, wait_for_query};
+
+const READY_TIMEOUT: Duration = Duration::from_secs(30);
+const QUERY_TIMEOUT: Duration = Duration::from_secs(25);
+static COUNTER_SUITE_LOCK: LazyLock<tokio::sync::Mutex<()>> =
+    LazyLock::new(|| tokio::sync::Mutex::new(()));
+
+fn counter_schema() -> Schema {
+    let counters = TableSchema::new(RowDescriptor::new(vec![
+        ColumnDescriptor::new("value", ColumnType::Integer)
+            .merge_strategy(ColumnMergeStrategy::Counter),
+    ]));
+    Schema::from([(TableName::new("counters"), counters)])
+}
+
+fn counter_value(row: &(jazz_tools::ObjectId, Vec<Value>)) -> Option<i32> {
+    match row.1.first() {
+        Some(Value::Integer(value)) => Some(*value),
+        _ => None,
+    }
+}
+
+#[tokio::test]
+async fn counter_merge_does_not_recount_a_writer_after_restart_and_reconnect() {
+    let _suite_guard = COUNTER_SUITE_LOCK.lock().await;
+    let schema = counter_schema();
+    let server = JazzServer::start_with_schema(schema.clone()).await;
+
+    let alice = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema.clone())
+        .with_user_id("alice-counter-reconnect")
+        .ready_on("counters", READY_TIMEOUT)
+        .connect()
+        .await;
+    let (mut bob_context, bob) = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema.clone())
+        .with_user_id("bob-counter-reconnect")
+        .with_persistent_storage()
+        .ready_on("counters", READY_TIMEOUT)
+        .connect_with_context()
+        .await;
+
+    let (counter_id, _, _) = alice
+        .insert("counters", jazz_tools::row_input!("value" => 0))
+        .expect("alice creates counter");
+    let query = QueryBuilder::new("counters").build();
+    wait_for_query(
+        &bob,
+        query.clone(),
+        Some(DurabilityTier::EdgeServer),
+        QUERY_TIMEOUT,
+        "bob sees the counter base",
+        |rows| {
+            (rows.len() == 1
+                && rows[0].0 == counter_id
+                && counter_value(&rows[0]) == Some(0))
+                .then_some(())
+        },
+    )
+    .await;
+
+    // Bob keeps the shared base locally, then goes offline before writing.
+    // Alice's +5 and Bob's offline +3 are concurrent absolute snapshots, so
+    // the server must merge their MRCA-relative deltas to the canonical 8.
+    let alice_batch = alice
+        .update(
+            counter_id,
+            vec![("value".to_string(), Value::Integer(5))],
+        )
+        .expect("alice writes +5");
+    alice
+        .wait_for_batch(alice_batch, DurabilityTier::EdgeServer)
+        .await
+        .expect("alice's write settles at the server");
+    bob.shutdown().await.expect("bob shuts down before offline write");
+    bob_context.server_url = String::new();
+    let bob_offline = JazzClient::connect(bob_context.clone())
+        .await
+        .expect("bob opens his persistent storage offline");
+    bob_offline
+        .update(
+            counter_id,
+            vec![("value".to_string(), Value::Integer(3))],
+        )
+        .expect("bob writes +3");
+    bob_offline
+        .shutdown()
+        .await
+        .expect("bob shuts down after offline write");
+    bob_context.server_url = server.base_url();
+
+    let observer = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema.clone())
+        .with_user_id("charlie-counter-observer")
+        .ready_on("counters", READY_TIMEOUT)
+        .connect()
+        .await;
+
+    let bob_restarted = JazzClient::connect(bob_context)
+        .await
+        .expect("bob reconnects with persistent storage");
+    wait_for_query(
+        &bob_restarted,
+        query.clone(),
+        Some(DurabilityTier::EdgeServer),
+        QUERY_TIMEOUT,
+        "restarted Bob converges to the canonical counter",
+        |rows| {
+            (rows.len() == 1
+                && rows[0].0 == counter_id
+                && counter_value(&rows[0]) == Some(8))
+                .then_some(())
+        },
+    )
+    .await;
+    wait_for_query(
+        &observer,
+        query,
+        Some(DurabilityTier::EdgeServer),
+        QUERY_TIMEOUT,
+        "fresh observer sees the canonical counter",
+        |rows| {
+            (rows.len() == 1
+                && rows[0].0 == counter_id
+                && counter_value(&rows[0]) == Some(8))
+                .then_some(())
+        },
+    )
+    .await;
+
+    bob_restarted.shutdown().await.expect("shutdown restarted Bob");
+    observer.shutdown().await.expect("shutdown observer");
+    alice.shutdown().await.expect("shutdown Alice");
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn counter_merge_does_not_recount_causal_updates_for_live_clients() {
+    let _suite_guard = COUNTER_SUITE_LOCK.lock().await;
+    let schema = counter_schema();
+    let server = JazzServer::start_with_schema(schema.clone()).await;
+
+    let alice = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema.clone())
+        .with_user_id("alice-counter-causal")
+        .ready_on("counters", READY_TIMEOUT)
+        .connect()
+        .await;
+    let bob = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema.clone())
+        .with_user_id("bob-counter-causal")
+        .ready_on("counters", READY_TIMEOUT)
+        .connect()
+        .await;
+
+    let (counter_id, _, _) = alice
+        .insert("counters", jazz_tools::row_input!("value" => 0))
+        .expect("alice creates counter");
+    let query = QueryBuilder::new("counters").build();
+    wait_for_query(
+        &bob,
+        query.clone(),
+        Some(DurabilityTier::EdgeServer),
+        QUERY_TIMEOUT,
+        "bob sees the causal counter base",
+        |rows| {
+            (rows.len() == 1
+                && rows[0].0 == counter_id
+                && counter_value(&rows[0]) == Some(0))
+                .then_some(())
+        },
+    )
+    .await;
+
+    let first_batch = alice
+        .update(
+            counter_id,
+            vec![("value".to_string(), Value::Integer(2))],
+        )
+        .expect("alice writes the first causal snapshot");
+    alice
+        .wait_for_batch(first_batch, DurabilityTier::EdgeServer)
+        .await
+        .expect("first causal snapshot settles");
+    let second_batch = alice
+        .update(
+            counter_id,
+            vec![("value".to_string(), Value::Integer(3))],
+        )
+        .expect("alice writes the second causal snapshot");
+    alice
+        .wait_for_batch(second_batch, DurabilityTier::EdgeServer)
+        .await
+        .expect("second causal snapshot settles");
+
+    for client in [&alice, &bob] {
+        wait_for_query(
+            client,
+            query.clone(),
+            Some(DurabilityTier::EdgeServer),
+            QUERY_TIMEOUT,
+            "live client sees the causal counter result",
+            |rows| {
+                (rows.len() == 1
+                    && rows[0].0 == counter_id
+                    && counter_value(&rows[0]) == Some(3))
+                    .then_some(())
+            },
+        )
+        .await;
+    }
+
+    let observer = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema)
+        .with_user_id("charlie-counter-causal")
+        .ready_on("counters", READY_TIMEOUT)
+        .connect()
+        .await;
+    wait_for_query(
+        &observer,
+        query,
+        Some(DurabilityTier::EdgeServer),
+        QUERY_TIMEOUT,
+        "fresh observer sees the causal counter result",
+        |rows| {
+            (rows.len() == 1
+                && rows[0].0 == counter_id
+                && counter_value(&rows[0]) == Some(3))
+                .then_some(())
+        },
+    )
+    .await;
+
+    observer.shutdown().await.expect("shutdown causal observer");
+    bob.shutdown().await.expect("shutdown causal Bob");
+    alice.shutdown().await.expect("shutdown causal Alice");
+    server.shutdown().await;
+}

--- a/crates/jazz-tools/tests/counter_merge.rs
+++ b/crates/jazz-tools/tests/counter_merge.rs
@@ -186,12 +186,13 @@ async fn counter_merge_does_not_recount_a_writer_after_restart_and_reconnect() {
 }
 
 #[tokio::test]
-/// Preserves a merged counter projection when the receiving writer contributed to it.
+/// Preserves a merged counter projection through the receiving writer's next update.
 ///
 /// ```text
 /// bob ── base ── offline +3 ────────────────► server
 /// alice ── +5 ──► server ── merged 8 ───────► bob
-/// bob ── offline follow-up 9 ───────────────► local view
+/// bob ── offline follow-up 9 ───────────────► server
+/// charlie ◄────────────── merged 9 ────────── server
 /// ```
 async fn counter_merge_preserves_projection_when_scoped_snapshot_replays_local_batch() {
     let _suite_guard = COUNTER_SUITE_LOCK.lock().await;
@@ -296,7 +297,7 @@ async fn counter_merge_preserves_projection_when_scoped_snapshot_replays_local_b
         .await
         .expect("shutdown restarted Bob");
     bob_context.server_url = String::new();
-    let bob_follow_up = JazzClient::connect(bob_context)
+    let bob_follow_up = JazzClient::connect(bob_context.clone())
         .await
         .expect("bob reopens his merged state offline");
     bob_follow_up
@@ -319,6 +320,28 @@ async fn counter_merge_preserves_projection_when_scoped_snapshot_replays_local_b
         .shutdown()
         .await
         .expect("shutdown Bob after the offline follow-up");
+
+    bob_context.server_url = server.base_url();
+    let bob_after_follow_up = JazzClient::connect(bob_context)
+        .await
+        .expect("bob reconnects with the offline follow-up");
+    wait_for_query(
+        &observer,
+        query,
+        Some(DurabilityTier::EdgeServer),
+        QUERY_TIMEOUT,
+        "observer sees exactly the merged counter plus Bob's follow-up",
+        |rows| {
+            (rows.len() == 1 && rows[0].0 == counter_id && counter_value(&rows[0]) == Some(9))
+                .then_some(())
+        },
+    )
+    .await;
+
+    bob_after_follow_up
+        .shutdown()
+        .await
+        .expect("shutdown Bob after reconnecting the follow-up");
     observer.shutdown().await.expect("shutdown observer");
     alice.shutdown().await.expect("shutdown Alice");
     server.shutdown().await;

--- a/crates/jazz-tools/tests/counter_merge.rs
+++ b/crates/jazz-tools/tests/counter_merge.rs
@@ -33,6 +33,12 @@ fn counter_value(row: &(jazz_tools::ObjectId, Vec<Value>)) -> Option<i32> {
 }
 
 #[tokio::test]
+/// Keeps concurrent counter deltas exact across persistent restart and replay.
+///
+/// ```text
+/// bob ── offline +3 ──► server ◄── +5 ── alice
+/// charlie ◄──────────── merged 8 ─────────── server
+/// ```
 async fn counter_merge_does_not_recount_a_writer_after_restart_and_reconnect() {
     let _suite_guard = COUNTER_SUITE_LOCK.lock().await;
     let schema = counter_schema();
@@ -156,6 +162,14 @@ async fn counter_merge_does_not_recount_a_writer_after_restart_and_reconnect() {
 }
 
 #[tokio::test]
+/// Keeps causal counter snapshots from being counted as independent roots.
+///
+/// ```text
+/// alice ── 0 ──► bob
+/// alice ── 2 ──► server ──► bob
+/// alice ── 3 (parent 2) ──► server ──► bob
+/// charlie ───────────── fresh observer ───────────► 3
+/// ```
 async fn counter_merge_does_not_recount_causal_updates_for_live_clients() {
     let _suite_guard = COUNTER_SUITE_LOCK.lock().await;
     let schema = counter_schema();

--- a/crates/jazz-tools/tests/counter_merge.rs
+++ b/crates/jazz-tools/tests/counter_merge.rs
@@ -112,7 +112,7 @@ async fn counter_merge_does_not_recount_a_writer_after_restart_and_reconnect() {
         .connect()
         .await;
 
-    let bob_restarted = JazzClient::connect(bob_context)
+    let bob_restarted = JazzClient::connect(bob_context.clone())
         .await
         .expect("bob reconnects with persistent storage");
     wait_for_query(
@@ -156,6 +156,29 @@ async fn counter_merge_does_not_recount_a_writer_after_restart_and_reconnect() {
         .shutdown()
         .await
         .expect("shutdown restarted Bob");
+    bob_context.server_url = String::new();
+    let bob_offline_after_merge = JazzClient::connect(bob_context)
+        .await
+        .expect("bob reopens his merged state offline");
+    bob_offline_after_merge
+        .update(counter_id, vec![("value".to_string(), Value::Integer(9))])
+        .expect("bob writes the next counter value offline");
+    let local_rows = bob_offline_after_merge
+        .query(QueryBuilder::new("counters").build(), None)
+        .await
+        .expect("query Bob's offline counter");
+    assert_eq!(
+        local_rows
+            .iter()
+            .find(|row| row.0 == counter_id)
+            .and_then(counter_value),
+        Some(9),
+        "a local write after a scoped merge must build on the merged visible value"
+    );
+    bob_offline_after_merge
+        .shutdown()
+        .await
+        .expect("shutdown Bob after the offline follow-up");
     observer.shutdown().await.expect("shutdown observer");
     alice.shutdown().await.expect("shutdown Alice");
     server.shutdown().await;

--- a/crates/jazz-tools/tests/gset_merge.rs
+++ b/crates/jazz-tools/tests/gset_merge.rs
@@ -335,6 +335,156 @@ async fn concurrent_writes_never_remove_a_shared_element() {
     server.shutdown().await;
 }
 
+#[tokio::test]
+/// Keeps a scoped GSet replay's merged elements when bob writes another column offline.
+///
+/// ```text
+/// bob ── offline +bob ──► server ◄── +alice ── alice
+/// bob ◄──────────── scoped merged snapshot ─────────── server
+/// bob ── offline name update ──► merged tags remain visible
+/// ```
+async fn scoped_replay_preserves_merged_elements_for_a_local_write() {
+    let _suite_guard = lock_gset_suite().await;
+    let schema = gset_schema();
+    let server = JazzServer::start_with_schema(schema.clone()).await;
+
+    let alice = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema.clone())
+        .with_user_id("alice-gset-scoped-replay")
+        .ready_on("docs", READY_TIMEOUT)
+        .connect()
+        .await;
+    let (mut bob_context, bob) = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema.clone())
+        .with_user_id("bob-gset-scoped-replay")
+        .with_persistent_storage()
+        .connect_with_context()
+        .await;
+
+    let (doc_id, _, _) = alice
+        .insert("docs", doc_values("shared", &["seed"]))
+        .expect("alice creates the document");
+    let query = QueryBuilder::new("docs").build();
+    wait_for_query(
+        &bob,
+        query.clone(),
+        Some(DurabilityTier::EdgeServer),
+        QUERY_TIMEOUT,
+        "bob sees the shared document base",
+        |rows| (rows.len() == 1 && rows[0].0 == doc_id).then_some(()),
+    )
+    .await;
+
+    bob.shutdown()
+        .await
+        .expect("bob shuts down before the offline write");
+    bob_context.server_url = String::new();
+    let bob_offline = JazzClient::connect(bob_context.clone())
+        .await
+        .expect("bob opens his persistent storage offline");
+    bob_offline
+        .update(
+            doc_id,
+            vec![("tags".to_string(), tags_value(&["seed", "bob"]))],
+        )
+        .expect("bob adds his tag offline");
+    bob_offline
+        .shutdown()
+        .await
+        .expect("bob shuts down after the offline write");
+    bob_context.server_url = server.base_url();
+
+    let alice_batch = alice
+        .update(
+            doc_id,
+            vec![("tags".to_string(), tags_value(&["seed", "alice"]))],
+        )
+        .expect("alice adds her tag");
+    alice
+        .wait_for_batch(alice_batch, DurabilityTier::EdgeServer)
+        .await
+        .expect("alice's write settles at the server");
+
+    let expected_tags = vec!["alice".to_string(), "bob".to_string(), "seed".to_string()];
+    let bob_restarted = JazzClient::connect(bob_context.clone())
+        .await
+        .expect("bob reconnects with persistent storage");
+    wait_for_query(
+        &bob_restarted,
+        query.clone(),
+        Some(DurabilityTier::EdgeServer),
+        QUERY_TIMEOUT,
+        "restarted bob sees the merged tags",
+        |rows| {
+            (rows.len() == 1
+                && rows[0].0 == doc_id
+                && tags_of(&rows[0]) == Some(expected_tags.clone()))
+            .then_some(())
+        },
+    )
+    .await;
+
+    let observer = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema.clone())
+        .with_user_id("charlie-gset-scoped-replay")
+        .ready_on("docs", READY_TIMEOUT)
+        .connect()
+        .await;
+    wait_for_query(
+        &observer,
+        query.clone(),
+        Some(DurabilityTier::EdgeServer),
+        QUERY_TIMEOUT,
+        "fresh observer sees the merged tags",
+        |rows| {
+            (rows.len() == 1
+                && rows[0].0 == doc_id
+                && tags_of(&rows[0]) == Some(expected_tags.clone()))
+            .then_some(())
+        },
+    )
+    .await;
+
+    bob_restarted
+        .shutdown()
+        .await
+        .expect("bob shuts down after receiving the scoped merge");
+
+    bob_context.server_url = String::new();
+    let bob_offline_after_merge = JazzClient::connect(bob_context)
+        .await
+        .expect("bob reopens the merged document offline");
+    bob_offline_after_merge
+        .update(
+            doc_id,
+            vec![(
+                "name".to_string(),
+                Value::Text("edited while offline".to_string()),
+            )],
+        )
+        .expect("bob updates the document name offline");
+    let local_rows = bob_offline_after_merge
+        .query(query, None)
+        .await
+        .expect("query bob's offline document");
+    let local_row = local_rows
+        .iter()
+        .find(|row| row.0 == doc_id)
+        .expect("offline document remains visible");
+    assert_eq!(tags_of(local_row), Some(expected_tags));
+    bob_offline_after_merge
+        .shutdown()
+        .await
+        .expect("shutdown bob after the offline follow-up");
+
+    observer.shutdown().await.expect("shutdown observer");
+    alice.shutdown().await.expect("shutdown alice");
+    server.shutdown().await;
+}
+
 /// `docs` table with a `scores` float-array column merging as a grow-only set.
 fn gset_float_schema() -> Schema {
     let scores = ColumnDescriptor::new(


### PR DESCRIPTION
## Summary

- Preserve raw row ancestry when scoped sync delivers a server-computed visible projection, updating only the materialised view rather than treating the projection as a new causal root.
- Translate Counter writes from the visible value the client edited into a delta against its actual raw frontier, including repeated writes in an open transaction.
- Rebase staged Counter rows in both ordinary and index-backed transaction queries so local reads and filters agree.
- Record the visible projection observed by the first transaction write in existing row metadata, then validate it against the authority's reconstructed pre-transaction projection. Rows from older clients retain parent-frontier validation.

## Correctness and performance trade-offs

> [!WARNING]
> Transaction validation now scans and resolves the full raw history of every touched row carrying projection-basis metadata when the batch is sealed. A focused authority-side Criterion benchmark found the basis path 22%-62% slower than the legacy parent-frontier path across the tested matrix. At history depth 10,000 for one row it took 9.48 ms versus 7.53 ms; at history depth 1,000 for 100 touched rows it took 158.3 ms versus 100.7 ms. Both paths also scaled materially with history depth and transaction size, so these results demonstrate a practical performance risk but do not isolate a basis-only asymptotic regression. This PR remains in draft while we decide whether the cost is acceptable or needs a bounded/cached alternative.

- The client deliberately does not attach the server's frontier as causal ancestry. That frontier may include rows outside the query scope or rows the client is not authorised to see.
- The observed projection is carried as a BLAKE3 basis hash in the existing metadata map, avoiding sync-protocol and storage-schema changes.
- Counter transaction writes may perform extra visible-projection and raw-parent loads so an absolute visible edit can be stored as the correct raw delta.
- Each transactional row carries a 64-character basis hash.
- Older clients remain compatible through the existing parent-frontier fallback. A new client talking to an older server can still encounter the original false transaction rejection, but should not corrupt the Counter value.

## Benchmark results

The benchmark enters the real authority-side transaction-sealing path through `SyncManager::process_from_client`. Deterministic history and submission fixtures are prepared outside the measured closure; Criterion times only final seal processing. It compares projection-basis metadata validation with the legacy parent-frontier fallback using `MemoryStorage`.

Command:

```bash
cargo bench -p jazz-tools --features bench-internals --bench transaction_projection_validation -- linear_memory
```

Matrix:

- One touched row at history depths 1, 10, 100, 1,000, and 10,000.
- 1, 10, and 100 touched rows at history depth 1,000.
- 30 samples per case, with deterministic correctness preflights for acceptance, exact visible output, stale-basis rejection, and changed-frontier/same-visible-projection semantics.

Headline results:

| History depth | Touched rows | Projection basis | Legacy frontier | Basis / legacy |
|---:|---:|---:|---:|---:|
| 1 | 1 | 25.9 us | 21.2 us | 1.22x |
| 100 | 1 | 117.9 us | 73.0 us | 1.62x |
| 1,000 | 1 | 869.1 us | 568.0 us | 1.53x |
| 10,000 | 1 | 9.48 ms | 7.53 ms | 1.26x |
| 1,000 | 10 | 8.59 ms | 6.21 ms | 1.38x |
| 1,000 | 100 | 158.3 ms | 100.7 ms | 1.57x |

The basis path was slower in every matched case. Scaling from 10 to 100 touched rows at depth 1,000 was superlinear for both paths, with a clear per-row penalty at 100 rows. The benchmark therefore supports the warning's operational concern, while follow-up profiling is needed before attributing the whole scaling curve specifically to projection-basis reconstruction.

## Testing

- `cargo test -p jazz-tools --features test --test counter_merge --test gset_merge --test history_conflict -- --nocapture` — passed, 27 tests
- `cargo test -p jazz-tools --features test --test transactions -- --nocapture` — passed, 12 tests
- `cargo test -p jazz-tools --features test --lib sync_manager::tests::transaction_sealing -- --nocapture` — passed, 25 tests
