### PR TITLE
(new core) Persistent lane worktrees, with a guard against destroying unpushed work

### DIFF
--- a/dev/lanes/lane.sh
+++ b/dev/lanes/lane.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Persistent lane worktrees.
+#
+# Lanes used to be created per task and never removed. With each carrying its
+# own Cargo `target/`, ~28 of them filled a 1.8 TB disk mid-run — three times.
+# A fixed pool bounds that, and reusing a lane keeps `target/` and
+# `node_modules` warm, which also avoids the `ts-wire-codec` false-failures
+# that fresh worktrees produce when they have no `node_modules`.
+#
+#   lane.sh acquire <branch> [base]   reset a free lane onto a new branch, print its path
+#   lane.sh list                      show every lane, its branch, and whether it is busy
+#   lane.sh reset <path> <branch> [base]
+#
+# A lane is "busy" if a codex process is running with it as cwd. Acquire never
+# takes a busy lane, so concurrency is capped at LANE_COUNT — which is the
+# point: 8 lanes x 6 build jobs already oversubscribes a 32-core box.
+set -euo pipefail
+
+LANE_ROOT="${LANE_ROOT:-/work}"
+LANE_COUNT="${LANE_COUNT:-8}"
+MAIN="${MAIN:-/work/jazz_core}"
+DEFAULT_BASE="${DEFAULT_BASE:-origin/codex/jazz-core-engine-swap}"
+
+lane_path() { echo "$LANE_ROOT/lane-$1"; }
+
+lane_busy() {
+  local path="$1" p cwd
+  for p in $(pgrep -f "codex exec" 2>/dev/null || true); do
+    cwd=$(readlink "/proc/$p/cwd" 2>/dev/null || true)
+    [ "$cwd" = "$path" ] && return 0
+  done
+  return 1
+}
+
+# Reset a lane to a fresh branch. Deliberately keeps target/ and node_modules:
+# they are the whole reason a pool beats fresh worktrees, and neither can carry
+# source state between lanes.
+#
+# The workspace crates ARE cleaned. Reusing their artifacts across branches
+# produced `error[E0460]: found possibly newer version of crate opfs_btree`,
+# which fails an entire test binary at once and reads like 32 test failures
+# rather than a build-cache problem. Third-party dependencies — the bulk of the
+# build and the whole point of keeping target/ — are untouched.
+lane_reset() {
+  local path="$1" branch="$2" base="${3:-$DEFAULT_BASE}"
+  git -C "$MAIN" fetch -q origin
+  git -C "$path" reset -q --hard
+  git -C "$path" clean -qfdx -e target -e node_modules
+  git -C "$path" checkout -q -B "$branch" "$base"
+  if [ -d "$path/target" ]; then
+    (cd "$path" && cargo clean -q -p jazz -p groove -p opfs-btree \
+        -p jazz-sim -p jazz-napi -p jazz-wasm 2>/dev/null || true)
+  fi
+  echo "$path"
+}
+
+cmd_ensure() {
+  local i path
+  for i in $(seq 1 "$LANE_COUNT"); do
+    path=$(lane_path "$i")
+    if [ ! -d "$path" ]; then
+      git -C "$MAIN" worktree add -q --detach "$path" "$DEFAULT_BASE"
+      echo "created $path"
+    fi
+  done
+}
+
+# A lane holding work that exists nowhere else must not be reset. Finished
+# lanes have repeatedly sat unpushed — one carried a fix for ten browser test
+# failures for a day — and reset would destroy them silently. Checks committed
+# work not on any remote, and uncommitted changes.
+lane_has_unsaved_work() {
+  local path="$1" branch
+  [ -d "$path" ] || return 1
+  [ -n "$(git -C "$path" status --porcelain 2>/dev/null)" ] && return 0
+  branch=$(git -C "$path" rev-parse --abbrev-ref HEAD 2>/dev/null)
+  [ "$branch" = "HEAD" ] && return 1
+  # HEAD, not --branches: --branches spans every local branch in the repo, so
+  # unpushed work in any unrelated worktree would flag every lane.
+  [ -n "$(git -C "$path" log --oneline HEAD --not --remotes -1 2>/dev/null)" ]
+}
+
+cmd_acquire() {
+  local branch="${1:?usage: lane.sh acquire <branch> [base]}" base="${2:-$DEFAULT_BASE}"
+  cmd_ensure >/dev/null
+  local i path skipped=0
+  for i in $(seq 1 "$LANE_COUNT"); do
+    path=$(lane_path "$i")
+    lane_busy "$path" && continue
+    if [ "${LANE_FORCE:-0}" != "1" ] && lane_has_unsaved_work "$path"; then
+      echo "skipping $path: unpushed or uncommitted work" >&2
+      skipped=$((skipped + 1))
+      continue
+    fi
+    lane_reset "$path" "$branch" "$base"
+    return 0
+  done
+  echo "no free lane (${skipped} held unsaved work; push them, or LANE_FORCE=1 to override)" >&2
+  return 1
+}
+
+cmd_list() {
+  local i path branch state
+  for i in $(seq 1 "$LANE_COUNT"); do
+    path=$(lane_path "$i")
+    if [ ! -d "$path" ]; then
+      printf "lane-%-3s %-44s %s\n" "$i" "(not created)" "-"
+      continue
+    fi
+    branch=$(git -C "$path" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "?")
+    state=$(lane_busy "$path" && echo BUSY || echo free)
+    printf "lane-%-3s %-44s %s\n" "$i" "$branch" "$state"
+  done
+}
+
+case "${1:-}" in
+  ensure)  shift; cmd_ensure "$@" ;;
+  acquire) shift; cmd_acquire "$@" ;;
+  reset)   shift; lane_reset "$@" ;;
+  list)    shift; cmd_list "$@" ;;
+  *) sed -n '2,20p' "$0" >&2; exit 2 ;;
+esac


