### PR TITLE
perf: bound per-connection scope bookkeeping and policy context scans

### DIFF
--- a/crates/jazz-tools/src/query_manager/manager_tests/e2e_sync.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests/e2e_sync.rs
@@ -498,7 +498,7 @@ fn sync_backed_subscription_without_remote_scope_snapshot_keeps_local_rows() {
 }
 
 #[test]
-fn e2e_three_tier_untrusted_downstream_keeps_result_only_scope() {
+fn e2e_three_tier_downstream_receives_authorized_policy_context_rows() {
     use crate::query_manager::policy::Operation;
     use crate::sync_manager::{ClientId, ServerId};
     use uuid::Uuid;
@@ -597,10 +597,124 @@ fn e2e_three_tier_untrusted_downstream_keeps_result_only_scope() {
         core_server_id_for_edge,
     );
 
+    // The folder row is policy context for the documents select policy, so
+    // the server includes it in the scope.
     let results = client.get_subscription_results(sub_id);
     assert_eq!(
         results.len(),
-        0,
-        "Untrusted downstream should keep current result-only sync behavior"
+        1,
+        "session-authorized policy context rows must sync so entitled rows become visible"
     );
+    assert_eq!(
+        results[0].1[1],
+        Value::Text("Bob doc in Alice folder".into())
+    );
+}
+
+/// Policy context closes transitively: proving access to a document needs
+/// the folder row and the membership row its read policy depends on.
+#[test]
+fn e2e_three_tier_downstream_receives_transitive_policy_context_rows() {
+    use crate::query_manager::policy::Operation;
+    use crate::sync_manager::{ClientId, ServerId};
+    use uuid::Uuid;
+
+    let mut schema = Schema::new();
+    schema.insert(
+        TableName::new("memberships"),
+        TableSchema::with_policies(
+            RowDescriptor::new(vec![ColumnDescriptor::new("member_id", ColumnType::Text)]),
+            TablePolicies::new()
+                .with_select(PolicyExpr::eq_session("member_id", vec!["user_id".into()])),
+        ),
+    );
+    schema.insert(
+        TableName::new("folders"),
+        TableSchema::with_policies(
+            RowDescriptor::new(vec![ColumnDescriptor::new("name", ColumnType::Text)]),
+            TablePolicies::new().with_select(PolicyExpr::Exists {
+                table: "memberships".into(),
+                condition: Box::new(PolicyExpr::eq_session("member_id", vec!["user_id".into()])),
+            }),
+        ),
+    );
+    schema.insert(
+        TableName::new("documents"),
+        TableSchema::with_policies(
+            RowDescriptor::new(vec![
+                ColumnDescriptor::new("title", ColumnType::Text),
+                ColumnDescriptor::new("folder_id", ColumnType::Uuid)
+                    .nullable()
+                    .references("folders"),
+            ]),
+            TablePolicies::new().with_select(PolicyExpr::inherits(Operation::Select, "folder_id")),
+        ),
+    );
+
+    let (mut core, mut core_io) = create_query_manager(SyncManager::new(), schema.clone());
+    core.insert(&mut core_io, "memberships", &[Value::Text("alice".into())])
+        .unwrap();
+    let folder_id = core
+        .insert(&mut core_io, "folders", &[Value::Text("Shared".into())])
+        .unwrap()
+        .row_id;
+    core.insert(
+        &mut core_io,
+        "documents",
+        &[
+            Value::Text("Doc in shared folder".into()),
+            Value::Uuid(folder_id),
+        ],
+    )
+    .unwrap();
+    core.process(&mut core_io);
+
+    let (mut edge, mut edge_io) = create_query_manager(SyncManager::new(), schema.clone());
+    let (mut client, mut client_io) = create_query_manager(SyncManager::new(), schema.clone());
+
+    let edge_server_id_for_client = ServerId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+    let client_id_on_edge = ClientId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+    let core_server_id_for_edge = ServerId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+    let edge_id_on_core = ClientId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+
+    client
+        .sync_manager_mut()
+        .add_server_with_storage(edge_server_id_for_client, false, &client_io);
+    connect_client(&mut edge, &edge_io, client_id_on_edge);
+    connect_server(&mut edge, &edge_io, core_server_id_for_edge);
+    connect_client(&mut core, &core_io, edge_id_on_core);
+
+    let _ = client.sync_manager_mut().take_outbox();
+    let _ = edge.sync_manager_mut().take_outbox();
+    let _ = core.sync_manager_mut().take_outbox();
+
+    let sub_id = client
+        .subscribe_with_sync(
+            client.query("documents").build(),
+            Some(PolicySession::new("alice")),
+            None,
+        )
+        .unwrap();
+    client.process(&mut client_io);
+
+    pump_messages_three_tier(
+        &mut client,
+        &mut edge,
+        &mut core,
+        &mut client_io,
+        &mut edge_io,
+        &mut core_io,
+        client_id_on_edge,
+        edge_server_id_for_client,
+        edge_id_on_core,
+        core_server_id_for_edge,
+    );
+
+    let results = client.get_subscription_results(sub_id);
+    assert_eq!(
+        results.len(),
+        1,
+        "transitive policy context (folder + membership) must sync so the document becomes visible"
+    );
+    assert_eq!(results[0].1[0], Value::Text("Doc in shared folder".into()));
 }

--- a/crates/jazz-tools/src/query_manager/manager_tests/server_subscriptions.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests/server_subscriptions.rs
@@ -960,3 +960,72 @@ fn server_does_not_push_non_matching() {
         "Should NOT send RowBatchNeeded for non-matching user"
     );
 }
