### PR TITLE
fix: resolve array reverse references through element index lookups

### DIFF
--- a/crates/jazz-tools/src/query_manager/graph_nodes/policy_eval.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/policy_eval.rs
@@ -158,7 +158,19 @@ impl<'a> PolicyContextEvaluator<'a> {
                 &Value::Uuid(row.id),
             ),
             ColumnType::Array { element } if **element == ColumnType::Uuid => {
-                io.index_scan_all(source_table_name.as_str(), col.name.as_str(), self.branch)
+                // Reference-array elements are indexed individually, so an
+                // element lookup narrows the candidates; the content check
+                // below still verifies every hit.
+                if source_schema.is_indexed_column(col.name.as_str()) {
+                    io.index_lookup(
+                        source_table_name.as_str(),
+                        col.name.as_str(),
+                        self.branch,
+                        &Value::Uuid(row.id),
+                    )
+                } else {
+                    io.index_scan_all(source_table_name.as_str(), "_id", self.branch)
+                }
             }
             _ => return false,
         };

--- a/crates/jazz-tools/src/query_manager/writes.rs
+++ b/crates/jazz-tools/src/query_manager/writes.rs
@@ -1627,15 +1627,19 @@ impl QueryManager {
             crate::query_manager::types::ColumnType::Array { element }
                 if **element == crate::query_manager::types::ColumnType::Uuid =>
             {
-                let candidate_ids = storage.index_scan_all(
-                    source_table_name.as_str(),
-                    if source_schema.is_indexed_column(col.name.as_str()) {
-                        col.name.as_str()
-                    } else {
-                        "_id"
-                    },
-                    branch,
-                );
+                // Reference-array elements are indexed individually, so an
+                // element lookup narrows the candidates; the content check
+                // below still verifies every hit.
+                let candidate_ids = if source_schema.is_indexed_column(col.name.as_str()) {
+                    storage.index_lookup(
+                        source_table_name.as_str(),
+                        col.name.as_str(),
+                        branch,
+                        &Value::Uuid(target_row_id),
+                    )
+                } else {
+                    storage.index_scan_all(source_table_name.as_str(), "_id", branch)
+                };
                 for source_row_id in candidate_ids {
                     let Some(source_content) =
                         self.load_row_content_on_branch(storage, source_row_id, branch)


### PR DESCRIPTION
Reverse references pointing into array columns resolved by scanning even though array elements are indexed individually. Look them up through the element index instead; the content check still verifies every hit.