### PR TITLE
fix: clear dropped per-index signals when reconcileArray truncates

### DIFF
--- a/.changeset/fresh-signals-truncate.md
+++ b/.changeset/fresh-signals-truncate.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix reactive array truncation and expose `reconcileArray` as a public subpath.

--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -110,6 +110,10 @@
       "types": "./dist/passkey-backup.d.ts",
       "default": "./dist/passkey-backup.js"
     },
+    "./reconcile-array": {
+      "types": "./dist/reconcile-array.d.ts",
+      "default": "./dist/reconcile-array.js"
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {

--- a/packages/jazz-tools/src/reconcile-array.test.ts
+++ b/packages/jazz-tools/src/reconcile-array.test.ts
@@ -67,6 +67,35 @@ describe("reconcileArray", () => {
     expect(target[0]!.name).toBe("Alice");
   });
 
+  it("clears removed indexes on reactive array proxies", () => {
+    type Item = { id: string; name: string };
+    const target = [
+      { id: "1", name: "Alice" },
+      { id: "2", name: "Bob" },
+    ];
+    const staleSignals = new Map<string, Item>();
+    const reactiveTarget = new Proxy(target, {
+      get(array, property, receiver) {
+        if (typeof property === "string" && /^\d+$/.test(property)) {
+          if (Number(property) < array.length) {
+            staleSignals.set(property, Reflect.get(array, property, receiver));
+          } else if (staleSignals.has(property)) {
+            return staleSignals.get(property);
+          }
+        }
+        return Reflect.get(array, property, receiver);
+      },
+      deleteProperty(array, property) {
+        staleSignals.delete(property);
+        return Reflect.deleteProperty(array, property);
+      },
+    });
+
+    reconcileArray(reactiveTarget, [{ id: "1", name: "Alice" }]);
+
+    expect(reactiveTarget[1]).toBeUndefined();
+  });
+
   it("skips property writes when values are identical", () => {
     const alice = { id: "1", name: "Alice" };
     const target = [alice];

--- a/packages/jazz-tools/src/reconcile-array.test.ts
+++ b/packages/jazz-tools/src/reconcile-array.test.ts
@@ -86,7 +86,7 @@ describe("reconcileArray", () => {
         return Reflect.get(array, property, receiver);
       },
       deleteProperty(array, property) {
-        staleSignals.delete(property);
+        if (typeof property === "string") staleSignals.delete(property);
         return Reflect.deleteProperty(array, property);
       },
     });

--- a/packages/jazz-tools/src/reconcile-array.ts
+++ b/packages/jazz-tools/src/reconcile-array.ts
@@ -64,7 +64,10 @@ export function reconcileArray<T extends { id: string }>(target: T[], source: T[
     }
   }
   if (target.length > result.length) {
-    target.length = result.length;
+    // splice, not `length =`: reactive proxies (e.g. deepsignal) leave the
+    // dropped per-index signals stale on a length truncation, so reads past
+    // the new length would return old rows.
+    target.splice(result.length);
   }
 }
 


### PR DESCRIPTION
Truncating with `length =` leaves reactive array proxies (we use deepsignal) holding stale per-index signals, so reads past the new length return old rows. Truncate with splice instead, and export `./reconcile-array` as a subpath so apps can reuse the reconciler directly.