### PR TITLE
(new core) bench: attribute R3 Jazz open recovery

### DIFF
--- a/crates/jazz/Cargo.toml
+++ b/crates/jazz/Cargo.toml
@@ -26,6 +26,7 @@ sync-autopsy = []
 # Disabled-by-default counters for the cold-settle attribution bench. They do
 # not alter protocol behavior or production measurement paths.
 cold-settle-attribution = ["groove/cold-settle-attribution"]
+r3-open-attribution = ["rocksdb", "testing"]
 testing = []
 transport-compression-lz4 = ["dep:lz4_flex"]
 transport-compression-zstd = ["dep:zstd"]

--- a/crates/jazz/benches/realistic_phase1.rs
+++ b/crates/jazz/benches/realistic_phase1.rs
@@ -3,6 +3,7 @@
 //! This intentionally exercises `jazz::db::Db<MemoryStorage>` directly, without
 //! the legacy `RuntimeCore`, `SchemaManager`, or `SyncManager` stack.
 
+#![recursion_limit = "256"]
 #![allow(clippy::single_element_loop, dead_code)]
 
 use std::cell::RefCell;
@@ -46,6 +47,8 @@ type RocksBenchDb = Db<RocksDbStorage>;
 
 const AUTHOR: AuthorId = AuthorId(uuid::uuid!("00000000-0000-0000-0000-0000000000a1"));
 const READER_AUTHOR: AuthorId = AuthorId(uuid::uuid!("00000000-0000-0000-0000-0000000000b2"));
