### PR TITLE
(new core) bench: capture PERF-4 known-state scaling

### DIFF
--- a/crates/jazz/Cargo.toml
+++ b/crates/jazz/Cargo.toml
@@ -151,6 +151,10 @@ name = "sync"
 harness = false
 
 [[bench]]
+name = "known_state_scaling"
+harness = false
+
+[[bench]]
 name = "cold_subscription"
 harness = false
 

--- a/crates/jazz/benches/known_state_scaling.rs
+++ b/crates/jazz/benches/known_state_scaling.rs
@@ -1,0 +1,252 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::time::Instant;
+
+mod support;
+
+use jazz::groove::records::Value;
+use jazz::groove::schema::{ColumnSchema, ColumnType};
+use jazz::groove::storage::{Durability, RocksDbStorage};
+use jazz::ids::{NodeUuid, RowUuid};
+use jazz::node::{MergeableCommit, NodeState, SKEW_TOLERANCE_MS};
+use jazz::peer::PeerState;
+use jazz::protocol::{
+    KnownStateDeclaration, RowVersionRef, SubscriptionKey, SyncMessage, expand_version_carriers,
+};
+use jazz::schema::{JazzSchema, TableSchema};
+use jazz::tx::{Fate, TxId};
+use jazz::wire::encode_sync_message;
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use support::{csv_usizes, emit_json_line, env_usize, phase_fields};
+
+const TABLE: &str = "documents";
+
+fn main() {
+    let rows = env_usize("JAZZ_KNOWN_STATE_ROWS", 1_000).max(1);
+    let coverage_percentages = csv_usizes("JAZZ_KNOWN_STATE_COVERAGE", "0,25,50,75,100");
+    assert!(
+        coverage_percentages.iter().all(|coverage| *coverage <= 100),
+        "known-state coverage percentages must be between 0 and 100"
+    );
+
+    let seed_started = Instant::now();
+    let mut fixture = Fixture::new();
+    let versions = fixture.seed(rows);
+    let seed_us = seed_started.elapsed().as_micros();
+    let subscription = fixture.subscription_key();
+    let mut expected_digest = None;
+
+    for coverage_percent in coverage_percentages {
+        let known_count = rows * coverage_percent / 100;
+        let known_versions = versions[..known_count]
+            .iter()
+            .map(|(row_uuid, tx_id)| RowVersionRef::new(TABLE, *row_uuid, *tx_id))
+            .collect::<Vec<_>>();
+        let declaration = (known_count > 0).then_some(KnownStateDeclaration::ExactVersionSet {
+            versions: known_versions,
+        });
+        let declaration_bytes = postcard::to_allocvec(&declaration)
+            .expect("encode known-state declaration payload")
+            .len();
+
+        let mut peer = PeerState::new();
+        peer.declare_known_state(subscription, declaration);
+        fixture.core.reset_storage_read_metrics();
+        let serve_started = Instant::now();
+        let update = peer
+            .current_rows_update(&mut fixture.core, TABLE)
+            .expect("serve current rows under known-state declaration");
+        let serve_us = serve_started.elapsed().as_micros();
+        let encoded_bytes = encode_sync_message(&update)
+            .expect("encode known-state view update")
+            .len();
+        let metrics = fixture.core.storage_read_metrics();
+
+        let SyncMessage::ViewUpdate {
+            version_carriers,
+            version_bundles,
+            peer_payload_inventory,
+            result_member_adds,
+            result_member_removes,
+            program_fact_adds,
+            program_fact_removes,
+            ..
+        } = &update
+        else {
+            panic!("expected one view update");
+        };
+        let mut expanded_bundles = version_bundles.clone();
+        expanded_bundles.extend(
+            expand_version_carriers(version_carriers).expect("expand benchmark version carriers"),
+        );
+        let emitted_bundles = expanded_bundles.len();
+        let expected_bundles = rows - known_count;
+        assert_eq!(emitted_bundles, expected_bundles);
+        assert_eq!(result_member_adds.len(), rows);
+        assert!(result_member_removes.is_empty());
+        assert!(program_fact_adds.is_empty());
+        assert!(program_fact_removes.is_empty());
+        let expected_versions = versions
+            .iter()
+            .map(|(row_uuid, tx_id)| RowVersionRef::new(TABLE, *row_uuid, *tx_id))
+            .collect::<BTreeSet<_>>();
+        let covered_versions = versions[..known_count]
+            .iter()
+            .map(|(row_uuid, tx_id)| RowVersionRef::new(TABLE, *row_uuid, *tx_id))
+            .chain(expanded_bundles.iter().flat_map(|bundle| {
+                bundle.versions.iter().map(|version| {
+                    RowVersionRef::new(version.table(), version.row_uuid(), bundle.tx.tx_id)
+                })
+            }))
+            .collect::<BTreeSet<_>>();
+        assert_eq!(covered_versions, expected_versions);
+
+        let digest = membership_digest(result_member_adds);
+        match &expected_digest {
+            Some(expected) => assert_eq!(&digest, expected, "known-state changed membership"),
+            None => expected_digest = Some(digest.clone()),
+        }
+
+        let mut fields = phase_fields("known_state_rehydrate", serve_us);
+        fields.insert("rows".to_owned(), json!(rows));
+        fields.insert("known_rows".to_owned(), json!(known_count));
+        fields.insert("known_percent".to_owned(), json!(coverage_percent));
+        fields.insert("seed_us".to_owned(), json!(seed_us));
+        fields.insert("encoded_bytes".to_owned(), json!(encoded_bytes));
+        fields.insert("declaration_bytes".to_owned(), json!(declaration_bytes));
+        fields.insert(
+            "variable_exchange_bytes".to_owned(),
+            json!(encoded_bytes + declaration_bytes),
+        );
+        fields.insert("version_bundles".to_owned(), json!(emitted_bundles));
+        fields.insert(
+            "complete_tx_payload_refs".to_owned(),
+            json!(peer_payload_inventory.complete_tx_payloads.len()),
+        );
+        fields.insert("result_adds".to_owned(), json!(result_member_adds.len()));
+        fields.insert(
+            "result_removes".to_owned(),
+            json!(result_member_removes.len()),
+        );
+        fields.insert("membership_digest".to_owned(), json!(digest));
+        fields.insert("storage_reads".to_owned(), json!(metrics.total.reads));
+        fields.insert("storage_ranges".to_owned(), json!(metrics.total.ranges));
+        emit_json_line("known_state_scaling", fields);
+    }
+}
+
+struct Fixture {
+    writer: NodeState<RocksDbStorage>,
+    core: NodeState<RocksDbStorage>,
+    _dirs: Vec<tempfile::TempDir>,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let schema = schema();
+        let (writer_dir, writer) = open_node(node(1), schema.clone());
+        let (core_dir, core) = open_node(node(2), schema);
+        Self {
+            writer,
+            core,
+            _dirs: vec![writer_dir, core_dir],
+        }
+    }
+
+    fn seed(&mut self, rows: usize) -> Vec<(RowUuid, TxId)> {
+        (0..rows)
+            .map(|index| {
+                let row_uuid = row(index);
+                let (tx_id, unit) = self
+                    .writer
+                    .commit_mergeable_unit(
+                        MergeableCommit::new(TABLE, row_uuid, 1_000 + index as u64)
+                            .cells(cells(index)),
+                    )
+                    .expect("create fixture commit");
+                let fate = core_ingest(&mut self.core, &unit, u64::MAX - SKEW_TOLERANCE_MS);
+                assert!(matches!(
+                    fate,
+                    SyncMessage::FateUpdate {
+                        fate: Fate::Accepted,
+                        ..
+                    }
+                ));
+                (row_uuid, tx_id)
+            })
+            .collect()
+    }
+
+    fn subscription_key(&mut self) -> SubscriptionKey {
+        let mut peer = PeerState::new();
+        let update = peer
+            .current_rows_update(&mut self.core, TABLE)
+            .expect("discover whole-table subscription key");
+        match update {
+            SyncMessage::ViewUpdate { subscription, .. } => subscription,
+            _ => panic!("expected one view update"),
+        }
+    }
+}
+
+fn membership_digest<T: serde::Serialize>(members: &T) -> String {
+    let bytes = postcard::to_allocvec(members).expect("encode membership digest input");
+    hex::encode(Sha256::digest(bytes))
+}
+
+fn core_ingest(
+    core: &mut NodeState<RocksDbStorage>,
+    message: &SyncMessage,
+    now_ms: u64,
+) -> SyncMessage {
+    let SyncMessage::CommitUnit { tx, versions } = message else {
+        panic!("expected commit unit");
+    };
+    let [fate] = core
+        .ingest_commit_unit(tx.clone(), versions.clone(), now_ms)
+        .expect("core ingest")
+        .try_into()
+        .expect("one fate update");
+    fate
+}
+
+fn schema() -> JazzSchema {
+    JazzSchema::new([TableSchema::new(
+        TABLE,
+        [ColumnSchema::new("title", ColumnType::String)],
+    )])
+}
+
+fn open_node(
+    node_uuid: NodeUuid,
+    schema: JazzSchema,
+) -> (tempfile::TempDir, NodeState<RocksDbStorage>) {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let column_families = schema.column_families();
+    let refs = column_families
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    let storage =
+        RocksDbStorage::open_with_durability(temp_dir.path(), &refs, Durability::WalNoSync)
+            .expect("open RocksDB");
+    let node = NodeState::new(node_uuid, schema, storage).expect("open node");
+    (temp_dir, node)
+}
+
+fn cells(index: usize) -> BTreeMap<String, Value> {
+    BTreeMap::from([(
+        "title".to_owned(),
+        Value::String(format!("document-{index}")),
+    )])
+}
+
+fn node(byte: u8) -> NodeUuid {
+    NodeUuid::from_bytes([byte; 16])
+}
+
+fn row(index: usize) -> RowUuid {
+    let mut bytes = [7; 16];
+    bytes[..8].copy_from_slice(&(index as u64).to_le_bytes());
+    RowUuid::from_bytes(bytes)
+}

