### PR TITLE
fix: lower filtered relation gathers

### DIFF
--- a/.changeset/filtered-gathers-work.md
+++ b/.changeset/filtered-gathers-work.md
@@ -1,0 +1,5 @@
+---
+"@jazz/rust": patch
+---
+
+Apply output filters when lowering recursive relation gathers.

--- a/crates/jazz/src/db/tests.rs
+++ b/crates/jazz/src/db/tests.rs
@@ -2410,6 +2410,32 @@ fn relation_query_gather_uses_unified_reachable_lowering_for_reads_and_subscript
         BTreeSet::from([root, leaf])
     );
 
+    let or_true = RelationQuery {
+        rel: RelationExpr::Filter {
+            input: Box::new(query.rel.clone()),
+            predicate: RelationPredicate::Or(vec![
+                RelationPredicate::True,
+                RelationPredicate::False,
+            ]),
+        },
+    };
+    let unfiltered = block_on(db.all_relation_query(&or_true, ReadOpts::default())).unwrap();
+    assert_eq!(
+        row_ids(&unfiltered.rows)
+            .into_iter()
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([root, middle, leaf])
+    );
+
+    let not_true = RelationQuery {
+        rel: RelationExpr::Filter {
+            input: Box::new(query.rel.clone()),
+            predicate: RelationPredicate::Not(Box::new(RelationPredicate::True)),
+        },
+    };
+    let empty = block_on(db.all_relation_query(&not_true, ReadOpts::default())).unwrap();
+    assert!(empty.rows.is_empty());
+
     let filter_after_limit = RelationQuery {
         rel: RelationExpr::Filter {
             input: Box::new(RelationExpr::Limit {

--- a/crates/jazz/src/db/tests.rs
+++ b/crates/jazz/src/db/tests.rs
@@ -17,8 +17,9 @@ use crate::protocol_limits::{
     MAX_SHAPE_AST_BYTES, MAX_SYNC_MESSAGE_BYTES, MAX_WIRE_FRAME_BYTES,
 };
 use crate::query::{
-    ArraySubquery, BindingId, Include, JoinMode, OrderDirection, PolicyBranch, Predicate, ShapeId,
-    all_of, any_of, claim, col, contains, eq, gt, in_list, is_null, lit, lte, ne, not,
+    ArraySubquery, BindingId, Include, JoinMode, OrderDirection, PolicyBranch, Predicate,
+    RelationOrderBy, ShapeId, all_of, any_of, claim, col, contains, eq, gt, in_list, is_null, lit,
+    lte, ne, not,
 };
 use crate::schema::{Policy, TableSchema, WritePolicies};
 use crate::time::{GlobalSeq, TxTime};
@@ -2407,6 +2408,40 @@ fn relation_query_gather_uses_unified_reachable_lowering_for_reads_and_subscript
     assert_eq!(
         row_ids(&filtered.rows).into_iter().collect::<BTreeSet<_>>(),
         BTreeSet::from([root, leaf])
+    );
+
+    let filter_after_limit = RelationQuery {
+        rel: RelationExpr::Filter {
+            input: Box::new(RelationExpr::Limit {
+                input: Box::new(RelationExpr::OrderBy {
+                    input: Box::new(query.rel.clone()),
+                    terms: vec![RelationOrderBy {
+                        column: RelationColumnRef {
+                            scope: Some("teams".to_owned()),
+                            column: "name".to_owned(),
+                        },
+                        direction: OrderDirection::Asc,
+                    }],
+                }),
+                limit: 1,
+            }),
+            predicate: RelationPredicate::Cmp {
+                left: RelationColumnRef {
+                    scope: Some("teams".to_owned()),
+                    column: "name".to_owned(),
+                },
+                op: RelationCmpOp::Eq,
+                right: RelationValueRef::Literal(serde_json::Value::String("root".to_owned())),
+            },
+        },
+    };
+    let error =
+        block_on(db.all_relation_query(&filter_after_limit, ReadOpts::default())).unwrap_err();
+    assert_eq!(error.code, ErrorCode::Query);
+    assert!(
+        error
+            .message
+            .contains("gather output filters cannot wrap limit or offset")
     );
 }
 

--- a/crates/jazz/src/db/tests.rs
+++ b/crates/jazz/src/db/tests.rs
@@ -2389,6 +2389,25 @@ fn relation_query_gather_uses_unified_reachable_lowering_for_reads_and_subscript
         row_ids(&snapshot.rows).into_iter().collect::<BTreeSet<_>>(),
         BTreeSet::from([root, middle, leaf])
     );
+
+    let filtered_query = RelationQuery {
+        rel: RelationExpr::Filter {
+            input: Box::new(query.rel.clone()),
+            predicate: RelationPredicate::Cmp {
+                left: RelationColumnRef {
+                    scope: Some("teams".to_owned()),
+                    column: "name".to_owned(),
+                },
+                op: RelationCmpOp::Ne,
+                right: RelationValueRef::Literal(serde_json::Value::String("middle".to_owned())),
+            },
+        },
+    };
+    let filtered = block_on(db.all_relation_query(&filtered_query, ReadOpts::default())).unwrap();
+    assert_eq!(
+        row_ids(&filtered.rows).into_iter().collect::<BTreeSet<_>>(),
+        BTreeSet::from([root, leaf])
+    );
 }
 
 fn teams_gather_relation_query() -> RelationQuery {

--- a/crates/jazz/src/query.rs
+++ b/crates/jazz/src/query.rs
@@ -946,12 +946,15 @@ fn relation_predicate_to_query_predicate(
                 relation_value_to_operand(right)?,
             ),
         ))),
