### PR TITLE
(new core) Optimize full-snapshot join hydration

### DIFF
--- a/crates/groove/src/ivm/runtime/join.rs
+++ b/crates/groove/src/ivm/runtime/join.rs
@@ -147,6 +147,32 @@ impl JoinState {
             update_mode,
         )?;
 
+        // Replace inputs are faithful full snapshots. Once both arrangements
+        // have been rebuilt, one probe produces the complete join result.
+        // The incremental identity below would emit that result twice and
+        // subtract one copy, only for consolidation to cancel it again.
+        if update_mode == ArrangementUpdateMode::Replace {
+            append_join_deltas(
+                &mut output,
+                &context,
+                &keyed_left_delta,
+                &right_arrangement.value().index,
+                JoinProbeSide::LeftDelta,
+                1,
+            )?;
+            let output_buffer = output.bytes.freeze();
+            return Ok(consolidate_deltas(
+                output
+                    .deltas
+                    .into_iter()
+                    .map(|(record, weight)| RecordDelta {
+                        record: output_buffer.slice(record),
+                        weight,
+                    })
+                    .collect(),
+            ));
+        }
+
         append_join_deltas(
             &mut output,
             &context,
@@ -892,6 +918,8 @@ pub(super) fn join_output_mapping(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::*;
     use crate::records::{RecordDescriptor, Value, ValueType};
 
@@ -935,5 +963,78 @@ mod tests {
             join_keys(&i64, &i64_record, &fields).unwrap(),
             "ordinary arrangement keys retain their exact typed encoding"
         );
+    }
+
+    #[test]
+    fn replace_join_matches_incremental_multiset_result() {
+        let left_descriptor =
+            RecordDescriptor::new([("id", ValueType::U64), ("key", ValueType::U64)]);
+        let right_descriptor =
+            RecordDescriptor::new([("key", ValueType::U64), ("value", ValueType::U64)]);
+        let output_descriptor =
+            RecordDescriptor::new([("left.id", ValueType::U64), ("right.value", ValueType::U64)]);
+        let left = [
+            RecordDelta {
+                record: Bytes::from(
+                    left_descriptor
+                        .create(&[Value::U64(1), Value::U64(7)])
+                        .expect("encode left row"),
+                ),
+                weight: 2,
+            },
+            RecordDelta {
+                record: Bytes::from(
+                    left_descriptor
+                        .create(&[Value::U64(2), Value::U64(7)])
+                        .expect("encode left row"),
+                ),
+                weight: 1,
+            },
+        ];
+        let right = [RecordDelta {
+            record: Bytes::from(
+                right_descriptor
+                    .create(&[Value::U64(7), Value::U64(9)])
+                    .expect("encode right row"),
+            ),
+            weight: 3,
+        }];
+        let left_on = ["key".to_owned()];
+        let right_on = ["key".to_owned()];
+        let output_mapping = [(0, 0), (1, 1)];
+        let sub_tick = SubTick {
+            tick: 1,
+            sub_tick: 0,
+        };
+
+        let run = |update_mode| {
+            JoinState
+                .apply(
+                    &mut AsOf::default(),
+                    &mut AsOf::default(),
+                    &left_descriptor,
+                    &right_descriptor,
+                    &output_descriptor,
+                    &output_mapping,
+                    &left_on,
+                    &right_on,
+                    ValueComparison::Exact,
+                    &left,
+                    &right,
+                    sub_tick,
+                    sub_tick,
+                    update_mode,
+                )
+                .expect("join snapshots")
+                .into_iter()
+                .map(|delta| (delta.record.to_vec(), delta.weight))
+                .collect::<BTreeMap<_, _>>()
+        };
+
+        let incremental = run(ArrangementUpdateMode::Accumulate);
+        let replacement = run(ArrangementUpdateMode::Replace);
+
+        assert_eq!(replacement, incremental);
+        assert_eq!(replacement.values().copied().collect::<Vec<_>>(), [6, 3]);
     }
 }

--- a/crates/jazz/Cargo.toml
+++ b/crates/jazz/Cargo.toml
@@ -142,6 +142,7 @@ test = false
 [[bin]]
 name = "jazz-server"
 path = "src/bin/jazz-server.rs"
+required-features = ["server"]
 
 [[bench]]
 name = "validation"


### PR DESCRIPTION
## Summary

Optimize join hydration when both inputs are faithful full snapshots.

`ArrangementUpdateMode::Replace` rebuilds both input arrangements from complete snapshots. The existing incremental join identity then:

1. probes the left delta against the complete right arrangement;
2. probes the right delta against the complete left arrangement;
3. emits the cross-term negatively; and
4. consolidates the three copies back into one result.

For replacement hydration, a single probe already produces the complete join. This PR uses that direct path while leaving ordinary incremental (`Accumulate`) processing unchanged.

## Impact

Seven local repetitions of the existing populated ACL scenarios, with commits disabled to isolate initial subscription hydration:

| Scenario | Base median | This PR | Change |
| --- | ---: | ---: | ---: |
| Direct ACL join subscriptions | 184.5 ms | 173.3 ms | 6.1% faster |
| Prepared ACL join family | 1,115.8 ms | 445.5 ms | 60.1% faster |

Both revisions materialized exactly 17,436 result rows on every run.

An additional private real-world fixture improved end-to-end first-read latency by approximately 15–16%, with the exact result digest unchanged across all samples.

## Validation

- Added a focused regression test proving replacement hydration matches the incremental join result for weighted multiset rows.
- `cargo test -p groove --lib`: 383 passed, 1 pre-existing receipt-only timing test ignored.
- Repository pre-commit gate passed: clippy, sensitive-data scan, rustfmt.

Stacked on #1207.