### PR TITLE
(new core) bench: capture selective Global hydration scaling

### DIFF
--- a/crates/jazz/Cargo.toml
+++ b/crates/jazz/Cargo.toml
@@ -11,13 +11,7 @@ default = ["rocksdb", "transport-compression-zstd"]
 rocksdb = ["groove/rocksdb", "dep:rocksdb"]
 sqlite = ["dep:rusqlite"]
 client = ["server"]
-server = [
-  "dep:axum",
-  "dep:tracing-subscriber",
-  "dep:tower-http",
-  "dep:async-stream",
-  "dep:reqwest",
-]
+server = ["dep:axum", "dep:tracing-subscriber", "dep:tower-http", "dep:async-stream", "dep:reqwest"]
 cli = ["server", "rocksdb", "dep:clap", "dep:mimalloc"]
 sync-autopsy = []
 testing = []
@@ -62,10 +56,17 @@ internment = "0.8"
 smallvec = { version = "1.11", features = ["serde"] }
 sha2 = "0.10"
 tokio = { version = "1", features = ["full"] }
-rocksdb = { package = "rust-rocksdb", version = "0.48.0", default-features = false, features = ["lz4", "zstd"], optional = true }
+rocksdb = { package = "rust-rocksdb", version = "0.48.0", default-features = false, features = [
+  "lz4",
+  "zstd",
+], optional = true }
 rusqlite = { version = "0.34", features = ["bundled"], optional = true }
 axum = { version = "0.7", features = ["ws"], optional = true }
-tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots", "rustls-tls-webpki-roots", "handshake"] }
+tokio-tungstenite = { version = "0.29", features = [
+  "rustls-tls-native-roots",
+  "rustls-tls-webpki-roots",
+  "handshake",
+] }
 tungstenite = { version = "0.29", default-features = false, features = ["handshake"] }
 bytes = { version = "1", optional = true }
 clap = { version = "4", features = ["derive", "env"], optional = true }
@@ -76,10 +77,24 @@ jsonwebtoken = { version = "10.4", features = ["rust_crypto"] }
 base64 = "0.22"
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 mimalloc = { version = "0.1", default-features = false, optional = true }
-reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"], optional = true }
+reqwest = { version = "0.12", default-features = false, features = [
+  "json",
+  "stream",
+  "rustls-tls",
+], optional = true }
 opentelemetry = { version = "0.31", optional = true }
-opentelemetry_sdk = { version = "0.31", features = ["rt-tokio", "logs", "metrics"], optional = true }
-opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic", "http-json", "reqwest-blocking-client", "logs", "metrics"], optional = true }
+opentelemetry_sdk = { version = "0.31", features = [
+  "rt-tokio",
+  "logs",
+  "metrics",
+], optional = true }
+opentelemetry-otlp = { version = "0.31", features = [
+  "grpc-tonic",
+  "http-json",
+  "reqwest-blocking-client",
+  "logs",
+  "metrics",
+], optional = true }
 opentelemetry-stdout = { version = "0.31", optional = true }
 opentelemetry-appender-tracing = { version = "0.31", optional = true }
 tracing-opentelemetry = { version = "0.32", optional = true }
@@ -91,7 +106,11 @@ opentelemetry_sdk = { version = "0.31", features = ["testing"] }
 criterion = "0.5"
 insta = "1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = [
+  "json",
+  "stream",
+  "rustls-tls",
+] }
 bytes = "1"
 jsonwebtoken = { version = "10.4", features = ["rust_crypto"] }
 futures = "0.3"

--- a/crates/jazz/Cargo.toml
+++ b/crates/jazz/Cargo.toml
@@ -134,6 +134,11 @@ name = "relation_include_delivery"
 harness = false
 
 [[bench]]
+name = "selective_global_hydration"
+harness = false
+required-features = ["rocksdb", "testing"]
+
+[[bench]]
 name = "observer_write_path"
 harness = false
 

--- a/crates/jazz/benches/README.md
+++ b/crates/jazz/benches/README.md
@@ -7,7 +7,8 @@ source material here.
 ## Active benches
 
 The active bench harness is the explicit `[[bench]]` list in
-`crates/jazz-tools/Cargo.toml`:
+`crates/jazz/Cargo.toml`. It includes the retained core/simulation receipts and
+the facade-level Criterion and realistic lanes, including:
 
 - `observer_write_path`
 - `db_benchmark`
