### PR TITLE
(new core) chore: improve Rust build time and artifact size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,7 @@ dependencies = [
  "serde",
  "sha2 0.11.0",
  "smol_str",
- "thiserror 2.0.18",
+ "thiserror",
  "tinyvec",
  "tracing",
  "unicode-segmentation",
@@ -215,14 +215,14 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.9"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "async-trait",
  "axum-core",
  "base64 0.22.1",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
@@ -235,15 +235,14 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite 0.24.0",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -252,19 +251,17 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
- "async-trait",
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
  "sync_wrapper",
  "tower-layer",
  "tower-service",
@@ -595,7 +592,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -1419,7 +1416,7 @@ dependencies = [
  "serde",
  "smallvec",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "uuid",
  "web-time",
 ]
@@ -1558,7 +1555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f4ecba0bb4e14df997df7cab6d1b584c6432d8865cf2adfced814706d715a7b"
 dependencies = [
  "leb128",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -1975,15 +1972,15 @@ dependencies = [
  "sha2 0.10.9",
  "smallvec",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
- "tokio-tungstenite 0.29.0",
+ "tokio-tungstenite",
  "tower",
- "tower-http 0.5.2",
+ "tower-http",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
- "tungstenite 0.29.0",
+ "tungstenite",
  "uuid",
  "web-time",
  "zstd",
@@ -2329,9 +2326,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -2681,7 +2678,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
@@ -2724,7 +2721,7 @@ dependencies = [
  "prost",
  "reqwest",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tonic",
  "tracing",
@@ -2770,7 +2767,7 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "rand 0.9.2",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-stream",
 ]
@@ -2785,7 +2782,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -3005,7 +3002,7 @@ dependencies = [
  "spin 0.10.0",
  "symbolic-demangle",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -3116,7 +3113,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -3137,7 +3134,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3398,14 +3395,12 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tokio-util",
  "tower",
- "tower-http 0.6.8",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.6",
 ]
@@ -3858,7 +3853,7 @@ checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
 ]
 
@@ -4068,31 +4063,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -4190,7 +4165,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -4232,18 +4206,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.24.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
@@ -4255,7 +4217,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite 0.29.0",
+ "tungstenite",
  "webpki-roots 0.26.11",
 ]
 
@@ -4347,23 +4309,6 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
-dependencies = [
- "bitflags 2.11.0",
- "bytes",
- "http",
- "http-body",
- "http-body-util",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
@@ -4378,6 +4323,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4398,7 +4344,6 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4478,24 +4423,6 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "rand 0.8.5",
- "sha1",
- "thiserror 1.0.69",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
@@ -4509,7 +4436,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -4581,12 +4508,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -4804,19 +4725,6 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
-]
-
-[[package]]
-name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,19 @@ rustc-hash = "2.1.1"
 [patch.crates-io]
 rust-rocksdb = { git = "https://github.com/zaidoon1/rust-rocksdb.git", tag = "v0.48.0" }
 
+# Keep useful file/line information in normal dev and test builds without
+# generating full debugger metadata. Tests inherit the dev profile.
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.dev.package."*"]
+debug = false
+
+# Opt into full debugger metadata with `--profile debugging`.
+[profile.debugging]
+inherits = "dev"
+debug = true
+
 [profile.perf]
 inherits = "release"
 opt-level = 2

--- a/crates/jazz/Cargo.toml
+++ b/crates/jazz/Cargo.toml
@@ -21,14 +21,7 @@ server = [
   "dep:tokio-tungstenite",
   "dep:tungstenite",
 ]
-cli = [
-  "server",
-  "rocksdb",
-  "dep:clap",
-  "dep:mimalloc",
-  "tokio/rt-multi-thread",
-  "tokio/signal",
-]
+cli = ["server", "rocksdb", "dep:clap", "dep:mimalloc", "tokio/rt-multi-thread", "tokio/signal"]
 sync-autopsy = []
 # Disabled-by-default counters for the cold-settle attribution bench. They do
 # not alter protocol behavior or production measurement paths.
@@ -74,13 +67,7 @@ jsonschema = { version = "0.42", default-features = false }
 internment = "0.8"
 smallvec = { version = "1.11", features = ["serde"] }
 sha2 = "0.10"
