### PR TITLE
(new core) Handle SubscriptionEvent::Rejected in the jazz-sim policy test

### DIFF
--- a/crates/jazz-sim/tests/customer_child_policy_minimal.rs
+++ b/crates/jazz-sim/tests/customer_child_policy_minimal.rs
@@ -220,6 +220,9 @@ fn apply_event(rows: &mut BTreeSet<RowUuid>, event: SubscriptionEvent) {
                 rows.insert(row.row_uuid());
             }
         }
+        SubscriptionEvent::Rejected { reason } => {
+            panic!("subscription rejected unexpectedly: {reason:?}");
+        }
         SubscriptionEvent::Closed => {}
     }
 }


### PR DESCRIPTION
Three lines. `cargo check --workspace --all-targets` has been failing on a stale exhaustive match since `SubscriptionEvent::Rejected` was added.

Today that one gap independently blocked four separate pieces of work: the CI sweep, the crate consolidation, the #1180 review, and the #1162 follow-up. Each rediscovered it and worked around it.

The arm **panics** rather than ignoring the event. A rejected subscription in this test means the scenario never ran, and silently treating that as "no rows" would leave the test passing while measuring nothing.

`cargo check --workspace --all-targets` now exits 0, with 9 crates genuinely rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RLK2isSYCQo5MaUG5PVVM