@@ -16,6 +17,13 @@ The active bench harness is the explicit `[[bench]]` list in
 - `insert_benchmark`
 - `update_benchmark`
 - `subscription_benchmark`
+- `validation`
+- `sync`
+- `cold_subscription`
+- `large_value_checkpointing`
+- `merge_back_cost`
+- `relation_include_delivery`
+- `selective_global_hydration`
 
 All active Criterion benches now exercise the workspace `jazz` engine facade
 directly instead of going through the legacy
@@ -49,6 +57,13 @@ than old helper behavior:
   revoked doc visible. Recursive write-policy settlement is covered in the
   `jazz` policy tests with global/settled support rows; local-only support rows
   correctly do not authorize writes.
+
+`selective_global_hydration` is a custom JSONL receipt over the persisted
+Global query path. It holds one selected team and its result page fixed while
+total table rows increase, then records exact result digests and logical
+Global-current row/index reads. It is intentionally not a timing gate: the
+deterministic read counts establish whether hydration is selective before an
+engine optimization is attempted.
 
 ## Intended next ports
 

--- a/crates/jazz/benches/selective_global_hydration.rs
+++ b/crates/jazz/benches/selective_global_hydration.rs
@@ -1,0 +1,430 @@
+//! Persistent Global-query hydration receipt with fixed selectivity.
+//!
+//! The selected team and result size stay fixed while total table size grows.
+//! Logical storage-read counters reveal whether initial query hydration follows
+//! the declared `team` index or scans the entire Global current table.
+//!
+//! ```text
+//! cargo bench -p jazz --features testing --bench selective_global_hydration --quiet
+//! ```
+//!
+//! `JAZZ_SELECTIVE_HYDRATION_ROWS` controls the comma-separated table-size
+//! ladder. `JAZZ_SELECTIVE_HYDRATION_TARGET_ROWS`,
+//! `JAZZ_SELECTIVE_HYDRATION_RESULT_ROWS`, and
+//! `JAZZ_SELECTIVE_HYDRATION_BATCH_ROWS` control the fixed selection and seed
+//! batching.
+
+mod support;
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::time::Instant;
+
+use jazz::db::{
+    Db, DbConfig, DbIdentity, LocalUpdates, MergeableTxOps, Propagation, ReadOpts,
+    SeededRowIdSource, block_on,
+};
+use jazz::groove::db::StorageReadMetrics;
+use jazz::groove::records::Value;
+use jazz::groove::schema::ColumnType;
+use jazz::groove::storage::RocksDbStorage;
+use jazz::ids::{AuthorId, NodeUuid, RowUuid};
+use jazz::query::{OrderDirection, Query, col, eq, lit, param};
+use jazz::schema::{ColumnSchema, JazzSchema, TableSchema};
+use jazz::tx::DurabilityTier;
+use serde_json::{Map, json};
+use sha2::{Digest, Sha256};
+
+const TABLE: &str = "documents";
+
+fn main() {
+    let config = Config::from_env();
+    config.validate();
+
+    let mut receipts = Vec::with_capacity(config.table_rows.len());
+    for &table_rows in &config.table_rows {
+        let receipt = run_rung(config.as_ref(), table_rows);
+        receipt.emit();
+        receipts.push(receipt);
+    }
+
+    let first = receipts.first().expect("non-empty table-size ladder");
+    let last = receipts.last().expect("non-empty table-size ladder");
+    let mut fields = Map::new();
+    fields.insert("phase".to_owned(), json!("scale_summary"));
+    fields.insert("selection_fixed".to_owned(), json!(true));
+    fields.insert("first_table_rows".to_owned(), json!(first.table_rows));
+    fields.insert("last_table_rows".to_owned(), json!(last.table_rows));
+    fields.insert(
+        "table_scale_ratio".to_owned(),
+        json!(last.table_rows as f64 / first.table_rows as f64),
+    );
+    fields.insert(
+        "query_path_global_current_row_read_ratio".to_owned(),
+        json!(ratio(
+            query_path_global_row_reads(last),
+            query_path_global_row_reads(first),
+        )),
+    );
+    fields.insert(
+        "query_path_global_current_index_read_ratio".to_owned(),
+        json!(ratio(
+            query_path_global_index_reads(last),
+            query_path_global_index_reads(first),
+        )),
+    );
+    fields.insert(
+        "end_to_end_global_current_row_read_ratio".to_owned(),
+        json!(ratio(
+            end_to_end_global_row_reads(last),
+            end_to_end_global_row_reads(first),
+        )),
+    );
+    fields.insert(
+        "end_to_end_global_current_index_read_ratio".to_owned(),
+        json!(ratio(
+            end_to_end_global_index_reads(last),
+            end_to_end_global_index_reads(first),
+        )),
+    );
+    fields.insert(
+        "tooling_friction".to_owned(),
+        json!("A reusable settled fixture would avoid reseeding each scale rung while preserving the fixed-selection read boundary."),
+    );
+    support::emit_json_line("selective_global_hydration", fields);
+}
+
+#[derive(Clone, Copy)]
+struct ConfigRef {
+    target_rows: usize,
+    result_rows: usize,
+    batch_rows: usize,
+}
+
+struct Config {
+    table_rows: Vec<usize>,
+    target_rows: usize,
+    result_rows: usize,
+    batch_rows: usize,
+}
+
+impl Config {
+    fn from_env() -> Self {
+        Self {
+            table_rows: support::csv_usizes("JAZZ_SELECTIVE_HYDRATION_ROWS", "1000,10000,100000"),
+            target_rows: support::env_usize("JAZZ_SELECTIVE_HYDRATION_TARGET_ROWS", 100),
+            result_rows: support::env_usize("JAZZ_SELECTIVE_HYDRATION_RESULT_ROWS", 50),
+            batch_rows: support::env_usize("JAZZ_SELECTIVE_HYDRATION_BATCH_ROWS", 1000),
+        }
+    }
+
+    fn validate(&self) {
+        assert!(
+            !self.table_rows.is_empty(),
+            "table-size ladder must not be empty"
+        );
+        assert!(self.target_rows > 0, "target row count must be positive");
+        assert!(self.result_rows > 0, "result row count must be positive");
+        assert!(self.batch_rows > 0, "seed batch size must be positive");
+        assert!(
+            self.result_rows <= self.target_rows,
+            "result rows must not exceed target rows"
+        );
+        assert!(
+            self.table_rows.iter().all(|rows| *rows >= self.target_rows),
+            "every table-size rung must contain the fixed target rows"
+        );
+        assert!(
+            self.table_rows.windows(2).all(|pair| pair[0] < pair[1]),
+            "table-size ladder must be strictly increasing"
+        );
+    }
+
+    fn as_ref(&self) -> ConfigRef {
+        ConfigRef {
+            target_rows: self.target_rows,
+            result_rows: self.result_rows,
+            batch_rows: self.batch_rows,
+        }
+    }
+}
+
+struct RungReceipt {
+    table_rows: usize,
+    target_rows: usize,
+    result_rows: usize,
+    seed_us: u128,
+    storage_open_us: u128,
+    db_open_us: u128,
+    prepare_us: u128,
+    query_us: u128,
+    result_digest: String,
+    open_metrics: StorageReadMetrics,
+    prepare_metrics: StorageReadMetrics,
+    query_metrics: StorageReadMetrics,
+}
+
+impl RungReceipt {
+    fn emit(&self) {
+        let mut fields = Map::new();
+        fields.insert("phase".to_owned(), json!("query_hydration"));
+        fields.insert("storage".to_owned(), json!("rocksdb_wal_no_sync"));
+        fields.insert("read_tier".to_owned(), json!("global"));
+        fields.insert(
+            "cache_state".to_owned(),
+            json!("fresh_rocksdb_instance_os_cache_uncontrolled"),
+        );
+        fields.insert("table_rows".to_owned(), json!(self.table_rows));
+        fields.insert("target_rows".to_owned(), json!(self.target_rows));
+        fields.insert("result_rows".to_owned(), json!(self.result_rows));
+        fields.insert("selection_fixed".to_owned(), json!(true));
+        fields.insert("result_digest".to_owned(), json!(self.result_digest));
+        fields.insert("seed_us".to_owned(), json!(self.seed_us));
+        fields.insert("storage_open_us".to_owned(), json!(self.storage_open_us));
+        fields.insert("db_open_us".to_owned(), json!(self.db_open_us));
+        fields.insert("prepare_us".to_owned(), json!(self.prepare_us));
+        fields.insert("query_us".to_owned(), json!(self.query_us));
+        insert_read_metrics(&mut fields, "open", &self.open_metrics);
+        insert_read_metrics(&mut fields, "prepare", &self.prepare_metrics);
+        insert_read_metrics(&mut fields, "query", &self.query_metrics);
+        support::emit_json_line("selective_global_hydration", fields);
+    }
+}
+
+fn run_rung(config: ConfigRef, table_rows: usize) -> RungReceipt {
+    let temp = tempfile::tempdir().expect("create selective-hydration RocksDB directory");
+    let schema = schema();
+    let (db, _, _) = open_db(temp.path(), schema.clone());
+
+    let seed_started = Instant::now();
+    seed_rows(&db, config, table_rows);
+    let seed_us = seed_started.elapsed().as_micros();
+    db.close()
+        .expect("close seeded selective-hydration database");
+    drop(db);
+
+    let (db, storage_open_us_after_seed, db_open_us_after_seed) = open_db(temp.path(), schema);
+    let open_metrics = db.take_storage_read_metrics_for_test();
+    let query = Query::from(TABLE)
+        .filter(eq(col("team"), param("team")))
+        .filter(eq(col("active"), lit(true)))
+        .order_by("updated_at", OrderDirection::Desc)
+        .order_by("id", OrderDirection::Desc)
+        .limit(config.result_rows);
+    db.reset_storage_read_metrics_for_test();
+    let prepare_started = Instant::now();
+    let prepared = db
+        .prepare_query_bound(
+            &query,
+            BTreeMap::from([("team".to_owned(), Value::Uuid(target_team().0))]),
+        )
+        .expect("prepare selective Global query");
+    let prepare_us = prepare_started.elapsed().as_micros();
+    let prepare_metrics = db.take_storage_read_metrics_for_test();
+
+    db.reset_storage_read_metrics_for_test();
+    let query_started = Instant::now();
+    let rows = block_on(db.all(&prepared, global_read_opts())).expect("run selective Global query");
+    let query_us = query_started.elapsed().as_micros();
+    let query_metrics = db.take_storage_read_metrics_for_test();
+
+    let observed = rows.iter().map(|row| row.row_uuid()).collect::<Vec<_>>();
+    let expected = (config.target_rows - config.result_rows..config.target_rows)
+        .rev()
+        .map(target_row)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        observed, expected,
+        "selective Global result changed at table size {table_rows}"
+    );
+    let result_digest = digest_rows(&observed);
+    assert_eq!(result_digest, digest_rows(&expected));
+
+    db.close()
+        .expect("close measured selective-hydration database");
+
+    RungReceipt {
+        table_rows,
+        target_rows: config.target_rows,
+        result_rows: config.result_rows,
+        seed_us,
+        storage_open_us: storage_open_us_after_seed,
+        db_open_us: db_open_us_after_seed,
+        prepare_us,
+        query_us,
+        result_digest,
+        open_metrics,
+        prepare_metrics,
+        query_metrics,
+    }
+}
+
+fn schema() -> JazzSchema {
+    JazzSchema::new([TableSchema::new(
+        TABLE,
+        [
+            ColumnSchema::new("team", ColumnType::Uuid),
+            ColumnSchema::new("active", ColumnType::Bool),
+            ColumnSchema::new("updated_at", ColumnType::U64),
+            ColumnSchema::new("title", ColumnType::String),
+        ],
+    )
+    .with_indexed_column("team")])
+}
+
+fn open_db(path: &Path, schema: JazzSchema) -> (Db<RocksDbStorage>, u128, u128) {
+    let column_families = schema.column_families();
+    let refs = column_families
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    let storage_started = Instant::now();
+    let storage = RocksDbStorage::open(path, &refs).expect("open selective-hydration RocksDB");
+    let storage_open_us = storage_started.elapsed().as_micros();
+    let db_started = Instant::now();
+    let db = block_on(Db::open_history_complete(
+        DbConfig::new(
+            schema,
+            storage,
+            DbIdentity {
+                node: NodeUuid::from_bytes([0x73; 16]),
+                author: AuthorId::SYSTEM,
+            },
+        )
+        .with_id_source(SeededRowIdSource::new(0x73)),
+    ))
+    .expect("open selective-hydration Jazz database");
+    let db_open_us = db_started.elapsed().as_micros();
+    (db, storage_open_us, db_open_us)
+}
+
+fn seed_rows(db: &Db<RocksDbStorage>, config: ConfigRef, table_rows: usize) {
+    for batch_start in (0..table_rows).step_by(config.batch_rows) {
+        let batch_end = table_rows.min(batch_start + config.batch_rows);
+        let tx = db
+            .mergeable_tx()
+            .expect("open selective-hydration seed transaction");
+        for index in batch_start..batch_end {
+            let (row, team, updated_at) = if index < config.target_rows {
+                (target_row(index), target_team(), index)
+            } else {
+                (filler_row(index), filler_team(), index)
+            };
+            tx.insert_with_id(
+                TABLE,
+                row,
+                BTreeMap::from([
+                    ("team".to_owned(), Value::Uuid(team.0)),
+                    ("active".to_owned(), Value::Bool(true)),
+                    ("updated_at".to_owned(), Value::U64(updated_at as u64)),
+                    (
+                        "title".to_owned(),
+                        Value::String(format!("document-{index}")),
+                    ),
+                ]),
+            )
+            .expect("stage selective-hydration seed row");
+        }
+        let tx_id = tx.commit().expect("commit selective-hydration seed batch");
+        db.finalize_local_mergeable_commit_for_test(tx_id)
+            .expect("settle selective-hydration seed batch");
+    }
+}
+
+fn global_read_opts() -> ReadOpts {
+    ReadOpts {
+        tier: DurabilityTier::Global,
+        local_updates: LocalUpdates::Deferred,
+        propagation: Propagation::LocalOnly,
+        include_deleted: false,
+        ..ReadOpts::default()
+    }
+}
+
+fn target_team() -> RowUuid {
+    tagged_row(0x10, 1)
+}
+
+fn filler_team() -> RowUuid {
+    tagged_row(0x20, 1)
+}
+
+fn target_row(index: usize) -> RowUuid {
+    tagged_row(0x30, index as u64)
+}
+
+fn filler_row(index: usize) -> RowUuid {
+    tagged_row(0x40, index as u64)
+}
+
+fn tagged_row(tag: u8, index: u64) -> RowUuid {
+    let mut bytes = [0_u8; 16];
+    bytes[0] = tag;
+    bytes[8..].copy_from_slice(&index.to_be_bytes());
+    RowUuid::from_bytes(bytes)
+}
+
+fn digest_rows(rows: &[RowUuid]) -> String {
+    let mut digest = Sha256::new();
+    for row in rows {
+        digest.update(row.0.as_bytes());
+    }
+    digest
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn insert_read_metrics(
+    fields: &mut Map<String, serde_json::Value>,
+    prefix: &str,
+    metrics: &StorageReadMetrics,
+) {
+    fields.insert(
+        format!("{prefix}_logical_reads"),
+        json!(metrics.total.reads),
+    );
+    fields.insert(
+        format!("{prefix}_logical_ranges"),
+        json!(metrics.total.ranges),
+    );
+    fields.insert(
+        format!("{prefix}_global_current_row_reads"),
+        json!(metrics.global_current_rows.reads),
+    );
+    fields.insert(
+        format!("{prefix}_global_current_row_ranges"),
+        json!(metrics.global_current_rows.ranges),
+    );
+    fields.insert(
+        format!("{prefix}_global_current_index_reads"),
+        json!(metrics.global_current_indexes.reads),
+    );
+    fields.insert(
+        format!("{prefix}_global_current_index_ranges"),
+        json!(metrics.global_current_indexes.ranges),
+    );
+}
+
+fn query_path_global_row_reads(receipt: &RungReceipt) -> usize {
+    receipt.prepare_metrics.global_current_rows.reads
+        + receipt.query_metrics.global_current_rows.reads
+}
+
+fn query_path_global_index_reads(receipt: &RungReceipt) -> usize {
+    receipt.prepare_metrics.global_current_indexes.reads
+        + receipt.query_metrics.global_current_indexes.reads
+}
+
+fn end_to_end_global_row_reads(receipt: &RungReceipt) -> usize {
+    receipt.open_metrics.global_current_rows.reads + query_path_global_row_reads(receipt)
+}
+
+fn end_to_end_global_index_reads(receipt: &RungReceipt) -> usize {
+    receipt.open_metrics.global_current_indexes.reads + query_path_global_index_reads(receipt)
+}
+
+fn ratio(numerator: usize, denominator: usize) -> Option<f64> {
+    (denominator != 0).then(|| numerator as f64 / denominator as f64)
+}

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -451,6 +451,23 @@ where
         Ok(tx_id)
     }
 