-tokio = { version = "1", features = [
-  "macros",
-  "net",
-  "rt",
-  "sync",
-  "time",
-], optional = true }
+tokio = { version = "1", features = ["macros", "net", "rt", "sync", "time"], optional = true }
 rocksdb = { package = "rust-rocksdb", version = "0.48.0", default-features = false, features = [
   "lz4",
   "zstd",
@@ -112,10 +99,7 @@ tower-http = { version = "0.6.8", default-features = false, features = [
   "trace",
 ], optional = true }
 async-stream = { version = "0.3", optional = true }
-jsonwebtoken = { version = "10.4", default-features = false, features = [
-  "rust_crypto",
-  "use_pem",
-] }
+jsonwebtoken = { version = "10.4", default-features = false, features = ["rust_crypto", "use_pem"] }
 base64 = "0.22"
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 mimalloc = { version = "0.1", default-features = false, optional = true }
@@ -147,15 +131,9 @@ opentelemetry_sdk = { version = "0.31", features = ["testing"] }
 criterion = "0.5"
 insta = "1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-reqwest = { version = "0.12", default-features = false, features = [
-  "json",
-  "rustls-tls",
-] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 bytes = "1"
-jsonwebtoken = { version = "10.4", default-features = false, features = [
-  "rust_crypto",
-  "use_pem",
-] }
+jsonwebtoken = { version = "10.4", default-features = false, features = ["rust_crypto", "use_pem"] }
 futures = "0.3"
 tokio = { version = "1", features = [
   "macros",

--- a/crates/jazz/Cargo.toml
+++ b/crates/jazz/Cargo.toml
@@ -21,7 +21,14 @@ server = [
   "dep:tokio-tungstenite",
   "dep:tungstenite",
 ]
-cli = ["server", "rocksdb", "dep:clap", "dep:mimalloc"]
+cli = [
+  "server",
+  "rocksdb",
+  "dep:clap",
+  "dep:mimalloc",
+  "tokio/rt-multi-thread",
+  "tokio/signal",
+]
 sync-autopsy = []
 # Disabled-by-default counters for the cold-settle attribution bench. They do
 # not alter protocol behavior or production measurement paths.
@@ -67,17 +74,32 @@ jsonschema = { version = "0.42", default-features = false }
 internment = "0.8"
 smallvec = { version = "1.11", features = ["serde"] }
 sha2 = "0.10"
-tokio = { version = "1", features = ["full"], optional = true }
+tokio = { version = "1", features = [
+  "macros",
+  "net",
+  "rt",
+  "sync",
+  "time",
+], optional = true }
 rocksdb = { package = "rust-rocksdb", version = "0.48.0", default-features = false, features = [
   "lz4",
   "zstd",
 ], optional = true }
 rusqlite = { version = "0.34", features = ["bundled"], optional = true }
-axum = { version = "0.7", features = ["ws"], optional = true }
-tokio-tungstenite = { version = "0.29", features = [
+axum = { version = "0.8.9", default-features = false, features = [
+  "http1",
+  "json",
+  "matched-path",
+  "original-uri",
+  "query",
+  "tokio",
+  "tracing",
+  "ws",
+], optional = true }
+tokio-tungstenite = { version = "0.29", default-features = false, features = [
+  "connect",
   "rustls-tls-native-roots",
   "rustls-tls-webpki-roots",
-  "handshake",
 ], optional = true }
 tungstenite = { version = "0.29", default-features = false, features = [
   "handshake",
@@ -85,15 +107,20 @@ tungstenite = { version = "0.29", default-features = false, features = [
 bytes = { version = "1", optional = true }
 clap = { version = "4", features = ["derive", "env"], optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
-tower-http = { version = "0.5", features = ["cors", "trace"], optional = true }
+tower-http = { version = "0.6.8", default-features = false, features = [
+  "cors",
+  "trace",
+], optional = true }
 async-stream = { version = "0.3", optional = true }
-jsonwebtoken = { version = "10.4", features = ["rust_crypto"] }
+jsonwebtoken = { version = "10.4", default-features = false, features = [
+  "rust_crypto",
+  "use_pem",
+] }
 base64 = "0.22"
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 mimalloc = { version = "0.1", default-features = false, optional = true }
 reqwest = { version = "0.12", default-features = false, features = [
   "json",
-  "stream",
   "rustls-tls",
 ], optional = true }
 opentelemetry = { version = "0.31", optional = true }
@@ -122,13 +149,23 @@ insta = "1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 reqwest = { version = "0.12", default-features = false, features = [
   "json",
-  "stream",
   "rustls-tls",
 ] }
 bytes = "1"
-jsonwebtoken = { version = "10.4", features = ["rust_crypto"] }
+jsonwebtoken = { version = "10.4", default-features = false, features = [
+  "rust_crypto",
+  "use_pem",
+] }
 futures = "0.3"
-tokio = { version = "1", features = ["test-util", "full"] }
+tokio = { version = "1", features = [
+  "macros",
+  "net",
+  "rt",
+  "rt-multi-thread",
+  "sync",
+  "test-util",
+  "time",
+] }
 tower = { version = "0.5", features = ["util"] }
 rcgen = { version = "0.13", default-features = false, features = ["ring"] }
 

--- a/crates/jazz/src/tools/middleware/auth.rs
+++ b/crates/jazz/src/tools/middleware/auth.rs
@@ -26,7 +26,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use axum::{
-    async_trait,
     extract::FromRequestParts,
     http::{HeaderMap, StatusCode, header::AUTHORIZATION, request::Parts},
 };
@@ -542,7 +541,6 @@ fn read_auth_token_from_cookie<'a>(headers: &'a HeaderMap, config: &AuthConfig) 
 #[allow(dead_code)]
 pub struct JwtAuth(pub Option<Session>);
 
-#[async_trait]
 impl FromRequestParts<Arc<ServerState>> for JwtAuth {
     type Rejection = (StatusCode, String);
 
@@ -596,7 +594,6 @@ impl FromRequestParts<Arc<ServerState>> for JwtAuth {
 #[allow(dead_code)]
 pub struct BackendAuth(pub Option<String>);
 
-#[async_trait]
 impl<S> FromRequestParts<S> for BackendAuth
 where
     S: Send + Sync,
@@ -617,7 +614,6 @@ where
 #[allow(dead_code)]
 pub struct AdminAuth(pub Option<String>);
 
-#[async_trait]
 impl<S> FromRequestParts<S> for AdminAuth
 where
     S: Send + Sync,
@@ -643,7 +639,6 @@ where
 #[allow(dead_code)]
 pub struct RequestSession(pub Option<Session>);
 
-#[async_trait]
 impl FromRequestParts<Arc<ServerState>> for RequestSession {
     type Rejection = (StatusCode, String);
 

--- a/crates/jazz/src/tools/server/routes/mod.rs
+++ b/crates/jazz/src/tools/server/routes/mod.rs
@@ -98,7 +98,7 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
         );
     let traced_routes = Router::new()
         .route("/ws", axum::routing::any(ws_handler))
-        .route("/schema/:hash", get(schema_handler))
+        .route("/schema/{hash}", get(schema_handler))
         .route("/schemas", get(schema_hashes_handler))
         .nest("/admin", admin_routes)
         .route_layer(middleware::from_fn_with_state(
@@ -111,7 +111,7 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
     Router::new()
         .route("/health", get(health_handler))
         .route("/internal/shutdown", post(internal_shutdown_handler))
-        .nest("/apps/:app_id", traced_routes)
+        .nest("/apps/{app_id}", traced_routes)
         .layer(CorsLayer::permissive())
         .with_state(state)
 }
@@ -616,7 +616,7 @@ mod tests {
                 }),
             )
             .route(
-                &test_app_route("/schema/:hash"),
+                &test_app_route("/schema/{hash}"),
                 get({
                     let forwarded = forwarded_for_router.clone();
                     move |Path(hash): Path<String>, headers: HeaderMap| {

--- a/crates/jazz/src/tools/server/routes/websocket.rs
+++ b/crates/jazz/src/tools/server/routes/websocket.rs
@@ -24,6 +24,7 @@ use axum::{
     http::HeaderMap,
     response::{IntoResponse, Response},
 };
+use futures::SinkExt as _;
 use tokio::sync::mpsc;
 
 use crate::tools::public_schema::AuthMode;
@@ -765,7 +766,7 @@ async fn send_ws_encoded_frames(
             "server websocket send batch bytes={}",
             batch.len()
         ));
-        socket.send(Message::Binary(batch)).await?;
+        socket.send(Message::Binary(batch.into())).await?;
     }
     Ok(())
 }
@@ -845,8 +846,8 @@ mod tests {
     use crate::wire::FEATURE_STRUCTURED_ERRORS;
     use crate::wire::decode_frame;
     use crate::wire::{TransportError, WireTransport};
+    use futures::StreamExt as _;
     use futures::stream::FuturesUnordered;
-    use futures::{SinkExt as _, StreamExt as _};
     use tokio_tungstenite::{connect_async, tungstenite::Message as WsMessage};
 
     use crate::tools::AppId;

--- a/dev/scripts/clippy-staged.mjs
+++ b/dev/scripts/clippy-staged.mjs
@@ -1,0 +1,93 @@
+// Scoped clippy: maps changed files to their owning crate via
+// and runs `cargo clippy --package <crate>` for each affected
+// crate instead of the whole workspace. Falls back to a full
+// --workspace run when a workspace-root file (Cargo.toml/Cargo.lock)
+// changes
+
+import { execFileSync, spawnSync } from "node:child_process";
+import path from "node:path";
+
+const workspaceRoot = process.cwd();
+const dryRun = process.argv[2] === "--dry-run";
+
+const stagedFiles = dryRun
+  ? process.argv.slice(3)
+  : execFileSync("git", ["diff", "--cached", "--name-only", "--diff-filter=ACMRD", "-z"], {
+      encoding: "buffer",
+    })
+      .toString("utf8")
+      .split("\0")
+      .filter(Boolean);
+
+const clippyInputs = stagedFiles.filter(
+  (file) => file.endsWith(".rs") || path.basename(file) === "Cargo.toml",
+);
+
+if (clippyInputs.length === 0) {
+  console.log("Clippy: no staged Rust or Cargo.toml changes");
+  process.exit(0);
+}
+
+const metadata = JSON.parse(
+  execFileSync("cargo", ["metadata", "--no-deps", "--format-version", "1"], { encoding: "utf8" }),
+);
+const workspaceMemberIds = new Set(metadata.workspace_members);
+const workspacePackages = metadata.packages
+  .filter((pkg) => workspaceMemberIds.has(pkg.id))
+  .map((pkg) => ({
+    name: pkg.name,
+    directory: path.dirname(pkg.manifest_path),
+  }))
+  .sort((left, right) => right.directory.length - left.directory.length);
+
+const rootManifest = path.join(workspaceRoot, "Cargo.toml");
+const packages = new Set();
+let lintWorkspace = false;
+
+for (const file of clippyInputs) {
+  const absoluteFile = path.resolve(workspaceRoot, file);
+  if (absoluteFile === rootManifest) {
+    lintWorkspace = true;
+    break;
+  }
+
+  const owningPackage = workspacePackages.find(({ directory }) => {
+    const relativePath = path.relative(directory, absoluteFile);
+    return (
+      relativePath === "" ||
+      (!relativePath.startsWith(`..${path.sep}`) &&
+        relativePath !== ".." &&
+        !path.isAbsolute(relativePath))
+    );
+  });
+
+  if (owningPackage) {
+    packages.add(owningPackage.name);
+  } else {
+    // Preserve the old hook's coverage for Rust files outside known packages.
+    lintWorkspace = true;
+    break;
+  }
+}
+
+const cargoArgs = ["clippy"];
+if (lintWorkspace) {
+  cargoArgs.push("--workspace");
+} else {
+  for (const packageName of [...packages].sort()) {
+    cargoArgs.push("--package", packageName);
+  }
+}
+cargoArgs.push("--", "-D", "warnings");
+
+console.log(`Clippy: cargo ${cargoArgs.join(" ")}`);
+if (dryRun) {
+  process.exit(0);
+}
+
+const result = spawnSync("cargo", cargoArgs, { stdio: "inherit" });
+if (result.error) {
+  console.error(`Failed to run Cargo: ${result.error.message}`);
+  process.exit(1);
+}
+process.exit(result.status ?? 1);

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -15,8 +15,11 @@ pre-commit:
       run: cargo fmt
       stage_fixed: true
     clippy:
-      glob: "*.rs"
-      run: cargo clippy --workspace -- -D warnings
+      glob:
+        - "*.rs"
+        - "Cargo.toml"
+        - "**/Cargo.toml"
+      run: node dev/scripts/clippy-staged.mjs
     oxfmt:
       glob: "*.{ts,tsx,js,jsx,md,mdx,json,html}"
       exclude: "dev/benchmarks/SMOKE_LEDGER.md"


### PR DESCRIPTION
## Description

Adds a few optimization to reduce Rust build times and the size of generated artifacts:
- dev/test builds now use `line-table-only` debug information
- minimize rust dependency features to speed up compilation

Current branch is substantially better for development builds; release builds are roughly unchanged:

Metric | codex/jazz-core-engine-swap | Current branch | Change
-- | -- | -- | --
Cold debug build | 107.99s | 73.16s | −32.3%
Cold release build | 130.86s | 128.46s | −1.8%
Debug .node | 114.18 MB | 99.18 MB | −13.1%
Debug .node, gzip | 25.18 MB | 22.06 MB | −12.4%
Release .node | 38.91 MB | 38.67 MB | −238,528 bytes / −0.6%
Release .node, gzip | 14.13 MB | 14.06 MB | −69,794 bytes / −0.5%
Debug target footprint | 5.49 GiB | 2.03 GiB | −63.0%
Release target footprint | 0.956 GiB | 0.943 GiB | −1.4%

This PR also modifies the pre-commit hook to only run Clippy on modified crates (instead of in all of them). CI still runs Clippy for all crates.