+
+/// A subscribe/unsubscribe pair coalesced into one inbox drain (a one-shot
+/// query) is served once but the subscription must not stay installed.
+#[test]
+fn coalesced_one_shot_subscription_is_served_once_and_not_installed() {
+    use crate::sync_manager::{ClientId, Destination, InboxEntry, QueryId, Source, SyncPayload};
+
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let (mut server_qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    server_qm
+        .insert(
+            &mut storage,
+            "users",
+            &[Value::Text("Alice".into()), Value::Integer(100)],
+        )
+        .unwrap();
+    server_qm.process(&mut storage);
+
+    let client_id = ClientId::new();
+    connect_client(&mut server_qm, &storage, client_id);
+    let _ = server_qm.sync_manager_mut().take_outbox();
+
+    let query = server_qm.query("users").build();
+    server_qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::QuerySubscription {
+            query_id: QueryId(1),
+            query: Box::new(query),
+            session: None,
+            required_tier: None,
+            propagation: crate::sync_manager::QueryPropagation::Full,
+            policy_context_tables: vec![],
+        },
+    });
+    server_qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::QueryUnsubscription {
+            query_id: QueryId(1),
+        },
+    });
+    server_qm.process(&mut storage);
+
+    let outbox = server_qm.sync_manager_mut().take_outbox();
+    let settled = outbox.iter().find_map(|entry| match entry {
+        crate::sync_manager::OutboxEntry {
+            destination: Destination::Client(id),
+            payload:
+                SyncPayload::QuerySettled {
+                    query_id: QueryId(1),
+                    scope,
+                    ..
+                },
+        } if *id == client_id => Some(scope.len()),
+        _ => None,
+    });
+    assert_eq!(
+        settled,
+        Some(1),
+        "the one-shot subscription must be served once with its full scope"
+    );
+    assert!(
+        !server_qm
+            .server_subscriptions
+            .contains_key(&(client_id, QueryId(1))),
+        "the one-shot subscription must not stay installed"
+    );
+}

--- a/crates/jazz-tools/src/query_manager/manager_tests/server_subscriptions.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests/server_subscriptions.rs
@@ -1028,4 +1028,139 @@ fn coalesced_one_shot_subscription_is_served_once_and_not_installed() {
             .contains_key(&(client_id, QueryId(1))),
         "the one-shot subscription must not stay installed"
     );
