### PR TITLE
(new core) Attribute the cold-start settle span — and contradict "grinding is exhausted"

### DIFF
--- a/dev/benchmarks/COLD_SETTLE_PROFILE_20260728.md
+++ b/dev/benchmarks/COLD_SETTLE_PROFILE_20260728.md
@@ -1,0 +1,74 @@
+# Cold settle profile — 2026-07-28
+
+## Verdict
+
+- **CLEARLY-BAD:** the isolated low-load cold receipt settled in 12.409s, above the <10s goal.
+- **CLEARLY-BAD:** the critical path is receiver-side bulk view ingest, not transfer or connection.
+- **UNCLEAR:** the final exact-timer receipt ran while host contention rose (one-minute load 2.74 to 16.00), so its 27.766s wall time is not a latency baseline. Its counters and phase ordering remain useful.
+
+## Command
+
+```sh
+JAZZ_CUSTOMER_IDENTITY=member JAZZ_CUSTOMER_PHASES=cold \
+JAZZ_CUSTOMER_SCALE=1.0 JAZZ_CUSTOMER_MAX_TICKS=200000 \
+JAZZ_REHYDRATE_TRACE=1 JAZZ_PROFILE_OUT=target/cold-settle-profile-receipt-20260728 \
+JAZZ_PROFILE_FREQUENCY=997 \
+  cargo bench -p jazz-sim --bench customer_cold_start --features profiling -- --nocapture
+```
+
+Only the anonymized in-repo customer-shape fixture was used. The benchmark has
+39 subscriptions and produced 27,518/27,518 final rows. The profile process
+ran on one foreground CPU; no RocksDB background CPU samples were observed.
+
+## Exact-timer phase accounting
+
+The final pass used in-process `SyncMessage` queues, not the byte-wire adapter:
+receive/decode is therefore effectively zero here. The separately measured
+streaming zstd probe was 35.277ms encode + 16.278ms decode over 20.191MB raw /
+0.492MB streaming-zstd payload, and is not the wall-time cause.
+
+| Settle phase | Time | Share | Rows / edges processed |
+|---|---:|---:|---|
+| Receive/decode | 0.039ms | 0.0% | 215 messages; in-process semantic messages, no wire decode |
+| Core ingest | 17.761s | 64.0% | 74,258 receiver bulk bundle ingests (46,740 relay + 27,518 client); 75,574 result-membership/program-fact edges |
+| Maintained-view settle | 7.026s | 25.3% | 47,437 core snapshot member edges, then 28,137 relay-to-client member edges |
+| Subscription adapter/materialization | 1.371s | 4.9% | 39 streams, 27,518 final rows |
+| Residual: scheduling, outbound queueing, checks | 1.607s | 5.8% | no additional row/edge transform counted |
+| **Total settle** | **27.766s** | **100.0%** | |
+
+The low-load CPU capture of the same shape (12.409s settle) independently put
+`apply_view_updates_in_batch` at 3,736/7,235 foreground samples (51.6%). That
+corroborates the exact counter ordering despite the final pass's contention.
+
+## Dominant child
+
+`res_l_child_3` gates readiness: 23,831 final rows reached ready at 28.304s,
+the all-holder endpoint. Its upstream maintained rehydrate processed 43,065
+member edges (794ms open + 361ms bundle); the relay then settled 23,867 visible
+member edges (583ms drain + 395ms bundle). The 43k-to-23.8k reduction is the
+policy boundary, and all of that work still lands before readiness.
+
+## Interpretation
+
+**Grind:** receiver bulk reset-view ingest and record/edge conversion dominate.
+The CPU profile's leading frames are sequence serialization, record projection,
+hashing, and `view_update_chunk_from_units`; transport compression is tiny.
+This is a concrete optimization lane, not an undifferentiated settle bucket.
+
+**Design:** the system insists on ingesting and settling the complete snapshot
+for every holder before any ready state. The dominant child alone requires
+43,065 upstream / 23,867 visible membership edges. Progressive first-page
+readiness and a persisted materialized snapshot would remove large portions of
+that work from the critical path.
+
+The prior claim that grinding was exhausted is **contradicted**: ingest is a
+measured majority cost. The design conclusion still stands for the larger goal:
+even a good ingest improvement leaves full-snapshot-to-all-holders work on the
+critical path.
+
+Raw logs and pprof artifacts are intentionally local under `target/`; temporary
+source instrumentation was removed before this receipt was committed.
+
+Tooling-friction: the optional pprof feature triggered a cold RocksDB/pprof
+release build before measurement; a prebuilt profiling bench target would save
+wall-clock.


### PR DESCRIPTION
Docs + receipt. Turns the 92%-of-time "settle/ingest" bucket into named phases.

## What was known

A cold-start assessment put native customer-shape cold at 15.5–18.7s against a <10s target, and ruled things **out**: connect 0ms, registration ~3%, transport 20.19MB raw / 0.511MB compressed — bytes cannot explain 15s. But **92% sat in one undifferentiated `settle/ingest` bucket**, which is a label, not attribution.

## The profile

| phase | share |
|---|---:|
| **receiver bulk view ingest** | **64.0%** |
| maintained settle | 25.3% |
| adapter / materialization | 4.9% |
| residual | 5.8% |

Low-contention settle measured **12.409s** — still CLEARLY-BAD against <10s, and lower than the 15.5–18.7s range, which indicates the earlier figures were inflated by host contention from concurrent lanes.

Leading CPU frames: sequence serialization, record projection, hashing, `view_update_chunk_from_units`. Transport compression is negligible.

The dominant child gates all-holder readiness on its own: **43,065 upstream membership edges reduced to 23,867 visible** at the policy boundary — and all of that work lands *before* any ready state.

## The finding that matters

**The prior conclusion that "grinding is exhausted" is contradicted.** Receiver-side ingest is a measured majority cost with identifiable hot frames — a concrete optimization lane, not a wall.

The design conclusion still holds for the larger goal: even a substantial ingest win leaves full-snapshot-to-all-holders work on the critical path, so progressive first-page readiness and a persisted materialized snapshot remain the route to genuinely less work. But those are no longer the *only* available move, which is what the record has said since 2026-07-14.

## Method

One deep instrumentation pass with per-phase row and edge counts, not staged guesses. Named phases account for the span with the residual stated explicitly. Anonymized in-repo fixture only; sensitive-data guard green. Temporary instrumentation removed before commit; pprof artifacts left local under `target/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)