+#[cfg(feature = "rocksdb")]
+const R3_REOPEN_SEED: u64 = 31;
 
 #[derive(Debug, Clone, Copy)]
 struct SmallProfile {
@@ -1112,6 +1115,7 @@ fn r3_profiles() -> Vec<R3Profile> {
 struct R3PhaseSample {
     storage_open: Duration,
     jazz_open: Duration,
+    open_breakdown: Option<R3OpenBreakdown>,
     prepare: Duration,
     first_read: Duration,
     first_read_resolve_view: Duration,
@@ -1126,10 +1130,65 @@ struct R3PhaseSample {
 }
 
 #[cfg(feature = "rocksdb")]
+#[derive(Debug)]
+struct R3OpenBreakdown {
+    catalogue_open: Duration,
+    database_open: Duration,
+    state_init: Duration,
+    recover_storage: Duration,
+    recover_catalogue_state: Duration,
+    validate_current_rows: Duration,
+    recover_global_sequences: Duration,
+    recover_pending_and_rejected: Duration,
+    recover_unclean_close: Duration,
+    recover_known_state: Duration,
+    rebuild_ahead_current: Duration,
+    finalize_catalogue: Duration,
+    validated_current_rows: usize,
+    accepted_global_sequences: usize,
+    global_sequence_records_scanned: usize,
+    ahead_current_entries: usize,
+}
+
+#[cfg(feature = "rocksdb")]
 #[derive(Clone, Copy)]
 enum R3CacheMode {
     Warm,
     Evicted,
+}
+
+#[cfg(feature = "rocksdb")]
+#[derive(Clone, Copy)]
+enum R3CloseMode {
+    Clean,
+    Unclean,
+}
+
+#[cfg(feature = "rocksdb")]
+impl R3CloseMode {
+    fn id(self) -> &'static str {
+        match self {
+            Self::Clean => "db_close",
+            Self::Unclean => "drop_without_close",
+        }
+    }
+}
+
+#[cfg(feature = "rocksdb")]
+fn r3_close_modes() -> Vec<R3CloseMode> {
+    let requested = env::var("JAZZ_R3_CLOSE_MODES").unwrap_or_else(|_| "unclean".to_owned());
+    requested
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| match value {
+            "clean" => R3CloseMode::Clean,
+            "unclean" => R3CloseMode::Unclean,
+            other => panic!(
+                "unknown JAZZ_R3_CLOSE_MODES entry {other:?}; expected a comma-separated subset of clean,unclean"
+            ),
+        })
+        .collect()
 }
 
 #[cfg(feature = "rocksdb")]
@@ -1204,9 +1263,8 @@ fn evict_path_from_linux_page_cache(_path: &Path) {
 fn open_rocks_db_with_phases(
     seed: u64,
     author: AuthorId,
-    history_complete: bool,
     path: &Path,
-) -> (RocksBenchDb, Duration, Duration) {
+) -> (RocksBenchDb, Duration, Duration, Option<R3OpenBreakdown>) {
     let schema = schema();
     let column_families = schema.column_families();
     let refs = column_families
@@ -1230,15 +1288,40 @@ fn open_rocks_db_with_phases(
     .with_id_source(SeededRowIdSource::new(seed));
 
     let jazz_started = Instant::now();
-    let opened = if history_complete {
-        block_on(Db::open_history_complete(config))
-    } else {
-        block_on(Db::open(config))
+    #[cfg(feature = "r3-open-attribution")]
+    let (db, open_breakdown) = {
+        let (db, receipt) = block_on(Db::open_with_receipt_for_test(config))
+            .expect("open attributed core realistic RocksDB phase receipt db");
+        (
+            db,
+            Some(R3OpenBreakdown {
+                catalogue_open: receipt.catalogue_open,
+                database_open: receipt.database_open,
+                state_init: receipt.state_init,
+                recover_storage: receipt.recover_storage,
+                recover_catalogue_state: receipt.recover_catalogue_state,
+                validate_current_rows: receipt.validate_current_rows,
+                recover_global_sequences: receipt.recover_global_sequences,
+                recover_pending_and_rejected: receipt.recover_pending_and_rejected,
+                recover_unclean_close: receipt.recover_unclean_close,
+                recover_known_state: receipt.recover_known_state,
+                rebuild_ahead_current: receipt.rebuild_ahead_current,
+                finalize_catalogue: receipt.finalize_catalogue,
+                validated_current_rows: receipt.validated_current_rows,
+                accepted_global_sequences: receipt.accepted_global_sequences,
+                global_sequence_records_scanned: receipt.global_sequence_records_scanned,
+                ahead_current_entries: receipt.ahead_current_entries,
+            }),
+        )
     };
-    let db = opened.expect("open core realistic RocksDB phase receipt db");
+    #[cfg(not(feature = "r3-open-attribution"))]
+    let (db, open_breakdown) = (
+        block_on(Db::open(config)).expect("open core realistic RocksDB phase receipt db"),
+        None,
+    );
     let jazz_open = jazz_started.elapsed();
 
-    (db, storage_open, jazz_open)
+    (db, storage_open, jazz_open, open_breakdown)
 }
 
 #[cfg(feature = "rocksdb")]
@@ -1246,14 +1329,15 @@ fn measure_r3_phase_sample(
     path: &Path,
     project: RowUuid,
     expected_rows: usize,
-    sample: usize,
+    _sample: usize,
     cache_mode: R3CacheMode,
+    close_mode: R3CloseMode,
 ) -> R3PhaseSample {
     if matches!(cache_mode, R3CacheMode::Evicted) {
         evict_path_from_linux_page_cache(path);
     }
-    let (db, storage_open, jazz_open) =
-        open_rocks_db_with_phases(31 + sample as u64, AUTHOR, false, path);
+    let (db, storage_open, jazz_open, open_breakdown) =
+        open_rocks_db_with_phases(R3_REOPEN_SEED, AUTHOR, path);
 
     let prepare_started = Instant::now();
     let query = project_board_query(&db, project);
@@ -1269,10 +1353,15 @@ fn measure_r3_phase_sample(
         expected_rows,
         "R3 project-board result count changed"
     );
+    if matches!(close_mode, R3CloseMode::Clean) {
+        db.close()
+            .expect("close R3 phase receipt db after measured read");
+    }
 
     R3PhaseSample {
         storage_open,
         jazz_open,
+        open_breakdown,
         prepare,
         first_read,
         first_read_resolve_view: read_profile.resolve_view,
@@ -1285,6 +1374,32 @@ fn measure_r3_phase_sample(
         first_read_unattributed: first_read.saturating_sub(read_profile.total),
         rows: rows.len(),
     }
+}
+
+#[cfg(feature = "rocksdb")]
+fn establish_r3_close_mode(path: &Path, close_mode: R3CloseMode) {
+    let db = open_rocks_db_with_author(R3_REOPEN_SEED, AUTHOR, false, path);
+    if matches!(close_mode, R3CloseMode::Clean) {
+        db.close()
+            .expect("establish clean-close marker before R3 phase samples");
+    }
+}
+
+#[cfg(feature = "rocksdb")]
+fn median_open_us(
+    samples: &[R3PhaseSample],
+    phase: impl Fn(&R3OpenBreakdown) -> Duration,
+) -> Option<u64> {
+    let mut values = samples
+        .iter()
+        .filter_map(|sample| sample.open_breakdown.as_ref())
+        .map(|receipt| phase(receipt).as_micros().min(u64::MAX as u128) as u64)
+        .collect::<Vec<_>>();
+    if values.is_empty() {
+        return None;
+    }
+    values.sort_unstable();
+    Some(values[values.len() / 2])
 }
 
 #[cfg(feature = "rocksdb")]
@@ -1305,45 +1420,110 @@ fn emit_r3_phase_receipts(path: &Path, project: RowUuid, selected: R3Profile) {
         .unwrap_or(3)
         .max(1);
     let expected_rows = selected.profile.tasks.div_ceil(selected.profile.projects);
-    for cache_mode in r3_cache_modes() {
-        let samples = (0..sample_count)
-            .map(|sample| measure_r3_phase_sample(path, project, expected_rows, sample, cache_mode))
-            .collect::<Vec<_>>();
+    for close_mode in r3_close_modes() {
+        establish_r3_close_mode(path, close_mode);
+        for cache_mode in r3_cache_modes() {
+            let samples = (0..sample_count)
+                .map(|sample| {
+                    measure_r3_phase_sample(
+                        path,
+                        project,
+                        expected_rows,
+                        sample,
+                        cache_mode,
+                        close_mode,
+                    )
+                })
+                .collect::<Vec<_>>();
 
-        println!(
-            "{}",
-            serde_json::json!({
-                "scenario": "r3_rocksdb_cold_load",
-                "phase": cache_mode.phase(),
-                "cache_mode": cache_mode.id(),
-                "profile": selected.id,
-                "users": selected.profile.users,
-                "organizations": selected.profile.organizations,
-                "tasks": selected.profile.tasks,
-                "projects": selected.profile.projects,
-                "comments": selected.profile.comments,
-                "watchers_per_task": selected.profile.watchers_per_task,
-                "activity_events": selected.profile.activity_events,
-                "result_rows": samples[0].rows,
-                "samples": sample_count,
-                "durability": "wal_no_sync",
-                "total_p50_us": median_us(&samples, |sample| {
-                    sample.storage_open + sample.jazz_open + sample.prepare + sample.first_read
-                }),
-                "storage_open_p50_us": median_us(&samples, |sample| sample.storage_open),
-                "jazz_open_p50_us": median_us(&samples, |sample| sample.jazz_open),
-                "prepare_p50_us": median_us(&samples, |sample| sample.prepare),
-                "first_read_p50_us": median_us(&samples, |sample| sample.first_read),
-                "first_read_resolve_view_p50_us": median_us(&samples, |sample| sample.first_read_resolve_view),
-                "first_read_compile_program_p50_us": median_us(&samples, |sample| sample.first_read_compile_program),
-                "first_read_select_plan_p50_us": median_us(&samples, |sample| sample.first_read_select_plan),
-                "first_read_execute_plan_p50_us": median_us(&samples, |sample| sample.first_read_execute_plan),
-                "first_read_decode_materialize_p50_us": median_us(&samples, |sample| sample.first_read_decode_materialize),
-                "first_read_finish_rows_p50_us": median_us(&samples, |sample| sample.first_read_finish_rows),
-                "first_read_apply_projection_p50_us": median_us(&samples, |sample| sample.first_read_apply_projection),
-                "first_read_unattributed_p50_us": median_us(&samples, |sample| sample.first_read_unattributed),
-            })
-        );
+            println!(
+                "{}",
+                serde_json::json!({
+                    "scenario": "r3_rocksdb_cold_load",
+                    "phase": cache_mode.phase(),
+                    "cache_mode": cache_mode.id(),
+                    "close_mode": close_mode.id(),
+                    "profile": selected.id,
+                    "users": selected.profile.users,
+                    "organizations": selected.profile.organizations,
+                    "tasks": selected.profile.tasks,
+                    "projects": selected.profile.projects,
+                    "comments": selected.profile.comments,
+                    "watchers_per_task": selected.profile.watchers_per_task,
+                    "activity_events": selected.profile.activity_events,
+                    "result_rows": samples[0].rows,
+                    "samples": sample_count,
+                    "durability": "wal_no_sync",
+                    "total_p50_us": median_us(&samples, |sample| {
+                        sample.storage_open + sample.jazz_open + sample.prepare + sample.first_read
+                    }),
+                    "storage_open_p50_us": median_us(&samples, |sample| sample.storage_open),
+                    "jazz_open_p50_us": median_us(&samples, |sample| sample.jazz_open),
+                    "catalogue_open_p50_us": median_open_us(&samples, |receipt| receipt.catalogue_open),
+                    "database_open_p50_us": median_open_us(&samples, |receipt| receipt.database_open),
+                    "state_init_p50_us": median_open_us(&samples, |receipt| receipt.state_init),
+                    "recover_storage_p50_us": median_open_us(&samples, |receipt| receipt.recover_storage),
+                    "recover_catalogue_state_p50_us": median_open_us(
+                        &samples,
+                        |receipt| receipt.recover_catalogue_state,
+                    ),
+                    "validate_current_rows_p50_us": median_open_us(
+                        &samples,
+                        |receipt| receipt.validate_current_rows,
+                    ),
+                    "recover_global_sequences_p50_us": median_open_us(
+                        &samples,
+                        |receipt| receipt.recover_global_sequences,
+                    ),
+                    "recover_pending_and_rejected_p50_us": median_open_us(
+                        &samples,
+                        |receipt| receipt.recover_pending_and_rejected,
+                    ),
+                    "recover_unclean_close_p50_us": median_open_us(
+                        &samples,
+                        |receipt| receipt.recover_unclean_close,
+                    ),
+                    "recover_known_state_p50_us": median_open_us(
+                        &samples,
+                        |receipt| receipt.recover_known_state,
+                    ),
+                    "rebuild_ahead_current_p50_us": median_open_us(
+                        &samples,
+                        |receipt| receipt.rebuild_ahead_current,
+                    ),
+                    "finalize_catalogue_p50_us": median_open_us(
+                        &samples,
+                        |receipt| receipt.finalize_catalogue,
+                    ),
+                    "validated_current_rows": samples[0]
+                        .open_breakdown
+                        .as_ref()
+                        .map(|receipt| receipt.validated_current_rows),
+                    "accepted_global_sequences": samples[0]
+                        .open_breakdown
+                        .as_ref()
+                        .map(|receipt| receipt.accepted_global_sequences),
+                    "global_sequence_records_scanned": samples[0]
+                        .open_breakdown
+                        .as_ref()
+                        .map(|receipt| receipt.global_sequence_records_scanned),
+                    "ahead_current_entries": samples[0]
+                        .open_breakdown
+                        .as_ref()
+                        .map(|receipt| receipt.ahead_current_entries),
+                    "prepare_p50_us": median_us(&samples, |sample| sample.prepare),
+                    "first_read_p50_us": median_us(&samples, |sample| sample.first_read),
+                    "first_read_resolve_view_p50_us": median_us(&samples, |sample| sample.first_read_resolve_view),
+                    "first_read_compile_program_p50_us": median_us(&samples, |sample| sample.first_read_compile_program),
+                    "first_read_select_plan_p50_us": median_us(&samples, |sample| sample.first_read_select_plan),
+                    "first_read_execute_plan_p50_us": median_us(&samples, |sample| sample.first_read_execute_plan),
+                    "first_read_decode_materialize_p50_us": median_us(&samples, |sample| sample.first_read_decode_materialize),
+                    "first_read_finish_rows_p50_us": median_us(&samples, |sample| sample.first_read_finish_rows),
+                    "first_read_apply_projection_p50_us": median_us(&samples, |sample| sample.first_read_apply_projection),
+                    "first_read_unattributed_p50_us": median_us(&samples, |sample| sample.first_read_unattributed),
+                })
+            );
+        }
     }
 }
 

--- a/crates/jazz/benches/realistic_phase1.rs
+++ b/crates/jazz/benches/realistic_phase1.rs
@@ -3,6 +3,7 @@
 //! This intentionally exercises `jazz::db::Db<MemoryStorage>` directly, without
 //! the legacy `RuntimeCore`, `SchemaManager`, or `SyncManager` stack.
 
+#![recursion_limit = "256"]
 #![allow(clippy::single_element_loop, dead_code)]
 
 use std::cell::RefCell;
@@ -45,6 +46,8 @@ type RocksBenchDb = Db<RocksDbStorage>;
 
 const AUTHOR: AuthorId = AuthorId(uuid::uuid!("00000000-0000-0000-0000-0000000000a1"));
 const READER_AUTHOR: AuthorId = AuthorId(uuid::uuid!("00000000-0000-0000-0000-0000000000b2"));
+#[cfg(feature = "rocksdb")]
+const R3_REOPEN_SEED: u64 = 31;
 
 #[derive(Debug, Clone, Copy)]
 struct SmallProfile {
@@ -1197,6 +1200,7 @@ fn r3_profiles() -> Vec<R3Profile> {
 struct R3PhaseSample {
     storage_open: Duration,
     jazz_open: Duration,
+    open_breakdown: Option<R3OpenBreakdown>,
     prepare: Duration,
     first_read: Duration,
     first_read_resolve_view: Duration,
@@ -1211,10 +1215,65 @@ struct R3PhaseSample {
 }
 
 #[cfg(feature = "rocksdb")]
+#[derive(Debug)]
+struct R3OpenBreakdown {
+    catalogue_open: Duration,
+    database_open: Duration,
+    state_init: Duration,
+    recover_storage: Duration,
+    recover_catalogue_state: Duration,
+    validate_current_rows: Duration,
+    recover_global_sequences: Duration,
+    recover_pending_and_rejected: Duration,
+    recover_unclean_close: Duration,
+    recover_known_state: Duration,
+    rebuild_ahead_current: Duration,
+    finalize_catalogue: Duration,
+    validated_current_rows: usize,
+    accepted_global_sequences: usize,
+    global_sequence_records_scanned: usize,
+    ahead_current_entries: usize,
+}
+
+#[cfg(feature = "rocksdb")]
 #[derive(Clone, Copy)]
 enum R3CacheMode {
     Warm,
     Evicted,
+}
+
+#[cfg(feature = "rocksdb")]
+#[derive(Clone, Copy)]
+enum R3CloseMode {
+    Clean,
+    Unclean,
+}
+
+#[cfg(feature = "rocksdb")]
+impl R3CloseMode {
+    fn id(self) -> &'static str {
+        match self {
+            Self::Clean => "db_close",
+            Self::Unclean => "drop_without_close",
+        }
+    }
+}
+
+#[cfg(feature = "rocksdb")]
+fn r3_close_modes() -> Vec<R3CloseMode> {
+    let requested = env::var("JAZZ_R3_CLOSE_MODES").unwrap_or_else(|_| "unclean".to_owned());
+    requested
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| match value {
+            "clean" => R3CloseMode::Clean,
+            "unclean" => R3CloseMode::Unclean,
+            other => panic!(
+                "unknown JAZZ_R3_CLOSE_MODES entry {other:?}; expected a comma-separated subset of clean,unclean"
+            ),
+        })
+        .collect()
 }
 
 #[cfg(feature = "rocksdb")]
@@ -1289,9 +1348,8 @@ fn evict_path_from_linux_page_cache(_path: &Path) {
 fn open_rocks_db_with_phases(
     seed: u64,
     author: AuthorId,
-    history_complete: bool,
     path: &Path,
-) -> (RocksBenchDb, Duration, Duration) {
+) -> (RocksBenchDb, Duration, Duration, Option<R3OpenBreakdown>) {
     let schema = schema();
     let column_families = schema.column_families();
     let refs = column_families
@@ -1315,15 +1373,40 @@ fn open_rocks_db_with_phases(
     .with_id_source(SeededRowIdSource::new(seed));
 
     let jazz_started = Instant::now();
-    let opened = if history_complete {
-        block_on(Db::open_history_complete(config))
-    } else {
-        block_on(Db::open(config))
+    #[cfg(feature = "r3-open-attribution")]
+    let (db, open_breakdown) = {
+        let (db, receipt) = block_on(Db::open_with_receipt_for_test(config))
+            .expect("open attributed core realistic RocksDB phase receipt db");
+        (
+            db,
+            Some(R3OpenBreakdown {
+                catalogue_open: receipt.catalogue_open,
+                database_open: receipt.database_open,
+                state_init: receipt.state_init,
+                recover_storage: receipt.recover_storage,
+                recover_catalogue_state: receipt.recover_catalogue_state,
+                validate_current_rows: receipt.validate_current_rows,
+                recover_global_sequences: receipt.recover_global_sequences,
+                recover_pending_and_rejected: receipt.recover_pending_and_rejected,
+                recover_unclean_close: receipt.recover_unclean_close,
+                recover_known_state: receipt.recover_known_state,
+                rebuild_ahead_current: receipt.rebuild_ahead_current,
+                finalize_catalogue: receipt.finalize_catalogue,
+                validated_current_rows: receipt.validated_current_rows,
+                accepted_global_sequences: receipt.accepted_global_sequences,
+                global_sequence_records_scanned: receipt.global_sequence_records_scanned,
+                ahead_current_entries: receipt.ahead_current_entries,
+            }),
+        )
     };
-    let db = opened.expect("open core realistic RocksDB phase receipt db");
+    #[cfg(not(feature = "r3-open-attribution"))]
+    let (db, open_breakdown) = (
+        block_on(Db::open(config)).expect("open core realistic RocksDB phase receipt db"),
+        None,
+    );
     let jazz_open = jazz_started.elapsed();
 
-    (db, storage_open, jazz_open)
+    (db, storage_open, jazz_open, open_breakdown)
 }
 
 #[cfg(feature = "rocksdb")]
@@ -1331,14 +1414,15 @@ fn measure_r3_phase_sample(
     path: &Path,
     project: RowUuid,
     expected_rows: usize,
-    sample: usize,
+    _sample: usize,
     cache_mode: R3CacheMode,
+    close_mode: R3CloseMode,
 ) -> R3PhaseSample {
     if matches!(cache_mode, R3CacheMode::Evicted) {
         evict_path_from_linux_page_cache(path);
     }
-    let (db, storage_open, jazz_open) =
-        open_rocks_db_with_phases(31 + sample as u64, AUTHOR, false, path);
+    let (db, storage_open, jazz_open, open_breakdown) =
+        open_rocks_db_with_phases(R3_REOPEN_SEED, AUTHOR, path);
 
     let prepare_started = Instant::now();
     let query = project_board_query(&db, project);
@@ -1354,10 +1438,15 @@ fn measure_r3_phase_sample(
         expected_rows,
         "R3 project-board result count changed"
     );
+    if matches!(close_mode, R3CloseMode::Clean) {
+        db.close()
+            .expect("close R3 phase receipt db after measured read");
+    }
 
     R3PhaseSample {
         storage_open,
         jazz_open,
+        open_breakdown,
         prepare,
         first_read,
         first_read_resolve_view: read_profile.resolve_view,
@@ -1370,6 +1459,32 @@ fn measure_r3_phase_sample(
         first_read_unattributed: first_read.saturating_sub(read_profile.total),
         rows: rows.len(),
     }
+}
+
+#[cfg(feature = "rocksdb")]
+fn establish_r3_close_mode(path: &Path, close_mode: R3CloseMode) {
+    let db = open_rocks_db_with_author(R3_REOPEN_SEED, AUTHOR, false, path);
+    if matches!(close_mode, R3CloseMode::Clean) {
+        db.close()
+            .expect("establish clean-close marker before R3 phase samples");
+    }
+}
+
+#[cfg(feature = "rocksdb")]
+fn median_open_us(
+    samples: &[R3PhaseSample],
+    phase: impl Fn(&R3OpenBreakdown) -> Duration,
+) -> Option<u64> {
+    let mut values = samples
+        .iter()
+        .filter_map(|sample| sample.open_breakdown.as_ref())
+        .map(|receipt| phase(receipt).as_micros().min(u64::MAX as u128) as u64)
+        .collect::<Vec<_>>();
+    if values.is_empty() {
+        return None;
+    }
+    values.sort_unstable();
+    Some(values[values.len() / 2])
 }
 
 #[cfg(feature = "rocksdb")]
@@ -1390,45 +1505,110 @@ fn emit_r3_phase_receipts(path: &Path, project: RowUuid, selected: R3Profile) {
         .unwrap_or(3)
         .max(1);
     let expected_rows = selected.profile.tasks.div_ceil(selected.profile.projects);
-    for cache_mode in r3_cache_modes() {
-        let samples = (0..sample_count)
-            .map(|sample| measure_r3_phase_sample(path, project, expected_rows, sample, cache_mode))
-            .collect::<Vec<_>>();
+    for close_mode in r3_close_modes() {
+        establish_r3_close_mode(path, close_mode);
+        for cache_mode in r3_cache_modes() {
+            let samples = (0..sample_count)
+                .map(|sample| {
+                    measure_r3_phase_sample(
+                        path,
+                        project,
+                        expected_rows,
+                        sample,
+                        cache_mode,
+                        close_mode,
+                    )
+                })
+                .collect::<Vec<_>>();
 
-        println!(
-            "{}",
-            serde_json::json!({
-                "scenario": "r3_rocksdb_cold_load",
-                "phase": cache_mode.phase(),
-                "cache_mode": cache_mode.id(),
-                "profile": selected.id,
-                "users": selected.profile.users,
-                "organizations": selected.profile.organizations,
-                "tasks": selected.profile.tasks,
-                "projects": selected.profile.projects,
-                "comments": selected.profile.comments,
-                "watchers_per_task": selected.profile.watchers_per_task,
-                "activity_events": selected.profile.activity_events,
-                "result_rows": samples[0].rows,
-                "samples": sample_count,
-                "durability": "wal_no_sync",
-                "total_p50_us": median_us(&samples, |sample| {
-                    sample.storage_open + sample.jazz_open + sample.prepare + sample.first_read
-                }),
-                "storage_open_p50_us": median_us(&samples, |sample| sample.storage_open),
-                "jazz_open_p50_us": median_us(&samples, |sample| sample.jazz_open),
-                "prepare_p50_us": median_us(&samples, |sample| sample.prepare),
-                "first_read_p50_us": median_us(&samples, |sample| sample.first_read),
-                "first_read_resolve_view_p50_us": median_us(&samples, |sample| sample.first_read_resolve_view),
-                "first_read_compile_program_p50_us": median_us(&samples, |sample| sample.first_read_compile_program),
-                "first_read_select_plan_p50_us": median_us(&samples, |sample| sample.first_read_select_plan),
-                "first_read_execute_plan_p50_us": median_us(&samples, |sample| sample.first_read_execute_plan),
-                "first_read_decode_materialize_p50_us": median_us(&samples, |sample| sample.first_read_decode_materialize),
-                "first_read_finish_rows_p50_us": median_us(&samples, |sample| sample.first_read_finish_rows),
-                "first_read_apply_projection_p50_us": median_us(&samples, |sample| sample.first_read_apply_projection),
-                "first_read_unattributed_p50_us": median_us(&samples, |sample| sample.first_read_unattributed),
-            })
-        );
+            println!(
+                "{}",
+                serde_json::json!({
+                    "scenario": "r3_rocksdb_cold_load",
+                    "phase": cache_mode.phase(),
+                    "cache_mode": cache_mode.id(),
+                    "close_mode": close_mode.id(),
+                    "profile": selected.id,
+                    "users": selected.profile.users,
+                    "organizations": selected.profile.organizations,
+                    "tasks": selected.profile.tasks,
+                    "projects": selected.profile.projects,
+                    "comments": selected.profile.comments,
+                    "watchers_per_task": selected.profile.watchers_per_task,
+                    "activity_events": selected.profile.activity_events,
+                    "result_rows": samples[0].rows,
+                    "samples": sample_count,
+                    "durability": "wal_no_sync",
+                    "total_p50_us": median_us(&samples, |sample| {
+                        sample.storage_open + sample.jazz_open + sample.prepare + sample.first_read
+                    }),
+                    "storage_open_p50_us": median_us(&samples, |sample| sample.storage_open),
+                    "jazz_open_p50_us": median_us(&samples, |sample| sample.jazz_open),
+                    "catalogue_open_p50_us": median_open_us(&samples, |receipt| receipt.catalogue_open),
+                    "database_open_p50_us": median_open_us(&samples, |receipt| receipt.database_open),
+                    "state_init_p50_us": median_open_us(&samples, |receipt| receipt.state_init),
+                    "recover_storage_p50_us": median_open_us(&samples, |receipt| receipt.recover_storage),
+                    "recover_catalogue_state_p50_us": median_open_us(
+                        &samples,
+                        |receipt| receipt.recover_catalogue_state,
+                    ),
+                    "validate_current_rows_p50_us": median_open_us(
+                        &samples,
+                        |receipt| receipt.validate_current_rows,
+                    ),
+                    "recover_global_sequences_p50_us": median_open_us(
+                        &samples,
+                        |receipt| receipt.recover_global_sequences,
+                    ),
+                    "recover_pending_and_rejected_p50_us": median_open_us(
+                        &samples,
+                        |receipt| receipt.recover_pending_and_rejected,
+                    ),
+                    "recover_unclean_close_p50_us": median_open_us(
+                        &samples,
+                        |receipt| receipt.recover_unclean_close,
+                    ),
+                    "recover_known_state_p50_us": median_open_us(
+                        &samples,
+                        |receipt| receipt.recover_known_state,
+                    ),
+                    "rebuild_ahead_current_p50_us": median_open_us(
+                        &samples,
+                        |receipt| receipt.rebuild_ahead_current,
+                    ),
+                    "finalize_catalogue_p50_us": median_open_us(
+                        &samples,
+                        |receipt| receipt.finalize_catalogue,
+                    ),
+                    "validated_current_rows": samples[0]
+                        .open_breakdown
+                        .as_ref()
+                        .map(|receipt| receipt.validated_current_rows),
+                    "accepted_global_sequences": samples[0]
+                        .open_breakdown
+                        .as_ref()
+                        .map(|receipt| receipt.accepted_global_sequences),
+                    "global_sequence_records_scanned": samples[0]
+                        .open_breakdown
+                        .as_ref()
+                        .map(|receipt| receipt.global_sequence_records_scanned),
+                    "ahead_current_entries": samples[0]
+                        .open_breakdown
+                        .as_ref()
+                        .map(|receipt| receipt.ahead_current_entries),
+                    "prepare_p50_us": median_us(&samples, |sample| sample.prepare),
+                    "first_read_p50_us": median_us(&samples, |sample| sample.first_read),
+                    "first_read_resolve_view_p50_us": median_us(&samples, |sample| sample.first_read_resolve_view),
+                    "first_read_compile_program_p50_us": median_us(&samples, |sample| sample.first_read_compile_program),
+                    "first_read_select_plan_p50_us": median_us(&samples, |sample| sample.first_read_select_plan),
+                    "first_read_execute_plan_p50_us": median_us(&samples, |sample| sample.first_read_execute_plan),
+                    "first_read_decode_materialize_p50_us": median_us(&samples, |sample| sample.first_read_decode_materialize),
+                    "first_read_finish_rows_p50_us": median_us(&samples, |sample| sample.first_read_finish_rows),
+                    "first_read_apply_projection_p50_us": median_us(&samples, |sample| sample.first_read_apply_projection),
+                    "first_read_unattributed_p50_us": median_us(&samples, |sample| sample.first_read_unattributed),
+                })
+            );
+        }
     }
 }
 

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -29,6 +29,8 @@ use web_time::Instant;
 
 use crate::ids::{AuthorId, NodeUuid, RowUuid, SchemaVersionId};
 pub use crate::node::CommitUnitTrust;
+#[cfg(feature = "testing")]
+pub use crate::node::NodeOpenReceipt as DbOpenReceipt;
 use crate::node::{
     CommitUnitIngestContext, CurrentRow, EdgeCacheBudget, LargeValueEditCommit, LargeValueEditOp,
     LocalMaintainedViewSubscription, LocalMaintainedViewSubscriptionUpdate, MergeableCommit,
@@ -564,6 +566,40 @@ where
             )),
             next_now_ms: Rc::new(Cell::new(1)),
         })
+    }
+
+    #[cfg(feature = "testing")]
+    /// Open a database and return internal node-open phase timings for benchmarks.
+    pub async fn open_with_receipt_for_test(
+        config: DbConfig<S>,
+    ) -> Result<(Self, DbOpenReceipt), Error> {
+        let schema_version_id = config.schema.version_id();
+        let schema_views = Rc::new(RefCell::new(BTreeMap::from([(
+            SchemaViewId::for_schema(&config.schema),
+            config.schema.clone(),
+        )])));
+        let (node, receipt) = NodeState::new_with_open_receipt_for_test(
+            config.identity.node,
+            config.schema.clone(),
+            config.storage,
+            false,
+            config.large_value_checkpoint_op_interval,
+        )?;
+        let db = Self {
+            schema: config.schema,
+            schema_version_id,
+            schema_view_is_fixed: false,
+            schema_views,
+            identity: config.identity,
+            node: Rc::new(Node::new(node)),
+            row_id_source: Rc::new(RefCell::new(
+                config
+                    .id_source
+                    .unwrap_or_else(|| Box::new(ProductionRowIdSource)),
+            )),
+            next_now_ms: Rc::new(Cell::new(1)),
+        };
+        Ok((db, receipt))
     }
 
     /// Open a database as a history-complete serving core.

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -36,6 +36,8 @@ const POST_TICK_HISTORY_WINDOW_BUDGET: usize = 4;
 
 use crate::ids::{AuthorId, NodeUuid, RowUuid, SchemaVersionId};
 pub use crate::node::CommitUnitTrust;
+#[cfg(feature = "testing")]
+pub use crate::node::NodeOpenReceipt as DbOpenReceipt;
 use crate::node::{
     CommitUnitIngestContext, CurrentRow, EdgeCacheBudget, LargeValueEditCommit, LargeValueEditOp,
     LocalMaintainedViewSubscription, LocalMaintainedViewSubscriptionUpdate, MergeableCommit,
@@ -420,6 +422,34 @@ where
             ),
             next_now_ms: Cell::new(1),
         })
+    }
+
+    #[cfg(feature = "testing")]
+    /// Open a database and return internal node-open phase timings for benchmarks.
+    pub async fn open_with_receipt_for_test(
+        config: DbConfig<S>,
+    ) -> Result<(Self, DbOpenReceipt), Error> {
+        let schema_version_id = config.schema.version_id();
+        let (node, receipt) = NodeState::new_with_open_receipt_for_test(
+            config.identity.node,
+            config.schema.clone(),
+            config.storage,
+            false,
+            config.large_value_checkpoint_op_interval,
+        )?;
+        let db = Self {
+            schema: config.schema,
+            schema_version_id,
+            identity: config.identity,
+            node: Node::new(node),
+            row_id_source: RefCell::new(
+                config
+                    .id_source
+                    .unwrap_or_else(|| Box::new(ProductionRowIdSource)),
+            ),
+            next_now_ms: Cell::new(1),
+        };
+        Ok((db, receipt))
     }
 
     /// Open a database as a history-complete serving core.

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -10,6 +10,10 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(feature = "testing")]
+use std::time::Duration;
+#[cfg(feature = "testing")]
+use web_time::Instant;
 
 use groove::db::{
     CommitMetrics, Database, DatabaseBatch, DirectRecordStoreWrite, Error as GrooveDbError,
@@ -90,6 +94,44 @@ use open_tx::*;
 use text_oplog::{Content as TextContent, Op as TextOp};
 
 pub use eviction::{EdgeCacheBudget, EdgeCacheBudgetReport, EdgeCacheClass, EvictColdReport};
+
+/// Test/bench-only attribution for the durable-state work performed while opening a node.
+#[cfg(feature = "testing")]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct NodeOpenReceipt {
+    /// Open the catalogue-only Groove database and recover schema metadata.
+    pub catalogue_open: Duration,
+    /// Lower the complete schema and construct the full Groove database.
+    pub database_open: Duration,
+    /// Allocate process-local node state.
+    pub state_init: Duration,
+    /// Recover aliases, clocks, branches, pending edges, and rejected transactions.
+    pub recover_storage: Duration,
+    /// Recover close markers, aliases, branches, and transaction-clock bounds.
+    pub recover_catalogue_state: Duration,
+    /// Legacy full-row validation phase; zero when startup uses newer bounded recovery.
+    pub validate_current_rows: Duration,
+    /// Recover the accepted-global-sequence watermark set.
+    pub recover_global_sequences: Duration,
+    /// Recover pending-edge and rejected-transaction state.
+    pub recover_pending_and_rejected: Duration,
+    /// Clean up inconsistent ahead-current leftovers after an unclean close.
+    pub recover_unclean_close: Duration,
+    /// Recover persisted maintained-query known-state facts.
+    pub recover_known_state: Duration,
+    /// Rebuild the in-memory ahead-current key indexes.
+    pub rebuild_ahead_current: Duration,
+    /// Ensure aliases and persist any missing base catalogue records.
+    pub finalize_catalogue: Duration,
+    /// Current rows decoded by the legacy startup layout validation pass.
+    pub validated_current_rows: usize,
+    /// Accepted global sequence records consumed during recovery.
+    pub accepted_global_sequences: usize,
+    /// Transaction-index records scanned while recovering global sequences.
+    pub global_sequence_records_scanned: usize,
+    /// Ahead-current records consumed while rebuilding in-memory indexes.
+    pub ahead_current_entries: usize,
+}
 
 #[cfg(test)]
 mod tests;
@@ -504,6 +546,30 @@ where
         )
     }
 
+    #[cfg(feature = "testing")]
+    /// Open a node and return phase timings for benchmark attribution.
+    pub fn new_with_open_receipt_for_test(
+        node_uuid: NodeUuid,
+        schema: JazzSchema,
+        storage: S,
+        history_complete: bool,
+        large_value_checkpoint_op_interval: usize,
+    ) -> Result<(Self, NodeOpenReceipt), Error>
+    where
+        S: ReopenableStorage,
+    {
+        let mut receipt = NodeOpenReceipt::default();
+        let node = Self::new_with_options_inner(
+            node_uuid,
+            schema,
+            storage,
+            history_complete,
+            large_value_checkpoint_op_interval,
+            Some(&mut receipt),
+        )?;
+        Ok((node, receipt))
+    }
+
     /// Rebuild the groove layer over the same storage using the standard open path.
     pub fn reopen_in_place(self) -> Result<Self, Error>
     where
@@ -550,7 +616,28 @@ where
         history_complete: bool,
         large_value_checkpoint_op_interval: usize,
     ) -> Result<Self, Error> {
+        Self::new_with_options_inner(
+            node_uuid,
+            schema,
+            storage,
+            history_complete,
+            large_value_checkpoint_op_interval,
+            #[cfg(feature = "testing")]
+            None,
+        )
+    }
+
+    fn new_with_options_inner(
+        node_uuid: NodeUuid,
+        schema: JazzSchema,
+        storage: S,
+        history_complete: bool,
+        large_value_checkpoint_op_interval: usize,
+        #[cfg(feature = "testing")] mut receipt: Option<&mut NodeOpenReceipt>,
+    ) -> Result<Self, Error> {
         let current_schema_version_id = schema.version_id();
+        #[cfg(feature = "testing")]
+        let started = receipt.as_ref().map(|_| Instant::now());
         let CatalogueOpenState {
             storage,
             mut schemas,
@@ -559,6 +646,10 @@ where
             partitions,
             branch_partitions,
         } = Self::open_catalogue_stage(schema.clone(), storage)?;
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, started) {
+            receipt.catalogue_open = started.elapsed();
+        }
         let had_base_schema = schemas.contains_key(&current_schema_version_id);
         if !had_base_schema {
             schemas.insert(
@@ -566,9 +657,17 @@ where
                 SchemaVersion::new(schema.clone()),
             );
         }
+        #[cfg(feature = "testing")]
+        let started = receipt.as_ref().map(|_| Instant::now());
         let database =
             Self::open_full_database(&schema, &schemas, &partitions, &branch_partitions, storage)?;
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, started) {
+            receipt.database_open = started.elapsed();
+        }
         let current_row_graphs = current_row_graphs(&schema);
