### PR TITLE
fix: scope browser client storage by identity for cookie sessions

### DIFF
--- a/.changeset/cookie-session-storage-scope.md
+++ b/.changeset/cookie-session-storage-scope.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Scope browser client storage by identity for cookie sessions.

--- a/packages/jazz-tools/src/react/create-jazz-client.test.ts
+++ b/packages/jazz-tools/src/react/create-jazz-client.test.ts
@@ -238,6 +238,44 @@ describe("react/create-jazz-client unit", () => {
     expect(api?.listLiveStorageNamespaces()).toEqual([]);
   });
 
+  it("RC-U08: scopes window storage by cookie session identity", async () => {
+    (globalThis as { window?: unknown }).window = {} as unknown;
+
+    const config: DbConfig = {
+      appId: "react-client-cookie-scope",
+      driver: { type: "persistent" },
+      cookieSession: {
+        user_id: "alice@example.com",
+        claims: {},
+        authMode: "external",
+      },
+    };
+    const db = createMockDb(null, config);
+    mocks.createDb.mockResolvedValue(db);
+
+    const client = await createJazzClient(config);
+
+    const api = (
+      window as {
+        __jazz?: {
+          clearStorage(namespace?: string): Promise<void>;
+          listLiveStorageNamespaces(): string[];
+        };
+      }
+    ).__jazz;
+
+    expect(api?.listLiveStorageNamespaces()).toEqual([
+      "react-client-cookie-scope::alice%40example.com",
+    ]);
+
+    await api?.clearStorage();
+
+    expect(db.deleteClientStorage).toHaveBeenCalledTimes(1);
+
+    await client.shutdown();
+    expect(api?.listLiveStorageNamespaces()).toEqual([]);
+  });
+
   it("RC-U07: requires a namespace when multiple live contexts exist", async () => {
     (globalThis as { window?: unknown }).window = {} as unknown;
 

--- a/packages/jazz-tools/src/runtime/connection-manager/browser-broker-utils.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/browser-broker-utils.ts
@@ -63,6 +63,10 @@ export function resolveDefaultPersistentDbName(config: DbConfig): string {
   const session = resolveClientSessionSync({
     appId: config.appId,
     jwtToken: config.jwtToken,
+    // Pass cookieSession like the other resolver call sites, so
+    // HttpOnly-cookie apps get the per-identity namespace instead of a
+    // store shared across logins.
+    cookieSession: config.cookieSession,
   });
 
   if (!session?.user_id || session.authMode === "anonymous") {

--- a/packages/jazz-tools/src/runtime/db.browser-storage-scope.test.ts
+++ b/packages/jazz-tools/src/runtime/db.browser-storage-scope.test.ts
@@ -45,6 +45,34 @@ describe("resolveDefaultPersistentDbName", () => {
     expect(resolveDefaultPersistentDbName(config)).toBe("chat-app::principal%2F456");
   });
 
+  it("scopes the default namespace by user_id for cookie sessions", () => {
+    const config: DbConfig = {
+      appId: "chat-app",
+      driver: { type: "persistent" },
+      cookieSession: {
+        user_id: "alice@example.com",
+        claims: {},
+        authMode: "external",
+      },
+    };
+
+    expect(resolveDefaultPersistentDbName(config)).toBe("chat-app::alice%40example.com");
+  });
+
+  it("does not scope by user_id for anonymous cookie sessions", () => {
+    const config: DbConfig = {
+      appId: "chat-app",
+      driver: { type: "persistent" },
+      cookieSession: {
+        user_id: "ephemeral-visitor",
+        claims: {},
+        authMode: "anonymous",
+      },
+    };
+
+    expect(resolveDefaultPersistentDbName(config)).toBe("chat-app");
+  });
+
   it("falls back to appId when no session can be resolved", () => {
     const config: DbConfig = {
       appId: "chat-app",

--- a/packages/jazz-tools/src/window-client-storage.ts
+++ b/packages/jazz-tools/src/window-client-storage.ts
@@ -45,16 +45,20 @@ function resolveStorageNamespace(config: DbConfig): string | null {
     return explicitDbName;
   }
 
-  const sessionUserId = resolveClientSessionSync({
+  // Mirror resolveDefaultPersistentDbName exactly (including the anonymous
+  // check) so the window storage API lists the namespace the client
+  // actually persists under.
+  const session = resolveClientSessionSync({
     appId: config.appId,
     jwtToken: config.jwtToken,
-  })?.user_id;
+    cookieSession: config.cookieSession,
+  });
 
-  if (!sessionUserId) {
+  if (!session?.user_id || session.authMode === "anonymous") {
     return config.appId;
   }
 
-  return `${config.appId}::${encodeURIComponent(sessionUserId)}`;
+  return `${config.appId}::${encodeURIComponent(session.user_id)}`;
 }
 
 function getLiveStorageContexts(currentWindow: Window): Set<LiveStorageContext> {


### PR DESCRIPTION
Cookie-authenticated sessions all shared one browser storage namespace, so switching users in the same browser read another identity's local replica (and the sync server then ignored their query subscriptions on the user_id mismatch, which shows up as queries loading forever until a reconnect). Key the storage scope by identity, mirroring resolveDefaultPersistentDbName. Comes with a runtime test.