### PR TITLE
Storage ingestion/cold-load benchmark (USDA plants): Jazz vs native engines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
   # "examples/todo-server-rs",
   # "examples/docs/todo-server-rs",
   "dev/benchmarks/storage/bench-core",
+  "dev/benchmarks/jazz-ingest",
 ]
 exclude = ["examples/todo-server-rs", "examples/docs/todo-server-rs"]
 

--- a/crates/groove/Cargo.toml
+++ b/crates/groove/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [features]
 default = ["rocksdb"]
 rocksdb = ["dep:rocksdb"]
+slatedb = ["dep:slatedb", "dep:tokio"]
 
 [dependencies]
 internment = { version = "0.8.6", features = ["serde"] }
@@ -23,6 +24,13 @@ uuid = { version = "1.18.1", features = ["serde", "v5"] }
 web-time = "1.1.0"
 rustc-hash.workspace = true
 opfs-btree = { path = "../opfs-btree" }
+slatedb = { version = "0.14.1", default-features = false, features = [
+  "moka",
+], optional = true }
+tokio = { version = "1", features = [
+  "rt-multi-thread",
+  "sync",
+], optional = true }
 
 [dev-dependencies]
 hdrhistogram = "7.5.4"

--- a/crates/groove/src/db/tests.rs
+++ b/crates/groove/src/db/tests.rs
@@ -9012,7 +9012,7 @@ fn persist_maintains_schema_index_entries() {
     let prefix = b"albums\0albums_by_title\0";
     let entries = database.storage.prefix("indices", prefix).unwrap();
     assert_eq!(entries.len(), 1);
-    assert_eq!(persisted_index_value(&entries[0].1), []);
+    assert_eq!(persisted_index_value(&entries[0].1), Vec::<u8>::new());
 
     let mut batch = database.open_batch();
     batch.update(
@@ -9029,7 +9029,7 @@ fn persist_maintains_schema_index_entries() {
             .windows("Giant Steps".len())
             .any(|window| window == b"Giant Steps")
     );
-    assert_eq!(persisted_index_value(&entries[0].1), []);
+    assert_eq!(persisted_index_value(&entries[0].1), Vec::<u8>::new());
 
     let mut batch = database.open_batch();
     batch.delete("albums", PrimaryKeyValue::U64(7));

--- a/crates/groove/src/storage/async_bridge.rs
+++ b/crates/groove/src/storage/async_bridge.rs
@@ -1,0 +1,390 @@
+//! Sync bridge over a natively-async ordered-KV backend.
+//!
+//! [`AsyncOrderedKvStorage`] is the async counterpart of the crate's
+//! [`OrderedKvStorage`] seam. The async backend lives on a dedicated worker
+//! thread that owns its own tokio runtime; [`SyncBridgeStorage`] forwards each
+//! sync call as an owned request over a channel and blocks on the reply. The
+//! engine and its frontends stay synchronous and never touch a reactor: every
+//! future they observe resolves immediately because all real async work has
+//! already completed on the worker thread.
+//!
+//! Scans cross the channel as materialized `Vec<KeyValue>` rather than through
+//! the borrowed [`ScanVisitor`] callback; the bridge replays the vector through
+//! the caller's visitor on the calling thread.
+
+use std::future::Future;
+use std::sync::mpsc::SyncSender;
+use std::thread::JoinHandle;
+
+use super::{
+    ColumnFamilyName, Error, Key, KeyValue, OrderedKvStorage, OwnedWriteOperation,
+    ReopenableStorage, ScanVisitor, Value, WriteOperation,
+};
+
+/// Natively-async ordered KV backend. Implementations live entirely on the
+/// bridge worker thread and need not be `Send`/`Sync`; only request and reply
+/// payloads cross threads.
+#[allow(async_fn_in_trait)]
+pub trait AsyncOrderedKvStorage: Sized + 'static {
+    async fn get(&self, cf: &str, key: &[u8]) -> Result<Option<Vec<u8>>, Error>;
+    async fn set(&self, cf: &str, key: &[u8], value: &[u8]) -> Result<(), Error>;
+    async fn delete(&self, cf: &str, key: &[u8]) -> Result<(), Error>;
+    /// Ascending byte-lexicographic order, start inclusive, end exclusive.
+    async fn scan_range(&self, cf: &str, start: &[u8], end: &[u8]) -> Result<Vec<KeyValue>, Error>;
+    async fn scan_prefix(&self, cf: &str, prefix: &[u8]) -> Result<Vec<KeyValue>, Error>;
+    /// Atomic batch; must reject unknown column families with
+    /// [`Error::ColumnFamilyNotFound`] before writing anything.
+    async fn write_many(&self, operations: Vec<OwnedWriteOperation>) -> Result<(), Error>;
+    async fn close(&self) -> Result<(), Error>;
+    /// Reopen with an expanded column-family set, consuming self like
+    /// [`ReopenableStorage::reopen`].
+    async fn reopen(self, column_families: Vec<String>) -> Result<Self, Error>;
+    fn column_family_names(&self) -> Option<Vec<String>>;
+}
+
+enum Request {
+    Get {
+        cf: String,
+        key: Vec<u8>,
+        reply: SyncSender<Result<Option<Vec<u8>>, Error>>,
+    },
+    Set {
+        cf: String,
+        key: Vec<u8>,
+        value: Vec<u8>,
+        reply: SyncSender<Result<(), Error>>,
+    },
+    Delete {
+        cf: String,
+        key: Vec<u8>,
+        reply: SyncSender<Result<(), Error>>,
+    },
+    ScanRange {
+        cf: String,
+        start: Vec<u8>,
+        end: Vec<u8>,
+        reply: SyncSender<Result<Vec<KeyValue>, Error>>,
+    },
+    ScanPrefix {
+        cf: String,
+        prefix: Vec<u8>,
+        reply: SyncSender<Result<Vec<KeyValue>, Error>>,
+    },
+    WriteMany {
+        operations: Vec<OwnedWriteOperation>,
+        reply: SyncSender<Result<(), Error>>,
+    },
+    ColumnFamilyNames {
+        reply: SyncSender<Option<Vec<String>>>,
+    },
+    Close {
+        reply: SyncSender<Result<(), Error>>,
+    },
+    Reopen {
+        column_families: Vec<String>,
+        reply: SyncSender<Result<(), Error>>,
+    },
+    Shutdown,
+}
+
+/// Sync [`OrderedKvStorage`] facade over an [`AsyncOrderedKvStorage`] running
+/// on a dedicated worker thread.
+pub struct SyncBridgeStorage {
+    request_tx: tokio::sync::mpsc::UnboundedSender<Request>,
+    worker: Option<JoinHandle<()>>,
+}
+
+impl SyncBridgeStorage {
+    /// Spawn the worker thread, run `open` on its runtime, and return once the
+    /// backend is ready. The backend is created on and never leaves the worker
+    /// thread, so neither it nor the open future needs `Send`.
+    pub fn open<A, F, Fut>(open: F) -> Result<Self, Error>
+    where
+        A: AsyncOrderedKvStorage,
+        F: FnOnce() -> Fut + Send + 'static,
+        Fut: Future<Output = Result<A, Error>>,
+    {
+        let (request_tx, request_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (startup_tx, startup_rx) = std::sync::mpsc::sync_channel(1);
+        let worker = std::thread::Builder::new()
+            .name("groove-async-storage".into())
+            .spawn(move || {
+                // One tokio worker thread besides this blocked one so backend
+                // background tasks keep making progress mid-request.
+                let runtime = match tokio::runtime::Builder::new_multi_thread()
+                    .worker_threads(1)
+                    .enable_all()
+                    .build()
+                {
+                    Ok(runtime) => runtime,
+                    Err(err) => {
+                        let _ = startup_tx.send(Err(Error::AsyncBridge(format!(
+                            "failed to build bridge runtime: {err}"
+                        ))));
+                        return;
+                    }
+                };
+                runtime.block_on(async move {
+                    match open().await {
+                        Ok(storage) => {
+                            let _ = startup_tx.send(Ok(()));
+                            worker_loop(storage, request_rx).await;
+                        }
+                        Err(err) => {
+                            let _ = startup_tx.send(Err(err));
+                        }
+                    }
+                });
+            })
+            .map_err(|err| {
+                Error::AsyncBridge(format!("failed to spawn bridge worker thread: {err}"))
+            })?;
+        match startup_rx.recv() {
+            Ok(Ok(())) => Ok(Self {
+                request_tx,
+                worker: Some(worker),
+            }),
+            Ok(Err(err)) => {
+                let _ = worker.join();
+                Err(err)
+            }
+            Err(_) => {
+                let _ = worker.join();
+                Err(Error::AsyncBridge(
+                    "bridge worker exited during startup".into(),
+                ))
+            }
+        }
+    }
+
+    fn roundtrip<T>(&self, build: impl FnOnce(SyncSender<T>) -> Request) -> Result<T, Error> {
+        let (reply_tx, reply_rx) = std::sync::mpsc::sync_channel(1);
+        self.request_tx
+            .send(build(reply_tx))
+            .map_err(|_| Error::AsyncBridge("bridge worker unavailable".into()))?;
+        reply_rx
+            .recv()
+            .map_err(|_| Error::AsyncBridge("bridge worker dropped reply".into()))
+    }
+}
+
+fn storage_closed() -> Error {
+    Error::AsyncBridge("storage closed".into())
+}
+
+async fn worker_loop<A: AsyncOrderedKvStorage>(
+    storage: A,
+    mut requests: tokio::sync::mpsc::UnboundedReceiver<Request>,
+) {
+    let mut storage = Some(storage);
+    while let Some(request) = requests.recv().await {
+        match request {
+            Request::Get { cf, key, reply } => {
+                let result = match storage.as_ref() {
+                    Some(storage) => storage.get(&cf, &key).await,
+                    None => Err(storage_closed()),
+                };
+                let _ = reply.send(result);
+            }
+            Request::Set {
+                cf,
+                key,
+                value,
+                reply,
+            } => {
+                let result = match storage.as_ref() {
+                    Some(storage) => storage.set(&cf, &key, &value).await,
+                    None => Err(storage_closed()),
+                };
+                let _ = reply.send(result);
+            }
+            Request::Delete { cf, key, reply } => {
+                let result = match storage.as_ref() {
+                    Some(storage) => storage.delete(&cf, &key).await,
+                    None => Err(storage_closed()),
+                };
+                let _ = reply.send(result);
+            }
+            Request::ScanRange {
+                cf,
+                start,
+                end,
+                reply,
+            } => {
+                let result = match storage.as_ref() {
+                    Some(storage) => storage.scan_range(&cf, &start, &end).await,
+                    None => Err(storage_closed()),
+                };
+                let _ = reply.send(result);
+            }
+            Request::ScanPrefix { cf, prefix, reply } => {
+                let result = match storage.as_ref() {
+                    Some(storage) => storage.scan_prefix(&cf, &prefix).await,
+                    None => Err(storage_closed()),
+                };
+                let _ = reply.send(result);
+            }
+            Request::WriteMany { operations, reply } => {
+                let result = match storage.as_ref() {
+                    Some(storage) => storage.write_many(operations).await,
+                    None => Err(storage_closed()),
+                };
+                let _ = reply.send(result);
+            }
+            Request::ColumnFamilyNames { reply } => {
+                let _ = reply.send(
+                    storage
+                        .as_ref()
+                        .and_then(AsyncOrderedKvStorage::column_family_names),
+                );
+            }
+            Request::Close { reply } => {
+                let result = match storage.take() {
+                    Some(storage) => storage.close().await,
+                    None => Ok(()),
+                };
+                let _ = reply.send(result);
+            }
+            Request::Reopen {
+                column_families,
+                reply,
+            } => {
+                let result = match storage.take() {
+                    Some(current) => match current.reopen(column_families).await {
+                        Ok(reopened) => {
+                            storage = Some(reopened);
+                            Ok(())
+                        }
+                        Err(err) => Err(err),
+                    },
+                    None => Err(storage_closed()),
+                };
+                let _ = reply.send(result);
+            }
+            Request::Shutdown => break,
+        }
+    }
+    if let Some(storage) = storage.take() {
+        let _ = storage.close().await;
+    }
+}
+
+impl OrderedKvStorage for SyncBridgeStorage {
+    fn get(&self, cf: &ColumnFamilyName, key: &Key) -> Result<Option<Value>, Error> {
+        self.roundtrip(|reply| Request::Get {
+            cf: cf.to_owned(),
+            key: key.to_vec(),
+            reply,
+        })?
+    }
+
+    fn set(&self, cf: &ColumnFamilyName, key: &Key, value: &[u8]) -> Result<(), Error> {
+        self.roundtrip(|reply| Request::Set {
+            cf: cf.to_owned(),
+            key: key.to_vec(),
+            value: value.to_vec(),
+            reply,
+        })?
+    }
+
+    fn delete(&self, cf: &ColumnFamilyName, key: &Key) -> Result<(), Error> {
+        self.roundtrip(|reply| Request::Delete {
+            cf: cf.to_owned(),
+            key: key.to_vec(),
+            reply,
+        })?
+    }
+
+    fn close(&self) -> Result<(), Error> {
+        self.roundtrip(|reply| Request::Close { reply })?
+    }
+
+    fn scan_range(
+        &self,
+        cf: &ColumnFamilyName,
+        start: &Key,
+        end: &Key,
+        visit: &mut ScanVisitor<'_>,
+    ) -> Result<(), Error> {
+        let entries = self.roundtrip(|reply| Request::ScanRange {
+            cf: cf.to_owned(),
+            start: start.to_vec(),
+            end: end.to_vec(),
+            reply,
+        })??;
+        for (key, value) in entries {
+            visit(&key, &value)?;
+        }
+        Ok(())
+    }
+
+    fn scan_prefix(
+        &self,
+        cf: &ColumnFamilyName,
+        prefix: &Key,
+        visit: &mut ScanVisitor<'_>,
+    ) -> Result<(), Error> {
+        let entries = self.roundtrip(|reply| Request::ScanPrefix {
+            cf: cf.to_owned(),
+            prefix: prefix.to_vec(),
+            reply,
+        })??;
+        for (key, value) in entries {
+            visit(&key, &value)?;
+        }
+        Ok(())
+    }
+
+    fn write_many(&self, operations: &[WriteOperation<'_>]) -> Result<(), Error> {
+        let operations = operations.iter().map(owned_write_operation).collect();
+        self.roundtrip(|reply| Request::WriteMany { operations, reply })?
+    }
+
+    fn column_family_names(&self) -> Option<Vec<String>> {
+        self.roundtrip(|reply| Request::ColumnFamilyNames { reply })
+            .ok()
+            .flatten()
+    }
+}
+
+impl ReopenableStorage for SyncBridgeStorage {
+    fn reopen(self, column_families: &[&str]) -> Result<Self, Error> {
+        let column_families = column_families
+            .iter()
+            .map(|cf| (*cf).to_owned())
+            .collect::<Vec<_>>();
+        self.roundtrip(|reply| Request::Reopen {
+            column_families,
+            reply,
+        })??;
+        Ok(self)
+    }
+}
+
+impl Drop for SyncBridgeStorage {
+    fn drop(&mut self) {
+        let _ = self.request_tx.send(Request::Shutdown);
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
+fn owned_write_operation(operation: &WriteOperation<'_>) -> OwnedWriteOperation {
+    match operation {
+        WriteOperation::Set { cf, key, value } => OwnedWriteOperation::Set {
+            cf: (*cf).to_owned(),
+            key: key.to_vec(),
+            value: value.to_vec(),
+        },
+        WriteOperation::Delete { cf, key } => OwnedWriteOperation::Delete {
+            cf: (*cf).to_owned(),
+            key: key.to_vec(),
+        },
+        WriteOperation::Delta { cf, key, delta } => OwnedWriteOperation::Delta {
+            cf: (*cf).to_owned(),
+            key: key.to_vec(),
+            delta: (*delta).clone(),
+        },
+    }
+}

--- a/crates/groove/src/storage/mod.rs
+++ b/crates/groove/src/storage/mod.rs
@@ -12,6 +12,8 @@
 //! implementation lives in [`rocksdb_storage`]; higher layers decide when a
 //! batch is durable and how storage writes relate to an IVM tick.
 
+#[cfg(feature = "slatedb")]
+mod async_bridge;
 #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
 mod key_codec;
 mod memory;
@@ -19,6 +21,9 @@ mod opfs;
 #[cfg(feature = "rocksdb")]
 #[path = "rocksdb.rs"]
 pub mod rocksdb_storage;
+#[cfg(feature = "slatedb")]
+#[path = "slatedb.rs"]
+pub mod slatedb_storage;
 
 use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
@@ -31,6 +36,8 @@ use crate::window_codec::{
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+#[cfg(feature = "slatedb")]
+pub use async_bridge::{AsyncOrderedKvStorage, SyncBridgeStorage};
 pub use memory::MemoryStorage;
 #[cfg(target_arch = "wasm32")]
 pub use opfs::OpfsStorage;
@@ -38,6 +45,8 @@ pub use opfs::OpfsStorage;
 pub use opfs::{BtreeSyncPolicy, NativeBtreeStorage};
 #[cfg(feature = "rocksdb")]
 pub use rocksdb_storage::{Durability, RocksDbStorage};
+#[cfg(feature = "slatedb")]
+pub use slatedb_storage::SlateDbStorage;
 
 pub type ColumnFamilyName = str;
 pub type Key = [u8];
@@ -2330,6 +2339,15 @@ pub enum Error {
     #[cfg(feature = "rocksdb")]
     #[error(transparent)]
     RocksDb(#[from] ::rocksdb::Error),
+    #[cfg(feature = "slatedb")]
+    #[error(transparent)]
+    SlateDb(#[from] Box<::slatedb::Error>),
+    #[cfg(feature = "slatedb")]
+    #[error("slatedb storage: {0}")]
+    SlateDbBackend(String),
+    #[cfg(feature = "slatedb")]
+    #[error("async storage bridge: {0}")]
+    AsyncBridge(String),
     #[error(transparent)]
     Opfs(#[from] opfs_btree::BTreeError),
 }

--- a/crates/groove/src/storage/slatedb.rs
+++ b/crates/groove/src/storage/slatedb.rs
@@ -1,0 +1,379 @@
+//! SlateDB-backed [`AsyncOrderedKvStorage`] implementation (prototype).
+//!
+//! SlateDB is an async LSM engine over `object_store`; this backend runs it on
+//! a `LocalFileSystem` store rooted at a local directory. SlateDB has no native
+//! column families, so families are flattened into one ordered keyspace with
+//! the same [`key_codec`] prefix scheme the opfs-btree backend uses. Writes use
+//! `await_durable: false` so each batch does not stall on the WAL flush
+//! interval; `close` flushes before shutting down. Delta operations are applied
+//! read-modify-write against pre-batch state via [`apply_storage_delta`],
+//! matching the memory and btree backends.
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use ::slatedb::config::{PutOptions, WriteOptions};
+use ::slatedb::object_store::ObjectStore;
+use ::slatedb::object_store::local::LocalFileSystem;
+
+use super::key_codec;
+use super::{
+    AsyncOrderedKvStorage, Error, KeyValue, OwnedWriteOperation, SyncBridgeStorage,
+    apply_storage_delta,
+};
+
+impl From<::slatedb::Error> for Error {
+    fn from(err: ::slatedb::Error) -> Self {
+        Error::SlateDb(Box::new(err))
+    }
+}
+
+pub struct SlateDbStorage {
+    db: ::slatedb::Db,
+    column_families: BTreeSet<String>,
+}
+
+fn write_options() -> WriteOptions {
+    WriteOptions {
+        await_durable: false,
+        ..WriteOptions::default()
+    }
+}
+
+impl SlateDbStorage {
+    /// Open (or create) a SlateDB database rooted at `path`.
+    pub async fn open(path: impl Into<PathBuf>, column_families: &[&str]) -> Result<Self, Error> {
+        let path = path.into();
+        std::fs::create_dir_all(&path)
+            .map_err(|err| Error::SlateDbBackend(format!("create data dir: {err}")))?;
+        let object_store: Arc<dyn ObjectStore> = Arc::new(
+            LocalFileSystem::new_with_prefix(&path)
+                .map_err(|err| Error::SlateDbBackend(format!("open local object store: {err}")))?,
+        );
+        let db = ::slatedb::Db::builder("groove", object_store)
+            .build()
+            .await?;
+        Ok(Self {
+            db,
+            column_families: column_families.iter().map(|cf| (*cf).to_owned()).collect(),
+        })
+    }
+
+    /// Open behind the sync bridge, yielding a storage that satisfies the
+    /// engine's synchronous [`OrderedKvStorage`] seam.
+    ///
+    /// [`OrderedKvStorage`]: super::OrderedKvStorage
+    pub fn open_bridged(
+        path: impl Into<PathBuf>,
+        column_families: &[&str],
+    ) -> Result<SyncBridgeStorage, Error> {
+        let path = path.into();
+        let column_families = column_families
+            .iter()
+            .map(|cf| (*cf).to_owned())
+            .collect::<Vec<_>>();
+        SyncBridgeStorage::open(move || async move {
+            let refs = column_families
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>();
+            Self::open(path, &refs).await
+        })
+    }
+
+    fn ensure_cf(&self, cf: &str) -> Result<(), Error> {
+        if self.column_families.contains(cf) {
+            Ok(())
+        } else {
+            Err(Error::ColumnFamilyNotFound(cf.to_owned()))
+        }
+    }
+
+    fn encoded_key(&self, cf: &str, key: &[u8]) -> Result<Vec<u8>, Error> {
+        self.ensure_cf(cf)?;
+        key_codec::encode_column_family_key(cf, key)
+    }
+
+    async fn collect_encoded_range(
+        &self,
+        start: Vec<u8>,
+        end: Vec<u8>,
+    ) -> Result<Vec<KeyValue>, Error> {
+        if start >= end {
+            // slatedb panics on logically empty scan ranges; equal-bound scans
+            // are legal at this seam and must yield nothing.
+            return Ok(Vec::new());
+        }
+        let mut entries = Vec::new();
+        let mut iterator = self.db.scan(start..end).await?;
+        while let Some(kv) = iterator.next().await? {
+            let (_, user_key) = key_codec::decode_column_family_key(&kv.key)?;
+            entries.push((user_key.to_vec(), kv.value.to_vec()));
+        }
+        Ok(entries)
+    }
+}
+
+impl AsyncOrderedKvStorage for SlateDbStorage {
+    async fn get(&self, cf: &str, key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
+        let key = self.encoded_key(cf, key)?;
+        Ok(self.db.get(&key).await?.map(|value| value.to_vec()))
+    }
+
+    async fn set(&self, cf: &str, key: &[u8], value: &[u8]) -> Result<(), Error> {
+        let key = self.encoded_key(cf, key)?;
+        self.db
+            .put_with_options(&key, value, &PutOptions::default(), &write_options())
+            .await?;
+        Ok(())
+    }
+
+    async fn delete(&self, cf: &str, key: &[u8]) -> Result<(), Error> {
+        let key = self.encoded_key(cf, key)?;
+        self.db.delete_with_options(&key, &write_options()).await?;
+        Ok(())
+    }
+
+    async fn scan_range(&self, cf: &str, start: &[u8], end: &[u8]) -> Result<Vec<KeyValue>, Error> {
+        let start = self.encoded_key(cf, start)?;
+        let end = self.encoded_key(cf, end)?;
+        self.collect_encoded_range(start, end).await
+    }
+
+    async fn scan_prefix(&self, cf: &str, prefix: &[u8]) -> Result<Vec<KeyValue>, Error> {
+        let start = self.encoded_key(cf, prefix)?;
+        let end = key_codec::prefix_upper_bound(&start).unwrap_or_else(|| vec![0xFF]);
+        self.collect_encoded_range(start, end).await
+    }
+
+    async fn write_many(&self, operations: Vec<OwnedWriteOperation>) -> Result<(), Error> {
+        for operation in &operations {
+            let cf = match operation {
+                OwnedWriteOperation::Set { cf, .. }
+                | OwnedWriteOperation::Delete { cf, .. }
+                | OwnedWriteOperation::Delta { cf, .. } => cf,
+            };
+            self.ensure_cf(cf)?;
+        }
+        let mut batch = ::slatedb::WriteBatch::new();
+        for operation in &operations {
+            match operation {
+                OwnedWriteOperation::Set { cf, key, value } => {
+                    batch.put(self.encoded_key(cf, key)?, value);
+                }
+                OwnedWriteOperation::Delete { cf, key } => {
+                    batch.delete(self.encoded_key(cf, key)?);
+                }
+                OwnedWriteOperation::Delta { cf, key, delta } => {
+                    // Same semantics as the memory/btree backends: deltas merge
+                    // against pre-batch state, not earlier ops in this batch.
+                    let encoded_key = self.encoded_key(cf, key)?;
+                    let existing = self.db.get(&encoded_key).await?;
+                    let merged = apply_storage_delta(existing.as_deref(), &delta.encode()?)?;
+                    batch.put(encoded_key, merged);
+                }
+            }
+        }
+        self.db.write_with_options(batch, &write_options()).await?;
+        Ok(())
+    }
+
+    async fn close(&self) -> Result<(), Error> {
+        self.db.flush().await?;
+        self.db.close().await?;
+        Ok(())
+    }
+
+    async fn reopen(mut self, column_families: Vec<String>) -> Result<Self, Error> {
+        // Column families are virtual key prefixes; expanding the set needs no
+        // database reopen (same as the btree backend).
+        self.column_families.extend(column_families);
+        Ok(self)
+    }
+
+    fn column_family_names(&self) -> Option<Vec<String>> {
+        Some(self.column_families.iter().cloned().collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // These are intentionally storage-level tests: byte-lexicographic ordering,
+    // batch atomicity, and delta-merge semantics at the ordered-KV seam are not
+    // meaningfully observable through public database APIs, and every other
+    // backend certifies against the same shared conformance harness.
+    use std::cell::RefCell;
+    use std::collections::BTreeMap;
+    use std::ops::Bound;
+
+    use super::super::conformance;
+    use super::*;
+
+    fn bridged_storage(column_families: &[&str]) -> SyncBridgeStorage {
+        let dir = tempfile::tempdir().unwrap();
+        SlateDbStorage::open_bridged(dir.keep(), column_families).unwrap()
+    }
+
+    #[test]
+    fn slatedb_conforms_to_order_and_atomic_batch_contract() {
+        let storage = bridged_storage(&["records"]);
+        conformance::persistence_order_and_batch_atomicity(storage);
+    }
+
+    #[test]
+    fn slatedb_conforms_to_delta_append_contract() {
+        let storage = bridged_storage(&["records"]);
+        conformance::delta_append_current_winner_observes_merged_state(storage);
+    }
+
+    #[test]
+    fn slatedb_reopen_adds_column_families_without_losing_data() {
+        let storage = bridged_storage(&["records"]);
+        conformance::reopen_preserves_data_and_adds_families(storage);
+    }
+
+    /// Minimal in-memory async backend so bridge bugs can be told apart from
+    /// slatedb bugs.
+    struct ShimStorage {
+        families: RefCell<BTreeMap<String, BTreeMap<Vec<u8>, Vec<u8>>>>,
+    }
+
+    impl ShimStorage {
+        fn new(column_families: &[&str]) -> Self {
+            Self {
+                families: RefCell::new(
+                    column_families
+                        .iter()
+                        .map(|cf| ((*cf).to_owned(), BTreeMap::new()))
+                        .collect(),
+                ),
+            }
+        }
+
+        fn ensure_cf(&self, cf: &str) -> Result<(), Error> {
+            if self.families.borrow().contains_key(cf) {
+                Ok(())
+            } else {
+                Err(Error::ColumnFamilyNotFound(cf.to_owned()))
+            }
+        }
+    }
+
+    impl AsyncOrderedKvStorage for ShimStorage {
+        async fn get(&self, cf: &str, key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
+            self.ensure_cf(cf)?;
+            Ok(self.families.borrow()[cf].get(key).cloned())
+        }
+
+        async fn set(&self, cf: &str, key: &[u8], value: &[u8]) -> Result<(), Error> {
+            self.ensure_cf(cf)?;
+            self.families
+                .borrow_mut()
+                .get_mut(cf)
+                .unwrap()
+                .insert(key.to_vec(), value.to_vec());
+            Ok(())
+        }
+
+        async fn delete(&self, cf: &str, key: &[u8]) -> Result<(), Error> {
+            self.ensure_cf(cf)?;
+            self.families.borrow_mut().get_mut(cf).unwrap().remove(key);
+            Ok(())
+        }
+
+        async fn scan_range(
+            &self,
+            cf: &str,
+            start: &[u8],
+            end: &[u8],
+        ) -> Result<Vec<KeyValue>, Error> {
+            self.ensure_cf(cf)?;
+            Ok(self.families.borrow()[cf]
+                .range::<[u8], _>((Bound::Included(start), Bound::Excluded(end)))
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect())
+        }
+
+        async fn scan_prefix(&self, cf: &str, prefix: &[u8]) -> Result<Vec<KeyValue>, Error> {
+            self.ensure_cf(cf)?;
+            Ok(self.families.borrow()[cf]
+                .range::<[u8], _>((Bound::Included(prefix), Bound::Unbounded))
+                .take_while(|(key, _)| key.starts_with(prefix))
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect())
+        }
+
+        async fn write_many(&self, operations: Vec<OwnedWriteOperation>) -> Result<(), Error> {
+            for operation in &operations {
+                let cf = match operation {
+                    OwnedWriteOperation::Set { cf, .. }
+                    | OwnedWriteOperation::Delete { cf, .. }
+                    | OwnedWriteOperation::Delta { cf, .. } => cf,
+                };
+                self.ensure_cf(cf)?;
+            }
+            for operation in &operations {
+                match operation {
+                    OwnedWriteOperation::Set { cf, key, value } => {
+                        self.set(cf, key, value).await?;
+                    }
+                    OwnedWriteOperation::Delete { cf, key } => {
+                        self.delete(cf, key).await?;
+                    }
+                    OwnedWriteOperation::Delta { cf, key, delta } => {
+                        let existing = self.get(cf, key).await?;
+                        let merged = apply_storage_delta(existing.as_deref(), &delta.encode()?)?;
+                        self.set(cf, key, &merged).await?;
+                    }
+                }
+            }
+            Ok(())
+        }
+
+        async fn close(&self) -> Result<(), Error> {
+            Ok(())
+        }
+
+        async fn reopen(self, column_families: Vec<String>) -> Result<Self, Error> {
+            {
+                let mut families = self.families.borrow_mut();
+                for cf in column_families {
+                    families.entry(cf).or_default();
+                }
+            }
+            Ok(self)
+        }
+
+        fn column_family_names(&self) -> Option<Vec<String>> {
+            Some(self.families.borrow().keys().cloned().collect())
+        }
+    }
+
+    fn bridged_shim(column_families: &[&str]) -> SyncBridgeStorage {
+        let column_families = column_families
+            .iter()
+            .map(|cf| (*cf).to_owned())
+            .collect::<Vec<_>>();
+        SyncBridgeStorage::open(move || async move {
+            let refs = column_families
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>();
+            Ok(ShimStorage::new(&refs))
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn bridge_conforms_with_in_memory_async_backend() {
+        let storage = bridged_shim(&["records"]);
+        conformance::persistence_order_and_batch_atomicity(storage);
+    }
+
+    #[test]
+    fn bridge_reopen_adds_column_families_without_losing_data() {
+        let storage = bridged_shim(&["records"]);
+        conformance::reopen_preserves_data_and_adds_families(storage);
+    }
+}

--- a/dev/benchmarks/jazz-ingest/Cargo.toml
+++ b/dev/benchmarks/jazz-ingest/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "jazz-ingest-bench"
+version = "0.0.0"
+edition = "2024"
+publish = false
+description = "End-to-end Jazz ingestion/cold-load storage benchmark over a cherry-picked storage adapter (USDA plants dataset)."
+
+[[bin]]
+name = "jazz-ingest-bench"
+path = "src/main.rs"
+
+[dependencies]
+# Full Jazz stack with every selectable storage adapter compiled in.
+# `testing` matches the jazz-sim benches and exposes encoded_storage_bytes_for_test.
+jazz = { workspace = true, features = ["rocksdb", "slatedb", "testing"] }
+tempfile = "3"
+
+# Direct storage-engine APIs for the `--raw` layer (no Jazz, no groove seam).
+# Versions match crates/groove/Cargo.toml so both layers exercise the same
+# engine builds. rust-rocksdb is redirected by the workspace [patch.crates-io].
+rocksdb = { package = "rust-rocksdb", version = "0.48.0", default-features = false, features = [
+  "lz4",
+  "zstd",
+] }
+slatedb = { version = "0.14.1", default-features = false, features = ["moka"] }
+tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/dev/benchmarks/jazz-ingest/README.md
+++ b/dev/benchmarks/jazz-ingest/README.md
@@ -1,0 +1,101 @@
+# Jazz ingestion / cold-load storage benchmark
+
+A single-dataset ingestion/cold-load benchmark with **two layers** you can run
+side by side on identical data and identical metrics:
+
+- **`--storage`** — through the **public `jazz::db::Db` API** (real schema,
+  transactions, queries) over a Jazz storage adapter. Measures _Jazz plus the
+  selected storage_: the transaction/encoding path and the footprint Jazz
+  actually produces.
+- **`--raw`** — straight through a storage engine's **own native crate API**
+  (no Jazz, no groove seam), tuned for bulk ingest. Measures the engine itself.
+
+Running both answers "how much of the write time / amplification / query latency
+is Jazz versus the storage engine underneath?" Unlike `dev/benchmarks/storage/`
+(synthetic op-streams behind the `BenchEngine` contract), this bench ingests a
+real dataset end to end.
+
+## Dataset
+
+`data/plantlst.txt` — the public-domain [USDA PLANTS checklist][usda] (~93k
+rows): `Symbol, Synonym Symbol, Scientific Name with Author, Common Name,
+Family`. It is ingested into one `plants` table with five string columns. The
+`(symbol, synonym_symbol)` pair is unique in the data and backs the point-lookup
+query; `family` (550 distinct values) backs the filter query.
+
+[usda]: https://plants.sc.egov.usda.gov/DocumentLibrary/Txt/plantlst.txt
+
+## What it measures
+
+1. **Write time** — wall-clock to insert every record in batched transactions,
+   plus the flush/close cost to make it durable.
+2. **Write amplification** — physical on-disk bytes (`du` of the backend's data
+   directory/file) divided by the logical bytes ingested, reported against both
+   the raw CSV payload and Jazz's own `encoded_storage_bytes_for_test()`.
+3. **Cold-load query latency** — the DB is closed and reopened from disk with
+   cold caches; the reopen cost and a fixed query set are timed reading from
+   cold storage. Each query runs twice so the cold (first) and warm (second)
+   reads are visible. The same eight queries run on both layers and return
+   identical row counts, so latencies are directly comparable:
+
+   | query                       | access pattern                       |
+   | --------------------------- | ------------------------------------ |
+   | `point_by_key`              | exact key lookup                     |
+   | `prefix_scan_AB`            | ordered range `[AB, AC)`             |
+   | `filter_family_Malvaceae`   | non-key equality (full scan)         |
+   | `full_scan`                 | count all rows                       |
+   | `contains_scientific_Carex` | substring match on `scientific_name` |
+   | `common_name_present`       | non-empty-column filter              |
+   | `family_in_set`             | membership in a set of families      |
+   | `top_100_by_symbol`         | first N ordered by `symbol`          |
+
+## Layers and engines
+
+`--storage` (Jazz layer) and `--raw` (native layer) both take a comma-separated
+list and can be combined in one run:
+
+| `--storage` (via Jazz `Db`) | backend                           | cold-load |
+| --------------------------- | --------------------------------- | --------- |
+| `rocksdb`                   | `RocksDbStorage` (WalNoSync)      | yes       |
+| `btree`                     | `NativeBtreeStorage` (opfs-btree) | yes       |
+| `slatedb`                   | `SlateDbStorage` (LSM, prototype) | yes       |
+| `memory`                    | `MemoryStorage` (baseline)        | no (warm) |
+
+| `--raw` (native crate API) | engine                                                | cold-load |
+| -------------------------- | ----------------------------------------------------- | --------- |
+| `rocksdb`                  | `rocksdb` crate: WriteBatch + LZ4/Zstd, block cache   | yes       |
+| `slatedb`                  | `slatedb` crate: async WriteBatch over `object_store` | yes       |
+
+Each run is labelled `jazz:<adapter>` or `raw:<engine>`, and failures are
+isolated so one backend can't abort the comparison.
+
+## Running
+
+```bash
+# Default (no flags): the direct engines — raw:rocksdb and raw:slatedb.
+cargo run --release -p jazz-ingest-bench
+
+# Jazz-vs-native head to head on the same dataset.
+cargo run --release -p jazz-ingest-bench -- --storage rocksdb,slatedb --raw rocksdb,slatedb
+
+# All Jazz adapters on a 20k-row slice, with JSON output.
+cargo run --release -p jazz-ingest-bench -- \
+  --storage memory,rocksdb,btree,slatedb --limit 20000 --json
+
+# Options:
+#   --storage <list>  Jazz adapters:  memory,rocksdb,btree,slatedb
+#   --raw <list>      native engines: rocksdb,slatedb   (default when no flags)
+#   --input <path>    CSV dataset                       (default bundled file)
+#   --batch-size <n>  rows per transaction/write-batch  (default 1000)
+#   --limit <n>       ingest only the first n rows
+#   --json            also emit one JSON line per run
+```
+
+## Caveats
+
+- Cold-load drops Jazz's in-process caches (close + reopen) but does **not**
+  drop the OS page cache — that needs elevated privileges. Numbers are
+  cold-relative-to-process, which is what a fresh `Db::open` sees in practice.
+- `SlateDbStorage` is a prototype backend; treat its numbers as indicative.
+- `encoded_storage_bytes_for_test` is gated by the `jazz` `testing` feature,
+  which this crate enables (as the jazz-sim benches do).

--- a/dev/benchmarks/jazz-ingest/data/.gitignore
+++ b/dev/benchmarks/jazz-ingest/data/.gitignore
@@ -1,0 +1,4 @@
+*
+!.gitignore
+!*.txt
+!*.license

--- a/dev/benchmarks/jazz-ingest/data/plantlst.license
+++ b/dev/benchmarks/jazz-ingest/data/plantlst.license
@@ -1,0 +1,1 @@
+USDA PLANTS Database checklist (plantlst.txt) — public domain (work of the U.S. federal government, 17 U.S.C. § 105). Source: https://plants.sc.egov.usda.gov/DocumentLibrary/Txt/plantlst.txt

--- a/dev/benchmarks/jazz-ingest/src/main.rs
+++ b/dev/benchmarks/jazz-ingest/src/main.rs
@@ -1,0 +1,1047 @@
+//! End-to-end Jazz ingestion / cold-load storage benchmark.
+//!
+//! Ingests the USDA PLANTS checklist (`data/plantlst.txt`, ~93k rows) through
+//! the **public `jazz::db::Db` API** — real schema, real transactions — over a
+//! storage adapter you cherry-pick on the command line, and measures the three
+//! things that matter for storage selection:
+//!
+//! 1. **Write time** — wall-clock to insert every record (batched transactions)
+//!    plus the flush/close cost to make it durable.
+//! 2. **Write amplification** — physical on-disk bytes divided by the logical
+//!    bytes ingested (both the raw CSV payload and Jazz's own encoded size).
+//! 3. **Cold-load query latency** — close the DB, reopen it from disk with cold
+//!    caches, and time a fixed set of queries reading from cold storage.
+//!
+//! The storage adapter is a runtime choice (`--storage rocksdb|btree|slatedb|memory`),
+//! so the same Jazz workload is compared across every backend the engine ships.
+//!
+//! ```text
+//! cargo run --release -p jazz-ingest-bench -- --storage rocksdb
+//! cargo run --release -p jazz-ingest-bench -- --storage rocksdb,btree,slatedb --limit 20000
+//! ```
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use jazz::db::{Db, DbConfig, DbIdentity};
+use jazz::groove::records::Value;
+use jazz::groove::schema::{ColumnSchema, ColumnType};
+use jazz::groove::storage::{
+    Durability, MemoryStorage, NativeBtreeStorage, OrderedKvStorage, ReopenableStorage,
+    RocksDbStorage, SlateDbStorage,
+};
+use jazz::ids::{AuthorId, NodeUuid};
+use jazz::query::{OrderDirection, Query, col, contains, eq, gte, in_list, lit, lt, ne};
+use jazz::schema::{JazzSchema, TableSchema};
+
+const TABLE: &str = "plants";
+const COLUMNS: [&str; 5] = [
+    "symbol",
+    "synonym_symbol",
+    "scientific_name",
+    "common_name",
+    "family",
+];
+
+// Query parameters shared by the Jazz and native layers so both run the exact
+// same workload.
+const SCI_TOKEN: &str = "Carex"; // substring searched in scientific_name
+const FAMILY_SET: [&str; 3] = ["Poaceae", "Asteraceae", "Cyperaceae"];
+const TOP_N: usize = 100;
+
+// ---------------------------------------------------------------------------
+// Dataset
+// ---------------------------------------------------------------------------
+
+/// One CSV record. Column order matches [`COLUMNS`].
+struct Plant {
+    fields: [String; 5],
+}
+
+impl Plant {
+    /// The logical payload size of this row: the sum of its field byte lengths.
+    fn raw_bytes(&self) -> usize {
+        self.fields.iter().map(String::len).sum()
+    }
+
+    /// The row as Jazz cells for `Db::insert` / `tx.insert`.
+    fn cells(&self) -> BTreeMap<String, Value> {
+        COLUMNS
+            .iter()
+            .zip(self.fields.iter())
+            .map(|(name, value)| ((*name).to_owned(), Value::String(value.clone())))
+            .collect()
+    }
+}
+
+/// Parse one RFC-4180-ish line: comma-separated, double-quoted fields, `""` is
+/// a literal quote, commas inside quotes are data. The USDA file quotes every
+/// field and keeps one record per line, so line-based parsing is sufficient.
+fn parse_csv_line(line: &str) -> Vec<String> {
+    let mut fields = Vec::new();
+    let mut cur = String::new();
+    let mut in_quotes = false;
+    let mut chars = line.chars().peekable();
+    while let Some(c) = chars.next() {
+        if in_quotes {
+            if c == '"' {
+                if chars.peek() == Some(&'"') {
+                    cur.push('"');
+                    chars.next();
+                } else {
+                    in_quotes = false;
+                }
+            } else {
+                cur.push(c);
+            }
+        } else {
+            match c {
+                '"' => in_quotes = true,
+                ',' => fields.push(std::mem::take(&mut cur)),
+                _ => cur.push(c),
+            }
+        }
+    }
+    fields.push(cur);
+    fields
+}
+
+fn load_dataset(path: &Path, limit: Option<usize>) -> Vec<Plant> {
+    let text =
+        fs::read_to_string(path).unwrap_or_else(|e| panic!("read dataset {}: {e}", path.display()));
+    let mut plants = Vec::new();
+    for line in text.lines().skip(1) {
+        if line.is_empty() {
+            continue;
+        }
+        let mut cols = parse_csv_line(line);
+        cols.resize(5, String::new());
+        plants.push(Plant {
+            fields: [
+                std::mem::take(&mut cols[0]),
+                std::mem::take(&mut cols[1]),
+                std::mem::take(&mut cols[2]),
+                std::mem::take(&mut cols[3]),
+                std::mem::take(&mut cols[4]),
+            ],
+        });
+        if let Some(limit) = limit
+            && plants.len() >= limit
+        {
+            break;
+        }
+    }
+    plants
+}
+
+// ---------------------------------------------------------------------------
+// Jazz plumbing
+// ---------------------------------------------------------------------------
+
+fn schema() -> JazzSchema {
+    JazzSchema::new([TableSchema::new(
+        TABLE,
+        COLUMNS
+            .iter()
+            .map(|name| ColumnSchema::new(*name, ColumnType::String)),
+    )])
+}
+
+fn open_db<S>(schema: &JazzSchema, storage: S) -> Db<S>
+where
+    S: OrderedKvStorage + ReopenableStorage + 'static,
+{
+    block_on(Db::open(DbConfig::new(
+        schema.clone(),
+        storage,
+        DbIdentity {
+            node: NodeUuid::from_bytes([1u8; 16]),
+            author: AuthorId::SYSTEM,
+        },
+    )))
+    .expect("open db")
+}
+
+/// The query set exercised against cold storage. Each returns a labelled,
+/// prepared-then-read closure so it can be timed against any open `Db`.
+fn queries(sample: &Plant) -> Vec<(String, Query)> {
+    let symbol = sample.fields[0].clone();
+    let synonym = sample.fields[1].clone();
+    vec![
+        // Point lookup: the (symbol, synonym_symbol) pair is unique in the data.
+        (
+            "point_by_key".to_owned(),
+            Query::from(TABLE)
+                .filter(eq(col("symbol"), lit(Value::String(symbol))))
+                .filter(eq(col("synonym_symbol"), lit(Value::String(synonym)))),
+        ),
+        // Range/prefix scan: all symbols in [AB, AC).
+        (
+            "prefix_scan_AB".to_owned(),
+            Query::from(TABLE)
+                .filter(gte(col("symbol"), lit(Value::String("AB".to_owned()))))
+                .filter(lt(col("symbol"), lit(Value::String("AC".to_owned())))),
+        ),
+        // Filter by a non-key column.
+        (
+            "filter_family_Malvaceae".to_owned(),
+            Query::from(TABLE).filter(eq(
+                col("family"),
+                lit(Value::String("Malvaceae".to_owned())),
+            )),
+        ),
+        // Full-table scan.
+        ("full_scan".to_owned(), Query::from(TABLE)),
+        // Substring match on scientific_name.
+        (
+            "contains_scientific_Carex".to_owned(),
+            Query::from(TABLE).filter(contains(
+                col("scientific_name"),
+                lit(Value::String(SCI_TOKEN.to_owned())),
+            )),
+        ),
+        // Rows that have a common name (non-empty column).
+        (
+            "common_name_present".to_owned(),
+            Query::from(TABLE).filter(ne(col("common_name"), lit(Value::String(String::new())))),
+        ),
+        // Membership in a set of families.
+        (
+            "family_in_set".to_owned(),
+            Query::from(TABLE).filter(in_list(
+                col("family"),
+                FAMILY_SET
+                    .iter()
+                    .map(|f| lit(Value::String((*f).to_owned()))),
+            )),
+        ),
+        // First N rows ordered by symbol.
+        (
+            "top_100_by_symbol".to_owned(),
+            Query::from(TABLE)
+                .order_by("symbol", OrderDirection::Asc)
+                .limit(TOP_N),
+        ),
+    ]
+}
+
+fn run_query<S>(db: &Db<S>, query: &Query) -> (Duration, usize)
+where
+    S: OrderedKvStorage + ReopenableStorage + 'static,
+{
+    let prepared = db.prepare_query(query).expect("prepare query");
+    let t = Instant::now();
+    let rows = db.read(&prepared).expect("read query");
+    (t.elapsed(), rows.len())
+}
+
+// ---------------------------------------------------------------------------
+// The benchmark, generic over the storage adapter
+// ---------------------------------------------------------------------------
+
+struct QueryReport {
+    name: String,
+    rows: usize,
+    cold_ms: Option<f64>,
+    warm_ms: f64,
+}
+
+struct Report {
+    adapter: String,
+    rows: usize,
+    batch_size: usize,
+    raw_input_bytes: u64,
+    // `None` when the backend does not report per-column-family byte accounting
+    // (only RocksDB and the in-memory store implement `approximate_class_bytes`).
+    encoded_logical_bytes: Option<u64>,
+    physical_bytes: Option<u64>,
+    write_time: Duration,
+    flush_close_time: Duration,
+    cold_open_time: Option<Duration>,
+    queries: Vec<QueryReport>,
+}
+
+/// `open` reopens storage at a fixed location every call, so the same bytes are
+/// seen on the cold reopen. `location` is the path to `du` for physical size
+/// (a directory for rocksdb/slatedb, a single file for btree); `None` for the
+/// in-memory adapter, which has no on-disk footprint and no cold path.
+fn benchmark<S>(
+    adapter: &str,
+    plants: &[Plant],
+    batch_size: usize,
+    schema: &JazzSchema,
+    location: Option<&Path>,
+    open: impl Fn() -> S,
+) -> Report
+where
+    S: OrderedKvStorage + ReopenableStorage + 'static,
+{
+    let raw_input_bytes = plants.iter().map(|p| p.raw_bytes() as u64).sum();
+
+    // --- Write phase: every record, in batched transactions. ---
+    let db = open_db(schema, open());
+    let t_write = Instant::now();
+    for chunk in plants.chunks(batch_size) {
+        db.transaction(|tx| {
+            for plant in chunk {
+                tx.insert(TABLE, plant.cells())?;
+            }
+            Ok(())
+        })
+        .expect("commit batch");
+    }
+    let write_time = t_write.elapsed();
+
+    // Backends without per-CF byte accounting report 0; treat that as "unknown".
+    let encoded_logical_bytes = match db.encoded_storage_bytes_for_test() {
+        Ok(0) | Err(_) => None,
+        Ok(bytes) => Some(bytes),
+    };
+
+    // --- Query phase. ---
+    let query_set = queries(&plants[0]);
+    let mut queries_out = Vec::new();
+    let (flush_close_time, physical_bytes, cold_open_time);
+
+    if let Some(location) = location {
+        // Persistent: flush + close, measure on-disk size, reopen cold.
+        let t_close = Instant::now();
+        if let Err(e) = db.close() {
+            // The slatedb prototype rejects the clean-close marker write; keep
+            // going so its write/size numbers are still reported.
+            eprintln!("  warning: {adapter} close() failed: {e}");
+        }
+        flush_close_time = t_close.elapsed();
+        // Drop the write DB so its storage releases the on-disk lock before we
+        // reopen the same path cold (RocksDB/btree hold an exclusive handle).
+        drop(db);
+        physical_bytes = Some(dir_size(location));
+
+        let t_open = Instant::now();
+        let cold_db = open_db(schema, open());
+        cold_open_time = Some(t_open.elapsed());
+
+        for (name, query) in &query_set {
+            let (cold, rows) = run_query(&cold_db, query); // first read = cold
+            let (warm, _) = run_query(&cold_db, query); // second read = warm
+            queries_out.push(QueryReport {
+                name: name.clone(),
+                rows,
+                cold_ms: Some(cold.as_secs_f64() * 1e3),
+                warm_ms: warm.as_secs_f64() * 1e3,
+            });
+        }
+        if let Err(e) = cold_db.close() {
+            eprintln!("  warning: {adapter} cold close() failed: {e}");
+        }
+    } else {
+        // In-memory: no disk, no cold path — query the warm DB, then close.
+        physical_bytes = None;
+        cold_open_time = None;
+        for (name, query) in &query_set {
+            let (warm, rows) = run_query(&db, query);
+            queries_out.push(QueryReport {
+                name: name.clone(),
+                rows,
+                cold_ms: None,
+                warm_ms: warm.as_secs_f64() * 1e3,
+            });
+        }
+        let t_close = Instant::now();
+        if let Err(e) = db.close() {
+            eprintln!("  warning: {adapter} close() failed: {e}");
+        }
+        flush_close_time = t_close.elapsed();
+    }
+
+    Report {
+        adapter: adapter.to_owned(),
+        rows: plants.len(),
+        batch_size,
+        raw_input_bytes,
+        encoded_logical_bytes,
+        physical_bytes,
+        write_time,
+        flush_close_time,
+        cold_open_time,
+        queries: queries_out,
+    }
+}
+
+/// Recursive on-disk size of a path (works for a directory or a single file).
+fn dir_size(path: &Path) -> u64 {
+    let Ok(md) = fs::symlink_metadata(path) else {
+        return 0;
+    };
+    if md.is_dir() {
+        let mut total = 0;
+        if let Ok(entries) = fs::read_dir(path) {
+            for entry in entries.flatten() {
+                total += dir_size(&entry.path());
+            }
+        }
+        total
+    } else {
+        md.len()
+    }
+}
+
+fn column_family_refs(schema: &JazzSchema) -> Vec<String> {
+    schema.column_families()
+}
+
+fn dispatch(adapter: &str, plants: &[Plant], batch_size: usize) -> Report {
+    let schema = schema();
+    let cfs = column_family_refs(&schema);
+    let refs: Vec<&str> = cfs.iter().map(String::as_str).collect();
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    match adapter {
+        "memory" => {
+            let refs = refs.clone();
+            benchmark(adapter, plants, batch_size, &schema, None, move || {
+                MemoryStorage::new(&refs)
+            })
+        }
+        "rocksdb" => {
+            let path = dir.path().to_path_buf();
+            let refs = refs.clone();
+            benchmark(
+                adapter,
+                plants,
+                batch_size,
+                &schema,
+                Some(dir.path()),
+                move || {
+                    RocksDbStorage::open_with_durability(&path, &refs, Durability::WalNoSync)
+                        .expect("open rocksdb")
+                },
+            )
+        }
+        "btree" => {
+            let file: PathBuf = dir.path().join("btree.store");
+            let file_for_size = file.clone();
+            let refs = refs.clone();
+            benchmark(
+                adapter,
+                plants,
+                batch_size,
+                &schema,
+                Some(&file_for_size),
+                move || NativeBtreeStorage::open(&file, &refs).expect("open btree"),
+            )
+        }
+        "slatedb" => {
+            let path = dir.path().to_path_buf();
+            let refs = refs.clone();
+            benchmark(
+                adapter,
+                plants,
+                batch_size,
+                &schema,
+                Some(dir.path()),
+                move || SlateDbStorage::open_bridged(path.clone(), &refs).expect("open slatedb"),
+            )
+        }
+        other => {
+            panic!("unknown storage adapter '{other}' (expected memory|rocksdb|btree|slatedb)")
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Direct storage-engine layer (`--raw`): no Jazz, no groove seam. Each engine
+// is driven through its own native crate API, tuned for bulk ingest.
+//
+// A plant becomes one KV pair: the key is `symbol \0 synonym_symbol` (unique and
+// ordered by symbol, so prefix/range scans work), the value is all five fields
+// joined by 0x1F so the family filter can decode without a secondary index —
+// the same "no index, filter is a scan" shape as the Jazz layer.
+// ---------------------------------------------------------------------------
+
+const FIELD_SEP: u8 = 0x1f;
+
+fn plant_key(p: &Plant) -> Vec<u8> {
+    let mut key = Vec::with_capacity(p.fields[0].len() + 1 + p.fields[1].len());
+    key.extend_from_slice(p.fields[0].as_bytes());
+    key.push(0);
+    key.extend_from_slice(p.fields[1].as_bytes());
+    key
+}
+
+fn plant_value(p: &Plant) -> Vec<u8> {
+    p.fields
+        .iter()
+        .map(String::as_bytes)
+        .collect::<Vec<_>>()
+        .join(&[FIELD_SEP][..])
+}
+
+/// Field `idx` (0-based, matching [`COLUMNS`]) out of an encoded value.
+fn value_field(value: &[u8], idx: usize) -> &[u8] {
+    value.split(|b| *b == FIELD_SEP).nth(idx).unwrap_or(&[])
+}
+
+fn is_subslice(haystack: &[u8], needle: &[u8]) -> bool {
+    !needle.is_empty() && haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+// Native-layer predicates mirroring the Jazz-layer queries, applied to a row's
+// encoded value. Kept as plain fns so both engines share them.
+fn pred_family_malvaceae(value: &[u8]) -> bool {
+    value_field(value, 4) == b"Malvaceae"
+}
+fn pred_contains_sci(value: &[u8]) -> bool {
+    is_subslice(value_field(value, 2), SCI_TOKEN.as_bytes())
+}
+fn pred_common_present(value: &[u8]) -> bool {
+    !value_field(value, 3).is_empty()
+}
+fn pred_family_in_set(value: &[u8]) -> bool {
+    let family = value_field(value, 4);
+    FAMILY_SET.iter().any(|f| f.as_bytes() == family)
+}
+
+fn timed(mut f: impl FnMut() -> usize) -> (f64, usize) {
+    let t = Instant::now();
+    let rows = f();
+    (t.elapsed().as_secs_f64() * 1e3, rows)
+}
+
+// --- RocksDB, via the `rocksdb` crate directly. ---
+
+fn rocks_options() -> rocksdb::Options {
+    use rocksdb::{BlockBasedOptions, Cache, DBCompressionType, Options};
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    // Idiomatic bulk-ingest tuning: compression like groove's default profile,
+    // a shared block cache, big write buffers, all cores for flush/compaction.
+    opts.set_compression_type(DBCompressionType::Lz4);
+    opts.set_bottommost_compression_type(DBCompressionType::Zstd);
+    let cores = std::thread::available_parallelism().map_or(4, |n| n.get()) as i32;
+    opts.increase_parallelism(cores);
+    opts.set_write_buffer_size(64 << 20);
+    opts.set_max_write_buffer_number(4);
+    let mut block = BlockBasedOptions::default();
+    block.set_block_cache(&Cache::new_lru_cache(128 << 20));
+    opts.set_block_based_table_factory(&block);
+    opts
+}
+
+fn run_rocksdb_raw(plants: &[Plant], batch_size: usize, dir: &Path) -> Report {
+    use rocksdb::{DB, Direction, IteratorMode, ReadOptions, WriteBatch, WriteOptions};
+
+    let raw_input_bytes = plants.iter().map(|p| p.raw_bytes() as u64).sum();
+    let mut write_opts = WriteOptions::default();
+    write_opts.set_sync(false); // WAL on, no per-commit fsync — matches Jazz's WalNoSync.
+
+    let db = DB::open(&rocks_options(), dir).expect("open rocksdb");
+    let t_write = Instant::now();
+    for chunk in plants.chunks(batch_size) {
+        let mut batch = WriteBatch::default();
+        for p in chunk {
+            batch.put(plant_key(p), plant_value(p));
+        }
+        db.write_opt(&batch, &write_opts).expect("write batch");
+    }
+    let write_time = t_write.elapsed();
+
+    let t_close = Instant::now();
+    db.flush().expect("flush rocksdb");
+    let flush_close_time = t_close.elapsed();
+    drop(db);
+    let physical_bytes = Some(dir_size(dir));
+
+    // Cold reopen.
+    let t_open = Instant::now();
+    let db = DB::open(&rocks_options(), dir).expect("reopen rocksdb");
+    let cold_open_time = Some(t_open.elapsed());
+
+    let key0 = plant_key(&plants[0]);
+    // Full scan applying a value predicate — shared by the filter queries.
+    let scan_pred = |pred: fn(&[u8]) -> bool| {
+        db.iterator(IteratorMode::Start)
+            .filter(|item| item.as_ref().map(|(_, v)| pred(v)).unwrap_or(false))
+            .count()
+    };
+    let point = || db.get(&key0).expect("get").is_some() as usize;
+    let prefix = || {
+        let mut ro = ReadOptions::default();
+        ro.set_iterate_upper_bound(b"AC".to_vec());
+        db.iterator_opt(IteratorMode::From(b"AB", Direction::Forward), ro)
+            .count()
+    };
+    let family = || scan_pred(pred_family_malvaceae);
+    let full = || db.iterator(IteratorMode::Start).count();
+    let contains_sci = || scan_pred(pred_contains_sci);
+    let common = || scan_pred(pred_common_present);
+    let family_set = || scan_pred(pred_family_in_set);
+    // Ordered keys already sort by symbol, so a forward take(N) is the top-N.
+    let top_n = || db.iterator(IteratorMode::Start).take(TOP_N).count();
+
+    let queries = run_query_pair(&[
+        ("point_by_key", &point as &dyn Fn() -> usize),
+        ("prefix_scan_AB", &prefix),
+        ("filter_family_Malvaceae", &family),
+        ("full_scan", &full),
+        ("contains_scientific_Carex", &contains_sci),
+        ("common_name_present", &common),
+        ("family_in_set", &family_set),
+        ("top_100_by_symbol", &top_n),
+    ]);
+    drop(db);
+
+    Report {
+        adapter: "raw:rocksdb".to_owned(),
+        rows: plants.len(),
+        batch_size,
+        raw_input_bytes,
+        encoded_logical_bytes: None,
+        physical_bytes,
+        write_time,
+        flush_close_time,
+        cold_open_time,
+        queries,
+    }
+}
+
+/// Run each `(name, exec)` query cold (first call) then warm (second call).
+fn run_query_pair(specs: &[(&str, &dyn Fn() -> usize)]) -> Vec<QueryReport> {
+    specs
+        .iter()
+        .map(|(name, exec)| {
+            let (cold_ms, rows) = timed(exec);
+            let (warm_ms, _) = timed(exec);
+            QueryReport {
+                name: (*name).to_owned(),
+                rows,
+                cold_ms: Some(cold_ms),
+                warm_ms,
+            }
+        })
+        .collect()
+}
+
+// --- SlateDB, via the `slatedb` crate directly (async). ---
+
+fn run_slatedb_raw(plants: &[Plant], batch_size: usize, dir: &Path) -> Report {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+    rt.block_on(slatedb_raw(plants, batch_size, dir))
+}
+
+async fn slatedb_raw(plants: &[Plant], batch_size: usize, dir: &Path) -> Report {
+    use slatedb::config::WriteOptions;
+    use slatedb::object_store::{ObjectStore, local::LocalFileSystem};
+    use std::sync::Arc;
+
+    let raw_input_bytes = plants.iter().map(|p| p.raw_bytes() as u64).sum();
+    let write_opts = WriteOptions {
+        await_durable: false, // batches don't stall on WAL flush; matches groove.
+        ..Default::default()
+    };
+    let store: Arc<dyn ObjectStore> =
+        Arc::new(LocalFileSystem::new_with_prefix(dir).expect("local fs store"));
+    let db = slatedb::Db::builder("bench", store.clone())
+        .build()
+        .await
+        .expect("open slatedb");
+
+    let t_write = Instant::now();
+    for chunk in plants.chunks(batch_size) {
+        let mut batch = slatedb::WriteBatch::new();
+        for p in chunk {
+            batch.put(plant_key(p), plant_value(p));
+        }
+        db.write_with_options(batch, &write_opts)
+            .await
+            .expect("write batch");
+    }
+    let write_time = t_write.elapsed();
+
+    let t_close = Instant::now();
+    db.flush().await.expect("flush slatedb");
+    db.close().await.expect("close slatedb");
+    let flush_close_time = t_close.elapsed();
+    let physical_bytes = Some(dir_size(dir));
+
+    // Cold reopen.
+    let t_open = Instant::now();
+    let db = slatedb::Db::builder("bench", store.clone())
+        .build()
+        .await
+        .expect("reopen slatedb");
+    let cold_open_time = Some(t_open.elapsed());
+
+    let key0 = plant_key(&plants[0]);
+    let full_range = vec![0u8]..vec![0xffu8];
+    let prefix_range = b"AB".to_vec()..b"AC".to_vec();
+
+    async fn count_scan(db: &slatedb::Db, range: std::ops::Range<Vec<u8>>) -> usize {
+        let mut iter = db.scan(range).await.expect("scan");
+        let mut n = 0;
+        while iter.next().await.expect("scan next").is_some() {
+            n += 1;
+        }
+        n
+    }
+    async fn count_where(
+        db: &slatedb::Db,
+        range: std::ops::Range<Vec<u8>>,
+        pred: fn(&[u8]) -> bool,
+    ) -> usize {
+        let mut iter = db.scan(range).await.expect("scan");
+        let mut n = 0;
+        while let Some(kv) = iter.next().await.expect("scan next") {
+            if pred(&kv.value) {
+                n += 1;
+            }
+        }
+        n
+    }
+    async fn count_take_n(db: &slatedb::Db, range: std::ops::Range<Vec<u8>>, take: usize) -> usize {
+        let mut iter = db.scan(range).await.expect("scan");
+        let mut n = 0;
+        while n < take && iter.next().await.expect("scan next").is_some() {
+            n += 1;
+        }
+        n
+    }
+
+    let mut queries = Vec::new();
+    // Time an async query expression cold (first eval) then warm (second eval).
+    macro_rules! timed_query {
+        ($name:expr, $body:expr) => {{
+            let t = Instant::now();
+            let rows = $body;
+            let cold = t.elapsed().as_secs_f64() * 1e3;
+            let t = Instant::now();
+            let _ = $body;
+            let warm = t.elapsed().as_secs_f64() * 1e3;
+            queries.push(QueryReport {
+                name: $name.to_owned(),
+                rows,
+                cold_ms: Some(cold),
+                warm_ms: warm,
+            });
+        }};
+    }
+    timed_query!(
+        "point_by_key",
+        db.get(&key0).await.expect("get").is_some() as usize
+    );
+    timed_query!(
+        "prefix_scan_AB",
+        count_scan(&db, prefix_range.clone()).await
+    );
+    timed_query!(
+        "filter_family_Malvaceae",
+        count_where(&db, full_range.clone(), pred_family_malvaceae).await
+    );
+    timed_query!("full_scan", count_scan(&db, full_range.clone()).await);
+    timed_query!(
+        "contains_scientific_Carex",
+        count_where(&db, full_range.clone(), pred_contains_sci).await
+    );
+    timed_query!(
+        "common_name_present",
+        count_where(&db, full_range.clone(), pred_common_present).await
+    );
+    timed_query!(
+        "family_in_set",
+        count_where(&db, full_range.clone(), pred_family_in_set).await
+    );
+    timed_query!(
+        "top_100_by_symbol",
+        count_take_n(&db, full_range.clone(), TOP_N).await
+    );
+
+    db.close().await.expect("close cold slatedb");
+
+    Report {
+        adapter: "raw:slatedb".to_owned(),
+        rows: plants.len(),
+        batch_size,
+        raw_input_bytes,
+        encoded_logical_bytes: None,
+        physical_bytes,
+        write_time,
+        flush_close_time,
+        cold_open_time,
+        queries,
+    }
+}
+
+fn dispatch_raw(engine: &str, plants: &[Plant], batch_size: usize) -> Report {
+    let dir = tempfile::tempdir().expect("tempdir");
+    match engine {
+        "rocksdb" => run_rocksdb_raw(plants, batch_size, dir.path()),
+        "slatedb" => run_slatedb_raw(plants, batch_size, dir.path()),
+        other => panic!("unknown raw engine '{other}' (expected rocksdb|slatedb)"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Reporting
+// ---------------------------------------------------------------------------
+
+fn print_report(report: &Report) {
+    let rows = report.rows as f64;
+    let write_s = report.write_time.as_secs_f64();
+    let throughput = if write_s > 0.0 { rows / write_s } else { 0.0 };
+    let amp = |n: u64, d: u64| if d > 0 { n as f64 / d as f64 } else { f64::NAN };
+
+    println!("\n═══ {} ═══", report.adapter);
+    println!("  rows                 {}", report.rows);
+    println!("  batch size           {}", report.batch_size);
+    println!(
+        "  write time           {:.3} s   ({:.0} rows/s)",
+        write_s, throughput
+    );
+    println!(
+        "  flush + close        {:.3} s",
+        report.flush_close_time.as_secs_f64()
+    );
+    if let Some(open) = report.cold_open_time {
+        println!("  cold reopen (Db)     {:.3} s", open.as_secs_f64());
+    }
+    println!(
+        "  raw input bytes      {:>12}  ({:.1} MiB)",
+        report.raw_input_bytes,
+        report.raw_input_bytes as f64 / (1024.0 * 1024.0)
+    );
+    match report.encoded_logical_bytes {
+        Some(enc) => println!(
+            "  encoded logical      {:>12}  ({:.1} MiB)",
+            enc,
+            enc as f64 / (1024.0 * 1024.0)
+        ),
+        None => println!("  encoded logical      n/a (backend has no byte accounting)"),
+    }
+    match report.physical_bytes {
+        Some(phys) => {
+            println!(
+                "  physical on disk     {:>12}  ({:.1} MiB)",
+                phys,
+                phys as f64 / (1024.0 * 1024.0)
+            );
+            let vs_encoded = match report.encoded_logical_bytes {
+                Some(enc) => format!("{:.2}× vs encoded", amp(phys, enc)),
+                None => "n/a vs encoded".to_owned(),
+            };
+            println!(
+                "  amplification        {:.2}× vs raw input   {}",
+                amp(phys, report.raw_input_bytes),
+                vs_encoded
+            );
+        }
+        None => println!("  physical on disk     n/a (in-memory)"),
+    }
+    println!("  queries:");
+    for q in &report.queries {
+        match q.cold_ms {
+            Some(cold) => println!(
+                "    {:<28} {:>7} rows   cold {:>8.3} ms   warm {:>8.3} ms",
+                q.name, q.rows, cold, q.warm_ms
+            ),
+            None => println!(
+                "    {:<28} {:>7} rows   warm {:>8.3} ms",
+                q.name, q.rows, q.warm_ms
+            ),
+        }
+    }
+}
+
+fn print_json(report: &Report) {
+    let amp = |n: u64, d: u64| if d > 0 { n as f64 / d as f64 } else { f64::NAN };
+    let mut q_json = Vec::new();
+    for q in &report.queries {
+        let cold = match q.cold_ms {
+            Some(c) => format!("{c:.3}"),
+            None => "null".to_owned(),
+        };
+        q_json.push(format!(
+            "{{\"name\":\"{}\",\"rows\":{},\"cold_ms\":{},\"warm_ms\":{:.3}}}",
+            q.name, q.rows, cold, q.warm_ms
+        ));
+    }
+    let (phys, amp_raw, amp_enc) = match report.physical_bytes {
+        Some(p) => (
+            p.to_string(),
+            format!("{:.4}", amp(p, report.raw_input_bytes)),
+            match report.encoded_logical_bytes {
+                Some(enc) => format!("{:.4}", amp(p, enc)),
+                None => "null".to_owned(),
+            },
+        ),
+        None => ("null".to_owned(), "null".to_owned(), "null".to_owned()),
+    };
+    let encoded = match report.encoded_logical_bytes {
+        Some(enc) => enc.to_string(),
+        None => "null".to_owned(),
+    };
+    let cold_open = match report.cold_open_time {
+        Some(d) => format!("{:.4}", d.as_secs_f64()),
+        None => "null".to_owned(),
+    };
+    println!(
+        "JSON {{\"adapter\":\"{}\",\"rows\":{},\"batch_size\":{},\"write_time_s\":{:.4},\"flush_close_s\":{:.4},\"cold_open_s\":{},\"raw_input_bytes\":{},\"encoded_logical_bytes\":{},\"physical_bytes\":{},\"amp_vs_raw\":{},\"amp_vs_encoded\":{},\"queries\":[{}]}}",
+        report.adapter,
+        report.rows,
+        report.batch_size,
+        report.write_time.as_secs_f64(),
+        report.flush_close_time.as_secs_f64(),
+        cold_open,
+        report.raw_input_bytes,
+        encoded,
+        phys,
+        amp_raw,
+        amp_enc,
+        q_json.join(","),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+struct Args {
+    storage: Vec<String>,
+    raw: Vec<String>,
+    input: PathBuf,
+    batch_size: usize,
+    limit: Option<usize>,
+    json: bool,
+}
+
+fn parse_args() -> Args {
+    let default_input = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("data/plantlst.txt");
+    let mut args = Args {
+        storage: Vec::new(),
+        raw: Vec::new(),
+        input: default_input,
+        batch_size: 1000,
+        limit: None,
+        json: false,
+    };
+    let mut it = std::env::args().skip(1);
+    while let Some(arg) = it.next() {
+        match arg.as_str() {
+            "--storage" => {
+                let v = it.next().expect("--storage needs a value");
+                args.storage = v.split(',').map(|s| s.trim().to_owned()).collect();
+            }
+            "--raw" => {
+                let v = it.next().expect("--raw needs a value");
+                args.raw = v.split(',').map(|s| s.trim().to_owned()).collect();
+            }
+            "--input" => args.input = PathBuf::from(it.next().expect("--input needs a path")),
+            "--batch-size" => {
+                args.batch_size = it
+                    .next()
+                    .expect("--batch-size needs a number")
+                    .parse()
+                    .expect("--batch-size must be a number");
+            }
+            "--limit" => {
+                args.limit = Some(
+                    it.next()
+                        .expect("--limit needs a number")
+                        .parse()
+                        .expect("--limit must be a number"),
+                );
+            }
+            "--json" => args.json = true,
+            "-h" | "--help" => {
+                eprintln!(
+                    "jazz-ingest-bench — storage ingestion/cold-load benchmark (USDA plants)\n\
+                     \n\
+                     Two layers on the same dataset and metrics:\n\
+                     \x20 --storage <list>  through the Jazz Db API: memory,rocksdb,btree,slatedb\n\
+                     \x20 --raw <list>      direct native engine API (no Jazz): rocksdb,slatedb\n\
+                     (with neither flag, defaults to --raw rocksdb,slatedb)\n\
+                     \n\
+                     Options:\n\
+                     \x20 --input <path>    CSV dataset (default bundled USDA plantlst.txt)\n\
+                     \x20 --batch-size <n>  rows per transaction/write-batch (default 1000)\n\
+                     \x20 --limit <n>       ingest only the first n rows\n\
+                     \x20 --json            also emit one machine-readable JSON line per run"
+                );
+                std::process::exit(0);
+            }
+            other => panic!("unknown argument '{other}' (try --help)"),
+        }
+    }
+    args
+}
+
+fn main() {
+    let mut args = parse_args();
+    if args.storage.is_empty() && args.raw.is_empty() {
+        args.raw = vec!["rocksdb".to_owned(), "slatedb".to_owned()];
+    }
+    let plants = load_dataset(&args.input, args.limit);
+    assert!(
+        !plants.is_empty(),
+        "dataset is empty: {}",
+        args.input.display()
+    );
+    println!(
+        "loaded {} records from {} ({} rows/batch)",
+        plants.len(),
+        args.input.display(),
+        args.batch_size
+    );
+
+    // Jazz-layer adapters first, then direct engines. Each run is isolated so
+    // one failure (e.g. the slatedb prototype) does not abort the comparison.
+    let emit = |report: &Report| {
+        print_report(report);
+        if args.json {
+            print_json(report);
+        }
+    };
+
+    for adapter in &args.storage {
+        let label = format!("jazz:{adapter}");
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut report = dispatch(adapter, &plants, args.batch_size);
+            report.adapter = label.clone();
+            report
+        }));
+        match result {
+            Ok(report) => emit(&report),
+            Err(_) => eprintln!("\n═══ {label} ═══\n  FAILED (see panic above)"),
+        }
+    }
+
+    for engine in &args.raw {
+        let label = format!("raw:{engine}");
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            dispatch_raw(engine, &plants, args.batch_size)
+        }));
+        match result {
+            Ok(report) => emit(&report),
+            Err(_) => eprintln!("\n═══ {label} ═══\n  FAILED (see panic above)"),
+        }
+    }
+}
+
+/// Minimal executor: drive an async future to completion by busy-polling with a
+/// no-op waker. Storage that actually suspends (SlateDB) does so on its own
+/// bridge thread, so this never spins forever waiting on real I/O. Copied from
+/// the jazz-sim benches (`customer_cold_start.rs`).
+fn block_on<F: std::future::Future>(future: F) -> F::Output {
+    let waker = std::task::Waker::noop();
+    let mut cx = std::task::Context::from_waker(waker);
+    let mut future = std::pin::pin!(future);
+    loop {
+        if let std::task::Poll::Ready(value) = future.as_mut().poll(&mut cx) {
+            return value;
+        }
+    }
+}


### PR DESCRIPTION
Stacked on top of #1094 (`codex/jazz-core-engine-swap`). **Draft** — depends on that branch's storage-engine work (the slatedb backend and the `jazz` `slatedb` feature), which is still in progress there.

## What this adds

A standalone benchmark crate `dev/benchmarks/jazz-ingest` that ingests the public-domain USDA PLANTS checklist (~93k rows) and measures **write time**, **write amplification**, and **cold-load query latency** — at two layers on the same dataset and metrics:

- **`--storage`** — through the public `jazz::db::Db` API (real schema, batched transactions, one-shot reads) over a cherry-picked adapter: `memory`, `rocksdb`, `btree`, `slatedb`.
- **`--raw`** — straight through each storage engine's own native crate API (`rocksdb`, `slatedb`), tuned for bulk ingest, bypassing Jazz and the groove seam entirely.

Both layers run the same eight queries (point lookup, prefix scan, non-key filters, substring, in-list, ordered top-N) and return **identical row counts**, so the numbers are directly comparable.

## Why

To attribute cost: how much of write time / amplification / query latency is Jazz's encoding + transaction path versus the storage engine underneath. Example finding on the full dataset — RocksDB via its own API ingests at ~6M rows/s with 0.77× amplification, versus ~47k rows/s and 14× through Jazz on the same engine.

## Scope / notes

- Additive only: one new crate + one workspace-member line in the root `Cargo.toml`. No existing source touched.
- `Cargo.lock` is intentionally **not** included here — the base branch's lockfile is mid-flight; it will pick up this crate's entry when the base lands.
- The 7 MB USDA fixture is committed (public domain, work of the US federal government) with a license note, mirroring the existing `dev/benchmarks/storage/data` convention.
- Builds warning-clean; passes `clippy -D warnings` (enforced by the pre-commit hook).
