### PR TITLE
(new core) Make the sensitive-data hook announce when it does not run

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,8 +2,14 @@ pre-commit:
   commands:
     no-sensitive-data:
       # Patterns live in jazz-private (cleartext there instead of decodable
-      # base64 here); hook is a no-op on machines without that checkout.
-      run: sh -c 'GATE="$HOME/jazz-private/dev/gates/no-sensitive-data.sh"; if [ -x "$GATE" ]; then "$GATE"; else exit 0; fi'
+      # base64 here). Contributors without that checkout are not blocked, but
+      # the skip is announced: a silent pass is indistinguishable from a clean
+      # scan, and this hook is the only thing keeping customer-identifying
+      # strings out of this public repo.
+      run: >-
+        sh -c 'GATE="$HOME/jazz-private/dev/gates/no-sensitive-data.sh";
+        if [ -x "$GATE" ]; then "$GATE";
+        else echo "WARNING - sensitive-data guard NOT RUN. $GATE is missing, so commits are not scanned for customer-identifying strings. Clone jazz-private to enable it." >&2; exit 0; fi'
     rustfmt:
       glob: "*.rs"
       run: cargo fmt


### PR DESCRIPTION
One-line change to `lefthook.yml`. Found while setting up a new build host.

## The problem

```sh
GATE="$HOME/jazz-private/dev/gates/no-sensitive-data.sh"; if [ -x "$GATE" ]; then "$GATE"; else exit 0; fi
```

If the guard script is absent, the hook exits 0 silently. Its output is then **indistinguishable from a clean scan** — lefthook prints the same green tick either way.

The consequence is not hypothetical: an entire session's worth of commits on a fresh machine reported passing the sensitive-data gate while it had never executed once. Nothing in the output distinguished that from a repo that had been properly scanned. It surfaced only because a subagent reported that gate as UNCLEAR rather than assuming it had passed.

This hook is the only automated thing keeping customer-identifying strings out of this public repo. A gate that reports success when it did not run is worse than no gate, because it manufactures confidence.

## The change

Contributors without the `jazz-private` checkout are still not blocked — that behaviour is deliberate and preserved. But the skip is now announced on stderr, so an unscanned commit is visible rather than inferred.

`run` becomes a YAML folded scalar, because the warning text contains a colon and would otherwise break plain-scalar parsing.

## Verification

- `yaml.safe_load` parses it; `lefthook validate` reports **All good**.
- With the guard present, a real commit runs it: `✔️ no-sensitive-data (11.47 seconds)` — actual scanning time, against the instant exit of the silent path.
- With the guard absent, the warning is emitted and the commit still proceeds.
- The guard itself was separately verified against a planted positive (exit 1, offending file and line named) and a clean tree (exit 0).

## Related

The guard script was missing entirely from `garden-co/jazz-private` — it had never been committed there, in any branch, in the repo's whole history. It now exists at `dev/gates/no-sensitive-data.sh` in that repo, which is where it belongs so the pattern list can stay cleartext.

🤖 Generated with [Claude Code](https://claude.com/claude-code)