### PR TITLE
(new core) Expose AVG/MIN/MAX on the public client

### DIFF
--- a/crates/jazz-tools/src/client.rs
+++ b/crates/jazz-tools/src/client.rs
@@ -1670,6 +1670,22 @@ fn core_query_condition(
     Ok(vec![predicate])
 }
 
+fn aggregate_output_column(output: &crate::public_api::query::AggregateOutput) -> String {
+    let column = || {
+        output
+            .column
+            .as_deref()
+            .expect("column aggregate has an input column")
+    };
+    match output.function {
+        crate::public_api::query::AggregateFunction::Count => "count".to_owned(),
+        crate::public_api::query::AggregateFunction::Sum => format!("sum_{}", column()),
+        crate::public_api::query::AggregateFunction::Avg => format!("avg_{}", column()),
+        crate::public_api::query::AggregateFunction::Min => format!("min_{}", column()),
+        crate::public_api::query::AggregateFunction::Max => format!("max_{}", column()),
+    }
+}
+
 fn aggregate_public_values(query: &Query, row: &jazz::node::CurrentRow) -> Result<Vec<Value>> {
     let Some(aggregate) = &query.aggregate else {
         return Ok(Vec::new());
@@ -1678,23 +1694,7 @@ fn aggregate_public_values(query: &Query, row: &jazz::node::CurrentRow) -> Resul
     if let Some(group_by) = &aggregate.group_by {
         columns.push(group_by.clone());
     }
-    columns.extend(
-        aggregate
-            .outputs
-            .iter()
-            .map(|output| match output.function {
-                crate::public_api::query::AggregateFunction::Count => "count".to_owned(),
-                crate::public_api::query::AggregateFunction::Sum => {
-                    format!(
-                        "sum_{}",
-                        output
-                            .column
-                            .as_deref()
-                            .expect("sum aggregate has an input column")
-                    )
-                }
-            }),
-    );
+    columns.extend(aggregate.outputs.iter().map(aggregate_output_column));
     let (descriptor, raw) = row.encoded_record();
     let borrowed = jazz::groove::records::BorrowedRecord::new(raw, descriptor);
     columns
@@ -1801,6 +1801,30 @@ impl JazzClient {
                                 .column
                                 .as_deref()
                                 .expect("sum aggregate has an input column"),
+                        )
+                    }
+                    crate::public_api::query::AggregateFunction::Avg => {
+                        jazz::query::Aggregate::avg(
+                            output
+                                .column
+                                .as_deref()
+                                .expect("avg aggregate has an input column"),
+                        )
+                    }
+                    crate::public_api::query::AggregateFunction::Min => {
+                        jazz::query::Aggregate::min(
+                            output
+                                .column
+                                .as_deref()
+                                .expect("min aggregate has an input column"),
+                        )
+                    }
+                    crate::public_api::query::AggregateFunction::Max => {
+                        jazz::query::Aggregate::max(
+                            output
+                                .column
+                                .as_deref()
+                                .expect("max aggregate has an input column"),
                         )
                     }
                 });

--- a/crates/jazz-tools/src/public_api/query.rs
+++ b/crates/jazz-tools/src/public_api/query.rs
@@ -622,13 +622,13 @@ pub struct AggregateOutput {
 }
 
 /// Public client aggregate functions.
-///
-/// The public client surface supports COUNT and SUM today. Core Jazz and Groove
-/// also support AVG, MIN, and MAX; widening this enum is tracked separately.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AggregateFunction {
     Count,
     Sum,
+    Avg,
+    Min,
+    Max,
 }
 
 /// Default disjuncts - one empty conjunction (matches all rows).
