### PR TITLE
(new core) Make gate parallelism a property of the box, not a fixed -j 2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,10 +20,11 @@ Before writing any test in Rust crates, always read `crates/jazz-tools/TESTING_G
 **Canonical gates:** do not let born-red or rotted targets accumulate silently.
 For ordinary Rust/core work, the full gate set is:
 
-- `cargo test -p jazz -j 2`
-- `cargo test -p groove -j 2`
-- `cargo test -p jazz-tools --features test -j 2` (matches `crates/jazz-tools/TESTING_GUIDELINES.md`)
-- `cargo test -p jazz-server -j 2`
+- `cargo test -p jazz`
+- `cargo test -p groove`
+- `cargo test -p jazz-tools --features test` (matches `crates/jazz-tools/TESTING_GUIDELINES.md`)
+- `cargo test -p jazz-server`
+
 - `cargo check -p jazz-sim --benches` (always; it is cheap enough and catches bench API rot)
 - `dev/gates/ts-wire-codec.sh` for TypeScript/native-runtime wire-codec coverage
   (Anselm-approved 2026-07-07)
@@ -34,6 +35,15 @@ For ordinary Rust/core work, the full gate set is:
 - the sensitive-data guard (lives in `jazz-private/dev/gates/`, runs via the
   optional lefthook hook) to keep customer-specific fixture names, domains,
   and IDs out of the public repository.
+
+Use a `-j` appropriate for the box. These gates previously specified `-j 2`,
+which was a workaround for spurious `linking with cc failed` under parallel
+builds on a memory-constrained laptop — a property of that machine, not of the
+build. Cap it only if you actually observe linker OOM. For reference, a cold
+`cargo test -p jazz -j 16` measured 2m23s wall / 18m18s CPU at ~2GB peak of
+187GB, so memory was never the binding constraint there; on a small machine
+`-j 2` is still the right answer. `dev/benchmarks/smoke.sh` derives this from
+`nproc` and honours `JAZZ_SMOKE_JOBS`.
 
 Run `dev/benchmarks/smoke.sh` for any change touching protocol, engine, storage,
 or benchmark harnesses. Any change to a public `jazz` type additionally gates the

--- a/crates/jazz-tools/TESTING_GUIDELINES.md
+++ b/crates/jazz-tools/TESTING_GUIDELINES.md
@@ -2,7 +2,9 @@
 
 Always prefer black-boxed integration tests that exercise public APIs over unit tests or white-box tests.
 
-- Canonical crate gate: `cargo test -p jazz-tools --features test -j 2`.
+- Canonical crate gate: `cargo test -p jazz-tools --features test`, with a `-j`
+  appropriate for the box (see `AGENTS.md`; the former fixed `-j 2` was a
+  laptop-specific linker-OOM workaround, not a property of the build).
   This runs integration tests with Rust's default per-binary parallelism; fixtures
   must isolate app ids, ports, storage, and client state unless a test explicitly
   constructs a shared topology.


### PR DESCRIPTION
Docs only.

The canonical gates in `AGENTS.md` (symlinked as `.claude/CLAUDE.md`) specified `-j 2`. That cap existed for a real reason — spurious `linking with cc failed` under parallel builds on a memory-constrained laptop — but it is a property of that machine, not of the build, and it was being applied everywhere.

Measured on a 32-core / 187GB host: a cold `cargo test -p jazz -j 16` takes **2m23s wall / 18m18s CPU at ~2GB peak**. Memory was never the binding constraint, and the fixed cap left 30 cores idle on every gate run.

The guidance now says to use a `-j` appropriate for the box, records *why* the old cap existed so nobody reintroduces it blindly, and keeps `-j 2` as the right answer on a small machine.

Companion to #1152, which made `dev/benchmarks/smoke.sh` derive its prebuild parallelism from `nproc` with a `JAZZ_SMOKE_JOBS` override.

`crates/jazz/SPEC/D_testing_gates.md` carries the same list and is being edited concurrently by spec work; it will be updated there rather than conflicting here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)