### PR TITLE
(new core) Widen query membership filters to non-text scalars and array elements

### DIFF
--- a/crates/jazz-tools/Cargo.toml
+++ b/crates/jazz-tools/Cargo.toml
@@ -212,6 +212,10 @@ required-features = ["test"]
 name = "policy_branch_closure"
 required-features = ["test"]
 
+[[test]]
+name = "query_membership_filters"
+required-features = ["test"]
+
 [[example]]
 name = "realistic_bench"
 required-features = ["client"]

--- a/crates/jazz-tools/src/client.rs
+++ b/crates/jazz-tools/src/client.rs
@@ -1656,6 +1656,13 @@ fn core_query_condition(
         PublicCondition::Contains { value, .. } => {
             jazz::query::contains(column_operand(), literal_operand(value)?)
         }
+        PublicCondition::In { values, .. } => jazz::query::in_list(
+            column_operand(),
+            values
+                .iter()
+                .map(|value| literal_operand(value))
+                .collect::<Result<Vec<_>>>()?,
+        ),
         PublicCondition::IsNull { .. } => jazz::query::is_null(column_operand()),
         PublicCondition::IsNotNull { .. } => {
             jazz::query::not(jazz::query::is_null(column_operand()))

--- a/crates/jazz-tools/src/public_api/query.rs
+++ b/crates/jazz-tools/src/public_api/query.rs
@@ -229,6 +229,8 @@ pub enum Condition {
         min: Value,
         max: Value,
     },
+    /// Column equals one of the listed values.
+    In { column: String, values: Vec<Value> },
     /// Array column contains value.
     Contains { column: String, value: Value },
     /// Column is null.
@@ -300,6 +302,16 @@ impl Condition {
                     value: encode(max),
                 },
             ]),
+            Condition::In { values, .. } if values.is_empty() => Predicate::Or(vec![]),
+            Condition::In { values, .. } => Predicate::Or(
+                values
+                    .iter()
+                    .map(|value| Predicate::RowIdEq {
+                        element_index,
+                        value: encode(value),
+                    })
+                    .collect(),
+            ),
             Condition::Contains { .. } => Predicate::Or(vec![]),
             Condition::IsNull { .. } => Predicate::RowIdIsNull { element_index },
             Condition::IsNotNull { .. } => Predicate::RowIdIsNotNull { element_index },
@@ -316,6 +328,7 @@ impl Condition {
             Condition::Gt { column, .. } => column,
             Condition::Ge { column, .. } => column,
             Condition::Between { column, .. } => column,
+            Condition::In { column, .. } => column,
             Condition::Contains { column, .. } => column,
             Condition::IsNull { column } => column,
             Condition::IsNotNull { column } => column,
@@ -347,6 +360,7 @@ impl Condition {
             | Condition::Gt { value, .. }
             | Condition::Ge { value, .. } => !value.is_null(),
             Condition::Between { min, max, .. } => !min.is_null() && !max.is_null(),
+            Condition::In { values, .. } => values.len() == 1 && !values[0].is_null(),
             _ => false,
         }
     }
@@ -394,6 +408,16 @@ impl Condition {
                         value: encode_value_with_type(max, col_type),
                     },
                 ]),
+                Condition::In { values, .. } if values.is_empty() => Predicate::Or(vec![]),
+                Condition::In { values, .. } => Predicate::Or(
+                    values
+                        .iter()
+                        .map(|value| Predicate::Eq {
+                            col_index,
+                            value: encode_value_with_type(value, col_type),
+                        })
+                        .collect(),
+                ),
                 Condition::Contains { value, .. } => Predicate::Contains {
                     col_index,
                     value: value.clone(),
@@ -881,6 +905,16 @@ impl QueryBuilder {
             column: column.into(),
             min,
             max,
+        });
+        self
+    }
+
+    /// Add an in-list filter condition.
+    pub fn filter_in(mut self, column: impl Into<String>, values: Vec<Value>) -> Self {
+        let current = self.query.disjuncts.last_mut().unwrap();
+        current.add(Condition::In {
+            column: column.into(),
+            values,
         });
         self
     }

