### PR TITLE
(new core) Add browser relation hydration benchmark

### DIFF
--- a/dev/benchmarks/realistic/README.md
+++ b/dev/benchmarks/realistic/README.md
@@ -167,6 +167,7 @@ Current browser scenarios:
 - `B4`: fanout delivery latency/throughput across many subscribers
 - `B5`: recursive policy schema read/update stress
 - `B6`: hotspot deep-history update stress with storage usage sampling
+- `B7`: large relation-result hydration over the project-board dataset
 
 ## CI / Runner
 

--- a/dev/benchmarks/realistic/scenarios/b7_server_relation_hydration.json
+++ b/dev/benchmarks/realistic/scenarios/b7_server_relation_hydration.json
@@ -1,0 +1,8 @@
+{
+  "id": "B7",
+  "name": "server_relation_hydration",
+  "seed": 20260731,
+  "read_cycles": 6,
+  "large_multiplier": 4,
+  "root_task_limit": 400
+}

--- a/packages/jazz-tools/tests/browser/realistic-bench.test.ts
+++ b/packages/jazz-tools/tests/browser/realistic-bench.test.ts
@@ -2210,7 +2210,7 @@ async function runB7(config: ProfileConfig): Promise<ScenarioResult> {
   try {
     db = await createServerDb(appId, dbName, "realistic-b7");
     await seedDataset(db, largeConfig);
-    const warmRows = await db.all(hydrationQuery, "local");
+    const warmRows = await db.all(hydrationQuery, { tier: "local" });
     rootRows = warmRows.length;
     commentRows = warmRows.reduce(
       (total, row) => total + (row.task_commentsViaTask?.length ?? 0),
@@ -2220,12 +2220,12 @@ async function runB7(config: ProfileConfig): Promise<ScenarioResult> {
     const wallStart = performance.now();
     for (let cycle = 0; cycle < cycles; cycle += 1) {
       const startedAt = performance.now();
-      const rows = await db.all(hydrationQuery, "local");
+      const rows = await db.all(hydrationQuery, { tier: "local" });
       latencies.push(performance.now() - startedAt);
       expect(rows.length).toBe(rootRows);
     }
     const wallMs = performance.now() - wallStart;
-    const validationRows = await db.all(hydrationQuery, "local");
+    const validationRows = await db.all(hydrationQuery, { tier: "local" });
     const relationIdentity = (rows: typeof warmRows) =>
       rows.map((row) => [row.id, (row.task_commentsViaTask ?? []).map((comment) => comment.id)]);
     expect(relationIdentity(validationRows)).toEqual(relationIdentity(warmRows));

--- a/packages/jazz-tools/tests/browser/realistic-bench.test.ts
+++ b/packages/jazz-tools/tests/browser/realistic-bench.test.ts
@@ -2187,10 +2187,13 @@ async function runB7(config: ProfileConfig): Promise<ScenarioResult> {
   const appId = await benchmarkAppId("b7");
   const dbName = uniqueDbName("b7");
   const cycles = Math.min(b7.read_cycles, CI_BROWSER_LIMITS.b7ReadCycles);
-  const largeConfig = scaledLargeProfile(
-    config,
-    Math.min(b7.large_multiplier, CI_BROWSER_LIMITS.b7LargeMultiplier),
-  );
+  const largeConfig = {
+    ...scaledLargeProfile(
+      config,
+      Math.min(b7.large_multiplier, CI_BROWSER_LIMITS.b7LargeMultiplier),
+    ),
+    seed: b7.seed,
+  };
   const rootTaskLimit = Math.min(
     largeConfig.tasks,
     b7.root_task_limit,
@@ -2222,6 +2225,13 @@ async function runB7(config: ProfileConfig): Promise<ScenarioResult> {
       expect(rows.length).toBe(rootRows);
     }
     const wallMs = performance.now() - wallStart;
+    const validationRows = await db.all(hydrationQuery, "local");
+    const relationIdentity = (rows: typeof warmRows) =>
+      rows.map((row) => [row.id, (row.task_commentsViaTask ?? []).map((comment) => comment.id)]);
+    expect(relationIdentity(validationRows)).toEqual(relationIdentity(warmRows));
+    expect(
+      validationRows.reduce((total, row) => total + (row.task_commentsViaTask?.length ?? 0), 0),
+    ).toBe(commentRows);
 
     return {
       scenario_id: b7.id,

--- a/packages/jazz-tools/tests/browser/realistic-bench.test.ts
+++ b/packages/jazz-tools/tests/browser/realistic-bench.test.ts
@@ -4,6 +4,7 @@ import { createDb, type Db, type QueryBuilder, type TableProxy } from "../../src
 import { generateAuthSecret } from "../../src/runtime/auth-secret-store.js";
 import type { WasmSchema } from "../../src/drivers/types.js";
 import { loadWasmModule } from "../../src/runtime/client.js";
+import { schema as s } from "../../src/index.js";
 import { getJazzServerInfo, getJazzServerJwtForUser } from "./testing-server.js";
 
 import schemaJson from "../../../../dev/benchmarks/realistic/schema/project_board.schema.json";
@@ -17,6 +18,7 @@ import b3Json from "../../../../dev/benchmarks/realistic/scenarios/b3_server_col
 import b4Json from "../../../../dev/benchmarks/realistic/scenarios/b4_server_fanout_updates.json";
 import b5Json from "../../../../dev/benchmarks/realistic/scenarios/b5_server_permission_recursive.json";
 import b6Json from "../../../../dev/benchmarks/realistic/scenarios/b6_server_hotspot_history.json";
+import b7Json from "../../../../dev/benchmarks/realistic/scenarios/b7_server_relation_hydration.json";
 
 declare const __JAZZ_REALISTIC_BROWSER_SCENARIOS__: string;
 declare const __JAZZ_REALISTIC_BROWSER_RUN_ID__: string;
@@ -116,6 +118,15 @@ interface B6Scenario {
   seed: number;
   hot_task_count: number;
   update_count: number;
+}
+
+interface B7Scenario {
+  id: string;
+  name: string;
+  seed: number;
+  read_cycles: number;
+  large_multiplier: number;
+  root_task_limit: number;
 }
 
 interface UserRow {
@@ -242,8 +253,52 @@ const DEFAULT_CI_BROWSER_LIMITS = {
   b5ReadRequests: 160,
   b5UpdateAttempts: 120,
   b6UpdateCount: 6000,
+  b7ReadCycles: 6,
+  b7LargeMultiplier: 4,
+  b7RootTaskLimit: 400,
 } as const;
 type BrowserLimitOverrides = Partial<Record<keyof typeof DEFAULT_CI_BROWSER_LIMITS, number>>;
+
+const projectBoardSchema = {
+  users: s.table({ display_name: s.string(), email: s.string() }),
+  organizations: s.table({ name: s.string(), created_at: s.timestamp() }),
+  memberships: s.table({
+    organization_id: s.ref("organizations"),
+    user_id: s.ref("users"),
+    role: s.string(),
+  }),
+  projects: s.table({
+    organization_id: s.ref("organizations"),
+    name: s.string(),
+    archived: s.boolean(),
+    updated_at: s.timestamp(),
+  }),
+  tasks: s.table({
+    project_id: s.ref("projects"),
+    title: s.string(),
+    status: s.string(),
+    priority: s.int(),
+    assignee_id: s.ref("users"),
+    updated_at: s.timestamp(),
+    due_at: s.timestamp().optional(),
+  }),
+  task_comments: s.table({
+    task_id: s.ref("tasks"),
+    author_id: s.ref("users"),
+    body: s.string(),
+    created_at: s.timestamp(),
+  }),
+  task_watchers: s.table({ task_id: s.ref("tasks"), user_id: s.ref("users") }),
+  activity_events: s.table({
+    project_id: s.ref("projects"),
+    task_id: s.ref("tasks").optional(),
+    actor_id: s.ref("users"),
+    kind: s.string(),
+    created_at: s.timestamp(),
+    payload: s.string(),
+  }),
+};
+const projectBoardApp = s.defineApp(projectBoardSchema);
 
 function resolveBrowserLimitOverrides(): BrowserLimitOverrides {
   const raw = (__JAZZ_REALISTIC_BROWSER_LIMIT_OVERRIDES_JSON__ ?? "").trim();
@@ -281,6 +336,7 @@ const b3 = b3Json as unknown as B3Scenario;
 const b4 = b4Json as unknown as B4Scenario;
 const b5 = b5Json as unknown as B5Scenario;
 const b6 = b6Json as unknown as B6Scenario;
+const b7 = b7Json as unknown as B7Scenario;
 const browserScenarioSelection = new Set(
   (__JAZZ_REALISTIC_BROWSER_SCENARIOS__ ?? "")
     .split(",")
@@ -2126,6 +2182,71 @@ async function runB6(config: ProfileConfig): Promise<ScenarioResult> {
   }
 }
 
+async function runB7(config: ProfileConfig): Promise<ScenarioResult> {
+  progressLog("B7 start");
+  const appId = await benchmarkAppId("b7");
+  const dbName = uniqueDbName("b7");
+  const cycles = Math.min(b7.read_cycles, CI_BROWSER_LIMITS.b7ReadCycles);
+  const largeConfig = scaledLargeProfile(
+    config,
+    Math.min(b7.large_multiplier, CI_BROWSER_LIMITS.b7LargeMultiplier),
+  );
+  const rootTaskLimit = Math.min(
+    largeConfig.tasks,
+    b7.root_task_limit,
+    CI_BROWSER_LIMITS.b7RootTaskLimit,
+  );
+  const hydrationQuery = projectBoardApp.tasks
+    .include({ task_commentsViaTask: true })
+    .limit(rootTaskLimit);
+  const latencies: number[] = [];
+  let rootRows = 0;
+  let commentRows = 0;
+  let db: Db | null = null;
+
+  try {
+    db = await createServerDb(appId, dbName, "realistic-b7");
+    await seedDataset(db, largeConfig);
+    const warmRows = await db.all(hydrationQuery, "local");
+    rootRows = warmRows.length;
+    commentRows = warmRows.reduce(
+      (total, row) => total + (row.task_commentsViaTask?.length ?? 0),
+      0,
+    );
+
+    const wallStart = performance.now();
+    for (let cycle = 0; cycle < cycles; cycle += 1) {
+      const startedAt = performance.now();
+      const rows = await db.all(hydrationQuery, "local");
+      latencies.push(performance.now() - startedAt);
+      expect(rows.length).toBe(rootRows);
+    }
+    const wallMs = performance.now() - wallStart;
+
+    return {
+      scenario_id: b7.id,
+      scenario_name: b7.name,
+      profile_id: largeConfig.id,
+      topology: "single_hop_browser",
+      total_operations: cycles,
+      wall_time_ms: wallMs,
+      throughput_ops_per_sec: cycles / Math.max(0.001, wallMs / 1000),
+      operation_summaries: {
+        relation_hydration: summarizeLatencies(latencies),
+      },
+      extra: {
+        cycles,
+        root_rows: rootRows,
+        leaf_rows: commentRows,
+        comment_rows: commentRows,
+        root_task_limit: rootTaskLimit,
+      },
+    };
+  } finally {
+    if (db) await db.shutdown();
+  }
+}
+
 describe("realistic browser benchmark harness", () => {
   it("delivers an initial scoped snapshot for a seeded server-backed project board query", async () => {
     const cfg = scaledProfile(profile);
@@ -2464,6 +2585,7 @@ describe("realistic browser benchmark harness", () => {
         { id: "B4", run: async (): Promise<ScenarioResult> => runB4(cfg) },
         { id: "B5", run: async (): Promise<ScenarioResult> => runB5(cfg) },
         { id: "B6", run: async (): Promise<ScenarioResult> => runB6(cfg) },
+        { id: "B7", run: async (): Promise<ScenarioResult> => runB7(profile) },
       ];
       const knownIds = new Set(runners.map((runner) => runner.id));
       for (const requestedId of browserScenarioSelection) {
@@ -2541,6 +2663,14 @@ describe("realistic browser benchmark harness", () => {
       const b6Result = resultsById.get("B6");
       if (b6Result) {
         expect(b6Result.operation_summaries.hotspot_update_sync.count).toBeGreaterThan(0);
+      }
+
+      const b7Result = resultsById.get("B7");
+      if (b7Result) {
+        expect(b7Result.operation_summaries.relation_hydration.count).toBeGreaterThan(0);
+        expect(Number(b7Result.extra.root_rows)).toBeGreaterThan(0);
+        expect(Number(b7Result.extra.leaf_rows)).toBeGreaterThan(0);
+        expect(Number(b7Result.extra.comment_rows)).toBeGreaterThan(0);
       }
     } finally {
       restoreLogs();

--- a/packages/jazz-tools/tests/browser/realistic-bench.test.ts
+++ b/packages/jazz-tools/tests/browser/realistic-bench.test.ts
@@ -2585,6 +2585,8 @@ describe("realistic browser benchmark harness", () => {
         { id: "B4", run: async (): Promise<ScenarioResult> => runB4(cfg) },
         { id: "B5", run: async (): Promise<ScenarioResult> => runB5(cfg) },
         { id: "B6", run: async (): Promise<ScenarioResult> => runB6(cfg) },
+        // B7 applies browser scaling inside scaledLargeProfile; passing cfg would scale twice
+        // and erase the relation density this scenario is intended to measure.
         { id: "B7", run: async (): Promise<ScenarioResult> => runB7(profile) },
       ];
       const knownIds = new Set(runners.map((runner) => runner.id));


### PR DESCRIPTION
## What changed

- add B7, a browser/OPFS benchmark for hydrating a large reverse-relation result
- reuse the existing project-board dataset through its typed schema and query API
- record root/leaf row counts and relation-hydration latency receipts
- cap the default fixture at 400 root tasks and 1,440 related comment rows for stable Chromium runs

## Why

The existing realistic browser scenarios exercise flat reads, writes, fanout, permissions, and history, but none measure TypeScript relation-result hydration. B7 provides reproducible public coverage for that path.

## Impact

The benchmark can validate relation-hydration changes without relying on private data. It is benchmark-only and does not alter production behavior.

## Validation

- browser smoke: 10 root tasks and 36 related rows, all assertions passed
- full local workload: 400 root tasks and 1,440 related rows
- formatting, lint, and sensitive-data hooks passed (existing harness warnings only)
