### PR TITLE
(new core) perf: avoid rebuilding ahead-current indexes

### DIFF
--- a/crates/jazz/Cargo.toml
+++ b/crates/jazz/Cargo.toml
@@ -26,6 +26,7 @@ sync-autopsy = []
 # Disabled-by-default counters for the cold-settle attribution bench. They do
 # not alter protocol behavior or production measurement paths.
 cold-settle-attribution = ["groove/cold-settle-attribution"]
+r3-open-attribution = ["rocksdb", "testing"]
 testing = []
 transport-compression-lz4 = ["dep:lz4_flex"]
 transport-compression-zstd = ["dep:zstd"]

--- a/crates/jazz/benches/realistic_phase1.rs
+++ b/crates/jazz/benches/realistic_phase1.rs
@@ -1142,7 +1142,6 @@ struct R3OpenBreakdown {
     recover_pending_and_rejected: Duration,
     recover_unclean_close: Duration,
     recover_known_state: Duration,
-    rebuild_ahead_current: Duration,
     finalize_catalogue: Duration,
     validated_current_rows: usize,
     accepted_global_sequences: usize,
@@ -1305,7 +1304,6 @@ fn open_rocks_db_with_phases(
                 recover_pending_and_rejected: receipt.recover_pending_and_rejected,
                 recover_unclean_close: receipt.recover_unclean_close,
                 recover_known_state: receipt.recover_known_state,
-                rebuild_ahead_current: receipt.rebuild_ahead_current,
                 finalize_catalogue: receipt.finalize_catalogue,
                 validated_current_rows: receipt.validated_current_rows,
                 accepted_global_sequences: receipt.accepted_global_sequences,
@@ -1486,10 +1484,6 @@ fn emit_r3_phase_receipts(path: &Path, project: RowUuid, selected: R3Profile) {
                 "recover_known_state_p50_us": median_open_us(
                     &samples,
                     |receipt| receipt.recover_known_state,
-                ),
-                "rebuild_ahead_current_p50_us": median_open_us(
-                    &samples,
-                    |receipt| receipt.rebuild_ahead_current,
                 ),
                 "finalize_catalogue_p50_us": median_open_us(
                     &samples,

--- a/crates/jazz/benches/realistic_phase1.rs
+++ b/crates/jazz/benches/realistic_phase1.rs
@@ -10,12 +10,12 @@ use std::cell::RefCell;
 use std::collections::{BTreeMap, VecDeque};
 #[cfg(feature = "rocksdb")]
 use std::env;
-#[cfg(all(feature = "rocksdb", target_os = "linux"))]
+#[cfg(feature = "rocksdb")]
 use std::fs;
 #[cfg(all(feature = "rocksdb", target_os = "linux"))]
 use std::os::fd::AsRawFd;
 #[cfg(feature = "rocksdb")]
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::rc::Rc;
 #[cfg(feature = "rocksdb")]
 use std::time::{Duration, Instant};
@@ -1115,6 +1115,9 @@ fn r3_profiles() -> Vec<R3Profile> {
 struct R3PhaseSample {
     storage_open: Duration,
     jazz_open: Duration,
+    memory_before_jazz_open: Option<R3ProcessMemory>,
+    memory_after_jazz_open: Option<R3ProcessMemory>,
+    memory_after_first_read: Option<R3ProcessMemory>,
     open_breakdown: Option<R3OpenBreakdown>,
     prepare: Duration,
     first_read: Duration,
@@ -1127,6 +1130,34 @@ struct R3PhaseSample {
     first_read_apply_projection: Duration,
     first_read_unattributed: Duration,
     rows: usize,
+}
+
+#[cfg(feature = "rocksdb")]
+#[derive(Clone, Copy, Debug)]
+struct R3ProcessMemory {
+    resident_bytes: u64,
+    peak_resident_bytes: u64,
+}
+
+#[cfg(all(feature = "rocksdb", target_os = "linux"))]
+fn r3_process_memory() -> Option<R3ProcessMemory> {
+    let status = fs::read_to_string("/proc/self/status").ok()?;
+    let kib = |name: &str| {
+        status
+            .lines()
+            .find_map(|line| line.strip_prefix(name))
+            .and_then(|value| value.split_whitespace().next())
+            .and_then(|value| value.parse::<u64>().ok())
+    };
+    Some(R3ProcessMemory {
+        resident_bytes: kib("VmRSS:")?.saturating_mul(1024),
+        peak_resident_bytes: kib("VmHWM:")?.saturating_mul(1024),
+    })
+}
+
+#[cfg(all(feature = "rocksdb", not(target_os = "linux")))]
+fn r3_process_memory() -> Option<R3ProcessMemory> {
+    None
 }
 
 #[cfg(feature = "rocksdb")]
@@ -1263,7 +1294,14 @@ fn open_rocks_db_with_phases(
     seed: u64,
     author: AuthorId,
     path: &Path,
-) -> (RocksBenchDb, Duration, Duration, Option<R3OpenBreakdown>) {
+) -> (
+    RocksBenchDb,
+    Duration,
+    Duration,
+    Option<R3ProcessMemory>,
+    Option<R3ProcessMemory>,
+    Option<R3OpenBreakdown>,
+) {
     let schema = schema();
     let column_families = schema.column_families();
     let refs = column_families
@@ -1286,6 +1324,7 @@ fn open_rocks_db_with_phases(
     )
     .with_id_source(SeededRowIdSource::new(seed));
 
+    let memory_before_jazz_open = r3_process_memory();
     let jazz_started = Instant::now();
     #[cfg(feature = "r3-open-attribution")]
     let (db, open_breakdown) = {
@@ -1318,8 +1357,16 @@ fn open_rocks_db_with_phases(
         None,
     );
     let jazz_open = jazz_started.elapsed();
+    let memory_after_jazz_open = r3_process_memory();
 
-    (db, storage_open, jazz_open, open_breakdown)
+    (
+        db,
+        storage_open,
+        jazz_open,
+        memory_before_jazz_open,
+        memory_after_jazz_open,
+        open_breakdown,
+    )
 }
 
 #[cfg(feature = "rocksdb")]
@@ -1334,8 +1381,14 @@ fn measure_r3_phase_sample(
     if matches!(cache_mode, R3CacheMode::Evicted) {
         evict_path_from_linux_page_cache(path);
     }
-    let (db, storage_open, jazz_open, open_breakdown) =
-        open_rocks_db_with_phases(R3_REOPEN_SEED, AUTHOR, path);
+    let (
+        db,
+        storage_open,
+        jazz_open,
+        memory_before_jazz_open,
+        memory_after_jazz_open,
+        open_breakdown,
+    ) = open_rocks_db_with_phases(R3_REOPEN_SEED, AUTHOR, path);
 
     let prepare_started = Instant::now();
     let query = project_board_query(&db, project);
@@ -1346,6 +1399,7 @@ fn measure_r3_phase_sample(
         .read_profiled(&query)
         .expect("read warm-cache project board");
     let first_read = read_started.elapsed();
+    let memory_after_first_read = r3_process_memory();
     assert_eq!(
         rows.len(),
         expected_rows,
@@ -1359,6 +1413,9 @@ fn measure_r3_phase_sample(
     R3PhaseSample {
         storage_open,
         jazz_open,
+        memory_before_jazz_open,
+        memory_after_jazz_open,
+        memory_after_first_read,
         open_breakdown,
         prepare,
         first_read,
@@ -1411,6 +1468,19 @@ fn median_us(samples: &[R3PhaseSample], phase: impl Fn(&R3PhaseSample) -> Durati
 }
 
 #[cfg(feature = "rocksdb")]
+fn median_memory_bytes(
+    samples: &[R3PhaseSample],
+    memory: impl Fn(&R3PhaseSample) -> Option<u64>,
+) -> Option<u64> {
+    let mut values = samples.iter().filter_map(memory).collect::<Vec<_>>();
+    if values.is_empty() {
+        return None;
+    }
+    values.sort_unstable();
+    Some(values[values.len() / 2])
+}
+
+#[cfg(feature = "rocksdb")]
 fn emit_r3_phase_receipts(path: &Path, project: RowUuid, selected: R3Profile) {
     let sample_count = env::var("JAZZ_R3_PHASE_SAMPLES")
         .ok()
@@ -1419,7 +1489,9 @@ fn emit_r3_phase_receipts(path: &Path, project: RowUuid, selected: R3Profile) {
         .max(1);
     let expected_rows = selected.profile.tasks.div_ceil(selected.profile.projects);
     for close_mode in r3_close_modes() {
-        establish_r3_close_mode(path, close_mode);
+        if env::var_os("JAZZ_R3_SKIP_CLOSE_MODE_SETUP").is_none() {
+            establish_r3_close_mode(path, close_mode);
+        }
         for cache_mode in r3_cache_modes() {
             let samples = (0..sample_count)
                 .map(|sample| {
@@ -1457,6 +1529,28 @@ fn emit_r3_phase_receipts(path: &Path, project: RowUuid, selected: R3Profile) {
                 }),
                 "storage_open_p50_us": median_us(&samples, |sample| sample.storage_open),
                 "jazz_open_p50_us": median_us(&samples, |sample| sample.jazz_open),
+                "rss_before_jazz_open_p50_bytes": median_memory_bytes(&samples, |sample| {
+                    sample.memory_before_jazz_open.map(|memory| memory.resident_bytes)
+                }),
+                "rss_after_jazz_open_p50_bytes": median_memory_bytes(&samples, |sample| {
+                    sample.memory_after_jazz_open.map(|memory| memory.resident_bytes)
+                }),
+                "rss_after_first_read_p50_bytes": median_memory_bytes(&samples, |sample| {
+                    sample.memory_after_first_read.map(|memory| memory.resident_bytes)
+                }),
+                "rss_jazz_open_delta_p50_bytes": median_memory_bytes(&samples, |sample| {
+                    Some(
+                        sample
+                            .memory_after_jazz_open?
+                            .resident_bytes
+                            .saturating_sub(sample.memory_before_jazz_open?.resident_bytes),
+                    )
+                }),
+                "peak_rss_p50_bytes": median_memory_bytes(&samples, |sample| {
+                    sample
+                        .memory_after_first_read
+                        .map(|memory| memory.peak_resident_bytes)
+                }),
                 "catalogue_open_p50_us": median_open_us(&samples, |receipt| receipt.catalogue_open),
                 "database_open_p50_us": median_open_us(&samples, |receipt| receipt.database_open),
                 "state_init_p50_us": median_open_us(&samples, |receipt| receipt.state_init),
@@ -1527,13 +1621,49 @@ fn r3_rocksdb_cold_load(c: &mut Criterion) {
 
     for selected in r3_profiles() {
         let profile = selected.profile;
-        let tempdir = TempDir::new().expect("create tempdir for RocksDB cold-load bench");
-        let db_path = tempdir.path().join("realistic_phase1.rocksdb");
-        let project = {
+        let persistent_fixture_dir = env::var_os("JAZZ_R3_FIXTURE_DIR").map(PathBuf::from);
+        let tempdir = persistent_fixture_dir
+            .is_none()
+            .then(|| TempDir::new().expect("create tempdir for RocksDB cold-load bench"));
+        let fixture_dir = persistent_fixture_dir.unwrap_or_else(|| {
+            tempdir
+                .as_ref()
+                .expect("R3 temporary fixture directory")
+                .path()
+                .to_path_buf()
+        });
+        fs::create_dir_all(&fixture_dir).expect("create R3 fixture directory");
+        let db_path = fixture_dir.join(format!("realistic_phase1_{}.rocksdb", selected.id));
+        let project_path =
+            fixture_dir.join(format!("realistic_phase1_{}.project.json", selected.id));
+        let project = if project_path.exists() {
+            serde_json::from_slice::<RowUuid>(
+                &fs::read(&project_path).expect("read persisted R3 fixture project"),
+            )
+            .expect("decode persisted R3 fixture project")
+        } else {
             let db = open_rocks_db_with_author(30, AUTHOR, false, &db_path);
             let fixture = seed_fixture(&db, profile);
-            fixture.projects[0]
+            let project = fixture.projects[0];
+            fs::write(
+                &project_path,
+                serde_json::to_vec(&project).expect("encode R3 fixture project"),
+            )
+            .expect("persist R3 fixture project");
+            project
         };
+        if env::var_os("JAZZ_R3_SEED_ONLY").is_some() {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "scenario": "r3_rocksdb_fixture_seed",
+                    "profile": selected.id,
+                    "fixture_dir": fixture_dir,
+                    "project": project,
+                })
+            );
+            continue;
+        }
         let expected_rows = profile.tasks.div_ceil(profile.projects);
         emit_r3_phase_receipts(&db_path, project, selected);
 

--- a/crates/jazz/benches/realistic_phase1.rs
+++ b/crates/jazz/benches/realistic_phase1.rs
@@ -4,6 +4,7 @@
 //! the legacy `RuntimeCore`, `SchemaManager`, or `SyncManager` stack.
 
 #![allow(clippy::single_element_loop, dead_code)]
+#![recursion_limit = "256"]
 
 use std::cell::RefCell;
 use std::collections::{BTreeMap, VecDeque};
@@ -46,6 +47,8 @@ type RocksBenchDb = Db<RocksDbStorage>;
 
 const AUTHOR: AuthorId = AuthorId(uuid::uuid!("00000000-0000-0000-0000-0000000000a1"));
 const READER_AUTHOR: AuthorId = AuthorId(uuid::uuid!("00000000-0000-0000-0000-0000000000b2"));
+#[cfg(feature = "rocksdb")]
+const R3_REOPEN_SEED: u64 = 31;
 
 #[derive(Debug, Clone, Copy)]
 struct SmallProfile {
@@ -1112,6 +1115,7 @@ fn r3_profiles() -> Vec<R3Profile> {
 struct R3PhaseSample {
     storage_open: Duration,
     jazz_open: Duration,
+    open_breakdown: Option<R3OpenBreakdown>,
     prepare: Duration,
     first_read: Duration,
     first_read_resolve_view: Duration,
@@ -1126,10 +1130,65 @@ struct R3PhaseSample {
 }
 
 #[cfg(feature = "rocksdb")]
+#[derive(Debug)]
+struct R3OpenBreakdown {
+    catalogue_open: Duration,
+    database_open: Duration,
+    state_init: Duration,
+    recover_storage: Duration,
+    recover_catalogue_state: Duration,
+    validate_current_rows: Duration,
+    recover_global_sequences: Duration,
+    recover_pending_and_rejected: Duration,
+    recover_unclean_close: Duration,
+    recover_known_state: Duration,
+    rebuild_ahead_current: Duration,
+    finalize_catalogue: Duration,
+    validated_current_rows: usize,
+    accepted_global_sequences: usize,
+    global_sequence_records_scanned: usize,
+    ahead_current_entries: usize,
+}
+
+#[cfg(feature = "rocksdb")]
 #[derive(Clone, Copy)]
 enum R3CacheMode {
     Warm,
     Evicted,
+}
+
+#[cfg(feature = "rocksdb")]
+#[derive(Clone, Copy)]
+enum R3CloseMode {
+    Clean,
+    Unclean,
+}
+
+#[cfg(feature = "rocksdb")]
+impl R3CloseMode {
+    fn id(self) -> &'static str {
+        match self {
+            Self::Clean => "db_close",
+            Self::Unclean => "drop_without_close",
+        }
+    }
+}
+
+#[cfg(feature = "rocksdb")]
+fn r3_close_modes() -> Vec<R3CloseMode> {
+    let requested = env::var("JAZZ_R3_CLOSE_MODES").unwrap_or_else(|_| "unclean".to_owned());
+    requested
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| match value {
+            "clean" => R3CloseMode::Clean,
+            "unclean" => R3CloseMode::Unclean,
+            other => panic!(
+                "unknown JAZZ_R3_CLOSE_MODES entry {other:?}; expected a comma-separated subset of clean,unclean"
+            ),
+        })
+        .collect()
 }
 
 #[cfg(feature = "rocksdb")]
@@ -1204,9 +1263,8 @@ fn evict_path_from_linux_page_cache(_path: &Path) {
 fn open_rocks_db_with_phases(
     seed: u64,
     author: AuthorId,
-    history_complete: bool,
     path: &Path,
-) -> (RocksBenchDb, Duration, Duration) {
+) -> (RocksBenchDb, Duration, Duration, Option<R3OpenBreakdown>) {
     let schema = schema();
     let column_families = schema.column_families();
     let refs = column_families
@@ -1230,15 +1288,40 @@ fn open_rocks_db_with_phases(
     .with_id_source(SeededRowIdSource::new(seed));
 
     let jazz_started = Instant::now();
-    let opened = if history_complete {
-        block_on(Db::open_history_complete(config))
-    } else {
-        block_on(Db::open(config))
+    #[cfg(feature = "r3-open-attribution")]
+    let (db, open_breakdown) = {
+        let (db, receipt) = block_on(Db::open_with_receipt_for_test(config))
+            .expect("open attributed core realistic RocksDB phase receipt db");
+        (
+            db,
+            Some(R3OpenBreakdown {
+                catalogue_open: receipt.catalogue_open,
+                database_open: receipt.database_open,
+                state_init: receipt.state_init,
+                recover_storage: receipt.recover_storage,
+                recover_catalogue_state: receipt.recover_catalogue_state,
+                validate_current_rows: receipt.validate_current_rows,
+                recover_global_sequences: receipt.recover_global_sequences,
+                recover_pending_and_rejected: receipt.recover_pending_and_rejected,
+                recover_unclean_close: receipt.recover_unclean_close,
+                recover_known_state: receipt.recover_known_state,
+                rebuild_ahead_current: receipt.rebuild_ahead_current,
+                finalize_catalogue: receipt.finalize_catalogue,
+                validated_current_rows: receipt.validated_current_rows,
+                accepted_global_sequences: receipt.accepted_global_sequences,
+                global_sequence_records_scanned: receipt.global_sequence_records_scanned,
+                ahead_current_entries: receipt.ahead_current_entries,
+            }),
+        )
     };
-    let db = opened.expect("open core realistic RocksDB phase receipt db");
+    #[cfg(not(feature = "r3-open-attribution"))]
+    let (db, open_breakdown) = (
+        block_on(Db::open(config)).expect("open core realistic RocksDB phase receipt db"),
+        None,
+    );
     let jazz_open = jazz_started.elapsed();
 
-    (db, storage_open, jazz_open)
+    (db, storage_open, jazz_open, open_breakdown)
 }
 
 #[cfg(feature = "rocksdb")]
@@ -1246,14 +1329,15 @@ fn measure_r3_phase_sample(
     path: &Path,
     project: RowUuid,
     expected_rows: usize,
-    sample: usize,
+    _sample: usize,
     cache_mode: R3CacheMode,
+    close_mode: R3CloseMode,
 ) -> R3PhaseSample {
     if matches!(cache_mode, R3CacheMode::Evicted) {
         evict_path_from_linux_page_cache(path);
     }
-    let (db, storage_open, jazz_open) =
-        open_rocks_db_with_phases(31 + sample as u64, AUTHOR, false, path);
+    let (db, storage_open, jazz_open, open_breakdown) =
+        open_rocks_db_with_phases(R3_REOPEN_SEED, AUTHOR, path);
 
     let prepare_started = Instant::now();
     let query = project_board_query(&db, project);
@@ -1269,10 +1353,15 @@ fn measure_r3_phase_sample(
         expected_rows,
         "R3 project-board result count changed"
     );
+    if matches!(close_mode, R3CloseMode::Clean) {
+        db.close()
+            .expect("close R3 phase receipt db after measured read");
+    }
 
     R3PhaseSample {
         storage_open,
         jazz_open,
+        open_breakdown,
         prepare,
         first_read,
         first_read_resolve_view: read_profile.resolve_view,
@@ -1285,6 +1374,32 @@ fn measure_r3_phase_sample(
         first_read_unattributed: first_read.saturating_sub(read_profile.total),
         rows: rows.len(),
     }
+}
+
+#[cfg(feature = "rocksdb")]
+fn establish_r3_close_mode(path: &Path, close_mode: R3CloseMode) {
+    let db = open_rocks_db_with_author(R3_REOPEN_SEED, AUTHOR, false, path);
+    if matches!(close_mode, R3CloseMode::Clean) {
+        db.close()
+            .expect("establish clean-close marker before R3 phase samples");
+    }
+}
+
+#[cfg(feature = "rocksdb")]
+fn median_open_us(
+    samples: &[R3PhaseSample],
+    phase: impl Fn(&R3OpenBreakdown) -> Duration,
+) -> Option<u64> {
+    let mut values = samples
+        .iter()
+        .filter_map(|sample| sample.open_breakdown.as_ref())
+        .map(|receipt| phase(receipt).as_micros().min(u64::MAX as u128) as u64)
+        .collect::<Vec<_>>();
+    if values.is_empty() {
+        return None;
+    }
+    values.sort_unstable();
+    Some(values[values.len() / 2])
 }
 
 #[cfg(feature = "rocksdb")]
@@ -1305,17 +1420,29 @@ fn emit_r3_phase_receipts(path: &Path, project: RowUuid, selected: R3Profile) {
         .unwrap_or(3)
         .max(1);
     let expected_rows = selected.profile.tasks.div_ceil(selected.profile.projects);
-    for cache_mode in r3_cache_modes() {
-        let samples = (0..sample_count)
-            .map(|sample| measure_r3_phase_sample(path, project, expected_rows, sample, cache_mode))
-            .collect::<Vec<_>>();
+    for close_mode in r3_close_modes() {
+        establish_r3_close_mode(path, close_mode);
+        for cache_mode in r3_cache_modes() {
+            let samples = (0..sample_count)
+                .map(|sample| {
+                    measure_r3_phase_sample(
+                        path,
+                        project,
+                        expected_rows,
+                        sample,
+                        cache_mode,
+                        close_mode,
+                    )
+                })
+                .collect::<Vec<_>>();
 
-        println!(
-            "{}",
-            serde_json::json!({
+            println!(
+                "{}",
+                serde_json::json!({
                 "scenario": "r3_rocksdb_cold_load",
                 "phase": cache_mode.phase(),
                 "cache_mode": cache_mode.id(),
+                "close_mode": close_mode.id(),
                 "profile": selected.id,
                 "users": selected.profile.users,
                 "organizations": selected.profile.organizations,
@@ -1332,6 +1459,58 @@ fn emit_r3_phase_receipts(path: &Path, project: RowUuid, selected: R3Profile) {
                 }),
                 "storage_open_p50_us": median_us(&samples, |sample| sample.storage_open),
                 "jazz_open_p50_us": median_us(&samples, |sample| sample.jazz_open),
+                "catalogue_open_p50_us": median_open_us(&samples, |receipt| receipt.catalogue_open),
+                "database_open_p50_us": median_open_us(&samples, |receipt| receipt.database_open),
+                "state_init_p50_us": median_open_us(&samples, |receipt| receipt.state_init),
+                "recover_storage_p50_us": median_open_us(&samples, |receipt| receipt.recover_storage),
+                "recover_catalogue_state_p50_us": median_open_us(
+                    &samples,
+                    |receipt| receipt.recover_catalogue_state,
+                ),
+                "validate_current_rows_p50_us": median_open_us(
+                    &samples,
+                    |receipt| receipt.validate_current_rows,
+                ),
+                "recover_global_sequences_p50_us": median_open_us(
+                    &samples,
+                    |receipt| receipt.recover_global_sequences,
+                ),
+                "recover_pending_and_rejected_p50_us": median_open_us(
+                    &samples,
+                    |receipt| receipt.recover_pending_and_rejected,
+                ),
+                "recover_unclean_close_p50_us": median_open_us(
+                    &samples,
+                    |receipt| receipt.recover_unclean_close,
+                ),
+                "recover_known_state_p50_us": median_open_us(
+                    &samples,
+                    |receipt| receipt.recover_known_state,
+                ),
+                "rebuild_ahead_current_p50_us": median_open_us(
+                    &samples,
+                    |receipt| receipt.rebuild_ahead_current,
+                ),
+                "finalize_catalogue_p50_us": median_open_us(
+                    &samples,
+                    |receipt| receipt.finalize_catalogue,
+                ),
+                "validated_current_rows": samples[0]
+                    .open_breakdown
+                    .as_ref()
+                    .map(|receipt| receipt.validated_current_rows),
+                "accepted_global_sequences": samples[0]
+                    .open_breakdown
+                    .as_ref()
+                    .map(|receipt| receipt.accepted_global_sequences),
+                "global_sequence_records_scanned": samples[0]
+                    .open_breakdown
+                    .as_ref()
+                    .map(|receipt| receipt.global_sequence_records_scanned),
+                "ahead_current_entries": samples[0]
+                    .open_breakdown
+                    .as_ref()
+                    .map(|receipt| receipt.ahead_current_entries),
                 "prepare_p50_us": median_us(&samples, |sample| sample.prepare),
                 "first_read_p50_us": median_us(&samples, |sample| sample.first_read),
                 "first_read_resolve_view_p50_us": median_us(&samples, |sample| sample.first_read_resolve_view),
@@ -1342,8 +1521,9 @@ fn emit_r3_phase_receipts(path: &Path, project: RowUuid, selected: R3Profile) {
                 "first_read_finish_rows_p50_us": median_us(&samples, |sample| sample.first_read_finish_rows),
                 "first_read_apply_projection_p50_us": median_us(&samples, |sample| sample.first_read_apply_projection),
                 "first_read_unattributed_p50_us": median_us(&samples, |sample| sample.first_read_unattributed),
-            })
-        );
+                })
+            );
+        }
     }
 }
 

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -36,6 +36,8 @@ const POST_TICK_HISTORY_WINDOW_BUDGET: usize = 4;
 
 use crate::ids::{AuthorId, NodeUuid, RowUuid, SchemaVersionId};
 pub use crate::node::CommitUnitTrust;
+#[cfg(feature = "testing")]
+pub use crate::node::NodeOpenReceipt as DbOpenReceipt;
 use crate::node::{
     CommitUnitIngestContext, CurrentRow, EdgeCacheBudget, LargeValueEditCommit, LargeValueEditOp,
     LocalMaintainedViewSubscription, LocalMaintainedViewSubscriptionUpdate, MergeableCommit,
@@ -420,6 +422,34 @@ where
             ),
             next_now_ms: Cell::new(1),
         })
+    }
+
+    #[cfg(feature = "testing")]
+    /// Open a database and return internal node-open phase timings for benchmarks.
+    pub async fn open_with_receipt_for_test(
+        config: DbConfig<S>,
+    ) -> Result<(Self, DbOpenReceipt), Error> {
+        let schema_version_id = config.schema.version_id();
+        let (node, receipt) = NodeState::new_with_open_receipt_for_test(
+            config.identity.node,
+            config.schema.clone(),
+            config.storage,
+            false,
+            config.large_value_checkpoint_op_interval,
+        )?;
+        let db = Self {
+            schema: config.schema,
+            schema_version_id,
+            identity: config.identity,
+            node: Node::new(node),
+            row_id_source: RefCell::new(
+                config
+                    .id_source
+                    .unwrap_or_else(|| Box::new(ProductionRowIdSource)),
+            ),
+            next_now_ms: Cell::new(1),
+        };
+        Ok((db, receipt))
     }
 
     /// Open a database as a history-complete serving core.

--- a/crates/jazz/src/node/ingest.rs
+++ b/crates/jazz/src/node/ingest.rs
@@ -4137,13 +4137,6 @@ where
                 .to_vec(),
             ),
         }
-        self.insert_ahead_current_key(
-            version.table().to_owned(),
-            version.layer(),
-            version.row_uuid(),
-            version.tx_time(),
-            version.tx_node_alias(),
-        );
         Ok(())
     }
 
@@ -4170,13 +4163,6 @@ where
             base_for_current_names,
         );
         batch.delete(table.as_ref(), history_primary_key(version));
-        self.remove_ahead_current_key(
-            version.table(),
-            version.layer(),
-            version.row_uuid(),
-            version.tx_time(),
-            version.tx_node_alias(),
-        );
         Ok(())
     }
 

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -1635,7 +1635,7 @@ where
     fn rebuild_ahead_current_keys(&mut self) -> Result<(), Error> {
         #[cfg(feature = "testing")]
         {
-            return self.rebuild_ahead_current_keys_inner(None);
+            self.rebuild_ahead_current_keys_inner(None)
         }
         #[cfg(not(feature = "testing"))]
         self.rebuild_ahead_current_keys_inner()

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -109,7 +109,7 @@ pub struct NodeOpenReceipt {
     pub recover_storage: Duration,
     /// Recover close markers, aliases, branches, and transaction-clock bounds.
     pub recover_catalogue_state: Duration,
-    /// Validate every persisted global-current and ahead-current row.
+    /// Validate persisted current rows and rebuild the ahead-current indexes.
     pub validate_current_rows: Duration,
     /// Recover the accepted-global-sequence watermark set.
     pub recover_global_sequences: Duration,
@@ -119,8 +119,6 @@ pub struct NodeOpenReceipt {
     pub recover_unclean_close: Duration,
     /// Recover persisted maintained-query known-state facts.
     pub recover_known_state: Duration,
-    /// Rebuild the in-memory ahead-current key indexes.
-    pub rebuild_ahead_current: Duration,
     /// Ensure aliases and persist any missing base catalogue records.
     pub finalize_catalogue: Duration,
     /// Current rows decoded by startup layout validation.
@@ -767,20 +765,6 @@ where
         #[cfg(feature = "testing")]
         if let (Some(receipt), Some(started)) = (&mut receipt, started) {
             receipt.recover_known_state = started.elapsed();
-        }
-        #[cfg(feature = "testing")]
-        let started = receipt.as_ref().map(|_| Instant::now());
-        #[cfg(feature = "testing")]
-        if let Some(receipt) = receipt.as_deref_mut() {
-            node.rebuild_ahead_current_keys_with_receipt(receipt)?;
-        } else {
-            node.rebuild_ahead_current_keys()?;
-        }
-        #[cfg(not(feature = "testing"))]
-        node.rebuild_ahead_current_keys()?;
-        #[cfg(feature = "testing")]
-        if let (Some(receipt), Some(started)) = (&mut receipt, started) {
-            receipt.rebuild_ahead_current = started.elapsed();
         }
         #[cfg(feature = "testing")]
         let started = receipt.as_ref().map(|_| Instant::now());
@@ -1632,86 +1616,6 @@ where
         self.local_layer_winner_tx_id(table, row_uuid, VersionLayer::Deletion)
     }
 
-    fn rebuild_ahead_current_keys(&mut self) -> Result<(), Error> {
-        #[cfg(feature = "testing")]
-        {
-            self.rebuild_ahead_current_keys_inner(None)
-        }
-        #[cfg(not(feature = "testing"))]
-        self.rebuild_ahead_current_keys_inner()
-    }
-
-    #[cfg(feature = "testing")]
-    fn rebuild_ahead_current_keys_with_receipt(
-        &mut self,
-        receipt: &mut NodeOpenReceipt,
-    ) -> Result<(), Error> {
-        self.rebuild_ahead_current_keys_inner(Some(receipt))
-    }
-
-    fn rebuild_ahead_current_keys_inner(
-        &mut self,
-        #[cfg(feature = "testing")] mut receipt: Option<&mut NodeOpenReceipt>,
-    ) -> Result<(), Error> {
-        self.ahead_current_keys.clear();
-        self.ahead_current_rows.clear();
-        self.ahead_current_latest.clear();
-        #[cfg(feature = "testing")]
-        let mut entries = 0usize;
-        for table in self.catalogue.schema.tables.clone() {
-            let storage_tables = table.ahead_current_storage_tables();
-            let content_rows = self
-                .database
-                .primary_key_scan_raw(&storage_tables[0].name, &[])?
-                .into_iter()
-                .map(|raw| raw.raw().to_vec())
-                .collect::<Vec<_>>();
-            let content_descriptor = storage_tables[0].record_schema();
-            for raw in content_rows {
-                #[cfg(feature = "testing")]
-                {
-                    entries += 1;
-                }
-                let record = BorrowedRecord::new(&raw, &content_descriptor);
-                self.insert_ahead_current_key(
-                    table.name.clone(),
-                    VersionLayer::Content,
-                    RowUuid(record.get_uuid(GlobalCurrentRowRecord::FIELD_ROW_UUID_IDX)?),
-                    TxTime(record.get_u64(GlobalCurrentRowRecord::FIELD_TX_TIME_IDX)?),
-                    NodeAlias(record.get_u64(GlobalCurrentRowRecord::FIELD_TX_NODE_ID_IDX)?),
-                );
-            }
-            let deletion_descriptor = storage_tables[1].record_schema();
-            let deletion_rows = self
-                .database
-                .primary_key_scan_raw(&storage_tables[1].name, &[])?
-                .into_iter()
-                .map(|raw| raw.raw().to_vec())
-                .collect::<Vec<_>>();
-            for raw in deletion_rows {
-                #[cfg(feature = "testing")]
-                {
-                    entries += 1;
-                }
-                let record = BorrowedRecord::new(&raw, &deletion_descriptor);
-                self.insert_ahead_current_key(
-                    table.name.clone(),
-                    VersionLayer::Deletion,
-                    RowUuid(record.get_uuid(RegisterGlobalCurrentRowRecord::FIELD_ROW_UUID_IDX)?),
-                    TxTime(record.get_u64(RegisterGlobalCurrentRowRecord::FIELD_TX_TIME_IDX)?),
-                    NodeAlias(
-                        record.get_u64(RegisterGlobalCurrentRowRecord::FIELD_TX_NODE_ID_IDX)?,
-                    ),
-                );
-            }
-        }
-        #[cfg(feature = "testing")]
-        if let Some(receipt) = &mut receipt {
-            receipt.ahead_current_entries = entries;
-        }
-        Ok(())
-    }
-
     fn insert_ahead_current_key(
         &mut self,
         table: String,
@@ -1731,6 +1635,37 @@ where
                 }
             })
             .or_insert((tx_time, tx_node_alias));
+    }
+
+    fn replace_ahead_current_keys(
+        &mut self,
+        mut keys: Vec<(String, VersionLayer, RowUuid, TxTime, NodeAlias)>,
+    ) {
+        keys.sort_unstable();
+        keys.dedup();
+
+        let mut rows = keys
+            .iter()
+            .map(|(table, _, row_uuid, _, _)| (table.clone(), *row_uuid))
+            .collect::<Vec<_>>();
+        rows.sort_unstable();
+        rows.dedup();
+
+        let mut latest = Vec::new();
+        for (table, layer, row_uuid, tx_time, tx_node_alias) in &keys {
+            let latest_key = (table.clone(), *layer, *row_uuid);
+            if let Some((previous_key, previous_value)) = latest.last_mut()
+                && *previous_key == latest_key
+            {
+                *previous_value = (*tx_time, *tx_node_alias);
+            } else {
+                latest.push((latest_key, (*tx_time, *tx_node_alias)));
+            }
+        }
+
+        self.ahead_current_rows = rows.into_iter().collect();
+        self.ahead_current_latest = latest.into_iter().collect();
+        self.ahead_current_keys = keys.into_iter().collect();
     }
 
     fn remove_ahead_current_key(

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -246,12 +246,6 @@ pub struct NodeState<S> {
     history_complete: bool,
     /// Mapping from stable node UUIDs to compact on-disk aliases.
     pub(crate) node_aliases: BTreeMap<NodeUuid, NodeAlias>,
-    /// Ahead-current overlay keys for rows whose non-global versions can affect local reads.
-    ahead_current_keys: BTreeSet<(String, VersionLayer, RowUuid, TxTime, NodeAlias)>,
-    /// Rows touched by the ahead-current overlay.
-    ahead_current_rows: BTreeSet<(String, RowUuid)>,
-    /// Latest ahead-current key per table/layer/row for local overlay reads.
-    ahead_current_latest: BTreeMap<(String, VersionLayer, RowUuid), (TxTime, NodeAlias)>,
     /// Minimum number of large-value ops replayed before storing a checkpoint.
     large_value_checkpoint_op_interval: usize,
     /// Runtime counters for large-value materialization and checkpoint behavior.
@@ -725,9 +719,6 @@ where
             groove_runtime_token: next_groove_runtime_token(),
             history_complete,
             node_aliases: BTreeMap::new(),
-            ahead_current_keys: BTreeSet::new(),
-            ahead_current_rows: BTreeSet::new(),
-            ahead_current_latest: BTreeMap::new(),
             large_value_checkpoint_op_interval: large_value_checkpoint_op_interval.max(1),
             large_value_metrics: LargeValueMetrics::default(),
             large_value_materialization_cache: BTreeMap::new(),
@@ -1616,109 +1607,6 @@ where
         self.local_layer_winner_tx_id(table, row_uuid, VersionLayer::Deletion)
     }
 
-    fn insert_ahead_current_key(
-        &mut self,
-        table: String,
-        layer: VersionLayer,
-        row_uuid: RowUuid,
-        tx_time: TxTime,
-        tx_node_alias: NodeAlias,
-    ) {
-        self.ahead_current_keys
-            .insert((table.clone(), layer, row_uuid, tx_time, tx_node_alias));
-        self.ahead_current_rows.insert((table.clone(), row_uuid));
-        self.ahead_current_latest
-            .entry((table, layer, row_uuid))
-            .and_modify(|latest| {
-                if (tx_time, tx_node_alias) > *latest {
-                    *latest = (tx_time, tx_node_alias);
-                }
-            })
-            .or_insert((tx_time, tx_node_alias));
-    }
-
-    fn replace_ahead_current_keys(
-        &mut self,
-        mut keys: Vec<(String, VersionLayer, RowUuid, TxTime, NodeAlias)>,
-    ) {
-        keys.sort_unstable();
-        keys.dedup();
-
-        let mut rows = keys
-            .iter()
-            .map(|(table, _, row_uuid, _, _)| (table.clone(), *row_uuid))
-            .collect::<Vec<_>>();
-        rows.sort_unstable();
-        rows.dedup();
-
-        let mut latest = Vec::new();
-        for (table, layer, row_uuid, tx_time, tx_node_alias) in &keys {
-            let latest_key = (table.clone(), *layer, *row_uuid);
-            if let Some((previous_key, previous_value)) = latest.last_mut()
-                && *previous_key == latest_key
-            {
-                *previous_value = (*tx_time, *tx_node_alias);
-            } else {
-                latest.push((latest_key, (*tx_time, *tx_node_alias)));
-            }
-        }
-
-        self.ahead_current_rows = rows.into_iter().collect();
-        self.ahead_current_latest = latest.into_iter().collect();
-        self.ahead_current_keys = keys.into_iter().collect();
-    }
-
-    fn remove_ahead_current_key(
-        &mut self,
-        table: &str,
-        layer: VersionLayer,
-        row_uuid: RowUuid,
-        tx_time: TxTime,
-        tx_node_alias: NodeAlias,
-    ) {
-        let table_key = table.to_owned();
-        self.ahead_current_keys.remove(&(
-            table_key.clone(),
-            layer,
-            row_uuid,
-            tx_time,
-            tx_node_alias,
-        ));
-        let latest_key = (table_key.clone(), layer, row_uuid);
-        if self.ahead_current_latest.get(&latest_key) == Some(&(tx_time, tx_node_alias)) {
-            let start = (table_key.clone(), layer, row_uuid, TxTime(0), NodeAlias(0));
-            let end = (
-                table_key.clone(),
-                layer,
-                row_uuid,
-                TxTime(u64::MAX),
-                NodeAlias(u64::MAX),
-            );
-            if let Some((_, _, _, next_time, next_alias)) = self
-                .ahead_current_keys
-                .range(start..=end)
-                .next_back()
-                .cloned()
-            {
-                self.ahead_current_latest
-                    .insert(latest_key, (next_time, next_alias));
-            } else {
-                self.ahead_current_latest.remove(&latest_key);
-            }
-        }
-        if !self.ahead_current_latest.contains_key(&(
-            table_key.clone(),
-            VersionLayer::Content,
-            row_uuid,
-        )) && !self.ahead_current_latest.contains_key(&(
-            table_key.clone(),
-            VersionLayer::Deletion,
-            row_uuid,
-        )) {
-            self.ahead_current_rows.remove(&(table_key, row_uuid));
-        }
-    }
-
     fn encode_large_value_cells(
         &mut self,
         table: &TableSchema,
@@ -2312,23 +2200,13 @@ where
             candidates.push((decode_current_row(table, record)?, tx));
         }
         let ahead_tables = table.ahead_current_storage_tables();
-        if let Some((tx_time, tx_node_alias)) = self
-            .ahead_current_latest
-            .get(&(table.name.clone(), VersionLayer::Content, row_uuid))
-            .copied()
+        if let Some(raw) = self
+            .database
+            .primary_key_last_raw(&ahead_tables[0].name, &[Value::Uuid(row_uuid.0)])?
         {
-            if let Some(raw) = self.database.primary_key_get_raw(
-                &ahead_tables[0].name,
-                &[
-                    Value::Uuid(row_uuid.0),
-                    Value::U64(tx_time.0),
-                    Value::U64(tx_node_alias.0),
-                ],
-            )? {
-                let record = raw.record();
-                let tx = self.current_record_sort_key(&table.name, row_uuid, record)?;
-                candidates.push((decode_current_row(table, record)?, tx));
-            }
+            let record = raw.record();
+            let tx = self.current_record_sort_key(&table.name, row_uuid, record)?;
+            candidates.push((decode_current_row(table, record)?, tx));
         }
         Ok(candidates.into_iter().max_by_key(|(_, tx)| *tx))
     }
@@ -2353,27 +2231,17 @@ where
             ));
         }
         let ahead_tables = table.ahead_current_storage_tables();
-        if let Some((tx_time, tx_node_alias)) = self
-            .ahead_current_latest
-            .get(&(table.name.clone(), VersionLayer::Deletion, row_uuid))
-            .copied()
+        if let Some(raw) = self
+            .database
+            .primary_key_last_raw(&ahead_tables[1].name, &[Value::Uuid(row_uuid.0)])?
         {
-            if let Some(raw) = self.database.primary_key_get_raw(
-                &ahead_tables[1].name,
-                &[
-                    Value::Uuid(row_uuid.0),
-                    Value::U64(tx_time.0),
-                    Value::U64(tx_node_alias.0),
-                ],
-            )? {
-                let record = raw.record();
-                candidates.push((
-                    deletion_event_from_value(
-                        record.get_idx(RegisterGlobalCurrentRowRecord::FIELD__DELETION_IDX)?,
-                    )?,
-                    self.current_record_sort_key(&table.name, row_uuid, record)?,
-                ));
-            }
+            let record = raw.record();
+            candidates.push((
+                deletion_event_from_value(
+                    record.get_idx(RegisterGlobalCurrentRowRecord::FIELD__DELETION_IDX)?,
+                )?,
+                self.current_record_sort_key(&table.name, row_uuid, record)?,
+            ));
         }
         Ok(candidates.into_iter().max_by_key(|(_, tx)| *tx))
     }

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -10,6 +10,10 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(feature = "testing")]
+use std::time::Duration;
+#[cfg(feature = "testing")]
+use web_time::Instant;
 
 use groove::db::{
     CommitMetrics, Database, DatabaseBatch, DirectRecordStoreWrite, Error as GrooveDbError,
@@ -90,6 +94,44 @@ use open_tx::*;
 use text_oplog::{Content as TextContent, Op as TextOp};
 
 pub use eviction::{EdgeCacheBudget, EdgeCacheBudgetReport, EdgeCacheClass, EvictColdReport};
+
+/// Test/bench-only attribution for the durable-state work performed while opening a node.
+#[cfg(feature = "testing")]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct NodeOpenReceipt {
+    /// Open the catalogue-only Groove database and recover schema metadata.
+    pub catalogue_open: Duration,
+    /// Lower the complete schema and construct the full Groove database.
+    pub database_open: Duration,
+    /// Allocate process-local node state.
+    pub state_init: Duration,
+    /// Recover aliases, clocks, branches, pending edges, and rejected transactions.
+    pub recover_storage: Duration,
+    /// Recover close markers, aliases, branches, and transaction-clock bounds.
+    pub recover_catalogue_state: Duration,
+    /// Validate every persisted global-current and ahead-current row.
+    pub validate_current_rows: Duration,
+    /// Recover the accepted-global-sequence watermark set.
+    pub recover_global_sequences: Duration,
+    /// Recover pending-edge and rejected-transaction state.
+    pub recover_pending_and_rejected: Duration,
+    /// Clean up inconsistent ahead-current leftovers after an unclean close.
+    pub recover_unclean_close: Duration,
+    /// Recover persisted maintained-query known-state facts.
+    pub recover_known_state: Duration,
+    /// Rebuild the in-memory ahead-current key indexes.
+    pub rebuild_ahead_current: Duration,
+    /// Ensure aliases and persist any missing base catalogue records.
+    pub finalize_catalogue: Duration,
+    /// Current rows decoded by startup layout validation.
+    pub validated_current_rows: usize,
+    /// Accepted global sequence records consumed during recovery.
+    pub accepted_global_sequences: usize,
+    /// Transaction-index records scanned while recovering global sequences.
+    pub global_sequence_records_scanned: usize,
+    /// Ahead-current records consumed while rebuilding in-memory indexes.
+    pub ahead_current_entries: usize,
+}
 
 #[cfg(test)]
 mod tests;
@@ -504,6 +546,30 @@ where
         )
     }
 
+    #[cfg(feature = "testing")]
+    /// Open a node and return phase timings for benchmark attribution.
+    pub fn new_with_open_receipt_for_test(
+        node_uuid: NodeUuid,
+        schema: JazzSchema,
+        storage: S,
+        history_complete: bool,
+        large_value_checkpoint_op_interval: usize,
+    ) -> Result<(Self, NodeOpenReceipt), Error>
+    where
+        S: ReopenableStorage,
+    {
+        let mut receipt = NodeOpenReceipt::default();
+        let node = Self::new_with_options_inner(
+            node_uuid,
+            schema,
+            storage,
+            history_complete,
+            large_value_checkpoint_op_interval,
+            Some(&mut receipt),
+        )?;
+        Ok((node, receipt))
+    }
+
     /// Rebuild the groove layer over the same storage using the standard open path.
     pub fn reopen_in_place(self) -> Result<Self, Error>
     where
@@ -550,7 +616,28 @@ where
         history_complete: bool,
         large_value_checkpoint_op_interval: usize,
     ) -> Result<Self, Error> {
+        Self::new_with_options_inner(
+            node_uuid,
+            schema,
+            storage,
+            history_complete,
+            large_value_checkpoint_op_interval,
+            #[cfg(feature = "testing")]
+            None,
+        )
+    }
+
+    fn new_with_options_inner(
+        node_uuid: NodeUuid,
+        schema: JazzSchema,
+        storage: S,
+        history_complete: bool,
+        large_value_checkpoint_op_interval: usize,
+        #[cfg(feature = "testing")] mut receipt: Option<&mut NodeOpenReceipt>,
+    ) -> Result<Self, Error> {
         let current_schema_version_id = schema.version_id();
+        #[cfg(feature = "testing")]
+        let started = receipt.as_ref().map(|_| Instant::now());
         let CatalogueOpenState {
             storage,
             mut schemas,
@@ -559,6 +646,10 @@ where
             partitions,
             branch_partitions,
         } = Self::open_catalogue_stage(schema.clone(), storage)?;
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, started) {
+            receipt.catalogue_open = started.elapsed();
+        }
         let had_base_schema = schemas.contains_key(&current_schema_version_id);
         if !had_base_schema {
             schemas.insert(
@@ -566,9 +657,17 @@ where
                 SchemaVersion::new(schema.clone()),
             );
         }
+        #[cfg(feature = "testing")]
+        let started = receipt.as_ref().map(|_| Instant::now());
         let database =
             Self::open_full_database(&schema, &schemas, &partitions, &branch_partitions, storage)?;
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, started) {
+            receipt.database_open = started.elapsed();
+        }
         let current_row_graphs = current_row_graphs(&schema);
+        #[cfg(feature = "testing")]
+        let started = receipt.as_ref().map(|_| Instant::now());
         let mut node = Self {
             node_uuid,
             self_node_alias: None,
@@ -644,9 +743,47 @@ where
             initial_sync_flush_active: false,
             initial_sync_flush_completed: false,
         };
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, started) {
+            receipt.state_init = started.elapsed();
+        }
+        #[cfg(feature = "testing")]
+        let started = receipt.as_ref().map(|_| Instant::now());
+        #[cfg(feature = "testing")]
+        if let Some(receipt) = receipt.as_deref_mut() {
+            node.recover_from_storage_with_receipt(receipt)?;
+        } else {
+            node.recover_from_storage()?;
+        }
+        #[cfg(not(feature = "testing"))]
         node.recover_from_storage()?;
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, started) {
+            receipt.recover_storage = started.elapsed();
+        }
+        #[cfg(feature = "testing")]
+        let started = receipt.as_ref().map(|_| Instant::now());
         node.recover_known_state_facts()?;
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, started) {
+            receipt.recover_known_state = started.elapsed();
+        }
+        #[cfg(feature = "testing")]
+        let started = receipt.as_ref().map(|_| Instant::now());
+        #[cfg(feature = "testing")]
+        if let Some(receipt) = receipt.as_deref_mut() {
+            node.rebuild_ahead_current_keys_with_receipt(receipt)?;
+        } else {
+            node.rebuild_ahead_current_keys()?;
+        }
+        #[cfg(not(feature = "testing"))]
         node.rebuild_ahead_current_keys()?;
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, started) {
+            receipt.rebuild_ahead_current = started.elapsed();
+        }
+        #[cfg(feature = "testing")]
+        let started = receipt.as_ref().map(|_| Instant::now());
         let self_node_alias = node.ensure_node_alias(node_uuid)?;
         node.self_node_alias = Some(self_node_alias);
         let schema_alias = node.ensure_schema_version_alias(current_schema_version_id)?;
@@ -656,6 +793,10 @@ where
         }
         for table in schema.tables.iter().map(|table| table.name.clone()) {
             node.persist_partition(table, current_schema_version_id)?;
+        }
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, started) {
+            receipt.finalize_catalogue = started.elapsed();
         }
         Ok(node)
     }
