### PR TITLE
fix: preserve sorted subscription order through projections

### DIFF
--- a/.changeset/preserve-sorting-through-projections.md
+++ b/.changeset/preserve-sorting-through-projections.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix: preserve sorting after updates on sorted values for queries that use projections and magic columns.

--- a/crates/jazz-tools/src/query_manager/graph/execute.rs
+++ b/crates/jazz-tools/src/query_manager/graph/execute.rs
@@ -389,6 +389,16 @@ impl QueryGraph {
         }
     }
 
+    fn ordered_tuples_from_node(&self, node_id: NodeId) -> Option<&[Tuple]> {
+        match self.get_node(node_id) {
+            Some(GraphNode::Sort(node)) => Some(node.sorted_tuples()),
+            Some(GraphNode::LimitOffset(node)) => Some(node.windowed_tuples()),
+            Some(GraphNode::MagicColumns(node)) => Some(node.ordered_tuples()),
+            Some(GraphNode::Project(node)) => Some(node.ordered_tuples()),
+            _ => None,
+        }
+    }
+
     /// Settle the graph - process all dirty nodes in topological order.
     /// Uses tuple-based processing internally, converts to RowDelta for output.
     pub fn settle<F>(&mut self, storage: &dyn Storage, mut row_loader: F) -> RowDelta
