### PR TITLE
fix: avoid reprocessing already received batch fates

### DIFF
--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -1366,21 +1366,24 @@ impl SyncManager {
                 }
             }
             SyncPayload::BatchFate { fate } => {
-                let fate = match self.persist_authoritative_batch_fate(storage, &fate) {
-                    Ok((fate, _)) => fate,
+                let (fate, changed) = match self.persist_authoritative_batch_fate(storage, &fate) {
+                    Ok(result) => result,
                     Err(_) => return,
                 };
-                self.pending_batch_fates.push(fate.clone());
-                if let BatchFate::AcceptedTransaction { batch_id, .. } = fate {
-                    let rows = self.known_transactional_batch_rows_for_fate(storage, batch_id);
-                    self.apply_transactional_batch_fate_to_rows(
-                        storage,
-                        None,
-                        Some(server_id),
-                        &fate,
-                        &rows,
-                    );
+                if changed {
+                    self.pending_batch_fates.push(fate.clone());
+                    if let BatchFate::AcceptedTransaction { batch_id, .. } = fate {
+                        let rows = self.known_transactional_batch_rows_for_fate(storage, batch_id);
+                        self.apply_transactional_batch_fate_to_rows(
+                            storage,
+                            None,
+                            Some(server_id),
+                            &fate,
+                            &rows,
+                        );
+                    }
                 }
+                // Keep forwarding downstream: another connected client may not know it.
                 let interested = self.interested_clients_for_batch_fate(&fate);
                 for cid in interested {
                     if let Some(fate) = self.batch_fate_for_client(cid, &fate) {


### PR DESCRIPTION
## Description

Fixes https://github.com/garden-co/jazz/issues/1120.

The performance problem was not caused by that issue's description, but rather due to the fact that servers re-send batch fates to clients when loading query rows (which was exacerbated by `.include()` queries).

The solution was to ensure that clients do not re-process already received batch fates, thus avoiding expensive history scans.

## Validation

Tested on https://github.com/Xelson/jazz-schema-bench:

- Before: 158.42 ms/update
- After: 1.54 ms/update