### PR TITLE
(new core) perf: bound current-row validation on open

### DIFF
--- a/crates/jazz-tools/benches/realistic_phase1.rs
+++ b/crates/jazz-tools/benches/realistic_phase1.rs
@@ -1168,7 +1168,7 @@ struct R3OpenBreakdown {
     validated_current_rows: usize,
     accepted_global_sequences: usize,
     global_sequence_records_scanned: usize,
-    ahead_current_entries: usize,
+    validated_ahead_current_rows: usize,
 }
 
 #[cfg(feature = "rocksdb")]
@@ -1338,7 +1338,7 @@ fn open_rocks_db_with_phases(
                 validated_current_rows: receipt.validated_current_rows,
                 accepted_global_sequences: receipt.accepted_global_sequences,
                 global_sequence_records_scanned: receipt.global_sequence_records_scanned,
-                ahead_current_entries: receipt.ahead_current_entries,
+                validated_ahead_current_rows: receipt.validated_ahead_current_rows,
             }),
         )
     };
@@ -1576,10 +1576,10 @@ fn emit_r3_phase_receipts(path: &Path, project: RowUuid, selected: R3Profile) {
                     .open_breakdown
                     .as_ref()
                     .map(|receipt| receipt.global_sequence_records_scanned),
-                "ahead_current_entries": samples[0]
+                "validated_ahead_current_rows": samples[0]
                     .open_breakdown
                     .as_ref()
-                    .map(|receipt| receipt.ahead_current_entries),
+                    .map(|receipt| receipt.validated_ahead_current_rows),
                 "prepare_p50_us": median_us(&samples, |sample| sample.prepare),
                 "first_read_p50_us": median_us(&samples, |sample| sample.first_read),
                 })

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -109,7 +109,7 @@ pub struct NodeOpenReceipt {
     pub recover_storage: Duration,
     /// Recover close markers, aliases, branches, and transaction-clock bounds.
     pub recover_catalogue_state: Duration,
-    /// Validate persisted current rows and rebuild the ahead-current indexes.
+    /// Validate representative persisted current rows for storage-layout compatibility.
     pub validate_current_rows: Duration,
     /// Recover the accepted-global-sequence watermark set.
     pub recover_global_sequences: Duration,
@@ -121,14 +121,14 @@ pub struct NodeOpenReceipt {
     pub recover_known_state: Duration,
     /// Ensure aliases and persist any missing base catalogue records.
     pub finalize_catalogue: Duration,
-    /// Current rows decoded by startup layout validation.
+    /// Representative current rows decoded by startup layout validation.
     pub validated_current_rows: usize,
     /// Accepted global sequence records consumed during recovery.
     pub accepted_global_sequences: usize,
     /// Transaction-index records scanned while recovering global sequences.
     pub global_sequence_records_scanned: usize,
-    /// Ahead-current records consumed while rebuilding in-memory indexes.
-    pub ahead_current_entries: usize,
+    /// Representative ahead-current rows decoded by startup layout validation.
+    pub validated_ahead_current_rows: usize,
 }
 
 #[cfg(test)]

--- a/crates/jazz/src/node/recovery.rs
+++ b/crates/jazz/src/node/recovery.rs
@@ -129,14 +129,14 @@ where
         #[cfg(feature = "testing")]
         let mut validated_current_rows = 0usize;
         #[cfg(feature = "testing")]
-        let mut ahead_current_entries = 0usize;
+        let mut validated_ahead_current_rows = 0usize;
         for table in self.catalogue.schema.tables.clone() {
             #[cfg(feature = "testing")]
             {
                 self.validate_current_row_storage_layout(
                     &table,
                     &mut validated_current_rows,
-                    &mut ahead_current_entries,
+                    &mut validated_ahead_current_rows,
                 )?;
             }
             #[cfg(not(feature = "testing"))]
@@ -162,7 +162,7 @@ where
         if let (Some(receipt), Some(started)) = (&mut receipt, stage_started) {
             receipt.validate_current_rows = started.elapsed();
             receipt.validated_current_rows = validated_current_rows;
-            receipt.ahead_current_entries = ahead_current_entries;
+            receipt.validated_ahead_current_rows = validated_ahead_current_rows;
         }
         #[cfg(feature = "testing")]
         let stage_started = receipt.as_ref().map(|_| Instant::now());
@@ -314,6 +314,12 @@ where
         #[cfg(feature = "testing")] rows: &mut usize,
         #[cfg(feature = "testing")] ahead_rows: &mut usize,
     ) -> Result<(), Error> {
+        // This treats startup validation as a storage-format compatibility
+        // check, not a full integrity scan. Under the supported lifecycle, one
+        // binary writes one current-row layout and open completes before writes
+        // are accepted. Decode one representative row from each non-empty table
+        // so uniformly old-format stores still fail loudly without making every
+        // open O(current rows). Isolated corruption is detected when accessed.
         let storage_tables = table.global_current_storage_tables();
         self.validate_content_current_rows(
             &storage_tables[0],
@@ -354,19 +360,16 @@ where
         #[cfg(feature = "testing")] ahead_row_count: &mut usize,
     ) -> Result<(), Error> {
         let descriptor = storage_table.record_schema();
-        let rows = self
+        if let Some(raw) = self
             .database
-            .primary_key_scan_raw(&storage_table.name, &[])?
-            .into_iter()
-            .map(|raw| raw.raw().to_vec())
-            .collect::<Vec<_>>();
-        #[cfg(feature = "testing")]
+            .primary_key_last_raw(&storage_table.name, &[])?
         {
-            *row_count += rows.len();
-            *ahead_row_count += rows.len();
-        }
-        for raw in rows {
-            let record = BorrowedRecord::new(&raw, &descriptor);
+            #[cfg(feature = "testing")]
+            {
+                *row_count += 1;
+                *ahead_row_count += 1;
+            }
+            let record = BorrowedRecord::new(raw.raw(), &descriptor);
             match layer {
                 VersionLayer::Content => {
                     record.get_u64(GlobalCurrentRowRecord::FIELD_SCHEMA_VERSION_IDX)?;
@@ -396,14 +399,14 @@ where
         #[cfg(feature = "testing")] row_count: &mut usize,
     ) -> Result<(), Error> {
         let descriptor = storage_table.record_schema();
-        let rows = self
+        if let Some(raw) = self
             .database
-            .primary_key_scan_raw(&storage_table.name, &[])?;
-        #[cfg(feature = "testing")]
+            .primary_key_last_raw(&storage_table.name, &[])?
         {
-            *row_count += rows.len();
-        }
-        for raw in rows {
+            #[cfg(feature = "testing")]
+            {
+                *row_count += 1;
+            }
             let record = BorrowedRecord::new(raw.raw(), &descriptor);
             record.get_u64(GlobalCurrentRowRecord::FIELD_SCHEMA_VERSION_IDX)?;
             record.get_idx(GlobalCurrentRowRecord::FIELD_PARENTS_IDX)?;
@@ -418,14 +421,14 @@ where
         #[cfg(feature = "testing")] row_count: &mut usize,
     ) -> Result<(), Error> {
         let descriptor = storage_table.record_schema();
-        let rows = self
+        if let Some(raw) = self
             .database
-            .primary_key_scan_raw(&storage_table.name, &[])?;
-        #[cfg(feature = "testing")]
+            .primary_key_last_raw(&storage_table.name, &[])?
         {
-            *row_count += rows.len();
-        }
-        for raw in rows {
+            #[cfg(feature = "testing")]
+            {
+                *row_count += 1;
+            }
             let record = BorrowedRecord::new(raw.raw(), &descriptor);
             record.get_u64(RegisterGlobalCurrentRowRecord::FIELD_SCHEMA_VERSION_IDX)?;
             record.get_idx(RegisterGlobalCurrentRowRecord::FIELD_PARENTS_IDX)?;

--- a/crates/jazz/src/node/tests/recovery.rs
+++ b/crates/jazz/src/node/tests/recovery.rs
@@ -163,6 +163,49 @@ fn opening_rejects_malformed_representative_ahead_current_row() {
 }
 
 #[test]
+fn opening_defers_isolated_non_representative_corruption_until_read() {
+    let schema = schema();
+    let temp_dir = tempfile::tempdir().unwrap();
+    {
+        let mut node = open_node_at(&temp_dir, schema.clone());
+        node.commit_mergeable(
+            MergeableCommit::new("todos", row(1), 10).cells(title_cells("corrupt me")),
+        )
+        .unwrap();
+        node.commit_mergeable(
+            MergeableCommit::new("todos", row(0xff), 11).cells(title_cells("representative")),
+        )
+        .unwrap();
+        let table = schema.tables[0].ahead_current_storage_tables()[0]
+            .name
+            .clone();
+        let (key, raw) = node
+            .database
+            .primary_key_scan_raw(&table, &[])
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap()
+            .into_parts();
+        node.database.close().unwrap();
+        drop(node);
+        let cfs = schema.column_families();
+        let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+        let storage = RocksDbStorage::open(temp_dir.path(), &refs).unwrap();
+        let storage =
+            groove::storage::LayoutStorage::new(storage, StorageLayout::jazz_class_v1()).unwrap();
+        storage.set(&table, &key, &raw[..1]).unwrap();
+        storage.close().unwrap();
+    }
+
+    let mut reopened = reopen_node_at(&temp_dir, node(1), schema);
+    assert!(
+        reopened.local_current_row("todos", row(1)).is_err(),
+        "isolated corruption outside the representative row must fail when read"
+    );
+}
+
+#[test]
 fn recovery_uses_storage_fallback_for_deletion_versions() {
     let schema = schema();
     let temp_dir = tempfile::tempdir().unwrap();

--- a/crates/jazz/src/node/tests/recovery.rs
+++ b/crates/jazz/src/node/tests/recovery.rs
@@ -74,7 +74,10 @@ fn recovery_reads_latest_ahead_current_and_fallback_versions_from_storage() {
     let mut reopened = NodeState::new(node(1), schema, storage).unwrap();
 
     #[cfg(feature = "testing")]
-    assert_eq!(receipt.ahead_current_entries, 2);
+    {
+        assert_eq!(receipt.validated_current_rows, 1);
+        assert_eq!(receipt.validated_ahead_current_rows, 1);
+    }
     reopened.reset_storage_read_metrics();
     assert_eq!(
         reopened
@@ -114,6 +117,48 @@ fn recovery_reads_latest_ahead_current_and_fallback_versions_from_storage() {
             .map(current_row_pair)
             .collect::<BTreeMap<_, _>>(),
         BTreeMap::from([(row(11), title_cells("first"))])
+    );
+}
+
+#[test]
+fn opening_rejects_malformed_representative_ahead_current_row() {
+    let schema = schema();
+    let temp_dir = tempfile::tempdir().unwrap();
+    {
+        let mut node = open_node_at(&temp_dir, schema.clone());
+        node.commit_mergeable(MergeableCommit::new("todos", row(0xff), 10).cells(title_cells(
+            "latest",
+        )))
+            .unwrap();
+        let table = schema.tables[0].ahead_current_storage_tables()[0]
+            .name
+            .clone();
+        let (key, raw) = node
+            .database
+            .primary_key_last_raw(&table, &[])
+            .unwrap()
+            .unwrap()
+            .into_parts();
+        node.database.close().unwrap();
+        drop(node);
+        let cfs = schema.column_families();
+        let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+        let storage = RocksDbStorage::open(temp_dir.path(), &refs).unwrap();
+        let storage =
+            groove::storage::LayoutStorage::new(storage, StorageLayout::jazz_class_v1()).unwrap();
+        storage.set(&table, &key, &raw[..1]).unwrap();
+        storage.close().unwrap();
+    }
+
+    let cfs = schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage = RocksDbStorage::open(temp_dir.path(), &refs).unwrap();
+    let Err(error) = NodeState::new(node(1), schema, storage) else {
+        panic!("malformed representative current row must fail open");
+    };
+    assert!(
+        matches!(error, Error::Record(_)),
+        "unexpected open error: {error}"
     );
 }
 


### PR DESCRIPTION
## Summary

- treat startup current-row validation as a storage-format compatibility check rather than a full integrity scan
- decode one representative row from each non-empty global/ahead current table
- keep malformed representative data failing loudly during open
- rename the R3 counters to report representative rows actually validated

This is stacked on #1199.

## Why

After #1199 removes eager ahead-current index reconstruction, startup still scans and decodes every current row solely for layout validation. In R3 profile M that means 952,620 records and accounts for effectively the entire remaining Jazz open time.

The scan was introduced when winner metadata was denormalized into current rows, to reject uniformly old-format stores. It is not specified as a comprehensive logical-integrity scan.

Under the supported lifecycle, one binary writes one current-row layout and opening completes before writes are accepted. This change samples the last row in each non-empty current table to preserve that compatibility check. Isolated malformed records are instead detected when accessed.

## Result

Profile M, warm OS page cache, clean database close, three samples:

- Jazz open: 408 ms → 1.47 ms
- current-row validation: 407 ms → 0.66 ms
- first read: 326 ms
- reopen + first read: 766 ms → 338 ms (about 56% faster)

The measured store validates eight representative ahead-current rows rather than scanning 952,620 records.

## Safety boundary

This intentionally changes the startup guarantee:

- uniformly old-format tables still fail during open
- a malformed sampled row still fails during open
- isolated corruption in a non-sampled row is detected when that row is decoded, not necessarily during open

There is currently no persisted Jazz row-envelope identifier and no normative specification requiring an exhaustive logical-integrity scan on every open.

Nearby mechanisms do not cover this:

- Groove's `groove-storage-layout = class-cf-v1` marker identifies physical class-CF mapping, not record encoding
- `SchemaVersionId` identifies the application schema, not Jazz's fixed current-row system envelope
- `RecordDescriptor` identity is process-local/intern-based, not a durable deterministic identifier

## Validation

- `cargo test -p jazz`
- `cargo test -p jazz --features testing`
- 732 unit tests passed and one ignored in each configuration
- all integration suites and 32 doctests passed
- focused malformed-representative recovery test
- `cargo clippy -p jazz --lib --features testing -- -D warnings`
- attributed R3 benchmark target compiled and ran
- pre-commit Clippy, sensitive-data, and rustfmt hooks passed

## Direction requested

I think the team should explicitly choose one of these startup contracts:

1. **Accept this PR:** opening checks format compatibility with representative rows; ordinary decoding catches isolated corruption lazily.
2. **Add a durable Jazz row-envelope marker:** an unmarked store receives one exhaustive certification scan, then persists a format version/fingerprint so later opens are O(1). This is the strongest long-term option, but adds a new migration/storage contract.
3. **Retain exhaustive validation:** every open remains a full logical-integrity scan and pays O(current rows).

My preference is option 2 long-term. This PR provides the measured upper bound and a concrete option 1 implementation, but the compatibility-versus-integrity policy should be a team decision.