--- a/crates/jazz-tools/tests/query_membership_filters.rs
+++ b/crates/jazz-tools/tests/query_membership_filters.rs
@@ -1,0 +1,246 @@
+#![cfg(feature = "test")]
+
+use jazz_tools::{
+    ColumnType, JazzClient, QueryBuilder, Schema, SchemaBuilder, TableSchema, Value, row_input,
+};
+
+fn membership_schema() -> Schema {
+    SchemaBuilder::new()
+        .table(TableSchema::builder("users").column("name", ColumnType::Text))
+        .table(
+            TableSchema::builder("items")
+                .column("title", ColumnType::Text)
+                .column("count", ColumnType::Integer)
+                .column("score", ColumnType::Double)
+                .column("active", ColumnType::Boolean)
+                .fk_column("owner_id", "users")
+                .column(
+                    "counts",
+                    ColumnType::Array {
+                        element: Box::new(ColumnType::Integer),
+                    },
+                )
+                .column(
+                    "flags",
+                    ColumnType::Array {
+                        element: Box::new(ColumnType::Boolean),
+                    },
+                )
+                .array_fk_column("watcher_ids", "users"),
+        )
+        .build()
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn in_filters_match_integer_float_boolean_and_reference_columns() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let client = JazzClient::test_client(membership_schema()).await;
+            let (owner_a, _, _) = client
+                .insert("users", row_input!("name" => "owner a"))
+                .expect("insert owner a");
+            let (owner_b, _, _) = client
+                .insert("users", row_input!("name" => "owner b"))
+                .expect("insert owner b");
+            let (match_a, _, _) = client
+                .insert(
+                    "items",
+                    row_input!(
+                        "title" => "alpha",
+                        "count" => 1,
+                        "score" => 1.5,
+                        "active" => true,
+                        "owner_id" => owner_a,
+                        "counts" => Value::Array(vec![Value::Integer(1), Value::Integer(3)]),
+                        "flags" => Value::Array(vec![Value::Boolean(true)]),
+                        "watcher_ids" => Value::Array(vec![Value::Uuid(owner_a)]),
+                    ),
+                )
+                .expect("insert matching item a");
+            let (match_b, _, _) = client
+                .insert(
+                    "items",
+                    row_input!(
+                        "title" => "beta",
+                        "count" => 2,
+                        "score" => 2.5,
+                        "active" => false,
+                        "owner_id" => owner_b,
+                        "counts" => Value::Array(vec![Value::Integer(2), Value::Integer(3)]),
+                        "flags" => Value::Array(vec![Value::Boolean(false)]),
+                        "watcher_ids" => Value::Array(vec![Value::Uuid(owner_b)]),
+                    ),
+                )
+                .expect("insert matching item b");
+            client
+                .insert(
+                    "items",
+                    row_input!(
+                        "title" => "gamma",
+                        "count" => 3,
+                        "score" => 3.5,
+                        "active" => true,
+                        "owner_id" => owner_b,
+                        "counts" => Value::Array(vec![Value::Integer(5)]),
+                        "flags" => Value::Array(vec![Value::Boolean(true)]),
+                        "watcher_ids" => Value::Array(vec![Value::Uuid(owner_b)]),
+                    ),
+                )
+                .expect("insert non-matching item");
+
+            let query = QueryBuilder::new("items")
+                .filter_in("count", vec![Value::Integer(1), Value::Integer(2)])
+                .filter_in("score", vec![Value::Double(1.5), Value::Double(2.5)])
+                .filter_in("active", vec![Value::Boolean(true), Value::Boolean(false)])
+                .filter_in("owner_id", vec![Value::Uuid(owner_a), Value::Uuid(owner_b)])
+                .select(&["title"])
+                .build();
+
+            let mut rows = client.query(query, None).await.expect("query items");
+            rows.sort_by_key(|(id, _)| *id);
+
+            assert_eq!(
+                rows,
+                vec![
+                    (match_a, vec![Value::Text("alpha".to_owned())]),
+                    (match_b, vec![Value::Text("beta".to_owned())]),
+                ]
+            );
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn contains_filters_match_non_text_array_elements_and_text_substrings() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let client = JazzClient::test_client(membership_schema()).await;
+            let (owner_a, _, _) = client
+                .insert("users", row_input!("name" => "owner a"))
+                .expect("insert owner a");
+            let (owner_b, _, _) = client
+                .insert("users", row_input!("name" => "owner b"))
+                .expect("insert owner b");
+            let (match_a, _, _) = client
+                .insert(
+                    "items",
+                    row_input!(
+                        "title" => "needle alpha",
+                        "count" => 1,
+                        "score" => 1.5,
+                        "active" => true,
+                        "owner_id" => owner_a,
+                        "counts" => Value::Array(vec![Value::Integer(1), Value::Integer(3)]),
+                        "flags" => Value::Array(vec![Value::Boolean(true)]),
+                        "watcher_ids" => Value::Array(vec![Value::Uuid(owner_a)]),
+                    ),
+                )
+                .expect("insert matching item a");
+            client
+                .insert(
+                    "items",
+                    row_input!(
+                        "title" => "plain beta",
+                        "count" => 2,
+                        "score" => 2.5,
+                        "active" => false,
+                        "owner_id" => owner_b,
+                        "counts" => Value::Array(vec![Value::Integer(2)]),
+                        "flags" => Value::Array(vec![Value::Boolean(false)]),
+                        "watcher_ids" => Value::Array(vec![Value::Uuid(owner_b)]),
+                    ),
+                )
+                .expect("insert non-matching item");
+
+            let count_rows = client
+                .query(
+                    QueryBuilder::new("items")
+                        .filter_contains("counts", Value::Integer(3))
+                        .select(&["title"])
+                        .build(),
+                    None,
+                )
+                .await
+                .expect("query integer array contains");
+            assert_eq!(
+                count_rows,
+                vec![(match_a, vec![Value::Text("needle alpha".to_owned())])]
+            );
+
+            let flag_rows = client
+                .query(
+                    QueryBuilder::new("items")
+                        .filter_contains("flags", Value::Boolean(true))
+                        .select(&["title"])
+                        .build(),
+                    None,
+                )
+                .await
+                .expect("query boolean array contains");
+            assert_eq!(flag_rows, count_rows);
+
+            let ref_rows = client
+                .query(
+                    QueryBuilder::new("items")
+                        .filter_contains("watcher_ids", Value::Uuid(owner_a))
+                        .select(&["title"])
+                        .build(),
+                    None,
+                )
+                .await
+                .expect("query uuid array contains");
+            assert_eq!(ref_rows, count_rows);
+
+            let text_rows = client
+                .query(
+                    QueryBuilder::new("items")
+                        .filter_contains("title", Value::Text("needle".to_owned()))
+                        .select(&["title"])
+                        .build(),
+                    None,
+                )
+                .await
+                .expect("query text substring contains");
+            assert_eq!(text_rows, count_rows);
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn invalid_membership_filters_return_type_errors() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let client = JazzClient::test_client(membership_schema()).await;
+
+            let scalar_contains = client
+                .query(
+                    QueryBuilder::new("items")
+                        .filter_contains("count", Value::Integer(1))
+                        .build(),
+                    None,
+                )
+                .await
+                .expect_err("contains on scalar integer column should fail");
+            assert!(
+                scalar_contains
+                    .to_string()
+                    .contains("operand type mismatch"),
+                "unexpected contains error: {scalar_contains}"
+            );
+
+            let wrong_in_type = client
+                .query(
+                    QueryBuilder::new("items")
+                        .filter_in("count", vec![Value::Text("not an integer".to_owned())])
+                        .build(),
+                    None,
+                )
+                .await
+                .expect_err("in with mismatched candidate type should fail");
+            assert!(
+                wrong_in_type.to_string().contains("operand type mismatch"),
+                "unexpected in error: {wrong_in_type}"
+            );
+        })
+        .await;
+}

