### PR TITLE
(new core) URGENT: fix the stack overflow on the integration base

### DIFF
--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -1415,14 +1415,15 @@ where
         table: &TableSchema,
         tier: DurabilityTier,
     ) -> Result<CurrentSourceGraph, SourceResolutionError> {
-        let rows = self
-            .node
-            .current_rows_for_schema(&request.source.table, self.read_view.read_schema, tier)
-            .map_err(|_| source_resolution_error(request, SourceGap::SchemaProjection))?;
-        let graph = inline_current_graph(table, rows)
-            .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?;
         Ok(CurrentSourceGraph {
-            graph,
+            // Resolve projected sources directly from their storage partitions.
+            // Calling `current_rows_for_schema` here re-enters query compilation;
+            // a renamed table maps back to this resolver and recurses forever.
+            graph: self
+                .projected_content_current_source_graph(request, table, tier, false)?
+                .project_fields(storage_to_canonical_current_source_fields(
+                    table, true, false,
+                )),
             descriptor: current_row_descriptor(table),
             metadata: BTreeMap::new(),
         })
@@ -1694,7 +1695,11 @@ fn project_current_content_fields(
                                         candidate.column_type.clone().value_type(),
                                     ))
                                 })
-                                .expect("compiled add lens must target a read-schema column"),
+                                // A multi-lens path can add a temporary column
+                                // and remove it again before reaching the read
+                                // schema. It still needs a type while we carry
+                                // the intermediate projection.
+                                .unwrap_or_else(|| ValueType::Nullable(Box::new(ValueType::Bytes))),
                         ),
                     );
                 }


### PR DESCRIPTION
**The integration branch aborts at runtime.** Verified on `codex/jazz-core-engine-swap` itself, not on a branch:

```
thread 'lowered_write_policy_keeps_v1_policy_pinned_after_table_rename' has overflowed its stack
fatal runtime error: stack overflow, aborting   (SIGABRT)
```

It came in with #1194. It **compiles fine**, so `build-integration` reports success — this is the class of break only a test run catches.

## Not what I expected

I briefed this as the recursive-`Inherits` class, given the parked `WIP: bound recursive Inherits lowering` commit and the browser suite's `normalize_policy_atom_chain` recursion. GDB says otherwise — it is neither `Inherits` nor a rename-lineage cycle:

```
projected_visible_current_source_graph → current_rows_for_schema → current_rows
  → query compilation → source resolution → projected_visible_current_source_graph
```

It repeatedly recompiles the same catalogue-projected `todos@v1` source after the rename. Source resolution re-enters query compilation, which re-enters source resolution, with nothing breaking the cycle.

## Fix

Projected visible sources are resolved directly from storage partitions rather than by round-tripping through query compilation, and provenance fields are canonicalized. It also preserves a safe type for temporary add/drop columns on multi-lens paths.

The existing regression is **unchanged and passes** — `lowered_write_policy_keeps_v1_policy_pinned_after_table_rename`, 1 passed. It was asserting a real property (a lowered write policy stays pinned to its v1 form across a rename) and the fix makes that reachable rather than weakening it.

## Scope note

The browser `normalize_policy_atom_chain` recursion is a **separate** `Inherits` normalization path and is **not** covered by this. The bounded-`Inherits` fix is already present on this base. Two different recursions that happened to look alike.

## Gates

`cargo test -p jazz` 0 (744 passed), `-p groove` 0 (384), `-p jazz-server` 0 (55), `cargo check --workspace --all-targets` 0.

`cargo test -p jazz-tools --features test` fails only `dynamic_server_publishes_seeded_reachable_policy_and_serves_member_rows`, which is a second base red also arriving with #1194 — fixed separately in the companion PR.