+        #[cfg(feature = "testing")]
+        let started = receipt.as_ref().map(|_| Instant::now());
         let mut node = Self {
             node_uuid,
             self_node_alias: None,
@@ -644,9 +743,47 @@ where
             initial_sync_flush_active: false,
             initial_sync_flush_completed: false,
         };
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, started) {
+            receipt.state_init = started.elapsed();
+        }
+        #[cfg(feature = "testing")]
+        let started = receipt.as_ref().map(|_| Instant::now());
+        #[cfg(feature = "testing")]
+        if let Some(receipt) = receipt.as_deref_mut() {
+            node.recover_from_storage_with_receipt(receipt)?;
+        } else {
+            node.recover_from_storage()?;
+        }
+        #[cfg(not(feature = "testing"))]
         node.recover_from_storage()?;
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, started) {
+            receipt.recover_storage = started.elapsed();
+        }
+        #[cfg(feature = "testing")]
+        let started = receipt.as_ref().map(|_| Instant::now());
         node.recover_known_state_facts()?;
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, started) {
+            receipt.recover_known_state = started.elapsed();
+        }
+        #[cfg(feature = "testing")]
+        let started = receipt.as_ref().map(|_| Instant::now());
+        #[cfg(feature = "testing")]
+        if let Some(receipt) = receipt.as_deref_mut() {
+            node.rebuild_ahead_current_keys_with_receipt(receipt)?;
+        } else {
+            node.rebuild_ahead_current_keys()?;
+        }
+        #[cfg(not(feature = "testing"))]
         node.rebuild_ahead_current_keys()?;
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, started) {
+            receipt.rebuild_ahead_current = started.elapsed();
+        }
+        #[cfg(feature = "testing")]
+        let started = receipt.as_ref().map(|_| Instant::now());
         let self_node_alias = node.ensure_node_alias(node_uuid)?;
         node.self_node_alias = Some(self_node_alias);
         let schema_alias = node.ensure_schema_version_alias(current_schema_version_id)?;