--- a/crates/jazz/SPEC/6_queries.md
+++ b/crates/jazz/SPEC/6_queries.md
@@ -72,6 +72,32 @@ subquery joins until their semantics are specified. `array_subqueries` are
 canonicalized into shape identity separately from includes; sibling ordering is
 not semantic, but duplicate sibling `column_name`s are rejected.
 
+### 6.1.1 Membership and containment filters
+
+Membership and containment semantics are core-owned query semantics. Binding
+layers may provide typed builders and literal conversion, but must lower into
+the core predicate vocabulary without re-implementing match rules.
+
+Supported matrix:
+
+| Column type | `in` | `contains` |
+| --- | --- | --- |
+| Text/String | Membership in a list of text values. UUID literals may be coerced to their string form for compatibility. | Substring containment with a text needle. |
+| Integer / BigInt / Float / Timestamp | Membership in a list of same-type scalar values. | Rejected. |
+| Boolean | Membership in a list of boolean values. | Rejected. |
+| UUID/reference | Membership in a list of UUID values. String UUID literals may be coerced to UUIDs at lowering boundaries. | Rejected. |
+| Enum | Membership in a list of enum-compatible values. String literals may be coerced to discriminants. | Rejected. |
+| Bytea | Membership in a list of whole byte-array values. | Rejected. |
+| Json | Whole-value equality membership only where the binding layer can represent the literal. | Rejected. |
+| Array<T> | Membership in a list of whole-array values. | Element membership with a needle of type `T`; this includes arrays of numbers, booleans, UUID/reference values, enums, timestamps, and text. |
+
+Invalid operator/type combinations must be rejected before execution with a
+clear type error. In particular, `contains` on a scalar non-text column is never
+interpreted as stringification, and `in` candidates must match the column type
+except for the narrow compatibility coercions listed above. The broader
+literal-vs-column coercion policy remains intentionally unspecified; new
+coercions need an explicit spec decision before implementation.
+
 ### 6.2 Shapes: validated, content-addressed, schema-stamped
 
 A shape is the validated, schema-stamped identity of a query. Validation

