### PR TITLE
(new core) Fix projected rename policy schema resolution (unblocks #1193 CI)

### DIFF
--- a/crates/jazz/src/node/policy.rs
+++ b/crates/jazz/src/node/policy.rs
@@ -281,6 +281,18 @@ where
         }
     }
 
+    pub(super) fn read_policy_schema_for_table_name(&self, table: &str) -> SchemaVersionId {
+        let write_schema = self.catalogue.current_write_schema.schema;
+        if self
+            .table_in_schema(table, write_schema)
+            .is_ok_and(|table| table.read_policy.is_some() || table.write_policies.any().is_some())
+        {
+            write_schema
+        } else {
+            self.catalogue.current_schema_version_id
+        }
+    }
+
     fn policy_target_schema_for_source(
         &mut self,
         source: SchemaVersionId,

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -5612,7 +5612,7 @@ where
             reads: current_query_read_set(
                 &input.shape,
                 shape.schema_version(),
-                self.catalogue.current_schema_version_id,
+                self.read_policy_schema_for_table_name(&shape.query().table),
                 tier,
                 None,
             ),
@@ -5957,7 +5957,7 @@ where
             reads: query_read_set_for_read_view(
                 &input.shape,
                 shape.schema_version(),
-                self.catalogue.current_schema_version_id,
+                self.read_policy_schema_for_table_name(&shape.query().table),
                 tier,
                 read_view,
                 settled_binding_view,
@@ -5973,6 +5973,16 @@ where
         shape: &ValidatedQuery,
         _binding: &Binding,
     ) -> Result<NormalizedRowSetShape, Error> {
+        let schema = if shape.schema_version() == self.catalogue.current_schema_version_id {
+            &self.catalogue.schema
+        } else {
+            &self
+                .catalogue
+                .catalogue_schemas
+                .get(&shape.schema_version())
+                .ok_or(Error::InvalidStoredValue("query schema version is unknown"))?
+                .schema
+        };
         let query = shape.query();
         let root_source = root_source_id(&query.table);
         let (mut auxiliary_sources, closure_paths) =
@@ -6008,7 +6018,7 @@ where
                     &mut auxiliary_sources,
                     &mut join_contributions,
                     &mut reachable_contributions,
-                    &self.catalogue.schema,
+                    schema,
                     &root_source,
                     base_source_node,
                     "policy_branch:base",
@@ -6048,7 +6058,7 @@ where
                     &mut auxiliary_sources,
                     &mut join_contributions,
                     &mut reachable_contributions,
-                    &self.catalogue.schema,
+                    schema,
                     &root_source,
                     branch_source_node,
                     &format!("policy_branch:{index}"),
@@ -6105,7 +6115,7 @@ where
                 &mut auxiliary_sources,
                 &mut join_contributions,
                 &mut reachable_contributions,
-                &self.catalogue.schema,
+                schema,
                 &root_source,
                 current,
                 "query",
@@ -6126,7 +6136,7 @@ where
             current = normalize_array_subquery(
                 &mut nodes,
                 current,
-                &self.catalogue.schema,
+                schema,
                 &root_source,
                 subquery,
                 &[index],


### PR DESCRIPTION
Fixes the two rename tests that fail on `codex/jazz-core-engine-swap` — the third and fourth reds that arrived with #1194, after the stack overflow (#1211) and the permissions-head fixture (#1212).

**These are what make `test-rust` red on #1193.** That PR inherits them; it does not cause them. Merging this clears its CI.

```
renamed_table_update_policy_uses_projected_parent_version   QueryLowering("unknown query table people")
renamed_table_insert_after_schema_evolution_reaches_edge
```

## Cause

`query_eval.rs:2936` called `table_schema` with the post-rename name `people`, while the normalizer had supplied the **pre-rename v1 schema**, which contains `users`. The error surfaces from `table_schema` at `:3922`. It should have used the validated v2 schema.

Adjacent to #1211 but a different bug: that one prevented recursive source resolution during projected reads; this is an earlier wrong-schema lookup during normalization. Two distinct defects in the same rename/projection area, which is where #1194's risk concentrated.

## Fix

- normalize filters, joins, inheritance, reachability, policy branches and array subqueries using **the query's** schema version
- select the projected table's policy-bearing write schema for current and include-deleted reads, otherwise preserve the pinned current policy schema — retaining existing lens RLS policy-pinning behaviour

The fix is centralized rather than patched at the failing call site, so it should cover other non-current-schema rename/projection paths.

## Verification is broader than the two tests

**Ten failing tests describe this defect**, and eight of them are currently invisible because `crates/jazz-tools/tests/catalogue_sync_integration.rs` is never compiled (see #1214). Seven `table_rename_*` / `multi_hop_table_renames_and_column_rename` tests there time out waiting for EdgeServer readiness on renamed `people`.

A verification pass against all ten is running separately — a fix validated against one symptom is a weaker claim than one validated against ten, and the centralized-coverage claim above is exactly what that pass tests.

## Gates

`cargo test -p jazz` 0 (744 unit + integration + 32 doctests), `-p groove` 0 (385 + 28 doctests), `cargo check --workspace --all-targets` 0, and `renamed_table_update_policy_uses_projected_parent_version` named as passing along with the edge rename subscription test.