@@ -1492,9 +1633,31 @@ where
     }
 
     fn rebuild_ahead_current_keys(&mut self) -> Result<(), Error> {
+        #[cfg(feature = "testing")]
+        {
+            return self.rebuild_ahead_current_keys_inner(None);
+        }
+        #[cfg(not(feature = "testing"))]
+        self.rebuild_ahead_current_keys_inner()
+    }
+
+    #[cfg(feature = "testing")]
+    fn rebuild_ahead_current_keys_with_receipt(
+        &mut self,
+        receipt: &mut NodeOpenReceipt,
+    ) -> Result<(), Error> {
+        self.rebuild_ahead_current_keys_inner(Some(receipt))
+    }
+
+    fn rebuild_ahead_current_keys_inner(
+        &mut self,
+        #[cfg(feature = "testing")] mut receipt: Option<&mut NodeOpenReceipt>,
+    ) -> Result<(), Error> {
         self.ahead_current_keys.clear();
         self.ahead_current_rows.clear();
         self.ahead_current_latest.clear();
+        #[cfg(feature = "testing")]
+        let mut entries = 0usize;
         for table in self.catalogue.schema.tables.clone() {
             let storage_tables = table.ahead_current_storage_tables();
             let content_rows = self
@@ -1505,6 +1668,10 @@ where
                 .collect::<Vec<_>>();
             let content_descriptor = storage_tables[0].record_schema();
             for raw in content_rows {
+                #[cfg(feature = "testing")]
+                {
+                    entries += 1;
+                }
                 let record = BorrowedRecord::new(&raw, &content_descriptor);
                 self.insert_ahead_current_key(
                     table.name.clone(),
@@ -1522,6 +1689,10 @@ where
                 .map(|raw| raw.raw().to_vec())
                 .collect::<Vec<_>>();
             for raw in deletion_rows {
+                #[cfg(feature = "testing")]
+                {
+                    entries += 1;
+                }
                 let record = BorrowedRecord::new(&raw, &deletion_descriptor);
                 self.insert_ahead_current_key(
                     table.name.clone(),
@@ -1533,6 +1704,10 @@ where
                     ),
                 );
             }
+        }
+        #[cfg(feature = "testing")]
+        if let Some(receipt) = &mut receipt {
+            receipt.ahead_current_entries = entries;
         }
         Ok(())
     }

--- a/crates/jazz/src/node/recovery.rs
+++ b/crates/jazz/src/node/recovery.rs
@@ -130,19 +130,17 @@ where
         let mut validated_current_rows = 0usize;
         #[cfg(feature = "testing")]
         let mut ahead_current_entries = 0usize;
-        let mut recovered_ahead_current_keys = Vec::new();
         for table in self.catalogue.schema.tables.clone() {
             #[cfg(feature = "testing")]
             {
                 self.validate_current_row_storage_layout(
                     &table,
-                    &mut recovered_ahead_current_keys,
                     &mut validated_current_rows,
                     &mut ahead_current_entries,
                 )?;
             }
             #[cfg(not(feature = "testing"))]
-            self.validate_current_row_storage_layout(&table, &mut recovered_ahead_current_keys)?;
+            self.validate_current_row_storage_layout(&table)?;
             if let Some(raw) =
                 self.database
                     .index_last_raw(&history_table_name(&table.name), "by_tx", &[])?
@@ -160,7 +158,6 @@ where
                 ));
             }
         }