--- a/crates/jazz/src/node/query_engine/lowering.rs
+++ b/crates/jazz/src/node/query_engine/lowering.rs
@@ -4324,7 +4324,7 @@ fn lower_contains(
     let needle = lower_value_ref(needle, source_id, source, request)?;
     match (value, needle) {
         (LoweredValueRef::Field(field), LoweredValueRef::Literal(value)) => {
-            let value = coerce_literal_for_source_field(value, source, &field);
+            let value = coerce_literal_for_source_array_element(value, source, &field);
             Ok(GroovePredicateExpr::Contains { field, value })
         }
         (LoweredValueRef::Field(field), LoweredValueRef::Field(needle_field)) => {
@@ -4353,6 +4353,20 @@ fn lower_contains(
     }
 }
 
+fn coerce_literal_for_source_array_element(
+    value: LiteralValue,
+    source: &ResolvedSource,
+    field: &str,
+) -> LiteralValue {
+    let Some(value_type) = source_field_type(source, field) else {
+        return value;
+    };
+    match non_null_value_type(value_type) {
+        ValueType::Array(member) => coerce_literal_for_value_type(value, member),
+        _ => value,
+    }
+}
+
 fn coerce_literal_for_source_field(
     value: LiteralValue,
     source: &ResolvedSource,
@@ -4371,6 +4385,13 @@ fn coerce_literal_for_source_field(
         return value;
     };
     coerce_literal_for_value_type(value, &column.column_type.value_type())
+}
+
+fn non_null_value_type(mut value_type: &ValueType) -> &ValueType {
+    while let ValueType::Nullable(inner) = value_type {
+        value_type = inner.as_ref();
+    }
+    value_type
 }
 
 fn coerce_literal_for_value_type(value: LiteralValue, value_type: &ValueType) -> LiteralValue {

--- a/dev/QUERY_MEMBERSHIP_FILTERS.md
+++ b/dev/QUERY_MEMBERSHIP_FILTERS.md
@@ -1,0 +1,56 @@
+# Query Membership Filters
+
+## Findings
+
+Reference PR #808 (`Support broader query membership filters`) was used only as
+a requirements reference. Its intent is:
+
+- widen typed `where` inputs so `in` works on scalar and reference columns;
+- translate scalar `in` lists element-by-element;
+- cover array-column `contains` for non-text element types;
+- keep TypeScript as typed pass-through, with semantics owned by the Rust core.
+
+Current branch support before implementation:
+
+| Column type                       | `in` validation                                                            | `in` lowering/eval                                    | `contains` validation                                                                | `contains` lowering/eval                                                                                                   |
+| --------------------------------- | -------------------------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| Text/String                       | accepts text values; uuid literals are coercible to strings                | lowered as OR of equality predicates                  | accepts text needle as substring search                                              | `TextContains` is not lowered in maintained core; TS/runtime path still covers text contains through existing surface      |
+| Integer / numeric                 | accepts matching numeric values                                            | lowered as OR of equality predicates                  | rejected on scalar columns                                                           | n/a                                                                                                                        |
+| Float                             | accepts matching float values                                              | lowered as OR of equality predicates                  | rejected on scalar columns                                                           | n/a                                                                                                                        |
+| Boolean                           | accepts boolean values                                                     | lowered as OR of equality predicates                  | rejected on scalar columns                                                           | n/a                                                                                                                        |
+| Uuid/reference                    | accepts uuid values; string uuid literals are coercible during lowering    | lowered as OR of equality predicates                  | rejected on scalar columns                                                           | n/a                                                                                                                        |
+| Enum                              | accepts enum-compatible values; string/uuid literals are coercible         | lowered as OR of equality predicates                  | rejected on scalar columns                                                           | n/a                                                                                                                        |
+| Timestamp                         | accepts timestamp values                                                   | lowered as OR of equality predicates                  | rejected on scalar columns                                                           | n/a                                                                                                                        |
+| Bytea                             | accepts byte arrays as whole-column values                                 | lowered as OR of equality predicates                  | rejected by TS adapter; core validation rejects non-array/non-string scalar contains | n/a                                                                                                                        |
+| Json                              | accepts JSON as whole-column values through TS adapter                     | core comparability depends on value representation    | rejected by TS adapter                                                               | n/a                                                                                                                        |
+| Array<Text>                       | accepts whole-array values for `in`                                        | lowered as OR of equality predicates                  | accepts text element needle                                                          | lowered as Groove `Contains` over array membership                                                                         |
+| Array<Integer/Float/Boolean/Uuid> | accepts whole-array values for `in`; accepts element values for `contains` | `in` lowered as OR of whole-array equality predicates | accepts matching element needle                                                      | Groove evaluation supports membership, but lowering coerced the needle against the array field instead of its element type |
+
+Main implementation gap:
+
+- `crates/jazz/src/node/query_engine/lowering.rs::lower_contains` calls
+  `coerce_literal_for_source_field` for `ArrayContains`. That helper targets the
+  array column type, so a scalar string UUID needle for `UUID[]` is not coerced
+  to `Uuid`, and nullable array element handling would also be shaped as the
+  whole field rather than the member type. The core validator already checks
+  `contains` needles against the array member type.
+
+## Change Classification
+
+- CLEARLY-GOOD: Coerce `ArrayContains` literal needles against the array member
+  type, preserving existing text substring behavior as `TextContains`.
+- CLEARLY-GOOD: Add public Rust `QueryBuilder::filter_in` pass-through so
+  black-box client tests can exercise core `Predicate::In` without private or
+  JSON-like query construction.
+- CLEARLY-GOOD: Add black-box Rust integration coverage through public
+  `JazzClient` APIs, builder-created schemas, and `row_input!` inserts.
+- CLEARLY-GOOD: Document the supported matrix in `crates/jazz/SPEC/6_queries.md`.
+- CLEARLY-GOOD: Append the required benchmark-smoke receipt to
+  `dev/benchmarks/SMOKE_LEDGER.md`.
+- SPECULATIVE: none so far.
+
+## Open Questions
+
+- Literal-vs-column coercion remains intentionally narrow. This work does not
+  add broad numeric coercion or string-to-numeric coercion; if broader coercion
+  is desired it needs a separate spec decision.


### PR DESCRIPTION
Supersedes #808, reimplemented from scratch against the new core (that branch targets the retired pre-swap query engine, so nothing was ported).

## What was broken

`in` and `contains` only worked usefully for text. `contains` on an array column coerced the literal against the **whole array type** rather than the element type, so `contains(numbers, 42)` or `contains(reviewerIds, <uuid>)` could never coerce. The public Rust builder had no `in` pass-through at all.

## What changed

- Array `contains` needles are coerced against the **element** type (unwrapping `Nullable` first).
- `QueryBuilder::filter_in` lowers to `Predicate::In`.
- `in` now covers integer / float / boolean / uuid-reference columns; `contains` covers arrays of numbers, booleans, references, enums, timestamps and text. Text `contains` keeps substring semantics; invalid combinations still error before execution.

Semantics live in the core per SPEC 13.13 — the TS layer carries types and pass-through only.

## Spec

`SPEC/6_queries.md` §6.1.1 now documents the supported column-type × operator matrix and names the narrow compatibility coercions.

**Deliberately not included:** broader literal-vs-column coercion (e.g. string→numeric). That needs its own spec decision rather than accreting case-by-case rules, and is called out as an open question in the chapter and in `dev/QUERY_MEMBERSHIP_FILTERS.md`.

## Coverage

Black-box tests in `crates/jazz-tools/tests/query_membership_filters.rs` through `JazzClient` with builder schemas and `row_input!`: scalar `in`, non-text array `contains`, text substring `contains`, and the rejection cases.

## Gates

jazz · groove · jazz-tools `--features test` · incremental delivery canaries · `JAZZ_SEED_COUNT=300` oracle · ts-wire-codec · jazz-server · jazz-sim bench check · smoke · clippy · fmt · sensitive-data guard — all green, re-verified by the reviewer.