### PR TITLE
(new core) Fix browser relation row transport

### DIFF
--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.ts
@@ -15,6 +15,7 @@ import {
   formatUuid,
   parseUuid,
 } from "./native-runtime-adapter.js";
+import { setNamedRowValuesEnumerable } from "./row-values-transport.js";
 
 type PendingCall = {
   resolve: (value: unknown) => void;
@@ -567,6 +568,7 @@ export class PersistentBrowserOpfsRuntime implements Runtime {
     if (!pending) return;
     this.pending.delete(message.id);
     if (message.ok) {
+      setNamedRowValuesEnumerable(message.result, false);
       pending.resolve(message.result);
     } else {
       const error = new Error(message.error.message ?? "Persistent browser worker call failed");

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-worker.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-worker.ts
@@ -7,6 +7,7 @@ import {
   type PersistentBrowserOpfsOwnerRequest,
   type PersistentBrowserSubscriptionFrame,
 } from "./persistent-browser-protocol.js";
+import { setNamedRowValuesEnumerable } from "./row-values-transport.js";
 
 type OpenMessage = Extract<PersistentBrowserOpfsOwnerRequest, { method: "open" }>;
 type WriteMessage = Extract<
@@ -78,7 +79,12 @@ async function handleMessage(message: PersistentBrowserOpfsOwnerRequest): Promis
       }
       case "query": {
         const result = await getRuntime().query(...message.args);
-        postResult(message.id, result);
+        setNamedRowValuesEnumerable(result, true);
+        try {
+          postResult(message.id, result);
+        } finally {
+          setNamedRowValuesEnumerable(result, false);
+        }
         return;
       }
       case "createExecutedSubscription": {

--- a/packages/jazz-tools/src/runtime/native-runtime/row-values-transport.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/row-values-transport.ts
@@ -1,0 +1,21 @@
+export function setNamedRowValuesEnumerable(value: unknown, enumerable: boolean): void {
+  visit(value, enumerable, new WeakSet<object>());
+}
+
+function visit(value: unknown, enumerable: boolean, seen: WeakSet<object>): void {
+  if (typeof value !== "object" || value === null || seen.has(value)) return;
+  seen.add(value);
+
+  if (value instanceof Map) {
+    for (const entry of value.values()) visit(entry, enumerable, seen);
+    return;
+  }
+
+  const descriptor = Object.getOwnPropertyDescriptor(value, "valuesByColumn");
+  if (descriptor) {
+    Object.defineProperty(value, "valuesByColumn", { ...descriptor, enumerable });
+    visit(descriptor.value, enumerable, seen);
+  }
+
+  for (const entry of Object.values(value)) visit(entry, enumerable, seen);
+}

--- a/packages/jazz-tools/src/runtime/native-runtime/row-values-transport.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/row-values-transport.ts
@@ -12,7 +12,7 @@ function visit(value: unknown, enumerable: boolean, seen: WeakSet<object>): void
   }
 
   const descriptor = Object.getOwnPropertyDescriptor(value, "valuesByColumn");
-  if (descriptor) {
+  if (descriptor?.value instanceof Map) {
     Object.defineProperty(value, "valuesByColumn", { ...descriptor, enumerable });
     visit(descriptor.value, enumerable, seen);
   }

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -1906,6 +1906,10 @@ describe("NativeRuntimeAdapter server transport", () => {
       type: "Text",
       value: "Ship relation reads",
     });
+
+    const unrelated = { valuesByColumn: "application data" };
+    setNamedRowValuesEnumerable(unrelated, false);
+    expect(Object.getOwnPropertyDescriptor(unrelated, "valuesByColumn")?.enumerable).toBe(true);
   });
 
   it("decodes native subscription chunks", async () => {

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -21,6 +21,7 @@ import { encodeSchema } from "./schema-codec.js";
 import { decodeNativeDelta } from "../subscription-manager.js";
 import { definePermissions } from "../../permissions/index.js";
 import { mergePermissionsIntoWasmSchema } from "../../schema-permissions.js";
+import { setNamedRowValuesEnumerable } from "./row-values-transport.js";
 
 const previousWebSocket = globalThis.WebSocket;
 
@@ -1886,6 +1887,24 @@ describe("NativeRuntimeAdapter server transport", () => {
           },
         },
       ],
+    });
+
+    setNamedRowValuesEnumerable(rows, true);
+    const clonedRows = structuredClone(rows);
+    setNamedRowValuesEnumerable(rows, false);
+    setNamedRowValuesEnumerable(clonedRows, false);
+    const clonedRelation = clonedRows[0]?.valuesByColumn?.get("todosViaOwner") as
+      | {
+          type: "Array";
+          value: Array<{
+            type: "Row";
+            value: { valuesByColumn?: Map<string, unknown> };
+          }>;
+        }
+      | undefined;
+    expect(clonedRelation?.value[0]?.value.valuesByColumn?.get("title")).toEqual({
+      type: "Text",
+      value: "Ship relation reads",
     });
   });
 