--- a/dev/benchmarks/KNOWN_STATE_SCALING.md
+++ b/dev/benchmarks/KNOWN_STATE_SCALING.md
@@ -1,0 +1,51 @@
+# PERF-4 known-state scaling
+
+`known_state_scaling` holds a 1,000-row persisted whole-table rehydrate fixed
+while sweeping the number of exact row-version identities declared by the
+receiver. It measures the variable declaration payload and response using
+Jazz's postcard wire encoding; fixed Subscribe framing is intentionally excluded
+from every rung.
+
+The hard validity gates require every rung to:
+
+- preserve the same 1,000 result additions and membership digest;
+- emit exactly the row-version bodies not covered by the declaration; and
+- cover the complete expected version set when declared and emitted versions
+  are combined.
+
+Run the default ladder with:
+
+```sh
+cargo bench -p jazz --bench known_state_scaling
+```
+
+Override it with `JAZZ_KNOWN_STATE_ROWS` and the comma-separated
+`JAZZ_KNOWN_STATE_COVERAGE` percentages.
+
+## Initial result
+
+One default-ladder run on the local development box produced:
+
+| Known rows | Known | Declaration |  Response | Variable exchange | Version bodies | Storage reads |
+| ---------: | ----: | ----------: | --------: | ----------------: | -------------: | ------------: |
+|          0 |    0% |         1 B | 382,586 B |         382,587 B |          1,000 |         4,000 |
+|        250 |   25% |    12,004 B | 306,323 B |         318,327 B |            750 |         4,000 |
+|        500 |   50% |    24,004 B | 229,823 B |         253,827 B |            500 |         4,000 |
+|        750 |   75% |    36,004 B | 153,323 B |         189,327 B |            250 |         4,000 |
+|      1,000 |  100% |    48,004 B |  76,936 B |         124,940 B |              0 |         4,000 |
+
+Known-state dedup is structurally effective: response bodies and bytes fall
+linearly with receiver coverage. Even after charging the explicit declaration,
+full coverage reduces the measured exchange by about 67%. Result membership is
+not deduplicated, as required by `INV-SYNC-24`, so the response retains a roughly
+77 KB floor at full coverage.
+
+The serving-side storage work does not fall with coverage: every rung performs
+4,000 aggregate reads. Wall time from a single run was noisy (roughly 8–11 ms) and is
+not used as an acceptance claim. The next optimization question, if this lane
+justifies one, is whether known-state can avoid assembling or reading payload
+witnesses that will subsequently be suppressed; that requires a separate
+profile and correctness-preserving design.
+
+Tooling friction: sharing compiled artifacts between clean benchmark worktrees
+would have avoided rebuilding RocksDB for this receipt.