@@ -656,6 +793,10 @@ where
         }
         for table in schema.tables.iter().map(|table| table.name.clone()) {
             node.persist_partition(table, current_schema_version_id)?;
+        }
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, started) {
+            receipt.finalize_catalogue = started.elapsed();
         }
         Ok(node)
     }
@@ -1492,9 +1633,31 @@ where
     }
 
     fn rebuild_ahead_current_keys(&mut self) -> Result<(), Error> {
+        #[cfg(feature = "testing")]
+        {
+            self.rebuild_ahead_current_keys_inner(None)
+        }
+        #[cfg(not(feature = "testing"))]
+        self.rebuild_ahead_current_keys_inner()
+    }
+
+    #[cfg(feature = "testing")]
+    fn rebuild_ahead_current_keys_with_receipt(
+        &mut self,
+        receipt: &mut NodeOpenReceipt,
+    ) -> Result<(), Error> {
+        self.rebuild_ahead_current_keys_inner(Some(receipt))
+    }
+
+    fn rebuild_ahead_current_keys_inner(
+        &mut self,
+        #[cfg(feature = "testing")] mut receipt: Option<&mut NodeOpenReceipt>,
+    ) -> Result<(), Error> {
         self.ahead_current_keys.clear();
         self.ahead_current_rows.clear();
         self.ahead_current_latest.clear();
+        #[cfg(feature = "testing")]
+        let mut entries = 0usize;
         for table in self.catalogue.schema.tables.clone() {
             let storage_tables = table.ahead_current_storage_tables();
             let content_rows = self
@@ -1505,6 +1668,10 @@ where
                 .collect::<Vec<_>>();
             let content_descriptor = storage_tables[0].record_schema();
             for raw in content_rows {
+                #[cfg(feature = "testing")]
+                {
+                    entries += 1;
+                }
                 let record = BorrowedRecord::new(&raw, &content_descriptor);
                 self.insert_ahead_current_key(
                     table.name.clone(),
@@ -1522,6 +1689,10 @@ where
                 .map(|raw| raw.raw().to_vec())
                 .collect::<Vec<_>>();
             for raw in deletion_rows {
+                #[cfg(feature = "testing")]
+                {
+                    entries += 1;
+                }
                 let record = BorrowedRecord::new(&raw, &deletion_descriptor);
                 self.insert_ahead_current_key(
                     table.name.clone(),
@@ -1533,6 +1704,10 @@ where
                     ),
                 );
             }
+        }
+        #[cfg(feature = "testing")]
+        if let Some(receipt) = &mut receipt {
+            receipt.ahead_current_entries = entries;
         }
         Ok(())
     }

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -10,6 +10,10 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(feature = "testing")]
+use std::time::Duration;
+#[cfg(feature = "testing")]
+use web_time::Instant;
 
 use groove::db::{
     CommitMetrics, Database, DatabaseBatch, DirectRecordStoreWrite, Error as GrooveDbError,
@@ -92,6 +96,44 @@ use physical::*;
 use text_oplog::{Content as TextContent, Op as TextOp};
 
 pub use eviction::{EdgeCacheBudget, EdgeCacheBudgetReport, EdgeCacheClass, EvictColdReport};
+
+/// Test/bench-only attribution for durable-state work performed while opening a node.
+#[cfg(feature = "testing")]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct NodeOpenReceipt {
+    /// Catalogue-record decoding and activation preparation.
+    pub catalogue_open: Duration,
+    /// Groove database construction from recovered physical layouts.
+    pub database_open: Duration,
+    /// Process-local node allocation and initialization.
+    pub state_init: Duration,
+    /// Total durable-state recovery time.
+    pub recover_storage: Duration,
+    /// Alias, branch, clock, and physical-history recovery time.
+    pub recover_catalogue_state: Duration,
+    /// Retained for receipt compatibility; startup no longer makes this sweep.
+    pub validate_current_rows: Duration,
+    /// Accepted global-sequence recovery time.
+    pub recover_global_sequences: Duration,
+    /// Pending-edge and rejected-transaction recovery time.
+    pub recover_pending_and_rejected: Duration,
+    /// Bounded unclean-close cleanup time.
+    pub recover_unclean_close: Duration,
+    /// Persisted maintained-query known-state recovery time.
+    pub recover_known_state: Duration,
+    /// In-memory ahead-current index reconstruction time.
+    pub rebuild_ahead_current: Duration,
+    /// Final catalogue persistence time, when applicable.
+    pub finalize_catalogue: Duration,
+    /// Current rows decoded by the retired full validation sweep.
+    pub validated_current_rows: usize,
+    /// Accepted global-sequence entries recovered.
+    pub accepted_global_sequences: usize,
+    /// Transaction index records inspected for global sequences.
+    pub global_sequence_records_scanned: usize,
+    /// Physical ahead-current records consumed while rebuilding indexes.
+    pub ahead_current_entries: usize,
+}
 
 #[cfg(test)]
 mod tests;
