### PR TITLE
(new core) Fix maintained TopBy binding partitions

### DIFF
--- a/crates/groove/Cargo.toml
+++ b/crates/groove/Cargo.toml
@@ -36,3 +36,7 @@ harness = false
 [[bench]]
 name = "micro"
 harness = false
+
+[[bench]]
+name = "saas_documents"
+harness = false

--- a/crates/groove/benches/saas_documents.rs
+++ b/crates/groove/benches/saas_documents.rs
@@ -1,0 +1,1092 @@
+//! SaaS-style team document query benchmark.
+//!
+//! The default fixture contains exactly 500k documents and 5k teams, including
+//! one 30k-document hot team and one 100-document small team. Those exact
+//! constraints are mathematically incompatible with every team having at least
+//! 100 documents (500k / 5k == 100), so the remaining teams absorb the skew and
+//! contain 94-95 documents. Set `GROOVE_SAAS_DOCUMENTS=529900` to instead keep
+//! every non-hot team at 100 documents.
+//!
+//! The benchmark compares:
+//!
+//! - full table hydration + membership semi-join + filtered TopBy(100);
+//! - explicit durable-index candidate enumeration before the same graph;
+//! - a raw composite-index prefix scan and a last-with-prefix control;
+//! - maintained TopBy writes inside and outside the selected team, plus a
+//!   100-row selected-team batch.
+//!
+//! Run the full default fixture:
+//!
+//! ```text
+//! cargo bench --profile perf -p groove --bench saas_documents --quiet
+//! ```
+//!
+//! Useful knobs:
+//! `GROOVE_SAAS_DOCUMENTS`, `GROOVE_SAAS_TEAMS`,
+//! `GROOVE_SAAS_HOT_TEAM_DOCUMENTS`, `GROOVE_SAAS_MEMBERS_PER_TEAM`,
+//! `GROOVE_SAAS_QUERY_ITERS`, `GROOVE_SAAS_WRITE_ITERS`, and
+//! `GROOVE_SAAS_BATCH_SIZE`.
+
+use std::collections::BTreeSet;
+use std::env;
+use std::time::{Duration, Instant};
+
+use groove::db::{Database, GraphBuilder, PredicateExpr, StorageReadMetrics};
+use groove::ivm::{RecordDeltas, TopByLimit, TopByOrder};
+use groove::records::{RecordDescriptor, Value};
+use groove::schema::{
+    ColumnSchema, ColumnType, DatabaseSchema, IndexSchema, IntegerKeyType, PrimaryKey, TableSchema,
+};
+use groove::storage::{Durability, MemoryStorage, OrderedKvStorage, RocksDbStorage};
+use hdrhistogram::Histogram;
+
+const HOT_TEAM_ID: u64 = 1;
+const SMALL_TEAM_ID: u64 = 2;
+const CURRENT_USER_ID: u64 = 1;
+const UNAUTHORIZED_USER_ID: u64 = u64::MAX - 1;
+const ACTIVE_STATUS: u8 = 1;
+const PAGE_SIZE: usize = 100;
+const SUBSCRIBED_BATCH_ROWS: usize = 100;
+
+const DOCUMENTS_BY_TEAM_UPDATED: &str = "documents_by_team_updated";
+const DOCUMENTS_BY_TEAM_STATUS_ARCHIVED_UPDATED: &str = "documents_by_team_status_archived_updated";
+const MEMBERSHIPS_BY_USER_TEAM: &str = "memberships_by_user_team";
+
+fn main() {
+    let config = Config::from_env();
+    config.validate();
+    let schema = saas_schema();
+    let column_families = schema
+        .column_families()
+        .into_iter()
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    let column_family_refs = column_families
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+
+    match env::var("GROOVE_SAAS_STORAGE")
+        .unwrap_or_else(|_| "rocksdb".to_owned())
+        .as_str()
+    {
+        "memory" => run(
+            config,
+            schema,
+            MemoryStorage::new(&column_family_refs),
+            "memory",
+        ),
+        "rocksdb" => {
+            let temp_dir = tempfile::tempdir().expect("create benchmark RocksDB directory");
+            let storage = RocksDbStorage::open_with_durability(
+                temp_dir.path(),
+                &column_family_refs,
+                Durability::WalNoSync,
+            )
+            .expect("open benchmark RocksDB");
+            run(config, schema, storage, "rocksdb_wal_no_sync");
+        }
+        other => panic!("unsupported GROOVE_SAAS_STORAGE={other}; use memory or rocksdb"),
+    }
+}
+
+fn run<S>(config: Config, schema: DatabaseSchema, storage: S, storage_name: &str)
+where
+    S: OrderedKvStorage,
+{
+    let document_descriptor = documents_table().record_schema();
+    let membership_descriptor = memberships_table().record_schema();
+    let mut database = Database::new(schema, storage).expect("open SaaS benchmark database");
+
+    eprintln!(
+        "seeding {} documents, {} teams, {} members/team into {storage_name}",
+        config.documents, config.teams, config.members_per_team
+    );
+    let seed_started = Instant::now();
+    let fixture = seed_fixture(&mut database, config);
+    let seed_elapsed = seed_started.elapsed();
+    println!(
+        concat!(
+            "{{",
+            "\"scenario\":\"saas_documents\",",
+            "\"case\":\"fixture\",",
+            "\"storage\":\"{}\",",
+            "\"documents\":{},",
+            "\"teams\":{},",
+            "\"memberships\":{},",
+            "\"hot_team_documents\":{},",
+            "\"small_team_documents\":{},",
+            "\"other_team_min_documents\":{},",
+            "\"other_team_max_documents\":{},",
+            "\"seed_us\":{}",
+            "}}"
+        ),
+        storage_name,
+        config.documents,
+        config.teams,
+        config.teams * config.members_per_team,
+        fixture.hot_documents.len(),
+        fixture.small_documents.len(),
+        fixture.other_team_min_documents,
+        fixture.other_team_max_documents,
+        duration_micros(seed_elapsed),
+    );
+
+    for target in [
+        TargetTeam::new("hot", HOT_TEAM_ID, &fixture.hot_documents),
+        TargetTeam::new("small", SMALL_TEAM_ID, &fixture.small_documents),
+    ] {
+        for filter in [DocumentFilter::Latest, DocumentFilter::ActiveUnarchived] {
+            run_query_case(
+                &mut database,
+                config,
+                storage_name,
+                AccessPath::FullScan,
+                target,
+                filter,
+                CURRENT_USER_ID,
+                &document_descriptor,
+                &membership_descriptor,
+            );
+            run_query_case(
+                &mut database,
+                config,
+                storage_name,
+                AccessPath::Indexed,
+                target,
+                filter,
+                CURRENT_USER_ID,
+                &document_descriptor,
+                &membership_descriptor,
+            );
+        }
+    }
+
+    run_query_case(
+        &mut database,
+        config,
+        storage_name,
+        AccessPath::FullScan,
+        TargetTeam::new("hot", HOT_TEAM_ID, &fixture.hot_documents),
+        DocumentFilter::Latest,
+        UNAUTHORIZED_USER_ID,
+        &document_descriptor,
+        &membership_descriptor,
+    );
+
+    run_index_controls(
+        &mut database,
+        config,
+        storage_name,
+        fixture.hot_documents.len(),
+    );
+    run_subscribed_writes(&mut database, config, storage_name, &fixture.hot_documents);
+
+    let stats = database.runtime_stats();
+    println!(
+        concat!(
+            "{{",
+            "\"scenario\":\"saas_documents\",",
+            "\"case\":\"runtime_final\",",
+            "\"storage\":\"{}\",",
+            "\"graph_nodes\":{},",
+            "\"arrangements\":{},",
+            "\"arrangement_rows\":{},",
+            "\"arrangement_bytes\":{},",
+            "\"logical_nodes_requested\":{},",
+            "\"deduped_graph_nodes\":{},",
+            "\"dedupe_ratio\":{},",
+            "\"tooling_friction\":\"bounded reverse-prefix iteration with early termination is not exposed\"",
+            "}}"
+        ),
+        storage_name,
+        stats.graph_nodes,
+        stats.arrangement_count,
+        stats.arrangement_rows,
+        stats.arrangement_encoded_bytes,
+        stats.logical_nodes_requested,
+        stats.deduped_graph_nodes,
+        stats.dedupe_ratio(),
+    );
+}
+
+#[derive(Clone, Copy)]
+struct Config {
+    documents: usize,
+    teams: usize,
+    hot_team_documents: usize,
+    small_team_documents: usize,
+    members_per_team: usize,
+    query_iterations: usize,
+    write_iterations: usize,
+    batch_size: usize,
+}
+
+impl Config {
+    fn from_env() -> Self {
+        Self {
+            documents: env_usize("GROOVE_SAAS_DOCUMENTS", 500_000),
+            teams: env_usize("GROOVE_SAAS_TEAMS", 5_000),
+            hot_team_documents: env_usize("GROOVE_SAAS_HOT_TEAM_DOCUMENTS", 30_000),
+            small_team_documents: env_usize("GROOVE_SAAS_SMALL_TEAM_DOCUMENTS", 100),
+            members_per_team: env_usize("GROOVE_SAAS_MEMBERS_PER_TEAM", 10),
+            query_iterations: env_usize("GROOVE_SAAS_QUERY_ITERS", 10),
+            write_iterations: env_usize("GROOVE_SAAS_WRITE_ITERS", 20),
+            batch_size: env_usize("GROOVE_SAAS_BATCH_SIZE", 10_000),
+        }
+    }
+
+    fn validate(self) {
+        assert!(self.teams >= 3, "benchmark requires at least three teams");
+        assert!(
+            self.documents >= self.hot_team_documents + self.small_team_documents,
+            "document count is smaller than the two target teams"
+        );
+        assert!(
+            self.hot_team_documents >= PAGE_SIZE,
+            "hot team must fill one page"
+        );
+        assert!(
+            self.small_team_documents >= PAGE_SIZE,
+            "small team must fill one page"
+        );
+        assert!(
+            self.members_per_team > 0,
+            "each team needs at least one member"
+        );
+        assert!(self.query_iterations > 0, "query iterations must be > 0");
+        assert!(self.write_iterations > 0, "write iterations must be > 0");
+        assert!(self.batch_size > 0, "batch size must be > 0");
+    }
+
+    fn team_document_counts(self) -> Vec<usize> {
+        let mut counts = vec![0; self.teams];
+        counts[0] = self.hot_team_documents;
+        counts[1] = self.small_team_documents;
+        let remaining = self
+            .documents
+            .saturating_sub(self.hot_team_documents + self.small_team_documents);
+        let other_teams = self.teams - 2;
+        let per_team = remaining / other_teams;
+        let remainder = remaining % other_teams;
+        for (offset, count) in counts[2..].iter_mut().enumerate() {
+            *count = per_team + usize::from(offset < remainder);
+        }
+        assert_eq!(counts.iter().sum::<usize>(), self.documents);
+        counts
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct SeedDocument {
+    id: u64,
+    updated_at: u64,
+    status: u8,
+    archived: bool,
+}
+
+struct Fixture {
+    hot_documents: Vec<SeedDocument>,
+    small_documents: Vec<SeedDocument>,
+    other_team_min_documents: usize,
+    other_team_max_documents: usize,
+}
+
+fn seed_fixture<S>(database: &mut Database<S>, config: Config) -> Fixture
+where
+    S: OrderedKvStorage,
+{
+    let counts = config.team_document_counts();
+
+    let mut teams = database.open_batch();
+    for team_id in 1..=config.teams as u64 {
+        teams.insert(
+            "teams",
+            vec![
+                Value::U64(team_id),
+                Value::String(format!("Team {team_id}")),
+            ],
+        );
+    }
+    database.commit_batch(teams).expect("seed teams");
+
+    let mut membership_id = 1_u64;
+    let mut staged = 0_usize;
+    let mut memberships = database.open_batch();
+    for team_id in 1..=config.teams as u64 {
+        for member_offset in 0..config.members_per_team {
+            let user_id =
+                if member_offset == 0 && (team_id == HOT_TEAM_ID || team_id == SMALL_TEAM_ID) {
+                    CURRENT_USER_ID
+                } else {
+                    2 + (team_id - 1) * config.members_per_team as u64 + member_offset as u64
+                };
+            memberships.insert(
+                "team_memberships",
+                vec![
+                    Value::U64(membership_id),
+                    Value::U64(team_id),
+                    Value::U64(user_id),
+                    Value::U8((member_offset % 3) as u8),
+                ],
+            );
+            membership_id += 1;
+            staged += 1;
+            if staged == config.batch_size {
+                database
+                    .commit_batch(std::mem::take(&mut memberships))
+                    .expect("seed membership batch");
+                staged = 0;
+            }
+        }
+    }
+    if staged != 0 {
+        database
+            .commit_batch(memberships)
+            .expect("seed final membership batch");
+    }
+
+    let mut hot_documents = Vec::with_capacity(counts[0]);
+    let mut small_documents = Vec::with_capacity(counts[1]);
+    let mut document_id = 1_u64;
+    let mut seeded_documents = 0_usize;
+    let mut staged = 0_usize;
+    let mut documents = database.open_batch();
+    for (team_offset, &document_count) in counts.iter().enumerate() {
+        let team_id = team_offset as u64 + 1;
+        for ordinal in 0..document_count {
+            let ordinal = ordinal as u64 + 1;
+            let status = (ordinal % 4) as u8;
+            let archived = ordinal.is_multiple_of(19);
+            let seed = SeedDocument {
+                id: document_id,
+                updated_at: ordinal,
+                status,
+                archived,
+            };
+            if team_id == HOT_TEAM_ID {
+                hot_documents.push(seed);
+            } else if team_id == SMALL_TEAM_ID {
+                small_documents.push(seed);
+            }
+            documents.insert(
+                "documents",
+                vec![
+                    Value::U64(document_id),
+                    Value::U64(team_id),
+                    Value::U64(ordinal),
+                    Value::U8(status),
+                    Value::Bool(archived),
+                    Value::String(format!("Document {document_id}")),
+                    Value::String(format!(
+                        "team-{team_id}-document-{ordinal}-benchmark-payload"
+                    )),
+                ],
+            );
+            document_id += 1;
+            staged += 1;
+            seeded_documents += 1;
+            if staged == config.batch_size {
+                database
+                    .commit_batch(std::mem::take(&mut documents))
+                    .expect("seed document batch");
+                staged = 0;
+                if seeded_documents.is_multiple_of(100_000) {
+                    eprintln!("seeded {seeded_documents}/{} documents", config.documents);
+                }
+            }
+        }
+    }
+    if staged != 0 {
+        database
+            .commit_batch(documents)
+            .expect("seed final document batch");
+    }
+
+    Fixture {
+        hot_documents,
+        small_documents,
+        other_team_min_documents: counts[2..].iter().copied().min().unwrap_or_default(),
+        other_team_max_documents: counts[2..].iter().copied().max().unwrap_or_default(),
+    }
+}
+
+#[derive(Clone, Copy)]
+struct TargetTeam<'a> {
+    name: &'static str,
+    id: u64,
+    documents: &'a [SeedDocument],
+}
+
+impl<'a> TargetTeam<'a> {
+    fn new(name: &'static str, id: u64, documents: &'a [SeedDocument]) -> Self {
+        Self {
+            name,
+            id,
+            documents,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum DocumentFilter {
+    Latest,
+    ActiveUnarchived,
+}
+
+impl DocumentFilter {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Latest => "latest",
+            Self::ActiveUnarchived => "active_unarchived",
+        }
+    }
+
+    fn matches(self, document: SeedDocument) -> bool {
+        match self {
+            Self::Latest => true,
+            Self::ActiveUnarchived => document.status == ACTIVE_STATUS && !document.archived,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum AccessPath {
+    FullScan,
+    Indexed,
+}
+
+impl AccessPath {
+    fn name(self) -> &'static str {
+        match self {
+            Self::FullScan => "full_scan",
+            Self::Indexed => "indexed_candidates",
+        }
+    }
+}
+
+struct BuiltGraph {
+    graph: GraphBuilder,
+    document_candidates: usize,
+    membership_candidates: usize,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_query_case<S>(
+    database: &mut Database<S>,
+    config: Config,
+    storage_name: &str,
+    access_path: AccessPath,
+    target: TargetTeam<'_>,
+    filter: DocumentFilter,
+    user_id: u64,
+    document_descriptor: &RecordDescriptor,
+    membership_descriptor: &RecordDescriptor,
+) where
+    S: OrderedKvStorage,
+{
+    let expected = expected_ids(target.documents, filter, user_id == CURRENT_USER_ID);
+    let mut repeat_histogram = Histogram::new(3).expect("repeat latency histogram");
+    let mut cold_us = 0_u64;
+    let mut cold_reads = StorageReadMetrics::default();
+    let mut document_candidates = 0_usize;
+    let mut membership_candidates = 0_usize;
+
+    for iteration in 0..=config.query_iterations {
+        database.reset_storage_read_metrics();
+        let started = Instant::now();
+        let built = build_query_graph(
+            database,
+            access_path,
+            target.id,
+            filter,
+            user_id,
+            document_descriptor,
+            membership_descriptor,
+        );
+        document_candidates = match access_path {
+            AccessPath::FullScan => config.documents,
+            AccessPath::Indexed => built.document_candidates,
+        };
+        membership_candidates = match access_path {
+            AccessPath::FullScan => config.teams * config.members_per_team,
+            AccessPath::Indexed => built.membership_candidates,
+        };
+        let result = database
+            .query_graph(built.graph)
+            .expect("execute SaaS document graph");
+        let elapsed = started.elapsed();
+        assert_result(&result, &expected);
+        let reads = database.take_storage_read_metrics();
+        if iteration == 0 {
+            cold_us = duration_micros(elapsed);
+            cold_reads = reads;
+        } else {
+            repeat_histogram
+                .record(duration_micros(elapsed))
+                .expect("record repeat query");
+        }
+    }
+
+    println!(
+        concat!(
+            "{{",
+            "\"scenario\":\"saas_documents\",",
+            "\"case\":\"query\",",
+            "\"storage\":\"{}\",",
+            "\"access_path\":\"{}\",",
+            "\"team\":\"{}\",",
+            "\"team_documents\":{},",
+            "\"filter\":\"{}\",",
+            "\"authorized\":{},",
+            "\"returned\":{},",
+            "\"document_candidates\":{},",
+            "\"membership_candidates\":{},",
+            "\"cold_us\":{},",
+            "\"repeat_us\":{},",
+            "\"cold_storage_records\":{},",
+            "\"cold_storage_ranges\":{}",
+            "}}"
+        ),
+        storage_name,
+        access_path.name(),
+        target.name,
+        target.documents.len(),
+        filter.name(),
+        user_id == CURRENT_USER_ID,
+        expected.len(),
+        document_candidates,
+        membership_candidates,
+        cold_us,
+        histogram_json(&repeat_histogram),
+        cold_reads.total.reads,
+        cold_reads.total.ranges,
+    );
+}
+
+fn build_query_graph<S>(
+    database: &Database<S>,
+    access_path: AccessPath,
+    team_id: u64,
+    filter: DocumentFilter,
+    user_id: u64,
+    document_descriptor: &RecordDescriptor,
+    membership_descriptor: &RecordDescriptor,
+) -> BuiltGraph
+where
+    S: OrderedKvStorage,
+{
+    let (documents, document_candidates) = match access_path {
+        AccessPath::FullScan => (GraphBuilder::table("documents"), 0),
+        AccessPath::Indexed => {
+            let (index, prefix) = match filter {
+                DocumentFilter::Latest => (DOCUMENTS_BY_TEAM_UPDATED, vec![Value::U64(team_id)]),
+                DocumentFilter::ActiveUnarchived => (
+                    DOCUMENTS_BY_TEAM_STATUS_ARCHIVED_UPDATED,
+                    vec![
+                        Value::U64(team_id),
+                        Value::U8(ACTIVE_STATUS),
+                        Value::Bool(false),
+                    ],
+                ),
+            };
+            let records = database
+                .index_scan_raw("documents", index, &prefix)
+                .expect("scan document index")
+                .into_iter()
+                .map(|row| row.record().raw().to_vec())
+                .collect::<Vec<_>>();
+            let count = records.len();
+            (
+                GraphBuilder::inline_records(*document_descriptor, records),
+                count,
+            )
+        }
+    };
+    let documents = documents.filter(document_predicate(team_id, filter));
+
+    let (memberships, membership_candidates) = match access_path {
+        AccessPath::FullScan => (GraphBuilder::table("team_memberships"), 0),
+        AccessPath::Indexed => {
+            let records = database
+                .index_scan_raw(
+                    "team_memberships",
+                    MEMBERSHIPS_BY_USER_TEAM,
+                    &[Value::U64(user_id), Value::U64(team_id)],
+                )
+                .expect("scan membership index")
+                .into_iter()
+                .map(|row| row.record().raw().to_vec())
+                .collect::<Vec<_>>();
+            let count = records.len();
+            (
+                GraphBuilder::inline_records(*membership_descriptor, records),
+                count,
+            )
+        }
+    };
+    let memberships = memberships.filter(PredicateExpr::eq("user_id", Value::U64(user_id)));
+    let authorized = GraphBuilder::semi_join(documents, memberships, ["team_id"], ["team_id"]);
+    let graph = GraphBuilder::top_by(
+        authorized,
+        Vec::<String>::new(),
+        [TopByOrder::desc("updated_at")],
+        ["id"],
+        0,
+        TopByLimit::Finite(PAGE_SIZE as u64),
+    );
+    BuiltGraph {
+        graph,
+        document_candidates,
+        membership_candidates,
+    }
+}
+
+fn document_predicate(team_id: u64, filter: DocumentFilter) -> PredicateExpr {
+    let mut predicates = vec![PredicateExpr::eq("team_id", Value::U64(team_id))];
+    if matches!(filter, DocumentFilter::ActiveUnarchived) {
+        predicates.extend([
+            PredicateExpr::eq("status", Value::U8(ACTIVE_STATUS)),
+            PredicateExpr::eq("archived", Value::Bool(false)),
+        ]);
+    }
+    PredicateExpr::And(predicates).canonicalize()
+}
+
+fn expected_ids(
+    documents: &[SeedDocument],
+    filter: DocumentFilter,
+    authorized: bool,
+) -> BTreeSet<u64> {
+    if !authorized {
+        return BTreeSet::new();
+    }
+    let mut matches = documents
+        .iter()
+        .copied()
+        .filter(|document| filter.matches(*document))
+        .collect::<Vec<_>>();
+    matches.sort_by(|left, right| {
+        right
+            .updated_at
+            .cmp(&left.updated_at)
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    matches
+        .into_iter()
+        .take(PAGE_SIZE)
+        .map(|document| document.id)
+        .collect()
+}
+
+fn assert_result(result: &RecordDeltas, expected: &BTreeSet<u64>) {
+    let mut actual = BTreeSet::new();
+    for (record, weight) in result.iter() {
+        assert_eq!(weight, 1, "one-shot TopBy rows must have unit weight");
+        let Value::U64(id) = record.get("id").expect("read result id") else {
+            panic!("document id is not u64");
+        };
+        actual.insert(id);
+    }
+    assert_eq!(&actual, expected, "SaaS query disagrees with oracle");
+}
+
+fn run_index_controls<S>(
+    database: &mut Database<S>,
+    config: Config,
+    storage_name: &str,
+    expected_hot_rows: usize,
+) where
+    S: OrderedKvStorage,
+{
+    let mut scan_histogram = Histogram::new(3).expect("index scan histogram");
+    let mut scan_reads = StorageReadMetrics::default();
+    for _ in 0..config.query_iterations {
+        database.reset_storage_read_metrics();
+        let started = Instant::now();
+        let rows = database
+            .index_scan_raw(
+                "documents",
+                DOCUMENTS_BY_TEAM_UPDATED,
+                &[Value::U64(HOT_TEAM_ID)],
+            )
+            .expect("scan hot-team ordered index");
+        assert_eq!(rows.len(), expected_hot_rows);
+        scan_histogram
+            .record(duration_micros(started.elapsed()))
+            .expect("record index scan");
+        scan_reads = database.take_storage_read_metrics();
+    }
+
+    let mut last_histogram = Histogram::new(3).expect("index last histogram");
+    let mut last_reads = StorageReadMetrics::default();
+    for _ in 0..config.query_iterations {
+        database.reset_storage_read_metrics();
+        let started = Instant::now();
+        let last = database
+            .index_last_raw(
+                "documents",
+                DOCUMENTS_BY_TEAM_UPDATED,
+                &[Value::U64(HOT_TEAM_ID)],
+            )
+            .expect("seek last hot-team document");
+        assert!(last.is_some());
+        last_histogram
+            .record(duration_micros(started.elapsed()))
+            .expect("record index last");
+        last_reads = database.take_storage_read_metrics();
+    }
+
+    println!(
+        concat!(
+            "{{",
+            "\"scenario\":\"saas_documents\",",
+            "\"case\":\"ordered_index_controls\",",
+            "\"storage\":\"{}\",",
+            "\"team_documents\":{},",
+            "\"prefix_scan_us\":{},",
+            "\"prefix_scan_records\":{},",
+            "\"prefix_scan_ranges\":{},",
+            "\"last_seek_us\":{},",
+            "\"last_seek_records\":{},",
+            "\"last_seek_ranges\":{}",
+            "}}"
+        ),
+        storage_name,
+        expected_hot_rows,
+        histogram_json(&scan_histogram),
+        scan_reads.total.reads,
+        scan_reads.total.ranges,
+        histogram_json(&last_histogram),
+        last_reads.total.reads,
+        last_reads.total.ranges,
+    );
+}
+
+fn run_subscribed_writes<S>(
+    database: &mut Database<S>,
+    config: Config,
+    storage_name: &str,
+    hot_documents: &[SeedDocument],
+) where
+    S: OrderedKvStorage,
+{
+    let expected = expected_ids(hot_documents, DocumentFilter::ActiveUnarchived, true);
+    let mut expected_page = expected.clone();
+    let initial_started = Instant::now();
+    let subscription = database
+        .subscribe_one_sink(
+            build_query_graph(
+                database,
+                AccessPath::FullScan,
+                HOT_TEAM_ID,
+                DocumentFilter::ActiveUnarchived,
+                CURRENT_USER_ID,
+                &documents_table().record_schema(),
+                &memberships_table().record_schema(),
+            )
+            .graph,
+        )
+        .expect("subscribe to hot team");
+    let initial = subscription.recv().expect("receive initial hot-team page");
+    let initial_elapsed = initial_started.elapsed();
+    assert_result(&initial, &expected);
+
+    let mut inside_wall = Histogram::new(3).expect("inside-team wall histogram");
+    let mut inside_tick = Histogram::new(3).expect("inside-team tick histogram");
+    let mut inside_storage = Histogram::new(3).expect("inside-team storage histogram");
+    let mut outside_wall = Histogram::new(3).expect("outside-team wall histogram");
+    let mut outside_tick = Histogram::new(3).expect("outside-team tick histogram");
+    let mut outside_storage = Histogram::new(3).expect("outside-team storage histogram");
+    let mut next_id = config.documents as u64 + 1;
+    let mut next_updated_at = hot_documents
+        .iter()
+        .map(|document| document.updated_at)
+        .max()
+        .unwrap_or_default()
+        + 1;
+
+    for iteration in 0..config.write_iterations {
+        let inserted_id = next_id;
+        let mut batch = database.open_batch();
+        batch.insert(
+            "documents",
+            document_values(
+                inserted_id,
+                HOT_TEAM_ID,
+                next_updated_at,
+                ACTIVE_STATUS,
+                false,
+            ),
+        );
+        let started = Instant::now();
+        database
+            .commit_batch(batch)
+            .expect("insert newest selected-team document");
+        inside_wall
+            .record(duration_micros(started.elapsed()))
+            .expect("record selected-team write");
+        let metrics = database
+            .last_commit_metrics()
+            .expect("selected-team commit metrics");
+        inside_tick
+            .record(duration_micros(metrics.ivm_tick_time))
+            .expect("record selected-team tick");
+        inside_storage
+            .record(duration_micros(metrics.storage_write_time))
+            .expect("record selected-team storage");
+        let delta = subscription
+            .recv()
+            .expect("receive selected-team TopBy delta");
+        expected_page.insert(inserted_id);
+        let removed_id = (expected_page.len() > PAGE_SIZE)
+            .then(|| expected_page.pop_first().expect("page has an oldest row"));
+        assert_top_by_write_delta(&delta, inserted_id, removed_id, iteration);
+        next_id += 1;
+        next_updated_at += 1;
+
+        let outside_team = 3 + iteration as u64 % (config.teams as u64 - 2);
+        let mut batch = database.open_batch();
+        batch.insert(
+            "documents",
+            document_values(next_id, outside_team, next_updated_at, ACTIVE_STATUS, false),
+        );
+        let started = Instant::now();
+        database
+            .commit_batch(batch)
+            .expect("insert outside selected team");
+        outside_wall
+            .record(duration_micros(started.elapsed()))
+            .expect("record outside-team write");
+        let metrics = database
+            .last_commit_metrics()
+            .expect("outside-team commit metrics");
+        outside_tick
+            .record(duration_micros(metrics.ivm_tick_time))
+            .expect("record outside-team tick");
+        outside_storage
+            .record(duration_micros(metrics.storage_write_time))
+            .expect("record outside-team storage");
+        assert!(
+            matches!(
+                subscription.try_recv(),
+                Err(std::sync::mpsc::TryRecvError::Empty)
+            ),
+            "outside-team write unexpectedly changed the selected-team page at iteration {iteration}"
+        );
+        next_id += 1;
+        next_updated_at += 1;
+    }
+
+    let previous_page = expected_page.clone();
+    let mut batch_page = BTreeSet::new();
+    let mut batch = database.open_batch();
+    for _ in 0..SUBSCRIBED_BATCH_ROWS {
+        batch.insert(
+            "documents",
+            document_values(next_id, HOT_TEAM_ID, next_updated_at, ACTIVE_STATUS, false),
+        );
+        batch_page.insert(next_id);
+        next_id += 1;
+        next_updated_at += 1;
+    }
+    let batch_started = Instant::now();
+    database
+        .commit_batch(batch)
+        .expect("insert selected-team document batch");
+    let batch_wall_us = duration_micros(batch_started.elapsed());
+    let batch_metrics = database
+        .last_commit_metrics()
+        .expect("selected-team batch commit metrics");
+    let batch_tick_us = duration_micros(batch_metrics.ivm_tick_time);
+    let batch_storage_us = duration_micros(batch_metrics.storage_write_time);
+    let batch_delta = subscription
+        .recv()
+        .expect("receive selected-team batch TopBy delta");
+    let (batch_added, batch_removed) = top_by_delta_ids(&batch_delta, "batch");
+    assert_eq!(
+        batch_added, batch_page,
+        "the 100 newest batch rows must replace the selected-team page"
+    );
+    assert_eq!(
+        batch_removed, previous_page,
+        "the selected-team batch evicted the wrong previous page"
+    );
+
+    database.unsubscribe(subscription.id());
+
+    println!(
+        concat!(
+            "{{",
+            "\"scenario\":\"saas_documents\",",
+            "\"case\":\"subscribed_writes\",",
+            "\"storage\":\"{}\",",
+            "\"initial_team_documents\":{},",
+            "\"pre_batch_team_documents\":{},",
+            "\"initial_us\":{},",
+            "\"inside_team_wall_us\":{},",
+            "\"inside_team_tick_us\":{},",
+            "\"inside_team_storage_us\":{},",
+            "\"outside_team_wall_us\":{},",
+            "\"outside_team_tick_us\":{},",
+            "\"outside_team_storage_us\":{},",
+            "\"batch_rows\":{},",
+            "\"batch_commit_wall_us\":{},",
+            "\"batch_tick_us\":{},",
+            "\"batch_storage_us\":{}",
+            "}}"
+        ),
+        storage_name,
+        hot_documents.len(),
+        hot_documents.len() + config.write_iterations,
+        duration_micros(initial_elapsed),
+        histogram_json(&inside_wall),
+        histogram_json(&inside_tick),
+        histogram_json(&inside_storage),
+        histogram_json(&outside_wall),
+        histogram_json(&outside_tick),
+        histogram_json(&outside_storage),
+        SUBSCRIBED_BATCH_ROWS,
+        batch_wall_us,
+        batch_tick_us,
+        batch_storage_us,
+    );
+}
+
+fn assert_top_by_write_delta(
+    delta: &RecordDeltas,
+    inserted_id: u64,
+    removed_id: Option<u64>,
+    iteration: usize,
+) {
+    let label = format!("iteration {iteration}");
+    let (added, removed) = top_by_delta_ids(delta, &label);
+    assert_eq!(
+        added,
+        BTreeSet::from([inserted_id]),
+        "newest selected-team row must enter the page at iteration {iteration}"
+    );
+    assert_eq!(
+        removed,
+        removed_id.into_iter().collect(),
+        "selected-team page evicted the wrong row at iteration {iteration}"
+    );
+}
+
+fn top_by_delta_ids(delta: &RecordDeltas, label: &str) -> (BTreeSet<u64>, BTreeSet<u64>) {
+    let mut added = BTreeSet::new();
+    let mut removed = BTreeSet::new();
+    for (record, weight) in delta.iter() {
+        let Value::U64(id) = record.get("id").expect("read subscription result id") else {
+            panic!("subscription document id is not u64");
+        };
+        match weight {
+            1 => {
+                added.insert(id);
+            }
+            -1 => {
+                removed.insert(id);
+            }
+            other => panic!("unexpected TopBy delta weight {other} for {label}"),
+        }
+    }
+    (added, removed)
+}
+
+fn document_values(
+    id: u64,
+    team_id: u64,
+    updated_at: u64,
+    status: u8,
+    archived: bool,
+) -> Vec<Value> {
+    vec![
+        Value::U64(id),
+        Value::U64(team_id),
+        Value::U64(updated_at),
+        Value::U8(status),
+        Value::Bool(archived),
+        Value::String(format!("Document {id}")),
+        Value::String(format!(
+            "team-{team_id}-document-{updated_at}-benchmark-payload"
+        )),
+    ]
+}
+
+fn saas_schema() -> DatabaseSchema {
+    DatabaseSchema::new([teams_table(), memberships_table(), documents_table()])
+}
+
+fn teams_table() -> TableSchema {
+    TableSchema::new(
+        "teams",
+        [
+            ColumnSchema::new("id", ColumnType::U64),
+            ColumnSchema::new("name", ColumnType::String),
+        ],
+    )
+    .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64))
+}
+
+fn memberships_table() -> TableSchema {
+    TableSchema::new(
+        "team_memberships",
+        [
+            ColumnSchema::new("id", ColumnType::U64),
+            ColumnSchema::new("team_id", ColumnType::U64),
+            ColumnSchema::new("user_id", ColumnType::U64),
+            ColumnSchema::new("role", ColumnType::U8),
+        ],
+    )
+    .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64))
+    .with_index(IndexSchema::new(
+        MEMBERSHIPS_BY_USER_TEAM,
+        ["user_id", "team_id", "id"],
+    ))
+}
+
+fn documents_table() -> TableSchema {
+    TableSchema::new(
+        "documents",
+        [
+            ColumnSchema::new("id", ColumnType::U64),
+            ColumnSchema::new("team_id", ColumnType::U64),
+            ColumnSchema::new("updated_at", ColumnType::U64),
+            ColumnSchema::new("status", ColumnType::U8),
+            ColumnSchema::new("archived", ColumnType::Bool),
+            ColumnSchema::new("title", ColumnType::String),
+            ColumnSchema::new("body", ColumnType::String),
+        ],
+    )
+    .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64))
+    .with_index(IndexSchema::new(
+        DOCUMENTS_BY_TEAM_UPDATED,
+        ["team_id", "updated_at", "id"],
+    ))
+    .with_index(IndexSchema::new(
+        DOCUMENTS_BY_TEAM_STATUS_ARCHIVED_UPDATED,
+        ["team_id", "status", "archived", "updated_at", "id"],
+    ))
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn duration_micros(duration: Duration) -> u64 {
+    duration.as_micros().try_into().unwrap_or(u64::MAX)
+}
+
+fn histogram_json(histogram: &Histogram<u64>) -> String {
+    format!(
+        "{{\"n\":{},\"p50\":{},\"p95\":{},\"p99\":{},\"max\":{}}}",
+        histogram.len(),
+        histogram.value_at_quantile(0.50),
+        histogram.value_at_quantile(0.95),
+        histogram.value_at_quantile(0.99),
+        histogram.max(),
+    )
+}

--- a/crates/jazz-tools/Cargo.toml
+++ b/crates/jazz-tools/Cargo.toml
@@ -172,6 +172,10 @@ harness = false
 name = "subscription_benchmark"
 harness = false
 
+[[bench]]
+name = "saas_documents"
+harness = false
+
 [[test]]
 name = "large_blob_permissions"
 required-features = ["test"]

--- a/crates/jazz-tools/benches/README.md
+++ b/crates/jazz-tools/benches/README.md
@@ -16,6 +16,7 @@ The active bench harness is the explicit `[[bench]]` list in
 - `insert_benchmark`
 - `update_benchmark`
 - `subscription_benchmark`
+- `saas_documents`
 
 All active Criterion benches now exercise the workspace `jazz` engine facade
 directly instead of going through the legacy
@@ -49,6 +50,12 @@ than old helper behavior:
   the revoked doc visible. Recursive write-policy settlement is covered in the
   `jazz` policy tests with global/settled support rows; local-only support rows
   correctly do not authorize writes.
+- `saas_documents` builds a configurable 500k-document / 5k-team fixture
+  through public `Db` APIs, validates authenticated latest-100 queries with
+  optional status/archive filters, compares literal and parameterized bindings,
+  and emits authorization and simultaneous-binding correctness canaries.
+  See the [benchmark receipt](../../../dev/benchmarks/SAAS_DOCUMENTS_500K_RECEIPT_20260728.md)
+  and [engine findings](../../../dev/benchmarks/SAAS_DOCUMENTS_ENGINE_FINDINGS_20260728.md).
 
 ## Intended next ports
 

--- a/crates/jazz-tools/benches/saas_documents.rs
+++ b/crates/jazz-tools/benches/saas_documents.rs
@@ -1,0 +1,1357 @@
+//! SaaS document-list benchmark using only the public `jazz::db::Db` facade.
+//!
+//! The default fixture is intentionally the arithmetic requested by the benchmark:
+//! 500,000 documents, 5,000 teams, one 30,000-document hot team, and one
+//! 100-document cold team. Those numbers cannot also give every team at least
+//! 100 documents: the requested minimum would require 529,900 documents. The
+//! emitted JSON reports the resulting skew explicitly.
+//! Set `JAZZ_SAAS_DOCUMENTS=529900` to keep all non-hot teams at 100 rows.
+//!
+//! Suggested invocations after registering this file as a `harness = false` bench:
+//!
+//! ```text
+//! cargo bench --profile perf -p jazz-tools --bench saas_documents
+//! JAZZ_SAAS_SEED_MODE=global cargo bench --profile perf -p jazz-tools --bench saas_documents
+//! ```
+//!
+//! Global mode is deliberately opt-in because the only public settled bootstrap
+//! API is per-row. Local mode batches rows in mergeable transactions of at most
+//! 2,048 versions, but reads the unindexed ahead-current layer. Global mode uses
+//! `seed_settled_mergeable_for_bootstrap` per row and can exercise the explicit
+//! global-current team indexes.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::hint::black_box;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::time::{Duration, Instant};
+
+use jazz::db::{
+    Db, DbConfig, DbIdentity, LocalUpdates, Propagation, ReadOpts, RowCells, SeededRowIdSource,
+    SubscriptionEvent, SubscriptionStream, block_on,
+};
+use jazz::groove::records::Value;
+use jazz::groove::schema::{ColumnSchema, ColumnType};
+use jazz::groove::storage::MemoryStorage;
+use jazz::ids::{AuthorId, NodeUuid, RowUuid};
+use jazz::query::{OrderDirection, Query, claim, col, eq, lit, param};
+use jazz::schema::{JazzSchema, Policy, TableSchema};
+use jazz::tx::DurabilityTier;
+use serde::Serialize;
+use serde_json::{Value as JsonValue, json};
+
+type BenchDb = Db<MemoryStorage>;
+
+const DEFAULT_DOCUMENTS: usize = 500_000;
+const DEFAULT_TEAMS: usize = 5_000;
+const DEFAULT_MEMBERS_PER_TEAM: usize = 10;
+const DEFAULT_QUERY_ITERS: usize = 50;
+const DEFAULT_HOT_DOCUMENTS: usize = 30_000;
+const DEFAULT_COLD_DOCUMENTS: usize = 100;
+const REQUESTED_MIN_DOCUMENTS_PER_TEAM: usize = 100;
+const REQUESTED_MAX_DOCUMENTS_PER_TEAM: usize = 30_000;
+
+// Half of MAX_COMMIT_UNIT_VERSIONS, leaving ample encoded-byte headroom for
+// the small benchmark rows as well as count headroom.
+const MAX_LOCAL_SEED_BATCH: usize = 2_048;
+
+const READER: AuthorId = AuthorId(uuid::uuid!("00000000-0000-0000-0000-0000000000a1"));
+const OUTSIDER: AuthorId = AuthorId(uuid::uuid!("00000000-0000-0000-0000-0000000000ee"));
+const SYSTEM_NODE: NodeUuid = NodeUuid(uuid::uuid!("51000000-0000-0000-0000-000000000001"));
+
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum SeedMode {
+    Local,
+    Global,
+}
+
+impl SeedMode {
+    fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "local" => Ok(Self::Local),
+            "global" => Ok(Self::Global),
+            other => Err(format!(
+                "JAZZ_SAAS_SEED_MODE must be local or global, got {other:?}"
+            )),
+        }
+    }
+
+    fn read_opts(self) -> ReadOpts {
+        ReadOpts {
+            tier: match self {
+                Self::Local => DurabilityTier::Local,
+                Self::Global => DurabilityTier::Global,
+            },
+            local_updates: match self {
+                Self::Local => LocalUpdates::Immediate,
+                Self::Global => LocalUpdates::Deferred,
+            },
+            propagation: Propagation::LocalOnly,
+            include_deleted: false,
+            ..ReadOpts::default()
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct Config {
+    documents: usize,
+    teams: usize,
+    members_per_team: usize,
+    query_iterations: usize,
+    hot_documents: usize,
+    cold_documents: usize,
+    local_seed_batch: usize,
+    seed_mode: SeedMode,
+}
+
+impl Config {
+    fn from_env() -> Result<Self, String> {
+        let documents = env_usize("JAZZ_SAAS_DOCUMENTS", DEFAULT_DOCUMENTS)?;
+        let teams = env_usize("JAZZ_SAAS_TEAMS", DEFAULT_TEAMS)?;
+        let members_per_team = env_usize("JAZZ_SAAS_MEMBERS_PER_TEAM", DEFAULT_MEMBERS_PER_TEAM)?;
+        let query_iterations = env_usize("JAZZ_SAAS_QUERY_ITERS", DEFAULT_QUERY_ITERS)?;
+        let hot_documents = env_usize("JAZZ_SAAS_HOT_DOCUMENTS", DEFAULT_HOT_DOCUMENTS)?;
+        let cold_documents = env_usize("JAZZ_SAAS_COLD_DOCUMENTS", DEFAULT_COLD_DOCUMENTS)?;
+        let requested_batch = env_usize("JAZZ_SAAS_SEED_BATCH", MAX_LOCAL_SEED_BATCH)?;
+        let seed_mode = SeedMode::parse(
+            &std::env::var("JAZZ_SAAS_SEED_MODE").unwrap_or_else(|_| "local".to_owned()),
+        )?;
+
+        if teams < 3 {
+            return Err("JAZZ_SAAS_TEAMS must be at least 3".to_owned());
+        }
+        if documents < hot_documents.saturating_add(cold_documents) {
+            return Err(format!(
+                "JAZZ_SAAS_DOCUMENTS ({documents}) must be at least hot + cold ({hot_documents} + {cold_documents})"
+            ));
+        }
+        if members_per_team == 0 {
+            return Err("JAZZ_SAAS_MEMBERS_PER_TEAM must be at least 1".to_owned());
+        }
+        if query_iterations == 0 {
+            return Err("JAZZ_SAAS_QUERY_ITERS must be at least 1".to_owned());
+        }
+        if requested_batch == 0 {
+            return Err("JAZZ_SAAS_SEED_BATCH must be at least 1".to_owned());
+        }
+        if requested_batch > MAX_LOCAL_SEED_BATCH {
+            return Err(format!(
+                "JAZZ_SAAS_SEED_BATCH must not exceed {MAX_LOCAL_SEED_BATCH}"
+            ));
+        }
+        teams
+            .checked_mul(members_per_team)
+            .ok_or_else(|| "teams * members_per_team overflows usize".to_owned())?;
+        u64::try_from(documents)
+            .map_err(|_| "document count does not fit in u64 updated_at values".to_owned())?;
+
+        Ok(Self {
+            documents,
+            teams,
+            members_per_team,
+            query_iterations,
+            hot_documents,
+            cold_documents,
+            local_seed_batch: requested_batch,
+            seed_mode,
+        })
+    }
+}
+
+#[derive(Debug)]
+struct Fixture {
+    team_document_counts: Vec<usize>,
+    team_document_starts: Vec<usize>,
+}
+
+impl Fixture {
+    fn team(&self, team_index: usize) -> RowUuid {
+        row_uuid(0x51, team_index)
+    }
+
+    fn count(&self, team_index: usize) -> usize {
+        self.team_document_counts[team_index]
+    }
+
+    fn start(&self, team_index: usize) -> usize {
+        self.team_document_starts[team_index]
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct DistributionReport {
+    total_documents: usize,
+    total_teams: usize,
+    hot_team_index: usize,
+    hot_team_documents: usize,
+    cold_team_index: usize,
+    cold_team_documents: usize,
+    requested_min_documents_per_team: usize,
+    requested_max_documents_per_team: usize,
+    actual_min_documents_per_team: usize,
+    actual_max_documents_per_team: usize,
+    teams_below_requested_min: usize,
+    teams_above_requested_max: usize,
+    minimum_total_for_requested_hot_and_bounds: usize,
+    arithmetic_shortfall: usize,
+    other_team_mean_documents: f64,
+    exact_total_preserved: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct PhaseReport {
+    rows: usize,
+    duration_ms: f64,
+    rows_per_second: f64,
+    write_api: &'static str,
+}
+
+impl PhaseReport {
+    fn new(rows: usize, elapsed: Duration, write_api: &'static str) -> Self {
+        let seconds = elapsed.as_secs_f64();
+        Self {
+            rows,
+            duration_ms: millis(elapsed),
+            rows_per_second: if seconds == 0.0 {
+                f64::INFINITY
+            } else {
+                rows as f64 / seconds
+            },
+            write_api,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct SeedReport {
+    open_ms: f64,
+    teams: PhaseReport,
+    memberships: PhaseReport,
+    documents: PhaseReport,
+    total_ms: f64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum QueryStyle {
+    Literal,
+    Parameterized,
+}
+
+impl QueryStyle {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Literal => "literal",
+            Self::Parameterized => "parameterized",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum FilterVariant {
+    TeamOnly,
+    ActiveUnarchived,
+}
+
+impl FilterVariant {
+    fn label(self) -> &'static str {
+        match self {
+            Self::TeamOnly => "team_only",
+            Self::ActiveUnarchived => "status_active_and_not_archived",
+        }
+    }
+
+    fn matches(self, local_document_index: usize) -> bool {
+        match self {
+            Self::TeamOnly => true,
+            Self::ActiveUnarchived => {
+                status(local_document_index) == "active" && !archived(local_document_index)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct LatencyStats {
+    iterations: usize,
+    total_ms: f64,
+    mean_us: f64,
+    min_us: f64,
+    p50_us: f64,
+    p95_us: f64,
+    p99_us: f64,
+    max_us: f64,
+    reads_per_second: f64,
+}
+
+#[derive(Debug, Serialize)]
+struct ScenarioReport {
+    name: String,
+    team_profile: &'static str,
+    team_index: usize,
+    documents_in_team: usize,
+    query_style: &'static str,
+    filter_variant: &'static str,
+    authorization_api: &'static str,
+    order_by: &'static str,
+    limit: usize,
+    expected_rows: usize,
+    prepare_us: f64,
+    first_binding_read_us: f64,
+    repeated_reads: LatencyStats,
+    first_to_repeated_mean_ratio: f64,
+    correctness: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct BenchmarkOutput {
+    benchmark: &'static str,
+    config: Config,
+    storage: &'static str,
+    index_scope: &'static str,
+    distribution: DistributionReport,
+    seeding: SeedReport,
+    scenarios: Vec<ScenarioReport>,
+    authorization_canary: JsonValue,
+    parameterized_cell_access_canary: JsonValue,
+    simultaneous_parameter_bindings_canary: JsonValue,
+    observed_ratios: JsonValue,
+    notes: Vec<&'static str>,
+    tooling_friction: &'static str,
+}
+
+fn main() {
+    match run() {
+        Ok(output) => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&output).expect("serialize SaaS benchmark output")
+            );
+        }
+        Err(error) => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&json!({
+                    "benchmark": "saas_documents",
+                    "ok": false,
+                    "error": error,
+                }))
+                .expect("serialize SaaS benchmark error")
+            );
+            std::process::exit(1);
+        }
+    }
+}
+
+fn run() -> Result<BenchmarkOutput, String> {
+    let config = Config::from_env()?;
+    let (fixture, distribution) = build_distribution(&config)?;
+    let schema = saas_schema();
+    let document_table = schema
+        .tables
+        .iter()
+        .find(|table| table.name == "documents")
+        .expect("SaaS schema has documents")
+        .clone();
+
+    let total_started = Instant::now();
+    let open_started = Instant::now();
+    let db = open_db(schema, config.seed_mode)?;
+    let open_elapsed = open_started.elapsed();
+
+    eprintln!(
+        "seeding {} teams, {} memberships, and {} documents in {:?} mode",
+        config.teams,
+        config.teams * config.members_per_team,
+        config.documents,
+        config.seed_mode
+    );
+
+    let teams = seed_rows(
+        &db,
+        config.seed_mode,
+        config.local_seed_batch,
+        "teams",
+        config.teams,
+        |index| {
+            (
+                "teams",
+                row_uuid(0x51, index),
+                BTreeMap::from([("name".to_owned(), Value::String(format!("Team {index}")))]),
+            )
+        },
+    )?;
+
+    let membership_count = config
+        .teams
+        .checked_mul(config.members_per_team)
+        .ok_or_else(|| "membership count overflowed".to_owned())?;
+    let members_per_team = config.members_per_team;
+    let memberships = seed_rows(
+        &db,
+        config.seed_mode,
+        config.local_seed_batch,
+        "team_memberships",
+        membership_count,
+        |index| {
+            let team_index = index / members_per_team;
+            let member_index = index % members_per_team;
+            (
+                "team_memberships",
+                row_uuid(0x52, index),
+                membership_cells(
+                    row_uuid(0x51, team_index),
+                    member_identity(team_index, member_index, index),
+                    member_index,
+                ),
+            )
+        },
+    )?;
+
+    let counts = fixture.team_document_counts.clone();
+    let mut team_index = 0usize;
+    let mut local_index = 0usize;
+    let documents = seed_rows(
+        &db,
+        config.seed_mode,
+        config.local_seed_batch,
+        "documents",
+        config.documents,
+        |global_index| {
+            while team_index < counts.len() && local_index == counts[team_index] {
+                team_index += 1;
+                local_index = 0;
+            }
+            let cells = document_cells(row_uuid(0x51, team_index), global_index, local_index);
+            let row = row_uuid(0x53, global_index);
+            local_index += 1;
+            ("documents", row, cells)
+        },
+    )?;
+
+    let seeding = SeedReport {
+        open_ms: millis(open_elapsed),
+        teams,
+        memberships,
+        documents,
+        total_ms: millis(total_started.elapsed()),
+    };
+
+    let read_opts = config.seed_mode.read_opts();
+    let mut scenarios = Vec::with_capacity(8);
+    for (team_profile, selected_team) in [("hot", 0usize), ("cold", 1usize)] {
+        for variant in [FilterVariant::TeamOnly, FilterVariant::ActiveUnarchived] {
+            for style in [QueryStyle::Literal, QueryStyle::Parameterized] {
+                eprintln!(
+                    "measuring {team_profile} / {} / {}",
+                    variant.label(),
+                    style.label()
+                );
+                scenarios.push(run_scenario(
+                    &db,
+                    &fixture,
+                    &read_opts,
+                    config.query_iterations,
+                    team_profile,
+                    selected_team,
+                    variant,
+                    style,
+                )?);
+            }
+        }
+    }
+
+    let authorization_canary = safe_canary(|| authorization_canary(&db, &fixture, &read_opts));
+    let parameterized_cell_access_canary = safe_canary(|| {
+        parameterized_cell_access_canary(&db, &fixture, &document_table, &read_opts)
+    });
+    let simultaneous_parameter_bindings_canary =
+        safe_canary(|| simultaneous_bindings_canary(&db, &fixture, config.seed_mode, &read_opts));
+    let observed_ratios = observed_ratios(&scenarios);
+
+    let (index_scope, notes) = match config.seed_mode {
+        SeedMode::Local => (
+            "declared team indexes are global-current only; local rows are read from ahead-current",
+            vec![
+                "Local mode is the fast-to-seed full-scan baseline, not an index benchmark.",
+                "first_binding_read measures first use of that shape/binding after the shared fixture was seeded; it is not a process/storage cold start.",
+                "The document policy is evaluated for READER through team_memberships by all_for_identity/subscribe_for_identity.",
+                "The schema has single-column team indexes; there is no composite (team, updated_at DESC) index builder in this public schema surface.",
+            ],
+        ),
+        SeedMode::Global => (
+            "explicit global-current team indexes on documents and team_memberships",
+            vec![
+                "Global bootstrap is per-row because that is the public settled import API; seed time should not be compared with local batch seed time.",
+                "first_binding_read measures first use of that shape/binding after the shared fixture was seeded; it is not a process/storage cold start.",
+                "The document policy is evaluated for READER through team_memberships by all_for_identity/subscribe_for_identity.",
+                "The schema has single-column team indexes; there is no composite (team, updated_at DESC) index builder in this public schema surface.",
+            ],
+        ),
+    };
+
+    Ok(BenchmarkOutput {
+        benchmark: "saas_documents",
+        config,
+        storage: "MemoryStorage",
+        index_scope,
+        distribution,
+        seeding,
+        scenarios,
+        authorization_canary,
+        parameterized_cell_access_canary,
+        simultaneous_parameter_bindings_canary,
+        observed_ratios,
+        notes,
+        tooling_friction: "Global settled bootstrap is row-at-a-time; a batch import API would shorten setup.",
+    })
+}
+
+fn saas_schema() -> JazzSchema {
+    let document_read_policy = Policy::shape(Query::from("documents").join_via_column(
+        "team_memberships",
+        "team",
+        "team",
+        [eq(col("user"), claim("sub"))],
+    ));
+
+    JazzSchema::new([
+        TableSchema::new("teams", [ColumnSchema::new("name", ColumnType::String)])
+            .with_read_policy(Policy::public())
+            .with_write_policy(Policy::public()),
+        TableSchema::new(
+            "team_memberships",
+            [
+                ColumnSchema::new("team", ColumnType::Uuid),
+                ColumnSchema::new("user", ColumnType::Uuid),
+                ColumnSchema::new("role", ColumnType::String),
+            ],
+        )
+        .with_reference("team", "teams")
+        .with_indexed_columns(["team", "user"])
+        .with_read_policy(Policy::public())
+        .with_write_policy(Policy::public()),
+        TableSchema::new(
+            "documents",
+            [
+                ColumnSchema::new("team", ColumnType::Uuid),
+                ColumnSchema::new("updated_at", ColumnType::U64),
+                ColumnSchema::new("status", ColumnType::String),
+                ColumnSchema::new("archived", ColumnType::Bool),
+                ColumnSchema::new("title", ColumnType::String),
+                ColumnSchema::new("body", ColumnType::String),
+            ],
+        )
+        .with_reference("team", "teams")
+        .with_indexed_column("team")
+        .with_read_policy(document_read_policy)
+        .with_write_policy(Policy::public()),
+    ])
+}
+
+fn open_db(schema: JazzSchema, mode: SeedMode) -> Result<BenchDb, String> {
+    let column_families = schema.column_families();
+    let refs = column_families
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    let config = DbConfig::new(
+        schema,
+        MemoryStorage::new(&refs),
+        DbIdentity {
+            node: SYSTEM_NODE,
+            author: AuthorId::SYSTEM,
+        },
+    )
+    .with_id_source(SeededRowIdSource::new(0x5aa5));
+
+    match mode {
+        SeedMode::Local => block_on(Db::open(config)),
+        SeedMode::Global => block_on(Db::open_history_complete(config)),
+    }
+    .map_err(|error| format!("open SaaS benchmark db: {error}"))
+}
+
+fn build_distribution(config: &Config) -> Result<(Fixture, DistributionReport), String> {
+    let mut counts = vec![0usize; config.teams];
+    counts[0] = config.hot_documents;
+    counts[1] = config.cold_documents;
+
+    let other_teams = config.teams - 2;
+    let remaining = config.documents - config.hot_documents - config.cold_documents;
+    let quotient = remaining / other_teams;
+    let remainder = remaining % other_teams;
+    for (offset, count) in counts[2..].iter_mut().enumerate() {
+        *count = quotient + usize::from(offset < remainder);
+    }
+
+    let exact_total = counts.iter().try_fold(0usize, |sum, count| {
+        sum.checked_add(*count)
+            .ok_or_else(|| "document distribution overflowed".to_owned())
+    })?;
+    if exact_total != config.documents {
+        return Err(format!(
+            "distribution generated {exact_total} documents, expected {}",
+            config.documents
+        ));
+    }
+
+    let mut starts = Vec::with_capacity(counts.len());
+    let mut next = 0usize;
+    for count in &counts {
+        starts.push(next);
+        next = next
+            .checked_add(*count)
+            .ok_or_else(|| "document start offset overflowed".to_owned())?;
+    }
+
+    let minimum_total = config
+        .hot_documents
+        .checked_add(config.cold_documents)
+        .and_then(|fixed| {
+            fixed.checked_add((config.teams - 2).saturating_mul(REQUESTED_MIN_DOCUMENTS_PER_TEAM))
+        })
+        .ok_or_else(|| "minimum requested distribution overflowed".to_owned())?;
+    let actual_min = *counts.iter().min().expect("at least three teams");
+    let actual_max = *counts.iter().max().expect("at least three teams");
+    let report = DistributionReport {
+        total_documents: exact_total,
+        total_teams: counts.len(),
+        hot_team_index: 0,
+        hot_team_documents: counts[0],
+        cold_team_index: 1,
+        cold_team_documents: counts[1],
+        requested_min_documents_per_team: REQUESTED_MIN_DOCUMENTS_PER_TEAM,
+        requested_max_documents_per_team: REQUESTED_MAX_DOCUMENTS_PER_TEAM,
+        actual_min_documents_per_team: actual_min,
+        actual_max_documents_per_team: actual_max,
+        teams_below_requested_min: counts
+            .iter()
+            .filter(|count| **count < REQUESTED_MIN_DOCUMENTS_PER_TEAM)
+            .count(),
+        teams_above_requested_max: counts
+            .iter()
+            .filter(|count| **count > REQUESTED_MAX_DOCUMENTS_PER_TEAM)
+            .count(),
+        minimum_total_for_requested_hot_and_bounds: minimum_total,
+        arithmetic_shortfall: minimum_total.saturating_sub(config.documents),
+        other_team_mean_documents: remaining as f64 / other_teams as f64,
+        exact_total_preserved: true,
+    };
+
+    Ok((
+        Fixture {
+            team_document_counts: counts,
+            team_document_starts: starts,
+        },
+        report,
+    ))
+}
+
+fn seed_rows(
+    db: &BenchDb,
+    mode: SeedMode,
+    batch_size: usize,
+    phase: &'static str,
+    count: usize,
+    mut make_row: impl FnMut(usize) -> (&'static str, RowUuid, RowCells),
+) -> Result<PhaseReport, String> {
+    let started = Instant::now();
+    let progress_step = (count / 10).max(1);
+    let mut next_progress = progress_step;
+
+    match mode {
+        SeedMode::Local => {
+            let mut start = 0usize;
+            while start < count {
+                let end = start.saturating_add(batch_size).min(count);
+                let mut tx = db.mergeable_tx();
+                for index in start..end {
+                    let (table, row, cells) = make_row(index);
+                    tx.insert_with_id(table, row, cells)
+                        .map_err(|error| format!("stage {phase} row {index}: {error}"))?;
+                }
+                tx.commit()
+                    .map_err(|error| format!("commit {phase} rows {start}..{end}: {error}"))?;
+                start = end;
+                if start >= next_progress || start == count {
+                    eprintln!("seeded {phase}: {start}/{count}");
+                    next_progress = next_progress.saturating_add(progress_step);
+                }
+            }
+            Ok(PhaseReport::new(
+                count,
+                started.elapsed(),
+                "Db::mergeable_tx (<=2048 rows/commit)",
+            ))
+        }
+        SeedMode::Global => {
+            for index in 0..count {
+                let (table, row, cells) = make_row(index);
+                db.seed_settled_mergeable_for_bootstrap(table, row, AuthorId::SYSTEM, cells)
+                    .map_err(|error| format!("settled-bootstrap {phase} row {index}: {error}"))?;
+                let done = index + 1;
+                if done >= next_progress || done == count {
+                    eprintln!("seeded {phase}: {done}/{count}");
+                    next_progress = next_progress.saturating_add(progress_step);
+                }
+            }
+            Ok(PhaseReport::new(
+                count,
+                started.elapsed(),
+                "Db::seed_settled_mergeable_for_bootstrap (one row/call)",
+            ))
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_scenario(
+    db: &BenchDb,
+    fixture: &Fixture,
+    read_opts: &ReadOpts,
+    query_iterations: usize,
+    team_profile: &'static str,
+    team_index: usize,
+    variant: FilterVariant,
+    style: QueryStyle,
+) -> Result<ScenarioReport, String> {
+    let team = fixture.team(team_index);
+    let query = build_query(style, variant, team);
+    let prepare_started = Instant::now();
+    let prepared = match style {
+        QueryStyle::Literal => db.prepare_query(&query),
+        QueryStyle::Parameterized => db.prepare_query_bound(
+            &query,
+            BTreeMap::from([("team".to_owned(), Value::Uuid(team.0))]),
+        ),
+    }
+    .map_err(|error| {
+        format!(
+            "prepare {} {} {team_profile} query: {error}",
+            style.label(),
+            variant.label()
+        )
+    })?;
+    let prepare_elapsed = prepare_started.elapsed();
+
+    let expected_updated_at = expected_updated_at(fixture, team_index, variant, 100);
+    let expected_rows = expected_updated_at.len();
+    let first_started = Instant::now();
+    let first_rows =
+        block_on(db.all_for_identity(&prepared, read_opts.clone(), READER)).map_err(|error| {
+            format!(
+                "first authorized {} {} {team_profile} read: {error}",
+                style.label(),
+                variant.label()
+            )
+        })?;
+    let first_elapsed = first_started.elapsed();
+    validate_rows(&first_rows, &expected_updated_at)?;
+    black_box(first_rows.len());
+
+    let mut repeated = Vec::with_capacity(query_iterations);
+    for iteration in 0..query_iterations {
+        let started = Instant::now();
+        let rows = block_on(db.all_for_identity(&prepared, read_opts.clone(), READER)).map_err(
+            |error| {
+                format!(
+                    "repeated authorized {} {} {team_profile} read {iteration}: {error}",
+                    style.label(),
+                    variant.label()
+                )
+            },
+        )?;
+        let elapsed = started.elapsed();
+        validate_rows(&rows, &expected_updated_at)?;
+        black_box(rows.len());
+        repeated.push(elapsed);
+    }
+    let repeated_reads = latency_stats(&repeated);
+    let first_us = micros(first_elapsed);
+    let first_to_repeated_mean_ratio = ratio(first_us, repeated_reads.mean_us);
+
+    Ok(ScenarioReport {
+        name: format!(
+            "{team_profile}/{}/{style}",
+            variant.label(),
+            style = style.label()
+        ),
+        team_profile,
+        team_index,
+        documents_in_team: fixture.count(team_index),
+        query_style: style.label(),
+        filter_variant: variant.label(),
+        authorization_api: "Db::all_for_identity(READER)",
+        order_by: "updated_at DESC",
+        limit: 100,
+        expected_rows,
+        prepare_us: micros(prepare_elapsed),
+        first_binding_read_us: first_us,
+        repeated_reads,
+        first_to_repeated_mean_ratio,
+        correctness: "validated exact deterministic row identities in descending updated_at order, filters, limit, and policy visibility",
+    })
+}
+
+fn build_query(style: QueryStyle, variant: FilterVariant, team: RowUuid) -> Query {
+    let team_predicate = match style {
+        QueryStyle::Literal => eq(col("team"), lit(team.0)),
+        QueryStyle::Parameterized => eq(col("team"), param("team")),
+    };
+    let mut query = Query::from("documents").filter(team_predicate);
+    if matches!(variant, FilterVariant::ActiveUnarchived) {
+        query = query
+            .filter(eq(col("status"), lit("active")))
+            .filter(eq(col("archived"), lit(false)));
+    }
+    query
+        .order_by("updated_at", OrderDirection::Desc)
+        .limit(100)
+}
+
+fn validate_rows(
+    rows: &[jazz::node::CurrentRow],
+    expected_updated_at: &[u64],
+) -> Result<(), String> {
+    if rows.len() != expected_updated_at.len() {
+        return Err(format!(
+            "query returned {} rows, expected {}",
+            rows.len(),
+            expected_updated_at.len()
+        ));
+    }
+
+    for (position, (row, expected_timestamp)) in rows.iter().zip(expected_updated_at).enumerate() {
+        let expected_row = row_uuid(
+            0x53,
+            usize::try_from(*expected_timestamp).expect("benchmark timestamp fits in usize"),
+        );
+        if row.row_uuid() != expected_row {
+            return Err(format!(
+                "row {position} is {}, expected {} for updated_at {expected_timestamp}",
+                row.row_uuid().0,
+                expected_row.0
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn expected_updated_at(
+    fixture: &Fixture,
+    team_index: usize,
+    variant: FilterVariant,
+    limit: usize,
+) -> Vec<u64> {
+    let start = fixture.start(team_index);
+    (0..fixture.count(team_index))
+        .rev()
+        .filter(|local_index| variant.matches(*local_index))
+        .take(limit)
+        .map(|local_index| {
+            u64::try_from(start + local_index).expect("validated document count fits in u64")
+        })
+        .collect()
+}
+
+fn authorization_canary(
+    db: &BenchDb,
+    fixture: &Fixture,
+    read_opts: &ReadOpts,
+) -> Result<JsonValue, String> {
+    let team = fixture.team(0);
+    let query = build_query(QueryStyle::Parameterized, FilterVariant::TeamOnly, team);
+    let prepared = db
+        .prepare_query_bound(
+            &query,
+            BTreeMap::from([("team".to_owned(), Value::Uuid(team.0))]),
+        )
+        .map_err(|error| format!("prepare outsider authorization canary: {error}"))?;
+    let rows = block_on(db.all_for_identity(&prepared, read_opts.clone(), OUTSIDER))
+        .map_err(|error| format!("run outsider authorization canary: {error}"))?;
+    if !rows.is_empty() {
+        return Err(format!(
+            "outsider saw {} hot-team documents without membership",
+            rows.len()
+        ));
+    }
+    Ok(json!({
+        "ok": true,
+        "authorized_identity": READER.0.to_string(),
+        "unauthorized_identity": OUTSIDER.0.to_string(),
+        "unauthorized_rows": 0,
+        "api": "Db::all_for_identity",
+    }))
+}
+
+fn parameterized_cell_access_canary(
+    db: &BenchDb,
+    fixture: &Fixture,
+    document_table: &TableSchema,
+    read_opts: &ReadOpts,
+) -> Result<JsonValue, String> {
+    let team = fixture.team(0);
+    let query = build_query(QueryStyle::Parameterized, FilterVariant::TeamOnly, team);
+    let prepared = db
+        .prepare_query_bound(
+            &query,
+            BTreeMap::from([("team".to_owned(), Value::Uuid(team.0))]),
+        )
+        .map_err(|error| format!("prepare parameterized cell canary: {error}"))?;
+    let rows = block_on(db.all_for_identity(&prepared, read_opts.clone(), READER))
+        .map_err(|error| format!("read parameterized cell canary: {error}"))?;
+    let actual = rows
+        .first()
+        .and_then(|row| row.cell(document_table, "team"));
+    Ok(json!({
+        "ok": actual == Some(Value::Uuid(team.0)),
+        "api": "CurrentRow::cell",
+        "expected_team": team.0.to_string(),
+        "actual_team": format!("{actual:?}"),
+        "observation": "parameter-constrained projections currently expose user_team as non-nullable; CurrentRow::cell expects nullable user cells",
+    }))
+}
+
+fn simultaneous_bindings_canary(
+    db: &BenchDb,
+    fixture: &Fixture,
+    seed_mode: SeedMode,
+    read_opts: &ReadOpts,
+) -> Result<JsonValue, String> {
+    let parameterized = build_query(
+        QueryStyle::Parameterized,
+        FilterVariant::TeamOnly,
+        fixture.team(0),
+    );
+    let hot_team = fixture.team(0);
+    let cold_team = fixture.team(1);
+    let hot = db
+        .prepare_query_bound(
+            &parameterized,
+            BTreeMap::from([("team".to_owned(), Value::Uuid(hot_team.0))]),
+        )
+        .map_err(|error| format!("prepare hot simultaneous binding: {error}"))?;
+    let cold = db
+        .prepare_query_bound(
+            &parameterized,
+            BTreeMap::from([("team".to_owned(), Value::Uuid(cold_team.0))]),
+        )
+        .map_err(|error| format!("prepare cold simultaneous binding: {error}"))?;
+    if hot.binding().binding_id() == cold.binding().binding_id() {
+        return Err("hot and cold prepared bindings have the same binding id".to_owned());
+    }
+
+    let mut hot_subscription = block_on(db.subscribe_for_identity(&hot, read_opts.clone(), READER))
+        .map_err(|error| format!("subscribe hot simultaneous binding: {error}"))?;
+    let mut cold_subscription =
+        block_on(db.subscribe_for_identity(&cold, read_opts.clone(), READER))
+            .map_err(|error| format!("subscribe cold simultaneous binding: {error}"))?;
+
+    let expected_hot = expected_row_ids(fixture, 0, FilterVariant::TeamOnly, 100);
+    let expected_cold = expected_row_ids(fixture, 1, FilterVariant::TeamOnly, 100);
+    let mut hot_rows = validate_initial_subscription(
+        "hot",
+        hot_subscription
+            .try_next_event()
+            .ok_or_else(|| "hot subscription did not queue its initial reset".to_owned())?,
+        &expected_hot,
+    )?;
+    let mut cold_rows = validate_initial_subscription(
+        "cold",
+        cold_subscription
+            .try_next_event()
+            .ok_or_else(|| "cold subscription did not queue its initial reset".to_owned())?,
+        &expected_cold,
+    )?;
+
+    let hot_post_bind_events =
+        drain_subscription_events("hot after cold bind", &mut hot_subscription, &mut hot_rows)?;
+    let cold_post_bind_events = drain_subscription_events(
+        "cold after hot bind",
+        &mut cold_subscription,
+        &mut cold_rows,
+    )?;
+    validate_subscription_snapshot("hot after both binds", &hot_rows, &expected_hot)?;
+    validate_subscription_snapshot("cold after both binds", &cold_rows, &expected_cold)?;
+
+    let total_documents = fixture.team_document_counts.iter().copied().sum::<usize>();
+    let hot_insert = row_uuid(0x5f, 0);
+    insert_canary_document(
+        db,
+        seed_mode,
+        hot_insert,
+        hot_team,
+        total_documents,
+        fixture.count(0),
+    )?;
+    let hot_mutation_events =
+        drain_subscription_events("hot mutation", &mut hot_subscription, &mut hot_rows)?;
+    if hot_mutation_events == 0 {
+        return Err("hot subscription emitted no event for a newest hot-team row".to_owned());
+    }
+    let cold_events_after_hot = drain_subscription_events(
+        "cold after hot mutation",
+        &mut cold_subscription,
+        &mut cold_rows,
+    )?;
+    let mut expected_hot_after = expected_hot.clone();
+    expected_hot_after.insert(hot_insert);
+    if expected_hot_after.len() > 100 {
+        expected_hot_after.pop_first();
+    }
+    validate_subscription_snapshot("hot after hot mutation", &hot_rows, &expected_hot_after)?;
+    validate_subscription_snapshot("cold after hot mutation", &cold_rows, &expected_cold)?;
+
+    let cold_insert = row_uuid(0x5f, 1);
+    insert_canary_document(
+        db,
+        seed_mode,
+        cold_insert,
+        cold_team,
+        total_documents + 1,
+        fixture.count(1),
+    )?;
+    let cold_mutation_events =
+        drain_subscription_events("cold mutation", &mut cold_subscription, &mut cold_rows)?;
+    if cold_mutation_events == 0 {
+        return Err("cold subscription emitted no event for a newest cold-team row".to_owned());
+    }
+    let hot_events_after_cold = drain_subscription_events(
+        "hot after cold mutation",
+        &mut hot_subscription,
+        &mut hot_rows,
+    )?;
+    let mut expected_cold_after = expected_cold.clone();
+    expected_cold_after.insert(cold_insert);
+    if expected_cold_after.len() > 100 {
+        expected_cold_after.pop_first();
+    }
+    validate_subscription_snapshot("hot after cold mutation", &hot_rows, &expected_hot_after)?;
+    validate_subscription_snapshot("cold after cold mutation", &cold_rows, &expected_cold_after)?;
+
+    Ok(json!({
+        "ok": true,
+        "api": "Db::subscribe_for_identity",
+        "same_shape": hot.shape().shape_id() == cold.shape().shape_id(),
+        "distinct_binding_ids": true,
+        "hot_rows": hot_rows.len(),
+        "cold_rows": cold_rows.len(),
+        "hot_post_bind_events": hot_post_bind_events,
+        "cold_post_bind_events": cold_post_bind_events,
+        "hot_mutation_events": hot_mutation_events,
+        "cold_events_after_hot": cold_events_after_hot,
+        "cold_mutation_events": cold_mutation_events,
+        "hot_events_after_cold": hot_events_after_cold,
+    }))
+}
+
+fn validate_initial_subscription(
+    label: &str,
+    event: SubscriptionEvent,
+    expected_rows: &BTreeSet<RowUuid>,
+) -> Result<BTreeSet<RowUuid>, String> {
+    match event {
+        SubscriptionEvent::Delta {
+            reset: true,
+            added,
+            updated,
+            removed,
+            ..
+        } => {
+            if !removed.is_empty() {
+                return Err(format!("{label} initial reset unexpectedly removed rows"));
+            }
+            let actual_rows = added
+                .iter()
+                .chain(updated.iter())
+                .map(|row| row.row_uuid())
+                .collect::<BTreeSet<_>>();
+            validate_subscription_snapshot(label, &actual_rows, expected_rows)?;
+            Ok(actual_rows)
+        }
+        other => Err(format!(
+            "expected {label} initial reset delta for simultaneous binding, got {other:?}"
+        )),
+    }
+}
+
+fn expected_row_ids(
+    fixture: &Fixture,
+    team_index: usize,
+    variant: FilterVariant,
+    limit: usize,
+) -> BTreeSet<RowUuid> {
+    expected_updated_at(fixture, team_index, variant, limit)
+        .into_iter()
+        .map(|timestamp| {
+            row_uuid(
+                0x53,
+                usize::try_from(timestamp).expect("benchmark timestamp fits in usize"),
+            )
+        })
+        .collect()
+}
+
+fn drain_subscription_events(
+    label: &str,
+    subscription: &mut SubscriptionStream,
+    snapshot: &mut BTreeSet<RowUuid>,
+) -> Result<usize, String> {
+    let mut events = 0;
+    while let Some(event) = subscription.try_next_event() {
+        events += 1;
+        apply_subscription_event(label, snapshot, event)?;
+    }
+    Ok(events)
+}
+
+fn apply_subscription_event(
+    label: &str,
+    snapshot: &mut BTreeSet<RowUuid>,
+    event: SubscriptionEvent,
+) -> Result<(), String> {
+    match event {
+        SubscriptionEvent::Delta {
+            reset,
+            added,
+            updated,
+            removed,
+            ..
+        } => {
+            if reset {
+                snapshot.clear();
+            }
+            for row in removed {
+                snapshot.remove(&row.row_uuid);
+            }
+            for row in added.into_iter().chain(updated) {
+                snapshot.insert(row.row_uuid());
+            }
+            Ok(())
+        }
+        other => Err(format!("{label} emitted non-delta event {other:?}")),
+    }
+}
+
+fn validate_subscription_snapshot(
+    label: &str,
+    actual: &BTreeSet<RowUuid>,
+    expected: &BTreeSet<RowUuid>,
+) -> Result<(), String> {
+    if actual != expected {
+        return Err(format!(
+            "{label} has {} rows, expected {}; simultaneous binding leaked or misrouted rows",
+            actual.len(),
+            expected.len()
+        ));
+    }
+    Ok(())
+}
+
+fn insert_canary_document(
+    db: &BenchDb,
+    seed_mode: SeedMode,
+    row: RowUuid,
+    team: RowUuid,
+    global_index: usize,
+    local_index: usize,
+) -> Result<(), String> {
+    let cells = document_cells(team, global_index, local_index);
+    match seed_mode {
+        SeedMode::Local => db
+            .insert_with_id("documents", row, cells)
+            .map(|_| ())
+            .map_err(|error| format!("insert local simultaneous-binding canary row: {error}")),
+        SeedMode::Global => db
+            .seed_settled_mergeable_for_bootstrap("documents", row, AuthorId::SYSTEM, cells)
+            .map(|_| ())
+            .map_err(|error| format!("insert settled simultaneous-binding canary row: {error}")),
+    }
+}
+
+fn safe_canary(canary: impl FnOnce() -> Result<JsonValue, String>) -> JsonValue {
+    match catch_unwind(AssertUnwindSafe(canary)) {
+        Ok(Ok(report)) => report,
+        Ok(Err(error)) => json!({
+            "ok": false,
+            "error": error,
+        }),
+        Err(payload) => json!({
+            "ok": false,
+            "panic": panic_message(payload),
+        }),
+    }
+}
+
+fn panic_message(payload: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_owned()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "non-string panic payload".to_owned()
+    }
+}
+
+fn observed_ratios(scenarios: &[ScenarioReport]) -> JsonValue {
+    let mean = |profile: &str, variant: &str, style: &str| {
+        scenarios
+            .iter()
+            .find(|scenario| {
+                scenario.team_profile == profile
+                    && scenario.filter_variant == variant
+                    && scenario.query_style == style
+            })
+            .map(|scenario| scenario.repeated_reads.mean_us)
+    };
+
+    let hot_literal = mean("hot", "team_only", "literal");
+    let cold_literal = mean("cold", "team_only", "literal");
+    let hot_parameterized = mean("hot", "team_only", "parameterized");
+    let hot_filtered = mean("hot", "status_active_and_not_archived", "parameterized");
+
+    json!({
+        "hot_to_cold_team_only_literal_repeated_ratio":
+            optional_ratio(hot_literal, cold_literal),
+        "hot_parameterized_to_literal_repeated_ratio":
+            optional_ratio(hot_parameterized, hot_literal),
+        "hot_filtered_to_team_only_parameterized_repeated_ratio":
+            optional_ratio(hot_filtered, hot_parameterized),
+        "interpretation": {
+            "hot_to_cold": "sensitivity to team cardinality, candidate scanning, authorization joins, and sorting",
+            "parameterized_to_literal": "binding/cache route overhead after preparation",
+            "filtered_to_team_only": "cost of non-indexed status/archived predicates over the team candidate set",
+        }
+    })
+}
+
+fn optional_ratio(numerator: Option<f64>, denominator: Option<f64>) -> JsonValue {
+    match (numerator, denominator) {
+        (Some(numerator), Some(denominator)) if denominator != 0.0 => {
+            json!(numerator / denominator)
+        }
+        _ => JsonValue::Null,
+    }
+}
+
+fn latency_stats(samples: &[Duration]) -> LatencyStats {
+    let mut nanos = samples.iter().map(Duration::as_nanos).collect::<Vec<_>>();
+    nanos.sort_unstable();
+    let total_nanos = nanos.iter().copied().sum::<u128>();
+    let total_seconds = total_nanos as f64 / 1_000_000_000.0;
+    let mean_us = total_nanos as f64 / nanos.len() as f64 / 1_000.0;
+
+    LatencyStats {
+        iterations: nanos.len(),
+        total_ms: total_nanos as f64 / 1_000_000.0,
+        mean_us,
+        min_us: nanos[0] as f64 / 1_000.0,
+        p50_us: percentile(&nanos, 0.50) as f64 / 1_000.0,
+        p95_us: percentile(&nanos, 0.95) as f64 / 1_000.0,
+        p99_us: percentile(&nanos, 0.99) as f64 / 1_000.0,
+        max_us: nanos[nanos.len() - 1] as f64 / 1_000.0,
+        reads_per_second: if total_seconds == 0.0 {
+            f64::INFINITY
+        } else {
+            nanos.len() as f64 / total_seconds
+        },
+    }
+}
+
+fn percentile(sorted_nanos: &[u128], percentile: f64) -> u128 {
+    let index = ((sorted_nanos.len() - 1) as f64 * percentile).round() as usize;
+    sorted_nanos[index]
+}
+
+fn membership_cells(team: RowUuid, user: AuthorId, member_index: usize) -> RowCells {
+    BTreeMap::from([
+        ("team".to_owned(), Value::Uuid(team.0)),
+        ("user".to_owned(), Value::Uuid(user.0)),
+        (
+            "role".to_owned(),
+            Value::String(if member_index == 0 { "owner" } else { "member" }.to_owned()),
+        ),
+    ])
+}
+
+fn document_cells(team: RowUuid, global_index: usize, local_index: usize) -> RowCells {
+    BTreeMap::from([
+        ("team".to_owned(), Value::Uuid(team.0)),
+        (
+            "updated_at".to_owned(),
+            Value::U64(u64::try_from(global_index).expect("validated document count fits in u64")),
+        ),
+        (
+            "status".to_owned(),
+            Value::String(status(local_index).to_owned()),
+        ),
+        ("archived".to_owned(), Value::Bool(archived(local_index))),
+        (
+            "title".to_owned(),
+            Value::String(format!("Document {global_index}")),
+        ),
+        (
+            "body".to_owned(),
+            Value::String("Synthetic SaaS benchmark document body".to_owned()),
+        ),
+    ])
+}
+
+fn status(local_index: usize) -> &'static str {
+    match local_index % 3 {
+        0 => "active",
+        1 => "draft",
+        _ => "closed",
+    }
+}
+
+fn archived(local_index: usize) -> bool {
+    local_index.is_multiple_of(10)
+}
+
+fn member_identity(team_index: usize, member_index: usize, membership_index: usize) -> AuthorId {
+    if member_index == 0 && team_index < 2 {
+        READER
+    } else {
+        AuthorId(row_uuid(0x54, membership_index).0)
+    }
+}
+
+fn row_uuid(kind: u8, index: usize) -> RowUuid {
+    let mut bytes = [0u8; 16];
+    bytes[0] = kind;
+    bytes[8..].copy_from_slice(
+        &u64::try_from(index)
+            .expect("benchmark row index fits in u64")
+            .wrapping_add(1)
+            .to_be_bytes(),
+    );
+    RowUuid::from_bytes(bytes)
+}
+
+fn env_usize(name: &str, default: usize) -> Result<usize, String> {
+    match std::env::var(name) {
+        Ok(value) => value
+            .parse::<usize>()
+            .map_err(|error| format!("{name}={value:?} is not a usize: {error}")),
+        Err(std::env::VarError::NotPresent) => Ok(default),
+        Err(error) => Err(format!("read {name}: {error}")),
+    }
+}
+
+fn ratio(numerator: f64, denominator: f64) -> f64 {
+    if denominator == 0.0 {
+        f64::INFINITY
+    } else {
+        numerator / denominator
+    }
+}
+
+fn millis(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000.0
+}
+
+fn micros(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000_000.0
+}

--- a/crates/jazz/src/node/query_engine/lowering.rs
+++ b/crates/jazz/src/node/query_engine/lowering.rs
@@ -3000,6 +3000,7 @@ fn lower_linear_plan_steps(
                     graph,
                     &order,
                     partition_by,
+                    &available_route_fields,
                     *limit,
                     *offset,
                     tie_breaker,
@@ -3031,6 +3032,7 @@ fn lower_linear_plan_steps(
             graph,
             &order,
             &[],
+            &available_route_fields,
             None,
             0,
             &[NormalizedValueRef::RowId(RowIdRef::Source(
@@ -3993,6 +3995,7 @@ fn lower_window(
     graph: GraphBuilder,
     order: &[OrderKey],
     partition_by: &[NormalizedValueRef],
+    binding_route_fields: &BTreeSet<String>,
     limit: Option<u32>,
     offset: u32,
     tie_breaker: &[NormalizedValueRef],
@@ -4000,10 +4003,19 @@ fn lower_window(
     source: &ResolvedSource,
     request: &QueryProgramRequest,
 ) -> Result<GraphBuilder, UnsupportedReason> {
-    let group_cols = partition_by
+    let mut group_cols = partition_by
         .iter()
         .map(|value| lower_field_ref(value, plan, source, request, "slice partition key"))
         .collect::<Result<Vec<_>, _>>()?;
+    // A maintained graph shares this TopBy across every bound route. The
+    // binding fields therefore define an implicit partition in addition to a
+    // query's explicit `partition_by`: routing after a global window would
+    // otherwise let one binding consume another binding's retained rows.
+    for route_field in binding_route_fields {
+        if !group_cols.contains(route_field) {
+            group_cols.push(route_field.clone());
+        }
+    }
     let tie_cols = if tie_breaker.is_empty() {
         vec![source.row_shape.row_uuid_field.clone()]
     } else {

--- a/crates/jazz/src/node/tests/policies_rls.rs
+++ b/crates/jazz/src/node/tests/policies_rls.rs
@@ -3753,6 +3753,123 @@ fn maintained_subscription_view_ordered_offset_limit_boundary_churn_stays_increm
 }
 
 #[test]
+fn maintained_subscription_view_top_by_partitions_windows_by_team_binding() {
+    let schema = JazzSchema::new([TableSchema::new(
+        "documents",
+        [
+            ColumnSchema::new("team", ColumnType::Uuid),
+            ColumnSchema::new("updated_at", ColumnType::U64),
+        ],
+    )]);
+    let (_core_dir, mut core) = open_node_with_schema(node(9), schema);
+    let team_a = row(0xa1);
+    let team_b = row(0xb2);
+
+    for index in 0..100_u64 {
+        accept_global(
+            &mut core,
+            MergeableCommit::new("documents", row(index as u8), index).cells(BTreeMap::from([
+                ("team".to_owned(), Value::Uuid(team_a.0)),
+                ("updated_at".to_owned(), Value::U64(index)),
+            ])),
+        );
+        accept_global(
+            &mut core,
+            MergeableCommit::new("documents", row((index + 100) as u8), index + 100)
+                .cells(BTreeMap::from([
+                    ("team".to_owned(), Value::Uuid(team_b.0)),
+                    ("updated_at".to_owned(), Value::U64(index + 100)),
+                ])),
+        );
+    }
+
+    let shape = Query::from("documents")
+        .filter(eq(col("team"), param("team")))
+        .order_by("updated_at", OrderDirection::Desc)
+        .limit(100)
+        .validate(&core.catalogue.schema)
+        .unwrap();
+    let binding_a = shape
+        .bind(BTreeMap::from([("team".to_owned(), Value::Uuid(team_a.0))]))
+        .unwrap();
+    let binding_b = shape
+        .bind(BTreeMap::from([("team".to_owned(), Value::Uuid(team_b.0))]))
+        .unwrap();
+
+    let mut peer_b = PeerState::new();
+    let update_b = peer_b
+        .rehydrate_query(&mut core, &shape, &binding_b)
+        .unwrap();
+    let mut peer_a = PeerState::new();
+    let update_a = peer_a
+        .rehydrate_query(&mut core, &shape, &binding_a)
+        .unwrap();
+
+    let (adds_a, removes_a) = canonical_view_update_rows(&update_a);
+    let (adds_b, removes_b) = canonical_view_update_rows(&update_b);
+    assert!(removes_a.is_empty());
+    assert!(removes_b.is_empty());
+    assert_eq!(adds_a.len(), 100, "team A should receive its own full window");
+    assert_eq!(adds_b.len(), 100, "team B should receive its own full window");
+}
+
+#[test]
+fn maintained_subscription_view_top_by_partitions_windows_by_policy_claim_binding() {
+    let schema = JazzSchema::new([TableSchema::new(
+        "documents",
+        [
+            ColumnSchema::new("owner", ColumnType::Uuid),
+            ColumnSchema::new("updated_at", ColumnType::U64),
+        ],
+    )
+    .with_read_policy(Policy::owner_only("documents", "owner"))]);
+    let (_core_dir, mut core) = open_node_with_schema(node(9), schema);
+    let owner_a = user(0xa1);
+    let owner_b = user(0xb2);
+
+    for index in 0..100_u64 {
+        accept_global(
+            &mut core,
+            MergeableCommit::new("documents", row(index as u8), index).cells(BTreeMap::from([
+                ("owner".to_owned(), Value::Uuid(owner_a.0)),
+                ("updated_at".to_owned(), Value::U64(index)),
+            ])),
+        );
+        accept_global(
+            &mut core,
+            MergeableCommit::new("documents", row((index + 100) as u8), index + 100)
+                .cells(BTreeMap::from([
+                    ("owner".to_owned(), Value::Uuid(owner_b.0)),
+                    ("updated_at".to_owned(), Value::U64(index + 100)),
+                ])),
+        );
+    }
+
+    let shape = Query::from("documents")
+        .order_by("updated_at", OrderDirection::Desc)
+        .limit(100)
+        .validate(&core.catalogue.schema)
+        .unwrap();
+    let binding = shape.bind(BTreeMap::new()).unwrap();
+
+    let mut peer_b = PeerState::for_author(owner_b);
+    let update_b = peer_b
+        .rehydrate_query(&mut core, &shape, &binding)
+        .unwrap();
+    let mut peer_a = PeerState::for_author(owner_a);
+    let update_a = peer_a
+        .rehydrate_query(&mut core, &shape, &binding)
+        .unwrap();
+
+    let (adds_a, removes_a) = canonical_view_update_rows(&update_a);
+    let (adds_b, removes_b) = canonical_view_update_rows(&update_b);
+    assert!(removes_a.is_empty());
+    assert!(removes_b.is_empty());
+    assert_eq!(adds_a.len(), 100, "owner A should receive its own full window");
+    assert_eq!(adds_b.len(), 100, "owner B should receive its own full window");
+}
+
+#[test]
 fn maintained_subscription_view_rehydrates_reference_bearing_root_table() {
     // The maintained subscription view footprint is table-aware and now ships
     // reference-closure rows from the fast path.

--- a/dev/benchmarks/SAAS_DOCUMENTS_500K_RECEIPT_20260728.md
+++ b/dev/benchmarks/SAAS_DOCUMENTS_500K_RECEIPT_20260728.md
@@ -1,0 +1,143 @@
+# 500k SaaS documents benchmark receipt
+
+Date: 2026-07-28
+
+Status: directional developer-machine result, not a performance promise.
+
+## Workload
+
+- 500,000 documents
+- 5,000 teams
+- 10 memberships per team
+- one 30,000-document hot team
+- one 100-document small team
+- `ORDER BY updated_at DESC LIMIT 100`
+- optional `status = active AND archived = false`
+- membership-based document read policy
+
+The requested cardinalities are not simultaneously satisfiable: 5,000 teams
+with at least 100 documents already consume all 500,000 rows. Keeping a 30,000
+row team requires 529,900 total documents. The default fixture preserves the
+500,000 total and gives the remaining teams 94-95 rows; setting the document
+count to 529,900 preserves the lower bound.
+
+## Harnesses
+
+- `crates/groove/benches/saas_documents.rs` isolates storage access, TopBy, and
+  subscribed-write maintenance against RocksDB with WAL and no per-write sync.
+- `crates/jazz-tools/benches/saas_documents.rs` exercises the public `Db`
+  facade, literal and parameterized queries, policies, Local and Global read
+  modes, and correctness canaries.
+
+Both harnesses validate exact result identities against an independent oracle.
+
+Primary commands:
+
+```sh
+cargo bench --profile perf -p groove --bench saas_documents --quiet
+JAZZ_SAAS_QUERY_ITERS=1 \
+  cargo bench --profile perf -p jazz-tools --bench saas_documents --quiet
+
+GROOVE_SAAS_QUERY_ITERS=1 GROOVE_SAAS_WRITE_ITERS=100 \
+  cargo bench --profile perf -p groove --bench saas_documents --quiet
+```
+
+Environment:
+
+- Rust 1.93.1
+- `aarch64-apple-darwin`
+- `[profile.perf]`
+
+## Groove and RocksDB results
+
+The primary query run used 10 repeated samples. Times below are p50.
+
+| Query | Team rows | Candidate rows | Time | Storage records / ranges |
+| --- | ---: | ---: | ---: | ---: |
+| Full scan, latest | 30,000 | 500,000 documents + 50,000 memberships | 181.9 ms | 550,000 / 2 |
+| Indexed candidates, latest | 30,000 | 30,000 documents + 1 membership | 105.9 ms | 60,002 / 30,003 |
+| Full scan, active/unarchived | 30,000 | 500,000 documents + 50,000 memberships | 236.5 ms | 550,000 / 2 |
+| Indexed candidates, active/unarchived | 30,000 | 7,106 documents + 1 membership | 24.2 ms | 14,214 / 7,109 |
+| Full scan, latest | 100 | 500,000 documents + 50,000 memberships | 197.9 ms | 550,000 / 2 |
+| Indexed candidates, latest | 100 | 100 documents + 1 membership | 0.310 ms | 202 / 103 |
+| Indexed candidates, active/unarchived | 100 | 24 documents + 1 membership | 0.109 ms | 50 / 27 |
+
+The current durable index is non-covering: each index entry causes a base-row
+lookup. A full 30,000-row prefix scan took 45.8 ms. A single seek to the last
+entry in that prefix took 7 us and read two records, demonstrating that ordered
+storage is available but bounded reverse iteration is not exposed to the query
+path.
+
+Fixture seeding took 4.41 s.
+
+## Subscribed writes
+
+The subscription targets the active/unarchived latest 100 rows of the
+30,000-document team.
+
+| Write | Samples | Commit wall | IVM tick | Storage |
+| --- | ---: | ---: | ---: | ---: |
+| One matching-team row | 100 | 8.45 ms p50 / 9.26 ms p95 | 8.42 ms p50 | 0.041 ms p50 |
+| One unrelated-team row | 100 | 0.046 ms p50 / 0.071 ms p95 | 0.019 ms p50 | 0.010 ms p50 |
+| `commit_batch` for 100 matching rows | 1 | 9.39 ms | 8.93 ms | 0.175 ms |
+
+The 9.39 ms measurement starts immediately before `commit_batch`; constructing
+and staging the 100 rows is outside that timer. The run started with 30,000
+team rows, performed 20 matching one-row writes, and committed the batch at a
+pre-batch cardinality of 30,020. The batch incurs one IVM tick. One hundred
+separate commits repeat the approximately 8-10 ms maintenance work 100 times,
+so batching is substantially more efficient even though this receipt does not
+measure end-to-end row construction.
+
+These numbers use one active subscription. The many-binding case is currently
+blocked by the correctness issue documented in
+`SAAS_DOCUMENTS_ENGINE_FINDINGS_20260728.md`.
+
+## Jazz public-API results
+
+The full 500k Local fixture used `MemoryStorage` and batched local writes.
+Seeding 5,000 teams, 50,000 memberships, and 500,000 documents took 31.14 s.
+Each first/repeated cell below is a single observation
+(`JAZZ_SAAS_QUERY_ITERS=1`), not a latency distribution.
+
+| Scenario | Predicate | First read | Repeated read |
+| --- | --- | ---: | ---: |
+| Hot team, literal | team only | 8.58 s | 8.52 s |
+| Hot team, parameterized | team only | 7.99 s | 171.5 ms |
+| Hot team, parameterized | team + active/unarchived | 187.8 ms | 162.0 ms |
+| Small team, literal | team only | 170.7 ms | 166.7 ms |
+| Small team, parameterized | team only | 231.0 ms | 237.1 ms |
+
+The parameterized hot-team result exposes a large first-binding hydration cost:
+7.99 s initially and 171.5 ms on reuse. The literal hot-team path remains at
+about 8.5 s on the repeated observation, so its cost is persistent rather than
+first-hydration-only. Later shapes can reuse already hydrated graph fragments.
+
+A 20k-row Global control confirmed team-cardinality sensitivity: latest-100
+literal reads were 88.1 ms for a 3,000-row team and 15.9 ms for a 100-row team.
+Global bootstrap was kept small because the public settled import API is
+row-at-a-time.
+
+## Correctness canaries
+
+Authorization denial passed: an identity without a membership saw zero rows.
+
+Two canaries failed:
+
+1. `CurrentRow::cell("team")` returned `None` for a parameterized result even
+   though the exact-row oracle passed.
+2. Two simultaneous bindings of the same parameterized latest-100 shape did not
+   produce isolated initial snapshots; the hot-team subscription returned 0
+   rows instead of 100.
+
+## Validation
+
+- both benchmark targets compile and pass Clippy
+- Rust formatting and diff checks pass
+- both `saas_documents` targets were run separately at full fixture size
+- the existing repository benchmark smoke suite passed as a regression check;
+  it does not invoke these new targets
+- query and subscription outputs are checked against exact-ID oracles
+
+Tooling friction: bounded reverse-prefix iteration and batched settled bootstrap
+would have made the intended production paths directly measurable at full size.

--- a/dev/benchmarks/SAAS_DOCUMENTS_ENGINE_FINDINGS_20260728.md
+++ b/dev/benchmarks/SAAS_DOCUMENTS_ENGINE_FINDINGS_20260728.md
@@ -1,0 +1,128 @@
+# SaaS documents engine findings
+
+This note interprets
+`SAAS_DOCUMENTS_500K_RECEIPT_20260728.md` and scopes the next work.
+
+## Why the initial query takes 8 seconds
+
+The 8-second observations are Local query work on a node holding all 500,000
+documents. They are not database-open or network time. The parameterized hot
+query drops from 7.99 s on its first binding to 171.5 ms on reuse, which isolates
+a large shape/binding-hydration component. The literal hot query remains at
+8.58 s initially and 8.52 s on its repeated observation, so that path also has
+a persistent per-evaluation cost; it should not be described as cold-only.
+
+Several costs stack:
+
+1. Local query planning explicitly returns no secondary access paths
+   (`crates/jazz/src/node/query_eval.rs:4850-4857`). The root document source
+   therefore starts from all 500,000 rows rather than the selected team.
+2. Local visible-current evaluation unions global and ahead-current rows,
+   computes the winning version with `ArgMax`, and anti-joins deletion winners
+   (`crates/jazz/src/node/codec.rs:1492-1595`).
+3. Authenticated reads build and join the membership-policy graph. The fixture
+   adds 50,000 membership rows to the cold source work.
+4. Groove eagerly hydrates referenced sources and builds join arrangements for
+   a new graph shape/binding.
+5. `TopBy(100)` copies the complete touched bucket, builds sort keys, and fully
+   sorts it. It reconstructs and sorts both the before and after windows
+   (`crates/groove/src/ivm/runtime/mod.rs:5815-5821`,
+   `crates/groove/src/ivm/runtime/mod.rs:7866-7930`).
+
+The isolated RocksDB full scan is roughly 0.18-0.24 s. The remaining difference
+is therefore in Jazz visible-current, policy, graph hydration, arrangement, and
+materialization work rather than simply reading 500k keys. This benchmark does
+not yet attribute an exact percentage to each phase.
+
+A partial client holding only its subscribed rows avoids the 500k local source,
+but a history-complete serving node still needs a selective initial access path.
+
+## The simultaneous-binding correctness issue
+
+The parameterized latest-100 query is intended to share one maintained graph
+across team bindings. It currently does not partition the window by the binding:
+
+- the top-level slice has no explicit partition key;
+- `lower_window` groups TopBy only by that slice partition
+  (`crates/jazz/src/node/query_engine/lowering.rs:3992-4047`);
+- Groove applies the binding route filter after the shared terminal graph
+  (`crates/groove/src/ivm/runtime/mod.rs:3361-3380`).
+
+Consequently multiple team bindings can share one global Top-100 window and only
+then filter by team. The two-binding canary observed the hot binding returning 0
+rows instead of 100.
+
+This is a correctness blocker for the many-active-team scenario. It can also
+turn the TopBy bucket into the sum of documents across active bindings, making
+write maintenance increasingly expensive.
+
+The separate `CurrentRow::cell` failure appears to be a nullable/projection
+descriptor mismatch for a parameter-constrained field. It should receive its
+own regression test and fix.
+
+## Writes with active subscriptions
+
+For one correct, literal subscription over a team that starts with 30,000 rows:
+
+- one matching insert costs 8.45 ms p50;
+- aggregate metrics place almost all of that time in the IVM tick rather than
+  storage; source inspection implicates TopBy, but there is no TopBy-only timer;
+- one unrelated-team insert costs 0.046 ms p50;
+- `commit_batch` for 100 matching inserts costs 9.39 ms after row construction
+  and staging; that run had 30,020 team rows before the batch;
+- 100 matching inserts as separate commits repeat the full touched-bucket work
+  per commit and are approximately two orders of magnitude more expensive than
+  the measured batch commit phase.
+
+With many parameterized team subscriptions, the intended Groove architecture is
+better than the old engine: graph nodes and arrangements are shared, and only
+the matching route should touch a TopBy group. Today the routing/window bug
+invalidates that expectation. Runtime delivery also visits active subscription
+states, so fan-out still needs a 1/100/1,000-binding measurement after the
+correctness fix.
+
+## Comparison with the previous engine
+
+There is no apples-to-apples retained old-engine receipt for this workload.
+Source inspection of the pre-swap tree (`489474ed4`) shows:
+
+- an explicit literal team predicate could use the single-column team index;
+- it still enumerated and materialized every document in that team, sorted all
+  of them, and only then applied the limit;
+- a policy-only query without the explicit team predicate scanned all
+  documents;
+- every subscription owned a separate graph and sorted candidate set;
+- every documents-table mutation dirtied every documents subscription,
+  including subscriptions for unrelated teams.
+
+The old engine may therefore have hydrated an explicit-team literal faster than
+today's broken prepared Local path, but it was structurally worse for many
+active subscriptions. Neither engine has the desired bounded ordered Top-K
+path.
+
+## Recommended order of work
+
+1. **Fix route-aware window correctness.** Add routing fields to the TopBy
+   partition for maintained parameterized queries. Add a black-box regression
+   with two teams, two simultaneous bindings, isolated initial snapshots, and
+   mutations to each team.
+2. **Fix parameterized row projection.** Make `CurrentRow::cell` agree with the
+   public nullable schema for constrained route fields.
+3. **Add the fan-out benchmark.** Sweep 1, 100, and 1,000 active team bindings;
+   compare one 100-row transaction with 100 one-row transactions and verify that
+   unrelated subscribers receive no events.
+4. **Make initial reads selective.** Preserve secondary access paths in
+   prepared/maintained plans and support the relevant Local/current source.
+5. **Add a bounded ordered index path.** Use a composite index such as
+   `(team, status, archived, updated_at, id)`, reverse-scan only the first 100
+   matches, then fetch at most 100 base rows.
+6. **Replace full TopBy sorting.** Maintain ordered per-team Top-K state so a
+   matching update is logarithmic rather than two full team sorts.
+
+Correctness is the immediate priority. After that, bounded initial index access
+has the largest read-latency payoff; ordered incremental Top-K is the next
+steady-state write optimization.
+
+Tooling friction: an old-engine retained receipt and phase timers around Jazz
+source hydration, policy evaluation, and TopBy would remove the remaining
+source-level inference.


### PR DESCRIPTION
Reported by an adopter testing the new core on #1170:

> many active team subscriptions are currently not correct: bindings share a global `TopBy(100)` before team routing. The two-team canary returned 0 instead of 100 documents for one team.

Maintained bindings shared one global `TopBy` applied *before* team routing, so the limit was taken across all teams and then filtered per team — leaving one team with none of the 100.

The window must be evaluated per binding partition, so each team gets its own top-N rather than a share of one global top-N.

## Coverage

Two maintained-subscription regressions in `crates/jazz/src/node/tests/policies_rls.rs`:

- two teams x 100 documents: each receives 100
- two owner-policy claim bindings x 100 documents: each receives 100

Both are multi-row-per-group by construction, so they exercise the partitioning rather than degenerating into per-row projection.

## Gates

`cargo test -p jazz`, `-p groove`, `-p jazz-server`, `cargo check -p jazz-sim --benches` all exit 0.

`cargo test -p jazz-tools --features test` fails **only** `numeric_claims_match_integer_columns_across_core_widths`, which is red on `codex/jazz-core-engine-swap` itself and is fixed by #1159 — not caused by this branch. Verified by running it on the unmodified base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RLK2isSYCQo5MaUG5PVVM