### PR TITLE
(new core) fix(inspector): avoid passing unset fields as "" on row insert

### DIFF
--- a/packages/inspector/src/components/data-explorer/TableDataGrid.module.css
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.module.css
@@ -189,6 +189,10 @@
   font-size: 0.92em;
 }
 
+.unsetCellMarker {
+  font-style: italic;
+}
+
 .booleanCell {
   display: flex;
   align-items: center;

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
@@ -60,7 +60,12 @@ const mockWasmSchema = {
     columns: [
       { name: "title", column_type: { type: "Text" }, nullable: false },
       { name: "done", column_type: { type: "Boolean" }, nullable: false },
-      { name: "maybe_done", column_type: { type: "Boolean" }, nullable: true },
+      {
+        name: "maybe_done",
+        column_type: { type: "Boolean" },
+        nullable: true,
+        default: { type: "Null" },
+      },
       { name: "meta", column_type: { type: "Row", columns: [] }, nullable: true },
       { name: "owner_id", column_type: { type: "Uuid" }, nullable: true, references: "users" },
       { name: "blob", column_type: { type: "Bytea" }, nullable: true },
@@ -663,9 +668,22 @@ describe("TableDataGrid", () => {
     const statusCell = stagedCells[7];
     expect(statusCell).not.toBeUndefined();
     expect(within(statusCell as HTMLElement).getByText("open")).not.toBeNull();
-    expect(within(initialStagedRow as HTMLElement).getAllByText("<null>").length).toBeGreaterThan(
-      0,
-    );
+    // italic <null>, actual value omitted until edited
+    const unsetTitle = within(stagedCells[1] as HTMLElement).getByText("<null>");
+    expect(unsetTitle.tagName).toBe("I");
+    expect(unsetTitle.getAttribute("data-cell-value-state")).toBe("unset");
+    // regular <null>, omitted so the database applies its default
+    const defaultNull = within(stagedCells[3] as HTMLElement).getByText("<null>");
+    expect(defaultNull.tagName).toBe("DIV");
+    expect(defaultNull.getAttribute("data-cell-value-state")).toBeNull();
+    // regular <null>, included in the insert
+    const nullableNull = within(stagedCells[4] as HTMLElement).getByText("<null>");
+    expect(nullableNull.tagName).toBe("DIV");
+    expect(nullableNull.getAttribute("data-cell-value-state")).toBeNull();
+    const doneCheckbox = within(initialStagedRow as HTMLElement).getByRole("checkbox", {
+      name: "Toggle done for staged insert",
+    });
+    expect((doneCheckbox as HTMLInputElement).checked).toBe(false);
 
     fireEvent.doubleClick(stagedCells[1] as HTMLElement);
     const titleEditor = screen.getByLabelText("Edit title");
@@ -683,19 +701,54 @@ describe("TableDataGrid", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
 
     await waitFor(() => {
-      expect(mockInsert).toHaveBeenCalledWith(
-        expect.objectContaining({ _table: "todos" }),
-        expect.objectContaining({
-          title: "new todo",
-          done: true,
-          meta: null,
-          owner_id: null,
-        }),
-      );
+      expect(mockInsert).toHaveBeenCalledWith(expect.objectContaining({ _table: "todos" }), {
+        title: "new todo",
+        done: true,
+        meta: null,
+        owner_id: null,
+      });
       expect(mockInsertWait).toHaveBeenCalledWith({ tier: "local" });
     });
 
     expect(mockInsert.mock.calls[0]?.[1]).not.toHaveProperty("status");
+  });
+
+  it("reports the Db insert error", async () => {
+    mockInsert.mockImplementationOnce(() => {
+      throw new Error('Insert failed: WriteError("missing required column title")');
+    });
+    renderGrid();
+
+    fireEvent.click(screen.getByRole("button", { name: "Insert row" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toContain("missing required column title");
+    });
+
+    expect(screen.getByText("1 staged insert")).not.toBeNull();
+  });
+
+  it("includes an explicitly entered empty string in a staged insert", async () => {
+    renderGrid();
+
+    fireEvent.click(screen.getByRole("button", { name: "Insert row" }));
+    const stagedCells = getCellsInRowContaining("staged");
+    fireEvent.doubleClick(stagedCells[1] as HTMLElement);
+    const titleEditor = screen.getByLabelText("Edit title");
+    fireEvent.change(titleEditor, { target: { value: "temporary" } });
+    fireEvent.change(titleEditor, { target: { value: "" } });
+    fireEvent.blur(titleEditor);
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(mockInsert).toHaveBeenCalledWith(expect.objectContaining({ _table: "todos" }), {
+        title: "",
+        done: false,
+        meta: null,
+        owner_id: null,
+      });
+    });
   });
 
   it("queues multiple staged insert rows and inserts them from the banner", async () => {
@@ -708,7 +761,7 @@ describe("TableDataGrid", () => {
     expect(screen.getByText("2 staged inserts")).not.toBeNull();
 
     let stagedBadges = screen.getAllByText("staged");
-    let firstStagedCells = getCellsInRow(stagedBadges[0] as HTMLElement);
+    const firstStagedCells = getCellsInRow(stagedBadges[0] as HTMLElement);
     fireEvent.doubleClick(firstStagedCells[1] as HTMLElement);
     const firstTitleEditor = screen.getByLabelText("Edit title");
     fireEvent.change(firstTitleEditor, { target: { value: "first todo" } });
@@ -734,26 +787,18 @@ describe("TableDataGrid", () => {
 
     await waitFor(() => {
       expect(mockInsert).toHaveBeenCalledTimes(2);
-      expect(mockInsert).toHaveBeenNthCalledWith(
-        1,
-        expect.objectContaining({ _table: "todos" }),
-        expect.objectContaining({
-          title: "first todo",
-          done: true,
-          meta: null,
-          owner_id: null,
-        }),
-      );
-      expect(mockInsert).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({ _table: "todos" }),
-        expect.objectContaining({
-          title: "second todo",
-          done: false,
-          meta: null,
-          owner_id: null,
-        }),
-      );
+      expect(mockInsert).toHaveBeenNthCalledWith(1, expect.objectContaining({ _table: "todos" }), {
+        title: "first todo",
+        done: true,
+        meta: null,
+        owner_id: null,
+      });
+      expect(mockInsert).toHaveBeenNthCalledWith(2, expect.objectContaining({ _table: "todos" }), {
+        title: "second todo",
+        done: false,
+        meta: null,
+        owner_id: null,
+      });
       expect(mockInsertWait).toHaveBeenCalledTimes(2);
     });
   });

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
@@ -296,14 +296,21 @@ function createInitialStagedInsertEdits(schemaColumns: ColumnDescriptor[]): Queu
   const edits: QueuedRowEdits = {};
 
   for (const column of schemaColumns) {
-    if (getFieldReadOnlyReason(column) !== null || hasColumnDefault(column)) {
+    if (hasColumnDefault(column) || getFieldReadOnlyReason(column) !== null) {
       continue;
     }
 
-    edits[column.name] = {
-      text: column.column_type.type === "Boolean" && !column.nullable ? "false" : "",
-      isNull: column.nullable,
-    };
+    if (column.nullable) {
+      edits[column.name] = {
+        text: "",
+        isNull: true,
+      };
+    } else if (column.column_type.type === "Boolean") {
+      edits[column.name] = {
+        text: "false",
+        isNull: false,
+      };
+    }
   }
 
   return edits;
@@ -329,14 +336,6 @@ function buildQueuedInsertValues(
 
     const edit = queuedInsertEdits[column.name];
     if (!edit) {
-      if (hasColumnDefault(column)) {
-        continue;
-      }
-
-      values[column.name] = parseQueuedEditForColumn(column, {
-        text: "",
-        isNull: column.nullable,
-      });
       continue;
     }
 
@@ -912,7 +911,9 @@ export function TableDataGrid() {
       setQueuedDeletes(new Set());
     } catch (error) {
       setQueuedSaveError(
-        error instanceof Error ? error.message : "Could not persist queued cell edits.",
+        error instanceof Error || (typeof Error.isError === "function" && Error.isError(error))
+          ? error.message
+          : "Could not persist queued cell edits.",
       );
     } finally {
       setIsQueuedSavePending(false);
@@ -1454,6 +1455,18 @@ function NullCellMarker() {
   );
 }
 
+function UnsetCellMarker() {
+  return (
+    <i
+      className={`${styles.cellContent} ${styles.nullCellMarker} ${styles.unsetCellMarker}`}
+      title="Unset — this field will be omitted from the insert"
+      data-cell-value-state="unset"
+    >
+      {NULL_CELL_MARKER}
+    </i>
+  );
+}
+
 function RelationCell({
   schema,
   relationTable,
@@ -1784,6 +1797,10 @@ function PlainTableView({
 
           const rawValue = row.row[column.accessorKey];
 
+          if (row.isStagedInsert && rawValue === undefined) {
+            return <UnsetCellMarker />;
+          }
+
           if (rawValue === null) {
             return <NullCellMarker />;
           }
@@ -2068,7 +2085,7 @@ function PlainTableView({
 
         if (schemaColumn.column_type.type === "Boolean") {
           const rawValue = args.row?.row[schemaColumn.name];
-          if (schemaColumn.nullable && (rawValue === null || rawValue === undefined)) {
+          if (rawValue === undefined || (schemaColumn.nullable && rawValue === null)) {
             queueCellEdit(args.row, schemaColumn, {
               text: "false",
               isNull: false,

--- a/packages/inspector/tsconfig.app.json
+++ b/packages/inspector/tsconfig.app.json
@@ -3,7 +3,7 @@
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2022",
     "useDefineForClassFields": true,
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "ESNext.Error", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "types": ["vite/client"],
     "skipLibCheck": true,

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/basic/schema.ts
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/basic/schema.ts
@@ -69,7 +69,7 @@ export const permissions = s.definePermissions(baseApp, ({ policy }) => {
   policy.projects.allowDelete.where({});
 
   policy.todos.allowRead.where({});
-  policy.todos.allowInsert.where({});
+  policy.todos.allowInsert.where({ done: false });
   policy.todos.allowUpdate.whereOld({ done: false }).whereNew({});
   policy.todos.allowDelete.where({ done: false });
 });

--- a/packages/jazz-tools/tests/ts-dsl/insert-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/insert-api.test.ts
@@ -28,7 +28,7 @@ describe("TS Insert API", () => {
 
     const { value: todo } = db.insert(app.todos, {
       title: "Test Todo",
-      done: true,
+      done: false,
       tags: ["tag1", "tag2"],
       projectId: project.id,
       ownerId: owner.id,
@@ -38,7 +38,7 @@ describe("TS Insert API", () => {
     expect(todo).toEqual({
       id: expect.any(String),
       title: "Test Todo",
-      done: true,
+      done: false,
       tags: ["tag1", "tag2"],
       projectId: project.id,
       ownerId: owner.id,
@@ -57,7 +57,7 @@ describe("TS Insert API", () => {
     const todo = await db
       .insert(app.todos, {
         title: "Test Todo",
-        done: true,
+        done: false,
         tags: ["tag1", "tag2"],
         projectId: project.id,
         ownerId: owner.id,
@@ -67,7 +67,7 @@ describe("TS Insert API", () => {
     expect(todo).toEqual({
       id: expect.any(String),
       title: "Test Todo",
-      done: true,
+      done: false,
       tags: ["tag1", "tag2"],
       projectId: project.id,
       ownerId: owner.id,
@@ -183,6 +183,25 @@ describe("TS Insert API", () => {
 
     const queried = await db.one(app.table_with_defaults.where({ id: { eq: rowWithDefaults.id } }));
     expect(queried).toEqual(rowWithDefaults);
+  });
+
+  it("fails synchronously if any required fields are missing", () => {
+    // @ts-expect-error `name` is missing
+    expect(() => db.insert(app.projects, {})).toThrow("missing required column name");
+  });
+
+  it("fails synchronously if a permission rejects the insert", () => {
+    const project = insertProject(db);
+    const owner = insertUser(db);
+    expect(() =>
+      db.insert(app.todos, {
+        title: "Test Todo",
+        projectId: project.id,
+        ownerId: owner.id,
+        // Rows can only be inserted with `done: false`
+        done: true,
+      }),
+    ).toThrow('Insert failed: WriteError("policy denied INSERT on table todos")');
   });
 
   it("stores explicit values for defaulted columns instead of replacing them", async () => {


### PR DESCRIPTION
## Description

Before this PR, when inserting a row via the inspector all unset values were set to an empty string (`""`). This led to unexpected errors when an unset field didn't comply with permissions. We now instead show these unset fields as _`<null>`_ (in italics, to distinguish it from regular null default values). The only exceptions are nullable and boolean fields, which still default to null/false.

I also added a `Error.isError` check to make sure we properly surface cross-runtime errors reported by Jazz and caught by the inspector.

## Validation

#### Before

https://github.com/user-attachments/assets/1c0cfa4c-9da1-4334-a418-860fbbb4aa6c

#### After

https://github.com/user-attachments/assets/8f37791c-73d1-469a-aa58-28386ddcb5ae