-        self.replace_ahead_current_keys(recovered_ahead_current_keys);
         #[cfg(feature = "testing")]
         if let (Some(receipt), Some(started)) = (&mut receipt, stage_started) {
             receipt.validate_current_rows = started.elapsed();
@@ -322,7 +319,6 @@ where
     fn validate_current_row_storage_layout(
         &mut self,
         table: &TableSchema,
-        ahead_current_keys: &mut Vec<(String, VersionLayer, RowUuid, TxTime, NodeAlias)>,
         #[cfg(feature = "testing")] rows: &mut usize,
         #[cfg(feature = "testing")] ahead_rows: &mut usize,
     ) -> Result<(), Error> {
@@ -339,21 +335,17 @@ where
         )?;
 
         let storage_tables = table.ahead_current_storage_tables();
-        self.validate_and_index_ahead_current_rows(
-            &table.name,
+        self.validate_ahead_current_rows(
             &storage_tables[0],
             VersionLayer::Content,
-            ahead_current_keys,
             #[cfg(feature = "testing")]
             rows,
             #[cfg(feature = "testing")]
             ahead_rows,
         )?;
-        self.validate_and_index_ahead_current_rows(
-            &table.name,
+        self.validate_ahead_current_rows(
             &storage_tables[1],
             VersionLayer::Deletion,
-            ahead_current_keys,
             #[cfg(feature = "testing")]
             rows,
             #[cfg(feature = "testing")]
@@ -362,12 +354,10 @@ where
         Ok(())
     }
 
-    fn validate_and_index_ahead_current_rows(
+    fn validate_ahead_current_rows(
         &mut self,
-        table: &str,
         storage_table: &groove::schema::TableSchema,
         layer: VersionLayer,
-        ahead_current_keys: &mut Vec<(String, VersionLayer, RowUuid, TxTime, NodeAlias)>,
         #[cfg(feature = "testing")] row_count: &mut usize,
         #[cfg(feature = "testing")] ahead_row_count: &mut usize,
     ) -> Result<(), Error> {
@@ -385,36 +375,25 @@ where
         }
         for raw in rows {
             let record = BorrowedRecord::new(&raw, &descriptor);
-            let (row_uuid, tx_time, tx_node_alias) = match layer {
+            match layer {
                 VersionLayer::Content => {
                     record.get_u64(GlobalCurrentRowRecord::FIELD_SCHEMA_VERSION_IDX)?;
                     record.get_idx(GlobalCurrentRowRecord::FIELD_PARENTS_IDX)?;
                     record.get_nullable_u64(GlobalCurrentRowRecord::FIELD_GLOBAL_SEQ_IDX)?;
-                    (
-                        record.get_uuid(GlobalCurrentRowRecord::FIELD_ROW_UUID_IDX)?,
-                        record.get_u64(GlobalCurrentRowRecord::FIELD_TX_TIME_IDX)?,
-                        record.get_u64(GlobalCurrentRowRecord::FIELD_TX_NODE_ID_IDX)?,
-                    )
+                    record.get_uuid(GlobalCurrentRowRecord::FIELD_ROW_UUID_IDX)?;
+                    record.get_u64(GlobalCurrentRowRecord::FIELD_TX_TIME_IDX)?;
+                    record.get_u64(GlobalCurrentRowRecord::FIELD_TX_NODE_ID_IDX)?;
                 }
                 VersionLayer::Deletion => {
                     record.get_u64(RegisterGlobalCurrentRowRecord::FIELD_SCHEMA_VERSION_IDX)?;
                     record.get_idx(RegisterGlobalCurrentRowRecord::FIELD_PARENTS_IDX)?;
                     record
                         .get_nullable_u64(RegisterGlobalCurrentRowRecord::FIELD_GLOBAL_SEQ_IDX)?;
-                    (
-                        record.get_uuid(RegisterGlobalCurrentRowRecord::FIELD_ROW_UUID_IDX)?,
-                        record.get_u64(RegisterGlobalCurrentRowRecord::FIELD_TX_TIME_IDX)?,
-                        record.get_u64(RegisterGlobalCurrentRowRecord::FIELD_TX_NODE_ID_IDX)?,
-                    )
+                    record.get_uuid(RegisterGlobalCurrentRowRecord::FIELD_ROW_UUID_IDX)?;
+                    record.get_u64(RegisterGlobalCurrentRowRecord::FIELD_TX_TIME_IDX)?;
+                    record.get_u64(RegisterGlobalCurrentRowRecord::FIELD_TX_NODE_ID_IDX)?;
                 }
-            };
-            ahead_current_keys.push((
-                table.to_owned(),
-                layer,
-                RowUuid(row_uuid),
-                TxTime(tx_time),
-                NodeAlias(tx_node_alias),
-            ));
+            }
         }
         Ok(())
     }

--- a/crates/jazz/src/node/recovery.rs
+++ b/crates/jazz/src/node/recovery.rs
@@ -46,6 +46,28 @@ where
     }
 
     pub(super) fn recover_from_storage(&mut self) -> Result<(), Error> {
+        #[cfg(feature = "testing")]
+        {
+            return self.recover_from_storage_inner(None);
+        }
+        #[cfg(not(feature = "testing"))]
+        self.recover_from_storage_inner()
+    }
+
+    #[cfg(feature = "testing")]
+    pub(super) fn recover_from_storage_with_receipt(
+        &mut self,
+        receipt: &mut NodeOpenReceipt,
+    ) -> Result<(), Error> {
+        self.recover_from_storage_inner(Some(receipt))
+    }
+
+    fn recover_from_storage_inner(
+        &mut self,
+        #[cfg(feature = "testing")] mut receipt: Option<&mut NodeOpenReceipt>,
+    ) -> Result<(), Error> {
+        #[cfg(feature = "testing")]
+        let stage_started = receipt.as_ref().map(|_| Instant::now());
         let cleanly_closed = self.take_valid_clean_close_marker()?;
         let storage_consistent_through = if cleanly_closed {
             None
@@ -98,7 +120,21 @@ where
                 raw.record().get_u64(TransactionRowRecord::FIELD_TIME_IDX)?,
             ));
         }
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, stage_started) {
+            receipt.recover_catalogue_state = started.elapsed();
+        }
+        #[cfg(feature = "testing")]
+        let stage_started = receipt.as_ref().map(|_| Instant::now());
+        #[cfg(feature = "testing")]
+        let mut validated_current_rows = 0usize;
         for table in self.catalogue.schema.tables.clone() {
+            #[cfg(feature = "testing")]
+            {
+                self.validate_current_row_storage_layout(&table, &mut validated_current_rows)?;
+            }
+            #[cfg(not(feature = "testing"))]
+            self.validate_current_row_storage_layout(&table)?;
             if let Some(raw) =
                 self.database
                     .index_last_raw(&history_table_name(&table.name), "by_tx", &[])?
@@ -116,11 +152,24 @@ where
                 ));
             }
         }
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, stage_started) {
+            receipt.validate_current_rows = started.elapsed();
+            receipt.validated_current_rows = validated_current_rows;
+        }
+        #[cfg(feature = "testing")]
+        let stage_started = receipt.as_ref().map(|_| Instant::now());
         let mut accepted_global_seqs = Vec::new();
