### PR TITLE
Preserve typed column modifier inference

### DIFF
--- a/.changeset/typed-column-modifiers.md
+++ b/.changeset/typed-column-modifiers.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Preserve specialised TypeScript types when chaining column merge and transform modifiers.

--- a/packages/jazz-tools/src/dsl.test.ts
+++ b/packages/jazz-tools/src/dsl.test.ts
@@ -250,9 +250,12 @@ describe("column merge strategy DSL", () => {
   });
 
   it("rejects counter merge strategy on nullable integer columns in either chaining order", () => {
-    expect(() => col.int().optional().merge("counter" as never)).toThrow(
-      "Counter merge strategy is only supported on non-nullable INTEGER columns.",
-    );
+    expect(() =>
+      col
+        .int()
+        .optional()
+        .merge("counter" as never),
+    ).toThrow("Counter merge strategy is only supported on non-nullable INTEGER columns.");
     expect(() => col.int().merge("counter").optional()).toThrow(
       "Counter merge strategy is only supported on non-nullable INTEGER columns.",
     );
@@ -295,9 +298,12 @@ describe("column merge strategy DSL", () => {
   });
 
   it("rejects g-set merge strategy on nullable array columns in either chaining order", () => {
-    expect(() => col.array(col.string()).optional().merge("g-set" as never)).toThrow(
-      "g-set merge strategy is only supported on non-nullable ARRAY columns.",
-    );
+    expect(() =>
+      col
+        .array(col.string())
+        .optional()
+        .merge("g-set" as never),
+    ).toThrow("g-set merge strategy is only supported on non-nullable ARRAY columns.");
     expect(() => col.array(col.string()).merge("g-set").optional()).toThrow(
       "g-set merge strategy is only supported on non-nullable ARRAY columns.",
     );

--- a/packages/jazz-tools/src/dsl.test.ts
+++ b/packages/jazz-tools/src/dsl.test.ts
@@ -244,13 +244,13 @@ describe("column merge strategy DSL", () => {
   });
 
   it("rejects counter merge strategy on non-integer columns", () => {
-    expect(() => col.string().merge("counter")).toThrow(
+    expect(() => col.string().merge("counter" as never)).toThrow(
       "Counter merge strategy is only supported on non-nullable INTEGER columns.",
     );
   });
 
   it("rejects counter merge strategy on nullable integer columns in either chaining order", () => {
-    expect(() => col.int().optional().merge("counter")).toThrow(
+    expect(() => col.int().optional().merge("counter" as never)).toThrow(
       "Counter merge strategy is only supported on non-nullable INTEGER columns.",
     );
     expect(() => col.int().merge("counter").optional()).toThrow(
@@ -289,13 +289,13 @@ describe("column merge strategy DSL", () => {
   });
 
   it("rejects g-set merge strategy on non-array columns", () => {
-    expect(() => col.string().merge("g-set")).toThrow(
+    expect(() => col.string().merge("g-set" as never)).toThrow(
       "g-set merge strategy is only supported on non-nullable ARRAY columns.",
     );
   });
 
   it("rejects g-set merge strategy on nullable array columns in either chaining order", () => {
-    expect(() => col.array(col.string()).optional().merge("g-set")).toThrow(
+    expect(() => col.array(col.string()).optional().merge("g-set" as never)).toThrow(
       "g-set merge strategy is only supported on non-nullable ARRAY columns.",
     );
     expect(() => col.array(col.string()).merge("g-set").optional()).toThrow(

--- a/packages/jazz-tools/src/dsl.ts
+++ b/packages/jazz-tools/src/dsl.ts
@@ -115,7 +115,7 @@ export type TypedColumnBuilder<
   Ref extends string | undefined = string | undefined,
   HasDefault extends boolean = boolean,
   Value = TSTypeFromSqlType<Sql>,
-> = Omit<ColumnBuilder, "optional" | "default"> & {
+> = Omit<ColumnBuilder, "optional" | "default" | "merge" | "transform"> & {
   readonly __jazzSqlType: Sql;
   readonly __jazzOptional: Optional;
   readonly __jazzReferences: Ref;

--- a/packages/jazz-tools/tests/ts-dsl/typed-column-modifiers.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/typed-column-modifiers.test.ts
@@ -1,0 +1,78 @@
+import { describe, expectTypeOf, it } from "vitest";
+import { schema as s } from "../../src/index.js";
+
+const schema = {
+  items: s.table({
+    count: s.int().merge("counter"),
+    tags: s.array(s.string()).merge("g-set"),
+    transformed: s.string().transform({
+      from: (value) => value.length,
+      to: (value) => value.toString(),
+    }),
+    optionalCount: s.int().optional(),
+    defaultedCount: s.int().default(0),
+    optionalDefaulted: s.int().optional().default(null),
+    transformedOptional: s.string().optional().transform({
+      from: (value) => (value === null ? null : value.length),
+      to: (value) => (value === null ? null : value.toString()),
+    }),
+    defaultedMerge: s.int().default(0).merge("counter"),
+  }),
+};
+
+type AppSchema = s.Schema<typeof schema>;
+const app: s.App<AppSchema> = s.defineApp(schema);
+
+describe("typed column modifiers", () => {
+  it("preserves specialised row and insert types", () => {
+    expectTypeOf<s.RowOf<typeof app.items>>().toEqualTypeOf<{
+      id: string;
+      count: number;
+      tags: string[];
+      transformed: number;
+      optionalCount: number | null;
+      defaultedCount: number;
+      optionalDefaulted: number | null;
+      transformedOptional: number | null;
+      defaultedMerge: number;
+    }>();
+
+    expectTypeOf<s.InsertOf<typeof app.items>>().toEqualTypeOf<{
+      count: number;
+      tags: string[];
+      transformed: number;
+      optionalCount?: number | null;
+      defaultedCount?: number;
+      optionalDefaulted?: number | null;
+      transformedOptional?: number | null;
+      defaultedMerge: number;
+    }>();
+  });
+
+  it("keeps query filters based on stored column types", () => {
+    expectTypeOf<s.WhereOf<typeof app.items>["count"]>().branded.toEqualTypeOf<
+      | number
+      | {
+          eq?: number;
+          ne?: number;
+          gt?: number;
+          gte?: number;
+          lt?: number;
+          lte?: number;
+          in?: number[];
+        }
+      | undefined
+    >();
+
+    expectTypeOf<s.WhereOf<typeof app.items>["transformed"]>().branded.toEqualTypeOf<
+      | string
+      | {
+          eq?: string;
+          ne?: string;
+          contains?: string;
+          in?: string[];
+        }
+      | undefined
+    >();
+  });
+});

--- a/packages/jazz-tools/tests/ts-dsl/typed-column-modifiers.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/typed-column-modifiers.test.ts
@@ -45,7 +45,7 @@ describe("typed column modifiers", () => {
       defaultedCount?: number;
       optionalDefaulted?: number | null;
       transformedOptional?: number | null;
-      defaultedMerge: number;
+      defaultedMerge?: number;
     }>();
   });
 

--- a/packages/jazz-tools/tests/ts-dsl/typed-column-modifiers.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/typed-column-modifiers.test.ts
@@ -12,10 +12,13 @@ const schema = {
     optionalCount: s.int().optional(),
     defaultedCount: s.int().default(0),
     optionalDefaulted: s.int().optional().default(null),
-    transformedOptional: s.string().optional().transform({
-      from: (value) => (value === null ? null : value.length),
-      to: (value) => (value === null ? null : value.toString()),
-    }),
+    transformedOptional: s
+      .string()
+      .optional()
+      .transform({
+        from: (value) => (value === null ? null : value.length),
+        to: (value) => (value === null ? null : value.toString()),
+      }),
     defaultedMerge: s.int().default(0).merge("counter"),
   }),
 };


### PR DESCRIPTION
## Summary

- Preserve specialised TypeScript types when chaining column `merge`, `transform`, `optional`, and `default` modifiers.
- Keep `WhereOf` filters based on stored column types while row and insert types use transformed view types.
- Add regression coverage and a `jazz-tools` patch changeset.

## Testing

- `pnpm --filter jazz-tools exec vitest run tests/ts-dsl/typed-column-modifiers.test.ts src/dsl.test.ts --config vitest.config.ts` — passed, 27 tests
- `pnpm --filter jazz-tools exec tsc --project tsconfig.tests.json --pretty false` — changed files pass; blocked by missing generated `jazz-wasm`/`jazz-rn` declarations