### PR TITLE
Order the stress-test todo list window

### DIFF
--- a/dev/stress-tests/todo-react/src/TodoList.tsx
+++ b/dev/stress-tests/todo-react/src/TodoList.tsx
@@ -6,7 +6,10 @@ export function TodoList() {
   const [filterTitle, setFilterTitle] = useState("");
   const [showDoneOnly, setShowDoneOnly] = useState(false);
   const trimmedFilterTitle = filterTitle.trim();
-  let todosQuery = app.todos.limit(100);
+  // The maintained-subscription engine only lowers windowed (limit) views that
+  // have a deterministic order — an unordered limit(100) is rejected with
+  // "maintained subscription view window shape is not lowered yet".
+  let todosQuery = app.todos.orderBy("title", "asc").limit(100);
   if (trimmedFilterTitle) {
     todosQuery = todosQuery.where({ title: { contains: trimmedFilterTitle } });
   }


### PR DESCRIPTION
The todo-react stress test's list view subscribes with `app.todos.limit(100)` — an unordered window. The engine's maintained-subscription lowering only supports windowed views with a deterministic order (`linear_window_supported` in `crates/jazz/src/node/query_engine/lowering.rs` allows a Slice only after an OrderBy, or as `limit(1)`/no-limit), so the subscribe was rejected with `maintained subscription view window shape is not lowered yet` — surfacing as an uncaught error from the browser runtime and an empty list. Adding `orderBy("title", "asc")` puts the query in the supported shape; verified live that the capability rejection disappears and the subscription registers.

Two adjacent issues observed while verifying, not addressed here:

- The capability rejection surfaces as an **uncaught** error from `persistent-browser-runtime.ts` instead of reaching the subscriber's error callback (and a one-shot `db.all` with the same unsupported shape hangs rather than rejecting). The `CapabilityReport` diagnosis is excellent; the browser runtime just drops it.
- Rows still don't render against a long-running dev server whose sync is wedged: `insert().wait({ tier: "edge" })` times out, so under settlement-before-visibility nothing becomes readable. A fresh `pnpm dev` clears it.