### PR TITLE
(new core) Clean up terminal permission subjects on every path

### DIFF
--- a/crates/jazz/src/node/ingest.rs
+++ b/crates/jazz/src/node/ingest.rs
@@ -599,7 +599,6 @@ where
             if !self.version_satisfies_write_policy(version, permission_subject) {
                 let fate = Fate::Rejected(RejectionReason::AuthorizationDenied);
                 self.ingest_rejected_transaction(stored.tx, fate)?;
-                self.open_tx.local_permission_subjects.remove(&tx_id);
                 return Ok(());
             }
         }
@@ -612,9 +611,7 @@ where
             Some(DurabilityTier::Global),
         )?;
         self.create_merge_versions_for(&records)?;
-        self.checkpoint_large_values_for_tx(tx_id)?;
-        self.open_tx.local_permission_subjects.remove(&tx_id);
-        Ok(())
+        self.checkpoint_large_values_for_tx(tx_id)
     }
 
     /// Finalize a locally-authored pending exclusive commit as the global
@@ -1628,6 +1625,28 @@ where
         global_seq: Option<GlobalSeq>,
         durability: Option<DurabilityTier>,
     ) -> Result<(), Error> {
+        let mut terminal_fate_persisted = false;
+        let result = self.apply_fate_update_once(
+            tx_id,
+            fate,
+            global_seq,
+            durability,
+            &mut terminal_fate_persisted,
+        );
+        if terminal_fate_persisted {
+            self.open_tx.local_permission_subjects.remove(&tx_id);
+        }
+        result
+    }
+
+    fn apply_fate_update_once(
+        &mut self,
+        tx_id: TxId,
+        fate: Fate,
+        global_seq: Option<GlobalSeq>,
+        durability: Option<DurabilityTier>,
+        terminal_fate_persisted: &mut bool,
+    ) -> Result<(), Error> {
         let mut stored = self
             .query_transaction(tx_id)?
             .ok_or(Error::MissingTransaction(tx_id))?;
@@ -1730,6 +1749,7 @@ where
             None
         };
         self.database.commit_batch(batch)?;
+        *terminal_fate_persisted = !matches!(stored.fate, Fate::Pending);
         if matches!(stored.fate, Fate::Rejected(_)) || stored.global_seq.is_some() {
             self.persist_storage_consistency_marker_through(tx_id.time)?;
         }

--- a/crates/jazz/src/node/tests/policies_rls.rs
+++ b/crates/jazz/src/node/tests/policies_rls.rs
@@ -158,6 +158,45 @@ fn attributed_write_retry_preserves_permission_subject_after_rejection_error() {
 }
 
 #[test]
+fn attributed_write_checkpoint_error_cleans_up_terminal_permission_subject() {
+    let schema = owner_policy_schema();
+    let backend = user(0xb0);
+    let attributed_user = user(0xa1);
+    let column_families = schema.column_families();
+    let column_family_refs = column_families
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    let storage = FailTransactionReadMemoryStorage::new(&column_family_refs);
+    let mut core = NodeState::new(node(0x90), schema, storage.clone()).unwrap();
+
+    let tx_id = core
+        .commit_mergeable(
+            MergeableCommit::new("todos", row(0x90), 10)
+                .made_by(attributed_user)
+                .permission_subject(backend)
+                .cells(owner_cells(backend, "checkpoint cleanup")),
+        )
+        .unwrap();
+
+    // The first six transaction reads are part of validation and acceptance;
+    // checkpoint_large_values_for_tx makes the seventh after Accepted persists.
+    storage.fail_after_transaction_reads(6);
+    let error = core.finalize_local_mergeable_commit(tx_id).unwrap_err();
+    assert!(error.to_string().contains("injected transaction read failure"));
+    let terminal_state = core.transaction_state(tx_id);
+    assert!(matches!(
+        terminal_state,
+        Some((Fate::Accepted, Some(_), DurabilityTier::Global))
+    ), "checkpoint failure must follow persisted acceptance, got {terminal_state:?}");
+
+    // This internal assertion is necessary because local_permission_subjects is
+    // deliberately local-only and has no user-visible API. A terminal transaction
+    // cannot retry, so its entry otherwise has no public lifecycle event.
+    assert!(!core.open_tx.local_permission_subjects.contains_key(&tx_id));
+}
+
+#[test]
 fn write_policy_rejection_cleans_up_client() {
     let schema = owner_policy_schema();
     let (_writer_dir, mut writer) = open_node_with_schema(node(1), schema.clone());


### PR DESCRIPTION
Addresses @joeinnes' comment on #1188. **It did leak — confirmed, not theoretical.**

> Can we make sure this always runs when the persisted fate is terminal? At the moment an error could return above this line (e.g. if checkpointing errors), even if the persisted fate is already terminal.

## Reproduced

A focused checkpoint-error reproduction persisted `Accepted/Global` and then observed the local override **still present**. Because terminal transactions never retry and transaction ids are not reused, repeated attributed writes would grow `local_permission_subjects` unboundedly on a long-lived node.

## This is the mirror of the bug #1188 fixed

#1188 fixed the override being consumed **too early** — `.remove()` before a fallible section, so any error left the transaction `Pending` with the override gone and a retry evaluated write policy against `made_by` instead of the authenticated link identity (`INV-RLS-17` / `INV-RLS-18`).

Deferring removal fixed that and created this: an error path returning *after* the fate is terminal but *before* the cleanup leaves the entry stranded forever.

## The fix makes it unskippable rather than adding another call site

Cleanup moved into the shared fate-persistence path: terminal status is marked immediately after the database batch commits, and the override is removed after all subsequent fallible work returns. So checkpointing — or any future post-persistence error — cannot bypass it. Adding another cleanup call would only have moved the gap to the next error path.

Errors **before** fate persistence still retain the override, so #1188's pending-retry regression still passes and the original bug is not reintroduced.

## Gates

`cargo test -p jazz` 0 (736 passed), `-p groove` 0 (383), `-p jazz-server` 0, `cargo check --workspace --all-targets` 0.