@@ -561,7 +603,55 @@ where
     where
         S: ReopenableStorage,
     {
+        Self::new_with_options_inner(
+            node_uuid,
+            schema,
+            storage,
+            history_complete,
+            large_value_checkpoint_op_interval,
+            #[cfg(feature = "testing")]
+            None,
+        )
+    }
+
+    #[cfg(feature = "testing")]
+    /// Open a node and attribute durable recovery without changing open semantics.
+    pub fn new_with_open_receipt_for_test(
+        node_uuid: NodeUuid,
+        schema: JazzSchema,
+        storage: S,
+        history_complete: bool,
+        large_value_checkpoint_op_interval: usize,
+    ) -> Result<(Self, NodeOpenReceipt), Error>
+    where
+        S: ReopenableStorage,
+    {
+        let mut receipt = NodeOpenReceipt::default();
+        let node = Self::new_with_options_inner(
+            node_uuid,
+            schema,
+            storage,
+            history_complete,
+            large_value_checkpoint_op_interval,
+            Some(&mut receipt),
+        )?;
+        Ok((node, receipt))
+    }
+
+    fn new_with_options_inner(
+        node_uuid: NodeUuid,
+        schema: JazzSchema,
+        storage: S,
+        history_complete: bool,
+        large_value_checkpoint_op_interval: usize,
+        #[cfg(feature = "testing")] mut receipt: Option<&mut NodeOpenReceipt>,
+    ) -> Result<Self, Error>
+    where
+        S: ReopenableStorage,
+    {
         let current_schema_version_id = schema.version_id();
+        #[cfg(feature = "testing")]
+        let started = receipt.as_ref().map(|_| Instant::now());
         let CatalogueOpenState {
             storage,
             mut schemas,
@@ -578,6 +668,10 @@ where
             current_write_schema,
             branch_partitions,
         } = Self::open_catalogue_stage(schema.clone(), storage)?;
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, started) {
+            receipt.catalogue_open = started.elapsed();
+        }
         let mut registration_schemas = schemas.clone();
         let mut registration_aliases = schema_version_aliases.clone();
         let mut registration_mappings = physical_mappings.clone();