-        RelationPredicate::And(predicates) => relation_predicate_list(predicates, Predicate::All),
-        RelationPredicate::Or(predicates) => relation_predicate_list(predicates, Predicate::Any),
+        RelationPredicate::And(predicates) => relation_predicate_list(predicates, true),
+        RelationPredicate::Or(predicates) => relation_predicate_list(predicates, false),
         RelationPredicate::Not(predicate) => {
             let Some((scope, predicate)) = relation_predicate_to_query_predicate(predicate)? else {
-                return Ok(None);
+                return Ok(Some((String::new(), Predicate::Any(Vec::new()))));
             };
+            if is_always_false(&predicate) {
+                return Ok(None);
+            }
             Ok(Some((scope, Predicate::Not(Box::new(predicate)))))
         }
         RelationPredicate::True => Ok(None),
@@ -961,15 +964,24 @@ fn relation_predicate_to_query_predicate(
 
 fn relation_predicate_list(
     predicates: &[RelationPredicate],
-    wrap: impl FnOnce(Vec<Predicate>) -> Predicate,
+    is_and: bool,
 ) -> Result<Option<(String, Predicate)>, QueryError> {
     let mut scope = None::<String>;
     let mut items = Vec::new();
     for predicate in predicates {
         let Some((predicate_scope, predicate)) = relation_predicate_to_query_predicate(predicate)?
         else {
-            continue;
+            if is_and {
+                continue;
+            }
+            return Ok(None);
         };
+        if is_always_false(&predicate) {
+            if is_and {
+                return Ok(Some((String::new(), Predicate::Any(Vec::new()))));
+            }
+            continue;
+        }
         if predicate_scope.is_empty() {
             items.push(predicate);
             continue;
@@ -986,9 +998,22 @@ fn relation_predicate_list(
         items.push(predicate);
     }
     let Some(scope) = scope else {
-        return Ok(None);
+        return if is_and {
+            Ok(None)
+        } else {
+            Ok(Some((String::new(), Predicate::Any(Vec::new()))))
+        };
     };
-    Ok(Some((scope, wrap(items))))
+    let predicate = if is_and {
+        Predicate::All(items)
+    } else {
+        Predicate::Any(items)
+    };
+    Ok(Some((scope, predicate)))
+}
+
+fn is_always_false(predicate: &Predicate) -> bool {
+    matches!(predicate, Predicate::Any(predicates) if predicates.is_empty())
 }
 
 fn relation_value_to_operand(value: &RelationValueRef) -> Result<Operand, QueryError> {
@@ -4252,6 +4277,33 @@ mod tests {
         assert_eq!(validated.params()["user"], ColumnType::Uuid);
         assert_eq!(validated.params()["tag"], ColumnType::Uuid);
         assert!(!validated.canonical_bytes().is_empty());
+    }
+
+    #[test]
+    fn relation_predicate_or_true_is_always_true() {
+        let predicate = RelationPredicate::Or(vec![
+            RelationPredicate::True,
+            RelationPredicate::Cmp {
+                left: RelationColumnRef {
+                    scope: Some("issues".to_owned()),
+                    column: "state".to_owned(),
+                },
+                op: RelationCmpOp::Eq,
+                right: RelationValueRef::Literal(serde_json::Value::String("open".to_owned())),
+            },
+        ]);
+
+        assert_eq!(relation_predicate_to_query_predicate(&predicate).unwrap(), None);
+    }
+
+    #[test]
+    fn relation_predicate_not_true_is_always_false() {
+        let predicate = RelationPredicate::Not(Box::new(RelationPredicate::True));
+
+        assert_eq!(
+            relation_predicate_to_query_predicate(&predicate).unwrap(),
+            Some((String::new(), Predicate::Any(Vec::new())))
+        );
     }
 
     #[test]

--- a/crates/jazz/src/query.rs
+++ b/crates/jazz/src/query.rs
@@ -413,6 +413,16 @@ fn peel_relation_output_steps(
     let mut limit = None;
     let mut current = expr;
     loop {
+        if !filters.is_empty()
+            && matches!(
+                current,
+                RelationExpr::Offset { .. } | RelationExpr::Limit { .. }
+            )
+        {
+            return Err(relation_unification_error(
+                "gather output filters cannot wrap limit or offset",
+            ));
+        }
         match current {
             RelationExpr::Filter { input, predicate } => {
                 filters.push(predicate);

--- a/crates/jazz/src/query.rs
+++ b/crates/jazz/src/query.rs
@@ -309,7 +309,7 @@ pub(crate) fn relation_query_to_query(query: &RelationQuery) -> Result<Query, Qu
 /// maintained and one-shot lowering, so relation gathers do not need a second
 /// evaluator or subscription implementation.
 fn relation_gather_to_query(expr: &RelationExpr) -> Result<Option<Query>, QueryError> {
-    let (expr, order_by, offset, limit) = peel_relation_output_steps(expr)?;
+    let (expr, filters, order_by, offset, limit) = peel_relation_output_steps(expr)?;
     let RelationExpr::Gather {
         seed,
         step,
@@ -338,6 +338,17 @@ fn relation_gather_to_query(expr: &RelationExpr) -> Result<Option<Query>, QueryE
         relation_gather_step(step, &seed_table)?;
 
     let mut query = Query::from(seed_table.clone());
+    for filter in filters {
+        let Some((scope, filter)) = relation_predicate_to_query_predicate(filter)? else {
+            continue;
+        };
+        if !scope.is_empty() && scope != seed_table {
+            return Err(relation_unification_error(
+                "gather output filters must be scoped to the gathered table",
+            ));
+        }
+        query = query.filter(filter);
+    }
     query.reachable.push(ReachableVia {
         // Treat each candidate output row as its own access row.  The
         // reachability closure then acts as a membership filter over that
@@ -386,13 +397,27 @@ fn relation_gather_to_query(expr: &RelationExpr) -> Result<Option<Query>, QueryE
 
 fn peel_relation_output_steps(
     expr: &RelationExpr,
-) -> Result<(&RelationExpr, Vec<RelationOrderBy>, usize, Option<usize>), QueryError> {
+) -> Result<
+    (
+        &RelationExpr,
+        Vec<&RelationPredicate>,
+        Vec<RelationOrderBy>,
+        usize,
+        Option<usize>,
+    ),
+    QueryError,
+> {
+    let mut filters = Vec::new();
     let mut order_by = Vec::new();
     let mut offset = 0;
     let mut limit = None;
     let mut current = expr;
     loop {
         match current {
+            RelationExpr::Filter { input, predicate } => {
+                filters.push(predicate);
+                current = input;
+            }
             RelationExpr::OrderBy { input, terms } => {
                 order_by.extend(terms.iter().cloned());
                 current = input;
@@ -415,7 +440,7 @@ fn peel_relation_output_steps(
         }
     }
 
-    Ok((current, order_by, offset, limit))
+    Ok((current, filters, order_by, offset, limit))
 }
 
 fn relation_gather_seed(seed: &RelationExpr) -> Result<(String, Vec<Predicate>), QueryError> {


### PR DESCRIPTION
## Summary

- lower output filters for recursive relation gathers once the gathered table is known
- reject filter wrappers that would otherwise be reordered across limit or offset
- cover direct filtered gathers and unsafe mixed pagination through the public database API

Follow-up to the unresolved review comment on #1173:
- https://github.com/garden-co/jazz/pull/1173#discussion_r3675654993

## Testing

Passed:
- `cargo test -p jazz -j 2`
- `cargo test -p groove -j 2`
- `cargo test -p jazz-server -j 2`
- `cargo check -p jazz-sim --benches`
- `JAZZ_SEED_COUNT=300 cargo test -p jazz m3_maintained_one_shot_differential_oracle`
- all three incremental-delivery canaries
- `dev/benchmarks/smoke.sh` (all scenarios)

Known target-branch failures:
- `cargo test -p jazz-tools --features test -j 2` has an assertion-text mismatch reproduced unchanged on the exact base
- `dev/gates/ts-wire-codec.sh` fails on the two native-runtime type errors fixed by #1204
- the private sensitive-data guard is not available in this checkout

Includes a patch changeset for `@jazz/rust`.