### PR TITLE
(new core) Reject unsupported maintained shapes instead of dropping them silently

### DIFF
--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -55,7 +55,8 @@ use crate::protocol_limits::{
     validate_wire_frame_len,
 };
 use crate::query::{
-    Binding, Query, QueryError, RelationQuery, ShapeId, ValidatedQuery, relation_query_to_query,
+    Binding, BindingId, Query, QueryError, RelationQuery, ShapeId, ValidatedQuery,
+    relation_query_to_query,
 };
 #[cfg(test)]
 use crate::query::{
@@ -875,7 +876,6 @@ where
         opts: ReadOpts,
     ) -> Result<QueryAttachment, Error> {
         ensure_supported_read_view(&opts)?;
-        ensure_supported_subscription_shape(&prepared.shape)?;
         let upstream_opts =
             upstream_register_shape_options(effective_read_tier(&opts), opts.read_view.clone());
         Ok(QueryAttachment {
@@ -896,7 +896,6 @@ where
         author: AuthorId,
     ) -> Result<QueryAttachment, Error> {
         ensure_supported_read_view(&opts)?;
-        ensure_supported_subscription_shape(&prepared.shape)?;
         let upstream_opts =
             upstream_register_shape_options(effective_read_tier(&opts), opts.read_view.clone());
         let (shape, binding, _) = self.node.node.borrow_mut().prepare_query_binding_for_link(
@@ -980,8 +979,17 @@ where
         author: AuthorId,
     ) -> Result<SubscriptionStream, Error> {
         ensure_supported_subscription_read_opts(&opts)?;
-        ensure_supported_subscription_shape(&prepared.shape)?;
         let read_tier = effective_read_tier(&opts);
+        self.node
+            .node
+            .borrow_mut()
+            .ensure_peer_maintained_subscription_view_supported(
+                &prepared.shape,
+                &prepared.binding,
+                read_tier,
+                author,
+                &opts.read_view,
+            )?;
         let (local_shape, local_binding, _local_plan) = self
             .node
             .node
@@ -1098,7 +1106,16 @@ where
         opts: RegisterShapeOptions,
         identity: AuthorId,
     ) -> Result<Vec<UpstreamCoverageHandle>, Error> {
-        ensure_supported_subscription_shape(shape)?;
+        self.node
+            .node
+            .borrow_mut()
+            .ensure_peer_maintained_subscription_view_supported(
+                shape,
+                binding,
+                opts.tier,
+                identity,
+                &opts.read_view,
+            )?;
         let coverage = coverage_key(shape, binding, opts.clone());
         if self
             .node
@@ -4636,19 +4653,80 @@ where
                             ast,
                         } => {
                             if let Err(message) = validate_shape_ast_size(&ast) {
-                                let _ = message;
-                                drop_peer_request(&self.node);
+                                send_unsupported_shape_capability_rejection(
+                                    &mut *self.transport,
+                                    register_shape_rejection_subscription(
+                                        shape_id,
+                                        opts.read_view_key(),
+                                    ),
+                                    message,
+                                )
+                                .map_err(transport_error)?;
                                 continue;
                             }
-                            if ensure_supported_register_shape_options(&opts).is_err() {
-                                drop_peer_request(&self.node);
+                            if let Err(error) = ensure_supported_register_shape_options(&opts) {
+                                send_unsupported_shape_capability_rejection(
+                                    &mut *self.transport,
+                                    register_shape_rejection_subscription(
+                                        shape_id,
+                                        opts.read_view_key(),
+                                    ),
+                                    error.message,
+                                )
+                                .map_err(transport_error)?;
                                 continue;
                             }
-                            if let Some(query) = ast.query() {
-                                if ensure_supported_maintained_coverage_query_shape(query).is_err()
-                                {
+                            let shape_validation = {
+                                let node = self.node.borrow();
+                                validate_shape_ast_for_registration(&node, shape_id, &ast)
+                            };
+                            let shape = match shape_validation {
+                                Ok(Some(shape)) => Some(shape),
+                                Ok(None) => None,
+                                Err(_) => {
                                     drop_peer_request(&self.node);
                                     continue;
+                                }
+                            };
+                            if let Some(shape) = &shape {
+                                if shape.params().is_empty() {
+                                    let binding = shape.bind(BTreeMap::new()).map_err(Error::from);
+                                    let binding = match binding {
+                                        Ok(binding) => binding,
+                                        Err(_) => {
+                                            drop_peer_request(&self.node);
+                                            continue;
+                                        }
+                                    };
+                                    let supported = self
+                                        .node
+                                        .borrow_mut()
+                                        .ensure_peer_maintained_subscription_view_supported(
+                                            shape,
+                                            &binding,
+                                            opts.tier,
+                                            ingest_context.identity,
+                                            &opts.read_view,
+                                        );
+                                    if let Err(crate::node::Error::QueryCapability(detail)) =
+                                        supported
+                                    {
+                                        let subscription = SubscriptionKey {
+                                            shape_id,
+                                            binding_id: binding.binding_id(),
+                                            read_view: opts.read_view_key(),
+                                        };
+                                        send_unsupported_shape_capability_rejection(
+                                            &mut *self.transport,
+                                            subscription,
+                                            detail,
+                                        )
+                                        .map_err(transport_error)?;
+                                        continue;
+                                    } else if supported.is_err() {
+                                        drop_peer_request(&self.node);
+                                        continue;
+                                    }
                                 }
                             }
                             let registration_key = (shape_id, opts.read_view_key());
@@ -4694,10 +4772,6 @@ where
                             let Some(shape) = self.node.borrow().registered_shape(shape_id) else {
                                 continue;
                             };
-                            if ensure_supported_subscription_shape(&shape).is_err() {
-                                drop_peer_request(&self.node);
-                                continue;
-                            }
                             let value_map = shape
                                 .params()
                                 .keys()
@@ -4731,6 +4805,28 @@ where
                                 drop_peer_request(&self.node);
                                 continue;
                             }
+                            let supported = self
+                                .node
+                                .borrow_mut()
+                                .ensure_peer_maintained_subscription_view_supported(
+                                    &shape,
+                                    &binding,
+                                    opts.tier,
+                                    ingest_context.identity,
+                                    &opts.read_view,
+                                );
+                            if let Err(crate::node::Error::QueryCapability(detail)) = supported {
+                                send_unsupported_shape_capability_rejection(
+                                    &mut *self.transport,
+                                    subscription,
+                                    detail,
+                                )
+                                .map_err(transport_error)?;
+                                continue;
+                            } else if supported.is_err() {
+                                drop_peer_request(&self.node);
+                                continue;
+                            }
                             let coverage = coverage_key(&shape, &binding, opts.clone());
                             let group_subscription = SubscriptionKey {
                                 shape_id: coverage.shape_id,
@@ -4754,14 +4850,12 @@ where
                                 let update = match update_result {
                                     Ok(update) => update,
                                     Err(crate::node::Error::QueryCapability(detail)) => {
-                                        self.transport
-                                            .send(SyncMessage::SubscribeRejected {
-                                                subscription,
-                                                reason: SubscribeRejectReason::UnsupportedShapeCapability {
-                                                    detail,
-                                                },
-                                            })
-                                            .map_err(transport_error)?;
+                                        send_unsupported_shape_capability_rejection(
+                                            &mut *self.transport,
+                                            subscription,
+                                            detail,
+                                        )
+                                        .map_err(transport_error)?;
                                         continue;
                                     }
                                     Err(error) => return Err(error.into()),
@@ -6131,15 +6225,6 @@ fn ensure_supported_subscription_read_opts(opts: &ReadOpts) -> Result<(), Error>
     ensure_supported_read_view(opts)
 }
 
-fn ensure_supported_subscription_shape(shape: &ValidatedQuery) -> Result<(), Error> {
-    ensure_supported_maintained_coverage_query_shape(shape.query())
-}
-
-fn ensure_supported_maintained_coverage_query_shape(query: &Query) -> Result<(), Error> {
-    let _ = query;
-    Ok(())
-}
-
 fn ensure_supported_register_shape_read_view(opts: &RegisterShapeOptions) -> Result<(), Error> {
     let read_opts = ReadOpts {
         read_view: opts.read_view.clone(),
@@ -6157,6 +6242,39 @@ fn ensure_supported_register_shape_options(opts: &RegisterShapeOptions) -> Resul
         ));
     }
     Ok(())
+}
+
+fn validate_shape_ast_for_registration<S>(
+    node: &NodeState<S>,
+    shape_id: ShapeId,
+    ast: &ShapeAst,
+) -> Result<Option<ValidatedQuery>, crate::node::Error>
+where
+    S: OrderedKvStorage,
+{
+    node.validate_shape_ast_for_registration(shape_id, ast)
+}
+
+fn send_unsupported_shape_capability_rejection(
+    transport: &mut dyn Transport,
+    subscription: SubscriptionKey,
+    detail: String,
+) -> Result<(), TransportError> {
+    transport.send(SyncMessage::SubscribeRejected {
+        subscription,
+        reason: SubscribeRejectReason::UnsupportedShapeCapability { detail },
+    })
+}
+
+fn register_shape_rejection_subscription(
+    shape_id: ShapeId,
+    read_view: ReadViewKey,
+) -> SubscriptionKey {
+    SubscriptionKey {
+        shape_id,
+        binding_id: BindingId(uuid::Uuid::nil()),
+        read_view,
+    }
 }
 
 fn coverage_key(

--- a/crates/jazz/src/db/tests.rs
+++ b/crates/jazz/src/db/tests.rs
@@ -395,6 +395,37 @@ fn assert_subscribe_rejected_branch_overlay(
     }
 }
 
+fn assert_subscribe_rejected_unsupported_window(
+    message: SyncMessage,
+    expected_subscription: SubscriptionKey,
+) {
+    assert_subscribe_rejected_unsupported_shape_capability_detail(
+        message,
+        expected_subscription,
+        "maintained subscription view window shape is not lowered yet",
+    );
+}
+
+fn assert_subscribe_rejected_unsupported_shape_capability_detail(
+    message: SyncMessage,
+    expected_subscription: SubscriptionKey,
+    expected_detail: &str,
+) {
+    match message {
+        SyncMessage::SubscribeRejected {
+            subscription,
+            reason: SubscribeRejectReason::UnsupportedShapeCapability { detail },
+        } => {
+            assert_eq!(subscription, expected_subscription);
+            assert!(
+                detail.contains(expected_detail),
+                "unexpected rejection detail: {detail}"
+            );
+        }
+        other => panic!("expected SubscribeRejected, got {other:?}"),
+    }
+}
+
 fn assert_view_update_for_subscription(
     message: SyncMessage,
     expected_subscription: SubscriptionKey,
@@ -5777,6 +5808,94 @@ fn subscriber_connection_rejects_one_gapped_subscription_and_keeps_serving_other
 }
 
 #[test]
+fn subscriber_connection_rejects_unsupported_maintained_shape_and_keeps_serving_others() {
+    let schema = schema();
+    let owner = AuthorId::from_bytes([0xa1; 16]);
+    let client_author = AuthorId::from_bytes([0xc1; 16]);
+    let server = open_core(0x5e, AuthorId::SYSTEM, &schema);
+    seed(&server, "todos", cells("first", false, owner));
+    seed(&server, "todos", cells("second", false, owner));
+
+    // Protocol-level coverage: jazz-tools subscriptions do not expose raw
+    // SubscribeRejected messages, so this exercises the first layer where the
+    // rejection is directly observable while still using public query builders.
+    let (mut client_transport, server_transport) = duplex();
+    let subscriber = server.accept_subscriber(server_transport, client_author);
+    let supported_shape = Query::from("todos").validate(&schema).unwrap();
+    let unsupported_shape = Query::from("todos")
+        .offset(1)
+        .limit(1)
+        .validate(&schema)
+        .unwrap();
+    let supported_binding = supported_shape.bind(BTreeMap::new()).unwrap();
+    let unsupported_binding = unsupported_shape.bind(BTreeMap::new()).unwrap();
+    let supported_subscription = SubscriptionKey {
+        shape_id: supported_shape.shape_id(),
+        binding_id: supported_binding.binding_id(),
+        read_view: RegisterShapeOptions::default().read_view_key(),
+    };
+    let unsupported_subscription = SubscriptionKey {
+        shape_id: unsupported_shape.shape_id(),
+        binding_id: unsupported_binding.binding_id(),
+        read_view: RegisterShapeOptions::default().read_view_key(),
+    };
+
+    client_transport
+        .send(SyncMessage::RegisterShape {
+            shape_id: unsupported_shape.shape_id(),
+            ast: ShapeAst::from_validated(&unsupported_shape),
+            opts: RegisterShapeOptions::default(),
+        })
+        .unwrap();
+    client_transport
+        .send(SyncMessage::RegisterShape {
+            shape_id: supported_shape.shape_id(),
+            ast: ShapeAst::from_validated(&supported_shape),
+            opts: RegisterShapeOptions::default(),
+        })
+        .unwrap();
+    client_transport
+        .send(SyncMessage::Subscribe(Subscribe {
+            shape_id: supported_shape.shape_id(),
+            subscription: supported_subscription,
+            values: Vec::new(),
+            known_state: None,
+        }))
+        .unwrap();
+
+    subscriber.borrow_mut().tick().unwrap();
+    assert_subscribe_rejected_unsupported_window(
+        client_transport
+            .try_recv()
+            .expect("expected unsupported shape rejection"),
+        unsupported_subscription,
+    );
+    assert_view_update_for_subscription(
+        client_transport
+            .try_recv()
+            .expect("expected supported subscription update after rejection"),
+        supported_subscription,
+    );
+
+    client_transport
+        .send(SyncMessage::Subscribe(Subscribe {
+            shape_id: unsupported_shape.shape_id(),
+            subscription: unsupported_subscription,
+            values: Vec::new(),
+            known_state: None,
+        }))
+        .unwrap();
+    seed(&server, "todos", cells("third", false, owner));
+    subscriber.borrow_mut().tick().unwrap();
+    assert_view_update_for_subscription(
+        client_transport
+            .try_recv()
+            .expect("supported subscription should continue after unsupported subscribe"),
+        supported_subscription,
+    );
+}
+
+#[test]
 fn subscriber_connection_rejects_local_tier_register_shape() {
     let schema = schema();
     let owner = AuthorId::from_bytes([0xa1; 16]);
@@ -5794,6 +5913,7 @@ fn subscriber_connection_rejects_local_tier_register_shape() {
         tier: DurabilityTier::Local,
         read_view: ReadViewSpec::default(),
     };
+    let rejected_read_view = opts.read_view_key();
 
     client_transport
         .send(SyncMessage::RegisterShape {
@@ -5804,13 +5924,16 @@ fn subscriber_connection_rejects_local_tier_register_shape() {
         .unwrap();
 
     subscriber.borrow_mut().tick().unwrap();
-    assert_eq!(
-        server
-            .node()
-            .borrow()
-            .sync_metrics()
-            .dropped_peer_request_messages,
-        1
+    assert_subscribe_rejected_unsupported_shape_capability_detail(
+        client_transport
+            .try_recv()
+            .expect("expected local-tier registration rejection"),
+        SubscriptionKey {
+            shape_id: shape.shape_id(),
+            binding_id: BindingId(uuid::Uuid::nil()),
+            read_view: rejected_read_view,
+        },
+        "global-tier registration",
     );
 
     let binding = shape.bind(BTreeMap::new()).unwrap();
@@ -6170,6 +6293,7 @@ fn subscriber_connection_rejects_non_global_register_shape_options() {
         tier: DurabilityTier::Edge,
         read_view: ReadViewSpec::default(),
     };
+    let rejected_read_view = edge_opts.read_view_key();
 
     client_transport
         .send(SyncMessage::RegisterShape {
@@ -6180,13 +6304,16 @@ fn subscriber_connection_rejects_non_global_register_shape_options() {
         .unwrap();
 
     subscriber.borrow_mut().tick().unwrap();
-    assert_eq!(
-        server
-            .node()
-            .borrow()
-            .sync_metrics()
-            .dropped_peer_request_messages,
-        1
+    assert_subscribe_rejected_unsupported_shape_capability_detail(
+        client_transport
+            .try_recv()
+            .expect("expected edge-tier registration rejection"),
+        SubscriptionKey {
+            shape_id: shape.shape_id(),
+            binding_id: BindingId(uuid::Uuid::nil()),
+            read_view: rejected_read_view,
+        },
+        "global-tier registration",
     );
 }
 

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -4125,6 +4125,30 @@ where
         Ok(())
     }
 
+    pub(crate) fn validate_shape_ast_for_registration(
+        &self,
+        shape_id: ShapeId,
+        ast: &ShapeAst,
+    ) -> Result<Option<ValidatedQuery>, Error> {
+        if ast.version != ShapeAst::VERSION {
+            return Err(Error::InvalidStoredValue("unsupported query AST version"));
+        }
+        let Some(schema) = self.catalogue.catalogue_schemas.get(&ast.schema_version) else {
+            return Ok(None);
+        };
+        let shape = match &ast.body {
+            ShapeBody::Query(query) => {
+                query.validate_with_schema_version(&schema.schema, ast.schema_version)?
+            }
+            ShapeBody::Relation(relation) => relation_query_to_query(relation)?
+                .validate_with_schema_version(&schema.schema, ast.schema_version)?,
+        };
+        if shape.shape_id() != shape_id {
+            return Err(Error::InvalidStoredValue("shape id does not match AST"));
+        }
+        Ok(Some(shape))
+    }
+
     pub(super) fn drain_parked_shape_registrations(&mut self) -> Result<(), Error> {
         let ready = self
             .parking
@@ -7788,6 +7812,25 @@ where
             std::sync::Arc::new(self.prepared_query_plan_from_program(&program, shape, binding)?);
         self.query.query_shape_cache.insert(key, plan.clone());
         Ok(plan)
+    }
+
+    pub(crate) fn ensure_peer_maintained_subscription_view_supported(
+        &mut self,
+        shape: &ValidatedQuery,
+        binding: &Binding,
+        tier: DurabilityTier,
+        identity: AuthorId,
+        read_view: &ReadViewSpec,
+    ) -> Result<(), Error> {
+        self.compile_current_query_program_for_read_view(
+            shape,
+            binding,
+            tier,
+            identity,
+            CurrentQueryProgramOutput::MaintainedView,
+            read_view,
+        )
+        .map(|_| ())
     }
 
     pub(crate) fn mark_peer_maintained_query_shape_cache(

--- a/crates/jazz/src/peer.rs
+++ b/crates/jazz/src/peer.rs
@@ -3867,6 +3867,9 @@ mod tests {
             .unwrap();
         accept_global(&mut core, first_tx, 1);
         accept_global(&mut core, second_tx, 2);
+        // Both shapes are unsupported on this branch: unordered limit > 1 is
+        // only lowered once default row-id ordering is injected, which lands
+        // with the default-ordering work, not here.
         let no_order_limit = Query::from("todos").limit(2).validate(&schema()).unwrap();
         let offset_limit_one = Query::from("todos")
             .limit(1)


### PR DESCRIPTION
Found by the spec-vs-code triage, then verified by hand. Fixes a real correctness gap: a client that asks for a shape the core cannot maintain currently gets **no error and no data, indefinitely**.

## What was wrong

SPEC `16_maintained_subscription_views.md` §16.4 and `INV-SYNC-23` require the server to answer an unservable shape with `SubscribeRejected { UnsupportedShapeCapability }`, leave that subscription inactive, and keep serving the connection's other subscriptions. Neither half held.

1. **The gate validated nothing.** `ensure_supported_maintained_coverage_query_shape` took the query, did `let _ = query;` and returned `Ok(())` unconditionally. The `RegisterShape` path called it and always passed.
2. **Failures were silent.** Where the sibling guards *did* fail, the code called `drop_peer_request(&self.node)` and `continue` — no message to the client. Same swallowed-error family as the OPFS poison we chased this week: the subscription just never delivers and nothing says why.

## What changed

- Real validation through the lowering path — `validate_shape_ast_for_registration` checks AST version, resolves the schema, validates the query, and confirms the shape id matches.
- Both the `RegisterShape` and `Subscribe` paths now emit `SubscribeRejected { reason: UnsupportedShapeCapability { detail } }`, so the client learns *why*, the offending subscription stays inactive, and the connection's other subscriptions keep delivering.
- Protocol-layer regression covering rejection of an unsupported shape plus continued delivery on a supported one.

The public `jazz-tools` client surface does not expose raw `SyncMessage`, so the test sits at the tightest layer that can observe the wire message; that limitation is recorded in the findings rather than papered over.

## Reviewer note — a deleted assertion, restored

The lane removed the unordered `limit(2)` case from `maintained_subscription_view_unsupported_limited_variants_error_loudly`, on the grounds that the unsupported set had narrowed. It has narrowed — but on the default-ordering branch (#1112), not on this base. `linear_window_supported` here still rejects unordered `limit > 1`, so that deletion dropped live, correct coverage. The assertion is restored and passes. It should narrow when #1112 merges, which that branch already does on its own.

Worth noting the failure mode: a removed assertion is invisible to a green suite. Every gate passed with the coverage gone.

## Gates

jazz · jazz-tools `--features test` · incremental delivery canaries (including the exact scale-independence canary) · `JAZZ_SEED_COUNT=300` oracle · jazz-server · fmt — all green, re-run by the reviewer with the restored assertion in place.