### PR TITLE
(new core) perf: fuse ahead-current recovery passes

### DIFF
--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -1672,11 +1672,7 @@ where
         &mut self,
         #[cfg(feature = "testing")] mut receipt: Option<&mut NodeOpenReceipt>,
     ) -> Result<(), Error> {
-        self.ahead_current_keys.clear();
-        self.ahead_current_rows.clear();
-        self.ahead_current_latest.clear();
-        #[cfg(feature = "testing")]
-        let mut entries = 0usize;
+        let mut keys = Vec::new();
         for table in self.catalogue.schema.tables.clone() {
             let storage_tables = table.ahead_current_storage_tables();
             let content_rows = self
@@ -1687,18 +1683,14 @@ where
                 .collect::<Vec<_>>();
             let content_descriptor = storage_tables[0].record_schema();
             for raw in content_rows {
-                #[cfg(feature = "testing")]
-                {
-                    entries += 1;
-                }
                 let record = BorrowedRecord::new(&raw, &content_descriptor);
-                self.insert_ahead_current_key(
+                keys.push((
                     table.name.clone(),
                     VersionLayer::Content,
                     RowUuid(record.get_uuid(GlobalCurrentRowRecord::FIELD_ROW_UUID_IDX)?),
                     TxTime(record.get_u64(GlobalCurrentRowRecord::FIELD_TX_TIME_IDX)?),
                     NodeAlias(record.get_u64(GlobalCurrentRowRecord::FIELD_TX_NODE_ID_IDX)?),
-                );
+                ));
             }
             let deletion_descriptor = storage_tables[1].record_schema();
             let deletion_rows = self
@@ -1708,12 +1700,8 @@ where
                 .map(|raw| raw.raw().to_vec())
                 .collect::<Vec<_>>();
             for raw in deletion_rows {
-                #[cfg(feature = "testing")]
-                {
-                    entries += 1;
-                }
                 let record = BorrowedRecord::new(&raw, &deletion_descriptor);
-                self.insert_ahead_current_key(
+                keys.push((
                     table.name.clone(),
                     VersionLayer::Deletion,
                     RowUuid(record.get_uuid(RegisterGlobalCurrentRowRecord::FIELD_ROW_UUID_IDX)?),
@@ -1721,13 +1709,14 @@ where
                     NodeAlias(
                         record.get_u64(RegisterGlobalCurrentRowRecord::FIELD_TX_NODE_ID_IDX)?,
                     ),
-                );
+                ));
             }
         }
         #[cfg(feature = "testing")]
         if let Some(receipt) = &mut receipt {
-            receipt.ahead_current_entries = entries;
+            receipt.ahead_current_entries = keys.len();
         }
+        self.replace_ahead_current_keys(keys);
         Ok(())
     }
 
@@ -1750,6 +1739,37 @@ where
                 }
             })
             .or_insert((tx_time, tx_node_alias));
