### PR TITLE
(new core) Preserve query order in subscription resets

### DIFF
--- a/crates/jazz/src/db/tests.rs
+++ b/crates/jazz/src/db/tests.rs
@@ -4775,6 +4775,34 @@ fn subscribe_uses_prepared_non_simple_plan() {
 }
 
 #[test]
+fn subscription_reset_preserves_ordered_window_rank() {
+    let schema = schema();
+    let author = AuthorId::from_bytes([0xa1; 16]);
+    let db = open_db(0xa3, author, &schema);
+    for (id, title) in [(4, "alpha"), (1, "bravo"), (3, "charlie"), (2, "delta")] {
+        db.seed_settled_mergeable_for_bootstrap(
+            "todos",
+            row(id),
+            author,
+            cells(title, false, author),
+        )
+        .unwrap();
+    }
+
+    let query = Query::from("todos")
+        .order_by("title", OrderDirection::Asc)
+        .offset(1)
+        .limit(2);
+    let mut subscription = prepared_subscribe(&db, &query, global_subscribe_opts()).unwrap();
+
+    assert_eq!(
+        row_ids(&opened_rows(block_on(subscription.next_event()).unwrap())),
+        vec![row(1), row(3)],
+        "reset rows must retain the selected ordered window rather than member-key order"
+    );
+}
+
+#[test]
 fn simple_prepared_current_write_query_uses_lowered_plan() {
     let schema = schema();
     let author = AuthorId::from_bytes([0xa1; 16]);

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -65,6 +65,7 @@ pub(crate) struct LocalMaintainedViewSubscription {
     maintained: MaintainedSubscriptionView,
     terminal_schemas: MaintainedTerminalSchemas,
     tables: BTreeMap<String, TableSchema>,
+    result_query: JazzQuery,
     result_table: String,
     result_select: Option<Vec<String>>,
     result_set: BTreeSet<ResultMemberEntry>,
@@ -4473,6 +4474,10 @@ where
             row_keys.insert((row.table().to_owned(), row.row_uuid()));
             rows.push(row);
         }
+        // Result-member ordering is for identity and deduplication, not public
+        // query rank. Membership/windowing is already lowered; only restore the
+        // selected roots to their advertised order before sending a reset.
+        self.apply_query_order(shape.query(), &mut rows)?;
         let root_count = rows.len();
         let mut edges = Vec::new();
         for fact in program_facts {
@@ -6412,6 +6417,7 @@ where
             maintained,
             terminal_schemas,
             tables,
+            result_query: shape.query().clone(),
             result_table: shape.query().table.clone(),
             result_select: shape.query().select.clone(),
             result_set: BTreeSet::new(),
@@ -6665,6 +6671,10 @@ where
                 rows.push(row);
             }
         }
+        // `result_set` is keyed by member identity, so its BTreeSet iteration
+        // order cannot be exposed as a query reset order. Do not re-window: the
+        // maintained program already chose this result set.
+        self.apply_query_order(&local.result_query, &mut rows)?;
         let root_count = rows.len();
         let mut edges = Vec::with_capacity(local.program_facts.len());
         for fact in &local.program_facts {
@@ -7573,6 +7583,9 @@ where
                 rows.push(self.materialize_current_row(&table, row)?);
             }
         }
+        // Multisink records are transport-key ordered. Restore public root rank
+        // while retaining the lowered program's membership and window.
+        self.apply_query_order(shape.query(), &mut rows)?;
         Ok(rows)
     }
 


### PR DESCRIPTION
Fixes the 10 browser-suite failures tracked as R2, in `packages/jazz-tools/tests/browser/db.subscribeAll.sort.test.ts`.

## The bug

The packed-reset fast path forwarded reset content in `chunk.delta.added` order — UUID/batch order — rather than the query's rank order. Eight of the ten failures were misordering. **Two (at lines 479 and 575) were window failures**, where a wrong limit/offset window yields a wrong *result set*, not merely a wrongly-ordered one.

## Fixed in core, deliberately not in the adapter

The obvious fix is to re-sort in the TypeScript adapter. That would have been wrong: it duplicates ordering semantics that core already owns — nulls, ties, and the encoded-bytes tie-break in `INV-QUERY-23` — and would drift from them over time. It is exactly the class of duplication `dev/TS_SEMANTIC_DUPLICATION_AUDIT.md` catalogues.

So core emits correctly-ordered reset content instead. The change is 13 lines in `crates/jazz/src/node/query_eval.rs` plus 28 lines of coverage in `crates/jazz/src/db/tests.rs` — additions only, no deletions.

## Provenance

Cherry-picked onto a clean base off `track/browser-consolidated`, deliberately leaving behind that branch's `WIP: bound recursive Inherits lowering` commit, which is unrelated and unfinished.

## Gates

`cargo test -p jazz`, `-p groove`, `-p jazz-server`, `cargo check -p jazz-sim --benches` — exit 0.

Because this changes delivery ordering, the mechanism gates were run explicitly rather than assumed:
- all three `incremental_delivery_canary` tests — ran and passed
- `JAZZ_SEED_COUNT=300 m3_maintained_one_shot_differential_oracle` — 1 passed, 107s

`cargo test -p jazz-tools --features test` fails only `numeric_claims_match_integer_columns_across_core_widths`, red on `codex/jazz-core-engine-swap` itself and fixed by #1159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RLK2isSYCQo5MaUG5PVVM