### PR DESCRIPTION
Dev tooling for orchestrating parallel work across git worktrees. Lives beside `dev/gates/`.

## Why

Lanes were created per task and never removed. Each carries its own Cargo `target/`, and ~28 of them filled a 1.8 TB disk **mid-run** — the third such incident, and the first on a machine large enough that it should not have been possible. A fixed pool of 8 bounds it, and reuse keeps `target/` and `node_modules` warm, which also removes the `ts-wire-codec` and `oxfmt` failures that fresh worktrees produce simply by having no `node_modules`.

## Two hazards found while building it, both encoded in the script

**Stale workspace artifacts.** Reusing `target/` across branches produced `error[E0460]: found possibly newer version of crate opfs_btree`, which kills an entire test binary and **presents as 32 test failures** rather than a build-cache problem. `lane_reset` now `cargo clean`s the workspace crates while leaving third-party dependencies — the bulk of the build, and the whole reason to keep `target/`.

**Destroying work that exists nowhere else.** Reset would silently wipe a lane holding unpushed commits. Not hypothetical: four finished lanes sat unpushed for a day, one of them a fix for ten browser test failures. `acquire` now skips any lane with uncommitted changes or commits unreachable from a remote, and says so. `LANE_FORCE=1` overrides.

The unpushed-detection predicate deliberately uses `HEAD` rather than `--branches`: `--branches` spans every local branch in the repository, so unpushed work in an unrelated worktree would flag every lane and make the guard useless. Verified against both a planted positive and a negative.

## Usage

```sh
dev/lanes/lane.sh acquire <branch> [base]   # reset a free lane, print its path
dev/lanes/lane.sh list                      # branch + busy/free per lane
```

A lane counts as busy if a process is running with it as cwd, so concurrency is capped at 8 — which is deliberate: 8 lanes at `-j 6` already oversubscribes a 32-core box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RLK2isSYCQo5MaUG5PVVM