+    assert!(
+        server_qm
+            .sync_manager()
+            .get_client(client_id)
+            .is_none_or(|client| client.queries.is_empty()),
+        "the one-shot subscription must not leave a client scope entry"
+    );
+}
+
+/// A processed unsubscription drops the client's query scope entry.
+#[test]
+fn unsubscription_drops_the_client_query_scope() {
+    use crate::sync_manager::{ClientId, InboxEntry, QueryId, Source, SyncPayload};
+
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let (mut server_qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    server_qm
+        .insert(
+            &mut storage,
+            "users",
+            &[Value::Text("Alice".into()), Value::Integer(100)],
+        )
+        .unwrap();
+    server_qm.process(&mut storage);
+
+    let client_id = ClientId::new();
+    connect_client(&mut server_qm, &storage, client_id);
+
+    let query = server_qm.query("users").build();
+    server_qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::QuerySubscription {
+            query_id: QueryId(1),
+            query: Box::new(query),
+            session: None,
+            required_tier: None,
+            propagation: crate::sync_manager::QueryPropagation::Full,
+            policy_context_tables: vec![],
+        },
+    });
+    server_qm.process(&mut storage);
+    assert!(
+        server_qm
+            .sync_manager()
+            .get_client(client_id)
+            .is_some_and(|client| !client.queries.is_empty()),
+        "the installed subscription must have a scope entry"
+    );
+
+    server_qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::QueryUnsubscription {
+            query_id: QueryId(1),
+        },
+    });
+    server_qm.process(&mut storage);
+    assert!(
+        server_qm
+            .sync_manager()
+            .get_client(client_id)
+            .is_some_and(|client| client.queries.is_empty()),
+        "the unsubscription must drop the scope entry"
+    );
+}
+
+/// A same-drain unsubscribe/resubscribe pair keeps the resubscription's
+/// query origin and scope.
+#[test]
+fn same_drain_resubscription_keeps_origin_and_scope() {
+    use crate::sync_manager::{ClientId, InboxEntry, QueryId, Source, SyncPayload};
+
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let (mut server_qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    server_qm
+        .insert(
+            &mut storage,
+            "users",
+            &[Value::Text("Alice".into()), Value::Integer(100)],
+        )
+        .unwrap();
+    server_qm.process(&mut storage);
+
+    let client_id = ClientId::new();
+    connect_client(&mut server_qm, &storage, client_id);
+
+    let query = server_qm.query("users").build();
+    let subscription_payload = SyncPayload::QuerySubscription {
+        query_id: QueryId(1),
+        query: Box::new(query),
+        session: None,
+        required_tier: None,
+        propagation: crate::sync_manager::QueryPropagation::Full,
+        policy_context_tables: vec![],
+    };
+    server_qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: subscription_payload.clone(),
+    });
+    server_qm.process(&mut storage);
+
+    server_qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::QueryUnsubscription {
+            query_id: QueryId(1),
+        },
+    });
+    server_qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: subscription_payload,
+    });
+    server_qm.process(&mut storage);
+
+    assert!(
+        server_qm
+            .server_subscriptions
+            .contains_key(&(client_id, QueryId(1))),
+        "the resubscription must be installed"
+    );
+    assert!(
+        server_qm
+            .sync_manager()
+            .query_origin_contains(QueryId(1), client_id),
+        "the resubscription must keep its query origin"
+    );
+    assert!(
+        server_qm
+            .sync_manager()
+            .get_client(client_id)
+            .is_some_and(|client| !client.queries.is_empty()),
+        "the resubscription must keep a scope entry"
+    );
 }

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -1143,8 +1143,10 @@ impl QueryManager {
             }
 
             // Forward QuerySubscription to upstream servers (multi-tier forwarding)