+    }
+
+    fn replace_ahead_current_keys(
+        &mut self,
+        mut keys: Vec<(String, VersionLayer, RowUuid, TxTime, NodeAlias)>,
+    ) {
+        keys.sort_unstable();
+        keys.dedup();
+
+        let mut rows = keys
+            .iter()
+            .map(|(table, _, row_uuid, _, _)| (table.clone(), *row_uuid))
+            .collect::<Vec<_>>();
+        rows.sort_unstable();
+        rows.dedup();
+
+        let mut latest = Vec::new();
+        for (table, layer, row_uuid, tx_time, tx_node_alias) in &keys {
+            let latest_key = (table.clone(), *layer, *row_uuid);
+            if let Some((previous_key, previous_value)) = latest.last_mut()
+                && *previous_key == latest_key
+            {
+                *previous_value = (*tx_time, *tx_node_alias);
+            } else {
+                latest.push((latest_key, (*tx_time, *tx_node_alias)));
+            }
+        }
+
+        self.ahead_current_rows = rows.into_iter().collect();
+        self.ahead_current_latest = latest.into_iter().collect();
+        self.ahead_current_keys = keys.into_iter().collect();
     }
 
     fn remove_ahead_current_key(

--- a/crates/jazz/src/node/tests/recovery.rs
+++ b/crates/jazz/src/node/tests/recovery.rs
@@ -45,6 +45,67 @@ fn opening_existing_storage_recovers_mirrors_and_high_water_marks() {
 }
 
 #[test]
+fn recovery_rebuilds_ahead_current_latest_and_fallback_versions() {
+    // This is intentionally internal: rejecting the latest local version must
+    // expose the prior pending version, which relies on both the full key set
+    // and the per-row latest-key index rebuilt during open.
+    let schema = schema();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let latest;
+    {
+        let mut node = open_node_at(&temp_dir, schema.clone());
+        node.commit_mergeable(
+            MergeableCommit::new("todos", row(11), 10).cells(title_cells("first")),
+        )
+        .unwrap();
+        latest = node
+            .commit_mergeable(
+                MergeableCommit::new("todos", row(11), 11).cells(title_cells("latest")),
+            )
+            .unwrap();
+    }
+
+    let cfs = schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage = RocksDbStorage::open(temp_dir.path(), &refs).unwrap();
+    #[cfg(feature = "testing")]
+    let (mut reopened, receipt) =
+        NodeState::new_with_open_receipt_for_test(node(1), schema, storage, false, 1024).unwrap();
+    #[cfg(not(feature = "testing"))]
+    let mut reopened = NodeState::new(node(1), schema, storage).unwrap();
+
+    #[cfg(feature = "testing")]
+    assert_eq!(receipt.ahead_current_entries, 2);
+    assert_eq!(
+        reopened
+            .current_rows("todos", DurabilityTier::Local)
+            .unwrap()
+            .into_iter()
+            .map(current_row_pair)
+            .collect::<BTreeMap<_, _>>(),
+        BTreeMap::from([(row(11), title_cells("latest"))])
+    );
+
+    reopened
+        .apply_fate_update(
+            latest,
+            Fate::Rejected(RejectionReason::ExclusiveConflict),
+            None,
+            None,
+        )
+        .unwrap();
+    assert_eq!(
+        reopened
+            .current_rows("todos", DurabilityTier::Local)
+            .unwrap()
+            .into_iter()
+            .map(current_row_pair)
+            .collect::<BTreeMap<_, _>>(),
+        BTreeMap::from([(row(11), title_cells("first"))])
+    );
+}
+
+#[test]
 fn opening_defers_malformed_current_row_to_read() {
     // This is necessarily an internal regression test: planting malformed
     // persisted bytes requires direct storage access, and the core point-read

--- a/dev/benchmarks/R3_FUSED_AHEAD_CURRENT_RECOVERY.md
+++ b/dev/benchmarks/R3_FUSED_AHEAD_CURRENT_RECOVERY.md
@@ -1,0 +1,70 @@
+# R3 bulk ahead-current recovery
+
+This receipt follows `R3_BOUNDED_GLOBAL_SEQ_RECOVERY.md`. It bulk-reconstructs
+the in-memory ahead-current indexes instead of inserting each recovered key
+into three ordered indexes individually.
+
+The original version of this change also fused reconstruction into the
+full-current-row layout-validation pass. The current stacked base removed that
+unbounded validation pass entirely, so recovery now keeps its single bounded
+ahead-current scan and retains the independently useful bulk construction.
+
+Recovery now:
+
+1. scans each ahead-current row once;
+2. retains its table, layer, row, time, and node key;
+3. sorts and deduplicates those keys once;
+4. bulk-constructs the full-key, touched-row, and latest-key indexes.
+
+The indexes are complete before unclean-close cleanup runs, preserving the
+existing cleanup ordering.
+
+## Correctness boundary
+
+An internal recovery regression persists two pending versions of one row and
+reopens the node. It verifies that:
+
+- the receipt counts both ahead-current entries;
+- the newer version is selected after reopen;
+- rejecting the newer version exposes the older pending version.
+
+The fallback assertion exercises both the recovered full-key set and the
+per-row latest-key index.
+
+## Initial local receipt
+
+These measurements describe the original fused-plus-bulk implementation before
+the stacked base removed layout validation. They demonstrate the optimization's
+origin but are not a fresh measurement of this restacked implementation.
+
+Three-sample warm-cache clean-close medians on `anselm-devbox`, 2026-07-29,
+using the same generated `m` workload:
+
+| phase                              |    #1176 | fused + bulk |               delta |
+| ---------------------------------- | -------: | -----------: | ------------------: |
+| Jazz open                          | 1,104 ms |       832 ms |              -24.6% |
+| validate and rebuild current state | 1,103 ms |       831 ms |              -24.7% |
+| standalone ahead-current rebuild   |   763 ms |            0 |          eliminated |
+| first read                         |   345 ms |       306 ms | within run variance |
+| total reopen plus first read       | 1,459 ms |     1,149 ms |              -21.2% |
+
+The fused-only intermediate measured 967 ms for Jazz open. Bulk reconstruction
+then removed another 135 ms by avoiding three ordered-tree mutations per row.
+Both results consumed the same 952,620 ahead-current entries.
+
+This optimization still performs work proportional to ahead-current entries
+and temporarily retains their decoded keys while constructing the indexes.
+Persisting or lazily materializing those indexes remains a separate design
+option if startup must avoid the full pass entirely.
+
+## Command
+
+```sh
+JAZZ_R3_PROFILES=m \
+JAZZ_R3_CACHE_MODES=warm \
+JAZZ_R3_CLOSE_MODES=clean \
+JAZZ_R3_PHASE_SAMPLES=3 \
+JAZZ_R3_PHASE_ONLY=1 \
+  cargo bench -p jazz --features r3-open-attribution \
+    --bench realistic_phase1 -- realistic_phase1/r3_rocksdb_cold_load
+```


### PR DESCRIPTION
## What changed

- Rebuild ahead-current in-memory indexes during the existing persisted-layout validation scan.
- Remove the second full scan of ahead-current RocksDB tables.
- Sort and deduplicate recovered keys once, then bulk-construct the full-key, touched-row, and latest-key B-tree indexes.
- Decode content and deletion records through their respective layouts.
- Add a reopen regression proving latest-version selection and fallback after the latest version is rejected.
- Remove the obsolete standalone rebuild timing field and document the local R3 receipt.

## Why

After #1176, startup still decoded 952,620 ahead-current records during layout validation, discarded their keys, then scanned and decoded the same records again to rebuild three in-memory indexes one entry at a time.

This change reuses the first pass and avoids repeated ordered-tree mutations while preserving the existing ordering: reconstructed indexes are complete before unclean-close cleanup runs.

## Local R3 result

Three-sample warm-cache, clean-close medians on the `m` workload:

- Jazz open: 1,104 ms → 832 ms (-24.6%)
- Current-state validation and reconstruction: 1,103 ms → 831 ms (-24.7%)
- Standalone ahead-current rebuild: 763 ms → eliminated
- Total reopen plus first read: 1,459 ms → 1,149 ms (-21.2%)

The optimization still performs work proportional to ahead-current entries and temporarily retains decoded keys during bulk construction.

## Validation

- Full Jazz suite: 730 passed, 1 ignored
- Focused recovery subset in ordinary and attributed builds
- 300-seed M3 differential oracle
- TypeScript wire codec gate: 86 passed, 1 skipped
- R3 attributed benchmark compilation
- Jazz simulation bench compilation
- Full local smoke benchmark suite
- Repository pre-commit Clippy, rustfmt, oxfmt, and sensitive-data gates
- `git diff --check`