### PR TITLE
feat(inspector): allow customizing table columns

### DIFF
--- a/packages/inspector/src/components/data-explorer/ColumnCustomizationModal.module.css
+++ b/packages/inspector/src/components/data-explorer/ColumnCustomizationModal.module.css
@@ -1,0 +1,286 @@
+.dialog {
+  inline-size: min(520px, calc(100vw - 32px));
+  max-block-size: min(680px, calc(100vh - 32px));
+  border: 1px solid var(--jz-border-control);
+  border-radius: 8px;
+  background: var(--jz-bg);
+  color: var(--jz-ink);
+  padding: 0;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.55);
+}
+
+.dialog::backdrop {
+  background: rgba(3, 7, 12, 0.72);
+  backdrop-filter: blur(2px);
+}
+
+.panel {
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  max-block-size: inherit;
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 18px 20px 15px;
+  border-bottom: 1px solid var(--jz-border-strong);
+}
+
+.title {
+  margin: 0;
+  color: var(--jz-ink-strong);
+  font-size: 16px;
+  line-height: 1.35;
+}
+
+.description {
+  margin: 4px 0 0;
+  color: var(--jz-muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.closeButton,
+.moveButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  background: transparent;
+  color: var(--jz-faint);
+  padding: 0;
+  cursor: pointer;
+}
+
+.closeButton {
+  inline-size: 26px;
+  block-size: 26px;
+  border-radius: 4px;
+}
+
+.closeButton:hover,
+.moveButton:hover:not(:disabled) {
+  background: var(--jz-border);
+  color: var(--jz-ink-strong);
+}
+
+.closeButton:focus-visible,
+.moveButton:focus-visible,
+.secondaryButton:focus-visible,
+.primaryButton:focus-visible,
+.resetButton:focus-visible {
+  outline: 2px solid var(--jz-focus);
+  outline-offset: 1px;
+}
+
+.closeButton svg {
+  inline-size: 15px;
+  block-size: 15px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-width: 1.5;
+}
+
+.listHeader,
+.columnRow {
+  display: grid;
+  grid-template-columns: 24px 28px minmax(0, 1fr) 58px 60px;
+  align-items: center;
+  gap: 8px;
+}
+
+.listHeader {
+  min-block-size: 32px;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--jz-border);
+  background: var(--jz-bg-sunken);
+  color: var(--jz-muted);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.orderHeader,
+.order {
+  text-align: center;
+}
+
+.visibilityHeader {
+  text-align: center;
+}
+
+.columnList {
+  min-block-size: 0;
+  max-block-size: min(440px, calc(100vh - 240px));
+  overflow-y: auto;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.columnRow {
+  min-block-size: 42px;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--jz-border);
+  background: var(--jz-bg);
+  transition:
+    background-color 120ms ease,
+    box-shadow 120ms ease;
+}
+
+.columnRow:hover {
+  background: var(--jz-surface);
+}
+
+.columnRow.dropTarget {
+  box-shadow: inset 0 2px 0 var(--jz-accent-line);
+}
+
+.dragHandle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--jz-faint);
+  cursor: grab;
+}
+
+.dragHandle svg {
+  inline-size: 10px;
+  block-size: 16px;
+  fill: currentColor;
+}
+
+.columnRow:active .dragHandle {
+  cursor: grabbing;
+}
+
+.order {
+  color: var(--jz-faint);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.columnName {
+  min-inline-size: 0;
+  overflow: hidden;
+  color: var(--jz-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.visibilityControl {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.visibilityControl input {
+  inline-size: 16px;
+  block-size: 16px;
+  margin: 0;
+  accent-color: var(--jz-accent-line);
+  cursor: pointer;
+}
+
+.moveButtons {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 2px;
+}
+
+.moveButton {
+  inline-size: 26px;
+  block-size: 26px;
+  border-radius: 4px;
+}
+
+.moveButton:disabled {
+  opacity: 0.25;
+  cursor: not-allowed;
+}
+
+.moveButton svg {
+  inline-size: 14px;
+  block-size: 14px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.6;
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 20px;
+  border-top: 1px solid var(--jz-border-strong);
+}
+
+.footerActions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.secondaryButton,
+.primaryButton,
+.resetButton {
+  min-block-size: 30px;
+  border-radius: 4px;
+  padding: 6px 11px;
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.secondaryButton,
+.resetButton {
+  border: 1px solid var(--jz-border-control);
+  background: var(--jz-surface);
+  color: var(--jz-text);
+}
+
+.secondaryButton:hover,
+.resetButton:hover {
+  background: #1b2430;
+}
+
+.resetButton {
+  border-color: transparent;
+  background: transparent;
+  color: var(--jz-muted);
+}
+
+.primaryButton {
+  border: 1px solid #294d78;
+  background: #1b3552;
+  color: #f3f7fb;
+}
+
+.primaryButton:hover {
+  background: #214062;
+}
+
+@media (max-width: 520px) {
+  .listHeader,
+  .columnRow {
+    grid-template-columns: 20px 24px minmax(0, 1fr) 50px 56px;
+    gap: 5px;
+    padding-inline: 10px;
+  }
+
+  .header,
+  .footer {
+    padding-inline: 14px;
+  }
+}

--- a/packages/inspector/src/components/data-explorer/ColumnCustomizationModal.tsx
+++ b/packages/inspector/src/components/data-explorer/ColumnCustomizationModal.tsx
@@ -4,8 +4,7 @@ import styles from "./ColumnCustomizationModal.module.css";
 export interface CustomizableColumn {
   id: string;
   header: string;
-  // `true` unless specified
-  visibleByDefault?: boolean;
+  hiddenByDefault?: true;
 }
 
 export interface ColumnPreference {
@@ -45,7 +44,7 @@ export function reconcileColumnPreferences(
 
   for (const column of columns) {
     if (!seenColumnIds.has(column.id)) {
-      preferences.push({ id: column.id, visible: column.visibleByDefault ?? true });
+      preferences.push({ id: column.id, visible: !column.hiddenByDefault });
     }
   }
 
@@ -282,7 +281,7 @@ export function ColumnCustomizationModal({
               setDraftPreferences(
                 columns.map((column) => ({
                   id: column.id,
-                  visible: column.visibleByDefault ?? true,
+                  visible: !column.hiddenByDefault,
                 })),
               );
             }}

--- a/packages/inspector/src/components/data-explorer/ColumnCustomizationModal.tsx
+++ b/packages/inspector/src/components/data-explorer/ColumnCustomizationModal.tsx
@@ -4,6 +4,8 @@ import styles from "./ColumnCustomizationModal.module.css";
 export interface CustomizableColumn {
   id: string;
   header: string;
+  // `true` unless specified
+  visibleByDefault?: boolean;
 }
 
 export interface ColumnPreference {
@@ -43,7 +45,7 @@ export function reconcileColumnPreferences(
 
   for (const column of columns) {
     if (!seenColumnIds.has(column.id)) {
-      preferences.push({ id: column.id, visible: true });
+      preferences.push({ id: column.id, visible: column.visibleByDefault ?? true });
     }
   }
 
@@ -277,7 +279,12 @@ export function ColumnCustomizationModal({
             type="button"
             className={styles.resetButton}
             onClick={() => {
-              setDraftPreferences(columns.map((column) => ({ id: column.id, visible: true })));
+              setDraftPreferences(
+                columns.map((column) => ({
+                  id: column.id,
+                  visible: column.visibleByDefault ?? true,
+                })),
+              );
             }}
           >
             Reset

--- a/packages/inspector/src/components/data-explorer/ColumnCustomizationModal.tsx
+++ b/packages/inspector/src/components/data-explorer/ColumnCustomizationModal.tsx
@@ -1,0 +1,333 @@
+import { useEffect, useRef, useState, type DragEvent, type MouseEvent } from "react";
+import styles from "./ColumnCustomizationModal.module.css";
+
+export interface CustomizableColumn {
+  id: string;
+  header: string;
+}
+
+export interface ColumnPreference {
+  id: string;
+  visible: boolean;
+}
+
+function isColumnPreference(value: unknown): value is ColumnPreference {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Partial<ColumnPreference>;
+  return typeof candidate.id === "string" && typeof candidate.visible === "boolean";
+}
+
+export function isColumnPreferences(value: unknown): value is ColumnPreference[] {
+  return Array.isArray(value) && value.every(isColumnPreference);
+}
+
+export function reconcileColumnPreferences(
+  columns: readonly CustomizableColumn[],
+  storedPreferences: readonly ColumnPreference[] | undefined,
+): ColumnPreference[] {
+  const availableColumnIds = new Set(columns.map((column) => column.id));
+  const seenColumnIds = new Set<string>();
+  const preferences: ColumnPreference[] = [];
+
+  for (const preference of storedPreferences ?? []) {
+    if (!availableColumnIds.has(preference.id) || seenColumnIds.has(preference.id)) {
+      continue;
+    }
+
+    seenColumnIds.add(preference.id);
+    preferences.push(preference);
+  }
+
+  for (const column of columns) {
+    if (!seenColumnIds.has(column.id)) {
+      preferences.push({ id: column.id, visible: true });
+    }
+  }
+
+  return preferences;
+}
+
+function movePreference(
+  preferences: readonly ColumnPreference[],
+  columnId: string,
+  nextIndex: number,
+): ColumnPreference[] {
+  const currentIndex = preferences.findIndex((preference) => preference.id === columnId);
+  if (currentIndex === -1 || currentIndex === nextIndex) {
+    return [...preferences];
+  }
+
+  const nextPreferences = [...preferences];
+  const [preference] = nextPreferences.splice(currentIndex, 1);
+  if (!preference) {
+    return nextPreferences;
+  }
+
+  nextPreferences.splice(Math.max(0, Math.min(nextIndex, nextPreferences.length)), 0, preference);
+  return nextPreferences;
+}
+
+interface ColumnCustomizationModalProps {
+  open: boolean;
+  columns: readonly CustomizableColumn[];
+  preferences: readonly ColumnPreference[];
+  onApply: (preferences: ColumnPreference[]) => void;
+  onRequestClose: () => void;
+}
+
+export function ColumnCustomizationModal({
+  open,
+  columns,
+  preferences,
+  onApply,
+  onRequestClose,
+}: ColumnCustomizationModalProps) {
+  const dialogRef = useRef<HTMLDialogElement | null>(null);
+  const [draftPreferences, setDraftPreferences] = useState<ColumnPreference[]>(() => [
+    ...preferences,
+  ]);
+  const [draggedColumnId, setDraggedColumnId] = useState<string | null>(null);
+  const [dropTargetColumnId, setDropTargetColumnId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) {
+      return;
+    }
+
+    if (open && !dialog.open) {
+      dialog.showModal();
+    } else if (!open && dialog.open) {
+      dialog.close();
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (open) {
+      setDraftPreferences([...preferences]);
+      setDraggedColumnId(null);
+      setDropTargetColumnId(null);
+    }
+  }, [open, preferences]);
+
+  const columnById = new Map(columns.map((column) => [column.id, column]));
+
+  const moveColumnBy = (columnId: string, offset: number) => {
+    setDraftPreferences((currentPreferences) => {
+      const currentIndex = currentPreferences.findIndex((preference) => preference.id === columnId);
+      if (currentIndex === -1) {
+        return currentPreferences;
+      }
+      return movePreference(currentPreferences, columnId, currentIndex + offset);
+    });
+  };
+
+  const handleDrop = (event: DragEvent<HTMLLIElement>, targetColumnId: string) => {
+    event.preventDefault();
+    if (!draggedColumnId || draggedColumnId === targetColumnId) {
+      setDropTargetColumnId(null);
+      return;
+    }
+
+    setDraftPreferences((currentPreferences) => {
+      const targetIndex = currentPreferences.findIndex(
+        (preference) => preference.id === targetColumnId,
+      );
+      return targetIndex === -1
+        ? currentPreferences
+        : movePreference(currentPreferences, draggedColumnId, targetIndex);
+    });
+    setDraggedColumnId(null);
+    setDropTargetColumnId(null);
+  };
+
+  const handleBackdropClick = (event: MouseEvent<HTMLDialogElement>) => {
+    if (event.target === event.currentTarget) {
+      onRequestClose();
+    }
+  };
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className={styles.dialog}
+      aria-labelledby="column-customization-title"
+      aria-describedby="column-customization-description"
+      onCancel={(event) => {
+        event.preventDefault();
+        onRequestClose();
+      }}
+      onClose={onRequestClose}
+      onClick={handleBackdropClick}
+    >
+      <div className={styles.panel}>
+        <header className={styles.header}>
+          <div>
+            <h2 id="column-customization-title" className={styles.title}>
+              Customize columns
+            </h2>
+            <p id="column-customization-description" className={styles.description}>
+              Choose which columns are visible and drag them to change their order.
+            </p>
+          </div>
+          <button
+            type="button"
+            className={styles.closeButton}
+            aria-label="Close column customization"
+            onClick={onRequestClose}
+          >
+            <CrossIcon />
+          </button>
+        </header>
+
+        <div className={styles.listHeader} aria-hidden="true">
+          <span />
+          <span className={styles.orderHeader}>#</span>
+          <span>Column</span>
+          <span className={styles.visibilityHeader}>Visible</span>
+          <span />
+        </div>
+        <ol className={styles.columnList} aria-label="Column order">
+          {draftPreferences.map((preference, index) => {
+            const column = columnById.get(preference.id);
+            if (!column) {
+              return null;
+            }
+
+            return (
+              <li
+                key={preference.id}
+                className={`${styles.columnRow} ${
+                  dropTargetColumnId === preference.id ? styles.dropTarget : ""
+                }`}
+                draggable
+                onDragStart={(event) => {
+                  setDraggedColumnId(preference.id);
+                  event.dataTransfer.effectAllowed = "move";
+                  event.dataTransfer.setData("text/plain", preference.id);
+                }}
+                onDragOver={(event) => {
+                  event.preventDefault();
+                  event.dataTransfer.dropEffect = "move";
+                  setDropTargetColumnId(preference.id);
+                }}
+                onDragLeave={() => {
+                  setDropTargetColumnId((currentTarget) =>
+                    currentTarget === preference.id ? null : currentTarget,
+                  );
+                }}
+                onDrop={(event) => handleDrop(event, preference.id)}
+                onDragEnd={() => {
+                  setDraggedColumnId(null);
+                  setDropTargetColumnId(null);
+                }}
+              >
+                <span className={styles.dragHandle} aria-hidden="true">
+                  <DragHandleIcon />
+                </span>
+                <span className={styles.order}>{index + 1}</span>
+                <span className={styles.columnName}>{column.header}</span>
+                <label className={styles.visibilityControl}>
+                  <input
+                    type="checkbox"
+                    checked={preference.visible}
+                    aria-label={`Show ${column.header}`}
+                    onChange={(event) => {
+                      const visible = event.target.checked;
+                      setDraftPreferences((currentPreferences) =>
+                        currentPreferences.map((currentPreference) =>
+                          currentPreference.id === preference.id
+                            ? { ...currentPreference, visible }
+                            : currentPreference,
+                        ),
+                      );
+                    }}
+                  />
+                </label>
+                <span className={styles.moveButtons}>
+                  <button
+                    type="button"
+                    className={styles.moveButton}
+                    aria-label={`Move ${column.header} up`}
+                    disabled={index === 0}
+                    onClick={() => moveColumnBy(preference.id, -1)}
+                  >
+                    <ChevronIcon direction="up" />
+                  </button>
+                  <button
+                    type="button"
+                    className={styles.moveButton}
+                    aria-label={`Move ${column.header} down`}
+                    disabled={index === draftPreferences.length - 1}
+                    onClick={() => moveColumnBy(preference.id, 1)}
+                  >
+                    <ChevronIcon direction="down" />
+                  </button>
+                </span>
+              </li>
+            );
+          })}
+        </ol>
+
+        <footer className={styles.footer}>
+          <button
+            type="button"
+            className={styles.resetButton}
+            onClick={() => {
+              setDraftPreferences(columns.map((column) => ({ id: column.id, visible: true })));
+            }}
+          >
+            Reset
+          </button>
+          <span className={styles.footerActions}>
+            <button type="button" className={styles.secondaryButton} onClick={onRequestClose}>
+              Cancel
+            </button>
+            <button
+              type="button"
+              className={styles.primaryButton}
+              onClick={() => {
+                onApply(draftPreferences);
+                onRequestClose();
+              }}
+            >
+              Apply
+            </button>
+          </span>
+        </footer>
+      </div>
+    </dialog>
+  );
+}
+
+function CrossIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+      <path d="m3.5 3.5 9 9m0-9-9 9" />
+    </svg>
+  );
+}
+
+function DragHandleIcon() {
+  return (
+    <svg viewBox="0 0 12 18" aria-hidden="true" focusable="false">
+      <circle cx="3" cy="4" r="1" />
+      <circle cx="9" cy="4" r="1" />
+      <circle cx="3" cy="9" r="1" />
+      <circle cx="9" cy="9" r="1" />
+      <circle cx="3" cy="14" r="1" />
+      <circle cx="9" cy="14" r="1" />
+    </svg>
+  );
+}
+
+function ChevronIcon({ direction }: { direction: "up" | "down" }) {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+      <path d={direction === "up" ? "m4 10 4-4 4 4" : "m4 6 4 4 4-4"} />
+    </svg>
+  );
+}

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
@@ -595,14 +595,15 @@ describe("TableDataGrid", () => {
     expect(screen.getByLabelText("Edit title")).not.toBeNull();
   });
 
-  it("caps data column width so long cell values do not stretch the whole grid", () => {
+  it("uses uncapped flexible widths so visible data columns can fill the grid", () => {
     renderGrid();
 
     const titleMeasuringCell = document.querySelector(
       '[data-measuring-cell-key="title"]',
     ) as HTMLElement | null;
     expect(titleMeasuringCell).not.toBeNull();
-    expect(titleMeasuringCell?.style.maxWidth).toBe("360px");
+    expect(titleMeasuringCell?.style.minWidth).toBe("120px");
+    expect(titleMeasuringCell?.style.maxWidth).toBe("");
   });
 
   it("renders without frozen columns so actions stay last and id scrolls normally", () => {

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
@@ -123,7 +123,9 @@ describe("TableDataGrid", () => {
         blob: new Uint8Array([1, 2]),
         status: "open",
         $createdAt: new Date("2026-07-17T08:00:00.000Z"),
+        $createdBy: "seed-user",
         $updatedAt: new Date("2026-07-17T09:00:00.000Z"),
+        $updatedBy: "editor-user",
       },
       {
         id: "row-1",
@@ -135,7 +137,9 @@ describe("TableDataGrid", () => {
         blob: new Uint8Array([5, 6]),
         status: "closed",
         $createdAt: new Date("2026-07-16T08:00:00.000Z"),
+        $createdBy: "import-user",
         $updatedAt: new Date("2026-07-16T09:00:00.000Z"),
+        $updatedBy: "import-user",
       },
     ];
     currentReferenceRowsByTable = {
@@ -210,9 +214,11 @@ describe("TableDataGrid", () => {
     expect(screen.getByRole("columnheader", { name: "title" })).not.toBeNull();
     expect(screen.getByRole("columnheader", { name: "done" })).not.toBeNull();
     expect(screen.getByRole("columnheader", { name: "meta" })).not.toBeNull();
-    // The $createdAt and $updatedAt magic columns are included by default as the last two columns
+    // Provenance timestamps are included by default as the last two columns.
     expect(screen.getByRole("columnheader", { name: "$createdAt" })).not.toBeNull();
     expect(screen.getByRole("columnheader", { name: "$updatedAt" })).not.toBeNull();
+    expect(screen.queryByRole("columnheader", { name: "$createdBy" })).toBeNull();
+    expect(screen.queryByRole("columnheader", { name: "$updatedBy" })).toBeNull();
     const dataColumnHeaders = screen
       .getAllByRole("columnheader")
       .map((header) => header.textContent ?? "")
@@ -223,7 +229,38 @@ describe("TableDataGrid", () => {
     expect(screen.getByText('{"done":true}')).not.toBeNull();
     expect(screen.getByText("2026-07-17T08:00:00.000Z")).not.toBeNull();
     expect(screen.getByText("2026-07-17T09:00:00.000Z")).not.toBeNull();
+    expect(screen.queryByText("seed-user")).toBeNull();
+    expect(screen.queryByText("editor-user")).toBeNull();
     expect((screen.getByLabelText("Rows per page") as HTMLSelectElement).value).toBe("25");
+  });
+
+  it("can show creator and updater columns", () => {
+    renderGrid();
+
+    fireEvent.click(screen.getByRole("button", { name: "Customize columns" }));
+    const createdByCheckbox = screen.getByRole("checkbox", { name: "Show $createdBy" });
+    const updatedByCheckbox = screen.getByRole("checkbox", { name: "Show $updatedBy" });
+    expect((createdByCheckbox as HTMLInputElement).checked).toBe(false);
+    expect((updatedByCheckbox as HTMLInputElement).checked).toBe(false);
+
+    fireEvent.click(createdByCheckbox);
+    fireEvent.click(updatedByCheckbox);
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+
+    expect(screen.getByRole("columnheader", { name: "$createdBy" })).not.toBeNull();
+    expect(screen.getByRole("columnheader", { name: "$updatedBy" })).not.toBeNull();
+    const dataColumnHeaders = screen
+      .getAllByRole("columnheader")
+      .map((header) => header.textContent ?? "")
+      .filter((header) => header.length > 0);
+    expect(dataColumnHeaders.slice(-4)).toEqual([
+      "$createdAt",
+      "$createdBy",
+      "$updatedAt",
+      "$updatedBy",
+    ]);
+    expect(screen.getByText("seed-user")).not.toBeNull();
+    expect(screen.getByText("editor-user")).not.toBeNull();
   });
 
   it("can hide and show a column", () => {
@@ -326,7 +363,7 @@ describe("TableDataGrid", () => {
 
     const firstQuery = mockUseAll.mock.calls[0]?.[0] as { _build: () => string };
     expect(JSON.parse(firstQuery._build())).toMatchObject({
-      select: ["*", "$createdAt", "$updatedAt"],
+      select: ["*", "$createdAt", "$createdBy", "$updatedAt", "$updatedBy"],
       orderBy: [["id", "asc"]],
       limit: 26,
       offset: 0,

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
@@ -111,6 +111,7 @@ describe("TableDataGrid", () => {
   });
 
   beforeEach(() => {
+    localStorage.clear();
     currentRows = [
       {
         id: "row-2",
@@ -198,6 +199,7 @@ describe("TableDataGrid", () => {
     // The toolbar actions are labelled via aria-label (their hover hint is now a
     // Popover-API tooltip, not a native title attribute).
     expect(screen.getByRole("link", { name: "Schema" })).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Customize columns" })).not.toBeNull();
     expect(screen.getByRole("button", { name: "Insert row" })).not.toBeNull();
     expect(screen.getByRole("button", { name: "Delete row(s)" })).not.toBeNull();
     expect(screen.getByRole("columnheader", { name: /ID/ })).not.toBeNull();
@@ -208,6 +210,72 @@ describe("TableDataGrid", () => {
     expect(screen.getByText("zeta")).not.toBeNull();
     expect(screen.getByText('{"done":true}')).not.toBeNull();
     expect((screen.getByLabelText("Rows per page") as HTMLSelectElement).value).toBe("25");
+  });
+
+  it("can hide and show a column", () => {
+    renderGrid();
+
+    fireEvent.click(screen.getByRole("button", { name: "Customize columns" }));
+    expect(screen.getByRole("dialog", { name: "Customize columns" })).not.toBeNull();
+    fireEvent.click(screen.getByRole("checkbox", { name: "Show done" }));
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    expect(screen.queryByRole("columnheader", { name: "done" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Customize columns" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Show done" }));
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    expect(screen.getByRole("columnheader", { name: "done" })).not.toBeNull();
+  });
+
+  it("reorders a column", () => {
+    renderGrid();
+
+    fireEvent.click(screen.getByRole("button", { name: "Customize columns" }));
+    fireEvent.click(screen.getByRole("button", { name: "Move owner_id up" }));
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+
+    const headers = screen.getAllByRole("columnheader").map((header) => header.textContent ?? "");
+    expect(headers.indexOf("owner_id")).toBeLessThan(headers.indexOf("meta"));
+  });
+
+  it("restores column choices after remounting", () => {
+    const { unmount } = renderGrid();
+
+    fireEvent.click(screen.getByRole("button", { name: "Customize columns" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Show done" }));
+    fireEvent.click(screen.getByRole("button", { name: "Move owner_id up" }));
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+
+    expect(localStorage.length).toBe(1);
+    expect(
+      JSON.parse(
+        localStorage.getItem("jazz.inspector.dataExplorer.columnPreferences.todos") ?? "[]",
+      ),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "done", visible: false }),
+        expect.objectContaining({ id: "owner_id", visible: true }),
+      ]),
+    );
+
+    unmount();
+    renderGrid();
+
+    expect(screen.queryByRole("columnheader", { name: "done" })).toBeNull();
+    const restoredHeaders = screen
+      .getAllByRole("columnheader")
+      .map((header) => header.textContent ?? "");
+    expect(restoredHeaders.indexOf("owner_id")).toBeLessThan(restoredHeaders.indexOf("meta"));
+  });
+
+  it("discards draft column changes when customization is cancelled", () => {
+    renderGrid();
+
+    fireEvent.click(screen.getByRole("button", { name: "Customize columns" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Show title" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.getByRole("columnheader", { name: "title" })).not.toBeNull();
   });
 
   it("renders null cell values with a marker", () => {

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
@@ -122,6 +122,8 @@ describe("TableDataGrid", () => {
         owner_id: "owner-a",
         blob: new Uint8Array([1, 2]),
         status: "open",
+        $createdAt: new Date("2026-07-17T08:00:00.000Z"),
+        $updatedAt: new Date("2026-07-17T09:00:00.000Z"),
       },
       {
         id: "row-1",
@@ -132,6 +134,8 @@ describe("TableDataGrid", () => {
         owner_id: "owner-b",
         blob: new Uint8Array([5, 6]),
         status: "closed",
+        $createdAt: new Date("2026-07-16T08:00:00.000Z"),
+        $updatedAt: new Date("2026-07-16T09:00:00.000Z"),
       },
     ];
     currentReferenceRowsByTable = {
@@ -206,9 +210,19 @@ describe("TableDataGrid", () => {
     expect(screen.getByRole("columnheader", { name: "title" })).not.toBeNull();
     expect(screen.getByRole("columnheader", { name: "done" })).not.toBeNull();
     expect(screen.getByRole("columnheader", { name: "meta" })).not.toBeNull();
+    // The $createdAt and $updatedAt magic columns are included by default as the last two columns
+    expect(screen.getByRole("columnheader", { name: "$createdAt" })).not.toBeNull();
+    expect(screen.getByRole("columnheader", { name: "$updatedAt" })).not.toBeNull();
+    const dataColumnHeaders = screen
+      .getAllByRole("columnheader")
+      .map((header) => header.textContent ?? "")
+      .filter((header) => header.length > 0);
+    expect(dataColumnHeaders.slice(-2)).toEqual(["$createdAt", "$updatedAt"]);
     expect(screen.getByText("row-2")).not.toBeNull();
     expect(screen.getByText("zeta")).not.toBeNull();
     expect(screen.getByText('{"done":true}')).not.toBeNull();
+    expect(screen.getByText("2026-07-17T08:00:00.000Z")).not.toBeNull();
+    expect(screen.getByText("2026-07-17T09:00:00.000Z")).not.toBeNull();
     expect((screen.getByLabelText("Rows per page") as HTMLSelectElement).value).toBe("25");
   });
 
@@ -312,6 +326,7 @@ describe("TableDataGrid", () => {
 
     const firstQuery = mockUseAll.mock.calls[0]?.[0] as { _build: () => string };
     expect(JSON.parse(firstQuery._build())).toMatchObject({
+      select: ["*", "$createdAt", "$updatedAt"],
       orderBy: [["id", "asc"]],
       limit: 26,
       offset: 0,

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
@@ -82,8 +82,7 @@ interface GridColumn {
   accessorKey: string;
   header: string;
   enableSorting: boolean;
-  // `true` unless specified
-  visibleByDefault?: boolean;
+  hiddenByDefault?: true;
 }
 
 const PROVENANCE_GRID_COLUMNS: readonly GridColumn[] = [
@@ -98,7 +97,7 @@ const PROVENANCE_GRID_COLUMNS: readonly GridColumn[] = [
     accessorKey: "$createdBy",
     header: "$createdBy",
     enableSorting: true,
-    visibleByDefault: false,
+    hiddenByDefault: true,
   },
   {
     id: "$updatedAt",
@@ -111,7 +110,7 @@ const PROVENANCE_GRID_COLUMNS: readonly GridColumn[] = [
     accessorKey: "$updatedBy",
     header: "$updatedBy",
     enableSorting: true,
-    visibleByDefault: false,
+    hiddenByDefault: true,
   },
 ];
 

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
@@ -26,7 +26,14 @@ import {
 import { Link, Navigate, useParams, useSearchParams } from "react-router";
 import { useDevtoolsContext } from "../../contexts/devtools-context.js";
 import { GenericQueryBuilder } from "../../utility/generic-query-builder.js";
+import { useLocalStorageState } from "../../utility/use-local-storage-state.js";
 import { Tooltip } from "../tooltip/Tooltip.js";
+import {
+  ColumnCustomizationModal,
+  isColumnPreferences,
+  reconcileColumnPreferences,
+  type ColumnPreference,
+} from "./ColumnCustomizationModal.js";
 import { TableFilterBuilder, type TableFilterClause } from "./TableFilterBuilder.js";
 import {
   formatMutationFieldValue,
@@ -68,6 +75,7 @@ const ROW_REMOVED_ANIMATION_MS = 650;
 const DATA_COLUMN_MAX_WIDTH = 360;
 const STAGED_INSERT_ROW_ID_PREFIX = "__jazz_inspector_staged_insert__";
 const ACTIONS_COLUMN_KEY = "__actions__";
+const COLUMN_PREFERENCES_STORAGE_KEY_PREFIX = "jazz.inspector.dataExplorer.columnPreferences";
 
 interface GridColumn {
   id: string;
@@ -684,6 +692,11 @@ export function TableDataGrid() {
   const [queuedSaveError, setQueuedSaveError] = useState<string | null>(null);
   const [queuedDeletes, setQueuedDeletes] = useState<Set<string>>(new Set());
   const [pendingScrollToRowId, setPendingScrollToRowId] = useState<string | null>(null);
+  const [isColumnCustomizationOpen, setIsColumnCustomizationOpen] = useState(false);
+  const columnPreferencesStorageKey = `${COLUMN_PREFERENCES_STORAGE_KEY_PREFIX}.${table}`;
+  const [storedColumnPreferences, setStoredColumnPreferences] = useLocalStorageState<
+    ColumnPreference[]
+  >(columnPreferencesStorageKey, [], { isValid: isColumnPreferences });
   const schemaColumns = schema[table]?.columns ?? [];
   const schemaColumnById = useMemo(
     () => new Map(schemaColumns.map((column) => [column.name, column])),
@@ -727,7 +740,7 @@ export function TableDataGrid() {
   const isInitialLoading = queryResult.isLoading;
   const rows = queryResult.data ?? EMPTY_ROWS;
 
-  const gridColumns = useMemo<GridColumn[]>(
+  const allGridColumns = useMemo<GridColumn[]>(
     () => [
       {
         id: "id",
@@ -746,6 +759,17 @@ export function TableDataGrid() {
     ],
     [schemaColumns],
   );
+  const columnPreferences = useMemo(
+    () => reconcileColumnPreferences(allGridColumns, storedColumnPreferences),
+    [allGridColumns, storedColumnPreferences],
+  );
+  const gridColumns = useMemo(() => {
+    const gridColumnById = new Map(allGridColumns.map((column) => [column.id, column]));
+    return columnPreferences.flatMap((preference) => {
+      const column = gridColumnById.get(preference.id);
+      return preference.visible && column ? [column] : [];
+    });
+  }, [allGridColumns, columnPreferences]);
   const hasNextPage = rows.length > pageSize;
   const visibleRows = hasNextPage ? rows.slice(0, pageSize) : rows;
   const queuedEditCount = useMemo(() => {
@@ -940,6 +964,16 @@ export function TableDataGrid() {
                 <CatalogIcon className={styles.buttonIcon} />
               </Link>
             </Tooltip>
+            <Tooltip label="Customize columns">
+              <button
+                type="button"
+                className={`${styles.secondaryButton} ${styles.iconButton}`}
+                aria-label="Customize columns"
+                onClick={() => setIsColumnCustomizationOpen(true)}
+              >
+                <ColumnsIcon className={styles.buttonIcon} />
+              </button>
+            </Tooltip>
             <Tooltip label="Insert row">
               <button
                 type="button"
@@ -973,6 +1007,13 @@ export function TableDataGrid() {
             </Tooltip>
           </>
         }
+      />
+      <ColumnCustomizationModal
+        open={isColumnCustomizationOpen}
+        columns={allGridColumns}
+        preferences={columnPreferences}
+        onApply={setStoredColumnPreferences}
+        onRequestClose={() => setIsColumnCustomizationOpen(false)}
       />
       <div className={styles.contentArea}>
         <div className={styles.gridFrame}>
@@ -1399,6 +1440,29 @@ function CatalogIcon({ className }: { className?: string }) {
       <path d="M8 7h6" />
       <path d="M8 11h8" />
       <path d="M8 15h5" />
+    </svg>
+  );
+}
+
+function ColumnsIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      focusable="false"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+    >
+      <path d="M4 6h16" />
+      <path d="M4 12h16" />
+      <path d="M4 18h16" />
+      <path d="M8 4v4" />
+      <path d="M15 10v4" />
+      <path d="M11 16v4" />
     </svg>
   );
 }

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
@@ -48,6 +48,7 @@ const NULL_CELL_MARKER = "<null>";
 function formatCellValue(value: unknown): string {
   if (value === null) return NULL_CELL_MARKER;
   if (value === undefined) return "";
+  if (value instanceof Date) return value.toISOString();
   if (typeof value === "string") return value;
   if (typeof value === "number" || typeof value === "boolean") return String(value);
   if (typeof value === "object") return JSON.stringify(value);
@@ -82,6 +83,21 @@ interface GridColumn {
   header: string;
   enableSorting: boolean;
 }
+
+const PROVENANCE_TIMESTAMP_GRID_COLUMNS: readonly GridColumn[] = [
+  {
+    id: "$createdAt",
+    accessorKey: "$createdAt",
+    header: "$createdAt",
+    enableSorting: true,
+  },
+  {
+    id: "$updatedAt",
+    accessorKey: "$updatedAt",
+    header: "$updatedAt",
+    enableSorting: true,
+  },
+];
 
 type RowChangeState = "added" | "removed";
 
@@ -707,7 +723,10 @@ export function TableDataGrid() {
   const queryOffset = pageIndex * pageSize;
   const queryLimit = pageSize + 1;
   const queryBuilder = useMemo(() => {
-    let builder = new GenericQueryBuilder(table, schema);
+    let builder = new GenericQueryBuilder(table, schema).select(
+      "*",
+      ...PROVENANCE_TIMESTAMP_GRID_COLUMNS.map((column) => column.id),
+    );
     for (const filter of filters) {
       if (filter.operator === "eq") {
         builder = builder.where({ [filter.column]: filter.value });
@@ -755,6 +774,7 @@ export function TableDataGrid() {
           enableSorting: isColumnSortable(column.column_type),
         }),
       ),
+      ...PROVENANCE_TIMESTAMP_GRID_COLUMNS,
     ],
     [schemaColumns],
   );

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
@@ -72,7 +72,6 @@ const EMPTY_ROWS: DynamicTableRow[] = [];
 const CELL_UPDATE_ANIMATION_MS = 1_200;
 const ROW_ADDED_ANIMATION_MS = 2_000;
 const ROW_REMOVED_ANIMATION_MS = 650;
-const DATA_COLUMN_MAX_WIDTH = 360;
 const STAGED_INSERT_ROW_ID_PREFIX = "__jazz_inspector_staged_insert__";
 const ACTIONS_COLUMN_KEY = "__actions__";
 const COLUMN_PREFERENCES_STORAGE_KEY_PREFIX = "jazz.inspector.dataExplorer.columnPreferences";
@@ -1828,9 +1827,8 @@ function PlainTableView({
         sortable: column.enableSorting,
         resizable: true,
         editable: isEditable,
+        width: isIdColumn ? "minmax(148px, 1fr)" : "minmax(120px, 1fr)",
         minWidth: isIdColumn ? 148 : 120,
-        maxWidth: isIdColumn ? 220 : DATA_COLUMN_MAX_WIDTH,
-        width: isIdColumn ? 180 : undefined,
         headerCellClass: column.enableSorting ? styles.sortableHeaderCell : styles.gridHeaderCell,
         cellClass: (row) =>
           row.changedCellIds?.[column.id]
@@ -2075,9 +2073,11 @@ function PlainTableView({
 
     onSelectedRowIdsChange(nextSelectedRowIds);
   };
+  const columnLayoutKey = JSON.stringify(gridColumns.map((column) => column.id));
 
   return (
     <DataGrid
+      key={columnLayoutKey}
       ref={dataGridRef}
       className={`${styles.dataGrid} rdg-dark`}
       columns={columns}

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
@@ -82,9 +82,11 @@ interface GridColumn {
   accessorKey: string;
   header: string;
   enableSorting: boolean;
+  // `true` unless specified
+  visibleByDefault?: boolean;
 }
 
-const PROVENANCE_TIMESTAMP_GRID_COLUMNS: readonly GridColumn[] = [
+const PROVENANCE_GRID_COLUMNS: readonly GridColumn[] = [
   {
     id: "$createdAt",
     accessorKey: "$createdAt",
@@ -92,10 +94,24 @@ const PROVENANCE_TIMESTAMP_GRID_COLUMNS: readonly GridColumn[] = [
     enableSorting: true,
   },
   {
+    id: "$createdBy",
+    accessorKey: "$createdBy",
+    header: "$createdBy",
+    enableSorting: true,
+    visibleByDefault: false,
+  },
+  {
     id: "$updatedAt",
     accessorKey: "$updatedAt",
     header: "$updatedAt",
     enableSorting: true,
+  },
+  {
+    id: "$updatedBy",
+    accessorKey: "$updatedBy",
+    header: "$updatedBy",
+    enableSorting: true,
+    visibleByDefault: false,
   },
 ];
 
@@ -725,7 +741,7 @@ export function TableDataGrid() {
   const queryBuilder = useMemo(() => {
     let builder = new GenericQueryBuilder(table, schema).select(
       "*",
-      ...PROVENANCE_TIMESTAMP_GRID_COLUMNS.map((column) => column.id),
+      ...PROVENANCE_GRID_COLUMNS.map((column) => column.id),
     );
     for (const filter of filters) {
       if (filter.operator === "eq") {
@@ -774,7 +790,7 @@ export function TableDataGrid() {
           enableSorting: isColumnSortable(column.column_type),
         }),
       ),
-      ...PROVENANCE_TIMESTAMP_GRID_COLUMNS,
+      ...PROVENANCE_GRID_COLUMNS,
     ],
     [schemaColumns],
   );

--- a/packages/inspector/src/utility/generic-query-builder.ts
+++ b/packages/inspector/src/utility/generic-query-builder.ts
@@ -21,6 +21,7 @@ export class GenericQueryBuilder implements QueryBuilder<DynamicTableRow> {
   readonly _rowType: DynamicTableRow = undefined as unknown as DynamicTableRow;
 
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
+  private _selectColumns: string[] = [];
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
   private _limitVal: number | undefined = undefined;
   private _offsetVal: number | undefined = undefined;
@@ -53,6 +54,12 @@ export class GenericQueryBuilder implements QueryBuilder<DynamicTableRow> {
     return clone;
   }
 
+  select(...columns: string[]): GenericQueryBuilder {
+    const clone = this._clone();
+    clone._selectColumns = [...columns];
+    return clone;
+  }
+
   orderBy(column: string, direction: "asc" | "desc" = "asc"): GenericQueryBuilder {
     const clone = this._clone();
     clone._orderBys.push([column, direction]);
@@ -76,6 +83,7 @@ export class GenericQueryBuilder implements QueryBuilder<DynamicTableRow> {
       table: this._table,
       conditions: this._conditions,
       includes: {},
+      select: this._selectColumns,
       orderBy: this._orderBys,
       limit: this._limitVal,
       offset: this._offsetVal,
@@ -86,6 +94,7 @@ export class GenericQueryBuilder implements QueryBuilder<DynamicTableRow> {
   private _clone(): GenericQueryBuilder {
     const clone = new GenericQueryBuilder(this._table, this._schema);
     clone._conditions = [...this._conditions];
+    clone._selectColumns = [...this._selectColumns];
     clone._orderBys = [...this._orderBys];
     clone._limitVal = this._limitVal;
     clone._offsetVal = this._offsetVal;


### PR DESCRIPTION
## Description

The inspector now supports hiding columns and reordering them. It also shows the `$createdAt` and `$updatedAt` magic columns by default. `$createdBy` and `$updatedBy` can be included as well.

https://github.com/user-attachments/assets/1fa38514-82a1-44f6-86d1-4c75d17ac3c9