-            // This allows hub servers to know about the query and push matching data
-            if sub.propagation == crate::sync_manager::QueryPropagation::Full {
+            // This allows hub servers to know about the query and push matching data.
+            // One-shot subscriptions are served from this server's storage and
+            // never installed, so there is nothing upstream to keep updated.
+            if !sub.one_shot && sub.propagation == crate::sync_manager::QueryPropagation::Full {
                 tracing::trace!(
                     %sub.client_id,
                     query_id = sub.query_id.0,
@@ -1161,26 +1163,29 @@ impl QueryManager {
                 );
             }
 
-            // Store the server subscription for reactive updates
-            self.server_subscriptions.insert(
-                (sub.client_id, sub.query_id),
-                ServerQuerySubscription {
-                    query: sub.query,
-                    graph,
-                    schema_context: subscription_context,
-                    session: session_for_policy,
-                    branches,
-                    policy_context_tables: sub.policy_context_tables,
-                    required_tier: sub.required_tier,
-                    sent_below_required_settled,
-                    last_emitted_settled_tier,
-                    last_scope: scope.unwrap_or_default(),
-                    needs_recompile: false,
-                    settled_once,
-                    propagation: sub.propagation,
-                    reported_schema_warnings,
-                },
-            );
+            // A one-shot subscription was already served above and must not
+            // stay installed.
+            if !sub.one_shot {
+                self.server_subscriptions.insert(
+                    (sub.client_id, sub.query_id),
+                    ServerQuerySubscription {
+                        query: sub.query,
+                        graph,
+                        schema_context: subscription_context,
+                        session: session_for_policy,
+                        branches,
+                        policy_context_tables: sub.policy_context_tables,
+                        required_tier: sub.required_tier,
+                        sent_below_required_settled,
+                        last_emitted_settled_tier,
+                        last_scope: scope.unwrap_or_default(),
+                        needs_recompile: false,
+                        settled_once,
+                        propagation: sub.propagation,
+                        reported_schema_warnings,
+                    },
+                );
+            }
 
             if self.sync_manager.outbox().len() >= MAX_INITIAL_QUERY_REPLAY_OUTBOX_PER_PASS {
                 for remaining_key in pending_keys.iter().skip(key_index + 1) {

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -758,33 +758,36 @@ impl QueryManager {
                 }
             }
         }
-        let context_table_names: HashSet<&str> =
-            context_tables.iter().map(|table| table.as_str()).collect();
-        if !context_table_names.is_empty()
-            && let Ok(objects) = storage.scan_row_locators()
-        {
+        if !context_tables.is_empty() {
+            // Iterate the context tables' own id indexes; a full
+            // scan_row_locators pass costs the whole store per settle.
             let branch_names: Vec<BranchName> = branches.iter().map(BranchName::new).collect();
-            for (object_id, row_locator) in objects {
-                let table_name = row_locator.table.as_str();
-                if !context_table_names.contains(table_name) {
-                    continue;
-                }
+            for table in &context_tables {
+                let table_name = table.as_str();
                 for branch_name in &branch_names {
-                    if scope.contains(&(object_id, *branch_name)) {
-                        continue;
-                    }
-                    let authorized = self.provenance_row_matches_current_select_policy(
-                        storage,
-                        settlement_eval_cache,
-                        object_id,
-                        *branch_name,
-                        session,
-                        &auth_schema,
-                        &auth_context,
-                        source_branch_schema_map,
-                    );
-                    if authorized {
-                        scope.insert((object_id, *branch_name));
+                    // Soft-deleted rows live in _id_deleted; their tombstones
+                    // must sync so clients drop stale context rows.
+                    for index in ["_id", "_id_deleted"] {
+                        for object_id in
+                            storage.index_scan_all(table_name, index, branch_name.as_str())
+                        {
+                            if scope.contains(&(object_id, *branch_name)) {
+                                continue;
+                            }
+                            let authorized = self.provenance_row_matches_current_select_policy(
+                                storage,
+                                settlement_eval_cache,
+                                object_id,
+                                *branch_name,
+                                session,
+                                &auth_schema,
+                                &auth_context,
+                                source_branch_schema_map,
+                            );
+                            if authorized {
+                                scope.insert((object_id, *branch_name));
+                            }
+                        }
                     }
                 }
             }
@@ -904,29 +907,28 @@ impl QueryManager {
             return scope;
         }
 
+        // Iterate the context tables' own id indexes; a full
+        // scan_row_locators pass costs the whole store per subscription.
         let branch_names: Vec<BranchName> = branches.iter().map(BranchName::new).collect();
-        let Ok(objects) = storage.scan_row_locators() else {
-            return scope;
-        };
-        for (object_id, row_locator) in objects {
-            let table_name = row_locator.table.as_str();
-            if !policy_tables
-                .iter()
-                .any(|table| table.as_str() == table_name)
-            {
-                continue;
-            }
-
+        for table in policy_tables {
+            let table_name = table.as_str();
             for branch_name in &branch_names {
-                let Some(row) = storage
-                    .load_visible_region_row(table_name, branch_name.as_str(), object_id)
-                    .ok()
-                    .flatten()
-                else {
-                    continue;
-                };
-                if !row.is_hard_deleted() {
-                    scope.insert((object_id, *branch_name));
+                // Soft-deleted rows live in _id_deleted; their tombstones
+                // must sync so clients drop stale context rows.
+                for index in ["_id", "_id_deleted"] {
+                    for object_id in storage.index_scan_all(table_name, index, branch_name.as_str())
+                    {
+                        let Some(row) = storage
+                            .load_visible_region_row(table_name, branch_name.as_str(), object_id)
+                            .ok()
+                            .flatten()
+                        else {
+                            continue;
+                        };
+                        if !row.is_hard_deleted() {
+                            scope.insert((object_id, *branch_name));
+                        }
+                    }
                 }
             }
         }
@@ -1237,7 +1239,11 @@ impl QueryManager {
             }
 
             // A one-shot subscription was already served above and must not
-            // stay installed.
+            // stay installed; drop its scope entry too.
+            if sub.one_shot {
+                self.sync_manager
+                    .drop_client_query_subscription(sub.client_id, sub.query_id);
+            }
             if !sub.one_shot {
                 self.server_subscriptions.insert(
                     (sub.client_id, sub.query_id),
@@ -1295,6 +1301,18 @@ impl QueryManager {
                 .remove(&(unsub.client_id, unsub.query_id))
                 .map(|sub| sub.propagation)
                 .unwrap_or(crate::sync_manager::QueryPropagation::Full);
+
+            // Drop the per-client query scope and sent-row tracking so
+            // unsubscribed queries stop growing the forwarding scope.
+            // A pending same-drain resubscription keeps its state: its
+            // arrival already registered the query origin.
+            if !self
+                .sync_manager
+                .has_pending_query_subscription(unsub.client_id, unsub.query_id)
+            {
+                self.sync_manager
+                    .drop_client_query_subscription(unsub.client_id, unsub.query_id);
+            }
 
             if propagation == crate::sync_manager::QueryPropagation::Full {
                 // Forward unsubscription to upstream servers

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -5,7 +5,9 @@ use std::time::{Duration, Instant};
 
 use crate::metadata::{MetadataKey, RowProvenance};
 use crate::object::{BranchName, ObjectId};
-use crate::query_manager::graph_nodes::policy_eval::PolicyContextEvaluator;
+use crate::query_manager::graph_nodes::policy_eval::{
+    PolicyContextEvaluator, collect_policy_dependency_tables,
+};
 use crate::row_histories::BatchId;
 use crate::schema_manager::{LensTransformer, transformer::translate_table_name_from_schema};
 use crate::storage::Storage;
@@ -663,6 +665,7 @@ impl QueryManager {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn authorized_scope_from_graph_if_available(
         &mut self,
         storage: &dyn Storage,
@@ -671,12 +674,19 @@ impl QueryManager {
         schema_context: &crate::schema_manager::SchemaContext,
         source_branch_schema_map: &std::collections::HashMap<String, SchemaHash>,
         session: Option<&Session>,
+        policy_context_tables: &HashSet<TableName>,
+        branches: &[String],
     ) -> Option<HashSet<(ObjectId, BranchName)>> {
         let Some((auth_schema, auth_context)) =
             self.authorization_schema_for_context(&schema_context.env, &schema_context.user_branch)
         else {
             if !self.authorization_schema_required {
-                return Some(graph.sync_scope_object_ids());
+                return Some(Self::scope_with_policy_context_rows_for_tables(
+                    &graph.sync_scope_object_ids(),
+                    policy_context_tables,
+                    branches,
+                    storage,
+                ));
             }
             return None;
         };
@@ -686,7 +696,12 @@ impl QueryManager {
                 .values()
                 .all(|table_schema| table_schema.policies.select.using.is_none())
         {
-            return Some(graph.sync_scope_object_ids());
+            return Some(Self::scope_with_policy_context_rows_for_tables(
+                &graph.sync_scope_object_ids(),
+                policy_context_tables,
+                branches,
+                storage,
+            ));
         }
 
         let mut authorization_cache: HashMap<(ObjectId, BranchName), bool> = HashMap::new();
@@ -714,12 +729,68 @@ impl QueryManager {
                 })
         });
 
-        Some(
-            authorized_scope_tuples
-                .into_iter()
-                .flat_map(|tuple| tuple.provenance().clone().into_iter())
-                .collect(),
-        )
+        let mut scope: HashSet<(ObjectId, BranchName)> = authorized_scope_tuples
+            .into_iter()
+            .flat_map(|tuple| tuple.provenance().clone().into_iter())
+            .collect();
+
+        // Policy-context rows let the client evaluate read policies with
+        // exists/join subqueries locally. Each context row must itself pass
+        // its table's read policy, so this never widens what the session
+        // can read.
+        // Expand to the transitive closure: a context table's read policy
+        // may itself depend on further context tables.
+        let mut context_tables: HashSet<TableName> = policy_context_tables.clone();
+        let mut context_worklist: Vec<TableName> = context_tables.iter().copied().collect();
+        while let Some(table) = context_worklist.pop() {
+            let Some(table_schema) = auth_schema.get(&table) else {
+                continue;
+            };
+            let Some(select_policy) = table_schema.policies.select_policy() else {
+                continue;
+            };
+            let dependencies =
+                collect_policy_dependency_tables(select_policy, &table_schema.columns);
+            for dependency in dependencies {
+                let dependency = TableName::new(&dependency);
+                if context_tables.insert(dependency) {
+                    context_worklist.push(dependency);
+                }
+            }
+        }
+        let context_table_names: HashSet<&str> =
+            context_tables.iter().map(|table| table.as_str()).collect();
+        if !context_table_names.is_empty()
+            && let Ok(objects) = storage.scan_row_locators()
+        {
+            let branch_names: Vec<BranchName> = branches.iter().map(BranchName::new).collect();
+            for (object_id, row_locator) in objects {
+                let table_name = row_locator.table.as_str();
+                if !context_table_names.contains(table_name) {
+                    continue;
+                }
+                for branch_name in &branch_names {
+                    if scope.contains(&(object_id, *branch_name)) {
+                        continue;
+                    }
+                    let authorized = self.provenance_row_matches_current_select_policy(
+                        storage,
+                        settlement_eval_cache,
+                        object_id,
+                        *branch_name,
+                        session,
+                        &auth_schema,
+                        &auth_context,
+                        source_branch_schema_map,
+                    );
+                    if authorized {
+                        scope.insert((object_id, *branch_name));
+                    }
+                }
+            }
+        }
+
+        Some(scope)
     }
 
     pub(super) fn resolved_server_query_branches(
@@ -1088,6 +1159,8 @@ impl QueryManager {
                     &subscription_context,
                     &branch_schema_map,
                     session_for_policy.as_ref(),
+                    &policy_context_tables,
+                    &branches,
                 )
             };
             let settled_once = scope.is_some();
@@ -1345,6 +1418,8 @@ impl QueryManager {
                         &sub.schema_context,
                         &branch_schema_map,
                         sub.session.as_ref(),
+                        &policy_context_tables,
+                        branches,
                     )
                     .map(Cow::Owned)
                 }

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -1785,6 +1785,7 @@ impl SyncManager {
                         required_tier: *required_tier,
                         propagation: *propagation,
                         policy_context_tables: policy_context_tables.clone(),
+                        one_shot: false,
                     });
             }
             // Handle query unsubscription
@@ -1802,6 +1803,21 @@ impl SyncManager {
                         self.query_origin.remove(query_id);
                     }
                 }
+                // A matching pending subscription means the client
+                // subscribed and unsubscribed within one drain (a one-shot
+                // query served locally). Mark it one-shot instead of
+                // dropping the pair: unsubscriptions are processed before
+                // subscriptions, so plain enqueueing would install the
+                // subscription afterwards and leak it.
+                for subscription in &mut self.pending_query_subscriptions {
+                    if subscription.client_id == client_id && subscription.query_id == *query_id {
+                        subscription.one_shot = true;
+                    }
+                }
+                // Still enqueue the unsubscription: the marked
+                // subscription can be an active-query replay after a
+                // reconnect, and only the processed unsubscription removes
+                // an already-installed server subscription.
                 self.pending_query_unsubscriptions
                     .push(PendingQueryUnsubscription {
                         client_id,

--- a/crates/jazz-tools/src/sync_manager/mod.rs
+++ b/crates/jazz-tools/src/sync_manager/mod.rs
@@ -748,6 +748,23 @@ impl SyncManager {
     /// Take pending query unsubscriptions for QueryManager to process.
     ///
     /// QueryManager will remove server-side QueryGraphs and forward upstream.
+    /// Whether the given client is registered as an origin for the query.
+    pub fn query_origin_contains(&self, query_id: QueryId, client_id: ClientId) -> bool {
+        self.query_origin
+            .get(&query_id)
+            .is_some_and(|clients| clients.contains(&client_id))
+    }
+
+    /// Whether a non-one-shot subscription for this client and query is
+    /// still queued for processing (a same-drain resubscription).
+    pub fn has_pending_query_subscription(&self, client_id: ClientId, query_id: QueryId) -> bool {
+        self.pending_query_subscriptions.iter().any(|subscription| {
+            subscription.client_id == client_id
+                && subscription.query_id == query_id
+                && !subscription.one_shot
+        })
+    }
+
     pub fn take_pending_query_unsubscriptions(&mut self) -> Vec<PendingQueryUnsubscription> {
         std::mem::take(&mut self.pending_query_unsubscriptions)
     }

--- a/crates/jazz-tools/src/sync_manager/tests/basic.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/basic.rs
@@ -79,6 +79,7 @@ fn memory_size_separates_sync_state_buckets() {
             required_tier: None,
             propagation: QueryPropagation::Full,
             policy_context_tables: vec![],
+            one_shot: false,
         });
     sm.pending_query_unsubscriptions
         .push(PendingQueryUnsubscription {

--- a/crates/jazz-tools/src/sync_manager/tests/subscriptions.rs
+++ b/crates/jazz-tools/src/sync_manager/tests/subscriptions.rs
@@ -119,6 +119,7 @@ fn remove_client_cleans_pending_query_subscriptions() {
             required_tier: None,
             propagation: QueryPropagation::Full,
             policy_context_tables: vec![],
+            one_shot: false,
         });
     sm.pending_query_subscriptions
         .push(PendingQuerySubscription {
@@ -129,6 +130,7 @@ fn remove_client_cleans_pending_query_subscriptions() {
             required_tier: None,
             propagation: QueryPropagation::Full,
             policy_context_tables: vec![],
+            one_shot: false,
         });
 
     sm.remove_client(alice);
@@ -213,4 +215,79 @@ fn initial_query_scope_sends_one_settlement_per_batch() {
             confirmed_tier: DurabilityTier::GlobalServer,
         } if *settled_batch_id == batch_id
     ));
+}
+
+/// A coalesced subscribe/unsubscribe pair marks the subscription one-shot
+/// and still enqueues the unsubscription for an already-installed
+/// subscription from a reconnect replay.
+#[test]
+fn coalesced_subscribe_unsubscribe_marks_one_shot_and_keeps_unsubscription() {
+    let mut sm = SyncManager::new();
+    let mut io = MemoryStorage::new();
+    let client_id = ClientId::new();
+    add_client(&mut sm, &io, client_id);
+
+    let query = QueryBuilder::new("messages").branch("main").build();
+    sm.push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::QuerySubscription {
+            query_id: QueryId(1),
+            query: Box::new(query),
+            session: None,
+            required_tier: None,
+            propagation: QueryPropagation::Full,
+            policy_context_tables: vec![],
+        },
+    });
+    sm.push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::QueryUnsubscription {
+            query_id: QueryId(1),
+        },
+    });
+    sm.process_inbox(&mut io);
+
+    let subscriptions = sm.take_pending_query_subscriptions();
+    assert_eq!(subscriptions.len(), 1);
+    assert!(subscriptions[0].one_shot);
+    let unsubscriptions = sm.take_pending_query_unsubscriptions();
+    assert_eq!(unsubscriptions.len(), 1);
+    assert_eq!(unsubscriptions[0].client_id, client_id);
+    assert_eq!(unsubscriptions[0].query_id, QueryId(1));
+}
+
+/// The unsubscribe-then-resubscribe replay pattern must keep the
+/// resubscription installed: only a pending subscription that precedes the
+/// unsubscription is a coalesced one-shot pair.
+#[test]
+fn unsubscribe_then_resubscribe_keeps_the_resubscription() {
+    let mut sm = SyncManager::new();
+    let mut io = MemoryStorage::new();
+    let client_id = ClientId::new();
+    add_client(&mut sm, &io, client_id);
+
+    sm.push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::QueryUnsubscription {
+            query_id: QueryId(1),
+        },
+    });
+    let query = QueryBuilder::new("messages").branch("main").build();
+    sm.push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::QuerySubscription {
+            query_id: QueryId(1),
+            query: Box::new(query),
+            session: None,
+            required_tier: None,
+            propagation: QueryPropagation::Full,
+            policy_context_tables: vec![],
+        },
+    });
+    sm.process_inbox(&mut io);
+
+    let subscriptions = sm.take_pending_query_subscriptions();
+    assert_eq!(subscriptions.len(), 1);
+    assert!(!subscriptions[0].one_shot);
+    assert_eq!(sm.take_pending_query_unsubscriptions().len(), 1);
 }

--- a/crates/jazz-tools/src/sync_manager/types.rs
+++ b/crates/jazz-tools/src/sync_manager/types.rs
@@ -671,6 +671,9 @@ pub struct PendingQuerySubscription {
     pub required_tier: Option<DurabilityTier>,
     pub propagation: QueryPropagation,
     pub policy_context_tables: Vec<String>,
+    /// The client unsubscribed within the same inbox drain (a one-shot
+    /// query): serve it once but never install it.
+    pub one_shot: bool,
 }
 
 /// A pending query unsubscription that needs cleanup.


### PR DESCRIPTION
Stacked on #1134 and #1135, review the last commit. Policy context collection scanned whole tables per settle, and per-client scope entries were never dropped on unsubscribe, so long-lived connections kept growing. Iterate the _id/_id_deleted indexes instead (tombstones included so deletions propagate) and drop scope with the client's last subscription, keeping same-drain resubscriptions intact.

cargo test -p jazz-tools --lib --features test-utils passes (1387).