### PR TITLE
fix: remove stale binaries before staging in stage-binary.mjs

### DIFF
--- a/examples/docs/todo-client-localfirst-react/tests/browser/todo-app.test.tsx
+++ b/examples/docs/todo-client-localfirst-react/tests/browser/todo-app.test.tsx
@@ -44,7 +44,7 @@ describe("React Todo App E2E", () => {
     config: {
       appId?: string;
       serverUrl?: string;
-      auth?: { localFirstSecret: string };
+      secret?: string;
       adminSecret?: string;
       driver?: DbConfig["driver"];
     } = {},
@@ -283,13 +283,13 @@ describe("React Todo App E2E", () => {
       appId: APP_ID,
       serverUrl,
       adminSecret: ADMIN_SECRET,
-      auth: { localFirstSecret: "Tb9eLjnS22z-_s9FK0EtiFIIRDe4EAygLAdni55RvAs" },
+      secret: "Tb9eLjnS22z-_s9FK0EtiFIIRDe4EAygLAdni55RvAs",
     });
     const el2 = await mountApp({
       appId: APP_ID,
       serverUrl,
       adminSecret: ADMIN_SECRET,
-      auth: { localFirstSecret: "VDOGX2nez-5T9Lgk4VfYMT33Qsa6J4loRAoKLZpvxBg" },
+      secret: "VDOGX2nez-5T9Lgk4VfYMT33Qsa6J4loRAoKLZpvxBg",
     });
 
     // Let both app instances finish server/event-stream setup before mutating.
@@ -331,13 +331,13 @@ describe("React Todo App E2E", () => {
     const el1 = await mountApp({
       appId: APP_ID,
       serverUrl,
-      auth: { localFirstSecret: "disAKUpEX273joMo4f1NTW-tDTpc4bzPy_l5tvNLXnc" },
+      secret: "disAKUpEX273joMo4f1NTW-tDTpc4bzPy_l5tvNLXnc",
       driver: { type: "memory" },
     });
     const el2 = await mountApp({
       appId: APP_ID,
       serverUrl,
-      auth: { localFirstSecret: "TqNBXTv_Mv7HBp3FZ6KtHJwBWvnkI7YcOlrS57d3eEs" },
+      secret: "TqNBXTv_Mv7HBp3FZ6KtHJwBWvnkI7YcOlrS57d3eEs",
       driver: { type: "memory" },
     });
 

--- a/packages/jazz-tools/scripts/stage-binary.mjs
+++ b/packages/jazz-tools/scripts/stage-binary.mjs
@@ -1,4 +1,4 @@
-import { chmod, copyFile, mkdir } from "node:fs/promises";
+import { chmod, copyFile, mkdir, rm } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -39,6 +39,9 @@ export async function stageBinary({ source, platform, arch }) {
 
   await mkdir(nativeDir, { recursive: true });
   const destination = join(nativeDir, fileName);
+  // Remove first: overwriting in place keeps the vnode, and the macOS
+  // kernel SIGKILLs a cached executable whose content changed under it.
+  await rm(destination, { force: true });
   await copyFile(sourcePath, destination);
 
   if (!fileName.endsWith(".exe")) {


### PR DESCRIPTION
On macOS, overwriting a staged binary in place keeps the old vnode and the kernel SIGKILLs the relaunched executable because its signature no longer matches the cached file. Delete the destination before copying.