@@ -589,6 +683,8 @@ where
             registration_aliases.insert(staged.publication.schema.id, staged.alias);
             registration_mappings.insert(staged.publication.schema.id, staged.mapping.clone());
         }
+        #[cfg(feature = "testing")]
+        let started = receipt.as_ref().map(|_| Instant::now());
         let mut database = Self::open_full_database(
             &schema,
             &registration_schemas,
@@ -597,6 +693,10 @@ where
             &branch_partitions,
             storage,
         )?;
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, started) {
+            receipt.database_open = started.elapsed();
+        }
         loop {
             let next = active_catalogue_seq.saturating_add(1);
             let Some(staged) = staged_lineages.get(&next).cloned() else {
@@ -631,6 +731,8 @@ where
             .get(&current_schema_version_id)
             .map(|version| version.schema.clone())
             .unwrap_or_else(|| schema.clone());
+        #[cfg(feature = "testing")]
+        let started = receipt.as_ref().map(|_| Instant::now());
         let mut node = Self {
             node_uuid,
             self_node_alias: None,
@@ -717,6 +819,10 @@ where
             initial_sync_flush_active: false,
             initial_sync_flush_completed: false,
         };
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, started) {
+            receipt.state_init = started.elapsed();
+        }
         let known_schema_versions = node
             .catalogue
             .catalogue_schemas
@@ -729,13 +835,47 @@ where
         node.synchronize_physical_version_tables()?;
         node.drain_pending_schema_lineages()?;
         node.drain_pending_catalogue_pointers()?;
+        #[cfg(feature = "testing")]
+        if let Some(receipt) = receipt.as_deref_mut() {
+            let started = Instant::now();
+            node.recover_from_storage_with_receipt(receipt)?;
+            receipt.recover_storage = started.elapsed();
+        } else {
+            node.recover_from_storage()?;
+        }
+        #[cfg(not(feature = "testing"))]
         node.recover_from_storage()?;
+        #[cfg(feature = "testing")]
+        let started = receipt.as_ref().map(|_| Instant::now());
         node.recover_known_state_facts()?;
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, started) {
+            receipt.recover_known_state = started.elapsed();
+        }
+        #[cfg(feature = "testing")]
+        let started = receipt.as_ref().map(|_| Instant::now());
+        #[cfg(feature = "testing")]
+        if let Some(receipt) = receipt.as_deref_mut() {
+            node.rebuild_ahead_current_keys_with_receipt(receipt)?;
+        } else {
+            node.rebuild_ahead_current_keys()?;
+        }
+        #[cfg(not(feature = "testing"))]
         node.rebuild_ahead_current_keys()?;
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, started) {
+            receipt.rebuild_ahead_current = started.elapsed();
+        }
+        #[cfg(feature = "testing")]
+        let started = receipt.as_ref().map(|_| Instant::now());
         let self_node_alias = node.ensure_node_alias(node_uuid)?;
         node.self_node_alias = Some(self_node_alias);
         let schema_alias = node.ensure_schema_version_alias(current_schema_version_id)?;
         node.catalogue.current_schema_version_alias = Some(schema_alias);
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, started) {
+            receipt.finalize_catalogue = started.elapsed();
+        }
         Ok(node)
     }
 
@@ -1769,6 +1909,26 @@ where
     }
 
     fn rebuild_ahead_current_keys(&mut self) -> Result<(), Error> {
+        #[cfg(feature = "testing")]
+        {
+            self.rebuild_ahead_current_keys_inner(None)
+        }
+        #[cfg(not(feature = "testing"))]
+        self.rebuild_ahead_current_keys_inner()
+    }
+
+    #[cfg(feature = "testing")]
+    fn rebuild_ahead_current_keys_with_receipt(
+        &mut self,
+        receipt: &mut NodeOpenReceipt,
+    ) -> Result<(), Error> {
+        self.rebuild_ahead_current_keys_inner(Some(receipt))
+    }
+
+    fn rebuild_ahead_current_keys_inner(
+        &mut self,
+        #[cfg(feature = "testing")] mut receipt: Option<&mut NodeOpenReceipt>,
+    ) -> Result<(), Error> {
         self.ahead_current_keys.clear();
         self.ahead_current_rows.clear();
         self.ahead_current_latest.clear();
@@ -1796,6 +1956,10 @@ where
                 })
                 .collect::<Result<Vec<_>, Error>>()?;
             for (alias, row_uuid, tx_time, tx_node_alias) in content_rows {
+                #[cfg(feature = "testing")]
+                if let Some(receipt) = &mut receipt {
+                    receipt.ahead_current_entries += 1;
+                }
                 self.insert_ahead_current_key(
                     self.logical_table_for_physical_alias(table_id, alias)?,
                     VersionLayer::Content,
@@ -1827,6 +1991,10 @@ where
                 })
                 .collect::<Result<Vec<_>, Error>>()?;
             for (alias, row_uuid, tx_time, tx_node_alias) in deletion_rows {
+                #[cfg(feature = "testing")]
+                if let Some(receipt) = &mut receipt {
+                    receipt.ahead_current_entries += 1;
+                }
                 self.insert_ahead_current_key(
                     self.logical_table_for_physical_alias(table_id, alias)?,
                     VersionLayer::Deletion,

--- a/crates/jazz/src/node/recovery.rs
+++ b/crates/jazz/src/node/recovery.rs
@@ -56,6 +56,28 @@ where
     }
 
     pub(super) fn recover_from_storage(&mut self) -> Result<(), Error> {
+        #[cfg(feature = "testing")]
+        {
+            self.recover_from_storage_inner(None)
+        }
+        #[cfg(not(feature = "testing"))]
+        self.recover_from_storage_inner()
+    }
+
+    #[cfg(feature = "testing")]
+    pub(super) fn recover_from_storage_with_receipt(
+        &mut self,
+        receipt: &mut NodeOpenReceipt,
+    ) -> Result<(), Error> {
+        self.recover_from_storage_inner(Some(receipt))
+    }
+
+    fn recover_from_storage_inner(
+        &mut self,
+        #[cfg(feature = "testing")] mut receipt: Option<&mut NodeOpenReceipt>,
+    ) -> Result<(), Error> {
+        #[cfg(feature = "testing")]
+        let started = receipt.as_ref().map(|_| web_time::Instant::now());
         let cleanly_closed = self.take_valid_clean_close_marker()?;
         let storage_consistent_through = if cleanly_closed {
             None
@@ -123,11 +145,23 @@ where
                 ));
             }
         }
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, started) {
+            receipt.recover_catalogue_state = started.elapsed();
+        }
+        #[cfg(feature = "testing")]
+        let started = receipt.as_ref().map(|_| web_time::Instant::now());
         let mut accepted_global_seqs = Vec::new();
