### PR TITLE
fix: stop leaking server subscriptions for one-shot queries

### DIFF
--- a/crates/jazz-tools/src/query_manager/manager_tests/server_subscriptions.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests/server_subscriptions.rs
@@ -960,3 +960,72 @@ fn server_does_not_push_non_matching() {
         "Should NOT send RowBatchNeeded for non-matching user"
     );
 }
+
+/// A subscribe/unsubscribe pair coalesced into one inbox drain (a one-shot
+/// query) is served once but the subscription must not stay installed.
+#[test]
+fn coalesced_one_shot_subscription_is_served_once_and_not_installed() {
+    use crate::sync_manager::{ClientId, Destination, InboxEntry, QueryId, Source, SyncPayload};
+
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let (mut server_qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    server_qm
+        .insert(
+            &mut storage,
+            "users",
+            &[Value::Text("Alice".into()), Value::Integer(100)],
+        )
+        .unwrap();
+    server_qm.process(&mut storage);
+
+    let client_id = ClientId::new();
+    connect_client(&mut server_qm, &storage, client_id);
+    let _ = server_qm.sync_manager_mut().take_outbox();
+
+    let query = server_qm.query("users").build();
+    server_qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::QuerySubscription {
+            query_id: QueryId(1),
+            query: Box::new(query),
+            session: None,
+            required_tier: None,
+            propagation: crate::sync_manager::QueryPropagation::Full,
+            policy_context_tables: vec![],
+        },
+    });
+    server_qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::QueryUnsubscription {
+            query_id: QueryId(1),
+        },
+    });
+    server_qm.process(&mut storage);
+
+    let outbox = server_qm.sync_manager_mut().take_outbox();
+    let settled = outbox.iter().find_map(|entry| match entry {
+        crate::sync_manager::OutboxEntry {
+            destination: Destination::Client(id),
+            payload:
+                SyncPayload::QuerySettled {
+                    query_id: QueryId(1),
+                    scope,
+                    ..
+                },
+        } if *id == client_id => Some(scope.len()),
+        _ => None,
+    });
+    assert_eq!(
+        settled,
+        Some(1),
+        "the one-shot subscription must be served once with its full scope"
+    );
+    assert!(
+        !server_qm
+            .server_subscriptions
+            .contains_key(&(client_id, QueryId(1))),
+        "the one-shot subscription must not stay installed"
+    );
+}

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -1143,8 +1143,10 @@ impl QueryManager {
             }
 
             // Forward QuerySubscription to upstream servers (multi-tier forwarding)
