### PR TITLE
(new core) Project renamed writes into the write schema, so they reach the edge

### DIFF
--- a/crates/jazz/src/node/ingest.rs
+++ b/crates/jazz/src/node/ingest.rs
@@ -839,7 +839,7 @@ where
         self.clock.next_global_seq = self.clock.next_global_seq.next();
         let fate = Fate::Accepted;
         let durability = DurabilityTier::Global;
-        let merge_rows = merge_rows_for_versions(&versions);
+        let merge_rows = self.merge_rows_for_versions(&versions)?;
         self.ingest_known_transaction(
             tx.clone(),
             versions,
@@ -1102,7 +1102,7 @@ where
         self.clock.next_global_seq = self.clock.next_global_seq.next();
         let fate = Fate::Accepted;
         let durability = DurabilityTier::Global;
-        let merge_rows = merge_rows_for_versions(&versions);
+        let merge_rows = self.merge_rows_for_versions(&versions)?;
         self.ingest_known_transaction(
             tx.clone(),
             versions,
@@ -1516,13 +1516,9 @@ where
             for version in versions {
                 let author_schema = version.schema_version();
                 let source_table_schema = self.table_in_schema(version.table(), author_schema)?;
-                let has_forward_lens = author_schema != self.catalogue.current_write_schema.schema
-                    && self.has_forward_lens_path(
-                        author_schema,
-                        self.catalogue.current_write_schema.schema,
-                        version.table(),
-                    );
-                let (table_schema, target_schema, stored) = if has_forward_lens {
+                let (table_schema, target_schema, stored) = if author_schema
+                    != self.catalogue.current_write_schema.schema
+                {
                     let mut target_table = version.table().to_owned();
                     let mut target_cells = source_table_schema
                         .columns
@@ -1534,13 +1530,13 @@ where
                                 .map(|value| (column.name.clone(), value))
                         })
                         .collect::<BTreeMap<_, _>>();
-                    let target_schema = self.catalogue.current_write_schema.schema;
-                    target_table = self.translate_cells_forward(
-                        author_schema,
-                        target_schema,
-                        &target_table,
-                        &mut target_cells,
-                    )?;
+                    let (target_schema, translated_table) = self
+                        .translate_cells_to_current_write_schema(
+                            author_schema,
+                            &target_table,
+                            &mut target_cells,
+                        )?;
+                    target_table = translated_table;
                     let table_schema = self.table_in_schema(&target_table, target_schema)?;
                     let schema_version_alias = self.ensure_schema_version_alias(target_schema)?;
                     let stored = VersionRow::from_parts_with_schema_version(
@@ -2592,7 +2588,29 @@ where
         &mut self,
         records: &[VersionRecord],
     ) -> Result<(), Error> {
-        self.create_merge_versions_for_rows(merge_rows_for_versions(records))
+        let rows = self.merge_rows_for_versions(records)?;
+        self.create_merge_versions_for_rows(rows)
+    }
+
+    fn merge_rows_for_versions(
+        &mut self,
+        records: &[VersionRecord],
+    ) -> Result<Vec<(String, RowUuid)>, Error> {
+        let mut rows = Vec::with_capacity(records.len());
+        for record in records {
+            if record.deletion().is_some() {
+                continue;
+            }
+            let (_, table) = self.translate_cells_to_current_write_schema(
+                record.schema_version(),
+                record.table(),
+                &mut BTreeMap::new(),
+            )?;
+            rows.push((table, record.row_uuid()));
+        }
+        rows.sort_unstable();
+        rows.dedup();
+        Ok(rows)
     }
 
     pub(super) fn create_merge_versions_for_rows(
@@ -4338,22 +4356,12 @@ where
                         .map(|value| (column.name.clone(), value))
                 })
                 .collect::<BTreeMap<_, _>>();
-            let mut target_schema = author_schema;
-            if author_schema != self.catalogue.current_write_schema.schema
-                && self.has_forward_lens_path(
-                    author_schema,
-                    self.catalogue.current_write_schema.schema,
-                    version.table(),
-                )
-            {
-                target_schema = self.catalogue.current_write_schema.schema;
-                target_table = self.translate_cells_forward(
-                    author_schema,
-                    target_schema,
-                    &target_table,
-                    &mut target_cells,
-                )?;
-            }
+            let (target_schema, translated_table) = self.translate_cells_to_current_write_schema(
+                author_schema,
+                &target_table,
+                &mut target_cells,
+            )?;
+            target_table = translated_table;
             let table_schema = self.table_in_schema(&target_table, target_schema)?;
             let schema_version_alias = self.ensure_schema_version_alias(target_schema)?;
             let layer = VersionLayer::for_record(&version);
@@ -4528,20 +4536,22 @@ where
         Ok(())
     }
 
-    fn translate_cells_forward(
+    fn translate_cells_to_current_write_schema(
         &mut self,
         source: SchemaVersionId,
-        target: SchemaVersionId,
         table: &str,
         cells: &mut BTreeMap<String, Value>,
-    ) -> Result<String, Error> {
+    ) -> Result<(SchemaVersionId, String), Error> {
+        let target = self.catalogue.current_write_schema.schema;
         if source == target {
-            return Ok(table.to_owned());
+            return Ok((source, table.to_owned()));
         }
-        let path = self
-            .compiled_lens_path(source, target, LensPathDirection::Forward, table)?
-            .ok_or(Error::InvalidCatalogueUpdate("lens chain is unknown"))?;
-        Ok(apply_compiled_lens_path(&path, cells))
+        for direction in [LensPathDirection::Forward, LensPathDirection::Reverse] {
+            if let Some(path) = self.compiled_lens_path(source, target, direction, table)? {
+                return Ok((target, apply_compiled_lens_path(&path, cells)));
+            }
+        }
+        Ok((source, table.to_owned()))
     }
 
     fn reject_source_delta_reason(&mut self, versions: &[VersionRecord]) -> Option<String> {
@@ -4579,16 +4589,6 @@ where
             }
         }
         None
-    }
-
-    fn has_forward_lens_path(
-        &mut self,
-        source: SchemaVersionId,
-        target: SchemaVersionId,
-        table: &str,
-    ) -> bool {
-        self.compiled_lens_path(source, target, LensPathDirection::Forward, table)
-            .is_ok_and(|path| path.is_some())
     }
 
     pub(super) fn ingest_rejected_transaction(
@@ -4714,18 +4714,6 @@ fn content_version_reaches_tx_in_staged_parents(
         stack.extend(parents.iter().copied());
     }
     Some(false)
-}
-
-fn merge_rows_for_versions(records: &[VersionRecord]) -> Vec<(String, RowUuid)> {
-    let mut rows = Vec::with_capacity(records.len());
-    for record in records {
-        if record.deletion().is_none() {
-            rows.push((record.table().to_owned(), record.row_uuid()));
-        }
-    }
-    rows.sort_unstable();
-    rows.dedup();
-    rows
 }
 
 fn counter_merge_value(


### PR DESCRIPTION
Stacked on #1217 — merge that first.

## The bug

A write authored against schema v2 (`people`) while permissions were still
published on v1 (`users`) never reached the EdgeServer. The client saw a
timeout; the server had failed internally and simply never returned a fate
update.

Ingest only ever projected writes **forward** into the current write schema. So
the v2 update stayed addressed as `people`, and merge scheduling used the wire
table name rather than the projected storage table. Nothing downstream could
resolve it.

The fix resolves forward **or reverse** lens paths when projecting a write into
the write schema (`crates/jazz/src/node/ingest.rs:4539`), and schedules merges
against the projected storage table (`:2595`).

## Why this was hard to see

Three genuinely distinct defects were presenting as the same
`timed out waiting for EdgeServer` message:

1. policy-schema resolution — fixed in #1217
2. write projection through lenses — this PR
3. the `core_query` client capability gap — still open

They only separated once the dark targets were enabled and the first was fixed.
That is the argument for enabling them even while some stay red: the test target
was the instrument that told these three apart.

It is also an argument for #1156. "The server failed internally and never
returned a fate update" is exactly the failure mode that PR removes. With it
landed, this would have surfaced as an error naming its cause instead of a
delivery timeout.

## Verification

`catalogue_sync_integration`: **21 passed, 3 failed** at `e6d1b1b7a`, clean
tree, verified independently of the implementing run.

- `cargo check --workspace --all-targets` — exit 0
- INV-INC-1 canary — exit 0
- workspace tree clean before each gate

All three remaining failures are the single `core_query` guard at
`crates/jazz/src/tools/client.rs:1933` — two joins and one array subquery. Core
lowers `Query::joins` only as a root-row membership join returning a single
`RealRow`; these need a flattened cross-table result, which needs a core
multi-source result contract with maintained and one-shot provenance semantics.
No client-side join was attempted.

So after this, the enabled target has **one** named blocker rather than a mixed
set — which is what the merge decision on #1217 was waiting on.
