### PR TITLE
(new core) Optimize leaf relation hydration

### DIFF
--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -3729,6 +3729,10 @@ function materializeRelationRow(
   const rowKeyValue = rowKey(row.table, row.id);
   const cached = materialized.get(rowKeyValue);
   if (cached) return { row: cached, satisfiesRequirements: true };
+  if (subqueries.length === 0) {
+    materialized.set(rowKeyValue, row);
+    return { row, satisfiesRequirements: true };
+  }
   materialized.set(rowKeyValue, row);
   const valuesByColumn = new Map(row.valuesByColumn ?? []);
   const relationValues: Value[] = [];


### PR DESCRIPTION
## What changed

Return relation leaf rows directly when they have no nested array subqueries, instead of rebuilding:

- the row object
- its named-value map
- empty relation-value collections

The row is still entered in the materialization cache, preserving shared-row behavior.

## Why

Large leaf-heavy relation results spent measurable time reconstructing rows even though there was no nested relation work to perform.

## Impact

- anonymized real-world fixture: median improvement of approximately 113 ms / 5.2%
- public B7 workload (400 roots, 1,440 leaves): p50 improved from 87.15 ms to 83.70 ms, approximately 4.0%
- the same public pair improved average latency from 86.88 ms to 85.51 ms, approximately 1.6%
- flat and small-query benchmarks showed no measurable change

## Validation

- 123 focused tests passed, 1 existing test skipped
- focused Chromium B7 scenario passed with non-empty root and leaf results
- formatting, lint, and sensitive-data hooks passed
