### PR TITLE
fix: recover id-seeks from wrong or missing row locators

### DIFF
--- a/crates/jazz-tools/src/query_manager/manager_tests/subscriptions.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests/subscriptions.rs
@@ -1200,6 +1200,144 @@ fn subscribe_with_sync_local_only_on_persistence_tier_does_not_send_upstream() {
 }
 
 #[test]
+fn failed_update_on_unknown_row_leaves_no_row_locator() {
+    use crate::object::ObjectId;
+
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let (mut qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    let unknown_row = ObjectId::new();
+    let result = qm.update(
+        &mut storage,
+        unknown_row,
+        &[Value::Text("ghost".into()), Value::Integer(1)],
+    );
+    assert!(result.is_err(), "updating an unknown row must fail");
+
+    // The failed write must not leave a locator behind: one minted here
+    // would claim the row originates locally at the current schema hash and
+    // misdirect every id-seek once the real row syncs in from upstream.
+    assert_eq!(
+        storage.load_row_locator(unknown_row).unwrap(),
+        None,
+        "a failed write must not mint a row locator"
+    );
+}
+
+#[test]
+fn incoming_row_metadata_repairs_divergent_row_locator() {
+    use crate::storage::RowLocator;
+    use crate::sync_manager::{InboxEntry, ServerId, Source, SyncPayload};
+    use uuid::Uuid;
+
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let (mut qm, mut storage) = create_query_manager(sync_manager, schema.clone());
+
+    // Seed a row through the normal local path, then corrupt its locator the
+    // way a failed pre-fix write did: wrong origin schema hash.
+    let handle = qm
+        .insert(
+            &mut storage,
+            "users",
+            &[Value::Text("Alice".into()), Value::Integer(100)],
+        )
+        .unwrap();
+    let row_id = handle.row_id;
+    qm.process(&mut storage);
+
+    let correct = storage.load_row_locator(row_id).unwrap().unwrap();
+    let wrong_hash = crate::query_manager::types::SchemaHash::from_bytes([9u8; 32]);
+    storage
+        .put_row_locator(
+            row_id,
+            Some(&RowLocator {
+                table: correct.table.clone(),
+                origin_schema_hash: Some(wrong_hash),
+            }),
+        )
+        .unwrap();
+
+    // A row batch arriving with authoritative metadata must repair the
+    // locator, not merely note the divergence.
+    let descriptor = RowDescriptor::new(vec![
+        ColumnDescriptor::new("name", ColumnType::Text),
+        ColumnDescriptor::new("score", ColumnType::Integer),
+    ]);
+    let data = encode_row(
+        &descriptor,
+        &[Value::Text("Alice Synced".into()), Value::Integer(200)],
+    )
+    .unwrap();
+    let branch = qm.current_branch();
+    let commit = stored_row_commit(smallvec![], data, 42, row_id.to_string());
+    let row = commit.to_row(row_id, &branch, RowState::VisibleDirect);
+    let metadata = crate::storage::metadata_from_row_locator(&correct);
+    qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Server(ServerId(Uuid::new_v7(uuid::Timestamp::now(
+            uuid::NoContext,
+        )))),
+        payload: SyncPayload::RowBatchCreated {
+            metadata: Some(crate::sync_manager::RowMetadata {
+                id: row_id,
+                metadata: metadata.clone(),
+            }),
+            row,
+        },
+    });
+    qm.process(&mut storage);
+
+    assert_eq!(
+        storage.load_row_locator(row_id).unwrap(),
+        Some(correct.clone()),
+        "server metadata must repair a divergent row locator"
+    );
+
+    // The same metadata arriving from a downstream client must not rewrite
+    // the locator: clients get no authority over where rows live.
+    storage
+        .put_row_locator(
+            row_id,
+            Some(&RowLocator {
+                table: correct.table.clone(),
+                origin_schema_hash: Some(wrong_hash),
+            }),
+        )
+        .unwrap();
+    let client_id = crate::sync_manager::ClientId::new();
+    connect_client(&mut qm, &storage, client_id);
+    let data = encode_row(
+        &descriptor,
+        &[Value::Text("Alice Client".into()), Value::Integer(300)],
+    )
+    .unwrap();
+    let commit = stored_row_commit(smallvec![], data, 43, row_id.to_string());
+    let row = commit.to_row(row_id, &branch, RowState::VisibleDirect);
+    qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::RowBatchCreated {
+            metadata: Some(crate::sync_manager::RowMetadata {
+                id: row_id,
+                metadata,
+            }),
+            row,
+        },
+    });
+    qm.process(&mut storage);
+
+    assert_eq!(
+        storage
+            .load_row_locator(row_id)
+            .unwrap()
+            .unwrap()
+            .origin_schema_hash,
+        Some(wrong_hash),
+        "client metadata must not rewrite the locator"
+    );
+}
+
+#[test]
 fn local_durability_tier_subscription_ignores_stale_upstream_scope() {
     use crate::sync_manager::{DurabilityTier, InboxEntry, QueryId, ServerId, Source, SyncPayload};
     use uuid::Uuid;

--- a/crates/jazz-tools/src/query_manager/writes.rs
+++ b/crates/jazz-tools/src/query_manager/writes.rs
@@ -416,18 +416,31 @@ impl QueryManager {
         self.ensure_known_schemas_catalogued(storage)
             .map_err(|err| QueryError::EncodingError(format!("persist known schemas: {err}")))?;
 
-        if storage
+        let minted_row_locator = if storage
             .load_row_locator(row_id)
             .map_err(|err| QueryError::EncodingError(format!("load row locator: {err}")))?
             .is_none()
         {
             let row_locator = self.row_locator_for_branch(table, branch_name.as_str());
             self.persist_row_locator(storage, row_id, &row_locator);
-        }
+            true
+        } else {
+            false
+        };
 
         let forwarded_row = row.clone();
-        let applied = apply_row_batch(storage, row_id, branch_name, row, index_mutations)
-            .map_err(|error| Self::query_error_for_local_row_history_write(row_id, error))?;
+        let applied = match apply_row_batch(storage, row_id, branch_name, row, index_mutations) {
+            Ok(applied) => applied,
+            Err(error) => {
+                // A failed apply did not establish the row; a locator minted
+                // for it would misdirect every id-seek once the real row
+                // syncs in.
+                if minted_row_locator {
+                    let _ = storage.put_row_locator(row_id, None);
+                }
+                return Err(Self::query_error_for_local_row_history_write(row_id, error));
+            }
+        };
 
         self.finish_local_row_history_write(storage, table, row_id, forwarded_row, applied)
     }