-            // This allows hub servers to know about the query and push matching data
-            if sub.propagation == crate::sync_manager::QueryPropagation::Full {
+            // This allows hub servers to know about the query and push matching data.
+            // One-shot subscriptions are served from this server's storage and
+            // never installed, so there is nothing upstream to keep updated.
+            if !sub.one_shot && sub.propagation == crate::sync_manager::QueryPropagation::Full {
                 tracing::trace!(
                     %sub.client_id,
                     query_id = sub.query_id.0,
@@ -1161,26 +1163,29 @@ impl QueryManager {
                 );
             }
 
-            // Store the server subscription for reactive updates
-            self.server_subscriptions.insert(
-                (sub.client_id, sub.query_id),
-                ServerQuerySubscription {
-                    query: sub.query,
-                    graph,
-                    schema_context: subscription_context,
-                    session: session_for_policy,
-                    branches,
-                    policy_context_tables: sub.policy_context_tables,
-                    required_tier: sub.required_tier,
-                    sent_below_required_settled,
-                    last_emitted_settled_tier,
-                    last_scope: scope.unwrap_or_default(),
-                    needs_recompile: false,
-                    settled_once,
-                    propagation: sub.propagation,
-                    reported_schema_warnings,
-                },
-            );
+            // A one-shot subscription was already served above and must not
+            // stay installed.
+            if !sub.one_shot {
+                self.server_subscriptions.insert(
+                    (sub.client_id, sub.query_id),
+                    ServerQuerySubscription {
+                        query: sub.query,
+                        graph,
+                        schema_context: subscription_context,
+                        session: session_for_policy,
+                        branches,
+                        policy_context_tables: sub.policy_context_tables,
+                        required_tier: sub.required_tier,
+                        sent_below_required_settled,
+                        last_emitted_settled_tier,
+                        last_scope: scope.unwrap_or_default(),
+                        needs_recompile: false,
+                        settled_once,
+                        propagation: sub.propagation,
+                        reported_schema_warnings,
+                    },
+                );
+            }
 
             if self.sync_manager.outbox().len() >= MAX_INITIAL_QUERY_REPLAY_OUTBOX_PER_PASS {
                 for remaining_key in pending_keys.iter().skip(key_index + 1) {

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -1785,6 +1785,7 @@ impl SyncManager {
                         required_tier: *required_tier,
                         propagation: *propagation,
                         policy_context_tables: policy_context_tables.clone(),
+                        one_shot: false,
                     });
             }
             // Handle query unsubscription
@@ -1802,6 +1803,21 @@ impl SyncManager {
                         self.query_origin.remove(query_id);
                     }
                 }
+                // A matching pending subscription means the client
+                // subscribed and unsubscribed within one drain (a one-shot
+                // query served locally). Mark it one-shot instead of
+                // dropping the pair: unsubscriptions are processed before
+                // subscriptions, so plain enqueueing would install the
+                // subscription afterwards and leak it.
+                for subscription in &mut self.pending_query_subscriptions {
+                    if subscription.client_id == client_id && subscription.query_id == *query_id {
+                        subscription.one_shot = true;
+                    }
+                }
+                // Still enqueue the unsubscription: the marked
+                // subscription can be an active-query replay after a
+                // reconnect, and only the processed unsubscription removes
+                // an already-installed server subscription.
                 self.pending_query_unsubscriptions
                     .push(PendingQueryUnsubscription {
                         client_id,

--- a/crates/jazz-tools/src/sync_manager/tests/basic.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/basic.rs
@@ -79,6 +79,7 @@ fn memory_size_separates_sync_state_buckets() {
             required_tier: None,
             propagation: QueryPropagation::Full,
             policy_context_tables: vec![],
+            one_shot: false,
         });
     sm.pending_query_unsubscriptions
         .push(PendingQueryUnsubscription {

--- a/crates/jazz-tools/src/sync_manager/tests/subscriptions.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/subscriptions.rs
@@ -119,6 +119,7 @@ fn remove_client_cleans_pending_query_subscriptions() {
             required_tier: None,
             propagation: QueryPropagation::Full,
             policy_context_tables: vec![],
+            one_shot: false,
         });
     sm.pending_query_subscriptions
         .push(PendingQuerySubscription {
@@ -129,6 +130,7 @@ fn remove_client_cleans_pending_query_subscriptions() {
             required_tier: None,
             propagation: QueryPropagation::Full,
             policy_context_tables: vec![],
+            one_shot: false,
         });
 
     sm.remove_client(alice);
@@ -213,4 +215,79 @@ fn initial_query_scope_sends_one_settlement_per_batch() {
             confirmed_tier: DurabilityTier::GlobalServer,
         } if *settled_batch_id == batch_id
     ));
+}
+
+/// A coalesced subscribe/unsubscribe pair marks the subscription one-shot
+/// and still enqueues the unsubscription for an already-installed
+/// subscription from a reconnect replay.
+#[test]
+fn coalesced_subscribe_unsubscribe_marks_one_shot_and_keeps_unsubscription() {
+    let mut sm = SyncManager::new();
+    let mut io = MemoryStorage::new();
+    let client_id = ClientId::new();
+    add_client(&mut sm, &io, client_id);
+
+    let query = QueryBuilder::new("messages").branch("main").build();
+    sm.push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::QuerySubscription {
+            query_id: QueryId(1),
+            query: Box::new(query),
+            session: None,
+            required_tier: None,
+            propagation: QueryPropagation::Full,
+            policy_context_tables: vec![],
+        },
+    });
+    sm.push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::QueryUnsubscription {
+            query_id: QueryId(1),
+        },
+    });
+    sm.process_inbox(&mut io);
+
+    let subscriptions = sm.take_pending_query_subscriptions();
+    assert_eq!(subscriptions.len(), 1);
+    assert!(subscriptions[0].one_shot);
+    let unsubscriptions = sm.take_pending_query_unsubscriptions();
+    assert_eq!(unsubscriptions.len(), 1);
+    assert_eq!(unsubscriptions[0].client_id, client_id);
+    assert_eq!(unsubscriptions[0].query_id, QueryId(1));
+}
+
+/// The unsubscribe-then-resubscribe replay pattern must keep the
+/// resubscription installed: only a pending subscription that precedes the
+/// unsubscription is a coalesced one-shot pair.
+#[test]
+fn unsubscribe_then_resubscribe_keeps_the_resubscription() {
+    let mut sm = SyncManager::new();
+    let mut io = MemoryStorage::new();
+    let client_id = ClientId::new();
+    add_client(&mut sm, &io, client_id);
+
+    sm.push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::QueryUnsubscription {
+            query_id: QueryId(1),
+        },
+    });
+    let query = QueryBuilder::new("messages").branch("main").build();
+    sm.push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::QuerySubscription {
+            query_id: QueryId(1),
+            query: Box::new(query),
+            session: None,
+            required_tier: None,
+            propagation: QueryPropagation::Full,
+            policy_context_tables: vec![],
+        },
+    });
+    sm.process_inbox(&mut io);
+
+    let subscriptions = sm.take_pending_query_subscriptions();
+    assert_eq!(subscriptions.len(), 1);
+    assert!(!subscriptions[0].one_shot);
+    assert_eq!(sm.take_pending_query_unsubscriptions().len(), 1);
 }

--- a/crates/jazz-tools/src/sync_manager/types.rs
+++ b/crates/jazz-tools/src/sync_manager/types.rs
@@ -671,6 +671,9 @@ pub struct PendingQuerySubscription {
     pub required_tier: Option<DurabilityTier>,
     pub propagation: QueryPropagation,
     pub policy_context_tables: Vec<String>,
+    /// The client unsubscribed within the same inbox drain (a one-shot
+    /// query): serve it once but never install it.
+    pub one_shot: bool,
 }
 
 /// A pending query unsubscription that needs cleanup.


### PR DESCRIPTION
One-shot reads (a subscribe/unsubscribe pair coalescing in one inbox drain) left their server subscription installed forever, so every read grew the server's subscription set. On our production backend point reads degraded from ~5 ms to ~228 ms after a few thousand reads. Serve the pair once, scope and rows included so cold replicas still get the data, without installing the subscription, and still enqueue the unsubscription so a reconnect replay cannot resurrect one.

cargo test -p jazz-tools --lib --features test-utils passes (1387).