### PR TITLE
(new core) perf: keep indexed one-shot reads selective

### DIFF
--- a/crates/jazz/benches/selective_global_hydration.rs
+++ b/crates/jazz/benches/selective_global_hydration.rs
@@ -228,6 +228,17 @@ fn run_rung(config: ConfigRef, table_rows: usize) -> RungReceipt {
     let query_us = query_started.elapsed().as_micros();
     let query_metrics = db.take_storage_read_metrics_for_test();
 
+    assert!(
+        query_metrics.global_current_rows.reads <= config.target_rows,
+        "selective Global hydration read {} current rows for {} indexed candidates at table size {table_rows}",
+        query_metrics.global_current_rows.reads,
+        config.target_rows,
+    );
+    assert!(
+        (1..=config.target_rows).contains(&query_metrics.global_current_indexes.reads),
+        "selective Global hydration must use the declared index without reading more than the fixed candidate set"
+    );
+
     let observed = rows.iter().map(|row| row.row_uuid()).collect::<Vec<_>>();
     let expected = (config.target_rows - config.result_rows..config.target_rows)
         .rev()

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -6591,6 +6591,29 @@ where
             .then(|| self.settled_binding_view_key_for_query(shape, binding))
             .transpose()?
             .flatten();
+        // A concrete one-shot access path is binding-specific. Inline that
+        // binding so execution keeps the selected graph instead of replacing it
+        // with the generic cached parameterized plan.
+        let inline_query = if prepared_plan.is_none()
+            && settled_binding_view.is_none()
+            && !self.one_shot_access_paths(shape, binding, tier)?.is_empty()
+        {
+            let schema = self
+                .catalogue
+                .catalogue_schemas
+                .get(&shape.schema_version())
+                .ok_or(Error::InvalidStoredValue("query schema version is unknown"))?;
+            let inline_shape =
+                inline_snapshot_bind_filter_literals(shape, binding, &schema.schema)?;
+            let inline_binding = inline_shape.bind(BTreeMap::new())?;
+            Some((inline_shape, inline_binding))
+        } else {
+            None
+        };
+        let (shape, binding) = inline_query
+            .as_ref()
+            .map(|(shape, binding)| (shape, binding))
+            .unwrap_or((shape, binding));
         let prepared_plan = prepared_plan
             .filter(|plan| !matches!(plan.as_ref(), PreparedQueryPlan::PeerMaintainedMarker));
         let program = if prepared_plan.is_some() {

--- a/crates/jazz/src/node/tests/queries.rs
+++ b/crates/jazz/src/node/tests/queries.rs
@@ -99,6 +99,42 @@ fn one_shot_filtered_read_uses_declared_index_for_indexed_column_equality() {
 }
 
 #[test]
+fn parameterized_one_shot_index_read_does_not_fall_back_to_cached_full_scan() {
+    let schema = access_path_schema();
+    let (_writer_dir, mut writer) = open_node_with_schema(node(8), schema.clone());
+    let (_core_dir, mut core) = open_node_with_schema(node(9), schema);
+    let (first, _second, owner) = seed_access_path_docs(&mut writer, &mut core);
+    let shape = Query::from("docs")
+        .filter(eq(col("owner"), param("owner")))
+        .validate(&core.catalogue.schema)
+        .expect("validate parameterized owner query");
+    let binding = shape
+        .bind(BTreeMap::from([(
+            "owner".to_owned(),
+            Value::Uuid(owner.0),
+        )]))
+        .expect("bind owner parameter");
+
+    core.reset_storage_read_metrics();
+    let rows = core
+        .query_rows_for_link(&shape, &binding, DurabilityTier::Global, AuthorId::SYSTEM)
+        .expect("run parameterized indexed one-shot");
+    let metrics = core.take_storage_read_metrics();
+
+    assert_eq!(
+        rows.into_iter()
+            .map(|row| row.row_uuid())
+            .collect::<Vec<_>>(),
+        vec![first]
+    );
+    assert_eq!(metrics.global_current_indexes.reads, 1);
+    assert_eq!(
+        metrics.global_current_rows.reads, 1,
+        "the concrete index-selected program must not be replaced by a cached full-scan plan"
+    );
+}
+
+#[test]
 fn one_shot_filtered_read_keeps_residual_filters_after_pushdown() {
     let schema = access_path_schema();
     let (_writer_dir, mut writer) = open_node_with_schema(node(8), schema.clone());

--- a/dev/benchmarks/SELECTIVE_GLOBAL_HYDRATION.md
+++ b/dev/benchmarks/SELECTIVE_GLOBAL_HYDRATION.md
@@ -66,6 +66,20 @@ are the retained baseline. Reopen separately reads every Global-current row;
 reporting that phase prevents a future query optimization from hiding
 equivalent work in startup.
 
+## Indexed one-shot result
+
+Inlining the concrete one-shot binding before lowering prevents execution from
+replacing the index-selected program with the generic cached parameterized
+shape. On the same default ladder, query-path reads are fixed at 100 index rows
+plus 100 selected current rows for every table size. The 100,000-row query fell
+from 174.877 ms in the baseline run to 0.744 ms in the optimized run, while the
+ordered-ID digest remained unchanged. Reopen work is unaffected and remains
+reported separately.
+
+The benchmark now enforces the structural result: query current-row reads must
+not exceed the fixed candidate count, and the candidate count must be supplied
+by the declared index. Wall time remains informational rather than gated.
+
 ## Acceptance rule for an optimization
 
 An optimization is admissible only if:


### PR DESCRIPTION
## What changed

- Inline the concrete binding for parameterized one-shot reads when a declared access path is available.
- Preserve the binding-specific indexed plan instead of replacing it with the generic cached parameterized plan.
- Add a regression test and structural benchmark assertions covering index and current-row reads.

## Why

The access-path selector correctly found a declared index, but execution subsequently reused the cached generic parameterized plan. That plan could not retain the concrete binding and fell back to a full-table scan.

This is deliberately narrow: it improves selective, indexed, parameterized one-shot reads. It does not claim an improvement for unindexed queries.

## Result

On the 100,000-row benchmark rung, query time fell from 174.877 ms to 0.744 ms. The query now reads the fixed 100 index candidates and 100 selected current rows, while the ordered result digest remains unchanged.

A separate real-world fixture used an unindexed reference column and, as expected, showed no material change. That confirms the optimization's applicability boundary.

## Validation

- `cargo test -p jazz parameterized_one_shot_index_read_does_not_fall_back_to_cached_full_scan --features rocksdb`
- Selective Global hydration benchmark ladder
- Structural assertions ensure reads remain bounded by the indexed candidate set

Stacked on #1227.
