### PR TITLE
Ship one-shot query results as transferable encoded payloads

### DIFF
--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -299,7 +299,7 @@ type SubscriptionSourceState = {
   reading: boolean;
 };
 
-type RowState = {
+export type RowState = {
   table: string;
   id: string;
   values: Value[];
@@ -730,6 +730,40 @@ export class NativeRuntimeAdapter implements Runtime {
     tier?: string | null,
     optionsJson?: string | null,
   ): Promise<unknown> {
+    const outcome = await this.queryTransportOutcome(queryJson, sessionJson, tier, optionsJson, {
+      preferEncoded: false,
+    });
+    return outcome.kind === "rows"
+      ? outcome.rows
+      : decodeEncodedQueryResult(outcome, this.schema, queryJson);
+  }
+
+  /**
+   * @internal Worker-boundary variant of {@link query}: returns the engine's
+   * encoded result payload whenever no adapter-side post-processing (edge
+   * refresh, transaction read overlay) was applied, so a message transport can
+   * move one transferable buffer instead of structured-cloning a decoded row
+   * tree. Decode with {@link decodeEncodedQueryResult} — a pure function of
+   * (payload, schema, queryJson) — on the receiving side.
+   */
+  async queryForTransport(
+    queryJson: string,
+    sessionJson?: string | null,
+    tier?: string | null,
+    optionsJson?: string | null,
+  ): Promise<QueryTransportOutcome> {
+    return this.queryTransportOutcome(queryJson, sessionJson, tier, optionsJson, {
+      preferEncoded: true,
+    });
+  }
+
+  private async queryTransportOutcome(
+    queryJson: string,
+    sessionJson: string | null | undefined,
+    tier: string | null | undefined,
+    optionsJson: string | null | undefined,
+    { preferEncoded }: { preferEncoded: boolean },
+  ): Promise<QueryTransportOutcome> {
     assertSupportedReadOptions(tier, optionsJson);
     assertTransactionReadOpen(optionsJson, this.pendingTxs, this.completedTxs);
     const session = readSession(sessionJson);
@@ -743,13 +777,17 @@ export class NativeRuntimeAdapter implements Runtime {
           throw new Error("Native runtime does not support session-scoped relation queries");
         }
         const payload = this.db.allRelationQueryForIdentity(coreQueryJson, session.identity, opts);
-        return rowsFromBatches(readRowBatches(payload), this.schema);
+        return preferEncoded
+          ? { kind: "encoded_row_batches", payload }
+          : { kind: "rows", rows: rowsFromBatches(readRowBatches(payload), this.schema) };
       }
       if (!this.db.allRelationQuery) {
         throw new Error("Native runtime does not support relation queries");
       }
       const payload = this.db.allRelationQuery(coreQueryJson, opts);
-      return rowsFromBatches(readRowBatches(payload), this.schema);
+      return preferEncoded
+        ? { kind: "encoded_row_batches", payload }
+        : { kind: "rows", rows: rowsFromBatches(readRowBatches(payload), this.schema) };
     }
     const query = this.prepareQuery(coreQueryJson);
     const attachment = await this.attachQueryIfNeeded(tier, optionsJson, query, session);
@@ -761,21 +799,46 @@ export class NativeRuntimeAdapter implements Runtime {
             throw new Error("Native runtime does not support session-scoped relation snapshots");
           }
           const payload = this.db.allRelationSnapshotForIdentity(query, session.identity, opts);
-          return rowsFromRelationSnapshot(
-            readRelationSnapshot(payload),
-            this.schema,
-            relationMaterializationSpec(coreQueryJson, this.schema),
-          );
+          return preferEncoded
+            ? { kind: "encoded_relation_snapshot", payload }
+            : {
+                kind: "rows",
+                rows: rowsFromRelationSnapshot(
+                  readRelationSnapshot(payload),
+                  this.schema,
+                  relationMaterializationSpec(coreQueryJson, this.schema),
+                ),
+              };
         }
         if (!this.db.allRelationSnapshot) {
           throw new Error("Native runtime does not support relation snapshots");
         }
         const payload = this.db.allRelationSnapshot(query, opts);