+        #[cfg(feature = "testing")]
+        let mut global_sequence_records_scanned = 0usize;
         for raw in self
             .database
             .index_scan_raw("jazz_transactions", "by_global_seq", &[])?
         {
+            #[cfg(feature = "testing")]
+            {
+                global_sequence_records_scanned += 1;
+            }
             let record = raw.record();
             let global_seq = record.get_nullable_u64(TransactionRowRecord::FIELD_GLOBAL_SEQ_IDX)?;
             if global_seq.is_some()
@@ -141,10 +190,21 @@ where
         }
         accepted_global_seqs.sort();
         accepted_global_seqs.dedup();
+        #[cfg(feature = "testing")]
+        if let Some(receipt) = &mut receipt {
+            receipt.accepted_global_sequences = accepted_global_seqs.len();
+            receipt.global_sequence_records_scanned = global_sequence_records_scanned;
+        }
         for global_seq in accepted_global_seqs {
             self.record_applied_global_seq(global_seq);
         }
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, stage_started) {
+            receipt.recover_global_sequences = started.elapsed();
+        }
 
+        #[cfg(feature = "testing")]
+        let stage_started = receipt.as_ref().map(|_| Instant::now());
         let mut pending_edges = Vec::new();
         for raw in self
             .database
@@ -219,8 +279,93 @@ where
                 .rejected_transactions
                 .insert(tx_id, RejectedTransaction::new(tx_id, record, versions));
         }
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, stage_started) {
+            receipt.recover_pending_and_rejected = started.elapsed();
+        }
+        #[cfg(feature = "testing")]
+        let stage_started = receipt.as_ref().map(|_| Instant::now());
         if !cleanly_closed {
             self.cleanup_settled_ahead_current_leftovers(storage_consistent_through)?;
+        }
+        #[cfg(feature = "testing")]
+        if let (Some(receipt), Some(started)) = (&mut receipt, stage_started) {
+            receipt.recover_unclean_close = started.elapsed();
+        }
+        Ok(())
+    }
+
+    fn validate_current_row_storage_layout(
+        &self,
+        table: &TableSchema,
+        #[cfg(feature = "testing")] rows: &mut usize,
+    ) -> Result<(), Error> {
+        let storage_tables = table.global_current_storage_tables();
+        self.validate_content_current_rows(
+            &storage_tables[0],
+            #[cfg(feature = "testing")]
+            rows,
+        )?;
+        self.validate_register_current_rows(
+            &storage_tables[1],
+            #[cfg(feature = "testing")]
+            rows,
+        )?;
+
+        let storage_tables = table.ahead_current_storage_tables();
+        self.validate_content_current_rows(
+            &storage_tables[0],
+            #[cfg(feature = "testing")]
+            rows,
+        )?;
+        self.validate_register_current_rows(
+            &storage_tables[1],
+            #[cfg(feature = "testing")]
+            rows,
+        )?;
+        Ok(())
+    }
+
+    fn validate_content_current_rows(
+        &self,
+        storage_table: &groove::schema::TableSchema,
+        #[cfg(feature = "testing")] row_count: &mut usize,
+    ) -> Result<(), Error> {
+        let descriptor = storage_table.record_schema();
+        let rows = self
+            .database
+            .primary_key_scan_raw(&storage_table.name, &[])?;
+        #[cfg(feature = "testing")]
+        {
+            *row_count += rows.len();
+        }
+        for raw in rows {
+            let record = BorrowedRecord::new(raw.raw(), &descriptor);
+            record.get_u64(GlobalCurrentRowRecord::FIELD_SCHEMA_VERSION_IDX)?;
+            record.get_idx(GlobalCurrentRowRecord::FIELD_PARENTS_IDX)?;
+            record.get_nullable_u64(GlobalCurrentRowRecord::FIELD_GLOBAL_SEQ_IDX)?;
+        }
+        Ok(())
+    }
+
+    fn validate_register_current_rows(
+        &self,
+        storage_table: &groove::schema::TableSchema,
+        #[cfg(feature = "testing")] row_count: &mut usize,
+    ) -> Result<(), Error> {
+        let descriptor = storage_table.record_schema();
+        let rows = self
+            .database
+            .primary_key_scan_raw(&storage_table.name, &[])?;
+        #[cfg(feature = "testing")]
+        {
+            *row_count += rows.len();
+        }
+        for raw in rows {
+            let record = BorrowedRecord::new(raw.raw(), &descriptor);
+            record.get_u64(RegisterGlobalCurrentRowRecord::FIELD_SCHEMA_VERSION_IDX)?;
+            record.get_idx(RegisterGlobalCurrentRowRecord::FIELD_PARENTS_IDX)?;
+            record.get_nullable_u64(RegisterGlobalCurrentRowRecord::FIELD_GLOBAL_SEQ_IDX)?;
         }
         Ok(())
     }

