### PR TITLE
(new core) URGENT: repair the integration base compile break, and guard against a repeat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [main, codex/jazz-core-engine-swap]
   push:
-    branches: [main]
+    branches: [main, codex/jazz-core-engine-swap]
 
 concurrency:
   # For pushes, this lets concurrent runs happen, so each push gets a result.
@@ -17,6 +17,35 @@ env:
   CACHE_SCOPE_REPOSITORY_ID: ${{ github.event.pull_request.head.repo.id || github.repository_id }}
 
 jobs:
+  # Does the integration branch still compile after a merge?
+  #
+  # PR-level checks cannot answer this. Each PR is built against the base as it
+  # was, so two PRs that are individually green can merge cleanly and produce a
+  # tree that does not build. That happened on 2026-07-29: one PR removed
+  # `RecursionBound::iteration_cap`, another kept a call to it, neither
+  # conflicted, and `codex/jazz-core-engine-swap` was left unable to compile —
+  # unnoticed until it broke unrelated work hours later.
+  #
+  # Deliberately narrow. The full suites are not yet green, so gating on them
+  # would force routine overrides and make "red" meaningless. This checks the
+  # one property we can guarantee, and is fast and flake-free. Promote the other
+  # jobs to gates individually as each goes green.
+  build-integration:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: ./.github/actions/setup-build
+        with:
+          rust-targets: wasm32-unknown-unknown
+          sccache: "true"
+
+      - name: Install Rust prerequisites
+        run: pnpm run ensure:rust-toolchain
+
+      - run: cargo check --workspace --all-targets
+
   lint:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10

--- a/crates/jazz-sim/tests/customer_child_policy_minimal.rs
+++ b/crates/jazz-sim/tests/customer_child_policy_minimal.rs
@@ -220,6 +220,9 @@ fn apply_event(rows: &mut BTreeSet<RowUuid>, event: SubscriptionEvent) {
                 rows.insert(row.row_uuid());
             }
         }
+        SubscriptionEvent::Rejected { reason } => {
+            panic!("subscription rejected unexpectedly: {reason:?}");
+        }
         SubscriptionEvent::Closed => {}
     }
 }

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -3668,7 +3668,7 @@ impl InheritanceExpansionPath {
         let used = self.uses.get(&key).copied().unwrap_or(0);
         let limit = inherits
             .max_depth
-            .unwrap_or_else(|| crate::query::RecursionBound::default_max_depth().iteration_cap());
+            .unwrap_or_else(|| crate::query::RecursionBound::default_max_depth().depth_steps());
         if used >= limit {
             return None;
         }

--- a/crates/jazz/src/query.rs
+++ b/crates/jazz/src/query.rs
@@ -2149,6 +2149,20 @@ impl RecursionBound {
     pub fn default_max_depth() -> Self {
         Self::MaxDepth(8)
     }
+
+    /// This bound expressed as a step count.
+    ///
+    /// `Fixpoint` carries no user-facing depth, so it falls back to the
+    /// conservative loop cap used by evaluator paths that are not true
+    /// fixpoint. Restores the behaviour of the `iteration_cap` accessor removed
+    /// in c2db5a8e4, whose last caller survived the removal and left the crate
+    /// unable to compile.
+    pub(crate) fn depth_steps(self) -> usize {
+        match self {
+            Self::Fixpoint => 128,
+            Self::MaxDepth(max_depth) => max_depth.max(1),
+        }
+    }
 }
 
 /// Query predicate.


### PR DESCRIPTION
## The integration branch does not compile

`codex/jazz-core-engine-swap` at `1ce294908`:

```
error[E0599]: no method named `iteration_cap` found for enum `RecursionBound`
  --> crates/jazz/src/node/query_eval.rs:3671
```

`c2db5a8e4` ("Remove recompute metrics and stale query names") removed `RecursionBound::iteration_cap` while one call site survived. **Neither PR conflicted textually**, so both merged cleanly and produced a tree that does not build.

This is currently blocking every branch. Three separate pieces of work were failing `cargo test -p jazz` on it rather than on their own changes, and two independent lanes rediscovered it before it was traced.

## The fix

Restores the accessor as `depth_steps`, preserving the exact prior mapping — `Fixpoint => 128`, `MaxDepth(n) => n.max(1)` — with a doc comment naming the commit that removed it, so the next person understands why it exists.

If the removal intended the *call site* to change rather than the accessor to survive, that is a fine follow-up; this restores compilation without guessing at that intent.

## The guard

Adds a `build-integration` job running `cargo check --workspace --all-targets`, and extends the `push:` trigger to this branch.

**The integration branch has had no CI run since 2026-07-20**, because `push:` covered only `main`. So the merge *result* was never built. PR-level checks structurally cannot catch this class of break: each PR is built against the base as it was, not against the other PR landing beside it.

The job is **deliberately narrow**. The three existing suites are not green — a one-line clippy fix (#1185) failed all three — so gating on them would force routine overrides and make "red" mean nothing. This checks the one property we can currently guarantee, and is fast and flake-free. The others should be promoted to gates individually as each goes green; `lint` is closest.

## Verification

`cargo check -p jazz` exits 0 with the fix, having genuinely rebuilt (not a cached result). `cargo test -p jazz` and `cargo check --workspace --all-targets` were still running at push time given how much this blocks; I will confirm both on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RLK2isSYCQo5MaUG5PVVM