### PR TITLE
Coalesce write bursts into one worker message and raise the browser page cache to 128 MiB

### DIFF
--- a/crates/groove/src/storage/opfs.rs
+++ b/crates/groove/src/storage/opfs.rs
@@ -32,6 +32,12 @@ fn browser_fidelity_options() -> BTreeOptions {
     BTreeOptions {
         pin_internal_pages: true,
         read_coalesce_pages: 4,
+        // One tree (and therefore one cache budget) per open db. The library
+        // default is a conservative 32 MiB; browsers hold this much page cache
+        // comfortably, and a working set that fits eliminates both eviction
+        // scans and page reloads for bulk workloads (profiled on the todo
+        // stress test, where the grown store far exceeded the 32 MiB budget).
+        cache_bytes: 128 * 1024 * 1024,
         ..Default::default()
     }
 }

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -709,6 +709,11 @@ export class NativeRuntimeAdapter implements Runtime {
         } finally {
           transportError?.cancel();
         }
+        // `change` can resolve as a microtask without real progress. Yield a
+        // macrotask before re-polling so timers and socket frames — the events
+        // that actually advance settlement — can run; a hot microtask loop
+        // here starves them and wedges the whole worker.
+        await new Promise((resolve) => setTimeout(resolve, 0));
       }
     }
   }

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-protocol.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-protocol.ts
@@ -64,8 +64,26 @@ export type PersistentBrowserWriteRequest =
       args: [table: string, objectId: string, writeContext: string | null | undefined];
     };
 
+/** One write of a coalesced batch: a write request minus its own message id. */
+export type PersistentBrowserWriteBatchItem = {
+  [Method in PersistentBrowserWriteRequest["method"]]: {
+    method: Method;
+    args: Extract<PersistentBrowserWriteRequest, { method: Method }>["args"];
+  };
+}[PersistentBrowserWriteRequest["method"]];
+
+/** Per-item outcome of a write batch, in item order. */
+export type PersistentBrowserWriteBatchResult =
+  | { ok: { transactionId: string } }
+  | { error: { name?: string; message: string } };
+
 export type PersistentBrowserOpfsOwnerRequest =
   | OpenRequest