@@ -547,14 +557,20 @@ impl QueryGraph {
                     }
                 }
                 Some(GraphNode::Project(_)) => {
-                    let input_delta = self
-                        .get_inputs(node_id)
-                        .first()
-                        .and_then(|dep| tuple_deltas.get(dep).cloned())
+                    let input_node = self.get_inputs(node_id).first().copied();
+                    let input_delta = input_node
+                        .and_then(|dep| tuple_deltas.get(&dep).cloned())
                         .unwrap_or_default();
+                    let ordered_input = input_node
+                        .and_then(|dep| self.ordered_tuples_from_node(dep))
+                        .map(<[Tuple]>::to_vec);
 
                     if let Some(GraphNode::Project(project_node)) = self.get_node_mut(node_id) {
-                        let delta = RowNode::process(project_node, input_delta);
+                        let delta = if let Some(ordered) = ordered_input {
+                            project_node.process_with_ordered_input(input_delta, &ordered)
+                        } else {
+                            RowNode::process(project_node, input_delta)
+                        };
                         tracing::debug!(
                             node_id = node_id.0,
                             node_type,
@@ -643,18 +659,29 @@ impl QueryGraph {
                     }
                 }
                 Some(GraphNode::MagicColumns(_)) => {
-                    let input_delta = self
-                        .get_inputs(node_id)
-                        .first()
-                        .and_then(|dep| tuple_deltas.get(dep).cloned())
+                    let input_node = self.get_inputs(node_id).first().copied();
+                    let input_delta = input_node
+                        .and_then(|dep| tuple_deltas.get(&dep).cloned())
                         .unwrap_or_default();
+                    let ordered_input = input_node
+                        .and_then(|dep| self.ordered_tuples_from_node(dep))
+                        .map(<[Tuple]>::to_vec);
 
                     if let Some(GraphNode::MagicColumns(magic_node)) = self.get_node_mut(node_id) {
-                        let delta = magic_node.process_with_context(
-                            input_delta,
-                            storage,
-                            &mut |id, hint| row_loader(id, hint),
-                        );
+                        let delta = if let Some(ordered) = ordered_input {
+                            magic_node.process_with_ordered_input(
+                                input_delta,
+                                &ordered,
+                                storage,
+                                &mut |id, hint| row_loader(id, hint),
+                            )
+                        } else {
+                            magic_node.process_with_context(
+                                input_delta,
+                                storage,
+                                &mut |id, hint| row_loader(id, hint),
+                            )
+                        };
                         tracing::debug!(
                             node_id = node_id.0,
                             node_type,
@@ -798,15 +825,9 @@ impl QueryGraph {
                 }
                 Some(GraphNode::Output(_)) => {
                     let input_node = self.get_inputs(node_id).first().copied();
-                    let ordered_input = input_node.and_then(|dep| match self.get_node(dep) {
-                        Some(GraphNode::LimitOffset(lo_node)) => {
-                            Some(lo_node.windowed_tuples().to_vec())
-                        }
-                        Some(GraphNode::Sort(sort_node)) => {
-                            Some(sort_node.sorted_tuples().to_vec())
-                        }
-                        _ => None,
-                    });
+                    let ordered_input = input_node
+                        .and_then(|dep| self.ordered_tuples_from_node(dep))
+                        .map(<[Tuple]>::to_vec);
 
                     if let Some(GraphNode::Output(output_node)) = self.get_node_mut(node_id) {
                         let delta = if let Some(ordered) = ordered_input {

--- a/crates/jazz-tools/src/query_manager/graph_nodes/magic_columns.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/magic_columns.rs
@@ -6,6 +6,7 @@ use crate::query_manager::encoding::{decode_row, encode_row};
 use crate::query_manager::graph_nodes::policy_eval::{
     PolicyContextEvaluator, collect_policy_dependency_tables,
 };
+use crate::query_manager::graph_nodes::tuple_delta::compute_tuple_delta;
 use crate::query_manager::magic_columns::{MagicColumnKind, magic_column_descriptor};
 use crate::query_manager::policy::Operation;
 use crate::query_manager::session::Session;
@@ -67,6 +68,7 @@ pub struct MagicColumnsNode {
     current_tuples: AHashSet<Tuple>,
     input_tuples: AHashSet<Tuple>,
     projected_by_input: AHashMap<Tuple, Tuple>,
+    ordered_tuples: Vec<Tuple>,
     dirty: bool,
 }
 
@@ -165,6 +167,7 @@ impl MagicColumnsNode {
             current_tuples: AHashSet::new(),
             input_tuples: AHashSet::new(),
             projected_by_input: AHashMap::new(),
+            ordered_tuples: Vec::new(),
             dirty: true,
         })
     }
@@ -175,6 +178,11 @@ impl MagicColumnsNode {
 
     pub fn dependency_tables(&self) -> &HashSet<String> {
         &self.dependency_tables
+    }
+
+    /// Augmented tuples in the same order as an ordered upstream node.
+    pub fn ordered_tuples(&self) -> &[Tuple] {
+        &self.ordered_tuples
     }
 
     pub fn mark_dependency_dirty(&mut self) {
@@ -255,6 +263,24 @@ impl MagicColumnsNode {
 
         self.dirty = false;
         result
+    }
+
+    /// Process an update while preserving the exact order supplied by an
+    /// upstream sort or pagination node.
+    pub fn process_with_ordered_input(
+        &mut self,
+        input: TupleDelta,
+        ordered_input: &[Tuple],
+        io: &dyn Storage,
+        row_loader: &mut dyn FnMut(ObjectId, Option<TableName>) -> Option<LoadedRow>,
+    ) -> TupleDelta {
+        let old_ordered = std::mem::take(&mut self.ordered_tuples);
+        self.process_with_context(input, io, row_loader);
+        self.ordered_tuples = ordered_input
+            .iter()
+            .filter_map(|tuple| self.projected_by_input.get(tuple).cloned())
+            .collect();
+        compute_tuple_delta(&old_ordered, &self.ordered_tuples)
     }
 
     fn reevaluate_all_with_context(

--- a/crates/jazz-tools/src/query_manager/graph_nodes/project.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/project.rs
@@ -1,6 +1,7 @@
 use ahash::AHashSet;
 
 use crate::query_manager::encoding::{decode_column, encode_row};
+use crate::query_manager::graph_nodes::tuple_delta::compute_tuple_delta;
 use crate::query_manager::relation_ir::{ProjectColumn, ProjectExpr, RowIdRef};
 use crate::query_manager::types::{
     ColumnDescriptor, ColumnName, ColumnType, RowDescriptor, Tuple, TupleDelta, TupleDescriptor,
@@ -33,6 +34,7 @@ pub struct ProjectNode {
     output_tuple_descriptor: TupleDescriptor,
     projection_fields: Vec<ProjectionField>,
     current_tuples: AHashSet<Tuple>,
+    ordered_tuples: Vec<Tuple>,
     dirty: bool,
 }
 
@@ -162,6 +164,7 @@ impl ProjectNode {
             output_tuple_descriptor,
             projection_fields,
             current_tuples: AHashSet::new(),
+            ordered_tuples: Vec::new(),
             dirty: true,
         }
     }
@@ -169,6 +172,28 @@ impl ProjectNode {
     /// Get the output tuple descriptor.
     pub fn output_tuple_descriptor(&self) -> &TupleDescriptor {
         &self.output_tuple_descriptor
+    }
+
+    /// Projected tuples in the same order as an ordered upstream node.
+    pub fn ordered_tuples(&self) -> &[Tuple] {
+        &self.ordered_tuples
+    }
+
+    /// Process an update while preserving the exact order supplied by an
+    /// upstream sort, pagination, or ordered projection node.
+    pub fn process_with_ordered_input(
+        &mut self,
+        input: TupleDelta,
+        ordered_input: &[Tuple],
+    ) -> TupleDelta {
+        let old_ordered = std::mem::take(&mut self.ordered_tuples);
+        RowNode::process(self, input);
+        self.ordered_tuples = ordered_input
+            .iter()
+            .filter_map(|tuple| self.project_tuple(tuple))
+            .collect();
+        self.current_tuples = self.ordered_tuples.iter().cloned().collect();
+        compute_tuple_delta(&old_ordered, &self.ordered_tuples)
     }
 
     fn projected_value(&self, tuple: &Tuple, source: &ProjectionSource) -> Option<Value> {

--- a/crates/jazz-tools/tests/query/pagination.rs
+++ b/crates/jazz-tools/tests/query/pagination.rs
@@ -1,14 +1,14 @@
 #![cfg(feature = "test")]
 
 use jazz_tools::server::JazzServer;
-use jazz_tools::{QueryBuilder, Value};
+use jazz_tools::{JazzClient, QueryBuilder, Value};
 
 use crate::common::{
     ClientPair, NO_DELTA_WINDOW, QUERY_TIMEOUT, READY_TIMEOUT, TodoSeed, create_todo,
     subscription_schema,
 };
 use crate::support::{
-    TestingClient, collect_stream_deltas, has_added, has_any_change, wait_for_rows,
+    TestingClient, collect_stream_deltas, has_added, has_any_change, wait_for_query, wait_for_rows,
     wait_for_subscription_update,
 };
 
@@ -363,6 +363,114 @@ async fn subscribe_all_sorted_limited_subscription_reorders_when_new_top_row_arr
     assert_eq!(rows[1].1[0], Value::Text("Alice".to_string()));
 
     pair.shutdown().await;
+}
+
+/// Verifies that a subscription preserves its sort order through pagination and projection
+/// (including magic columns) when an update changes the active sort key
+#[tokio::test]
+async fn subscribe_all_preserves_sorting_on_sort_key_changes() {
+    let client = JazzClient::test_client(subscription_schema()).await;
+    let query = QueryBuilder::new("todos")
+        .select(&["id", "title", "priority", "$createdAt", "$updatedAt"])
+        .order_by("priority")
+        .limit(3)
+        .build();
+    let mut stream = client
+        .subscribe(query.clone())
+        .await
+        .expect("subscribe to sorted projected query");
+    let mut log = Vec::new();
+
+    let alice_id = create_todo(
+        &client,
+        TodoSeed {
+            title: "Alice",
+            done: false,
+            priority: Some(100),
+            tags: &["page"],
+            payload: None,
+        },
+    )
+    .await;
+    let bob_id = create_todo(
+        &client,
+        TodoSeed {
+            title: "Bob",
+            done: false,
+            priority: Some(50),
+            tags: &["page"],
+            payload: None,
+        },
+    )
+    .await;
+    let charlie_id = create_todo(
+        &client,
+        TodoSeed {
+            title: "Charlie",
+            done: false,
+            priority: Some(75),
+            tags: &["page"],
+            payload: None,
+        },
+    )
+    .await;
+
+    wait_for_query(
+        &client,
+        query.clone(),
+        None,
+        QUERY_TIMEOUT,
+        "initial projected rows are sorted by priority",
+        |rows| {
+            (rows.len() == 3
+                && rows[0].0 == bob_id
+                && rows[1].0 == charlie_id
+                && rows[2].0 == alice_id)
+                .then_some(rows)
+        },
+    )
+    .await;
+    collect_stream_deltas(&mut stream, &mut log, NO_DELTA_WINDOW).await;
+    log.clear();
+
+    client
+        .update(alice_id, vec![("priority".to_string(), Value::Integer(25))])
+        .expect("update the active sort key");
+
+    wait_for_subscription_update(
+        &mut stream,
+        &mut log,
+        QUERY_TIMEOUT,
+        "updated row moves to the first subscription position",
+        |log| {
+            log.iter().any(|delta| {
+                delta
+                    .updated
+                    .iter()
+                    .any(|change| change.id == alice_id && change.new_index == 0)
+            })
+        },
+    )
+    .await;
+
+    let rows = wait_for_query(
+        &client,
+        query,
+        None,
+        QUERY_TIMEOUT,
+        "projected query returns the updated sort order",
+        |rows| {
+            (rows.len() == 3
+                && rows[0].0 == alice_id
+                && rows[1].0 == bob_id
+                && rows[2].0 == charlie_id)
+                .then_some(rows)
+        },
+    )
+    .await;
+    assert_eq!(rows[0].1[1], Value::Integer(25));
+
+    client.shutdown().await.expect("shutdown client");
 }
 
 /// Verifies that deleting a row before an offset/limited page shifts the live


### PR DESCRIPTION
## Description

When a value in a column used as a query's sort criteria changed:
1. The sort node moved the row to its correct new position.
2. The magic columns/projection nodes preserved the new row content, but not the reordered row sequence.
3. The output node therefore received “this row was updated” without its new ordering.
4. It replaced the row’s content in place at its old index, making it appear that updated rows were unsorted or appended at the bottom.

The fix makes the magic columns/projection nodes preserve the exact ordered tuple list from upstream. They now calculate their delta from the ordered before/after sequences, so the output receives both the updated content and the correct new position.