### PR TITLE
(new core) URGENT: handle the pending-admission variant in wasm and napi bindings

### DIFF
--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -2042,6 +2042,15 @@ fn core_subscription_event_to_json(event: &SubscriptionEvent) -> napi::Result<se
                         "detail": detail,
                     })
                 }
+                // Transient: the shape is awaiting catalogue admission and may
+                // yet be served. Surfaced distinctly so a caller cannot mistake
+                // it for an unsupported capability, which is permanent — that
+                // conflation is the bug this variant was introduced to fix.
+                jazz::protocol::SubscribeRejectReason::ShapeRegistrationPendingCatalogueAdmission => {
+                    serde_json::json!({
+                        "type": "ShapeRegistrationPendingCatalogueAdmission",
+                    })
+                }
             };
             Ok(serde_json::json!({
                 "type": "rejected",

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -2518,6 +2518,17 @@ fn subscription_chunk_to_js(event: SubscriptionEvent) -> Result<JsValue, JsValue
                     )?;
                     set_prop(&reason_object, "detail", JsValue::from_str(&detail))?;
                 }
+                // Transient: the shape is awaiting catalogue admission and may
+                // yet be served. Surfaced distinctly so a caller cannot mistake
+                // it for an unsupported capability, which is permanent — that
+                // conflation is the bug this variant was introduced to fix.
+                jazz::protocol::SubscribeRejectReason::ShapeRegistrationPendingCatalogueAdmission => {
+                    set_prop(
+                        &reason_object,
+                        "type",
+                        JsValue::from_str("ShapeRegistrationPendingCatalogueAdmission"),
+                    )?;
+                }
             }
             set_prop(&object, "type", JsValue::from_str("rejected"))?;
             set_prop(&object, "reason", reason_object.into())?;


### PR DESCRIPTION
**The integration branch is red on `cargo check --workspace --all-targets`.** #1194 added `SubscribeRejectReason::ShapeRegistrationPendingCatalogueAdmission` without extending the exhaustive matches in two binding crates:

```
error[E0004]: non-exhaustive patterns: `SubscribeRejectReason::ShapeRegistrationPendingCatalogueAdmission` not covered
  --> crates/jazz-wasm/src/lib.rs:2512
  --> crates/jazz-napi/src/lib.rs:2038
```

## The fix keeps the distinction the variant exists for

Both bindings surface it as its own type rather than folding it into `UnsupportedShapeCapability`. That difference is the whole point: **pending admission is transient** and the shape may yet be served, **unsupported capability is permanent**. Conflating them is precisely the bug #1194 was written to fix — so the bindings must not reintroduce it at the boundary, which a catch-all arm would have done.

## Second occurrence of this pattern

A new enum variant broke a binding crate's exhaustive match once already today: `SubscriptionEvent::Rejected` did the same in `jazz-sim`, and that one blocked four separate pieces of work before it was traced.

`cargo check --workspace --all-targets` is the check that catches this, and it is exactly what the `build-integration` CI job added in #1186 runs on pushes to this branch. That job should have caught #1194 on merge — worth confirming it fired, since this is its first real test.

## Verification

`cargo check --workspace --all-targets` exits 0, with both binding crates forcibly rebuilt rather than served from cache — a cached pass reports success without checking anything.
