### PR TITLE
(new core) Fix non-null writes into nullable columns

### DIFF
--- a/crates/jazz-tools/Cargo.toml
+++ b/crates/jazz-tools/Cargo.toml
@@ -212,6 +212,10 @@ required-features = ["test"]
 name = "policy_branch_closure"
 required-features = ["test"]
 
+[[test]]
+name = "nullable_writes"
+required-features = ["test-utils"]
+
 [[example]]
 name = "realistic_bench"
 required-features = ["client"]

--- a/crates/jazz-tools/src/client.rs
+++ b/crates/jazz-tools/src/client.rs
@@ -15,7 +15,8 @@ use crate::public_api::types::{OrderedAdded, OrderedRemoved, OrderedUpdated};
 use crate::public_schema::Schema;
 use crate::public_schema::TableName;
 use crate::public_schema::{
-    ColumnType, LargeValueHandle, Query, Session, TableSchema, Value, WriteContext,
+    ColumnDescriptor, ColumnType, LargeValueHandle, Query, Session, TableSchema, Value,
+    WriteContext,
 };
 use crate::public_schema::{OrderedRowDelta, Row};
 use crate::server::core_websocket_transport::WebSocketTransport;
@@ -1487,6 +1488,29 @@ fn public_to_core_value(value: Value) -> Result<CoreValue> {
     }
 }
 
