### PR TITLE
(new core) Reject scalar `in` candidates for array columns instead of silently matching nothing

### DIFF
--- a/crates/jazz-tools/tests/query_membership_filters.rs
+++ b/crates/jazz-tools/tests/query_membership_filters.rs
@@ -1,7 +1,8 @@
 #![cfg(feature = "test")]
 
 use jazz_tools::{
-    ColumnType, JazzClient, QueryBuilder, Schema, SchemaBuilder, TableSchema, Value, row_input,
+    ColumnType, JazzClient, ObjectId, QueryBuilder, Schema, SchemaBuilder, TableSchema, Value,
+    row_input,
 };
 
 fn membership_schema() -> Schema {
@@ -240,6 +241,52 @@ async fn invalid_membership_filters_return_type_errors() {
             assert!(
                 wrong_in_type.to_string().contains("operand type mismatch"),
                 "unexpected in error: {wrong_in_type}"
+            );
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn in_filter_rejects_scalar_candidate_for_array_column() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let client = JazzClient::test_client(membership_schema()).await;
+            client
+                .insert(
+                    "items",
+                    row_input!(
+                        "title" => "array member",
+                        "count" => 1,
+                        "score" => 1.5,
+                        "active" => true,
+                        "owner_id" => ObjectId::new(),
+                        "counts" => Value::Array(vec![Value::Integer(3)]),
+                        "flags" => Value::Array(vec![Value::Boolean(true)]),
+                        "watcher_ids" => Value::Array(Vec::new()),
+                    ),
+                )
+                .expect("insert item with array value");
+
+            let error = client
+                .query(
+                    QueryBuilder::new("items")
+                        .filter_in("counts", vec![Value::Integer(3)])
+                        .build(),
+                    None,
+                )
+                .await
+                .expect_err(
+                    "a scalar in candidate for an array column must fail validation, not return no rows",
+                );
+
+            let message = error.to_string();
+            assert!(
+                message.contains("counts"),
+                "validation error should name the array column: {message}"
+            );
+            assert!(
+                message.contains("Array") && message.contains("I32"),
+                "validation error should name the array/scalar type mismatch: {message}"
             );
         })
         .await;

--- a/crates/jazz/SPEC/6_queries.md
+++ b/crates/jazz/SPEC/6_queries.md
@@ -121,8 +121,12 @@ Supported matrix:
 
 Invalid operator/type combinations must be rejected before execution with a
 clear type error. In particular, `contains` on a scalar non-text column is never
-interpreted as stringification, and `in` candidates must match the column type
-except for the narrow compatibility coercions listed above. The broader
+interpreted as stringification, and `in` candidates (including parameters) must
+match the column's whole-value type except for the narrow compatibility
+coercions listed above. Thus an `Array<T>` `in` candidate must itself be an
+array; a scalar `T` is rejected rather than being rewritten as a singleton array
+or a `contains` predicate. Compatibility coercions may recurse into an
+array-valued literal only when they preserve that array shape. The broader
 literal-vs-column coercion policy remains intentionally unspecified; new
 coercions need an explicit spec decision before implementation.
 

--- a/crates/jazz/SPEC/6_queries.md
+++ b/crates/jazz/SPEC/6_queries.md
@@ -130,6 +130,20 @@ array-valued literal only when they preserve that array shape. The broader
 literal-vs-column coercion policy remains intentionally unspecified; new
 coercions need an explicit spec decision before implementation.
 
+🔶 **Open question: a subset/superset predicate over array columns.** Rejecting
+a scalar `in` candidate for `Array<T>` is correct, but it is worth naming why
+that shape gets written at all. `in` gives whole-value membership and `contains`
+gives single-element membership; there is currently nothing for "this array
+contains all of these" or "this array is contained by these". A user wanting
+that has no operator to reach for, and `in` with a list of elements is the
+natural wrong guess.
+
+If we add the capability it MUST be an explicit predicate with its own
+semantics — never an implicit reinterpretation of `in` that changes meaning
+depending on whether the column happens to be an array. The value of rejecting
+today is exactly that the gap stays visible, rather than being filled by a
+coercion whose meaning nobody chose (Anselm, 2026-07-29).
+
 ### 6.2 Shapes: validated, content-addressed, schema-stamped
 
 A shape is the validated, schema-stamped identity of a query. Validation

--- a/crates/jazz/src/query.rs
+++ b/crates/jazz/src/query.rs
@@ -2147,6 +2147,18 @@ pub enum QueryError {
     /// Operand types do not match.
     #[error("operand type mismatch")]
     OperandTypeMismatch,
+    /// An `in` candidate does not match its column's whole-value type.
+    #[error(
+        "in candidate for column {column} has type {candidate_type:?}, but the column has type {column_type:?}"
+    )]
+    InCandidateTypeMismatch {
+        /// Column on the left side of the `in` predicate.
+        column: String,
+        /// Declared type of that column.
+        column_type: ColumnType,
+        /// Type of the mismatched candidate.
+        candidate_type: ColumnType,
+    },
     /// Claim and column operand types do not match.
     #[error(
         "claim {claim_path} has type {claim_type:?}, but column {column} has type {column_type:?}"