-        return rowsFromRelationSnapshot(
-          readRelationSnapshot(payload),
-          this.schema,
-          relationMaterializationSpec(coreQueryJson, this.schema),
-        );
+        return preferEncoded
+          ? { kind: "encoded_relation_snapshot", payload }
+          : {
+              kind: "rows",
+              rows: rowsFromRelationSnapshot(
+                readRelationSnapshot(payload),
+                this.schema,
+                relationMaterializationSpec(coreQueryJson, this.schema),
+              ),
+            };
+      }
+      // The plain path can ship encoded only when the adapter adds nothing on
+      // top of the engine result: an edge/global read may refresh and re-query,
+      // and an open transaction read overlays pending writes — both require
+      // decoded rows here.
+      if (
+        preferEncoded &&
+        tier !== "edge" &&
+        tier !== "global" &&
+        txIdFromOptions(optionsJson) === undefined
+      ) {
+        const payload = session
+          ? this.db.allForIdentity(query, session.identity, opts)
+          : this.db.all(query, opts);
+        return { kind: "encoded_row_batches", payload };
       }
       let rows = session
         ? this.db.allForIdentity(query, session.identity, opts)
@@ -788,7 +851,10 @@ export class NativeRuntimeAdapter implements Runtime {
           : this.db.all(query, opts);
         rowStates = rowsFromBatches(readRowBatches(rows), this.schema);
       }
-      return this.applyTransactionReadOverlay(rowStates, coreQueryJson, optionsJson);
+      return {
+        kind: "rows",
+        rows: this.applyTransactionReadOverlay(rowStates, coreQueryJson, optionsJson),
+      };
     } finally {
       if (attachment !== undefined) this.db.detachQuery?.(attachment);
     }
@@ -3514,6 +3580,38 @@ function expectString(value: Value, type: string): string {
     return value.value;
   }
   throw new Error(`expected ${type} value`);
