### PR TITLE
(new core) Cache relation target schemas during hydration

### DIFF
--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -8289,6 +8289,7 @@ where
                 ))
         });
         let mut counts = BTreeMap::<(String, RowUuid, String), usize>::new();
+        let mut target_tables = BTreeMap::<String, TableSchema>::new();
         for candidate in candidates {
             let group = (
                 candidate.edge.source_table.clone(),
@@ -8307,12 +8308,18 @@ where
                 candidate.edge.target_table.clone(),
                 candidate.edge.target_row,
             )) {
-                let target_table = self
-                    .table_in_schema(&candidate.edge.target_table, shape.schema_version())?
-                    .clone();
+                if !target_tables.contains_key(&candidate.edge.target_table) {
+                    let target_table = self
+                        .table_in_schema(&candidate.edge.target_table, shape.schema_version())?
+                        .clone();
+                    target_tables.insert(candidate.edge.target_table.clone(), target_table);
+                }
+                let target_table = target_tables
+                    .get(&candidate.edge.target_table)
+                    .expect("target table was inserted");
                 let row = self.materialize_relation_edge_target_row(
                     read_view,
-                    &target_table,
+                    target_table,
                     &candidate.edge.target_table,
                     candidate.edge.target_row,
                     candidate.target_tx_time,


### PR DESCRIPTION
## What changed

Cache each relation target table schema for the duration of relation snapshot materialization instead of resolving and cloning the same schema once per unique target row.

## Why

Large relation snapshots repeatedly materialize target rows from a small number of tables. The previous path called `table_in_schema` and cloned the table schema for every unique target row; an anonymized real-world fixture exercised this 43,448 times in one first read.

Fine-grained profiling measured target-table schema work at approximately 52.8 ms before this change and 1.4 ms after it.

## Results

A same-binary runtime-toggle A/B benchmark ran 16 interleaved samples per variant in ABBA order on a quiet machine:

- cache disabled: 2,221.25 ms median
- cache enabled: 2,139.70 ms median
- improvement: 81.55 ms / 3.67%
- mean improvement: 76.02 ms / 3.42%

All 32 runs produced identical result digests. The public B2 browser scenario showed no measurable change, as expected for its much smaller relation result sets.

## Validation

- focused relation snapshot regression test passed
- `cargo test -p jazz --lib` — 728 passed, 1 ignored
- workspace Clippy, rustfmt, and sensitive-data pre-commit checks passed

Stacked on #1221.