--- a/packages/jazz-tools/tests/browser/db.all.test.ts
+++ b/packages/jazz-tools/tests/browser/db.all.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { createDb, type Db, type QueryBuilder, type TableProxy } from "../../src/runtime/db.js";
 import type { WasmSchema } from "../../src/drivers/types.js";
+import { PersistentBrowserOpfsRuntime } from "../../src/runtime/native-runtime/persistent-browser-runtime.js";
 
 const schema: WasmSchema = {
   orgs: {
@@ -514,6 +515,66 @@ describe("db.all browser integration", () => {
         expect.objectContaining({ title: "with-owner-2", owner_id: ownerId }),
       ]),
     );
+  });
+
+  it("preserves nested row names across the persistent worker boundary", async () => {
+    const ownerId = "00000000-0000-0000-0000-000000000201";
+    const runtime = new PersistentBrowserOpfsRuntime(
+      undefined,
+      schema,
+      uniqueDbName("relation-worker-boundary"),
+      new Uint8Array(16),
+      new Uint8Array(16),
+    );
+
+    try {
+      runtime.insert("users", { name: { type: "Text", value: "Owner" } }, null, ownerId);
+      runtime.insert(
+        "todos",
+        {
+          title: { type: "Text", value: "through-worker" },
+          done: { type: "Boolean", value: false },
+          owner_id: { type: "Uuid", value: ownerId },
+          tags: { type: "Array", value: [] },
+        },
+        null,
+      );
+
+      // This stays below Db because positional decoding can mask lost named-row transport metadata.
+      const rows = (await runtime.query(
+        JSON.stringify({
+          table: "users",
+          array_subqueries: [
+            {
+              column_name: "todosViaOwner",
+              table: "todos",
+              inner_column: "owner_id",
+              outer_column: "users.id",
+            },
+          ],
+        }),
+        null,
+        "local",
+        null,
+      )) as Array<{ valuesByColumn?: Map<string, unknown> }>;
+      expect(Object.getOwnPropertyDescriptor(rows[0]!, "valuesByColumn")?.enumerable).toBe(false);
+      const relation = rows[0]?.valuesByColumn?.get("todosViaOwner") as
+        | {
+            type: "Array";
+            value: Array<{
+              type: "Row";
+              value: { valuesByColumn?: Map<string, unknown> };
+            }>;
+          }
+        | undefined;
+
+      expect(relation?.value[0]?.value.valuesByColumn?.get("title")).toEqual({
+        type: "Text",
+        value: "through-worker",
+      });
+    } finally {
+      await runtime.close();
+    }
   });
 
   it("supports multi-hop queries", async () => {


### PR DESCRIPTION
## What changed

- preserve native row `valuesByColumn` metadata while query results cross the browser worker boundary
- restore the metadata to its hidden representation on both sides of the boundary
- add regression coverage for nested relation rows surviving structured cloning

## Why

`valuesByColumn` is intentionally non-enumerable, so browser structured cloning omitted it. Relation results then fell back to positional decoding and could map an unrelated scalar value onto an included relation.

## Impact

Typed relation includes returned through the persistent browser runtime retain their named row values and decode correctly. Direct runtime results keep the existing hidden-property shape.

## Validation

- 91 focused tests passed, 1 existing test skipped
- focused Chromium relation-hydration smoke test passed with 10 root rows and 36 related rows
- formatting, lint, and sensitive-data hooks passed (one pre-existing unused-variable warning)