@@ -2573,7 +2585,7 @@ fn validate_array_subquery(
     let child = table(schema, &subquery.table)?;
     let parent_type = planner_column_type(parent, &subquery.outer_column)?;
     let child_type = planner_column_type(&child, &subquery.inner_column)?;
-    if !in_operand_types_compatible(parent_type, child_type) {
+    if !array_correlation_types_compatible(parent_type, child_type) {
         return Err(QueryError::OperandTypeMismatch);
     }
     for predicate in &subquery.filters {
@@ -2738,14 +2750,12 @@ fn validate_predicate(
                         if !in_operand_types_compatible(&left_type, &value_type)
                             && !in_literal_value_coercible(&left_type, value) =>
                     {
-                        return Err(QueryError::OperandTypeMismatch);
+                        return Err(in_candidate_type_mismatch_error(
+                            left, left_type, value_type,
+                        ));
                     }
                     (Some(left_type), None) => {
-                        let expected = match non_null_column_type(&left_type) {
-                            ColumnType::Array(member) => *member,
-                            other => other,
-                        };
-                        infer_param(value, expected, params)?;
+                        infer_param(value, left_type, params)?;
                     }
                     (None, Some(value_type)) => infer_param(left, value_type, params)?,
                     (Some(_), Some(_)) => {}
@@ -2875,8 +2885,17 @@ fn in_operand_types_compatible(left: &ColumnType, right: &ColumnType) -> bool {
     {
         return true;
     }
-    match left {
-        ColumnType::Array(member) => column_types_comparable(&member, &right),
+    false
+}
+
+fn array_correlation_types_compatible(parent: &ColumnType, child: &ColumnType) -> bool {
+    if in_operand_types_compatible(parent, child) {
+        return true;
+    }
+    // Array-subquery correlation expands the parent array into child lookup
+    // keys; it is distinct from whole-value `Predicate::In` membership.
+    match non_null_column_type(parent) {
+        ColumnType::Array(member) => column_types_comparable(&member, child),
         _ => false,
     }
 }
@@ -2888,10 +2907,26 @@ fn in_literal_value_coercible(left: &ColumnType, value: &Operand) -> bool {
     match non_null_column_type(left) {
         ColumnType::String => matches!(value, Value::Uuid(_)),
         ColumnType::Enum(_) => matches!(value, Value::String(_) | Value::Uuid(_)),
-        ColumnType::Array(member) => {
+        ColumnType::Array(member) => matches!(value, Value::Array(values)
+        if values.iter().all(|value| {
             in_literal_value_coercible(&member, &Operand::Literal(value.clone()))
-        }
+        })),
         _ => false,
+    }
+}
+
+fn in_candidate_type_mismatch_error(
+    left: &Operand,
+    column_type: ColumnType,
+    candidate_type: ColumnType,
+) -> QueryError {
+    match left {
+        Operand::Column(column) => QueryError::InCandidateTypeMismatch {
+            column: column.clone(),
+            column_type,
+            candidate_type,
+        },
+        _ => QueryError::OperandTypeMismatch,
     }
 }
 


### PR DESCRIPTION
Addresses @joeinnes' review comment on #1141, which was merged before it was answered.

## The bug

For a column typed `Array<I32>`:

```rust
QueryBuilder::new("items").filter_in("counts", vec![Value::Integer(3)])
```

passed validation — the scalar `3` matches the *member* type of `Array<I32>` — and then matched nothing at runtime, because Groove compares the whole array value against a scalar. **Silently zero rows, which reads as "no data" rather than "malformed query".**

## The decision, and why not coercion

`filter_in` is whole-value membership: "is this column's value one of these candidates". For an array column the candidate must therefore itself be an array. A scalar is now rejected at validation with an error naming the column, the column type, and the candidate type (`counts`, `Array(I32)`, `I32`).

Coercing was tempting, but the user could plausibly have meant either of two things that **already have distinct operators**:

- `counts == [3]` — whole-array equality, `in` with `Value::Array([3])`
- `counts` contains `3` — element membership, which is what `contains` is for

So coercing would not be filling a gap; it would be silently guessing between two supported operators and returning a plausible wrong answer. Rejecting points the user at the operator they wanted.

Grounded in `INV-API-1` (validate before execution) and `INV-LOWER-11` (accepted predicates preserve semantics or are rejected). The rule is written into `SPEC/6_queries.md`, which also states explicitly that the broader literal-vs-column coercion policy stays unspecified and that new coercions need a spec decision first — so this settles the case without becoming a precedent to argue from.

## Open question recorded

A second commit records *why* this shape gets written at all: there is no subset/superset predicate over array columns. `in` gives whole-value membership, `contains` gives single-element membership, and nothing expresses "contains all of these". If we add it, it must be an explicit predicate — never an implicit reinterpretation of `in` that changes meaning based on column type. Rejecting today keeps that gap visible instead of filling it with a coercion nobody chose.

## Compatibility

Queries hitting this previously returned empty, so nothing could depend on them except code depending on "no results". New core is pre-release.

## Gates

`cargo test -p jazz`, `-p groove`, `-p jazz-server`, `cargo check -p jazz-sim --benches` all exit 0. The new membership regression passes directly.

`cargo test -p jazz-tools --features test` fails only `numeric_claims_match_integer_columns_across_core_widths`, which is red on `codex/jazz-core-engine-swap` itself and is fixed by #1159 — not caused by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RLK2isSYCQo5MaUG5PVVM