### PR TITLE
perf: reconcile only tracked rows on re-delivered batch fates

### DIFF
--- a/crates/jazz-tools/src/runtime_core/sync.rs
+++ b/crates/jazz-tools/src/runtime_core/sync.rs
@@ -69,6 +69,8 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         }));
         batch_ids.sort();
         batch_ids.dedup();
+        // Keep the scanning fallback: replicas that predate the batch row
+        // index hold batches only the history scan can find.
         batch_ids.retain(|batch_id| !self.local_batch_rows(*batch_id).is_empty());
         batch_ids
     }

--- a/crates/jazz-tools/src/runtime_core/ticks.rs
+++ b/crates/jazz-tools/src/runtime_core/ticks.rs
@@ -191,7 +191,13 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         })
     }
 
-    pub(crate) fn local_batch_rows(&self, batch_id: BatchId) -> Vec<LocalBatchRow> {
+    /// Load a batch's rows from the tracked member sources only, without
+    /// the full-store scan fallback. A batch no tracked source knows is
+    /// treated as row-less.
+    pub(crate) fn local_batch_rows_from_tracked_sources(
+        &self,
+        batch_id: BatchId,
+    ) -> Vec<LocalBatchRow> {
         let member_sources: [fn(&Self, BatchId) -> Vec<LocalBatchMember>; 4] = [
             Self::sealed_submission_batch_members,
             Self::cached_local_batch_members,
@@ -206,13 +212,18 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
                 break;
             }
         }
+        Self::sort_local_batch_rows(&mut rows);
+        rows
+    }
+
+    pub(crate) fn local_batch_rows(&self, batch_id: BatchId) -> Vec<LocalBatchRow> {
+        let mut rows = self.local_batch_rows_from_tracked_sources(batch_id);
         if rows.is_empty() {
             // Last-resort fallback if the batchId->rows index is not found.
             // This is extremely inefficient, as we're scanning across all tables' rows.
             rows = self.scan_local_batch_rows(batch_id);
+            Self::sort_local_batch_rows(&mut rows);
         }
-
-        Self::sort_local_batch_rows(&mut rows);
         rows
     }
 
@@ -303,7 +314,10 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
             self.schema_manager
                 .query_manager_mut()
                 .mark_subscriptions_visibility_recompute_for_tier(acked_tier);
-            for (member, row_locator, _) in self.local_batch_rows(batch_id) {
+            // Tracked sources only: servers re-deliver settled fates for
+            // batches this node never tracked, and the scanning fallback
+            // would pay a store-wide history scan per re-delivered fate.
+            for (member, row_locator, _) in self.local_batch_rows_from_tracked_sources(batch_id) {
                 self.schema_manager
                     .query_manager_mut()
                     .mark_local_row_updated_in_subscriptions(

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -1372,16 +1372,19 @@ impl SyncManager {
                 };
                 if changed {
                     self.pending_batch_fates.push(fate.clone());
-                    if let BatchFate::AcceptedTransaction { batch_id, .. } = fate {
-                        let rows = self.known_transactional_batch_rows_for_fate(storage, batch_id);
-                        self.apply_transactional_batch_fate_to_rows(
-                            storage,
-                            None,
-                            Some(server_id),
-                            &fate,
-                            &rows,
-                        );
-                    }
+                }
+                // Apply transactional fates even when unchanged: a crash
+                // between fate persistence and row application leaves rows
+                // staging, and the replayed fate is the only repair signal.
+                if let BatchFate::AcceptedTransaction { batch_id, .. } = fate {
+                    let rows = self.known_transactional_batch_rows_for_fate(storage, batch_id);
+                    self.apply_transactional_batch_fate_to_rows(
+                        storage,
+                        None,
+                        Some(server_id),
+                        &fate,
+                        &rows,
+                    );
                 }
                 // Keep forwarding downstream: another connected client may not know it.
                 let interested = self.interested_clients_for_batch_fate(&fate);

--- a/crates/jazz-tools/src/sync_manager/tests/settlements.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/settlements.rs
@@ -944,3 +944,37 @@ fn seal_batch_rejection_stops_when_settlement_persistence_fails() {
     );
     assert!(sm.take_outbox().is_empty());
 }
+
+/// A re-delivered identical batch fate must not be reprocessed: the first
+/// delivery queues it, the unchanged replay is dropped. Guards the hot-path
+/// dedup from upstream #1127.
+#[test]
+fn redelivered_identical_batch_fate_is_not_requeued() {
+    let mut sm = SyncManager::new();
+    let mut io = MemoryStorage::new();
+    let server_id = ServerId::new();
+    add_server(&mut sm, &io, server_id);
+    sm.take_outbox();
+
+    let fate = BatchFate::DurableDirect {
+        batch_id: BatchId([7; 16]),
+        confirmed_tier: DurabilityTier::GlobalServer,
+    };
+
+    sm.push_inbox(InboxEntry {
+        source: Source::Server(server_id),
+        payload: SyncPayload::BatchFate { fate: fate.clone() },
+    });
+    sm.process_inbox(&mut io);
+    assert_eq!(sm.take_pending_batch_fates().len(), 1);
+
+    sm.push_inbox(InboxEntry {
+        source: Source::Server(server_id),
+        payload: SyncPayload::BatchFate { fate },
+    });
+    sm.process_inbox(&mut io);
+    assert!(
+        sm.take_pending_batch_fates().is_empty(),
+        "an unchanged re-delivered fate must not be requeued"
+    );
+}


### PR DESCRIPTION
Follow-up to #1127. Servers re-deliver settled fates for batches a node never tracked, and each one still paid a store-wide history scan, so repeated bulk imports slowed down as the store grew: by our 8th 100-row import run inserts took ~140 ms each, with this they stay at ~16 ms. Reconcile only the rows the tracked member sources know and keep the full scan as a fallback for replicas that predate the batch row index.

Also applies AcceptedTransaction fates even when the fate itself is unchanged, so a crash between fate persistence and row application heals on replay.

cargo test -p jazz-tools --lib --features test-utils passes (1387).