### PR TITLE
(new core) Enable the 343 suppressed jazz-tools library tests, and repair the five that fail

### DIFF
--- a/crates/jazz-tools/Cargo.toml
+++ b/crates/jazz-tools/Cargo.toml
@@ -11,7 +11,6 @@ autotests = false
 [lib]
 name = "jazz_tools"
 path = "src/lib.rs"
-test = false
 doctest = false
 
 [[bin]]

--- a/crates/jazz-tools/src/server/routes/mod.rs
+++ b/crates/jazz-tools/src/server/routes/mod.rs
@@ -207,6 +207,25 @@ mod tests {
         create_router(state)
     }
 
+    async fn publish_schema_for_test(app: &axum::Router, schema: Schema) {
+        let response = app
+            .clone()
+            .oneshot(
+                axum::http::Request::builder()
+                    .method("POST")
+                    .uri(test_app_route("/admin/schemas"))
+                    .header("Content-Type", "application/json")
+                    .header("X-Jazz-Admin-Secret", "admin-secret")
+                    .body(axum::body::Body::from(
+                        serde_json::json!({ "schema": schema }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .expect("publish schema through admin route");
+        assert_eq!(response.status(), StatusCode::CREATED);
+    }
+
     async fn post_internal_shutdown(
         app: axum::Router,
         admin_secret: Option<&str>,
@@ -1358,11 +1377,8 @@ mod tests {
         let v2_hash = SchemaHash::compute(&v2);
 
         let state = make_state_with_schema(v2).await;
-        state
-            .catalogue_store
-            .add_known_schema(v1)
-            .expect("seed known schema for connectivity test");
         let app = make_test_router(state.clone());
+        publish_schema_for_test(&app, v1).await;
 
         let disconnected = app
             .clone()
@@ -1581,11 +1597,8 @@ mod tests {
         let v2_hash = SchemaHash::compute(&v2);
 
         let state = make_state_with_schema(v2).await;
-        state
-            .catalogue_store
-            .add_known_schema(v1)
-            .expect("seed known schema for publish test");
         let app = make_test_router(state.clone());
+        publish_schema_for_test(&app, v1).await;
 
         let request_body = serde_json::json!({
             "fromHash": v1_hash.to_string(),
@@ -1666,11 +1679,8 @@ mod tests {
         let v2_hash = SchemaHash::compute(&v2);
 
         let state = make_state_with_schema(v2).await;
-        state
-            .catalogue_store
-            .add_known_schema(v1)
-            .expect("seed known schema for publish test");
         let app = make_test_router(state.clone());
+        publish_schema_for_test(&app, v1).await;
 
         let request_body = serde_json::json!({
             "fromHash": v1_hash.to_string(),
@@ -1755,11 +1765,8 @@ mod tests {
         let v2_hash = SchemaHash::compute(&v2);
 
         let state = make_state_with_schema(v2.clone()).await;
-        state
-            .catalogue_store
-            .add_known_schema(v1.clone())
-            .expect("seed known schema for publish test");
         let app = make_test_router(state.clone());
+        publish_schema_for_test(&app, v1.clone()).await;
 
         let request_body = serde_json::json!({
             "fromHash": v1_hash.to_string(),


### PR DESCRIPTION
`crates/jazz-tools/Cargo.toml` sets `[lib] test = false`, so **343 `#[test]` attributes in `crates/jazz-tools/src/` have never been compiled or run.** This enables them.

**1,085 pass.** That is coverage the project has never had. Five failed, and this PR fixes them.

## The five, and what was actually wrong

Four returned HTTP 500 where 201 was expected, in migration-publish and schema-connectivity handlers. The real error:

```
failed to bridge migration lens into server shell … invalid catalogue update: lens endpoint is unknown
```

**Fixture rot, not a handler bug.** The tests seeded the source schema directly into the catalogue, which never admits it to the runtime shell. They now go through the public `POST /admin/schemas` route — the same path a real application uses.

I had guessed this would be the `permissions_head_missing` class that #1212 fixed, since a 500 means the server is erroring rather than rejecting. Wrong guess, same family: a fixture doing setup by a private path that no longer suffices.

The fifth (`ws_empty_covered_reader_…`) passed unchanged once the others were fixed — it was fan-out.

## Why the suppression cannot simply be preserved

PR #1193 consolidates `jazz-tools` into `jazz`, after which **one `[lib]` policy governs both crates**. Re-applying `test = false` there would also silence `jazz`'s own library tests, including the whole `node::tests::harness::*` suite. Hiding hundreds of passing tests to avoid five failing ones is strictly worse, so the five had to be understood rather than re-suppressed.

Doctests stay disabled — this change is deliberately minimal.

## Separately: one pre-existing red is NOT fixed here

`renamed_table_update_policy_uses_projected_parent_version` fails with `QueryLowering("unknown query table people")` while authorizing a v2 update projected from a v1 parent. **Verified failing on the pristine base**, so it predates this PR — it is the third red that arrived with #1194, after the stack overflow (#1211) and the permissions-head fixture (#1212). Being fixed separately; the assertion was left untouched.

## Gates

`cargo test -p jazz` 0 (744 passed), `cargo check --workspace --all-targets` 0, and the newly exposed library suite at **329 passed** including all five named tests.
