### PR TITLE
(new core) Fix the membership type-error assertion left red by #1182

### DIFF
--- a/crates/jazz-tools/tests/query_membership_filters.rs
+++ b/crates/jazz-tools/tests/query_membership_filters.rs
@@ -238,10 +238,17 @@ async fn invalid_membership_filters_return_type_errors() {
                 )
                 .await
                 .expect_err("in with mismatched candidate type should fail");
-            assert!(
-                wrong_in_type.to_string().contains("operand type mismatch"),
-                "unexpected in error: {wrong_in_type}"
-            );
+            // #1182 replaced the bare "operand type mismatch" with a message
+            // naming the column and both types. Assert on those parts rather
+            // than the old wording: it is what makes the error actionable, and
+            // it is strictly stronger than the string it replaced.
+            let wrong_in_message = wrong_in_type.to_string();
+            for expected in ["count", "String", "I32"] {
+                assert!(
+                    wrong_in_message.contains(expected),
+                    "in type-mismatch error should name {expected}: {wrong_in_message}"
+                );
+            }
         })
         .await;
 }


### PR DESCRIPTION
`invalid_membership_filters_return_type_errors` has been **red on `codex/jazz-core-engine-swap` since #1182 merged**. Verified on the base at `a65e0aa71`: 3 passed, 1 failed.

#1182 deliberately replaced the bare `"operand type mismatch"` with a message naming the column and both types:

```
in candidate for column count has type String, but the column has type I32
```

The test still asserted on the old wording. Its intent — a mismatched `in` candidate must be rejected — is unaffected; it now asserts the error names the column and both types, which is **stronger** than the string it replaces.

## How I missed it

The lane that ran gates for #1182 reported `jazz-tools exit=101` and attributed it to the then-known `numeric_claims_match_integer_columns_across_core_widths` red. **Two tests were failing and only one was named**, and I took the attribution instead of enumerating the failure list myself. Exactly the verification gap I had been catching in other lanes all day.

Worth noting the new `build-integration` CI job added in #1186 would not have caught this either — it runs `cargo check --workspace --all-targets`, which compiles but does not run tests. That job was scoped narrowly on purpose; this is a concrete example of what it does not cover.

`cargo test -p jazz-tools --features test --test query_membership_filters` now exits 0 with all 4 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RLK2isSYCQo5MaUG5PVVM