--- a/dev/benchmarks/OVERVIEW.md
+++ b/dev/benchmarks/OVERVIEW.md
@@ -113,6 +113,11 @@ latency numbers. #1224 adds B7 for public relation-result hydration coverage.
    route, persisted-hydration, and subscription-count evidence plus
    implementation plans. Its stable findings still need extraction into
    focused retained lanes.
+6. **PERF-4 known-state payload dedup:** `known_state_scaling` holds a persisted
+   whole-table rehydrate fixed while sweeping exact receiver coverage. The
+   retained receipt proves that emitted bodies and variable exchange bytes fall
+   with coverage while result membership remains identical. Full coverage cuts
+   the measured variable exchange by about 67%, including declaration cost.
 
 ### Important negative results retained
 
@@ -132,29 +137,26 @@ Ranked by their ability to change an engineering decision:
 1. **Policy and selective-hydration cost receipts.** Extract the stable lanes
    from #1170: authorized write-to-reader visibility, route/subscription scale,
    policy churn/reconnect, and selective Global hydration.
-2. **PERF-4 known-state payload dedup.** Hold the changed payload fixed while
-   sweeping peer-known-state cardinality; retain bundle/reference counts,
-   encoded bytes, and correctness digests.
-3. **PERF-5 maintained versus rehydrate.** Compare work, bytes, and retained
+2. **PERF-5 maintained versus rehydrate.** Compare work, bytes, and retained
    state over increasing view sizes while asserting identical results.