--- a/crates/jazz/src/node/recovery.rs
+++ b/crates/jazz/src/node/recovery.rs
@@ -357,43 +357,17 @@ where
     fn validate_ahead_current_rows(
         &mut self,
         storage_table: &groove::schema::TableSchema,
-        layer: VersionLayer,
+        _layer: VersionLayer,
         #[cfg(feature = "testing")] row_count: &mut usize,
         #[cfg(feature = "testing")] ahead_row_count: &mut usize,
     ) -> Result<(), Error> {
-        let descriptor = storage_table.record_schema();
-        let rows = self
+        let _rows = self
             .database
-            .primary_key_scan_raw(&storage_table.name, &[])?
-            .into_iter()
-            .map(|raw| raw.raw().to_vec())
-            .collect::<Vec<_>>();
+            .primary_key_scan_raw(&storage_table.name, &[])?;
         #[cfg(feature = "testing")]
         {
-            *row_count += rows.len();
-            *ahead_row_count += rows.len();
-        }
-        for raw in rows {
-            let record = BorrowedRecord::new(&raw, &descriptor);
-            match layer {
-                VersionLayer::Content => {
-                    record.get_u64(GlobalCurrentRowRecord::FIELD_SCHEMA_VERSION_IDX)?;
-                    record.get_idx(GlobalCurrentRowRecord::FIELD_PARENTS_IDX)?;
-                    record.get_nullable_u64(GlobalCurrentRowRecord::FIELD_GLOBAL_SEQ_IDX)?;
-                    record.get_uuid(GlobalCurrentRowRecord::FIELD_ROW_UUID_IDX)?;
-                    record.get_u64(GlobalCurrentRowRecord::FIELD_TX_TIME_IDX)?;
-                    record.get_u64(GlobalCurrentRowRecord::FIELD_TX_NODE_ID_IDX)?;
-                }
-                VersionLayer::Deletion => {
-                    record.get_u64(RegisterGlobalCurrentRowRecord::FIELD_SCHEMA_VERSION_IDX)?;
-                    record.get_idx(RegisterGlobalCurrentRowRecord::FIELD_PARENTS_IDX)?;
-                    record
-                        .get_nullable_u64(RegisterGlobalCurrentRowRecord::FIELD_GLOBAL_SEQ_IDX)?;
-                    record.get_uuid(RegisterGlobalCurrentRowRecord::FIELD_ROW_UUID_IDX)?;
-                    record.get_u64(RegisterGlobalCurrentRowRecord::FIELD_TX_TIME_IDX)?;
-                    record.get_u64(RegisterGlobalCurrentRowRecord::FIELD_TX_NODE_ID_IDX)?;
-                }
-            }
+            *row_count += _rows.len();
+            *ahead_row_count += _rows.len();
         }
         Ok(())
     }
