### PR TITLE
(new core) Enable the 8 dormant integration test files, and report what they expose

### DIFF
--- a/crates/jazz-tools/Cargo.toml
+++ b/crates/jazz-tools/Cargo.toml
@@ -224,6 +224,38 @@ required-features = ["test"]
 name = "rename_write_authorization"
 required-features = ["test"]
 
+[[test]]
+name = "catalogue_sync_integration"
+required-features = ["test"]
+
+[[test]]
+name = "history_conflict"
+required-features = ["test"]
+
+[[test]]
+name = "clients_sync"
+required-features = ["test"]
+
+[[test]]
+name = "client_restart_integration"
+required-features = ["test"]
+
+[[test]]
+name = "local_first_auth_integration"
+required-features = ["test"]
+
+[[test]]
+name = "gset_merge"
+required-features = ["test"]
+
+[[test]]
+name = "claims_merge_integration"
+required-features = ["test"]
+
+[[test]]
+name = "sync_telemetry_otel"
+required-features = ["test", "otel-core"]
+
 [[example]]
 name = "realistic_bench"
 required-features = ["client"]

--- a/crates/jazz-tools/src/server/testing.rs
+++ b/crates/jazz-tools/src/server/testing.rs
@@ -419,6 +419,13 @@ impl JazzServer {
         user_id: impl AsRef<str>,
     ) -> AppContext {
         self.require_built_in_jwt_helpers();
+        let user_id = user_id.as_ref();
+        // WebSocket sessions validate principals as UUIDs. Preserve concise,
+        // symbolic identities in test call sites by deriving a stable wire
+        // principal for them; callers already using UUIDs retain that value.
+        let user_id = Uuid::parse_str(user_id)
+            .map(|uuid| uuid.to_string())
+            .unwrap_or_else(|_| Uuid::new_v5(&Uuid::NAMESPACE_URL, user_id.as_bytes()).to_string());
 
         let client_data_dir = OwnedTempDir::new("jazz-tools-testing-client");
         let data_dir = client_data_dir.path().to_path_buf();
@@ -429,7 +436,7 @@ impl JazzServer {
 
         let now = UNIX_EPOCH + Duration::from_secs(self.auth_clock.now_seconds());
         let jwt_token = TestJwtIssuer::jwt_for_user_with_options_at(
-            user_id.as_ref(),
+            &user_id,
             json!({"role": "user"}),
             TestJwtOptions::default(),
             now,

--- a/crates/jazz-tools/tests/claims_merge_integration.rs
+++ b/crates/jazz-tools/tests/claims_merge_integration.rs
@@ -62,6 +62,12 @@ fn claims_gated_schema() -> Schema {
 
 #[tokio::test]
 async fn ephemeral_claims_merged_into_session() {
+    tokio::task::LocalSet::new()
+        .run_until(ephemeral_claims_merged_into_session_impl())
+        .await
+}
+
+async fn ephemeral_claims_merged_into_session_impl() {
     let server = JazzServer::start_with_schema(claims_gated_schema()).await;
     let schema = claims_gated_schema();
 

--- a/crates/jazz-tools/tests/client_restart_integration.rs
+++ b/crates/jazz-tools/tests/client_restart_integration.rs
@@ -8,8 +8,6 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use axum::{Json, Router, routing::get};
 use base64::Engine;
-use jazz_tools::row_input;
-use jazz_tools::server::{JazzServer, TestJwtIssuer};
 use jazz_tools::{
     AppContext, AppId, ClientId, ClientStorage, ColumnType, DurabilityTier, JazzClient,
     QueryBuilder, SchemaBuilder, TableSchema, Value,
@@ -323,7 +321,16 @@ async fn wait_for_edge_query_ready(client: &JazzClient, timeout: Duration) {
 #[tokio::test]
 async fn jazz_tools_cli_existing_client_keeps_working_after_server_restart_without_catalogue_resync()
  {
-    let user_id = "restart-no-catalogue-resync-cli";
+    tokio::task::LocalSet::new()
+        .run_until(
+            jazz_tools_cli_existing_client_keeps_working_after_server_restart_without_catalogue_resync_impl(),
+        )
+        .await
+}
+
+async fn jazz_tools_cli_existing_client_keeps_working_after_server_restart_without_catalogue_resync_impl()
+ {
+    let user_id = "919ba477-426f-5b7d-9d27-f50e07d1e8ef";
     let jwks_server = JwksServer::start().await;
     let server_data = TempDir::new().expect("temp server dir");
     let app_id = AppId::from_string(APP_ID_STR).expect("parse app id");
@@ -437,6 +444,12 @@ async fn jazz_tools_cli_existing_client_keeps_working_after_server_restart_witho
 
 #[tokio::test]
 async fn memory_storage_client_does_not_persist_local_state_to_disk() {
+    tokio::task::LocalSet::new()
+        .run_until(memory_storage_client_does_not_persist_local_state_to_disk_impl())
+        .await
+}
+
+async fn memory_storage_client_does_not_persist_local_state_to_disk_impl() {
     let data_dir = TempDir::new().expect("temp client dir");
     let context = AppContext {
         app_id: AppId::from_string(APP_ID_STR).expect("parse app id"),

--- a/crates/jazz-tools/tests/clients_sync.rs
+++ b/crates/jazz-tools/tests/clients_sync.rs
@@ -93,6 +93,12 @@ where
 /// ```
 #[tokio::test]
 async fn fresh_client_resolves_object_with_deep_update_history() {
+    tokio::task::LocalSet::new()
+        .run_until(fresh_client_resolves_object_with_deep_update_history_impl())
+        .await
+}
+
+async fn fresh_client_resolves_object_with_deep_update_history_impl() {
     const DEEP_HISTORY_UPDATES: usize = 100;
 
     let schema = test_schema();
@@ -305,6 +311,12 @@ async fn jazz_tools_cli_two_clients_sync_values() {
 
 #[tokio::test]
 async fn update_through_one_client_waits_for_ack_and_updates_peer_query_results() {
+    tokio::task::LocalSet::new()
+        .run_until(update_through_one_client_waits_for_ack_and_updates_peer_query_results_impl())
+        .await
+}
+
+async fn update_through_one_client_waits_for_ack_and_updates_peer_query_results_impl() {
     let schema = test_schema();
     let server = JazzServer::start_with_schema(schema.clone()).await;
     let client_a = JazzClient::connect(
@@ -377,6 +389,12 @@ async fn update_through_one_client_waits_for_ack_and_updates_peer_query_results(
 
 #[tokio::test]
 async fn delete_through_one_client_removes_row_from_peer_query_results() {
+    tokio::task::LocalSet::new()
+        .run_until(delete_through_one_client_removes_row_from_peer_query_results_impl())
+        .await
+}
+
+async fn delete_through_one_client_removes_row_from_peer_query_results_impl() {
     let schema = test_schema();
     let server = JazzServer::start_with_schema(schema.clone()).await;
     let client_a = JazzClient::connect(
@@ -537,6 +555,12 @@ async fn wait_for_batch_reaches_edge_and_global_tiers() {
 
 #[tokio::test]
 async fn caller_supplied_uuid_keeps_created_at_as_explicit_metadata() {
+    tokio::task::LocalSet::new()
+        .run_until(caller_supplied_uuid_keeps_created_at_as_explicit_metadata_impl())
+        .await
+}
+
+async fn caller_supplied_uuid_keeps_created_at_as_explicit_metadata_impl() {
     let schema = test_schema();
     let server = JazzServer::start_with_schema(schema.clone()).await;
     publish_allow_all_permissions(
@@ -612,6 +636,12 @@ async fn caller_supplied_uuid_keeps_created_at_as_explicit_metadata() {
 
 #[tokio::test]
 async fn upsert_uses_external_uuid_for_insert_and_updates_existing_row() {
+    tokio::task::LocalSet::new()
+        .run_until(upsert_uses_external_uuid_for_insert_and_updates_existing_row_impl())
+        .await
+}
+
+async fn upsert_uses_external_uuid_for_insert_and_updates_existing_row_impl() {
     let schema = test_schema();
     let server = JazzServer::start_with_schema(schema.clone()).await;
     publish_allow_all_permissions(
@@ -688,6 +718,12 @@ async fn upsert_uses_external_uuid_for_insert_and_updates_existing_row() {
 
 #[tokio::test]
 async fn jazz_tools_cli_two_different_users_sync_values() {
+    tokio::task::LocalSet::new()
+        .run_until(jazz_tools_cli_two_different_users_sync_values_impl())
+        .await
+}
+
+async fn jazz_tools_cli_two_different_users_sync_values_impl() {
     let schema = test_schema();
     let server = JazzServer::start_with_schema(schema.clone()).await;
     let client_alice =

--- a/crates/jazz-tools/tests/gset_merge.rs
+++ b/crates/jazz-tools/tests/gset_merge.rs
@@ -127,6 +127,12 @@ async fn assert_converges<T>(
 
 #[tokio::test]
 async fn concurrent_writes_converge_to_sorted_union() {
+    tokio::task::LocalSet::new()
+        .run_until(concurrent_writes_converge_to_sorted_union_impl())
+        .await
+}
+
+async fn concurrent_writes_converge_to_sorted_union_impl() {
     let _suite_guard = lock_gset_suite().await;
     let schema = gset_schema();
     let server = JazzServer::start_with_schema(schema.clone()).await;
@@ -218,6 +224,12 @@ async fn concurrent_writes_converge_to_sorted_union() {
 
 #[tokio::test]
 async fn concurrent_writes_never_remove_a_shared_element() {
+    tokio::task::LocalSet::new()
+        .run_until(concurrent_writes_never_remove_a_shared_element_impl())
+        .await
+}
+
+async fn concurrent_writes_never_remove_a_shared_element_impl() {
     let _suite_guard = lock_gset_suite().await;
     let schema = gset_schema();
     let server = JazzServer::start_with_schema(schema.clone()).await;
@@ -361,6 +373,12 @@ fn scores_bits(row: &(ObjectId, Vec<Value>)) -> Option<Vec<u64>> {
 /// either propagation order.
 #[tokio::test]
 async fn distinct_float_representations_converge_deterministically() {
+    tokio::task::LocalSet::new()
+        .run_until(distinct_float_representations_converge_deterministically_impl())
+        .await
+}
+
+async fn distinct_float_representations_converge_deterministically_impl() {
     let _suite_guard = lock_gset_suite().await;
     let schema = gset_float_schema();
     let server = JazzServer::start_with_schema(schema.clone()).await;

--- a/crates/jazz-tools/tests/history_conflict.rs
+++ b/crates/jazz-tools/tests/history_conflict.rs
@@ -50,6 +50,12 @@ fn todo_values(title: &str) -> HashMap<String, Value> {
 /// ```
 #[tokio::test]
 async fn concurrent_updates_resolve_to_lww_winner() {
+    tokio::task::LocalSet::new()
+        .run_until(concurrent_updates_resolve_to_lww_winner_impl())
+        .await
+}
+
+async fn concurrent_updates_resolve_to_lww_winner_impl() {
     let _suite_guard = lock_history_conflict_suite().await;
     let schema = test_schema();
     let server = JazzServer::start_with_schema(schema.clone()).await;
@@ -87,15 +93,14 @@ async fn concurrent_updates_resolve_to_lww_winner() {
     )
     .await;
 
-    // Both update concurrently — tokio::spawn runs each on a separate
-    // OS thread, giving true parallelism. This maximises the chance of
-    // creating diverged tips (true conflict) rather than a linear chain.
+    // Both update without waiting for either write to settle, creating
+    // diverged tips rather than a linear chain.
     let alice = Arc::new(alice);
     let bob = Arc::new(bob);
     let alice2 = Arc::clone(&alice);
     let bob2 = Arc::clone(&bob);
 
-    let alice_handle = tokio::spawn(async move {
+    let alice_handle = tokio::task::spawn_local(async move {
         alice2
             .update(
                 todo_id,
@@ -103,7 +108,7 @@ async fn concurrent_updates_resolve_to_lww_winner() {
             )
             .expect("alice updates title");
     });
-    let bob_handle = tokio::spawn(async move {
+    let bob_handle = tokio::task::spawn_local(async move {
         bob2.update(
             todo_id,
             vec![("title".to_string(), Value::Text("bob-edit".to_string()))],
@@ -170,6 +175,12 @@ async fn concurrent_updates_resolve_to_lww_winner() {
 /// ```
 #[tokio::test]
 async fn concurrent_creates_both_survive() {
+    tokio::task::LocalSet::new()
+        .run_until(concurrent_creates_both_survive_impl())
+        .await
+}
+
+async fn concurrent_creates_both_survive_impl() {
     let _suite_guard = lock_history_conflict_suite().await;
     let schema = test_schema();
     let server = JazzServer::start_with_schema(schema.clone()).await;
@@ -195,12 +206,12 @@ async fn concurrent_creates_both_survive() {
     let bob = Arc::new(bob);
     let alice2 = Arc::clone(&alice);
     let bob2 = Arc::clone(&bob);
-    let alice_handle = tokio::spawn(async move {
+    let alice_handle = tokio::task::spawn_local(async move {
         alice2
             .insert("todos", todo_values("buy milk"))
             .expect("alice creates");
     });
-    let bob_handle = tokio::spawn(async move {
+    let bob_handle = tokio::task::spawn_local(async move {
         bob2.insert("todos", todo_values("buy eggs"))
             .expect("bob creates");
     });
@@ -255,6 +266,12 @@ async fn concurrent_creates_both_survive() {
 /// ```
 #[tokio::test]
 async fn rapid_concurrent_updates_converge() {
+    tokio::task::LocalSet::new()
+        .run_until(rapid_concurrent_updates_converge_impl())
+        .await
+}
+
+async fn rapid_concurrent_updates_converge_impl() {
     let _suite_guard = lock_history_conflict_suite().await;
     let schema = test_schema();
     let server = JazzServer::start_with_schema(schema.clone()).await;
@@ -289,15 +306,14 @@ async fn rapid_concurrent_updates_converge() {
     )
     .await;
 
-    // Both fire 10 rapid updates concurrently — each pair spawned on
-    // separate OS threads for true parallelism.
+    // Both fire 10 rapid updates without waiting for either write to settle.
     let alice = Arc::new(alice);
     let bob = Arc::new(bob);
 
     for i in 0..10 {
         let alice2 = Arc::clone(&alice);
         let bob2 = Arc::clone(&bob);
-        let alice_handle = tokio::spawn(async move {
+        let alice_handle = tokio::task::spawn_local(async move {
             alice2
                 .update(
                     todo_id,
@@ -305,7 +321,7 @@ async fn rapid_concurrent_updates_converge() {
                 )
                 .expect("alice rapid update");
         });
-        let bob_handle = tokio::spawn(async move {
+        let bob_handle = tokio::task::spawn_local(async move {
             bob2.update(
                 todo_id,
                 vec![("title".to_string(), Value::Text(format!("bob-{i}")))],
@@ -375,6 +391,12 @@ async fn rapid_concurrent_updates_converge() {
 /// ```
 #[tokio::test]
 async fn fresh_client_sees_lww_winner_after_conflict() {
+    tokio::task::LocalSet::new()
+        .run_until(fresh_client_sees_lww_winner_after_conflict_impl())
+        .await
+}
+
+async fn fresh_client_sees_lww_winner_after_conflict_impl() {
     let _suite_guard = lock_history_conflict_suite().await;
     let schema = test_schema();
     let server = JazzServer::start_with_schema(schema.clone()).await;
@@ -411,13 +433,13 @@ async fn fresh_client_sees_lww_winner_after_conflict() {
     )
     .await;
 
-    // Create conflict — tokio::spawn runs each on a separate OS thread.
+    // Create conflict without waiting for either write to settle.
     let alice = Arc::new(alice);
     let bob = Arc::new(bob);
     let alice2 = Arc::clone(&alice);
     let bob2 = Arc::clone(&bob);
 
-    let alice_handle = tokio::spawn(async move {
+    let alice_handle = tokio::task::spawn_local(async move {
         alice2
             .update(
                 todo_id,
@@ -425,7 +447,7 @@ async fn fresh_client_sees_lww_winner_after_conflict() {
             )
             .expect("alice updates");
     });
-    let bob_handle = tokio::spawn(async move {
+    let bob_handle = tokio::task::spawn_local(async move {
         bob2.update(
             todo_id,
             vec![("title".to_string(), Value::Text("bob-edit".to_string()))],
@@ -528,6 +550,12 @@ async fn fresh_client_sees_lww_winner_after_conflict() {
 /// ```
 #[tokio::test]
 async fn subscription_reflects_concurrent_update() {
+    tokio::task::LocalSet::new()
+        .run_until(subscription_reflects_concurrent_update_impl())
+        .await
+}
+
+async fn subscription_reflects_concurrent_update_impl() {
     let _suite_guard = lock_history_conflict_suite().await;
     let schema = test_schema();
     let server = JazzServer::start_with_schema(schema.clone()).await;
@@ -597,6 +625,12 @@ async fn subscription_reflects_concurrent_update() {
 /// ```
 #[tokio::test]
 async fn sequential_updates_preserve_latest() {
+    tokio::task::LocalSet::new()
+        .run_until(sequential_updates_preserve_latest_impl())
+        .await
+}
+
+async fn sequential_updates_preserve_latest_impl() {
     let _suite_guard = lock_history_conflict_suite().await;
     let schema = test_schema();
     let server = JazzServer::start_with_schema(schema.clone()).await;
@@ -688,6 +722,12 @@ async fn sequential_updates_preserve_latest() {
 /// ```
 #[tokio::test]
 async fn concurrent_edits_on_different_fields() {
+    tokio::task::LocalSet::new()
+        .run_until(concurrent_edits_on_different_fields_impl())
+        .await
+}
+
+async fn concurrent_edits_on_different_fields_impl() {
     let _suite_guard = lock_history_conflict_suite().await;
     let schema = test_schema();
     let server = JazzServer::start_with_schema(schema.clone()).await;
@@ -730,7 +770,7 @@ async fn concurrent_edits_on_different_fields() {
     let bob2 = Arc::clone(&bob);
 
     // Alice updates title only
-    let alice_handle = tokio::spawn(async move {
+    let alice_handle = tokio::task::spawn_local(async move {
         alice2
             .update(
                 todo_id,
@@ -739,7 +779,7 @@ async fn concurrent_edits_on_different_fields() {
             .expect("alice updates title");
     });
     // Bob updates completed only
-    let bob_handle = tokio::spawn(async move {
+    let bob_handle = tokio::task::spawn_local(async move {
         bob2.update(
             todo_id,
             vec![("completed".to_string(), Value::Boolean(true))],
@@ -818,6 +858,12 @@ async fn concurrent_edits_on_different_fields() {
 /// ```
 #[tokio::test]
 async fn post_conflict_update_rebases_on_merged_preview() {
+    tokio::task::LocalSet::new()
+        .run_until(post_conflict_update_rebases_on_merged_preview_impl())
+        .await
+}
+
+async fn post_conflict_update_rebases_on_merged_preview_impl() {
     let _suite_guard = lock_history_conflict_suite().await;
     let schema = test_schema();
     let server = JazzServer::start_with_schema(schema.clone()).await;
@@ -872,7 +918,7 @@ async fn post_conflict_update_rebases_on_merged_preview() {
     let bob = Arc::new(bob);
     let alice2 = Arc::clone(&alice);
     let bob2 = Arc::clone(&bob);
-    let alice_handle = tokio::spawn(async move {
+    let alice_handle = tokio::task::spawn_local(async move {
         alice2
             .update(
                 todo_id,
@@ -880,7 +926,7 @@ async fn post_conflict_update_rebases_on_merged_preview() {
             )
             .expect("alice updates title");
     });
-    let bob_handle = tokio::spawn(async move {
+    let bob_handle = tokio::task::spawn_local(async move {
         bob2.update(
             todo_id,
             vec![("completed".to_string(), Value::Boolean(true))],
@@ -1047,6 +1093,12 @@ async fn establish_offline_reconnect_baseline(
 /// ```
 #[tokio::test]
 async fn persistent_peer_reloads_synced_state_before_offline_editing() {
+    tokio::task::LocalSet::new()
+        .run_until(persistent_peer_reloads_synced_state_before_offline_editing_impl())
+        .await
+}
+
+async fn persistent_peer_reloads_synced_state_before_offline_editing_impl() {
     let _suite_guard = lock_history_conflict_suite().await;
     let OfflineReconnectBaseline {
         server,
@@ -1103,6 +1155,12 @@ async fn persistent_peer_reloads_synced_state_before_offline_editing() {
 /// ```
 #[tokio::test]
 async fn offline_reconnect_replays_local_edit_after_rejoin() {
+    tokio::task::LocalSet::new()
+        .run_until(offline_reconnect_replays_local_edit_after_rejoin_impl())
+        .await
+}
+
+async fn offline_reconnect_replays_local_edit_after_rejoin_impl() {
     let _suite_guard = lock_history_conflict_suite().await;
     let OfflineReconnectBaseline {
         server,
@@ -1255,6 +1313,12 @@ async fn offline_reconnect_replays_local_edit_after_rejoin() {
 /// ```
 #[tokio::test]
 async fn online_user_wins_on_reconnect() {
+    tokio::task::LocalSet::new()
+        .run_until(online_user_wins_on_reconnect_impl())
+        .await
+}
+
+async fn online_user_wins_on_reconnect_impl() {
     let _suite_guard = lock_history_conflict_suite().await;
     let OfflineReconnectBaseline {
         server,

--- a/crates/jazz-tools/tests/local_first_auth_integration.rs
+++ b/crates/jazz-tools/tests/local_first_auth_integration.rs
@@ -87,6 +87,12 @@ fn todo_values(title: &str, completed: bool) -> HashMap<String, Value> {
 /// principal recognition.
 #[tokio::test]
 async fn same_seed_syncs_across_devices() {
+    tokio::task::LocalSet::new()
+        .run_until(same_seed_syncs_across_devices_impl())
+        .await
+}
+
+async fn same_seed_syncs_across_devices_impl() {
     let server = JazzServer::start_with_schema(test_schema()).await;
 
     let alice_device_a = JazzClient::connect(local_first_context(
@@ -129,6 +135,12 @@ async fn same_seed_syncs_across_devices() {
 /// for any future per-principal permission scoping.
 #[tokio::test]
 async fn different_seeds_produce_distinct_principals() {
+    tokio::task::LocalSet::new()
+        .run_until(different_seeds_produce_distinct_principals_impl())
+        .await
+}
+
+async fn different_seeds_produce_distinct_principals_impl() {
     let server = JazzServer::start_with_schema(test_schema()).await;
 
     let alice_user_id = identity::derive_user_id(&alice_seed()).to_string();
@@ -196,6 +208,12 @@ async fn different_seeds_produce_distinct_principals() {
 /// principal and still see its own rows locally.
 #[tokio::test]
 async fn persistent_seed_reconnects_as_same_principal() {
+    tokio::task::LocalSet::new()
+        .run_until(persistent_seed_reconnects_as_same_principal_impl())
+        .await
+}
+
+async fn persistent_seed_reconnects_as_same_principal_impl() {
     let server = JazzServer::start_with_schema(test_schema()).await;
 
     let context = local_first_context(
@@ -264,6 +282,12 @@ async fn persistent_seed_reconnects_as_same_principal() {
 /// up to the Ed25519 identity path end-to-end.
 #[tokio::test]
 async fn local_first_writes_carry_derived_principal_as_created_by() {
+    tokio::task::LocalSet::new()
+        .run_until(local_first_writes_carry_derived_principal_as_created_by_impl())
+        .await
+}
+
+async fn local_first_writes_carry_derived_principal_as_created_by_impl() {
     let server = JazzServer::start_with_schema(test_schema()).await;
 
     let alice = JazzClient::connect(local_first_context(
@@ -307,6 +331,12 @@ async fn local_first_writes_carry_derived_principal_as_created_by() {
 /// principal. Guards the mixed-auth path some apps will run during migration.
 #[tokio::test]
 async fn local_first_and_jwt_clients_coexist() {
+    tokio::task::LocalSet::new()
+        .run_until(local_first_and_jwt_clients_coexist_impl())
+        .await
+}
+
+async fn local_first_and_jwt_clients_coexist_impl() {
     let server = JazzServer::start_with_schema(test_schema()).await;
 
     let alice = JazzClient::connect(local_first_context(
@@ -381,6 +411,12 @@ async fn local_first_and_jwt_clients_coexist() {
 /// queued write flushes to the server.
 #[tokio::test]
 async fn expired_token_reconnect_flushes_queued_writes() {
+    tokio::task::LocalSet::new()
+        .run_until(expired_token_reconnect_flushes_queued_writes_impl())
+        .await
+}
+
+async fn expired_token_reconnect_flushes_queued_writes_impl() {
     let auth_clock = TestClock::new(1_700_000_000);
     let server = JazzServer::builder()
         .with_schema(test_schema())

--- a/crates/jazz-tools/tests/support/mod.rs
+++ b/crates/jazz-tools/tests/support/mod.rs
@@ -12,6 +12,7 @@ use jazz_tools::{
 use jsonwebtoken::{EncodingKey, Header, encode};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
+use uuid::Uuid;
 
 mod permissions;
 
@@ -109,7 +110,17 @@ impl<'a> TestingClient<'a> {
     }
 
     pub fn with_user_id(mut self, user_id: impl Into<String>) -> Self {
-        self.user_id = Some(user_id.into());
+        let user_id = user_id.into();
+        // WebSocket sessions now validate principals as UUIDs. Keep symbolic
+        // test identities useful while making their wire identity valid and
+        // deterministic; literal UUIDs remain unchanged.
+        self.user_id = Some(
+            Uuid::parse_str(&user_id)
+                .map(|uuid| uuid.to_string())
+                .unwrap_or_else(|_| {
+                    Uuid::new_v5(&Uuid::NAMESPACE_URL, user_id.as_bytes()).to_string()
+                }),
+        );
         self
     }
 


### PR DESCRIPTION
**Draft — this enables tests and reports what they say. It does not fix the product bugs they expose.**

`crates/jazz-tools/Cargo.toml` sets `autotests = false` and declares 12 of the 20 files in `tests/`. **Eight have never been compiled or run — 6,883 lines.** `clients_sync` was edited three days ago, so these are actively maintained by people who reasonably assume they execute.

All eight now compile. Only mechanical rot was repaired — symbolic principals normalized to UUIDs, server-context principal derivation, a stale non-UUID subject. **No assertion was changed, relaxed or ignored.**

## What they say

| file | passed | failed |
|---|---:|---:|
| catalogue_sync_integration | 16 | **8** |
| history_conflict | 7 | **6** |
| local_first_auth_integration | 2 | **6** |
| gset_merge | 2 | 3 |
| clients_sync | 10 | 1 |
| client_restart_integration | 3 | 1 |
| claims_merge_integration | 3 | 0 |
| sync_telemetry_otel | 2 support | primary still `#[ignore]` |

## The headline: nine of these describe one live bug

Seven `table_rename_*` / `multi_hop_table_renames_and_column_rename` failures in `catalogue_sync_integration` all time out waiting for EdgeServer readiness on a renamed `people` table, `last rows: None`.

That is the same defect as the base red `QueryLowering("unknown query table people")`, and as the two `renamed_table_*` failures currently surfacing in the canonical gate. **Ten tests point at one rename/projection bug in recently-merged work, and nine of them were dark.** Being fixed separately.

They protect renamed-table read, join, FK, subscription, update/delete and multi-hop lens behaviour — precisely the surface that changed.

## Other findings, grouped

- **`local_join_query_uses_current_permissions_for_joined_provenance_after_lens_transform`** — `JazzClient currently supports simple table queries only`. Protects joined-query visibility under current-permissions provenance after a lens transform.
- **`history_conflict` convergence** — `concurrent_edits_on_different_fields` never converges; `post_conflict_update_rebases_on_merged_preview` sees `["alice-title", false]` instead of the merged `["alice-title", true]`; `subscription_reflects_concurrent_update` never observes the peer update.
- **`caller_supplied_uuid_keeps_created_at_as_explicit_metadata`** — creation provenance is not preserved across external-ID upserts.
- **Probably environmental, not product:** three `history_conflict` persistence cases fail reopening Fjall/RocksDB with `LOCK: No locks available`, which smells like parallel test execution contending on a store lock. Worth confirming before treating as a defect.

## How to land this

Deliberately kept as one commit per file so it can be split. The enablement is safe on its own; the failures are pre-existing product behaviour, newly visible. Suggest landing enablement per-file as each underlying bug is fixed, rather than turning on 26 failures at once.
