### PR TITLE
fix: properly enforce complex OR permissions in client writes

### DIFF
--- a/crates/jazz-tools/src/query_manager/graph_nodes/policy_eval.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/policy_eval.rs
@@ -399,12 +399,18 @@ impl<'a> PolicyContextEvaluator<'a> {
         let parent_table_name = *parent_table;
         let parent_row = match row_loader(parent_id, Some(parent_table_name)) {
             Some(content) => content,
-            None => return false,
+            None => {
+                visited.remove(&parent_id);
+                return false;
+            }
         };
 
         let parent_schema = match self.schema.get(&parent_table_name) {
             Some(schema) => schema,
-            None => return false,
+            None => {
+                visited.remove(&parent_id);
+                return false;
+            }
         };
 
         let parent_policy = match operation {
@@ -414,29 +420,30 @@ impl<'a> PolicyContextEvaluator<'a> {
             Operation::Delete => parent_schema.policies.effective_delete_using(),
         };
 
-        let parent_policy = match parent_policy {
-            Some(p) => p,
-            None => return false,
+        let result = match parent_policy {
+            Some(parent_policy) => {
+                let parent_row = Row::new(
+                    parent_id,
+                    parent_row.data,
+                    parent_row.batch_id,
+                    parent_row.row_provenance,
+                );
+                self.evaluate_expr_with_context(
+                    parent_policy,
+                    operation,
+                    &parent_row,
+                    &parent_schema.columns,
+                    parent_table_name.as_str(),
+                    io,
+                    row_loader,
+                    depth + 1,
+                    visited,
+                    visited_referencing,
+                )
+            }
+            None => !self.row_policy_mode.denies_missing_explicit_policy(),
         };
-
-        let parent_row = Row::new(
-            parent_id,
-            parent_row.data,
-            parent_row.batch_id,
-            parent_row.row_provenance,
-        );
-        let result = self.evaluate_expr_with_context(
-            parent_policy,
-            operation,
-            &parent_row,
-            &parent_schema.columns,
-            parent_table_name.as_str(),
-            io,
-            row_loader,
-            depth + 1,
-            visited,
-            visited_referencing,
-        );
+        visited.remove(&parent_id);
         if let Some(cache_key) = cache_key
             && let Some(cache) = self.settlement_eval_cache.as_mut()
         {

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -361,11 +361,6 @@ pub(super) struct WriteTableCacheEntry {
     pub(super) indexed_columns: Option<Arc<Vec<ColumnName>>>,
     pub(super) row_layout: Arc<crate::row_format::CompiledRowLayout>,
     pub(super) row_locator: RowLocator,
-    pub(super) insert_policy: Option<Arc<PolicyExpr>>,
-    pub(super) update_using_policy: Option<Arc<PolicyExpr>>,
-    pub(super) update_check_policy: Option<Arc<PolicyExpr>>,
-    pub(super) delete_using_policy: Option<Arc<PolicyExpr>>,
-    pub(super) select_policy: Option<Arc<PolicyExpr>>,
 }
 
 /// Server-side query subscription state.
@@ -572,8 +567,8 @@ pub struct QueryManager {
     /// Application id for catalogue schema persistence, when available.
     pub(super) catalogue_app_id: Option<String>,
 
-    /// Per-schema, per-table write metadata cached to avoid cloning policy
-    /// trees and descriptors on every hot write.
+    /// Per-schema, per-table write metadata cached to avoid cloning descriptors
+    /// on every hot write.
     pub(super) write_table_cache: HashMap<(SchemaHash, TableName), Arc<WriteTableCacheEntry>>,
 }
 

--- a/crates/jazz-tools/src/query_manager/policy_graph.rs
+++ b/crates/jazz-tools/src/query_manager/policy_graph.rs
@@ -41,7 +41,6 @@ pub struct PolicyGraph {
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct PolicyGraphBuildOptions<'a> {
     branch: &'a str,
-    initial_depth: usize,
     row_policy_mode: RowPolicyMode,
 }
 
@@ -49,14 +48,8 @@ impl<'a> PolicyGraphBuildOptions<'a> {
     pub(crate) fn new(branch: &'a str, row_policy_mode: RowPolicyMode) -> Self {
         Self {
             branch,
-            initial_depth: 0,
             row_policy_mode,
         }
-    }
-
-    pub(crate) fn with_initial_depth(mut self, initial_depth: usize) -> Self {
-        self.initial_depth = initial_depth;
-        self
     }
 }
 
@@ -136,7 +129,6 @@ impl PolicyGraph {
             schema.clone(),
             table.as_str(),
             PolicyFilterOptions::for_branch(options.branch)
-                .with_initial_depth(options.initial_depth)
                 .with_row_policy_mode(options.row_policy_mode),
         );
         let policy_id = graph.add_node_with_id(GraphNode::PolicyFilter(policy_node));
@@ -154,30 +146,6 @@ impl PolicyGraph {
             exists_node: exists_id,
             table: *table,
         })
-    }
-
-    /// Create a graph for INHERITS: does parent row pass parent's policy?
-    ///
-    /// Graph structure: IndexScan(parent_table, _id = parent_id) → Materialize → PolicyFilter → ExistsOutput
-    ///
-    /// Returns None if the parent table is not in the schema.
-    pub(crate) fn for_inherits(
-        parent_table: &TableName,
-        parent_id: ObjectId,
-        parent_policy: &PolicyExpr,
-        session: &Session,
-        schema: &Schema,
-        options: PolicyGraphBuildOptions<'_>,
-    ) -> Option<Self> {
-        // INHERITS is essentially the same as a USING check on the parent table
-        Self::for_using_check_with_options(
-            parent_table,
-            parent_id,
-            parent_policy,
-            session,
-            schema,
-            options,
-        )
     }
 
     /// Create a graph for EXISTS: does any row in table match condition?

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -14,13 +14,11 @@ use crate::sync_manager::{
 };
 
 use super::manager::{QueryManager, SchemaWarningAccumulator, ServerQuerySubscription};
-use super::policy::{ComplexClause, Operation, PolicyExpr};
-use super::policy_graph::{PolicyGraph, PolicyGraphBuildOptions};
+use super::policy::{Operation, PolicyExpr};
 use super::session::Session;
 use super::settlement_eval_cache::SettlementEvalCache;
 use super::types::{
-    ComposedBranchName, LoadedRow, Row, RowDescriptor, Schema, SchemaHash, TableName, TableSchema,
-    Value,
+    ComposedBranchName, LoadedRow, Row, Schema, SchemaHash, TableName, TableSchema,
 };
 
 const MAX_INITIAL_QUERY_REPLAY_OUTBOX_PER_PASS: usize = 32;
@@ -1966,124 +1964,6 @@ impl QueryManager {
         }
 
         self.sync_manager.approve_permission_check(storage, check);
-    }
-
-    /// Create policy graphs for complex clauses (INHERITS/EXISTS).
-    #[allow(clippy::too_many_arguments)]
-    pub(super) fn create_policy_graphs_for_complex_clauses(
-        &self,
-        clauses: &[ComplexClause],
-        content: &[u8],
-        descriptor: &RowDescriptor,
-        table: &TableName,
-        operation: Operation,
-        session: &Session,
-        branch: &str,
-    ) -> Option<Vec<PolicyGraph>> {
-        let mut graphs = Vec::new();
-
-        for clause in clauses {
-            match clause {
-                ComplexClause::Inherits {
-                    operation,
-                    via_column,
-                    max_depth: _,
-                } => {
-                    // Get the FK column to find the parent
-                    let col_idx = match descriptor.column_index(via_column) {
-                        Some(idx) => idx,
-                        None => continue, // Column not found
-                    };
-
-                    // Get the referenced table
-                    let parent_table = match &descriptor.columns[col_idx].references {
-                        Some(t) => *t,
-                        None => continue, // No FK reference
-                    };
-
-                    // Check if FK is NULL - if so, INHERITS passes
-                    if super::encoding::column_is_null(descriptor, content, col_idx)
-                        .unwrap_or(false)
-                    {
-                        continue;
-                    }
-
-                    // Decode the FK value to get parent ObjectId
-                    let parent_id =
-                        match super::encoding::decode_column(descriptor, content, col_idx) {
-                            Ok(Value::Uuid(id)) => id,
-                            _ => continue, // Can't decode FK
-                        };
-
-                    // Get parent's policy for the specified operation
-                    let parent_schema = self.schema.get(&parent_table)?;
-
-                    let parent_policy = match operation {
-                        Operation::Select => parent_schema.policies.select_policy(),
-                        Operation::Insert => parent_schema.policies.insert_policy(),
-                        Operation::Update => parent_schema.policies.update_using_policy(),
-                        Operation::Delete => parent_schema.policies.effective_delete_using(),
-                    };
-                    let Some(parent_policy) = parent_policy else {
-                        if self.row_policy_mode.denies_missing_explicit_policy() {
-                            return None;
-                        }
-                        continue;
-                    };
-
-                    // Create policy graph for INHERITS
-                    if let Some(graph) = PolicyGraph::for_inherits(
-                        &parent_table,
-                        parent_id,
-                        parent_policy,
-                        session,
-                        &self.schema,
-                        PolicyGraphBuildOptions::new(branch, self.row_policy_mode)
-                            .with_initial_depth(1),
-                    ) {
-                        graphs.push(graph);
-                    } else {
-                        return None;
-                    }
-                }
-                ComplexClause::Exists { table, condition } => {
-                    let target_table = TableName::new(table);
-                    if let Some(graph) = PolicyGraph::for_exists(
-                        &target_table,
-                        condition,
-                        session,
-                        &self.schema,
-                        branch,
-                        operation,
-                        self.row_policy_mode,
-                    ) {
-                        graphs.push(graph);
-                    } else {
-                        return None;
-                    }
-                }
-                ComplexClause::ExistsRel { rel } => {
-                    if let Some(graph) = PolicyGraph::for_exists_rel(
-                        rel,
-                        &self.schema,
-                        branch,
-                        Some(session.clone()),
-                        self.row_policy_mode,
-                        Some(table),
-                        false,
-                    ) {
-                        graphs.push(graph);
-                    } else {
-                        return None;
-                    }
-                }
-                ComplexClause::InheritsReferencing { .. } => {
-                    // Evaluated directly in write permission checks (needs target row context).
-                }
-            }
-        }
-
-        Some(graphs)
     }
 
     /// Settle active policy checks and finalize completed ones.

--- a/crates/jazz-tools/src/query_manager/writes.rs
+++ b/crates/jazz-tools/src/query_manager/writes.rs
@@ -16,16 +16,17 @@ use crate::storage::{
 };
 use crate::sync_manager::RowBatchKey;
 
-use super::encoding::{decode_column, decode_row, encode_row};
+use super::encoding::{decode_row, encode_row};
+use super::graph_nodes::policy_eval::PolicyContextEvaluator;
 use super::manager::{
     DeleteHandle, InsertResult, QueryError, QueryManager, SchemaWarningAccumulator,
     WriteTableCacheEntry,
 };
-use super::policy::{ComplexClause, Operation, evaluate_simple_parts_with_row_id};
+use super::policy::Operation;
 use super::server_queries::{AuthorizationPolicyRequest, RowTransformContext};
 use super::session::{AuthMode, Session, WriteContext};
 use super::types::{
-    ColumnName, ColumnType, ComposedBranchName, LoadedRow, RowDescriptor, Schema, SchemaHash,
+    ColumnName, ColumnType, ComposedBranchName, LoadedRow, Row, RowDescriptor, Schema, SchemaHash,
     TableName, Value,
 };
 
@@ -113,23 +114,6 @@ impl QueryManager {
                 table: table_name.as_str().to_string().into(),
                 origin_schema_hash: Some(schema_hash),
             },
-            insert_policy: table_schema.policies.insert_policy().cloned().map(Arc::new),
-            update_using_policy: table_schema
-                .policies
-                .update_using_policy()
-                .cloned()
-                .map(Arc::new),
-            update_check_policy: table_schema
-                .policies
-                .update_check_policy()
-                .cloned()
-                .map(Arc::new),
-            delete_using_policy: table_schema
-                .policies
-                .effective_delete_using()
-                .cloned()
-                .map(Arc::new),
-            select_policy: table_schema.policies.select_policy().cloned().map(Arc::new),
         });
         self.write_table_cache.insert(cache_key, entry.clone());
         Ok(entry)