--- a/crates/jazz-tools/src/storage/conformance.rs
+++ b/crates/jazz-tools/src/storage/conformance.rs
@@ -603,6 +603,80 @@ pub fn test_visible_region_uses_flat_bytes_when_schema_known(
     );
 }
 
+pub fn test_visible_row_seek_falls_back_when_locator_is_wrong(
+    factory: &dyn Fn() -> Box<dyn Storage>,
+) {
+    let mut storage = factory();
+    let schema_hash = seed_row_history_table(storage.as_mut(), "tasks");
+    let schema = row_history_test_schema("tasks");
+    let descriptor = row_history_user_descriptor();
+    let row_id = ObjectId::new();
+
+    let row = StoredRowBatch::new(
+        row_id,
+        "main",
+        Vec::new(),
+        encode_row(&descriptor, &[Value::Text("survive".to_string())]).unwrap(),
+        RowProvenance::for_insert("alice".to_string(), 100),
+        HashMap::new(),
+        RowState::VisibleDirect,
+        Some(DurabilityTier::Local),
+    );
+    let entry = VisibleRowEntry::rebuild(row.clone(), std::slice::from_ref(&row));
+
+    storage
+        .upsert_catalogue_entry(&CatalogueEntry {
+            object_id: schema_hash.to_object_id(),
+            metadata: HashMap::from([(
+                MetadataKey::Type.to_string(),
+                ObjectType::CatalogueSchema.to_string(),
+            )]),
+            content: encode_schema(&schema),
+        })
+        .unwrap();
+    storage
+        .put_row_locator(
+            row_id,
+            Some(&crate::storage::RowLocator {
+                table: "tasks".into(),
+                origin_schema_hash: Some(schema_hash),
+            }),
+        )
+        .unwrap();
+    storage
+        .upsert_visible_region_rows("tasks", std::slice::from_ref(&entry))
+        .unwrap();
+
+    // Corrupt the row locator the way a failed pre-repair write did, and
+    // drop the branch-exact locator so neither resolution path can find the
+    // row. Scans would still see it; the seek must not see less.
+    storage
+        .put_row_locator(
+            row_id,
+            Some(&crate::storage::RowLocator {
+                table: "tasks".into(),
+                origin_schema_hash: Some(SchemaHash::from_bytes([9u8; 32])),
+            }),
+        )
+        .unwrap();
+    storage
+        .raw_table_delete(
+            super::VISIBLE_ROW_TABLE_LOCATOR_TABLE,
+            &super::visible_row_table_locator_key("main", row_id),
+        )
+        .unwrap();
+
+    let encoded = storage
+        .load_visible_region_row_bytes("tasks", "main", row_id)
+        .unwrap()
+        .expect("a seek with a wrong locator must fall back to the raw tables");
+
+    assert_eq!(
+        decode_flat_visible_row_entry(&descriptor, row_id, "main", &encoded).unwrap(),
+        entry
+    );
+}
+
 pub fn test_visible_region_does_not_write_separate_batch_side_index(
     factory: &dyn Fn() -> Box<dyn Storage>,
 ) {
@@ -1466,6 +1540,11 @@ macro_rules! storage_conformance_tests {
             #[test]
             fn row_locator_isolation() {
                 conformance::test_row_locator_isolation(&$factory);
+            }
+
+            #[test]
+            fn visible_row_seek_falls_back_when_locator_is_wrong() {
+                conformance::test_visible_row_seek_falls_back_when_locator_is_wrong(&$factory);
             }
 
             #[test]

--- a/crates/jazz-tools/src/storage/mod.rs
+++ b/crates/jazz-tools/src/storage/mod.rs
@@ -2180,7 +2180,7 @@ pub(super) fn load_history_row_batch_row_bytes_with_storage<H: Storage + ?Sized>
 
 pub(super) fn load_visible_region_row_bytes_with_storage<H: Storage + ?Sized>(
     storage: &H,
-    _table: &str,
+    table: &str,
     branch: &str,
     row_id: ObjectId,
 ) -> Result<Option<OwnedVisibleRowBytes>, StorageError> {
@@ -2207,28 +2207,51 @@ pub(super) fn load_visible_region_row_bytes_with_storage<H: Storage + ?Sized>(
         }
     }
 
-    let Some(locator) = storage.load_visible_row_table_locator(branch, row_id)? else {
-        return Ok(None);
-    };
-    let resolved = resolved_row_table_from_locator(storage, &locator)?
-        .expect("locator-resolved row table must exist");
-    let row_raw_table = locator.row_raw_table.to_string();
-    Ok(storage
-        .raw_table_get(&row_raw_table, &key)?
-        .map(|bytes| OwnedVisibleRowBytes {
-            row_raw_table_id: RowRawTableId {
-                kind: RowRawTableKind::Visible,
-                table_name: locator.table_name.clone(),
-                schema_hash: locator.schema_hash,
-                raw_table_name: locator.row_raw_table.clone(),
-            },
-            row_raw_table,
-            user_descriptor: resolved.user_descriptor,
-            branch: branch.to_string(),
-            row_id,
-            needs_exact_locator: true,
-            bytes,
-        }))
+    if let Some(locator) = storage.load_visible_row_table_locator(branch, row_id)? {
+        let resolved = resolved_row_table_from_locator(storage, &locator)?
+            .expect("locator-resolved row table must exist");
+        let row_raw_table = locator.row_raw_table.to_string();
+        if let Some(bytes) = storage.raw_table_get(&row_raw_table, &key)? {
+            return Ok(Some(OwnedVisibleRowBytes {
+                row_raw_table_id: RowRawTableId {
+                    kind: RowRawTableKind::Visible,
+                    table_name: locator.table_name.clone(),
+                    schema_hash: locator.schema_hash,
+                    raw_table_name: locator.row_raw_table.clone(),
+                },
+                row_raw_table,
+                user_descriptor: resolved.user_descriptor,
+                branch: branch.to_string(),
+                row_id,
+                needs_exact_locator: true,
+                bytes,
+            }));
+        }
+    }
+
+    // Scans union every schema generation's raw table, so a seek must too:
+    // a wrong locator can point away from the generation that holds the
+    // row. The exact-locator request repairs the seek for the next access.
+    for row_raw_table_id in row_raw_table_ids_for_table(storage, RowRawTableKind::Visible, table)? {
+        if let Some(bytes) = storage.raw_table_get(row_raw_table_id.raw_table_name(), &key)? {
+            let Some(resolved) = resolved_row_table_from_id(storage, row_raw_table_id.clone())?
+            else {
+                continue;
+            };
+            let row_raw_table = row_raw_table_id.raw_table_name().to_string();
+            return Ok(Some(OwnedVisibleRowBytes {
+                row_raw_table_id: row_raw_table_id.clone(),
+                row_raw_table,
+                user_descriptor: resolved.user_descriptor,
+                branch: branch.to_string(),
+                row_id,
+                needs_exact_locator: true,
+                bytes,
+            }));
+        }
+    }
+
+    Ok(None)
 }
 
 fn scan_history_row_batches_for_schema_hash<H: Storage + ?Sized>(

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -226,6 +226,7 @@ impl SyncManager {
         storage: &mut H,
         object_id: ObjectId,
         metadata: HashMap<String, String>,
+        metadata_is_authoritative: bool,
     ) -> (bool, bool) {
         let existing_row_locator = storage.load_row_locator(object_id).ok().flatten();
         let Some(metadata_row_locator) = crate::storage::row_locator_from_metadata(&metadata)
@@ -234,10 +235,18 @@ impl SyncManager {
         };
         let metadata_schema_hash = metadata_row_locator.origin_schema_hash;
         match existing_row_locator {
-            Some(existing_row_locator) => (
-                false,
-                existing_row_locator.origin_schema_hash != metadata_schema_hash,
-            ),
+            Some(existing_row_locator) => {
+                let diverged = existing_row_locator.origin_schema_hash != metadata_schema_hash;
+                if diverged && metadata_is_authoritative {
+                    // An upstream server is authoritative about where the
+                    // row's data lives: repair a divergent local locator
+                    // (typically minted by a local write that raced the
+                    // row's arrival). Downstream client metadata gets no
+                    // such trust.
+                    let _ = storage.put_row_locator(object_id, Some(&metadata_row_locator));
+                }
+                (false, diverged)
+            }
             None => {
                 let _ = storage.put_row_locator(object_id, Some(&metadata_row_locator));
                 (true, false)
@@ -399,6 +408,7 @@ impl SyncManager {
         metadata: Option<RowMetadata>,
         mut row: StoredRowBatch,
         fate_recording: AuthoritativeFateRecording,
+        metadata_is_authoritative: bool,
     ) -> Option<AppliedRowBatch> {
         let authoritative_tier = match (row.confirmed_tier, self.max_local_durability_tier()) {
             (Some(incoming), Some(local)) => Some(incoming.max(local)),
@@ -429,8 +439,12 @@ impl SyncManager {
             }
             row.state = RowState::Rejected;
         }
-        let (is_newly_located_object, needs_exact_locator) =
-            self.ensure_object_metadata(storage, row.row_id, metadata.clone());
+        let (is_newly_located_object, needs_exact_locator) = self.ensure_object_metadata(
+            storage,
+            row.row_id,
+            metadata.clone(),
+            metadata_is_authoritative,
+        );
         let branch_name = BranchName::new(&row.branch);
         let visibility_change =
             match self.row_context_from_metadata(storage, &metadata, needs_exact_locator) {
@@ -1348,6 +1362,7 @@ impl SyncManager {
                     metadata,
                     row.clone(),
                     AuthoritativeFateRecording::AcceptedByLocalAuthority,
+                    true,
                 ) {
                     self.apply_authoritative_transaction_fate_for_row(
                         storage,
@@ -1880,7 +1895,7 @@ impl SyncManager {
                     .insert(client_id);
 
                 if let Some(applied) =
-                    self.apply_row_updated(storage, metadata, row.clone(), fate_recording)
+                    self.apply_row_updated(storage, metadata, row.clone(), fate_recording, false)
                 {
                     self.forward_row_batch_to_servers(
                         storage,


### PR DESCRIPTION
A row locator minted by a local write that races the row's arrival (or by a write whose apply fails) points at the wrong origin and misdirects every id-seek for that row from then on; we hit this as rows that exist upstream staying unreadable on a replica. Three repairs: roll back locators minted by failed applies, let authoritative upstream metadata fix a divergent local locator (downstream clients get no such trust), and make id-seeks fall back to the per-generation raw tables like scans already do so a wrong locator cannot hide an existing row. Covered by storage conformance tests.

cargo test -p jazz-tools --lib --features test-utils passes (1382).