@@ -403,19 +377,12 @@ where
         storage_table: &groove::schema::TableSchema,
         #[cfg(feature = "testing")] row_count: &mut usize,
     ) -> Result<(), Error> {
-        let descriptor = storage_table.record_schema();
-        let rows = self
+        let _rows = self
             .database
             .primary_key_scan_raw(&storage_table.name, &[])?;
         #[cfg(feature = "testing")]
         {
-            *row_count += rows.len();
-        }
-        for raw in rows {
-            let record = BorrowedRecord::new(raw.raw(), &descriptor);
-            record.get_u64(GlobalCurrentRowRecord::FIELD_SCHEMA_VERSION_IDX)?;
-            record.get_idx(GlobalCurrentRowRecord::FIELD_PARENTS_IDX)?;
-            record.get_nullable_u64(GlobalCurrentRowRecord::FIELD_GLOBAL_SEQ_IDX)?;
+            *row_count += _rows.len();
         }
         Ok(())
     }
@@ -425,19 +392,12 @@ where
         storage_table: &groove::schema::TableSchema,
         #[cfg(feature = "testing")] row_count: &mut usize,
     ) -> Result<(), Error> {
-        let descriptor = storage_table.record_schema();
-        let rows = self
+        let _rows = self
             .database
             .primary_key_scan_raw(&storage_table.name, &[])?;
         #[cfg(feature = "testing")]
         {
-            *row_count += rows.len();
-        }
-        for raw in rows {
-            let record = BorrowedRecord::new(raw.raw(), &descriptor);
-            record.get_u64(RegisterGlobalCurrentRowRecord::FIELD_SCHEMA_VERSION_IDX)?;
-            record.get_idx(RegisterGlobalCurrentRowRecord::FIELD_PARENTS_IDX)?;
-            record.get_nullable_u64(RegisterGlobalCurrentRowRecord::FIELD_GLOBAL_SEQ_IDX)?;
+            *row_count += _rows.len();
         }
         Ok(())
     }

--- a/crates/jazz/src/node/recovery.rs
+++ b/crates/jazz/src/node/recovery.rs
@@ -128,13 +128,21 @@ where
         let stage_started = receipt.as_ref().map(|_| Instant::now());
         #[cfg(feature = "testing")]
         let mut validated_current_rows = 0usize;
+        #[cfg(feature = "testing")]
+        let mut ahead_current_entries = 0usize;
+        let mut recovered_ahead_current_keys = Vec::new();
         for table in self.catalogue.schema.tables.clone() {
             #[cfg(feature = "testing")]
             {
-                self.validate_current_row_storage_layout(&table, &mut validated_current_rows)?;
+                self.validate_current_row_storage_layout(
+                    &table,
+                    &mut recovered_ahead_current_keys,
+                    &mut validated_current_rows,
+                    &mut ahead_current_entries,
+                )?;
             }
             #[cfg(not(feature = "testing"))]
-            self.validate_current_row_storage_layout(&table)?;
+            self.validate_current_row_storage_layout(&table, &mut recovered_ahead_current_keys)?;
             if let Some(raw) =
                 self.database
                     .index_last_raw(&history_table_name(&table.name), "by_tx", &[])?
@@ -152,10 +160,12 @@ where
                 ));
             }
         }
+        self.replace_ahead_current_keys(recovered_ahead_current_keys);
         #[cfg(feature = "testing")]
         if let (Some(receipt), Some(started)) = (&mut receipt, stage_started) {
             receipt.validate_current_rows = started.elapsed();
             receipt.validated_current_rows = validated_current_rows;
+            receipt.ahead_current_entries = ahead_current_entries;
         }
         #[cfg(feature = "testing")]
         let stage_started = receipt.as_ref().map(|_| Instant::now());
