### PR TITLE
perf: stop indexing blob columns

### DIFF
--- a/.changeset/quiet-blob-indexes.md
+++ b/.changeset/quiet-blob-indexes.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Stop indexing Bytea columns to reduce write and index storage overhead.

--- a/crates/jazz-tools/src/query_manager/indices.rs
+++ b/crates/jazz-tools/src/query_manager/indices.rs
@@ -111,6 +111,11 @@ impl QueryManager {
         indexed_columns: Option<&[ColumnName]>,
         column: &ColumnDescriptor,
     ) -> bool {
+        // Blob equality stays supported through the id-scan fallback;
+        // indexing would copy a prefix of every payload into index keys.
+        if matches!(column.column_type, ColumnType::Bytea) {
+            return false;
+        }
         indexed_columns.is_none_or(|columns| columns.contains(&column.name))
     }
 

--- a/crates/jazz-tools/src/query_manager/types/schema.rs
+++ b/crates/jazz-tools/src/query_manager/types/schema.rs
@@ -443,6 +443,15 @@ impl TableSchema {
         if column == "_id" || column == "_id_deleted" {
             return true;
         }
+        // Blob columns carry no index (see should_index_column), so the
+        // planner must not consult one.
+        if self
+            .columns
+            .column(column)
+            .is_some_and(|descriptor| matches!(descriptor.column_type, ColumnType::Bytea))
+        {
+            return false;
+        }
         self.indexed_columns
             .as_ref()
             .is_none_or(|columns| columns.iter().any(|name| name.as_str() == column))


### PR DESCRIPTION
Indexing blob columns copies a prefix of every payload into index keys on each write, and blobs cannot be compared in queries anyway. Skip them; blob equality still works through the id-scan fallback.