+fn public_to_core_cell_value(value: Value, column: &ColumnDescriptor) -> Result<CoreValue> {
+    let value = public_to_core_value_for_column_type(value, &column.column_type)?;
+    if column.nullable && !matches!(value, CoreValue::Nullable(_)) {
+        Ok(CoreValue::Nullable(Some(Box::new(value))))
+    } else {
+        Ok(value)
+    }
+}
+
+fn public_to_core_value_for_column_type(
+    value: Value,
+    column_type: &ColumnType,
+) -> Result<CoreValue> {
+    match (value, column_type) {
+        (Value::Array(values), ColumnType::Array { element }) => values
+            .into_iter()
+            .map(|value| public_to_core_value_for_column_type(value, element))
+            .collect::<Result<Vec<_>>>()
+            .map(CoreValue::Array),
+        (value, _) => public_to_core_value(value),
+    }
+}
+
 fn json_claim_to_core_value(value: serde_json::Value) -> Result<CoreValue> {
     match value {
         serde_json::Value::Null => Ok(CoreValue::Nullable(None)),
@@ -2063,11 +2087,37 @@ impl JazzClient {
         };
         Ok(Some(value))
     }
-    fn core_cells(values: HashMap<String, Value>) -> Result<jazz::db::RowCells> {
+    fn core_cells_for_table(
+        &self,
+        table: &str,
+        values: HashMap<String, Value>,
+    ) -> Result<jazz::db::RowCells> {
+        let schema = self.schema()?;
+        let table_schema = schema
+            .get(&TableName::new(table))
+            .ok_or_else(|| JazzError::Write(format!("unknown table {table}")))?;
         values
             .into_iter()
-            .map(|(name, value)| Ok((name, public_to_core_value(value)?)))
+            .map(|(name, value)| {
+                let column = table_schema.columns.column(&name).ok_or_else(|| {
+                    JazzError::Write(format!("unknown column {name} on table {table}"))
+                })?;
+                Ok((name, public_to_core_cell_value(value, column)?))
+            })
             .collect()
+    }
+    fn table_for_row(&self, object_id: ObjectId) -> Result<String> {
+        self.db
+            .inner
+            .borrow()
+            .row_tables
+            .get(&object_id)
+            .cloned()
+            .ok_or_else(|| {
+                JazzError::Write(format!(
+                    "unknown table for row {object_id}; insert or query the row before updating"
+                ))
+            })
     }
     fn core_ordered_values(
         &self,
@@ -2271,7 +2321,7 @@ impl JazzClient {
     ) -> Result<(ObjectId, Vec<Value>, BatchId)> {
         {
             let row_values = self.core_ordered_values(table, &values)?;
-            let cells = Self::core_cells(values)?;
+            let cells = self.core_cells_for_table(table, values)?;
             if let Some(batch_id) = self.write_context.as_ref().and_then(|ctx| ctx.batch_id) {
                 let row_id =
                     self.db
@@ -2298,7 +2348,7 @@ impl JazzClient {
         values: HashMap<String, Value>,
     ) -> Result<BatchId> {
         {
-            let cells = Self::core_cells(values)?;
+            let cells = self.core_cells_for_table(table, values)?;
             if let Some(batch_id) = self.write_context.as_ref().and_then(|ctx| ctx.batch_id) {
                 self.db
                     .stage_upsert(batch_id, table.to_string(), object_id, cells)?;
@@ -2315,7 +2365,8 @@ impl JazzClient {
     /// Update a row.
     pub fn update(&self, object_id: ObjectId, updates: Vec<(String, Value)>) -> Result<BatchId> {
         {
-            let cells = Self::core_cells(updates.into_iter().collect())?;
+            let table = self.table_for_row(object_id)?;
+            let cells = self.core_cells_for_table(&table, updates.into_iter().collect())?;
             if let Some(batch_id) = self.write_context.as_ref().and_then(|ctx| ctx.batch_id) {
                 self.db.stage_update(batch_id, object_id, cells)?;
                 Ok(batch_id)

--- a/crates/jazz-tools/tests/nullable_writes.rs
+++ b/crates/jazz-tools/tests/nullable_writes.rs
@@ -1,0 +1,249 @@
+#![cfg(feature = "test-utils")]
+
+use jazz_tools::row_input;
+use jazz_tools::{
+    ColumnType, JazzClient, ObjectId, QueryBuilder, Schema, SchemaBuilder, TableSchema, Value,
+    WriteContext,
+};
+use uuid::Uuid;
+
+fn nullable_schema() -> Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("profiles")
+                .nullable_column("name", ColumnType::Text)
+                .nullable_column("age", ColumnType::Integer)
+                .nullable_column("visits", ColumnType::BigInt)
+                .nullable_column("active", ColumnType::Boolean)
+                .nullable_fk_column("manager_id", "profiles")
+                .nullable_column(
+                    "tags",
+                    ColumnType::Array {
+                        element: Box::new(ColumnType::Text),
+                    },
+                ),
+        )
+        .build()
+}
+
+fn profiles_query() -> jazz_tools::Query {
+    QueryBuilder::new("profiles")
+        .select(&["name", "age", "visits", "active", "manager_id", "tags"])
+        .build()
+}
+
+async fn profile_values(client: &JazzClient, row_id: ObjectId) -> Vec<Value> {
+    client
+        .query(profiles_query(), None)
+        .await
+        .expect("query profiles")
+        .into_iter()
+        .find(|(id, _)| *id == row_id)
+        .map(|(_, values)| values)
+        .unwrap_or_else(|| panic!("profile row {row_id} should be visible"))
+}
+
+fn full_values(manager_id: ObjectId, name: &str, age: i32) -> Vec<Value> {
+    vec![
+        Value::Text(name.to_owned()),
+        Value::Integer(age),
+        Value::BigInt(9_007_199_254_740_993),
+        Value::Boolean(true),
+        Value::Uuid(manager_id),
+        Value::Array(vec![
+            Value::Text("alpha".to_owned()),
+            Value::Text("beta".to_owned()),
+        ]),
+    ]
+}
+
+#[tokio::test]
+async fn insert_reads_back_non_null_values_in_nullable_columns() {
+    let client = JazzClient::test_client(nullable_schema()).await;
+    let manager_id = ObjectId::new();
+    let expected = full_values(manager_id, "inserted", 41);
+
+    let (row_id, _, _) = client
+        .insert(
+            "profiles",
+            row_input!(
+                "name" => "inserted",
+                "age" => 41,
+                "visits" => Value::BigInt(9_007_199_254_740_993),
+                "active" => true,
+                "manager_id" => manager_id,
+                "tags" => Value::Array(vec![Value::Text("alpha".to_owned()), Value::Text("beta".to_owned())])
+            ),
+        )
+        .expect("insert non-null values into nullable columns");
+
+    assert_eq!(profile_values(&client, row_id).await, expected);
+}
+
+#[tokio::test]
+async fn insert_with_id_reads_back_non_null_values_in_nullable_columns() {
+    let client = JazzClient::test_client(nullable_schema()).await;
+    let row_uuid = Uuid::now_v7();
+    let manager_id = ObjectId::new();
+    let expected = full_values(manager_id, "with id", 42);
+
+    let (row_id, _, _) = client
+        .insert_with_id(
+            "profiles",
+            row_uuid,
+            row_input!(
+                "name" => "with id",
+                "age" => 42,
+                "visits" => Value::BigInt(9_007_199_254_740_993),
+                "active" => true,
+                "manager_id" => manager_id,
+                "tags" => Value::Array(vec![Value::Text("alpha".to_owned()), Value::Text("beta".to_owned())])
+            ),
+        )
+        .expect("insert_with_id non-null values into nullable columns");
+
+    assert_eq!(*row_id.uuid(), row_uuid);
+    assert_eq!(profile_values(&client, row_id).await, expected);
+}
+
+#[tokio::test]
+async fn upsert_reads_back_non_null_values_in_nullable_columns() {
+    let client = JazzClient::test_client(nullable_schema()).await;
+    let row_uuid = Uuid::now_v7();
+    let row_id = ObjectId::from_uuid(row_uuid);
+    let manager_id = ObjectId::new();
+    let expected = full_values(manager_id, "upserted", 43);
+
+    client
+        .upsert(
+            "profiles",
+            row_uuid,
+            row_input!(
+                "name" => "upserted",
+                "age" => 43,
+                "visits" => Value::BigInt(9_007_199_254_740_993),
+                "active" => true,
+                "manager_id" => manager_id,
+                "tags" => Value::Array(vec![Value::Text("alpha".to_owned()), Value::Text("beta".to_owned())])
+            ),
+        )
+        .expect("upsert non-null values into nullable columns");
+
+    assert_eq!(profile_values(&client, row_id).await, expected);
+}
+
+#[tokio::test]
+async fn update_reads_back_non_null_values_in_nullable_columns() {
+    let client = JazzClient::test_client(nullable_schema()).await;
+    let (row_id, _, _) = client
+        .insert(
+            "profiles",
+            row_input!(
+                "name" => Value::Null,
+                "age" => Value::Null,
+                "visits" => Value::Null,
+                "active" => Value::Null,
+                "manager_id" => Value::Null,
+                "tags" => Value::Null
+            ),
+        )
+        .expect("insert null values into nullable columns");
+    let manager_id = ObjectId::new();
+    let expected = full_values(manager_id, "updated", 44);
+
+    client
+        .update(
+            row_id,
+            vec![
+                ("name".to_owned(), Value::Text("updated".to_owned())),
+                ("age".to_owned(), Value::Integer(44)),
+                ("visits".to_owned(), Value::BigInt(9_007_199_254_740_993)),
+                ("active".to_owned(), Value::Boolean(true)),
+                ("manager_id".to_owned(), Value::Uuid(manager_id)),
+                (
+                    "tags".to_owned(),
+                    Value::Array(vec![
+                        Value::Text("alpha".to_owned()),
+                        Value::Text("beta".to_owned()),
+                    ]),
+                ),
+            ],
+        )
+        .expect("update non-null values into nullable columns");
+
+    assert_eq!(profile_values(&client, row_id).await, expected);
+}
+
+#[tokio::test]
+async fn staged_insert_and_update_read_back_non_null_values_in_nullable_columns_after_commit() {
+    let client = JazzClient::test_client(nullable_schema()).await;
+    let batch_id = client
+        .begin_transaction()
+        .expect("begin transaction")
+        .batch_id();
+    let tx = client.with_write_context(WriteContext::default().with_batch_id(batch_id));
+    let manager_id = ObjectId::new();
+    let expected = full_values(manager_id, "staged updated", 46);
+
+    let (row_id, _, _) = tx
+        .insert(
+            "profiles",
+            row_input!(
+                "name" => "staged inserted",
+                "age" => 45,
+                "visits" => Value::BigInt(9_007_199_254_740_993),
+                "active" => false,
+                "manager_id" => manager_id,
+                "tags" => Value::Array(vec![Value::Text("alpha".to_owned()), Value::Text("beta".to_owned())])
+            ),
+        )
+        .expect("stage insert non-null values into nullable columns");
+
+    tx.update(
+        row_id,
+        vec![
+            ("name".to_owned(), Value::Text("staged updated".to_owned())),
+            ("age".to_owned(), Value::Integer(46)),
+            ("active".to_owned(), Value::Boolean(true)),
+        ],
+    )
+    .expect("stage update non-null values into nullable columns");
+
+    client
+        .commit_transaction(batch_id)
+        .expect("commit staged nullable writes");
+    assert_eq!(profile_values(&client, row_id).await, expected);
+}
+
+#[tokio::test]
+async fn staged_upsert_reads_back_non_null_values_in_nullable_columns_after_commit() {
+    let client = JazzClient::test_client(nullable_schema()).await;
+    let batch_id = client
+        .begin_transaction()
+        .expect("begin transaction")
+        .batch_id();
+    let tx = client.with_write_context(WriteContext::default().with_batch_id(batch_id));
+    let row_uuid = Uuid::now_v7();
+    let row_id = ObjectId::from_uuid(row_uuid);
+    let manager_id = ObjectId::new();
+    let expected = full_values(manager_id, "staged upsert", 47);
+
+    tx.upsert(
+        "profiles",
+        row_uuid,
+        row_input!(
+            "name" => "staged upsert",
+            "age" => 47,
+            "visits" => Value::BigInt(9_007_199_254_740_993),
+            "active" => true,
+            "manager_id" => manager_id,
+            "tags" => Value::Array(vec![Value::Text("alpha".to_owned()), Value::Text("beta".to_owned())])
+        ),
+    )
+    .expect("stage upsert non-null values into nullable columns");
+
+    client
+        .commit_transaction(batch_id)
+        .expect("commit staged nullable upsert");
+    assert_eq!(profile_values(&client, row_id).await, expected);
+}


### PR DESCRIPTION
## The bug

Writing a **non-null** value into a **nullable** column through the public client produced a row that could not be read back correctly.

`core_cells` in `crates/jazz-tools/src/client.rs` converted public `Value`s to core values without consulting the schema. A nullable column expects `CoreValue::Nullable(Some(..))`, but a non-null public value arrived as the bare `CoreValue`. `Value::Null` was handled correctly (it became `Nullable(None)`), which is exactly why this stayed hidden: only the non-null-into-nullable direction was broken, and the null direction is what tests reached for.

Every public write entry point shared that conversion: `insert`, `insert_with_id`, `upsert`, `update`, and the staged transaction variants of each.

## The fix

Route all of them through a schema-aware conversion that wraps non-null values for nullable columns. The sibling function `core_ordered_values` already had schema access, so the asymmetry was accidental rather than structural.

## Coverage

New `crates/jazz-tools/tests/nullable_writes.rs` does black-box readback across nullable `Text`, `Integer`, `BigInt`, `Boolean`, FK/UUID and array columns, once per affected entry point — direct and staged.

## Gates

`cargo test -p jazz-tools --features test -j 2` green (full crate suite).

## Found in passing, deliberately *not* fixed here

`crates/jazz-tools/tests/catalogue_sync_integration.rs` is an **orphaned test target**: the crate sets `autotests = false` and the file has no `[[test]]` entry, so it has never been compiled or run. Registering it lists 25 tests, of which 21 fail (`websocket session user_id must be a UUID`, and `spawn_local called from outside of a task::LocalSet`).

That is out of scope here and registering it would turn this PR red, so it is left alone. It needs its own decision — the failures may mean the target rotted after an API evolution and should be repaired, or that it was superseded and should be deleted. Filed separately rather than resolved unilaterally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)