+}
+
+/**
+ * Encoded query result crossing a message transport (see
+ * {@link NativeRuntimeAdapter.queryForTransport}). The payload stays in the
+ * engine's postcard encoding so it can ride a transfer list.
+ */
+export type EncodedQueryResult =
+  | { kind: "encoded_row_batches"; payload: Uint8Array }
+  | { kind: "encoded_relation_snapshot"; payload: Uint8Array };
+
+export type QueryTransportOutcome = EncodedQueryResult | { kind: "rows"; rows: unknown };
+
+/**
+ * Decode a transported encoded query result. Pure function of its inputs, so
+ * both sides of a worker boundary produce identical rows from the same
+ * payload, schema, and original query JSON.
+ */
+export function decodeEncodedQueryResult(
+  result: EncodedQueryResult,
+  schema: WasmSchema,
+  queryJson: string,
+): RowState[] {
+  if (result.kind === "encoded_row_batches") {
+    return rowsFromBatches(readRowBatches(result.payload), schema);
+  }
+  const coreQueryJson = addNestedOuterColumns(queryJson);
+  return rowsFromRelationSnapshot(
+    readRelationSnapshot(result.payload),
+    schema,
+    relationMaterializationSpec(coreQueryJson, schema),
+  );
 }
 
 function readRowBatches(payload: Uint8Array): NativeRowBatch[] {

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.ts
@@ -10,10 +10,12 @@ import type {
   PersistentBrowserWriteRequest,
 } from "./persistent-browser-protocol.js";
 import {
+  decodeEncodedQueryResult,
   encodeCellsForPatch,
   encodeCellsForRow,
   formatUuid,
   parseUuid,
+  type EncodedQueryResult,
 } from "./native-runtime-adapter.js";
 
 type PendingCall = {
@@ -254,7 +256,13 @@ export class PersistentBrowserOpfsRuntime implements Runtime {
       await this.connectionReady;
       await this.settleServerWaitsForRead(tier);
     }
-    return this.send("query", [queryJson, sessionJson, tier, translatedOptionsJson]);
+    const result = await this.send("query", [queryJson, sessionJson, tier, translatedOptionsJson]);
+    // The worker ships an encoded payload (moved via transfer list) whenever it
+    // applied no post-processing; decoding here is the same pure function of
+    // (payload, schema, query) the worker would otherwise have run.
+    const encoded = (result as { encodedQueryResult?: EncodedQueryResult } | null | undefined)
+      ?.encodedQueryResult;
+    return encoded ? decodeEncodedQueryResult(encoded, this.schema, queryJson) : result;
   }
 
   createSubscription(

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-worker.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-worker.ts
@@ -77,8 +77,19 @@ async function handleMessage(message: PersistentBrowserOpfsOwnerRequest): Promis
         return;
       }
       case "query": {
-        const result = await getRuntime().query(...message.args);
-        postResult(message.id, result);
+        const outcome = await getRuntime().queryForTransport(...message.args);
+        if (outcome.kind === "rows") {
+          postResult(message.id, outcome.rows);
+          return;
+        }
+        // Transfer the encoded payload instead of structured-cloning a decoded
+        // row tree; the page decodes with the same pure helpers. Transfer moves
+        // the whole backing buffer, so a partial view is sliced to an exact one
+        // first (and slicing also detaches nothing the sender still needs).
+        const payload = exactByteView(outcome.payload);
+        postResult(message.id, { encodedQueryResult: { kind: outcome.kind, payload } }, [
+          payload.buffer,
+        ]);
         return;
       }
       case "createExecutedSubscription": {
@@ -222,8 +233,16 @@ function getRuntime(): NativeRuntimeAdapter {
   return runtime;
 }
 
-function postResult(id: number, result: unknown): void {
-  workerScope.postMessage({ id, ok: true, result });
+function postResult(id: number, result: unknown, transfer?: Transferable[]): void {
+  workerScope.postMessage({ id, ok: true, result }, transfer);
+}
+
+function exactByteView(bytes: Uint8Array): Uint8Array<ArrayBuffer> {
+  return bytes.byteOffset === 0 &&
+    bytes.byteLength === bytes.buffer.byteLength &&
+    bytes.buffer instanceof ArrayBuffer
+    ? (bytes as Uint8Array<ArrayBuffer>)
+    : (bytes.slice() as Uint8Array<ArrayBuffer>);
 }
 
 function postError(id: number, error: unknown): void {


### PR DESCRIPTION
Stacked on #1105 (independent code, shared perf series).

While scoping SharedArrayBuffer transport, profiling showed the messaging boundary is single-digit percent of write storms — but the one-shot query path had a real structural gap: the worker decoded rows into JS object trees and structured-cloned them to the page, while the subscription path already ships encoded frames with transfer lists and decodes lazily page-side.

## Changes

- `NativeRuntimeAdapter.queryForTransport` (worker boundary variant of `query`): returns the engine's postcard-encoded result payload whenever no adapter-side post-processing was applied — relation queries, relation snapshots, and plain local-tier reads with no open transaction read. Edge/global reads (which refresh and re-query) and transaction-overlay reads still decode worker-side and cross as rows, unchanged.
- The worker posts `{ encodedQueryResult: { kind, payload } }` with the payload buffer in the transfer list (sliced to an exact view first — transferring moves the whole backing buffer).
- The page decodes with `decodeEncodedQueryResult`, a pure function of (payload, schema, queryJson), producing identical rows to what the worker would have produced — including the `valuesByColumn` map that structured clone silently dropped (consumers already tolerate its absence, so this is a strict superset).
- Request-side write values stay structured-cloned deliberately: they're caller-owned buffers, and a transfer would detach the caller's data.

## Receipts

- 5,000-row `db.all` over the worker channel, 25-run mean: **78.3ms → 71.8ms (−8.4%)** — and the decode CPU moves from the worker thread (the contended side under write load) to the idle page thread.
- jazz-tools unit suite 1146 passed; `tsc` clean.
- Browser suites `db.all` / `db.include-subscriptions` / `db.transaction-reads` / `useAll`: 72/76 — the 4 failures are the pre-existing hop/gather capability gaps, verified to fail identically on the unpatched baseline.

## Context: why not SharedArrayBuffer

SAB + ring buffer was evaluated first: it requires cross-origin isolation (COOP/COEP) on every consumer app — breaking OAuth popups and third-party embeds — can only ever be an opt-in second transport, and the measured postMessage overhead (~12µs/message, <3% of a write storm) doesn't justify it yet. `SubscriptionChannel` remains the seam where a ring-backed transport could slot in later behind a `crossOriginIsolated` check. Remaining cheap wins on this channel, not in this PR: coalescing queued write batches page-side, and prioritizing hydration/read requests over queued writes in the worker pump.