@@ -310,9 +320,11 @@ where
     }
 
     fn validate_current_row_storage_layout(
-        &self,
+        &mut self,
         table: &TableSchema,
+        ahead_current_keys: &mut Vec<(String, VersionLayer, RowUuid, TxTime, NodeAlias)>,
         #[cfg(feature = "testing")] rows: &mut usize,
+        #[cfg(feature = "testing")] ahead_rows: &mut usize,
     ) -> Result<(), Error> {
         let storage_tables = table.global_current_storage_tables();
         self.validate_content_current_rows(
@@ -327,16 +339,83 @@ where
         )?;
 
         let storage_tables = table.ahead_current_storage_tables();
-        self.validate_content_current_rows(
+        self.validate_and_index_ahead_current_rows(
+            &table.name,
             &storage_tables[0],
+            VersionLayer::Content,
+            ahead_current_keys,
             #[cfg(feature = "testing")]
             rows,
+            #[cfg(feature = "testing")]
+            ahead_rows,
         )?;
-        self.validate_register_current_rows(
+        self.validate_and_index_ahead_current_rows(
+            &table.name,
             &storage_tables[1],
+            VersionLayer::Deletion,
+            ahead_current_keys,
             #[cfg(feature = "testing")]
             rows,
+            #[cfg(feature = "testing")]
+            ahead_rows,
         )?;
+        Ok(())
+    }
+
+    fn validate_and_index_ahead_current_rows(
+        &mut self,
+        table: &str,
+        storage_table: &groove::schema::TableSchema,
+        layer: VersionLayer,
+        ahead_current_keys: &mut Vec<(String, VersionLayer, RowUuid, TxTime, NodeAlias)>,
+        #[cfg(feature = "testing")] row_count: &mut usize,
+        #[cfg(feature = "testing")] ahead_row_count: &mut usize,
+    ) -> Result<(), Error> {
+        let descriptor = storage_table.record_schema();
+        let rows = self
+            .database
+            .primary_key_scan_raw(&storage_table.name, &[])?
+            .into_iter()
+            .map(|raw| raw.raw().to_vec())
+            .collect::<Vec<_>>();
+        #[cfg(feature = "testing")]
+        {
+            *row_count += rows.len();
+            *ahead_row_count += rows.len();
+        }
+        for raw in rows {
+            let record = BorrowedRecord::new(&raw, &descriptor);
+            let (row_uuid, tx_time, tx_node_alias) = match layer {
+                VersionLayer::Content => {
+                    record.get_u64(GlobalCurrentRowRecord::FIELD_SCHEMA_VERSION_IDX)?;
+                    record.get_idx(GlobalCurrentRowRecord::FIELD_PARENTS_IDX)?;
+                    record.get_nullable_u64(GlobalCurrentRowRecord::FIELD_GLOBAL_SEQ_IDX)?;
+                    (
+                        record.get_uuid(GlobalCurrentRowRecord::FIELD_ROW_UUID_IDX)?,
+                        record.get_u64(GlobalCurrentRowRecord::FIELD_TX_TIME_IDX)?,
+                        record.get_u64(GlobalCurrentRowRecord::FIELD_TX_NODE_ID_IDX)?,
+                    )
+                }
+                VersionLayer::Deletion => {
+                    record.get_u64(RegisterGlobalCurrentRowRecord::FIELD_SCHEMA_VERSION_IDX)?;
+                    record.get_idx(RegisterGlobalCurrentRowRecord::FIELD_PARENTS_IDX)?;
+                    record
+                        .get_nullable_u64(RegisterGlobalCurrentRowRecord::FIELD_GLOBAL_SEQ_IDX)?;
+                    (
+                        record.get_uuid(RegisterGlobalCurrentRowRecord::FIELD_ROW_UUID_IDX)?,
+                        record.get_u64(RegisterGlobalCurrentRowRecord::FIELD_TX_TIME_IDX)?,
+                        record.get_u64(RegisterGlobalCurrentRowRecord::FIELD_TX_NODE_ID_IDX)?,
+                    )
+                }
+            };
+            ahead_current_keys.push((
+                table.to_owned(),
+                layer,
+                RowUuid(row_uuid),
+                TxTime(tx_time),
+                NodeAlias(tx_node_alias),
+            ));
+        }
         Ok(())
     }
 

--- a/crates/jazz/src/node/recovery.rs
+++ b/crates/jazz/src/node/recovery.rs
@@ -48,7 +48,7 @@ where
     pub(super) fn recover_from_storage(&mut self) -> Result<(), Error> {
         #[cfg(feature = "testing")]
         {
-            return self.recover_from_storage_inner(None);
+            self.recover_from_storage_inner(None)
         }
         #[cfg(not(feature = "testing"))]
         self.recover_from_storage_inner()
@@ -162,10 +162,24 @@ where
         let mut accepted_global_seqs = Vec::new();
         #[cfg(feature = "testing")]
         let mut global_sequence_records_scanned = 0usize;
-        for raw in self
-            .database
-            .index_scan_raw("jazz_transactions", "by_global_seq", &[])?
-        {
+        // Nullable index keys order `None` before `Some`. Range over only the
+        // `Some` bucket so local pending/rejected transactions cannot make
+        // recovery O(total transactions). The range end is exclusive, hence
+        // the separate exact lookup preserves the prior u64::MAX behavior.
+        let first_global_seq = Value::Nullable(Some(Box::new(Value::U64(0))));
+        let last_global_seq = Value::Nullable(Some(Box::new(Value::U64(u64::MAX))));
+        let mut sequenced_transactions = self.database.index_scan_range_raw(
+            "jazz_transactions",
+            "by_global_seq",
+            std::slice::from_ref(&first_global_seq),
+            std::slice::from_ref(&last_global_seq),
+        )?;
+        sequenced_transactions.extend(self.database.index_scan_raw(
+            "jazz_transactions",
+            "by_global_seq",
+            std::slice::from_ref(&last_global_seq),
+        )?);
+        for raw in sequenced_transactions {
             #[cfg(feature = "testing")]
             {
                 global_sequence_records_scanned += 1;

--- a/crates/jazz/src/node/tests/queries.rs
+++ b/crates/jazz/src/node/tests/queries.rs
@@ -275,7 +275,7 @@ fn groove_current_rows_match_oracle_for_seeded_m1_commits() {
 }
 
 #[test]
-fn local_current_from_ahead_index_matches_history_argmax_for_seeded_commits() {
+fn local_current_from_ahead_storage_matches_history_argmax_for_seeded_commits() {
     for seed in 0..16_u64 {
         let (_temp_dir, mut node) = open_node();
         let mut parents = BTreeMap::<RowUuid, TxId>::new();

--- a/crates/jazz/src/node/tests/recovery.rs
+++ b/crates/jazz/src/node/tests/recovery.rs
@@ -45,6 +45,67 @@ fn opening_existing_storage_recovers_mirrors_and_high_water_marks() {
 }
 
 #[test]
+fn recovery_rebuilds_ahead_current_latest_and_fallback_versions() {
+    // This is intentionally internal: rejecting the latest local version must
+    // expose the prior pending version, which relies on both the full key set
+    // and the per-row latest-key index rebuilt during open.
+    let schema = schema();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let latest;
+    {
+        let mut node = open_node_at(&temp_dir, schema.clone());
+        node.commit_mergeable(
+            MergeableCommit::new("todos", row(11), 10).cells(title_cells("first")),
+        )
+        .unwrap();
+        latest = node
+            .commit_mergeable(
+                MergeableCommit::new("todos", row(11), 11).cells(title_cells("latest")),
+            )
+            .unwrap();
+    }
+
+    let cfs = schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage = RocksDbStorage::open(temp_dir.path(), &refs).unwrap();
+    #[cfg(feature = "testing")]
+    let (mut reopened, receipt) =
+        NodeState::new_with_open_receipt_for_test(node(1), schema, storage, false, 1024).unwrap();
+    #[cfg(not(feature = "testing"))]
+    let mut reopened = NodeState::new(node(1), schema, storage).unwrap();
+
+    #[cfg(feature = "testing")]
+    assert_eq!(receipt.ahead_current_entries, 2);
+    assert_eq!(
+        reopened
+            .current_rows("todos", DurabilityTier::Local)
+            .unwrap()
+            .into_iter()
+            .map(current_row_pair)
+            .collect::<BTreeMap<_, _>>(),
+        BTreeMap::from([(row(11), title_cells("latest"))])
+    );
+
+    reopened
+        .apply_fate_update(
+            latest,
+            Fate::Rejected(RejectionReason::ExclusiveConflict),
+            None,
+            None,
+        )
+        .unwrap();
+    assert_eq!(
+        reopened
+            .current_rows("todos", DurabilityTier::Local)
+            .unwrap()
+            .into_iter()
+            .map(current_row_pair)
+            .collect::<BTreeMap<_, _>>(),
+        BTreeMap::from([(row(11), title_cells("first"))])
+    );
+}
+
+#[test]
 fn opening_defers_malformed_current_row_to_read() {
     // This is necessarily an internal regression test: planting malformed
     // persisted bytes requires direct storage access, and the core point-read

--- a/crates/jazz/src/node/tests/recovery.rs
+++ b/crates/jazz/src/node/tests/recovery.rs
@@ -443,6 +443,87 @@ fn reopen_refuses_preexisting_sequenced_non_global_transaction() {
     ));
 }
 
+#[test]
+fn recovery_scans_only_sequenced_transactions_and_preserves_global_gaps() {
+    // This is intentionally an internal recovery test: the distinction between
+    // the contiguous watermark and above-watermark gaps is not exposed through
+    // the public Db API, but it is the correctness invariant of the bounded scan.
+    let schema = schema();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let gap;
+    {
+        let mut node = open_node_at(&temp_dir, schema.clone());
+        let first = node
+            .commit_mergeable(
+                MergeableCommit::new("todos", row(20), 20).cells(title_cells("first")),
+            )
+            .unwrap();
+        gap = node
+            .commit_mergeable(
+                MergeableCommit::new("todos", row(21), 21).cells(title_cells("gap")),
+            )
+            .unwrap();
+        let third = node
+            .commit_mergeable(
+                MergeableCommit::new("todos", row(22), 22).cells(title_cells("third")),
+            )
+            .unwrap();
+        let rejected = node
+            .commit_mergeable(
+                MergeableCommit::new("todos", row(23), 23).cells(title_cells("rejected")),
+            )
+            .unwrap();
+        node.apply_fate_update(
+            rejected,
+            Fate::Rejected(RejectionReason::ExclusiveConflict),
+            None,
+            None,
+        )
+        .unwrap();
+        for index in 0..64 {
+            node.commit_mergeable(
+                MergeableCommit::new("todos", row(100 + index), u64::from(100 + index))
+                    .cells(title_cells("pending")),
+            )
+            .unwrap();
+        }
+        mark_accepted_without_ahead_cleanup(&mut node, first, GlobalSeq(1));
+        mark_accepted_without_ahead_cleanup(&mut node, third, GlobalSeq(3));
+    }
+
+    let cfs = schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage = RocksDbStorage::open(temp_dir.path(), &refs).unwrap();
+    #[cfg(feature = "testing")]
+    let (mut reopened, receipt) =
+        NodeState::new_with_open_receipt_for_test(node(1), schema, storage, false, 1024).unwrap();
+    #[cfg(not(feature = "testing"))]
+    let mut reopened = NodeState::new(node(1), schema, storage).unwrap();
+
+    #[cfg(feature = "testing")]
+    {
+        assert_eq!(receipt.global_sequence_records_scanned, 2);
+        assert_eq!(receipt.accepted_global_sequences, 2);
+    }
+    assert_eq!(reopened.clock.applied_global_watermark, GlobalSeq(1));
+    assert_eq!(
+        reopened.clock.applied_global_above_watermark,
+        BTreeSet::from([GlobalSeq(3)])
+    );
+    assert_eq!(reopened.clock.next_global_seq, GlobalSeq(4));
+
+    reopened
+        .apply_fate_update(
+            gap,
+            Fate::Accepted,
+            Some(GlobalSeq(2)),
+            Some(DurabilityTier::Global),
+        )
+        .unwrap();
+    assert_eq!(reopened.clock.applied_global_watermark, GlobalSeq(3));
+    assert!(reopened.clock.applied_global_above_watermark.is_empty());
+}
+
 // This is necessarily an internal mechanism regression test: the public API
 // exposes the restored upload queue but not candidate-record work. It seeds
 // transaction states through node ingest APIs, then compares the null-slice

--- a/crates/jazz/src/node/tests/recovery.rs
+++ b/crates/jazz/src/node/tests/recovery.rs
@@ -45,10 +45,9 @@ fn opening_existing_storage_recovers_mirrors_and_high_water_marks() {
 }
 
 #[test]
-fn recovery_rebuilds_ahead_current_latest_and_fallback_versions() {
-    // This is intentionally internal: rejecting the latest local version must
-    // expose the prior pending version, which relies on both the full key set
-    // and the per-row latest-key index rebuilt during open.
+fn recovery_reads_latest_ahead_current_and_fallback_versions_from_storage() {
+    // Rejecting the latest local version must expose the prior pending version,
+    // including after reopening the storage.
     let schema = schema();
     let temp_dir = tempfile::tempdir().unwrap();
     let latest;
@@ -76,6 +75,19 @@ fn recovery_rebuilds_ahead_current_latest_and_fallback_versions() {
 
     #[cfg(feature = "testing")]
     assert_eq!(receipt.ahead_current_entries, 2);
+    reopened.reset_storage_read_metrics();
+    assert_eq!(
+        reopened
+            .local_current_row("todos", row(11))
+            .unwrap()
+            .map(current_row_pair),
+        Some((row(11), title_cells("latest")))
+    );
+    let point_read_metrics = reopened.take_storage_read_metrics();
+    assert_eq!(
+        point_read_metrics.other.ranges, 2,
+        "point lookup should use one bounded range per ahead-current layer"
+    );
     assert_eq!(
         reopened
             .current_rows("todos", DurabilityTier::Local)
@@ -102,6 +114,74 @@ fn recovery_rebuilds_ahead_current_latest_and_fallback_versions() {
             .map(current_row_pair)
             .collect::<BTreeMap<_, _>>(),
         BTreeMap::from([(row(11), title_cells("first"))])
+    );
+}
+
+#[test]
+fn recovery_uses_storage_fallback_for_deletion_versions() {
+    let schema = schema();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let restored;
+    {
+        let mut node = open_node_at(&temp_dir, schema.clone());
+        node.commit_mergeable(
+            MergeableCommit::new("todos", row(12), 9).cells(title_cells("persisted")),
+        )
+        .unwrap();
+        node.commit_mergeable(
+            MergeableCommit::new("todos", row(12), 10).deletion(DeletionEvent::Deleted),
+        )
+        .unwrap();
+        restored = node
+            .commit_mergeable(
+                MergeableCommit::new("todos", row(12), 11)
+                    .deletion(DeletionEvent::Restored),
+            )
+            .unwrap();
+    }
+
+    let cfs = schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage = RocksDbStorage::open(temp_dir.path(), &refs).unwrap();
+    let mut reopened = NodeState::new(node(1), schema, storage).unwrap();
+
+    reopened.reset_storage_read_metrics();
+    assert_eq!(
+        reopened
+            .local_current_row("todos", row(12))
+            .unwrap()
+            .map(current_row_pair),
+        Some((row(12), title_cells("persisted")))
+    );
+    let point_read_metrics = reopened.take_storage_read_metrics();
+    assert_eq!(
+        point_read_metrics.other.ranges, 2,
+        "point lookup should use one bounded range per ahead-current layer"
+    );
+    assert_eq!(
+        reopened
+            .current_rows("todos", DurabilityTier::Local)
+            .unwrap()
+            .into_iter()
+            .map(current_row_pair)
+            .collect::<BTreeMap<_, _>>(),
+        BTreeMap::from([(row(12), title_cells("persisted"))])
+    );
+
+    reopened
+        .apply_fate_update(
+            restored,
+            Fate::Rejected(RejectionReason::ExclusiveConflict),
+            None,
+            None,
+        )
+        .unwrap();
+    assert!(
+        reopened
+            .current_rows("todos", DurabilityTier::Local)
+            .unwrap()
+            .is_empty(),
+        "rejecting the restore must expose the prior pending deletion"
     );
 }
 

--- a/crates/jazz/src/node/tests/recovery.rs
+++ b/crates/jazz/src/node/tests/recovery.rs
@@ -739,6 +739,39 @@ fn reopen_replay_lookup_keeps_local_pending_write() {
 }
 
 #[test]
+fn recovery_includes_the_maximum_global_sequence_endpoint() {
+    let schema = schema();
+    let temp_dir = tempfile::tempdir().unwrap();
+    {
+        let mut node = open_node_at(&temp_dir, schema.clone());
+        let tx_id = node
+            .commit_mergeable(
+                MergeableCommit::new("todos", row(24), 24).cells(title_cells("last sequence")),
+            )
+            .unwrap();
+        mark_accepted_without_ahead_cleanup(&mut node, tx_id, GlobalSeq(u64::MAX));
+    }
+
+    let cfs = schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage = RocksDbStorage::open(temp_dir.path(), &refs).unwrap();
+    #[cfg(feature = "testing")]
+    let (reopened, receipt) =
+        NodeState::new_with_open_receipt_for_test(node(1), schema, storage, false, 1024).unwrap();
+    #[cfg(not(feature = "testing"))]
+    let reopened = NodeState::new(node(1), schema, storage).unwrap();
+
+    #[cfg(feature = "testing")]
+    assert_eq!(receipt.global_sequence_records_scanned, 1);
+    assert_eq!(reopened.clock.applied_global_watermark, GlobalSeq(0));
+    assert_eq!(
+        reopened.clock.applied_global_above_watermark,
+        BTreeSet::from([GlobalSeq(u64::MAX)])
+    );
+    assert_eq!(reopened.clock.next_global_seq, GlobalSeq(u64::MAX));
+}
+
+#[test]
 fn reopen_in_place_recovers_history_watermarks_pending_edges_and_rehydrates_peer() {
     let (_dir, mut core) = open_node_with_uuid(node(0x3a));
     let mut peer = PeerState::new();

--- a/crates/jazz/src/time.rs
+++ b/crates/jazz/src/time.rs
@@ -26,7 +26,7 @@ pub struct GlobalSeq(pub u64);
 impl GlobalSeq {
     /// Return the next global sequence value.
     pub fn next(self) -> Self {
-        Self(self.0 + 1)
+        Self(self.0.saturating_add(1))
     }
 }
 

--- a/dev/benchmarks/R3_BOUNDED_GLOBAL_SEQ_RECOVERY.md
+++ b/dev/benchmarks/R3_BOUNDED_GLOBAL_SEQ_RECOVERY.md
@@ -1,0 +1,59 @@
+# R3 bounded global-sequence recovery
+
+This receipt follows `R3_JAZZ_OPEN_ATTRIBUTION.md`. It changes startup recovery
+to range-scan only non-null entries in `jazz_transactions/by_global_seq`,
+instead of scanning the nullable index from its empty prefix.
+
+The previous scan visited every transaction, including local pending and
+rejected transactions whose `global_seq` is null. Recovery still filters for
+accepted fate, sorts and deduplicates the recovered sequences, and rebuilds the
+same contiguous watermark plus above-watermark gap set.
+
+## Correctness boundary
+
+An internal recovery regression covers accepted global sequences `{1, 3}`,
+64 pending transactions, and one rejected transaction. Reopen must:
+
+- scan only the two sequenced transactions;
+- recover watermark `1`, above-watermark set `{3}`, and next sequence `4`;
+- advance to watermark `3` when sequence `2` subsequently arrives.
+
+The test is internal because the distinction between contiguous watermark and
+above-watermark gaps is not exposed through the public `Db` API.
+
+## Initial local receipt
+
+Three-sample warm-cache clean-close medians on `anselm-devbox`, 2026-07-29,
+using the same generated `m` workload:
+
+| phase                         |   before |    after |                  delta |
+| ----------------------------- | -------: | -------: | ---------------------: |
+| Jazz open                     | 2,919 ms | 1,104 ms |                 -62.2% |
+| recover global sequences      | 1,648 ms |    31 us | effectively eliminated |
+| recover storage               | 1,984 ms |   340 ms |                 -82.9% |
+| rebuild ahead-current indexes |   946 ms |   763 ms |                 -19.3% |
+| validate current rows         |   337 ms |   340 ms |              unchanged |
+| first read                    |   359 ms |   345 ms |    within run variance |
+
+The transaction-index work counter falls from 952,620 scanned records to zero
+because this fixture has no accepted global sequences. The optimization is
+proportional to sequenced transactions rather than total transactions; the
+gap regression demonstrates the non-zero path.
+
+Ahead-current reconstruction is now the dominant open phase, followed by
+current-row validation. Those remain separate optimization lanes.
+
+## Command
+
+```sh
+JAZZ_R3_PROFILES=m \
+JAZZ_R3_CACHE_MODES=warm \
+JAZZ_R3_CLOSE_MODES=clean \
+JAZZ_R3_PHASE_SAMPLES=3 \
+JAZZ_R3_PHASE_ONLY=1 \
+  cargo bench -p jazz-tools --features r3-open-attribution \
+    --bench realistic_phase1 -- realistic_phase1/r3_rocksdb_cold_load
+```
+
+Tooling friction: an opt-in reusable seeded fixture would reduce the several
+minutes spent rebuilding unchanged `m` data for every recovery iteration.

--- a/dev/benchmarks/R3_FUSED_AHEAD_CURRENT_RECOVERY.md
+++ b/dev/benchmarks/R3_FUSED_AHEAD_CURRENT_RECOVERY.md
@@ -1,0 +1,66 @@
+# R3 fused ahead-current recovery
+
+This receipt follows `R3_BOUNDED_GLOBAL_SEQ_RECOVERY.md`. It removes a duplicate
+startup pass over every ahead-current row and bulk-reconstructs the in-memory
+ahead-current indexes from the existing layout-validation scan.
+
+Previously, recovery decoded every global-current and ahead-current row to
+validate its stored layout. Startup then scanned every ahead-current table
+again, decoded the row keys again, and inserted 952,620 entries one at a time
+into three B-tree indexes.
+
+Recovery now:
+
+1. validates each ahead-current row;
+2. retains its table, layer, row, time, and node key;
+3. sorts and deduplicates those keys once;
+4. bulk-constructs the full-key, touched-row, and latest-key indexes.
+
+The indexes are complete before unclean-close cleanup runs, preserving the
+existing cleanup ordering.
+
+## Correctness boundary
+
+An internal recovery regression persists two pending versions of one row and
+reopens the node. It verifies that:
+
+- the receipt counts both ahead-current entries;
+- the newer version is selected after reopen;
+- rejecting the newer version exposes the older pending version.
+
+The fallback assertion exercises both the recovered full-key set and the
+per-row latest-key index.
+
+## Initial local receipt
+
+Three-sample warm-cache clean-close medians on `anselm-devbox`, 2026-07-29,
+using the same generated `m` workload:
+
+| phase                              |    #1176 | fused + bulk |               delta |
+| ---------------------------------- | -------: | -----------: | ------------------: |
+| Jazz open                          | 1,104 ms |       832 ms |              -24.6% |
+| validate and rebuild current state | 1,103 ms |       831 ms |              -24.7% |
+| standalone ahead-current rebuild   |   763 ms |            0 |          eliminated |
+| first read                         |   345 ms |       306 ms | within run variance |
+| total reopen plus first read       | 1,459 ms |     1,149 ms |              -21.2% |
+
+The fused-only intermediate measured 967 ms for Jazz open. Bulk reconstruction
+then removed another 135 ms by avoiding three ordered-tree mutations per row.
+Both results consumed the same 952,620 ahead-current entries.
+
+This optimization still performs work proportional to ahead-current entries
+and temporarily retains their decoded keys while constructing the indexes.
+Persisting or lazily materializing those indexes remains a separate design
+option if startup must avoid the full pass entirely.
+
+## Command
+
+```sh
+JAZZ_R3_PROFILES=m \
+JAZZ_R3_CACHE_MODES=warm \
+JAZZ_R3_CLOSE_MODES=clean \
+JAZZ_R3_PHASE_SAMPLES=3 \
+JAZZ_R3_PHASE_ONLY=1 \
+  cargo bench -p jazz-tools --features r3-open-attribution \
+    --bench realistic_phase1 -- realistic_phase1/r3_rocksdb_cold_load
+```

--- a/dev/benchmarks/R3_JAZZ_OPEN_ATTRIBUTION.md
+++ b/dev/benchmarks/R3_JAZZ_OPEN_ATTRIBUTION.md
@@ -1,0 +1,63 @@
+# R3 Jazz open attribution
+
+This receipt drills into the `jazz_open` phase established by
+`R3_PERSISTED_READ_RECEIPT.md`. It is local characterization, not an acceptance
+target or an optimization.
+
+The diagnostic API is available only through Jazz's `testing` feature. The
+ordinary `rocksdb` benchmark path remains unchanged and does not collect
+internal timings.
+
+## Initial local receipt
+
+Warm-cache `m` profile on `anselm-devbox`, 2026-07-29. Values are three-sample
+medians over one shared generated workload.
+
+| phase | clean close | unclean drop |
+| --- | ---: | ---: |
+| recover storage | 1,984 ms | 2,082 ms |
+| rebuild ahead-current indexes | 946 ms | 938 ms |
+| recover known-state facts | <1 ms | 28 ms |
+| all other measured open work | <1 ms | <1 ms |
+| **Jazz open** | **2,919 ms** | **3,045 ms** |
+
+`recover_storage` breaks down as:
+
+| recovery child | clean close | unclean drop | observed work |
+| --- | ---: | ---: | --- |
+| recover global sequences | 1,648 ms | 1,507 ms | 952,620 transaction-index records scanned; zero accepted global sequences recovered |
+| validate current rows | 337 ms | 338 ms | 952,620 global/ahead current rows decoded |
+| unclean-close cleanup | 0 ms | 221 ms | scoped crash recovery |
+| pending/rejected recovery | 2 ms | 2 ms | no dominant contribution |
+| catalogue/clock recovery | <1 ms | <1 ms | no dominant contribution |
+
+Ahead-current index reconstruction then scans and inserts 952,620 entries
+again. Startup therefore performs multiple whole-dataset passes before the
+first read. The leading optimization question is whether global-sequence
+recovery can seek directly to persisted watermark metadata (or otherwise avoid
+scanning transactions that cannot contribute a global sequence). The clean
+lifecycle still spends about 2.9 seconds in Jazz open, so crash recovery is not
+the primary problem. The second question is whether current-row validation and
+ahead-current reconstruction can share one pass or recover a persisted
+index/checkpoint.
+
+Clean-close and unclean-drop modes use the same node identity and stored
+fixture. Lifecycle setup and `Db::close` happen outside the measured window.
+The clean marker is therefore valid for every clean sample, while every
+unclean sample deliberately enters crash recovery.
+
+## Command
+
+```sh
+JAZZ_R3_PROFILES=m \
+JAZZ_R3_CACHE_MODES=warm \
+JAZZ_R3_CLOSE_MODES=clean,unclean \
+JAZZ_R3_PHASE_SAMPLES=3 \
+JAZZ_R3_PHASE_ONLY=1 \
+  cargo bench -p jazz-tools --features r3-open-attribution \
+    --bench realistic_phase1 -- realistic_phase1/r3_rocksdb_cold_load
+```
+
+Tooling friction: retaining an opt-in seeded fixture directory would avoid
+repeating several minutes of public-API fixture construction for attribution
+changes that do not alter stored data.

--- a/dev/benchmarks/realistic/README.md
+++ b/dev/benchmarks/realistic/README.md
@@ -106,6 +106,27 @@ eviction is outside the measured window and does not drop the machine-wide page
 cache. Both modes are process-cold. The M fixture is intentionally opt-in
 because its public-API seed takes several minutes.
 
+To attribute Jazz's internal open work, enable the test/bench-only diagnostic
+feature:
+
+```bash
+JAZZ_R3_PROFILES=m \
+JAZZ_R3_CACHE_MODES=warm \
+JAZZ_R3_CLOSE_MODES=clean,unclean \
+JAZZ_R3_PHASE_SAMPLES=3 \
+JAZZ_R3_PHASE_ONLY=1 \
+  cargo bench -p jazz-tools --features r3-open-attribution \
+    --bench realistic_phase1 -- realistic_phase1/r3_rocksdb_cold_load
+```
+
+This adds timings and work counts for catalogue recovery, full database open,
+current-row validation, global-sequence recovery, known-state recovery,
+ahead-current index reconstruction, and final catalogue persistence. `clean`
+calls `Db::close` after seeding and after every measured read; `unclean` drops
+the database without closing. Lifecycle setup and close happen outside the
+measured window. The default remains `unclean`. See
+`dev/benchmarks/R3_JAZZ_OPEN_ATTRIBUTION.md` for the initial local receipt.
+
 Export consolidated Criterion artifacts (JSON + markdown summary) from `target/criterion`:
 
 ```bash


### PR DESCRIPTION
## Summary

- stop rebuilding in-memory ahead-current key, row, and latest-candidate indexes during open
- resolve direct local-row candidates with one bounded storage lookup per content/deletion layer
- retain full ahead-current storage-layout validation during recovery
- cover content and deletion fallback behavior across reopen and fate updates
- add Linux RSS/peak-RSS fields and persistent-fixture controls to the R3 phase benchmark

## Why

R3 recovery rebuilt three resident indexes from 952,620 ahead-current records even though the representative query path does not consume them. Direct point-row helpers are the remaining consumer and can retrieve the latest candidate from the ordered primary key instead.

This trades two bounded RocksDB ranges on a direct local-row lookup for substantially less eager open work and memory.

## R3 result

Compared with #1178 on profile M, warm OS page cache, clean database close, three samples:

- Jazz open: 832 ms → 408 ms (about 51% faster)
- first read: about 317 ms → 346 ms (about 29 ms slower)
- reopen + first read: 1.149 s → 766 ms (about 33% faster)

All 952,620 ahead-current records remain validated during open.

## Memory result

Compared with #1178 on the same persisted profile-M fixture, warm cache and clean close. Each value is the median of three independent fresh-process runs with one measured reopen per process, avoiding allocator/page retention from fixture construction or an earlier reopen:

| Measure | #1178 | This PR | Change |
| --- | ---: | ---: | ---: |
| RSS growth during Jazz open | 449.2 MiB | 278.0 MiB | -171.2 MiB (-38.1%) |
| RSS immediately after Jazz open | 480.1 MiB | 308.9 MiB | -171.2 MiB (-35.7%) |
| Process peak RSS through first read | 679.5 MiB | 421.9 MiB | -257.6 MiB (-37.9%) |

The remaining Jazz-open RSS growth is largely transient allocator retention from validating all 952,620 current rows; this PR deliberately preserves that validation policy.

## Validation

- `cargo test -p jazz`
- `cargo test -p jazz --features testing`
- focused content and deletion recovery/fallback tests
- storage-read assertion confirming two bounded ahead-current ranges
- `cargo clippy -p jazz --lib --features testing -- -D warnings`
- `cargo check -p jazz-tools --features r3-open-attribution --bench realistic_phase1`
- profile-M fresh-process RSS comparison against #1178 (three runs per revision)
- pre-commit Clippy, sensitive-data, and rustfmt hooks
