### PR TITLE
fix: replica clients must not pre-settle tier reads from their own store

### DIFF
--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -370,8 +370,10 @@ fn build_napi_runtime(
     // Parse optional tier
     let node_tiers = parse_node_durability_tier(tier)?;
 
-    // Create sync manager
-    let mut sync_manager = SyncManager::new();
+    // The runtime's durability identity settles its own writes, but its
+    // store replicates any upstream server, so it is never a read-frontier
+    // authority.
+    let mut sync_manager = SyncManager::new().as_replica_client();
     if !node_tiers.is_empty() {
         sync_manager = sync_manager.with_durability_tiers(node_tiers);
     }

--- a/crates/jazz-tools/src/query_manager/manager_tests/subscriptions.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests/subscriptions.rs
@@ -1200,6 +1200,56 @@ fn subscribe_with_sync_local_only_on_persistence_tier_does_not_send_upstream() {
 }
 
 #[test]
+fn replica_client_subscription_waits_for_upstream_frontier() {
+    use crate::sync_manager::{DurabilityTier, InboxEntry, QueryId, ServerId, Source, SyncPayload};
+    use uuid::Uuid;
+
+    // Same durability identity as an edge server, but marked as a replica
+    // client: reads must wait for the upstream query frontier.
+    let sync_manager = SyncManager::new()
+        .with_durability_tier(DurabilityTier::EdgeServer)
+        .as_replica_client();
+    let schema = test_schema();
+    let (mut qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    let upstream_id = ServerId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+    connect_server(&mut qm, &storage, upstream_id);
+    let _ = qm.sync_manager_mut().take_outbox();
+
+    let query = qm.query("users").build();
+    let sub_id = qm
+        .subscribe_with_sync(query, None, Some(DurabilityTier::EdgeServer))
+        .unwrap();
+    qm.process(&mut storage);
+
+    assert!(
+        qm.take_updates().is_empty(),
+        "a replica client must not deliver a cold local answer before the \
+         upstream confirms the query frontier"
+    );
+
+    qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Server(upstream_id),
+        payload: SyncPayload::QuerySettled {
+            query_id: QueryId(sub_id.0),
+            tier: DurabilityTier::GlobalServer,
+            scope: vec![],
+            through_seq: 0,
+        },
+    });
+    qm.process(&mut storage);
+
+    let updates = qm.take_updates();
+    assert_eq!(
+        updates.len(),
+        1,
+        "the settled frontier must deliver the initial (empty) result"
+    );
+    assert_eq!(updates[0].subscription_id, sub_id);
+    assert!(updates[0].delta.added.is_empty());
+}
+
+#[test]
 fn local_durability_tier_subscription_ignores_stale_upstream_scope() {
     use crate::sync_manager::{DurabilityTier, InboxEntry, QueryId, ServerId, Source, SyncPayload};
     use uuid::Uuid;

--- a/crates/jazz-tools/src/query_manager/subscriptions.rs
+++ b/crates/jazz-tools/src/query_manager/subscriptions.rs
@@ -157,9 +157,14 @@ impl QueryManager {
 
         let id = QuerySubscriptionId(self.next_subscription_id);
         self.next_subscription_id += 1;
+        // A durability identity only pre-settles a read when the local
+        // store is authoritative for that data (servers). A replica client
+        // must still wait for the upstream query frontier.
         let query_frontier_settled_tier = (durability_tier.is_none()
-            || durability_tier
-                .is_some_and(|tier| self.sync_manager.has_local_durability_at_least(tier))
+            || durability_tier.is_some_and(|tier| {
+                self.sync_manager.read_frontier_authority()
+                    && self.sync_manager.has_local_durability_at_least(tier)
+            })
             || !self.should_send_local_subscription_upstream(propagation)
             || !self.sync_manager.has_servers_or_pending_servers())
         .then_some(DurabilityTier::GlobalServer);

--- a/crates/jazz-tools/src/sync_manager/mod.rs
+++ b/crates/jazz-tools/src/sync_manager/mod.rs
@@ -54,6 +54,9 @@ pub(crate) struct OutgoingQuerySubscription {
 /// - Downstream clients (untrusted, receive query-filtered subsets)
 #[derive(Clone)]
 pub struct SyncManager {
+    /// Whether the local store is authoritative for reads at this node's
+    /// identity tiers. Servers own their stores; replica clients do not.
+    read_frontier_authority: bool,
     pub(super) clock: MonotonicClock,
     pub(super) catalogue_entries: HashMap<ObjectId, CatalogueEntry>,
     pub(super) allow_unprivileged_schema_catalogue_writes: bool,
@@ -232,6 +235,7 @@ impl SyncManager {
     pub fn new() -> Self {
         Self {
             clock: MonotonicClock::new(),
+            read_frontier_authority: true,
             catalogue_entries: HashMap::new(),
             allow_unprivileged_schema_catalogue_writes: false,
             servers: HashMap::new(),
@@ -291,6 +295,22 @@ impl SyncManager {
     /// (worker/edge/global) rather than a top-level client.
     pub fn has_durability_identity(&self) -> bool {
         !self.my_tiers.is_empty()
+    }
+
+    /// Mark this node as a replica client: its durability identity still
+    /// settles the writes it accepts, but tier reads must wait for the
+    /// upstream query frontier.
+    pub fn as_replica_client(mut self) -> Self {
+        self.read_frontier_authority = false;
+        self
+    }
+
+    /// True when this node's local store is authoritative for reads at its
+    /// identity tiers (servers). Replica clients return false: an answer
+    /// served before the frontier is confirmed would present "not synced
+    /// yet" as "does not exist".
+    pub fn read_frontier_authority(&self) -> bool {
+        self.read_frontier_authority
     }
 
     /// True when this node can satisfy acknowledgements for the requested tier


### PR DESCRIPTION
We run gateways as edge-tier clients that replicate from an upstream server. Because the client claims the edge tier, reads at that tier were satisfied from its local store, so a cold replica answered with an authoritative-looking empty result instead of waiting for the upstream query frontier (for us: logins failing right after a deploy). This tracks read-frontier authority on the sync manager: servers keep it, replica clients give it up while their durability identity still settles the writes they accept.

cargo test -p jazz-tools --lib --features test-utils passes (1382).