### PR TITLE
Validate s.int() values before native writes

### DIFF
--- a/.changeset/quiet-integers-check.md
+++ b/.changeset/quiet-integers-check.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Validate `s.int()` values against Jazz's signed 32-bit range before native writes and report actionable errors for invalid values.

--- a/docs/content/partials/available-column-types.mdx
+++ b/docs/content/partials/available-column-types.mdx
@@ -16,6 +16,10 @@ There are a number of column types available which cover most common use cases:
 
 Any column can be made nullable with `.optional()`.
 
+`s.int()` values are signed 32-bit integers from `-2,147,483,648` through `2,147,483,647`. The
+runtime rejects fractional, non-finite, and out-of-range values before sending a write to the
+native engine. Use `s.float()` when a wider or fractional numeric range is required.
+
 > **JSON columns are atomic.** The entire value is replaced on every write. Use `s.json()` for untyped JSON, or `s.json(schema)` with a [Zod](https://zod.dev)-compatible schema for typed validation. For structured data that needs per-field updates, use separate columns or a related table instead.
 
 > **Ref naming convention:** `s.ref()` columns must have a name ending in `Id` or `_id`. For `s.array(s.ref())`, the name must end in `Ids` or `_ids`. The runtime will throw if a ref column does not follow this convention.

--- a/packages/jazz-tools/src/runtime/integer-boundary.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/integer-boundary.integration.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { schema as s } from "../index.js";
+import { createPolicyTestApp } from "../testing/index.js";
+
+const app = s.defineApp({
+  ints: s.table({ value: s.int() }),
+});
+
+const permissions = s.definePermissions(app, ({ policy }) => {
+  policy.ints.allowInsert.always();
+  policy.ints.allowRead.always();
+  policy.ints.allowUpdate.always();
+  policy.ints.allowDelete.always();
+});
+
+describe("public integer values", () => {
+  it("round-trips i32 boundaries and rejects invalid values before the runtime", async () => {
+    const testApp = await createPolicyTestApp(app, permissions, expect);
+
+    try {
+      const db = testApp.as({ user_id: "integer-boundary", claims: {}, authMode: "local-first" });
+      const boundaries = [-2_147_483_648, 2_147_483_647];
+
+      for (const value of boundaries) {
+        const row = await db.insert(app.ints, { value }).wait({ tier: "global" });
+        expect(row.value).toBe(value);
+      }
+
+      for (const value of [-2_147_483_649, 2_147_483_648, 1.5, NaN, Infinity]) {
+        expect(() => db.insert(app.ints, { value })).toThrow(
+          "Integer values must be signed 32-bit integers between -2147483648 and 2147483647",
+        );
+      }
+    } finally {
+      await testApp.shutdown();
+    }
+  }, 10_000);
+});

--- a/packages/jazz-tools/src/runtime/value-converter.test.ts
+++ b/packages/jazz-tools/src/runtime/value-converter.test.ts
@@ -35,6 +35,25 @@ describe("toValue", () => {
     const colType: ColumnType = { type: "Integer" };
     expect(toValue(42, colType)).toEqual({ type: "Integer", value: 42 });
     expect(toValue(-1, colType)).toEqual({ type: "Integer", value: -1 });
+    expect(toValue(-2_147_483_648, colType)).toEqual({
+      type: "Integer",
+      value: -2_147_483_648,
+    });
+    expect(toValue(2_147_483_647, colType)).toEqual({
+      type: "Integer",
+      value: 2_147_483_647,
+    });
+  });
+
+  it("rejects Integer values outside the signed 32-bit range", () => {
+    const colType: ColumnType = { type: "Integer" };
+    const invalidValues = [-2_147_483_649, 2_147_483_648, 1.5, NaN, Infinity];
+
+    for (const value of invalidValues) {
+      expect(() => toValue(value, colType)).toThrow(
+        "Integer values must be signed 32-bit integers between -2147483648 and 2147483647",
+      );
+    }
   });
 
   it("converts BigInt values", () => {

--- a/packages/jazz-tools/src/runtime/value-converter.ts
+++ b/packages/jazz-tools/src/runtime/value-converter.ts
@@ -8,6 +8,9 @@
 import type { WasmSchema, ColumnType, Value as WasmValue, InsertValues } from "../drivers/types.js";
 import { toJsonText } from "./json-text.js";
 
+const INTEGER_MIN = -2_147_483_648;
+const INTEGER_MAX = 2_147_483_647;
+
 function toTimestampMs(value: unknown): number {
   const numeric = value instanceof Date ? value.getTime() : Number(value);
   if (!Number.isFinite(numeric)) {
@@ -35,6 +38,16 @@ function normalizeByteaValue(value: unknown): Uint8Array {
   throw new Error("Expected Uint8Array or byte array for Bytea column type");
 }
 
+function toIntegerValue(value: unknown): number {
+  const numeric = Number(value);
+  if (!Number.isInteger(numeric) || numeric < INTEGER_MIN || numeric > INTEGER_MAX) {
+    throw new Error(
+      `Integer values must be signed 32-bit integers between ${INTEGER_MIN} and ${INTEGER_MAX}; received ${String(value)}`,
+    );
+  }
+  return numeric;
+}
+
 /**
  * Convert a JS value to WasmValue based on column type.
  */
@@ -49,7 +62,7 @@ export function toValue(value: unknown, columnType: ColumnType): WasmValue {
     case "Boolean":
       return { type: "Boolean", value: Boolean(value) };
     case "Integer":
-      return { type: "Integer", value: Number(value) };
+      return { type: "Integer", value: toIntegerValue(value) };
     case "BigInt":
       return { type: "BigInt", value: Number(value) };
     case "Double":


### PR DESCRIPTION
## Summary
- Enforce Jazz INTEGER's signed 32-bit range before native writes.
- Report actionable errors for fractional, non-finite, and out-of-range values.
- Document the contract and add boundary regression coverage.

## Testing
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/runtime/value-converter.test.ts src/runtime/integer-boundary.integration.test.ts src/runtime/napi.integration.test.ts` — passed (39 tests)