@@ -1011,7 +1011,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Add COUNT(*). Public client aggregates are COUNT and SUM today.
+    /// Add COUNT(*).
     pub fn count(mut self) -> Self {
         self.query.aggregate.get_or_insert_with(|| AggregateSpec {
             group_by: None,
@@ -1029,7 +1029,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Add SUM(column). Core Jazz/Groove also support AVG/MIN/MAX separately.
+    /// Add SUM(column).
     pub fn sum(mut self, column: impl Into<String>) -> Self {
         self.query.aggregate.get_or_insert_with(|| AggregateSpec {
             group_by: None,
@@ -1042,6 +1042,60 @@ impl QueryBuilder {
             .outputs
             .push(AggregateOutput {
                 function: AggregateFunction::Sum,
+                column: Some(column.into()),
+            });
+        self
+    }
+
+    /// Add AVG(column).
+    pub fn avg(mut self, column: impl Into<String>) -> Self {
+        self.query.aggregate.get_or_insert_with(|| AggregateSpec {
+            group_by: None,
+            outputs: Vec::new(),
+        });
+        self.query
+            .aggregate
+            .as_mut()
+            .expect("aggregate initialized")
+            .outputs
+            .push(AggregateOutput {
+                function: AggregateFunction::Avg,
+                column: Some(column.into()),
+            });
+        self
+    }
+
+    /// Add MIN(column).
+    pub fn min(mut self, column: impl Into<String>) -> Self {
+        self.query.aggregate.get_or_insert_with(|| AggregateSpec {
+            group_by: None,
+            outputs: Vec::new(),
+        });
+        self.query
+            .aggregate
+            .as_mut()
+            .expect("aggregate initialized")
+            .outputs
+            .push(AggregateOutput {
+                function: AggregateFunction::Min,
+                column: Some(column.into()),
+            });
+        self
+    }
+
+    /// Add MAX(column).
+    pub fn max(mut self, column: impl Into<String>) -> Self {
+        self.query.aggregate.get_or_insert_with(|| AggregateSpec {
+            group_by: None,
+            outputs: Vec::new(),
+        });
+        self.query
+            .aggregate
+            .as_mut()
+            .expect("aggregate initialized")
+            .outputs
+            .push(AggregateOutput {
+                function: AggregateFunction::Max,
                 column: Some(column.into()),
             });
         self

--- a/crates/jazz-tools/tests/aggregate_subscriptions.rs
+++ b/crates/jazz-tools/tests/aggregate_subscriptions.rs
@@ -58,6 +58,87 @@ fn policy_metrics_schema() -> Schema {
         .build()
 }
 
+#[derive(Clone, Copy)]
+enum AggregateCase {
+    Avg,
+    Min,
+    Max,
+}
+
+impl AggregateCase {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Avg => "avg",
+            Self::Min => "min",
+            Self::Max => "max",
+        }
+    }
+
+    fn query(self) -> jazz_tools::Query {
+        match self {
+            Self::Avg => QueryBuilder::new("metrics").avg("score").build(),
+            Self::Min => QueryBuilder::new("metrics").min("score").build(),
+            Self::Max => QueryBuilder::new("metrics").max("score").build(),
+        }
+    }
+
+    fn grouped_query(self) -> jazz_tools::Query {
+        match self {
+            Self::Avg => QueryBuilder::new("metrics")
+                .avg("score")
+                .group_by("bucket")
+                .build(),
+            Self::Min => QueryBuilder::new("metrics")
+                .min("score")
+                .group_by("bucket")
+                .build(),
+            Self::Max => QueryBuilder::new("metrics")
+                .max("score")
+                .group_by("bucket")
+                .build(),
+        }
+    }
+
+    fn populated_value(self) -> Value {
+        match self {
+            Self::Avg => Value::Double(15.0),
+            Self::Min => Value::Integer(5),
+            Self::Max => Value::Integer(30),
+        }
+    }
+
+    fn grouped_values(self) -> Vec<Vec<Value>> {
+        match self {
+            Self::Avg => vec![
+                vec![Value::Text("a".to_owned()), Value::Double(20.0)],
+                vec![Value::Text("b".to_owned()), Value::Double(5.0)],
+            ],
+            Self::Min => vec![
+                vec![Value::Text("a".to_owned()), Value::Integer(10)],
+                vec![Value::Text("b".to_owned()), Value::Integer(5)],
+            ],
+            Self::Max => vec![
+                vec![Value::Text("a".to_owned()), Value::Integer(30)],
+                vec![Value::Text("b".to_owned()), Value::Integer(5)],
+            ],
+        }
+    }
+
+    fn populated_schema(self) -> Schema {
+        match self {
+            Self::Avg => bigint_metrics_schema(),
+            Self::Min | Self::Max => metrics_schema(),
+        }
+    }
+
+    fn score_input(self, score: i64) -> Value {
+        match self {
+            Self::Avg => Value::BigInt(score),
+            Self::Min | Self::Max => Value::Integer(score.try_into().expect("score fits i32")),
+        }
+    }
+}
+
 async fn wait_for_values(
     client: &JazzClient,
     query: jazz_tools::Query,
@@ -118,6 +199,156 @@ async fn wait_for_subscription_driven_values(
         }
     }
     assert_eq!(last_actual, expected, "{label}");
+}
+
+async fn assert_nullable_empty_and_all_null(case: AggregateCase, subject: &str) {
+    let schema = nullable_metrics_schema();
+    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let client =
+        JazzClient::connect(server.make_client_context_for_user(schema, test_user_id(subject)))
+            .await
+            .expect("connect client");
+    let query = case.query();
+    let mut stream = client
+        .subscribe(query.clone())
+        .await
+        .unwrap_or_else(|err| panic!("subscribe {} aggregate: {err}", case.name()));
+
+    wait_for_values(
+        &client,
+        query.clone(),
+        vec![vec![Value::Null]],
+        &format!("one-shot empty {} is public null", case.name()),
+    )
+    .await;
+    wait_for_subscription_driven_values(
+        &client,
+        &mut stream,
+        query.clone(),
+        vec![vec![Value::Null]],
+        &format!("subscription empty {} is public null", case.name()),
+    )
+    .await;
+
+    let (_null_row, _, batch) = client
+        .insert(
+            "metrics",
+            row_input!("bucket" => "a", "score" => Value::Null),
+        )
+        .expect("insert null score");
+    client
+        .wait_for_batch(batch, DurabilityTier::Local)
+        .await
+        .expect("null score settles");
+    wait_for_values(
+        &client,
+        query.clone(),
+        vec![vec![Value::Null]],
+        &format!("one-shot all-null {} is public null", case.name()),
+    )
+    .await;
+    wait_for_subscription_driven_values(
+        &client,
+        &mut stream,
+        query,
+        vec![vec![Value::Null]],
+        &format!("subscription all-null {} is public null", case.name()),
+    )
+    .await;
+}
+
+async fn assert_populated_and_grouped(case: AggregateCase, subject: &str) {
+    let schema = case.populated_schema();
+    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let client =
+        JazzClient::connect(server.make_client_context_for_user(schema, test_user_id(subject)))
+            .await
+            .expect("connect client");
+    let query = case.query();
+    let grouped_query = case.grouped_query();
+    let mut stream = client
+        .subscribe(query.clone())
+        .await
+        .unwrap_or_else(|err| panic!("subscribe {} aggregate: {err}", case.name()));
+    let mut grouped_stream = client
+        .subscribe(grouped_query.clone())
+        .await
+        .unwrap_or_else(|err| panic!("subscribe grouped {} aggregate: {err}", case.name()));
+
+    for (bucket, score) in [("a", 10), ("a", 30), ("b", 5)] {
+        let (_row, _, batch) = client
+            .insert(
+                "metrics",
+                row_input!("bucket" => bucket, "score" => case.score_input(score)),
+            )
+            .expect("insert score");
+        client
+            .wait_for_batch(batch, DurabilityTier::Local)
+            .await
+            .expect("score settles");
+    }
+
+    wait_for_values(
+        &client,
+        query.clone(),
+        vec![vec![case.populated_value()]],
+        &format!("one-shot populated {}", case.name()),
+    )
+    .await;
+    wait_for_subscription_driven_values(
+        &client,
+        &mut stream,
+        query,
+        vec![vec![case.populated_value()]],
+        &format!("subscription populated {}", case.name()),
+    )
+    .await;
+
+    wait_for_values(
+        &client,
+        grouped_query.clone(),
+        case.grouped_values(),
+        &format!("one-shot grouped {}", case.name()),
+    )
+    .await;
+    wait_for_subscription_driven_values(
+        &client,
+        &mut grouped_stream,
+        grouped_query,
+        case.grouped_values(),
+        &format!("subscription grouped {}", case.name()),
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn aggregate_avg_public_boundary_and_subscription_results() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            assert_nullable_empty_and_all_null(AggregateCase::Avg, "aggregate-avg-null").await;
+            assert_populated_and_grouped(AggregateCase::Avg, "aggregate-avg-populated").await;
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn aggregate_min_public_boundary_and_subscription_results() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            assert_nullable_empty_and_all_null(AggregateCase::Min, "aggregate-min-null").await;
+            assert_populated_and_grouped(AggregateCase::Min, "aggregate-min-populated").await;
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn aggregate_max_public_boundary_and_subscription_results() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            assert_nullable_empty_and_all_null(AggregateCase::Max, "aggregate-max-null").await;
+            assert_populated_and_grouped(AggregateCase::Max, "aggregate-max-populated").await;
+        })
+        .await;
 }
 
 #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
Core Jazz and Groove already implement AVG, MIN and MAX. Only the public `QueryBuilder` surface was missing them, and a stale doc comment said so. This widens the public `AggregateFunction` enum, adds `avg`/`min`/`max` builder methods, and maps them onto the existing core aggregates.

Also collapses the aggregate output-column naming (`count`, `sum_x`, `avg_x`, …) into one function instead of repeating the match at each call site.

## ⚠️ Draft — must not merge before the Integer encoding fix

**AVG over a public `Integer` column returns a wrong number today.** This PR does not cause that, but it does *expose* it, so merging this first would ship a broken public API.

The public client encodes `Integer` (i32) into core `U32` with an order-preserving sign-bit flip (`^ 0x8000_0000`). That is fine for MIN/MAX and ORDER BY, and it round-trips for a single value — but it is not arithmetic-preserving, and AVG/SUM do arithmetic in the encoded domain.

Measured, on two rows in one group with scores 10 and 7:

| query | returns | correct |
|---|---|---|
| `AVG(score)` over `Integer` | `Double(2147483656.5)` | `Double(8.5)` |
| `SUM(score)` over `Integer` | `Query error: Storage: unsupported operator` | `Integer(17)` |

`2147483656.5` is exactly `((10 ^ 0x80000000) + (7 ^ 0x80000000)) / 2`. SUM errors rather than lying because the two encoded values exceed `u32::MAX` and `u32::try_from` fails in the IVM runtime.

MIN and MAX in this PR are correct and unaffected — the flip preserves order.

Fix is in flight on a separate branch off `main`; this becomes ready once that lands.

## A note on the AVG coverage here

The AVG cases in `aggregate_subscriptions.rs` use a **BigInt** schema, while MIN/MAX use `Integer`. That asymmetry is not a natural choice — it is this bug. BigInt is not sign-flipped, so it is the only integer type AVG currently gets right. Once the encoding fix lands, the AVG cases should move to `Integer` alongside MIN/MAX, otherwise this reads like deliberate coverage when it is really a workaround.

## Gates

`cargo test -p jazz-tools --features test -j 2` green; `cargo fmt --check -p jazz-tools` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)