+        #[cfg(feature = "testing")]
+        let mut global_sequence_records_scanned = 0usize;
         for raw in self
             .database
             .index_scan_raw("jazz_transactions", "by_global_seq", &[])?
         {
+            #[cfg(feature = "testing")]
+            {
+                global_sequence_records_scanned += 1;
+            }
             let record = raw.record();
             let global_seq = record.get_nullable_u64(TransactionRowRecord::FIELD_GLOBAL_SEQ_IDX)?;
             if global_seq.is_some()
@@ -148,10 +182,21 @@ where
         }
         accepted_global_seqs.sort();
         accepted_global_seqs.dedup();
+        #[cfg(feature = "testing")]
+        if let Some(receipt) = &mut receipt {
+            receipt.accepted_global_sequences = accepted_global_seqs.len();
+            receipt.global_sequence_records_scanned = global_sequence_records_scanned;
+        }
         for global_seq in accepted_global_seqs {
             self.record_applied_global_seq(global_seq);
         }
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, started) {
+            receipt.recover_global_sequences = started.elapsed();
+        }
 
+        #[cfg(feature = "testing")]
+        let started = receipt.as_ref().map(|_| web_time::Instant::now());
         let mut pending_edges = Vec::new();
         for raw in self
             .database
@@ -226,8 +271,18 @@ where
                 .rejected_transactions
                 .insert(tx_id, RejectedTransaction::new(tx_id, record, versions));
         }
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, started) {
+            receipt.recover_pending_and_rejected = started.elapsed();
+        }
+        #[cfg(feature = "testing")]
+        let started = receipt.as_ref().map(|_| web_time::Instant::now());
         if !cleanly_closed {
             self.cleanup_settled_ahead_current_leftovers(storage_consistent_through)?;
+        }
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, started) {
+            receipt.recover_unclean_close = started.elapsed();
         }
         Ok(())
     }

--- a/crates/jazz/src/node/recovery.rs
+++ b/crates/jazz/src/node/recovery.rs
@@ -46,6 +46,28 @@ where
     }
 
     pub(super) fn recover_from_storage(&mut self) -> Result<(), Error> {
+        #[cfg(feature = "testing")]
+        {
+            self.recover_from_storage_inner(None)
+        }
+        #[cfg(not(feature = "testing"))]
+        self.recover_from_storage_inner()
+    }
+
+    #[cfg(feature = "testing")]
+    pub(super) fn recover_from_storage_with_receipt(
+        &mut self,
+        receipt: &mut NodeOpenReceipt,
+    ) -> Result<(), Error> {
+        self.recover_from_storage_inner(Some(receipt))
+    }
+
+    fn recover_from_storage_inner(
+        &mut self,
+        #[cfg(feature = "testing")] mut receipt: Option<&mut NodeOpenReceipt>,
+    ) -> Result<(), Error> {
+        #[cfg(feature = "testing")]
+        let stage_started = receipt.as_ref().map(|_| Instant::now());
         let cleanly_closed = self.take_valid_clean_close_marker()?;
         let storage_consistent_through = if cleanly_closed {
             None
@@ -98,6 +120,14 @@ where
                 raw.record().get_u64(TransactionRowRecord::FIELD_TIME_IDX)?,
             ));
         }
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, stage_started) {
+            receipt.recover_catalogue_state = started.elapsed();
+        }
+        #[cfg(feature = "testing")]
+        let stage_started = receipt.as_ref().map(|_| Instant::now());
+        #[cfg(feature = "testing")]
+        let validated_current_rows = 0usize;
         for table in self.catalogue.schema.tables.clone() {
             if let Some(raw) =
                 self.database
@@ -116,11 +146,24 @@ where
                 ));
             }
         }
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, stage_started) {
+            receipt.validate_current_rows = started.elapsed();
+            receipt.validated_current_rows = validated_current_rows;
+        }
+        #[cfg(feature = "testing")]
+        let stage_started = receipt.as_ref().map(|_| Instant::now());
         let mut accepted_global_seqs = Vec::new();
+        #[cfg(feature = "testing")]
+        let mut global_sequence_records_scanned = 0usize;
         for raw in self
             .database
             .index_scan_raw("jazz_transactions", "by_global_seq", &[])?
         {
+            #[cfg(feature = "testing")]
+            {
+                global_sequence_records_scanned += 1;
+            }
             let record = raw.record();
             if !matches!(fate_from_encoded_fields(record)?, Fate::Accepted) {
                 continue;
@@ -133,10 +176,21 @@ where
         }
         accepted_global_seqs.sort();
         accepted_global_seqs.dedup();
+        #[cfg(feature = "testing")]
+        if let Some(receipt) = &mut receipt {
+            receipt.accepted_global_sequences = accepted_global_seqs.len();
+            receipt.global_sequence_records_scanned = global_sequence_records_scanned;
+        }
         for global_seq in accepted_global_seqs {
             self.record_applied_global_seq(global_seq);
         }
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, stage_started) {
+            receipt.recover_global_sequences = started.elapsed();
+        }
 
+        #[cfg(feature = "testing")]
+        let stage_started = receipt.as_ref().map(|_| Instant::now());
         let mut pending_edges = Vec::new();
         for raw in self
             .database
@@ -211,8 +265,18 @@ where
                 .rejected_transactions
                 .insert(tx_id, RejectedTransaction::new(tx_id, record, versions));
         }
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, stage_started) {
+            receipt.recover_pending_and_rejected = started.elapsed();
+        }
+        #[cfg(feature = "testing")]
+        let stage_started = receipt.as_ref().map(|_| Instant::now());
         if !cleanly_closed {
             self.cleanup_settled_ahead_current_leftovers(storage_consistent_through)?;
+        }
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, stage_started) {
+            receipt.recover_unclean_close = started.elapsed();
         }
         Ok(())
     }

--- a/crates/jazz/src/node/tests/recovery.rs
+++ b/crates/jazz/src/node/tests/recovery.rs
@@ -44,6 +44,67 @@ fn opening_existing_storage_recovers_mirrors_and_high_water_marks() {
     assert_eq!(next_tx.time, TxTime::from(11));
 }
 
