### PR TITLE
fix: align native runtime event types

### DIFF
--- a/.changeset/quiet-websockets-smile.md
+++ b/.changeset/quiet-websockets-smile.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Correct the native runtime's WebSocket close-event and subscription error-stack types.

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-protocol.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-protocol.ts
@@ -145,7 +145,7 @@ export type PersistentBrowserSubscriptionMessage = {
   subscription: number;
 } & (
   | { frame: PersistentBrowserSubscriptionFrame }
-  | { error: { name?: string; message?: string } }
+  | { error: { name?: string; message?: string; stack?: string } }
 );
 
 export function isNativeRowDelta(value: unknown): value is NativeRowDelta {

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { NativeRowDelta, WasmSchema } from "../../drivers/types.js";
+import type { PersistentBrowserSubscriptionMessage } from "./persistent-browser-protocol.js";
 import {
   PersistentBrowserOpfsRuntime,
   type PersistentBrowserOpfsOwnerRequest,
@@ -76,13 +77,14 @@ class FakeWorker {
     });
   }
 
-  emitSubscriptionError(subscription: number, message: string): void {
+  emitSubscriptionError(subscription: number, message: string, stack?: string): void {
+    const data = {
+      subscription,
+      error: { name: "Error", message, stack },
+    } satisfies PersistentBrowserSubscriptionMessage;
     queueMicrotask(() => {
       this.onmessage?.({
-        data: {
-          subscription,
-          error: { name: "Error", message },
-        },
+        data,
       } as MessageEvent);
     });
   }
@@ -438,13 +440,14 @@ describe("PersistentBrowserOpfsRuntime", () => {
     );
     worker.respond(createSubscriptionMessage!.id, 7);
 
-    worker.emitSubscriptionError(subscriptionHandle, "server transport died");
+    worker.emitSubscriptionError(subscriptionHandle, "server transport died", "remote stack");
 
     await vi.waitFor(() => {
       expect(updates).toHaveLength(1);
     });
     expect(updates[0]![0]).toBeInstanceOf(Error);
     expect((updates[0]![0] as Error).message).toBe("server transport died");
+    expect((updates[0]![0] as Error).stack).toBe("remote stack");
     expect(updates[0]![1]).toBeNull();
 
     await runtime.close();

--- a/packages/jazz-tools/src/runtime/native-runtime/websocket.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/websocket.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
+import type { BrowserWebSocket } from "./websocket.js";
 import { PostcardReader, PostcardWriter } from "./native-codec.js";
 import {
   CLIENT_WIRE_FEATURES,
@@ -19,6 +20,15 @@ import {
 } from "./websocket.js";
 
 describe("websocket frame carrier", () => {
+  it("types close listeners with close event details", () => {
+    type CloseListener = Parameters<BrowserWebSocket["addEventListener"]>[1];
+
+    expectTypeOf<Parameters<CloseListener>[0]>().toEqualTypeOf<{
+      code: number;
+      reason: string;
+    }>();
+  });
+
   it("encodes websocket messages as postcard batches of encoded frames", () => {
     const frames = [Uint8Array.from([1, 2, 3]), Uint8Array.from([4, 5])];
 

--- a/packages/jazz-tools/src/runtime/native-runtime/websocket.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/websocket.test.ts
@@ -188,8 +188,20 @@ class MessageWebSocket {
 
   close(): void {}
 
-  addEventListener(type: string, listener: (event: { data: unknown }) => void): void {
-    if (type === "message") this.messageListeners.push(listener);
+  addEventListener(type: "open", listener: () => void): void;
+  addEventListener(type: "message", listener: (event: { data: unknown }) => void): void;
+  addEventListener(type: "error", listener: (event: unknown) => void): void;
+  addEventListener(
+    type: "close",
+    listener: (event: { code: number; reason: string }) => void,
+  ): void;
+  addEventListener(
+    type: string,
+    listener: ((event: { data: unknown }) => void) | ((event: unknown) => void),
+  ): void {
+    if (type === "message") {
+      this.messageListeners.push(listener as (event: { data: unknown }) => void);
+    }
   }
 
   emitMessage(data: Uint8Array): void {

--- a/packages/jazz-tools/src/runtime/native-runtime/websocket.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/websocket.test.ts
@@ -195,10 +195,7 @@ class MessageWebSocket {
     type: "close",
     listener: (event: { code: number; reason: string }) => void,
   ): void;
-  addEventListener(
-    type: string,
-    listener: ((event: { data: unknown }) => void) | ((event: unknown) => void),
-  ): void {
+  addEventListener(type: string, listener: unknown): void {
     if (type === "message") {
       this.messageListeners.push(listener as (event: { data: unknown }) => void);
     }

--- a/packages/jazz-tools/src/runtime/native-runtime/websocket.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/websocket.ts
@@ -31,7 +31,10 @@ export type BrowserWebSocket = {
   addEventListener(type: "open", listener: () => void): void;
   addEventListener(type: "message", listener: (event: { data: unknown }) => void): void;
   addEventListener(type: "error", listener: (event: unknown) => void): void;
-  addEventListener(type: "close", listener: () => void): void;
+  addEventListener(
+    type: "close",
+    listener: (event: { code: number; reason: string }) => void,
+  ): void;
 };
 
 export const WIRE_PROTOCOL_VERSION = 3;


### PR DESCRIPTION
## Summary

- type browser WebSocket close callbacks with the close event already consumed by the implementation
- allow persistent subscription errors to carry their optional remote stack
- preserve that stack when reconstructing the local error

Follow-up to the unresolved review comments on #1173:
- https://github.com/garden-co/jazz/pull/1173#discussion_r3675125382
- https://github.com/garden-co/jazz/pull/1173#discussion_r3675170121

## Testing

- `pnpm build:core`
- `dev/gates/ts-wire-codec.sh` (88 passed, 1 skipped)
- focused native-runtime tests (21 passed)
- `pnpm --filter jazz-tools test`: 100 test files and 1,257 tests passed; three existing policy-graph NAPI integration cases timed out in two isolated runs

Includes a patch changeset for `jazz-tools`.