### PR TITLE
Source create-jazz starters from published releases

### DIFF
--- a/.changeset/released-starters.md
+++ b/.changeset/released-starters.md
@@ -1,0 +1,5 @@
+---
+"create-jazz": patch
+---
+
+Clone starter templates and resolve workspace dependencies from the matching published release tag.

--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -408,7 +408,7 @@ jobs:
       )
     permissions:
       actions: read
-      contents: read
+      contents: write
       id-token: write
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -778,6 +778,18 @@ jobs:
           fi
 
           npm dist-tag add "create-jazz@${CREATE_JAZZ_VERSION}" latest
+
+      - name: Tag published source
+        if: env.RELEASE_MODE == 'publish'
+        run: |
+          VERSION=$(node -p 'JSON.parse(require("fs").readFileSync("packages/create-jazz/package.json","utf8")).version')
+          TAG="v${VERSION}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "${TAG} already exists; skipping tag creation."
+          else
+            git tag "${TAG}" "${GITHUB_SHA}"
+            git push origin "${TAG}"
+          fi
 
   deploy-inspector-production:
     name: Promote inspector production

--- a/packages/create-jazz/src/deps.ts
+++ b/packages/create-jazz/src/deps.ts
@@ -213,10 +213,10 @@ async function fetchOnce(url: string): Promise<Response> {
 
 export async function resolveRemoteDeps(
   manifest: PackageManifest,
-  repoConfig: { repo: string; branch: string },
+  repoConfig: { repo: string; ref: string },
   onProgress?: ResolveProgressCallback,
 ): Promise<PackageManifest> {
-  const rawBase = `https://raw.githubusercontent.com/${repoConfig.repo}/refs/heads/${repoConfig.branch}`;
+  const rawBase = `https://raw.githubusercontent.com/${repoConfig.repo}/${repoConfig.ref}`;
   const workspaceUrl = `${rawBase}/pnpm-workspace.yaml`;
 
   const wsRes = await fetchOnce(workspaceUrl);

--- a/packages/create-jazz/src/scaffold-release.test.ts
+++ b/packages/create-jazz/src/scaffold-release.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { scaffold } from "./scaffold.js";
+
+const { tigedMock } = vi.hoisted(() => ({ tigedMock: vi.fn() }));
+
+vi.mock("tiged", () => ({ default: tigedMock }));
+
+const packageVersion = (
+  JSON.parse(fs.readFileSync(path.resolve(import.meta.dirname, "../package.json"), "utf8")) as {
+    version: string;
+  }
+).version;
+
+describe("scaffold release source", () => {
+  let tmpRoot: string;
+  let targetDir: string;
+  let previousStarterPath: string | undefined;
+
+  beforeEach(() => {
+    previousStarterPath = process.env.JAZZ_STARTER_PATH;
+    delete process.env.JAZZ_STARTER_PATH;
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "create-jazz-release-"));
+    targetDir = path.join(tmpRoot, "app");
+    tigedMock.mockImplementation(() => ({
+      clone: async (dir: string) => {
+        await fs.promises.writeFile(
+          path.join(dir, "package.json"),
+          JSON.stringify({ name: "release-starter" }),
+        );
+      },
+    }));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("packages: []\n")),
+    );
+  });
+
+  afterEach(() => {
+    if (previousStarterPath === undefined) delete process.env.JAZZ_STARTER_PATH;
+    else process.env.JAZZ_STARTER_PATH = previousStarterPath;
+    vi.unstubAllGlobals();
+    tigedMock.mockReset();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("fetches the starter and workspace metadata from the installed release", async () => {
+    await scaffold({
+      appName: "release-app",
+      targetDir,
+      pm: null,
+      starter: "next-betterauth",
+      git: false,
+    });
+
+    const releaseRef = `v${packageVersion}`;
+    expect(tigedMock).toHaveBeenCalledWith(
+      `garden-co/jazz/starters/next-betterauth#${releaseRef}`,
+      { disableCache: true },
+    );
+    expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+      `https://raw.githubusercontent.com/garden-co/jazz/refs/tags/${releaseRef}/pnpm-workspace.yaml`,
+      expect.anything(),
+    );
+  });
+});

--- a/packages/create-jazz/src/scaffold.ts
+++ b/packages/create-jazz/src/scaffold.ts
@@ -9,7 +9,13 @@ import {
 } from "./deps.js";
 
 const REPO = "garden-co/jazz";
-const BRANCH = "main";
+const RELEASE_REF = `v${
+  (
+    JSON.parse(fs.readFileSync(path.resolve(import.meta.dirname, "../package.json"), "utf-8")) as {
+      version: string;
+    }
+  ).version
+}`;
 const DEFAULT_STARTER = "next-betterauth";
 
 export const KNOWN_STARTERS = [
@@ -77,7 +83,7 @@ async function fetchStarter(starter: StarterName, dir: string): Promise<void> {
     return;
   }
   const tiged = (await import("tiged")).default;
-  const emitter = tiged(`${REPO}/starters/${starter}#${BRANCH}`, { disableCache: true });
+  const emitter = tiged(`${REPO}/starters/${starter}#${RELEASE_REF}`, { disableCache: true });
   await emitter.clone(dir);
 }
 
@@ -89,7 +95,7 @@ async function resolveManifest(
   if (localPath) {
     return resolveLocalDeps(manifest, path.resolve(localPath, "../.."), onProgress);
   }
-  return resolveRemoteDeps(manifest, { repo: REPO, branch: BRANCH }, onProgress);
+  return resolveRemoteDeps(manifest, { repo: REPO, ref: `refs/tags/${RELEASE_REF}` }, onProgress);
 }
 
 export async function scaffold(options: ScaffoldOptions): Promise<void> {


### PR DESCRIPTION
## Summary

- Clone starter templates from the matching `v<version>` release tag.
- Resolve remote workspace packages from that same release tag.
- Create the matching tag in the alpha publish workflow.

## Testing

- `pnpm --filter create-jazz test` — 71 tests passed.