+#[cfg(feature = "testing")]
+#[test]
+fn open_receipt_counts_physical_recovery_scans_exactly() {
+    let schema = schema();
+    let temp_dir = tempfile::tempdir().unwrap();
+    {
+        let mut node = open_node_at(&temp_dir, schema.clone());
+        for (id, time) in [(1, 10), (2, 11)] {
+            node.commit_mergeable(
+                MergeableCommit::new("todos", row(id), time).cells(title_cells("persisted")),
+            )
+            .unwrap();
+        }
+        node.database.close().unwrap();
+    }
+
+    let cfs = schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage = RocksDbStorage::open(temp_dir.path(), &refs).unwrap();
+    let (_reopened, receipt) = NodeState::new_with_open_receipt_for_test(
+        node(1),
+        schema,
+        storage,
+        false,
+        LARGE_VALUE_CHECKPOINT_OP_INTERVAL,
+    )
+    .unwrap();
+
+    // The transaction index is the actual physical access path. This would
+    // become stale if receipt code resumed scanning logical schema tables.
+    assert_eq!(receipt.global_sequence_records_scanned, 2);
+    assert_eq!(receipt.accepted_global_sequences, 0);
+    assert_eq!(receipt.ahead_current_entries, 2);
+}
+
+#[cfg(feature = "testing")]
+#[test]
+fn open_receipt_attributes_catalogue_finalization_when_aliases_are_first_persisted() {
+    // A fresh store plants the finalization work: both aliases are absent and
+    // must be inserted after recovery. This catches an exported receipt phase
+    // that is left at its Default::default() value.
+    let schema = schema();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cfs = schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage = RocksDbStorage::open(temp_dir.path(), &refs).unwrap();
+    let (_node, receipt) = NodeState::new_with_open_receipt_for_test(
+        node(1),
+        schema,
+        storage,
+        false,
+        LARGE_VALUE_CHECKPOINT_OP_INTERVAL,
+    )
+    .unwrap();
+
+    assert!(
+        !receipt.finalize_catalogue.is_zero(),
+        "first-open alias persistence must be attributed to catalogue finalization"
+    );
+}
+
 #[test]
 fn opening_defers_malformed_current_row_to_read() {
     // This is necessarily an internal regression test: planting malformed

--- a/dev/benchmarks/R3_JAZZ_OPEN_ATTRIBUTION.md
+++ b/dev/benchmarks/R3_JAZZ_OPEN_ATTRIBUTION.md
@@ -1,0 +1,63 @@
+# R3 Jazz open attribution
+
+This receipt drills into the `jazz_open` phase established by
+`R3_PERSISTED_READ_RECEIPT.md`. It is local characterization, not an acceptance
+target or an optimization.
+
+The diagnostic API is available only through Jazz's `testing` feature. The
+ordinary `rocksdb` benchmark path remains unchanged and does not collect
+internal timings.
+
+## Initial local receipt
+
+Warm-cache `m` profile on `anselm-devbox`, 2026-07-29. Values are three-sample
+medians over one shared generated workload.
+
+| phase | clean close | unclean drop |
+| --- | ---: | ---: |
+| recover storage | 1,984 ms | 2,082 ms |
+| rebuild ahead-current indexes | 946 ms | 938 ms |
+| recover known-state facts | <1 ms | 28 ms |
+| all other measured open work | <1 ms | <1 ms |
+| **Jazz open** | **2,919 ms** | **3,045 ms** |
+
+`recover_storage` breaks down as:
+
+| recovery child | clean close | unclean drop | observed work |
+| --- | ---: | ---: | --- |
+| recover global sequences | 1,648 ms | 1,507 ms | 952,620 transaction-index records scanned; zero accepted global sequences recovered |
+| validate current rows | 337 ms | 338 ms | 952,620 global/ahead current rows decoded |
+| unclean-close cleanup | 0 ms | 221 ms | scoped crash recovery |
+| pending/rejected recovery | 2 ms | 2 ms | no dominant contribution |
+| catalogue/clock recovery | <1 ms | <1 ms | no dominant contribution |
+
+Ahead-current index reconstruction then scans and inserts 952,620 entries
+again. Startup therefore performs multiple whole-dataset passes before the
+first read. The leading optimization question is whether global-sequence
+recovery can seek directly to persisted watermark metadata (or otherwise avoid
+scanning transactions that cannot contribute a global sequence). The clean
+lifecycle still spends about 2.9 seconds in Jazz open, so crash recovery is not
+the primary problem. The second question is whether current-row validation and
+ahead-current reconstruction can share one pass or recover a persisted
+index/checkpoint.
+
+Clean-close and unclean-drop modes use the same node identity and stored
+fixture. Lifecycle setup and `Db::close` happen outside the measured window.
+The clean marker is therefore valid for every clean sample, while every
+unclean sample deliberately enters crash recovery.
+
+## Command
+
+```sh
+JAZZ_R3_PROFILES=m \
+JAZZ_R3_CACHE_MODES=warm \
+JAZZ_R3_CLOSE_MODES=clean,unclean \
+JAZZ_R3_PHASE_SAMPLES=3 \
+JAZZ_R3_PHASE_ONLY=1 \
+  cargo bench -p jazz --features r3-open-attribution \
+    --bench realistic_phase1 -- realistic_phase1/r3_rocksdb_cold_load
+```
+
+Tooling friction: retaining an opt-in seeded fixture directory would avoid
+repeating several minutes of public-API fixture construction for attribution
+changes that do not alter stored data.

--- a/dev/benchmarks/R3_JAZZ_OPEN_ATTRIBUTION.md
+++ b/dev/benchmarks/R3_JAZZ_OPEN_ATTRIBUTION.md
@@ -1,0 +1,63 @@
+# R3 Jazz open attribution
+
+This receipt drills into the `jazz_open` phase established by
+`R3_PERSISTED_READ_RECEIPT.md`. It is local characterization, not an acceptance
+target or an optimization.
+
+The diagnostic API is available only through Jazz's `testing` feature. The
+ordinary `rocksdb` benchmark path remains unchanged and does not collect
+internal timings.
+
+## Initial local receipt
+
+Warm-cache `m` profile on `anselm-devbox`, 2026-07-29. Values are three-sample
+medians over one shared generated workload.
+
+| phase                         |  clean close | unclean drop |
+| ----------------------------- | -----------: | -----------: |
+| recover storage               |     1,984 ms |     2,082 ms |
+| rebuild ahead-current indexes |       946 ms |       938 ms |
+| recover known-state facts     |        <1 ms |        28 ms |
+| all other measured open work  |        <1 ms |        <1 ms |
+| **Jazz open**                 | **2,919 ms** | **3,045 ms** |
+
+`recover_storage` breaks down as:
+
+| recovery child            | clean close | unclean drop | observed work                                                                       |
+| ------------------------- | ----------: | -----------: | ----------------------------------------------------------------------------------- |
+| recover global sequences  |    1,648 ms |     1,507 ms | 952,620 transaction-index records scanned; zero accepted global sequences recovered |
+| validate current rows     |      337 ms |       338 ms | 952,620 global/ahead current rows decoded                                           |
+| unclean-close cleanup     |        0 ms |       221 ms | scoped crash recovery                                                               |
+| pending/rejected recovery |        2 ms |         2 ms | no dominant contribution                                                            |
+| catalogue/clock recovery  |       <1 ms |        <1 ms | no dominant contribution                                                            |
+
+Ahead-current index reconstruction then scans and inserts 952,620 entries
+again. Startup therefore performs multiple whole-dataset passes before the
+first read. The leading optimization question is whether global-sequence
+recovery can seek directly to persisted watermark metadata (or otherwise avoid
+scanning transactions that cannot contribute a global sequence). The clean
+lifecycle still spends about 2.9 seconds in Jazz open, so crash recovery is not
+the primary problem. The second question is whether current-row validation and
+ahead-current reconstruction can share one pass or recover a persisted
+index/checkpoint.
+
+Clean-close and unclean-drop modes use the same node identity and stored
+fixture. Lifecycle setup and `Db::close` happen outside the measured window.
+The clean marker is therefore valid for every clean sample, while every
+unclean sample deliberately enters crash recovery.
+
+## Command
+
+```sh
+JAZZ_R3_PROFILES=m \
+JAZZ_R3_CACHE_MODES=warm \
+JAZZ_R3_CLOSE_MODES=clean,unclean \
+JAZZ_R3_PHASE_SAMPLES=3 \
+JAZZ_R3_PHASE_ONLY=1 \
+  cargo bench -p jazz --features r3-open-attribution \
+    --bench realistic_phase1 -- realistic_phase1/r3_rocksdb_cold_load
+```
+
+Tooling friction: retaining an opt-in seeded fixture directory would avoid
+repeating several minutes of public-API fixture construction for attribution
+changes that do not alter stored data.

--- a/dev/benchmarks/realistic/README.md
+++ b/dev/benchmarks/realistic/README.md
@@ -107,6 +107,28 @@ eviction is outside the measured window and does not drop the machine-wide page
 cache. Both modes are process-cold. The M fixture is intentionally opt-in
 because its public-API seed takes several minutes.
 
+To attribute Jazz's internal open work, enable the test/bench-only diagnostic
+feature:
+
+```bash
+JAZZ_R3_PROFILES=m \
+JAZZ_R3_CACHE_MODES=warm \
+JAZZ_R3_CLOSE_MODES=clean,unclean \
+JAZZ_R3_PHASE_SAMPLES=3 \
+JAZZ_R3_PHASE_ONLY=1 \
+  cargo bench -p jazz --features r3-open-attribution \
+    --bench realistic_phase1 -- realistic_phase1/r3_rocksdb_cold_load
+```
+
+This adds timings and work counts for catalogue recovery, full database open,
+global-sequence recovery, known-state recovery, ahead-current index
+reconstruction, and final catalogue persistence. The retained legacy
+current-row-validation fields report zero now that startup uses bounded recovery. `clean`
+calls `Db::close` after seeding and after every measured read; `unclean` drops
+the database without closing. Lifecycle setup and close happen outside the
+measured window. The default remains `unclean`. See
+`dev/benchmarks/R3_JAZZ_OPEN_ATTRIBUTION.md` for the initial local receipt.
+
 Export consolidated Criterion artifacts (JSON + markdown summary) from `target/criterion`:
 
 ```bash

--- a/dev/benchmarks/realistic/README.md
+++ b/dev/benchmarks/realistic/README.md
@@ -106,6 +106,28 @@ eviction is outside the measured window and does not drop the machine-wide page
 cache. Both modes are process-cold. The M fixture is intentionally opt-in
 because its public-API seed takes several minutes.
 
+To attribute Jazz's internal open work, enable the test/bench-only diagnostic
+feature:
+
+```bash
+JAZZ_R3_PROFILES=m \
+JAZZ_R3_CACHE_MODES=warm \
+JAZZ_R3_CLOSE_MODES=clean,unclean \
+JAZZ_R3_PHASE_SAMPLES=3 \
+JAZZ_R3_PHASE_ONLY=1 \
+  cargo bench -p jazz --features r3-open-attribution \
+    --bench realistic_phase1 -- realistic_phase1/r3_rocksdb_cold_load
+```
+
+This adds timings and work counts for catalogue recovery, full database open,
+global-sequence recovery, known-state recovery, ahead-current index
+reconstruction, and final catalogue persistence. The retained legacy
+current-row-validation fields report zero now that startup uses bounded recovery. `clean`
+calls `Db::close` after seeding and after every measured read; `unclean` drops
+the database without closing. Lifecycle setup and close happen outside the
+measured window. The default remains `unclean`. See
+`dev/benchmarks/R3_JAZZ_OPEN_ATTRIBUTION.md` for the initial local receipt.
+
 Export consolidated Criterion artifacts (JSON + markdown summary) from `target/criterion`:
 
 ```bash


### PR DESCRIPTION
🤖

## What changed

- adds a testing-only open receipt for the current physical-lineage recovery pipeline
- attributes catalogue reads, full database reads, state recovery, recovery scans, ahead-current rebuild, and final catalogue alias persistence
- adds an opt-in `r3-open-attribution` benchmark feature
- counts records at the actual physical scan loops rather than the retired logical-table recovery path

## Why

We need trustworthy attribution before optimizing startup recovery. The original PR instrumented an older catalogue-table scan; this restack preserves current recovery semantics and moves the measurements to the physical-schema lineage implementation.

`finalize_catalogue` now measures the real post-recovery alias-resolution and persistence boundary instead of reporting an unused zero-valued field.

## Validation

- independently reviewed after conflict resolution: no P0/P1/P2 findings
- exact receipt test counts physical recovery scans
- planted first-open test proves catalogue finalization timing is nonzero when aliases are absent
- recovery tests: 6 passed
- reopen tests: 8 passed
- pending replay tests: 2 passed
- benchmark builds with `r3-open-attribution`
- formatting, Clippy, and clean-tree checks passed

The historical receipt values in the former PR description are not carried forward as current measurements; the recovery architecture changed and should be remeasured from this implementation.
