### PR TITLE
(new core) Bound the OPFS WAL by checkpointing on tail growth

### DIFF
--- a/crates/opfs-btree/src/db.rs
+++ b/crates/opfs-btree/src/db.rs
@@ -22,6 +22,11 @@ const OVERFLOW_REUSE_MIN_BYTES: usize = 128 * 1024;
 const OVERFLOW_DIRECT_READ_MIN_BYTES: usize = 128 * 1024;
 const BOOTSTRAP_GENERATION: u64 = 1;
 const ALLOC_NEAR_WINDOW: u64 = 32;
+// Larger WAL tails reduce checkpoint frequency, but make browser files larger
+// during long sessions and increase replay work on open. 1024 pages is 16 MiB
+// at the default 16 KiB page size, enough to amortize checkpoints without
+// allowing the unbounded tail growth seen in long browser ingests.
+const WAL_CHECKPOINT_THRESHOLD_PAGES: u64 = 1024;
 
 type OpfsMap<K, V> = FxHashMap<K, V>;
 type OpfsSet<T> = FxHashSet<T>;
@@ -578,6 +583,7 @@ impl<F: SyncFile> OpfsBTree<F> {
             self.total_pages,
         );
         self.freelist_dirty = false;
+        self.checkpoint_wal_tail_if_needed()?;
         Ok(())
     }
 
@@ -1513,6 +1519,17 @@ impl<F: SyncFile> OpfsBTree<F> {
         self.flush_for_write()?;
         self.persisted_pages = self.total_pages;
         Ok(())
+    }
+
+    fn checkpoint_wal_tail_if_needed(&mut self) -> Result<(), BTreeError> {
+        if self.wal_tail_pages() >= WAL_CHECKPOINT_THRESHOLD_PAGES {
+            self.checkpoint()?;
+        }
+        Ok(())
+    }
+
+    fn wal_tail_pages(&self) -> u64 {
+        self.persisted_pages.saturating_sub(self.total_pages)
     }
 
     fn flush_for_write(&self) -> Result<(), BTreeError> {
@@ -2885,6 +2902,50 @@ mod tests {
                     checkpoint
                 );
             }
+        }
+    }
+
+    #[test]
+    fn flush_wal_checkpoints_when_tail_crosses_threshold() {
+        let file = MemoryFile::new();
+        let options = small_options();
+        let page_size = options.page_size;
+        let mut tree = OpfsBTree::open(file.clone(), options).expect("open tree");
+        let mut saw_auto_checkpoint = false;
+
+        for i in 0..600u32 {
+            let key = format!("k{i:05}");
+            let value = deterministic_bytes(i as u64, 512);
+            tree.put(key.as_bytes(), &value).expect("put");
+            tree.flush_wal().expect("flush wal");
+
+            let file_pages = file.len().expect("file len") / page_size as u64;
+            assert_eq!(
+                file_pages, tree.persisted_pages,
+                "tree should track the physical file length after flush {i}"
+            );
+            assert!(
+                tree.wal_tail_pages() < WAL_CHECKPOINT_THRESHOLD_PAGES,
+                "WAL tail should stay below threshold after flush {i}: persisted_pages={} total_pages={}",
+                tree.persisted_pages,
+                tree.total_pages
+            );
+            saw_auto_checkpoint |= tree.wal_pages.is_empty() && tree.dirty_pages.is_empty();
+        }
+
+        assert!(
+            saw_auto_checkpoint,
+            "test workload should cross the WAL threshold and trigger a checkpoint"
+        );
+
+        let mut reopened = OpfsBTree::open(file, options).expect("reopen tree");
+        for i in 0..600u32 {
+            let key = format!("k{i:05}");
+            assert_eq!(
+                reopened.get(key.as_bytes()).expect("get"),
+                Some(deterministic_bytes(i as u64, 512)),
+                "key {i} should survive automatic checkpointing"
+            );
         }
     }
 


### PR DESCRIPTION
Fixes a browser-only failure that killed long ingests, and removes what profiling showed to be the dominant remaining cost in the browser commit path.

## What was wrong

The browser storage engine opens with `SyncPolicy::OnClose`, so within a session `flush_wal` only ever **appended**: `checkpoint` — which writes pages to their home locations, rewrites the superblock and truncates the WAL — was reached at close and nowhere else. A long ingest therefore grew the WAL without bound. Two measured consequences:

- **Performance.** Per-commit `flush_wal` climbed from **28 ms to 133 ms** across a 60k-row ingest, and became the dominant remaining cost: late commits ran ~156 ms of which ~133 ms was `flush_wal`. Every other phase was flat and already at native parity (IVM tick ~2 ms, delta computation ~5 ms, TS layers ~0).
- **Correctness.** Partway through, the worker died with `Storage: database instance is poisoned after a failed atomic commit`, after which every write and subscription in that session silently stopped.

## The change

Checkpoint from `flush_wal` once the WAL tail reaches 1024 pages (16 MiB at the default page size). It fires **after** the WAL append is durable, so the existing ordering — WAL commit first, then checkpoint and truncate — is unchanged and an interrupted checkpoint still replays from the WAL. The threshold is a named constant with the tradeoff documented: larger means fewer checkpoints but a bigger file and longer replay on open.

## Receipts

**Browser (the one that matters):** a full 60k-row generate on the stress app now completes with **no poison error**, the worker queue drains in 56 s, and the list renders. Before this change the same run reliably poisoned the database partway through.

**Native:** unchanged within noise — 4.86 s vs 4.97 s over 60k rows with periodic checkpoint spikes. That is expected and is *not* evidence of the win: native never grew a WAL big enough to hurt, so the native harness can only demonstrate absence of regression.

## Durability

This is crash-recovery-sensitive code, so: no existing durability guarantee is weakened, the WAL-before-checkpoint ordering is preserved, and the existing opfs-btree WAL/replay tests pass unchanged. A new test drives many commits and asserts the WAL tail stays bounded and the tree reopens correctly with every key intact.

## Gates

opfs-btree · groove · jazz · clippy `-D warnings` · fmt — all green.