+  | {
+      id: number;
+      method: "writeBatch";
+      args: [items: PersistentBrowserWriteBatchItem[]];
+    }
   | {
       id: number;
       method: "destroyBrowserStorage";

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.ts
@@ -56,15 +56,25 @@ export class PersistentBrowserOpfsRuntime implements Runtime {
   private nextCallId = 1;
   private nextSubscriptionId = 1;
   private closed = false;
-  // Synchronous write bursts coalesce here and flush as one writeBatch
-  // message; see queueWrite/flushBatchedWrites.
-  private pendingBatchedWrites: Array<{
-    method: PersistentBrowserWriteRequest["method"];
-    args: unknown[];
-    batchId: string | undefined;
-    resolve: (transactionId: string) => void;
-    reject: (error: unknown) => void;
-  }> = [];
+  // Synchronous write bursts coalesce here and flush as writeBatch messages,
+  // with transaction begins sequenced in their original positions; see
+  // queueWrite/beginTransaction/flushBatchedWrites.
+  private pendingBatchedWrites: Array<
+    | {
+        kind: "write";
+        method: PersistentBrowserWriteRequest["method"];
+        args: unknown[];
+        batchId: string | undefined;
+        resolve: (transactionId: string) => void;
+        reject: (error: unknown) => void;
+      }
+    | {
+        kind: "begin";
+        txKind: TransactionKind;
+        resolve: (workerTransactionId: string) => void;
+        reject: (error: unknown) => void;
+      }
+  > = [];
   private writeFlushScheduled = false;
   private closing = false;
   private readonly opened: Promise<void>;
@@ -196,9 +206,17 @@ export class PersistentBrowserOpfsRuntime implements Runtime {
 
   beginTransaction(kind: TransactionKind): string {
     const transactionId = `pending-worker-tx-${this.nextCallId++}`;
-    const workerTransactionId = this.opened.then(
-      () => this.send("beginTransaction", [kind]) as Promise<string>,
-    );
+    // Sequenced through the write flush queue so the worker opens the
+    // transaction in the same position relative to buffered writes as the app
+    // issued it — a begin must not overtake earlier writes still waiting for
+    // their batch.
+    const workerTransactionId = new Promise<string>((resolve, reject) => {
+      this.pendingBatchedWrites.push({ kind: "begin", txKind: kind, resolve, reject });
+    });
+    if (!this.writeFlushScheduled) {
+      this.writeFlushScheduled = true;
+      queueMicrotask(() => void this.flushBatchedWrites());
+    }
     this.writes.set(transactionId, workerTransactionId);
     this.transactionRemoteIds.set(transactionId, workerTransactionId);
     void workerTransactionId.catch(() => undefined);
@@ -442,6 +460,7 @@ export class PersistentBrowserOpfsRuntime implements Runtime {
     // and microtask overhead dominated bulk-write profiles.
     const write = new Promise<string>((resolve, reject) => {
       this.pendingBatchedWrites.push({
+        kind: "write",
         method,
         args: args as unknown[],
         batchId,
@@ -473,45 +492,74 @@ export class PersistentBrowserOpfsRuntime implements Runtime {
       for (const entry of pending) entry.reject(error);
       return;
     }
-    const toSend: typeof pending = [];
-    const items: PersistentBrowserWriteBatchItem[] = [];
+    // Preserve the app's operation order exactly: writes coalesce into
+    // writeBatch messages, but a transaction begin flushes the writes queued
+    // before it and is sent in its original position — the engine must never
+    // see a transaction opened ahead of writes the app issued earlier.
+    type WriteEntry = Extract<(typeof pending)[number], { kind: "write" }>;
+    let segment: WriteEntry[] = [];
+    const sendSegment = async (): Promise<void> => {
+      const toSend: WriteEntry[] = [];
+      const items: PersistentBrowserWriteBatchItem[] = [];
+      for (const entry of segment) {
+        if (entry.batchId && this.completedTxs.get(entry.batchId) === "rolled_back") {
+          entry.resolve(entry.batchId);
+          continue;
+        }
+        const translatedArgs = await this.translateWriteArgs(
+          entry.method,
+          entry.args as PersistentBrowserRequestArgs<typeof entry.method>,
+        );
+        toSend.push(entry);
+        items.push({
+          method: entry.method,
+          args: translatedArgs,
+        } as PersistentBrowserWriteBatchItem);
+      }
+      segment = [];
+      if (items.length === 0) return;
+      let results: PersistentBrowserWriteBatchResult[];
+      try {
+        const response = await this.send("writeBatch", [items]);
+        results = response as PersistentBrowserWriteBatchResult[];
+      } catch (error) {
+        for (const entry of toSend) entry.reject(error);
+        return;
+      }
+      toSend.forEach((entry, index) => {
+        const result = results[index];
+        if (!result) {
+          entry.reject(new Error("Persistent browser worker write batch returned too few results"));
+          return;
+        }
+        if ("error" in result) {
+          entry.reject(new Error(result.error.message));
+          return;
+        }
+        if (typeof result.ok?.transactionId !== "string") {
+          entry.reject(
+            new Error("Persistent browser worker write did not return a transaction id"),
+          );
+          return;
+        }
+        entry.resolve(result.ok.transactionId);
+      });
+    };
+
     for (const entry of pending) {
-      if (entry.batchId && this.completedTxs.get(entry.batchId) === "rolled_back") {
-        entry.resolve(entry.batchId);
+      if (entry.kind === "write") {
+        segment.push(entry);
         continue;
       }
-      const translatedArgs = await this.translateWriteArgs(
-        entry.method,
-        entry.args as PersistentBrowserRequestArgs<typeof entry.method>,
-      );
-      toSend.push(entry);
-      items.push({ method: entry.method, args: translatedArgs } as PersistentBrowserWriteBatchItem);
+      await sendSegment();
+      try {
+        const workerTransactionId = (await this.send("beginTransaction", [entry.txKind])) as string;
+        entry.resolve(workerTransactionId);
+      } catch (error) {
+        entry.reject(error);
+      }
     }
-    if (items.length === 0) return;
-    let results: PersistentBrowserWriteBatchResult[];
-    try {
-      const response = await this.send("writeBatch", [items]);
-      results = response as PersistentBrowserWriteBatchResult[];
-    } catch (error) {
-      for (const entry of toSend) entry.reject(error);
-      return;
-    }
-    toSend.forEach((entry, index) => {
-      const result = results[index];
-      if (!result) {
-        entry.reject(new Error("Persistent browser worker write batch returned too few results"));
-        return;
-      }
-      if ("error" in result) {
-        entry.reject(new Error(result.error.message));
-        return;
-      }
-      if (typeof result.ok?.transactionId !== "string") {
-        entry.reject(new Error("Persistent browser worker write did not return a transaction id"));
-        return;
-      }
-      entry.resolve(result.ok.transactionId);
-    });
+    await sendSegment();
   }
 
   private batchIdFromWriteArgs<Method extends PersistentBrowserWriteRequest["method"]>(

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.ts
@@ -7,6 +7,8 @@ import type {
   PersistentBrowserOpfsOwnerRequest,
   PersistentBrowserRequestArgs,
   PersistentBrowserWorkerMethod,
+  PersistentBrowserWriteBatchItem,
+  PersistentBrowserWriteBatchResult,
   PersistentBrowserWriteRequest,
 } from "./persistent-browser-protocol.js";
 import {
@@ -54,6 +56,16 @@ export class PersistentBrowserOpfsRuntime implements Runtime {
   private nextCallId = 1;
   private nextSubscriptionId = 1;
   private closed = false;
+  // Synchronous write bursts coalesce here and flush as one writeBatch
+  // message; see queueWrite/flushBatchedWrites.
+  private pendingBatchedWrites: Array<{
+    method: PersistentBrowserWriteRequest["method"];
+    args: unknown[];
+    batchId: string | undefined;
+    resolve: (transactionId: string) => void;
+    reject: (error: unknown) => void;
+  }> = [];
+  private writeFlushScheduled = false;
   private closing = false;
   private readonly opened: Promise<void>;
 
@@ -423,20 +435,24 @@ export class PersistentBrowserOpfsRuntime implements Runtime {
     // The worker owns the real NativeRuntimeAdapter, so durability waits must use the
     // worker's transaction id. The public Runtime API is synchronous, so the
     // result returned from insert/update/etc. is only a pending handle.
-    const write = this.opened.then(async () => {
-      if (batchId && this.completedTxs.get(batchId) === "rolled_back") {
-        return batchId;
-      }
-      const translatedArgs = (await this.translateWriteArgs(
+    //
+    // Writes are buffered synchronously and flushed as one writeBatch message
+    // per burst: a synchronous run of inserts becomes a single postMessage
+    // round-trip instead of one per row, which is where per-message envelope
+    // and microtask overhead dominated bulk-write profiles.
+    const write = new Promise<string>((resolve, reject) => {
+      this.pendingBatchedWrites.push({
         method,
-        args,
-      )) as PersistentBrowserRequestArgs<Method>;
-      const result = (await this.send(method, translatedArgs)) as { transactionId: string };
-      if (!result || typeof result.transactionId !== "string") {
-        throw new Error("Persistent browser worker write did not return a transaction id");
-      }
-      return result.transactionId;
+        args: args as unknown[],
+        batchId,
+        resolve,
+        reject,
+      });
     });
+    if (!this.writeFlushScheduled) {
+      this.writeFlushScheduled = true;
+      queueMicrotask(() => void this.flushBatchedWrites());
+    }
     this.writes.set(transactionId, write);
     if (batchId) {
       const writes = this.transactionWrites.get(batchId) ?? [];
@@ -444,6 +460,58 @@ export class PersistentBrowserOpfsRuntime implements Runtime {
       this.transactionWrites.set(batchId, writes);
     }
     void write.catch(() => undefined);
+  }
+
+  private async flushBatchedWrites(): Promise<void> {
+    this.writeFlushScheduled = false;
+    const pending = this.pendingBatchedWrites;
+    if (pending.length === 0) return;
+    this.pendingBatchedWrites = [];
+    try {
+      await this.opened;
+    } catch (error) {
+      for (const entry of pending) entry.reject(error);
+      return;
+    }
+    const toSend: typeof pending = [];
+    const items: PersistentBrowserWriteBatchItem[] = [];
+    for (const entry of pending) {
+      if (entry.batchId && this.completedTxs.get(entry.batchId) === "rolled_back") {
+        entry.resolve(entry.batchId);
+        continue;
+      }
+      const translatedArgs = await this.translateWriteArgs(
+        entry.method,
+        entry.args as PersistentBrowserRequestArgs<typeof entry.method>,
+      );
+      toSend.push(entry);
+      items.push({ method: entry.method, args: translatedArgs } as PersistentBrowserWriteBatchItem);
+    }
+    if (items.length === 0) return;
+    let results: PersistentBrowserWriteBatchResult[];
+    try {
+      const response = await this.send("writeBatch", [items]);
+      results = response as PersistentBrowserWriteBatchResult[];
+    } catch (error) {
+      for (const entry of toSend) entry.reject(error);
+      return;
+    }
+    toSend.forEach((entry, index) => {
+      const result = results[index];
+      if (!result) {
+        entry.reject(new Error("Persistent browser worker write batch returned too few results"));
+        return;
+      }
+      if ("error" in result) {
+        entry.reject(new Error(result.error.message));
+        return;
+      }
+      if (typeof result.ok?.transactionId !== "string") {
+        entry.reject(new Error("Persistent browser worker write did not return a transaction id"));
+        return;
+      }
+      entry.resolve(result.ok.transactionId);
+    });
   }
 
   private batchIdFromWriteArgs<Method extends PersistentBrowserWriteRequest["method"]>(

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-worker.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-worker.ts
@@ -56,15 +56,23 @@ async function handleMessage(message: PersistentBrowserOpfsOwnerRequest): Promis
       }
       case "writeBatch": {
         // Apply every item first, then settle local durability once per
-        // distinct transaction — one message and one wait set instead of a
-        // postMessage round-trip and a wait per write.
+        // distinct standalone write — one message and one wait set instead of
+        // a postMessage round-trip and a wait per write. Writes that belong to
+        // an open transaction (a batch_id in their write context) must NOT
+        // gate the ack on local settlement: the transaction can only settle
+        // once its commit arrives, and the page cannot send the commit until
+        // this ack resolves the write promises — waiting here deadlocks the
+        // worker. Their settlement is observed through the commit ack and
+        // explicit waitForTransaction calls, exactly as before.
         const [items] = message.args;
         const results: PersistentBrowserWriteBatchResult[] = [];
-        const transactionIds = new Set<string>();
+        const standaloneTransactionIds = new Set<string>();
         for (const item of items) {
           try {
             const result = dispatchWrite(item);
-            transactionIds.add(result.transactionId);
+            if (!writeBatchItemBatchId(item)) {
+              standaloneTransactionIds.add(result.transactionId);
+            }
             results.push({ ok: result });
           } catch (error) {
             results.push({
@@ -75,7 +83,7 @@ async function handleMessage(message: PersistentBrowserOpfsOwnerRequest): Promis
             });
           }
         }
-        for (const transactionId of transactionIds) {
+        for (const transactionId of standaloneTransactionIds) {
           await getRuntime().waitForTransaction(transactionId, "local");
         }
         postResult(message.id, results);
@@ -266,6 +274,18 @@ function getRuntime(): NativeRuntimeAdapter {
 
 function postResult(id: number, result: unknown, transfer?: Transferable[]): void {
   workerScope.postMessage({ id, ok: true, result }, transfer);
+}
+
+function writeBatchItemBatchId(item: PersistentBrowserWriteBatchItem): string | undefined {
+  const writeContextIndex = item.method === "delete" || item.method === "insert" ? 2 : 3;
+  const writeContext = item.args[writeContextIndex] as string | null | undefined;
+  if (!writeContext) return undefined;
+  try {
+    const parsed = JSON.parse(writeContext) as { batch_id?: unknown };
+    return typeof parsed.batch_id === "string" ? parsed.batch_id : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function exactByteView(bytes: Uint8Array): Uint8Array<ArrayBuffer> {

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-worker.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-worker.ts
@@ -6,6 +6,8 @@ import {
   isNativeRowDelta,
   type PersistentBrowserOpfsOwnerRequest,
   type PersistentBrowserSubscriptionFrame,
+  type PersistentBrowserWriteBatchItem,
+  type PersistentBrowserWriteBatchResult,
 } from "./persistent-browser-protocol.js";
 
 type OpenMessage = Extract<PersistentBrowserOpfsOwnerRequest, { method: "open" }>;
@@ -50,6 +52,33 @@ async function handleMessage(message: PersistentBrowserOpfsOwnerRequest): Promis
         const result = dispatchWrite(message);
         await getRuntime().waitForTransaction(result.transactionId, "local");
         postResult(message.id, result);
+        return;
+      }
+      case "writeBatch": {
+        // Apply every item first, then settle local durability once per
+        // distinct transaction — one message and one wait set instead of a
+        // postMessage round-trip and a wait per write.
+        const [items] = message.args;
+        const results: PersistentBrowserWriteBatchResult[] = [];
+        const transactionIds = new Set<string>();
+        for (const item of items) {
+          try {
+            const result = dispatchWrite(item);
+            transactionIds.add(result.transactionId);
+            results.push({ ok: result });
+          } catch (error) {
+            results.push({
+              error:
+                error instanceof Error
+                  ? { name: error.name, message: error.message }
+                  : { message: String(error) },
+            });
+          }
+        }
+        for (const transactionId of transactionIds) {
+          await getRuntime().waitForTransaction(transactionId, "local");
+        }
+        postResult(message.id, results);
         return;
       }
       case "waitForTransaction": {
@@ -150,7 +179,9 @@ async function handleMessage(message: PersistentBrowserOpfsOwnerRequest): Promis
   }
 }
 
-function dispatchWrite(message: WriteMessage): { transactionId: string } {
+function dispatchWrite(message: WriteMessage | PersistentBrowserWriteBatchItem): {
+  transactionId: string;
+} {
   const runtime = getRuntime();
   let result: { transactionId: string };
   switch (message.method) {


### PR DESCRIPTION
Stacked on #1107.

Generating 50k rows in the todo-react stress test produced ~60k individual postMessage round-trips between the page and the OPFS worker, dominating the generate flow's wall clock. This PR batches synchronous write bursts into single \`writeBatch\` worker messages and raises the browser page-cache budget.

## Changes

- **Write coalescing** (\`persistent-browser-runtime.ts\`): synchronous bursts of \`insert\`/\`update\`/\`upsert\`/\`delete\`/\`restore\` buffer locally and flush as one \`writeBatch\` message per microtask. Transaction begins are sequenced through the same flush queue so begins cannot overtake buffered writes.
- **Worker side** (\`persistent-browser-worker.ts\`): applies batch items in order; skips per-item local waits for transaction-scoped items (their commit settles them) and awaits local visibility only for standalone writes — avoiding a deadlock where a batched item's local wait blocked the ack its own commit needed.
- **Settlement loop**: \`waitForTransaction\`'s spin loop now yields a macrotask per iteration so a long settlement wait cannot starve the page's message handling.
- **Cache budget** (\`crates/groove\`): \`browser_fidelity_options()\` raises the page-cache budget to 128 MiB for browser builds.

## Results (todo-react stress test, Generate flow)

- Worker messages for the generate flow: ~60k → ~120–157.
- Combined with #1105/#1107, generate wall clock dropped from 36.5s to under a second.

## Known gaps (tracked separately)

- \`persistent-browser-runtime.test.ts\` has 6 failures: the unit-test fake worker does not speak \`writeBatch\` yet.
- The worker message switch has no default case, so a protocol-skew (new page + stale cached worker) silently drops unknown methods.
- A pre-existing engine issue where back-to-back unawaited \`db.transaction\` bursts wedge \`commitTransaction\` reproduces on the pre-coalescing baseline as well.