@@ -690,11 +674,14 @@ impl QueryManager {
             old_provenance_for_policy,
         } = write;
         let table_name = TableName::new(table);
+        let table_schema = write_schema
+            .get(&table_name)
+            .ok_or(QueryError::TableNotFound(table_name))?;
+        let using_policy = table_schema.policies.update_using_policy();
+        let check_policy = table_schema.policies.update_check_policy();
         let table_write =
             self.write_table_cache_entry_for_schema(branch, table_name, write_schema)?;
         let descriptor = table_write.descriptor.as_ref();
-        let using_policy = table_write.update_using_policy.as_deref();
-        let check_policy = table_write.update_check_policy.as_deref();
 
         if values.len() != descriptor.columns.len() {
             return Err(QueryError::ColumnCountMismatch {
@@ -785,7 +772,7 @@ impl QueryManager {
                         operation: Operation::Update,
                     });
                 }
-                if let Some(policy) = &using_policy {
+                if let Some(policy) = using_policy {
                     let mut visited = HashSet::new();
                     if !self.evaluate_policy_for_content_with_context_for_row(
                         storage,
@@ -1056,10 +1043,13 @@ impl QueryManager {
         deny_anonymous_writes: bool,
     ) -> Result<InsertResult, QueryError> {
         let table_name = TableName::new(table);
+        let table_schema = write_schema
+            .get(&table_name)
+            .ok_or(QueryError::TableNotFound(table_name))?;
+        let insert_policy = table_schema.policies.insert_policy();
         let table_write =
             self.write_table_cache_entry_for_schema(branch, table_name, write_schema)?;
         let descriptor = table_write.descriptor.as_ref();
-        let insert_policy = table_write.insert_policy.as_deref();
 
         if values.len() != descriptor.columns.len() {
             return Err(QueryError::ColumnCountMismatch {
@@ -1379,103 +1369,13 @@ impl QueryManager {
         depth: usize,
         visited: &mut HashSet<(TableName, ObjectId, Operation)>,
     ) -> bool {
-        self.evaluate_policy_for_content_with_context_inner(
-            storage,
-            policy,
-            content,
-            provenance,
-            descriptor,
-            session,
-            table,
-            branch,
-            operation,
-            Some(row_id),
-            depth,
-            visited,
-        )
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn evaluate_policy_for_content_with_context_inner<H: Storage>(
-        &mut self,
-        storage: &mut H,
-        policy: &crate::query_manager::policy::PolicyExpr,
-        content: &[u8],
-        provenance: &RowProvenance,
-        descriptor: &RowDescriptor,
-        session: &Session,
-        table: &str,
-        branch: &str,
-        operation: Operation,
-        row_id: Option<ObjectId>,
-        depth: usize,
-        visited: &mut HashSet<(TableName, ObjectId, Operation)>,
-    ) -> bool {
-        if depth > crate::query_manager::policy::RECURSIVE_POLICY_MAX_DEPTH_HARD_CAP {
-            return false;
-        }
-        let simple_result = evaluate_simple_parts_with_row_id(
-            policy, content, provenance, descriptor, session, row_id,
+        let schema = self.schema.clone();
+        let row = Row::new(
+            row_id,
+            content.to_vec(),
+            BatchId([0; 16]),
+            provenance.clone(),
         );
-        if !simple_result.passed {
-            return false;
-        }
-        if simple_result.complex_clauses.is_empty() {
-            return true;
-        }
-
-        let table_name = TableName::new(table);
-        let mut graph_clauses = Vec::new();
-        for clause in simple_result.complex_clauses {
-            match clause {
-                ComplexClause::InheritsReferencing {
-                    operation,
-                    source_table,
-                    via_column,
-                    max_depth,
-                } => {
-                    let Some(target_row_id) = row_id else {
-                        return false;
-                    };
-                    if !self.evaluate_referencing_inherited_access_recursive(
-                        storage,
-                        table_name,
-                        target_row_id,
-                        operation,
-                        &source_table,
-                        &via_column,
-                        max_depth,
-                        session,
-                        branch,
-                        depth,
-                        visited,
-                    ) {
-                        return false;
-                    }
-                }
-                other => graph_clauses.push(other),
-            }
-        }
-
-        if graph_clauses.is_empty() {
-            return true;
-        }
-
-        let Some(mut graphs) = self.create_policy_graphs_for_complex_clauses(
-            &graph_clauses,
-            content,
-            descriptor,
-            &table_name,
-            operation,
-            session,
-            branch,
-        ) else {
-            return false;
-        };
-        if graphs.is_empty() {
-            return true;
-        }
-
         let storage_ref: &dyn Storage = storage;
         let branch_schema_map = Self::branch_schema_map_for_context(&self.schema_context);
         let mut row_loader = |id: ObjectId, table_hint: Option<TableName>| -> Option<LoadedRow> {
@@ -1502,237 +1402,18 @@ impl QueryManager {
             ))
         };
 
-        for graph in &mut graphs {
-            for _ in 0..100 {
-                if graph.settle(storage_ref, &mut row_loader) {
-                    break;
-                }
-            }
-            if !graph.result() {
-                return false;
-            }
-        }
-
-        true
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn evaluate_referencing_inherited_access_recursive<H: Storage>(
-        &mut self,
-        storage: &mut H,
-        target_table: TableName,
-        target_row_id: ObjectId,
-        operation: Operation,
-        source_table: &str,
-        via_column: &str,
-        max_depth: Option<usize>,
-        session: &Session,
-        branch: &str,
-        depth: usize,
-        visited: &mut HashSet<(TableName, ObjectId, Operation)>,
-    ) -> bool {
-        if depth > crate::query_manager::policy::RECURSIVE_POLICY_MAX_DEPTH_HARD_CAP {
-            return false;
-        }
-        let Some(effective_max_depth) =
-            crate::query_manager::policy::normalize_recursive_max_depth(max_depth)
-        else {
-            return false;
-        };
-        if depth >= effective_max_depth {
-            return false;
-        }
-
-        let source_table_name = TableName::new(source_table);
-        let Some(source_schema) = self.schema.get(&source_table_name) else {
-            return false;
-        };
-        let source_descriptor = source_schema.columns.clone();
-
-        let Some(col_idx) = source_descriptor.column_index(via_column) else {
-            return false;
-        };
-        let col = &source_descriptor.columns[col_idx];
-        if col.references != Some(target_table) {
-            return false;
-        }
-
-        match &col.column_type {
-            crate::query_manager::types::ColumnType::Uuid => {
-                let candidate_ids = if source_schema.is_indexed_column(col.name.as_str()) {
-                    storage.index_lookup(
-                        source_table_name.as_str(),
-                        col.name.as_str(),
-                        branch,
-                        &Value::Uuid(target_row_id),
-                    )
-                } else {
-                    storage
-                        .index_scan_all(source_table_name.as_str(), "_id", branch)
-                        .into_iter()
-                        .filter(|source_row_id| {
-                            let Some(source_content) =
-                                self.load_row_content_on_branch(storage, *source_row_id, branch)
-                            else {
-                                return false;
-                            };
-                            declared_edge_references_target(
-                                &source_descriptor,
-                                &source_content,
-                                col_idx,
-                                target_row_id,
-                            )
-                        })
-                        .collect()
-                };
-                for source_row_id in candidate_ids {
-                    if self.evaluate_source_row_access_for_operation(
-                        storage,
-                        source_table_name,
-                        source_row_id,
-                        operation,
-                        session,
-                        branch,
-                        depth + 1,
-                        visited,
-                        None,
-                    ) {
-                        return true;
-                    }
-                }
-            }
-            crate::query_manager::types::ColumnType::Array { element }
-                if **element == crate::query_manager::types::ColumnType::Uuid =>
-            {
-                let candidate_ids = storage.index_scan_all(
-                    source_table_name.as_str(),
-                    if source_schema.is_indexed_column(col.name.as_str()) {
-                        col.name.as_str()
-                    } else {
-                        "_id"
-                    },
-                    branch,
-                );
-                for source_row_id in candidate_ids {
-                    let Some(source_content) =
-                        self.load_row_content_on_branch(storage, source_row_id, branch)
-                    else {
-                        continue;
-                    };
-
-                    if !declared_edge_references_target(
-                        &source_descriptor,
-                        &source_content,
-                        col_idx,
-                        target_row_id,
-                    ) {
-                        continue;
-                    }
-
-                    if self.evaluate_source_row_access_for_operation(
-                        storage,
-                        source_table_name,
-                        source_row_id,
-                        operation,
-                        session,
-                        branch,
-                        depth + 1,
-                        visited,
-                        Some(source_content),
-                    ) {
-                        return true;
-                    }
-                }
-            }
-            _ => {}
-        }
-
-        false
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn evaluate_source_row_access_for_operation<H: Storage>(
-        &mut self,
-        storage: &mut H,
-        table_name: TableName,
-        row_id: ObjectId,
-        operation: Operation,
-        session: &Session,
-        branch: &str,
-        depth: usize,
-        visited: &mut HashSet<(TableName, ObjectId, Operation)>,
-        preloaded_content: Option<Vec<u8>>,
-    ) -> bool {
-        if depth > crate::query_manager::policy::RECURSIVE_POLICY_MAX_DEPTH_HARD_CAP {
-            return false;
-        }
-
-        let key = (table_name, row_id, operation);
-        if !visited.insert(key) {
-            // Cycle detected for this recursion branch.
-            return false;
-        }
-
-        let Some(content) =
-            preloaded_content.or_else(|| self.load_row_content_on_branch(storage, row_id, branch))
-        else {
-            visited.remove(&(table_name, row_id, operation));
-            return false;
-        };
-        let Some(provenance) = self.load_row_provenance_on_branch(storage, row_id, branch) else {
-            visited.remove(&(table_name, row_id, operation));
-            return false;
-        };
-
-        let write_schema = self.schema.clone();
-        let Ok(table_write) =
-            self.write_table_cache_entry_for_schema(branch, table_name, write_schema.as_ref())
-        else {
-            visited.remove(&(table_name, row_id, operation));
-            return false;
-        };
-
-        let local_policy = match operation {
-            Operation::Select => table_write.select_policy.as_deref(),
-            Operation::Insert => table_write.insert_policy.as_deref(),
-            Operation::Update => table_write.update_using_policy.as_deref(),
-            Operation::Delete => table_write.delete_using_policy.as_deref(),
-        };
-
-        let local_allow = local_policy
-            .map(|policy| {
-                self.evaluate_policy_for_content_with_context_for_row(
-                    storage,
-                    policy,
-                    &content,
-                    &provenance,
-                    table_write.descriptor.as_ref(),
-                    session,
-                    table_name.as_str(),
-                    branch,
-                    operation,
-                    row_id,
-                    depth,
-                    visited,
-                )
-            })
-            .unwrap_or(!self.row_policy_mode.denies_missing_explicit_policy());
-
-        visited.remove(&(table_name, row_id, operation));
-        local_allow
-    }
-
-    fn load_row_content_on_branch<H: Storage>(
-        &mut self,
-        storage: &mut H,
-        row_id: ObjectId,
-        branch: &str,
-    ) -> Option<Vec<u8>> {
-        let (_, row) = self.load_visible_row_on_branch(storage, row_id, branch)?;
-        if row.is_hard_deleted() {
-            return None;
-        }
-        Some(row.data.to_vec())
+        PolicyContextEvaluator::new(schema.as_ref(), session, branch, self.row_policy_mode)
+            .evaluate_row_access(
+                operation,
+                &row,
+                descriptor,
+                table,
+                Some(policy),
+                storage_ref,
+                &mut row_loader,
+                depth,
+                visited,
+            )
     }
 
     pub(super) fn visible_row_is_hard_deleted(
@@ -2041,7 +1722,11 @@ impl QueryManager {
         let table_write =
             self.write_table_cache_entry_for_schema(branch, table_name, write_schema)?;
         let descriptor = table_write.descriptor.as_ref();
-        let using_policy = table_write.delete_using_policy.as_deref();
+        let using_policy = write_schema
+            .get(&table_name)
+            .ok_or(QueryError::TableNotFound(table_name))?
+            .policies
+            .effective_delete_using();
 
         if let Some(session) = write_context.and_then(WriteContext::session) {
             if let Some((auth_schema, auth_context)) =
@@ -2511,20 +2196,5 @@ impl QueryManager {
         storage
             .row_batch_exists(&table, self.current_branch().as_str(), object_id, *batch_id)
             .unwrap_or(false)
-    }
-}
-
-fn declared_edge_references_target(
-    descriptor: &RowDescriptor,
-    content: &[u8],
-    column_index: usize,
-    target_row_id: ObjectId,
-) -> bool {
-    match decode_column(descriptor, content, column_index) {
-        Ok(Value::Uuid(id)) => id == target_row_id,
-        Ok(Value::Array(values)) => values
-            .iter()
-            .any(|value| matches!(value, Value::Uuid(id) if *id == target_row_id)),
-        _ => false,
     }
 }

--- a/crates/jazz-tools/src/server/testing.rs
+++ b/crates/jazz-tools/src/server/testing.rs
@@ -446,19 +446,34 @@ impl JazzServer {
         }
     }
 
-    pub fn make_client_context_for_user(
-        &self,
-        schema: Schema,
-        user_id: impl AsRef<str>,
-    ) -> AppContext {
-        self.require_built_in_jwt_helpers();
-
+    fn make_base_client_context(&self, schema: Schema) -> AppContext {
         let client_data_dir = OwnedTempDir::new("jazz-tools-testing-client");
         let data_dir = client_data_dir.path().to_path_buf();
         self.client_data_dirs
             .lock()
             .expect("lock test client data dirs")
             .push(client_data_dir);
+
+        AppContext {
+            app_id: self.app_id,
+            client_id: None,
+            schema,
+            server_url: self.base_url(),
+            data_dir,
+            storage: crate::ClientStorage::Memory,
+            jwt_token: None,
+            backend_secret: None,
+            admin_secret: None,
+            sync_tracer: None,
+        }
+    }
+
+    pub fn make_client_context_for_user(
+        &self,
+        schema: Schema,
+        user_id: impl AsRef<str>,
+    ) -> AppContext {
+        self.require_built_in_jwt_helpers();
 
         let now = UNIX_EPOCH + Duration::from_secs(self.auth_clock.now_seconds());
         let jwt_token = TestJwtIssuer::jwt_for_user_with_options_at(
@@ -467,18 +482,20 @@ impl JazzServer {
             TestJwtOptions::default(),
             now,
         );
-        AppContext {
-            app_id: self.app_id,
-            client_id: None,
-            schema,
-            server_url: self.base_url(),
-            data_dir,
-            storage: crate::ClientStorage::Memory,
-            jwt_token: Some(jwt_token),
-            backend_secret: Some(self.backend_secret().to_string()),
-            admin_secret: None,
-            sync_tracer: None,
-        }
+        let mut context = self.make_base_client_context(schema);
+        context.jwt_token = Some(jwt_token);
+        context.backend_secret = Some(self.backend_secret().to_string());
+        context
+    }
+
+    /// Creates a client context authenticated only with the backend secret.
+    ///
+    /// Use this context with [`crate::JazzClient::for_session`] when a test
+    /// needs to perform an operation on behalf of a specific user.
+    pub fn make_client_context_for_backend(&self, schema: Schema) -> AppContext {
+        let mut context = self.make_base_client_context(schema);
+        context.backend_secret = Some(self.backend_secret().to_string());
+        context
     }
 
     pub fn data_dir(&self) -> &Path {
@@ -686,6 +703,23 @@ mod tests {
         let context = server.make_client_context_for_user(Schema::new(), "default-helper-user");
 
         assert!(context.jwt_token.is_some());
+        assert!(context.admin_secret.is_none());
+
+        server.shutdown().await;
+    }
+
+    /// The backend helper must not attach a JWT, because a JWT would make the
+    /// server authenticate the connection as that user instead of as a backend.
+    #[tokio::test]
+    async fn backend_client_context_uses_backend_secret_without_jwt() {
+        let server = JazzServer::start().await;
+        let context = server.make_client_context_for_backend(Schema::new());
+
+        assert!(context.jwt_token.is_none());
+        assert_eq!(
+            context.backend_secret.as_deref(),
+            Some(server.backend_secret())
+        );
         assert!(context.admin_secret.is_none());
 
         server.shutdown().await;

--- a/crates/jazz-tools/tests/policies_integration/exists_policies.rs
+++ b/crates/jazz-tools/tests/policies_integration/exists_policies.rs
@@ -127,6 +127,81 @@ async fn rebac_exists_clause_denies_non_matching_insert() {
     server.shutdown().await;
 }
 
+/// Verifies that an INSERT policy composed with `anyOf` accepts a write locally when
+/// one of its two EXISTS branches matches alice, even though the other does not.
+///
+/// Regression test: https://github.com/garden-co/jazz/issues/1104
+///
+/// backend ──seed gate_a(alice)──► server
+///    │
+///    └──for_session(alice)──► protected insert──► server──► bob
+///                               └──anyOf(EXISTS gate_a, EXISTS gate_b)──► accept
+#[cfg(feature = "test-utils")]
+#[tokio::test]
+async fn rebac_local_insert_allowed_when_only_one_any_of_exists_branch_matches() {
+    let protected_policies = permissions(|p| {
+        p.allow_read().always();
+        p.allow_insert().where_(pe::any_of([
+            pe::exists(pe::table("gate_a").where_(pe::eq("user_id", pe::session("user_id")))),
+            pe::exists(pe::table("gate_b").where_(pe::eq("user_id", pe::session("user_id")))),
+        ]));
+    });
+    let gate_table = |name| {
+        TableSchema::builder(name)
+            .column("user_id", ColumnType::Text)
+            .policies(permissions(|p| {
+                p.allow_read().always();
+                p.allow_insert().always();
+            }))
+    };
+    let schema = SchemaBuilder::new()
+        .table(gate_table("gate_a"))
+        .table(gate_table("gate_b"))
+        .table(
+            TableSchema::builder("protected")
+                .column("data", ColumnType::Text)
+                .policies(protected_policies),
+        )
+        .build();
+
+    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let backend = JazzClient::connect(server.make_client_context_for_backend(schema.clone()))
+        .await
+        .expect("connect backend");
+    let bob = JazzClient::connect(server.make_client_context_for_user(schema, "bob"))
+        .await
+        .expect("connect bob");
+
+    let (_, _, gate_batch_id) = backend
+        .insert("gate_a", crate::row_input!("user_id" => "alice"))
+        .expect("seed alice's gate_a row");
+    backend
+        .wait_for_batch(gate_batch_id, DurabilityTier::EdgeServer)
+        .await
+        .expect("gate_a seed should reach the server");
+
+    let alice = backend.for_session(Session::new("alice"));
+    let (protected_id, _, protected_batch_id) = alice
+        .insert(
+            "protected",
+            crate::row_input!("data" => "allowed by gate_a"),
+        )
+        .expect("one matching EXISTS branch should satisfy alice's local anyOf insert policy");
+    alice
+        .wait_for_batch(protected_batch_id, DurabilityTier::EdgeServer)
+        .await
+        .expect("one matching EXISTS branch should satisfy the anyOf insert policy");
+    wait_for_protected_row(
+        &bob,
+        protected_id,
+        "allowed by gate_a",
+        "bob sees alice's insert accepted through the matching anyOf branch",
+    )
+    .await;
+
+    server.shutdown().await;
+}
+
 /// Verifies that UPDATE USING policies with EXISTS are enforced on sync, and
 /// that a rejected optimistic update rolls back to server-authoritative state.
 #[cfg(feature = "test-utils")]


### PR DESCRIPTION
Fixes https://github.com/garden-co/jazz/issues/1104.

## Background

Policy expressions fall into two categories:
- Simple expressions, such as column comparisons and null checks. These can be evaluated directly against the row being written.
- Complex expressions, such as `EXISTS` and `INHERITS`. These require reading other rows and sometimes constructing query graphs.

The old local-write evaluator tried to optimize policy checks by splitting evaluation into two phases:
- It evaluated simple expressions immediately.
- It extracted complex expressions into a flat `Vec<ComplexClause>` for later batched evaluation.

The problem was that this flat vector did not preserve the OR/AND distinction, turning everything into an AND.

## Fix

Remove the local write optimization to prioritize correctness. Switch to using the `PolicyContextEvaluator` already used by server authorization and local reads.