-4. **S4 fixed-delta/varying-view gate.** S4 already separates settlement and
+3. **S4 fixed-delta/varying-view gate.** S4 already separates settlement and
    propagation; add a deterministic structural bound proving propagation stays
    proportional to the affected delta.
-5. **S8 branch/merge/offline lifecycle.** Cover accumulated offline edits,
+4. **S8 branch/merge/offline lifecycle.** Cover accumulated offline edits,
    reconnect, merge-back, conflicts, and payload reuse end to end.
-6. **S5–S7 promised dimensions.** Add remote resume and evicted-prefix coverage
+5. **S5–S7 promised dimensions.** Add remote resume and evicted-prefix coverage
    for S5, full-history memory for S6, and native-versus-lens plus migration-wave
    costs for S7.
 
 ## Source of acceptance targets
 
-| property                                   | current evidence                                          | next enforcement                                                                               |
-| ------------------------------------------ | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `INV-INC-1` bounded incremental delivery   | retained 1k–20k ladder and `1.025x` gate                  | land #1192 and extend only when a new maintained mechanism needs its own shape-specific canary |
-| PERF-4 known-state payload dedup           | sync/S1 bundle and reference counters                     | controlled known-state-cardinality sweep                                                       |
-| PERF-5 maintained converges to rehydrate   | correctness and differential oracles                      | cost/bytes/state comparison over view scale                                                    |
-| PERF-7/8 current reads are O(current rows) | R3 persisted receipts, current-row and checkpoint benches | retained filtered/indexed-read slope where selection is held fixed                             |
-| S4 post-acceptance propagation is O(delta) | separate settlement/propagation phases                    | fixed-delta/varying-view structural gate                                                       |
+| property                                   | current evidence                                                                 | next enforcement                                                                               |
+| ------------------------------------------ | -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `INV-INC-1` bounded incremental delivery   | retained 1k–20k ladder and `1.025x` gate                                         | land #1192 and extend only when a new maintained mechanism needs its own shape-specific canary |
+| PERF-4 known-state payload dedup           | retained exact-coverage sweep with bytes, bundles, reads, and correctness digest | profile the coverage-invariant serving work only if a user-facing cost justifies it            |
+| PERF-5 maintained converges to rehydrate   | correctness and differential oracles                                             | cost/bytes/state comparison over view scale                                                    |
+| PERF-7/8 current reads are O(current rows) | R3 persisted receipts, current-row and checkpoint benches                        | retained filtered/indexed-read slope where selection is held fixed                             |
+| S4 post-acceptance propagation is O(delta) | separate settlement/propagation phases                                           | fixed-delta/varying-view structural gate                                                       |
 
 Targets should come from specification properties and measured deterministic
 spread, not from an arbitrary percentage around today’s laptop timing.
@@ -166,9 +168,8 @@ spread, not from an arbitrary percentage around today’s laptop timing.
    its durable-format decision has team agreement.
 2. Extract focused policy/selective-hydration receipts from #1170 rather than
    merging one omnibus benchmark investigation.
-3. Add the PERF-4 known-state sweep.
-4. Add PERF-5 and the S4 structural gate.
-5. Build S8, then fill the remaining S5–S7 dimensions.
+3. Add PERF-5 and the S4 structural gate.
+4. Build S8, then fill the remaining S5–S7 dimensions.
 
 Add retention alongside each lane. A broad receipt-unification project is no
 longer a prerequisite for useful performance work.


### PR DESCRIPTION
## What changed

- add a persisted PERF-4 benchmark that holds a 1,000-row rehydrate fixed while sweeping exact known-state coverage through 0/25/50/75/100%
- retain declaration bytes, response bytes, emitted bundle/reference counts, storage reads, timing, and a deterministic membership digest
- hard-gate that declared plus emitted versions exactly cover the expected version set
- update the performance roadmap to mark the PERF-4 receipt complete and advance the next work to PERF-5/S4

## Result

Known-state payload dedup scales correctly. At full coverage, emitted version bodies fall from 1,000 to zero and the measured variable exchange falls from roughly 383 KB to 125 KB, including the exact declaration cost—a reduction of about 67%.

Result membership and its digest remain identical at every rung, as required by `INV-SYNC-24`.

Serving-side storage work remains fixed at 4,000 aggregate reads. Wall time is noisy at roughly 6–11 ms, so this PR records that observation without proposing an optimization.

## Validation

- `cargo check -p jazz --bench known_state_scaling --features rocksdb`
- `cargo bench -p jazz --bench known_state_scaling`
- `cargo fmt --all -- --check`
- `oxfmt --check crates/jazz/Cargo.toml dev/benchmarks/KNOWN_STATE_SCALING.md dev/benchmarks/OVERVIEW.md`
- pre-commit clippy, sensitive-data, formatting, and Rust formatting hooks

Stacked on #1226.
