### PR TITLE
(new core) Fix the redundant closure blocking the pre-commit clippy hook

### DIFF
--- a/crates/jazz-tools/src/client.rs
+++ b/crates/jazz-tools/src/client.rs
@@ -1736,7 +1736,7 @@ fn core_query_condition(
             column_operand(),
             values
                 .iter()
-                .map(|value| literal_operand(value))
+                .map(&literal_operand)
                 .collect::<Result<Vec<_>>>()?,
         ),
         PublicCondition::IsNull { .. } => jazz::query::is_null(column_operand()),


### PR DESCRIPTION
One line. `cargo clippy --workspace -- -D warnings` is the lefthook pre-commit step, and it has been failing at `crates/jazz-tools/src/client.rs:1739` since #1141 added the `in` handling.

Consequence: **every commit today went through with `--no-verify`**, which also skips the sensitive-data guard. The lanes each ran that guard manually and it passed, so nothing leaked — but it was only running because each one chose to, not because the hook enforced it.

```diff
-                .map(|value| literal_operand(value))
+                .map(&literal_operand)
```

`cargo clippy --workspace -- -D warnings` now exits 0, with 8 crates genuinely re-checked (verified by the `Checking` lines, not just the exit code — a cached clippy run reports success without linting anything).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RLK2isSYCQo5MaUG5PVVM