+    #[cfg(feature = "testing")]
+    /// Test/bench-only authority finalization for a locally committed mergeable
+    /// transaction.
+    ///
+    /// This allows scale fixtures to use the ordinary batched transaction API
+    /// before performing the same self-acceptance step as
+    /// [`Db::seed_settled_mergeable_for_bootstrap`].
+    pub fn finalize_local_mergeable_commit_for_test(&self, tx_id: TxId) -> Result<(), Error> {
+        self.node
+            .node
+            .borrow_mut()
+            .finalize_local_mergeable_commit(tx_id)?;
+        self.refresh_subscriptions()?;
+        self.node.mark_subscriber_connections_dirty();
+        Ok(())
+    }
+
     /// Return the locally observed fate and durability for a write transaction.
     pub fn write_state(&self, tx_id: TxId) -> Result<WriteState, Error> {
         let Some((fate, _, durability)) = self.node.node.borrow_mut().transaction_state(tx_id)
@@ -3033,6 +3050,18 @@ where
     /// storage path immediately after a synthetic lifecycle transition.
     pub fn flush_for_test(&self) -> Result<(), Error> {
         Ok(self.node.node.borrow_mut().flush_query_runtime()?)
+    }
+
+    #[cfg(feature = "testing")]
+    /// Test/bench-only reset for logical storage-read attribution.
+    pub fn reset_storage_read_metrics_for_test(&self) {
+        self.node.node.borrow().reset_storage_read_metrics();
+    }
+
+    #[cfg(feature = "testing")]
+    /// Test/bench-only drain for logical storage-read attribution.
+    pub fn take_storage_read_metrics_for_test(&self) -> groove::db::StorageReadMetrics {
+        self.node.node.borrow().take_storage_read_metrics()
     }
 
     #[cfg(feature = "testing")]

--- a/dev/benchmarks/SELECTIVE_GLOBAL_HYDRATION.md
+++ b/dev/benchmarks/SELECTIVE_GLOBAL_HYDRATION.md
@@ -1,0 +1,81 @@
+# Selective Global hydration receipt
+
+`crates/jazz/benches/selective_global_hydration.rs` measures the persisted
+Global query path that the permission/fan-out investigation identified as
+potentially non-selective.
+
+## Question
+
+When a prepared query selects a fixed team and a fixed-size page, does initial
+hydration work remain bounded by that selection, or grow with the total number
+of current rows in the table?
+
+## Method
+
+Each ladder rung creates a fresh RocksDB fixture with:
+
+- one `documents` table whose `team` column is declared indexed;
+- exactly 100 rows in the selected team;
+- an increasing number of rows belonging to another team;
+- a prepared `team = $team AND active = true` query ordered by
+  `updated_at DESC, id DESC` and limited to 50 rows;
+- settled Global rows, a clean close, and a fresh RocksDB/Jazz reopen before
+  measurement.
+
+The selected IDs and their SHA-256 digest must be identical at every rung. The
+receipt records logical reads and ranges for Global-current rows and indexes,
+alongside query wall time. Logical reads are the primary mechanism evidence;
+wall time is directional because the same-process seed leaves operating-system
+cache state uncontrolled.
+
+The default ladder is 1,000 / 10,000 / 100,000 total rows. Override it for a
+bounded smoke run:
+
+```sh
+JAZZ_SELECTIVE_HYDRATION_ROWS=1000,10000 \
+  cargo bench -p jazz --features testing \
+  --bench selective_global_hydration --quiet
+```
+
+The final `scale_summary` line reports the table-size ratio and both query-path
+and end-to-end Global-current row/index read ratios. Reopen, preparation, and
+query execution have separate counters. The query-path summary combines
+preparation and execution; the end-to-end summary also includes reopen so work
+cannot disappear by moving between phases. This benchmark does not gate the
+current behavior: its first purpose is to establish a durable before/after
+boundary for selective hydration work.
+
+## Baseline
+
+A single default-ladder run on the local development box produced:
+
+| Total rows | Selected rows | Result rows | Open row reads | Prepare row reads | Query row reads | Query index reads | Query time |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1,000 | 100 | 50 | 1,000 | 0 | 1,100 | 100 | 2.443 ms |
+| 10,000 | 100 | 50 | 10,000 | 0 | 10,100 | 100 | 15.793 ms |
+| 100,000 | 100 | 50 | 100,000 | 0 | 100,100 | 100 | 174.877 ms |
+
+All three rungs returned the same ordered-ID digest,
+`1ab7cbe99449f81b16f1375ce2f8ff751f03940a6f1287b6d561c0146ec9be3d`.
+The declared index supplies the same 100 candidates at every size, while each
+rung reads exactly the total table rows plus those 100 candidates from
+Global-current row storage. This is evidence that initial hydration currently
+combines the selective index walk with table-wide row work. Timings are
+illustrative rather than a performance claim; the deterministic logical reads
+are the retained baseline. Reopen separately reads every Global-current row;
+reporting that phase prevents a future query optimization from hiding
+equivalent work in startup.
+
+## Acceptance rule for an optimization
+
+An optimization is admissible only if:
+
+1. every rung returns the same exact ordered IDs and digest as this baseline;
+2. Global-current row reads are bounded by the selected candidates rather than
+   total table rows;
+3. the declared Global-current index records non-zero use when it supplies the
+   candidate set; and
+4. no full-table work is moved into an unreported preparation or reopen phase.
+
+Tooling friction: a reusable settled fixture would avoid reseeding each scale
+rung while preserving the fixed-selection read boundary.

--- a/dev/benchmarks/SELECTIVE_GLOBAL_HYDRATION.md
+++ b/dev/benchmarks/SELECTIVE_GLOBAL_HYDRATION.md
@@ -50,10 +50,10 @@ boundary for selective hydration work.
 A single default-ladder run on the local development box produced:
 
 | Total rows | Selected rows | Result rows | Open row reads | Prepare row reads | Query row reads | Query index reads | Query time |
-| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1,000 | 100 | 50 | 1,000 | 0 | 1,100 | 100 | 2.443 ms |
-| 10,000 | 100 | 50 | 10,000 | 0 | 10,100 | 100 | 15.793 ms |
-| 100,000 | 100 | 50 | 100,000 | 0 | 100,100 | 100 | 174.877 ms |
+| ---------: | ------------: | ----------: | -------------: | ----------------: | --------------: | ----------------: | ---------: |
+|      1,000 |           100 |          50 |          1,000 |                 0 |           1,100 |               100 |   2.443 ms |
+|     10,000 |           100 |          50 |         10,000 |                 0 |          10,100 |               100 |  15.793 ms |
+|    100,000 |           100 |          50 |        100,000 |                 0 |         100,100 |               100 | 174.877 ms |
 
 All three rungs returned the same ordered-ID digest,
 `1ab7cbe99449f81b16f1375ce2f8ff751f03940a6f1287b6d561c0146ec9be3d`.


### PR DESCRIPTION
## What changed

- adds a persisted RocksDB benchmark for selective Global query hydration
- holds the selected team and result page fixed while scaling total table rows from 1,000 to 100,000
- records exact ordered-result digests and logical reads separately for reopen, query preparation, and execution
- exposes test-only helpers for settling batched fixture transactions and collecting storage-read metrics
- documents the methodology, baseline, and acceptance boundary for a future optimization

## Why

The existing permission/fan-out investigation suggested that a selective Global query still performs table-wide row work. This receipt makes that behavior reproducible and attributable before changing the query engine.

The baseline shows that the declared index consistently supplies 100 candidates, while execution reads the total table size plus those 100 candidates. Reopen independently reads the entire Global-current table, so the receipt reports both query-path and end-to-end scaling to prevent work from being hidden in another phase.

This PR does not change query behavior or add a timing gate.

## Validation

- `cargo check -p jazz --features testing --bench selective_global_hydration`
- `cargo bench -p jazz --features testing --bench selective_global_hydration --quiet`
- `cargo fmt --all -- --check`
- `git diff --check`

The full 1,000 / 10,000 / 100,000 ladder returned the same exact ordered-ID digest at every rung.
